### PR TITLE
Add value argument to pad op

### DIFF
--- a/csrc/ir_internal_nodes.h
+++ b/csrc/ir_internal_nodes.h
@@ -2238,7 +2238,8 @@ class TORCH_CUDA_CU_API PadOp : public Expr {
       IrBuilderPasskey passkey,
       TensorView* out,
       TensorView* inp,
-      const std::vector<Val*>& pad_widths);
+      const std::vector<Val*>& pad_widths,
+      Val* value);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
@@ -2257,6 +2258,10 @@ class TORCH_CUDA_CU_API PadOp : public Expr {
     return input(0);
   }
 
+  Val* value() const {
+    return input(1);
+  }
+
   //! Return axes that are actually paded, i.e., those that have
   //! non-zero pad widths
   std::vector<int> getPaddedAxes() const;
@@ -2271,7 +2276,7 @@ class TORCH_CUDA_CU_API PadOp : public Expr {
  private:
   //! Offset of pad_width inputs in the input vector
   int getPadWidthInputOffset() const {
-    return 1;
+    return 2;
   }
 
   //! Iterator to the first pad_width input

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -3117,7 +3117,8 @@ PadOp::PadOp(
     IrBuilderPasskey passkey,
     TensorView* out,
     TensorView* inp,
-    const std::vector<Val*>& pad_widths)
+    const std::vector<Val*>& pad_widths,
+    Val* value)
     : Expr(passkey) {
   const auto ndims =
       TensorDomain::noReductions(inp->getMaybeRFactorDomain()).size();
@@ -3133,6 +3134,7 @@ PadOp::PadOp(
       ". All dimensions, padded or not, must have width vals. Use zero for non non-padded dimensions.");
   addOutput(out);
   addInput(inp);
+  addInput(value);
   for (auto width : pad_widths) {
     TORCH_CHECK(width != nullptr, "Padding width must not be nullptr");
     addInput(width);

--- a/csrc/lower_index.cpp
+++ b/csrc/lower_index.cpp
@@ -1423,11 +1423,7 @@ void IndexLowering::handle(const PadOp* pad) {
   const auto in = lowerSrcIndex(pad->in(), pad->out());
   const auto out = lowerDstIndex(pad->out());
 
-  DataType dt = producer_tv->getDataType().value();
-  // Currently it's always padded by zero
-  const auto pad_val = isFloatingPointType(dt)
-      ? static_cast<Val*>(IrBuilder::create<Double>(0, dt))
-      : static_cast<Val*>(IrBuilder::create<Int>(0, dt));
+  const auto pad_val = pad->value();
 
   const auto producer_root_indices = Index::getProducerPerDimLogicalIndex(
       producer_tv, consumer_tv, for_loops_, getRotatedLoop());

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -381,7 +381,17 @@ TensorView* transpose(TensorView* x) {
 
 // Padding widths are assumed to be non-negative. Currently there's no
 // validation.
-TensorView* pad(TensorView* inp, const std::vector<Val*>& pad_widths) {
+TensorView* pad(
+    TensorView* inp,
+    const std::vector<Val*>& pad_widths,
+    Val* value) {
+  if (!value) {
+    DataType dt = inp->getDataType().value();
+    // Create a zero of the appropriate type
+    value = isFloatingPointType(dt)
+        ? static_cast<Val*>(IrBuilder::create<Double>(0, dt))
+        : static_cast<Val*>(IrBuilder::create<Int>(0, dt));
+  }
   const auto inp_dom = TensorDomain::noReductions(inp->getMaybeRFactorDomain());
   const auto ndims = inp_dom.size();
 
@@ -454,7 +464,7 @@ TensorView* pad(TensorView* inp, const std::vector<Val*>& pad_widths) {
           TensorDomain::getContiguityFilledWith(rfactor_ids, true)),
       *inp->getDataType());
 
-  IrBuilder::create<PadOp>(out, inp, normalized_pad_widths);
+  IrBuilder::create<PadOp>(out, inp, normalized_pad_widths, value);
 
   return out;
 }

--- a/csrc/ops/alias.h
+++ b/csrc/ops/alias.h
@@ -73,13 +73,16 @@ TORCH_CUDA_CU_API TensorView* transpose(
 //! Transpose a 2D tensor.
 TORCH_CUDA_CU_API TensorView* transpose(TensorView* x);
 
-//! Pad a tensor by given widths of zero. Similar to torch.pad, the
+//! Pad a tensor by given widths by specified value. Similar to torch.pad, the
 //! pad_widths vector specifies the padding widths of the innermost N
-//! dimensions, where N is half the size of the width vector. Padding
-//! is always done just by zero. TODO: Support other padding types
+//! dimensions, where N is half the size of the width vector. If value is
+//! omitted, a default value of zero is assumed. The provied value will be cast
+//! to the dtype of the argument x.
+//! TODO: Support other padding types
 TORCH_CUDA_CU_API TensorView* pad(
     TensorView* x,
-    const std::vector<Val*>& pad_widths);
+    const std::vector<Val*>& pad_widths,
+    Val* value = nullptr);
 
 //! Concatenate tensors in the given dimension
 TORCH_CUDA_CU_API TensorView* cat(

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -1591,4 +1591,66 @@ TEST_F(NVFuserTest, FusionResizeSoftmaxSliceScheduler2_CUDA) {
       __FILE__);
 }
 
+// Same as Pad1 but pad by specified value
+TEST_F(NVFuserTest, FusionResizePadWithValue_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape({9});
+
+  auto tv0 = makeSymbolicTensor(1);
+  fusion.addInput(tv0);
+
+  auto tv1 =
+      pad(tv0,
+          {IrBuilder::create<Int>(1), IrBuilder::create<Int>(1)},
+          IrBuilder::create<Int>(2));
+  fusion.addOutput(tv1);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::manual_seed(0);
+
+  auto t0 = at::randn(shape, options);
+  std::vector<c10::IValue> aten_inputs({t0});
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion, aten_inputs);
+  auto cg_outputs = fe.runFusion(aten_inputs);
+
+  auto ref = at::pad(t0, {1, 1}, "constant", 2);
+
+  TORCH_CHECK(ref.equal(cg_outputs[0]));
+}
+
+// Same as above but try to pad an int tensor with a double value
+TEST_F(NVFuserTest, FusionResizePadIntWithDoubleValue_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape({9});
+
+  auto tv0 = makeSymbolicTensor(1, DataType::Int);
+  fusion.addInput(tv0);
+
+  auto tv1 =
+      pad(tv0,
+          {IrBuilder::create<Int>(1), IrBuilder::create<Int>(1)},
+          IrBuilder::create<Double>(2.5));
+  fusion.addOutput(tv1);
+
+  auto options = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
+  at::manual_seed(0);
+
+  auto t0 = at::ones(shape, options);
+  std::vector<c10::IValue> aten_inputs({t0});
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion, aten_inputs);
+  auto cg_outputs = fe.runFusion(aten_inputs);
+
+  auto ref = at::pad(t0, {1, 1}, "constant", 2.5);
+
+  TORCH_CHECK(ref.equal(cg_outputs[0]));
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
This adds a fill value argument (default 0) for the pad op.