### PR TITLE
Allow struct dtype to be named

### DIFF
--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -24,8 +24,9 @@ namespace nvfuser {
 
 template <typename T>
 struct Struct {
-  // In theory, we should just use std::unordered_map<std::string, T>, but this
-  // doesn't work on old gcc. See also SetTheoreticNaturalNumbers
+  // Using std::unordered_map<std::string, T> is more convenient and
+  // straightforward, but this is not guaranteed to work by C++ standard.
+  // See [Incomplete type support in STL]
 #if defined(STD_UNORDERED_SET_SUPPORTS_INCOMPLETE_TYPE)
   std::unordered_map<std::string, T> fields;
 #define MAYBE_STAR

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -107,6 +107,13 @@ struct PointerOf {
 };
 
 struct StructOf {
+  // In nvfuser's type system, there are two types of structs: named structs and
+  // anonymous structs. Named structs are lowered to its name in the generated
+  // code, while anonymous structs are lowered to `struct {...}`. Generally, we
+  // should use named structs for structures that has definition in a file in
+  // runtime/, and anonymous structs for others.
+  std::string name;
+
   // Note [Incomplete type support in STL]
   // std::unordered_map<std::string, DataType> is a STL container of incomplete
   // type. Not all C++ STL containers supports incomplete type due to historical
@@ -124,7 +131,6 @@ struct StructOf {
   //   std::vector<A> a; // valid on C++17
   //   std::unordered_set<A> s; // undefined behavior, working on newer gcc.
   //   struct A {};
-
 #if defined(STD_UNORDERED_SET_SUPPORTS_INCOMPLETE_TYPE)
   std::unordered_map<std::string, DataType> types;
 #define NVFUSER_MAYBE_MAKE_SHARED(x) x

--- a/test/test_loop_rotation.cpp
+++ b/test/test_loop_rotation.cpp
@@ -595,7 +595,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   alignas(16) extern __shared__ char array[];
   unsigned smem_offset = 0;
   NVFUSER_DEFINE_MAGIC_ZERO;
-  struct { Array<nvfuser_index_t, 2, 1> stride; Array<nvfuser_index_t, 2, 1> size; float* data; } s0;
+  Tensor<float, 2, 2> s0;
   s0.stride = T0.stride;
   s0.size = T0.size;
   s0.data = T0.data;

--- a/test/test_tensor_factories.cpp
+++ b/test/test_tensor_factories.cpp
@@ -531,8 +531,10 @@ TEST_F(TensorFactoryTest, MetadataAsTensor) {
   std::get<StructOf>(unamed_dtype1.type).name = "";
   auto meta0_copy1 = IrBuilder::newScalar(unamed_dtype0);
   auto meta1_copy1 = IrBuilder::newScalar(unamed_dtype1);
-  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, meta0_copy1, meta0_copy0);
-  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, meta1_copy1, meta1_copy0);
+  IrBuilder::create<LoadStoreOp>(
+      LoadStoreOpType::Set, meta0_copy1, meta0_copy0);
+  IrBuilder::create<LoadStoreOp>(
+      LoadStoreOpType::Set, meta1_copy1, meta1_copy0);
 
   auto meta0_copy2 = set(meta0_copy1);
   auto meta1_copy2 = set(meta1_copy1);

--- a/test/test_tensor_factories.cpp
+++ b/test/test_tensor_factories.cpp
@@ -524,8 +524,15 @@ TEST_F(TensorFactoryTest, MetadataAsTensor) {
   auto meta0_copy0 = set(meta0);
   auto meta1_copy0 = set(meta1);
 
-  auto meta0_copy1 = set(meta0_copy0);
-  auto meta1_copy1 = set(meta1_copy0);
+  // also test unamed structure
+  auto unamed_dtype0 = metaDataTypeOf(tv0);
+  std::get<StructOf>(unamed_dtype0.type).name = "";
+  auto unamed_dtype1 = metaDataTypeOf(tv1);
+  std::get<StructOf>(unamed_dtype1.type).name = "";
+  auto meta0_copy1 = IrBuilder::newScalar(unamed_dtype0);
+  auto meta1_copy1 = IrBuilder::newScalar(unamed_dtype1);
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, meta0_copy1, meta0_copy0);
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, meta1_copy1, meta1_copy0);
 
   auto meta0_copy2 = set(meta0_copy1);
   auto meta1_copy2 = set(meta1_copy1);


### PR DESCRIPTION
If a struct is already defined in the `runtime/`, we do not have to generate its definition during lowering. For that case, we just generate the name as defined in `runtime`. For example, we do not have to generate tensor metadata as `struct {....}`, instead, we can just do things like `Tensor<float, 4, 4>`.