### PR TITLE
optimize layer norm backward with hidden size in the range of 7K to 10K by increasing maximum allowed batch size by 1 and changing threads_per_block searching method

### DIFF
--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -679,7 +679,8 @@ getOptionalInnerOuterPersistentBufferBatches(
   };
   const int64_t after_vectorization = inner_dim_numel / vectorize_factor;
   const int64_t threads_per_block_min = std::min(after_vectorization, 128l);
-  const int64_t threads_per_block_max = getThreadsPerSMGivenRegPerThread(scheduler_utils::max_registers_per_thread);
+  const int64_t threads_per_block_max = getThreadsPerSMGivenRegPerThread(
+      scheduler_utils::max_registers_per_thread);
   const int64_t batch_min = getMinimumBatch();
   const int64_t batch_max = getMaximumInnerOuterPersistentBufferBatch();
   // increase batch_max by 1 to allow a small amount of register spills to keep

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -695,7 +695,11 @@ getOptionalInnerOuterPersistentBufferBatches(
   // directly increase threads_per_block from 128 to 256 to avoid intermediate
   // values such as 160, 192, 224, etc. which can only use a portion of all the
   // registers on a SM. Because for these intermediate values, one SM can only
-  // host one block if each thread uses 255 registers.
+  // host one block if each thread uses 255 registers. Due to the change of
+  // persistent batch size, each threads will not always use 255 registers. But
+  // for the layer norm backward case, we only need to increase threads per
+  // block when persistent batch size is larger than 8. So the smallest batch is
+  // ceilDiv(9,2) = 5, which already uses 216 registers on A100.
   int64_t threads_per_block = threads_per_block_min;
   int64_t inner_batch = ceilDiv(after_vectorization, threads_per_block);
   while (inner_batch > batch_max_spill_for_occupancy &&


### PR DESCRIPTION
**Issue:**
The performance dropped from 1400 GB/s to 1100 GB/s when the hidden size increased from 7K to 7K+128. This is because at 7K, vect = 8, threads_per_block = 128, and batch = 7. The maximum allowed batch size without causing register spill is 7. So at hidden size 7K+128, threads_per_block is increased to 160 and batch is decreased to 6. Blocks per SM is reduced from 2 to 1.
![image](https://github.com/NVIDIA/Fuser/assets/116412316/cb4f3867-8b84-4a5a-83bf-50a6f394e780)


**Fix:**

1. Allow a small register spill by increasing the maximum allowed batch size from 7 to 8. With this fix, the bandwidth can maintain around 1350 GB/s for cases with hidden size in the range of (7K, 8K]. But the bandwidth still drops to 1100 GB/s after 8K. Tried to further increase maximum batch size to 9, the bandwidth still stays around 1100 GB/s.
![image](https://github.com/NVIDIA/Fuser/assets/116412316/89990712-67c1-4317-b984-b0dc83339659)

2. Double threads_per_block instead of increasing by 32. In the original code, when batch size exceeds the maximum allowed value, threads_per_block will be increased by a step_size and check if the new batch size is smaller than maximum allowed value. With this searching method, the next threads_per_block is 160 and blocks per SM is reduced from 2 to 1. This means the code is only using 160 x 255 registers instead of all the 64K registers on each SM. To reduce this register waste, we can directly double threads_per_block from 128 to 256 and still have 255 registers per thread and one block per SM.
![image](https://github.com/NVIDIA/Fuser/assets/116412316/6c4339da-3db1-406c-a8e4-930de5aec907)

**Results:**
Bandwidth increased about 10% for cases with hidden size in the range of (7K,8K]
Bandwidth increased about 5% for cases with hidden size in the range of (8K,10K]
![image](https://github.com/NVIDIA/Fuser/assets/116412316/11cb6436-5cc5-4ce5-8ac6-5dd962e7ee0a)


