### PR TITLE
fix output format of matmul heuristic

### DIFF
--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -102,15 +102,16 @@ class MatmulParams : public HeuristicParams {
        << "Async global mem load: "
        << (async_gmem_load_operands ? "true" : "false") << "\n"
        << "Indexing mode: "
-       << "Tile rastrization order: "
-       << ((cta_order == TileRasterizationOrder::RowMajor) ? "row-major"
-                                                           : "column-major")
-       << "Grid swizzle factor: " << grid_swizzle_factor
        << (cparams.index_type.has_value()
                ? (cparams.index_type.value() == PrimDataType::Int ? "int64_t"
                                                                   : "int32_t")
                : "unavailable")
        << "\n"
+       << "Tile rastrization order: "
+       << ((cta_order == TileRasterizationOrder::RowMajor) ? "row-major"
+                                                           : "column-major")
+       << "\n"
+       << "Grid swizzle factor: " << grid_swizzle_factor << "\n"
        << "====================================\n";
     return ss.str();
   }


### PR DESCRIPTION
after fix:

```
===== Matmul Parameters ========

MMA macro: Ampere_16_16_16
DoubleBufferOptions:
  double_buffer_smem_write: true
  double_buffer_smem_read: true
  smem_double_buffer_stage: 3
MatMulTileOptions: instruction tile [16, 16, 16], warp tile [64, 64, 32], CTA tile [128, 128, 32]
Rotate ldmatrix out of main loop: true
Async global mem load: true
Indexing mode: int32_t
Tile rastrization order: row-major
Grid swizzle factor: 1
====================================
```