### PR TITLE
allow var_mean on complex number

### DIFF
--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -2954,7 +2954,8 @@ void testVarMean(at::ScalarType dtype, int correction, bool keepdim) {
 } // namespace
 
 TEST_F(NVFuserTest, FusionVarMean_CUDA) {
-  std::vector<at::ScalarType> dtypes = {at::kFloat, at::kDouble};
+  std::vector<at::ScalarType> dtypes = {
+      at::kFloat, at::kDouble, at::kComplexFloat, at::kComplexDouble};
   std::vector<int> corrections = {0, 1};
   std::vector<bool> keepdims = {false, true};
   for (auto correction : corrections) {


### PR DESCRIPTION
The op to construct a tensor of complex number from two tensors representing real and imag parts was added in #168.
That feature also enables var_mean on tensor of complex numbers.