### PR TITLE
clang-tidy fixes Pt.1

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -501,7 +501,7 @@ class CudaKernelGenerator : private OptOutConstDispatch {
   //!  vectorization handling logic but this path will be updated in
   //!  follow ups to optimize the generated assembly so keeping them
   //!  separate path for now.
-  std::string genVectorPointer(Val* val, DataType dtype, int vec_size) {
+  std::string genVectorPointer(Val* val, DataType dtype, size_t vec_size) {
     std::stringstream ss;
 
     ss << "reinterpret_cast<Array<" << dtype << "," << vec_size << ","
@@ -511,7 +511,7 @@ class CudaKernelGenerator : private OptOutConstDispatch {
   }
 
   // Utility function to emit a cp.async intrinsic
-  void genCpAsync(const LoadStoreOp* ldst, int vec_size) {
+  void genCpAsync(const LoadStoreOp* ldst, size_t vec_size) {
     auto dtype = ldst->in()->getDataType().value();
     bool is_cg = ldst->opType() == LoadStoreOpType::CpAsyncCg;
 
@@ -535,7 +535,7 @@ class CudaKernelGenerator : private OptOutConstDispatch {
     }
   }
 
-  void genLdMatrix(const LoadStoreOp* ldst, int vector_word_size) {
+  void genLdMatrix(const LoadStoreOp* ldst, size_t vector_word_size) {
     auto dtype = ldst->in()->getDataType().value();
     indent() << "Turing::ldMatrix";
     if (ldst->opType() == LoadStoreOpType::LdMatrixTranspose) {
@@ -1771,7 +1771,7 @@ class CudaKernelGenerator : private OptOutConstDispatch {
     std::vector<std::vector<int64_t>> index_combinationsatoins;
 
     // Initialize with an empty vector
-    index_combinationsatoins.push_back(std::vector<int64_t>());
+    index_combinationsatoins.emplace_back();
 
     // Incrementally build a combinatorial set
     for (const auto loop : grouped_loops_) {
@@ -2789,7 +2789,7 @@ class CudaKernelGenerator : private OptOutConstDispatch {
         } else {
           indent() << "} else if (";
         }
-        code_ << gen(cat->getPred(i)) << ") {\n";
+        code_ << gen(cat->getPred((int)i)) << ") {\n";
       } else {
         // last case doesn't need to be predicated
         indent() << "} else {\n";

--- a/csrc/compute_at.cpp
+++ b/csrc/compute_at.cpp
@@ -25,18 +25,18 @@ class ComputeAtSelector : public MaxInfoSpanningTree::Selector {
   std::unordered_set<TensorView*> selected_;
 
  public:
-  virtual bool allowC2P(TensorView* from, TensorView* to) override {
+  bool allowC2P(TensorView* from, TensorView* to) override {
     return selected_.count(to) > 0;
   }
 
-  virtual bool allowP2C(TensorView* from, TensorView* to) override {
+  bool allowP2C(TensorView* from, TensorView* to) override {
     // If the producer is in the selected set, then the consumer must also be
     // replayed to obtain a compatible loop structure so that this producer
     // can be consumed in this loop.
     return selected_.count(from) > 0 || selected_.count(to) > 0;
   }
 
-  virtual bool allowSibling(TensorView* from, TensorView* to) override {
+  bool allowSibling(TensorView* from, TensorView* to) override {
     return true;
   }
 

--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -410,7 +410,7 @@ void IterDomainGraph::build(Fusion* fusion) {
         // Map the entire replay map between the multiple
         // consumers
         auto c2f_disjoint_sets = replay_FasC.getIterDomainEquivalence();
-        for (auto disjoint_set : c2f_disjoint_sets.disjointSets()) {
+        for (const auto& disjoint_set : c2f_disjoint_sets.disjointSets()) {
           if (disjoint_set->empty()) {
             continue;
           }
@@ -620,13 +620,13 @@ void IterDomainGraph::build(Fusion* fusion) {
             rfactor_id_uses.at(rfactor_inp_id),
             "\nand\n",
             expr->toString());
-        rfactor_id_uses.emplace(std::make_pair(rfactor_inp_id, expr));
+        rfactor_id_uses.emplace(rfactor_inp_id, expr);
         rfactor_id_order.push_back(rfactor_inp_id);
       }
     }
     for (auto rfactor_id : consumer_tv->getMaybeRFactorDomain()) {
       if (rfactor_id->isRFactorProduct()) {
-        rfactor_id_uses.emplace(std::make_pair(rfactor_id, nullptr));
+        rfactor_id_uses.emplace(rfactor_id, nullptr);
         rfactor_id_order.push_back(rfactor_id);
       }
     }
@@ -788,25 +788,24 @@ void ComputeAtMap::allocateIndexVariables() {
   //  all lowered kir::ForLoop will correspond to one of the disjoint sets
   //  and we only need one index variable for each set.
   for (const auto& loop_disjoint_set : id_graph_.loopNodes().disjointSets()) {
-    ParallelType ptype;
+    ParallelType ptype = ParallelType::Serial;
     // first allocate thread and grid parallel indices:
     //  The validation pass will check that the parallel bindings within the
     //  loop nodes are consistent so all the loops within this disjoint set
     //  will be realized implicitly using parallel index variables.
-    if (std::any_of(
-            loop_disjoint_set->vector().begin(),
-            loop_disjoint_set->vector().end(),
-            [&ptype](IterDomain* id) {
-              if (id->isThread() &&
-                  // Halo extended parallel loops currently are handled
-                  // differently and an index variable would still
-                  // be allocated in this case.
-                  (GpuLower::current()->haloInfo()->getExtent(id) == nullptr)) {
-                ptype = id->getParallelType();
-                return true;
-              }
-              return false;
-            })) {
+
+    auto result = std::find_if(
+        loop_disjoint_set->vector().begin(),
+        loop_disjoint_set->vector().end(),
+        [](IterDomain* id) {
+          // Halo extended parallel loops currently are handled
+          // differently and an index variable would still
+          // be allocated in this case.
+          return id->isThread() &&
+              (GpuLower::current()->haloInfo()->getExtent(id) == nullptr);
+        });
+    if (result != loop_disjoint_set->vector().end()) {
+      ptype = (*result)->getParallelType();
       loop_index_variable_map_[loop_disjoint_set.get()] =
           NamedScalar::getParallelIndex(ptype);
       continue;
@@ -895,7 +894,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
   const auto& disjoint_set_shared_ptr = disjointSetOf(id, mode);
 
   TORCH_INTERNAL_ASSERT(
-      disjoint_set_shared_ptr->vector().size(),
+      !disjoint_set_shared_ptr->vector().empty(),
       "Empty disjoint set found for ",
       id->toString());
 
@@ -924,7 +923,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
   // Shouldn't ever happen, it would mean there's an error somewhere in the
   // graph.
   TORCH_INTERNAL_ASSERT(
-      maybe_concrete_ids.vector().size() > 0,
+      !maybe_concrete_ids.vector().empty(),
       "No potential concrete_id's found for ",
       id->toString());
 
@@ -976,9 +975,9 @@ IterDomain* ComputeAtMap::computeConcreteId(
     VectorOfUniqueEntries<std::shared_ptr<VectorOfUniqueEntries<IterDomain*>>>
         resolved_broadcasts;
 
-    for (auto exact_set : all_exact_sets_covered) {
+    for (const auto& exact_set : all_exact_sets_covered) {
       TORCH_INTERNAL_ASSERT(
-          exact_set->vector().size(),
+          !exact_set->vector().empty(),
           "Cannot compute concrete id of empty set.");
       auto c_id = getConcreteMappedID(
           exact_set->vector().front(), IdMappingMode::EXACT);
@@ -1018,7 +1017,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
     VectorOfUniqueEntries<std::shared_ptr<VectorOfUniqueEntries<IterDomain*>>>
         tmp_all_exact_sets_covered;
     std::swap(tmp_all_exact_sets_covered, all_exact_sets_covered);
-    for (auto entry : tmp_all_exact_sets_covered) {
+    for (const auto& entry : tmp_all_exact_sets_covered) {
       if (all_resolved_broadcast_uses.has(entry)) {
         continue;
       }
@@ -1031,7 +1030,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
     // All exact sets in the history of an rfactored domain
     VectorOfUniqueEntries<std::shared_ptr<VectorOfUniqueEntries<IterDomain*>>>
         produces_rfactor_dom;
-    for (auto exact_set : all_exact_sets_covered) {
+    for (const auto& exact_set : all_exact_sets_covered) {
       if (produces_rfactor_dom.has(exact_set)) {
         // Already processed
         continue;
@@ -1044,7 +1043,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
       }
       VectorOfUniqueEntries<std::shared_ptr<VectorOfUniqueEntries<IterDomain*>>>
           rfactor_history = getAllDisjointSetProducers({exact_set});
-      for (auto entry : rfactor_history) {
+      for (const auto& entry : rfactor_history) {
         // Leave rfactor exact set, unless it's in the history of another
         // rfactor domain.
         if (entry != exact_set) {
@@ -1058,7 +1057,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
     VectorOfUniqueEntries<std::shared_ptr<VectorOfUniqueEntries<IterDomain*>>>
         tmp_all_exact_sets_covered;
     std::swap(tmp_all_exact_sets_covered, all_exact_sets_covered);
-    for (auto entry : tmp_all_exact_sets_covered) {
+    for (const auto& entry : tmp_all_exact_sets_covered) {
       if (produces_rfactor_dom.has(entry)) {
         continue;
       }
@@ -1083,7 +1082,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
   }
 
   TORCH_INTERNAL_ASSERT(
-      maybe_concrete_ids.vector().size() > 0,
+      !maybe_concrete_ids.vector().empty(),
       "No potential concrete_id's found for disjoint set ",
       disjoint_set_shared_ptr->toString());
 
@@ -1102,7 +1101,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
   for (auto maybe_concrete_id : maybe_concrete_ids.vector()) {
     auto concrete_id_root_sets = getInputDisjointSetsOf(maybe_concrete_id);
 
-    int bcast_root_count = std::count_if(
+    int bcast_root_count = (int)std::count_if(
         concrete_id_root_sets.vector().begin(),
         concrete_id_root_sets.vector().end(),
         [&](std::shared_ptr<VectorOfUniqueEntries<IterDomain*>> set) {
@@ -1136,7 +1135,7 @@ void ComputeAtMap::buildConcreteIds() {
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.exactNodes().disjointSets()) {
     TORCH_INTERNAL_ASSERT(
-        disjoint_set_shared_ptr->vector().size(),
+        !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
     concrete_id_cache_[disjoint_set_shared_ptr] = first_id;
@@ -1147,7 +1146,7 @@ void ComputeAtMap::buildConcreteIds() {
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.permissiveNodes().disjointSets()) {
     TORCH_INTERNAL_ASSERT(
-        disjoint_set_shared_ptr->vector().size(),
+        !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
     auto concrete_id = computeConcreteId(first_id, IdMappingMode::PERMISSIVE);
@@ -1158,7 +1157,7 @@ void ComputeAtMap::buildConcreteIds() {
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.almostExactNodes().disjointSets()) {
     TORCH_INTERNAL_ASSERT(
-        disjoint_set_shared_ptr->vector().size(),
+        !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
     auto concrete_id = computeConcreteId(first_id, IdMappingMode::ALMOSTEXACT);
@@ -1168,7 +1167,7 @@ void ComputeAtMap::buildConcreteIds() {
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.loopNodes().disjointSets()) {
     TORCH_INTERNAL_ASSERT(
-        disjoint_set_shared_ptr->vector().size(),
+        !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
     auto concrete_id = computeConcreteId(first_id, IdMappingMode::LOOP);
@@ -1178,7 +1177,7 @@ void ComputeAtMap::buildConcreteIds() {
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.permissiveResizeNodes().disjointSets()) {
     TORCH_INTERNAL_ASSERT(
-        disjoint_set_shared_ptr->vector().size(),
+        !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
     auto concrete_id =
@@ -1335,7 +1334,7 @@ IterDomain* ComputeAtMap::getConcreteMappedID(
   auto disjoint_set_shared_ptr = disjointSetOf(id, mode);
 
   TORCH_INTERNAL_ASSERT(
-      disjoint_set_shared_ptr->vector().size() > 0,
+      !disjoint_set_shared_ptr->vector().empty(),
       "Empty disjoint set found for ",
       id->toString());
 
@@ -1531,7 +1530,7 @@ ComputeAtMap::getInputDisjointSetsOf(IterDomain* of_id, bool stop_at_rfactor) {
     }
 
     // Add producers to visit if not already there
-    for (auto producer : producers_of_currently_visiting.vector()) {
+    for (const auto& producer : producers_of_currently_visiting.vector()) {
       if (visited.find(producer) == visited.end()) {
         to_visit.push_back(producer);
       }
@@ -1579,7 +1578,7 @@ ComputeAtMap::getAllDisjointSetProducers(
     }
 
     // Add producers to visit if not already there
-    for (auto producer : producers_of_currently_visiting.vector()) {
+    for (const auto& producer : producers_of_currently_visiting.vector()) {
       if (!visited.has(producer)) {
         to_visit.push_back(producer);
       }
@@ -1627,7 +1626,7 @@ ComputeAtMap::getAllDisjointSetConsumers(
     }
 
     // Add consumers to visit if not already there
-    for (auto consumer : consumers_of_currently_visiting.vector()) {
+    for (const auto& consumer : consumers_of_currently_visiting.vector()) {
       if (!visited.has(consumer)) {
         to_visit.push_back(consumer);
       }
@@ -1649,7 +1648,7 @@ void IterDomainGraph::updateComputeWith(TensorView* compute_with_tv) {
   for (auto pos = compute_with_tv->getComputeAtPosition();
        pos < compute_with_tv->getComputeWithPosition();
        ++pos) {
-    auto id = compute_with_tv->axis(pos);
+    auto id = compute_with_tv->axis((int)pos);
 
     // Find the matching consumer ID using the permissive map
     auto it = std::find_if(
@@ -1683,7 +1682,7 @@ void ComputeAtMap::updateComputeWith(TensorView* compute_with_tv) {
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.loopNodes().disjointSets()) {
     TORCH_INTERNAL_ASSERT(
-        disjoint_set_shared_ptr->vector().size(),
+        !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
     auto concrete_id = computeConcreteId(first_id, IdMappingMode::LOOP);

--- a/csrc/contiguity.cpp
+++ b/csrc/contiguity.cpp
@@ -17,7 +17,7 @@ OrderedIdInformation::OrderedIdInformation(
     const std::vector<IterDomain*>& ids,
     const std::vector<IterDomain*>& root_domain,
     std::shared_ptr<const ConcretizedBroadcastDomains> concrete_info)
-    : active_ids_(root_domain), concrete_info_(concrete_info) {
+    : active_ids_(root_domain), concrete_info_(std::move(concrete_info)) {
   if (ids.empty() || root_domain.empty()) {
     return;
   }
@@ -451,7 +451,7 @@ ContigIDs::ContigIDs(
       ignore_indexability_(ignore_indexability),
       ignore_consistent_ordering_(ignore_consistent_ordering),
       non_divisible_id_info_(ids, root_domain_, divisible_splits_) {
-  if (ids.size() > 0) {
+  if (!ids.empty()) {
     // This constructor doesn't provide the following information so it needs to
     // be built.
     ca_map_ = std::make_shared<ComputeAtMap>(ids[0]->fusion());
@@ -483,9 +483,9 @@ ContigIDs::ContigIDs(
       final_ids_(final_ids),
       index_map_(index_map),
       divisible_splits_(divisible_splits),
-      ca_map_(ca_map),
-      halo_info_(halo_info),
-      concrete_info_(concrete_info),
+      ca_map_(std::move(ca_map)),
+      halo_info_(std::move(halo_info)),
+      concrete_info_(std::move(concrete_info)),
       p2c_id_map_(std::move(p2c_id_map)),
       ignore_indexability_(ignore_indexability),
       ignore_consistent_ordering_(ignore_consistent_ordering),

--- a/csrc/contiguity.h
+++ b/csrc/contiguity.h
@@ -281,7 +281,7 @@ class ContigIDs : public OptInDispatch {
   const std::unordered_set<IterDomain*>& final_ids_;
   //! Mapping of concrete domains to indices. Just used to check if
   //! there's an index for an IterDomain.
-  const std::unordered_map<IterDomain*, Val*> index_map_;
+  const std::unordered_map<IterDomain*, Val*>& index_map_;
   // Divisible split information as we can still consider iter domains
   // contiguous through divisible splits.
   const std::unordered_set<Split*>& divisible_splits_;


### PR DESCRIPTION
Minor Errors:

1.  Error (CLANGTIDY) [performance-for-range-copy,-warnings-as-errors] loop variable is copied but only used as const reference; consider making it a const reference
2.  Error (CLANGTIDY) [modernize-use-emplace,-warnings-as-errors] unnecessary temporary object created while calling emplace
3. Error (CLANGTIDY) [readability-container-size-empty,-warnings-as-errors] the 'empty' method should be used to check for emptiness instead of 'size'
4. Error (CLANGTIDY) [bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions,-warnings-as-errors] narrowing conversion from 'unsigned int' to signed type 'int' is implementation-defined