### PR TITLE
Internal only Python API matmul functions

### DIFF
--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -89,6 +89,12 @@ LstmResult lstm(
 // inputs were presented to Pytorch's matmul where input1 = weights and
 // input2 = activations.
 TensorView* _matmul_nn(TensorView* input1, TensorView* input2) {
+  TORCH_CHECK(
+      input1->getMaybeRFactorDomain().size() == 2,
+      "Only 2-D Tensors are currently supported.");
+  TORCH_CHECK(
+      input2->getMaybeRFactorDomain().size() == 2,
+      "Only 2-D Tensors are currently supported.");
   // [K, M] (non-transposed / col-major)
   auto tv1b = broadcast(input1, {true, false, false});
   // [N, K] (non-transposed / col-major)
@@ -101,6 +107,12 @@ TensorView* _matmul_nn(TensorView* input1, TensorView* input2) {
   return output;
 }
 TensorView* _matmul_nt(TensorView* input1, TensorView* input2) {
+  TORCH_CHECK(
+      input1->getMaybeRFactorDomain().size() == 2,
+      "Only 2-D Tensors are currently supported.");
+  TORCH_CHECK(
+      input2->getMaybeRFactorDomain().size() == 2,
+      "Only 2-D Tensors are currently supported.");
   // [K, M] (non-transposed / col-major)
   auto tv1b = broadcast(input1, {false, false, true});
   // [K, N] (transposed / row-major)
@@ -111,6 +123,12 @@ TensorView* _matmul_nt(TensorView* input1, TensorView* input2) {
   return output;
 }
 TensorView* _matmul_tn(TensorView* input1, TensorView* input2) {
+  TORCH_CHECK(
+      input1->getMaybeRFactorDomain().size() == 2,
+      "Only 2-D Tensors are currently supported.");
+  TORCH_CHECK(
+      input2->getMaybeRFactorDomain().size() == 2,
+      "Only 2-D Tensors are currently supported.");
   // [M, K] (transposed / row-major)
   auto tv1b = broadcast(input1, {false, true, false});
   // [N, K] (non-transposed / col-major)
@@ -121,6 +139,12 @@ TensorView* _matmul_tn(TensorView* input1, TensorView* input2) {
   return output;
 }
 TensorView* _matmul_tt(TensorView* input1, TensorView* input2) {
+  TORCH_CHECK(
+      input1->getMaybeRFactorDomain().size() == 2,
+      "Only 2-D Tensors are currently supported.");
+  TORCH_CHECK(
+      input2->getMaybeRFactorDomain().size() == 2,
+      "Only 2-D Tensors are currently supported.");
   // [M, K] (transposed / row-major)
   auto tv1b = broadcast(input1, {false, false, true});
   // [K, N] (transposed / row-major)

--- a/csrc/ops/composite.h
+++ b/csrc/ops/composite.h
@@ -52,10 +52,18 @@ TORCH_CUDA_CU_API LstmResult lstm(
 // In order to plumb ops for measurement and scheduling experimentation,
 // all the way up to the python API, these 4 functions are explicitly being
 // writen separately.
-TORCH_CUDA_CU_API TensorView* _matmul_nn(TensorView* input1, TensorView* input2);
-TORCH_CUDA_CU_API TensorView* _matmul_nt(TensorView* input1, TensorView* input2);
-TORCH_CUDA_CU_API TensorView* _matmul_tn(TensorView* input1, TensorView* input2);
-TORCH_CUDA_CU_API TensorView* _matmul_tt(TensorView* input1, TensorView* input2);
+TORCH_CUDA_CU_API TensorView* _matmul_nn(
+    TensorView* input1,
+    TensorView* input2);
+TORCH_CUDA_CU_API TensorView* _matmul_nt(
+    TensorView* input1,
+    TensorView* input2);
+TORCH_CUDA_CU_API TensorView* _matmul_tn(
+    TensorView* input1,
+    TensorView* input2);
+TORCH_CUDA_CU_API TensorView* _matmul_tt(
+    TensorView* input1,
+    TensorView* input2);
 
 TORCH_CUDA_CU_API TensorView* sign(TensorView* x);
 TORCH_CUDA_CU_API Val* sign(Val* x);

--- a/csrc/ops/composite.h
+++ b/csrc/ops/composite.h
@@ -47,6 +47,16 @@ TORCH_CUDA_CU_API LstmResult lstm(
     TensorView* cell_x,
     TensorView* out_x);
 
+// TODO: We need to figure out how we want to represent and communicate,
+// top-to-bottom, stride ordering in order to determine the matmul layout.
+// In order to plumb ops for measurement and scheduling experimentation,
+// all the way up to the python API, these 4 functions are explicitly being
+// writen separately.
+TORCH_CUDA_CU_API TensorView* _matmul_nn(TensorView* input1, TensorView* input2);
+TORCH_CUDA_CU_API TensorView* _matmul_nt(TensorView* input1, TensorView* input2);
+TORCH_CUDA_CU_API TensorView* _matmul_tn(TensorView* input1, TensorView* input2);
+TORCH_CUDA_CU_API TensorView* _matmul_tt(TensorView* input1, TensorView* input2);
+
 TORCH_CUDA_CU_API TensorView* sign(TensorView* x);
 TORCH_CUDA_CU_API Val* sign(Val* x);
 TORCH_CUDA_CU_API TensorView* softplus(

--- a/csrc/ops/composite.h
+++ b/csrc/ops/composite.h
@@ -51,7 +51,7 @@ TORCH_CUDA_CU_API LstmResult lstm(
 // top-to-bottom, stride ordering in order to determine the matmul layout.
 // In order to plumb ops for measurement and scheduling experimentation,
 // all the way up to the python API, these 4 functions are explicitly being
-// writen separately.
+// written separately.
 TORCH_CUDA_CU_API TensorView* _matmul_nn(
     TensorView* input1,
     TensorView* input2);

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -720,6 +720,7 @@ void initNvFuserPythonBindings(PyObject* module) {
       },                                                                       \
       py::return_value_policy::reference);
 
+  NVFUSER_PYTHON_BINDING_BINARY_OP_TENSORS_ONLY("_matmul_nn", _matmul_nn)
   NVFUSER_PYTHON_BINDING_BINARY_OP_TENSORS_ONLY("_matmul_nt", _matmul_nt)
   NVFUSER_PYTHON_BINDING_BINARY_OP_TENSORS_ONLY("_matmul_tn", _matmul_tn)
   NVFUSER_PYTHON_BINDING_BINARY_OP_TENSORS_ONLY("_matmul_tt", _matmul_tt)


### PR DESCRIPTION
Three internal matmul functions are exposed.  These is not intended to be the final matmul API, therefore, they are marked as internal as the final version should not be layout specific.
- `ops._matmul_nn` 
- `ops._matmul_nt`
- `ops._matmul_tn`
- `ops._matmul_tt`

We need to figure out how we want to represent and communicate, top-to-bottom, stride ordering in order to determine the matmul layout. In order to plumb ops for measurement and scheduling experimentation, all the way up to the python API, these 4 functions are explicitly being  written separately but are intended to be integrated into one function.

**Pytorch's `matmul` Implementation Notes**:
Pytorch Matmul's are calculating (M x K) @ (K x M) = [M, N]                                                                                                                                                                                                                              Pytorch has a default output of row-major (N) which is not to be confused with Cublas that defaults to column-major (M) such that Pytorch's Eager mode swaps input1 and input2 when giving them to Cublas such that N is produced on the inner dimension.

**Pytorch's `Linear` Implementation Notes**:                                                                                                                                                                                                                                                               
Pytorch's Linear operation defaults to producing a Column-major output [N, M] for it's forward pass that is the opposite if the same inputs were presented to Pytorch's matmul where input1 = weights and input2 = activations.

TODOS:

- [x] Write up PR description
- [ ] Make Python tests
- [ ] Feedback 
- [x]  Add 2-D Tensor asserts for now.