### PR TITLE
Prove `i1 * i2 >= i1` if `i2 >= 1 && i1 >= 0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ nvfuser/lib
 *~
 .~lock.*
 .vscode
+
+# debuggin temporaries
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,5 @@ nvfuser/lib
 .~lock.*
 .vscode
 
-# debuggin temporaries
+# debugging temporaries
 *.log

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -956,20 +956,23 @@ std::pair<Val*, std::list<Val*>> getConstAndSymbolicFactors(Val* x) {
   return {IrBuilder::newConstant(const_factor, const_dtype), symbolic_factors};
 }
 
+inline Val* maybeFlattenedOpOf(BinaryOpType bop, std::vector<Val*> inputs) {
+  if (inputs.size() == 1) {
+    return inputs.at(0);
+  }
+  auto result = IrBuilder::newScalar(inferDtypes(inputs));
+  IrBuilder::create<FOp>(bop, result, std::move(inputs));
+  return result;
+}
+
 Val* productOfFactors(Val* const_factor, std::vector<Val*> symbolic_factors) {
   if (*const_factor->getInt() != 1) {
     symbolic_factors.emplace_back(const_factor);
   }
-  if (symbolic_factors.size() == 1) {
-    return symbolic_factors.at(0);
-  }
   if (symbolic_factors.empty()) {
     return IrBuilder::newConstant(1, *const_factor->getDataType());
   }
-  auto output = IrBuilder::newScalar(inferDtypes(symbolic_factors));
-  IrBuilder::create<FOp>(
-      BinaryOpType::Mul, output, std::move(symbolic_factors));
-  return output;
+  return maybeFlattenedOpOf(BinaryOpType::Mul, std::move(symbolic_factors));
 }
 
 } // namespace
@@ -1127,6 +1130,7 @@ Val* factorizeFlattenedAdd(Val* x) {
   }
   // divide by common factors
   std::vector<Val*> quotient_inputs;
+  quotient_inputs.reserve(factorized_inputs.size());
   for (auto inp : factorized_inputs) {
     auto quotient = divideFactorized(inp, gcd);
     TORCH_INTERNAL_ASSERT(quotient != nullptr);
@@ -1258,6 +1262,16 @@ bool isNonNegativeHelper(Val* value, const Context& context) {
           isNonNegative(bop->rhs(), context);
     }
   }
+  for (const auto& [a, b] : context.getKnownLessThan()) {
+    if (a->isZero() && b->sameAs(value)) {
+      return true;
+    }
+  }
+  for (const auto& [a, b] : context.getKnownLessEqual()) {
+    if (a->isZero() && b->sameAs(value)) {
+      return true;
+    }
+  }
   return false;
 }
 
@@ -1280,6 +1294,11 @@ bool isPositiveHelper(Val* value, const Context& context) {
           return false;
         }
       }
+      return true;
+    }
+  }
+  for (const auto& [a, b] : context.getKnownLessThan()) {
+    if (a->isZero() && b->sameAs(value)) {
       return true;
     }
   }
@@ -1382,6 +1401,60 @@ bool lessEqual(Val* x, Val* y, const Context& context) {
     // x <= b & b <= y  -->  x <= y
     if (a->sameAs(x) && lessEqual(b, y, context)) {
       return true;
+    }
+  }
+  // if i is an integer, i > 0, then i >= 1
+  if (x->isOneInt() && y->isIntegralScalar()) {
+    if (isPositiveHelper(y, context)) {
+      return true;
+    }
+  }
+  // if a >= 0, b >= 1, then a <= a * b
+  if (auto fop = toFlattenedMul(y->definition())) {
+    std::vector<Val*> remaining_inputs;
+    remaining_inputs.reserve(fop->inputs().size());
+    bool found = false;
+    for (auto inp : fop->inputs()) {
+      if (!found && x->sameAs(inp)) {
+        found = true;
+        continue;
+      }
+      remaining_inputs.emplace_back(inp);
+    }
+    if (found) {
+      auto zero = IrBuilder::newConstant(0, *x->getDataType());
+      if (lessEqual(zero, x, context)) {
+        auto remaining =
+            maybeFlattenedOpOf(BinaryOpType::Mul, std::move(remaining_inputs));
+        auto one = IrBuilder::newConstant(1, *remaining->getDataType());
+        if (lessEqual(one, remaining, context)) {
+          return true;
+        }
+      }
+    }
+  }
+  // if a <= 0, b >= 1, then a * b <= a
+  if (auto fop = toFlattenedMul(x->definition())) {
+    std::vector<Val*> remaining_inputs;
+    remaining_inputs.reserve(fop->inputs().size());
+    bool found = false;
+    for (auto inp : fop->inputs()) {
+      if (!found && y->sameAs(inp)) {
+        found = true;
+        continue;
+      }
+      remaining_inputs.emplace_back(inp);
+    }
+    if (found) {
+      auto zero = IrBuilder::newConstant(0, *y->getDataType());
+      if (lessEqual(y, zero, context)) {
+        auto remaining =
+            maybeFlattenedOpOf(BinaryOpType::Mul, std::move(remaining_inputs));
+        auto one = IrBuilder::newConstant(1, *remaining->getDataType());
+        if (lessEqual(one, remaining, context)) {
+          return true;
+        }
+      }
     }
   }
   return false;
@@ -1514,12 +1587,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
         if (const_term != nullptr) {
           new_inputs.emplace_back(const_term);
         }
-        if (new_inputs.size() == 1) {
-          return new_inputs.at(0);
-        }
-        auto output = IrBuilder::newScalar(inferDtypes(new_inputs));
-        IrBuilder::create<FOp>(op, output, std::move(new_inputs));
-        return output;
+        return maybeFlattenedOpOf(op, std::move(new_inputs));
       }
     }
     { // b && b -> b, b || b -> b, max(i, i) -> i, min(i, i) -> i
@@ -1539,13 +1607,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
           }
         }
         if (dedup_input.size() < fop->inputs().size()) {
-          if (dedup_input.size() == 1) {
-            return dedup_input.at(0);
-          } else {
-            auto output = IrBuilder::newScalar(inferDtypes(dedup_input));
-            IrBuilder::create<FOp>(op, output, std::move(dedup_input));
-            return output;
-          }
+          return maybeFlattenedOpOf(op, std::move(dedup_input));
         }
       }
     }
@@ -1751,14 +1813,8 @@ Val* distributeDivisibleDivMod(Val* value, const Context& context) {
       }
       other_terms.emplace_back(fop->input(j));
     }
-    Val* sum_of_other_terms = nullptr;
-    if (other_terms.size() == 1) {
-      sum_of_other_terms = other_terms.at(0);
-    } else {
-      sum_of_other_terms = IrBuilder::newScalar(inferDtypes(other_terms));
-      IrBuilder::create<FOp>(
-          BinaryOpType::Add, sum_of_other_terms, std::move(other_terms));
-    }
+    Val* sum_of_other_terms =
+        maybeFlattenedOpOf(BinaryOpType::Add, std::move(other_terms));
     if (prove::hasCompatibleSign(divisible_term, sum_of_other_terms, context)) {
       std::vector<Val*> new_inputs;
       auto term1 = IrBuilder::newScalar(
@@ -1906,22 +1962,9 @@ Val* distributeGcdRemainderDivMod(Val* value, const Context& context) {
         }
       }
       // compute sum of combo_xs and sum of combo_other
-      Val* sum_xs = nullptr;
-      if (combo_xs.size() == 1) {
-        sum_xs = combo_xs.at(0);
-      } else {
-        sum_xs = IrBuilder::newScalar(inferDtypes(combo_xs));
-        IrBuilder::create<FOp>(BinaryOpType::Add, sum_xs, combo_xs);
-      }
-      Val* sum_other = nullptr;
-      if (combo_other.size() == 1) {
-        sum_other = combo_other.at(0);
-        // sum_other is already factorized
-      } else {
-        sum_other = IrBuilder::newScalar(inferDtypes(combo_other));
-        IrBuilder::create<FOp>(BinaryOpType::Add, sum_other, combo_other);
-        sum_other = sym_algebra::factorize(sum_other);
-      }
+      Val* sum_xs = maybeFlattenedOpOf(BinaryOpType::Add, std::move(combo_xs));
+      Val* sum_other =
+          maybeFlattenedOpOf(BinaryOpType::Add, std::move(combo_other));
       // prove -|g| < sum_xs < |g|
       bool allowed_to_simplify =
           prove::hasCompatibleSign(sum_other, sum_xs, context);
@@ -2106,19 +2149,13 @@ Val* reducePredicateRegisterUsage(Val* value, const Context& context) {
   Val* rhs = nullptr;
   if (new_lhs.empty()) {
     lhs = IrBuilder::newConstant(0, ltype);
-  } else if (new_lhs.size() == 1) {
-    lhs = new_lhs.at(0);
   } else {
-    lhs = IrBuilder::newScalar(ltype);
-    IrBuilder::create<FOp>(BinaryOpType::Add, lhs, std::move(new_lhs));
+    lhs = maybeFlattenedOpOf(BinaryOpType::Add, std::move(new_lhs));
   }
   if (new_rhs.empty()) {
     rhs = IrBuilder::newConstant(0, rtype);
-  } else if (new_rhs.size() == 1) {
-    rhs = new_rhs.at(0);
   } else {
-    rhs = IrBuilder::newScalar(rtype);
-    IrBuilder::create<FOp>(BinaryOpType::Add, rhs, std::move(new_rhs));
+    rhs = maybeFlattenedOpOf(BinaryOpType::Add, std::move(new_rhs));
   }
   auto output = IrBuilder::newScalar(DataType::Bool);
   IrBuilder::create<BinaryOp>(op_type, output, lhs, rhs);
@@ -2168,11 +2205,8 @@ Val* fundamentalDivisionWithRemainderProperty(
         Val* c = nullptr;
         if (other_terms.empty()) {
           continue;
-        } else if (other_terms.size() == 1) {
-          c = other_terms.at(0);
         } else {
-          c = IrBuilder::newScalar(inferDtypes(other_terms));
-          IrBuilder::create<FOp>(BinaryOpType::Mul, c, std::move(other_terms));
+          c = maybeFlattenedOpOf(BinaryOpType::Mul, std::move(other_terms));
         }
         if (!isIntegralType(*a->getDataType()) ||
             !isIntegralType(*b->getDataType()) ||
@@ -2248,13 +2282,7 @@ Val* fundamentalDivisionWithRemainderProperty(
           }
           terms.emplace_back(fadd->input(k));
         }
-        if (terms.size() == 1) {
-          return terms.at(0);
-        } else {
-          Val* result = IrBuilder::newScalar(inferDtypes(terms));
-          IrBuilder::create<FOp>(BinaryOpType::Add, result, terms);
-          return result;
-        }
+        return maybeFlattenedOpOf(BinaryOpType::Add, terms);
       }
     }
   }

--- a/test/test_expr_simplifier.cpp
+++ b/test/test_expr_simplifier.cpp
@@ -768,6 +768,11 @@ TEST_F(ExprSimplifierTest, Compare_CUDA) {
   ASSERT_TRUE(*simplify(
       "i1 < 3"_,
       "i1 < i2 && i2 <= i3 && i3 < i4 && i4 <= i5 && i5 <= i6 && i6 < i7 && i7 <= i8 && i8 <= 2"_));
+
+  ASSERT_TRUE(*simplify("i1 <= i1 * i2"_, "i1 >= 0 && i2 > 0"_));
+  ASSERT_TRUE(*simplify("i1 >= i1 * i2"_, "i1 <= 0 && i2 > 0"_));
+  ASSERT_TRUE(*simplify("d1 <= d1 * d2"_, "d1 >= 0.0 && d2 >= 1.0"_));
+  ASSERT_TRUE(*simplify("d1 >= d1 * d2"_, "d1 <= 0.0 && d2 >= 1.0"_));
 }
 
 TEST_F(ExprSimplifierTest, FundamentalDivisionWithRemainderProperty_CUDA) {

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -9029,27 +9029,27 @@ TEST_F(NVFuserTest, FusionChannelsLastParser_CUDA) {
   // 2. use a fuzzy compare (ignore non-significant whitespaces for example)
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<__half, 4> T0, Tensor<__half, 4> T2, Tensor<__half, 4> T7) {
-  int64_t i1405;
-  i1405 = T0.size[2] * T0.size[1];
-  int64_t i1408;
-  i1408 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)blockIdx.x));
-  int64_t i1410;
-  i1410 = (T0.size[1] * T0.size[2]) * T0.size[3];
-  int64_t i1442;
-  i1442 = i1408 % i1410;
-  int64_t i1419;
-  i1419 = T0.size[2] * T0.size[3];
-  int64_t i1443;
-  i1443 = i1442 % i1419;
-  if ((i1408 < (((T0.size[0] * T0.size[1]) * T0.size[2]) * T0.size[3]))) {
+  int64_t i1409;
+  i1409 = T0.size[2] * T0.size[1];
+  int64_t i1412;
+  i1412 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)blockIdx.x));
+  int64_t i1414;
+  i1414 = (T0.size[1] * T0.size[2]) * T0.size[3];
+  int64_t i1446;
+  i1446 = i1412 % i1414;
+  int64_t i1423;
+  i1423 = T0.size[2] * T0.size[3];
+  int64_t i1447;
+  i1447 = i1446 % i1423;
+  if ((i1412 < (((T0.size[0] * T0.size[1]) * T0.size[2]) * T0.size[3]))) {
     __half T9[1];
     T9[0] = 0;
     T9[0]
-       = T2[(((((i1405 * T0.size[3]) * (i1408 / i1410)) + (i1405 * (i1443 % T0.size[3]))) + (T0.size[2] * (i1442 / i1419))) + (i1443 / T0.size[3]))];
+       = T2[(((((i1409 * T0.size[3]) * (i1412 / i1414)) + (i1409 * (i1447 % T0.size[3]))) + (T0.size[2] * (i1446 / i1423))) + (i1447 / T0.size[3]))];
     __half T8[1];
     T8[0] = 0;
     T8[0]
-       = T0[i1408];
+       = T0[i1412];
     float T3[1];
     T3[0]
        = __half2float(T9[0]);
@@ -9069,7 +9069,7 @@ __global__ void CUDAGeneratedKernel(Tensor<__half, 4> T0, Tensor<__half, 4> T2, 
     __half T10[1];
     T10[0]
        = __float2half(T6[0]);
-    T7[i1408]
+    T7[i1412]
        = T10[0];
   }
 }

--- a/test/test_loop_rotation.cpp
+++ b/test/test_loop_rotation.cpp
@@ -206,8 +206,8 @@ TEST_F(LoopRotationTest, NonDivisibleSplit_CUDA) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO
-  int64_t i1509;
-  i1509 = T0.size[0] * T0.size[1];
+  int64_t i1511;
+  i1511 = T0.size[0] * T0.size[1];
   float T1[5];
   float T2[5];
   #pragma unroll
@@ -219,7 +219,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   for(nvfuser_index_t i36 = 0; i36 < 5; ++i36) {
     int64_t i154;
     i154 = i36 + nvfuser_zero;
-    if ((i154 < i1509)) {
+    if ((i154 < i1511)) {
       T1[i36]
          = T0[((T0.stride[0] * (i154 / T0.size[1])) + (T0.stride[1] * (i154 % T0.size[1])))];
     }
@@ -235,8 +235,8 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   for(nvfuser_index_t i39 = 0; i39 < (ceilDiv((T0.size[0] * T0.size[1]), 5)); ++i39) {
     int64_t i628;
     i628 = 5 * i39;
-    int64_t i1216;
-    i1216 = 5 + i628;
+    int64_t i1218;
+    i1218 = 5 + i628;
     // Alias Allocation - register
     auto& T3 = T1;
     #pragma unroll
@@ -249,7 +249,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     for(nvfuser_index_t i40 = 0; i40 < 5; ++i40) {
       int64_t i629;
       i629 = i628 + (i40 + nvfuser_zero);
-      if ((i629 < i1509)) {
+      if ((i629 < i1511)) {
         T4[i629]
            = T3[i40];
       }
@@ -262,11 +262,11 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i36 = 0; i36 < 5; ++i36) {
-      int64_t i1217;
-      i1217 = i1216 + (i36 + nvfuser_zero);
-      if ((i1217 < i1509)) {
+      int64_t i1219;
+      i1219 = i1218 + (i36 + nvfuser_zero);
+      if ((i1219 < i1511)) {
         T1[i36]
-           = T0[((T0.stride[0] * (i1217 / T0.size[1])) + (T0.stride[1] * (i1217 % T0.size[1])))];
+           = T0[((T0.stride[0] * (i1219 / T0.size[1])) + (T0.stride[1] * (i1219 % T0.size[1])))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO


### PR DESCRIPTION
I shall use this to prove `ceilDiv(T0.size[0], 128) <= ceilDiv(T0.size[0], 128) * 4`, so that I can simplify
```C++
max(ceilDiv(T0.size[0], 128), ceilDiv(T0.size[0], 128) * 4)
```
as
```C++
ceilDiv(T0.size[0], 128) * 4
```
which will help remove the trivial predicate
```C++
blockIdx.x < ceilDiv(T0.size[0], 128) * 4
```
where `gridDim.x` is known to be
```C++
max(ceilDiv(T0.size[0], 128), ceilDiv(T0.size[0], 128) * 4, 4)
```

Note that I also need to prove
```C++
4 <= ceilDiv(T0.size[0], 128) * 4
```
which is indeed not true for empty tensor. So, unfortunately, I have to introduce an assumption `T0.size[0] > 0` when simplifying exprs in `parallel_dimension_map.cpp`. I don't think in practice this will cause any issue, but if it does, then we should more systematically special handling empty tensors.

TODO:
- [ ] Update string compare tests

cc: @mmigdal-nv @drzejan2