### PR TITLE
Use `bitwise_right_shift` in python frontend

### DIFF
--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -835,7 +835,7 @@ void initNvFuserPythonBindings(PyObject* module) {
   NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_or", bitwise_or)
   NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_xor", bitwise_xor)
   NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_left_shift", bitwise_left_shift)
-  NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_right_shift", bitwise_left_shift)
+  NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_right_shift", bitwise_right_shift)
 #undef NVFUSER_PYTHON_BINDING_BINARY_OP
 
 #define NVFUSER_PYTHON_BINDING_BINARY_OP_SPECIAL(py_op, op_str, op_name)       \
@@ -919,7 +919,7 @@ void initNvFuserPythonBindings(PyObject* module) {
   NVFUSER_PYTHON_BINDING_BINARY_OP_SPECIAL(
       "__lshift__", "bitwise_left_shift", bitwise_left_shift)
   NVFUSER_PYTHON_BINDING_BINARY_OP_SPECIAL(
-      "__rshift__", "bitwise_right_shift", bitwise_left_shift)
+      "__rshift__", "bitwise_right_shift", bitwise_right_shift)
   // In PyTorch, __div__ (//) and __truediv__ (/) are different.
   // When applied to integer-dtype arguments, they do as expected, returning
   // integer and float outputs, respectively. When applied to two floating-type

--- a/csrc/serde/fusion_record_serde.cpp
+++ b/csrc/serde/fusion_record_serde.cpp
@@ -847,7 +847,7 @@ void RecordFunctorFactory::setupFunctionMaps() {
   NVFUSER_BINARY_TV_OP("bitwise_or", bitwise_or)
   NVFUSER_BINARY_TV_OP("bitwise_xor", bitwise_xor)
   NVFUSER_BINARY_TV_OP("bitwise_left_shift", bitwise_left_shift)
-  NVFUSER_BINARY_TV_OP("bitwise_right_shift", bitwise_left_shift)
+  NVFUSER_BINARY_TV_OP("bitwise_right_shift", bitwise_right_shift)
 
   NVFUSER_BINARY_TV_ALPHA_OP("add_alpha", add_alpha)
   NVFUSER_BINARY_TV_ALPHA_OP("sub_alpha", sub_alpha)

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2228,6 +2228,21 @@ class TestNvFuserFrontend(TestCase):
         )
         self.assertEqual(nvf_out[1], torch.true_divide(inputs[0], inputs[1]))
 
+    def test_right_shift_arithmetic(self):
+        inputs = [
+            torch.tensor([-2147483648, 1073741824], dtype=torch.int32, device="cuda")
+        ]
+
+        def fusion_func(fd: FusionDefinition):
+            t0 = fd.from_pytorch(inputs[0])
+            c0 = fd.define_constant(3)
+            t1 = fd.ops.bitwise_right_shift(t0, c0)
+            fd.add_output(t1)
+
+        nvf_out1, _ = self.exec_nvfuser(fusion_func, inputs)
+        eager_out = torch.bitwise_right_shift(inputs[0], 3)
+        self.assertEqual(eager_out, nvf_out1[0])
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Currently, we're calling the cpp `bitwise_left_shift` from the frontend.