### PR TITLE
parallelize on leaf

### DIFF
--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1901,7 +1901,6 @@ std::vector<Val*> Index::getProducerRootIndices(
 
   auto producer_indexing = producer_indexing_from_idgraph.index;
 
-
   // Indices should now be mapped onto IterDomains in producer, so just grab
   // and use them.
   auto root_dom = producer_tv->getMaybeRFactorDomain();

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -2502,21 +2502,15 @@ void IterDomain::parallelize(ParallelType t) {
 
   // assert check that we only parallelize a leaf domain.
   // leaf domains are domains that are not used by any other domains.
-  // this check is only applied to isParallelTypeThread
-  // getNonGlobalProducerStridedIndices in NVFuserTest.FusionIndexHoist2_CUDA
-  // is trying to parallelize a non-leaf domain using vectorize
-  // should be albe to apply to all parallel types after computeAt is retired.
-  if (isParallelTypeThread(t)) {
-    TORCH_CHECK(
-        uses().empty(),
-        "Only allowed to parallelize a leaf domain.",
-        " Domain: ",
-        toString(),
-        ", Parallel type: ",
-        t,
-        definition() != nullptr ? ", Definition: " + definition()->toString()
-                                : "");
-  }
+  TORCH_CHECK(
+      uses().empty(),
+      "Only allowed to parallelize a leaf domain.",
+      " Domain: ",
+      toString(),
+      ", Parallel type: ",
+      t,
+      definition() != nullptr ? ", Definition: " + definition()->toString()
+                              : "");
 
   if (t == ParallelType::Unroll || isParallelTypeVectorize(t) ||
       t == ParallelType::Group) {

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -2500,24 +2500,15 @@ void IterDomain::parallelize(ParallelType t) {
     return;
   }
 
-  // Leaf domains are domains that are not used by any other domains.
-  auto isLeafDomain = [&]() {
-    for (auto expr : uses()) {
-      if (expr->isA<Split>() || expr->isA<Merge>() || expr->isA<Resize>()) {
-        return false;
-      }
-    }
-    return true;
-  };
-
   // assert check that we only parallelize a leaf domain.
+  // leaf domains are domains that are not used by any other domains.
   // this check is only applied to isParallelTypeThread
   // getNonGlobalProducerStridedIndices in NVFuserTest.FusionIndexHoist2_CUDA
   // is trying to parallelize a non-leaf domain using vectorize
   // should be albe to apply to all parallel types after computeAt is retired.
   if (isParallelTypeThread(t)) {
     TORCH_CHECK(
-        isLeafDomain(),
+        uses().empty(),
         "Only allowed to parallelize a leaf domain.",
         " Domain: ",
         toString(),

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -2502,15 +2502,17 @@ void IterDomain::parallelize(ParallelType t) {
 
   // assert check that we only parallelize a leaf domain.
   // leaf domains are domains that are not used by any other domains.
-  TORCH_CHECK(
-      uses().empty(),
-      "Only allowed to parallelize a leaf domain.",
-      " Domain: ",
-      toString(),
-      ", Parallel type: ",
-      t,
-      definition() != nullptr ? ", Definition: " + definition()->toString()
-                              : "");
+  if (t != ParallelType::Serial) {
+    TORCH_CHECK(
+        uses().empty(),
+        "Only allowed to parallelize a leaf domain.",
+        " Domain: ",
+        toString(),
+        ", Parallel type: ",
+        t,
+        definition() != nullptr ? ", Definition: " + definition()->toString()
+                                : "");
+  }
 
   if (t == ParallelType::Unroll || isParallelTypeVectorize(t) ||
       t == ParallelType::Group) {

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -8223,6 +8223,8 @@ TEST_F(NVFuserTest, DoublePrecisionNorm_CUDA) {
       {ref},
       __LINE__,
       __FILE__);
+}
+
 // Test for void IterDomain::parallelize(ParallelType t)
 // Only allowed to parallelize a leaf domain.
 TEST_F(NVFuserTest, FusionIllegalParallelizeNonLeafDomain_CUDA) {

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -8223,6 +8223,31 @@ TEST_F(NVFuserTest, DoublePrecisionNorm_CUDA) {
       {ref},
       __LINE__,
       __FILE__);
+// Test for void IterDomain::parallelize(ParallelType t)
+// Only allowed to parallelize a leaf domain.
+TEST_F(NVFuserTest, FusionIllegalParallelizeNonLeafDomain_CUDA) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(2);
+  fusion.addInput(tv0);
+  auto tv1 = set(tv0);
+  fusion.addOutput(tv1);
+
+  // [I0, I1]
+  tv1->split(1, 4);
+  // [I0, I1/4, 4]
+
+  const auto& root_domain = tv1->getRootDomain();
+
+  // legal, as I0 is also a leaf domain
+  root_domain[0]->parallelize(ParallelType::BIDx);
+
+  // llegal, as I1 is not a leaf domain
+  EXPECT_THAT(
+      [&]() { root_domain[1]->parallelize(ParallelType::BIDy); },
+      testing::ThrowsMessage<c10::Error>(
+          testing::HasSubstr("Only allowed to parallelize a leaf domain")));
 }
 
 // delete intermediate tensors between segments to reduce memory usage of large


### PR DESCRIPTION
Added assert check that we only parallelize a leaf domain. #127 
Ideally, leaf domains are domains that are not used by any other domains.
However, this is not true if reduandant split/merge operations are added by the user manually. e.g. case FusionAdvancedComputeAt8_CUDA.
so the check is relaxed to include intermediate domains between root and leaf.

```
  tv7->split(1, 2);
  tv7->merge(0);
  tv7->split(0, 128, false);
  tv7->split(0, 4, false);

  tv7->axis(0)->parallelize(ParallelType::BIDx);
  tv7->axis(1)->parallelize(ParallelType::TIDx);
  tv0->computeAt(tv4, -1);
  tv2->computeAt(tv4, -1);
  tv0->computeAt(tv7, -1);
```
we did one merge and three splits on tv7, but why the printed transform history is different?
```
T7_g[ iS9{i0}, iS12{2}, iS11{( ceilDiv(i13, 2) )} ] produce_pos( 1 )
 root domain : (iS9{i0}, iS10{i13})
 contiguity: t t
  Split: iS10{i13} by factor 2 -> iS11{( ceilDiv(i13, 2) )}, iS12{2}, start offset: 0, stop offset: 0
 leaf domain : (iS9{i0}, iS12{2}, iS11{( ceilDiv(i13, 2) )})
```