### PR TITLE
Add `NVFUSER_ENABLE=cuda_from_file` option

### DIFF
--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -153,6 +153,7 @@ std::unordered_map<EnableOption, std::vector<std::string>> Options<
   const std::unordered_map<std::string, EnableOption> available_options = {
       {"complex", EnableOption::Complex},
       {"conv_decomposition", EnableOption::ConvDecomposition},
+      {"cuda_from_file", EnableOption::CudaFromFile},
       {"graph_op_fusion", EnableOption::GraphOp},
       {"kernel_db", EnableOption::KernelDb},
       {"kernel_profile", EnableOption::KernelProfile},

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -79,6 +79,7 @@ enum class DebugDumpOption {
 enum class EnableOption {
   Complex, //! Enable complex support on python
   ConvDecomposition, //! Enable conv-bias decomposition
+  CudaFromFile, //! Load cuda code from file, overriding generated code
   GraphOp, //! Enable graphOps(index_select/gather/scatter)
   KernelDb, //! Enable Kernel Database
   KernelProfile, //! Enable intra-kernel performance profiling


### PR DESCRIPTION
This change introduces `EnableOption::CudaFromFile`, which causes `FusionExecutor` to bypass its own generated code and instead load the kernel with preamble from a file. The filename matches the location written when `DebugDumpOption::CudaToFile` is true. A typical usage would be to run a fusion with `NVFUSER_DUMP=cuda_to_file`, then edit the `__tmp_kernel1.cu` (or multiple of these files), then run again with `NVFUSER_ENABLE=cuda_from_file`. Note that if `cuda_from_file_` is given, `cuda_to_file` is ignored.

This is a utility I found useful when testing out smem reuse. In that case I still needed to change the launch parameters manually, but being able to drop a kernel in and compile and launch it exactly as we would normally  seemed simpler than isolating and compiling individual programs.
