### PR TITLE
Refinement of the `FusionCache` for printing and thread-safety

### DIFF
--- a/csrc/python_frontend/fusion_cache.cpp
+++ b/csrc/python_frontend/fusion_cache.cpp
@@ -5,12 +5,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <instrumentation.h>
 #include <python_frontend/fusion_cache.h>
-#include <mutex>
 
 namespace nvfuser::python_frontend {
 
-static std::mutex fusion_cache_lock;
+// FusionCache static data member definitions for singleton usage
+std::mutex FusionCache::singleton_lock_;
 FusionCache* FusionCache::singleton_ = nullptr;
 
 UserSchedule::UserSchedule() : schedule(nullptr), executor(nullptr) {
@@ -19,7 +20,7 @@ UserSchedule::UserSchedule() : schedule(nullptr), executor(nullptr) {
 }
 
 FusionSchedules::FusionSchedules()
-    : auto_gen_schedules(nullptr), user_def_schedules() {
+    : auto_gen_schedules(nullptr), user_def_schedules(), scheds_lock() {
   auto_gen_schedules =
       std::make_unique<FusionExecutorCache>(std::make_unique<Fusion>());
 }
@@ -30,15 +31,21 @@ Fusion* FusionSchedules::preschedFusion() {
   return fusion;
 }
 
-TrieNode::TrieNode(RecordFunctor* rec, size_t _fusion_id)
-    : record(rec), children(), fusion_id(_fusion_id), visits(0) {}
+TrieNode::TrieNode(RecordFunctor* rec, TrieNode* _parent, size_t _fusion_id)
+    : record(rec),
+      children(),
+      fusion_id(_fusion_id),
+      visits(0),
+      parent(_parent),
+      trie_node_lock() {}
 
 bool TrieNode::isTerminal() const {
   return (record.get()->recordType() == RecordType::End);
 }
 
 FusionCache* FusionCache::get(size_t max_fusions) {
-  std::lock_guard<std::mutex> guard(fusion_cache_lock);
+  FUSER_PERF_SCOPE("FusionCache::get");
+  std::lock_guard<std::mutex> guard(singleton_lock_);
   if (singleton_ == nullptr) {
     singleton_ = new FusionCache(max_fusions);
   }
@@ -54,6 +61,42 @@ size_t FusionCache::numFusions() const {
 }
 
 void FusionCache::print(std::ostream& os) {
+  os << "Fusions by id:" << std::endl;
+  std::vector<TrieNode*> stack;
+  stack.push_back(root_.get());
+
+  while (!stack.empty()) {
+    TrieNode* node = stack.back();
+    stack.pop_back();
+
+    if (node->isTerminal()) {
+      std::vector<TrieNode*> rev_fusion_records;
+      TrieNode* end = node->parent;
+      while (end) {
+        if (end->record->recordType() != RecordType::Start) {
+          rev_fusion_records.emplace_back(end);
+        }
+        end = end->parent;
+      }
+
+      os << node->fusion_id << ":" << std::endl;
+      std::for_each(
+          rev_fusion_records.rbegin(),
+          rev_fusion_records.rend(),
+          [&os](const auto elem) {
+            os << "    ";
+            elem->record->print(os);
+            os << std::endl;
+          });
+    } else {
+      for (auto& iter : node->children) {
+        stack.push_back(iter.second.get());
+      }
+    }
+  }
+}
+
+void FusionCache::stats(std::ostream& os) {
   os << "Total Fusions: " << fusions_.size() << "\n";
 
   // Does not make sense to print stats if the cache is disabled.
@@ -76,7 +119,7 @@ void FusionCache::print(std::ostream& os) {
 }
 
 void FusionCache::reset() {
-  std::lock_guard<std::mutex> guard(fusion_cache_lock);
+  std::lock_guard<std::mutex> guard(singleton_lock_);
   if (singleton_ != nullptr) {
     auto max_fusions = singleton_->max_fusions_;
     delete singleton_;
@@ -87,42 +130,47 @@ void FusionCache::reset() {
 FusionCache::FusionCache(size_t max_fusions)
     : max_fusions_(max_fusions),
       root_(nullptr),
-      trie_ptr_(nullptr),
       fusions_(),
+      terminal_nodes_(),
       user_def_input_encodings_() {
   RecordFunctor* start = new StartRecord();
   root_ = std::make_unique<TrieNode>(start);
-  trie_ptr_ = root_.get();
 }
 
-c10::optional<TrieNode*> FusionCache::queryChildren(RecordFunctor* rec) const {
-  std::lock_guard<std::mutex> guard(fusion_cache_lock);
+// In order to keep queries fast, this method does not lock.
+// In the worst case, the query should fail and if you try to create a child,
+// it should give you back an already created child if two threads are walking
+// the trie at the same time with the same definition.
+c10::optional<TrieNode*> FusionCache::queryChildren(
+    TrieNode* node,
+    RecordFunctor* rec) const {
   TORCH_CHECK(
-      !triePtr()->isTerminal(),
-      "There should be no children from a Terminal Node!");
+      !node->isTerminal(), "There should be no children from a Terminal Node!");
   TORCH_CHECK(rec, "Record is null!");
-  auto trie_node = triePtr()->children.find(rec);
-  if (trie_node == std::end(triePtr()->children)) {
+  auto trie_node = node->children.find(rec);
+  if (trie_node == std::end(node->children)) {
     return c10::nullopt;
   } else {
+    ++(trie_node->second.get()->visits);
     return c10::optional<TrieNode*>(trie_node->second.get());
   }
 }
-FusionSchedules& FusionCache::queryFusionSchedules(size_t fusion_id) {
-  std::lock_guard<std::mutex> guard(fusion_cache_lock);
+FusionSchedules* FusionCache::queryFusionSchedules(size_t fusion_id) {
   TORCH_CHECK(
       fusion_id < fusions_.size(),
       "Invalid scheduler query for id:",
       fusion_id);
-  return fusions_.at(fusion_id);
+  FusionSchedules* ptr = fusions_.at(fusion_id).get();
+  TORCH_CHECK(ptr != nullptr, "Unexpected null FusionSchedules object.");
+  return ptr;
 }
 c10::optional<size_t> FusionCache::queryUserScheduleId(
-    const FusionSchedules& scheds,
+    const FusionSchedules* scheds,
     const at::ArrayRef<c10::IValue>& inputs,
     int device) {
   c10::optional<size_t> result = c10::nullopt;
 
-  auto& user_scheds = scheds.user_def_schedules;
+  auto& user_scheds = scheds->user_def_schedules;
   if (user_scheds.size() != 0) {
     auto input_id = user_def_input_encodings_.lookupId(inputs);
     auto user_sched = user_scheds.find(input_id.id);
@@ -133,10 +181,10 @@ c10::optional<size_t> FusionCache::queryUserScheduleId(
   return result;
 }
 const UserSchedule& FusionCache::queryUserSchedule(
-    const FusionSchedules& scheds,
+    const FusionSchedules* scheds,
     size_t id,
     int device) {
-  auto& user_scheds = scheds.user_def_schedules;
+  auto& user_scheds = scheds->user_def_schedules;
   TORCH_CHECK(
       user_scheds.size() > 0,
       "Expecting there to be at least one user schedule!");
@@ -146,83 +194,79 @@ const UserSchedule& FusionCache::queryUserSchedule(
   return user_sched->second.at(device);
 }
 
-c10::optional<size_t> FusionCache::createChild(RecordFunctor* rec) {
-  std::lock_guard<std::mutex> guard(fusion_cache_lock);
-  c10::optional<size_t> result = c10::nullopt;
+TrieNode* FusionCache::createChild(TrieNode* node, RecordFunctor* rec) {
+  FUSER_PERF_SCOPE("FusionCache::createChild");
+  TrieNode* child = nullptr;
   TORCH_CHECK(
-      !triePtr()->isTerminal(),
-      "Cannot create a trie node from a terminal node!");
+      !node->isTerminal(), "Cannot create a trie node from a terminal node!");
   TORCH_CHECK(rec, "Record is null!");
 
-  size_t fusion_id = 0;
-  if (rec->recordType() == RecordType::End) {
-    TORCH_CHECK(
-        (fusions_.size() + 1) <= max_fusions_,
-        "The number of fusions in nvfuser has exceeded ",
-        max_fusions_,
-        "fusions.  The max_fusions for the FusionCache might need to be ",
-        "increased if the max number is not being exceeded due to an error.");
-    fusions_.emplace_back(FusionSchedules());
-    fusion_id = fusions_.size() - 1;
-    result = c10::optional<size_t>(fusion_id);
-  }
+  std::lock_guard<std::mutex> guard(node->trie_node_lock);
 
-  // Copying the record owned by the FusionDefinition that calls this function
-  // so the trie owns a copy when the FusionDefinition gets destroyed rather
-  // than managing a shared pointer that would only share with
-  // FusionDefinition that creates a trie node but not cache lookups
-  RecordFunctor* new_rec = rec->clone();
-  triePtr()->children[new_rec] = std::make_unique<TrieNode>(new_rec, fusion_id);
-  if (rec->recordType() == RecordType::End) {
-    terminal_nodes_.push_back(triePtr()->children[new_rec].get());
+  // As a thread-safety compromise for fast queries, the node is re-queried
+  // prior to child creation incase another thread slipped in the node.
+  auto child_node = queryChildren(node, rec);
+  if (child_node.has_value()) {
+    child = child_node.value();
+  } else {
+    size_t fusion_id = 0;
+    if (rec->recordType() == RecordType::End) {
+      TORCH_CHECK(
+          (fusions_.size() + 1) <= max_fusions_,
+          "The number of fusions in nvfuser has exceeded ",
+          max_fusions_,
+          "fusions.  The max_fusions for the FusionCache might need to be ",
+          "increased if the max number is not being exceeded due to an error.");
+      fusions_.emplace_back(std::make_unique<FusionSchedules>());
+      fusion_id = fusions_.size() - 1;
+    }
+
+    // Copying the record owned by the FusionDefinition that calls this function
+    // so the trie owns a copy when the FusionDefinition gets destroyed rather
+    // than managing a shared pointer that would only share with
+    // FusionDefinition that creates a trie node but not cache lookups
+    RecordFunctor* new_rec = rec->clone();
+    node->children[new_rec] =
+        std::make_unique<TrieNode>(new_rec, node, fusion_id);
+    child = node->children[new_rec].get();
+    ++(child->visits);
+    TORCH_CHECK(
+        child != nullptr, "Created child of TrieNode should not be null!");
+    if (rec->recordType() == RecordType::End) {
+      terminal_nodes_.push_back(node->children[new_rec].get());
+    }
+    if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
+      std::stringstream ss;
+      new_rec->print(ss);
+      std::cout << "\nFusionDefinition: Create new trie node for: " << ss.str()
+                << "\n";
+    }
   }
-  if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-    std::stringstream ss;
-    new_rec->print(ss);
-    std::cout << "\nFusionDefinition: Create new trie node for: " << ss.str()
-              << "\n";
-  }
-  return result;
+  return child;
 }
 
 UserSchedule* FusionCache::createUserSchedule(
-    FusionSchedules& scheds,
+    FusionSchedules* scheds,
     const at::ArrayRef<c10::IValue>& inputs,
     int device) {
-  auto& user_scheds = scheds.user_def_schedules;
+  FUSER_PERF_SCOPE("FusionCache::createUserSchedule");
+  std::lock_guard<std::mutex> guard(scheds->scheds_lock);
+  auto& user_scheds = scheds->user_def_schedules;
   auto input_id = user_def_input_encodings_.lookupId(inputs);
   auto user_sched = user_scheds.find(input_id.id);
-  // TODO: Make this better.  This just seems ugly and inefficient.
   if (user_sched == user_scheds.end()) {
     user_scheds[input_id.id] = std::vector<UserSchedule>(device + 1);
   } else {
-    user_scheds[input_id.id].resize(device + 1);
+    if (static_cast<size_t>(device) >= user_scheds[input_id.id].size()) {
+      user_scheds[input_id.id].resize(device + 1);
+    }
   }
   return &user_scheds[input_id.id].at(device);
 }
 
-void FusionCache::resetTriePtr() {
-  trie_ptr_ = root_.get();
-  TORCH_CHECK(triePtr()->record->recordType() == RecordType::Start);
-  ++(triePtr()->visits);
-}
-
-void FusionCache::traverseTrie(RecordFunctor* rec) {
-  TORCH_CHECK(
-      !triePtr()->isTerminal(), "Cannot traverse trie from a terminal entry!");
-  auto trie_node = triePtr()->children.find(rec);
-  TORCH_CHECK(
-      trie_node != std::end(triePtr()->children),
-      "Trie Node for Trie Traverse is not found!");
-  TORCH_CHECK(trie_node->second, "Record in Trie Node is null!");
-  trie_ptr_ = trie_node->second.get();
-  ++(triePtr()->visits);
-}
-
-TrieNode* FusionCache::triePtr() const {
-  TORCH_INTERNAL_ASSERT(
-      trie_ptr_ != nullptr, "The trie node is unexpectedly null.");
-  return trie_ptr_;
+TrieNode* FusionCache::rootTriePtr() {
+  ++(root_.get()->visits);
+  return root_.get();
 }
 
 } // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/fusion_cache.h
+++ b/csrc/python_frontend/fusion_cache.h
@@ -12,6 +12,7 @@
 #include <python_frontend/fusion_record.h>
 
 #include <memory>
+#include <mutex>
 
 namespace nvfuser::python_frontend {
 
@@ -43,6 +44,8 @@ struct FusionSchedules {
   //!        InputsIdLookup struct found inside of the FusionCache.
   //! Value: A vector based on device_id of User Defined Fusion Schedules.
   std::unordered_map<size_t, std::vector<UserSchedule>> user_def_schedules;
+  //! For thread-Safe locking of Fusion Schedules
+  std::mutex scheds_lock;
 };
 
 //! \struct TrieNode
@@ -51,7 +54,10 @@ struct FusionSchedules {
 //! the leaf Nodes represent a complete Fusion that is cached.
 
 struct TORCH_CUDA_CU_API TrieNode {
-  TrieNode(RecordFunctor* rec, size_t _fusion_id = 0);
+  TrieNode(
+      RecordFunctor* rec,
+      TrieNode* _parent = nullptr,
+      size_t _fusion_id = 0);
 
   // Queries whether the entry denotes a leaf node which also represents
   // a the end of Fusion entry in the cache.
@@ -68,6 +74,10 @@ struct TORCH_CUDA_CU_API TrieNode {
   size_t fusion_id;
   //! Count of times the Entry is traversed
   size_t visits;
+  //! Parent node for printing
+  TrieNode* parent;
+  //! For thread-Safe locking of a node
+  std::mutex trie_node_lock;
 };
 
 //! \class FusionCache
@@ -78,8 +88,16 @@ struct TORCH_CUDA_CU_API TrieNode {
 //! cache fusions.  A leaf of the tree with a terminal node contains a
 //! container for caching the kernels generated for specific fusions.
 //!
-//! \todo Add the ability to evict a fusion.  There is currently a max number
+//! \todo
+//! Add the ability to evict a fusion.  There is currently a max number
 //! of fusions that is checked to prevent a runaway case.
+//!
+//! \note
+//! Thread-Safety is assured by the Python GIL.  If a no-GIL python is used
+//! then further scrutiny needs to be applied to the mutexes used to limit
+//! acccess to the singleton pointer, node creation, and user schedule
+//! creation.  Otherwise, the Python GIL provides a natural thread based mutex
+//! that does not allow for multiple threads to interact.
 
 class TORCH_CUDA_CU_API FusionCache {
   //! The constructor is private given the FusionCache is only constructed
@@ -97,60 +115,55 @@ class TORCH_CUDA_CU_API FusionCache {
   static FusionCache* get(size_t max_fusions = 8192);
   //! Number of fusions cached
   size_t numFusions() const;
-  //! print cache stats
+  //! print cache contents
   void print(std::ostream& os);
+  //! print cache stats
+  void stats(std::ostream& os);
   //! Reset Cache to an empty state
   static void reset();
 
   //! The rest of the public methods are only used in C++
 
-  //! Queries the current trie node to see if a record matches one of its
-  //! children
-  c10::optional<TrieNode*> queryChildren(RecordFunctor* rec) const;
+  //! Thread-Unsafe: Queries the current trie node to see if a record matches
+  //! one of its children
+  c10::optional<TrieNode*> queryChildren(TrieNode* node, RecordFunctor* rec)
+      const;
   //! Query a Fusion's Schedules based on fusion id or cache id
-  FusionSchedules& queryFusionSchedules(size_t fusion_id);
+  FusionSchedules* queryFusionSchedules(size_t fusion_id);
   //! Lookup the User Schedule Id and return null if one does not exist.
   c10::optional<size_t> queryUserScheduleId(
-      const FusionSchedules& scheds,
+      const FusionSchedules* scheds,
       const at::ArrayRef<c10::IValue>& inputs,
       int device);
   //! Lookup the User Schedule based on Id
   const UserSchedule& queryUserSchedule(
-      const FusionSchedules& scheds,
+      const FusionSchedules* scheds,
       size_t id,
       int device);
-  //! Creates a child node for the current cache entry and an optional
-  //! fusion_id is returned if the new entry is terminal
-  c10::optional<size_t> createChild(RecordFunctor* rec);
+  //! Thread-Safe: Creates a child node for the current cache entry and an
+  //! optional fusion_id is returned if the new entry is terminal
+  TrieNode* createChild(TrieNode* node, RecordFunctor* rec);
   //! Lookup the User Schedule based on Id
   UserSchedule* createUserSchedule(
-      FusionSchedules& scheds,
+      FusionSchedules* scheds,
       const at::ArrayRef<c10::IValue>& inputs,
       int device);
-  //! Resets the current cache pointer to the top of the tree
-  void resetTriePtr();
-  //! Traverses the trie from the current node to the child associated
-  //! with the record given.
-  void traverseTrie(RecordFunctor* rec);
-
-  friend class FusionInterface;
+  //! Get the root Trie ptr
+  TrieNode* rootTriePtr();
 
  private:
-  //! Returns the pointer to the current trie node
-  TrieNode* triePtr() const;
-
   //! The static pointer to the FusionCache
   static FusionCache* singleton_;
+  //! Lock for accessing the singleton by multiple threads
+  static std::mutex singleton_lock_;
 
   //! The max allowed number of fusions in the cache
   size_t max_fusions_;
   //! The root (start) of the prefix tree to start a cache look up of a given
   //! fusion definition.
   std::unique_ptr<TrieNode> root_;
-  //! A pointer to the trie node in a cache lookup of a fusion definition.
-  TrieNode* trie_ptr_;
   //! A vector of nvFuser Fusion IR fusions.
-  std::vector<FusionSchedules> fusions_;
+  std::vector<std::unique_ptr<FusionSchedules>> fusions_;
   //! A vector of Terminal trie nodes for Stats collection
   std::vector<TrieNode*> terminal_nodes_;
 

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -87,20 +87,20 @@ FusionCache* FusionDefinition::fusionCache() const {
 FusionDefinition* FusionDefinition::setupDefinition() {
   TORCH_CHECK(max_length_ > 0, "Can't make a FusionDefinition with 0 records!");
   TORCH_CHECK(!id().has_value(), "Fusion Schedule is already found!");
-  fusionCache()->resetTriePtr();
+  trie_node_ = fusionCache()->rootTriePtr();
   return this;
 }
 
 void FusionDefinition::finalizeDefinition() {
   FUSER_PERF_SCOPE("FusionDefinition::finalizeDefinition");
-  auto cache_entry = fusionCache()->queryChildren(end_record_.get());
-  if (!cache_entry.has_value()) {
+  auto child_node = fusionCache()->queryChildren(trie_node_, end_record_.get());
+  if (!child_node.has_value()) {
     if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
       std::cout << "\nFusionDefinition: Terminal Node not found.\n";
     }
-    fusion_id_ = fusionCache()->createChild(end_record_.get());
+    trie_node_ = fusionCache()->createChild(trie_node_, end_record_.get());
+    fusion_id_ = c10::optional<size_t>(trie_node_->fusion_id);
     TORCH_CHECK(id().has_value(), "Invalid fusion id!");
-    fusionCache()->traverseTrie(end_record_.get());
 
     if (isDebugDumpEnabled(DebugDumpOption::PythonDefinition)) {
       print(std::cout);
@@ -115,15 +115,15 @@ void FusionDefinition::finalizeDefinition() {
     if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
       std::cout << "\nFusionDefinition: Terminal Node found!\n";
     }
-    fusion_id_ = c10::optional<size_t>(cache_entry.value()->fusion_id);
-    fusionCache()->traverseTrie(end_record_.get());
+    trie_node_ = child_node.value();
+    fusion_id_ = c10::optional<size_t>(trie_node_->fusion_id);
   }
 }
 
 void FusionDefinition::setupSchedule(const at::ArrayRef<c10::IValue>& inputs) {
   FUSER_PERF_SCOPE("FusionDefinition::setupSchedule");
   TORCH_CHECK(id().has_value(), "FusionDefinition definition does not exist!");
-  auto& scheds = fusionCache()->queryFusionSchedules(id().value());
+  auto scheds = fusionCache()->queryFusionSchedules(id().value());
   auto device = getCommonDeviceCUDA(inputs);
   TORCH_CHECK(
       inputs.size() == 0 || device > -1,
@@ -174,7 +174,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
     bool override_user_schedule) const {
   TORCH_CHECK(id().has_value(), "Valid fusion schedule is not available!");
 
-  auto& scheds = fusionCache()->queryFusionSchedules(id().value());
+  auto scheds = fusionCache()->queryFusionSchedules(id().value());
 
   if (!override_user_schedule) {
     auto device = getCommonDeviceCUDA(inputs);
@@ -190,7 +190,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
     }
   }
 
-  return scheds.auto_gen_schedules->runFusionWithInputs(inputs);
+  return scheds->auto_gen_schedules->runFusionWithInputs(inputs);
 }
 
 c10::optional<size_t> FusionDefinition::id() const {
@@ -220,24 +220,26 @@ void FusionDefinition::defineRecord(RecordFunctor* record) {
       "operations.  The max_length for FusionDefintion's might need to be ",
       "increased if the definition is created as expected.");
   addRecord(record);
-  auto cache_entry = fusionCache()->queryChildren(recording_.back().get());
+  auto child_node =
+      fusionCache()->queryChildren(trie_node_, recording_.back().get());
   // If the Record is found in the cache, the FusionDefinition and the Cache
   // will not share Record given the Record had to be created in order to
   // match it but it also already existed in the cache.
-  if (cache_entry.has_value()) {
+  if (child_node.has_value()) {
     if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
       std::cout << "\nFusionDefinition: Record (hash: 0x" << std::hex
                 << record->hash() << ") hit in Fusion Cache.\n";
     }
+    trie_node_ = child_node.value();
     // The FusionDefinition and the Cache will share the Record
   } else {
     if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
       std::cout << "\nFusionDefinition: Record (hash: 0x" << std::hex
                 << record->hash() << ") missed in Fusion Cache.\n";
     }
-    fusionCache()->createChild(recording_.back().get());
+    trie_node_ =
+        fusionCache()->createChild(trie_node_, recording_.back().get());
   }
-  fusionCache()->traverseTrie(recording_.back().get());
 }
 
 Fusion* FusionDefinition::preschedFusion() {
@@ -246,7 +248,7 @@ Fusion* FusionDefinition::preschedFusion() {
       "FusionDefinition does not contain a definition, yet!");
   return fusionCache()
       ->queryFusionSchedules(fusion_id_.value())
-      .preschedFusion();
+      ->preschedFusion();
 }
 
 void FusionDefinition::printMathIr() {

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -20,11 +20,33 @@ class FusionInterface;
 class FusionState;
 struct RecordFunctor;
 struct UserSchedule;
+struct TrieNode;
 
 //! This is helper function used to print a python formated
 //! Fusion IR DataType when printing a fusion definition.
 
 TORCH_CUDA_CU_API const char* dtypeToPyString(PrimDataType t);
+
+//! The State and the StateType enum are used to define state objects to
+//! encapsulate the recording of state in the FusionDefinition.
+
+enum class StateType {
+  Tensor,
+  Scalar,
+  None,
+};
+
+struct TORCH_CUDA_CU_API State {
+  State(size_t _index, StateType _stype) : index(_index), stype(_stype) {}
+
+  bool operator==(const State& other) const;
+  bool operator!=(const State& other) const;
+
+  //! A unique index to identifiy each recorded state item.
+  size_t index;
+  //! StateType is either: Tensor or Scalar
+  StateType stype;
+};
 
 TORCH_CUDA_CU_API std::ostream& operator<<(
     std::ostream& os,
@@ -144,6 +166,8 @@ class TORCH_CUDA_CU_API FusionDefinition : public FusionState {
   c10::optional<size_t> fusion_id_;
   //! A pointer to the FusionCache.
   FusionCache* fusion_cache_;
+  //! Current pointer to node in FusionCache.
+  TrieNode* trie_node_;
 
   //! A vector of state recorded in the FusionDefinition
   std::vector<State> recording_state_;

--- a/csrc/python_frontend/fusion_state.h
+++ b/csrc/python_frontend/fusion_state.h
@@ -12,27 +12,6 @@ namespace nvfuser::python_frontend {
 
 struct RecordFunctor;
 
-//! The State and the StateType enum are used to define state objects to
-//! encapsulate the recording of state in the FusionDefinition.
-
-enum class StateType {
-  Tensor,
-  Scalar,
-  None,
-};
-
-struct TORCH_CUDA_CU_API State {
-  State(size_t _index, StateType _stype) : index(_index), stype(_stype) {}
-
-  bool operator==(const State& other) const;
-  bool operator!=(const State& other) const;
-
-  //! A unique index to identifiy each recorded state item.
-  size_t index;
-  //! StateType is either: Tensor or Scalar
-  StateType stype;
-};
-
 //! FusionState contains the information used to build a new cpp Fusion object.
 //! Unlike FusionDefinition, it does not modify the FusionCache Trie structure.
 class TORCH_CUDA_CU_API FusionState {

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -89,7 +89,18 @@ void initNvFuserPythonBindings(PyObject* module) {
           py::arg("max_fusions") = int(8192),
           py::return_value_policy::reference)
       .def("num_fusions", &FusionCache::numFusions)
-      .def("print_stats", [](FusionCache& self) { self.print(std::cout); });
+      .def(
+          "__repr__",
+          [](FusionCache& self) {
+            std::stringstream ss;
+            self.print(ss);
+            return ss.str();
+          })
+      .def("stats", [](FusionCache& self) {
+        std::stringstream ss;
+        self.stats(ss);
+        return ss.str();
+      });
 
   //! These are the FusionDefinition supported object types that are either
   //! defined as inputs or the output of an operation.
@@ -142,8 +153,7 @@ void initNvFuserPythonBindings(PyObject* module) {
           "_setup_definition",
           [](FusionDefinition& self) -> FusionDefinition* {
             // Instrumentation to mark the beginning of a FusionDefinition
-            inst::Trace::instance()->beginEvent(
-                "FusionDefinition setupDefinition");
+            inst::Trace::instance()->beginEvent("FusionDefinition Definition");
             return self.setupDefinition();
           })
       .def(
@@ -157,7 +167,7 @@ void initNvFuserPythonBindings(PyObject* module) {
           "_setup_schedule",
           [](FusionDefinition& self, const py::iterable& iter) {
             // Instrumentation to mark the beginning of a schedule
-            inst::Trace::instance()->beginEvent("FusionDefinition schedule");
+            inst::Trace::instance()->beginEvent("FusionDefinition Schedule");
             std::vector<c10::IValue> inputs;
             for (py::handle obj : iter) {
               inputs.push_back(torch::jit::toIValue(obj, c10::AnyType::get()));

--- a/csrc/python_frontend/test/test_nvfuser_fusion_cache.cpp
+++ b/csrc/python_frontend/test/test_nvfuser_fusion_cache.cpp
@@ -36,30 +36,17 @@ TEST_F(NVFuserTest, PyFusionCache_CUDA) {
   // Check that cache methods all assert when presented with a null record.
   {
     std::unique_ptr<RecordFunctor> null_record(nullptr);
+    TrieNode* node = fc->rootTriePtr();
 
     try {
-      fc->queryChildren(null_record.get());
+      fc->queryChildren(node, null_record.get());
       FAIL() << "Should trigger an assert when the record is looked up!";
     } catch (...) {
       SUCCEED();
     }
 
     try {
-      fc->traverseTrie(null_record.get());
-      FAIL() << "Should trigger an assert when the record is looked up!";
-    } catch (...) {
-      SUCCEED();
-    }
-
-    try {
-      fc->createChild(null_record.get());
-      FAIL() << "Should trigger an assert when the record is looked up!";
-    } catch (...) {
-      SUCCEED();
-    }
-
-    try {
-      fc->createChild(null_record.get());
+      fc->createChild(node, null_record.get());
       FAIL() << "Should trigger an assert when the record is looked up!";
     } catch (...) {
       SUCCEED();
@@ -71,55 +58,43 @@ TEST_F(NVFuserTest, PyFusionCache_CUDA) {
   {
     std::unique_ptr<RecordFunctor> test_record(new TensorRecord(
         {State(0, StateType::Tensor)}, {3}, {true}, DataType::Float));
+    TrieNode* root = fc->rootTriePtr();
+    TrieNode* node = nullptr;
 
     // Check Methods prior to adding an entry to the cache
 
     // Cache Lookup should not succeed becase no records are in the cache
     try {
-      auto empty_cache_entry_ptr = fc->queryChildren(test_record.get());
-      ASSERT_TRUE(empty_cache_entry_ptr == c10::nullopt);
+      auto undefined_node = fc->queryChildren(root, test_record.get());
+      ASSERT_TRUE(undefined_node == c10::nullopt);
       SUCCEED();
     } catch (const std::exception& e) {
       FAIL() << "Unexpected assert during cache lookup!" << e.what();
     }
 
-    // Traversal of the cache should fail because there is nothing to traverse
-    try {
-      fc->traverseTrie(test_record.get());
-      FAIL() << "Expected the cache traversal to fail!";
-    } catch (...) {
-      SUCCEED();
-    }
-
     // Add a cache entry and check methods
 
     try {
-      fc->createChild(test_record.get());
+      fc->createChild(root, test_record.get());
       SUCCEED();
     } catch (const std::exception& e) {
       FAIL() << "An unexpected assert on Cache Entry creation!" << e.what();
     }
 
     try {
-      auto cache_entry_ptr = fc->queryChildren(test_record.get());
-      ASSERT_FALSE(cache_entry_ptr == c10::nullopt);
+      auto child_node = fc->queryChildren(root, test_record.get());
+      ASSERT_FALSE(child_node == c10::nullopt);
+      node = child_node.value();
       SUCCEED();
     } catch (const std::exception& e) {
       FAIL() << "An unexpected assert on cache lookup!" << e.what();
-    }
-
-    try {
-      fc->traverseTrie(test_record.get());
-      SUCCEED();
-    } catch (const std::exception& e) {
-      FAIL() << "An unexpected assert during Cache Traverse!" << e.what();
     }
 
     // Add a terminal cache entry and check methods
 
     std::unique_ptr<RecordFunctor> end_record(new EndRecord());
     try {
-      fc->createChild(end_record.get());
+      node = fc->createChild(node, end_record.get());
       SUCCEED();
     } catch (const std::exception& e) {
       FAIL() << "An unexpected assert on Terminal Cache Entry creation!"
@@ -127,35 +102,11 @@ TEST_F(NVFuserTest, PyFusionCache_CUDA) {
     }
 
     try {
-      fc->traverseTrie(end_record.get());
-      SUCCEED();
-    } catch (const std::exception& e) {
-      FAIL() << "An unexpected assert while traversing to a Terminal Entry!"
-             << e.what();
-    }
-
-    try {
-      fc->queryChildren(test_record.get());
+      fc->queryChildren(node, test_record.get());
       FAIL() << "Expected an assert from a terminal entry!";
     } catch (...) {
       SUCCEED();
     }
-
-    try {
-      fc->traverseTrie(test_record.get());
-      FAIL() << "Expected an assert from a terminal entry!";
-    } catch (...) {
-      SUCCEED();
-    }
-  }
-
-  // Setup cache for a new cache lookup
-  try {
-    fc->resetTriePtr();
-    SUCCEED();
-  } catch (const std::exception& e) {
-    FAIL() << "Did not properly set cache to pointer to top of tree!"
-           << e.what();
   }
 
   // Check that cache methods act appropriately when presenting a new
@@ -165,60 +116,40 @@ TEST_F(NVFuserTest, PyFusionCache_CUDA) {
         {State(0, StateType::Tensor)}, {3}, {true}, DataType::Float));
     std::unique_ptr<RecordFunctor> new_record(
         new ScalarRecord({State(1, StateType::Scalar)}, DataType::Float));
+    TrieNode* root = fc->rootTriePtr();
+    TrieNode* node = nullptr;
 
     try {
-      auto hit_cache_entry = fc->queryChildren(cached_record.get());
-      ASSERT_FALSE(hit_cache_entry == c10::nullopt);
+      auto child_node = fc->queryChildren(root, cached_record.get());
+      ASSERT_FALSE(child_node == c10::nullopt);
+      node = child_node.value();
       SUCCEED();
     } catch (const std::exception& e) {
       FAIL() << "Cache lookup unexpectedly asserted!" << e.what();
     }
 
     try {
-      fc->traverseTrie(cached_record.get());
-      SUCCEED();
-    } catch (const std::exception& e) {
-      FAIL() << "Fusion cache traverse unexpectedly asserted!" << e.what();
-    }
-
-    try {
-      auto miss_cache_entry = fc->queryChildren(new_record.get());
-      ASSERT_TRUE(miss_cache_entry == c10::nullopt);
+      auto undefined_node = fc->queryChildren(node, new_record.get());
+      ASSERT_TRUE(undefined_node == c10::nullopt);
       SUCCEED();
     } catch (const std::exception& e) {
       FAIL() << "Cache lookup unexpectedly asserted!" << e.what();
     }
 
     try {
-      fc->createChild(new_record.get());
+      node = fc->createChild(node, new_record.get());
       SUCCEED();
     } catch (const std::exception& e) {
       FAIL() << "An unexpected assert on Cache Entry creation!" << e.what();
     }
 
-    try {
-      fc->traverseTrie(new_record.get());
-      SUCCEED();
-    } catch (const std::exception& e) {
-      FAIL() << "Fusion cache traverse unexpectedly asserted!" << e.what();
-    }
-
     std::unique_ptr<RecordFunctor> end_record(new EndRecord());
     try {
-      fc->createChild(end_record.get());
+      fc->createChild(node, end_record.get());
       FAIL() << "Expected the cache to assert because it is full!";
     } catch (...) {
       SUCCEED();
     }
-  }
-
-  // Setup cache for a new cache lookup
-  try {
-    fc->resetTriePtr();
-    SUCCEED();
-  } catch (const std::exception& e) {
-    FAIL() << "Did not properly set cache to pointer to top of tree!"
-           << e.what();
   }
 
   // Verify proper cache lookup up of complete fusion already cached.
@@ -228,36 +159,24 @@ TEST_F(NVFuserTest, PyFusionCache_CUDA) {
         {State(0, StateType::Tensor)}, {3}, {true}, DataType::Float));
     std::unique_ptr<RecordFunctor> dummy_record(new TensorRecord(
         {State(0, StateType::Tensor)}, {3}, {true}, DataType::Float));
+    TrieNode* root = fc->rootTriePtr();
+    TrieNode* node = nullptr;
 
     try {
-      auto cache_entry_ptr = fc->queryChildren(test_record.get());
-      ASSERT_FALSE(cache_entry_ptr == c10::nullopt);
+      auto child_node = fc->queryChildren(root, test_record.get());
+      ASSERT_FALSE(child_node == c10::nullopt);
+      node = child_node.value();
       SUCCEED();
     } catch (const std::exception& e) {
       FAIL() << "An unexpected assert on cache lookup!" << e.what();
-    }
-
-    try {
-      fc->traverseTrie(test_record.get());
-      SUCCEED();
-    } catch (const std::exception& e) {
-      FAIL() << "An unexpected assert during Cache Traverse!" << e.what();
     }
 
     std::unique_ptr<RecordFunctor> end_record(new EndRecord());
     try {
-      fc->queryChildren(end_record.get());
+      fc->queryChildren(node, end_record.get());
       SUCCEED();
     } catch (const std::exception& e) {
       FAIL() << "An unexpected assert on cache lookup!" << e.what();
-    }
-
-    try {
-      fc->traverseTrie(end_record.get());
-      SUCCEED();
-    } catch (const std::exception& e) {
-      FAIL() << "An unexpected assert while traversing to a Terminal Entry!"
-             << e.what();
     }
   }
 }


### PR DESCRIPTION
Moved PR [#2552](https://github.com/csarofeen/pytorch/pull/2552) to this new repo.

**NOTE:** Thread-safety in the python API is irrelevant as long as the Python GIL exists given that each thread, except for I/O, run completely exclusively.  https://www.backblaze.com/blog/the-python-gil-past-present-and-future/

- Added some thread-safety mutexes to node creation (`FusionCache::createChild`) and user schedule creation (`FusionCache::createUserSchedule`), although, these do nothing in Python due to the global interpreter lock that disallows CPU bound multithreading.  The point was to make queries fast and pay the mutex penalty on creation of objects.
- Added printing of the contents of the `FusionCache` via depth-first search of the contents and a reverse printing of the traversal from each terminal point back up to the root.
- Moved the Trie Pointer from one single pointer in the `FusionCache` to one per `FusionDefinition` to allow concurrent lookup of the `FusionCache` from multiple `FusionDefinition`s.  Given the Python GIL, this will not matter until a no-GIL python is available.
- Added a Note to the `FusionCache` class comment to explain the thread-safety of the class given the constraints of the Python GIL.

**Example of new `FusionCache` printing:**

```
import torch
from nvfuser import FusionDefinition, FusionCache

inputs = [
    torch.randn(4, 4, device='cuda'),
]

with FusionDefinition() as fd:
    t0 = fd.from_pytorch(inputs[0])
    t1 = fd.ops.relu(t0)
    fd.add_output(t1)

out = fd.execute(inputs)

fc = FusionCache.get()
print(fc)
print(fc.stats())
```
Output:
```
$ python test.py 
Fusions by id:
0:
    T0 = fd.define_tensor(symbolic_sizes=[-1, -1], contiguous=[True, True], dtype=DataType.Float, is_cpu=False)
    T1 = fd.ops.relu(T0)
    fd.add_output(T1)

Total Fusions: 1
Cache Hits by Fusion Id:
        0 -> 0 hits
Cache Lookups: 1 Cache Hits: 0 Hit Rate: 0%
```