### PR TITLE
Stop extending lifetimes past end of for loops in aliasing pass

### DIFF
--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -607,7 +607,9 @@ class AllocationAliasModifier;
 //!       T1 = ...            <--  Inner Live Interval of T1 begin
 //!       T2 = ...
 //!       T3 = T1 + ...    <-- Inner Live Interval of T1 end
-//!       T5 = T3 + ...    <-------  Outer Live Interval of T1 end
+//!       T5 = T3 + ...
+//!     EndFor Idx2 ...
+//!   EndFor Idx1 ... <-------  Outer Live Interval of T1 end
 //!
 //!   Alloc(T4, register)
 //!   For Idx3 ...
@@ -618,7 +620,10 @@ class AllocationAliasModifier;
 //!  write and last read of the buffer. Outer interval marks the beginning of
 //!  the loop of first write and end of the loop of last read, at the same loop
 //!  level as the buffer allocation. Note that the end of a ForLoop is marked by
-//!  the last expression within it.
+//!  the last expression within it. In the case of an outer live interval, if
+//!  the end point is the end of a for loop, it is given a position at which
+//!  that expression would reside, but no actual `Expr` is associated with that
+//!  position.
 class AllocationInfoMap : private kir::IrVisitor {
  public:
   // Alias local memory if it exceeds this threshold

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -1900,10 +1900,10 @@ class PromoteReuseSyncModifier : private kir::ExprMutator {
   void dispatch(Expr* expr) final {
     auto position = allocation_info_map_.getScopeMap().getExprPos(expr);
 
-    // Intervals are open. If this is the first expr past the lower endpoint of
-    // a sync interval, then add the corresponding upper endpoint.
-    // Note that we add these first so that we can detect adjacent intervals
-    // properly.
+    // Lifetime intervals are closed, so sync intervals are open. If this is the
+    // first expr past a lifetime's last read, then add the corresponding upper
+    // endpoint for the sync interval. Note that we add these before checking
+    // for first writes so that we can detect adjacent intervals properly.
     auto range = sync_intervals_.equal_range(position - 1);
     for (auto& it = range.first; it != range.second; ++it) {
       if (isDebugDumpEnabled(DebugDumpOption::BufferReuseInfo)) {

--- a/test/test_smem_reuse.cpp
+++ b/test/test_smem_reuse.cpp
@@ -271,7 +271,7 @@ TEST_F(SmemReuseTest, PromoteReuseMultipleDownstream) {
 
   // The outer live intervals of tv0, tv2, and tv4 will be non-overlapping, but
   // adjacent. tv0->promoteReuse() should be able to insert a sync before tv2,
-  // so that tv2 re-uses the memory from tv0, then tv4 is stacked above tv2.
+  // so that tv4 re-uses the memory from tv0, then tv2 is stacked above tv4.
 
   auto tv0 =
       full({IrBuilder::create<Val>(H)}, fusion->oneVal(), DataType::Float);

--- a/test/test_smem_reuse.cpp
+++ b/test/test_smem_reuse.cpp
@@ -278,7 +278,7 @@ TEST_F(SmemReuseTest, PromoteReuseMultipleDownstream) {
   tv0->setMemoryType(MemoryType::Shared);
 
   // NOTE: This should work with only a single expression between tv0 and tv1 as
-  // well, since a since could be placed after tv1 in that case as well. Here we
+  // well, since a sync could be placed after tv1 in that case as well. Here we
   // use two expressions until fixing interval closedness.
   // See https://github.com/NVIDIA/Fuser/issues/772.
   auto tv1 = neg(neg(tv0));

--- a/test/test_smem_reuse.cpp
+++ b/test/test_smem_reuse.cpp
@@ -277,10 +277,6 @@ TEST_F(SmemReuseTest, PromoteReuseMultipleDownstream) {
       full({IrBuilder::create<Val>(H)}, fusion->oneVal(), DataType::Float);
   tv0->setMemoryType(MemoryType::Shared);
 
-  // NOTE: This should work with only a single expression between tv0 and tv1 as
-  // well, since a sync could be placed after tv1 in that case as well. Here we
-  // use two expressions until fixing interval closedness.
-  // See https://github.com/NVIDIA/Fuser/issues/772.
   auto tv1 = neg(tv0);
 
   auto tv2 = pad(tv1, {fusion->zeroVal(), fusion->oneVal()});

--- a/test/test_smem_reuse.cpp
+++ b/test/test_smem_reuse.cpp
@@ -277,21 +277,17 @@ TEST_F(SmemReuseTest, PromoteReuseMultipleDownstream) {
       full({IrBuilder::create<Val>(H)}, fusion->oneVal(), DataType::Float);
   tv0->setMemoryType(MemoryType::Shared);
 
-  // NOTE: This should work with only a single expression between tv0 and tv1 as
-  // well, since a sync could be placed after tv1 in that case as well. Here we
-  // use two expressions until fixing interval closedness.
-  // See https://github.com/NVIDIA/Fuser/issues/772.
-  auto tv1 = neg(neg(tv0));
+  auto tv1 = neg(tv0);
 
   auto tv2 = pad(tv1, {fusion->zeroVal(), fusion->oneVal()});
   tv2->setMemoryType(MemoryType::Shared);
 
-  auto tv3 = neg(neg(tv2));
+  auto tv3 = neg(tv2);
 
   auto tv4 = pad(tv3, {fusion->zeroVal(), fusion->oneVal()});
   tv4->setMemoryType(MemoryType::Shared);
 
-  auto tv5 = neg(neg(tv4));
+  auto tv5 = neg(tv4);
 
   fusion->addOutput(tv5);
 

--- a/test/test_smem_reuse.cpp
+++ b/test/test_smem_reuse.cpp
@@ -262,29 +262,36 @@ TEST_F(SmemReuseTest, PromoteReuse) {
 }
 
 // In this example, we promote a single tensor for re-use in a Fusion with two
-// downstream tensors that could use its memory. The first downstream tensor is
-// not re-used since it is not promoted.
+// downstream tensors that could use its memory.
 TEST_F(SmemReuseTest, PromoteReuseMultipleDownstream) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
   int64_t H = 7;
 
+  // The outer live intervals of tv0, tv2, and tv4 will be non-overlapping, but
+  // adjacent. tv0->promoteReuse() should be able to insert a sync before tv2,
+  // so that tv2 re-uses the memory from tv0, then tv4 is stacked above tv2.
+  
   auto tv0 =
       full({IrBuilder::create<Val>(H)}, fusion->oneVal(), DataType::Float);
   tv0->setMemoryType(MemoryType::Shared);
 
-  auto tv1 = neg(tv0);
+  // NOTE: This should work with only a single expression between tv0 and tv1 as
+  // well, since a since could be placed after tv1 in that case as well. Here we
+  // use two expressions until fixing interval closedness.
+  // See https://github.com/NVIDIA/Fuser/issues/772.
+  auto tv1 = neg(neg(tv0));
 
   auto tv2 = pad(tv1, {fusion->zeroVal(), fusion->oneVal()});
   tv2->setMemoryType(MemoryType::Shared);
 
-  auto tv3 = neg(tv2);
+  auto tv3 = neg(neg(tv2));
 
   auto tv4 = pad(tv3, {fusion->zeroVal(), fusion->oneVal()});
   tv4->setMemoryType(MemoryType::Shared);
 
-  auto tv5 = neg(tv4);
+  auto tv5 = neg(neg(tv4));
 
   fusion->addOutput(tv5);
 
@@ -322,7 +329,7 @@ TEST_F(SmemReuseTest, PromoteReuseMultipleDownstream) {
           dataTypeSize(alloc->buffer()->dtype());
       smem_usage = std::max(smem_usage, addr + size);
     }
-    EXPECT_EQ(smem_usage, alignInt((H + 1) * 4) + (H + 2) * 4);
+    EXPECT_EQ(smem_usage, alignInt((H + 2) * 4) + (H + 1) * 4);
   }
 }
 

--- a/test/test_smem_reuse.cpp
+++ b/test/test_smem_reuse.cpp
@@ -272,7 +272,7 @@ TEST_F(SmemReuseTest, PromoteReuseMultipleDownstream) {
   // The outer live intervals of tv0, tv2, and tv4 will be non-overlapping, but
   // adjacent. tv0->promoteReuse() should be able to insert a sync before tv2,
   // so that tv2 re-uses the memory from tv0, then tv4 is stacked above tv2.
-  
+
   auto tv0 =
       full({IrBuilder::create<Val>(H)}, fusion->oneVal(), DataType::Float);
   tv0->setMemoryType(MemoryType::Shared);

--- a/test/test_smem_reuse.cpp
+++ b/test/test_smem_reuse.cpp
@@ -281,17 +281,17 @@ TEST_F(SmemReuseTest, PromoteReuseMultipleDownstream) {
   // well, since a sync could be placed after tv1 in that case as well. Here we
   // use two expressions until fixing interval closedness.
   // See https://github.com/NVIDIA/Fuser/issues/772.
-  auto tv1 = neg(neg(tv0));
+  auto tv1 = neg(tv0);
 
   auto tv2 = pad(tv1, {fusion->zeroVal(), fusion->oneVal()});
   tv2->setMemoryType(MemoryType::Shared);
 
-  auto tv3 = neg(neg(tv2));
+  auto tv3 = neg(tv2);
 
   auto tv4 = pad(tv3, {fusion->zeroVal(), fusion->oneVal()});
   tv4->setMemoryType(MemoryType::Shared);
 
-  auto tv5 = neg(neg(tv4));
+  auto tv5 = neg(tv4);
 
   fusion->addOutput(tv5);
 


### PR DESCRIPTION
Currently, `ScopeMap` increments the position when recording the end of either a `ForLoop` or the top-level scope. This means we cannot interpret the end position as an actual last read, breaking the guarantee that `BufferLiveInterval` is a closed interval. Since we do not have separate expressions for the end of loops, we cannot point to a specific location for the loop ending, but interpreting the interval as half-open depending on the loop nest structure is confusing, as seen in #772.

This PR introduces positions for the ends of for loops, although they do not have corresponding `Expr`s in the kernel IR. As a result, two adjacent for loops will have non-intersecting intervals, and allocations with uses confined to each will thus have non-intersecting outer live intervals. Since the intervals are closed, if an actual expression is the last read of one interval and first write of another, they will be properly considered as  overlapping, and not eligible for inserting a sync.

The example from #772 now looks like:
```
1  T0_s[ iS0{7} ] = ALLOCATE(buffer=T0_s[ iS0{7} ], mem_type=shared, size=7, zero_init=false)
   ^^^^^ ---Buffer Reuse Info---   not aliased  , inner live interval: [ 7 , 11 ] , size expr : 7 , outer live interval: [ 6 , 12 ]    
2  T2_s[ iS3{8}rf ] = ALLOCATE(buffer=T2_s[ iS3{8}rf ], mem_type=shared, size=8, zero_init=false)
   ^^^^^ ---Buffer Reuse Info---   not aliased  , inner live interval: [ 14 , 18 ] , size expr : 8 , outer live interval: [ 13 , 19 ]    
3  T4_s[ iS6{9}rf ] = ALLOCATE(buffer=T4_s[ iS6{9}rf ], mem_type=shared, size=9, zero_init=false)
   ^^^^^ ---Buffer Reuse Info---   not aliased  , inner live interval: [ 21 , 24 ] , size expr : 9 , outer live interval: [ 20 , 25 ]    
4  f2 = ALLOCATE(buffer=f2, mem_type=register, size=1, zero_init=false)
5  f2 = (float)(1);
6  FOR i58 in iS0{7}:
7    T0_s[ iS0{7} ]
   = full({7}, ( (float)(1) ));
9  T1_l[ iS1{7} ] = ALLOCATE(buffer=T1_l[ iS1{7} ], mem_type=register, size=7, zero_init=false)
   ^^^^^ ---Buffer Reuse Info---   not aliased  , inner live interval: [ 11 , 14 ] , size expr : 7 , outer live interval: [ 10 , 15 ]    
10  FOR i59 in iS1{7}:
11    T1_l[ iS1{7} ]
   = -T0_s[ iS0{7} ];
13  FOR i60 in iS3{8}rf:
14    T2_s[ iS3{8}rf ]
   = pad( T1_l[ iS1{7} ], {0, 1} )
16  T3_l[ iS4{8} ] = ALLOCATE(buffer=T3_l[ iS4{8} ], mem_type=register, size=8, zero_init=false)
   ^^^^^ ---Buffer Reuse Info---   not aliased  , inner live interval: [ 18 , 21 ] , size expr : 8 , outer live interval: [ 17 , 22 ]    
17  FOR i61 in iS4{8}:
18    T3_l[ iS4{8} ]
   = -T2_s[ iS3{8}rf ];
20  FOR i62 in iS6{9}rf:
21    T4_s[ iS6{9}rf ]
   = pad( T3_l[ iS4{8} ], {0, 1} )
23  FOR i63 in iS7{9}:
24    T5_g[ iS7{9} ]
   = -T4_s[ iS6{9}rf ];
```
Notice that `T0_s` has an outer live interval with right endpoint at position 12, which does not exist but signifies  the end of the `FOR i59` loop. In this case, `T0` was set for `promoteReuse` so a sync was inserted in the interval `(12, 13)`.

Fixes #772.