### PR TITLE
Bug fix: Resize memory promotion

### DIFF
--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2436,7 +2436,6 @@ bool revertUseOfInputCacheInResize(
 
 void prepareForMemoryTypePromotion(Fusion* fusion) {
   auto resized_tensors = getResizedTensors(fusion);
-  std::unordered_set<TensorView*> cached;
   for (auto resized_tensor : resized_tensors) {
     // Resized tensors are those created by operations like pad and
     // slice. If it has no defining expression, it must be a fusion
@@ -2468,15 +2467,13 @@ void prepareForMemoryTypePromotion(Fusion* fusion) {
         producer->getMemoryType());
 
     // If already placed on Global, nothing to worry about
-    if (producer->getMemoryType() == MemoryType::Global ||
-        cached.count(producer) != 0) {
+    if (producer->getMemoryType() == MemoryType::Global) {
       continue;
     }
     // Insert a copy between resized_tensor and producer
     auto copy_of_producer = set(producer);
     ir_utils::replaceValInExpr(
         resized_tensor->definition(), producer, copy_of_producer);
-    cached.insert(producer);
   }
 }
 

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -573,6 +573,27 @@ inline void rotateLoop(
 //! caches of those tensors so that original operations producing
 //! them should keep using the same memory. This avoids, for example,
 //! reductions to global memory.
+//!
+//! Example:
+//!
+//! tv1 = sum(tv0)
+//! tv2 = some_resize_op(tv1);
+//! tv3 = some_other_op(tv1);
+//!
+//! When tv1 is promoted to Global, we want to avoid reducing to a
+//! global memory tensor. After the transformation by this function,
+//! the fusion should look like:
+//!
+//! tv1 = sum(tv0);
+//! tv4 = tv1
+//! tv4->setMemoryType(Global)
+//! tv2 = some_resize_op(tv4)
+//! tv3 = some_other_op(tv1);
+//!
+//! Note that the sum reduction is done using a Local buffer, i.e.,
+//! tv1, but the data dependency for the resize op is still satisfied
+//! by having a copy of tv1, i.e., tv4. Note that the other op using
+//! tv1 still uses tv1.
 TORCH_CUDA_CU_API void prepareForMemoryTypePromotion(Fusion* fusion);
 
 //! If a resized tensor induces a data dependency between threads,

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -1680,7 +1680,7 @@ TEST_F(NVFuserTest, FusionResizePadHalfWithDoubleValue_CUDA) {
   TORCH_CHECK(ref.equal(cg_outputs[0]));
 }
 
-TEST_F(NVFuserTest, FusionSliceForNanoGPT_CUDA) {
+TEST_F(NVFuserTest, FusionSliceForNanoGPT1_CUDA) {
   auto fusion_ptr = std::make_unique<Fusion>();
   auto& fusion = *fusion_ptr;
   FusionGuard fg(fusion_ptr.get());
@@ -1748,6 +1748,136 @@ TEST_F(NVFuserTest, FusionSliceForNanoGPT_CUDA) {
       cg_outputs,
       aten_inputs,
       {aten_t3, aten_t3},
+      __LINE__,
+      __FILE__);
+}
+
+// Similar to FusionSliceForNanoGPT1 but the input to slice is an
+// intermediate tensor
+TEST_F(NVFuserTest, FusionSliceForNanoGPT2_CUDA) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  auto& fusion = *fusion_ptr;
+  FusionGuard fg(fusion_ptr.get());
+
+  std::vector<int64_t> input_shape0{100, 100};
+  std::vector<int64_t> input_shape1{32, 32};
+
+  auto tv0 = makeSymbolicTensor(2);
+  auto tv1 = makeSymbolicTensor(2);
+
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  auto tv2 = add(tv0, IrBuilder::create<Double>(1));
+
+  Slice dim0{
+      IrBuilder::create<Int>(0),
+      IrBuilder::create<Int>(32),
+      IrBuilder::create<Int>(1)};
+  Slice dim1{
+      IrBuilder::create<Int>(0),
+      IrBuilder::create<Int>(32),
+      IrBuilder::create<Int>(1)};
+
+  auto tv3 = slice(tv2, {dim0, dim1});
+  auto tv4 = add(tv3, tv1);
+  fusion.addOutput(tv4);
+
+  auto tv5 = slice(tv2, {dim0, dim1});
+  auto tv6 = add(tv5, tv1);
+  fusion.addOutput(tv6);
+
+  // Another use of tv2. Unlike the above two slice ops, this should
+  // not use the copy of tv2
+  auto tv7 = add(tv2, IrBuilder::create<Double>(1));
+  fusion.addOutput(tv7);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::manual_seed(0);
+
+  auto t0 = at::randn(input_shape0, options);
+  auto t1 = at::randn(input_shape1, options);
+  std::vector<c10::IValue> aten_inputs({t0, t1});
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+
+  auto kernel =
+      executor_cache.getMostRecentKernelRuntime()->executors().at(0).kernel();
+
+  // Make sure the slices ops use the same producer
+  TensorView* known_slice_producer = nullptr;
+  for (auto expr : KernelExprVisitor::getAllExprs(kernel)) {
+    if (!ir_utils::isTvOp(expr)) {
+      continue;
+    }
+    auto out_tv = ir_utils::getTvOutput(expr);
+    if (out_tv->name() == tv3->name() || out_tv->name() == tv5->name()) {
+      TORCH_CHECK(
+          expr->isA<UnaryOp>() &&
+              expr->as<UnaryOp>()->getUnaryOpType() == UnaryOpType::Set,
+          "Unexpected defintion of slice output tensor: ",
+          out_tv->toString(),
+          ", ",
+          expr->toString());
+      auto producer =
+          dynamic_cast<kir::TensorIndex*>(expr->as<UnaryOp>()->in());
+      if (producer == nullptr) {
+        // this could be a default initialization
+        continue;
+      }
+      if (known_slice_producer == nullptr) {
+        known_slice_producer = producer->view();
+      } else {
+        TORCH_CHECK(
+            known_slice_producer == producer->view(),
+            "Expected to have the same tensor is used for the two slice ops. ",
+            "Previously found producer: ",
+            known_slice_producer->toString(),
+            ", new producer: ",
+            producer->view()->toString());
+      }
+    } else if (auto binary_op = dynamic_cast<BinaryOp*>(expr)) {
+      // If this is a binary op producing tv7, make sure its producer
+      // is tv2
+      if (binary_op->getBinaryOpType() == BinaryOpType::Add &&
+          binary_op->out()->isA<kir::TensorIndex>() &&
+          binary_op->out()->as<kir::TensorIndex>()->view()->name() ==
+              tv7->name()) {
+        TORCH_CHECK(
+            binary_op->lhs()->as<kir::TensorIndex>()->view()->name() ==
+                tv2->name(),
+            "Unexpected tv7 definition: ",
+            binary_op->toString());
+      }
+    }
+  }
+
+  TORCH_CHECK(known_slice_producer != nullptr, "Slice producer not found");
+
+  // The slice producer must be a copy of tv2
+  TORCH_CHECK(
+      known_slice_producer->definition() &&
+          known_slice_producer->definition()->isA<UnaryOp>() &&
+          known_slice_producer->definition()->as<UnaryOp>()->getUnaryOpType() ==
+              UnaryOpType::Set &&
+          known_slice_producer->definition()->as<UnaryOp>()->in()->name() ==
+              tv2->name(),
+      "Unexpected slice producer: ",
+      known_slice_producer->toString());
+
+  auto aten_t2 = t0 + 1;
+  auto aten_slice = aten_t2.index(
+      {at::indexing::Slice(0, 32, 1), at::indexing::Slice(0, 32, 1)});
+  auto aten_t4 = aten_slice + t1;
+
+  auto aten_t7 = aten_t2 + 1;
+
+  testValidate(
+      executor_cache.fusion(),
+      cg_outputs,
+      aten_inputs,
+      {aten_t4, aten_t4, aten_t7},
       __LINE__,
       __FILE__);
 }

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -1710,10 +1710,15 @@ TEST_F(NVFuserTest, FusionSliceForNanoGPT_CUDA) {
       IrBuilder::create<Int>(0),
       IrBuilder::create<Int>(128),
       IrBuilder::create<Int>(1)};
-  auto tv0_slice = slice(tv0, {dim0, dim1, dim2, dim3});
+  auto tv2 = slice(tv0, {dim0, dim1, dim2, dim3});
 
-  auto tv2 = add(tv0_slice, tv1);
-  fusion.addOutput(tv2);
+  auto tv3 = add(tv2, tv1);
+  fusion.addOutput(tv3);
+
+  auto tv4 = slice(tv0, {dim0, dim1, dim2, dim3});
+
+  auto tv5 = add(tv4, tv1);
+  fusion.addOutput(tv5);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::manual_seed(0);
@@ -1736,13 +1741,13 @@ TEST_F(NVFuserTest, FusionSliceForNanoGPT_CUDA) {
        at::indexing::Slice(0, 1, 1),
        at::indexing::Slice(0, 128, 1),
        at::indexing::Slice(0, 128, 1)});
-  auto aten_t2 = torch::add(aten_t0_slice, t1);
+  auto aten_t3 = torch::add(aten_t0_slice, t1);
 
   testValidate(
       executor_cache.fusion(),
       cg_outputs,
       aten_inputs,
-      {aten_t2},
+      {aten_t3, aten_t3},
       __LINE__,
       __FILE__);
 }


### PR DESCRIPTION
When a single tensor is sliced multiple times, the insertion of a copy was done just once, which is a bug. Previously I used `cacheAfter`, so that was the right thing to do.

Changed a test to exhibit the problem.