### PR TITLE
`DynamicType`: null == null

### DIFF
--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -158,18 +158,19 @@ struct Containers {
 
   template <typename DynamicType, typename... MemberTypes>
   using TypeIdentitiesAsTuple = std::tuple<
+      std::type_identity<std::monostate>,
       std::type_identity<MemberTypes>...,
       std::type_identity<Templates<DynamicType>>...>;
 
   template <typename DynamicType, typename... MemberTypes>
-  using ForAllTypes =
-      nvfuser::ForAllTypes<MemberTypes..., Templates<DynamicType>...>;
+  using ForAllTypes = nvfuser::
+      ForAllTypes<std::monostate, MemberTypes..., Templates<DynamicType>...>;
 
   // Check if T is one of the types in the type list MemberTypes..., or a
   // container
   template <typename T, typename DynamicType, typename... MemberTypes>
-  static constexpr auto is_candidate_type =
-      nvfuser::belongs_to<T, MemberTypes..., Templates<DynamicType>...>;
+  static constexpr auto is_candidate_type = nvfuser::
+      belongs_to<T, std::monostate, MemberTypes..., Templates<DynamicType>...>;
 };
 
 using NoContainers = Containers<>;

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -360,6 +360,40 @@ TEST_F(DynamicTypeTest, MoveCtor) {
   NonCopyableType b(std::move(a));
 }
 
+namespace null_tests {
+
+constexpr DoubleInt64Bool a, b;
+static_assert(a.isNull());
+static_assert(!a.hasValue());
+static_assert(b.isNull());
+static_assert(!b.hasValue());
+static_assert(a == b);
+static_assert(b == a);
+static_assert(!(a != b));
+static_assert(!(b != a));
+static_assert(!(a < b));
+static_assert(!(b < a));
+static_assert(!(a > b));
+static_assert(!(b > a));
+static_assert(a <= b);
+static_assert(b <= a);
+static_assert(a >= b);
+static_assert(b >= a);
+static_assert(a == std::monostate{});
+static_assert(std::monostate{} == a);
+static_assert(!(a != std::monostate{}));
+static_assert(!(std::monostate{} != a));
+static_assert(!(a < std::monostate{}));
+static_assert(!(std::monostate{} < a));
+static_assert(!(a > std::monostate{}));
+static_assert(!(std::monostate{} > a));
+static_assert(a <= std::monostate{});
+static_assert(std::monostate{} <= a);
+static_assert(a >= std::monostate{});
+static_assert(std::monostate{} >= a);
+
+} // namespace null_tests
+
 #define TEST_BINARY_OP_ALLTYPE(name, op)                                       \
   TEST_F(DynamicTypeTest, name) {                                              \
     static_assert(opcheck<DoubleInt64Bool> op opcheck<DoubleInt64Bool>);       \


### PR DESCRIPTION
In the past, we were not overloading ops for `std::monostate`. This is a mistake and should be fixed.