### PR TITLE
Build system fix

### DIFF
--- a/csrc/type_traits.h
+++ b/csrc/type_traits.h
@@ -442,7 +442,7 @@ namespace nvfuser {
 // (Void, T1, Void, T2, Void, T3, ...) -> (T1, T2, T3, ...)
 
 template <typename... Ts>
-constexpr auto remove_void_from_tuple(std::tuple<Ts...> t) {
+constexpr auto remove_void_from_tuple([[maybe_unused]] std::tuple<Ts...> t) {
   if constexpr (sizeof...(Ts) == 0) {
     return std::tuple<>{};
   } else {


### PR DESCRIPTION
Fix an error for unused variable, present in gcc94 builds:


```
Fuser/csrc/type_traits.h: In instantiation of ‘constexpr auto nvfuser::remove_void_from_tuple(std::tuple<_Tps ...>) [with Ts = {}]’:
Fuser/csrc/type_traits.h:455:52:   recursively required from ‘constexpr auto nvfuser::remove_void_from_tuple(std::tuple<_Tps ...>) [with Ts = {int, nvfuser::Void, bool, nvfuser::Void, double, nvfuser::Void}]’
Fuser/csrc/type_traits.h:455:52:   required from ‘constexpr auto nvfuser::remove_void_from_tuple(std::tuple<_Tps ...>) [with Ts = {nvfuser::Void, int, nvfuser::Void, bool, nvfuser::Void, double, nvfuser::Void}]’
Fuser/csrc/type_traits.h:469:70:   required from here
Fuser/csrc/type_traits.h:445:57: error: parameter ‘t’ set but not used [-Werror=unused-but-set-parameter]
  445 | constexpr auto remove_void_from_tuple(std::tuple<Ts...> t) {
      |                                       ~~~~~~~~~~~~~~~~~~^
```