### PR TITLE
Check concretizations for each Expr

### DIFF
--- a/csrc/ir_base_nodes.h
+++ b/csrc/ir_base_nodes.h
@@ -586,6 +586,11 @@ class TORCH_CUDA_CU_API Expr : public Statement {
   // Get the label for Graphviz
   virtual std::string getGraphvizLabel() const;
 
+  //! Perform assertions on new_val to ensure that it is valid for this
+  //! particular expression. This ensures that invalid values are not propagated
+  //! through the graph during concretization.
+  virtual void checkConcretization(Val* old_val, Val* new_val) const {}
+
  protected:
   // TODO: Protect based on being in kernel container
   void setPredicate(kir::Predicate* predicate);

--- a/csrc/ir_internal_base_nodes.h
+++ b/csrc/ir_internal_base_nodes.h
@@ -188,6 +188,10 @@ class TORCH_CUDA_CU_API IterDomain : public Val {
     return getIterType() == IterType::Broadcast;
   }
 
+  bool isSymbolic() const {
+    return getIterType() == IterType::Symbolic;
+  }
+
   bool isGatherScatter() const {
     return getIterType() == IterType::GatherScatter;
   }

--- a/csrc/ir_internal_nodes.h
+++ b/csrc/ir_internal_nodes.h
@@ -1387,6 +1387,32 @@ class TORCH_CUDA_CU_API LoadStoreOp : public Expr {
   }
 };
 
+//! Represents dropping an IterDomain due to squeezing a broadcast dimension
+class TORCH_CUDA_CU_API SqueezeID : public Expr {
+ public:
+  using Expr::Expr;
+
+  SqueezeID(IrBuilderPasskey passkey, IterDomain* in) : Expr(passkey) {
+    addInput(in);
+  }
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  const char* getOpString() const override {
+    return "SqueezeID";
+  }
+
+  void checkConcretization(Val* old_id, Val* new_id) const override;
+
+  std::string toString(int indent_size = 0) const override;
+
+  std::string toInlineString(int indent_size = 0) const override;
+
+  IterDomain* in() const {
+    return input(0)->as<IterDomain>();
+  }
+};
+
 //! Representation a split on an IterDomain by "factor"
 //! inner_split dictates if the factor section of the split should be inside the
 //! remainer or outside.

--- a/csrc/ir_nodes.cpp
+++ b/csrc/ir_nodes.cpp
@@ -3252,6 +3252,40 @@ void TensorDomain::setAllocationDomain(
   contiguity_ = std::move(new_contiguity);
 }
 
+void SqueezeID::checkConcretization(Val* old_val, Val* new_val) const {
+  Expr::checkConcretization(old_val, new_val);
+  if (auto new_id = dynamic_cast<IterDomain*>(new_val)) {
+    TORCH_CHECK(
+        new_id->isBroadcast(),
+        "SqueezeID input ",
+        old_val->toString(),
+        " must concretize to Broadcast IterDomain but found ",
+        new_id->toString());
+    // TODO: It is currently difficult to check expanded_extent at this stage
+    // since the expanded extent may be non-constant but provably 1, so it is
+    // left unchecked. What may be needed is a more powerful framework for
+    // proving properties like this, see
+    // https://github.com/NVIDIA/Fuser/issues/320
+  } else {
+    TORCH_CHECK(
+        new_val->isA<IterDomain>(),
+        "SqueezeID input must concretize to IterDomain. Found ",
+        new_val->toString());
+  }
+}
+
+std::string SqueezeID::toString(int indent_size) const {
+  return toInlineString(indent_size) + "\n";
+}
+
+std::string SqueezeID::toInlineString(int indent_size) const {
+  std::stringstream ss;
+  ss << "SqueezeID: " << in()->toString();
+  return ss.str();
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(SqueezeID)
+
 Split::Split(
     IrBuilderPasskey passkey,
     IterDomain* outer,

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -192,12 +192,20 @@ TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
     auto id = x_dom[idx];
     if (to_squeeze[idx]) {
       TORCH_CHECK(
-          id->isBroadcast(), "Can not squeeze non-broadcasting dimension(s).");
+          id->isBroadcast() || id->isSymbolic(),
+          "Squeeze dimension should be either Symbolic or Broadcast. Found ",
+          id->getIterType());
       TORCH_CHECK(
           !id->hasExpandedExtent(), "Can not squeeze expanded dimension(s).");
-      TORCH_CHECK(
-          id->extent()->isOneInt(),
-          "Can not squeeze dimension(s) with size != 1.");
+      if (id->isBroadcast()) {
+        // Check concrete broadcast extent here. For Symbolic inputs, this check
+        // will be deferred to concretization. See dynamic_transform.cpp
+        TORCH_CHECK(
+            id->extent()->isOneInt(),
+            "Can not squeeze dimension(s) with size != 1.");
+      }
+      // Create a SqueezeID op that drops this dimension
+      IrBuilder::create<SqueezeID>(x->container(), id);
     } else {
       out_domain.push_back(id->cloneWithoutRFactor());
     }


### PR DESCRIPTION
When concretizing `Val* old_val` with `Val* new_val`, we should check that it is valid at each location it is used. This is best done by a check that's internal to each `Expr`. This PR introduces a new method, `checkConcretization(Val* old_val, Val* new_val)` which will be called for all `uses()` of replaced `Val`s during concretization.

Currently, this is only used to check that concretized inputs to `SqueezeOp` have squeezed IDs that are of type `Broadcast`. To do so, this PR introduces an `IterDomain` op called `SqueezeID` in order to track this operation, since determining which IDs get squeezed by inspecting the graph is slightly complicated. The `SqueezeID` op checks the concretized `IterType` to ensure we do not silently concretize to an invalid `Fusion` that squeezes an `Iteration` domain.