### PR TITLE
Add new expr `ReverseArray`

### DIFF
--- a/csrc/dispatch.cpp
+++ b/csrc/dispatch.cpp
@@ -118,6 +118,10 @@ void Expr::dispatch(T handler, Expr* expr) {
     ptr(handler)->handle(expr->as<GetItem>());
     return;
   }
+  if (expr->isStrictlyA<ReverseArray>()) {
+    ptr(handler)->handle(expr->as<ReverseArray>());
+    return;
+  }
   if (expr->isStrictlyA<GetMetaData>()) {
     ptr(handler)->handle(expr->as<GetMetaData>());
     return;
@@ -388,6 +392,10 @@ void Expr::constDispatch(T handler, const Expr* expr) {
   }
   if (expr->isStrictlyA<GetItem>()) {
     ptr(handler)->handle(expr->as<GetItem>());
+    return;
+  }
+  if (expr->isStrictlyA<ReverseArray>()) {
+    ptr(handler)->handle(expr->as<ReverseArray>());
     return;
   }
   if (expr->isStrictlyA<GetMetaData>()) {
@@ -790,6 +798,9 @@ void OptOutConstDispatch::handle(const GetAttr* stmt) {
 void OptOutConstDispatch::handle(const GetItem* stmt) {
   unhandled(stmt);
 }
+void OptOutConstDispatch::handle(const ReverseArray* stmt) {
+  unhandled(stmt);
+}
 void OptOutConstDispatch::handle(const GetMetaData* stmt) {
   unhandled(stmt);
 }
@@ -988,6 +999,9 @@ void OptOutDispatch::handle(GetAttr* stmt) {
   unhandled(stmt);
 }
 void OptOutDispatch::handle(GetItem* stmt) {
+  unhandled(stmt);
+}
+void OptOutDispatch::handle(ReverseArray* stmt) {
   unhandled(stmt);
 }
 void OptOutDispatch::handle(GetMetaData* stmt) {

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -80,6 +80,7 @@ class TernaryOp;
 class ArrayConstruct;
 class GetAttr;
 class GetItem;
+class ReverseArray;
 class GetMetaData;
 class TensorConstruct;
 class SelectOp;
@@ -171,6 +172,7 @@ class TORCH_CUDA_CU_API OptOutConstDispatch : public PolymorphicBase {
   virtual void handle(const ArrayConstruct* stmt);
   virtual void handle(const GetAttr* stmt);
   virtual void handle(const GetItem* stmt);
+  virtual void handle(const ReverseArray* stmt);
   virtual void handle(const GetMetaData* stmt);
   virtual void handle(const TensorConstruct* stmt);
   virtual void handle(const SelectOp* stmt);
@@ -254,6 +256,7 @@ class TORCH_CUDA_CU_API OptOutDispatch : public PolymorphicBase {
   virtual void handle(ArrayConstruct* stmt);
   virtual void handle(GetAttr* stmt);
   virtual void handle(GetItem* stmt);
+  virtual void handle(ReverseArray* stmt);
   virtual void handle(GetMetaData* stmt);
   virtual void handle(TensorConstruct* stmt);
   virtual void handle(SelectOp* stmt);

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -240,6 +240,12 @@ Val* IrBuilder::getAttrExpr(Val* struct_, std::string attr) {
   return out;
 }
 
+Val* IrBuilder::reverseArrayExpr(Val* array) {
+  auto out = newScalar(array->dtype());
+  create<ReverseArray>(out, array);
+  return out;
+}
+
 Val* IrBuilder::metadataExpr(TensorView* tv) {
   return tv->fusion()->metadataOf(tv);
 }

--- a/csrc/ir/builder.h
+++ b/csrc/ir/builder.h
@@ -94,6 +94,7 @@ class TORCH_CUDA_CU_API IrBuilder {
   static Val* getItemExpr(Val* array, Val* index);
   static Val* getItemExpr(Val* array, PolymorphicValue index);
   static Val* getAttrExpr(Val* struct_, std::string attr);
+  static Val* reverseArrayExpr(Val* array);
 
   // Get tensor metadata
   static Val* metadataExpr(TensorView* tv);

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -442,6 +442,34 @@ class TORCH_CUDA_CU_API ArrayConstruct : public Expr {
   }
 };
 
+class TORCH_CUDA_CU_API ReverseArray : public Expr {
+ public:
+  using Expr::Expr;
+
+  ReverseArray(IrBuilderPasskey, Val* output, Val* input);
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  const char* getOpString() const override {
+    return "ReverseArray";
+  }
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+
+  std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
+      const std::vector<PolymorphicValue>& inputs) const override;
+
+  Val* out() const {
+    return output(0);
+  }
+
+  Val* in() const {
+    return input(0);
+  }
+};
+
 // Get an item from an array, array[index]
 class TORCH_CUDA_CU_API GetItem : public Expr {
  public:

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -383,4 +383,19 @@ TEST_F(ExprEvalTest, Validation) {
   evaluator.bind(d, 299792460L, true);
 }
 
+TEST_F(ExprEvalTest, ReverseArray) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto input = IrBuilder::create<Val>(
+      DataType(ArrayOf{std::make_shared<DataType>(DataType::Int), 5}));
+  auto output = IrBuilder::reverseArrayExpr(input);
+
+  ExpressionEvaluator evaluator;
+  evaluator.bind(input, std::vector<int64_t>{1, 2, 3, 4, 5});
+
+  auto expect = std::vector<int64_t>{5, 4, 3, 2, 1};
+  EXPECT_EQ((std::vector<int64_t>)evaluator.evaluate(output), expect);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Add `ReverseArray` which does the same as `std::reverse`. Currently, this expr can only be eagerly evaluated. The lowering of this expr is not supported yet, but not needed today either.