### PR TITLE
Randomize `Val*` for expr simplifier test

### DIFF
--- a/test/test_expr_simplifier.cpp
+++ b/test/test_expr_simplifier.cpp
@@ -92,7 +92,9 @@ using token_t = std::variant<
     Comma,
     LowestPrecedence>;
 
-Val* randomlyReuseOrCreateNamedScalar(std::string_view name_view, DataType dtype) {
+Val* randomlyReuseOrCreateNamedScalar(
+    std::string_view name_view,
+    DataType dtype) {
   Fusion* fusion = FusionGuard::getCurFusion();
   auto name = std::string(name_view);
   if (!fusion->hasManaged(name)) {

--- a/test/test_expr_simplifier.cpp
+++ b/test/test_expr_simplifier.cpp
@@ -621,9 +621,6 @@ TEST_F(ExprSimplifierTest, EliminateTrivialComputation) {
   // Using the same Val* multiple times in FlattenedAdd so that we can test if
   // our passes are working correctly with the same Val* appearing multiple
   // times
-  // TODO: we shouldn't just test this single case, we need to make a more
-  // complete test plan for all our passes. I don't think this case is well
-  // tested currently.
   auto i = "i"_;
   EXPECT_TRUE(
       simplifyExpr(IrBuilder::subExpr(IrBuilder::addExpr(i, i), i))->sameAs(i));

--- a/test/test_expr_simplifier.cpp
+++ b/test/test_expr_simplifier.cpp
@@ -15,6 +15,7 @@
 #include <cctype>
 #include <deque>
 #include <memory>
+#include <random>
 #include <regex>
 #include <string>
 #include <string_view>
@@ -91,6 +92,30 @@ using token_t = std::variant<
     Comma,
     LowestPrecedence>;
 
+Val* randomlyReuseOrCreateNamedScalar(std::string_view name_view, DataType dtype) {
+  Fusion* fusion = FusionGuard::getCurFusion();
+  auto name = std::string(name_view);
+  if (!fusion->hasManaged(name)) {
+    auto ns = IrBuilder::create<NamedScalar>(name, dtype);
+    fusion->manage(name, std::vector<Val*>{ns});
+    return ns;
+  }
+  auto& existing_vals = fusion->getManaged<std::vector<Val*>>(name);
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<size_t> dis(0, existing_vals.size());
+  auto index = dis(gen);
+  if (index == existing_vals.size()) {
+    // create a new one
+    auto ns = IrBuilder::create<NamedScalar>(name, dtype);
+    existing_vals.push_back(ns);
+    return ns;
+  } else {
+    // reuse an existing one
+    return existing_vals[index];
+  }
+}
+
 Val* parseIdentifier(std::string_view token_str) {
   if (token_str == "true") {
     return IrBuilder::newConstant(true, DataType::Bool);
@@ -123,14 +148,11 @@ Val* parseIdentifier(std::string_view token_str) {
       token_str == "blockDim.y" || token_str == "blockDim.z" ||
       token_str == "gridDim.x" || token_str == "gridDim.y" ||
       token_str == "gridDim.z") {
-    return IrBuilder::create<NamedScalar>(
-        std::string(token_str), DataType::Int);
+    return randomlyReuseOrCreateNamedScalar(token_str, DataType::Int);
   } else if (token_str.at(0) == 'b') {
-    return IrBuilder::create<NamedScalar>(
-        std::string(token_str), DataType::Bool);
+    return randomlyReuseOrCreateNamedScalar(token_str, DataType::Bool);
   } else if (token_str.at(0) == 'd') {
-    return IrBuilder::create<NamedScalar>(
-        std::string(token_str), DataType::Double);
+    return randomlyReuseOrCreateNamedScalar(token_str, DataType::Double);
   } else {
     TORCH_INTERNAL_ASSERT(false, "Identifier with unknown type: ", token_str);
   }


### PR DESCRIPTION
Currently, in expr simplifier tests, we always create a new `Val*` for each variable that appears in the expression. For example, in `"i + i + i"_`, we will create three `NamedScalar`s, all with name `i`. This behavior does not have good coverage on the case where there are the same `Val*` as different inputs of the same expr. And there can be bugs related to this, for example, if I want to simplify `FlattenedAdd(i, i, i, -i)`, if not implemented carefully, I might be removing all the `i`s in the `FlattenedAdd`, instead of just removing one, if all the `i`s has the same `Val*`. In this PR, I changed the "stupid_simple_compiler" to randomly decide whether to reuse an existing `Val*` or to create a new one. This will increase our test coverage, although determinism might get hurt.