### PR TITLE
Run flatc only when fusion_cache.fbs is modified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,10 +218,18 @@ if (PROJECT_IS_TOP_LEVEL)
   install(TARGETS ${NVFUSER_CODEGEN} EXPORT NvfuserTargets DESTINATION lib)
 
   # We are keeping fusion_cache_generated.h for the submodule build because flatc is unavailable.
-  add_custom_target(build_flatbuffer_config
-      COMMAND ./third_party/flatbuffers/flatc -o ../csrc/serde/ -c -b ../csrc/serde/fusion_cache.fbs
-      DEPENDS flatc
-      COMMENT "Generating fusion_cache_generated header from fusion_cache.fbs")
+  add_custom_command(
+    OUTPUT
+      ${NVFUSER_ROOT}/csrc/serde/fusion_cache_generated.h
+    DEPENDS
+      ${NVFUSER_ROOT}/csrc/serde/fusion_cache.fbs
+    DEPENDS flatc
+    COMMAND ./third_party/flatbuffers/flatc -o ../csrc/serde/ -c -b ../csrc/serde/fusion_cache.fbs
+    COMMENT "Generating fusion_cache_generated header from fusion_cache.fbs"
+    VERBATIM
+    )
+  add_custom_target(build_flatbuffer_config ALL
+      DEPENDS ${NVFUSER_ROOT}/csrc/serde/fusion_cache_generated.h)
 
   add_dependencies(${NVFUSER_CODEGEN} flatc build_flatbuffer_config)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ if (PROJECT_IS_TOP_LEVEL)
     DEPENDS
       ${NVFUSER_ROOT}/csrc/serde/fusion_cache.fbs
     DEPENDS flatc
-    COMMAND ./third_party/flatbuffers/flatc -o ${NVFUSER_ROOT}/csrc/serde/ -c -b ${NVFUSER_ROOT}/csrc/serde/fusion_cache.fbs
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/third_party/flatbuffers/flatc -o ${NVFUSER_ROOT}/csrc/serde/ -c -b ${NVFUSER_ROOT}/csrc/serde/fusion_cache.fbs
     COMMENT "Generating fusion_cache_generated header from fusion_cache.fbs"
     VERBATIM
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ if (PROJECT_IS_TOP_LEVEL)
     DEPENDS
       ${NVFUSER_ROOT}/csrc/serde/fusion_cache.fbs
     DEPENDS flatc
-    COMMAND ./third_party/flatbuffers/flatc -o ../csrc/serde/ -c -b ../csrc/serde/fusion_cache.fbs
+    COMMAND ./third_party/flatbuffers/flatc -o ${NVFUSER_ROOT}/csrc/serde/ -c -b ${NVFUSER_ROOT}/csrc/serde/fusion_cache.fbs
     COMMENT "Generating fusion_cache_generated header from fusion_cache.fbs"
     VERBATIM
     )


### PR DESCRIPTION
I noticed that cmake is running flatc for every build lately. I think this PR fixes it by explicitly stating that `fusion_cache_generated.h` depends on `fusion_cache.fbs`. I got this pattern from https://samthursfield.wordpress.com/2015/11/21/cmake-dependencies-between-targets-and-files-and-custom-commands/.