### PR TITLE
Matmul INPUT_C role load vectorization

### DIFF
--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -437,6 +437,37 @@ void scheduleProlog(TensorView* shared_mem_tv, const MatmulParams& params) {
           .propagateParallelType());
 }
 
+//! Propagates transformations from fusion output to fusion tv inputs that are
+//!  producers in the epilogue. Transformations' propagation aims at input tvs
+//!  which are not assigned to core roles, that is, are not MMA inputs.
+void scheduleFusionInputsForEpilogue(const mma_utils::RolesMap& roles_map) {
+  std::vector<TensorView*> cached_tvs;
+
+  // Handling transformations in fusion input tvs with assigned INPUT_C role by
+  //  propagating fusion output transformations through cached views of INPUT_C
+  //  fusion input tvs and by setting vectorization of the inner most iterdomain
+  //  of these cached views
+  {
+    auto& c_tvs = roles_map.at(MatmulRole::INPUT_C);
+    for (auto* c : c_tvs) {
+      cached_tvs.push_back(c->cacheAfter());
+    }
+
+    // The system supports only scenario where there is only one fusion output
+    //  with assigned OUTPUT_D role, this condition is already verified so there
+    //  is no need for an additional checks here
+    scheduler_utils::BoundedDirectionalTransformPropagator::backward(
+        roles_map.at(MatmulRole::OUTPUT_D).front(), -1, c_tvs);
+
+    for (auto* cc : cached_tvs) {
+      cc->axis(-1)->parallelize(ParallelType::Vectorize);
+    }
+
+    // The cached INPUT_C tvs are not needed anymore
+    cached_tvs.clear();
+  }
+}
+
 } // namespace
 
 void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
@@ -734,15 +765,14 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
           .propagateParallelType()
           .propagateToBoundary());
 
+  d->axis(-1)->parallelize(ParallelType::Vectorize);
+
   // propagate output transformations to all inputs that are part of epilogue
   //  operations, input tvs with non-core roles
   //  core roles: essential for matmul, for example mma inputs' producers
   if (has_non_mma_input_tvs) {
-    scheduler_utils::BoundedDirectionalTransformPropagator::backward(
-        d, -1, roles_map.at(MatmulRole::INPUT_C));
+    scheduleFusionInputsForEpilogue(roles_map);
   }
-
-  d->axis(-1)->parallelize(ParallelType::Vectorize);
 
   // auto inline for all tensors except register tensors and output tensor
   inlineMost(ir_utils::allTvsExcept(fusion, {acr, bcr, ab, bb, d}));


### PR DESCRIPTION
The goal of this PR is to improve the way how data from fusion input TensorView objects, with assigned `INPUT_C role`, is loaded. The current implementation is inefficient as it is not vectorized, the proposed changes fix this.

Below are examples of epilogue from functional tests where `INPUT_C` tensors are present (literally, beta tests).

---
test case: `FusionMatmulSchedulerEpilogueBeta_CUDA`
- `main`:
```
  #pragma unroll
  for(nvfuser_index_t i117 = 0; i117 < 4; ++i117) {
    int i118 = i49 + (i50 * i117);
    int i119 = 16 * i117;
    int i120 = -i119;
    #pragma unroll
    for(nvfuser_index_t i121 = 0; i121 < 4; ++i121) {
      int i122 = 8 * i121;
      int i123 = i118 + i122;
      int i124 = i119 + (2 * i121);
      bool b125 = i61 < (-i122);
      #pragma unroll
      for(nvfuser_index_t i126 = 0; i126 < 2; ++i126) {
        int i127 = i123 + (i1 * i126);
        int i128 = 8 * i126;
        int i129 = i124 + i128;
        bool b130 = b125 && (i62 < (i120 - i128));
        Array<float, 2, 2> T10;
        #pragma unroll
        for(nvfuser_index_t i131 = 0; i131 < 2; ++i131) {
          float T7[1];
          T7[0] = 0;
          if (b130) {
            T7[0] = __half2float(T2[(i127 + i131)]);
          }
          float T8[1];
          T8[0] = (float) d0 * T7[0];
          T10[i131] = T6[(i129 + i131)] + T8[0];
        }
        if (b130) {
          loadLocalToGlobal<float, 2, false>( &T9[i127], &T10[0]);
        }
      }
    }
  }
```
- `fix`:
```
  #pragma unroll
  for(nvfuser_index_t i117 = 0; i117 < 4; ++i117) {
    int i118 = i49 + (i50 * i117);
    int i119 = 16 * i117;
    int i120 = -i119;
    #pragma unroll
    for(nvfuser_index_t i121 = 0; i121 < 4; ++i121) {
      int i122 = 8 * i121;
      int i123 = i118 + i122;
      int i124 = i119 + (2 * i121);
      bool b125 = i61 < (-i122);
      #pragma unroll
      for(nvfuser_index_t i126 = 0; i126 < 2; ++i126) {
        int i127 = i123 + (i1 * i126);
        int i128 = 8 * i126;
        int i129 = i124 + i128;
        bool b130 = b125 && (i62 < (i120 - i128));
        Array<__half, 2, 2> T14;
        T14.set(__half(0));
        if (b130) {
          loadGlobalToLocal<__half, 2, false>(&T14[0],  &T2[i127]);
        }
        Array<float, 2, 2> T10;
        #pragma unroll
        for(nvfuser_index_t i131 = 0; i131 < 2; ++i131) {
          float T7[1];
          T7[0] = __half2float(T14[i131]);
          float T8[1];
          T8[0] = (float) d0 * T7[0];
          T10[i131] = T6[(i129 + i131)] + T8[0];
        }
        if (b130) {
          loadLocalToGlobal<float, 2, false>( &T9[i127], &T10[0]);
        }
      }
    }
  }
```
---
test case: `FusionMatmulSchedulerEpilogueAlphaBeta_CUDA`
- `main`:
```
  #pragma unroll
  for(nvfuser_index_t i118 = 0; i118 < 4; ++i118) {
    int i119 = i50 + (i51 * i118);
    int i120 = 16 * i118;
    int i121 = -i120;
    #pragma unroll
    for(nvfuser_index_t i122 = 0; i122 < 4; ++i122) {
      int i123 = 8 * i122;
      int i124 = i119 + i123;
      int i125 = i120 + (2 * i122);
      bool b126 = i62 < (-i123);
      #pragma unroll
      for(nvfuser_index_t i127 = 0; i127 < 2; ++i127) {
        int i128 = i124 + (i2 * i127);
        int i129 = 8 * i127;
        int i130 = i125 + i129;
        bool b131 = b126 && (i63 < (i121 - i129));
        Array<float, 2, 2> T11;
        #pragma unroll
        for(nvfuser_index_t i132 = 0; i132 < 2; ++i132) {
          float T8[1];
          T8[0] = 0;
          if (b131) {
            T8[0] = __half2float(T2[(i128 + i132)]);
          }
          float T9[1];
          T9[0]
            = (float) d1
            * T8[0];
          float T7[1];
          T7[0]
            = (float) d0
            * T6[(i130 + i132)];
          T11[i132]
            = T7[0]
            + T9[0];
        }
        if (b131) {
          loadLocalToGlobal<float, 2, false>( &T10[i128], &T11[0]);
        }
      }
    }
  }
```
- `fix`:
```
  #pragma unroll
  for(nvfuser_index_t i118 = 0; i118 < 4; ++i118) {
    int i119;
    i119 = i50 + (i51 * i118);
    int i120;
    i120 = 16 * i118;
    int i121;
    i121 = -i120;
    #pragma unroll
    for(nvfuser_index_t i122 = 0; i122 < 4; ++i122) {
      int i123;
      i123 = 8 * i122;
      int i124;
      i124 = i119 + i123;
      int i125;
      i125 = i120 + (2 * i122);
      bool b126;
      b126 = i62 < (-i123);
      #pragma unroll
      for(nvfuser_index_t i127 = 0; i127 < 2; ++i127) {
        int i128;
        i128 = i124 + (i2 * i127);
        int i129;
        i129 = 8 * i127;
        int i130;
        i130 = i125 + i129;
        bool b131;
        b131 = b126 && (i63 < (i121 - i129));
        Array<__half, 2, 2> T15;
        T15.set(__half(0));
        if (b131) {
          loadGlobalToLocal<__half, 2, false>(&T15[0],  &T2[i128]);
        }
        Array<float, 2, 2> T11;
        #pragma unroll
        for(nvfuser_index_t i132 = 0; i132 < 2; ++i132) {
          float T8[1];
          T8[0]
             = __half2float(T15[i132]);
          float T9[1];
          T9[0]
            = (float) d1
            * T8[0];
          float T7[1];
          T7[0]
            = (float) d0
            * T6[(i130 + i132)];
          T11[i132]
            = T7[0]
            + T9[0];
        }
        if (b131) {
          loadLocalToGlobal<float, 2, false>( &T10[i128], &T11[0]);
        }
      }
    }
  }
```
---
test case: `FusionMatmulSegmenterEpilogueAlphaBetaGeluOutputCast_CUDA`
- `main`:
```
  #pragma unroll
  for(nvfuser_index_t i118 = 0; i118 < 4; ++i118) {
    int i119 = i50 + (i51 * i118);
    int i120 = 16 * i118;
    int i121 = -i120;
    #pragma unroll
    for(nvfuser_index_t i122 = 0; i122 < 4; ++i122) {
      int i123 = 8 * i122;
      int i124 = i119 + i123;
      int i125 = i120 + (2 * i122);
      bool b126 = i62 < (-i123);
      #pragma unroll
      for(nvfuser_index_t i127 = 0; i127 < 2; ++i127) {
        int i128 = i124 + (i2 * i127);
        int i129 = 8 * i127;
        int i130 = i125 + i129;
        bool b131 = b126 && (i63 < (i121 - i129));
        Array<__half, 2, 2> T17;
        #pragma unroll
        for(nvfuser_index_t i132 = 0; i132 < 2; ++i132) {
          float T8[1];
          T8[0] = 0;
          if (b131) {
            T8[0]
               = __half2float(T2[(i128 + i132)]);
          }
          float T9[1];
          T9[0]
            = (float) d1
            * T8[0];
          float T7[1];
          T7[0]
            = (float) d0
            * T6[(i130 + i132)];
          float T10[1];
          T10[0]
            = T7[0]
            + T9[0];
          float T11[1];
          T11[0]
            = T10[0]
            * (float) 7.07106781186547573e-01;
          float T12[1];
          T12[0]
             = erff(T11[0]);
          float T13[1];
          T13[0]
            = (float) 1.00000000000000000e+00
            + T12[0];
          float T14[1];
          T14[0]
            = (float) 5.00000000000000000e-01
            * T13[0];
          float T15[1];
          T15[0]
            = T10[0]
            * T14[0];
          T17[i132]
             = __float2half(T15[0]);
        }
        if (b131) {
          loadLocalToGlobal<__half, 2, false>( &T16[i128], &T17[0]);
        }
      }
    }
  }
```
- `fix`:
```
  #pragma unroll
  for(nvfuser_index_t i118 = 0; i118 < 4; ++i118) {
    int i119;
    i119 = i50 + (i51 * i118);
    int i120;
    i120 = 16 * i118;
    int i121;
    i121 = -i120;
    #pragma unroll
    for(nvfuser_index_t i122 = 0; i122 < 4; ++i122) {
      int i123;
      i123 = 8 * i122;
      int i124;
      i124 = i119 + i123;
      int i125;
      i125 = i120 + (2 * i122);
      bool b126;
      b126 = i62 < (-i123);
      #pragma unroll
      for(nvfuser_index_t i127 = 0; i127 < 2; ++i127) {
        int i128;
        i128 = i124 + (i2 * i127);
        int i129;
        i129 = 8 * i127;
        int i130;
        i130 = i125 + i129;
        bool b131;
        b131 = b126 && (i63 < (i121 - i129));
        Array<__half, 2, 2> T21;
        T21.set(__half(0));
        if (b131) {
          loadGlobalToLocal<__half, 2, false>(&T21[0],  &T2[i128]);
        }
        // Alias Allocation - register
        auto& T17 = T21;
        #pragma unroll
        for(nvfuser_index_t i132 = 0; i132 < 2; ++i132) {
          float T8[1];
          T8[0]
             = __half2float(T21[i132]);
          float T9[1];
          T9[0]
            = (float) d1
            * T8[0];
          float T7[1];
          T7[0]
            = (float) d0
            * T6[(i130 + i132)];
          float T10[1];
          T10[0]
            = T7[0]
            + T9[0];
          float T11[1];
          T11[0]
            = T10[0]
            * (float) 7.07106781186547573e-01;
          float T12[1];
          T12[0]
             = erff(T11[0]);
          float T13[1];
          T13[0]
            = (float) 1.00000000000000000e+00
            + T12[0];
          float T14[1];
          T14[0]
            = (float) 5.00000000000000000e-01
            * T13[0];
          float T15[1];
          T15[0]
            = T10[0]
            * T14[0];
          T17[i132]
             = __float2half(T15[0]);
        }
        if (b131) {
          loadLocalToGlobal<__half, 2, false>( &T16[i128], &T17[0]);
        }
      }
    }
  }
```