### PR TITLE
Periodically clear c10 memory allocator in nvfuser_tests

### DIFF
--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -38,6 +38,13 @@ int64_t prime_number(int64_t i) {
   return p.at(i);
 }
 
+void maybeEmptyAllocator() {
+  static int calls = 0;
+  if (++calls % 100 == 0) {
+    c10::cuda::CUDACachingAllocator::emptyCache();
+  }
+}
+
 void assertCUDAKernel(Fusion* fusion, const std::string& expected_kernel) {
   const std::string actual_kernel =
       "\n" + codegen::generateCudaKernel(GpuLower(fusion).kernel());

--- a/test/utils.h
+++ b/test/utils.h
@@ -39,12 +39,7 @@ inline torch::jit::Stack createStack(std::vector<at::Tensor>&& list) {
 }
 
 //! Clear the allocator occasionally
-void maybeEmptyAllocator() {
-  static int calls = 0;
-  if (++calls % 100 == 0) {
-    c10::cuda::CUDACachingAllocator::emptyCache();
-  }
-}
+void maybeEmptyAllocator();
 
 // Make a tensor that is known to be fully contiguous of dimensionality=ndims,
 // but unknown sizes


### PR DESCRIPTION
The `c10::cuda::CUDACachingAllocator` tends to accumulate memory leading to >20GB usage when running `nvfuser_tests`. This causes OOM on some CI jobs. This PR just empties the allocator every time 100 tensors have been allocated using the `make*Tensor` functions in `test/utils.h`.