### PR TITLE
avoid 0 batch in layer norm backward

### DIFF
--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -136,11 +136,9 @@ std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
   // warp, gradually increase it. Runtime checkCombinedReductionShape ensures
   // inner_dim_numel is dividable by the multiplication of a quarter warp and
   // vectorize_factor.
+  int64_t threads_per_block = dev_prop->warpSize / 4;
   iop.inner_vect = (int64_t)vectorize_factor;
-  int64_t after_vectorization = inner_dim_numel / iop.inner_vect;
-  int64_t threads_per_block =
-      std::min((int64_t)dev_prop->warpSize / 4l, after_vectorization);
-  iop.inner_batch = after_vectorization / threads_per_block;
+  iop.inner_batch = inner_dim_numel / iop.inner_vect / threads_per_block;
   TORCH_INTERNAL_ASSERT(
       iop.inner_vect * iop.inner_batch * threads_per_block == inner_dim_numel,
       " inner_dim_numel must be dividable by the multiplication of a quarter warp and vectorize_factor");

--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -136,9 +136,11 @@ std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
   // warp, gradually increase it. Runtime checkCombinedReductionShape ensures
   // inner_dim_numel is dividable by the multiplication of a quarter warp and
   // vectorize_factor.
-  int64_t threads_per_block = dev_prop->warpSize / 4;
   iop.inner_vect = (int64_t)vectorize_factor;
-  iop.inner_batch = inner_dim_numel / iop.inner_vect / threads_per_block;
+  int64_t after_vectorization = inner_dim_numel / iop.inner_vect;
+  int64_t threads_per_block =
+      std::min((int64_t)dev_prop->warpSize / 4l, after_vectorization);
+  iop.inner_batch = after_vectorization / threads_per_block;
   TORCH_INTERNAL_ASSERT(
       iop.inner_vect * iop.inner_batch * threads_per_block == inner_dim_numel,
       " inner_dim_numel must be dividable by the multiplication of a quarter warp and vectorize_factor");

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -1932,7 +1932,7 @@ class PersistentKernelScheduler : public SchedulerEntry {
           data_cache,
           (int)(reduced_tv->nDims() - properties.inner_most_dimension_ndims));
       if (!checkCombinedReductionShape(
-              runtime_info, reduction_tvs, vectorize_factor)) {
+              runtime_info, reduction_tvs, (int64_t)vectorize_factor)) {
         scheduler_debug_utils::canScheduleRejectReason(
             ScheduleHeuristic::Persistent,
             "Inner dim of combined reduction should be a multiplication of a quarter warp and max vectorization factor!");

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -1922,7 +1922,17 @@ class PersistentKernelScheduler : public SchedulerEntry {
       }
     }
     if (inner_reduction && outer_reduction) {
-      if (!checkCombinedReductionShape(runtime_info, reduction_tvs)) {
+      // get vectorize_factor, same process to that in getPersistentHeuristics
+      auto reduced_tv = ir_utils::getSoleProducerTv(first_inner_reduction_tv);
+      auto properties = scheduler_utils::getReductionProperties(
+          fusion, runtime_info, first_inner_reduction_tv);
+      const auto vectorize_factor = vectorize_helper::getVectorizationFactor(
+          runtime_info,
+          reduced_tv,
+          data_cache,
+          (int)(reduced_tv->nDims() - properties.inner_most_dimension_ndims));
+      if (!checkCombinedReductionShape(
+              runtime_info, reduction_tvs, vectorize_factor)) {
         scheduler_debug_utils::canScheduleRejectReason(
             ScheduleHeuristic::Persistent,
             "Inner dim of combined reduction should be a multiplication of a quarter warp and max vectorization factor!");
@@ -2079,7 +2089,8 @@ class PersistentKernelScheduler : public SchedulerEntry {
 
   static bool checkCombinedReductionShape(
       SchedulerRuntimeInfo& runtime_info,
-      const std::vector<TensorView*>& reduction_tvs) {
+      const std::vector<TensorView*>& reduction_tvs,
+      const int64_t vectorization_factor) {
     // In combined_inner_outer_reduction, the inner dim should be a
     // multiplication of a quarter warp and vectorization factor. Otherwise,
     // will use segregated version. Since inner reduction dim is splitted by
@@ -2090,9 +2101,6 @@ class PersistentKernelScheduler : public SchedulerEntry {
         at::cuda::getCurrentDeviceProperties()->warpSize / 4;
     for (auto tv : reduction_tvs) {
       int64_t n_elements = 1;
-      const int64_t vectorization_factor = 16 /
-          (int64_t)dataTypeSize(tv->getDataType().value(),
-                                runtime_info.getIndexType());
       const int64_t n_elements_factor = quarter_warp * vectorization_factor;
       const bool is_inner_reduction =
           scheduler_utils::isFastestDimReduction(tv);

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -233,7 +233,7 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
   std::vector<DataType> data_types = {DataType::Half, DataType::Float};
   std::vector<std::vector<int64_t>> batch_sizes = {{216}};
   std::vector<std::vector<int64_t>> hidden_sizes = {
-      {576}, {768}, {1024}, {1280}, {1600}};
+      {32}, {576}, {768}, {1024}, {1280}, {1600}};
 
   bool isBenchmark = false;
   bool onlyTestFirstCase = false;

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -160,8 +160,30 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
         __LINE__,
         __FILE__);
 
+    // In combined_inner_outer_reduction, the inner dim should be a
+    // multiplication of a quarter warp and vectorization factor. Otherwise,
+    // will use segregated version, see checkCombinedReductionShape.
+    int64_t feature_size = 1;
+    for (auto s : norm_shape) {
+      feature_size *= s;
+    }
+    int64_t vectorization_factor = 16l / dataTypeSize(dtype);
+    // try 8, 4, 2, 1
+    while (feature_size % vectorization_factor) {
+      vectorization_factor /= 2;
+    }
+    const int64_t quarter_warp =
+        at::cuda::getCurrentDeviceProperties()->warpSize / 4;
+    const int64_t n_elements_factor = quarter_warp * vectorization_factor;
+    bool expect_segmentation = feature_size % n_elements_factor;
+
     bool is_segmented = fec.getMostRecentKernelRuntime()->isSegmented();
-    TORCH_CHECK(!is_segmented, "Fusion is segmented");
+    TORCH_CHECK(
+        expect_segmentation == is_segmented,
+        "Fusion segmentation is different from expected!, expected: ",
+        expect_segmentation,
+        ", actual: ",
+        is_segmented);
 
     if (isBenchmark) {
       FusionKernelRuntime* fkr = fec.getMostRecentKernelRuntime();
@@ -233,7 +255,7 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
   std::vector<DataType> data_types = {DataType::Half, DataType::Float};
   std::vector<std::vector<int64_t>> batch_sizes = {{216}};
   std::vector<std::vector<int64_t>> hidden_sizes = {
-      {32}, {576}, {768}, {1024}, {1280}, {1600}};
+      {32}, {96}, {576}, {768}, {1024}, {1280}, {1600}};
 
   bool isBenchmark = false;
   bool onlyTestFirstCase = false;


### PR DESCRIPTION
Fix #465 
The vectorization factor was not correctly calculated in `checkCombinedReductionShape`