### PR TITLE
fix text MultiClusterFusion

### DIFF
--- a/test/test_multicluster_fusion.cpp
+++ b/test/test_multicluster_fusion.cpp
@@ -106,6 +106,9 @@ TEST_F(NVFuserTest, MultiClusterFusion_CUDA) {
       "  }\n"
       "} //MultiClusterFusion"};
 
+  std::sort(obtained_string_MCF.begin(), obtained_string_MCF.end());
+  std::sort(ref_string_MCF.begin(), ref_string_MCF.end());
+
   TORCH_INTERNAL_ASSERT(
       obtained_string_MCF == ref_string_MCF,
       "the obtained MultiClusterFusion is not the one expected");
@@ -135,6 +138,10 @@ TEST_F(NVFuserTest, MultiClusterFusion_CUDA) {
       "AggregateDag's outputs:{\n"
       " AggregateVal representing Val T6_g[ iS14{i3} ] on cluster 3\n"
       "}"};
+
+  std::sort(obtained_string_aDag.begin(), obtained_string_aDag.end());
+  std::sort(ref_string_aDag.begin(), ref_string_aDag.end());
+
   TORCH_INTERNAL_ASSERT(
       obtained_string_aDag == ref_string_aDag,
       "the obtained AggregateDag is not the one expected");


### PR DESCRIPTION
### Why ?
The test MultiClusterFusion gives non-deterministic results.

### What ?
In this test, we check that the MultiClusterFusion gives the expected results when running on a single process, even though this object is intended for distributed settings.
To do so, we compare the strings printed from the MultiClusterFusion, but in this string the lines can be reordered (maybe because exprs and vals are stored in unordered sets, but tbh I am not sure about the cause) which does not harm anything but makes the test fail.

### How ? 
This PR implements a cheap and easy fix that consists in reordering the compared strings alphabetically