### PR TITLE
Pip wheel build patch

### DIFF
--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -391,7 +391,7 @@ class TORCH_CUDA_CU_API Fusion : public IrContainer {
   }
 
   inline bool hasManaged(size_t index) const {
-    return index >= 0 && index < managed_data_.size() &&
+    return index < managed_data_.size() &&
         managed_data_[index].first.has_value();
   }
 

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2126,7 +2126,6 @@ class TestNvFuserFrontend(TestCase):
 
         for mm_str, nvf_test_inputs, eager_test_inputs in tests:
             if prop.major == 8:
-                print("Uh Oh!")
                 nvf_out, _ = self.exec_nvfuser(
                     partial(fusion_func, inps=nvf_test_inputs, matmul_fn=mm_str),
                     nvf_test_inputs,

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,8 @@ def version_tag():
     if OVERWRITE_VERSION:
         version = version.split("+")[0]
         if len(VERSION_TAG) != 0:
-            version = "+".join([version, VERSION_TAG])
+            # use "." to be pypi friendly
+            version = ".".join([version, VERSION_TAG])
     return version
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@
 #     this is used for pip wheel build to specify package required for install
 #     e.g. -install_requires=nvidia-cuda-nvrtc-cu12
 #
+#   -wheel-name=NAME
+#     Specify the wheel name this is used for pip wheel package where we want
+#     to identify the cuda toolkit version
+#
 
 import multiprocessing
 import os
@@ -54,6 +58,7 @@ PATCH_NVFUSER = True
 OVERWRITE_VERSION = False
 VERSION_TAG = None
 BUILD_TYPE = "Release"
+WHEEL_NAME = "nvfuser"
 INSTALL_REQUIRES = []
 forward_args = []
 for i, arg in enumerate(sys.argv):
@@ -81,6 +86,9 @@ for i, arg in enumerate(sys.argv):
     if arg.startswith("-version-tag="):
         OVERWRITE_VERSION = True
         VERSION_TAG = arg.split("=")[1]
+        continue
+    if arg.startswith("-wheel-name="):
+        WHEEL_NAME = arg.split("=")[1]
         continue
     if arg in ["clean"]:
         # only disables BUILD_SETUP, but keep the argument for setuptools
@@ -318,7 +326,7 @@ def main():
         ]
 
         setup(
-            name="nvfuser",
+            name=WHEEL_NAME,
             version=version_tag(),
             url="https://github.com/NVIDIA/Fuser",
             description="A Fusion Code Generator for NVIDIA GPUs (commonly known as 'nvFuser')",


### PR DESCRIPTION
1. Added `-wheel-name` option on setuptools to allow custom package name
2. changed version separator `+` to `.` to be pypi compatible