### PR TITLE
Fix printing of BFloat16 in python error repros

### DIFF
--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -28,7 +28,7 @@ const char* dtypeToPyString(PrimDataType t) {
     case DataType::Half:
       return "DataType.Half";
     case DataType::BFloat16:
-      return "DataType.Bfloat16";
+      return "DataType.BFloat16";
     case DataType::Int:
       return "DataType.Int";
     case DataType::Int32:


### PR DESCRIPTION
This is a single-character typo that fixes printing of repros in the error messages we see when python frontend crashes.