### PR TITLE
Fix vectorization with reduction domains in fusion inputs

### DIFF
--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -1242,82 +1242,6 @@ std::shared_ptr<ReductionParams> persistentHeuristic(
   return rparams;
 }
 
-namespace {
-
-// Find the break point for vectorization. Here, we vectorize either
-// the innermost reduction or iteration domains. We use the producer
-// of the reduction as a reference of the vectorization
-// analsis.
-// Since this is for the normalization scheduler, the producer of
-// the normalization reduction should not have reduction domains,
-// except when it's a fusion input, in which case the reduction
-// domains should just be ignored.
-int64_t getVectorizationProducerBreakPoint(
-    TensorView* reduction_consumer,
-    int64_t inner_most_dimension_ndims,
-    TensorView* reduction_producer) {
-  const auto c2p =
-      PairwiseRootDomainMap(reduction_producer, reduction_consumer)
-          .mapConsumerToProducer(
-              reduction_consumer->domain(), reduction_producer->domain());
-  // Grab all the corresponding producer IDs that are mapped with the
-  // innermost consumer IDs
-  std::unordered_set<IterDomain*> producer_innermost_ids;
-
-  for (auto it = reduction_consumer->getRootDomain().begin() +
-           (reduction_consumer->nDims() - inner_most_dimension_ndims);
-       it != reduction_consumer->getRootDomain().end();
-       ++it) {
-    auto consumer_id = *it;
-    auto c2p_it = c2p.find(consumer_id);
-    // Since this is for a reduction op, there must be a mapped
-    // producer ID
-    TORCH_INTERNAL_ASSERT(c2p_it != c2p.end());
-    auto producer_id = c2p_it->second;
-    producer_innermost_ids.insert(producer_id);
-  }
-
-  // Find the conrresponding producer break point. To the right of the
-  // break point, there must be only the producer innermost IDs or
-  // reduction IDs
-  int64_t break_point = (int64_t)(reduction_producer->nDims());
-  int num_detected_producer_innermost_ids = 0;
-  for (auto it = reduction_producer->getMaybeRFactorDomain().rbegin();
-       it != reduction_producer->getMaybeRFactorDomain().rend();
-       ++it) {
-    auto producer_rf_id = *it;
-    if (producer_rf_id->isReduction()) {
-      TORCH_INTERNAL_ASSERT(
-          reduction_producer->isFusionInput(),
-          "Unexpected producer of reduction: ",
-          reduction_producer->toString());
-      --break_point;
-      continue;
-    }
-
-    if (producer_innermost_ids.count(producer_rf_id)) {
-      --break_point;
-      ++num_detected_producer_innermost_ids;
-      // If all innermost IDs are found, stop shifting the break point
-      // further
-      if (num_detected_producer_innermost_ids ==
-          (int64_t)producer_innermost_ids.size()) {
-        break;
-      }
-      continue;
-    }
-
-    // Neither reduction nor mapped to consumer innermost IDs.
-    // This should not happen
-    TORCH_INTERNAL_ASSERT(
-        false, "Unexpected producer RF ID: ", producer_rf_id->toString())
-  }
-
-  return break_point;
-}
-
-} // namespace
-
 std::shared_ptr<ReductionParams> getPersistentHeuristics(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
@@ -1470,8 +1394,8 @@ std::shared_ptr<ReductionParams> getPersistentHeuristics(
       runtime_info,
       reduced_tv,
       data_cache,
-      getVectorizationProducerBreakPoint(
-          first_red_tv, properties.inner_most_dimension_ndims, reduced_tv));
+      vectorize_helper::getVectorizationBreakPointOfReductionProducer(
+          first_red_tv, reduced_tv, properties.inner_most_dimension_ndims));
 
   // Base max dtype and n_tensor_inputs on tensors that are vectorizable (i.e.
   // share inner dimension with data pattern we're looking at).

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -945,7 +945,8 @@ std::shared_ptr<ReductionParams> getReductionHeuristics(
       runtime_info,
       reduced_tv,
       data_cache,
-      (int)(reduced_tv->nDims() - properties.inner_most_dimension_ndims));
+      vectorize_helper::getVectorizationBreakPointOfReductionProducer(
+          reduction_tv, reduced_tv, properties.inner_most_dimension_ndims));
 
   // Base max dtype and n_tensor_inputs on tensors that are vectorizable (i.e.
   // share inner dimension with data pattern we're looking at).

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -92,8 +92,10 @@ ContiguousInnerDimensionsMapper::ContiguousInnerDimensionsMapper(
   std::vector<IterDomain*> reordered_rfactor;
   for (auto id : reference->getMaybeRFactorDomain()) {
     // Exclude reduction IDs if the reference is a fusion input as they
-    // don't manifest at all in the fusion. This simplifies following
-    // analyses
+    // don't manifest at all in the fusion. This simplifies the
+    // analysis in getContigMergeOfInnerSize, which only looks at
+    // non-reduction rfactor domains. Including reduction domains here
+    // can result in incorrect ordering
     if (reference->isFusionInput() && id->isReduction()) {
       continue;
     }

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -802,7 +802,7 @@ int64_t getVectorizationFactor(
     SchedulerRuntimeInfo& runtime_info,
     TensorView* reference_tv,
     HeuristicSummary* data_cache,
-    int break_point) {
+    int64_t break_point) {
   auto vectorizable_inputs_outputs_entry =
       HeuristicSummaryEntry<HeuristicCompileTime::VectorizableInputsAndOutputs>(
           data_cache, [&reference_tv]() {
@@ -894,7 +894,7 @@ int64_t getVectorizationBreakPointOfReductionProducer(
   // innermost consumer IDs
   std::unordered_set<IterDomain*> producer_innermost_ids;
   for (auto it = reduction_consumer->getRootDomain().begin() +
-           (reduction_consumer->nDims() - consumer_innermost_ndims);
+           ((int64_t)reduction_consumer->nDims() - consumer_innermost_ndims);
        it != reduction_consumer->getRootDomain().end();
        ++it) {
     auto consumer_id = *it;

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -99,6 +99,13 @@ ContiguousInnerDimensionsMapper::ContiguousInnerDimensionsMapper(
     if (reference->isFusionInput() && id->isReduction()) {
       continue;
     }
+    // If not a fusion input, can this be a reduction domain?
+    TORCH_INTERNAL_ASSERT(
+        !id->isReduction(),
+        "Unexpected reduction domain: ",
+        id->toString(),
+        " of tensor ",
+        reference->toString());
     if (std::find(reference_ids.begin(), reference_ids.end(), id) !=
         reference_ids.end()) {
       reordered_rfactor.push_back(id);

--- a/csrc/scheduler/vectorize_helper.h
+++ b/csrc/scheduler/vectorize_helper.h
@@ -304,5 +304,23 @@ int64_t getVectorizationFactor(
     HeuristicSummary* data_cache,
     int break_point);
 
+//! Find the break point for vectorization. Here, we vectorize either
+//! the innermost reduction or iteration domains. We use the producer
+//! of the reduction as a reference of the vectorization
+//! analsis.
+//
+//! Since this is for the reduction and normalization schedulers, the
+//! producer of the reduction should not have reduction domains,
+//! except when it's a fusion input, in which case the reduction
+//! domains of the producer should just be ignored.
+//
+//! \param reduction_consumer
+//! \param reduction_producer
+//! \param consumer_innermost_ndims Innermost consumer domains to vectorize
+int64_t getVectorizationBreakPointOfReductionProducer(
+    TensorView* reduction_consumer,
+    TensorView* reduction_producer,
+    int64_t consumer_innermost_ndims);
+
 } // namespace vectorize_helper
 } // namespace nvfuser

--- a/csrc/scheduler/vectorize_helper.h
+++ b/csrc/scheduler/vectorize_helper.h
@@ -302,7 +302,7 @@ int64_t getVectorizationFactor(
     SchedulerRuntimeInfo& runtime_info,
     TensorView* reference_tv,
     HeuristicSummary* data_cache,
-    int break_point);
+    int64_t break_point);
 
 //! Find the break point for vectorization. Here, we vectorize either
 //! the innermost reduction or iteration domains. We use the producer


### PR DESCRIPTION
Issue #658 is because we are using the number of consumer domains to compute a position in its producer tensor. Since a producer may have reduction IDs that the consumer do not have, the computed position can result in larger than intended, making fewer number of vectorized innermost domains. This issue happens only with the reduction and normalization schedulers.

Fixes #658 
