### PR TITLE
Use `empty_strided_meta` to create meta tensor

### DIFF
--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -635,14 +635,14 @@ void KernelArgumentHolder::pushTensorProxy(
     const std::vector<int64_t>& strides,
     at::ScalarType dtype) {
   TORCH_INTERNAL_ASSERT(strides.size() == sizes.size());
-  auto meta_tensor = at::native::empty_strided_cpu(
+  auto meta_tensor = at::detail::empty_strided_meta(
       sizes,
       strides,
       dtype,
       c10::nullopt,
       c10::Device(c10::DeviceType::Meta, 0),
       c10::nullopt);
-  arguments_.push_back(getAbstractTensorArg(meta_tensor));
+  arguments_.push_back(getAbstractTensorArg(at::Tensor(meta_tensor)));
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
Avoid pytorch debug build assertion at https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/EmptyTensor.cpp#L280.