### PR TITLE
Concretize dynamic slices

### DIFF
--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -40,7 +40,8 @@ class TORCH_CUDA_CU_API DynamicTransformInitialInfo {
 
   //! Return whether any dynamic transforms exist in the Fusion
   bool hasDynamicTransforms() const {
-    return !dynamic_reshaped_tvs_.empty() || !dynamic_resized_ids_.empty();
+    return !dynamic_reshaped_tvs_.empty() || !dynamic_resized_ids_.empty() ||
+        !dynamic_sliced_tvs_.empty();
   }
 
   //! Return a set of scalars that are inputs or extents of input TensorViews
@@ -60,6 +61,11 @@ class TORCH_CUDA_CU_API DynamicTransformInitialInfo {
   //! IterTypes
   const std::vector<IterDomain*>& getDynamicResizedIterDomains() const {
     return dynamic_resized_ids_;
+  }
+
+  //! Return a vector of outputs of Slice expressions
+  const std::vector<TensorView*>& getDynamicSlicedTensorViews() const {
+    return dynamic_sliced_tvs_;
   }
 
   std::string toString() const;
@@ -93,10 +99,49 @@ class TORCH_CUDA_CU_API DynamicTransformInitialInfo {
 
   std::vector<IterDomain*> dynamic_resized_ids_;
 
+  // Slice operations can have complicated output extents. The inputs to slice
+  // are a start, stop, and step for each sliced dimension. Each of these is an
+  // integer, and any combination of three finite integers with step != 0 is
+  // acceptable and should run without error. Normalization of the start and
+  // stop values must be done, followed by computation of the output extent:
+  //
+  //   normed_start = min(max(where(start < 0, extent + start, start), 0),
+  //   extent); normed_stop = max(min(max(where(stop < 0, extent + stop, stop),
+  //   0), extent), normed_start); extent = max((normed_stop - normed_start + 1)
+  //   / step, 0);
+  //
+  // These expressions are unwieldy and cannot be significantly simplified
+  // unless we know certain relations about the start, stop, and step scalars.
+  // Here we keep track of non-static slices or slices with non-static input
+  // extents. That way we can restrict to a single branch in each of these
+  // expressions during concretization.
+  std::vector<TensorView*> dynamic_sliced_tvs_;
+
   // Root Vals that determine concretization
   std::unordered_set<Val*> root_dynamic_vals_;
 
   friend class DynamicTransformInitialInfoBuilder;
+};
+
+//! This enum describes cases that can occur for the start or stop arguments to
+//! slice(). Each of these leads to a different branch in the normalized form's
+//! general expression.
+enum class SliceIndexBranch {
+  AlwaysZero, // a <= -extent
+  Negative, // -ext < a < 0
+  Positive, // 0 <= a < extent
+  AlwaysExtent // extent <= a
+};
+
+//! Describes a 1D slice in terms of the start, stop, and extent values
+struct Concrete1DSliceDescriptor {
+  //! These enums determine the form of the simplified expressions
+  SliceIndexBranch start_branch = SliceIndexBranch::Positive;
+  SliceIndexBranch stop_branch = SliceIndexBranch::Positive;
+
+  //! True if normalized values satisfy (stop - start) * step <= 0 in which case
+  //! we would return an empty tensor.
+  bool is_empty = false;
 };
 
 //! A set of transformations for a symbolic fusion with concrete sizes
@@ -117,6 +162,8 @@ class TORCH_CUDA_CU_API DynamicTransformConcretizationInfo {
 
     analyzeReshapes(expr_eval);
 
+    analyzeSlices(expr_eval);
+
     analyzeResizes(expr_eval);
   }
 
@@ -136,6 +183,15 @@ class TORCH_CUDA_CU_API DynamicTransformConcretizationInfo {
     return resize_itertypes_;
   }
 
+  //! Return a vector of pairs holding the index of each sliced TensorView in
+  //! the vector returned by initialInfo()->getDynamicSlicedTensorViews(),
+  //! along with a vector of descriptors indicating how each axis should be
+  //! concretized.
+  const std::vector<std::pair<size_t, std::vector<Concrete1DSliceDescriptor>>>&
+  getSliceDescriptors() const {
+    return slice_descriptors_;
+  }
+
   //! Comparison operator for the purposes of determining cache hits. This does
   //! not guarantee equality of all members. Instead, it returns equal if the
   //! resulting concretizations would be structurally equivalent. Note that
@@ -151,6 +207,10 @@ class TORCH_CUDA_CU_API DynamicTransformConcretizationInfo {
   //! determine the decomposition of each dynamic reshape operation to use
   //! during concretization.
   void analyzeReshapes(ExpressionEvaluator* expr_eval);
+
+  //! Given an ExpressionEvaluator which already has input scalars bound to it,
+  //! determine the branches of expressions in dynamic slice ops.
+  void analyzeSlices(ExpressionEvaluator* expr_eval);
 
   //! Given an ExpressionEvaluator which already has input scalars bound to it,
   //! determine the concrete IterType of each resized IterDomain.
@@ -189,6 +249,12 @@ class TORCH_CUDA_CU_API DynamicTransformConcretizationInfo {
   //! vector returned by initial_info_->getDynamicResizedIterDomains() along
   //! with its concretized IterType
   std::vector<std::pair<size_t, IterType>> resize_itertypes_;
+
+  //! Holds the index of the sliced TensorView (output of the SliceOp) in the
+  //! vector returned by initial_info_->getDynamicSlicedTensorViews() along
+  //! with a descriptor of how it should be concretized.
+  std::vector<std::pair<size_t, std::vector<Concrete1DSliceDescriptor>>>
+      slice_descriptors_;
 };
 
 class TORCH_CUDA_CU_API DynamicTransform {

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -639,10 +639,14 @@ TensorView* cat(const std::vector<TensorView*>& inputs, int64_t cat_dim) {
   return out;
 }
 
-// Currently there's no error check about  the actual values of the
-// Slice parameters. For example, the start parameter of a range of a
-// domain is assumed to be >= 0 and < the extent of the domain.
-TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges) {
+// If skip_symbolic is true, then the start and stop parameters of a range of a
+// domain is assumed to be >= 0 and < the extent of the domain. Otherwise,
+// non-constant inputs will lead to Symbolic IterDomains in the output, which
+// must be later concretized.
+TensorView* slice(
+    TensorView* inp,
+    const std::vector<Slice>& ranges,
+    bool skip_symbolic) {
   const auto inp_dom = TensorDomain::noReductions(inp->getMaybeRFactorDomain());
   const int ndims = static_cast<int>(inp_dom.size());
 
@@ -664,6 +668,19 @@ TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges) {
       range.step = FusionGuard::getCurFusion()->oneVal();
     }
     return range;
+  };
+
+  // Adjust an integer value relative to a given extent. This is
+  // min(max(where(a < 0, extent + a, a), 0), extent)
+  auto adjust_start_stop = [](int64_t& a, int64_t extent) {
+    if (a < 0) {
+      a += extent;
+    }
+    if (a < 0) {
+      a = 0;
+    } else if (a > extent) {
+      a = extent;
+    }
   };
 
   for (auto& range : ranges) {
@@ -693,11 +710,39 @@ TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges) {
     } else {
       out_root_id =
           IterDomainBuilder(inp_root_id).is_rfactor_domain(true).build();
-      out_rf_id = IterDomain::resize(
-          out_root_id,
-          SimplifyingIrBuilder::negExpr(range.start),
-          sub(range.stop, inp_root_id->extent()),
-          true);
+      // The start, stop, and extent of the output will all require complicated
+      // expressions which will be simplified at concretization. Here we set
+      // the output to Symbolic unless all required scalars are constant.
+      if (range.start->isConstInt() && range.stop->isConstInt() &&
+          inp_root_id->isConstInt()) {
+        auto start = range.start->evaluateInt();
+        auto stop = range.stop->evaluateInt();
+        auto step = range.step->evaluateInt();
+        TORCH_INTERNAL_ASSERT(step != 0, "Slice step must be non-zero");
+        TORCH_INTERNAL_ASSERT(
+            step == 1, "Slicing with step != 1 is not currently supported");
+        auto inp_extent = inp_root_id->extent()->evaluateInt();
+        adjust_start_stop(start, inp_extent);
+        adjust_start_stop(stop, inp_extent);
+        out_rf_id = IterDomain::resize(
+            out_root_id,
+            SimplifyingIrBuilder::negExpr(IrBuilder::create<Int>(start)),
+            sub(IrBuilder::create<Int>(stop), inp_root_id->extent()),
+            true);
+      } else if (skip_symbolic) {
+        out_rf_id = IterDomain::resize(
+            out_root_id,
+            SimplifyingIrBuilder::negExpr(range.start),
+            sub(range.stop, inp_root_id->extent()),
+            true);
+      } else {
+        out_rf_id = IterDomainBuilder(
+                        FusionGuard::getCurFusion()->zeroVal(),
+                        IrBuilder::create<Int>())
+                        .is_rfactor_domain(true)
+                        .iter_type(IterType::Symbolic)
+                        .build();
+      }
       needs_real_slicing = true;
     }
     root_ids.at(idx) = out_root_id;

--- a/csrc/ops/alias.h
+++ b/csrc/ops/alias.h
@@ -106,8 +106,13 @@ TORCH_CUDA_CU_API TensorView* cat(
 
 //! Return a tensor where each dimension is sliced as specified by the
 //! ranges parameter. Stepping must be one at this moment.
+//! If skip_symbolic is true, we assume start < stop and both start and stop are
+//! between 0 and extent (inclusive). Otherwise, unless all input scalars are
+//! constant, the output will have Symbolic IterDomains that must be concretized
+//! later.
 TORCH_CUDA_CU_API TensorView* slice(
     TensorView* inp,
-    const std::vector<Slice>& ranges);
+    const std::vector<Slice>& ranges,
+    bool skip_symbolic = false);
 
 } // namespace nvfuser


### PR DESCRIPTION
As discussed in #460 and #439, `start` & `stop` arguments to `slice` must be normalized, resulting in complicated branching expressions. In this PR, we make slices dynamic and decide the branches for these expressions at concretization, which lets us simplify the expressions. In some special cases this also lets us replace the slice with a `set` or `full` (for empty tensors).

Fixes #439.