### PR TITLE
Removing unused TypePromotionConfig constructor.

### DIFF
--- a/csrc/type_promotion.h
+++ b/csrc/type_promotion.h
@@ -30,7 +30,6 @@ namespace nvfuser {
 struct TypePromotionConfig {
   bool promote_integer_inputs_to_float = false;
   bool require_full_precision_promoted = false;
-  TypePromotionConfig() = default;
 };
 
 namespace TypePromotion {


### PR DESCRIPTION
I'm getting a new compiler error. The default constructor defined prevents aggregate initialization.

```
[ 32%] Building CXX object CMakeFiles/nvFuserGemm.dir/src/nvFuserGemm/nvFuserGemm.cpp.o
In file included from /home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/ops/arith.h:15,
                 from /home/mmigdal/nvFuser/nvfuser-perf-evaluation/src/nvFuserGemm/nvFuserHelpers.hpp:17,
                 from /home/mmigdal/nvFuser/nvfuser-perf-evaluation/src/nvFuserGemm/nvFuserGemm.cpp:9:
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:42:48: error: no matching function for call to ‘nvfuser::TypePromotionConfig::TypePromotionConfig(<brace-enclosed initializer list>)’
   42 |     /* require_full_precision_promoted */ false};
      |                                                ^
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:33:3: note: candidate: ‘constexpr nvfuser::TypePromotionConfig::TypePromotionConfig()’
   33 |   TypePromotionConfig() = default;
      |   ^~~~~~~~~~~~~~~~~~~
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:33:3: note:   candidate expects 0 arguments, 2 provided
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:30:8: note: candidate: ‘constexpr nvfuser::TypePromotionConfig::TypePromotionConfig(const nvfuser::TypePromotionConfig&)’
   30 | struct TypePromotionConfig {
      |        ^~~~~~~~~~~~~~~~~~~
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:30:8: note:   candidate expects 1 argument, 2 provided
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:30:8: note: candidate: ‘constexpr nvfuser::TypePromotionConfig::TypePromotionConfig(nvfuser::TypePromotionConfig&&)’
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:30:8: note:   candidate expects 1 argument, 2 provided
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:45:47: error: no matching function for call to ‘nvfuser::TypePromotionConfig::TypePromotionConfig(<brace-enclosed initializer list>)’
   45 |     /* require_full_precision_promoted */ true};
      |                                               ^
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:33:3: note: candidate: ‘constexpr nvfuser::TypePromotionConfig::TypePromotionConfig()’
   33 |   TypePromotionConfig() = default;
      |   ^~~~~~~~~~~~~~~~~~~
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:33:3: note:   candidate expects 0 arguments, 2 provided
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:30:8: note: candidate: ‘constexpr nvfuser::TypePromotionConfig::TypePromotionConfig(const nvfuser::TypePromotionConfig&)’
   30 | struct TypePromotionConfig {
      |        ^~~~~~~~~~~~~~~~~~~
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:30:8: note:   candidate expects 1 argument, 2 provided
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:30:8: note: candidate: ‘constexpr nvfuser::TypePromotionConfig::TypePromotionConfig(nvfuser::TypePromotionConfig&&)’
/home/mmigdal/nvFuser/pytorch/torch/include/nvfuser/type_promotion.h:30:8: note:   candidate expects 1 argument, 2 provided
make[2]: *** [CMakeFiles/nvFuserGemm.dir/build.make:80: CMakeFiles/nvFuserGemm.dir/src/nvFuserGemm/nvFuserGemm.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:132: CMakeFiles/nvFuserGemm.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```