### PR TITLE
Capture debugging output in Python frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ list(APPEND NVFUSER_SRCS
     ${NVFUSER_SRCS_DIR}/compute_at_map.cpp
     ${NVFUSER_SRCS_DIR}/codegen.cpp
     ${NVFUSER_SRCS_DIR}/contiguity.cpp
+    ${NVFUSER_SRCS_DIR}/debug.cpp
     ${NVFUSER_SRCS_DIR}/dispatch.cpp
     ${NVFUSER_SRCS_DIR}/dynamic_transform.cpp
     ${NVFUSER_SRCS_DIR}/expr_evaluator.cpp

--- a/csrc/debug.cpp
+++ b/csrc/debug.cpp
@@ -1,0 +1,36 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <debug.h>
+
+#include <iostream>
+
+namespace nvfuser {
+
+static thread_local std::ostream* ACTIVE_STREAM = &std::cout;
+
+DebugStreamGuard::DebugStreamGuard(std::ostream& stream)
+    : prev_stream_{ACTIVE_STREAM} {
+  ACTIVE_STREAM = &stream;
+}
+
+DebugStreamGuard::~DebugStreamGuard() {
+  ACTIVE_STREAM = prev_stream_;
+}
+
+std::ostream& DebugStreamGuard::getCurStream() {
+  return *ACTIVE_STREAM;
+}
+void DebugStreamGuard::setCurStream(std::ostream& stream) {
+  ACTIVE_STREAM = &stream;
+}
+
+std::ostream& nvfdebug() {
+  return DebugStreamGuard::getCurStream();
+}
+
+} // namespace nvfuser

--- a/csrc/debug.h
+++ b/csrc/debug.h
@@ -1,0 +1,51 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <c10/macros/Export.h>
+#include <c10/util/Exception.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace nvfuser {
+
+//! This guard controls the output for debug info, such as any output resulting
+//! from use of the $NVFUSER_DUMP environment variable options. Debug output can
+//! be captured like so:
+//!
+//!   std::stringstream ss
+//!   {
+//!     DebugStreamGuard dsg(ss);
+//!     // Unmodified original code
+//!
+//!     // ss.str() now holds a std::string of debug info
+//!     // The guard resets the debug stream at the end of its lifetime
+//!   }
+//!   // Code after the dsg object is destroyed will use the previously-set
+//!   // stream, which defaults to std::cout.
+class TORCH_CUDA_CU_API DebugStreamGuard {
+ public:
+  DebugStreamGuard(std::ostream& stream);
+
+  ~DebugStreamGuard();
+
+  static std::ostream& getCurStream();
+
+  void setCurStream(std::ostream& stream);
+
+ private:
+  std::ostream* prev_stream_;
+};
+
+//! This is just a short alias to avoid having to type
+//! DebugStreamGuard::getCurStream() for each line we want to debug-print.
+TORCH_CUDA_CU_API std::ostream& nvfdebug();
+
+} // namespace nvfuser

--- a/csrc/device_lower/analysis/shift.cpp
+++ b/csrc/device_lower/analysis/shift.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <debug.h>
 #include <device_lower/analysis/index_compute.h>
 #include <device_lower/analysis/shift.h>
 #include <device_lower/lower2device.h>
@@ -203,7 +204,7 @@ HaloInfo::HaloInfo(Fusion* fusion, std::shared_ptr<const ComputeAtMap> ca_map) {
   }
 
   if (isDebugDumpEnabled(DebugDumpOption::Halo)) {
-    std::cout << toString() << std::endl;
+    nvfdebug() << toString() << std::endl;
   }
 
   // Note that validation requires consumer halo info

--- a/csrc/device_lower/analysis/thread_predicate.cpp
+++ b/csrc/device_lower/analysis/thread_predicate.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <device_lower/analysis/thread_predicate.h>
 
+#include <debug.h>
 #include <device_lower/lower2device.h>
 #include <device_lower/utils.h>
 #include <instrumentation.h>
@@ -854,15 +855,15 @@ void ThreadPredicateMap::markAsUpdated(const TensorView* tv) {
 }
 
 void ThreadPredicateMap::print() const {
-  std::cout << "\nThreadPredicateMap\n";
-  std::cout << "--------------------------------\n";
+  nvfdebug() << "\nThreadPredicateMap\n";
+  nvfdebug() << "--------------------------------\n";
   for (const auto& kv : thread_predicates_) {
-    std::cout << "T" << kv.first->name();
-    std::cout << " {" << kv.second.limited_types.toString() << "}\n";
-    std::cout << "{" << kv.second.redundant_types.toString() << "}\n";
-    std::cout << "{" << kv.second.redundant_use_types.toString() << "}\n";
+    nvfdebug() << "T" << kv.first->name();
+    nvfdebug() << " {" << kv.second.limited_types.toString() << "}\n";
+    nvfdebug() << "{" << kv.second.redundant_types.toString() << "}\n";
+    nvfdebug() << "{" << kv.second.redundant_use_types.toString() << "}\n";
   }
-  std::cout << "--------------------------------\n\n";
+  nvfdebug() << "--------------------------------\n\n";
 }
 
 } // namespace nvfuser

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -8,6 +8,7 @@
 #include <device_lower/lower2device.h>
 
 #include <ATen/cuda/CUDAContext.h>
+#include <debug.h>
 #include <device_lower/analysis/divisible_split.h>
 #include <device_lower/analysis/shift.h>
 #include <device_lower/pass/alias_memory.h>
@@ -230,9 +231,9 @@ void dumpExprsIfEnabled(
         std::find(args.begin(), args.end(), pass_name) != args.end());
   };
   if (force_enable || enabled_by_env()) {
-    std::cout << "After " << pass_name << ":" << std::endl;
+    nvfdebug() << "After " << pass_name << ":" << std::endl;
     for (auto exp : exprs) {
-      std::cout << exp->toString() << std::endl;
+      nvfdebug() << exp->toString() << std::endl;
     }
   }
 }
@@ -298,7 +299,7 @@ void GpuLower::lower(Fusion* fusion) {
   dumpExprsIfEnabled(fusion_->exprs(), "resolveComputeWith");
 
   if (isDebugDumpEnabled(DebugDumpOption::ComputeAtMap)) {
-    std::cout << compute_at_map_->toString() << std::endl;
+    nvfdebug() << compute_at_map_->toString() << std::endl;
   }
   compute_at_map_->validateAndPropagatePType();
   dumpExprsIfEnabled(fusion_->exprs(), "validateAndPropagatePType");
@@ -314,8 +315,8 @@ void GpuLower::lower(Fusion* fusion) {
 
   parallelDimensionMap().build(fusion_);
   if (isDebugDumpEnabled(DebugDumpOption::ParallelDimensions)) {
-    std::cout << "Parallel dimension map:" << std::endl;
-    std::cout << parallel_dimension_map_.toString() << std::endl;
+    nvfdebug() << "Parallel dimension map:" << std::endl;
+    nvfdebug() << parallel_dimension_map_.toString() << std::endl;
   }
   dumpExprsIfEnabled(fusion_->exprs(), "build parallelDimensionMap");
 
@@ -368,7 +369,7 @@ void GpuLower::lower(Fusion* fusion) {
   // tensor views need WAR or RAW syncs
   sync_map_ = std::make_shared<const SyncMap>(fusion_);
   if (isDebugDumpEnabled(DebugDumpOption::SyncMap)) {
-    std::cout << sync_map_->toString() << std::endl;
+    nvfdebug() << sync_map_->toString() << std::endl;
   }
   dumpExprsIfEnabled(fusion_->exprs(), "SyncMap");
 

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <device_lower/pass/alias_memory.h>
 
+#include <debug.h>
 #include <device_lower/lower2device.h>
 #include <device_lower/utils.h>
 #include <expr_evaluator.h>
@@ -602,7 +603,7 @@ class AllocationInfoMap : private kir::IrVisitor {
     handle(exprs);
     if (debug_printer_) {
       debug_printer_->popScope();
-      std::cout << debug_printer_->dumpDebugInfo(this);
+      nvfdebug() << debug_printer_->dumpDebugInfo(this);
     }
     current_stack_.pop_back();
   }

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <compute_at_map.h>
+#include <debug.h>
 #include <device_lower/lower2device.h>
 #include <device_lower/pass/expr_sort.h>
 #include <device_lower/utils.h>
@@ -879,10 +880,10 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
   }
 
   if (isDebugDumpEnabled(DebugDumpOption::ExprSort)) {
-    std::cout << "==========================================\n" << std::endl;
-    std::cout << "Producer:\n" << producer->toString() << std::endl;
-    std::cout << "Consumer:\n" << consumer->toString() << std::endl;
-    std::cout << "Merged:\n" << joined_groups->toString() << std::endl;
+    nvfdebug() << "==========================================\n" << std::endl;
+    nvfdebug() << "Producer:\n" << producer->toString() << std::endl;
+    nvfdebug() << "Consumer:\n" << consumer->toString() << std::endl;
+    nvfdebug() << "Merged:\n" << joined_groups->toString() << std::endl;
   }
 
   return joined_groups;

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1115,26 +1115,26 @@ void ExprSegmentationSorter::initializeForLoopDependencies() {
     visited.emplace(id);
   }
   if (failed) {
-    std::cerr
+    nvfdebug()
         << "ERROR: Iteration domain sorting has failed, infinite loop detected."
         << std::endl;
-    std::cerr << "Failed to sort out: " << std::endl;
+    nvfdebug() << "Failed to sort out: " << std::endl;
     for (auto entry : to_visit) {
-      std::cerr << entry->toString();
+      nvfdebug() << entry->toString();
       if (entry != to_visit.back()) {
-        std::cerr << ", ";
+        nvfdebug() << ", ";
       }
     }
 
-    std::cerr << "Dependencies: " << std::endl;
+    nvfdebug() << "Dependencies: " << std::endl;
     for (const auto& dep_entry : concrete_id_dependencies_) {
-      std::cerr << "  Deps of " << dep_entry.first->toString() << std::endl
-                << "   ";
+      nvfdebug() << "  Deps of " << dep_entry.first->toString() << std::endl
+                 << "   ";
 
       for (auto dep : dep_entry.second) {
-        std::cerr << dep->toString() << ", ";
+        nvfdebug() << dep->toString() << ", ";
       }
-      std::cerr << std::endl;
+      nvfdebug() << std::endl;
     }
 
     TORCH_INTERNAL_ASSERT(false);

--- a/csrc/device_lower/pass/loop_rotation.cpp
+++ b/csrc/device_lower/pass/loop_rotation.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <debug.h>
 #include <device_lower/pass/loop_rotation.h>
 #include <device_lower/utils.h>
 #include <ir/all_nodes.h>
@@ -306,8 +307,8 @@ class RotateLoop : kir::ExprMutator {
   //   }
   void rotate(kir::ForLoop* fl) {
     if (isDebugDumpEnabled(DebugDumpOption::LoopRotation)) {
-      std::cout << "[Loop rotation] Rotating loop:" << std::endl
-                << fl->toString() << std::endl;
+      nvfdebug() << "[Loop rotation] Rotating loop:" << std::endl
+                 << fl->toString() << std::endl;
     }
     // Insert selected allocations and `prologue` before `fl`, and replace `fl`
     // with `rotated`
@@ -331,7 +332,7 @@ class RotateLoop : kir::ExprMutator {
     }
     if (prologue->empty()) {
       if (isDebugDumpEnabled(DebugDumpOption::LoopRotation)) {
-        std::cout << "[Loop rotation] Nothing to do." << std::endl;
+        nvfdebug() << "[Loop rotation] Nothing to do." << std::endl;
       }
       return;
     }
@@ -344,8 +345,8 @@ class RotateLoop : kir::ExprMutator {
     }
     registerInsertBefore(fl, prologue);
     if (isDebugDumpEnabled(DebugDumpOption::LoopRotation)) {
-      std::cout << "[Loop rotation] Prologue:" << std::endl
-                << prologue->toString() << std::endl;
+      nvfdebug() << "[Loop rotation] Prologue:" << std::endl
+                 << prologue->toString() << std::endl;
     }
     // main
     auto rotated = IrBuilder::create<kir::IfThenElse>(
@@ -360,8 +361,8 @@ class RotateLoop : kir::ExprMutator {
     }
     main->body().push_back(rotated);
     if (isDebugDumpEnabled(DebugDumpOption::LoopRotation)) {
-      std::cout << "[Loop rotation] Main:" << std::endl
-                << main->toString() << std::endl;
+      nvfdebug() << "[Loop rotation] Main:" << std::endl
+                 << main->toString() << std::endl;
     }
     registerReplace(fl, main);
   }

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <evaluator_common.h>
 
+#include <debug.h>
 #include <device_lower/lower2device.h>
 #include <executor_kernel_arg.h>
 #include <expr_evaluator.h>
@@ -231,11 +232,11 @@ EvaluatorValue PrecomputedValues::getMaybeValueFor(const Val* val) const {
 }
 
 void PrecomputedValues::print() const {
-  std::cout << "Precomputed Values:\n";
+  nvfdebug() << "Precomputed Values:\n";
   for (auto i : c10::irange(symbols_.size())) {
     if (defined_[i]) {
-      std::cout << symbols_[i]->toInlineString() << " = " << values_[i]
-                << std::endl;
+      nvfdebug() << symbols_[i]->toInlineString() << " = " << values_[i]
+                 << std::endl;
     }
   }
 }

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -9,6 +9,7 @@
 #include <executor.h>
 
 #include <codegen.h>
+#include <debug.h>
 #include <device_lower/analysis/bank_conflict.h>
 #include <executor_kernel_arg.h>
 #include <executor_utils.h>
@@ -102,19 +103,19 @@ std::string FusionExecutor::getStructuredCode(
       executor_utils::kernelPreamble() + kernel_str + "}\n";
 
   if (isDebugDumpEnabled(DebugDumpOption::CudaKernel)) {
-    std::cout << "\n======= Codegen output for kernel: " << kernelName()
-              << " =======\n\n"
-              << kernel_str << "\n======================================\n\n";
+    nvfdebug() << "\n======= Codegen output for kernel: " << kernelName()
+               << " =======\n\n"
+               << kernel_str << "\n======================================\n\n";
   } else if (isDebugDumpEnabled(DebugDumpOption::CudaFull)) {
-    std::cout << "\n======= Codegen output for kernel: " << kernelName()
-              << " =======\n\n"
-              << code << "\n======================================\n\n";
+    nvfdebug() << "\n======= Codegen output for kernel: " << kernelName()
+               << " =======\n\n"
+               << code << "\n======================================\n\n";
   }
   if (isDebugDumpEnabled(DebugDumpOption::CudaToFile) ||
       isDebugDumpEnabled(DebugDumpOption::DebugInfo)) {
     std::stringstream file_name;
     file_name << "__tmp_kernel" << fusion_id_ << ".cu";
-    std::cout << "PRINTING: " << file_name.str() << std::endl;
+    nvfdebug() << "PRINTING: " << file_name.str() << std::endl;
     std::ofstream out(file_name.str());
     out << code << std::endl;
     out.close();
@@ -143,11 +144,11 @@ void FusionExecutor::debugCompileFusionFromStr(
   }
 
   if (isDebugDumpEnabled(DebugDumpOption::CudaFull)) {
-    std::cout << "\n==== codegen output for kernel: " << kernelName()
-              << " ====" << std::endl
-              << code << std::endl
-              << "======================================\n"
-              << std::endl;
+    nvfdebug() << "\n==== codegen output for kernel: " << kernelName()
+               << " ====" << std::endl
+               << code << std::endl
+               << "======================================\n"
+               << std::endl;
   }
 
   lowered_ = std::make_unique<GpuLower>(fusion);
@@ -278,29 +279,29 @@ void FusionExecutor::compileFusion(
   if (isDebugDumpEnabled(DebugDumpOption::BankConflictInfo)) {
     auto bank_conflict_info = getBankConflictInfo(kernel);
     if (bank_conflict_info.empty()) {
-      std::cout << "===== No bank confliction =====" << std::endl;
+      nvfdebug() << "===== No bank confliction =====" << std::endl;
     } else {
-      std::cout << "======= Bank confliction =======" << std::endl;
+      nvfdebug() << "======= Bank confliction =======" << std::endl;
       for (auto info : bank_conflict_info) {
-        std::cout << "Expr: " << info.first->toString() << std::endl;
+        nvfdebug() << "Expr: " << info.first->toString() << std::endl;
         auto conflict = info.second;
         if (conflict.first > 1) {
-          std::cout << "input conflict: " << conflict.first << " way, ";
+          nvfdebug() << "input conflict: " << conflict.first << " way, ";
         }
         if (conflict.second > 1) {
-          std::cout << "output conflict: " << conflict.second << " way";
+          nvfdebug() << "output conflict: " << conflict.second << " way";
         }
-        std::cout << std::endl;
+        nvfdebug() << std::endl;
       }
-      std::cout << "================================" << std::endl;
+      nvfdebug() << "================================" << std::endl;
     }
   }
 
   kernel_code_ = codegen::generateCudaKernel(kernel, kernelName());
 
   auto load_external_code = [](const char* external_code_path) {
-    std::cout << "--------> Compiling external cuda code: "
-              << external_code_path << std::endl;
+    nvfdebug() << "--------> Compiling external cuda code: "
+               << external_code_path << std::endl;
     std::ifstream cuda_src(external_code_path);
     std::stringstream buffer;
     buffer << cuda_src.rdbuf();
@@ -380,7 +381,7 @@ void FusionExecutor::compileFusion(
   }
 
   if (isDebugDumpEnabled(DebugDumpOption::Sass)) {
-    std::cout << disassembledKernelSASS() << std::endl;
+    nvfdebug() << disassembledKernelSASS() << std::endl;
   }
 }
 
@@ -1351,18 +1352,18 @@ void dumpFusionArgs(
     const LaunchParams& launch_constraints,
     const CompileParams& compile_params,
     const std::vector<at::Tensor>& outputs) {
-  std::cout << "Arguments for fusion" << fusion_id << ":" << std::endl
-            << "Inputs:" << std::endl;
+  nvfdebug() << "Arguments for fusion" << fusion_id << ":" << std::endl
+             << "Inputs:" << std::endl;
   for (auto i : c10::irange(args.size())) {
-    std::cout << "  " << args[i]->toString() << std::endl;
+    nvfdebug() << "  " << args[i]->toString() << std::endl;
   }
-  std::cout << "Outputs:" << std::endl;
+  nvfdebug() << "Outputs:" << std::endl;
   for (const auto& output : outputs) {
-    std::cout << "  " << output.scalar_type() << " " << output.sizes()
-              << " (strides = " << output.strides() << ")" << std::endl;
+    nvfdebug() << "  " << output.scalar_type() << " " << output.sizes()
+               << " (strides = " << output.strides() << ")" << std::endl;
   }
-  std::cout << launch_constraints.toString();
-  std::cout << "maxrregcount= " << compile_params.maxrregcount << std::endl;
+  nvfdebug() << launch_constraints.toString();
+  nvfdebug() << "maxrregcount= " << compile_params.maxrregcount << std::endl;
 }
 
 // Dump arguments that are passed to a CUDA kernel call, which include
@@ -1377,24 +1378,24 @@ void dumpKernelArgs(
     const std::vector<at::Tensor>& allocated_outputs,
     const std::vector<at::Tensor>& intermediates,
     const std::vector<FusionExecutor::GlobalBufferInfo>& intermediates_info) {
-  std::cout << "Arguments for kernel" << fusion_id << ":" << std::endl
-            << "Inputs:" << std::endl;
+  nvfdebug() << "Arguments for kernel" << fusion_id << ":" << std::endl
+             << "Inputs:" << std::endl;
   for (auto i : c10::irange(num_inputs)) {
-    std::cout << "  " << args[i]->toString() << std::endl;
+    nvfdebug() << "  " << args[i]->toString() << std::endl;
   }
-  std::cout << "Outputs:" << std::endl;
+  nvfdebug() << "Outputs:" << std::endl;
   // note: add aliased outputs here.
   for (const auto& output : allocated_outputs) {
-    std::cout << "  " << output.scalar_type() << " " << output.sizes()
-              << " (strides = " << output.strides()
-              << ", address = " << output.data_ptr() << ")" << std::endl;
+    nvfdebug() << "  " << output.scalar_type() << " " << output.sizes()
+               << " (strides = " << output.strides()
+               << ", address = " << output.data_ptr() << ")" << std::endl;
   }
-  std::cout << "Intermediate global buffers:" << std::endl;
+  nvfdebug() << "Intermediate global buffers:" << std::endl;
   for (const auto i : c10::irange(intermediates.size())) {
     const auto& buffer = intermediates.at(i);
     const auto& zero_init = intermediates_info.at(i).zero_init;
-    std::cout << "  " << buffer.scalar_type() << " " << buffer.sizes()
-              << " is_zero_initialized: " << zero_init << std::endl;
+    nvfdebug() << "  " << buffer.scalar_type() << " " << buffer.sizes()
+               << " is_zero_initialized: " << zero_init << std::endl;
   }
 }
 
@@ -1712,7 +1713,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   }
 
   if (isDebugDumpEnabled(DebugDumpOption::IndexType)) {
-    std::cout << "Index type: " << kernel()->indexType() << std::endl;
+    nvfdebug() << "Index type: " << kernel()->indexType() << std::endl;
   }
 
   const bool measure_kernel_time = measure_kernel_time_ ||
@@ -1749,9 +1750,9 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
       const float occupancy = (float)warps_per_sm / (float)hw_max_warps * 100.f;
       std::ostringstream oss;
       oss << std::fixed << std::setprecision(2) << occupancy << "%";
-      std::cout << "blocks_per_sm= " << blocks_per_sm
-                << ", warps_per_sm= " << warps_per_sm
-                << ", occupancy= " << oss.str() << std::endl;
+      nvfdebug() << "blocks_per_sm= " << blocks_per_sm
+                 << ", warps_per_sm= " << warps_per_sm
+                 << ", occupancy= " << oss.str() << std::endl;
     }
 
     if (measure_kernel_time) {
@@ -1808,14 +1809,14 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
         double gb_per_s =
             ((double)bytes_processed_ / ((double)kernel_time_ms_ / 1000)) /
             (double)1.0e9;
-        std::cout << "kernel" << fusion_id_ << " run in " << kernel_time_ms_
-                  << " ms, achieved: " << gb_per_s << " GB/s" << std::endl;
+        nvfdebug() << "kernel" << fusion_id_ << " run in " << kernel_time_ms_
+                   << " ms, achieved: " << gb_per_s << " GB/s" << std::endl;
       }
     }
   }
 
   if (isOptionEnabled(EnableOption::KernelProfile)) {
-    std::cout << kernel()->profile().toString(profile_buffer);
+    nvfdebug() << kernel()->profile().toString(profile_buffer);
   }
 
   return outputs;

--- a/csrc/executor_params.cpp
+++ b/csrc/executor_params.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <debug.h>
 #include <executor_params.h>
 
 #include <ATen/cuda/CUDAContext.h>
@@ -116,7 +117,7 @@ bool LaunchParams::operator==(const LaunchParams& other) const {
 }
 
 void LaunchParams::print() const {
-  std::cout << toString();
+  nvfdebug() << toString();
 }
 
 std::string LaunchParams::toString() const {

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -12,6 +12,7 @@
 #include <c10/util/irange.h>
 
 #include <contiguity.h>
+#include <debug.h>
 #include <executor_utils.h>
 #include <instrumentation.h>
 #include <ir/all_nodes.h>
@@ -978,7 +979,7 @@ void dumpCompiledCodeToFile(
   std::stringstream file_name;
   file_name << "__tmp_kernel" << fusion_id << "."
             << (dump_cubin ? "cubin" : "ptx");
-  std::cout << "PRINTING: " << file_name.str() << std::endl;
+  nvfdebug() << "PRINTING: " << file_name.str() << std::endl;
   std::ofstream out(file_name.str());
   TORCH_INTERNAL_ASSERT(out.is_open());
   out.write(code.data(), (std::streamsize)code.size());
@@ -1065,7 +1066,7 @@ class NvrtcCompileDriver {
           false, src, "\nCUDA NVRTC compile error: ", log_buf);
     }
     if (isDebugDumpEnabled(DebugDumpOption::PrintPtxasLog)) {
-      std::cout << log_buf << std::endl;
+      nvfdebug() << log_buf << std::endl;
     }
     return std::string(log_buf);
   }
@@ -1120,7 +1121,7 @@ class CuModuleLoadDataDriver {
         &module, image, opts.size(), opts.data(), opt_vals.data()));
 
     if (logging_enabled_) {
-      std::cout << log_ << std::endl;
+      nvfdebug() << log_ << std::endl;
     }
 
     return log_;
@@ -1298,15 +1299,15 @@ void warnRegisterSpill(const std::string& compile_log) {
       try {
         allowed_spill = std::stoi(optionArgs[0]);
       } catch (const std::exception& e) {
-        std::cout << "skip invalid argument for WarnRegisterSpill, arg = "
-                  << optionArgs[0] << std::endl;
+        nvfdebug() << "skip invalid argument for WarnRegisterSpill, arg = "
+                   << optionArgs[0] << std::endl;
       }
     }
   }
   if (stack_count > allowed_spill || store_count > allowed_spill ||
       load_count > allowed_spill) {
-    std::cout << "WARNING: Register spill detected\n"
-              << compile_log << std::endl;
+    nvfdebug() << "WARNING: Register spill detected\n"
+               << compile_log << std::endl;
   }
 }
 

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 
+#include <debug.h>
 #include <evaluator_common.h>
 #include <expr_evaluator.h>
 #include <instrumentation.h>
@@ -175,23 +176,23 @@ EvaluatorValue ExpressionEvaluator::getValue(const Val* value) {
 }
 
 void ExpressionEvaluator::print() const {
-  std::cout << "\nEvaluation context\n";
-  std::cout << "--------------------\n";
+  nvfdebug() << "\nEvaluation context\n";
+  nvfdebug() << "--------------------\n";
   for (const auto& kv : known_values_) {
     TORCH_INTERNAL_ASSERT(!kv.first->isConstScalar());
-    std::cout << kv.first << " = " << kv.second << " ; "
-              << *kv.first->getValType() << "\n";
+    nvfdebug() << kv.first << " = " << kv.second << " ; "
+               << *kv.first->getValType() << "\n";
   }
 
   for (const auto& kv : known_named_scalars_) {
-    std::cout << kv.first << " = " << kv.second << " ;\n";
+    nvfdebug() << kv.first << " = " << kv.second << " ;\n";
   }
 
-  std::cout << "\nPre-computed Values\n";
+  nvfdebug() << "\nPre-computed Values\n";
   if (precomputed_values_ != nullptr) {
     precomputed_values_->print();
   }
-  std::cout << "--------------------\n\n";
+  nvfdebug() << "--------------------\n\n";
 }
 
 void ExpressionEvaluator::propagateBoundValuesThroughExactMaps(Fusion* fusion) {

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <expr_simplifier.h>
 
+#include <debug.h>
 #include <device_lower/pass/magic_zero.h>
 #include <ir/all_nodes.h>
 #include <ir/builder.h>
@@ -107,12 +108,12 @@ class Logger : public NoOpLogger {
       };
 
       std::string header = "Simplifying expression:\n" + str(init_val_);
-      std::cout << header << std::endl;
+      nvfdebug() << header << std::endl;
       for (auto r : record_) {
-        std::cout << r.name << ":\n" << str(r.result) << std::endl;
+        nvfdebug() << r.name << ":\n" << str(r.result) << std::endl;
       }
-      std::cout << std::string(std::min<size_t>(header.size(), 80), '=')
-                << std::endl;
+      nvfdebug() << std::string(std::min<size_t>(header.size(), 80), '=')
+                 << std::endl;
     } catch (...) {
       // clang-tidy don't want this function to throw, but this is just a
       // debugging helper, I don't really care if it has throw or not.

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <codegen.h>
+#include <debug.h>
 #include <device_lower/analysis/bank_conflict.h>
 #include <device_lower/lower2device.h>
 #include <disjoint_set.h>
@@ -397,7 +398,7 @@ void Fusion::printKernel(const CompileParams& compile_params) {
       !this->isA<kir::Kernel>(),
       "Cannot \"print kernel\" of a kernel container. ",
       "This would require lowering during lowering.");
-  std::cout << codegen::generateCudaKernel(
+  nvfdebug() << codegen::generateCudaKernel(
       GpuLower(this, compile_params).kernel());
 }
 
@@ -474,14 +475,16 @@ void Fusion::printMath(bool from_outputs_only) {
 
   FusionGuard fg(this);
   auto exprs_for_print = exprs();
-  std::cout << "Inputs:" << std::endl;
+  nvfdebug() << "Inputs:" << std::endl;
   for (auto inp : inputs()) {
-    std::cout << "  " << inp << ", " << inp->getDataType().value() << std::endl;
+    nvfdebug() << "  " << inp << ", " << inp->getDataType().value()
+               << std::endl;
   }
 
-  std::cout << "Outputs:" << std::endl;
+  nvfdebug() << "Outputs:" << std::endl;
   for (auto out : outputs()) {
-    std::cout << "  " << out << ", " << out->getDataType().value() << std::endl;
+    nvfdebug() << "  " << out << ", " << out->getDataType().value()
+               << std::endl;
   }
 
   // If we want everything in the fusion, grab all values without uses to
@@ -496,11 +499,11 @@ void Fusion::printMath(bool from_outputs_only) {
     exprs_for_print = StmtSort::getExprs(this, leaf_vals);
   }
 
-  std::cout << "\n%kernel_math {\n";
+  nvfdebug() << "\n%kernel_math {\n";
   for (auto expr : exprs_for_print) {
-    std::cout << expr;
+    nvfdebug() << expr;
   }
-  std::cout << "}\n\n";
+  nvfdebug() << "}\n\n";
 }
 
 std::vector<Val*> Fusion::inputsAndCreated() {
@@ -520,7 +523,7 @@ void Fusion::printTransforms() {
   FUSER_PERF_SCOPE("Fusion::printTransforms");
 
   FusionGuard fg(this);
-  IrTransformPrinter t_exprs(std::cout);
+  IrTransformPrinter t_exprs(nvfdebug());
   t_exprs.handle(this);
 }
 

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -11,6 +11,7 @@
 #include <c10/macros/Export.h>
 #include <c10/util/Exception.h>
 
+#include <debug.h>
 #include <executor_params.h>
 #include <ir/base_nodes.h>
 #include <ir/container.h>
@@ -133,9 +134,12 @@ class TORCH_CUDA_CU_API Fusion : public IrContainer {
   void validateInputs();
 
   //! Print this fusion to an output stream
-  std::ostream& print(
-      std::ostream& os = std::cout,
-      bool include_tensor_transforms = true);
+  std::ostream& print(std::ostream& os, bool include_tensor_transforms = true);
+
+  //! Print to default debugging output stream
+  std::ostream& print() {
+    return print(nvfdebug());
+  }
 
   //! Print Arith exprs
   //! \param from_outputs_only Only print exprs reachable from outputs

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <debug.h>
 #include <fusion.h>
 #include <fusion_segmenter.h>
 #include <instrumentation.h>
@@ -244,7 +245,7 @@ std::ostream& operator<<(std::ostream& os, const SegmentedGroup* group) {
 }
 
 void SegmentedGroup::print() const {
-  std::cout << this << "\n";
+  nvfdebug() << this << "\n";
 }
 
 bool SegmentedGroup::isFusionInputGroup() const {
@@ -264,7 +265,7 @@ std::ostream& operator<<(std::ostream& os, const SegmentedEdge* edge) {
 }
 
 void SegmentedEdge::print() const {
-  std::cout << this << "\n";
+  nvfdebug() << this << "\n";
 }
 
 std::string toString(const SegmentedEdge* edge) {
@@ -1424,10 +1425,10 @@ std::ostream& operator<<(
 }
 
 void SegmentedFusion::print() const {
-  std::cout << "Segmented_Fusion Dump: -- Re-written complete fusion:{\n";
+  nvfdebug() << "Segmented_Fusion Dump: -- Re-written complete fusion:{\n";
   completeFusion()->printMath();
-  std::cout << "} // {Re-written complete fusion}\n";
-  std::cout << this << "\n";
+  nvfdebug() << "} // {Re-written complete fusion}\n";
+  nvfdebug() << this << "\n";
 }
 
 std::string toString(const SegmentedFusion* segmented_fusion) {

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <debug.h>
 #include <fusion.h>
 #include <ir/base_nodes.h>
 #include <kernel_cache.h>
@@ -523,8 +524,8 @@ class TORCH_CUDA_CU_API SegmentCandidateFinder {
       SegmentCandidateFinderOptions options = SegmentCandidateFinderOptions()) {
     auto fusion_copy = std::make_unique<Fusion>(*fusion);
     if (isDebugDumpEnabled(DebugDumpOption::FusionSegments)) {
-      std::cout << "Segment the fusion (Original Fusion Un-modified): "
-                << std::endl;
+      nvfdebug() << "Segment the fusion (Original Fusion Un-modified): "
+                 << std::endl;
       fusion_copy->printMath();
     }
     SegmentCandidateFinder scf(std::move(fusion_copy), inputs, options);
@@ -538,8 +539,8 @@ class TORCH_CUDA_CU_API SegmentCandidateFinder {
       SegmentCandidateFinderOptions options = SegmentCandidateFinderOptions()) {
     SegmentCandidateFinder scf(std::move(fusion), inputs, options);
     if (isDebugDumpEnabled(DebugDumpOption::FusionSegments)) {
-      std::cout << "Segment the fusion (Original Fusion Un-modified): "
-                << std::endl;
+      nvfdebug() << "Segment the fusion (Original Fusion Un-modified): "
+                 << std::endl;
       scf.completeFusion()->printMath();
     }
     return std::move(scf.segmented_fusion_);

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <debug.h>
 #include <device_lower/lower2device.h>
 #include <expr_evaluator.h>
 #include <instrumentation.h>
@@ -316,7 +317,7 @@ void Kernel::analyze() {
 }
 
 void Kernel::print() const {
-  IrPrinter ir_printer(std::cout);
+  IrPrinter ir_printer(nvfdebug());
   ir_printer.handle(this);
 }
 

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <kernel_cache.h>
 
+#include <debug.h>
 #include <dynamic_transform.h>
 #include <executor_params.h>
 #include <executor_utils.h>
@@ -631,7 +632,7 @@ FusionKernelRuntime* FusionExecutorCache::getKernelRuntimeFor(
       conc_info->setInitialInfo(&conc_initial_info);
 
       if (isDebugDumpEnabled(DebugDumpOption::FusionIrConcretized)) {
-        std::cout << "Fusion before concretization:" << std::endl;
+        nvfdebug() << "Fusion before concretization:" << std::endl;
         conc_fusion->printMath();
       }
 
@@ -642,7 +643,7 @@ FusionKernelRuntime* FusionExecutorCache::getKernelRuntimeFor(
       conc_fusion->stopManaging("initial_info");
 
       if (isDebugDumpEnabled(DebugDumpOption::FusionIrConcretized)) {
-        std::cout << "Concretized Fusion:" << std::endl;
+        nvfdebug() << "Concretized Fusion:" << std::endl;
         conc_fusion->printMath();
       }
     }
@@ -735,26 +736,26 @@ std::vector<at::Tensor> FusionKernelRuntime::runKernelWithInput(
 
   // Print relevant information all at once for easy debuging of perf
   if (isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose)) {
-    std::cout << "\nRun kernel:\n";
+    nvfdebug() << "\nRun kernel:\n";
     if (sg) {
       segmented_fusion_->makeFusion(sg)->printMath();
     } else {
       segmented_fusion_->completeFusion()->printMath();
     }
-    std::cout << "With inputs:\n";
+    nvfdebug() << "With inputs:\n";
     for (auto i : c10::irange(args.size())) {
-      std::cout << "  " << args[i]->toString() << std::endl;
+      nvfdebug() << "  " << args[i]->toString() << std::endl;
     }
-    std::cout << "Compiler log: " << executor.compilerLog() << "\n";
-    std::cout << scheduler_entry->params()->toString() << "\n";
-    std::cout << "With arguments: " << executor.lastLaunchParams().toString();
-    std::cout << executor.kernelName() << " " << executor.bytesProcessed()
-              << " bytes/ " << std::setprecision(3) << executor.kernelTimeMs()
-              << " ms "
-              << ((double)executor.bytesProcessed() /
-                  ((double)executor.kernelTimeMs() / 1000)) /
+    nvfdebug() << "Compiler log: " << executor.compilerLog() << "\n";
+    nvfdebug() << scheduler_entry->params()->toString() << "\n";
+    nvfdebug() << "With arguments: " << executor.lastLaunchParams().toString();
+    nvfdebug() << executor.kernelName() << " " << executor.bytesProcessed()
+               << " bytes/ " << std::setprecision(3) << executor.kernelTimeMs()
+               << " ms "
+               << ((double)executor.bytesProcessed() /
+                   ((double)executor.kernelTimeMs() / 1000)) /
             (double)1.0e9
-              << " GB/s" << std::endl;
+               << " GB/s" << std::endl;
     executor.setMeasureKernelTimeFlag(false);
   }
 
@@ -920,16 +921,16 @@ std::vector<at::Tensor> FusionKernelRuntime::runWithInputs(
   FUSER_PERF_SCOPE("FusionKernelRuntime::runWithInputs");
 
   if (isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose)) {
-    std::cout << "=================RUNNING FUSION SEGMENTS================="
-              << std::endl;
+    nvfdebug() << "=================RUNNING FUSION SEGMENTS================="
+               << std::endl;
   }
 
   c10::Device device(c10::DeviceType::CUDA, (int8_t)args.getDeviceIndex());
   const auto& tensor_map = runSegmentsWithInputs(args);
 
   if (isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose)) {
-    std::cout << "============= FINISHED RUNNING FUSION SEGMENTS ============"
-              << std::endl;
+    nvfdebug() << "============= FINISHED RUNNING FUSION SEGMENTS ============"
+               << std::endl;
   }
 
   // Produce final global output

--- a/csrc/maxinfo_propagator.h
+++ b/csrc/maxinfo_propagator.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <debug.h>
 #include <ir/interface_nodes.h>
 #include <ir/utils.h>
 
@@ -263,7 +264,8 @@ class TORCH_CUDA_CU_API SpanningTreePrinter
   void propagateC2P(TensorView* from, TensorView* to) override;
   void propagateP2C(TensorView* from, TensorView* to) override;
   void propagateSibling(TensorView* from, TensorView* to) override;
-  SpanningTreePrinter(std::ostream& stream = std::cout) : stream_(stream) {}
+  SpanningTreePrinter(std::ostream& stream) : stream_(stream) {}
+  SpanningTreePrinter() : SpanningTreePrinter(nvfdebug()) {}
 };
 
 // Simple selector for selecting subgraphs to build spanning trees. The selector

--- a/csrc/python_frontend/fusion_cache.cpp
+++ b/csrc/python_frontend/fusion_cache.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <debug.h>
 #include <instrumentation.h>
 #include <options.h>
 #include <python_frontend/fusion_cache.h>
@@ -266,8 +267,8 @@ TrieNode* FusionCache::createChild(TrieNode* node, RecordFunctor* rec) {
     if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
       std::stringstream ss;
       new_rec->print(ss);
-      std::cout << "\nFusionDefinition: Create new trie node for: " << ss.str()
-                << "\n";
+      nvfdebug() << "\nFusionDefinition: Create new trie node for: " << ss.str()
+                 << "\n";
     }
   }
   return child;

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -74,14 +74,14 @@ void FusionDefinition::finalizeDefinition() {
   auto child_node = fusionCache()->queryChildren(trie_node_, end_record_.get());
   if (!child_node.has_value()) {
     if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-      std::cout << "\nFusionDefinition: Terminal Node not found.\n";
+      nvfdebug() << "\nFusionDefinition: Terminal Node not found.\n";
     }
     trie_node_ = fusionCache()->createChild(trie_node_, end_record_.get());
     fusion_id_ = std::optional<size_t>(trie_node_->fusion_id);
     TORCH_CHECK(id().has_value(), "Invalid fusion id!");
 
     if (isDebugDumpEnabled(DebugDumpOption::PythonDefinition)) {
-      print(std::cout);
+      print(nvfdebug());
     }
 
     buildFusionIr(preschedFusion());
@@ -91,7 +91,7 @@ void FusionDefinition::finalizeDefinition() {
     }
   } else {
     if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-      std::cout << "\nFusionDefinition: Terminal Node found!\n";
+      nvfdebug() << "\nFusionDefinition: Terminal Node found!\n";
     }
     trie_node_ = child_node.value();
     fusion_id_ = std::optional<size_t>(trie_node_->fusion_id);
@@ -316,15 +316,15 @@ void FusionDefinition::defineRecord(RecordFunctor* record) {
   // match it but it also already existed in the cache.
   if (child_node.has_value()) {
     if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-      std::cout << "\nFusionDefinition: Record (hash: 0x" << std::hex
-                << record->hash() << ") hit in Fusion Cache.\n";
+      nvfdebug() << "\nFusionDefinition: Record (hash: 0x" << std::hex
+                 << record->hash() << ") hit in Fusion Cache.\n";
     }
     trie_node_ = child_node.value();
     // The FusionDefinition and the Cache will share the Record
   } else {
     if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-      std::cout << "\nFusionDefinition: Record (hash: 0x" << std::hex
-                << record->hash() << ") missed in Fusion Cache.\n";
+      nvfdebug() << "\nFusionDefinition: Record (hash: 0x" << std::hex
+                 << record->hash() << ") missed in Fusion Cache.\n";
     }
     trie_node_ =
         fusionCache()->createChild(trie_node_, recording_.back().get());

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -11,6 +11,8 @@
 #include <python_frontend/fusion_definition.h>
 #include <utils.h>
 
+#include <sstream>
+
 // Require namespace for perf scope instrumentation
 using namespace nvfuser::inst;
 
@@ -150,10 +152,17 @@ void FusionDefinition::print(std::ostream& os) const {
 std::vector<at::Tensor> FusionDefinition::execute(
     const at::ArrayRef<c10::IValue>& inputs,
     bool override_user_schedule,
-    std::optional<int8_t> selected_device) const {
+    bool capture_debug_output,
+    std::optional<int8_t> selected_device) {
+  debug_output_ = std::nullopt;
+  std::stringstream debug_ss;
+  DebugStreamGuard dsg(capture_debug_output ? debug_ss : std::cout);
+
   TORCH_CHECK(id().has_value(), "Valid fusion schedule is not available!");
 
   auto scheds = fusionCache()->queryFusionSchedules(id().value());
+
+  std::vector<at::Tensor> outputs;
 
   if (!override_user_schedule) {
     auto device = getCommonDeviceCUDA(inputs, selected_device);
@@ -166,12 +175,18 @@ std::vector<at::Tensor> FusionDefinition::execute(
           scheds, user_sched_id.value(), device);
       scheds->last_user_def_scheduled_ir = user_sched.schedule.get();
       scheds->last_user_def_executor = user_sched.executor.get();
-      return user_sched.executor->runFusion(inputs);
+      outputs = user_sched.executor->runFusion(inputs);
     }
   }
 
-  return scheds->auto_gen_schedules->runFusionWithInputs(
+  outputs = scheds->auto_gen_schedules->runFusionWithInputs(
       inputs, std::nullopt, selected_device);
+
+  if (capture_debug_output) {
+    debug_output_ = debug_ss.str();
+  }
+
+  return outputs;
 }
 
 std::string FusionDefinition::fusionIr() {

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -127,7 +127,13 @@ class TORCH_CUDA_CU_API FusionDefinition : public FusionState {
   std::vector<at::Tensor> execute(
       const at::ArrayRef<c10::IValue>& inputs,
       bool override_user_schedule,
-      std::optional<int8_t> device) const;
+      bool capture_debug_output,
+      std::optional<int8_t> device);
+  //! Return debugging output captured through exeuction with
+  //! capture_debug_output=true
+  std::optional<std::string> getDebugOutput() const {
+    return debug_output_;
+  }
   //! Return the unscheduled Fusion IR
   std::string fusionIr();
   //! Return the Cuda code for the last executed set of inputs
@@ -225,6 +231,9 @@ class TORCH_CUDA_CU_API FusionDefinition : public FusionState {
 
   Operators ops;
   SchedOperators sched;
+
+ private:
+  std::optional<std::string> debug_output_ = std::nullopt;
 };
 
 } // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <c10/util/complex.h>
+#include <debug.h>
 #include <ir/interface_nodes.h>
 #include <ops/all_ops.h>
 #include <options.h>
@@ -258,9 +259,9 @@ struct OpRecord : RecordFunctor {
         result = result &&
             (fusion_op_.target_type() == child_ptr->fusion_op_.target_type());
         if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-          std::cout << "\nOpRecord: " << name_ << " Target Type [self: 0x"
-                    << fusion_op_.target_type().name() << "] [other: 0x"
-                    << child_ptr->fusion_op_.target_type().name() << "] ";
+          nvfdebug() << "\nOpRecord: " << name_ << " Target Type [self: 0x"
+                     << fusion_op_.target_type().name() << "] [other: 0x"
+                     << child_ptr->fusion_op_.target_type().name() << "] ";
         }
         // Match the nvFuser arith function pointers
         // IMPORTANT! you need to dereference the target pointer in order
@@ -270,7 +271,7 @@ struct OpRecord : RecordFunctor {
              *child_ptr->fusion_op_
                   .template target<OutType (*)(ArgTypes...)>());
         if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-          std::cout
+          nvfdebug()
               << "Target  Ptr [self: 0x" << std::hex
               << (size_t)*fusion_op_.template target<OutType (*)(ArgTypes...)>()
               << "] [other: 0x" << std::hex
@@ -1106,9 +1107,9 @@ struct CastOpRecord : RecordFunctor {
         result = result &&
             (fusion_op_.target_type() == child_ptr->fusion_op_.target_type());
         if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-          std::cout << "\nCastOpRecord: " << name_ << " Target Type [self: 0x"
-                    << fusion_op_.target_type().name() << "] [other: 0x"
-                    << child_ptr->fusion_op_.target_type().name() << "]";
+          nvfdebug() << "\nCastOpRecord: " << name_ << " Target Type [self: 0x"
+                     << fusion_op_.target_type().name() << "] [other: 0x"
+                     << child_ptr->fusion_op_.target_type().name() << "]";
         }
         // IMPORTANT! you need to dereference the target pointer in order
         // to match the function
@@ -1117,13 +1118,13 @@ struct CastOpRecord : RecordFunctor {
              *child_ptr->fusion_op_
                   .template target<OutType (*)(DataType, ArgType)>());
         if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-          std::cout << " Target  Ptr [self: 0x" << std::hex
-                    << (size_t)*fusion_op_
-                           .template target<OutType (*)(DataType, ArgType)>()
-                    << "] [other: 0x" << std::hex
-                    << (size_t)*child_ptr->fusion_op_
-                           .template target<OutType (*)(DataType, ArgType)>()
-                    << "]\n";
+          nvfdebug() << " Target  Ptr [self: 0x" << std::hex
+                     << (size_t)*fusion_op_
+                            .template target<OutType (*)(DataType, ArgType)>()
+                     << "] [other: 0x" << std::hex
+                     << (size_t)*child_ptr->fusion_op_
+                            .template target<OutType (*)(DataType, ArgType)>()
+                     << "]\n";
         }
         result = result && (dtype_ == child_ptr->dtype_);
       }
@@ -1655,10 +1656,10 @@ struct ReductionOpRecord : RecordFunctor {
         result = result &&
             (fusion_op_.target_type() == child_ptr->fusion_op_.target_type());
         if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-          std::cout << "\nReductionOpRecord: " << name_
-                    << " Target Type [self: 0x"
-                    << fusion_op_.target_type().name() << "] [other: 0x"
-                    << child_ptr->fusion_op_.target_type().name() << "]";
+          nvfdebug() << "\nReductionOpRecord: " << name_
+                     << " Target Type [self: 0x"
+                     << fusion_op_.target_type().name() << "] [other: 0x"
+                     << child_ptr->fusion_op_.target_type().name() << "]";
         }
         // IMPORTANT! you need to dereference the target pointer in order
         // to match the function
@@ -1676,21 +1677,21 @@ struct ReductionOpRecord : RecordFunctor {
                                  bool,
                                  DataType)>());
         if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-          std::cout << " Target  Ptr [self: 0x" << std::hex
-                    << (size_t)*fusion_op_.template target<
+          nvfdebug() << " Target  Ptr [self: 0x" << std::hex
+                     << (size_t)*fusion_op_.template target<
 
-                           TensorView* (*)(TensorView*,
-                                           const std::vector<int>&,
-                                           bool,
-                                           DataType)>()
-                    << "] [other: 0x" << std::hex
-                    << (size_t)*child_ptr->fusion_op_.template target<
+                            TensorView* (*)(TensorView*,
+                                            const std::vector<int>&,
+                                            bool,
+                                            DataType)>()
+                     << "] [other: 0x" << std::hex
+                     << (size_t)*child_ptr->fusion_op_.template target<
 
-                           TensorView* (*)(TensorView*,
-                                           const std::vector<int>&,
-                                           bool,
-                                           DataType)>()
-                    << "]\n";
+                            TensorView* (*)(TensorView*,
+                                            const std::vector<int>&,
+                                            bool,
+                                            DataType)>()
+                     << "]\n";
         }
         result = result && (keep_dim_ == child_ptr->keep_dim_);
         result = result && (dtype_ == child_ptr->dtype_);

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -256,7 +256,8 @@ void initNvFuserPythonBindings(PyObject* module) {
           [](FusionDefinition& self,
              const py::iterable& iter,
              bool override_user_schedule,
-             std::optional<int64_t> device) {
+             std::optional<int64_t> device,
+             bool capture_debug_output) {
             std::vector<c10::IValue> inputs;
             for (py::handle obj : iter) {
               inputs.push_back(torch::jit::toIValue(obj, c10::AnyType::get()));
@@ -266,12 +267,21 @@ void initNvFuserPythonBindings(PyObject* module) {
               TORCH_CHECK(device.value() < 256, "Maximum device index is 255");
               int8_device = (int8_t)device.value();
             }
-            return self.execute(inputs, override_user_schedule, int8_device);
+            return self.execute(
+                inputs,
+                override_user_schedule,
+                capture_debug_output,
+                int8_device);
           },
           py::arg("inputs"),
           py::arg("override_user_schedule") = false,
           py::kw_only(),
           py::arg("device") = py::none(),
+          py::arg("capture_debug_output") = false,
+          py::return_value_policy::reference)
+      .def(
+          "_debug_output",
+          [](FusionDefinition& self) { return self.getDebugOutput(); },
           py::return_value_policy::reference)
       .def(
           "_fusion_ir",

--- a/csrc/root_domain_map.cpp
+++ b/csrc/root_domain_map.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <debug.h>
 #include <ir/iostream.h>
 #include <ir/utils.h>
 #include <iter_visitor.h>
@@ -745,7 +746,7 @@ ComputeAtRootDomainMapBuilder::ComputeAtRootDomainMapBuilder(
         ss << "\t\t" << dk.toString() << "\n";
       }
     }
-    std::cerr << ss.str();
+    nvfdebug() << ss.str();
   }
   TORCH_INTERNAL_ASSERT(pending_map_.empty());
 }

--- a/csrc/scheduler/debug_utils.h
+++ b/csrc/scheduler/debug_utils.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <debug.h>
 #include <options.h>
 #include <utils.h>
 
@@ -23,7 +24,7 @@ void canScheduleMessage(const Args&... args) {
   //  alternatively may want to allow this message in debug
   //  build only but that'd be inconvenient for user support.
   if (C10_UNLIKELY(isDebugDumpEnabled(DebugDumpOption::FusionSegmenterLog))) {
-    std::cout << c10::str(args...) << "\n";
+    nvfdebug() << c10::str(args...) << "\n";
   }
 }
 

--- a/csrc/scheduler/debug_utils.h
+++ b/csrc/scheduler/debug_utils.h
@@ -40,21 +40,21 @@ void canScheduleRejectReason(HeuristicType heuristic, const Args&... args) {
 // https://learn.microsoft.com/en-us/cpp/cpp/ellipses-and-variadic-templates?view=msvc-170#example
 inline void log() {
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerVerbose)) {
-    std::cerr << std::endl;
+    nvfdebug() << std::endl;
   }
 }
 
 template <typename T>
 void log(const T& t) {
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerVerbose)) {
-    std::cerr << t << std::endl;
+    nvfdebug() << t << std::endl;
   }
 }
 
 template <typename First, typename... Rest>
 void log(const First& first, const Rest&... rest) {
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerVerbose)) {
-    std::cerr << first;
+    nvfdebug() << first;
     log(rest...);
   }
 }

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -11,6 +11,7 @@
 
 // NOTE: included to avoid compilation error caused by missing destructor in
 // 'SchedulerRuntimeInfo'
+#include <debug.h>
 #include <executor_utils.h>
 #include <ir/base_nodes.h>
 #include <ir/interface_nodes.h>
@@ -42,7 +43,7 @@ using ProblemShape = std::array<int64_t, 3>;
 
 //! A wrapper for printing debug details.
 void printMsg(const std::string& msg) {
-  std::cout << msg << std::endl;
+  nvfdebug() << msg << std::endl;
 }
 
 //! A helper for deciding the type of MMA op for given fusion and problem shape.

--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <scheduler/reduction.h>
 
+#include <debug.h>
 #include <executor_utils.h>
 #include <grouped_reduction.h>
 #include <inlining.h>
@@ -247,21 +248,21 @@ std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
   rparams->tag = "InnerOuter Persistent Heuristic.\n";
 
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    std::cerr << "\n===== Combined InnerOuter Reduction Stats ========\n"
-              << "outer_dim_numel: " << outer_dim_numel << "\n"
-              << "inner_dim_numel: " << inner_dim_numel << "\n"
-              << "vectorize_factor_input: " << iop.inner_vect << "\n"
-              << "vectorization_factor_tmp_gmem_write: "
-              << iop.tmp_gmem_write_vect << "\n"
-              << "vectorization_factor_outer: "
-              << iop.vectorization_factor_outer << "\n"
-              << "multiple_reds_per_blk: " << rparams->multiple_reds_per_blk
-              << "\n"
-              << "threads_per_sm: " << threads_per_sm << "\n"
-              << "gdimy: " << iop.gdimy << "\n"
-              << "block(" << (iop.bdimx) << ", " << iop.bdimy << ", " << 1
-              << ")";
-    std::cerr << rparams->toString() << std::endl;
+    nvfdebug() << "\n===== Combined InnerOuter Reduction Stats ========\n"
+               << "outer_dim_numel: " << outer_dim_numel << "\n"
+               << "inner_dim_numel: " << inner_dim_numel << "\n"
+               << "vectorize_factor_input: " << iop.inner_vect << "\n"
+               << "vectorization_factor_tmp_gmem_write: "
+               << iop.tmp_gmem_write_vect << "\n"
+               << "vectorization_factor_outer: "
+               << iop.vectorization_factor_outer << "\n"
+               << "multiple_reds_per_blk: " << rparams->multiple_reds_per_blk
+               << "\n"
+               << "threads_per_sm: " << threads_per_sm << "\n"
+               << "gdimy: " << iop.gdimy << "\n"
+               << "block(" << (iop.bdimx) << ", " << iop.bdimy << ", " << 1
+               << ")";
+    nvfdebug() << rparams->toString() << std::endl;
   }
   return rparams;
 }
@@ -775,21 +776,21 @@ std::shared_ptr<ReductionParams> innerPersistentHeuristic(
   rparams->tag = "Inner Persistent Heuristic.\n";
 
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    std::cerr << "\n===== Reduction Stats ========\n"
-              << "total_reduction_numel: " << total_reduction_numel << "\n"
-              << "total_iteration_numel: " << total_iteration_numel << "\n"
-              << "inner_most_dimension_numel: " << inner_most_dimension_numel
-              << "\n"
-              << "vectorize_factor: " << vectorize_factor << "\n"
-              << "n_tensor_inputs: " << n_tensor_inputs << "\n"
-              << "max_input_dtype_size: " << max_input_dtype_size << "\n"
-              << "max_persistent_buffer_size: " << max_persistent_buffer_size
-              << "\n"
-              << "max_multi_reduction_factor: " << max_multi_reduction_factor
-              << "\n"
-              << "block(" << (pad_bdimx ? padded_bdimx : bdimx) << ", " << bdimy
-              << ", " << bdimz << ")";
-    std::cerr << rparams->toString() << std::endl;
+    nvfdebug() << "\n===== Reduction Stats ========\n"
+               << "total_reduction_numel: " << total_reduction_numel << "\n"
+               << "total_iteration_numel: " << total_iteration_numel << "\n"
+               << "inner_most_dimension_numel: " << inner_most_dimension_numel
+               << "\n"
+               << "vectorize_factor: " << vectorize_factor << "\n"
+               << "n_tensor_inputs: " << n_tensor_inputs << "\n"
+               << "max_input_dtype_size: " << max_input_dtype_size << "\n"
+               << "max_persistent_buffer_size: " << max_persistent_buffer_size
+               << "\n"
+               << "max_multi_reduction_factor: " << max_multi_reduction_factor
+               << "\n"
+               << "block(" << (pad_bdimx ? padded_bdimx : bdimx) << ", "
+               << bdimy << ", " << bdimz << ")";
+    nvfdebug() << rparams->toString() << std::endl;
   }
 
   return rparams;
@@ -849,18 +850,18 @@ std::shared_ptr<ReductionParams> gridOuterPersistentHeuristic(
       LaunchParams::UNINITIALIZED_VAL);
 
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    std::cerr << "\n===== Reduction Stats ========\n"
-              << "total_reduction_numel: " << total_reduction_numel << "\n"
-              << "total_iteration_numel: " << total_iteration_numel << "\n"
-              << "vectorize_factor: " << vectorize_factor << "\n"
-              << "n_tensor_inputs: " << n_tensor_inputs << "\n"
-              << "max_input_dtype_size: " << max_input_dtype_size << "\n"
-              << "max_persistent_buffer_size: " << max_persistent_buffer_size
-              << "\n"
-              << "persistent_buffer_factor: " << pb_size << "\n"
-              << "block(" << outer_params->launch_params.bdimx() << ", "
-              << outer_params->launch_params.bdimy() << ", 1)" << std::endl;
-    std::cerr << rparams->toString() << std::endl;
+    nvfdebug() << "\n===== Reduction Stats ========\n"
+               << "total_reduction_numel: " << total_reduction_numel << "\n"
+               << "total_iteration_numel: " << total_iteration_numel << "\n"
+               << "vectorize_factor: " << vectorize_factor << "\n"
+               << "n_tensor_inputs: " << n_tensor_inputs << "\n"
+               << "max_input_dtype_size: " << max_input_dtype_size << "\n"
+               << "max_persistent_buffer_size: " << max_persistent_buffer_size
+               << "\n"
+               << "persistent_buffer_factor: " << pb_size << "\n"
+               << "block(" << outer_params->launch_params.bdimx() << ", "
+               << outer_params->launch_params.bdimy() << ", 1)" << std::endl;
+    nvfdebug() << rparams->toString() << std::endl;
   }
 
   return rparams;
@@ -1146,18 +1147,18 @@ std::shared_ptr<ReductionParams> outerPersistentHeuristic(
   rparams->tag = "Outer persistent kernel heuristic.\n";
 
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    std::cerr << "\n===== Reduction Stats ========\n"
-              << "total_reduction_numel: " << total_reduction_numel << "\n"
-              << "total_iteration_numel: " << total_iteration_numel << "\n"
-              << "vectorize_factor: " << vectorize_factor << "\n"
-              << "n_tensor_inputs: " << n_tensor_inputs << "\n"
-              << "max_input_dtype_size: " << max_input_dtype_size << "\n"
-              << "max_persistent_buffer_size: " << max_persistent_buffer_size
-              << "\n"
-              << "max_multi_reduction_factor: " << max_multi_reduction_factor
-              << "\n"
-              << "block(" << bdimx << ", " << bdimy << ", 1)" << std::endl;
-    std::cerr << rparams->toString() << std::endl;
+    nvfdebug() << "\n===== Reduction Stats ========\n"
+               << "total_reduction_numel: " << total_reduction_numel << "\n"
+               << "total_iteration_numel: " << total_iteration_numel << "\n"
+               << "vectorize_factor: " << vectorize_factor << "\n"
+               << "n_tensor_inputs: " << n_tensor_inputs << "\n"
+               << "max_input_dtype_size: " << max_input_dtype_size << "\n"
+               << "max_persistent_buffer_size: " << max_persistent_buffer_size
+               << "\n"
+               << "max_multi_reduction_factor: " << max_multi_reduction_factor
+               << "\n"
+               << "block(" << bdimx << ", " << bdimy << ", 1)" << std::endl;
+    nvfdebug() << rparams->toString() << std::endl;
   }
 
   return rparams;

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <scheduler/pointwise.h>
 
+#include <debug.h>
 #include <device_lower/utils.h>
 #include <executor_utils.h>
 #include <inlining.h>
@@ -377,21 +378,21 @@ std::shared_ptr<PointwiseParams> getPointwiseHeuristics(
   }
 
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    std::cerr << "\n===== Pointwise Stats ========\n"
-              << "num_elems: " << n_elems << "\n"
-              << "elem_counts: " << elem_counts << "\n"
-              << "max_input_dtype_size: " << max_input_dtype_size << "\n"
-              << "vectorize_factor: " << vectorize_factor << std::endl;
-    std::cerr << "broadcast_byte_multiples: ";
+    nvfdebug() << "\n===== Pointwise Stats ========\n"
+               << "num_elems: " << n_elems << "\n"
+               << "elem_counts: " << elem_counts << "\n"
+               << "max_input_dtype_size: " << max_input_dtype_size << "\n"
+               << "vectorize_factor: " << vectorize_factor << std::endl;
+    nvfdebug() << "broadcast_byte_multiples: ";
     for (auto multiple : broadcast_byte_multiples) {
-      std::cerr << "(" << multiple.lhs_multiple << ", " << multiple.rhs_multiple
-                << "), ";
+      nvfdebug() << "(" << multiple.lhs_multiple << ", "
+                 << multiple.rhs_multiple << "), ";
     }
-    std::cerr << "LHS elems: "
-              << (right_elem_count > 0 ? n_elems / right_elem_count : 0)
-              << " RHS elems: " << right_elem_count << std::endl;
-    std::cerr << std::endl;
-    std::cerr << params->toString() << std::endl;
+    nvfdebug() << "LHS elems: "
+               << (right_elem_count > 0 ? n_elems / right_elem_count : 0)
+               << " RHS elems: " << right_elem_count << std::endl;
+    nvfdebug() << std::endl;
+    nvfdebug() << params->toString() << std::endl;
   }
 
   return params;

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <scheduler/reduction.h>
 
+#include <debug.h>
 #include <executor_utils.h>
 #include <instrumentation.h>
 #include <ir/all_nodes.h>
@@ -473,17 +474,17 @@ std::shared_ptr<ReductionParams> innerReductionHeuristic(
       bdimz > 1 ? bdimz : LaunchParams::UNINITIALIZED_VAL);
 
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    std::cerr << "\n===== Reduction Stats ========\n"
-              << "total_reduction_numel: "
-              << total_reduction_numel / inner_most_dimension_numel << " * "
-              << inner_most_dimension_numel << "\n"
-              << "total_iteration_numel: " << total_iteration_numel << "\n"
-              << "vectorize_factor: " << vectorize_factor << "\n"
-              << "n_tensor_inputs: " << n_tensor_inputs << "\n"
-              << "max_input_dtype_size: " << max_input_dtype_size << "\n"
-              << "block(" << bdimx << ", " << bdimy << ", " << bdimz << ")"
-              << std::endl;
-    std::cerr << rparams->toString() << std::endl;
+    nvfdebug() << "\n===== Reduction Stats ========\n"
+               << "total_reduction_numel: "
+               << total_reduction_numel / inner_most_dimension_numel << " * "
+               << inner_most_dimension_numel << "\n"
+               << "total_iteration_numel: " << total_iteration_numel << "\n"
+               << "vectorize_factor: " << vectorize_factor << "\n"
+               << "n_tensor_inputs: " << n_tensor_inputs << "\n"
+               << "max_input_dtype_size: " << max_input_dtype_size << "\n"
+               << "block(" << bdimx << ", " << bdimy << ", " << bdimz << ")"
+               << std::endl;
+    nvfdebug() << rparams->toString() << std::endl;
   }
 
   // If 3d, check if it's supported by the scheduler, otherwise force 1D
@@ -493,10 +494,10 @@ std::shared_ptr<ReductionParams> innerReductionHeuristic(
         (rparams->cross_grid_inner_reduction ||
          rparams->cross_grid_outer_reduction)) {
       if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-        std::cerr << "\n===== UNSUPPORTED REDUCTION HEURISTIC ========\n";
-        std::cerr << rparams->multiple_reds_per_blk << ", "
-                  << (rparams->unroll_factor_inner_reduction > 1) << ", "
-                  << rparams->cross_grid_inner_reduction << std::endl;
+        nvfdebug() << "\n===== UNSUPPORTED REDUCTION HEURISTIC ========\n";
+        nvfdebug() << rparams->multiple_reds_per_blk << ", "
+                   << (rparams->unroll_factor_inner_reduction > 1) << ", "
+                   << rparams->cross_grid_inner_reduction << std::endl;
       }
       return innerReductionHeuristic(
           total_reduction_numel,
@@ -837,14 +838,14 @@ std::shared_ptr<ReductionParams> outerReductionHeuristic(
       LaunchParams::UNINITIALIZED_VAL);
 
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    std::cerr << "\n===== Reduction Stats ========\n"
-              << "total_reduction_numel: " << total_reduction_numel << "\n"
-              << "total_iteration_numel: " << total_iteration_numel << "\n"
-              << "vectorize_factor: " << vectorize_factor << "\n"
-              << "n_tensor_inputs: " << n_tensor_inputs << "\n"
-              << "max_input_dtype_size: " << max_input_dtype_size << "\n"
-              << "block(" << bdimx << ", " << bdimy << ", 1)" << std::endl;
-    std::cerr << rparams->toString() << std::endl;
+    nvfdebug() << "\n===== Reduction Stats ========\n"
+               << "total_reduction_numel: " << total_reduction_numel << "\n"
+               << "total_iteration_numel: " << total_iteration_numel << "\n"
+               << "vectorize_factor: " << vectorize_factor << "\n"
+               << "n_tensor_inputs: " << n_tensor_inputs << "\n"
+               << "max_input_dtype_size: " << max_input_dtype_size << "\n"
+               << "block(" << bdimx << ", " << bdimy << ", 1)" << std::endl;
+    nvfdebug() << rparams->toString() << std::endl;
   }
   return rparams;
 }

--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <scheduler/transpose.h>
 
+#include <debug.h>
 #include <device_lower/utils.h>
 #include <executor_utils.h>
 #include <inlining.h>
@@ -722,31 +723,31 @@ std::shared_ptr<TransposeParams> getTransposeHeuristics(
   params->lparams.bind(params->getThreadsPerBlock(), ParallelType::TIDx);
 
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    std::cerr << "\n===== Transpose Stats ========\n"
-              << "inputs: " << ir_utils::toString(fusion->inputs()) << "\n"
-              << "outputs: " << ir_utils::toString(fusion->outputs()) << "\n"
-              << "shape: " << shape_in_ref1 << "\n"
-              << "num_elems: " << n_elems << "\n"
-              << "n_input_tensors: " << n_input_tensors << "\n"
-              << "max_input_dtype_size: " << max_input_dtype_size << "\n"
-              << "group 1: " << ir_utils::toString(grouped_inputs_outputs[0])
-              << "\n"
-              << "reference1: " << reference1 << "\n"
-              << "inner_most_id1 position: " << inner_most_pos1_in_ref1
-              << " (in reference 1)\n"
-              << "group 2: " << ir_utils::toString(grouped_inputs_outputs[1])
-              << "\n"
-              << "reference2: " << reference2 << "\n"
-              << "inner_most_id2 position: " << inner_most_pos2_in_ref1
-              << " (in reference 1)" << std::endl;
+    nvfdebug() << "\n===== Transpose Stats ========\n"
+               << "inputs: " << ir_utils::toString(fusion->inputs()) << "\n"
+               << "outputs: " << ir_utils::toString(fusion->outputs()) << "\n"
+               << "shape: " << shape_in_ref1 << "\n"
+               << "num_elems: " << n_elems << "\n"
+               << "n_input_tensors: " << n_input_tensors << "\n"
+               << "max_input_dtype_size: " << max_input_dtype_size << "\n"
+               << "group 1: " << ir_utils::toString(grouped_inputs_outputs[0])
+               << "\n"
+               << "reference1: " << reference1 << "\n"
+               << "inner_most_id1 position: " << inner_most_pos1_in_ref1
+               << " (in reference 1)\n"
+               << "group 2: " << ir_utils::toString(grouped_inputs_outputs[1])
+               << "\n"
+               << "reference2: " << reference2 << "\n"
+               << "inner_most_id2 position: " << inner_most_pos2_in_ref1
+               << " (in reference 1)" << std::endl;
     if (!params->split_before_tiling.empty() ||
         !params->dims_merged_with_1.empty() ||
         !params->dims_merged_with_2.empty()) {
-      std::cerr << "small transposed dim, needs virtual inner-most dim"
-                << std::endl;
+      nvfdebug() << "small transposed dim, needs virtual inner-most dim"
+                 << std::endl;
     }
-    std::cerr << std::endl;
-    std::cerr << params->toString() << std::endl;
+    nvfdebug() << std::endl;
+    nvfdebug() << params->toString() << std::endl;
   }
 
   return params;

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -8,6 +8,7 @@
 #include <transform_replay.h>
 
 #include <compute_at_map.h>
+#include <debug.h>
 #include <disjoint_set.h>
 #include <fusion.h>
 #include <instrumentation.h>
@@ -1080,9 +1081,9 @@ void TransformPropagator::propagateC2P(TensorView* from, TensorView* to) {
       TransformReplay::getMatchedLeafPosWithoutReplayPasC(to, from, pos, true);
   bool debug = isDebugDumpEnabled(DebugDumpOption::TransformPropagator);
   if (debug) {
-    std::cout << "TransformPropagator::propagateC2P" << std::endl;
-    std::cout << "  from: " << from << " @ " << pos << std::endl;
-    std::cout << "  to: " << to << std::endl;
+    nvfdebug() << "TransformPropagator::propagateC2P" << std::endl;
+    nvfdebug() << "  from: " << from << " @ " << pos << std::endl;
+    nvfdebug() << "  to: " << to << std::endl;
   }
   if (new_pos < 0) {
     auto replay = TransformReplay::replayPasC(to, from, pos);
@@ -1096,10 +1097,10 @@ void TransformPropagator::propagateC2P(TensorView* from, TensorView* to) {
     to->setDomain(replay.first);
     new_pos = (int)replay.second;
     if (debug) {
-      std::cout << "  replayed: " << to << " @ " << new_pos << std::endl;
+      nvfdebug() << "  replayed: " << to << " @ " << new_pos << std::endl;
     }
   } else if (debug) {
-    std::cout << "  replay skipped. result position: " << new_pos << std::endl;
+    nvfdebug() << "  replay skipped. result position: " << new_pos << std::endl;
   }
   replayed_pos_[to] = new_pos;
 }
@@ -1111,9 +1112,9 @@ void TransformPropagator::propagateP2C(TensorView* from, TensorView* to) {
       TransformReplay::getMatchedLeafPosWithoutReplayCasP(to, from, pos, true);
   bool debug = isDebugDumpEnabled(DebugDumpOption::TransformPropagator);
   if (debug) {
-    std::cout << "TransformPropagator::propagateP2C" << std::endl;
-    std::cout << "  from: " << from << " @ " << pos << std::endl;
-    std::cout << "  to: " << to << std::endl;
+    nvfdebug() << "TransformPropagator::propagateP2C" << std::endl;
+    nvfdebug() << "  from: " << from << " @ " << pos << std::endl;
+    nvfdebug() << "  to: " << to << std::endl;
   }
   if (new_pos < 0) {
     auto replay = TransformReplay::replayCasP(to, from, pos);
@@ -1127,10 +1128,10 @@ void TransformPropagator::propagateP2C(TensorView* from, TensorView* to) {
     to->setDomain(replay.first);
     new_pos = (int)replay.second;
     if (debug) {
-      std::cout << "  replayed: " << to << " @ " << new_pos << std::endl;
+      nvfdebug() << "  replayed: " << to << " @ " << new_pos << std::endl;
     }
   } else if (debug) {
-    std::cout << "  replay skipped. result position: " << new_pos << std::endl;
+    nvfdebug() << "  replay skipped. result position: " << new_pos << std::endl;
   }
   replayed_pos_[to] = new_pos;
 }
@@ -1140,9 +1141,9 @@ void TransformPropagator::propagateSibling(TensorView* from, TensorView* to) {
   // See note [Using multiple TransformPropagators]
   bool debug = isDebugDumpEnabled(DebugDumpOption::TransformPropagator);
   if (debug) {
-    std::cout << "TransformPropagator::propagateSibling" << std::endl;
-    std::cout << "  from: " << from << " @ " << pos << std::endl;
-    std::cout << "  to: " << to << std::endl;
+    nvfdebug() << "TransformPropagator::propagateSibling" << std::endl;
+    nvfdebug() << "  from: " << from << " @ " << pos << std::endl;
+    nvfdebug() << "  to: " << to << std::endl;
   }
   if (!TransformReplay::fullSelfMatching(to, from)) {
     auto replay = TransformReplay::fullSelfReplay(to->domain(), from->domain());
@@ -1155,10 +1156,10 @@ void TransformPropagator::propagateSibling(TensorView* from, TensorView* to) {
         " but that would invalidate previously compute at position or max producer position.");
     to->setDomain(replay);
     if (debug) {
-      std::cout << "  replayed: " << to << " @ " << pos << std::endl;
+      nvfdebug() << "  replayed: " << to << " @ " << pos << std::endl;
     }
   } else if (debug) {
-    std::cout << "  replay skipped. result position: " << pos << std::endl;
+    nvfdebug() << "  replay skipped. result position: " << pos << std::endl;
   }
   replayed_pos_[to] = pos;
 }
@@ -1182,9 +1183,9 @@ void MostInlinedTransformPropagator::propagateC2P(
       TransformReplay::getMatchedLeafPosWithoutReplayPasC(to, from, pos, true);
   bool debug = isDebugDumpEnabled(DebugDumpOption::TransformPropagator);
   if (debug) {
-    std::cout << "MostInlinedTransformPropagator::propagateC2P" << std::endl;
-    std::cout << "  from: " << from << std::endl;
-    std::cout << "  to: " << to << std::endl;
+    nvfdebug() << "MostInlinedTransformPropagator::propagateC2P" << std::endl;
+    nvfdebug() << "  from: " << from << std::endl;
+    nvfdebug() << "  to: " << to << std::endl;
   }
   if (new_pos < 0) {
     auto replay = TransformReplay::replayPasC(to, from, pos);
@@ -1197,10 +1198,10 @@ void MostInlinedTransformPropagator::propagateC2P(
         " but that would invalidate previously compute at position or max producer position.");
     to->setDomain(replay.first);
     if (debug) {
-      std::cout << "  replayed: " << to << std::endl;
+      nvfdebug() << "  replayed: " << to << std::endl;
     }
   } else if (debug) {
-    std::cout << "  replay skipped" << std::endl;
+    nvfdebug() << "  replay skipped" << std::endl;
   }
 }
 
@@ -1213,9 +1214,9 @@ void MostInlinedTransformPropagator::propagateP2C(
       TransformReplay::getMatchedLeafPosWithoutReplayCasP(to, from, pos, true);
   bool debug = isDebugDumpEnabled(DebugDumpOption::TransformPropagator);
   if (debug) {
-    std::cout << "MostInlinedTransformPropagator::propagateP2C" << std::endl;
-    std::cout << "  from: " << from << std::endl;
-    std::cout << "  to: " << to << std::endl;
+    nvfdebug() << "MostInlinedTransformPropagator::propagateP2C" << std::endl;
+    nvfdebug() << "  from: " << from << std::endl;
+    nvfdebug() << "  to: " << to << std::endl;
   }
   if (new_pos < 0) {
     auto replay = TransformReplay::replayCasP(to, from, pos);
@@ -1228,10 +1229,10 @@ void MostInlinedTransformPropagator::propagateP2C(
         " but that would invalidate previously compute at position or max producer position.");
     to->setDomain(replay.first);
     if (debug) {
-      std::cout << "  replayed: " << to << std::endl;
+      nvfdebug() << "  replayed: " << to << std::endl;
     }
   } else if (debug) {
-    std::cout << "  replay skipped" << std::endl;
+    nvfdebug() << "  replay skipped" << std::endl;
   }
 }
 
@@ -1241,10 +1242,10 @@ void MostInlinedTransformPropagator::propagateSibling(
   // See note [Using multiple TransformPropagators]
   bool debug = isDebugDumpEnabled(DebugDumpOption::TransformPropagator);
   if (debug) {
-    std::cout << "MostInlinedTransformPropagator::propagateSibling"
-              << std::endl;
-    std::cout << "  from: " << from << std::endl;
-    std::cout << "  to: " << to << std::endl;
+    nvfdebug() << "MostInlinedTransformPropagator::propagateSibling"
+               << std::endl;
+    nvfdebug() << "  from: " << from << std::endl;
+    nvfdebug() << "  to: " << to << std::endl;
   }
   if (!TransformReplay::fullSelfMatching(to, from)) {
     auto replay = TransformReplay::fullSelfReplay(to->domain(), from->domain());
@@ -1257,10 +1258,10 @@ void MostInlinedTransformPropagator::propagateSibling(
         " but that would invalidate previously compute at position or max producer position.");
     to->setDomain(replay);
     if (debug) {
-      std::cout << "  replayed: " << to << std::endl;
+      nvfdebug() << "  replayed: " << to << std::endl;
     }
   } else if (debug) {
-    std::cout << "  replay skipped" << std::endl;
+    nvfdebug() << "  replay skipped" << std::endl;
   }
 }
 

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -8,6 +8,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/util/string_view.h>
 #include <cuda_occupancy.h>
+#include <debug.h>
 #include <options.h>
 #include <utils.h>
 
@@ -33,7 +34,7 @@ void debugPrint(const c10::TensorTypePtr& type) {
   } else {
     sizes_s << "no size available";
   }
-  std::cout << "sizes:" << sizes_s.str() << std::endl;
+  nvfdebug() << "sizes:" << sizes_s.str() << std::endl;
   if (const auto& stride_properties = type->stride_properties().sizes()) {
     std::stringstream stride_s;
     std::stringstream index_s;
@@ -58,11 +59,11 @@ void debugPrint(const c10::TensorTypePtr& type) {
         contig_s << "?, ";
       }
     }
-    std::cout << "stride: " << stride_s.str() << std::endl;
-    std::cout << "stride index: " << index_s.str() << std::endl;
-    std::cout << "contiguous: " << contig_s.str() << std::endl;
+    nvfdebug() << "stride: " << stride_s.str() << std::endl;
+    nvfdebug() << "stride index: " << index_s.str() << std::endl;
+    nvfdebug() << "contiguous: " << contig_s.str() << std::endl;
   } else {
-    std::cout << "no stride properties available" << std::endl;
+    nvfdebug() << "no stride properties available" << std::endl;
   }
 }
 C10_DIAGNOSTIC_POP()

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -11,6 +11,7 @@
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/ir/ir.h>
 
+#include <debug.h>
 #include <type.h>
 
 #include <deque>
@@ -366,12 +367,12 @@ template <typename... Args>
 class DebugPrintScope {
  public:
   DebugPrintScope(std::string name, Args... args) : name_(std::move(name)) {
-    std::cout << "Entering " << name_ << "("
-              << toDelimitedString(std::forward_as_tuple(args...)) << ")"
-              << std::endl;
+    nvfdebug() << "Entering " << name_ << "("
+               << toDelimitedString(std::forward_as_tuple(args...)) << ")"
+               << std::endl;
   }
   ~DebugPrintScope() {
-    std::cout << "Leaving " << name_ << std::endl;
+    nvfdebug() << "Leaving " << name_ << std::endl;
   }
 
  private:

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -45,7 +45,14 @@ class FusionDefinition(_C._FusionDefinition):
     def schedule(self):
         raise NotImplementedError("schedule() should be implemented by child class!")
 
-    def execute(self, inputs, *, device=None, **kwargs):
+    def execute(
+        self,
+        inputs,
+        *,
+        device=None,
+        override_user_schedule=False,
+        capture_debug_output=False,
+    ):
         """
         Executes an nvFuser set of kernels for a given Fusion
 
@@ -78,11 +85,14 @@ class FusionDefinition(_C._FusionDefinition):
             NVFuser where to run the resulting kernel, or let it default to 0.
             Note that passing this option providing and input tensors that lie
             on another device is an error.
+            capture_debug_output (bool): Whether to capture any printed
+            debugging information as a string. If True, the string can be
+            retrieved after execution using :meth:`get_debug_output`. If False,
+            then that method will return None when called.
 
         Returns:
             List[Tensor]
         """
-        override_user_schedule = kwargs.pop("override_user_schedule", False)
         func_based_def = False
 
         if device is not None:
@@ -108,7 +118,12 @@ class FusionDefinition(_C._FusionDefinition):
 
         result = None
         try:
-            result = self._execute(inputs, override_user_schedule, device=device)
+            result = self._execute(
+                inputs,
+                override_user_schedule,
+                device=device,
+                capture_debug_output=capture_debug_output,
+            )
         except Exception as err:
             msg = (
                 f"An error occurred while executing nvFuser FusionDefinition {self.id()}.\n"
@@ -147,6 +162,21 @@ class FusionDefinition(_C._FusionDefinition):
             raise
 
         return result
+
+    def get_debug_output(self):
+        """
+        Retrieve string of captured debug information from the previous execution.
+
+        Note that `capture_debug_output=True` must be passed to `execute()` in
+        order to enable capturing this output. Otherwise, this method will
+        return `None`.
+
+        Returns:
+            Optional[String] : the captured debug output for the previous call
+            to execute(). If the `capture_debug_output` argument to that call
+            was False, returns None. Otherwise, returns the output as a string.
+        """
+        return self._debug_output()
 
     def from_pytorch(self, tensor, static_sizes=False):
         """

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2359,6 +2359,27 @@ class TestNvFuserFrontend(TestCase):
         # Just test that this executes, not that it's correct
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
 
+    def test_debug_output(self):
+        inputs = [
+            torch.randn((3,), dtype=torch.float32, device="cuda:0"),
+            0.1,
+        ]
+
+        with FusionDefinition() as fd:
+            T0 = fd.from_pytorch(inputs[0])
+            S1 = fd.define_scalar()
+            T1 = fd.ops.mul(T0, S1)
+            fd.add_output(T1)
+
+        out1 = fd.execute(inputs)
+        self.assertIsNone(fd.get_debug_output())
+
+        # If debug output is captured, getDebugOutput() will not return None.
+        # The output will depend on the NVFUSER_DUMP environment variable in
+        # such case
+        out2 = fd.execute(inputs, capture_debug_output=True)
+        self.assertIsNotNone(fd.get_debug_output())
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
This PR introduces the `nvfdebug()` function to use in place of `std::cout` for debug printing in C++. Anything piped to this can be optionally redirected using a new guard called `DebugStreamGuard` like so:
```c++
std::stringstream ss;
DebugStreamGuard dsg(ss);
foo();
// ss.str() now holds the debugging output from foo() for the lifetime of dsg
```
In the Python frontend, the new optional argument to `fd.execute` called `capture_debug_output` enables this sort of capturing and saves the result to a `std::optional<std::string>` attached to `FusionDefinition`. That optional string can be retrieved via `fd.get_debug_output()`, which returns `None` if the `FusionDefinition` has not been executed, or if the most recent execution had `capture_debug_output=False` (the default).