### PR TITLE
Evaluate bitwise operations properly in ExpressionEvaluator

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -437,12 +437,21 @@ std::vector<PolymorphicValue> BinaryOp::evaluate(
       return {ceildiv(lhs, rhs)};
       break;
     case BinaryOpType::And:
-      return {lhs && rhs};
+      if (lhs.is<bool>() && rhs.is<bool>()) {
+        return {lhs && rhs};
+      }
+      return {lhs & rhs};
       break;
     case BinaryOpType::Or:
-      return {lhs || rhs};
+      if (lhs.is<bool>() && rhs.is<bool>()) {
+        return {lhs || rhs};
+      }
+      return {lhs | rhs};
       break;
     case BinaryOpType::Xor:
+      if (lhs.is<bool>() && rhs.is<bool>()) {
+        return {lhs != rhs};
+      }
       return {lhs ^ rhs};
       break;
     case BinaryOpType::Eq:

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -9748,6 +9748,39 @@ TEST_F(NVFuserTest, AllInputDtypes) {
   }
 }
 
+// Test bitwise operations on ints in ExpressionEvaluator
+TEST_F(NVFuserTest, ExpressionEvaluatorBitwise) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto s0 = IrBuilder::create<Val>(17);
+  auto s1 = IrBuilder::create<Val>(31);
+
+  auto s2 = bitwise_and(s0, s1);
+  auto s3 = bitwise_or(s0, s1);
+  auto s4 = bitwise_xor(s0, s1);
+
+  ExpressionEvaluator ee;
+
+  for (auto s : {s2, s3, s4}) {
+    auto pv = ee.evaluate(s);
+    TORCH_CHECK(
+        pv.hasValue(), "Could not evaluate scalar ", s->toInlineString());
+    TORCH_CHECK(
+        !pv.is<bool>(),
+        "Scalar ",
+        s->toInlineString(),
+        " evaluates to bool value ",
+        pv);
+    TORCH_CHECK(
+        pv.is<int64_t>(),
+        "Scalar ",
+        s->toInlineString(),
+        " should be int64_t but found ",
+        pv);
+  }
+}
+
 // Test file size should be up to 10K LoC. Create a new file for more tests.
 
 } // namespace nvfuser


### PR DESCRIPTION
Currently, we implement `BinaryOpType::And` evaluation via `a && b` when evaluating a scalar expression. This is incorrect when one of the inputs is an integer. This bug can hide when evaluating large expressions since the `bool` value returned will be promoted back to integer.

This PR fixes this behavior by modifying `BinaryOp::evaluate` for the cases `And`, `Or`, and `Xor` to use `&&`, `||`, `!=` when both inputs are boolean, and `&`, `|`, and `^` otherwise.