### PR TITLE
Fast path for trivial allocation domain

### DIFF
--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -339,11 +339,14 @@ std::vector<PolymorphicValue> GetMetaData::evaluate(
       Pointer(input.data_ptr(), aten_to_data_type(input.scalar_type())));
   concrete_value["logical_size"] = PolymorphicValue(input.sizes().vec());
   concrete_value["logical_stride"] = PolymorphicValue(input.strides().vec());
-  {
+  if (tv->hasAllocation()) {
     auto allocation_data =
         inferAndValidateAllocationSizesAndStrides(input, tv, ee);
     concrete_value["alloc_size"] = std::move(allocation_data.first);
     concrete_value["alloc_stride"] = std::move(allocation_data.second);
+  } else {
+    concrete_value["alloc_size"] = PolymorphicValue(input.sizes().vec());
+    concrete_value["alloc_stride"] = PolymorphicValue(input.strides().vec());
   }
   return {PolymorphicValue(std::move(concrete_value))};
 }


### PR DESCRIPTION
Partially take back regressions from shape inference due to recent refactor: https://github.com/NVIDIA/Fuser/issues/749

Shape inference benchmark:
```C++
-------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations
-------------------------------------------------------------------------------------------
LayerNormBackward_ShapeInference                        128 us          128 us         5428
LayerNormForward_ShapeInference                        44.9 us         44.8 us        15608
LayerNormBackward_NoShapeInferenceCachedBaseline       78.2 us         78.1 us         8917
LayerNormForward_NoShapeInferenceCachedBaseline        37.4 us         37.4 us        18735
```

This is only a short term fix, in the long term, we should not do IterDomain traversal on the fly for each `at::Tensor`. Instead, we should do the analysis once, and emit IR nodes that converts logical sizes and strides into allocation sizes and strides, cache these IR nodes, and evaluate them on each `at::Tensor`.