### PR TITLE
Add SFINAE for the ctor of `DynamicType`

### DIFF
--- a/csrc/dynamic_type.h
+++ b/csrc/dynamic_type.h
@@ -206,7 +206,7 @@ struct DynamicType {
 
   constexpr DynamicType() = default;
 
-  template <typename T>
+  template <typename T, typename = decltype(VariantType(std::declval<T>()))>
   constexpr DynamicType(T value) : value(std::move(value)) {}
 
   template <

--- a/test/test_dynamic_type.cpp
+++ b/test/test_dynamic_type.cpp
@@ -742,6 +742,18 @@ TEST_F(DynamicTypeTest, BinaryOpAdvancedTyping) {
   static_assert((Int(2) && Int(3)) == 1);
 }
 
+TEST_F(DynamicTypeTest, CastToDynamicType) {
+  using IntOrFloat = DynamicType<NoContainers, int, float>;
+  struct A {
+    constexpr operator IntOrFloat() const {
+      return 1;
+    }
+  };
+  static_assert((IntOrFloat)A{} == 1);
+  IntOrFloat x = A{};
+  EXPECT_EQ(x, 1);
+}
+
 TEST_F(DynamicTypeTest, Printing) {
   std::stringstream ss;
   ss << DoubleInt64Bool(299792458L) << ", " << DoubleInt64Bool(3.14159) << ", "


### PR DESCRIPTION
Just noticed that the casting operator from a custom class to `DynamicType` is broken, the failing case is shown in `DynamicTypeTest.CastToDynamicType`. The failure is because of the lack of SFINAE in the ctor of `DynamicType`, when a conversion is needed, the compiler always tries to use the ctor of `DynamicType` instead of the casting operator. This PR adds the required SFINAE.