### PR TITLE
Llu/refactor batch

### DIFF
--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -122,8 +122,9 @@ std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
   // inner_dim_numel is dividable by the multiplication of a quarter warp and
   // vectorize_factor.
   iop.inner_vect = (int64_t)vectorize_factor;
-  iop.inner_batch = normalization_scheduler_utils::getInnerOuterPersistentBufferBatches(
-      iop.inner_vect, inner_dim_numel, outer_dim_numel, dev_prop->warpSize);
+  iop.inner_batch =
+      normalization_scheduler_utils::getInnerOuterPersistentBufferBatches(
+          iop.inner_vect, inner_dim_numel, outer_dim_numel, dev_prop->warpSize);
   int64_t threads_per_block =
       inner_dim_numel / iop.inner_vect / iop.inner_batch;
   TORCH_INTERNAL_ASSERT(

--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -122,7 +122,7 @@ std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
   // inner_dim_numel is dividable by the multiplication of a quarter warp and
   // vectorize_factor.
   iop.inner_vect = (int64_t)vectorize_factor;
-  iop.inner_batch = normalization_scheduler_utils::getPersistentBufferBatches(
+  iop.inner_batch = normalization_scheduler_utils::getInnerOuterPersistentBufferBatches(
       iop.inner_vect, inner_dim_numel, outer_dim_numel, dev_prop->warpSize);
   int64_t threads_per_block =
       inner_dim_numel / iop.inner_vect / iop.inner_batch;

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -625,7 +625,7 @@ int64_t partialReductionBufferSize(
   return partial_reduction_buffer_size;
 }
 
-int64_t getPersistentBufferBatches(
+int64_t getInnerOuterPersistentBufferBatches(
     const int64_t inner_vect,
     const int64_t inner_dim_numel,
     const int64_t outer_dim_numel,

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -625,5 +625,54 @@ int64_t partialReductionBufferSize(
   return partial_reduction_buffer_size;
 }
 
+int64_t getPersistentBufferBatches(
+    const int64_t inner_vect,
+    const int64_t inner_dim_numel,
+    const int64_t outer_dim_numel,
+    const int64_t warpSize) {
+  // if inner_dim_numel <= 1024, we are doing multiple reductions per block
+  // with a constant batch size of 1
+  if (inner_dim_numel <= 1024l) {
+    return 1l;
+  }
+  // Set a minimum workload for each thread to take advantage of low
+  // intra-threads communication cost. Tuned for layer_norm backward on A100.
+  auto getMinimumBatch = [&]() -> int64_t {
+    if (inner_dim_numel >= 3072l) {
+      if (outer_dim_numel <= 2048l && inner_dim_numel == 3072l) {
+        return 3l;
+      } else {
+        return 4l;
+      }
+    } else if (inner_dim_numel >= 2048l) {
+      return 2l;
+    }
+    return 1l;
+  };
+  int64_t threads_per_block = warpSize / 4;
+  int64_t inner_batch = inner_dim_numel / inner_vect / threads_per_block;
+  const int64_t threads_per_block_max = inner_dim_numel >= 20480l ? 512l : 256l;
+  const int64_t batch_min = getMinimumBatch();
+  auto tryReduceBatch = [&](auto factor) -> bool {
+    return inner_batch % factor == 0 && inner_batch / factor >= batch_min &&
+        threads_per_block * factor <= threads_per_block_max;
+  };
+  while (inner_batch > batch_min && threads_per_block < threads_per_block_max) {
+    bool modified = false;
+    for (auto factor : {2, 3, 5}) {
+      if (tryReduceBatch(factor)) {
+        inner_batch /= factor;
+        threads_per_block *= factor;
+        modified = true;
+        break;
+      }
+    }
+    if (!modified) {
+      break;
+    }
+  }
+  return inner_batch;
+}
+
 } // namespace normalization_scheduler_utils
 } // namespace nvfuser

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -631,7 +631,8 @@ int64_t getInnerOuterPersistentBufferBatches(
     const int64_t outer_dim_numel,
     const int64_t warpSize) {
   // if inner_dim_numel <= 1024, we are doing multiple reductions per block
-  // with a constant batch size of 1
+  // with a constant batch size of 1. See Step 5 of
+  // innerOuterPersistentHeuristic
   if (inner_dim_numel <= 1024l) {
     return 1l;
   }

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -180,5 +180,16 @@ bool isConnectedOnlyThroughReductionProducer(
 int64_t partialReductionBufferSize(
     const std::vector<TensorView*>& outer_reduction_tvs,
     SchedulerRuntimeInfo& runtime_info);
+
+//! Calculate the persistent buffer batches in each thread.
+//! Start from a large value of inner_dim_numel / (inner_vect * warpSize/4),
+//! gradually reduce to small values but not smaller than a threshold determined
+//! by inner_dim_numel and outer_dim_numel.
+int64_t getPersistentBufferBatches(
+    const int64_t inner_vect,
+    const int64_t inner_dim_numel,
+    const int64_t outer_dim_numel,
+    const int64_t warpSize);
+
 } // namespace normalization_scheduler_utils
 } // namespace nvfuser

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -185,7 +185,7 @@ int64_t partialReductionBufferSize(
 //! Start from a large value of inner_dim_numel / (inner_vect * warpSize/4),
 //! gradually reduce to small values but not smaller than a threshold determined
 //! by inner_dim_numel and outer_dim_numel.
-int64_t getPersistentBufferBatches(
+int64_t getInnerOuterPersistentBufferBatches(
     const int64_t inner_vect,
     const int64_t inner_dim_numel,
     const int64_t outer_dim_numel,


### PR DESCRIPTION
This PR refactored the code to calculate batch size from `innerOuterPersistentHeuristic` to `normalization_scheduler_utils::getInnerOuterPersistentBufferBatches`.