### PR TITLE
Add binary op gcd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ nvfuser/cmake
 
 # debugging temporaries
 *.log
+foo.bin

--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <iostream>
 #include <variant>
+#include <numeric>
 
 namespace nvfuser {
 
@@ -290,6 +291,10 @@ inline EvaluatorValue max(const EvaluatorValue& a, const EvaluatorValue& b) {
 
 inline EvaluatorValue min(const EvaluatorValue& a, const EvaluatorValue& b) {
   return EvaluatorValue((a < b).as<bool>() ? a : b);
+}
+
+inline EvaluatorValue gcd(const EvaluatorValue& a, const EvaluatorValue& b) {
+  return EvaluatorValue(std::gcd(a.as<int64_t>(), b.as<int64_t>()));
 }
 
 inline EvaluatorValue notExpr(const EvaluatorValue& a) {

--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -12,8 +12,8 @@
 #include <c10/util/variant.h>
 #include <cmath>
 #include <iostream>
-#include <variant>
 #include <numeric>
+#include <variant>
 
 namespace nvfuser {
 

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -565,6 +565,9 @@ void NaiveValueMachine::runBinaryOp(int index) {
     case BinaryOpType::Min:
       dest = lhs < rhs ? lhs : rhs;
       break;
+    case BinaryOpType::Gcd:
+      dest = gcd(lhs, rhs);
+      break;
     default:
       TORCH_CHECK(!"Unexpected operator type");
   }

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -196,6 +196,10 @@ Val* IrBuilder::minExpr(Val* lhs, Val* rhs) {
   return newArithmeticExpr(BinaryOpType::Min, lhs, rhs);
 }
 
+Val* IrBuilder::gcdExpr(Val* lhs, Val* rhs) {
+  return newArithmeticExpr(BinaryOpType::Gcd, lhs, rhs);
+}
+
 Val* SimplifyingIrBuilder::negExpr(Val* val) {
   if (val->isZeroInt()) {
     return val->container()->zeroVal();
@@ -467,6 +471,19 @@ Val* SimplifyingIrBuilder::minExpr(Val* lhs, Val* rhs) {
       rhs,
       [](Val* lhs, Val* rhs) { return IrBuilder::minExpr(lhs, rhs); },
       [](int64_t lhs, int64_t rhs) { return std::min(lhs, rhs); });
+}
+
+Val* SimplifyingIrBuilder::gcdExpr(Val* lhs, Val* rhs) {
+  if (lhs->isZeroInt()) {
+    return rhs;
+  }
+  if (rhs->isZeroInt()) {
+    return lhs;
+  }
+  if (lhs->isOneInt() || rhs->isOneInt()) {
+    return lhs->container()->oneVal();
+  }
+  return IrBuilder::gcdExpr(lhs, rhs);
 }
 
 Val* SimplifyingIrBuilder::whereExpr(Val* pred, Val* lhs, Val* rhs) {

--- a/csrc/ir/builder.h
+++ b/csrc/ir/builder.h
@@ -79,6 +79,7 @@ class TORCH_CUDA_CU_API IrBuilder {
   static Val* modExpr(Val* lhs, Val* rhs);
   static Val* maxExpr(Val* lhs, Val* rhs);
   static Val* minExpr(Val* lhs, Val* rhs);
+  static Val* gcdExpr(Val* lhs, Val* rhs);
 
   // Ternary operations
   static Val* whereExpr(Val* pred, Val* lhs, Val* rhs);
@@ -149,6 +150,7 @@ class TORCH_CUDA_CU_API SimplifyingIrBuilder : public IrBuilder {
   static Bool* andExpr(Val* lhs, Val* rhs);
   static Val* maxExpr(Val* lhs, Val* rhs);
   static Val* minExpr(Val* lhs, Val* rhs);
+  static Val* gcdExpr(Val* lhs, Val* rhs);
 
   static Val* whereExpr(Val* pred, Val* lhs, Val* rhs);
 };

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -531,6 +531,9 @@ std::vector<EvaluatorValue> BinaryOp::evaluate(
     case BinaryOpType::Min:
       return {min(lhs, rhs)};
       break;
+    case BinaryOpType::Gcd:
+      return {gcd(lhs, rhs)};
+      break;
     default:
       TORCH_CHECK(
           false,

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -848,7 +848,7 @@ NVFUSER_DEFINE_BITWISE_OP(bitwise_or, Or)
 NVFUSER_DEFINE_BITWISE_OP(bitwise_xor, Xor)
 #undef NVFUSER_DEFINE_BITWISE_OP
 
-#define NVFUSER_DEFINE_BITWISE_SHIFT_OP(op_name, op_type)                 \
+#define NVFUSER_DEFINE_INT_ONLY_OP(op_name, op_type)                      \
   Val* op_name(Val* v1, Val* v2) {                                        \
     TORCH_CHECK(                                                          \
         isIntegralType(v1->dtype()) && isIntegralType(v2->dtype()),       \
@@ -890,9 +890,10 @@ NVFUSER_DEFINE_BITWISE_OP(bitwise_xor, Xor)
         BinaryOpType::op_type, v1, v2, TypePromotion::default_op_config); \
   }
 
-NVFUSER_DEFINE_BITWISE_SHIFT_OP(bitwise_left_shift, Lshift)
-NVFUSER_DEFINE_BITWISE_SHIFT_OP(bitwise_right_shift, Rshift)
-#undef NVFUSER_DEFINE_BITWISE_SHIFT_OP
+NVFUSER_DEFINE_INT_ONLY_OP(bitwise_left_shift, Lshift)
+NVFUSER_DEFINE_INT_ONLY_OP(bitwise_right_shift, Rshift)
+NVFUSER_DEFINE_INT_ONLY_OP(gcd, Gcd)
+#undef NVFUSER_DEFINE_INT_ONLY_OP
 
 #define NVFUSER_DEFINE_BINARY_COMPARE_OP(op_name, op_type)                   \
   Val* op_name(Val* v1, Val* v2) {                                           \

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -487,6 +487,11 @@ TORCH_CUDA_CU_API Val* bitwise_xor(Val* v1, Val* v2);
 TORCH_CUDA_CU_API TensorView* bitwise_xor(TensorView* v1, Val* v2);
 TORCH_CUDA_CU_API TensorView* bitwise_xor(Val* v1, TensorView* v2);
 TORCH_CUDA_CU_API TensorView* bitwise_xor(TensorView* v1, TensorView* v2);
+// gcd
+TORCH_CUDA_CU_API Val* gcd(Val* v1, Val* v2);
+TORCH_CUDA_CU_API TensorView* gcd(TensorView* v1, Val* v2);
+TORCH_CUDA_CU_API TensorView* gcd(Val* v1, TensorView* v2);
+TORCH_CUDA_CU_API TensorView* gcd(TensorView* v1, TensorView* v2);
 // Logical binary ops
 // eq
 TORCH_CUDA_CU_API Val* eq(Val* v1, Val* v2);

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -836,6 +836,7 @@ void initNvFuserPythonBindings(PyObject* module) {
   NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_xor", bitwise_xor)
   NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_left_shift", bitwise_left_shift)
   NVFUSER_PYTHON_BINDING_BINARY_OP("bitwise_right_shift", bitwise_right_shift)
+  NVFUSER_PYTHON_BINDING_BINARY_OP("gcd", gcd)
 #undef NVFUSER_PYTHON_BINDING_BINARY_OP
 
 #define NVFUSER_PYTHON_BINDING_BINARY_OP_SPECIAL(py_op, op_str, op_name)       \

--- a/csrc/serde/fusion_record_serde.cpp
+++ b/csrc/serde/fusion_record_serde.cpp
@@ -848,6 +848,7 @@ void RecordFunctorFactory::setupFunctionMaps() {
   NVFUSER_BINARY_TV_OP("bitwise_xor", bitwise_xor)
   NVFUSER_BINARY_TV_OP("bitwise_left_shift", bitwise_left_shift)
   NVFUSER_BINARY_TV_OP("bitwise_right_shift", bitwise_right_shift)
+  NVFUSER_BINARY_TV_OP("gcd", gcd)
 
   NVFUSER_BINARY_TV_ALPHA_OP("add_alpha", add_alpha)
   NVFUSER_BINARY_TV_ALPHA_OP("sub_alpha", sub_alpha)

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -405,6 +405,8 @@ static const char* binary_op_type2string(BinaryOpType t) {
       return "lshift";
     case BinaryOpType::Rshift:
       return "rshift";
+    case BinaryOpType::Gcd:
+      return "gcd";
 
     // Logical Ops
     case BinaryOpType::And:

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -396,6 +396,7 @@ enum class BinaryOpType {
   CeilDiv,
   Lshift,
   Rshift,
+  Gcd,
 
   // Logical Ops
   // Int operations, leave position of Mod as first logical op see

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2256,9 +2256,7 @@ class TestNvFuserFrontend(TestCase):
             fd.add_output(t2)
 
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
-        self.assertEqual(
-            nvf_out[0], torch.gcd(inputs[0], inputs[1])
-        )
+        self.assertEqual(nvf_out[0], torch.gcd(inputs[0], inputs[1]))
 
 
 if __name__ == "__main__":

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2243,6 +2243,23 @@ class TestNvFuserFrontend(TestCase):
         eager_out = torch.bitwise_right_shift(inputs[0], 3)
         self.assertEqual(eager_out, nvf_out1[0])
 
+    def test_gcd(self):
+        inputs = [
+            torch.testing.make_tensor(1024, device="cuda", dtype=torch.long),
+            torch.testing.make_tensor(1024, device="cuda", dtype=torch.long),
+        ]
+
+        def fusion_func(fd: FusionDefinition):
+            t0 = fd.from_pytorch(inputs[0])
+            t1 = fd.from_pytorch(inputs[1])
+            t2 = fd.ops.gcd(t0, t1)
+            fd.add_output(t2)
+
+        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
+        self.assertEqual(
+            nvf_out[0], torch.gcd(inputs[0], inputs[1])
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/runtime/helpers.cu
+++ b/runtime/helpers.cu
@@ -369,6 +369,16 @@ __device__ int64_t signbit(int64_t a) {
   return a < 0;
 }
 
+// Reference:
+// https://github.com/llvm/llvm-project/blob/273303ad66a32e5e599bef5ee18c3a9f589e530d/compiler-rt/lib/xray/xray_utils.h#L57-L59
+__device__ int64_t gcd(int64_t a, int64_t b) {
+  return (b == 0) ? a : gcd(b, a % b);
+}
+
+__device__ int gcd(int a, int b) {
+  return (b == 0) ? a : gcd(b, a % b);
+}
+
 template <int size, int align = size>
 struct alignas(align) TypelessData {
   int8_t data[size];

--- a/runtime/helpers.cu
+++ b/runtime/helpers.cu
@@ -370,13 +370,18 @@ __device__ int64_t signbit(int64_t a) {
 }
 
 // Reference:
-// https://github.com/llvm/llvm-project/blob/273303ad66a32e5e599bef5ee18c3a9f589e530d/compiler-rt/lib/xray/xray_utils.h#L57-L59
-__device__ int64_t gcd(int64_t a, int64_t b) {
-  return (b == 0) ? a : gcd(b, a % b);
-}
-
-__device__ int gcd(int a, int b) {
-  return (b == 0) ? a : gcd(b, a % b);
+// https://en.wikipedia.org/wiki/Euclidean_algorithm#Implementations
+// https://github.com/pytorch/pytorch/blob/c9f4f01981fd73fcc7c27676cc50230cd1b5bc22/aten/src/ATen/native/Math.h#L1232
+template <typename T>
+__device__ T gcd(T a, T b) {
+  a = abs(a);
+  b = abs(b);
+  while (b != 0) {
+    auto t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
 }
 
 template <int size, int align = size>

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -3615,6 +3615,16 @@ TEST_F(NVFuserTest, FusionBinaryOps_CUDA) {
       OpTuple{at::mul, BinaryOpType::Mul, "mul"},
       OpTuple{at::pow, BinaryOpType::Pow, "pow"}};
 
+  std::vector<OpTuple> int_only_ops{
+      OpTuple{at::gcd, BinaryOpType::Gcd, "gcd"},
+      OpTuple{at::bitwise_left_shift, BinaryOpType::Lshift, "bitwise_left_shift"},
+      OpTuple{at::bitwise_right_shift, BinaryOpType::Rshift, "bitwise_right_shift"}};
+
+  std::vector<OpTuple> int_and_bool_ops{
+      OpTuple{at::bitwise_and, BinaryOpType::And, "bitwise_and"},
+      OpTuple{at::bitwise_or, BinaryOpType::Or, "bitwise_or"},
+      OpTuple{at::bitwise_xor, BinaryOpType::Xor, "bitwise_xor"}};
+
   // The following ops has no complex support in eager mode
   std::vector<OpTuple> math_ops_without_complex{
       OpTuple{at::atan2, BinaryOpType::Atan2, "atan2"},
@@ -3656,6 +3666,22 @@ TEST_F(NVFuserTest, FusionBinaryOps_CUDA) {
           enabled_math_ops.end(),
           math_ops_without_complex.begin(),
           math_ops_without_complex.end());
+    }
+    if (isIntegralType(dtype)) {
+      enabled_math_ops.insert(
+          enabled_math_ops.end(),
+          int_only_ops.begin(),
+          int_only_ops.end());
+      enabled_math_ops.insert(
+          enabled_math_ops.end(),
+          int_and_bool_ops.begin(),
+          int_and_bool_ops.end());
+    }
+    if (dtype == DataType::Bool) {
+      enabled_math_ops.insert(
+          enabled_math_ops.end(),
+          int_and_bool_ops.begin(),
+          int_and_bool_ops.end());
     }
     std::for_each(
         enabled_math_ops.begin(), enabled_math_ops.end(), [&](OpTuple& op) {


### PR DESCRIPTION
The main purpose for adding this op is to use it to fix https://github.com/NVIDIA/Fuser/issues/413, but since this op is supported by PyTorch, so why not expose it to the user?