### PR TITLE
Mark contiguity of reduction ID as nullopt

### DIFF
--- a/csrc/contiguity.cpp
+++ b/csrc/contiguity.cpp
@@ -527,9 +527,8 @@ void ContigIDs::build(const std::vector<IterDomain*>& ids) {
     // rfactor root domains, which should just return "zero"
     // RootAxisInfo. This should be safe as no rfactor tensor should
     // need halo.
-    auto alloc_contiguity_opt = alloc_contiguity_.at(alloc_domain_i);
-    TORCH_INTERNAL_ASSERT(alloc_contiguity_opt.has_value());
-    if (alloc_contiguity_opt.value() &&
+    auto alloc_contiguity = alloc_contiguity_.at(alloc_domain_i);
+    if (alloc_contiguity.value_or(false) &&
         !halo_info_->getRootAxisInfo(alloc_domain_id).hasHalo() &&
         alloc_domain_id->getIterType() != IterType::GatherScatter) {
       contig_ids_.emplace(alloc_domain_id);
@@ -619,9 +618,8 @@ void ContigIDs::handle(Merge* merge) {
       // If we're computing predicates (ignore_consistent_ordering_==true),
       // then we don't have this same constraint, we can just ignore
       // contiguity of the allocations all together.
-      auto alloc_contiguity_opt = alloc_contiguity_.at(alloc_id_i);
-      TORCH_INTERNAL_ASSERT(alloc_contiguity_opt.has_value());
-      if (!alloc_contiguity_opt.value() && is_indexing_pass) {
+      auto alloc_contiguity = alloc_contiguity_.at(alloc_id_i);
+      if (!alloc_contiguity.value_or(false) && is_indexing_pass) {
         if (!alloc_ids.empty()) {
           return;
         }

--- a/csrc/contiguity.cpp
+++ b/csrc/contiguity.cpp
@@ -532,6 +532,8 @@ void ContigIDs::build(const std::vector<IterDomain*>& ids) {
         alloc_domain_id->isReduction() != alloc_contiguity.has_value(),
         "Expecting a reduction because contiguity has no value, get ",
         alloc_domain_id->toString());
+    // Index of merged reductions can always be coalesced, so considering
+    // reduction as true contiguity.
     if (alloc_contiguity.value_or(true) &&
         !halo_info_->getRootAxisInfo(alloc_domain_id).hasHalo() &&
         alloc_domain_id->getIterType() != IterType::GatherScatter) {
@@ -627,6 +629,8 @@ void ContigIDs::handle(Merge* merge) {
           alloc_id->isReduction() != alloc_contiguity.has_value(),
           "Expecting a reduction because contiguity has no value, get ",
           alloc_id->toString());
+      // Index of merged reductions can always be coalesced, so considering
+      // reduction as true contiguity.
       if (!alloc_contiguity.value_or(true) && is_indexing_pass) {
         if (!alloc_ids.empty()) {
           return;

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -94,23 +94,28 @@ class Logger : public NoOpLogger {
       : NoOpLogger(value), init_val_(value), current_val_(value) {}
 
   ~Logger() override {
-    if (!shouldPrint()) {
-      return;
-    }
+    try {
+      if (!shouldPrint()) {
+        return;
+      }
 
-    auto str = [](Val* v) {
-      std::stringstream ss;
-      ss << ir_utils::varName(v) << " = " << v->toInlineString();
-      return ss.str();
-    };
+      auto str = [](Val* v) {
+        std::stringstream ss;
+        ss << ir_utils::varName(v) << " = " << v->toInlineString();
+        return ss.str();
+      };
 
-    std::string header = "Simplifying expression:\n" + str(init_val_);
-    std::cout << header << std::endl;
-    for (auto r : record_) {
-      std::cout << r.name << ":\n" << str(r.result) << std::endl;
+      std::string header = "Simplifying expression:\n" + str(init_val_);
+      std::cout << header << std::endl;
+      for (auto r : record_) {
+        std::cout << r.name << ":\n" << str(r.result) << std::endl;
+      }
+      std::cout << std::string(std::min<size_t>(header.size(), 80), '=')
+                << std::endl;
+    } catch (...) {
+      // clang-tidy don't want this function to throw, but this is just a
+      // debugging helper, I don't really care if it has throw or not.
     }
-    std::cout << std::string(std::min<size_t>(header.size(), 80), '=')
-              << std::endl;
   }
 
   void record(const char* name, Val* value) override {

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -1355,8 +1355,17 @@ bool lessThan(Val* x, Val* y, const Context& context) {
   if (x->isZero() && isPositiveHelper(y, context)) {
     return true;
   }
+  // i1 % i2 < i2
+  if (auto bop = dynamic_cast<BinaryOp*>(x->definition());
+      bop != nullptr && bop->getBinaryOpType() == BinaryOpType::Mod) {
+    auto denominator = bop->rhs();
+    if (denominator->sameAs(y) && isValidDenominator(denominator, context) &&
+        isNonNegative(y, context)) {
+      return true;
+    }
+  }
+  // x <= a & a < b & b <= y  -->  x < y
   for (const auto& [a, b] : context.getKnownLessThan()) {
-    // x <= a & a < b & b <= y  -->  x < y
     if (lessEqual(x, a, context) && lessEqual(b, y, context)) {
       return true;
     }

--- a/csrc/expr_simplifier.h
+++ b/csrc/expr_simplifier.h
@@ -589,7 +589,7 @@
 //
 // So, we have the following rule for trunc division:
 // Rule 1: For i >= 0, d > 0, i / d < D <=> i < D * d
-// > D*d Proof:
+// Proof:
 // 1. i / d < D => i < D * d
 //    Consider the function f(x) = x / d, it is weakly increasing. Also note
 //    that D = D * d / d.

--- a/csrc/expr_simplifier.h
+++ b/csrc/expr_simplifier.h
@@ -532,6 +532,75 @@
 // = a + 0 (Rule I)
 // = a
 
+// Note: [Simplification of boolean predicates]
+//
+// This note lists some rules we use to simplify boolean predicates, and provide
+// the proofs of these rules.
+//
+// The following definitions and lemmas are helpful:
+// (Reference: https://en.wikipedia.org/wiki/Monotonic_function)
+//
+// Definition 1: A function is called strictly increasing if for all x < y,
+//   we have f(x) < f(y)
+// Definition 2: A function is called weakly increasing if for all x <= y,
+//   we have f(x) <= f(y)
+//
+// Lemma 1: if f is strictly increasing, then
+// 1. x < y <=> f(x) < f(y)
+// 2. x <= y <=> f(x) <= f(y)
+// Proof:
+// 1. x < y => f(x) < f(y) by definition.
+// 2. x <= y => f(x) <= f(y)
+//    x <= y means either x < y or x = y. For the first case, f(x) < f(y).
+//    For the second case, f(x) = f(y), in combination, f(x) <= f(y).
+// 1. f(x) < f(y) => x < y
+//    Assume x < y was not true, then y <= x, then f(y) <= f(x), which conflict
+//    with f(x) < f(y)
+// 2. f(x) <= f(y) => x <= y
+//    Assume x <= y was not true, then y < x, then f(y) < f(x), which conflict
+//    with f(x) <= f(y)
+//
+// Lemma 2: if f is weakly increasing, then
+// 1. x <= y => f(x) <= f(y)
+// 2. x < y => f(x) <= f(y)
+// 3. f(x) <= f(y) does not provide much information, especially, it is not
+//    guaranteed that x <= y
+// 4. f(x) < f(y) => x < y
+// Proof:
+// 1. x <= y => f(x) <= f(y) by definition
+// 2. x < y => f(x) <= f(y) because x < y => x <= y
+// 3. Consider f(x) = 1 (constant function), then f is weakly increasing. For
+//    this function, f(x) <= f(y) is trivially true, and x and y can be
+//    arbitrary number.
+// 4. f(x) < f(y) => x < y
+//    Assume that x < y was not true, that is, y <= x, then f(y) <= f(x), which
+//    conflict with f(x) < f(y)
+//
+// With these lemmas, we can study possible simplification rules for boolean
+// predicates. One interesting application is on division.
+//
+// Different type of divisions are studied in the following paper:
+//   Boute, Raymond T. "The Euclidean definition of the functions div and mod."
+//   ACM Transactions on Programming Languages and Systems (TOPLAS) 14.2 (1992):
+//   127-144.
+// Referring to that paper, we can conclude that:
+// - For all types of division (Euclidean/trunc/floor div) f(x) = x / d, f is
+//   weakly increasing if d > 0, and weakly decreasing if d < 0.
+//
+// So, we have the following rule for trunc division:
+// Rule 1: For i >= 0, d > 0, i / d < D <=> i < D * d
+// > D*d Proof:
+// 1. i / d < D => i < D * d
+//    Consider the function f(x) = x / d, it is weakly increasing. Also note
+//    that D = D * d / d.
+//    According to Lemma 2 (4), we have f(i) < f(D*d) => i < D*d.
+// 2. i < D * d => i / d < D
+//    According to the fundamental division-with-remainder equation, i < D * d
+//    can be written as i / d * d + i % d < D * d. Because i >= 0, d > 0, we
+//    have i % d >= 0. So i / d * d <= i / d * d + i % d < D * d. That is,
+//    i / d * d < D * d. Consider the function g(x) = x * d, which is strictly
+//    increasing. According to Lemma 1 (1), g(i / d) < g(D) indicates i/d < D.
+
 namespace nvfuser {
 
 // Information for a single variable. Possible values that this variable can

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -2607,8 +2607,8 @@ void validateContiguity(
          allocation_domain.at(i)->isReduction());
     TORCH_CHECK(
         expect_null != contiguity.at(i).has_value(),
-        "The contiguity of a broadcast dimension must be None. "
-        "The contiguity of a non-broadcast dimension must be true/false");
+        "The contiguity of a broadcast/reduction dimension must be None. "
+        "The contiguity of a non-broadcast/reduction dimension must be true/false");
   }
 }
 

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -2602,8 +2602,11 @@ void validateContiguity(
       " but needed one of size ",
       allocation_domain.size());
   for (auto i : c10::irange(contiguity.size())) {
+    bool expect_null =
+        (allocation_domain.at(i)->isBroadcast() ||
+         allocation_domain.at(i)->isReduction());
     TORCH_CHECK(
-        allocation_domain.at(i)->isBroadcast() != contiguity.at(i).has_value(),
+        expect_null != contiguity.at(i).has_value(),
         "The contiguity of a broadcast dimension must be None. "
         "The contiguity of a non-broadcast dimension must be true/false");
   }
@@ -3113,7 +3116,7 @@ std::vector<std::optional<bool>> TensorDomain::getContiguityFilledWith(
   std::vector<std::optional<bool>> contiguity;
   contiguity.reserve(rfactor_domain.size());
   for (auto id : rfactor_domain) {
-    if (id->isBroadcast()) {
+    if (id->isBroadcast() || id->isReduction()) {
       contiguity.emplace_back(std::nullopt);
     } else {
       contiguity.emplace_back(fill_value);

--- a/test/test_expr_simplifier.cpp
+++ b/test/test_expr_simplifier.cpp
@@ -1081,4 +1081,15 @@ TEST_F(ExprSimplifierTest, Assume_CUDA) {
   ASSERT_TRUE(assume::tensorsAreNotEmpty(expr)->sameAs("T0.size[0] > 0"_));
 }
 
+TEST_F(ExprSimplifierTest, PredicateDivToMul_CUDA) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  auto simplified = simplifyExpr("i1 / T0.size[0] < i2"_, {}, {"i1 >= 0"_b});
+  auto expect = "i1 < ( i2 * T0.size[0] )"_;
+
+  ASSERT_TRUE(simplified->sameAs(expect));
+}
+
 } // namespace nvfuser

--- a/test/test_expr_simplifier.cpp
+++ b/test/test_expr_simplifier.cpp
@@ -866,6 +866,8 @@ TEST_F(ExprSimplifierTest, Compare_CUDA) {
   ASSERT_TRUE(*simplify(
       "blockIdx.x < ceilDiv( T0.size[0] , 128 ) * 4"_,
       "blockIdx.x < ceilDiv( T0.size[0] , 128 ) * 4"_));
+
+  ASSERT_TRUE(*simplify("i1 % i2 < i2"_, "i2 >= 0"_));
 }
 
 TEST_F(ExprSimplifierTest, FundamentalDivisionWithRemainderProperty_CUDA) {

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -6862,7 +6862,7 @@ TEST_F(NVFuserTest, FusionSqueezeOnlyWelford_CUDA) {
     auto dim1 = IterDomainBuilder(w1.avg->axis(1)).build();
     auto td = IrBuilder::create<TensorDomain>(
         std::vector<IterDomain*>{dim0, dim1},
-        std::vector<std::optional<bool>>{true, true});
+        std::vector<std::optional<bool>>{true, std::nullopt});
     auto tv = IrBuilder::create<TensorView>(td, dtype);
     return tv;
   };


### PR DESCRIPTION
Reduction IDs does not exist, so it makes no sense to mark them as true or false.

Also:
- Add prove for `i1 % size < size`
- Add simplification `i1 / d < D` -> `i1 < d * D`

The above two items is important to make the predicate of reduction unrelated to contiguity.