### PR TITLE
fix(docs): fix typo spelling grammar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ endif()
 # as the latter is not respected by nvcc
 target_compile_definitions(${NVFUSER_CODEGEN} PRIVATE "-DTORCH_CUDA_BUILD_MAIN_LIB")
 
-# For kernel_db, linking STL Filesystem Library for backward compatability with C++14
+# For kernel_db, linking STL Filesystem Library for backward compatibility with C++14
 target_link_libraries(${NVFUSER_CODEGEN} PRIVATE stdc++fs)
 target_link_libraries(${NVFUSER_CODEGEN} PRIVATE ${CUDA_NVRTC_LIB} ${LIBNVTOOLSEXT})
 target_include_directories(${NVFUSER_CODEGEN} PRIVATE ${CUDA_INCLUDE_DIRS})

--- a/benchmark/gelu_backward_reduction.cpp
+++ b/benchmark/gelu_backward_reduction.cpp
@@ -32,7 +32,7 @@ static void setupGeluBackwardReduction(
   constexpr float k_004 = 0.044715;
   constexpr float k_010 = 0.1070322243;
 
-  // input fp16 is converted to fp32 before caluclation and converted back to
+  // input fp16 is converted to fp32 before calculation and converted back to
   // fp16 after calculation
   bool is_fp16 = dtype == DataType::Half;
 

--- a/csrc/compute_at_map.h
+++ b/csrc/compute_at_map.h
@@ -201,8 +201,8 @@ class TORCH_CUDA_CU_API ComputeAtMap {
 
   //! Returns an iter domain that is the maximum expanded size of all iter
   //! domains the one provided maps to. Useful for opening loops to the correct
-  //! iteration size. Not guarenteed to return the same ID every call, but is
-  //! guarenteed to return iter domains in the same disjoint set.
+  //! iteration size. Not guaranteed to return the same ID every call, but is
+  //! guaranteed to return iter domains in the same disjoint set.
   IterDomain* getConcreteMappedID(IterDomain* id, IdMappingMode mode) const;
 
   //! Returns a list of expressions that produce the iter domains of all exact

--- a/csrc/contiguity.cpp
+++ b/csrc/contiguity.cpp
@@ -375,7 +375,7 @@ void OrderedIdInformation::handle(Resize* resize) {
 
 NonDivisibleSplitDependencies::NonDivisibleSplitDependencies(
     // TODO: Revisit reduction rfactor axes and propagation. Should probably use
-    // ca_map to propogate non divisibility dependencies across exact map. Still
+    // ca_map to propagate non divisibility dependencies across exact map. Still
     // need to think through divisible split and non divisible dependencies to
     // see if there's conflicts where a split might look non divisible but
     // actually is divisible and one's overruling the other.

--- a/csrc/disjoint_set.h
+++ b/csrc/disjoint_set.h
@@ -35,7 +35,7 @@ std::string abstractToString(T ref) {
 } // namespace
 
 // Vector like class that will prevent adding duplicate entries by also
-// maintaing a set
+// maintaining a set
 template <typename T, typename Hash = std::hash<T>>
 class VectorOfUniqueEntries {
  public:

--- a/csrc/dispatch.cpp
+++ b/csrc/dispatch.cpp
@@ -778,12 +778,12 @@ void OptInConstDispatch::unhandled(const Statement* stmt) {
   if (stmt->isExpr()) {
     TORCH_INTERNAL_ASSERT(
         false,
-        "Handle not overriden for ",
+        "Handle not overridden for ",
         stmt->as<Expr>()->getOpString(),
         ".");
   } else if (stmt->isVal()) {
     TORCH_INTERNAL_ASSERT(
-        false, "Handle not overriden for ", stmt->getValType().value(), ".");
+        false, "Handle not overridden for ", stmt->getValType().value(), ".");
   } else {
     TORCH_INTERNAL_ASSERT(false, "Unrecognized statement type.");
   }
@@ -793,12 +793,12 @@ void OptInDispatch::unhandled(Statement* stmt) {
   if (stmt->isExpr()) {
     TORCH_INTERNAL_ASSERT(
         false,
-        "Handle not overriden for ",
+        "Handle not overridden for ",
         stmt->as<Expr>()->getOpString(),
         ".");
   } else if (stmt->isVal()) {
     TORCH_INTERNAL_ASSERT(
-        false, "Handle not overriden for ", stmt->getValType().value(), ".");
+        false, "Handle not overridden for ", stmt->getValType().value(), ".");
   } else {
     TORCH_INTERNAL_ASSERT(false, "Unrecognized statement type.");
   }

--- a/csrc/graph_fuser.cpp
+++ b/csrc/graph_fuser.cpp
@@ -347,7 +347,7 @@ struct CudaGraphFuser {
   // to prepare for fusion and replace uses of n with the new group
   torch::jit::Node* createSingletonFusionGroup(torch::jit::Node* n) {
     auto group = block_->owningGraph()->createWithSubgraph(kind_);
-    // propogate position information for the new node so we can always
+    // propagate position information for the new node so we can always
     // have a valid mapping
     group->insertBefore(n);
     torch::jit::Node* mergedNode = mergeNodeIntoGroup(group, n);

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -79,8 +79,8 @@ Val* getProducerIndexWithHalo(
     size_t producer_axis,
     Val* producer_index,
     const TensorView* consumer_tv,
-    bool is_overriden_index) {
-  const auto offset = is_overriden_index
+    bool is_overridden_index) {
+  const auto offset = is_overridden_index
       ? 0
       : getProducerHaloOffset(producer_tv, producer_axis, consumer_tv);
 
@@ -1672,12 +1672,12 @@ std::vector<Val*> Index::getNonGlobalProducerStridedIndices(
         root_dom[i]->toString());
 
     auto override_it = override_index.find(root_dom[i]);
-    const bool is_overriden = override_it != override_index.end();
+    const bool is_overridden = override_it != override_index.end();
     auto root_ind_i =
-        is_overriden ? override_it->second : index_map.at(root_dom[i]);
+        is_overridden ? override_it->second : index_map.at(root_dom[i]);
 
     root_ind_i = getProducerIndexWithHalo(
-        producer_tv, i, root_ind_i, consumer_tv, is_overriden);
+        producer_tv, i, root_ind_i, consumer_tv, is_overridden);
 
     root_ind_i = getProducerIndexWithGather(
         root_ind_i,
@@ -1980,8 +1980,8 @@ std::vector<Val*> Index::getProducerRootIndices(
 
     Val* root_ind = nullptr;
     auto override_it = override_index.find(root_dom[i]);
-    const bool is_overriden = override_it != override_index.end();
-    if (is_overriden) {
+    const bool is_overridden = override_it != override_index.end();
+    if (is_overridden) {
       root_ind = override_it->second;
     } else if (
         producer_indexing.indexMap().find(root_dom[i]) !=
@@ -1999,7 +1999,7 @@ std::vector<Val*> Index::getProducerRootIndices(
         root_dom[i]->toString());
 
     root_ind = getProducerIndexWithHalo(
-        producer_tv, i, root_ind, consumer_tv, is_overriden);
+        producer_tv, i, root_ind, consumer_tv, is_overridden);
 
     root_ind = getProducerIndexWithGather(
         root_ind,

--- a/csrc/ir_interface_nodes.h
+++ b/csrc/ir_interface_nodes.h
@@ -174,7 +174,7 @@ class TVDomainGuard;
 
 //! TensorView is our primitive Tensor Type used in code generation. It can be
 //! thought of as representing physical memory, however, its dimensionality is
-//! modifed as split/merge/computeAt functions are called. The history of
+//! modified as split/merge/computeAt functions are called. The history of
 //! these transformations are kept and used for generating actual code
 //! referncing physical memory. Generally when users are thinking of code
 //! generation in reference to a Tensor, this is the class they should be

--- a/csrc/ir_utils.h
+++ b/csrc/ir_utils.h
@@ -366,13 +366,13 @@ TORCH_CUDA_CU_API std::vector<IterDomain*> allIDsOf(const TensorView* tv);
 // Check if the given tv is an input of SelectOp
 TORCH_CUDA_CU_API bool isSelectInput(TensorView* tv);
 
-// Check if the given tv is first argment of index_select(lookup, dim, indices)
+// Check if the given tv is first argument of index_select(lookup, dim, indices)
 TORCH_CUDA_CU_API bool isIndexSelectLookupTv(const TensorView* tv);
 
-// Check if the given tv is third argment of index_select(lookup, dim, indices)
+// Check if the given tv is third argument of index_select(lookup, dim, indices)
 TORCH_CUDA_CU_API bool isIndexSelectIndicesTv(const TensorView* tv);
 
-// Check if the given tv is first/third argment of torch_gather(lookup, dim,
+// Check if the given tv is first/third argument of torch_gather(lookup, dim,
 // indices)
 TORCH_CUDA_CU_API bool isTorchGatherIndicesTv(const Val* tv);
 TORCH_CUDA_CU_API bool isTorchGatherLookupTv(const Val* tv);

--- a/csrc/iter_visitor.h
+++ b/csrc/iter_visitor.h
@@ -75,8 +75,8 @@ class TORCH_CUDA_CU_API IterVisitor : public OptOutDispatch {
 
   // The entire stack during traversal. stmt_stack.back().back() is the node
   // that is being called in handle(). stmt_stack.back() contains siblings (not
-  // guarenteed to be all siblings throughout traversal). stmt_stack.front()
-  // contains the outputs we started with (not guarenteed to be all outputs
+  // guaranteed to be all siblings throughout traversal). stmt_stack.front()
+  // contains the outputs we started with (not guaranteed to be all outputs
   // throughout traversal).
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::vector<std::vector<Statement*>> stmt_stack;
@@ -220,8 +220,8 @@ class TORCH_CUDA_CU_API BackwardVisitor : public OptOutDispatch {
 
   // The entire stack during traversal. stmt_stack.back().back() is the node
   // that is being called in handle(). stmt_stack.back() contains siblings (not
-  // guarenteed to be all siblings throughout traversal). stmt_stack.front()
-  // contains the inputs we started with (not guarenteed to be all outputs
+  // guaranteed to be all siblings throughout traversal). stmt_stack.front()
+  // contains the inputs we started with (not guaranteed to be all outputs
   // throughout traversal).
   std::deque<std::deque<Statement*>> stmt_stack_;
 

--- a/csrc/lower_expr_sort.cpp
+++ b/csrc/lower_expr_sort.cpp
@@ -775,7 +775,7 @@ std::unordered_set<ExprGroupConnections*> ExprSegmentationSorter::
   return removed_edges;
 }
 
-// TODO: This function may be sub optimial. If we find that an iteration domain
+// TODO: This function may be sub optimal. If we find that an iteration domain
 // matches later in the other domain, we will hold all other iteration domains
 // until that one matches. There may be cases where duplicating that iteration
 // domain, and moving on could be more efficient.

--- a/csrc/ops/alias.h
+++ b/csrc/ops/alias.h
@@ -76,7 +76,7 @@ TORCH_CUDA_CU_API TensorView* transpose(TensorView* x);
 //! Pad a tensor by given widths by specified value. Similar to torch.pad, the
 //! pad_widths vector specifies the padding widths of the innermost N
 //! dimensions, where N is half the size of the width vector. If value is
-//! omitted, a default value of zero is assumed. The provied value will be cast
+//! omitted, a default value of zero is assumed. The provided value will be cast
 //! to the dtype of the argument x.
 //! TODO: Support other padding types
 TORCH_CUDA_CU_API TensorView* pad(

--- a/csrc/parallel_type_bitmap.h
+++ b/csrc/parallel_type_bitmap.h
@@ -128,17 +128,17 @@ class ParallelTypeBitmap {
     return ParallelTypeBitmap(~bitset_);
   }
 
-  //! Return true if none of the mapppings is true
+  //! Return true if none of the mappings is true
   bool none() const {
     return bitset_.none();
   }
 
-  //! Return true if any of the mapppings is true
+  //! Return true if any of the mappings is true
   bool any() const {
     return bitset_.any();
   }
 
-  //! Return true if all of the mapppings is true
+  //! Return true if all of the mappings is true
   bool all() const {
     return bitset_.all();
   }

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -42,7 +42,7 @@ struct TORCH_CUDA_CU_API State {
   bool operator==(const State& other) const;
   bool operator!=(const State& other) const;
 
-  //! A unique index to identifiy each recorded state item.
+  //! A unique index to identify each recorded state item.
   size_t index;
   //! StateType is either: Tensor or Scalar
   StateType stype;
@@ -68,7 +68,7 @@ struct TORCH_CUDA_CU_API Tensor {
     return index;
   }
 
-  //! A unique index to identifiy each recorded state item.
+  //! A unique index to identify each recorded state item.
   size_t index;
   size_t dims;
 
@@ -84,7 +84,7 @@ struct TORCH_CUDA_CU_API Scalar {
     return index;
   }
 
-  //! A unique index to identifiy each recorded state item.
+  //! A unique index to identify each recorded state item.
   size_t index;
 
   //! Pointer to the FusionDefinition used to create this scalar

--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -170,7 +170,7 @@ std::shared_ptr<ReductionParams> innerPersistentHeuristic(
           ceilDiv(n_elems, target_blocks * target_unroll),
           (int64_t)dev_prop->maxThreadsPerBlock);
     } else {
-      // targetting 4 waves, so try to use a quarter of available threads
+      // targeting 4 waves, so try to use a quarter of available threads
       max_threads_in_block = std::min(
           ceilDiv(n_elems, target_blocks * target_unroll),
           ceilDiv(device_max_threads_per_multiprocessor, (int64_t)4));
@@ -720,7 +720,7 @@ std::shared_ptr<ReductionParams> outerPersistentHeuristic(
   target_blocks = std::min(target_blocks, device_multiprocessor_count * 4);
 
   if (target_blocks * target_unroll * max_threads_in_block < n_elems) {
-    // targetting 4 waves, so try to use a quarter of available threads
+    // targeting 4 waves, so try to use a quarter of available threads
     max_threads_in_block = std::min(
         ceilDiv(n_elems, target_blocks * target_unroll),
         ceilDiv(device_max_threads_per_multiprocessor, (int64_t)4));
@@ -1037,7 +1037,7 @@ std::shared_ptr<ReductionParams> getPersistentHeuristics(
             persistent_buffer_size_info.persistent_buffer_size,
             persistent_buffer_size_info.projected_persistent_buffer_size);
 
-  // Figure out if we want to projet persistent buffers to the inputs for
+  // Figure out if we want to project persistent buffers to the inputs for
   // exmaple if we have an input tensor t0 that's fp16:
   //
   // t0 = makeSymbolicTensor(2, DataType::Half)

--- a/csrc/scheduler/normalization.h
+++ b/csrc/scheduler/normalization.h
@@ -13,7 +13,7 @@
 #include <scheduler/reduction_heuristic.h>
 
 // TODO: If caching inputs would require persistence we are sending it to the
-// persistent kerenl scheduler. This isn't necessary if the only persistent
+// persistent kernel scheduler. This isn't necessary if the only persistent
 // buffers are inputs as we could re-read them from global memory. Need to
 // consider if this is worth implementing.
 

--- a/csrc/scheduler/pointwise_heuristic.h
+++ b/csrc/scheduler/pointwise_heuristic.h
@@ -13,10 +13,10 @@
 
 namespace nvfuser {
 
-// Parameters of the pointwise heuristic to describe the optimial schedule.
+// Parameters of the pointwise heuristic to describe the optimal schedule.
 // Warning: equal operator is intended for use in caching the kernel associated
 // with these pointwise parameters. It does not check if the launch parameters
-// are equivelent!
+// are equivalent!
 class PointwiseParams : public HeuristicParams {
  public:
   // vectorize if true, otherwise unroll

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -188,7 +188,7 @@ std::shared_ptr<ReductionParams> innerReductionHeuristic(
   target_blocks = std::min(target_blocks, device_multiprocessor_count * 4);
 
   if (target_blocks * target_unroll * target_iterations < n_elems) {
-    // targetting 4 waves, so try to use a quarter of available threads
+    // targeting 4 waves, so try to use a quarter of available threads
     target_threads_in_block = std::min(
         ceilDiv(n_elems, target_blocks * target_unroll),
         ceilDiv(device_max_threads_per_multiprocessor, (int64_t)4));

--- a/csrc/scheduler/reduction_heuristic.h
+++ b/csrc/scheduler/reduction_heuristic.h
@@ -13,10 +13,10 @@
 
 namespace nvfuser {
 
-// Parameters of the reduction heuristic to describe the optimial schedule.
+// Parameters of the reduction heuristic to describe the optimal schedule.
 // Warning: equal operator is intended for use in caching the kernel associated
 // with these reduction parameters. It does not check if the launch parameters
-// are equivelent!
+// are equivalent!
 class ReductionParams : public HeuristicParams {
  public:
   // Reducing inner most dimension?

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -692,7 +692,7 @@ std::vector<TensorView*> projectPersistentBuffers(Fusion* fusion) {
 
     // Go through the resolution points one by one. Resolution points are points
     // in which the reduction branch meets the residual branch. These are points
-    // where the persitent buffer may no longer be needed (one point could be
+    // where the persisten buffer may no longer be needed (one point could be
     // after another, and the buffer would be needed until the last resolution
     // points)
     for (auto resolution_point : resolution_points) {

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -484,7 +484,7 @@ bool isConnectedFusionGraph(Fusion* fusion) {
 }
 
 // Returns if a fusion cannot transformed into a consistent format since we
-// can't transform forward through view operations, for exmaple:
+// can't transform forward through view operations, for example:
 //
 // tv0[I0, I1, I2]
 // tv1[I0*I1, I2] = view(tv0)

--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -130,7 +130,7 @@ class DomainMap : public pointwise_utils::DomainMap {
   // The returned groups are sorted in descending size. If the sizes of two
   // group are equal, then we sort them by their members in the following order:
   //   output[0], output[1], ..., input[0], input[1], ...
-  // That is, {ouput[0], output[2]} will be in front of {ouput[1], output[3]}
+  // That is, {output[0], output[2]} will be in front of {output[1], output[3]}
   // The order here must be deterministic, because in transpose heuristics, we
   // have `vectorize_factor1` and `vectorize_factor2` and we need to be sure
   // that `1` and `2` are assigned to the same group across runs.

--- a/csrc/scheduler/transpose_heuristic.h
+++ b/csrc/scheduler/transpose_heuristic.h
@@ -15,10 +15,10 @@
 
 namespace nvfuser {
 
-// Parameters of the transpose heuristic to describe the optimial schedule.
+// Parameters of the transpose heuristic to describe the optimal schedule.
 // Warning: equal operator is intended for use in caching the kernel associated
 // with these reduction parameters. It does not check if the launch parameters
-// are equivelent!
+// are equivalent!
 class TransposeParams : public HeuristicParams {
  public:
   static constexpr size_t getMaxThreadsPerBlock() {

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -666,7 +666,7 @@ getScopePersistenceFactors(
     // to actually generate the kernel before we know if it would fit
     // persistently in registers. In practice, though, this should not happen
     // as inlining loop structures where the persistent buffer is used should
-    // prevent muiltiple persistent buffers from being merged togther if not
+    // prevent multiple persistent buffers from being merged together if not
     // necessary.
     auto resolution_points =
         persistent_buffer_resolution_points[persistent_buffer_i];
@@ -1725,7 +1725,7 @@ void makeTile(TensorView* tv, std::vector<int> tile_sizes) {
 
   // Split the inner dimensions:
   for (auto idx : c10::irange(tile_dimension_size)) {
-    // Using negative indexing to accomodate potential batching
+    // Using negative indexing to accommodate potential batching
     //  dimensions on the further left. Eg.:
     //  0, 1, 2   ->         -3,-2,-1
     // [M, N, K]  -> [B0, B1, M, N, K]
@@ -1862,7 +1862,7 @@ void orderTiledConcreteIdAsRoot(TensorView* tv) {
 
   // Calculate the ordering:
 
-  // pointer to the current target postion after
+  // pointer to the current target position after
   //  repordering
   int current_pos = leftmost_pos;
   std::unordered_map<int, int> reorder_map_old_to_new;

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -388,7 +388,7 @@ TORCH_CUDA_CU_API void scheduleWarpTileWithNoReduction(
     TensorView* tv,
     MatMulTileOptions tile);
 
-//! Lower level primitive spliting inner iterdomains into tiles:
+//! Lower level primitive splitting inner iterdomains into tiles:
 //! Eg.
 //!  A[B,I0,I1,I2] -> makeTile({1,2,3})
 //! Gives A[B, I0o, I1o, I2o, I0i(1), I1i(2), I2i(3)]

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -1074,8 +1074,8 @@ std::vector<std::pair<ProjectedExtent&, IterDomain*>> getContigVectorSizesOf(
   std::vector<std::pair<ProjectedExtent&, IterDomain*>> vectorizable_dim_sizes;
 
   // Order is important, need to make sure dimensions match up correctly with
-  // what was propogated through the mapper. The mapper's dimensions is
-  // propogated in the order of the reference, if that order doesn't match the
+  // what was propagated through the mapper. The mapper's dimensions is
+  // propagated in the order of the reference, if that order doesn't match the
   // tensor we're mapping too then a transpose interfered with expanded the
   // vectorize dimension.
   size_t projected_dims_i = projected_dims.size();

--- a/csrc/scheduler/vectorize_helper.h
+++ b/csrc/scheduler/vectorize_helper.h
@@ -326,7 +326,7 @@ class TORCH_CUDA_CU_API ProjectedExtent {
 // Reference: T5[i0, i1, i2]
 // If we want to base the vectorization size on the reference being contiguous
 // in a 1D scheduler, we'd start the proces on the reference with {i0, i1,
-// i2}. When we propogate to the input what we would still like is: {i0, i1,
+// i2}. When we propagate to the input what we would still like is: {i0, i1,
 // i2} to signify to us that the root domains in the input that map to the
 // reference are not contiguous. So when we think of vector word, if we want
 // the input to be included in the vectorized dimensions, we can only check
@@ -335,7 +335,7 @@ class TORCH_CUDA_CU_API ProjectedExtent {
 // Another example:
 // Input:[i1, i0, i2]
 // Refrence [i0, i1, i2]
-// Similarly as above when we propogate from the reference to the Input we'd
+// Similarly as above when we propagate from the reference to the Input we'd
 // like {i0, i1, i2}, which is the order of the reference, not the input. This
 // is because we can compare that with the input domains to understand it's
 // not ordered consistently, so once again we can only take into consideration
@@ -567,7 +567,7 @@ class TORCH_CUDA_CU_API ContiguousInnerDimensionsMapper
   std::shared_ptr<const ComputeAtMap> ca_map_;
   std::unordered_set<Split*> divisible_splits_;
 
-  // Mapped root dimensions for each TensorView as we propogate. These
+  // Mapped root dimensions for each TensorView as we propagate. These
   // mappings are in the order of the reference.
 
   std::unordered_map<

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -1882,7 +1882,7 @@ class TestNvFuserFrontend(TestCase):
             T1 = fd.ops.slice(T0, start_indices=[2, 2], end_indices=[4, 4])
             fd.add_output(T1)
 
-        # TODO: Currently, this check fails to produce a zero-element tensor whne the tensor
+        # TODO: Currently, this check fails to produce a zero-element tensor when the tensor
         # is smaller than the index range of the slize.  Therefore, it is disabled.
         # Issue: https://github.com/NVIDIA/Fuser/issues/52
         def legal(fd: FusionDefinition, acts) -> None:

--- a/python_tests/test_torchscript.py
+++ b/python_tests/test_torchscript.py
@@ -4413,7 +4413,7 @@ class TestCudaFuser(JitTestCase):
         complete_views = set(tuple_original_view)
 
         to_visit = []
-        # empty new view, curent originaal view, start pos=0, move count = 0, last_move
+        # empty new view, current originaal view, start pos=0, move count = 0, last_move
         to_visit.append(([], original_view, 0, [], Moves.Keep))
 
         # depth-first search of view shapes, starting from the original view
@@ -6207,7 +6207,7 @@ class TestCudaFuser(JitTestCase):
         t_jit = torch.jit.script(t)
         self._run_helper(t_jit, t, x, check_stride=True)
 
-        # Note that curently TS embeds constant tensor in the graph
+        # Note that currently TS embeds constant tensor in the graph
         # this triggers memory leak check in CI
         torch.jit._state._python_cu.drop_all_functions()
 

--- a/runtime/block_reduction.cu
+++ b/runtime/block_reduction.cu
@@ -16,7 +16,7 @@
 //    (output[output_index], inputs[input_index],
 //      [] __device__ (T& a, const T b) { a += b; });
 //
-// Note: We agressively template functions taking dim3 in the functions below
+// Note: We aggressively template functions taking dim3 in the functions below
 //       because ROCM uses different types for the various dim3 and maps them
 //       directly to intrinsics, but they're dim3 when used after modification.
 //

--- a/runtime/block_welford_outer.cu
+++ b/runtime/block_welford_outer.cu
@@ -53,7 +53,7 @@ namespace impl {
 // long as the above assumptions hold.
 //
 // Note: Having an output reference parameter resulted in using more
-// registers than just returing the output. Results would vary
+// registers than just returning the output. Results would vary
 // depending on compiler versions, but it seems safer to return outputs
 // as a new value.
 template <int NumVals, typename DataType, int BDIMX, int BDIMY>

--- a/runtime/fused_reduction.cu
+++ b/runtime/fused_reduction.cu
@@ -586,7 +586,7 @@ class ParallelReduce {
 
   // This is highly specific to the outer-reduction pattern. All the
   // assumptions should be asserted with static_assert at the begging of
-  // the fuction.
+  // the function.
   template <int NumVals, typename DataType, int BDIMX, int BDIMY>
   __device__ __inline__ void welfordGroupOuter(
       DataType out_avg[NumVals],

--- a/runtime/grid_sync.cu
+++ b/runtime/grid_sync.cu
@@ -39,7 +39,7 @@ __device__ void sync(
   if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
     // Get increment value, only want a single block to have the large
     // increment, doesn't really matter which one, the goal is to flip/flop the
-    // first bit of a uint64_t value, since our semaphores are actualy int64_t
+    // first bit of a uint64_t value, since our semaphores are actually int64_t
     // we will just reinterpret_cast it to act as a uint64_t
     uint64_t semaphore_increment = 1;
 

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -2211,7 +2211,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer2_CUDA) {
   // consumer.
   tv1->computeAt(computeAtTarget, 1);
 
-  // All tensors should have the same dimenionality as the target
+  // All tensors should have the same dimensionality as the target
   for (Val* val : fusion.vals()) {
     if (val->isFusionInput() ||
         val->getValType().value() != ValType::TensorView) {
@@ -2297,7 +2297,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer3_CUDA) {
 
   tv1->computeAt(computeAtTarget, 1);
 
-  // All tensors should have the same dimenionality as the target
+  // All tensors should have the same dimensionality as the target
   for (auto tv : ir_utils::filterByType<TensorView>(fusion.vals())) {
     if (tv->isFusionInput()) {
       continue;

--- a/test/test_gpu_indexing.cpp
+++ b/test/test_gpu_indexing.cpp
@@ -667,7 +667,7 @@ TEST_F(NVFuserTest, FusionIndexing14_CUDA) {
       &fusion, cg_outputs, aten_inputs, aten_outputs, __LINE__, __FILE__);
 }
 
-// This excercises indexing with broadcast root axes. Non-broadcast
+// This exercises indexing with broadcast root axes. Non-broadcast
 // axes need to be preferred when propagating index exprs to root
 // axes. See, e.g., Index::getConsumerIndex_impl.
 TEST_F(NVFuserTest, FusionIndexing15_CUDA) {

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -325,7 +325,7 @@ TEST_F(NVFuserTest, FusionVectorizeBackwardMapper1_CUDA) {
   }
 
   {
-    // Inner mapping partial propogates
+    // Inner mapping partial propagates
     auto mapper = vectorize_helper::ContiguousInnerDimensionsMapper::map(
         tv1, {tv1->axis(1)});
 
@@ -716,7 +716,7 @@ TEST_F(NVFuserTest, FusionVectorizeForwardMapper1_CUDA) {
   }
 
   {
-    // Inner mapping partial propogates
+    // Inner mapping partial propagates
     auto mapper = vectorize_helper::ContiguousInnerDimensionsMapper::map(
         tv0, {tv0->axis(1)});
 
@@ -1091,9 +1091,9 @@ TEST_F(NVFuserTest, FusionVectorizeMapperAdvanced_CUDA) {
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
 
-  // For broadcast we can't back propogate mapped axes to the left of bcast
+  // For broadcast we can't back propagate mapped axes to the left of bcast
   // axis.
-  // For reduction we can't forward propogate mapped axes to the left of the
+  // For reduction we can't forward propagate mapped axes to the left of the
   // reduce axis.
 
   auto tv0 = makeContigConcreteTensor({3, 4 * 6});

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -1816,7 +1816,7 @@ TEST_F(NVFuserTest, FusionSliceForNanoGPT2_CUDA) {
       TORCH_CHECK(
           expr->isA<UnaryOp>() &&
               expr->as<UnaryOp>()->getUnaryOpType() == UnaryOpType::Set,
-          "Unexpected defintion of slice output tensor: ",
+          "Unexpected definition of slice output tensor: ",
           out_tv->toString(),
           ", ",
           expr->toString());


### PR DESCRIPTION
fix typo spelling grammar with following guidelines from [merriam-webster dictionary](https://www.merriam-webster.com/)