### PR TITLE
Allocate intermediate tensors using the shape provided by Allocate node

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -494,18 +494,14 @@ std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShape(
 // Infer the shape of an intemediate tensor using kir::Allocate
 std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShapeOfIntermediate(
     const TensorView* tv,
+    const kir::Allocate* alloc,
     ExpressionEvaluator& expr_eval) {
-  auto alloc_dom = TensorDomain::noReductions(tv->getMaybeAllocationDomain());
-  std::vector<nvfuser::Val*> symbolic_sizes;
-  symbolic_sizes.reserve(alloc_dom.size());
-  for (auto id : alloc_dom) {
-    if (id->isBroadcast()) {
-      symbolic_sizes.emplace_back(id->container()->oneVal());
-    } else {
-      symbolic_sizes.emplace_back(id->extent());
-    }
-  }
-
+  // The allocation domain represents the logical allocation domain,
+  // bu its actual allocation size may be different, e.g., for
+  // supporting halo accesses. The actual size is currently computed
+  // when creating the Allocate expr.
+  TORCH_INTERNAL_ASSERT(alloc != nullptr);
+  const auto& symbolic_sizes = alloc->shape();
   // For intermediate tensors, we just need to allocate a memory chunk
   // of the specified size. Broadcast expansion does not need to be considered.
   const auto expand_flags = std::vector<bool>(symbolic_sizes.size(), false);
@@ -1129,7 +1125,7 @@ std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::
     GlobalBufferInfo info;
     info.zero_init = alloc->zeroInit();
     std::tie(info.sizes, info.strides) =
-        inferShapeOfIntermediate(tv, expr_eval);
+        inferShapeOfIntermediate(tv, alloc, expr_eval);
     info.type = data_type_to_aten(tv->dtype());
 
     // Remember the tensor buffer used for storing kernel profile


### PR DESCRIPTION
Some of the shift tests use global memory tensors just for testing the functionality. In those cases, there are intermediate global tensors that are extended with halo. Their allocation sizes are not the same as the logical size represented by their allocation domains, but slightly larger to account for the halo regions.

With the current main, the intermediate tensors for `FusionShift2` are:

```
Intermediate global buffers:
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
```

This PR effectively reverts the change of executor.cpp by #324. I think this is the easiest fix.

With this fix, they are:

```
Intermediate global buffers:
  Float [10, 11] is_zero_initialized: 0
  Float [11, 12] is_zero_initialized: 0
  Float [11, 12] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
  Float [9, 11] is_zero_initialized: 0
```

Alternatively, we may also want to think about extending the allocation domain itself such that it truly holds the allocation information, not just the logical domains and their ordering but their actual sizes. Given that the halo support is experimental and likely needs an almost complete rewrite, a quick fix would be just fine for now.
