### PR TITLE
Fix getInputsTo

### DIFF
--- a/csrc/iter_visitor.cpp
+++ b/csrc/iter_visitor.cpp
@@ -336,7 +336,8 @@ class Inputs : public IterVisitor {
   Inputs(const std::vector<Val*>& all_inputs) : all_inputs_(all_inputs) {}
 
   std::vector<Statement*> next(Val* v) override {
-    if (std::find(inputs_.begin(), inputs_.end(), v) != inputs_.end()) {
+    if (std::find(all_inputs_.begin(), all_inputs_.end(), v) !=
+        all_inputs_.end()) {
       return {};
     }
     return IterVisitor::next(v);

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -9346,6 +9346,31 @@ TEST_F(NVFuserTest, IterVisitorTraverseSiblings_CUDA) {
       "Welford var_sum not traversed in getStmtsTo({n})");
 }
 
+TEST_F(NVFuserTest, IterVisitorGetInputsTo) {
+  // Test that IterVisitor::getInputsTo() will stop further traverse when
+  // reaching the target tensors
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto a = makeSymbolicTensor(1);
+  auto b = makeSymbolicTensor(1);
+  auto c = makeSymbolicTensor(1);
+
+  fusion.addInput(a);
+  fusion.addInput(b);
+  fusion.addInput(c);
+
+  auto d = add(b, c);
+  auto e = add(a, d);
+
+  fusion.addOutput(e);
+
+  auto inputs = IterVisitor::getInputsTo({e}, {a, d});
+  std::unordered_set<Val*> inputs_set(inputs.begin(), inputs.end());
+
+  EXPECT_EQ(inputs_set, std::unordered_set<Val*>({a, d}));
+}
+
 // Test file size should be up to 10K LoC. Create a new file for more tests.
 
 } // namespace nvfuser


### PR DESCRIPTION
Today, `getInputsTo` is not doing as documented:
```C++
  //! Optional list of input vals. While traversing to inputs if a value in the
  //! all_inputs list is found, that value will be added to the inputs_ and
  //! traversal will not go into its definition. Otherwise traversal follows
  //! definition paths until hitting a definition that is a nullptr (i.e. a
  //! terminating input).
  const std::vector<Val*>& all_inputs_;
```
This PR fixes it. See the new test.