### PR TITLE
add a test to track inf due to fp16 overflow

### DIFF
--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -118,12 +118,10 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
                                   .dtype(data_type_to_aten(dtype))
                                   .device(at::kCUDA, 0);
 
-    // scale down to avoid fp16 overflow in segmented cases.
-    // In this scenario, the fusion undergoes segmentation and
-    // intermediate results are stored in fp16. Scaling down the inputs is
-    // necessary to prevent fp16 overflow. See
+    // Reduce the scale to avoid fp16 overflow. In segmented scenarios,
+    // intermediates across different segments are saved in fp16. Input down
+    // scaling is essential to avert fp16 overflow. Refer to:
     // https://github.com/NVIDIA/Fuser/issues/704
-    // results are scaled back to original scale for correctness check.
     constexpr float scale_down_factor = 0.01;
     constexpr float scale_back_factor = 1.0 / scale_down_factor;
     at::Tensor aten_grad_out =

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -124,14 +124,18 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
     // https://github.com/NVIDIA/Fuser/issues/704
     constexpr float scale_down_factor = 0.01;
     constexpr float scale_back_factor = 1.0 / scale_down_factor;
-    at::Tensor aten_grad_out =
-        at::randn(input_shape, maybe_fp16_options).mul(scale_down_factor);
-    at::Tensor aten_input =
-        at::randn(input_shape, maybe_fp16_options).mul(scale_down_factor);
-    at::Tensor aten_weight =
-        at::randn(norm_shape, maybe_fp16_options).mul(scale_down_factor);
-    at::Tensor aten_bias =
-        at::randn(norm_shape, maybe_fp16_options).mul(scale_down_factor);
+    at::Tensor aten_grad_out = at::randn(input_shape, maybe_fp16_options)
+                                   .mul(scale_down_factor)
+                                   .to(data_type_to_aten(dtype));
+    at::Tensor aten_input = at::randn(input_shape, maybe_fp16_options)
+                                .mul(scale_down_factor)
+                                .to(data_type_to_aten(dtype));
+    at::Tensor aten_weight = at::randn(norm_shape, maybe_fp16_options)
+                                 .mul(scale_down_factor)
+                                 .to(data_type_to_aten(dtype));
+    at::Tensor aten_bias = at::randn(norm_shape, maybe_fp16_options)
+                               .mul(scale_down_factor)
+                               .to(data_type_to_aten(dtype));
 
     auto at_weight = c10::optional<at::Tensor>(aten_weight);
     auto at_bias = c10::optional<at::Tensor>(aten_bias);

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -119,8 +119,12 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
                                   .device(at::kCUDA, 0);
 
     // scale down to avoid fp16 overflow in segmented cases.
+    // In this scenario, the fusion undergoes segmentation and
+    // intermediate results are stored in fp16. Scaling down the inputs is
+    // necessary to prevent fp16 overflow. See
+    // https://github.com/NVIDIA/Fuser/issues/704
     // results are scaled back to original scale for correctness check.
-    constexpr float scale_down_factor = 1;
+    constexpr float scale_down_factor = 0.01;
     constexpr float scale_back_factor = 1.0 / scale_down_factor;
     at::Tensor aten_grad_out =
         at::randn(input_shape, maybe_fp16_options).mul(scale_down_factor);
@@ -258,7 +262,7 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
       {1600},
       {1984},
       {1987},
-      {27648}};
+      {65536}};
   bool isBenchmark = false;
   bool onlyTestFirstCase = false;
   int verbose = 0;


### PR DESCRIPTION
When layer norm backward is segmented, the intermediate tensors between different fusion segments are saved as fp16. In a case with a hidden size of 27K, it leads to inf values. see https://github.com/NVIDIA/Fuser/issues/704
If the test case is using a dtype of fp16 and segmented, this PR scales down the inputs by a factor of 0.01.
It allows us to validate the fp16 segmented cases.