### PR TITLE
Refactoring type switch

### DIFF
--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -88,36 +88,20 @@ std::unique_ptr<TensorArgAbstract> getTensorArg(int nDims) {
   return nullptr;
 }
 
+template <typename nvfuser_index_t>
+struct GetTensorArgWithNativeType {
+  template <typename T>
+  std::unique_ptr<TensorArgAbstract> operator()(int ndims) {
+    return getTensorArg<T, nvfuser_index_t>(ndims);
+  };
+};
+
 template <typename INDEX_MODE>
 std::unique_ptr<TensorArgAbstract> getTensorArg(
     c10::ScalarType dtype,
     int nDims) {
-  switch (dtype) {
-    case c10::ScalarType::Double:
-      return getTensorArg<double, INDEX_MODE>(nDims);
-    case c10::ScalarType::Float:
-      return getTensorArg<float, INDEX_MODE>(nDims);
-    case c10::ScalarType::Half:
-      return getTensorArg<at::Half, INDEX_MODE>(nDims);
-    case c10::ScalarType::BFloat16:
-      return getTensorArg<at::BFloat16, INDEX_MODE>(nDims);
-    case c10::ScalarType::Bool:
-      return getTensorArg<bool, INDEX_MODE>(nDims);
-    case c10::ScalarType::Long:
-      return getTensorArg<int64_t, INDEX_MODE>(nDims);
-    case c10::ScalarType::Int:
-      return getTensorArg<int32_t, INDEX_MODE>(nDims);
-    case c10::ScalarType::ComplexFloat:
-      return getTensorArg<c10::complex<float>, INDEX_MODE>(nDims);
-    case c10::ScalarType::ComplexDouble:
-      return getTensorArg<c10::complex<double>, INDEX_MODE>(nDims);
-    default:
-      TORCH_CHECK(
-          false,
-          "Dtype: ",
-          dtype,
-          " not currently supported in code generated kernels.");
-  }
+  return atenTypeDispatchWithC10Complex(
+      dtype, GetTensorArgWithNativeType<INDEX_MODE>(), nDims);
 }
 
 std::unique_ptr<TensorArgAbstract> getTensorArg(
@@ -176,68 +160,24 @@ KernelArgumentHolder KernelArgumentHolder::createKernelArgumentHolder(
   return args;
 }
 
+namespace {
+
+struct MakeCpuScalarTensor {
+  template <typename T>
+  std::unique_ptr<ArgAbstract> operator()(const at::Tensor& tensor) const {
+    return std::make_unique<CpuScalarTensorArg<CpuScalarTensorCodegen<T>>>(
+        tensor.data_ptr<T>()[0]);
+  }
+};
+
+} // namespace
+
 // Push a tensor to the arguments
 void KernelArgumentHolder::push(const at::Tensor& tensor) {
   changed_ = true;
   if (is_cpu_scalar(tensor)) {
-    switch (tensor.scalar_type()) {
-      case c10::ScalarType::ComplexDouble:
-        arguments_.push_back(std::make_unique<CpuScalarTensorArg<
-                                 CpuScalarTensorCodegen<c10::complex<double>>>>(
-            tensor.data_ptr<c10::complex<double>>()[0]));
-        break;
-      case c10::ScalarType::ComplexFloat:
-        arguments_.push_back(std::make_unique<CpuScalarTensorArg<
-                                 CpuScalarTensorCodegen<c10::complex<float>>>>(
-            tensor.data_ptr<c10::complex<float>>()[0]));
-        break;
-      case c10::ScalarType::Double:
-        arguments_.push_back(
-            std::make_unique<
-                CpuScalarTensorArg<CpuScalarTensorCodegen<double>>>(
-                tensor.data_ptr<double>()[0]));
-        break;
-      case c10::ScalarType::Float:
-        arguments_.push_back(
-            std::make_unique<CpuScalarTensorArg<CpuScalarTensorCodegen<float>>>(
-                tensor.data_ptr<float>()[0]));
-        break;
-      case c10::ScalarType::Half:
-        arguments_.push_back(
-            std::make_unique<
-                CpuScalarTensorArg<CpuScalarTensorCodegen<at::Half>>>(
-                tensor.data_ptr<at::Half>()[0]));
-        break;
-      case c10::ScalarType::BFloat16:
-        arguments_.push_back(
-            std::make_unique<
-                CpuScalarTensorArg<CpuScalarTensorCodegen<at::BFloat16>>>(
-                tensor.data_ptr<at::BFloat16>()[0]));
-        break;
-      case c10::ScalarType::Bool:
-        arguments_.push_back(
-            std::make_unique<CpuScalarTensorArg<CpuScalarTensorCodegen<bool>>>(
-                tensor.data_ptr<bool>()[0]));
-        break;
-      case c10::ScalarType::Long:
-        arguments_.push_back(
-            std::make_unique<
-                CpuScalarTensorArg<CpuScalarTensorCodegen<int64_t>>>(
-                tensor.data_ptr<int64_t>()[0]));
-        break;
-      case c10::ScalarType::Int:
-        arguments_.push_back(
-            std::make_unique<
-                CpuScalarTensorArg<CpuScalarTensorCodegen<int32_t>>>(
-                tensor.data_ptr<int32_t>()[0]));
-        break;
-      default:
-        TORCH_CHECK(
-            false,
-            "Dtype: ",
-            tensor.scalar_type(),
-            " not currently supported in code generated kernels.");
-    }
+    arguments_.push_back(atenTypeDispatchWithC10Complex(
+        tensor.scalar_type(), MakeCpuScalarTensor(), tensor));
   } else {
     int nDims = (int)tensor.ndimension();
 

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -54,27 +54,19 @@ std::unique_ptr<TensorArgAbstract> getTensorArg(int nDims) {
       return std::make_unique<TensorArg<
           TensorArgCodegen<T, 4, nvfuser_index_t>,
           nvfuser_index_t>>();
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     case (5):
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return std::make_unique<TensorArg<
           TensorArgCodegen<T, 5, nvfuser_index_t>,
           nvfuser_index_t>>();
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     case (6):
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return std::make_unique<TensorArg<
           TensorArgCodegen<T, 6, nvfuser_index_t>,
           nvfuser_index_t>>();
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     case (7):
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return std::make_unique<TensorArg<
           TensorArgCodegen<T, 7, nvfuser_index_t>,
           nvfuser_index_t>>();
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     case (8):
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return std::make_unique<TensorArg<
           TensorArgCodegen<T, 8, nvfuser_index_t>,
           nvfuser_index_t>>();
@@ -204,7 +196,6 @@ void KernelArgumentHolder::push(const c10::IValue& val) {
       val);
   auto scalar_val = val.toScalar();
   switch (scalar_val.type()) {
-    // NOLINTNEXTLINE(bugprone-branch-clone)
     case c10::ScalarType::ComplexDouble:
       arguments_.push_back(
           std::make_unique<ComplexDoubleArg>(scalar_val.toComplexDouble()));

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -212,27 +212,103 @@ TORCH_CUDA_CU_API bool isSupportedTypeByDevice(DataType dtype);
 template <PrimDataType DT>
 struct DataTypeToNativeType;
 
+template <PrimDataType DT>
+struct DataTypeToNativeTypeWithC10Complex;
+
+template <PrimDataType DT>
+struct DataTypeToAtenType;
+
 template <typename NativeType>
 struct NativeTypeToDataType;
 
-#define DEFINE_DATATYPE_TO_NATIVE_TYPE(data_type, native_type) \
-  template <>                                                  \
-  struct DataTypeToNativeType<data_type> {                     \
-    using type = native_type;                                  \
-  };                                                           \
-  template <>                                                  \
-  struct NativeTypeToDataType<native_type> {                   \
-    static constexpr PrimDataType type = data_type;            \
+template <typename NativeType>
+struct NativeTypeWithC10ComplexToDataType;
+
+template <at::ScalarType aten_type>
+struct AtenTypeToDataType;
+
+template <at::ScalarType aten_type>
+struct AtenTypeToNativeType;
+
+template <at::ScalarType aten_type>
+struct AtenTypeToNativeTypeWithC10Complex;
+
+#define DEFINE_DATATYPE_TO_NATIVE_TYPE(                                     \
+    data_type, at_type, native_type, native_type_with_c10_complex)          \
+  template <>                                                               \
+  struct DataTypeToNativeType<data_type> {                                  \
+    using type = native_type;                                               \
+  };                                                                        \
+  template <>                                                               \
+  struct DataTypeToNativeTypeWithC10Complex<data_type> {                    \
+    using type = native_type_with_c10_complex;                              \
+  };                                                                        \
+  template <>                                                               \
+  struct DataTypeToAtenType<data_type> {                                    \
+    static constexpr at::ScalarType type = at_type;                         \
+  };                                                                        \
+  template <>                                                               \
+  struct NativeTypeToDataType<native_type> {                                \
+    static constexpr PrimDataType type = data_type;                         \
+  };                                                                        \
+  template <>                                                               \
+  struct NativeTypeWithC10ComplexToDataType<native_type_with_c10_complex> { \
+    static constexpr PrimDataType type = data_type;                         \
+  };                                                                        \
+  template <>                                                               \
+  struct AtenTypeToDataType<at_type> {                                      \
+    static constexpr PrimDataType type = data_type;                         \
+  };                                                                        \
+  template <>                                                               \
+  struct AtenTypeToNativeType<at_type> {                                    \
+    using type = native_type;                                               \
+  };                                                                        \
+  template <>                                                               \
+  struct AtenTypeToNativeTypeWithC10Complex<at_type> {                      \
+    using type = native_type_with_c10_complex;                              \
   };
 
-// TODO: Add more type specializations
-DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Float, float);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Double, double);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Int, int64_t);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Int32, int);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Bool, bool);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::ComplexFloat, std::complex<float>);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::ComplexDouble, std::complex<double>);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
+    DataType::Float,
+    at::ScalarType::Float,
+    float,
+    float);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
+    DataType::Double,
+    at::ScalarType::Double,
+    double,
+    double);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
+    DataType::Half,
+    at::ScalarType::Half,
+    at::Half,
+    at::Half);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
+    DataType::BFloat16,
+    at::ScalarType::BFloat16,
+    at::BFloat16,
+    at::BFloat16);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
+    DataType::Int,
+    at::ScalarType::Long,
+    int64_t,
+    int64_t);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Int32, at::ScalarType::Int, int, int);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
+    DataType::Bool,
+    at::ScalarType::Bool,
+    bool,
+    bool);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
+    DataType::ComplexFloat,
+    at::ScalarType::ComplexFloat,
+    std::complex<float>,
+    c10::complex<float>);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
+    DataType::ComplexDouble,
+    at::ScalarType::ComplexDouble,
+    std::complex<double>,
+    c10::complex<double>);
 
 #undef DEFINE_DATATYPE_TO_NATIVE_TYPE
 

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -450,7 +450,7 @@ class DebugPrintScope {
 //! c10::complex<float>. For the latter behavior, please use
 //! atenTypeDispatchWithC10Complex below.
 template <typename Functor, typename... Args>
-auto atenTypeDispatch(at::ScalarType type, Functor func, Args... args) {
+auto atenTypeDispatch(at::ScalarType type, Functor func, Args&&... args) {
   switch (type) {
     case at::ScalarType::Int:
       return func
@@ -504,7 +504,7 @@ template <typename Functor, typename... Args>
 auto atenTypeDispatchWithC10Complex(
     at::ScalarType type,
     Functor func,
-    Args... args) {
+    Args&&... args) {
   switch (type) {
     case at::ScalarType::Int:
       return func.template

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -442,4 +442,107 @@ class DebugPrintScope {
 #define DEBUG_PRINT_SCOPE(...) \
   DebugPrintScope _debug_print_scope(__func__, ##__VA_ARGS__)
 
+//! Dispatch Functor::opeartor()<NativeType>(Args) where NativeType is
+//! the actual C++ type that corresponds to the given Aten scalar
+//! type. Deduction of the native type is done using
+//! AtenTypeToNativeType, so for example at::ScalarType::ComplexFloat
+//! corresponds to std::complex<float> rathe than
+//! c10::complex<float>. For the latter behavior, please use
+//! atenTypeDispatchWithC10Complex below.
+template <typename Functor, typename... Args>
+auto atenTypeDispatch(at::ScalarType type, Functor func, Args... args) {
+  switch (type) {
+    case at::ScalarType::Int:
+      return func
+          .template operator()<AtenTypeToNativeType<at::ScalarType::Int>::type>(
+              std::forward<Args>(args)...);
+    case at::ScalarType::Long:
+      return func.template
+      operator()<AtenTypeToNativeType<at::ScalarType::Long>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::Bool:
+      return func.template
+      operator()<AtenTypeToNativeType<at::ScalarType::Bool>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::Float:
+      return func.template
+      operator()<AtenTypeToNativeType<at::ScalarType::Float>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::Double:
+      return func.template
+      operator()<AtenTypeToNativeType<at::ScalarType::Double>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::Half:
+      return func.template
+      operator()<AtenTypeToNativeType<at::ScalarType::Half>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::BFloat16:
+      return func.template
+      operator()<AtenTypeToNativeType<at::ScalarType::BFloat16>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::ComplexFloat:
+      return func.template
+      operator()<AtenTypeToNativeType<at::ScalarType::ComplexFloat>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::ComplexDouble:
+      return func.template
+      operator()<AtenTypeToNativeType<at::ScalarType::ComplexDouble>::type>(
+          std::forward<Args>(args)...);
+    default:
+      TORCH_INTERNAL_ASSERT(false, "Unexpected aten type: ", type);
+  }
+}
+
+//! Dispatch Functor::opeartor()<NativeType>(Args) where NativeType is
+//! the actual C++ type that corresponds to the given Aten scalar
+//! type. Deduction of the native type is done using
+//! AtenTypeToNativeTypeWithC10Complex, so for example
+//! at::ScalarType::ComplexFloat corresponds to c10::complex<float> rathe than
+//! std::complex<float>. For the latter behavior, please use
+//! atenTypeDispatch above.
+template <typename Functor, typename... Args>
+auto atenTypeDispatchWithC10Complex(
+    at::ScalarType type,
+    Functor func,
+    Args... args) {
+  switch (type) {
+    case at::ScalarType::Int:
+      return func.template
+      operator()<AtenTypeToNativeTypeWithC10Complex<at::ScalarType::Int>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::Long:
+      return func.template operator()<
+          AtenTypeToNativeTypeWithC10Complex<at::ScalarType::Long>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::Bool:
+      return func.template operator()<
+          AtenTypeToNativeTypeWithC10Complex<at::ScalarType::Bool>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::Float:
+      return func.template operator()<
+          AtenTypeToNativeTypeWithC10Complex<at::ScalarType::Float>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::Double:
+      return func.template operator()<
+          AtenTypeToNativeTypeWithC10Complex<at::ScalarType::Double>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::Half:
+      return func.template operator()<
+          AtenTypeToNativeTypeWithC10Complex<at::ScalarType::Half>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::BFloat16:
+      return func.template operator()<
+          AtenTypeToNativeTypeWithC10Complex<at::ScalarType::BFloat16>::type>(
+          std::forward<Args>(args)...);
+    case at::ScalarType::ComplexFloat:
+      return func.template operator()<AtenTypeToNativeTypeWithC10Complex<
+          at::ScalarType::ComplexFloat>::type>(std::forward<Args>(args)...);
+    case at::ScalarType::ComplexDouble:
+      return func.template operator()<AtenTypeToNativeTypeWithC10Complex<
+          at::ScalarType::ComplexDouble>::type>(std::forward<Args>(args)...);
+    default:
+      TORCH_INTERNAL_ASSERT(false, "Unexpected aten type: ", type);
+  }
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
As part of overall refactoring of the executor, I wanted to clean up the type switch pattern like: `switch (aten_scalar_type) { case at::ScalarType::Float: ....`.

I added two utility template functions: `atenTypeDispatch` and `atenTypeDispatchWithC10Complex`. Here's what `atenTypeDispatch` looks like:

```
template <typename Functor, typename... Args>
auto atenTypeDispatch(at::ScalarType type, Functor func, Args&&... args);
```

`Functor` should be a struct with `operator()(Args...)` templated with the native C++ type of `at::ScalarType type`. `atenTypeDispatch` then calls the functor with the native type.

A variant of this dispatch is `atenTypeDispatchWithC10Complex`. This may not be necessary, but currently we are using both `c10::complex` and `std::complex`, and so sometimes we may want to dispatch with `std::complex<float>` or `c10::complex<float>`. `atenTypeDispatchWithC10Complex` does the latter.

According to @zasdfgbnm, it should be safe to treat `c10::complex<float>` and `std::complex<float>` as reinterpretable to each other. I'm not sure if that means we can just replace `c10::complex<float>` with `std::complex<float>`. In this PR, I modified two switch-based dispatch with `atenTypeDispatchWithC10Complex`. It seems one of them can be fine with `atenTypeDispatch`, but for another, the question is if the following is valid:

```
at::Tensor scalar_tensor; // type = at::ScalarType::ComplexFloat
std::complex<float> val = scalar_tensor.data_ptr<std::complex<float>>()[0];
kernel<<<>>>(val);
```

And the kernel is defined as:
```
__global__ void kernel(std::complex<float> val);
```

Here, `std::complex` is the struct defined in `complex_number.cu`. 

This is effectively what's done here (https://github.com/NVIDIA/Fuser/blob/main/csrc/executor_kernel_arg.cpp#L184), where `c10::complex<float>` is used in the host side.

So, my two questions are:

1. Is this valid? `std::complex<float> val = scalar_tensor.data_ptr<std::complex<float>>()[0];`
2. Is it valid to pass a `std::complex<float>` value on the host side to a CUDA kernel as argument to a parameter of type `std::complex<float>`

Note that on the host side, the definition of `std::complex` is not the same as our `std::complex` definition in complex_numbers.cu. Are they ABI-compatible?

That actually seems to be the case per "Array-oriented access" in https://en.cppreference.com/w/cpp/numeric/complex, but I'm not completely sure.

Currently, this PR should reproduce what the TOT does faithfully. If both usages should be fine with just using `atenTypeDispatch`, I'd happy to update the PR.