### PR TITLE
enable SchedulerDebug for matmul params

### DIFF
--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -128,7 +128,6 @@ std::unordered_map<DebugDumpOption, std::vector<std::string>> Options<
       {"launch_param", DebugDumpOption::LaunchParam},
       {"loop_rotation", DebugDumpOption::LoopRotation},
       {"lower_verbose", DebugDumpOption::LowerVerbose},
-      {"matmul_checks", DebugDumpOption::MatmulChecks},
       {"occupancy", DebugDumpOption::Occupancy},
       {"parallel_dimensions", DebugDumpOption::ParallelDimensions},
       {"perf_debug_verbose", DebugDumpOption::PerfDebugVerbose},

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -65,8 +65,6 @@ enum class DebugDumpOption {
   ExprSort, //! Print merging decisions on expression sorting
   ExprSortVerbose, //! Print verbose debug info on expression sorting
   LoopRotation, //! Print loop rotation log
-  MatmulChecks, //! Print logs from tools around matmul scheduler used in
-                //! segmenter
   Occupancy, // Dump occupancy
   IndexType, //! Print the index type of the launched kernel
   EndOfOption //! Placeholder for counting the number of elements

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -427,7 +427,8 @@ std::shared_ptr<MatmulParams> getMatmulHeuristics(
       params->double_buffer_options.smem_double_buffer_stage,
       getMmaDataTypes(roles_map_opt.getData()));
 
-  if (isDebugDumpEnabled(DebugDumpOption::MatmulChecks)) {
+  if (isDebugDumpEnabled(DebugDumpOption::MatmulChecks) ||
+      isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
     debug() << params->toString() << std::endl;
   }
 

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -346,7 +346,7 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
     std::stringstream ss;
     ss << "Matmul scheduler supports fusions only with a single MMA op, got: "
        << mma_exprs.size();
-    if (isDebugDumpEnabled(DebugDumpOption::MatmulChecks)) {
+    if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
       debug() << MATMUL_LOG_PREFIX << ss.str() << std::endl;
     }
     return ss.str();
@@ -356,7 +356,7 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
   {
     const auto input_layout_opt = mma_utils::getMatmulLayout(fusion);
     if (!input_layout_opt.isValid()) {
-      if (isDebugDumpEnabled(DebugDumpOption::MatmulChecks)) {
+      if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
         debug() << MATMUL_LOG_PREFIX << input_layout_opt.getErrorMsg()
                 << std::endl;
       }
@@ -369,7 +369,7 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
     for (auto mma_expr : mma_exprs) {
       auto support_status = isMatmulFusionDefinitionSupported(fusion, mma_expr);
       if (!support_status.empty()) {
-        if (isDebugDumpEnabled(DebugDumpOption::MatmulChecks)) {
+        if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
           debug() << MATMUL_LOG_PREFIX << support_status << std::endl;
         }
         return support_status;
@@ -427,8 +427,7 @@ std::shared_ptr<MatmulParams> getMatmulHeuristics(
       params->double_buffer_options.smem_double_buffer_stage,
       getMmaDataTypes(roles_map_opt.getData()));
 
-  if (isDebugDumpEnabled(DebugDumpOption::MatmulChecks) ||
-      isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
+  if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
     debug() << params->toString() << std::endl;
   }
 


### PR DESCRIPTION
Issue: `NVFUSER_DUMP=scheduler_params` dumps params for all schedulers except matmul. 

This one line change makes matmul heuristic params can be checked with `NVFUSER_DUMP=scheduler_params`, keep consisent with other schedulers.