### PR TITLE
Sign compare patch

### DIFF
--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1199,7 +1199,7 @@ struct OutputRecord : RecordFunctor {
     if (!stride_order.empty()) {
       bool requires_permutation = false;
       for (const auto i : c10::irange(stride_order.size())) {
-        if (stride_order[i] != i) {
+        if (stride_order[i] != (int64_t)i) {
           requires_permutation = true;
           break;
         }
@@ -1268,7 +1268,7 @@ struct OutputRecord : RecordFunctor {
 
         if (!stride_order_.empty()) {
           std::vector<int64_t> reverse_perm(stride_order_.size());
-          size_t duplicate_check = 0;
+          int64_t duplicate_check = 0;
           for (const auto i : c10::irange(stride_order_.size())) {
             TORCH_CHECK(
                 stride_order_[i] >= 0 &&

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -247,7 +247,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             TORCH_CHECK(
                 stride_order.empty() || output.dims == stride_order.size(),
                 "stride_order needs to be either empty or the same length of Tensor `output`");
-            size_t duplicate_check = 0;
+            int64_t duplicate_check = 0;
             for (const auto& v : stride_order) {
               TORCH_CHECK(
                   v >= 0 && v < (int64_t)stride_order.size(),

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -9719,7 +9719,8 @@ TEST_F(NVFuserTest, FusionPersistentBufferProjection2_CUDA) {
   // projectable buffer inputs. Thus, the buffer size would be
   // calculated as the sum of tv1, tv0 and tv1.
   auto projected_size = persistent_buffer_size.projected_persistent_buffer_size;
-  auto expected_size = static_cast<int64_t>(shape[1] * 2 * dataTypeSize(DataType::Half));
+  auto expected_size =
+      static_cast<int64_t>(shape[1] * 2 * dataTypeSize(DataType::Half));
   TORCH_CHECK(
       projected_size == expected_size,
       "Buffer projection failure. Expected size: ",

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -9721,7 +9721,7 @@ TEST_F(NVFuserTest, FusionPersistentBufferProjection2_CUDA) {
   auto projected_size = persistent_buffer_size.projected_persistent_buffer_size;
   auto expected_size = shape[1] * 2 * dataTypeSize(DataType::Half);
   TORCH_CHECK(
-      projected_size == expected_size,
+      (int64_t)projected_size == expected_size,
       "Buffer projection failure. Expected size: ",
       expected_size,
       ". Actual: ",

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -9719,9 +9719,9 @@ TEST_F(NVFuserTest, FusionPersistentBufferProjection2_CUDA) {
   // projectable buffer inputs. Thus, the buffer size would be
   // calculated as the sum of tv1, tv0 and tv1.
   auto projected_size = persistent_buffer_size.projected_persistent_buffer_size;
-  auto expected_size = shape[1] * 2 * dataTypeSize(DataType::Half);
+  auto expected_size = static_cast<int64_t>(shape[1] * 2 * dataTypeSize(DataType::Half));
   TORCH_CHECK(
-      (int64_t)projected_size == expected_size,
+      projected_size == expected_size,
       "Buffer projection failure. Expected size: ",
       expected_size,
       ". Actual: ",

--- a/test/test_gpu_gather_ops.cpp
+++ b/test/test_gpu_gather_ops.cpp
@@ -52,13 +52,13 @@ at::Tensor generateScatter2DIndex(
       torch::TensorOptions().dtype(torch::kLong).device(at::kCUDA, 0);
   if (select_id == 0) {
     auto idx = at::randint(0, extent_2d, {extent_1d, extent_2d}, options_i);
-    for (size_t i = 0; i < extent_1d; ++i) {
+    for (int64_t i = 0; i < extent_1d; ++i) {
       idx[i] = at::randperm(extent_2d, options_i) + min;
     }
     return idx.transpose(0, 1).contiguous();
   } else {
     auto idx = at::randint(0, extent_1d, {extent_2d, extent_1d}, options_i);
-    for (size_t i = 0; i < extent_2d; ++i) {
+    for (int64_t i = 0; i < extent_2d; ++i) {
       idx[i] = at::randperm(extent_1d, options_i) + min;
     }
     return idx;

--- a/test/test_gpu_outer_reduction.cpp
+++ b/test/test_gpu_outer_reduction.cpp
@@ -1383,7 +1383,7 @@ bool shouldBePersistent(
   const int64_t max_gdimy =
       at::cuda::getCurrentDeviceProperties()->multiProcessorCount / 2;
   const int64_t pb_factor = ceilDiv(ceilDiv(N * HW * HW, max_bdimy), max_gdimy);
-  const auto req_reg_count = pb_factor * vec_factor * dataTypeSize(dtype) /
+  const int64_t req_reg_count = pb_factor * vec_factor * dataTypeSize(dtype) /
       sizeof(int) *
       (is_bwd ? 2 : 1); // Two tensors are cached in the backward batchnorm
 


### PR DESCRIPTION
Patched build failure against upstream pytorch where no-sign-compare is enforced now.