### PR TITLE
fixing transpose scheduler merge dimension issue

### DIFF
--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -897,54 +897,35 @@ void scheduleTranspose(Fusion* fusion, TransposeParams params) {
   // split big dims so that we have enough dimensions available to merge with
   // inner-most dims to create the virtual inner-most dim
   scheduler_utils::splitDims(reference1, params.split_before_tiling);
-  // Merging reference 1's dims_merged_with_1 but updating dims_merged_with_2
-  // based on the changes in the dimensions that were merged. So we can then run
-  // merge with dims_merged_with_2.
-  auto merged1 = scheduler_utils::mergeDims(
-      reference1, params.dims_merged_with_1, params.dims_merged_with_2);
-  // Merging reference 1's dims_merged_with_2 and updating `merged1`.
+
+  // prepare all dimensions in merge order for group1
+  std::vector<size_t> dims_group1 = params.dims_merged_with_1;
+  size_t inner_most_pos1_in_ref1 =
+      domain_map.getInnerLeafDim(reference1, inner_most_id1);
+  dims_group1.insert(dims_group1.begin(), inner_most_pos1_in_ref1);
+
+  // prepare all dimensions in merge order for group2
+  std::vector<size_t> dims_group2 = params.dims_merged_with_2;
+  size_t inner_most_pos2_in_ref1 =
+      domain_map.getInnerLeafDim(reference1, inner_most_id2);
+  dims_group2.insert(dims_group2.begin(), inner_most_pos2_in_ref1);
+
+  // merge all dimensions in group1, while updating all indices for group2
+  auto merged1 =
+      scheduler_utils::mergeDims(reference1, dims_group1, dims_group2);
   std::vector<size_t> merged1_vec;
   if (merged1.has_value()) {
     merged1_vec.push_back(*merged1);
   }
-  auto merged2 = scheduler_utils::mergeDims(
-      reference1, params.dims_merged_with_2, merged1_vec);
-  if (merged1.has_value()) {
-    merged1 = merged1_vec[0];
-  }
+  // merge all dimensions in group2, while updating merged index for group1
+  auto merged2 =
+      scheduler_utils::mergeDims(reference1, dims_group2, merged1_vec);
 
-  // merge with inner most dims to get virtual inner most dims
-  size_t inner_most_pos1_in_ref1 =
-      domain_map.getInnerLeafDim(reference1, inner_most_id1);
-  size_t inner_most_pos2_in_ref1 =
-      domain_map.getInnerLeafDim(reference1, inner_most_id2);
+  // updating merged1 & merged2 indices if applicable
   if (merged1.has_value()) {
-    if (inner_most_pos1_in_ref1 < *merged1) {
-      reference1->reorder(
-          {{*merged1, inner_most_pos1_in_ref1},
-           {inner_most_pos1_in_ref1, *merged1}});
-      std::swap(*merged1, inner_most_pos1_in_ref1);
-    }
-    if (inner_most_pos2_in_ref1 > inner_most_pos1_in_ref1) {
-      inner_most_pos2_in_ref1--;
-    }
-    if (merged2.has_value() && *merged2 > inner_most_pos1_in_ref1) {
-      (*merged2)--;
-    }
-    reference1->merge((int)*merged1, (int)inner_most_pos1_in_ref1);
-    inner_most_pos1_in_ref1 = *merged1;
+    inner_most_pos1_in_ref1 = merged1_vec[0];
   }
   if (merged2.has_value()) {
-    if (inner_most_pos2_in_ref1 < *merged2) {
-      reference1->reorder(
-          {{*merged2, inner_most_pos2_in_ref1},
-           {inner_most_pos2_in_ref1, *merged2}});
-      std::swap(*merged2, inner_most_pos2_in_ref1);
-    }
-    if (inner_most_pos1_in_ref1 > inner_most_pos2_in_ref1) {
-      inner_most_pos1_in_ref1--;
-    }
-    reference1->merge((int)*merged2, (int)inner_most_pos2_in_ref1);
     inner_most_pos2_in_ref1 = *merged2;
   }
 

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -172,7 +172,10 @@ std::optional<size_t> mergeDims(
   }
   auto inner = to_merge[0];
 
-  // NOTE: we need to merge dimensions in the order specified by `to_merge`, otherwise this could results in misaligned memory access due to indexing. This is because we compute vectorization width before applying scheduling transformations.
+  // NOTE: we need to merge dimensions in the order specified by `to_merge`,
+  // otherwise this could results in misaligned memory access due to indexing.
+  // This is because we compute vectorization width before applying scheduling
+  // transformations.
   for (size_t i = 1; i < to_merge.size(); i++) {
     auto outer = to_merge[i];
     if (outer > inner) {

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -170,21 +170,33 @@ std::optional<size_t> mergeDims(
   if (to_merge.size() == 1) {
     return to_merge[0];
   }
-  std::sort(to_merge.begin(), to_merge.end());
-  size_t left = to_merge[0];
-  int64_t offset = 0;
-  for (auto right = to_merge.begin() + 1; right != to_merge.end(); right++) {
-    auto actual_right = offset-- + *right;
-    tv->merge((int)left, (int)actual_right);
-    for (auto& i : to_update) {
-      if (i == actual_right) {
-        i = left;
-      } else if (i > actual_right) {
-        i--;
+  auto inner = to_merge[0];
+
+  // NOTE: we need to merge dimensions in the order specified by `to_merge`, otherwise this could results in misaligned memory access due to indexing. This is because we compute vectorization width before applying scheduling transformations.
+  for (size_t i = 1; i < to_merge.size(); i++) {
+    auto outer = to_merge[i];
+    if (outer > inner) {
+      tv->reorder({{inner, outer}, {outer, inner}});
+      std::swap(inner, outer);
+    }
+    tv->merge(static_cast<int>(outer), static_cast<int>(inner));
+
+    // compensate future indices for the diminishing inner.
+    for (size_t j = i + 1; j < to_merge.size(); j++) {
+      if (to_merge[j] > inner) {
+        to_merge[j]--;
       }
     }
+    for (auto& val : to_update) {
+      if (val == inner) {
+        val = outer;
+      } else if (val > inner) {
+        val--;
+      }
+    }
+    inner = outer;
   }
-  return left;
+  return inner;
 }
 
 size_t mergeReduction(TensorView* tv) {

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -185,11 +185,15 @@ std::optional<size_t> mergeDims(
     // If outer > inner, the merge order conflicts with their order in leaf
     // domain
     if (outer > inner) {
-      // NOTE: reorder here is necessary.
-      // since we want to have the merge dimension be like
-      // (tv->axis(to_merge[i]) * tv->axis(to_merge[i-1]))
-      // without reorder, the merged dimension would be in the wrong order
+      // NOTE: reorder here is necessary to work around the automatic swap in
+      // `TensorDomain::merge`, if the first axis position is larger than the
+      // second. we want to have the merge dimension be like
+      // (tv->axis(to_merge[i]) * tv->axis(to_merge[i-1])), reorder allows us to
+      // compensate the automatic swap in `TensorDomain::merge`.
       tv->reorder({{inner, outer}, {outer, inner}});
+      // swapping inner with outer since we also need to keep track of the
+      // actual outer position for the remaining merge operations as well as for
+      // return value.
       std::swap(inner, outer);
     }
     // from

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -172,16 +172,30 @@ std::optional<size_t> mergeDims(
   }
   auto inner = to_merge[0];
 
-  // NOTE: we need to merge dimensions in the order specified by `to_merge`,
-  // otherwise this could results in misaligned memory access due to indexing.
+  // NOTE: The merge is done in the order of `to_merge`, assuming going from
+  // inner to outer dimensions. We want the merged IterDomain to be like:
+  //
+  // tv->axis(to_merge[i-1])*tv->axis(to_merge[i-2])*...*tv->axis(to_merge[0])
+  //
+  // Otherwise this could results in misaligned memory access due to indexing.
   // This is because we compute vectorization width before applying scheduling
   // transformations.
   for (size_t i = 1; i < to_merge.size(); i++) {
     auto outer = to_merge[i];
+    // If outer > inner, the merge order conflicts with their order in leaf
+    // domain
     if (outer > inner) {
+      // NOTE: reorder here is necessary.
+      // since we want to have the merge dimension be like
+      // (tv->axis(to_merge[i]) * tv->axis(to_merge[i-1]))
+      // without reorder, the merged dimension would be in the wrong order
       tv->reorder({{inner, outer}, {outer, inner}});
       std::swap(inner, outer);
     }
+    // from
+    //   (i..., tv->axis(outer), j..., tv->axis(inner), k...)
+    // to
+    //   (i..., tv->axis(outer) * tv->axis(inner), j..., k...)
     tv->merge(static_cast<int>(outer), static_cast<int>(inner));
 
     // compensate future indices for the diminishing inner.

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -100,6 +100,8 @@ TORCH_CUDA_CU_API inline void splitDims(
 // update the dimensions in `to_update` to the positions in the merged tensor.
 // Returns the merged dimension. All given dimensions are numbers before any
 // merge.
+// NOTE: merged is done as the entries in the order of `to_merge`, assuming an
+// order from inner to outer
 TORCH_CUDA_CU_API std::optional<size_t> mergeDims(
     TensorView* tv,
     std::vector<size_t> to_merge,

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -49,7 +49,8 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
   auto tv = makeConcreteTensor(
       {p(0), p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8), p(9), p(10)});
   std::vector<size_t> dims{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto merged = scheduler_utils::mergeDims(tv, {3, 2, 9, 7, 8}, dims);
+  std::vector<size_t> to_merge{3, 2, 9, 7, 8};
+  auto merged = scheduler_utils::mergeDims(tv, to_merge, dims);
   EXPECT_EQ(merged, (size_t)2);
   std::vector<int64_t> expect_shape{
       p(0), p(1), p(2) * p(3) * p(7) * p(8) * p(9), p(4), p(5), p(6), p(10)};
@@ -59,11 +60,13 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
   }
   std::vector<size_t> expect_dims{0, 1, 2, 2, 3, 4, 5, 2, 2, 2, 6};
   EXPECT_EQ(dims, expect_dims);
-
-  auto merged_dim = tv->axis(2)->toString(0);
-  EXPECT_EQ(
-      merged_dim.substr(merged_dim.find("{")),
-      "{( 23 * ( 19 * ( 29 * ( 5 * 7 ) ) ) )}");
+  auto root_domain = tv->getRootDomain();
+  auto num_merged_dim = to_merge.size();
+  auto inputs = IterVisitor::getInputsTo({tv->axis(2)});
+  for (auto index : c10::irange(num_merged_dim)) {
+    EXPECT_TRUE(root_domain[to_merge[num_merged_dim - 1 - index]]->sameAs(
+        inputs[index]));
+  }
 }
 
 TEST_F(NVFuserTest, FusionReorderAsRFactor_CUDA) {

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -49,7 +49,7 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
   auto tv = makeConcreteTensor(
       {p(0), p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8), p(9), p(10)});
   std::vector<size_t> dims{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto merged = scheduler_utils::mergeDims(tv, {2, 3, 7, 8, 9}, dims);
+  auto merged = scheduler_utils::mergeDims(tv, {3, 2, 9, 8, 7}, dims);
   EXPECT_EQ(merged, (size_t)2);
   std::vector<int64_t> expect_shape{
       p(0), p(1), p(2) * p(3) * p(7) * p(8) * p(9), p(4), p(5), p(6), p(10)};
@@ -59,6 +59,11 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
   }
   std::vector<size_t> expect_dims{0, 1, 2, 2, 3, 4, 5, 2, 2, 2, 6};
   EXPECT_EQ(dims, expect_dims);
+
+  auto merged_dim = tv->axis(2)->toString(0);
+  EXPECT_EQ(
+      merged_dim.substr(merged_dim.find("{")),
+      "{( 23 * ( 19 * ( 29 * ( 5 * 7 ) ) ) )}");
 }
 
 TEST_F(NVFuserTest, FusionReorderAsRFactor_CUDA) {

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -49,7 +49,7 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
   auto tv = makeConcreteTensor(
       {p(0), p(1), p(2), p(3), p(4), p(5), p(6), p(7), p(8), p(9), p(10)});
   std::vector<size_t> dims{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto merged = scheduler_utils::mergeDims(tv, {3, 2, 9, 8, 7}, dims);
+  auto merged = scheduler_utils::mergeDims(tv, {3, 2, 9, 7, 8}, dims);
   EXPECT_EQ(merged, (size_t)2);
   std::vector<int64_t> expect_shape{
       p(0), p(1), p(2) * p(3) * p(7) * p(8) * p(9), p(4), p(5), p(6), p(10)};


### PR DESCRIPTION
fixes: #675 (Although the problem only shows up after a few other PR that refactors transpose vectorization computation)

Transpose scheduler should merge dimensions in the expected order (from inner to outer on each group).
Otherwise generated kernel would violate alignment requirement for vectorization.