### PR TITLE
Matmul scheduler - relax fusion inputs/outputs order

### DIFF
--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -11,6 +11,15 @@
 
 namespace nvfuser {
 
+//! Named descriptors of domains in matmul
+enum class MatmulDomain { M = 0, N, K };
+
+//! Named descriptors of TensorView roles in fusion
+enum class MatmulRole { MMA_INPUT_A = 0, MMA_INPUT_B, MMA_OUTPUT };
+
+//! The expected number of occurances of core TensorView roles in fusion
+static constexpr size_t MATMUL_CORE_ROLES_EXPECTED_COUNT = 1;
+
 //! Utility data structure for recording gemm tiles
 struct GemmTile {
   int m, n, k;
@@ -81,9 +90,6 @@ struct MmaOptions {
   //! NN : K,M X N,K -> M,N
   //! TODO: NN is currently not supported on pre-Turing and Hopper wgmma
   enum class MmaLayout { NT = 0, TT, TN, NN };
-
-  //! Named descriptors of domains in matmul
-  enum class MmaDomains { M = 0, N, K };
 
   //! Utility to annotate which input of mma this option struct describes
   enum class Operand { Accumulator = 0, A, B };

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -3482,6 +3482,69 @@ TEST_F(NVFuserTest, FusionMatmulSegmenterBasicMatmulRelaxedCheck_CUDA) {
   }
 }
 
+// Matmul test that reslies on segmenter for 'C = A x B' fusion, for Ampere
+//  MMA first input is passed as second fusion parameter.
+//  MMA second input is passed as first fusion parameter.
+TEST_F(NVFuserTest, FusionMatmulSegmenterBasicMatmulInputShuffledTT_CUDA) {
+  // skip until we have Hopper support
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
+  const int M = 504, N = 136, K = 2048;
+  const auto layout = MmaOptions::MmaLayout::TT;
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeContigTensor(2, DataType::Half);
+  auto tv1 = makeContigTensor(2, DataType::Half);
+  auto tv2 = matmul(tv0, tv1, layout, true);
+
+  fusion->addInput(tv1);
+  fusion->addInput(tv0);
+  fusion->addOutput(tv2);
+
+  TORCH_CHECK(
+      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      "matmul fusion must have at least one MmaOp");
+  TORCH_CHECK(
+      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      "input layout has not be set for MmaOp");
+  TORCH_CHECK(
+      MatmulLayout::TN ==
+          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+      "the MmaOp layout of Ampere MMA must be always TN");
+
+  const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
+  TORCH_CHECK(
+      fusion_layout.isValid(),
+      "failed to get decide matmul layout through fusion definition");
+  TORCH_CHECK(
+      fusion_layout.getData() == layout,
+      "mismatch between test layout (",
+      toString(layout),
+      ") and layout inferred from fusion definition (",
+      toString(fusion_layout.getData()),
+      ")");
+
+  at::Tensor t0 = matmulAtInput(M, N, K, layout, TensorMatmulPos::A, at::kHalf);
+  at::Tensor t1 = matmulAtInput(M, N, K, layout, TensorMatmulPos::B, at::kHalf);
+  at::Tensor tref = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
+
+  FusionExecutorCache executor_cache(std::move(fusion));
+
+  auto outputs = executor_cache.runFusionWithInputs({t1, t0});
+
+  TORCH_CHECK(
+      !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
+      "fusion got segmented, expected to match whole fusion with single segment");
+
+  TORCH_CHECK(
+      isSchedulerInUse(
+          executor_cache.getMostRecentKernelRuntime(),
+          ScheduleHeuristic::Matmul),
+      "matmul scheduler was not used to handle prepared fusion");
+
+  TORCH_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
+}
+
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD
 
 } // namespace nvfuser


### PR DESCRIPTION
The scope of this PR:
- relax requirements for fusion inputs / outputs ordering
  - currently: fusion 1st and 2nd input are mapped to MMA 1st and 2nd input, first fusion output is handled as MMA output consumer
  - new: fusion inputs'/outputs' definitions are checked and mapped to predefined roles

These changes will enable simplified implementation of compile-time checks when new types of epilogues are introduced. 