### PR TITLE
Promote fusing select-like ops with producers

### DIFF
--- a/csrc/foo.cpp
+++ b/csrc/foo.cpp
@@ -1,0 +1,2 @@
+#include "ir_interface_nodes.h"
+#include "ir_internal_nodes.h"

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -2973,6 +2973,108 @@ bool areDirectlyConnected(SegmentedGroup* group1, SegmentedGroup* group2) {
   return false;
 }
 
+//! Allow the segmentation algorithm to prefer certain exprs to merge
+class PreferredMergeCandidatePicker {
+ public:
+  static std::vector<std::pair<SegmentedGroup*, SegmentedGroup::NeighborGroup>>
+  get(const std::vector<SegmentedGroup*>& groups) {
+    return PreferredMergeCandidatePicker(groups).candidates_;
+  }
+
+ private:
+  PreferredMergeCandidatePicker(const std::vector<SegmentedGroup*>& groups)
+      : groups_(groups) {
+    for (auto& group : groups_) {
+      // Currently there's only one preference for select-like
+      // ops. Additional preferences can be added similarly.
+      auto neighbor_to_merge = mergeSelectLikeOpsWithProducers(group);
+      if (!neighbor_to_merge.has_value()) {
+        continue;
+      }
+      candidates_.emplace_back(group, *neighbor_to_merge);
+    }
+  }
+
+  //! Prefer merging groups with select-like exprs with producer
+  //! groups, including index_select, torch_gather and take_along_axis
+  //! where only one element is selected/gathered/taken, producing a
+  //! broadcast domain. Fusing these exprs with producers is
+  //! straightforward, but may not be always possible with consumers as
+  //! consumer reference tensors may not know about the gathered
+  //! domain, much like reduction domains. Moreover, if segmentation is
+  //! necessary, it would be more efficient to segment a kernel after
+  //! these exprs as the segment output tensors would become smaller.
+  //!
+  //! A motivating example is cross-entropy loss, where softmax is
+  //! followed by take_along_axis, and then is followed by a
+  //! reduction. Currently, it's not possible to fuse the softmax and
+  //! the reduction, so it must be segmented to two groups, and we
+  //! want to segment the fusion between the take_along_axis and the
+  //! reduction, not between the softma and take_along_axis.
+  std::optional<SegmentedGroup::NeighborGroup> mergeSelectLikeOpsWithProducers(
+      SegmentedGroup* group) const;
+
+ private:
+  const std::vector<SegmentedGroup*>& groups_;
+  std::vector<std::pair<SegmentedGroup*, SegmentedGroup::NeighborGroup>>
+      candidates_;
+};
+
+std::optional<SegmentedGroup::NeighborGroup> PreferredMergeCandidatePicker::
+    mergeSelectLikeOpsWithProducers(SegmentedGroup* group) const {
+  const auto& exprs = group->exprs();
+
+  // I *think* it's enough to consider the initial merge of
+  // select-like ops.
+  if (exprs.size() != 1) {
+    return std::nullopt;
+  }
+
+  auto expr = exprs.at(0);
+
+  // Select-like exprs have a producer ID that is indirectly
+  // accessed with an index input
+  if (ir_utils::getIndexedProducerID(expr) == nullptr) {
+    return std::nullopt;
+  }
+
+  auto lookup_tv = ir_utils::getTvInput(expr);
+
+  // If the lookup tv is a fusion input, there's nothing to do
+  if (lookup_tv->isFusionInput()) {
+    return std::nullopt;
+  }
+
+  auto consumer_of_indexed_id = ir_utils::getConsumerOfIndexedProducerID(expr);
+
+  // There must be a consumer ID unless it's a Select expr
+  TORCH_INTERNAL_ASSERT(
+      consumer_of_indexed_id != nullptr || expr->isA<SelectOp>(),
+      "Consumer of indexed ID not found: ",
+      expr->toString());
+
+  // In case of non select expr, make sure the consumer ID is a broadcat
+  if (!expr->isA<SelectOp>() && !consumer_of_indexed_id->isBroadcast()) {
+    return std::nullopt;
+  }
+
+  // Find the producer group that corresponds to the lookup tensor
+  // of the expr.
+  auto producer_edge_it = std::find_if(
+      group->producer_edges.begin(),
+      group->producer_edges.end(),
+      [&lookup_tv](SegmentedEdge* edge) { return edge->val == lookup_tv; });
+
+  // Not sure this could happen happen. Just assert for now.
+  if (producer_edge_it == group->producer_edges.end()) {
+    TORCH_INTERNAL_ASSERT(false, "Unexpected");
+    return std::nullopt;
+  }
+
+  return SegmentedGroup::NeighborGroup(
+      (*producer_edge_it)->from, *producer_edge_it);
+}
+
 } // namespace
 
 bool SegmentCandidateFinder::codeGenSupportedMerge(
@@ -3073,6 +3175,42 @@ void SegmentCandidateFinder::buildInitialSegments() {
   }
 }
 
+void SegmentCandidateFinder::trySetUpMerge(
+    SegmentedGroup* group,
+    std::vector<SegmentedGroup::NeighborGroup> candidates) {
+  if (group->merged_ || group->isFusionInputGroup()) {
+    return;
+  }
+
+  if (candidates.empty()) {
+    candidates = group->getMergeCandidates();
+  }
+
+  if (candidates.empty()) {
+    return;
+  }
+
+  auto candidate_it = candidates.begin();
+  while (candidate_it != candidates.end() &&
+         !codeGenSupportedMerge(group, candidate_it->group)) {
+    candidate_it++;
+  }
+  if (candidate_it == candidates.end()) {
+    return;
+  }
+
+  to_merge_.emplace_back(group);
+  to_merge_.emplace_back(candidate_it->group);
+
+  group->merged_ = true;
+  group->merge_with_ = candidate_it->group;
+  group->merge_through_ = candidate_it->edge;
+
+  candidate_it->group->merged_ = true;
+  candidate_it->group->merge_with_ = group;
+  candidate_it->group->merge_through_ = candidate_it->edge;
+}
+
 void SegmentCandidateFinder::findSegments() {
   FUSER_PERF_SCOPE("Finding valid fusion segment solutions");
 
@@ -3123,34 +3261,14 @@ void SegmentCandidateFinder::findSegments() {
 
       resetLevels();
 
+      // Try preferred merge first
+      for (auto& [group, neighbor] :
+           PreferredMergeCandidatePicker::get(groups())) {
+        trySetUpMerge(group, {neighbor});
+      }
+
       for (auto& group : groups()) {
-        if (group->merged_ || group->isFusionInputGroup()) {
-          continue;
-        }
-        auto candidates = group->getMergeCandidates();
-        if (candidates.empty()) {
-          continue;
-        }
-
-        auto candidate_it = candidates.begin();
-        while (candidate_it != candidates.end() &&
-               !codeGenSupportedMerge(group, candidate_it->group)) {
-          candidate_it++;
-        }
-        if (candidate_it == candidates.end()) {
-          continue;
-        }
-
-        to_merge_.emplace_back(group);
-        to_merge_.emplace_back(candidate_it->group);
-
-        group->merged_ = true;
-        group->merge_with_ = candidate_it->group;
-        group->merge_through_ = candidate_it->edge;
-
-        candidate_it->group->merged_ = true;
-        candidate_it->group->merge_with_ = group;
-        candidate_it->group->merge_through_ = candidate_it->edge;
+        trySetUpMerge(group);
       }
 
       if (to_merge_.empty()) {

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -237,7 +237,8 @@ class TORCH_CUDA_CU_API FusionHeuristics {
   explicit FusionHeuristics(
       ScheduleHeuristic schedule_heuristic,
       SchedulerRuntimeInfo& runtime_info,
-      HeuristicSummary* data_cache = nullptr): is_segmented_(false) {
+      HeuristicSummary* data_cache = nullptr)
+      : is_segmented_(false) {
     heuristics_.emplace_back(SchedulerEntry::makeEntry(
         schedule_heuristic, runtime_info.fusion(), runtime_info, data_cache));
   }

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -44,6 +44,15 @@ std::ostream& operator<<(std::ostream& os, const SegmentedEdge* edge);
 //! Can be used to produce fusions
 class TORCH_CUDA_CU_API SegmentedGroup {
  public:
+  //! Utility struct to represent a group connection
+  //!  both the group to connect with and the edge
+  //!  to connect through
+  struct NeighborGroup {
+    NeighborGroup(SegmentedGroup* g, SegmentedEdge* e) : group(g), edge(e) {}
+    SegmentedGroup* group;
+    SegmentedEdge* edge;
+  };
+
   SegmentedGroup(SegmentedFusion* segmented_fusion)
       : segmented_fusion_(segmented_fusion) {}
 
@@ -185,15 +194,6 @@ class TORCH_CUDA_CU_API SegmentedGroup {
 
   //! Return all segmented groups connected with *this
   std::vector<SegmentedGroup*> getNeighbors();
-
-  //! Utility struct to represent a group connection
-  //!  both the group to connect with and the edge
-  //!  to connect through
-  struct NeighborGroup {
-    NeighborGroup(SegmentedGroup* g, SegmentedEdge* e) : group(g), edge(e) {}
-    SegmentedGroup* group;
-    SegmentedEdge* edge;
-  };
 
   //! TODO: May want to sort this based on size of connections between this and
   //! neighbors as well as if the connection is an output of the fusion (has to
@@ -566,6 +566,14 @@ class TORCH_CUDA_CU_API SegmentCandidateFinder {
   void buildInitialSegments();
 
   void findSegments();
+
+  //! Find a group found in candidates that can be merged with the
+  //! given group and set them to be merged if found. When no
+  //! candidate is given, SegmentedGroup::getMergeCandidates is used
+  //! to get candidates.
+  void trySetUpMerge(
+      SegmentedGroup* group,
+      std::vector<SegmentedGroup::NeighborGroup> candidates = {});
 
   std::unordered_set<SegmentedEdge*> disconnectGroup(SegmentedGroup* group);
 

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -237,10 +237,9 @@ class TORCH_CUDA_CU_API FusionHeuristics {
   explicit FusionHeuristics(
       ScheduleHeuristic schedule_heuristic,
       SchedulerRuntimeInfo& runtime_info,
-      HeuristicSummary* data_cache = nullptr) {
+      HeuristicSummary* data_cache = nullptr): is_segmented_(false) {
     heuristics_.emplace_back(SchedulerEntry::makeEntry(
         schedule_heuristic, runtime_info.fusion(), runtime_info, data_cache));
-    is_segmented_ = false;
   }
 
   FusionHeuristics(const FusionHeuristics&) = delete;


### PR DESCRIPTION
For #278, our schedulers currently can't fuse them into a single kernel, so a segmentation needs to happen. Currently, it's segmented between softmax and take_along_axis, just because of the ordering of the segmenter. However, we want the take_along_axis op to be fused together with the preceding softmax since then the temporary output from the first segment would be much smaller, reducing gmem access overhead. In the case of `[8192, 32768]`, the (logical) I/O cost would be `1 / 32768`.

This PR introduces a simple mechanism to allow preferred fusions in the segmentation steps. Currently, there's only preference of select-like ops with producers. "Select-like" here also includes index_select and torch_gather to size-one domains. In those ops, it's guaranteed that the size of the consumer tensor is no larger than the lookup tensor, so it makes sense to fuse them with producers.

Currently, it's only tested with the cross-entropy loss case. The overall segmentation algorithm would need to go through significant refactoring, so I don't think making this interface super robust is worth doing at this moment, and it's likely to be redesigned. For now, this is very important for the cross-entropy performance.