### PR TITLE
Add `ir_utils::dependenciesSatisfied`

### DIFF
--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -12,6 +12,7 @@
 #include <ir/builder.h>
 #include <ir/cloner.h>
 #include <ir/printer.h>
+#include <ir/utils.h>
 #include <kernel.h>
 #include <kernel_ir.h>
 #include <kernel_ir_dispatch.h>
@@ -146,70 +147,6 @@ void Val::resolveIndexDtype() {
   dtype_ = index_dtype;
 }
 
-namespace {
-
-// Traverse definition of all values involved in constructing the provided val.
-// Check if all values involved are constant values, meaning the provided
-// val is also a constant value.
-class ConstCheck : private OptOutConstDispatch {
- private:
-  bool is_const_ = true;
-
-  // Returns true if all Val's in the hisotry of provided Val is an Int. Since
-  // our expression evaluator doesn't support any type besides int, it's
-  // important to check it is one.
-  bool is_int_ = true;
-
-  void handle(const Val* b) final {
-    is_const_ = is_const_ && b->isConst();
-  }
-
-  void handle(const NamedScalar* ns) final {
-    is_const_ = false;
-  }
-
-  void handle(const TensorView* ns) final {
-    is_const_ = false;
-  }
-
-  void handle(const kir::TensorIndex* ns) final {
-    is_const_ = false;
-  }
-
-  void dispatch(const Expr* expr) final {
-    for (auto inp : expr->inputs()) {
-      dispatch(inp);
-    }
-  }
-
-  void dispatch(const Val* val) final {
-    if (!val->isIntegralScalar()) {
-      is_int_ = false;
-    }
-
-    if (val->definition() != nullptr) {
-      dispatch(val->definition());
-    } else {
-      OptOutConstDispatch::dispatch(val);
-    }
-  }
-
- public:
-  static bool isConst(const Val* val) {
-    ConstCheck cc;
-    cc.dispatch(val);
-    return cc.is_const_;
-  }
-
-  static bool isConstInt(const Val* val) {
-    ConstCheck cc;
-    cc.dispatch(val);
-    return cc.is_const_ && cc.is_int_;
-  }
-};
-
-} // namespace
-
 bool Val::sameAs(const Statement* other) const {
   if (this == other) {
     return true;
@@ -293,16 +230,16 @@ bool Val::isConstScalar() const {
   if (!isScalar()) {
     return false;
   }
-  return ConstCheck::isConst(this);
+  return ir_utils::dependenciesSatisfied({this});
 }
 
 bool Val::isConstInt() const {
-  return ConstCheck::isConst(this) && isIntegralScalar();
+  return ir_utils::dependenciesSatisfied({this}) && isIntegralScalar();
 }
 
 int64_t Val::evaluateInt() {
   TORCH_INTERNAL_ASSERT(
-      ConstCheck::isConst(this),
+      ir_utils::dependenciesSatisfied(std::vector<const Val*>{this}),
       "Cannot get Int of not const values through IR nodes, must use runtime ExpressionEvaluator.");
 
   if (this->value().hasValue()) {
@@ -320,7 +257,7 @@ int64_t Val::evaluateInt() {
 
 double Val::evaluateDouble() {
   TORCH_INTERNAL_ASSERT(
-      ConstCheck::isConst(this),
+      ir_utils::dependenciesSatisfied(std::vector<const Val*>{this}),
       "Cannot get Double of not const doubles through IR nodes, must use runtime ExpressionEvaluator.");
 
   if (this->value().hasValue()) {
@@ -337,7 +274,7 @@ double Val::evaluateDouble() {
 
 bool Val::evaluateBool() {
   TORCH_INTERNAL_ASSERT(
-      ConstCheck::isConst(this),
+      ir_utils::dependenciesSatisfied(std::vector<const Val*>{this}),
       "Cannot get Bool of not const bools through IR nodes, must use runtime ExpressionEvaluator.");
 
   if (this->value().hasValue()) {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -427,6 +427,19 @@ void validateDomainEquivalence(
     const std::vector<IterDomain*>& initial_domain,
     const std::vector<IterDomain*>& derived_domain);
 
+//! Check if all the inputs required to compute needed_val are known
+bool dependenciesSatisfied(
+    std::vector<const Val*> needed_vals,
+    std::unordered_set<const Val*> known_vals = {});
+
+inline bool dependenciesSatisfied(
+    std::vector<Val*> needed_vals,
+    std::unordered_set<Val*> known_vals = {}) {
+  return dependenciesSatisfied(
+      std::vector<const Val*>(needed_vals.begin(), needed_vals.end()),
+      std::unordered_set<const Val*>(known_vals.begin(), known_vals.end()));
+}
+
 //! Check if a conditional scope, i.e., ForLoop or IfThenElse, is
 //! guaranteed not to cause thread divergence
 bool isAlignedScopeExpr(const Expr* expr);


### PR DESCRIPTION
It is used to check if all the dependencies to compute a `Val` is known (either a const or in the specified `known_vals` set)