### PR TITLE
Support for parallelization accross devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,10 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/multidevice/collective.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/communicator.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/executor.cpp
-  ${NVFUSER_SRCS_DIR}/multidevice/runtime.cpp
+  ${NVFUSER_SRCS_DIR}/multidevice/lower_communication.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/pipeline.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/pipeline_ir.cpp
+  ${NVFUSER_SRCS_DIR}/multidevice/runtime.cpp
   ${NVFUSER_SRCS_DIR}/mutator.cpp
   ${NVFUSER_SRCS_DIR}/non_divisible_split.cpp
   ${NVFUSER_SRCS_DIR}/ops/alias.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/device_lower/lower2device.cpp
   ${NVFUSER_SRCS_DIR}/manager.cpp
   ${NVFUSER_SRCS_DIR}/maxinfo_propagator.cpp
+  ${NVFUSER_SRCS_DIR}/multidevice/collective.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/communicator.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/executor.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/runtime.cpp

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1215,6 +1215,34 @@ std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::
   return global_buffers;
 }
 
+std::vector<at::Tensor> FusionExecutor::allocOutputSpace(
+    const at::ArrayRef<c10::IValue>& inputs) {
+  auto kernel_inputs = KernelArgumentHolder::createKernelArgumentHolder(inputs);
+  auto expr_eval =
+      executor_utils::bindInputs(kernel_inputs, lowered_->kernel());
+
+  auto input_alias_indices_entry =
+      executor_utils::caching::ExecutorCompileTimeEntry<
+          executor_utils::caching::InputAliasIndices>(
+          compileTimeDataCache(), [&]() {
+            return std::make_unique<std::vector<std::pair<int, int>>>(
+                fusion_->getOutputToInputAliasIndices());
+          });
+
+  const auto& output_to_input_aliases = input_alias_indices_entry.get();
+
+  auto output_info = getOutputBufferInfo(
+      kernel_inputs, expr_eval, output_to_input_aliases, kernel()->indexType());
+
+  return allocOutputs(
+      kernel(),
+      output_info,
+      output_to_input_aliases,
+      kernel_inputs,
+      options_.device,
+      expr_eval);
+}
+
 std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::
     getOutputBufferInfo(
         const KernelArgumentHolder& args,

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -260,6 +260,12 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
       Fusion* fusion,
       CompileParams compile_params);
 
+  //! Used in distributed setting where we only want to
+  //!  allocate output space and receive output data from
+  //!  a different rank instead of computing them.
+  std::vector<at::Tensor> allocOutputSpace(
+      const at::ArrayRef<c10::IValue>& inputs);
+
  private:
   static std::string kernelNamespace() {
     return "CudaCodeGen";

--- a/csrc/multidevice/collective.cpp
+++ b/csrc/multidevice/collective.cpp
@@ -1,0 +1,192 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#ifdef USE_DISTRIBUTED
+
+#include <multidevice/collective.h>
+
+namespace nvfuser {
+
+static inline void doLocalCopy(at::Tensor dst, at::Tensor src) {
+  // TODO: can we make it non-blocking?
+  at::copy(dst, src, /*non_blocking*/ true);
+}
+
+static inline std::vector<std::vector<at::Tensor>> setBufList(
+    std::vector<at::Tensor>& bufs) {
+  return {std::move(bufs)};
+}
+
+static inline void assertBufferCount(
+    std::vector<at::Tensor> bufs,
+    size_t count) {
+  TORCH_INTERNAL_ASSERT(
+      bufs.size() == count,
+      "there must be ",
+      count,
+      " buffer(s), but ",
+      bufs.size(),
+      " were given");
+}
+
+static inline void assertBuffersHaveSameSize(std::vector<at::Tensor> bufs) {
+  if (bufs.size() < 2) {
+    return;
+  }
+  auto sizes = bufs.at(0).sizes();
+  for (auto& buf : bufs) {
+    TORCH_INTERNAL_ASSERT(
+        buf.sizes() == sizes, "all buffers must have the same size");
+  }
+}
+
+void Collective::post() {
+  if (!is_init_) {
+    init();
+    is_init_ = true;
+  }
+
+  TORCH_INTERNAL_ASSERT(
+      !work_, "the collective must complete before being posted again");
+  post_specialized();
+};
+
+bool Collective::test() {
+  if (!work_)
+    return true;
+  bool ret = work_->isCompleted();
+  if (ret) {
+    work_ = nullptr;
+  }
+  return ret;
+}
+
+void Collective::wait() {
+  if (!work_)
+    return;
+  TORCH_INTERNAL_ASSERT(work_->wait(), "the collective has been aborted");
+  work_ = nullptr;
+}
+
+void Collective::init() {
+  assertBuffersHaveSameSize(src_bufs_);
+  assertBuffersHaveSameSize(dst_bufs_);
+
+  TORCH_INTERNAL_ASSERT(
+      std::unique(team_.begin(), team_.end()) == team_.end(),
+      "the collective must not involve the same device more than once");
+  TORCH_INTERNAL_ASSERT(
+      comm_,
+      "the communicator of the collective must be set before using the method setCommunicator");
+  TORCH_INTERNAL_ASSERT(
+      std::find(team_.begin(), team_.end(), comm_->deviceId()) != team_.end(),
+      "current device index ",
+      comm_->deviceId(),
+      " must be present in the collective's team");
+  TORCH_INTERNAL_ASSERT(!team_.empty(), "the team is empty");
+  backend_ = comm_->getTeam(team_);
+  if (has_root_) {
+    auto it = std::find(team_.begin(), team_.end(), root_);
+    TORCH_INTERNAL_ASSERT(
+        it != team_.end(),
+        "root (device ",
+        root_,
+        ") must be present in the collective's team");
+    root_rank_ = std::distance(team_.begin(), it);
+  }
+
+  init_specialized();
+}
+
+std::string Collective::toString(int indent) const {
+  std::stringstream ss;
+  std::string ext_indent(" ", indent);
+  std::string indent1 = ext_indent + "  ";
+  std::string indent2 = ext_indent + "    ";
+
+  ss << ext_indent << "Collective " << collective_type_ << ": {\n";
+
+  if (has_root_) {
+    ss << indent1 << "root: " << root_ << ",\n";
+  }
+  ss << indent1 << "team: {";
+  for (auto r : team_) {
+    ss << r << ", ";
+  }
+  ss << indent1 << "}\n";
+  ss << indent1 << "src_bufs: {";
+  for (auto& t : src_bufs_) {
+    ss << "\n" << t;
+  }
+  ss << "\n" << indent1 << "}\n";
+  ss << ext_indent << "}";
+
+  return ss.str();
+}
+
+void Broadcast::post_specialized() {
+  if (comm_->deviceId() == root_ && !dst_bufs_.empty()) {
+    doLocalCopy(dst_bufs_.at(0), src_bufs_.at(0));
+    if (team_.size() == 1)
+      return;
+  }
+  work_ = backend_->broadcast(
+      comm_->deviceId() == root_ ? src_bufs_ : dst_bufs_,
+      {.rootRank = root_rank_});
+}
+
+void Broadcast::init_specialized() {
+  if (comm_->deviceId() == root_) {
+    assertBufferCount(src_bufs_, 1);
+    assertBufferCount(dst_bufs_, 0);
+  } else {
+    assertBufferCount(src_bufs_, 0);
+    assertBufferCount(dst_bufs_, 1);
+  }
+}
+
+void Gather::post_specialized() {
+  work_ = backend_->gather(buf_list_, src_bufs_, {.rootRank = root_rank_});
+}
+
+void Gather::init_specialized() {
+  assertBufferCount(src_bufs_, 1);
+  if (comm_->deviceId() == root_) {
+    assertBufferCount(dst_bufs_, team_.size());
+    buf_list_ = setBufList(dst_bufs_);
+  } else {
+    assertBufferCount(dst_bufs_, 0);
+  }
+}
+
+void Allgather::post_specialized() {
+  work_ = backend_->allgather(buf_list_, src_bufs_, {});
+}
+
+void Allgather::init_specialized() {
+  assertBufferCount(src_bufs_, 1);
+  assertBufferCount(dst_bufs_, team_.size());
+  buf_list_ = setBufList(dst_bufs_);
+}
+
+void Scatter::post_specialized() {
+  work_ = backend_->scatter(dst_bufs_, buf_list_, {.rootRank = root_rank_});
+}
+
+void Scatter::init_specialized() {
+  assertBufferCount(dst_bufs_, 1);
+  if (comm_->deviceId() == root_) {
+    assertBufferCount(src_bufs_, team_.size());
+    buf_list_ = setBufList(src_bufs_);
+  } else {
+    assertBufferCount(src_bufs_, 0);
+  }
+}
+
+} // namespace nvfuser
+
+#endif

--- a/csrc/multidevice/collective.h
+++ b/csrc/multidevice/collective.h
@@ -1,0 +1,230 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+#ifdef USE_DISTRIBUTED
+
+#include <multidevice/communicator.h>
+#include <multidevice/multidevice.h>
+
+namespace nvfuser {
+
+/*
+This file implements the class "Collective" which represents a MPI collective
+communication operation to be executed on the network. The base class Collective
+should not be used directly but through its derived classes:
+Broadcast, Gather, Scatter, Allgather. Other collectives will be added later.
+
+Later, Collective could be made a derived class of Expr and be thought
+as a kernel IRs resulting of the lowering of a PipelineCommunication.
+
+The flow for using this class is as follows:
+1. After instantiation of a derived class, specify the argument of the
+   collective through the class's interface using the methods "setCommunicator",
+   "addDevice", "addSrcBuf", "addDstBuf", "setRoot" (if applicable). Each rank
+   (associated with a device index) will fill the args differently, depending on
+   the role they play in this collective. In particular, the ranks not
+   participating in the collective should not instantiate it.
+2. The method "post" triggers the execution of the collective. This call is
+   non-blocking. After this call, the args of the collective cannot be changed
+   (and the methods listed in 1. will throw). Once the collective has complete,
+   it can be posted again (the initialization overhead occurs only on the first
+   post)
+3. Once posted, "test" allows to test for completion of the collective
+   The method "wait" blocks until completion.
+*/
+
+class TORCH_CUDA_CU_API Collective {
+ public:
+  virtual ~Collective() = default;
+
+  std::string toString(int indent = 0) const;
+
+  // Set the backend communicator to be used for executing the collective
+  void setCommunicator(Communicator* comm) {
+    assertIsNotInit();
+    comm_ = comm;
+  }
+
+  // Add a device index to the team that will perform the collective
+  void addDevice(const DeviceIdxType device) {
+    assertIsNotInit();
+    team_.push_back(device);
+  }
+
+  // Add a source buffer
+  void addSrcBuf(at::Tensor buf) {
+    assertIsNotInit();
+    src_bufs_.push_back(buf);
+  }
+
+  // Add a destination buffer
+  void addDstBuf(at::Tensor buf) {
+    assertIsNotInit();
+    dst_bufs_.push_back(buf);
+  }
+
+  // Set the root of the collective (if applicable)
+  void setRoot(const DeviceIdxType root) {
+    TORCH_INTERNAL_ASSERT(has_root_, "this collective must not be rooted");
+    assertIsNotInit();
+    root_ = root;
+  }
+
+  // Triggers the execution of the collective. This is a non-blocking call.
+  // Once this method is called, the argument of the collective cannot be
+  // modified. Once the collective has complete, it can be posted again. The
+  // initialization overhead occurs only on the first post
+  virtual void post() final;
+
+  // Returns true if the collective has complete, false if it is in progress.
+  // This method can only be called after the collective has been posted.
+  bool test();
+
+  // Blocks until completion
+  // This method can only be called after the collective has been posted.
+  void wait();
+
+ protected:
+  // name is for printing purposes and has_root indicates is the collective is
+  // rooted
+  Collective(std::string name, bool has_root)
+      : collective_type_(std::move(name)), has_root_(has_root){};
+
+ private:
+  void assertIsNotInit() {
+    TORCH_INTERNAL_ASSERT(
+        !is_init_, "this method cannot be called after the collective is init");
+  }
+
+  // Perform the prelimiary set up before the collective can be posted.
+  // Once called, the arguments of the collective cannot be modified.
+  // After the method has been called once, the collective can be posted
+  // multiple times without the need of calling again this method
+  virtual void init() final;
+  // implemented in the derived classes, called inside "init"
+  // performs the initialization specific to the derived class
+  virtual void init_specialized() {
+    TORCH_INTERNAL_ASSERT(false, "not implemented in the base class");
+  }
+
+  // implemented in the derived classes, called inside "post"
+  virtual void post_specialized() {
+    TORCH_INTERNAL_ASSERT(false, "not implemented in the base class");
+  }
+
+ protected:
+  // Stores the world communicator
+  Communicator* comm_ = nullptr;
+  DeviceIdxType root_ = 0;
+  std::vector<at::Tensor> src_bufs_;
+  std::vector<at::Tensor> dst_bufs_;
+  // Stores all the device indices that will participate in the collective
+  std::vector<DeviceIdxType> team_;
+  c10::intrusive_ptr<c10d::Work> work_ = nullptr;
+  // Stores the team's backend that will perform the collective
+  c10::intrusive_ptr<c10d::Backend> backend_ = nullptr;
+  // utility buffer used in Gather and Scatter derived classes
+  std::vector<std::vector<at::Tensor>> buf_list_;
+  // stores the index of the root in the team
+  DeviceIdxType root_rank_ = 0;
+
+ private:
+  // used for printing
+  std::string collective_type_;
+  // track if the collective has already been initialized
+  bool is_init_ = false;
+  // indicates if the collective is rooted
+  bool has_root_ = false;
+};
+
+/*
+Copies the unique src buffer of the root to the unique dst buffer of the other
+device For convenience, we allow the root to have a unique dst buffer as well,
+in which we perform a local copy when "post()" is called. Note that this extends
+the classic MPI definition of Broadcast
+
+Requirements:
+  - the communicator is set
+  - the root is set
+  - the root has one src buffer, and zero or one dst buffer
+  - non-roots have no src buffer and exactly one dst buffer
+  - All buffers have the same size
+*/
+class TORCH_CUDA_CU_API Broadcast : public Collective {
+ public:
+  Broadcast() : Collective("broadcast", true){};
+
+ private:
+  void init_specialized() override;
+  void post_specialized() override;
+};
+
+/*
+Copies each of the unique src buffer of each device to the respective src
+buffers of the root. The order of the sender devices matches the order of the
+root's buffers
+
+Requirements:
+  - the communicator is set
+  - the root is set
+  - the root has one src buffer and <team_size> dst buffers
+  - non-roots have one src buffer and no dst buffer
+  - All buffers have the same size
+*/
+class TORCH_CUDA_CU_API Gather : public Collective {
+ public:
+  Gather() : Collective("gather", true){};
+
+ private:
+  void init_specialized() override;
+  void post_specialized() override;
+};
+
+/*
+Copies each of the unique src buffer of each device to the respective src
+buffers of each device. The order of the devices matches the order of the
+buffers
+
+Requirements:
+  - the communicator is set
+  - all device have one src buffer and <team_size> dst buffers
+  - All buffers have the same size
+*/
+class TORCH_CUDA_CU_API Allgather : public Collective {
+ public:
+  Allgather() : Collective("allgather", false){};
+
+ private:
+  void init_specialized() override;
+  void post_specialized() override;
+};
+
+/*
+Copies each of the <team_size> src buffers of the root to the unique dst buffer
+of the respective receiver device. The order of the buffer matches the order of
+the receiver devices
+
+Requirements:
+  - the communicator is set
+  - the root is set
+  - the root has <team_size> src buffers and one dst buffer
+  - non-roots have no src buffer and one dst buffer
+  - All buffers have the same size
+*/
+class TORCH_CUDA_CU_API Scatter : public Collective {
+ public:
+  Scatter() : Collective("scatter", true){};
+
+ private:
+  void init_specialized() override;
+  void post_specialized() override;
+};
+
+} // namespace nvfuser
+
+#endif

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -27,9 +27,9 @@ namespace nvfuser {
 // Returns true if the distributed configuration is valid, false otherwise
 bool parseEnv(
     RankType& rank,
-    int64_t& size,
+    uint64_t& size,
     RankType& local_rank,
-    int64_t& local_size,
+    uint64_t& local_size,
     std::string& master_addr,
     int& master_port) {
   char* env = nullptr;
@@ -52,7 +52,7 @@ bool parseEnv(
       return false;
     }
   }
-  size = std::atoi(env);
+  size = static_cast<uint64_t>(std::atoi(env));
 
   // retrieves the size of the communicator
   env = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
@@ -72,7 +72,7 @@ bool parseEnv(
       return false;
     }
   }
-  local_size = std::atoi(env);
+  local_size = static_cast<uint64_t>(std::atoi(env));
 
   // retrieves master address
   env = std::getenv("MASTER_ADDR");

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -101,9 +101,9 @@ class TORCH_CUDA_CU_API Communicator {
   bool is_available_;
   CommunicatorBackend backend_;
   RankType rank_;
-  int64_t size_;
+  uint64_t size_;
   RankType local_rank_;
-  int64_t local_size_;
+  uint64_t local_size_;
   std::string master_addr_;
   int master_port_;
   // stores the world's store used for the backend init

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -12,63 +12,51 @@
 namespace nvfuser {
 
 /*
-   The class DevishMesh represents a set of devices on which a Pipeline Stage
-   will be executed. This can be simply seen as a list (or n-array) of device
-   indices (i.e. ints). Here, "dimensions" stands for the shape of the Mesh seen
-   as an array. By default, we assume a flat Mesh, i.e., dimensions =
-   (number_of_device_indices)
+   The class DeviceMesh represents a set of (unique) devices on which a Pipeline
+   Stage will be executed. For now, we only support flat meshes, but later we
+   will add support for n-dimensional meshes.
 */
 class DeviceMesh final {
  public:
-  // return the flatten vector of device indices
-  const auto& deviceIndices() const {
-    return device_indices_;
+  DeviceMesh(std::vector<DeviceIdxType> devices = {0}) {
+    set_(devices);
   }
 
-  // return the shape of the mesh
-  const auto& dimensions() const {
-    return dimensions_;
+  DeviceMesh& operator=(const std::vector<DeviceIdxType>& devices) {
+    set_(devices);
+    return *this;
   }
 
-  // return the total length of the mesh
-  int64_t size() const {
-    int64_t ret = 1;
-    for (auto dimension : dimensions_) {
-      ret *= dimension;
-    }
-    return ret;
+  // return a vector containing the device indices of the mesh
+  const auto& vector() const {
+    return vector_;
   }
 
-  // set the attributes of the mesh
-  void set(
-      std::vector<DeviceIdxType> device_indices,
-      std::vector<DimensionType> dimensions) {
-    device_indices_ = std::move(device_indices);
-    dimensions_ = std::move(dimensions);
+  // returns whether a device is present in the mesh
+  bool has(const DeviceIdxType device) const {
+    return std::find(vector_.begin(), vector_.end(), device) != vector_.end();
+  }
 
+  // returns the index (or position) of a device that has been previously added
+  // to the collective throws if the device is not found
+  DeviceIdxType findIndex(const DeviceIdxType device) const {
+    auto it = std::find(vector_.begin(), vector_.end(), device);
     TORCH_INTERNAL_ASSERT(
-        validate(device_indices_), "invalid parameters for Mesh Device");
-  }
-
-  void set(std::vector<DeviceIdxType> device_indices) {
-    DimensionType length = static_cast<DimensionType>(device_indices.size());
-    set(std::move(device_indices), {length});
+        it != vector_.end(), "device index ", device, " is not in the mesh");
+    return std::distance(vector_.begin(), it);
   }
 
  private:
-  /*
-    returns whether the mesh is valid, i.e., its size is strictly positive and
-    the size matches the number of device indices.
-  */
-  bool validate(const std::vector<DeviceIdxType>& device_indices) {
-    return (
-        size() == static_cast<int64_t>(device_indices.size()) && size() > 0);
+  void set_(std::vector<DeviceIdxType> devices) {
+    vector_ = devices;
+    TORCH_INTERNAL_ASSERT(!devices.empty(), "empty device mesh");
+    TORCH_INTERNAL_ASSERT(
+        std::unique(vector_.begin(), vector_.end()) == vector_.end(),
+        "device mesh has duplicates");
   }
 
-  // stores the device indices
-  std::vector<DeviceIdxType> device_indices_;
-  // stores the mesh shape
-  std::vector<DimensionType> dimensions_;
+  // stores the list of device indices
+  std::vector<DeviceIdxType> vector_;
 };
 
 } // namespace nvfuser

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -13,13 +13,9 @@
 namespace nvfuser {
 
 bool PipelineExecutor::shouldRun(PipelineStage* stage) {
-  if (!should_run_.count(stage)) {
+  if (should_run_.find(stage) == should_run_.end()) {
     should_run_.emplace(
-        stage,
-        std::count(
-            stage->descriptor()->mesh.deviceIndices().begin(),
-            stage->descriptor()->mesh.deviceIndices().end(),
-            runtime_.rankToDiD(runtime_.rank())));
+        stage, stage->descriptor()->mesh.has(runtime_.comm_.deviceId()));
   }
   return should_run_[stage];
 }
@@ -31,19 +27,40 @@ void PipelineExecutor::handle(PipelineStage* stage) {
     stage_input_IValues.push_back(val_to_IValue_[input_val]);
   }
 
-  // Create the stage executor
-  if (!fec_.count(stage)) {
-    fec_.emplace(
-        stage,
-        std::make_unique<FusionExecutorCache>(
-            runtime_.pipeline_->stageToFusion(stage)));
+  std::vector<at::Tensor> outputs;
+
+  // Compile the stage and either execute it or allocate output buffers
+  // if the stage is configured to be autoscheduled, use FusionExecutorCache,
+  // otherwise use FusionExecutor
+  if (stage->descriptor()->auto_schedule) {
+    // Check if the executor has been cached. If not, create and cache it
+    if (fec_.find(stage) == fec_.end()) {
+      fec_.emplace(
+          stage,
+          std::make_unique<FusionExecutorCache>(
+              runtime_.pipeline_->stageToFusion(stage)));
+    }
+    // Run the stage to get concrete outputs or placeholders
+    // TODO: reimplement allocOutputSpace
+    // TODO: allocate output space only if strictly necessary,
+    //       and move the allocation to
+    //       PipelineExecutor::handle(PipelineCommunication*)
+    outputs = shouldRun(stage)
+        ? fec_[stage]->runFusionWithInputs(stage_input_IValues)
+        : fec_[stage]->allocOutputSpace(stage_input_IValues);
+
+  } else {
+    // Check if the executor has been cached. If not, create and cache it
+    if (fe_.find(stage) == fe_.end()) {
+      fe_.emplace(stage, std::make_unique<FusionExecutor>());
+      fe_[stage]->compileFusion(
+          runtime_.pipeline_->stageToFusion(stage).get(), stage_input_IValues);
+    }
+    // Run the stage to get concrete outputs or placeholders
+    outputs = shouldRun(stage)
+        ? fe_[stage]->runFusion(stage_input_IValues)
+        : fe_[stage]->allocOutputSpace(stage_input_IValues);
   }
-  // Run the stage to get concrete outputs or placeholders
-  // TODO: reimplement allocOutputSpace
-  // TODO: allocate output space only if strictly necessary
-  std::vector<at::Tensor> outputs = shouldRun(stage)
-      ? fec_[stage]->runFusionWithInputs(stage_input_IValues)
-      : fec_[stage]->allocOutputSpace(stage_input_IValues);
 
   // Store the outputs or placeholders in the context
   for (auto output_idx : c10::irange(stage->outputs().size())) {

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -10,6 +10,7 @@
 
 #include <iter_visitor.h>
 #include <kernel_cache.h>
+#include <multidevice/collective.h>
 #include <multidevice/pipeline_ir.h>
 #include <multidevice/runtime.h>
 
@@ -44,6 +45,11 @@ class PipelineExecutor : public IterVisitor {
   // Stores FusionExecutor(Cache) for each PipelineStage
   std::unordered_map<PipelineStage*, std::unique_ptr<FusionExecutor>> fe_;
   std::unordered_map<PipelineStage*, std::unique_ptr<FusionExecutorCache>> fec_;
+  // Stores the resulting Collectives after lowering each PipelineCommunication
+  std::unordered_map<
+      PipelineCommunication*,
+      std::vector<std::shared_ptr<Collective>>>
+      colls_;
 
   // Cache results of shouldRun method
   std::unordered_map<PipelineStage*, bool> should_run_;

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -41,7 +41,8 @@ class PipelineExecutor : public IterVisitor {
   // Stores concrete computed values,
   std::unordered_map<Val*, c10::IValue> val_to_IValue_;
 
-  // Stores FusionExecutorCache for each PipelineStage
+  // Stores FusionExecutor(Cache) for each PipelineStage
+  std::unordered_map<PipelineStage*, std::unique_ptr<FusionExecutor>> fe_;
   std::unordered_map<PipelineStage*, std::unique_ptr<FusionExecutorCache>> fec_;
 
   // Cache results of shouldRun method

--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -84,7 +84,7 @@ void FillGatherScatter(
 
   if (device_index == root) {
     for (auto i : c10::irange(mesh.vector().size())) {
-      addBuf(root_buf.index({i, "..."}), !is_scatter, coll);
+      addBuf(root_buf.index({static_cast<int>(i), "..."}), !is_scatter, coll);
     }
     // The scatter/gather semantics imposes the root to be both
     // sender and receiver. If the root is not in the mesh, we thus
@@ -159,7 +159,7 @@ void lowerToAllgather(
     coll->addDevice(src);
   }
   for (auto i : c10::irange(mesh.vector().size())) {
-    coll->addDstBuf(output_tensor.index({i, "..."}));
+    coll->addDstBuf(output_tensor.index({static_cast<int>(i), "..."}));
   }
   coll->addSrcBuf(input_tensor.index({mesh.findIndex(device_index), "..."}));
 
@@ -214,8 +214,8 @@ void lowerToBroadcast(
           device_index,
           sender_mesh.vector().at(i),
           DeviceMesh({receiver_mesh.vector().at(i)}),
-          input_tensor.index({i, "..."}),
-          output_tensor.index({i, "..."}),
+          input_tensor.index({static_cast<int>(i), "..."}),
+          output_tensor.index({static_cast<int>(i), "..."}),
           colls);
     }
   } else {

--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -1,0 +1,320 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#ifdef USE_DISTRIBUTED
+#include <ir/interface_nodes.h>
+#include <multidevice/device_mesh.h>
+#include <multidevice/lower_communication.h>
+#include <multidevice/pipeline.h>
+
+namespace nvfuser {
+
+// Returns whether a TensorView has its first axis parallelized on Didx
+// Checks that the other axis are not parallelized on Didx
+bool isParallelD(TensorView* tv) {
+  std::vector<bool> is_parallel_d;
+  for (IterDomain* id : tv->getRootDomain()) {
+    is_parallel_d.push_back(isParallelTypeDeviceDim(id->getParallelType()));
+  }
+  // Currently, only the most external dim is alloed to be parallelized
+  for (auto i : c10::irange(1, is_parallel_d.size())) {
+    TORCH_INTERNAL_ASSERT(
+        !is_parallel_d.at(i),
+        "only the outmost dimension can be device-parallelized");
+  }
+  return is_parallel_d.empty() ? false : is_parallel_d.at(0);
+}
+
+// utility function that add a buff as a collective's src or dst depending on
+// the bool to_dst
+static inline void addBuf(
+    at::Tensor buf,
+    bool to_dst,
+    std::shared_ptr<Collective> coll) {
+  to_dst ? coll->addDstBuf(buf) : coll->addSrcBuf(buf);
+}
+
+static inline bool isDeviceInvolved(
+    DeviceIdxType device_index,
+    DeviceIdxType root,
+    DeviceMesh mesh) {
+  return device_index == root || mesh.has(device_index);
+}
+
+static inline bool isDeviceInvolved(
+    DeviceIdxType device_index,
+    DeviceMesh sender_mesh,
+    DeviceMesh receiver_mesh) {
+  return sender_mesh.has(device_index) || receiver_mesh.has(device_index);
+}
+
+static inline at::Tensor createDummyTensor(at::Tensor reference) {
+  return at::empty(reference.sizes(), reference.options());
+}
+
+// Utility function used for setting up a scatter or gather collective "coll".
+// Since most  of the steps are somewhat similar/opposite in those cases,
+// we gathered the two implementations into one function.
+// The argument "is_scatter" allows to discriminate which collective type
+// "coll" actually is.
+void FillGatherScatter(
+    DeviceIdxType device_index,
+    DeviceIdxType root,
+    DeviceMesh mesh, // is_scatter? receivers : senders
+    at::Tensor root_buf, // is_scatter? input buf : output buf
+    at::Tensor buf, // is_scatter? output buf : input buf
+    bool is_scatter,
+    std::shared_ptr<Collective> coll) {
+  coll->setRoot(root);
+  for (auto dst : mesh.vector()) {
+    coll->addDevice(dst);
+  }
+  bool is_root_in_mesh = mesh.has(root);
+  if (!is_root_in_mesh) {
+    coll->addDevice(root);
+  }
+
+  if (mesh.has(device_index)) {
+    addBuf(buf.index({mesh.findIndex(device_index), "..."}), is_scatter, coll);
+  }
+
+  if (device_index == root) {
+    for (auto i : c10::irange(mesh.vector().size())) {
+      addBuf(root_buf.index({i, "..."}), !is_scatter, coll);
+    }
+    // The scatter/gather semantics imposes the root to be both
+    // sender and receiver. If the root is not in the mesh, we thus
+    // have to artificially make it send and receive a dummy buffer
+    // Since it is an "inplace" operation, this should not cause any overhead
+    if (!is_root_in_mesh) {
+      at::Tensor dummy = createDummyTensor(root_buf.index({0, "..."}));
+      addBuf(dummy, true, coll);
+      addBuf(dummy, false, coll);
+    }
+  }
+}
+
+void lowerToScatter(
+    DeviceIdxType device_index,
+    DeviceMesh sender_mesh,
+    DeviceMesh receiver_mesh,
+    at::Tensor input_tensor,
+    at::Tensor output_tensor,
+    std::vector<std::shared_ptr<Collective>>& colls) {
+  // we arbitrarily choose the first device of the sender mesh to be the root
+  auto root = sender_mesh.vector().at(0);
+  if (!isDeviceInvolved(device_index, root, receiver_mesh))
+    return;
+  auto coll = std::make_shared<Scatter>();
+  FillGatherScatter(
+      device_index,
+      root,
+      receiver_mesh,
+      input_tensor,
+      output_tensor,
+      true,
+      coll);
+  colls.push_back(coll);
+}
+
+void lowerToGather(
+    DeviceIdxType device_index,
+    DeviceMesh sender_mesh,
+    DeviceMesh receiver_mesh,
+    at::Tensor input_tensor,
+    at::Tensor output_tensor,
+    std::vector<std::shared_ptr<Collective>>& colls) {
+  // we create as many Gathers as there are devices in the receiver mesh
+  for (auto root : receiver_mesh.vector()) {
+    if (!isDeviceInvolved(device_index, root, sender_mesh))
+      continue;
+    auto coll = std::make_shared<Gather>();
+    FillGatherScatter(
+        device_index,
+        root,
+        sender_mesh,
+        output_tensor,
+        input_tensor,
+        false,
+        coll);
+    colls.push_back(coll);
+  }
+}
+
+void lowerToAllgather(
+    DeviceIdxType device_index,
+    DeviceMesh mesh,
+    at::Tensor input_tensor,
+    at::Tensor output_tensor,
+    std::vector<std::shared_ptr<Collective>>& colls) {
+  if (!mesh.has(device_index))
+    return;
+
+  auto coll = std::make_shared<Allgather>();
+  for (auto src : mesh.vector()) {
+    coll->addDevice(src);
+  }
+  for (auto i : c10::irange(mesh.vector().size())) {
+    coll->addDstBuf(output_tensor.index({i, "..."}));
+  }
+  coll->addSrcBuf(input_tensor.index({mesh.findIndex(device_index), "..."}));
+
+  colls.push_back(coll);
+}
+
+void lowerToSingleBroadcast(
+    DeviceIdxType device_index,
+    DeviceIdxType root,
+    DeviceMesh mesh, // receiver devices
+    at::Tensor input_tensor,
+    at::Tensor output_tensor,
+    std::vector<std::shared_ptr<Collective>>& colls) {
+  if (!isDeviceInvolved(device_index, root, mesh))
+    return;
+
+  auto coll = std::make_shared<Broadcast>();
+  coll->setRoot(root);
+  for (auto dst : mesh.vector()) {
+    coll->addDevice(dst);
+  }
+
+  if (!mesh.has(root)) {
+    coll->addDevice(root);
+  }
+
+  if (device_index == root) {
+    coll->addSrcBuf(input_tensor);
+  } else {
+    coll->addDstBuf(output_tensor);
+  }
+
+  colls.push_back(coll);
+}
+
+// For now, we assume that this function is called only if
+// the input and output have the same parallelization (given by
+// the argument "is_parallelized"). Later we could support more general cases.
+void lowerToBroadcast(
+    DeviceIdxType device_index,
+    DeviceMesh sender_mesh,
+    DeviceMesh receiver_mesh,
+    at::Tensor input_tensor,
+    at::Tensor output_tensor,
+    bool is_parallelized,
+    std::vector<std::shared_ptr<Collective>>& colls) {
+  if (is_parallelized) {
+    // if the inputs and ouputs are parallelized,
+    // we create as many Broadcast as that will be handled in parallel
+    for (auto i : c10::irange(sender_mesh.vector().size())) {
+      lowerToSingleBroadcast(
+          device_index,
+          sender_mesh.vector().at(i),
+          DeviceMesh({receiver_mesh.vector().at(i)}),
+          input_tensor.index({i, "..."}),
+          output_tensor.index({i, "..."}),
+          colls);
+    }
+  } else {
+    // we arbitrarily choose the first device of the sender mesh to be the root
+    lowerToSingleBroadcast(
+        device_index,
+        sender_mesh.vector().at(0),
+        receiver_mesh,
+        input_tensor,
+        output_tensor,
+        colls);
+  }
+}
+
+/*
+TODO:
+*) Propose several lowering paths for each given communication
+   and provide a logic to decide which path to take
+*) Leverage replication in the source to create several collectives handled in
+parallel The idea would be to evenly split the destinations accross the sources
+*) Leverage the topology to ensure that the senders and recerivers are close
+*/
+std::vector<std::shared_ptr<Collective>> lowerCommunication(
+    DeviceIdxType device_index,
+    PipelineCommunication* c,
+    at::Tensor input_tensor,
+    at::Tensor output_tensor) {
+  std::vector<std::shared_ptr<Collective>> colls;
+  TensorView* input_tv =
+      c->in()->as<PipelineVal>()->getOriginalVal()->as<TensorView>();
+  TensorView* output_tv =
+      c->out()->as<PipelineVal>()->getOriginalVal()->as<TensorView>();
+  at::Tensor dummy;
+
+  auto sender_mesh = c->in()->as<PipelineVal>()->getStage()->descriptor()->mesh;
+  auto receiver_mesh =
+      c->out()->as<PipelineVal>()->getStage()->descriptor()->mesh;
+
+  // Stores whether the I/O has its first axis parallelized on Didx
+  bool is_input_parallel_d = isParallelD(input_tv);
+  bool is_output_parallel_d = isParallelD(output_tv);
+
+  TORCH_INTERNAL_ASSERT(
+      !is_input_parallel_d ||
+          sender_mesh.vector().size() ==
+              static_cast<size_t>(input_tensor.size(0)),
+      "the size of the mesh",
+      sender_mesh.vector().size(),
+      " doesn't match the size of the tensor ",
+      input_tensor.size(0));
+  TORCH_INTERNAL_ASSERT(
+      !is_output_parallel_d ||
+          receiver_mesh.vector().size() ==
+              static_cast<size_t>(output_tensor.size(0)),
+      "the size of the mesh",
+      receiver_mesh.vector().size(),
+      " doesn't match the size of the tensor ",
+      output_tensor.size(0));
+  TORCH_INTERNAL_ASSERT(!sender_mesh.vector().empty(), "sender mesh is empty");
+  TORCH_INTERNAL_ASSERT(
+      !receiver_mesh.vector().empty(), "receiver mesh is empty");
+
+  if (!isDeviceInvolved(device_index, sender_mesh, receiver_mesh))
+    return {};
+
+  if (!is_input_parallel_d && is_output_parallel_d) {
+    lowerToScatter(
+        device_index,
+        sender_mesh,
+        receiver_mesh,
+        input_tensor,
+        output_tensor,
+        colls);
+  } else if (is_input_parallel_d && !is_output_parallel_d) {
+    if (receiver_mesh.vector() == sender_mesh.vector()) {
+      lowerToAllgather(
+          device_index, sender_mesh, input_tensor, output_tensor, colls);
+    } else {
+      lowerToGather(
+          device_index,
+          sender_mesh,
+          receiver_mesh,
+          input_tensor,
+          output_tensor,
+          colls);
+    }
+  } else {
+    lowerToBroadcast(
+        device_index,
+        sender_mesh,
+        receiver_mesh,
+        input_tensor,
+        output_tensor,
+        is_input_parallel_d,
+        colls);
+  }
+  return colls;
+}
+
+} // namespace nvfuser
+
+#endif

--- a/csrc/multidevice/lower_communication.h
+++ b/csrc/multidevice/lower_communication.h
@@ -1,0 +1,27 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#ifdef USE_DISTRIBUTED
+#pragma once
+
+#include <multidevice/collective.h>
+#include <multidevice/multidevice.h>
+#include <multidevice/pipeline_ir.h>
+
+namespace nvfuser {
+
+// Lower a PipelineCommunication into a series of Collective, given a
+// device_index.
+std::vector<std::shared_ptr<Collective>> lowerCommunication(
+    DeviceIdxType device_index,
+    PipelineCommunication* c,
+    at::Tensor input_tensor,
+    at::Tensor output_tensor);
+
+} // namespace nvfuser
+
+#endif

--- a/csrc/multidevice/multidevice.h
+++ b/csrc/multidevice/multidevice.h
@@ -11,8 +11,7 @@
 #include <c10/core/Device.h>
 
 namespace nvfuser {
-using RankType = int;
+using RankType = int64_t;
 using DeviceIdxType = RankType;
-using DimensionType = int;
 using DeviceType = c10::Device;
 } // namespace nvfuser

--- a/csrc/multidevice/pipeline.cpp
+++ b/csrc/multidevice/pipeline.cpp
@@ -152,9 +152,6 @@ class PipelineBuilder final {
         // then add the newly created PipelineVal as an input of the pipeline
         if (isGlobalInput(val)) {
           pipeline_->addInput(p_val);
-          TORCH_INTERNAL_ASSERT(
-              stage_desc.mesh.size() == 1,
-              "A global input must belong to a stage which mesh is of size 1");
         } else {
           // if the Val is a stage input but not a global input, it must be
           // defined by a "Set" operation
@@ -262,6 +259,16 @@ std::unique_ptr<Fusion> Pipeline::stageToFusion(PipelineStage*& stage) const {
       });
 
   return fusion_copy;
+}
+
+uint64_t Pipeline::requestedNumberOfDevices() const {
+  std::set<DeviceIdxType> device_indices;
+  for (auto& stage_desc : descriptor().stage_descriptors) {
+    for (auto d_id : stage_desc.mesh.vector()) {
+      device_indices.insert(d_id);
+    }
+  }
+  return device_indices.size();
 }
 
 // Printer for Pipeline

--- a/csrc/multidevice/pipeline.h
+++ b/csrc/multidevice/pipeline.h
@@ -133,6 +133,10 @@ class TORCH_CUDA_CU_API Pipeline : public Fusion {
      the inputs and outputs. Should be optimized */
   std::unique_ptr<Fusion> stageToFusion(PipelineStage*& stage) const;
 
+  // returns the number of device indices present accross all
+  // stage's device mesh in the pipeline
+  uint64_t requestedNumberOfDevices() const;
+
  private:
   // utility class called at instantiation
   friend class PipelineBuilder;

--- a/csrc/multidevice/pipeline.h
+++ b/csrc/multidevice/pipeline.h
@@ -62,8 +62,11 @@ class TORCH_CUDA_CU_API PipelineStageDescriptor final {
   using ValSet = VectorOfUniqueEntries<Val*>;
 
  public:
-  PipelineStageDescriptor() : unique_id(running_unique_id_++) {}
+  PipelineStageDescriptor()
+      : auto_schedule(true), unique_id(running_unique_id_++) {}
 
+  // whether the stage should be auto-scheduled
+  bool auto_schedule;
   // The mesh on which the stage will be executed at runtime.
   DeviceMesh mesh;
   /* Unique identifier for the stage.

--- a/csrc/multidevice/runtime.cpp
+++ b/csrc/multidevice/runtime.cpp
@@ -17,34 +17,31 @@ namespace nvfuser {
 
 std::vector<at::Tensor> MultiDeviceRuntime::runWithInput(
     std::vector<c10::IValue> inputs) {
+  auto error_msg = validate();
+  TORCH_INTERNAL_ASSERT(error_msg.empty(), error_msg);
   PipelineExecutor executor(*this);
   return executor.runWithInput(inputs);
 }
 
-void MultiDeviceRuntime::validate() const {
-  // stores all the device indices present in the pipeline accross all stages
-  std::unordered_set<DeviceIdxType> device_indices;
-  for (auto& stage_desc : pipeline_->descriptor().stage_descriptors) {
-    for (auto d_id : stage_desc.mesh.deviceIndices()) {
-      device_indices.insert(d_id);
-    }
+std::string MultiDeviceRuntime::validate() const {
+  if (!comm_.is_available()) {
+    return "distributed configuration required";
   }
 
-  // Checks if all the devices indices involved in the pipeline are
-  // associated with a rank in the communicator
-  for (auto d_id : device_indices) {
-    TORCH_INTERNAL_ASSERT(
-        d_id < comm_.size(),
-        "device index " + std::to_string(d_id) +
-            " is present in the pipeline but no process in the communicator runs it");
+  if (pipeline_->requestedNumberOfDevices() > comm_.size()) {
+    return "the pipeline requests " +
+        std::to_string(pipeline_->requestedNumberOfDevices()) +
+        " GPUs to run, but there are only " + std::to_string(comm_.size()) +
+        " ranks in the communicator";
   }
 
-  // Checks that the number of processes within the node is less or equal
-  // to the number of available GPUs.
-  TORCH_INTERNAL_ASSERT(
-      comm_.local_size() <= at::cuda::getNumGPUs(),
-      std::to_string(comm_.local_size()) + " processes are spawn but only " +
-          std::to_string(at::cuda::getNumGPUs()) + " GPUs are available");
+  if (comm_.local_size() > at::cuda::getNumGPUs()) {
+    return std::to_string(comm_.local_size()) +
+        " processes are spawn on the node but only " +
+        std::to_string(at::cuda::getNumGPUs()) + " GPUs are available";
+  }
+
+  return "";
 }
 
 } // namespace nvfuser

--- a/csrc/multidevice/runtime.cpp
+++ b/csrc/multidevice/runtime.cpp
@@ -35,7 +35,7 @@ std::string MultiDeviceRuntime::validate() const {
         " ranks in the communicator";
   }
 
-  if (comm_.local_size() > at::cuda::getNumGPUs()) {
+  if (comm_.local_size() > static_cast<uint64_t>(at::cuda::getNumGPUs())) {
     return std::to_string(comm_.local_size()) +
         " processes are spawn on the node but only " +
         std::to_string(at::cuda::getNumGPUs()) + " GPUs are available";

--- a/csrc/multidevice/runtime.h
+++ b/csrc/multidevice/runtime.h
@@ -19,8 +19,7 @@ namespace nvfuser {
   The MultiDeviceRuntime class gather all what is needed for executing a
   Pipeline on a multi-device setting. It is instantiated from a Pipeline and a
   Communicator (a default Communicator is built at initialization if none is
-  provided). It also holds mappings ranks <-> device IDs, and associate a device
-  to the current node
+  provided).
 */
 class TORCH_CUDA_CU_API MultiDeviceRuntime {
  public:
@@ -42,25 +41,6 @@ class TORCH_CUDA_CU_API MultiDeviceRuntime {
     return pipeline_;
   }
 
-  // Returns the rank of the process
-  auto rank() const {
-    return comm_.rank();
-  }
-
-  // returns the device associated with the process
-  auto device() const {
-    return at::Device("cuda:" + std::to_string(comm_.local_rank()));
-  }
-
-  // returns the rank corresponding to device index
-  auto dIdToRank(DeviceIdxType d_id) const {
-    return static_cast<RankType>(d_id);
-  }
-
-  // returns the device index corresponding to the rank
-  auto rankToDiD(RankType rank) const {
-    return static_cast<DeviceIdxType>(rank);
-  }
 
  private:
   friend class PipelineExecutor; // could remove friendship by passing pipeline_
@@ -69,7 +49,7 @@ class TORCH_CUDA_CU_API MultiDeviceRuntime {
   void validate() const;
 
   Pipeline* pipeline_;
-  Communicator comm_;
+  Communicator& comm_;
 };
 
 } // namespace nvfuser

--- a/csrc/multidevice/runtime.h
+++ b/csrc/multidevice/runtime.h
@@ -24,9 +24,7 @@ namespace nvfuser {
 class TORCH_CUDA_CU_API MultiDeviceRuntime {
  public:
   explicit MultiDeviceRuntime(Pipeline* pipeline, Communicator& comm)
-      : pipeline_(pipeline), comm_(comm) {
-    validate();
-  }
+      : pipeline_(pipeline), comm_(comm) {}
 
   // Run the multidevice fusion with the given global inputs
   std::vector<at::Tensor> runWithInput(std::vector<c10::IValue> inputs);
@@ -41,12 +39,14 @@ class TORCH_CUDA_CU_API MultiDeviceRuntime {
     return pipeline_;
   }
 
+  // check if the runtime is valid returns an error msg.
+  // An empty message means that the runtime is valid
+  std::string validate() const;
 
  private:
   friend class PipelineExecutor; // could remove friendship by passing pipeline_
                                  // and comm_ to PipelineExecutor
   // test if the runtime is valid and satisfies our assumptions
-  void validate() const;
 
   Pipeline* pipeline_;
   Communicator& comm_;

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -645,6 +645,8 @@ static const char* rng_op_type2string(RNGOpType t) {
 
 static const char* parallel_type2string(ParallelType t) {
   switch (t) {
+    case ParallelType::DIDx:
+      return "deviceIdx.x";
     case ParallelType::BIDz:
       return "blockIdx.z";
     case ParallelType::BIDy:
@@ -1189,6 +1191,10 @@ bool isParallelTypeThreadDim(ParallelType ptype) {
 bool isParallelTypeBlockDim(ParallelType ptype) {
   return ptype == ParallelType::BIDx || ptype == ParallelType::BIDy ||
       ptype == ParallelType::BIDz;
+}
+
+bool isParallelTypeDeviceDim(ParallelType ptype) {
+  return ptype == ParallelType::DIDx;
 }
 
 bool isParallelTypeThread(ParallelType ptype) {

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -628,6 +628,7 @@ bool isLogicalOp(const BinaryOpType bopt);
 enum class TernaryOpType { Clamp, Lerp, Threshold, Where };
 
 enum class ParallelType {
+  DIDx,
   BIDz,
   BIDy,
   BIDx,
@@ -653,6 +654,9 @@ static constexpr std::array<ParallelType, 6> kParallelTypeThreads = {
     ParallelType::TIDx,
     ParallelType::TIDy,
     ParallelType::TIDz};
+
+static constexpr std::array<ParallelType, 1> kParallelTypeDIDs = {
+    ParallelType::DIDx};
 
 static constexpr std::array<ParallelType, 3> kParallelTypeBIDs = {
     ParallelType::BIDx,
@@ -874,6 +878,9 @@ TORCH_CUDA_CU_API bool isParallelTypeThreadDim(ParallelType);
 TORCH_CUDA_CU_API bool isParallelTypeBlockDim(ParallelType);
 // Returns if parallel type is a grid or block parallelization dimension
 TORCH_CUDA_CU_API bool isParallelTypeThread(ParallelType);
+
+// Returns if parallel type is DIDx
+TORCH_CUDA_CU_API bool isParallelTypeDeviceDim(ParallelType);
 
 TORCH_CUDA_CU_API bool isParallelTypeVectorize(ParallelType);
 

--- a/test/test_gpu_multidevice.cpp
+++ b/test/test_gpu_multidevice.cpp
@@ -284,7 +284,7 @@ TEST_F(NVFuserTest, FusionMultiGPU_CUDA) {
       at::TensorOptions().dtype(at::kFloat).device(comm.device());
   // Note: the concrete values are only used at the relevant ranks
   std::vector<c10::IValue> inputs{
-      at::randn({3, 11}, options), at::randn({2, 7, 8}, options)};
+      at::randn({3096, 1123}, options), at::randn({2048, 73, 81}, options)};
 
   executeAndTestPipeline(std::move(fusion_ptr), pipeline, comm, inputs);
 }


### PR DESCRIPTION
 # Main components of this patch:

- Add a new parallel type `DIDx` to express parallelization accross devices
- Add creation and cache of multiple subteams from the world communicator.
- Simplify the implementation of Device Mesh
- Design and implementation of the class Collective and derived class that represent non-blocking collective MPI operations
- Implement a logic for lowering pipeline communication into a series of collectives
- Execution support for fusion involving device parallelization
- Utility function for testing, and several test units for testing the different collectives

 # Main limitations and future directions

- Only 1d mesh are supported. Therefore the tensors are either not or fully sharded
- Only the tensors outmost dimension can be parallelized
- Reduction collectives are not yet supported
- We didn’t modify the Fusion’s scheduling, lowering and execution portion. If the fusion is parallelized accross devices, the generated kernel will simply discards the device index and therefore perform the computations on the whole tensor instead of a slice. This results in garbage computation and allocation
- The communication to collective lowering logic can be fleshed up with other lowering paths for optimization
- For now, the collectives are executed in a “blocking” way (even if the interface for non blocking execution is implemented). Later we would like to have a logic for asynchronous and parallel execution.
- It would be nice to think of a way to trigger the collectives from within the kernel (even though they need to be managed by CPU). For this, we would need some primitive to synchronize the CPU and GPU.
- The Collectives could be inherit from Expr and made kernel IRs that we add to the Fusion during lowering. This way we could allow the kernels to be fused accross communications and to better overlap communications and computations