### PR TITLE
Remove TypeHash

### DIFF
--- a/csrc/evaluator_common.h
+++ b/csrc/evaluator_common.h
@@ -127,7 +127,7 @@ class PrecomputedValues {
   void bindInputs(const KernelArgumentHolder& args);
 
   using ParallelExtentMap =
-      std::unordered_map<ParallelType, std::vector<const Val*>, TypeHash>;
+      std::unordered_map<ParallelType, std::vector<const Val*>>;
 
   //! Bind concrete values from launch constraints
   void bindParallelExtents(
@@ -162,7 +162,7 @@ class PrecomputedValues {
 
   //! Contains all the named scalars correspond
   //!  to thread size of each parallel type.
-  std::unordered_map<ParallelType, std::unique_ptr<std::vector<int>>, TypeHash>
+  std::unordered_map<ParallelType, std::unique_ptr<std::vector<int>>>
       thread_dim_value_indices_;
 
   //! Initialize the workspace before first use.

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -141,8 +141,7 @@ class ParallelBindingIterDomains {
 //!    iterdomains corresponding to each used parallel type.
 class ParallelIterExtentMap {
  public:
-  using DataType =
-      std::unordered_map<ParallelType, std::vector<const Val*>, TypeHash>;
+  using DataType = std::unordered_map<ParallelType, std::vector<const Val*>>;
   static const CompileTimeEntryType EntryType =
       CompileTimeEntryType::PARALLEL_ITER_EXTENT_MAP;
 };
@@ -284,7 +283,7 @@ std::vector<IterDomain*> getParallelBindingsIterDomains(
     const std::vector<TensorView*>& used_tvs);
 
 using ParallelExtentMap =
-    std::unordered_map<ParallelType, std::vector<const Val*>, TypeHash>;
+    std::unordered_map<ParallelType, std::vector<const Val*>>;
 
 //! Returns the extents of all parallel binding iterdomains corresponding
 //!  to each parallel type.

--- a/csrc/ir_container.h
+++ b/csrc/ir_container.h
@@ -151,7 +151,7 @@ class TORCH_CUDA_CU_API IrContainer : public PolymorphicBase {
   std::unordered_set<void*> raw_ptrs_;
 
   // Values names counters
-  std::unordered_map<ValType, StmtNameType, TypeHash> val_type_name_map_;
+  std::unordered_map<ValType, StmtNameType> val_type_name_map_;
 
   // Expression names counter
   StmtNameType expr_name_counter_ = 0;

--- a/csrc/lower_thread_predicate.h
+++ b/csrc/lower_thread_predicate.h
@@ -41,10 +41,8 @@ namespace nvfuser {
 //! tensor.
 class TORCH_CUDA_CU_API ThreadPredicateMap {
  public:
-  using SourceMap = std::unordered_map<
-      ParallelType,
-      std::unordered_set<const TensorView*>,
-      TypeHash>;
+  using SourceMap =
+      std::unordered_map<ParallelType, std::unordered_set<const TensorView*>>;
 
   //! Thread predicate information for each tensor
   struct PredicateInfo {

--- a/csrc/lower_utils.cpp
+++ b/csrc/lower_utils.cpp
@@ -300,7 +300,7 @@ c10::optional<IterDomain*> getMaybeWarpReductionDim(
   return c10::nullopt;
 }
 
-std::unordered_map<ParallelType, IterDomain*, TypeHash> getParallelDomains(
+std::unordered_map<ParallelType, IterDomain*> getParallelDomains(
     const Val* val) {
   const TensorView* tv = nullptr;
   if (val->isA<TensorView>()) {
@@ -312,7 +312,7 @@ std::unordered_map<ParallelType, IterDomain*, TypeHash> getParallelDomains(
         false, "Provided val is not TensorIndex or TensorView.");
   }
 
-  std::unordered_map<ParallelType, IterDomain*, TypeHash> parallel_domains;
+  std::unordered_map<ParallelType, IterDomain*> parallel_domains;
   for (auto d : tv->domain()->domain()) {
     if (d->isThread()) {
       parallel_domains.insert(std::make_pair(d->getParallelType(), d));

--- a/csrc/lower_utils.h
+++ b/csrc/lower_utils.h
@@ -113,7 +113,7 @@ const TensorView* getTv(const Val*);
 //! Get only TensorView potentially via kir::TensorIndex.
 std::vector<TensorView*> getTvs(const std::vector<Val*>& vals);
 
-std::unordered_map<ParallelType, IterDomain*, TypeHash> getParallelDomains(
+std::unordered_map<ParallelType, IterDomain*> getParallelDomains(
     const Val* val);
 
 //! Returns true if the expression will be lowered to

--- a/csrc/parallel_dimension_map.h
+++ b/csrc/parallel_dimension_map.h
@@ -35,7 +35,7 @@ class TORCH_CUDA_CU_API ParallelDimensionMap {
 
   std::string toString() const;
 
-  const std::unordered_map<ParallelType, Val*, TypeHash>& getMap() const {
+  const std::unordered_map<ParallelType, Val*>& getMap() const {
     return dim_map_;
   }
 
@@ -47,10 +47,10 @@ class TORCH_CUDA_CU_API ParallelDimensionMap {
  private:
   //! Maps from parallel types to dimensions, which are constant if
   //! a unique value is found.
-  std::unordered_map<ParallelType, Val*, TypeHash> dim_map_;
+  std::unordered_map<ParallelType, Val*> dim_map_;
   //! Set of parallel types whose dimensions are identified to be
   //! exactly the same as extents of mapped domains.
-  std::unordered_set<ParallelType, TypeHash> exact_types_;
+  std::unordered_set<ParallelType> exact_types_;
 };
 
 } // namespace nvfuser

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -119,10 +119,7 @@ bool isFullyUnswitched(
 
 } // namespace
 
-std::unordered_map<
-    ParallelType,
-    ParallelizedDomainPredicate::PredicateInfo,
-    TypeHash>
+std::unordered_map<ParallelType, ParallelizedDomainPredicate::PredicateInfo>
 ParallelizedDomainPredicate::getPredicateMap(
     const Expr* expr,
     const std::vector<kir::ForLoop*>& loops,
@@ -135,7 +132,7 @@ ParallelizedDomainPredicate::getPredicateMap(
   }
 
   // Initialize a map with empty predicate info
-  std::unordered_map<ParallelType, PredicateInfo, TypeHash> map;
+  std::unordered_map<ParallelType, PredicateInfo> map;
   for (auto pt : kParallelTypeThreads) {
     map.insert({pt, PredicateInfo(pt)});
   }

--- a/csrc/predicate_compute.h
+++ b/csrc/predicate_compute.h
@@ -67,8 +67,7 @@ class ParallelizedDomainPredicate {
 
   //! Returns predicate information for parallelied domains of an
   //! expression.
-  static std::unordered_map<ParallelType, PredicateInfo, TypeHash>
-  getPredicateMap(
+  static std::unordered_map<ParallelType, PredicateInfo> getPredicateMap(
       const Expr* expr,
       const std::vector<kir::ForLoop*>& loops,
       kir::ForLoop* unswitched_loop = nullptr);
@@ -117,8 +116,7 @@ class UnswitchPredicateKey {
   //! Predicated concrete domain
   IterDomain* predicated_concrete_id_ = nullptr;
   //! Store parallelized concrete domains
-  std::unordered_map<ParallelType, IterDomain*, TypeHash>
-      parallel_concrete_ids_;
+  std::unordered_map<ParallelType, IterDomain*> parallel_concrete_ids_;
 };
 
 struct UnswitchPredicateKeyHash {
@@ -183,10 +181,7 @@ class TORCH_CUDA_CU_API UnswitchPredicate {
   std::vector<MergedPredicates> pending_predicates_;
 
   //! Track which parallelized domains have been predicated
-  std::unordered_map<
-      ParallelType,
-      ParallelizedDomainPredicate::PredicateInfo,
-      TypeHash>
+  std::unordered_map<ParallelType, ParallelizedDomainPredicate::PredicateInfo>
       parallelized_dom_predicates_;
 
   //! The predicates that have been generated.

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -23,14 +23,6 @@
 
 namespace nvfuser {
 
-// https://stackoverflow.com/questions/18837857/cant-use-enum-class-as-unordered-map-key
-struct TypeHash {
-  template <typename T>
-  std::size_t operator()(T t) const {
-    return static_cast<std::size_t>(t);
-  }
-};
-
 // Order of strength
 enum class ValType {
   TensorDomain,


### PR DESCRIPTION
This is a minor PR removing `TypeHash` from the codebase. This was a workaround (introduced in https://github.com/pytorch/pytorch/pull/35917/commits/c5f805590d69a83729a524be5c39db319209e7e5) for the lack of support for using `enum class`es like `ValType` as keys in STL hash-tables like `std::unordered_map`. See https://stackoverflow.com/questions/18837857/cant-use-enum-class-as-unordered-map-key for more discussion on the general issue. As noted in that issue, this was resolved in C++14 (see https://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#2148) so I think it should no longer be necessary as NVFuser has even moved on to C++17 by now.

