### PR TITLE
Rename the prefix of environment variables to NVFUSER.

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -373,7 +373,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     }
 
     // Call the initialization function if using a custom block sync
-    if (std::getenv("PYTORCH_NVFUSER_USE_BLOCK_SYNC_ATOMIC")) {
+    if (getNvFuserEnv("USE_BLOCK_SYNC_ATOMIC")) {
       indent() << "block_sync::init();\n";
     }
   }
@@ -2832,7 +2832,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
   void handle(const kir::BlockSync* sync) final {
     // Use a custom synchronization method if enabled
-    if (std::getenv("PYTORCH_NVFUSER_USE_BLOCK_SYNC_ATOMIC")) {
+    if (getNvFuserEnv("USE_BLOCK_SYNC_ATOMIC")) {
       indent() << "block_sync::sync();\n";
     } else if (isAligned()) {
       indent() << "__syncthreads();\n";

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -951,7 +951,7 @@ bool PredicateElimination::setReductionInitValue(
 
 bool PredicateElimination::canOmitPredicate(const Expr* expr) const {
   // Predicate elimination can be disabled with
-  // PYTORCH_NVFUSER_DISABLE=predicate_elimination
+  // NVFUSER_DISABLE=predicate_elimination
   if (isOptionDisabled(DisableOption::PredicateElimination)) {
     assertOnWarpOps(expr);
     return false;

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -306,7 +306,7 @@ void FusionExecutor::compileFusion(
     buffer << cuda_src.rdbuf();
     return buffer.str();
   };
-  auto external_code_path = std::getenv("PYTORCH_NVFUSER_EXTERNAL_SRC");
+  auto external_code_path = getNvFuserEnv("EXTERNAL_SRC");
   const auto structured_code = external_code_path
       ? load_external_code(external_code_path)
       : getStructuredCode();

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -32,16 +32,16 @@ namespace nvfuser {
 namespace debug_print {
 
 // In order to print transformations from expr simplifier, use:
-//   PYTORCH_NVFUSER_DUMP="expr_simplify"
+//   NVFUSER_DUMP="expr_simplify"
 // By default (i.e. no trigger specified), enabling the above debug dump option
 // will trigger printing when the expression is transformed by at least one
 // simplification pass (A simplification pass is a pass that is not a flatten
 // or unflatten). If you want to print even if there is no simplification pass,
 // applied, use the following:
-//   PYTORCH_NVFUSER_DUMP="expr_simplify(assoc_comm::flatten)"
+//   NVFUSER_DUMP="expr_simplify(assoc_comm::flatten)"
 // If you want to trigger printing only on a specified set of passes, put the
 // pass names as arguments of `expr_simplify`, for example:
-//   PYTORCH_NVFUSER_DUMP="expr_simplify(eliminateTrivialComputation)"
+//   NVFUSER_DUMP="expr_simplify(eliminateTrivialComputation)"
 
 constexpr const char* kFlattenName = "assoc_comm::flatten";
 constexpr const char* kUnflattenName = "assoc_comm::unflatten";

--- a/csrc/instrumentation.cpp
+++ b/csrc/instrumentation.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <instrumentation.h>
 #include <options.h>
+#include <utils.h>
 
 #include <c10/macros/Export.h>
 
@@ -21,7 +22,7 @@ namespace nvfuser {
 namespace inst {
 
 Trace::Trace() {
-  const char* trace_filename = getenv("PYTORCH_NVFUSER_TRACE");
+  const char* trace_filename = getNvFuserEnv("TRACE");
   if (trace_filename != nullptr) {
     log_file_ = fopen(trace_filename, "w");
     TORCH_CHECK(log_file_ != nullptr, "Can't open trace file");

--- a/csrc/instrumentation.h
+++ b/csrc/instrumentation.h
@@ -24,7 +24,7 @@ namespace inst {
 //! This class is not intended to be used directly. Instead, the operations
 //! to be traced are marked (for example using the FUSER_PERF_SCOPE macro)
 //!
-//! In order to enable tracing, the `PYTORCH_NVFUSER_TRACE` environment
+//! In order to enable tracing, the `NVFUSER_TRACE` environment
 //! variable is set to point to a trace file (ex `test.trace`). The file name
 //! may be a relative or an absolute path.
 //!

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -29,8 +29,8 @@ namespace nvfuser {
 namespace {
 
 int getNumThreads() {
-  const char* option_env_name = "NVFUSER_NUM_THREADS";
-  auto dump_options = std::getenv(option_env_name);
+  const char* option_env_name = "NUM_THREADS";
+  auto dump_options = getNvFuserEnv(option_env_name);
   if (dump_options == nullptr) {
     constexpr int default_num_threads = 8;
     return default_num_threads;

--- a/csrc/manager.cpp
+++ b/csrc/manager.cpp
@@ -256,7 +256,7 @@ void compileCudaFusionGroup(torch::jit::Node* fusion_node) {
           __FUNCTION__,
           ". This is an indication that codegen Failed for some reason.\n"
           "To debug try disable codegen fallback path via setting the env"
-          " variable `export PYTORCH_NVFUSER_DISABLE=fallback`\n"
+          " variable `export NVFUSER_DISABLE=fallback`\n"
           "To report the issue, try enable logging via setting the env"
           "variable ` export PYTORCH_JIT_LOG_LEVEL=manager.cpp`\n");
       GRAPH_DUMP("`compile_fusion` hits fallback on graph\n", graph);

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -25,7 +25,7 @@ auto parseEnvOptions(
 
   std::unordered_map<OptionEnum, std::vector<std::string>> options;
 
-  if (const char* dump_options = std::getenv(option_env_name)) {
+  if (const char* dump_options = getNvFuserEnv(option_env_name)) {
     std::string_view options_view(dump_options);
     while (!options_view.empty()) {
       const auto comma_pos = options_view.find_first_of(',');
@@ -142,7 +142,7 @@ std::unordered_map<DebugDumpOption, std::vector<std::string>> Options<
       {"sync_map", DebugDumpOption::SyncMap},
       {"transform_propagator", DebugDumpOption::TransformPropagator}};
 
-  return parseEnvOptions("PYTORCH_NVFUSER_DUMP", available_options);
+  return parseEnvOptions("DUMP", available_options);
 }
 
 template <>
@@ -157,7 +157,7 @@ std::unordered_map<EnableOption, std::vector<std::string>> Options<
       {"linear_decomposition", EnableOption::LinearDecomposition},
       {"warn_register_spill", EnableOption::WarnRegisterSpill}};
 
-  return parseEnvOptions("PYTORCH_NVFUSER_ENABLE", available_options);
+  return parseEnvOptions("ENABLE", available_options);
 }
 
 template <>
@@ -177,11 +177,11 @@ std::unordered_map<DisableOption, std::vector<std::string>> Options<
       {"var_name_remapping", DisableOption::VarNameRemapping},
       {"welford_vectorization", DisableOption::WelfordVectorization}};
 
-  auto options = parseEnvOptions("PYTORCH_NVFUSER_DISABLE", available_options);
+  auto options = parseEnvOptions("DISABLE", available_options);
 
   if (options.count(DisableOption::Fma)) {
     TORCH_WARN(
-        "fmad is disabled for nvrtc, which could negatively affect performance. Try removing `fma` from env variable PYTORCH_NVFUSER_DISABLE for optimal performance.");
+        "fmad is disabled for nvrtc, which could negatively affect performance. Try removing `fma` from env variable NVFUSER_DISABLE for optimal performance.");
   }
 
   return options;

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -18,7 +18,7 @@ namespace nvfuser {
 
 //! Types of debug print-outs
 //!
-//! These can be set through the `PYTORCH_NVFUSER_DUMP` environment variable
+//! These can be set through the `NVFUSER_DUMP` environment variable
 //!
 enum class DebugDumpOption {
   FusionIr, //!< Dump the Fusion IR before lowering
@@ -72,7 +72,7 @@ enum class DebugDumpOption {
 
 //! Types of features to enable
 //!
-//! These can be set through the `PYTORCH_NVFUSER_ENABLE` environment variable
+//! These can be set through the `NVFUSER_ENABLE` environment variable
 //!
 enum class EnableOption {
   Complex, //! Enable complex support on python
@@ -87,7 +87,7 @@ enum class EnableOption {
 
 //! Types of features to disable
 //!
-//! These can be set through the `PYTORCH_NVFUSER_DISABLE` environment variable
+//! These can be set through the `NVFUSER_DISABLE` environment variable
 //!
 enum class DisableOption {
   CompileToSass, //! Disable direct compilation to sass so the ptx can be

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -188,15 +188,17 @@ int64_t getThreadsPerSMGivenRegPerThread(int64_t reg_per_thread) {
 }
 
 char* getNvFuserEnv(const char* env_name) {
+  // Prepend the default prefix and try if the variable is defined.
   const std::string prefix = "NVFUSER_";
-  const std::string pyt_prefix = "PYTORCH_NVFUSER_";
-
   auto prefixed_name = prefix + env_name;
   auto env = std::getenv(prefixed_name.c_str());
   if (env) {
     return env;
   }
 
+  // Try the PYTROCH_NVFUSER prefix as well, which is considered
+  // deprecated.
+  const std::string pyt_prefix = "PYTORCH_NVFUSER_";
   auto pyt_prefixed_name = pyt_prefix + env_name;
   auto pyt_env = std::getenv(pyt_prefixed_name.c_str());
   if (pyt_env) {

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -131,7 +131,7 @@ int8_t getCommonDeviceCUDA(
 
 bool useFallback() {
   // Keep this env var for compatibility
-  const char* disable_fb_env = getenv("PYTORCH_NVFUSER_DISABLE_FALLBACK");
+  const char* disable_fb_env = getNvFuserEnv("DISABLE_FALLBACK");
   bool fallback_disabled = disable_fb_env ? atoi(disable_fb_env) : false;
   fallback_disabled =
       fallback_disabled || isOptionDisabled(DisableOption::Fallback);
@@ -186,4 +186,30 @@ int64_t getThreadsPerSMGivenRegPerThread(int64_t reg_per_thread) {
   int num_warps = warps_per_sm_partition * num_partition;
   return num_warps * static_cast<int64_t>(warp_size);
 }
+
+char* getNvFuserEnv(const char* env_name) {
+  const std::string prefix = "NVFUSER_";
+  const std::string pyt_prefix = "PYTORCH_NVFUSER_";
+
+  auto prefixed_name = prefix + env_name;
+  auto env = std::getenv(prefixed_name.c_str());
+  if (env) {
+    return env;
+  }
+
+  auto pyt_prefixed_name = pyt_prefix + env_name;
+  auto pyt_env = std::getenv(pyt_prefixed_name.c_str());
+  if (pyt_env) {
+    TORCH_WARN(
+        "Environment variable, ",
+        pyt_prefixed_name,
+        ", is deprecated. Please use ",
+        prefixed_name,
+        " instead.");
+    return pyt_env;
+  }
+
+  return nullptr;
+}
+
 } // namespace nvfuser

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -436,4 +436,6 @@ inline void hashCombine(size_t& hash, size_t new_hash) {
   hash ^= new_hash + 0x9e3779b9 + (hash << 6) + (hash >> 2);
 }
 
+char* getNvFuserEnv(const char* env_name);
+
 } // namespace nvfuser

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -436,6 +436,7 @@ inline void hashCombine(size_t& hash, size_t new_hash) {
   hash ^= new_hash + 0x9e3779b9 + (hash << 6) + (hash >> 2);
 }
 
+//! A wrapper to std::getenv. env_name is prepended with NVFUSER_.
 char* getNvFuserEnv(const char* env_name);
 
 } // namespace nvfuser

--- a/nvfuser/README.md
+++ b/nvfuser/README.md
@@ -119,7 +119,7 @@ python -c "from nvfuser import FusionDefinition; help(FusionDefinition.Operators
 ```
 **View the fusion definitions that are executed by setting an environment variable:**
 ```python
-export PYTORCH_NVFUSER_DUMP=python_definition
+export NVFUSER_DUMP=python_definition
 ```
 Example Output:
 ```python

--- a/python_tests/test_torchscript.py
+++ b/python_tests/test_torchscript.py
@@ -26,7 +26,7 @@ if "NVFUSER_DISABLE" not in os.environ:
 os.environ["NVFUSER_DISABLE"] = (
     "fallback,fma," + os.environ["NVFUSER_DISABLE"]
 )
-os.environ["JIT_OPT_LEVEL"] = "0"
+os.environ["NVFUSER_JIT_OPT_LEVEL"] = "0"
 
 import torch
 from torch.nn import functional

--- a/python_tests/test_torchscript.py
+++ b/python_tests/test_torchscript.py
@@ -15,18 +15,18 @@ import warnings
 
 # Set NVFUSER_ envrionment variables. Make sure this is done before
 # loading nvfuser
-if "PYTORCH_NVFUSER_ENABLE" not in os.environ:
-    os.environ["PYTORCH_NVFUSER_ENABLE"] = ""
-os.environ["PYTORCH_NVFUSER_ENABLE"] = (
+if "NVFUSER_ENABLE" not in os.environ:
+    os.environ["NVFUSER_ENABLE"] = ""
+os.environ["NVFUSER_ENABLE"] = (
     "linear_decomposition,conv_decomposition,graph_op_fusion,"
-    + os.environ["PYTORCH_NVFUSER_ENABLE"]
+    + os.environ["NVFUSER_ENABLE"]
 )
-if "PYTORCH_NVFUSER_DISABLE" not in os.environ:
-    os.environ["PYTORCH_NVFUSER_DISABLE"] = ""
-os.environ["PYTORCH_NVFUSER_DISABLE"] = (
-    "fallback,fma," + os.environ["PYTORCH_NVFUSER_DISABLE"]
+if "NVFUSER_DISABLE" not in os.environ:
+    os.environ["NVFUSER_DISABLE"] = ""
+os.environ["NVFUSER_DISABLE"] = (
+    "fallback,fma," + os.environ["NVFUSER_DISABLE"]
 )
-os.environ["PYTORCH_NVFUSER_JIT_OPT_LEVEL"] = "0"
+os.environ["JIT_OPT_LEVEL"] = "0"
 
 import torch
 from torch.nn import functional
@@ -80,7 +80,7 @@ if os.environ.get("NVFUSER_TEST_ONLY_RUN_WHEEL_BUILD_SUBSET", "0") == "1":
 
 # TODO: enable complex when we fixes the extremal cases in OpInfo
 # see issue https://github.com/csarofeen/pytorch/issues/1730"
-# os.environ['PYTORCH_NVFUSER_ENABLE'] = 'complex'
+# os.environ['NVFUSER_ENABLE'] = 'complex'
 
 if GRAPH_EXECUTOR == ProfilingMode.PROFILING:
     torch._C._jit_set_texpr_fuser_enabled(False)

--- a/python_tests/test_torchscript.py
+++ b/python_tests/test_torchscript.py
@@ -23,9 +23,7 @@ os.environ["NVFUSER_ENABLE"] = (
 )
 if "NVFUSER_DISABLE" not in os.environ:
     os.environ["NVFUSER_DISABLE"] = ""
-os.environ["NVFUSER_DISABLE"] = (
-    "fallback,fma," + os.environ["NVFUSER_DISABLE"]
-)
+os.environ["NVFUSER_DISABLE"] = "fallback,fma," + os.environ["NVFUSER_DISABLE"]
 os.environ["NVFUSER_JIT_OPT_LEVEL"] = "0"
 
 import torch

--- a/runtime/grid_reduction.cu
+++ b/runtime/grid_reduction.cu
@@ -295,7 +295,7 @@ __device__ void gridReduce(
 // measure the elapsed cycles. The measurement must be done just by
 // one thread, and in this case it should be done by one of the
 // threads in the last thread block.
-#ifdef PYTORCH_NVFUSER_PROFILE_KERNEL
+#ifdef NVFUSER_PROFILE_KERNEL
 template <
     bool X_BLOCK,
     bool Y_BLOCK,
@@ -357,7 +357,7 @@ __device__ void gridReduce(
     ++count;
   }
 }
-#endif // PYTORCH_NVFUSER_PROFILE_KERNEL
+#endif // NVFUSER_PROFILE_KERNEL
 
 template <
     bool X_BLOCK,
@@ -545,7 +545,7 @@ __device__ void gridReduceGroup(
   }
 }
 
-#ifdef PYTORCH_NVFUSER_PROFILE_KERNEL
+#ifdef NVFUSER_PROFILE_KERNEL
 template <
     bool X_BLOCK,
     bool Y_BLOCK,
@@ -621,6 +621,6 @@ __device__ void gridReduceGroup(
     ++count;
   }
 }
-#endif // PYTORCH_NVFUSER_PROFILE_KERNEL
+#endif // NVFUSER_PROFILE_KERNEL
 
 } // namespace reduction

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -291,7 +291,8 @@ TEST_F(DynamicTypeTest, Typing) {
   static_assert(!can_static_cast<IntSomeType, CustomType>);
   static_assert((int64_t)IntSomeType(1) == 1);
   EXPECT_THAT(
-      []() { (SomeType) IntSomeType(1); },
+      // suppress unused value warning
+      []() { (void)(SomeType)IntSomeType(1); },
       ::testing::ThrowsMessage<c10::Error>(
           ::testing::HasSubstr("Cannot cast to ")));
 }

--- a/test/test_external_src.cpp
+++ b/test/test_external_src.cpp
@@ -12,6 +12,7 @@
 #include <fusion.h>
 #include <test/utils.h>
 #include <test/validator.h>
+#include <utils.h>
 
 namespace nvfuser {
 
@@ -19,7 +20,7 @@ class ExternalSrcExample : public NVFuserTest {};
 
 // This is for internal testing only and is intended to be used as a template to
 // compile and run an external source file. By default, it should just
-// return immediately, but if PYTORCH_NVFUSER_EXTERNAL_SRC is defined,
+// return immediately, but if NVFUSER_EXTERNAL_SRC is defined,
 // the file specified by the env var is loaded and compiled.
 TEST_F(ExternalSrcExample, Reduction_CUDA) {
   Fusion fusion;
@@ -29,7 +30,7 @@ TEST_F(ExternalSrcExample, Reduction_CUDA) {
   // By default, this env var should not be defined. To test using an
   // external source file, set it to the path to the external source
   // file.
-  auto path = std::getenv("PYTORCH_NVFUSER_EXTERNAL_SRC");
+  auto path = getNvFuserEnv("EXTERNAL_SRC");
   if (path == nullptr) {
     return;
   }
@@ -101,7 +102,7 @@ TEST_F(ExternalSrcExample, Matmul_CUDA) {
   // By default, this env var should not be defined. To test using an
   // external source file, set it to the path to the external source
   // file.
-  auto path = std::getenv("PYTORCH_NVFUSER_EXTERNAL_SRC");
+  auto path = getNvFuserEnv("EXTERNAL_SRC");
   if (path == nullptr) {
     return;
   }

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -38,6 +38,7 @@
 #include <test/validator.h>
 #include <transform_replay.h>
 #include <transform_rfactor.h>
+#include <utils.h>
 
 #include <parser.h>
 #include <torch/csrc/jit/api/function_impl.h>
@@ -1163,7 +1164,7 @@ TEST_F(NVFuserTest, FusionParser_CUDA) {
   // This test may not pass if using a custom block sync as there may
   // be additional calls. Skip the test as it's not specifically
   // relevant with block synchronizatin.
-  if (std::getenv("PYTORCH_NVFUSER_USE_BLOCK_SYNC_ATOMIC")) {
+  if (getNvFuserEnv("USE_BLOCK_SYNC_ATOMIC")) {
     return;
   }
   auto g = std::make_shared<torch::jit::Graph>();

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -39,6 +39,7 @@
 #include <test/validator.h>
 #include <transform_replay.h>
 #include <transform_rfactor.h>
+#include <utils.h>
 
 #include <parser.h>
 #include <torch/csrc/jit/api/function_impl.h>
@@ -8998,7 +8999,7 @@ TEST_F(NVFuserTest, FusionChannelsLastParser_CUDA) {
   // This test may not pass if using a custom block sync as there may
   // be additional calls. Skip the test as it's not specifically
   // relevant with block synchronizatin.
-  if (std::getenv("PYTORCH_NVFUSER_USE_BLOCK_SYNC_ATOMIC")) {
+  if (getNvFuserEnv("USE_BLOCK_SYNC_ATOMIC")) {
     return;
   }
   auto g = std::make_shared<torch::jit::Graph>();

--- a/test/test_gpu_outer_reduction.cpp
+++ b/test/test_gpu_outer_reduction.cpp
@@ -18,6 +18,7 @@
 #include <scheduler/utils.h>
 #include <test/utils.h>
 #include <test/validator.h>
+#include <utils.h>
 
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/Exceptions.h>
@@ -230,7 +231,7 @@ namespace {
 
 // A quick opt-in switch to enable performance measurements.
 bool isBenchmarkMode() {
-  return getenv("PYTORCH_NVFUSER_OUTER_REDUCTION_BENCHMARK") != nullptr;
+  return getNvFuserEnv("OUTER_REDUCTION_BENCHMARK") != nullptr;
 }
 
 struct OuterReductionParams {


### PR DESCRIPTION
Renamed `PYTORCH_NVFUSER_` to just `NVFUSER_`, e.g., `PYTORCH_NVFUSER_DUMP` is now `NVFUSER_DUMP`.

PYTORCH_NVFUSER is still available but a warning is issued if used.