### PR TITLE
Workaround for no-input fusion with reduction

### DIFF
--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -1271,6 +1271,13 @@ class ReductionScheduler : public SchedulerEntry {
       return false;
     }
 
+    if (ir_utils::filterByType<TensorView>(fusion->inputs()).empty()) {
+      scheduler_debug_utils::canScheduleRejectReason(
+          ScheduleHeuristic::Reduction,
+          "Scheduling not supported with no input");
+      return false;
+    }
+
     // Check that inputs of all select/gather-like ops are fusion inputs
     if (rejectScheduleForSelectLikeOps(fusion, ScheduleHeuristic::Reduction)) {
       return false;
@@ -1650,6 +1657,13 @@ class PersistentKernelScheduler : public SchedulerEntry {
     if (reduction_ops.empty()) {
       scheduler_debug_utils::canScheduleRejectReason(
           ScheduleHeuristic::Persistent, "needs a reduction op");
+      return false;
+    }
+
+    if (ir_utils::filterByType<TensorView>(fusion->inputs()).empty()) {
+      scheduler_debug_utils::canScheduleRejectReason(
+          ScheduleHeuristic::Persistent,
+          "Scheduling not supported with no input");
       return false;
     }
 


### PR DESCRIPTION
The reduction and persistent schedulers assume a fusion has inputs, and there's no check in their `canScheduleCompileTime`, so they just fail when scheduling a fusion if there's no input. This PR avoids the failure by rejecting the schedulers if no input is available.

Here's an example fusion, which is a segment of the fusion defined by the repro #132.

```
T6_l[ iS12{4}, iS13{4} ]
   = full({4, 4}, ( (double)(0) ));
T7_g[ iS14{4}, rS15{4} ]
   = reduction( T6_l[ iS12{4}, iS13{4} ], op = add, initial value = double(0), allreduce = false )
```

This is a WAR. Ideally, we should be able to support reductions with no input. That's not addressed in this PR.

Closes #132 