### PR TITLE
Add `full`, `iota`, and `where` Opinfo error tests

### DIFF
--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -316,7 +316,7 @@ TensorView* iota(Val* length, Val* start, Val* step, DataType dtype) {
   }
 
   TORCH_INTERNAL_ASSERT(
-      step->isConstScalar() && !step->isZero(),
+      !step->isConstScalar() || !step->isZero(),
       "iota: step value must not equal zero.");
 
   auto out = TensorViewBuilder()

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -278,27 +278,47 @@ TensorView* iota(Val* length, Val* start, Val* step, DataType dtype) {
       "length must be integer, but get dtype ",
       *length->getDataType());
   TORCH_CHECK(
-      isIntegralType(*start->getDataType()) == isIntegralType(dtype) &&
+      !isComplexType(*start->getDataType()) &&
+          isIntegralType(*start->getDataType()) == isIntegralType(dtype) &&
           isFloatingPointType(*start->getDataType()) ==
               isFloatingPointType(dtype),
-      "dtype does not match for iota, should be ",
+      "iota: start dtype does not match specified dtype argument, should be ",
       dtype,
       " but get ",
       *start->getDataType());
   TORCH_CHECK(
-      isIntegralType(*step->getDataType()) == isIntegralType(dtype) &&
+      !isComplexType(*step->getDataType()) &&
+          isIntegralType(*step->getDataType()) == isIntegralType(dtype) &&
           isFloatingPointType(*step->getDataType()) ==
               isFloatingPointType(dtype),
-      "dtype does not match for iota, should be ",
+      "iota: step dtype does not match specified dtype argument, should be ",
       dtype,
       " but get ",
       *step->getDataType());
+
   if (start->getDataType() != dtype) {
     start = castOp(dtype, start);
   }
   if (step->getDataType() != dtype) {
     step = castOp(dtype, step);
   }
+
+  if (start->isConst() && start->isFloatingPointScalar()) {
+    TORCH_INTERNAL_ASSERT(
+        std::isfinite(start->getDouble().value()),
+        "iota: length, start, step must be finite numbers.");
+  }
+
+  if (step->isConst() && step->isFloatingPointScalar()) {
+    TORCH_INTERNAL_ASSERT(
+        std::isfinite(step->getDouble().value()),
+        "iota: length, start, step must be finite numbers.");
+  }
+
+  TORCH_INTERNAL_ASSERT(
+      step->isConstScalar() && !step->isZero(),
+      "iota: step value must not equal zero.");
+
   auto out = TensorViewBuilder()
                  .ndims(1)
                  .dtype(dtype)

--- a/python_tests/pytest_core.py
+++ b/python_tests/pytest_core.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Owner(s): ["module: nvfuser"]
 
-from pytest_utils import all_dtypes
+from pytest_utils import all_dtypes, ArgumentType
 from typing import Callable, Optional
 import torch
 import jax.numpy as jnp
@@ -109,4 +109,4 @@ class OpInfo:
     # symbolic_parameter_list specifies whether an operation's parameters are symbolic.
     # All keyword arguments are considered constant.
     # If symbolic_parameter_list is None, then we assume all parameters to be symbolic.
-    symbolic_parameter_list: Optional[list[bool]] = None
+    symbolic_parameter_list: Optional[list[ArgumentType]] = None

--- a/python_tests/pytest_ops.py
+++ b/python_tests/pytest_ops.py
@@ -10,10 +10,14 @@ from torch.testing import assert_close
 from pytest_framework import create_op_test
 from pytest_core import ReferenceType, OpInfo, SampleInput
 from pytest_opinfos import opinfos
+from pytest_utils import ArgumentType
 from typing import Callable, Optional
 
 from nvfuser import FusionDefinition
-from nvfuser.pytorch_utils import python_scalar_to_nvfuser_dtype
+from nvfuser.pytorch_utils import (
+    python_scalar_to_nvfuser_dtype,
+    torch_dtype_to_nvfuser_dtype,
+)
 
 
 def is_pre_volta():
@@ -30,11 +34,13 @@ def parse_inputs_fusion_definition(fd: FusionDefinition, opinfo: OpInfo, *args):
         return []
 
     nvf_args = []
+
     if opinfo.symbolic_parameter_list is None:
-        opinfo.symbolic_parameter_list = [True] * len(args)
+        opinfo.symbolic_parameter_list = [ArgumentType.Symbolic] * len(args)
     assert len(opinfo.symbolic_parameter_list) == len(args)
-    for is_symbolic, a in zip(opinfo.symbolic_parameter_list, args):
-        if is_symbolic:
+
+    for arg_type, a in zip(opinfo.symbolic_parameter_list, args):
+        if arg_type == ArgumentType.Symbolic:
             if type(a) is torch.Tensor:
                 nvf_args.append(fd.from_pytorch(a))
             elif type(a) is list and all(map(is_tensor, a)):
@@ -45,8 +51,14 @@ def parse_inputs_fusion_definition(fd: FusionDefinition, opinfo: OpInfo, *args):
                 # For symbolic scalars, we do not define with constant value.
                 # Otherwise, it becomes a constant and is not a fusion input.
                 nvf_args.append(fd.define_scalar(python_scalar_to_nvfuser_dtype(a)))
+        elif arg_type == ArgumentType.ConstantScalar:
+            assert type(a) is not torch.Tensor
+            nvf_args.append(fd.define_scalar(a))
+        elif isinstance(a, torch.dtype):
+            nvf_args.append(torch_dtype_to_nvfuser_dtype(a))
         else:
             assert type(a) is not torch.Tensor
+            assert arg_type == ArgumentType.Constant
             nvf_args.append(a)
     return nvf_args
 
@@ -56,8 +68,8 @@ def parse_args_fusion_execution(opinfo: OpInfo, *args):
         return []
 
     result = []
-    for is_symbolic, a in zip(opinfo.symbolic_parameter_list, args):
-        if is_symbolic:
+    for arg_type, a in zip(opinfo.symbolic_parameter_list, args):
+        if arg_type == ArgumentType.Symbolic:
             if type(a) is list and all(map(is_tensor, a)):
                 result.extend(a)
             else:

--- a/python_tests/pytest_utils.py
+++ b/python_tests/pytest_utils.py
@@ -103,6 +103,7 @@ def make_number(
     """
     return make_tensor([1], device="cpu", dtype=dtype, low=low, high=high).item()
 
+
 def find_nonmatching_dtype(dtype: torch.dtype):
     if dtype in int_float_dtypes:
         return torch.complex128

--- a/python_tests/pytest_utils.py
+++ b/python_tests/pytest_utils.py
@@ -5,6 +5,19 @@
 
 import torch
 from torch.testing import make_tensor
+from typing import Optional
+
+from enum import Enum, auto
+
+
+class ArgumentType(Enum):
+    # a symbolic value requires an input argument during kernel execution
+    Symbolic = auto()
+    # scalar with constant value
+    ConstantScalar = auto()
+    # python number - int, float, complex, bool
+    Constant = auto()
+
 
 # uint8, int8, int16, bf16, fp16 are disables because nvfuser upcasts those dtypes to fp32
 # but does not return the original type.
@@ -40,6 +53,8 @@ float_complex_dtypes = (
     torch.complex128,
 )
 
+int_dtypes = (torch.int32, torch.int64)
+float_dtypes = (torch.float32, torch.float64, torch.bfloat16, torch.float16)
 complex_dtypes = (torch.complex64, torch.complex128)
 
 map_dtype_to_str = {
@@ -73,11 +88,15 @@ def make_tensor_like(a):
     )
 
 
-def make_number(dtype: torch.dtype):
+def make_number(
+    dtype: torch.dtype, low: Optional[float] = None, high: Optional[float] = None
+):
     """Returns a random number with desired dtype
 
     Args:
         dtype (torch.dtype): Desired dtype for number.
+        low (Optional[Number]): Sets the lower limit (inclusive) of the given range.
+        high (Optional[Number]): Sets the upper limit (exclusive) of the given range.
 
     Returns:
         (Scalar): The scalar number with specified dtype.
@@ -93,3 +112,15 @@ def find_nonmatching_dtype(dtype: torch.dtype):
     elif dtype is torch.bool:
         return torch.float32
     return None
+
+
+def is_complex_dtype(dtype: torch.dtype):
+    return dtype in complex_dtypes
+
+
+def is_floating_dtype(dtype: torch.dtype):
+    return dtype in float_dtypes
+
+
+def is_integer_dtype(dtype: torch.dtype):
+    return dtype in int_dtypes

--- a/python_tests/pytest_utils.py
+++ b/python_tests/pytest_utils.py
@@ -101,8 +101,7 @@ def make_number(
     Returns:
         (Scalar): The scalar number with specified dtype.
     """
-    return make_tensor([1], device="cpu", dtype=dtype).item()
-
+    return make_tensor([1], device="cpu", dtype=dtype, low=low, high=high).item()
 
 def find_nonmatching_dtype(dtype: torch.dtype):
     if dtype in int_float_dtypes:


### PR DESCRIPTION
* Expand const scalar checks for `iota`