### PR TITLE
cleanup `replaceValInIndexVal`

### DIFF
--- a/csrc/device_lower/pass/magic_zero.cpp
+++ b/csrc/device_lower/pass/magic_zero.cpp
@@ -166,7 +166,7 @@ IndexMagicZeroInfo protectIndexByReplacingLoopIndex(
   replacement_map[loop_index_to_protect] = protected_loop_index;
 
   auto protected_index =
-      ir_utils::replaceValInIndexVal(overall_index_val, replacement_map);
+      ir_utils::replaceValInDef(overall_index_val, replacement_map);
 
   IndexMagicZeroInfo info;
   info.index = protected_index;

--- a/csrc/device_lower/pass/magic_zero.cpp
+++ b/csrc/device_lower/pass/magic_zero.cpp
@@ -166,7 +166,7 @@ IndexMagicZeroInfo protectIndexByReplacingLoopIndex(
   replacement_map[loop_index_to_protect] = protected_loop_index;
 
   auto protected_index =
-      ir_utils::replaceValInDef(overall_index_val, replacement_map);
+      ir_utils::replaceValRecursively(overall_index_val, replacement_map);
 
   IndexMagicZeroInfo info;
   info.index = protected_index;

--- a/csrc/device_lower/pass/vectorize_welford.cpp
+++ b/csrc/device_lower/pass/vectorize_welford.cpp
@@ -412,7 +412,7 @@ class WelfordVectorizer : public kir::ExprMutator {
         GpuLower::current()->kernel()->zeroVal());
 
     Val* indices_zero =
-        ir_utils::replaceValInIndexVal(original_index, index_replacement_map);
+        ir_utils::replaceValInDef(original_index, index_replacement_map);
 
     auto hoisted_count =
         IrBuilder::create<kir::TensorIndex>(out_N->view(), indices_zero);

--- a/csrc/device_lower/pass/vectorize_welford.cpp
+++ b/csrc/device_lower/pass/vectorize_welford.cpp
@@ -412,7 +412,7 @@ class WelfordVectorizer : public kir::ExprMutator {
         GpuLower::current()->kernel()->zeroVal());
 
     Val* indices_zero =
-        ir_utils::replaceValInDef(original_index, index_replacement_map);
+        ir_utils::replaceValRecursively(original_index, index_replacement_map);
 
     auto hoisted_count =
         IrBuilder::create<kir::TensorIndex>(out_N->view(), indices_zero);

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -611,7 +611,7 @@ std::vector<ViewOp*> getViewOps(Fusion* fusion) {
   return view_ops;
 }
 
-Val* replaceValInIndexVal(
+Val* replaceValInDef(
     Val* val,
     const std::unordered_map<Val*, Val*>& replacement_map) {
   if (replacement_map.find(val) != replacement_map.end()) {
@@ -630,7 +630,7 @@ Val* replaceValInIndexVal(
   std::vector<Val*> mutated_inputs;
   mutated_inputs.reserve(def->inputs().size());
   for (auto input : def->inputs()) {
-    auto new_input = replaceValInIndexVal(input, replacement_map);
+    auto new_input = replaceValInDef(input, replacement_map);
     if (new_input != input) {
       mutated = true;
     }
@@ -641,7 +641,7 @@ Val* replaceValInIndexVal(
   mutated_attrs.reserve(def->attributes().size());
   for (auto attr : def->attributes()) {
     if (auto attr_val = dynamic_cast<Val*>(attr)) {
-      auto new_attr_val = replaceValInIndexVal(attr_val, replacement_map);
+      auto new_attr_val = replaceValInDef(attr_val, replacement_map);
       if (new_attr_val != attr_val) {
         mutated = true;
       }

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -611,102 +611,55 @@ std::vector<ViewOp*> getViewOps(Fusion* fusion) {
   return view_ops;
 }
 
-namespace {
-
-struct ReplaceValInIndexVal : public OptInDispatch {
- public:
-  //! Apply replacements to index as specified in
-  //! replacement_map. index is assumed to consist only from Int and
-  //! NamedScalar
-  static Val* replace(
-      Val* index,
-      const std::unordered_map<Val*, Val*>& replacement_map) {
-    ReplaceValInIndexVal replace_index_val(replacement_map);
-    replace_index_val.dispatch(index);
-    // Return the original index if not replaced
-    if (replace_index_val.is_replaced_) {
-      return replace_index_val.last_visited_val_;
-    } else {
-      return index;
-    }
-  }
-
- private:
-  ReplaceValInIndexVal(const std::unordered_map<Val*, Val*>& replacement_map)
-      : replacement_map_(replacement_map) {}
-
-  using OptOutDispatch::dispatch;
-  using OptOutDispatch::handle;
-
-  void dispatch(Val* val) override {
-    // if val appears in the replacement map, stop traversing and set
-    // the current val with the replacement
-    auto it = replacement_map_.find(val);
-    if (it != replacement_map_.end()) {
-      last_visited_val_ = it->second;
-      is_replaced_ = true;
-      return;
-    }
-
-    // Recursively traverse its defining expr
-    auto def = val->definition();
-    if (def != nullptr) {
-      if (def->isOneOf<UnaryOp, BinaryOp, TernaryOp>()) {
-        dispatch(val->definition());
-      } else {
-        TORCH_INTERNAL_ASSERT(false, "Unexpected definition: ", def->toString())
-      }
-      // last_visited_val_ is set in the expr handlers
-    } else {
-      last_visited_val_ = val;
-    }
-  }
-
-  // Clone expression after recurisvely replacing inputs
-  void handle(UnaryOp* uop) override {
-    dispatch(uop->in());
-    auto inp = last_visited_val_;
-    auto out = IrBuilder::create<Val>(uop->out()->dtype());
-    IrBuilder::create<UnaryOp>(uop->getUnaryOpType(), out, inp);
-    last_visited_val_ = out;
-  }
-
-  // Clone expression after recurisvely replacing inputs
-  void handle(BinaryOp* bop) override {
-    dispatch(bop->lhs());
-    auto lhs = last_visited_val_;
-    dispatch(bop->rhs());
-    auto rhs = last_visited_val_;
-    auto out = IrBuilder::create<Val>(bop->out()->dtype());
-    IrBuilder::create<BinaryOp>(bop->getBinaryOpType(), out, lhs, rhs);
-    last_visited_val_ = out;
-  }
-
-  // Clone expression after recurisvely replacing inputs
-  void handle(TernaryOp* top) override {
-    dispatch(top->in1());
-    auto in1 = last_visited_val_;
-    dispatch(top->in2());
-    auto in2 = last_visited_val_;
-    dispatch(top->in3());
-    auto in3 = last_visited_val_;
-    auto out = IrBuilder::create<Val>(top->out()->dtype());
-    IrBuilder::create<TernaryOp>(top->getTernaryOpType(), out, in1, in2, in3);
-    last_visited_val_ = out;
-  }
-
- private:
-  const std::unordered_map<Val*, Val*>& replacement_map_;
-  Val* last_visited_val_ = nullptr;
-  bool is_replaced_ = false;
-};
-
-} // namespace
-
 Val* replaceValInIndexVal(
-    Val* index,
+    Val* val,
     const std::unordered_map<Val*, Val*>& replacement_map) {
-  return ReplaceValInIndexVal::replace(index, replacement_map);
+  if (replacement_map.find(val) != replacement_map.end()) {
+    return replacement_map.at(val);
+  }
+
+  auto def = val->definition();
+  if (def == nullptr) {
+    return val;
+  }
+
+  TORCH_INTERNAL_ASSERT(def->outputs().size() == 1);
+
+  bool mutated = false;
+
+  std::vector<Val*> mutated_inputs;
+  mutated_inputs.reserve(def->inputs().size());
+  for (auto input : def->inputs()) {
+    auto new_input = replaceValInIndexVal(input, replacement_map);
+    if (new_input != input) {
+      mutated = true;
+    }
+    mutated_inputs.emplace_back(new_input);
+  }
+
+  std::vector<Statement*> mutated_attrs;
+  mutated_attrs.reserve(def->attributes().size());
+  for (auto attr : def->attributes()) {
+    if (auto attr_val = dynamic_cast<Val*>(attr)) {
+      auto new_attr_val = replaceValInIndexVal(attr_val, replacement_map);
+      if (new_attr_val != attr_val) {
+        mutated = true;
+      }
+      mutated_attrs.emplace_back(new_attr_val);
+    } else {
+      mutated_attrs.emplace_back(attr);
+    }
+  }
+
+  if (!mutated) {
+    return val;
+  }
+
+  auto out = IrBuilder::create<Val>(val->dtype());
+  auto newObjectFunc = def->newObjectFunc();
+  newObjectFunc(def->container(), mutated_inputs, {out}, mutated_attrs);
+
+  return out;
 }
 
 bool isSqueezeInput(const TensorView* tv) {

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -611,7 +611,7 @@ std::vector<ViewOp*> getViewOps(Fusion* fusion) {
   return view_ops;
 }
 
-Val* replaceValInDef(
+Val* replaceValRecursively(
     Val* val,
     const std::unordered_map<Val*, Val*>& replacement_map) {
   if (replacement_map.find(val) != replacement_map.end()) {
@@ -630,7 +630,7 @@ Val* replaceValInDef(
   std::vector<Val*> mutated_inputs;
   mutated_inputs.reserve(def->inputs().size());
   for (auto input : def->inputs()) {
-    auto new_input = replaceValInDef(input, replacement_map);
+    auto new_input = replaceValRecursively(input, replacement_map);
     if (new_input != input) {
       mutated = true;
     }
@@ -641,7 +641,7 @@ Val* replaceValInDef(
   mutated_attrs.reserve(def->attributes().size());
   for (auto attr : def->attributes()) {
     if (auto attr_val = dynamic_cast<Val*>(attr)) {
-      auto new_attr_val = replaceValInDef(attr_val, replacement_map);
+      auto new_attr_val = replaceValRecursively(attr_val, replacement_map);
       if (new_attr_val != attr_val) {
         mutated = true;
       }

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -173,14 +173,14 @@ TORCH_CUDA_CU_API Expr* replaceValInExpr(
     Val* reference,
     Val* substitute);
 
-//! Replace Vals in the definition of the given Val as specified by
-//! replacement_map while cloning the given Val.
+//! Recursively goes to the definition of the given Val and replace the Vals as
+//! specified by replacement_map while cloning the given Val.
 //!
 //! This is similar to replaceValInExpr but is different as Vals are
 //! cloned such that no other exprs using the same leaf Vals are not
 //! modified. TODO: Consider cleaning up the multiple replacement
 //! routines.
-Val* replaceValInDef(
+Val* replaceValRecursively(
     Val* val,
     const std::unordered_map<Val*, Val*>& replacement_map);
 

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -181,7 +181,7 @@ TORCH_CUDA_CU_API Expr* replaceValInExpr(
 //! cloned such that no other exprs using the same leaf Vals are not
 //! modified. TODO: Consider cleaning up the multiple replacement
 //! routines.
-Val* replaceValInIndexVal(
+Val* replaceValInDef(
     Val* val,
     const std::unordered_map<Val*, Val*>& replacement_map);
 

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -173,9 +173,8 @@ TORCH_CUDA_CU_API Expr* replaceValInExpr(
     Val* reference,
     Val* substitute);
 
-//! Replace Vals in an index Val as specified by replacement_map while
-//! cloning the given index Val. The index val is assumed to represent
-//! a tensor index consisting of Ints and arithmetic expressions.
+//! Replace Vals in the definition of the given Val as specified by
+//! replacement_map while cloning the given Val.
 //!
 //! This is similar to replaceValInExpr but is different as Vals are
 //! cloned such that no other exprs using the same leaf Vals are not

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -182,7 +182,7 @@ TORCH_CUDA_CU_API Expr* replaceValInExpr(
 //! modified. TODO: Consider cleaning up the multiple replacement
 //! routines.
 Val* replaceValInIndexVal(
-    Val* index,
+    Val* val,
     const std::unordered_map<Val*, Val*>& replacement_map);
 
 // Makes rfactor generic with reduction ops and Welford


### PR DESCRIPTION
Rename `replaceValInIndexVal` into `replaceValInDef`, make it support all expr types.