### PR TITLE
Allow `Expr::evaluate` to have full access to the evaluator

### DIFF
--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -104,7 +104,7 @@ PolymorphicValue ExpressionEvaluator::evaluate(const Val* value) {
         }
         inputs.emplace_back(eval_i);
       }
-      auto outputs = def->evaluate(inputs);
+      auto outputs = def->evaluate(*this, inputs);
       for (auto i : c10::irange(def->outputs().size())) {
         known_values_[def->output(i)] = outputs[i];
       }

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -697,6 +697,7 @@ class FlattenedAssocCommOp : public Expr {
   }
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override {
     using namespace PolymorphicValue_functions;
     std::vector<PolymorphicValue> inputs_ = inputs;

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -490,6 +490,7 @@ Expr* Expr::withWritePredicate(kir::Predicate* predicate) {
 }
 
 std::vector<PolymorphicValue> Expr::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   TORCH_INTERNAL_ASSERT(
       false,

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -54,20 +54,14 @@ using StmtNameType = unsigned int;
 constexpr StmtNameType kInvalidStmName =
     std::numeric_limits<unsigned int>::max();
 
-class NonCopyable;
-class PolymorphicBase;
 class Fusion;
-class FusionGuard;
 class Expr;
 class Val;
-class UnaryOp;
-class BinaryOp;
-class RNGOp;
-class IterDomain;
 class IrCloner;
 class IrContainer;
 class IrBuilderPasskey;
 class IrContainerPasskey;
+class ExpressionEvaluator;
 
 namespace kir {
 class Kernel;
@@ -81,8 +75,6 @@ class ExprPasskey {
  private:
   explicit ExprPasskey() = default;
 };
-
-TORCH_CUDA_CU_API void swap(Fusion& a, Fusion& b) noexcept;
 
 #define NVFUSER_DECLARE_CLONE \
   virtual Statement* clone(IrCloner* ir_cloner) const override;
@@ -547,6 +539,7 @@ class TORCH_CUDA_CU_API Expr : public Statement {
   bool sameAs(const Statement* other) const override;
 
   virtual std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const;
 
   // Input/output accessors

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -299,6 +299,7 @@ class TORCH_CUDA_CU_API UnaryOp : public Expr {
   }
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   std::string toString(int indent_size = 0) const override;
@@ -336,6 +337,7 @@ class TORCH_CUDA_CU_API BinaryOp : public Expr {
   }
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   std::string toString(int indent_size = 0) const override;
@@ -382,6 +384,7 @@ class TORCH_CUDA_CU_API TernaryOp : public Expr {
   }
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   std::string toString(int indent_size = 0) const override;
@@ -431,6 +434,7 @@ class TORCH_CUDA_CU_API ArrayConstruct : public Expr {
   std::string toInlineString(int indent_size = 0) const override;
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   Val* out() const {
@@ -455,6 +459,7 @@ class TORCH_CUDA_CU_API GetItem : public Expr {
   std::string toInlineString(int indent_size = 0) const override;
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   Val* out() const {
@@ -487,6 +492,7 @@ class TORCH_CUDA_CU_API GetAttr : public Expr {
   std::string toInlineString(int indent_size = 0) const override;
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   Val* out() const {
@@ -533,6 +539,7 @@ class TORCH_CUDA_CU_API GetMetaData : public Expr {
   }
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   Val* out() const {
@@ -561,6 +568,7 @@ class TORCH_CUDA_CU_API TensorConstruct : public Expr {
   std::string toInlineString(int indent_size = 0) const override;
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   TensorView* out() const {
@@ -702,6 +710,7 @@ class TORCH_CUDA_CU_API BroadcastOp : public Expr {
   std::string toInlineString(int indent_size = 0) const override;
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   Val* out() const {
@@ -752,6 +761,7 @@ class TORCH_CUDA_CU_API SqueezeOp : public Expr {
   std::string toInlineString(int indent_size = 0) const override;
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   Val* out() const {
@@ -1544,6 +1554,7 @@ class TORCH_CUDA_CU_API LoadStoreOp : public Expr {
   }
 
   std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
   std::string toString(int indent_size = 0) const override;

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -294,6 +294,7 @@ UnaryOp::UnaryOp(IrBuilderPasskey passkey, UnaryOpType type, Val* out, Val* in)
 }
 
 std::vector<PolymorphicValue> UnaryOp::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   using namespace PolymorphicValue_functions;
   const auto& in = inputs.at(0);
@@ -398,6 +399,7 @@ BinaryOp::BinaryOp(
 }
 
 std::vector<PolymorphicValue> BinaryOp::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   using namespace PolymorphicValue_functions;
   const auto& lhs = inputs.at(0);
@@ -550,6 +552,7 @@ TernaryOp::TernaryOp(
 }
 
 std::vector<PolymorphicValue> TernaryOp::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   using namespace PolymorphicValue_functions;
   const auto& in1 = inputs.at(0);
@@ -665,6 +668,7 @@ std::string ArrayConstruct::toInlineString(int indent_size) const {
 }
 
 std::vector<PolymorphicValue> ArrayConstruct::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   return {PolymorphicValue(inputs)};
 }
@@ -696,6 +700,7 @@ std::string GetItem::toInlineString(int indent_size) const {
 }
 
 std::vector<PolymorphicValue> GetItem::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   TORCH_INTERNAL_ASSERT(inputs.size() == 2, "GetItem expects 2 inputs");
   return {PolymorphicValue(inputs.at(0)[inputs.at(1)])};
@@ -732,6 +737,7 @@ std::string GetAttr::toInlineString(int indent_size) const {
 }
 
 std::vector<PolymorphicValue> GetAttr::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   TORCH_INTERNAL_ASSERT(inputs.size() == 1, "GetAttr expects 1 input");
   return {inputs.at(0)[attr()]};
@@ -762,6 +768,7 @@ std::string GetMetaData::toInlineString(int indent_size) const {
 }
 
 std::vector<PolymorphicValue> GetMetaData::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   TORCH_INTERNAL_ASSERT(inputs.size() == 1, "GetMetaData expects 1 input");
   TORCH_INTERNAL_ASSERT(
@@ -810,6 +817,7 @@ std::string TensorConstruct::toInlineString(int indent_size) const {
 }
 
 std::vector<PolymorphicValue> TensorConstruct::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   TORCH_INTERNAL_ASSERT(inputs.size() == 1, "TensorConstruct expects 1 input");
   using namespace PolymorphicValue_functions;
@@ -961,6 +969,7 @@ std::string BroadcastOp::toInlineString(int indent_size) const {
 }
 
 std::vector<PolymorphicValue> BroadcastOp::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   TORCH_INTERNAL_ASSERT(
       inputs.size() == 1,
@@ -1057,6 +1066,7 @@ std::string SqueezeOp::toInlineString(int indent_size) const {
 }
 
 std::vector<PolymorphicValue> SqueezeOp::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   TORCH_INTERNAL_ASSERT(
       inputs.size() == 1,
@@ -2143,6 +2153,7 @@ LoadStoreOp::LoadStoreOp(
 }
 
 std::vector<PolymorphicValue> LoadStoreOp::evaluate(
+    const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   return inputs;
 }


### PR DESCRIPTION
Some expressions might need context information to evaluate, for example `GetMetaData` might need the split size for symbolic splits in order to compute the sizes and strides of the allocation domain. So I added a const reference of the expr evaluator to `Expr::evaluate`. I think it makes sense to have access to such context information. This change will also allow expr evaluator to evaluate tensor factories like `FullOp` on the non-zero device, because the expr evaluator can just store the desired device and the `FullOp::evaluate` can pull that information out. However, `ExpressionEvaluator` must be passed as a const reference to ensure that the `evaluate` function does not modify it. For example, I don't want someone to do a `ee.bind(...)` inside the `evaluate` function, because this definitely looks too hacky to accept.