### PR TITLE
Overload `->*` for `DynamicType`

### DIFF
--- a/csrc/C++20/type_traits
+++ b/csrc/C++20/type_traits
@@ -19,4 +19,13 @@ template <typename T>
 using type_identity_t = typename type_identity<T>::type;
 #endif
 
+#if !__cpp_lib_remove_cvref
+template <class T>
+struct remove_cvref {
+  typedef std::remove_cv_t<std::remove_reference_t<T>> type;
+};
+template< class T >
+using remove_cvref_t = typename remove_cvref<T>::type;
+#endif
+
 } // namespace std

--- a/csrc/C++20/type_traits
+++ b/csrc/C++20/type_traits
@@ -22,12 +22,11 @@ using type_identity_t = typename type_identity<T>::type;
 #endif
 
 #if !__cpp_lib_remove_cvref
-template<class T>
-struct remove_cvref
-{
-    typedef std::remove_cv_t<std::remove_reference_t<T>> type;
+template <class T>
+struct remove_cvref {
+  typedef std::remove_cv_t<std::remove_reference_t<T>> type;
 };
-template< class T >
+template <class T>
 using remove_cvref_t = typename remove_cvref<T>::type;
 #endif
 

--- a/csrc/C++20/type_traits
+++ b/csrc/C++20/type_traits
@@ -7,6 +7,8 @@
 // clang-format on
 #pragma once
 
+#include <type_traits>
+
 namespace std {
 
 #if !__cpp_lib_type_identity
@@ -17,6 +19,16 @@ struct type_identity {
 
 template <typename T>
 using type_identity_t = typename type_identity<T>::type;
+#endif
+
+#if !__cpp_lib_remove_cvref
+template<class T>
+struct remove_cvref
+{
+    typedef std::remove_cv_t<std::remove_reference_t<T>> type;
+};
+template< class T >
+using remove_cvref_t = typename remove_cvref<T>::type;
 #endif
 
 } // namespace std

--- a/csrc/C++20/type_traits
+++ b/csrc/C++20/type_traits
@@ -19,13 +19,4 @@ template <typename T>
 using type_identity_t = typename type_identity<T>::type;
 #endif
 
-#if !__cpp_lib_remove_cvref
-template <class T>
-struct remove_cvref {
-  typedef std::remove_cv_t<std::remove_reference_t<T>> type;
-};
-template< class T >
-using remove_cvref_t = typename remove_cvref<T>::type;
-#endif
-
 } // namespace std

--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -423,47 +423,52 @@ struct DynamicType {
   DEFINE_SQUARE_BRACKET_OPERATOR(const)
 #undef DEFINE_SQUARE_BRACKET_OPERATOR
 
-  template <typename Ret, typename Class>
-  static constexpr bool has_arrow_star = any_check(
-      [](auto t) {
-        using T = typename decltype(t)::type;
-        using MemberPtr = Ret Class::*;
-        if constexpr (opcheck<T>->*opcheck<MemberPtr>) {
-          return std::is_same_v<
-              decltype(std::declval<T>()->*std::declval<MemberPtr>()),
-              const Ret&>;
-        }
-        return false;
-      },
-      type_identities_as_tuple);
-
-  template <typename Ret, typename Class>
-  constexpr std::enable_if_t<
-      is_candidate_type<Class> || has_arrow_star<Ret, Class>,
-      const Ret&>
-  operator->*(Ret Class::*member) const {
-    if constexpr (is_candidate_type<Class>) {
-      return as<Class>().*member;
-    } else {
-      std::optional<const Ret*> ret = std::nullopt;
-      for_all_types([this, &member, &ret](auto t) {
-        using T = typename decltype(t)::type;
-        if constexpr (opcheck<T>->*opcheck<Ret Class::*>) {
-          if (is<T>()) {
-            ret = &(as<T>()->*member);
-          }
-        }
-      });
-      TORCH_CHECK(
-          ret.has_value(),
-          "Cannot access member with type ",
-          typeid(Ret).name(),
-          " in class ",
-          typeid(Class).name(),
-          " : incompatible type");
-      return *ret.value();
-    }
+#define DEFINE_ARROW_STAR_OPERATOR(__const)                            \
+  template <typename Ret, typename Class>                              \
+  static constexpr bool has_arrow_star##__const = any_check(           \
+      [](auto t) {                                                     \
+        using T = typename decltype(t)::type;                          \
+        using MemberPtr = Ret Class::*;                                \
+        if constexpr (opcheck<T>->*opcheck<MemberPtr>) {               \
+          return std::is_same_v<                                       \
+              decltype(std::declval<T>()->*std::declval<MemberPtr>()), \
+              __const Ret&>;                                           \
+        }                                                              \
+        return false;                                                  \
+      },                                                               \
+      type_identities_as_tuple);                                       \
+                                                                       \
+  template <typename Ret, typename Class>                              \
+  constexpr std::enable_if_t<                                          \
+      is_candidate_type<Class> || has_arrow_star<Ret, Class>,          \
+      __const Ret&>                                                    \
+  operator->*(Ret Class::*member) __const {                            \
+    if constexpr (is_candidate_type<Class>) {                          \
+      return as<Class>().*member;                                      \
+    } else {                                                           \
+      std::optional<__const Ret*> ret = std::nullopt;                  \
+      for_all_types([this, &member, &ret](auto t) {                    \
+        using T = typename decltype(t)::type;                          \
+        if constexpr (opcheck<T>->*opcheck<Ret Class::*>) {            \
+          if (is<T>()) {                                               \
+            ret = &(as<T>()->*member);                                 \
+          }                                                            \
+        }                                                              \
+      });                                                              \
+      TORCH_CHECK(                                                     \
+          ret.has_value(),                                             \
+          "Cannot access member with type ",                           \
+          typeid(Ret).name(),                                          \
+          " in class ",                                                \
+          typeid(Class).name(),                                        \
+          " : incompatible type");                                     \
+      return *ret.value();                                             \
+    }                                                                  \
   }
+
+  DEFINE_ARROW_STAR_OPERATOR()
+  DEFINE_ARROW_STAR_OPERATOR(const)
+#undef DEFINE_ARROW_STAR_OPERATOR
 
   // TODO: support operator(). This is not supported yet because it is the most
   // difficulty one to implement because it can has arbitrary number of

--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -423,9 +423,47 @@ struct DynamicType {
   DEFINE_SQUARE_BRACKET_OPERATOR(const)
 #undef DEFINE_SQUARE_BRACKET_OPERATOR
 
-  // TODO: support ->* operator. This operator is rarely used, so we don't
-  // implement it yet. But if in the future, it turns to be useful, we should
-  // implement it.
+  template <typename Ret, typename Class>
+  static constexpr bool has_arrow_star = any_check(
+      [](auto t) {
+        using T = typename decltype(t)::type;
+        using MemberPtr = Ret Class::*;
+        if constexpr (opcheck<T>->*opcheck<MemberPtr>) {
+          return std::is_same_v<
+              decltype(std::declval<T>()->*std::declval<MemberPtr>()),
+              const Ret&>;
+        }
+        return false;
+      },
+      type_identities_as_tuple);
+
+  template <typename Ret, typename Class>
+  constexpr std::enable_if_t<
+      is_candidate_type<Class> || has_arrow_star<Ret, Class>,
+      const Ret&>
+  operator->*(Ret Class::*member) const {
+    if constexpr (is_candidate_type<Class>) {
+      return as<Class>().*member;
+    } else {
+      std::optional<const Ret*> ret = std::nullopt;
+      for_all_types([this, &member, &ret](auto t) {
+        using T = typename decltype(t)::type;
+        if constexpr (opcheck<T>->*opcheck<Ret Class::*>) {
+          if (is<T>()) {
+            ret = &(as<T>()->*member);
+          }
+        }
+      });
+      TORCH_CHECK(
+          ret.has_value(),
+          "Cannot access member with type ",
+          typeid(Ret).name(),
+          " in class ",
+          typeid(Class).name(),
+          " : incompatible type");
+      return *ret.value();
+    }
+  }
 
   // TODO: support operator(). This is not supported yet because it is the most
   // difficulty one to implement because it can has arbitrary number of

--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -423,47 +423,48 @@ struct DynamicType {
   DEFINE_SQUARE_BRACKET_OPERATOR(const)
 #undef DEFINE_SQUARE_BRACKET_OPERATOR
 
-#define DEFINE_ARROW_STAR_OPERATOR(__const)                            \
-  template <typename Ret, typename Class>                              \
-  static constexpr bool has_arrow_star##__const = any_check(           \
-      [](auto t) {                                                     \
-        using T = typename decltype(t)::type;                          \
-        using MemberPtr = Ret Class::*;                                \
-        if constexpr (opcheck<T>->*opcheck<MemberPtr>) {               \
-          return std::is_same_v<                                       \
-              decltype(std::declval<T>()->*std::declval<MemberPtr>()), \
-              __const Ret&>;                                           \
-        }                                                              \
-        return false;                                                  \
-      },                                                               \
-      type_identities_as_tuple);                                       \
-                                                                       \
-  template <typename Ret, typename Class>                              \
-  constexpr std::enable_if_t<                                          \
-      is_candidate_type<Class> || has_arrow_star##__const<Ret, Class>, \
-      __const Ret&>                                                    \
-  operator->*(Ret Class::*member) __const {                            \
-    if constexpr (is_candidate_type<Class>) {                          \
-      return as<Class>().*member;                                      \
-    } else {                                                           \
-      std::optional<__const Ret*> ret = std::nullopt;                  \
-      for_all_types([this, &member, &ret](auto t) {                    \
-        using T = typename decltype(t)::type;                          \
-        if constexpr (opcheck<T>->*opcheck<Ret Class::*>) {            \
-          if (is<T>()) {                                               \
-            ret = &(as<T>()->*member);                                 \
-          }                                                            \
-        }                                                              \
-      });                                                              \
-      TORCH_CHECK(                                                     \
-          ret.has_value(),                                             \
-          "Cannot access member with type ",                           \
-          typeid(Ret).name(),                                          \
-          " in class ",                                                \
-          typeid(Class).name(),                                        \
-          " : incompatible type");                                     \
-      return *ret.value();                                             \
-    }                                                                  \
+#define DEFINE_ARROW_STAR_OPERATOR(__const)                                 \
+  template <typename Ret, typename Class>                                   \
+  static constexpr bool has_arrow_star##__const = any_check(                \
+      [](auto t) {                                                          \
+        using T = typename decltype(t)::type;                               \
+        using MemberPtr = Ret Class::*;                                     \
+        if constexpr (opcheck<T>->*opcheck<MemberPtr>) {                    \
+          return std::is_same_v<                                            \
+              std::remove_cvref_t<                                          \
+                  decltype(std::declval<T>()->*std::declval<MemberPtr>())>, \
+              Ret>;                                                         \
+        }                                                                   \
+        return false;                                                       \
+      },                                                                    \
+      type_identities_as_tuple);                                            \
+                                                                            \
+  template <typename Ret, typename Class>                                   \
+  constexpr std::enable_if_t<                                               \
+      is_candidate_type<Class> || has_arrow_star##__const<Ret, Class>,      \
+      __const Ret&>                                                         \
+  operator->*(Ret Class::*member) __const {                                 \
+    if constexpr (is_candidate_type<Class>) {                               \
+      return as<Class>().*member;                                           \
+    } else {                                                                \
+      std::optional<__const Ret*> ret = std::nullopt;                       \
+      for_all_types([this, &member, &ret](auto t) {                         \
+        using T = typename decltype(t)::type;                               \
+        if constexpr (opcheck<T>->*opcheck<Ret Class::*>) {                 \
+          if (is<T>()) {                                                    \
+            ret = &(as<T>()->*member);                                      \
+          }                                                                 \
+        }                                                                   \
+      });                                                                   \
+      TORCH_CHECK(                                                          \
+          ret.has_value(),                                                  \
+          "Cannot access member with type ",                                \
+          typeid(Ret).name(),                                               \
+          " in class ",                                                     \
+          typeid(Class).name(),                                             \
+          " : incompatible type");                                          \
+      return *ret.value();                                                  \
+    }                                                                       \
   }
 
   DEFINE_ARROW_STAR_OPERATOR()

--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -440,7 +440,7 @@ struct DynamicType {
                                                                        \
   template <typename Ret, typename Class>                              \
   constexpr std::enable_if_t<                                          \
-      is_candidate_type<Class> || has_arrow_star<Ret, Class>,          \
+      is_candidate_type<Class> || has_arrow_star##__const<Ret, Class>, \
       __const Ret&>                                                    \
   operator->*(Ret Class::*member) __const {                            \
     if constexpr (is_candidate_type<Class>) {                          \

--- a/csrc/type_traits.h
+++ b/csrc/type_traits.h
@@ -92,15 +92,6 @@ struct HasArrowOperator<
     std::void_t<decltype(std::declval<decltype(&T::operator->)>())>>
     : std::true_type {};
 
-template <typename T, typename = void>
-struct HasArrowStarOperator : std::false_type {};
-
-template <typename T>
-struct HasArrowStarOperator<
-    T,
-    std::void_t<decltype(std::declval<decltype(&T::operator->*)>())>>
-    : std::true_type {};
-
 struct TrueType {
   static constexpr bool value() {
     return true;
@@ -178,18 +169,12 @@ struct OperatorChecker {
     return nullptr;
   }
 
-  template <
-      typename T1,
-      typename T2 = int,
-      std::enable_if_t<HasArrowStarOperator<T>::value, T2> = 0>
-  constexpr bool operator->*(T1) const {
+  template <typename T1>
+  constexpr auto operator->*(OperatorChecker<T1>) const
+      -> decltype((std::declval<T>()->*std::declval<T1>()), true) {
     return true;
   }
-  template <
-      typename T1,
-      typename T2 = int,
-      std::enable_if_t<!HasArrowStarOperator<T>::value, T2> = 0>
-  constexpr bool operator->*(T1) const {
+  constexpr bool operator->*(CastableFromOperatorChecker) const {
     return false;
   }
 

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -1168,6 +1168,14 @@ struct CD {
   constexpr const int& operator->*(int D::*member) const {
     return std::get<D>(v).*member;
   }
+
+  constexpr int& operator->*(int C::*member) {
+    return std::get<C>(v).*member;
+  }
+
+  constexpr int& operator->*(int D::*member) {
+    return std::get<D>(v).*member;
+  }
 };
 
 using ABCD = DynamicType<NoContainers, A, B, CD>;
@@ -1189,7 +1197,23 @@ static_assert(opcheck<ABCD>->*opcheck<int C::*>);
 static_assert(opcheck<ABCD>->*opcheck<int D::*>);
 static_assert(!(opcheck<ABCD>->*opcheck<int E::*>));
 
-TEST_F(DynamicTypeTest, MemberPointer) {}
+TEST_F(DynamicTypeTest, MemberPointer) {
+  ABCD aa = a;
+  EXPECT_EQ(aa->*&A::x, 1);
+  EXPECT_EQ(aa->*&A::y, 2);
+  aa->*&A::x = 299792458;
+  aa->*&A::y = 314159;
+  EXPECT_EQ(aa->*&A::x, 299792458);
+  EXPECT_EQ(aa->*&A::y, 314159);
+
+  ABCD cc = c;
+  EXPECT_EQ(cc->*&C::x, 5);
+  EXPECT_EQ(cc->*&C::y, 6);
+  cc->*&C::x = 299792458;
+  cc->*&C::y = 314159;
+  EXPECT_EQ(cc->*&C::x, 299792458);
+  EXPECT_EQ(cc->*&C::y, 314159);
+}
 
 } // namespace member_pointer_test
 

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -1201,16 +1201,16 @@ TEST_F(DynamicTypeTest, MemberPointer) {
   ABCD aa = a;
   EXPECT_EQ(aa->*&A::x, 1);
   EXPECT_EQ(aa->*&A::y, 2);
-  aa->*&A::x = 299792458;
-  aa->*&A::y = 314159;
+  aa->*& A::x = 299792458;
+  aa->*& A::y = 314159;
   EXPECT_EQ(aa->*&A::x, 299792458);
   EXPECT_EQ(aa->*&A::y, 314159);
 
   ABCD cc = c;
   EXPECT_EQ(cc->*&C::x, 5);
   EXPECT_EQ(cc->*&C::y, 6);
-  cc->*&C::x = 299792458;
-  cc->*&C::y = 314159;
+  cc->*& C::x = 299792458;
+  cc->*& C::y = 314159;
   EXPECT_EQ(cc->*&C::x, 299792458);
   EXPECT_EQ(cc->*&C::y, 314159);
 }

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -192,11 +192,8 @@ struct OverloadArrowStar {
   }
 };
 
-static_assert(opcheck<OverloadArrowStar>->*2);
-static_assert(opcheck<OverloadArrowStar>->*true);
-static_assert(opcheck<OverloadArrowStar>->*opcheck<int>);
-static_assert(!(opcheck<int>->*2));
-static_assert(!(opcheck<int>->*true));
+static_assert(!(opcheck<OverloadArrowStar>->*opcheck<int>));
+static_assert(opcheck<OverloadArrowStar>->*opcheck<int OverloadArrowStar::*>);
 static_assert(!(opcheck<int>->*opcheck<OverloadArrowStar>));
 
 // Casting operators
@@ -1138,5 +1135,62 @@ TEST_F(DynamicTypeTest, Hash2) {
   EXPECT_EQ(m.at(DoubleInt64Bool(299792458.0)), 299792458);
   EXPECT_EQ(m.at(DoubleInt64Bool(3.14159)), 3.14159);
 }
+
+namespace member_pointer_test {
+struct A {
+  int x;
+  int y;
+};
+struct B {
+  int x;
+  int y;
+};
+struct C {
+  int x;
+  int y;
+};
+struct D {
+  int x;
+  int y;
+};
+struct E {
+  int x;
+  int y;
+};
+
+struct CD {
+  std::variant<C, D> v;
+
+  constexpr const int& operator->*(int C::*member) const {
+    return std::get<C>(v).*member;
+  }
+
+  constexpr const int& operator->*(int D::*member) const {
+    return std::get<D>(v).*member;
+  }
+};
+
+using ABCD = DynamicType<NoContainers, A, B, CD>;
+constexpr ABCD a = A{1, 2};
+static_assert(a->*&A::x == 1);
+static_assert(a->*&A::y == 2);
+constexpr ABCD b = B{3, 4};
+static_assert(b->*&B::x == 3);
+static_assert(b->*&B::y == 4);
+constexpr ABCD c = CD{C{5, 6}};
+static_assert(c->*&C::x == 5);
+static_assert(c->*&C::y == 6);
+constexpr ABCD d = CD{D{7, 8}};
+static_assert(d->*&D::x == 7);
+static_assert(d->*&D::y == 8);
+static_assert(opcheck<ABCD>->*opcheck<int A::*>);
+static_assert(opcheck<ABCD>->*opcheck<int B::*>);
+static_assert(opcheck<ABCD>->*opcheck<int C::*>);
+static_assert(opcheck<ABCD>->*opcheck<int D::*>);
+static_assert(!(opcheck<ABCD>->*opcheck<int E::*>));
+
+TEST_F(DynamicTypeTest, MemberPointer) {}
+
+} // namespace member_pointer_test
 
 } // namespace nvfuser


### PR DESCRIPTION
I am about to rewrite struct type in `PolymorphicValue` for better performance, but before doing so, I'd like to have `->*` which will provide a good interface. See `namespace member_pointer_test` to get an idea about how it will be used.