### PR TITLE
Warn when casting from complex to real

### DIFF
--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -398,10 +398,10 @@ TensorView* pad(
       value = static_cast<Val*>(IrBuilder::create<Int>(0, dt));
     }
   }
-
-  TORCH_CHECK(
-      !isComplexType(value->dtype()) || isComplexType(dt),
-      "Only TensorViews with complex dtypes may be padded with complex values");
+  if (value->getDataType().value() != dt) {
+    // Insert an explicit castOp if dtype of value does not match TensorView's
+    value = castOp(dt, value);
+  }
   const auto inp_dom = TensorDomain::noReductions(inp->getMaybeRFactorDomain());
   const auto ndims = inp_dom.size();
 

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -24,18 +24,27 @@
 namespace nvfuser {
 
 Val* castOp(DataType dtype, Val* v1) {
-  if (v1->getDataType().value() == dtype) {
+  auto orig_dtype = v1->getDataType().value();
+  if (dtype == orig_dtype) {
     return set(v1);
   }
 
-  if (cast_func_str(std::make_pair(v1->getDataType().value(), dtype)) ==
-      c10::nullopt) {
+  if (cast_func_str(std::make_pair(orig_dtype, dtype)) == c10::nullopt) {
     TORCH_CHECK(
         false,
         "Illegal Cast value from  DataType: ",
-        v1->getDataType().value(),
+        orig_dtype,
         " to DataType: ",
         dtype);
+  }
+
+  if (isComplexType(orig_dtype) && !isComplexType(dtype)) {
+    TORCH_WARN(
+        "Casting from ",
+        orig_dtype,
+        " to ",
+        dtype,
+        " discards the imaginary part.");
   }
 
   Val* out = ops::newValLike(v1, dtype);


### PR DESCRIPTION
We currently allow `castOp` to convert complex values to real, using `std::real`. In PyTorch, when this is done a warning is presented indicating that this operation discards the imaginary part. This PR adds such a warning to `castOp`.