### PR TITLE
Cleanups to FusionExecutorCache and DynamicFusionConcretizationInfo

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -679,10 +679,10 @@ void DynamicTransform::concretizeFusion(
 size_t DynamicTransformConcretizationInfo::hash() const {
   size_t hash = 0;
   for (const auto& [tv, view_result] : getReshapeTransforms()) {
-    hash_combine(hash, view_result.hash());
+    hashCombine(hash, view_result.hash());
   }
   for (const auto& [id, iter_type] : getResizeIterTypes()) {
-    hash_combine(hash, (size_t)iter_type);
+    hashCombine(hash, (size_t)iter_type);
   }
   return hash;
 }

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -36,6 +36,12 @@ DynamicTransformInitialInfo DynamicTransformInitialInfo::clone(
       cloned_info.dynamic_resizes_.push_back(ir_cloner.clone(op));
     }
   }
+  cloned_info.root_dynamic_vals_.reserve(root_dynamic_vals_.size());
+  for (const auto v : root_dynamic_vals_) {
+    if (v) {
+      cloned_info.root_dynamic_vals_.insert(ir_cloner.clone(v));
+    }
+  }
   return cloned_info;
 }
 

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -9,6 +9,7 @@
 #include <dynamic_transform.h>
 #include <executor_kernel_arg.h>
 #include <expr_evaluator.h>
+#include <fusion.h>
 #include <ir/cloner.h>
 #include <ir/utils.h>
 #include <ops/utils.h>
@@ -49,11 +50,11 @@ std::string DynamicTransformInitialInfo::toString() const {
   std::stringstream ss;
   ss << "DynamicTransformInitialInfo\n";
   std::string indent = "  ";
-  ss << indent << "Dynamic reshapes:\n";
+  ss << indent << "Dynamic reshaped TensorViews:\n";
   for (const auto& op : dynamic_reshapes_) {
     ss << indent << indent << op->toString() << "\n";
   }
-  ss << indent << "Dynamic resizes:\n";
+  ss << indent << "Dynamic resized IterDomains:\n";
   for (const auto& op : dynamic_resizes_) {
     ss << indent << indent << op->toString() << "\n";
   }
@@ -76,18 +77,6 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
     traverseTo(fusion, fusion->getTerminatingOutputs(), false, false);
 
     finalizeDynamicVals();
-
-    // initial_info_ provides a set of Vals that are used for concretization.
-    // Here we check which scalar inputs, if any, correspond to any of those
-    // Vals. These will be the inputs that are explicitly used in the cache ID
-    // for KernelArgumentHolder.
-    auto dyn_vals = info_.getRootDynamicVals();
-    for (const auto i : c10::irange(fusion->inputs().size())) {
-      auto input = fusion->inputs().at(i);
-      if (dyn_vals.find(input) != dyn_vals.end()) {
-        info_.scalar_inputs_affecting_concretization_.insert(i);
-      }
-    }
   }
 
   const auto& getInfo() const {
@@ -103,7 +92,7 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
     auto out_tv = op->out()->as<TensorView>();
     // If there's no symbolic axis, this is a static reshape op
     if (out_tv->domain()->hasSymbolicAxis()) {
-      info_.dynamic_reshapes_.push_back(op);
+      info_.dynamic_reshapes_.push_back(out_tv);
 
       // Input and output extent expressions both affect concretization
       const auto& inp_dom =
@@ -125,8 +114,8 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
       if (!id->definition() || id->getIterType() != IterType::Symbolic) {
         continue;
       }
-      if (auto op = dynamic_cast<Resize*>(id->definition())) {
-        info_.dynamic_resizes_.push_back(op);
+      if (id->definition()->isA<Resize>()) {
+        info_.dynamic_resizes_.push_back(id);
         // extent of output determines its IterType
         leaf_dynamic_vals_.push_back(id->extent());
       }
@@ -138,6 +127,18 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
   void finalizeDynamicVals() {
     const auto inputs = InputsOf::outputs(info_.fusion(), leaf_dynamic_vals_);
     info_.root_dynamic_vals_.insert(inputs.begin(), inputs.end());
+
+    // initial_info_ provides a set of Vals that are used for concretization.
+    // Here we check which scalar inputs, if any, correspond to any of those
+    // Vals. These will be the inputs that are explicitly used in the cache ID
+    // for KernelArgumentHolder.
+    auto dyn_vals = info_.getRootDynamicVals();
+    for (const auto i : c10::irange(info_.fusion()->inputs().size())) {
+      auto input = info_.fusion()->inputs().at(i);
+      if (dyn_vals.find(input) != dyn_vals.end()) {
+        info_.scalar_inputs_affecting_concretization_.insert(i);
+      }
+    }
   }
 
  private:
@@ -154,11 +155,12 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
 };
 
 void DynamicTransformConcretizationInfo::analyzeReshapes(
-    const DynamicTransformInitialInfo& initial_info,
     ExpressionEvaluator& expr_eval) {
-  for (const auto op : initial_info.getDynamicReshapes()) {
+  auto reshape_tvs = initial_info_->getDynamicReshapes();
+  for (const auto tv_index : c10::irange(reshape_tvs.size())) {
+    auto out_tv = reshape_tvs.at(tv_index);
+    auto op = out_tv->definition()->as<ViewOp>();
     auto inp_tv = op->in()->as<TensorView>();
-    auto out_tv = op->out()->as<TensorView>();
 
     // If there's no symblic axis, this is a static reshape op
     if (!out_tv->domain()->hasSymbolicAxis()) {
@@ -232,15 +234,16 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
 
     auto view_result = analyzeView(inp_tv, inp_shape, out_shape);
 
-    reshape_transforms_.emplace_back(out_tv, view_result);
+    reshape_transforms_.emplace_back(tv_index, view_result);
   }
 }
 
 void DynamicTransformConcretizationInfo::analyzeResizes(
-    const DynamicTransformInitialInfo& initial_info,
     ExpressionEvaluator& expr_eval) {
-  for (const auto op : initial_info.getDynamicResizes()) {
-    auto out_id = op->out()->as<IterDomain>();
+  auto resize_ids = initial_info_->getDynamicResizes();
+  for (const auto id_index : c10::irange(resize_ids.size())) {
+    auto out_id = resize_ids.at(id_index);
+    auto op = out_id->definition()->as<Resize>();
 
     TORCH_CHECK(
         out_id->getIterType() == IterType::Symbolic,
@@ -267,7 +270,7 @@ void DynamicTransformConcretizationInfo::analyzeResizes(
     auto iter_type =
         extent_int == 1 ? IterType::Broadcast : IterType::Iteration;
 
-    resize_transforms_.emplace_back(out_id, iter_type);
+    resize_transforms_.emplace_back(id_index, iter_type);
   }
 }
 
@@ -275,10 +278,6 @@ bool DynamicTransformConcretizationInfo::operator==(
     const DynamicTransformConcretizationInfo& other) const {
   if (this == &other) {
     return true;
-  }
-
-  if (fusion_ != other.fusion_) {
-    return false;
   }
 
   if (reshape_transforms_.size() != other.reshape_transforms_.size() ||
@@ -305,40 +304,21 @@ bool DynamicTransformConcretizationInfo::operator==(
   return true;
 }
 
-DynamicTransformConcretizationInfo DynamicTransformConcretizationInfo::clone(
-    IrCloner& ir_cloner) const {
-  DynamicTransformConcretizationInfo cloned_info(
-      static_cast<Fusion*>(ir_cloner.container()));
-  for (const auto& [tv, analyze_result] : reshape_transforms_) {
-    cloned_info.reshape_transforms_.emplace_back(
-        ir_cloner.clone(tv),
-        // reshape_transforms_ holds pairs of TensorView* and AnalyzeViewResult
-        // AnalyzeViewResult can be copied directly as it holds no references to
-        // Statements that would need cloning, only integer indices of axes.
-        analyze_result);
-  }
-  for (const auto& [id, iter_type] : resize_transforms_) {
-    cloned_info.resize_transforms_.emplace_back(
-        ir_cloner.clone(id),
-        // Similar to reshape_transforms_, we only clone the IterDomains in
-        // resize_transforms_
-        iter_type);
-  }
-  return cloned_info;
-}
-
 std::string DynamicTransformConcretizationInfo::toString() const {
   std::stringstream ss;
   ss << "DynamicTransformConcretizationInfo\n";
   std::string indent = "  ";
   ss << indent << "Reshape:\n";
-  for (const auto& kv : reshape_transforms_) {
-    ss << indent << indent << kv.first->toString() << ", "
-       << kv.second.toString() << "\n";
+  for (const auto& [tv_index, analyze_result] : reshape_transforms_) {
+    // auto tv = initial_info_->getDynamicReshapes().at(tv_index);
+    ss << indent //<< indent << tv->toString()
+       << " (index=" << tv_index << "), " << analyze_result.toString() << "\n";
   }
   ss << indent << "Resize:\n";
-  for (const auto& [id, iter_type] : resize_transforms_) {
-    ss << indent << indent << id->toString() << ", " << iter_type << "\n";
+  for (const auto& [id_index, iter_type] : resize_transforms_) {
+    // auto id = initial_info_->getDynamicResizes().at(id_index);
+    ss << indent << indent //<< id->toString()
+       << " (index=" << id_index << "), " << iter_type << "\n";
   }
   return ss.str();
 }
@@ -348,10 +328,10 @@ class DynamicTransformConcretizer : public OptOutMutator {
  public:
   DynamicTransformConcretizer(
       Fusion* fusion,
-      const DynamicTransformConcretizationInfo& info)
+      const DynamicTransformConcretizationInfo* info)
       : info_(info) {
     TORCH_INTERNAL_ASSERT(
-        fusion == info.fusion(),
+        fusion == info->fusion(),
         "Invalid DynamicTransformInitialInfo. The associated Fusion is different from the given Fusion");
     concretize();
   }
@@ -386,7 +366,7 @@ class DynamicTransformConcretizer : public OptOutMutator {
   bool propagateFromProducerToConsumer(TensorView* consumer);
 
  private:
-  const DynamicTransformConcretizationInfo& info_;
+  const DynamicTransformConcretizationInfo* info_;
 };
 
 void DynamicTransformConcretizer::concretize() {
@@ -397,7 +377,7 @@ void DynamicTransformConcretizer::concretize() {
   concretizeResize();
 
   // Finally, propagate concretized domains
-  auto all_stmts = StmtSort::getStmts(info_.fusion(), true);
+  auto all_stmts = StmtSort::getStmts(info_->fusion(), true);
   for (auto stmt : all_stmts) {
     if (stmt->isA<Val>()) {
       mutate(stmt);
@@ -407,11 +387,11 @@ void DynamicTransformConcretizer::concretize() {
 
 void DynamicTransformConcretizer::concretizeReshape() {
   // Concretize each reshape op.
-  for (const auto& kv : info_.getReshapeTransforms()) {
-    auto incomplete_out_tv = kv.first;
-    const auto view_analysis = kv.second;
-
-    auto inp_tv = ir_utils::producerTvsOf(incomplete_out_tv).at(0);
+  for (const auto& [tv_index, view_analysis] : info_->getReshapeTransforms()) {
+    auto incomplete_out_tv =
+        info_->initialInfo()->getDynamicReshapes().at(tv_index);
+    auto view_op = incomplete_out_tv->definition()->as<ViewOp>();
+    auto inp_tv = view_op->in()->as<TensorView>();
 
     auto concrete_reshape_out_tv = reshape(inp_tv, view_analysis);
 
@@ -430,13 +410,14 @@ void DynamicTransformConcretizer::concretizeReshape() {
           incomplete_out_tv, concrete_reshape_out_tv);
     }
 
-    incomplete_out_tv->fusion()->removeVal(incomplete_out_tv);
+    info_->fusion()->removeVal(incomplete_out_tv);
   }
 }
 
 void DynamicTransformConcretizer::concretizeResize() {
   // Concretize each resize op.
-  for (const auto& [id, iter_type] : info_.getResizeTransforms()) {
+  for (const auto& [id_index, iter_type] : info_->getResizeTransforms()) {
+    auto id = info_->initialInfo()->getDynamicResizes().at(id_index);
     TORCH_CHECK(
         id->definition() && id->definition()->isA<Resize>(),
         "Resized IterDomain must have a Resize definition");
@@ -691,7 +672,7 @@ DynamicTransformInitialInfo DynamicTransform::getInitialInfo(Fusion* fusion) {
 
 void DynamicTransform::concretizeFusion(
     Fusion* fusion,
-    const DynamicTransformConcretizationInfo& info) {
+    const DynamicTransformConcretizationInfo* info) {
   DynamicTransformConcretizer concretizer(fusion, info);
 }
 

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -679,7 +679,10 @@ void DynamicTransform::concretizeFusion(
 size_t DynamicTransformConcretizationInfo::hash() const {
   size_t hash = 0;
   for (const auto& [tv, view_result] : getReshapeTransforms()) {
-    hash += view_result.hash();
+    hash_combine(hash, view_result.hash());
+  }
+  for (const auto& [id, iter_type] : getResizeTransforms()) {
+    hash_combine(hash, (size_t)iter_type);
   }
   return hash;
 }

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -156,7 +156,7 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
 
 void DynamicTransformConcretizationInfo::analyzeReshapes(
     ExpressionEvaluator* expr_eval) {
-  auto reshape_tvs = initial_info_->getDynamicReshapedTensorViews();
+  const auto& reshape_tvs = initial_info_->getDynamicReshapedTensorViews();
   for (const auto tv_index : c10::irange(reshape_tvs.size())) {
     auto out_tv = reshape_tvs.at(tv_index);
     auto op = out_tv->definition()->as<ViewOp>();
@@ -240,7 +240,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
 
 void DynamicTransformConcretizationInfo::analyzeResizes(
     ExpressionEvaluator* expr_eval) {
-  auto resize_ids = initial_info_->getDynamicResizedIterDomains();
+  const auto& resize_ids = initial_info_->getDynamicResizedIterDomains();
   for (const auto id_index : c10::irange(resize_ids.size())) {
     auto out_id = resize_ids.at(id_index);
     auto op = out_id->definition()->as<Resize>();

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -310,15 +310,15 @@ std::string DynamicTransformConcretizationInfo::toString() const {
   std::string indent = "  ";
   ss << indent << "Reshape:\n";
   for (const auto& [tv_index, analyze_result] : reshape_transforms_) {
-    // auto tv = initial_info_->getDynamicReshapes().at(tv_index);
-    ss << indent //<< indent << tv->toString()
-       << " (index=" << tv_index << "), " << analyze_result.toString() << "\n";
+    auto tv = initial_info_->getDynamicReshapes().at(tv_index);
+    ss << indent << indent << tv->toString() << " (index=" << tv_index << "), "
+       << analyze_result.toString() << "\n";
   }
   ss << indent << "Resize:\n";
   for (const auto& [id_index, iter_type] : resize_transforms_) {
-    // auto id = initial_info_->getDynamicResizes().at(id_index);
-    ss << indent << indent //<< id->toString()
-       << " (index=" << id_index << "), " << iter_type << "\n";
+    auto id = initial_info_->getDynamicResizes().at(id_index);
+    ss << indent << indent << id->toString() << " (index=" << id_index << "), "
+       << iter_type << "\n";
   }
   return ss.str();
 }

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -155,7 +155,7 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
 };
 
 void DynamicTransformConcretizationInfo::analyzeReshapes(
-    ExpressionEvaluator& expr_eval) {
+    ExpressionEvaluator* expr_eval) {
   auto reshape_tvs = initial_info_->getDynamicReshapes();
   for (const auto tv_index : c10::irange(reshape_tvs.size())) {
     auto out_tv = reshape_tvs.at(tv_index);
@@ -185,7 +185,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
           !inp_id->maybePartial(),
           "Invalid domain to reshape: ",
           inp_id->toString());
-      auto extent_val = expr_eval.evaluate(inp_id->extent());
+      auto extent_val = expr_eval->evaluate(inp_id->extent());
       TORCH_INTERNAL_ASSERT(
           extent_val.has_value(),
           "Cannot evaluate the extent of an input domain to reshape: ",
@@ -209,7 +209,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
     bool extent_m1_found = false;
     for (const auto i : c10::irange(out_dom.size())) {
       auto out_id = out_dom.at(i);
-      auto extent_val = expr_eval.evaluate(out_id->extent());
+      auto extent_val = expr_eval->evaluate(out_id->extent());
       TORCH_INTERNAL_ASSERT(
           extent_val.has_value(),
           "Cannot evaluate the extent of an output domain to reshape: ",
@@ -239,7 +239,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
 }
 
 void DynamicTransformConcretizationInfo::analyzeResizes(
-    ExpressionEvaluator& expr_eval) {
+    ExpressionEvaluator* expr_eval) {
   auto resize_ids = initial_info_->getDynamicResizes();
   for (const auto id_index : c10::irange(resize_ids.size())) {
     auto out_id = resize_ids.at(id_index);
@@ -250,7 +250,7 @@ void DynamicTransformConcretizationInfo::analyzeResizes(
         "Found non-dynamic Resize in initial concretization info: ",
         op->toString());
 
-    auto extent_val = expr_eval.evaluate(out_id->extent());
+    auto extent_val = expr_eval->evaluate(out_id->extent());
     TORCH_INTERNAL_ASSERT(
         extent_val.has_value(),
         "Cannot evaluate the extent of a resized domain: ",

--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -105,7 +105,7 @@ class TORCH_CUDA_CU_API DynamicTransformConcretizationInfo {
  public:
   DynamicTransformConcretizationInfo(
       const DynamicTransformInitialInfo* initial_info,
-      ExpressionEvaluator& expr_eval)
+      ExpressionEvaluator* expr_eval)
       : initial_info_(initial_info) {
     TORCH_INTERNAL_ASSERT(
         !fusion()->isA<kir::Kernel>(),
@@ -113,7 +113,7 @@ class TORCH_CUDA_CU_API DynamicTransformConcretizationInfo {
 
     // Make sure all exactly mapped IDs have the same value in the
     // evaluator when any one of the IDs has a known value
-    expr_eval.propagateBoundValuesThroughExactMaps(initial_info->fusion());
+    expr_eval->propagateBoundValuesThroughExactMaps(initial_info->fusion());
 
     analyzeReshapes(expr_eval);
 
@@ -140,9 +140,9 @@ class TORCH_CUDA_CU_API DynamicTransformConcretizationInfo {
     return !(*this == other);
   }
 
-  void analyzeReshapes(ExpressionEvaluator& expr_eval);
+  void analyzeReshapes(ExpressionEvaluator* expr_eval);
 
-  void analyzeResizes(ExpressionEvaluator& expr_eval);
+  void analyzeResizes(ExpressionEvaluator* expr_eval);
 
   const DynamicTransformInitialInfo* initialInfo() const {
     return initial_info_;

--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -148,6 +148,10 @@ class TORCH_CUDA_CU_API DynamicTransformConcretizationInfo {
     return initial_info_;
   }
 
+  void setInitialInfo(const DynamicTransformInitialInfo* initial_info) {
+    initial_info_ = initial_info;
+  }
+
   Fusion* fusion() const {
     return initial_info_->fusion();
   }

--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -198,13 +198,6 @@ class TORCH_CUDA_CU_API DynamicTransform {
   //! faster concretization once inputs are available.
   static DynamicTransformInitialInfo getInitialInfo(Fusion* fusion);
 
-  //! Get concrete transformations for a symbolic fusion with concrete
-  //! input sizes given through kernel arguments
-  static DynamicTransformConcretizationInfo getConcretizationInfo(
-      Fusion* fusion,
-      const DynamicTransformInitialInfo* info,
-      const KernelArgumentHolder* args);
-
   //! Concretizes a given fusion. Note that the concretization is
   //! in-place and the given fusion is modified.
   static void concretizeFusion(

--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -60,10 +60,6 @@ class TORCH_CUDA_CU_API DynamicTransformInitialInfo {
     return dynamic_resizes_;
   }
 
-  const ExpressionEvaluator& getExpressionEvaluator() const {
-    return expr_eval_;
-  }
-
   std::string toString() const;
 
   DynamicTransformInitialInfo clone(IrCloner& ir_cloner) const;
@@ -91,9 +87,6 @@ class TORCH_CUDA_CU_API DynamicTransformInitialInfo {
 
   // Root Vals that determine concretization
   std::unordered_set<Val*> root_dynamic_vals_;
-
-  // ExpressionEvaluator that we use to pre-compute as much as possible
-  ExpressionEvaluator expr_eval_;
 
   friend class DynamicTransformInitialInfoBuilder;
 };

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -581,7 +581,7 @@ FusionKernelRuntime* FusionExecutorCache::getKernelRuntimeFor(
     auto expr_eval = executor_utils::bindInputs(args, fusion_.get());
     cached_conc_info_.emplace_back(
         std::make_unique<DynamicTransformConcretizationInfo>(
-            &initial_info, expr_eval));
+            &initial_info, &expr_eval));
     conc_info = cached_conc_info_.back().get();
   }
 

--- a/csrc/kernel_cache.h
+++ b/csrc/kernel_cache.h
@@ -90,8 +90,7 @@ class TORCH_CUDA_CU_API FusionKernelRuntime {
   explicit FusionKernelRuntime(
       std::unique_ptr<Fusion> fusion,
       const KernelArgumentHolder& inputs,
-      std::optional<PrimDataType> forced_index_type = std::nullopt,
-      std::unique_ptr<PrecomputedValues> precomputed_values = nullptr);
+      std::optional<PrimDataType> forced_index_type = std::nullopt);
 
   //! Type notations within FusionKernelRuntime Context
   using HashType = size_t;

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -516,9 +516,9 @@ class KernelIndexTypeCompute {
 };
 
 //! Alter an existing hash in order to combine it with a new hash in a way that
-//! is order-dependent and spreads bits over the entire range of a size_t. Taken
-//! from boost::hash_combine. See https://stackoverflow.com/q/35985960
-inline void hash_combine(size_t& hash, size_t new_hash) {
+//! is order-dependent and spreads bits over the entire range of a size_t.
+//! Inspired by boost::hash_combine. See https://stackoverflow.com/q/35985960
+inline void hashCombine(size_t& hash, size_t new_hash) {
   hash ^= new_hash + 0x9e3779b9 + (hash << 6) + (hash >> 2);
 }
 

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -515,4 +515,11 @@ class KernelIndexTypeCompute {
   int64_t tensor_most_positive_index_ = 0;
 };
 
+//! Alter an existing hash in order to combine it with a new hash in a way that
+//! is order-dependent and spreads bits over the entire range of a size_t. Taken
+//! from boost::hash_combine. See https://stackoverflow.com/q/35985960
+inline void hash_combine(size_t& hash, size_t new_hash) {
+  hash ^= new_hash + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+}
+
 } // namespace nvfuser

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -64,7 +64,7 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
     expr_eval.bind(reshape_shape1, 4);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
     TORCH_CHECK(
         info.getReshapeTransforms().size() == 1,
         "Expected to have one reshape transform: ",
@@ -82,7 +82,7 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
     expr_eval.bind(reshape_shape1, -1);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
     TORCH_CHECK(
         info.getReshapeTransforms().size() == 1,
         "Expected to have one reshape transform: ",
@@ -104,7 +104,7 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
         [&]() {
           auto initial_info = DynamicTransform::getInitialInfo(&fusion);
           auto info =
-              DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+              DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
         },
         ::testing::ThrowsMessage<c10::Error>(
             ::testing::HasSubstr("Cannot infer")));
@@ -143,7 +143,7 @@ TEST_F(NVFuserTest, DynamicTransform2_CUDA) {
     expr_eval.bind(tv2->axis(1)->extent(), 4);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
     TORCH_CHECK(
         info.getReshapeTransforms().size() == 1,
@@ -184,7 +184,7 @@ TEST_F(NVFuserTest, DynamicTransform3_CUDA) {
   expr_eval.bind(tv1->axis(1)->extent(), shape_after.at(1));
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-  auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+  auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
   DynamicTransform::concretizeFusion(&fusion, &info);
   TORCH_CHECK(
@@ -249,7 +249,7 @@ TEST_F(NVFuserTest, DynamicTransform4_CUDA) {
     }
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
     DynamicTransform::concretizeFusion(&fusion, &info);
 
@@ -297,7 +297,7 @@ TEST_F(NVFuserTest, DynamicTransform5_CUDA) {
     expr_eval.bind(tv1->axis(1)->extent(), before_after.second.at(1));
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
     DynamicTransform::concretizeFusion(&fusion, &info);
 
@@ -350,7 +350,7 @@ TEST_F(NVFuserTest, DynamicTransform6_CUDA) {
     }
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
     DynamicTransform::concretizeFusion(&fusion, &info);
 
@@ -431,7 +431,7 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
 
     auto ref_initial_info = DynamicTransform::getInitialInfo(&fusion);
     auto ref_info =
-        DynamicTransformConcretizationInfo(&ref_initial_info, ref_expr_eval);
+        DynamicTransformConcretizationInfo(&ref_initial_info, &ref_expr_eval);
 
     for (const auto& transform : pattern.equal_transforms) {
       TORCH_CHECK(transform.shapes.size() == ref_transform.shapes.size());
@@ -445,7 +445,7 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
       }
 
       auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-      auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+      auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
       TORCH_CHECK(
           ref_info == info,
@@ -467,7 +467,7 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
       }
 
       auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-      auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+      auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
       TORCH_CHECK(
           ref_info != info,
@@ -532,7 +532,7 @@ TEST_F(NVFuserTest, DynamicTransform9_CUDA) {
   expr_eval.bind(reshape_shape0, 12);
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-  auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+  auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
   // There must be only one dynamic reshape entry, and that must be
   // for tv2.
@@ -571,7 +571,7 @@ TEST_F(NVFuserTest, DynamicTransform10_CUDA) {
   expr_eval.bind(tv1->axis(1)->extent(), 3);
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-  auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
+  auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
   DynamicTransform::concretizeFusion(&fusion, &info);
 
@@ -606,7 +606,7 @@ TEST_F(NVFuserTest, DynamicTransform11_CUDA) {
   expr_eval1.bind(tv1->axis(2)->extent(), 3);
 
   auto initial_info1 = DynamicTransform::getInitialInfo(&fusion);
-  auto info1 = DynamicTransformConcretizationInfo(&initial_info1, expr_eval1);
+  auto info1 = DynamicTransformConcretizationInfo(&initial_info1, &expr_eval1);
 
   ExpressionEvaluator expr_eval2;
   ;
@@ -619,7 +619,7 @@ TEST_F(NVFuserTest, DynamicTransform11_CUDA) {
   expr_eval2.bind(tv1->axis(2)->extent(), 2);
 
   auto initial_info2 = DynamicTransform::getInitialInfo(&fusion);
-  auto info2 = DynamicTransformConcretizationInfo(&initial_info2, expr_eval2);
+  auto info2 = DynamicTransformConcretizationInfo(&initial_info2, &expr_eval2);
 
   // Generally different concretizations doesn't always mean different
   // hashes, but in this case they should be different

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -64,8 +64,8 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
     expr_eval.bind(reshape_shape1, 4);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransform::getConcretizationInfo(
-        &fusion, &initial_info, &expr_eval);
+    auto info =
+        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
     TORCH_CHECK(
         info.getReshapeTransforms().size() == 1,
         "Expected to have one reshape transform: ",
@@ -83,8 +83,8 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
     expr_eval.bind(reshape_shape1, -1);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransform::getConcretizationInfo(
-        &fusion, &initial_info, &expr_eval);
+    auto info =
+        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
     TORCH_CHECK(
         info.getReshapeTransforms().size() == 1,
         "Expected to have one reshape transform: ",
@@ -105,10 +105,8 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
     EXPECT_THAT(
         [&]() {
           auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-          auto info = DynamicTransform::getConcretizationInfo(
-              &fusion, &initial_info, &expr_eval);
-          DynamicTransform::getConcretizationInfo(
-              &fusion, &initial_info, &expr_eval);
+          auto info = DynamicTransformConcretizationInfo(
+              &fusion, initial_info, expr_eval);
         },
         ::testing::ThrowsMessage<c10::Error>(
             ::testing::HasSubstr("Cannot infer")));
@@ -147,8 +145,8 @@ TEST_F(NVFuserTest, DynamicTransform2_CUDA) {
     expr_eval.bind(tv2->axis(1)->extent(), 4);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransform::getConcretizationInfo(
-        &fusion, &initial_info, &expr_eval);
+    auto info =
+        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
 
     TORCH_CHECK(
         info.getReshapeTransforms().size() == 1,
@@ -189,8 +187,8 @@ TEST_F(NVFuserTest, DynamicTransform3_CUDA) {
   expr_eval.bind(tv1->axis(1)->extent(), shape_after.at(1));
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-  auto info = DynamicTransform::getConcretizationInfo(
-      &fusion, &initial_info, &expr_eval);
+  auto info =
+      DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
 
   DynamicTransform::concretizeFusion(&fusion, info);
   TORCH_CHECK(
@@ -255,8 +253,8 @@ TEST_F(NVFuserTest, DynamicTransform4_CUDA) {
     }
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransform::getConcretizationInfo(
-        &fusion, &initial_info, &expr_eval);
+    auto info =
+        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
 
     DynamicTransform::concretizeFusion(&fusion, info);
 
@@ -304,8 +302,8 @@ TEST_F(NVFuserTest, DynamicTransform5_CUDA) {
     expr_eval.bind(tv1->axis(1)->extent(), before_after.second.at(1));
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransform::getConcretizationInfo(
-        &fusion, &initial_info, &expr_eval);
+    auto info =
+        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
 
     DynamicTransform::concretizeFusion(&fusion, info);
 
@@ -358,8 +356,8 @@ TEST_F(NVFuserTest, DynamicTransform6_CUDA) {
     }
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info = DynamicTransform::getConcretizationInfo(
-        &fusion, &initial_info, &expr_eval);
+    auto info =
+        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
 
     DynamicTransform::concretizeFusion(&fusion, info);
 
@@ -439,8 +437,8 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
     }
 
     auto ref_initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto ref_info = DynamicTransform::getConcretizationInfo(
-        &fusion, &ref_initial_info, &ref_expr_eval);
+    auto ref_info = DynamicTransformConcretizationInfo(
+        &fusion, ref_initial_info, ref_expr_eval);
 
     for (const auto& transform : pattern.equal_transforms) {
       TORCH_CHECK(transform.shapes.size() == ref_transform.shapes.size());
@@ -454,8 +452,8 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
       }
 
       auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-      auto info = DynamicTransform::getConcretizationInfo(
-          &fusion, &initial_info, &expr_eval);
+      auto info =
+          DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
 
       TORCH_CHECK(
           ref_info == info,
@@ -477,8 +475,8 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
       }
 
       auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-      auto info = DynamicTransform::getConcretizationInfo(
-          &fusion, &initial_info, &expr_eval);
+      auto info =
+          DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
 
       TORCH_CHECK(
           ref_info != info,
@@ -543,8 +541,8 @@ TEST_F(NVFuserTest, DynamicTransform9_CUDA) {
   expr_eval.bind(reshape_shape0, 12);
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-  auto info = DynamicTransform::getConcretizationInfo(
-      &fusion, &initial_info, &expr_eval);
+  auto info =
+      DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
 
   // There must be only one dynamic reshape entry, and that must be
   // for tv2.
@@ -583,8 +581,8 @@ TEST_F(NVFuserTest, DynamicTransform10_CUDA) {
   expr_eval.bind(tv1->axis(1)->extent(), 3);
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-  auto info = DynamicTransform::getConcretizationInfo(
-      &fusion, &initial_info, &expr_eval);
+  auto info =
+      DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
 
   DynamicTransform::concretizeFusion(&fusion, info);
 
@@ -619,8 +617,8 @@ TEST_F(NVFuserTest, DynamicTransform11_CUDA) {
   expr_eval1.bind(tv1->axis(2)->extent(), 3);
 
   auto initial_info1 = DynamicTransform::getInitialInfo(&fusion);
-  auto info1 = DynamicTransform::getConcretizationInfo(
-      &fusion, &initial_info1, &expr_eval1);
+  auto info1 =
+      DynamicTransformConcretizationInfo(&fusion, initial_info1, expr_eval1);
 
   ExpressionEvaluator expr_eval2;
   ;
@@ -633,8 +631,8 @@ TEST_F(NVFuserTest, DynamicTransform11_CUDA) {
   expr_eval2.bind(tv1->axis(2)->extent(), 2);
 
   auto initial_info2 = DynamicTransform::getInitialInfo(&fusion);
-  auto info2 = DynamicTransform::getConcretizationInfo(
-      &fusion, &initial_info2, &expr_eval2);
+  auto info2 =
+      DynamicTransformConcretizationInfo(&fusion, initial_info2, expr_eval2);
 
   // Generally different concretizations doesn't always mean different
   // hashes, but in this case they should be different

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -64,8 +64,7 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
     expr_eval.bind(reshape_shape1, 4);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info =
-        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
     TORCH_CHECK(
         info.getReshapeTransforms().size() == 1,
         "Expected to have one reshape transform: ",
@@ -83,8 +82,7 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
     expr_eval.bind(reshape_shape1, -1);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info =
-        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
     TORCH_CHECK(
         info.getReshapeTransforms().size() == 1,
         "Expected to have one reshape transform: ",
@@ -105,8 +103,8 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
     EXPECT_THAT(
         [&]() {
           auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-          auto info = DynamicTransformConcretizationInfo(
-              &fusion, initial_info, expr_eval);
+          auto info =
+              DynamicTransformConcretizationInfo(&initial_info, expr_eval);
         },
         ::testing::ThrowsMessage<c10::Error>(
             ::testing::HasSubstr("Cannot infer")));
@@ -145,8 +143,7 @@ TEST_F(NVFuserTest, DynamicTransform2_CUDA) {
     expr_eval.bind(tv2->axis(1)->extent(), 4);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info =
-        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
 
     TORCH_CHECK(
         info.getReshapeTransforms().size() == 1,
@@ -187,10 +184,9 @@ TEST_F(NVFuserTest, DynamicTransform3_CUDA) {
   expr_eval.bind(tv1->axis(1)->extent(), shape_after.at(1));
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-  auto info =
-      DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+  auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
 
-  DynamicTransform::concretizeFusion(&fusion, info);
+  DynamicTransform::concretizeFusion(&fusion, &info);
   TORCH_CHECK(
       !fusion.hasDynamicTransform(), "Expected to have no dynamic transform");
 
@@ -253,10 +249,9 @@ TEST_F(NVFuserTest, DynamicTransform4_CUDA) {
     }
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info =
-        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
 
-    DynamicTransform::concretizeFusion(&fusion, info);
+    DynamicTransform::concretizeFusion(&fusion, &info);
 
     TORCH_CHECK(
         !fusion.hasDynamicTransform(), "Expected to have no dynamic transform");
@@ -302,10 +297,9 @@ TEST_F(NVFuserTest, DynamicTransform5_CUDA) {
     expr_eval.bind(tv1->axis(1)->extent(), before_after.second.at(1));
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info =
-        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
 
-    DynamicTransform::concretizeFusion(&fusion, info);
+    DynamicTransform::concretizeFusion(&fusion, &info);
 
     TORCH_CHECK(
         !fusion.hasDynamicTransform(), "Expected to have no dynamic transform");
@@ -356,10 +350,9 @@ TEST_F(NVFuserTest, DynamicTransform6_CUDA) {
     }
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto info =
-        DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+    auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
 
-    DynamicTransform::concretizeFusion(&fusion, info);
+    DynamicTransform::concretizeFusion(&fusion, &info);
 
     TORCH_CHECK(
         !fusion.hasDynamicTransform(), "Expected to have no dynamic transform");
@@ -437,8 +430,8 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
     }
 
     auto ref_initial_info = DynamicTransform::getInitialInfo(&fusion);
-    auto ref_info = DynamicTransformConcretizationInfo(
-        &fusion, ref_initial_info, ref_expr_eval);
+    auto ref_info =
+        DynamicTransformConcretizationInfo(&ref_initial_info, ref_expr_eval);
 
     for (const auto& transform : pattern.equal_transforms) {
       TORCH_CHECK(transform.shapes.size() == ref_transform.shapes.size());
@@ -452,8 +445,7 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
       }
 
       auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-      auto info =
-          DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+      auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
 
       TORCH_CHECK(
           ref_info == info,
@@ -475,8 +467,7 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
       }
 
       auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-      auto info =
-          DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+      auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
 
       TORCH_CHECK(
           ref_info != info,
@@ -541,14 +532,13 @@ TEST_F(NVFuserTest, DynamicTransform9_CUDA) {
   expr_eval.bind(reshape_shape0, 12);
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-  auto info =
-      DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+  auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
 
   // There must be only one dynamic reshape entry, and that must be
   // for tv2.
   TORCH_CHECK(
       info.getReshapeTransforms().size() == 1,
-      info.getReshapeTransforms().at(0).first == tv2,
+      info.getReshapeTransforms().at(0).first == 0, // first and only reshape
       "Unexpected dynamic transform info:",
       info.toString());
 }
@@ -581,10 +571,9 @@ TEST_F(NVFuserTest, DynamicTransform10_CUDA) {
   expr_eval.bind(tv1->axis(1)->extent(), 3);
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
-  auto info =
-      DynamicTransformConcretizationInfo(&fusion, initial_info, expr_eval);
+  auto info = DynamicTransformConcretizationInfo(&initial_info, expr_eval);
 
-  DynamicTransform::concretizeFusion(&fusion, info);
+  DynamicTransform::concretizeFusion(&fusion, &info);
 
   TORCH_CHECK(
       !fusion.hasDynamicTransform(), "Expected to have no dynamic transform");
@@ -617,8 +606,7 @@ TEST_F(NVFuserTest, DynamicTransform11_CUDA) {
   expr_eval1.bind(tv1->axis(2)->extent(), 3);
 
   auto initial_info1 = DynamicTransform::getInitialInfo(&fusion);
-  auto info1 =
-      DynamicTransformConcretizationInfo(&fusion, initial_info1, expr_eval1);
+  auto info1 = DynamicTransformConcretizationInfo(&initial_info1, expr_eval1);
 
   ExpressionEvaluator expr_eval2;
   ;
@@ -631,8 +619,7 @@ TEST_F(NVFuserTest, DynamicTransform11_CUDA) {
   expr_eval2.bind(tv1->axis(2)->extent(), 2);
 
   auto initial_info2 = DynamicTransform::getInitialInfo(&fusion);
-  auto info2 =
-      DynamicTransformConcretizationInfo(&fusion, initial_info2, expr_eval2);
+  auto info2 = DynamicTransformConcretizationInfo(&initial_info2, expr_eval2);
 
   // Generally different concretizations doesn't always mean different
   // hashes, but in this case they should be different
@@ -678,21 +665,8 @@ TEST_F(NVFuserTest, DynamicTransformFusionExecutorCache_CUDA) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
 
-  // Return pair of: number of concretizations & total number of kernel runtimes
-  auto countRuntimes = [&executor_cache]() {
-    std::unordered_set<const std::pair<
-        size_t,
-        std::optional<DynamicTransformConcretizationInfo>>*>
-        concs;
-    size_t runtime_count = 0;
-    for (auto& it : executor_cache.getKernelRuntimes()) {
-      concs.insert(&it.first);
-      runtime_count += it.second.size();
-    }
-    return std::make_pair(concs.size(), runtime_count);
-  };
-
-  TORCH_CHECK(countRuntimes().second == 0, "Expect to start with no runtimes");
+  TORCH_CHECK(
+      executor_cache.countRuntimes() == 0, "Expect to start with no runtimes");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   { // trivial reshape
@@ -704,7 +678,8 @@ TEST_F(NVFuserTest, DynamicTransformFusionExecutorCache_CUDA) {
     testValidate(
         executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
     TORCH_CHECK(
-        countRuntimes().second == 1, "Expect to create a single runtime");
+        executor_cache.countRuntimes() == 1,
+        "Expect to create a single runtime");
   }
   { // non-trivial reshape: merge and split
     auto t0 = at::randn({3, 4}, options);
@@ -714,11 +689,11 @@ TEST_F(NVFuserTest, DynamicTransformFusionExecutorCache_CUDA) {
     auto ref = t0.view({4, 3}) + t1;
     testValidate(
         executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
-    auto num_rts = countRuntimes();
+    auto num_rts = executor_cache.countRuntimes();
+    auto num_concs = executor_cache.countConcretizations();
+    TORCH_CHECK(num_rts == 2, "Non-trivial reshape should create new runtime");
     TORCH_CHECK(
-        num_rts.second == 2, "Non-trivial reshape should create new runtime");
-    TORCH_CHECK(
-        num_rts.first == 2,
+        num_concs == 2,
         "Non-trivial reshape should create new concretization cache level");
   }
   { // different non-trivial reshape
@@ -729,12 +704,13 @@ TEST_F(NVFuserTest, DynamicTransformFusionExecutorCache_CUDA) {
     auto ref = t0.view({4, 3}) + t1;
     testValidate(
         executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
-    auto num_rts = countRuntimes();
+    auto num_rts = executor_cache.countRuntimes();
+    auto num_concs = executor_cache.countConcretizations();
     TORCH_CHECK(
-        num_rts.second == 2,
+        num_rts == 2,
         "Second non-trivial reshape should not create new runtime");
     TORCH_CHECK(
-        num_rts.first == 2,
+        num_concs == 2,
         "Second non-trivial reshape should not create new concretization cache level");
   }
 }
@@ -787,23 +763,11 @@ void reductionDynamicViewAddFusion(
 
   FusionExecutorCache fusion_executor_cache(std::move(fusion_ptr));
 
-  // Return pair of: number of concretizations & total number of kernel runtimes
-  auto countConcretizations = [&fusion_executor_cache]() {
-    std::unordered_set<const std::pair<
-        size_t,
-        std::optional<DynamicTransformConcretizationInfo>>*>
-        concs;
-    for (auto& it : fusion_executor_cache.getKernelRuntimes()) {
-      concs.insert(&it.first);
-    }
-    return concs.size();
-  };
-  size_t num_concretizations = countConcretizations();
+  size_t num_concretizations = fusion_executor_cache.countConcretizations();
   // Check that concretizations and runtimes are cache misses only when they
   // should be
-  auto checkCache = [&countConcretizations,
-                     &num_concretizations](bool expect_miss) {
-    auto current = countConcretizations();
+  auto checkCache = [&](bool expect_miss) {
+    auto current = fusion_executor_cache.countConcretizations();
     ASSERT_EQ(current, num_concretizations + (size_t)expect_miss);
     num_concretizations = current;
   };


### PR DESCRIPTION
This PR makes a few changes to the dynamic Fusion machinery. Mainly, this is to make ownership of `DynamicTransformInitialInfo`, `DynamicTransformConcretizationInfo`, and `ExpressionEvaluator` more clear. It avoids cloning (and using fusion-managed data for) `DynamicTransformConcretizationInfo` and does not store `Statement` pointers in that object. Instead we refer to lists of dynamic ops that are held in `initial_info`, which _can_ be cloned and is managed by the `Fusion`. This makes it easier to compare concretization infos that apply to different `Fusion`s, and to reuse it for the actual concretization without needing to clone again.

Minor changes:
- Move iteration through root dynamic vals to `finalizeDynamicVals()`.
- Use `executor_utils::bindInputs()` instead of manually binding inputs as in `getConcretizationInfo()`.
- Expose `FusionExecutorCache::countConcretizations()` and `FusionExecutorCache::countRuntimes()`