### PR TITLE
Return true in hasBlockSync(kir::GridSync)

### DIFF
--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -615,7 +615,7 @@ std::vector<Expr*> getAllSwizzlesBetween(
 namespace lower_utils {
 
 bool hasBlockSync(const Expr* expr, const ThreadPredicateMap& pred_map) {
-  if (expr->isA<kir::BlockSync>()) {
+  if (expr->isA<kir::BlockSync>() || expr->isA<kir::GridSync>()) {
     return true;
   }
 


### PR DESCRIPTION
Grid sync performs a block sync, so this should be treated as a block-synchronizing expression.