### PR TITLE
[WIP] Pad to broadcast

### DIFF
--- a/csrc/root_domain_map.cpp
+++ b/csrc/root_domain_map.cpp
@@ -132,6 +132,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseRootDomainMap::map(
     //  domains of torch_gather)
     // 3. Squeeze and unsqueeze
     // 4. Broadcast and non broadcast
+    // 5. At least one domain is symbolic and extents are not identical
 
     // Condition 1: when the producer ID is the dim of a select-like op
     if (producer_id == indexed_producer_id) {
@@ -177,6 +178,15 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseRootDomainMap::map(
     // Condition 4
     if (!map_broadcast_ &&
         producer_id->isBroadcast() != consumer_id->isBroadcast()) {
+      itc++;
+      itp++;
+      continue;
+    }
+
+    // Condition 5
+    if (!map_symbolic_ &&
+        (producer_id->isSymbolic() || consumer_id->isSymbolic()) &&
+        !producer_id->extent()->sameAs(consumer_id->extent())) {
       itc++;
       itp++;
       continue;

--- a/csrc/root_domain_map.h
+++ b/csrc/root_domain_map.h
@@ -100,6 +100,11 @@ class TORCH_CUDA_CU_API PairwiseRootDomainMap : public RootDomainMap {
     return *this;
   }
 
+  PairwiseRootDomainMap& mapSymbolic(bool b) {
+    map_symbolic_ = b;
+    return *this;
+  }
+
   PairwiseRootDomainMap& mapDifferentExtents(bool b) {
     map_different_extents_ = b;
     return *this;
@@ -136,6 +141,8 @@ class TORCH_CUDA_CU_API PairwiseRootDomainMap : public RootDomainMap {
   //! Map broadcast and non-broadcast domains. Note that this is on by
   //! default
   bool map_broadcast_ = true;
+  //! If false, map Symbolic IterDomains only if extents match exactly.
+  bool map_symbolic_ = false;
   //! Map domains that may have different extents, e.g., torch_gather
   bool map_different_extents_ = false;
   //! Map domains that are indirectly accessed, e.g., index_select


### PR DESCRIPTION
The `pad` command accepts negative pad widths, in which case a tensor may become size 1 (broadcast), at which point it can be used like a regular padded dimension. Currently, this is not handled well even if we concretize to the proper `IterType` since there is no root tensor to resolve the broadcast to. Instead, we should address this by translating pad operations that result in broadcasts to select + broadcast operations instead. Both the static and dynamic cases need to be handled.