### PR TITLE
Bank conflict checker fix

### DIFF
--- a/csrc/ir_internal_nodes.h
+++ b/csrc/ir_internal_nodes.h
@@ -2196,8 +2196,40 @@ class TORCH_CUDA_CU_API NamedScalar : public Val {
   //! Check if this is something like T0.stride[1]
   bool isTensorStride() const;
 
-  //! Return the named scalar extent of a parallel dimension (e.g. blockDim.x)
-  //! WARNING: Only works with Fusion container at the moment
+  //! Check if this is threadIdx.{x,y,z}
+  bool isThreadIdx() const {
+    auto p = getParallelIndex();
+    return (
+        p == ParallelType::TIDx || p == ParallelType::TIDy ||
+        p == ParallelType::TIDz);
+  }
+
+  //! Check if this is blockIdx.{x,y,z}
+  bool isBlockIdx() const {
+    auto p = getParallelIndex();
+    return (
+        p == ParallelType::BIDx || p == ParallelType::BIDy ||
+        p == ParallelType::BIDz);
+  }
+
+  //! Check if this is blockDim.{x,y,z}
+  bool isBlockDim() const {
+    auto p = getParallelDim();
+    return (
+        p == ParallelType::TIDx || p == ParallelType::TIDy ||
+        p == ParallelType::TIDz);
+  }
+
+  //! Check if this is gridDim.{x,y,z}
+  bool isGridDim() const {
+    auto p = getParallelDim();
+    return (
+        p == ParallelType::BIDx || p == ParallelType::BIDy ||
+        p == ParallelType::BIDz);
+  }
+
+  //! Return the named scalar extent of a parallel dimension (e.g.
+  //! blockDim.x) WARNING: Only works with Fusion container at the moment
   static NamedScalar* getParallelDim(ParallelType p_type);
 
   //! Return the named scalar index of a parallel dimension (e.g. threadIdx.x)

--- a/csrc/ir_internal_nodes.h
+++ b/csrc/ir_internal_nodes.h
@@ -2228,8 +2228,8 @@ class TORCH_CUDA_CU_API NamedScalar : public Val {
         p == ParallelType::BIDz);
   }
 
-  //! Return the named scalar extent of a parallel dimension (e.g.
-  //! blockDim.x) WARNING: Only works with Fusion container at the moment
+  //! Return the named scalar extent of a parallel dimension (e.g. blockDim.x)
+  //! WARNING: Only works with Fusion container at the moment
   static NamedScalar* getParallelDim(ParallelType p_type);
 
   //! Return the named scalar index of a parallel dimension (e.g. threadIdx.x)

--- a/csrc/ir_utils.h
+++ b/csrc/ir_utils.h
@@ -177,7 +177,7 @@ TORCH_CUDA_CU_API Expr* replaceValInExpr(
 
 //! Replace Vals in an index Val as specified by replacement_map while
 //! cloning the given index Val. The index val is assumed to represent
-//! a tensor index consisting of Ints  and arithmetic expressions.
+//! a tensor index consisting of Ints and arithmetic expressions.
 //!
 //! This is similar to replaceValInExpr but is different as Vals are
 //! cloned such that no other exprs using the same leaf Vals are not

--- a/csrc/lower_bank_conflict.h
+++ b/csrc/lower_bank_conflict.h
@@ -45,6 +45,6 @@ namespace nvfuser {
 std::unordered_map<const Expr*, std::pair<int, int>> getBankConflictInfo(
     kir::Kernel* kernel,
     c10::optional<LaunchParams> launch_params = c10::nullopt,
-    const std::unordered_map<std::string, EvaluatorValue>& known_values = {});
+    const std::unordered_map<Val*, EvaluatorValue>& known_values = {});
 
 } // namespace nvfuser


### PR DESCRIPTION
Currently, the bank conflict check does not work for matmul, because its address contain tensor's base address (something like `BaseAddress(T7) + 16 * threadIdx.x + 8192 * i487 + 2048 * i481`). This PR fixes this issue, and in addition, this PR also does some cleanup.