### PR TITLE
Skip entire python frontend when build with --no-python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,27 +7,32 @@ project(nvfuser)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # compensating the lack of PROJECT_IS_TOP_LEVEL for older cmake version
-if (CMAKE_VERSION VERSION_LESS 3.21)
-    if ("${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
-        set (PROJECT_IS_TOP_LEVEL ON)
-    endif ()
-endif ()
+if(CMAKE_VERSION VERSION_LESS 3.21)
+  if("${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
+    set(PROJECT_IS_TOP_LEVEL ON)
+  endif()
+endif()
 
 set(NVFUSER_ROOT ${PROJECT_SOURCE_DIR})
 set(NVFUSER_SRCS_DIR "${NVFUSER_ROOT}/csrc")
-if (PROJECT_IS_TOP_LEVEL)
+
+if(PROJECT_IS_TOP_LEVEL)
   find_package(Torch REQUIRED)
   find_package(Python REQUIRED Development Interpreter)
   find_package(pybind11 REQUIRED)
+
   # need this since the pytorch execution uses a different name
   set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
   set(ATEN_CUDA_ROOT "${TORCH_INSTALL_PREFIX}/include/ATen")
+
   # CXX flags is necessary since https://github.com/pytorch/pytorch/issues/98093
   string(APPEND CMAKE_CXX_FLAGS ${TORCH_CXX_FLAGS})
   include(cmake/FlatBuffers.cmake)
+
   if(BUILD_NVFUSER_BENCHMARK)
     include(cmake/Dependencies.cmake)
   endif()
+
   # set CUDA_ARCH for cu tests.
   if(EXISTS ${TORCH_CUDA_ARCH_LIST})
     set(ARCH_FLAGS)
@@ -37,7 +42,7 @@ if (PROJECT_IS_TOP_LEVEL)
 else() # PROJECT_IS_TOP_LEVEL
   # TODO: move this to the top~
   # if we are included by other project and `BUILD_NVFUSER` is not set, we skip
-  if (NOT BUILD_NVFUSER)
+  if(NOT BUILD_NVFUSER)
     return()
   endif()
 
@@ -56,163 +61,172 @@ if(NOT MSVC)
   find_library(LIBNVTOOLSEXT libnvToolsExt.so PATHS ${CUDA_TOOLKIT_ROOT_DIR}/lib64/)
 endif()
 
-#------------------------------
+# ------------------------------
 # build nvfuser_codegen library
-#------------------------------
+# ------------------------------
 
 # nvfuser codegen sources
 set(NVFUSER_SRCS)
 list(APPEND NVFUSER_SRCS
-    ${NVFUSER_SRCS_DIR}/compute_at.cpp
-    ${NVFUSER_SRCS_DIR}/inlining.cpp
-    ${NVFUSER_SRCS_DIR}/compute_at_map.cpp
-    ${NVFUSER_SRCS_DIR}/codegen.cpp
-    ${NVFUSER_SRCS_DIR}/contiguity.cpp
-    ${NVFUSER_SRCS_DIR}/dispatch.cpp
-    ${NVFUSER_SRCS_DIR}/dynamic_transform.cpp
-    ${NVFUSER_SRCS_DIR}/expr_evaluator.cpp
-    ${NVFUSER_SRCS_DIR}/expr_simplifier.cpp
-    ${NVFUSER_SRCS_DIR}/executor.cpp
-    ${NVFUSER_SRCS_DIR}/executor_kernel_arg.cpp
-    ${NVFUSER_SRCS_DIR}/executor_params.cpp
-    ${NVFUSER_SRCS_DIR}/evaluator_common.cpp
-    ${NVFUSER_SRCS_DIR}/executor_utils.cpp
-    ${NVFUSER_SRCS_DIR}/fusion.cpp
-    ${NVFUSER_SRCS_DIR}/graph_fuser.cpp
-    ${NVFUSER_SRCS_DIR}/grouped_reduction.cpp
-    ${NVFUSER_SRCS_DIR}/index_compute.cpp
-    ${NVFUSER_SRCS_DIR}/instrumentation.cpp
-    ${NVFUSER_SRCS_DIR}/ir/base_nodes.cpp
-    ${NVFUSER_SRCS_DIR}/ir/builder.cpp
-    ${NVFUSER_SRCS_DIR}/ir/cloner.cpp
-    ${NVFUSER_SRCS_DIR}/ir/container.cpp
-    ${NVFUSER_SRCS_DIR}/ir/graphviz.cpp
-    ${NVFUSER_SRCS_DIR}/ir/iostream.cpp
-    ${NVFUSER_SRCS_DIR}/ir/utils.cpp
-    ${NVFUSER_SRCS_DIR}/ir/nodes.cpp
-    ${NVFUSER_SRCS_DIR}/iter_visitor.cpp
-    ${NVFUSER_SRCS_DIR}/kernel.cpp
-    ${NVFUSER_SRCS_DIR}/kernel_cache.cpp
-    ${NVFUSER_SRCS_DIR}/kernel_db/kernel_db.cpp
-    ${NVFUSER_SRCS_DIR}/kernel_db/utils.cpp
-    ${NVFUSER_SRCS_DIR}/kernel_ir.cpp
-    ${NVFUSER_SRCS_DIR}/kernel_ir_dispatch.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/analysis/index_compute.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/analysis/divisible_split.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/analysis/fused_reduction.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/analysis/predicate_elimination.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/analysis/shift.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/analysis/sync_information.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/analysis/thread_predicate.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/analysis/trivial_broadcast.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/analysis/bank_conflict.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/alias_memory.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/allocation.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/double_buffer.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/expr_sort.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/fusion_simplifier.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/index.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/scalar_hoist.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/insert_syncs.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/instrument.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/loop_rotation.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/loops.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/magic_zero.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/misaligned_vectorization.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/predicate.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/replace_size.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/unroll.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/vectorize_welford.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/pass/warp_reduce.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/utils.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/validation.cpp
-    ${NVFUSER_SRCS_DIR}/device_lower/lower2device.cpp
-    ${NVFUSER_SRCS_DIR}/manager.cpp
-    ${NVFUSER_SRCS_DIR}/maxinfo_propagator.cpp
-    ${NVFUSER_SRCS_DIR}/multidevice/aggregate_dag.cpp
-    ${NVFUSER_SRCS_DIR}/multidevice/multidevice_runtime.cpp
-    ${NVFUSER_SRCS_DIR}/multidevice/multicluster_fusion.cpp
-    ${NVFUSER_SRCS_DIR}/multidevice/ProcessGroupBuilder.cpp
-    ${NVFUSER_SRCS_DIR}/mutator.cpp
-    ${NVFUSER_SRCS_DIR}/non_divisible_split.cpp
-    ${NVFUSER_SRCS_DIR}/ops/alias.cpp
-    ${NVFUSER_SRCS_DIR}/ops/arith.cpp
-    ${NVFUSER_SRCS_DIR}/ops/composite.cpp
-    ${NVFUSER_SRCS_DIR}/ops/indexing.cpp
-    ${NVFUSER_SRCS_DIR}/ops/normalization.cpp
-    ${NVFUSER_SRCS_DIR}/ops/utils.cpp
-    ${NVFUSER_SRCS_DIR}/options.cpp
-    ${NVFUSER_SRCS_DIR}/parallel_dimension_map.cpp
-    ${NVFUSER_SRCS_DIR}/parallel_type_bitmap.cpp
-    ${NVFUSER_SRCS_DIR}/parser.cpp
-    ${NVFUSER_SRCS_DIR}/partial_split_map.cpp
-    ${NVFUSER_SRCS_DIR}/partition.cpp
-    ${NVFUSER_SRCS_DIR}/predicate_compute.cpp
+  ${NVFUSER_SRCS_DIR}/compute_at.cpp
+  ${NVFUSER_SRCS_DIR}/inlining.cpp
+  ${NVFUSER_SRCS_DIR}/compute_at_map.cpp
+  ${NVFUSER_SRCS_DIR}/codegen.cpp
+  ${NVFUSER_SRCS_DIR}/contiguity.cpp
+  ${NVFUSER_SRCS_DIR}/dispatch.cpp
+  ${NVFUSER_SRCS_DIR}/dynamic_transform.cpp
+  ${NVFUSER_SRCS_DIR}/expr_evaluator.cpp
+  ${NVFUSER_SRCS_DIR}/expr_simplifier.cpp
+  ${NVFUSER_SRCS_DIR}/executor.cpp
+  ${NVFUSER_SRCS_DIR}/executor_kernel_arg.cpp
+  ${NVFUSER_SRCS_DIR}/executor_params.cpp
+  ${NVFUSER_SRCS_DIR}/evaluator_common.cpp
+  ${NVFUSER_SRCS_DIR}/executor_utils.cpp
+  ${NVFUSER_SRCS_DIR}/fusion.cpp
+  ${NVFUSER_SRCS_DIR}/graph_fuser.cpp
+  ${NVFUSER_SRCS_DIR}/grouped_reduction.cpp
+  ${NVFUSER_SRCS_DIR}/index_compute.cpp
+  ${NVFUSER_SRCS_DIR}/instrumentation.cpp
+  ${NVFUSER_SRCS_DIR}/ir/base_nodes.cpp
+  ${NVFUSER_SRCS_DIR}/ir/builder.cpp
+  ${NVFUSER_SRCS_DIR}/ir/cloner.cpp
+  ${NVFUSER_SRCS_DIR}/ir/container.cpp
+  ${NVFUSER_SRCS_DIR}/ir/graphviz.cpp
+  ${NVFUSER_SRCS_DIR}/ir/iostream.cpp
+  ${NVFUSER_SRCS_DIR}/ir/utils.cpp
+  ${NVFUSER_SRCS_DIR}/ir/nodes.cpp
+  ${NVFUSER_SRCS_DIR}/iter_visitor.cpp
+  ${NVFUSER_SRCS_DIR}/kernel.cpp
+  ${NVFUSER_SRCS_DIR}/kernel_cache.cpp
+  ${NVFUSER_SRCS_DIR}/kernel_db/kernel_db.cpp
+  ${NVFUSER_SRCS_DIR}/kernel_db/utils.cpp
+  ${NVFUSER_SRCS_DIR}/kernel_ir.cpp
+  ${NVFUSER_SRCS_DIR}/kernel_ir_dispatch.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/analysis/index_compute.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/analysis/divisible_split.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/analysis/fused_reduction.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/analysis/predicate_elimination.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/analysis/shift.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/analysis/sync_information.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/analysis/thread_predicate.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/analysis/trivial_broadcast.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/analysis/bank_conflict.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/alias_memory.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/allocation.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/double_buffer.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/expr_sort.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/fusion_simplifier.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/index.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/scalar_hoist.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/insert_syncs.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/instrument.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/loop_rotation.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/loops.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/magic_zero.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/misaligned_vectorization.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/predicate.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/replace_size.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/unroll.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/vectorize_welford.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/pass/warp_reduce.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/utils.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/validation.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/lower2device.cpp
+  ${NVFUSER_SRCS_DIR}/manager.cpp
+  ${NVFUSER_SRCS_DIR}/maxinfo_propagator.cpp
+  ${NVFUSER_SRCS_DIR}/multidevice/aggregate_dag.cpp
+  ${NVFUSER_SRCS_DIR}/multidevice/multidevice_runtime.cpp
+  ${NVFUSER_SRCS_DIR}/multidevice/multicluster_fusion.cpp
+  ${NVFUSER_SRCS_DIR}/multidevice/ProcessGroupBuilder.cpp
+  ${NVFUSER_SRCS_DIR}/mutator.cpp
+  ${NVFUSER_SRCS_DIR}/non_divisible_split.cpp
+  ${NVFUSER_SRCS_DIR}/ops/alias.cpp
+  ${NVFUSER_SRCS_DIR}/ops/arith.cpp
+  ${NVFUSER_SRCS_DIR}/ops/composite.cpp
+  ${NVFUSER_SRCS_DIR}/ops/indexing.cpp
+  ${NVFUSER_SRCS_DIR}/ops/normalization.cpp
+  ${NVFUSER_SRCS_DIR}/ops/utils.cpp
+  ${NVFUSER_SRCS_DIR}/options.cpp
+  ${NVFUSER_SRCS_DIR}/parallel_dimension_map.cpp
+  ${NVFUSER_SRCS_DIR}/parallel_type_bitmap.cpp
+  ${NVFUSER_SRCS_DIR}/parser.cpp
+  ${NVFUSER_SRCS_DIR}/partial_split_map.cpp
+  ${NVFUSER_SRCS_DIR}/partition.cpp
+  ${NVFUSER_SRCS_DIR}/predicate_compute.cpp
+  ${NVFUSER_SRCS_DIR}/register_interface.cpp
+  ${NVFUSER_SRCS_DIR}/root_domain_map.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/pointwise.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/pointwise_utils.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/transpose.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/matmul.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/matmul_utils.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/normalization.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/normalization_utils.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/reduction.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/reduction_utils.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/registry.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/utils.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/vectorize_helper.cpp
+  ${NVFUSER_SRCS_DIR}/swizzle.cpp
+  ${NVFUSER_SRCS_DIR}/sys_utils.cpp
+  ${NVFUSER_SRCS_DIR}/type_inference.cpp
+  ${NVFUSER_SRCS_DIR}/type_promotion.cpp
+  ${NVFUSER_SRCS_DIR}/fusion_segmenter.cpp
+  ${NVFUSER_SRCS_DIR}/tensor_view.cpp
+  ${NVFUSER_SRCS_DIR}/transform_iter.cpp
+  ${NVFUSER_SRCS_DIR}/transform_replay.cpp
+  ${NVFUSER_SRCS_DIR}/transform_rfactor.cpp
+  ${NVFUSER_SRCS_DIR}/transform_view.cpp
+  ${NVFUSER_SRCS_DIR}/type.cpp
+  ${NVFUSER_SRCS_DIR}/utils.cpp
+  ${NVFUSER_SRCS_DIR}/mma_type.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/mma_utils.cpp
+  ${NVFUSER_SRCS_DIR}/optimization/add_axioms.cpp
+  ${NVFUSER_SRCS_DIR}/optimization/consecutive_cast.cpp
+  ${NVFUSER_SRCS_DIR}/optimization/pre_segmenter.cpp
+)
+
+if(BUILD_PYTHON)
+  list(APPEND NVFUSER_SRCS
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_cache.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_definition.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_state.cpp
-    ${NVFUSER_SRCS_DIR}/register_interface.cpp
-    ${NVFUSER_SRCS_DIR}/root_domain_map.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/pointwise.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/pointwise_utils.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/transpose.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/matmul.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/matmul_utils.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/normalization.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/normalization_utils.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/reduction.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/reduction_utils.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/registry.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/utils.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/vectorize_helper.cpp
     ${NVFUSER_SRCS_DIR}/serde/fusion_record_serde.cpp
-    ${NVFUSER_SRCS_DIR}/serde/utils.cpp
-    ${NVFUSER_SRCS_DIR}/swizzle.cpp
-    ${NVFUSER_SRCS_DIR}/sys_utils.cpp
-    ${NVFUSER_SRCS_DIR}/type_inference.cpp
-    ${NVFUSER_SRCS_DIR}/type_promotion.cpp
-    ${NVFUSER_SRCS_DIR}/fusion_segmenter.cpp
-    ${NVFUSER_SRCS_DIR}/tensor_view.cpp
-    ${NVFUSER_SRCS_DIR}/transform_iter.cpp
-    ${NVFUSER_SRCS_DIR}/transform_replay.cpp
-    ${NVFUSER_SRCS_DIR}/transform_rfactor.cpp
-    ${NVFUSER_SRCS_DIR}/transform_view.cpp
-    ${NVFUSER_SRCS_DIR}/type.cpp
-    ${NVFUSER_SRCS_DIR}/utils.cpp
-    ${NVFUSER_SRCS_DIR}/mma_type.cpp
-    ${NVFUSER_SRCS_DIR}/scheduler/mma_utils.cpp
-    ${NVFUSER_SRCS_DIR}/optimization/add_axioms.cpp
-    ${NVFUSER_SRCS_DIR}/optimization/consecutive_cast.cpp
-    ${NVFUSER_SRCS_DIR}/optimization/pre_segmenter.cpp
-)
+    ${NVFUSER_SRCS_DIR}/serde/utils.cpp)
+endif()
 
 set(NVFUSER_CODEGEN ${PROJECT_NAME}_codegen)
 add_library(${NVFUSER_CODEGEN} SHARED ${NVFUSER_SRCS})
 target_compile_options(${NVFUSER_CODEGEN} PRIVATE -Wall -Wno-unused-function)
 target_compile_options(${NVFUSER_CODEGEN} PRIVATE "-DTORCH_CUDA_BUILD_MAIN_LIB")
+
 if(NOT MSVC)
   target_compile_options(${NVFUSER_CODEGEN} PRIVATE -Werror)
 endif()
+
 # NB: This must be target_compile_definitions, not target_compile_options,
 # as the latter is not respected by nvcc
 target_compile_definitions(${NVFUSER_CODEGEN} PRIVATE "-DTORCH_CUDA_BUILD_MAIN_LIB")
 
 # Link flatbuffers for serialization support
 target_link_libraries(${NVFUSER_CODEGEN} PRIVATE flatbuffers)
+
 # For kernel_db, linking STL Filesystem Library for backward compatability with C++14
 target_link_libraries(${NVFUSER_CODEGEN} PRIVATE stdc++fs)
 target_link_libraries(${NVFUSER_CODEGEN} PRIVATE ${CUDA_NVRTC_LIB} ${LIBNVTOOLSEXT})
 target_include_directories(${NVFUSER_CODEGEN} PRIVATE ${CUDA_INCLUDE_DIRS})
+
 # TODO: we should guard the include of gloo
 target_include_directories(${NVFUSER_CODEGEN} PRIVATE ${PROJECT_SOURCE_DIR}/third_party/gloo)
 target_include_directories(${NVFUSER_CODEGEN} PUBLIC
-                          "$<BUILD_INTERFACE:${NVFUSER_SRCS_DIR}>"
-                          "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/nvfuser>"
-                          )
+  "$<BUILD_INTERFACE:${NVFUSER_SRCS_DIR}>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/nvfuser>"
+)
 set_property(TARGET ${NVFUSER_CODEGEN} PROPERTY CXX_STANDARD 17)
 
-if (PROJECT_IS_TOP_LEVEL)
+if(PROJECT_IS_TOP_LEVEL)
   target_link_libraries(${NVFUSER_CODEGEN} PRIVATE torch ${TORCH_LIBRARIES})
+
   # this is to find pip installed nvrtc .so
   set_target_properties(${NVFUSER_CODEGEN} PROPERTIES INSTALL_RPATH "$ORIGIN/../../nvidia/cuda_nvrtc/lib")
   install(TARGETS ${NVFUSER_CODEGEN} EXPORT NvfuserTargets DESTINATION lib)
@@ -220,87 +234,91 @@ if (PROJECT_IS_TOP_LEVEL)
   # We are keeping fusion_cache_generated.h for the submodule build because flatc is unavailable.
   add_custom_command(
     OUTPUT
-      ${NVFUSER_ROOT}/csrc/serde/fusion_cache_generated.h
+    ${NVFUSER_ROOT}/csrc/serde/fusion_cache_generated.h
     DEPENDS
-      ${NVFUSER_ROOT}/csrc/serde/fusion_cache.fbs
+    ${NVFUSER_ROOT}/csrc/serde/fusion_cache.fbs
     DEPENDS flatc
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/third_party/flatbuffers/flatc -o ${NVFUSER_ROOT}/csrc/serde/ -c -b ${NVFUSER_ROOT}/csrc/serde/fusion_cache.fbs
     COMMENT "Generating fusion_cache_generated header from fusion_cache.fbs"
     VERBATIM
-    )
+  )
   add_custom_target(build_flatbuffer_config ALL
-      DEPENDS ${NVFUSER_ROOT}/csrc/serde/fusion_cache_generated.h)
+    DEPENDS ${NVFUSER_ROOT}/csrc/serde/fusion_cache_generated.h)
 
   add_dependencies(${NVFUSER_CODEGEN} flatc build_flatbuffer_config)
 else()
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/nvfuser")
   target_link_libraries(${NVFUSER_CODEGEN} PRIVATE torch ${TORCHLIB_FLAVOR})
+
   # NOTE: our CI build somehow fails with find driver lib.
   target_link_libraries(${NVFUSER_CODEGEN} PUBLIC CUDA::cuda_driver)
+
   # installing nvfuser python tests
   install(DIRECTORY "${NVFUSER_ROOT}/python_tests/"
-  	DESTINATION "${TORCH_ROOT}/test/_nvfuser"
-          FILES_MATCHING PATTERN "*.py" )
+    DESTINATION "${TORCH_ROOT}/test/_nvfuser"
+    FILES_MATCHING PATTERN "*.py")
+
   # installing nvfuser lib
   install(TARGETS ${NVFUSER_CODEGEN} EXPORT NvfuserTargets DESTINATION "${TORCH_INSTALL_LIB_DIR}")
 endif()
 
 # installing nvfuser headers
 install(DIRECTORY "${NVFUSER_SRCS_DIR}/"
-      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nvfuser"
-      FILES_MATCHING
-      PATTERN "*.h"
-      PATTERN "csrc/C++20/type_traits")
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nvfuser"
+  FILES_MATCHING
+  PATTERN "*.h"
+  PATTERN "csrc/C++20/type_traits")
 
-#-----------------------------
+# -----------------------------
 # build nvfuser python library
-#-----------------------------
-
+# -----------------------------
 if(BUILD_PYTHON)
   # nvfuser python API sources
   set(NVFUSER_PYTHON_SRCS)
   list(APPEND NVFUSER_PYTHON_SRCS
-      ${NVFUSER_SRCS_DIR}/python_frontend/python_bindings.cpp
-      ${NVFUSER_SRCS_DIR}/python_frontend/python_bindings_extension.cpp
+    ${NVFUSER_SRCS_DIR}/python_frontend/python_bindings.cpp
+    ${NVFUSER_SRCS_DIR}/python_frontend/python_bindings_extension.cpp
   )
 
-    set(NVFUSER "${PROJECT_NAME}")
-    add_library(${NVFUSER} MODULE ${NVFUSER_PYTHON_SRCS})
-    set_property(TARGET ${NVFUSER} PROPERTY CXX_STANDARD 17)
+  set(NVFUSER "${PROJECT_NAME}")
+  add_library(${NVFUSER} MODULE ${NVFUSER_PYTHON_SRCS})
+  set_property(TARGET ${NVFUSER} PROPERTY CXX_STANDARD 17)
 
-    # setup python API version
-    add_custom_command(
-      OUTPUT ${NVFUSER_ROOT}/nvfuser/version.py
-      COMMAND
-        "${PYTHON_EXECUTABLE}" -c \"from pathlib import Path\; Path('${NVFUSER_ROOT}/tools/gen_nvfuser_version.py').touch()\"
-      COMMAND
-        "${PYTHON_EXECUTABLE}" ${NVFUSER_ROOT}/tools/gen_nvfuser_version.py
-      DEPENDS ${NVFUSER_ROOT}/tools/gen_nvfuser_version.py
-      WORKING_DIRECTORY ${NVFUSER_ROOT}/tools/
-    )
-    add_custom_target(
-      gen_nvfuser_version ALL
-      DEPENDS ${NVFUSER_ROOT}/nvfuser/version.py
-    )
-    add_dependencies(${NVFUSER} gen_nvfuser_version)
+  # setup python API version
+  add_custom_command(
+    OUTPUT ${NVFUSER_ROOT}/nvfuser/version.py
+    COMMAND
+    "${PYTHON_EXECUTABLE}" -c \"from pathlib import Path\; Path('${NVFUSER_ROOT}/tools/gen_nvfuser_version.py') .touch() \"
+    COMMAND
+    "${PYTHON_EXECUTABLE}" ${NVFUSER_ROOT}/tools/gen_nvfuser_version.py
+    DEPENDS ${NVFUSER_ROOT}/tools/gen_nvfuser_version.py
+    WORKING_DIRECTORY ${NVFUSER_ROOT}/tools/
+  )
+  add_custom_target(
+    gen_nvfuser_version ALL
+    DEPENDS ${NVFUSER_ROOT}/nvfuser/version.py
+  )
+  add_dependencies(${NVFUSER} gen_nvfuser_version)
 
-    target_compile_options(${NVFUSER} PRIVATE "-DTORCH_CUDA_BUILD_MAIN_LIB")
-    # NB: This must be target_compile_definitions, not target_compile_options,
-    # as the latter is not respected by nvcc
-    target_compile_definitions(${NVFUSER} PRIVATE "-DTORCH_CUDA_BUILD_MAIN_LIB")
-    if(NOT MSVC)
-      target_compile_options(${NVFUSER} PRIVATE -Werror)
-      set_target_properties(${NVFUSER} PROPERTIES SUFFIX ".so")
-    else()
-      set_target_properties(${NVFUSER} PROPERTIES SUFFIX ".pyd")
-    endif()
+  target_compile_options(${NVFUSER} PRIVATE "-DTORCH_CUDA_BUILD_MAIN_LIB")
 
-    target_link_libraries(${NVFUSER} PRIVATE ${LIBNVTOOLSEXT})
-    target_link_libraries(${NVFUSER} PRIVATE ${NVFUSER_CODEGEN})
+  # NB: This must be target_compile_definitions, not target_compile_options,
+  # as the latter is not respected by nvcc
+  target_compile_definitions(${NVFUSER} PRIVATE "-DTORCH_CUDA_BUILD_MAIN_LIB")
 
-    target_compile_definitions(${NVFUSER} PRIVATE EXTENSION_NAME=_C)
+  if(NOT MSVC)
+    target_compile_options(${NVFUSER} PRIVATE -Werror)
+    set_target_properties(${NVFUSER} PROPERTIES SUFFIX ".so")
+  else()
+    set_target_properties(${NVFUSER} PROPERTIES SUFFIX ".pyd")
+  endif()
 
-  if (PROJECT_IS_TOP_LEVEL)
+  target_link_libraries(${NVFUSER} PRIVATE ${LIBNVTOOLSEXT})
+  target_link_libraries(${NVFUSER} PRIVATE ${NVFUSER_CODEGEN})
+
+  target_compile_definitions(${NVFUSER} PRIVATE EXTENSION_NAME=_C)
+
+  if(PROJECT_IS_TOP_LEVEL)
     target_compile_options(${NVFUSER} PRIVATE -Wall -Wno-unused-function)
     target_link_libraries(${NVFUSER} PRIVATE ${TORCH_LIBRARIES})
     target_link_libraries(${NVFUSER} PRIVATE "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so")
@@ -313,31 +331,30 @@ if(BUILD_PYTHON)
     target_link_libraries(${NVFUSER} PRIVATE torch torch_python ${TORCHLIB_FLAVOR})
     target_include_directories(${NVFUSER} PRIVATE ${TORCH_ROOT})
 
-
     target_link_libraries(${NVFUSER} PRIVATE pybind::pybind11)
     target_compile_options(${NVFUSER} PRIVATE ${TORCH_PYTHON_COMPILE_OPTIONS})
 
     # avoid using Python3_add_library, copied from functorch
     set_target_properties(${NVFUSER} PROPERTIES PREFIX "" DEBUG_POSTFIX "")
     set_target_properties(${NVFUSER} PROPERTIES LIBRARY_OUTPUT_DIRECTORY
-          ${CMAKE_BINARY_DIR}/nvfuser)
+      ${CMAKE_BINARY_DIR}/nvfuser)
     set_target_properties(${NVFUSER} PROPERTIES INSTALL_RPATH "${_rpath_portable_origin}/../torch/lib")
+
     if(TORCH_PYTHON_LINK_FLAGS AND NOT TORCH_PYTHON_LINK_FLAGS STREQUAL "")
       set_target_properties(${NVFUSER} PROPERTIES LINK_FLAGS ${TORCH_PYTHON_LINK_FLAGS})
     endif()
+
     install(TARGETS ${NVFUSER} EXPORT NvfuserTargets DESTINATION ${TORCH_ROOT}/nvfuser/)
 
     # install nvfuser python files
     install(DIRECTORY "${NVFUSER_ROOT}/nvfuser/"
-            DESTINATION "${TORCH_ROOT}/nvfuser"
-            FILES_MATCHING PATTERN "*.py" )
+      DESTINATION "${TORCH_ROOT}/nvfuser"
+      FILES_MATCHING PATTERN "*.py")
     file(WRITE "${TORCH_ROOT}/nvfuser/.gitignore" "*")
   endif()
 endif()
 
-
 # -- build tests
-
 if(BUILD_TEST)
   # nvfuser test sources
   set(JIT_TEST_SRCS)
@@ -346,9 +363,6 @@ if(BUILD_TEST)
     ${NVFUSER_SRCS_DIR}/kernel_db/test/test_nvfuser_kernel_db_open.cpp
     ${NVFUSER_SRCS_DIR}/kernel_db/test/test_nvfuser_kernel_db_query.cpp
     ${NVFUSER_SRCS_DIR}/kernel_db/test/test_nvfuser_kernel_db_write.cpp
-    ${NVFUSER_SRCS_DIR}/python_frontend/test/test_nvfuser_fusion_definition.cpp
-    ${NVFUSER_SRCS_DIR}/python_frontend/test/test_nvfuser_fusion_cache.cpp
-    ${NVFUSER_SRCS_DIR}/python_frontend/test/test_nvfuser_fusion_record.cpp
     ${NVFUSER_ROOT}/test/main.cpp
     ${NVFUSER_ROOT}/test/utils.cpp
     ${NVFUSER_ROOT}/test/test_allocation_domain.cpp
@@ -381,22 +395,31 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/test/test_optimization_pass.cpp
     ${NVFUSER_ROOT}/test/test_rng.cpp
   )
+
+  if(BUILD_PYTHON)
+    list(APPEND JIT_TEST_SRCS
+      ${NVFUSER_SRCS_DIR}/python_frontend/test/test_nvfuser_fusion_definition.cpp
+      ${NVFUSER_SRCS_DIR}/python_frontend/test/test_nvfuser_fusion_cache.cpp
+      ${NVFUSER_SRCS_DIR}/python_frontend/test/test_nvfuser_fusion_record.cpp)
+  endif()
+
   list(APPEND JIT_TEST_CU_SRCS ${NVFUSER_ROOT}/test/rng_kernels.cu)
 
   set(NVFUSER_TESTS "${PROJECT_NAME}_tests")
 
   add_executable(${NVFUSER_TESTS}
-             ${JIT_TEST_SRCS}
-             ${JIT_TEST_CU_SRCS})
+    ${JIT_TEST_SRCS}
+    ${JIT_TEST_CU_SRCS})
   set_property(TARGET ${NVFUSER_TESTS} PROPERTY CXX_STANDARD 17)
   target_compile_definitions(${NVFUSER_TESTS} PRIVATE USE_GTEST)
   target_link_libraries(${NVFUSER_TESTS} PRIVATE ${NVFUSER_CODEGEN} gtest_main gmock_main flatbuffers)
   target_include_directories(${NVFUSER_TESTS} PRIVATE "${NVFUSER_ROOT}")
 
-  if (PROJECT_IS_TOP_LEVEL)
+  if(PROJECT_IS_TOP_LEVEL)
     target_compile_options(${NVFUSER_TESTS} PRIVATE -Wall -Wno-unused-function)
     target_link_libraries(${NVFUSER_TESTS} PRIVATE ${TORCH_LIBRARIES})
-    # only install nvfuser_tests with submodule build
+
+  # only install nvfuser_tests with submodule build
   else()
     torch_compile_options(${NVFUSER_TESTS})
     target_include_directories(${NVFUSER_TESTS} PRIVATE "${TORCH_ROOT}/torch/csrc/api/include/")
@@ -448,22 +471,25 @@ if(BUILD_NVFUSER_BENCHMARK)
   set(NVFUSER_BENCHMARK "${PROJECT_NAME}_bench")
   add_executable(${NVFUSER_BENCHMARK} ${BENCHMARK_SRCS})
   set_property(TARGET ${NVFUSER_BENCHMARK} PROPERTY CXX_STANDARD 17)
+
   if(PROJECT_IS_TOP_LEVEL)
     target_compile_options(${NVFUSER_BENCHMARK} PRIVATE -Wall -Wno-unused-function)
     target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE ${TORCH_LIBRARIES})
     target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE benchmark::benchmark)
-    # only install nvfuser_bench with submodule build
+
+  # only install nvfuser_bench with submodule build
   else()
     torch_compile_options(${NVFUSER_BENCHMARK})
     target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE torch_library benchmark)
     install(TARGETS ${NVFUSER_BENCHMARK} DESTINATION bin)
   endif()
+
   if(NOT MSVC)
     target_compile_options(${NVFUSER_BENCHMARK} PRIVATE -Werror -Wno-deprecated-copy)
   endif()
+
   target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE ${NVFUSER_CODEGEN})
   target_include_directories(${NVFUSER_BENCHMARK} PRIVATE ${NVFUSER_ROOT})
-
 endif()
 
 # --- generate runtime files
@@ -501,12 +527,12 @@ list(APPEND NVFUSER_RUNTIME_FILES
   ${ATEN_CUDA_ROOT}/cuda/detail/UnpackRaw.cuh
 )
 
-
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/include/nvfuser_resources")
 
 # "stringify" NVFUSER runtime sources
 # (generate C++ header files embedding the original input as a string literal)
 set(NVFUSER_STRINGIFY_TOOL "${NVFUSER_ROOT}/tools/stringify_file.py")
+
 foreach(src ${NVFUSER_RUNTIME_FILES})
   get_filename_component(filename ${src} NAME_WE)
   set(dst "${CMAKE_BINARY_DIR}/include/nvfuser_resources/${filename}.h")
@@ -529,7 +555,8 @@ target_include_directories(${NVFUSER_CODEGEN} PRIVATE "${CMAKE_BINARY_DIR}/inclu
 
 # -- install nvfuser cmake config files and symlink to build binaries
 install(EXPORT NvfuserTargets FILE NvfuserConfig.cmake DESTINATION share/cmake/nvfuser)
-if (PROJECT_IS_TOP_LEVEL)
+
+if(PROJECT_IS_TOP_LEVEL)
   file(CREATE_LINK "${CMAKE_BINARY_DIR}" "${NVFUSER_ROOT}/bin" SYMBOLIC)
 else()
   file(CREATE_LINK "${CMAKE_BINARY_DIR}/bin" "${NVFUSER_ROOT}/bin" SYMBOLIC)


### PR DESCRIPTION
Also, format the cmake file. I suggest reading this PR skipping whitespace changes.

I am working on a big PR https://github.com/NVIDIA/Fuser/pull/529 that requires changes in python frontend, serde, and backend. As an incremental development step, I want to begin with skipping frontend and serde first to only build backend and tests. After backend work are done, I will start working on frontend and serde.

This requires us to be able to only build the backend, and this PR fixes `--no-python` to do so.