### PR TITLE
Do not `resolveIndexDtype` in lowering

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -270,21 +270,15 @@ void GpuLower::lower(Fusion* fusion) {
   } lower_guard(this);
 
   // Use int64 by default as the kernel index type
-  auto kernel_index_type = cparams_.index_type.has_value()
-      ? cparams_.index_type.value()
-      : PrimDataType::Int;
+  if (!cparams_.index_type.has_value()) {
+    cparams_.index_type = PrimDataType::Int;
+  }
 
   // Copy fusion into a new kernel for processing
-  kernel_ = std::make_unique<kir::Kernel>(fusion, kernel_index_type);
+  kernel_ = std::make_unique<kir::Kernel>(fusion, indexType());
   // Alias the fusion kernel caries around as a view of itself.
   fusion_ = kernel_.get();
 
-  // Convert tensor views of DataType::Index type to either Int or Int32
-  for (auto tv : ir_utils::allTvs(fusion_)) {
-    if (tv->dtype() == DataType::Index) {
-      tv->resolveIndexDtype();
-    }
-  }
   segmenterHintCleanup(fusion_);
   FusionGuard fg(fusion_);
 

--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -70,6 +70,10 @@ class TORCH_CUDA_CU_API GpuLower : public NonCopyable {
   //! Query if lowering is in progress
   static bool hasCurrent();
 
+  const PrimDataType& indexType() const {
+    return cparams_.index_type.value();
+  }
+
   std::shared_ptr<const ConcretizedBroadcastDomains>
   concretizedBroadcastDomains() {
     return concretized_broadcast_domains_;

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -1062,8 +1062,10 @@ class ReusableAllocationFinder : private kir::IrVisitor {
             continue;
           }
         } else if (
-            dataTypeSize(alloc_info->data_type) !=
-            dataTypeSize(alloc_to_reuse->data_type)) {
+            dataTypeSize(
+                alloc_info->data_type, GpuLower::current()->indexType()) !=
+            dataTypeSize(
+                alloc_to_reuse->data_type, GpuLower::current()->indexType())) {
           // Behavior for shared or global memory and default behavior for
           // registers is to re-use if dtypes have same size.
           continue;

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -1013,7 +1013,8 @@ void validateSizeMemoryOp(LoadStoreOp* ldst) {
       break;
     }
   }
-  byte_size *= (int)dataTypeSize(*output->getDataType());
+  byte_size *= (int)dataTypeSize(
+      *output->getDataType(), GpuLower::current()->indexType());
   switch (ldst->opType()) {
     case LoadStoreOpType::CpAsyncCg:
       TORCH_CHECK(byte_size == 16, "Not supported byte size for cp.async.cg");

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -429,7 +429,9 @@ class VectorizeValidator : public OptInDispatch {
 
     auto vector_word_size = v_id->extent()->evaluateInt();
     auto vector_size =
-        ((int64_t)dataTypeSize(tv->getDataType().value())) * vector_word_size;
+        ((int64_t)dataTypeSize(
+            tv->getDataType().value(), GpuLower::current()->indexType())) *
+        vector_word_size;
 
     // Allow half2, float2, float4 and same sized vtypes.
     std::array<int64_t, 4> allowed_vector_sizes = {2, 4, 8, 16}; // NOLINT

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -477,14 +477,15 @@ void NaiveValueMachine::runUnaryOp(int index) {
       dest = -src;
       break;
     case UnaryOpType::Cast:
-      if (data_type_[index] == DataType::Double) {
+      if (isFloatingPointType(data_type_[index])) {
         dest = PolymorphicValue((double)src);
-      } else if (data_type_[index] == DataType::Int) {
+      } else if (isIntegralType(data_type_[index])) {
         dest = PolymorphicValue((int64_t)src);
       } else if (data_type_[index] == DataType::Bool) {
         dest = PolymorphicValue((bool)src);
       } else {
-        TORCH_INTERNAL_ASSERT(false, "dtype not supported in evaluator");
+        TORCH_INTERNAL_ASSERT(
+            false, "dtype not supported in evaluator: ", data_type_[index]);
       }
       break;
     case UnaryOpType::Abs:

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -167,7 +167,9 @@ void FusionExecutor::debugCompileFusionFromStr(
   if (!kernel_summary.static_smem_allocations.empty()) {
     ExpressionEvaluator static_evaluator;
     const auto static_smem_size = computeSharedMemory(
-        static_evaluator, kernel_summary.static_smem_allocations);
+        static_evaluator,
+        kernel_summary.static_smem_allocations,
+        kernel->indexType());
     TORCH_INTERNAL_ASSERT(
         static_smem_size < max_static_smem_,
         "The static shared memory allocation is larger than available memory.");
@@ -320,7 +322,9 @@ void FusionExecutor::compileFusion(
   if (!kernel_summary.static_smem_allocations.empty()) {
     ExpressionEvaluator static_evaluator;
     const auto static_smem_size = computeSharedMemory(
-        static_evaluator, kernel_summary.static_smem_allocations);
+        static_evaluator,
+        kernel_summary.static_smem_allocations,
+        kernel->indexType());
     TORCH_INTERNAL_ASSERT(
         static_smem_size < max_static_smem_,
         "The static shared memory allocation is larger than available memory.");
@@ -341,8 +345,8 @@ void FusionExecutor::compileFusion(
   std::optional<int64_t> block_size = std::nullopt;
   if (!args.empty()) {
     auto expr_eval = executor_utils::bindInputs(args, kernel);
-    auto launch_params =
-        computeLaunchParams(launch_constraints, expr_eval, warp_size_);
+    auto launch_params = computeLaunchParams(
+        launch_constraints, expr_eval, warp_size_, kernel->indexType());
     block_size = launch_params.nThreads();
     dynamic_smem = launch_params.smem();
     TORCH_INTERNAL_ASSERT(
@@ -924,6 +928,7 @@ std::vector<at::Tensor> allocOutputs(
 int64_t FusionExecutor::computeSharedMemory(
     ExpressionEvaluator& expr_eval,
     const std::vector<const kir::Allocate*>& buffers,
+    DataType index_type,
     int64_t smem_offset) {
   FUSER_PERF_SCOPE("computeSharedMemory");
   int64_t total = smem_offset;
@@ -961,7 +966,8 @@ int64_t FusionExecutor::computeSharedMemory(
           smem_alloc->buffer()->name());
 
       const auto first_byte = smem_offset + address_val.as<int64_t>();
-      const auto data_size = dataTypeSize(smem_alloc->buffer()->dtype());
+      const auto data_size =
+          dataTypeSize(smem_alloc->buffer()->dtype(), index_type);
       const int64_t size_bytes = size_val.as<int64_t>() * data_size;
       const auto last_byte = first_byte + size_bytes;
 
@@ -974,7 +980,8 @@ int64_t FusionExecutor::computeSharedMemory(
 LaunchParams FusionExecutor::computeLaunchParams(
     const LaunchParams& launch_constraints,
     ExpressionEvaluator& expr_eval,
-    const int64_t warp_size) {
+    const int64_t warp_size,
+    DataType index_type) {
   FUSER_PERF_SCOPE("FusionExecutor::ComputeLaunchParams");
   TORCH_INTERNAL_ASSERT(warp_size > 0, "WARP_SIZE should be larger than 0");
 
@@ -1092,7 +1099,8 @@ LaunchParams FusionExecutor::computeLaunchParams(
         kernel_summary.has_block_welford || kernel_summary.has_grid_welford ? 3
                                                                             : 1;
     reduction_broadcast_workspace =
-        (int64_t)dataTypeSize(kernel_summary.largest_smem_data_type) *
+        (int64_t)dataTypeSize(
+            kernel_summary.largest_smem_data_type, index_type) *
         welford_factor * launch_params.bdimx() * launch_params.bdimy() *
         launch_params.bdimz();
 
@@ -1106,6 +1114,7 @@ LaunchParams FusionExecutor::computeLaunchParams(
   const auto dynamic_smem_size = computeSharedMemory(
       expr_eval,
       kernel_summary.dynamic_smem_allocations,
+      index_type,
       reduction_broadcast_workspace);
 
   // Check that requested smem size can be dynamically allocated.
@@ -1122,7 +1131,9 @@ LaunchParams FusionExecutor::computeLaunchParams(
 }
 
 std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::
-    getIntermediateBufferInfo(ExpressionEvaluator& expr_eval) {
+    getIntermediateBufferInfo(
+        ExpressionEvaluator& expr_eval,
+        DataType index_type) {
   FUSER_PERF_SCOPE("FusionExecutor::GetIntermediateBufferInfo");
 
   std::vector<GlobalBufferInfo> global_buffers;
@@ -1142,7 +1153,8 @@ std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::
     info.zero_init = alloc->zeroInit();
     std::tie(info.sizes, info.strides) =
         inferShapeOfIntermediate(tv, alloc, expr_eval);
-    info.type = data_type_to_aten(tv->dtype());
+    auto dtype = (tv->dtype() == DataType::Index ? index_type : tv->dtype());
+    info.type = data_type_to_aten(dtype);
 
     // Remember the tensor buffer used for storing kernel profile
     if (isOptionEnabled(EnableOption::KernelProfile) &&
@@ -1397,15 +1409,16 @@ void FusionExecutor::initializeExecutorEntry(
     const KernelArgumentHolder& args,
     const LaunchParams& launch_constraints,
     const CompileParams& compile_params,
-    const std::vector<at::Tensor>& outputs) {
+    const std::vector<at::Tensor>& outputs,
+    DataType index_type) {
   FUSER_PERF_SCOPE("ExecutorRunFusion::InitializeExecutorEntry");
 
   ExpressionEvaluator expr_eval;
   evaluatorPrecomputedValues()->bindInputs(args);
   expr_eval.precomputedValues() = evaluatorPrecomputedValues().get();
 
-  auto launch_params =
-      computeLaunchParams(launch_constraints, expr_eval, warp_size_);
+  auto launch_params = computeLaunchParams(
+      launch_constraints, expr_eval, warp_size_, index_type);
 
   executor_utils::validateVectorizedTensors(
       kernel(), args, outputs, compileTimeDataCache(), expr_eval);
@@ -1433,7 +1446,7 @@ void FusionExecutor::initializeExecutorEntry(
     }
   }
 
-  auto intermediates = getIntermediateBufferInfo(expr_eval);
+  auto intermediates = getIntermediateBufferInfo(expr_eval, index_type);
 
   // All information is gathered. Save it to ExecutorEntry
   executor_entry.launch_params = launch_params;
@@ -1577,7 +1590,12 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   // Initialize the executor entry if not initlized
   if (!executor_entry->init) {
     initializeExecutorEntry(
-        *executor_entry, args, launch_constraints, compile_params, outputs);
+        *executor_entry,
+        args,
+        launch_constraints,
+        compile_params,
+        outputs,
+        kernel()->indexType());
   }
 
   recompileKernel(executor_entry->launch_params, compile_params);

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -279,7 +279,8 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
   std::vector<GlobalBufferInfo> getOutputBufferInfo(
       const KernelArgumentHolder& args,
       ExpressionEvaluator& expr_eval,
-      const std::vector<std::pair<int, int>>& input_to_output_aliases);
+      const std::vector<std::pair<int, int>>& input_to_output_aliases,
+      DataType index_dtype);
 
   void setUsedTVs();
 

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -257,18 +257,21 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
   LaunchParams computeLaunchParams(
       const LaunchParams& launch_constraints,
       ExpressionEvaluator& expr_eval,
-      const int64_t warp_size);
+      const int64_t warp_size,
+      DataType index_dtype);
 
   int64_t computeSharedMemory(
       ExpressionEvaluator& expr_eval,
       const std::vector<const kir::Allocate*>& buffers,
+      DataType index_dtype,
       int64_t smem_offset = 0);
 
   //! Return information necessay for allocating intermediate tensors,
   //! including temporary work buffers as well as intermediate
   //! global-memory tensors
   std::vector<GlobalBufferInfo> getIntermediateBufferInfo(
-      ExpressionEvaluator& expr_eval);
+      ExpressionEvaluator& expr_eval,
+      DataType index_dtype);
 
   //! Return information necessay for allocating output tensors. Input
   //! and output tensors are allowed to alias each other, which is
@@ -294,7 +297,8 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
       const KernelArgumentHolder& args,
       const LaunchParams& launch_constraints,
       const CompileParams& compile_params,
-      const std::vector<at::Tensor>& outputs);
+      const std::vector<at::Tensor>& outputs,
+      DataType index_type);
 
   std::unique_ptr<PrecomputedValues>& evaluatorPrecomputedValues();
 

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -43,7 +43,8 @@ void validateValWithConcreteValue(
         t.dim());
     auto actual_dtype = aten_to_data_type(t.scalar_type());
     TORCH_CHECK(
-        value->dtype() == actual_dtype,
+        (value->dtype() == DataType::Index && isIntegralType(actual_dtype)) ||
+            (value->dtype() == actual_dtype),
         "Expected ",
         tv->toString(),
         " to be bound to a tensor of dtype ",

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -29,6 +29,7 @@ namespace {
 class KernelIrScanner : private IrVisitor {
  public:
   explicit KernelIrScanner(const Kernel* kernel) {
+    index_type_ = kernel->indexType();
     IrVisitor::handle(kernel->topLevelExprs());
     const auto gpu_lower = GpuLower::current();
     for (auto split : gpu_lower->nonDivisibleSplitInfo().splitsToValidate()) {
@@ -100,7 +101,7 @@ class KernelIrScanner : private IrVisitor {
     if (domain->hasBlockReduction() || domain->hasGridReduction() ||
         tv->getMemoryType() == MemoryType::Shared) {
       const auto data_type = tv->dtype();
-      const size_t type_size = dataTypeSize(data_type);
+      const size_t type_size = dataTypeSize(data_type, index_type_);
       if (type_size > max_smem_type_size_) {
         max_smem_type_size_ = type_size;
         summary_.largest_smem_data_type = data_type;
@@ -188,6 +189,7 @@ class KernelIrScanner : private IrVisitor {
  private:
   size_t max_smem_type_size_ = 0;
   KernelSummary summary_;
+  DataType index_type_;
 };
 
 //! Make sure tensors have valid allocations even when parallelized

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -335,8 +335,8 @@ std::vector<PolymorphicValue> GetMetaData::evaluate(
       "GetMetaData expects a CUDA tensor as input, but got undefined tensor");
 
   Struct<PolymorphicValue> concrete_value;
-  concrete_value["data"] =
-      PolymorphicValue(Pointer(input.data_ptr(), tv->dtype()));
+  concrete_value["data"] = PolymorphicValue(
+      Pointer(input.data_ptr(), aten_to_data_type(input.scalar_type())));
   concrete_value["logical_size"] = PolymorphicValue(input.sizes().vec());
   concrete_value["logical_stride"] = PolymorphicValue(input.strides().vec());
   {


### PR DESCRIPTION
Instead, make our system capable of handling `DataType::Index`. `resolveIndexDtype` is a workaround for us for not having a well handling of different integer types. I am fixing this issue right now in https://github.com/NVIDIA/Fuser/pull/696, therefore, this workaround should be removed as well.