### PR TITLE
Simplification of predicate elimination conditions

### DIFF
--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -18,6 +18,7 @@
 #include <ops/arith.h>
 #include <root_domain_map.h>
 
+#include <expr_simplifier.h>
 #include <algorithm>
 
 // TODO: refactor this file (one per namespace)
@@ -760,6 +761,16 @@ bool isScalarExpr(Expr* expr) {
     }
   }
   return true;
+}
+
+bool isExtentEqualToMaxParallelTypeExtent(const IterDomain* id) {
+  const auto& parallel_dim_map = GpuLower::current()->parallelDimensionMap();
+  auto* pdm_max_extent = parallel_dim_map.get(id->getParallelType());
+  if (nullptr == pdm_max_extent) {
+    return false;
+  }
+  auto* is_exact_val = IrBuilder::eqExpr(id->extent(), pdm_max_extent);
+  return simplifyExpr(is_exact_val)->isTrue();
 }
 
 } // namespace lower_utils

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -287,6 +287,11 @@ bool supportInlinePredicate(Expr* expr);
 //! Test if an expression is a scalar expression.
 bool isScalarExpr(Expr* expr);
 
+//! Test if provided IterDomain instance has an extent that matches maximum
+//!  extent stored in parallel dimension map for parallel type of provided
+//!  IterDomain object.
+bool isExtentEqualToMaxParallelTypeExtent(const IterDomain* id);
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -888,7 +888,7 @@ void validateMmaTensors(MmaOp* mma) {
           const auto& paralel_dim_map =
               GpuLower::current()->parallelDimensionMap();
           TORCH_INTERNAL_ASSERT(
-              paralel_dim_map.isExact(ptype) &&
+              lower_utils::isExtentEqualToMaxParallelTypeExtent(id) &&
                   paralel_dim_map.get(ptype)->isConstInt() &&
                   paralel_dim_map.get(ptype)->evaluateInt() ==
                       at::cuda::warp_size(),

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -1049,7 +1049,7 @@ Val* productOfFactors(
     DataType default_dtype) {
   if (const_factor == nullptr) {
     if (symbolic_factors.empty()) {
-      return IrBuilder::newConstant(1, default_dtype);
+      return IrBuilder::newConstant(1L, default_dtype);
     }
     return maybeFlattenedOpOf(BinaryOpType::Mul, std::move(symbolic_factors));
   }

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -2805,8 +2805,7 @@ bool canOmitStopPredicate(
   // exact. Otherwise, there would be extra threads/blocks that need
   // to be predicated out.
   if (isParallelTypeThread(contig_id->getParallelType())) {
-    if (!gpu_lower->parallelDimensionMap().isExact(
-            contig_id->getParallelType())) {
+    if (!lower_utils::isExtentEqualToMaxParallelTypeExtent(contig_id)) {
       return false;
     }
     // If the domain has halo, the loop is expanded by the halo

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1403,7 +1403,7 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
       strides[i] = IrBuilder::getItemExpr(
           IrBuilder::getAttrExpr(
               IrBuilder::metadataExpr(producer_tv), "alloc_stride"),
-          stride_i++);
+          (int64_t)stride_i++);
     }
   }
 
@@ -1759,7 +1759,7 @@ std::vector<Val*> Index::getStrides(TensorView* tv) {
       }
       strides[i] = IrBuilder::getItemExpr(
           IrBuilder::getAttrExpr(IrBuilder::metadataExpr(tv), "alloc_stride"),
-          stride_i++);
+          (int64_t)stride_i++);
     }
   }
 

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -17,6 +17,7 @@
 #include <transform_iter.h>
 
 #include <c10/util/irange.h>
+#include <device_lower/utils.h>
 
 namespace nvfuser {
 
@@ -159,7 +160,7 @@ ParallelizedDomainPredicate::getPredicateMap(
 
     // Not necessary to add a predicate if the paralle type is exact
     if (!isParallelTypeThread(loop_ptype) ||
-        gpu_lower->parallelDimensionMap().isExact(loop_ptype)) {
+        lower_utils::isExtentEqualToMaxParallelTypeExtent(loop_id)) {
       continue;
     }
     auto parallel_dim = gpu_lower->parallelDimensionMap().getRaw(loop_ptype);

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -340,8 +340,12 @@ std::vector<PolymorphicValue> GetMetaData::evaluate(
       PolymorphicValue(Pointer(input.data_ptr(), tv->dtype()));
   concrete_value["logical_size"] = PolymorphicValue(input.sizes().vec());
   concrete_value["logical_stride"] = PolymorphicValue(input.strides().vec());
-  std::tie(concrete_value["alloc_size"], concrete_value["alloc_stride"]) =
-      inferAndValidateAllocationSizesAndStrides(input, tv, ee);
+  {
+    auto allocation_data =
+        inferAndValidateAllocationSizesAndStrides(input, tv, ee);
+    concrete_value["alloc_size"] = std::move(allocation_data.first);
+    concrete_value["alloc_stride"] = std::move(allocation_data.second);
+  }
   return {PolymorphicValue(concrete_value)};
 }
 


### PR DESCRIPTION
The core change introduced by this PR is loosing requirements for predicate elimination,
a result of adding support for bias epilogue in matmul scheduler.

Previous behaviour:
One of conditions required for predicate elimination was that for parallel type of
the domain the stored in parallel dimension map extend was exact, that is, all
domains with the parallel type have same extent,

New behaviour:
Instead of checking if extent for given parallel type in parallel dimension map is exact,
we check if this domain's extent is same/equal to stored extent in parallel dimension
map for given parallel type.