### PR TITLE
Enable clang-tidy check in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,63 +10,62 @@ env:
   working_directory: .
 
 jobs:
-  # NOTE: enable clang-tidy when we have it cleaned up.
-  #clang-tidy:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #      with:
-  #        submodules: true
-  #    - uses: actions/setup-python@v4
-  #      with:
-  #        python-version: '3.10'
-  #    - name: Run lintrunner
-  #      working-directory: ${{ env.working_directory }}
-  #      run: |
-  #        this_dir=$(pwd)
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Run lintrunner
+        working-directory: ${{ env.working_directory }}
+        run: |
+          this_dir=$(pwd)
 
-  #        # Install lintrunner
-  #        pip install lintrunner
+          # Install lintrunner
+          pip install lintrunner
 
-  #        # Initialize lintrunner
-  #        lintrunner init 2> /dev/null
+          # Initialize lintrunner
+          lintrunner init 2> /dev/null
 
-  #        # Install cuda
-  #        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
-  #        sudo dpkg -i cuda-keyring_1.0-1_all.deb
-  #        sudo apt-get update
-  #        sudo apt-get -y install cuda
+          # Install cuda
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+          sudo dpkg -i cuda-keyring_1.0-1_all.deb
+          sudo apt-get update
+          sudo apt-get -y install cuda
 
-  #        # cmake environment variables
-  #        export CUDAARCHS=86
-  #        export CUDACXX=/usr/local/cuda/bin/nvcc
-  #        export PATH=/usr/local/cuda/bin:${PATH}
-  #        export CUDA_INSTALL_PATH=/usr/local/cuda
+          # cmake environment variables
+          export CUDAARCHS=86
+          export CUDACXX=/usr/local/cuda/bin/nvcc
+          export PATH=/usr/local/cuda/bin:${PATH}
+          export CUDA_INSTALL_PATH=/usr/local/cuda
 
-  #        # pytorch environment variables
-  #        export TORCH_CUDA_ARCH_LIST="8.6"
-  #        export BUILD_NVFUSER=1
-  #        export USE_MKLDNN=0
-  #        export USE_CUDNN=0
-  #        export USE_DISTRIBUTED=0
-  #        export NVFUSER_SOURCE_DIR=$this_dir
+          # pytorch environment variables
+          export TORCH_CUDA_ARCH_LIST="8.6"
+          export BUILD_NVFUSER=1
+          export USE_MKLDNN=0
+          export USE_CUDNN=0
+          export USE_DISTRIBUTED=0
+          export NVFUSER_SOURCE_DIR=$this_dir
 
-  #        # Clone pytorch and run cmake build
-  #        git clone https://github.com/pytorch/pytorch.git
-  #        cd pytorch
-  #        python3 -m tools.linter.clang_tidy.generate_build_files
-  #        cd $this_dir
+          # Clone pytorch and run cmake build
+          git clone https://github.com/pytorch/pytorch.git
+          cd pytorch
+          python3 -m tools.linter.clang_tidy.generate_build_files
+          cd $this_dir
 
-  #        # Run lintrunner on all csrc files
-  #        # find csrc/ -type f | xargs lintrunner --force-color
+          # Run lintrunner on all csrc files
+          # find csrc/ -type f | xargs lintrunner --force-color
 
-  #        # Run lintrunner on all csrc files
-  #        this_commit=$(git rev-parse HEAD)
-  #        git fetch origin main
-  #        git checkout origin/main
-  #        head_commit=$(git rev-parse HEAD)
-  #        git checkout $this_commit
-  #        git --no-pager diff --name-only $head_commit |  grep -e "\.cpp" -e "\.h" |tail | xargs lintrunner --take CLANGTIDY --force-color
+          # Run lintrunner on all csrc files exclude benchmark and test folders
+          this_commit=$(git rev-parse HEAD)
+          git fetch origin main
+          git checkout origin/main
+          head_commit=$(git rev-parse HEAD)
+          git checkout $this_commit
+          git --no-pager diff --name-only $head_commit | grep -e "csrc/.*\.cpp" -e "csrc/.*\.h" | xargs lintrunner --take CLANGTIDY --force-color
 
   lintrunner:
     runs-on: ubuntu-latest

--- a/csrc/contiguity.cpp
+++ b/csrc/contiguity.cpp
@@ -527,7 +527,7 @@ void ContigIDs::build(const std::vector<IterDomain*>& ids) {
     // rfactor root domains, which should just return "zero"
     // RootAxisInfo. This should be safe as no rfactor tensor should
     // need halo.
-    if (*root_contiguity_.at(root_domain_i) &&
+    if (root_contiguity_.at(root_domain_i).value_or(false) &&
         !halo_info_->getRootAxisInfo(root_domain_id).hasHalo() &&
         root_domain_id->getIterType() != IterType::GatherScatter) {
       contig_ids_.emplace(root_domain_id);
@@ -617,7 +617,7 @@ void ContigIDs::handle(Merge* merge) {
       // If we're computing predicates (ignore_consistent_ordering_==true),
       // then we don't have this same constraint, we can just ignore
       // contiguity of the roots all together.
-      if (!*root_contiguity_.at(root_id_i) && is_indexing_pass) {
+      if (!root_contiguity_.at(root_id_i).value_or(false) && is_indexing_pass) {
         if (!root_ids.empty()) {
           return;
         }

--- a/csrc/contiguity.cpp
+++ b/csrc/contiguity.cpp
@@ -527,7 +527,9 @@ void ContigIDs::build(const std::vector<IterDomain*>& ids) {
     // rfactor root domains, which should just return "zero"
     // RootAxisInfo. This should be safe as no rfactor tensor should
     // need halo.
-    if (root_contiguity_.at(root_domain_i).value_or(false) &&
+    auto root_contiguity_opt = root_contiguity_.at(root_domain_i);
+    TORCH_INTERNAL_ASSERT(root_contiguity_opt.has_value());
+    if (root_contiguity_opt.value() &&
         !halo_info_->getRootAxisInfo(root_domain_id).hasHalo() &&
         root_domain_id->getIterType() != IterType::GatherScatter) {
       contig_ids_.emplace(root_domain_id);
@@ -617,7 +619,9 @@ void ContigIDs::handle(Merge* merge) {
       // If we're computing predicates (ignore_consistent_ordering_==true),
       // then we don't have this same constraint, we can just ignore
       // contiguity of the roots all together.
-      if (!root_contiguity_.at(root_id_i).value_or(false) && is_indexing_pass) {
+      auto root_contiguity_opt = root_contiguity_.at(root_id_i);
+      TORCH_INTERNAL_ASSERT(root_contiguity_opt.has_value());
+      if (!root_contiguity_opt.value() && is_indexing_pass) {
         if (!root_ids.empty()) {
           return;
         }

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1421,7 +1421,7 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
       strides[dim] = cur_contig_stride->fusion()->zeroVal();
       TORCH_INTERNAL_ASSERT(
           !producer_tv->domain()->contiguity().at(dim).has_value());
-    } else if (*producer_tv->domain()->contiguity().at(dim)) {
+    } else if (producer_tv->domain()->contiguity().at(dim).value_or(false)) {
       // If contig, used the stored stride which may be the previous
       // dimensions stride * previous dimensions size
       strides[dim] = cur_contig_stride;
@@ -1771,7 +1771,7 @@ std::vector<Val*> Index::getStrides(const TensorView* tv) {
     if (root_dom[dim]->isBroadcast()) {
       strides[dim] = cur_contig_stride->fusion()->zeroVal();
       TORCH_INTERNAL_ASSERT(!tv->domain()->contiguity().at(dim).has_value());
-    } else if (*tv->domain()->contiguity().at(dim)) {
+    } else if (tv->domain()->contiguity().at(dim).value_or(false)) {
       // If contig, used the stored stride which may be the previous
       // dimensions stride * previous dimensions size
       strides[dim] = cur_contig_stride;

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1417,11 +1417,13 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
       continue;
     }
 
+    auto producer_dim_contiguity = producer_tv->domain()->contiguity().at(dim);
     if (root_dom[dim]->isBroadcast()) {
       strides[dim] = cur_contig_stride->fusion()->zeroVal();
-      TORCH_INTERNAL_ASSERT(
-          !producer_tv->domain()->contiguity().at(dim).has_value());
-    } else if (producer_tv->domain()->contiguity().at(dim).value_or(false)) {
+      TORCH_INTERNAL_ASSERT(!producer_dim_contiguity.has_value());
+    } else if (!producer_dim_contiguity.has_value()) {
+      TORCH_INTERNAL_ASSERT(false, "Expected value for dimension contiguity");
+    } else if (producer_dim_contiguity.value()) {
       // If contig, used the stored stride which may be the previous
       // dimensions stride * previous dimensions size
       strides[dim] = cur_contig_stride;
@@ -1768,10 +1770,13 @@ std::vector<Val*> Index::getStrides(const TensorView* tv) {
       continue;
     }
 
+    auto dim_contiguity = tv->domain()->contiguity().at(dim);
     if (root_dom[dim]->isBroadcast()) {
       strides[dim] = cur_contig_stride->fusion()->zeroVal();
-      TORCH_INTERNAL_ASSERT(!tv->domain()->contiguity().at(dim).has_value());
-    } else if (tv->domain()->contiguity().at(dim).value_or(false)) {
+      TORCH_INTERNAL_ASSERT(!dim_contiguity.has_value());
+    } else if (!dim_contiguity.has_value()) {
+      TORCH_INTERNAL_ASSERT(false, "Expected value for dimension contiguity");
+    } else if (dim_contiguity.value()) {
       // If contig, used the stored stride which may be the previous
       // dimensions stride * previous dimensions size
       strides[dim] = cur_contig_stride;

--- a/csrc/ir_internal_nodes.h
+++ b/csrc/ir_internal_nodes.h
@@ -1054,7 +1054,7 @@ class TORCH_CUDA_CU_API MmaOp : public Expr {
     }
   };
 
-  using AxesData = std::vector<int>;
+  using AxesData = std::vector<int64_t>;
   using MmaLayoutOpt = std::optional<MmaOptions::MmaLayout>;
   using Expr::Expr;
 

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -1391,7 +1391,7 @@ struct TensorViewDetails {
 // A helper for gathering details about TensorView object
 TensorViewDetails getDetailsFor(const std::vector<IterDomain*>& dims) {
   TensorViewDetails details;
-  for (size_t pos = 0; pos < dims.size(); ++pos) {
+  for (auto pos : c10::irange((int64_t)dims.size())) {
     const auto axis = dims.at(pos);
     if (axis->isReduction()) {
       details.rdomains.push_back(pos);

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -822,7 +822,7 @@ class ArgumentManager {
   void updateWithSegmentOutputs(
       const std::vector<Val*>& group_outputs,
       const T& group_runtime_outputs,
-      const int group_id) {
+      const int64_t group_id) {
     addOutputsToArgsAndTensorMap(group_outputs, group_runtime_outputs);
     deleteUnusedArgs(group_id);
   }
@@ -832,7 +832,7 @@ class ArgumentManager {
   // map from val to args
   std::unordered_map<Val*, const ArgAbstract*> tensor_map_;
   // map segment_id to vector of fusion vals lastly used at this segment
-  std::unordered_map<int, std::vector<Val*>> vals_last_used_at_segment_;
+  std::unordered_map<int64_t, std::vector<Val*>> vals_last_used_at_segment_;
 
   void mapFusionInputsToArgs(
       const std::vector<Val*>& fusion_inputs,
@@ -868,14 +868,14 @@ class ArgumentManager {
       return val->isFusionInput() || val->isFusionOutput();
     };
     // map val to segment_id where arg is lastly used
-    std::unordered_map<Val*, int> last_used_segment_map;
-    const int n_groups = group_run_order.size();
+    std::unordered_map<Val*, int64_t> last_used_segment_map;
+    const int64_t num_groups = (int64_t)group_run_order.size();
     // only need to set lifetime of vals if there are more than 3 groups
-    if (n_groups >= 3) {
+    if (num_groups >= 3) {
       // start from the 2nd group, since the input of the first group is always
       // the global input and its outputs are always used by at least one of the
       // following groups
-      for (int group_id = 1; group_id < n_groups; ++group_id) {
+      for (auto group_id : c10::irange(1l, num_groups)) {
         auto group_to_run = group_run_order.at(group_id);
         // set/update life of vals in inputs of this group
         for (auto val : group_to_run->inputs()) {
@@ -887,7 +887,7 @@ class ArgumentManager {
         }
         // set/update life of vals in outputs of this group
         // skip the last group since its outputs are always the global outputs
-        if (group_id < n_groups - 1) {
+        if (group_id < num_groups - 1) {
           for (auto val : group_to_run->outputs()) {
             // skip fusion inputs and outputs, they may be used by other fusions
             // or code
@@ -904,7 +904,7 @@ class ArgumentManager {
       }
     }
   }
-  void deleteUnusedArgs(int group_id) {
+  void deleteUnusedArgs(int64_t group_id) {
     // erase args corresponding to vals lastly used in this segment
     if (group_id >= 1 && vals_last_used_at_segment_.count(group_id)) {
       for (auto val : vals_last_used_at_segment_[group_id]) {
@@ -950,9 +950,9 @@ std::unordered_map<Val*, const ArgAbstract*> FusionKernelRuntime::
 
   // group should share cache id.
   auto group_cache_id = args.getCacheId();
-  const int n_groups = runtime_workspace_.group_run_order.size();
-  num_live_args_after_segment_runs_.reserve(n_groups);
-  for (int group_id = 0; group_id < n_groups; ++group_id) {
+  const int64_t num_groups = (int64_t)runtime_workspace_.group_run_order.size();
+  num_live_args_after_segment_runs_.reserve(num_groups);
+  for (auto group_id : c10::irange(num_groups)) {
     // TODO: index mode should be updated per segmented kernel
     // Prepare input vector
     auto group_to_run = runtime_workspace_.group_run_order.at(group_id);
@@ -980,7 +980,7 @@ std::unordered_map<Val*, const ArgAbstract*> FusionKernelRuntime::
       args_manager.updateWithSegmentOutputs(
           group_to_run->outputs(), group_runtime_outputs, group_id);
     }
-    num_live_args_after_segment_runs_.push_back(args.size());
+    num_live_args_after_segment_runs_.push_back((int64_t)args.size());
   }
 
   return args_manager.getTensorMap();

--- a/csrc/kernel_cache.h
+++ b/csrc/kernel_cache.h
@@ -112,7 +112,7 @@ class TORCH_CUDA_CU_API FusionKernelRuntime {
   //! Unified interface to run the managed kernels with given input
   std::vector<at::Tensor> runWithInputs(KernelArgumentHolder& args);
 
-  const std::vector<int>& getArgsNumAfterSegmentRuns() {
+  const std::vector<int64_t>& getArgsNumAfterSegmentRuns() {
     return num_live_args_after_segment_runs_;
   }
 
@@ -254,7 +254,7 @@ class TORCH_CUDA_CU_API FusionKernelRuntime {
   //! store number of arguments in KernelArgumentHolder after each segment
   //! used to check if arguments are erased if not being used in the following
   //! segments
-  std::vector<int> num_live_args_after_segment_runs_;
+  std::vector<int64_t> num_live_args_after_segment_runs_;
 
   // States for profiling support
   bool profiling_ = false;

--- a/csrc/lower_misaligned_vectorization.cpp
+++ b/csrc/lower_misaligned_vectorization.cpp
@@ -539,7 +539,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
 
       // If it's not contiguous, extending the vectorization domain
       // further is not possible
-      if (!(producer_contig.at(i).value_or(false) &&
+      if (!(*producer_contig.at(i) &&
             consumer_contig.at(consumer_root_idx).value_or(false))) {
         break;
       }

--- a/csrc/lower_misaligned_vectorization.cpp
+++ b/csrc/lower_misaligned_vectorization.cpp
@@ -539,8 +539,14 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
 
       // If it's not contiguous, extending the vectorization domain
       // further is not possible
-      if (!(producer_contig.at(i).value_or(false) &&
-            consumer_contig.at(consumer_root_idx).value_or(false))) {
+      auto producer_dim_contiguity = producer_contig.at(i);
+      TORCH_INTERNAL_ASSERT(producer_dim_contiguity.has_value());
+
+      auto consumer_dim_contiguity = consumer_contig.at(consumer_root_idx);
+      TORCH_INTERNAL_ASSERT(consumer_dim_contiguity.has_value());
+
+      if (!(producer_dim_contiguity.value() &&
+            consumer_dim_contiguity.value())) {
         break;
       }
 

--- a/csrc/lower_misaligned_vectorization.cpp
+++ b/csrc/lower_misaligned_vectorization.cpp
@@ -539,7 +539,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
 
       // If it's not contiguous, extending the vectorization domain
       // further is not possible
-      if (!(*producer_contig.at(i) &&
+      if (!(producer_contig.at(i).value_or(false) &&
             consumer_contig.at(consumer_root_idx).value_or(false))) {
         break;
       }

--- a/csrc/lower_misaligned_vectorization.cpp
+++ b/csrc/lower_misaligned_vectorization.cpp
@@ -539,7 +539,8 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
 
       // If it's not contiguous, extending the vectorization domain
       // further is not possible
-      if (!(*producer_contig.at(i) && *consumer_contig.at(consumer_root_idx))) {
+      if (!(producer_contig.at(i).value_or(false) &&
+            consumer_contig.at(consumer_root_idx).value_or(false))) {
         break;
       }
 

--- a/csrc/lower_validation.cpp
+++ b/csrc/lower_validation.cpp
@@ -210,7 +210,7 @@ void checkContiguity(
           "Issue found in, ",
           tv);
       TORCH_INTERNAL_ASSERT(
-          *tv->domain()->contiguity().at(idx),
+          tv->domain()->contiguity().at(idx).value_or(false),
           "Cannot merge non-contiguous root domains with misaligned vectorization.",
           "Issue found in, ",
           tv);
@@ -258,7 +258,7 @@ void checkContiguity(
       TORCH_INTERNAL_ASSERT(root_c2p.find(consumer_root) != root_c2p.end());
 
       TORCH_INTERNAL_ASSERT(
-          *producer_domain_contiguity.at(producer_root),
+          producer_domain_contiguity.at(producer_root).value_or(false),
           "Cannot merge non-contiguous root domains with misaligned vectorization.",
           "Issue found in, ",
           consumer);
@@ -450,7 +450,7 @@ class VectorizeValidator : public OptInDispatch {
       // "vectorized" read from discontiguous memory
       TORCH_CHECK(
           last_root_dim == validator.vectorized_id_ &&
-              *tv->domain()->contiguity().at(last_root_dim_pos),
+              tv->domain()->contiguity().at(last_root_dim_pos).value_or(false),
           "Vectorized dim has to be from a contiguous inner most position: ",
           tv,
           "\n");


### PR DESCRIPTION
- Checks only `csrc` folder
- Excludes `benchmark` and `test` folders
- Only modified files between given branch and the `main` branch are checked.
- The clang-tidy CI runtime is proportional to the number of modified files. About 20 minutes on average. 1 hour for all files in `csrc`.