### PR TITLE
Better validation of domains when creating TensorDomain

### DIFF
--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -2576,33 +2576,6 @@ TensorDomain::TensorDomain(
   resetDomains();
 }
 
-namespace {
-
-// Validate that the root domain consists of all inputs to domain
-// Uncertain if this will hold for RFactor
-void validateInputDependency(
-    const std::vector<IterDomain*>& root_domain,
-    const std::vector<IterDomain*>& domain) {
-  std::vector<Val*> non_symbolic_domain;
-  std::copy_if(
-      domain.begin(),
-      domain.end(),
-      std::back_inserter(non_symbolic_domain),
-      [](auto dom) { return dom->getIterType() != IterType::Symbolic; });
-  auto inps = IterVisitor::getInputsTo(non_symbolic_domain);
-
-  std::unordered_set<Val*> root_vals(root_domain.begin(), root_domain.end());
-  std::for_each(inps.begin(), inps.end(), [root_vals](Val* inp) {
-    TORCH_INTERNAL_ASSERT(
-        root_vals.find(inp) != root_vals.end(),
-        "Invalid tensor domain, ",
-        inp,
-        " is an input of domain, but it is not found in the root domain.");
-  });
-}
-
-} // namespace
-
 TensorDomain::TensorDomain(
     IrBuilderPasskey passkey,
     std::vector<IterDomain*> root_domain,
@@ -2628,7 +2601,9 @@ TensorDomain::TensorDomain(
         "The contiguity of a non-broadcast dimension must be true/false");
   }
 
-  validateInputDependency(root_domain_, domain_);
+  if (!root_domain_.empty()) {
+    ir_utils::validateDomainEquivalence(root_domain_, domain_);
+  }
 
   // Just due to clang-tidy, correct value set in resetDomains
   has_reduction_ = false;
@@ -2662,8 +2637,12 @@ TensorDomain::TensorDomain(
         "The contiguity of a non-broadcast dimension must be true/false");
   }
 
-  validateInputDependency(root_domain_, rfactor_domain_);
-  validateInputDependency(root_domain_, domain_);
+  if (!root_domain_.empty()) {
+    if (!rfactor_domain_.empty()) {
+      ir_utils::validateDomainEquivalence(root_domain_, rfactor_domain_);
+    }
+    ir_utils::validateDomainEquivalence(root_domain_, domain_);
+  }
 
   // Just due to clang-tidy, correct value set in resetDomains
   has_reduction_ = false;

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -2602,6 +2602,7 @@ TensorDomain::TensorDomain(
   }
 
   if (!root_domain_.empty()) {
+    TORCH_CHECK(!domain_.empty(), "Root domain is not empty but leaf is");
     ir_utils::validateDomainEquivalence(root_domain_, domain_);
   }
 
@@ -2638,10 +2639,12 @@ TensorDomain::TensorDomain(
   }
 
   if (!root_domain_.empty()) {
-    if (!rfactor_domain_.empty()) {
-      ir_utils::validateDomainEquivalence(root_domain_, rfactor_domain_);
-    }
+    TORCH_CHECK(
+        !rfactor_domain_.empty(), "Root domain is not empty but rfactor is");
+    ir_utils::validateDomainEquivalence(root_domain_, rfactor_domain_);
+    TORCH_CHECK(!domain_.empty(), "Root domain is not empty but leaf is");
     ir_utils::validateDomainEquivalence(root_domain_, domain_);
+    ir_utils::validateDomainEquivalence(rfactor_domain_, domain_);
   }
 
   // Just due to clang-tidy, correct value set in resetDomains

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -2639,12 +2639,12 @@ TensorDomain::TensorDomain(
   }
 
   if (!root_domain_.empty()) {
-    TORCH_CHECK(
-        !rfactor_domain_.empty(), "Root domain is not empty but rfactor is");
-    ir_utils::validateDomainEquivalence(root_domain_, rfactor_domain_);
     TORCH_CHECK(!domain_.empty(), "Root domain is not empty but leaf is");
     ir_utils::validateDomainEquivalence(root_domain_, domain_);
-    ir_utils::validateDomainEquivalence(rfactor_domain_, domain_);
+    if (!rfactor_domain_.empty()) {
+      ir_utils::validateDomainEquivalence(root_domain_, rfactor_domain_);
+      ir_utils::validateDomainEquivalence(rfactor_domain_, domain_);
+    }
   }
 
   // Just due to clang-tidy, correct value set in resetDomains

--- a/csrc/ir_utils.cpp
+++ b/csrc/ir_utils.cpp
@@ -905,7 +905,8 @@ class ValidateDomainEquivalence : private IterVisitor {
 
   void handle(Expr* expr) override {
     // If any of the inputs is included in derived_domain_, that means there's a
-    // dependency within derived_domain_, which is invalid
+    // dependency within derived_domain_ and the dependent domains
+    // redundantly cover the initial domain
     TORCH_INTERNAL_ASSERT(
         std::none_of(
             expr->inputs().begin(),
@@ -913,7 +914,7 @@ class ValidateDomainEquivalence : private IterVisitor {
             [&](Val* input_val) {
               return derived_domain_.find(input_val) != derived_domain_.end();
             }),
-        "Invalid derived domain due to expr: ",
+        "Invalid derived domain due to dependent expr: ",
         expr->toString(),
         ". Derived domain: ",
         toDelimitedString(derived_domain_));

--- a/csrc/ir_utils.cpp
+++ b/csrc/ir_utils.cpp
@@ -874,8 +874,7 @@ class ValidateDomainEquivalence : private IterVisitor {
         "Duplicated entry is detected in derived_domain: ",
         toDelimitedString(derived_domain));
     traverseTo(
-        initial_domain.at(0)->fusion(),
-        {derived_domain.begin(), derived_domain.end()});
+        initial_domain.at(0)->fusion(), {derived_domain.begin(), derived_domain.end()});
     // If there's any symbolic ID, can't completely validate. Just
     // make sure all non-symbolic IDs are included in the frontier set
     if (std::any_of(derived_domain.begin(), derived_domain.end(), [](auto id) {
@@ -907,6 +906,7 @@ class ValidateDomainEquivalence : private IterVisitor {
     // If any of the inputs is included in derived_domain_, that means there's a
     // dependency within derived_domain_ and the dependent domains
     // redundantly cover the initial domain
+#if 0
     TORCH_INTERNAL_ASSERT(
         std::none_of(
             expr->inputs().begin(),
@@ -918,11 +918,13 @@ class ValidateDomainEquivalence : private IterVisitor {
         expr->toString(),
         ". Derived domain: ",
         toDelimitedString(derived_domain_));
-    for (auto inp : expr->inputs()) {
-      frontier_.erase(inp);
+#endif
+    for (auto out : expr->outputs()) {
+      // Make sure the output is not yet visited
+      TORCH_INTERNAL_ASSERT(frontier_.insert(out).second, "Invalid derived domain output");
     }
-    for (auto inp : expr->outputs()) {
-      frontier_.insert(inp);
+    for (auto inp : expr->inputs()) {
+      TORCH_INTERNAL_ASSERT(frontier_.erase(inp) == 1, "Invalid derived domain input");
     }
   }
 

--- a/csrc/ir_utils.h
+++ b/csrc/ir_utils.h
@@ -390,5 +390,19 @@ bool hasResizedRfactor(const TensorView* tv);
 // Returns tvs that have symbolic axes
 std::vector<TensorView*> getTVsWithDynamicTransform(Fusion* fusion);
 
+//! Validate derived_domain completely covers initial_domain with no
+//! redundancy. Consider derived_domains as a different view of the
+//! same logical domain as initial_domain with affine
+//! transformations. This validation makes sure both sets
+//! of domains represent the same logical space.
+//!
+//! For example, it's an error if a root ID is split and
+//! only one of the outputs is included in the ids vector. It is
+//! also an error if both a producer and consumer ID are included in
+//! ids as they partially have the same dependency with root_ids.
+void validateDomainEquivalence(
+    const std::vector<IterDomain*>& initial_domain,
+    const std::vector<IterDomain*>& derived_domain);
+
 } // namespace ir_utils
 } // namespace nvfuser

--- a/csrc/ir_utils.h
+++ b/csrc/ir_utils.h
@@ -396,10 +396,14 @@ std::vector<TensorView*> getTVsWithDynamicTransform(Fusion* fusion);
 //! transformations. This validation makes sure both sets
 //! of domains represent the same logical space.
 //!
-//! For example, it's an error if a root ID is split and
+//! It is intended to be used to validate rfactor and leaf domains
+//! of a tensor root domain.
+//!
+//! For example, it's an error if a initial ID is split and
 //! only one of the outputs is included in the ids vector. It is
 //! also an error if both a producer and consumer ID are included in
-//! ids as they partially have the same dependency with root_ids.
+//! ids as they partially have the same dependency with the initial
+//! domain.
 void validateDomainEquivalence(
     const std::vector<IterDomain*>& initial_domain,
     const std::vector<IterDomain*>& derived_domain);

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -400,9 +400,9 @@ std::string toDelimitedString(
 
 template <typename Printable>
 std::string toDelimitedString(
-    const std::unordered_set<Printable>& vec,
+    const std::unordered_set<Printable>& set,
     std::string delim = ", ") {
-  return toDelimitedString(vec.begin(), vec.end(), delim);
+  return toDelimitedString(set.begin(), set.end(), delim);
 }
 
 template <int64_t index, int64_t stop, int64_t step, typename func_t>

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -398,6 +398,13 @@ std::string toDelimitedString(
   return toDelimitedString(dq.begin(), dq.end(), delim);
 }
 
+template <typename Printable>
+std::string toDelimitedString(
+    const std::unordered_set<Printable>& vec,
+    std::string delim = ", ") {
+  return toDelimitedString(vec.begin(), vec.end(), delim);
+}
+
 template <int64_t index, int64_t stop, int64_t step, typename func_t>
 void unrolled_for(func_t fun) {
   if constexpr (index < stop) {

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -8141,6 +8141,11 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
   tv1->split(0, 3);
   // [I0/4*4/3, 3, I1]
 
+  ir_utils::validateDomainEquivalence(
+      tv1->getRootDomain(),
+      {tv1_intermediate_id, tv1->axis(0), tv1->axis(1), tv1->axis(2)});
+
+
   // Initial domain: root domain
   // Derived domain: leaf + tv1_intermediate_id
   // Should fail as the intermediate ID and the first two leaves are redundant

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -8141,11 +8141,6 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
   tv1->split(0, 3);
   // [I0/4*4/3, 3, I1]
 
-  ir_utils::validateDomainEquivalence(
-      tv1->getRootDomain(),
-      {tv1_intermediate_id, tv1->axis(0), tv1->axis(1), tv1->axis(2)});
-
-
   // Initial domain: root domain
   // Derived domain: leaf + tv1_intermediate_id
   // Should fail as the intermediate ID and the first two leaves are redundant


### PR DESCRIPTION
This is for #225 

A `TensorDomain` is created with a list of IterDomains representing a root domain, and optionally another list of IterDomains for an rfactor domain and also one more list for the leaf domain.

Currently, we do some error check using `IterVisitor::getInputsTo`, but that's not always sufficient. We need to make sure that the root domain and the other domains represent the same logical space without any overlap. 

For example:

```
IterDomain* id0 = IterDomainBuilder()....build();
IterDomain* id1, id2 = IterDomain::split(id0, 4);
```

Here, it'd be valid to have a root and leaf domain as follows:

```
Root: id0
Leaf: id1, id2
```

Suppose `id2` is further split as:

```
IterDomain* id3, id4 = IterDomain::split(id2, 5);
```
Then, this is invalid:

```
Root: id0
Leaf: id1, id2, id3, id4
```

`id3` and `id4` are disjoint, but they overlap with `id2`. To represent the original space using the new leaf IDs, `id2` shouldn't be included, however, the current error check won't detect these kinds of invalid domains.

This PR replaces the existing error check with more complete analysis. As long as all IDs are non-symbolic, it should be able to determine whether a list of initial IDs and another list of derived IDs represent the same space. It also checks if the derived IDs are disjoint.

Since the error check is always used when TensorDomain is created, I consider it well tested, so I just added one unit test for testing some corner cases.