### PR TITLE
Llu/all vect

### DIFF
--- a/benchmark/layer_norm_backward.cpp
+++ b/benchmark/layer_norm_backward.cpp
@@ -264,6 +264,58 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_fp16)
     ->Args({16 * 1024, 1600})
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
+
+// Non-divisible batch split
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_LayerNorm_BWD_nondiv_fp16,
+    setupLayerNorm_BWD,
+    NvFuserScheduler_LayerNorm_BWD,
+    DataType::Half);
+
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_LayerNorm_BWD_nondiv_fp32,
+    setupLayerNorm_BWD,
+    NvFuserScheduler_LayerNorm_BWD,
+    DataType::Float);
+
+auto add_args = [](benchmark::internal::Benchmark* b) {
+  const int64_t batch_size = 16 * 1024;
+  std::vector<std::vector<int64_t>> args;
+  std::vector<int64_t> prime_factors = {
+      7,
+      11,
+      13,
+      17,
+      19,
+      101,
+      103,
+      107,
+      109,
+      113,
+      211,
+      223,
+      227,
+      229,
+      233,
+      239,
+      241};
+  for (auto p : prime_factors) {
+    args.push_back({batch_size, p * 64l});
+  }
+  for (const auto& a : args) {
+    b->Args(a);
+  }
+};
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_nondiv_fp16)
+    ->Apply(add_args)
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_nondiv_fp32)
+    ->Apply(add_args)
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
 //------------------------------------------------------------------------------
 
 BENCHMARK(Baseline_LayerNorm_BWD_fp32)

--- a/benchmark/layer_norm_backward.cpp
+++ b/benchmark/layer_norm_backward.cpp
@@ -317,6 +317,58 @@ NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_nondiv_fp32)
     ->Unit(benchmark::kMicrosecond)
     ->UseManualTime();
 //------------------------------------------------------------------------------
+// Not a factor of 64
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_LayerNorm_BWD_non64_fp16,
+    setupLayerNorm_BWD,
+    NvFuserScheduler_LayerNorm_BWD,
+    DataType::Half);
+
+NVFUSER_BENCHMARK_DEFINE(
+    NvFuserScheduler_LayerNorm_BWD_non64_fp32,
+    setupLayerNorm_BWD,
+    NvFuserScheduler_LayerNorm_BWD,
+    DataType::Float);
+
+auto add_args_non64 = [](benchmark::internal::Benchmark* b) {
+  const int64_t batch_size = 16 * 1024;
+  std::vector<std::vector<int64_t>> args;
+  std::vector<int64_t> prime_factors = {
+      7,
+      11,
+      13,
+      17,
+      19,
+      101,
+      103,
+      107,
+      109,
+      113,
+      211,
+      223,
+      227,
+      229,
+      233,
+      239,
+      241};
+  for (auto p : prime_factors) {
+    args.push_back({batch_size, p * 63l});
+  }
+  for (const auto& a : args) {
+    b->Args(a);
+  }
+};
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_non64_fp16)
+    ->Apply(add_args_non64)
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+
+NVFUSER_BENCHMARK_RUN(NvFuserScheduler_LayerNorm_BWD_non64_fp32)
+    ->Apply(add_args_non64)
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();
+//------------------------------------------------------------------------------
 
 BENCHMARK(Baseline_LayerNorm_BWD_fp32)
     // ->RangeMultiplier(2)

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -343,6 +343,10 @@ Bool* PredicateCompute::getInlinePredicate(
   // If outputs are registers, no need to predicate for threads
   if (isOutputLocal(expr)) {
     thread_pred = gpu_lower->kernel()->trueVal();
+    // If it is a initilization op, return immediately.
+    if (ir_utils::isTensorScalarFillOp(expr)) {
+      return thread_pred;
+    }
   }
 
   if (loops.empty()) {

--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -123,20 +123,26 @@ std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
   // inner_dim_numel is dividable by the multiplication of a quarter warp and
   // vectorize_factor.
   iop.inner_vect = (int64_t)vectorize_factor;
-  auto opt_inner_batch = normalization_scheduler_utils::
+  const auto& batch_and_block_size = normalization_scheduler_utils::
       getOptionalInnerOuterPersistentBufferBatches(
           inner_dim_numel,
           outer_dim_numel,
           max_persistent_buffer_size,
           iop.inner_vect,
-          dev_prop->warpSize);
+          dev_prop->warpSize,
+          true);
+  auto opt_inner_batch = batch_and_block_size.first;
   TORCH_INTERNAL_ASSERT(opt_inner_batch.has_value());
   iop.inner_batch = opt_inner_batch.value();
-  int64_t threads_per_block =
-      inner_dim_numel / iop.inner_vect / iop.inner_batch;
+  int64_t threads_per_block = batch_and_block_size.second;
+
   TORCH_INTERNAL_ASSERT(
-      iop.inner_vect * iop.inner_batch * threads_per_block == inner_dim_numel,
-      " inner_dim_numel must be dividable by the multiplication of a quarter warp and vectorize_factor");
+      iop.inner_vect * iop.inner_batch * threads_per_block >= inner_dim_numel,
+      " iop.inner_vect * iop.inner_batch * threads_per_block should >= inner_dim_numel.");
+  const int64_t factor_of_block_size = dev_prop->warpSize / 4;
+  TORCH_INTERNAL_ASSERT(
+      threads_per_block % factor_of_block_size == 0,
+      " threads_per_block must have a factor of warp_size / 4.");
 
   // Step-2, set InnerParams Iteration dim: gdimy. reg_per_thread is estimated
   // from buffer size, then it is used to calculate threads_per_sm and gdimy.
@@ -170,9 +176,19 @@ std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
   const int64_t workload_per_thread = inner_dim_numel >= 4096 ? 4 : 2;
   iop.vectorization_factor_outer =
       std::min(workload_per_thread, max_tmp_gmem_vect_factor);
-  iop.bdimx = scheduler_utils::roundUpPow2(
+  // threads_per_block starts from 8 and multiplied by 2, 3, or 5.
+  // round bdimx to multiple of 8 will increase the probability of
+  // bdimx * bdimy == threads_per_block.
+  iop.bdimx = scheduler_utils::roundUpPow2Or8(
       ceilDiv(inner_dim_numel / iop.vectorization_factor_outer, iop.gdimy));
-
+  while (threads_per_block % iop.bdimx) {
+    iop.bdimx += 8;
+    if (iop.bdimx > threads_per_block) {
+      // should never reach here
+      iop.bdimx = threads_per_block;
+      break;
+    }
+  }
   // Step-4, set OuterParams Reduction dim: bdimy.
   iop.bdimy = ceilDiv(threads_per_block, iop.bdimx);
 
@@ -249,6 +265,8 @@ std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
     std::cerr << "\n===== Combined InnerOuter Reduction Stats ========\n"
               << "outer_dim_numel: " << outer_dim_numel << "\n"
               << "inner_dim_numel: " << inner_dim_numel << "\n"
+              << "max_persistent_buffer_size: " << max_persistent_buffer_size
+              << "\n"
               << "vectorize_factor_input: " << iop.inner_vect << "\n"
               << "vectorization_factor_tmp_gmem_write: "
               << iop.tmp_gmem_write_vect << "\n"

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -670,8 +670,9 @@ getOptionalInnerOuterPersistentBufferBatches(
   };
 
   int64_t threads_per_block = warp_size / 4;
-  const int64_t after_vectorization = inner_dim_numel / vectorize_factor;
-  int64_t inner_batch = after_vectorization / threads_per_block;
+  const int64_t after_vectorization =
+      ceilDiv(inner_dim_numel, vectorize_factor);
+  int64_t inner_batch = ceilDiv(after_vectorization, threads_per_block);
   const int64_t threads_per_block_min = std::min(after_vectorization, 128l);
   const int64_t threads_per_block_max = getThreadsPerSMGivenRegPerThread(255l);
   const int64_t batch_min = getMinimumBatch();

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -1978,8 +1978,9 @@ class PersistentKernelScheduler : public SchedulerEntry {
                    properties.total_iteration_numel,
                    persistent_buffer_size,
                    (int64_t)vectorize_factor,
-                   warp_size)
-                   .has_value()) {
+                   warp_size,
+                   false)
+                   .first.has_value()) {
         scheduler_debug_utils::canScheduleRejectReason(
             ScheduleHeuristic::Persistent,
             "Required batch number is larger than available batch number! Will cause register spills!");

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -1962,13 +1962,6 @@ class PersistentKernelScheduler : public SchedulerEntry {
           reduced_tv,
           data_cache,
           (int)(reduced_tv->nDims() - properties.inner_most_dimension_ndims));
-      if (!checkCombinedReductionShape(
-              runtime_info, reduction_tvs, (int64_t)vectorize_factor)) {
-        scheduler_debug_utils::canScheduleRejectReason(
-            ScheduleHeuristic::Persistent,
-            "Inner dim of combined reduction should be a multiplication of a quarter warp and max vectorization factor!");
-        return false;
-      }
 
       // check if we can schedule the combined reductions with a reasonable
       // batch size without register spills.
@@ -2098,41 +2091,6 @@ class PersistentKernelScheduler : public SchedulerEntry {
         scheduler_debug_utils::canScheduleRejectReason(
             ScheduleHeuristic::Persistent,
             "to use combined reduction, inner reduction and outer reduction should not have shared consumer, their consumers should not have shared non-outer-reduction producer.");
-        return false;
-      }
-    }
-    return true;
-  }
-
-  static bool checkCombinedReductionShape(
-      SchedulerRuntimeInfo& runtime_info,
-      const std::vector<TensorView*>& reduction_tvs,
-      const int64_t vectorization_factor) {
-    // In combined_inner_outer_reduction, the inner dim should be a
-    // multiplication of a quarter warp and vectorization factor. Otherwise,
-    // will use segregated version. Since inner reduction dim is splitted by
-    // bdimx, this ensures the largest possible bdimx can be at least of a
-    // quarter warp. So we have enough bdimx threads to cover the iteration
-    // domain of the outer reductions to avoid low performance.
-    const int64_t quarter_warp =
-        at::cuda::getCurrentDeviceProperties()->warpSize / 4;
-    for (auto tv : reduction_tvs) {
-      int64_t n_elements = 1;
-      const int64_t n_elements_factor = quarter_warp * vectorization_factor;
-      const bool is_inner_reduction =
-          scheduler_utils::isFastestDimReduction(tv);
-      for (auto id : tv->getMaybeRFactorDomain()) {
-        // check reduction domain for inner reduction and iteration domain for
-        // outer reduction
-        if (id->isReduction() == is_inner_reduction) {
-          auto id_size =
-              runtime_info.expressionEvaluator().evaluate(id->extent());
-          TORCH_INTERNAL_ASSERT(
-              id_size.has_value(), "Could not infer reduction dim size.");
-          n_elements *= id_size->as<int64_t>();
-        }
-      }
-      if (n_elements % n_elements_factor) {
         return false;
       }
     }

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -192,9 +192,10 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
             batch_size,
             persistent_bytes_per_row,
             vectorization_factor,
-            warp_size);
+            warp_size,
+            false);
     bool expect_segmentation =
-        feature_size % n_elements_factor || !opt_inner_batch.has_value();
+        feature_size % n_elements_factor || !opt_inner_batch.first.has_value();
 
     bool is_segmented = fec.getMostRecentKernelRuntime()->isSegmented();
     TORCH_CHECK(


### PR DESCRIPTION
This PR builds upon #494 and extends the functionality of the combined layer norm to handle cases where feature sizes cannot be vectorized. Even without accounting for the segmentation overhead, the combined version outperforms the segmented version in speed. If the feature size exceeds 14K, segmentation will occur to avoid severe register spills.
Feature size is set to 63 x selected prime_numbers from 7 to 241.
Performance change for fp16:
![image](https://github.com/NVIDIA/Fuser/assets/116412316/abad5b27-5ba6-48e7-94eb-dd816172fbd4)

Performance change for fp32:
![image](https://github.com/NVIDIA/Fuser/assets/116412316/7dbacbe7-e2a1-48b2-a79e-90421e0b0e24)
