### PR TITLE
remove unused `hash_scalars_`

### DIFF
--- a/csrc/kernel_cache.h
+++ b/csrc/kernel_cache.h
@@ -342,12 +342,6 @@ class TORCH_CUDA_CU_API InputsIdLookup : public NonCopyable {
   //! `EncodingEntry`
   //! ). We store an iterator to `used_entry_` to implement LRU
   std::unordered_map<std::string, EncodingEntry> encoding_lookup_;
-
-  //! If true, input scalars will also affect the cache. For static Fusions this
-  //! is not desirable. However, for dynamic Fusions, the concretization of
-  //! dynamic reshapes may depend on input scalars, so we must take this into
-  //! account in order to avoid short-circuiting cache lookups in those cases.
-  [[maybe_unused]] bool hash_scalars_ = false;
 };
 
 //! [ Note -- 2 level cache implementation ]

--- a/csrc/kernel_cache.h
+++ b/csrc/kernel_cache.h
@@ -347,7 +347,7 @@ class TORCH_CUDA_CU_API InputsIdLookup : public NonCopyable {
   //! is not desirable. However, for dynamic Fusions, the concretization of
   //! dynamic reshapes may depend on input scalars, so we must take this into
   //! account in order to avoid short-circuiting cache lookups in those cases.
-  bool hash_scalars_ = false;
+  [[maybe_unused]] bool hash_scalars_ = false;
 };
 
 //! [ Note -- 2 level cache implementation ]


### PR DESCRIPTION
In my dirty local environment with clang-14, I needed this attribute.

```
[4/103] Building CXX object CMakeFiles/nvfuser_codegen.dir/csrc/kernel_cache.cpp.o
FAILED: CMakeFiles/nvfuser_codegen.dir/csrc/kernel_cache.cpp.o
/usr/bin/c++ -DTORCH_CUDA_BUILD_MAIN_LIB -DUSE_C10D_GLOO -DUSE_C10D_NCCL -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dnvfuser_codegen_EXPORTS -I/home/mkozuki/ghq/github.com/NVIDIA/fuser/cmake/../third_party/benchmark/include -I/home/mkozuki/ghq/github.com/NVIDIA/fuser/third_party/gloo -I/home/mkozuki/ghq/github.com/NVIDIA/fuser/csrc -I/home/mkozuki/ghq/github.com/NVIDIA/fuser/build/include -I/home/mkozuki/ghq/github.com/NVIDIA/fuser/../third_party/flatbuffers/include -isystem /home/mkozuki/ghq/github.com/NVIDIA/fuser/cmake/../third_party/googletest/googlemock/include -isystem /home/mkozuki/ghq/github.com/NVIDIA/fuser/cmake/../third_party/googletest/googletest/include -isystem /home/mkozuki/ghq/github.com/NVIDIA/fuser/cmake/../third_party/flatbuffers/include -isystem /usr/local/cuda-12.0/include -isystem /home/mkozuki/ghq/github.com/crcrpar/torch-3/torch/include -isystem /home/mkozuki/ghq/github.com/crcrpar/torch-3/torch/include/torch/csrc/api/include -D_GLIBCXX_USE_CXX11_ABI=1 -O3 -DNDEBUG -std=gnu++17 -fPIC -Wall -Wno-unused-function -DTORCH_CUDA_BUILD_MAIN_LIB -Werror -D_GLIBCXX_USE_CXX11_ABI=1 -MD -MT CMakeFiles/nvfuser_codegen.dir/csrc/kernel_cache.cpp.o -MF CMakeFiles/nvfuser_codegen.dir/csrc/kernel_cache.cpp.o.d -o CMakeFiles/nvfuser_codegen.dir/csrc/kernel_cache.cpp.o -c /home/mkozuki/ghq/github.com/NVIDIA/fuser/csrc/kernel_cache.cpp
In file included from /home/mkozuki/ghq/github.com/NVIDIA/fuser/csrc/kernel_cache.cpp:8:
/home/mkozuki/ghq/github.com/NVIDIA/fuser/csrc/kernel_cache.h:350:8: error: private field 'hash_scalars_' is not used [-Werror,-Wunused-private-field]
  bool hash_scalars_ = false;
       ^
1 error generated.
```