### PR TITLE
Optionally traverse Expr attributes

### DIFF
--- a/csrc/dispatch.cpp
+++ b/csrc/dispatch.cpp
@@ -100,6 +100,10 @@ void Val::dispatch(T handler, Val* val) {
     case ValType::AggregateVal:
       ptr(handler)->handle(val->as<AggregateVal>());
       return;
+    case ValType::Attribute:
+      TORCH_INTERNAL_ASSERT(
+          false,
+          "ValType::Attribute can not be dispatched. Template type is needed.");
     default:
       break;
   }

--- a/csrc/ir_cloner.cpp
+++ b/csrc/ir_cloner.cpp
@@ -57,7 +57,7 @@ TensorView* RecomputeTv::recompute(TensorView* tv) {
       "Cannot recompute buffers that are inputs of the fusion.");
 
   // Grab all the expressions used to generate the TensorView
-  auto exprs = StmtSort::getExprs(tv->fusion(), {tv}, false);
+  auto exprs = StmtSort::getExprs(tv->fusion(), {tv}, false, false);
 
   // Run the replicator
   RecomputeTv replicator(tv->fusion(), exprs);

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -2167,9 +2167,23 @@ IterDomain* IterDomain::resize(
       "Non-zero stop offset not considered: ",
       in->toString());
 
-  Val* resized_id_size = SimplifyingIrBuilder::addExpr(
-      SimplifyingIrBuilder::addExpr(in->extent(), left_expansion),
-      right_expansion);
+  // The overall extent is (in->extent() + left_expansion +
+  // right_expansion). This can be simplified for a slice op as
+  // the right expansion should look like (slice_end_offset -
+  // in->extent()), so the overall extent is left_expansion + slice_end_offset.
+  Val* resized_id_size = nullptr;
+  if (right_expansion->definition() != nullptr &&
+      right_expansion->definition()->isA<BinaryOp>() &&
+      right_expansion->definition()->as<BinaryOp>()->getBinaryOpType() ==
+          BinaryOpType::Sub &&
+      right_expansion->definition()->as<BinaryOp>()->rhs() == in->extent()) {
+    resized_id_size = SimplifyingIrBuilder::addExpr(
+        left_expansion, right_expansion->definition()->as<BinaryOp>()->lhs());
+  } else {
+    resized_id_size = SimplifyingIrBuilder::addExpr(
+        SimplifyingIrBuilder::addExpr(in->extent(), left_expansion),
+        right_expansion);
+  }
 
   auto resized_id =
       IterDomainBuilder(in->container()->zeroVal(), resized_id_size->as<Int>())

--- a/csrc/ir_utils.cpp
+++ b/csrc/ir_utils.cpp
@@ -452,7 +452,7 @@ class ValReplacementMutator : private OptOutMutator {
     // typically not used by anything else. If we don't grab that count, then it
     // would be a tensorview that doesn't get updated extents. Therefore, first
     // grab all leaves towards outputs and grab stmts from there.
-    auto stmts = StmtSort::getStmts(fusion, allLeafOuts(fusion), true);
+    auto stmts = StmtSort::getStmts(fusion, allLeafOuts(fusion), true, true);
 
     // Some fusions, such as standalone rand_like, can have disconnected DAG, so
     // we need some mechanism to make sure our replacement set is as complete as
@@ -465,7 +465,7 @@ class ValReplacementMutator : private OptOutMutator {
         more.emplace_back(v);
       }
     }
-    auto more_stmts = StmtSort::getStmts(fusion, more, true);
+    auto more_stmts = StmtSort::getStmts(fusion, more, true, true);
     more_stmts.insert(more_stmts.end(), stmts.begin(), stmts.end());
 
     for (auto stmt : more_stmts) {

--- a/csrc/iter_visitor.cpp
+++ b/csrc/iter_visitor.cpp
@@ -141,7 +141,8 @@ void IterVisitor::traverseBetween(
     const std::unordered_set<Val*>& from,
     const std::vector<Val*>& to,
     bool traverse_all_paths,
-    bool traverse_into_members) {
+    bool traverse_into_members,
+    bool traverse_attributes) {
   FusionGuard fg(fusion);
 
   std::unordered_set<Statement*> visited;
@@ -192,6 +193,18 @@ void IterVisitor::traverseBetween(
         next_stmts = next(stmt);
       }
 
+      // If stmt is an expression, traverse attributes as well
+      if (traverse_attributes && stmt->isExpr()) {
+        for (Statement* x : stmt->as<Expr>()->attributes()) {
+          // Note that attributes of type Attribute is not possible to
+          // dispatch as it's a template type.
+          if (x->getValType() == ValType::Attribute) {
+            continue;
+          }
+          next_stmts.push_back(x);
+        }
+      }
+
       if (traverse_into_members) {
         auto members = MemberStatements::next(stmt);
         next_stmts.insert(next_stmts.end(), members.begin(), members.end());
@@ -220,8 +233,15 @@ void IterVisitor::traverseTo(
     Fusion* fusion,
     const std::vector<Val*>& to,
     bool traverse_all_paths,
-    bool traverse_into_members) {
-  traverseBetween(fusion, {}, to, traverse_all_paths, traverse_into_members);
+    bool traverse_into_members,
+    bool traverse_attributes) {
+  traverseBetween(
+      fusion,
+      {},
+      to,
+      traverse_all_paths,
+      traverse_into_members,
+      traverse_attributes);
 }
 
 void IterVisitor::traverseHelper(Fusion* fusion, bool traverse_all_paths) {
@@ -794,16 +814,22 @@ void StmtSort::handle(Statement* stmt) {
   stmts.push_back(stmt);
 }
 
-std::vector<Expr*> StmtSort::getExprs(Fusion* fusion, bool traverse_members) {
+std::vector<Expr*> StmtSort::getExprs(
+    Fusion* fusion,
+    bool traverse_members,
+    bool traverse_attributes) {
   auto terminating_outputs = fusion->getTerminatingOutputs();
-  return StmtSort::getExprs(fusion, terminating_outputs, traverse_members);
+  return StmtSort::getExprs(
+      fusion, terminating_outputs, traverse_members, traverse_attributes);
 }
 
 std::vector<Expr*> StmtSort::getExprs(
     Fusion* fusion,
     const std::vector<Val*>& to,
-    bool traverse_members) {
-  auto stmts = StmtSort::getStmts(fusion, to, traverse_members);
+    bool traverse_members,
+    bool traverse_attributes) {
+  auto stmts =
+      StmtSort::getStmts(fusion, to, traverse_members, traverse_attributes);
   auto filter = ir_utils::filterByType<Expr>(stmts.begin(), stmts.end());
   std::vector<Expr*> exprs(filter.begin(), filter.end());
   return exprs;
@@ -813,8 +839,10 @@ std::vector<Expr*> StmtSort::getExprsBetween(
     Fusion* fusion,
     const std::vector<Val*>& from,
     const std::vector<Val*>& to,
-    bool traverse_members) {
-  auto stmts = StmtSort::getStmtsBetween(fusion, from, to, traverse_members);
+    bool traverse_members,
+    bool traverse_attributes) {
+  auto stmts = StmtSort::getStmtsBetween(
+      fusion, from, to, traverse_members, traverse_attributes);
   auto filter = ir_utils::filterByType<Expr>(stmts.begin(), stmts.end());
   std::vector<Expr*> exprs(filter.begin(), filter.end());
   return exprs;
@@ -822,17 +850,20 @@ std::vector<Expr*> StmtSort::getExprsBetween(
 
 std::vector<Statement*> StmtSort::getStmts(
     Fusion* fusion,
-    bool traverse_members) {
+    bool traverse_members,
+    bool traverse_attributes) {
   auto terminating_outputs = fusion->getTerminatingOutputs();
-  return StmtSort::getStmts(fusion, terminating_outputs, traverse_members);
+  return StmtSort::getStmts(
+      fusion, terminating_outputs, traverse_members, traverse_attributes);
 }
 
 std::vector<Statement*> StmtSort::getStmts(
     Fusion* fusion,
     const std::vector<Val*>& to,
-    bool traverse_members) {
+    bool traverse_members,
+    bool traverse_attributes) {
   StmtSort es;
-  es.traverseTo(fusion, to, false, traverse_members);
+  es.traverseTo(fusion, to, false, traverse_members, traverse_attributes);
   return es.stmts;
 }
 
@@ -840,10 +871,16 @@ std::vector<Statement*> StmtSort::getStmtsBetween(
     Fusion* fusion,
     const std::vector<Val*>& from,
     const std::vector<Val*>& to,
-    bool traverse_members) {
+    bool traverse_members,
+    bool traverse_attributes) {
   StmtSort es;
   es.traverseBetween(
-      fusion, {from.begin(), from.end()}, to, false, traverse_members);
+      fusion,
+      {from.begin(), from.end()},
+      to,
+      false,
+      traverse_members,
+      traverse_attributes);
   return es.stmts;
 }
 

--- a/csrc/iter_visitor.h
+++ b/csrc/iter_visitor.h
@@ -93,11 +93,15 @@ class TORCH_CUDA_CU_API IterVisitor : public OptOutDispatch {
   //! TensorDomain, or IterDomain where there are members of the nodes that are
   //! Val's a value of "true" will also traverse into those member Val's, a
   //! value of "false" will not traverse into the members.
+  //! \param traverse_attributes When true, traverse into expr
+  //! attributes. Note that attributes of template type Attribute are
+  //! not traversed as there's no dispatch support.
   void traverseTo(
       Fusion* fusion,
       const std::vector<Val*>& to,
       bool traverse_all_paths = false,
-      bool traverse_into_members = false);
+      bool traverse_into_members = false,
+      bool traverse_attributes = false);
 
   //! Traverses nodes in Fusion from inputs in topological order to "to". i.e.
   //! from inputs towards outputs.
@@ -112,12 +116,16 @@ class TORCH_CUDA_CU_API IterVisitor : public OptOutDispatch {
   //! on path from inputs to "to" node it will not be visited. If there's a path
   //! from inputs to "to" that doesn't go through "from" that input and the path
   //! from it will also be traversed.
+  //! \param traverse_attributes When true, traverse into expr
+  //! attributes. Note that attributes of template type Attribute are
+  //! not traversed as there's no dispatch support.
   void traverseBetween(
       Fusion* fusion,
       const std::unordered_set<Val*>& from,
       const std::vector<Val*>& to,
       bool traverse_all_paths = false,
-      bool traverse_into_members = false);
+      bool traverse_into_members = false,
+      bool traverse_attributes = false);
 
   // Iterates from terminating outputs registered with the fusion. Terminating
   // means value is not used to generate any other value used in producing
@@ -287,16 +295,19 @@ class StmtSort : public IterVisitor {
  public:
   // If traverse_members it will also extract all member nodes in the sorted
   // statement list in the fusion. i.e. all IterDomains, extents, and associated
-  // expressions of them
+  // expressions of them. Similarly, if traverse_attributes it will
+  // grab all nodes associated as Expr attributes.
   static std::vector<Statement*> getStmts(
       Fusion* fusion,
-      bool traverse_members = false);
+      bool traverse_members = false,
+      bool traverse_attributes = false);
 
   // Returns ordered Statements required to produce from, including from.
   static std::vector<Statement*> getStmts(
       Fusion* fusion,
       const std::vector<Val*>& to,
-      bool traverse_members = false);
+      bool traverse_members = false,
+      bool traverse_attributes = false);
 
   // Returns ordered Statements required to produce from, including from.
   // Stops traversal once hiting any Statements in to. Includes Statements in
@@ -319,25 +330,29 @@ class StmtSort : public IterVisitor {
       Fusion* fusion,
       const std::vector<Val*>& from,
       const std::vector<Val*>& to,
-      bool traverse_members = false);
+      bool traverse_members = false,
+      bool traverse_attributes = false);
 
   // Same as getStmts version but filters to only return the Expr*s
   static std::vector<Expr*> getExprs(
       Fusion* fusion,
-      bool traverse_members = false);
+      bool traverse_members = false,
+      bool traverse_attributes = false);
 
   // Same as getStmts version but filters to only return the Expr*s
   static std::vector<Expr*> getExprs(
       Fusion* fusion,
       const std::vector<Val*>& to,
-      bool traverse_members = false);
+      bool traverse_members = false,
+      bool traverse_attributes = false);
 
   // Same as getStmts version but filters to only return the Expr*s
   static std::vector<Expr*> getExprsBetween(
       Fusion* fusion,
       const std::vector<Val*>& from,
       const std::vector<Val*>& to,
-      bool traverse_members = false);
+      bool traverse_members = false,
+      bool traverse_attributes = false);
 };
 
 class TORCH_CUDA_CU_API InputsOf : public IterVisitor {

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1058,7 +1058,8 @@ IterDomain* projectIdToRoot(
     return reference_id;
   }
 
-  auto replay_exprs = StmtSort::getExprs(tv->fusion(), {reference_id}, false);
+  auto replay_exprs =
+      StmtSort::getExprs(tv->fusion(), {reference_id}, false, false);
   if (replay_exprs.empty()) {
     return reference_id;
   }


### PR DESCRIPTION
Add `traverse_attributes` optional flag to `IterVisitor` routines to traverse into attributes as well. The original motivation is that `ValReplacementMutator`, used by `replaceSymbolicSizes`, needs to apply replacements to the left and right expand parameters of `Resize`. This hasn't been an issue but is exhibited as an error with a small optimization.

One caveat is that the traversal doesn't visit attributes of type `Attribute` as it's a template type and the dispatch system doesn't support dispatching `Val`'s to handlers for template types. Not a problem for the Resize traversal, but may need to be revisited.