### PR TITLE
Minor cleanup of HaloInfo

### DIFF
--- a/csrc/lower_index_compute.h
+++ b/csrc/lower_index_compute.h
@@ -117,6 +117,10 @@ class LoopIndexing {
     return loop_domains_;
   }
 
+  const auto& loopRootDomains() const {
+    return loop_root_;
+  }
+
   //! Returns the consumer tv that the view info
   //!  was derived from.
   auto consumerTv() const {

--- a/csrc/lower_shift.h
+++ b/csrc/lower_shift.h
@@ -65,8 +65,6 @@ class AxisHaloInfo {
 class TORCH_CUDA_CU_API HaloInfo {
  public:
   //! Scan a fusion and collect all information for lowering
-  // HaloInfo(Fusion* fusion, std::shared_ptr<const ComputeAtMap>
-  // ca_map);
   HaloInfo(Fusion* fusion, std::shared_ptr<const ComputeAtMap> ca_map);
 
   //! Almost exact duplicate of build(TensorDomain* td), except that

--- a/csrc/lower_shift.h
+++ b/csrc/lower_shift.h
@@ -65,6 +65,8 @@ class AxisHaloInfo {
 class TORCH_CUDA_CU_API HaloInfo {
  public:
   //! Scan a fusion and collect all information for lowering
+  // HaloInfo(Fusion* fusion, std::shared_ptr<const ComputeAtMap>
+  // ca_map);
   HaloInfo(Fusion* fusion, std::shared_ptr<const ComputeAtMap> ca_map);
 
   //! Almost exact duplicate of build(TensorDomain* td), except that
@@ -172,9 +174,6 @@ class TORCH_CUDA_CU_API HaloInfo {
   void setHaloWidth(IterDomain* id, int halo_width);
 
  private:
-  // Copy the permissive map from the passed in compute at map
-  const DisjointSets<IterDomain*> permissive_map_;
-
   //! Halo information of root axes
   std::unordered_map<IterDomain*, AxisHaloInfo> root_axis_map_;
 


### PR DESCRIPTION
@jacobhinkle found `HaloInfo::buildConcreteHaloExtentMap` is a major overhead in fusion lowering. This PR should fix it.

`HaloInfo` previously kept a permissive map, which shouldn't be necessary as it's only used in lowering. Also, analysis for LoopIndexing can be skipped when no root ID is extended with halo.

Note that overall rewrite of halo handling is needed, but it's not high priority at this moment.


