### PR TITLE
Print `cp.async` predicate

### DIFF
--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -1686,9 +1686,15 @@ LoadStoreOp::LoadStoreOp(
 
 std::string LoadStoreOp::toString(int indent_size) const {
   std::stringstream ss;
+  std::string optype = load_store_type2string(opType());
   indent(ss, indent_size) << out()->toString() << "\n";
-  indent(ss, indent_size + 1)
-      << " = " << opType() << "( " << in()->toString() << " )\n";
+  indent(ss, indent_size + 1) << " = " << optype << "( " << in()->toString();
+  if (predicate()) {
+    ss << ", " << std::endl;
+    indent(ss, indent_size + 1)
+        << std::string(optype.size() + 5, ' ') << predicate()->toInlineString();
+  }
+  ss << " )\n";
   return ss.str();
 }
 

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -670,7 +670,7 @@ static const char* thread_size2string(ParallelType t) {
   }
 }
 
-static const char* load_store_type2string(LoadStoreOpType t) {
+const char* load_store_type2string(LoadStoreOpType t) {
   switch (t) {
     case LoadStoreOpType::LdMatrix:
       return "LdMatrix";

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -633,6 +633,7 @@ TORCH_CUDA_CU_API c10::optional<std::string> inline_op_str(const RNGOpType);
 TORCH_CUDA_CU_API c10::optional<std::string> integer_op_str(const BinaryOpType);
 TORCH_CUDA_CU_API c10::optional<std::string> bool_op_str(const BinaryOpType);
 TORCH_CUDA_CU_API const char* predicate_type2string(PredicateType t);
+TORCH_CUDA_CU_API const char* load_store_type2string(LoadStoreOpType t);
 
 TORCH_CUDA_CU_API c10::optional<std::string> cast_func_str(
     const std::pair<DataType, DataType>&);


### PR DESCRIPTION
`cp.async` uses inline predicate, that is, the predicate is passed as an argument to the function call instead of protecting the expr inside an `if` block. As a result, we can not see the predicate information in the printed kernel ir. This makes the debugging not convenient because we don't know when the predicate is created, when the predicated is indexed, and what the indexed predicate is. With the change in this PR, we can clearly see how the predicate is generated during lowering:

Using
```
PYTORCH_NVFUSER_DUMP="lower_verbose" ./build/bin/nvfuser_tests --gtest_filter=*FusionAmpereMatmul_CUDA*
```

We can see before `UnrollPass`, the `cp.async` is printed as:
(tensors are not indexed, and there is no predicated)
```C++
T6_s[ iblockIdx.x45{( ceilDiv(T0.size[0], 128) )}, iS47{( ceilDiv(T0.size[1], 32) )}, iS112{( ceilDiv(( 128 * 32 ), 1024) )}, ithreadIdx.z118{( ceilDiv(( ceilDiv(( ceilDiv(1024, 8) ), 32) ), 2) )}, ithreadIdx.y119{2}, ithreadIdx.x117{32}, iV115{8} ] ca_pos( 2 )
    = CpAsyncCg( T0_g[ iS49{( ceilDiv(T0.size[0], 128) )}, iS51{( ceilDiv(T0.size[1], 32) )}, iS50{128}, iS52{32} ] )
```
after `UnrollPass` and before `IndexLowering`, the `cp.async` is printed as:
(tensors are not indexed, a `Vectorize` predicate is generated but not indexed)
```C++
T6_s[ iblockIdx.x45{( ceilDiv(T0.size[0], 128) )}, iS47{( ceilDiv(T0.size[1], 32) )}, iS112{( ceilDiv(( 128 * 32 ), 1024) )}, ithreadIdx.z118{( ceilDiv(( ceilDiv(( ceilDiv(1024, 8) ), 32) ), 2) )}, ithreadIdx.y119{2}, ithreadIdx.x117{32}, iV115{8} ] ca_pos( 2 )
    = CpAsyncCg( T0_g[ iS49{( ceilDiv(T0.size[0], 128) )}, iS51{( ceilDiv(T0.size[1], 32) )}, iS50{128}, iS52{32} ], 
                 Vectorize )
```
after `IndexLowering` and before `generateConditionalFromPredicate`, the `cp.async` is printed as:
(tensors are indexed, predicate is not indexed)
```C++
T6_s[( ( ( ( ( ( BaseAddress(T6) ) + ( 16 * threadIdx.x ) ) + ( 512 * threadIdx.y ) ) + ( 1024 * threadIdx.z ) ) + ( 8192 * ( ( 3 + i488 ) % 4 ) ) ) + ( 2048 * i471 ) )] view( T6 )
    = CpAsyncCg( T0_g[( ( ( ( ( ( ( ( 96 + ( BaseAddress(T0) ) ) + ( T0.size[1] * ( threadIdx.x / 4 ) ) ) + ( 8 * ( threadIdx.x % 4 ) ) ) + ( ( T0.size[1] * 8 ) * threadIdx.y ) ) + ( ( T0.size[1] * 16 ) * threadIdx.z ) ) + ( ( T0.size[1] * 128 ) * blockIdx.x ) ) + ( 32 * i488 ) ) + ( ( T0.size[1] * 32 ) * i471 ) )] view( T0 ), 
                 Vectorize )
```
and after `IndexLowering`, the `cp.async` is printed as:
(tensors are indexed, predicate is also indexed)
```C++
T6_s[( ( ( ( ( ( BaseAddress(T6) ) + ( 16 * threadIdx.x ) ) + ( 512 * threadIdx.y ) ) + ( 1024 * threadIdx.z ) ) + ( 8192 * ( ( 3 + i488 ) % 4 ) ) ) + ( 2048 * i471 ) )] view( T6 )
    = CpAsyncCg( T0_g[( ( ( ( ( ( ( ( 96 + ( BaseAddress(T0) ) ) + ( T0.size[1] * ( threadIdx.x / 4 ) ) ) + ( 8 * ( threadIdx.x % 4 ) ) ) + ( ( T0.size[1] * 8 ) * threadIdx.y ) ) + ( ( T0.size[1] * 16 ) * threadIdx.z ) ) + ( ( T0.size[1] * 128 ) * blockIdx.x ) ) + ( 32 * i488 ) ) + ( ( T0.size[1] * 32 ) * i471 ) )] view( T0 ), 
                 Vectorize ( ( ( ( 103 + ( 8 * ( threadIdx.x % 4 ) ) ) + ( 32 * i488 ) ) < T0.size[1] ) & ( ( ( ( ( ( -T0.size[0] ) + ( threadIdx.x / 4 ) ) + ( 8 * threadIdx.y ) ) + ( 16 * threadIdx.z ) ) + ( 128 * blockIdx.x ) ) < ( -( 32 * i471 ) ) ) ) )
```