### PR TITLE
Fix `pytest_core.py`

### DIFF
--- a/python_tests/pytest_core.py
+++ b/python_tests/pytest_core.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional
 import torch
 import jax.numpy as jnp
 from enum import Enum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 class ReferenceType(Enum):
@@ -85,7 +85,7 @@ class OpInfo:
     name: str
 
     # Set of valid inputs for this operation
-    domain: Domain = Domain(None, None)
+    domain: Domain = field(default_factory=lambda: Domain(None, None))
 
     # Set of valid dtypes for this operation
     dtypes: tuple = all_dtypes


### PR DESCRIPTION
I am getting this error:
```python
❯ python python_tests/pytest_ops.py
Traceback (most recent call last):
  File "/home/gaoxiang/Fuser3/python_tests/pytest_ops.py", line 11, in <module>
    from pytest_fusion_definitions import default_fd_fn, parse_inputs_fusion_definition
  File "/home/gaoxiang/Fuser3/python_tests/pytest_fusion_definitions.py", line 8, in <module>
    from pytest_core import OpInfo
  File "/home/gaoxiang/Fuser3/python_tests/pytest_core.py", line 79, in <module>
    @dataclass
     ^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 1223, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 1213, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'pytest_core.Domain'> for field domain is not allowed: use default_factory
```