### PR TITLE
Use `ArgumentBuilder` and `genCall` to cleanup codegen of `cp.async` and `ldmatrix`

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -612,8 +612,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     auto dtype = ldst->in()->getDataType().value();
 
     bool is_transpose = (ldst->opType() == LoadStoreOpType::LdMatrixTranspose);
-    std::string name = (is_transpose ? "Turing::ldMatrixT"
-                                     : "Turing::ldMatrix");
+    std::string name =
+        (is_transpose ? "Turing::ldMatrixT" : "Turing::ldMatrix");
 
     ArgumentBuilder func_args;
     func_args.arg(genVectorPointer(ldst->out(), dtype, vector_word_size));

--- a/runtime/memory.cu
+++ b/runtime/memory.cu
@@ -77,12 +77,12 @@ DEVICE_INLINE void adjustPartialLdMatrixAddrInTuring(unsigned& addr_in_byte) {
 // warp.
 
 template <typename T>
-DEVICE_INLINE void ldMatrix(Array<T, 4, 4>& out, unsigned addr) {
+DEVICE_INLINE void ldMatrix(Array<T, 4, 4>* out, unsigned addr) {
   static_assert(sizeof(T) == 2);
-  uint2& val = reinterpret_cast<uint2&>(out);
+  uint2* val = reinterpret_cast<uint2*>(out);
   util::adjustPartialLdMatrixAddrInTuring(addr);
   asm volatile("ldmatrix.sync.aligned.x2.m8n8.shared.b16 {%0,%1}, [%2];"
-               : "=r"(val.x), "=r"(val.y)
+               : "=r"(val->x), "=r"(val->y)
                : "r"(addr));
 }
 
@@ -90,31 +90,31 @@ DEVICE_INLINE void ldMatrix(Array<T, 4, 4>& out, unsigned addr) {
 // transpose) so threads will hold 2 values down a column (instead of the
 // previous instruction that's across a row).
 template <typename T>
-DEVICE_INLINE void ldMatrixT(Array<T, 4, 4>& out, unsigned addr) {
+DEVICE_INLINE void ldMatrixT(Array<T, 4, 4>* out, unsigned addr) {
   static_assert(sizeof(T) == 2);
-  uint2& val = reinterpret_cast<uint2&>(out);
+  uint2* val = reinterpret_cast<uint2*>(out);
   util::adjustPartialLdMatrixAddrInTuring(addr);
   asm volatile("ldmatrix.sync.aligned.x2.trans.m8n8.shared.b16 {%0,%1}, [%2];"
-               : "=r"(val.x), "=r"(val.y)
+               : "=r"(val->x), "=r"(val->y)
                : "r"(addr));
 }
 
 template <typename T>
-DEVICE_INLINE void ldMatrix(Array<T, 8, 8>& out, unsigned addr) {
+DEVICE_INLINE void ldMatrix(Array<T, 8, 8>* out, unsigned addr) {
   static_assert(sizeof(T) == 2);
-  uint4& val = reinterpret_cast<uint4&>(out);
+  uint4* val = reinterpret_cast<uint4*>(out);
   asm volatile("ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0,%1,%2,%3}, [%4];"
-               : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)
+               : "=r"(val->x), "=r"(val->y), "=r"(val->z), "=r"(val->w)
                : "r"(addr));
 }
 
 template <typename T>
-DEVICE_INLINE void ldMatrixT(Array<T, 8, 8>& out, unsigned addr) {
+DEVICE_INLINE void ldMatrixT(Array<T, 8, 8>* out, unsigned addr) {
   static_assert(sizeof(T) == 2);
-  uint4& val = reinterpret_cast<uint4&>(out);
+  uint4* val = reinterpret_cast<uint4*>(out);
   asm volatile(
       "ldmatrix.sync.aligned.x4.trans.m8n8.shared.b16 {%0,%1,%2,%3}, [%4];"
-      : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)
+      : "=r"(val->x), "=r"(val->y), "=r"(val->z), "=r"(val->w)
       : "r"(addr));
 }
 

--- a/test/test_loop_rotation.cpp
+++ b/test/test_loop_rotation.cpp
@@ -590,7 +590,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     b5 = (i2 + nvfuser_zero) < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-      Ampere::cpAsyncCa<float, 1>((i4 + (4 * i6)),(ptr3 + (T0.stride[1] * (i6 + nvfuser_zero))),b5);
+      Ampere::cpAsyncCa<float, 1>((i4 + (4 * i6)), (ptr3 + (T0.stride[1] * (i6 + nvfuser_zero))), b5);
     }
     Ampere::cpAsyncCommit();
   }
@@ -615,7 +615,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     b13 = i9 < T0.size[0];
     #pragma unroll
     for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-      Ampere::cpAsyncCa<float, 1>((i10 + (4 * i6)),(ptr8 + (T0.stride[1] * (i6 + nvfuser_zero))),b13);
+      Ampere::cpAsyncCa<float, 1>((i10 + (4 * i6)), (ptr8 + (T0.stride[1] * (i6 + nvfuser_zero))), b13);
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     Ampere::cpAsyncCommit();


### PR DESCRIPTION
There should be no behavioral change, just make `codegen.cpp` more readable.