### PR TITLE
Don't allow parallelization propagation goes from outer reduction to …

### DIFF
--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -1797,8 +1797,8 @@ void schedulePersistentKernelInnerOuter(
   // Don't allow parallelization propagation goes through cached_gmem, see issue
   // 246.
   for (long unsigned int i = 0; i < outer_reference_tvs.size(); i++) {
-    const auto& selected_tvs_outer =
-        scheduler_utils::getAllTvsFrom(outer_reduction_tvs[i], {cached_gmem[i]});
+    const auto& selected_tvs_outer = scheduler_utils::getAllTvsFrom(
+        outer_reduction_tvs[i], {cached_gmem[i]});
     reduction_scheduler_utils::propagateTransformation(
         outer_reference_tvs[i], boundaryNodesSet);
     reduction_scheduler_utils::propagateParallelization(

--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -1798,7 +1798,7 @@ void schedulePersistentKernelInnerOuter(
   // 246.
   for (long unsigned int i = 0; i < outer_reference_tvs.size(); i++) {
     const auto& selected_tvs_outer =
-        scheduler_utils::getAllTvsFrom(outer_reduction_tvs, {cached_gmem[i]});
+        scheduler_utils::getAllTvsFrom(outer_reduction_tvs[i], {cached_gmem[i]});
     reduction_scheduler_utils::propagateTransformation(
         outer_reference_tvs[i], boundaryNodesSet);
     reduction_scheduler_utils::propagateParallelization(

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -445,12 +445,11 @@ void propagateParallelization(
     const std::vector<TensorView*>& reduction_tvs,
     const std::vector<TensorView*>& cached_inputs,
     const std::vector<std::pair<TensorView*, TensorView*>>& cached_outputs,
-    const std::unordered_set<TensorView*>& unselected_tvs) {
+    const std::vector<TensorView*>& selected_tvs) {
   // Propagate parallelization except vectorization and unrolling
-  auto selected_tvs =
-      ir_utils::allTvsExcept(reference_tv->fusion(), unselected_tvs);
   scheduler_utils::parallelizeAllLike(
       reference_tv,
+      -1,
       selected_tvs,
       allParallelTypesExcept(
           {ParallelType::Unroll,

--- a/csrc/scheduler/reduction_utils.h
+++ b/csrc/scheduler/reduction_utils.h
@@ -68,7 +68,7 @@ TORCH_CUDA_CU_API void propagateParallelization(
     const std::vector<TensorView*>& reduction_tvs,
     const std::vector<TensorView*>& cached_inputs,
     const std::vector<std::pair<TensorView*, TensorView*>>& cached_outputs,
-    const std::unordered_set<TensorView*>& unselected_tvs = {});
+    const std::vector<TensorView*>& selected_tvs = {});
 
 // Sort and rfactor the reference tv in a consistent way for reduction inliner.
 // Order of the sort is:

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -581,5 +581,11 @@ TORCH_CUDA_CU_API void promoteProducerMemoryTypesOfResizedTensors(
     Fusion* fusion,
     const std::vector<TensorView*>& input_caches);
 
+//! Get all tensors that are connected to from_tvs without going through
+//! any tvs in the cutoff_tv_set.
+TORCH_CUDA_CU_API std::unordered_set<TensorView*> getAllTvsFrom(
+    const std::vector<TensorView*>& from_tvs,
+    const std::unordered_set<TensorView*>& cutoff_tv_set);
+
 } // namespace scheduler_utils
 } // namespace nvfuser


### PR DESCRIPTION
#246 
I modified the interface of propagateParallelization to avoid propagate from outer reduction to inner reduction. @naoyam actually asked this question during the code review but at that time I didn't think a case like this should happen as the inner reduciton and outer reduction are parallelized differently. However, #246 shows it may happen.