### PR TITLE
`slice` fix up to add `strides=` argument as optional

### DIFF
--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -1831,7 +1831,7 @@ class TestNvFuserFrontend(TestCase):
         def check_start_indices(fd: FusionDefinition, acts) -> None:
             T0 = fd.from_pytorch(acts[0])
             T1 = fd.ops.slice(
-                T0, start_indices=[-1, -2], end_indices=[5, 5], strides=[1, 1]
+                T0, start_indices=[-1, -2], end_indices=[5, 5], strides=[7, 7]
             )
             fd.add_output(T1)
 
@@ -1876,6 +1876,11 @@ class TestNvFuserFrontend(TestCase):
                 T0, start_indices=[0, 0], end_indices=[4, 4], strides=[1, 1, 1]
             )
             fd.add_output(T1)
+        
+        def check_nostrides(fd: FusionDefinition, acts) -> None:
+            T0 = fd.from_pytorch(acts[0])
+            T1 = fd.ops.slice(T0, start_indices=[2, 2], end_indices=[4, 4])
+            fd.add_output(T1)
 
         # TODO: Currently, this check fails to produce a zero-element tensor whne the tensor
         # is smaller than the index range of the slize.  Therefore, it is disabled.
@@ -1906,7 +1911,7 @@ class TestNvFuserFrontend(TestCase):
             ),
             (
                 check_slice_dims_start,
-                "Number of tensor dimensions does not match slice dimensions! .*",
+                "Slice start_indices and strides don't match! .*",
             ),
             (
                 check_slice_dims_end,
@@ -1914,22 +1919,27 @@ class TestNvFuserFrontend(TestCase):
             ),
             (
                 check_slice_dims_stride,
-                "Slice indexing attribute dimensions don't match! .*",
+                "Slice start_indices and strides don't match! .*",
             ),
+            (check_nostrides, None),
             # (legal, None),
         ]
 
+        first_check = True
         for inp in inputs:
             for check, error in checks:
                 if error is None:
-                    out = self.exec_nvfuser(partial(check, acts=inp), inp)
+                    # First check is here on legel fusions since the second time
+                    # through they should already be cached
+                    out = self.exec_nvfuser(partial(check, acts=inp), inp, first_check)
                 else:
                     self.assertRaisesRegex(
                         RuntimeError,
                         error,
-                        partial(self.exec_nvfuser, partial(check, acts=inp)),
+                        self.exec_nvfuser, partial(check, acts=inp),
                         inp,
                     )
+            first_check = False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `strides=` argument to `slice` should have been made as optional with a default of a vector of 1's but I forget to add this functionality.

I also added a check to make sure the lack of the strides argument works.