### PR TITLE
Fix dtype calculation in expr simplifier

### DIFF
--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -192,7 +192,7 @@ bool hasSimilarType(DataType t1, DataType t2) {
   if (t1 == t2) {
     return true;
   }
-  if (isIntegralType(t1) && isIntegralType(t2)) {
+  if (isIntegralOrPointerType(t1) && isIntegralOrPointerType(t2)) {
     return true;
   }
   if (isFloatingPointType(t1) && isFloatingPointType(t2)) {
@@ -345,6 +345,14 @@ bool hasUnrolledLoopIndex(Val* value, const Context& context) {
     }
   }
   return false;
+}
+
+inline DataType inferDtypes(const std::vector<Val*>& vals) {
+  auto dtype = *vals.at(0)->getDataType();
+  for (auto v : vals) {
+    dtype = promoteType(dtype, *v->getDataType());
+  }
+  return dtype;
 }
 
 } // namespace
@@ -735,7 +743,7 @@ Val* flattenRule(Val* value) {
       return inputs.at(0);
     }
 
-    auto output = IrBuilder::newScalar(*value->getDataType());
+    auto output = IrBuilder::newScalar(inferDtypes(inputs));
     IrBuilder::create<FlattenedAssocCommOp>(op, output, std::move(inputs));
     return output;
   }
@@ -779,11 +787,7 @@ Val* unflattenRule(Val* value, const Context& context) {
     while (next < (int64_t)sorted_inputs.size()) {
       auto rhs = unflatten(sorted_inputs.at(next), context);
       if (fop->getOpType() == BinaryOpType::Add) {
-        // For binary add/sub op, we need to correctly handle the promotion rule
-        // ptr + int -> ptr and ptr - int -> ptr, so we use IrBuilder::addExpr
-        // and IrBuilder::subExpr here.
-        // Also, convert a + (-b) to a - b here for better readibility on
-        // generated code
+        // Convert a + (-b) to a - b for better readibility on generated code
         auto uop = dynamic_cast<UnaryOp*>(rhs->definition());
         if (uop != nullptr && uop->getUnaryOpType() == UnaryOpType::Neg) {
           lhs = IrBuilder::subExpr(lhs, uop->in());
@@ -791,7 +795,8 @@ Val* unflattenRule(Val* value, const Context& context) {
           lhs = IrBuilder::addExpr(lhs, rhs);
         }
       } else {
-        auto output = IrBuilder::newScalar(*value->getDataType());
+        auto output = IrBuilder::newScalar(
+            promoteType(*lhs->getDataType(), *rhs->getDataType()));
         IrBuilder::create<BinaryOp>(fop->getOpType(), output, lhs, rhs);
         lhs = output;
       }
@@ -861,40 +866,47 @@ BinaryOp* toDivModOp(Expr* expr) {
 // a * b --> (1, {a, b})
 // 3 * 5 --> (15, {})
 // If the given Val `x` is not a flattened mul, then return (1, {x})
-std::pair<int64_t, std::list<Val*>> getConstAndSymbolicFactors(Val* x) {
+std::pair<Val*, std::list<Val*>> getConstAndSymbolicFactors(Val* x) {
   std::vector<Val*> factors;
   if (auto fop = toFlattenedMul(x->definition())) {
     factors = fop->inputs();
   } else {
     factors.emplace_back(x);
   }
+  DataType const_dtype = DataType::Null;
   int64_t const_factor = 1;
   std::list<Val*> symbolic_factors;
   for (auto f : factors) {
     f = foldConstants(f);
     if (f->getInt().has_value()) {
+      if (const_dtype == DataType::Null) {
+        const_dtype = *f->getDataType();
+      } else {
+        const_dtype = promoteType(const_dtype, *f->getDataType());
+      }
       const_factor *= *f->getInt();
     } else {
       symbolic_factors.emplace_back(f);
     }
   }
-  return {const_factor, symbolic_factors};
+  if (const_dtype == DataType::Null) {
+    // If there is no constant factors, use the dtype of x
+    const_dtype = *x->getDataType();
+  }
+  return {IrBuilder::newConstant(const_factor, const_dtype), symbolic_factors};
 }
 
-Val* productOfFactors(
-    int64_t const_factor,
-    std::vector<Val*> symbolic_factors,
-    DataType dtype) {
-  if (const_factor != 1) {
-    symbolic_factors.emplace_back(IrBuilder::newConstant(const_factor, dtype));
+Val* productOfFactors(Val* const_factor, std::vector<Val*> symbolic_factors) {
+  if (*const_factor->getInt() != 1) {
+    symbolic_factors.emplace_back(const_factor);
   }
   if (symbolic_factors.size() == 1) {
     return symbolic_factors.at(0);
   }
   if (symbolic_factors.empty()) {
-    return IrBuilder::newConstant(1, dtype);
+    return IrBuilder::newConstant(1, *const_factor->getDataType());
   }
-  auto output = IrBuilder::newScalar(dtype);
+  auto output = IrBuilder::newScalar(inferDtypes(symbolic_factors));
   IrBuilder::create<FOp>(
       BinaryOpType::Mul, output, std::move(symbolic_factors));
   return output;
@@ -922,11 +934,12 @@ Val* divideFactorized(Val* x, Val* y) {
   int64_t quoient_const_factor;
   std::vector<Val*> quoient_symbolic_factors;
 
-  if (x_factors.first % y_factors.first != 0) {
+  if (*x_factors.first->getInt() % *y_factors.first->getInt() != 0) {
     // not divisible
     return nullptr;
   } else {
-    quoient_const_factor = x_factors.first / y_factors.first;
+    quoient_const_factor =
+        *x_factors.first->getInt() / *y_factors.first->getInt();
   }
 
   for (auto yf : y_factors.second) {
@@ -945,9 +958,12 @@ Val* divideFactorized(Val* x, Val* y) {
       x_factors.second.begin(),
       x_factors.second.end());
   return productOfFactors(
-      quoient_const_factor,
-      std::move(quoient_symbolic_factors),
-      *x->getDataType());
+      IrBuilder::newConstant(
+          quoient_const_factor,
+          promoteType(
+              *x_factors.first->getDataType(),
+              *y_factors.first->getDataType())),
+      std::move(quoient_symbolic_factors));
 }
 
 // Symbolic gcd, for example: greatestCommonDivisor({6*a*b, 9*b*c}) -> 3*b
@@ -958,9 +974,18 @@ Val* greatestCommonDivisor(const std::vector<Val*>& inputs) {
   // The gcd of the symbolic part. nullptr serve as 0, empty vector serve as 1.
   std::unique_ptr<std::vector<Val*>> common_symbolic_factors = nullptr;
 
+  DataType const_factor_dtype = DataType::Null;
+
   for (auto inp : inputs) {
     auto factors = getConstAndSymbolicFactors(inp);
-    common_const_factor = std::gcd(common_const_factor, factors.first);
+    if (const_factor_dtype == DataType::Null) {
+      const_factor_dtype = *factors.first->getDataType();
+    } else {
+      const_factor_dtype =
+          promoteType(const_factor_dtype, *factors.first->getDataType());
+    }
+    common_const_factor =
+        std::gcd(common_const_factor, *factors.first->getInt());
     std::vector<Val*> new_common_symbolic_factors;
     if (common_symbolic_factors == nullptr) {
       // gcd(0, x) -> x
@@ -987,9 +1012,8 @@ Val* greatestCommonDivisor(const std::vector<Val*>& inputs) {
   TORCH_INTERNAL_ASSERT(common_const_factor != 0);
   TORCH_INTERNAL_ASSERT(common_symbolic_factors != nullptr);
   return productOfFactors(
-      common_const_factor,
-      std::move(*common_symbolic_factors),
-      *inputs[0]->getDataType());
+      IrBuilder::newConstant(common_const_factor, const_factor_dtype),
+      std::move(*common_symbolic_factors));
 }
 
 namespace {
@@ -1000,11 +1024,18 @@ Val* factorizeFlattenedMul(Val* x) {
   // Recursively factorize all its inputs, and combine their terms
   int64_t const_factor = 1;
   std::vector<Val*> symbolic_factors;
+  DataType const_factor_dtype = DataType::Null;
   bool changed = false;
   for (auto inp : fop->inputs()) {
     auto factorized_inp = factorize(inp);
     auto factors = getConstAndSymbolicFactors(factorized_inp);
-    const_factor *= factors.first;
+    if (const_factor_dtype == DataType::Null) {
+      const_factor_dtype = *factors.first->getDataType();
+    } else {
+      const_factor_dtype =
+          promoteType(const_factor_dtype, *factors.first->getDataType());
+    }
+    const_factor *= *factors.first->getInt();
     symbolic_factors.insert(
         symbolic_factors.end(), factors.second.begin(), factors.second.end());
     if (factors.second != std::list<Val*>{inp}) {
@@ -1016,7 +1047,8 @@ Val* factorizeFlattenedMul(Val* x) {
     return x;
   }
   return productOfFactors(
-      const_factor, std::move(symbolic_factors), *x->getDataType());
+      IrBuilder::newConstant(const_factor, const_factor_dtype),
+      std::move(symbolic_factors));
 }
 
 Val* factorizeFlattenedAdd(Val* x) {
@@ -1042,10 +1074,11 @@ Val* factorizeFlattenedAdd(Val* x) {
     TORCH_INTERNAL_ASSERT(quotient != nullptr);
     quotient_inputs.emplace_back(quotient);
   }
-  auto quotient = IrBuilder::newScalar(*x->getDataType());
+  auto quotient = IrBuilder::newScalar(inferDtypes(quotient_inputs));
   IrBuilder::create<FOp>(
       BinaryOpType::Add, quotient, std::move(quotient_inputs));
-  auto product = IrBuilder::newScalar(*x->getDataType());
+  auto product = IrBuilder::newScalar(
+      promoteType(*quotient->getDataType(), *gcd->getDataType()));
   IrBuilder::create<FOp>(
       BinaryOpType::Mul, product, std::vector<Val*>{quotient, gcd});
   // Quotient might contain nested FlattenedAdd, for example, if we have:
@@ -1305,7 +1338,8 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
           if (const_term == nullptr) {
             const_term = inp;
           } else {
-            auto out = IrBuilder::newScalar(*const_term->getDataType());
+            auto out = IrBuilder::newScalar(
+                promoteType(*const_term->getDataType(), *inp->getDataType()));
             IrBuilder::create<BinaryOp>(op, out, const_term, inp);
             const_term = out;
             changed = true;
@@ -1337,7 +1371,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
         if (new_inputs.size() == 1) {
           return new_inputs.at(0);
         }
-        auto output = IrBuilder::newScalar(*value->getDataType());
+        auto output = IrBuilder::newScalar(inferDtypes(new_inputs));
         IrBuilder::create<FOp>(op, output, std::move(new_inputs));
         return output;
       }
@@ -1361,7 +1395,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
           if (dedup_input.size() == 1) {
             return dedup_input.at(0);
           } else {
-            auto output = IrBuilder::newScalar(*value->getDataType());
+            auto output = IrBuilder::newScalar(inferDtypes(dedup_input));
             IrBuilder::create<FOp>(op, output, std::move(dedup_input));
             return output;
           }
@@ -1369,9 +1403,10 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       }
     }
   } else if (auto bop = dynamic_cast<BinaryOp*>(value->definition())) {
+    auto lhs = foldConstants(bop->lhs());
+    auto rhs = foldConstants(bop->rhs());
     if (bop->getBinaryOpType() == BinaryOpType::Mod) {
       // a % 1 -> 0
-      auto rhs = foldConstants(bop->rhs());
       if (rhs->isOneInt()) {
         return IrBuilder::newConstant(0, *value->getDataType());
       }
@@ -1380,15 +1415,11 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
         bop->getBinaryOpType() == BinaryOpType::CeilDiv) {
       // a / 1 -> a
       // 0 / a -> 0
-      auto lhs = foldConstants(bop->lhs());
-      auto rhs = foldConstants(bop->rhs());
       if (rhs->isOne() ||
           (isValidDenominator(rhs, context) && lhs->getInt() == 0)) {
         return lhs;
       }
     } else if (bop->getBinaryOpType() == BinaryOpType::Sub) {
-      auto lhs = foldConstants(bop->lhs());
-      auto rhs = foldConstants(bop->rhs());
       if (lhs->sameAs(rhs)) {
         return IrBuilder::newConstant(0, *value->getDataType());
       }
@@ -1578,20 +1609,22 @@ Val* distributeDivisibleDivMod(Val* value, const Context& context) {
     if (other_terms.size() == 1) {
       sum_of_other_terms = other_terms.at(0);
     } else {
-      sum_of_other_terms = IrBuilder::newScalar(*value->getDataType());
+      sum_of_other_terms = IrBuilder::newScalar(inferDtypes(other_terms));
       IrBuilder::create<FOp>(
           BinaryOpType::Add, sum_of_other_terms, std::move(other_terms));
     }
     if (prove::hasCompatibleSign(divisible_term, sum_of_other_terms, context)) {
       std::vector<Val*> new_inputs;
-      auto term1 = IrBuilder::newScalar(*value->getDataType());
+      auto term1 = IrBuilder::newScalar(
+          promoteType(*divisible_term->getDataType(), *rhs->getDataType()));
       IrBuilder::create<BinaryOp>(
           divmod->getBinaryOpType(), term1, divisible_term, rhs);
       new_inputs.emplace_back(simplifyDivisibleDivMod(term1, context));
-      new_inputs.emplace_back(IrBuilder::newScalar(*value->getDataType()));
+      new_inputs.emplace_back(IrBuilder::newScalar(promoteType(
+          *sum_of_other_terms->getDataType(), *rhs->getDataType())));
       IrBuilder::create<BinaryOp>(
           divmod->getBinaryOpType(), new_inputs[1], sum_of_other_terms, rhs);
-      auto output = IrBuilder::newScalar(*value->getDataType());
+      auto output = IrBuilder::newScalar(inferDtypes(new_inputs));
       IrBuilder::create<FOp>(BinaryOpType::Add, output, std::move(new_inputs));
       return output;
     }
@@ -1622,11 +1655,11 @@ Val* distributeMul(Val* value, const Context& context) {
   for (auto inp : fadd_op->inputs()) {
     std::vector<Val*> inputs = other_terms;
     inputs.emplace_back(inp);
-    add_terms.emplace_back(IrBuilder::newScalar(*value->getDataType()));
+    add_terms.emplace_back(IrBuilder::newScalar(inferDtypes(inputs)));
     IrBuilder::create<FOp>(
         BinaryOpType::Mul, add_terms.back(), std::move(inputs));
   }
-  auto output = IrBuilder::newScalar(*value->getDataType());
+  auto output = IrBuilder::newScalar(inferDtypes(add_terms));
   IrBuilder::create<FOp>(BinaryOpType::Add, output, std::move(add_terms));
   return output;
 }
@@ -1805,7 +1838,7 @@ Val* fundamentalDivisionWithRemainderProperty(
         } else if (other_terms.size() == 1) {
           c = other_terms.at(0);
         } else {
-          c = IrBuilder::newScalar(*vmul->getDataType());
+          c = IrBuilder::newScalar(inferDtypes(other_terms));
           IrBuilder::create<FOp>(BinaryOpType::Mul, c, std::move(other_terms));
         }
         if (!isIntegralType(*a->getDataType()) ||
@@ -1872,7 +1905,8 @@ Val* fundamentalDivisionWithRemainderProperty(
         // Found match!
         // Simplify [1] + [2] + ... + [i] + ... + [j] + ...
         // As: [1] + [2] + a * c ... + ...  + ...
-        Val* ac = IrBuilder::newScalar(*value->getDataType());
+        Val* ac = IrBuilder::newScalar(
+            promoteType(*a1->getDataType(), *c->getDataType()));
         IrBuilder::create<FOp>(BinaryOpType::Mul, ac, std::vector<Val*>{a1, c});
         std::vector<Val*> terms{ac};
         for (auto k : c10::irange(fadd->inputs().size())) {
@@ -1884,7 +1918,7 @@ Val* fundamentalDivisionWithRemainderProperty(
         if (terms.size() == 1) {
           return terms.at(0);
         } else {
-          Val* result = IrBuilder::newScalar(*value->getDataType());
+          Val* result = IrBuilder::newScalar(inferDtypes(terms));
           IrBuilder::create<FOp>(BinaryOpType::Add, result, terms);
           return result;
         }

--- a/csrc/ir_builder.cpp
+++ b/csrc/ir_builder.cpp
@@ -58,27 +58,10 @@ Val* IrBuilder::newArithmeticExpr(BinaryOpType op_type, Val* lhs, Val* rhs) {
   // than just allowing the integer type promotion for the two inputs as below.
   // Note that this is only needed for integer types. See also PR #2228.
   if (lhs->dtype() != rhs->dtype()) {
-    if (isPointerType(lhs->dtype())) {
-      TORCH_INTERNAL_ASSERT(isIntegralType(rhs->dtype()));
+    dtype = promoteType(lhs->dtype(), rhs->dtype());
+    if (isPointerType(lhs->dtype()) || isPointerType(rhs->dtype())) {
       TORCH_INTERNAL_ASSERT(
           op_type == BinaryOpType::Add || op_type == BinaryOpType::Sub);
-      dtype = lhs->dtype();
-    } else if (isPointerType(rhs->dtype())) {
-      TORCH_INTERNAL_ASSERT(isIntegralType(lhs->dtype()));
-      TORCH_INTERNAL_ASSERT(
-          op_type == BinaryOpType::Add || op_type == BinaryOpType::Sub);
-      dtype = rhs->dtype();
-    } else if (
-        (lhs->dtype() == DataType::Int && rhs->dtype() == DataType::Int32) ||
-        (lhs->dtype() == DataType::Int32 && rhs->dtype() == DataType::Int)) {
-      dtype = DataType::Int;
-    } else {
-      TORCH_CHECK(
-          false,
-          "Incompatible operand types: ",
-          lhs->dtype(),
-          " and ",
-          rhs->dtype());
     }
   }
   auto result = newScalar(dtype);

--- a/csrc/ir_interface_nodes.h
+++ b/csrc/ir_interface_nodes.h
@@ -58,7 +58,8 @@ class TORCH_CUDA_CU_API Scalar : public Val {
   explicit Scalar(IrBuilderPasskey passkey, DataType dtype = kDefaultDataType)
       : Val(passkey, ValType::Scalar, dtype), maybe_value_{c10::nullopt} {
     TORCH_INTERNAL_ASSERT(
-        (std::is_integral<UnderlyingType>::value && isIntegralType(dtype)) ||
+        (std::is_integral<UnderlyingType>::value &&
+         isIntegralOrPointerType(dtype)) ||
             (std::is_same<UnderlyingType, bool>::value &&
              isBooleanType(dtype)) ||
             (std::is_floating_point<UnderlyingType>::value &&

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -89,7 +89,7 @@ TensorIndex::TensorIndex(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   TORCH_INTERNAL_ASSERT(
-      isIntegralType(index->dtype()),
+      isIntegralOrPointerType(index->dtype()),
       "Cannot index with a value other than an int.");
 }
 

--- a/csrc/lower_scalar_hoist.cpp
+++ b/csrc/lower_scalar_hoist.cpp
@@ -278,7 +278,7 @@ std::vector<Bool*> getAssumptions(const std::vector<kir::ForLoop*>& loops) {
 Val* CommonScalarMap::hoistScalar(
     Val* value,
     const std::vector<kir::ForLoop*>& loops) {
-  value = simplifyExpr(value, getLoopIndices(loops), getAssumptions(loops));
+  value = simplifyExpr(value, getVariableInfo(loops), getAssumptions(loops));
   if (isOptionDisabled(DisableOption::IndexHoist)) {
     return value;
   }

--- a/csrc/lower_scalar_hoist.cpp
+++ b/csrc/lower_scalar_hoist.cpp
@@ -278,7 +278,8 @@ std::vector<Bool*> getAssumptions(const std::vector<kir::ForLoop*>& loops) {
 Val* CommonScalarMap::hoistScalar(
     Val* value,
     const std::vector<kir::ForLoop*>& loops) {
-  value = simplifyExpr(value, getVariableInfo(loops), getAssumptions(loops));
+  value =
+      simplifyExpr(value, getVariableInfo(value, loops), getAssumptions(loops));
   if (isOptionDisabled(DisableOption::IndexHoist)) {
     return value;
   }

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -768,7 +768,7 @@ DataType getOutputType(
   if (isLogicalOp(op_type)) {
     return DataType::Bool;
   } else if (common_dtype == DataType::Null) {
-    return promote_type(v1->getDataType().value(), v2->getDataType().value());
+    return promoteType(v1->getDataType().value(), v2->getDataType().value());
   } else {
     return common_dtype;
   }
@@ -779,7 +779,7 @@ DataType getOutputType(
 Val* binaryOp(BinaryOpType type, Val* v1, Val* v2, DataType common_dtype) {
   const auto out_dtype = getOutputType(type, v1, v2, common_dtype);
   const auto out_vtype =
-      promote_type(v1->getValType().value(), v2->getValType().value());
+      promoteType(v1->getValType().value(), v2->getValType().value());
   auto vals = ops::maybeBroadcast({v1, v2});
   Val* out = nullptr;
   if (out_vtype == ValType::TensorView) {
@@ -1835,9 +1835,9 @@ Val* lerp(Val* start, Val* end, Val* weight) {
   weight = cast_values[2];
 
   auto out_dtype =
-      promote_type(start->getDataType().value(), end->getDataType().value());
+      promoteType(start->getDataType().value(), end->getDataType().value());
   auto out_vtype =
-      promote_type(start->getValType().value(), end->getValType().value());
+      promoteType(start->getValType().value(), end->getValType().value());
 
   auto vals = ops::maybeBroadcast({start, end, weight});
   Val* out = nullptr;
@@ -1928,7 +1928,7 @@ Val* where(Val* c, Val* v1, Val* v2) {
   TORCH_CHECK(c->getDataType().value() == DataType::Bool);
   auto out_dtype = common_dtype;
   auto out_vtype =
-      promote_type(v1->getValType().value(), v2->getValType().value());
+      promoteType(v1->getValType().value(), v2->getValType().value());
   // Even when v1 and v2 are scalar, the output is a tensor if the
   // conditional input is a tensor.
   if (c->getValType() == ValType::TensorView) {

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -32,58 +32,6 @@ KernelIndexMode indexTypeToMode(DataType index_type) {
       : KernelIndexMode::INT64;
 }
 
-bool isFloatingPointType(DataType dtype) {
-  TORCH_CHECK(
-      dtype != DataType::Null,
-      "Null type is not a valid argument to isFloatingPointType");
-  return dtype == DataType::Double || dtype == DataType::Float ||
-      dtype == DataType::Half || dtype == DataType::BFloat16;
-}
-
-bool isBooleanType(DataType dtype) {
-  TORCH_CHECK(
-      dtype != DataType::Null,
-      "Null type is not a valid argument to isBooleanType");
-  return dtype == DataType::Bool;
-}
-
-bool isIntegralType(DataType dtype) {
-  return std::visit(
-      [](auto&& dtype) {
-        using T = std::decay_t<decltype(dtype)>;
-        if constexpr (std::is_same_v<T, PrimDataType>) {
-          switch (dtype) {
-            case DataType::Index:
-            case DataType::Int:
-            case DataType::Int32:
-            case DataType::SMemAddress:
-              return true;
-            case DataType::Null:
-              TORCH_CHECK(
-                  false, "Null type is not a valid argument to isIntegralType");
-            default:
-              return false;
-          }
-        } else if constexpr (std::is_same_v<T, PointerOf>) {
-          return true;
-        }
-        return false;
-      },
-      dtype.type);
-}
-
-bool isPointerType(DataType dtype) {
-  return std::holds_alternative<PointerOf>(dtype.type) ||
-      dtype == DataType::SMemAddress;
-}
-
-bool isComplexType(DataType dtype) {
-  TORCH_CHECK(
-      dtype != DataType::Null,
-      "Null type is not a valid argument to isComplexType");
-  return dtype == DataType::ComplexFloat || dtype == DataType::ComplexDouble;
-}
-
 DataType getTypeFromComplexType(DataType dtype) {
   switch (std::get<PrimDataType>(dtype.type)) {
     case DataType::ComplexFloat:
@@ -121,19 +69,7 @@ bool alsoBooleanOperator(const UnaryOpType uopt) {
 }
 
 // Return highest on list (smallest enum val)
-DataType promote_type(const DataType& t1, const DataType& t2) {
-  TORCH_CHECK(
-      DataType::Null != t1 && DataType::Null != t2,
-      "Expected promotable DataTypes but got: ",
-      t1,
-      " and ",
-      t2);
-  return aten_to_data_type(
-      c10::promoteTypes(data_type_to_aten(t1), data_type_to_aten(t2)));
-}
-
-// Return highest on list (smallest enum val)
-ValType promote_type(const ValType& t1, const ValType& t2) {
+ValType promoteType(const ValType& t1, const ValType& t2) {
   if (t1 == ValType::TensorView || t2 == ValType::TensorView) {
     return ValType::TensorView;
   }
@@ -157,6 +93,10 @@ static std::string data_type2string(DataType t) {
         using T = std::decay_t<decltype(dtype)>;
         if constexpr (std::is_same_v<T, PrimDataType>) {
           switch (dtype) {
+            case DataType::Null:
+              // This is not a real C++ type, but being able to print a string
+              // for it is convenient for debugging.
+              return "null_type";
             case DataType::Bool:
               return "bool";
             case DataType::Double:

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -146,15 +146,64 @@ PrimDataType indexModeToDtype(KernelIndexMode index_mode);
 KernelIndexMode indexTypeToMode(DataType index_type);
 
 // Returns if the datatype is a floating point type
-TORCH_CUDA_CU_API bool isFloatingPointType(DataType dtype);
+TORCH_CUDA_CU_API inline bool isFloatingPointType(DataType dtype) {
+  TORCH_CHECK(
+      dtype != DataType::Null,
+      "Null type is not a valid argument to isFloatingPointType");
+  return dtype == DataType::Double || dtype == DataType::Float ||
+      dtype == DataType::Half || dtype == DataType::BFloat16;
+}
+
 // Returns if the datatype is an integer type
-TORCH_CUDA_CU_API bool isIntegralType(DataType dtype);
+TORCH_CUDA_CU_API inline bool isIntegralType(DataType dtype) {
+  return std::visit(
+      [](auto&& dtype) {
+        using T = std::decay_t<decltype(dtype)>;
+        if constexpr (std::is_same_v<T, PrimDataType>) {
+          switch (dtype) {
+            case DataType::Index:
+            case DataType::Int:
+            case DataType::Int32:
+              return true;
+            case DataType::Null:
+              TORCH_CHECK(
+                  false, "Null type is not a valid argument to isIntegralType");
+            default:
+              return false;
+          }
+        }
+        return false;
+      },
+      dtype.type);
+}
+
 // Returns if the datatype is a pointer type
-TORCH_CUDA_CU_API bool isPointerType(DataType dtype);
-// Returns if the datatype is an boolean type
-TORCH_CUDA_CU_API bool isBooleanType(DataType dtype);
+TORCH_CUDA_CU_API inline bool isPointerType(DataType dtype) {
+  return std::holds_alternative<PointerOf>(dtype.type) ||
+      dtype == DataType::SMemAddress;
+}
+
+// Returns if the datatype is an integer or pointer type
+TORCH_CUDA_CU_API inline bool isIntegralOrPointerType(DataType dtype) {
+  return isIntegralType(dtype) || isPointerType(dtype);
+}
+
+// Returns if the datatype is a boolean type
+TORCH_CUDA_CU_API inline bool isBooleanType(DataType dtype) {
+  TORCH_CHECK(
+      dtype != DataType::Null,
+      "Null type is not a valid argument to isBooleanType");
+  return dtype == DataType::Bool;
+}
+
 // Returns if the datatype is a complex type
-TORCH_CUDA_CU_API bool isComplexType(DataType dtype);
+TORCH_CUDA_CU_API inline bool isComplexType(DataType dtype) {
+  TORCH_CHECK(
+      dtype != DataType::Null,
+      "Null type is not a valid argument to isComplexType");
+  return dtype == DataType::ComplexFloat || dtype == DataType::ComplexDouble;
+}
+
 // Return the corresponding scalar of a complex type
 DataType getTypeFromComplexType(DataType dtype);
 // Return if the datatype is supported on the current device
@@ -422,8 +471,110 @@ bool needFloatSuffix(UnaryOpType t);
 bool needFloatSuffix(BinaryOpType t);
 bool needFloatSuffix(RNGOpType t);
 
-ValType promote_type(const ValType& t1, const ValType& t2);
-DataType promote_type(const DataType& t1, const DataType& t2);
+ValType promoteType(const ValType& t1, const ValType& t2);
+
+#define HANDLE_TYPE_PROMOTION(Type1, Type2)                              \
+  if (t1 == NativeTypeToDataType<Type1>::type &&                         \
+      t2 == NativeTypeToDataType<Type2>::type) {                         \
+    return NativeTypeToDataType<std::common_type_t<Type1, Type2>>::type; \
+  }
+
+#define HANDLE_TYPE_PROMOTION1(Type1)                \
+  HANDLE_TYPE_PROMOTION(Type1, float);               \
+  HANDLE_TYPE_PROMOTION(Type1, double);              \
+  HANDLE_TYPE_PROMOTION(Type1, int64_t);             \
+  HANDLE_TYPE_PROMOTION(Type1, int);                 \
+  HANDLE_TYPE_PROMOTION(Type1, bool);                \
+  HANDLE_TYPE_PROMOTION(Type1, std::complex<float>); \
+  HANDLE_TYPE_PROMOTION(Type1, std::complex<double>)
+
+inline DataType promoteType(const DataType& t1, const DataType& t2) {
+  if (t1 == t2) {
+    return t1;
+  }
+  // pointer +- integer = pointer
+  if (isPointerType(t1) && isIntegralType(t2)) {
+    return t1;
+  }
+  if (isPointerType(t2) && isIntegralType(t1)) {
+    return t2;
+  }
+  // When seeing DataType::Index, assuming we are computing index, so propagate
+  // DataType::Index
+  if ((t1 == DataType::Index && isIntegralType(t2)) ||
+      (t2 == DataType::Index && isIntegralType(t1))) {
+    return DataType::Index;
+  }
+  // Workaround a case where C++ and ATen have different type promotion rules
+  if ((t1 == DataType::Double && t2 == DataType::ComplexFloat) ||
+      (t2 == DataType::Double && t1 == DataType::ComplexFloat)) {
+    // WARNING: ATen and C++ behave differently for this case. ATen returns
+    // DataType::ComplexDouble but C++ returns DataType::ComplexFloat. Right now
+    // we choose to be consistent with ATen.
+    // TODO: I am pretty sure that for some cases we would need C++'s promotion
+    // rule, for example, when we are simplifying scalar expressions, and for
+    // other cases, we need ATen's promotion rule, for example, when we define
+    // fusion from ATen graph. Fortunately, right now this is the only case to
+    // worry about, and I don't think in practice, using ATen's rule would cause
+    // any trouble.
+    return DataType::ComplexDouble;
+  }
+  // Use C++ promotion rule when dtype has a native C++ type
+  HANDLE_TYPE_PROMOTION1(float);
+  HANDLE_TYPE_PROMOTION1(double);
+  HANDLE_TYPE_PROMOTION1(int64_t);
+  HANDLE_TYPE_PROMOTION1(int);
+  HANDLE_TYPE_PROMOTION1(bool);
+  HANDLE_TYPE_PROMOTION1(std::complex<float>);
+  HANDLE_TYPE_PROMOTION1(std::complex<double>);
+  // double + half/bfloat16 = double
+  if ((t1 == DataType::Double && isFloatingPointType(t2)) ||
+      (t2 == DataType::Double && isFloatingPointType(t1))) {
+    return DataType::Double;
+  }
+  // float + half/bfloat16 = float
+  // half + bfloat16 = float
+  if (isFloatingPointType(t1) && isFloatingPointType(t2)) {
+    return DataType::Float;
+  }
+  // complex + half/bfloat16 = complex
+  if (isComplexType(t1)) {
+    return t1;
+  }
+  if (isComplexType(t2)) {
+    return t2;
+  }
+  // half + integers/bool = half
+  // bfloat16 + integers/bool = bfloat16
+  if (isFloatingPointType(t1)) {
+    return t1;
+  }
+  if (isFloatingPointType(t2)) {
+    return t2;
+  }
+  TORCH_CHECK(
+      false, "Expected promotable DataTypes but got: ", t1, " and ", t2);
+}
+
+#undef HANDLE_TYPE_PROMOTION
+#undef HANDLE_TYPE_PROMOTION1
+
+template <typename... Args>
+inline DataType promoteType(
+    const DataType& t1,
+    const DataType& t2,
+    const Args&... args) {
+  return promoteType(t1, promoteType(t2, promoteType(args...)));
+}
+
+inline DataType promoteType(const std::vector<DataType>& types) {
+  TORCH_CHECK(types.size() > 0, "Can not promote empty type vector")
+  DataType result = types.at(0);
+  for (auto t : types) {
+    result = promoteType(result, t);
+  }
+  return result;
+}
 
 // If type cannot be found (i.e. codegen does not support provided type) returns
 // DataType::Null

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -9040,27 +9040,27 @@ TEST_F(NVFuserTest, FusionChannelsLastParser_CUDA) {
   // 2. use a fuzzy compare (ignore non-significant whitespaces for example)
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<__half, 4> T0, Tensor<__half, 4> T2, Tensor<__half, 4> T7) {
-  int64_t i558;
-  i558 = T0.size[2] * T0.size[1];
-  int64_t i561;
-  i561 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)blockIdx.x));
-  int64_t i563;
-  i563 = (T0.size[1] * T0.size[2]) * T0.size[3];
-  int64_t i595;
-  i595 = i561 % i563;
-  int64_t i572;
-  i572 = T0.size[2] * T0.size[3];
-  int64_t i596;
-  i596 = i595 % i572;
-  if ((i561 < (((T0.size[0] * T0.size[1]) * T0.size[2]) * T0.size[3]))) {
+  int64_t i848;
+  i848 = T0.size[2] * T0.size[1];
+  int64_t i851;
+  i851 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)blockIdx.x));
+  int64_t i853;
+  i853 = (T0.size[1] * T0.size[2]) * T0.size[3];
+  int64_t i885;
+  i885 = i851 % i853;
+  int64_t i862;
+  i862 = T0.size[2] * T0.size[3];
+  int64_t i886;
+  i886 = i885 % i862;
+  if ((i851 < (((T0.size[0] * T0.size[1]) * T0.size[2]) * T0.size[3]))) {
     __half T9[1];
     T9[0] = 0;
     T9[0]
-       = T2[(((((i558 * T0.size[3]) * (i561 / i563)) + (i558 * (i596 % T0.size[3]))) + (T0.size[2] * (i595 / i572))) + (i596 / T0.size[3]))];
+       = T2[(((((i848 * T0.size[3]) * (i851 / i853)) + (i848 * (i886 % T0.size[3]))) + (T0.size[2] * (i885 / i862))) + (i886 / T0.size[3]))];
     __half T8[1];
     T8[0] = 0;
     T8[0]
-       = T0[i561];
+       = T0[i851];
     float T3[1];
     T3[0]
        = __half2float(T9[0]);
@@ -9080,7 +9080,7 @@ __global__ void CUDAGeneratedKernel(Tensor<__half, 4> T0, Tensor<__half, 4> T2, 
     __half T10[1];
     T10[0]
        = __float2half(T6[0]);
-    T7[i561]
+    T7[i851]
        = T10[0];
   }
 }

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -7775,7 +7775,6 @@ TEST_F(NVFuserTest, FusionTypePromotionATenConsistency_CUDA) {
     for (auto t2 : convertible_to_aten) {
       auto t1_aten = data_type_to_aten(t1);
       auto t2_aten = data_type_to_aten(t2);
-      std::cout << t1 << ", " << t2 << std::endl;
       auto result_aten = c10::promoteTypes(t1_aten, t2_aten);
       auto result = promoteType(t1, t2);
       ASSERT_EQ(data_type_to_aten(result), result_aten);

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -7760,6 +7760,29 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitGlobal_CUDA) {
       fe.kernel(), cg_outputs, inputs, {ref_t1, ref_t3}, __LINE__, __FILE__);
 }
 
+TEST_F(NVFuserTest, FusionTypePromotionATenConsistency_CUDA) {
+  auto convertible_to_aten = {
+      DataType::Bool,
+      DataType::Double,
+      DataType::Float,
+      DataType::Half,
+      DataType::BFloat16,
+      DataType::Int,
+      DataType::Int32,
+      DataType::ComplexFloat,
+      DataType::ComplexDouble};
+  for (auto t1 : convertible_to_aten) {
+    for (auto t2 : convertible_to_aten) {
+      auto t1_aten = data_type_to_aten(t1);
+      auto t2_aten = data_type_to_aten(t2);
+      std::cout << t1 << ", " << t2 << std::endl;
+      auto result_aten = c10::promoteTypes(t1_aten, t2_aten);
+      auto result = promoteType(t1, t2);
+      ASSERT_EQ(data_type_to_aten(result), result_aten);
+    }
+  }
+}
+
 // Make sure invalid usage of index type is detected
 TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
   Fusion fusion;

--- a/test/test_loop_rotation.cpp
+++ b/test/test_loop_rotation.cpp
@@ -206,8 +206,8 @@ TEST_F(LoopRotationTest, NonDivisibleSplit_CUDA) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO
-  int64_t i1195;
-  i1195 = T0.size[0] * T0.size[1];
+  int64_t i1413;
+  i1413 = T0.size[0] * T0.size[1];
   float T1[5];
   float T2[5];
   #pragma unroll
@@ -219,7 +219,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   for(nvfuser_index_t i36 = 0; i36 < 5; ++i36) {
     int64_t i154;
     i154 = i36 + nvfuser_zero;
-    if ((i154 < i1195)) {
+    if ((i154 < i1413)) {
       T1[i36]
          = T0[((T0.stride[0] * (i154 / T0.size[1])) + (T0.stride[1] * (i154 % T0.size[1])))];
     }
@@ -233,10 +233,10 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll 1
   for(nvfuser_index_t i39 = 0; i39 < (ceilDiv((T0.size[0] * T0.size[1]), 5)); ++i39) {
-    int64_t i608;
-    i608 = 5 * i39;
-    int64_t i900;
-    i900 = 5 + i608;
+    int64_t i632;
+    i632 = 5 * i39;
+    int64_t i1118;
+    i1118 = 5 + i632;
     // Alias Allocation - register
     auto& T3 = T1;
     #pragma unroll
@@ -247,10 +247,10 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i40 = 0; i40 < 5; ++i40) {
-      int64_t i609;
-      i609 = i608 + (i40 + nvfuser_zero);
-      if ((i609 < i1195)) {
-        T4[i609]
+      int64_t i633;
+      i633 = i632 + (i40 + nvfuser_zero);
+      if ((i633 < i1413)) {
+        T4[i633]
            = T3[i40];
       }
     }
@@ -262,11 +262,11 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i36 = 0; i36 < 5; ++i36) {
-      int64_t i901;
-      i901 = i900 + (i36 + nvfuser_zero);
-      if ((i901 < i1195)) {
+      int64_t i1119;
+      i1119 = i1118 + (i36 + nvfuser_zero);
+      if ((i1119 < i1413)) {
         T1[i36]
-           = T0[((T0.stride[0] * (i901 / T0.size[1])) + (T0.stride[1] * (i901 % T0.size[1])))];
+           = T0[((T0.stride[0] * (i1119 / T0.size[1])) + (T0.stride[1] * (i1119 % T0.size[1])))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO
@@ -310,8 +310,8 @@ TEST_F(LoopRotationTest, DoubleBuffered_CUDA) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO
-  int64_t i537;
-  i537 = T0.stride[0] * 4;
+  int64_t i563;
+  i563 = T0.stride[0] * 4;
   float T1[15];
   #pragma unroll
   for(nvfuser_index_t i24 = 0; i24 < 4; ++i24) {
@@ -319,15 +319,15 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     i152 = 3 * i24;
     int64_t i223;
     i223 = T0.stride[0] * i24;
-    bool b1072;
-    b1072 = (i24 + nvfuser_zero) < T0.size[0];
+    bool b1150;
+    b1150 = (i24 + nvfuser_zero) < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
       T1[(i152 + i21)] = 0;
     }
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      if (b1072) {
+      if (b1150) {
         T1[(i152 + i21)]
            = T0[(i223 + (T0.stride[1] * (i21 + nvfuser_zero)))];
       }
@@ -343,28 +343,28 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll 1
   for(nvfuser_index_t i25 = 0; i25 < T0.size[0]; ++i25) {
-    int64_t i453;
-    i453 = 4 + i25;
-    int64_t i455;
-    i455 = 3 * (i453 % 5);
-    int64_t i539;
-    i539 = i537 + (T0.stride[0] * i25);
-    int64_t i868;
-    i868 = 3 * i25;
-    int64_t i949;
-    i949 = 3 * ((1 + i25) % 5);
-    bool b1342;
-    b1342 = i453 < T0.size[0];
+    int64_t i479;
+    i479 = 4 + i25;
+    int64_t i481;
+    i481 = 3 * (i479 % 5);
+    int64_t i565;
+    i565 = i563 + (T0.stride[0] * i25);
+    int64_t i920;
+    i920 = 3 * i25;
+    int64_t i1027;
+    i1027 = 3 * ((1 + i25) % 5);
+    bool b1420;
+    b1420 = i479 < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      T1[(i455 + i21)] = 0;
+      T1[(i481 + i21)] = 0;
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      if (b1342) {
-        T1[(i455 + i21)]
-           = T0[(i539 + (T0.stride[1] * (i21 + nvfuser_zero)))];
+      if (b1420) {
+        T1[(i481 + i21)]
+           = T0[(i565 + (T0.stride[1] * (i21 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO
@@ -377,14 +377,14 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i27 = 0; i27 < 3; ++i27) {
-      T4[(i868 + (i27 + nvfuser_zero))]
+      T4[(i920 + (i27 + nvfuser_zero))]
          = T3[i27];
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i22 = 0; i22 < 3; ++i22) {
       T2[i22]
-         = T1[(i949 + i22)];
+         = T1[(i1027 + i22)];
     }
     NVFUSER_UPDATE_MAGIC_ZERO
   }
@@ -423,12 +423,12 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO
   int64_t i545;
   i545 = 4 * T0.stride[0];
-  int64_t i1116;
-  i1116 = T0.stride[0] * 5;
-  bool b1425;
-  b1425 = 0 < T0.size[0];
-  bool b1744;
-  b1744 = 4 < T0.size[0];
+  int64_t i1156;
+  i1156 = T0.stride[0] * 5;
+  bool b1531;
+  b1531 = 0 < T0.size[0];
+  bool b1850;
+  b1850 = 4 < T0.size[0];
   float T1[15];
   #pragma unroll
   for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
@@ -437,7 +437,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll
   for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-    if (b1425) {
+    if (b1531) {
       T1[i21]
          = T0[(T0.stride[1] * (i21 + nvfuser_zero))];
     }
@@ -449,15 +449,15 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     i285 = 3 + (3 * i24);
     int64_t i368;
     i368 = T0.stride[0] + (T0.stride[0] * i24);
-    bool b1679;
-    b1679 = ((1 + i24) + nvfuser_zero) < T0.size[0];
+    bool b1785;
+    b1785 = ((1 + i24) + nvfuser_zero) < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
       T1[(i285 + i21)] = 0;
     }
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      if (b1679) {
+      if (b1785) {
         T1[(i285 + i21)]
            = T0[(i368 + (T0.stride[1] * (i21 + nvfuser_zero)))];
       }
@@ -472,7 +472,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll
   for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-    if (b1744) {
+    if (b1850) {
       T1[(12 + i21)]
          = T0[(i545 + (T0.stride[1] * (i21 + nvfuser_zero)))];
     }
@@ -488,14 +488,14 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   for(nvfuser_index_t i25 = 0; i25 < T0.size[0]; ++i25) {
     int64_t i925;
     i925 = 3 * i25;
-    int64_t i1026;
-    i1026 = 3 * (i25 % 5);
-    int64_t i1118;
-    i1118 = i1116 + (T0.stride[0] * i25);
-    int64_t i1302;
-    i1302 = 3 * ((1 + i25) % 5);
-    bool b2180;
-    b2180 = (5 + i25) < T0.size[0];
+    int64_t i1066;
+    i1066 = 3 * (i25 % 5);
+    int64_t i1158;
+    i1158 = i1156 + (T0.stride[0] * i25);
+    int64_t i1408;
+    i1408 = 3 * ((1 + i25) % 5);
+    bool b2286;
+    b2286 = (5 + i25) < T0.size[0];
     float T3[3];
     #pragma unroll
     for(nvfuser_index_t i23 = 0; i23 < 3; ++i23) {
@@ -511,21 +511,21 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      T1[(i1026 + i21)] = 0;
+      T1[(i1066 + i21)] = 0;
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      if (b2180) {
-        T1[(i1026 + i21)]
-           = T0[(i1118 + (T0.stride[1] * (i21 + nvfuser_zero)))];
+      if (b2286) {
+        T1[(i1066 + i21)]
+           = T0[(i1158 + (T0.stride[1] * (i21 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i22 = 0; i22 < 3; ++i22) {
       T2[i22]
-         = T1[(i1302 + i22)];
+         = T1[(i1408 + i22)];
     }
     NVFUSER_UPDATE_MAGIC_ZERO
   }
@@ -581,7 +581,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T3) {
   float* ptr98;
   ptr98 = T0.data;
   float* ptr384;
-  ptr384 = ptr98 + (T0.stride[0] * 4);
+  ptr384 = (T0.stride[0] * 4) + ptr98;
   smem_offset = alignBufferSize(smem_offset, 16);
   float* T4 = reinterpret_cast<float*>(array + smem_offset);
   smem_offset += (15 * sizeof(float));
@@ -591,11 +591,11 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T3) {
     ptr165 = ptr98 + (T0.stride[0] * i18);
     unsigned i249;
     i249 = (toSmem(T4)) + (12 * i18);
-    bool b1167;
-    b1167 = (i18 + nvfuser_zero) < T0.size[0];
+    bool b1286;
+    b1286 = (i18 + nvfuser_zero) < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i17 = 0; i17 < 3; ++i17) {
-      Ampere::cpAsyncCa<float, 1>((i249 + (4 * i17)),(ptr165 + (T0.stride[1] * (i17 + nvfuser_zero))),b1167);
+      Ampere::cpAsyncCa<float, 1>((i249 + (4 * i17)),(ptr165 + (T0.stride[1] * (i17 + nvfuser_zero))),b1286);
     }
     Ampere::cpAsyncCommit();
   }
@@ -608,38 +608,38 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T3) {
   for(nvfuser_index_t i19 = 0; i19 < T0.size[0]; ++i19) {
     float* ptr385;
     ptr385 = ptr384 + (T0.stride[0] * i19);
-    int64_t i486;
-    i486 = 4 + i19;
-    unsigned i489;
-    i489 = (toSmem(T4)) + (12 * (i486 % 5));
-    int64_t i567;
-    i567 = 1 + (3 * (i19 % 5));
-    int64_t i895;
-    i895 = 3 * i19;
-    bool b1359;
-    b1359 = i486 < T0.size[0];
+    int64_t i538;
+    i538 = 4 + i19;
+    unsigned i541;
+    i541 = (toSmem(T4)) + (12 * (i538 % 5));
+    int64_t i629;
+    i629 = 1 + (3 * (i19 % 5));
+    int64_t i988;
+    i988 = 3 * i19;
+    bool b1478;
+    b1478 = i538 < T0.size[0];
     Ampere::cpAsyncPartialBarrier<3>();
     #pragma unroll
     for(nvfuser_index_t i17 = 0; i17 < 3; ++i17) {
-      Ampere::cpAsyncCa<float, 1>((i489 + (4 * i17)),(ptr385 + (T0.stride[1] * (i17 + nvfuser_zero))),b1359);
+      Ampere::cpAsyncCa<float, 1>((i541 + (4 * i17)),(ptr385 + (T0.stride[1] * (i17 + nvfuser_zero))),b1478);
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     Ampere::cpAsyncCommit();
     #pragma unroll
     for(nvfuser_index_t i22 = 0; i22 < 2; ++i22) {
       T1[((1 + i22) % 2)]
-         = T4[(i567 + i22)];
+         = T4[(i629 + i22)];
       float T2[1];
       T2[0]
          = T1[(i22 % 2)];
-      T3[(i895 + (i22 + nvfuser_zero))]
+      T3[(i988 + (i22 + nvfuser_zero))]
          = T2[0];
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     float T2[1];
     T2[0]
        = T1[0];
-    T3[(2 + i895)]
+    T3[(2 + i988)]
        = T2[0];
     NVFUSER_UPDATE_MAGIC_ZERO
     T1[0]


### PR DESCRIPTION
When working on https://github.com/csarofeen/pytorch/pull/1900, I find that sometimes expr simplifier will assign the dtype of a value wrongly. This is because expr simplifier is written loosely assuming the dtypes of all `Val`s are the same. However, because we are putting pointer types into the expression, we need to be more careful, otherwise we will get wrong kernel code like:
```
__half* ptr1 = threadIdx.x * 128;
__half* ptr2 = ptr1 + 256 + T1.data;
```
This PR changes all passes in the expr simplifier to let it infer dtype from its inputs.

- [x] TODO: update all the failing `assertCUDAKernel` tests😵‍💫😵‍💫😵‍💫😵‍💫