### PR TITLE
Revert "Replace initializeCudaContext() with cudaFree(nullptr) (#430)"

### DIFF
--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -1374,14 +1374,7 @@ std::tuple<NvrtcFunction, std::string, std::vector<char>> getCompiledKernel(
     bool return_compiled_binary) {
   FUSER_PERF_SCOPE("executor_utils::NVRTC");
 
-  int device = 0;
-  cudaGetDevice(&device);
-  if (!at::detail::getCUDAHooks().hasPrimaryContext(device)) {
-    // CUDA>=12 creates a context when cudaSetDevice is called. However, before
-    // cu12, that context is not necessarily created. In that case, we create
-    // one here implicitly. See https://github.com/NVIDIA/Fuser/issues/429
-    cudaFree(nullptr);
-  }
+  at::cuda::jit::initializeCudaContext();
 
   const auto prop = at::cuda::getCurrentDeviceProperties();
 


### PR DESCRIPTION
This reverts commit 0d55f6c20f81ad03cfd98bff4fd307199ca55d82.

I merged #430 too hastily. There are many failing tests now due to invalid context.