### PR TITLE
Handle constant -1 values in dynamic reshape at definition

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -276,7 +276,14 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
           extent_val.is<int64_t>(),
           "Invalid evaluated value of domain extent: ",
           out_id->toString());
-      out_shape.at(i) = extent_val.as<int64_t>();
+      auto extent_int = extent_val.as<int64_t>();
+      if (extent_int == -1) {
+        // For non-constant Scalar sizes, check that we have not passed -1.
+        TORCH_CHECK(
+            out_id->extent()->isConst(),
+            "Values of -1 passed to reshape must be constant at definition.")
+      }
+      out_shape.at(i) = extent_int;
     }
 
     auto view_result = analyzeView(inp_tv, inp_shape, out_shape);

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -265,7 +265,6 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
     // Determine output shape using expr evaluator. Note there may be
     // one domain of extent -1
     std::vector<int64_t> out_shape(out_dom.size(), 0);
-    bool extent_m1_found = false;
     for (const auto i : c10::irange(out_dom.size())) {
       auto out_id = out_dom.at(i);
       auto extent_val = expr_eval->evaluate(out_id->extent());
@@ -277,18 +276,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
           extent_val.is<int64_t>(),
           "Invalid evaluated value of domain extent: ",
           out_id->toString());
-      const auto extent_int = extent_val.as<int64_t>();
-      if (extent_int == -1) {
-        TORCH_INTERNAL_ASSERT(
-            !extent_m1_found,
-            "Multiple output domains of size -1 not allowed",
-            out_tv->toString());
-        extent_m1_found = true;
-      } else {
-        TORCH_INTERNAL_ASSERT(
-            extent_int > 0, "Invalid output domain extent: ", extent_int);
-      }
-      out_shape.at(i) = extent_int;
+      out_shape.at(i) = extent_val.as<int64_t>();
     }
 
     auto view_result = analyzeView(inp_tv, inp_shape, out_shape);

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -1105,4 +1105,50 @@ TEST_F(NVFuserTest, Issue249_CUDA) {
       __FILE__);
 }
 
+// This is just like the test above, but uses an input scalar with value -1
+TEST_F(NVFuserTest, Issue249InputNegative1_CUDA) {
+  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeSymbolicTensor(4);
+  fusion.addInput(tv0);
+
+  auto s0 = IrBuilder::create<Scalar>(DataType::Int);
+  auto s1 = IrBuilder::create<Scalar>(DataType::Int);
+  auto s2 = IrBuilder::create<Scalar>(DataType::Int);
+  fusion.addInput(s0);
+  fusion.addInput(s1);
+  fusion.addInput(s2);
+
+  auto tv1 = add(tv0, tv0);
+  auto tv2 = reshape(tv1, {s0, s1, s2});
+  auto tv3 = add(tv2, tv2);
+  fusion.addOutput(tv3);
+
+  FusionExecutorCache fusion_executor_cache(std::move(fusion_ptr));
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor at_x = at::randn({2, 3, 4, 5}, options);
+  auto at_y = (at_x + at_x).reshape({2, 4, -1});
+  auto at_z = at_y + at_y;
+
+  // Dynamic reshape sizes that are not constant at definition must be explicit:
+  // no -1 allowed
+  EXPECT_THROW(
+      fusion_executor_cache.runFusionWithInputs({at_x, 2, 4, -1}),
+      std::exception);
+
+  // Passing explicit sizes works fine
+  auto outputs = fusion_executor_cache.runFusionWithInputs({at_x, 2, 4, 15});
+
+  testValidate(
+      fusion_executor_cache.fusion(),
+      outputs,
+      {at_x, 2, 4, 15},
+      {at_z},
+      __LINE__,
+      __FILE__);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
This replaces scalar new sizes that evaluate to `-1` at definition time in the `reshape()` op with a simplified expression for the new output extent. Previous to this change, the output shape would be set to the `Val*` that was provided, which evaluates to `-1`; after which it is difficult to reliably change even at concretization, since that scalar might have legitimate other uses.

Before this change:
```c++
auto tv0 = makeSymbolicTensor(4); // [ iS0{i0}, iS1{i2}, iS2{i3}, iS3{i4} ]
auto tv1 = reshape({tv0->axis(0)->extent(), tv0->axis(2)->extent(), IrBuilder::create<Scalar>(-1)});
// [ ?S4{i0}, ?S5{i3}, ?S6{-1} ]
```
After this change:
```c++
auto tv0 = makeSymbolicTensor(4); // [ iS0{i0}, iS1{i2}, iS2{i3}, iS3{i4} ]
auto tv1 = reshape({tv0->axis(0)->extent(), tv0->axis(2)->extent(), IrBuilder::create<Scalar>(-1)});
// [ iS4{i0}, iS5{i3}, ?S6{( i2 * i4 )} ]
```

In this PR we also introduce a check that only allows values of -1 when that value is known at compile time; for example passing an input scalar of -1 or an expression that evaluates to -1 to a dynamic reshape will result in an error at concretization.

Fixes #249 