### PR TITLE
Better validate producer vectorization

### DIFF
--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -566,7 +566,7 @@ void validateAlignedVectorizeExtents(
     const VectorizedSetInfo& info,
     ExpressionEvaluator& expr_eval) {
   TORCH_INTERNAL_ASSERT(
-      !info.contig_root_ids.empty(),
+      !info.contig_alloc_ids.empty(),
       "No root ID found for vectorization with ",
       info.consumer_tv->toString(),
       " and ",
@@ -574,7 +574,7 @@ void validateAlignedVectorizeExtents(
 
   // TODO: Rewrite validation of the vectorized dimension
   // int64_t vectorized_merged_domain_extent = 1;
-  for (auto id : info.contig_root_ids) {
+  for (auto id : info.contig_alloc_ids) {
     auto extent_val = expr_eval.evaluate(id->extent());
     TORCH_INTERNAL_ASSERT(
         extent_val.has_value(),

--- a/csrc/lower_index_compute.cpp
+++ b/csrc/lower_index_compute.cpp
@@ -926,10 +926,10 @@ IndexFromIdGraph getTensorIndexFromIdGraph(
   // Fill validation info.
   // TODO: cleanup seems possible.
   if (index_producer) {
-    fillProducerVectorizedContigRootDomains(
+    fillProducerVectorizedContigAllocationDomains(
         producer_tv, consumer_tv, c2p_map, contig_finder);
   } else {
-    fillConsumerVectorizedContigRootDomains(consumer_tv, contig_finder);
+    fillConsumerVectorizedContigAllocationDomains(consumer_tv, contig_finder);
   }
 
   return IndexFromIdGraph(

--- a/csrc/lower_index_compute.cpp
+++ b/csrc/lower_index_compute.cpp
@@ -927,7 +927,7 @@ IndexFromIdGraph getTensorIndexFromIdGraph(
   // TODO: cleanup seems possible.
   if (index_producer) {
     fillProducerVectorizedContigAllocationDomains(
-        producer_tv, consumer_tv, c2p_map, contig_finder);
+        producer_tv, consumer_tv, contig_finder);
   } else {
     fillConsumerVectorizedContigAllocationDomains(consumer_tv, contig_finder);
   }

--- a/csrc/lower_validation.cpp
+++ b/csrc/lower_validation.cpp
@@ -194,34 +194,34 @@ void validateIr(Fusion* fusion) {
 
 namespace {
 
-// Check contiguity for all root domains associated with Misaligned Vectorize
-// ParallelType
+// Check contiguity for all allocation domains associated with Misaligned
+// Vectorize ParallelType
 void checkContiguity(
     const std::unordered_set<IterDomain*>& domains,
     TensorView* tv) {
   TORCH_INTERNAL_ASSERT(tv->getMemoryType() == MemoryType::Global);
 
-  for (const auto idx : c10::irange(tv->getRootDomain().size())) {
-    auto root = tv->getRootDomain()[idx];
-    if (domains.find(root) != domains.end()) {
+  for (const auto idx : c10::irange(tv->getMaybeAllocationDomain().size())) {
+    auto alloc = tv->getMaybeAllocationDomain()[idx];
+    if (domains.find(alloc) != domains.end()) {
       TORCH_INTERNAL_ASSERT(
-          !root->isBroadcast(),
+          !alloc->isBroadcast(),
           "Misaligned vectorization prohibits merging broadcast domains.",
           "Issue found in, ",
           tv);
       TORCH_INTERNAL_ASSERT(
           tv->domain()->contiguity().at(idx).value_or(false),
-          "Cannot merge non-contiguous root domains with misaligned vectorization.",
+          "Cannot merge non-contiguous allocation domains with misaligned vectorization.",
           "Issue found in, ",
           tv);
     }
   }
 }
 
-// Check all root iter domains in consumer that are present in domain, making
-// sure they're contiguous. Map these domains to producer and make sure they are
-// also contiguous in producer. Producer-consumer relationship is assumed to be
-// through a set operation.
+// Check all allocation iter domains in consumer that are present in domain,
+// making sure they're contiguous. Map these domains to producer and make sure
+// they are also contiguous in producer. Producer-consumer relationship is
+// assumed to be through a set operation.
 void checkContiguity(
     const std::unordered_set<IterDomain*>& domains,
     TensorView* consumer,
@@ -230,36 +230,42 @@ void checkContiguity(
   TORCH_INTERNAL_ASSERT(consumer->getMemoryType() == MemoryType::Local);
   TORCH_INTERNAL_ASSERT(producer->getMemoryType() == MemoryType::Global);
 
-  auto root_c2p =
+  // TODO: we should use BestEffortReplay to find the correct c2p map for
+  // allocation domain when it is different from rFactor domain.
+  TORCH_INTERNAL_ASSERT(
+      !consumer->hasAllocation() && !producer->hasAllocation(),
+      "Misaligned vectorization for allocation domain is not supported.");
+  auto alloc_c2p =
       PairwiseRootDomainMap(producer, consumer)
           .mapConsumerToProducer(consumer->domain(), producer->domain());
 
   std::unordered_map<IterDomain*, std::optional<bool>>
       producer_domain_contiguity;
-  for (const auto idx : c10::irange(producer->getMaybeRFactorDomain().size())) {
-    auto root = producer->getMaybeRFactorDomain().at(idx);
+  for (const auto idx :
+       c10::irange(producer->getMaybeAllocationDomain().size())) {
+    auto alloc = producer->getMaybeAllocationDomain().at(idx);
     auto contiguity = producer->domain()->contiguity().at(idx);
-    producer_domain_contiguity.insert({root, contiguity});
+    producer_domain_contiguity.insert({alloc, contiguity});
   }
 
-  for (auto consumer_root : consumer->getMaybeRFactorDomain()) {
-    if (domains.find(consumer_root) != domains.end()) {
-      auto producer_root = root_c2p.at(consumer_root);
+  for (auto consumer_alloc : consumer->getMaybeAllocationDomain()) {
+    if (domains.find(consumer_alloc) != domains.end()) {
+      auto producer_alloc = alloc_c2p.at(consumer_alloc);
       TORCH_INTERNAL_ASSERT(
-          producer_domain_contiguity.find(producer_root) !=
+          producer_domain_contiguity.find(producer_alloc) !=
           producer_domain_contiguity.end());
 
       TORCH_INTERNAL_ASSERT(
-          !consumer_root->isBroadcast() || !producer_root->isBroadcast(),
+          !consumer_alloc->isBroadcast() || !producer_alloc->isBroadcast(),
           "Misaligned vectorization prohibits merging broadcast domains.",
           "Issue found in, ",
           consumer);
 
-      TORCH_INTERNAL_ASSERT(root_c2p.find(consumer_root) != root_c2p.end());
+      TORCH_INTERNAL_ASSERT(alloc_c2p.find(consumer_alloc) != alloc_c2p.end());
 
       TORCH_INTERNAL_ASSERT(
-          producer_domain_contiguity.at(producer_root).value_or(false),
-          "Cannot merge non-contiguous root domains with misaligned vectorization.",
+          producer_domain_contiguity.at(producer_alloc).value_or(false),
+          "Cannot merge non-contiguous allocation domains with misaligned vectorization.",
           "Issue found in, ",
           consumer);
     }
@@ -270,7 +276,7 @@ class VectorizeValidator : public OptInDispatch {
  private:
   // Initially, vectorized_id is the IterDomain with Vectorize ParallelType
   // After processing all merge and split operations,
-  // vectorized_id is the corresponding root domain
+  // vectorized_id is the corresponding allocation domain
   VectorizeValidator(IterDomain* vectorized_id)
       : vectorized_id_(vectorized_id) {}
 
@@ -387,7 +393,7 @@ class VectorizeValidator : public OptInDispatch {
           contiguity);
     }
     return validator.vectorized_id_;
-  };
+  }
 
  private:
   std::unordered_set<IterDomain*> domains_;
@@ -474,7 +480,7 @@ class VectorizeValidator : public OptInDispatch {
     // specific vectorized set.
     vectorized_set_info.word_size = (int)vector_word_size;
     vectorized_set_info.vectorized_leaf_id = v_id;
-    vectorized_set_info.vectorized_root_id = consumer_vectorized_id;
+    vectorized_set_info.vectorized_consumer_alloc_id = consumer_vectorized_id;
 
     // Validate producer
     auto pairwise_map = PairwiseRootDomainMap(producer_tv, tv);
@@ -488,24 +494,25 @@ class VectorizeValidator : public OptInDispatch {
         BestEffortReplay::replayPasC(producer_tv, tv, -1, pairwise_map)
             .getReplay();
     if (auto c2p_it = c2p_map.find(v_id); c2p_it != c2p_map.end()) {
-      vectorized_set_info.vectorized_producer_root_id =
+      vectorized_set_info.vectorized_producer_alloc_id =
           getVectorizedIdInAllocationDomain(
               c2p_it->second, producer_tv, "producer");
     }
 
     // For aligned vectorize, the extent of a vectorized domain must
     // be divisible by the vector word size. The domain is usually
-    // just one of the root domains, but can be a merged domain of
+    // just one of the allocation domains, but can be a merged domain of
     // contiguous domains. Those domains are saved in
-    // VectorizedSetInfo.contig_root_ids in
-    // fillConsumerVectorizedContigRootDomains called in lower_index_compute.
+    // VectorizedSetInfo.contig_alloc_ids in
+    // fillConsumerVectorizedContigAllocationDomains called in
+    // lower_index_compute.
     GpuLower::current()->vectorizedSetInfo().emplace_back(vectorized_set_info);
   }
 };
 
 } // namespace
 
-// Uses ContigIDs to find root contig domains that a vectorized domain
+// Uses ContigIDs to find allocation contig domains that a vectorized domain
 // depends on. As ContigIDs depends on HaloInfo, this must be done
 // after HaloInfo is created.
 void validateAndCollectVectorizeInfo(Fusion* fusion) {
@@ -580,32 +587,32 @@ void validateAndCollectVectorizeInfo(Fusion* fusion) {
 
 namespace {
 
-void fillVectorizedContigRootDomains(
+void fillVectorizedContigAllocationDomains(
     const TensorView* tv,
     const ContigIDs& contig_finder,
-    IterDomain* vectorized_root_id,
+    IterDomain* vectorized_alloc_id,
     VectorizedSetInfo& info) {
-  const auto& root_dom = tv->getMaybeRFactorDomain();
+  const auto& alloc_dom = tv->getMaybeAllocationDomain();
 
-  // Find the root domains that are dependency of the merged contig
+  // Find the allocation domains that are dependency of the merged contig
   // domain.
 
   auto consumer_indexed_it =
-      contig_finder.allocToIndexedID().find(vectorized_root_id);
+      contig_finder.allocToIndexedID().find(vectorized_alloc_id);
   TORCH_INTERNAL_ASSERT(
       consumer_indexed_it != contig_finder.allocToIndexedID().end(),
-      "Contiguity information not found for root domain: ",
-      vectorized_root_id->toString());
+      "Contiguity information not found for allocation domain: ",
+      vectorized_alloc_id->toString());
   auto consumer_indexed_id = consumer_indexed_it->second;
 
-  // Actual indexed root domains for this root domain. If
-  // contig merge is done, multiple root domains are included.
-  std::unordered_set<IterDomain*> indexed_root_ids;
+  // Actual indexed allocation domains for this allocation domain. If
+  // contig merge is done, multiple allocation domains are included.
+  std::unordered_set<IterDomain*> indexed_alloc_ids;
 
-  if (consumer_indexed_id == vectorized_root_id) {
-    // Indexed domain is equal to the root domain, meaning no contig
+  if (consumer_indexed_id == vectorized_alloc_id) {
+    // Indexed domain is equal to the allocation domain, meaning no contig
     // merge is involved.
-    indexed_root_ids.insert(vectorized_root_id);
+    indexed_alloc_ids.insert(vectorized_alloc_id);
   } else {
     auto consumer_within_contig_it =
         contig_finder.withinContigIDs().find(consumer_indexed_id);
@@ -613,26 +620,26 @@ void fillVectorizedContigRootDomains(
         consumer_within_contig_it != contig_finder.withinContigIDs().end());
     const auto& within_ids = consumer_within_contig_it->second;
     std::copy_if(
-        root_dom.begin(),
-        root_dom.end(),
-        std::inserter(indexed_root_ids, indexed_root_ids.end()),
-        [&](IterDomain* root_id) {
-          return within_ids.find(root_id) != within_ids.end();
+        alloc_dom.begin(),
+        alloc_dom.end(),
+        std::inserter(indexed_alloc_ids, indexed_alloc_ids.end()),
+        [&](IterDomain* alloc_id) {
+          return within_ids.find(alloc_id) != within_ids.end();
         });
   }
 
-  // Store the contig merged root domains. If it is already set, pick
+  // Store the contig merged allocation domains. If it is already set, pick
   // the smaller one as it is used for validating divisibility of the
   // merged extent.
-  if (info.contig_root_ids.empty() ||
-      indexed_root_ids.size() < info.contig_root_ids.size()) {
-    info.contig_root_ids = indexed_root_ids;
+  if (info.contig_alloc_ids.empty() ||
+      indexed_alloc_ids.size() < info.contig_alloc_ids.size()) {
+    info.contig_alloc_ids = indexed_alloc_ids;
   }
 }
 
 } // namespace
 
-void fillConsumerVectorizedContigRootDomains(
+void fillConsumerVectorizedContigAllocationDomains(
     const TensorView* consumer_tv,
     const ContigIDs& contig_finder) {
   auto& info_vector = GpuLower::current()->vectorizedSetInfo();
@@ -646,15 +653,15 @@ void fillConsumerVectorizedContigRootDomains(
 
   VectorizedSetInfo& info = *it;
 
-  // info.vectorized_root_id is validated at this point to be the
-  // last concrete root domain in consumer.
-  auto consumer_root_id = info.vectorized_root_id;
+  // info.vectorized_consumer_alloc_id is validated at this point to be the
+  // last concrete allocation domain in consumer.
+  auto consumer_alloc_id = info.vectorized_consumer_alloc_id;
 
-  fillVectorizedContigRootDomains(
-      consumer_tv, contig_finder, consumer_root_id, info);
+  fillVectorizedContigAllocationDomains(
+      consumer_tv, contig_finder, consumer_alloc_id, info);
 }
 
-void fillProducerVectorizedContigRootDomains(
+void fillProducerVectorizedContigAllocationDomains(
     const TensorView* producer_tv,
     const TensorView* consumer_tv,
     const std::unordered_map<IterDomain*, IterDomain*>& c2p_map,
@@ -673,8 +680,8 @@ void fillProducerVectorizedContigRootDomains(
 
   VectorizedSetInfo& info = *it;
 
-  fillVectorizedContigRootDomains(
-      producer_tv, contig_finder, info.vectorized_producer_root_id, info);
+  fillVectorizedContigAllocationDomains(
+      producer_tv, contig_finder, info.vectorized_producer_alloc_id, info);
 }
 
 namespace {

--- a/csrc/lower_validation.cpp
+++ b/csrc/lower_validation.cpp
@@ -376,9 +376,10 @@ class VectorizeValidator : public OptInDispatch {
     if (!is_ldmatrix_trans) {
       // ldmatrix.trans is a hardware transpose instruction that can do
       // "vectorized" read from discontiguous memory
-      auto contiguity = *tv->domain()->contiguity().at(last_alloc_dim_pos);
+      auto contiguity = tv->domain()->contiguity().at(last_alloc_dim_pos);
       TORCH_CHECK(
-          last_alloc_dim == validator.vectorized_id_ && contiguity,
+          last_alloc_dim == validator.vectorized_id_ &&
+              contiguity.value_or(false),
           "Vectorized dim for ",
           name,
           " has to be from a contiguous inner most position. tv: ",
@@ -390,7 +391,7 @@ class VectorizeValidator : public OptInDispatch {
           ", innermost id: ",
           last_alloc_dim,
           ", contiguity: ",
-          contiguity);
+          contiguity.has_value() ? (*contiguity ? "t" : "f") : "n");
     }
     return validator.vectorized_id_;
   }

--- a/csrc/lower_validation.cpp
+++ b/csrc/lower_validation.cpp
@@ -390,70 +390,88 @@ class VectorizeValidator : public OptInDispatch {
         vector_size,
         " however, vector sizes only upto and including 16 bytes are supported.");
 
-    auto replay_exprs = DependencyCheck::getAllExprsBetween(
-        {tv->getMaybeRFactorDomain().begin(),
-         tv->getMaybeRFactorDomain().end()},
-        {v_id});
+    auto getVectorizedIdInAllocationDomain =
+        [misaligned_vectorize](
+            IterDomain* v_id, TensorView* tv) -> IterDomain* {
+      auto replay_exprs = DependencyCheck::getAllExprsBetween(
+          {tv->getMaybeRFactorDomain().begin(),
+           tv->getMaybeRFactorDomain().end()},
+          {v_id});
 
-    VectorizeValidator validator(v_id);
+      VectorizeValidator validator(v_id);
 
-    for (auto expr_it = replay_exprs.rbegin(); expr_it != replay_exprs.rend();
-         ++expr_it) {
-      auto expr = *expr_it;
-      validator.handle(expr);
-    }
-
-    TORCH_CHECK(
-        validator.is_valid,
-        "Invalid vectorized pattern found, vectorization iter domains must be descendants of inner-most dimension.",
-        "Issue found in, ",
-        tv,
-        "\n");
-
-    if (misaligned_vectorize) {
-      if (tv->getMemoryType() == MemoryType::Global) {
-        checkContiguity(validator.domains_, tv);
-      } else if (tv->definition()->isA<LoadStoreOp>()) {
-        auto input = tv->definition()->input(0);
-        TORCH_INTERNAL_ASSERT(input->isA<TensorView>());
-        auto input_tv = input->as<TensorView>();
-        checkContiguity(validator.domains_, tv, input_tv);
+      for (auto expr_it = replay_exprs.rbegin(); expr_it != replay_exprs.rend();
+           ++expr_it) {
+        auto expr = *expr_it;
+        validator.handle(expr);
       }
-    }
 
-    TORCH_INTERNAL_ASSERT(validator.vectorized_id_ != nullptr);
-
-    // Contiguity is based on rfactor domain.
-    IterDomain* last_root_dim = nullptr;
-    size_t last_root_dim_pos = 0;
-    for (size_t i = tv->getMaybeRFactorDomain().size(); i > 0; i--) {
-      auto r_id = tv->getMaybeRFactorDomain()[i - 1];
-      if (r_id->isReduction() || r_id->isBroadcast()) {
-        continue;
-      }
-      last_root_dim = r_id;
-      last_root_dim_pos = i - 1;
-      break;
-    }
-
-    if (last_root_dim == nullptr) {
-      // Should never get here, but that would mean there are no concrete dims,
-      // so we should be fine.
-      return;
-    }
-
-    auto ldst = dynamic_cast<LoadStoreOp*>(tv->definition());
-    bool is_ldmatrix_trans =
-        ldst != nullptr && ldst->opType() == LoadStoreOpType::LdMatrixTranspose;
-    if (!is_ldmatrix_trans) {
-      // ldmatrix.trans is a hardware transpose instruction that can do
-      // "vectorized" read from discontiguous memory
       TORCH_CHECK(
-          last_root_dim == validator.vectorized_id_ &&
-              *tv->domain()->contiguity().at(last_root_dim_pos),
-          "Vectorized dim has to be from a contiguous inner most position: ",
+          validator.is_valid,
+          "Invalid vectorized pattern found, vectorization iter domains must be descendants of inner-most dimension.",
+          "Issue found in, ",
           tv,
           "\n");
+
+      if (misaligned_vectorize) {
+        if (tv->getMemoryType() == MemoryType::Global) {
+          checkContiguity(validator.domains_, tv);
+        } else if (tv->definition()->isA<LoadStoreOp>()) {
+          auto input = tv->definition()->input(0);
+          TORCH_INTERNAL_ASSERT(input->isA<TensorView>());
+          auto input_tv = input->as<TensorView>();
+          checkContiguity(validator.domains_, tv, input_tv);
+        }
+      }
+
+      TORCH_INTERNAL_ASSERT(validator.vectorized_id_ != nullptr);
+
+      // Contiguity is based on rfactor domain.
+      IterDomain* last_allocation_dim = nullptr;
+      size_t last_allocation_dim_pos = 0;
+      for (size_t i = tv->getMaybeRFactorDomain().size(); i > 0; i--) {
+        auto r_id = tv->getMaybeRFactorDomain()[i - 1];
+        if (r_id->isReduction() || r_id->isBroadcast()) {
+          continue;
+        }
+        last_allocation_dim = r_id;
+        last_allocation_dim_pos = i - 1;
+        break;
+      }
+
+      if (last_allocation_dim == nullptr) {
+        // Should never get here, but that would mean there are no concrete
+        // dims, so we should be fine.
+        return nullptr;
+      }
+
+      auto ldst = dynamic_cast<LoadStoreOp*>(tv->definition());
+      bool is_ldmatrix_trans = ldst != nullptr &&
+          ldst->opType() == LoadStoreOpType::LdMatrixTranspose;
+      if (!is_ldmatrix_trans) {
+        // ldmatrix.trans is a hardware transpose instruction that can do
+        // "vectorized" read from discontiguous memory
+        auto contiguity =
+            *tv->domain()->contiguity().at(last_allocation_dim_pos);
+        TORCH_CHECK(
+            last_allocation_dim == validator.vectorized_id_ && contiguity,
+            "Vectorized dim has to be from a contiguous inner most position. tv: ",
+            tv,
+            ", allocation domain: ",
+            ir_utils::toString(tv->getMaybeRFactorDomain()),
+            ", vectorized id: ",
+            validator.vectorized_id_,
+            ", innermost id: ",
+            last_allocation_dim,
+            ", contiguity: ",
+            contiguity);
+      }
+      return validator.vectorized_id_;
+    };
+
+    auto consumer_vectorized_id = getVectorizedIdInAllocationDomain(v_id, tv);
+    if (consumer_vectorized_id == nullptr) {
+      return;
     }
 
     // Save info required to lowering and runtime validation
@@ -467,6 +485,7 @@ class VectorizeValidator : public OptInDispatch {
       GpuLower::current()->vectorizedAccesses().emplace(
           tv, (int)vector_word_size);
     }
+
     auto producer_tv = tv->definition()->inputs().at(0)->as<TensorView>();
     auto producer_word_size_it =
         GpuLower::current()->vectorizedAccesses().find(producer_tv);
@@ -487,7 +506,24 @@ class VectorizeValidator : public OptInDispatch {
     // specific vectorized set.
     vectorized_set_info.word_size = (int)vector_word_size;
     vectorized_set_info.vectorized_leaf_id = v_id;
-    vectorized_set_info.vectorized_root_id = validator.vectorized_id_;
+    vectorized_set_info.vectorized_root_id = consumer_vectorized_id;
+
+    // Validate producer
+    auto pairwise_map = PairwiseRootDomainMap(producer_tv, tv);
+    auto producer_replayed_as_consumer =
+        TransformReplay::replayPasC(
+            producer_tv, tv, -1, pairwise_map, false, true)
+            .first;
+    ir_utils::TVDomainGuard domain_guard(
+        producer_tv, producer_replayed_as_consumer);
+    auto c2p_map =
+        BestEffortReplay::replayPasC(producer_tv, tv, -1, pairwise_map)
+            .getReplay();
+    if (auto c2p_it = c2p_map.find(v_id); c2p_it != c2p_map.end()) {
+      vectorized_set_info.vectorized_producer_root_id =
+          getVectorizedIdInAllocationDomain(c2p_it->second, producer_tv);
+    }
+
     // For aligned vectorize, the extent of a vectorized domain must
     // be divisible by the vector word size. The domain is usually
     // just one of the root domains, but can be a merged domain of
@@ -668,13 +704,8 @@ void fillProducerVectorizedContigRootDomains(
 
   VectorizedSetInfo& info = *it;
 
-  // info.vectorized_root_id is validated at this point to be the
-  // last concrete root domain in consumer.
-  auto consumer_root_id = info.vectorized_root_id;
-
-  auto root_id = c2p_map.at(consumer_root_id);
-
-  fillVectorizedContigRootDomains(producer_tv, contig_finder, root_id, info);
+  fillVectorizedContigRootDomains(
+      producer_tv, contig_finder, info.vectorized_producer_root_id, info);
 }
 
 namespace {

--- a/csrc/lower_validation.cpp
+++ b/csrc/lower_validation.cpp
@@ -493,11 +493,9 @@ class VectorizeValidator : public OptInDispatch {
     auto c2p_map =
         BestEffortReplay::replayPasC(producer_tv, tv, -1, pairwise_map)
             .getReplay();
-    if (auto c2p_it = c2p_map.find(v_id); c2p_it != c2p_map.end()) {
-      vectorized_set_info.vectorized_producer_alloc_id =
-          getVectorizedIdInAllocationDomain(
-              c2p_it->second, producer_tv, "producer");
-    }
+    vectorized_set_info.vectorized_producer_alloc_id =
+        getVectorizedIdInAllocationDomain(
+            c2p_map.at(v_id), producer_tv, "producer");
 
     // For aligned vectorize, the extent of a vectorized domain must
     // be divisible by the vector word size. The domain is usually
@@ -664,7 +662,6 @@ void fillConsumerVectorizedContigAllocationDomains(
 void fillProducerVectorizedContigAllocationDomains(
     const TensorView* producer_tv,
     const TensorView* consumer_tv,
-    const std::unordered_map<IterDomain*, IterDomain*>& c2p_map,
     const ContigIDs& contig_finder) {
   auto& info_vector = GpuLower::current()->vectorizedSetInfo();
   auto it = std::find_if(

--- a/csrc/lower_validation.h
+++ b/csrc/lower_validation.h
@@ -33,7 +33,6 @@ void fillConsumerVectorizedContigAllocationDomains(
 void fillProducerVectorizedContigAllocationDomains(
     const TensorView* producer_tv,
     const TensorView* consumer_tv,
-    const std::unordered_map<IterDomain*, IterDomain*>& c2p_map,
     const ContigIDs& contig_finder);
 
 //! Validates partial split expressions. Partial split only uses an

--- a/csrc/lower_validation.h
+++ b/csrc/lower_validation.h
@@ -21,16 +21,16 @@ void validateIr(Fusion* fusion);
 //! used in code generation as well as runtime validation.
 void validateAndCollectVectorizeInfo(Fusion* fusion);
 
-//! Find the contig root domains that a vectorized leaf domain
+//! Find the contig allocation domains that a vectorized leaf domain
 //! of a consumer TV depends on. Required for runtime validation.
-void fillConsumerVectorizedContigRootDomains(
+void fillConsumerVectorizedContigAllocationDomains(
     const TensorView* consumer_tv,
     const ContigIDs& contig_finder);
 
-//! Find the contig root domains that a vectorized leaf domain
+//! Find the contig allocation domains that a vectorized leaf domain
 //! of a producer TV depends on. Required for runtime validation.
 //! Producer must be transformed as consumer.
-void fillProducerVectorizedContigRootDomains(
+void fillProducerVectorizedContigAllocationDomains(
     const TensorView* producer_tv,
     const TensorView* consumer_tv,
     const std::unordered_map<IterDomain*, IterDomain*>& c2p_map,

--- a/csrc/vectorization_info.h
+++ b/csrc/vectorization_info.h
@@ -22,8 +22,10 @@ struct VectorizedSetInfo {
   int word_size = -1;
   //! Vectorized domain
   IterDomain* vectorized_leaf_id = nullptr;
-  //! Right-most root dependent domain of the leaf domain
+  //! Right-most root dependent domain of the leaf domain for consumer
   IterDomain* vectorized_root_id = nullptr;
+  //! Right-most root dependent domain of the leaf domain for producer
+  IterDomain* vectorized_producer_root_id = nullptr;
   //! All of the dependent root domains that are contiguously merged
   std::unordered_set<IterDomain*> contig_root_ids;
 };

--- a/csrc/vectorization_info.h
+++ b/csrc/vectorization_info.h
@@ -22,12 +22,12 @@ struct VectorizedSetInfo {
   int word_size = -1;
   //! Vectorized domain
   IterDomain* vectorized_leaf_id = nullptr;
-  //! Right-most root dependent domain of the leaf domain for consumer
-  IterDomain* vectorized_root_id = nullptr;
-  //! Right-most root dependent domain of the leaf domain for producer
-  IterDomain* vectorized_producer_root_id = nullptr;
-  //! All of the dependent root domains that are contiguously merged
-  std::unordered_set<IterDomain*> contig_root_ids;
+  //! Right-most allocation dependent domain of the leaf domain for consumer
+  IterDomain* vectorized_consumer_alloc_id = nullptr;
+  //! Right-most allocation dependent domain of the leaf domain for producer
+  IterDomain* vectorized_producer_alloc_id = nullptr;
+  //! All of the dependent allocation domains that are contiguously merged
+  std::unordered_set<IterDomain*> contig_alloc_ids;
 };
 
 } // namespace nvfuser

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -4117,8 +4117,8 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicPass_CUDA) {
   constexpr int kVecSize = 2;
   constexpr int kNumElems = kTDX * kVecSize;
 
-  auto tv0 = makeSymbolicTensor(kNumDims);
-  auto tv1 = makeSymbolicTensor(kNumDims);
+  auto tv0 = makeContigTensor(kNumDims);
+  auto tv1 = makeContigTensor(kNumDims);
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
@@ -4333,8 +4333,8 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStride_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto tv0 = makeSymbolicTensor(2);
-  auto tv1 = makeSymbolicTensor(2);
+  auto tv0 = makeContigTensor(2);
+  auto tv1 = makeContigTensor(2);
 
   fusion.addInput(tv0);
   fusion.addInput(tv1);
@@ -4384,8 +4384,8 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStrideFail_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto tv0 = makeSymbolicTensor(2);
-  auto tv1 = makeSymbolicTensor(2);
+  auto tv0 = makeContigTensor(2);
+  auto tv1 = makeContigTensor(2);
 
   fusion.addInput(tv0);
   fusion.addInput(tv1);
@@ -4437,9 +4437,8 @@ TEST_F(NVFuserTest, FusionVectorization1_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto tv0 = makeSymbolicTensor(2);
-
-  auto tv1 = makeSymbolicTensor(2);
+  auto tv0 = makeContigTensor(2);
+  auto tv1 = makeContigTensor(2);
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -4333,8 +4333,10 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStride_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto tv0 = makeContigTensor(2);
-  auto tv1 = makeContigTensor(2);
+  auto tv0 = makeSymbolicTensor(2);
+  auto tv1 = makeSymbolicTensor(2);
+  tv0->setContiguity({false, true});
+  tv1->setContiguity({false, true});
 
   fusion.addInput(tv0);
   fusion.addInput(tv1);
@@ -4384,8 +4386,10 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStrideFail_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto tv0 = makeContigTensor(2);
-  auto tv1 = makeContigTensor(2);
+  auto tv0 = makeSymbolicTensor(2);
+  auto tv1 = makeSymbolicTensor(2);
+  tv0->setContiguity({false, true});
+  tv1->setContiguity({false, true});
 
   fusion.addInput(tv0);
   fusion.addInput(tv1);

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -2805,8 +2805,8 @@ TEST_F(NVFuserTest, FusionDoubleBufferCpAsync1_CUDA) {
   // Using vectorization so need to keep n multiple of 4.
   int m = 33, n = 48;
 
-  TensorView* tv0 = makeConcreteTensor({m, n});
-  TensorView* tv1 = makeConcreteTensor({m, n});
+  TensorView* tv0 = makeContigConcreteTensor({m, n});
+  TensorView* tv1 = makeContigConcreteTensor({m, n});
 
   fusion.addInput(tv0);
   fusion.addInput(tv1);
@@ -2971,7 +2971,7 @@ TEST_F(NVFuserTest, FusionCpAsyncPredicate_CUDA) {
   // Using vectorization so need to keep n multiple of 4.
   int m = 33, n = 48;
 
-  TensorView* tv0 = makeConcreteTensor({m, n});
+  TensorView* tv0 = makeContigConcreteTensor({m, n});
 
   fusion.addInput(tv0);
   auto tv1 = sum(tv0, {1});

--- a/test/test_gpu_fused_reduction.cpp
+++ b/test/test_gpu_fused_reduction.cpp
@@ -2299,7 +2299,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduceWelfordShmoo_CUDA) {
     std::vector<bool> bcast_pattern{true, true, true, false};
     std::vector<int> reduction_dims{2, 1, 0};
 
-    auto tv0 = makeSymbolicTensor(4);
+    auto tv0 = makeContigTensor(4);
     fusion.addInput(tv0);
 
     auto tv1 = set(tv0);

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -1101,11 +1101,11 @@ TEST_F(NVFuserTest, FusionMatmulMatmulAmpere_CUDA) {
 
   // Fusion definition (Both gemms are TN)
   // [M,K1]
-  auto tv0 = makeConcreteTensor({M, K1}, DataType::Half);
+  auto tv0 = makeContigConcreteTensor({M, K1}, DataType::Half);
   // [K2,K1]
-  auto tv1 = makeConcreteTensor({K2, K1}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K2, K1}, DataType::Half);
   // [N,K2]
-  auto tv2 = makeConcreteTensor({N, K2}, DataType::Half);
+  auto tv2 = makeContigConcreteTensor({N, K2}, DataType::Half);
 
   fusion.addInput(tv0);
   fusion.addInput(tv1);
@@ -1386,11 +1386,11 @@ TEST_F(NVFuserTest, FusionMatmulSoftmaxMatmulAmpere_CUDA) {
 
   // Fusion definition (Both gemms are TN)
   // [M,K1]
-  auto inp = makeConcreteTensor({M1, K1}, DataType::Half);
+  auto inp = makeContigConcreteTensor({M1, K1}, DataType::Half);
   // Query matrix
-  auto qk = makeConcreteTensor({N1, K1}, DataType::Half);
+  auto qk = makeContigConcreteTensor({N1, K1}, DataType::Half);
   // Second linear matrix
-  auto acc = makeConcreteTensor({N2, K2}, DataType::Half);
+  auto acc = makeContigConcreteTensor({N2, K2}, DataType::Half);
 
   fusion.addInput(inp);
   fusion.addInput(qk);

--- a/test/test_gpu_transpose.cpp
+++ b/test/test_gpu_transpose.cpp
@@ -922,7 +922,7 @@ TEST_F(NVFuserTest, FusionTransposeBankConflict4_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto tv0 = makeConcreteTensor({32, 32});
+  auto tv0 = makeContigConcreteTensor({32, 32});
   fusion.addInput(tv0);
   auto tv1 = set(tv0);
   auto tv2 = transpose(tv1, 0, 1);
@@ -1058,7 +1058,7 @@ TEST_F(NVFuserTest, FusionTransposeBankConflict9_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto tv0 = makeConcreteTensor({32, 32, 2});
+  auto tv0 = makeContigConcreteTensor({32, 32, 2});
   fusion.addInput(tv0);
   auto tv1 = set(tv0);
   auto tv2 = transpose(tv1, 0, 1);


### PR DESCRIPTION
Split out from https://github.com/NVIDIA/Fuser/pull/276. I suggest reviewing this PR hiding whitespaces.

Currently, we are not validating vectorization correctly, especially, we are not checking the contiguity of producer. Also `fillProducerVectorizedContigRootDomains` does not support the case where the allocation domain is different from rFactor domain.