### PR TITLE
Refactor transpose and set

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1164,7 +1164,7 @@ class CudaKernelGenerator : private OptOutConstDispatch {
         auto mma = dynamic_cast<MmaOp*>(out_tv->definition());
         TORCH_INTERNAL_ASSERT(
             mma != nullptr, "CodeGen: mma op not in mma loop");
-        TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Automatic);
+        TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Set);
         genMmaInitialization(mma, ldst);
         return;
       }
@@ -1219,7 +1219,7 @@ class CudaKernelGenerator : private OptOutConstDispatch {
 
       // dispatch vectorized load/store
       if (is_vector_op) {
-        TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Automatic);
+        TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Set);
         if (ldst->in()->isScalar()) {
           // Note:
           //  Double buffered local tensors need indexed initialization,
@@ -1293,7 +1293,7 @@ class CudaKernelGenerator : private OptOutConstDispatch {
     }
 
     // Generic set op
-    TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Automatic);
+    TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Set);
 
     if (!print_inline_) {
       indent() << gen(ldst->out());

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -563,139 +563,6 @@ class CudaKernelGenerator : private OptOutConstDispatch {
   }
 
   void handle(const UnaryOp* uop) final {
-    bool is_vector_op = false;
-    size_t vector_word_size = 1;
-
-    if (uop->out()->isA<kir::TensorIndex>()) {
-      auto out_tv = uop->out()->as<kir::TensorIndex>()->view();
-      if (std::any_of(
-              out_tv->domain()->domain().begin(),
-              out_tv->domain()->domain().end(),
-              [&](IterDomain* id) { return id->isMma(); })) {
-        auto mma = dynamic_cast<MmaOp*>(
-            uop->out()->as<kir::TensorIndex>()->view()->definition());
-        TORCH_INTERNAL_ASSERT(
-            mma != nullptr, "CodeGen: mma op not in mma loop");
-        genMmaInitialization(mma, uop);
-        return;
-      }
-    }
-
-    if (vectorize_scope_ && uop->out()->isA<kir::TensorIndex>()) {
-      auto ti = uop->out()->as<kir::TensorIndex>();
-
-      bool vectorize_op = false;
-      bool misaligned_op = false;
-
-      for (auto id : ti->view()->domain()->domain()) {
-        if (!isParallelTypeVectorize(id->getParallelType())) {
-          continue;
-        }
-
-        TORCH_INTERNAL_ASSERT(
-            id->extent()->isConstInt(),
-            "Could not evaluate constant value bound to vectorized dim.");
-
-        vector_word_size = id->extent()->evaluateInt();
-
-        vectorize_op = id->getParallelType() == ParallelType::Vectorize;
-        misaligned_op =
-            id->getParallelType() == ParallelType::MisalignedVectorize;
-        break;
-      }
-
-      if (vectorize_op) {
-        TORCH_INTERNAL_ASSERT(
-            uop->getUnaryOpType() == UnaryOpType::Set,
-            "Cannot vectorize operations that are not sets. ",
-            "Use cacheBefore and cacheAfter to store/load with vectorized reads into buffers.");
-        is_vector_op = true;
-      }
-
-      if (misaligned_op) {
-        is_vector_op = (uop->getUnaryOpType() == UnaryOpType::Set);
-      }
-
-      if (is_vector_op && !uop->in()->isScalar()) {
-        TORCH_INTERNAL_ASSERT(
-            uop->out()->dtype() == uop->in()->dtype(),
-            "Vectorized store/load requires input and output datatypes match.");
-      }
-
-      if (is_vector_op) {
-        auto out_tv = uop->out()->as<kir::TensorIndex>()->view();
-        if (uop->in()->isScalar()) {
-          // Note:
-          //  Double buffered local tensors need indexed initialization,
-          //   so will need to use `arraySet` option.
-          if (out_tv->getMemoryType() == MemoryType::Local &&
-              !(out_tv->isDoubleBuffered() || out_tv->isCircularBuffered())) {
-            // Vectorized initialization, explicit type conversion is needed for
-            // complex numbers
-            indent() << ir_utils::varName(out_tv) << ".set("
-                     << genCall(out_tv->dtype(), gen(uop->in())) << ");\n";
-          } else {
-            // Note: currently arraySet option is not vectorized, so it will
-            //  rely on auto vectorization pass of cuda compiler.
-            indent() << "arraySet<" << out_tv->getDataType().value() << ", "
-                     << vector_word_size << ">(&" << gen(uop->out()) << ", "
-                     << "(" << out_tv->getDataType().value() << ")"
-                     << gen(uop->in()) << ");\n";
-          }
-        } else {
-          // Vectorized load
-          TORCH_INTERNAL_ASSERT(
-              uop->in()->isA<kir::TensorIndex>(),
-              "Invalid input to unary op with tensor output, found: ",
-              uop->in()->toString());
-
-          auto in_tv = uop->in()->as<kir::TensorIndex>()->view();
-          bool localToGlobal = out_tv->getMemoryType() == MemoryType::Global &&
-              in_tv->getMemoryType() == MemoryType::Local;
-
-          bool globalToLocal = out_tv->getMemoryType() == MemoryType::Local &&
-              in_tv->getMemoryType() == MemoryType::Global;
-
-          bool globalToGlobal = out_tv->getMemoryType() == MemoryType::Global &&
-              in_tv->getMemoryType() == MemoryType::Global;
-
-          bool is_volatile_to = out_tv->getMemoryType() == MemoryType::Global &&
-              kernel_->summary().sync_map->needsRawSync(out_tv).hasBID();
-
-          bool is_volatile_from =
-              in_tv->getMemoryType() == MemoryType::Global &&
-              kernel_->summary().sync_map->needsRawSync(in_tv).hasBID();
-
-          if (localToGlobal) {
-            indent() << "loadLocalToGlobal<" << uop->out()->dtype() << ", "
-                     << vector_word_size << ", "
-                     << (is_volatile_to ? "true" : "false") << ">(";
-            code_ << " &" << gen(uop->out()) << ", &" << gen(uop->in())
-                  << ");\n";
-          } else if (globalToLocal) {
-            indent() << "loadGlobalToLocal<" << uop->out()->dtype() << ", "
-                     << vector_word_size << ", "
-                     << (is_volatile_from ? "true" : "false") << ">(&"
-                     << gen(uop->out()) << ", ";
-            code_ << " &" << gen(uop->in()) << ");\n";
-          } else if (globalToGlobal) {
-            indent() << "loadGlobalToGlobal<" << uop->out()->dtype() << ", "
-                     << vector_word_size << ", "
-                     << (is_volatile_to ? "true" : "false") << ", "
-                     << (is_volatile_from ? "true" : "false") << ">(";
-            code_ << " &" << gen(uop->out()) << ", ";
-            code_ << " &" << gen(uop->in()) << ");\n";
-          } else {
-            indent() << "loadGeneric<" << uop->out()->dtype() << ", "
-                     << vector_word_size << ">(";
-            code_ << " &" << gen(uop->out()) << ", ";
-            code_ << " &" << gen(uop->in()) << ");\n";
-          }
-        }
-        return;
-      }
-    }
-
     const auto op_type = uop->getUnaryOpType();
 
     if (!print_inline_) {
@@ -1101,14 +968,14 @@ class CudaKernelGenerator : private OptOutConstDispatch {
              << "])";
   }
 
-  void genMmaInitialization(const MmaOp* mma, const UnaryOp* uop) {
+  void genMmaInitialization(const MmaOp* mma, const LoadStoreOp* ldst) {
     auto options = mma->options();
 
     indent() << genMmaOp(mma, true) << "(reinterpret_cast<Array<"
              << mma->out()->getDataType().value() << ","
              << getOutputRegisterSize(options.macro) << ","
              << getOutputRegisterSize(options.macro) << ">*>"
-             << "(&" << gen(uop->out()) << "));\n";
+             << "(&" << gen(ldst->out()) << "));\n";
   }
 
   void handle(const MmaOp* mma) final {
@@ -1284,46 +1151,161 @@ class CudaKernelGenerator : private OptOutConstDispatch {
   }
 
   void handle(const LoadStoreOp* ldst) final {
-    // TODO:
-    //  Need to gradually merge the code path of this
-    //   with UnaryOp::Set for vectorization.
-    //  There is quite a bit of possible clean up.
-    bool vectorize_op = false;
-    size_t vector_word_size = 1;
-    auto ti = ldst->out()->as<kir::TensorIndex>();
+    auto optype = ldst->opType();
+    if (ldst->out()->isA<kir::TensorIndex>()) {
+      auto out_ti = ldst->out()->as<kir::TensorIndex>();
+      auto out_tv = out_ti->view();
 
-    // Check vectorization and set vector word size
-    for (auto id : ti->view()->domain()->domain()) {
-      if (!isParallelTypeVectorize(id->getParallelType())) {
-        continue;
+      // dispatch mma initialization
+      if (std::any_of(
+              out_tv->domain()->domain().begin(),
+              out_tv->domain()->domain().end(),
+              [&](IterDomain* id) { return id->isMma(); })) {
+        auto mma = dynamic_cast<MmaOp*>(out_tv->definition());
+        TORCH_INTERNAL_ASSERT(
+            mma != nullptr, "CodeGen: mma op not in mma loop");
+        TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Automatic);
+        genMmaInitialization(mma, ldst);
+        return;
       }
 
-      TORCH_INTERNAL_ASSERT(
-          id->extent()->isConstInt(),
-          "Could not evaluate constant value bound to vectorized dim.");
+      // Get vectorization information
+      bool is_vector_op = false;
+      size_t vector_word_size = 1;
 
-      TORCH_INTERNAL_ASSERT(
-          id->getParallelType() != ParallelType::MisalignedVectorize,
-          "LoadStoreOp: no support yet for mis-aligned vectorization");
-      vector_word_size = id->extent()->evaluateInt();
-      vectorize_op = true;
-      break;
+      if (vectorize_scope_ && ldst->out()->isA<kir::TensorIndex>()) {
+        for (auto id : out_tv->domain()->domain()) {
+          if (!isParallelTypeVectorize(id->getParallelType())) {
+            continue;
+          }
+
+          TORCH_INTERNAL_ASSERT(
+              id->extent()->isConstInt(),
+              "Could not evaluate constant value bound to vectorized dim.");
+
+          vector_word_size = id->extent()->evaluateInt();
+
+          is_vector_op = true;
+          break;
+        }
+      }
+
+      if (is_vector_op && !ldst->in()->isScalar()) {
+        TORCH_INTERNAL_ASSERT(
+            ldst->out()->dtype() == ldst->in()->dtype(),
+            "Vectorized store/load requires input and output datatypes match.");
+      }
+
+      // dispatch ldmatrix
+      if (optype == LoadStoreOpType::LdMatrix ||
+          optype == LoadStoreOpType::LdMatrixTranspose) {
+        TORCH_INTERNAL_ASSERT(
+            is_vector_op, "LdMatrix: Vectorization required: ", ldst);
+        genLdMatrix(ldst, vector_word_size);
+        return;
+      }
+
+      // dispatch cp.async
+      if (optype == LoadStoreOpType::CpAsyncCa ||
+          optype == LoadStoreOpType::CpAsyncCg) {
+        if (optype == LoadStoreOpType::CpAsyncCg) {
+          TORCH_INTERNAL_ASSERT(
+              is_vector_op && vector_word_size == 8,
+              "cp.async.cg only support vectorize 8");
+        }
+        genCpAsync(ldst, vector_word_size);
+        return;
+      }
+
+      // dispatch vectorized load/store
+      if (is_vector_op) {
+        TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Automatic);
+        if (ldst->in()->isScalar()) {
+          // Note:
+          //  Double buffered local tensors need indexed initialization,
+          //   so will need to use `arraySet` option.
+          if (out_tv->getMemoryType() == MemoryType::Local &&
+              !(out_tv->isDoubleBuffered() || out_tv->isCircularBuffered())) {
+            // Vectorized initialization, explicit type conversion is needed for
+            // complex numbers
+            indent() << ir_utils::varName(out_tv) << ".set("
+                     << genCall(out_tv->dtype(), gen(ldst->in())) << ");\n";
+          } else {
+            // Note: currently arraySet option is not vectorized, so it will
+            //  rely on auto vectorization pass of cuda compiler.
+            indent() << "arraySet<" << out_tv->getDataType().value() << ", "
+                     << vector_word_size << ">(&" << gen(ldst->out()) << ", "
+                     << "(" << out_tv->getDataType().value() << ")"
+                     << gen(ldst->in()) << ");\n";
+          }
+        } else {
+          // Vectorized load
+          TORCH_INTERNAL_ASSERT(
+              ldst->in()->isA<kir::TensorIndex>(),
+              "Invalid input to unary op with tensor output, found: ",
+              ldst->in()->toString());
+
+          auto in_tv = ldst->in()->as<kir::TensorIndex>()->view();
+          bool localToGlobal = out_tv->getMemoryType() == MemoryType::Global &&
+              in_tv->getMemoryType() == MemoryType::Local;
+
+          bool globalToLocal = out_tv->getMemoryType() == MemoryType::Local &&
+              in_tv->getMemoryType() == MemoryType::Global;
+
+          bool globalToGlobal = out_tv->getMemoryType() == MemoryType::Global &&
+              in_tv->getMemoryType() == MemoryType::Global;
+
+          bool is_volatile_to = out_tv->getMemoryType() == MemoryType::Global &&
+              kernel_->summary().sync_map->needsRawSync(out_tv).hasBID();
+
+          bool is_volatile_from =
+              in_tv->getMemoryType() == MemoryType::Global &&
+              kernel_->summary().sync_map->needsRawSync(in_tv).hasBID();
+
+          if (localToGlobal) {
+            indent() << "loadLocalToGlobal<" << ldst->out()->dtype() << ", "
+                     << vector_word_size << ", "
+                     << (is_volatile_to ? "true" : "false") << ">(";
+            code_ << " &" << gen(ldst->out()) << ", &" << gen(ldst->in())
+                  << ");\n";
+          } else if (globalToLocal) {
+            indent() << "loadGlobalToLocal<" << ldst->out()->dtype() << ", "
+                     << vector_word_size << ", "
+                     << (is_volatile_from ? "true" : "false") << ">(&"
+                     << gen(ldst->out()) << ", ";
+            code_ << " &" << gen(ldst->in()) << ");\n";
+          } else if (globalToGlobal) {
+            indent() << "loadGlobalToGlobal<" << ldst->out()->dtype() << ", "
+                     << vector_word_size << ", "
+                     << (is_volatile_to ? "true" : "false") << ", "
+                     << (is_volatile_from ? "true" : "false") << ">(";
+            code_ << " &" << gen(ldst->out()) << ", ";
+            code_ << " &" << gen(ldst->in()) << ");\n";
+          } else {
+            indent() << "loadGeneric<" << ldst->out()->dtype() << ", "
+                     << vector_word_size << ">(";
+            code_ << " &" << gen(ldst->out()) << ", ";
+            code_ << " &" << gen(ldst->in()) << ");\n";
+          }
+        }
+        return;
+      }
     }
 
-    // Dispatch instruction generation:
-    switch (ldst->opType()) {
-      case LoadStoreOpType::LdMatrix:
-      case LoadStoreOpType::LdMatrixTranspose:
-        TORCH_INTERNAL_ASSERT(
-            vectorize_op, "LdMatrix: Vectorization required: ", ldst);
-        genLdMatrix(ldst, vector_word_size);
-        break;
-      case LoadStoreOpType::CpAsyncCa:
-      case LoadStoreOpType::CpAsyncCg:
-        genCpAsync(ldst, vector_word_size);
-        break;
-      default:
-        TORCH_INTERNAL_ASSERT(false, "LoadStoreOp: Unknown op type");
+    // Generic set op
+    TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Automatic);
+
+    if (!print_inline_) {
+      indent() << gen(ldst->out());
+      if (!ldst->out()->isScalar() && !ldst->in()->isScalar()) {
+        code_ << "\n";
+        indent() << kTab;
+      }
+      code_ << " = ";
+    }
+    code_ << gen(ldst->in());
+    if (!print_inline_) {
+      code_ << ";\n";
     }
   }
 

--- a/csrc/dispatch.cpp
+++ b/csrc/dispatch.cpp
@@ -221,10 +221,6 @@ void Expr::dispatch(T handler, Expr* expr) {
     ptr(handler)->handle(expr->as<Resize>());
     return;
   }
-  if (expr->isStrictlyA<TransposeOp>()) {
-    ptr(handler)->handle(expr->as<TransposeOp>());
-    return;
-  }
   if (expr->isStrictlyA<ExpandOp>()) {
     ptr(handler)->handle(expr->as<ExpandOp>());
     return;
@@ -509,10 +505,6 @@ void Expr::constDispatch(T handler, const Expr* expr) {
   }
   if (expr->isStrictlyA<Resize>()) {
     ptr(handler)->handle(expr->as<Resize>());
-    return;
-  }
-  if (expr->isStrictlyA<TransposeOp>()) {
-    ptr(handler)->handle(expr->as<TransposeOp>());
     return;
   }
   if (expr->isStrictlyA<ExpandOp>()) {
@@ -921,9 +913,6 @@ void OptOutConstDispatch::handle(const Swizzle2D* stmt) {
 void OptOutConstDispatch::handle(const Resize* stmt) {
   unhandled(stmt);
 }
-void OptOutConstDispatch::handle(const TransposeOp* stmt) {
-  unhandled(stmt);
-}
 void OptOutConstDispatch::handle(const ExpandOp* stmt) {
   unhandled(stmt);
 }
@@ -1116,9 +1105,6 @@ void OptOutDispatch::handle(Swizzle2D* stmt) {
   unhandled(stmt);
 }
 void OptOutDispatch::handle(Resize* stmt) {
-  unhandled(stmt);
-}
-void OptOutDispatch::handle(TransposeOp* stmt) {
   unhandled(stmt);
 }
 void OptOutDispatch::handle(ExpandOp* stmt) {

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -96,7 +96,6 @@ class LoadStoreOp;
 class MmaOp;
 class BroadcastOp;
 class SqueezeOp;
-class TransposeOp;
 class ExpandOp;
 class ShiftOp;
 class GatherOp;
@@ -194,7 +193,6 @@ class TORCH_CUDA_CU_API OptOutConstDispatch : public PolymorphicBase {
   virtual void handle(const Merge* stmt);
   virtual void handle(const Swizzle2D* stmt);
   virtual void handle(const Resize* stmt);
-  virtual void handle(const TransposeOp* stmt);
   virtual void handle(const ExpandOp* stmt);
   virtual void handle(const ShiftOp* stmt);
   virtual void handle(const GatherOp* stmt);
@@ -276,7 +274,6 @@ class TORCH_CUDA_CU_API OptOutDispatch : public PolymorphicBase {
   virtual void handle(Merge* stmt);
   virtual void handle(Swizzle2D* stmt);
   virtual void handle(Resize* stmt);
-  virtual void handle(TransposeOp* stmt);
   virtual void handle(ExpandOp* stmt);
   virtual void handle(ShiftOp* stmt);
   virtual void handle(GatherOp* stmt);

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -400,6 +400,10 @@ int NaiveValueMachine::makeInstructionEntry() {
 
 void NaiveValueMachine::runInstruction(int index) {
   switch (inst_type_[index]) {
+    case InstructionType::SET_OP:
+      precomputed_values_.values_[dest_[index]] =
+          precomputed_values_.values_[src0_[index]];
+      break;
     case InstructionType::UNARY_OP:
       runUnaryOp(index);
       break;
@@ -426,9 +430,6 @@ void NaiveValueMachine::runUnaryOp(int index) {
   switch (uop_type_[index]) {
     case UnaryOpType::Neg:
       dest = -src;
-      break;
-    case UnaryOpType::Set:
-      dest = src;
       break;
     case UnaryOpType::Cast:
       if (data_type_[index] == DataType::Double) {

--- a/csrc/evaluator_common.h
+++ b/csrc/evaluator_common.h
@@ -30,7 +30,7 @@ class PrecomputedValues;
 class NaiveValueMachine {
   //! The generic types of instructions supported for this
   //!  machine, currently only binary and unary.
-  enum class InstructionType { UNARY_OP, BINARY_OP };
+  enum class InstructionType { UNARY_OP, BINARY_OP, SET_OP };
 
  public:
   //! Constructor lowers all the expr IR nodes stored in precomputed_values

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -2414,7 +2414,8 @@ void TranslateApplicableWelford::translateSingleWelford(WelfordOp* welford) {
       IrBuilder::create<Double>(0.0),
       out_var,
       x_mean_sub_pow);
-  IrBuilder::create<UnaryOp>(UnaryOpType::Set, out_N, num_features);
+  IrBuilder::create<LoadStoreOp>(
+      LoadStoreOpType::Automatic, out_N, num_features);
 
   // out_avg, out_N are now outputs of a pointwise ops and we
   //  need to clear out its reduction domains.

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -2414,8 +2414,7 @@ void TranslateApplicableWelford::translateSingleWelford(WelfordOp* welford) {
       IrBuilder::create<Double>(0.0),
       out_var,
       x_mean_sub_pow);
-  IrBuilder::create<LoadStoreOp>(
-      LoadStoreOpType::Set, out_N, num_features);
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out_N, num_features);
 
   // out_avg, out_N are now outputs of a pointwise ops and we
   //  need to clear out its reduction domains.

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -2415,7 +2415,7 @@ void TranslateApplicableWelford::translateSingleWelford(WelfordOp* welford) {
       out_var,
       x_mean_sub_pow);
   IrBuilder::create<LoadStoreOp>(
-      LoadStoreOpType::Automatic, out_N, num_features);
+      LoadStoreOpType::Set, out_N, num_features);
 
   // out_avg, out_N are now outputs of a pointwise ops and we
   //  need to clear out its reduction domains.

--- a/csrc/ir_builder.cpp
+++ b/csrc/ir_builder.cpp
@@ -114,14 +114,14 @@ Val* IrBuilder::absExpr(Val* val) {
 Val* IrBuilder::setExpr(Val* val) {
   TORCH_CHECK(val != nullptr, "val is a nullptr in setExpr.");
   auto result = newScalar(val->dtype());
-  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, result, val);
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, result, val);
   return result;
 }
 
 Val* IrBuilder::setExprNamedScalar(const std::string& name, Val* val) {
   TORCH_CHECK(val != nullptr, "val is a nullptr in setExprNamedScalar.");
   auto result = IrBuilder::create<NamedScalar>(name, val->dtype());
-  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, result, val);
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, result, val);
   return result;
 }
 

--- a/csrc/ir_builder.cpp
+++ b/csrc/ir_builder.cpp
@@ -114,14 +114,14 @@ Val* IrBuilder::absExpr(Val* val) {
 Val* IrBuilder::setExpr(Val* val) {
   TORCH_CHECK(val != nullptr, "val is a nullptr in setExpr.");
   auto result = newScalar(val->dtype());
-  IrBuilder::create<UnaryOp>(UnaryOpType::Set, result, val);
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, result, val);
   return result;
 }
 
 Val* IrBuilder::setExprNamedScalar(const std::string& name, Val* val) {
   TORCH_CHECK(val != nullptr, "val is a nullptr in setExprNamedScalar.");
   auto result = IrBuilder::create<NamedScalar>(name, val->dtype());
-  IrBuilder::create<UnaryOp>(UnaryOpType::Set, result, val);
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, result, val);
   return result;
 }
 

--- a/csrc/ir_interface_nodes.h
+++ b/csrc/ir_interface_nodes.h
@@ -412,14 +412,14 @@ class TORCH_CUDA_CU_API TensorView : public Val {
   //! @param cache_op: memory operator to use for the inserted op between
   //!   the the data tensor and the cache tensor
   TensorView* cacheBefore(
-      LoadStoreOpType cache_op = LoadStoreOpType::Automatic);
+      LoadStoreOpType cache_op = LoadStoreOpType::Set);
 
   //! Create a TensorView after the original tensor. A common use case is to
   //! read tensor into shared memory or registers. Analogous to TVM Cache_Read
   //!
   //! @param cache_op: memory operator to use for the inserted op between
   //!   the the data tensor and the cache tensor
-  TensorView* cacheAfter(LoadStoreOpType cache_op = LoadStoreOpType::Automatic);
+  TensorView* cacheAfter(LoadStoreOpType cache_op = LoadStoreOpType::Set);
 
   // For a fusion output with other uses, we want to avoid writing to global
   // memory and then reading the output again. We write to global memory

--- a/csrc/ir_interface_nodes.h
+++ b/csrc/ir_interface_nodes.h
@@ -411,8 +411,7 @@ class TORCH_CUDA_CU_API TensorView : public Val {
   //!
   //! @param cache_op: memory operator to use for the inserted op between
   //!   the the data tensor and the cache tensor
-  TensorView* cacheBefore(
-      LoadStoreOpType cache_op = LoadStoreOpType::Set);
+  TensorView* cacheBefore(LoadStoreOpType cache_op = LoadStoreOpType::Set);
 
   //! Create a TensorView after the original tensor. A common use case is to
   //! read tensor into shared memory or registers. Analogous to TVM Cache_Read

--- a/csrc/ir_interface_nodes.h
+++ b/csrc/ir_interface_nodes.h
@@ -412,15 +412,14 @@ class TORCH_CUDA_CU_API TensorView : public Val {
   //! @param cache_op: memory operator to use for the inserted op between
   //!   the the data tensor and the cache tensor
   TensorView* cacheBefore(
-      c10::optional<LoadStoreOpType> cache_op = c10::nullopt);
+      LoadStoreOpType cache_op = LoadStoreOpType::Automatic);
 
   //! Create a TensorView after the original tensor. A common use case is to
   //! read tensor into shared memory or registers. Analogous to TVM Cache_Read
   //!
   //! @param cache_op: memory operator to use for the inserted op between
   //!   the the data tensor and the cache tensor
-  TensorView* cacheAfter(
-      c10::optional<LoadStoreOpType> cache_op = c10::nullopt);
+  TensorView* cacheAfter(LoadStoreOpType cache_op = LoadStoreOpType::Automatic);
 
   // For a fusion output with other uses, we want to avoid writing to global
   // memory and then reading the output again. We write to global memory

--- a/csrc/ir_internal_nodes.h
+++ b/csrc/ir_internal_nodes.h
@@ -1092,40 +1092,6 @@ class TORCH_CUDA_CU_API MmaOp : public Expr {
   void configureOptions(MmaOptions options);
 };
 
-class TORCH_CUDA_CU_API TransposeOp : public Expr {
- public:
-  using Expr::Expr;
-
-  TransposeOp(
-      IrBuilderPasskey,
-      TensorView* out,
-      TensorView* in,
-      std::vector<int64_t> new2old);
-
-  NVFUSER_DECLARE_CLONE_AND_CREATE
-
-  virtual const char* getOpString() const override {
-    return "TransposeOp";
-  }
-
-  std::string toString(int indent_size = 0) const override;
-  std::string toInlineString(int indent_size = 0) const override;
-
-  TensorView* out() const {
-    return output(0)->as<TensorView>();
-  }
-
-  TensorView* in() const {
-    return input(0)->as<TensorView>();
-  }
-
-  const std::vector<int64_t>& new2old() const {
-    return attribute(0)->as<Attribute<std::vector<int64_t>>>()->value;
-  }
-
-  std::vector<int64_t> old2new() const;
-};
-
 class TORCH_CUDA_CU_API ExpandOp : public Expr {
  public:
   using Expr::Expr;
@@ -1338,6 +1304,9 @@ class TORCH_CUDA_CU_API LoadStoreOp : public Expr {
   virtual const char* getOpString() const override {
     return "LoadStoreOp";
   }
+
+  virtual std::vector<EvaluatorValue> evaluate(
+      const std::vector<EvaluatorValue>& inputs) const override;
 
   std::string toString(int indent_size = 0) const override;
   std::string toInlineString(int indent_size = 0) const override;

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -353,9 +353,6 @@ std::vector<EvaluatorValue> UnaryOp::evaluate(
   switch (getUnaryOpType()) {
     case UnaryOpType::Neg:
       return {-in};
-    case UnaryOpType::Set:
-      return {in};
-      break;
     case UnaryOpType::Cast:
       if (isIntegralType(*out()->getDataType())) {
         return {EvaluatorValue(in.cast<int64_t>())};
@@ -1407,65 +1404,6 @@ void MmaOp::configureOptions(MmaOptions options) {
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(MmaOp)
 
-TransposeOp::TransposeOp(
-    IrBuilderPasskey passkey,
-    TensorView* out,
-    TensorView* in,
-    std::vector<int64_t> new2old)
-    : Expr(passkey) {
-  // Sanity check of the input parameters. Maybe not necessary as they
-  // should be checked at function transpose.
-
-  TORCH_INTERNAL_ASSERT(
-      TensorDomain::noReductions(in->getMaybeRFactorDomain()).size() ==
-      out->getMaybeRFactorDomain().size());
-
-  TORCH_INTERNAL_ASSERT(new2old.size() == out->getMaybeRFactorDomain().size());
-
-  // Make sure the entries of new2old are unique and range from 0 to
-  // N-1, where N == new2old.size().
-  std::set<int64_t> old_positions(new2old.begin(), new2old.end());
-  TORCH_INTERNAL_ASSERT(old_positions.size() == new2old.size());
-  // old_positions is sorted, so the first entry must be 0.
-  TORCH_INTERNAL_ASSERT(
-      *(old_positions.begin()) == 0,
-      "Invalid new2old vector detected: ",
-      new2old);
-  // The last entry must be N-1, since old_positions is sorted, starts
-  // with 0, and its length is N.
-  TORCH_INTERNAL_ASSERT(
-      *(old_positions.rbegin()) == (int)(new2old.size() - 1),
-      "Invalid new2old vector detected: ",
-      new2old);
-
-  addOutput(out);
-  addInput(in);
-  addAttribute(IrBuilder::create<Attribute<std::vector<int64_t>>>(
-      passkey.ir_container_, std::move(new2old)));
-}
-
-std::string TransposeOp::toString(int indent_size) const {
-  std::stringstream ss;
-  indent(ss, indent_size) << out()->toString() << " = transpose( "
-                          << in()->toString() << " )\n";
-  return ss.str();
-}
-
-std::string TransposeOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
-}
-
-std::vector<int64_t> TransposeOp::old2new() const {
-  std::vector<int64_t> old2new(new2old().size());
-  for (auto new_axis : c10::irange(new2old().size())) {
-    auto old_axis = new2old().at(new_axis);
-    old2new[old_axis] = (int64_t)new_axis;
-  }
-  return old2new;
-}
-
-NVFUSER_DEFINE_CLONE_AND_CREATE(TransposeOp)
-
 ExpandOp::ExpandOp(
     IrBuilderPasskey passkey,
     TensorView* out,
@@ -1682,6 +1620,11 @@ LoadStoreOp::LoadStoreOp(
   addInput(in);
   addAttribute(IrBuilder::create<Attribute<LoadStoreOpType>>(
       passkey.ir_container_, op_type));
+}
+
+std::vector<EvaluatorValue> LoadStoreOp::evaluate(
+    const std::vector<EvaluatorValue>& inputs) const {
+  return inputs;
 }
 
 std::string LoadStoreOp::toString(int indent_size) const {

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -1630,8 +1630,19 @@ std::vector<EvaluatorValue> LoadStoreOp::evaluate(
 std::string LoadStoreOp::toString(int indent_size) const {
   std::stringstream ss;
   std::string optype = load_store_type2string(opType());
+  std::string modifier = "";
+  { // Get modifier
+    TensorView* tv = dynamic_cast<TensorView*>(out());
+    if (auto ti = dynamic_cast<kir::TensorIndex*>(out())) {
+      tv = ti->view();
+    }
+    if (tv != nullptr && tv->hasRFactor()) {
+      modifier = ".Permute";
+    }
+  }
   indent(ss, indent_size) << out()->toString() << "\n";
-  indent(ss, indent_size + 1) << " = " << optype << "( " << in()->toString();
+  indent(ss, indent_size + 1)
+      << " = " << optype << modifier << "( " << in()->toString();
   // Fusion IR does not have predicate
   if (container()->isA<kir::Kernel>() && predicate() != nullptr) {
     ss << ", " << std::endl;

--- a/csrc/lower_allocation.cpp
+++ b/csrc/lower_allocation.cpp
@@ -130,7 +130,7 @@ class AllocationInserter : public kir::ExprMutator {
       init_dims.push_back(concrete_id);
     }
     Expr* init_expr = IrBuilder::create<LoadStoreOp>(
-        LoadStoreOpType::Automatic, info.buffer, init_val);
+        LoadStoreOpType::Set, info.buffer, init_val);
     for (auto init_loop_it = init_dims.rbegin();
          init_loop_it != init_dims.rend();
          ++init_loop_it) {

--- a/csrc/lower_allocation.cpp
+++ b/csrc/lower_allocation.cpp
@@ -129,8 +129,8 @@ class AllocationInserter : public kir::ExprMutator {
           info.buffer->axis((int)axis_i), IdMappingMode::LOOP);
       init_dims.push_back(concrete_id);
     }
-    Expr* init_expr =
-        IrBuilder::create<UnaryOp>(UnaryOpType::Set, info.buffer, init_val);
+    Expr* init_expr = IrBuilder::create<LoadStoreOp>(
+        LoadStoreOpType::Automatic, info.buffer, init_val);
     for (auto init_loop_it = init_dims.rbegin();
          init_loop_it != init_dims.rend();
          ++init_loop_it) {

--- a/csrc/lower_bank_conflict.cpp
+++ b/csrc/lower_bank_conflict.cpp
@@ -245,30 +245,7 @@ class BankConflictInfo : public kir::IrVisitor {
       return;
     }
 
-    if (expr->isA<UnaryOp>()) {
-      auto uop = expr->as<UnaryOp>();
-      if (uop->getUnaryOpType() != UnaryOpType::Set) {
-        return;
-      }
-      std::pair<int, int> conflict_ways{0, 0};
-      if (isSmemTensorIndex(uop->in())) {
-        conflict_ways.first = getConflictWays(evaluateAddressesOnFirstPhase(
-            uop->in()->as<kir::TensorIndex>(),
-            for_loops_,
-            launch_params_,
-            expr_eval_common_));
-      }
-      if (isSmemTensorIndex(uop->out())) {
-        conflict_ways.second = getConflictWays(evaluateAddressesOnFirstPhase(
-            uop->out()->as<kir::TensorIndex>(),
-            for_loops_,
-            launch_params_,
-            expr_eval_common_));
-      }
-      if (conflict_ways.first > 1 || conflict_ways.second > 1) {
-        bank_conflict_info_[expr] = conflict_ways;
-      }
-    } else if (expr->isA<LoadStoreOp>()) {
+    if (expr->isA<LoadStoreOp>()) {
       auto ldst = expr->as<LoadStoreOp>();
       std::pair<int, int> conflict_ways{0, 0};
       if (isSmemTensorIndex(ldst->in())) {

--- a/csrc/lower_double_buffer.cpp
+++ b/csrc/lower_double_buffer.cpp
@@ -71,20 +71,17 @@ IterDomain* getDoubleBufferAxis(const TensorView* tv) {
 void validateDoubleBufferedTensor(const TensorView* tv) {
   auto double_buffer_pos = getDoubleBufferAxisPosition(tv);
 
-  // Like vectorization, only UnaryOp::Set with another TensorView is
+  // Like vectorization, only LoadStoreOp with another TensorView is
   // considered.
   auto def = tv->definition();
   TORCH_INTERNAL_ASSERT(
-      (def->isA<UnaryOp>() &&
-       def->as<UnaryOp>()->getUnaryOpType() == UnaryOpType::Set) ||
-          // Load store op should generally support double buffering.
-          def->isA<LoadStoreOp>(),
-      "Invalid tensor to double-buffer. Only tensor defined by UnaryOp::Set is supported: ",
+      def->isA<LoadStoreOp>(),
+      "Invalid tensor to double-buffer. Only tensor defined by LoadStoreOp is supported: ",
       def->toString());
 
   TORCH_INTERNAL_ASSERT(
       def->input(0)->isA<TensorView>(),
-      "Invalid tensor to double-buffer. Only tensor defined by UnaryOp::Set with TensorView is supported: ",
+      "Invalid tensor to double-buffer. Only tensor defined by LoadStoreOp with TensorView is supported: ",
       def->toString());
 
   TORCH_INTERNAL_ASSERT(

--- a/csrc/lower_fusion_simplifier.cpp
+++ b/csrc/lower_fusion_simplifier.cpp
@@ -36,20 +36,14 @@ class UnaryOpInserter : private kir::ExprMutator {
     GpuLower::current()->propagateExprInfo(old_expr, new_expr);
   }
 
-  void handle(TransposeOp* top) final {
-    auto out = top->out();
-    auto in = top->in();
-    auto container = out->container();
-    registerReplaceAndPropagate(
-        top, IrBuilder::create<UnaryOp>(container, UnaryOpType::Set, out, in));
-  }
-
   void handle(SqueezeOp* sop) final {
     auto out = sop->out();
     auto in = sop->in();
     auto container = out->container();
     registerReplaceAndPropagate(
-        sop, IrBuilder::create<UnaryOp>(container, UnaryOpType::Set, out, in));
+        sop,
+        IrBuilder::create<LoadStoreOp>(
+            container, LoadStoreOpType::Automatic, out, in));
   }
 
   void handle(ExpandOp* eop) final {
@@ -57,7 +51,9 @@ class UnaryOpInserter : private kir::ExprMutator {
     auto in = eop->in();
     auto container = out->container();
     registerReplaceAndPropagate(
-        eop, IrBuilder::create<UnaryOp>(container, UnaryOpType::Set, out, in));
+        eop,
+        IrBuilder::create<LoadStoreOp>(
+            container, LoadStoreOpType::Automatic, out, in));
   }
 
   void handle(ShiftOp* sop) final {
@@ -65,7 +61,9 @@ class UnaryOpInserter : private kir::ExprMutator {
     auto in = sop->in();
     auto container = out->container();
     registerReplaceAndPropagate(
-        sop, IrBuilder::create<UnaryOp>(container, UnaryOpType::Set, out, in));
+        sop,
+        IrBuilder::create<LoadStoreOp>(
+            container, LoadStoreOpType::Automatic, out, in));
   }
 
   void handle(GatherOp* gop) final {
@@ -73,7 +71,9 @@ class UnaryOpInserter : private kir::ExprMutator {
     auto in = gop->in();
     auto container = out->container();
     registerReplaceAndPropagate(
-        gop, IrBuilder::create<UnaryOp>(container, UnaryOpType::Set, out, in));
+        gop,
+        IrBuilder::create<LoadStoreOp>(
+            container, LoadStoreOpType::Automatic, out, in));
   }
 
   void handle(ViewOp* vop) final {
@@ -81,7 +81,9 @@ class UnaryOpInserter : private kir::ExprMutator {
     auto in = vop->in();
     auto container = out->container();
     registerReplaceAndPropagate(
-        vop, IrBuilder::create<UnaryOp>(container, UnaryOpType::Set, out, in));
+        vop,
+        IrBuilder::create<LoadStoreOp>(
+            container, LoadStoreOpType::Automatic, out, in));
   }
 };
 

--- a/csrc/lower_fusion_simplifier.cpp
+++ b/csrc/lower_fusion_simplifier.cpp
@@ -43,7 +43,7 @@ class UnaryOpInserter : private kir::ExprMutator {
     registerReplaceAndPropagate(
         sop,
         IrBuilder::create<LoadStoreOp>(
-            container, LoadStoreOpType::Automatic, out, in));
+            container, LoadStoreOpType::Set, out, in));
   }
 
   void handle(ExpandOp* eop) final {
@@ -53,7 +53,7 @@ class UnaryOpInserter : private kir::ExprMutator {
     registerReplaceAndPropagate(
         eop,
         IrBuilder::create<LoadStoreOp>(
-            container, LoadStoreOpType::Automatic, out, in));
+            container, LoadStoreOpType::Set, out, in));
   }
 
   void handle(ShiftOp* sop) final {
@@ -63,7 +63,7 @@ class UnaryOpInserter : private kir::ExprMutator {
     registerReplaceAndPropagate(
         sop,
         IrBuilder::create<LoadStoreOp>(
-            container, LoadStoreOpType::Automatic, out, in));
+            container, LoadStoreOpType::Set, out, in));
   }
 
   void handle(GatherOp* gop) final {
@@ -73,7 +73,7 @@ class UnaryOpInserter : private kir::ExprMutator {
     registerReplaceAndPropagate(
         gop,
         IrBuilder::create<LoadStoreOp>(
-            container, LoadStoreOpType::Automatic, out, in));
+            container, LoadStoreOpType::Set, out, in));
   }
 
   void handle(ViewOp* vop) final {
@@ -83,7 +83,7 @@ class UnaryOpInserter : private kir::ExprMutator {
     registerReplaceAndPropagate(
         vop,
         IrBuilder::create<LoadStoreOp>(
-            container, LoadStoreOpType::Automatic, out, in));
+            container, LoadStoreOpType::Set, out, in));
   }
 };
 

--- a/csrc/lower_index.cpp
+++ b/csrc/lower_index.cpp
@@ -172,7 +172,7 @@ void IndexLowering::handle(const FullOp* fop) {
   GpuLower::current()->commonScalarMap().hoistScalar(result, for_loops_);
 
   auto lowered =
-      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out, result);
+      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, result);
   pushBack(lowered);
   GpuLower::current()->propagateExprInfo(fop, back());
 }
@@ -193,7 +193,7 @@ void IndexLowering::handle(const IotaOp* aop) {
       aop->step(),
       aop->dtype());
   auto lowered =
-      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out, result);
+      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, result);
 
   pushBack(lowered);
   GpuLower::current()->propagateExprInfo(aop, back());
@@ -207,7 +207,7 @@ void IndexLowering::handle(const EyeOp* eop) {
   const auto out = lowerDstIndex(out_tv);
   auto result = Index::eye(out_tv, for_loops_, getRotatedLoop(), eop->dtype());
   auto lowered =
-      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out, result);
+      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, result);
 
   pushBack(lowered);
   GpuLower::current()->propagateExprInfo(eop, back());
@@ -281,7 +281,7 @@ void IndexLowering::handle(const TorchGatherOp* top) {
 
   const auto out = lowerDstIndex(top->output(0));
   pushBack(
-      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out, input));
+      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, input));
   GpuLower::current()->propagateExprInfo(top, back());
 }
 
@@ -326,7 +326,7 @@ void IndexLowering::handle(const SelectOp* sop) {
   const auto out = lowerDstIndex(sop->output(0));
 
   pushBack(
-      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out, input));
+      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, input));
   GpuLower::current()->propagateExprInfo(sop, back());
 }
 
@@ -1461,7 +1461,7 @@ void IndexLowering::handle(const SliceOp* slice) {
   const auto in = lowerSrcIndex(slice->in(), slice->out());
   const auto out = lowerDstIndex(slice->out());
 
-  pushBack(IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out, in));
+  pushBack(IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, in));
   GpuLower::current()->propagateExprInfo(slice, back());
 }
 

--- a/csrc/lower_index.cpp
+++ b/csrc/lower_index.cpp
@@ -280,8 +280,7 @@ void IndexLowering::handle(const TorchGatherOp* top) {
   auto input = lowerSrcIndex(top->lookupTv(), top->output(0), override_index);
 
   const auto out = lowerDstIndex(top->output(0));
-  pushBack(
-      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, input));
+  pushBack(IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, input));
   GpuLower::current()->propagateExprInfo(top, back());
 }
 
@@ -325,8 +324,7 @@ void IndexLowering::handle(const SelectOp* sop) {
 
   const auto out = lowerDstIndex(sop->output(0));
 
-  pushBack(
-      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, input));
+  pushBack(IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, input));
   GpuLower::current()->propagateExprInfo(sop, back());
 }
 

--- a/csrc/lower_misaligned_vectorization.cpp
+++ b/csrc/lower_misaligned_vectorization.cpp
@@ -360,7 +360,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
     return new_parent_for_loop;
   }
 
-  // Determine that the expression is UnaryOpType::Set AND
+  // Determine that the expression is LoadStoreOp AND
   // the output TensorView domain is vectorized
   bool isVectorizeSetOp(kir::ForLoop* fl, Expr* expr) {
     if (fl->iter_domain()->getParallelType() !=
@@ -368,12 +368,11 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
       return false;
     }
 
-    if (expr->isA<UnaryOp>()) {
-      auto unaryOp = expr->as<UnaryOp>();
-      if (unaryOp->out()->isA<TensorView>()) {
-        auto out_tv = unaryOp->out()->as<TensorView>();
-        return unaryOp->getUnaryOpType() == UnaryOpType::Set &&
-            out_tv->domain()->hasVectorize();
+    if (expr->isA<LoadStoreOp>()) {
+      auto ldst = expr->as<LoadStoreOp>();
+      if (ldst->out()->isA<TensorView>()) {
+        auto out_tv = ldst->out()->as<TensorView>();
+        return out_tv->domain()->hasVectorize();
       }
     }
     return false;
@@ -511,7 +510,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
       }
 
       // There must be a matching consumer root ID as the producer ID is
-      // not reduction and the expression between them is UnaryOpType::Set.
+      // not reduction and the expression between them is LoadStoreOp.
       auto it = p2c.find(producer_root_id);
       TORCH_INTERNAL_ASSERT(
           it != p2c.end(), "No matching consumer root ID found");

--- a/csrc/lower_shift.cpp
+++ b/csrc/lower_shift.cpp
@@ -87,8 +87,8 @@ Expr* ShiftPredicateInserter::insert(
       PredicateType::Padding, expr, thread_pred);
   auto bounds_ite = IrBuilder::create<kir::IfThenElse>(padding_pred);
   const int pad_value = 0;
-  auto pad_expr = IrBuilder::create<UnaryOp>(
-      UnaryOpType::Set, out_tv, IrBuilder::create<Int>(pad_value));
+  auto pad_expr = IrBuilder::create<LoadStoreOp>(
+      LoadStoreOpType::Automatic, out_tv, IrBuilder::create<Int>(pad_value));
   bounds_ite->thenBody().push_back(pad_expr);
   // Insert the else block
   shift_ite->elseBody().push_back(bounds_ite);

--- a/csrc/lower_shift.cpp
+++ b/csrc/lower_shift.cpp
@@ -88,7 +88,7 @@ Expr* ShiftPredicateInserter::insert(
   auto bounds_ite = IrBuilder::create<kir::IfThenElse>(padding_pred);
   const int pad_value = 0;
   auto pad_expr = IrBuilder::create<LoadStoreOp>(
-      LoadStoreOpType::Automatic, out_tv, IrBuilder::create<Int>(pad_value));
+      LoadStoreOpType::Set, out_tv, IrBuilder::create<Int>(pad_value));
   bounds_ite->thenBody().push_back(pad_expr);
   // Insert the else block
   shift_ite->elseBody().push_back(bounds_ite);

--- a/csrc/lower_utils.cpp
+++ b/csrc/lower_utils.cpp
@@ -142,7 +142,6 @@ bool isTvOp(const Expr* expr) {
           MmaOp,
           BroadcastOp,
           SqueezeOp,
-          TransposeOp,
           ExpandOp,
           ShiftOp,
           GatherOp,
@@ -187,10 +186,6 @@ bool isTensorScalarFillOp(const Expr* expr) {
     //  into a tensor.
     if (expr->isA<LoadStoreOp>()) {
       return true;
-    }
-    // Unary copy op is also a scalar filling op.
-    if (auto uop = dynamic_cast<const UnaryOp*>(expr)) {
-      return uop->getUnaryOpType() == UnaryOpType::Set;
     }
   }
   // Ideally any scalar expression that outputs
@@ -348,9 +343,7 @@ c10::optional<Expr*> getMaybePredicatedSingleton(Expr* expr) {
 
 //! Short-cut for checking if the expression loads from global memory.
 bool isGlobalLoad(const Expr* expr) {
-  if (expr->isA<LoadStoreOp>() ||
-      (expr->isA<UnaryOp>() &&
-       expr->as<UnaryOp>()->getUnaryOpType() == UnaryOpType::Set)) {
+  if (expr->isA<LoadStoreOp>()) {
     if (auto in_tv = getTv(expr->input(0))) {
       return in_tv->getMemoryType() == MemoryType::Global;
     }

--- a/csrc/lower_validation.cpp
+++ b/csrc/lower_validation.cpp
@@ -408,10 +408,7 @@ class VectorizeValidator : public OptInDispatch {
     if (misaligned_vectorize) {
       if (tv->getMemoryType() == MemoryType::Global) {
         checkContiguity(validator.domains_, tv);
-      } else if (
-          tv->definition()->isA<UnaryOp>() &&
-          tv->definition()->as<UnaryOp>()->getUnaryOpType() ==
-              UnaryOpType::Set) {
+      } else if (tv->definition()->isA<LoadStoreOp>()) {
         auto input = tv->definition()->input(0);
         TORCH_INTERNAL_ASSERT(input->isA<TensorView>());
         auto input_tv = input->as<TensorView>();
@@ -549,11 +546,7 @@ void validateAndCollectVectorizeInfo(Fusion* fusion) {
     }
     if (has_vectorize_dim) {
       TORCH_INTERNAL_ASSERT(
-          tv->definition() == nullptr ||
-              (tv->definition()->isA<UnaryOp>() &&
-               tv->definition()->as<UnaryOp>()->getUnaryOpType() ==
-                   UnaryOpType::Set) ||
-              tv->definition()->isA<LoadStoreOp>(),
+          tv->definition() == nullptr || tv->definition()->isA<LoadStoreOp>(),
           "Vectorized accesses cannot be inline with computation, they are only supported with a Set operation.",
           "TensorView: ",
           tv);

--- a/csrc/lower_vectorize_welford.cpp
+++ b/csrc/lower_vectorize_welford.cpp
@@ -260,8 +260,8 @@ class WelfordVectorizer : public kir::ExprMutator {
     // Allocate a boolean scalar for cond
     auto pred_var = defineScalar(DataType::Bool)->as<Bool>();
 
-    registerInsertBeforeInnerMostLoop(
-        IrBuilder::create<UnaryOp>(UnaryOpType::Set, pred_var, conditional));
+    registerInsertBeforeInnerMostLoop(IrBuilder::create<LoadStoreOp>(
+        LoadStoreOpType::Automatic, pred_var, conditional));
 
     auto vectorized_wop = applyVectorizeTransformation(wop, pred_var);
 
@@ -362,8 +362,8 @@ class WelfordVectorizer : public kir::ExprMutator {
       registerInsertBeforeInnerMostLoop(reciprocal_expr);
     } else {
       // Initialize reciprocal as 0;
-      registerInsertBeforeInnerMostLoop(IrBuilder::create<UnaryOp>(
-          UnaryOpType::Set,
+      registerInsertBeforeInnerMostLoop(IrBuilder::create<LoadStoreOp>(
+          LoadStoreOpType::Automatic,
           reciprocal,
           GpuLower::current()->kernel()->zeroVal()));
 

--- a/csrc/lower_vectorize_welford.cpp
+++ b/csrc/lower_vectorize_welford.cpp
@@ -261,7 +261,7 @@ class WelfordVectorizer : public kir::ExprMutator {
     auto pred_var = defineScalar(DataType::Bool)->as<Bool>();
 
     registerInsertBeforeInnerMostLoop(IrBuilder::create<LoadStoreOp>(
-        LoadStoreOpType::Automatic, pred_var, conditional));
+        LoadStoreOpType::Set, pred_var, conditional));
 
     auto vectorized_wop = applyVectorizeTransformation(wop, pred_var);
 
@@ -363,7 +363,7 @@ class WelfordVectorizer : public kir::ExprMutator {
     } else {
       // Initialize reciprocal as 0;
       registerInsertBeforeInnerMostLoop(IrBuilder::create<LoadStoreOp>(
-          LoadStoreOpType::Automatic,
+          LoadStoreOpType::Set,
           reciprocal,
           GpuLower::current()->kernel()->zeroVal()));
 

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -299,7 +299,6 @@ TensorView* permute(TensorView* x, const std::vector<int64_t>& new2old) {
     return set(x);
   }
   auto inp_domain = TensorDomain::noReductions(x->getMaybeRFactorDomain());
-  std::vector<IterDomain*> out_domain(inp_domain.size());
 
   TORCH_CHECK(
       inp_domain.size() == new2old.size(),
@@ -317,16 +316,26 @@ TensorView* permute(TensorView* x, const std::vector<int64_t>& new2old) {
   auto normalized_new2old =
       ir_utils::normalizeNew2Old(new2old, inp_domain.size());
 
-  for (const auto i : c10::irange(out_domain.size())) {
-    auto in_id = inp_domain[normalized_new2old[i]];
-    out_domain[i] = in_id->cloneWithoutRFactor();
+  std::vector<IterDomain*> out_root;
+  out_root.reserve(inp_domain.size());
+  for (const auto id : inp_domain) {
+    out_root.emplace_back(id->cloneWithoutRFactor());
+  }
+
+  std::vector<IterDomain*> out_rfactor;
+  out_rfactor.reserve(inp_domain.size());
+  for (const auto i : normalized_new2old) {
+    out_rfactor.emplace_back(out_root.at(i));
   }
 
   TensorView* out_tensor = IrBuilder::create<TensorView>(
       IrBuilder::create<TensorDomain>(
-          out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
+          out_root,
+          out_rfactor,
+          out_rfactor,
+          TensorDomain::getContiguityFilledWith(out_rfactor, true)),
       x->getDataType().value());
-  IrBuilder::create<TransposeOp>(out_tensor, x, normalized_new2old);
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out_tensor, x);
   return out_tensor;
 }
 

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -15,6 +15,16 @@
 
 namespace nvfuser {
 
+Val* set(Val* v) {
+  Val* out = ops::newValLike(v, v->getDataType().value());
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out, v);
+  return out;
+}
+
+TensorView* set(TensorView* tv) {
+  return set(tv->as<Val>())->as<TensorView>();
+}
+
 namespace {
 
 //! Transform TensorView according to keep, merge, and split transformations.

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -17,7 +17,7 @@ namespace nvfuser {
 
 Val* set(Val* v) {
   Val* out = ops::newValLike(v, v->getDataType().value());
-  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out, v);
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, v);
   return out;
 }
 
@@ -345,7 +345,7 @@ TensorView* permute(TensorView* x, const std::vector<int64_t>& new2old) {
           out_rfactor,
           TensorDomain::getContiguityFilledWith(out_rfactor, true)),
       x->getDataType().value());
-  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out_tensor, x);
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out_tensor, x);
   return out_tensor;
 }
 

--- a/csrc/ops/alias.h
+++ b/csrc/ops/alias.h
@@ -20,6 +20,9 @@
 
 namespace nvfuser {
 
+TORCH_CUDA_CU_API Val* set(Val*);
+TORCH_CUDA_CU_API TensorView* set(TensorView*);
+
 TORCH_CUDA_CU_API TensorView* view(TensorView* x, DataType dtype);
 
 TORCH_CUDA_CU_API TensorView* reshape(

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1545,7 +1545,7 @@ TensorView* expand(TensorView* inp, const std::vector<Val*>& expanded_sizes) {
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       inp->getDataType().value());
   if (!expanded) {
-    IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out_tensor, inp);
+    IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out_tensor, inp);
   } else {
     IrBuilder::create<ExpandOp>(out_tensor, inp, maybe_expanded_sizes);
   }
@@ -1605,7 +1605,7 @@ TensorView* expand_as(TensorView* inp, TensorView* other) {
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       inp->getDataType().value());
   if (!expanded) {
-    IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out_tensor, inp);
+    IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out_tensor, inp);
   } else {
     IrBuilder::create<ExpandOp>(out_tensor, inp, maybe_expanded_sizes);
   }

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -74,16 +74,6 @@ TensorView* bitCastOp(DataType dtype, TensorView* v1) {
   return bitCastOp(dtype, v1->as<Val>())->as<TensorView>();
 }
 
-Val* set(Val* v) {
-  Val* out = ops::newValLike(v, v->getDataType().value());
-  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, out, v);
-  return out;
-}
-
-TensorView* set(TensorView* tv) {
-  return set(tv->as<Val>())->as<TensorView>();
-}
-
 Val* unaryOp(UnaryOpType type, Val* v1) {
   TORCH_INTERNAL_ASSERT(
       type != UnaryOpType::Address,

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -571,10 +571,12 @@ TensorView* eye(Val* size, DataType dtype) {
 
 // UNARY OPERATIONS
 
-#define NVFUSER_DEFINE_UNARY_OP(op_name, op_type)                   \
-  Val* op_name(Val* v) { return unaryOp(UnaryOpType::op_type, v); } \
-  TensorView* op_name(TensorView* tv) {                             \
-    return unaryOp(UnaryOpType::op_type, tv);                       \
+#define NVFUSER_DEFINE_UNARY_OP(operator_name, operator_type) \
+  Val* operator_name(Val* value) {                            \
+    return unaryOp(UnaryOpType::operator_type, value);        \
+  }                                                           \
+  TensorView* operator_name(TensorView* tv) {                 \
+    return unaryOp(UnaryOpType::operator_type, tv);           \
   }
 
 NVFUSER_DEFINE_UNARY_OP(ceil, Ceil)
@@ -704,10 +706,12 @@ NVFUSER_DEFINE_UNARY_FLOAT_OP(tan, Tan)
 NVFUSER_DEFINE_UNARY_FLOAT_OP(tanh, Tanh)
 #undef NVFUSER_DEFINE_UNARY_FLOAT_OP
 
-#define NVFUSER_DEFINE_UNARY_IS_OP(op_name, op_type)                  \
-  Val* op_name(Val* v) { return unaryIsOp(UnaryOpType::op_type, v); } \
-  TensorView* op_name(TensorView* tv) {                               \
-    return unaryIsOp(UnaryOpType::op_type, tv);                       \
+#define NVFUSER_DEFINE_UNARY_IS_OP(operator_name, operator_type) \
+  Val* operator_name(Val* value) {                               \
+    return unaryIsOp(UnaryOpType::operator_type, value);         \
+  }                                                              \
+  TensorView* operator_name(TensorView* tv) {                    \
+    return unaryIsOp(UnaryOpType::operator_type, tv);            \
   }
 
 NVFUSER_DEFINE_UNARY_IS_OP(isfinite, IsFinite)

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -311,9 +311,6 @@ TORCH_CUDA_CU_API TensorView* rsqrt(TensorView*);
 // round
 TORCH_CUDA_CU_API Val* round(Val*);
 TORCH_CUDA_CU_API TensorView* round(TensorView*);
-// set
-TORCH_CUDA_CU_API Val* set(Val*);
-TORCH_CUDA_CU_API TensorView* set(TensorView*);
 // sigmoid
 TORCH_CUDA_CU_API Val* sigmoid(Val*);
 TORCH_CUDA_CU_API TensorView* sigmoid(TensorView*);

--- a/csrc/root_domain_map.h
+++ b/csrc/root_domain_map.h
@@ -114,12 +114,6 @@ class TORCH_CUDA_CU_API PairwiseRootDomainMap : public RootDomainMap {
       const std::unordered_set<IterDomain*>& root_dims_to_map,
       bool producer_to_consumer) const override;
 
-  std::unordered_map<IterDomain*, IterDomain*> mapTranspose(
-      const TensorDomain* producer,
-      const TensorDomain* consumer,
-      const std::unordered_set<IterDomain*>& root_dims_to_map,
-      bool producer_to_consumer) const;
-
  private:
   const TensorView* producer_tv_ = nullptr;
   const TensorView* consumer_tv_ = nullptr;
@@ -462,8 +456,6 @@ class TORCH_CUDA_CU_API ComputeAtRootDomainMapBuilder
   void handle(BroadcastOp* op) override;
 
   void handle(SqueezeOp* op) override;
-
-  void handle(TransposeOp* op) override;
 
   void handle(ExpandOp* op) override {
     mapPointwiseOrReductionOp(op);

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -185,7 +185,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
 
   } else {
     // Use cp.async as requested in scheduler params.
-    c10::optional<LoadStoreOpType> load_op = c10::nullopt;
+    LoadStoreOpType load_op = LoadStoreOpType::Automatic;
     if (params.async_gmem_load_operands) {
       load_op = LoadStoreOpType::CpAsyncCg;
     }

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -185,7 +185,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
 
   } else {
     // Use cp.async as requested in scheduler params.
-    LoadStoreOpType load_op = LoadStoreOpType::Automatic;
+    LoadStoreOpType load_op = LoadStoreOpType::Set;
     if (params.async_gmem_load_operands) {
       load_op = LoadStoreOpType::CpAsyncCg;
     }

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -816,9 +816,8 @@ bool isMmaInitLoop(const kir::Scope& loop_body) {
       if (!isMmaInitLoop(inner_loop->body())) {
         return false;
       }
-    } else if (auto uop = dynamic_cast<UnaryOp*>(expr)) {
-      if (!ir_utils::isTvOp(expr) ||
-          uop->getUnaryOpType() != UnaryOpType::Set) {
+    } else if (expr->isA<LoadStoreOp>()) {
+      if (!ir_utils::isTvOp(expr)) {
         return false;
       }
       if (auto ti = dynamic_cast<kir::TensorIndex*>(expr->output(0))) {

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -419,9 +419,7 @@ void multiReductionInliner(
     auto vectorizable_inputs_outputs =
         scheduler_utils::getInputsOutputsWithInnerDim(reference_tv, true, true);
 
-    auto vectorizable_expr = [](Expr* e) {
-      return e->isA<LoadStoreOp>();
-    };
+    auto vectorizable_expr = [](Expr* e) { return e->isA<LoadStoreOp>(); };
 
     for (auto cached_input : cached_inputs) {
       if (vectorize) {

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -420,8 +420,7 @@ void multiReductionInliner(
         scheduler_utils::getInputsOutputsWithInnerDim(reference_tv, true, true);
 
     auto vectorizable_expr = [](Expr* e) {
-      return e->isA<UnaryOp>() &&
-          e->as<UnaryOp>()->getUnaryOpType() == UnaryOpType::Set;
+      return e->isA<LoadStoreOp>();
     };
 
     for (auto cached_input : cached_inputs) {

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -1056,11 +1056,6 @@ bool SchedulerEntry::sameAs(const SchedulerEntry* other) {
 }
 
 namespace {
-std::vector<TransposeOp*> findTransposeOps(Fusion* fusion) {
-  auto exprs = fusion->exprs();
-  auto transpose_ops = ir_utils::filterByType<TransposeOp>(exprs);
-  return std::vector<TransposeOp*>(transpose_ops.begin(), transpose_ops.end());
-}
 
 static bool checkPatternEquivalence(
     TensorView* out_tv0,

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2383,10 +2383,8 @@ bool revertUseOfInputCacheInResize(
     MemoryType promoted_memory_type,
     const std::vector<TensorView*>& input_caches) {
   auto get_copy_src = [](TensorView* tv) -> TensorView* {
-    if (auto uop = dynamic_cast<UnaryOp*>(tv->definition())) {
-      if (uop->getUnaryOpType() == UnaryOpType::Set) {
-        return uop->in()->as<TensorView>();
-      }
+    if (auto uop = dynamic_cast<LoadStoreOp*>(tv->definition())) {
+      return uop->in()->as<TensorView>();
     }
     return nullptr;
   };

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1319,7 +1319,7 @@ TensorView* TensorView::cacheFork() {
 
   // Create write operation from this TV to new output
   IrBuilder::create<LoadStoreOp>(
-      container(), LoadStoreOpType::Automatic, new_output, this);
+      container(), LoadStoreOpType::Set, new_output, this);
 
   // The new TV becomes an output.
   // New TV has global memory type.

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -667,7 +667,7 @@ static const char* thread_size2string(ParallelType t) {
 
 const char* load_store_type2string(LoadStoreOpType t) {
   switch (t) {
-    case LoadStoreOpType::Automatic:
+    case LoadStoreOpType::Set:
       return "Set";
     case LoadStoreOpType::LdMatrix:
       return "LdMatrix";

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -198,7 +198,6 @@ bool needFloatSuffix(UnaryOpType t) {
     case UnaryOpType::Real:
     case UnaryOpType::Relu:
     case UnaryOpType::Reciprocal:
-    case UnaryOpType::Set:
     case UnaryOpType::Sigmoid:
     case UnaryOpType::IsFinite:
     case UnaryOpType::IsInf:
@@ -287,8 +286,6 @@ static const char* unary_op_type2string(UnaryOpType t) {
       return "rsqrt";
     case UnaryOpType::Round:
       return "nearbyint";
-    case UnaryOpType::Set:
-      return "set";
     case UnaryOpType::Sigmoid:
       return "sigmoid";
     case UnaryOpType::Sin:
@@ -336,8 +333,6 @@ static const char* unary_op_type_inline_op2string(UnaryOpType t) {
       return "-";
     case UnaryOpType::Not:
       return "~";
-    case UnaryOpType::Set:
-      return "";
     case UnaryOpType::Address:
       return "(int64_t) &";
     default:
@@ -672,6 +667,8 @@ static const char* thread_size2string(ParallelType t) {
 
 const char* load_store_type2string(LoadStoreOpType t) {
   switch (t) {
+    case LoadStoreOpType::Automatic:
+      return "Set";
     case LoadStoreOpType::LdMatrix:
       return "LdMatrix";
     case LoadStoreOpType::LdMatrixTranspose:

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -441,7 +441,7 @@ static constexpr std::array<IdMappingMode, 5> kIdMappingModes = {
 // Used to annotate the special memory intrinsics that a loadstore
 //  op will be lowered to.
 enum class LoadStoreOpType {
-  Automatic, // load store type automatically determined at codegen
+  Automatic, // load store type automatically determined at codegen.cpp
   LdMatrix,
   LdMatrixTranspose,
   CpAsyncCa,

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -441,7 +441,7 @@ static constexpr std::array<IdMappingMode, 5> kIdMappingModes = {
 // Used to annotate the special memory intrinsics that a loadstore
 //  op will be lowered to.
 enum class LoadStoreOpType {
-  Automatic, // load store type automatically determined at codegen.cpp
+  Set,
   LdMatrix,
   LdMatrixTranspose,
   CpAsyncCa,

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -277,7 +277,6 @@ enum class UnaryOpType {
   Relu,
   Rsqrt,
   Round,
-  Set,
   Sigmoid,
   Sin,
   Sinh,
@@ -442,6 +441,7 @@ static constexpr std::array<IdMappingMode, 5> kIdMappingModes = {
 // Used to annotate the special memory intrinsics that a loadstore
 //  op will be lowered to.
 enum class LoadStoreOpType {
+  Automatic, // load store type automatically determined at codegen
   LdMatrix,
   LdMatrixTranspose,
   CpAsyncCa,

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -3515,7 +3515,7 @@ TEST_F(NVFuserTest, FusionUnaryOps_CUDA) {
 
   // The following ops only supports complex
   std::vector<OpTuple> ops_complex_only{
-      // real is supported via UnaryOpType::Set for non-complex types, and
+      // real is supported via LoadStoreOp for non-complex types, and
       // UnaryOpType::Real requires input to be complex
       OpTuple{at::real, UnaryOpType::Real, "real"},
       OpTuple{at::imag, UnaryOpType::Imag, "imag"},

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -1412,7 +1412,7 @@ TEST_F(NVFuserTest, FusionCodegenAllocatedScalars_CUDA) {
   auto tki0 = IrBuilder::create<kir::TensorIndex>(tk0, ks0);
   auto tki1 = IrBuilder::create<kir::TensorIndex>(tk0, ks1);
   auto tk0_expr =
-      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Automatic, tki0, tki1);
+      IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, tki0, tki1);
 
   // Insert the scalar expression and the allocation of the
   // output directly to the kernel

--- a/test/test_gpu_indexing.cpp
+++ b/test/test_gpu_indexing.cpp
@@ -12,7 +12,7 @@
 #include <inlining.h>
 #include <ir_all_nodes.h>
 #include <ir_builder.h>
-#include <ops/arith.h>
+#include <ops/all_ops.h>
 #include <scheduler/all_schedulers.h>
 
 #include <test/test_gpu_validator.h>

--- a/test/test_gpu_indexing.cpp
+++ b/test/test_gpu_indexing.cpp
@@ -751,8 +751,8 @@ TEST_F(NVFuserTest, FusionIndexing17_CUDA) {
   fusion.addInput(tv0);
   auto tv1 = makeConcreteTensor({4});
   fusion.addInput(tv1);
-  auto tv2 = unaryOp(UnaryOpType::Set, tv0);
-  auto tv3 = unaryOp(UnaryOpType::Set, tv1);
+  auto tv2 = set(tv0);
+  auto tv3 = set(tv1);
 
   auto tv4 = sum(tv2, {0, 2});
   auto tv5 = add(tv4, tv3);

--- a/test/test_gpu_rng.cu
+++ b/test/test_gpu_rng.cu
@@ -13,7 +13,7 @@
 #include <fusion.h>
 #include <ir_all_nodes.h>
 #include <kernel_cache.h>
-#include <ops/arith.h>
+#include <ops/all_ops.h>
 #include <scheduler/all_schedulers.h>
 #include <test/test_gpu_validator.h>
 #include <test/test_utils.h>

--- a/test/test_loop_rotation.cpp
+++ b/test/test_loop_rotation.cpp
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <inlining.h>
-#include <ops/arith.h>
+#include <ops/all_ops.h>
 #include <scheduler/utils.h>
 #include <test/test_gpu_validator.h>
 #include <test/test_utils.h>


### PR DESCRIPTION
This cleanup comes to my mind during @jacobhinkle's talk (thank you so much for having this talk) where he mentioned that transpose does not use rfactor domain. I think it makes more sense to model transpose as a set with rfactor domain in its consumer, and I think this new way would help me model `ldmatrix.T` and matmul's `NN` support better.

This refactor does the following:
- Remove `UnaryOpType::Set`. Set is now a `LoadStoreOp` with `LoadStoreOpType::Automatic`. This get rid of a lot of special handling for set.
- If the consumer of a `LoadStoreOp` contains an rfactor domain, then this load store op has fused permutation. (I think view can be modeled the same way, but this is not the purpose of this PR).
- `TransposeOp` is removed completely. Permutation/transpose is now a `LoadStoreOp` with rfactor in consumer.
- There is no more special handling for transpose in `PairwiseRootDomainMap` and `ComputeAtRootDomainMap`
- In the future, I will consider modeling `ldmatrix.T` as an operation with fused transpose, I have not carefully investigated this idea yet, but I believe this would make it more straightforward to support `NN` in matmul.