### PR TITLE
Use top-level build with clang-tidy CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,12 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install cuda-toolkit-12-1
 
+          # cmake environment variables
+          export CUDAARCHS=86
+          export CUDACXX=/usr/local/cuda/bin/nvcc
+          export PATH=/usr/local/cuda/bin:${PATH}
+          export CUDA_INSTALL_PATH=/usr/local/cuda
+
           # Install pytorch
           pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
           sudo dpkg -i cuda-keyring_1.0-1_all.deb
           sudo apt-get update
-          sudo apt-get -y install cuda
+          sudo apt-get -y install cuda-toolkit-12-1
 
           # Install pytorch
           pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,28 +36,18 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install cuda
 
-          # cmake environment variables
-          export CUDAARCHS=86
-          export CUDACXX=/usr/local/cuda/bin/nvcc
-          export PATH=/usr/local/cuda/bin:${PATH}
-          export CUDA_INSTALL_PATH=/usr/local/cuda
+          # Install pytorch
+          pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu118
 
-          # pytorch environment variables
-          export TORCH_CUDA_ARCH_LIST="8.6"
-          export BUILD_NVFUSER=1
-          export USE_MKLDNN=0
-          export USE_CUDNN=0
-          export USE_DISTRIBUTED=0
-          export NVFUSER_SOURCE_DIR=$this_dir
+          # Get submodules
+          git submodule sync --recursive
+          git submodule update --init --recursive
 
-          # Clone pytorch and run cmake build
-          git clone https://github.com/pytorch/pytorch.git
-          cd pytorch
-          python3 -m tools.linter.clang_tidy.generate_build_files
-          cd $this_dir
+          # Install other requirements
+          pip install -r requirements.txt
 
-          # Run lintrunner on all csrc files
-          # find csrc/ -type f | xargs lintrunner --force-color
+          # Run cmake build
+          python setup.py --cmake-only
 
           # Run lintrunner on all csrc files exclude benchmark and test folders
           this_commit=$(git rev-parse HEAD)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,13 +31,13 @@ jobs:
           lintrunner init 2> /dev/null
 
           # Install cuda
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
           sudo dpkg -i cuda-keyring_1.0-1_all.deb
           sudo apt-get update
           sudo apt-get -y install cuda
 
           # Install pytorch
-          pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu118
+          pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
 
           # Get submodules
           git submodule sync --recursive

--- a/csrc/lower_misaligned_vectorization.cpp
+++ b/csrc/lower_misaligned_vectorization.cpp
@@ -539,14 +539,13 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
 
       // If it's not contiguous, extending the vectorization domain
       // further is not possible
-      auto producer_dim_contiguity = producer_contig.at(i);
-      TORCH_INTERNAL_ASSERT(producer_dim_contiguity.has_value());
+      // auto producer_dim_contiguity = producer_contig.at(i);
+      // TORCH_INTERNAL_ASSERT(producer_dim_contiguity.has_value());
 
       auto consumer_dim_contiguity = consumer_contig.at(consumer_root_idx);
       TORCH_INTERNAL_ASSERT(consumer_dim_contiguity.has_value());
 
-      if (!(producer_dim_contiguity.value() &&
-            consumer_dim_contiguity.value())) {
+      if (!(producer_contig.at(i).value() && consumer_dim_contiguity.value())) {
         break;
       }
 

--- a/csrc/lower_misaligned_vectorization.cpp
+++ b/csrc/lower_misaligned_vectorization.cpp
@@ -539,13 +539,14 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
 
       // If it's not contiguous, extending the vectorization domain
       // further is not possible
-      // auto producer_dim_contiguity = producer_contig.at(i);
-      // TORCH_INTERNAL_ASSERT(producer_dim_contiguity.has_value());
+      auto producer_dim_contiguity = producer_contig.at(i);
+      TORCH_INTERNAL_ASSERT(producer_dim_contiguity.has_value());
 
       auto consumer_dim_contiguity = consumer_contig.at(consumer_root_idx);
       TORCH_INTERNAL_ASSERT(consumer_dim_contiguity.has_value());
 
-      if (!(producer_contig.at(i).value() && consumer_dim_contiguity.value())) {
+      if (!(producer_dim_contiguity.value() &&
+            consumer_dim_contiguity.value())) {
         break;
       }
 

--- a/setup.py
+++ b/setup.py
@@ -271,7 +271,7 @@ def cmake(build_dir: str = "", install_prefix: str = "./nvfuser"):
         cmd_str.append("-DBUILD_NVFUSER_BENCHMARK=ON")
     cmd_str.append(".")
 
-    print(f"Configuraing CMake with {' '.join(cmd_str)}")
+    print(f"Configuring CMake with {' '.join(cmd_str)}")
     subprocess.check_call(cmd_str)
 
     if not CMAKE_ONLY:


### PR DESCRIPTION
Reduce clang-tidy CI setup time.
e.g., from ~13 minutes to ~6 minutes