### PR TITLE
Fixes for torch_gather and take_along_axis with broadcast input tensors

### DIFF
--- a/csrc/ir_utils.h
+++ b/csrc/ir_utils.h
@@ -200,7 +200,7 @@ TORCH_CUDA_CU_API TensorView* rfactorHelper(
 // limited to not go through fusion inputs/outputs, but if on a path that isn't
 // strictly between fusion inputs/outputs, it could effectively return dead
 // code.
-TORCH_CUDA_CU_API std::vector<Val*> producerValsOf(Val* val);
+TORCH_CUDA_CU_API std::vector<Val*> producerValsOf(const Val* val);
 
 // Return immediate consumers of val, this function can be used on any Val and
 // will return consumers through Exprs.
@@ -210,7 +210,7 @@ TORCH_CUDA_CU_API std::vector<Val*> producerValsOf(Val* val);
 // limited to not go through fusion inputs/outputs, but if on a path that isn't
 // strictly between fusion inputs/outputs, it could effectively return dead
 // code.
-TORCH_CUDA_CU_API std::vector<Val*> consumerValsOf(Val* val);
+TORCH_CUDA_CU_API std::vector<Val*> consumerValsOf(const Val* val);
 
 // Return immediate siblings of val, this function can be used on any Val and
 // will return siblings through Exprs.
@@ -220,7 +220,7 @@ TORCH_CUDA_CU_API std::vector<Val*> consumerValsOf(Val* val);
 // limited to not go through fusion inputs/outputs, but if on a path that isn't
 // strictly between fusion inputs/outputs, it could effectively return dead
 // code.
-TORCH_CUDA_CU_API std::vector<Val*> siblingValsOf(Val* val);
+TORCH_CUDA_CU_API std::vector<Val*> siblingValsOf(const Val* val);
 
 // Return immediate producers of vals, this function can be used on any vals and
 // will return producers through Exprs.
@@ -252,7 +252,7 @@ TORCH_CUDA_CU_API std::vector<Val*> consumerValsOf(
 // limited to not go through fusion inputs/outputs, but if on a path that isn't
 // strictly between fusion inputs/outputs, it could effectively return dead
 // code.
-TORCH_CUDA_CU_API std::vector<TensorView*> producerTvsOf(TensorView* tv);
+TORCH_CUDA_CU_API std::vector<TensorView*> producerTvsOf(const TensorView* tv);
 
 // Return immediate consumers of tv, this function will return all immediate
 // consumers of tv through Exprs.
@@ -262,7 +262,7 @@ TORCH_CUDA_CU_API std::vector<TensorView*> producerTvsOf(TensorView* tv);
 // limited to not go through fusion inputs/outputs, but if on a path that isn't
 // strictly between fusion inputs/outputs, it could effectively return dead
 // code.
-TORCH_CUDA_CU_API std::vector<TensorView*> consumerTvsOf(TensorView* tv);
+TORCH_CUDA_CU_API std::vector<TensorView*> consumerTvsOf(const TensorView* tv);
 
 // Return immediate siblings of tv, this function will return all immediate
 // siblings of tv through Exprs.
@@ -272,7 +272,7 @@ TORCH_CUDA_CU_API std::vector<TensorView*> consumerTvsOf(TensorView* tv);
 // limited to not go through fusion inputs/outputs, but if on a path that isn't
 // strictly between fusion inputs/outputs, it could effectively return dead
 // code.
-TORCH_CUDA_CU_API std::vector<TensorView*> siblingTvsOf(TensorView* tv);
+TORCH_CUDA_CU_API std::vector<TensorView*> siblingTvsOf(const TensorView* tv);
 
 // Return immediate producers of tvs, this function will return all immediate
 // producers of tvs through Exprs.
@@ -363,6 +363,22 @@ TORCH_CUDA_CU_API bool isSqueezeInput(const TensorView* tv);
 
 // Test if the given ID in the given tensor is squeezed
 TORCH_CUDA_CU_API bool isSqueezedID(const TensorView* tv, const IterDomain* id);
+
+// Test if the given ID in the given tensor is indirectly accessed by,
+// e.g., index_select, torch_gather and scatter
+TORCH_CUDA_CU_API bool isIndexedID(const TensorView* tv, const IterDomain* id);
+
+// Test if the given ID in the given tensor is indirectly read by,
+// e.g., index_select and torch_gather
+TORCH_CUDA_CU_API bool isIndexedProducerID(
+    const TensorView* tv,
+    const IterDomain* id);
+
+// Test if the given ID in the given tensor is indirectly written to by,
+// e.g., scatter
+TORCH_CUDA_CU_API bool isIndexedConsumerID(
+    const TensorView* tv,
+    const IterDomain* id);
 
 // Get all IDs of a tensor. Returned values are topologicaly ordered, and
 // unique.

--- a/csrc/root_domain_map.cpp
+++ b/csrc/root_domain_map.cpp
@@ -747,19 +747,20 @@ void ComputeAtRootDomainMapBuilder::initializeBcastMap(
     return;
   }
 
-  // This initialization should be only used for: 1) fusion output tensors, 2)
-  // outputs of multi-consumer expressions that are not fusion outputs, 3) view
-  // outputs as broadcasts can be merged with non-broadcast domains, resulting
-  // in non-broadcast rfactor domains, and 4) squeeze inputs as broadcasts can
-  // be removed by squeeze.
-  TORCH_INTERNAL_ASSERT(
-      tv->isFusionOutput() || ir_utils::isSqueezeInput(tv) ||
-          tv->definition()->outputs().size() > 1 ||
-          tv->isDefinitionType<ViewOp>(),
-      "Invalid tensor to initialize bcast map t",
-      tv->name(),
-      " in tensor ",
-      tv->toString());
+  // This initialization of the entry for the broadcast ID should only
+  // happen when the broadcast has no further consumer ID, including
+  // resolved non-broadcast IDs. An equivalent condition is that the
+  // pairwise map has no mapping for the broadcast.
+  for (auto consumer : ir_utils::consumerTvsOf(tv)) {
+    const auto p2c =
+        PairwiseRootDomainMap(tv, consumer)
+            .mapProducerToConsumer(tv->domain(), consumer->domain());
+    // Unfortunately, const_cast is required as our const model is
+    // broken.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    TORCH_INTERNAL_ASSERT(p2c.find(const_cast<IterDomain*>(id)) == p2c.end());
+  }
+
   root_map_.bcast_map_.insert({key, {id}});
 }
 
@@ -1075,8 +1076,11 @@ void ComputeAtRootDomainMapBuilder::handle(GatherOp* op) {
 }
 
 void ComputeAtRootDomainMapBuilder::handle(TorchGatherOp* op) {
+  const TensorDomain* lookup_td = op->lookupTv()->as<TensorView>()->domain();
   const TensorDomain* idx_td = op->indexTv()->as<TensorView>()->domain();
   const TensorDomain* out_td = op->output(0)->as<TensorView>()->domain();
+  const auto lookup_root =
+      TensorDomain::noReductions(lookup_td->getMaybeRFactorDomain());
   const auto idx_root =
       TensorDomain::noReductions(idx_td->getMaybeRFactorDomain());
   const auto& out_root = out_td->getRootDomain();
@@ -1088,11 +1092,21 @@ void ComputeAtRootDomainMapBuilder::handle(TorchGatherOp* op) {
       idx_root,
       "\nOutput root domain: ",
       out_root);
+  TORCH_INTERNAL_ASSERT(
+      lookup_root.size() == out_root.size(),
+      "\nExpression: ",
+      op,
+      "\nLookup root domain: ",
+      lookup_root,
+      "\nOutput root domain: ",
+      out_root);
 
-  // Only maps the index root axes. Do not map the input axes due to non-equal
-  // size problem.
-  for (const auto it : c10::irange(idx_root.size())) {
-    setMaybeMapped(idx_td, idx_root[it], out_td, out_root[it]);
+  // Only maps the index root axes unless exact_sizes is true
+  for (const auto i : c10::irange(idx_root.size())) {
+    if (static_cast<int>(i) != op->dim() && op->exactSizes()) {
+      setMaybeMapped(lookup_td, lookup_root[i], out_td, out_root[i]);
+    }
+    setMaybeMapped(idx_td, idx_root[i], out_td, out_root[i]);
   }
 }
 

--- a/test/test_gather.cpp
+++ b/test/test_gather.cpp
@@ -509,10 +509,11 @@ TEST_F(IndexingOpTest, GatherBroadcastInput_CUDA) {
         // [I, B] when idx_index_dim == 1, otherwise [I, I]
         // In torch_gather, an index dimension must be smaller or
         // equal to the corresponding input dimension
-        std::vector<int64_t> index_dims{is_take_along ? 5 : input_dims.at(0), idx_index_dim};
+        std::vector<int64_t> index_dims{
+            is_take_along ? 5 : input_dims.at(0), idx_index_dim};
         // This needs to match with the take_along_axis output
         std::vector<int64_t> out_dims{
-          index_dims.at(0), index_dims.at(1), input_dims.at(2)};
+            index_dims.at(0), index_dims.at(1), input_dims.at(2)};
 
         auto fusion_ptr = std::make_unique<Fusion>();
         Fusion& fusion = *fusion_ptr.get();
@@ -531,7 +532,8 @@ TEST_F(IndexingOpTest, GatherBroadcastInput_CUDA) {
         fusion.addOutput(tv5);
 
         at::manual_seed(0);
-        auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+        auto options =
+            at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
         auto options_i =
             at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
         at::Tensor t0 = at::randn(input_dims, options);
@@ -542,12 +544,12 @@ TEST_F(IndexingOpTest, GatherBroadcastInput_CUDA) {
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
         auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
-        auto t4 =
-            is_take_along ? at::take_along_dim(t0, t1.unsqueeze(-1), 1) :
-             at::gather(t0, 1, t1.unsqueeze(-1));
+        auto t4 = is_take_along ? at::take_along_dim(t0, t1.unsqueeze(-1), 1)
+                                : at::gather(t0, 1, t1.unsqueeze(-1));
         auto ref = t4 + t2;
 
-        testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+        testValidate(
+            &fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
       }
     }
   }

--- a/test/test_gather.cpp
+++ b/test/test_gather.cpp
@@ -489,58 +489,68 @@ TEST_F(IndexingOpTest, TakeAlongBroadcastIndex_CUDA) {
   }
 }
 
-// Disabled for now as it fails likely due to
-// https://github.com/NVIDIA/Fuser/issues/93
-#if 0
-TEST_F(IndexingOpTest, TakeAlongBroadcastInput_CUDA) {
-  for (const auto inp_indexed_dim : {1, 11}) {
-    for (const auto idx_index_dim : {1, 3}) {
-      // [B, B, I] when inp_indexed_dim == 1, otherwise [B, I, I]
-      std::vector<int64_t> input_dims{1, inp_indexed_dim, 12};
-      // [I, B] when idx_index_dim == 1, otherwise [I, I]
-      std::vector<int64_t> index_dims{5, idx_index_dim};
-      // This needs to match with the take_along_axis output
-      std::vector<int64_t> out_dims{
+TEST_F(IndexingOpTest, GatherBroadcastInput_CUDA) {
+  for (const auto is_take_along : {false, true}) {
+    // torch_gather not supported yet. The issue is one of the index
+    // tensor has a broadcast domain, but its corresponding input
+    // domain is a normal domain. The output domain is also a
+    // broadcast in torch_gather, whereas it's a normal domain in
+    // take_along_axis. In the case of torch_gather, indexing the
+    // input domain needs to be able to index the normal producer
+    // domain with a broadcast reference domain. getProduerIndex needs
+    // some fix.
+    if (!is_take_along) {
+      continue;
+    }
+    for (const auto inp_indexed_dim : {1, 11}) {
+      for (const auto idx_index_dim : {1, 3}) {
+        // [B, B, I] when inp_indexed_dim == 1, otherwise [B, I, I]
+        std::vector<int64_t> input_dims{1, inp_indexed_dim, 12};
+        // [I, B] when idx_index_dim == 1, otherwise [I, I]
+        // In torch_gather, an index dimension must be smaller or
+        // equal to the corresponding input dimension
+        std::vector<int64_t> index_dims{is_take_along ? 5 : input_dims.at(0), idx_index_dim};
+        // This needs to match with the take_along_axis output
+        std::vector<int64_t> out_dims{
           index_dims.at(0), index_dims.at(1), input_dims.at(2)};
 
-      auto fusion_ptr = std::make_unique<Fusion>();
-      Fusion& fusion = *fusion_ptr.get();
-      FusionGuard fg(&fusion);
+        auto fusion_ptr = std::make_unique<Fusion>();
+        Fusion& fusion = *fusion_ptr.get();
+        FusionGuard fg(&fusion);
 
-      auto tv0 = makeConcreteTensor({1, inp_indexed_dim == 1 ? 1 : -1, -1});
-      auto tv1 =
-          makeConcreteTensor({-1, idx_index_dim == 1 ? 1 : -1}, DataType::Int);
-      auto tv2 =
-          makeConcreteTensor({-1, idx_index_dim == 1 ? idx_index_dim : -1, -1});
-      fusion.addInput(tv0);
-      fusion.addInput(tv1);
-      fusion.addInput(tv2);
+        auto tv0 = makeSymbolicTensor(input_dims);
+        auto tv1 = makeSymbolicTensor(index_dims, DataType::Int);
+        auto tv2 = makeSymbolicTensor(out_dims);
+        fusion.addInput(tv0);
+        fusion.addInput(tv1);
+        fusion.addInput(tv2);
 
-      auto tv3 = broadcast(tv1, {false, false, true});
-      auto tv4 = take_along_axis(tv0, tv3, 1);
-      auto tv5 = add(tv4, tv2);
-      fusion.addOutput(tv5);
+        auto tv3 = broadcast(tv1, {false, false, true});
+        auto tv4 = take_along_axis(tv0, tv3, 1);
+        auto tv5 = add(tv4, tv2);
+        fusion.addOutput(tv5);
 
-      at::manual_seed(0);
-      auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-      auto options_i =
-          at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-      at::Tensor t0 = at::randn(input_dims, options);
-      at::Tensor t1 = at::randint(0, input_dims[1], index_dims, options_i);
-      at::Tensor t2 = at::randn(out_dims, options);
-      std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
+        at::manual_seed(0);
+        auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+        auto options_i =
+            at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
+        at::Tensor t0 = at::randn(input_dims, options);
+        at::Tensor t1 = at::randint(0, input_dims[1], index_dims, options_i);
+        at::Tensor t2 = at::randn(out_dims, options);
+        std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
-      FusionExecutorCache executor_cache(std::move(fusion_ptr));
-      auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+        FusionExecutorCache executor_cache(std::move(fusion_ptr));
+        auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
-      auto t4 =
-          at::take_along_dim(t0, t1.unsqueeze(0).unsqueeze(-1).expand(out_dims), 1);
-      auto ref = t4 + t2;
+        auto t4 =
+            is_take_along ? at::take_along_dim(t0, t1.unsqueeze(-1), 1) :
+             at::gather(t0, 1, t1.unsqueeze(-1));
+        auto ref = t4 + t2;
 
-      testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+        testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+      }
     }
   }
 }
-#endif
 
 } // namespace nvfuser

--- a/test/utils.h
+++ b/test/utils.h
@@ -54,6 +54,20 @@ inline TensorView* makeSymbolicTensor(
   return TensorViewBuilder().ndims(ndims).dtype(dtype).build();
 }
 
+// Similar to the other overload but uses shape only to create
+// broadcast IterDomains for size-1 axes. The extents of other axes
+// remain symbolic.
+inline TensorView* makeSymbolicTensor(
+    std::vector<int64_t> shape,
+    DataType dtype = DataType::Float) {
+  for (auto& s : shape) {
+    if (s != 1) {
+      s = -1;
+    }
+  }
+  return TensorViewBuilder().shape(shape).dtype(dtype).build();
+}
+
 // Make a non-contiguous tensor of compile-time known sizes
 inline TensorView* makeConcreteTensor(
     std::vector<int64_t> shape,


### PR DESCRIPTION
There remain some more issues for torch_gather, but the disabled test for take_along_axis is now working.

Haven't tried yet, but hopefully this should also fixes issue #93