### PR TITLE
refactor `getKernelArgument` and `getTensorArgBuffer`

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1839,10 +1839,10 @@ float FusionExecutor::runRtc(
     dtype.field_names = {"data", "logical_size", "alloc_stride"};
     dtype.types["data"] = NVFUSER_MAYBE_MAKE_SHARED(PointerOf{
         std::make_shared<DataType>(aten_to_data_type(input.scalar_type()))});
-    dtype.types["logical_size"] = NVFUSER_MAYBE_MAKE_SHARED2(
-        ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)input.dim()});
-    dtype.types["alloc_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(
-        ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)input.dim()});
+    dtype.types["logical_size"] = NVFUSER_MAYBE_MAKE_SHARED2(ArrayOf{
+        std::make_shared<DataType>(DataType::Index), (size_t)input.dim()});
+    dtype.types["alloc_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(ArrayOf{
+        std::make_shared<DataType>(DataType::Index), (size_t)input.dim()});
 
     Struct<PolymorphicValue> concrete_value;
     concrete_value["data"] = PolymorphicValue(
@@ -1850,7 +1850,8 @@ float FusionExecutor::runRtc(
     concrete_value["logical_size"] = PolymorphicValue(input.sizes().vec());
     concrete_value["alloc_stride"] = PolymorphicValue(input.strides().vec());
 
-    data.emplace_back(getKernelArgumentData(concrete_value, dtype, index_type));
+    data.emplace_back(
+        polymorphicValueToBytes(concrete_value, dtype, index_type));
     pointers.emplace_back(data.back().data());
   }
 

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1835,12 +1835,22 @@ float FusionExecutor::runRtc(
   std::vector<void*> pointers;
 
   for (const auto& input : args) {
+    StructOf dtype;
+    dtype.field_names = {"data", "logical_size", "alloc_stride"};
+    dtype.types["data"] = NVFUSER_MAYBE_MAKE_SHARED(PointerOf{
+        std::make_shared<DataType>(aten_to_data_type(input.scalar_type()))});
+    dtype.types["logical_size"] = NVFUSER_MAYBE_MAKE_SHARED2(
+        ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)input.dim()});
+    dtype.types["alloc_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(
+        ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)input.dim()});
+
     Struct<PolymorphicValue> concrete_value;
     concrete_value["data"] = PolymorphicValue(
         Pointer(input.data_ptr(), aten_to_data_type(input.scalar_type())));
     concrete_value["logical_size"] = PolymorphicValue(input.sizes().vec());
     concrete_value["alloc_stride"] = PolymorphicValue(input.strides().vec());
-    data.emplace_back(getTensorArgBuffer(concrete_value, index_type));
+
+    data.emplace_back(getKernelArgumentData(concrete_value, dtype, index_type));
     pointers.emplace_back(data.back().data());
   }
 

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1835,14 +1835,8 @@ float FusionExecutor::runRtc(
   std::vector<void*> pointers;
 
   for (const auto& input : args) {
-    StructOf dtype;
-    dtype.field_names = {"data", "logical_size", "alloc_stride"};
-    dtype.types["data"] = NVFUSER_MAYBE_MAKE_SHARED(PointerOf{
-        std::make_shared<DataType>(aten_to_data_type(input.scalar_type()))});
-    dtype.types["logical_size"] = NVFUSER_MAYBE_MAKE_SHARED2(ArrayOf{
-        std::make_shared<DataType>(DataType::Index), (size_t)input.dim()});
-    dtype.types["alloc_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(ArrayOf{
-        std::make_shared<DataType>(DataType::Index), (size_t)input.dim()});
+    DataType metadata_type = globalTensorMetaData(
+        aten_to_data_type(input.scalar_type()), input.dim());
 
     Struct<PolymorphicValue> concrete_value;
     concrete_value["data"] = PolymorphicValue(
@@ -1851,7 +1845,7 @@ float FusionExecutor::runRtc(
     concrete_value["alloc_stride"] = PolymorphicValue(input.strides().vec());
 
     data.emplace_back(
-        polymorphicValueToBytes(concrete_value, dtype, index_type));
+        polymorphicValueToBytes(concrete_value, metadata_type, index_type));
     pointers.emplace_back(data.back().data());
   }
 

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -340,7 +340,8 @@ std::vector<std::byte> polymorphicValueToBytes(
     PrimDataType index_type) {
   if (argument.is<Struct>()) {
     TORCH_INTERNAL_ASSERT(
-        std::holds_alternative<StructOf>(dtype), "Expected StructOf type.");
+        std::holds_alternative<StructOf>(dtype.type),
+        "Expected StructOf type.");
     auto dtype_ = std::get<StructOf>(dtype.type);
     auto struct_ = argument.as<Struct>();
     std::vector<std::byte> buffer;

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -351,7 +351,7 @@ std::vector<std::byte> polymorphicValueToBytes(
     }
     return buffer;
   } else if (argument.is<at::Tensor>()) {
-    auto tensor = argument.as<at::Tensor>();
+    const auto& tensor = argument.as<at::Tensor>();
     TORCH_INTERNAL_ASSERT(
         tensor.is_cpu() && tensor.numel() == 1,
         "Only CPU scalar tensors are supported here. ",

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -334,7 +334,7 @@ void KernelArgumentHolder::pushTensorProxy(
   arguments_.push_back(getAbstractTensorArg(at::Tensor(meta_tensor)));
 }
 
-std::vector<std::byte> getKernelArgumentData(
+std::vector<std::byte> polymorphicValueToBytes(
     const PolymorphicValue& argument,
     const DataType& dtype,
     PrimDataType index_type) {
@@ -343,8 +343,10 @@ std::vector<std::byte> getKernelArgumentData(
     auto struct_ = argument.as<Struct>();
     std::vector<std::byte> buffer;
     for (const auto& field : dtype_.field_names) {
-      auto field_data = getKernelArgumentData(
-          struct_[field], NVFUSER_MAYBE_STAR dtype_.types.at(field), index_type);
+      auto field_data = polymorphicValueToBytes(
+          struct_[field],
+          NVFUSER_MAYBE_STAR dtype_.types.at(field),
+          index_type);
       buffer.insert(buffer.end(), field_data.begin(), field_data.end());
     }
     return buffer;
@@ -375,7 +377,7 @@ std::vector<std::byte> getKernelArgumentData(
     auto dtype_ = std::get<ArrayOf>(dtype.type);
     std::vector<std::byte> buffer;
     for (const auto& elem : argument.as<std::vector>()) {
-      auto elem_data = getKernelArgumentData(elem, *dtype_.type, index_type);
+      auto elem_data = polymorphicValueToBytes(elem, *dtype_.type, index_type);
       buffer.insert(buffer.end(), elem_data.begin(), elem_data.end());
     }
     return buffer;
@@ -457,14 +459,15 @@ std::vector<std::byte> getKernelArgument(
   PolymorphicValue pv = ee.evaluate(parameter);
   if (auto tv = dynamic_cast<TensorView*>(parameter)) {
     if (tv->isCpuScalar()) {
-      return getKernelArgumentData(pv, tv->dtype(), index_type);
+      return polymorphicValueToBytes(pv, tv->dtype(), index_type);
     } else {
       auto metadata_val = IrBuilder::metadataExpr(tv);
       auto metadata = ee.evaluate(metadata_val);
-      return getKernelArgumentData(metadata, metadata_val->dtype(), index_type);
+      return polymorphicValueToBytes(
+          metadata, metadata_val->dtype(), index_type);
     }
   }
-  return getKernelArgumentData(pv, parameter->dtype(), index_type);
+  return polymorphicValueToBytes(pv, parameter->dtype(), index_type);
 }
 
 } // namespace nvfuser

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -339,6 +339,8 @@ std::vector<std::byte> polymorphicValueToBytes(
     const DataType& dtype,
     PrimDataType index_type) {
   if (argument.is<Struct>()) {
+    TORCH_INTERNAL_ASSERT(
+        std::holds_alternative<StructOf>(dtype), "Expected StructOf type.");
     auto dtype_ = std::get<StructOf>(dtype.type);
     auto struct_ = argument.as<Struct>();
     std::vector<std::byte> buffer;
@@ -357,7 +359,13 @@ std::vector<std::byte> polymorphicValueToBytes(
         "Only CPU scalar tensors are supported here. ",
         "For GPU tensors, please use their metadata.");
     auto scalar_type = tensor.scalar_type();
-    TORCH_INTERNAL_ASSERT(dtype == aten_to_data_type(scalar_type));
+    TORCH_INTERNAL_ASSERT(
+        dtype == aten_to_data_type(scalar_type),
+        "Expected ",
+        dtype,
+        " but got ",
+        aten_to_data_type(scalar_type),
+        ".");
     std::vector<std::byte> buffer;
     buffer.reserve(tensor.element_size());
     buffer.insert(
@@ -366,7 +374,9 @@ std::vector<std::byte> polymorphicValueToBytes(
         (std::byte*)tensor.data_ptr() + tensor.element_size());
     return buffer;
   } else if (argument.is<Pointer>()) {
-    TORCH_INTERNAL_ASSERT(std::holds_alternative<PointerOf>(dtype.type));
+    TORCH_INTERNAL_ASSERT(
+        std::holds_alternative<PointerOf>(dtype.type),
+        "Expected PointerOf type.");
     void* ptr = (void*)argument;
     std::vector<std::byte> buffer;
     buffer.reserve(sizeof(void*));
@@ -374,6 +384,8 @@ std::vector<std::byte> polymorphicValueToBytes(
         buffer.end(), (std::byte*)&ptr, (std::byte*)&ptr + sizeof(void*));
     return buffer;
   } else if (argument.is<std::vector>()) {
+    TORCH_INTERNAL_ASSERT(
+        std::holds_alternative<ArrayOf>(dtype.type), "Expected ArrayOf type.");
     auto dtype_ = std::get<ArrayOf>(dtype.type);
     std::vector<std::byte> buffer;
     for (const auto& elem : argument.as<std::vector>()) {
@@ -400,7 +412,7 @@ std::vector<std::byte> polymorphicValueToBytes(
     }
   } else if (argument.is<bool>()) {
     bool v = argument.as<bool>();
-    TORCH_INTERNAL_ASSERT(dtype == DataType::Bool);
+    TORCH_INTERNAL_ASSERT(dtype == DataType::Bool, "Expected Bool type.");
     return std::vector<std::byte>((std::byte*)&v, (std::byte*)&v + 1);
   } else if (argument.is<double>()) {
     double v = argument.as<double>();

--- a/csrc/executor_kernel_arg.h
+++ b/csrc/executor_kernel_arg.h
@@ -472,7 +472,7 @@ class TORCH_CUDA_CU_API KernelArgumentHolder {
   std::optional<size_t> cache_id_ = std::nullopt;
 };
 
-std::vector<std::byte> getKernelArgumentData(
+std::vector<std::byte> polymorphicValueToBytes(
     const PolymorphicValue& argument,
     const DataType& dtype,
     PrimDataType index_type);

--- a/csrc/executor_kernel_arg.h
+++ b/csrc/executor_kernel_arg.h
@@ -472,8 +472,9 @@ class TORCH_CUDA_CU_API KernelArgumentHolder {
   std::optional<size_t> cache_id_ = std::nullopt;
 };
 
-std::vector<std::byte> getTensorArgBuffer(
-    const PolymorphicValue& metadata,
+std::vector<std::byte> getKernelArgumentData(
+    const PolymorphicValue& argument,
+    const DataType& dtype,
     PrimDataType index_type);
 
 std::vector<std::byte> getKernelArgument(

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -17,6 +17,26 @@
 
 namespace nvfuser {
 
+DataType globalTensorMetaData(DataType dtype, int64_t dim, int64_t alloc_dim) {
+  std::stringstream ss;
+  ss << "Tensor<" << tv->dtype() << ", " << dim << ", " << alloc_dim << ">";
+
+  StructOf tv_metadata;
+  tv_metadata.name = ss.str();
+  tv_metadata.field_names = {"data", "logical_size", "alloc_stride"};
+  tv_metadata.types["data"] =
+      NVFUSER_MAYBE_MAKE_SHARED(PointerOf{std::make_shared<DataType>(dtype)});
+  tv_metadata.types["logical_size"] = NVFUSER_MAYBE_MAKE_SHARED2(
+      ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)dim});
+  tv_metadata.types["logical_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(
+      ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)dim});
+  tv_metadata.types["alloc_size"] = NVFUSER_MAYBE_MAKE_SHARED2(
+      ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)alloc_dim});
+  tv_metadata.types["alloc_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(
+      ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)alloc_dim});
+  return tv_metadata;
+}
+
 DataType metaDataTypeOf(const Val* v) {
   auto tv = dynamic_cast<const TensorView*>(v);
   TORCH_INTERNAL_ASSERT(
@@ -29,24 +49,7 @@ DataType metaDataTypeOf(const Val* v) {
   size_t dim = TensorDomain::noReductions(tv->getMaybeRFactorDomain()).size();
   size_t alloc_dim =
       TensorDomain::noReductions(tv->getMaybeAllocationDomain()).size();
-
-  std::stringstream ss;
-  ss << "Tensor<" << tv->dtype() << ", " << dim << ", " << alloc_dim << ">";
-
-  StructOf tv_metadata;
-  tv_metadata.name = ss.str();
-  tv_metadata.field_names = {"data", "logical_size", "alloc_stride"};
-  tv_metadata.types["data"] = NVFUSER_MAYBE_MAKE_SHARED(
-      PointerOf{std::make_shared<DataType>(tv->dtype())});
-  tv_metadata.types["logical_size"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), dim});
-  tv_metadata.types["logical_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), dim});
-  tv_metadata.types["alloc_size"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), alloc_dim});
-  tv_metadata.types["alloc_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), alloc_dim});
-  return tv_metadata;
+  return globalTensorMetaData(tv->dtype(), dim, alloc_dim);
 }
 
 PrimDataType indexModeToDtype(KernelIndexMode index_mode) {

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -19,8 +19,8 @@ namespace nvfuser {
 
 DataType globalTensorMetaData(
     const DataType& dtype,
-    int64_t dim,
-    int64_t alloc_dim) {
+    size_t dim,
+    size_t alloc_dim) {
   std::stringstream ss;
   ss << "Tensor<" << dtype << ", " << dim << ", " << alloc_dim << ">";
 
@@ -30,13 +30,13 @@ DataType globalTensorMetaData(
   tv_metadata.types["data"] =
       NVFUSER_MAYBE_MAKE_SHARED(PointerOf{std::make_shared<DataType>(dtype)});
   tv_metadata.types["logical_size"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)dim});
+      ArrayOf{std::make_shared<DataType>(DataType::Index), dim});
   tv_metadata.types["logical_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)dim});
+      ArrayOf{std::make_shared<DataType>(DataType::Index), dim});
   tv_metadata.types["alloc_size"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)alloc_dim});
+      ArrayOf{std::make_shared<DataType>(DataType::Index), alloc_dim});
   tv_metadata.types["alloc_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), (size_t)alloc_dim});
+      ArrayOf{std::make_shared<DataType>(DataType::Index), alloc_dim});
   return tv_metadata;
 }
 

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -17,9 +17,12 @@
 
 namespace nvfuser {
 
-DataType globalTensorMetaData(DataType dtype, int64_t dim, int64_t alloc_dim) {
+DataType globalTensorMetaData(
+    const DataType& dtype,
+    int64_t dim,
+    int64_t alloc_dim) {
   std::stringstream ss;
-  ss << "Tensor<" << tv->dtype() << ", " << dim << ", " << alloc_dim << ">";
+  ss << "Tensor<" << dtype << ", " << dim << ", " << alloc_dim << ">";
 
   StructOf tv_metadata;
   tv_metadata.name = ss.str();

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -219,10 +219,10 @@ bool StructOf::operator==(const StructOf& other) const {
 
 DataType globalTensorMetaData(
     const DataType& dtype,
-    int64_t dim,
-    int64_t alloc_dim);
+    size_t dim,
+    size_t alloc_dim);
 
-inline DataType globalTensorMetaData(const DataType& dtype, int64_t dim) {
+inline DataType globalTensorMetaData(const DataType& dtype, size_t dim) {
   return globalTensorMetaData(dtype, dim, dim);
 }
 

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -222,7 +222,7 @@ DataType globalTensorMetaData(
     int64_t dim,
     int64_t alloc_dim);
 
-DataType globalTensorMetaData(const DataType& dtype, int64_t dim) {
+inline DataType globalTensorMetaData(const DataType& dtype, int64_t dim) {
   return globalTensorMetaData(dtype, dim, dim);
 }
 

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -217,6 +217,8 @@ bool StructOf::operator==(const StructOf& other) const {
 #endif
 }
 
+DataType globalTensorMetaData(DataType dtype, int64_t dim, int64_t alloc_dim = dim);
+
 class Val;
 //! Get the type of a Val's metadata, currently only supporting tensors
 DataType metaDataTypeOf(const Val* tv);

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -217,7 +217,14 @@ bool StructOf::operator==(const StructOf& other) const {
 #endif
 }
 
-DataType globalTensorMetaData(DataType dtype, int64_t dim, int64_t alloc_dim = dim);
+DataType globalTensorMetaData(
+    const DataType& dtype,
+    int64_t dim,
+    int64_t alloc_dim);
+
+DataType globalTensorMetaData(const DataType& dtype, int64_t dim) {
+  return globalTensorMetaData(dtype, dim, dim);
+}
 
 class Val;
 //! Get the type of a Val's metadata, currently only supporting tensors


### PR DESCRIPTION
1. `getTensorArgBuffer` is renamed as `polymorphicValueToBytes`. In the past, it was specifically to convert tensor metadata to byte buffer. Now it is used to convert all polymorphic values to byte buffers. This will allow us to support using arbitrary `PolymorphicValue` as kernel parameter.
2. `getKernelArgument` is refactored to use `polymorphicValueToBytes`