### PR TITLE
MmaOp - consistency checks for basic matmul

### DIFF
--- a/csrc/ir_internal_nodes.h
+++ b/csrc/ir_internal_nodes.h
@@ -1044,6 +1044,8 @@ class TORCH_CUDA_CU_API MmaOp : public Expr {
     }
   };
 
+  using AxesData = std::vector<int>;
+  using MmaInputLayoutOpt = c10::optional<MmaOptions::MmaInputLayout>;
   using Expr::Expr;
 
   MmaOp(IrBuilderPasskey, Val* out, Val* in_a, Val* in_b, Val* init);
@@ -1082,7 +1084,7 @@ class TORCH_CUDA_CU_API MmaOp : public Expr {
   }
 
   const auto& options() const {
-    return attribute(1)->as<Attribute<OptionsInMma>>()->value;
+    return attribute(ATTR_POS_OPTS)->as<Attribute<OptionsInMma>>()->value;
   }
 
   auto accStride() const {
@@ -1090,6 +1092,40 @@ class TORCH_CUDA_CU_API MmaOp : public Expr {
   }
 
   void configureOptions(MmaOptions options);
+
+  auto inputLayout() const {
+    return attribute(ATTR_POS_INPUT_LAYOUT)
+        ->as<Attribute<MmaInputLayoutOpt>>()
+        ->value;
+  }
+
+  const auto& mAxes() const {
+    return attribute(ATTR_POS_M_AXES)->as<Attribute<AxesData>>()->value;
+  }
+
+  const auto& nAxes() const {
+    return attribute(ATTR_POS_N_AXES)->as<Attribute<AxesData>>()->value;
+  }
+
+  const auto& kAxes() const {
+    return attribute(ATTR_POS_K_AXES)->as<Attribute<AxesData>>()->value;
+  }
+
+  const auto& batchAxes() const {
+    return attribute(ATTR_POS_BATCH_AXES)->as<Attribute<AxesData>>()->value;
+  }
+
+ private:
+  // Predefined idexes of attributes stored for this IR node, to avoid
+  //  magic numbers, based on order in which attributes are initialized
+  //  in constructor
+  static constexpr size_t ATTR_POS_INIT = 0;
+  static constexpr size_t ATTR_POS_OPTS = 1;
+  static constexpr size_t ATTR_POS_M_AXES = 2;
+  static constexpr size_t ATTR_POS_N_AXES = 3;
+  static constexpr size_t ATTR_POS_K_AXES = 4;
+  static constexpr size_t ATTR_POS_BATCH_AXES = 5;
+  static constexpr size_t ATTR_POS_INPUT_LAYOUT = 6;
 };
 
 class TORCH_CUDA_CU_API ExpandOp : public Expr {

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -14,8 +14,6 @@
 // 'SchedulerRuntimeInfo'
 #include <executor_utils.h>
 
-#include <sstream>
-
 namespace nvfuser {
 
 namespace {

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -125,87 +125,6 @@ inline c10::optional<MmaOptions::MacroType> getMmaOp(
   return c10::nullopt;
 }
 
-//! A helper for checking if layout of MMA op's inputs. It will return optional
-//! message if check fails.
-LayoutData getInputsLayout(const MmaOp* mma_expr) {
-  std::stringstream ss;
-  const auto& mmaExprInputs = mma_expr->inputs();
-
-  const auto* in_A = mmaExprInputs[0]->as<TensorView>();
-  const auto* in_B = mmaExprInputs[1]->as<TensorView>();
-
-  // The number of IterDomains of MMA inputs must be the same
-  if (in_A->nDims() != in_B->nDims()) {
-    ss << "Mma op inputs don't have the same number of IterDomains, 1st input("
-       << std::to_string(in_A->nDims()) << "), 2nd input("
-       << std::to_string(in_B->nDims()) + ")";
-    return {c10::nullopt, ss.str()};
-  }
-
-  // The currently supported number of IterDomains per MMA op input is 3
-  constexpr size_t supportedDims = 3;
-  if (in_A->nDims() != supportedDims) {
-    ss << "Mma op inputs have unsupported number of IterDomains, got: "
-       << std::to_string(in_A->nDims()) << ", expected "
-       << std::to_string(supportedDims);
-    return {c10::nullopt, ss.str()};
-  }
-
-  using AxisPos = decltype(std::declval<TensorView>().nDims());
-  constexpr AxisPos unInitPos = -1;
-  AxisPos bcastInApos = unInitPos;
-  AxisPos bcastInBpos = unInitPos;
-
-  // The first and the second input of MMA have the same number of
-  // IterDomains
-  for (AxisPos pos = 0; pos < in_A->nDims(); ++pos) {
-    if (in_A->axis(static_cast<int>(pos))->isBroadcast()) {
-      if (bcastInApos != unInitPos) {
-        ss << "Mma op first input has more than one broadcast IterDomain: "
-           << std::to_string(bcastInApos) << " and " << std::to_string(pos);
-        return {c10::nullopt, ss.str()};
-      }
-      bcastInApos = pos;
-    }
-    if (in_B->axis(static_cast<int>(pos))->isBroadcast()) {
-      if (bcastInBpos != unInitPos) {
-        ss << "Mma op second input has more than one broadcast IterDomain: "
-           << std::to_string(bcastInBpos) << " and " << std::to_string(pos);
-        return {c10::nullopt, ss.str()};
-      }
-      bcastInBpos = pos;
-    }
-  }
-
-  // MMA inputs need to have broadcast IterDomains
-  if (bcastInApos == unInitPos || bcastInBpos == unInitPos) {
-    ss << "The " << (bcastInApos == unInitPos ? "first" : "second")
-       << " mma op has no broadcast IterDomain";
-    return {c10::nullopt, ss.str()};
-  }
-
-  // MMA inputs must have supported data layout, defined in MatmulLayout
-  // MatmulLayout::TT
-  if (bcastInApos == static_cast<size_t>(2) &&
-      bcastInBpos == static_cast<size_t>(0)) {
-    return {MatmulLayout::TT, c10::nullopt};
-  }
-  // MatmulLayout::TN
-  if (bcastInApos == static_cast<size_t>(1) &&
-      bcastInBpos == static_cast<size_t>(0)) {
-    return {MatmulLayout::TN, c10::nullopt};
-  }
-  // MatmulLayout::NT
-  if (bcastInApos == static_cast<size_t>(2) &&
-      bcastInBpos == static_cast<size_t>(1)) {
-    return {MatmulLayout::NT, c10::nullopt};
-  }
-
-  ss << "Unsupported layout, broadcasts: inputA(" << bcastInApos << "), inputB("
-     << bcastInBpos << ")";
-  return {c10::nullopt, ss.str()};
-}
-
 //! A wrapper for core heuristics initialization
 inline bool initCoreHeuristics(
     std::shared_ptr<MatmulParams> params,
@@ -345,7 +264,7 @@ c10::optional<ProblemShape> getProblemShape(
   const auto getShape = [&runtime_info](const TensorView* tv) {
     TensorShape tv_shape;
     const auto concrete_domains = TensorDomain::noReductions(
-        TensorDomain::noBroadcasts(tv->as<TensorView>()->domain()->domain()));
+        TensorDomain::noBroadcasts(tv->domain()->domain()));
     for (const auto* domain : concrete_domains) {
       const auto domain_extend =
           runtime_info.expressionEvaluator().evaluate(domain->extent());
@@ -436,7 +355,19 @@ std::string checkMatmulType(Fusion* fusion, const MmaOp* mma_expr) {
   constexpr size_t expected_number_of_inputs = 2;
   constexpr size_t expected_number_of_outputs = 1;
 
-  // Quick checks
+  // Quick checks - MmaOp
+  {
+    // Check if MmaOp processes single gemm
+    constexpr size_t expected_axes_numbers = 1;
+    if (mma_expr->mAxes().size() != expected_axes_numbers ||
+        mma_expr->nAxes().size() != expected_axes_numbers ||
+        mma_expr->kAxes().size() != expected_axes_numbers ||
+        !mma_expr->batchAxes().empty()) {
+      return "MmaOp has unsupported number of one of M/N/K/Batch axes";
+    }
+  }
+
+  // Quick checks - Fusion
   {
     // Fusion can only have two TV inputs
     if (fusion_inputs.size() != fusion_inputs_tvs.size()) {
@@ -446,12 +377,9 @@ std::string checkMatmulType(Fusion* fusion, const MmaOp* mma_expr) {
       return "Fusion inputs contain at least one non-TensorView object";
     }
 
-    // Fusion can only have TVs as outputs, and there can be only one output
-    if (fusion_outputs_tvs.size() != fusion_outputs.size()) {
-      return "Fusion has output which is not a TensorView object";
-    }
+    // Fusion has only TVs as outputs, and we expect only one object in the list
     if ((expected_number_of_outputs != fusion_outputs_tvs.size())) {
-      return "Fusion has more than a single TensorView object in outputs";
+      return "Fusion has more than a single TensorView object in its outputs";
     }
 
     // Each of fusion input TVs must have:
@@ -548,9 +476,9 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
   // #2
   {
     for (const auto* mma_expr : mma_exprs) {
-      const auto layout_data = getInputsLayout(mma_expr);
-      if (layout_data.second) {
-        return layout_data.second.value();
+      const auto input_layout = mma_expr->inputLayout();
+      if (!input_layout) {
+        return "Failed to acquire inputs layout.";
       }
     }
   }
@@ -578,16 +506,15 @@ std::shared_ptr<MatmulParams> getMatmulHeuristics(
   auto params = std::make_shared<MatmulParams>();
 
   // Check initial conditions
-  const auto fusion_exprs = fusion->exprs();
-  auto mma_exprs = ir_utils::filterByType<MmaOp>(fusion_exprs).vector();
+  auto mma_exprs = ir_utils::getMmaOps(fusion);
   TORCH_INTERNAL_ASSERT(
       mma_exprs.size() == 1, "Support only fusion with a single mma op.");
 
-  const auto layout = getInputsLayout(mma_exprs.front());
-  TORCH_INTERNAL_ASSERT(!layout.second.has_value(), layout.second.value());
+  const auto layout = mma_exprs.front()->inputLayout();
+  TORCH_INTERNAL_ASSERT(layout.has_value(), "Failed to acquire inputs layout.");
 
   const auto problem_shape = getProblemShape(
-      fusion, mma_exprs[0]->as<MmaOp>(), runtime_info, layout.first.value());
+      fusion, mma_exprs[0]->as<MmaOp>(), runtime_info, layout.value());
   TORCH_INTERNAL_ASSERT(
       problem_shape.has_value(), "Failed to acquire problem shape.");
 
@@ -599,7 +526,7 @@ std::shared_ptr<MatmulParams> getMatmulHeuristics(
 
   // Populate heuristic details
   auto status = initCoreHeuristics(
-      params, mma_op.value(), layout.first.value(), problem_shape.value());
+      params, mma_op.value(), layout.value(), problem_shape.value());
   TORCH_INTERNAL_ASSERT(
       status, "Core part of heuristics failed to initialize.");
 
@@ -607,7 +534,7 @@ std::shared_ptr<MatmulParams> getMatmulHeuristics(
   TORCH_INTERNAL_ASSERT(
       status, "Additional part of heuristics failed to initialize.");
 
-  // set kernel index mode
+  // Set kernel index mode
   params->cparams.index_type = getIndexType(problem_shape.value());
 
   if (isDebugDumpEnabled(DebugDumpOption::MatmulChecks)) {

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -3133,6 +3133,17 @@ TEST_F(NVFuserTest, FusionMatmulSegmenterBasicMatmulStrictCheckTT_CUDA) {
   fusion->addInput(tv1);
   fusion->addOutput(tv2);
 
+  TORCH_CHECK(
+      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      "matmul fusion must have at least one MmaOp");
+  TORCH_CHECK(
+      ir_utils::getMmaOps(fusion.get()).front()->inputLayout().has_value(),
+      "input layout has not be set for MmaOp");
+  TORCH_CHECK(
+      layout ==
+          ir_utils::getMmaOps(fusion.get()).front()->inputLayout().value(),
+      "input layout from test and MmaOp do not match");
+
   at::manual_seed(0);
 
   at::Tensor t0 = matmulAtInput(M, N, K, layout, TensorMatmulPos::A, at::kHalf);
@@ -3173,6 +3184,17 @@ TEST_F(NVFuserTest, FusionMatmulSegmenterBasicMatmulRelaxedCheck_CUDA) {
     fusion->addInput(tv0);
     fusion->addInput(tv1);
     fusion->addOutput(tv2);
+
+    TORCH_CHECK(
+        1 == ir_utils::getMmaOps(fusion.get()).size(),
+        "matmul fusion must have at least one MmaOp");
+    TORCH_CHECK(
+        ir_utils::getMmaOps(fusion.get()).front()->inputLayout().has_value(),
+        "input layout has not be set for MmaOp");
+    TORCH_CHECK(
+        layout ==
+            ir_utils::getMmaOps(fusion.get()).front()->inputLayout().value(),
+        "input layout from test and MmaOp do not match");
 
     at::manual_seed(0);
 


### PR DESCRIPTION
### The goal of this PR:
- when MmaOp is constructed there are no checks to validate if provided parameters (inputs/outputs) are valid,
- this resulted in implementing consistency checks as rules in compile time checks in matmul scheduler,
- this PR covers part of follow-up tasks mentioned [this comment](https://github.com/NVIDIA/Fuser/pull/23#discussion_r1156366522) in #23 

### The scope of changes:
- move some checks from compile time checks in matmul scheduler to `MmaOp` constructor,
- gather M / N / K / Batch axes from MmaOp inputs/outputs,
- move input layout check from matmul scheduler compile time checks to MmaOp constructor,
- M / N / K / Batch axes and inputs' layout are stored as attributes in MmaOp object,

Tests will be re-enabled with follow up PR that will add in MmaOp handling of scenarios covered by these tests.

### Verification results:
- c++ tests
  - cmd:
  `.build/bin/nvfuser_tests`
  - result:
  `all tests passed`

cc @mmigdal-nv 