### PR TITLE
Disallow `tv = scalar + scalar`

### DIFF
--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -955,8 +955,8 @@ TEST_F(NVFuserTest, FusionOuterSplit_CUDA) {
   auto outputs = fe.runFusion({});
   const auto& output = outputs.at(0);
 
-  at::Tensor output_ref = at::zeros_like(output, options);
-  output_ref = output_ref + 1.0 + 2.0 + 3.0;
+  at::Tensor output_ref = at::ones_like(output, options);
+  output_ref = output_ref + 2.0 + 3.0;
 
   TORCH_CHECK(output_ref.equal(output));
 }
@@ -995,8 +995,8 @@ TEST_F(NVFuserTest, FusionCodeGen_CUDA) {
   auto outputs = fe.runFusion({});
   const auto& output = outputs.at(0);
 
-  at::Tensor output_ref = at::zeros_like(output, options);
-  output_ref = output_ref + 1.0 + 2.0 + 3.0;
+  at::Tensor output_ref = at::ones_like(output, options);
+  output_ref = output_ref + 2.0 + 3.0;
 
   TORCH_CHECK(output_ref.equal(output));
 }

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -924,13 +924,13 @@ TEST_F(NVFuserTest, FusionOuterSplit_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  TensorView* tv0 = makeSymbolicTensor(3);
+  TensorView* tv0 = full(
+      {IrBuilder::create<Val>(2),
+       IrBuilder::create<Val>(6),
+       IrBuilder::create<Val>(32)},
+      IrBuilder::create<Val>(1.0, DataType::Float),
+      DataType::Float);
 
-  IrBuilder::create<BinaryOp>(
-      BinaryOpType::Add,
-      tv0,
-      IrBuilder::create<Val>(0.0),
-      IrBuilder::create<Val>(1.0));
   TensorView* tv1 = add(tv0, IrBuilder::create<Val>(2.0));
   TensorView* tv2 = add(tv1, IrBuilder::create<Val>(3.0));
   fusion.addOutput(tv2);
@@ -950,14 +950,13 @@ TEST_F(NVFuserTest, FusionOuterSplit_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
-  at::Tensor output = at::empty({2, 6, 32}, options);
-
   FusionExecutor fe;
   fe.compileFusion(&fusion);
-  fe.runFusion({}, {output});
+  auto outputs = fe.runFusion({});
+  const auto& output = outputs.at(0);
 
   at::Tensor output_ref = at::zeros_like(output, options);
-  output_ref = output_ref + 0.0 + 1.0 + 2.0 + 3.0;
+  output_ref = output_ref + 1.0 + 2.0 + 3.0;
 
   TORCH_CHECK(output_ref.equal(output));
 }
@@ -966,13 +965,13 @@ TEST_F(NVFuserTest, FusionCodeGen_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  TensorView* tv0 = makeSymbolicTensor(3);
+  TensorView* tv0 = full(
+      {IrBuilder::create<Val>(16),
+       IrBuilder::create<Val>(8),
+       IrBuilder::create<Val>(8)},
+      IrBuilder::create<Val>(1.0, DataType::Float),
+      DataType::Float);
 
-  IrBuilder::create<BinaryOp>(
-      BinaryOpType::Add,
-      tv0,
-      IrBuilder::create<Val>(0.0),
-      IrBuilder::create<Val>(1.0));
   TensorView* tv1 = add(tv0, IrBuilder::create<Val>(2.0));
   TensorView* tv2 = add(tv1, IrBuilder::create<Val>(3.0));
   fusion.addOutput(tv2);
@@ -991,14 +990,13 @@ TEST_F(NVFuserTest, FusionCodeGen_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
-  at::Tensor output = at::empty({16, 8, 8}, options);
-
   FusionExecutor fe;
   fe.compileFusion(&fusion);
-  fe.runFusion({}, {output});
+  auto outputs = fe.runFusion({});
+  const auto& output = outputs.at(0);
 
   at::Tensor output_ref = at::zeros_like(output, options);
-  output_ref = output_ref + 0.0 + 1.0 + 2.0 + 3.0;
+  output_ref = output_ref + 1.0 + 2.0 + 3.0;
 
   TORCH_CHECK(output_ref.equal(output));
 }


### PR DESCRIPTION
The addition of two scalars should always be a scalar. If we want a tensor filled with a scalar, we should use `FullOp`.