### PR TITLE
not exporting `libnvfuser.so`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,7 @@ if(BUILD_PYTHON)
     target_link_libraries(${NVFUSER} PRIVATE "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so")
     target_link_libraries(${NVFUSER} PRIVATE pybind11::pybind11)
     set_target_properties(${NVFUSER} PROPERTIES INSTALL_RPATH "$ORIGIN/../torch/lib")
-    install(TARGETS ${NVFUSER} EXPORT NvfuserTargets DESTINATION lib)
+    install(TARGETS ${NVFUSER} DESTINATION lib)
   else() # PROJECT_IS_TOP_LEVEL
     torch_compile_options(${NVFUSER})
 


### PR DESCRIPTION
Optimistically remove `EXPORT` from `install` command.

rel: https://github.com/NVIDIA/Fuser/issues/153#issuecomment-1533519956

### Main branch's CMake config
- https://gist.github.com/crcrpar/485582e25e551ac36f24a2170a690723

```cmake
foreach(_cmake_expected_target IN ITEMS nvfuser_codegen nvfuser)
  list(APPEND _cmake_expected_targets "${_cmake_expected_target}")
  if(TARGET "${_cmake_expected_target}")
    list(APPEND _cmake_targets_defined "${_cmake_expected_target}")
  else()
    list(APPEND _cmake_targets_not_defined "${_cmake_expected_target}")
  endif()
endforeach()
```

### This branch's CMake config
- https://gist.github.com/crcrpar/3c020c7a5a88d6972f3ad32261984cc7

```cmake
foreach(_cmake_expected_target IN ITEMS nvfuser_codegen)
  list(APPEND _cmake_expected_targets "${_cmake_expected_target}")
  if(TARGET "${_cmake_expected_target}")
    list(APPEND _cmake_targets_defined "${_cmake_expected_target}")
  else()
    list(APPEND _cmake_targets_not_defined "${_cmake_expected_target}")
  endif()
endforeach()
```