### PR TITLE
Add tensor factory `torch.tensor`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,7 +358,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/test/test_expr_simplifier.cpp
     ${NVFUSER_ROOT}/test/test_external_src.cpp
     ${NVFUSER_ROOT}/test/test_swizzle.cpp
-    ${NVFUSER_ROOT}/test/test_gpu_tensor_factories.cpp
+    ${NVFUSER_ROOT}/test/test_tensor_factories.cpp
     ${NVFUSER_ROOT}/test/test_gpu_fused_reduction.cpp
     ${NVFUSER_ROOT}/test/test_gpu_outer_reduction.cpp
     ${NVFUSER_ROOT}/test/test_loop_rotation.cpp

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -572,6 +572,16 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     TORCH_INTERNAL_ASSERT(false, "Unreachable");
   }
 
+  void handleUntypedVal(const Val* v) final {
+    const auto def = v->definition();
+    const bool has_alloc = alloc_map_.find(v) != alloc_map_.end();
+    if (def != nullptr && !has_alloc) {
+      code_ << v->dtype() << "(" << genInline(def) << ")";
+    } else {
+      code_ << genVariableName(v);
+    }
+  }
+
   //! Utility for generating vectorized pointer access in ldsm and
   //!  cpasync.
   //! TODO: this access pattern as is could be merged with exisiting
@@ -959,6 +969,39 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       code_ << top->getTernaryOpType() << "(" << gen(top->in1()) << ", "
             << gen(top->in2()) << ", " << gen(top->in3()) << ")";
     }
+
+    if (!print_inline_) {
+      code_ << ";\n";
+    }
+  }
+
+  void handle(const ArrayConstruct* aop) final {
+    if (!print_inline_) {
+      indent() << gen(aop->out()) << " = ";
+    }
+
+    code_ << "{";
+    bool first = true;
+    for (auto in : aop->inputs()) {
+      if (!first) {
+        code_ << ", ";
+      }
+      first = false;
+      code_ << gen(in);
+    }
+    code_ << "}";
+
+    if (!print_inline_) {
+      code_ << ";\n";
+    }
+  }
+
+  void handle(const GetItem* gop) final {
+    if (!print_inline_) {
+      indent() << gen(gop->out()) << " = ";
+    }
+
+    code_ << gen(gop->array()) << "[" << gen(gop->index()) << "]";
 
     if (!print_inline_) {
       code_ << ";\n";

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -572,7 +572,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     TORCH_INTERNAL_ASSERT(false, "Unreachable");
   }
 
-  void handleUntypedVal(const Val* v) final {
+  void handleArrayType(const Val* v) final {
     const auto def = v->definition();
     const bool has_alloc = alloc_map_.find(v) != alloc_map_.end();
     if (def != nullptr && !has_alloc) {

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -48,9 +48,11 @@ class TORCH_CUDA_CU_API IndexLowering : private OptOutConstDispatch {
   void handle(const EyeOp*) final;
   void handle(const ViewAsScalar*) final;
   void handle(const UnaryOp*) final;
-
   void handle(const BinaryOp*) final;
   void handle(const TernaryOp*) final;
+  void handle(const ArrayConstruct*) final;
+  void handle(const GetItem*) final;
+  void handle(const TensorConstruct*) final;
   void handle(const SelectOp*) final;
   void handle(const IndexSelectOp*) final;
   void handle(const TorchGatherOp*) final;

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -134,6 +134,7 @@ bool isTvOp(const Expr* expr) {
           UnaryOp,
           BinaryOp,
           TernaryOp,
+          TensorConstruct,
           SelectOp,
           IndexSelectOp,
           TorchGatherOp,

--- a/csrc/dispatch.cpp
+++ b/csrc/dispatch.cpp
@@ -52,8 +52,8 @@ void Val::dispatch(T handler, Val* val) {
         ptr(handler)->handle(val->as<Int>());
         return;
       }
-      if (!std::holds_alternative<PrimDataType>(val->getDataType()->type)) {
-        ptr(handler)->handleUntypedVal(val);
+      if (std::holds_alternative<ArrayOf>(val->getDataType()->type)) {
+        ptr(handler)->handleArrayType(val);
         return;
       }
       switch (std::get<PrimDataType>(val->getDataType()->type)) {
@@ -354,8 +354,8 @@ void Val::constDispatch(T handler, const Val* val) {
         ptr(handler)->handle(val->as<Int>());
         return;
       }
-      if (!std::holds_alternative<PrimDataType>(val->getDataType()->type)) {
-        ptr(handler)->handleUntypedVal(val);
+      if (std::holds_alternative<ArrayOf>(val->getDataType()->type)) {
+        ptr(handler)->handleArrayType(val);
         return;
       }
       switch (std::get<PrimDataType>(val->getDataType()->type)) {
@@ -869,7 +869,7 @@ void OptOutConstDispatch::handle(const AggregateVal* stmt) {
   unhandled(stmt);
 }
 
-void OptOutConstDispatch::handleUntypedVal(const Val* stmt) {
+void OptOutConstDispatch::handleArrayType(const Val* stmt) {
   unhandled(stmt);
 }
 
@@ -1076,7 +1076,7 @@ void OptOutDispatch::handle(AggregateVal* stmt) {
   unhandled(stmt);
 }
 
-void OptOutDispatch::handleUntypedVal(Val* stmt) {
+void OptOutDispatch::handleArrayType(Val* stmt) {
   unhandled(stmt);
 }
 

--- a/csrc/dispatch.cpp
+++ b/csrc/dispatch.cpp
@@ -667,8 +667,8 @@ void Val::mutatorDispatch(T mutator, Val* val) {
         ptr(mutator)->mutate(val->as<Int>());
         return;
       }
-      if (!std::holds_alternative<PrimDataType>(val->getDataType()->type)) {
-        ptr(mutator)->mutateUntypedVal(val);
+      if (std::holds_alternative<ArrayOf>(val->getDataType()->type)) {
+        ptr(mutator)->mutateArrayType(val);
         return;
       }
       switch (std::get<PrimDataType>(val->getDataType()->type)) {

--- a/csrc/dispatch.cpp
+++ b/csrc/dispatch.cpp
@@ -52,6 +52,10 @@ void Val::dispatch(T handler, Val* val) {
         ptr(handler)->handle(val->as<Int>());
         return;
       }
+      if (!std::holds_alternative<PrimDataType>(val->getDataType()->type)) {
+        ptr(handler)->handleUntypedVal(val);
+        return;
+      }
       switch (std::get<PrimDataType>(val->getDataType()->type)) {
         case DataType::Bool:
           ptr(handler)->handle(val->as<Bool>());
@@ -139,6 +143,18 @@ void Expr::dispatch(T handler, Expr* expr) {
   }
   if (expr->isStrictlyA<TernaryOp>()) {
     ptr(handler)->handle(expr->as<TernaryOp>());
+    return;
+  }
+  if (expr->isStrictlyA<ArrayConstruct>()) {
+    ptr(handler)->handle(expr->as<ArrayConstruct>());
+    return;
+  }
+  if (expr->isStrictlyA<GetItem>()) {
+    ptr(handler)->handle(expr->as<GetItem>());
+    return;
+  }
+  if (expr->isStrictlyA<TensorConstruct>()) {
+    ptr(handler)->handle(expr->as<TensorConstruct>());
     return;
   }
   if (expr->isStrictlyA<SelectOp>()) {
@@ -338,6 +354,10 @@ void Val::constDispatch(T handler, const Val* val) {
         ptr(handler)->handle(val->as<Int>());
         return;
       }
+      if (!std::holds_alternative<PrimDataType>(val->getDataType()->type)) {
+        ptr(handler)->handleUntypedVal(val);
+        return;
+      }
       switch (std::get<PrimDataType>(val->getDataType()->type)) {
         case DataType::Bool:
           ptr(handler)->handle(val->as<Bool>());
@@ -425,6 +445,18 @@ void Expr::constDispatch(T handler, const Expr* expr) {
   }
   if (expr->isStrictlyA<TernaryOp>()) {
     ptr(handler)->handle(expr->as<TernaryOp>());
+    return;
+  }
+  if (expr->isStrictlyA<ArrayConstruct>()) {
+    ptr(handler)->handle(expr->as<ArrayConstruct>());
+    return;
+  }
+  if (expr->isStrictlyA<GetItem>()) {
+    ptr(handler)->handle(expr->as<GetItem>());
+    return;
+  }
+  if (expr->isStrictlyA<TensorConstruct>()) {
+    ptr(handler)->handle(expr->as<TensorConstruct>());
     return;
   }
   if (expr->isStrictlyA<SelectOp>()) {
@@ -635,6 +667,10 @@ void Val::mutatorDispatch(T mutator, Val* val) {
         ptr(mutator)->mutate(val->as<Int>());
         return;
       }
+      if (!std::holds_alternative<PrimDataType>(val->getDataType()->type)) {
+        ptr(mutator)->mutateUntypedVal(val);
+        return;
+      }
       switch (std::get<PrimDataType>(val->getDataType()->type)) {
         case DataType::Bool:
           ptr(mutator)->mutate(val->as<Bool>());
@@ -833,6 +869,10 @@ void OptOutConstDispatch::handle(const AggregateVal* stmt) {
   unhandled(stmt);
 }
 
+void OptOutConstDispatch::handleUntypedVal(const Val* stmt) {
+  unhandled(stmt);
+}
+
 // Exprs
 void OptOutConstDispatch::handle(const FullOp* stmt) {
   unhandled(stmt);
@@ -850,6 +890,15 @@ void OptOutConstDispatch::handle(const BinaryOp* stmt) {
   unhandled(stmt);
 }
 void OptOutConstDispatch::handle(const TernaryOp* stmt) {
+  unhandled(stmt);
+}
+void OptOutConstDispatch::handle(const ArrayConstruct* stmt) {
+  unhandled(stmt);
+}
+void OptOutConstDispatch::handle(const GetItem* stmt) {
+  unhandled(stmt);
+}
+void OptOutConstDispatch::handle(const TensorConstruct* stmt) {
   unhandled(stmt);
 }
 void OptOutConstDispatch::handle(const SelectOp* stmt) {
@@ -1027,6 +1076,10 @@ void OptOutDispatch::handle(AggregateVal* stmt) {
   unhandled(stmt);
 }
 
+void OptOutDispatch::handleUntypedVal(Val* stmt) {
+  unhandled(stmt);
+}
+
 // Exprs
 void OptOutDispatch::handle(FullOp* stmt) {
   unhandled(stmt);
@@ -1044,6 +1097,15 @@ void OptOutDispatch::handle(BinaryOp* stmt) {
   unhandled(stmt);
 }
 void OptOutDispatch::handle(TernaryOp* stmt) {
+  unhandled(stmt);
+}
+void OptOutDispatch::handle(ArrayConstruct* stmt) {
+  unhandled(stmt);
+}
+void OptOutDispatch::handle(GetItem* stmt) {
+  unhandled(stmt);
+}
+void OptOutDispatch::handle(TensorConstruct* stmt) {
   unhandled(stmt);
 }
 void OptOutDispatch::handle(SelectOp* stmt) {

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -83,6 +83,9 @@ class EyeOp;
 class UnaryOp;
 class BinaryOp;
 class TernaryOp;
+class ArrayConstruct;
+class GetItem;
+class TensorConstruct;
 class SelectOp;
 class IndexSelectOp;
 class TorchGatherOp;
@@ -165,6 +168,8 @@ class TORCH_CUDA_CU_API OptOutConstDispatch : public PolymorphicBase {
 
   virtual void handle(const AggregateVal*);
 
+  virtual void handleUntypedVal(const Val*);
+
   // Exprs
   virtual void handle(const FullOp* stmt);
   virtual void handle(const IotaOp* stmt);
@@ -172,6 +177,9 @@ class TORCH_CUDA_CU_API OptOutConstDispatch : public PolymorphicBase {
   virtual void handle(const UnaryOp* stmt);
   virtual void handle(const BinaryOp* stmt);
   virtual void handle(const TernaryOp* stmt);
+  virtual void handle(const ArrayConstruct* stmt);
+  virtual void handle(const GetItem* stmt);
+  virtual void handle(const TensorConstruct* stmt);
   virtual void handle(const SelectOp* stmt);
   virtual void handle(const IndexSelectOp* stmt);
   virtual void handle(const TorchGatherOp* stmt);
@@ -246,6 +254,8 @@ class TORCH_CUDA_CU_API OptOutDispatch : public PolymorphicBase {
 
   virtual void handle(AggregateVal*);
 
+  virtual void handleUntypedVal(Val*);
+
   // Exprs
   virtual void handle(FullOp* stmt);
   virtual void handle(IotaOp* stmt);
@@ -253,6 +263,9 @@ class TORCH_CUDA_CU_API OptOutDispatch : public PolymorphicBase {
   virtual void handle(UnaryOp* stmt);
   virtual void handle(BinaryOp* stmt);
   virtual void handle(TernaryOp* stmt);
+  virtual void handle(ArrayConstruct* stmt);
+  virtual void handle(GetItem* stmt);
+  virtual void handle(TensorConstruct* stmt);
   virtual void handle(SelectOp* stmt);
   virtual void handle(IndexSelectOp* stmt);
   virtual void handle(TorchGatherOp* stmt);
@@ -365,6 +378,8 @@ class TORCH_CUDA_CU_API OptOutMutator : public PolymorphicBase {
 
   virtual void mutate(kir::Predicate*);
   virtual void mutate(kir::TensorIndex*);
+
+  virtual void mutateUntypedVal(Val*);
 
  protected:
   virtual void removeExpr(IrContainer*, Expr*) const;

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -379,7 +379,7 @@ class TORCH_CUDA_CU_API OptOutMutator : public PolymorphicBase {
   virtual void mutate(kir::Predicate*);
   virtual void mutate(kir::TensorIndex*);
 
-  virtual void mutateUntypedVal(Val*);
+  virtual void mutateArrayType(Val*);
 
  protected:
   virtual void removeExpr(IrContainer*, Expr*) const;

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -168,7 +168,7 @@ class TORCH_CUDA_CU_API OptOutConstDispatch : public PolymorphicBase {
 
   virtual void handle(const AggregateVal*);
 
-  virtual void handleUntypedVal(const Val*);
+  virtual void handleArrayType(const Val*);
 
   // Exprs
   virtual void handle(const FullOp* stmt);
@@ -254,7 +254,7 @@ class TORCH_CUDA_CU_API OptOutDispatch : public PolymorphicBase {
 
   virtual void handle(AggregateVal*);
 
-  virtual void handleUntypedVal(Val*);
+  virtual void handleArrayType(Val*);
 
   // Exprs
   virtual void handle(FullOp* stmt);

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -233,6 +233,12 @@ class TORCH_CUDA_CU_API Val : public Statement {
 
   Val(const Val* src, IrCloner* ir_cloner);
 
+  std::string toString(int = 0) const override {
+    std::stringstream ss;
+    ss << "[" << dtype() << " value " << name() << "]";
+    return ss.str();
+  }
+
   // Dispatch functions, definitions in dispatch.cpp
   template <typename T>
   static void dispatch(T handler, Val*);

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -21,6 +21,9 @@ Val* IrBuilder::newScalar(DataType dtype) {
   if (isPointerType(dtype)) {
     return IrBuilder::create<Int>(dtype);
   }
+  if (!std::holds_alternative<PrimDataType>(dtype.type)) {
+    return IrBuilder::create<Val>(ValType::Scalar, dtype);
+  }
   switch (std::get<PrimDataType>(dtype.type)) {
     case DataType::Bool:
       return IrBuilder::create<Bool>();
@@ -198,6 +201,13 @@ Val* IrBuilder::minExpr(Val* lhs, Val* rhs) {
 
 Val* IrBuilder::gcdExpr(Val* lhs, Val* rhs) {
   return newArithmeticExpr(BinaryOpType::Gcd, lhs, rhs);
+}
+
+Val* IrBuilder::getItemExpr(Val* array, Val* index) {
+  auto item_dtype = std::get<ArrayOf>(array->dtype().type).type;
+  auto out = newScalar(*item_dtype);
+  create<GetItem>(array->container(), out, array, index);
+  return out;
 }
 
 Val* SimplifyingIrBuilder::negExpr(Val* val) {

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -419,6 +419,81 @@ class TORCH_CUDA_CU_API TernaryOp : public Expr {
       std::string in3) const;
 };
 
+// construct an array from a list of values
+class TORCH_CUDA_CU_API ArrayConstruct : public Expr {
+ public:
+  using Expr::Expr;
+
+  ArrayConstruct(IrBuilderPasskey, Val* output, std::vector<Val*> inputs);
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  const char* getOpString() const override {
+    return "ArrayConstruct";
+  }
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+
+  Val* out() const {
+    return output(0);
+  }
+};
+
+// Get an item from an array, array[index]
+class TORCH_CUDA_CU_API GetItem : public Expr {
+ public:
+  using Expr::Expr;
+
+  GetItem(IrBuilderPasskey, Val* output, Val* array, Val* index);
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  const char* getOpString() const override {
+    return "GetItem";
+  }
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+
+  Val* out() const {
+    return output(0);
+  }
+
+  Val* array() const {
+    return input(0);
+  }
+
+  Val* index() const {
+    return input(1);
+  }
+};
+
+// Construct a tensor from an array
+class TORCH_CUDA_CU_API TensorConstruct : public Expr {
+ public:
+  using Expr::Expr;
+
+  TensorConstruct(IrBuilderPasskey, TensorView* output, Val* input);
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  const char* getOpString() const override {
+    return "TensorConstruct";
+  }
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+
+  TensorView* out() const {
+    return output(0)->as<TensorView>();
+  }
+
+  Val* in() const {
+    return input(0);
+  }
+};
+
 //! A specialization for random number generator (RNG) operations. RNG
 //! operations take in no tensor input and produce a single output.
 class TORCH_CUDA_CU_API RNGOp : public Expr {

--- a/csrc/kernel_ir_dispatch.h
+++ b/csrc/kernel_ir_dispatch.h
@@ -34,7 +34,7 @@ class Scope;
 // Expr list
 class TORCH_CUDA_CU_API IrVisitor : public OptOutDispatch {
  public:
-  std::vector<Expr*> handle(const std::vector<Expr*>& expr);
+  std::vector<Expr*> handle(const std::vector<Expr*>& exprs);
 
  protected:
   using OptOutDispatch::handle;
@@ -52,7 +52,7 @@ class TORCH_CUDA_CU_API IrVisitor : public OptOutDispatch {
 // Const version of IrVisitor
 class TORCH_CUDA_CU_API ConstIrVisitor : public OptOutConstDispatch {
  public:
-  std::vector<const Expr*> handle(const std::vector<const Expr*>& expr);
+  std::vector<const Expr*> handle(const std::vector<const Expr*>& exprs);
 
  protected:
   using OptOutConstDispatch::handle;
@@ -93,7 +93,7 @@ class TORCH_CUDA_CU_API ConstIrVisitor : public OptOutConstDispatch {
 class ExprMutator : public IrVisitor {
  protected:
   std::vector<Expr*> traverseAndInsert(
-      const std::vector<Expr*>& expr,
+      const std::vector<Expr*>& exprs,
       bool reverse_order = false);
 
   std::vector<Expr*> mutate(bool reverse_order = false);

--- a/csrc/mutator.cpp
+++ b/csrc/mutator.cpp
@@ -133,6 +133,8 @@ void OptOutMutator::mutate(kir::TensorIndex*) {
   TORCH_INTERNAL_ASSERT(false, "Not implemented yet.");
 }
 
+void OptOutMutator::mutateUntypedVal(Val* v) {}
+
 void OptOutMutator::mutate(Expr* op) {
   std::vector<Val*> mutated_inputs;
   mutated_inputs.reserve(op->inputs().size());

--- a/csrc/mutator.cpp
+++ b/csrc/mutator.cpp
@@ -133,7 +133,7 @@ void OptOutMutator::mutate(kir::TensorIndex*) {
   TORCH_INTERNAL_ASSERT(false, "Not implemented yet.");
 }
 
-void OptOutMutator::mutateUntypedVal(Val* v) {}
+void OptOutMutator::mutateArrayType(Val* v) {}
 
 void OptOutMutator::mutate(Expr* op) {
   std::vector<Val*> mutated_inputs;

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2401,7 +2401,7 @@ TensorView* tensor(Val* val) {
   }
   std::vector<int64_t> sizes;
   while (std::holds_alternative<ArrayOf>(dtype.type)) {
-    sizes.push_back(std::get<ArrayOf>(dtype.type).size);
+    sizes.push_back((int64_t)std::get<ArrayOf>(dtype.type).size);
     dtype = *std::get<ArrayOf>(dtype.type).type;
   }
   TORCH_INTERNAL_ASSERT(

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -9,6 +9,7 @@
 
 #include <c10/macros/Export.h>
 
+#include <ir/builder.h>
 #include <ir/interface_nodes.h>
 #include <type.h>
 #include <type_promotion.h>
@@ -769,5 +770,14 @@ TORCH_CUDA_CU_API TensorView* fusedMultiplySum(
     TensorView* tv_b,
     const std::vector<int>& axes,
     Val* init = nullptr);
+
+// Create a tensor view from the given value. The given value can be a single
+// scalar, an array of scalars, or a nested array of scalars.
+TensorView* tensor(Val* val);
+
+template <typename T>
+TensorView* tensor(const std::vector<T>& vals) {
+  return tensor(IrBuilder::arrayExpr(vals));
+}
 
 } // namespace nvfuser

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1093,6 +1093,9 @@ std::string typePrefix(const DataType data_type) {
   if (std::holds_alternative<PointerOf>(data_type.type)) {
     return "ptr";
   }
+  if (std::holds_alternative<ArrayOf>(data_type.type)) {
+    return "a";
+  }
   switch (std::get<PrimDataType>(data_type.type)) {
     case DataType::Bool:
       return "b";

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -86,7 +86,7 @@ struct DataType;
 
 struct ArrayOf {
   std::shared_ptr<DataType> type;
-  int64_t size;
+  size_t size;
   inline bool operator==(const ArrayOf& other) const;
 };
 

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -86,7 +86,7 @@ struct DataType;
 
 struct ArrayOf {
   std::shared_ptr<DataType> type;
-  size_t size;
+  int64_t size;
   inline bool operator==(const ArrayOf& other) const;
 };
 

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -301,8 +301,9 @@ std::vector<KeyType> getSortedKeys(
 
 // Based on https://stackoverflow.com/a/9154394
 template <typename T>
-static auto hasToStringHelper(int)
-    -> decltype(std::declval<typename std::remove_pointer<T>::type>().toString(), std::true_type{});
+static auto hasToStringHelper(int) -> decltype(
+    std::declval<typename std::remove_pointer<T>::type>().toString(),
+    std::true_type{});
 
 template <typename>
 static auto hasToStringHelper(long) -> std::false_type;

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -301,9 +301,8 @@ std::vector<KeyType> getSortedKeys(
 
 // Based on https://stackoverflow.com/a/9154394
 template <typename T>
-static auto hasToStringHelper(int) -> decltype(
-    std::declval<typename std::remove_pointer<T>::type>().toString(),
-    std::true_type{});
+static auto hasToStringHelper(int)
+    -> decltype(std::declval<typename std::remove_pointer<T>::type>().toString(), std::true_type{});
 
 template <typename>
 static auto hasToStringHelper(long) -> std::false_type;
@@ -457,6 +456,22 @@ std::string toDelimitedString(
   return ss.str();
 }
 
+template <typename ContainerOfStatement>
+std::string toDelimitedInlineString(
+    const ContainerOfStatement& container,
+    std::string delim = ", ") {
+  std::stringstream ss;
+  bool first_val = true;
+  for (const auto& item : container) {
+    if (!first_val) {
+      ss << delim;
+    }
+    ss << item->toInlineString();
+    first_val = false;
+  }
+  return ss.str();
+}
+
 template <typename... Args>
 class DebugPrintScope {
  public:
@@ -514,5 +529,14 @@ class KernelIndexTypeCompute {
  private:
   int64_t tensor_most_positive_index_ = 0;
 };
+
+template <typename>
+struct is_std_vector : std::false_type {};
+
+template <typename T, typename A>
+struct is_std_vector<std::vector<T, A>> : std::true_type {};
+
+template <typename T>
+constexpr auto is_std_vector_v = is_std_vector<T>::value;
 
 } // namespace nvfuser

--- a/runtime/array.cu
+++ b/runtime/array.cu
@@ -6,7 +6,7 @@
  */
 // clang-format on
 // aligned register array for vectorized load/store
-template <typename scalar_t, int size, int align_size>
+template <typename scalar_t, int size, int align_size = 1>
 struct alignas(sizeof(scalar_t) * align_size) Array {
   scalar_t array[size];
 

--- a/test/test_tensor_factories.cpp
+++ b/test/test_tensor_factories.cpp
@@ -20,7 +20,9 @@
 
 namespace nvfuser {
 
-TEST_F(NVFuserTest, FusionStandaloneFull_CUDA) {
+class TensorFactoryTest : public NVFuserTest {};
+
+TEST_F(TensorFactoryTest, StandaloneFull) {
   auto sizes = {0, 1, 10, 17, 1024};
   auto dtypes = {
       at::kBool,
@@ -83,7 +85,7 @@ TEST_F(NVFuserTest, FusionStandaloneFull_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionStandaloneZeros_CUDA) {
+TEST_F(TensorFactoryTest, StandaloneZeros) {
   auto sizes = {0, 1, 10, 17, 1024};
   auto dtypes = {
       at::kBool,
@@ -140,7 +142,7 @@ TEST_F(NVFuserTest, FusionStandaloneZeros_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionStandaloneOnes_CUDA) {
+TEST_F(TensorFactoryTest, StandaloneOnes) {
   auto sizes = {0, 1, 10, 17, 1024};
   auto dtypes = {
       at::kBool,
@@ -197,7 +199,7 @@ TEST_F(NVFuserTest, FusionStandaloneOnes_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionStandaloneIota_CUDA) {
+TEST_F(TensorFactoryTest, StandaloneIota) {
   auto starts = {-1., 0., 10.3, 1024. * 256};
   auto steps = {-1.5, 1., 2.};
   auto lengths = {0, 1, 2, 10, 1023, 1024, 1024 * 1024};
@@ -289,7 +291,7 @@ TEST_F(NVFuserTest, FusionStandaloneIota_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionStandaloneARange_CUDA) {
+TEST_F(TensorFactoryTest, StandaloneARange) {
   auto starts_ends = {-1., 0., 10.3, 1024. * 256};
   auto steps = {-1.5, 1., 2.};
   auto dtypes = {at::kFloat, at::kLong, at::kDouble};
@@ -368,7 +370,7 @@ TEST_F(NVFuserTest, FusionStandaloneARange_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionStandaloneEye_CUDA) {
+TEST_F(TensorFactoryTest, StandaloneEye) {
   auto sizes = {0, 1, 10, 17, 1024};
   auto dtypes = {
       at::kBool,
@@ -424,7 +426,7 @@ TEST_F(NVFuserTest, FusionStandaloneEye_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionARangeScalarHoisting1_CUDA) {
+TEST_F(TensorFactoryTest, ARangeScalarHoisting1) {
   if (isOptionDisabled(DisableOption::IndexHoist)) {
     GTEST_SKIP() << "Index hoisting disabled";
   }
@@ -483,6 +485,33 @@ __global__ void CUDAGeneratedKernel(int64_t i0, int64_t i1, int64_t i2, Tensor<i
       {t0, t1},
       __LINE__,
       __FILE__);
+}
+
+TEST_F(TensorFactoryTest, TensorConstruct) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  Val* i00 = IrBuilder::create<Int>();
+  Val* i01 = IrBuilder::create<Int>();
+  Val* i10 = IrBuilder::create<Int>();
+  Val* i11 = IrBuilder::create<Int>();
+  fusion->addInput(i00);
+  fusion->addInput(i01);
+  fusion->addInput(i10);
+  fusion->addInput(i11);
+  auto output = tensor(std::vector<std::vector<Val*>>{{i00, i01}, {i10, i11}});
+  fusion->addOutput(output);
+
+  FusionExecutor fe;
+  fe.compileFusion(fusion.get());
+  auto cg_outputs = fe.runFusion({00, 01, 10, 11});
+
+  const auto options =
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
+  at::Tensor expect = at::tensor({00, 01, 10, 11}, options).view({2, 2});
+
+  testValidate(
+      fusion.get(), cg_outputs, {00, 01, 10, 11}, {expect}, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
[`torch.tensor`](https://pytorch.org/docs/stable/generated/torch.tensor.html?highlight=tensor#torch.tensor) is a tensor factory that constructs a tensor from given scalar values. This PR adds support for this tensor factory to our C++ API. Python frontend is not supported yet, because of the following reason:

This tensor factory is not something we prioritize to have. However, building this out requires improving our array support in codegen. The main purpose of this PR is to build out array infrastructure and a great portion of this work will be reused for TMA support (which takes an argument of N dimensional coordinates as index). The prototype for TMA is at https://github.com/NVIDIA/Fuser/pull/455

In the future, if this tensor factory turns out to be useful, we can add python frontend at that time. (It will NOT be easy, because python's `[[1, 2], [2, 4]]` and `[1, 2]` are identical types, but in C++, they are different types)

Generated code for `TensorFactoryTest.TensorConstruct`:

```CUDA
__global__ void kernel1(int64_t i0, int64_t i1, int64_t i2, int64_t i3, Tensor<int64_t, 2, 2> T0) {
  NVFUSER_DEFINE_MAGIC_ZERO;
  Array<int64_t, 2, 1> a4;
  a4 = {i2, i3};
  Array<int64_t, 2, 1> a5;
  a5 = {i0, i1};
  Array<Array<int64_t, 2, 1>, 2, 1> a6;
  a6 = {a5, a4};
  #pragma unroll
  for(nvfuser_index_t i7 = 0; i7 < 2; ++i7) {
    int64_t i8;
    i8 = 2 * i7;
    Array<int64_t, 2, 1> a9;
    a9 = a6[i7];
    #pragma unroll
    for(nvfuser_index_t i10 = 0; i10 < 2; ++i10) {
      int64_t i11;
      i11 = i10 + nvfuser_zero;
      T0[(i8 + i11)] = (a9[i11]);
    }
  }
  NVFUSER_UPDATE_MAGIC_ZERO;
}
```