### PR TITLE
Vectorize global memory write in matmul schedule

### DIFF
--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -2499,7 +2499,7 @@ void IterDomain::parallelize(ParallelType t) {
     //  they are swizzled.
     TORCH_CHECK(
         t == ParallelType::Vectorize || t == ParallelType::TIDx ||
-            t == ParallelType::Serial,
+            t == ParallelType::Serial || t == ParallelType::Mma,
         "Parallel type other than serial, tidx, vectorize not allowed for mma swizzled ids");
   }
 

--- a/csrc/lower_validation.cpp
+++ b/csrc/lower_validation.cpp
@@ -898,7 +898,8 @@ void validateMmaTensors(MmaOp* mma) {
                   //  CA axis are constant sized to ensure early detection of
                   //  invalid mma schedules.
                   ((id->isBroadcast() || id->extent()->isConstInt()) &&
-                   id->getParallelType() == ParallelType::Serial);
+                   id->getParallelType() == ParallelType::Serial) ||
+                  id->isThread();
             }),
         "All id's on the right of CA pos needs to be mma-swizzled by WarpMmaSwizzler\n",
         tv);

--- a/test/test_gpu_matmul_sass.cpp
+++ b/test/test_gpu_matmul_sass.cpp
@@ -69,8 +69,6 @@ sass::Container getSASSFor(
   params.double_buffer_options.smem_double_buffer_stage = 4;
   scheduleMatmul(&fusion, params);
 
-  fusion.printTransforms();
-
   at::manual_seed(0);
   auto inputs = fp16MatmulAtInput(M, N, K, layout);
 


### PR DESCRIPTION
This PR has a few changes cherry-picked from https://github.com/NVIDIA/Fuser/pull/38, the most important change is to vectorize global memory write. The perf improvement is actually not small:

On my RTX 3090:
```C++
$CUDA_VISIBLE_DEVICES=1 ./build/nvfuser_bench --benchmark_filter=.*Matmul.*Legacy/2048/3456/4096.*
```

Before:
```C++
---------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                       Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------------------------------
Nvfuser_Matmul_4warp3stage/no_quant_nvfuser_4warp_TT_Legacy/2048/3456/4096/manual_time        861 us         2571 us          753
Nvfuser_Matmul_4warp3stage/no_quant_nvfuser_4warp_TN_Legacy/2048/3456/4096/manual_time        893 us         2602 us          691
Nvfuser_Matmul_4warp3stage/no_quant_nvfuser_4warp_NT_Legacy/2048/3456/4096/manual_time        867 us         2577 us          710
Nvfuser_Matmul_4warp4stage/no_quant_nvfuser_4warp_TT_Legacy/2048/3456/4096/manual_time        882 us         2589 us          757
Nvfuser_Matmul_4warp4stage/no_quant_nvfuser_4warp_TN_Legacy/2048/3456/4096/manual_time        908 us         2616 us          688
Nvfuser_Matmul_4warp4stage/no_quant_nvfuser_4warp_NT_Legacy/2048/3456/4096/manual_time        879 us         2586 us          759
Nvfuser_Matmul_8warp3stage/no_quant_nvfuser_8warp_TT_Legacy/2048/3456/4096/manual_time        880 us         2590 us          734
Nvfuser_Matmul_8warp3stage/no_quant_nvfuser_8warp_TN_Legacy/2048/3456/4096/manual_time        900 us         2609 us          698
Nvfuser_Matmul_8warp3stage/no_quant_nvfuser_8warp_NT_Legacy/2048/3456/4096/manual_time        884 us         2592 us          756
Nvfuser_Matmul_8warp4stage/no_quant_nvfuser_8warp_TT_Legacy/2048/3456/4096/manual_time        881 us         2590 us          736
Nvfuser_Matmul_8warp4stage/no_quant_nvfuser_8warp_TN_Legacy/2048/3456/4096/manual_time        885 us         2594 us          706
Nvfuser_Matmul_8warp4stage/no_quant_nvfuser_8warp_NT_Legacy/2048/3456/4096/manual_time        884 us         2593 us          756
EagerModeMatmul/no_quant_eagermode_TT_Legacy/2048/3456/4096/manual_time                       819 us          847 us          860
EagerModeMatmul/no_quant_eagermode_TN_Legacy/2048/3456/4096/manual_time                       859 us          888 us          815
EagerModeMatmul/no_quant_eagermode_NT_Legacy/2048/3456/4096/manual_time                       747 us          778 us          940
```

After:
```C++
---------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                       Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------------------------------
Nvfuser_Matmul_4warp3stage/no_quant_nvfuser_4warp_TT_Legacy/2048/3456/4096/manual_time        837 us         2547 us          750
Nvfuser_Matmul_4warp3stage/no_quant_nvfuser_4warp_TN_Legacy/2048/3456/4096/manual_time        856 us         2565 us          743
Nvfuser_Matmul_4warp3stage/no_quant_nvfuser_4warp_NT_Legacy/2048/3456/4096/manual_time        840 us         2550 us          748
Nvfuser_Matmul_4warp4stage/no_quant_nvfuser_4warp_TT_Legacy/2048/3456/4096/manual_time        847 us         2557 us          761
Nvfuser_Matmul_4warp4stage/no_quant_nvfuser_4warp_TN_Legacy/2048/3456/4096/manual_time        863 us         2571 us          774
Nvfuser_Matmul_4warp4stage/no_quant_nvfuser_4warp_NT_Legacy/2048/3456/4096/manual_time        852 us         2563 us          741
Nvfuser_Matmul_8warp3stage/no_quant_nvfuser_8warp_TT_Legacy/2048/3456/4096/manual_time        852 us         2563 us          759
Nvfuser_Matmul_8warp3stage/no_quant_nvfuser_8warp_TN_Legacy/2048/3456/4096/manual_time        866 us         2576 us          770
Nvfuser_Matmul_8warp3stage/no_quant_nvfuser_8warp_NT_Legacy/2048/3456/4096/manual_time        859 us         2570 us          756
Nvfuser_Matmul_8warp4stage/no_quant_nvfuser_8warp_TT_Legacy/2048/3456/4096/manual_time        849 us         2560 us          734
Nvfuser_Matmul_8warp4stage/no_quant_nvfuser_8warp_TN_Legacy/2048/3456/4096/manual_time        859 us         2570 us          739
Nvfuser_Matmul_8warp4stage/no_quant_nvfuser_8warp_NT_Legacy/2048/3456/4096/manual_time        862 us         2574 us          762
EagerModeMatmul/no_quant_eagermode_TT_Legacy/2048/3456/4096/manual_time                       819 us          848 us          860
EagerModeMatmul/no_quant_eagermode_TN_Legacy/2048/3456/4096/manual_time                       863 us          893 us          811
EagerModeMatmul/no_quant_eagermode_NT_Legacy/2048/3456/4096/manual_time                       749 us          781 us          936
```