### PR TITLE
disable clang-tidy since there are too many violations there

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,62 +10,63 @@ env:
   working_directory: .
 
 jobs:
-  clang-tidy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Run lintrunner
-        working-directory: ${{ env.working_directory }}
-        run: |
-          this_dir=$(pwd)
+  # NOTE: enable clang-tidy when we have it cleaned up.
+  #clang-tidy:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #      with:
+  #        submodules: true
+  #    - uses: actions/setup-python@v4
+  #      with:
+  #        python-version: '3.10'
+  #    - name: Run lintrunner
+  #      working-directory: ${{ env.working_directory }}
+  #      run: |
+  #        this_dir=$(pwd)
 
-          # Install lintrunner
-          pip install lintrunner
+  #        # Install lintrunner
+  #        pip install lintrunner
 
-          # Initialize lintrunner
-          lintrunner init 2> /dev/null
+  #        # Initialize lintrunner
+  #        lintrunner init 2> /dev/null
 
-          # Install cuda
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
-          sudo dpkg -i cuda-keyring_1.0-1_all.deb
-          sudo apt-get update
-          sudo apt-get -y install cuda
+  #        # Install cuda
+  #        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+  #        sudo dpkg -i cuda-keyring_1.0-1_all.deb
+  #        sudo apt-get update
+  #        sudo apt-get -y install cuda
 
-          # cmake environment variables
-          export CUDAARCHS=86
-          export CUDACXX=/usr/local/cuda/bin/nvcc
-          export PATH=/usr/local/cuda/bin:${PATH}
-          export CUDA_INSTALL_PATH=/usr/local/cuda
+  #        # cmake environment variables
+  #        export CUDAARCHS=86
+  #        export CUDACXX=/usr/local/cuda/bin/nvcc
+  #        export PATH=/usr/local/cuda/bin:${PATH}
+  #        export CUDA_INSTALL_PATH=/usr/local/cuda
 
-          # pytorch environment variables
-          export TORCH_CUDA_ARCH_LIST="8.6"
-          export BUILD_NVFUSER=1
-          export USE_MKLDNN=0
-          export USE_CUDNN=0
-          export USE_DISTRIBUTED=0
-          export NVFUSER_SOURCE_DIR=$this_dir
+  #        # pytorch environment variables
+  #        export TORCH_CUDA_ARCH_LIST="8.6"
+  #        export BUILD_NVFUSER=1
+  #        export USE_MKLDNN=0
+  #        export USE_CUDNN=0
+  #        export USE_DISTRIBUTED=0
+  #        export NVFUSER_SOURCE_DIR=$this_dir
 
-          # Clone pytorch and run cmake build
-          git clone https://github.com/pytorch/pytorch.git
-          cd pytorch
-          python3 -m tools.linter.clang_tidy.generate_build_files
-          cd $this_dir
+  #        # Clone pytorch and run cmake build
+  #        git clone https://github.com/pytorch/pytorch.git
+  #        cd pytorch
+  #        python3 -m tools.linter.clang_tidy.generate_build_files
+  #        cd $this_dir
 
-          # Run lintrunner on all csrc files
-          # find csrc/ -type f | xargs lintrunner --force-color
+  #        # Run lintrunner on all csrc files
+  #        # find csrc/ -type f | xargs lintrunner --force-color
 
-          # Run lintrunner on all csrc files
-          this_commit=$(git rev-parse HEAD)
-          git fetch origin main
-          git checkout origin/main
-          head_commit=$(git rev-parse HEAD)
-          git checkout $this_commit
-          git --no-pager diff --name-only $head_commit |  grep -e "\.cpp" -e "\.h" |tail | xargs lintrunner --take CLANGTIDY --force-color
+  #        # Run lintrunner on all csrc files
+  #        this_commit=$(git rev-parse HEAD)
+  #        git fetch origin main
+  #        git checkout origin/main
+  #        head_commit=$(git rev-parse HEAD)
+  #        git checkout $this_commit
+  #        git --no-pager diff --name-only $head_commit |  grep -e "\.cpp" -e "\.h" |tail | xargs lintrunner --take CLANGTIDY --force-color
 
   lintrunner:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Turning clang-tidy test off to avoid distraction