### PR TITLE
Add correctness tests for remaining unary-float operations

### DIFF
--- a/python_tests/Pytest.md
+++ b/python_tests/Pytest.md
@@ -3,10 +3,12 @@
 
 ## Usage
 
-* Run tests: `pytest python_tests/pytest_test_definitions.py`
-* Filter tests with `-k` option: `pytest python_tests/pytest_test_definitions.py -k var_mean`
-* Show all possible tests: `pytest python_tests/pytest_test_definitions.py --collect-only`
-* Filter all possible tests with `-k` option: `pytest python_tests/pytest_test_definitions.py --collect-only -k var_mean`
+<!-- TO DO: Rename pytest_ops.py to pytest_test_definition.py -->
+
+* Run tests: `pytest python_tests/pytest_ops.py`
+* Filter tests with `-k` option: `pytest python_tests/pytest_ops.py -k var_mean`
+* Show all possible tests: `pytest python_tests/pytest_ops.py --collect-only`
+* Filter all possible tests with `-k` option: `pytest python_tests/pytest_ops.py --collect-only -k var_mean`
 
 ## Dependencies
 * pytest

--- a/python_tests/pytest_opinfos.py
+++ b/python_tests/pytest_opinfos.py
@@ -85,6 +85,14 @@ fusion_input_ops.append(define_vector_input_opinfo)
 """ Start Unary-Float Operations """
 elementwise_unary_ops = []
 
+abs_opinfo = OpInfo(
+    lambda fd: fd.ops.abs,
+    "abs",
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.abs),
+)
+elementwise_unary_ops.append(abs_opinfo)
+
 acos_opinfo = OpInfo(
     lambda fd: fd.ops.acos,
     "acos",
@@ -97,7 +105,7 @@ elementwise_unary_ops.append(acos_opinfo)
 acosh_opinfo = OpInfo(
     lambda fd: fd.ops.acosh,
     "acosh",
-    domain=(-1, math.inf),
+    domain=Domain(-1, math.inf),
     sample_input_generator=elementwise_unary_generator,
     reference=_elementwise_unary_torch(torch.acosh),
 )
@@ -106,7 +114,7 @@ elementwise_unary_ops.append(acosh_opinfo)
 asin_opinfo = OpInfo(
     lambda fd: fd.ops.asin,
     "asin",
-    domain=(-1, 1),
+    domain=Domain(-1, 1),
     sample_input_generator=elementwise_unary_generator,
     reference=_elementwise_unary_torch(torch.asin),
 )
@@ -131,7 +139,7 @@ elementwise_unary_ops.append(atan_opinfo)
 atanh_opinfo = OpInfo(
     lambda fd: fd.ops.atanh,
     "atanh",
-    domain=(-1 + eps, 1 + eps),
+    domain=Domain(-1 + eps, 1 + eps),
     sample_input_generator=elementwise_unary_generator,
     reference=_elementwise_unary_torch(torch.atanh),
 )
@@ -175,7 +183,7 @@ erfcinv_opinfo = OpInfo(
     lambda fd: fd.ops.erfcinv,
     "erfcinv",
     dtypes=int_float_dtypes,
-    domain=(0.3, 0.7),
+    domain=Domain(0.3, 0.7),
     sample_input_generator=elementwise_unary_generator,
     reference=_elementwise_unary_torch(lambda x: torch.erfinv(1 - x)),
 )
@@ -185,7 +193,7 @@ erfinv_opinfo = OpInfo(
     lambda fd: fd.ops.erfinv,
     "erfinv",
     dtypes=int_float_dtypes,
-    domain=(-1, 1),
+    domain=Domain(-1, 1),
     sample_input_generator=elementwise_unary_generator,
     reference=_elementwise_unary_torch(torch.erfinv),
 )
@@ -221,7 +229,7 @@ lgamma_opinfo = OpInfo(
     lambda fd: fd.ops.lgamma,
     "lgamma",
     dtypes=int_float_dtypes,
-    domain=(-1.0 + eps, math.inf),
+    domain=Domain(-1.0 + eps, math.inf),
     sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
     reference=_elementwise_unary_torch(torch.lgamma),
 )
@@ -230,7 +238,7 @@ elementwise_unary_ops.append(lgamma_opinfo)
 log_opinfo = OpInfo(
     lambda fd: fd.ops.log,
     "log",
-    domain=(0, math.inf),
+    domain=Domain(0, math.inf),
     sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
     reference=_elementwise_unary_torch(torch.log),
 )
@@ -240,7 +248,7 @@ log10_opinfo = OpInfo(
     lambda fd: fd.ops.log10,
     "log10",
     dtypes=int_float_dtypes,
-    domain=(0, math.inf),
+    domain=Domain(0, math.inf),
     sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
     reference=_elementwise_unary_torch(torch.log10),
 )
@@ -250,7 +258,7 @@ log1p_opinfo = OpInfo(
     lambda fd: fd.ops.log1p,
     "log1p",
     dtypes=int_float_dtypes,
-    domain=(-1 + eps, math.inf),
+    domain=Domain(-1 + eps, math.inf),
     sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
     reference=_elementwise_unary_torch(torch.log1p),
 )
@@ -259,7 +267,7 @@ elementwise_unary_ops.append(log1p_opinfo)
 log2_opinfo = OpInfo(
     lambda fd: fd.ops.log2,
     "log2",
-    domain=(0, math.inf),
+    domain=Domain(0, math.inf),
     sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
     reference=_elementwise_unary_torch(torch.log2),
 )
@@ -268,7 +276,7 @@ elementwise_unary_ops.append(log2_opinfo)
 reciprocal_opinfo = OpInfo(
     lambda fd: fd.ops.reciprocal,
     "reciprocal",
-    domain=(0 + eps, math.inf),
+    domain=Domain(0 + eps, math.inf),
     sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
     reference=_elementwise_unary_torch(torch.reciprocal),
 )
@@ -277,7 +285,7 @@ elementwise_unary_ops.append(reciprocal_opinfo)
 rsqrt_opinfo = OpInfo(
     lambda fd: fd.ops.rsqrt,
     "rqrt",
-    domain=(0 + eps, math.inf),
+    domain=Domain(0 + eps, math.inf),
     sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
     reference=_elementwise_unary_torch(torch.rsqrt),
 )
@@ -310,7 +318,7 @@ elementwise_unary_ops.append(sinh_opinfo)
 sqrt_opinfo = OpInfo(
     lambda fd: fd.ops.sqrt,
     "sqrt",
-    domain=(0, math.inf),
+    domain=Domain(0, math.inf),
     sample_input_generator=elementwise_unary_generator,
     reference=_elementwise_unary_torch(torch.sqrt),
 )

--- a/python_tests/pytest_opinfos.py
+++ b/python_tests/pytest_opinfos.py
@@ -182,7 +182,7 @@ elementwise_unary_ops.append(erfc_opinfo)
 erfcinv_opinfo = OpInfo(
     lambda fd: fd.ops.erfcinv,
     "erfcinv",
-    dtypes=int_float_dtypes,
+    dtypes=(torch.float32, torch.float64,),
     domain=Domain(0.3, 0.7),
     sample_input_generator=elementwise_unary_generator,
     reference=_elementwise_unary_torch(lambda x: torch.erfinv(1 - x)),

--- a/python_tests/pytest_opinfos.py
+++ b/python_tests/pytest_opinfos.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Owner(s): ["module: nvfuser"]
 
+import math
 import torch
 import jax
 from pytest_core import OpInfo, ReferenceType, Domain
@@ -37,7 +38,7 @@ from pytest_input_generators import (
     var_mean_generator,
     where_error_generator,
 )
-from pytest_utils import float_complex_dtypes, ArgumentType
+from pytest_utils import int_float_dtypes, float_complex_dtypes, ArgumentType
 from functools import partial
 from typing import List
 

--- a/python_tests/pytest_opinfos.py
+++ b/python_tests/pytest_opinfos.py
@@ -182,7 +182,10 @@ elementwise_unary_ops.append(erfc_opinfo)
 erfcinv_opinfo = OpInfo(
     lambda fd: fd.ops.erfcinv,
     "erfcinv",
-    dtypes=(torch.float32, torch.float64,),
+    dtypes=(
+        torch.float32,
+        torch.float64,
+    ),
     domain=Domain(0.3, 0.7),
     sample_input_generator=elementwise_unary_generator,
     reference=_elementwise_unary_torch(lambda x: torch.erfinv(1 - x)),

--- a/python_tests/pytest_opinfos.py
+++ b/python_tests/pytest_opinfos.py
@@ -93,6 +93,246 @@ acos_opinfo = OpInfo(
 )
 elementwise_unary_ops.append(acos_opinfo)
 
+acosh_opinfo = OpInfo(
+    lambda fd: fd.ops.acosh,
+    "acosh",
+    domain=(-1, math.inf),
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.acosh),
+)
+elementwise_unary_ops.append(acosh_opinfo)
+
+asin_opinfo = OpInfo(
+    lambda fd: fd.ops.asin,
+    "asin",
+    domain=(-1, 1),
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.asin),
+)
+elementwise_unary_ops.append(asin_opinfo)
+
+asinh_opinfo = OpInfo(
+    lambda fd: fd.ops.asinh,
+    "asinh",
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.asinh),
+)
+elementwise_unary_ops.append(asinh_opinfo)
+
+atan_opinfo = OpInfo(
+    lambda fd: fd.ops.atan,
+    "atan",
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.atan),
+)
+elementwise_unary_ops.append(atan_opinfo)
+
+atanh_opinfo = OpInfo(
+    lambda fd: fd.ops.atanh,
+    "atanh",
+    domain=(-1 + eps, 1 + eps),
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.atanh),
+)
+elementwise_unary_ops.append(atanh_opinfo)
+
+cos_opinfo = OpInfo(
+    lambda fd: fd.ops.cos,
+    "cos",
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.cos),
+)
+elementwise_unary_ops.append(cos_opinfo)
+
+cosh_opinfo = OpInfo(
+    lambda fd: fd.ops.cosh,
+    "cosh",
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.cosh),
+)
+elementwise_unary_ops.append(cosh_opinfo)
+
+erf_opinfo = OpInfo(
+    lambda fd: fd.ops.erf,
+    "erf",
+    dtypes=int_float_dtypes,
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.erf),
+)
+elementwise_unary_ops.append(erf_opinfo)
+
+erfc_opinfo = OpInfo(
+    lambda fd: fd.ops.erfc,
+    "erfc",
+    dtypes=int_float_dtypes,
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.erfc),
+)
+elementwise_unary_ops.append(erfc_opinfo)
+
+erfcinv_opinfo = OpInfo(
+    lambda fd: fd.ops.erfcinv,
+    "erfcinv",
+    dtypes=int_float_dtypes,
+    domain=(0.3, 0.7),
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(lambda x: torch.erfinv(1 - x)),
+)
+elementwise_unary_ops.append(erfcinv_opinfo)
+
+erfinv_opinfo = OpInfo(
+    lambda fd: fd.ops.erfinv,
+    "erfinv",
+    dtypes=int_float_dtypes,
+    domain=(-1, 1),
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.erfinv),
+)
+elementwise_unary_ops.append(erfinv_opinfo)
+
+exp_opinfo = OpInfo(
+    lambda fd: fd.ops.exp,
+    "exp",
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.exp),
+)
+elementwise_unary_ops.append(exp_opinfo)
+
+exp2_opinfo = OpInfo(
+    lambda fd: fd.ops.exp2,
+    "exp2",
+    dtypes=int_float_dtypes,
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.exp2),
+)
+elementwise_unary_ops.append(exp2_opinfo)
+
+expm1_opinfo = OpInfo(
+    lambda fd: fd.ops.expm1,
+    "expm1",
+    dtypes=int_float_dtypes,
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.expm1),
+)
+elementwise_unary_ops.append(expm1_opinfo)
+
+lgamma_opinfo = OpInfo(
+    lambda fd: fd.ops.lgamma,
+    "lgamma",
+    dtypes=int_float_dtypes,
+    domain=(-1.0 + eps, math.inf),
+    sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
+    reference=_elementwise_unary_torch(torch.lgamma),
+)
+elementwise_unary_ops.append(lgamma_opinfo)
+
+log_opinfo = OpInfo(
+    lambda fd: fd.ops.log,
+    "log",
+    domain=(0, math.inf),
+    sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
+    reference=_elementwise_unary_torch(torch.log),
+)
+elementwise_unary_ops.append(log_opinfo)
+
+log10_opinfo = OpInfo(
+    lambda fd: fd.ops.log10,
+    "log10",
+    dtypes=int_float_dtypes,
+    domain=(0, math.inf),
+    sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
+    reference=_elementwise_unary_torch(torch.log10),
+)
+elementwise_unary_ops.append(log10_opinfo)
+
+log1p_opinfo = OpInfo(
+    lambda fd: fd.ops.log1p,
+    "log1p",
+    dtypes=int_float_dtypes,
+    domain=(-1 + eps, math.inf),
+    sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
+    reference=_elementwise_unary_torch(torch.log1p),
+)
+elementwise_unary_ops.append(log1p_opinfo)
+
+log2_opinfo = OpInfo(
+    lambda fd: fd.ops.log2,
+    "log2",
+    domain=(0, math.inf),
+    sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
+    reference=_elementwise_unary_torch(torch.log2),
+)
+elementwise_unary_ops.append(log2_opinfo)
+
+reciprocal_opinfo = OpInfo(
+    lambda fd: fd.ops.reciprocal,
+    "reciprocal",
+    domain=(0 + eps, math.inf),
+    sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
+    reference=_elementwise_unary_torch(torch.reciprocal),
+)
+elementwise_unary_ops.append(reciprocal_opinfo)
+
+rsqrt_opinfo = OpInfo(
+    lambda fd: fd.ops.rsqrt,
+    "rqrt",
+    domain=(0 + eps, math.inf),
+    sample_input_generator=partial(elementwise_unary_generator, exclude_zero=True),
+    reference=_elementwise_unary_torch(torch.rsqrt),
+)
+elementwise_unary_ops.append(rsqrt_opinfo)
+
+sigmoid_opinfo = OpInfo(
+    lambda fd: fd.ops.sigmoid,
+    "sigmoid",
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.sigmoid),
+)
+elementwise_unary_ops.append(sigmoid_opinfo)
+
+sin_opinfo = OpInfo(
+    lambda fd: fd.ops.sin,
+    "sin",
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.sin),
+)
+elementwise_unary_ops.append(sin_opinfo)
+
+sinh_opinfo = OpInfo(
+    lambda fd: fd.ops.sinh,
+    "sinh",
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.sinh),
+)
+elementwise_unary_ops.append(sinh_opinfo)
+
+sqrt_opinfo = OpInfo(
+    lambda fd: fd.ops.sqrt,
+    "sqrt",
+    domain=(0, math.inf),
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.sqrt),
+)
+elementwise_unary_ops.append(sqrt_opinfo)
+
+tan_opinfo = OpInfo(
+    lambda fd: fd.ops.tan,
+    "tan",
+    dtypes=int_float_dtypes,
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.tan),
+)
+elementwise_unary_ops.append(tan_opinfo)
+
+tanh_opinfo = OpInfo(
+    lambda fd: fd.ops.tanh,
+    "tanh",
+    dtypes=int_float_dtypes,
+    sample_input_generator=elementwise_unary_generator,
+    reference=_elementwise_unary_torch(torch.tanh),
+)
+elementwise_unary_ops.append(tanh_opinfo)
+
 """ End Unary-Float Operations """
 
 """ Start Ternary Operations """


### PR DESCRIPTION
This PR adds tests for the following operations:
- abs, acosh, asin, asinh, atan, atanh, cos, cosh, erf, erfc, erfcinv, erfinv, exp, exp2, expm1, lgamma, log, log10, log1p, log2, reciprocal, rsqrt, sign, sin, sinh, sqrt, tan, tanh

The `elementwise_unary_torch` input generator creates random values for a function's input domain. It does not test specific small, large, or extremal ('-inf', 'inf', 'nan') input values.
