### PR TITLE
Remove `resolveIndexDtype`

### DIFF
--- a/csrc/device_lower/pass/scalar_hoist.cpp
+++ b/csrc/device_lower/pass/scalar_hoist.cpp
@@ -455,16 +455,6 @@ class CommonIndexInserter : private kir::ExprMutator {
         alloc_point = existing_alloc_info.first;
         insert_ref = exprs[alloc_point];
       }
-      // Make the type of the hoisted value be the value type of the
-      // kernel, which can be either int64_t or int. Not very clean,
-      // but this seems to be the quickest way to use the value type
-      // as we don't have a scalar IR node for the value type.
-      // TODO: remove this. I think we are fine removing this now, but I need
-      // to double check the benchmarks.
-      auto dtype = value->dtype();
-      if (isIntegralType(dtype) && !isPointerType(dtype)) {
-        value->resolveIndexDtype();
-      }
 
       auto alloc = IrBuilder::create<kir::Allocate>(
           value, MemoryType::Local, GpuLower::current()->kernel()->oneVal());

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -120,35 +120,6 @@ bool Val::removeUse(Expr* expr) {
   return false;
 }
 
-// Converts the data type of TensorView or Scalar representing index
-// values. The data type of the original input should be
-// DataType::Index, but DataType::Int is also allowed as it is used
-// for index expressions.
-// TODO: remove this function. I think we are fine removing this now, but I need
-// to double check the benchmarks.
-void Val::resolveIndexDtype() {
-  TORCH_INTERNAL_ASSERT(
-      vtype_ == ValType::TensorView || vtype_ == ValType::Others ||
-          vtype_ == ValType::NamedScalar,
-      "Resolving index type is currently only supported on tensor view or scalar values. "
-      "Value type: ",
-      vtype_);
-  TORCH_INTERNAL_ASSERT(
-      isIntegralType(dtype_),
-      "Can only resolve index type if a Val has an Index or Int DataType. ",
-      "Data type: ",
-      dtype_);
-  TORCH_INTERNAL_ASSERT(
-      container()->isA<kir::Kernel>(),
-      "Index type can only be resolved at compile time.");
-  auto index_dtype = container()->as<kir::Kernel>()->indexType();
-  TORCH_INTERNAL_ASSERT(
-      index_dtype == DataType::Int || index_dtype == DataType::Int32,
-      "Invalid index data type: ",
-      index_dtype);
-  dtype_ = DataType::Index;
-}
-
 bool Val::sameAs(const Statement* other) const {
   if (this == other) {
     return true;

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -423,10 +423,6 @@ class TORCH_CUDA_CU_API Val : public Statement {
     definition_ = expr;
   }
 
-  // TODO: remove this function. I think we are fine removing this now, but I
-  // need to double check the benchmarks.
-  void resolveIndexDtype();
-
   NVFUSER_DECLARE_CLONE
 
  protected:

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -93,7 +93,7 @@ TensorIndex::TensorIndex(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   TORCH_INTERNAL_ASSERT(
-      isPointerType(index->dtype()) || index->dtype() == DataType::Index,
+      isIntegralOrPointerType(index->dtype()),
       "Cannot index with a value other than an int.");
 }
 

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -93,7 +93,7 @@ TensorIndex::TensorIndex(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   TORCH_INTERNAL_ASSERT(
-      isIntegralOrPointerType(index->dtype()),
+      isPointerType(index->dtype()) || index->dtype() == DataType::Index,
       "Cannot index with a value other than an int.");
 }
 


### PR DESCRIPTION
I changed `resolveIndexDtype` into:

```C++
void Val::resolveIndexDtype() {
  TORCH_INTERNAL_ASSERT(dtype_ == DataType::Index);
}
```

And run all C++ tests and benchmarks. The only failure is `TensorFactoryTest.StandaloneARange`. I think it is fine, because the "index" of `arange` by definition can be an arbitrary dtype including double and complex, etc., so having an explicit int64 or int32 will not be a problem.