### PR TITLE
Tunning index hoisting

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -450,7 +450,13 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     const bool has_alloc = alloc_map_.find(s) != alloc_map_.end();
     const bool is_param = kernel_params_.find(s) != kernel_params_.end();
     if (def != nullptr && !has_alloc && !is_param) {
-      code_ << "(" << genInline(def) << ")";
+      if (def->isOneOf<GetAttr, GetItem, GetMetaData>() ||
+          (def->isA<UnaryOp>() &&
+           !inline_op_str(def->as<UnaryOp>()->getUnaryOpType()).has_value())) {
+        code_ << genInline(def);
+      } else {
+        code_ << "(" << genInline(def) << ")";
+      }
     } else if (s->isConst()) {
       auto value = s->value();
       auto dtype = s->dtype();

--- a/test/test_loop_rotation.cpp
+++ b/test/test_loop_rotation.cpp
@@ -35,39 +35,33 @@ TEST_F(LoopRotationTest, RotateInner) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
-  Array<nvfuser_index_t, 2, 1> a0;
-  a0 = (T0).alloc_stride;
-  nvfuser_index_t i1;
-  i1 = a0[0];
-  nvfuser_index_t i2;
-  i2 = a0[1];
   #pragma unroll 1
-  for(nvfuser_index_t i3 = 0; i3 < T0.logical_size[0]; ++i3) {
-    nvfuser_index_t i4;
-    i4 = i1 * i3;
-    nvfuser_index_t i5;
-    i5 = 3 * i3;
+  for(nvfuser_index_t i0 = 0; i0 < T0.logical_size[0]; ++i0) {
+    nvfuser_index_t i1;
+    i1 = T0.alloc_stride[0] * i0;
+    nvfuser_index_t i2;
+    i2 = 3 * i0;
     float T1[1];
     float T2[1];
     T1[0] = 0;
     T1[0]
-       = T0[i4];
+       = T0[i1];
     T2[0]
        = T1[0];
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-      nvfuser_index_t i7;
-      i7 = (1 + i6) + nvfuser_zero;
+    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+      nvfuser_index_t i4;
+      i4 = (1 + i3) + nvfuser_zero;
       float T3[1];
       T3[0]
          = T2[0];
-      T4[(i5 + (i6 + nvfuser_zero))]
+      T4[(i2 + (i3 + nvfuser_zero))]
          = T3[0];
       T1[0] = 0;
-      if ((i7 < 3)) {
+      if ((i4 < 3)) {
         T1[0]
-           = T0[(i4 + (i2 * i7))];
+           = T0[(i1 + (T0.alloc_stride[1] * i4))];
       }
       T2[0]
          = T1[0];
@@ -107,70 +101,64 @@ TEST_F(LoopRotationTest, RotateOuter) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
-  Array<nvfuser_index_t, 2, 1> a0;
-  a0 = (T0).alloc_stride;
-  nvfuser_index_t i1;
-  i1 = a0[1];
-  nvfuser_index_t i2;
-  i2 = a0[0];
   float T1[3];
   float T2[3];
   #pragma unroll
-  for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
-    T1[i3] = 0;
+  for(nvfuser_index_t i0 = 0; i0 < 3; ++i0) {
+    T1[i0] = 0;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
-    T1[i3]
-       = T0[(i1 * (i3 + nvfuser_zero))];
+  for(nvfuser_index_t i0 = 0; i0 < 3; ++i0) {
+    T1[i0]
+       = T0[(T0.alloc_stride[1] * (i0 + nvfuser_zero))];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i4 = 0; i4 < 3; ++i4) {
-    T2[i4]
-       = T1[i4];
+  for(nvfuser_index_t i1 = 0; i1 < 3; ++i1) {
+    T2[i1]
+       = T1[i1];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i5 = 0; i5 < T0.logical_size[0]; ++i5) {
-    nvfuser_index_t i6;
-    i6 = 3 * i5;
-    nvfuser_index_t i7;
-    i7 = i2 + (i2 * i5);
-    bool b8;
-    b8 = (1 + i5) < T0.logical_size[0];
+  for(nvfuser_index_t i2 = 0; i2 < T0.logical_size[0]; ++i2) {
+    nvfuser_index_t i3;
+    i3 = 3 * i2;
+    nvfuser_index_t i4;
+    i4 = T0.alloc_stride[0] + (T0.alloc_stride[0] * i2);
+    bool b5;
+    b5 = (1 + i2) < T0.logical_size[0];
     // Alias Allocation - register
     auto& T3 = T1;
     #pragma unroll
-    for(nvfuser_index_t i9 = 0; i9 < 3; ++i9) {
-      T3[i9]
-         = T2[i9];
+    for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
+      T3[i6]
+         = T2[i6];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i10 = 0; i10 < 3; ++i10) {
-      T4[(i6 + (i10 + nvfuser_zero))]
-         = T3[i10];
+    for(nvfuser_index_t i7 = 0; i7 < 3; ++i7) {
+      T4[(i3 + (i7 + nvfuser_zero))]
+         = T3[i7];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
-      T1[i3] = 0;
+    for(nvfuser_index_t i0 = 0; i0 < 3; ++i0) {
+      T1[i0] = 0;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
-      if (b8) {
-        T1[i3]
-           = T0[(i7 + (i1 * (i3 + nvfuser_zero)))];
+    for(nvfuser_index_t i0 = 0; i0 < 3; ++i0) {
+      if (b5) {
+        T1[i0]
+           = T0[(i4 + (T0.alloc_stride[1] * (i0 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i4 = 0; i4 < 3; ++i4) {
-      T2[i4]
-         = T1[i4];
+    for(nvfuser_index_t i1 = 0; i1 < 3; ++i1) {
+      T2[i1]
+         = T1[i1];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
   }
@@ -214,78 +202,72 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   i0 = T0.logical_size[0] * T0.logical_size[1];
   nvfuser_index_t i1;
   i1 = ceilDiv(i0, 5);
-  Array<nvfuser_index_t, 2, 1> a2;
-  a2 = (T0).alloc_stride;
-  nvfuser_index_t i3;
-  i3 = a2[0];
-  nvfuser_index_t i4;
-  i4 = a2[1];
   float T1[5];
   float T2[5];
   #pragma unroll
-  for(nvfuser_index_t i5 = 0; i5 < 5; ++i5) {
-    T1[i5] = 0;
+  for(nvfuser_index_t i2 = 0; i2 < 5; ++i2) {
+    T1[i2] = 0;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i5 = 0; i5 < 5; ++i5) {
-    nvfuser_index_t i6;
-    i6 = i5 + nvfuser_zero;
-    if ((i6 < i0)) {
-      T1[i5]
-         = T0[((i3 * (i6 / T0.logical_size[1])) + (i4 * (i6 % T0.logical_size[1])))];
+  for(nvfuser_index_t i2 = 0; i2 < 5; ++i2) {
+    nvfuser_index_t i3;
+    i3 = i2 + nvfuser_zero;
+    if ((i3 < i0)) {
+      T1[i2]
+         = T0[((T0.alloc_stride[0] * (i3 / T0.logical_size[1])) + (T0.alloc_stride[1] * (i3 % T0.logical_size[1])))];
     }
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i7 = 0; i7 < 5; ++i7) {
-    T2[i7]
-       = T1[i7];
+  for(nvfuser_index_t i4 = 0; i4 < 5; ++i4) {
+    T2[i4]
+       = T1[i4];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i8 = 0; i8 < i1; ++i8) {
-    nvfuser_index_t i9;
-    i9 = 5 * i8;
-    nvfuser_index_t i10;
-    i10 = 5 + i9;
+  for(nvfuser_index_t i5 = 0; i5 < i1; ++i5) {
+    nvfuser_index_t i6;
+    i6 = 5 * i5;
+    nvfuser_index_t i7;
+    i7 = 5 + i6;
     // Alias Allocation - register
     auto& T3 = T1;
     #pragma unroll
-    for(nvfuser_index_t i11 = 0; i11 < 5; ++i11) {
-      T3[i11]
-         = T2[i11];
+    for(nvfuser_index_t i8 = 0; i8 < 5; ++i8) {
+      T3[i8]
+         = T2[i8];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i12 = 0; i12 < 5; ++i12) {
-      nvfuser_index_t i13;
-      i13 = i9 + (i12 + nvfuser_zero);
-      if ((i13 < i0)) {
-        T4[i13]
-           = T3[i12];
+    for(nvfuser_index_t i9 = 0; i9 < 5; ++i9) {
+      nvfuser_index_t i10;
+      i10 = i6 + (i9 + nvfuser_zero);
+      if ((i10 < i0)) {
+        T4[i10]
+           = T3[i9];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 5; ++i5) {
-      T1[i5] = 0;
+    for(nvfuser_index_t i2 = 0; i2 < 5; ++i2) {
+      T1[i2] = 0;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 5; ++i5) {
-      nvfuser_index_t i14;
-      i14 = i10 + (i5 + nvfuser_zero);
-      if ((i14 < i0)) {
-        T1[i5]
-           = T0[((i3 * (i14 / T0.logical_size[1])) + (i4 * (i14 % T0.logical_size[1])))];
+    for(nvfuser_index_t i2 = 0; i2 < 5; ++i2) {
+      nvfuser_index_t i11;
+      i11 = i7 + (i2 + nvfuser_zero);
+      if ((i11 < i0)) {
+        T1[i2]
+           = T0[((T0.alloc_stride[0] * (i11 / T0.logical_size[1])) + (T0.alloc_stride[1] * (i11 % T0.logical_size[1])))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i7 = 0; i7 < 5; ++i7) {
-      T2[i7]
-         = T1[i7];
+    for(nvfuser_index_t i4 = 0; i4 < 5; ++i4) {
+      T2[i4]
+         = T1[i4];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
   }
@@ -322,87 +304,81 @@ TEST_F(LoopRotationTest, DoubleBuffered) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
-  Array<nvfuser_index_t, 2, 1> a0;
-  a0 = (T0).alloc_stride;
-  nvfuser_index_t i1;
-  i1 = a0[0];
-  nvfuser_index_t i2;
-  i2 = a0[1];
-  nvfuser_index_t i3;
-  i3 = 4 * i1;
+  nvfuser_index_t i0;
+  i0 = 4 * T0.alloc_stride[0];
   float T1[15];
   #pragma unroll
-  for(nvfuser_index_t i4 = 0; i4 < 4; ++i4) {
-    nvfuser_index_t i5;
-    i5 = 3 * i4;
-    nvfuser_index_t i6;
-    i6 = i1 * i4;
-    bool b7;
-    b7 = (i4 + nvfuser_zero) < T0.logical_size[0];
+  for(nvfuser_index_t i1 = 0; i1 < 4; ++i1) {
+    nvfuser_index_t i2;
+    i2 = 3 * i1;
+    nvfuser_index_t i3;
+    i3 = T0.alloc_stride[0] * i1;
+    bool b4;
+    b4 = (i1 + nvfuser_zero) < T0.logical_size[0];
     #pragma unroll
-    for(nvfuser_index_t i8 = 0; i8 < 3; ++i8) {
-      T1[(i5 + i8)] = 0;
+    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
+      T1[(i2 + i5)] = 0;
     }
     #pragma unroll
-    for(nvfuser_index_t i8 = 0; i8 < 3; ++i8) {
-      if (b7) {
-        T1[(i5 + i8)]
-           = T0[(i6 + (i2 * (i8 + nvfuser_zero)))];
+    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
+      if (b4) {
+        T1[(i2 + i5)]
+           = T0[(i3 + (T0.alloc_stride[1] * (i5 + nvfuser_zero)))];
       }
     }
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   float T2[3];
   #pragma unroll
-  for(nvfuser_index_t i9 = 0; i9 < 3; ++i9) {
-    T2[i9]
-       = T1[i9];
+  for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
+    T2[i6]
+       = T1[i6];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i10 = 0; i10 < T0.logical_size[0]; ++i10) {
+  for(nvfuser_index_t i7 = 0; i7 < T0.logical_size[0]; ++i7) {
+    nvfuser_index_t i8;
+    i8 = 4 + i7;
+    nvfuser_index_t i9;
+    i9 = 3 * (i8 % 5);
+    nvfuser_index_t i10;
+    i10 = i0 + (T0.alloc_stride[0] * i7);
     nvfuser_index_t i11;
-    i11 = 4 + i10;
+    i11 = 3 * i7;
     nvfuser_index_t i12;
-    i12 = 3 * (i11 % 5);
-    nvfuser_index_t i13;
-    i13 = i3 + (i1 * i10);
-    nvfuser_index_t i14;
-    i14 = 3 * i10;
-    nvfuser_index_t i15;
-    i15 = 3 * ((1 + i10) % 5);
-    bool b16;
-    b16 = i11 < T0.logical_size[0];
+    i12 = 3 * ((1 + i7) % 5);
+    bool b13;
+    b13 = i8 < T0.logical_size[0];
     #pragma unroll
-    for(nvfuser_index_t i8 = 0; i8 < 3; ++i8) {
-      T1[(i12 + i8)] = 0;
+    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
+      T1[(i9 + i5)] = 0;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i8 = 0; i8 < 3; ++i8) {
-      if (b16) {
-        T1[(i12 + i8)]
-           = T0[(i13 + (i2 * (i8 + nvfuser_zero)))];
+    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
+      if (b13) {
+        T1[(i9 + i5)]
+           = T0[(i10 + (T0.alloc_stride[1] * (i5 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     float T3[3];
     #pragma unroll
-    for(nvfuser_index_t i17 = 0; i17 < 3; ++i17) {
-      T3[i17]
-         = T2[i17];
+    for(nvfuser_index_t i14 = 0; i14 < 3; ++i14) {
+      T3[i14]
+         = T2[i14];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i18 = 0; i18 < 3; ++i18) {
-      T4[(i14 + (i18 + nvfuser_zero))]
-         = T3[i18];
+    for(nvfuser_index_t i15 = 0; i15 < 3; ++i15) {
+      T4[(i11 + (i15 + nvfuser_zero))]
+         = T3[i15];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i9 = 0; i9 < 3; ++i9) {
-      T2[i9]
-         = T1[(i15 + i9)];
+    for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
+      T2[i6]
+         = T1[(i12 + i6)];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
   }
@@ -439,113 +415,107 @@ TEST_F(LoopRotationTest, SelectDoubleBufferLoad) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
-  Array<nvfuser_index_t, 2, 1> a0;
-  a0 = (T0).alloc_stride;
+  nvfuser_index_t i0;
+  i0 = 4 * T0.alloc_stride[0];
   nvfuser_index_t i1;
-  i1 = a0[1];
-  nvfuser_index_t i2;
-  i2 = a0[0];
-  nvfuser_index_t i3;
-  i3 = 4 * i2;
-  nvfuser_index_t i4;
-  i4 = 5 * i2;
-  bool b5;
-  b5 = 4 < T0.logical_size[0];
+  i1 = 5 * T0.alloc_stride[0];
+  bool b2;
+  b2 = 4 < T0.logical_size[0];
   float T1[15];
   #pragma unroll
-  for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-    T1[i6] = 0;
+  for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+    T1[i3] = 0;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-    T1[i6]
-       = T0[(i1 * (i6 + nvfuser_zero))];
+  for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+    T1[i3]
+       = T0[(T0.alloc_stride[1] * (i3 + nvfuser_zero))];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i7 = 0; i7 < 4; ++i7) {
-    nvfuser_index_t i8;
-    i8 = 3 + (3 * i7);
-    nvfuser_index_t i9;
-    i9 = i2 + (i2 * i7);
-    bool b10;
-    b10 = ((1 + i7) + nvfuser_zero) < T0.logical_size[0];
+  for(nvfuser_index_t i4 = 0; i4 < 4; ++i4) {
+    nvfuser_index_t i5;
+    i5 = 3 + (3 * i4);
+    nvfuser_index_t i6;
+    i6 = T0.alloc_stride[0] + (T0.alloc_stride[0] * i4);
+    bool b7;
+    b7 = ((1 + i4) + nvfuser_zero) < T0.logical_size[0];
     #pragma unroll
-    for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-      T1[(i8 + i6)] = 0;
+    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+      T1[(i5 + i3)] = 0;
     }
     #pragma unroll
-    for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-      if (b10) {
-        T1[(i8 + i6)]
-           = T0[(i9 + (i1 * (i6 + nvfuser_zero)))];
+    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+      if (b7) {
+        T1[(i5 + i3)]
+           = T0[(i6 + (T0.alloc_stride[1] * (i3 + nvfuser_zero)))];
       }
     }
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   float T2[3];
   #pragma unroll
-  for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-    T1[(12 + i6)] = 0;
+  for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+    T1[(12 + i3)] = 0;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-    if (b5) {
-      T1[(12 + i6)]
-         = T0[(i3 + (i1 * (i6 + nvfuser_zero)))];
+  for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+    if (b2) {
+      T1[(12 + i3)]
+         = T0[(i0 + (T0.alloc_stride[1] * (i3 + nvfuser_zero)))];
     }
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i11 = 0; i11 < 3; ++i11) {
-    T2[i11]
-       = T1[i11];
+  for(nvfuser_index_t i8 = 0; i8 < 3; ++i8) {
+    T2[i8]
+       = T1[i8];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i12 = 0; i12 < T0.logical_size[0]; ++i12) {
+  for(nvfuser_index_t i9 = 0; i9 < T0.logical_size[0]; ++i9) {
+    nvfuser_index_t i10;
+    i10 = 3 * i9;
+    nvfuser_index_t i11;
+    i11 = 3 * (i9 % 5);
+    nvfuser_index_t i12;
+    i12 = i1 + (T0.alloc_stride[0] * i9);
     nvfuser_index_t i13;
-    i13 = 3 * i12;
-    nvfuser_index_t i14;
-    i14 = 3 * (i12 % 5);
-    nvfuser_index_t i15;
-    i15 = i4 + (i2 * i12);
-    nvfuser_index_t i16;
-    i16 = 3 * ((1 + i12) % 5);
-    bool b17;
-    b17 = (5 + i12) < T0.logical_size[0];
+    i13 = 3 * ((1 + i9) % 5);
+    bool b14;
+    b14 = (5 + i9) < T0.logical_size[0];
     float T3[3];
     #pragma unroll
-    for(nvfuser_index_t i18 = 0; i18 < 3; ++i18) {
-      T3[i18]
-         = T2[i18];
+    for(nvfuser_index_t i15 = 0; i15 < 3; ++i15) {
+      T3[i15]
+         = T2[i15];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i19 = 0; i19 < 3; ++i19) {
-      T4[(i13 + (i19 + nvfuser_zero))]
-         = T3[i19];
+    for(nvfuser_index_t i16 = 0; i16 < 3; ++i16) {
+      T4[(i10 + (i16 + nvfuser_zero))]
+         = T3[i16];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-      T1[(i14 + i6)] = 0;
+    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+      T1[(i11 + i3)] = 0;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
-      if (b17) {
-        T1[(i14 + i6)]
-           = T0[(i15 + (i1 * (i6 + nvfuser_zero)))];
+    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+      if (b14) {
+        T1[(i11 + i3)]
+           = T0[(i12 + (T0.alloc_stride[1] * (i3 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i11 = 0; i11 < 3; ++i11) {
-      T2[i11]
-         = T1[(i16 + i11)];
+    for(nvfuser_index_t i8 = 0; i8 < 3; ++i8) {
+      T2[i8]
+         = T1[(i13 + i8)];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
   }
@@ -597,32 +567,20 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   alignas(16) extern __shared__ char array[];
   const unsigned smem_offset = 0;
   NVFUSER_DEFINE_MAGIC_ZERO;
-  Tensor<float, 2, 2> s0;
-  s0.data = T0.data;
-  s0.logical_size = T0.logical_size;
-  s0.alloc_stride = T0.alloc_stride;
-  float* ptr1;
-  ptr1 = s0.data;
-  Array<nvfuser_index_t, 2, 1> a2;
-  a2 = s0.alloc_stride;
-  nvfuser_index_t i3;
-  i3 = a2[0];
-  nvfuser_index_t i4;
-  i4 = a2[1];
-  float* ptr5;
-  ptr5 = ptr1 + (4 * i3);
+  float* ptr0;
+  ptr0 = T0.data + (4 * T0.alloc_stride[0]);
   float* T4 = reinterpret_cast<float*>(array + smem_offset + 0);
   #pragma unroll
-  for(nvfuser_index_t i6 = 0; i6 < 4; ++i6) {
-    float* ptr7;
-    ptr7 = ptr1 + (i3 * i6);
-    unsigned i8;
-    i8 = (toSmem((T4))) + (12 * i6);
-    bool b9;
-    b9 = (i6 + nvfuser_zero) < T0.logical_size[0];
+  for(nvfuser_index_t i1 = 0; i1 < 4; ++i1) {
+    float* ptr2;
+    ptr2 = T0.data + (T0.alloc_stride[0] * i1);
+    unsigned i3;
+    i3 = toSmem(T4) + (12 * i1);
+    bool b4;
+    b4 = (i1 + nvfuser_zero) < T0.logical_size[0];
     #pragma unroll
-    for(nvfuser_index_t i10 = 0; i10 < 3; ++i10) {
-      Ampere::cpAsyncCa<float, 1>((i8 + (4 * i10)), (ptr7 + (i4 * (i10 + nvfuser_zero))), b9);
+    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
+      Ampere::cpAsyncCa<float, 1>((i3 + (4 * i5)), (ptr2 + (T0.alloc_stride[1] * (i5 + nvfuser_zero))), b4);
     }
     Ampere::cpAsyncCommit();
   }
@@ -632,45 +590,45 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   T1[0]
      = T4[0];
   #pragma unroll 1
-  for(nvfuser_index_t i11 = 0; i11 < T0.logical_size[0]; ++i11) {
-    float* ptr12;
-    ptr12 = ptr5 + (i3 * i11);
-    nvfuser_index_t i13;
-    i13 = 4 + i11;
-    unsigned i14;
-    i14 = (toSmem((T4))) + (12 * (i13 % 5));
-    nvfuser_index_t i15;
-    i15 = 1 + (3 * (i11 % 5));
-    nvfuser_index_t i16;
-    i16 = 3 * i11;
-    bool b17;
-    b17 = i13 < T0.logical_size[0];
+  for(nvfuser_index_t i6 = 0; i6 < T0.logical_size[0]; ++i6) {
+    float* ptr7;
+    ptr7 = ptr0 + (T0.alloc_stride[0] * i6);
+    nvfuser_index_t i8;
+    i8 = 4 + i6;
+    unsigned i9;
+    i9 = toSmem(T4) + (12 * (i8 % 5));
+    nvfuser_index_t i10;
+    i10 = 1 + (3 * (i6 % 5));
+    nvfuser_index_t i11;
+    i11 = 3 * i6;
+    bool b12;
+    b12 = i8 < T0.logical_size[0];
     #pragma unroll
-    for(nvfuser_index_t i10 = 0; i10 < 3; ++i10) {
-      Ampere::cpAsyncCa<float, 1>((i14 + (4 * i10)), (ptr12 + (i4 * (i10 + nvfuser_zero))), b17);
+    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
+      Ampere::cpAsyncCa<float, 1>((i9 + (4 * i5)), (ptr7 + (T0.alloc_stride[1] * (i5 + nvfuser_zero))), b12);
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     Ampere::cpAsyncCommit();
     #pragma unroll
-    for(nvfuser_index_t i18 = 0; i18 < 2; ++i18) {
-      T1[((1 + i18) % 2)]
-         = T4[(i15 + i18)];
+    for(nvfuser_index_t i13 = 0; i13 < 2; ++i13) {
+      T1[((1 + i13) % 2)]
+         = T4[(i10 + i13)];
       float T2[1];
       T2[0]
-         = T1[(i18 % 2)];
-      T3[(i16 + (i18 + nvfuser_zero))]
+         = T1[(i13 % 2)];
+      T3[(i11 + (i13 + nvfuser_zero))]
          = T2[0];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     float T2[1];
     T2[0]
        = T1[0];
-    T3[(2 + i16)]
+    T3[(2 + i11)]
        = T2[0];
     NVFUSER_UPDATE_MAGIC_ZERO;
     Ampere::cpAsyncPartialBarrier<3>();
     T1[0]
-       = T4[(3 * ((1 + i11) % 5))];
+       = T4[(3 * ((1 + i6) % 5))];
   }
 }
 )";


### PR DESCRIPTION
By intentionally not allocating some identified common subexpr, we can make the generated code less verbose and more readable