### PR TITLE
Improve `operator[]` for `DynamicType`

### DIFF
--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -356,32 +356,74 @@ struct DynamicType {
       },
       type_identities_as_tuple);
 
-  template <
-      typename IndexT,
-      typename = std::enable_if_t<has_square_bracket<IndexT>>>
-  DynamicType& operator[](const IndexT& i) {
-    std::optional<std::reference_wrapper<DynamicType>> ret = std::nullopt;
-    for_all_types([this, &ret, &i](auto t) {
-      using T = typename decltype(t)::type;
-      if constexpr (opcheck<T>[opcheck<IndexT>]) {
-        if constexpr (std::is_same_v<
-                          decltype(std::declval<T>()[std::declval<IndexT>()]),
-                          DynamicType&>) {
-          if (is<T>()) {
-            ret = std::ref(as<T>()[i]);
-          }
-        }
-      }
-    });
-    TORCH_CHECK(
-        ret.has_value(),
-        "Cannot index ",
-        type().name(),
-        " with ",
-        typeid(IndexT).name(),
-        " : incompatible type");
-    return ret.value();
+#define DEFINE_SQUARE_BRACKET_OPERATOR(__const)                                \
+  template <typename IndexT>                                                   \
+  std::enable_if_t<                                                            \
+      !std::is_same_v<IndexT, DynamicType> && has_square_bracket<IndexT>,      \
+      __const DynamicType&>                                                    \
+  operator[](const IndexT& i) __const {                                        \
+    std::optional<std::reference_wrapper<__const DynamicType>> ret =           \
+        std::nullopt;                                                          \
+    for_all_types([this, &ret, &i](auto t) {                                   \
+      using T = typename decltype(t)::type;                                    \
+      if constexpr (opcheck<T>[opcheck<IndexT>]) {                             \
+        if constexpr (std::is_same_v<                                          \
+                          decltype(std::declval<T>()[std::declval<IndexT>()]), \
+                          DynamicType&>) {                                     \
+          if (is<T>()) {                                                       \
+            ret = std::ref(as<T>()[i]);                                        \
+          }                                                                    \
+        }                                                                      \
+      }                                                                        \
+    });                                                                        \
+    TORCH_CHECK(                                                               \
+        ret.has_value(),                                                       \
+        "Cannot index ",                                                       \
+        type().name(),                                                         \
+        " with ",                                                              \
+        typeid(IndexT).name(),                                                 \
+        " : incompatible type");                                               \
+    return ret.value();                                                        \
   }
+
+  DEFINE_SQUARE_BRACKET_OPERATOR()
+  DEFINE_SQUARE_BRACKET_OPERATOR(const)
+#undef DEFINE_SQUARE_BRACKET_OPERATOR
+
+  static constexpr bool has_any_square_bracket = any_check(
+      [](auto t) {
+        using IndexT = typename decltype(t)::type;
+        return has_square_bracket<IndexT>;
+      },
+      type_identities_as_tuple);
+
+#define DEFINE_SQUARE_BRACKET_OPERATOR(__const)                      \
+  template <typename DT>                                             \
+  std::enable_if_t<                                                  \
+      std::is_same_v<DT, DynamicType> && has_any_square_bracket,     \
+      __const DynamicType&>                                          \
+  operator[](const DT& i) __const {                                  \
+    std::optional<std::reference_wrapper<__const DynamicType>> ret = \
+        std::nullopt;                                                \
+    for_all_types([this, &ret, &i](auto t) {                         \
+      using IndexT = typename decltype(t)::type;                     \
+      if constexpr (has_square_bracket<IndexT>) {                    \
+        ret = std::ref((*this)[i.template as<IndexT>()]);            \
+      }                                                              \
+    });                                                              \
+    TORCH_CHECK(                                                     \
+        ret.has_value(),                                             \
+        "Cannot index ",                                             \
+        type().name(),                                               \
+        " with ",                                                    \
+        i.type().name(),                                             \
+        " : incompatible type");                                     \
+    return ret.value();                                              \
+  }
+
+  DEFINE_SQUARE_BRACKET_OPERATOR()
+  DEFINE_SQUARE_BRACKET_OPERATOR(const)
+#undef DEFINE_SQUARE_BRACKET_OPERATOR
 
   // TODO: support ->* operator. This operator is rarely used, so we don't
   // implement it yet. But if in the future, it turns to be useful, we should

--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -408,7 +408,9 @@ struct DynamicType {
     for_all_types([this, &ret, &i](auto t) {                         \
       using IndexT = typename decltype(t)::type;                     \
       if constexpr (has_square_bracket<IndexT>) {                    \
-        ret = std::ref((*this)[i.template as<IndexT>()]);            \
+        if (i.template is<IndexT>()) {                               \
+          ret = std::ref((*this)[i.template as<IndexT>()]);          \
+        }                                                            \
       }                                                              \
     });                                                              \
     TORCH_CHECK(                                                     \

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -958,8 +958,11 @@ TEST_F(DynamicTypeTest, SetTheoreticNaturalNumbers) {
           zero, one, two, three, four, five, six, seven, eight, nine}));
 }
 
+#undef insert
+
 TEST_F(DynamicTypeTest, FromContainerToContainer) {
   using IntOrVec = DynamicType<Containers<std::vector>, int>;
+  using Vec = DynamicType<Containers<std::vector>>;
 
   static_assert(std::is_constructible_v<IntOrVec, std::vector<int>>);
   static_assert(
@@ -979,6 +982,19 @@ TEST_F(DynamicTypeTest, FromContainerToContainer) {
   static_assert(opcheck<IntOrVec>.canCastTo(
       opcheck<std::vector<std::vector<std::vector<std::vector<double>>>>>));
 
+  static_assert(opcheck<IntOrVec>[opcheck<IntOrVec>]);
+  static_assert(!opcheck<Vec>[opcheck<Vec>]);
+  static_assert(opcheck<const IntOrVec>[opcheck<IntOrVec>]);
+  static_assert(!opcheck<const Vec>[opcheck<Vec>]);
+  static_assert(opcheck<IntOrVec>[opcheck<const IntOrVec>]);
+  static_assert(!opcheck<Vec>[opcheck<const Vec>]);
+  static_assert(opcheck<const IntOrVec>[opcheck<const IntOrVec>]);
+  static_assert(!opcheck<const Vec>[opcheck<const Vec>]);
+
+  IntOrVec zero = 0;
+  IntOrVec one = 1;
+  IntOrVec two = 2;
+
   std::vector<std::vector<int>> vvi{{1, 2, 3}, {4, 5, 6}};
   IntOrVec x = vvi;
   EXPECT_EQ(x[0], IntOrVec(std::vector<int>{1, 2, 3}));
@@ -990,13 +1006,39 @@ TEST_F(DynamicTypeTest, FromContainerToContainer) {
   EXPECT_EQ(x[1][1], 5);
   EXPECT_EQ(x[1][2], 6);
 
+  EXPECT_EQ(x[zero], IntOrVec(std::vector<int>{1, 2, 3}));
+  EXPECT_EQ(x[zero][zero], 1);
+  EXPECT_EQ(x[zero][one], 2);
+  EXPECT_EQ(x[zero][two], 3);
+  EXPECT_EQ(x[one], IntOrVec(std::vector<int>{4, 5, 6}));
+  EXPECT_EQ(x[one][zero], 4);
+  EXPECT_EQ(x[one][one], 5);
+  EXPECT_EQ(x[one][two], 6);
+
+  const IntOrVec xx = vvi;
+  EXPECT_EQ(xx[0], IntOrVec(std::vector<int>{1, 2, 3}));
+  EXPECT_EQ(xx[0][0], 1);
+  EXPECT_EQ(xx[0][1], 2);
+  EXPECT_EQ(xx[0][2], 3);
+  EXPECT_EQ(xx[1], IntOrVec(std::vector<int>{4, 5, 6}));
+  EXPECT_EQ(xx[1][0], 4);
+  EXPECT_EQ(xx[1][1], 5);
+  EXPECT_EQ(xx[1][2], 6);
+
+  EXPECT_EQ(xx[zero], IntOrVec(std::vector<int>{1, 2, 3}));
+  EXPECT_EQ(xx[zero][zero], 1);
+  EXPECT_EQ(xx[zero][one], 2);
+  EXPECT_EQ(xx[zero][two], 3);
+  EXPECT_EQ(xx[one], IntOrVec(std::vector<int>{4, 5, 6}));
+  EXPECT_EQ(xx[one][zero], 4);
+  EXPECT_EQ(xx[one][one], 5);
+  EXPECT_EQ(xx[one][two], 6);
+
   std::vector<std::vector<double>> vvd{{1, 2, 3}, {4, 5, 6}};
   EXPECT_EQ((std::vector<std::vector<double>>)x, vvd);
   EXPECT_EQ((std::vector<double>)x[0], vvd[0]);
   EXPECT_EQ((std::vector<double>)x[1], vvd[1]);
 }
-
-#undef insert
 
 } // namespace container_test
 


### PR DESCRIPTION
This PR adds
- `const` overload for `operator[]` of `DynamicType`
- indexing a `DynamicType` with a `DynamicType`, that is, `DynamicType[DynamicType]`