### PR TITLE
Reduce CPU overhead on `allocOutputs` when there is no allocation domain

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -961,8 +961,12 @@ std::vector<at::Tensor> allocOutputs(
       if (shouldFillAllocationWithNan()) {
         fillTensorWithNan(alloc_tensor);
       }
-      outputs.emplace_back(transformOutputFromAllocationToRFactor(
-          alloc_tensor, buf_info.tv, ee));
+      if (buf_info.tv->hasAllocation()) {
+        outputs.emplace_back(transformOutputFromAllocationToRFactor(
+            alloc_tensor, buf_info.tv, ee));
+      } else {
+        outputs.emplace_back(std::move(alloc_tensor));
+      }
     }
   }
 

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1730,10 +1730,13 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   }
 
   std::vector<std::vector<std::byte>> arg_buffers;
-  arg_buffers.reserve(kernel()->parameters().size());
-  for (auto v : kernel()->parameters()) {
-    arg_buffers.emplace_back(
-        getKernelArgument(expr_eval, v, kernel()->indexType()));
+  {
+    FUSER_PERF_SCOPE("ExecutorRunFusion::GetArgsBuffers");
+    arg_buffers.reserve(kernel()->parameters().size());
+    for (auto v : kernel()->parameters()) {
+      arg_buffers.emplace_back(
+          getKernelArgument(expr_eval, v, kernel()->indexType()));
+    }
   }
 
   if (isDebugDumpEnabled(DebugDumpOption::LaunchParam)) {

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -172,7 +172,7 @@ std::vector<std::byte> polymorphicValueToBytes(
     const DataType& dtype,
     PrimDataType index_type) {
   if (argument.is<Struct>()) {
-    FUSER_PERF_SCOPE("polymorphicValueToBytes(Struct)");
+    // FUSER_PERF_SCOPE("polymorphicValueToBytes(Struct)");
     TORCH_INTERNAL_ASSERT(
         std::holds_alternative<StructType>(dtype.type),
         "Expected StructType type.");
@@ -188,7 +188,7 @@ std::vector<std::byte> polymorphicValueToBytes(
     }
     return buffer;
   } else if (argument.is<at::Tensor>()) {
-    FUSER_PERF_SCOPE("polymorphicValueToBytes(at::Tensor)");
+    // FUSER_PERF_SCOPE("polymorphicValueToBytes(at::Tensor)");
     const auto& tensor = argument.as<at::Tensor>();
     TORCH_INTERNAL_ASSERT(
         tensor.is_cpu() && tensor.numel() == 1,
@@ -210,7 +210,7 @@ std::vector<std::byte> polymorphicValueToBytes(
         (std::byte*)tensor.data_ptr() + tensor.element_size());
     return buffer;
   } else if (argument.is<Pointer>()) {
-    FUSER_PERF_SCOPE("polymorphicValueToBytes(Pointer)");
+    // FUSER_PERF_SCOPE("polymorphicValueToBytes(Pointer)");
     TORCH_INTERNAL_ASSERT(
         std::holds_alternative<PointerType>(dtype.type),
         "Expected PointerType type.");
@@ -221,7 +221,7 @@ std::vector<std::byte> polymorphicValueToBytes(
         buffer.end(), (std::byte*)&ptr, (std::byte*)&ptr + sizeof(void*));
     return buffer;
   } else if (argument.is<std::vector>()) {
-    FUSER_PERF_SCOPE("polymorphicValueToBytes(std::vector)");
+    // FUSER_PERF_SCOPE("polymorphicValueToBytes(std::vector)");
     TORCH_INTERNAL_ASSERT(
         std::holds_alternative<ArrayType>(dtype.type),
         "Expected ArrayType type.");
@@ -233,7 +233,7 @@ std::vector<std::byte> polymorphicValueToBytes(
     }
     return buffer;
   } else if (argument.is<int64_t>()) {
-    FUSER_PERF_SCOPE("polymorphicValueToBytes(int64_t)");
+    // FUSER_PERF_SCOPE("polymorphicValueToBytes(int64_t)");
     int64_t v = argument.as<int64_t>();
     if (dtype == DataType::Int ||
         (index_type == PrimDataType::Int && dtype == DataType::Index)) {
@@ -251,12 +251,12 @@ std::vector<std::byte> polymorphicValueToBytes(
           " type: only int32 and int64 are supported.");
     }
   } else if (argument.is<bool>()) {
-    FUSER_PERF_SCOPE("polymorphicValueToBytes(bool)");
+    // FUSER_PERF_SCOPE("polymorphicValueToBytes(bool)");
     bool v = argument.as<bool>();
     TORCH_INTERNAL_ASSERT(dtype == DataType::Bool, "Expected Bool type.");
     return std::vector<std::byte>((std::byte*)&v, (std::byte*)&v + 1);
   } else if (argument.is<double>()) {
-    FUSER_PERF_SCOPE("polymorphicValueToBytes(double)");
+    // FUSER_PERF_SCOPE("polymorphicValueToBytes(double)");
     double v = argument.as<double>();
     if (dtype == DataType::Double) {
       return std::vector<std::byte>(
@@ -281,7 +281,7 @@ std::vector<std::byte> polymorphicValueToBytes(
           " type: only half, bfloat16, float and double are supported.");
     }
   } else if (argument.is<std::complex<double>>()) {
-    FUSER_PERF_SCOPE("polymorphicValueToBytes(std::complex<double>)");
+    // FUSER_PERF_SCOPE("polymorphicValueToBytes(std::complex<double>)");
     std::complex<double> v = argument.as<std::complex<double>>();
     if (dtype == DataType::ComplexDouble) {
       return std::vector<std::byte>(
@@ -298,6 +298,7 @@ std::vector<std::byte> polymorphicValueToBytes(
           " type: only complex float and complex double are supported.");
     }
   } else if (argument.is<Opaque>()) {
+    // FUSER_PERF_SCOPE("polymorphicValueToBytes(Opaque)");
     return argument.as<Opaque>().bytes();
   } else {
     TORCH_INTERNAL_ASSERT(


### PR DESCRIPTION
Shape inference benchmark:

main:
```C++
-------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations
-------------------------------------------------------------------------------------------
LayerNormBackward_ShapeInference                        129 us          129 us         5434
LayerNormForward_ShapeInference                        46.1 us         46.0 us        15050
LayerNormBackward_NoShapeInferenceCachedBaseline       79.8 us         79.6 us         8682
LayerNormForward_NoShapeInferenceCachedBaseline        37.7 us         37.7 us        18564
```

this:
```C++
-------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations
-------------------------------------------------------------------------------------------
LayerNormBackward_ShapeInference                        120 us          120 us         5769
LayerNormForward_ShapeInference                        33.9 us         33.9 us        21020
LayerNormBackward_NoShapeInferenceCachedBaseline       70.1 us         70.0 us         9947
LayerNormForward_NoShapeInferenceCachedBaseline        25.5 us         25.5 us        27247
```

Python benchmark as posted in https://github.com/NVIDIA/Fuser/issues/749#issuecomment-1689896825:

main:
```markdown
[------------------  -----------------]
           |  nvfuser 0.0.19+git874e5c2
1 threads: ----------------------------
      2    |             27.3          
      4    |             37.6          
      8    |             57.5          
      16   |             95.2          
      32   |            191.9          
      64   |            369.3          
      128  |            726.5          

Times are in microseconds (us).
```
this
```markdown
[------------------  -----------------]
           |  nvfuser 0.0.19+git284989d
1 threads: ----------------------------
      2    |             23.1          
      4    |             33.8          
      8    |             53.4          
      16   |             90.5          
      32   |            190.3          
      64   |            368.9          
      128  |            733.7 

Times are in microseconds (us).
```