### PR TITLE
More robustly detect size one dim

### DIFF
--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1511,10 +1511,11 @@ TensorView* TensorViewBuilder::build() const {
     if (shape_.empty()) {
       *shape_extent = IrBuilder::create<Val>(DataType::Index);
     } else {
-      *shape_extent = maybeCastOp(DataType::Index, shape_.at(i));
+      *shape_extent =
+          SimplifyingIrBuilder::maybeCastExpr(DataType::Index, shape_.at(i));
     }
     IterDomainBuilder builder(FusionGuard::getCurFusion()->zeroVal(), extent);
-    if (extent->isOneInt()) {
+    if (extent->isConstScalar() && extent->evaluateInt() == 1) {
       builder.iter_type(IterType::Broadcast);
     }
     if (expanded_extent != nullptr) {


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/Fuser/issues/718. Currently, we use `isOneInt` to detect if a dimension is size 1. This is not robust, because not all size one dims are constant one. A dim's extent might be something like `(nvfuser_index_t)1L`, which is still one. For that case, we should be able to detect it correctly.