### PR TITLE
Make `DynamicType` a standalone library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ target_link_libraries(${NVFUSER_CODEGEN} PRIVATE flatbuffers)
 
 # For kernel_db, linking STL Filesystem Library for backward compatability with C++14
 target_link_libraries(${NVFUSER_CODEGEN} PRIVATE stdc++fs)
+target_link_libraries(${NVFUSER_CODEGEN} PRIVATE dynamic_type)
 target_link_libraries(${NVFUSER_CODEGEN} PRIVATE ${CUDA_NVRTC_LIB} ${LIBNVTOOLSEXT})
 target_include_directories(${NVFUSER_CODEGEN} PRIVATE ${CUDA_INCLUDE_DIRS})
 
@@ -351,6 +352,7 @@ if(BUILD_PYTHON)
     target_compile_options(${NVFUSER} PRIVATE -Wall -Wno-unused-function)
     target_link_libraries(${NVFUSER} PRIVATE ${TORCH_LIBRARIES})
     target_link_libraries(${NVFUSER} PRIVATE "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so")
+    target_link_libraries(${NVFUSER} PRIVATE dynamic_type)
     target_link_libraries(${NVFUSER} PRIVATE pybind11::pybind11)
     set_target_properties(${NVFUSER} PROPERTIES INSTALL_RPATH "$ORIGIN/../torch/lib")
     install(TARGETS ${NVFUSER} DESTINATION lib)
@@ -360,6 +362,7 @@ if(BUILD_PYTHON)
     target_link_libraries(${NVFUSER} PRIVATE torch torch_python ${TORCHLIB_FLAVOR})
     target_include_directories(${NVFUSER} PRIVATE ${TORCH_ROOT})
 
+    target_link_libraries(${NVFUSER} PRIVATE dynamic_type)
     target_link_libraries(${NVFUSER} PRIVATE pybind::pybind11)
     target_compile_options(${NVFUSER} PRIVATE ${TORCH_PYTHON_COMPILE_OPTIONS})
 
@@ -396,7 +399,6 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/test/utils.cpp
     ${NVFUSER_ROOT}/test/test_allocation_domain.cpp
     ${NVFUSER_ROOT}/test/test_dynamic_transform.cpp
-    ${NVFUSER_ROOT}/test/test_dynamic_type.cpp
     ${NVFUSER_ROOT}/test/test_evaluator.cpp
     ${NVFUSER_ROOT}/test/test_expr_sort.cpp
     ${NVFUSER_ROOT}/test/test_gather.cpp
@@ -446,7 +448,7 @@ if(BUILD_TEST)
     ${JIT_TEST_CU_SRCS})
   set_property(TARGET ${NVFUSER_TESTS} PROPERTY CXX_STANDARD 17)
   target_compile_definitions(${NVFUSER_TESTS} PRIVATE USE_GTEST)
-  target_link_libraries(${NVFUSER_TESTS} PRIVATE ${NVFUSER_CODEGEN} gtest_main gmock_main flatbuffers)
+  target_link_libraries(${NVFUSER_TESTS} PRIVATE ${NVFUSER_CODEGEN} dynamic_type gtest_main gmock_main flatbuffers)
   target_include_directories(${NVFUSER_TESTS} PRIVATE "${NVFUSER_ROOT}")
 
   if(PROJECT_IS_TOP_LEVEL)
@@ -508,6 +510,7 @@ if(BUILD_NVFUSER_BENCHMARK)
 
   if(PROJECT_IS_TOP_LEVEL)
     target_compile_options(${NVFUSER_BENCHMARK} PRIVATE -Wall -Wno-unused-function)
+    target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE dynamic_type)
     target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE ${TORCH_LIBRARIES})
     target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE benchmark::benchmark)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -12,6 +12,8 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libs" FORCE)
 set(INSTALL_GTEST OFF CACHE BOOL "Install gtest." FORCE)
 set(BUILD_GMOCK ON CACHE BOOL "Build gmock." FORCE)
 
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../lib/dynamic_type)
+
 # Add googletest subdirectory but make sure our INCLUDE_DIRECTORIES do not bleed into it.
 # This is because libraries installed into the root conda env (e.g. MKL) add a global /opt/conda/include directory,
 # and if there is gtest installed in conda, the third_party/googletest/**.cc source files would try to include headers

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -19,8 +19,8 @@
 
 #define DYNAMIC_TYPE_CHECK TORCH_INTERNAL_ASSERT
 
-#include <macros.h>
 #include <dynamic_type.h>
+#include <macros.h>
 #include <opaque_type.h>
 
 namespace nvfuser {

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -7,10 +7,6 @@
 // clang-format on
 #pragma once
 
-#include <macros.h>
-
-#include <dynamic_type.h>
-#include <opaque_type.h>
 #include <any>
 #include <complex>
 #include <cstddef>
@@ -20,6 +16,12 @@
 #include <unordered_map>
 
 #include <ATen/ATen.h>
+
+#define DYNAMIC_TYPE_CHECK TORCH_INTERNAL_ASSERT
+
+#include <macros.h>
+#include <dynamic_type.h>
+#include <opaque_type.h>
 
 namespace nvfuser {
 
@@ -236,8 +238,8 @@ inline std::ostream& operator<<(std::ostream& os, const Pointer& ptr) {
   return os;
 }
 
-using PolymorphicValue = DynamicType<
-    Containers<std::vector, LegacyStruct>,
+using PolymorphicValue = dynamic_type::DynamicType<
+    dynamic_type::Containers<std::vector, LegacyStruct>,
     Pointer,
     Opaque,
     at::Tensor,

--- a/lib/dynamic_type/CMakeLists.txt
+++ b/lib/dynamic_type/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(dynamic_type INTERFACE)
+target_include_directories(dynamic_type INTERFACE src)
+
+add_executable(test_dynamic_type test/test_dynamic_type.cpp)
+target_include_directories(test_dynamic_type PUBLIC src)
+target_link_libraries(test_dynamic_type PRIVATE gtest_main gmock_main)
+set_property(TARGET test_dynamic_type PROPERTY CXX_STANDARD 17)

--- a/lib/dynamic_type/src/C++20/type_traits
+++ b/lib/dynamic_type/src/C++20/type_traits
@@ -9,6 +9,10 @@
 
 #include <type_traits>
 
+#if __has_include(<bits/c++config.h>)
+#include <bits/c++config.h>
+#endif
+
 namespace std {
 
 #if !__cpp_lib_type_identity

--- a/lib/dynamic_type/src/error.h
+++ b/lib/dynamic_type/src/error.h
@@ -1,0 +1,24 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <stdexcept>
+
+// Users should provide their own implementation of DYNAMIC_TYPE_CHECK, so that
+// the error message is more aligned with their codebase. However, if they don't
+// provide one, we provide a default implementation here with minimal
+// information.
+
+#if !defined(DYNAMIC_TYPE_CHECK)
+
+#define DYNAMIC_TYPE_CHECK(cond, msg1, ...) \
+  if (!(cond)) [[unlikely]] {               \
+    throw std::runtime_error(msg1);         \
+  }
+
+#endif

--- a/lib/dynamic_type/src/type_traits.h
+++ b/lib/dynamic_type/src/type_traits.h
@@ -7,15 +7,16 @@
 // clang-format on
 #pragma once
 
-#include <C++20/type_traits>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 
+#include "C++20/type_traits"
+
 // Note on the coding style of this file:
-// - I use `namespace nvfuser` and `} // namespace nvfuser` a lot to separate
-//   different parts of the code, so that we can easily fold and unfold them in
-//   editors that support folding.
+// - I use `namespace dynamic_type` and `} // namespace dynamic_type` a lot to
+//   separate different parts of the code, so that we can easily fold and unfold
+//   them in editors that support folding.
 // - Many tests are done with static_assert, so I just put it here, instead of
 //   writing a separate test file. Because I think these tests serves as a good
 //   documentation of the usage.
@@ -42,7 +43,7 @@
 //    }
 //  };
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // Implementation detail
 namespace can_use_args_impl {
@@ -72,9 +73,9 @@ constexpr bool can_use_args =
 static_assert(can_use_args<float (*)(float), int>);
 static_assert(!can_use_args<float (*)(float), float*>);
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // Implementation detail for opcheck. This implementation is very long, I
 // recommend read the usage doc below first before reading this implementation.
@@ -316,9 +317,9 @@ static_assert(!(opcheck<int>->value()));
 // Reference about operator overloading:
 // https://en.cppreference.com/w/cpp/language/operators
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // Basically just "void". We need this because if we have something like
 // std::tuple<void, int> we will be unable to create an instance of it.
@@ -371,9 +372,9 @@ struct ForAllTypes<> {
   }
 };
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // Check if all the booleans in the arguments are true. There are two versions:
 // one for variadic arguments, and one for std::tuple.
@@ -394,9 +395,9 @@ static_assert(all(std::make_tuple(true, true, true)));
 static_assert(!all(true, false, true));
 static_assert(!all(std::make_tuple(true, false, true)));
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // Check if all the booleans in the arguments are true. There are two versions:
 // one for variadic arguments, and one for std::tuple.
@@ -419,9 +420,9 @@ static_assert(any(std::make_tuple(true, false, true)));
 static_assert(!any(false, false, false));
 static_assert(!any(std::make_tuple(false, false, false)));
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // Remove all the voids from a tuple. For example:
 // (Void, T1, Void, T2, Void, T3, ...) -> (T1, T2, T3, ...)
@@ -454,9 +455,9 @@ static_assert(
         std::make_tuple(Void{}, 1, Void{}, true, Void{}, 3.5, Void{})) ==
     std::make_tuple(1, true, 3.5));
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 namespace belongs_to_impl {
 
@@ -492,9 +493,9 @@ constexpr bool belongs_to =
 static_assert(belongs_to<int, float, double, int>);
 static_assert(!belongs_to<int, float, double, long>);
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // Take the cartesion product of two tuples.
 // For example:
@@ -556,9 +557,9 @@ static_assert(
         std::make_tuple(true, 4, std::size_t(0)),
         std::make_tuple(true, 4, nullptr)));
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // Can I find an x from tuple1 and a y from tuple12 such that f(x, y) is
 // true? f(x, y) must be defined for all x in tuple1 and y in tuple2.
@@ -588,9 +589,9 @@ static_assert(!any_check(
     std::make_tuple(1.0, 1),
     std::make_tuple(-2, -1)));
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // Check if all the types in the tuple are the same. If the tuple is empty, or
 // the provided type is not a tuple, then it is considered to be false.
@@ -617,9 +618,9 @@ static_assert(are_all_same<const std::tuple<int, int, int>>::value);
 static_assert(!are_all_same<std::tuple<int, int, float>>::value);
 static_assert(!are_all_same<std::tuple<>>::value);
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // Get the first type in a tuple. If the tuple is empty, or the type is not a
 // tuple, then it is considered to be void.
@@ -646,9 +647,9 @@ static_assert(
 static_assert(std::is_same_v<first_or_void<std::tuple<>>::type, void>);
 static_assert(std::is_same_v<first_or_void<int>::type, void>);
 
-} // namespace nvfuser
+} // namespace dynamic_type
 
-namespace nvfuser {
+namespace dynamic_type {
 
 // If T is not a reference, then return T, otherwise the wrapped reference type.
 
@@ -673,4 +674,4 @@ static_assert(std::is_same_v<
               wrap_reference<const int&>::type,
               std::reference_wrapper<const int>>);
 
-} // namespace nvfuser
+} // namespace dynamic_type

--- a/manual_ci.sh
+++ b/manual_ci.sh
@@ -17,6 +17,7 @@ run_test() {
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+run_test './bin/lib/dynamic_type/test_dynamic_type'
 run_test './bin/nvfuser_tests'
 run_test 'pytest python_tests/pytest_ops.py'
 run_test 'python python_tests/test_python_frontend.py'


### PR DESCRIPTION
This PR split out `DynamicType` from nvFuser to maintain it as a separate C++ template library. The codebase of this library is located in `Fuser/lib/dynamic_type`. The main reason for doing so is because I want to be able to build the test for `DynamicType` separately without building the entire nvFuser. This is important for the productivity of the development of `DynamicType`, because I need to do a lot of try-and-errors in development, and each change of the `dynamic_type.h` requires rebuilding almost the entire nvFuser, which today is very slow (due to `DynamicType`). I want to be able to ignore the rest of nvFuser and just try and error in the test of `test_dynamic_type.cpp`. In the future, `test_dynamic_type.cpp` will be split into multiple separate files for better parallelizing the build. By pulling `DynamicType` as a separate library, I think we can get better code organization, because, for example, we can put the documentation in a separate `.md` file, put tests in a lot of different files, while nvFuser still treats `DynamicType` as a whole.

Because `DynamicType` heavily uses advanced C++ features, we should have a higher standard for `DynamicType` by writing more thorough tests, and run the tests on multiple different platforms (gcc9, gcc10, gcc11, gcc12, gcc13, clang++, C++17, C++20, C++23, C++26). Currently, I already have something like "this function can not be `constexpr` in C++17, but should automatically become `constexpr` in C++20" in mind, but there is no way for me to validate this, because we are using C++17. By making it a separate library, we can build the tests for `DynamicType` on all modern C++ standards, and test if it works. It also makes me possible to add many CIs to test only `DynamicType` on multiple different platforms. It is not practical to test the entire nvFuser on all these platforms, because building the entire nvFuser on GitHub actions today already takes 3 hours, and I don't want to furture add latency.

Generally, I think being modular is a good thing, and we should split more pieces of nvFuser into separate libraries if it makes sense. I would consider the relationship of `DynamicType` vs nvFuser as c10 vs PyTorch.

This PR should be only code movement, there should be no behavioral change.