### PR TITLE
`FusionExecutor::runRtc` don't use `getBuffer`

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1836,7 +1836,7 @@ float FusionExecutor::runRtc(
   std::vector<std::vector<std::byte>> data;
   std::vector<void*> pointers;
 
-  for (auto input : args) {
+  for (const auto& input : args) {
     Struct<PolymorphicValue> concrete_value;
     concrete_value["data"] = PolymorphicValue(
         Pointer(input.data_ptr(), aten_to_data_type(input.scalar_type())));

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -647,4 +647,46 @@ void KernelArgumentHolder::pushTensorProxy(
   arguments_.push_back(getAbstractTensorArg(at::Tensor(meta_tensor)));
 }
 
+std::vector<std::byte> getTensorArgBuffer(
+    const PolymorphicValue& metadata,
+    PrimDataType index_type) {
+  auto struct_ = metadata.as<Struct>();
+  std::vector<std::byte> buffer;
+  void* ptr = (void*)struct_["data"];
+  std::vector<int64_t> sizes = (std::vector<int64_t>)struct_["size"];
+  std::vector<int64_t> strides = (std::vector<int64_t>)struct_["stride"];
+  if (index_type == PrimDataType::Int) {
+    buffer.reserve(
+        sizeof(ptr) + sizeof(int64_t) * (sizes.size() + strides.size()));
+    buffer.insert(
+        buffer.end(), (std::byte*)&ptr, (std::byte*)&ptr + sizeof(ptr));
+    buffer.insert(
+        buffer.end(),
+        (std::byte*)sizes.data(),
+        (std::byte*)sizes.data() + sizeof(int64_t) * sizes.size());
+    buffer.insert(
+        buffer.end(),
+        (std::byte*)strides.data(),
+        (std::byte*)strides.data() + sizeof(int64_t) * strides.size());
+  } else {
+    TORCH_INTERNAL_ASSERT(
+        index_type == PrimDataType::Int32, "unknown index type");
+    std::vector<int32_t> sizes32(sizes.begin(), sizes.end());
+    std::vector<int32_t> strides32(strides.begin(), strides.end());
+    buffer.reserve(
+        sizeof(ptr) + sizeof(int32_t) * (sizes32.size() + strides32.size()));
+    buffer.insert(
+        buffer.end(), (std::byte*)&ptr, (std::byte*)&ptr + sizeof(ptr));
+    buffer.insert(
+        buffer.end(),
+        (std::byte*)sizes32.data(),
+        (std::byte*)sizes32.data() + sizeof(int32_t) * sizes32.size());
+    buffer.insert(
+        buffer.end(),
+        (std::byte*)strides32.data(),
+        (std::byte*)strides32.data() + sizeof(int32_t) * strides32.size());
+  }
+  return buffer;
+}
+
 } // namespace nvfuser

--- a/csrc/executor_kernel_arg.h
+++ b/csrc/executor_kernel_arg.h
@@ -14,9 +14,11 @@
 #include <ir/all_nodes.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <type.h>
+
 #include <array>
 #include <cstddef>
 #include <optional>
+#include <vector>
 
 namespace nvfuser {
 
@@ -484,5 +486,9 @@ class TORCH_CUDA_CU_API KernelArgumentHolder {
   int8_t device_index_ = 0;
   std::optional<size_t> cache_id_ = std::nullopt;
 };
+
+std::vector<std::byte> getTensorArgBuffer(
+    const PolymorphicValue& metadata,
+    PrimDataType index_type);
 
 } // namespace nvfuser

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -69,7 +69,6 @@ class Pointer {
 
   template <typename T>
   explicit operator T*() const {
-    TORCH_INTERNAL_ASSERT(size_ == sizeof(T));
     return static_cast<T*>(ptr_);
   }
 


### PR DESCRIPTION
Because it is deprecated in https://github.com/NVIDIA/Fuser/pull/644