### PR TITLE
Grid reshape to increase hit rate

### DIFF
--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -346,6 +346,7 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
   // increases, recompile to adjust maxregister count.
   int64_t block_size_high_water_mark = 1;
   int maxrregcount_high_water_mark = 255;
+  int swizzle_factor = 1;
 
   // lookup table to take short cut to retrieve recorded information in order to
   // launch kernels without re-inference parameters.

--- a/csrc/executor_params.cpp
+++ b/csrc/executor_params.cpp
@@ -33,25 +33,25 @@ void LaunchParams::assertValid() {
       gdimz());
 }
 
-void LaunchParams::bind(int64_t val, ParallelType p_type) {
+void LaunchParams::bind(int64_t val, ParallelType p_type, bool allow_rebind) {
   switch (p_type) {
     case ParallelType::TIDx:
-      checkAndSet(val, bdimx_, "blockDim.x");
+      checkAndSet(val, bdimx_, "blockDim.x", allow_rebind);
       break;
     case ParallelType::BIDx:
-      checkAndSet(val, gdimx_, "gridDim.x");
+      checkAndSet(val, gdimx_, "gridDim.x", allow_rebind);
       break;
     case ParallelType::TIDy:
-      checkAndSet(val, bdimy_, "blockDim.y");
+      checkAndSet(val, bdimy_, "blockDim.y", allow_rebind);
       break;
     case ParallelType::BIDy:
-      checkAndSet(val, gdimy_, "gridDim.y");
+      checkAndSet(val, gdimy_, "gridDim.y", allow_rebind);
       break;
     case ParallelType::TIDz:
-      checkAndSet(val, bdimz_, "blockdim.z");
+      checkAndSet(val, bdimz_, "blockdim.z", allow_rebind);
       break;
     case ParallelType::BIDz:
-      checkAndSet(val, gdimz_, "gridDim.z");
+      checkAndSet(val, gdimz_, "gridDim.z", allow_rebind);
       break;
     default:
       TORCH_INTERNAL_ASSERT(

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -1028,6 +1028,7 @@ std::tuple<NvrtcFunction, std::string, std::vector<char>> nvrtcCompile(
     const std::string& code,
     const std::string& func_name,
     int id,
+    const int swizzle_factor,
     c10::optional<int> opt_block_size,
     const int max_register_heuristic,
     bool return_compiled_binary) {
@@ -1091,6 +1092,10 @@ std::tuple<NvrtcFunction, std::string, std::vector<char>> nvrtcCompile(
   if (isOptionEnabled(EnableOption::KernelProfile)) {
     args.push_back("-DPYTORCH_NVFUSER_PROFILE_KERNEL");
   }
+
+  const std::string swizzle_factor_str =
+      "-DSWIZZLE_FACTOR=" + std::to_string(std::max(swizzle_factor, 1));
+  args.push_back(swizzle_factor_str.c_str());
 
   const char* ptxas_opt_level = getenv("PYTORCH_NVFUSER_JIT_OPT_LEVEL");
   std::string jit_opt_level = "-O";

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -63,6 +63,7 @@ std::tuple<NvrtcFunction, std::string, std::vector<char>> nvrtcCompile(
     const std::string& code,
     const std::string& func_name,
     int id,
+    const int swizzle_factor,
     c10::optional<int> opt_block_size = c10::nullopt,
     const int max_register_heuristic = 255,
     bool return_compiled_binary = false);

--- a/csrc/lower_bank_conflict.cpp
+++ b/csrc/lower_bank_conflict.cpp
@@ -50,13 +50,32 @@ inline int64_t getPhaseSize(int64_t word_size_bytes) {
   return 32;
 }
 
+ParallelType getParallelType(const std::string& name) {
+  if (name == "threadIdx.x") {
+    return ParallelType::TIDx;
+  } else if (name == "threadIdx.y") {
+    return ParallelType::TIDy;
+  } else if (name == "threadIdx.z") {
+    return ParallelType::TIDz;
+  } else if (name == "getBlockIdX()") {
+    return ParallelType::BIDx;
+  } else if (name == "getBlockIdY()") {
+    return ParallelType::BIDy;
+  } else if (name == "getBlockIdZ()") {
+    return ParallelType::BIDz;
+  }
+  TORCH_INTERNAL_ASSERT(false, "Not a parallel type");
+}
+
 bool isThreadIdx(const std::string& name) {
   return name == "threadIdx.x" || name == "threadIdx.y" ||
       name == "threadIdx.z";
 }
 
 bool isBlockIdx(const std::string& name) {
-  return name == "blockIdx.x" || name == "blockIdx.y" || name == "blockIdx.z";
+  auto parallelType = getParallelType(name);
+  return parallelType == ParallelType::BIDx ||
+      parallelType == ParallelType::BIDy || parallelType == ParallelType::BIDz;
 }
 
 bool isBlockDim(const std::string& name) {
@@ -65,23 +84,6 @@ bool isBlockDim(const std::string& name) {
 
 bool isGridDim(const std::string& name) {
   return name == "gridDim.x" && name == "gridDim.y" && name == "gridDim.z";
-}
-
-ParallelType getParallelType(const std::string& name) {
-  if (name == "threadIdx.x") {
-    return ParallelType::TIDx;
-  } else if (name == "threadIdx.y") {
-    return ParallelType::TIDy;
-  } else if (name == "threadIdx.z") {
-    return ParallelType::TIDz;
-  } else if (name == "blockIdx.x") {
-    return ParallelType::BIDx;
-  } else if (name == "blockIdx.y") {
-    return ParallelType::BIDy;
-  } else if (name == "blockIdx.z") {
-    return ParallelType::BIDz;
-  }
-  TORCH_INTERNAL_ASSERT(false, "Not a parallel type");
 }
 
 std::vector<int64_t> evaluateAddressesOnFirstPhase(

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -377,6 +377,17 @@ void scheduleMatmul(
   // [... M,N,K]
   scheduler_utils::matmul_utils::makeTile(cc, gemm_tile.cta_tile.toVector());
 
+  // int factor =
+  //     getenv("SWIZZLE_FACTOR") != nullptr ?
+  //     std::atoi(getenv("SWIZZLE_FACTOR")) : 1;
+  // if (factor != 1) {
+  //   cc->split(1, factor, false); // outer split
+  //   cc->split(0, factor, true); // inner
+  //   // Mo, Mi, Ni, Mo
+  //   cc->merge(1, 2);
+  //   cc->merge(2, 1);
+  // }
+
   // [Mo, No, Ko, Mi, Ni, Ki]
   // Propagate tiling globally
   scheduler_utils::transformPropagateToAllFrom(cc, -1);

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -607,11 +607,11 @@ static const char* rng_op_type2string(RNGOpType t) {
 static const char* parallel_type2string(ParallelType t) {
   switch (t) {
     case ParallelType::BIDz:
-      return "blockIdx.z";
+      return "getBlockIdZ()";
     case ParallelType::BIDy:
-      return "blockIdx.y";
+      return "getBlockIdY()";
     case ParallelType::BIDx:
-      return "blockIdx.x";
+      return "getBlockIdX()";
     case ParallelType::TIDz:
       return "threadIdx.z";
     case ParallelType::TIDy:

--- a/runtime/helpers.cu
+++ b/runtime/helpers.cu
@@ -22,6 +22,31 @@
 #include <assert.h>
 #endif // __NVCC__
 
+
+constexpr unsigned swizzle_factor = SWIZZLE_FACTOR;
+
+__device__ unsigned getBlockIdX() {
+  static_assert(swizzle_factor >= 1);
+  if constexpr (swizzle_factor == 1) {
+    return blockIdx.x;
+  } else {
+    return blockIdx.x / swizzle_factor;
+  }
+}
+
+__device__ unsigned getBlockIdY() {
+  static_assert(swizzle_factor >= 1);
+  if constexpr (swizzle_factor == 1) {
+    return blockIdx.y;
+  } else {
+    return blockIdx.y * swizzle_factor + (blockIdx.x % swizzle_factor);
+  }
+}
+
+__device__ unsigned getBlockIdZ() {
+  return blockIdx.z;
+}
+
 __device__ constexpr int ceilDiv(int a, int b) {
   return (a + b - 1) / b;
 }

--- a/runtime/helpers.cu
+++ b/runtime/helpers.cu
@@ -22,7 +22,6 @@
 #include <assert.h>
 #endif // __NVCC__
 
-
 constexpr unsigned swizzle_factor = SWIZZLE_FACTOR;
 
 __device__ unsigned getBlockIdX() {


### PR DESCRIPTION

Runtimes in ms:
Current tracking-matmul:
```
SWIZZLE_FACTOR=1 ./bin/nvfuser_tests --gtest_filter=*FusionAmpereMatmul_CUDA*
...
6.80659
5.72541
5.78003
5.336
5.7224
5.59946
```

With swizzle_factor:
```
SWIZZLE_FACTOR=4 ./bin/nvfuser_tests --gtest_filter=*FusionAmpereMatmul_CUDA*
...
5.14675
5.06474
5.08704
5.13798
5.12608
5.07923
```