### PR TITLE
allow fusion_ir to print tv transforms

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -150,7 +150,7 @@ void FusionExecutor::debugCompileFusionFromStr(
   options_ = options;
 
   if (isDebugDumpEnabled(DebugDumpOption::FusionIr)) {
-    fusion->print();
+    fusion->print(std::cout, true);
   } else if (isDebugDumpEnabled(DebugDumpOption::FusionIrMath)) {
     fusion->printMath();
   }
@@ -238,7 +238,7 @@ void FusionExecutor::compileFusion(
   }
 
   if (isDebugDumpEnabled(DebugDumpOption::FusionIr)) {
-    fusion->print();
+    fusion->print(std::cout, true);
   } else if (isDebugDumpEnabled(DebugDumpOption::FusionIrMath)) {
     fusion->printMath();
   }


### PR DESCRIPTION
tmp fix to allow fusion_ir option print tv transforms.