### PR TITLE
Matmul, avoid vectorization causing misaligned reads

### DIFF
--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -482,7 +482,7 @@ Val* SimplifyingIrBuilder::bitwiseAndExpr(Val* lhs, Val* rhs) {
   if (lhs_zero || rhs_zero) {
     return FusionGuard::getCurFusion()->zeroVal();
   } else if (lhs_all_ones && rhs_all_ones) {
-    return IrBuilder::IrBuilder::create<Val>(-1, lhs->dtype());
+    return IrBuilder::IrBuilder::create<Val>((int64_t)-1, lhs->dtype());
   } else if (lhs_all_ones) {
     return rhs_scalar;
   } else if (rhs_all_ones) {
@@ -520,7 +520,7 @@ Val* SimplifyingIrBuilder::bitwiseOrExpr(Val* lhs, Val* rhs) {
   }
 
   if (lhs_all_ones || rhs_all_ones) {
-    return IrBuilder::IrBuilder::create<Val>(-1, lhs->dtype());
+    return IrBuilder::IrBuilder::create<Val>((int64_t)-1, lhs->dtype());
   } else if (lhs_zero && rhs_zero) {
     return FusionGuard::getCurFusion()->zeroVal();
   } else if (lhs_zero) {

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -64,6 +64,7 @@ bool generateSharedMemoryEpilogueHeuristics(
   const auto blocks_per_sm_with_smem_epilogue = std::min(
       shared_memory_available / (smem_a + smem_b + smem_c),
       (size_t)blocks_per_sm_by_register);
+
   return blocks_per_sm_with_smem_epilogue ==
       blocks_per_sm_without_smem_epilogue;
 }

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -4227,7 +4227,6 @@ TEST_F(NVFuserTest, FusionMatmulSchedulerEpilogueAlphaBetaGeluOutputCast_CUDA) {
 // Matmul test that relies on segmenter for fusion for Ampere:
 //  D = (A x B) + bias
 TEST_F(NVFuserTest, FusionMatmulSchedulerEpilogueBias_CUDA) {
-  GTEST_SKIP() << "https://github.com/NVIDIA/Fuser/issues/682";
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   const auto layout = MatmulLayout::TT;
   auto fusion = std::make_unique<Fusion>();
@@ -4299,7 +4298,6 @@ TEST_F(NVFuserTest, FusionMatmulSchedulerEpilogueBias_CUDA) {
 // Matmul test that relies on segmenter for fusion for Ampere:
 //  D = alpha * ((A x B) + bias) + beta * C
 TEST_F(NVFuserTest, FusionMatmulSchedulerEpilogueAlphaBetaBias_CUDA) {
-  GTEST_SKIP() << "https://github.com/NVIDIA/Fuser/issues/682";
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   const auto layout = MatmulLayout::TT;
   auto fusion = std::make_unique<Fusion>();


### PR DESCRIPTION
Address issue reported for Ada device:
  https://github.com/NVIDIA/Fuser/issues/682

The core problem:
On Ada devices heuristics enable smem epilogue and in case of
fusion with bias, the propagation of parallelization mode lead
to risk of unaligned reads of bias vector

Solution:
Prevent propagation of vectorization parallel type to epilogue
inputs (bias) if smem feature is enabled.

Note:
Sources of kernels generated for Ada device can be in comments
in PR.
PR contains also fixes that enable builds on GCC 9.4.