### PR TITLE
Remove z-shape block swizzle

### DIFF
--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -181,7 +181,7 @@ void scheduleMatmul(
   // [... M,N,K]
   scheduler_utils::matmul_utils::makeTile(cc, gemm_tile.cta_tile.toVector());
 
-  // Applies swizzle factor on C
+  // Swizzle block tiles:
   if (params.grid_swizzle_factor != 1) {
     int factor = std::max(1, params.grid_swizzle_factor); // must be >=1
     if (params.rasterization_order ==
@@ -251,9 +251,6 @@ void scheduleMatmul(
   //   and needs more configurability.
   // ------------------------------------------------------------------
   // CTA tile:
-
-  // Swizzle block tiles:
-  c->swizzle(Swizzle2DType::ZShape, 0, 1, SwizzleMode::Loop);
 
   a->computeAt(c, 2);
   b->computeAt(c, 2);


### PR DESCRIPTION
z-shape swizzle was not used in tracking-matmul, and now we have a better swizzle implemented in https://github.com/NVIDIA/Fuser/pull/90