### PR TITLE
Cleanup bank conflict checker to better infer launch param

### DIFF
--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -133,6 +133,14 @@ c10::optional<EvaluatorValue> ExpressionEvaluator::evaluate(const Val* value) {
   return maybe_concrete_value;
 }
 
+c10::optional<EvaluatorValue> ExpressionEvaluator::evaluate(ParallelType pt) {
+  auto it = known_named_scalars_.find(stringifyThreadSize(pt));
+  if (it != known_named_scalars_.end()) {
+    return it->second;
+  }
+  return c10::nullopt;
+}
+
 c10::optional<EvaluatorValue> ExpressionEvaluator::getValue(const Val* value) {
   TORCH_INTERNAL_ASSERT(
       value->isIntegralScalar() || value->isFloatingPointScalar() ||

--- a/csrc/expr_evaluator.h
+++ b/csrc/expr_evaluator.h
@@ -46,6 +46,9 @@ class TORCH_CUDA_CU_API ExpressionEvaluator {
   //! Try to evaluate a Fusion IR value
   c10::optional<EvaluatorValue> evaluate(const Val* value);
 
+  //! Try to evaluate a parallel dimension
+  c10::optional<EvaluatorValue> evaluate(ParallelType pt);
+
   //! Debugging helper, prints all the currently known values
   void print() const;
 

--- a/csrc/lower_bank_conflict.h
+++ b/csrc/lower_bank_conflict.h
@@ -43,8 +43,8 @@ namespace nvfuser {
 // way == 0 --> not applicable (for example, tensor is not a smem tensor)
 // way == 1 --> no conflict
 std::unordered_map<const Expr*, std::pair<int, int>> getBankConflictInfo(
-    kir::Kernel* kernel,
-    c10::optional<LaunchParams> launch_params = c10::nullopt,
+    const kir::Kernel* kernel,
+    LaunchParams launch_params = {},
     const std::unordered_map<Val*, EvaluatorValue>& known_values = {});
 
 } // namespace nvfuser


### PR DESCRIPTION
- Use `kernel->summary().parallel_dimension_map_` to replace `InferLaunchParams`
- Use `LaunchParams()` (all `LaunchParams::UNINITIALIZED_VAL`) to replace `c10::optional<LaunchParams>`