### PR TITLE
extend aligned sync to broadcast and warp reduction to solve perf iss…

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1065,6 +1065,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       }
       flags_str << (parallel_bcast ? "true" : "false");
     }
+    flags_str << ", " << (isAligned() ? "true" : "false");
 
     const auto data_type = stmt->out()->dtype();
     indent() << "broadcast::blockBroadcast<" << flags_str.str() << ">(\n";

--- a/runtime/broadcast.cu
+++ b/runtime/broadcast.cu
@@ -15,7 +15,7 @@ namespace broadcast {
 // inp_val: Per-thread source value. Only valid when the thread is a source.
 // out: Per-thread output location
 //
-template <bool X_THREAD, bool Y_THREAD, bool Z_THREAD, typename T>
+template <bool X_THREAD, bool Y_THREAD, bool Z_THREAD, bool aligned, typename T>
 __device__ void blockBroadcast(
     T& out,
     const T& inp_val,
@@ -32,13 +32,13 @@ __device__ void blockBroadcast(
     shared_mem[shared_offset] = inp_val;
   }
 
-  block_sync::sync();
+  block_sync::sync<aligned>();
 
   if (read_write_pred) {
     out = shared_mem[shared_offset];
   }
 
-  block_sync::sync();
+  block_sync::sync<aligned>();
 }
 
 } // namespace broadcast

--- a/runtime/warp.cu
+++ b/runtime/warp.cu
@@ -61,14 +61,14 @@ __device__ void warpReduceTIDX(
     unsigned int reduction_size = block_dim.x;
     unsigned int num_of_warps = reduction_size / WARP_SIZE;
     unsigned int smem_offset = reduce_group_id * num_of_warps;
-
-    block_sync::sync();
+    constexpr bool aligned = true;
+    block_sync::sync<aligned>();
 
     if (is_warp_head) {
       shared_mem[smem_offset + warp_idx] = reduce_val;
     }
 
-    block_sync::sync();
+    block_sync::sync<aligned>();
 
     if (warp_idx == 0) {
       // This assumes num_of_warps will be < 32, meaning < 1024 threads.


### PR DESCRIPTION
Results:
Before this PR: 
On H100, Shared Memory Configuration Size reported by ncu is 8.19 Kbyte and occupancy is 18.75% (6 blocks per sm, 2 warps per block), Bandwidth is 780 GB/s. see #322 
After this PR: occupancy back 100%, achieved: 2700.34 GB/s

Method:
following #351 
1. set aligned to true in warp reduction
2. add template parameter aligned in broadcast
