### PR TITLE
Add `broadcast_in_dim` opinfo test

### DIFF
--- a/python_tests/pytest_framework.py
+++ b/python_tests/pytest_framework.py
@@ -4,6 +4,7 @@
 # Owner(s): ["module: nvfuser"]
 
 import inspect
+import os
 import sys
 import torch
 from typing import Callable
@@ -53,5 +54,11 @@ def run_test_fn(test_fn, opinfo, dtype, *args, **kwargs):
     try:
         test_fn(*args, **kwargs)
     except Exception as e:
+        # Raises exceptions that occur with pytest, and returns debug information when
+        # called otherwise
+        # NOTE: PYTEST_CURRENT_TEST is set by pytest
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            raise e
+
         return e, sys.exc_info(), test_fn, opinfo, dtype, args, kwargs
     return None

--- a/python_tests/pytest_framework.py
+++ b/python_tests/pytest_framework.py
@@ -4,8 +4,6 @@
 # Owner(s): ["module: nvfuser"]
 
 import inspect
-import os
-import sys
 import torch
 from typing import Callable
 from pytest_utils import map_dtype_to_str
@@ -48,17 +46,3 @@ class create_op_test:
                 )
                 # Adds the instantiated test to the requested scope
                 self.scope[test.__name__] = test
-
-
-def run_test_fn(test_fn, opinfo, dtype, *args, **kwargs):
-    try:
-        test_fn(*args, **kwargs)
-    except Exception as e:
-        # Raises exceptions that occur with pytest, and returns debug information when
-        # called otherwise
-        # NOTE: PYTEST_CURRENT_TEST is set by pytest
-        if "PYTEST_CURRENT_TEST" in os.environ:
-            raise e
-
-        return e, sys.exc_info(), test_fn, opinfo, dtype, args, kwargs
-    return None

--- a/python_tests/pytest_input_generators.py
+++ b/python_tests/pytest_input_generators.py
@@ -54,13 +54,7 @@ def bcast_in_dim_error_generator(
 
     # 2. New shape has weakly more dimentions than the original tensor.
     fewer_dims_in_output_shape = (
-        (
-            [2, 2],
-            [
-                2,
-            ],
-            [0],
-        ),
+        ([2, 2], [2], [0]),
         RuntimeError,
         "The new shape is expected to be greater-then-or-equal to the input",
     )

--- a/python_tests/pytest_input_generators.py
+++ b/python_tests/pytest_input_generators.py
@@ -13,7 +13,7 @@ from pytest_core import OpInfo, SampleInput, ErrorSample
 from nvfuser import DataType
 
 
-def bcast_error_generator(
+def broadcast_error_generator(
     op: OpInfo, dtype: torch.dtype, requires_grad: bool = False, **kwargs
 ):
     # jax.lax.broadcast(operand, sizes)
@@ -48,7 +48,7 @@ def bcast_error_generator(
         yield SampleInput(input_tensor, bcast_dims), ex_type, ex_str
 
 
-def bcast_in_dim_generator(
+def broadcast_in_dim_generator(
     op: OpInfo, dtype: torch.dtype, requires_grad: bool = False, **kwargs
 ):
     make_arg = partial(
@@ -72,7 +72,7 @@ def bcast_in_dim_generator(
         yield SampleInput(a, output_shape, bcast_dims)
 
 
-def bcast_in_dim_error_generator(
+def broadcast_in_dim_error_generator(
     op: OpInfo, dtype: torch.dtype, requires_grad: bool = False, **kwargs
 ):
     # jax.lax.broadcast_in_dim(operand, shape, broadcast_dimensions)

--- a/python_tests/pytest_opinfos.py
+++ b/python_tests/pytest_opinfos.py
@@ -7,9 +7,9 @@ import torch
 import jax
 from pytest_core import OpInfo, ReferenceType, Domain
 from pytest_input_generators import (
-    bcast_error_generator,
-    bcast_in_dim_generator,
-    bcast_in_dim_error_generator,
+    broadcast_error_generator,
+    broadcast_in_dim_generator,
+    broadcast_in_dim_error_generator,
     elementwise_unary_generator,
     _elementwise_unary_torch,
     define_tensor_generator,
@@ -76,7 +76,7 @@ shape_ops = []
 broadcast_opinfo = OpInfo(
     lambda fd: fd.ops.broadcast,
     "broadcast",
-    error_input_generator=bcast_error_generator,
+    error_input_generator=broadcast_error_generator,
     symbolic_parameter_list=(True, False),
 )
 shape_ops.append(broadcast_opinfo)
@@ -84,8 +84,8 @@ shape_ops.append(broadcast_opinfo)
 broadcast_in_dim_opinfo = OpInfo(
     lambda fd: fd.ops.broadcast_in_dim,
     "broadcast_in_dim",
-    sample_input_generator=bcast_in_dim_generator,
-    error_input_generator=bcast_in_dim_error_generator,
+    sample_input_generator=broadcast_in_dim_generator,
+    error_input_generator=broadcast_in_dim_error_generator,
     reference=jax.lax.broadcast_in_dim,
     reference_type=ReferenceType.Jax,
     symbolic_parameter_list=(True, False, False),

--- a/python_tests/pytest_opinfos.py
+++ b/python_tests/pytest_opinfos.py
@@ -7,6 +7,8 @@ import torch
 import jax
 from pytest_core import OpInfo, ReferenceType, Domain
 from pytest_input_generators import (
+    bcast_in_dim_generator,
+    bcast_in_dim_error_generator,
     elementwise_unary_generator,
     _elementwise_unary_torch,
     define_tensor_generator,
@@ -69,6 +71,17 @@ normalization_ops.append(var_mean_opinfo)
 """ Start Shape Operations """
 
 shape_ops = []
+
+broadcast_in_dim_opinfo = OpInfo(
+    lambda fd: fd.ops.broadcast_in_dim,
+    "broadcast_in_dim",
+    sample_input_generator=bcast_in_dim_generator,
+    error_input_generator=bcast_in_dim_error_generator,
+    reference=jax.lax.broadcast_in_dim,
+    reference_type=ReferenceType.Jax,
+    symbolic_parameter_list=(True, False, False),
+)
+shape_ops.append(broadcast_in_dim_opinfo)
 
 slice_opinfo = OpInfo(
     lambda fd: fd.ops.slice,

--- a/python_tests/pytest_opinfos.py
+++ b/python_tests/pytest_opinfos.py
@@ -7,6 +7,7 @@ import torch
 import jax
 from pytest_core import OpInfo, ReferenceType, Domain
 from pytest_input_generators import (
+    bcast_error_generator,
     bcast_in_dim_generator,
     bcast_in_dim_error_generator,
     elementwise_unary_generator,
@@ -71,6 +72,14 @@ normalization_ops.append(var_mean_opinfo)
 """ Start Shape Operations """
 
 shape_ops = []
+
+broadcast_opinfo = OpInfo(
+    lambda fd: fd.ops.broadcast,
+    "broadcast",
+    error_input_generator=bcast_error_generator,
+    symbolic_parameter_list=(True, False),
+)
+shape_ops.append(broadcast_opinfo)
 
 broadcast_in_dim_opinfo = OpInfo(
     lambda fd: fd.ops.broadcast_in_dim,

--- a/python_tests/pytest_ops.py
+++ b/python_tests/pytest_ops.py
@@ -190,7 +190,7 @@ def test_correctness(op: OpInfo, dtype: torch.dtype):
 
 
 # TODO Maybe only test a single dtype
-@create_op_test(tuple(op for op in opinfos))
+@create_op_test(tuple(op for op in opinfos if op.sample_input_generator is not None))
 def test_definition_op_in_schedule_error(op: OpInfo, dtype: torch.dtype):
     for sample in op.sample_input_generator(op, torch.float32):
         result = run_test_fn(


### PR DESCRIPTION
Adds correctness and error checks for `broadcast_in_dim`

We are missing a check for this assumption `tensor.shape[idx] == 1 or tensor.shape[idx] == output_shape[new_idx]` in `broadcast_in_dim`