### PR TITLE
Don't skip Ada for some matmul tests

### DIFF
--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -3427,7 +3427,7 @@ TEST_F(NVFuserTest, FusionMatmulSegmenterBasicMatmulStrictCheckTT_CUDA) {
 //   with relaxed result verification
 TEST_F(NVFuserTest, FusionMatmulSegmenterBasicMatmulRelaxedCheck_CUDA) {
   // skip until we have Hopper support
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   const int M = 504, N = 136, K = 2048;
   for (auto layout : kAllSupportedMatmulLayout) {
     auto fusion = std::make_unique<Fusion>();

--- a/test/test_matmul_sass.cpp
+++ b/test/test_matmul_sass.cpp
@@ -137,7 +137,7 @@ TEST_F(MatmulSASSTest, AmpereSanity_CUDA) {
 // test's asserts are based on experimental result of this test itself. In the
 // future, we should use cutlass's kernel as ground truth.
 TEST_F(MatmulSASSTest, AmpereModifiers_CUDA) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
   bool found_LDGSTS = false;


### PR DESCRIPTION
`NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD` check if the current arch satisfy `left <= current < right`, so we should not put `8, 9` on the second arch, but should put `9, 0`.