### PR TITLE
Add nextafter op

### DIFF
--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -893,6 +893,28 @@ NVFUSER_DEFINE_BINARY_FLOAT_OP(div, Div)
 NVFUSER_DEFINE_BINARY_FLOAT_OP(atan2, Atan2)
 #undef NVFUSER_DEFINE_BINARY_FLOAT_OP
 
+// These ops require full-precision floating point types (after float type
+// promotion)
+#define NVFUSER_DEFINE_BINARY_FLOAT_ONLY_OP(op_name, op_type)                \
+  Val* op_name(Val* v1, Val* v2) {                                           \
+    return binaryOp(                                                         \
+        BinaryOpType::op_type, v1, v2, TypePromotion::float_only_op_config); \
+  }                                                                          \
+  TensorView* op_name(TensorView* v1, Val* v2) {                             \
+    return binaryOp(                                                         \
+        BinaryOpType::op_type, v1, v2, TypePromotion::float_only_op_config); \
+  }                                                                          \
+  TensorView* op_name(Val* v1, TensorView* v2) {                             \
+    return binaryOp(                                                         \
+        BinaryOpType::op_type, v1, v2, TypePromotion::float_only_op_config); \
+  }                                                                          \
+  TensorView* op_name(TensorView* v1, TensorView* v2) {                      \
+    return binaryOp(                                                         \
+        BinaryOpType::op_type, v1, v2, TypePromotion::float_only_op_config); \
+  }
+NVFUSER_DEFINE_BINARY_FLOAT_ONLY_OP(nextafter, Nextafter)
+#undef NVFUSER_DEFINE_BINARY_FLOAT_ONLY_OP
+
 #define NVFUSER_DEFINE_BINARY_CAST_OP(op_name, op_type)                   \
   Val* op_name(Val* v1, Val* v2) {                                        \
     return binaryOp(                                                      \

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -441,6 +441,12 @@ TORCH_CUDA_CU_API Val* sub(Val* v1, Val* v2);
 TORCH_CUDA_CU_API TensorView* sub(TensorView* v1, Val* v2);
 TORCH_CUDA_CU_API TensorView* sub(Val* v1, TensorView* v2);
 TORCH_CUDA_CU_API TensorView* sub(TensorView* v1, TensorView* v2);
+// nextafter: Only single- or double-precision
+// floating point types (after promotion) are supported.
+TORCH_CUDA_CU_API Val* nextafter(Val* v1, Val* v2);
+TORCH_CUDA_CU_API TensorView* nextafter(TensorView* v1, Val* v2);
+TORCH_CUDA_CU_API TensorView* nextafter(Val* v1, TensorView* v2);
+TORCH_CUDA_CU_API TensorView* nextafter(TensorView* v1, TensorView* v2);
 // Integer binary ops
 // mod
 TORCH_CUDA_CU_API Val* mod(Val* v1, Val* v2);

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -762,6 +762,7 @@ void initNvFuserPythonBindings(PyObject* module) {
   NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_xor", bitwise_xor)
   NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_left_shift", bitwise_left_shift)
   NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_right_shift", bitwise_left_shift)
+  NVFUSER_PYTHON_BINDING_BINARY_OP("nextafter", nextafter)
 #undef NVFUSER_PYTHON_BINDING_BINARY_OP
 
 #define NVFUSER_PYTHON_BINDING_BINARY_OP_SPECIAL(py_op, op_str, op_name)       \

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -437,6 +437,8 @@ static const char* binary_op_type2string(BinaryOpType t) {
       return "remainder";
     case BinaryOpType::Sub:
       return "sub";
+    case BinaryOpType::Nextafter:
+      return "nextafter";
 
     // Integer Ops
     case BinaryOpType::Mod:

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -269,6 +269,7 @@ enum class BinaryOpType {
   Pow,
   Remainder,
   Sub,
+  Nextafter,
   // TypeAs,
 
   // Integer output ops. If changing modify isIntegerOp

--- a/csrc/type_promotion.cpp
+++ b/csrc/type_promotion.cpp
@@ -107,6 +107,16 @@ c10::ScalarType computeTypes(
       c10::isIntegralType(common_dtype, /*includeBool=*/true)) {
     common_dtype = c10::get_default_dtype_as_scalartype();
   }
+
+  // Some ops like nextafter are not implemented for non-float types
+  if (config.require_full_precision_promoted) {
+    TORCH_CHECK(
+        common_dtype == c10::ScalarType::Float ||
+            common_dtype == c10::ScalarType::Double,
+        "Promoted type must be single or double precision float but found ",
+        common_dtype);
+  }
+
   return common_dtype;
 }
 

--- a/csrc/type_promotion.h
+++ b/csrc/type_promotion.h
@@ -29,6 +29,7 @@ namespace nvfuser {
 //!
 struct TypePromotionConfig {
   bool promote_integer_inputs_to_float = false;
+  bool require_full_precision_promoted = false;
   TypePromotionConfig() = default;
 };
 
@@ -37,7 +38,11 @@ namespace TypePromotion {
 static const TypePromotionConfig comparison_op_config;
 static const TypePromotionConfig default_op_config;
 static const TypePromotionConfig float_op_config{
-    /* promote_integer_inputs_to_float */ true};
+    /* promote_integer_inputs_to_float */ true,
+    /* require_full_precision_promoted */ false};
+static const TypePromotionConfig float_only_op_config{
+    /* promote_integer_inputs_to_float */ false,
+    /* require_full_precision_promoted */ true};
 
 } // namespace TypePromotion
 

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -18,7 +18,7 @@ import torch._prims as prims
 
 # Will only create the nvfuser module if CUDA is available
 try:
-    from nvfuser import FusionCache, FusionDefinition, DataType, version, compute_contiguity
+    from nvfuser import FusionCache, FusionDefinition, DataType, Tensor, version, compute_contiguity
     from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 except ImportError:
     pass
@@ -1516,16 +1516,13 @@ class TestNvFuserFrontend(TestCase):
             s0 = fd.define_constant(1.0, dtype=DataType.Float)
             s1 = fd.define_constant(-1.0, dtype=DataType.Double)
 
-            t2 = fd.ops.add(t0, s0)  # float
-            t3 = fd.ops.add(t1, s1)  # double
-
             for a, b in itertools.product(
                 [t0, t1, s0, s1],
                 [t0, t1, s0, s1],
             ):
                 # always enter the fusion...
                 t = fd.ops.nextafter(a, b)
-                if a in [t0, t1] or b in [t0, t1]:
+                if isinstance(t, Tensor):
                     # ...but skip outputting scalars, which we don't support
                     fd.add_output(t)
 

--- a/runtime/helpers.cu
+++ b/runtime/helpers.cu
@@ -276,6 +276,14 @@ __device__ constexpr float fmod(float a, float b) {
   return ::fmod(a, b);
 }
 
+__device__ constexpr double nextafter(double a, double b) {
+  return ::nextafter(a, b);
+}
+
+__device__ constexpr float nextafter(float a, float b) {
+  return ::nextafterf(a, b);
+}
+
 template <typename T>
 __device__ T pow(T a, T b) {
   if (b < 0) {


### PR DESCRIPTION
The `nextafter(x, y)` operation provides the nearest distinct representable floating point value to `x` between `x` and `y`. In CUDA these are obtained with the builtins `nextafter` and `nextafterf`. Other types such as bfloat16 are not directly supported, though PyTorch has implemented that case based on some code in musl: https://github.com/pytorch/pytorch/pull/61829/files#diff-ece04c31934b3504382e10ed3e9a69f03ffabd81ad1a2a890aab19b1642f53c0R120.

In PyTorch, the torch.nextafter function is defined for any pair of arguments which would normally be promoted to either float32 or float64. So arguments which are both ints, bools, complex, or half-precision floats are not supported. This PR implements a binary op macro with a TypePromotionConfig that enforces that rule.

This is a translation/update of https://github.com/csarofeen/pytorch/pull/2510.