### PR TITLE
shfl for complex number

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -31,6 +31,7 @@ code = 'CLANGFORMAT'
 include_patterns = [
     '**/*.h',
     '**/*.cpp',
+    '**/*.cu',
 ]
 exclude_patterns = [
     'third_party/**',

--- a/csrc/lower_utils.cpp
+++ b/csrc/lower_utils.cpp
@@ -265,12 +265,6 @@ c10::optional<IterDomain*> getMaybeWarpReductionDim(
 
   auto tv_in = getTv(input);
 
-  // __shfl_xor_sync() doesn't support complex number
-  if (tv_in->dtype() == DataType::ComplexFloat ||
-      tv_in->dtype() == DataType::ComplexDouble) {
-    return c10::nullopt;
-  }
-
   // only support reducing to registers for now.
   if (tv_in->getMemoryType() != MemoryType::Local ||
       tv_out->getMemoryType() != MemoryType::Local) {

--- a/runtime/warp.cu
+++ b/runtime/warp.cu
@@ -7,6 +7,17 @@
 // clang-format on
 namespace warp {
 
+template <typename T>
+__device__ __forceinline__ T shfl_xor(T var, int laneMask, int width = 32) {
+  return __shfl_xor_sync(0xffffffff, var, laneMask, width);
+}
+template <typename T>
+__device__ __forceinline__ std::complex<T> shfl_xor(std::complex<T> var, int laneMask, int width = 32) {
+  T real = __shfl_xor_sync(0xffffffff, var.real(), laneMask, width);
+  T imag = __shfl_xor_sync(0xffffffff, var.imag(), laneMask, width);
+  return std::complex<T>(real, imag);
+}
+
 template <
     bool SINGLE_WARP,
     typename T,
@@ -35,7 +46,7 @@ __device__ void warpReduceTIDX(
   // Reduce within each warp
   for (int i = 16; i >= 1; i /= 2) {
     reduction_op(
-        reduce_val, __shfl_xor_sync(0xffffffff, reduce_val, i, WARP_SIZE));
+        reduce_val, shfl_xor(reduce_val, i, WARP_SIZE));
   }
 
   // Reduce across warp if needed
@@ -68,167 +79,7 @@ __device__ void warpReduceTIDX(
       // Reduce within warp 0
       for (int i = 16; i >= 1; i /= 2) {
         reduction_op(
-            reduce_val, __shfl_xor_sync(0xffffffff, reduce_val, i, 32));
-      }
-    }
-
-    if (is_warp_head) {
-      reduction_op(out, reduce_val);
-    }
-  } else {
-    reduction_op(out, reduce_val);
-  }
-}
-
-// specialized version with T = std::complex<float>
-template <
-    bool SINGLE_WARP,
-    typename Func,
-    typename _dim3ti,
-    typename _dim3bd>
-__device__ void warpReduceTIDX(
-    std::complex<float>& out,
-    const std::complex<float>& inp_val,
-    Func reduction_op,
-    const _dim3ti& thread_idx,
-    const _dim3bd& block_dim,
-    std::complex<float>* shared_mem,
-    bool read_write_pred,
-    std::complex<float> init_val) {
-  constexpr int WARP_SIZE = 32;
-
-  // Assume input padded to multiples of a warp
-  std::complex<float> reduce_val = init_val;
-
-  // Do warp reduction
-  if (read_write_pred) {
-    reduce_val = inp_val;
-  }
-
-  // Reduce within each warp
-  for (int i = 16; i >= 1; i /= 2) {
-    float real = __shfl_xor_sync(0xffffffff, reduce_val.real(), i, WARP_SIZE);
-    float imag = __shfl_xor_sync(0xffffffff, reduce_val.imag(), i, WARP_SIZE);
-    std::complex<float> other_val(real, imag);
-    reduction_op(
-        reduce_val, other_val);
-  }
-
-  // Reduce across warp if needed
-  // Load value to shared mem
-  if (!SINGLE_WARP) {
-    unsigned int warp_idx = thread_idx.x / WARP_SIZE;
-    unsigned int lane_idx = thread_idx.x % WARP_SIZE;
-    unsigned int reduce_group_id = thread_idx.z * block_dim.y + thread_idx.y;
-    bool is_warp_head = lane_idx == 0;
-    unsigned int reduction_size = block_dim.x;
-    unsigned int num_of_warps = reduction_size / WARP_SIZE;
-    unsigned int smem_offset = reduce_group_id * num_of_warps;
-
-    block_sync::sync();
-
-    if (is_warp_head) {
-      shared_mem[smem_offset + warp_idx] = reduce_val;
-    }
-
-    block_sync::sync();
-
-    if (warp_idx == 0) {
-      // This assumes num_of_warps will be < 32, meaning < 1024 threads.
-      //  Should be true for long enough.
-      assert(num_of_warps <= 32);
-
-      reduce_val =
-          lane_idx < num_of_warps ? shared_mem[smem_offset + lane_idx]
-                                  : init_val;
-
-      // Reduce within warp 0
-      for (int i = 16; i >= 1; i /= 2) {
-        float real = __shfl_xor_sync(0xffffffff, reduce_val.real(), i, WARP_SIZE);
-        float imag = __shfl_xor_sync(0xffffffff, reduce_val.imag(), i, WARP_SIZE);
-        std::complex<float> other_val(real, imag);
-        reduction_op(
-            reduce_val, other_val);
-      }
-    }
-
-    if (is_warp_head) {
-      reduction_op(out, reduce_val);
-    }
-  } else {
-    reduction_op(out, reduce_val);
-  }
-}
-
-// specialized versionwith T = std::complex<double>
-template <
-    bool SINGLE_WARP,
-    typename Func,
-    typename _dim3ti,
-    typename _dim3bd>
-__device__ void warpReduceTIDX(
-    std::complex<double>& out,
-    const std::complex<double>& inp_val,
-    Func reduction_op,
-    const _dim3ti& thread_idx,
-    const _dim3bd& block_dim,
-    std::complex<double>* shared_mem,
-    bool read_write_pred,
-    std::complex<double> init_val) {
-  constexpr int WARP_SIZE = 32;
-
-  // Assume input padded to multiples of a warp
-  std::complex<double> reduce_val = init_val;
-
-  // Do warp reduction
-  if (read_write_pred) {
-    reduce_val = inp_val;
-  }
-
-  // Reduce within each warp
-  for (int i = 16; i >= 1; i /= 2) {
-    double real = __shfl_xor_sync(0xffffffff, reduce_val.real(), i, WARP_SIZE);
-    double imag = __shfl_xor_sync(0xffffffff, reduce_val.imag(), i, WARP_SIZE);
-    std::complex<double> other_val(real, imag);
-    reduction_op(
-        reduce_val, other_val);
-  }
-
-  // Reduce across warp if needed
-  // Load value to shared mem
-  if (!SINGLE_WARP) {
-    unsigned int warp_idx = thread_idx.x / WARP_SIZE;
-    unsigned int lane_idx = thread_idx.x % WARP_SIZE;
-    unsigned int reduce_group_id = thread_idx.z * block_dim.y + thread_idx.y;
-    bool is_warp_head = lane_idx == 0;
-    unsigned int reduction_size = block_dim.x;
-    unsigned int num_of_warps = reduction_size / WARP_SIZE;
-    unsigned int smem_offset = reduce_group_id * num_of_warps;
-
-    block_sync::sync();
-
-    if (is_warp_head) {
-      shared_mem[smem_offset + warp_idx] = reduce_val;
-    }
-
-    block_sync::sync();
-
-    if (warp_idx == 0) {
-      // This assumes num_of_warps will be < 32, meaning < 1024 threads.
-      //  Should be true for long enough.
-      assert(num_of_warps <= 32);
-
-      reduce_val =
-          lane_idx < num_of_warps ? shared_mem[smem_offset + lane_idx]
-                                  : init_val;
-
-      // Reduce within warp 0
-      for (int i = 16; i >= 1; i /= 2) {
-        double real = __shfl_xor_sync(0xffffffff, reduce_val.real(), i, WARP_SIZE);
-        double imag = __shfl_xor_sync(0xffffffff, reduce_val.imag(), i, WARP_SIZE);
-        std::complex<double> other_val(real, imag);
-        reduction_op(
-            reduce_val, other_val);
+            reduce_val, shfl_xor(reduce_val, i, 32));
       }
     }
 

--- a/runtime/warp.cu
+++ b/runtime/warp.cu
@@ -12,7 +12,10 @@ __device__ __forceinline__ T shfl_xor(T var, int laneMask, int width = 32) {
   return __shfl_xor_sync(0xffffffff, var, laneMask, width);
 }
 template <typename T>
-__device__ __forceinline__ std::complex<T> shfl_xor(std::complex<T> var, int laneMask, int width = 32) {
+__device__ __forceinline__ std::complex<T> shfl_xor(
+    std::complex<T> var,
+    int laneMask,
+    int width = 32) {
   T real = __shfl_xor_sync(0xffffffff, var.real(), laneMask, width);
   T imag = __shfl_xor_sync(0xffffffff, var.imag(), laneMask, width);
   return std::complex<T>(real, imag);
@@ -45,8 +48,7 @@ __device__ void warpReduceTIDX(
 
   // Reduce within each warp
   for (int i = 16; i >= 1; i /= 2) {
-    reduction_op(
-        reduce_val, shfl_xor(reduce_val, i, WARP_SIZE));
+    reduction_op(reduce_val, shfl_xor(reduce_val, i, WARP_SIZE));
   }
 
   // Reduce across warp if needed
@@ -78,8 +80,7 @@ __device__ void warpReduceTIDX(
 
       // Reduce within warp 0
       for (int i = 16; i >= 1; i /= 2) {
-        reduction_op(
-            reduce_val, shfl_xor(reduce_val, i, 32));
+        reduction_op(reduce_val, shfl_xor(reduce_val, i, 32));
       }
     }
 

--- a/runtime/warp.cu
+++ b/runtime/warp.cu
@@ -80,4 +80,164 @@ __device__ void warpReduceTIDX(
   }
 }
 
+// specialized version with T = std::complex<float>
+template <
+    bool SINGLE_WARP,
+    typename Func,
+    typename _dim3ti,
+    typename _dim3bd>
+__device__ void warpReduceTIDX(
+    std::complex<float>& out,
+    const std::complex<float>& inp_val,
+    Func reduction_op,
+    const _dim3ti& thread_idx,
+    const _dim3bd& block_dim,
+    std::complex<float>* shared_mem,
+    bool read_write_pred,
+    std::complex<float> init_val) {
+  constexpr int WARP_SIZE = 32;
+
+  // Assume input padded to multiples of a warp
+  std::complex<float> reduce_val = init_val;
+
+  // Do warp reduction
+  if (read_write_pred) {
+    reduce_val = inp_val;
+  }
+
+  // Reduce within each warp
+  for (int i = 16; i >= 1; i /= 2) {
+    float real = __shfl_xor_sync(0xffffffff, reduce_val.real(), i, WARP_SIZE);
+    float imag = __shfl_xor_sync(0xffffffff, reduce_val.imag(), i, WARP_SIZE);
+    std::complex<float> other_val(real, imag);
+    reduction_op(
+        reduce_val, other_val);
+  }
+
+  // Reduce across warp if needed
+  // Load value to shared mem
+  if (!SINGLE_WARP) {
+    unsigned int warp_idx = thread_idx.x / WARP_SIZE;
+    unsigned int lane_idx = thread_idx.x % WARP_SIZE;
+    unsigned int reduce_group_id = thread_idx.z * block_dim.y + thread_idx.y;
+    bool is_warp_head = lane_idx == 0;
+    unsigned int reduction_size = block_dim.x;
+    unsigned int num_of_warps = reduction_size / WARP_SIZE;
+    unsigned int smem_offset = reduce_group_id * num_of_warps;
+
+    block_sync::sync();
+
+    if (is_warp_head) {
+      shared_mem[smem_offset + warp_idx] = reduce_val;
+    }
+
+    block_sync::sync();
+
+    if (warp_idx == 0) {
+      // This assumes num_of_warps will be < 32, meaning < 1024 threads.
+      //  Should be true for long enough.
+      assert(num_of_warps <= 32);
+
+      reduce_val =
+          lane_idx < num_of_warps ? shared_mem[smem_offset + lane_idx]
+                                  : init_val;
+
+      // Reduce within warp 0
+      for (int i = 16; i >= 1; i /= 2) {
+        float real = __shfl_xor_sync(0xffffffff, reduce_val.real(), i, WARP_SIZE);
+        float imag = __shfl_xor_sync(0xffffffff, reduce_val.imag(), i, WARP_SIZE);
+        std::complex<float> other_val(real, imag);
+        reduction_op(
+            reduce_val, other_val);
+      }
+    }
+
+    if (is_warp_head) {
+      reduction_op(out, reduce_val);
+    }
+  } else {
+    reduction_op(out, reduce_val);
+  }
+}
+
+// specialized versionwith T = std::complex<double>
+template <
+    bool SINGLE_WARP,
+    typename Func,
+    typename _dim3ti,
+    typename _dim3bd>
+__device__ void warpReduceTIDX(
+    std::complex<double>& out,
+    const std::complex<double>& inp_val,
+    Func reduction_op,
+    const _dim3ti& thread_idx,
+    const _dim3bd& block_dim,
+    std::complex<double>* shared_mem,
+    bool read_write_pred,
+    std::complex<double> init_val) {
+  constexpr int WARP_SIZE = 32;
+
+  // Assume input padded to multiples of a warp
+  std::complex<double> reduce_val = init_val;
+
+  // Do warp reduction
+  if (read_write_pred) {
+    reduce_val = inp_val;
+  }
+
+  // Reduce within each warp
+  for (int i = 16; i >= 1; i /= 2) {
+    double real = __shfl_xor_sync(0xffffffff, reduce_val.real(), i, WARP_SIZE);
+    double imag = __shfl_xor_sync(0xffffffff, reduce_val.imag(), i, WARP_SIZE);
+    std::complex<double> other_val(real, imag);
+    reduction_op(
+        reduce_val, other_val);
+  }
+
+  // Reduce across warp if needed
+  // Load value to shared mem
+  if (!SINGLE_WARP) {
+    unsigned int warp_idx = thread_idx.x / WARP_SIZE;
+    unsigned int lane_idx = thread_idx.x % WARP_SIZE;
+    unsigned int reduce_group_id = thread_idx.z * block_dim.y + thread_idx.y;
+    bool is_warp_head = lane_idx == 0;
+    unsigned int reduction_size = block_dim.x;
+    unsigned int num_of_warps = reduction_size / WARP_SIZE;
+    unsigned int smem_offset = reduce_group_id * num_of_warps;
+
+    block_sync::sync();
+
+    if (is_warp_head) {
+      shared_mem[smem_offset + warp_idx] = reduce_val;
+    }
+
+    block_sync::sync();
+
+    if (warp_idx == 0) {
+      // This assumes num_of_warps will be < 32, meaning < 1024 threads.
+      //  Should be true for long enough.
+      assert(num_of_warps <= 32);
+
+      reduce_val =
+          lane_idx < num_of_warps ? shared_mem[smem_offset + lane_idx]
+                                  : init_val;
+
+      // Reduce within warp 0
+      for (int i = 16; i >= 1; i /= 2) {
+        double real = __shfl_xor_sync(0xffffffff, reduce_val.real(), i, WARP_SIZE);
+        double imag = __shfl_xor_sync(0xffffffff, reduce_val.imag(), i, WARP_SIZE);
+        std::complex<double> other_val(real, imag);
+        reduction_op(
+            reduce_val, other_val);
+      }
+    }
+
+    if (is_warp_head) {
+      reduction_op(out, reduce_val);
+    }
+  } else {
+    reduction_op(out, reduce_val);
+  }
+}
+
 } // namespace warp


### PR DESCRIPTION
solve https://github.com/csarofeen/pytorch/issues/2526
we need to do shfl two times, one for real part and the other for imag part. The speed is still faster than block reduction. 
In a tested case, warp: achieved: 1324.28 GB/s,  block: achieved: 1248.61 GB/s