### PR TITLE
Remove a requirement that inputs cannot be used multiple times

### DIFF
--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -51,15 +51,6 @@ bool rejectScheduleFusionInputRequirement(
         " must be fusion input.");
     return true;
   }
-  if (expr->input(0)->uses().size() > 1) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        schedule_stragety,
-        "First input of ",
-        expr->getOpString(),
-        " can only be used by ",
-        expr->getOpString());
-    return true;
-  }
   return false;
 }
 


### PR DESCRIPTION
Not sure why we have this check. 