### PR TITLE
add sync to warp reduction runtime avoid smem data race

### DIFF
--- a/runtime/warp.cu
+++ b/runtime/warp.cu
@@ -80,6 +80,9 @@ __device__ void warpReduceTIDX(
     if (is_warp_head) {
       reduction_op(out, reduce_val);
     }
+    // needs sync, otherwise other warps may access shared memory before this
+    // reduction is done.
+    block_sync::sync<Aligned>();    
   } else {
     reduction_op(out, reduce_val);
   }

--- a/runtime/warp.cu
+++ b/runtime/warp.cu
@@ -82,7 +82,7 @@ __device__ void warpReduceTIDX(
     }
     // needs sync, otherwise other warps may access shared memory before this
     // reduction is done.
-    block_sync::sync<Aligned>();    
+    block_sync::sync<Aligned>();
   } else {
     reduction_op(out, reduce_val);
   }


### PR DESCRIPTION
Add sync to warp reduction runtime avoid smem data race. It solves #271 