### PR TITLE
Let `ExpressionEvaluator::print` better print tensors

### DIFF
--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -174,14 +174,27 @@ PolymorphicValue ExpressionEvaluator::getValue(const Val* value) {
 void ExpressionEvaluator::print() const {
   debug() << "\nEvaluation context\n";
   debug() << "--------------------\n";
+
+  auto print_val = [](const PolymorphicValue& v) {
+    std::stringstream ss;
+    if (v.is<at::Tensor>()) {
+      const auto& t = v.as<at::Tensor>();
+      ss << "Tensor({" << t.sizes() << "}, " << t.dtype() << ", " << t.device()
+         << ")";
+    } else {
+      ss << v;
+    }
+    return ss.str();
+  };
+
   for (const auto& kv : known_values_) {
     TORCH_INTERNAL_ASSERT(!kv.first->isConstScalar());
-    debug() << kv.first << " = " << kv.second << " ; "
+    debug() << kv.first << " = " << print_val(kv.second) << " ; "
             << *kv.first->getValType() << "\n";
   }
 
   for (const auto& kv : known_named_scalars_) {
-    debug() << kv.first << " = " << kv.second << " ;\n";
+    debug() << kv.first << " = " << print_val(kv.second) << " ;\n";
   }
 
   debug() << "\nPre-computed Values\n";

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -49,9 +49,24 @@ struct Struct {
     return *fields.at(key);
 #endif
   }
+};
+
+template <typename T>
+inline std::ostream& operator<<(std::ostream& os, const Struct<T>& s) {
+  os << "struct { ";
+  bool first = true;
+  for (const auto& [key, value] : s.fields) {
+    if (!first) {
+      os << ", ";
+    }
+    os << key << " = " << MAYBE_STAR value;
+    first = false;
+  }
+  os << "}";
+  return os;
+}
 
 #undef MAYBE_STAR
-};
 
 struct DataType;
 
@@ -180,6 +195,11 @@ class Pointer {
 
 inline Pointer operator+(int64_t offset, const Pointer& ptr) {
   return ptr + offset;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const Pointer& ptr) {
+  os << (void*)ptr;
+  return os;
 }
 
 struct Opaque {


### PR DESCRIPTION
Currently, `ExpressionEvaluator::print` print all types of values using the default `operator<<` of `std::ostream`. This makes sense for most types, but not really for tensors. Because the print of a tensor can be super long. For example, the following code

```C++
TEST_F(ExprEvalTest, AAA) {
  Fusion fusion;
  FusionGuard fg(&fusion);

  TensorView* tv = makeSymbolicTensor(2);

  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
  at::Tensor input = at::randn({256, 1024}, options);

  ExpressionEvaluator ee;
  ee.bind(tv, input);
  ee.print();
}
```

prints something like

```
Evaluation context
--------------------
T0_l[ iS0{i0}, iS1{i2} ] = Columns 1 to 6-9.2466e-01 -4.2534e-01 -2.6438e+00  1.4518e-01 -1.2087e-01 -5.7973e-01
-1.0323e+00 -8.8939e-01 -1.9145e-01  8.2447e-01  1.8971e-01  9.1374e-01
 1.4954e+00 -1.5724e+00  3.3130e-01 -9.9140e-02  1.0858e+00 -5.2700e-01
-1.0169e-01 -3.4786e-01  6.5752e-01  1.1155e+00  4.0484e-01 -4.5770e-01
 2.2892e+00  1.5158e-01  2.0667e+00 -1.1766e+00  1.5680e+00 -8.3971e-01
-1.4741e+00 -3.6920e-01  7.9716e-01 -2.1870e+00 -5.8738e-01 -1.6555e-01

.... (40k lines omitted)

 2.1621e+00  1.0334e-01 -5.8527e-01  9.5312e-02
 7.4711e-01  1.4714e+00  1.2678e+00  1.4912e+00
-5.0126e-01  1.3043e-01  2.2225e-01  9.1188e-01
-5.0865e-02 -1.5161e-01  1.2151e+00  1.0133e-01
 1.1884e+00 -1.5568e+00  2.3744e-01  1.9448e+00
-4.9641e-01 -2.2210e+00  1.2916e+00 -1.9427e-01
-2.5083e+00  1.5171e+00  2.7133e-01  9.0631e-02
 4.1330e-01  1.9822e-01  1.2371e+00 -1.8587e+00
 4.5828e-01 -7.5181e-01 -2.4887e-01  5.6508e-01
 6.6118e-01 -6.4419e-01  1.6727e-01 -2.4909e-01
-1.9550e+00 -5.2785e-01  9.0103e-01  3.0207e-01
-8.2726e-01 -4.5035e-02 -1.7124e-02  9.8678e-02
[ CUDAFloatType{256,1024} ] ; TensorView

Pre-computed Values
--------------------
```

This PR changes the print function to only print the meta data when the value is a tensor.