### PR TITLE
set pad bdimx to ttrue if bdimx is a multiple of warp size

### DIFF
--- a/benchmark/layer_norm.cpp
+++ b/benchmark/layer_norm.cpp
@@ -185,7 +185,7 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp32)
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
-//------------------------------------------------------------------------------    
+//------------------------------------------------------------------------------
 NVFUSER_BENCHMARK_DEFINE(
     NvFuserScheduler_LayerNorm_fp16,
     setupLayerNorm,

--- a/benchmark/layer_norm.cpp
+++ b/benchmark/layer_norm.cpp
@@ -168,6 +168,24 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp32)
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
+// GPT-2
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp32)
+    ->Args({8 * 1024, 768})
+    ->Args({8 * 1024, 1024})
+    ->Args({8 * 1024, 1280})
+    ->Args({8 * 1024, 1600})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp32)
+    ->Args({16 * 1024, 768})
+    ->Args({16 * 1024, 1024})
+    ->Args({16 * 1024, 1280})
+    ->Args({16 * 1024, 1600})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+//------------------------------------------------------------------------------    
 NVFUSER_BENCHMARK_DEFINE(
     NvFuserScheduler_LayerNorm_fp16,
     setupLayerNorm,
@@ -195,6 +213,23 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp16)
 NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp16)
     // ->RangeMultiplier(2)
     ->Ranges({{128, 1024 * 16}, {128, 1024 * 16}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+// GPT-2
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp16)
+    ->Args({8 * 1024, 768})
+    ->Args({8 * 1024, 1024})
+    ->Args({8 * 1024, 1280})
+    ->Args({8 * 1024, 1600})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_fp16)
+    ->Args({16 * 1024, 768})
+    ->Args({16 * 1024, 1024})
+    ->Args({16 * 1024, 1280})
+    ->Args({16 * 1024, 1600})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 

--- a/benchmark/layer_norm_backward.cpp
+++ b/benchmark/layer_norm_backward.cpp
@@ -198,6 +198,23 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_fp32)
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
+// GPT-2
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_fp32)
+    ->Args({8 * 1024, 768})
+    ->Args({8 * 1024, 1024})
+    ->Args({8 * 1024, 1280})
+    ->Args({8 * 1024, 1600})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_fp32)
+    ->Args({16 * 1024, 768})
+    ->Args({16 * 1024, 1024})
+    ->Args({16 * 1024, 1280})
+    ->Args({16 * 1024, 1600})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
 NVFUSER_BENCHMARK_DEFINE(
     NvFuserScheduler_LayerNorm_BWD_fp16,
     setupLayerNorm_BWD,
@@ -228,6 +245,22 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_fp16)
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 
+// GPT-2
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_fp16)
+    ->Args({8 * 1024, 768})
+    ->Args({8 * 1024, 1024})
+    ->Args({8 * 1024, 1280})
+    ->Args({8 * 1024, 1600})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_fp16)
+    ->Args({16 * 1024, 768})
+    ->Args({16 * 1024, 1024})
+    ->Args({16 * 1024, 1280})
+    ->Args({16 * 1024, 1600})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
 //------------------------------------------------------------------------------
 
 BENCHMARK(Baseline_LayerNorm_BWD_fp32)

--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -425,9 +425,6 @@ std::shared_ptr<ReductionParams> innerPersistentHeuristic(
   bool pad_bdimx = bdimx > 16 &&
       padded_bdimx * bdimy * bdimz < (int64_t)dev_prop->maxThreadsPerBlock;
 
-  pad_bdimx = pad_bdimx &&
-      bdimx * inner_reduction_unroll_factor != inner_most_dimension_numel;
-
   // estimate register usage and occupancy raito.
   // If occupancy raito is less than a preset occupancy_ratio, reduce register
   // usage register per thread is estimated as overhead + buffer_size /


### PR DESCRIPTION
Fixes https://github.com/csarofeen/pytorch/issues/2331
set pad_bimx to true if bdimx is a multiple of warp size.
I tested shapes of {8K, 16K} x {768, 1024, 1280, 1600} which are used in GPT-2. Bandwidth is improved by 6% to 10% for hidden size of 768 and 1024 since codegen will use warp reduction instead of block reduciton. No influence for 1280 and 1600 as they were using warp reduciton in the devel branch.
