### PR TITLE
Try workaround gcc9 bug

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,7 @@ env:
 
 jobs:
   standalone-build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, ubuntu-20.04]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,10 @@ env:
 
 jobs:
   standalone-build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/csrc/device_lower/analysis/bank_conflict.cpp
+++ b/csrc/device_lower/analysis/bank_conflict.cpp
@@ -223,9 +223,9 @@ class BankConflictInfo : public kir::IrVisitor {
   void bindValues(
       LaunchParams launch_params,
       const std::unordered_map<Val*, EvaluatorValue>& known_values) {
-    expr_eval_.bind("blockIdx.x", 0);
-    expr_eval_.bind("blockIdx.y", 0);
-    expr_eval_.bind("blockIdx.z", 0);
+    expr_eval_.bind("blockIdx.x", 0L);
+    expr_eval_.bind("blockIdx.y", 0L);
+    expr_eval_.bind("blockIdx.z", 0L);
     if (launch_params.bdimx() != LaunchParams::UNINITIALIZED_VAL) {
       expr_eval_.bind(ParallelType::TIDx, launch_params.bdimx());
     }

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -198,7 +198,7 @@ void PrecomputedValues::initializeValueList(
   num_of_values_ = (int)sorted_value_list.size();
   defined_ = std::vector<bool>(num_of_values_, false);
   is_constant_ = std::vector<bool>(num_of_values_, false);
-  values_ = std::vector<EvaluatorValue>(num_of_values_, EvaluatorValue(-1));
+  values_ = std::vector<EvaluatorValue>(num_of_values_, EvaluatorValue());
 
   // Fill in constants and assign evaluator indices
   for (const auto i : c10::irange(num_of_values_)) {
@@ -350,7 +350,7 @@ void PrecomputedValues::bindTensorMetaData(
     if (root_domain[dim]->hasExpandedExtent()) {
       auto extent = root_domain[dim]->extent();
       auto expanded_extent = root_domain[dim]->expandedExtent();
-      bindValue(extent->evaluatorIndex(), 1);
+      bindValue(extent->evaluatorIndex(), 1L);
       bindValue(expanded_extent->evaluatorIndex(), value);
     } else {
       auto extent = root_domain[dim]->extent();

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -58,10 +58,10 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
 
     // input: 4, 3
     // output: 3, 4
-    expr_eval.bind(tv0->axis(0)->extent(), 4);
-    expr_eval.bind(tv0->axis(1)->extent(), 3);
-    expr_eval.bind(reshape_shape0, 3);
-    expr_eval.bind(reshape_shape1, 4);
+    expr_eval.bind(tv0->axis(0)->extent(), 4L);
+    expr_eval.bind(tv0->axis(1)->extent(), 3L);
+    expr_eval.bind(reshape_shape0, 3L);
+    expr_eval.bind(reshape_shape1, 4L);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
     auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
@@ -76,10 +76,10 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
 
     // input: 4, 3
     // output: 3, -1
-    expr_eval.bind(tv0->axis(0)->extent(), 4);
-    expr_eval.bind(tv0->axis(1)->extent(), 3);
-    expr_eval.bind(reshape_shape0, 3);
-    expr_eval.bind(reshape_shape1, -1);
+    expr_eval.bind(tv0->axis(0)->extent(), 4L);
+    expr_eval.bind(tv0->axis(1)->extent(), 3L);
+    expr_eval.bind(reshape_shape0, 3L);
+    expr_eval.bind(reshape_shape1, -1L);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
     auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
@@ -94,10 +94,10 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
 
     // input: 4, 3
     // output: 5, -1
-    expr_eval.bind(tv0->axis(0)->extent(), 4);
-    expr_eval.bind(tv0->axis(1)->extent(), 3);
-    expr_eval.bind(reshape_shape0, 5);
-    expr_eval.bind(reshape_shape1, -1);
+    expr_eval.bind(tv0->axis(0)->extent(), 4L);
+    expr_eval.bind(tv0->axis(1)->extent(), 3L);
+    expr_eval.bind(reshape_shape0, 5L);
+    expr_eval.bind(reshape_shape1, -1L);
 
     // This should fail as (4 * 3) is not evenly divisible by 5
     EXPECT_THAT(
@@ -135,12 +135,12 @@ TEST_F(NVFuserTest, DynamicTransform2_CUDA) {
 
     // input: 4, 3
     // output: 3, 4
-    expr_eval.bind(tv0->axis(0)->extent(), 4);
-    expr_eval.bind(tv0->axis(1)->extent(), 3);
+    expr_eval.bind(tv0->axis(0)->extent(), 4L);
+    expr_eval.bind(tv0->axis(1)->extent(), 3L);
     // Bind only tv2 extents. It should be enough as tv1 has the same
     // shape
-    expr_eval.bind(tv2->axis(0)->extent(), 3);
-    expr_eval.bind(tv2->axis(1)->extent(), 4);
+    expr_eval.bind(tv2->axis(0)->extent(), 3L);
+    expr_eval.bind(tv2->axis(1)->extent(), 4L);
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
     auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
@@ -527,9 +527,9 @@ TEST_F(NVFuserTest, DynamicTransform9_CUDA) {
 
   ExpressionEvaluator expr_eval;
 
-  expr_eval.bind(tv0->axis(0)->extent(), 3);
-  expr_eval.bind(tv0->axis(1)->extent(), 4);
-  expr_eval.bind(reshape_shape0, 12);
+  expr_eval.bind(tv0->axis(0)->extent(), 3L);
+  expr_eval.bind(tv0->axis(1)->extent(), 4L);
+  expr_eval.bind(reshape_shape0, 12L);
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
   auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
@@ -565,10 +565,10 @@ TEST_F(NVFuserTest, DynamicTransform10_CUDA) {
 
   ExpressionEvaluator expr_eval;
 
-  expr_eval.bind(tv0->axis(0)->extent(), 3);
-  expr_eval.bind(tv0->axis(1)->extent(), 4);
-  expr_eval.bind(tv1->axis(0)->extent(), 4);
-  expr_eval.bind(tv1->axis(1)->extent(), 3);
+  expr_eval.bind(tv0->axis(0)->extent(), 3L);
+  expr_eval.bind(tv0->axis(1)->extent(), 4L);
+  expr_eval.bind(tv1->axis(0)->extent(), 4L);
+  expr_eval.bind(tv1->axis(1)->extent(), 3L);
 
   auto initial_info = DynamicTransform::getInitialInfo(&fusion);
   auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
@@ -599,11 +599,11 @@ TEST_F(NVFuserTest, DynamicTransform11_CUDA) {
   ExpressionEvaluator expr_eval1;
   // input: 4, 3
   // output: 2, 2, 3
-  expr_eval1.bind(tv0->axis(0)->extent(), 4);
-  expr_eval1.bind(tv0->axis(1)->extent(), 3);
-  expr_eval1.bind(tv1->axis(0)->extent(), 2);
-  expr_eval1.bind(tv1->axis(1)->extent(), 2);
-  expr_eval1.bind(tv1->axis(2)->extent(), 3);
+  expr_eval1.bind(tv0->axis(0)->extent(), 4L);
+  expr_eval1.bind(tv0->axis(1)->extent(), 3L);
+  expr_eval1.bind(tv1->axis(0)->extent(), 2L);
+  expr_eval1.bind(tv1->axis(1)->extent(), 2L);
+  expr_eval1.bind(tv1->axis(2)->extent(), 3L);
 
   auto initial_info1 = DynamicTransform::getInitialInfo(&fusion);
   auto info1 = DynamicTransformConcretizationInfo(&initial_info1, &expr_eval1);
@@ -612,11 +612,11 @@ TEST_F(NVFuserTest, DynamicTransform11_CUDA) {
   ;
   // input: 4, 3
   // output: 3, 2, 2
-  expr_eval2.bind(tv0->axis(0)->extent(), 4);
-  expr_eval2.bind(tv0->axis(1)->extent(), 3);
-  expr_eval2.bind(tv1->axis(0)->extent(), 3);
-  expr_eval2.bind(tv1->axis(1)->extent(), 2);
-  expr_eval2.bind(tv1->axis(2)->extent(), 2);
+  expr_eval2.bind(tv0->axis(0)->extent(), 4L);
+  expr_eval2.bind(tv0->axis(1)->extent(), 3L);
+  expr_eval2.bind(tv1->axis(0)->extent(), 3L);
+  expr_eval2.bind(tv1->axis(1)->extent(), 2L);
+  expr_eval2.bind(tv1->axis(2)->extent(), 2L);
 
   auto initial_info2 = DynamicTransform::getInitialInfo(&fusion);
   auto info2 = DynamicTransformConcretizationInfo(&initial_info2, &expr_eval2);

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -365,13 +365,13 @@ TEST_F(DynamicTypeTest, Typing) {
         (3L op DoubleInt64BoolVec(2L)).as<decltype((3L op 2L))>(),             \
         (3L op 2L));                                                           \
     EXPECT_THAT(                                                               \
-        [&]() { DoubleInt64Bool() op DoubleInt64Bool(2); },                    \
+        [&]() { DoubleInt64Bool() op DoubleInt64Bool(2L); },                   \
         ::testing::ThrowsMessage<c10::Error>(                                  \
             ::testing::HasSubstr("Can not compute ")));                        \
     EXPECT_THAT(                                                               \
         [&]() {                                                                \
           DoubleInt64BoolVec(std::vector<DoubleInt64BoolVec>{})                \
-              op DoubleInt64BoolVec(2);                                        \
+              op DoubleInt64BoolVec(2L);                                       \
         },                                                                     \
         ::testing::ThrowsMessage<c10::Error>(                                  \
             ::testing::HasSubstr("Can not compute ")));                        \
@@ -419,13 +419,13 @@ TEST_BINARY_OP_ALLTYPE(LogicalOr, ||);
     static_assert((3L op DoubleInt64Bool(2L)) == (3L op 2L));                  \
     EXPECT_EQ((3L op DoubleInt64BoolVec(2L)), (3L op 2L));                     \
     EXPECT_THAT(                                                               \
-        [&]() { DoubleInt64Bool() op DoubleInt64Bool(2); },                    \
+        [&]() { DoubleInt64Bool() op DoubleInt64Bool(2L); },                   \
         ::testing::ThrowsMessage<c10::Error>(                                  \
             ::testing::HasSubstr("Can not compute ")));                        \
     EXPECT_THAT(                                                               \
         [&]() {                                                                \
           DoubleInt64BoolVec(std::vector<DoubleInt64BoolVec>{})                \
-              op DoubleInt64BoolVec(2);                                        \
+              op DoubleInt64BoolVec(2L);                                       \
         },                                                                     \
         ::testing::ThrowsMessage<c10::Error>(                                  \
             ::testing::HasSubstr("Can not compute ")));                        \
@@ -463,13 +463,13 @@ TEST_COMPARE_OP(Ge, >=);
     static_assert((3L op DoubleInt64Bool(2L)).as<int64_t>() == (3L op 2L));    \
     EXPECT_EQ((3L op DoubleInt64BoolVec(2L)).as<int64_t>(), (3L op 2L));       \
     EXPECT_THAT(                                                               \
-        [&]() { DoubleInt64Bool() op DoubleInt64Bool(2); },                    \
+        [&]() { DoubleInt64Bool() op DoubleInt64Bool(2L); },                   \
         ::testing::ThrowsMessage<c10::Error>(                                  \
             ::testing::HasSubstr("Can not compute ")));                        \
     EXPECT_THAT(                                                               \
         [&]() {                                                                \
           DoubleInt64BoolVec(std::vector<DoubleInt64BoolVec>{})                \
-              op DoubleInt64BoolVec(2);                                        \
+              op DoubleInt64BoolVec(2L);                                       \
         },                                                                     \
         ::testing::ThrowsMessage<c10::Error>(                                  \
             ::testing::HasSubstr("Can not compute ")));                        \

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -178,16 +178,16 @@ TEST_F(NVFuserTest, FusionExprEvalBindings_CUDA) {
   TORCH_CHECK(!evaluator.evaluate(a).hasValue());
   TORCH_CHECK(!evaluator.evaluate(d).hasValue());
 
-  evaluator.bind(a, 7);
-  evaluator.bind(b, 3);
+  evaluator.bind(a, 7L);
+  evaluator.bind(b, 3L);
 
   // can't bind to the results of expressions
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(evaluator.bind(c, 100));
+  ASSERT_ANY_THROW(evaluator.bind(c, 100L));
 
   // can't bind to concrete values
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(evaluator.bind(e, 100));
+  ASSERT_ANY_THROW(evaluator.bind(e, 100L));
 
   checkIntValue(evaluator, c, 10);
   checkIntValue(evaluator, sub(a, b), 4);
@@ -198,8 +198,8 @@ TEST_F(NVFuserTest, FusionExprEvalBindings_CUDA) {
   // Reset evaluation context
   evaluator = ExpressionEvaluator();
 
-  evaluator.bind(a, 2);
-  evaluator.bind(b, 5);
+  evaluator.bind(a, 2L);
+  evaluator.bind(b, 5L);
 
   checkIntValue(evaluator, c, 7);
   checkIntValue(evaluator, sub(a, b), -3);
@@ -247,10 +247,10 @@ TEST_F(NVFuserTest, FusionExprEvalBasic_CUDA) {
   //  (ex. `tv0->getRootDomain()[0]->extent()`
   //   instead of `tv0->axis(0)->extent()`)
   //
-  evaluator.bind(tv0->getRootDomain()[0]->extent(), 6);
-  evaluator.bind(tv0->getRootDomain()[1]->extent(), 128);
-  evaluator.bind(tv1->getRootDomain()[0]->extent(), 6);
-  evaluator.bind(tv1->getRootDomain()[1]->extent(), 128);
+  evaluator.bind(tv0->getRootDomain()[0]->extent(), 6L);
+  evaluator.bind(tv0->getRootDomain()[1]->extent(), 128L);
+  evaluator.bind(tv1->getRootDomain()[0]->extent(), 6L);
+  evaluator.bind(tv1->getRootDomain()[1]->extent(), 128L);
 
   // 3. Evaluate and check result values
   TORCH_CHECK(tv2->domain()->nDims() == 3);
@@ -291,8 +291,8 @@ TEST_F(NVFuserTest, FusionExprEvalComplex_CUDA) {
   ExpressionEvaluator evaluator;
 
   // 2. Bind values
-  evaluator.bind(tv0->getRootDomain()[0]->extent(), 129);
-  evaluator.bind(tv0->getRootDomain()[1]->extent(), 127);
+  evaluator.bind(tv0->getRootDomain()[0]->extent(), 129L);
+  evaluator.bind(tv0->getRootDomain()[1]->extent(), 127L);
 
   // Evaluate and check extent values
   TORCH_CHECK(tv0->domain()->nDims() == 2);
@@ -354,10 +354,10 @@ TEST_F(NVFuserTest, FusionExprEvalPostLower_CUDA) {
   ExpressionEvaluator evaluator;
 
   // 2. Bind values
-  evaluator.bind(tv0->getRootDomain()[0]->extent(), 6);
-  evaluator.bind(tv0->getRootDomain()[1]->extent(), 128);
-  evaluator.bind(tv1->getRootDomain()[0]->extent(), 6);
-  evaluator.bind(tv1->getRootDomain()[1]->extent(), 128);
+  evaluator.bind(tv0->getRootDomain()[0]->extent(), 6L);
+  evaluator.bind(tv0->getRootDomain()[1]->extent(), 128L);
+  evaluator.bind(tv1->getRootDomain()[0]->extent(), 6L);
+  evaluator.bind(tv1->getRootDomain()[1]->extent(), 128L);
 
   // 3. Evaluate and check result values
   TORCH_CHECK(tv2->domain()->nDims() == 3);
@@ -413,16 +413,16 @@ TEST_F(NVFuserTest, FusionKernelExprEvalBindings_CUDA) {
   TORCH_CHECK(!evaluator.evaluate(a).hasValue());
   TORCH_CHECK(!evaluator.evaluate(d).hasValue());
 
-  evaluator.bind(a, 7);
-  evaluator.bind(b, 3);
+  evaluator.bind(a, 7L);
+  evaluator.bind(b, 3L);
 
   // can't bind to the results of expressions
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(evaluator.bind(c, 100));
+  ASSERT_ANY_THROW(evaluator.bind(c, 100L));
 
   // can't bind to concrete values
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(evaluator.bind(e, 100));
+  ASSERT_ANY_THROW(evaluator.bind(e, 100L));
 
   checkIntValue(evaluator, c, 10);
   checkIntValue(evaluator, IrBuilder::subExpr(a, b), 4);
@@ -433,8 +433,8 @@ TEST_F(NVFuserTest, FusionKernelExprEvalBindings_CUDA) {
   // Reset the evaluation context
   evaluator = ExpressionEvaluator();
 
-  evaluator.bind(a, 2);
-  evaluator.bind(b, 5);
+  evaluator.bind(a, 2L);
+  evaluator.bind(b, 5L);
 
   checkIntValue(evaluator, c, 7);
   checkIntValue(evaluator, IrBuilder::subExpr(a, b), -3);

--- a/test/test_gpu_shift.cpp
+++ b/test/test_gpu_shift.cpp
@@ -4140,7 +4140,7 @@ TEST_F(NVFuserTest, FusionPartialSplit1_CUDA) {
 
   // gridDim.x is ceilDiv(numel_x - 2, 8), not ceilDiv(numel_x, 8),
   // so it's going to be just 2 rather than 3.
-  const int numel_x = 18;
+  const int64_t numel_x = 18;
 
   ExpressionEvaluator evaluator;
   auto root_extent = tv4->getRootDomain()[0]->extent();


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/Fuser/issues/538. GCC9's ctor of `std::variant` is buggy and can not handle the case like:
```C++
std::variant<float, long, double> z = 0; // OK, holds long
                                         // float and double are not candidates
```
(example taken from https://en.cppreference.com/w/cpp/utility/variant/variant), so when using `DynamicType` and `EvaluatorValue`, we should use exactly the same type as in the type list. GCC9 is not smart enough to automatically convert `int` into `long` when needed.