### PR TITLE
Python: on error print the way to generate inputs alongside the printed FusionDefinition

### DIFF
--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -102,7 +102,7 @@ class FusionDefinition(_C._FusionDefinition):
                 else:
                     msg += f"    {i},\n"
             msg += "]"
-            msg += f"\nfd.execute(inputs)\n"
+            msg += "\nfd.execute(inputs)\n"
             msg += "```\n"
             logger.exception(msg)
             raise

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -94,9 +94,15 @@ class FusionDefinition(_C._FusionDefinition):
             for i in inputs:
                 if isinstance(i, torch.Tensor):
                     if i.dtype.is_floating_point:
-                        msg += f"    torch.randn({tuple(i.size())}, dtype={i.dtype}, device='{i.device}').as_strided({tuple(i.size())}, {tuple(i.stride())}),\n"
+                        msg += (
+                            f"    torch.randn({tuple(i.size())}, dtype={i.dtype}, device='{i.device}')"
+                            f".as_strided({tuple(i.size())}, {tuple(i.stride())}),\n"
+                        )
                     else:
-                        msg += f"    torch.randint(0, 10, {tuple(i.size())}, dtype={i.dtype}, device='{i.device}').as_strided({tuple(i.size())}, {tuple(i.stride())}),\n"
+                        msg += (
+                            f"    torch.randint(0, 10, {tuple(i.size())}, dtype={i.dtype}, device='{i.device}')"
+                            f".as_strided({tuple(i.size())}, {tuple(i.stride())}),\n"
+                        )
                 else:
                     msg += f"    {i},\n"
             msg += "]"

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -18,8 +18,6 @@ if pytorch_lib_dir not in sys.path:
 try:
     from . import _C
 except ImportError as err:
-    import logging
-
     logging.getLogger("nvfuser").error(
         """==== importing nvfuser failed ====
              try run `patch-nvfuser` if https://github.com/NVIDIA/Fuser is installed via pip package"""

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -75,7 +75,18 @@ class FusionDefinition(_C._FusionDefinition):
         except Exception as err:
             print("\nError executing nvFuser FusionDefinition:")
             print(self)
-            raise RuntimeError(err)
+            print("# Generate similar inputs to reproduce:")
+            print("inputs = [")
+            for i in inputs:
+                if isinstance(i, torch.Tensor):
+                    if i.dtype.is_floating_point:
+                        print(f"    torch.randn({tuple(i.size())}, dtype={i.dtype}, device='{i.device}').as_strided({tuple(i.size())}, {tuple(i.stride())}),")
+                    else:
+                        print(f"    torch.randint(0, 10, {tuple(i.size())}, dtype={i.dtype}, device='{i.device}').as_strided({tuple(i.size())}, {tuple(i.stride())}),")
+                else:
+                    print(f"    {i},")
+            print("]")
+            raise err
 
         return result
 


### PR DESCRIPTION
Example:
```py
Error executing nvFuser FusionDefinition:

def nvfuser_fusion_id0(fd : FusionDefinition) -> None :
    T0 = fd.define_tensor(symbolic_sizes=[-1, -1], contiguous=[True, True], dtype=DataType.Float, is_cpu=False)
    T1 = fd.ops.max(T0, axes=[1], keepdim=False, dtype=DataType.Null)
    T2 = fd.ops.broadcast_in_dim(T1, output_shape=[3, 1], broadcast_dims=[0])
    T3 = fd.ops.broadcast_in_dim(T2, output_shape=[3, 3], broadcast_dims=[0, 1])
    T4 = fd.ops.sub(T0, T3)
    T5 = fd.ops.exp(T4)
    T6 = fd.ops.sum(T5, axes=[1], keepdim=False, dtype=DataType.Null)
    T7 = fd.ops.broadcast_in_dim(T6, output_shape=[3, 1], broadcast_dims=[0])
    T8 = fd.ops.broadcast_in_dim(T7, output_shape=[3, 3], broadcast_dims=[0, 1])
    T9 = fd.ops.div(T5, T8)
    fd.add_output(T9)


# Generate similar inputs to reproduce:
inputs = [
    torch.randn((3, 3), dtype=torch.float32, device='cuda:0').as_strided((3, 3), (3, 1)),
]
```