### PR TITLE
Delete an unnecessary copy constructor

### DIFF
--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -75,9 +75,6 @@ class TORCH_CUDA_CU_API DynamicTransformInitialInfo {
     return scalar_inputs_affecting_concretization_;
   }
 
-  DynamicTransformInitialInfo(const DynamicTransformInitialInfo& other) =
-      default;
-
  protected:
   //! Holds the set of scalar fusion inputs that affect concretization.
   std::unordered_set<size_t> scalar_inputs_affecting_concretization_;


### PR DESCRIPTION
Declaring a copy constructor should come with a copy constructor as well. Compilation with clang resulted in:

```
error: definition of implicit copy assignment operator for
'DynamicTransformInitialInfo' is deprecated because it has a
user-declared copy constructor [-Werror,-Wdeprecated-copy]
  DynamicTransformInitialInfo(const DynamicTransformInitialInfo& other)
  =
    ^
    /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/optional:789:21:
    note: in implicit copy assignment operator for
    'nvfuser::DynamicTransformInitialInfo' first required here
                this->_M_get() = std::forward<_Up>(__u);
```

