### PR TITLE
Clean up nvrtcCompileProgram

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -174,7 +174,7 @@ void FusionExecutor::debugCompileFusionFromStr(
   }
 
   std::tie(compiled_kernel_, last_compiler_log_, last_compiled_binary_) =
-      executor_utils::nvrtcCompile(c10::nullopt, code, name, fusion_id_);
+      executor_utils::getCompiledKernel(c10::nullopt, code, name, fusion_id_);
   TORCH_INTERNAL_ASSERT(
       fusion_id_ > 0, "assign a fusion_id_ <= 0 is not accepted.");
 }
@@ -355,7 +355,7 @@ void FusionExecutor::compileFusion(
       block_size_high_water_mark);
   maxrregcount_high_water_mark = compile_params.maxrregcount;
   std::tie(compiled_kernel_, last_compiler_log_, last_compiled_binary_) =
-      executor_utils::nvrtcCompile(
+      executor_utils::getCompiledKernel(
           kernel_code_,
           structured_code,
           (kernelNamespace() + "::" + kernelName()).c_str(),
@@ -1122,7 +1122,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
       maxrregcount_high_water_mark = compile_params.maxrregcount;
 
       std::tie(compiled_kernel_, last_compiler_log_, last_compiled_binary_) =
-          executor_utils::nvrtcCompile(
+          executor_utils::getCompiledKernel(
               kernel_code_,
               structured_code,
               (kernelNamespace() + "::" + kernelName()).c_str(),
@@ -1396,7 +1396,7 @@ void FusionExecutor::compileRtc(
   fusion_id_ = 1;
 
   std::tie(compiled_kernel_, last_compiler_log_, last_compiled_binary_) =
-      executor_utils::nvrtcCompile(c10::nullopt, scode, name, fusion_id_);
+      executor_utils::getCompiledKernel(c10::nullopt, scode, name, fusion_id_);
 }
 
 float FusionExecutor::runRtc(

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -49,8 +49,10 @@
 #include <nvfuser_resources/type_traits.h>
 #include <nvfuser_resources/warp.h>
 #include <nvfuser_resources/welford.h>
+
 #include <cstdlib>
 #include <fstream>
+#include <variant>
 
 #include <nvrtc.h>
 
@@ -319,6 +321,8 @@ bool validateKernelArg(
     const Val* param,
     const c10::Device& device,
     std::stringstream& msg) {
+  // clang-tidy complains that arg may be null without tis assertion
+  TORCH_INTERNAL_ASSERT(arg != nullptr);
   if (auto tensor_arg_abstract = dynamic_cast<const TensorArgAbstract*>(arg)) {
     // TODO: don't use get tensor here. We would want to remove tensor reference
     // for async compilation
@@ -955,6 +959,7 @@ ExpressionEvaluator bindInputs(
   const auto& inputs = kernel->inputs();
 
   for (const auto i : c10::irange(inputs.size())) {
+    std::cerr << "Binding input: " << inputs[i]->toString() << std::endl;
     bindInputForExprEvaluation(
         inputs[i], args[i], check_consistency, expr_eval);
   }
@@ -964,12 +969,19 @@ ExpressionEvaluator bindInputs(
 namespace {
 
 // Dump PTX or CUBIN to a file
-#if CUDA_VERSION >= 11010
 std::vector<char> dumpCompiledCode(
     const nvrtcProgram& program,
     bool dump_cubin) {
+#if CUDA_VERSION >= 11010
   const auto getSize = dump_cubin ? nvrtcGetCUBINSize : nvrtcGetPTXSize;
   const auto getCode = dump_cubin ? nvrtcGetCUBIN : nvrtcGetPTX;
+#else
+  TORCH_INTERNAL_ASSERT(
+      !dump_cubin, "CUBIN not supported in CUDA versions older than 11.0");
+  const auto getSize = nvrtcGetPTXSize;
+  const auto getCode = nvrtcGetPTX;
+#endif
+
   size_t size = 0;
   NVRTC_SAFE_CALL(getSize(program, &size));
   std::vector<char> code(size);
@@ -990,7 +1002,6 @@ void dumpCompiledCodeToFile(
   out.write(code.data(), (std::streamsize)code.size());
   out.close();
 }
-#endif
 
 // Get the max register count passed as -maxrregcount ptxas
 // option. The count is determined based on block sizes, an optional
@@ -1055,11 +1066,335 @@ c10::optional<int> getMaxRegCount(
   }
 }
 
+//! Utility class to invoke nvrtcCompileProgram
+class NvrtcCompileProgram {
+ public:
+  void setOption(const std::string& opt) {
+    options_.push_back(opt);
+  }
+
+  const std::vector<std::string>& options() const {
+    return options_;
+  }
+
+  //! Call nvrtcCompileProgram with set options
+  std::string invoke(nvrtcProgram program, const std::string& src) const {
+    FUSER_PERF_SCOPE("executor_utils::Nvrtc::CompileProgram");
+    auto opts = getOptions();
+    auto result = nvrtcCompileProgram(
+        program, static_cast<int>(opts.size()), opts.data());
+
+    size_t logsize = 0;
+    NVRTC_SAFE_CALL(nvrtcGetProgramLogSize(program, &logsize));
+    std::string log;
+    log.reserve(logsize);
+    NVRTC_SAFE_CALL(nvrtcGetProgramLog(program, log.data()));
+    if (result != NVRTC_SUCCESS) {
+      TORCH_INTERNAL_ASSERT(
+          false, src, "\nCUDA NVRTC compile error: ", log.data());
+    }
+
+    if (isDebugDumpEnabled(DebugDumpOption::PrintPtxasLog)) {
+      std::cout << log.data() << std::endl;
+    }
+
+    return log;
+  }
+
+ private:
+  // Get options that can be passed to nvrtcCompileProgram
+  std::vector<const char*> getOptions() const {
+    std::vector<const char*> opts(options_.size());
+    for (const auto i : c10::irange(options_.size())) {
+      opts.at(i) = options_.at(i).c_str();
+    }
+    return opts;
+  }
+
+ private:
+  std::vector<std::string> options_;
+};
+
+//! Utility class to invoke cuModuleLoadDataEx
+class ModuleLoadData {
+ public:
+  //! Valid option type is either int or char*
+  using OptionType = std::variant<int, char*>;
+
+  template <typename OptionValType>
+  void setOption(CUjit_option key, OptionValType val) {
+    options_.push_back(key);
+    option_vals_.push_back(val);
+  }
+
+  void enableLogging() {
+    logging_enabled_ = true;
+    log_.reserve(kLogSize);
+  }
+
+  const std::string& log() const {
+    TORCH_INTERNAL_ASSERT(logging_enabled_, "Logging not enabled");
+    return log_;
+  }
+
+  // load ptx or cubin directly
+  std::string invoke(CUmodule& module, const void* image) {
+    FUSER_PERF_SCOPE("executor_utils::Nvrtc::LoadPTX");
+
+    auto [opts, opt_vals] = getOptions();
+
+    CUDA_SAFE_CALL(cuModuleLoadDataEx(
+        &module, image, opts.size(), opts.data(), opt_vals.data()));
+
+    if (logging_enabled_) {
+      std::cout << log_ << std::endl;
+    }
+
+    return log_;
+  }
+
+ private:
+  // Get options that can be passed to cuModuleLoadDataEx
+  std::pair<std::vector<CUjit_option>, std::vector<void*>> getOptions() {
+    auto opts = options_;
+    auto opt_vals = option_vals_;
+
+    // Append options for saving log message to log_
+    if (logging_enabled_) {
+      opts.push_back(CU_JIT_LOG_VERBOSE);
+      opt_vals.emplace_back(1);
+
+      opts.push_back(CU_JIT_INFO_LOG_BUFFER);
+      opt_vals.emplace_back(log_.data());
+
+      opts.push_back(CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES);
+      opt_vals.emplace_back(kLogSize);
+    }
+
+    std::vector<void*> opt_val_voidp(opt_vals.size());
+    for (const auto i : c10::irange(opt_vals.size())) {
+      auto opt_val = opt_vals.at(i);
+      if (std::holds_alternative<int>(opt_val)) {
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        opt_val_voidp.at(i) = (void*)(int64_t)std::get<int>(opt_val);
+      } else if (std::holds_alternative<char*>(opt_val)) {
+        opt_val_voidp.at(i) = std::get<char*>(opt_val);
+      } else {
+        TORCH_INTERNAL_ASSERT(false, "Invalid option");
+      }
+    }
+
+    return std::make_pair(opts, opt_val_voidp);
+  }
+
+ private:
+  static constexpr int kLogSize = 8196;
+  //! cuModuleLoadDataEx options
+  std::vector<CUjit_option> options_;
+  //! Option parameters
+  std::vector<OptionType> option_vals_;
+  //! Save log to log_ if true
+  bool logging_enabled_ = false;
+  std::string log_;
+};
+
+// Fill options for nvrtcCompileProgram and cuModuleLoadDataEx
+void fillCompileOptions(
+    NvrtcCompileProgram& nvrtc_compile,
+    ModuleLoadData& module_load,
+    bool compile_to_sass,
+    int major,
+    int minor,
+    c10::optional<int> opt_block_size,
+    const int max_register_heuristic) {
+  nvrtc_compile.setOption("--std=c++17");
+
+  // CUDA 11.1 allows going directly to SASS (sm_) instead of PTX (compute_)
+  // which gives better backwards compatibility to work on older driver,
+  // (since older driver doesn't necessrily recognize PTX emitted by new
+  // toolkit);
+  // Meanwhile, for forward compatibility (future device with
+  // `unsupported_arch==True`), since SASS are not necessarily compatible,
+  // we fallback to PTX instead.
+  const std::string compute = std::string("--gpu-architecture=") +
+      (compile_to_sass ? "sm_" : "compute_") + std::to_string(major) +
+      std::to_string(minor);
+  nvrtc_compile.setOption(compute);
+
+  nvrtc_compile.setOption("-default-device");
+
+  if (isOptionDisabled(DisableOption::Fma)) {
+    nvrtc_compile.setOption("--fmad=false");
+  } else {
+    nvrtc_compile.setOption("--fmad=true");
+  }
+
+  // Add line info to generated kernels
+  if (isDebugDumpEnabled(DebugDumpOption::DebugInfo)) {
+    nvrtc_compile.setOption("-lineinfo");
+  }
+
+#ifdef NDEBUG
+  // Avoid excessive register usage from assertion
+  nvrtc_compile.add("-DNDEBUG");
+#endif
+
+  if (isOptionEnabled(EnableOption::KernelProfile)) {
+    nvrtc_compile.setOption("-DPYTORCH_NVFUSER_PROFILE_KERNEL");
+  }
+
+  if (isDebugDumpEnabled(DebugDumpOption::PrintPtxasLog) ||
+      isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose) ||
+      isOptionEnabled(EnableOption::WarnRegisterSpill)) {
+    // show register usage in compilation log
+    if (compile_to_sass) {
+      nvrtc_compile.setOption("--ptxas-options");
+      nvrtc_compile.setOption("--verbose");
+    } else {
+      module_load.enableLogging();
+    }
+  }
+
+  const char* ptxas_opt_level = getenv("PYTORCH_NVFUSER_JIT_OPT_LEVEL");
+
+  if (ptxas_opt_level) {
+    int val = atoi(ptxas_opt_level);
+    if (val <= 4 && val >= 0) {
+      if (val < 4) {
+        TORCH_WARN(
+            "ptxas optimization level manually set as ",
+            val,
+            ", which could negatively affect performance. Try removing env variable PYTORCH_NVFUSER_JIT_OPT_LEVEL for optimal performance.");
+      }
+      if (compile_to_sass) {
+        nvrtc_compile.setOption("--ptxas-options");
+        nvrtc_compile.setOption("-O" + std::to_string(val));
+      } else {
+        module_load.setOption(CU_JIT_OPTIMIZATION_LEVEL, val);
+      }
+    } else {
+      TORCH_WARN_ONCE(
+          "acceptable range for PYTORCH_NVFUSER_JIT_OPT_LEVEL is between 0 and 4, but received ",
+          val,
+          ", ignoring the option");
+    }
+  }
+
+  const auto max_register =
+      getMaxRegCount(opt_block_size, max_register_heuristic);
+
+  // If the max register count is set
+  if (max_register.has_value()) {
+    if (compile_to_sass) {
+      nvrtc_compile.setOption(
+          "--maxrregcount=" + std::to_string(*max_register));
+    } else {
+      module_load.setOption(CU_JIT_MAX_REGISTERS, *max_register);
+    }
+  }
+}
+
+void warnRegisterSpill(const std::string& compile_log) {
+  auto getRegisterSpillInfo = [](const std::string& log, const char* subStr) {
+    auto it_end =
+        std::search(log.begin(), log.end(), subStr, subStr + strlen(subStr)) -
+        1;
+    auto it_beg = it_end - 1;
+    while (!std::isspace(*(it_beg - 1))) {
+      it_beg--;
+    }
+    std::string str(it_beg, it_end);
+    return std::stoi(str);
+  };
+
+  const char* str_stack = "bytes stack frame";
+  const char* str_store = "bytes spill stores";
+  const char* str_load = "bytes spill loads";
+  int stack_count = getRegisterSpillInfo(compile_log, str_stack);
+  int store_count = getRegisterSpillInfo(compile_log, str_store);
+  int load_count = getRegisterSpillInfo(compile_log, str_load);
+  auto optionArgs = getEnableOptionArguments(EnableOption::WarnRegisterSpill);
+  int allowed_spill = 0;
+  if (!optionArgs.empty()) {
+    try {
+      allowed_spill = std::stoi(optionArgs[0]);
+    } catch (const std::exception& e) {
+      std::cout << "skip invalid argument for WarnRegisterSpill, arg = "
+                << optionArgs[0] << std::endl;
+    }
+  }
+  if (stack_count > allowed_spill || store_count > allowed_spill ||
+      load_count > allowed_spill) {
+    std::cout << compile_log << std::endl;
+  }
+}
+
+void createNvrtcProgram(
+    nvrtcProgram& program,
+    int id,
+    const std::string& full_src_code) {
+  std::stringstream ss;
+  ss << "__tmp_kernel" << id << ".cu";
+  std::string name = ss.str();
+  FUSER_PERF_SCOPE("executor_utils::NvrtcCreateProgram");
+  NVRTC_SAFE_CALL(nvrtcCreateProgram(
+      &program, full_src_code.c_str(), name.c_str(), 0, nullptr, nullptr));
+}
+
+std::vector<char> extractObjectCode(
+    nvrtcProgram program,
+    bool compile_to_sass) {
+  FUSER_PERF_SCOPE("executor_utils::Nvrtc::GetObjectCode");
+  const auto getSize = compile_to_sass ? nvrtcGetCUBINSize : nvrtcGetPTXSize;
+  const auto getFunc = compile_to_sass ? nvrtcGetCUBIN : nvrtcGetPTX;
+  size_t object_code_size = 0;
+  NVRTC_SAFE_CALL(getSize(program, &object_code_size));
+  std::vector<char> object_code(object_code_size);
+  NVRTC_SAFE_CALL(getFunc(program, object_code.data()));
+  return object_code;
+}
+
+std::tuple<std::vector<char>, std::string, std::vector<char>> getObjectCode(
+    const std::string& full_src_code,
+    const std::string& func_name,
+    int id,
+    bool compile_to_sass,
+    NvrtcCompileProgram& nvrtc_compile) {
+  std::stringstream log;
+
+  nvrtcProgram program; // NOLINT(cppcoreguidelines-init-variables)
+  torch::jit::ResourceGuard holdProgram([&] {
+    FUSER_PERF_SCOPE("executor_utils::NvrtcDestroyProgram");
+    NVRTC_SAFE_CALL(nvrtcDestroyProgram(&program));
+  });
+
+  createNvrtcProgram(program, id, full_src_code);
+
+  NVRTC_SAFE_CALL(nvrtcAddNameExpression(program, func_name.c_str()));
+  log << nvrtc_compile.invoke(program, full_src_code) << std::endl;
+
+  const char* lowered_kernel_name = nullptr;
+  NVRTC_SAFE_CALL(
+      nvrtcGetLoweredName(program, func_name.c_str(), &lowered_kernel_name));
+  auto lowered_kernel_name_str = std::string(lowered_kernel_name);
+
+  auto object_code = extractObjectCode(program, compile_to_sass);
+
+  auto binary = dumpCompiledCode(program, compile_to_sass);
+
+  if (isDebugDumpEnabled(DebugDumpOption::Ptx) ||
+      isDebugDumpEnabled(DebugDumpOption::Cubin)) {
+    dumpCompiledCodeToFile(binary, id, compile_to_sass);
+  }
+
+  return {object_code, lowered_kernel_name_str, binary};
+}
+
 } // namespace
 
-std::tuple<NvrtcFunction, std::string, std::vector<char>> nvrtcCompile(
+std::tuple<NvrtcFunction, std::string, std::vector<char>> getCompiledKernel(
     c10::optional<std::reference_wrapper<const std::string>> kernel_code,
-    const std::string& code,
+    const std::string& full_src_code,
     const std::string& func_name,
     int id,
     c10::optional<int> opt_block_size,
@@ -1072,8 +1407,6 @@ std::tuple<NvrtcFunction, std::string, std::vector<char>> nvrtcCompile(
   }
 
   at::cuda::jit::initializeCudaContext();
-
-  std::stringstream ptxas_log;
 
   const auto prop = at::cuda::getCurrentDeviceProperties();
 
@@ -1092,299 +1425,87 @@ std::tuple<NvrtcFunction, std::string, std::vector<char>> nvrtcCompile(
     //  so the intermediate ptx could be checked.
     compile_to_sass = false;
   }
-  // CUDA 11.1 allows going directly to SASS (sm_) instead of PTX (compute_)
-  // which gives better backwards compatibility to work on older driver,
-  // (since older driver doesn't necessrily recognize PTX emitted by new
-  // toolkit);
-  // Meanwhile, for forward compatibility (future device with
-  // `unsupported_arch==True`), since SASS are not necessarily compatible,
-  // we fallback to PTX instead.
-  const std::string compute = std::string("--gpu-architecture=") +
-      (compile_to_sass ? "sm_" : "compute_") + std::to_string(major) +
-      std::to_string(minor);
-  std::vector<const char*> args = {
-      "--std=c++17", compute.c_str(), "-default-device"};
 
-  const bool disable_fma = isOptionDisabled(DisableOption::Fma);
-  if (disable_fma) {
-    args.push_back("--fmad=false");
-  } else {
-    args.push_back("--fmad=true");
-  }
-  // Add line info to generated kernels
-  if (isDebugDumpEnabled(DebugDumpOption::DebugInfo)) {
-    args.push_back("-lineinfo");
-  }
-#ifdef NDEBUG
-  // Avoid excessive register usage from assertion
-  args.push_back("-DNDEBUG");
-#endif
+  NvrtcCompileProgram nvrtc_compile;
+  ModuleLoadData module_load;
 
-  if (isOptionEnabled(EnableOption::KernelProfile)) {
-    args.push_back("-DPYTORCH_NVFUSER_PROFILE_KERNEL");
-  }
+  fillCompileOptions(
+      nvrtc_compile,
+      module_load,
+      compile_to_sass,
+      major,
+      minor,
+      opt_block_size,
+      max_register_heuristic);
 
-  const char* ptxas_opt_level = getenv("PYTORCH_NVFUSER_JIT_OPT_LEVEL");
-  std::string jit_opt_level = "-O";
-
-  std::vector<CUjit_option> options;
-  std::vector<void*> option_vals;
-  std::vector<char> info_log;
-  unsigned int log_size = 8196;
-  const bool isWarnRegisterSpill =
-      isOptionEnabled(EnableOption::WarnRegisterSpill);
-  if (isDebugDumpEnabled(DebugDumpOption::PrintPtxasLog) ||
-      isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose) ||
-      isWarnRegisterSpill) {
-    // show register usage in compilation log
-    if (compile_to_sass) {
-      args.push_back("--ptxas-options");
-      args.push_back("--verbose");
-    } else {
-      options.push_back(CU_JIT_LOG_VERBOSE);
-      option_vals.push_back((void*)1);
-      info_log.reserve(log_size);
-
-      options.push_back(CU_JIT_INFO_LOG_BUFFER);
-      option_vals.push_back((void*)info_log.data());
-
-      options.push_back(CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES);
-      // NOLINTNEXTLINE(performance-no-int-to-ptr)
-      option_vals.push_back((void*)(intptr_t)log_size);
-    }
-  }
-
-  if (ptxas_opt_level) {
-    int val = atoi(ptxas_opt_level);
-    if (val <= 4 && val >= 0) {
-      if (val < 4) {
-        TORCH_WARN(
-            "ptxas optimization level manually set as ",
-            val,
-            ", which could negatively affect performance. Try removing env variable PYTORCH_NVFUSER_JIT_OPT_LEVEL for optimal performance.");
-      }
-      if (compile_to_sass) {
-        jit_opt_level += std::to_string(val);
-        args.push_back("--ptxas-options");
-        args.push_back(jit_opt_level.c_str());
-      } else {
-        options.push_back(CU_JIT_OPTIMIZATION_LEVEL);
-        // NOLINTNEXTLINE(performance-no-int-to-ptr)
-        option_vals.push_back((void*)(intptr_t)val);
-      }
-    } else {
-      TORCH_WARN_ONCE(
-          "acceptable range for PYTORCH_NVFUSER_JIT_OPT_LEVEL is between 0 and 4, but received ",
-          val,
-          ", ignoring the option");
-    }
-  }
-
-  const auto max_register =
-      getMaxRegCount(opt_block_size, max_register_heuristic);
-
-  // keeping the string outside the loop for lifetime
-  std::string max_register_usage = "--maxrregcount=";
-
-  // If the max register count is set
-  if (max_register.has_value()) {
-    if (compile_to_sass) {
-      max_register_usage += std::to_string(*max_register);
-      args.push_back(max_register_usage.c_str());
-    } else {
-      // TODO: Why max register is set when compiled to PTX?
-      options.push_back(CU_JIT_MAX_REGISTERS);
-      // NOLINTNEXTLINE(performance-no-int-to-ptr)
-      option_vals.push_back((void*)(intptr_t)*max_register);
-    }
-  }
+  std::stringstream log;
 
   if (compile_to_sass) {
-    ptxas_log << "\nCompile options: ";
-    for (auto arg : args) {
-      ptxas_log << arg << " ";
+    log << "\nCompile options: ";
+    for (const auto& opt : nvrtc_compile.options()) {
+      log << opt << " ";
     }
     if (opt_block_size.has_value()) {
-      ptxas_log << " ; block size=" << opt_block_size.value() << "\n";
+      log << " ; block size=" << opt_block_size.value() << "\n";
     }
   }
 
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  std::vector<char> ptx;
+  std::vector<char> object_code;
   std::string lowered_kernel_name_str;
-  std::string compile_args;
-  bool first_arg = true;
-  for (auto arg : args) {
-    if (first_arg) {
-      compile_args += arg;
-      first_arg = false;
-    } else {
-      compile_args += " ";
-      compile_args += arg;
-    }
-  }
+  const auto compile_args = toDelimitedString(nvrtc_compile.options(), " ");
 
   std::vector<char> binary;
 
   auto& kernel_db = KernelDb::get();
+  const auto use_kernel_db = kernel_db.enabled() && kernel_code.has_value();
+
   // If the Kernel Query failes, the Kernel is recompiled
-  if (!(kernel_db.enabled() && kernel_code.has_value() &&
+  if (!(use_kernel_db &&
         kernel_db.query(
-            kernel_code.value(), compile_args, lowered_kernel_name_str, ptx))) {
-    nvrtcProgram program; // NOLINT(cppcoreguidelines-init-variables)
-    torch::jit::ResourceGuard holdProgram([&] {
-      FUSER_PERF_SCOPE("executor_utils::NvrtcDestroyProgram");
-      NVRTC_SAFE_CALL(nvrtcDestroyProgram(&program));
-    });
+            kernel_code.value(),
+            compile_args,
+            lowered_kernel_name_str,
+            object_code))) {
+    std::tie(object_code, lowered_kernel_name_str, binary) = getObjectCode(
+        full_src_code, func_name, id, compile_to_sass, nvrtc_compile);
 
-    {
-      FUSER_PERF_SCOPE("executor_utils::Nvrtc::CompileProgram");
-      {
-        std::stringstream ss;
-        ss << "__tmp_kernel" << id << ".cu";
-        std::string name = ss.str();
-        FUSER_PERF_SCOPE("executor_utils::NvrtcCreateProgram");
-        NVRTC_SAFE_CALL(nvrtcCreateProgram(
-            &program, code.c_str(), name.c_str(), 0, nullptr, nullptr));
-      }
-
-      NVRTC_SAFE_CALL(nvrtcAddNameExpression(program, func_name.c_str()));
-
-      // NOTE: not using NVRTC_SAFE_CALL on the return here, since we want to
-      // display log if the compilation fails here.
-      const auto result =
-          nvrtcCompileProgram(program, (int)args.size(), args.data());
-      size_t logsize = 0;
-      NVRTC_SAFE_CALL(nvrtcGetProgramLogSize(program, &logsize));
-      std::vector<char> log(logsize);
-      NVRTC_SAFE_CALL(nvrtcGetProgramLog(program, log.data()));
-      if (result != NVRTC_SUCCESS) {
-        TORCH_INTERNAL_ASSERT(
-            false, code.c_str(), "\nCUDA NVRTC compile error: ", log.data());
-      }
-
-      ptxas_log << log.data() << std::endl;
-      if (isDebugDumpEnabled(DebugDumpOption::PrintPtxasLog)) {
-        if (max_register.has_value()) {
-          std::cout << "Max register count: " << *max_register << std::endl;
-        }
-        std::cout << log.data() << std::endl;
-      }
-
-      if (isWarnRegisterSpill) {
-        auto getRegisterSpillInfo = [&log](const char* subStr) {
-          auto it_end =
-              std::search(
-                  log.begin(), log.end(), subStr, subStr + strlen(subStr)) -
-              1;
-          auto it_beg = it_end - 1;
-          while (!std::isspace(*(it_beg - 1))) {
-            it_beg--;
-          }
-          std::string str(it_beg, it_end);
-          return std::stoi(str);
-        };
-
-        const char* str_stack = "bytes stack frame";
-        const char* str_store = "bytes spill stores";
-        const char* str_load = "bytes spill loads";
-        int stack_count = getRegisterSpillInfo(str_stack);
-        int store_count = getRegisterSpillInfo(str_store);
-        int load_count = getRegisterSpillInfo(str_load);
-        auto optionArgs =
-            getEnableOptionArguments(EnableOption::WarnRegisterSpill);
-        int allowed_spill = 0;
-        if (!optionArgs.empty()) {
-          try {
-            allowed_spill = std::stoi(optionArgs[0]);
-          } catch (const std::exception& e) {
-            std::cout << "skip invalid argument for WarnRegisterSpill, arg = "
-                      << optionArgs[0] << std::endl;
-          }
-        }
-        if (stack_count > allowed_spill || store_count > allowed_spill ||
-            load_count > allowed_spill) {
-          std::cout << ptxas_log.str() << std::endl;
-        }
-      }
-    }
-
-    const char* lowered_kernel_name = nullptr;
-    NVRTC_SAFE_CALL(
-        nvrtcGetLoweredName(program, func_name.c_str(), &lowered_kernel_name));
-    lowered_kernel_name_str.assign(lowered_kernel_name);
-
-    size_t ptx_size = 0;
-
-    {
-      FUSER_PERF_SCOPE("executor_utils::Nvrtc::GetPTX");
-#if CUDA_VERSION >= 11010
-      // compile_to_sass determines whether we are generating SASS or PTX, hence
-      // the different API.
-      const auto getSize =
-          compile_to_sass ? nvrtcGetCUBINSize : nvrtcGetPTXSize;
-      const auto getFunc = compile_to_sass ? nvrtcGetCUBIN : nvrtcGetPTX;
-#else
-      const auto getSize = nvrtcGetPTXSize;
-      const auto getFunc = nvrtcGetPTX;
-#endif
-      NVRTC_SAFE_CALL(getSize(program, &ptx_size));
-      ptx.resize(ptx_size);
-      NVRTC_SAFE_CALL(getFunc(program, ptx.data()));
-    }
-
-    if (kernel_db.enabled() && kernel_code.has_value()) {
+    if (use_kernel_db) {
       auto result = kernel_db.write(
-          kernel_code.value(), compile_args, lowered_kernel_name_str, ptx);
+          kernel_code.value(),
+          compile_args,
+          lowered_kernel_name_str,
+          object_code);
       if (!result) {
         TORCH_WARN(
             "kernel_db was unable to write kernel: ", lowered_kernel_name_str);
       }
     }
-
-#if CUDA_VERSION >= 11010
-    binary = dumpCompiledCode(program, compile_to_sass);
-
-    if (isDebugDumpEnabled(DebugDumpOption::Ptx) ||
-        isDebugDumpEnabled(DebugDumpOption::Cubin)) {
-      dumpCompiledCodeToFile(binary, id, compile_to_sass);
-    }
-
-    if (!return_compiled_binary) {
-      binary.clear();
-    }
-#endif
   }
 
-  NvrtcFunction compiled_kernel_;
+  NvrtcFunction compiled_kernel;
 
-  {
-    FUSER_PERF_SCOPE("executor_utils::Nvrtc::LoadPTX");
+  log << module_load.invoke(compiled_kernel.module, object_code.data())
+      << std::endl;
 
-    // load ptx or cubin directly
-    CUDA_SAFE_CALL(cuModuleLoadDataEx(
-        &(compiled_kernel_.module),
-        ptx.data(),
-        options.size(),
-        options.data(),
-        option_vals.data()));
-
-    if (!compile_to_sass &&
-        isDebugDumpEnabled(DebugDumpOption::PrintPtxasLog)) {
-      std::cout << info_log.data() << std::endl;
-    }
+  if (isOptionEnabled(EnableOption::WarnRegisterSpill)) {
+    warnRegisterSpill(log.str());
   }
 
   CUDA_SAFE_CALL(cuModuleGetFunction(
-      &(compiled_kernel_.function),
-      compiled_kernel_.module,
+      &(compiled_kernel.function),
+      compiled_kernel.module,
       lowered_kernel_name_str.c_str()));
+
+  if (!return_compiled_binary) {
+    binary.clear();
+  }
 
   TORCH_CHECK(
       !isOptionDisabled(DisableOption::ArchCheck),
       "NVFuser Compile: arch check disabled, should not return any compiled kernel");
 
-  return {compiled_kernel_, ptxas_log.str(), binary};
+  return {compiled_kernel, log.str(), binary};
 }
 
 namespace caching {

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -288,7 +288,7 @@ bool validateKernelArg(
     const Val* param,
     const c10::Device& device,
     std::stringstream& msg) {
-  // clang-tidy complains that arg may be null without tis assertion
+  // clang-tidy complains that arg may be null without this assertion
   TORCH_INTERNAL_ASSERT(arg != nullptr);
   if (auto tensor_arg_abstract = dynamic_cast<const TensorArgAbstract*>(arg)) {
     // TODO: don't use get tensor here. We would want to remove tensor reference

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -1414,6 +1414,7 @@ std::tuple<NvrtcFunction, std::string, std::vector<char>> getCompiledKernel(
   bool compile_to_sass = false;
   queryTargetGPUVersion(prop, major, minor, compile_to_sass);
 
+  // TODO: Do we still need this? PyTorch requires CUDA 11 or later.
 #if CUDA_VERSION < 11010
   // compile to sass is not allowed prior to CUDA 11.1
   compile_to_sass = false;

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -94,7 +94,7 @@ struct NvrtcFunction {
 };
 
 // Returns executable function and the ptxas log from compilation
-std::tuple<NvrtcFunction, std::string, std::vector<char>> nvrtcCompile(
+std::tuple<NvrtcFunction, std::string, std::vector<char>> getCompiledKernel(
     c10::optional<std::reference_wrapper<const std::string>> kernel_code,
     const std::string& code,
     const std::string& func_name,


### PR DESCRIPTION
Did some cleanups around `nvrtcCompileProgram`. The interface of nvrtc and cuModuleLoadDataEx is quite ugly as it expects options passed as `char**` or `void**`. Managing option values needs careful memory management as we can't just pass `std::string`.

This PR adds two helper classes for them:

- `NvrtcCompileDriver`
- `CuModuleLoadDataDriver`

Both are meant to encapsulate the management of option values, so now adding a new option is just calling the `setOption` method of the helper class. Invoking `nvrtcCompileProgram` through the helper class ensures the options are correctly configured and passed to `nvrtcCompileProgram`.

I also refactored `executor_utils::nvrtcCompile`. Previously there's a lot more done than just invoking nvrtcCompileProgram, including option configurations, kernel DB query/save, setting up nvrtcProgram, etc. Hopefully, the updated version, which I renamed to `getCompiledKernel`, gives a clearer view to what's actually done there.