### PR TITLE
PYTORCH_NVFUSER_DUMP=index_type to print index type of launched kernel

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1472,6 +1472,10 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
         executor_entry->intermediates);
   }
 
+  if (isDebugDumpEnabled(DebugDumpOption::IndexType)) {
+    std::cout << "Index type: " << kernel()->indexType() << std::endl;
+  }
+
   cudaEvent_t start_event = {};
   cudaEvent_t finish_event = {};
 

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -120,6 +120,7 @@ auto parseDebugDumpOptions() {
       {"segmenter_logging", DebugDumpOption::FusionSegmenterLog},
       {"fusion_args", DebugDumpOption::FusionArgs},
       {"kernel_args", DebugDumpOption::KernelArgs},
+      {"index_type", DebugDumpOption::IndexType},
       {"dump_eff_bandwidth", DebugDumpOption::EffectiveBandwidth},
       {"draw_segmented_fusion", DebugDumpOption::FusionSegmentsDrawing},
       {"ptxas_verbose", DebugDumpOption::PrintPtxasLog},

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -81,6 +81,7 @@ enum class DebugDumpOption {
   LoopRotation, //! Print loop rotation log
   MatmulChecks, //! Print logs from tools around matmul scheduler used in
                 //! segmenter
+  IndexType, //! Print the index type of the launched kernel
   EndOfOption //! Placeholder for counting the number of elements
 };
 


### PR DESCRIPTION
Forgot to add this to the recent index-type PR (#108)
