### PR TITLE
Avoid input cache when resized

### DIFF
--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -1157,7 +1157,7 @@ void schedulePersistentKernel(Fusion* fusion, const ReductionParams& rparams) {
   // fusion segmentation
   scheduler_utils::clearMemorySpace(fusion);
 
-  scheduler_utils::prepareForMemoryTypePromotion(fusion, cached_inputs);
+  scheduler_utils::prepareForMemoryTypePromotion(fusion);
 
   auto reduction_tvs = scheduler_utils::getReductionTvs(fusion);
 
@@ -1229,7 +1229,8 @@ void schedulePersistentKernel(Fusion* fusion, const ReductionParams& rparams) {
     }
   }
 
-  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(fusion, cached_inputs);
+  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(
+      fusion, cached_inputs);
 }
 
 } // namespace nvfuser

--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -1157,7 +1157,7 @@ void schedulePersistentKernel(Fusion* fusion, const ReductionParams& rparams) {
   // fusion segmentation
   scheduler_utils::clearMemorySpace(fusion);
 
-  scheduler_utils::prepareForMemoryTypePromotion(fusion);
+  scheduler_utils::prepareForMemoryTypePromotion(fusion, cached_inputs);
 
   auto reduction_tvs = scheduler_utils::getReductionTvs(fusion);
 
@@ -1229,7 +1229,7 @@ void schedulePersistentKernel(Fusion* fusion, const ReductionParams& rparams) {
     }
   }
 
-  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(fusion);
+  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(fusion, cached_inputs);
 }
 
 } // namespace nvfuser

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -448,9 +448,7 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
   // Cache and fork outputs
   auto cached_outputs = scheduler_utils::cacheAndForkOutputs(fusion, true);
 
-  // Create a cache for a tensor if it may need to be placed on a
-  // farther but shared memory space
-  scheduler_utils::prepareForMemoryTypePromotion(fusion);
+  scheduler_utils::prepareForMemoryTypePromotion(fusion, cached_inputs);
 
   std::vector<TensorView*> input_tvs;
   {
@@ -805,7 +803,8 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
   }
   inlineMost(inner_most_tensors);
 
-  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(fusion);
+  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(
+      fusion, cached_inputs);
 }
 
 } // namespace nvfuser

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -448,7 +448,7 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
   // Cache and fork outputs
   auto cached_outputs = scheduler_utils::cacheAndForkOutputs(fusion, true);
 
-  scheduler_utils::prepareForMemoryTypePromotion(fusion, cached_inputs);
+  scheduler_utils::prepareForMemoryTypePromotion(fusion);
 
   std::vector<TensorView*> input_tvs;
   {

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -995,7 +995,7 @@ void scheduleReduction(Fusion* fusion, const ReductionParams& rparams) {
   // fusion segmentation
   scheduler_utils::clearMemorySpace(fusion);
 
-  scheduler_utils::prepareForMemoryTypePromotion(fusion);
+  scheduler_utils::prepareForMemoryTypePromotion(fusion, cached_inputs);
 
   auto reduction_tvs = scheduler_utils::getReductionTvs(fusion);
 
@@ -1049,7 +1049,7 @@ void scheduleReduction(Fusion* fusion, const ReductionParams& rparams) {
       cached_inputs,
       cached_outputs);
 
-  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(fusion);
+  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(fusion, cached_inputs);
 }
 
 } // namespace nvfuser

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -995,7 +995,7 @@ void scheduleReduction(Fusion* fusion, const ReductionParams& rparams) {
   // fusion segmentation
   scheduler_utils::clearMemorySpace(fusion);
 
-  scheduler_utils::prepareForMemoryTypePromotion(fusion, cached_inputs);
+  scheduler_utils::prepareForMemoryTypePromotion(fusion);
 
   auto reduction_tvs = scheduler_utils::getReductionTvs(fusion);
 
@@ -1049,7 +1049,8 @@ void scheduleReduction(Fusion* fusion, const ReductionParams& rparams) {
       cached_inputs,
       cached_outputs);
 
-  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(fusion, cached_inputs);
+  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(
+      fusion, cached_inputs);
 }
 
 } // namespace nvfuser

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2439,7 +2439,16 @@ void prepareForMemoryTypePromotion(Fusion* fusion) {
   std::unordered_set<TensorView*> cached;
   for (auto resized_tensor : resized_tensors) {
     // Resized tensors are those created by operations like pad and
-    // slice. Assume it has only one input tensor, which may need to
+    // slice. If it has no defining expression, it must be a fusion
+    // input, and no need of the memory type promotion
+    if (resized_tensor->definition() == nullptr) {
+      TORCH_INTERNAL_ASSERT(
+          resized_tensor->isFusionInput(),
+          "Unexpected resized tensor: ",
+          resized_tensor->toString());
+      continue;
+    }
+    // Assume it has only one input tensor, which may need to
     // be placed on a non-local memory for data dependencies.
     TORCH_INTERNAL_ASSERT(
         resized_tensor->definition(),

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2371,7 +2371,7 @@ std::vector<TensorView*> getResizedTensors(Fusion* fusion) {
 }
 
 // If the producer of a resized tensor is an input cache and we need to promote
-// it to global memory, just do not cache the input but directy read from the
+// it to global memory, just do not cache the input but directly read from the
 // global memory input. It doesn't make any sense to cache a global memory input
 // in global memory. Note that a copy of an input cache is inserted by
 // prepareForMemoryTypePromotion, so grab the producer of the
@@ -2392,7 +2392,7 @@ bool revertUseOfInputCacheInResize(
 
   // Only applies if the promoted new type is Global
   if (promoted_memory_type != MemoryType::Global) {
-    return true;
+    return false;
   }
 
   // To see if the producer is a cache of an input, need to look at
@@ -2400,7 +2400,7 @@ bool revertUseOfInputCacheInResize(
   auto producer_of_producer = get_copy_src(producer_of_resize);
   if (producer_of_producer == nullptr) {
     // No copy is detected. This must mean the producer is not a copy
-    // of an input cache
+    // of any input cache
     return false;
   }
 
@@ -2422,7 +2422,6 @@ bool revertUseOfInputCacheInResize(
   // tv2 = tv1 // copy of the tv1. Placed on Global
   // tv3 = resizeOp(tv2) // some op using resize
 
-  //
   // Translate it to:
   // tv0: fusion input
   // tv3 = resizeOp(tv0) // some op using resize

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -573,14 +573,17 @@ inline void rotateLoop(
 //! caches of those tensors so that original operations producing
 //! them should keep using the same memory. This avoids, for example,
 //! reductions to global memory.
-TORCH_CUDA_CU_API void prepareForMemoryTypePromotion(Fusion* fusion);
+TORCH_CUDA_CU_API void prepareForMemoryTypePromotion(
+    Fusion* fusion,
+    const std::vector<TensorView*>& input_caches = {});
 
 //! If a resized tensor induces a data dependency between threads,
 //! move its producer to a shared memory that is sufficient to satisfy
 //! the dependency. A proper RAW sync will be automatically inserted
 //! when the fusion is lowered.
 TORCH_CUDA_CU_API void promoteProducerMemoryTypesOfResizedTensors(
-    Fusion* fusion);
+    Fusion* fusion,
+    const std::vector<TensorView*>& maybe_reverted_input_caches = {});
 
 } // namespace scheduler_utils
 } // namespace nvfuser

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -573,9 +573,7 @@ inline void rotateLoop(
 //! caches of those tensors so that original operations producing
 //! them should keep using the same memory. This avoids, for example,
 //! reductions to global memory.
-TORCH_CUDA_CU_API void prepareForMemoryTypePromotion(
-    Fusion* fusion,
-    const std::vector<TensorView*>& input_caches = {});
+TORCH_CUDA_CU_API void prepareForMemoryTypePromotion(Fusion* fusion);
 
 //! If a resized tensor induces a data dependency between threads,
 //! move its producer to a shared memory that is sufficient to satisfy
@@ -583,7 +581,7 @@ TORCH_CUDA_CU_API void prepareForMemoryTypePromotion(
 //! when the fusion is lowered.
 TORCH_CUDA_CU_API void promoteProducerMemoryTypesOfResizedTensors(
     Fusion* fusion,
-    const std::vector<TensorView*>& maybe_reverted_input_caches = {});
+    const std::vector<TensorView*>& input_caches);
 
 } // namespace scheduler_utils
 } // namespace nvfuser

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -325,11 +325,6 @@ TEST_F(NVFuserTest, FusionResizePad8_CUDA) {
 
   scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(&fusion, {});
 
-  fusion.printMath();
-  fusion.print();
-
-  fusion.printKernel();
-
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::manual_seed(0);
 
@@ -1632,8 +1627,6 @@ TEST_F(NVFuserTest, FusionSliceForNanoGPT_CUDA) {
   auto t0 = at::randn(input_shape0, options);
   auto t1 = at::randn(input_shape1, options);
   std::vector<c10::IValue> aten_inputs({t0, t1});
-
-  fusion.print();
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);


### PR DESCRIPTION
C++ test copied from #27 

If the producer of a resized tensor is an input cache and we need to promote it to global memory, just do not cache the input but directly read from the global memory input. It doesn't make any sense to cache a global memory input in global memory. 

This fixes the issue of #27, which is due to the grid sync inserted for an input to pad, where the input is a copy of a fusion input.