### PR TITLE
Rename non-primitive types

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -585,7 +585,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       std::visit(
           [&](auto&& dtype) {
             using T = std::decay_t<decltype(dtype)>;
-            if constexpr (std::is_same_v<T, StructOf>) {
+            if constexpr (std::is_same_v<T, StructType>) {
               for (auto& name : dtype.field_names) {
                 indent() << gen(gop->output(0)) << "." << name << " = "
                          << gen(gop->in()) << "." << name << ";\n";
@@ -1379,9 +1379,9 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Set);
 
     if (!print_inline_ &&
-        std::holds_alternative<StructOf>(ldst->out()->dtype().type)) {
-      auto out_type = std::get<StructOf>(ldst->out()->dtype().type);
-      auto in_type = std::get<StructOf>(ldst->in()->dtype().type);
+        std::holds_alternative<StructType>(ldst->out()->dtype().type)) {
+      auto out_type = std::get<StructType>(ldst->out()->dtype().type);
+      auto in_type = std::get<StructType>(ldst->in()->dtype().type);
       TORCH_INTERNAL_ASSERT(
           out_type.types.size() == in_type.types.size(),
           "Mismatched number of fields in struct assignment: ",

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -1014,7 +1014,7 @@ Val* PredicateElimination::getInitValue(TensorView* tv) const {
   if (init_val == nullptr) {
     // No reduction restriction. Just use zero
     auto dtype = *tv->getDataType();
-    if (std::holds_alternative<ArrayOf>(dtype.type)) {
+    if (std::holds_alternative<ArrayType>(dtype.type)) {
       return IrBuilder::create<NamedScalar>("{}", dtype);
     }
     return GpuLower::current()->kernel()->zeroVal();

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -172,9 +172,9 @@ std::vector<std::byte> polymorphicValueToBytes(
     PrimDataType index_type) {
   if (argument.is<Struct>()) {
     TORCH_INTERNAL_ASSERT(
-        std::holds_alternative<StructOf>(dtype.type),
-        "Expected StructOf type.");
-    auto dtype_ = std::get<StructOf>(dtype.type);
+        std::holds_alternative<StructType>(dtype.type),
+        "Expected StructType type.");
+    auto dtype_ = std::get<StructType>(dtype.type);
     auto struct_ = argument.as<Struct>();
     std::vector<std::byte> buffer;
     for (const auto& field : dtype_.field_names) {
@@ -208,8 +208,8 @@ std::vector<std::byte> polymorphicValueToBytes(
     return buffer;
   } else if (argument.is<Pointer>()) {
     TORCH_INTERNAL_ASSERT(
-        std::holds_alternative<PointerOf>(dtype.type),
-        "Expected PointerOf type.");
+        std::holds_alternative<PointerType>(dtype.type),
+        "Expected PointerType type.");
     void* ptr = (void*)argument;
     std::vector<std::byte> buffer;
     buffer.reserve(sizeof(void*));
@@ -218,8 +218,8 @@ std::vector<std::byte> polymorphicValueToBytes(
     return buffer;
   } else if (argument.is<std::vector>()) {
     TORCH_INTERNAL_ASSERT(
-        std::holds_alternative<ArrayOf>(dtype.type), "Expected ArrayOf type.");
-    auto dtype_ = std::get<ArrayOf>(dtype.type);
+        std::holds_alternative<ArrayType>(dtype.type), "Expected ArrayType type.");
+    auto dtype_ = std::get<ArrayType>(dtype.type);
     std::vector<std::byte> buffer;
     for (const auto& elem : argument.as<std::vector>()) {
       auto elem_data = polymorphicValueToBytes(elem, *dtype_.type, index_type);

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -218,7 +218,8 @@ std::vector<std::byte> polymorphicValueToBytes(
     return buffer;
   } else if (argument.is<std::vector>()) {
     TORCH_INTERNAL_ASSERT(
-        std::holds_alternative<ArrayType>(dtype.type), "Expected ArrayType type.");
+        std::holds_alternative<ArrayType>(dtype.type),
+        "Expected ArrayType type.");
     auto dtype_ = std::get<ArrayType>(dtype.type);
     std::vector<std::byte> buffer;
     for (const auto& elem : argument.as<std::vector>()) {

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -233,8 +233,9 @@ Val* IrBuilder::getItemExpr(Val* array, PolymorphicValue index) {
 }
 
 Val* IrBuilder::getAttrExpr(Val* struct_, std::string attr) {
-  auto item_dtype = NVFUSER_MAYBE_STAR std::get<StructType>(struct_->dtype().type)
-                        .types.at(attr);
+  auto item_dtype =
+      NVFUSER_MAYBE_STAR std::get<StructType>(struct_->dtype().type)
+          .types.at(attr);
   auto out = newScalar(item_dtype);
   create<GetAttr>(struct_->container(), out, struct_, std::move(attr));
   return out;

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -96,7 +96,7 @@ Val* IrBuilder::bitwiseNotExpr(Val* val) {
 
 Val* IrBuilder::derefExpr(Val* val) {
   TORCH_CHECK(val != nullptr, "val is a nullptr in derefExpr.");
-  auto result = newScalar(*(std::get<PointerOf>(val->dtype().type).type));
+  auto result = newScalar(*(std::get<PointerType>(val->dtype().type).type));
   IrBuilder::create<UnaryOp>(UnaryOpType::Dereference, result, val);
   return result;
 }
@@ -218,14 +218,14 @@ Val* IrBuilder::gcdExpr(Val* lhs, Val* rhs) {
 }
 
 Val* IrBuilder::getItemExpr(Val* array, Val* index) {
-  auto item_dtype = std::get<ArrayOf>(array->dtype().type).type;
+  auto item_dtype = std::get<ArrayType>(array->dtype().type).type;
   auto out = newScalar(*item_dtype);
   create<GetItem>(array->container(), out, array, index);
   return out;
 }
 
 Val* IrBuilder::getItemExpr(Val* array, PolymorphicValue index) {
-  auto item_dtype = std::get<ArrayOf>(array->dtype().type).type;
+  auto item_dtype = std::get<ArrayType>(array->dtype().type).type;
   auto out = newScalar(*item_dtype);
   create<GetItem>(
       array->container(), out, array, newConstant(index, DataType::Int));
@@ -233,7 +233,7 @@ Val* IrBuilder::getItemExpr(Val* array, PolymorphicValue index) {
 }
 
 Val* IrBuilder::getAttrExpr(Val* struct_, std::string attr) {
-  auto item_dtype = NVFUSER_MAYBE_STAR std::get<StructOf>(struct_->dtype().type)
+  auto item_dtype = NVFUSER_MAYBE_STAR std::get<StructType>(struct_->dtype().type)
                         .types.at(attr);
   auto out = newScalar(item_dtype);
   create<GetAttr>(struct_->container(), out, struct_, std::move(attr));
@@ -253,7 +253,7 @@ Val* IrBuilder::metadataExpr(TensorView* tv) {
 Val* IrBuilder::structExpr(
     const std::vector<std::pair<std::string, Val*>>& fields,
     std::string name) {
-  StructOf output_type;
+  StructType output_type;
   output_type.name = std::move(name);
   for (auto& field : fields) {
     output_type.types.emplace(

--- a/csrc/ir/builder.h
+++ b/csrc/ir/builder.h
@@ -107,7 +107,7 @@ class TORCH_CUDA_CU_API IrBuilder {
           !members.empty(), "Cannot create an array with no members.");
       auto in_dtype = members.at(0)->dtype();
       auto out_dtype =
-          ArrayOf{std::make_shared<DataType>(in_dtype), members.size()};
+          ArrayType{std::make_shared<DataType>(in_dtype), members.size()};
       auto out = newScalar(out_dtype);
       create<ArrayConstruct>(out, members);
       return out;

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -662,7 +662,7 @@ ArrayConstruct::ArrayConstruct(
     }
   }
   auto expected_output_dtype =
-      ArrayOf{std::make_shared<DataType>(input_dtype), inputs.size()};
+      ArrayType{std::make_shared<DataType>(input_dtype), inputs.size()};
   TORCH_CHECK(
       output->getDataType() == expected_output_dtype,
       "Output of ArrayConstruct must be an array of the same data type as the inputs");
@@ -692,13 +692,13 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(ArrayConstruct)
 ReverseArray::ReverseArray(IrBuilderPasskey passkey, Val* output, Val* input)
     : Expr(passkey) {
   TORCH_INTERNAL_ASSERT(
-      std::holds_alternative<ArrayOf>(input->dtype().type),
+      std::holds_alternative<ArrayType>(input->dtype().type),
       "Cannot reverse a non-array type.");
   TORCH_INTERNAL_ASSERT(
-      std::holds_alternative<ArrayOf>(output->dtype().type),
+      std::holds_alternative<ArrayType>(output->dtype().type),
       "Cannot reverse a non-array type.");
-  auto input_array_type = std::get<ArrayOf>(input->dtype().type);
-  auto output_array_type = std::get<ArrayOf>(output->dtype().type);
+  auto input_array_type = std::get<ArrayType>(input->dtype().type);
+  auto output_array_type = std::get<ArrayType>(output->dtype().type);
   TORCH_INTERNAL_ASSERT(
       input_array_type.type == output_array_type.type,
       "Cannot reverse an array of type ",
@@ -746,7 +746,7 @@ GetItem::GetItem(IrBuilderPasskey passkey, Val* output, Val* array, Val* index)
   addInput(array);
   addInput(index);
   TORCH_INTERNAL_ASSERT(
-      *(std::get<ArrayOf>(array->dtype().type).type) == output->dtype(),
+      *(std::get<ArrayType>(array->dtype().type).type) == output->dtype(),
       "GetItem array input must have a data type");
 }
 
@@ -780,7 +780,7 @@ StructConstruct::StructConstruct(
     : Expr(passkey) {
   TORCH_INTERNAL_ASSERT(
       !fields.empty(), "Cannot create a struct with no members.");
-  auto output_dtype = std::get<StructOf>(output->dtype().type);
+  auto output_dtype = std::get<StructType>(output->dtype().type);
   TORCH_INTERNAL_ASSERT(
       output_dtype.types.size() == fields.size(),
       "StructConstruct output must have the same number of fields as the inputs");
@@ -855,7 +855,7 @@ GetAttr::GetAttr(
     std::string attr)
     : Expr(passkey) {
   TORCH_INTERNAL_ASSERT(
-      NVFUSER_MAYBE_STAR std::get<StructOf>(struct_->dtype().type)
+      NVFUSER_MAYBE_STAR std::get<StructType>(struct_->dtype().type)
               .types.at(attr) == output->dtype(),
       "Data type mismatch for GetAttr");
   addOutput(output);

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2433,8 +2433,8 @@ TensorView* gather(
 
 TensorView* viewAsScalar(TensorView* inp) {
   auto inp_type = inp->getDataType().value();
-  auto vec_size = std::get<ArrayOf>(inp_type.type).size;
-  auto out_type = *std::get<ArrayOf>(inp_type.type).type;
+  auto vec_size = std::get<ArrayType>(inp_type.type).size;
+  auto out_type = *std::get<ArrayType>(inp_type.type).type;
 
   std::vector<IterDomain*> out_domain;
   auto inp_domain = TensorDomain::noReductions(inp->getMaybeRFactorDomain());
@@ -2584,9 +2584,9 @@ TensorView* tensor(Val* val) {
     return full({}, val, dtype);
   }
   std::vector<int64_t> sizes;
-  while (std::holds_alternative<ArrayOf>(dtype.type)) {
-    sizes.push_back((int64_t)std::get<ArrayOf>(dtype.type).size);
-    dtype = *std::get<ArrayOf>(dtype.type).type;
+  while (std::holds_alternative<ArrayType>(dtype.type)) {
+    sizes.push_back((int64_t)std::get<ArrayType>(dtype.type).size);
+    dtype = *std::get<ArrayType>(dtype.type).type;
   }
   TORCH_INTERNAL_ASSERT(
       std::holds_alternative<PrimDataType>(dtype.type),

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -274,7 +274,7 @@ TensorView* view_as_real(TensorView* x) {
       isComplexType(input_type),
       "Operand of view_as_real must have complex type");
 
-  auto vec_type = ArrayOf{
+  auto vec_type = ArrayType{
       std::make_shared<DataType>(getTypeFromComplexType(input_type)), 2};
   auto tv_vector = bitCastOp(vec_type, x);
   return viewAsScalar(tv_vector);

--- a/csrc/rng.cpp
+++ b/csrc/rng.cpp
@@ -31,7 +31,7 @@ getRNGSeedAndOffsetFromHost() {
   // host to the dereferenced offset pointer. In this ways, the offset value on
   // the host is the intra-cuda-graph offset, and the offset value on the device
   // is the base offset for this entire CUDA graph.
-  auto intptr = PointerOf{std::make_shared<DataType>(DataType::Int)};
+  auto intptr = PointerType{std::make_shared<DataType>(DataType::Int)};
   Val* seed_ptr = IrBuilder::newScalar(intptr);
   Val* seed_val = IrBuilder::newScalar(DataType::Int);
   Val* offset_ptr = IrBuilder::newScalar(intptr);

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -24,19 +24,19 @@ DataType globalTensorMetaData(
   std::stringstream ss;
   ss << "Tensor<" << dtype << ", " << dim << ", " << alloc_dim << ">";
 
-  StructOf tv_metadata;
+  StructType tv_metadata;
   tv_metadata.name = ss.str();
   tv_metadata.field_names = {"data", "logical_size", "alloc_stride"};
   tv_metadata.types["data"] =
-      NVFUSER_MAYBE_MAKE_SHARED(PointerOf{std::make_shared<DataType>(dtype)});
+      NVFUSER_MAYBE_MAKE_SHARED(PointerType{std::make_shared<DataType>(dtype)});
   tv_metadata.types["logical_size"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), dim});
+      ArrayType{std::make_shared<DataType>(DataType::Index), dim});
   tv_metadata.types["logical_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), dim});
+      ArrayType{std::make_shared<DataType>(DataType::Index), dim});
   tv_metadata.types["alloc_size"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), alloc_dim});
+      ArrayType{std::make_shared<DataType>(DataType::Index), alloc_dim});
   tv_metadata.types["alloc_stride"] = NVFUSER_MAYBE_MAKE_SHARED2(
-      ArrayOf{std::make_shared<DataType>(DataType::Index), alloc_dim});
+      ArrayType{std::make_shared<DataType>(DataType::Index), alloc_dim});
   return tv_metadata;
 }
 
@@ -46,7 +46,7 @@ DataType metaDataTypeOf(const Val* v) {
       tv != nullptr, "Currently, only supports getting metadata of TensorView");
   if (tv->getMemoryType() == MemoryType::Shared) {
     // Smem tensor is defined locally as a pointer
-    return PointerOf{std::make_shared<DataType>(tv->dtype())};
+    return PointerType{std::make_shared<DataType>(tv->dtype())};
   }
 
   size_t dim = TensorDomain::noReductions(tv->getMaybeRFactorDomain()).size();
@@ -203,14 +203,14 @@ static std::string data_type2string(DataType t) {
             default:
               TORCH_INTERNAL_ASSERT(false, "No string found for data type.");
           }
-        } else if constexpr (std::is_same_v<T, PointerOf>) {
+        } else if constexpr (std::is_same_v<T, PointerType>) {
           return data_type2string(*dtype.type) + "*";
-        } else if constexpr (std::is_same_v<T, ArrayOf>) {
+        } else if constexpr (std::is_same_v<T, ArrayType>) {
           std::stringstream ss;
           ss << "Array<" << data_type2string(*dtype.type) << ", " << dtype.size
              << ", 1>";
           return ss.str();
-        } else if constexpr (std::is_same_v<T, StructOf>) {
+        } else if constexpr (std::is_same_v<T, StructType>) {
           if (dtype.name != "") {
             return dtype.name;
           }
@@ -1148,13 +1148,13 @@ std::string stringifyThread(const ParallelType ptype) {
 }
 
 std::string typePrefix(const DataType data_type) {
-  if (std::holds_alternative<PointerOf>(data_type.type)) {
+  if (std::holds_alternative<PointerType>(data_type.type)) {
     return "ptr";
   }
-  if (std::holds_alternative<ArrayOf>(data_type.type)) {
+  if (std::holds_alternative<ArrayType>(data_type.type)) {
     return "a";
   }
-  if (std::holds_alternative<StructOf>(data_type.type)) {
+  if (std::holds_alternative<StructType>(data_type.type)) {
     return "s";
   }
   switch (std::get<PrimDataType>(data_type.type)) {
@@ -1213,11 +1213,11 @@ int64_t dataTypeSize(DataType type) {
         using T = std::decay_t<decltype(dtype)>;
         if constexpr (std::is_same_v<T, PrimDataType>) {
           return primDataTypeSize(dtype);
-        } else if constexpr (std::is_same_v<T, PointerOf>) {
+        } else if constexpr (std::is_same_v<T, PointerType>) {
           return sizeof(void*);
-        } else if constexpr (std::is_same_v<T, ArrayOf>) {
+        } else if constexpr (std::is_same_v<T, ArrayType>) {
           return dataTypeSize(*dtype.type) * dtype.size;
-        } else if constexpr (std::is_same_v<T, StructOf>) {
+        } else if constexpr (std::is_same_v<T, StructType>) {
           int64_t size = 0;
           for (const auto& field : dtype.field_names) {
             size += dataTypeSize(NVFUSER_MAYBE_STAR dtype.types.at(field));

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -95,18 +95,18 @@ enum class PrimDataType {
 
 struct DataType;
 
-struct ArrayOf {
+struct ArrayType {
   std::shared_ptr<DataType> type;
   size_t size;
-  inline bool operator==(const ArrayOf& other) const;
+  inline bool operator==(const ArrayType& other) const;
 };
 
-struct PointerOf {
+struct PointerType {
   std::shared_ptr<DataType> type;
-  inline bool operator==(const PointerOf& other) const;
+  inline bool operator==(const PointerType& other) const;
 };
 
-struct StructOf {
+struct StructType {
   // In nvfuser's type system, there are two types of structs: named structs and
   // anonymous structs. Named structs are lowered to its name in the generated
   // code, while anonymous structs are lowered to `struct {...}`. Generally, we
@@ -147,20 +147,20 @@ struct StructOf {
 #define NVFUSER_MAYBE_MAKE_SHARED2(x, y) std::make_shared<DataType>(x, y)
 #define NVFUSER_MAYBE_STAR *
 #endif
-  inline bool operator==(const StructOf& other) const;
+  inline bool operator==(const StructType& other) const;
 };
 
 struct DataType {
   using VariantOfSupportedTypes =
-      std::variant<PrimDataType, ArrayOf, PointerOf, StructOf>;
+      std::variant<PrimDataType, ArrayType, PointerType, StructType>;
   VariantOfSupportedTypes type = PrimDataType::Null;
 
   DataType() = default;
   DataType(VariantOfSupportedTypes type) : type(std::move(type)) {}
   DataType(const PrimDataType& type) : type(type) {}
-  DataType(const ArrayOf& type) : type(type) {}
-  DataType(const PointerOf& type) : type(type) {}
-  DataType(const StructOf& type) : type(type) {}
+  DataType(const ArrayType& type) : type(type) {}
+  DataType(const PointerType& type) : type(type) {}
+  DataType(const StructType& type) : type(type) {}
 
   static constexpr PrimDataType Double = PrimDataType::Double;
   static constexpr PrimDataType Float = PrimDataType::Float;
@@ -185,15 +185,15 @@ inline bool operator!=(const DataType& lhs, const DataType& rhs) {
   return !operator==(lhs, rhs);
 }
 
-bool ArrayOf::operator==(const ArrayOf& other) const {
+bool ArrayType::operator==(const ArrayType& other) const {
   return *type == *other.type && size == other.size;
 }
 
-bool PointerOf::operator==(const PointerOf& other) const {
+bool PointerType::operator==(const PointerType& other) const {
   return *type == *other.type;
 }
 
-bool StructOf::operator==(const StructOf& other) const {
+bool StructType::operator==(const StructType& other) const {
 #if defined(STD_UNORDERED_SET_SUPPORTS_INCOMPLETE_TYPE)
   return types == other.types;
 #else
@@ -267,7 +267,7 @@ TORCH_CUDA_CU_API inline bool isIntegralType(DataType dtype) {
 
 // Returns if the datatype is a pointer type
 TORCH_CUDA_CU_API inline bool isPointerType(DataType dtype) {
-  return std::holds_alternative<PointerOf>(dtype.type) ||
+  return std::holds_alternative<PointerType>(dtype.type) ||
       dtype == DataType::SMemAddress;
 }
 
@@ -407,12 +407,12 @@ inline DataType getDataType(const PolymorphicValue& value) {
         const auto& vec = value.as<T>();
         size_t size = vec.size();
         TORCH_CHECK(size > 0, "Empty array is not supported");
-        dtype = ArrayOf{std::make_shared<DataType>(getDataType(vec[0])), size};
+        dtype = ArrayType{std::make_shared<DataType>(getDataType(vec[0])), size};
       }
     } else if constexpr (std::is_same_v<T, Struct<PolymorphicValue>>) {
       if (value.is<T>()) {
         const auto& struct_ = value.as<T>();
-        StructOf result;
+        StructType result;
         for (const auto& [name, value] : struct_.fields) {
           result.types[name] =
               NVFUSER_MAYBE_MAKE_SHARED(getDataType(NVFUSER_MAYBE_STAR value));
@@ -442,17 +442,17 @@ inline bool isCompatibleDataType(DataType dtype, DataType dtype2) {
   if (isComplexType(dtype) && isComplexType(dtype2)) {
     return true;
   }
-  if (std::holds_alternative<ArrayOf>(dtype.type) &&
-      std::holds_alternative<ArrayOf>(dtype2.type)) {
-    const auto& array_of = std::get<ArrayOf>(dtype.type);
-    const auto& array_of2 = std::get<ArrayOf>(dtype2.type);
+  if (std::holds_alternative<ArrayType>(dtype.type) &&
+      std::holds_alternative<ArrayType>(dtype2.type)) {
+    const auto& array_of = std::get<ArrayType>(dtype.type);
+    const auto& array_of2 = std::get<ArrayType>(dtype2.type);
     return array_of.size == array_of2.size &&
         isCompatibleDataType(*array_of.type, *array_of2.type);
   }
-  if (std::holds_alternative<StructOf>(dtype.type) &&
-      std::holds_alternative<StructOf>(dtype2.type)) {
-    const auto& struct_of = std::get<StructOf>(dtype.type);
-    const auto& struct_of2 = std::get<StructOf>(dtype2.type);
+  if (std::holds_alternative<StructType>(dtype.type) &&
+      std::holds_alternative<StructType>(dtype2.type)) {
+    const auto& struct_of = std::get<StructType>(dtype.type);
+    const auto& struct_of2 = std::get<StructType>(dtype2.type);
     if (struct_of.types.size() != struct_of2.types.size()) {
       return false;
     }
@@ -476,11 +476,11 @@ inline bool hasCompatibleDataType(
     DataType dtype) {
   // We can not always completely infer data type from value, so we need some
   // special handling here.
-  if (std::holds_alternative<PointerOf>(dtype.type)) {
+  if (std::holds_alternative<PointerType>(dtype.type)) {
     if (!value.is<Pointer>()) {
       return false;
     }
-    auto ptr = std::get<PointerOf>(dtype.type);
+    auto ptr = std::get<PointerType>(dtype.type);
     return dataTypeSize(*ptr.type) == value.as<Pointer>().size();
   }
   return isCompatibleDataType(getDataType(value), dtype);

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -407,7 +407,8 @@ inline DataType getDataType(const PolymorphicValue& value) {
         const auto& vec = value.as<T>();
         size_t size = vec.size();
         TORCH_CHECK(size > 0, "Empty array is not supported");
-        dtype = ArrayType{std::make_shared<DataType>(getDataType(vec[0])), size};
+        dtype =
+            ArrayType{std::make_shared<DataType>(getDataType(vec[0])), size};
       }
     } else if constexpr (std::is_same_v<T, Struct<PolymorphicValue>>) {
       if (value.is<T>()) {

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -410,7 +410,7 @@ TEST_F(ExprEvalTest, ReverseArray) {
   FusionGuard fg(&fusion);
 
   auto input = IrBuilder::create<Val>(
-      DataType(ArrayOf{std::make_shared<DataType>(DataType::Int), 5}));
+      DataType(ArrayType{std::make_shared<DataType>(DataType::Int), 5}));
   auto output = IrBuilder::reverseArrayExpr(input);
 
   ExpressionEvaluator evaluator;

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -9679,10 +9679,10 @@ TEST_F(NVFuserTest, AllInputDtypes) {
     auto bf16 = IrBuilder::create<Val>(DataType::BFloat16);
     auto cf = IrBuilder::create<Val>(DataType::ComplexFloat);
     auto cd = IrBuilder::create<Val>(DataType::ComplexDouble);
-    DataType ptr_type = PointerOf{std::make_shared<DataType>(DataType::Float)};
+    DataType ptr_type = PointerType{std::make_shared<DataType>(DataType::Float)};
     auto ptr = IrBuilder::create<Val>(ptr_type);
     DataType array_type =
-        ArrayOf{std::make_shared<DataType>(DataType::Float), 2};
+        ArrayType{std::make_shared<DataType>(DataType::Float), 2};
     auto array = IrBuilder::create<Val>(array_type);
     fusion->addInput(tv0);
     fusion->addInput(tv1);

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -9679,7 +9679,8 @@ TEST_F(NVFuserTest, AllInputDtypes) {
     auto bf16 = IrBuilder::create<Val>(DataType::BFloat16);
     auto cf = IrBuilder::create<Val>(DataType::ComplexFloat);
     auto cd = IrBuilder::create<Val>(DataType::ComplexDouble);
-    DataType ptr_type = PointerType{std::make_shared<DataType>(DataType::Float)};
+    DataType ptr_type =
+        PointerType{std::make_shared<DataType>(DataType::Float)};
     auto ptr = IrBuilder::create<Val>(ptr_type);
     DataType array_type =
         ArrayType{std::make_shared<DataType>(DataType::Float), 2};

--- a/test/test_tensor_factories.cpp
+++ b/test/test_tensor_factories.cpp
@@ -530,9 +530,9 @@ TEST_F(TensorFactoryTest, MetadataAsTensor) {
 
   // also test unamed structure
   auto unamed_dtype0 = metaDataTypeOf(tv0);
-  std::get<StructOf>(unamed_dtype0.type).name = "";
+  std::get<StructType>(unamed_dtype0.type).name = "";
   auto unamed_dtype1 = metaDataTypeOf(tv1);
-  std::get<StructOf>(unamed_dtype1.type).name = "";
+  std::get<StructType>(unamed_dtype1.type).name = "";
   auto meta0_copy1 = IrBuilder::newScalar(unamed_dtype0);
   auto meta1_copy1 = IrBuilder::newScalar(unamed_dtype1);
   IrBuilder::create<LoadStoreOp>(


### PR DESCRIPTION
I think the previous names are confusing
- `ArrayOf` -> `ArrayType`
- `PointerOf` -> `PointerType`
- `StructOf` -> `StructType`