### PR TITLE
Ignore Resize ops when validating all ID uses are exactly mapped.

### DIFF
--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -558,6 +558,12 @@ bool requiresForwardViewReplay(Fusion* fusion, ComputeAtMap& ca_map) {
         continue;
       }
 
+      // rfactor_def can be Resize, but resize transformation is not
+      // replayed, so mismatch doesn't matter
+      if (rfactor_def->isA<Resize>()) {
+        continue;
+      }
+
       // If one output of the expression is an rfactor ID all of them should be
       auto def_outs =
           ir_utils::filterByType<IterDomain>(rfactor_def->outputs());
@@ -583,6 +589,13 @@ bool requiresForwardViewReplay(Fusion* fusion, ComputeAtMap& ca_map) {
 
       // Check which definition in the unique exact definition set this
       // definition matches to:
+      // TODO: Why does it need to check all unique defs? It actually
+      // only looks at those that are exact with rfactor_def and
+      // adds those unique_defs, which are all exactly mapped, to the
+      // unique_exact_use map. Since the objective of this analysis is
+      // to find non-exact exprs using the same exact ID set, it seems
+      // it's just sufficient to register rfactor_def as a user of the
+      // exact set.
       for (auto unique_def : unique_defs) {
         if (ca_map.areExactExprs(rfactor_def, unique_def)) {
           // Check if we already have an expression that consumes an

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -1928,8 +1928,10 @@ TEST_F(NVFuserTest, FusionSliceForNanoGPT3_CUDA) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
-  auto kernel =
-      executor_cache.getMostRecentKernelRuntime()->executors().at(0).kernel();
+  auto runtime = executor_cache.getMostRecentKernelRuntime();
+  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+
+  auto kernel = runtime->executors().at(0).kernel();
   TORCH_CHECK(
       !kernel->summary().has_cooperative_grid_reduction,
       "Grid sync should not be used as slicing input should avoid input caching");


### PR DESCRIPTION
Resize ops are not replayed, so they don't need to be exactly mapped

Previously, `FusionSliceForNanoGPT3_CUDA` was segmented as the `resize` ops are not exactly mapped since they have the different expansion arguments. Since those `resize` ops are part of rfactor transformations, they were detected as conflicting rfactor transformations. However, unlike the `split` and `merge` used by `reshape`, `resize` ops are not replayed, so they don't need to be uniform.

This is also part of the fix for #58. Looks like the Python example is not segmented anymore, although I suspect there's still something need to do for `permute`.