### PR TITLE
`UnaryOpType::Address` returns pointers instead of `int64_t`

### DIFF
--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -125,6 +125,14 @@ Val* IrBuilder::maybeCastExpr(DataType dtype, Val* val) {
   return result;
 }
 
+Val* IrBuilder::addressExpr(Val* val) {
+  TORCH_CHECK(val != nullptr, "val is a nullptr in addressExpr.");
+  auto result = newScalar(
+      DataType(PointerType{std::make_shared<DataType>(val->dtype())}));
+  IrBuilder::create<UnaryOp>(UnaryOpType::Address, result, val);
+  return result;
+}
+
 NamedScalar* IrBuilder::setExprNamedScalar(const std::string& name, Val* val) {
   TORCH_CHECK(val != nullptr, "val is a nullptr in setExprNamedScalar.");
   auto result = IrBuilder::create<NamedScalar>(name, val->dtype());
@@ -135,9 +143,9 @@ NamedScalar* IrBuilder::setExprNamedScalar(const std::string& name, Val* val) {
 NamedScalar* IrBuilder::addressExprNamedScalar(
     const std::string& name,
     Val* val) {
-  TORCH_CHECK(val != nullptr, "val is a nullptr in addressExprNamedScalar.");
+  auto ptr = addressExpr(val);
   auto result = IrBuilder::create<NamedScalar>(name, DataType::Int);
-  IrBuilder::create<UnaryOp>(UnaryOpType::Address, result, val);
+  IrBuilder::create<UnaryOp>(UnaryOpType::BitCast, result, ptr);
   return result;
 }
 

--- a/csrc/ir/builder.h
+++ b/csrc/ir/builder.h
@@ -63,6 +63,7 @@ class TORCH_CUDA_CU_API IrBuilder {
   static Val* absExpr(Val* val);
   static Val* setExpr(Val* val);
   static Val* maybeCastExpr(DataType dtype, Val* val);
+  static Val* addressExpr(Val* val);
   static NamedScalar* setExprNamedScalar(const std::string& name, Val* val);
   static NamedScalar* addressExprNamedScalar(const std::string& name, Val* val);
 

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -89,9 +89,6 @@ TensorView* bitCastOp(DataType dtype, TensorView* v1) {
 }
 
 Val* unaryOp(UnaryOpType type, Val* v1) {
-  TORCH_INTERNAL_ASSERT(
-      type != UnaryOpType::Address,
-      "The reference operator & is not accessible in the Fusion IR");
   Val* out = ops::newValLike(v1, v1->getDataType().value());
   IrBuilder::create<UnaryOp>(type, out, v1);
   return out;

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -437,7 +437,7 @@ static const char* unary_op_type_inline_op2string(UnaryOpType t) {
     case UnaryOpType::BitwiseNot:
       return "~";
     case UnaryOpType::Address:
-      return "(int64_t) &";
+      return "&";
     default:
       break;
   }


### PR DESCRIPTION
Due to historical reason (when we do not have pointer dtype), `UnaryOpType::Address` was returning `int64_t` instead of pointers. This is changed now.