### PR TITLE
Clang format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: '3.10' 
       - name: Install clang-format
-        run: pip install clang-format==10.0.1
+        run: pip install clang-format==12.0.1.2
       - name: Run clang-format
         working-directory: ${{ env.working_directory }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: '3.10' 
       - name: Install clang-format
-        run: pip install clang-format
+        run: pip install clang-format=10.0.1
       - name: Run clang-format
         working-directory: ${{ env.working_directory }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: '3.10' 
       - name: Install clang-format
-        run: pip install clang-format=10.0.1
+        run: pip install clang-format==10.0.1
       - name: Run clang-format
         working-directory: ${{ env.working_directory }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,4 +41,6 @@ jobs:
         run: |
           find ./csrc -regex '.*\.\(cpp\|hpp\|cu\|c\|h\)' -exec clang-format -style=file -i {} \;
           find ./test -regex '.*\.\(cpp\|hpp\|cu\|c\|h\)' -exec clang-format -style=file -i {} \;
+          find ./benchmark -regex '.*\.\(cpp\|hpp\|cu\|c\|h\)' -exec clang-format -style=file -i {} \;
+          find ./runtime -regex '.*\.\(cpp\|hpp\|cu\|c\|h\)' -exec clang-format -style=file -i {} \;
           git --no-pager diff --exit-code

--- a/csrc/executor_kernel_arg.h
+++ b/csrc/executor_kernel_arg.h
@@ -135,9 +135,15 @@ struct ArgAbstract {
   bool isType(ArgType type) const override {                      \
     return ArgType::TARGET_TYPE == type;                          \
   }                                                               \
-  ArgType type() const override { return ArgType::TARGET_TYPE; }  \
-  const void* arg() const override { return &ARG_NAME; }          \
-  void* arg() override { return &ARG_NAME; }                      \
+  ArgType type() const override {                                 \
+    return ArgType::TARGET_TYPE;                                  \
+  }                                                               \
+  const void* arg() const override {                              \
+    return &ARG_NAME;                                             \
+  }                                                               \
+  void* arg() override {                                          \
+    return &ARG_NAME;                                             \
+  }                                                               \
   std::unique_ptr<ArgAbstract> copy_unique_ptr() const override { \
     return std::make_unique<TARGET_TYPE##Arg>(*this);             \
   }

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -552,10 +552,12 @@ TensorView* eye(Val* size, DataType dtype) {
 
 // UNARY OPERATIONS
 
-#define NVFUSER_DEFINE_UNARY_OP(op_name, op_type)                   \
-  Val* op_name(Val* v) { return unaryOp(UnaryOpType::op_type, v); } \
-  TensorView* op_name(TensorView* tv) {                             \
-    return unaryOp(UnaryOpType::op_type, tv);                       \
+#define NVFUSER_DEFINE_UNARY_OP(op_name, op_type) \
+  Val* op_name(Val* v) {                          \
+    return unaryOp(UnaryOpType::op_type, v);      \
+  }                                               \
+  TensorView* op_name(TensorView* tv) {           \
+    return unaryOp(UnaryOpType::op_type, tv);     \
   }
 
 NVFUSER_DEFINE_UNARY_OP(set, Set)
@@ -686,10 +688,12 @@ NVFUSER_DEFINE_UNARY_FLOAT_OP(tan, Tan)
 NVFUSER_DEFINE_UNARY_FLOAT_OP(tanh, Tanh)
 #undef NVFUSER_DEFINE_UNARY_FLOAT_OP
 
-#define NVFUSER_DEFINE_UNARY_IS_OP(op_name, op_type)                  \
-  Val* op_name(Val* v) { return unaryIsOp(UnaryOpType::op_type, v); } \
-  TensorView* op_name(TensorView* tv) {                               \
-    return unaryIsOp(UnaryOpType::op_type, tv);                       \
+#define NVFUSER_DEFINE_UNARY_IS_OP(op_name, op_type) \
+  Val* op_name(Val* v) {                             \
+    return unaryIsOp(UnaryOpType::op_type, v);       \
+  }                                                  \
+  TensorView* op_name(TensorView* tv) {              \
+    return unaryIsOp(UnaryOpType::op_type, tv);      \
   }
 
 NVFUSER_DEFINE_UNARY_IS_OP(isfinite, IsFinite)

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -267,8 +267,9 @@ std::vector<KeyType> getSortedKeys(
 
 // Based on https://stackoverflow.com/a/9154394
 template <typename T>
-static auto hasToStringHelper(int)
-    -> decltype(std::declval<typename std::remove_pointer<T>::type>().toString(), std::true_type{});
+static auto hasToStringHelper(int) -> decltype(
+    std::declval<typename std::remove_pointer<T>::type>().toString(),
+    std::true_type{});
 
 template <typename>
 static auto hasToStringHelper(long) -> std::false_type;

--- a/runtime/array.cu
+++ b/runtime/array.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 // aligned register array for vectorized load/store
 template <typename scalar_t, int size, int align_size>
 struct alignas(sizeof(scalar_t) * align_size) Array {

--- a/runtime/basic_type_traits.cu
+++ b/runtime/basic_type_traits.cu
@@ -1,3 +1,4 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.

--- a/runtime/bf16_support.cu
+++ b/runtime/bf16_support.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 
 #define __NVFUSER_BFLOAT_TO_US(var) *(reinterpret_cast<unsigned short*>(&(var)))
 #define __NVFUSER_BFLOAT_TO_CUS(var) \

--- a/runtime/block_reduction.cu
+++ b/runtime/block_reduction.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 // [Z,Y,X]_THREADS is the number of participating threads in the z, y, x
 // dimension of the block. If set to false the dimension doesn't
 // participate in the reduction. We could start with warp reductions, then

--- a/runtime/block_sync_atomic.cu
+++ b/runtime/block_sync_atomic.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 
 // Counter-based block synchronization. Only meant to be used for
 // debugging and validating synchronization. This should be replaced

--- a/runtime/block_sync_default.cu
+++ b/runtime/block_sync_default.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 
 // Default block synchronization. Just use __barrier_sync
 namespace block_sync {

--- a/runtime/block_welford_outer.cu
+++ b/runtime/block_welford_outer.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 namespace fused_reduction {
 namespace impl {
 

--- a/runtime/broadcast.cu
+++ b/runtime/broadcast.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 
 namespace broadcast {
 // Broadcasts within partitioned groups of threads.

--- a/runtime/complex_number.cu
+++ b/runtime/complex_number.cu
@@ -1,3 +1,4 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.

--- a/runtime/fp16_support.cu
+++ b/runtime/fp16_support.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 
 #define __NVFUSER_HALF_TO_US(var) *(reinterpret_cast<unsigned short*>(&(var)))
 #define __NVFUSER_HALF_TO_CUS(var) \

--- a/runtime/fused_reduction.cu
+++ b/runtime/fused_reduction.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 namespace fused_reduction {
 
 namespace impl {

--- a/runtime/fused_welford_helper.cu
+++ b/runtime/fused_welford_helper.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 namespace fused_reduction {
 
 // Tuple of Welford avg, var and N parameters.

--- a/runtime/fused_welford_impl.cu
+++ b/runtime/fused_welford_impl.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 namespace fused_reduction {
 
 namespace impl {

--- a/runtime/fused_welford_impl_outer.cu
+++ b/runtime/fused_welford_impl_outer.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 namespace fused_reduction {
 
 namespace impl {

--- a/runtime/grid_broadcast.cu
+++ b/runtime/grid_broadcast.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 namespace grid_broadcast {
 
 // Broadcasts per-thread values across threads and blocks.

--- a/runtime/grid_reduction.cu
+++ b/runtime/grid_reduction.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 // Inter-block reduction.
 //
 // The gridReduce function performs point-wise reductions of scalars across

--- a/runtime/grid_sync.cu
+++ b/runtime/grid_sync.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 namespace grid_sync {
 
 // Get the first bit in a 64 bit integer

--- a/runtime/helpers.cu
+++ b/runtime/helpers.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 #define NVFUSER_DEFINE_MAGIC_ZERO          \
   __shared__ int nvfuser_zero_s;           \
   if (threadIdx.x == 0)                    \

--- a/runtime/index_utils.cu
+++ b/runtime/index_utils.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 namespace index_utils {
 
 // Utility functions

--- a/runtime/memory.cu
+++ b/runtime/memory.cu
@@ -1,3 +1,4 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.

--- a/runtime/random_numbers.cu
+++ b/runtime/random_numbers.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 __device__ unsigned int mulhilo32(
     unsigned int a,
     unsigned int b,

--- a/runtime/tensor.cu
+++ b/runtime/tensor.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 template <typename T, int N>
 struct Tensor {
   __device__ T& operator[](nvfuser_index_t ind) {

--- a/runtime/tensorcore.cu
+++ b/runtime/tensorcore.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 // Utility macro for this file
 #define DEVICE_INLINE __device__ inline
 

--- a/runtime/tuple.cu
+++ b/runtime/tuple.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 // std::tuple-like type
 template <typename... Types>
 struct Tuple;

--- a/runtime/type_traits.cu
+++ b/runtime/type_traits.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 // Type trait utils
 template <typename Type, bool is_volatile>
 struct MaybeVolatile;

--- a/runtime/warp.cu
+++ b/runtime/warp.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 namespace warp {
 
 template <

--- a/runtime/welford.cu
+++ b/runtime/welford.cu
@@ -1,8 +1,10 @@
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 template <typename DataType>
 struct WelfordTriplet {
   DataType avg;


### PR DESCRIPTION
- Enable clang-format with benchmark and runtime files
-  Add clang-format off/on to runtime files. Note that clang-format is entirely disabled for those files that are mostly just copied from external code such as basic_type_traits.cu
- A few real format fixes