### PR TITLE
Simplification of mma macro usage in matmul scheduling

### DIFF
--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -528,9 +528,8 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   auto ab = mma->inA()->as<TensorView>();
   auto bb = mma->inB()->as<TensorView>();
 
-  // Get exact configurations from mma builder.
+  // Set accumulation tv for mma op.
   mma_builder.accumulatorTv(cc);
-  auto mma_options = mma_builder.build();
 
   // Staging register for global memory load
   TensorView *ar = a, *br = b;
@@ -557,7 +556,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   // TODO:
   // Also a few additional parameters should be introduced
   // to control this stage of scheduling.
-  if (isVolta(mma_options.macro)) {
+  if (isVolta(params.mma_macro)) {
     acw_smem = ab->cacheAfter();
     bcw_smem = bb->cacheAfter();
     // Cache again to be able to vectorize.
@@ -657,7 +656,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   //   TODO: this section goes to a separate matmul util,
   //   and needs more configurability.
   // ------------------------------------------------------------------
-  if (isTuring(mma_options.macro) || isAmpere(mma_options.macro)) {
+  if (isTuring(params.mma_macro) || isAmpere(params.mma_macro)) {
     moveInnerBroadcastLeft(ab);
     moveInnerBroadcastLeft(bb);
   }


### PR DESCRIPTION
The scope of the changes:
--
- matmul heuristic instance is the main source of mma macro,
- scheduleMarmul and all its helpers uses matmul heuristic for accessing mma macro data
- mma builder uses mma macro from matmul heur to initialize attribute in MmaOp instance in matmul,

Local verification:
--
- c++ tests on a100, all passed

cc @mmigdal-nv 