### PR TITLE
`ForAllTypes` cleanup

### DIFF
--- a/csrc/C++20/type_traits
+++ b/csrc/C++20/type_traits
@@ -9,6 +9,7 @@
 
 namespace std {
 
+#if !__cpp_lib_type_identity
 template <typename T>
 struct type_identity {
   using type = T;
@@ -16,5 +17,6 @@ struct type_identity {
 
 template <typename T>
 using type_identity_t = typename type_identity<T>::type;
+#endif
 
 } // namespace std

--- a/csrc/C++20/type_traits
+++ b/csrc/C++20/type_traits
@@ -1,0 +1,20 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+namespace std {
+
+template <typename T>
+struct type_identity {
+  using type = T;
+};
+
+template <typename T>
+using type_identity_t = typename type_identity<T>::type;
+
+} // namespace std

--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -177,8 +177,8 @@ struct DynamicType {
   template <typename T, typename = std::enable_if_t<can_cast_to<T>>>
   explicit constexpr operator T() const {
     std::optional<T> ret = std::nullopt;
-    for_all_types([this, &ret](auto* from) {
-      using From = std::remove_pointer_t<decltype(from)>;
+    for_all_types([this, &ret](auto from) {
+      using From = typename decltype(from)::type;
       if constexpr (opcheck<From>.canCastTo(opcheck<T>)) {
         if (is<From>()) {
           ret = (T)as<From>();
@@ -251,10 +251,10 @@ constexpr bool is_dynamic_type_v = is_dynamic_type<T>::value;
           DT::types_as_tuple)>>                                             \
   inline constexpr DT operator op(DT x, DT y) {                             \
     DT ret(std::monostate{});                                               \
-    DT::for_all_types([&ret, x, y](auto* lhs) {                             \
-      using LHS = std::remove_pointer_t<decltype(lhs)>;                     \
-      DT::for_all_types([&ret, x, y](auto* rhs) {                           \
-        using RHS = std::remove_pointer_t<decltype(rhs)>;                   \
+    DT::for_all_types([&ret, x, y](auto lhs) {                              \
+      using LHS = typename decltype(lhs)::type;                             \
+      DT::for_all_types([&ret, x, y](auto rhs) {                            \
+        using RHS = typename decltype(rhs)::type;                           \
         if constexpr ((opcheck<LHS> op opcheck<RHS>)) {                     \
           if constexpr (DT::template is_candidate_type<                     \
                             decltype(std::declval<LHS>()                    \
@@ -291,8 +291,8 @@ constexpr bool is_dynamic_type_v = is_dynamic_type<T>::value;
           DT::types_as_tuple)>>                                             \
   inline constexpr DT operator op(DT x, RHS y) {                            \
     DT ret(std::monostate{});                                               \
-    DT::for_all_types([&ret, x, y](auto* lhs) {                             \
-      using LHS = std::remove_pointer_t<decltype(lhs)>;                     \
+    DT::for_all_types([&ret, x, y](auto lhs) {                              \
+      using LHS = typename decltype(lhs)::type;                             \
       if constexpr ((opcheck<LHS> op opcheck<RHS>)) {                       \
         if constexpr (DT::template is_candidate_type<                       \
                           decltype(std::declval<LHS>()                      \
@@ -328,8 +328,8 @@ constexpr bool is_dynamic_type_v = is_dynamic_type<T>::value;
           DT::types_as_tuple)>>                                             \
   inline constexpr DT operator op(LHS x, DT y) {                            \
     DT ret(std::monostate{});                                               \
-    DT::for_all_types([&ret, x, y](auto* rhs) {                             \
-      using RHS = std::remove_pointer_t<decltype(rhs)>;                     \
+    DT::for_all_types([&ret, x, y](auto rhs) {                              \
+      using RHS = typename decltype(rhs)::type;                             \
       if constexpr ((opcheck<LHS> op opcheck<RHS>)) {                       \
         if constexpr (DT::template is_candidate_type<                       \
                           decltype(std::declval<LHS>()                      \
@@ -384,8 +384,8 @@ DEFINE_BINARY_OP(ge, >=);
           opname##_helper, DT::types_as_tuple, DT::types_as_tuple)>>           \
   inline constexpr DT operator op(DT x) {                                      \
     DT ret(std::monostate{});                                                  \
-    DT::for_all_types([&ret, x](auto* _) {                                     \
-      using Type = std::remove_pointer_t<decltype(_)>;                         \
+    DT::for_all_types([&ret, x](auto _) {                                      \
+      using Type = typename decltype(_)::type;                                 \
       if constexpr (op opcheck<Type>) {                                        \
         if constexpr (DT::template is_candidate_type<                          \
                           decltype(op std::declval<Type>())>) {                \
@@ -436,8 +436,8 @@ template <
     typename = std::enable_if_t<any_check(can_print, DT::types_as_tuple)>>
 std::ostream& operator<<(std::ostream& os, const DT& dt) {
   bool printed = false;
-  DT::for_all_types([&printed, &os, &dt](auto* _) {
-    using T = std::remove_pointer_t<decltype(_)>;
+  DT::for_all_types([&printed, &os, &dt](auto _) {
+    using T = typename decltype(_)::type;
     if constexpr (opcheck<std::ostream&> << opcheck<T>) {
       if constexpr (std::is_same_v<
                         decltype(os << std::declval<T>()),
@@ -468,8 +468,8 @@ std::ostream& operator<<(std::ostream& os, const DT& dt) {
           std::enable_if_t<any_check(opname##_helper, DT::types_as_tuple)>>    \
   inline constexpr DT& operator op(DT& x) {                                    \
     bool computed = false;                                                     \
-    DT::for_all_types([&computed, &x](auto* _) {                               \
-      using Type = std::remove_pointer_t<decltype(_)>;                         \
+    DT::for_all_types([&computed, &x](auto _) {                                \
+      using Type = typename decltype(_)::type;                                 \
       if constexpr (op opcheck<Type&>) {                                       \
         if constexpr (std::is_same_v<                                          \
                           decltype(op std::declval<Type&>()),                  \
@@ -505,8 +505,8 @@ DEFINE_LEFT_PPMM(lmm, --);
           opname##_helper, DT::types_as_tuple, DT::types_as_tuple)>>           \
   inline constexpr DT operator op(DT& x, int) {                                \
     DT ret;                                                                    \
-    DT::for_all_types([&ret, &x](auto* _) {                                    \
-      using Type = std::remove_pointer_t<decltype(_)>;                         \
+    DT::for_all_types([&ret, &x](auto _) {                                     \
+      using Type = typename decltype(_)::type;                                 \
       if constexpr (opcheck<Type&> op) {                                       \
         if constexpr (DT::template is_candidate_type<                          \
                           decltype(std::declval<Type&>() op)>) {               \

--- a/csrc/type_traits.h
+++ b/csrc/type_traits.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <C++20/type_traits>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -349,8 +350,8 @@ struct Void {};
 //
 // For example, if you want to print 0.2 as bool, int, and float, you can do the
 // following:
-//   auto f = [](auto* x) {
-//     using T = std::remove_pointer_t<decltype(x)>;
+//   auto f = [](auto x) {
+//     using T = typename decltype(x)::type;
 //     std::cout << T(0.2) << std::endl;
 //   };
 //   ForAllTypes<bool, int, float>{}(f);
@@ -373,13 +374,13 @@ template <typename T, typename... Ts>
 struct ForAllTypes<T, Ts...> {
   template <typename Fun>
   constexpr auto operator()(Fun f) const {
-    using RetT = decltype(f((T*)nullptr));
+    using RetT = decltype(f(std::type_identity<T>{}));
     if constexpr (std::is_void_v<RetT>) {
-      f((T*)nullptr);
+      f(std::type_identity<T>{});
       return std::tuple_cat(std::tuple<Void>{}, ForAllTypes<Ts...>{}(f));
     } else {
       return std::tuple_cat(
-          std::make_tuple(f((T*)nullptr)), ForAllTypes<Ts...>{}(f));
+          std::make_tuple(f(std::type_identity<T>{})), ForAllTypes<Ts...>{}(f));
     }
   }
 };
@@ -487,8 +488,8 @@ namespace belongs_to_impl {
 // bool), then the return type is (true, void, void).
 template <typename T, typename... Ts>
 auto get_match_tuple() {
-  auto true_or_void = [](auto* x) {
-    using U = std::remove_pointer_t<decltype(x)>;
+  auto true_or_void = [](auto x) {
+    using U = typename decltype(x)::type;
     if constexpr (std::is_same_v<T, U>) {
       return true;
     } else {

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -219,14 +219,14 @@ using From2To10 = ForAllTypes<
     std::integral_constant<int, 10>>;
 
 constexpr bool is_prime(int n) {
-  return all(From2To10{}([n](auto* _) {
-    auto divisor = std::remove_pointer_t<decltype(_)>::value;
+  return all(From2To10{}([n](auto _) {
+    auto divisor = decltype(_)::type::value;
     return n % divisor != 0 || n == divisor;
   }));
 }
 
-auto void_or_prime = [](auto* _) constexpr {
-  constexpr auto value = std::remove_pointer_t<decltype(_)>::value;
+auto void_or_prime = [](auto _) constexpr {
+  constexpr auto value = decltype(_)::type::value;
   if constexpr (is_prime(value)) {
     return std::integral_constant<int, value>{};
   } else {


### PR DESCRIPTION
In `ForAllTypes`, we were using pointers to pass type information. However, this is not the standard way. The standard way is to use `std::type_identity`