### PR TITLE
More smartly determine `MAX_JOBS`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -257,7 +257,7 @@ def get_available_memory_gb():
         import psutil
 
         return psutil.virtual_memory().available / 1024 / 1024 / 1024
-    except:
+    except:  # noqa: E722
         pass
 
     try:
@@ -270,7 +270,7 @@ def get_available_memory_gb():
                     return int(mem) / 1024 / 1024
                 if not line:
                     break
-    except:
+    except:  # noqa: E722
         pass
 
     return 0

--- a/setup.py
+++ b/setup.py
@@ -251,6 +251,31 @@ def version_tag():
     return version
 
 
+def get_available_memory_gb():
+    """Returns the available memory in GB."""
+    try:
+        import psutil
+
+        return psutil.virtual_memory().available / 1024 / 1024 / 1024
+    except:
+        pass
+
+    try:
+        with open("/proc/meminfo", "r") as f:
+            while True:
+                line = f.readline()
+                if line.startswith("MemAvailable:"):
+                    mem = line.split()[1]
+                    assert line.split()[2] == "kB"
+                    return int(mem) / 1024 / 1024
+                if not line:
+                    break
+    except:
+        pass
+
+    return 0
+
+
 def cmake(build_dir: str = "", install_prefix: str = "./nvfuser"):
     # make build directories
     cwd = os.path.dirname(os.path.abspath(__file__))
@@ -298,9 +323,17 @@ def cmake(build_dir: str = "", install_prefix: str = "./nvfuser"):
     print(f"Configuring CMake with {' '.join(cmd_str)}")
     subprocess.check_call(cmd_str)
 
+    max_jobs = multiprocessing.cpu_count()
+    mem_gb_per_task = 3  # Currently compilation of nvFuser souce code takes ~3GB of memory per task, we should adjust this value if it changes in the future.
+    available_mem = get_available_memory_gb()
+    if available_mem > 0:
+        max_jobs_mem = int(available_mem / mem_gb_per_task)
+        max_jobs = min(max_jobs, max_jobs_mem)
+
     if not CMAKE_ONLY:
         # build binary
-        max_jobs = os.getenv("MAX_JOBS", str(multiprocessing.cpu_count()))
+        max_jobs = os.getenv("MAX_JOBS", str(max_jobs))
+        print(f"Using {max_jobs} jobs for compilation")
         cmd_str = [
             get_cmake_bin(),
             "--build",

--- a/setup.py
+++ b/setup.py
@@ -251,29 +251,7 @@ def version_tag():
     return version
 
 
-def get_available_memory_gb():
-    """Returns the available memory in GB."""
-    try:
-        import psutil
-
-        return psutil.virtual_memory().available / 1024 / 1024 / 1024
-    except:  # noqa: E722
-        pass
-
-    try:
-        with open("/proc/meminfo", "r") as f:
-            while True:
-                line = f.readline()
-                if line.startswith("MemAvailable:"):
-                    mem = line.split()[1]
-                    assert line.split()[2] == "kB"
-                    return int(mem) / 1024 / 1024
-                if not line:
-                    break
-    except:  # noqa: E722
-        pass
-
-    return 0
+from tools.memory import get_available_memory_gb
 
 
 def cmake(build_dir: str = "", install_prefix: str = "./nvfuser"):

--- a/tools/memory.py
+++ b/tools/memory.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+def get_available_memory_gb():
+    """Returns the available memory in GB."""
+    try:
+        import psutil
+
+        return psutil.virtual_memory().available / 1024 / 1024 / 1024
+    except:  # noqa: E722
+        pass
+
+    try:
+        with open("/proc/meminfo", "r") as f:
+            while True:
+                line = f.readline()
+                if line.startswith("MemAvailable:"):
+                    mem = line.split()[1]
+                    assert line.split()[2] == "kB"
+                    return int(mem) / 1024 / 1024
+                if not line:
+                    break
+    except:  # noqa: E722
+        pass
+
+    return 0


### PR DESCRIPTION
The default `MAX_JOBS` should make the build as fast as possible, while still run out of memory. I tested locally with gcc 13.1, with 64 jobs in parallel, the highest memory usage is 181GB, so roughly 2.8GB/task. To be safer, we should consider capping the max jobs to `available mem / 3`.