### PR TITLE
Rename `Struct` -> `LegacyStruct` and misc cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ if(PROJECT_IS_TOP_LEVEL)
 
   # this is to find pip installed nvrtc/nvtx .so
   set_target_properties(${NVFUSER_CODEGEN} PROPERTIES INSTALL_RPATH
-	  "$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN/../../nvidia/nvtx/lib")
+    "$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN/../../nvidia/nvtx/lib")
   install(TARGETS ${NVFUSER_CODEGEN} EXPORT NvfuserTargets DESTINATION lib)
 
   # We are keeping fusion_cache_generated.h for the submodule build because flatc is unavailable.
@@ -414,6 +414,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/test/test_gpu_shift.cpp
     ${NVFUSER_ROOT}/test/test_resize.cpp
     ${NVFUSER_ROOT}/test/test_gpu_tensorcore.cpp
+    ${NVFUSER_ROOT}/test/test_polymorphic_value.cpp
     ${NVFUSER_ROOT}/test/test_matmul_sass.cpp
     ${NVFUSER_ROOT}/test/test_matmul_scheduler.cpp
     ${NVFUSER_ROOT}/test/test_gpu_view.cpp

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1917,7 +1917,7 @@ float FusionExecutor::runRtc(
         std::get<PrimDataType>(aten_to_data_type(input.scalar_type()).type),
         input.dim());
 
-    Struct<PolymorphicValue> concrete_value;
+    LegacyStruct<PolymorphicValue> concrete_value;
     concrete_value["data"] = PolymorphicValue(
         Pointer(input.data_ptr(), aten_to_data_type(input.scalar_type())));
     concrete_value["logical_size"] = PolymorphicValue(input.sizes().vec());

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -171,13 +171,13 @@ std::vector<std::byte> polymorphicValueToBytes(
     const PolymorphicValue& argument,
     const DataType& dtype,
     PrimDataType index_type) {
-  if (argument.is<Struct>()) {
-    // FUSER_PERF_SCOPE("polymorphicValueToBytes(Struct)");
+  if (argument.is<LegacyStruct>()) {
+    // FUSER_PERF_SCOPE("polymorphicValueToBytes(LegacyStruct)");
     TORCH_INTERNAL_ASSERT(
         std::holds_alternative<StructType>(dtype.type),
         "Expected StructType type.");
     auto dtype_ = std::get<StructType>(dtype.type);
-    auto struct_ = argument.as<Struct>();
+    auto struct_ = argument.as<LegacyStruct>();
     std::vector<std::byte> buffer;
     for (const auto& field : dtype_.fields) {
       if (!field.used_in_kernel) {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -835,7 +835,7 @@ std::vector<PolymorphicValue> StructConstruct::evaluate(
       "StructConstruct expects ",
       this->inputs().size(),
       " inputs");
-  Struct<PolymorphicValue> result;
+  LegacyStruct<PolymorphicValue> result;
   for (int64_t i : c10::irange((int64_t)inputs.size())) {
     result[attribute<std::string>(i)] = inputs.at(i);
   }

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -24,21 +24,21 @@
 namespace nvfuser {
 
 template <typename T>
-struct Struct {
+struct LegacyStruct {
   // Using std::unordered_map<std::string, T> is more convenient and
   // straightforward, but this is not guaranteed to work by C++ standard.
   // See [Incomplete type support in STL]
 #if defined(STD_UNORDERED_SET_SUPPORTS_INCOMPLETE_TYPE)
 
   std::unordered_map<std::string, T> fields;
-  Struct(std::initializer_list<std::pair<const std::string, T>> init)
+  LegacyStruct(std::initializer_list<std::pair<const std::string, T>> init)
       : fields(init) {}
 #define NVFUSER_MAYBE_STAR
 
 #else
 
   std::unordered_map<std::string, std::shared_ptr<T>> fields;
-  Struct(std::initializer_list<std::pair<const std::string, T>> init) {
+  LegacyStruct(std::initializer_list<std::pair<const std::string, T>> init) {
     for (const auto& [key, value] : init) {
       fields[key] = std::make_shared<T>(value);
     }
@@ -47,11 +47,11 @@ struct Struct {
 
 #endif
 
-  Struct() = default;
-  Struct(const Struct& other) = default;
-  Struct(Struct&& other) = default;
-  Struct& operator=(const Struct& other) = default;
-  Struct& operator=(Struct&& other) = default;
+  LegacyStruct() = default;
+  LegacyStruct(const LegacyStruct& other) = default;
+  LegacyStruct(LegacyStruct&& other) = default;
+  LegacyStruct& operator=(const LegacyStruct& other) = default;
+  LegacyStruct& operator=(LegacyStruct&& other) = default;
 
   const T& operator[](const std::string& key) const {
     return NVFUSER_MAYBE_STAR fields.at(key);
@@ -68,7 +68,7 @@ struct Struct {
 #endif
   }
 
-  bool operator==(const Struct& other) const {
+  bool operator==(const LegacyStruct& other) const {
     if (this == &other) {
       return true;
     }
@@ -88,7 +88,7 @@ struct Struct {
 };
 
 template <typename T>
-inline std::ostream& operator<<(std::ostream& os, const Struct<T>& s) {
+inline std::ostream& operator<<(std::ostream& os, const LegacyStruct<T>& s) {
   os << "struct { ";
   bool first = true;
   for (const auto& [key, value] : s.fields) {
@@ -237,7 +237,7 @@ inline std::ostream& operator<<(std::ostream& os, const Pointer& ptr) {
 }
 
 using PolymorphicValue = DynamicType<
-    Containers<std::vector, Struct>,
+    Containers<std::vector, LegacyStruct>,
     Pointer,
     Opaque,
     at::Tensor,

--- a/csrc/serde/polymorphic_value_serde.cpp
+++ b/csrc/serde/polymorphic_value_serde.cpp
@@ -117,7 +117,7 @@ flatbuffers::Offset<serde::PolymorphicValue> serializePolymorphicValue(
   TORCH_INTERNAL_ASSERT(
       !v->is<std::monostate>(), "PolymorphicValue is a std::monostate.");
   TORCH_INTERNAL_ASSERT(
-      !v->is<nvfuser::Struct>(),
+      !v->is<nvfuser::LegacyStruct>(),
       "Serialization of arbitrary struct is not implemented.");
   TORCH_INTERNAL_ASSERT(
       !v->is<nvfuser::Opaque>(),

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -334,7 +334,7 @@ std::vector<PolymorphicValue> GetMetaData::evaluate(
       input.is_cuda() || input.is_meta(),
       "GetMetaData expects a CUDA tensor as input, but got undefined tensor");
 
-  Struct<PolymorphicValue> concrete_value;
+  LegacyStruct<PolymorphicValue> concrete_value;
   concrete_value["data"] = PolymorphicValue(
       Pointer(input.data_ptr(), aten_to_data_type(input.scalar_type())));
   concrete_value["logical_size"] = PolymorphicValue(input.sizes().vec());

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -396,7 +396,7 @@ inline DataType getDataType(const PolymorphicValue& value) {
         dtype =
             ArrayType{std::make_shared<DataType>(getDataType(vec[0])), size};
       }
-    } else if constexpr (std::is_same_v<T, Struct<PolymorphicValue>>) {
+    } else if constexpr (std::is_same_v<T, LegacyStruct<PolymorphicValue>>) {
       if (value.is<T>()) {
         const auto& struct_ = value.as<T>();
         std::vector<StructType::FieldInfo> fields_info;

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -30,6 +30,7 @@ inline void checkIntValue(
   EXPECT_TRUE(actual_value.hasValue());
   EXPECT_EQ(actual_value, expected_value);
 }
+
 } // namespace
 
 // Evaluate basic scalar operations with constant values
@@ -309,7 +310,7 @@ TEST_F(ExprEvalTest, Struct) {
   evaluator.bind(a, 2L);
   evaluator.bind(b, 5L);
 
-  Struct<PolymorphicValue> expect({{"a", 2L}, {"b", 5L}});
+  LegacyStruct<PolymorphicValue> expect({{"a", 2L}, {"b", 5L}});
   EXPECT_EQ(evaluator.evaluate(struct_), expect);
   EXPECT_EQ(evaluator.evaluate(aa), 2L);
   EXPECT_EQ(evaluator.evaluate(bb), 5L);
@@ -363,14 +364,6 @@ TEST_F(ExprEvalTest, TensorMetaData) {
   checkIntValue(evaluator, size1, 128L);
   checkIntValue(evaluator, stride0, 128L);
   checkIntValue(evaluator, stride1, 1L);
-}
-
-TEST_F(ExprEvalTest, OpaqueEquality) {
-  Opaque a{DataType::Int}, b{DataType::Int};
-  EXPECT_EQ(a, a);
-  EXPECT_EQ(b, b);
-  EXPECT_EQ(a, b);
-  EXPECT_EQ(b, a);
 }
 
 TEST_F(ExprEvalTest, Validation) {

--- a/test/test_polymorphic_value.cpp
+++ b/test/test_polymorphic_value.cpp
@@ -1,0 +1,28 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <test/utils.h>
+
+#include <polymorphic_value.h>
+
+namespace nvfuser {
+
+class PolymorphicValueTest : public NVFuserTest {};
+
+TEST_F(PolymorphicValueTest, OpaqueEquality) {
+  Opaque a{DataType::Int}, b{DataType::Int};
+  EXPECT_EQ(a, a);
+  EXPECT_EQ(b, b);
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(b, a);
+}
+
+} // namespace nvfuser


### PR DESCRIPTION
Rename `Struct` -> `LegacyStruct`, this class template will be deprecated soon. Also, created a `test/test_polymorphic_value.cpp` for polymorphic value tests. Currently, there is only one test `OpaqueEquality` moved from `test/test_evaluator.cpp`, in the future, more will be added.