### PR TITLE
Fix trivial loop handling

### DIFF
--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1272,7 +1272,7 @@ indexMapFromTV(
     if (!within_alloc) {
       if ((loop->iter_domain()->isThreadDim() && is_shared) ||
           (loop->iter_domain()->isThread() && is_global)) {
-        idx = loop->indexOrStart();
+        idx = loop->indexOrStartIfTrivial();
       } else {
         idx = GpuLower::current()->kernel()->zeroVal();
         zero_loops.insert(loop);
@@ -1282,7 +1282,7 @@ indexMapFromTV(
       idx = GpuLower::current()->kernel()->zeroVal();
       zero_loops.insert(loop);
     } else {
-      idx = loop->indexOrStart();
+      idx = loop->indexOrStartIfTrivial();
     }
 
     if (rotated_loops.count(loop) > 0 && zero_loops.count(loop) == 0) {
@@ -1724,7 +1724,7 @@ std::vector<Val*> Index::getNonGlobalProducerStridedIndices(
     if (db_loop != nullptr) {
       auto stage_depth = gpu_lower->doubleBufferInfo().getStageDepthFor(
           db_loop->iter_domain());
-      auto loop_index = db_loop->indexOrStart();
+      auto loop_index = db_loop->indexOrStartIfTrivial();
       if (rotated_loops.count(db_loop) > 0) {
         loop_index = SimplifyingIrBuilder::addExpr(loop_index, db_loop->step());
       }
@@ -2184,13 +2184,13 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
       if (is_prolog && is_circular_buffer_loop) {
         // The buffer switching logic is the same as original index
         //  in the case of circular buffer prolog.
-        db_switch_index = db_loop->indexOrStart();
+        db_switch_index = db_loop->indexOrStartIfTrivial();
         if (rotated_loops.count(db_loop)) {
           db_switch_index =
               SimplifyingIrBuilder::addExpr(db_switch_index, db_loop->step());
         }
       } else {
-        auto loop_index = db_loop->indexOrStart();
+        auto loop_index = db_loop->indexOrStartIfTrivial();
         if (rotated_loops.count(db_loop)) {
           loop_index =
               SimplifyingIrBuilder::addExpr(loop_index, db_loop->step());

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1272,7 +1272,7 @@ indexMapFromTV(
     if (!within_alloc) {
       if ((loop->iter_domain()->isThreadDim() && is_shared) ||
           (loop->iter_domain()->isThread() && is_global)) {
-        idx = loop->index();
+        idx = loop->indexOrStart();
       } else {
         idx = GpuLower::current()->kernel()->zeroVal();
         zero_loops.insert(loop);
@@ -1282,13 +1282,7 @@ indexMapFromTV(
       idx = GpuLower::current()->kernel()->zeroVal();
       zero_loops.insert(loop);
     } else {
-      idx = loop->index();
-    }
-
-    // If the loop is trivial, the loop index can only be the loop
-    // start value.
-    if (idx == loop->index() && loop->isTrivial()) {
-      idx = loop->start();
+      idx = loop->indexOrStart();
     }
 
     if (rotated_loops.count(loop) > 0 && zero_loops.count(loop) == 0) {
@@ -1730,8 +1724,7 @@ std::vector<Val*> Index::getNonGlobalProducerStridedIndices(
     if (db_loop != nullptr) {
       auto stage_depth = gpu_lower->doubleBufferInfo().getStageDepthFor(
           db_loop->iter_domain());
-      auto loop_index =
-          db_loop->isTrivial() ? db_loop->start() : db_loop->index();
+      auto loop_index = db_loop->indexOrStart();
       if (rotated_loops.count(db_loop) > 0) {
         loop_index = SimplifyingIrBuilder::addExpr(loop_index, db_loop->step());
       }
@@ -2191,13 +2184,13 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
       if (is_prolog && is_circular_buffer_loop) {
         // The buffer switching logic is the same as original index
         //  in the case of circular buffer prolog.
-        db_switch_index = db_loop->index();
+        db_switch_index = db_loop->indexOrStart();
         if (rotated_loops.count(db_loop)) {
           db_switch_index =
               SimplifyingIrBuilder::addExpr(db_switch_index, db_loop->step());
         }
       } else {
-        auto loop_index = db_loop->index();
+        auto loop_index = db_loop->indexOrStart();
         if (rotated_loops.count(db_loop)) {
           loop_index =
               SimplifyingIrBuilder::addExpr(loop_index, db_loop->step());

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -627,7 +627,8 @@ bool ForLoop::isTrivial() const {
   }
 
   // Extent-1 loop: for (int i = 0; i < 1; ++i) {
-  if (start()->isZeroInt() && stop()->isOneInt() && step()->isOneInt()) {
+  if (start()->isZeroInt() && simplifiedStop()->isOneInt() &&
+      step()->isOneInt()) {
     return true;
   }
 

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -539,6 +539,10 @@ class TORCH_CUDA_CU_API ForLoop final : public Expr {
     return input(0);
   }
 
+  Val* indexOrStart() const {
+    return isTrivial() ? start() : index();
+  }
+
   Val* start() const;
 
   Val* stop() const;

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -539,7 +539,7 @@ class TORCH_CUDA_CU_API ForLoop final : public Expr {
     return input(0);
   }
 
-  Val* indexOrStart() const {
+  Val* indexOrStartIfTrivial() const {
     return isTrivial() ? start() : index();
   }
 

--- a/csrc/lower_double_buffer.cpp
+++ b/csrc/lower_double_buffer.cpp
@@ -169,9 +169,10 @@ class DoubleBufferLoopCloner : public kir::IrVisitor {
   static kir::ForLoop* clone(
       kir::ForLoop* double_buffer_loop,
       const std::vector<Expr*>& double_buffer_load_exprs,
-      DoubleBufferLoopStage loop_type) {
+      DoubleBufferLoopStage loop_type,
+      const std::unordered_set<Expr*>& exclude = {}) {
     DoubleBufferLoopCloner cloner(
-        double_buffer_loop, double_buffer_load_exprs, loop_type);
+        double_buffer_loop, double_buffer_load_exprs, loop_type, exclude);
     cloner.clone();
     return cloner.cloned_top_level_loop_;
   }
@@ -180,10 +181,12 @@ class DoubleBufferLoopCloner : public kir::IrVisitor {
   DoubleBufferLoopCloner(
       kir::ForLoop* double_buffer_loop,
       const std::vector<Expr*>& double_buffer_load_exprs,
-      DoubleBufferLoopStage loop_type)
+      DoubleBufferLoopStage loop_type,
+      const std::unordered_set<Expr*>& exclude)
       : double_buffer_loop_(double_buffer_loop),
         double_buffer_load_exprs_(double_buffer_load_exprs),
-        loop_type_(loop_type) {}
+        loop_type_(loop_type),
+        exclude_(exclude) {}
 
   using kir::IrVisitor::handle;
 
@@ -255,6 +258,10 @@ class DoubleBufferLoopCloner : public kir::IrVisitor {
   }
 
   void handle(Expr* expr) final {
+    if (exclude_.count(expr) > 0) {
+      return;
+    }
+
     if (expr->isA<kir::ForLoop>() || expr->isA<kir::IfThenElse>()) {
       kir::IrVisitor::handle(expr);
       return;
@@ -295,6 +302,7 @@ class DoubleBufferLoopCloner : public kir::IrVisitor {
 
   kir::ForLoop* cloned_top_level_loop_ = nullptr;
   std::deque<kir::Scope*> cloned_scopes_;
+  const std::unordered_set<Expr*>& exclude_;
 };
 
 using InsertionInfo = std::unordered_map<kir::ForLoop*, std::vector<Expr*>>;
@@ -409,6 +417,25 @@ class DoubleBufferLoopNestInspector : private kir::IrVisitor {
 
   InsertionInfo insertion_info_;
 };
+
+namespace {
+
+void getAllocInTrivialLoop(
+    kir::ForLoop* fl,
+    std::unordered_set<Expr*>& output) {
+  if (!fl->isTrivial()) {
+    return;
+  }
+  for (auto expr : fl->body().exprs()) {
+    if (expr->isA<kir::Allocate>()) {
+      output.emplace(expr);
+    } else if (auto loop = dynamic_cast<kir::ForLoop*>(expr)) {
+      getAllocInTrivialLoop(loop, output);
+    }
+  }
+}
+
+} // namespace
 
 // Apply double buffering transformations
 class DoubleBufferInserter : private kir::ExprMutator {
@@ -548,8 +575,26 @@ class DoubleBufferInserter : private kir::ExprMutator {
     }
 
     if (requireEpilogue(loads)) {
+      // In the case where the main loop is trivial (for example, ldmatrix in
+      // matmul kernel), we need to be careful when copying epilog loop. For
+      // example, if the main loop is:
+      //   for (int i = 0; i < 1; ++i) {
+      //     ...
+      //     float T1[2];
+      //     T1 = ...
+      //     ...
+      //   }
+      // Because trivial loop is not generated, the allocation of T1 will be one
+      // level above in the generated scope. So when we copy epilog, we need to
+      // make sure we don't copy these allocation so that there is no duplicate
+      // allocation.
+      std::unordered_set<Expr*> alloc_in_main;
+      getAllocInTrivialLoop(main_loop, alloc_in_main);
       auto epilogue_loop = DoubleBufferLoopCloner::clone(
-          double_buffer_loop, loads, DoubleBufferLoopStage::Epilog);
+          double_buffer_loop,
+          loads,
+          DoubleBufferLoopStage::Epilog,
+          alloc_in_main);
       registerInsertAfter(double_buffer_loop, epilogue_loop);
     }
   }

--- a/csrc/lower_index.cpp
+++ b/csrc/lower_index.cpp
@@ -337,7 +337,7 @@ void IndexLowering::handle(const ViewAsScalar* uop) {
             uop->vector_id()->as<IterDomain>(),
             IdMappingMode::LOOP)) {
       // TODO: this doesn't work with loop rotation
-      Val* index = loop->indexOrStart();
+      Val* index = loop->indexOrStartIfTrivial();
       pushBack(
           IrBuilder::create<ViewAsScalar>(out, in, uop->vector_id(), index));
       GpuLower::current()->propagateExprInfo(uop, back());
@@ -509,7 +509,7 @@ Val* getEntranceLinIndGridReduce(std::vector<kir::ForLoop*>& for_loops) {
     linear_index = SimplifyingIrBuilder::addExpr(
         SimplifyingIrBuilder::mulExpr(
             linear_index, loop->iter_domain()->extent()),
-        loop->indexOrStart());
+        loop->indexOrStartIfTrivial());
   }
   return linear_index;
 }

--- a/csrc/lower_index.cpp
+++ b/csrc/lower_index.cpp
@@ -337,7 +337,7 @@ void IndexLowering::handle(const ViewAsScalar* uop) {
             uop->vector_id()->as<IterDomain>(),
             IdMappingMode::LOOP)) {
       // TODO: this doesn't work with loop rotation
-      Val* index = loop->index();
+      Val* index = loop->indexOrStart();
       pushBack(
           IrBuilder::create<ViewAsScalar>(out, in, uop->vector_id(), index));
       GpuLower::current()->propagateExprInfo(uop, back());
@@ -509,7 +509,7 @@ Val* getEntranceLinIndGridReduce(std::vector<kir::ForLoop*>& for_loops) {
     linear_index = SimplifyingIrBuilder::addExpr(
         SimplifyingIrBuilder::mulExpr(
             linear_index, loop->iter_domain()->extent()),
-        loop->index());
+        loop->indexOrStart());
   }
   return linear_index;
 }

--- a/csrc/lower_index_compute.cpp
+++ b/csrc/lower_index_compute.cpp
@@ -118,7 +118,7 @@ IndexingParameters getLinearIndexParameters(
     auto loop = loops[loop_idx];
     auto index_domain = GpuLower::current()->caMap()->getConcreteMappedID(
         loop_domain[loop_idx], IdMappingMode::EXACT);
-    loop_index_map[index_domain] = loop->indexOrStart();
+    loop_index_map[index_domain] = loop->indexOrStartIfTrivial();
     if (rotated_loops.count(loop) > 0) {
       loop_index_map[index_domain] = SimplifyingIrBuilder::addExpr(
           loop_index_map.at(index_domain), loop->step());
@@ -442,8 +442,8 @@ IndexingParameters getPredicateInitialIndexParameters(
       bool is_same =
           (rotated_loops.count(db_loop)
                ? cur_index->sameAs(SimplifyingIrBuilder::addExpr(
-                     db_loop->indexOrStart(), db_loop->step()))
-               : cur_index == db_loop->indexOrStart());
+                     db_loop->indexOrStartIfTrivial(), db_loop->step()))
+               : cur_index == db_loop->indexOrStartIfTrivial());
       if (is_same) {
         loop_to_ind_map[db_loop] = SimplifyingIrBuilder::addExpr(
             cur_index, SimplifyingIrBuilder::create<Int>(stage_depth - 1));

--- a/csrc/lower_index_compute.cpp
+++ b/csrc/lower_index_compute.cpp
@@ -118,14 +118,7 @@ IndexingParameters getLinearIndexParameters(
     auto loop = loops[loop_idx];
     auto index_domain = GpuLower::current()->caMap()->getConcreteMappedID(
         loop_domain[loop_idx], IdMappingMode::EXACT);
-    if (loop->isTrivial()) {
-      // This is useful information in the case of
-      //  MisalignedVectorize and double buffer epilog, etc.
-      loop_index_map[index_domain] = loop->start();
-    } else {
-      // Default use pre-allocated integers for index
-      loop_index_map[index_domain] = loop->index();
-    }
+    loop_index_map[index_domain] = loop->indexOrStart();
     if (rotated_loops.count(loop) > 0) {
       loop_index_map[index_domain] = SimplifyingIrBuilder::addExpr(
           loop_index_map.at(index_domain), loop->step());
@@ -449,8 +442,8 @@ IndexingParameters getPredicateInitialIndexParameters(
       bool is_same =
           (rotated_loops.count(db_loop)
                ? cur_index->sameAs(SimplifyingIrBuilder::addExpr(
-                     db_loop->index(), db_loop->step()))
-               : cur_index == db_loop->index());
+                     db_loop->indexOrStart(), db_loop->step()))
+               : cur_index == db_loop->indexOrStart());
       if (is_same) {
         loop_to_ind_map[db_loop] = SimplifyingIrBuilder::addExpr(
             cur_index, SimplifyingIrBuilder::create<Int>(stage_depth - 1));

--- a/csrc/lower_misaligned_vectorization.cpp
+++ b/csrc/lower_misaligned_vectorization.cpp
@@ -418,7 +418,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
       if (pred_stop != nullptr) {
         // TODO: this doesn't work with loop rotation
         auto body_pred = IrBuilder::create<kir::Predicate>(
-            IrBuilder::ltExpr(new_loop->index(), pred_stop)->as<Bool>());
+            IrBuilder::ltExpr(new_loop->indexOrStart(), pred_stop)->as<Bool>());
         auto body_ite = IrBuilder::create<kir::IfThenElse>(body_pred);
         body->push_back(body_ite);
         body = &body_ite->thenBody();

--- a/csrc/lower_misaligned_vectorization.cpp
+++ b/csrc/lower_misaligned_vectorization.cpp
@@ -418,7 +418,8 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
       if (pred_stop != nullptr) {
         // TODO: this doesn't work with loop rotation
         auto body_pred = IrBuilder::create<kir::Predicate>(
-            IrBuilder::ltExpr(new_loop->indexOrStartIfTrivial(), pred_stop)->as<Bool>());
+            IrBuilder::ltExpr(new_loop->indexOrStartIfTrivial(), pred_stop)
+                ->as<Bool>());
         auto body_ite = IrBuilder::create<kir::IfThenElse>(body_pred);
         body->push_back(body_ite);
         body = &body_ite->thenBody();

--- a/csrc/lower_misaligned_vectorization.cpp
+++ b/csrc/lower_misaligned_vectorization.cpp
@@ -418,7 +418,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
       if (pred_stop != nullptr) {
         // TODO: this doesn't work with loop rotation
         auto body_pred = IrBuilder::create<kir::Predicate>(
-            IrBuilder::ltExpr(new_loop->indexOrStart(), pred_stop)->as<Bool>());
+            IrBuilder::ltExpr(new_loop->indexOrStartIfTrivial(), pred_stop)->as<Bool>());
         auto body_ite = IrBuilder::create<kir::IfThenElse>(body_pred);
         body->push_back(body_ite);
         body = &body_ite->thenBody();

--- a/csrc/lower_vectorize_welford.cpp
+++ b/csrc/lower_vectorize_welford.cpp
@@ -408,7 +408,8 @@ class WelfordVectorizer : public kir::ExprMutator {
     const auto& original_index = out_N->index();
     std::unordered_map<Val*, Val*> index_replacement_map;
     index_replacement_map.emplace(
-        innermost_loop->index(), GpuLower::current()->kernel()->zeroVal());
+        innermost_loop->indexOrStart(),
+        GpuLower::current()->kernel()->zeroVal());
 
     Val* indices_zero =
         ir_utils::replaceValInIndexVal(original_index, index_replacement_map);

--- a/csrc/lower_vectorize_welford.cpp
+++ b/csrc/lower_vectorize_welford.cpp
@@ -408,7 +408,7 @@ class WelfordVectorizer : public kir::ExprMutator {
     const auto& original_index = out_N->index();
     std::unordered_map<Val*, Val*> index_replacement_map;
     index_replacement_map.emplace(
-        innermost_loop->indexOrStart(),
+        innermost_loop->indexOrStartIfTrivial(),
         GpuLower::current()->kernel()->zeroVal());
 
     Val* indices_zero =

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -1201,17 +1201,17 @@ TEST_F(NVFuserTest, FusionParser_CUDA) {
   // 2. use a fuzzy compare (ignore non-significant whitespaces for example)
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 1> T0, Tensor<float, 1> T1, Tensor<float, 1> T3) {
-  int64_t i248;
-  i248 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)blockIdx.x));
-  if ((i248 < T0.size[0])) {
+  int64_t i590;
+  i590 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)blockIdx.x));
+  if ((i590 < T0.size[0])) {
     float T5[1];
     T5[0] = 0;
     T5[0]
-       = T1[i248];
+       = T1[i590];
     float T4[1];
     T4[0] = 0;
     T4[0]
-       = T0[i248];
+       = T0[i590];
     float T2[1];
     T2[0]
       = T4[0]
@@ -1220,7 +1220,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 1> T0, Tensor<float, 1> T1, Te
     T6[0]
       = T2[0]
       * T4[0];
-    T3[i248]
+    T3[i590]
        = T6[0];
   }
 }

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -9029,27 +9029,27 @@ TEST_F(NVFuserTest, FusionChannelsLastParser_CUDA) {
   // 2. use a fuzzy compare (ignore non-significant whitespaces for example)
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<__half, 4> T0, Tensor<__half, 4> T2, Tensor<__half, 4> T7) {
-  int64_t i1435;
-  i1435 = T0.size[2] * T0.size[1];
-  int64_t i1438;
-  i1438 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)blockIdx.x));
-  int64_t i1440;
-  i1440 = (T0.size[1] * T0.size[2]) * T0.size[3];
-  int64_t i1472;
-  i1472 = i1438 % i1440;
-  int64_t i1449;
-  i1449 = T0.size[2] * T0.size[3];
-  int64_t i1473;
-  i1473 = i1472 % i1449;
-  if ((i1438 < (((T0.size[0] * T0.size[1]) * T0.size[2]) * T0.size[3]))) {
+  int64_t i1777;
+  i1777 = T0.size[2] * T0.size[1];
+  int64_t i1780;
+  i1780 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)blockIdx.x));
+  int64_t i1782;
+  i1782 = (T0.size[1] * T0.size[2]) * T0.size[3];
+  int64_t i7574;
+  i7574 = i1780 % i1782;
+  int64_t i1791;
+  i1791 = T0.size[2] * T0.size[3];
+  int64_t i7647;
+  i7647 = i7574 % i1791;
+  if ((i1780 < (((T0.size[0] * T0.size[1]) * T0.size[2]) * T0.size[3]))) {
     __half T9[1];
     T9[0] = 0;
     T9[0]
-       = T2[(((((i1435 * T0.size[3]) * (i1438 / i1440)) + (i1435 * (i1473 % T0.size[3]))) + (T0.size[2] * (i1472 / i1449))) + (i1473 / T0.size[3]))];
+       = T2[(((((i1777 * T0.size[3]) * (i1780 / i1782)) + (i1777 * (i7647 % T0.size[3]))) + (T0.size[2] * (i7574 / i1791))) + (i7647 / T0.size[3]))];
     __half T8[1];
     T8[0] = 0;
     T8[0]
-       = T0[i1438];
+       = T0[i1780];
     float T3[1];
     T3[0]
        = __half2float(T9[0]);
@@ -9069,7 +9069,7 @@ __global__ void CUDAGeneratedKernel(Tensor<__half, 4> T0, Tensor<__half, 4> T2, 
     __half T10[1];
     T10[0]
        = __float2half(T6[0]);
-    T7[i1438]
+    T7[i1780]
        = T10[0];
   }
 }

--- a/test/test_loop_rotation.cpp
+++ b/test/test_loop_rotation.cpp
@@ -41,31 +41,31 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO
   #pragma unroll 1
   for(nvfuser_index_t i21 = 0; i21 < T0.size[0]; ++i21) {
-    int64_t i160;
-    i160 = T0.stride[0] * i21;
-    int64_t i516;
-    i516 = 3 * i21;
+    int64_t i286;
+    i286 = T0.stride[0] * i21;
+    int64_t i1290;
+    i1290 = 3 * i21;
     float T1[1];
     float T2[1];
     T1[0] = 0;
     T1[0]
-       = T0[i160];
+       = T0[i286];
     T2[0]
        = T1[0];
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i22 = 0; i22 < 3; ++i22) {
-      int64_t i651;
-      i651 = (1 + i22) + nvfuser_zero;
+      int64_t i1929;
+      i1929 = (1 + i22) + nvfuser_zero;
       float T3[1];
       T3[0]
          = T2[0];
-      T4[(i516 + (i22 + nvfuser_zero))]
+      T4[(i1290 + (i22 + nvfuser_zero))]
          = T3[0];
       T1[0] = 0;
-      if ((i651 < 3)) {
+      if ((i1929 < 3)) {
         T1[0]
-           = T0[(i160 + (T0.stride[1] * i651))];
+           = T0[(i286 + (T0.stride[1] * i1929))];
       }
       T2[0]
          = T1[0];
@@ -105,8 +105,8 @@ TEST_F(LoopRotationTest, RotateOuter_CUDA) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO
-  bool b918;
-  b918 = 0 < T0.size[0];
+  bool b3402;
+  b3402 = 0 < T0.size[0];
   float T1[3];
   float T2[3];
   #pragma unroll
@@ -116,7 +116,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll
   for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-    if (b918) {
+    if (b3402) {
       T1[i21]
          = T0[(T0.stride[1] * (i21 + nvfuser_zero))];
     }
@@ -130,12 +130,12 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll 1
   for(nvfuser_index_t i24 = 0; i24 < T0.size[0]; ++i24) {
-    int64_t i540;
-    i540 = 3 * i24;
-    int64_t i681;
-    i681 = T0.stride[0] + (T0.stride[0] * i24);
-    bool b1323;
-    b1323 = (1 + i24) < T0.size[0];
+    int64_t i1494;
+    i1494 = 3 * i24;
+    int64_t i2157;
+    i2157 = T0.stride[0] + (T0.stride[0] * i24);
+    bool b4473;
+    b4473 = (1 + i24) < T0.size[0];
     // Alias Allocation - register
     auto& T3 = T1;
     #pragma unroll
@@ -146,7 +146,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i25 = 0; i25 < 3; ++i25) {
-      T4[(i540 + (i25 + nvfuser_zero))]
+      T4[(i1494 + (i25 + nvfuser_zero))]
          = T3[i25];
     }
     NVFUSER_UPDATE_MAGIC_ZERO
@@ -157,9 +157,9 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      if (b1323) {
+      if (b4473) {
         T1[i21]
-           = T0[(i681 + (T0.stride[1] * (i21 + nvfuser_zero)))];
+           = T0[(i2157 + (T0.stride[1] * (i21 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO
@@ -206,8 +206,8 @@ TEST_F(LoopRotationTest, NonDivisibleSplit_CUDA) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO
-  int64_t i1529;
-  i1529 = T0.size[0] * T0.size[1];
+  int64_t i6157;
+  i6157 = T0.size[0] * T0.size[1];
   float T1[5];
   float T2[5];
   #pragma unroll
@@ -217,11 +217,11 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll
   for(nvfuser_index_t i36 = 0; i36 < 5; ++i36) {
-    int64_t i154;
-    i154 = i36 + nvfuser_zero;
-    if ((i154 < i1529)) {
+    int64_t i266;
+    i266 = i36 + nvfuser_zero;
+    if ((i266 < i6157)) {
       T1[i36]
-         = T0[((T0.stride[0] * (i154 / T0.size[1])) + (T0.stride[1] * (i154 % T0.size[1])))];
+         = T0[((T0.stride[0] * (i266 / T0.size[1])) + (T0.stride[1] * (i266 % T0.size[1])))];
     }
   }
   NVFUSER_UPDATE_MAGIC_ZERO
@@ -233,10 +233,10 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll 1
   for(nvfuser_index_t i39 = 0; i39 < (ceilDiv((T0.size[0] * T0.size[1]), 5)); ++i39) {
-    int64_t i636;
-    i636 = 5 * i39;
-    int64_t i1230;
-    i1230 = 5 + i636;
+    int64_t i2020;
+    i2020 = 5 * i39;
+    int64_t i4590;
+    i4590 = 5 + i2020;
     // Alias Allocation - register
     auto& T3 = T1;
     #pragma unroll
@@ -247,10 +247,10 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i40 = 0; i40 < 5; ++i40) {
-      int64_t i637;
-      i637 = i636 + (i40 + nvfuser_zero);
-      if ((i637 < i1529)) {
-        T4[i637]
+      int64_t i2021;
+      i2021 = i2020 + (i40 + nvfuser_zero);
+      if ((i2021 < i6157)) {
+        T4[i2021]
            = T3[i40];
       }
     }
@@ -262,11 +262,11 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i36 = 0; i36 < 5; ++i36) {
-      int64_t i1231;
-      i1231 = i1230 + (i36 + nvfuser_zero);
-      if ((i1231 < i1529)) {
+      int64_t i4671;
+      i4671 = i4590 + (i36 + nvfuser_zero);
+      if ((i4671 < i6157)) {
         T1[i36]
-           = T0[((T0.stride[0] * (i1231 / T0.size[1])) + (T0.stride[1] * (i1231 % T0.size[1])))];
+           = T0[((T0.stride[0] * (i4671 / T0.size[1])) + (T0.stride[1] * (i4671 % T0.size[1])))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO
@@ -310,26 +310,26 @@ TEST_F(LoopRotationTest, DoubleBuffered_CUDA) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO
-  int64_t i577;
-  i577 = T0.stride[0] * 4;
+  int64_t i2539;
+  i2539 = T0.stride[0] * 4;
   float T1[15];
   #pragma unroll
   for(nvfuser_index_t i24 = 0; i24 < 4; ++i24) {
-    int64_t i152;
-    i152 = 3 * i24;
-    int64_t i223;
-    i223 = T0.stride[0] * i24;
-    bool b1187;
-    b1187 = (i24 + nvfuser_zero) < T0.size[0];
+    int64_t i278;
+    i278 = 3 * i24;
+    int64_t i637;
+    i637 = T0.stride[0] * i24;
+    bool b5903;
+    b5903 = (i24 + nvfuser_zero) < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      T1[(i152 + i21)] = 0;
+      T1[(i278 + i21)] = 0;
     }
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      if (b1187) {
-        T1[(i152 + i21)]
-           = T0[(i223 + (T0.stride[1] * (i21 + nvfuser_zero)))];
+      if (b5903) {
+        T1[(i278 + i21)]
+           = T0[(i637 + (T0.stride[1] * (i21 + nvfuser_zero)))];
       }
     }
   }
@@ -343,28 +343,28 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll 1
   for(nvfuser_index_t i25 = 0; i25 < T0.size[0]; ++i25) {
-    int64_t i493;
-    i493 = 4 + i25;
-    int64_t i495;
-    i495 = 3 * (i493 % 5);
-    int64_t i579;
-    i579 = i577 + (T0.stride[0] * i25);
-    int64_t i946;
-    i946 = 3 * i25;
-    int64_t i1067;
-    i1067 = 3 * ((1 + i25) % 5);
-    bool b1448;
-    b1448 = i493 < T0.size[0];
+    int64_t i1879;
+    i1879 = 4 + i25;
+    int64_t i1881;
+    i1881 = 3 * (i1879 % 5);
+    int64_t i2541;
+    i2541 = i2539 + (T0.stride[0] * i25);
+    int64_t i4528;
+    i4528 = 3 * i25;
+    int64_t i5045;
+    i5045 = 3 * ((1 + i25) % 5);
+    bool b6884;
+    b6884 = i1879 < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      T1[(i495 + i21)] = 0;
+      T1[(i1881 + i21)] = 0;
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      if (b1448) {
-        T1[(i495 + i21)]
-           = T0[(i579 + (T0.stride[1] * (i21 + nvfuser_zero)))];
+      if (b6884) {
+        T1[(i1881 + i21)]
+           = T0[(i2541 + (T0.stride[1] * (i21 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO
@@ -377,14 +377,14 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i27 = 0; i27 < 3; ++i27) {
-      T4[(i946 + (i27 + nvfuser_zero))]
+      T4[(i4528 + (i27 + nvfuser_zero))]
          = T3[i27];
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i22 = 0; i22 < 3; ++i22) {
       T2[i22]
-         = T1[(i1067 + i22)];
+         = T1[(i5045 + i22)];
     }
     NVFUSER_UPDATE_MAGIC_ZERO
   }
@@ -421,14 +421,14 @@ TEST_F(LoopRotationTest, SelectDoubleBufferLoad_CUDA) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO
-  int64_t i545;
-  i545 = 4 * T0.stride[0];
-  int64_t i1150;
-  i1150 = T0.stride[0] * 5;
-  bool b1536;
-  b1536 = 0 < T0.size[0];
-  bool b1843;
-  b1843 = 4 < T0.size[0];
+  int64_t i2471;
+  i2471 = 4 * T0.stride[0];
+  int64_t i4858;
+  i4858 = T0.stride[0] * 5;
+  bool b7080;
+  b7080 = 0 < T0.size[0];
+  bool b8125;
+  b8125 = 4 < T0.size[0];
   float T1[15];
   #pragma unroll
   for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
@@ -437,7 +437,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll
   for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-    if (b1536) {
+    if (b7080) {
       T1[i21]
          = T0[(T0.stride[1] * (i21 + nvfuser_zero))];
     }
@@ -445,21 +445,21 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll
   for(nvfuser_index_t i24 = 0; i24 < 4; ++i24) {
-    int64_t i285;
-    i285 = 3 + (3 * i24);
-    int64_t i368;
-    i368 = T0.stride[0] + (T0.stride[0] * i24);
-    bool b1781;
-    b1781 = ((1 + i24) + nvfuser_zero) < T0.size[0];
+    int64_t i717;
+    i717 = 3 + (3 * i24);
+    int64_t i1214;
+    i1214 = T0.stride[0] + (T0.stride[0] * i24);
+    bool b7685;
+    b7685 = ((1 + i24) + nvfuser_zero) < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      T1[(i285 + i21)] = 0;
+      T1[(i717 + i21)] = 0;
     }
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      if (b1781) {
-        T1[(i285 + i21)]
-           = T0[(i368 + (T0.stride[1] * (i21 + nvfuser_zero)))];
+      if (b7685) {
+        T1[(i717 + i21)]
+           = T0[(i1214 + (T0.stride[1] * (i21 + nvfuser_zero)))];
       }
     }
   }
@@ -472,9 +472,9 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll
   for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-    if (b1843) {
+    if (b8125) {
       T1[(12 + i21)]
-         = T0[(i545 + (T0.stride[1] * (i21 + nvfuser_zero)))];
+         = T0[(i2471 + (T0.stride[1] * (i21 + nvfuser_zero)))];
     }
   }
   NVFUSER_UPDATE_MAGIC_ZERO
@@ -486,16 +486,16 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
   NVFUSER_UPDATE_MAGIC_ZERO
   #pragma unroll 1
   for(nvfuser_index_t i25 = 0; i25 < T0.size[0]; ++i25) {
-    int64_t i919;
-    i919 = 3 * i25;
-    int64_t i1060;
-    i1060 = 3 * (i25 % 5);
-    int64_t i1152;
-    i1152 = i1150 + (T0.stride[0] * i25);
-    int64_t i1416;
-    i1416 = 3 * ((1 + i25) % 5);
-    bool b2264;
-    b2264 = (5 + i25) < T0.size[0];
+    int64_t i3817;
+    i3817 = 3 * i25;
+    int64_t i4354;
+    i4354 = 3 * (i25 % 5);
+    int64_t i4860;
+    i4860 = i4858 + (T0.stride[0] * i25);
+    int64_t i6294;
+    i6294 = 3 * ((1 + i25) % 5);
+    bool b9230;
+    b9230 = (5 + i25) < T0.size[0];
     float T3[3];
     #pragma unroll
     for(nvfuser_index_t i23 = 0; i23 < 3; ++i23) {
@@ -505,27 +505,27 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T4) {
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i27 = 0; i27 < 3; ++i27) {
-      T4[(i919 + (i27 + nvfuser_zero))]
+      T4[(i3817 + (i27 + nvfuser_zero))]
          = T3[i27];
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      T1[(i1060 + i21)] = 0;
+      T1[(i4354 + i21)] = 0;
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
-      if (b2264) {
-        T1[(i1060 + i21)]
-           = T0[(i1152 + (T0.stride[1] * (i21 + nvfuser_zero)))];
+      if (b9230) {
+        T1[(i4354 + i21)]
+           = T0[(i4860 + (T0.stride[1] * (i21 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     #pragma unroll
     for(nvfuser_index_t i22 = 0; i22 < 3; ++i22) {
       T2[i22]
-         = T1[(i1416 + i22)];
+         = T1[(i6294 + i22)];
     }
     NVFUSER_UPDATE_MAGIC_ZERO
   }
@@ -577,24 +577,24 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T3) {
   alignas(16) extern __shared__ char array[];
   unsigned smem_offset = 0;
   NVFUSER_DEFINE_MAGIC_ZERO
-  float* ptr98;
-  ptr98 = T0.data;
-  float* ptr382;
-  ptr382 = (T0.stride[0] * 4) + ptr98;
+  float* ptr171;
+  ptr171 = T0.data;
+  float* ptr2237;
+  ptr2237 = (T0.stride[0] * 4) + ptr171;
   smem_offset = alignBufferSize(smem_offset, 16);
   float* T4 = reinterpret_cast<float*>(array + smem_offset);
   smem_offset += (15 * sizeof(float));
   #pragma unroll
   for(nvfuser_index_t i18 = 0; i18 < 4; ++i18) {
-    float* ptr165;
-    ptr165 = ptr98 + (T0.stride[0] * i18);
-    unsigned i249;
-    i249 = (toSmem(T4)) + (12 * i18);
-    bool b1334;
-    b1334 = (i18 + nvfuser_zero) < T0.size[0];
+    float* ptr310;
+    ptr310 = ptr171 + (T0.stride[0] * i18);
+    unsigned i988;
+    i988 = (toSmem(T4)) + (12 * i18);
+    bool b6852;
+    b6852 = (i18 + nvfuser_zero) < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i17 = 0; i17 < 3; ++i17) {
-      Ampere::cpAsyncCa<float, 1>((i249 + (4 * i17)),(ptr165 + (T0.stride[1] * (i17 + nvfuser_zero))),b1334);
+      Ampere::cpAsyncCa<float, 1>((i988 + (4 * i17)),(ptr310 + (T0.stride[1] * (i17 + nvfuser_zero))),b6852);
     }
     Ampere::cpAsyncCommit();
   }
@@ -605,39 +605,39 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2> T0, Tensor<float, 2> T3) {
      = T4[0];
   #pragma unroll 1
   for(nvfuser_index_t i19 = 0; i19 < T0.size[0]; ++i19) {
-    float* ptr383;
-    ptr383 = ptr382 + (T0.stride[0] * i19);
-    int64_t i568;
-    i568 = 4 + i19;
-    unsigned i571;
-    i571 = (toSmem(T4)) + (12 * (i568 % 5));
-    int64_t i657;
-    i657 = 1 + (3 * (i19 % 5));
-    int64_t i1029;
-    i1029 = 3 * i19;
-    bool b1517;
-    b1517 = i568 < T0.size[0];
+    float* ptr2292;
+    ptr2292 = ptr2237 + (T0.stride[0] * i19);
+    int64_t i2765;
+    i2765 = 4 + i19;
+    unsigned i2768;
+    i2768 = (toSmem(T4)) + (12 * (i2765 % 5));
+    int64_t i3667;
+    i3667 = 1 + (3 * (i19 % 5));
+    int64_t i5370;
+    i5370 = 3 * i19;
+    bool b7647;
+    b7647 = i2765 < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i17 = 0; i17 < 3; ++i17) {
-      Ampere::cpAsyncCa<float, 1>((i571 + (4 * i17)),(ptr383 + (T0.stride[1] * (i17 + nvfuser_zero))),b1517);
+      Ampere::cpAsyncCa<float, 1>((i2768 + (4 * i17)),(ptr2292 + (T0.stride[1] * (i17 + nvfuser_zero))),b7647);
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     Ampere::cpAsyncCommit();
     #pragma unroll
     for(nvfuser_index_t i22 = 0; i22 < 2; ++i22) {
       T1[((1 + i22) % 2)]
-         = T4[(i657 + i22)];
+         = T4[(i3667 + i22)];
       float T2[1];
       T2[0]
          = T1[(i22 % 2)];
-      T3[(i1029 + (i22 + nvfuser_zero))]
+      T3[(i5370 + (i22 + nvfuser_zero))]
          = T2[0];
     }
     NVFUSER_UPDATE_MAGIC_ZERO
     float T2[1];
     T2[0]
        = T1[0];
-    T3[(2 + i1029)]
+    T3[(2 + i5370)]
        = T2[0];
     NVFUSER_UPDATE_MAGIC_ZERO
     Ampere::cpAsyncPartialBarrier<3>();


### PR DESCRIPTION
`ForLoop::isTrivial` should use `simplifiedStop` instead of `stop` for detecting trivial loop. And after switching, I actually see a few bugs in our codebase, I fixed those bugs.

Diff in a matmul kernel: https://www.diffchecker.com/zDtT4IWL/, note that the trivial loop `for(nvfuser_index_t i523 = 0; i523 < 1; ++i523)` is gone.