### PR TITLE
Do not allow non-projected extents

### DIFF
--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -147,6 +147,7 @@ template <typename MergeOrSplit>
 void ContiguousInnerDimensionsMapper::combinePE(
     const MergeOrSplit* merge_or_split,
     bool outer_maps) {
+  // Nothing to do unless recording
   if (!recording_) {
     return;
   }
@@ -190,6 +191,7 @@ void ContiguousInnerDimensionsMapper::combinePE(
 template <typename MergeOrSplit>
 void ContiguousInnerDimensionsMapper::distributePE(
     const MergeOrSplit* merge_or_split) {
+  // Nothing to do unless recording
   if (!recording_) {
     return;
   }

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -147,6 +147,10 @@ template <typename MergeOrSplit>
 void ContiguousInnerDimensionsMapper::combinePE(
     const MergeOrSplit* merge_or_split,
     bool outer_maps) {
+  if (!recording_) {
+    return;
+  }
+
   auto projected_inner_extent = getProjectedExtent(merge_or_split->inner());
   Val* projected_combined_extent = projected_inner_extent;
 
@@ -186,6 +190,10 @@ void ContiguousInnerDimensionsMapper::combinePE(
 template <typename MergeOrSplit>
 void ContiguousInnerDimensionsMapper::distributePE(
     const MergeOrSplit* merge_or_split) {
+  if (!recording_) {
+    return;
+  }
+
   auto inner_extent = commonOrConstExtent(ca_map_, merge_or_split->inner());
   auto outer_extent = commonOrConstExtent(ca_map_, merge_or_split->outer());
   Val* projected_combined_extent = nullptr;

--- a/csrc/scheduler/vectorize_helper.h
+++ b/csrc/scheduler/vectorize_helper.h
@@ -235,6 +235,16 @@ class TORCH_CUDA_CU_API ContiguousInnerDimensionsMapper
     if (!recording_) {
       return;
     }
+
+    TORCH_INTERNAL_ASSERT(
+        projected_extent_.count(id) == 0,
+        "Already registered: ",
+        id->toString(),
+        ", existing: ",
+        projected_extent_.at(id)->toInlineString(),
+        ", new: ",
+        pe->toInlineString());
+
     projected_extent_[id] = pe;
   }
 

--- a/csrc/scheduler/vectorize_helper.h
+++ b/csrc/scheduler/vectorize_helper.h
@@ -179,11 +179,7 @@ class TORCH_CUDA_CU_API ContiguousInnerDimensionsMapper
 
   Val* getProjectedExtent(IterDomain* id) const {
     if (projected_extent_.find(id) == projected_extent_.end()) {
-      if (recording_ || true) {
-        TORCH_INTERNAL_ASSERT(false, "Not projected: ", id->toString());
-      } else {
-        return id->container()->oneVal();
-      }
+      TORCH_INTERNAL_ASSERT(false, "Not projected: ", id->toString());
     }
     return projected_extent_.at(id);
   }

--- a/csrc/scheduler/vectorize_helper.h
+++ b/csrc/scheduler/vectorize_helper.h
@@ -177,9 +177,13 @@ class TORCH_CUDA_CU_API ContiguousInnerDimensionsMapper
         ->mapped_rfactor_ids_;
   }
 
-  Val* getProjectedExtent(IterDomain* id) {
+  Val* getProjectedExtent(IterDomain* id) const {
     if (projected_extent_.find(id) == projected_extent_.end()) {
-      projected_extent_[id] = id->container()->oneVal();
+      if (recording_ || true) {
+        TORCH_INTERNAL_ASSERT(false, "Not projected: ", id->toString());
+      } else {
+        return id->container()->oneVal();
+      }
     }
     return projected_extent_.at(id);
   }

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -178,12 +178,6 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
          std::get<2>(aten_gradients).mul(scale_back_factor)},
         __LINE__,
         __FILE__);
-
-    int64_t hidden_size = 1;
-    for (auto s : norm_shape) {
-      hidden_size *= s;
-    }
-
     if (isBenchmark) {
       FusionKernelRuntime* fkr = fec.getMostRecentKernelRuntime();
       fkr->enableKernelTimeMeasurement();

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -309,7 +309,8 @@ TEST_F(VectorizeHelperTest, BackwardMapper2_CUDA) {
 
   EXPECT_THAT(
       [&]() { mapper.getProjectedExtent(tv2->axis(0)); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr("Not projected")));
+      ::testing::ThrowsMessage<c10::Error>(
+          ::testing::HasSubstr("Not projected")));
   EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3);
   EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 4);
   // Inner dim fully maps, outer dim of split partially maps
@@ -631,7 +632,8 @@ TEST_F(VectorizeHelperTest, ForwardMapper2_CUDA) {
 
   EXPECT_THAT(
       [&]() { mapper.getProjectedExtent(tv0->axis(0)); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr("Not projected")));
+      ::testing::ThrowsMessage<c10::Error>(
+          ::testing::HasSubstr("Not projected")));
   EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3);
   EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 4);
   // Inner dim fully maps, outer dim of split partially maps

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -307,7 +307,9 @@ TEST_F(VectorizeHelperTest, BackwardMapper2_CUDA) {
   auto mapper = vectorize_helper::ContiguousInnerDimensionsMapper::map(
       tv2, {tv2->axis(1), tv2->axis(2)});
 
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 1);
+  EXPECT_THAT(
+      [&]() { mapper.getProjectedExtent(tv2->axis(0)); },
+      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr("Not projected")));
   EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3);
   EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 4);
   // Inner dim fully maps, outer dim of split partially maps
@@ -627,7 +629,9 @@ TEST_F(VectorizeHelperTest, ForwardMapper2_CUDA) {
   auto mapper = vectorize_helper::ContiguousInnerDimensionsMapper::map(
       tv0, {tv0->axis(1), tv0->axis(2)});
 
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 1);
+  EXPECT_THAT(
+      [&]() { mapper.getProjectedExtent(tv0->axis(0)); },
+      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr("Not projected")));
   EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3);
   EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 4);
   // Inner dim fully maps, outer dim of split partially maps


### PR DESCRIPTION
It seems odd to me that `ContiguousInnerDimensionMapper::getProjectedExtent` automatically returns 1 for any domain that is not projected. It seems that was necessary for it to work under the non-recording mode, but there's no reason to use the function if no recording projected extents. 

This PR makes `getProjectedExtent` with non-projected domains result in an error. Also changed `distributePE` and `combinePE` to do nothing while not recording as they use `getProjectedExtent`.

Also added an error check to `addProjectedExtent`.