### PR TITLE
Matmul scheduler - utils refactoring

### DIFF
--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -82,6 +82,9 @@ struct MmaOptions {
   //! TODO: NN is currently not supported on pre-Turing and Hopper wgmma
   enum class MmaLayout { NT = 0, TT, TN, NN };
 
+  //! Named descriptors of domains in matmul
+  enum class MmaDomains { M = 0, N, K };
+
   //! Utility to annotate which input of mma this option struct describes
   enum class Operand { Accumulator = 0, A, B };
 

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -3377,7 +3377,19 @@ TEST_F(NVFuserTest, FusionMatmulSegmenterBasicMatmulStrictCheckTT_CUDA) {
   TORCH_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
-      "input layout from test and MmaOp do not match");
+      "the MmaOp layout of Ampere MMA must be always TN");
+
+  const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
+  TORCH_CHECK(
+      fusion_layout.isValid(),
+      "failed to get decide matmul layout through fusion definition");
+  TORCH_CHECK(
+      fusion_layout.getData() == layout,
+      "mismatch between test layout (",
+      toString(layout),
+      ") and layout inferred from fusion definition (",
+      toString(fusion_layout.getData()),
+      ")");
 
   at::Tensor t0 = matmulAtInput(M, N, K, layout, TensorMatmulPos::A, at::kHalf);
   at::Tensor t1 = matmulAtInput(M, N, K, layout, TensorMatmulPos::B, at::kHalf);
@@ -3428,7 +3440,19 @@ TEST_F(NVFuserTest, FusionMatmulSegmenterBasicMatmulRelaxedCheck_CUDA) {
     TORCH_CHECK(
         MatmulLayout::TN ==
             ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
-        "input layout from test and MmaOp do not match");
+        "the MmaOp layout of Ampere MMA must be always TN");
+
+    const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
+    TORCH_CHECK(
+        fusion_layout.isValid(),
+        "failed to get decide matmul layout through fusion definition");
+    TORCH_CHECK(
+        fusion_layout.getData() == layout,
+        "mismatch between test layout (",
+        toString(layout),
+        ") and layout inferred from fusion definition (",
+        toString(fusion_layout.getData()),
+        ")");
 
     at::Tensor t0 =
         matmulAtInput(M, N, K, layout, TensorMatmulPos::A, at::kHalf);
@@ -3450,13 +3474,7 @@ TEST_F(NVFuserTest, FusionMatmulSegmenterBasicMatmulRelaxedCheck_CUDA) {
             ScheduleHeuristic::Matmul),
         "matmul scheduler was not used to handle prepared fusion");
 
-    // NOTE: checking with lower expectations for relative/absolute error
-#if 1
     TORCH_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
-#else
-    testValidate(
-        executor_cache.fusion(), outputs, {t0, t1}, {tref}, __LINE__, __FILE__);
-#endif
   }
 }
 


### PR DESCRIPTION
The scope of the PR:

- replace hand-written topology checks with tools that rely on computeAt map data, this includes:
  - tool for accessing problem shapes for heuristics,
  - tool for inferring the layout of matmul,
- update existing matmul schedule tests to verify:
  - `MmaOp` layout, for Ampere should TN
  - inferred from input data layout, should match layout defined as test parameter,