### PR TITLE
quick flag to skip torchscript test

### DIFF
--- a/python_tests/test_torchscript.py
+++ b/python_tests/test_torchscript.py
@@ -73,7 +73,7 @@ os.environ["PYTORCH_NVFUSER_DISABLE"] = (
 os.environ["PYTORCH_NVFUSER_JIT_OPT_LEVEL"] = "0"
 
 # flag used to skip C++ integration test for torchscript
-if os.environ["NVFUSER_TEST_ONLY_RUN_WHEEL_BUILD_SUBSET"] == "1":
+if os.environ.get("NVFUSER_TEST_ONLY_RUN_WHEEL_BUILD_SUBSET", "0") == "1":
     RUN_NVFUSER = False
 
 # TODO: enable complex when we fixes the extremal cases in OpInfo

--- a/python_tests/test_torchscript.py
+++ b/python_tests/test_torchscript.py
@@ -71,6 +71,11 @@ os.environ["PYTORCH_NVFUSER_DISABLE"] = (
     "fallback,fma," + os.environ["PYTORCH_NVFUSER_DISABLE"]
 )
 os.environ["PYTORCH_NVFUSER_JIT_OPT_LEVEL"] = "0"
+
+# flag used to skip C++ integration test for torchscript
+if os.environ["NVFUSER_TEST_ONLY_RUN_WHEEL_BUILD_SUBSET"] == "1":
+    RUN_NVFUSER = False
+
 # TODO: enable complex when we fixes the extremal cases in OpInfo
 # see issue https://github.com/csarofeen/pytorch/issues/1730"
 # os.environ['PYTORCH_NVFUSER_ENABLE'] = 'complex'


### PR DESCRIPTION
add flag to skip test. This should be used by internal nightly CI

set env variable `NVFUSER_TEST_ONLY_RUN_WHEEL_BUILD_SUBSET` to 1 to skip torchscript test.