### PR TITLE
Cache metadata access expr inside IR container

### DIFF
--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -209,9 +209,7 @@ Val* IrBuilder::getAttrExpr(Val* struct_, std::string attr) {
 }
 
 Val* IrBuilder::metadataExpr(TensorView* tv) {
-  auto out = newScalar(metaDataTypeOf(tv));
-  create<GetMetaData>(tv->container(), out, tv);
-  return out;
+  return tv->fusion()->metadataOf(tv);
 }
 
 Val* SimplifyingIrBuilder::negExpr(Val* val) {

--- a/csrc/ir/cloner.h
+++ b/csrc/ir/cloner.h
@@ -77,6 +77,21 @@ class TORCH_CUDA_CU_API IrCloner {
         tup);
   }
 
+  template <typename T, typename U>
+  std::pair<T, U> clone(const std::pair<T, U>& p) {
+    return std::make_pair<T, U>(this->clone(p.first), this->clone(p.second));
+  }
+
+  template <class T, class U>
+  std::unordered_map<T, U> clone(const std::unordered_map<T, U>& container) {
+    std::unordered_map<T, U> copy;
+    copy.reserve(container.size());
+    for (const auto& [k, v] : container) {
+      copy.emplace(clone(k), clone(v));
+    }
+    return copy;
+  }
+
   IrContainer* container() const {
     return ir_container_;
   }

--- a/csrc/ir/container.cpp
+++ b/csrc/ir/container.cpp
@@ -29,6 +29,8 @@ void swap(IrContainer& a, IrContainer& b) noexcept {
   swap(a.val_type_name_map_, b.val_type_name_map_);
   swap(a.expr_name_counter_, b.expr_name_counter_);
 
+  swap(a.metadata_, b.metadata_);
+
   // Fixup the Statement::fusion_ links for a
   for (auto val : a.vals_) {
     val->ir_container_ = &a;
@@ -67,6 +69,8 @@ IrCloner IrContainer::copy(const IrContainer* from, IrContainer* to) {
       to->axioms_->emplace_back(ir_cloner.clone(pred));
     }
   }
+
+  to->metadata_ = ir_cloner.clone(from->metadata_);
 
   return ir_cloner;
 }
@@ -198,6 +202,7 @@ void IrContainer::clear() noexcept {
   raw_ptrs_.clear();
   axioms_.reset();
   val_type_name_map_.clear();
+  metadata_.clear();
   expr_name_counter_ = 0;
 }
 
@@ -309,6 +314,16 @@ NamedScalar* IrContainer::magicZeroVal() {
     vals_up_.pop_back();
   }
   return magic_zero_val_.get();
+}
+
+Val* IrContainer::metadataOf(Val* v) {
+  if (metadata_.count(v) == 0) {
+    auto metadata_val = IrBuilder::create<Val>(this, metaDataTypeOf(v));
+    auto metadata_expr =
+        IrBuilder::create<GetMetaData>(this, metadata_val, v);
+    metadata_[v] = std::make_pair(metadata_val, metadata_expr);
+  }
+  return metadata_.at(v).first;
 }
 
 void IrContainer::lazyInitAxioms() {

--- a/csrc/ir/container.cpp
+++ b/csrc/ir/container.cpp
@@ -319,8 +319,7 @@ NamedScalar* IrContainer::magicZeroVal() {
 Val* IrContainer::metadataOf(Val* v) {
   if (metadata_.count(v) == 0) {
     auto metadata_val = IrBuilder::create<Val>(this, metaDataTypeOf(v));
-    auto metadata_expr =
-        IrBuilder::create<GetMetaData>(this, metadata_val, v);
+    auto metadata_expr = IrBuilder::create<GetMetaData>(this, metadata_val, v);
     metadata_[v] = std::make_pair(metadata_val, metadata_expr);
   }
   return metadata_.at(v).first;

--- a/csrc/ir/container.h
+++ b/csrc/ir/container.h
@@ -91,6 +91,8 @@ class TORCH_CUDA_CU_API IrContainer : public PolymorphicBase {
   NamedScalar* magicZeroVal();
   Val* zeroVal(DataType dtype);
   Val* oneVal(DataType dtype);
+  Val* metadataOf(Val*);
+
   // Axioms about CUDA programming, for example: threadIdx.x < blockDim.x
   const std::vector<Val*>& axioms() {
     lazyInitAxioms();
@@ -176,6 +178,7 @@ class TORCH_CUDA_CU_API IrContainer : public PolymorphicBase {
   std::unique_ptr<Val> zero_val_;
   std::unique_ptr<NamedScalar> magic_zero_val_;
   std::unique_ptr<std::vector<Val*>> axioms_;
+  std::unordered_map<Val*, std::pair<Val*, Expr*>> metadata_;
 };
 
 } // namespace nvfuser


### PR DESCRIPTION
`GetMetaData` expr is so widely used. We should avoid creating many instances of it. Also, this would be helpful for kernel parameters support.  For example, if we set `Kernel::parameters` as `v1 = GetMetaData(tv1)` instead of `tv1`, then without this PR, the generated kernel might not work because in the tensor index, we might have `v2 = GetMetaData(tv1)`, although `v2` and `v1` are the same, if scalar hoisting does not work for some reason and `v2` is not replaced with `v1`, the lowered expr might fail, because `tv1` is not a kernel parameter, therefore unknown to the kernel, therefore `v2` can not be evaluated in the kernel.