### PR TITLE
fix FusionReshapeMagicSchedule6_CUDA on H100

### DIFF
--- a/test/test_gpu_view.cpp
+++ b/test/test_gpu_view.cpp
@@ -1741,7 +1741,10 @@ TEST_F(NVFuserTest, FusionReshapeMagicSchedule6_CUDA) {
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
 
-  int x = 128, y = 128;
+  // pointwise heuristics will avoid vectorization if can't achieve a full wave.
+  // use a large size to make sure we can achieve a full wave, e.g. x * y >= 128
+  // * sm_count
+  int x = 1024, y = 1024;
 
   auto tv0 = makeContigTensor(2);
   fusion.addInput(tv0);


### PR DESCRIPTION
trivial fix for [ FAILED ] NVFuserTest.FusionReshapeMagicSchedule6_CUDA at #301 
Afther this PR, all the remaining failures on H100 are validation errors and should be fixed by syncthreads.
