### PR TITLE
disable warning check in dynamo integration

### DIFF
--- a/python_tests/test_dynamo.py
+++ b/python_tests/test_dynamo.py
@@ -51,10 +51,7 @@ class TestNvFuserDynamo(TestCase):
         def func(a, b):
             return a.sin() + b.cos()
 
-        # No warnings and no errors
-        with warnings.catch_warnings(record=True) as w:
-            nvfuser_result = func(input1, input2)
-            self.assertEqual(len(w), 0)
+        nvfuser_result = func(input1, input2)
         eager_result = func.__wrapped__(input1, input2)
         self.assertEqual(eager_result, nvfuser_result)
 


### PR DESCRIPTION
dynamo integration has run into these deprecation warning. Since we are no long maintaining the stack, I'm removing the warning check
```
{message : UserWarning("'has_cuda' is deprecated, please use 'torch.backends.cuda.is_built()'"), category : 'UserWarning', filename : '/opt/pytorch/pytorch/torch/overrides.py', lineno : 111, line : None}
{message : UserWarning("'has_cudnn' is deprecated, please use 'torch.backends.cudnn.is_available()'"), category : 'UserWarning', filename : '/opt/pytorch/pytorch/torch/overrides.py', lineno : 112, line : None}
{message : UserWarning("'has_mps' is deprecated, please use 'torch.backends.mps.is_built()'"), category : 'UserWarning', filename : '/opt/pytorch/pytorch/torch/overrides.py', lineno : 118, line : None}
{message : UserWarning("'has_mkldnn' is deprecated, please use 'torch.backends.mkldnn.is_available()'"), category : 'UserWarning', filename : '/opt/pytorch/pytorch/torch/overrides.py', lineno : 119, line : None}

```