### PR TITLE
Change the semantics of uninlinable IDs in MaxPosCalculator

### DIFF
--- a/csrc/inlining.h
+++ b/csrc/inlining.h
@@ -20,7 +20,8 @@ class MaxPosCalculator {
   // Root domains in producer that's unmappable to any of its consumers
   std::unordered_set<IterDomain*> unmappable_dims_;
 
-  // User set IterDomains to not inline
+  // User set IterDomains to not inline to consumers. Producer IDs can
+  // still be inlined to these IDs
   std::unordered_set<IterDomain*> uninlinable_ids_;
 
   // Iterate through all TVs and collect the dimensions of each TV that don't
@@ -37,7 +38,8 @@ class MaxPosCalculator {
       bool best_effort,
       bool allow_reduction,
       bool allow_vectorize,
-      bool allow_unmappable) const;
+      bool allow_unmappable,
+      bool allow_uninlinable) const;
 
  public:
   // Returns the position at which tv can be inlined within.
@@ -46,7 +48,8 @@ class MaxPosCalculator {
       bool best_effort,
       bool allow_reduction,
       bool allow_vectorize,
-      bool allow_unmappable) const;
+      bool allow_unmappable,
+      bool allow_uninlinable) const;
 
   // Returns the maximum position producer can be inlined based on consumer
   // given the set ComputeAtMode


### PR DESCRIPTION
Uninlinable IDs are not inlined to consumers, but producers can be inlined to uninlinable IDs