### PR TITLE
Replace TORCH_CHECK and TORCH_INTERNAL_ASSERT Macros

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -49,6 +49,91 @@ init_command = [
 is_formatter = true
 
 [[linter]]
+code = 'TORCH_INTERNAL_ASSERT'
+include_patterns = [
+    '**/*.h',
+    '**/*.cpp',
+    '**/*.cu',
+    '**/*.inl',
+]
+exclude_patterns = [
+    'pytorch/**/*.cpp',
+    'third_party/**',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=TORCH_INTERNAL_ASSERT',
+    '--linter-name=TORCH_INTERNAL_ASSERT',
+    '--error-name=calling TORCH_INTERNAL_ASSERT, user NVF_ERROR instead',
+    '--replace-pattern=s/TORCH_INTERNAL_ASSERT/NVF_ERROR/',
+    """--error-description=\
+        using TORCH_INTERNAL_ASSERT in nvfuser code base is deprecated, \
+        use NVF_ERROR instead\
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]
+is_formatter = true
+
+[[linter]]
+code = 'TORCH_CHECK'
+include_patterns = [
+    '**/*.h',
+    '**/*.cpp',
+    '**/*.cu',
+    '**/*.inl',
+]
+exclude_patterns = [
+    'pytorch/**/*.cpp',
+    'third_party/**',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=TORCH_CHECK',
+    '--linter-name=TORCH_CHECK',
+    '--error-name=calling TORCH_CHECK, user NVF_CHECK instead',
+    '--replace-pattern=s/TORCH_CHECK/NVF_CHECK/',
+    """--error-description=\
+        using TORCH_CHECK in nvfuser code base is deprecated, \
+        use NVF_CHECK instead\
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]
+is_formatter = true
+
+[[linter]]
+code = 'C10_ERROR'
+include_patterns = [
+    '**/*.h',
+    '**/*.cpp',
+    '**/*.cu',
+    '**/*.inl',
+]
+exclude_patterns = [
+    'pytorch/**/*.cpp',
+    'third_party/**',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=c10::Error',
+    '--linter-name=C10_ERROR',
+    '--error-name=using c10::Error',
+    '--replace-pattern=s/c10::Error/nvfuser::nvfError/',
+    """--error-description=\
+        using c10::Error in nvfuser code base is deprecated, \
+        use nvfuser::nvfError instead\
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]
+is_formatter = true
+
+
+[[linter]]
 code = 'CLANGTIDY'
 include_patterns = [
     '**/*.h',

--- a/benchmark/batch_norm_channels_first.cpp
+++ b/benchmark/batch_norm_channels_first.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -26,7 +27,7 @@ using namespace nvfuser;
 //------------------------------------------------------------------------------
 
 static void setupBatchNorm(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
 
@@ -79,7 +80,7 @@ static void NvFuserScheduler_BatchNorm(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0),
@@ -116,7 +117,7 @@ static void NvFuserScheduler_BatchNorm(
 static void Baseline_BatchNorm(
     benchmark::State& benchmark_state,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   const float kMomentum = 0.1;
   const float kEps = 1e-5;

--- a/benchmark/batch_norm_channels_first_backward.cpp
+++ b/benchmark/batch_norm_channels_first_backward.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -28,7 +29,7 @@ using namespace nvfuser;
 //------------------------------------------------------------------------------
 
 static void setupBatchNorm_BWD(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
 
@@ -90,7 +91,7 @@ static void NvFuserScheduler_BatchNorm_BWD(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0),
@@ -129,7 +130,7 @@ static void NvFuserScheduler_BatchNorm_BWD(
 static void Baseline_BatchNorm_BWD(
     benchmark::State& benchmark_state,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   const float kMomentum = 0.1;
   const float kEps = 1e-5;

--- a/benchmark/batch_norm_channels_last.cpp
+++ b/benchmark/batch_norm_channels_last.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -26,7 +27,7 @@ using namespace nvfuser;
 //------------------------------------------------------------------------------
 
 static void setupBatchNorm_nhwc(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
 
@@ -80,7 +81,7 @@ static void NvFuserScheduler_BatchNorm_nhwc(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0),
@@ -117,7 +118,7 @@ static void NvFuserScheduler_BatchNorm_nhwc(
 static void Baseline_BatchNorm_nhwc(
     benchmark::State& benchmark_state,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   const float kMomentum = 0.1;
   const float kEps = 1e-5;

--- a/benchmark/batch_norm_channels_last_backward.cpp
+++ b/benchmark/batch_norm_channels_last_backward.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -28,7 +29,7 @@ using namespace nvfuser;
 //------------------------------------------------------------------------------
 
 static void setupBatchNorm_nhwc_BWD(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
 
@@ -91,7 +92,7 @@ static void NvFuserScheduler_BatchNorm_nhwc_BWD(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0),
@@ -130,7 +131,7 @@ static void NvFuserScheduler_BatchNorm_nhwc_BWD(
 static void Baseline_BatchNorm_nhwc_BWD(
     benchmark::State& benchmark_state,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   const float kMomentum = 0.1;
   const float kEps = 1e-5;

--- a/benchmark/heuristic_cache.cpp
+++ b/benchmark/heuristic_cache.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -107,8 +108,7 @@ static void LayerNormBackward_HeuristicLookup(
 
   auto runtime = getLayerBackwardNormRuntime(
       std::move(fusion_ptr), fec, aten_inputs, shape, norm_shape);
-  TORCH_INTERNAL_ASSERT(
-      runtime->getMaybeHeuristicsFor(aten_inputs).has_value());
+  NVF_ERROR(runtime->getMaybeHeuristicsFor(aten_inputs).has_value());
 
   for (auto _ : benchmark_state) {
     // Setup (not included in the measurement)
@@ -160,8 +160,7 @@ static void LayerNormForward_HeuristicLookup(
 
   auto runtime = getLayerForwardNormRuntime(
       std::move(fusion_ptr), fec, aten_inputs, shape, norm_shape);
-  TORCH_INTERNAL_ASSERT(
-      runtime->getMaybeHeuristicsFor(aten_inputs).has_value());
+  NVF_ERROR(runtime->getMaybeHeuristicsFor(aten_inputs).has_value());
 
   for (auto _ : benchmark_state) {
     // Setup (not included in the measurement)

--- a/benchmark/heuristic_lookup.cpp
+++ b/benchmark/heuristic_lookup.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -111,7 +112,7 @@ static void LayerNormBackward_HeuristicLookup(
   KernelArgumentHolder args =
       KernelArgumentHolder::createKernelArgumentHolder(aten_inputs);
 
-  TORCH_INTERNAL_ASSERT(runtime->getMaybeHeuristicsFor(args).has_value());
+  NVF_ERROR(runtime->getMaybeHeuristicsFor(args).has_value());
 
   for (auto _ : benchmark_state) {
     // Setup (not included in the measurement)
@@ -167,7 +168,7 @@ static void LayerNormForward_HeuristicLookup(
   KernelArgumentHolder args =
       KernelArgumentHolder::createKernelArgumentHolder(aten_inputs);
 
-  TORCH_INTERNAL_ASSERT(runtime->getMaybeHeuristicsFor(args).has_value());
+  NVF_ERROR(runtime->getMaybeHeuristicsFor(args).has_value());
 
   for (auto _ : benchmark_state) {
     // Setup (not included in the measurement)

--- a/benchmark/instance_norm.cpp
+++ b/benchmark/instance_norm.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -25,7 +26,7 @@ static void setupInstanceNorm(
     Fusion* fusion,
     DataType dtype,
     bool channels_last_3d = false) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
 
@@ -83,7 +84,7 @@ static void NvFuserScheduler_InstanceNorm(
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype,
     bool channels_last_3d = false) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0),
@@ -130,7 +131,7 @@ static void NvFuserScheduler_InstanceNorm(
 // ------------------------------------------------------------------------------
 // performance of https://github.com/NVIDIA/Fuser/issues/443
 static void setupInstanceNormNHWC(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
   FusionGuard fg(fusion);
 
   auto input = makeContigTensor(4, dtype);
@@ -166,7 +167,7 @@ static void NvFuserScheduler_InstanceNormNHWC(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0),
@@ -200,7 +201,7 @@ static void Baseline_InstanceNorm(
     benchmark::State& benchmark_state,
     DataType dtype,
     bool channels_last_3d = false) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0),

--- a/benchmark/layer_norm.cpp
+++ b/benchmark/layer_norm.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -26,7 +27,7 @@ using namespace nvfuser;
 //------------------------------------------------------------------------------
 
 static void setupLayerNorm(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
 
@@ -68,7 +69,7 @@ static void NvFuserScheduler_LayerNorm(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0), benchmark_state.range(1)};
@@ -96,7 +97,7 @@ static void NvFuserScheduler_LayerNorm(
 static void Baseline_LayerNorm(
     benchmark::State& benchmark_state,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0), benchmark_state.range(1)};
@@ -143,7 +144,7 @@ static void NvFuserScheduler_TIMM_LayerNorm(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   // NHWC, norm on C
   std::vector<int64_t> input_shape{
@@ -172,7 +173,7 @@ static void NvFuserScheduler_TIMM_LayerNorm(
 static void Baseline_TIMM_LayerNorm(
     benchmark::State& benchmark_state,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   // NHWC, norm on C
   std::vector<int64_t> input_shape{

--- a/benchmark/layer_norm_backward.cpp
+++ b/benchmark/layer_norm_backward.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -28,7 +29,7 @@ using namespace nvfuser;
 static void setupLayerNorm_BWD(Fusion* fusion, DataType dtype) {
   FusionGuard fg(fusion);
 
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   // setup fusion
   auto grad_out = makeContigTensor(2, dtype);
@@ -81,7 +82,7 @@ static void NvFuserScheduler_LayerNorm_BWD(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0), benchmark_state.range(1)};
@@ -116,7 +117,7 @@ static void NvFuserScheduler_LayerNorm_BWD(
 static void Baseline_LayerNorm_BWD(
     benchmark::State& benchmark_state,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0), benchmark_state.range(1)};

--- a/benchmark/layer_norm_fused.cpp
+++ b/benchmark/layer_norm_fused.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -26,7 +27,7 @@ using namespace nvfuser;
 //------------------------------------------------------------------------------
 
 static void setupLayerNormFused(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Half);
   const float kEps = 1e-5;
 
   FusionGuard fg(fusion);
@@ -85,7 +86,7 @@ static void NvFuserScheduler_LayerNormFused(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0), benchmark_state.range(1)};
@@ -116,7 +117,7 @@ static void NvFuserScheduler_LayerNormFused(
 static void Baseline_LayerNormFused(
     benchmark::State& benchmark_state,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   std::vector<int64_t> input_shape{
       benchmark_state.range(0), benchmark_state.range(1)};

--- a/benchmark/matmul.cpp
+++ b/benchmark/matmul.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/analysis/bank_conflict.h>
 #include <executor.h>
 #include <fusion.h>
@@ -72,7 +73,7 @@ void checkMatch(at::Tensor expect, at::Tensor result, int64_t k) {
   if (allclose) {
     return;
   }
-  TORCH_INTERNAL_ASSERT(is_close.dim() == 2);
+  NVF_ERROR(is_close.dim() == 2);
 
   int64_t lower_row, higher_row, lower_col, higher_col;
   for (lower_row = 0; lower_row < is_close.size(0); lower_row++) {
@@ -96,7 +97,7 @@ void checkMatch(at::Tensor expect, at::Tensor result, int64_t k) {
     }
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       false,
       "Fusion returns wrong results! ",
       "The result tensor has shape [",
@@ -161,7 +162,7 @@ static void SingleMatmulBase(
   FusionExecutor fe;
   fe.compileFusion(fusion, args, launch_constraints, cparams);
   if (turing_or_later) {
-    TORCH_CHECK(
+    NVF_CHECK(
         getBankConflictInfo(fe.kernel(), launch_constraints).empty(),
         "Shared memory bank conflict not removed.");
   }

--- a/benchmark/rms_norm.cpp
+++ b/benchmark/rms_norm.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -26,7 +27,7 @@ using namespace nvfuser;
 //------------------------------------------------------------------------------
 
 static void setupRMSNorm(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       dtype == DataType::Float || dtype == DataType::Half ||
       dtype == DataType::BFloat16);
 
@@ -63,7 +64,7 @@ static void NvFuserScheduler_RMSNorm(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       dtype == DataType::Float || dtype == DataType::Half ||
       dtype == DataType::BFloat16);
 

--- a/benchmark/rms_norm_backward.cpp
+++ b/benchmark/rms_norm_backward.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -28,7 +29,7 @@ using namespace nvfuser;
 static void setupRMSNorm_BWD(Fusion* fusion, DataType dtype) {
   FusionGuard fg(fusion);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       dtype == DataType::Float || dtype == DataType::Half ||
       dtype == DataType::BFloat16);
 
@@ -70,7 +71,7 @@ static void NvFuserScheduler_RMSNorm_BWD(
     benchmark::State& benchmark_state,
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       dtype == DataType::Float || dtype == DataType::Half ||
       dtype == DataType::BFloat16);
 

--- a/benchmark/scale_bias_relu.cpp
+++ b/benchmark/scale_bias_relu.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -21,7 +22,7 @@
 using namespace nvfuser;
 
 static void setupSBR(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
 
@@ -64,7 +65,7 @@ static void setupSBR(Fusion* fusion, DataType dtype) {
 }
 
 static void setupSBRNorm(Fusion* fusion, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
   FusionGuard fg(fusion);
 
   const size_t kNumberOfDims = 4;

--- a/benchmark/shape_inference.cpp
+++ b/benchmark/shape_inference.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -112,7 +113,7 @@ void LayerNormBackward_ShapeInference_Base(
   KernelArgumentHolder args =
       KernelArgumentHolder::createKernelArgumentHolder(aten_inputs);
 
-  TORCH_INTERNAL_ASSERT(runtime->getMaybeHeuristicsFor(args).has_value());
+  NVF_ERROR(runtime->getMaybeHeuristicsFor(args).has_value());
 
   fec->profile(true);
   fec->disableKernelLaunch();
@@ -186,7 +187,7 @@ void LayerNormForward_ShapeInferenceBase(
   KernelArgumentHolder args =
       KernelArgumentHolder::createKernelArgumentHolder(aten_inputs);
 
-  TORCH_INTERNAL_ASSERT(runtime->getMaybeHeuristicsFor(args).has_value());
+  NVF_ERROR(runtime->getMaybeHeuristicsFor(args).has_value());
 
   fec->profile(true);
   fec->disableKernelLaunch();

--- a/benchmark/softmax.cpp
+++ b/benchmark/softmax.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -29,7 +30,7 @@ static void setupSoftmax(
     Fusion* fusion,
     DataType dtype,
     const int reduction_axis) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
   // setup fusion
@@ -54,7 +55,7 @@ static void NvFuserScheduler_Softmax(
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype,
     const int reduction_axis) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   at::manual_seed(0);
   auto options =
@@ -96,7 +97,7 @@ static void Softmax_WarpReduceReference(benchmark::State& benchmark_state) {
 
   // Schedule through magic scheduler:
   SchedulerRuntimeInfo runtime_info(fusion, aten_inputs);
-  TORCH_INTERNAL_ASSERT(SchedulerEntry::canSchedule(
+  NVF_ERROR(SchedulerEntry::canSchedule(
       ScheduleHeuristic::Persistent, fusion, runtime_info));
   auto scheduler = SchedulerEntry::makeEntry(
       ScheduleHeuristic::Persistent, fusion, runtime_info);
@@ -131,7 +132,7 @@ static void Softmax_WarpReduce(benchmark::State& benchmark_state) {
 
   // Schedule through magic scheduler:
   SchedulerRuntimeInfo runtime_info(fusion, aten_inputs);
-  TORCH_INTERNAL_ASSERT(SchedulerEntry::canSchedule(
+  NVF_ERROR(SchedulerEntry::canSchedule(
       ScheduleHeuristic::Persistent, fusion, runtime_info));
   auto scheduler = SchedulerEntry::makeEntry(
       ScheduleHeuristic::Persistent, fusion, runtime_info);

--- a/benchmark/softmax_backward.cpp
+++ b/benchmark/softmax_backward.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -28,7 +29,7 @@ static void setupSoftmaxBWD(
     Fusion* fusion,
     DataType dtype,
     const int reduction_axis) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
   // setup fusion
@@ -59,7 +60,7 @@ static void NvFuserScheduler_Softmax_BWD(
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype,
     const int reduction_axis) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   at::manual_seed(0);
   auto options =

--- a/benchmark/softmax_dropout.cpp
+++ b/benchmark/softmax_dropout.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <arith.h>
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -30,7 +31,7 @@ static void setupSoftmaxDropout(
     Fusion* fusion,
     DataType dtype,
     const int kReductionAxis) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   FusionGuard fg(fusion);
 
@@ -81,7 +82,7 @@ static void NvFuserScheduler_SoftmaxDropout(
     FusionExecutorCache* fusion_executor_cache,
     DataType dtype,
     const int kReductionAxis) {
-  TORCH_INTERNAL_ASSERT(dtype == DataType::Float || dtype == DataType::Half);
+  NVF_ERROR(dtype == DataType::Float || dtype == DataType::Half);
 
   // reduce across 1, [256, 12, 100, 8]
   std::vector<int64_t> input_shape{256, 12, 100, benchmark_state.range(0)};

--- a/benchmark/utils.cpp
+++ b/benchmark/utils.cpp
@@ -122,7 +122,7 @@ std::string toString(const std::shared_ptr<HeuristicParams>& params) {
   if (tparams) {
     return toString(*tparams);
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false,
       "Unknown heuristic parameter type. Did you just added a new heuristic parameter type but forget to update here?");
 }

--- a/benchmark/utils.h
+++ b/benchmark/utils.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <executor.h>
 #include <fusion.h>
@@ -111,7 +112,7 @@ class BenchmarkGraph : public benchmark::Fixture {
 
   FusionExecutorCache* getExecutorCache() {
     auto& executor_ = getExecutorCacheMap()[graphName()];
-    TORCH_INTERNAL_ASSERT(executor_);
+    NVF_ERROR(executor_);
     return executor_.get();
   }
 

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -151,7 +151,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     codegen.genPrologue();
     codegen.genBody();
     codegen.endBlock();
-    TORCH_CHECK(codegen.block_nest_level_ == 0);
+    NVF_CHECK(codegen.block_nest_level_ == 0);
     return codegen.code_.str();
   }
 
@@ -170,7 +170,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void setPrecision(std::stringstream& ss, DataType dtype) {
-    TORCH_INTERNAL_ASSERT(isFloatingPointType(dtype));
+    NVF_ERROR(isFloatingPointType(dtype));
     ss << std::setprecision(max_digits10(dtype));
   }
 
@@ -264,7 +264,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
               << "> " << var_name_ss.str();
         }
       } else {
-        TORCH_INTERNAL_ASSERT(param->isScalar()); // NOLINT (LLVM bug 48525)
+        NVF_ERROR(param->isScalar()); // NOLINT (LLVM bug 48525)
         code_ << param->dtype() << " " << var_name_ss.str();
       }
 
@@ -373,7 +373,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
   void endBlock(const char* sep = "\n") {
     --block_nest_level_;
-    TORCH_CHECK(block_nest_level_ >= 0);
+    NVF_CHECK(block_nest_level_ >= 0);
     indent() << "}" << sep;
   }
 
@@ -407,12 +407,12 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     if (stmt->isA<Expr>()) {
       // This expr should just be an individul expr with no nested
       // scope
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !stmt->isA<kir::IfThenElse>() && !stmt->isA<kir::ForLoop>(),
           "Invalid expr: ",
           stmt->toString());
     } else {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           stmt->isA<Val>(), "Unknown Statement IR type: ", stmt->toString());
     }
 
@@ -434,7 +434,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const kir::Predicate* pred) final {
-    TORCH_INTERNAL_ASSERT(pred->hasValue());
+    NVF_ERROR(pred->hasValue());
     code_ << gen(pred->value());
   }
 
@@ -484,12 +484,11 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         if (dtype == DataType::ComplexFloat) {
           code_ << "std::complex<float>" << value;
         } else {
-          TORCH_INTERNAL_ASSERT(dtype == DataType::ComplexDouble);
+          NVF_ERROR(dtype == DataType::ComplexDouble);
           code_ << "std::complex<double>" << value;
         }
       } else {
-        TORCH_INTERNAL_ASSERT(
-            false, "Unhandled constant type: ", s->dtype(), " ", value);
+        NVF_ERROR(false, "Unhandled constant type: ", s->dtype(), " ", value);
       }
     } else {
       code_ << genVariableName(s);
@@ -516,11 +515,11 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const IterDomain*) final {
-    TORCH_INTERNAL_ASSERT(false, "Unreachable");
+    NVF_ERROR(false, "Unreachable");
   }
 
   void handle(const TensorDomain*) final {
-    TORCH_INTERNAL_ASSERT(false, "Unreachable");
+    NVF_ERROR(false, "Unreachable");
   }
 
   void handle(const TensorView* tv) final {
@@ -648,7 +647,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       if (op_type == UnaryOpType::Cast) {
         const auto cast_str =
             cast_func_str({uop->in()->dtype(), uop->out()->dtype()});
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             cast_str.has_value(),
             "Invalid cast. Input type: ",
             uop->in()->dtype(),
@@ -674,7 +673,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const RNGOp* rop) final {
-    // TODO: TORCH_INTERNAL_ASSERT that the scheduler correctly creates an
+    // TODO: NVF_ERROR that the scheduler correctly creates an
     // innermost ID of size 4 (float) or size 2 (double)?
     auto index = genInline(rop->getPhiloxIndex());
     int multiple = rop->getPhiloxMultiple();
@@ -703,13 +702,13 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     switch (op_type) {
       case RNGOpType::UniformRange: {
         auto parameters = rop->getParameters();
-        TORCH_INTERNAL_ASSERT(parameters.size() == 2);
+        NVF_ERROR(parameters.size() == 2);
         code_ << ", " << gen(parameters[0]) << ", " << gen(parameters[1]);
         break;
       }
       case RNGOpType::NormalGeneral: {
         auto parameters = rop->getParameters();
-        TORCH_INTERNAL_ASSERT(parameters.size() == 2);
+        NVF_ERROR(parameters.size() == 2);
         code_ << ", " << gen(parameters[0]) << ", " << gen(parameters[1]);
         break;
       }
@@ -991,7 +990,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       // non-deterministic
       indent() << gen(sop->output(0)) << " = " << gen(sop->input(2)) << ";\n";
     } else {
-      TORCH_INTERNAL_ASSERT(false, "unkown scatterOp");
+      NVF_ERROR(false, "unkown scatterOp");
     }
   }
 
@@ -1004,7 +1003,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     } else if (isAmpere(macro)) {
       ss << "Ampere";
     } else {
-      TORCH_INTERNAL_ASSERT(false, "mma macro unknown arch");
+      NVF_ERROR(false, "mma macro unknown arch");
     }
     return ss.str();
   }
@@ -1021,10 +1020,9 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     // clang-tidy: bugprone-unchecked-optional-access
     // clang-tidy assumes that function result is unstable, so we need a copy.
     auto mma_layout_opt = mma->layout();
-    TORCH_INTERNAL_ASSERT(
-        mma_layout_opt.has_value(), "mma unknown input layout");
+    NVF_ERROR(mma_layout_opt.has_value(), "mma unknown input layout");
     if (isTuring(options.macro) || isAmpere(options.macro)) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           mma_layout_opt == MmaOptions::MmaLayout::TN,
           "MMAs in Turing and Ampere are TN only, transpose is handled either "
           "via ldmatrix.trans for fp16 or explicitly for other types.");
@@ -1032,7 +1030,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     ss << toString(mma_layout_opt.value());
     // TODO: additional parameter could be removed by swizzling iterdomain
     auto acc_stride = mma->accStride();
-    TORCH_INTERNAL_ASSERT(acc_stride > 0);
+    NVF_ERROR(acc_stride > 0);
     ss << "<" << acc_stride << ">";
     return ss.str();
   }
@@ -1088,7 +1086,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const BroadcastOp* stmt) final {
-    TORCH_INTERNAL_ASSERT(stmt->out()->isA<kir::TensorIndex>());
+    NVF_ERROR(stmt->out()->isA<kir::TensorIndex>());
 
     const ParallelTypeBitmap parallel_types =
         kernel_->summary().broadcast_parallel_types.at(stmt);
@@ -1100,7 +1098,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       return;
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !parallel_types.hasBID(),
         "Parallel broadcast across blocks should have been translated to a GridBroadcast IR node");
 
@@ -1116,8 +1114,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_args.arg(gen(stmt->out()));
     func_args.arg(gen(stmt->in()));
     func_args.arg(genStaticCast(genPtrType(data_type), "shared_mem"));
-    TORCH_INTERNAL_ASSERT(
-        stmt->predicate() != nullptr && stmt->predicate()->hasValue());
+    NVF_ERROR(stmt->predicate() != nullptr && stmt->predicate()->hasValue());
     func_args.arg(genInline(stmt->predicate()));
 
     indent() << genCall("broadcast::blockBroadcast", template_args, func_args)
@@ -1151,7 +1148,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_args.arg(gen(input));
     func_args.arg(genReductionOp(reduction_op_type, output->dtype()));
     func_args.arg(genStaticCast(genPtrType(output->dtype()), "shared_mem"));
-    TORCH_INTERNAL_ASSERT(read_pred != nullptr && read_pred->hasValue());
+    NVF_ERROR(read_pred != nullptr && read_pred->hasValue());
     func_args.arg(genInline(read_pred));
     func_args.arg(genStaticCast(output->dtype(), genInline(init)));
 
@@ -1189,14 +1186,14 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_args.arg(gen(input));
     func_args.arg(genReductionOp(reduction_op_type, output->dtype()));
     func_args.arg(genStaticCast(genPtrType(data_type), "shared_mem"));
-    TORCH_INTERNAL_ASSERT(read_pred != nullptr && read_pred->hasValue());
+    NVF_ERROR(read_pred != nullptr && read_pred->hasValue());
     func_args.arg(genInline(read_pred));
     // Pass the write predicate if available and different from the
     // default predicate. The blockReduce runtime function uses the
     // default predicate for both read and write when only the
     // default one is given.
     if (write_pred != nullptr) {
-      TORCH_INTERNAL_ASSERT(write_pred->hasValue());
+      NVF_ERROR(write_pred->hasValue());
       func_args.arg(genInline(write_pred));
     }
     func_args.arg(genCall(data_type, genInline(init)));
@@ -1205,7 +1202,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const ReductionOp* rop) final {
-    TORCH_INTERNAL_ASSERT(rop->out()->isA<kir::TensorIndex>());
+    NVF_ERROR(rop->out()->isA<kir::TensorIndex>());
 
     const auto output = rop->out()->as<kir::TensorIndex>();
     const auto input = rop->in()->as<kir::TensorIndex>();
@@ -1215,7 +1212,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     const bool has_block_reduce = domain->hasBlockReduction();
     const bool has_grid_reduce = domain->hasGridReduction();
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !has_grid_reduce,
         "ReductionOp does not support block parallelization. GridReductionOp must be used. ",
         rop->toString());
@@ -1248,9 +1245,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
               out_tv->getLeafDomain().end(),
               [&](IterDomain* id) { return id->isMma(); })) {
         auto mma = dynamic_cast<MmaOp*>(out_tv->definition());
-        TORCH_INTERNAL_ASSERT(
-            mma != nullptr, "CodeGen: mma op not in mma loop");
-        TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Set);
+        NVF_ERROR(mma != nullptr, "CodeGen: mma op not in mma loop");
+        NVF_ERROR(optype == LoadStoreOpType::Set);
         genMmaInitialization(mma, ldst);
         return;
       }
@@ -1265,7 +1261,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
             continue;
           }
 
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               id->extent()->isConstInt(),
               "Could not evaluate constant value bound to vectorized dim.");
 
@@ -1277,7 +1273,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       }
 
       if (is_vector_op && !ldst->in()->isScalar()) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             ldst->out()->dtype() == ldst->in()->dtype(),
             "Vectorized store/load requires input and output datatypes match.");
       }
@@ -1285,8 +1281,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       // dispatch ldmatrix
       if (optype == LoadStoreOpType::LdMatrix ||
           optype == LoadStoreOpType::LdMatrixTranspose) {
-        TORCH_INTERNAL_ASSERT(
-            is_vector_op, "LdMatrix: Vectorization required: ", ldst);
+        NVF_ERROR(is_vector_op, "LdMatrix: Vectorization required: ", ldst);
         genLdMatrix(ldst, vector_word_size);
         return;
       }
@@ -1295,7 +1290,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       if (optype == LoadStoreOpType::CpAsyncCa ||
           optype == LoadStoreOpType::CpAsyncCg) {
         if (optype == LoadStoreOpType::CpAsyncCg) {
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               is_vector_op && vector_word_size == 8,
               "cp.async.cg only support vectorize 8");
         }
@@ -1305,7 +1300,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
       // dispatch vectorized load/store
       if (is_vector_op) {
-        TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Set);
+        NVF_ERROR(optype == LoadStoreOpType::Set);
         if (ldst->in()->isScalar()) {
           // Note:
           //  Double buffered local tensors need indexed initialization,
@@ -1326,7 +1321,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           }
         } else {
           // Vectorized load
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               ldst->in()->isA<kir::TensorIndex>(),
               "Invalid input to unary op with tensor output, found: ",
               ldst->in()->toString());
@@ -1379,7 +1374,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     }
 
     // Generic set op
-    TORCH_INTERNAL_ASSERT(optype == LoadStoreOpType::Set);
+    NVF_ERROR(optype == LoadStoreOpType::Set);
 
     if (!print_inline_ &&
         std::holds_alternative<StructType>(ldst->out()->dtype().type)) {
@@ -1410,7 +1405,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void genBlockWelford(const WelfordOp* wop) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         ir_utils::getTvOutput(wop)->domain()->hasBlockReduction(),
         "Not block-parallel WelfordOp: ",
         wop->toString());
@@ -1478,12 +1473,11 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_args.arg(genReinterpretCast(genPtrType(data_type), "shared_mem_avg"));
     func_args.arg(genReinterpretCast(genPtrType(data_type), "shared_mem_var"));
     func_args.arg(genReinterpretCast(genPtrType(index_type), "shared_mem_n"));
-    TORCH_INTERNAL_ASSERT(wop->predicate() != nullptr);
-    TORCH_INTERNAL_ASSERT(
-        wop->predicate() != nullptr && wop->predicate()->hasValue());
+    NVF_ERROR(wop->predicate() != nullptr);
+    NVF_ERROR(wop->predicate() != nullptr && wop->predicate()->hasValue());
     func_args.arg(genInline(wop->predicate()));
     if (wop->writePredicate() != nullptr) {
-      TORCH_INTERNAL_ASSERT(wop->writePredicate()->hasValue());
+      NVF_ERROR(wop->writePredicate()->hasValue());
       func_args.arg(genInline(wop->writePredicate()));
     }
     func_args.arg(genStaticCast(data_type, 0));
@@ -1492,7 +1486,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const WelfordOp* wop) final {
-    TORCH_INTERNAL_ASSERT(wop->out()->isA<kir::TensorIndex>());
+    NVF_ERROR(wop->out()->isA<kir::TensorIndex>());
 
     const auto out = wop->out()->as<kir::TensorIndex>();
     const auto& domain = out->view()->domain();
@@ -1506,8 +1500,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     const auto in_N = wop->inN();
 
     // inVar was allowed to be nullptr. Make sure it isn't.
-    TORCH_INTERNAL_ASSERT(
-        in_var != nullptr, "Welford var input nullptr not allowed");
+    NVF_ERROR(in_var != nullptr, "Welford var input nullptr not allowed");
 
     const bool has_block_reduce = domain->hasBlockReduction();
     const bool has_grid_reduce = domain->hasGridReduction();
@@ -1567,7 +1560,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   std::string generateGridReduceTemplateFlags(
       const REDUCTION_OP* rop,
       const ParallelTypeBitmap& thread_pred) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !rop->isAllreduce(),
         "This is not for the allreduce reduction kernel\n");
 
@@ -1578,7 +1571,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           par_domains.find(pt) != par_domains.end() &&
           par_domains.at(pt)->isReduction();
       const bool pred = thread_pred.get(pt);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !(parallel_reduction && pred), "Cannot reduce predicated axis: ", pt);
       bool flag = false;
       if (isParallelTypeBlockDim(pt)) {
@@ -1597,7 +1590,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   std::string generateGridReduceTemplateFlags2(
       const REDUCTION_OP* rop,
       const ParallelTypeBitmap& thread_pred) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !rop->isAllreduce(),
         "This is not for the allreduce reduction kernel\n");
 
@@ -1609,7 +1602,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           par_domains.find(pt) != par_domains.end() &&
           par_domains.at(pt)->isReduction();
       const bool pred = thread_pred.get(pt);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !(parallel_reduction && pred), "Cannot reduce predicated axis: ", pt);
       flags.arg(parallel_reduction);
     }
@@ -1622,7 +1615,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       const auto& buffer_indices =
           kernel_->profile().getIndicesInProfileBuffer(expr);
       auto buffer = kernel_->profile().getBuffer();
-      TORCH_INTERNAL_ASSERT(buffer != nullptr);
+      NVF_ERROR(buffer != nullptr);
       for (const auto& index : buffer_indices) {
         func_args.arg(genVariableName(buffer))
             .append("[")
@@ -1633,18 +1626,17 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const kir::GridReduction* grop) final {
-    TORCH_INTERNAL_ASSERT(grop->out()->isA<kir::TensorIndex>());
+    NVF_ERROR(grop->out()->isA<kir::TensorIndex>());
 
     const auto out = grop->out()->as<kir::TensorIndex>();
     const auto domain = out->view()->domain();
-    TORCH_INTERNAL_ASSERT(domain->hasGridReduction());
+    NVF_ERROR(domain->hasGridReduction());
 
     const auto data_type = grop->out()->dtype();
     const auto op_type = grop->getReductionOpType();
 
-    TORCH_INTERNAL_ASSERT(
-        grop->reduction_buffer()->buffer()->isA<TensorView>());
-    TORCH_INTERNAL_ASSERT(grop->sync_buffer()->buffer()->isA<TensorView>());
+    NVF_ERROR(grop->reduction_buffer()->buffer()->isA<TensorView>());
+    NVF_ERROR(grop->sync_buffer()->buffer()->isA<TensorView>());
     const auto work_buffer =
         grop->reduction_buffer()->buffer()->as<TensorView>();
     const auto sync_buffer = grop->sync_buffer()->buffer()->as<TensorView>();
@@ -1674,12 +1666,11 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_args.arg("&").append(genVariableName(sync_buffer)).append("[0]");
     func_args.arg(genCall("static_cast", ptrType(data_type), "shared_mem"));
     // read and write predicates
-    TORCH_INTERNAL_ASSERT(
-        grop->predicate() != nullptr && grop->predicate()->hasValue());
+    NVF_ERROR(grop->predicate() != nullptr && grop->predicate()->hasValue());
     const auto read_pred = genInline(grop->predicate());
     func_args.arg(read_pred);
     if (grop->writePredicate() != nullptr) {
-      TORCH_INTERNAL_ASSERT(grop->writePredicate()->hasValue());
+      NVF_ERROR(grop->writePredicate()->hasValue());
       func_args.arg(genInline(grop->writePredicate()));
     } else {
       func_args.arg(read_pred);
@@ -1700,7 +1691,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void generateGridAllreduce(const kir::GridReduction* grop) {
-    TORCH_INTERNAL_ASSERT(grop->isAllreduce());
+    NVF_ERROR(grop->isAllreduce());
 
     const auto out = grop->out()->as<kir::TensorIndex>();
 
@@ -1747,12 +1738,11 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         data_type,
         genCall("static_cast", ptrType(data_type), "shared_mem")));
     // read and write predicates
-    TORCH_INTERNAL_ASSERT(
-        grop->predicate() != nullptr && grop->predicate()->hasValue());
+    NVF_ERROR(grop->predicate() != nullptr && grop->predicate()->hasValue());
     const auto read_pred = genInline(grop->predicate());
     auto write_pred = read_pred;
     if (grop->writePredicate() != nullptr) {
-      TORCH_INTERNAL_ASSERT(grop->writePredicate()->hasValue());
+      NVF_ERROR(grop->writePredicate()->hasValue());
       write_pred = genInline(grop->writePredicate());
     }
     func_args.arg(read_pred).arg(write_pred);
@@ -1770,10 +1760,9 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   void handle(const kir::GroupedGridReduction* grouped_grop) final {
     const auto out = ir_utils::getTvOutput(grouped_grop);
     const auto domain = out->domain();
-    TORCH_INTERNAL_ASSERT(domain->hasGridReduction());
+    NVF_ERROR(domain->hasGridReduction());
 
-    TORCH_INTERNAL_ASSERT(
-        grouped_grop->sync_buffer()->buffer()->isA<TensorView>());
+    NVF_ERROR(grouped_grop->sync_buffer()->buffer()->isA<TensorView>());
     const auto sync_buffer =
         grouped_grop->sync_buffer()->buffer()->as<TensorView>();
 
@@ -1782,7 +1771,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       return;
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         grouped_grop->numHorizontallyGroupedExprs() == 2,
         "Only grouping of 2 reductions is supported. ",
         grouped_grop->toString());
@@ -1804,7 +1793,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     // Append arguments for each reduction
     for (const auto i :
          c10::irange(grouped_grop->numHorizontallyGroupedExprs())) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           grouped_grop->reduction_buffers().at(i)->buffer()->isA<TensorView>());
       const auto work_buffer =
           grouped_grop->reduction_buffers().at(i)->buffer()->as<TensorView>();
@@ -1824,13 +1813,13 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_args.arg("&").append(genVariableName(sync_buffer)).append("[0]");
     func_args.arg("shared_mem");
     // read and write predicates
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         grouped_grop->predicate() != nullptr &&
         grouped_grop->predicate()->hasValue());
     const auto read_pred = genInline(grouped_grop->predicate());
     func_args.arg(read_pred);
     if (grouped_grop->writePredicate() != nullptr) {
-      TORCH_INTERNAL_ASSERT(grouped_grop->writePredicate()->hasValue());
+      NVF_ERROR(grouped_grop->writePredicate()->hasValue());
       func_args.arg(genInline(grouped_grop->writePredicate()));
     } else {
       func_args.arg(read_pred);
@@ -1854,7 +1843,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       }
       return;
     } else {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           false, "Non-allreduce grouped grid welford is not yet supported");
     }
   }
@@ -1915,7 +1904,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
     // Create maps from loop index Vals to integers
     for (const auto& index_values : index_val_sets) {
-      TORCH_INTERNAL_ASSERT(loop_indices.size() == index_values.size());
+      NVF_ERROR(loop_indices.size() == index_values.size());
       std::unordered_map<const Val*, int64_t> index_val_map;
       for (const auto i : c10::irange(loop_indices.size())) {
         auto loop_index = loop_indices.at(i);
@@ -1930,7 +1919,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
   void generateGroupedGridAllreduce(
       const kir::GroupedGridReduction* grouped_grop) {
-    TORCH_INTERNAL_ASSERT(grouped_grop->isAllreduce());
+    NVF_ERROR(grouped_grop->isAllreduce());
 
     // There are two dimensions of grouping: horizontal grouping and
     // iteration grouping. The total number of individual reductions
@@ -1952,7 +1941,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
     // This is also checked at the lowering validaiton time, so it
     // isn't strictly necessary.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         num_grouped_iterations * grouped_grop->numHorizontallyGroupedExprs() <=
             kMaxNumGroupedReductions,
         "Too many grouped reductions: ",
@@ -1978,10 +1967,10 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     for (const auto expr_index :
          c10::irange(grouped_grop->numHorizontallyGroupedExprs())) {
       const auto data_type = grouped_grop->outputs().at(expr_index)->dtype();
-      TORCH_INTERNAL_ASSERT(grouped_grop->reduction_buffers()
-                                .at(expr_index)
-                                ->buffer()
-                                ->isA<TensorView>());
+      NVF_ERROR(grouped_grop->reduction_buffers()
+                    .at(expr_index)
+                    ->buffer()
+                    ->isA<TensorView>());
 
       for (const auto& group_index :
            c10::irange(index_replacement_maps.size())) {
@@ -2030,13 +2019,13 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         bool_types.arg("bool");
         // Same argument for all inputs. Different predicates would be
         // used when grouping is done across iterations
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             grouped_grop->predicate() != nullptr &&
             grouped_grop->predicate()->hasValue());
         const auto read_pred = genInline(grouped_grop->predicate());
         read_preds.arg(read_pred);
         if (grouped_grop->writePredicate() != nullptr) {
-          TORCH_INTERNAL_ASSERT(grouped_grop->writePredicate()->hasValue());
+          NVF_ERROR(grouped_grop->writePredicate()->hasValue());
           write_preds.arg(genInline(grouped_grop->writePredicate()));
         } else {
           write_preds.arg(read_pred);
@@ -2078,14 +2067,14 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   // Mostly the same as the grouped grid redution version
   void generateGroupedGridAllreduceWelford(
       const kir::GroupedGridWelford* grouped_gwop) {
-    TORCH_INTERNAL_ASSERT(grouped_gwop->isAllreduce());
+    NVF_ERROR(grouped_gwop->isAllreduce());
 
     const auto index_replacement_maps = getLoopIndexReplacementMaps();
     const auto num_grouped_iterations = index_replacement_maps.size();
 
     // This is also checked at the lowering validaiton time, so it
     // isn't strictly necessary.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         num_grouped_iterations * grouped_gwop->numHorizontallyGroupedExprs() <=
             kMaxNumGroupedReductions,
         "Too many grouped reductions: ",
@@ -2157,14 +2146,14 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         bool_types.arg("bool");
         // Same argument for all inputs. Different predicates would be
         // used when grouping is done across iterations
-        TORCH_INTERNAL_ASSERT(grouped_gwop->predicate() != nullptr);
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(grouped_gwop->predicate() != nullptr);
+        NVF_ERROR(
             grouped_gwop->predicate() != nullptr &&
             grouped_gwop->predicate()->hasValue());
         const auto read_pred = genInline(grouped_gwop->predicate());
         read_preds.arg(read_pred);
         if (grouped_gwop->writePredicate() != nullptr) {
-          TORCH_INTERNAL_ASSERT(grouped_gwop->writePredicate()->hasValue());
+          NVF_ERROR(grouped_gwop->writePredicate()->hasValue());
           write_preds.arg(genInline(grouped_gwop->writePredicate()));
         } else {
           write_preds.arg(read_pred);
@@ -2232,14 +2221,14 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
   void generateGroupedGridAllreduceWelfordOuter(
       const kir::GroupedGridWelford* grouped_gwop) {
-    TORCH_INTERNAL_ASSERT(grouped_gwop->isAllreduce());
+    NVF_ERROR(grouped_gwop->isAllreduce());
 
     const auto num_grouped_iterations =
         getGroupedLoopIndexConcreteIntSets().size();
 
     // This is also checked at the lowering validaiton time, so it
     // isn't strictly necessary.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         num_grouped_iterations * grouped_gwop->numHorizontallyGroupedExprs() <=
             kMaxNumGroupedReductions,
         "Too many grouped reductions: ",
@@ -2248,7 +2237,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         kMaxNumGroupedReductions,
         " reductions are allowed.");
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         grouped_gwop->numHorizontallyGroupedExprs() == 1,
         "Horizontal grouped Welford reduciton is not yet supported: ",
         grouped_gwop->toString());
@@ -2308,8 +2297,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_template_args.arg(data_type);
 
     const auto& par_dim_map = kernel_->summary().parallel_dimension_map_;
-    TORCH_INTERNAL_ASSERT(par_dim_map.get(ParallelType::TIDx)->isConstInt());
-    TORCH_INTERNAL_ASSERT(par_dim_map.get(ParallelType::TIDy)->isConstInt());
+    NVF_ERROR(par_dim_map.get(ParallelType::TIDx)->isConstInt());
+    NVF_ERROR(par_dim_map.get(ParallelType::TIDy)->isConstInt());
     func_template_args.arg(genInline(par_dim_map.get(ParallelType::TIDx)));
     func_template_args.arg(genInline(par_dim_map.get(ParallelType::TIDy)));
 
@@ -2323,18 +2312,17 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
   void handle(const kir::GridBroadcast* grop) final {
     const auto bop = grop->broadcast_op();
-    TORCH_INTERNAL_ASSERT(bop->out()->isA<kir::TensorIndex>());
+    NVF_ERROR(bop->out()->isA<kir::TensorIndex>());
 
     const ParallelTypeBitmap parallel_types =
         kernel_->summary().broadcast_parallel_types.at(bop);
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         parallel_types.hasBID(),
         "GridBroadcast needs to be used with a broadcast op that is parallelized with the BID parallel types");
 
-    TORCH_INTERNAL_ASSERT(
-        grop->broadcast_buffer()->buffer()->isA<TensorView>());
-    TORCH_INTERNAL_ASSERT(grop->sync_buffer()->buffer()->isA<TensorView>());
+    NVF_ERROR(grop->broadcast_buffer()->buffer()->isA<TensorView>());
+    NVF_ERROR(grop->sync_buffer()->buffer()->isA<TensorView>());
     const auto work_buffer =
         grop->broadcast_buffer()->buffer()->as<TensorView>();
     const auto sync_buffer = grop->sync_buffer()->buffer()->as<TensorView>();
@@ -2353,8 +2341,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_args.arg(gen(bop->in()));
     func_args.arg("&").append(genVariableName(work_buffer)).append("[0]");
     func_args.arg(genVariableName(sync_buffer));
-    TORCH_INTERNAL_ASSERT(
-        grop->predicate() != nullptr && grop->predicate()->hasValue());
+    NVF_ERROR(grop->predicate() != nullptr && grop->predicate()->hasValue());
     func_args.arg(genInline(grop->predicate()));
 
     indent() << genCall("grid_broadcast::broadcast", template_args, func_args)
@@ -2363,17 +2350,17 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
   void handle(const kir::GridWelford* gwop) final {
     const auto wop = gwop->welford_op();
-    TORCH_INTERNAL_ASSERT(wop->outAvg()->isA<kir::TensorIndex>());
+    NVF_ERROR(wop->outAvg()->isA<kir::TensorIndex>());
 
     const auto out = wop->out()->as<kir::TensorIndex>();
     const auto domain = out->view()->domain();
-    TORCH_INTERNAL_ASSERT(domain->hasGridReduction());
+    NVF_ERROR(domain->hasGridReduction());
 
     const auto data_type = out->dtype();
     const auto index_type = wop->outN()->dtype();
 
-    TORCH_INTERNAL_ASSERT(gwop->var_buffer()->buffer()->isA<TensorView>());
-    TORCH_INTERNAL_ASSERT(gwop->sync_buffer()->buffer()->isA<TensorView>());
+    NVF_ERROR(gwop->var_buffer()->buffer()->isA<TensorView>());
+    NVF_ERROR(gwop->sync_buffer()->buffer()->isA<TensorView>());
 
     const auto avg_buffer = gwop->avg_buffer()->buffer()->as<TensorView>();
     const auto var_buffer = gwop->var_buffer()->buffer()->as<TensorView>();
@@ -2407,7 +2394,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       block_reduce_name_++;
     } else {
       func_args.arg(gen(wop->inAvg()));
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           wop->inVar() != nullptr, "Welford var input nullptr not allowed");
       func_args.arg(genStaticCast(data_type, gen(wop->inVar())));
       func_args.arg(genStaticCast(index_type, gen(wop->inN())));
@@ -2419,12 +2406,11 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_args.arg(genReinterpretCast(genPtrType(data_type), "shared_mem_avg"));
     func_args.arg(genReinterpretCast(genPtrType(data_type), "shared_mem_var"));
     func_args.arg(genReinterpretCast(genPtrType(index_type), "shared_mem_n"));
-    TORCH_INTERNAL_ASSERT(
-        gwop->predicate() != nullptr && gwop->predicate()->hasValue());
+    NVF_ERROR(gwop->predicate() != nullptr && gwop->predicate()->hasValue());
     auto read_pred = genInline(gwop->predicate());
     func_args.arg(read_pred);
     if (gwop->writePredicate() != nullptr) {
-      TORCH_INTERNAL_ASSERT(gwop->writePredicate()->hasValue());
+      NVF_ERROR(gwop->writePredicate()->hasValue());
       auto write_pred = genInline(gwop->writePredicate());
       func_args.arg(write_pred);
     } else {
@@ -2441,13 +2427,13 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
   void generateGridAllreduce(const kir::GridWelford* gwop) {
     const auto wop = gwop->welford_op();
-    TORCH_INTERNAL_ASSERT(wop->isAllreduce());
+    NVF_ERROR(wop->isAllreduce());
 
     const auto out = wop->out()->as<kir::TensorIndex>();
 
     const auto data_type = wop->outAvg()->dtype();
     const auto index_type = wop->outN()->dtype();
-    TORCH_INTERNAL_ASSERT(wop->outAvg()->dtype() == wop->outVar()->dtype());
+    NVF_ERROR(wop->outAvg()->dtype() == wop->outVar()->dtype());
 
     ArgumentBuilder data_type_args;
     data_type_args.arg(data_type).arg(data_type).arg(index_type);
@@ -2523,12 +2509,11 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     // shared_buf
     func_args.arg(genCall("PtrTuple", data_type_args, smem_buffer_args));
     // read and write predicates
-    TORCH_INTERNAL_ASSERT(
-        gwop->predicate() != nullptr && gwop->predicate()->hasValue());
+    NVF_ERROR(gwop->predicate() != nullptr && gwop->predicate()->hasValue());
     const auto read_pred = genInline(gwop->predicate());
     auto write_pred = read_pred;
     if (gwop->writePredicate() != nullptr) {
-      TORCH_INTERNAL_ASSERT(gwop->writePredicate()->hasValue());
+      NVF_ERROR(gwop->writePredicate()->hasValue());
       write_pred = genInline(gwop->writePredicate());
     }
     func_args.arg(read_pred).arg(write_pred);
@@ -2579,7 +2564,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
     for (const auto predicated_pt : alloc_fused_reduction->threadPredicate()) {
       auto& state = states[predicated_pt];
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           state != ReductionParallelTypeState::Reduce,
           "Invalid thread predication: ",
           predicated_pt);
@@ -2617,7 +2602,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   void handle(const GroupedReductionOp* grouped_rop) final {
     for (const auto i :
          c10::irange(grouped_rop->numHorizontallyGroupedExprs())) {
-      TORCH_INTERNAL_ASSERT(grouped_rop->output(i)->isA<kir::TensorIndex>());
+      NVF_ERROR(grouped_rop->output(i)->isA<kir::TensorIndex>());
 
       const auto output = grouped_rop->output(i)->as<kir::TensorIndex>();
       const auto input = grouped_rop->input(i)->as<kir::TensorIndex>();
@@ -2627,7 +2612,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       const bool has_block_reduce = domain->hasBlockReduction();
       const bool has_grid_reduce = domain->hasGridReduction();
 
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !has_grid_reduce,
           "GroupedReductionOp does not support block parallelization. GroupedGridReduction must be used. ",
           grouped_rop->toString());
@@ -2656,7 +2641,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const GroupedWelfordOp* grouped_wop) final {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         false,
         "Should not reach here as grouped welford is only enabled for grid welford,",
         " which is handled by its own handler");
@@ -2748,7 +2733,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   void handle(const kir::Allocate* alloc) final {
     const auto buffer_dtype = alloc->buffer()->dtype();
 
-    TORCH_INTERNAL_ASSERT(alloc->buffer() != nullptr);
+    NVF_ERROR(alloc->buffer() != nullptr);
     alloc_map_.emplace(alloc->buffer(), alloc);
 
     if (!alloc->buffer()->isA<TensorView>()) {
@@ -2759,7 +2744,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     const auto tv = alloc->buffer()->as<TensorView>();
 
     const auto size = alloc->size();
-    TORCH_INTERNAL_ASSERT(size != nullptr);
+    NVF_ERROR(size != nullptr);
 
     if (alloc->alias() != nullptr) {
       // Allocate alias another Allocate stmt
@@ -2785,7 +2770,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           break;
         case MemoryType::Shared:
           // Assume we have already aligned offsets to 16B
-          TORCH_CHECK(
+          NVF_CHECK(
               alloc->address() != nullptr,
               "Allocation did not receive an address: ",
               alloc->toString());
@@ -2807,7 +2792,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           }
         } break;
         default:
-          TORCH_INTERNAL_ASSERT(false, "Unexpected memory type");
+          NVF_ERROR(false, "Unexpected memory type");
       }
     }
   }

--- a/csrc/codegen.h
+++ b/csrc/codegen.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 #include <kernel.h>
 
 #include <string>

--- a/csrc/compute_at.cpp
+++ b/csrc/compute_at.cpp
@@ -76,7 +76,7 @@ std::deque<std::deque<TensorView*>> tvChains(
 std::unordered_set<TensorView*> getAllTVsBetween(
     TensorView* producer,
     TensorView* consumer) {
-  TORCH_CHECK(
+  NVF_CHECK(
       DependencyCheck::isDependencyOf(producer, consumer),
       "Compute At expects ",
       producer->name(),
@@ -114,7 +114,7 @@ TensorView* getCommonConsumer(TensorView* producer, TensorView* consumer) {
 
   // Right now we only support compute at if at some point in the graph consumer
   // is dependent on producer.
-  TORCH_CHECK(
+  NVF_CHECK(
       !all_chains.empty(),
       "Compute At expects ",
       producer->name(),
@@ -140,7 +140,7 @@ TensorView* getCommonConsumer(TensorView* producer, TensorView* consumer) {
         break;
       }
     }
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         common_consumer != nullptr,
         "Hit a logical inconsistency in the computeAt pass.");
   }
@@ -168,7 +168,7 @@ std::unordered_set<TensorView*> pullInSiblings(
 std::unordered_set<TensorView*> getPropagationSubgraph(
     TensorView* producer,
     TensorView* consumer) {
-  TORCH_CHECK(
+  NVF_CHECK(
       DependencyCheck::isDependencyOf(producer, consumer),
       "Compute At expects ",
       producer->name(),
@@ -204,7 +204,7 @@ void ComputeAt::runAt(
   FUSER_PERF_SCOPE("ComputeAt::runAt");
 
   // Make sure the correct fusion is setup between this and consumer.
-  TORCH_CHECK(
+  NVF_CHECK(
       producer->fusion() == consumer->fusion(),
       producer,
       " and ",

--- a/csrc/compute_at.h
+++ b/csrc/compute_at.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <inlining.h>
 #include <root_domain_map.h>
 #include <transform_replay.h>

--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -46,7 +46,7 @@ IterDomainGraph::IterDomainGraph(Fusion* fusion, bool allow_self_mapping) {
   build(fusion);
 
   if (!allow_self_mapping) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !hasSelfMapping(),
         "Unsupported domain mapping detected in ",
         std::get<0>(*self_mapping_info_)->toString(),
@@ -98,7 +98,7 @@ bool IterDomainGraph::exprsMap(
     return false;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       first->isA<Merge>() || first->isA<Split>() || first->isA<Resize>(),
       "Merge, split and resize are the only expressions supported through rfactor operations in compute at map, but found:\n",
       first->toString());
@@ -111,7 +111,7 @@ bool IterDomainGraph::exprsMap(
                         forward ? second->inputs() : second->outputs())
                         .vector();
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       first_ids.size() == second_ids.size(),
       "Expected number of ",
       (forward ? "inputs" : "outputs"),
@@ -211,7 +211,7 @@ void IterDomainGraph::mapThroughExpr(Expr* first, Expr* second, bool forward) {
   auto second_ids = ir_utils::filterByType<IterDomain>(
                         forward ? second->outputs() : second->inputs())
                         .vector();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       first_ids.size() == second_ids.size(),
       "This should be unreachable, if transformation expressions match, their number of inputs and outputs should as well.\n However found:\n",
       first->toString(),
@@ -279,7 +279,7 @@ std::optional<std::pair<IterDomain*, IterDomain*>> detectMappablePair(
           return std::make_pair(id1, id2);
         }
       } else {
-        TORCH_INTERNAL_ASSERT(false, "Unrecognized IdMappingMode mode.");
+        NVF_ERROR(false, "Unrecognized IdMappingMode mode.");
       }
     }
   }
@@ -385,7 +385,7 @@ void IterDomainGraph::build(Fusion* fusion) {
         // case of mapping multiple outputs since they do share the
         // same loops.
 
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             c_tv->getRootDomain().size() ==
                 first_output_tv->getRootDomain().size(),
             "Multiple outputs with mismatched dimensions is not supported. ",
@@ -611,13 +611,13 @@ void IterDomainGraph::build(Fusion* fusion) {
          consumer_tv->getMaybeRFactorDomain().end()});
     for (auto expr : exprs) {
       auto rfactor_inp_ids = ir_utils::filterByType<IterDomain>(expr->inputs());
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           expr->isA<Split>() || expr->isA<Merge>() || expr->isA<Resize>(),
           "Wasn't expecting the expression type of:\n",
           expr->toString(),
           "\nto be an expression defined in an rfactor transformation.");
       for (auto rfactor_inp_id : rfactor_inp_ids) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             rfactor_id_uses.find(rfactor_inp_id) == rfactor_id_uses.end(),
             "Was expecting iter domains to only have one active transformation but found id ",
             rfactor_inp_id->toString(),
@@ -784,7 +784,7 @@ void ComputeAtMap::validateAndPropagatePType() {
     ParallelType common_ptype = ParallelType::Serial;
     for (auto id : loop_disjoint_set->vector()) {
       auto id_ptype = id->getParallelType();
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           id_ptype == common_ptype || id_ptype == ParallelType::Serial ||
               common_ptype == ParallelType::Serial,
           "Issue validating parallel type disjoint ptype is, ",
@@ -841,7 +841,7 @@ void ComputeAtMap::allocateIndexVariables() {
 
     // Allocate variable for the iterdomains:
     auto concrete_loop_id_it = concrete_id_cache_.find(loop_disjoint_set);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         concrete_loop_id_it != concrete_id_cache_.end(),
         "Concrete id not computed");
 
@@ -871,7 +871,7 @@ void ComputeAtMap::allocateIndexVariables() {
 Val* ComputeAtMap::getIndexVariable(
     IterDomain* id,
     DoubleBufferLoopStage double_buffer_loop_stage) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       id_graph_.loopNodes().mappingExists(id),
       "Index Variable: no index variable allocated as ",
       id->toString(),
@@ -911,7 +911,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
     IdMappingMode mode) {
   const auto& disjoint_set_shared_ptr = disjointSetOf(id, mode);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !disjoint_set_shared_ptr->vector().empty(),
       "Empty disjoint set found for ",
       id->toString());
@@ -940,7 +940,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
 
   // Shouldn't ever happen, it would mean there's an error somewhere in the
   // graph.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !maybe_concrete_ids.vector().empty(),
       "No potential concrete_id's found for ",
       id->toString());
@@ -994,7 +994,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
         resolved_broadcasts;
 
     for (const auto& exact_set : all_exact_sets_covered) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !exact_set->vector().empty(),
           "Cannot compute concrete id of empty set.");
       auto c_id = getConcreteMappedID(
@@ -1099,7 +1099,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !maybe_concrete_ids.vector().empty(),
       "No potential concrete_id's found for disjoint set ",
       disjoint_set_shared_ptr->toString());
@@ -1137,7 +1137,7 @@ IterDomain* ComputeAtMap::computeConcreteId(
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       concrete_id != nullptr,
       "No concrete_id found for disjoint set ",
       disjoint_set_shared_ptr->toString());
@@ -1152,7 +1152,7 @@ void ComputeAtMap::buildConcreteIds() {
   // generating the set (compute at map build).
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.exactNodes().disjointSets()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
@@ -1163,7 +1163,7 @@ void ComputeAtMap::buildConcreteIds() {
   // efficient way to compute concrete IDs.
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.permissiveNodes().disjointSets()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
@@ -1174,7 +1174,7 @@ void ComputeAtMap::buildConcreteIds() {
   // Same as exact computation
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.almostExactNodes().disjointSets()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
@@ -1184,7 +1184,7 @@ void ComputeAtMap::buildConcreteIds() {
 
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.loopNodes().disjointSets()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
@@ -1194,7 +1194,7 @@ void ComputeAtMap::buildConcreteIds() {
 
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.permissiveResizeNodes().disjointSets()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();
@@ -1218,7 +1218,7 @@ bool ComputeAtMap::areExactExprs(Expr* expr_1, Expr* expr_2) {
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       expr_1->inputs().size() == expr_2->inputs().size() &&
           expr_1->outputs().size() == expr_2->outputs().size(),
       "Expr traversal doesn't support variable number of inputs and outputs.");
@@ -1351,14 +1351,14 @@ IterDomain* ComputeAtMap::getConcreteMappedID(
     IdMappingMode mode) const {
   auto disjoint_set_shared_ptr = disjointSetOf(id, mode);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !disjoint_set_shared_ptr->vector().empty(),
       "Empty disjoint set found for ",
       id->toString());
 
   auto cache_it = concrete_id_cache_.find(disjoint_set_shared_ptr);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       cache_it != concrete_id_cache_.end(),
       "Could not find concrete id for: ",
       id->toString(),
@@ -1469,7 +1469,7 @@ std::vector<IterDomain*> ComputeAtMap::getRfactorDomainsOfIdGroup(
 
 const std::shared_ptr<VectorOfUniqueEntries<IterDomain*>>& ComputeAtMap::
     disjointSetOf(IterDomain* id, IdMappingMode mode) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       idExistsInMap(id),
       id->toString(),
       " has not been processed in this Compute At Map, yet the disjoint set for it was requested.");
@@ -1492,7 +1492,7 @@ const DisjointSets<IterDomain*>& ComputeAtMap::getIdSets(
     case IdMappingMode::INNERMOST:
       return id_graph_.innermostNodes();
   }
-  TORCH_INTERNAL_ASSERT(false, "Error with mapping mode provided.");
+  NVF_ERROR(false, "Error with mapping mode provided.");
 }
 
 bool ComputeAtMap::idExistsInMap(IterDomain* id) const {
@@ -1518,7 +1518,7 @@ ComputeAtMap::getInputDisjointSetsOf(IterDomain* of_id, bool stop_at_rfactor) {
       continue;
     }
     auto defs_it = unique_exact_definitions_.find(currently_visiting);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         defs_it != unique_exact_definitions_.end(),
         "unique_exact_definitions_ wasn't correctly generated, missing the disjoint set:\n",
         currently_visiting->toString());
@@ -1581,7 +1581,7 @@ ComputeAtMap::getAllDisjointSetProducers(
       continue;
     }
     auto defs_it = unique_exact_definitions_.find(currently_visiting);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         defs_it != unique_exact_definitions_.end(),
         "unique_exact_definitions_ wasn't correctly generated, missing the disjoint set:\n",
         currently_visiting->toString());
@@ -1629,7 +1629,7 @@ ComputeAtMap::getAllDisjointSetConsumers(
       continue;
     }
     auto uses_it = unique_exact_uses_.find(currently_visiting);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         uses_it != unique_exact_uses_.end(),
         "unique_exact_uses_ wasn't correctly generated, missing the disjoint set:\n",
         currently_visiting->toString());
@@ -1659,7 +1659,7 @@ ComputeAtMap::getAllDisjointSetConsumers(
 }
 
 void IterDomainGraph::updateComputeWith(TensorView* compute_with_tv) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       compute_with_tv->hasResolvedComputeWith(),
       "Invalid tensor: ",
       compute_with_tv->toString());
@@ -1679,7 +1679,7 @@ void IterDomainGraph::updateComputeWith(TensorView* compute_with_tv) {
         [&](auto consumer_id) {
           return permissiveNodes().disjointSetMap().at(id)->has(consumer_id);
         });
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         it != consumer_tv->getLeafDomain().end(),
         "No consumer leaf ID of tensor ",
         consumer_tv->toString(),
@@ -1693,7 +1693,7 @@ void IterDomainGraph::updateComputeWith(TensorView* compute_with_tv) {
 }
 
 void ComputeAtMap::updateComputeWith(TensorView* compute_with_tv) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       compute_with_tv->hasResolvedComputeWith(),
       "Invalid tensor: ",
       compute_with_tv->toString());
@@ -1703,7 +1703,7 @@ void ComputeAtMap::updateComputeWith(TensorView* compute_with_tv) {
   // Update the LOOP concrete IDs
   for (const auto& disjoint_set_shared_ptr :
        id_graph_.loopNodes().disjointSets()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !disjoint_set_shared_ptr->vector().empty(),
         "Cannot compute concrete id of empty set.");
     auto first_id = disjoint_set_shared_ptr->vector().front();

--- a/csrc/compute_at_map.h
+++ b/csrc/compute_at_map.h
@@ -9,6 +9,7 @@
 
 #include <device_lower/analysis/trivial_broadcast.h>
 #include <disjoint_set.h>
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <kernel_ir.h>
 

--- a/csrc/contiguity.h
+++ b/csrc/contiguity.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <compute_at_map.h>
 #include <device_lower/analysis/shift.h>

--- a/csrc/cuda_utils.h
+++ b/csrc/cuda_utils.h
@@ -9,11 +9,12 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <exceptions.h>
 
 #define NVFUSER_NVRTC_SAFE_CALL(x)               \
   do {                                           \
     nvrtcResult _result = x;                     \
-    TORCH_INTERNAL_ASSERT(                       \
+    NVF_ERROR(                                   \
         _result == NVRTC_SUCCESS,                \
         "NVRTC error: " #x "failed with error ", \
         nvrtcGetErrorString(_result));           \
@@ -27,7 +28,7 @@
       const char* name;                \
       cuGetErrorName(_result, &name);  \
       cuGetErrorString(_result, &msg); \
-      TORCH_INTERNAL_ASSERT(           \
+      NVF_ERROR(                       \
           _result == CUDA_SUCCESS,     \
           "CUDA error: ",              \
           name,                        \
@@ -39,7 +40,7 @@
 #define NVFUSER_CUDA_RT_SAFE_CALL(x)  \
   do {                                \
     cudaError_t _result = x;          \
-    TORCH_INTERNAL_ASSERT(            \
+    NVF_ERROR(                        \
         _result == cudaSuccess,       \
         "CUDA error: ",               \
         cudaGetErrorName(_result),    \

--- a/csrc/device_lower/analysis/bank_conflict.cpp
+++ b/csrc/device_lower/analysis/bank_conflict.cpp
@@ -32,7 +32,7 @@ int64_t getVectorizeSize(kir::TensorIndex* ti) {
       continue;
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         id->extent()->isConstInt(),
         "Could not evaluate constant value bound to vectorized dim.");
 
@@ -83,7 +83,7 @@ int64_t getLdMatrixNumThreads(int64_t word_size) {
       // and all the 32 threads contain useful addresses.
       return 32;
     default:
-      TORCH_INTERNAL_ASSERT(false, "Invalid word size for ldmatrix");
+      NVF_ERROR(false, "Invalid word size for ldmatrix");
   }
 }
 
@@ -141,8 +141,7 @@ std::vector<int64_t> evaluateAddressesOnFirstPhase(
     for (auto fl : for_loops) {
       if (fl->index()->isA<NamedScalar>()) {
         auto ns = fl->index()->as<NamedScalar>();
-        TORCH_INTERNAL_ASSERT(
-            ns->isThreadIdx() || ns->isBlockIdx(), "unknow loop index");
+        NVF_ERROR(ns->isThreadIdx() || ns->isBlockIdx(), "unknow loop index");
       } else {
         auto start = expr_eval.evaluate(fl->start()).as<int64_t>();
         expr_eval.bind(fl->index(), start);
@@ -273,16 +272,16 @@ std::unordered_map<const Expr*, std::pair<int, int>> getBankConflictInfo(
     const std::unordered_map<Val*, PolymorphicValue>& known_values) {
   for (const auto& pair : known_values) {
     if (auto ns = dynamic_cast<NamedScalar*>(pair.first)) {
-      TORCH_CHECK(
+      NVF_CHECK(
           !ns->isThreadIdx(),
           "threadIdx.{x,y,z} should be computed instead of provided");
-      TORCH_CHECK(
+      NVF_CHECK(
           !ns->isBlockIdx(),
           "blockIdx.{x,y,z} should not be provided (they are always zero)");
-      TORCH_CHECK(
+      NVF_CHECK(
           !ns->isBlockDim(),
           "blockDim.{x,y,z} should be provided by launch_params");
-      TORCH_CHECK(
+      NVF_CHECK(
           !ns->isGridDim(),
           "gridDim.{x,y,z} should be provided by launch_params");
     }

--- a/csrc/device_lower/analysis/bank_conflict.h
+++ b/csrc/device_lower/analysis/bank_conflict.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <executor_params.h>
 #include <ir/base_nodes.h>
 #include <kernel.h>

--- a/csrc/device_lower/analysis/fused_reduction.h
+++ b/csrc/device_lower/analysis/fused_reduction.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 
 namespace nvfuser {

--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -70,7 +70,7 @@ std::unordered_map<IterDomain*, IterDomain*> invertOneToOneMap(
   std::unordered_map<IterDomain*, IterDomain*> inverted;
   for (const auto& kv : map) {
     bool inserted = inverted.emplace(kv.second, kv.first).second;
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         inserted,
         "Multiple mappings to the same value detected: ",
         kv.second->toString());
@@ -218,7 +218,7 @@ IndexingParameters getNonGlobalInitialIndexParameters(
 
   ensureStaticIndexing(alloc_tv, alloc_info.init_for_loop, loops, alloc_id_map);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       loops.size() <= loop_domains.size(),
       "Loop domain didn't replay all loops");
 
@@ -350,7 +350,7 @@ IndexingParameters getPredicateInitialIndexParameters(
   const auto& loop_domains = loop_indexing.loopDomains();
 
   // This shouldn't be needed.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       loops.size() <= loop_domains.size(),
       "Loop domain didn't replay all loops");
 
@@ -475,7 +475,7 @@ IndexingParameters getPredicateInitialIndexParameters(
         double_buffer_axis, loops, true);
     if (db_loop != nullptr) {
       auto loop_to_ind_map_it = loop_to_ind_map.find(db_loop);
-      TORCH_INTERNAL_ASSERT(loop_to_ind_map_it != loop_to_ind_map.end());
+      NVF_ERROR(loop_to_ind_map_it != loop_to_ind_map.end());
       auto cur_index = loop_to_ind_map_it->second;
       // if cur_index is not the same as the index of db_loop, it must
       // be true that that index has been modified to support
@@ -565,7 +565,7 @@ LoopIndexingAnalysis::LoopIndexingAnalysis(
       std::back_inserter(initial_loop_domain_ids_),
       [&](IterDomain* consumer_leaf_id) {
         // Make sure consumer_leaf_id is indeed a consumer leaf ID
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             std::find(
                 consumer_tv->getLeafDomain().begin(),
                 consumer_tv->getLeafDomain().end(),
@@ -635,7 +635,7 @@ void LoopIndexingAnalysis::validateLoopStructure(
     auto concrete_loop_id = GpuLower::current()->caMap()->getConcreteMappedID(
         loop_id, IdMappingMode::EXACT);
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !concrete_to_loop.count(concrete_loop_id),
         "Unsupported loop structure. Two loops are mapped together.",
         loop_id->toString(),
@@ -793,7 +793,7 @@ void LoopIndexingAnalysis::constructLoopDomains() {
                   concrete_id, loop_id, IdMappingMode::PERMISSIVE);
         });
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         ref_id_it != replayed_concrete_ids_.vector().end(),
         "Could not find required iter domain in reference replay: ",
         loop_id->toString());
@@ -1155,7 +1155,7 @@ LoopIndexingTraversal::LoopIndexingTraversal(
     for (auto id : next_ids) {
       auto concrete_id = GpuLower::current()->caMap()->getConcreteMappedID(
           id, IdMappingMode::EXACT);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           concrete_id_to_dependency_.insert(std::make_pair(concrete_id, expr))
               .second,
           "Repeated dependency, invalid iterdomain traversal.");
@@ -1174,7 +1174,7 @@ const std::vector<Val*>& LoopIndexingTraversal::nextValsInTraversalOrder(
       break;
 
     default:
-      TORCH_INTERNAL_ASSERT(false, "unimplemented traversal order");
+      NVF_ERROR(false, "unimplemented traversal order");
   }
   return expr->inputs();
 }
@@ -1190,7 +1190,7 @@ const std::vector<Val*>& LoopIndexingTraversal::prevValsInTraversalOrder(
       break;
 
     default:
-      TORCH_INTERNAL_ASSERT(false, "unimplemented traversal order");
+      NVF_ERROR(false, "unimplemented traversal order");
   }
   return expr->inputs();
 }
@@ -1229,7 +1229,7 @@ std::vector<Expr*> LoopIndexingTraversal::getExprList() {
         if (!visited.count(prev_expr)) {
           ready = false;
           to_visit.push_front(prev_expr);
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               inserted.insert(prev_expr).second,
               "Circular dependency in loop index expressions.");
           break;
@@ -1343,7 +1343,7 @@ bool isPermissivelyMappedWithAny(IterDomain* id, const std::vector<Val*>& ids) {
     if (auto id_resize = dynamic_cast<Resize*>(id->uses().at(0))) {
       auto mapped_id_resize =
           dynamic_cast<Resize*>(val->as<IterDomain>()->uses().at(0));
-      TORCH_INTERNAL_ASSERT(mapped_id_resize != nullptr);
+      NVF_ERROR(mapped_id_resize != nullptr);
       if (!(id_resize->leftExpand()->sameAs(mapped_id_resize->leftExpand()) &&
             id_resize->rightExpand()->sameAs(
                 mapped_id_resize->rightExpand()))) {

--- a/csrc/device_lower/analysis/index_compute.h
+++ b/csrc/device_lower/analysis/index_compute.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <fusion.h>
 #include <index_compute.h>
 

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -27,11 +27,11 @@ namespace {
 //   predicating these ops will require extra steps to ensure that
 //   the whole warp will get the same value.
 void assertOnWarpOps(const Expr* expr) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !ir_utils::isLdMatrixOp(expr),
       "Predicate elimination: cannot eliminate pred for ldmatrix, use exact parallel dims. ",
       expr->toString());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !expr->isA<MmaOp>(),
       "Mma op: cannot eliminate predicate for mma op, tiling not valid. ",
       expr->toString());
@@ -110,7 +110,7 @@ class PredicateAnalyzer : public OptOutDispatch {
 
   void handle(IterDomain* consumer_id) override {
     // The traversal should have ended if needs_predicate_ was true
-    TORCH_INTERNAL_ASSERT(!needs_predicate_);
+    NVF_ERROR(!needs_predicate_);
 
     // If consumer_id is not going to be materialized as a loop (e.g.,
     // broadcast), no need to predicate
@@ -229,7 +229,7 @@ class PredicateChcker : public IterVisitor {
     //  logic. But this part along with [Predicate Inversion for CpAsync]
     //  should be cleaned up all together when we extend predicate/masking
     //  logic to cover this usage.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !(ir_utils::isCpAsyncOp(expr) && needs_predicate_smem_access),
         "predicate removal: unsupported use case of cp.async");
 
@@ -265,7 +265,7 @@ class PredicateChcker : public IterVisitor {
       return false;
     }
     auto tv_inputs = ir_utils::getTvs(expr->inputs());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !tv_inputs.empty(),
         "Should never have a reduction op without a tensor view input.");
     bool found_expand = false;
@@ -285,7 +285,7 @@ class PredicateChcker : public IterVisitor {
       tv_outputs = std::vector<TensorView*>(tv_inputs.size(), tv_outputs[0]);
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         tv_outputs.size() == tv_inputs.size(),
         "Was expecting matching number of inputs and outputs for expression: ",
         expr->toString());
@@ -456,7 +456,7 @@ class PredicateChcker : public IterVisitor {
   // For details on zero loops, see indexMapFromTV in
   //  lower index pass.
   std::vector<Val*> getZeroLeafIds(const TensorView* tv) const {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         tv->getMemoryType() == MemoryType::Local ||
             tv->getMemoryType() == MemoryType::Shared,
         "Local or shared memory tensor is assumed: ",
@@ -585,7 +585,7 @@ class PredicateChcker : public IterVisitor {
     // so that must be allocated on global memory. Since we don't omit
     // predication for expressions involving global memory, this
     // should never occur.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         input_def != nullptr, "Inconsistent input found: ", input->toString());
 
     // The input needs to be initialized to the init value to omit
@@ -637,7 +637,7 @@ class PredicateChcker : public IterVisitor {
       }
 
       auto input_tv = dynamic_cast<TensorView*>(input);
-      TORCH_INTERNAL_ASSERT(input_tv != nullptr);
+      NVF_ERROR(input_tv != nullptr);
 
       auto input_def = input->definition();
 
@@ -645,7 +645,7 @@ class PredicateChcker : public IterVisitor {
       // so that must be allocated on global memory. Since we don't omit
       // predication for expressions involving global memory, this
       // should never occur.
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           input_def != nullptr,
           "Inconsistent input found: ",
           input->toString());
@@ -681,7 +681,7 @@ class PredicateChcker : public IterVisitor {
       // so that must be allocated on global memory. Since we don't omit
       // predication for expressions involving global memory, this
       // should never occur.
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           input_def != nullptr,
           "Inconsistent input found: ",
           input->toString());
@@ -753,7 +753,7 @@ class PredicateChcker : public IterVisitor {
         }
 
         auto input_tv = dynamic_cast<TensorView*>(input);
-        TORCH_INTERNAL_ASSERT(input_tv != nullptr);
+        NVF_ERROR(input_tv != nullptr);
 
         auto input_def = input->definition();
 
@@ -761,7 +761,7 @@ class PredicateChcker : public IterVisitor {
         // so that must be allocated on global memory. Since we don't omit
         // predication for expressions involving global memory, this
         // should never occur.
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             input_def != nullptr,
             "Inconsistent input found: ",
             input->toString());
@@ -796,7 +796,7 @@ class PredicateChcker : public IterVisitor {
   void handle(MmaOp* mma) final {
     for (auto input : ir_utils::filterByType<TensorView>(mma->inputs())) {
       auto input_def = input->definition();
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           input_def != nullptr,
           "Inconsistent input found: ",
           input->toString());
@@ -886,7 +886,7 @@ void PredicateElimination::dispatch(Expr* expr) {
     // so that must be allocated on global memory. Since we don't omit
     // predication for expressions involving global memory, this
     // should never occur.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         input_def != nullptr, "Inconsistent input found: ", input->toString());
 
     // If input is an output of reduction, it should be fully
@@ -934,7 +934,7 @@ bool PredicateElimination::setDefaultInitValue(TensorView* tv) {
 bool PredicateElimination::setReductionInitValue(
     TensorView* tv,
     Val* reduction_init) {
-  TORCH_INTERNAL_ASSERT(tv != nullptr);
+  NVF_ERROR(tv != nullptr);
 
   auto it = init_value_map_.find(tv);
   if (it == init_value_map_.end()) {
@@ -952,7 +952,7 @@ bool PredicateElimination::setReductionInitValue(
   } else if (existing_val->sameAs(reduction_init)) {
     return true;
   } else {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         false,
         "Inconsistent setting of initialization value for t",
         tv->name(),
@@ -972,9 +972,9 @@ bool PredicateElimination::canOmitPredicate(const Expr* expr) const {
     return false;
   }
 
-  TORCH_INTERNAL_ASSERT(expr != nullptr);
+  NVF_ERROR(expr != nullptr);
   const auto out_tv = ir_utils::getTvOutput(expr);
-  TORCH_INTERNAL_ASSERT(out_tv != nullptr, "Not a tensor expression");
+  NVF_ERROR(out_tv != nullptr, "Not a tensor expression");
 
   if (ir_utils::isTensorScalarFillOp(expr)) {
     if (out_tv->getMemoryType() == MemoryType::Local) {
@@ -1028,7 +1028,7 @@ std::string PredicateElimination::toString() const {
   ss << "Tensors that do not need predication:";
   for (auto expr : non_predicated_exprs_) {
     for (auto out : expr->outputs()) {
-      TORCH_INTERNAL_ASSERT(out->isA<TensorView>());
+      NVF_ERROR(out->isA<TensorView>());
       ss << " T" << out->name();
     }
   }

--- a/csrc/device_lower/analysis/predicate_elimination.h
+++ b/csrc/device_lower/analysis/predicate_elimination.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/all_nodes.h>
 #include <kernel_ir.h>

--- a/csrc/device_lower/analysis/shift.cpp
+++ b/csrc/device_lower/analysis/shift.cpp
@@ -31,7 +31,7 @@ Expr* ShiftPredicateInserter::insert(
   const auto gpu_lower = GpuLower::current();
 
   TensorView* out_tv = ir_utils::getTvOutput(expr);
-  TORCH_INTERNAL_ASSERT(out_tv != nullptr, "Missing TensorView output");
+  NVF_ERROR(out_tv != nullptr, "Missing TensorView output");
 
   const bool needs_shift_predicate =
       gpu_lower->haloInfo()->needsShiftPredicate(out_tv->definition());
@@ -105,12 +105,12 @@ int AxisHaloInfo::width() const {
 }
 
 int AxisHaloInfo::width(int pos) const {
-  TORCH_INTERNAL_ASSERT(pos >= 0 && pos < 2);
+  NVF_ERROR(pos >= 0 && pos < 2);
   return widths_[pos];
 }
 
 void AxisHaloInfo::setWidth(int pos, int width) {
-  TORCH_INTERNAL_ASSERT(pos >= 0 && pos < 2);
+  NVF_ERROR(pos >= 0 && pos < 2);
   widths_[pos] = width;
 }
 
@@ -142,12 +142,12 @@ bool HaloInfo::hasRootAxisInfo(IterDomain* id) const {
 
 const AxisHaloInfo& HaloInfo::getRootAxisInfo(IterDomain* id) const {
   // TODO: Enable this check, was failing in many tests
-  // TORCH_INTERNAL_ASSERT(
+  // NVF_ERROR(
   //     id->definition() == nullptr || id->isRFactorProduct(),
   //     "Invalid IterDomain: ",
   //     id);
   auto it = root_axis_map_.find(id);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       it != root_axis_map_.end(),
       "Halo root axis info not found for ",
       id->toString());
@@ -266,12 +266,12 @@ void HaloInfo::propagateRootAxisInfo(
     // If the root axes are broadcast, no halo should be associated
     // with them.
     if (c_id->isBroadcast()) {
-      TORCH_INTERNAL_ASSERT(!c_info.hasHalo());
+      NVF_ERROR(!c_info.hasHalo());
       p_info.merge(c_info);
       setRootAxisInfo(p_id, p_info);
       continue;
     } else if (p_id->isRFactorProduct()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !c_info.hasHalo(),
           "Propagating halo info to a rfactor producer domain not yet supported.");
       continue;
@@ -330,11 +330,11 @@ void HaloInfo::insertToInheritanceMap(
     }
   }
   // No matching set found. This should not happen.
-  TORCH_INTERNAL_ASSERT(inserted);
+  NVF_ERROR(inserted);
 }
 
 void HaloInfo::initializeFromRootAxisInfo(IterDomain* id) {
-  TORCH_INTERNAL_ASSERT(hasRootAxisInfo(id));
+  NVF_ERROR(hasRootAxisInfo(id));
 
   const auto& halo_info = getRootAxisInfo(id);
   auto halo_width = halo_info.width();
@@ -397,10 +397,10 @@ void HaloInfo::build(TensorDomain* td) {
 
   for (auto expr : exprs) {
     // clang-tidy complains without this about expr being nullptr
-    TORCH_INTERNAL_ASSERT(expr != nullptr);
+    NVF_ERROR(expr != nullptr);
     if (auto split = dynamic_cast<Split*>(expr)) {
       // Merge-then-split of halo-extended IDs is not allowed
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           merged_shifted_ids.find(split->in()) == merged_shifted_ids.end(),
           "Splitting IterDomain that is a merged domain of halo-extended domains is not allowed");
 
@@ -460,7 +460,7 @@ void HaloInfo::build(TensorDomain* td) {
     } else {
       // Assume no halo
       for (auto input_id : ir_utils::filterByType<IterDomain>(expr->inputs())) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             getExtent(input_id) == nullptr,
             "Halo is not supported. Halo-extended ID: ",
             input_id->toString(),
@@ -502,7 +502,7 @@ void HaloInfo::validate(
     auto concrete_id = ca_map->getConcreteMappedID(axis, IdMappingMode::LOOP);
 
     // The extent is assumed to be the same
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         extentEqual(axis, concrete_id),
         "Axis does not have the same exact size with its concrete ID due to halo extension.",
         " Tensor: T",
@@ -528,7 +528,7 @@ void HaloInfo::validate(
     }
 
     // Only threading parallelism is considered for now
-    TORCH_CHECK(
+    NVF_CHECK(
         isParallelTypeThread(ptype), "Unsupported parallel type: ", ptype);
 
     bool shared_mem_needed = false;
@@ -567,7 +567,7 @@ void HaloInfo::validate(
       // expressions is shift, any memory should be fine. Otherwise, it
       // must be accessible by all threads involved in the
       // parallelization.
-      TORCH_CHECK(
+      NVF_CHECK(
           mem_type == MemoryType::Shared,
           "TV",
           tv->name(),
@@ -575,7 +575,7 @@ void HaloInfo::validate(
           ptype);
 
     } else if (isParallelTypeBlockDim(ptype)) {
-      TORCH_CHECK(
+      NVF_CHECK(
           false,
           "Block-based parallelization of a halo-extended axis is not supported: ",
           axis);
@@ -595,7 +595,7 @@ Val* HaloInfo::getExtent(IterDomain* id) const {
 
 int HaloInfo::getHaloWidth(IterDomain* id) const {
   auto it = halo_width_map_.find(id);
-  TORCH_INTERNAL_ASSERT(it != halo_width_map_.end());
+  NVF_ERROR(it != halo_width_map_.end());
   return it->second;
 }
 
@@ -606,7 +606,7 @@ bool HaloInfo::hasHaloWidth(IterDomain* id) const {
 const std::unordered_set<IterDomain*>& HaloInfo::getChildDomains(
     IterDomain* root_id) const {
   auto it = inheritance_map_.find(root_id);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       it != inheritance_map_.end(),
       "Domain not found in the inheritance map: ",
       root_id);
@@ -648,7 +648,7 @@ bool extentCompare(
     IterDomain* id2,
     Cmp cmp,
     const DisjointSets<IterDomain*>& permissive_map) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       permissive_map.strictAreMapped(id1, id2),
       "Invalid axes to compare: ",
       id1->toString(),
@@ -659,22 +659,21 @@ bool extentCompare(
   // halo.
 
   if (halo_map.hasHaloWidth(id1)) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         halo_map.hasHaloWidth(id2), "Invalid comparison: ", id1, " and ", id2);
     // Both axes have halo. We assume the axes themselves have equal
     // extents, excluding halo, as they are mapped with the CA
     // map. So, we just need to compare the halo width of each axis.
     return cmp(halo_map.getHaloWidth(id1), halo_map.getHaloWidth(id2));
   } else {
-    TORCH_INTERNAL_ASSERT(!halo_map.hasHaloWidth(id2));
+    NVF_ERROR(!halo_map.hasHaloWidth(id2));
     // Both don't have halo. The only case this can happen must be
     // both axes are the output of a merge expression, so each merge
     // input is recursively compared, and returns true only when both
     // inputs return.
     if (auto merge1 = dynamic_cast<Merge*>(id1->definition())) {
       auto merge2 = dynamic_cast<Merge*>(id2->definition());
-      TORCH_INTERNAL_ASSERT(
-          merge2 != nullptr, "Invalid comparison: ", id1, " and ", id2);
+      NVF_ERROR(merge2 != nullptr, "Invalid comparison: ", id1, " and ", id2);
       auto inner_le = extentCompare(
           halo_map, merge1->inner(), merge2->inner(), cmp, permissive_map);
       auto outer_le = extentCompare(
@@ -682,7 +681,7 @@ bool extentCompare(
       return inner_le && outer_le;
     } else {
       // This is not considered. Should never reach here.
-      TORCH_INTERNAL_ASSERT(false, "Invalid comparison: ", id1, " and ", id2);
+      NVF_ERROR(false, "Invalid comparison: ", id1, " and ", id2);
     }
   }
 }
@@ -690,7 +689,7 @@ bool extentCompare(
 } // namespace
 
 bool HaloInfo::extentLessEqual(IterDomain* id1, IterDomain* id2) const {
-  TORCH_INTERNAL_ASSERT(GpuLower::hasCurrent(), "No GpuLower found");
+  NVF_ERROR(GpuLower::hasCurrent(), "No GpuLower found");
   return extentCompare(
       *this,
       id1,
@@ -700,7 +699,7 @@ bool HaloInfo::extentLessEqual(IterDomain* id1, IterDomain* id2) const {
 }
 
 bool HaloInfo::extentEqual(IterDomain* id1, IterDomain* id2) const {
-  TORCH_INTERNAL_ASSERT(GpuLower::hasCurrent(), "No GpuLower found");
+  NVF_ERROR(GpuLower::hasCurrent(), "No GpuLower found");
   return extentCompare(
       *this,
       id1,
@@ -788,10 +787,10 @@ std::unordered_map<IterDomain*, Val*> HaloInfo::buildConcreteHaloExtentMap(
 
   for (auto expr : loop_indexing.getForwardExprList()) {
     // clang-tidy complains without this about expr being nullptr
-    TORCH_INTERNAL_ASSERT(expr != nullptr);
+    NVF_ERROR(expr != nullptr);
     if (auto split = dynamic_cast<Split*>(expr)) {
       // Merge-then-split of halo-extended IDs is not allowed
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           merged_shifted_ids.find(split->in()) == merged_shifted_ids.end(),
           "Splitting IterDomain that is a merged domain of halo-extended domains is not allowed");
 
@@ -873,7 +872,7 @@ std::unordered_map<IterDomain*, Val*> HaloInfo::buildConcreteHaloExtentMap(
     } else {
       // Halo not yet supported, just set the width to zero at the moment.
       for (auto input_id : ir_utils::filterByType<IterDomain>(expr->inputs())) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             local_halo_info.getHaloWidth(
                 GpuLower::current()->caMap()->getConcreteMappedID(
                     input_id, IdMappingMode::EXACT)) == 0,

--- a/csrc/device_lower/analysis/shift.h
+++ b/csrc/device_lower/analysis/shift.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <compute_at_map.h>
 #include <dispatch.h>

--- a/csrc/device_lower/analysis/sync_information.cpp
+++ b/csrc/device_lower/analysis/sync_information.cpp
@@ -35,7 +35,7 @@ void validateParallelizationOfTensor(TensorView* tv) {
       continue;
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !pt_map.get(ptype),
         "Multiple use of ",
         ptype,
@@ -54,7 +54,7 @@ void validateParallelizationOfTensor(TensorView* tv) {
 
   auto predicated_parallel_types = pt_map & thread_pred.limited_types;
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       predicated_parallel_types.none(),
       "Invalid parallelization of tensor t",
       tv->name(),
@@ -745,7 +745,7 @@ SyncMap::SyncMap(Fusion* fusion) {
               continue;
             }
             // Can this happen?
-            TORCH_INTERNAL_ASSERT(
+            NVF_ERROR(
                 false,
                 "Unexpected case. Producer: ",
                 producer->toString(),
@@ -762,7 +762,7 @@ SyncMap::SyncMap(Fusion* fusion) {
         } // end for ptypes
 
         if (raw_dims.hasBID()) {
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               producer->getMemoryType() == MemoryType::Global,
               "Inconsistent parallelization found between TV",
               producer->name(),
@@ -776,7 +776,7 @@ SyncMap::SyncMap(Fusion* fusion) {
               " RAW flags: ",
               raw_dims.toString());
         } else if (raw_dims.hasTID()) {
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               producer->getMemoryType() == MemoryType::Global ||
                   producer->getMemoryType() == MemoryType::Shared,
               "Inconsistent parallelization found between TV",

--- a/csrc/device_lower/analysis/sync_information.h
+++ b/csrc/device_lower/analysis/sync_information.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <parallel_type_bitmap.h>
 

--- a/csrc/device_lower/analysis/thread_predicate.cpp
+++ b/csrc/device_lower/analysis/thread_predicate.cpp
@@ -78,7 +78,7 @@ Val* ThreadPredicateMap::getPredicateFromPredicateInfo(
     const auto tp = getPredicatePerParallelType(pt, pred_info);
     pred = SimplifyingIrBuilder::logicalAndExpr(pred, tp);
   }
-  TORCH_INTERNAL_ASSERT(pred != nullptr);
+  NVF_ERROR(pred != nullptr);
 
   return pred;
 }
@@ -252,7 +252,7 @@ void ThreadPredicateMap::updateBitSet(const Expr* expr) {
       }
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         thread_predicates_.find(tv_inp) != thread_predicates_.end(),
         "Thread predicate map was not initialized, couldn't find ",
         inp->toString());
@@ -282,11 +282,11 @@ void ThreadPredicateMap::updateBitSet(const Expr* expr) {
     for (const auto i : c10::irange(ParallelTypeBitmap::kNumParallelTypes)) {
       if (input_reductions[i]) {
         if (id_ptypes[i]) {
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               id_reductions[i],
               "Mismatched parallelized reductions found on inputs of epxr: ",
               expr);
-          TORCH_CHECK(
+          NVF_CHECK(
               !id_bcasts[i],
               "Invalid broadcast and reduction combination, tried to parallelize both with the same thread dim: ",
               inp);
@@ -493,7 +493,7 @@ class RedundantUseAnalysis : BackwardVisitor {
         }
       }
 
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           maybe_expr_pred_map.has_value(), "TV op not having a tv output");
       redundant_expr_use_map_[expr] = maybe_expr_pred_map.value();
     }
@@ -610,7 +610,7 @@ class ConcretizedBroadcastRedundantWriteRemover {
           continue;
         }
         auto concrete_root_id = *it;
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             concretized_broadcast_root_domains_.emplace(rd, concrete_root_id)
                 .second);
       }
@@ -651,8 +651,7 @@ class ConcretizedBroadcastRedundantWriteRemover {
     // The following sort is added because in NVFuserTest.FusionIssue2076_CUDA
     // the order is [I3, I1, B2] while the correct order should be [I1, B2, I3]
     size_t n_elements = merged_root_domains.size();
-    TORCH_INTERNAL_ASSERT(
-        n_elements, "The number of merged root domains should > 0");
+    NVF_ERROR(n_elements, "The number of merged root domains should > 0");
     std::vector<int> indices(n_elements);
     std::iota(indices.begin(), indices.end(), 0);
     std::sort(indices.begin(), indices.end(), [&](int a, int b) {
@@ -815,7 +814,7 @@ bool ThreadPredicateMap::update(
 Val* ThreadPredicateMap::getPredicate(
     const TensorView* tv,
     ParallelTypeBitmap mask) const {
-  TORCH_INTERNAL_ASSERT(find(tv) != end(), "Couldn't find ", tv);
+  NVF_ERROR(find(tv) != end(), "Couldn't find ", tv);
   auto pred_info = getPredicateInfo(tv);
   return getPredicateFromPredicateInfo(pred_info, mask);
 }
@@ -863,8 +862,7 @@ ParallelTypeBitmap ThreadPredicateMap::getRedundantConsumerType(
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
-      result.has_value(), "ThreadPredicateMap : TV op assumed");
+  NVF_ERROR(result.has_value(), "ThreadPredicateMap : TV op assumed");
   return result.value();
 }
 

--- a/csrc/device_lower/analysis/thread_predicate.h
+++ b/csrc/device_lower/analysis/thread_predicate.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <device_lower/utils.h>
 #include <ir/all_nodes.h>

--- a/csrc/device_lower/analysis/trivial_broadcast.cpp
+++ b/csrc/device_lower/analysis/trivial_broadcast.cpp
@@ -95,7 +95,7 @@ void ConcretizedBroadcastDomains::dispatch(Expr* expr) {
         const bool is_concretized =
             !c_id->isBroadcast() && !c_id->isReduction();
         auto it = broadcast_origin_map_.find(p_id);
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             it != broadcast_origin_map_.end(),
             "Broadcast origin info not found for producer broadcast domain: ",
             p_id->toString(),

--- a/csrc/device_lower/analysis/trivial_broadcast.h
+++ b/csrc/device_lower/analysis/trivial_broadcast.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <root_domain_map.h>
 

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -162,7 +162,7 @@ void GpuLower::collectPaddedParallelDims() {
 
       // Check ifi TIDx is padded in this kernel
       if (id->hasPaddingToMultipleOfWarp()) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             id->getParallelType() == ParallelType::TIDx,
             "Padded types supported only on TIDx");
         warp_pad_info_.is_tidx_padded = true;
@@ -256,8 +256,8 @@ void dumpExprsIfEnabled(
 
 void GpuLower::lower(Fusion* fusion) {
   FUSER_PERF_SCOPE("GpuLower::lower");
-  TORCH_INTERNAL_ASSERT(fusion != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(fusion != nullptr);
+  NVF_ERROR(
       active_gpu_lower == nullptr, "Nested lowering passes are not supported");
 
   struct LowerGuard {
@@ -524,13 +524,12 @@ void GpuLower::lower(Fusion* fusion) {
 }
 
 kir::Kernel* GpuLower::kernel() const {
-  TORCH_CHECK(kernel_);
+  NVF_CHECK(kernel_);
   return kernel_.get();
 }
 
 GpuLower* GpuLower::current() {
-  TORCH_INTERNAL_ASSERT(
-      active_gpu_lower != nullptr, "No active GpuLower available");
+  NVF_ERROR(active_gpu_lower != nullptr, "No active GpuLower available");
   return active_gpu_lower;
 }
 

--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <compute_at_map.h>
 #include <device_lower/analysis/fused_reduction.h>
@@ -106,12 +107,12 @@ class TORCH_CUDA_CU_API GpuLower : public NonCopyable {
   }
 
   PredicateElimination& predicateElimination() {
-    TORCH_INTERNAL_ASSERT(pred_elimination_.get() != nullptr);
+    NVF_ERROR(pred_elimination_.get() != nullptr);
     return *pred_elimination_;
   }
 
   const PredicateElimination& predicateElimination() const {
-    TORCH_INTERNAL_ASSERT(pred_elimination_.get() != nullptr);
+    NVF_ERROR(pred_elimination_.get() != nullptr);
     return *pred_elimination_;
   }
 

--- a/csrc/device_lower/pass/alias_memory.h
+++ b/csrc/device_lower/pass/alias_memory.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <dispatch.h>
 #include <ir/all_nodes.h>

--- a/csrc/device_lower/pass/allocation.h
+++ b/csrc/device_lower/pass/allocation.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/all_nodes.h>
 #include <kernel_ir.h>

--- a/csrc/device_lower/pass/double_buffer.cpp
+++ b/csrc/device_lower/pass/double_buffer.cpp
@@ -25,7 +25,7 @@ unsigned int getDoubleBufferAxisPosition(const TensorView* tv) {
   // which defines the loop where prefetching is applied. Therefore,
   // the CA position must be larger than 0.
 
-  TORCH_INTERNAL_ASSERT(tv->getComputeAtPosition() > 0);
+  NVF_ERROR(tv->getComputeAtPosition() > 0);
 
   // Unroll must not exist outside of double-buffer axis
   auto first_unroll_it = std::find_if(
@@ -41,7 +41,7 @@ unsigned int getDoubleBufferAxisPosition(const TensorView* tv) {
   const int unroll_or_ca_pos =
       std::min((int)tv->getComputeAtPosition(), first_unroll_pos);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       unroll_or_ca_pos > 0,
       "Invalid tensor to double-buffer. Valid double buffer axis not found due to Unroll. ",
       tv->toString());
@@ -56,7 +56,7 @@ unsigned int getDoubleBufferAxisPosition(const TensorView* tv) {
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       valid_pos >= 0,
       "Invalid tensor to double-buffer. Valid double buffer axis not found. ",
       tv->toString());
@@ -74,17 +74,17 @@ void validateDoubleBufferedTensor(const TensorView* tv) {
   // Like vectorization, only LoadStoreOp with another TensorView is
   // considered.
   auto def = tv->definition();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       def->isA<LoadStoreOp>(),
       "Invalid tensor to double-buffer. Only tensor defined by LoadStoreOp is supported: ",
       def->toString());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       def->input(0)->isA<TensorView>(),
       "Invalid tensor to double-buffer. Only tensor defined by LoadStoreOp with TensorView is supported: ",
       def->toString());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !tv->hasComputeWith(),
       "computeWith is not supported with double buffering: ",
       tv->toString());
@@ -93,7 +93,7 @@ void validateDoubleBufferedTensor(const TensorView* tv) {
   // the double-buffering loop. Otherwise, the producer itself would
   // also need to be double-bufferred.
   auto producer = def->input(0)->as<TensorView>();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       producer->getComputePosition(tv) <= double_buffer_pos,
       "Invalid tensor to double-buffer. The computeAt position of the producer tensor must be moved left: ",
       producer->toString());
@@ -102,7 +102,7 @@ void validateDoubleBufferedTensor(const TensorView* tv) {
   // are allowed.
   const auto p_mem_type = producer->getMemoryType();
   const auto c_mem_type = tv->getMemoryType();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       (p_mem_type == MemoryType::Global &&
        (c_mem_type == MemoryType::Shared || c_mem_type == MemoryType::Local)) ||
           (p_mem_type == MemoryType::Shared && c_mem_type == MemoryType::Local),
@@ -134,7 +134,7 @@ class DoubleBufferFusionInspector : private IterVisitor {
       return;
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         tv->definition(), "Fusion input shouldn't be double buffered.", tv);
 
     validateDoubleBufferedTensor(tv);
@@ -207,7 +207,7 @@ class DoubleBufferLoopCloner : public kir::IrVisitor {
         double_buffer_loop_->iter_domain());
 
     if (loop_type_ == DoubleBufferLoopStage::Prolog) {
-      TORCH_INTERNAL_ASSERT(start->isZeroInt());
+      NVF_ERROR(start->isZeroInt());
       stop = SimplifyingIrBuilder::create<Val>(
           int64_t(stage_depth - 1), DataType::Index);
     } else if (
@@ -216,7 +216,7 @@ class DoubleBufferLoopCloner : public kir::IrVisitor {
       stop = IrBuilder::subExpr(
           double_buffer_loop_->stop(), gpu_lower->kernel()->oneVal());
     } else if (loop_type_ == DoubleBufferLoopStage::Epilog) {
-      TORCH_INTERNAL_ASSERT(requireEpilogue(double_buffer_load_exprs_));
+      NVF_ERROR(requireEpilogue(double_buffer_load_exprs_));
       start = IrBuilder::subExpr(
           double_buffer_loop_->stop(),
           SimplifyingIrBuilder::create<Val>(
@@ -256,7 +256,7 @@ class DoubleBufferLoopCloner : public kir::IrVisitor {
   }
 
   void handle(kir::IfThenElse* ite) final {
-    TORCH_INTERNAL_ASSERT(false, "No IfThenElse should exist yet");
+    NVF_ERROR(false, "No IfThenElse should exist yet");
   }
 
   void dispatch(Expr* expr) final {
@@ -269,7 +269,7 @@ class DoubleBufferLoopCloner : public kir::IrVisitor {
       return;
     }
 
-    TORCH_INTERNAL_ASSERT(!cloned_scopes_.empty());
+    NVF_ERROR(!cloned_scopes_.empty());
 
     if (loop_type_ == DoubleBufferLoopStage::Main) {
       cloned_scopes_.back()->push_back(expr);
@@ -286,7 +286,7 @@ class DoubleBufferLoopCloner : public kir::IrVisitor {
         double_buffer_load_exprs_.end(),
         [out_tv](const auto load_expr) {
           auto double_buffer_tv = ir_utils::getTvOutput(load_expr);
-          TORCH_INTERNAL_ASSERT(double_buffer_tv != nullptr);
+          NVF_ERROR(double_buffer_tv != nullptr);
           return out_tv == double_buffer_tv;
         });
     if ((loop_type_ == DoubleBufferLoopStage::Prolog &&
@@ -384,7 +384,7 @@ class DoubleBufferLoopNestInspector : private kir::IrVisitor {
     auto double_buffer_loop =
         gpu_lower->doubleBufferInfo().getDoubleBufferLoop(out_tv, for_loops_);
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         double_buffer_loop != nullptr,
         "No double buffer loop found for a double buffered tensor: ",
         out_tv->toString());
@@ -403,15 +403,14 @@ class DoubleBufferLoopNestInspector : private kir::IrVisitor {
   }
 
   static void validateDoubleBufferLoop(kir::ForLoop* loop) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         loop->start()->isZeroInt(), "Unsupported loop: ", loop->toString());
-    TORCH_INTERNAL_ASSERT(
-        loop->step()->isOneInt(), "Unsupported loop: ", loop->toString());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(loop->step()->isOneInt(), "Unsupported loop: ", loop->toString());
+    NVF_ERROR(
         !loop->vectorize(),
         "Vectorized loop should not be the allocation loop for double-buffered tensor: ",
         loop->toString());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !loop->vectorize_shift(),
         "Vectorize shift loop should not be the allocation loop for double-buffered tensor: ",
         loop->toString());
@@ -463,8 +462,8 @@ class DoubleBufferInserter : private kir::ExprMutator {
       : insertion_info_(insertion_info) {
     auto num_double_buffer_loops = insertion_info.size();
     traverseAndInsert(exprs);
-    TORCH_INTERNAL_ASSERT(processed_loop_ != nullptr);
-    TORCH_INTERNAL_ASSERT(insertion_info.size() == num_double_buffer_loops - 1);
+    NVF_ERROR(processed_loop_ != nullptr);
+    NVF_ERROR(insertion_info.size() == num_double_buffer_loops - 1);
   }
 
   using kir::ExprMutator::handle;
@@ -606,7 +605,7 @@ class DoubleBufferInserter : private kir::ExprMutator {
   void insertCpAsyncCommitWaitInMainLoop(
       kir::ForLoop* main_loop,
       const std::vector<Expr*>& loads) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !main_loop->body().empty(),
         "Double buffer sync insertion: empty main loop.");
     auto& exprs = main_loop->body().exprs();
@@ -627,7 +626,7 @@ class DoubleBufferInserter : private kir::ExprMutator {
         last_double_buffer_load = it;
       }
     }
-    TORCH_INTERNAL_ASSERT(last_double_buffer_load != exprs.end());
+    NVF_ERROR(last_double_buffer_load != exprs.end());
     std::vector<Expr*>::const_iterator commit_it =
         main_loop->body().insert(last_double_buffer_load + 1, cp_async_commit);
 
@@ -678,7 +677,7 @@ bool DoubleBufferInfo::isDoubleBufferedIterDomain(IterDomain* id) {
 }
 
 DoubleBufferInfo::TvInfo& DoubleBufferInfo::getTvInfo(const TensorView* tv) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       tv->isDoubleBuffered() || tv->isCircularBuffered(),
       "Not a double-buffered tensor: ",
       tv->toString());
@@ -712,7 +711,7 @@ void DoubleBufferInfo::setStageDepth(IterDomain* id, unsigned int stage_depth) {
   if (maybe_exisiting_depth_it == stage_depth_.end()) {
     stage_depth_[concrete_loop_id] = stage_depth;
   } else {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         stage_depth == maybe_exisiting_depth_it->second,
         "Unsupported multiple depth pipelining, was set to ",
         maybe_exisiting_depth_it->second,
@@ -740,8 +739,7 @@ unsigned int DoubleBufferInfo::getStageDepthFor(
 
   auto maybe_depth_it = stage_depth_.find(concrete_id);
 
-  TORCH_INTERNAL_ASSERT(
-      maybe_depth_it != stage_depth_.end(), "Stage depth not found");
+  NVF_ERROR(maybe_depth_it != stage_depth_.end(), "Stage depth not found");
 
   return maybe_depth_it->second;
 }

--- a/csrc/device_lower/pass/double_buffer.h
+++ b/csrc/device_lower/pass/double_buffer.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/all_nodes.h>
 #include <kernel_ir.h>

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -215,7 +215,7 @@ class ExprGroup {
       std::vector<ExprGroupConnections*>& edges,
       ExprGroupConnections* edge_to_remove) {
     auto it = std::find(edges.begin(), edges.end(), edge_to_remove);
-    TORCH_INTERNAL_ASSERT(it != edges.end(), "Could not find edge to remove.");
+    NVF_ERROR(it != edges.end(), "Could not find edge to remove.");
     edges.erase(it);
   }
 
@@ -483,7 +483,7 @@ std::vector<ExprGroup*> ExprGroup::getMergeCandidates(
   // If fallback mode already detected a merge somewhere, we shouldn't still be
   // traversing.
   if (fallback_mode_enabled) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !neighbor_merged,
         "Shouldn't still be traversing in fallback mode if a merge was found.");
   }
@@ -645,7 +645,7 @@ void ExprSegmentationSorter::resetLevels() {
           std::max(visit->payload()->level, inp->from->payload()->level + 1);
     }
   }
-  TORCH_INTERNAL_ASSERT(next_to_visit.empty(), "Error in graph, is not a DAG.");
+  NVF_ERROR(next_to_visit.empty(), "Error in graph, is not a DAG.");
 }
 
 ExprGroup* ExprSegmentationSorter::makeEmptyGroup(bool is_scalar_only) {
@@ -735,7 +735,7 @@ std::vector<ExprGroupConnections*> getMergedEdges(
     const std::vector<ExprGroupConnections*>& edges1,
     const ExprGroup* sg2,
     const std::vector<ExprGroupConnections*>& edges2) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       sg1 != nullptr && sg2 != nullptr,
       "This function doesn't handle trivial.");
 
@@ -882,7 +882,7 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
   auto joined_groups =
       makeEmptyGroup(sg1->isScalarOnly() && sg2->isScalarOnly());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       producer != nullptr,
       "Tried to merge expr's together that aren't neighbors.");
 
@@ -932,7 +932,7 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
       ca_ids.emplace(kernelScopeDomain());
       auto consumer_of_consumer_edge =
           dynamic_cast<TensorView*>(consumer_group_edge->consumer_val);
-      TORCH_INTERNAL_ASSERT(consumer_of_consumer_edge != nullptr);
+      NVF_ERROR(consumer_of_consumer_edge != nullptr);
       for (const auto tv_i :
            c10::irange(producer_of_consumer_edge->getComputePosition(
                consumer_of_consumer_edge))) {
@@ -1091,7 +1091,7 @@ bool ExprSegmentationSorter::interIterUpdate() {
       return false;
     }
     // If we didn't finish and we tried the fallback, throw.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !fallback_mode_enabled_,
         "Couldn't succcessfully sort out the fusion expressions. ",
         "There are remaining connections of the heirarchical segmentation which should have been ",
@@ -1114,7 +1114,7 @@ void ExprSegmentationSorter::mergeNodes() {
     ExprGroup *group1 = nullptr, *group2 = nullptr;
     std::tie(group1, group2) = to_merge_.back();
     to_merge_.pop_back();
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         group2 == group1->payload()->merge_with,
         "Expression Sorter: inconsistent to_merge packing");
     clean_up_groups.emplace(group1);
@@ -1138,7 +1138,7 @@ void ExprSegmentationSorter::mergeNodes() {
 
 // Initialize concrete_id_dependencies and concrete_id_to_all_ids
 void ExprSegmentationSorter::initializeForLoopDependencies() {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       concrete_id_dependencies_.empty(),
       "For loop dependencies have already been initialized.");
 
@@ -1255,7 +1255,7 @@ void ExprSegmentationSorter::initializeForLoopDependencies() {
       desc << std::endl;
     }
 
-    TORCH_INTERNAL_ASSERT(false, desc.str());
+    NVF_ERROR(false, desc.str());
   }
 }
 
@@ -1277,13 +1277,13 @@ bool ExprSegmentationSorter::hasCADomains(
 // additional tracking, however we recreate ca_domain_ when we merge groups,
 // so it's hard to track what is no longer needed.
 bool ExprSegmentationSorter::loopReady(IterDomain* concrete_id) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       concrete_id == getConcreteID(concrete_id),
       "Received a non-concrete ID: ",
       concrete_id->toString(),
       ", LOOP concrete ID: ",
       getConcreteID(concrete_id)->toString());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       concrete_id_dependencies_.find(concrete_id) !=
           concrete_id_dependencies_.end(),
       "Dependency information not found for ",
@@ -1401,7 +1401,7 @@ bool ExprSegmentationSorter::supportedMerge(ExprGroup* sg1, ExprGroup* sg2) {
         continue;
       }
 
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           consumer_val->isA<TensorView>(),
           "Mismatched tensorview to non-tensorview in expression sorting. ",
           producer_val,
@@ -1738,11 +1738,11 @@ std::vector<Expr*> reorderExprsForComputeAt() {
   if (fusion->isNoOp()) {
     return {};
   }
-  TORCH_INTERNAL_ASSERT(fusion != nullptr);
+  NVF_ERROR(fusion != nullptr);
   ExprSegmentationSorter sorter(fusion);
   sorter.sort();
   auto sorted_exprs = sorter.getExprs();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !sorted_exprs.empty(),
       "Error during expression sorting, no expressions produced.");
   return sorted_exprs;

--- a/csrc/device_lower/pass/expr_sort.h
+++ b/csrc/device_lower/pass/expr_sort.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/base_nodes.h>
 
 namespace nvfuser {

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <instrumentation.h>
 #include <kernel_ir.h>

--- a/csrc/device_lower/pass/insert_syncs.h
+++ b/csrc/device_lower/pass/insert_syncs.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/all_nodes.h>
 #include <kernel_ir.h>

--- a/csrc/device_lower/pass/loop_rotation.cpp
+++ b/csrc/device_lower/pass/loop_rotation.cpp
@@ -25,7 +25,7 @@ namespace {
 // Clone an expr, if this expr is a container (ForLoop, IfThenElse), then
 // recursively clone all exprs in its scope.
 Expr* recursivelyClone(Expr* expr) {
-  TORCH_INTERNAL_ASSERT(expr != nullptr);
+  NVF_ERROR(expr != nullptr);
   if (auto fl = dynamic_cast<kir::ForLoop*>(expr)) {
     auto new_loop = IrBuilder::create<kir::ForLoop>(fl);
     for (auto e : fl->body().exprs()) {
@@ -39,8 +39,7 @@ Expr* recursivelyClone(Expr* expr) {
     // we only want to rotate the loop in the unswitch path?). We should be
     // definitely revisit how to deal with this ite->predicate() if this is the
     // case.
-    TORCH_INTERNAL_ASSERT(
-        false, "Don't expect to see IfThenElse in loop rotation pass.");
+    NVF_ERROR(false, "Don't expect to see IfThenElse in loop rotation pass.");
     auto new_ite = IrBuilder::create<kir::IfThenElse>(ite->predicate());
     for (auto e : ite->thenBody().exprs()) {
       new_ite->thenBody().push_back(recursivelyClone(e));
@@ -132,7 +131,7 @@ class RotateLoop : kir::ExprMutator {
   //   then the container is automatically selected.
   // This function modifies selection_ to implement this strategy
   void expandSelection(Expr* expr) {
-    TORCH_INTERNAL_ASSERT(expr != nullptr);
+    NVF_ERROR(expr != nullptr);
     for (auto fl : for_loops_) {
       if (fl->iter_domain() != loop_concrete_id_) {
         continue;
@@ -374,7 +373,7 @@ class RotateLoop : kir::ExprMutator {
     expandSelection(fl);
     auto id = fl->iter_domain();
     if (id == loop_concrete_id_) {
-      TORCH_CHECK(
+      NVF_CHECK(
           validateSelection(fl), "Unable to rotate loop ", fl->toString());
       rotate(fl);
     }

--- a/csrc/device_lower/pass/loop_rotation.h
+++ b/csrc/device_lower/pass/loop_rotation.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <executor_params.h>
 #include <ir/all_nodes.h>
 

--- a/csrc/device_lower/pass/loops.cpp
+++ b/csrc/device_lower/pass/loops.cpp
@@ -25,7 +25,7 @@ namespace nvfuser {
 std::vector<Expr*> LoopNestGenerator::loweredExprs(
     const std::vector<Expr*>& exprs) {
   FUSER_PERF_SCOPE("GpuLower::Lower::LoopNestGenerator::loweredExprs");
-  TORCH_INTERNAL_ASSERT(FusionGuard::getCurFusion() != nullptr);
+  NVF_ERROR(FusionGuard::getCurFusion() != nullptr);
   LoopNestGenerator generator(exprs);
   return generator.lowered_exprs_;
 }
@@ -42,7 +42,7 @@ kir::ForLoop* openForHelper(kir::ForLoop* scope, IterDomain* id) {
   if (extent_with_halo) {
     // When an axis is extended with halo, unrolling and vectorization
     // are assumed to not be used for now.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         id->getParallelType() != ParallelType::Unroll &&
         !isParallelTypeVectorize(id->getParallelType()));
     // Use the extent that's extended by halo
@@ -79,7 +79,7 @@ void LoopNestGenerator::openFor(IterDomain* id) {
 }
 
 void LoopNestGenerator::closeFor() {
-  TORCH_INTERNAL_ASSERT(!for_loops_.empty());
+  NVF_ERROR(!for_loops_.empty());
   for_loops_.pop_back();
 }
 
@@ -103,7 +103,7 @@ void LoopNestGenerator::handle(Expr* expr) {
     pushFront(expr);
 
     for (auto out : expr->outputs()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           out->getValType().value() == ValType::Others,
           "Unrecognized output type found in expr ",
           expr,
@@ -119,7 +119,7 @@ void LoopNestGenerator::handle(Expr* expr) {
   TensorView* out_tv = expr->output(0)->as<TensorView>();
 
   // Grab the loop structure
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       loop_structures_.find(out_tv) != loop_structures_.end(),
       "Could not find loop structure of ",
       out_tv);
@@ -153,7 +153,7 @@ void LoopNestGenerator::handle(Expr* expr) {
 
 // Generate the loop nest structure and place it in lowered_exprs_
 void LoopNestGenerator::generate(const std::vector<Expr*>& exprs) {
-  TORCH_INTERNAL_ASSERT(lowered_exprs_.empty());
+  NVF_ERROR(lowered_exprs_.empty());
 
   // Figure out loop structure of each expression. This can be a bit convoluted,
   // for an example why see Indexing17 test
@@ -243,7 +243,7 @@ void LoopNestGenerator::generate(const std::vector<Expr*>& exprs) {
     auto last_id_concrete = ca_map->getConcreteMappedID(
         tv->axis((int)(tv->nDims() - 1)), IdMappingMode::LOOP);
     auto all_loops_it = concrete_id_dependencies.find(last_id_concrete);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         all_loops_it != concrete_id_dependencies.end(),
         "Should have processed all id's in all tvs.");
     std::vector<IterDomain*> loop_structure(

--- a/csrc/device_lower/pass/loops.h
+++ b/csrc/device_lower/pass/loops.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <compute_at_map.h>
 #include <device_lower/analysis/thread_predicate.h>

--- a/csrc/device_lower/pass/magic_zero.cpp
+++ b/csrc/device_lower/pass/magic_zero.cpp
@@ -32,7 +32,7 @@ class MagicZeroInserter : public kir::ExprMutator {
   };
 
   MagicZeroInserter(const std::vector<Expr*>& exprs) {
-    TORCH_INTERNAL_ASSERT(!exprs.empty());
+    NVF_ERROR(!exprs.empty());
     kir::ExprMutator::registerInsertBefore(
         exprs.front(), IrBuilder::create<kir::InitMagicZero>(), nullptr);
     kir::ExprMutator::traverseAndInsert(exprs);
@@ -44,7 +44,7 @@ class MagicZeroInserter : public kir::ExprMutator {
         kir::ExprMutator::registerInsertAfter(
             fl, IrBuilder::create<kir::UpdateMagicZero>());
       } else {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             !scope_.back()->exprs().empty(), "Not expecting an empty loop.");
         kir::ExprMutator::registerInsertAfter(
             fl, IrBuilder::create<kir::UpdateMagicZero>(), scope_.back());
@@ -188,7 +188,7 @@ IndexMagicZeroInfo protectPredicateIndexWithMagicZero(
     auto concrete_loop_id = GpuLower::current()->caMap()->getConcreteMappedID(
         loop_id, IdMappingMode::EXACT);
     auto index_it = id_graph.initial_concrete_index_map.find(concrete_loop_id);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         index_it != id_graph.initial_concrete_index_map.end(),
         "Index not found for loop: ",
         concrete_loop_id->toString());
@@ -204,14 +204,13 @@ IndexMagicZeroInfo protectPredicateIndexWithMagicZero(
   for (int i = static_cast<int>(loops.size()) - 1; i >= 0; --i) {
     auto loop = loops.at(i);
     auto loop_id = id_graph.resolved_loop_domains.at(i);
-    TORCH_INTERNAL_ASSERT(GpuLower::current()->caMap()->areMapped(
+    NVF_ERROR(GpuLower::current()->caMap()->areMapped(
         loop_id, loop->iter_domain(), IdMappingMode::PERMISSIVE));
     IterDomain* concrete_loop_id =
         GpuLower::current()->caMap()->getConcreteMappedID(
             loop_id, IdMappingMode::EXACT);
     auto index_it = id_graph.initial_concrete_index_map.find(concrete_loop_id);
-    TORCH_INTERNAL_ASSERT(
-        index_it != id_graph.initial_concrete_index_map.end());
+    NVF_ERROR(index_it != id_graph.initial_concrete_index_map.end());
     auto loop_index = index_it->second;
 
     const auto is_loop_index_used =

--- a/csrc/device_lower/pass/magic_zero.h
+++ b/csrc/device_lower/pass/magic_zero.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <kernel_ir.h>
 

--- a/csrc/device_lower/pass/misaligned_vectorization.cpp
+++ b/csrc/device_lower/pass/misaligned_vectorization.cpp
@@ -94,10 +94,9 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
   };
 
   ReferenceTensors getReferenceTensors(Expr* vectorized_expr) {
-    TORCH_INTERNAL_ASSERT(vectorized_expr != nullptr);
-    TORCH_INTERNAL_ASSERT(
-        vectorized_expr->outputs().front()->isA<TensorView>());
-    TORCH_INTERNAL_ASSERT(vectorized_expr->inputs().front()->isA<TensorView>());
+    NVF_ERROR(vectorized_expr != nullptr);
+    NVF_ERROR(vectorized_expr->outputs().front()->isA<TensorView>());
+    NVF_ERROR(vectorized_expr->inputs().front()->isA<TensorView>());
 
     auto in_tv = vectorized_expr->inputs().front()->as<TensorView>();
     auto out_tv = vectorized_expr->outputs().front()->as<TensorView>();
@@ -108,7 +107,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
     const bool global_vectorize_read_op =
         (out_tv->getMemoryType() == MemoryType::Local &&
          in_tv->getMemoryType() == MemoryType::Global);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         global_vectorize_write_op || global_vectorize_read_op,
         "Unsupported vectorize memory configuration detected.");
 
@@ -317,7 +316,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
     // Assumption: All vectorize operations have the same shift
     auto vectorized_expr =
         findFirstVectorizedSetOp(for_loop_structure, child_loops);
-    TORCH_INTERNAL_ASSERT(vectorized_expr != nullptr);
+    NVF_ERROR(vectorized_expr != nullptr);
 
     auto reference_tensors = getReferenceTensors(vectorized_expr);
 
@@ -396,8 +395,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
 
       // If the for loop contains a vectorize Set operation, then
       // it should only contain a single expression
-      TORCH_INTERNAL_ASSERT(
-          !has_vectorize_op || fl->body().exprs().size() == 1);
+      NVF_ERROR(!has_vectorize_op || fl->body().exprs().size() == 1);
 
       const auto new_loop = IrBuilder::create<kir::ForLoop>(
           fl->iter_domain(),
@@ -511,8 +509,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
       // There must be a matching consumer root ID as the producer ID is
       // not reduction and the expression between them is LoadStoreOp.
       auto it = p2c.find(producer_root_id);
-      TORCH_INTERNAL_ASSERT(
-          it != p2c.end(), "No matching consumer root ID found");
+      NVF_ERROR(it != p2c.end(), "No matching consumer root ID found");
       auto consumer_root_id = it->second;
 
       // Don't extend the vectorization domain beyond the CA position
@@ -538,10 +535,10 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
       // If it's not contiguous, extending the vectorization domain
       // further is not possible
       auto producer_dim_contiguity = producer_contig.at(i);
-      TORCH_INTERNAL_ASSERT(producer_dim_contiguity.has_value());
+      NVF_ERROR(producer_dim_contiguity.has_value());
 
       auto consumer_dim_contiguity = consumer_contig.at(consumer_root_idx);
-      TORCH_INTERNAL_ASSERT(consumer_dim_contiguity.has_value());
+      NVF_ERROR(consumer_dim_contiguity.has_value());
 
       if (!(producer_dim_contiguity.value() &&
             consumer_dim_contiguity.value())) {
@@ -551,7 +548,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
       --consumer_root_idx;
     }
 
-    TORCH_INTERNAL_ASSERT(extent != nullptr);
+    NVF_ERROR(extent != nullptr);
 
     return extent;
   }
@@ -563,7 +560,7 @@ class MisalignedVectorizationModifier : public kir::ExprMutator {
       bool address = false) {
     auto namedScalar = (address) ? IrBuilder::addressExprNamedScalar(name, val)
                                  : IrBuilder::setExprNamedScalar(name, val);
-    TORCH_INTERNAL_ASSERT(namedScalar->definition() != nullptr);
+    NVF_ERROR(namedScalar->definition() != nullptr);
     return namedScalar;
   }
 

--- a/csrc/device_lower/pass/misaligned_vectorization.h
+++ b/csrc/device_lower/pass/misaligned_vectorization.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/all_nodes.h>
 

--- a/csrc/device_lower/pass/predicate.cpp
+++ b/csrc/device_lower/pass/predicate.cpp
@@ -54,14 +54,14 @@ class ConditionalFromPredicateModifier : public kir::ExprMutator {
           // now.
           auto ite = expr->as<kir::IfThenElse>();
 
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               ite->thenBody().size() == 1,
               "Expecting predicated body to only have one vectorized expression.");
           auto vec_expr = ite->thenBody()[0];
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               vec_expr->isA<UnaryOp>() || vec_expr->isA<LoadStoreOp>(),
               "Vectorize predicate exprs only supported on set operations.");
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               ir_utils::isTvOp(vec_expr),
               "Vectorize predicate exprs only supported on tensor view operations.");
           if (!vec_expr->inputs()[0]->isConstScalar()) {
@@ -71,21 +71,21 @@ class ConditionalFromPredicateModifier : public kir::ExprMutator {
                     ir_utils::getTvOutput(vec_expr)));
           }
         } else {
-          TORCH_INTERNAL_ASSERT(lower_utils::supportInlinePredicate(expr));
+          NVF_ERROR(lower_utils::supportInlinePredicate(expr));
           auto thread_pred = GpuLower::current()->threadPredMap().getPredicate(
               ir_utils::getTvOutput(expr));
-          TORCH_INTERNAL_ASSERT(thread_pred->isConst() && thread_pred->value());
+          NVF_ERROR(thread_pred->isConst() && thread_pred->value());
           conditional = SimplifyingIrBuilder::logicalAndExpr(
               conditional,
               GpuLower::current()->threadPredMap().getPredicate(
                   ir_utils::getTvOutput(expr)));
         }
       }
-      TORCH_INTERNAL_ASSERT(conditional != nullptr);
+      NVF_ERROR(conditional != nullptr);
       conditional = GpuLower::current()->commonScalarMap().hoistScalar(
           conditional, for_loops_);
       expr->predicate()->setValue(conditional);
-      TORCH_INTERNAL_ASSERT(expr->predicate()->value() != nullptr);
+      NVF_ERROR(expr->predicate()->value() != nullptr);
       setWritePredicate(expr);
     }
 
@@ -155,7 +155,7 @@ class ConditionalFromPredicateModifier : public kir::ExprMutator {
   }
 
   void handle(kir::IfThenElse* ite) final {
-    TORCH_INTERNAL_ASSERT(ite->predicate() != nullptr);
+    NVF_ERROR(ite->predicate() != nullptr);
 
     // Loop rotation transform loops like
     //  for i ...
@@ -182,13 +182,13 @@ class ConditionalFromPredicateModifier : public kir::ExprMutator {
     // Otherwise, generate conditional and update predicate
     if (!ite->predicate()->hasValue()) {
       auto conditional = generateConditional(ite->predicate());
-      TORCH_INTERNAL_ASSERT(conditional != nullptr);
+      NVF_ERROR(conditional != nullptr);
       conditional = GpuLower::current()->commonScalarMap().hoistScalar(
           conditional, for_loops_);
 
       // Update bool conditional in-place
       ite->predicate()->setValue(conditional);
-      TORCH_INTERNAL_ASSERT(ite->predicate()->value() != nullptr);
+      NVF_ERROR(ite->predicate()->value() != nullptr);
     }
     kir::ExprMutator::handle(ite);
 
@@ -224,8 +224,7 @@ class ConditionalFromPredicateModifier : public kir::ExprMutator {
             outer_loops.emplace_back(loop);
           }
         }
-        TORCH_INTERNAL_ASSERT(
-            vectorized_loop != nullptr, "Should be unreachable.");
+        NVF_ERROR(vectorized_loop != nullptr, "Should be unreachable.");
         return UnswitchPredicate::get(outer_loops, vectorized_loop);
       }
       case PredicateType::Unswitch: {

--- a/csrc/device_lower/pass/predicate.h
+++ b/csrc/device_lower/pass/predicate.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/all_nodes.h>
 #include <kernel_ir.h>

--- a/csrc/device_lower/pass/scalar_hoist.cpp
+++ b/csrc/device_lower/pass/scalar_hoist.cpp
@@ -208,7 +208,7 @@ std::pair<Val*, bool> CommonScalarMap::hoistScalarImpl(
   // are replaced with hoisted input
   if (changed) {
     value = IrBuilder::newScalar(*value->getDataType());
-    TORCH_INTERNAL_ASSERT(def->outputs().size() == 1);
+    NVF_ERROR(def->outputs().size() == 1);
     auto create_fn = def->newObjectFunc();
     create_fn(value->container(), inputs, {value}, def->attributes());
   }
@@ -365,7 +365,7 @@ std::vector<Val*> CommonScalarMap::getHoistedScalars(kir::ForLoop* loop) const {
 void CommonScalarMap::initialize(const std::vector<Expr*> exprs) {
   // We only hoist scalars not depending on tensors. In lowered expressions, all
   // these scalars are computed in top level scope.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       common_scalar_map_.empty(),
       "CommonScalarMap used before initialization.");
   for (auto expr : exprs) {
@@ -406,7 +406,7 @@ std::pair<int64_t, bool> findAllocPointFromDataDependency(
   int64_t pos = -1;
   for (auto i : c10::irange(exprs.size())) {
     auto expr = exprs[i];
-    TORCH_INTERNAL_ASSERT(expr != nullptr);
+    NVF_ERROR(expr != nullptr);
     if (auto alloc = dynamic_cast<kir::Allocate*>(expr)) {
       // Currently this branch is only to handle shared memory address. For
       // shared memory address, we generate code like `toSmem(T7)`, this does
@@ -481,7 +481,7 @@ class CommonIndexInserter : private kir::ExprMutator {
       auto alloc = IrBuilder::create<kir::Allocate>(
           value, MemoryType::Local, GpuLower::current()->kernel()->oneVal());
       const auto def = value->definition();
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           def != nullptr,
           "Hoisted value must have a definition. ",
           value->toString());

--- a/csrc/device_lower/pass/scalar_hoist.h
+++ b/csrc/device_lower/pass/scalar_hoist.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 
 #include <list>

--- a/csrc/device_lower/pass/unroll.cpp
+++ b/csrc/device_lower/pass/unroll.cpp
@@ -92,7 +92,7 @@ void UnrollPass::dispatch(Expr* expr) {
         // In the case of Global, we cannot ignore any predicates at
         // all, so don't modify thread_pred. Just make sure no other
         // memory type shows up here.
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             out_tv->getMemoryType() == MemoryType::Global,
             "Unexpected memory type: ",
             out_tv->getMemoryType(),

--- a/csrc/device_lower/pass/unroll.h
+++ b/csrc/device_lower/pass/unroll.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <device_lower/analysis/thread_predicate.h>
 #include <device_lower/utils.h>

--- a/csrc/device_lower/pass/vectorize_welford.cpp
+++ b/csrc/device_lower/pass/vectorize_welford.cpp
@@ -75,7 +75,7 @@ class WelfordVectorizer : public kir::ExprMutator {
     }
 
     // Check if the innermost loop can be vectorized
-    TORCH_INTERNAL_ASSERT(!for_loops_.empty());
+    NVF_ERROR(!for_loops_.empty());
     auto innermost_loop = for_loops_.back();
 
     if (innermost_loop->isTrivial()) {
@@ -126,7 +126,7 @@ class WelfordVectorizer : public kir::ExprMutator {
     //
     // Bail out if the structure is not detected.
 
-    TORCH_INTERNAL_ASSERT(!scope_exprs_.empty());
+    NVF_ERROR(!scope_exprs_.empty());
     kir::IfThenElse* wop_ite =
         dynamic_cast<kir::IfThenElse*>(scope_exprs_.back());
     if (wop_ite == nullptr) {
@@ -140,7 +140,7 @@ class WelfordVectorizer : public kir::ExprMutator {
       return false;
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         wop_ite->predicate()->hasValue(),
         "All predicates should have been lowered at this point: ",
         wop_ite->toString());
@@ -155,15 +155,15 @@ class WelfordVectorizer : public kir::ExprMutator {
 
   // Transform a serial WelfordOp.
   void vectorize(WelfordOp* wop) {
-    TORCH_INTERNAL_ASSERT(!scope_exprs_.empty());
+    NVF_ERROR(!scope_exprs_.empty());
     kir::IfThenElse* wop_ite =
         dynamic_cast<kir::IfThenElse*>(scope_exprs_.back());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         wop_ite != nullptr,
         "Predicate IfThenElse not found for ",
         wop->toString());
 
-    TORCH_INTERNAL_ASSERT(!for_loops_.empty());
+    NVF_ERROR(!for_loops_.empty());
     innermost_loop_ = for_loops_.back();
 
     scope_of_innermost_loop_ = nullptr;
@@ -172,7 +172,7 @@ class WelfordVectorizer : public kir::ExprMutator {
         scope_of_innermost_loop_ = scope_.at(i - 1);
       }
     }
-    TORCH_INTERNAL_ASSERT(scope_of_innermost_loop_ != nullptr);
+    NVF_ERROR(scope_of_innermost_loop_ != nullptr);
 
     // If the expr is predicated, hoist the predicate as the innermost
     // loop should not have any dependency with the predicate (which
@@ -189,7 +189,7 @@ class WelfordVectorizer : public kir::ExprMutator {
       if (!pred->value()->value()) {
         // Can this happen? This should be just ignored, assuming
         // there's no else path.
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             wop_ite->elseBody().empty(),
             "Unexpected IfThenElse: ",
             wop_ite->toString());
@@ -403,7 +403,7 @@ class WelfordVectorizer : public kir::ExprMutator {
   // with what ever value within the loop range since it is
   // independent of the loop index.
   kir::TensorIndex* hoistCount(kir::TensorIndex* out_N) {
-    TORCH_INTERNAL_ASSERT(!for_loops_.empty());
+    NVF_ERROR(!for_loops_.empty());
     auto innermost_loop = for_loops_.back();
     const auto& original_index = out_N->index();
     std::unordered_map<Val*, Val*> index_replacement_map;
@@ -468,7 +468,7 @@ class WelfordVectorizer : public kir::ExprMutator {
       return false;
     }
 
-    TORCH_INTERNAL_ASSERT(!for_loops_.empty());
+    NVF_ERROR(!for_loops_.empty());
     auto innermost_loop = for_loops_.back();
 
     // Check all the exprs in the same scope

--- a/csrc/device_lower/pass/vectorize_welford.h
+++ b/csrc/device_lower/pass/vectorize_welford.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <vector>
 
 namespace nvfuser {

--- a/csrc/device_lower/pass/warp_reduce.cpp
+++ b/csrc/device_lower/pass/warp_reduce.cpp
@@ -282,8 +282,7 @@ class FuseBroadcastWithWarpReduce : private kir::IrVisitor {
         }
       }
     }
-    TORCH_INTERNAL_ASSERT(
-        false, "lower_warp_reduce: cannot find allocation for this op");
+    NVF_ERROR(false, "lower_warp_reduce: cannot find allocation for this op");
     return nullptr;
   }
 
@@ -318,7 +317,7 @@ class FuseBroadcastWithWarpReduce : private kir::IrVisitor {
       return;
     }
     auto reduction_ti_out = dynamic_cast<kir::TensorIndex*>(reduction->out());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         reduction_ti_out,
         "lower_warp_reduce: Pass needs to be run after indexing");
 

--- a/csrc/device_lower/pass/warp_reduce.h
+++ b/csrc/device_lower/pass/warp_reduce.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <kernel_ir.h>
 
 namespace nvfuser {

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -318,8 +318,7 @@ std::unordered_map<ParallelType, IterDomain*> getParallelDomains(
   } else if (val->isA<kir::TensorIndex>()) {
     tv = val->as<kir::TensorIndex>()->view();
   } else {
-    TORCH_INTERNAL_ASSERT(
-        false, "Provided val is not TensorIndex or TensorView.");
+    NVF_ERROR(false, "Provided val is not TensorIndex or TensorView.");
   }
 
   std::unordered_map<ParallelType, IterDomain*> parallel_domains;
@@ -674,7 +673,7 @@ BasicAllocInfo getAllocInformation(
 
     if (tv->axis((int)info.alloc_pos)->isReduction()) {
       const auto outputs = FusionGuard::getCurFusion()->getTerminatingOutputs();
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           std::find(outputs.begin(), outputs.end(), tv) != outputs.end(),
           "Invalid computeAt of T",
           tv->name(),

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <compute_at_map.h>
 #include <ir/all_nodes.h>

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -59,7 +59,7 @@ class ValidateSiblings : public IterVisitor {
         continue;
       }
 
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           sibling->nDims() == ref_ndims,
           "Mismatched dimensionality detected. Expr: ",
           expr->toString(),
@@ -82,7 +82,7 @@ class ValidateSiblings : public IterVisitor {
               .getIterDomainEquivalence();
 
       for (const auto i : c10::irange(ref_ndims)) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             replay.strictAreMapped(ref_output->axis(i), sibling->axis(i)),
             "Matching sibling ID not found. Expr: ",
             expr->toString(),
@@ -102,7 +102,7 @@ class ValidateSiblings : public IterVisitor {
     if (ptype0 == ParallelType::Vectorize ||
         ptype1 == ParallelType::Vectorize) {
       auto other_type = ptype0 == ParallelType::Vectorize ? ptype1 : ptype0;
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           other_type == ParallelType::Vectorize ||
               (!isParallelTypeThreadDim(other_type) &&
                !isParallelTypeBlockDim(other_type)),
@@ -112,7 +112,7 @@ class ValidateSiblings : public IterVisitor {
     }
 
     if (ptype0 != ptype1) {
-      TORCH_CHECK(
+      NVF_CHECK(
           ptype0 == ParallelType::Serial || ptype1 == ParallelType::Serial,
           "Error promoting parallel types: ",
           ptype0,
@@ -157,7 +157,7 @@ void validateIterDomainUsage(Fusion* fusion) {
 
     for (auto id : ir_utils::filterByType<IterDomain>(all_domain_vals)) {
       auto it = domain_use_map.find(id);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           it == domain_use_map.end(),
           "Multiple use of ",
           id,
@@ -186,7 +186,7 @@ void validateIr(Fusion* fusion) {
   validateIterDomainUsage(fusion);
 
   auto dynamic_tvs = ir_utils::getTVsWithDynamicTransform(fusion);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       dynamic_tvs.empty(),
       "Tensor with dynamic transform must be concretized before lowering: ",
       toDelimitedString(dynamic_tvs.begin(), dynamic_tvs.end()));
@@ -199,17 +199,17 @@ namespace {
 void checkContiguity(
     const std::unordered_set<IterDomain*>& domains,
     TensorView* tv) {
-  TORCH_INTERNAL_ASSERT(tv->getMemoryType() == MemoryType::Global);
+  NVF_ERROR(tv->getMemoryType() == MemoryType::Global);
 
   for (const auto idx : c10::irange(tv->getMaybeAllocationDomain().size())) {
     auto alloc = tv->getMaybeAllocationDomain()[idx];
     if (domains.find(alloc) != domains.end()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !alloc->isBroadcast(),
           "Misaligned vectorization prohibits merging broadcast domains.",
           "Issue found in, ",
           tv);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           tv->domain()->contiguity().at(idx).value_or(false),
           "Cannot merge non-contiguous allocation domains with misaligned vectorization.",
           "Issue found in, ",
@@ -227,12 +227,12 @@ void checkContiguity(
     TensorView* consumer,
     TensorView* producer) {
   // This seems not quite right, shouldn't we be able to reverse this?
-  TORCH_INTERNAL_ASSERT(consumer->getMemoryType() == MemoryType::Local);
-  TORCH_INTERNAL_ASSERT(producer->getMemoryType() == MemoryType::Global);
+  NVF_ERROR(consumer->getMemoryType() == MemoryType::Local);
+  NVF_ERROR(producer->getMemoryType() == MemoryType::Global);
 
   // TODO: we should use BestEffortReplay to find the correct c2p map for
   // allocation domain when it is different from rFactor domain.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !consumer->hasAllocation() && !producer->hasAllocation(),
       "Misaligned vectorization for allocation domain is not supported.");
   auto alloc_c2p =
@@ -251,19 +251,19 @@ void checkContiguity(
   for (auto consumer_alloc : consumer->getMaybeAllocationDomain()) {
     if (domains.find(consumer_alloc) != domains.end()) {
       auto producer_alloc = alloc_c2p.at(consumer_alloc);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           producer_domain_contiguity.find(producer_alloc) !=
           producer_domain_contiguity.end());
 
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !consumer_alloc->isBroadcast() || !producer_alloc->isBroadcast(),
           "Misaligned vectorization prohibits merging broadcast domains.",
           "Issue found in, ",
           consumer);
 
-      TORCH_INTERNAL_ASSERT(alloc_c2p.find(consumer_alloc) != alloc_c2p.end());
+      NVF_ERROR(alloc_c2p.find(consumer_alloc) != alloc_c2p.end());
 
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           producer_domain_contiguity.at(producer_alloc).value_or(false),
           "Cannot merge non-contiguous allocation domains with misaligned vectorization.",
           "Issue found in, ",
@@ -338,7 +338,7 @@ class VectorizeValidator : public OptInDispatch {
       validator.dispatch(expr);
     }
 
-    TORCH_CHECK(
+    NVF_CHECK(
         validator.is_valid,
         "Invalid vectorized pattern found, vectorization iter domains must be descendants of inner-most dimension.",
         "Issue found in, ",
@@ -350,13 +350,13 @@ class VectorizeValidator : public OptInDispatch {
         checkContiguity(validator.domains_, tv);
       } else if (tv->definition()->isA<LoadStoreOp>()) {
         auto input = tv->definition()->input(0);
-        TORCH_INTERNAL_ASSERT(input->isA<TensorView>());
+        NVF_ERROR(input->isA<TensorView>());
         auto input_tv = input->as<TensorView>();
         checkContiguity(validator.domains_, tv, input_tv);
       }
     }
 
-    TORCH_INTERNAL_ASSERT(validator.vectorized_id_ != nullptr);
+    NVF_ERROR(validator.vectorized_id_ != nullptr);
 
     // Contiguity is based on rfactor domain.
     IterDomain* last_alloc_dim = nullptr;
@@ -384,7 +384,7 @@ class VectorizeValidator : public OptInDispatch {
       // ldmatrix.trans is a hardware transpose instruction that can do
       // "vectorized" read from discontiguous memory
       auto contiguity = tv->domain()->contiguity().at(last_alloc_dim_pos);
-      TORCH_CHECK(
+      NVF_CHECK(
           last_alloc_dim == validator.vectorized_id_ &&
               contiguity.value_or(false),
           "Vectorized dim for ",
@@ -414,7 +414,7 @@ class VectorizeValidator : public OptInDispatch {
     IterDomain* v_id = nullptr;
     for (auto id : tv->getLeafDomain()) {
       if (isParallelTypeVectorize(id->getParallelType())) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             v_id == nullptr,
             "Found two vectorized domains in ",
             tv,
@@ -430,7 +430,7 @@ class VectorizeValidator : public OptInDispatch {
       return;
     }
 
-    TORCH_CHECK(
+    NVF_CHECK(
         v_id->extent()->isConstInt(),
         "Vectorizing a domain requires a constant integer size.");
 
@@ -443,7 +443,7 @@ class VectorizeValidator : public OptInDispatch {
     // Allow half2, float2, float4 and same sized vtypes.
     std::array<int64_t, 4> allowed_vector_sizes = {2, 4, 8, 16}; // NOLINT
 
-    TORCH_CHECK(
+    NVF_CHECK(
         std::find(
             allowed_vector_sizes.begin(),
             allowed_vector_sizes.end(),
@@ -560,7 +560,7 @@ void validateAndCollectVectorizeInfo(Fusion* fusion) {
         // (2) Check any producers of the tensor view with vectorize being set
         // on it to make sure their compute at position isn't to the right of
         // the vectorize dim.
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             i >= tv->getMaxComputePosition(),
             "IterDomains to the left of the compute at point cannot be vectorized: ",
             tv,
@@ -569,11 +569,11 @@ void validateAndCollectVectorizeInfo(Fusion* fusion) {
       }
 
       if (concrete_id->getParallelType() == ParallelType::MisalignedVectorize) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             tv->getMaxComputePosition() == 0 ||
                 tv->getMaxComputePosition() == tv->nDims() - 1,
             "Only allow misaligned vectorization in the -2 computeAt position.");
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             tv->getMemoryType() == MemoryType::Local ||
                 tv->getMemoryType() == MemoryType::Global,
             "Only allow misaligned vectorization between global and local memory.");
@@ -581,7 +581,7 @@ void validateAndCollectVectorizeInfo(Fusion* fusion) {
       }
     }
     if (has_vectorize_dim) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           tv->definition() == nullptr || tv->definition()->isA<LoadStoreOp>() ||
               tv->definition()->isA<SliceOp>(),
           "Vectorized accesses cannot be inline with computation, they are only supported with a Set operation.",
@@ -612,7 +612,7 @@ void fillVectorizedContigAllocationDomains(
 
   auto consumer_indexed_it =
       contig_finder.allocToIndexedID().find(vectorized_alloc_id);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       consumer_indexed_it != contig_finder.allocToIndexedID().end(),
       "Contiguity information not found for allocation domain: ",
       vectorized_alloc_id->toString());
@@ -629,7 +629,7 @@ void fillVectorizedContigAllocationDomains(
   } else {
     auto consumer_within_contig_it =
         contig_finder.withinContigIDs().find(consumer_indexed_id);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         consumer_within_contig_it != contig_finder.withinContigIDs().end());
     const auto& within_ids = consumer_within_contig_it->second;
     std::copy_if(
@@ -722,11 +722,11 @@ std::unordered_map<IterDomain*, std::pair<int64_t, int64_t>> getLiveRangeOffsets
     auto expr = *it;
     for (auto consumer : ir_utils::filterByType<TensorView>(expr->outputs())) {
       for (auto consumer_root : consumer->getRootDomain()) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             consumer_root->start()->isConstInt(),
             "Can't evaluate start value of ",
             consumer_root->start());
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             consumer_root->stopOffset()->isConstInt(),
             "Can't evaluate stop value of ",
             consumer_root->stopOffset());
@@ -751,9 +751,9 @@ std::unordered_map<IterDomain*, std::pair<int64_t, int64_t>> getLiveRangeOffsets
           // range by the consumers is covered by the defined range of
           // this root domain.
           auto& consumer_range = it->second;
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               consumer_root->start()->evaluateInt() <= consumer_range.first);
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               consumer_root->stopOffset()->evaluateInt() <=
               consumer_range.second);
         }
@@ -805,13 +805,13 @@ void validateSplit(
     Val* split_offset,
     int64_t domain_offset,
     const std::string& err_msg_prefix) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       split_offset->isConstInt(),
       err_msg_prefix,
       ": Unknown offset of split: ",
       split_offset);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       split_offset->evaluateInt() <= domain_offset,
       err_msg_prefix,
       ": Split offset is larger than the domain offset.",
@@ -855,7 +855,7 @@ void validatePartialSplit(Fusion* fusion) {
       auto root_domain = split->in();
       std::stringstream err_msg_prefix;
       err_msg_prefix << "Error with " << root_domain << " in T" << tv->name();
-      TORCH_INTERNAL_ASSERT(range_info.find(root_domain) != range_info.end());
+      NVF_ERROR(range_info.find(root_domain) != range_info.end());
       const auto& valid_range = range_info.at(root_domain);
       // Check the start offset. If it's zero, no validation regarding
       // the required range can occur.
@@ -888,7 +888,7 @@ void validateMmaTensors(MmaOp* mma) {
     for (auto id : tv->getLeafDomain()) {
       auto ptype = id->getParallelType();
       if (ptype == ParallelType::TIDx) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             id->isMmaSwizzled(),
             "TIDx for mma input/output must be set by WarpMmaSwizzler",
             id,
@@ -897,7 +897,7 @@ void validateMmaTensors(MmaOp* mma) {
           // Check that TIDx is exact lane_id
           const auto& paralel_dim_map =
               GpuLower::current()->parallelDimensionMap();
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               lower_utils::isExtentEqualToMaxParallelTypeExtent(id) &&
                   paralel_dim_map.get(ptype)->isConstInt() &&
                   paralel_dim_map.get(ptype)->evaluateInt() ==
@@ -911,11 +911,11 @@ void validateMmaTensors(MmaOp* mma) {
 
   // Note: this check will be relaxed in a follow up.
   auto validate_operand = [](const TensorView* tv) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         tv->getMemoryType() == MemoryType::Local,
         "Only supporting register input for mma ops, up to sm80 all mma ops have to take register inputs.");
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         std::all_of(
             tv->getLeafDomain().begin() + tv->getComputeAtPosition(),
             tv->getLeafDomain().end(),
@@ -941,10 +941,10 @@ void validateMmaTensors(MmaOp* mma) {
   // Additionally validate that mma is not directly taking a double buffered
   //  register input as the double buffer indexing is currently not compatible
   //  with fragment iteration. Would need to require a cache stage in this case.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !mma->inA()->as<TensorView>()->isDoubleBuffered(),
       "MMA op cannot directly take double buffered register input, put a set stage before.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !mma->inB()->as<TensorView>()->isDoubleBuffered(),
       "MMA op cannot directly take double buffered register input, put a set stage before.");
 }
@@ -975,12 +975,12 @@ void validateTuringMmaInput(TensorView* tv) {
   //  support any pointwise ops that does not change the
   //  datalayout.
   auto tv_def = tv->definition();
-  TORCH_INTERNAL_ASSERT(tv_def);
+  NVF_ERROR(tv_def);
   if (tv_def->isA<BroadcastOp>()) {
     tv_def = tv_def->input(0)->definition();
   }
-  TORCH_INTERNAL_ASSERT(tv_def);
-  TORCH_INTERNAL_ASSERT(ir_utils::isLdMatrixOp(tv_def));
+  NVF_ERROR(tv_def);
+  NVF_ERROR(ir_utils::isLdMatrixOp(tv_def));
 }
 
 // Output of ldmatrix is swizzled with the mma format, so it
@@ -997,7 +997,7 @@ void validateLdMatrixOutput(TensorView* tv) {
   // TODO: restricting to single use pipelines for now which
   //  is true to matmul mainloop. This Could be relaxed to
   //  support more complex mma usage.
-  TORCH_INTERNAL_ASSERT(out_uses.size() == 1);
+  NVF_ERROR(out_uses.size() == 1);
   auto out_use = *(out_uses.begin());
 
   if (out_use->isA<BroadcastOp>()) {
@@ -1005,7 +1005,7 @@ void validateLdMatrixOutput(TensorView* tv) {
     return;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       out_use->isA<MmaOp>(),
       "validateLdMatrixOutput: currently only supports single mma use for ldmatrix",
       out_use);
@@ -1027,10 +1027,10 @@ void validateSizeMemoryOp(LoadStoreOp* ldst) {
       *output->getDataType(), GpuLower::current()->indexType());
   switch (ldst->opType()) {
     case LoadStoreOpType::CpAsyncCg:
-      TORCH_CHECK(byte_size == 16, "Not supported byte size for cp.async.cg");
+      NVF_CHECK(byte_size == 16, "Not supported byte size for cp.async.cg");
       break;
     case LoadStoreOpType::CpAsyncCa:
-      TORCH_CHECK(
+      NVF_CHECK(
           byte_size == 4 || byte_size == 8 || byte_size == 16,
           "Not supported byte size for cp.async.ca");
       return;
@@ -1077,7 +1077,7 @@ void validateMma(Fusion* fusion) {
           validateTuringMmaInput(mma->inB()->as<TensorView>());
           break;
         default:
-          TORCH_INTERNAL_ASSERT(false, "validate mma: unsupported macro");
+          NVF_ERROR(false, "validate mma: unsupported macro");
           break;
       }
     }
@@ -1101,7 +1101,7 @@ void validateLoopSwizzle(
     std::unordered_set<IterDomain*>& leaf_domains) {
   for (auto out_id :
        ir_utils::filterByType<IterDomain>(swizzle_expr->outputs())) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         leaf_domains.count(out_id),
         "Loop swizzle can only be direct producer of leaf domains.");
     if (GpuLower::current()->caMap()->getConcreteMappedID(
@@ -1135,7 +1135,7 @@ void validateSwizzle(Fusion* fusion) {
       //  as inlining data swizzles would require addtional support of unswizzle
       //  operator, which currently doesn't have important use cases.
       for (auto swizzle_expr : inlined_swizzles) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             swizzle_expr->as<Swizzle2D>()->swizzleMode() == SwizzleMode::Loop,
             "Only support inlining loop swizzles");
         validateLoopSwizzle(swizzle_expr, tv_leaf_domain_set);
@@ -1150,7 +1150,7 @@ void validateSwizzle(Fusion* fusion) {
       // The latter would mean that one output of the swizzle is inlined while
       //  the other is not. Such case will not be supported.
       for (auto swizzle_expr : not_inlined_swizzles) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             !inlined_swizzle_set.count(swizzle_expr),
             "Cannot partially inline across swizzle domains.",
             swizzle_expr->toString());
@@ -1180,7 +1180,7 @@ void validateAndConvertIterDomainGrouping(Fusion* fusion) {
       is_grouped = true;
 
       // Grouping only makes sense for the normal iteration type
-      TORCH_CHECK(
+      NVF_CHECK(
           id->getIterType() == IterType::Iteration,
           "Invalid use of ParallelType::Group.",
           " Grouping of ",
@@ -1189,28 +1189,28 @@ void validateAndConvertIterDomainGrouping(Fusion* fusion) {
           tv->toString());
 
       // Extent must be static
-      TORCH_CHECK(
+      NVF_CHECK(
           id->extent()->getInt().has_value(),
           "Invalid use of ParallelType::Group.",
           " IterDomain must have a static extent: ",
           id->toString());
 
       // The CA position must be left of any grouped ID
-      TORCH_CHECK(
+      NVF_CHECK(
           tv->getMaxComputePosition() <= id_idx,
           "Invalid use of ParallelType::Group.",
           " ComputeAt position must be left of grouped IDs: ",
           tv->toString());
 
       // Similarly, the produce-at position must be left of any grouped ID
-      TORCH_CHECK(
+      NVF_CHECK(
           tv->getMaxProducerPosition() <= id_idx,
           "Invalid use of ParallelType::Group.",
           " ProduceAt position must be left of grouped IDs: ",
           tv->toString());
 
       // Halo is not allowed
-      TORCH_CHECK(
+      NVF_CHECK(
           GpuLower::current()->haloInfo()->getExtent(id) == nullptr,
           "Invalid use of ParallelType::Group.",
           " Grouping of halo-extended IterDomain, ",
@@ -1225,13 +1225,13 @@ void validateAndConvertIterDomainGrouping(Fusion* fusion) {
 
     // Must be defined by ReductionOp
     auto def = tv->definition();
-    TORCH_CHECK(
+    NVF_CHECK(
         def != nullptr,
         "Invalid use of ParallelType::Group.",
         " Definition of tv with ParallelType::Group not found. ",
         tv->toString());
 
-    TORCH_CHECK(
+    NVF_CHECK(
         tv->definition()->isA<ReductionOp>() ||
             tv->definition()->isA<GroupedReductionOp>() ||
             tv->definition()->isA<WelfordOp>() ||
@@ -1244,13 +1244,13 @@ void validateAndConvertIterDomainGrouping(Fusion* fusion) {
       auto rop = def->as<ReductionOp>();
       auto is_allreduce = rop->isAllreduce();
 
-      TORCH_CHECK(
+      NVF_CHECK(
           is_allreduce,
           "Invalid use of ParallelType::Group.",
           " Only enabled for allreduce reductions: ",
           rop->toString());
 
-      TORCH_CHECK(
+      NVF_CHECK(
           tv->domain()->hasGridReduction(),
           "Invalid use of ParallelType::Group.",
           " Only enabled for grid reductions: ",
@@ -1274,13 +1274,13 @@ void validateAndConvertIterDomainGrouping(Fusion* fusion) {
       auto wop = def->as<WelfordOp>();
       auto is_allreduce = wop->isAllreduce();
 
-      TORCH_CHECK(
+      NVF_CHECK(
           is_allreduce,
           "Invalid use of ParallelType::Group.",
           " Only enabled for allreduce reductions: ",
           wop->toString());
 
-      TORCH_CHECK(
+      NVF_CHECK(
           tv->domain()->hasGridReduction(),
           "Invalid use of ParallelType::Group.",
           " Only enabled for grid reductions: ",
@@ -1315,7 +1315,7 @@ void validateGroupedReductions(Fusion* fusion) {
           num_grouped_iterations *= (int)axis->extent()->getInt().value();
         }
       }
-      TORCH_CHECK(
+      NVF_CHECK(
           num_exprs * num_grouped_iterations <= kMaxNumGroupedReductions,
           "Too many grouped reductions: ",
           grouped_reduction_op->toString(),
@@ -1329,7 +1329,7 @@ void validateGroupedReductions(Fusion* fusion) {
 void validateLookupTV(Fusion* fusion) {
   for (auto expr : fusion->exprs()) {
     if (expr->isA<SelectOp>() || expr->isA<IndexSelectOp>()) {
-      TORCH_CHECK(
+      NVF_CHECK(
           expr->input(0)->isFusionInput(),
           "Lookup input must be a fusion input: ",
           expr->toString());
@@ -1347,7 +1347,7 @@ void validateResize(Fusion* fusion) {
          tv->getMaybeRFactorDomain().end()},
         {tv->getLeafDomain().begin(), tv->getLeafDomain().end()});
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         std::none_of(
             rf_to_leaf_exprs.begin(),
             rf_to_leaf_exprs.end(),

--- a/csrc/device_lower/validation.h
+++ b/csrc/device_lower/validation.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/all_nodes.h>
 

--- a/csrc/disjoint_set.h
+++ b/csrc/disjoint_set.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/util/Exception.h>
+#include <exceptions.h>
 
 #include <algorithm>
 #include <initializer_list>
@@ -71,7 +72,7 @@ class VectorOfUniqueEntries {
   // Returns first element in vector
   T front() const {
 #ifndef NDEBUG
-    TORCH_INTERNAL_ASSERT(!empty());
+    NVF_ERROR(!empty());
 #endif // NDEBUG
     return vector_.front();
   }
@@ -79,7 +80,7 @@ class VectorOfUniqueEntries {
   // Returns last element in vector
   T back() const {
 #ifndef NDEBUG
-    TORCH_INTERNAL_ASSERT(!empty());
+    NVF_ERROR(!empty());
 #endif // NDEBUG
     return vector_.back();
   }
@@ -87,7 +88,7 @@ class VectorOfUniqueEntries {
   // Remove and returns the last element in vector
   T popBack() {
 #ifndef NDEBUG
-    TORCH_INTERNAL_ASSERT(!empty());
+    NVF_ERROR(!empty());
 #endif // NDEBUG
     T v = vector_.back();
     set_.erase(v);
@@ -217,7 +218,7 @@ class DisjointSets {
   // Return the entire disjoint set of provided entry
   const VectorOfUniqueEntries<T, Hash>& getDisjointSetOf(T entry) const {
     auto set_it = disjoint_set_maps_.find(entry);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         set_it != disjoint_set_maps_.end(),
         "Could not find entry for ",
         entry->toString());
@@ -289,7 +290,7 @@ class DisjointSets {
   // returns if entry0 and entry1 are in the same disjoint set.
   bool strictAreMapped(T entry0, T entry1) const {
     auto entry_it = disjointSetMap().find(entry0);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         entry_it != disjointSetMap().end(),
         "Strict mapping failed on element: ",
         abstractToString(entry0),
@@ -368,7 +369,7 @@ DisjointSets<T, Hash>::DisjointSets(const DisjointSets<T, Hash>& other) {
     auto new_set = std::make_shared<VectorOfUniqueEntries<T, Hash>>(*other_set);
     int new_set_index = disjoint_sets_.size();
     disjoint_sets_.emplace_back(new_set);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         ptr_map.emplace(other_set, new_set_index).second,
         "Duplicated set found: ",
         other_set->toString());

--- a/csrc/dispatch.cpp
+++ b/csrc/dispatch.cpp
@@ -72,7 +72,7 @@ void Val::dispatch(T handler, Val* val) {
       ptr(handler)->handle(val);
       return;
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false,
       "Unknown valtype in dispatch! val: ",
       val->toString(),
@@ -310,7 +310,7 @@ void Expr::dispatch(T handler, Expr* expr) {
     ptr(handler)->handle(expr->as<PipelineCommunication>());
     return;
   }
-  TORCH_INTERNAL_ASSERT(false, "Unknown exprtype in dispatch!");
+  NVF_ERROR(false, "Unknown exprtype in dispatch!");
 }
 
 template <typename T>
@@ -320,7 +320,7 @@ void Statement::dispatch(T handler, Statement* stmt) {
   } else if (stmt->isExpr()) {
     ptr(handler)->dispatch(stmt->as<Expr>());
   } else {
-    TORCH_INTERNAL_ASSERT(false, "Unknown stmttype in dispatch!");
+    NVF_ERROR(false, "Unknown stmttype in dispatch!");
   }
 }
 
@@ -352,7 +352,7 @@ void Val::constDispatch(T handler, const Val* val) {
       ptr(handler)->handle(val);
       return;
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false,
       "Unknown valtype in dispatch! val: ",
       val->toString(),
@@ -590,7 +590,7 @@ void Expr::constDispatch(T handler, const Expr* expr) {
     ptr(handler)->handle(expr->as<PipelineCommunication>());
     return;
   }
-  TORCH_INTERNAL_ASSERT(false, "Unknown exprtype in dispatch!");
+  NVF_ERROR(false, "Unknown exprtype in dispatch!");
 }
 
 template <typename T>
@@ -600,7 +600,7 @@ void Statement::constDispatch(T handler, const Statement* stmt) {
   } else if (stmt->isExpr()) {
     ptr(handler)->dispatch(stmt->as<Expr>());
   } else
-    TORCH_INTERNAL_ASSERT(false, "Unknown stmttype in dispatch!");
+    NVF_ERROR(false, "Unknown stmttype in dispatch!");
 }
 
 /*
@@ -642,7 +642,7 @@ void Val::mutatorDispatch(T mutator, Val* val) {
       ptr(mutator)->mutate(val);
       return;
   }
-  TORCH_INTERNAL_ASSERT(false, "Unknown valtype in dispatch!");
+  NVF_ERROR(false, "Unknown valtype in dispatch!");
 }
 
 template <typename T>
@@ -655,7 +655,7 @@ void Statement::mutatorDispatch(T mutator, Statement* stmt) {
     ptr(mutator)->mutate(stmt->as<Expr>());
     return;
   }
-  TORCH_INTERNAL_ASSERT(false, "Unknown stmttype in dispatch!");
+  NVF_ERROR(false, "Unknown stmttype in dispatch!");
 }
 
 /*
@@ -722,31 +722,31 @@ void OptOutConstDispatch::dispatch(const Val* v) {
 
 void OptInConstDispatch::unhandled(const Statement* stmt) {
   if (stmt->isExpr()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         false,
         "Handle not overriden for ",
         stmt->as<Expr>()->getOpString(),
         ".");
   } else if (stmt->isVal()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         false, "Handle not overriden for ", stmt->getValType().value(), ".");
   } else {
-    TORCH_INTERNAL_ASSERT(false, "Unrecognized statement type.");
+    NVF_ERROR(false, "Unrecognized statement type.");
   }
 }
 
 void OptInDispatch::unhandled(Statement* stmt) {
   if (stmt->isExpr()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         false,
         "Handle not overriden for ",
         stmt->as<Expr>()->getOpString(),
         ".");
   } else if (stmt->isVal()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         false, "Handle not overriden for ", stmt->getValType().value(), ".");
   } else {
-    TORCH_INTERNAL_ASSERT(false, "Unrecognized statement type.");
+    NVF_ERROR(false, "Unrecognized statement type.");
   }
 }
 

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -9,6 +9,7 @@
 
 #include <c10/macros/Export.h>
 #include <c10/util/Exception.h>
+#include <exceptions.h>
 
 #include <utils.h>
 

--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <expr_evaluator.h>
 #include <ir/all_nodes.h>

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -159,12 +159,12 @@ void PrecomputedValues::bindInputs(const KernelArgumentHolder& args) {
   }
 
   const auto& inputs = fusion_->inputs();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       args.size() == inputs.size(), "kernel inputs size does not match args");
 
   for (const auto i : c10::irange((int64_t)inputs.size())) {
     const auto input = inputs[i];
-    TORCH_INTERNAL_ASSERT(input != nullptr);
+    NVF_ERROR(input != nullptr);
     if (auto tensor_input = dynamic_cast<TensorView*>(input)) {
       const auto& tensor = args[i]->as<at::Tensor>();
       if (!tensor.is_cpu()) {
@@ -310,7 +310,7 @@ void PrecomputedValues::validate() {
   FUSER_PERF_SCOPE("PrecomputedValuess::Validate");
   using namespace PolymorphicValue_functions;
   for (const auto& it : binding_log_) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         isSame(values_[it.first], it.second),
         "Precomputed values failed to validate.",
         "\nSomething unexpected changed between the compilation and execution.\n",
@@ -326,7 +326,7 @@ void PrecomputedValues::bindTensorMetaData(
     const at::Tensor& tensor) {
   const auto root_domain =
       TensorDomain::noReductions(tv->getMaybeRFactorDomain());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       tensor.dim() == static_cast<int64_t>(root_domain.size()),
       "Something went wrong configuring launch. Inputs do not match.");
 
@@ -405,8 +405,8 @@ void NaiveValueMachine::run() {
 void NaiveValueMachine::makeUnaryOp(UnaryOp* uop) {
   int in = uop->inputs()[0]->evaluatorIndex();
   int out = uop->outputs()[0]->evaluatorIndex();
-  TORCH_INTERNAL_ASSERT(in >= 0, "Integer Machine: unknown input: ", uop);
-  TORCH_INTERNAL_ASSERT(out >= 0, "Integer Machine: unknown out: ", uop);
+  NVF_ERROR(in >= 0, "Integer Machine: unknown input: ", uop);
+  NVF_ERROR(out >= 0, "Integer Machine: unknown out: ", uop);
 
   int index = makeInstructionEntry();
   inst_type_[index] = InstructionType::UNARY_OP;
@@ -423,9 +423,9 @@ void NaiveValueMachine::makeBinaryOp(BinaryOp* bop) {
   int in1 = bop->inputs()[1]->evaluatorIndex();
   int out = bop->outputs()[0]->evaluatorIndex();
 
-  TORCH_INTERNAL_ASSERT(in0 >= 0, "Integer Machine: unknown lhs: ", bop);
-  TORCH_INTERNAL_ASSERT(in1 >= 0, "Integer Machine: unknown rhs: ", bop);
-  TORCH_INTERNAL_ASSERT(out >= 0, "Integer Machine: unknown out: ", bop);
+  NVF_ERROR(in0 >= 0, "Integer Machine: unknown lhs: ", bop);
+  NVF_ERROR(in1 >= 0, "Integer Machine: unknown rhs: ", bop);
+  NVF_ERROR(out >= 0, "Integer Machine: unknown out: ", bop);
 
   int index = makeInstructionEntry();
   inst_type_[index] = InstructionType::BINARY_OP;
@@ -488,7 +488,7 @@ void NaiveValueMachine::runUnaryOp(int index) {
       } else if (data_type_[index] == DataType::Bool) {
         dest = PolymorphicValue((bool)src);
       } else {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             false, "dtype not supported in evaluator: ", data_type_[index]);
       }
       break;
@@ -502,7 +502,7 @@ void NaiveValueMachine::runUnaryOp(int index) {
       dest = ~src;
       break;
     default:
-      TORCH_CHECK(!"Unexpected operator type ", uop_type_[index]);
+      NVF_CHECK(!"Unexpected operator type ", uop_type_[index]);
   }
 
   precomputed_values_.defined_[dest_index] = true;
@@ -539,15 +539,15 @@ void NaiveValueMachine::runBinaryOp(int index) {
       dest = lhs * rhs;
       break;
     case BinaryOpType::Div:
-      TORCH_CHECK(rhs != 0);
+      NVF_CHECK(rhs != 0);
       dest = lhs / rhs;
       break;
     case BinaryOpType::Mod:
-      TORCH_CHECK(rhs != 0);
+      NVF_CHECK(rhs != 0);
       dest = lhs % rhs;
       break;
     case BinaryOpType::CeilDiv:
-      TORCH_CHECK(rhs != 0);
+      NVF_CHECK(rhs != 0);
       dest = ceildiv(lhs, rhs);
       break;
     case BinaryOpType::LogicalAnd:
@@ -575,7 +575,7 @@ void NaiveValueMachine::runBinaryOp(int index) {
       dest = gcd(lhs, rhs);
       break;
     default:
-      TORCH_CHECK(!"Unexpected operator type");
+      NVF_CHECK(!"Unexpected operator type");
   }
 
   precomputed_values_.defined_[dest_index] = true;

--- a/csrc/evaluator_common.h
+++ b/csrc/evaluator_common.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <device_lower/lower2device.h>
+#include <exceptions.h>
 #include <executor_params.h>
 #include <fusion.h>
 #include <ir/all_nodes.h>
@@ -230,7 +231,7 @@ class PrecomputedValues {
   //! Returns true if workspace has a computed or constant
   //!  value for given index.
   bool hasValue(int index) {
-    TORCH_INTERNAL_ASSERT(index > 0);
+    NVF_ERROR(index > 0);
     return defined_[index] || is_constant_[index];
   }
 

--- a/csrc/exceptions.cpp
+++ b/csrc/exceptions.cpp
@@ -1,4 +1,4 @@
-// This is a refactor of the TORCH_INTERNAL_ASSERT and TORCH_CHECK macros
+// This is a refactor of the NVF_ERROR and NVF_CHECK macros
 // from PyTorch for implementing NVFuser specific macros.
 
 #include <c10/util/irange.h>

--- a/csrc/exceptions.h
+++ b/csrc/exceptions.h
@@ -1,8 +1,9 @@
-// This is a refactor of the TORCH_INTERNAL_ASSERT and TORCH_CHECK macros
+// This is a refactor of the NVF_ERROR and NVF_CHECK macros
 // from PyTorch for implementing NVFuser specific macros.
 
 #pragma once
 
+#include <exceptions.h>
 #include <array>
 #include <deque>
 #include <fstream>

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -57,7 +57,7 @@ static const char* defineIndexType(PrimDataType index_type) {
   } else if (index_type == DataType::Int) {
     return "typedef int64_t nvfuser_index_t;\n";
   } else {
-    TORCH_INTERNAL_ASSERT(false, "invalid indexing type: ", index_type);
+    NVF_ERROR(false, "invalid indexing type: ", index_type);
   }
 }
 
@@ -221,15 +221,14 @@ void FusionExecutor::debugCompileFusionFromStr(
         static_evaluator,
         kernel_summary.static_smem_allocations,
         kernel->indexType());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         static_smem_size < max_static_smem_,
         "The static shared memory allocation is larger than available memory.");
   }
 
   std::tie(compiled_kernel_, last_compiler_log_, last_compiled_binary_) =
       executor_utils::getCompiledKernel(std::nullopt, code, name, fusion_id_);
-  TORCH_INTERNAL_ASSERT(
-      fusion_id_ > 0, "assign a fusion_id_ <= 0 is not accepted.");
+  NVF_ERROR(fusion_id_ > 0, "assign a fusion_id_ <= 0 is not accepted.");
 }
 
 void FusionExecutor::compileFusion(
@@ -239,11 +238,11 @@ void FusionExecutor::compileFusion(
     CompileParams compile_params) {
   FUSER_PERF_SCOPE("compileFusion");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !fusion->outputs().empty(), "No output found for this kernel, aborting.");
 
   for (auto out : fusion->outputs()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         out->getValType() == ValType::TensorView,
         "Output types from fusions that are not tensors are not supported at this point.");
 
@@ -294,7 +293,7 @@ void FusionExecutor::compileFusion(
   if (compile_params.index_type.has_value()) {
     // If the int32 compilation is requested, but the arguments demand
     // int64, that's an error
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !(compile_params.index_type.value() == PrimDataType::Int32 &&
           arg_index_type == PrimDataType::Int),
         "Compilation with int32 is requested but int64 is required for the arguments");
@@ -309,7 +308,7 @@ void FusionExecutor::compileFusion(
 
   c10::DeviceGuard dg(options_.device);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       options_.device.is_cuda(), "Provided device to CUDA fuser is the CPU.");
   auto properties = at::cuda::getDeviceProperties(options_.device.index());
   // TODO: These properties should be set as part of the constructor so that it
@@ -372,7 +371,7 @@ void FusionExecutor::compileFusion(
         static_evaluator,
         kernel_summary.static_smem_allocations,
         kernel->indexType());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         static_smem_size < max_static_smem_,
         "The static shared memory allocation is larger than available memory.");
   }
@@ -384,7 +383,7 @@ void FusionExecutor::compileFusion(
       ss << alloc->buffer()->toString() << ", ";
     }
     ss << " have dynamic allocations but are placed in local memory.";
-    TORCH_INTERNAL_ASSERT(false, ss.str());
+    NVF_ERROR(false, ss.str());
   }
 
   // TODO: pass block_size here;
@@ -396,8 +395,7 @@ void FusionExecutor::compileFusion(
         launch_constraints, expr_eval, warp_size_, kernel->indexType());
     block_size = launch_params.nThreads();
     dynamic_smem = launch_params.smem();
-    TORCH_INTERNAL_ASSERT(
-        block_size > 0, "launch param inferred block size < 0");
+    NVF_ERROR(block_size > 0, "launch param inferred block size < 0");
   }
 
   // TODO: high water mark should be computed via occupancy API after
@@ -419,8 +417,7 @@ void FusionExecutor::compileFusion(
           compile_params,
           block_size,
           save_compiled_binary_ || isDebugDumpEnabled(DebugDumpOption::Sass));
-  TORCH_INTERNAL_ASSERT(
-      fusion_id_ > 0, "failed to assign a fusion_id_ after compilation.");
+  NVF_ERROR(fusion_id_ > 0, "failed to assign a fusion_id_ after compilation.");
 
   // These should be nullopt at this point, but reset just in case
   resetCompiledKernelProperties();
@@ -470,20 +467,20 @@ void fillTensorWithNan(at::Tensor& t) {
       t.fill_(c10::complex<double>(std::nan(""), std::nan("")));
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unknown dtype");
+      NVF_ERROR(false, "Unknown dtype");
   }
 }
 
 std::vector<int64_t> getContiguousStrides(
     const std::vector<int64_t>& sizes,
     const std::vector<bool>& expand_flags) {
-  TORCH_INTERNAL_ASSERT(sizes.size() == expand_flags.size());
+  NVF_ERROR(sizes.size() == expand_flags.size());
 
   std::vector<int64_t> strides(sizes.size());
   int64_t cur_stride = 1;
   for (auto i = sizes.size(); i > 0; --i) {
     auto size = sizes.at(i - 1);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         size >= 0,
         "Positive size is assumed non-negative but received: ",
         size);
@@ -525,7 +522,7 @@ std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShape(
   for (const auto i : c10::irange(symbolic_sizes.size())) {
     auto symbolic_size = symbolic_sizes.at(i);
     const auto inferred_val = expr_eval.evaluate(symbolic_size);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         inferred_val.hasValue(),
         "Could not launch kernel as program could not infer ",
         symbolic_size->toInlineString(),
@@ -552,7 +549,7 @@ std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShapeOfIntermediate(
   // bu its actual allocation size may be different, e.g., for
   // supporting halo accesses. The actual size is currently computed
   // when creating the Allocate expr.
-  TORCH_INTERNAL_ASSERT(alloc != nullptr);
+  NVF_ERROR(alloc != nullptr);
   const auto& symbolic_sizes = alloc->shape();
   // For intermediate tensors, we just need to allocate a memory chunk
   // of the specified size. Broadcast expansion does not need to be considered.
@@ -579,7 +576,7 @@ std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShapeOfOutput(
     }
     symbolic_sizes.push_back(id->getMaybeExpandedExtent());
     if (id->hasExpandedExtent()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           id->isBroadcast(),
           "Non-broadcast domain should not have an expanded extent: ",
           id->toString());
@@ -608,7 +605,7 @@ class ForwardTraverseFromAllocToRFactor {
     auto outer = split->outer();
     auto factor = ee_.evaluate(split->factor()).as<int64_t>();
     auto in_it = std::find(frontier_.begin(), frontier_.end(), in);
-    // TORCH_INTERNAL_ASSERT(in_it != frontier_.end());
+    // NVF_ERROR(in_it != frontier_.end());
     if (in_it == frontier_.end()) {
       // TODO: We should get rid of this return and enable the above assert.
       // Note [Allocation domain on both side of rFactor]
@@ -652,8 +649,8 @@ class ForwardTraverseFromAllocToRFactor {
     auto out = merge->out();
     auto inner_it = std::find(frontier_.begin(), frontier_.end(), inner);
     auto outer_it = std::find(frontier_.begin(), frontier_.end(), outer);
-    // TORCH_INTERNAL_ASSERT(inner_it != frontier_.end());
-    // TORCH_INTERNAL_ASSERT(outer_it != frontier_.end());
+    // NVF_ERROR(inner_it != frontier_.end());
+    // NVF_ERROR(outer_it != frontier_.end());
     if (inner_it == frontier_.end() || outer_it == frontier_.end()) {
       // TODO: see [Allocation domain on both side of rFactor]
       return;
@@ -707,8 +704,7 @@ class ForwardTraverseFromAllocToRFactor {
     } else if (auto merge = dynamic_cast<Merge*>(expr)) {
       handle(merge);
     } else {
-      TORCH_INTERNAL_ASSERT(
-          false, "Unsupported transormation in allocation domain");
+      NVF_ERROR(false, "Unsupported transormation in allocation domain");
     }
   }
 
@@ -750,8 +746,8 @@ class BackwardTraverseFromAllocToRFactor {
     auto in = split->in();
     auto inner_it = std::find(frontier_.begin(), frontier_.end(), inner);
     auto outer_it = std::find(frontier_.begin(), frontier_.end(), outer);
-    // TORCH_INTERNAL_ASSERT(inner_it != frontier_.end());
-    // TORCH_INTERNAL_ASSERT(outer_it != frontier_.end());
+    // NVF_ERROR(inner_it != frontier_.end());
+    // NVF_ERROR(outer_it != frontier_.end());
     if (inner_it == frontier_.end() || outer_it == frontier_.end()) {
       // TODO: see [Allocation domain on both side of rFactor]
       return;
@@ -807,7 +803,7 @@ class BackwardTraverseFromAllocToRFactor {
     auto outer = merge->outer();
     auto factor = ee_.evaluate(inner->extent()).as<int64_t>();
     auto out_it = std::find(frontier_.begin(), frontier_.end(), out);
-    // TORCH_INTERNAL_ASSERT(out_it != frontier_.end());
+    // NVF_ERROR(out_it != frontier_.end());
     if (out_it == frontier_.end()) {
       // TODO: see [Allocation domain on both side of rFactor]
       return;
@@ -836,8 +832,7 @@ class BackwardTraverseFromAllocToRFactor {
     } else if (auto merge = dynamic_cast<Merge*>(expr)) {
       handle(merge);
     } else {
-      TORCH_INTERNAL_ASSERT(
-          false, "Unsupported transormation in allocation domain");
+      NVF_ERROR(false, "Unsupported transormation in allocation domain");
     }
   }
 
@@ -884,12 +879,12 @@ at::Tensor transformOutputFromAllocationToRFactor(
   // allocation domain can be before or after the rFactor domain, we need both a
   // forward and a backward traverse.
   std::list<IterDomain*> frontier(alloc.begin(), alloc.end());
-  TORCH_INTERNAL_ASSERT(tensor.dim() == (int64_t)frontier.size());
+  NVF_ERROR(tensor.dim() == (int64_t)frontier.size());
   tensor = ForwardTraverseFromAllocToRFactor(tensor, tv, ee, frontier)
                .run(rfactor, alloc);
   tensor = BackwardTraverseFromAllocToRFactor(tensor, tv, ee, frontier)
                .run(rfactor, alloc);
-  TORCH_INTERNAL_ASSERT(frontier.size() == rfactor.size());
+  NVF_ERROR(frontier.size() == rfactor.size());
   // Now that all affine transformations are handled, and frontiers should
   // contain the same set of IDs as rfactor. We still need to do a final
   // permutation so that their orders are also consistent.
@@ -935,7 +930,7 @@ std::vector<at::Tensor> allocOutputs(
     // for kernel execution, so would need to push them to args
     if (alias_it != output_to_input_aliases.end()) {
       auto aliased_input_index = alias_it->second;
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           inputs[aliased_input_index]->is<at::Tensor>(),
           "alias io only supports tensor");
       outputs.emplace_back(*inputs[aliased_input_index]);
@@ -989,18 +984,18 @@ int64_t FusionExecutor::computeSharedMemory(
     // If this buffer aliases another buffer,
     // then do not allocate memory for this buffer.
     if (smem_alloc->alias() == nullptr) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           smem_alloc->address(),
           "Smem address is not set for buffer T",
           smem_alloc->buffer()->name());
       const auto address_val = expr_eval.evaluate(smem_alloc->address());
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           address_val.hasValue(),
           "Failed to evaluate the address ",
           smem_alloc->address()->toInlineString(),
           " of shared memory buffer T",
           smem_alloc->buffer()->name());
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           address_val.is<int64_t>(),
           "Address val ",
           smem_alloc->address()->toInlineString(),
@@ -1009,7 +1004,7 @@ int64_t FusionExecutor::computeSharedMemory(
           " should be int64 but found ",
           address_val);
       const auto size_val = expr_eval.evaluate(smem_alloc->size());
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           size_val.hasValue(),
           "Failed to evaluate the size ",
           smem_alloc->size(),
@@ -1034,7 +1029,7 @@ LaunchParams FusionExecutor::computeLaunchParams(
     const int64_t warp_size,
     DataType index_type) {
   FUSER_PERF_SCOPE("FusionExecutor::ComputeLaunchParams");
-  TORCH_INTERNAL_ASSERT(warp_size > 0, "WARP_SIZE should be larger than 0");
+  NVF_ERROR(warp_size > 0, "WARP_SIZE should be larger than 0");
 
   LaunchParams launch_params;
 
@@ -1110,7 +1105,7 @@ LaunchParams FusionExecutor::computeLaunchParams(
   for (auto [p_type, extent] : simplified_parallel_iter_extents) {
     FUSER_PERF_SCOPE("FusionExecutor::ParallelBindingResolution");
     auto val = expr_eval.evaluate(extent);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         val.hasValue(),
         "Tried to evaluate the extent, ",
         extent->toInlineString(),
@@ -1193,7 +1188,7 @@ std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::
   const auto& kernel_summary = kernel->summary();
 
   for (auto alloc : kernel_summary.global_allocations) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         alloc->buffer()->isA<TensorView>(),
         "Cannot allocate global buffers that are not tensors.");
     auto tv = alloc->buffer()->as<TensorView>();
@@ -1229,7 +1224,7 @@ std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::
   FUSER_PERF_SCOPE("FusionExecutor::GetOutbufferInfo");
   const auto kernel = lowered_->kernel();
   std::vector<GlobalBufferInfo> outputs;
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       args.size() == kernel->inputs().size(),
       "kernel arguments length does not match runtime arguments.");
   for (const auto out_i : c10::irange(kernel->outputs().size())) {
@@ -1242,7 +1237,7 @@ std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::
       info.type = at::kFloat;
       info.sizes = {0};
     } else {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           info.tv != nullptr, "Cannot allocate outputs that are not tensors.");
       auto output = out_val->as<TensorView>();
       auto alias_it = std::find_if(
@@ -1302,13 +1297,13 @@ KernelArgumentHolder FusionExecutor::inferOutputSizes(
           fusion->inputs().begin(),
           fusion->inputs().end(),
           fusion->outputs()[out_i]);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           input_it != fusion->inputs().end(),
           "Issue with an input showing up as output but could not find input.");
       auto inp_i = std::distance(fusion->inputs().begin(), input_it);
       ret.push(*args[inp_i]);
     } else {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           fusion->outputs()[out_i]->isA<TensorView>(),
           "Cannot allocate outputs that are not tensors.");
       auto output_tv = fusion->outputs()[out_i]->as<TensorView>();
@@ -1336,7 +1331,7 @@ KernelArgumentHolder FusionExecutor::inferOutputSizes(
 
   for (const auto& [aliased_output_index, aliased_input_index] :
        output_to_input_aliases) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         args[aliased_input_index]->is<at::Tensor>(),
         "alias io only supports tensor");
     *ret[aliased_output_index] = *args[aliased_input_index];
@@ -1350,7 +1345,7 @@ namespace {
 void validateIndexType(
     kir::Kernel* kernel,
     const CompileParams& compile_params) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !compile_params.index_type.has_value() ||
           kernel->indexType() == compile_params.index_type.value(),
       "Kernel index type and compilation index type don't match. Kernel type: ",
@@ -1376,7 +1371,7 @@ void validateCooperativeLaunch(
       launch_params.gdimx() * launch_params.gdimy() * launch_params.gdimz();
   auto max_active_blocks = num_blocks_per_SM *
       at::cuda::getDeviceProperties(device_index)->multiProcessorCount;
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       (int64_t)(max_active_blocks) >= grid_size,
       "Wanted to launch a cooperative kernel, however the number of blocks is greater than ",
       "what can be resident on the GPU at once. Need: ",
@@ -1550,7 +1545,7 @@ void FusionExecutor::recompileKernel(
 }
 
 int64_t FusionExecutor::getAvailableDynamicSmemSize() {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       isCompiled(), "Cannot get dynamic smem size unless kernel is compiled");
   if (!available_dynamic_smem_size_.has_value()) {
     int size = 0;
@@ -1564,7 +1559,7 @@ int64_t FusionExecutor::getAvailableDynamicSmemSize() {
 }
 
 int64_t FusionExecutor::getStaticSmemSize() {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       isCompiled(), "Cannot get static smem size unless kernel is compiled");
   if (!static_smem_size_.has_value()) {
     int size = 0;
@@ -1577,7 +1572,7 @@ int64_t FusionExecutor::getStaticSmemSize() {
 }
 
 void FusionExecutor::validateDynamicSmemSize(int64_t dynamic_smem_size) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       getStaticSmemSize() + dynamic_smem_size < device_smem_limit_,
       "The total shared memory allocation is larger than available memory.",
       " Dynamic size: ",
@@ -1592,7 +1587,7 @@ void FusionExecutor::validateDynamicSmemSize(int64_t dynamic_smem_size) {
 
 int64_t FusionExecutor::ensureAvailableDynamicSmemSize(
     int64_t dynamic_smem_size) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       isCompiled(), "Cannot set dynamic smem size unless kernel is compiled");
   if (dynamic_smem_size > getAvailableDynamicSmemSize()) {
     validateDynamicSmemSize(dynamic_smem_size);
@@ -1616,10 +1611,9 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     CompileParams compile_params,
     std::vector<at::Tensor> outputs) {
   FUSER_PERF_SCOPE("FusionExecutor::RunFusion");
-  TORCH_INTERNAL_ASSERT(isCompiled());
-  TORCH_INTERNAL_ASSERT(
-      fusion_id_ > 0, "Cannot run fusion, it was not compiled.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(isCompiled());
+  NVF_ERROR(fusion_id_ > 0, "Cannot run fusion, it was not compiled.");
+  NVF_ERROR(
       !args.getCacheId().has_value() || outputs.empty(),
       "short cut input cache is not compatible with pre-allocated output");
 
@@ -1635,7 +1629,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   c10::DeviceGuard dg(options_.device);
   auto stream = at::cuda::getCurrentCUDAStream();
   at::cuda::jit::initializeCudaContext();
-  TORCH_INTERNAL_ASSERT(lowered_);
+  NVF_ERROR(lowered_);
 
   // Placeholder for the case where parameter cache is not used
   ExecutorEntry temporary_executor_entry;
@@ -1682,7 +1676,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
         expr_eval);
   } else {
     // TODO: Use validateKernelOutputs
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         outputs.size() == fusion_->outputs().size(),
         __func__,
         " provided number of outputs does not match fusion output");
@@ -1877,7 +1871,7 @@ void FusionExecutor::compileRtc(
     bool structured,
     PrimDataType index_type) {
   FUSER_PERF_SCOPE("ExecutorRunFusion::compileRtc");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       index_type == PrimDataType::Int || index_type == PrimDataType::Int32 ||
           "Invalid index type: ",
       index_type);
@@ -2075,7 +2069,7 @@ void FusionExecutor::deserialize(
     CompileParams compile_params) {
   // See table definition for FusionExecutor in serde/fusion_cache.fbs
 
-  TORCH_INTERNAL_ASSERT(buffer != nullptr, "serde::FusionExecutor is nullptr.");
+  NVF_ERROR(buffer != nullptr, "serde::FusionExecutor is nullptr.");
 
   // Initialize internal fields
   device_smem_limit_ = buffer->device_smem_limit();
@@ -2115,14 +2109,14 @@ void FusionExecutor::deserialize(
           block_size_high_water_mark_,
           save_compiled_binary_);
 
-  TORCH_INTERNAL_ASSERT(isCompiled(), "Failed to deserialize FusionExecutor");
+  NVF_ERROR(isCompiled(), "Failed to deserialize FusionExecutor");
 }
 
 FusionExecutor::ExecutorEntry FusionExecutor::deserialize(
     const serde::ExecutorEntry* buffer) {
   // See table definition for ExecutorEntry in serde/fusion_cache.fbs
 
-  TORCH_INTERNAL_ASSERT(buffer != nullptr, "serde::ExecutorEntry is nullptr.");
+  NVF_ERROR(buffer != nullptr, "serde::ExecutorEntry is nullptr.");
 
   ExecutorEntry entry;
 
@@ -2150,22 +2144,21 @@ FusionExecutor::GlobalBufferInfo FusionExecutor::deserialize(
     const serde::GlobalBufferInfo* buffer) {
   // See table definition for GlobalBufferInfo in serde/fusion_cache.fbs
 
-  TORCH_INTERNAL_ASSERT(
-      buffer != nullptr, "serde::GlobalBufferInfo is nullptr.");
+  NVF_ERROR(buffer != nullptr, "serde::GlobalBufferInfo is nullptr.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       buffer->tv() != -1, "Serialization failed to encode buffer tv position.");
 
-  TORCH_INTERNAL_ASSERT(fusion_ != nullptr, "Fusion is not initialized.");
+  NVF_ERROR(fusion_ != nullptr, "Fusion is not initialized.");
 
   GlobalBufferInfo info;
   if (buffer->is_fusion_output()) {
     auto out_val = fusion_->outputs().at(buffer->tv());
-    TORCH_INTERNAL_ASSERT(out_val != nullptr);
+    NVF_ERROR(out_val != nullptr);
     info.tv = dynamic_cast<TensorView*>(out_val);
   } else {
     auto out_val = kernel()->summary().global_allocations.at(buffer->tv());
-    TORCH_INTERNAL_ASSERT(out_val != nullptr);
+    NVF_ERROR(out_val != nullptr);
     info.tv = dynamic_cast<TensorView*>(out_val->buffer());
   }
 

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <device_lower/lower2device.h>
+#include <exceptions.h>
 #include <executor_params.h>
 #include <executor_utils.h>
 #include <expr_evaluator.h>
@@ -140,7 +141,7 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
       executor_utils::caching::ExecutorCompileTimeInfoCache;
 
   kir::Kernel* kernel() const {
-    TORCH_INTERNAL_ASSERT(lowered_);
+    NVF_ERROR(lowered_);
     return lowered_->kernel();
   }
 
@@ -184,7 +185,7 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
 
   //! Returns the string of the compiled kernel
   std::string kernelString() const {
-    TORCH_INTERNAL_ASSERT(!kernel_code_.empty(), "Kernel code not generated");
+    NVF_ERROR(!kernel_code_.empty(), "Kernel code not generated");
     return kernel_code_;
   }
 

--- a/csrc/executor_kernel_arg.h
+++ b/csrc/executor_kernel_arg.h
@@ -9,6 +9,7 @@
 
 #include <ATen/core/ivalue.h>
 #include <c10/util/Exception.h>
+#include <exceptions.h>
 #include <expr_evaluator.h>
 #include <ir/all_nodes.h>
 #include <serde/fusion_cache_generated.h>

--- a/csrc/executor_params.cpp
+++ b/csrc/executor_params.cpp
@@ -13,22 +13,22 @@
 namespace nvfuser {
 
 void LaunchParams::assertValid() {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       bdimx() * bdimy() * bdimz() > 0 &&
           bdimx() * bdimy() * bdimz() <=
               (int64_t)at::cuda::getCurrentDeviceProperties()
                   ->maxThreadsPerMultiProcessor,
       "Selected invalid number of threads for cuda: ",
       bdimx() * bdimy() * bdimz());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       gdimx() > 0 && gdimx() < (std::int64_t(1) << 32) - 1,
       "Invalid number of blocks in x direction: ",
       gdimx());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       gdimy() > 0 && gdimy() <= 65535,
       "Invalid number of blocks in y direction: ",
       gdimy());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       gdimz() > 0 && gdimz() <= 65535,
       "Invalid number of blocks in z direction: ",
       gdimz());
@@ -55,7 +55,7 @@ void LaunchParams::bind(int64_t val, ParallelType p_type) {
       checkAndSet(val, gdimz_, "gridDim.z");
       break;
     default:
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           false,
           "Tried to bind invalid parallel type in launch config: ",
           p_type);
@@ -78,7 +78,7 @@ int64_t LaunchParams::getDim(ParallelType p_type) const {
     case ParallelType::BIDz:
       return gdimz();
     default:
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           false,
           "Tried to get with invalid parallel type in launch config: ",
           p_type);
@@ -104,7 +104,7 @@ const int64_t& LaunchParams::getRawVal(ParallelType p_type) const {
     case ParallelType::BIDz:
       return gdimz_;
     default:
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           false,
           "Tried to get with invalid parallel type in launch config: ",
           p_type);
@@ -157,7 +157,7 @@ flatbuffers::Offset<serde::LaunchParams> LaunchParams::serialize(
 void LaunchParams::deserialize(const serde::LaunchParams* buffer) {
   // See table definitions for LaunchParams and TensorShape in
   // serde/fusion_cache.fbs
-  TORCH_INTERNAL_ASSERT(buffer != nullptr, "serde::LaunchParams is nullptr.");
+  NVF_ERROR(buffer != nullptr, "serde::LaunchParams is nullptr.");
 
   gdimx_ = buffer->gdimx();
   gdimy_ = buffer->gdimy();

--- a/csrc/executor_params.h
+++ b/csrc/executor_params.h
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #pragma once
+#include <exceptions.h>
 #include <serde/fusion_cache_generated.h>
 #include <type.h>
 
@@ -22,10 +23,10 @@ struct TORCH_CUDA_CU_API CompileParams {
 
   bool operator==(const CompileParams& other) const {
     // Disallow comparison if the index type is nullopt
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         index_type.has_value(),
         "cannot compare as the index type is not defined");
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         other.index_type.has_value(),
         "cannot compare as the other index type is not defined");
     return index_type == other.index_type &&
@@ -104,7 +105,7 @@ class TORCH_CUDA_CU_API LaunchParams {
       const int64_t incoming_val,
       int64_t& class_val,
       std::string val) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         class_val == UNINITIALIZED_VAL || incoming_val == class_val,
         "Tried to set ",
         val,
@@ -114,7 +115,7 @@ class TORCH_CUDA_CU_API LaunchParams {
         incoming_val,
         ", but it was already set and new value does not match.",
         " Thread dims all have to be bound to the same value.");
-    TORCH_CHECK(
+    NVF_CHECK(
         incoming_val > 0,
         "Received a thread binding on ",
         val,

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <exceptions.h>
 
 #include <c10/core/DeviceType.h>
 #include <c10/util/Exception.h>

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -26,7 +26,7 @@ void validateValWithConcreteValue(
     const Val* value,
     const PolymorphicValue& concrete_value) {
   if (auto tv = dynamic_cast<const TensorView*>(value)) {
-    TORCH_CHECK(
+    NVF_CHECK(
         concrete_value.is<at::Tensor>(),
         "Expected ",
         tv->toString(),
@@ -35,7 +35,7 @@ void validateValWithConcreteValue(
     const auto& t = concrete_value.as<at::Tensor>();
     auto expect_dim =
         (int64_t)TensorDomain::noReductions(tv->getMaybeRFactorDomain()).size();
-    TORCH_CHECK(
+    NVF_CHECK(
         t.dim() == expect_dim,
         "Expected ",
         tv->toString(),
@@ -44,7 +44,7 @@ void validateValWithConcreteValue(
         ", but got a tensor of rank ",
         t.dim());
     auto actual_dtype = aten_to_data_type(t.scalar_type());
-    TORCH_CHECK(
+    NVF_CHECK(
         (value->dtype() == DataType::Index && isIntegralType(actual_dtype)) ||
             (value->dtype() == actual_dtype),
         "Expected ",
@@ -54,7 +54,7 @@ void validateValWithConcreteValue(
         ", but got a tensor of dtype ",
         actual_dtype);
     if (tv->isCpuScalar()) {
-      TORCH_CHECK(
+      NVF_CHECK(
           is_cpu_scalar(t),
           "Expected ",
           tv->toString(),
@@ -65,7 +65,7 @@ void validateValWithConcreteValue(
           t.numel(),
           " elements");
     } else {
-      TORCH_CHECK(
+      NVF_CHECK(
           t.is_cuda() || t.is_meta(),
           "Expected ",
           tv->toString(),
@@ -73,7 +73,7 @@ void validateValWithConcreteValue(
           t.device());
     }
   } else {
-    TORCH_CHECK(
+    NVF_CHECK(
         hasCompatibleDataType(concrete_value, value->dtype()),
         "Scalar value is not compatible with the given data type.");
   }
@@ -86,9 +86,9 @@ void ExpressionEvaluator::bind_(
     PolymorphicValue concrete_value,
     bool evaluate_validate) {
   using namespace PolymorphicValue_functions;
-  TORCH_CHECK(concrete_value.hasValue(), "Cannot bind to undefined value");
+  NVF_CHECK(concrete_value.hasValue(), "Cannot bind to undefined value");
   if (value->isConst()) {
-    TORCH_CHECK(
+    NVF_CHECK(
         value->value() == concrete_value,
         "Tried to bind to a constant value: ",
         toString(value->value()),
@@ -102,7 +102,7 @@ void ExpressionEvaluator::bind_(
     auto evaluated_value = evaluate(value);
     using namespace PolymorphicValue_functions;
     auto same = isSame(evaluated_value, concrete_value);
-    TORCH_CHECK(
+    NVF_CHECK(
         same,
         "Tried to bind to a value: ",
         value->toInlineString(),
@@ -115,7 +115,7 @@ void ExpressionEvaluator::bind_(
     const auto& t = concrete_value.as<at::Tensor>();
     auto rfactor_domain =
         TensorDomain::noReductions(tv->getMaybeRFactorDomain());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         t.dim() == (int64_t)rfactor_domain.size(),
         "Expected ",
         tv->toString(),
@@ -147,7 +147,7 @@ void ExpressionEvaluator::bind_(
 void ExpressionEvaluator::bind(
     ParallelType pt,
     PolymorphicValue concrete_value) {
-  TORCH_INTERNAL_ASSERT(isParallelTypeThread(pt));
+  NVF_ERROR(isParallelTypeThread(pt));
   if (precomputed_values_) {
     // Need to bind the thread value to integer machine
     //  in pre-computed mode.
@@ -220,7 +220,7 @@ void ExpressionEvaluator::print() const {
   debug() << "--------------------\n";
 
   for (const auto& kv : known_values_) {
-    TORCH_INTERNAL_ASSERT(!kv.first->isConstScalar());
+    NVF_ERROR(!kv.first->isConstScalar());
     debug() << kv.first << " = " << toString(kv.second) << " ; "
             << *kv.first->getValType() << "\n";
   }
@@ -245,10 +245,10 @@ void ExpressionEvaluator::propagateBoundValuesThroughExactMaps(Fusion* fusion) {
     for (const auto id : *set) {
       auto eval_val = evaluate(id->extent());
       if (eval_val.hasValue()) {
-        TORCH_INTERNAL_ASSERT(eval_val.is<int64_t>(), "Invalid extent value");
+        NVF_ERROR(eval_val.is<int64_t>(), "Invalid extent value");
         int64_t this_size = eval_val.as<int64_t>();
         if (known_size != -1) {
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               known_size == this_size,
               "Conflicting sizes: ",
               known_size,
@@ -275,7 +275,7 @@ void ExpressionEvaluator::propagateBoundValuesThroughExactMaps(Fusion* fusion) {
 
 ExpressionEvaluator ExpressionEvaluator::clone(IrCloner& ir_cloner) const {
   ExpressionEvaluator expr_eval;
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !precomputed_values_,
       "Cannot clone ExpressionEvaluator with bound PrecomputedValues");
   for (const auto& kv : known_values_) {

--- a/csrc/expr_evaluator.h
+++ b/csrc/expr_evaluator.h
@@ -9,6 +9,7 @@
 
 #include <c10/macros/Export.h>
 #include <evaluator_common.h>
+#include <exceptions.h>
 #include <ir/cloner.h>
 #include <ir/interface_nodes.h>
 #include <iter_visitor.h>

--- a/csrc/expr_simplifier.h
+++ b/csrc/expr_simplifier.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 
 #include <vector>

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -10,6 +10,7 @@
 #include <ATen/core/ivalue.h>
 #include <c10/macros/Export.h>
 #include <c10/util/Exception.h>
+#include <exceptions.h>
 
 #include <debug.h>
 #include <executor_params.h>

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1991,6 +1991,7 @@ class FusionSegmentGuard : public NonCopyable {
     narrowToNewSegment(new_inputs, new_outputs);
   }
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~FusionSegmentGuard() {
     FUSER_PERF_SCOPE("~Segmenter::FusionSegmentGuard");
 

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -210,7 +210,7 @@ void SegmentedGroup::finalize() {
   for (auto output : output_vals) {
     if (auto aliased_input = segmented_fusion_->findAlias(output)) {
       // aliasing currently only supported as output to input
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           aliased_input->isFusionInput(),
           "aliased input is not found in the complete fusion");
       if (!input_set.count(aliased_input)) {
@@ -279,7 +279,7 @@ std::unique_ptr<SegmentedFusion> SegmentedFusion::fromCompleteFusion(
     ScheduleHeuristic heuristic,
     const KernelArgumentHolder& runtime_inputs) {
   auto fusion = fusion_ptr.get();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !SegmentCandidateFinder::hasSegmentHints(fusion),
       "SegmentedFusion::fromCompleteFusion cannot be called on a fusion with segment hints!");
 
@@ -439,7 +439,7 @@ std::vector<SegmentedEdge*> getMergedProducerEdges(
     const SegmentedGroup* sg2,
     bool dedup = true) {
   // At least either of sg1 or sg2 must not be null
-  TORCH_INTERNAL_ASSERT(sg1 != nullptr || sg2 != nullptr);
+  NVF_ERROR(sg1 != nullptr || sg2 != nullptr);
   // If either is null, just return the edges of the other group
   if (sg1 == nullptr) {
     return sg2->producer_edges;
@@ -482,7 +482,7 @@ std::vector<SegmentedEdge*> getMergedConsumerEdges(
     const SegmentedGroup* sg1,
     const SegmentedGroup* sg2) {
   // At least either of sg1 or sg2 must not be null
-  TORCH_INTERNAL_ASSERT(sg1 != nullptr || sg2 != nullptr);
+  NVF_ERROR(sg1 != nullptr || sg2 != nullptr);
   // If either is null, just return the edges of the other group
   if (sg1 == nullptr) {
     return sg2->consumer_edges;
@@ -708,7 +708,7 @@ std::vector<Expr*> groupExprPrintSorting(const std::vector<Expr*>& exprs) {
         }
       }
     }
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         expr_added_to_sorted_list,
         "group debug print failed, exprs within given vector not a DAG");
   }
@@ -807,7 +807,7 @@ TensorView* castIntermediateValueInCompleteFusion(
     }
     auto replaced =
         ir_utils::replaceValInExpr(expr, original_fp32_tv, reverted_fp32_tv);
-    TORCH_INTERNAL_ASSERT(replaced != expr);
+    NVF_ERROR(replaced != expr);
     is_replaced = true;
   }
 
@@ -968,7 +968,7 @@ std::vector<SegmentedEdge*> SegmentedFusion::castInputOutputToLowerPrecision(
           edge_tv,
           uses_to_modify,
           force_half_precision_type_);
-      TORCH_INTERNAL_ASSERT(cast_tv != nullptr);
+      NVF_ERROR(cast_tv != nullptr);
       fp32_to_half_cast_map[edge_tv] = cast_tv;
     } else {
       // There was cast insertion for this edge_tv, so we already have
@@ -1017,7 +1017,7 @@ void SegmentedFusion::revertInputOutputPrecisionChanges(
     auto lowered_tv = edge->val;
     auto original_tv = lowered_tv->definition()->inputs().at(0);
     for (auto cast_back_expr : lowered_tv->uses()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           cast_back_expr->isA<UnaryOp>() &&
           cast_back_expr->as<UnaryOp>()->getUnaryOpType() == UnaryOpType::Cast);
       auto same_precision_tv = cast_back_expr->outputs().at(0);
@@ -1125,7 +1125,7 @@ class GroupDependencyAnalysis : public NonCopyable, public SegmenterAnalysis {
 
     GroupSet values_between;
     auto& all_producers_of_consumer = known_producers_of_.at(consumer);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         all_producers_of_consumer->has(producer),
         "Fusion segment: Trying to compute path between two nodes that are not producer-consumer pairs");
 
@@ -1361,7 +1361,7 @@ void GroupDependencyAnalysis::computeAllProducers() {
       to_visit.erase(to_update);
       visited.pushBack(to_update);
     } else {
-      TORCH_INTERNAL_ASSERT(false, "unreachable, original graph not a DAG");
+      NVF_ERROR(false, "unreachable, original graph not a DAG");
     }
   }
 }
@@ -1481,8 +1481,7 @@ void convertInputRfactorsToRoots(Fusion* fusion) {
       }
     }
 
-    TORCH_INTERNAL_ASSERT(
-        new_root_domain.size() == tv->domain()->contiguity().size());
+    NVF_ERROR(new_root_domain.size() == tv->domain()->contiguity().size());
     auto new_td = IrBuilder::create<TensorDomain>(
         new_root_domain, tv->domain()->contiguity());
     replacement_map.emplace(tv->domain(), new_td);
@@ -1516,7 +1515,7 @@ std::unique_ptr<Fusion> SegmentedFusion::makeFusion(SegmentedGroup* sg) {
     auto clone_tv = complete_to_segment_map.clone(inp);
     fusion_segment->addInput(clone_tv);
     if (inp->isDefinitionType<ViewOp>()) {
-      TORCH_INTERNAL_ASSERT(clone_tv != nullptr && clone_tv->isA<TensorView>());
+      NVF_ERROR(clone_tv != nullptr && clone_tv->isA<TensorView>());
       view_tvs.push_back(clone_tv->as<TensorView>());
     }
   }
@@ -1549,7 +1548,7 @@ std::unique_ptr<SegmentedFusion> SegmentCandidateFinder::segment(
   if (fusion) {
     return SegmentCandidateFinder::segment(std::move(fusion), inputs);
   } else {
-    TORCH_INTERNAL_ASSERT(false, "unreachable!");
+    NVF_ERROR(false, "unreachable!");
   }
 }
 
@@ -1613,8 +1612,7 @@ void SegmentCandidateFinder::resetLevels() {
       visit->level_ = std::max(visit->level_, inp->from->level_ + 1);
     }
   }
-  TORCH_INTERNAL_ASSERT(
-      next_to_visit_.empty(), "Error in graph, is not a DAG.");
+  NVF_ERROR(next_to_visit_.empty(), "Error in graph, is not a DAG.");
 }
 
 // Disconect group from neighbors, and return edges that were disconnected
@@ -1627,7 +1625,7 @@ std::unordered_set<SegmentedEdge*> SegmentCandidateFinder::disconnectGroup(
     auto from = edge->from;
     auto& from_edges = from->consumer_edges;
     auto from_edge_it = std::find(from_edges.begin(), from_edges.end(), edge);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         from_edge_it != from_edges.end(), "Could not find edge to remove.");
     from_edges.erase(from_edge_it);
   }
@@ -1637,8 +1635,7 @@ std::unordered_set<SegmentedEdge*> SegmentCandidateFinder::disconnectGroup(
     auto to = edge->to;
     auto& to_edges = to->producer_edges;
     auto to_edge_it = std::find(to_edges.begin(), to_edges.end(), edge);
-    TORCH_INTERNAL_ASSERT(
-        to_edge_it != to_edges.end(), "Could not find edge to remove.");
+    NVF_ERROR(to_edge_it != to_edges.end(), "Could not find edge to remove.");
     to_edges.erase(to_edge_it);
   }
 
@@ -1684,7 +1681,7 @@ void SegmentCandidateFinder::eraseGroups(
 SegmentedGroup* SegmentCandidateFinder::mergeNodes() {
   SegmentedGroup* last_merged = nullptr;
   auto it = to_merge_.begin();
-  TORCH_INTERNAL_ASSERT(to_merge_.size() % 2 == 0);
+  NVF_ERROR(to_merge_.size() % 2 == 0);
   while (it != to_merge_.end()) {
     auto group1 = *it++;
     auto group2 = *it++;
@@ -1787,7 +1784,7 @@ SegmentedGroup* SegmentCandidateFinder::mergeNodes() {
 //  a clean up and share the implementations.
 SegmentedGroup* SegmentCandidateFinder::mergeAllGivenGroups(
     const std::vector<SegmentedGroup*>& groups_to_merge) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !groups_to_merge.empty(),
       "fusion segment :(mergeAllGivenGroups) tried to merge no groups")
 
@@ -1919,7 +1916,7 @@ class FusionSegmentGuard : public NonCopyable {
       std::vector<Val*> outputs)
       : fusion_(fusion) {
     FUSER_PERF_SCOPE("Segmenter::FusionSegmentGuard");
-    TORCH_INTERNAL_ASSERT(fusion_ != nullptr);
+    NVF_ERROR(fusion_ != nullptr);
 #ifndef NDEBUG
     num_original_exprs_ = fusion_->exprs().size();
     original_tvs_ = ir_utils::allTvs(fusion_);
@@ -2013,14 +2010,14 @@ class FusionSegmentGuard : public NonCopyable {
     // can't just compare Expr pointers as we replace Exprs. For
     // now, just make sure there are the same number of exprs.
     auto num_current_exprs = fusion_->exprs().size();
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         num_original_exprs_ == num_current_exprs,
         "Failed to revert temporary changes. Expected: ",
         num_original_exprs_,
         ", actual: ",
         num_current_exprs);
     auto current_tvs = ir_utils::allTvs(fusion_);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         original_tvs_ == current_tvs, "Failed to revert temporary changes.");
 #endif
   }
@@ -2029,7 +2026,7 @@ class FusionSegmentGuard : public NonCopyable {
   void narrowToNewSegment(
       const std::vector<Val*>& new_inputs,
       const std::vector<Val*>& new_outputs) {
-    TORCH_INTERNAL_ASSERT(fusion_ != nullptr);
+    NVF_ERROR(fusion_ != nullptr);
 
     old_inputs_ = fusion_->inputs();
     old_outputs_ = fusion_->outputs();
@@ -2052,7 +2049,7 @@ class FusionSegmentGuard : public NonCopyable {
   }
 
   void restoreOriginalSegment() {
-    TORCH_INTERNAL_ASSERT(fusion_ != nullptr);
+    NVF_ERROR(fusion_ != nullptr);
 
     // If both old inputs and outpus are empty, narrowing must have
     // not been done
@@ -2379,7 +2376,7 @@ bool TranslateApplicableWelford::wouldTranslateToPersistent(
 
   // Make sure all welford ops come from the same complete fusion
   auto fusion = orignal_welfords[0]->fusion();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       std::all_of(
           orignal_welfords.begin(),
           orignal_welfords.end(),
@@ -2474,7 +2471,7 @@ void TranslateApplicableWelford::translateSingleWelford(WelfordOp* welford) {
   // i.e. an r-factor product.
   // This translation works on un-scheduled fusions so
   //  shouldn't expect to see this.
-  TORCH_INTERNAL_ASSERT(welford->inN()->isOneInt());
+  NVF_ERROR(welford->inN()->isOneInt());
 
   // Grab the inputs and outputs of the welford
   auto in_val = welford->in()->as<TensorView>();
@@ -2493,7 +2490,7 @@ void TranslateApplicableWelford::translateSingleWelford(WelfordOp* welford) {
   const auto& out_root = out_avg->getRootDomain();
   std::vector<int> red_axes;
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       in_root.size() == out_root.size(),
       "Invalid root domains of Welford input and output.",
       " Input: ",
@@ -2670,10 +2667,9 @@ class CombineReductions {
       SegmentedGroup* second_group) {
     // This is part of ReductionCombine pass, and we should only call this
     // function on a pair of reduction/normalization groups
-    TORCH_INTERNAL_ASSERT(
-        group_reduction_signature_map_.at(first_group)
-            ->sameAs(group_reduction_signature_map_.at(second_group)));
-    TORCH_INTERNAL_ASSERT(first_group != second_group);
+    NVF_ERROR(group_reduction_signature_map_.at(first_group)
+                  ->sameAs(group_reduction_signature_map_.at(second_group)));
+    NVF_ERROR(first_group != second_group);
     // Get the group dependency data from segment finder
     auto dependency_analysis = segment_candidate_finder_->getGroupDependency();
 
@@ -2753,10 +2749,9 @@ class CombineReductions {
     // This is part of ReductionCombine pass, and we should only call this
     // function on a pair of
     //  reduction/normalization groups
-    TORCH_INTERNAL_ASSERT(
-        group_reduction_signature_map_.at(first_group)
-            ->sameAs(group_reduction_signature_map_.at(second_group)));
-    TORCH_INTERNAL_ASSERT(first_group != second_group);
+    NVF_ERROR(group_reduction_signature_map_.at(first_group)
+                  ->sameAs(group_reduction_signature_map_.at(second_group)));
+    NVF_ERROR(first_group != second_group);
 
     auto dependency_analysis = segment_candidate_finder_->getGroupDependency();
 
@@ -2821,7 +2816,7 @@ class CombineReductions {
           //  no path to first group
           continue;
         }
-        TORCH_INTERNAL_ASSERT(!dependency_analysis->isProducerOf(
+        NVF_ERROR(!dependency_analysis->isProducerOf(
             producer_of_first_group, second_group));
         for (auto second_consumer_edge : common_producer->consumer_edges) {
           auto producer_of_second_group = second_consumer_edge->to;
@@ -2834,7 +2829,7 @@ class CombineReductions {
             //  there's no path to second group
             continue;
           }
-          TORCH_INTERNAL_ASSERT(!dependency_analysis->isProducerOf(
+          NVF_ERROR(!dependency_analysis->isProducerOf(
               producer_of_second_group, first_group));
           // At this point we should have a pair of valid candidates,final check
           // is to see if the combined group
@@ -3005,7 +3000,7 @@ class CombineReductions {
         }
 
         if (new_signature != nullptr) {
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               signature == nullptr || !signature->has_reduction_ ||
                   !new_signature->has_reduction_ ||
                   signature->sameAs(new_signature.get()),
@@ -3019,7 +3014,7 @@ class CombineReductions {
     template <typename REDUCTION = ReductionOp>
     ReductionSignature(REDUCTION* rop) {
       auto out_tv = rop->out()->template as<TensorView>();
-      TORCH_INTERNAL_ASSERT(out_tv != nullptr);
+      NVF_ERROR(out_tv != nullptr);
       has_reduction_ = out_tv->hasReduction();
       auto& root_domain = out_tv->getRootDomain();
       root_domain_size_ = root_domain.size();
@@ -3172,7 +3167,7 @@ std::optional<SegmentedGroup::NeighborGroup> PreferredMergeCandidatePicker::
   auto consumer_of_indexed_id = ir_utils::getConsumerOfIndexedProducerID(expr);
 
   // There must be a consumer ID unless it's a Select expr
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       consumer_of_indexed_id != nullptr || expr->isA<SelectOp>(),
       "Consumer of indexed ID not found: ",
       expr->toString());
@@ -3191,7 +3186,7 @@ std::optional<SegmentedGroup::NeighborGroup> PreferredMergeCandidatePicker::
 
   // Not sure this could happen. Just assert for now.
   if (producer_edge_it == group->producer_edges.end()) {
-    TORCH_INTERNAL_ASSERT(false, "Unexpected");
+    NVF_ERROR(false, "Unexpected");
     return std::nullopt;
   }
 
@@ -3204,7 +3199,7 @@ std::optional<SegmentedGroup::NeighborGroup> PreferredMergeCandidatePicker::
 bool SegmentCandidateFinder::codeGenSupportedMerge(
     SegmentedGroup* group1,
     SegmentedGroup* group2) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       areDirectlyConnected(group1, group2),
       "only support testing immediate producer-consumer groups");
   auto h = tryMerge(segmented_fusion_.get(), runtime_info_, group1, group2);
@@ -3216,7 +3211,7 @@ bool SegmentCandidateFinder::codeGenSupportedMerge(
 ScheduleHeuristic SegmentCandidateFinder::deriveHeuristic(
     SegmentedGroup* group) {
   auto h = tryMerge(segmented_fusion_.get(), runtime_info_, group);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       h.has_value(), "Can not find a scheduler to schedule fusion segment");
   return h.value();
 }
@@ -3572,7 +3567,7 @@ void SegmentCandidateFinder::finalMerge() {
     if (to_merge_.empty()) {
       merged_nodes = false;
     } else {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           to_merge_.size() == 2, "merging more than 2 nodes in final iter");
       mergeNodes();
     }
@@ -3776,7 +3771,7 @@ HeuristicSummary* SegmentedFusion::getCachedHeuristicDataFor(
 void SegmentedFusion::setCachedHeuristicDataFor(
     SegmentedGroup* group,
     std::unique_ptr<HeuristicSummary> data) {
-  TORCH_INTERNAL_ASSERT(!heuristic_summary_cache_.count(group));
+  NVF_ERROR(!heuristic_summary_cache_.count(group));
   heuristic_summary_cache_[group] = std::move(data);
 }
 
@@ -3810,16 +3805,16 @@ void SegmentedFusion::validateDAG() const {
         // group from the visited group set
         if (!dfs_stack.empty()) {
           auto& parent_frame = dfs_stack.back();
-          TORCH_INTERNAL_ASSERT(!parent_frame.empty());
+          NVF_ERROR(!parent_frame.empty());
           auto parent_group = parent_frame.back();
           parent_frame.pop_back();
           // Remove parent group from visited
-          TORCH_INTERNAL_ASSERT(visited_groups.erase(parent_group) == 1);
+          NVF_ERROR(visited_groups.erase(parent_group) == 1);
         }
       } else {
         // DFS traversal to one of the frontier groups
         auto group_to_visit = cur_frontiers.back();
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             visited_groups.count(group_to_visit) == 0,
             "Cycle detected at ",
             group_to_visit);
@@ -3860,7 +3855,7 @@ void SegmentedFusion::validateDisjoint() const {
       if (ir_utils::isScalarOp(expr)) {
         continue;
       }
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           exprs.insert(expr).second,
           "Duplicate expression detected: ",
           expr->toString());
@@ -3909,7 +3904,7 @@ class ForceHalfAnnotation : public IterVisitor {
         [&cast_to_type, &other_half_type](auto* val) {
           auto dtype = val->getDataType().value();
           if (cast_to_type) {
-            TORCH_INTERNAL_ASSERT(
+            NVF_ERROR(
                 other_half_type != dtype,
                 "Mix of BFloat16 and Float16 in the same graph is not supported.");
           }

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <debug.h>
+#include <exceptions.h>
 #include <fusion.h>
 #include <ir/base_nodes.h>
 #include <kernel_cache.h>
@@ -213,7 +214,7 @@ class TORCH_CUDA_CU_API SegmentedGroup {
 
   //! Assign Id for this group
   void setID(int id) {
-    TORCH_INTERNAL_ASSERT(group_id_ == -1);
+    NVF_ERROR(group_id_ == -1);
     group_id_ = id;
   }
 
@@ -250,7 +251,7 @@ class TORCH_CUDA_CU_API FusionHeuristics {
 
   //! Place a scheduler entry on the list. Applies to segmented fusion only.
   void emplaceBack(SchedulerEntryOwningPtr&& pt) {
-    TORCH_INTERNAL_ASSERT(is_segmented_);
+    NVF_ERROR(is_segmented_);
     heuristics_.emplace_back(std::move(pt));
   }
 
@@ -261,7 +262,7 @@ class TORCH_CUDA_CU_API FusionHeuristics {
 
   //! Returns the single scheduler for a complete fusion.
   SchedulerEntry* singleKernelHeuristics() {
-    TORCH_INTERNAL_ASSERT(!is_segmented_);
+    NVF_ERROR(!is_segmented_);
     return heuristics_.begin()->get();
   }
 
@@ -587,19 +588,19 @@ class TORCH_CUDA_CU_API SegmentCandidateFinder {
   std::unordered_set<SegmentedEdge*> disconnectGroup(SegmentedGroup* group);
 
   std::vector<SegmentedGroup*>& groups() {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         segmented_fusion_ != nullptr, "Segment finder not owinging any fusion");
     return segmented_fusion_->groups();
   }
 
   std::vector<SegmentedEdge*>& edges() {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         segmented_fusion_ != nullptr, "Segment finder not owinging any fusion");
     return segmented_fusion_->edges();
   }
 
   Fusion* completeFusion() {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         segmented_fusion_ != nullptr, "Segment finder not owinging any fusion");
     return segmented_fusion_->completeFusion();
   }

--- a/csrc/graph_fuser.cpp
+++ b/csrc/graph_fuser.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <exceptions.h>
 #include <torch/csrc/jit/passes/cuda_graph_fuser.h>
 
 #include <c10/util/Exception.h>
@@ -69,7 +70,7 @@ torch::jit::Value* broadcastSizes(at::ArrayRef<torch::jit::Value*> sizes) {
 }
 
 torch::jit::Value* createConditionalConstant(torch::jit::Node* profile_ivalue) {
-  TORCH_INTERNAL_ASSERT(profile_ivalue->kind() == at::prim::profile_ivalue);
+  NVF_ERROR(profile_ivalue->kind() == at::prim::profile_ivalue);
 
   auto graph = profile_ivalue->owningGraph();
 
@@ -636,7 +637,7 @@ struct CudaGraphFuser {
       bchunk = promoteChunkToBroadcastingChunk(chunk);
     }
     size_t nchunks = bchunk->i(at::attr::chunks);
-    TORCH_INTERNAL_ASSERT(nchunks > 0, "number of chunks cannot be zero");
+    NVF_ERROR(nchunks > 0, "number of chunks cannot be zero");
     torch::jit::WithInsertPoint guard(bchunk->next());
 
     std::vector<torch::jit::Value*> producer_chunk_outputs;
@@ -973,7 +974,7 @@ struct CudaGraphFuser {
         continue;
       }
       if (n->kind() == at::prim::ConstantChunk) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input()) > 0,
             "buildShapeExpressions failed at accessing input shapes");
         torch::jit::Node* sizes_node = graph->insertNode(
@@ -1001,7 +1002,7 @@ struct CudaGraphFuser {
       if (reduction_ops.find(n->kind()) != reduction_ops.end()) {
         // TODO: expand support to wire non-constant inputs, this is currently
         // blocked by profiling executor not capable of profiling scalar inputs.
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             n->input(1)->node()->kind() == at::prim::Constant &&
                 n->input(2)->node()->kind() == at::prim::Constant,
             "only supports reduction axes and keepdim being constant");
@@ -1013,7 +1014,7 @@ struct CudaGraphFuser {
             graph->createClone(n->input(2)->node(), map_inputs);
         graph->insertNode(in2_const);
 
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input(0)) > 0,
             "buildShapeExpressions failed at accessing input shapes");
         std::vector<torch::jit::Value*> inputs = {
@@ -1027,7 +1028,7 @@ struct CudaGraphFuser {
       }
       // TODO: output(1) & output(2) should also be marked
       if (n->kind() == at::aten::native_layer_norm) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input(0)) > 0,
             "buildShapeExpressions failed at accessing input shapes");
         shape_of.emplace(n->output(0), shape_of.at(n->input(0)));
@@ -1035,7 +1036,7 @@ struct CudaGraphFuser {
       }
       // TODO: output(1) & output(2) should also be marked
       if (n->kind() == at::aten::native_layer_norm_backward) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input(0)) > 0,
             "buildShapeExpressions failed at accessing input shapes");
         shape_of.emplace(n->output(0), shape_of.at(n->input(0)));
@@ -1050,7 +1051,7 @@ struct CudaGraphFuser {
       // TODO: output(1) & output(2) should also be marked
       if (n->kind() == at::aten::native_batch_norm ||
           n->kind() == at::aten::_batch_norm_impl_index) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input(0)) > 0,
             "buildShapeExpressions failed at accessing input shapes");
         shape_of.emplace(n->output(0), shape_of.at(n->input(0)));
@@ -1058,7 +1059,7 @@ struct CudaGraphFuser {
       }
       // TODO: output(1) & output(2) should also be marked
       if (n->kind() == at::aten::native_batch_norm_backward) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input(0)) > 0,
             "buildShapeExpressions failed at accessing input shapes");
         shape_of.emplace(n->output(0), shape_of.at(n->input(0)));
@@ -1070,7 +1071,7 @@ struct CudaGraphFuser {
         continue;
       }
       if (n->kind() == at::aten::_batch_norm_impl_index_backward) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input(1)) > 0,
             "buildShapeExpressions failed at accessing input shapes");
         shape_of.emplace(n->output(0), shape_of.at(n->input(1)));
@@ -1082,7 +1083,7 @@ struct CudaGraphFuser {
         continue;
       }
       if (n->kind() == at::aten::native_dropout) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input(0)) > 0,
             "buildShapeExpressions failed at accessing input shapes");
         shape_of.emplace(n->output(0), shape_of.at(n->input(0)));
@@ -1090,10 +1091,10 @@ struct CudaGraphFuser {
         continue;
       }
       if (n->kind() == at::aten::unsqueeze_copy) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input(0)) > 0,
             "buildShapeExpressions failed at accessing input shapes");
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             n->input(1)->node()->kind() == at::prim::Constant,
             "only supports unsqueeze axes being constant");
         torch::jit::Node* dim_const =
@@ -1111,16 +1112,16 @@ struct CudaGraphFuser {
         continue;
       }
       if (n->kind() == at::aten::squeeze_copy) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input(0)) > 0,
             "buildShapeExpressions failed at accessing input shapes");
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             n->inputs().size() == 2 || n->inputs().size() == 1,
             "aten::squeeze_copy expects one or two inputs");
         std::vector<torch::jit::Value*> inputs = {shape_of.at(n->input(0))};
 
         if (n->inputs().size() == 2) {
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               n->input(1)->node()->kind() == at::prim::Constant,
               "only supports squeeze axes being constant");
           torch::jit::Node* dim_const =
@@ -1138,12 +1139,12 @@ struct CudaGraphFuser {
         continue;
       }
       if (n->kind() == at::aten::index_select) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(n->input(0)) > 0,
             "buildShapeExpressions failed at accessing input shapes");
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             n->inputs().size() == 3, "aten::index_select expects three inputs");
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             n->input(1)->node()->kind() == at::prim::Constant,
             "only supports selected_dim being constant");
         torch::jit::Node* dim_const =
@@ -1165,7 +1166,7 @@ struct CudaGraphFuser {
         return v->type()->isSubtypeOf(*at::TensorType::get());
       });
       auto shapes = fmap(tensor_inputs, [&](torch::jit::Value* v) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             shape_of.count(v) > 0,
             "buildShapeExpressions failed at accessing input shapes");
         return shape_of.at(v);
@@ -1372,22 +1373,22 @@ struct CudaGraphFuser {
 
 void removeCudaFusionPathForGuardNode(torch::jit::Node* n) {
   auto uses = n->output()->uses();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       uses.size() == 1,
       "CudaFusionGuard should only be used once by prim::If or prim::ListConstruct");
   torch::jit::Node* if_node = uses[0].user;
   if (if_node->kind() != at::prim::If) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         if_node->kind() == at::prim::ListConstruct,
         "CudaFusionGuard is not used by neither prim::If or prim::ListConstruct");
     // break all inputs so producer prim::CudaFusionGuard can be removed later
     if_node->removeAllInputs();
     auto list_use = if_node->output()->uses();
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         list_use.size() == 1 && list_use[0].user->kind() == at::aten::all,
         "prim::ListConstruct should only be used once by aten::all");
     auto all_use = list_use[0].user->output()->uses();
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         all_use.size() == 1 && all_use[0].user->kind() == at::prim::If,
         "aten::all should only be used once by prim::If");
     if_node = all_use[0].user;
@@ -1396,21 +1397,21 @@ void removeCudaFusionPathForGuardNode(torch::jit::Node* n) {
   auto fall_back_graph = if_node->blocks()[1];
   torch::jit::Node* fallback_node = nullptr;
   for (auto fb_n : fall_back_graph->nodes()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         fb_n->kind() == at::prim::FallbackGraph,
         "CudaFusionGuard fallback path should only have single fallback node");
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         fallback_node == nullptr,
         "CudaFusionGuard fallback path should only have single fallback node");
     fallback_node = fb_n;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       fallback_node != nullptr,
       "CudaFusionGuard fallback path found no fallback node");
   fallback_node->moveBefore(n);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       fallback_node->outputs().size() == if_node->outputs().size(),
       "CudaFusionGuard fallback should have same number of outputs as with nesting if block");
 
@@ -1537,7 +1538,7 @@ torch::jit::Value* guardView(
 
   auto view_sizes_constant_list =
       torch::jit::constant_as<c10::List<int64_t>>(view->inputs().back());
-  TORCH_INTERNAL_ASSERT(view_sizes_constant_list.has_value());
+  NVF_ERROR(view_sizes_constant_list.has_value());
   std::vector<int64_t> view_sizes = view_sizes_constant_list->vec();
   // 2. Get constraints for self tensor and view_sizes
   auto constraints =
@@ -1550,7 +1551,7 @@ torch::jit::Value* guardView(
 
   // 4. Create CudaFusionViewGuard using input tensor, profile_ivalue
   // for view_sizes list, and constraints
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       fusion_value_to_runtime_size.find(self_value) !=
           fusion_value_to_runtime_size.end(),
       "Failed to find runtime size for fusion value:\t",
@@ -1680,7 +1681,7 @@ void guardFusionGroup(
       // val->uses() before hand.
       for (const auto& use : uses) {
         // re-wire inputs and remove conditional constant nodes;
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             use.user->kind() == at::prim::Constant,
             "profile_ivalue at index: ",
             offset,
@@ -1718,7 +1719,7 @@ void guardFusionGroup(
       // remove inputs to fusion, and update check logic for fallback
       auto profiled_ival = fusion->input(offset)->node()->input();
       auto const_o = createConditionalConstant(fusion->input(offset)->node());
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           const_o,
           "profile_ivalue node are expected to have profile information, at node: ",
           *fusion->input(offset)->node());
@@ -1741,7 +1742,7 @@ void guardFusionGroup(
       } else if (fusion->input(offset)->node()->hasAttribute(
                      torch::jit::Symbol::attr("profiled_reduction_size"))) {
         // TODO(profile_size): check sizes here with special size comparison op
-        // TORCH_INTERNAL_ASSERT(false, "not implemented yet");
+        // NVF_ERROR(false, "not implemented yet");
         ivalue_check =
             fusion->owningGraph()
                 ->create(
@@ -1762,9 +1763,9 @@ void guardFusionGroup(
         auto subgraph_arg = fusion_graph->inputs()[offset];
         auto constant = subgraph_arg->uses().front().user->output();
 
-        TORCH_INTERNAL_ASSERT(!constant->uses().empty());
+        NVF_ERROR(!constant->uses().empty());
         auto view = constant->uses().front().user;
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             view->kind() == at::aten::view_copy ||
             view->kind() == at::aten::_reshape_copy);
 
@@ -1800,7 +1801,7 @@ void guardFusionGroup(
 
       // step b. remove the extra dependency inside fusion;
       for (const auto& use : fusion_graph->inputs()[offset]->uses()) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             use.user->kind() == at::prim::Constant,
             "profile_ivalue at index: ",
             offset,
@@ -1966,7 +1967,7 @@ void alterBatchNormImplIndexBackward(torch::jit::Node* node) {
       // TODO: we can actually support it by adding an extra inputs to the
       // subgraph
       // TODO: assert on empty buffer
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           byte_input->node() == subgraph->param_node(),
           "Assumption that reserve input to aten::_batch_norm_impl_index_backward comes from forward graph is broken");
       bn_buffer_in_indices.emplace(byte_input->offset());
@@ -2050,7 +2051,7 @@ void alterBatchNormImpls(torch::jit::Block* block) {
 //   ... (uses %2, %4, but never reference to %3 any more)
 void removeOutputUsedOnlyInDtype(torch::jit::Node* fusion_node) {
   auto fusion_block = fusion_node->owningBlock();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       fusion_block->owningNode() &&
           fusion_block->owningNode()->kind() == at::prim::If,
       "CudaFusionGroup should be inside `prim::CudaFusionGuard` / `prim::If`");
@@ -2073,10 +2074,9 @@ void removeOutputUsedOnlyInDtype(torch::jit::Node* fusion_node) {
         // update fusion_block to output profiled scalar type
         auto fusion_output = fusion_block->outputs()[i];
         auto tensor_type = fusion_output->type()->cast<at::TensorType>();
-        TORCH_INTERNAL_ASSERT(
-            tensor_type, "non tensor fed to dtype is not supported");
+        NVF_ERROR(tensor_type, "non tensor fed to dtype is not supported");
         auto scalar_type = tensor_type->scalarType();
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             scalar_type.has_value(),
             "ScalarType should be static for Tensors in fusion for amp optimization");
         auto type_const = fusion_block->owningGraph()->insertConstant(
@@ -2227,7 +2227,7 @@ void decomposeLinearOps(torch::jit::Block* block) {
     }
 
     auto out_size = mat0_size.value();
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         mat1_size->size() == 2 || mat1_size->size() == 1,
         "weight dimension for linear is expected to be 1 or 2, but got: ",
         mat1_size->size());
@@ -2468,7 +2468,7 @@ void mutateNode(
 // For the given CudaFusionGroup, separate nested views and remove any unused,
 // intermediate views
 void separateNestedViews(torch::jit::Node* cuda_fusion_group) {
-  TORCH_INTERNAL_ASSERT(cuda_fusion_group->kind() == at::prim::CudaFusionGroup);
+  NVF_ERROR(cuda_fusion_group->kind() == at::prim::CudaFusionGroup);
 
   auto isView = [](torch::jit::Node* node) {
     static std::unordered_set<c10::Symbol> alias_op_set(

--- a/csrc/grouped_reduction.cpp
+++ b/csrc/grouped_reduction.cpp
@@ -19,7 +19,7 @@ namespace {
 #define GROUP_REDUCTION_CHECK(error_on_failure, condition, ...) \
   do {                                                          \
     if (error_on_failure) {                                     \
-      TORCH_CHECK(condition, ##__VA_ARGS__);                    \
+      NVF_CHECK(condition, ##__VA_ARGS__);                      \
     } else {                                                    \
       if (!(condition)) {                                       \
         return false;                                           \
@@ -53,11 +53,11 @@ bool validateReductionGrouping(
     const std::vector<Val*>& inputs,
     const std::vector<Val*>& outputs,
     bool error_on_failure) {
-  TORCH_INTERNAL_ASSERT(inputs.size() == outputs.size());
-  TORCH_INTERNAL_ASSERT(!inputs.empty());
+  NVF_ERROR(inputs.size() == outputs.size());
+  NVF_ERROR(!inputs.empty());
 
   auto fusion = dynamic_cast<Fusion*>(outputs[0]->container());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       fusion != nullptr, "Grouping of reductions must be done within a Fusion");
 
   ExactRootDomainMap exact_map(fusion);
@@ -205,7 +205,7 @@ bool validateReductionGrouping(
 bool groupReductions(
     const std::vector<TensorView*>& reduction_outputs,
     bool error_on_failure) {
-  TORCH_CHECK(!reduction_outputs.empty(), "No tensor is given");
+  NVF_CHECK(!reduction_outputs.empty(), "No tensor is given");
 
   auto container = reduction_outputs[0]->container();
 
@@ -234,8 +234,7 @@ bool groupReductions(
         reduction_out->definition()->toString());
     // Fused reduction is only enabled during the lowering, so at this
     // point it should be false.
-    TORCH_INTERNAL_ASSERT(
-        !rop->isAllreduce(), "Invalid ReductionOp: ", rop->toString());
+    NVF_ERROR(!rop->isAllreduce(), "Invalid ReductionOp: ", rop->toString());
     op_types.at(i) = rop->getReductionOpType();
     init_vals.at(i) = rop->init();
     outputs.at(i) = rop->out();

--- a/csrc/grouped_reduction.h
+++ b/csrc/grouped_reduction.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 
 namespace nvfuser {

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -57,7 +57,7 @@ int getProducerHaloOffset(
   // reduction axis. Since this function is only used for indexing
   // producer tensors, where reduction axes are skipped, producer_id
   // should never be a reduction axis.
-  TORCH_INTERNAL_ASSERT(it != p2c.end());
+  NVF_ERROR(it != p2c.end());
   IterDomain* consumer_id = it->second;
 
   const auto& halo_map = GpuLower::current()->haloInfo();
@@ -137,7 +137,7 @@ Val* getProducerOffsetWithGather(
     auto concrete_window_id = gpu_lower->caMap()->getConcreteMappedID(
         window_id, IdMappingMode::EXACT);
     auto concrete_2_ref_it = concrete_to_ref_map.find(concrete_window_id);
-    TORCH_INTERNAL_ASSERT(concrete_2_ref_it != concrete_to_ref_map.end());
+    NVF_ERROR(concrete_2_ref_it != concrete_to_ref_map.end());
     window_id = concrete_2_ref_it->second;
   }
 
@@ -237,7 +237,7 @@ Val* getProducerIndexWithGather(
     ++consumer_axis;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       consumer_axis >= 0 &&
           consumer_axis < (int)gather_op->windowShape().size(),
       "Invalid consumer axis",
@@ -313,7 +313,7 @@ Val* getProducerIndexWithPartialSplit(
 
   auto diff = SimplifyingIrBuilder::subExpr(consumer_offset, producer_offset);
   // We currently only allow constant offsetting
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       diff->isConstScalar(),
       "Invalid partial split, must be a constant value.");
 
@@ -338,7 +338,7 @@ Val* getTensorBaseAddress(TensorView* tv) {
       return output;
     }
     default:
-      TORCH_CHECK(false, "Unsupported memory type ", memtype);
+      NVF_CHECK(false, "Unsupported memory type ", memtype);
   }
 }
 
@@ -351,7 +351,7 @@ bool IndexCompute::hasUnswitchedDependentDomains(IterDomain* id) const {
 }
 
 void IndexCompute::initializeUnswitchDomainMap() {
-  TORCH_INTERNAL_ASSERT(unswitched_domain_map_.empty());
+  NVF_ERROR(unswitched_domain_map_.empty());
   for (auto id : unswitched_leaf_domains_) {
     auto concrete_id = maybeGetExactMapConcreteID(id);
     unswitched_domain_map_.emplace(
@@ -385,7 +385,7 @@ void IndexCompute::updateUnswitchedDomains(Expr* expr) {
     }
   } else {
     // Suppress a clang-tidy warning
-    TORCH_INTERNAL_ASSERT(expr != nullptr);
+    NVF_ERROR(expr != nullptr);
     // Propagate the unswitch info if any of outputs is
     // unswitched. Unlike the split case, the propagated info
     // is just reset as there's no obvious way to back-propagate the
@@ -475,7 +475,7 @@ bool IndexCompute::isModuloInvalidUnswitchedIndex(
   }
 
   for (const auto& unswitched_domain_list : unswitched_domain_map_it->second) {
-    TORCH_INTERNAL_ASSERT(!unswitched_domain_list.empty());
+    NVF_ERROR(!unswitched_domain_list.empty());
 
     // If the stride is a multiple of the inner extent, the leaf
     // unswitched index remains to be a valid maximum index as the
@@ -550,7 +550,7 @@ void IndexCompute::handle(Merge* merge) {
         {merge->out()}, td_->maybeAllocation());
 
     // Shouldn't hit this, but don't want to segfault if somehow we do.
-    TORCH_INTERNAL_ASSERT(!input_ids.empty());
+    NVF_ERROR(!input_ids.empty());
 
     // Try to find the last non broadcast entry to put the index in if it's a
     // contiguous merge. This isn't strictly necessary but there's implicit
@@ -742,7 +742,7 @@ void IndexCompute::handle(Resize* resize) {
 
 void IndexCompute::dispatch(Expr* e) {
   auto is_expected_type = e->isOneOf<Split, Merge, Swizzle2D, Resize>();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       is_expected_type, "Invalid expr type found in transform traversal.");
   updateUnswitchedDomains(e);
   BackwardVisitor::dispatch(e);
@@ -791,8 +791,7 @@ IndexCompute::IndexCompute(
   const auto& within_contig = contig_finder.withinContigIDs();
   for (auto contig_id : contig_ids_) {
     if (index_map_.find(contig_id) != index_map_.end()) {
-      TORCH_INTERNAL_ASSERT(
-          within_contig.find(contig_id) != within_contig.end());
+      NVF_ERROR(within_contig.find(contig_id) != within_contig.end());
       for (auto id : within_contig.at(contig_id)) {
         index_map_.erase(id);
       }
@@ -821,8 +820,7 @@ IndexCompute::IndexCompute(
 }
 
 void IndexCompute::run(const LoopIndexing& loop_indexing) {
-  TORCH_INTERNAL_ASSERT(
-      concrete_id_pass_, "concrete pass only for this option");
+  NVF_ERROR(concrete_id_pass_, "concrete pass only for this option");
   // Apply loop swizzles if there are any that outputs to
   //  the loop domains.
   // Currently only support loop swizzles that directly output
@@ -1052,7 +1050,7 @@ class UpdateLeafIndices : public IterVisitor {
     // Nothing need to be done when mappings for the output axes
     // already exist.
     if (index_map_.find(outer_id) != index_map_.end()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           index_map_.find(inner_id) != index_map_.end(),
           "Outer exists but inner not found");
       return;
@@ -1063,7 +1061,7 @@ class UpdateLeafIndices : public IterVisitor {
       //  propagation pass and current implementation does not yet
       //  support reduciton on swizzled iterdomains, so un-indexed
       //  reduction iterdomains are just ignored for now.
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           in_id->isReduction(), "Undefined index for ", in_id->toString());
       return;
     }
@@ -1088,7 +1086,7 @@ class UpdateLeafIndices : public IterVisitor {
       //  propagation pass and current implementation does not yet
       //  support reduciton on swizzled iterdomains, so un-indexed
       //  reduction iterdomains are just ignored for now.
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           outer_id->isReduction() && inner_id->isReduction(),
           "Undefined index for ",
           outer_id->toString(),
@@ -1103,9 +1101,9 @@ class UpdateLeafIndices : public IterVisitor {
       return;
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         index_map_.find(outer_id) != index_map_.end(), "Outer ID not found");
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         index_map_.find(inner_id) != index_map_.end(), "Inner ID not found");
 
     index_map_[out_id] = SimplifyingIrBuilder::addExpr(
@@ -1247,7 +1245,7 @@ void IndexSwizzle::handle(Swizzle2D* swizzle_2d) {
   auto out_x_it = index_map_.find(out_x_id);
   auto out_y_it = index_map_.find(out_y_id);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       out_x_it != index_map_.end() && out_y_it != index_map_.end(),
       "Swizzle output indices were not propagated through");
 
@@ -1355,7 +1353,7 @@ bool isParallelLoopIndexSubstitutedAsZero(
   // conditions are already validated, but just double checking.
 
   if (loop_id->getParallelType() != producer_id->getParallelType()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         (loop_id->isBlockDim() && !producer_id->isBlockDim()) ||
             (loop_id->isThreadDim() && !producer_id->isThread()),
         "Found invalid parallelization that should have been detected by the parallel validation: loop ID: ",
@@ -1510,7 +1508,7 @@ std::unordered_map<IterDomain*, IterDomain*> invertOneToOneMap(
   std::unordered_map<IterDomain*, IterDomain*> inverted;
   for (const auto& kv : map) {
     bool inserted = inverted.emplace(kv.second, kv.first).second;
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         inserted,
         "Multiple mappings to the same value detected: ",
         kv.second->toString());
@@ -1549,8 +1547,7 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
-      alloc_dom.size() == producer_tv->domain()->contiguity().size());
+  NVF_ERROR(alloc_dom.size() == producer_tv->domain()->contiguity().size());
   Val* cur_contig_stride = GpuLower::current()->kernel()->oneVal();
   for (const auto i : c10::irange(alloc_dom.size())) {
     auto dim = alloc_dom.size() - i - 1;
@@ -1561,9 +1558,9 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
     auto producer_dim_contiguity = producer_tv->domain()->contiguity().at(dim);
     if (alloc_dom[dim]->isBroadcast()) {
       strides[dim] = cur_contig_stride->fusion()->zeroVal();
-      TORCH_INTERNAL_ASSERT(!producer_dim_contiguity.has_value());
+      NVF_ERROR(!producer_dim_contiguity.has_value());
     } else if (!producer_dim_contiguity.has_value()) {
-      TORCH_INTERNAL_ASSERT(false, "Expected value for dimension contiguity");
+      NVF_ERROR(false, "Expected value for dimension contiguity");
     } else if (producer_dim_contiguity.value()) {
       // If contig, used the stored stride which may be the previous
       // dimensions stride * previous dimensions size
@@ -1773,7 +1770,7 @@ std::vector<Val*> Index::getNonGlobalProducerStridedIndices(
     auto override_it = override_index.find(alloc_dom[i]);
     const bool is_overriden = override_it != override_index.end();
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         is_overriden || index_map.find(alloc_dom[i]) != index_map.end(),
         "Couldn't find allocation mapping for ",
         producer_tv->toString(),
@@ -1906,7 +1903,7 @@ std::vector<Val*> Index::getStrides(TensorView* tv) {
     }
   }
 
-  TORCH_INTERNAL_ASSERT(alloc_dom.size() == tv->domain()->contiguity().size());
+  NVF_ERROR(alloc_dom.size() == tv->domain()->contiguity().size());
   Val* cur_contig_stride = GpuLower::current()->kernel()->oneVal();
   for (const auto i : c10::irange(alloc_dom.size())) {
     auto dim = alloc_dom.size() - i - 1;
@@ -1917,9 +1914,9 @@ std::vector<Val*> Index::getStrides(TensorView* tv) {
     auto dim_contiguity = tv->domain()->contiguity().at(dim);
     if (alloc_dom[dim]->isBroadcast()) {
       strides[dim] = cur_contig_stride->fusion()->zeroVal();
-      TORCH_INTERNAL_ASSERT(!dim_contiguity.has_value());
+      NVF_ERROR(!dim_contiguity.has_value());
     } else if (!dim_contiguity.has_value()) {
-      TORCH_INTERNAL_ASSERT(false, "Expected value for dimension contiguity");
+      NVF_ERROR(false, "Expected value for dimension contiguity");
     } else if (dim_contiguity.value()) {
       // If contig, used the stored stride which may be the previous
       // dimensions stride * previous dimensions size
@@ -1956,7 +1953,7 @@ std::vector<Val*> Index::getConsumerAllocationIndices(
       continue;
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         indexing.indexMap().find(alloc_dom[i]) != indexing.indexMap().end(),
         "Couldn't find allocation mapping for ",
         tv->toString(),
@@ -2072,7 +2069,7 @@ std::vector<Val*> Index::getProducerAllocationIndices(
       alloc_ind = producer_indexing.indexMap().at(alloc_dom[i]);
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         alloc_ind != nullptr,
         "Couldn't find allocation mapping for ",
         producer_tv->toString(),
@@ -2140,7 +2137,7 @@ std::vector<Val*> Index::getGlobalConsumerStridedIndices(
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       strided_inds.size() == consumer_tv->getMaybeAllocationDomain().size());
 
   return strided_inds;
@@ -2155,7 +2152,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
   const auto gpu_lower = GpuLower::current();
   // At now, only ScatterOp set override_index, and the output of ScatterOp
   // is on global memory, so in this method, the override_index must be empty.
-  TORCH_INTERNAL_ASSERT(override_index.empty());
+  NVF_ERROR(override_index.empty());
   auto consumer_indexing_from_idgraph = getTensorIndexFromIdGraph(
       loops,
       rotated_loops,
@@ -2198,7 +2195,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
       }
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         index_map.find(alloc_dom[i]) != index_map.end(),
         "Couldn't find allocation mapping for ",
         consumer_tv->toString(),
@@ -2222,7 +2219,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
         continue;
       }
 
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           index_map.find(alloc_dom[j]) != index_map.end(),
           "Couldn't find allocation mapping for ",
           consumer_tv->toString(),
@@ -2259,7 +2256,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
   // the prologue loop, strided_inds ends up having one more
   // index, so it's just much simpler to check here before adding the
   // additional index for double buffering.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       strided_inds.size() == consumer_tv->getMaybeAllocationDomain().size());
 
   if (consumer_tv->isDoubleBuffered() || consumer_tv->isCircularBuffered()) {
@@ -2519,7 +2516,7 @@ std::vector<PredicateDomainInfo> getPredicateContigIds(
 
     auto contig_id_it = contig_finder.allocToIndexedID().find(root_id);
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         contig_id_it != contig_finder.allocToIndexedID().end(),
         "Error in predicate contiguity analysis, missing index for root ",
         root_id->toString());
@@ -2620,7 +2617,7 @@ std::pair<Val*, Val*> getStartAndStopOffsetsForShift(
     TensorView* consumer_tv,
     IterDomain* consumer_id,
     bool padding_predicate) {
-  TORCH_INTERNAL_ASSERT(consumer_id != nullptr);
+  NVF_ERROR(consumer_id != nullptr);
 
   auto shift_expr = dynamic_cast<ShiftOp*>(consumer_tv->definition());
 
@@ -2660,7 +2657,7 @@ std::pair<Val*, Val*> getStartAndStopOffsetsForGather(
     const std::unordered_map<IterDomain*, Val*>& ref_start_index_map,
     const std::unordered_map<IterDomain*, Val*>& ref_stop_index_map,
     bool padding_predicate) {
-  TORCH_INTERNAL_ASSERT(consumer_id != nullptr);
+  NVF_ERROR(consumer_id != nullptr);
 
   // Adjustment is not necessary if not gather. Even so, padding
   // predicate does not need any adjustment.
@@ -2742,8 +2739,8 @@ std::pair<Val*, Val*> getStartAndStopOffsetsForGather(
         consumer_stop_offset, producer_stop_offset);
   }
 
-  TORCH_INTERNAL_ASSERT(start_offset != nullptr);
-  TORCH_INTERNAL_ASSERT(stop_offset != nullptr);
+  NVF_ERROR(start_offset != nullptr);
+  NVF_ERROR(stop_offset != nullptr);
 
   return {start_offset, stop_offset};
 }
@@ -2760,7 +2757,7 @@ std::pair<Val*, Val*> getStartAndStopLimitOffsets(
     bool intemediate_domain_pred) {
   const auto gpu_lower = GpuLower::current();
 
-  TORCH_INTERNAL_ASSERT(consumer_id != nullptr);
+  NVF_ERROR(consumer_id != nullptr);
 
   Val* start_limit = consumer_id->start();
   Val* stop_limit = SimplifyingIrBuilder::negExpr(consumer_id->stopOffset());
@@ -2851,7 +2848,7 @@ std::pair<Val*, Val*> getStartAndStopOffsets(
     // accommodate the addition of halo to the loop stop. See the
     // comment in getPredicateIndexingFromIdGraph as well.
     if (unswitch) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !padding_predicate, "Unswitch should not use the padding predicate");
       auto stop_unswitch_offset =
           getUnswitchStopOffset(consumer_id, consumer_tv);
@@ -2970,7 +2967,7 @@ std::unordered_map<IterDomain*, Val*> updateInitialLoopIndexMap(
     const std::unordered_map<IterDomain*, Val*>& initial_loop_index_map,
     const IndexMagicZeroInfo& magic_zero_info) {
   if (magic_zero_info.original_loop_index != nullptr) {
-    TORCH_INTERNAL_ASSERT(magic_zero_info.protected_loop_index != nullptr);
+    NVF_ERROR(magic_zero_info.protected_loop_index != nullptr);
     auto concrete_loop_id = GpuLower::current()->caMap()->getConcreteMappedID(
         magic_zero_info.loop_id, IdMappingMode::EXACT);
     auto updated_map = initial_loop_index_map;
@@ -3170,7 +3167,7 @@ Val* Index::eye(
     DataType dtype) {
   auto indices =
       Index::getConsumerPerDimLogicalIndex(consumer_tv, loops, rotated_loops);
-  TORCH_INTERNAL_ASSERT(indices.size() == 2);
+  NVF_ERROR(indices.size() == 2);
   auto result = maybeCastOp(dtype, eq(indices[0], indices[1]));
   GpuLower::current()->commonScalarMap().hoistScalar(result, loops);
   return result;

--- a/csrc/index_compute.h
+++ b/csrc/index_compute.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <iter_visitor.h>
 #include <root_domain_map.h>
 

--- a/csrc/inlining.cpp
+++ b/csrc/inlining.cpp
@@ -217,7 +217,7 @@ FindMappedPositions::FindMappedPositions(
   if (reference_pos < 0) {
     reference_pos += int64_t(reference->nDims()) + 1;
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       reference_pos >= 0 && reference_pos <= int64_t(reference->nDims()),
       "Invalid axis received ",
       reference_pos,
@@ -259,7 +259,7 @@ void FindMappedPositions::propagateP2C(TensorView* from, TensorView* to) {
 
 void FindMappedPositions::propagateSibling(TensorView* from, TensorView* to) {
   auto from_pos = output_.at(from);
-  TORCH_CHECK(
+  NVF_CHECK(
       TransformReplay::fullSelfMatching(to, from),
       "Transformations in siblings ",
       from,

--- a/csrc/inlining.h
+++ b/csrc/inlining.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/interface_nodes.h>
 #include <maxinfo_propagator.h>
 #include <transform_replay.h>

--- a/csrc/instrumentation.cpp
+++ b/csrc/instrumentation.cpp
@@ -25,7 +25,7 @@ Trace::Trace() {
   const char* trace_filename = getNvFuserEnv("TRACE");
   if (trace_filename != nullptr) {
     log_file_ = fopen(trace_filename, "w");
-    TORCH_CHECK(log_file_ != nullptr, "Can't open trace file");
+    NVF_CHECK(log_file_ != nullptr, "Can't open trace file");
 
     // Disable the file stream buffering, since it may result
     // in torn writes in multi-threaded tracing

--- a/csrc/instrumentation.h
+++ b/csrc/instrumentation.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <utils.h>
 
 #include <nvToolsExt.h>

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -47,28 +47,28 @@ void Statement::setName(IrBuilderPasskey, StmtNameType name) {
 }
 
 Val* Statement::asVal() {
-  TORCH_INTERNAL_ASSERT(isVal(), "Cannot cast to Val as this is not a Val.");
+  NVF_ERROR(isVal(), "Cannot cast to Val as this is not a Val.");
   return this->as<Val>();
 }
 
 Expr* Statement::asExpr() {
-  TORCH_INTERNAL_ASSERT(isExpr(), "Cannot cast to Expr as this is not a Expr.");
+  NVF_ERROR(isExpr(), "Cannot cast to Expr as this is not a Expr.");
   return this->as<Expr>();
 }
 
 bool Statement::lessThan(const Statement* stmt1, const Statement* stmt2) {
-  TORCH_INTERNAL_ASSERT(stmt1 != nullptr);
-  TORCH_INTERNAL_ASSERT(stmt2 != nullptr);
+  NVF_ERROR(stmt1 != nullptr);
+  NVF_ERROR(stmt2 != nullptr);
   return stmt1->name() < stmt2->name();
 }
 
 std::string Statement::toString(int indent_size) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false, "toString for IR node ", typeid(*this).name(), " is not defined");
 }
 
 std::string Statement::toInlineString(int indent_size) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false,
       "toInlineString for IR node ",
       typeid(*this).name(),
@@ -76,13 +76,13 @@ std::string Statement::toInlineString(int indent_size) const {
 }
 
 Fusion* Statement::fusion() const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ir_container_->isA<Fusion>(), "Statement does not belong to a fusion.");
   return ir_container_->as<Fusion>();
 }
 
 kir::Kernel* Statement::kernel() const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ir_container_->isA<kir::Kernel>(),
       "Statement does not belong to a kernel.");
   return ir_container_->as<kir::Kernel>();
@@ -207,7 +207,7 @@ bool Val::isConstInt() const {
 }
 
 int64_t Val::evaluateInt() {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ir_utils::dependenciesSatisfied(this),
       "Cannot get Int of not const values through IR nodes, must use runtime ExpressionEvaluator.");
 
@@ -217,7 +217,7 @@ int64_t Val::evaluateInt() {
 
   ExpressionEvaluator ee;
   auto evaluated_val = ee.evaluate(this);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       evaluated_val.hasValue(),
       "Detected a const integer but failed to infer its value: ",
       toInlineString());
@@ -225,7 +225,7 @@ int64_t Val::evaluateInt() {
 }
 
 double Val::evaluateDouble() {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ir_utils::dependenciesSatisfied(this),
       "Cannot get Double of not const doubles through IR nodes, must use runtime ExpressionEvaluator.");
 
@@ -235,14 +235,14 @@ double Val::evaluateDouble() {
 
   ExpressionEvaluator ee;
   auto evaluated_val = ee.evaluate(this);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       evaluated_val.hasValue(),
       "Detected a const integer but failed to infer its value.");
   return evaluated_val.as<double>();
 }
 
 bool Val::evaluateBool() {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ir_utils::dependenciesSatisfied(this),
       "Cannot get Bool of not const bools through IR nodes, must use runtime ExpressionEvaluator.");
 
@@ -252,7 +252,7 @@ bool Val::evaluateBool() {
 
   ExpressionEvaluator ee;
   auto evaluated_val = ee.evaluate(this);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       evaluated_val.hasValue(),
       "Detected a const integer but failed to infer its value.");
   return evaluated_val.as<bool>();
@@ -318,14 +318,13 @@ bool Val::isFalse() const {
 }
 
 std::optional<DataType> Val::getDataType() const {
-  TORCH_INTERNAL_ASSERT(
-      dtype_ != DataType::Null, "Value does not have a data type.");
+  NVF_ERROR(dtype_ != DataType::Null, "Value does not have a data type.");
   return dtype_;
 }
 
 bool Val::isProducerOf(const Val* other) const {
-  TORCH_INTERNAL_ASSERT(other != nullptr);
-  TORCH_INTERNAL_ASSERT(container() == other->container());
+  NVF_ERROR(other != nullptr);
+  NVF_ERROR(container() == other->container());
 
   if (definition() == nullptr) {
     return false;
@@ -386,9 +385,9 @@ std::string Expr::getGraphvizLabel() const {
 }
 
 void Expr::checkConcretization(Val* old_val, Val* new_val) const {
-  TORCH_CHECK(old_val, "Pre-concretized value was null");
-  TORCH_CHECK(new_val, "Concretized value is null");
-  TORCH_CHECK(
+  NVF_CHECK(old_val, "Pre-concretized value was null");
+  NVF_CHECK(new_val, "Concretized value is null");
+  NVF_CHECK(
       old_val->vtype() == new_val->vtype(),
       "Concretization must not change ValType");
 }
@@ -423,14 +422,12 @@ bool Expr::sameAs(const Statement* other) const {
 }
 
 kir::Predicate* Expr::predicate() const {
-  TORCH_INTERNAL_ASSERT(
-      container()->isA<kir::Kernel>(), "Function invalid for fusion.");
+  NVF_ERROR(container()->isA<kir::Kernel>(), "Function invalid for fusion.");
   return predicate_;
 }
 
 void Expr::setPredicate(kir::Predicate* predicate) {
-  TORCH_INTERNAL_ASSERT(
-      container()->isA<kir::Kernel>(), "Function invalid for fusion.");
+  NVF_ERROR(container()->isA<kir::Kernel>(), "Function invalid for fusion.");
   predicate_ = predicate;
 }
 
@@ -441,14 +438,12 @@ Expr* Expr::withPredicate(kir::Predicate* predicate) {
 }
 
 kir::Predicate* Expr::writePredicate() const {
-  TORCH_INTERNAL_ASSERT(
-      container()->isA<kir::Kernel>(), "Function invalid for fusion.");
+  NVF_ERROR(container()->isA<kir::Kernel>(), "Function invalid for fusion.");
   return write_predicate_;
 }
 
 void Expr::setWritePredicate(kir::Predicate* write_predicate) {
-  TORCH_INTERNAL_ASSERT(
-      container()->isA<kir::Kernel>(), "Function invalid for fusion.");
+  NVF_ERROR(container()->isA<kir::Kernel>(), "Function invalid for fusion.");
   write_predicate_ = write_predicate;
 }
 
@@ -461,7 +456,7 @@ Expr* Expr::withWritePredicate(kir::Predicate* predicate) {
 std::vector<PolymorphicValue> Expr::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false,
       "`evaluate` method for expression ",
       getOpString(),

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -10,6 +10,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/macros/Export.h>
 #include <c10/util/Exception.h>
+#include <exceptions.h>
 
 #include <ir/builder_passkey.h>
 #include <polymorphic_value.h>
@@ -228,7 +229,7 @@ class TORCH_CUDA_CU_API Val : public Statement {
         dtype_(std::move(_dtype)),
         value_(std::move(_value)) {
     if (value_.hasValue()) {
-      TORCH_CHECK(
+      NVF_CHECK(
           hasCompatibleDataType(value_, dtype_),
           "Scalar value is not compatible with the given data type ",
           dtype_,
@@ -409,7 +410,7 @@ class TORCH_CUDA_CU_API Val : public Statement {
   bool sameAs(const Statement* other) const override;
 
   void setEvaluatorIndex(int to) {
-    TORCH_INTERNAL_ASSERT(evaluator_index_ == -1);
+    NVF_ERROR(evaluator_index_ == -1);
     evaluator_index_ = to;
   }
 
@@ -620,13 +621,13 @@ class TORCH_CUDA_CU_API Expr : public Statement {
 
   // TODO: Add Fusion passkey
   void addInput(Val* input) {
-    TORCH_INTERNAL_ASSERT(input != nullptr);
+    NVF_ERROR(input != nullptr);
     inputs_.push_back(input);
   }
 
   // TODO: Add Fusion passkey
   void addOutput(Val* output) {
-    TORCH_INTERNAL_ASSERT(output != nullptr);
+    NVF_ERROR(output != nullptr);
     outputs_.push_back(output);
   }
 

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -23,7 +23,7 @@ Val* IrBuilder::newScalar(DataType dtype) {
 }
 
 Val* IrBuilder::newArithmeticExpr(BinaryOpType op_type, Val* lhs, Val* rhs) {
-  TORCH_CHECK(
+  NVF_CHECK(
       lhs != nullptr && rhs != nullptr,
       "Either lhs or rhs is a nullptr in newArithmeticExpr.");
 
@@ -43,8 +43,7 @@ Val* IrBuilder::newArithmeticExpr(BinaryOpType op_type, Val* lhs, Val* rhs) {
   if (lhs->dtype() != rhs->dtype()) {
     dtype = promoteType(lhs->dtype(), rhs->dtype());
     if (isPointerType(lhs->dtype()) || isPointerType(rhs->dtype())) {
-      TORCH_INTERNAL_ASSERT(
-          op_type == BinaryOpType::Add || op_type == BinaryOpType::Sub);
+      NVF_ERROR(op_type == BinaryOpType::Add || op_type == BinaryOpType::Sub);
     }
   }
   auto result = newScalar(dtype);
@@ -54,7 +53,7 @@ Val* IrBuilder::newArithmeticExpr(BinaryOpType op_type, Val* lhs, Val* rhs) {
 }
 
 Val* IrBuilder::newLogicExpr(BinaryOpType op_type, Val* lhs, Val* rhs) {
-  TORCH_CHECK(
+  NVF_CHECK(
       lhs != nullptr && rhs != nullptr,
       "Either lhs or rhs is a nullptr in newLogicExpr.");
   auto result = newScalar(DataType::Bool);
@@ -64,59 +63,59 @@ Val* IrBuilder::newLogicExpr(BinaryOpType op_type, Val* lhs, Val* rhs) {
 }
 
 Val* IrBuilder::whereExpr(Val* pred, Val* lhs, Val* rhs) {
-  TORCH_CHECK(
+  NVF_CHECK(
       pred != nullptr && lhs != nullptr && rhs != nullptr,
       "Either pred, lhs, or rhs is a nullptr in whereExpr.");
-  TORCH_CHECK(lhs->dtype() == rhs->dtype(), "Incompatible operand types");
+  NVF_CHECK(lhs->dtype() == rhs->dtype(), "Incompatible operand types");
   auto result = newScalar(lhs->dtype());
   IrBuilder::create<TernaryOp>(TernaryOpType::Where, result, pred, lhs, rhs);
   return result;
 }
 
 Val* IrBuilder::negExpr(Val* val) {
-  TORCH_CHECK(val != nullptr, "val is a nullptr in negExpr.");
+  NVF_CHECK(val != nullptr, "val is a nullptr in negExpr.");
   auto result = newScalar(val->dtype());
   IrBuilder::create<UnaryOp>(UnaryOpType::Neg, result, val);
   return result;
 }
 
 Val* IrBuilder::logicalNotExpr(Val* val) {
-  TORCH_CHECK(val != nullptr, "val is a nullptr in logicalNotExpr.");
+  NVF_CHECK(val != nullptr, "val is a nullptr in logicalNotExpr.");
   auto result = newScalar(val->dtype());
   IrBuilder::create<UnaryOp>(UnaryOpType::LogicalNot, result, val);
   return result;
 }
 
 Val* IrBuilder::bitwiseNotExpr(Val* val) {
-  TORCH_CHECK(val != nullptr, "val is a nullptr in bitwiseNotExpr.");
+  NVF_CHECK(val != nullptr, "val is a nullptr in bitwiseNotExpr.");
   auto result = newScalar(val->dtype());
   IrBuilder::create<UnaryOp>(UnaryOpType::BitwiseNot, result, val);
   return result;
 }
 
 Val* IrBuilder::derefExpr(Val* val) {
-  TORCH_CHECK(val != nullptr, "val is a nullptr in derefExpr.");
+  NVF_CHECK(val != nullptr, "val is a nullptr in derefExpr.");
   auto result = newScalar(*(std::get<PointerType>(val->dtype().type).type));
   IrBuilder::create<UnaryOp>(UnaryOpType::Dereference, result, val);
   return result;
 }
 
 Val* IrBuilder::absExpr(Val* val) {
-  TORCH_CHECK(val != nullptr, "val is a nullptr in absExpr.");
+  NVF_CHECK(val != nullptr, "val is a nullptr in absExpr.");
   auto result = newScalar(val->dtype());
   IrBuilder::create<UnaryOp>(UnaryOpType::Abs, result, val);
   return result;
 }
 
 Val* IrBuilder::setExpr(Val* val) {
-  TORCH_CHECK(val != nullptr, "val is a nullptr in setExpr.");
+  NVF_CHECK(val != nullptr, "val is a nullptr in setExpr.");
   auto result = newScalar(val->dtype());
   IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, result, val);
   return result;
 }
 
 Val* IrBuilder::maybeCastExpr(DataType dtype, Val* val) {
-  TORCH_CHECK(val != nullptr, "val is a nullptr in castExpr.");
+  NVF_CHECK(val != nullptr, "val is a nullptr in castExpr.");
   if (val->dtype() == dtype) {
     return val;
   }
@@ -126,7 +125,7 @@ Val* IrBuilder::maybeCastExpr(DataType dtype, Val* val) {
 }
 
 Val* IrBuilder::addressExpr(Val* val) {
-  TORCH_CHECK(val != nullptr, "val is a nullptr in addressExpr.");
+  NVF_CHECK(val != nullptr, "val is a nullptr in addressExpr.");
   auto result = newScalar(
       DataType(PointerType{std::make_shared<DataType>(val->dtype())}));
   IrBuilder::create<UnaryOp>(UnaryOpType::Address, result, val);
@@ -134,7 +133,7 @@ Val* IrBuilder::addressExpr(Val* val) {
 }
 
 NamedScalar* IrBuilder::setExprNamedScalar(const std::string& name, Val* val) {
-  TORCH_CHECK(val != nullptr, "val is a nullptr in setExprNamedScalar.");
+  NVF_CHECK(val != nullptr, "val is a nullptr in setExprNamedScalar.");
   auto result = IrBuilder::create<NamedScalar>(name, val->dtype());
   IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, result, val);
   return result;
@@ -402,7 +401,7 @@ Val* SimplifyingIrBuilder::modExpr(Val* lhs, Val* rhs) {
 Val* SimplifyingIrBuilder::logicalAndExpr(Val* lhs, Val* rhs) {
   auto lhs_scalar = dynamic_cast<Val*>(lhs);
   auto rhs_scalar = dynamic_cast<Val*>(rhs);
-  TORCH_INTERNAL_ASSERT(!(lhs_scalar == nullptr && rhs_scalar == nullptr));
+  NVF_ERROR(!(lhs_scalar == nullptr && rhs_scalar == nullptr));
 
   if (lhs == nullptr) {
     return rhs_scalar;
@@ -439,7 +438,7 @@ Val* SimplifyingIrBuilder::logicalAndExpr(Val* lhs, Val* rhs) {
 Val* SimplifyingIrBuilder::logicalOrExpr(Val* lhs, Val* rhs) {
   auto lhs_scalar = dynamic_cast<Val*>(lhs);
   auto rhs_scalar = dynamic_cast<Val*>(rhs);
-  TORCH_INTERNAL_ASSERT(!(lhs_scalar == nullptr && rhs_scalar == nullptr));
+  NVF_ERROR(!(lhs_scalar == nullptr && rhs_scalar == nullptr));
 
   if (lhs == nullptr) {
     return rhs_scalar;
@@ -476,7 +475,7 @@ Val* SimplifyingIrBuilder::logicalOrExpr(Val* lhs, Val* rhs) {
 Val* SimplifyingIrBuilder::bitwiseAndExpr(Val* lhs, Val* rhs) {
   auto lhs_scalar = dynamic_cast<Val*>(lhs);
   auto rhs_scalar = dynamic_cast<Val*>(rhs);
-  TORCH_INTERNAL_ASSERT(!(lhs_scalar == nullptr && rhs_scalar == nullptr));
+  NVF_ERROR(!(lhs_scalar == nullptr && rhs_scalar == nullptr));
 
   if (lhs == nullptr) {
     return rhs_scalar;
@@ -517,7 +516,7 @@ Val* SimplifyingIrBuilder::bitwiseAndExpr(Val* lhs, Val* rhs) {
 Val* SimplifyingIrBuilder::bitwiseOrExpr(Val* lhs, Val* rhs) {
   auto lhs_scalar = dynamic_cast<Val*>(lhs);
   auto rhs_scalar = dynamic_cast<Val*>(rhs);
-  TORCH_INTERNAL_ASSERT(!(lhs_scalar == nullptr && rhs_scalar == nullptr));
+  NVF_ERROR(!(lhs_scalar == nullptr && rhs_scalar == nullptr));
 
   if (lhs == nullptr) {
     return rhs_scalar;
@@ -608,7 +607,7 @@ Val* SimplifyingIrBuilder::gcdExpr(Val* lhs, Val* rhs) {
 }
 
 Val* SimplifyingIrBuilder::whereExpr(Val* pred, Val* lhs, Val* rhs) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       pred->dtype() == DataType::Bool,
       "Where requires a predicate as an input, but received");
 

--- a/csrc/ir/builder.h
+++ b/csrc/ir/builder.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <ir/builder_passkey.h>
 #include <utils.h>
@@ -28,8 +29,7 @@ class TORCH_CUDA_CU_API IrBuilder {
   static T* create(Args&&... args) {
     auto container = FusionGuard::getCurFusion();
     // return create<T>(container, std::forward<Args>(args)...);
-    TORCH_INTERNAL_ASSERT(
-        container != nullptr, "Need an active container to build IR.");
+    NVF_ERROR(container != nullptr, "Need an active container to build IR.");
     T* node = new T(IrBuilderPasskey(container), std::forward<Args>(args)...);
 
     container->registerStmt(IrBuilderPasskey(container), node);
@@ -41,8 +41,7 @@ class TORCH_CUDA_CU_API IrBuilder {
   //! constructor and registering with the container
   template <class T, class... Args>
   static T* create(IrContainer* container, Args&&... args) {
-    TORCH_INTERNAL_ASSERT(
-        container != nullptr, "Need an active container to build IR.");
+    NVF_ERROR(container != nullptr, "Need an active container to build IR.");
     T* node = new T(IrBuilderPasskey(container), std::forward<Args>(args)...);
 
     container->registerStmt(IrBuilderPasskey(container), node);
@@ -104,8 +103,7 @@ class TORCH_CUDA_CU_API IrBuilder {
   template <typename T>
   static Val* arrayExpr(std::vector<T> members) {
     if constexpr (std::is_same_v<T, Val*>) {
-      TORCH_INTERNAL_ASSERT(
-          !members.empty(), "Cannot create an array with no members.");
+      NVF_ERROR(!members.empty(), "Cannot create an array with no members.");
       auto in_dtype = members.at(0)->dtype();
       auto out_dtype =
           ArrayType{std::make_shared<DataType>(in_dtype), members.size()};

--- a/csrc/ir/cloner.cpp
+++ b/csrc/ir/cloner.cpp
@@ -30,17 +30,17 @@ Statement* IrCloner::clone(const Statement* statement) {
     // The base cloning constructor (Statement) should have
     // registered the new node. Failure to do so indicates
     // that something went horribly wrong.
-    TORCH_INTERNAL_ASSERT(new_node != nullptr);
-    TORCH_INTERNAL_ASSERT(clones_map_[statement] == new_node);
+    NVF_ERROR(new_node != nullptr);
+    NVF_ERROR(clones_map_[statement] == new_node);
 
     return new_node;
   }
 }
 
 void IrCloner::registerClone(const Statement* src, Statement* clone) {
-  TORCH_CHECK(src != nullptr);
-  TORCH_CHECK(clone != nullptr);
-  TORCH_CHECK(clones_map_.insert({src, clone}).second);
+  NVF_CHECK(src != nullptr);
+  NVF_CHECK(clone != nullptr);
+  NVF_CHECK(clones_map_.insert({src, clone}).second);
 }
 
 Statement* IrCloner::handle(const Statement* s) {
@@ -54,7 +54,7 @@ TensorView* RecomputeTv::recompute(
 
   // Disallow recomputation of inputs or outputs. User would have to be aware of
   // these changes and informed they happened somehow.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !tv->isFusionInput(),
       "Cannot recompute buffers that are inputs of the fusion.");
 
@@ -81,9 +81,9 @@ TensorView* RecomputeTv::recompute(
   const auto const_tv = tv;
   // Find the recomputed tensor from the cloner
   auto clone_it = replicator.clones_map_.find(const_tv);
-  TORCH_INTERNAL_ASSERT(clone_it != replicator.clones_map_.end());
+  NVF_ERROR(clone_it != replicator.clones_map_.end());
   auto cloned_val = clone_it->second;
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       cloned_val->isA<TensorView>(),
       "Cloned value is somehow not a tensor view.");
 

--- a/csrc/ir/cloner.h
+++ b/csrc/ir/cloner.h
@@ -9,6 +9,7 @@
 
 #include <c10/macros/Export.h>
 #include <dispatch.h>
+#include <exceptions.h>
 #include <ir/builder.h>
 
 #include <tuple>
@@ -134,11 +135,11 @@ class TORCH_CUDA_CU_API RecomputeTv : private IrCloner {
 //! Clone an IR node, forwarding the arguments to the IrCloner constructor.
 template <class T>
 T* IrBuilder::clone(const T* src, IrCloner* ir_cloner) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ir_cloner != nullptr,
       "Cannot use create when a cloner object is set. Use clone.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ir_cloner->container() != nullptr,
       "Cloner doesn't have a valid container to store cloned object.");
 

--- a/csrc/ir/container.cpp
+++ b/csrc/ir/container.cpp
@@ -126,7 +126,7 @@ void IrContainer::registerExpr(IrBuilderPasskey, Expr* expr) {
 }
 
 void IrContainer::removeExpr(Expr* expr) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       exprs_.find(expr) != exprs_.end(),
       "Wanted to remove an expression but it doesn't exist in this container.");
   auto expr_in_deque = std::find_if(
@@ -134,7 +134,7 @@ void IrContainer::removeExpr(Expr* expr) {
       exprs_up_.end(),
       [expr](std::unique_ptr<Expr>& expr_up) { return expr_up.get() == expr; });
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       expr_in_deque != exprs_up_.end(),
       "Wanted to remove an expression but its unique ptr is missing.");
 
@@ -153,7 +153,7 @@ void IrContainer::removeVal(Val* val) {
     return;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       vals_.find(val) != vals_.end(),
       "Wanted to remove a value but it doesn't exist in this container.");
   auto val_in_deque = std::find_if(
@@ -161,7 +161,7 @@ void IrContainer::removeVal(Val* val) {
         return val_up.get() == val;
       });
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       val_in_deque != vals_up_.end(),
       "Wanted to remove a value but its unique ptr is missing.");
 
@@ -213,18 +213,18 @@ bool IrContainer::inContainer(const Statement* stmt) const {
     return false;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       stmt->container() == this,
       "Container claims to own stmt, but stmt disagrees.");
 
   Statement* nonconst_stmt = const_cast<Statement*>(stmt); // NOLINT
   if (stmt->isExpr()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         exprs_.find(nonconst_stmt->as<Expr>()) != exprs_.end(),
         "Somehow container claims to and not to own an Expr.");
   }
   if (stmt->isVal()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         vals_.find(nonconst_stmt->as<Val>()) != vals_.end(),
         "Somehow container claims to and not to own an Val.");
   }
@@ -236,7 +236,7 @@ bool IrContainer::inContainer(const Statement* stmt) const {
 Val* IrContainer::zeroVal() {
   if (!zero_val_) {
     auto zero_val = IrBuilder::create<Val>(this, 0L, DataType::Index);
-    TORCH_INTERNAL_ASSERT(vals_up_.back().get() == zero_val);
+    NVF_ERROR(vals_up_.back().get() == zero_val);
     zero_val_ = std::unique_ptr<Val>(vals_up_.back().release());
     vals_up_.pop_back();
   }
@@ -257,7 +257,7 @@ Val* IrContainer::zeroVal(DataType dtype) {
 Val* IrContainer::oneVal() {
   if (!one_val_) {
     auto one_val = IrBuilder::create<Val>(this, 1L, DataType::Index);
-    TORCH_INTERNAL_ASSERT(vals_up_.back().get() == one_val);
+    NVF_ERROR(vals_up_.back().get() == one_val);
     one_val_ = std::unique_ptr<Val>(vals_up_.back().release());
     vals_up_.pop_back();
   }
@@ -278,7 +278,7 @@ Val* IrContainer::oneVal(DataType dtype) {
 Val* IrContainer::falseVal() {
   if (!false_val_) {
     auto false_val = IrBuilder::create<Val>(this, false, DataType::Bool);
-    TORCH_INTERNAL_ASSERT(vals_up_.back().get() == false_val);
+    NVF_ERROR(vals_up_.back().get() == false_val);
     false_val_ = std::unique_ptr<Val>(vals_up_.back().release());
     vals_up_.pop_back();
   }
@@ -288,7 +288,7 @@ Val* IrContainer::falseVal() {
 Val* IrContainer::trueVal() {
   if (!true_val_) {
     auto true_val = IrBuilder::create<Val>(this, true, DataType::Bool);
-    TORCH_INTERNAL_ASSERT(vals_up_.back().get() == true_val);
+    NVF_ERROR(vals_up_.back().get() == true_val);
     true_val_ = std::unique_ptr<Val>(vals_up_.back().release());
     vals_up_.pop_back();
   }
@@ -299,7 +299,7 @@ NamedScalar* IrContainer::magicZeroVal() {
   if (!magic_zero_val_) {
     auto magic_zero =
         IrBuilder::create<NamedScalar>(kMagicZeroName, DataType::Index);
-    TORCH_INTERNAL_ASSERT(vals_up_.back().get() == magic_zero);
+    NVF_ERROR(vals_up_.back().get() == magic_zero);
     magic_zero_val_ = std::unique_ptr<NamedScalar>(
         vals_up_.back().release()->as<NamedScalar>());
     vals_up_.pop_back();
@@ -332,13 +332,13 @@ void IrContainer::lazyInitAxioms() {
 }
 
 void IrContainer::assumePositive(Val* val) {
-  TORCH_INTERNAL_ASSERT(val->container() == this);
+  NVF_ERROR(val->container() == this);
   lazyInitAxioms();
   axioms_->emplace_back(IrBuilder::gtExpr(val, zeroVal()));
 }
 
 void IrContainer::assumeNonNegative(Val* val) {
-  TORCH_INTERNAL_ASSERT(val->container() == this);
+  NVF_ERROR(val->container() == this);
   lazyInitAxioms();
   axioms_->emplace_back(IrBuilder::geExpr(val, zeroVal()));
 }

--- a/csrc/ir/container.h
+++ b/csrc/ir/container.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/base_nodes.h>
 #include <utils.h>
@@ -47,7 +48,7 @@ class TORCH_CUDA_CU_API IrContainer : public PolymorphicBase {
   bool inContainer(const Statement* stmt) const;
 
   void assertInContainer(const Statement* stmt, const std::string& msg) const {
-    TORCH_CHECK(
+    NVF_CHECK(
         inContainer(stmt), msg, " it was not found in the active container.");
   }
 

--- a/csrc/ir/graphviz.cpp
+++ b/csrc/ir/graphviz.cpp
@@ -119,7 +119,7 @@ void IrGraphGenerator::print(
     DetailLevel detail_level,
     ExprColorMap* expr_color_map) {
   std::ofstream dot_file(filename);
-  TORCH_CHECK(dot_file.good(), "Failed to open the IR graph file");
+  NVF_CHECK(dot_file.good(), "Failed to open the IR graph file");
   dot_file << toGraphviz(fusion, detail_level, expr_color_map);
 }
 
@@ -141,11 +141,11 @@ IrGraphGenerator::IrGraphGenerator(
   // setup inputs & outputs
   // (indexes used to quickly check if a value is fusion input or output)
   for (const auto* input : fusion->inputs()) {
-    TORCH_CHECK(inputs_.count(input) == 0);
+    NVF_CHECK(inputs_.count(input) == 0);
     inputs_.insert(input);
   }
   for (const auto* output : fusion->outputs()) {
-    TORCH_CHECK(outputs_.count(output) == 0);
+    NVF_CHECK(outputs_.count(output) == 0);
     outputs_.insert(output);
   }
 }
@@ -196,8 +196,8 @@ void IrGraphGenerator::printValue(const Val* val, const std::string& label) {
 
 std::string IrGraphGenerator::generate() {
   // IrGraphGenerator instances are not reusable
-  TORCH_CHECK(graph_def_.str().empty());
-  TORCH_CHECK(visited_.empty());
+  NVF_CHECK(graph_def_.str().empty());
+  NVF_CHECK(visited_.empty());
 
   // record detail level
   graph_def_ << "// detail level: ";
@@ -215,7 +215,7 @@ std::string IrGraphGenerator::generate() {
       graph_def_ << "verbose\n";
       break;
     default:
-      TORCH_CHECK(!"Unexpected detail level");
+      NVF_CHECK(!"Unexpected detail level");
   }
 
   graph_def_ << "digraph fusion_ir {\n"
@@ -250,7 +250,7 @@ std::string IrGraphGenerator::generate() {
 
   // Make sure that all referenced nodes have been visited
   for (const auto& kv : id_map_) {
-    TORCH_CHECK(visited(kv.first));
+    NVF_CHECK(visited(kv.first));
   }
 
   return graph_def_.str();

--- a/csrc/ir/graphviz.h
+++ b/csrc/ir/graphviz.h
@@ -9,6 +9,7 @@
 
 #include <c10/macros/Export.h>
 #include <dispatch.h>
+#include <exceptions.h>
 
 #include <sstream>
 #include <string>

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <fusion.h>
 #include <ir/builder_passkey.h>
@@ -402,8 +403,7 @@ class TORCH_CUDA_CU_API TensorView : public Val {
 
   // Returns the depth of circular buffering if applicable.
   unsigned int circularBufferDepth() const {
-    TORCH_INTERNAL_ASSERT(
-        is_circular_buffered_, toString(), "not circular buffered");
+    NVF_ERROR(is_circular_buffered_, toString(), "not circular buffered");
     return circular_buffer_stage_;
   }
 
@@ -513,7 +513,7 @@ class TORCH_CUDA_CU_API TensorView : public Val {
   //! is present in the kernel to reuse memory and inserts new block
   //! synchronizations if necessary.
   void promoteReuse(bool b = true) {
-    TORCH_CHECK(
+    NVF_CHECK(
         memory_type_ == MemoryType::Shared,
         "promoteReuse should only be called on shared memory tensors");
     promote_reuse_ = b;

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/base_nodes.h>
 #include <optional>
 
@@ -247,7 +248,7 @@ class TORCH_CUDA_CU_API IterDomain : public Val {
   Val* stopOffset() const;
 
   Val* extent() const {
-    TORCH_INTERNAL_ASSERT(extent_ != nullptr);
+    NVF_ERROR(extent_ != nullptr);
     return extent_;
   }
 
@@ -257,7 +258,7 @@ class TORCH_CUDA_CU_API IterDomain : public Val {
 
   // Returns the expanded extent of a strided broadcast entry.
   Val* expandedExtent() const {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         hasExpandedExtent(),
         "Requested expanded extent, but none found on this dimension.");
     return expanded_extent_;
@@ -286,7 +287,7 @@ class TORCH_CUDA_CU_API IterDomain : public Val {
   //!      based on the given input.
   void padToMultipleOfWarp(std::optional<int64_t> maybe_to_size = {}) {
     // Currently only restricted to TIDx to generate warp reduce
-    TORCH_CHECK(
+    NVF_CHECK(
         parallel_type_ == ParallelType::TIDx,
         "padToMultipleOfWarp : warp padding only supported on TIDx parallel dimension");
     is_padded_dimension_ = true;

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 #include <ir/interface_nodes.h>
 
 #include <fusion.h>
@@ -726,7 +727,7 @@ class TORCH_CUDA_CU_API RNGOp : public Expr {
   }
 
   void setSeedAndOffset(Val* seed, Val* offset) {
-    TORCH_INTERNAL_ASSERT(!isDeterministic());
+    NVF_ERROR(!isDeterministic());
     addInput(seed);
     addInput(offset);
   }
@@ -972,7 +973,7 @@ class TORCH_CUDA_CU_API WelfordTriplet {
   }
 
   TensorView* avgTv() const {
-    TORCH_INTERNAL_ASSERT(avg()->isA<TensorView>());
+    NVF_ERROR(avg()->isA<TensorView>());
     return avg()->as<TensorView>();
   }
 
@@ -985,7 +986,7 @@ class TORCH_CUDA_CU_API WelfordTriplet {
   }
 
   TensorView* varTv() const {
-    TORCH_INTERNAL_ASSERT(var()->isA<TensorView>());
+    NVF_ERROR(var()->isA<TensorView>());
     return var()->as<TensorView>();
   }
 
@@ -998,7 +999,7 @@ class TORCH_CUDA_CU_API WelfordTriplet {
   }
 
   TensorView* NTv() const {
-    TORCH_INTERNAL_ASSERT(N()->isA<TensorView>());
+    NVF_ERROR(N()->isA<TensorView>());
     return N()->as<TensorView>();
   }
 
@@ -1064,7 +1065,7 @@ class TORCH_CUDA_CU_API WelfordTriplet {
 
   //! Convert a given index to a name
   static ValName indexToValName(int index) {
-    TORCH_INTERNAL_ASSERT(index >= 0 && index < 3, "Invalid index: ", index);
+    NVF_ERROR(index >= 0 && index < 3, "Invalid index: ", index);
     return static_cast<ValName>(index);
   }
 
@@ -1685,14 +1686,14 @@ class TORCH_CUDA_CU_API Split : public Expr {
   //! Start position of the input domain. Non-zero means partial
   //! split. Elements until this offset are ignored.
   Val* startOffset() const {
-    TORCH_INTERNAL_ASSERT(attributeVal(2) != nullptr);
+    NVF_ERROR(attributeVal(2) != nullptr);
     return attributeVal(2);
   }
 
   //! Offset from extent of the input domain. Non-zero means partial
   //! split. Elements after this offset are ignored.
   Val* stopOffset() const {
-    TORCH_INTERNAL_ASSERT(attributeVal(3) != nullptr);
+    NVF_ERROR(attributeVal(3) != nullptr);
     return attributeVal(3);
   }
 

--- a/csrc/ir/iostream.cpp
+++ b/csrc/ir/iostream.cpp
@@ -23,16 +23,16 @@ namespace nvfuser {
 // Make sure we can inline something, before we attempt to.
 void checkInlineable(const Expr* expr) {
   for (auto input : expr->inputs()) {
-    TORCH_CHECK(
+    NVF_CHECK(
         input->isScalar() || input->isA<kir::TensorIndex>() ||
             (expr->isA<UnaryOp>() &&
              expr->as<UnaryOp>()->getUnaryOpType() == UnaryOpType::Address),
         "Printing inline computations involving values other than scalars is not currently supported.");
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       expr->outputs().size() == 1,
       "Cannot print inline computations if there's more than one output.");
-  TORCH_CHECK(
+  NVF_CHECK(
       expr->output(0)->isScalar() || expr->output(0)->isA<NamedScalar>(),
       "Printing inline computations involving values other than scalars is not currently supported.");
 }
@@ -46,7 +46,7 @@ void IrPrinter::handle(Fusion* fusion) {
 }
 
 void IrPrinter::handle(const kir::Kernel* kernel) {
-  TORCH_CHECK(kernel != nullptr);
+  NVF_CHECK(kernel != nullptr);
 
   // kernel declaration
   os_ << "\nKERNEL (";

--- a/csrc/ir/iostream.h
+++ b/csrc/ir/iostream.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <dispatch.h>
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -8,6 +8,7 @@
 #include <device_lower/lower2device.h>
 #include <disjoint_set.h>
 #include <dynamic_transform.h>
+#include <exceptions.h>
 #include <ir/cloner.h>
 #include <ir/interface_nodes.h>
 #include <ir/iostream.h>
@@ -63,7 +64,7 @@ std::string FullOp::toString(int indent_size) const {
 }
 
 std::string FullOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(FullOp)
@@ -92,7 +93,7 @@ std::string SelectOp::toString(int indent_size) const {
 }
 
 std::string SelectOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 IterDomain* SelectOp::getIndexedID() const {
@@ -127,7 +128,7 @@ std::string IndexSelectOp::toString(int indent_size) const {
 }
 
 std::string IndexSelectOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 IterDomain* IndexSelectOp::getIndexedID() const {
@@ -173,7 +174,7 @@ std::string TorchGatherOp::toString(int indent_size) const {
 }
 
 std::string TorchGatherOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 IterDomain* TorchGatherOp::getIndexedID() const {
@@ -216,7 +217,7 @@ std::string ScatterOp::toString(int indent_size) const {
 }
 
 std::string ScatterOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Scatter op can not be printed inline");
+  NVF_CHECK(false, "Scatter op can not be printed inline");
 }
 
 IterDomain* ScatterOp::getIndexedID() const {
@@ -232,10 +233,10 @@ IotaOp::IotaOp(
     Val* start,
     Val* step)
     : Expr(passkey) {
-  TORCH_CHECK(isIntegralType(*length->getDataType()));
+  NVF_CHECK(isIntegralType(*length->getDataType()));
   addInput(length);
-  TORCH_CHECK(start->getDataType() == step->getDataType());
-  TORCH_CHECK(start->getDataType() == out->getDataType());
+  NVF_CHECK(start->getDataType() == step->getDataType());
+  NVF_CHECK(start->getDataType() == out->getDataType());
   addInput(start);
   addInput(step);
   addOutput(out);
@@ -253,7 +254,7 @@ std::string IotaOp::toString(int indent_size) const {
 }
 
 std::string IotaOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(IotaOp)
@@ -281,7 +282,7 @@ std::string EyeOp::toString(int indent_size) const {
 }
 
 std::string EyeOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(EyeOp)
@@ -314,7 +315,7 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
       } else if (isComplexType(*out()->getDataType())) {
         return {PolymorphicValue((std::complex<double>)in)};
       } else {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             false, "dtype not supported in evaluator: ", *out()->getDataType());
       }
     case UnaryOpType::Reciprocal:
@@ -339,11 +340,11 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
       if (*out()->getDataType() == DataType::Float) {
         return {PolymorphicValue((double)*(float*)in)};
       } else {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             false, "dtype not supported in evaluator: ", *out()->getDataType());
       }
     default:
-      TORCH_CHECK(
+      NVF_CHECK(
           false,
           "Unexpected operator type ",
           getUnaryOpType(),
@@ -361,7 +362,7 @@ void UnaryOp::printHelper(std::stringstream& ss, std::string input) const {
     if (op_type == UnaryOpType::Cast) {
       std::optional<std::string> cast_str = cast_func_str(std::make_pair(
           in()->getDataType().value(), out()->getDataType().value()));
-      TORCH_INTERNAL_ASSERT(cast_str != std::nullopt, "Unsupported Cast");
+      NVF_ERROR(cast_str != std::nullopt, "Unsupported Cast");
       ss << cast_str.value();
     } else {
       ss << op_type;
@@ -429,15 +430,15 @@ std::vector<PolymorphicValue> BinaryOp::evaluate(
       return {lhs * rhs};
       break;
     case BinaryOpType::Div:
-      TORCH_CHECK(rhs != 0);
+      NVF_CHECK(rhs != 0);
       return {lhs / rhs};
       break;
     case BinaryOpType::Mod:
-      TORCH_CHECK(rhs != 0);
+      NVF_CHECK(rhs != 0);
       return {lhs % rhs};
       break;
     case BinaryOpType::CeilDiv:
-      TORCH_CHECK(rhs != 0);
+      NVF_CHECK(rhs != 0);
       return {ceildiv(lhs, rhs)};
       break;
     case BinaryOpType::LogicalAnd:
@@ -483,7 +484,7 @@ std::vector<PolymorphicValue> BinaryOp::evaluate(
       return {gcd(lhs, rhs)};
       break;
     default:
-      TORCH_CHECK(
+      NVF_CHECK(
           false,
           "Unexpected operator type: ",
           getBinaryOpType(),
@@ -577,7 +578,7 @@ std::vector<PolymorphicValue> TernaryOp::evaluate(
       return {in1.as<bool>() ? in2 : in3};
       break;
     default:
-      TORCH_CHECK(
+      NVF_CHECK(
           false,
           "Unexpected operator type: ",
           getTernaryOpType(),
@@ -645,25 +646,24 @@ ArrayConstruct::ArrayConstruct(
     Val* output,
     std::vector<Val*> inputs)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(
-      !inputs.empty(), "Cannot create an array with no members.");
+  NVF_ERROR(!inputs.empty(), "Cannot create an array with no members.");
   addOutput(output);
   DataType input_dtype = DataType::Null;
   for (auto in : inputs) {
     addInput(in);
     auto in_dtype_opt = in->getDataType();
-    TORCH_INTERNAL_ASSERT(in_dtype_opt.has_value());
+    NVF_ERROR(in_dtype_opt.has_value());
     if (input_dtype == DataType::Null) {
       input_dtype = *in_dtype_opt;
     } else {
-      TORCH_CHECK(
+      NVF_CHECK(
           input_dtype == *in_dtype_opt,
           "All inputs to ArrayConstruct must have the same data type");
     }
   }
   auto expected_output_dtype =
       ArrayType{std::make_shared<DataType>(input_dtype), inputs.size()};
-  TORCH_CHECK(
+  NVF_CHECK(
       output->getDataType() == expected_output_dtype,
       "Output of ArrayConstruct must be an array of the same data type as the inputs");
 }
@@ -691,21 +691,21 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(ArrayConstruct)
 
 ReverseArray::ReverseArray(IrBuilderPasskey passkey, Val* output, Val* input)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       std::holds_alternative<ArrayType>(input->dtype().type),
       "Cannot reverse a non-array type.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       std::holds_alternative<ArrayType>(output->dtype().type),
       "Cannot reverse a non-array type.");
   auto input_array_type = std::get<ArrayType>(input->dtype().type);
   auto output_array_type = std::get<ArrayType>(output->dtype().type);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       input_array_type.type == output_array_type.type,
       "Cannot reverse an array of type ",
       input_array_type.type,
       " into an array of type ",
       output_array_type.type);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       input_array_type.size == output_array_type.size,
       "Cannot reverse an array of size ",
       input_array_type.size,
@@ -731,7 +731,7 @@ std::string ReverseArray::toInlineString(int indent_size) const {
 std::vector<PolymorphicValue> ReverseArray::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  TORCH_INTERNAL_ASSERT(inputs.size() == 1, "ReverseArray expects 1 input");
+  NVF_ERROR(inputs.size() == 1, "ReverseArray expects 1 input");
   PolymorphicValue array = inputs.at(0);
   auto& vec = array.as<std::vector>();
   std::reverse(vec.begin(), vec.end());
@@ -745,7 +745,7 @@ GetItem::GetItem(IrBuilderPasskey passkey, Val* output, Val* array, Val* index)
   addOutput(output);
   addInput(array);
   addInput(index);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       *(std::get<ArrayType>(array->dtype().type).type) == output->dtype(),
       "GetItem array input must have a data type");
 }
@@ -767,7 +767,7 @@ std::string GetItem::toInlineString(int indent_size) const {
 std::vector<PolymorphicValue> GetItem::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  TORCH_INTERNAL_ASSERT(inputs.size() == 2, "GetItem expects 2 inputs");
+  NVF_ERROR(inputs.size() == 2, "GetItem expects 2 inputs");
   return {PolymorphicValue(inputs.at(0)[inputs.at(1)])};
 }
 
@@ -778,18 +778,17 @@ StructConstruct::StructConstruct(
     Val* output,
     const std::vector<std::pair<std::string, Val*>>& fields)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(
-      !fields.empty(), "Cannot create a struct with no members.");
+  NVF_ERROR(!fields.empty(), "Cannot create a struct with no members.");
   auto output_dtype = std::get<StructType>(output->dtype().type);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       output_dtype.fields.size() == fields.size(),
       "StructConstruct output must have the same number of fields as the inputs");
   auto it = output_dtype.fields.begin();
   for (const auto& field : fields) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         it->name == field.first,
         "StructConstruct field names must match the output");
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         *(it->type) == field.second->dtype(),
         "StructConstruct field ",
         field.first,
@@ -830,7 +829,7 @@ std::string StructConstruct::toInlineString(int indent_size) const {
 std::vector<PolymorphicValue> StructConstruct::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       this->inputs().size() == inputs.size(),
       "StructConstruct expects ",
       this->inputs().size(),
@@ -851,7 +850,7 @@ GetAttr::GetAttr(
     Val* struct_,
     std::string attr)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       std::get<StructType>(struct_->dtype().type).fieldDataType(attr) ==
           output->dtype(),
       "Data type mismatch for GetAttr");
@@ -876,7 +875,7 @@ std::string GetAttr::toInlineString(int indent_size) const {
 std::vector<PolymorphicValue> GetAttr::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  TORCH_INTERNAL_ASSERT(inputs.size() == 1, "GetAttr expects 1 input");
+  NVF_ERROR(inputs.size() == 1, "GetAttr expects 1 input");
   return {inputs.at(0)->*attr()};
 }
 
@@ -886,7 +885,7 @@ GetMetaData::GetMetaData(IrBuilderPasskey passkey, Val* output, Val* input)
     : Expr(passkey) {
   addOutput(output);
   addInput(input);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       out()->dtype() == metaDataTypeOf(in()),
       "Data type mismatch for GetMetaData")
 }
@@ -923,13 +922,13 @@ std::string TensorConstruct::toString(int indent_size) const {
 }
 
 std::string TensorConstruct::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 std::vector<PolymorphicValue> TensorConstruct::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  TORCH_INTERNAL_ASSERT(inputs.size() == 1, "TensorConstruct expects 1 input");
+  NVF_ERROR(inputs.size() == 1, "TensorConstruct expects 1 input");
   using namespace PolymorphicValue_functions;
   return {toTensor(inputs.at(0))};
 }
@@ -948,7 +947,7 @@ RNGOp::RNGOp(
     : Expr(passkey) {
   if (auto tv_out = dynamic_cast<TensorView*>(out)) {
     for (auto id : tv_out->getRootDomain()) {
-      TORCH_CHECK(!id->isReduction(), "Output of RNGOp can not have reduction");
+      NVF_CHECK(!id->isReduction(), "Output of RNGOp can not have reduction");
       addInput(id->extent());
     }
   }
@@ -956,7 +955,7 @@ RNGOp::RNGOp(
     addInput(v);
   }
   if (philox_seed || philox_offset) {
-    TORCH_CHECK(
+    NVF_CHECK(
         philox_seed && philox_offset,
         "If either philox_seed or philox_offset is provided, the other must be also");
     addInput(philox_seed);
@@ -989,7 +988,7 @@ std::string RNGOp::toString(int indent_size) const {
 }
 
 std::string RNGOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 int64_t RNGOp::getOutputDims() const {
@@ -1011,7 +1010,7 @@ BroadcastOp::BroadcastOp(
   auto out_type = out->getValType().value();
   auto in_type = in->getValType().value();
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       (out_type == ValType::TensorView && in_type == ValType::TensorView) ||
           (out_type == ValType::TensorIndex && in_type == ValType::TensorIndex),
       "Cannot braodcast a non-tensor object.");
@@ -1023,12 +1022,12 @@ BroadcastOp::BroadcastOp(
   // TensorView. Broadcast with TensorIndex only appears after
   // lowering, so it should have already been validated.
   if (out->isA<TensorView>()) {
-    TORCH_INTERNAL_ASSERT(in->isA<TensorView>());
+    NVF_ERROR(in->isA<TensorView>());
     auto in_tv = in->as<TensorView>();
     auto out_tv = out->as<TensorView>();
     auto in_dom = TensorDomain::noReductions(in_tv->getMaybeRFactorDomain());
     auto& out_dom = out_tv->getRootDomain();
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         is_broadcast_dims.size() == out_dom.size(),
         "The dimensions of output tensor and does not match with is_broadcast_dims");
 
@@ -1038,23 +1037,23 @@ BroadcastOp::BroadcastOp(
       if (is_broadcast_dims[i]) {
         num_new_broadcasts++;
         auto id = out_dom[i];
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             id->isBroadcast(),
             "New broadcast dimension does not properly set its IterType.");
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             !id->hasExpandedExtent(),
             "New broadcast dimension can not be expanded.");
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             id->extent()->isOneInt(),
             "New broadcast dimension must have extent 1");
       } else {
         auto in_id = in_dom[i - num_new_broadcasts];
         auto out_id = out_dom[i];
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             in_id->sameAs(out_id), "IterDomain does not match in BroadcastOp");
       }
     }
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         out_size == in_dom.size() + num_new_broadcasts,
         "The dimensions of output tensor and does not match with is_broadcast_dims and input tensor");
   }
@@ -1070,13 +1069,13 @@ std::string BroadcastOp::toString(int indent_size) const {
 }
 
 std::string BroadcastOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 std::vector<PolymorphicValue> BroadcastOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       inputs.size() == 1,
       "BroadcastOp expects exactly 1 input, but received ",
       inputs.size());
@@ -1104,12 +1103,12 @@ SqueezeOp::SqueezeOp(
   auto out_type = out->getValType().value();
   auto in_type = in->getValType().value();
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       in_type == ValType::TensorView,
       "Squeeze input must be a TensorView: ",
       in->toString());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       out_type == ValType::TensorView,
       "Squeeze output must be a TensorView: ",
       in->toString());
@@ -1122,7 +1121,7 @@ SqueezeOp::SqueezeOp(
   auto out_tv = out->as<TensorView>();
   auto in_dom = TensorDomain::noReductions(in_tv->getMaybeRFactorDomain());
   auto& out_dom = out_tv->getRootDomain();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       is_squeeze_dims.size() == in_dom.size(),
       "The dimensions of input tensor and does not match with is_squeeze_dims");
 
@@ -1132,27 +1131,27 @@ SqueezeOp::SqueezeOp(
     if (is_squeeze_dims[i]) {
       num_removed_broadcasts++;
       auto id = in_dom[i];
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           id->isBroadcast() || id->isSymbolic(),
           "Squeeze dimension should be either Symbolic or Broadcast. Found ",
           id->getIterType());
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !id->hasExpandedExtent(), "Can not squeeze expanded dimension(s).");
       if (id->isBroadcast()) {
         // Check concrete broadcast extent here. For Symbolic inputs, this check
         // will be deferred to concretization. See dynamic_transform.cpp
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             id->extent()->isOneInt(),
             "Can not squeeze dimension(s) with size != 1.");
       }
     } else {
       auto in_id = in_dom[i];
       auto out_id = out_dom[i - num_removed_broadcasts];
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           in_id->sameAs(out_id), "IterDomain does not match in BroadcastOp");
     }
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       in_size == out_tv->nDims() + num_removed_broadcasts,
       "The dimensions of output tensor and does not match with is_squeeze_dims and input tensor");
 
@@ -1167,20 +1166,20 @@ std::string SqueezeOp::toString(int indent_size) const {
 }
 
 std::string SqueezeOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 std::vector<PolymorphicValue> SqueezeOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       inputs.size() == 1,
       "SqueezeOp expects exactly 1 input, but received ",
       inputs.size());
   std::vector<int64_t> out_shape;
   const auto& in = inputs.at(0).as<at::Tensor>();
   const auto& is_squeeze_dims = getSqueezeDimFlags();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       (int64_t)is_squeeze_dims.size() == in.dim(),
       "The dimensions of input tensor and does not match with is_squeeze_dims");
   for (int64_t i : c10::irange((int64_t)is_squeeze_dims.size())) {
@@ -1193,7 +1192,7 @@ std::vector<PolymorphicValue> SqueezeOp::evaluate(
 
 void SqueezeOp::checkConcretization(Val* old_val, Val* new_val) const {
   Expr::checkConcretization(old_val, new_val); // does nullptr, vtype checks
-  TORCH_CHECK(
+  NVF_CHECK(
       old_val == in(),
       "Pre-concretized Val ",
       old_val->toString(),
@@ -1204,7 +1203,7 @@ void SqueezeOp::checkConcretization(Val* old_val, Val* new_val) const {
       TensorView>(); // NOLINT(clang-analyzer-core.CallAndMessage,-warnings-as-errors)
   auto old_rfactor = old_tv->getMaybeRFactorDomain();
   auto new_rfactor = new_tv->getMaybeRFactorDomain();
-  TORCH_CHECK(
+  NVF_CHECK(
       new_rfactor.size() == old_tv->getMaybeRFactorDomain().size(),
       "New TV ",
       new_tv->toString(),
@@ -1219,15 +1218,15 @@ void SqueezeOp::checkConcretization(Val* old_val, Val* new_val) const {
     }
     auto new_id = new_rfactor.at(i);
     // Check that squeezed dimension concretizes to Broadcast
-    TORCH_CHECK(
+    NVF_CHECK(
         new_id->getIterType() == IterType::Broadcast,
         "Squeezed IterDomain ",
         new_id->toString(),
         " must concretize to IterType::Broadcast but found ",
         new_id->toString());
-    TORCH_CHECK(
+    NVF_CHECK(
         !new_id->hasExpandedExtent(), "Can not squeeze expanded dimension(s).");
-    TORCH_CHECK(
+    NVF_CHECK(
         new_id->extent()->isOneInt(),
         "Can not squeeze dimension(s) with size != 1.");
   }
@@ -1243,11 +1242,11 @@ ReductionOp::ReductionOp(
     Val* in,
     bool is_allreduce)
     : Expr(passkey) {
-  TORCH_CHECK(
+  NVF_CHECK(
       out->getValType().value() == ValType::TensorView ||
       out->getValType().value() == ValType::TensorIndex);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       (in->getValType() == ValType::TensorView &&
        out->getValType() == ValType::TensorView) ||
           (in->getValType() == ValType::TensorIndex &&
@@ -1255,13 +1254,13 @@ ReductionOp::ReductionOp(
       "Reduction operation was created that does not have tensor inputs and outputs.");
 
   if (in->isA<TensorView>()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         TensorDomain::noReductions(
             in->as<TensorView>()->getMaybeRFactorDomain())
                 .size() == out->as<TensorView>()->getRootDomain().size(),
         "Reduction operation created with mismatched domains.");
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       init->isConstScalar(),
       "Tried to create a reduction operation whith an initial value that isn't a constant.");
 
@@ -1284,7 +1283,7 @@ std::string ReductionOp::toString(int indent_size) const {
 }
 
 std::string ReductionOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(ReductionOp)
@@ -1329,7 +1328,7 @@ std::string GroupedReductionOp::toString(int indent_size) const {
 }
 
 std::string GroupedReductionOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 int GroupedReductionOp::getExprIndexOfOutput(Val* output_val) const {
@@ -1338,7 +1337,7 @@ int GroupedReductionOp::getExprIndexOfOutput(Val* output_val) const {
     return (int)std::distance(outputs().begin(), it);
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false, "Not an output, ", output_val->toString(), ", of ", toString());
 }
 
@@ -1384,39 +1383,39 @@ WelfordOp::WelfordOp(
   // Previously, nullptr was accepted and implicitly replaced by
   // default values. Looks like we always pass some non-null values,
   // so removed the implicit default behavior for code simplicity.
-  TORCH_INTERNAL_ASSERT(output.avg() != nullptr);
-  TORCH_INTERNAL_ASSERT(output.var() != nullptr);
-  TORCH_INTERNAL_ASSERT(output.N() != nullptr);
-  TORCH_INTERNAL_ASSERT(init.avg() != nullptr);
-  TORCH_INTERNAL_ASSERT(init.var() != nullptr);
-  TORCH_INTERNAL_ASSERT(init.N() != nullptr);
-  TORCH_INTERNAL_ASSERT(input.avg() != nullptr);
-  TORCH_INTERNAL_ASSERT(input.var() != nullptr);
-  TORCH_INTERNAL_ASSERT(input.N() != nullptr);
+  NVF_ERROR(output.avg() != nullptr);
+  NVF_ERROR(output.var() != nullptr);
+  NVF_ERROR(output.N() != nullptr);
+  NVF_ERROR(init.avg() != nullptr);
+  NVF_ERROR(init.var() != nullptr);
+  NVF_ERROR(init.N() != nullptr);
+  NVF_ERROR(input.avg() != nullptr);
+  NVF_ERROR(input.var() != nullptr);
+  NVF_ERROR(input.N() != nullptr);
 
   // Check output type
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       output.avg()->getValType().value() == ValType::TensorView ||
       output.avg()->getValType().value() == ValType::TensorIndex);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       output.var()->getValType().value() == ValType::TensorView ||
       output.var()->getValType().value() == ValType::TensorIndex);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       output.N()->getValType().value() == ValType::TensorView ||
       output.N()->getValType().value() == ValType::TensorIndex);
-  TORCH_INTERNAL_ASSERT(isIntegralType(output.N()->dtype()));
+  NVF_ERROR(isIntegralType(output.N()->dtype()));
 
   // check initial value
-  TORCH_INTERNAL_ASSERT(init.N()->getValType().value() == ValType::Others);
-  TORCH_INTERNAL_ASSERT(isIntegralType(init.N()->dtype()));
+  NVF_ERROR(init.N()->getValType().value() == ValType::Others);
+  NVF_ERROR(isIntegralType(init.N()->dtype()));
   if (!init.N()->isZeroInt()) {
     // when initial count is zero, no initial variance or average is needed
     // initial value with a count of 1 is un-common enough that I'll push
     // the responsibility of creating all-zero var tensors to the user
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         init.avg()->getValType().value() == ValType::TensorView ||
         init.avg()->getValType().value() == ValType::TensorIndex);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         init.var()->getValType().value() == ValType::TensorView ||
             init.var()->getValType().value() == ValType::TensorIndex,
         "Invalid initial var: ",
@@ -1424,23 +1423,23 @@ WelfordOp::WelfordOp(
   }
 
   // check input
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       input.avg()->getValType().value() == ValType::TensorView ||
           input.avg()->getValType().value() == ValType::TensorIndex,
       input.avg()->getValType().value());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       input.N()->getValType().value() == ValType::Others ||
       input.N()->getValType().value() == ValType::TensorView ||
       input.N()->getValType().value() == ValType::TensorIndex);
-  TORCH_INTERNAL_ASSERT(isIntegralType(input.N()->dtype()));
+  NVF_ERROR(isIntegralType(input.N()->dtype()));
   if (!input.N()->isOneInt()) {
     // when input is only one value, only the value is required through avg
     // input the var part is implicitly 0 and codegen will handle that.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         input.var()->getValType().value() == ValType::TensorView ||
         input.var()->getValType().value() == ValType::TensorIndex);
   } else {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         input.var() == nullptr || input.var()->isZeroInt(),
         "Invalid var input, which must be either nullptr or scalar zero when the N input is one.");
   }
@@ -1458,7 +1457,7 @@ WelfordOp::WelfordOp(
   addAttribute(init.N());
   addDataAttribute(is_fused);
 
-  TORCH_INTERNAL_ASSERT(attributes().size() == kNumAttrs);
+  NVF_ERROR(attributes().size() == kNumAttrs);
 }
 
 WelfordOp::WelfordOp(
@@ -1483,7 +1482,7 @@ WelfordOp::WelfordOp(
 Val* WelfordOp::getInitValOfOutput(Val* output_val) const {
   auto val_name = outputTriplet().getNameOf(output_val);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       val_name.has_value(),
       "Not an output val ",
       output_val->toString(),
@@ -1520,7 +1519,7 @@ std::string WelfordOp::toString(int indent_size) const {
 }
 
 std::string WelfordOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(WelfordOp)
@@ -1534,13 +1533,13 @@ GroupedWelfordOp::GroupedWelfordOp(
     : Expr(passkey) {
   const auto num_grouped_ops = output_vals.size();
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       input_vals.size() == num_grouped_ops,
       "Invalid number of input arguments. Expected: ",
       num_grouped_ops,
       ", Given: ",
       input_vals.size());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       init_vals.size() == num_grouped_ops,
       "Invalid number of N arguments. Expected: ",
       num_grouped_ops,
@@ -1549,27 +1548,27 @@ GroupedWelfordOp::GroupedWelfordOp(
 
   for (const auto i : c10::irange(num_grouped_ops)) {
     // Check output type
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         output_vals[i].avg()->getValType().value() == ValType::TensorView ||
         output_vals[i].avg()->getValType().value() == ValType::TensorIndex);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         output_vals[i].var()->getValType().value() == ValType::TensorView ||
         output_vals[i].var()->getValType().value() == ValType::TensorIndex);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         output_vals[i].N()->getValType().value() == ValType::TensorView ||
         output_vals[i].N()->getValType().value() == ValType::TensorIndex);
-    TORCH_INTERNAL_ASSERT(isIntegralType(output_vals[i].N()->dtype()));
+    NVF_ERROR(isIntegralType(output_vals[i].N()->dtype()));
 
     // check initial value
     auto init_avg = init_vals[i].avg();
     auto init_var = init_vals[i].var();
     auto init_N = init_vals[i].N();
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         init_avg != nullptr && init_var != nullptr && init_N != nullptr,
         "nullptr init vals are not allowed");
-    TORCH_INTERNAL_ASSERT(init_N->getValType().value() == ValType::Others);
-    TORCH_INTERNAL_ASSERT(isIntegralType(init_N->dtype()));
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(init_N->getValType().value() == ValType::Others);
+    NVF_ERROR(isIntegralType(init_N->dtype()));
+    NVF_ERROR(
         init_avg->getValType().value() == ValType::TensorView ||
             init_avg->getValType().value() == ValType::TensorIndex ||
             (init_N->isZeroInt() &&
@@ -1579,7 +1578,7 @@ GroupedWelfordOp::GroupedWelfordOp(
         init_avg->toString(),
         ". Initial N: ",
         init_N->toString());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         init_var->getValType().value() == ValType::TensorView ||
             init_var->getValType().value() == ValType::TensorIndex ||
             (init_N->isZeroInt() &&
@@ -1591,15 +1590,15 @@ GroupedWelfordOp::GroupedWelfordOp(
     auto in_avg = input_vals[i].avg();
     auto in_var = input_vals[i].var();
     auto in_N = input_vals[i].N();
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         in_avg != nullptr && in_var != nullptr && in_N != nullptr,
         "nullptr input vals are not allowed");
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         in_N->getValType().value() == ValType::Others ||
         in_N->getValType().value() == ValType::TensorView ||
         in_N->getValType().value() == ValType::TensorIndex);
-    TORCH_INTERNAL_ASSERT(isIntegralType(in_N->dtype()));
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(isIntegralType(in_N->dtype()));
+    NVF_ERROR(
         in_avg->getValType().value() == ValType::TensorView ||
             in_avg->getValType().value() == ValType::TensorIndex,
         "Invalid input avg argument type: ",
@@ -1608,12 +1607,12 @@ GroupedWelfordOp::GroupedWelfordOp(
     if (in_N->isOneInt()) {
       // when input is only one value, only the value is required through avg
       // input the var part must be implicitly 0
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           in_var->isZeroInt(),
           "Invalid var input, which must be scalar zero when the N input is one: ",
           in_var->toString());
     } else {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           in_var->getValType().value() == ValType::TensorView ||
               in_var->getValType().value() == ValType::TensorIndex,
           in_var->getValType().value(),
@@ -1662,7 +1661,7 @@ std::string GroupedWelfordOp::toString(int indent_size) const {
 }
 
 std::string GroupedWelfordOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 int GroupedWelfordOp::getExprIndexOfOutput(Val* output_val) const {
@@ -1672,7 +1671,7 @@ int GroupedWelfordOp::getExprIndexOfOutput(Val* output_val) const {
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false, "Not an output, ", output_val->toString(), ", of ", toString());
 }
 
@@ -1788,7 +1787,7 @@ MmaOptions::MmaLayout getInputLayout(
     return MmaOptions::MmaLayout::NN;
   }
 
-  TORCH_INTERNAL_ASSERT(false, "Unsupported input layout");
+  NVF_ERROR(false, "Unsupported input layout");
 }
 
 MmaOpDetails getMmaOpDetails(
@@ -1871,11 +1870,9 @@ MmaOpDetails getMmaOpDetails(
 
   const auto validateInputDetails = [](const TensorViewDetails& details,
                                        const std::string& desc) {
-    TORCH_INTERNAL_ASSERT(
-        !details.bcasts.empty(), desc, ": has no broadcast domains.");
-    TORCH_INTERNAL_ASSERT(
-        details.rdomains.empty(), desc, ": has reduction domains.");
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(!details.bcasts.empty(), desc, ": has no broadcast domains.");
+    NVF_ERROR(details.rdomains.empty(), desc, ": has reduction domains.");
+    NVF_ERROR(
         details.cdomains.size() >= expected_gemm_cdomains,
         desc,
         ": has unsupported number of concrete domains, expected at least ",
@@ -1887,11 +1884,9 @@ MmaOpDetails getMmaOpDetails(
   const auto validateOutputDetails = [](const TensorViewDetails& details,
                                         const std::string& desc) {
     // TODO: revise rules when add support for batch gemms
-    TORCH_INTERNAL_ASSERT(
-        details.bcasts.empty(), desc, ": has broadcast domains.");
-    TORCH_INTERNAL_ASSERT(
-        !details.rdomains.empty(), desc, ": has no reduction domains.");
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(details.bcasts.empty(), desc, ": has broadcast domains.");
+    NVF_ERROR(!details.rdomains.empty(), desc, ": has no reduction domains.");
+    NVF_ERROR(
         (details.cdomains.size() >= expected_gemm_cdomains),
         desc,
         ": has unsupported number of concrete domains, expected at least ",
@@ -1915,13 +1910,13 @@ MmaOpDetails getMmaOpDetails(
       in_a_details.cdomains, in_b_details.cdomains, out_details.rdomains);
   details.batch_axes = getBatchAxes(in_a_details, in_b_details, out_details);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !details.m_axes.empty(),
       "MmaOp inputs must define at least a single M dimension");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !details.n_axes.empty(),
       "MmaOp inputs must define at least a single N dimension");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !details.k_axes.empty(),
       "MmaOp inputs must define at least a single K dimension");
 
@@ -1946,17 +1941,17 @@ MmaOp::MmaOp(
     Val* in_b,
     Val* init)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       out->getValType().value() == ValType::TensorView ||
           out->getValType().value() == ValType::TensorIndex,
       out->getValType().value());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       in_a->getValType().value() == ValType::TensorView ||
           in_a->getValType().value() == ValType::TensorIndex,
       in_a->getValType().value());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       in_b->getValType().value() == ValType::TensorView ||
           in_b->getValType().value() == ValType::TensorIndex,
       in_b->getValType().value());
@@ -2008,8 +2003,8 @@ MmaOp::MmaOp(
 
   const auto input_layout_ = attribute<MmaLayoutOpt>(ATTR_POS_INPUT_LAYOUT);
   if (input_layout_.has_value()) {
-    TORCH_INTERNAL_ASSERT(input_layout.has_value());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(input_layout.has_value());
+    NVF_ERROR(
         input_layout_.value() == input_layout.value(),
         "Input layout mismatch, infered attribute (",
         nvfuser::toString(input_layout_.value()),
@@ -2030,15 +2025,15 @@ std::string MmaOp::toString(int indent_size) const {
 }
 
 std::string MmaOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 void MmaOp::configureOptions(MmaOptions options) {
   OptionsInMma& opt = attribute<OptionsInMma>(ATTR_POS_OPTS);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       options.macro != MmaOptions::MacroType::NoMMA,
       "Un-configured mma type from options.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       options.accumulator_stride > 0, "Un-configured accumulator stride.");
   opt.accumulator_stride = options.accumulator_stride;
   opt.macro = options.macro;
@@ -2055,8 +2050,8 @@ ExpandOp::ExpandOp(
   addOutput(out);
   addInput(in);
   for (auto expanded_extent : _expanded_extents) {
-    TORCH_INTERNAL_ASSERT(expanded_extent != nullptr);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(expanded_extent != nullptr);
+    NVF_ERROR(
         expanded_extent->dtype() == DataType::Index,
         "Expanded extents must be of index type.");
     addInput(expanded_extent);
@@ -2073,7 +2068,7 @@ std::string ExpandOp::toString(int indent_size) const {
 }
 
 std::string ExpandOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(ExpandOp)
@@ -2086,24 +2081,24 @@ ShiftOp::ShiftOp(
     std::vector<int> pad_width)
     : Expr(passkey) {
   // clang-tidy complains about out that it may be null.
-  TORCH_INTERNAL_ASSERT(out != nullptr);
-  TORCH_INTERNAL_ASSERT(in != nullptr);
+  NVF_ERROR(out != nullptr);
+  NVF_ERROR(in != nullptr);
 
   auto out_type = out->getValType().value();
   auto in_type = in->getValType().value();
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       out_type == ValType::TensorView && in_type == ValType::TensorView,
       "Cannot shift a non-tensor object.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       offsets.size() ==
           TensorDomain::noReductions(in->as<TensorView>()->getRootDomain())
               .size(),
       "Invalid offset vector: ",
       offsets);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       pad_width.size() ==
           TensorDomain::noReductions(in->as<TensorView>()->getRootDomain())
               .size(),
@@ -2125,7 +2120,7 @@ std::string ShiftOp::toString(int indent_size) const {
 }
 
 std::string ShiftOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(ShiftOp)
@@ -2138,28 +2133,27 @@ GatherOp::GatherOp(
     std::vector<std::vector<int>> pad_width)
     : Expr(passkey) {
   // clang-tidy complains about out_ that it may be null.
-  TORCH_INTERNAL_ASSERT(out != nullptr);
-  TORCH_INTERNAL_ASSERT(in != nullptr);
+  NVF_ERROR(out != nullptr);
+  NVF_ERROR(in != nullptr);
 
   auto out_type = out->getValType().value();
   auto in_type = in->getValType().value();
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       out_type == ValType::TensorView && in_type == ValType::TensorView,
       "Cannot shift a non-tensor object.");
 
   const auto ndims =
       TensorDomain::noReductions(in->as<TensorView>()->getRootDomain()).size();
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       window_shape.size() == ndims,
       "Invalid window_shape vector: ",
       window_shape);
-  TORCH_INTERNAL_ASSERT(
-      pad_width.size() == ndims, "Invalid pad_width vector: ", pad_width);
+  NVF_ERROR(pad_width.size() == ndims, "Invalid pad_width vector: ", pad_width);
 
   for (const auto& pad : pad_width) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         pad.size() == 2, "Padding size for each axis must have two Int vals.");
   }
 
@@ -2187,14 +2181,14 @@ std::string GatherOp::toString(int indent_size) const {
 }
 
 std::string GatherOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 int64_t GatherOp::gatherAxis(int64_t axis) const {
   if (axis < 0) {
     axis += (int64_t)out()->as<TensorView>()->nDims();
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       axis >= 0 && axis < (int64_t)windowShape().size(),
       "Invalid axis: ",
       axis);
@@ -2223,7 +2217,7 @@ std::string ViewAsScalar::toString(int indent_size) const {
 }
 
 std::string ViewAsScalar::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(ViewAsScalar)
@@ -2241,7 +2235,7 @@ std::string ViewOp::toString(int indent_size) const {
 }
 
 std::string ViewOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(ViewOp)
@@ -2290,7 +2284,7 @@ std::string LoadStoreOp::toString(int indent_size) const {
 }
 
 std::string LoadStoreOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 bool LoadStoreOp::hasInnerTranspose() const {
@@ -2305,7 +2299,7 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(LoadStoreOp)
 
 IterDomainBuilder::IterDomainBuilder(Val* _start, Val* _extent)
     : start_(_start), extent_(_extent) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       start_ != nullptr && extent_ != nullptr,
       "Start and extent are required to build an iter domain.");
 }
@@ -2391,7 +2385,7 @@ IterDomainBuilder& IterDomainBuilder::is_mma_swizzled(bool _is_mma_swizzled) {
 }
 
 IterDomain* IterDomainBuilder::build() const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       start_ != nullptr && extent_ != nullptr,
       "Start and extent are required to build an iter domain.");
   return IrBuilder::create<IterDomain>(start_->container(), *this);
@@ -2429,25 +2423,25 @@ IterDomain::IterDomain(
   // size 1, we will mark it as Broadcast, but the resize must lie between root
   // and rfactor.
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       extent->dtype() == DataType::Index,
       "Cannot create an iter domain over an extent that is not an nvfuser_index_t but received ",
       extent->dtype(),
       " .");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       expanded_extent == nullptr || expanded_extent->dtype() == DataType::Index,
       "Cannot create an iter domain over an expanded_extent that is not an nvfuser_index_t but received ",
       expanded_extent->dtype(),
       " .");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       start->dtype() == DataType::Index,
       "Cannot create an iter domain with a start that is not an nvfuser_index_t but received ",
       start->dtype(),
       " .");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       stop_offset_->dtype() == DataType::Index,
       "Cannot create an iter domain with a stop_offset_ that is not an nvfuser_index_t but received ",
       stop_offset_->dtype(),
@@ -2582,19 +2576,19 @@ std::vector<IterDomain*> IterDomain::clone(
 // domains have valid start and stop, it's not possible to contiguous
 // predication.
 IterDomain* IterDomain::merge(IterDomain* outer, IterDomain* inner) {
-  TORCH_CHECK(
+  NVF_CHECK(
       outer->isReduction() == inner->isReduction(),
       "Merging IterDomains requires that their iteration types match. ",
       "Outer: ",
       outer->toString(),
       ", Inner: ",
       inner->toString());
-  TORCH_CHECK(
+  NVF_CHECK(
       (outer->isGather() && inner->isGather()) ||
           (!outer->isGather() && !inner->isGather()),
       "Merging gather and non-gather domains is not supported.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !outer->isStride() && !inner->isStride(),
       "No support for merging stride domains");
 
@@ -2658,7 +2652,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
     bool inner_split,
     Val* start_offset,
     Val* stop_offset) {
-  TORCH_CHECK(
+  NVF_CHECK(
       factor->isIntegralScalar(), "Cannot split by non-integer value ", factor);
 
   // outer loop size
@@ -2672,7 +2666,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
 
   if ((start_offset != nullptr && !start_offset->isZeroInt()) ||
       (stop_offset != nullptr && !stop_offset->isZeroInt())) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         in->definition() == nullptr,
         "Partial split is only allowed with root domains");
   }
@@ -2739,23 +2733,23 @@ std::pair<IterDomain*, IterDomain*> IterDomain::swizzle(
     IterDomain* in_x,
     IterDomain* in_y,
     SwizzleMode swizzle_mode) {
-  TORCH_CHECK(
+  NVF_CHECK(
       !in_x->extent()->isZeroInt() && !in_y->extent()->isZeroInt(),
       "Invalid swizzling of a empty dimension.");
 
   // TODO: reduction check on swizzle:
-  TORCH_CHECK(
+  NVF_CHECK(
       !in_x->isReduction() && !in_y->isReduction(),
       "swizzled reduction not yet supported");
 
   for (auto input : InputsOf::outputs(in_x->fusion(), {in_x, in_y})) {
-    TORCH_CHECK(
+    NVF_CHECK(
         !input->as<IterDomain>()->isBroadcast(),
         "swizzling broadcast axes not yet supported");
   }
 
   // TODO: gather and shift check on swizzle
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !in_x->isGather() && !in_y->isGather(),
       "Swizzled gather not yet supported");
 
@@ -2775,11 +2769,11 @@ IterDomain* IterDomain::resize(
     Val* right_expansion,
     bool mark_as_rfactor,
     std::optional<IterType> iter_type_opt) {
-  TORCH_CHECK(
+  NVF_CHECK(
       left_expansion->isIntegralScalar(),
       "Expansion factor must be an integer scalar: ",
       left_expansion->toString());
-  TORCH_CHECK(
+  NVF_CHECK(
       right_expansion->isIntegralScalar(),
       "Expansion factor must be an integer scalar: ",
       right_expansion->toString());
@@ -2790,24 +2784,24 @@ IterDomain* IterDomain::resize(
     if (left == 0 && right == 0) {
       // This is a trivial resize. Check that we are not changing the IterType,
       // then return the input.
-      TORCH_CHECK(
+      NVF_CHECK(
           !iter_type_opt.has_value() ||
               iter_type_opt.value() == in->getIterType(),
           "If IterType is specified in pad with zero expansion then it must match input");
       return in;
     }
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       in->getIterType() == IterType::Iteration ||
           in->getIterType() == IterType::Broadcast ||
           in->getIterType() == IterType::Symbolic || "Not a valid IterType: ",
       in->getIterType());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       in->start()->isZeroInt(),
       "Non-zero start not supported: ",
       in->toString());
-  TORCH_CHECK(
+  NVF_CHECK(
       in->stopOffset()->isZeroInt(),
       "Non-zero stop offset not considered: ",
       in->toString());
@@ -2874,7 +2868,7 @@ void IterDomain::parallelize(ParallelType t) {
   // assert check that we only parallelize a leaf domain.
   // leaf domains are domains that are not used by any other domains.
   if (t != ParallelType::Serial) {
-    TORCH_CHECK(
+    NVF_CHECK(
         uses().empty(),
         "Only allowed to parallelize a leaf domain.",
         " Domain: ",
@@ -2887,7 +2881,7 @@ void IterDomain::parallelize(ParallelType t) {
 
   if (t == ParallelType::Unroll || isParallelTypeVectorize(t) ||
       t == ParallelType::Group) {
-    TORCH_CHECK(
+    NVF_CHECK(
         start()->isZeroInt() && extent()->isConstScalar(),
         "Vectorization, unrolling, unswitching and grouping are only supported with start = 0 and extent as a const int, but got ",
         "a start of ",
@@ -2898,7 +2892,7 @@ void IterDomain::parallelize(ParallelType t) {
   }
 
   if (t == ParallelType::Group) {
-    TORCH_CHECK(
+    NVF_CHECK(
         getIterType() == IterType::Iteration,
         "Grouping IterDomain of non Iteration type is not allowed. ",
         getIterType());
@@ -2912,7 +2906,7 @@ void IterDomain::parallelize(ParallelType t) {
     //  to make copies of the iterdomains. We might eventually just want
     //  to lock these parallel types and not allowing any changes once
     //  they are swizzled.
-    TORCH_CHECK(
+    NVF_CHECK(
         t == ParallelType::Vectorize || t == ParallelType::TIDx ||
             t == ParallelType::Serial || t == ParallelType::Mma,
         "Parallel type other than serial, tidx, vectorize not allowed for mma swizzled ids");
@@ -2942,7 +2936,7 @@ namespace {
 void validateContiguity(
     const std::vector<IterDomain*>& allocation_domain,
     const std::vector<std::optional<bool>>& contiguity) {
-  TORCH_CHECK(
+  NVF_CHECK(
       contiguity.size() == allocation_domain.size(),
       "Invalid contiguity information provided, incorrect size. Received vector of size ",
       contiguity.size(),
@@ -2952,7 +2946,7 @@ void validateContiguity(
     bool expect_null =
         (allocation_domain.at(i)->isBroadcast() ||
          allocation_domain.at(i)->isReduction());
-    TORCH_CHECK(
+    NVF_CHECK(
         expect_null != contiguity.at(i).has_value(),
         "The contiguity of a broadcast/reduction dimension must be None. "
         "The contiguity of a non-broadcast/reduction dimension must be true/false");
@@ -2992,7 +2986,7 @@ TensorDomain::TensorDomain(
   validateContiguity(maybeAllocation(), contiguity_);
 
   if (!root_domain_.empty()) {
-    TORCH_CHECK(!leaf_domain_.empty(), "Root domain is not empty but leaf is");
+    NVF_CHECK(!leaf_domain_.empty(), "Root domain is not empty but leaf is");
     ir_utils::validateDomainEquivalence(root_domain_, leaf_domain_);
   }
 
@@ -3017,7 +3011,7 @@ TensorDomain::TensorDomain(
   validateContiguity(maybeAllocation(), contiguity_);
 
   if (!root_domain_.empty()) {
-    TORCH_CHECK(!leaf_domain_.empty(), "Root domain is not empty but leaf is");
+    NVF_CHECK(!leaf_domain_.empty(), "Root domain is not empty but leaf is");
     ir_utils::validateDomainEquivalence(root_domain_, leaf_domain_);
     if (!rfactor_domain_.empty()) {
       ir_utils::validateDomainEquivalence(root_domain_, rfactor_domain_);
@@ -3048,7 +3042,7 @@ TensorDomain::TensorDomain(
   validateContiguity(maybeAllocation(), contiguity_);
 
   if (!root_domain_.empty()) {
-    TORCH_CHECK(!leaf_domain_.empty(), "Root domain is not empty but leaf is");
+    NVF_CHECK(!leaf_domain_.empty(), "Root domain is not empty but leaf is");
     ir_utils::validateDomainEquivalence(root_domain_, leaf_domain_);
     if (!rfactor_domain_.empty()) {
       ir_utils::validateDomainEquivalence(root_domain_, rfactor_domain_);
@@ -3200,11 +3194,11 @@ std::string TensorDomain::toInlineString(int indent_size) const {
 
 void TensorDomain::setContiguity(
     const std::vector<std::optional<bool>>& contig) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       maybeAllocation().size() == contig.size(),
       "Invalid size of contiguity vector");
   for (auto i : c10::irange(contig.size())) {
-    TORCH_CHECK(
+    NVF_CHECK(
         maybeAllocation().at(i)->isBroadcast() != contig.at(i).has_value(),
         "The contiguity of a broadcast dimension must be None. "
         "The contiguity of a non-broadcast dimension must be true/false");
@@ -3277,12 +3271,11 @@ std::optional<unsigned int> TensorDomain::getReductionAxis() const {
 // i here is int, as we want to accept negative value and ::size_type can be a
 // uint.
 IterDomain* TensorDomain::axis(int i) const {
-  TORCH_INTERNAL_ASSERT(
-      nDims() > 0, "Tried to access an axis in a 0-dim domain");
+  NVF_ERROR(nDims() > 0, "Tried to access an axis in a 0-dim domain");
   if (i < 0) {
     i += (int)nDims();
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       i >= 0 && (unsigned int)i < nDims(),
       "Tried to access axis ",
       i,
@@ -3292,21 +3285,21 @@ IterDomain* TensorDomain::axis(int i) const {
 }
 
 int64_t TensorDomain::posOf(IterDomain* id) const {
-  TORCH_INTERNAL_ASSERT(nDims() > 0, "Tried to find an axis in a 0-dim domain");
+  NVF_ERROR(nDims() > 0, "Tried to find an axis in a 0-dim domain");
   int64_t i = 0;
   while (i < (int64_t)leaf_domain_.size()) {
     if (leaf_domain_[i] == id)
       return i;
     i++;
   }
-  TORCH_CHECK(false, "Provided id is not part of this domain.");
+  NVF_CHECK(false, "Provided id is not part of this domain.");
 }
 
 int64_t TensorDomain::rootPosOf(IterDomain* id) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !root_domain_.empty(), "Tried to find an axis in a 0-dim root domain");
   auto it = std::find(root_domain_.begin(), root_domain_.end(), id);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       it != root_domain_.end(), "Provided id is not part of root domain.");
   return std::distance(root_domain_.begin(), it);
 }
@@ -3316,11 +3309,11 @@ void TensorDomain::split(
     Val* factor,
     bool inner_split,
     bool trim_out_of_bounds) {
-  TORCH_INTERNAL_ASSERT(nDims() > 0, "Tried to do split on a 0-dim domain");
+  NVF_ERROR(nDims() > 0, "Tried to do split on a 0-dim domain");
   if (axis_ < 0)
     axis_ += (int)nDims();
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       axis_ >= 0 && (unsigned int)axis_ < nDims(),
       "Tried to split on axis outside TensorDomain's range.");
 
@@ -3328,12 +3321,12 @@ void TensorDomain::split(
 
   // partial split is only allowed with root domains
   if (trim_out_of_bounds) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         std::find(root().begin(), root().end(), id) != root().end(),
         "Partial split is only allowed with root domains");
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !id->isMmaSwizzled(),
       "Further transformation on warp mapped id's not allowed.");
 
@@ -3347,19 +3340,19 @@ void TensorDomain::split(
 
 // Merge "axis_o" and "axis_i" into 1 dimension
 void TensorDomain::merge(int axis_o, int axis_i) {
-  TORCH_INTERNAL_ASSERT(nDims() > 0, "Tried to do merge on a 0-dim domain");
+  NVF_ERROR(nDims() > 0, "Tried to do merge on a 0-dim domain");
   if (axis_o < 0)
     axis_o += (int)nDims();
 
   if (axis_i < 0)
     axis_i += (int)nDims();
 
-  TORCH_CHECK(
+  NVF_CHECK(
       axis_o >= 0 && (unsigned int)axis_o < nDims() && axis_i >= 0 &&
           (unsigned int)axis_i < nDims(),
       "Invalid merge detected, either one or both axes are outside of TensorView's range.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       axis_o != axis_i,
       "Invalid merge detected, axes provided are the same axis.");
 
@@ -3372,7 +3365,7 @@ void TensorDomain::merge(int axis_o, int axis_i) {
   IterDomain* first = axis(axis_o);
   IterDomain* second = axis(axis_i);
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !first->isMmaSwizzled() && !second->isMmaSwizzled(),
       "Further transformation on warp mapped id's not allowed.");
 
@@ -3386,7 +3379,7 @@ void TensorDomain::merge(int axis_o, int axis_i) {
 
 // Reorder axes according to map[old_pos] = new_pos
 void TensorDomain::reorder(const std::unordered_map<int, int>& old2new_) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       nDims() != 0 || old2new_.empty(), "Tried to reorder a 0-dim domain");
   leaf_domain_ = orderedAs(leaf_domain_, old2new_);
   resetDomains();
@@ -3395,7 +3388,7 @@ void TensorDomain::reorder(const std::unordered_map<int, int>& old2new_) {
 std::vector<IterDomain*> TensorDomain::orderedAs(
     const std::vector<IterDomain*>& dom,
     const std::unordered_map<int, int>& old2new_) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !dom.empty() || old2new_.empty(), "Tried to reorder a 0-dim domain");
 
   // Eventhough these checks are already in TensorView, we want to redo them as
@@ -3418,13 +3411,13 @@ void TensorDomain::swizzle(
     int x,
     int y,
     SwizzleMode swizzle_mode) {
-  TORCH_INTERNAL_ASSERT(nDims() > 0, "Tried to do merge on a 0-dim domain");
+  NVF_ERROR(nDims() > 0, "Tried to do merge on a 0-dim domain");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       x >= 0 && (unsigned int)x < nDims(),
       "Invalid swizzle detected, either one or both axes are outside of TensorView's range.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       y >= 0 && (unsigned int)y < nDims(),
       "Invalid swizzle detected, either one or both axes are outside of TensorView's range.");
 
@@ -3502,7 +3495,7 @@ bool TensorDomain::hasReduction(const std::vector<IterDomain*>& td) {
 }
 
 TensorDomain* TensorDomain::view(const AnalyzeViewResult& view_analysis) {
-  TORCH_INTERNAL_ASSERT(nDims() > 0, "Tried to view transform a 0-dim domain");
+  NVF_ERROR(nDims() > 0, "Tried to view transform a 0-dim domain");
   return transformView(this, view_analysis);
 }
 
@@ -3515,15 +3508,15 @@ TensorDomain* TensorDomain::flatten(int64_t start_dim, int64_t end_dim) {
   if (end_dim < 0) {
     end_dim += (int64_t)inp_domain.size();
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       start_dim >= 0 && start_dim < int64_t(inp_domain.size()),
       "Invalid start_dim ",
       start_dim);
-  TORCH_CHECK(
+  NVF_CHECK(
       end_dim >= 0 && end_dim < int64_t(inp_domain.size()),
       "Invalid end_dim ",
       end_dim);
-  TORCH_CHECK(start_dim <= end_dim, "start_dim must be <= end_dim");
+  NVF_CHECK(start_dim <= end_dim, "start_dim must be <= end_dim");
 
   std::vector<IterDomain*> new_root_domain;
   new_root_domain.reserve(inp_domain.size());
@@ -3604,7 +3597,7 @@ Split::Split(
     Val* start_offset,
     Val* stop_offset)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       factor->isIntegralScalar(),
       "Attempted to create a Split node with a non-integer factor.");
   if (start_offset == nullptr) {
@@ -3645,11 +3638,11 @@ std::string Split::toString(int indent_size) const {
 }
 
 std::string Split::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Split can not be printed inline");
+  NVF_CHECK(false, "Split can not be printed inline");
 }
 
 Val* Split::extent(Val* in_extent, Val* start_offset, Val* stop_offset) {
-  TORCH_INTERNAL_ASSERT(in_extent != nullptr);
+  NVF_ERROR(in_extent != nullptr);
 
   if (start_offset != nullptr && !start_offset->isZeroInt()) {
     in_extent = sub(in_extent, start_offset);
@@ -3688,7 +3681,7 @@ std::string Merge::toString(int indent_size) const {
 }
 
 std::string Merge::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(Merge)
@@ -3725,7 +3718,7 @@ std::string Swizzle2D::toString(int indent_size) const {
 }
 
 std::string Swizzle2D::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(Swizzle2D)
@@ -3756,7 +3749,7 @@ std::string Resize::toString(int indent_size) const {
 }
 
 std::string Resize::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Resize can not be printed inline");
+  NVF_CHECK(false, "Resize can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(Resize)
@@ -3783,17 +3776,17 @@ bool NamedScalar::sameAs(const Statement* other) const {
 }
 
 NamedScalar* NamedScalar::getParallelDim(ParallelType p_type) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       isParallelTypeThread(p_type),
       "Cannot get parallel dim of non thread type, received: ",
       p_type);
-  TORCH_INTERNAL_ASSERT(FusionGuard::getCurFusion() != nullptr);
+  NVF_ERROR(FusionGuard::getCurFusion() != nullptr);
   std::string parallel_dim = stringifyThreadSize(p_type);
   return IrBuilder::create<NamedScalar>(parallel_dim, DataType::Index);
 }
 
 NamedScalar* NamedScalar::getParallelIndex(ParallelType p_type) {
-  TORCH_INTERNAL_ASSERT(FusionGuard::getCurFusion() != nullptr);
+  NVF_ERROR(FusionGuard::getCurFusion() != nullptr);
   std::string parallel_ind = stringifyThread(p_type);
   return IrBuilder::create<NamedScalar>(parallel_ind, DataType::Index);
 }
@@ -3841,12 +3834,12 @@ PadOp::PadOp(
     : Expr(passkey) {
   const auto ndims =
       TensorDomain::noReductions(inp->getMaybeRFactorDomain()).size();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       pad_widths.size() % 2 == 0,
       "Invalid size of padding width vector: ",
       pad_widths.size(),
       ". Number of width vals must be even.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       pad_widths.size() == ndims * 2,
       "Invalid size of padding width vector: ",
       pad_widths.size(),
@@ -3855,7 +3848,7 @@ PadOp::PadOp(
   addInput(inp);
   addInput(value);
   for (auto width : pad_widths) {
-    TORCH_CHECK(width != nullptr, "Padding width must not be nullptr");
+    NVF_CHECK(width != nullptr, "Padding width must not be nullptr");
     addInput(width);
   }
 }
@@ -3872,7 +3865,7 @@ std::string PadOp::toString(int indent_size) const {
 }
 
 std::string PadOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 std::vector<int> PadOp::getPaddedAxes() const {
@@ -3900,7 +3893,7 @@ std::pair<Val*, Val*> PadOp::getPadWidths(int axis) const {
     axis += num_dims;
   }
 
-  TORCH_CHECK(axis >= 0 && axis < num_dims, "Invalid axis: ", axis);
+  NVF_CHECK(axis >= 0 && axis < num_dims, "Invalid axis: ", axis);
 
   int64_t offset_even = (int64_t)axis * 2;
   int64_t offset_odd = offset_even + 1;
@@ -3917,7 +3910,7 @@ SliceOp::SliceOp(
     : Expr(passkey) {
   const auto ndims =
       TensorDomain::noReductions(inp->getMaybeRFactorDomain()).size();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ndims == ranges.size(),
       "The range vector must have the same number of Slice descriptors. Given: ",
       ranges.size(),
@@ -3927,9 +3920,9 @@ SliceOp::SliceOp(
   addOutput(out);
   addInput(inp);
   for (const auto& range : ranges) {
-    TORCH_INTERNAL_ASSERT(range.start != nullptr, "nullptr not allowed");
-    TORCH_INTERNAL_ASSERT(range.stop != nullptr, "nullptr not allowed");
-    TORCH_INTERNAL_ASSERT(range.step != nullptr, "nullptr not allowed");
+    NVF_ERROR(range.start != nullptr, "nullptr not allowed");
+    NVF_ERROR(range.stop != nullptr, "nullptr not allowed");
+    NVF_ERROR(range.step != nullptr, "nullptr not allowed");
     addInput(range.start);
     addInput(range.stop);
     addInput(range.step);
@@ -3955,13 +3948,13 @@ std::string SliceOp::toString(int indent_size) const {
 }
 
 std::string SliceOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 std::vector<Slice> SliceOp::getRanges() const {
   const auto num_range_vals =
       std::distance(getRangeInputBegin(), getRangeInputEnd());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       num_range_vals % 3 == 0,
       "Unexpected number of range vals: ",
       num_range_vals);
@@ -3988,7 +3981,7 @@ CatOp::CatOp(
   for (auto inp : inputs) {
     addInput(inp);
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       concatenated_dim >= 0 &&
           concatenated_dim <
               static_cast<int>(ir_utils::getTv(out)->getRootDomain().size()),
@@ -4006,10 +3999,10 @@ CatOp::CatOp(
     Val* concatenated_domain_index,
     const std::vector<Val*>& preds)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       passkey.ir_container_ != nullptr,
       "IrContainer must be provided to create a CatOp.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "Should only be used for Kernel container.");
 
@@ -4037,37 +4030,35 @@ std::string CatOp::toString(int indent_size) const {
 }
 
 std::string CatOp::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 Val* CatOp::getConcatenatedDomainIndex() const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       container()->isA<kir::Kernel>(),
       "Should only be used for Kernel container.");
-  TORCH_INTERNAL_ASSERT(!attributes().empty(), "No attribute found");
-  TORCH_INTERNAL_ASSERT(
-      attribute(1) != nullptr, "nulllptr attribute is invalid");
+  NVF_ERROR(!attributes().empty(), "No attribute found");
+  NVF_ERROR(attribute(1) != nullptr, "nulllptr attribute is invalid");
   auto idx = attribute(1)->as<Val>();
   return idx;
 }
 
 Val* CatOp::getPred(int input_idx) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       container()->isA<kir::Kernel>(),
       "Should only be used for Kernel container.");
   const auto num_input_tensors = static_cast<int>(inputs().size());
-  TORCH_INTERNAL_ASSERT(
-      input_idx < num_input_tensors, "Invalid input index: ", input_idx);
+  NVF_ERROR(input_idx < num_input_tensors, "Invalid input index: ", input_idx);
   const auto attr_idx = input_idx + 2;
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       attr_idx < static_cast<int>(attributes().size()),
       "Invalid attribute index: ",
       attr_idx,
       ", number of attributes: ",
       attributes().size());
   auto attr = attributeVal(attr_idx);
-  TORCH_INTERNAL_ASSERT(attr != nullptr, "nullptr attribute is invalid");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(attr != nullptr, "nullptr attribute is invalid");
+  NVF_ERROR(
       attr->dtype() == DataType::Bool,
       "Attribute must be a Bool val: ",
       attr->toInlineString());

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -22,7 +22,7 @@ namespace nvfuser::ir_utils {
 std::vector<int64_t> normalizeNew2Old(
     const std::vector<int64_t>& new2old_in,
     size_t ndims) {
-  TORCH_CHECK(
+  NVF_CHECK(
       new2old_in.size() == ndims,
       "There must be a transpose mapping for each dimension in domain");
 
@@ -35,7 +35,7 @@ std::vector<int64_t> normalizeNew2Old(
       [ndims](int64_t entry) { return entry < 0 ? entry + ndims : entry; });
 
   // Check if any adjusted values are < 0, or >= nDims, which are invalid
-  TORCH_CHECK(
+  NVF_CHECK(
       std::none_of(
           new2old.begin(),
           new2old.end(),
@@ -54,7 +54,7 @@ std::vector<int64_t> normalizeNew2Old(
       [](int64_t entry) { return entry; });
 
   // Error out if duplicate values are found.
-  TORCH_CHECK(
+  NVF_CHECK(
       new2old.size() == ndims && old_pos_set.size() == new2old.size(),
       "Duplicate entries in transformation map.");
 
@@ -81,7 +81,7 @@ std::vector<int> normalizeOld2New(
 
   // Check if any adjusted values are < 0, or >= nDims, which are invalid
 
-  TORCH_CHECK(
+  NVF_CHECK(
       std::none_of(
           old2new.begin(),
           old2new.end(),
@@ -112,7 +112,7 @@ std::vector<int> normalizeOld2New(
       });
 
   // Error out if duplicate values are found.
-  TORCH_CHECK(
+  NVF_CHECK(
       old_pos_set.size() == old2new.size() &&
           new_pos_set.size() == old2new.size(),
       "Duplicate entries in transformation map sent to TensorView reorder.");
@@ -164,7 +164,7 @@ namespace ValReplacement {
 struct SubstituteInExpr : public OptOutMutator {
  public:
   static Expr* subsitute(Expr* expr, Val* reference, Val* substitute) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         expr != nullptr && reference != nullptr && substitute != nullptr,
         "Nullptr arg found.");
     SubstituteInExpr sie(reference, substitute);
@@ -200,7 +200,7 @@ Expr* replaceValInExpr(Expr* expr, Val* reference, Val* substitute) {
 TensorView* rfactorHelper(
     TensorView* reduction_tv,
     const std::vector<int>& axes) {
-  TORCH_INTERNAL_ASSERT(reduction_tv->definition() != nullptr);
+  NVF_ERROR(reduction_tv->definition() != nullptr);
   const bool has_multiple_tvs = reduction_tv->definition()->inputs().size() > 1;
   if (!has_multiple_tvs) {
     return reduction_tv->rFactor(axes);
@@ -623,7 +623,7 @@ Val* replaceValRecursively(
     return val;
   }
 
-  TORCH_INTERNAL_ASSERT(def->outputs().size() == 1);
+  NVF_ERROR(def->outputs().size() == 1);
 
   bool mutated = false;
 
@@ -830,14 +830,14 @@ class ValidateDomainEquivalence : private IterVisitor {
       : initial_domain_({initial_domain.begin(), initial_domain.end()}),
         derived_domain_({derived_domain.begin(), derived_domain.end()}),
         frontier_({initial_domain.begin(), initial_domain.end()}) {
-    TORCH_INTERNAL_ASSERT(!initial_domain.empty());
-    TORCH_INTERNAL_ASSERT(!derived_domain.empty());
+    NVF_ERROR(!initial_domain.empty());
+    NVF_ERROR(!derived_domain.empty());
     // Make sure there's no duplicate in the parameter vectors
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         initial_domain.size() == initial_domain_.size(),
         "Duplicated entry is detected in inial_domain: ",
         toDelimitedString(initial_domain));
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         derived_domain.size() == derived_domain_.size(),
         "Duplicated entry is detected in derived_domain: ",
         toDelimitedString(derived_domain));
@@ -855,7 +855,7 @@ class ValidateDomainEquivalence : private IterVisitor {
         })) {
       // Make sure all non-symbolic IDs of the derived set are included
       // in the frontier set
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           std::all_of(
               derived_domain.begin(),
               derived_domain.end(),
@@ -871,12 +871,12 @@ class ValidateDomainEquivalence : private IterVisitor {
       // derived set. It is also possible that an ID in the initial
       // domain set still remains in the frontier set as there may be
       // no expr connecting to the derived set, e.g., dynamic reshape
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           std::all_of(
               frontier_.begin(),
               frontier_.end(),
               [&](Val* val) {
-                TORCH_INTERNAL_ASSERT(val->isA<IterDomain>());
+                NVF_ERROR(val->isA<IterDomain>());
                 return derived_domain_.count(val->as<IterDomain>()) ||
                     initial_domain_.count(val);
               }),
@@ -885,7 +885,7 @@ class ValidateDomainEquivalence : private IterVisitor {
           ". Derived domain: ",
           toDelimitedString(derived_domain));
     } else {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           derived_domain_ == frontier_,
           "Invalid derived domain. Initial domain: ",
           toDelimitedString(initial_domain),
@@ -895,18 +895,18 @@ class ValidateDomainEquivalence : private IterVisitor {
   };
 
   void dispatch(Expr* expr) override {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         std::all_of(expr->inputs().begin(), expr->inputs().end(), [](Val* v) {
           return v->isA<IterDomain>();
         }));
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         std::all_of(expr->outputs().begin(), expr->outputs().end(), [](Val* v) {
           return v->isA<IterDomain>();
         }));
     // If any of the inputs is included in derived_domain_, that means there's a
     // dependency within derived_domain_ and the dependent domains
     // redundantly cover the initial domain
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         std::none_of(
             expr->inputs().begin(),
             expr->inputs().end(),
@@ -919,7 +919,7 @@ class ValidateDomainEquivalence : private IterVisitor {
         toDelimitedString(derived_domain_));
     for (auto out : expr->outputs()) {
       // Make sure the output is not yet visited
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           frontier_.insert(out).second,
           "Invalid derived domain due to dependent expr: ",
           expr->toString(),
@@ -927,7 +927,7 @@ class ValidateDomainEquivalence : private IterVisitor {
           out->toString());
     }
     for (auto inp : expr->inputs()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           frontier_.erase(inp) == 1,
           "Invalid derived domain due to dependent expr: ",
           expr->toString(),
@@ -1024,7 +1024,7 @@ std::vector<Statement*> checkCycle(
 }
 
 bool isAlignedScopeExpr(const Expr* expr) {
-  TORCH_INTERNAL_ASSERT(expr != nullptr);
+  NVF_ERROR(expr != nullptr);
   if (auto ite = dynamic_cast<const kir::IfThenElse*>(expr)) {
     if (ite->predicate()->hasValue() &&
         getRegisterType(ite->predicate()->value()) ==
@@ -1041,7 +1041,7 @@ bool isAlignedScopeExpr(const Expr* expr) {
       return false;
     }
   } else {
-    TORCH_INTERNAL_ASSERT(false, "Invalid scope expr: ", expr->toString());
+    NVF_ERROR(false, "Invalid scope expr: ", expr->toString());
   }
 
   return true;
@@ -1054,7 +1054,7 @@ std::vector<Statement*> checkCycle(Fusion* fusion) {
 namespace {
 
 inline bool isTensorAttr(const Val* val, const std::string& attr_name) {
-  TORCH_INTERNAL_ASSERT(val != nullptr);
+  NVF_ERROR(val != nullptr);
   auto getitem = dynamic_cast<GetItem*>(val->definition());
   if (getitem == nullptr) {
     return false;

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <type.h>
 
@@ -55,7 +56,7 @@ class FilterIterator {
   }
 
   bool operator==(const FilterIterator& other) const {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         end_ == other.end_,
         "Comparing two FilteredViews that originate from different containers");
     return current_ == other.current_;
@@ -470,7 +471,7 @@ bool isAlignedScopeExpr(const Expr* expr);
 //! then throw an error.
 inline TensorView* getSoleProducerTv(const TensorView* tv) {
   auto producers = producerTvsOf(tv);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       producers.size() == 1,
       "Expected only one producer of ",
       tv->toString(),

--- a/csrc/iter_visitor.h
+++ b/csrc/iter_visitor.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <dispatch.h>
 #include <ir/base_nodes.h>

--- a/csrc/kernel.h
+++ b/csrc/kernel.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <device_lower/analysis/sync_information.h>
 #include <device_lower/pass/warp_reduce.h>
@@ -178,7 +179,7 @@ class TORCH_CUDA_CU_API Kernel final : public Fusion {
   Kernel(Fusion* fusion, PrimDataType index_type = PrimDataType::Int)
       : Fusion(*fusion), index_type_(index_type) {
     // Index type must be resolved to either int32 or int64
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         index_type_ == PrimDataType::Int ||
             index_type_ == PrimDataType::Int32 || "Invalid index type: ",
         index_type_);

--- a/csrc/kernel_cache.h
+++ b/csrc/kernel_cache.h
@@ -9,6 +9,7 @@
 
 #include <dynamic_transform.h>
 #include <evaluator_common.h>
+#include <exceptions.h>
 #include <executor.h>
 #include <fusion.h>
 #include <fusion_segmenter.h>
@@ -129,7 +130,7 @@ class TORCH_CUDA_CU_API FusionKernelRuntime {
       return PrimDataType::Int;
     }
     auto index_type = schedulers().at(0).get()->params()->cparams.index_type;
-    TORCH_INTERNAL_ASSERT(index_type.has_value());
+    NVF_ERROR(index_type.has_value());
     return index_type.value();
   }
 
@@ -198,8 +199,7 @@ class TORCH_CUDA_CU_API FusionKernelRuntime {
   //! TODO: have a interface for grabbing all recent logs. Need to put a buffer
   //! space for recent logs
   ExecutorLog getMostRecentExecutorLog() {
-    TORCH_INTERNAL_ASSERT(
-        profiling_, "Executor log is only produced in profiling mode");
+    NVF_ERROR(profiling_, "Executor log is only produced in profiling mode");
     return most_recent_executor_log_;
   }
 
@@ -556,7 +556,7 @@ class TORCH_CUDA_CU_API FusionExecutorCache {
   //  to capture runtime profiling info. We also need to define
   //  a suitable profiling window / buffer size.
   ExecutorLog getMostRecentExecutorInfo() {
-    TORCH_INTERNAL_ASSERT(most_recent_runtime_ != nullptr);
+    NVF_ERROR(most_recent_runtime_ != nullptr);
     return most_recent_runtime_->getMostRecentExecutorLog();
   }
 
@@ -634,7 +634,7 @@ class TORCH_CUDA_CU_API FusionExecutorCache {
   //! be zero if the measurement is not enabled
   float getMostRecentKernelTimeMs() const {
     auto rt = getMostRecentKernelRuntime();
-    TORCH_INTERNAL_ASSERT(rt != nullptr);
+    NVF_ERROR(rt != nullptr);
     return rt->kernelTimeMs();
   }
 

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -38,34 +38,33 @@ Predicate::Predicate(
       ptype_(ptype),
       expr_(expr),
       thread_pred_(thread_pred) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
-  TORCH_INTERNAL_ASSERT(
-      ptype != PredicateType::Unswitch && ptype != PredicateType::Manual);
+  NVF_ERROR(ptype != PredicateType::Unswitch && ptype != PredicateType::Manual);
 }
 
 Predicate::Predicate(IrBuilderPasskey passkey, ForLoop* unrolled_loop)
     : Val(passkey, ValType::Predicate, DataType::Bool),
       ptype_(PredicateType::Unswitch),
       unrolled_loop_(unrolled_loop) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
-  TORCH_INTERNAL_ASSERT(unrolled_loop != nullptr);
+  NVF_ERROR(unrolled_loop != nullptr);
 }
 
 Predicate::Predicate(IrBuilderPasskey passkey, Val* value)
     : Val(passkey, ValType::Predicate, DataType::Bool),
       ptype_(PredicateType::Manual),
       value_(value) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
-  TORCH_INTERNAL_ASSERT(value != nullptr);
+  NVF_ERROR(value != nullptr);
 }
 
 std::string Predicate::toString(int indent_size) const {
@@ -88,11 +87,11 @@ TensorIndex::TensorIndex(
     : Val(passkey, ValType::TensorIndex, view->getDataType().value()),
       view_(view),
       index_(index) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       isPointerType(index->dtype()) || index->dtype() == DataType::Index,
       "Cannot index with a value other than an int.");
 }
@@ -111,7 +110,7 @@ std::string TensorIndex::toString(int indent_size) const {
       ss << "_l";
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unknown tensor memory type.");
+      NVF_ERROR(false, "Unknown tensor memory type.");
   }
   ss << "[";
   ss << index()->toInlineString(indent_size);
@@ -132,18 +131,17 @@ Allocate::Allocate(
     bool zero_init,
     Allocate* alias)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   if (!shape.empty()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         (shape.size() == 1 && shape[0]->isOneInt()) ||
         buffer->isA<TensorView>());
   } else {
-    TORCH_INTERNAL_ASSERT(buffer->isA<TensorView>());
-    TORCH_INTERNAL_ASSERT(
-        buffer->as<TensorView>()->getMemoryType() == memory_type);
+    NVF_ERROR(buffer->isA<TensorView>());
+    NVF_ERROR(buffer->as<TensorView>()->getMemoryType() == memory_type);
     const auto domain = buffer->as<TensorView>()->domain();
     for (auto axis : domain->noReductions()) {
       shape.push_back(axis->extent());
@@ -164,8 +162,8 @@ Allocate::Allocate(
   }
 
   if (alias != nullptr) {
-    TORCH_INTERNAL_ASSERT(alias != this, "Invalid alias");
-    TORCH_INTERNAL_ASSERT(alias->memoryType() == memory_type, "Invalid alias");
+    NVF_ERROR(alias != this, "Invalid alias");
+    NVF_ERROR(alias->memoryType() == memory_type, "Invalid alias");
   }
 
   size = simplifyExpr(size);
@@ -213,14 +211,14 @@ std::string Allocate::toString(int indent_size) const {
 }
 
 std::string Allocate::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(Allocate)
 
 BlockSync::BlockSync(IrBuilderPasskey passkey, bool war_sync) : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   addDataAttribute(war_sync);
@@ -234,7 +232,7 @@ std::string BlockSync::toString(int indent_size) const {
 }
 
 std::string BlockSync::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(BlockSync)
@@ -244,7 +242,7 @@ GridSync::GridSync(
     ParallelTypeBitmap sync_dims,
     Val* sync_buffer)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
+  NVF_ERROR(passkey.ir_container_ != nullptr);
   addDataAttribute(sync_dims);
   addAttribute(sync_buffer);
 }
@@ -257,15 +255,15 @@ std::string GridSync::toString(int indent_size) const {
 }
 
 std::string GridSync::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(GridSync)
 
 CpAsyncWait::CpAsyncWait(IrBuilderPasskey passkey, int64_t keep_stages)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   addDataAttribute(keep_stages);
@@ -278,14 +276,14 @@ std::string CpAsyncWait::toString(int indent_size) const {
 }
 
 std::string CpAsyncWait::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(CpAsyncWait)
 
 CpAsyncCommit::CpAsyncCommit(IrBuilderPasskey passkey) : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
 }
@@ -297,14 +295,14 @@ std::string CpAsyncCommit::toString(int indent_size) const {
 }
 
 std::string CpAsyncCommit::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(CpAsyncCommit)
 
 InitMagicZero::InitMagicZero(IrBuilderPasskey passkey) : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
 }
@@ -316,14 +314,14 @@ std::string InitMagicZero::toString(int indent_size) const {
 }
 
 std::string InitMagicZero::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(InitMagicZero)
 
 UpdateMagicZero::UpdateMagicZero(IrBuilderPasskey passkey) : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
 }
@@ -335,7 +333,7 @@ std::string UpdateMagicZero::toString(int indent_size) const {
 }
 
 std::string UpdateMagicZero::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(UpdateMagicZero)
@@ -356,7 +354,7 @@ std::vector<Expr*>::iterator Scope::insert(
 
 std::vector<Expr*>::iterator Scope::insert_before(Expr* ref, Expr* expr) {
   const auto it = std::find(exprs_.begin(), exprs_.end(), ref);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       it != exprs_.end(),
       "Tried to insert ",
       expr,
@@ -370,7 +368,7 @@ std::vector<Expr*>::iterator Scope::insert_before(Expr* ref, Expr* expr) {
 
 std::vector<Expr*>::iterator Scope::insert_after(Expr* ref, Expr* expr) {
   const auto it = std::find(exprs_.begin(), exprs_.end(), ref);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       it != exprs_.end(),
       "Tried to insert ",
       expr,
@@ -423,11 +421,11 @@ ForLoop::ForLoop(
     bool unroll_required,
     DoubleBufferLoopStage double_buffer_loop_stage)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
-  TORCH_INTERNAL_ASSERT(isIntegralType(index->dtype()));
+  NVF_ERROR(isIntegralType(index->dtype()));
   addInput(index);
   addInput(iter_domain);
   if (start == nullptr && iter_domain->isThread()) {
@@ -440,14 +438,14 @@ ForLoop::ForLoop(
       step = FusionGuard::getCurFusion()->oneVal();
     }
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       index->dtype() == DataType::Index, "Loop index must be an index type.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       start == nullptr || start->dtype() == DataType::Index,
       "Loop start must be an index type.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       step->dtype() == DataType::Index, "Loop step must be an index type.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       stop == nullptr || stop->dtype() == DataType::Index,
       "Loop stop must be an index type.");
   addAttribute(start);
@@ -509,7 +507,7 @@ std::string ForLoop::toString(int indent_size) const {
 }
 
 std::string ForLoop::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 bool ForLoop::isUnrollable() const {
@@ -560,7 +558,7 @@ Val* ForLoop::start() const {
     return attributeVal(0);
   } else {
     // clang-tidy complains without this
-    TORCH_INTERNAL_ASSERT(iter_domain() != nullptr);
+    NVF_ERROR(iter_domain() != nullptr);
     return iter_domain()->start();
   }
 }
@@ -570,13 +568,13 @@ Val* ForLoop::stop() const {
     return attributeVal(1);
   } else {
     // clang-tidy complains without this
-    TORCH_INTERNAL_ASSERT(iter_domain() != nullptr);
+    NVF_ERROR(iter_domain() != nullptr);
     return iter_domain()->extent();
   }
 }
 
 Val* ForLoop::step() const {
-  TORCH_INTERNAL_ASSERT(attributeVal(2) != nullptr);
+  NVF_ERROR(attributeVal(2) != nullptr);
   return attributeVal(2);
 }
 
@@ -712,7 +710,7 @@ std::string IfThenElse::toString(int indent_size) const {
 }
 
 std::string IfThenElse::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(IfThenElse)
@@ -729,11 +727,11 @@ GridReduction::GridReduction(
     Val* entrances,
     bool is_allreduce)
     : ReductionOp(passkey, reduction_op_type, init, out, in, is_allreduce) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       attributes().size() == num_reduction_op_attr,
       "The num_reduction_op_attr does not match the number of attributes ReductionOp has."
       "If you changed ReductionOp, please change num_reduction_op_attr accordingly.");
@@ -778,7 +776,7 @@ std::string GridReduction::toString(int indent_size) const {
 }
 
 std::string GridReduction::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(GridReduction)
@@ -802,11 +800,11 @@ GroupedGridReduction::GroupedGridReduction(
           std::move(outputs),
           std::move(inputs),
           is_allreduce) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       attributes().size() == numGroupedReductionOpAttr(),
       "The numGroupedReductionOpAttr() does not match the number of attributes GroupedReductionOp has."
       "If you changed GroupedReductionOp, please change numGroupedReductionOpAttr() accordingly.");
@@ -857,7 +855,7 @@ std::string GroupedGridReduction::toString(int indent_size) const {
 }
 
 std::string GroupedGridReduction::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(GroupedGridReduction)
@@ -868,8 +866,8 @@ GridBroadcast::GridBroadcast(
     Allocate* broadcast_buffer,
     Allocate* sync_buffer)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   addAttribute(broadcast_op);
@@ -891,7 +889,7 @@ std::string GridBroadcast::toString(int indent_size) const {
 }
 
 std::string GridBroadcast::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(GridBroadcast)
@@ -906,8 +904,8 @@ GridWelford::GridWelford(
     Val* entrance_index,
     Val* entrances)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   addAttribute(welford_op);
@@ -982,7 +980,7 @@ std::string GridWelford::toString(int indent_size) const {
 }
 
 std::string GridWelford::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(GridWelford)
@@ -1005,11 +1003,11 @@ GroupedGridWelford::GroupedGridWelford(
           std::move(input_vals),
           std::move(init_vals),
           is_allreduce) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       attributes().size() == numGroupedWelfordOpAttr(),
       "The numGroupedWelfordOpAttr() does not match the number of attributes GroupedWelfordOp has."
       "If you changed GroupedReductionOp, please change numGroupedWelfordOpAttr() accordingly.");
@@ -1018,10 +1016,8 @@ GroupedGridWelford::GroupedGridWelford(
   addAttribute(entrances);
   addAttribute(buffer_stride);
   addDataAttribute(ParallelTypeBitmap{});
-  TORCH_INTERNAL_ASSERT(
-      reduction_buffers[0].size() == reduction_buffers[1].size());
-  TORCH_INTERNAL_ASSERT(
-      reduction_buffers[0].size() == reduction_buffers[2].size());
+  NVF_ERROR(reduction_buffers[0].size() == reduction_buffers[1].size());
+  NVF_ERROR(reduction_buffers[0].size() == reduction_buffers[2].size());
   for (auto i : c10::irange(reduction_buffers[0].size())) {
     addAttribute(reduction_buffers[0].at(i));
     addAttribute(reduction_buffers[1].at(i));
@@ -1035,7 +1031,7 @@ int GroupedGridWelford::getSmemBufferSize(int bdimx, int bdimy, int bdimz)
     const {
   auto out_tv = ir_utils::getTvOutput(this);
   auto kernel = dynamic_cast<kir::Kernel*>(container());
-  TORCH_INTERNAL_ASSERT(kernel != nullptr);
+  NVF_ERROR(kernel != nullptr);
 
   // By default, the required size is the same as the normal Welford reduction
   if (!useOuterOpt()) {
@@ -1053,15 +1049,15 @@ int GroupedGridWelford::getSmemBufferSize(int bdimx, int bdimy, int bdimz)
     auto pt = axis->getParallelType();
     if (pt == ParallelType::Group) {
       auto extent_int = axis->extent()->getInt();
-      TORCH_INTERNAL_ASSERT(extent_int.has_value());
+      NVF_ERROR(extent_int.has_value());
       group_count *= (int)extent_int.value();
     }
   }
 
-  TORCH_INTERNAL_ASSERT(group_count > 1);
+  NVF_ERROR(group_count > 1);
 
   int num_warps = bdimx * bdimy / 32;
-  TORCH_INTERNAL_ASSERT((bdimx * bdimy) % 32 == 0);
+  NVF_ERROR((bdimx * bdimy) % 32 == 0);
 
   int buf_size_for_avg_var = bdimx * num_warps * group_count *
       (int)dataTypeSize(out_tv->getDataType().value());
@@ -1124,7 +1120,7 @@ std::string GroupedGridWelford::toString(int indent_size) const {
 }
 
 std::string GroupedGridWelford::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(GroupedGridWelford)
@@ -1138,8 +1134,8 @@ VectorizedWelfordOp::VectorizedWelfordOp(
     Val* reciprocal_of_count,
     Val* hoisted_predicate)
     : WelfordOp(passkey, output, input, init, false) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   addAttribute(count);
@@ -1153,8 +1149,8 @@ AllocateFusedReduction::AllocateFusedReduction(
     IrBuilderPasskey passkey,
     Expr* grid_expr)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(passkey.ir_container_ != nullptr);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   addAttribute(grid_expr);
@@ -1168,11 +1164,11 @@ std::string AllocateFusedReduction::toString(int indent_size) const {
 }
 
 std::string AllocateFusedReduction::toInlineString(int indent_size) const {
-  TORCH_CHECK(false, "Tensor op can not be printed inline");
+  NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
 TensorIndex* AllocateFusedReduction::out() const {
-  TORCH_INTERNAL_ASSERT(gridExpr() != nullptr);
+  NVF_ERROR(gridExpr() != nullptr);
   if (gridExpr()->isA<GridReduction>() ||
       gridExpr()->isA<GroupedGridReduction>()) {
     return gridExpr()->outputs().at(0)->as<kir::TensorIndex>();
@@ -1183,13 +1179,12 @@ TensorIndex* AllocateFusedReduction::out() const {
           dynamic_cast<GroupedGridWelford*>(gridExpr())) {
     return grouped_grid_welford->out(0)->as<kir::TensorIndex>();
   } else {
-    TORCH_INTERNAL_ASSERT(
-        false, "Invalid grid expression: ", gridExpr()->toString());
+    NVF_ERROR(false, "Invalid grid expression: ", gridExpr()->toString());
   }
 }
 
 const ParallelTypeBitmap& AllocateFusedReduction::threadPredicate() const {
-  TORCH_INTERNAL_ASSERT(gridExpr() != nullptr);
+  NVF_ERROR(gridExpr() != nullptr);
   if (auto grid_reduction = dynamic_cast<GridReduction*>(gridExpr())) {
     return grid_reduction->threadPredicate();
   } else if (auto grid_welford = dynamic_cast<GridWelford*>(gridExpr())) {
@@ -1203,8 +1198,7 @@ const ParallelTypeBitmap& AllocateFusedReduction::threadPredicate() const {
           dynamic_cast<GroupedGridWelford*>(gridExpr())) {
     return grouped_grid_welford->threadPredicate();
   } else {
-    TORCH_INTERNAL_ASSERT(
-        false, "Invalid grid expression: ", gridExpr()->toString());
+    NVF_ERROR(false, "Invalid grid expression: ", gridExpr()->toString());
   }
 }
 

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <ir/base_nodes.h>
 #include <parallel_type_bitmap.h>
@@ -72,14 +73,14 @@ class TORCH_CUDA_CU_API Predicate final : public Val {
   }
 
   const Expr* expr() const {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         ptype_ != PredicateType::Unswitch &&
         ptype_ != PredicateType::Vectorize && ptype_ != PredicateType::Manual);
     return expr_;
   }
 
   Val* thread_pred() const {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         ptype_ == PredicateType::Inline ||
         ptype_ == PredicateType::Misaligned || ptype_ == PredicateType::Shift ||
         ptype_ == PredicateType::Padding ||
@@ -88,7 +89,7 @@ class TORCH_CUDA_CU_API Predicate final : public Val {
   }
 
   ForLoop* unrolled_loop() const {
-    TORCH_INTERNAL_ASSERT(ptype_ == PredicateType::Unswitch);
+    NVF_ERROR(ptype_ == PredicateType::Unswitch);
     return unrolled_loop_;
   }
 
@@ -97,14 +98,14 @@ class TORCH_CUDA_CU_API Predicate final : public Val {
   }
 
   Val* value() const {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         value_ != nullptr,
         "The conditional expression for this Predicate is invalid.");
     return value_;
   }
 
   void setValue(Val* value) {
-    TORCH_INTERNAL_ASSERT(value != nullptr, "The Bool expression is invalid.");
+    NVF_ERROR(value != nullptr, "The Bool expression is invalid.");
     value_ = value;
   }
 
@@ -143,7 +144,7 @@ class TORCH_CUDA_CU_API TensorIndex final : public Val {
   }
 
   TensorView* view() const {
-    TORCH_INTERNAL_ASSERT(view_ != nullptr);
+    NVF_ERROR(view_ != nullptr);
     return const_cast<TensorView*>(view_); // NOLINT
   }
 
@@ -231,11 +232,11 @@ class TORCH_CUDA_CU_API Allocate final : public Expr {
   // memory array. The addr argument should be a scalar expression describing an
   // aligned address in bytes.
   void setAddress(Val* addr) {
-    TORCH_CHECK(
+    NVF_CHECK(
         memoryType() == MemoryType::Shared,
         "Allocation address may only be set for shared memory allocations. Memory type is ",
         memoryType());
-    TORCH_CHECK(
+    NVF_CHECK(
         address() == nullptr,
         "Attempted to set address twice for allocation ",
         toString());
@@ -445,7 +446,7 @@ class TORCH_CUDA_CU_API Scope {
   }
 
   bool operator==(const Scope&) const {
-    TORCH_INTERNAL_ASSERT(false, "Should not reach here");
+    NVF_ERROR(false, "Should not reach here");
   }
 
   // Insert expr before pos

--- a/csrc/kernel_ir_dispatch.cpp
+++ b/csrc/kernel_ir_dispatch.cpp
@@ -103,7 +103,7 @@ std::vector<Expr*> ExprMutator::mutate(bool reverse_order) {
         return;
       }
       auto pos_it = std::find(exprs_.begin(), exprs_.end(), info.reference);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           pos_it != exprs_.end(),
           "Issue finding reference expression for insertion.");
       if (info.mode == MutationMode::BEFORE) {
@@ -140,7 +140,7 @@ std::vector<Expr*> ExprMutator::mutate(bool reverse_order) {
     if (replacement_info.scope == nullptr) {
       auto pos_it =
           std::find(exprs_.begin(), exprs_.end(), replacement_info.reference);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           pos_it != exprs_.end(),
           "Issue finding reference expression for replacement.");
       exprs_.insert(pos_it, replacement_info.new_expr);
@@ -159,11 +159,10 @@ std::vector<Expr*> ExprMutator::mutate(bool reverse_order) {
     if (removal_info.scope == nullptr) {
       auto pos_it =
           std::find(exprs_.begin(), exprs_.end(), removal_info.reference);
-      TORCH_INTERNAL_ASSERT(
-          pos_it != exprs_.end(), "Issue finding expression to remove.");
+      NVF_ERROR(pos_it != exprs_.end(), "Issue finding expression to remove.");
       exprs_.erase(pos_it);
     } else {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           removal_info.scope->contains(removal_info.reference),
           "Expression to remove is not found in the given scope: ",
           removal_info.reference->toString());
@@ -201,7 +200,7 @@ void ExprMutator::registerMutation(
   } else if (mode == MutationMode::REMOVE) {
     removal_.push_back(mutation);
   } else {
-    TORCH_INTERNAL_ASSERT(false, "Invalid mutation type");
+    NVF_ERROR(false, "Invalid mutation type");
   }
 }
 

--- a/csrc/kernel_ir_dispatch.h
+++ b/csrc/kernel_ir_dispatch.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <dispatch.h>
+#include <exceptions.h>
 
 namespace nvfuser {
 

--- a/csrc/manager.h
+++ b/csrc/manager.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 #include <torch/csrc/jit/ir/ir.h>
 
 /*

--- a/csrc/maxinfo_propagator.cpp
+++ b/csrc/maxinfo_propagator.cpp
@@ -152,7 +152,7 @@ void MaxInfoSpanningTree::traverse(Propagator* propagator) {
         propagator->propagateC2P(next_hop.from, next_hop.to);
         break;
       default:
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             false, "Unknown next hop type in MaxInfoSpanningTree::traverse.");
     }
   }
@@ -379,7 +379,7 @@ MaxRootDomainInfoSpanningTree::getReferenceRootIDInfo(
   if (leaf_pos < 0) {
     leaf_pos += int64_t(tv->nDims()) + 1;
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       leaf_pos >= 0 && leaf_pos <= int64_t(tv->nDims()),
       "MaxRootDomainInfoSpanningTree called on an leaf_pos outside valid range.");
   RootDomainInfo result;
@@ -422,9 +422,9 @@ std::shared_ptr<MaxInfoSpanningTree::Information> MaxRootDomainInfoSpanningTree:
   const auto& from_rfactor_dom = from->getMaybeRFactorDomain();
   const auto& to_rfactor_dom = to->getMaybeRFactorDomain();
 
-  TORCH_INTERNAL_ASSERT(from->hasRFactor() == to->hasRFactor());
-  TORCH_INTERNAL_ASSERT(from_root_dom.size() == to_root_dom.size());
-  TORCH_INTERNAL_ASSERT(from_rfactor_dom.size() == to_rfactor_dom.size());
+  NVF_ERROR(from->hasRFactor() == to->hasRFactor());
+  NVF_ERROR(from_root_dom.size() == to_root_dom.size());
+  NVF_ERROR(from_rfactor_dom.size() == to_rfactor_dom.size());
 
   std::unordered_map<IterDomain*, IterDomain*> id_map;
   for (auto i : c10::irange(from_root_dom.size())) {

--- a/csrc/maxinfo_propagator.h
+++ b/csrc/maxinfo_propagator.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <debug.h>
+#include <exceptions.h>
 #include <ir/interface_nodes.h>
 #include <ir/utils.h>
 

--- a/csrc/mma_type.cpp
+++ b/csrc/mma_type.cpp
@@ -13,12 +13,11 @@
 namespace nvfuser {
 
 MmaOp* MmaOptions::mmaOp() const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       accumulator_tv != nullptr && accumulator_tv->definition() != nullptr,
       "Invalid accumulator_tv.");
   auto mma_op = dynamic_cast<MmaOp*>(accumulator_tv->definition());
-  TORCH_INTERNAL_ASSERT(
-      mma_op != nullptr, "accumulator tv not an output of mma op");
+  NVF_ERROR(mma_op != nullptr, "accumulator tv not an output of mma op");
   return mma_op;
 }
 
@@ -42,7 +41,7 @@ MmaBuilder::MmaBuilder(
       option_.accumulator_stride = outer_stride * 4;
       break;
     default:
-      TORCH_CHECK(false, "unsupported macro");
+      NVF_CHECK(false, "unsupported macro");
       break;
   }
 }
@@ -59,22 +58,22 @@ MmaBuilder& MmaBuilder::operand(MmaOptions::Operand a_or_b) {
 
 // TODO: validate op config
 MmaOptions MmaBuilder::build() const {
-  TORCH_CHECK(
+  NVF_CHECK(
       option_.accumulator_tv != nullptr,
       "Please configure accumulator tv before using swizzle options.")
   return option_;
 }
 
 void MmaBuilder::configureMma(MmaOp* mma) const {
-  TORCH_CHECK(mma, "configureMma: invalid op object ", mma);
+  NVF_CHECK(mma, "configureMma: invalid op object ", mma);
   mma->configureOptions(option_);
 }
 
 void MmaBuilder::accumulatorTv(TensorView* tv) {
-  TORCH_CHECK(
+  NVF_CHECK(
       tv->getMemoryType() == MemoryType::Local, "Mma only outputs to register");
-  TORCH_CHECK(tv->definition(), "Input cannot be accumulator tv");
-  TORCH_CHECK(
+  NVF_CHECK(tv->definition(), "Input cannot be accumulator tv");
+  NVF_CHECK(
       tv->definition()->isA<MmaOp>(),
       "Requires mma op output for reduction tv");
   option_.accumulator_tv = tv;
@@ -97,7 +96,7 @@ LoadStoreOpType getLdMatrixType(MmaOptions options) {
            isOperandTransposed(options));
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "unsupported op with ldmatrix");
+      NVF_ERROR(false, "unsupported op with ldmatrix");
       break;
   }
   return transpose ? LoadStoreOpType::LdMatrixTranspose
@@ -135,7 +134,7 @@ int getOutputRegisterSize(MmaOptions::MacroType macro) {
     case MmaOptions::MacroType::Ampere_16_8_16:
       return 4;
     default:
-      TORCH_INTERNAL_ASSERT(false, "unknown macro");
+      NVF_ERROR(false, "unknown macro");
       break;
   }
   return -1;
@@ -151,7 +150,7 @@ int getInputARegisterSize(MmaOptions::MacroType macro) {
     case MmaOptions::MacroType::Ampere_16_16_16:
       return 8;
     default:
-      TORCH_INTERNAL_ASSERT(false, "unknown macro");
+      NVF_ERROR(false, "unknown macro");
       break;
   }
   return -1;
@@ -167,7 +166,7 @@ int getInputBRegisterSize(MmaOptions::MacroType macro) {
     case MmaOptions::MacroType::Ampere_16_16_16:
       return 8;
     default:
-      TORCH_INTERNAL_ASSERT(false, "unknown macro");
+      NVF_ERROR(false, "unknown macro");
       break;
   }
   return -1;
@@ -182,7 +181,7 @@ bool isOperandTransposed(MmaOptions options) {
       return options.layout == MmaOptions::MmaLayout::TT ||
           options.layout == MmaOptions::MmaLayout::NT;
     default:
-      TORCH_CHECK(false, "isOperandTransposed: please specify operand");
+      NVF_CHECK(false, "isOperandTransposed: please specify operand");
   }
   return false;
 }
@@ -203,7 +202,7 @@ GemmTile getMmaOpShape(MmaOptions::MacroType macro) {
       return {1, 1, 1};
   }
 
-  TORCH_INTERNAL_ASSERT(false, "unknown MMA macro");
+  NVF_ERROR(false, "unknown MMA macro");
 }
 
 std::string toString(MmaOptions::MmaLayout input_layout) {
@@ -222,7 +221,7 @@ std::string toString(MmaOptions::MmaLayout input_layout) {
       ss << "NN";
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "unsupported operand layout");
+      NVF_ERROR(false, "unsupported operand layout");
   }
   return ss.str();
 }
@@ -245,7 +244,7 @@ std::string toString(MmaOptions::MacroType mt) {
       ss << "M16N16K16";
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "undefined mma type");
+      NVF_ERROR(false, "undefined mma type");
       break;
   }
   return ss.str();
@@ -283,7 +282,7 @@ std::string toString(MmaOptions::MacroType mt, bool) {
     case MmaOptions::MacroType::Volta_16_16_4:
       return "Volta_16_16_4";
   }
-  TORCH_INTERNAL_ASSERT(false, "Unsupported mma type");
+  NVF_ERROR(false, "Unsupported mma type");
   return "Unsupported";
 }
 

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 #include <fusion.h>
 
 namespace nvfuser {

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -126,7 +126,7 @@ c10::intrusive_ptr<c10d::Backend> createBackend(
     return c10::make_intrusive<::c10d::ProcessGroupUCC>(store, rank, size);
   }
 #endif
-  TORCH_CHECK(false, "no distributed backend available");
+  NVF_CHECK(false, "no distributed backend available");
 }
 
 Communicator::Communicator(
@@ -150,7 +150,7 @@ Communicator::Communicator(
   c10d::TCPStoreOptions store_opts;
   {
     char hostname[HOST_NAME_MAX]; // NOLINT (modernize-avoid-c-arrays)
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         gethostname(hostname, HOST_NAME_MAX) == 0,
         "error when retrieving hostname");
     // we define the server as the process at the master host with local rank 0
@@ -175,12 +175,12 @@ void Communicator::sendRecv(
   }
   if (rank() == sender_rank) {
     // post send and wait for completion
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         pg_->send(tensor, receiver_rank, tag)->wait(),
         "error during communication");
   } else if (rank() == receiver_rank) {
     // post receive and wait for completion
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         pg_->recv(tensor, sender_rank, tag)->wait(),
         "error during communication");
   }

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifdef USE_DISTRIBUTED
 
+#include <exceptions.h>
 #include <multidevice/multidevice.h>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/Store.hpp>

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -7,6 +7,7 @@
 // clang-format on
 
 #pragma once
+#include <exceptions.h>
 #include <multidevice/multidevice.h>
 
 namespace nvfuser {
@@ -46,8 +47,7 @@ class DeviceMesh final {
     device_indices_ = std::move(device_indices);
     dimensions_ = std::move(dimensions);
 
-    TORCH_INTERNAL_ASSERT(
-        validate(device_indices_), "invalid parameters for Mesh Device");
+    NVF_ERROR(validate(device_indices_), "invalid parameters for Mesh Device");
   }
 
   void set(std::vector<DeviceIdxType> device_indices) {

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -120,7 +120,7 @@ void PipelineExecutor::handle(PipelineCommunication* c) {
 std::vector<at::Tensor> PipelineExecutor::runWithInput(
     const std::vector<c10::IValue>& inputs) {
   // Make sure inputs align at global boundary.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       inputs.size() == runtime_.pipeline_->inputs().size(),
       "Wrong number of inputs");
 

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -8,6 +8,7 @@
 #ifdef USE_DISTRIBUTED
 #pragma once
 
+#include <exceptions.h>
 #include <iter_visitor.h>
 #include <kernel_cache.h>
 #include <multidevice/pipeline_ir.h>

--- a/csrc/multidevice/pipeline.cpp
+++ b/csrc/multidevice/pipeline.cpp
@@ -72,7 +72,7 @@ class PipelineBuilder final {
     for (auto& stage_desc : pipeline_->descriptor().stage_descriptors) {
       for (auto val : stage_desc.vals()) {
         if (val->isA<TensorView>()) {
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               tv_in_stages.insert(val->as<TensorView>()).second,
               "the TensorView " + val->toString() +
                   " belongs to more than one stage");
@@ -82,7 +82,7 @@ class PipelineBuilder final {
     // Check that each TensorView belongs to at least one stage
     for (auto tv : ir_utils::filterByType<TensorView>(
              pipeline_->originalFusion()->vals())) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           tv_in_stages.count(tv),
           "the Val " + tv->toString() + " must be added to a stage");
     }
@@ -152,13 +152,13 @@ class PipelineBuilder final {
         // then add the newly created PipelineVal as an input of the pipeline
         if (isGlobalInput(val)) {
           pipeline_->addInput(p_val);
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               stage_desc.mesh.size() == 1,
               "A global input must belong to a stage which mesh is of size 1");
         } else {
           // if the Val is a stage input but not a global input, it must be
           // defined by a "Set" operation
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               (val->definition()->isA<LoadStoreOp>()) &&
                   (val->definition()->as<LoadStoreOp>()->opType() ==
                    LoadStoreOpType::Set),
@@ -211,7 +211,7 @@ class PipelineBuilder final {
         for (auto& producer : val->definition()->inputs()) {
           ins.push_back(val_to_pipeline_val_output_of_stage_.at(producer));
         }
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             std::size(ins) == 1 && std::size(outs) == 1,
             "Pipeline Communications must involve one input and one output");
         IrBuilder::create<PipelineCommunication>(

--- a/csrc/multidevice/pipeline.h
+++ b/csrc/multidevice/pipeline.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <disjoint_set.h>
+#include <exceptions.h>
 #include <fusion.h>
 #include <ir/base_nodes.h>
 #include <multidevice/device_mesh.h>

--- a/csrc/multidevice/pipeline_ir.cpp
+++ b/csrc/multidevice/pipeline_ir.cpp
@@ -18,17 +18,17 @@ PipelineStage::PipelineStage(
     ValSet input_vals,
     ValSet output_vals)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       passkey.ir_container_ ? passkey.ir_container_->isA<Pipeline>() : false,
       "IR type only valid for Pipeline container.");
 
   for (auto v : output_vals) {
-    TORCH_INTERNAL_ASSERT(v->isA<PipelineVal>());
+    NVF_ERROR(v->isA<PipelineVal>());
     addOutput(v);
     v->as<PipelineVal>()->setStage(this);
   }
   for (auto v : input_vals) {
-    TORCH_INTERNAL_ASSERT(v->isA<PipelineVal>());
+    NVF_ERROR(v->isA<PipelineVal>());
     addInput(v);
     v->as<PipelineVal>()->setStage(this);
   }
@@ -71,10 +71,10 @@ PipelineCommunication::PipelineCommunication(
     Val* in,
     Val* out)
     : Expr(passkey) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       passkey.ir_container_ ? passkey.ir_container_->isA<Pipeline>() : false,
       "IR type only valid for Pipeline container.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       in->isA<PipelineVal>() && out->isA<PipelineVal>(),
       "I/O must be PipelineVal IRs");
   addOutput(out);
@@ -95,7 +95,7 @@ std::string PipelineCommunication::toInlineString(int indent_size) const {
 
 PipelineVal::PipelineVal(IrBuilderPasskey passkey, Val* val)
     : Val(passkey, ValType::PipelineVal, val->dtype()), original_val_(val) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       passkey.ir_container_->isA<Pipeline>(),
       "IR type only valid for Pipeline container.");
 }

--- a/csrc/multidevice/pipeline_ir.h
+++ b/csrc/multidevice/pipeline_ir.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <disjoint_set.h>
+#include <exceptions.h>
 #include <ir/base_nodes.h>
 #include <ir/printer.h>
 

--- a/csrc/multidevice/runtime.cpp
+++ b/csrc/multidevice/runtime.cpp
@@ -33,7 +33,7 @@ void MultiDeviceRuntime::validate() const {
   // Checks if all the devices indices involved in the pipeline are
   // associated with a rank in the communicator
   for (auto d_id : device_indices) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         d_id < comm_.size(),
         "device index " + std::to_string(d_id) +
             " is present in the pipeline but no process in the communicator runs it");
@@ -41,7 +41,7 @@ void MultiDeviceRuntime::validate() const {
 
   // Checks that the number of processes within the node is less or equal
   // to the number of available GPUs.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       comm_.local_size() <= at::cuda::getNumGPUs(),
       std::to_string(comm_.local_size()) + " processes are spawn but only " +
           std::to_string(at::cuda::getNumGPUs()) + " GPUs are available");

--- a/csrc/multidevice/runtime.h
+++ b/csrc/multidevice/runtime.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <c10/core/DeviceType.h>
+#include <exceptions.h>
 #include <multidevice/communicator.h>
 #include <multidevice/pipeline.h>
 #include <multidevice/pipeline_ir.h>

--- a/csrc/mutator.cpp
+++ b/csrc/mutator.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <c10/util/irange.h>
+#include <exceptions.h>
 #include <fusion.h>
 #include <ir/all_nodes.h>
 #include <ir/builder.h>
@@ -37,7 +38,7 @@ void OptOutMutator::registerMutation(Val* val, Val* mutation) {
   bool mutation_is_ns = mutation->vtype() == ValType::NamedScalar;
   bool val_is_scalar = val->vtype() == ValType::Others;
   bool mutation_is_scalar = mutation->vtype() == ValType::Others;
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       mutation->dtype() == val->dtype() &&
           (mutation->vtype() == val->vtype() ||
            ((val_is_ns && mutation_is_scalar) ||
@@ -129,15 +130,15 @@ void OptOutMutator::mutate(TensorView* tv) {
 }
 
 void OptOutMutator::mutate(kir::Predicate*) {
-  TORCH_INTERNAL_ASSERT(false, "Not implemented yet.");
+  NVF_ERROR(false, "Not implemented yet.");
 }
 
 void OptOutMutator::mutate(kir::TensorIndex*) {
-  TORCH_INTERNAL_ASSERT(false, "Not implemented yet.");
+  NVF_ERROR(false, "Not implemented yet.");
 }
 
 void OptOutMutator::mutate(PipelineVal*) {
-  TORCH_INTERNAL_ASSERT(false, "Not implemented yet.");
+  NVF_ERROR(false, "Not implemented yet.");
 }
 
 void OptOutMutator::mutate(Expr* op) {

--- a/csrc/non_divisible_split.cpp
+++ b/csrc/non_divisible_split.cpp
@@ -50,14 +50,13 @@ void NonDivisibleSplitInfo::handle(Split* split) {
     if (maybe_non_divisible_extent) {
       // If the outputs are vectorized, predication isn't
       // sufficient, it must be divisible.
-      TORCH_INTERNAL_ASSERT(
-          split->outer()->getParallelType() != ParallelType::Vectorize);
+      NVF_ERROR(split->outer()->getParallelType() != ParallelType::Vectorize);
       if (split->inner()->getParallelType() == ParallelType::Vectorize) {
         splits_to_validate_.insert(split);
       } else {
         // Not proven to be a divisible split
         auto gpu_lower = GpuLower::current();
-        TORCH_INTERNAL_ASSERT(gpu_lower != nullptr);
+        NVF_ERROR(gpu_lower != nullptr);
 
         // If we know this split must be divisible, it's either validated as
         // above, exact matches to a case matching the above, or exact matches
@@ -141,7 +140,7 @@ void NonDivisibleSplitInfo::propagateReachability(Merge* merge) {
 
 void NonDivisibleSplitInfo::removeRedundancy() {
   auto gpu_lower = GpuLower::current();
-  TORCH_INTERNAL_ASSERT(gpu_lower != nullptr);
+  NVF_ERROR(gpu_lower != nullptr);
 
   std::unordered_set<IterDomain*> split_to_validate_outer;
   for (auto it = splits_to_validate_.begin();

--- a/csrc/non_divisible_split.h
+++ b/csrc/non_divisible_split.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/all_nodes.h>
 #include <iter_visitor.h>

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -37,7 +37,7 @@ TensorView* segment_set(TensorView* tv) {
 }
 
 TensorView* view(TensorView* x, DataType dtype) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   if (x->getDataType() == dtype) {
     return x;
   }
@@ -50,15 +50,15 @@ TensorView* view(TensorView* x, DataType dtype) {
     return bitCastOp(dtype, x);
   }
   // TODO: support view(dtype) for dtypes where input_size != newsize
-  TORCH_INTERNAL_ASSERT(false, "Unsupported reinterpret casting view");
+  NVF_ERROR(false, "Unsupported reinterpret casting view");
 }
 
 TensorView* reshape(
     TensorView* x,
     const std::vector<int64_t>& original_sizes,
     const std::vector<int64_t>& new_sizes) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(x != nullptr, "Input is invalid.");
+  NVF_ERROR(
       TensorDomain::noReductions(x->getMaybeRFactorDomain()).size() ==
       original_sizes.size());
 
@@ -104,7 +104,7 @@ TensorView* tryStaticReshape(
 TensorView* reshape(TensorView* inp_tv, const std::vector<Val*>& new_sizes) {
   auto inp_dom = TensorDomain::noReductions(inp_tv->getMaybeRFactorDomain());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       std::none_of(
           inp_dom.begin(),
           inp_dom.end(),
@@ -130,7 +130,7 @@ TensorView* reshape(TensorView* inp_tv, const std::vector<Val*>& new_sizes) {
       // However, if -1 is provided for some position, it will not correspond to
       // the actual extent in that position.
 
-      TORCH_CHECK(
+      NVF_CHECK(
           !found_neg_one,
           "A maximum of one value of -1 can be provided to reshape.");
       found_neg_one = true;
@@ -174,7 +174,7 @@ TensorView* reshape(TensorView* inp_tv, const std::vector<Val*>& new_sizes) {
 }
 
 TensorView* flatten(TensorView* x, int64_t start_dim, int64_t end_dim) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   auto inp_domain = TensorDomain::noReductions(x->getMaybeRFactorDomain());
   if (start_dim < 0) {
     start_dim += (int64_t)inp_domain.size();
@@ -182,15 +182,15 @@ TensorView* flatten(TensorView* x, int64_t start_dim, int64_t end_dim) {
   if (end_dim < 0) {
     end_dim += (int64_t)inp_domain.size();
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       start_dim >= 0 && start_dim < (int64_t)inp_domain.size(),
       "Invalid start_dim ",
       start_dim);
-  TORCH_CHECK(
+  NVF_CHECK(
       end_dim >= 0 && end_dim < (int64_t)inp_domain.size(),
       "Invalid end_dim ",
       end_dim);
-  TORCH_CHECK(start_dim <= end_dim, "start_dim must be <= end_dim");
+  NVF_CHECK(start_dim <= end_dim, "start_dim must be <= end_dim");
 
   if (start_dim == end_dim) {
     return x;
@@ -206,11 +206,11 @@ TensorView* flatten(TensorView* x, int64_t start_dim, int64_t end_dim) {
 }
 
 TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   auto x_dom = x->domain()->noReductions();
   const auto ndims = static_cast<int>(x_dom.size());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ndims == (int)to_squeeze.size(),
       "Invalid to_squeeze for squeeze: ",
       to_squeeze,
@@ -222,12 +222,12 @@ TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
     auto id = x_dom[idx];
     if (to_squeeze[idx]) {
       if (!id->isSymbolic()) {
-        TORCH_CHECK(
+        NVF_CHECK(
             id->isBroadcast(),
             "Can not squeeze non-broadcasting dimension(s).");
-        TORCH_CHECK(
+        NVF_CHECK(
             !id->hasExpandedExtent(), "Can not squeeze expanded dimension(s).");
-        TORCH_CHECK(
+        NVF_CHECK(
             id->extent()->isOneInt(),
             "Can not squeeze dimension(s) with size != 1.");
       }
@@ -247,10 +247,10 @@ TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
 }
 
 TensorView* squeeze(TensorView* x, const std::vector<int64_t>& sizes) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   const auto ndims = static_cast<int>(x->domain()->noReductions().size());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ndims == int(sizes.size()),
       "Invalid sizes for squeeze: ",
       sizes,
@@ -265,10 +265,10 @@ TensorView* squeeze(TensorView* x, const std::vector<int64_t>& sizes) {
 }
 
 TensorView* squeeze(TensorView* x, const std::vector<int64_t>& sizes, int dim) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   const auto ndims = static_cast<int>(x->domain()->noReductions().size());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ndims == int(sizes.size()),
       "Invalid sizes for squeeze: ",
       sizes,
@@ -279,7 +279,7 @@ TensorView* squeeze(TensorView* x, const std::vector<int64_t>& sizes, int dim) {
     dim = ndims + dim;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       dim >= 0 && dim < ndims,
       "Invalid position to squeeze: ",
       dim,
@@ -299,10 +299,10 @@ TensorView* squeeze(
     TensorView* x,
     const std::vector<int64_t>& sizes,
     const std::vector<int64_t>& dims) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   const auto ndims = static_cast<int>(x->domain()->noReductions().size());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       ndims == int(sizes.size()),
       "Invalid sizes for squeeze: ",
       sizes,
@@ -317,7 +317,7 @@ TensorView* squeeze(
       dim = ndims + dim;
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         dim >= 0 && dim < ndims,
         "Invalid position to squeeze: ",
         dim,
@@ -337,14 +337,14 @@ TensorView* squeeze(
 }
 
 TensorView* unsqueeze(TensorView* x, int dim) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   const auto ndims = static_cast<int>(x->domain()->noReductions().size());
 
   if (dim < 0) {
     dim = ndims + dim + 1;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       dim >= 0 && dim <= ndims,
       "Invalid position to unsqueeze: ",
       dim,
@@ -357,13 +357,13 @@ TensorView* unsqueeze(TensorView* x, int dim) {
 }
 
 TensorView* permute(TensorView* x, const std::vector<int64_t>& new2old) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   if (new2old.empty()) {
     return set(x);
   }
   auto inp_domain = TensorDomain::noReductions(x->getMaybeRFactorDomain());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       inp_domain.size() == new2old.size(),
       "The number of dimensions in the tensor input does not match the length",
       " of the desired ordering of dimensions i.e. input.dim() = ",
@@ -403,7 +403,7 @@ TensorView* permute(TensorView* x, const std::vector<int64_t>& new2old) {
 }
 
 TensorView* transpose(TensorView* x, int64_t dim0, int64_t dim1) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   const auto ndims = static_cast<int>(x->domain()->noReductions().size());
 
   if (dim0 < 0) {
@@ -414,10 +414,10 @@ TensorView* transpose(TensorView* x, int64_t dim0, int64_t dim1) {
     dim1 = ndims + dim1;
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       dim0 >= 0 && dim0 <= ndims, "Invalid transpose dimension 0: ", dim0);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       dim1 >= 0 && dim1 <= ndims, "Invalid transpose dimension 1: ", dim1);
 
   std::vector<int64_t> new2old(ndims);
@@ -434,10 +434,10 @@ TensorView* transpose(TensorView* x, int64_t dim0, int64_t dim1) {
 }
 
 TensorView* transpose(TensorView* x) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   const auto ndims = static_cast<int>(x->domain()->noReductions().size());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ndims <= 2,
       "Expected a tensor with <= 2 dimensions, but it has ",
       ndims,
@@ -463,7 +463,7 @@ bool hasSimilarDtype(DataType base, DataType dt) {
   } else if (isIntegralType(base)) {
     return isIntegralType(dt);
   }
-  TORCH_INTERNAL_ASSERT(false, "Unrecognized base dtype.");
+  NVF_ERROR(false, "Unrecognized base dtype.");
 }
 
 // Padding widths are assumed to be non-negative. Currently there's no
@@ -487,13 +487,13 @@ TensorView* pad(
       value = static_cast<Val*>(IrBuilder::create<Val>(0L, dt));
     }
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       hasSimilarDtype(dt, value->getDataType().value()),
       "Tensor arg and pad value must have the same dtype.");
   const auto inp_dom = TensorDomain::noReductions(inp->getMaybeRFactorDomain());
   const auto ndims = inp_dom.size();
 
-  TORCH_CHECK(
+  NVF_CHECK(
       pad_widths.size() % 2 == 0 && pad_widths.size() / 2 <= ndims,
       "Invalid number of padding widths: ",
       pad_widths.size());
@@ -576,7 +576,7 @@ TensorView* cat(
     const std::vector<TensorView*>& inputs,
     int64_t cat_dim,
     std::optional<IterType> iter_type_opt) {
-  TORCH_CHECK(!inputs.empty(), "No input tensor given");
+  NVF_CHECK(!inputs.empty(), "No input tensor given");
 
   const auto dtype = inputs.at(0)->getDataType().value();
 
@@ -584,7 +584,7 @@ TensorView* cat(
   int64_t ndims = -1;
 
   for (auto inp : inputs) {
-    TORCH_CHECK(
+    NVF_CHECK(
         inp->getDataType().value() == dtype,
         "Can't concatenate tensors with different data types: ",
         dtype,
@@ -596,7 +596,7 @@ TensorView* cat(
     if (ndims == -1) {
       ndims = i_ndims;
     } else {
-      TORCH_CHECK(
+      NVF_CHECK(
           ndims == i_ndims,
           "Unexpected number of dimensions: ",
           inp->toString(),
@@ -609,7 +609,7 @@ TensorView* cat(
     cat_dim += ndims;
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       cat_dim >= 0 && cat_dim < ndims, "Invalid dimension to cat: ", cat_dim);
 
   // Special handling for the case where there's only one input
@@ -659,7 +659,7 @@ TensorView* cat(
         // TODO: what to do if inp_id is not a normal iterdomain, i.e.,
         // broadcast, partial, etc? For now, assume it's a normal
         // IterDomain.
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             inp_root_id->getIterType() == IterType::Iteration &&
                 !inp_root_id->maybePartial(),
             "Unsupported IterDomain to concatenate: ",
@@ -697,7 +697,7 @@ TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges) {
   const auto inp_dom = TensorDomain::noReductions(inp->getMaybeRFactorDomain());
   const int ndims = static_cast<int>(inp_dom.size());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ndims == static_cast<int>(ranges.size()),
       "The range vector must have the same number of Slice descriptors. Given: ",
       ranges.size(),
@@ -731,7 +731,7 @@ TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges) {
 
   for (auto& range : ranges) {
     // Step not supported yet
-    TORCH_CHECK(
+    NVF_CHECK(
         range.step == nullptr || range.step->isOneInt(),
         "Unsupported step: ",
         range.step->toString());

--- a/csrc/ops/alias.h
+++ b/csrc/ops/alias.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/interface_nodes.h>
 #include <type.h>

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/base_nodes.h>
 #include <ir/builder.h>

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -21,12 +21,12 @@ ForwardDropoutResult dropout(TensorView* x, Val* prob) {
 }
 
 ForwardDropoutResult dropout(TensorView* x, Val* prob, Val* scale) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(x != nullptr, "Input is invalid.");
+  NVF_ERROR(
       prob != nullptr && prob->getDataType().has_value() &&
           prob->getDataType().value() == DataType::Double,
       "Probability is not a valid Double.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       scale != nullptr && scale->getDataType().has_value() &&
           scale->getDataType().value() == DataType::Double,
       "Scale is not a valid Double.");
@@ -40,9 +40,9 @@ ForwardDropoutResult dropout(TensorView* x, Val* prob, Val* scale) {
 }
 
 TensorView* dropout_backward(TensorView* dy, TensorView* mask, Val* scale) {
-  TORCH_INTERNAL_ASSERT(dy != nullptr, "Grad Output is invalid.");
-  TORCH_INTERNAL_ASSERT(mask != nullptr, "Mask is invalid");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(dy != nullptr, "Grad Output is invalid.");
+  NVF_ERROR(mask != nullptr, "Mask is invalid");
+  NVF_ERROR(
       scale != nullptr && scale->getDataType().has_value() &&
           scale->getDataType().value() == DataType::Double,
       "Scale is not a valid Double.");
@@ -54,10 +54,10 @@ TensorView* dropout_backward(TensorView* dy, TensorView* mask, Val* scale) {
 }
 
 TensorView* _matmul_nn(TensorView* a, TensorView* b) {
-  TORCH_CHECK(
+  NVF_CHECK(
       a->nDims() == 2 && b->nDims() == 2, "Only 2-D Tensors are supported!");
   const auto device_prop = at::cuda::getCurrentDeviceProperties();
-  TORCH_CHECK(
+  NVF_CHECK(
       device_prop->major == 8,
       "Only the Ampere MMA Op is currently supported!");
   auto tv0t = transpose(a, 0, 1);
@@ -67,10 +67,10 @@ TensorView* _matmul_nn(TensorView* a, TensorView* b) {
   return tv2;
 }
 TensorView* _matmul_nt(TensorView* a, TensorView* b) {
-  TORCH_CHECK(
+  NVF_CHECK(
       a->nDims() == 2 && b->nDims() == 2, "Only 2-D Tensors are supported!");
   const auto device_prop = at::cuda::getCurrentDeviceProperties();
-  TORCH_CHECK(
+  NVF_CHECK(
       device_prop->major == 8,
       "Only the Ampere MMA Op is currently supported!");
   auto tv0t = transpose(a, 0, 1);
@@ -81,10 +81,10 @@ TensorView* _matmul_nt(TensorView* a, TensorView* b) {
   return tv2;
 }
 TensorView* _matmul_tn(TensorView* a, TensorView* b) {
-  TORCH_CHECK(
+  NVF_CHECK(
       a->nDims() == 2 && b->nDims() == 2, "Only 2-D Tensors are supported!");
   const auto device_prop = at::cuda::getCurrentDeviceProperties();
-  TORCH_CHECK(
+  NVF_CHECK(
       device_prop->major == 8,
       "Only the Ampere MMA Op is currently supported!");
   auto tv0b = broadcast(a, {false, true, false});
@@ -93,10 +93,10 @@ TensorView* _matmul_tn(TensorView* a, TensorView* b) {
   return tv2;
 }
 TensorView* _matmul_tt(TensorView* a, TensorView* b) {
-  TORCH_CHECK(
+  NVF_CHECK(
       a->nDims() == 2 && b->nDims() == 2, "Only 2-D Tensors are supported!");
   const auto device_prop = at::cuda::getCurrentDeviceProperties();
-  TORCH_CHECK(
+  NVF_CHECK(
       device_prop->major == 8,
       "Only the Ampere MMA Op is currently supported!");
   auto tv1t = transpose(b, 0, 1);
@@ -112,12 +112,11 @@ LstmResult lstm(
     TensorView* forget_x,
     TensorView* cell_x,
     TensorView* out_x) {
-  TORCH_INTERNAL_ASSERT(
-      prev_cell != nullptr, "Previous cell state is invalid.");
-  TORCH_INTERNAL_ASSERT(in_x != nullptr, "In-gate input is invalid");
-  TORCH_INTERNAL_ASSERT(forget_x != nullptr, "Forget-gate input is invalid");
-  TORCH_INTERNAL_ASSERT(cell_x != nullptr, "Cell-gate input is invalid");
-  TORCH_INTERNAL_ASSERT(out_x != nullptr, "Out-gate input is invalid");
+  NVF_ERROR(prev_cell != nullptr, "Previous cell state is invalid.");
+  NVF_ERROR(in_x != nullptr, "In-gate input is invalid");
+  NVF_ERROR(forget_x != nullptr, "Forget-gate input is invalid");
+  NVF_ERROR(cell_x != nullptr, "Cell-gate input is invalid");
+  NVF_ERROR(out_x != nullptr, "Out-gate input is invalid");
 
   const auto in_gate = sigmoid(in_x);
   const auto forget_gate = sigmoid(forget_x);
@@ -133,7 +132,7 @@ LstmResult lstm(
 namespace {
 template <typename T>
 T* sign(T* x) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   auto zero = IrBuilder::create<Val>(x->container(), 0.);
   auto one = IrBuilder::create<Val>(x->container(), 1.);
   auto minus_one = IrBuilder::create<Val>(x->container(), -1.);
@@ -151,10 +150,9 @@ Val* sign(Val* x) {
 }
 
 TensorView* softplus(TensorView* x, Val* beta, Val* threshold) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
-  TORCH_INTERNAL_ASSERT(beta != nullptr, "Beta is invalid.");
-  TORCH_INTERNAL_ASSERT(
-      threshold != nullptr, "Threshold is not a valid Double.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
+  NVF_ERROR(beta != nullptr, "Beta is invalid.");
+  NVF_ERROR(threshold != nullptr, "Threshold is not a valid Double.");
 
   auto op_beta = mul(x, beta);
   auto maybe_result = div(log1p(exp(op_beta)), beta);
@@ -163,7 +161,7 @@ TensorView* softplus(TensorView* x, Val* beta, Val* threshold) {
 }
 
 TensorView* gelu(TensorView* x) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid");
+  NVF_ERROR(x != nullptr, "Input is invalid");
 
   auto kappa = IrBuilder::create<Val>(x->container(), M_SQRT1_2);
   auto half = IrBuilder::create<Val>(x->container(), 0.5);
@@ -175,8 +173,8 @@ TensorView* gelu(TensorView* x) {
 }
 
 TensorView* gelu_backward(TensorView* dy, TensorView* x) {
-  TORCH_INTERNAL_ASSERT(dy != nullptr, "Grad Output is invalid.");
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid");
+  NVF_ERROR(dy != nullptr, "Grad Output is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid");
 
   constexpr double kAlpha = M_2_SQRTPI * M_SQRT1_2 * 0.5;
   const double kHalf = 0.5;
@@ -197,7 +195,7 @@ TensorView* gelu_backward(TensorView* dy, TensorView* x) {
 }
 
 TensorView* tanh_gelu(TensorView* x) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid");
+  NVF_ERROR(x != nullptr, "Input is invalid");
 
   constexpr double kBeta = M_SQRT2 * M_2_SQRTPI * 0.5;
   constexpr double kKappa = 0.044715;
@@ -216,8 +214,8 @@ TensorView* tanh_gelu(TensorView* x) {
 }
 
 TensorView* tanh_gelu_backward(TensorView* dy, TensorView* x) {
-  TORCH_INTERNAL_ASSERT(dy != nullptr, "Grad Output is invalid.");
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid");
+  NVF_ERROR(dy != nullptr, "Grad Output is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid");
 
   constexpr double kBeta = M_SQRT2 * M_2_SQRTPI * 0.5;
   constexpr double kKappa = 0.044715;
@@ -251,8 +249,8 @@ TensorView* tanh_gelu_backward(TensorView* dy, TensorView* x) {
 }
 
 TensorView* tanh_backward(TensorView* dy, TensorView* tanh_x) {
-  TORCH_INTERNAL_ASSERT(dy != nullptr, "Grad Output is invalid.");
-  TORCH_INTERNAL_ASSERT(tanh_x != nullptr, "Input is invalid");
+  NVF_ERROR(dy != nullptr, "Grad Output is invalid.");
+  NVF_ERROR(tanh_x != nullptr, "Input is invalid");
 
   auto one = IrBuilder::create<Val>(tanh_x->container(), 1.);
   auto tanh_sq = mul(tanh_x, tanh_x);
@@ -262,15 +260,15 @@ TensorView* tanh_backward(TensorView* dy, TensorView* tanh_x) {
 }
 
 TensorView* leaky_relu(TensorView* x, Val* negative_slope) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "input is invalid.");
-  TORCH_INTERNAL_ASSERT(negative_slope != nullptr, "negative_slope is invalid");
+  NVF_ERROR(x != nullptr, "input is invalid.");
+  NVF_ERROR(negative_slope != nullptr, "negative_slope is invalid");
   auto zero = IrBuilder::create<Val>(x->container(), 0.);
   return where(ge(x, zero), x, mul(negative_slope, x));
 }
 
 TensorView* view_as_real(TensorView* x) {
   auto input_type = x->getDataType().value();
-  TORCH_CHECK(
+  NVF_CHECK(
       isComplexType(input_type),
       "Operand of view_as_real must have complex type");
 

--- a/csrc/ops/composite.h
+++ b/csrc/ops/composite.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/interface_nodes.h>
 #include <type.h>

--- a/csrc/ops/indexing.cpp
+++ b/csrc/ops/indexing.cpp
@@ -23,7 +23,7 @@ namespace nvfuser {
 
 TensorView* select(TensorView* tv, int dim, Val* index) {
   auto dom = TensorDomain::noReductions(tv->getMaybeRFactorDomain());
-  TORCH_CHECK(!dom.empty(), "select can not be applied to 0d tensor.");
+  NVF_CHECK(!dom.empty(), "select can not be applied to 0d tensor.");
 
   std::vector<IterDomain*> new_root;
   new_root.reserve(dom.size() - 1);
@@ -32,7 +32,7 @@ TensorView* select(TensorView* tv, int dim, Val* index) {
     dim += (int)dom.size();
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       dim >= 0 && dim < (int)dom.size(),
       "Select on invalid axis, received: ",
       dim,
@@ -56,16 +56,15 @@ TensorView* select(TensorView* tv, int dim, Val* index) {
 // index_select
 TensorView* index_select(TensorView* lookup_tv, int dim, TensorView* index_tv) {
   DataType dtype = lookup_tv->getDataType().value();
-  TORCH_CHECK(
+  NVF_CHECK(
       dtype != DataType::Null, "Invalid datatype provided for new value.");
   auto lookup_dom =
       TensorDomain::noReductions(lookup_tv->getMaybeRFactorDomain());
   auto index_dom =
       TensorDomain::noReductions(index_tv->getMaybeRFactorDomain());
   size_t n_dims = lookup_dom.size();
-  TORCH_CHECK(n_dims > 0, "index_select can not be applied to 0d tensor.");
-  TORCH_CHECK(
-      index_dom.size() <= 1, "index array must be 1d or scalar tensor.");
+  NVF_CHECK(n_dims > 0, "index_select can not be applied to 0d tensor.");
+  NVF_CHECK(index_dom.size() <= 1, "index array must be 1d or scalar tensor.");
 
   if (index_dom.empty()) {
     auto select_tv = select(lookup_tv, dim, index_tv);
@@ -78,7 +77,7 @@ TensorView* index_select(TensorView* lookup_tv, int dim, TensorView* index_tv) {
 
   std::vector<IterDomain*> new_root;
   new_root.reserve(lookup_dom.size() - 1);
-  TORCH_CHECK(
+  NVF_CHECK(
       dim >= 0 && dim < (int)lookup_dom.size(),
       "index_select on invalid axis, received: ",
       dim,
@@ -109,16 +108,16 @@ TensorView* index_select(TensorView* lookup_tv, int dim, TensorView* index_tv) {
 TensorView* torch_gather(TensorView* inp, int dim, TensorView* index) {
   auto inp_domain = TensorDomain::noReductions(inp->getMaybeRFactorDomain());
   auto idx_domain = TensorDomain::noReductions(index->getMaybeRFactorDomain());
-  TORCH_CHECK(
+  NVF_CHECK(
       !inp_domain.empty(), "torch.gather can not be applied to 0d tensor.");
-  TORCH_CHECK(
+  NVF_CHECK(
       idx_domain.size() == inp_domain.size(),
       "the input and index tensor must have the same dimensions for torch.gather");
 
   if (dim < 0) {
     dim += (int)idx_domain.size();
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       dim >= 0 && dim < (int)inp_domain.size(),
       "torch.gather on invalid axis, received: ",
       dim,
@@ -157,14 +156,14 @@ TensorView* scatterOp(
   auto idx_dom = TensorDomain::noReductions(index->getMaybeRFactorDomain());
   auto src_dom = TensorDomain::noReductions(src->getMaybeRFactorDomain());
 
-  TORCH_CHECK(!self_dom.empty(), "scatter can not be applied to 0d tensor.");
-  TORCH_CHECK(
+  NVF_CHECK(!self_dom.empty(), "scatter can not be applied to 0d tensor.");
+  NVF_CHECK(
       self_dom.size() == idx_dom.size() && self_dom.size() == src_dom.size(),
       "self, index and src tensor should all have the same number of dimensions in scatter like ops.");
   if (dim < 0) {
     dim += (int)self_dom.size();
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       dim >= 0 && dim < (int)self_dom.size(),
       "Scatter on invalid axis, received: ",
       dim,
@@ -207,9 +206,9 @@ TensorView* take_along_axis(TensorView* inp, TensorView* index, int64_t dim) {
   const auto idx_domain =
       TensorDomain::noReductions(index->getMaybeRFactorDomain());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !inp_domain.empty(), "take_along_axis can not be applied to 0d tensor.");
-  TORCH_CHECK(
+  NVF_CHECK(
       idx_domain.size() == inp_domain.size(),
       "The input and index tensor must have the same dimensions for take_along_axis");
 
@@ -217,7 +216,7 @@ TensorView* take_along_axis(TensorView* inp, TensorView* index, int64_t dim) {
     dim += (int)idx_domain.size();
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       dim >= 0 && dim < (int)inp_domain.size(),
       "take_along_axis on invalid axis, received: ",
       dim,
@@ -231,21 +230,21 @@ TensorView* take_along_axis(TensorView* inp, TensorView* index, int64_t dim) {
     auto inp_id = inp_domain.at(i);
     auto idx_id = idx_domain.at(i);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         !inp_id->maybePartial(),
         "Partial domain not supported: ",
         inp_id->toString());
-    TORCH_CHECK(
+    NVF_CHECK(
         !idx_id->maybePartial(),
         "Partial domain not supported: ",
         idx_id->toString());
 
-    TORCH_CHECK(
+    NVF_CHECK(
         inp_id->getIterType() != IterType::Iteration ||
             inp_id->getIterType() != IterType::Broadcast,
         "Unsupported IterType of an input domian: ",
         inp_id->toString());
-    TORCH_CHECK(
+    NVF_CHECK(
         idx_id->getIterType() != IterType::Iteration ||
             idx_id->getIterType() != IterType::Broadcast,
         "Unsupported IterType of an index domian: ",

--- a/csrc/ops/indexing.h
+++ b/csrc/ops/indexing.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/interface_nodes.h>
 #include <type.h>

--- a/csrc/ops/normalization.cpp
+++ b/csrc/ops/normalization.cpp
@@ -25,7 +25,7 @@ Val* numFeatures(TensorView* x, const std::vector<int>& dims, size_t ndims) {
 }
 
 TensorView* mean(TensorView* x, const std::vector<int>& dims, bool keepdim) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
 
   const size_t kNumberOfDims =
       TensorDomain::noReductions(x->getMaybeRFactorDomain()).size();
@@ -40,7 +40,7 @@ TensorView* variance(
     const std::vector<int>& dims,
     bool unbiased,
     bool keepdim) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   int64_t correction = unbiased ? 1 : 0;
   return variance(x, dims, correction, keepdim);
 }
@@ -50,9 +50,9 @@ TensorView* variance(
     const std::vector<int>& dims,
     int64_t correction,
     bool keepdim) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       correction >= 0, "correction must be non-negative, but got ", correction);
 
   const size_t kNumberOfDims =
@@ -78,14 +78,14 @@ VarMeanResult variance_mean(
     const std::vector<int>& dims,
     int64_t correction,
     bool keepdim) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       correction >= 0, "correction must be non-negative, but got ", correction);
 
   // There are compilation errors for half precision
   auto dtype = x->getDataType().value();
-  TORCH_CHECK(
+  NVF_CHECK(
       !(dtype == DataType::Half || dtype == DataType::BFloat16),
       "variance_mean is not supported for ",
       dtype,
@@ -131,18 +131,17 @@ TensorView* standard_deviation(
     const std::vector<int>& dims,
     bool unbiased,
     bool keepdim) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
   return sqrt(variance(x, dims, unbiased, keepdim));
 }
 
 TensorView* softmax(TensorView* x, int dim) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
 
   const size_t kNumberOfDims =
       TensorDomain::noReductions(x->getMaybeRFactorDomain()).size();
   const int kReductionAxis = (dim < 0) ? dim + (int)kNumberOfDims : dim;
-  TORCH_INTERNAL_ASSERT(
-      kReductionAxis >= 0 && kReductionAxis < (int)kNumberOfDims);
+  NVF_ERROR(kReductionAxis >= 0 && kReductionAxis < (int)kNumberOfDims);
 
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   broadcast_mask[kReductionAxis] = true;
@@ -159,14 +158,13 @@ TensorView* softmax(TensorView* x, int dim) {
 }
 
 TensorView* softmax_backward(TensorView* dy, TensorView* y, int dim) {
-  TORCH_INTERNAL_ASSERT(dy != nullptr, "Grad Output is invalid.");
-  TORCH_INTERNAL_ASSERT(y != nullptr, "Output is invalid.");
+  NVF_ERROR(dy != nullptr, "Grad Output is invalid.");
+  NVF_ERROR(y != nullptr, "Output is invalid.");
 
   const size_t kNumberOfDims =
       TensorDomain::noReductions(y->getMaybeRFactorDomain()).size();
   const int kReductionAxis = (dim < 0) ? dim + (int)kNumberOfDims : dim;
-  TORCH_INTERNAL_ASSERT(
-      kReductionAxis >= 0 && kReductionAxis < (int)kNumberOfDims);
+  NVF_ERROR(kReductionAxis >= 0 && kReductionAxis < (int)kNumberOfDims);
 
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   broadcast_mask[kReductionAxis] = true;
@@ -181,13 +179,12 @@ TensorView* softmax_backward(TensorView* dy, TensorView* y, int dim) {
 }
 
 TensorView* log_softmax(TensorView* x, int dim) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
 
   const size_t kNumberOfDims =
       TensorDomain::noReductions(x->getMaybeRFactorDomain()).size();
   const int kReductionAxis = (dim < 0) ? dim + (int)kNumberOfDims : dim;
-  TORCH_INTERNAL_ASSERT(
-      kReductionAxis >= 0 && kReductionAxis < (int)kNumberOfDims);
+  NVF_ERROR(kReductionAxis >= 0 && kReductionAxis < (int)kNumberOfDims);
 
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   broadcast_mask[kReductionAxis] = true;
@@ -204,14 +201,13 @@ TensorView* log_softmax(TensorView* x, int dim) {
 }
 
 TensorView* log_softmax_backward(TensorView* dy, TensorView* y, int dim) {
-  TORCH_INTERNAL_ASSERT(dy != nullptr, "Grad Output is invalid.");
-  TORCH_INTERNAL_ASSERT(y != nullptr, "Output is invalid.");
+  NVF_ERROR(dy != nullptr, "Grad Output is invalid.");
+  NVF_ERROR(y != nullptr, "Output is invalid.");
 
   const size_t kNumberOfDims =
       TensorDomain::noReductions(y->getMaybeRFactorDomain()).size();
   const int kReductionAxis = (dim < 0) ? dim + (int)kNumberOfDims : dim;
-  TORCH_INTERNAL_ASSERT(
-      kReductionAxis >= 0 && kReductionAxis < (int)kNumberOfDims);
+  NVF_ERROR(kReductionAxis >= 0 && kReductionAxis < (int)kNumberOfDims);
 
   auto bcast_sum_grad = sum(dy, {kReductionAxis}, true /* keepdim */);
   auto softmax = exp(y);
@@ -280,8 +276,8 @@ ForwardNormResult layer_norm(
     TensorView* weight,
     TensorView* bias,
     Val* eps) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(x != nullptr, "Input is invalid.");
+  NVF_ERROR(
       eps != nullptr && eps->getDataType().has_value() &&
           eps->getDataType().value() == DataType::Double,
       "Epsilon (eps) is not a valid Double.");
@@ -328,8 +324,8 @@ ForwardRMSNormResult rms_norm(
     const size_t kNormShapeNumDims,
     TensorView* weight,
     Val* eps) {
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(x != nullptr, "Input is invalid.");
+  NVF_ERROR(
       eps != nullptr && eps->getDataType().has_value() &&
           eps->getDataType().value() == DataType::Double,
       "Epsilon (eps) is not a valid Double.");
@@ -363,10 +359,10 @@ BackwardNormResult layer_norm_backward(
     TensorView* weight,
     TensorView* bias,
     const std::vector<bool>& output_mask) {
-  TORCH_INTERNAL_ASSERT(dy != nullptr, "Grad Output is invalid.");
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
-  TORCH_INTERNAL_ASSERT(mean != nullptr, "Mean is invalid.");
-  TORCH_INTERNAL_ASSERT(invstd != nullptr, "Inv std is invalid.");
+  NVF_ERROR(dy != nullptr, "Grad Output is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
+  NVF_ERROR(mean != nullptr, "Mean is invalid.");
+  NVF_ERROR(invstd != nullptr, "Inv std is invalid.");
 
   auto r = norm_properties_from_num_dims(x, norm_shape.size());
 
@@ -417,9 +413,9 @@ BackwardRMSNormResult rms_norm_backward(
     TensorView* invstd,
     TensorView* weight,
     const std::vector<bool>& output_mask) {
-  TORCH_INTERNAL_ASSERT(dy != nullptr, "Grad Output is invalid.");
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
-  TORCH_INTERNAL_ASSERT(invstd != nullptr, "Inv std is invalid.");
+  NVF_ERROR(dy != nullptr, "Grad Output is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
+  NVF_ERROR(invstd != nullptr, "Inv std is invalid.");
 
   auto r = norm_properties_from_num_dims(x, norm_shape.size());
 
@@ -471,18 +467,18 @@ ForwardNormResult batch_norm(
     bool channels_last) {
   auto fusion = FusionGuard::getCurFusion();
 
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !((running_var == nullptr) ^ (running_mean == nullptr)),
       "running stats should comes in pairs");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       momentum != nullptr && momentum->getDataType().has_value() &&
           momentum->getDataType().value() == DataType::Double,
       "Momentum is not a valid Double.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       eps != nullptr && eps->getDataType().has_value() &&
           eps->getDataType().value() == DataType::Double,
       "Epsilon (eps) is not a valid Double.");
@@ -518,7 +514,7 @@ ForwardNormResult batch_norm(
     // updating running mean and running var
     if (running_mean != nullptr && running_var != nullptr) {
       // Note: kTraining is true here!
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           kTraining,
           "When running stats are provided, batch stats should only be computed during training");
 
@@ -540,16 +536,16 @@ ForwardNormResult batch_norm(
       auto cast_to_input_dtype = [fusion](
                                      Val* cast_input, Val* aliased_output) {
         auto unary_op = cast_input->definition();
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             unary_op->isA<UnaryOp>() &&
                 unary_op->as<UnaryOp>()->getUnaryOpType() == UnaryOpType::Cast,
             "check for cast op");
         auto input_to_cast = unary_op->input(0);
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             input_to_cast->isFusionInput(),
             "IO_tensor batch_norm::running_stats can only updating input tensor to fusion");
         auto rm_dtype = input_to_cast->getDataType();
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             rm_dtype.has_value(),
             "Input running stats must have dtype defined");
         auto cast_output = castOp(*rm_dtype, aliased_output);
@@ -623,9 +619,9 @@ BackwardNormResult batch_norm_backward(
     Val* eps,
     const std::vector<bool>& output_mask,
     bool channels_last) {
-  TORCH_INTERNAL_ASSERT(input != nullptr, "Input is invalid.");
-  TORCH_INTERNAL_ASSERT(grad_output != nullptr, "Grad Output is invalid.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(input != nullptr, "Input is invalid.");
+  NVF_ERROR(grad_output != nullptr, "Grad Output is invalid.");
+  NVF_ERROR(
       eps != nullptr && eps->getDataType().has_value() &&
           eps->getDataType().value() == DataType::Double,
       "Epsilon (eps) is not a valid Double.");
@@ -660,7 +656,7 @@ BackwardNormResult batch_norm_backward(
   auto mean = save_mean;
   auto invstd = save_invstd;
   if (kTraining) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         save_mean != nullptr && save_invstd != nullptr,
         "When training=True, save_mean and save_invstd are required.");
   } else {
@@ -722,18 +718,18 @@ ForwardNormResult instance_norm(
     bool channels_last) {
   auto fusion = FusionGuard::getCurFusion();
 
-  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  NVF_ERROR(x != nullptr, "Input is invalid.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !((running_var == nullptr) ^ (running_mean == nullptr)),
       "running stats should comes in pairs");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       momentum != nullptr && momentum->getDataType().has_value() &&
           momentum->getDataType().value() == DataType::Double,
       "Momentum is not a valid Double.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       eps != nullptr && eps->getDataType().has_value() &&
           eps->getDataType().value() == DataType::Double,
       "Epsilon (eps) is not a valid Double.");
@@ -878,9 +874,9 @@ BackwardNormResult instance_norm_backward(
     Val* eps,
     const std::vector<bool>& output_mask,
     bool channels_last) {
-  TORCH_INTERNAL_ASSERT(input != nullptr, "Input is invalid.");
-  TORCH_INTERNAL_ASSERT(grad_output != nullptr, "Grad Output is invalid.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(input != nullptr, "Input is invalid.");
+  NVF_ERROR(grad_output != nullptr, "Grad Output is invalid.");
+  NVF_ERROR(
       eps != nullptr && eps->getDataType().has_value() &&
           eps->getDataType().value() == DataType::Double,
       "Epsilon (eps) is not a valid Double.");
@@ -922,7 +918,7 @@ BackwardNormResult instance_norm_backward(
   auto mean = save_mean;
   auto invstd = save_invstd;
   if (kTraining) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         save_mean != nullptr && save_invstd != nullptr,
         "When training=True, save_mean and save_invstd are required.");
   } else {

--- a/csrc/ops/normalization.h
+++ b/csrc/ops/normalization.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/interface_nodes.h>
 #include <type.h>

--- a/csrc/ops/utils.h
+++ b/csrc/ops/utils.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <type.h>
 

--- a/csrc/optimization/optimization_pass.h
+++ b/csrc/optimization/optimization_pass.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/interface_nodes.h>
 #include <ir/utils.h>
 
@@ -52,7 +53,7 @@ class TORCH_CUDA_CU_API OptimizationPass {
     DerivedClass::runPass(fusion);
 #ifndef NDEBUG
     // cycle detection is only enabled on debug run
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         ir_utils::checkCycle(fusion).empty(), "cycle detected in fusion IR");
 #endif
   }

--- a/csrc/optimization/remove_empty.cpp
+++ b/csrc/optimization/remove_empty.cpp
@@ -86,7 +86,7 @@ class EmptyTensorRemover : public DeadCodeRemover {
 
     if (isTVEmpty(tv)) {
       if (tv->isFusionInput()) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             allUsesDead(tv),
             "Empty Fusion input ",
             tv,
@@ -98,7 +98,7 @@ class EmptyTensorRemover : public DeadCodeRemover {
       // Any non-input that we traverse to should be the input to an expression,
       // or a Fusion output. If it's the input to an expression, we should have
       // replaced that expression by handling the appropriate Expr subclass.
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           tv->isFusionOutput(),
           "Found unexpected empty intermediate TensorView ",
           tv->toString());
@@ -140,7 +140,7 @@ class EmptyTensorRemover : public DeadCodeRemover {
     for (auto ax : empty_input_axes) {
       auto id = out->getRootDomain().at(ax);
       // Input rfactor domain positions correspond to output root positions
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           id->isReduction(),
           "Found unexpected unreduced empty axis at position ",
           ax,
@@ -174,7 +174,7 @@ class EmptyTensorRemover : public DeadCodeRemover {
     for (auto ax : empty_input_axes) {
       auto id = avg->getRootDomain().at(ax);
       // Input rfactor domain positions correspond to output root positions
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           id->isReduction(),
           "Found unexpected unreduced empty axis at position ",
           ax,
@@ -247,7 +247,7 @@ class EmptyTensorRemover : public DeadCodeRemover {
     auto dim = cop->concatenatedDim();
     std::vector<TensorView*> non_empty_inputs;
     for (auto inp : cop->inputs()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           inp->definition() && inp->definition()->isA<PadOp>(),
           "Inputs to CatOp must be outputs of PadOps");
       auto tv = inp->definition()->as<PadOp>()->in()->as<TensorView>();

--- a/csrc/optimization/remove_empty.h
+++ b/csrc/optimization/remove_empty.h
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <exceptions.h>
 #include <optimization/optimization_pass.h>
 
 namespace nvfuser::optimization {

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -19,7 +19,7 @@ auto parseEnvOptions(
     const char* option_env_name,
     const std::unordered_map<std::string, OptionEnum>& available_options) {
   // Make sure available_options includes all of the enum values
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       available_options.size() == static_cast<int>(OptionEnum::EndOfOption),
       "Invalid available option map");
 
@@ -43,7 +43,7 @@ auto parseEnvOptions(
             std::back_inserter(option_values),
             [](const auto& kv) { return kv.first; });
         std::sort(option_values.begin(), option_values.end());
-        TORCH_CHECK(
+        NVF_CHECK(
             false,
             "Parsing ",
             option_env_name,
@@ -63,7 +63,7 @@ auto parseEnvOptions(
         while (!closed) {
           const auto comma_pos = options_view.find_first_of(',');
           const auto rparentheses_pos = options_view.find_first_of(')');
-          TORCH_CHECK(
+          NVF_CHECK(
               rparentheses_pos != std::string_view::npos,
               "Parsing ",
               option_env_name,
@@ -77,7 +77,7 @@ auto parseEnvOptions(
           closed = (rparentheses_pos < comma_pos);
         }
         if (!options_view.empty()) {
-          TORCH_CHECK(
+          NVF_CHECK(
               options_view[0] == ',',
               "Parsing ",
               option_env_name,

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -9,6 +9,7 @@
 
 #include <c10/macros/Export.h>
 #include <c10/util/Exception.h>
+#include <exceptions.h>
 
 #include <string>
 #include <unordered_map>
@@ -123,7 +124,7 @@ class Options {
   }
 
   const std::vector<std::string>& getArgs(OptionEnum option) const {
-    TORCH_INTERNAL_ASSERT(has(option), "Option not set");
+    NVF_ERROR(has(option), "Option not set");
     return options_.at(option);
   }
 

--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -101,7 +101,7 @@ void ParallelDimensionMap::adjustMappingsForWarpPadding() {
   auto warp_size_val = IrBuilder::create<Val>(32L, DataType::Index);
   auto tidx_dim = getRaw(tidx_pt);
 
-  TORCH_INTERNAL_ASSERT(tidx_dim != nullptr);
+  NVF_ERROR(tidx_dim != nullptr);
 
   // If tidx is strictly defined as blockDim.x then it must be set to a
   // multiple of the warp, there is nothing to do
@@ -134,7 +134,7 @@ void ParallelDimensionMap::adjustMappingsForWarpPadding() {
 }
 
 Val* ParallelDimensionMap::getRaw(ParallelType pt) const {
-  TORCH_INTERNAL_ASSERT(isParallelTypeThread(pt), "Invalid ParallelType: ", pt);
+  NVF_ERROR(isParallelTypeThread(pt), "Invalid ParallelType: ", pt);
   auto it = dim_map_.find(pt);
   if (it == dim_map_.end()) {
     return nullptr;

--- a/csrc/parallel_dimension_map.h
+++ b/csrc/parallel_dimension_map.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <kernel_ir.h>
 

--- a/csrc/parallel_type_bitmap.h
+++ b/csrc/parallel_type_bitmap.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 #include <type.h>
 
 #include <array>
@@ -85,16 +86,14 @@ class ParallelTypeBitmap {
   //! Return true if pt is included
   bool get(ParallelType pt) const {
     auto offset = getParallelTypeBitMapOffset(pt);
-    TORCH_INTERNAL_ASSERT(
-        offset != -1, "Could not recognize parallel type: ", pt);
+    NVF_ERROR(offset != -1, "Could not recognize parallel type: ", pt);
     return bitset_[offset];
   }
 
   //! Set the flag of pt
   bool set(ParallelType pt, bool new_val = true) {
     auto offset = getParallelTypeBitMapOffset(pt);
-    TORCH_INTERNAL_ASSERT(
-        offset != -1, "Could not recognize parallel type: ", pt);
+    NVF_ERROR(offset != -1, "Could not recognize parallel type: ", pt);
     bool old_val = bitset_[offset];
     bitset_[offset] = new_val;
     return old_val;
@@ -146,7 +145,7 @@ class ParallelTypeBitmap {
   //! Return true if the parallel type corresponding to a position
   //! defined in offset_to_pt_ is true
   bool operator[](size_t pos) const {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         pos < kNumParallelTypes, "Invalid index to ParallelTypeBitset: ", pos);
     return bitset_[pos];
   }

--- a/csrc/parser.h
+++ b/csrc/parser.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/runtime/profiling_record.h>
 

--- a/csrc/partition.cpp
+++ b/csrc/partition.cpp
@@ -141,7 +141,7 @@ static bool isDeviceCompatible(
 static bool isFusibleDevice(
     const torch::jit::Node* node,
     const c10::Device& device) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       device.index() != INVALID_INDEX, "fusible device needs to be validate");
   auto opt_device = getDevice(node);
   // we can be more relaxed here as we known that this function tries to merge

--- a/csrc/partition.h
+++ b/csrc/partition.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 #include <torch/csrc/jit/ir/ir.h>
 
 /*

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <any>
 #include <complex>
 #include <cstddef>
@@ -17,7 +18,7 @@
 
 #include <ATen/ATen.h>
 
-#define DYNAMIC_TYPE_CHECK TORCH_INTERNAL_ASSERT
+#define DYNAMIC_TYPE_CHECK NVF_ERROR
 
 #include <dynamic_type.h>
 #include <macros.h>
@@ -93,7 +94,7 @@ class Pointer {
   }
 
   int64_t operator-(const Pointer& other) const {
-    TORCH_INTERNAL_ASSERT(size_ == other.size_);
+    NVF_ERROR(size_ == other.size_);
     return (ptr_ - other.ptr_) / (int64_t)size_;
   }
 
@@ -284,7 +285,7 @@ inline PolymorphicValue abs(const PolymorphicValue& a) {
   if (a.is<std::complex<double>>()) {
     return std::abs(a.as<std::complex<double>>());
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false, "PolymorphicValue abs not implemented for ", a.type().name());
 }
 
@@ -292,7 +293,7 @@ inline PolymorphicValue erf(const PolymorphicValue& a) {
   if (a.is<at::Tensor>()) {
     return PolymorphicValue(a.as<at::Tensor>().erf());
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false, "PolymorphicValue erf not implemented for ", a.type().name());
 }
 
@@ -334,7 +335,7 @@ inline PolymorphicValue toTensor(
     }
     return PolymorphicValue(at::stack(tensors));
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       false, "PolymorphicValue toTensor not implemented for ", x.type().name());
 }
 

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -57,7 +57,7 @@ Val* ParallelizedDomainPredicate::PredicateInfo::getPredicate() const {
 
   for (const auto& pred_id : ids()) {
     // Just sanity check that pred_id is concrete
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         pred_id ==
         GpuLower::current()->caMap()->getConcreteMappedID(
             pred_id, IdMappingMode::EXACT));
@@ -232,7 +232,7 @@ Val* ParallelizedDomainPredicate::getPredicate(
     }
   }
 
-  TORCH_INTERNAL_ASSERT(pred != nullptr);
+  NVF_ERROR(pred != nullptr);
   return pred;
 }
 
@@ -351,12 +351,12 @@ Val* PredicateCompute::getInlinePredicate(
   }
 
   if (loops.empty()) {
-    TORCH_INTERNAL_ASSERT(thread_pred != nullptr);
+    NVF_ERROR(thread_pred != nullptr);
     return thread_pred;
   }
 
   auto out_tv = ir_utils::getTvOutput(expr);
-  TORCH_INTERNAL_ASSERT(out_tv != nullptr, "Missing TensorView output");
+  NVF_ERROR(out_tv != nullptr, "Missing TensorView output");
 
   if (gpu_lower->predicateElimination().canOmitPredicate(expr)) {
     return thread_pred;
@@ -411,7 +411,7 @@ Val* PredicateCompute::getInlinePredicate(
 
   auto parallel_dom_pred =
       ParallelizedDomainPredicate::getPredicate(expr, loops);
-  TORCH_INTERNAL_ASSERT(parallel_dom_pred != nullptr);
+  NVF_ERROR(parallel_dom_pred != nullptr);
 
   preds.push_back(parallel_dom_pred);
 
@@ -466,7 +466,7 @@ void UnswitchPredicate::predicateOn(Expr* tv_expr) {
   }
 
   auto out_tv = ir_utils::getTvOutput(tv_expr);
-  TORCH_INTERNAL_ASSERT(out_tv != nullptr, "Missing TensorView output");
+  NVF_ERROR(out_tv != nullptr, "Missing TensorView output");
 
   auto ref_pred_info = Index::getReferenceRootPredicates(
       out_tv, for_loops_, rotated_loop_, unrolled_loop_, false);
@@ -480,8 +480,8 @@ void UnswitchPredicate::predicateOn(Expr* tv_expr) {
   // predicates are generated in the finalize function.
 
   for (const auto& pred_info : ref_pred_info) {
-    TORCH_INTERNAL_ASSERT(pred_info.startPredicate() != nullptr);
-    TORCH_INTERNAL_ASSERT(pred_info.stopPredicate() != nullptr);
+    NVF_ERROR(pred_info.startPredicate() != nullptr);
+    NVF_ERROR(pred_info.stopPredicate() != nullptr);
 
     const auto& root_ids = pred_info.rootIds();
 

--- a/csrc/predicate_compute.h
+++ b/csrc/predicate_compute.h
@@ -9,6 +9,7 @@
 
 #include <device_lower/analysis/thread_predicate.h>
 #include <device_lower/utils.h>
+#include <exceptions.h>
 #include <index_compute.h>
 #include <kernel_ir.h>
 #include <root_domain_map.h>

--- a/csrc/python_frontend/fusion_cache.cpp
+++ b/csrc/python_frontend/fusion_cache.cpp
@@ -37,7 +37,7 @@ FusionSchedules::FusionSchedules()
 
 Fusion* FusionSchedules::preschedFusion() {
   auto fusion = auto_gen_schedules->fusion();
-  TORCH_CHECK(fusion != nullptr, "Prescheduled Fusion is unexpectedly null!");
+  NVF_CHECK(fusion != nullptr, "Prescheduled Fusion is unexpectedly null!");
   return fusion;
 }
 
@@ -80,7 +80,7 @@ FusionCache* FusionCache::get(size_t max_fusions) {
   if (singleton_ == nullptr) {
     singleton_ = new FusionCache(max_fusions);
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       max_fusions >= singleton_->fusions_.size(),
       "The max fusions is set less than the number of fusions in the cache.");
   singleton_->max_fusions_ = max_fusions;
@@ -175,9 +175,9 @@ FusionCache::FusionCache(size_t max_fusions)
 std::optional<TrieNode*> FusionCache::queryChildren(
     TrieNode* node,
     RecordFunctor* rec) const {
-  TORCH_CHECK(
+  NVF_CHECK(
       !node->isTerminal(), "There should be no children from a Terminal Node!");
-  TORCH_CHECK(rec, "Record is null!");
+  NVF_CHECK(rec, "Record is null!");
   auto trie_node = node->children.find(rec);
   if (trie_node == std::end(node->children)) {
     return std::nullopt;
@@ -187,12 +187,12 @@ std::optional<TrieNode*> FusionCache::queryChildren(
   }
 }
 FusionSchedules* FusionCache::queryFusionSchedules(size_t fusion_id) const {
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_id < fusions_.size(),
       "Invalid scheduler query for id:",
       fusion_id);
   FusionSchedules* ptr = fusions_.at(fusion_id).get();
-  TORCH_CHECK(ptr != nullptr, "Unexpected null FusionSchedules object.");
+  NVF_CHECK(ptr != nullptr, "Unexpected null FusionSchedules object.");
   return ptr;
 }
 std::optional<size_t> FusionCache::queryUserScheduleId(
@@ -215,11 +215,11 @@ const UserSchedule& FusionCache::queryUserSchedule(
     size_t id,
     int device) const {
   auto& user_scheds = scheds->user_def_schedules;
-  TORCH_CHECK(
+  NVF_CHECK(
       !user_scheds.empty(),
       "Expecting there to be at least one user schedule!");
   auto user_sched = user_scheds.find(id);
-  TORCH_CHECK(
+  NVF_CHECK(
       user_sched != user_scheds.end(), "Lookup of non-existent user schedule!");
   return user_sched->second.at(device);
 }
@@ -227,9 +227,9 @@ const UserSchedule& FusionCache::queryUserSchedule(
 TrieNode* FusionCache::createChild(TrieNode* node, RecordFunctor* rec) {
   FUSER_PERF_SCOPE("FusionCache::createChild");
   TrieNode* child = nullptr;
-  TORCH_CHECK(
+  NVF_CHECK(
       !node->isTerminal(), "Cannot create a trie node from a terminal node!");
-  TORCH_CHECK(rec, "Record is null!");
+  NVF_CHECK(rec, "Record is null!");
 
   std::lock_guard<std::mutex> guard(node->trie_node_lock);
 
@@ -241,7 +241,7 @@ TrieNode* FusionCache::createChild(TrieNode* node, RecordFunctor* rec) {
   } else {
     size_t fusion_id = 0;
     if (rec->recordType() == serde::RecordType_End) {
-      TORCH_CHECK(
+      NVF_CHECK(
           (fusions_.size() + 1) <= max_fusions_,
           "The number of fusions in nvfuser has exceeded ",
           max_fusions_,
@@ -259,7 +259,7 @@ TrieNode* FusionCache::createChild(TrieNode* node, RecordFunctor* rec) {
     node->children[new_rec] =
         std::make_unique<TrieNode>(new_rec, node, fusion_id);
     child = node->children[new_rec].get();
-    TORCH_CHECK(child, "Created child of TrieNode should not be null!");
+    NVF_CHECK(child, "Created child of TrieNode should not be null!");
     ++(child->visits);
     if (rec->recordType() == serde::RecordType_End) {
       terminal_nodes_.push_back(node->children[new_rec].get());
@@ -377,7 +377,7 @@ void FusionCache::serialize(std::string filename) const {
   auto file_handle = std::fopen(filename.c_str(), "wb");
   size_t write_status =
       std::fwrite(fb.data(), sizeof(uint8_t), fb.size(), file_handle);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       write_status == fb.size(),
       "Failed to write entire FusionCache Flatbuffer.\n");
   std::fclose(file_handle);
@@ -388,16 +388,16 @@ typedef std::vector<uint8_t> BinaryBuffer;
 
 BinaryBuffer openFusionCache(std::string filename) {
   auto file_handle = std::fopen(filename.c_str(), "rb");
-  TORCH_CHECK(file_handle != nullptr, "Failed to open FusionCache buffer.");
+  NVF_CHECK(file_handle != nullptr, "Failed to open FusionCache buffer.");
 
   auto file_path = fs::path(filename.c_str());
   auto file_size = fs::file_size(file_path);
-  TORCH_CHECK(file_size > 0, "FusionCache buffer is empty.");
+  NVF_CHECK(file_size > 0, "FusionCache buffer is empty.");
 
   BinaryBuffer buffer(file_size);
   size_t read_status =
       std::fread(buffer.data(), sizeof(uint8_t), file_size, file_handle);
-  TORCH_CHECK(
+  NVF_CHECK(
       read_status == file_size, "Failed to read entire FusionCache buffer.\n");
   return buffer;
 }
@@ -405,10 +405,10 @@ BinaryBuffer openFusionCache(std::string filename) {
 const serde::FusionCache* verifyFusionCache(const BinaryBuffer& buffer) {
   auto fusion_cache_buffer = serde::GetFusionCache(buffer.data());
   flatbuffers::Verifier v(buffer.data(), buffer.size());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_cache_buffer->Verify(v),
       "Failed to verify the integrity of FusionCache buffer.");
-  TORCH_CHECK(
+  NVF_CHECK(
       serde::FusionCacheBufferHasIdentifier(buffer.data()),
       "Failed to verify the schema version of the FusionCache buffer");
   return fusion_cache_buffer;
@@ -420,7 +420,7 @@ void FusionCache::deserialize(std::string filename) {
   // See table definition for FusionCache in serde/fusion_cache.fbs
   // 0. Load flatbuffer binary from file
   FUSER_PERF_SCOPE("FusionCache::deserialize");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusions_.empty(),
       "Deserialization is prohibited if FusionCache is already populated.");
   auto buffer = openFusionCache(filename);
@@ -473,13 +473,13 @@ void FusionCache::deserialize(std::string filename) {
 
     // Build fusion container if current node is a terminal node
     if (fb_trie_node->is_terminal()) {
-      TORCH_CHECK(
+      NVF_CHECK(
           fb_trie_node->children()->size() == 0,
           "This terminal node should not have any children.")
-      TORCH_CHECK(
+      NVF_CHECK(
           fb_trie_node->record()->type() == serde::RecordType_End,
           "This terminal node should have an EndRecord RecordFunctor")
-      TORCH_CHECK(
+      NVF_CHECK(
           trie_ptr->fusion_id == fb_trie_node->fusion_id(),
           "The fusion id for this TrieNode should already be set.")
       Fusion* fusion =
@@ -503,7 +503,7 @@ void FusionCache::deserialize(std::string filename) {
           rec,
           std::make_unique<TrieNode>(
               rec, trie_ptr, fb_child_trie_node->fusion_id()));
-      TORCH_CHECK(
+      NVF_CHECK(
           status.second,
           "Fusion-Cache Deserialization: Failed to add child to the current TrieNode.");
 

--- a/csrc/python_frontend/fusion_cache.h
+++ b/csrc/python_frontend/fusion_cache.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <kernel_cache.h>
 #include <python_frontend/fusion_record.h>

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -42,7 +42,7 @@ const char* dtypeToPyString(PrimDataType t) {
     default:
       break;
   }
-  TORCH_INTERNAL_ASSERT(false, "No string found for data type.");
+  NVF_ERROR(false, "No string found for data type.");
   return nullptr;
 }
 
@@ -58,14 +58,13 @@ FusionDefinition::FusionDefinition(std::optional<size_t> id, size_t max_length)
       sched(this) {}
 
 FusionCache* FusionDefinition::fusionCache() const {
-  TORCH_INTERNAL_ASSERT(
-      fusion_cache_ != nullptr, "FusionCache pointer is null!");
+  NVF_ERROR(fusion_cache_ != nullptr, "FusionCache pointer is null!");
   return fusion_cache_;
 }
 
 FusionDefinition* FusionDefinition::setupDefinition() {
-  TORCH_CHECK(max_length_ > 0, "Can't make a FusionDefinition with 0 records!");
-  TORCH_CHECK(!id().has_value(), "Fusion Schedule is already found!");
+  NVF_CHECK(max_length_ > 0, "Can't make a FusionDefinition with 0 records!");
+  NVF_CHECK(!id().has_value(), "Fusion Schedule is already found!");
   trie_node_ = fusionCache()->rootTriePtr();
   return this;
 }
@@ -79,7 +78,7 @@ void FusionDefinition::finalizeDefinition() {
     }
     trie_node_ = fusionCache()->createChild(trie_node_, end_record_.get());
     fusion_id_ = std::optional<size_t>(trie_node_->fusion_id);
-    TORCH_CHECK(id().has_value(), "Invalid fusion id!");
+    NVF_CHECK(id().has_value(), "Invalid fusion id!");
 
     if (isDebugDumpEnabled(DebugDumpOption::PythonDefinition)) {
       print(debug());
@@ -101,12 +100,12 @@ void FusionDefinition::finalizeDefinition() {
 
 void FusionDefinition::setupSchedule(const at::ArrayRef<c10::IValue>& inputs) {
   FUSER_PERF_SCOPE("FusionDefinition::setupSchedule");
-  TORCH_CHECK(id().has_value(), "FusionDefinition definition does not exist!");
+  NVF_CHECK(id().has_value(), "FusionDefinition definition does not exist!");
   auto scheds = fusionCache()->queryFusionSchedules(id().value());
   auto device = getCommonDeviceCUDA(inputs);
-  TORCH_CHECK(
+  NVF_CHECK(
       inputs.empty() || device > -1, "Inputs are not all on the same device!");
-  TORCH_CHECK(user_sched_ == nullptr, "Expected User Scheduler to be null!");
+  NVF_CHECK(user_sched_ == nullptr, "Expected User Scheduler to be null!");
   user_sched_ = fusionCache()->createUserSchedule(scheds, inputs, device);
 
   // Building a new Fusion container for scheduling with definition such that
@@ -157,7 +156,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
   std::stringstream debug_ss;
   DebugStreamGuard dsg(capture_debug_output ? debug_ss : std::cout);
 
-  TORCH_CHECK(id().has_value(), "Valid fusion schedule is not available!");
+  NVF_CHECK(id().has_value(), "Valid fusion schedule is not available!");
 
   auto scheds = fusionCache()->queryFusionSchedules(id().value());
 
@@ -165,7 +164,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
 
   if (!override_user_schedule) {
     auto device = getCommonDeviceCUDA(inputs, selected_device);
-    TORCH_CHECK(
+    NVF_CHECK(
         inputs.empty() || device > -1,
         "Inputs are not all on the same device or don't match selection!");
     auto user_sched_id = fusionCache()->queryUserScheduleId(scheds, inputs);
@@ -189,7 +188,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
 }
 
 std::string FusionDefinition::fusionIr() {
-  TORCH_CHECK(id().has_value(), "Invalid fusion definition!");
+  NVF_CHECK(id().has_value(), "Invalid fusion definition!");
   std::stringstream ss;
   preschedFusion()->print(ss, false);
   return ss.str();
@@ -199,7 +198,7 @@ std::string FusionDefinition::lastCudaCode(
     bool intrinsic_code,
     bool override_user_schedule) const {
   std::string result;
-  TORCH_CHECK(id().has_value(), "Invalid fusion definition!");
+  NVF_CHECK(id().has_value(), "Invalid fusion definition!");
   auto scheds = fusionCache()->queryFusionSchedules(id().value());
   auto user_exec = scheds->last_user_def_executor;
 
@@ -220,12 +219,12 @@ std::string FusionDefinition::cudaCodeFor(
     const at::ArrayRef<c10::IValue>& inputs,
     bool intrinsic_code,
     bool override_user_schedule) const {
-  TORCH_CHECK(id().has_value(), "Invalid fusion definition!");
+  NVF_CHECK(id().has_value(), "Invalid fusion definition!");
   auto scheds = fusionCache()->queryFusionSchedules(id().value());
 
   if (!override_user_schedule) {
     auto device = getCommonDeviceCUDA(inputs);
-    TORCH_CHECK(
+    NVF_CHECK(
         inputs.empty() || device > -1,
         "Inputs are not all on the same device!");
     auto user_sched_id = fusionCache()->queryUserScheduleId(scheds, inputs);
@@ -248,7 +247,7 @@ std::string FusionDefinition::lastScheduledFusionIr(
     bool tensor_transforms,
     bool override_user_schedule) const {
   std::string result;
-  TORCH_CHECK(id().has_value(), "Invalid fusion definition!");
+  NVF_CHECK(id().has_value(), "Invalid fusion definition!");
   auto scheds = fusionCache()->queryFusionSchedules(id().value());
   auto user_sched_ir = scheds->last_user_def_scheduled_ir;
 
@@ -267,12 +266,12 @@ std::string FusionDefinition::scheduledFusionIrFor(
     const at::ArrayRef<c10::IValue>& inputs,
     bool tensor_transforms,
     bool override_user_schedule) const {
-  TORCH_CHECK(id().has_value(), "Invalid fusion definition!");
+  NVF_CHECK(id().has_value(), "Invalid fusion definition!");
   auto scheds = fusionCache()->queryFusionSchedules(id().value());
 
   if (!override_user_schedule) {
     auto device = getCommonDeviceCUDA(inputs);
-    TORCH_CHECK(
+    NVF_CHECK(
         inputs.empty() || device > -1,
         "Inputs are not all on the same device!");
     auto user_sched_id = fusionCache()->queryUserScheduleId(scheds, inputs);
@@ -316,7 +315,7 @@ Vector FusionDefinition::defineVector(size_t size) {
 
 void FusionDefinition::defineRecord(RecordFunctor* record) {
   FUSER_PERF_SCOPE("FusionDefinition::defineRecord");
-  TORCH_CHECK(
+  NVF_CHECK(
       (recording_.size() + 1) <= max_length_,
       "The fusion definition has exceeded ",
       max_length_,
@@ -346,7 +345,7 @@ void FusionDefinition::defineRecord(RecordFunctor* record) {
 }
 
 Fusion* FusionDefinition::preschedFusion() {
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_id_.has_value(),
       "FusionDefinition does not contain a definition, yet!");
   return fusionCache()

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #pragma once
+#include <exceptions.h>
 #include <iostream>
 
 #include <c10/macros/Export.h>

--- a/csrc/python_frontend/fusion_state.cpp
+++ b/csrc/python_frontend/fusion_state.cpp
@@ -16,14 +16,14 @@ using namespace nvfuser::inst;
 namespace nvfuser::python_frontend {
 
 bool State::operator==(const State& other) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       (index == other.index ? (stype == other.stype) : true),
       "State indices should not match with different State Types!");
   return (index == other.index) && (stype == other.stype);
 }
 
 bool State::operator!=(const State& other) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       (index == other.index ? (stype == other.stype) : true),
       "State indices should not match with different State Types!");
   return (index != other.index) || (stype != other.stype);
@@ -40,7 +40,7 @@ std::ostream& operator<<(std::ostream& os, const State& state) {
   } else if (state.stype == serde::StateType_None) {
     os << "None";
   } else {
-    TORCH_INTERNAL_ASSERT(false, "Unsupported StateType");
+    NVF_ERROR(false, "Unsupported StateType");
   }
   os << state.index;
   return os;
@@ -68,7 +68,7 @@ std::unique_ptr<FusionState> FusionState::clone() {
 
 void FusionState::buildFusionIr(Fusion* fusion) {
   FUSER_PERF_SCOPE("FusionContainer::buildFusionIr");
-  TORCH_CHECK(fusion != nullptr, "Fusion is undefined.");
+  NVF_CHECK(fusion != nullptr, "Fusion is undefined.");
   resetFusionState(fusion, num_recording_states_);
   auto fusion_guard = FusionGuard(fusion);
   for (auto& record : recording_) {
@@ -84,17 +84,17 @@ void FusionState::addRecord(RecordFunctor* record) {
 }
 
 Fusion* FusionState::fusion() {
-  TORCH_CHECK(fusion_ != nullptr, "Fusion is undefined.");
+  NVF_CHECK(fusion_ != nullptr, "Fusion is undefined.");
   return fusion_;
 }
 
 void FusionState::printIr() const {
-  TORCH_CHECK(fusion_ != nullptr, "Fusion is undefined.");
+  NVF_CHECK(fusion_ != nullptr, "Fusion is undefined.");
   fusion_->printMath();
 }
 
 void FusionState::resetFusionState(Fusion* fusion, size_t size) {
-  TORCH_CHECK(fusion != nullptr, "Fusion is undefined.");
+  NVF_CHECK(fusion != nullptr, "Fusion is undefined.");
   fusion_ = fusion;
   fusion_state_.clear();
   fusion_state_.resize(size, {});
@@ -106,7 +106,7 @@ void FusionState::addFusionState(Val* val) {
 
 void FusionState::addFusionStateVector(std::vector<Val*> val) {
   for (auto v : val) {
-    TORCH_CHECK(
+    NVF_CHECK(
         !v->isA<TensorView>(),
         "TensorViews should not be added to State Vectors!");
   }
@@ -115,7 +115,7 @@ void FusionState::addFusionStateVector(std::vector<Val*> val) {
 
 Val* FusionState::getFusionState(size_t index) const {
   const auto& ret = fusion_state_.at(index);
-  TORCH_CHECK(ret.size() == 1, "Expecting to return only one Val*.");
+  NVF_CHECK(ret.size() == 1, "Expecting to return only one Val*.");
   return ret[0];
 }
 
@@ -133,7 +133,7 @@ void FusionState::setFusionState(size_t index, Val* val) {
 
 void FusionState::setFusionStateVector(size_t index, std::vector<Val*> val) {
   for (auto v : val) {
-    TORCH_CHECK(
+    NVF_CHECK(
         !v->isA<TensorView>(),
         "TensorViews should not be added to State Vectors!");
   }
@@ -141,26 +141,26 @@ void FusionState::setFusionStateVector(size_t index, std::vector<Val*> val) {
 }
 
 void FusionState::addInput(Val* input) {
-  TORCH_CHECK(fusion_ != nullptr, "Fusion is undefined.");
+  NVF_CHECK(fusion_ != nullptr, "Fusion is undefined.");
   fusion_->addInput(input);
 }
 
 void FusionState::addOutput(Val* output) {
-  TORCH_CHECK(fusion_ != nullptr, "Fusion is undefined.");
+  NVF_CHECK(fusion_ != nullptr, "Fusion is undefined.");
   fusion_->addOutput(output);
 }
 
 void FusionState::addOutput(
     Val* output,
     const std::vector<int64_t>& permutation) {
-  TORCH_CHECK(fusion_ != nullptr, "Fusion is undefined.");
+  NVF_CHECK(fusion_ != nullptr, "Fusion is undefined.");
   fusion_->addOutput(output);
   fusion_->setPermutationOnOutput(
       (int)fusion_->outputs().size() - 1, permutation);
 }
 
 void FusionState::aliasOutputToInput(Val* output, Val* input) {
-  TORCH_CHECK(fusion_ != nullptr, "Fusion is undefined.");
+  NVF_CHECK(fusion_ != nullptr, "Fusion is undefined.");
   fusion_->aliasOutputToInput(output, input);
 }
 

--- a/csrc/python_frontend/fusion_state.h
+++ b/csrc/python_frontend/fusion_state.h
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #pragma once
+#include <exceptions.h>
 #include <ir/interface_nodes.h>
 #include <serde/fusion_cache_generated.h>
 

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -34,7 +34,7 @@ namespace nvfuser::python_frontend {
 namespace {
 Vector define_vector_base_fn(FusionDefinition& fd, std::vector<Scalar>& args) {
   FUSER_PERF_SCOPE("python_frontend::define_vector_base_fn");
-  TORCH_CHECK(!fd.completed(), "Attempting to add to a completed definition!");
+  NVF_CHECK(!fd.completed(), "Attempting to add to a completed definition!");
   std::vector<State> inputs;
   inputs.reserve(args.size());
   for (const auto& arg : args) {
@@ -55,12 +55,12 @@ Vector define_vector_fn(
   std::vector<Scalar> args;
   size_t idx = 0;
   for (const auto& item : values) {
-    TORCH_CHECK(
+    NVF_CHECK(
         idx < 8,
         "The specified vector size exceeds the max tensor size for nvfuser.");
     if (py::isinstance<py::int_>(item)) {
       auto int_value = py::cast<int64_t>(item);
-      TORCH_CHECK(
+      NVF_CHECK(
           int_value >= -1,
           "The value ",
           int_value,
@@ -74,7 +74,7 @@ Vector define_vector_fn(
     } else if (py::isinstance<Scalar>(item)) {
       args.emplace_back(py::cast<Scalar>(item));
     } else {
-      TORCH_CHECK(
+      NVF_CHECK(
           false,
           "Unsupported iterable object type for define_vector! Index:",
           idx);
@@ -92,15 +92,15 @@ Tensor broadcast_in_dim_fn(
     std::vector<int64_t>& broadcast_dims) {
   FUSER_PERF_SCOPE("Operators.broadcast_in_dim");
   FusionDefinition* fd = op.fusion_definition;
-  TORCH_CHECK(!fd->completed(), "Attempting to add to a completed definition!");
+  NVF_CHECK(!fd->completed(), "Attempting to add to a completed definition!");
   size_t output_size = 0;
   if constexpr (std::is_same_v<ShapeType, Vector>) {
     output_size = shape.size;
   } else {
     output_size = shape.size();
   }
-  TORCH_CHECK(op.validUse(), "Attempting to add to a completed definition!");
-  TORCH_CHECK(
+  NVF_CHECK(op.validUse(), "Attempting to add to a completed definition!");
+  NVF_CHECK(
       output_size >= broadcast_dims.size(),
       "broadcast_dims vector size is too big for output shape!");
 
@@ -110,7 +110,7 @@ Tensor broadcast_in_dim_fn(
     } else {
       if constexpr (!(std::is_same_v<ShapeType, py::list> ||
                       std::is_same_v<ShapeType, py::tuple>)) {
-        TORCH_CHECK(
+        NVF_CHECK(
             false, "broadcast_in_dim's shape argument type is not supported!");
       }
       return define_vector_fn<ShapeType>(fd, shape);
@@ -130,7 +130,7 @@ Tensor broadcast_in_dim_fn(
 std::vector<std::optional<bool>> computeContiguity(
     const std::vector<int64_t>& sizes,
     const std::vector<int64_t>& strides) {
-  TORCH_CHECK(
+  NVF_CHECK(
       sizes.size() == strides.size(),
       "compute_contiguity: Sizes and strides must have the same number of dimensions");
   // Not a broadcast means neither the stride == 0 (size can be non-zero)
@@ -335,7 +335,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             }
             std::optional<int8_t> int8_device = std::nullopt;
             if (device.has_value()) {
-              TORCH_CHECK(device.value() < 256, "Maximum device index is 255");
+              NVF_CHECK(device.value() < 256, "Maximum device index is 255");
               int8_device = (int8_t)device.value();
             }
             return self.execute(
@@ -422,7 +422,7 @@ void initNvFuserPythonBindings(PyObject* module) {
           "add_output",
           [](FusionDefinition& self, Scalar output) {
             FUSER_PERF_SCOPE("FusionDefinition.add_output (scalar)");
-            TORCH_CHECK(
+            NVF_CHECK(
                 !self.completed(),
                 "Attempting to add to a completed definition!");
             self.defineRecord(new OutputRecord<Val>(
@@ -435,7 +435,7 @@ void initNvFuserPythonBindings(PyObject* module) {
              Tensor output,
              std::optional<Tensor> alias_input = std::nullopt) {
             FUSER_PERF_SCOPE("FusionDefinition.add_output (tensor)");
-            TORCH_CHECK(
+            NVF_CHECK(
                 !self.completed(),
                 "Attempting to add to a completed definition!");
             if (alias_input.has_value()) {
@@ -456,20 +456,20 @@ void initNvFuserPythonBindings(PyObject* module) {
              Tensor output,
              std::vector<int64_t> stride_order) {
             FUSER_PERF_SCOPE("FusionDefinition.add_output (tensor)");
-            TORCH_CHECK(
+            NVF_CHECK(
                 !self.completed(),
                 "Attempting to add to a completed definition!");
-            TORCH_CHECK(
+            NVF_CHECK(
                 stride_order.empty() || output.dims == stride_order.size(),
                 "stride_order needs to be either empty or the same length of Tensor `output`");
             int64_t duplicate_check = 0;
             for (const auto& v : stride_order) {
-              TORCH_CHECK(
+              NVF_CHECK(
                   v >= 0 && v < (int64_t)stride_order.size(),
                   "stride_order elements need to be within [0, stride_order.size())");
               duplicate_check |= 1 << v;
             }
-            TORCH_CHECK(
+            NVF_CHECK(
                 duplicate_check == (1 << stride_order.size()) - 1,
                 "duplicated elements in stride_order detected!");
             self.defineRecord(new OutputRecord<TensorView>(
@@ -497,12 +497,12 @@ void initNvFuserPythonBindings(PyObject* module) {
              PrimDataType dtype = DataType::Float,
              bool is_cpu = false) -> Tensor {
             FUSER_PERF_SCOPE("FusionDefinition.define_tensor (default)");
-            TORCH_CHECK(
+            NVF_CHECK(
                 !self.completed(),
                 "Attempting to add to a completed definition!");
 
             for (size_t i = 0; i < shape.size(); ++i) {
-              TORCH_CHECK(
+              NVF_CHECK(
                   shape[i] >= -1,
                   "The value ",
                   shape[i],
@@ -535,10 +535,10 @@ void initNvFuserPythonBindings(PyObject* module) {
              bool static_sizes = false,
              bool is_cpu = false) -> Tensor {
             FUSER_PERF_SCOPE("FusionDefinition.define_tensor (integration)");
-            TORCH_CHECK(
+            NVF_CHECK(
                 !self.completed(),
                 "Attempting to add to a completed definition!");
-            TORCH_CHECK(
+            NVF_CHECK(
                 sizes.size() == strides.size(),
                 "The number of sizes does not match the number of strides.",
                 sizes.size(),
@@ -552,7 +552,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             std::vector<int64_t> dim_sizes;
             dim_sizes.reserve(sizes.size());
             for (const auto i : c10::irange(sizes.size())) {
-              TORCH_INTERNAL_ASSERT(
+              NVF_ERROR(
                   sizes[i] >= 0,
                   "Size of ",
                   sizes[i],
@@ -589,7 +589,7 @@ void initNvFuserPythonBindings(PyObject* module) {
           [](FusionDefinition& self,
              PrimDataType dtype = DataType::Double) -> Scalar {
             FUSER_PERF_SCOPE("FusionDefinition.define_scalar (input_specific)");
-            TORCH_CHECK(
+            NVF_CHECK(
                 !self.completed(),
                 "Attempting to add to a completed definition!");
             Scalar out = self.defineScalar();
@@ -634,7 +634,7 @@ void initNvFuserPythonBindings(PyObject* module) {
   fusion_def.def(
       "define_vector",
       [](FusionDefinition& self, size_t size) -> Vector {
-        TORCH_CHECK(
+        NVF_CHECK(
             size < 8,
             "The specified vector size exceeds the max tensor size for nvfuser.");
         std::vector<Scalar> args;
@@ -682,7 +682,7 @@ void initNvFuserPythonBindings(PyObject* module) {
       op_str,                                                                 \
       [](FusionDefinition::Operators& self, Tensor input) -> Tensor {         \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(input.dims);                         \
@@ -699,7 +699,7 @@ void initNvFuserPythonBindings(PyObject* module) {
       op_str,                                                                 \
       [](FusionDefinition::Operators& self, Scalar input) -> Scalar {         \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Scalar output = fd->defineScalar();                                   \
@@ -782,7 +782,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar rng_seed,                                                     \
          Scalar rng_offset) -> Tensor {                                       \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(input.dims);                         \
@@ -813,7 +813,7 @@ void initNvFuserPythonBindings(PyObject* module) {
       [](Tensor input) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
         FusionDefinition* fd = input.fusion_definition;                        \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             !fd->completed(), "Attempting to add to a completed definition!"); \
         Tensor output = fd->defineTensor(input.dims);                          \
         fd->defineRecord(new OpRecord<TensorView*, TensorView*>(               \
@@ -830,7 +830,7 @@ void initNvFuserPythonBindings(PyObject* module) {
       [](Scalar input) -> Scalar {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
         FusionDefinition* fd = input.fusion_definition;                        \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             !fd->completed(), "Attempting to add to a completed definition!"); \
         Scalar output = fd->defineScalar();                                    \
         fd->defineRecord(new OpRecord<Val*, Val*>(                             \
@@ -853,7 +853,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg1,                                                          \
          Tensor arg2) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg1.dims);                           \
@@ -880,7 +880,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg1,                                                          \
          Tensor arg2) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg1.dims);                           \
@@ -899,7 +899,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg1,                                                          \
          Scalar arg2) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg1.dims);                           \
@@ -918,7 +918,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg1,                                                          \
          Tensor arg2) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg2.dims);                           \
@@ -937,7 +937,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg1,                                                          \
          Scalar arg2) -> Scalar {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Scalar output = fd->defineScalar();                                    \
@@ -1080,7 +1080,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg2,                                                         \
          Scalar arg3) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg1.dims);                          \
@@ -1104,7 +1104,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg2,                                                         \
          Scalar arg3) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg1.dims);                          \
@@ -1126,7 +1126,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg2,                                                         \
          Scalar arg3) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg2.dims);                          \
@@ -1148,7 +1148,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg2,                                                         \
          Scalar arg3) -> Scalar {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Scalar output = fd->defineScalar();                                   \
@@ -1176,7 +1176,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg2,                                                         \
          Scalar arg3) -> Scalar {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Scalar output = fd->defineScalar();                                   \
@@ -1198,7 +1198,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg2,                                                         \
          Tensor arg3) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg1.dims);                          \
@@ -1223,7 +1223,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg2,                                                         \
          Scalar arg3) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg1.dims);                          \
@@ -1247,7 +1247,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg2,                                                         \
          Tensor arg3) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg1.dims);                          \
@@ -1271,7 +1271,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg2,                                                         \
          Tensor arg3) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg2.dims);                          \
@@ -1295,7 +1295,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg2,                                                         \
          Tensor arg3) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg3.dims);                          \
@@ -1317,7 +1317,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg2,                                                         \
          Scalar arg3) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg1.dims);                          \
@@ -1339,7 +1339,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg2,                                                         \
          Scalar arg3) -> Tensor {                                             \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg2.dims);                          \
@@ -1367,7 +1367,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg2,                                                          \
          Scalar arg3) -> Scalar {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             !self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                         \
         Scalar output = fd->defineScalar();                                    \
@@ -1389,7 +1389,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg2,                                                          \
          Scalar arg3) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             !self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg1.dims);                           \
@@ -1418,7 +1418,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg3,                                                          \
          Scalar arg4) -> Scalar {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Scalar output = fd->defineScalar();                                    \
@@ -1442,7 +1442,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg3,                                                          \
          Scalar arg4) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg1.dims);                           \
@@ -1473,7 +1473,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg3,                                                          \
          Scalar arg4) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg1.dims);                           \
@@ -1500,7 +1500,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg3,                                                          \
          Scalar arg4) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg1.dims);                           \
@@ -1527,7 +1527,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg3,                                                          \
          Scalar arg4) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg2.dims);                           \
@@ -1554,7 +1554,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg3,                                                          \
          Scalar arg4) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg3.dims);                           \
@@ -1580,7 +1580,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg3,                                                          \
          Scalar arg4) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg1.dims);                           \
@@ -1606,7 +1606,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg3,                                                          \
          Scalar arg4) -> Tensor {                                              \
         FUSER_PERF_SCOPE("Operators." op_str);                                 \
-        TORCH_CHECK(                                                           \
+        NVF_CHECK(                                                             \
             self.validUse(), "Attempting to add to a completed definition!");  \
         FusionDefinition* fd = self.fusion_definition;                         \
         Tensor output = fd->defineTensor(arg2.dims);                           \
@@ -1635,7 +1635,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg,                                                          \
          PrimDataType dtype) -> Tensor {                                      \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         size_t ndims = 0;                                                     \
@@ -1667,7 +1667,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          bool keepdim,                                                        \
          PrimDataType dtype) -> Tensor {                                      \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         size_t ndims = keepdim ? arg.dims : (arg.dims - 1);                   \
@@ -1699,7 +1699,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          bool keepdim,                                                        \
          PrimDataType dtype) -> Tensor {                                      \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         size_t ndims = keepdim ? arg.dims : (arg.dims - axes.size());         \
@@ -1741,7 +1741,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg,                                                          \
          PrimDataType dtype) -> Tensor {                                      \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Tensor output = fd->defineTensor(arg.dims);                           \
@@ -1763,7 +1763,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Scalar arg,                                                          \
          PrimDataType dtype) -> Scalar {                                      \
         FUSER_PERF_SCOPE("Operators." op_str);                                \
-        TORCH_CHECK(                                                          \
+        NVF_CHECK(                                                            \
             self.validUse(), "Attempting to add to a completed definition!"); \
         FusionDefinition* fd = self.fusion_definition;                        \
         Scalar output = fd->defineScalar();                                   \
@@ -1796,7 +1796,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          bool training,
          bool channels_last) -> decltype(auto) {
         FUSER_PERF_SCOPE("Operators.batch_norm");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(arg.dims);
@@ -1868,7 +1868,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg,
          std::vector<bool>& is_broadcast_dim) -> Tensor {
         FUSER_PERF_SCOPE("Operators.broadcast");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(arg.dims);
@@ -1887,10 +1887,10 @@ void initNvFuserPythonBindings(PyObject* module) {
       [](FusionDefinition::Operators& self,
          std::vector<Tensor> tensors,
          int64_t dim) -> Tensor {
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
-        TORCH_CHECK(
+        NVF_CHECK(
             !tensors.empty(), "Attempting to concatenate empty list of tensors")
         Tensor output = fd->defineTensor(tensors[0].dims);
         std::vector<State> tensor_states;
@@ -1912,7 +1912,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor index,
          int64_t dim) -> Tensor {
         FUSER_PERF_SCOPE("Operators.index_select");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(arg.dims);
@@ -1936,16 +1936,16 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor index,
          int64_t dim) -> Tensor {
         FUSER_PERF_SCOPE("Operators.gather");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
-        TORCH_CHECK(
+        NVF_CHECK(
             arg1.dims == index.dims,
             "Tensor arguments have different dimensions ",
             arg1.dims,
             " and ",
             index.dims);
         auto num_dims = (int64_t)arg1.dims;
-        TORCH_CHECK(
+        NVF_CHECK(
             dim >= -num_dims && dim < num_dims,
             "Tensor arguments have dimension ",
             num_dims,
@@ -1998,9 +1998,9 @@ void initNvFuserPythonBindings(PyObject* module) {
          std::vector<int64_t>& pad_widths,
          std::optional<Scalar> value) -> Tensor {
         FUSER_PERF_SCOPE("Operators.pad");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
-        TORCH_CHECK(
+        NVF_CHECK(
             pad_widths.size() <= 2 * arg.dims,
             "Number of pad widths must be at most twice the input dimension");
         FusionDefinition* fd = self.fusion_definition;
@@ -2025,16 +2025,16 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor index,
          int64_t dim) -> Tensor {
         FUSER_PERF_SCOPE("Operators.take_along_axis");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
-        TORCH_CHECK(
+        NVF_CHECK(
             arg1.dims == index.dims,
             "Tensor arguments have different dimensions ",
             arg1.dims,
             " and ",
             index.dims);
         auto num_dims = (int64_t)arg1.dims;
-        TORCH_CHECK(
+        NVF_CHECK(
             dim >= -num_dims && dim < num_dims,
             "Tensor arguments have dimension ",
             num_dims,
@@ -2082,7 +2082,7 @@ void initNvFuserPythonBindings(PyObject* module) {
       [](FusionDefinition::Operators& self,
          Tensor arg,
          std::vector<int64_t>& dims) -> Tensor {
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(arg.dims);
@@ -2099,7 +2099,7 @@ void initNvFuserPythonBindings(PyObject* module) {
   auto shape_def = [](Tensor arg) -> Vector {
     FUSER_PERF_SCOPE("Operators.shape");
     auto fd = arg.fusion_definition;
-    TORCH_CHECK(
+    NVF_CHECK(
         fd->ops.validUse(), "Attempting to add to a completed definition!");
     Vector output = fd->defineVector(arg.dims);
     fd->defineRecord(new ShapeOpRecord(
@@ -2122,7 +2122,7 @@ void initNvFuserPythonBindings(PyObject* module) {
   auto size_def = [](Tensor arg, int64_t dim) -> Scalar {
     FUSER_PERF_SCOPE("Operators.size");
     auto fd = arg.fusion_definition;
-    TORCH_CHECK(
+    NVF_CHECK(
         fd->ops.validUse(), "Attempting to add to a completed definition!");
     Scalar output = fd->defineScalar();
     fd->defineRecord(new SizeOpRecord(
@@ -2147,7 +2147,7 @@ void initNvFuserPythonBindings(PyObject* module) {
   auto at_def = [](Vector arg, int64_t index) -> Scalar {
     FUSER_PERF_SCOPE("Operators.at");
     auto fd = arg.fusion_definition;
-    TORCH_CHECK(
+    NVF_CHECK(
         fd->ops.validUse(), "Attempting to add to a completed definition!");
     Scalar output = fd->defineScalar();
     fd->defineRecord(new AtOpRecord(
@@ -2188,12 +2188,12 @@ void initNvFuserPythonBindings(PyObject* module) {
          std::optional<std::vector<int64_t>> opt_strides =
              std::nullopt) -> Tensor {
         FUSER_PERF_SCOPE("Operators.slice");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
 
         std::vector<int64_t> strides(start_indices.size(), int64_t(1));
         if (opt_strides.has_value()) {
-          TORCH_CHECK(
+          NVF_CHECK(
               start_indices.size() == opt_strides.value().size(),
               "Slice start_indices and strides don't match! Start Indices: ",
               start_indices.size(),
@@ -2202,13 +2202,13 @@ void initNvFuserPythonBindings(PyObject* module) {
           strides.assign(
               opt_strides.value().begin(), opt_strides.value().end());
         }
-        TORCH_CHECK(
+        NVF_CHECK(
             arg.dims == start_indices.size(),
             "Number of tensor dimensions does not match slice dimensions! Tensor-dims: ",
             arg.dims,
             " Slice-dims: ",
             start_indices.size());
-        TORCH_CHECK(
+        NVF_CHECK(
             start_indices.size() == end_indices.size(),
             "Slice indexing attribute dimensions don't match! Start Indices: ",
             start_indices.size(),
@@ -2220,7 +2220,7 @@ void initNvFuserPythonBindings(PyObject* module) {
           auto start_idx = start_indices[i];
           auto end_idx = end_indices[i];
           auto stride = strides[i];
-          TORCH_CHECK(
+          NVF_CHECK(
               start_idx >= 0,
               "Slice operation start_indices must be greater-than-or-equal-to 0. Start Indices: ",
               start_indices,
@@ -2228,7 +2228,7 @@ void initNvFuserPythonBindings(PyObject* module) {
               end_indices,
               " Strides: ",
               strides);
-          TORCH_CHECK(
+          NVF_CHECK(
               end_idx >= start_idx,
               "Slice operation end_indices must be greater-than-or-equal-to start_indices. Start Indices: ",
               start_indices,
@@ -2236,7 +2236,7 @@ void initNvFuserPythonBindings(PyObject* module) {
               end_indices,
               " Strides: ",
               strides);
-          TORCH_CHECK(
+          NVF_CHECK(
               stride == 1,
               "nvFuser Limitation: All slice operation strides must be of size 1. Start Indices: ",
               start_indices,
@@ -2267,7 +2267,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          std::vector<int64_t>& original_shape,
          std::vector<int64_t>& dims) -> Tensor {
         FUSER_PERF_SCOPE("Operators.squeeze");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(arg.dims - 1);
@@ -2286,7 +2286,7 @@ void initNvFuserPythonBindings(PyObject* module) {
       "tensor_sizes",
       [](FusionDefinition::Operators& self, Tensor arg) -> std::vector<Scalar> {
         FUSER_PERF_SCOPE("Operators.tensor_sizes");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         std::vector<Scalar> outputs;
@@ -2307,7 +2307,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg,
          std::vector<int64_t>& original_shape,
          std::vector<int64_t>& new_shape) -> Tensor {
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(new_shape.size());
@@ -2328,7 +2328,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          std::vector<int64_t>& shape,
          Scalar fill_value,
          PrimDataType dtype) -> Tensor {
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(shape.size());
@@ -2350,7 +2350,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          std::optional<Scalar> start,
          std::optional<Scalar> step,
          PrimDataType dtype) -> Tensor {
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(1);
@@ -2378,7 +2378,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          int64_t correction,
          bool keepdim) -> Tensor {
         FUSER_PERF_SCOPE("Operators.var");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         size_t ndims = keepdim ? arg.dims : (arg.dims - axes.size());
@@ -2404,7 +2404,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          int64_t correction,
          bool keepdim) -> decltype(auto) {
         FUSER_PERF_SCOPE("Operators.var_mean");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         size_t ndims = keepdim ? arg.dims : (arg.dims - axes.size());
@@ -2433,7 +2433,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          std::optional<Scalar> rng_seed,
          std::optional<Scalar> rng_offset) -> Tensor {
         FUSER_PERF_SCOPE("Operators.uniform");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(shape.size());
@@ -2449,7 +2449,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             fd->recordingState(maxval()),
         };
         if (rng_seed.has_value()) {
-          TORCH_CHECK(
+          NVF_CHECK(
               rng_offset.has_value(),
               "When providing rng_seed, rng_offset must also be provided");
           arg_states.push_back(fd->recordingState(rng_seed.value()()));
@@ -2481,7 +2481,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          std::optional<Scalar> rng_seed,
          std::optional<Scalar> rng_offset) -> Tensor {
         FUSER_PERF_SCOPE("Operators.normal");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(shape.size());
@@ -2497,7 +2497,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             fd->recordingState(std()),
         };
         if (rng_seed.has_value()) {
-          TORCH_CHECK(
+          NVF_CHECK(
               rng_offset.has_value(),
               "When providing rng_seed, rng_offset must also be provided");
           arg_states.push_back(fd->recordingState(rng_seed.value()()));
@@ -2533,7 +2533,7 @@ void initNvFuserPythonBindings(PyObject* module) {
       "merge",
       [](FusionDefinition::SchedOperators& self, Tensor arg, int dim) {
         FUSER_PERF_SCOPE("SchedOperators.merge");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(),
             "Attempting to use a SchedOperators Op prior to definition!");
         FusionDefinition* fd = self.fusion_definition;
@@ -2547,14 +2547,14 @@ void initNvFuserPythonBindings(PyObject* module) {
                                   Tensor arg,
                                   const std::vector<int>& dims) -> Tensor {
     FUSER_PERF_SCOPE("SchedOperators.reduction_factor");
-    TORCH_CHECK(
+    NVF_CHECK(
         self.validUse(),
         "Attempting to use a SchedOperators Op prior to definition!");
     FusionDefinition* fd = self.fusion_definition;
     auto input_tv = fd->getFusionState(arg.index)->template as<TensorView>();
     auto output_tv = input_tv->rFactor(dims);
     Tensor output = fd->defineTensor(arg.dims);
-    TORCH_CHECK(
+    NVF_CHECK(
         output.index == fd->numFusionStates(),
         "Fusion State index does not match the size!");
     fd->addFusionState(output_tv);
@@ -2573,7 +2573,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg,
          const std::unordered_map<int, int>& old2new) {
         FUSER_PERF_SCOPE("SchedOperators.reorder");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(),
             "Attempting to use a SchedOperators Op prior to definition!");
         FusionDefinition* fd = self.fusion_definition;
@@ -2592,7 +2592,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          bool inner_split,
          bool trim_out_of_bounds) {
         FUSER_PERF_SCOPE("SchedOperators.split");
-        TORCH_CHECK(
+        NVF_CHECK(
             self.validUse(),
             "Attempting to use a SchedOperators Op prior to definition!");
         FusionDefinition* fd = self.fusion_definition;

--- a/csrc/python_frontend/python_bindings.h
+++ b/csrc/python_frontend/python_bindings.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <torch/csrc/jit/python/pybind.h>
 #include <torch/csrc/utils/pybind.h>
 

--- a/csrc/register_interface.h
+++ b/csrc/register_interface.h
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #pragma once
+#include <exceptions.h>
 #include <manager.h>
 #include <transform_view.h>
 

--- a/csrc/root_domain_map.cpp
+++ b/csrc/root_domain_map.cpp
@@ -53,11 +53,11 @@ PairwiseRootDomainMap::PairwiseRootDomainMap(
     const TensorView* producer,
     const TensorView* consumer)
     : producer_tv_(producer), consumer_tv_(consumer) {
-  TORCH_INTERNAL_ASSERT(producer != nullptr);
-  TORCH_INTERNAL_ASSERT(consumer != nullptr);
-  TORCH_INTERNAL_ASSERT(producer->fusion() == consumer->fusion());
+  NVF_ERROR(producer != nullptr);
+  NVF_ERROR(consumer != nullptr);
+  NVF_ERROR(producer->fusion() == consumer->fusion());
   // Make sure they are really a producer and its consumer
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       producer->isConsumerOf(consumer),
       "Not a producer-consumer pair: ",
       producer,
@@ -161,7 +161,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseRootDomainMap::map(
     // Condition 3: when the consumer ID is a new broadcast domain, there is no
     // mapping for it.
     if (!broadcast_flags.empty() && broadcast_flags.at(itc)) {
-      TORCH_INTERNAL_ASSERT(consumer_id->isBroadcast());
+      NVF_ERROR(consumer_id->isBroadcast());
       itc++;
       continue;
     }
@@ -169,7 +169,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseRootDomainMap::map(
     // Condition 3: when the producer ID is a removed broadcast domain, there is
     // no mapping for it.
     if (!squeeze_flags.empty() && squeeze_flags.at(itp)) {
-      TORCH_INTERNAL_ASSERT(producer_id->isBroadcast());
+      NVF_ERROR(producer_id->isBroadcast());
       itp++;
       continue;
     }
@@ -248,7 +248,7 @@ std::string DomainKey::toString() const {
   ss << " in ";
   if (td()) {
     auto tv = lookUpTv(td());
-    TORCH_INTERNAL_ASSERT(tv != nullptr, "No TV found for ", td()->toString());
+    NVF_ERROR(tv != nullptr, "No TV found for ", td()->toString());
     ss << "T" << tv->name() << "[ " << td()->root() << " ]";
     if (td()->hasRFactor()) {
       ss << " (Rfactor: [ " << td()->maybeRFactor() << " ])";
@@ -469,11 +469,11 @@ bool ComputeAtRootDomainMap::canMap(
     const IterDomain* id_a,
     const TensorDomain* td_b,
     const IterDomain* id_b) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       id_a->definition() == nullptr || id_a->isRFactorProduct(),
       "Non-root domain is not supported: ",
       id_a);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       id_b->definition() == nullptr || id_b->isRFactorProduct(),
       "Non-root domain is not supported: ",
       id_b);
@@ -518,7 +518,7 @@ bool ComputeAtRootDomainMap::canMap(
     const DomainKey& key_a,
     const TensorDomain* td_b,
     const IterDomain* id_b) const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       id_b->definition() == nullptr || id_b->isRFactorProduct(),
       "Non-root domain is not supported: ",
       id_b);
@@ -603,7 +603,7 @@ std::vector<DomainKey> ComputeAtRootDomainMap::getConcretizedKeys(
     const IterDomain* id) const {
   DomainKey key(td, id);
   auto it = bcast_map_.find(key);
-  TORCH_INTERNAL_ASSERT(it != bcast_map_.end(), "Not found: ", key.toString());
+  NVF_ERROR(it != bcast_map_.end(), "Not found: ", key.toString());
   std::vector<DomainKey> domains;
   std::transform(
       it->second.begin(),
@@ -619,7 +619,7 @@ std::unordered_set<const IterDomain*>& ComputeAtRootDomainMap::
     getConcretizedDomains(const TensorDomain* td, const IterDomain* id) {
   DomainKey key(td, id);
   auto it = bcast_map_.find(key);
-  TORCH_INTERNAL_ASSERT(it != bcast_map_.end(), "Not found: ", key.toString());
+  NVF_ERROR(it != bcast_map_.end(), "Not found: ", key.toString());
   return it->second;
 }
 
@@ -633,7 +633,7 @@ std::unordered_map<IterDomain*, IterDomain*> ComputeAtRootDomainMap::
   for (auto& from_id : from_root) {
     for (const auto& to_id : to_root) {
       if (canMap(from_td, from_id, to_td, to_id)) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             id_map.insert({from_id, to_id}).second,
             "Multiple matching ID detected for ",
             from_id);
@@ -682,7 +682,7 @@ std::unordered_map<IterDomain*, IterDomain*> ComputeAtRootDomainMap::map(
              removed_broadcast_domains_.end())) {
       continue;
     }
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         false,
         "Mapping IterDomain ",
         from_id,
@@ -735,7 +735,7 @@ ComputeAtRootDomainMapBuilder::ComputeAtRootDomainMapBuilder(
       root_map_(root_map),
       map_through_reduction_(map_through_reduction) {
   Fusion* fusion = FusionGuard::getCurFusion();
-  TORCH_INTERNAL_ASSERT(fusion != nullptr);
+  NVF_ERROR(fusion != nullptr);
   traverseTo(fusion, fusion->outputs(), false);
   if (!pending_map_.empty()) {
     std::stringstream ss;
@@ -748,7 +748,7 @@ ComputeAtRootDomainMapBuilder::ComputeAtRootDomainMapBuilder(
     }
     debug() << ss.str();
   }
-  TORCH_INTERNAL_ASSERT(pending_map_.empty());
+  NVF_ERROR(pending_map_.empty());
 }
 
 // Set concrete domains for broadcast domains that never get joined
@@ -757,7 +757,7 @@ ComputeAtRootDomainMapBuilder::ComputeAtRootDomainMapBuilder(
 void ComputeAtRootDomainMapBuilder::initializeBcastMap(
     const TensorView* tv,
     const IterDomain* id) {
-  TORCH_INTERNAL_ASSERT(id->isBroadcast(), "Not a broadcast axis");
+  NVF_ERROR(id->isBroadcast(), "Not a broadcast axis");
   auto key = DomainKey(tv->domain(), id);
   auto it = root_map_.bcast_map_.find(key);
   if (it != root_map_.bcast_map_.end()) {
@@ -776,7 +776,7 @@ void ComputeAtRootDomainMapBuilder::initializeBcastMap(
     // Unfortunately, const_cast is required as our const model is
     // broken.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    TORCH_INTERNAL_ASSERT(p2c.find(const_cast<IterDomain*>(id)) == p2c.end());
+    NVF_ERROR(p2c.find(const_cast<IterDomain*>(id)) == p2c.end());
   }
 
   root_map_.bcast_map_.insert({key, {id}});
@@ -862,7 +862,7 @@ void ComputeAtRootDomainMapBuilder::setMaybeMapped(
   }
 
   if (consumer_id->isBroadcast()) {
-    TORCH_INTERNAL_ASSERT(producer_id->isBroadcast());
+    NVF_ERROR(producer_id->isBroadcast());
     // Get bcast_map_ entry for consumer_id
     const auto consumer_bcast_domains =
         root_map_.getConcretizedKeys(consumer_td, consumer_id);
@@ -905,10 +905,10 @@ void ComputeAtRootDomainMapBuilder::mapPointwiseOrReductionOp(Expr* e) {
   }
 
   // Broadcast is handled separately, so e should never be BroadcastOp.
-  TORCH_INTERNAL_ASSERT(!e->isA<BroadcastOp>());
-  TORCH_INTERNAL_ASSERT(!e->isA<SqueezeOp>());
+  NVF_ERROR(!e->isA<BroadcastOp>());
+  NVF_ERROR(!e->isA<SqueezeOp>());
 
-  TORCH_INTERNAL_ASSERT(!e->outputs().empty());
+  NVF_ERROR(!e->outputs().empty());
   const TensorView* out_tv = e->output(0)->as<TensorView>();
   const TensorDomain* out_td = out_tv->domain();
   const auto& out_root = out_td->root();
@@ -919,7 +919,7 @@ void ComputeAtRootDomainMapBuilder::mapPointwiseOrReductionOp(Expr* e) {
     const TensorDomain* in_td = in_tv->domain();
     std::vector<IterDomain*> in_root =
         TensorDomain::noReductions(in_tv->getMaybeRFactorDomain());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         in_root.size() == out_root.size(),
         "\nExpression: ",
         e,
@@ -929,7 +929,7 @@ void ComputeAtRootDomainMapBuilder::mapPointwiseOrReductionOp(Expr* e) {
         out_root);
     for (const auto it : c10::irange(in_root.size())) {
       if (e->outputs().size() > 1) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             e->isA<WelfordOp>() || e->isA<GroupedReductionOp>() ||
                 e->isA<GroupedWelfordOp>(),
             "Unknown multi-output Expr type ",
@@ -954,7 +954,7 @@ void ComputeAtRootDomainMapBuilder::handle(BroadcastOp* op) {
   const auto in_root = TensorDomain::noReductions(in_td->maybeRFactor());
   const auto& out_root = out_td->root();
   const auto& bcast_dim_flags = op->getBroadcastDimFlags();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       out_root.size() == bcast_dim_flags.size(),
       "dim flags: ",
       bcast_dim_flags,
@@ -976,7 +976,7 @@ void ComputeAtRootDomainMapBuilder::handle(BroadcastOp* op) {
   }
   // At this point, the input domain should have been scanned
   // entirely.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       in_it == in_root.end(),
       "Unmatched domain detected: ",
       *in_it,
@@ -985,7 +985,7 @@ void ComputeAtRootDomainMapBuilder::handle(BroadcastOp* op) {
   // On the other hand, the output may still have some domains left,
   // and they must be new broadcast domains.
   for (; out_it != out_root.end(); ++out_it) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         bcast_dim_flags.at(std::distance(out_root.begin(), out_it)),
         "Unmatched domain detected: ",
         *out_it,
@@ -1001,7 +1001,7 @@ void ComputeAtRootDomainMapBuilder::handle(SqueezeOp* op) {
   const auto in_root = TensorDomain::noReductions(in_td->maybeRFactor());
   const auto& out_root = out_td->root();
   const auto& squeeze_dim_flags = op->getSqueezeDimFlags();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       in_root.size() == squeeze_dim_flags.size(),
       "dim flags: ",
       squeeze_dim_flags,
@@ -1023,7 +1023,7 @@ void ComputeAtRootDomainMapBuilder::handle(SqueezeOp* op) {
   }
   // At this point, the output domain should have been scanned
   // entirely.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       out_it == out_root.end(),
       "Unmatched domain detected: ",
       *out_it,
@@ -1032,7 +1032,7 @@ void ComputeAtRootDomainMapBuilder::handle(SqueezeOp* op) {
   // On the other hand, the input may still have some domains left,
   // and they must be removed broadcast domains.
   for (; in_it != in_root.end(); ++in_it) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         squeeze_dim_flags.at(std::distance(in_root.begin(), in_it)),
         "Unmatched domain detected: ",
         *in_it,
@@ -1052,7 +1052,7 @@ void ComputeAtRootDomainMapBuilder::handle(ViewAsScalar* op) {
 
   std::vector<IterDomain*> in_root =
       TensorDomain::noReductions(in_tv->getMaybeRFactorDomain());
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       in_root.size() + 1 == out_root.size(),
       "\nExpression: ",
       op,
@@ -1067,7 +1067,7 @@ void ComputeAtRootDomainMapBuilder::handle(ViewAsScalar* op) {
     ++in_it;
     ++out_it;
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       (*out_it)->isVectorComponent(),
       "The last dim of ViewDtypeOp's output must be a ViewAsScalar");
 }
@@ -1099,7 +1099,7 @@ void ComputeAtRootDomainMapBuilder::handle(TorchGatherOp* op) {
   const auto idx_root = TensorDomain::noReductions(idx_td->maybeRFactor());
   const auto& out_root = out_td->root();
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       idx_root.size() == out_root.size(),
       "\nExpression: ",
       op,
@@ -1107,7 +1107,7 @@ void ComputeAtRootDomainMapBuilder::handle(TorchGatherOp* op) {
       idx_root,
       "\nOutput root domain: ",
       out_root);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       lookup_root.size() == out_root.size(),
       "\nExpression: ",
       op,
@@ -1133,7 +1133,7 @@ void ComputeAtRootDomainMapBuilder::mapAllPendingMappings(
   }
   const auto& pending_set = it->second;
   // All entries in key_set must be equivalent with each other.
-  TORCH_INTERNAL_ASSERT(!pending_set.empty());
+  NVF_ERROR(!pending_set.empty());
   bool consistent = safeToMap(pending_set);
   for (const auto pending_key : pending_set) {
     if (consistent) {
@@ -1294,7 +1294,7 @@ std::unordered_map<IterDomain*, IterDomain*> ExactRootDomainMap::map(
     }
     for (const auto& to_id : to_ids) {
       if (areMapped(from_id, to_id)) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             id_map.insert({from_id, to_id}).second,
             "Multiple matching ID detected for ",
             from_id);

--- a/csrc/root_domain_map.h
+++ b/csrc/root_domain_map.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <disjoint_set.h>
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <iter_visitor.h>
 #include <utils.h>

--- a/csrc/scheduler/matmul.h
+++ b/csrc/scheduler/matmul.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <exceptions.h>
 
 #include <fusion.h>
 #include <mma_type.h>

--- a/csrc/scheduler/matmul_utils.h
+++ b/csrc/scheduler/matmul_utils.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <fusion.h>
 
 namespace nvfuser {

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <fusion.h>
 #include <mma_type.h>
 #include <array>

--- a/csrc/scheduler/normalization.h
+++ b/csrc/scheduler/normalization.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <exceptions.h>
 
 #include <fusion.h>
 #include <scheduler/reduction_heuristic.h>

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -38,7 +38,7 @@ bool PreferredLaunchConfig::setBdimx(int bdimx, bool dry_run) {
     return false;
   }
 
-  TORCH_INTERNAL_ASSERT(block_size % bdimx == 0, "Invalid bdimx: ", bdimx);
+  NVF_ERROR(block_size % bdimx == 0, "Invalid bdimx: ", bdimx);
   int bdimy = block_size / bdimx;
 
   if (!dry_run) {
@@ -187,7 +187,7 @@ bool checkIfWithinRegisterSpace(
   auto pb_factor =
       getMinPersistentBufferSize(total_reduction_numel, bdimy, gdimy);
 
-  TORCH_INTERNAL_ASSERT(pb_factor > 0);
+  NVF_ERROR(pb_factor > 0);
 
   const auto available_reg_count = getAvailableRegisterCount(pb_factor);
 
@@ -498,7 +498,7 @@ std::optional<GridOuterNormalizationParams> getGridOuterNormalizationParams(
 
   // No valid config found. Return launch_cfg, which should be marked
   // as invalid
-  TORCH_INTERNAL_ASSERT(launch_cfg.isInvalid());
+  NVF_ERROR(launch_cfg.isInvalid());
   return std::nullopt;
 }
 
@@ -608,8 +608,7 @@ int64_t partialReductionBufferSize(
         continue;
       }
       auto id_size = runtime_info.expressionEvaluator().evaluate(id->extent());
-      TORCH_INTERNAL_ASSERT(
-          id_size.hasValue(), "Could not infer persistent buffer size.");
+      NVF_ERROR(id_size.hasValue(), "Could not infer persistent buffer size.");
       if (buffer_size == -1) {
         buffer_size = id_size.as<int64_t>();
       } else {

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <executor_params.h>
 #include <ir/all_nodes.h>
 #include <cmath>

--- a/csrc/scheduler/pointwise.h
+++ b/csrc/scheduler/pointwise.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <exceptions.h>
 
 #include <fusion.h>
 #include <scheduler/pointwise_heuristic.h>

--- a/csrc/scheduler/pointwise_utils.cpp
+++ b/csrc/scheduler/pointwise_utils.cpp
@@ -30,21 +30,19 @@ getIndexedConsumerToProducerMap(Fusion* fusion, const ComputeAtMap& ca_map) {
     if (auto gather = dynamic_cast<TorchGatherOp*>(expr)) {
       auto p_id = gather->getIndexedID();
       auto c_id = gather->getConsumerOfIndexedID();
-      TORCH_INTERNAL_ASSERT(
-          indexed_id_map
-              .emplace(
-                  ca_map.disjointSetOf(c_id, IdMappingMode::EXACT),
-                  ca_map.disjointSetOf(p_id, IdMappingMode::EXACT))
-              .second);
+      NVF_ERROR(indexed_id_map
+                    .emplace(
+                        ca_map.disjointSetOf(c_id, IdMappingMode::EXACT),
+                        ca_map.disjointSetOf(p_id, IdMappingMode::EXACT))
+                    .second);
     } else if (auto index_select = dynamic_cast<IndexSelectOp*>(expr)) {
       auto p_id = index_select->getIndexedID();
       auto c_id = index_select->getConsumerOfIndexedID();
-      TORCH_INTERNAL_ASSERT(
-          indexed_id_map
-              .emplace(
-                  ca_map.disjointSetOf(c_id, IdMappingMode::EXACT),
-                  ca_map.disjointSetOf(p_id, IdMappingMode::EXACT))
-              .second);
+      NVF_ERROR(indexed_id_map
+                    .emplace(
+                        ca_map.disjointSetOf(c_id, IdMappingMode::EXACT),
+                        ca_map.disjointSetOf(p_id, IdMappingMode::EXACT))
+                    .second);
     } else {
       // Note there's no consumer ID for select. This means we can't
       // just propagate from consumers to indexed producers. It seems
@@ -68,7 +66,7 @@ bool canIgnoreIndexedInputDomainID(
     TensorView* input_tv,
     IterDomain* root_id,
     const ComputeAtMap& ca_map) {
-  TORCH_INTERNAL_ASSERT(input_tv->isFusionInput());
+  NVF_ERROR(input_tv->isFusionInput());
   for (auto use : input_tv->uses()) {
     if (auto select = dynamic_cast<SelectOp*>(use)) {
       if (root_id != select->getIndexedID()) {

--- a/csrc/scheduler/pointwise_utils.h
+++ b/csrc/scheduler/pointwise_utils.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <compute_at_map.h>
+#include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <ir/utils.h>
 #include <scheduler/utils.h>

--- a/csrc/scheduler/reduction.h
+++ b/csrc/scheduler/reduction.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <exceptions.h>
 
 #include <fusion.h>
 #include <scheduler/reduction_heuristic.h>

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -37,7 +37,7 @@ TensorView* scheduleReductionTV(
   const bool is_outer_grid_persistence = rparams.persistent_kernel &&
       rparams.cross_grid_inner_reduction && !rparams.fastest_dim;
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       (int)reduction_tv->nDims() >
           std::max(iter_axis, std::max(outer_reduce_axis, inner_reduce_axis)),
       "Issue in scheduling reduction tv, expecting >",
@@ -45,19 +45,19 @@ TensorView* scheduleReductionTV(
       " dimensions, but found ",
       reduction_tv->nDims());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !(rparams.fastest_dim && rparams.vectorize_iter_dom),
       "Cannot vectorize iteration domain on inner reductions.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !(!rparams.fastest_dim && rparams.vectorize_inner_reduction),
       "Cannot vectorize reduction domain on outer reductions.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !(rparams.multiple_reds_per_blk && !has_iter_axis),
       "Multiple reductions requires an iter domain, but one wasn't found.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !(rparams.unroll_factor_iter_dom > 1 && !has_iter_axis),
       "Unrolling on iter domain requires an iter domain.");
 
@@ -104,7 +104,7 @@ TensorView* scheduleReductionTV(
 
   if (is_outer_grid_persistence) {
     const auto reduction_axis = inner_reduce_axis;
-    TORCH_INTERNAL_ASSERT(rparams.static_bdimy, "blockDim.y must be static");
+    NVF_ERROR(rparams.static_bdimy, "blockDim.y must be static");
     inner_parallel_static(
         reduction_axis,
         rparams.block_dim_inner_reduction,
@@ -237,8 +237,7 @@ TensorView* scheduleReductionTV(
 
     if (isParallelTypeThread(rparams.block_dim_iter_dom)) {
       if (is_outer_grid_persistence) {
-        TORCH_INTERNAL_ASSERT(
-            rparams.static_bdimx, "blockDim.x must be static");
+        NVF_ERROR(rparams.static_bdimx, "blockDim.x must be static");
         inner_parallel_static(
             iter_axis, rparams.block_dim_iter_dom, rparams.lparams.bdimx());
       } else {
@@ -284,7 +283,7 @@ TensorView* scheduleReductionTV(
         vec_reorder_map[i] = i - 1;
       }
     }
-    TORCH_INTERNAL_ASSERT(vec_id_cur_pos != -1, "Vectorized ID not found");
+    NVF_ERROR(vec_id_cur_pos != -1, "Vectorized ID not found");
     reduction_rf_tv->reorder(vec_reorder_map);
   }
 
@@ -664,7 +663,7 @@ TensorView* sortAndRFactor(TensorView* reference_tv) {
   }
   for (int old_i = 0; old_i < (int)reference_tv->nDims(); old_i++) {
     auto new_i_it = domain_pos.find(reference_tv->axis(old_i));
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         new_i_it != domain_pos.end(),
         "Error in schedule reorder, didn't reorder all axes in provided tv.");
     auto new_i = new_i_it->second;
@@ -825,7 +824,7 @@ class PersistentBufferProjector {
     // persistent section of the graph, recompute the persistent buffer.
     auto buffer = persistent_buffers[buffer_i];
     for (auto use : getPersistentUseOfBuffer(buffer_i)) {
-      TORCH_INTERNAL_ASSERT(use->definition() != nullptr);
+      NVF_ERROR(use->definition() != nullptr);
       auto buffer_replicate = RecomputeTv::recompute(buffer, producers);
       // Create a shortcut buffer <--> buffer_replicate for propagation.
       // Why is this needed?

--- a/csrc/scheduler/reduction_utils.h
+++ b/csrc/scheduler/reduction_utils.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <fusion.h>
 #include <ir/all_nodes.h>
 #include <scheduler/reduction_heuristic.h>

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -225,8 +225,7 @@ class SchedulerTopologyChecker {
               TensorView* backward_running_consumer = nullptr;
               backward_tv_chain.pop_back();
 
-              TORCH_INTERNAL_ASSERT(
-                  backward_running_producer == forward_running_consumer);
+              NVF_ERROR(backward_running_producer == forward_running_consumer);
 
               while (!backward_tv_chain.empty()) {
                 backward_running_consumer = backward_running_producer;
@@ -340,7 +339,7 @@ class SchedulerTopologyChecker {
   static bool supportedPostReductionFusion(
       Fusion* fusion,
       std::vector<TensorView*> reduction_tvs) {
-    TORCH_INTERNAL_ASSERT(!reduction_tvs.empty());
+    NVF_ERROR(!reduction_tvs.empty());
     bool fastest_dim_reduction = true;
     auto red_root_dom = reduction_tvs[0]->getRootDomain();
     for (size_t i = red_root_dom.size(); i > 0; i--) {
@@ -535,15 +534,14 @@ bool isConnectedFusionGraph(Fusion* fusion) {
   // A set of connected components on the fusion graph
   DisjointSets<Val*> component_sets;
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !fusion->outputs().empty(), "Fusion without output is not supported");
   auto output0 = fusion->outputs()[0];
   component_sets.initializeSet(output0);
 
   // Iterate through all used exprs
   for (auto expr : fusion->exprs()) {
-    TORCH_INTERNAL_ASSERT(
-        !expr->outputs().empty(), "unknown expr with zero output");
+    NVF_ERROR(!expr->outputs().empty(), "unknown expr with zero output");
 
     // Each expr maps all its inputs and
     //  outputs to the same component
@@ -657,7 +655,7 @@ bool requiresForwardViewReplay(Fusion* fusion, ComputeAtMap& ca_map) {
       // If one output of the expression is an rfactor ID all of them should be
       auto def_outs =
           ir_utils::filterByType<IterDomain>(rfactor_def->outputs());
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           std::all_of(
               def_outs.begin(),
               def_outs.end(),
@@ -669,7 +667,7 @@ bool requiresForwardViewReplay(Fusion* fusion, ComputeAtMap& ca_map) {
       // make sense to have transforms on non-rfactor domains that produce
       // rfactor domains.
       auto def_inps = ir_utils::filterByType<IterDomain>(rfactor_def->inputs());
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           std::all_of(
               def_inps.begin(),
               def_inps.end(),
@@ -779,8 +777,7 @@ bool reductionInterferingView(
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
-      dims.empty(), "Error processing ", dims, " in registry.cpp.");
+  NVF_ERROR(dims.empty(), "Error processing ", dims, " in registry.cpp.");
 
   // Make sure groups are disjoint based on view
 
@@ -798,13 +795,13 @@ bool reductionInterferingView(
           reduction_reference->getMaybeRFactorDomain().begin(),
           reduction_reference->getMaybeRFactorDomain().end(),
           id);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           find_it != reduction_reference->getMaybeRFactorDomain().end(),
           "Issue with view analysis on reduction like schedule, with reference: ",
           reduction_reference->toString());
       auto rfactor_pos = std::distance(
           reduction_reference->getMaybeRFactorDomain().begin(), find_it);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           rfactor_pos < (int)disjoint_set_information.disjoint_set_ids.size(),
           "Error computing disjoint group on the rfactor domain of ",
           reduction_reference->toString());
@@ -838,7 +835,7 @@ bool reductionInterferingView(
 }
 
 PrimDataType getTensorIndexType(TensorView* tv, ExpressionEvaluator& ee) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !tv->isFusionInput(),
       "This function is not supposed to be used for fusion inputs: ",
       tv->toString());
@@ -859,7 +856,7 @@ PrimDataType getTensorIndexType(TensorView* tv, ExpressionEvaluator& ee) {
   // non-contig tensor means a fusion intermediate tensor. However,
   // since we don't support non-contiguous intermediates, there must be
   // something wrong.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !non_contig, "Unexpected non-contiguous tensor found: ", tv->toString());
 
   // Note that at this point tensors are not scheduled yet. Each
@@ -884,7 +881,7 @@ PrimDataType getTensorIndexType(TensorView* tv, ExpressionEvaluator& ee) {
     // We could also just conservatively use 64-bit indexing if the
     // extent size is not determined, but this should be possible to
     // evaluate.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         extent.hasValue(),
         "Axis with unknown extent found: ",
         id->toString(),
@@ -893,8 +890,7 @@ PrimDataType getTensorIndexType(TensorView* tv, ExpressionEvaluator& ee) {
 
     auto extent_int = extent.as<int64_t>();
 
-    TORCH_INTERNAL_ASSERT(
-        extent_int >= 0, "Unexpected size of axis: ", extent_int);
+    NVF_ERROR(extent_int >= 0, "Unexpected size of axis: ", extent_int);
 
     if (extent_int > 0) {
       if (index_type_helper.addDim(extent.as<int64_t>(), stride) ==
@@ -947,7 +943,7 @@ SchedulerRuntimeInfo::SchedulerRuntimeInfo(
     const std::vector<TensorView*>& all_tvs,
     std::optional<PrimDataType> forced_index_type)
     : complete_fusion_(complete_fusion) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       complete_fusion_->inputs().size() == args.size(),
       "Invalid number of arguments passed in for provided fusion group.");
 
@@ -972,7 +968,7 @@ SchedulerRuntimeInfo::SchedulerRuntimeInfo(
           expression_evaluator_->evaluate(IrBuilder::metadataExpr(input_tv));
       const auto& alloc_sizes = metadata->*&TensorMetaData::alloc_size;
       const auto& alloc_strides = metadata->*&TensorMetaData::alloc_stride;
-      TORCH_INTERNAL_ASSERT(alloc_sizes.size() == alloc_strides.size());
+      NVF_ERROR(alloc_sizes.size() == alloc_strides.size());
 
       input_ptrs_[fusion_inp] = (size_t)(metadata->*&TensorMetaData::data);
 
@@ -1426,7 +1422,7 @@ class ReductionScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr) {
     params_ = getReductionHeuristics(fusion, runtime_info, data_cache);
-    TORCH_INTERNAL_ASSERT(params_ != nullptr);
+    NVF_ERROR(params_ != nullptr);
   }
 };
 
@@ -1540,7 +1536,7 @@ class TransposeScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr) {
     params_ = getTransposeHeuristics(fusion, runtime_info, data_cache);
-    TORCH_INTERNAL_ASSERT(params_ != nullptr);
+    NVF_ERROR(params_ != nullptr);
   }
 };
 
@@ -1634,7 +1630,7 @@ class PointWiseScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr) {
     params_ = getPointwiseHeuristics(fusion, runtime_info, data_cache);
-    TORCH_INTERNAL_ASSERT(params_ != nullptr);
+    NVF_ERROR(params_ != nullptr);
   }
 };
 
@@ -1939,7 +1935,7 @@ class PersistentKernelScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr) {
     params_ = getPersistentHeuristics(fusion, runtime_info, data_cache);
-    TORCH_INTERNAL_ASSERT(params_ != nullptr);
+    NVF_ERROR(params_ != nullptr);
   }
 
   static bool checkReductionPattern(
@@ -2191,7 +2187,7 @@ class PersistentKernelScheduler : public SchedulerEntry {
       }
     }
 
-    TORCH_INTERNAL_ASSERT(!is_cross_grid || cross_grid_params.has_value())
+    NVF_ERROR(!is_cross_grid || cross_grid_params.has_value())
 
     // Maximum number of iteration dimensions we can have and still be
     // persistent.
@@ -2333,7 +2329,7 @@ class MatmulScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr) {
     params_ = getMatmulHeuristics(fusion, runtime_info, data_cache);
-    TORCH_INTERNAL_ASSERT(params_ != nullptr);
+    NVF_ERROR(params_ != nullptr);
   }
 };
 
@@ -2403,7 +2399,7 @@ bool SchedulerEntry::canSchedule(
       return checkCanSchedule<MatmulScheduler>(
           fusion, runtime_info, data_cache);
     default:
-      TORCH_INTERNAL_ASSERT(false, "unreachable");
+      NVF_ERROR(false, "unreachable");
       return false;
   }
   return false;
@@ -2441,7 +2437,7 @@ std::unique_ptr<SchedulerEntry> SchedulerEntry::makeEntry(
           std::make_unique<MatmulScheduler>(fusion, runtime_info, data_cache);
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "unreachable");
+      NVF_ERROR(false, "unreachable");
   }
 
   return scheduler_entry;
@@ -2479,7 +2475,7 @@ std::string toString(ScheduleHeuristic sh) {
     case ScheduleHeuristic::Matmul:
       return "matmul";
     default:
-      TORCH_INTERNAL_ASSERT(false, "undefined schedule");
+      NVF_ERROR(false, "undefined schedule");
   }
   return "";
 }
@@ -2538,15 +2534,14 @@ HeuristicSummary::HeuristicSummary(
       break;
     case ScheduleHeuristic::Matmul: {
       const auto heuristics = getMatmulHeuristics(fusion, runtime_info, this);
-      TORCH_INTERNAL_ASSERT(heuristics, "Failed to get matmul heuristics");
+      NVF_ERROR(heuristics, "Failed to get matmul heuristics");
       const auto canSchedule =
           MatmulScheduler::canScheduleRunTime(fusion, runtime_info, this);
-      TORCH_INTERNAL_ASSERT(
-          canSchedule, "Could not schedule matmul (run time)");
+      NVF_ERROR(canSchedule, "Could not schedule matmul (run time)");
       break;
     }
     default:
-      TORCH_INTERNAL_ASSERT(false, "unknown heuristic");
+      NVF_ERROR(false, "unknown heuristic");
   }
   validate();
   recording_ = false;
@@ -2561,17 +2556,14 @@ void HeuristicSummary::validate() const {
     case ScheduleHeuristic::Transpose:
     case ScheduleHeuristic::PointWise: {
       if (heuristic_ == ScheduleHeuristic::PointWise) {
-        TORCH_INTERNAL_ASSERT(entry_type_map_.count(EntryType::DOMAIN_MAP));
-        TORCH_INTERNAL_ASSERT(
-            entry_type_map_.count(EntryType::REFERENCE_TENSORS));
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(entry_type_map_.count(EntryType::DOMAIN_MAP));
+        NVF_ERROR(entry_type_map_.count(EntryType::REFERENCE_TENSORS));
+        NVF_ERROR(
             entry_type_map_.count(EntryType::VECTORIZABLE_INPUTS_AND_OUTPUTS));
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             entry_type_map_.count(EntryType::TV_TO_CONTIG_INNER_SIZE_MAPS));
-        TORCH_INTERNAL_ASSERT(
-            entry_type_map_.count(EntryType::BROADCAST_BYTE_MULTIPLES));
-        TORCH_INTERNAL_ASSERT(
-            entry_type_map_.count(EntryType::CAN_SCHEDULE_TRANSPOSE));
+        NVF_ERROR(entry_type_map_.count(EntryType::BROADCAST_BYTE_MULTIPLES));
+        NVF_ERROR(entry_type_map_.count(EntryType::CAN_SCHEDULE_TRANSPOSE));
         auto can_schedule_transpose =
             entry_type_map_.at(EntryType::CAN_SCHEDULE_TRANSPOSE)
                 ->as<CompileTimeInfo<
@@ -2581,43 +2573,37 @@ void HeuristicSummary::validate() const {
           break;
         }
       }
-      TORCH_INTERNAL_ASSERT(
-          entry_type_map_.count(EntryType::TRANSPOSE_DOMAIN_MAP));
-      TORCH_INTERNAL_ASSERT(entry_type_map_.count(
+      NVF_ERROR(entry_type_map_.count(EntryType::TRANSPOSE_DOMAIN_MAP));
+      NVF_ERROR(entry_type_map_.count(
           EntryType::INPUTS_AND_OUTPUTS_INNER_DIM_GROUPS));
-      TORCH_INTERNAL_ASSERT(
-          entry_type_map_.count(EntryType::REFERENCE_TENSORS_FOR_GROUPS));
-      TORCH_INTERNAL_ASSERT(
-          entry_type_map_.count(EntryType::INNER_MOST_DIMS_INFO));
+      NVF_ERROR(entry_type_map_.count(EntryType::REFERENCE_TENSORS_FOR_GROUPS));
+      NVF_ERROR(entry_type_map_.count(EntryType::INNER_MOST_DIMS_INFO));
       break;
     }
     case ScheduleHeuristic::Reduction: {
-      TORCH_INTERNAL_ASSERT(entry_type_map_.count(EntryType::REDUCTION_TVS));
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(entry_type_map_.count(EntryType::REDUCTION_TVS));
+      NVF_ERROR(
           entry_type_map_.count(EntryType::VECTORIZABLE_INPUTS_AND_OUTPUTS));
-      TORCH_INTERNAL_ASSERT(
-          entry_type_map_.count(EntryType::TV_TO_CONTIG_INNER_SIZE_MAPS));
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(entry_type_map_.count(EntryType::TV_TO_CONTIG_INNER_SIZE_MAPS));
+      NVF_ERROR(
           entry_type_map_.count(EntryType::UNROLLABLE_INPUTS_AND_OUTPUTS));
       break;
     }
     case ScheduleHeuristic::Persistent: {
-      TORCH_INTERNAL_ASSERT(entry_type_map_.count(EntryType::REDUCTION_TVS));
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(entry_type_map_.count(EntryType::REDUCTION_TVS));
+      NVF_ERROR(
           entry_type_map_.count(EntryType::VECTORIZABLE_INPUTS_AND_OUTPUTS));
-      TORCH_INTERNAL_ASSERT(
-          entry_type_map_.count(EntryType::TV_TO_CONTIG_INNER_SIZE_MAPS));
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(entry_type_map_.count(EntryType::TV_TO_CONTIG_INNER_SIZE_MAPS));
+      NVF_ERROR(
           entry_type_map_.count(EntryType::UNROLLABLE_INPUTS_AND_OUTPUTS));
-      TORCH_INTERNAL_ASSERT(
-          entry_type_map_.count(EntryType::PERSISTENT_BUFFER_INFO));
+      NVF_ERROR(entry_type_map_.count(EntryType::PERSISTENT_BUFFER_INFO));
       // If check persistent factor only when persistent buffers needed.
       auto persistent_buffer_info =
           entry_type_map_.at(EntryType::PERSISTENT_BUFFER_INFO)
               ->as<
                   CompileTimeInfo<HeuristicCompileTime::PersistentBufferInfo>>()
               ->get();
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !persistent_buffer_info->persistent_buffers.empty() &&
           entry_type_map_.count(EntryType::SCOPE_PERSISTENT_FACTOR_INFO));
       break;
@@ -2627,13 +2613,12 @@ void HeuristicSummary::validate() const {
       break;
     }
     default:
-      TORCH_INTERNAL_ASSERT(false, "unknown heuristic");
+      NVF_ERROR(false, "unknown heuristic");
   }
 }
 
 void HeuristicSummary::insert(HeuristicSummary::EntryOwningPtr new_entry) {
-  TORCH_INTERNAL_ASSERT(
-      recording_, "should only insert entries at recording phase");
+  NVF_ERROR(recording_, "should only insert entries at recording phase");
   // Just override when insertion duplicates, equality not checked.
   entry_type_map_[new_entry->type()] = new_entry.get();
   entries_.emplace_back(std::move(new_entry));

--- a/csrc/scheduler/registry.h
+++ b/csrc/scheduler/registry.h
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #pragma once
+#include <exceptions.h>
 #include <executor_kernel_arg.h>
 #include <expr_evaluator.h>
 #include <fusion.h>
@@ -81,7 +82,7 @@ class TORCH_CUDA_CU_API SchedulerRuntimeInfo : public NonCopyable {
   }
 
   ExpressionEvaluator& expressionEvaluator() {
-    TORCH_INTERNAL_ASSERT(expression_evaluator_ != nullptr);
+    NVF_ERROR(expression_evaluator_ != nullptr);
     return *expression_evaluator_;
   }
 
@@ -178,28 +179,28 @@ class TORCH_CUDA_CU_API SchedulerEntry {
 
   const ReductionParams& reductionParams() const {
     auto rparams = std::dynamic_pointer_cast<ReductionParams>(params_);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         rparams != nullptr, "Heuristic parameter is not a reduction parameter");
     return *rparams;
   }
 
   const PointwiseParams& pointwiseParams() const {
     auto pparams = std::dynamic_pointer_cast<PointwiseParams>(params_);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         pparams != nullptr, "Heuristic parameter is not a pointwise parameter");
     return *pparams;
   }
 
   const TransposeParams& transposeParams() const {
     auto tparams = std::dynamic_pointer_cast<TransposeParams>(params_);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         tparams != nullptr, "Heuristic parameter is not a transpose parameter");
     return *tparams;
   }
 
   const MatmulParams& matmulParams() const {
     auto mparams = std::dynamic_pointer_cast<MatmulParams>(params_);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         mparams != nullptr, "Heuristic parameter is not a matmul parameter");
     return *mparams;
   }

--- a/csrc/scheduler/transpose.h
+++ b/csrc/scheduler/transpose.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <exceptions.h>
 
 #include <fusion.h>
 #include <scheduler/transpose_heuristic.h>

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -278,7 +278,7 @@ void parallelizeAllLike(
   if (pos < 0) {
     pos += (int64_t)reference_tv->nDims() + 1;
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       pos >= 0 && pos <= (int64_t)reference_tv->nDims(),
       "parallelizeAllLike called on an position outside valid range.");
 
@@ -351,7 +351,7 @@ class PersistentBufferResolution : public IterVisitor {
       TensorView* persistent_buffer) {
     PersistentBufferResolution resolution(fusion, persistent_buffer);
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !resolution.resolution_points_.empty(),
         "Could not resolve persistent buffer: ",
         persistent_buffer);
@@ -592,7 +592,7 @@ ReductionTvProperties getReductionProperties(
     TensorView* tv) {
   FusionGuard fg(fusion);
 
-  TORCH_INTERNAL_ASSERT(tv != nullptr);
+  NVF_ERROR(tv != nullptr);
 
   bool fastest_dim_reduction = isFastestDimReduction(tv);
 
@@ -620,8 +620,7 @@ ReductionTvProperties getReductionProperties(
     } else if (dimensionality == 1) {
       auto inferred_val =
           runtime_info.expressionEvaluator().evaluate(id->extent());
-      TORCH_INTERNAL_ASSERT(
-          inferred_val.hasValue(), "Error inferring reduction size.");
+      NVF_ERROR(inferred_val.hasValue(), "Error inferring reduction size.");
       inner_most_dimension_numel =
           inner_most_dimension_numel * inferred_val.as<int64_t>();
       inner_most_dimension_ndims++;
@@ -636,7 +635,7 @@ ReductionTvProperties getReductionProperties(
   for (auto id : root_dom) {
     auto inferred_val =
         runtime_info.expressionEvaluator().evaluate(id->extent());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         inferred_val.hasValue(),
         "Error inferring dimensions of reduction fusion.");
     if (id->isReduction()) {
@@ -831,8 +830,7 @@ PersistentBufferSizeReturn persistentBufferSize(
       }
 
       auto id_size = runtime_info.expressionEvaluator().evaluate(id->extent());
-      TORCH_INTERNAL_ASSERT(
-          id_size.hasValue(), "Could not infer persistent buffer size.");
+      NVF_ERROR(id_size.hasValue(), "Could not infer persistent buffer size.");
       if (persistent_buffer_sizes[buffer_i] == -1) {
         persistent_buffer_sizes[buffer_i] = id_size.as<int64_t>();
       } else {
@@ -875,7 +873,7 @@ PersistentBufferSizeReturn persistentBufferSize(
                                const std::vector<int64_t>& sizes,
                                const std::vector<TensorView*>& all_buffers) {
     int64_t buffer_size = 0;
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         mask0.size() == mask1.size() && mask0.size() == sizes.size() &&
         mask0.size() == all_buffers.size());
     // Keep track of which buffer is counted as there can be tensors
@@ -928,7 +926,7 @@ std::pair<bool, bool> canonicalDimReduction(
     Fusion* fusion,
     TensorView* tv,
     bool schedule_3D) {
-  TORCH_INTERNAL_ASSERT(tv != nullptr);
+  NVF_ERROR(tv != nullptr);
 
   if (!schedule_3D) {
     // We coalesce all reduction axes to the right;
@@ -937,8 +935,7 @@ std::pair<bool, bool> canonicalDimReduction(
     bool has_iter_axis = mergeNonReduction(tv) > 0;
     return {has_iter_axis, has_red_axis};
   } else {
-    TORCH_INTERNAL_ASSERT(
-        merge_3d(tv) == 3, "Tried 3D merge, but result is not 3D.");
+    NVF_ERROR(merge_3d(tv) == 3, "Tried 3D merge, but result is not 3D.");
     return {true, true};
   }
 }
@@ -963,7 +960,7 @@ std::vector<TensorView*> getReductionTvs(Fusion* fusion) {
           reduction_tvs.begin(),
           reduction_tvs.end(),
           [&seen_reduction_exprs](TensorView* tv) {
-            TORCH_INTERNAL_ASSERT(
+            NVF_ERROR(
                 tv->definition() != nullptr,
                 "Somehow a tensor view without a definition but a reduction snuck into the scheduler reduction list.");
             if (!seen_reduction_exprs.emplace(tv->definition()).second) {
@@ -1131,8 +1128,7 @@ IterDomain* projectIdToRoot(
         }
       }
     } else {
-      TORCH_INTERNAL_ASSERT(
-          false, "Didn't recognize the iterdomain expression: ", expr);
+      NVF_ERROR(false, "Didn't recognize the iterdomain expression: ", expr);
     }
     if (projected_id == nullptr) {
       break;
@@ -1194,8 +1190,7 @@ IterDomain* projectIdToRFactor(
         }
       }
     } else {
-      TORCH_INTERNAL_ASSERT(
-          false, "Didn't recognize the iterdomain expression: ", expr);
+      NVF_ERROR(false, "Didn't recognize the iterdomain expression: ", expr);
     }
     if (projected_id == nullptr) {
       break;
@@ -1296,7 +1291,7 @@ void FindAllMappedDims::propagateSibling(TensorView* from, TensorView* to) {
       }
     }
   }
-  TORCH_INTERNAL_ASSERT(false, "Unable to find mapped root/rfactor domain");
+  NVF_ERROR(false, "Unable to find mapped root/rfactor domain");
 }
 
 std::unordered_set<IterDomain*> FindAllMappedDims::get() const {
@@ -1347,11 +1342,11 @@ bool hasInnerDim(
 
   const auto& contiguity = tv->domain()->contiguity();
 
-  TORCH_INTERNAL_ASSERT(contiguity.size() == rfactor_dom.size());
+  NVF_ERROR(contiguity.size() == rfactor_dom.size());
 
   // Don't vectorize if inner most dimension is not contiguous
   auto contiguity_opt = contiguity.at(inner_most_dim_pos);
-  TORCH_INTERNAL_ASSERT(contiguity_opt.has_value())
+  NVF_ERROR(contiguity_opt.has_value())
   if (!*contiguity_opt) {
     return false;
   }
@@ -1364,8 +1359,7 @@ std::vector<TensorView*> getInputsOutputsWithInnerDim(
     bool inner_only,
     bool vectorize_pass) {
   if (vectorize_pass) {
-    TORCH_INTERNAL_ASSERT(
-        inner_only, "Can only vectorize inner-most dimensions");
+    NVF_ERROR(inner_only, "Can only vectorize inner-most dimensions");
   }
 
   auto inner_most_id = innerMostRootDim(reference_tv);
@@ -1452,7 +1446,7 @@ DisjointRFactorSetInfo getDisjointRFactorSetsOf(
     current_group_id++;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       std::none_of(
           disjoint_group_ids.begin(),
           disjoint_group_ids.end(),
@@ -1460,7 +1454,7 @@ DisjointRFactorSetInfo getDisjointRFactorSetsOf(
       "Failed to generate the rfactor disjoint groups of the reference ",
       of->toString());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       std::none_of(
           disjoint_set_of_id.begin(),
           disjoint_set_of_id.end(),
@@ -1787,7 +1781,7 @@ void BoundedDirectionalTransformPropagator::forward(
   if (!options.has_value()) {
     options = Options();
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !to.empty(),
       "Propagation needs to be bounded, so no support for empty boundary.")
 
@@ -1809,7 +1803,7 @@ void BoundedDirectionalTransformPropagator::bothWays(
   if (!options.has_value()) {
     options = Options();
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !backward_to.empty() && !forward_to.empty(),
       "Propagation needs to be bounded, so no support for empty boundary.")
 
@@ -1852,7 +1846,7 @@ DisjointSets<IterDomain*> disjointRFactorSets(Fusion* fusion) {
         auto resize = expr->as<Resize>();
         disjoint_rfactor_ids.mapEntries(resize->in(), resize->out());
       } else {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             false, "Expression type: ", expr->toString(), " not supported.");
       }
     }
@@ -1864,7 +1858,7 @@ bool breakIsDisjoint(std::vector<int> group_ids, int pos) {
   if (pos < 0) {
     pos += (int)group_ids.size();
   }
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       pos >= 0 && pos <= (int)group_ids.size(),
       "Invalid position, size of vec is ",
       group_ids.size(),
@@ -1915,7 +1909,7 @@ std::unordered_map<int, int> domainReorderAsRfactorMap(TensorView* tv) {
         // Transformations before rfactor, ignore those.
         continue;
       }
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           find_it_0 != reordered_ids.end() && find_it_1 != reordered_ids.end(),
           "Error in transformations of ",
           tv->toString(),
@@ -1926,7 +1920,7 @@ std::unordered_map<int, int> domainReorderAsRfactorMap(TensorView* tv) {
         std::swap(pos0, pos1);
       }
       // Should be impossible.
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           pos0 != pos1,
           "Didn't expect merge inputs to be the same iteration domain:\n",
           merge->toString());
@@ -1942,8 +1936,8 @@ std::unordered_map<int, int> domainReorderAsRfactorMap(TensorView* tv) {
       }
       *find_it = resize->out();
     } else {
-      TORCH_INTERNAL_ASSERT(expr != nullptr);
-      TORCH_INTERNAL_ASSERT(false, "Unexpected expression: ", expr->toString());
+      NVF_ERROR(expr != nullptr);
+      NVF_ERROR(false, "Unexpected expression: ", expr->toString());
     }
   }
 
@@ -1952,7 +1946,7 @@ std::unordered_map<int, int> domainReorderAsRfactorMap(TensorView* tv) {
     auto leaf_id = tv->axis(id_i);
     auto find_it =
         std::find(reordered_ids.begin(), reordered_ids.end(), leaf_id);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         find_it != reordered_ids.end(),
         "Reordering map creation failed, uninitialized iterdomain,",
         " likely something is wrong with the transformations between the rfactor domain and the leaves.");
@@ -2024,7 +2018,7 @@ void propagateReshapeTransforms(Fusion* fusion, const ComputeAtMap& ca_map) {
           terminating_reshape_dims.end()) {
         auto find_it = std::find(
             tv->getLeafDomain().begin(), tv->getLeafDomain().end(), rfactor_id);
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             find_it != tv->getLeafDomain().end(),
             "Require ",
             rfactor_id,
@@ -2089,7 +2083,7 @@ getNonPointwiseProducerConsumerPairs(Fusion* fusion) {
     } else if (ir_utils::hasResizedRfactor(consumer)) {
       // Exprs based on ResizeOp, e.g., slice
       auto producers = ir_utils::producerTvsOf(consumer);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           producers.size() == 1,
           "Unexpected number of inputs of the defining expression: ",
           consumer->definition()->toString());
@@ -2139,7 +2133,7 @@ bool revertUseOfInputCache(
   }
 
   auto fusion_input = get_copy_src(producer_of_producer);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       fusion_input != nullptr,
       "Unexpected input cache: ",
       producer_of_producer->toString());
@@ -2174,7 +2168,7 @@ void prepareForMemoryTypePromotion(Fusion* fusion) {
 
   for (auto& [producer, consumer] : non_pwise_pairs) {
     // At this point, all tensors should be either on Global or Local
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         producer->getMemoryType() == MemoryType::Local ||
             producer->getMemoryType() == MemoryType::Global,
         "Unexpected memory type: ",
@@ -2216,7 +2210,7 @@ void promoteProducerMemoryTypes(
       case MemoryType::Global:
         return 3;
       default:
-        TORCH_INTERNAL_ASSERT(false, "Unexpected memory type: ", m_type);
+        NVF_ERROR(false, "Unexpected memory type: ", m_type);
     }
   };
 
@@ -2273,7 +2267,7 @@ void promoteProducerMemoryTypes(
       } else if (isParallelTypeBlockDim(producer_non_ca_id_ptype)) {
         setPromotion(producer, MemoryType::Global);
       } else {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             false, "Unexpected parallel type: ", producer_non_ca_id_ptype);
       }
     }

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -10,6 +10,7 @@
 #include <compute_at_map.h>
 #include <device_lower/pass/loop_rotation.h>
 #include <disjoint_set.h>
+#include <exceptions.h>
 #include <fusion.h>
 #include <ir/all_nodes.h>
 #include <ir/cloner.h>
@@ -50,7 +51,7 @@ constexpr int64_t maxVectorizationWidth(int64_t n) {
 
 // Largest Power of 2 less-than n
 constexpr int64_t lastPow2(int64_t n) {
-  TORCH_INTERNAL_ASSERT(n >= 0);
+  NVF_ERROR(n >= 0);
   n |= (n >> 1);
   n |= (n >> 2);
   n |= (n >> 4);

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -77,7 +77,7 @@ ContiguousInnerDimensionsMapper::ContiguousInnerDimensionsMapper(
     rfactor_domain = TensorDomain::noReductions(rfactor_domain);
     filtered_ids = TensorDomain::noReductions(filtered_ids);
   } else {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !TensorDomain::hasReduction(rfactor_domain) &&
             !TensorDomain::hasReduction(filtered_ids),
         "Unexpected reduction domain given to ContiguousInnerDimensionsMapper");
@@ -395,7 +395,7 @@ std::vector<IterDomain*> ContiguousInnerDimensionsMapper::projectId(
     } else {
       // TODO: I wonder if we should just remove all inputs instead of erroring.
       // Seems that would be safe.
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           false,
           "ProjectDimensions does not support expr type: ",
           expr->toString());
@@ -423,7 +423,7 @@ std::vector<IterDomain*> ContiguousInnerDimensionsMapper::projectId(
     } else {
       // TODO: I wonder if we should just remove all inputs instead of erroring.
       // Seems that would be safe.
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           false,
           "ProjectDimensions does not support expr type: ",
           expr->toString());
@@ -578,7 +578,7 @@ ContiguousInnerDimensionsMapper::computeInfoSibling(
     TensorView* from,
     TensorView* to,
     std::shared_ptr<MaxInfoSpanningTree::Information> from_info) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       from->getRootDomain().size() == to->getRootDomain().size(),
       "Siblings of different root sizes not supported, but found:\n  ",
       from->toString(),
@@ -598,7 +598,7 @@ ContiguousInnerDimensionsMapper::computeInfoSibling(
         from->getRootDomain().begin(),
         from->getRootDomain().end(),
         from_root_id);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         from_it != from->getRootDomain().end(),
         "Expected ",
         from_root_id->toString(),
@@ -620,7 +620,7 @@ ContiguousInnerDimensionsMapper::computeInfoSibling(
         false /*shouldn't matter how we initialize this*/);
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       from->getRFactorDomain().size() == to->getRFactorDomain().size(),
       "Siblings of different rfactor sizes not supported, but found:\n  ",
       from->toString(),
@@ -641,7 +641,7 @@ ContiguousInnerDimensionsMapper::computeInfoSibling(
         from->getRFactorDomain().begin(),
         from->getRFactorDomain().end(),
         from_rfactor_id);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         from_it != from->getRFactorDomain().end(),
         "Expected ",
         from_rfactor_id->toString(),
@@ -692,7 +692,7 @@ Val* ContiguousInnerDimensionsMapper::getContigMergeOfInnerSize(
   Val* product_of_inner_extents = of_tv->container()->oneVal();
   auto of_tv_root = of_tv->getMaybeRFactorDomain();
 
-  TORCH_INTERNAL_ASSERT(hasMappedDims(of_tv));
+  NVF_ERROR(hasMappedDims(of_tv));
 
   const std::vector<IterDomain*>& projected_dims = mappedRFactorIds(of_tv);
   auto of_tv_root_no_reductions = TensorDomain::noReductions(of_tv_root);
@@ -718,7 +718,7 @@ Val* ContiguousInnerDimensionsMapper::getContigMergeOfInnerSize(
     return product_of_inner_extents;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       of_tv_root_no_reductions_size == contiguity.size(),
       "Contiguity mismatch found.");
 
@@ -745,7 +745,7 @@ Val* ContiguousInnerDimensionsMapper::getContigMergeOfInnerSize(
 
     auto contiguity_i = contiguity.at(root_i);
     if (!contiguity_i.has_value()) {
-      TORCH_INTERNAL_ASSERT(false, "contiguity flag at root_i can't be null");
+      NVF_ERROR(false, "contiguity flag at root_i can't be null");
     } else {
       // Not contiguous
       if (!contiguity_i.value()) {
@@ -833,7 +833,7 @@ int64_t getVectorizationFactor(
 
     // factor <= alignment / dtype_size
     int64_t alignment_size = (int64_t)runtime_info.getAlignmentSize(inp_or_out);
-    TORCH_INTERNAL_ASSERT(alignment_size % dtype_size == 0);
+    NVF_ERROR(alignment_size % dtype_size == 0);
     max_vec_size = std::min(max_vec_size, alignment_size / dtype_size);
 
     // factor <= projected_extent
@@ -849,7 +849,7 @@ int64_t getVectorizationFactor(
     }
     auto inner_size_opt =
         runtime_info.expressionEvaluator().evaluate(inner_size_it->second);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         inner_size_opt.hasValue(),
         "Vectorization heuristic could not evaluate inner most size.");
 
@@ -893,7 +893,7 @@ int64_t getVectorizationFactorTransposeGroup(
         : runtime_info.expressionEvaluator().evaluate(inner_size_it->second);
     // TODO: Do not assert here. we can just reduce vectorization size to 1 if
     // we can't infer an inner size.
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         tv_vectorize_factor_opt.hasValue(),
         "Vectorization heuristic could not evaluate inner most size.");
     int64_t tv_vectorize_factor = tv_vectorize_factor_opt.as<int64_t>();
@@ -909,7 +909,7 @@ int64_t getVectorizationBreakPointOfReductionProducer(
     TensorView* reduction_consumer,
     TensorView* reduction_producer,
     int64_t consumer_innermost_ndims) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       reduction_consumer->definition() != nullptr &&
           ir_utils::isReductionOp(reduction_consumer->definition()) &&
           reduction_consumer->definition()->input(0) == reduction_producer,
@@ -934,7 +934,7 @@ int64_t getVectorizationBreakPointOfReductionProducer(
     auto c2p_it = c2p.find(consumer_id);
     // Since this is for a reduction op, there must be a mapped
     // producer ID
-    TORCH_INTERNAL_ASSERT(c2p_it != c2p.end());
+    NVF_ERROR(c2p_it != c2p.end());
     auto producer_id = c2p_it->second;
     producer_innermost_ids.insert(producer_id);
   }
@@ -954,7 +954,7 @@ int64_t getVectorizationBreakPointOfReductionProducer(
     // reduction/normalization scheduler do not support fusing
     // multiple back-to-back reductions
     if (producer_rf_id->isReduction()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           reduction_producer->isFusionInput(),
           "Unexpected producer of reduction: ",
           reduction_producer->toString());
@@ -976,8 +976,7 @@ int64_t getVectorizationBreakPointOfReductionProducer(
 
     // Neither reduction nor mapped to consumer innermost IDs.
     // This should not happen
-    TORCH_INTERNAL_ASSERT(
-        false, "Unexpected producer RF ID: ", producer_rf_id->toString())
+    NVF_ERROR(false, "Unexpected producer RF ID: ", producer_rf_id->toString())
   }
 
   return break_point;

--- a/csrc/scheduler/vectorize_helper.h
+++ b/csrc/scheduler/vectorize_helper.h
@@ -9,6 +9,7 @@
 
 #include <compute_at_map.h>
 #include <device_lower/analysis/divisible_split.h>
+#include <exceptions.h>
 #include <fusion.h>
 #include <ir/all_nodes.h>
 #include <maxinfo_propagator.h>
@@ -160,7 +161,7 @@ class TORCH_CUDA_CU_API ContiguousInnerDimensionsMapper
   }
 
   const std::vector<IterDomain*>& mappedRootIds(TensorView* tv) const {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         tv_infos_.find(tv) != tv_infos_.end(),
         "TensorView not found: ",
         tv->toString());
@@ -169,7 +170,7 @@ class TORCH_CUDA_CU_API ContiguousInnerDimensionsMapper
   }
 
   const std::vector<IterDomain*>& mappedRFactorIds(TensorView* tv) const {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         tv_infos_.find(tv) != tv_infos_.end(),
         "TensorView not found: ",
         tv->toString());
@@ -179,7 +180,7 @@ class TORCH_CUDA_CU_API ContiguousInnerDimensionsMapper
 
   Val* getProjectedExtent(IterDomain* id) const {
     if (projected_extent_.find(id) == projected_extent_.end()) {
-      TORCH_INTERNAL_ASSERT(false, "Not projected: ", id->toString());
+      NVF_ERROR(false, "Not projected: ", id->toString());
     }
     return projected_extent_.at(id);
   }
@@ -236,7 +237,7 @@ class TORCH_CUDA_CU_API ContiguousInnerDimensionsMapper
       return;
     }
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         projected_extent_.count(id) == 0,
         "Already registered: ",
         id->toString(),

--- a/csrc/serde/factory.h
+++ b/csrc/serde/factory.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/util/Exception.h>
+#include <exceptions.h>
 #include <functional>
 
 namespace nvfuser::serde {
@@ -28,7 +29,7 @@ class Factory {
   Factory(size_t num_parsers) : parsers_(num_parsers, nullptr){};
 
   void registerParser(int serde_type, SerdeParser parser) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         serde_type >= 0 && serde_type < (int)parsers_.size(),
         "RegisterParser: Invalid serde type: ",
         serde_type);
@@ -36,7 +37,7 @@ class Factory {
   }
 
   BaseTypePtr parse(int serde_type, const SerdeBuffer* buffer) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         serde_type >= 0 && serde_type < (int)parsers_.size(),
         "Deserialize: Invalid serde type: ",
         serde_type);

--- a/csrc/serde/fusion_record_serde.cpp
+++ b/csrc/serde/fusion_record_serde.cpp
@@ -32,7 +32,7 @@ std::optional<bool> mapContiguityEnumToOptional(int v) {
     case serde::Contiguity_None:
       return std::nullopt;
   }
-  TORCH_INTERNAL_ASSERT(false, "Invalid contiguity type.");
+  NVF_ERROR(false, "Invalid contiguity type.");
   return std::nullopt;
 }
 
@@ -41,7 +41,7 @@ python_frontend::RecordFunctor* deserializeOpRecord(
     const std::unordered_map<std::string, fn_type>& str_to_func_map,
     serde::RecordType record_type,
     const serde::RecordFunctor* buffer) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       str_to_func_map.find(buffer->name()->str()) != str_to_func_map.end(),
       "Missing mapping from operation string to nvfuser function in serde deserialization.");
   return new python_frontend::OpRecord<Signature...>(

--- a/csrc/serde/fusion_record_serde.h
+++ b/csrc/serde/fusion_record_serde.h
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #pragma once
+#include <exceptions.h>
 #include <python_frontend/fusion_record.h>
 #include <serde/factory.h>
 

--- a/csrc/serde/polymorphic_value_serde.cpp
+++ b/csrc/serde/polymorphic_value_serde.cpp
@@ -16,13 +16,13 @@ namespace {
 
 nvfuser::PolymorphicValue makeCpuScalarTensor(
     const serde::ScalarCpu* scalar_cpu) {
-  TORCH_INTERNAL_ASSERT(scalar_cpu != nullptr);
+  NVF_ERROR(scalar_cpu != nullptr);
   auto scalar = deserializePolymorphicValue(scalar_cpu->scalar_value());
   return nvfuser::PolymorphicValue_functions::toTensor(scalar, at::kCPU);
 }
 
 nvfuser::PolymorphicValue getMetaTensorArg(const serde::TensorArg* tensor) {
-  TORCH_INTERNAL_ASSERT(tensor != nullptr);
+  NVF_ERROR(tensor != nullptr);
   if (tensor->strides() != nullptr) {
     auto meta_tensor = at::detail::empty_strided_meta(
         parseVector(tensor->sizes()),
@@ -57,8 +57,7 @@ nvfuser::PolymorphicValue deserializePolymorphicValue(const serde::Scalar* c) {
     return nvfuser::PolymorphicValue(
         std::complex<double>(c->real_value(), c->imag_value()));
   }
-  TORCH_INTERNAL_ASSERT(
-      false, "Unable to deserialize serde::Scalar as PolymorphicValue.");
+  NVF_ERROR(false, "Unable to deserialize serde::Scalar as PolymorphicValue.");
 }
 
 void PolymorphicValueFactory::registerAllParsers() {
@@ -84,7 +83,7 @@ void PolymorphicValueFactory::registerAllParsers() {
 flatbuffers::Offset<serde::Scalar> serializeScalarCpu(
     flatbuffers::FlatBufferBuilder& builder,
     const at::Tensor& tensor) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       tensor.is_cpu() && tensor.numel() == 1,
       "Only CPU scalar tensors are supported here.");
 
@@ -107,24 +106,23 @@ flatbuffers::Offset<serde::Scalar> serializeScalarCpu(
       return serializeScalar(builder, pv, nvfuser::DataType::ComplexDouble);
     }
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unsupported scalar type.");
+      NVF_ERROR(false, "Unsupported scalar type.");
   }
 }
 
 flatbuffers::Offset<serde::PolymorphicValue> serializePolymorphicValue(
     flatbuffers::FlatBufferBuilder& builder,
     std::shared_ptr<nvfuser::PolymorphicValue> v) {
-  TORCH_INTERNAL_ASSERT(
-      !v->is<std::monostate>(), "PolymorphicValue is a std::monostate.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(!v->is<std::monostate>(), "PolymorphicValue is a std::monostate.");
+  NVF_ERROR(
       !v->is<StructHandle>(),
       "Serialization of arbitrary struct is not implemented.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !v->is<nvfuser::Opaque>(),
       "Serialization of arbitrary opaque value is not implemented.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !v->is<nvfuser::Pointer>(), "Serialization of pointer is not allowed.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !v->is<std::vector>(), "Serialization of vector is not implemented.");
 
   if (v->is<at::Tensor>()) {
@@ -200,8 +198,7 @@ flatbuffers::Offset<serde::Scalar> serializeScalar(
     builder_.add_imag_value(std::imag(c));
     return builder_.Finish();
   }
-  TORCH_INTERNAL_ASSERT(
-      false, "Unable to convert ", v.type().name(), " to serde::Scalar.");
+  NVF_ERROR(false, "Unable to convert ", v.type().name(), " to serde::Scalar.");
 }
 
 } // namespace nvfuser::serde

--- a/csrc/serde/polymorphic_value_serde.h
+++ b/csrc/serde/polymorphic_value_serde.h
@@ -7,6 +7,7 @@
  */
 // clang-format on
 #pragma once
+#include <exceptions.h>
 #include <executor_kernel_arg.h>
 #include <serde/factory.h>
 #include <serde/fusion_cache_generated.h>

--- a/csrc/serde/utils.cpp
+++ b/csrc/serde/utils.cpp
@@ -53,7 +53,7 @@ at::ScalarType mapToAtenDtype(serde::DataType t) {
     default:
       break;
   }
-  TORCH_INTERNAL_ASSERT(false, "No nvfuser dtype found for serde data type.");
+  NVF_ERROR(false, "No nvfuser dtype found for serde data type.");
   return at::ScalarType::Undefined;
 }
 
@@ -90,7 +90,7 @@ serde::DataType mapToSerdeDtype(PrimDataType t) {
     default:
       break;
   }
-  TORCH_INTERNAL_ASSERT(false, "No serde dtype found for nvfuser data type.");
+  NVF_ERROR(false, "No serde dtype found for nvfuser data type.");
   return serde::DataType_MAX;
 }
 
@@ -119,7 +119,7 @@ PrimDataType mapToNvfuserDtype(serde::DataType t) {
     default:
       break;
   }
-  TORCH_INTERNAL_ASSERT(false, "No nvfuser dtype found for serde data type.");
+  NVF_ERROR(false, "No nvfuser dtype found for serde data type.");
   return PrimDataType::Null;
 }
 

--- a/csrc/serde/utils.h
+++ b/csrc/serde/utils.h
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #pragma once
+#include <exceptions.h>
 #include <serde/fusion_cache_generated.h>
 #include <type.h>
 

--- a/csrc/struct.inl
+++ b/csrc/struct.inl
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <functional>
 #include <memory>
 #include <string>
@@ -113,12 +114,12 @@ struct NotImplementedStruct : public Struct {
 
   std::function<PolymorphicValue()> getter(
       const std::string& key) const override {
-    TORCH_INTERNAL_ASSERT(false, "Not implemented");
+    NVF_ERROR(false, "Not implemented");
   }
 
   std::function<void(const PolymorphicValue&)> setter(
       const std::string& key) override {
-    TORCH_INTERNAL_ASSERT(false, "Not implemented");
+    NVF_ERROR(false, "Not implemented");
   }
 };
 

--- a/csrc/swizzle.cpp
+++ b/csrc/swizzle.cpp
@@ -86,7 +86,7 @@ std::pair<Val*, Val*> dispatchSwizzle(
     case Swizzle2DType::CyclicShift:
       return swizzles::CyclicShift(x, y, maybe_size_x);
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unsupported swizzle type");
+      NVF_ERROR(false, "Unsupported swizzle type");
   }
 }
 
@@ -104,7 +104,7 @@ std::pair<Val*, Val*> dispatchUnSwizzle(
     case Swizzle2DType::CyclicShift:
       return swizzles::unCyclicShift(x, y, maybe_size_x);
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unsupported swizzle type");
+      NVF_ERROR(false, "Unsupported swizzle type");
   }
 }
 

--- a/csrc/swizzle.h
+++ b/csrc/swizzle.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/interface_nodes.h>
 #include <type.h>

--- a/csrc/tensor_metadata.h
+++ b/csrc/tensor_metadata.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <polymorphic_value.h>
 #include <type.h>
 
@@ -57,7 +58,7 @@ struct TensorMetaData : public Struct {
         return [this]() { return PolymorphicValue(alloc_stride.vec()); };
       }
     } else {
-      TORCH_INTERNAL_ASSERT(false, "Unknown key ", key);
+      NVF_ERROR(false, "Unknown key ", key);
     }
   }
 
@@ -86,13 +87,13 @@ struct TensorMetaData : public Struct {
         alloc_stride = c10::makeArrayRef(alloc_stride_data);
       };
     } else {
-      TORCH_INTERNAL_ASSERT(false, "Unknown key ", key);
+      NVF_ERROR(false, "Unknown key ", key);
     }
   }
 
   StructType type() const override {
-    TORCH_INTERNAL_ASSERT(logical_size.size() == logical_stride.size());
-    TORCH_INTERNAL_ASSERT(alloc_size.size() == alloc_stride.size());
+    NVF_ERROR(logical_size.size() == logical_stride.size());
+    NVF_ERROR(alloc_size.size() == alloc_stride.size());
     return globalTensorMetaData(dtype, logical_size.size(), alloc_size.size());
   }
 };

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -9,6 +9,7 @@
 #include <compute_at.h>
 #include <device_lower/lower2device.h>
 #include <device_lower/pass/double_buffer.h>
+#include <exceptions.h>
 #include <fusion.h>
 #include <inlining.h>
 #include <ir/all_nodes.h>
@@ -48,12 +49,11 @@ TensorView::TensorView(
     : Val(passkey,
           ValType::TensorView,
           aten_opt_type_map(tensor_type->scalarType())) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
 
-  TORCH_CHECK(
-      tensor_type->dim().has_value(), "Requires static rank for Tensor");
+  NVF_CHECK(tensor_type->dim().has_value(), "Requires static rank for Tensor");
 
   // [ Note -- stride_properties in tensor type ]
   //
@@ -177,7 +177,7 @@ TensorView::TensorView(
     IrBuilderPasskey passkey,
     const std::shared_ptr<torch::jit::Value>& jit_value)
     : TensorView(passkey, jit_value->type()->cast<c10::TensorType>()) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
 }
@@ -198,7 +198,7 @@ std::string TensorView::toString(int indent_size) const {
       ss << "_l";
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unknown tensor memory type.");
+      NVF_ERROR(false, "Unknown tensor memory type.");
   }
   ss << domain()->toString(indent_size);
 
@@ -262,17 +262,15 @@ TensorView::TensorView(const TensorView* src, IrCloner* ir_cloner)
 // avoid explicit copying of the data, so we want to pass the data value as a
 // standard kernel argument value.
 void TensorView::setCpuScalar(bool is_cpu_scalar) {
-  TORCH_INTERNAL_ASSERT(
-      nDims() == 0, "Only 0-dim tensors can be marked as a cpu scalar.");
+  NVF_ERROR(nDims() == 0, "Only 0-dim tensors can be marked as a cpu scalar.");
   cpu_scalar_ = is_cpu_scalar;
 }
 
 IterDomain* TensorView::axis(int pos) const {
-  TORCH_INTERNAL_ASSERT(
-      nDims() > 0, "Tried to access an axis in a 0-dim TensorView");
+  NVF_ERROR(nDims() > 0, "Tried to access an axis in a 0-dim TensorView");
   if (pos < 0)
     pos += (int)domain()->nDims();
-  TORCH_CHECK(
+  NVF_CHECK(
       pos >= 0 && (unsigned int)pos < domain()->nDims(),
       "Tried to access position ",
       pos,
@@ -285,7 +283,7 @@ void TensorView::inlineAt(
     int64_t pos,
     bool best_effort,
     MaxPosCalculator* calc) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
 
@@ -299,7 +297,7 @@ void TensorView::inlineAt(
     pos += int64_t(nDims()) + 1;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       pos >= 0 && pos <= (int64_t)nDims(),
       "Invalid inline position for T",
       name(),
@@ -317,7 +315,7 @@ void TensorView::inlineAt(
     pos--;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       pos <= (int64_t)max_inline_pos,
       "Invalid inline position for T",
       name(),
@@ -421,11 +419,11 @@ TensorView* TensorView::computeAt(
     TensorView* consumer,
     int position,
     ComputeAtMode mode) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
   // Make sure this and consumer are not the same tensor, that's illegal
-  TORCH_CHECK(!sameAs(consumer), "Cannot call this->computeAt(this, ...)");
+  NVF_CHECK(!sameAs(consumer), "Cannot call this->computeAt(this, ...)");
 
   // We support negative axes, so increment it by consumer->nDims() + 1 and make
   // sure the result is within consumer->nDims() + 1. being at consumer->nDims()
@@ -434,7 +432,7 @@ TensorView* TensorView::computeAt(
     position += int(consumer->nDims()) + 1;
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       (position >= 0 && (unsigned int)position < consumer->nDims() + 1) ||
           mode == ComputeAtMode::BestEffort,
       "Compute at called on an position outside valid range.");
@@ -450,7 +448,7 @@ TensorView* TensorView::computeAt(
 }
 
 void TensorView::computeWith(int pos, bool best_effort) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
 
@@ -458,7 +456,7 @@ void TensorView::computeWith(int pos, bool best_effort) {
     return;
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !ir_utils::consumerTvsOf(this).empty(),
       "There must be at least one consumer of this tensor to use computeWith: ",
       toString());
@@ -467,7 +465,7 @@ void TensorView::computeWith(int pos, bool best_effort) {
     pos += int(nDims()) + 1;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       pos >= 0 && pos <= (int)nDims(),
       "Invalid inline position for ",
       toString(),
@@ -486,7 +484,7 @@ void TensorView::computeWith(int pos, bool best_effort) {
     pos--;
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       pos <= (int)max_inline_pos,
       "Invalid computeWith position for T",
       name(),
@@ -496,7 +494,7 @@ void TensorView::computeWith(int pos, bool best_effort) {
       max_inline_pos);
 
   // The position must be right of the computeAt position
-  TORCH_CHECK(
+  NVF_CHECK(
       pos >= (int)getComputeAtPosition(),
       "Position must be right of the computeAt position. Position: ",
       pos,
@@ -537,8 +535,7 @@ bool TensorView::isComputedWith(const TensorView* consumer) const {
   }
 
   // Quering is an error if the compute-with consumer is still unresolved
-  TORCH_INTERNAL_ASSERT(
-      hasResolvedComputeWith(), "Not resolved yet: ", toString());
+  NVF_ERROR(hasResolvedComputeWith(), "Not resolved yet: ", toString());
 
   return std::find(
              getComputeWithConsumers().begin(),
@@ -547,7 +544,7 @@ bool TensorView::isComputedWith(const TensorView* consumer) const {
 }
 
 const std::vector<TensorView*>& TensorView::getComputeWithConsumers() const {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !hasComputeWith() || hasResolvedComputeWith(),
       "computeWith not yet resolved: ",
       toString());
@@ -563,13 +560,12 @@ unsigned int TensorView::getComputePosition(const TensorView* consumer) const {
 }
 
 bool TensorView::resolveComputeWith(const std::vector<Expr*>& sorted_exprs) {
-  TORCH_INTERNAL_ASSERT(
-      container()->isA<kir::Kernel>(), "Function invalid for fusion.");
+  NVF_ERROR(container()->isA<kir::Kernel>(), "Function invalid for fusion.");
 
   auto siblings = ir_utils::filterByType<TensorView>(definition()->outputs());
 
   for (auto sibling : siblings) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         sibling->hasComputeWith(),
         "Invlaid attempt to resolve computeWith: ",
         sibling->toString());
@@ -607,20 +603,19 @@ bool TensorView::resolveComputeWith(const std::vector<Expr*>& sorted_exprs) {
   }
 
   // No expr found
-  TORCH_INTERNAL_ASSERT(
-      false, "No use expr found in the sorted expr list: ", toString());
+  NVF_ERROR(false, "No use expr found in the sorted expr list: ", toString());
 }
 
 void TensorView::clearComputeWith() {
   //! This should be only used while in a Fusion container.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
 
   compute_with_pos_ = getComputeAtPosition();
 
   // compute_with_consumers_ should still be empty
-  TORCH_INTERNAL_ASSERT(compute_with_consumers_.empty());
+  NVF_ERROR(compute_with_consumers_.empty());
 }
 
 TensorView* TensorView::split(
@@ -630,7 +625,7 @@ TensorView* TensorView::split(
     bool trim_out_of_bounds) {
   // Only check things associated with axis, factor will be validated in
   // IterDomain
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       nDims() > 0,
       "Tried to do split on a 0-dim TensorView. ",
       "Tensor: ",
@@ -639,14 +634,14 @@ TensorView* TensorView::split(
   if (axis_ < 0)
     axis_ += (int)domain()->nDims();
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       axis_ >= 0,
       "Split axis is less than 0 even after adjusting for nDims: ",
       axis_,
       ". Tensor: ",
       toString());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       axis_ >= (int)getMaxComputePosition(),
       "Cannot split axis within compute at position. Axis = ",
       axis_,
@@ -655,7 +650,7 @@ TensorView* TensorView::split(
       ". Tensor: ",
       toString());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       axis_ >= (int)getMaybeMaxProducerPosition(),
       "Cannot split axis within max producer position. Axis = ",
       axis_,
@@ -664,7 +659,7 @@ TensorView* TensorView::split(
       ". Tensor: ",
       toString());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       axis(axis_)->getParallelType() == ParallelType::Serial,
       "Splitting an axis of non-Serial parallel type is not supported at this time."
       " Parallelization strategy must be set after calling split.",
@@ -695,7 +690,7 @@ TensorView* TensorView::split(
 
 // Merge "axis_o" and "axis_i" into 1 dimension
 TensorView* TensorView::merge(int axis_o, int axis_i) {
-  TORCH_INTERNAL_ASSERT(nDims() > 0, "Tried to do merge on a 0-dim TensorView");
+  NVF_ERROR(nDims() > 0, "Tried to do merge on a 0-dim TensorView");
 
   if (axis_o < 0)
     axis_o += (int)domain()->nDims();
@@ -703,7 +698,7 @@ TensorView* TensorView::merge(int axis_o, int axis_i) {
   if (axis_i < 0)
     axis_i += (int)domain()->nDims();
 
-  TORCH_CHECK(
+  NVF_CHECK(
       axis_o >= (int)getMaxComputePosition() &&
           axis_i >= (int)getMaxComputePosition(),
       false,
@@ -714,7 +709,7 @@ TensorView* TensorView::merge(int axis_o, int axis_i) {
       " are within computePosition = ",
       getMaxComputePosition());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       axis_o >= (int)getMaybeMaxProducerPosition() &&
           axis_i >= (int)getMaybeMaxProducerPosition(),
       "Cannot merge axes within max producer position. Either axis ",
@@ -724,7 +719,7 @@ TensorView* TensorView::merge(int axis_o, int axis_i) {
       " are within maxProducerPosition = ",
       getMaybeMaxProducerPosition());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       axis(axis_o)->getParallelType() == ParallelType::Serial ||
           axis(axis_i)->getParallelType() == ParallelType::Serial,
       "Merging axes of non-Serial parallel type is not supported at this time."
@@ -735,10 +730,10 @@ TensorView* TensorView::merge(int axis_o, int axis_i) {
 }
 
 TensorView* TensorView::reorder(const std::unordered_map<int, int>& old2new_) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !(nDims() == 0 && !old2new_.empty()),
       "Tried to reorder a 0-dim TensorView");
 
@@ -749,15 +744,15 @@ TensorView* TensorView::reorder(const std::unordered_map<int, int>& old2new_) {
     if (old_pos == new_pos) {
       continue;
     }
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         old_pos >= 0,
         "Found \"old\" position that's less than 0 even though already adjusted by nDims: ",
         old_pos);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         new_pos >= 0,
         "Found \"new\" position that's less than 0 even though already adjusted by nDims: ",
         new_pos);
-    TORCH_CHECK(
+    NVF_CHECK(
         old_pos >= (int)getMaxComputePosition() &&
             new_pos >= (int)getMaxComputePosition(),
         "Cannot reorder axes within compute at position. Either axis ",
@@ -767,7 +762,7 @@ TensorView* TensorView::reorder(const std::unordered_map<int, int>& old2new_) {
         " are within computePosition = ",
         getMaxComputePosition());
 
-    TORCH_CHECK(
+    NVF_CHECK(
         old_pos >= (int)getMaybeMaxProducerPosition() &&
             new_pos >= (int)getMaybeMaxProducerPosition(),
         "Cannot reorder axes within max producer position. Either axis ",
@@ -795,19 +790,19 @@ TensorView* TensorView::swizzle(
     y += (int)domain()->nDims();
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !(getMemoryType() == MemoryType::Global &&
         swizzle_mode == SwizzleMode::Data),
       "Data swizzle on global memory is not supported.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       x >= (int)getMaxComputePosition(),
       "Cannot swizzle axes within compute at position. Axis ",
       x,
       " is within computePosition = ",
       getMaxComputePosition());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       y >= (int)getMaybeMaxProducerPosition(),
       "Cannot swizzle axes within max producer position. Axis ",
       y,
@@ -819,7 +814,7 @@ TensorView* TensorView::swizzle(
   //   swizzled dimensions.
   auto all_inputs = InputsOf::outputs(fusion(), {axis(x), axis(y)});
   for (auto id : ir_utils::filterByType<IterDomain>(all_inputs)) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !id->isBroadcast() && !id->isReduction(),
         "Unsupported use case for swizzle.");
   }
@@ -829,7 +824,7 @@ TensorView* TensorView::swizzle(
   auto all_exprs = DependencyCheck::getAllValsBetween(
       {all_inputs.begin(), all_inputs.end()}, {axis(x), axis(y)});
   for (auto expr : all_exprs) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         !expr->isA<Swizzle2D>(), "Composing swizzles is not yet supported");
   }
 
@@ -838,7 +833,7 @@ TensorView* TensorView::swizzle(
     auto x_id = axis(x);
     auto y_id = axis(y);
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         x_id->extent()->isConstInt() && y_id->extent()->isConstInt(),
         "Only constant iterdomains supported on given swizzle type");
 
@@ -848,14 +843,13 @@ TensorView* TensorView::swizzle(
     // Check size constraints based on swizzle type
     if (swizzle_type == Swizzle2DType::XOR ||
         swizzle_type == Swizzle2DType::CyclicShift) {
-      TORCH_INTERNAL_ASSERT(
-          in_x_size == in_y_size, "Swizzle: equal dim iterdomains only");
+      NVF_ERROR(in_x_size == in_y_size, "Swizzle: equal dim iterdomains only");
     }
 
     if (swizzle_type == Swizzle2DType::XOR) {
       // XOR swizzle only support power of 2 swizzle unit sizes:
       bool is_pow_of_2 = in_x_size > 1 && ((in_x_size & (in_x_size - 1)) == 0);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           is_pow_of_2, "XOR swizzle only support power of 2 domain sizes.");
     }
   }
@@ -866,28 +860,28 @@ TensorView* TensorView::swizzle(
 }
 
 TensorView* TensorView::rFactor(const std::vector<int>& axes) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
   // TODO: I think we should do this but
   // NVFuserTest.FusionSmemBlockGemmCache_CUDA prevents it from going in at the
   // moment.
 
-  // TORCH_INTERNAL_ASSERT(
+  // NVF_ERROR(
   //     !hasComputeAt(), "Cannot rfactor tensors after compute at has been
   //     set.");
-  TORCH_INTERNAL_ASSERT(nDims() > 0, "Tried to rFactor a 0-dim TensorView");
+  NVF_ERROR(nDims() > 0, "Tried to rFactor a 0-dim TensorView");
   FusionGuard fg(fusion());
-  TORCH_CHECK(
+  NVF_CHECK(
       definition() != nullptr &&
           (definition()->isStrictlyOneOf<ReductionOp, MmaOp>()),
       "Error rfactoring ",
       this,
       " its definition is either a nullptr or not a reduction.");
-  TORCH_CHECK(
+  NVF_CHECK(
       !domain()->hasRFactor(), "Cannot call rfactor on the same view twice.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !definition()->isA<GroupedReductionOp>(),
       "For GroupedReductionOp, use TensorView::rFactor(const std::vector<int>& axes, const std::vector<TensorView*>& tvs)");
 
@@ -938,7 +932,7 @@ TensorView* TensorView::rFactor(const std::vector<int>& axes) {
     IrBuilder::create<ReductionOp>(
         BinaryOpType::Add, this_mma->init(), consumer, producer);
   } else {
-    TORCH_INTERNAL_ASSERT(false, "RFactor: unsupported tensor definition");
+    NVF_ERROR(false, "RFactor: unsupported tensor definition");
   }
   return producer;
 }
@@ -946,7 +940,7 @@ TensorView* TensorView::rFactor(const std::vector<int>& axes) {
 TensorView* TensorView::multiOutputRfactorHelper(
     TensorView* tv,
     const std::vector<int>& axes) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
   // Hack:
@@ -971,7 +965,7 @@ TensorView* TensorView::multiOutputRfactorHelper(
     // construct the new tensor domain
     std::vector<IterDomain*> new_id;
     for (auto id : getLeafDomain()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           replay.getReplay().count(id), "Multi-output reduction replay failed");
       new_id.push_back(replay.getReplay().at(id));
     }
@@ -1002,26 +996,26 @@ TensorView* TensorView::multiOutputRfactorHelper(
 std::vector<TensorView*> TensorView::rFactor(
     const std::vector<int>& axes,
     const std::vector<TensorView*>& tvs) {
-  TORCH_CHECK(
+  NVF_CHECK(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
-  TORCH_CHECK(nDims() > 0, "Tried to rFactor a 0-dim TensorView");
+  NVF_CHECK(nDims() > 0, "Tried to rFactor a 0-dim TensorView");
   FusionGuard fg(fusion());
-  TORCH_CHECK(
+  NVF_CHECK(
       definition() != nullptr && ir_utils::isReductionOp(definition()),
       "Error rfactoring multi-output reduction op ",
       this,
       " its definition is either a nullptr or not a GroupedReductionOp or a multi-output reduction op.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !domain()->hasRFactor(), "Cannot call rfactor on the same view twice.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       definition()->outputs().size() == tvs.size(),
       "Rfactor of a multi-output reduction not used correctly");
 
   for (const auto i : c10::irange(tvs.size())) {
-    TORCH_CHECK(
+    NVF_CHECK(
         definition()->output(i) == tvs.at(i),
         "Rfactor of a multi-output reduction not used correctly");
   }
@@ -1030,7 +1024,7 @@ std::vector<TensorView*> TensorView::rFactor(
   // ParallelType::Group, so GroupedWelfordOp is only created during
   // the lowering time. As rFactor is done before lowering, there
   // should be no GroupedWelfordOp at this point.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !definition()->isA<GroupedWelfordOp>(),
       "GroupedWelfordOp found: ",
       definition()->toString());
@@ -1094,20 +1088,19 @@ std::vector<TensorView*> TensorView::rFactor(
         grouped_rop->outputs(),
         std::vector<Val*>{rf_tvs.begin(), rf_tvs.end()});
   } else {
-    TORCH_INTERNAL_ASSERT(
-        false, "Invalid definition: ", definition()->toString());
+    NVF_ERROR(false, "Invalid definition: ", definition()->toString());
   }
 
   return rf_tvs;
 }
 
 TensorView* TensorView::cacheBefore(LoadStoreOpType cache_op) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
   FusionGuard fg(fusion());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       definition() != nullptr && !isFusionInput(),
       "Error adding cacheBefore ",
       this,
@@ -1115,7 +1108,7 @@ TensorView* TensorView::cacheBefore(LoadStoreOpType cache_op) {
 
   // Previously, caching computed-at tensors was allowed but was never
   // really robust. Make it an error unless it is really needed.
-  TORCH_CHECK(
+  NVF_CHECK(
       !hasComputeAt(),
       "Caching computed-at tensors is not allowed. Apply caching before computeAt");
 
@@ -1124,7 +1117,7 @@ TensorView* TensorView::cacheBefore(LoadStoreOpType cache_op) {
   if (definition() != nullptr) {
     for (TensorView* producer_of_producer :
          ir_utils::filterByType<TensorView>(definition()->inputs())) {
-      TORCH_CHECK(
+      NVF_CHECK(
           !producer_of_producer->hasComputeAt(),
           "Potentially invalid computeAt and caching detected. Apply caching before computeAt.");
     }
@@ -1187,7 +1180,7 @@ TensorView* TensorView::cacheBefore(LoadStoreOpType cache_op) {
 }
 
 TensorView* TensorView::cacheFork() {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
   FusionGuard fg(fusion());
@@ -1196,7 +1189,7 @@ TensorView* TensorView::cacheFork() {
   // After:  [Expr] -> This TV (Local) -> [Usage Expr] > Next TV
   //                            (Fork) -> [Set Expr]   -> New TV (Global Output)
 
-  TORCH_CHECK(
+  NVF_CHECK(
       this->isFusionOutput() && !this->uses().empty(),
       "Error adding cacheFork ",
       this,
@@ -1204,7 +1197,7 @@ TensorView* TensorView::cacheFork() {
 
   // Previously, caching computed-at tensors was allowed but was never
   // really robust. Make it an error unless it is really needed.
-  TORCH_CHECK(
+  NVF_CHECK(
       !hasComputeAt(),
       "Caching computed-at tensors is not allowed. Apply caching before computeAt");
 
@@ -1237,13 +1230,13 @@ TensorView* TensorView::cacheFork() {
 }
 
 TensorView* TensorView::cacheAfter(LoadStoreOpType cache_op) {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
   FusionGuard fg(fusion());
 
   // Get all the uses for this Tensorview
-  TORCH_CHECK(
+  NVF_CHECK(
       !uses().empty(),
       "Error adding cacheAfter ",
       this,
@@ -1251,11 +1244,11 @@ TensorView* TensorView::cacheAfter(LoadStoreOpType cache_op) {
 
   // Previously, caching computed-at tensors was allowed but was never
   // really robust. Make it an error unless it is really needed.
-  TORCH_CHECK(
+  NVF_CHECK(
       !hasComputeAt(),
       "Caching computed-at tensors is not allowed. Apply caching before computeAt.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !ir_utils::isSelectInput(this) && !ir_utils::isIndexSelectLookupTv(this),
       "Right now, caching tensors that are input to the select op is not allowed as they must be in global memory.")
 
@@ -1266,7 +1259,7 @@ TensorView* TensorView::cacheAfter(LoadStoreOpType cache_op) {
     for (const auto& expr : uses()) {
       for (TensorView* output :
            ir_utils::filterByType<TensorView>(expr->outputs())) {
-        TORCH_CHECK(
+        NVF_CHECK(
             !output->hasComputeAt(),
             "Potentially invalid computeAt and caching detected. Apply caching before computeAt.");
       }
@@ -1319,18 +1312,18 @@ TensorView* TensorView::cacheAfter(LoadStoreOpType cache_op) {
 void TensorView::setMemoryType(MemoryType mt) {
   memory_type_ = mt;
   if (isFusionInput() || isFusionOutput()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         mt == MemoryType::Global,
         "Tried to set an input or output to the fusion to a non-global memory type.");
   }
 }
 
 void TensorView::clearReductionIterDomains() {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !domain()->hasRFactor(),
       "should not call clearReductionIterDomains on rfactor tv");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       getLeafDomain() == getRootDomain(),
       "should not call clearReductionIterDomains on already transformed TensorDomains");
 
@@ -1359,7 +1352,7 @@ void TensorView::circularBuffer(unsigned int stage) {
   // Early correctness checking. May miss eventual errors as the
   // checks depend on memory types and parallelization, which may not
   // be finalized until lowering.
-  TORCH_INTERNAL_ASSERT(stage > 1, "Unsupported stage number");
+  NVF_ERROR(stage > 1, "Unsupported stage number");
   if (stage == 2) {
     // Re-direct to double buffer interface if stage is 2;
     doubleBuffer();
@@ -1388,13 +1381,13 @@ void TensorView::applyMmaSwizzle(MmaOptions options) {
       mma_utils::WarpMmaSwizzler::scheduleOperandRead(this, options);
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "unknown operand flag");
+      NVF_ERROR(false, "unknown operand flag");
       break;
   }
 }
 
 void TensorView::commitLeafToRFactor() {
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::consumerTvsOf(this).empty(),
       "Changing the rFactor domain of an intermediate tensor is not supported yet");
   setDomain(IrBuilder::create<TensorDomain>(
@@ -1412,8 +1405,8 @@ void TensorView::commitLeafToRFactor() {
 }
 
 TensorViewBuilder& TensorViewBuilder::ndims(size_t ndims) {
-  TORCH_CHECK(shape_.empty() || shape_.size() == ndims);
-  TORCH_CHECK(contiguity_.empty() || contiguity_.size() == ndims);
+  NVF_CHECK(shape_.empty() || shape_.size() == ndims);
+  NVF_CHECK(contiguity_.empty() || contiguity_.size() == ndims);
   ndims_ = ndims;
   return *this;
 }
@@ -1425,7 +1418,7 @@ TensorViewBuilder& TensorViewBuilder::dtype(DataType dtype) {
 
 TensorViewBuilder& TensorViewBuilder::contiguity(
     std::vector<std::optional<bool>> contiguity) {
-  TORCH_CHECK(
+  NVF_CHECK(
       contiguity_.empty() && !uniform_contiguity_.has_value(),
       "Attempting to reset contiguity");
   contiguity_ = std::move(contiguity);
@@ -1433,7 +1426,7 @@ TensorViewBuilder& TensorViewBuilder::contiguity(
 }
 
 TensorViewBuilder& TensorViewBuilder::contiguity(bool contiguity) {
-  TORCH_CHECK(
+  NVF_CHECK(
       contiguity_.empty() && !uniform_contiguity_.has_value(),
       "Attempting to reset contiguity");
   uniform_contiguity_ = contiguity;
@@ -1441,9 +1434,9 @@ TensorViewBuilder& TensorViewBuilder::contiguity(bool contiguity) {
 }
 
 TensorViewBuilder& TensorViewBuilder::shape(const std::vector<int64_t>& shape) {
-  TORCH_CHECK(shape_.empty(), "Attempting to reset shape");
+  NVF_CHECK(shape_.empty(), "Attempting to reset shape");
   if (!shape.empty()) {
-    TORCH_CHECK(ndims_ == 0 || ndims_ == shape.size());
+    NVF_CHECK(ndims_ == 0 || ndims_ == shape.size());
     ndims_ = shape.size();
   }
   shape_.clear();
@@ -1456,7 +1449,7 @@ TensorViewBuilder& TensorViewBuilder::shape(const std::vector<int64_t>& shape) {
     } else if (i == 0) {
       shape_.emplace_back(FusionGuard::getCurFusion()->zeroVal());
     } else {
-      TORCH_CHECK(
+      NVF_CHECK(
           i >= 0,
           "Invalid extent value. ",
           "For a tensor representing a single scalar use ndims = 0 with no sizes set.");
@@ -1467,9 +1460,9 @@ TensorViewBuilder& TensorViewBuilder::shape(const std::vector<int64_t>& shape) {
 }
 
 TensorViewBuilder& TensorViewBuilder::shape(std::vector<Val*> shape) {
-  TORCH_CHECK(shape_.empty(), "Attempting to reset shape");
+  NVF_CHECK(shape_.empty(), "Attempting to reset shape");
   if (!shape.empty()) {
-    TORCH_CHECK(ndims_ == 0 || ndims_ == shape.size());
+    NVF_CHECK(ndims_ == 0 || ndims_ == shape.size());
     ndims_ = shape.size();
   }
   shape_ = std::move(shape);
@@ -1477,9 +1470,9 @@ TensorViewBuilder& TensorViewBuilder::shape(std::vector<Val*> shape) {
 }
 
 TensorViewBuilder& TensorViewBuilder::expanded(std::vector<bool> expanded) {
-  TORCH_CHECK(expanded_.empty(), "Attempting to reset expanded shape");
+  NVF_CHECK(expanded_.empty(), "Attempting to reset expanded shape");
   if (!expanded.empty()) {
-    TORCH_CHECK(ndims_ == 0 || ndims_ == expanded.size());
+    NVF_CHECK(ndims_ == 0 || ndims_ == expanded.size());
     ndims_ = expanded.size();
   }
   expanded_ = std::move(expanded);
@@ -1525,19 +1518,19 @@ TensorView* TensorViewBuilder::build() const {
     domain[i] = builder.build();
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       contiguity_.empty() || contiguity_.size() == domain.size(),
       "The size of contiguity must equal to the number of non-broadcasting IterDomains");
 
   for (auto i : c10::irange(contiguity_.size())) {
-    TORCH_CHECK(
+    NVF_CHECK(
         domain.at(i)->isBroadcast() != contiguity_.at(i).has_value(),
         "The contiguity of a broadcast dimension must be None. "
         "The contiguity of a non-broadcast dimension must be true/false");
   }
 
   if (uniform_contiguity_.has_value()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         contiguity_.empty(),
         "contiguity_ and uniform_contiguity_ can not be set at the same time");
     // Create the final TensorView

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -17,7 +17,7 @@ namespace nvfuser {
 // Transform dispatch
 void ReplayTransformations::dispatch(Expr* e) {
   auto is_supported_expr = e->isOneOf<Split, Merge, Swizzle2D, Resize>();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       is_supported_expr, "Invalid expr type found in transform traversal.");
   IterVisitor::dispatch(e);
 }
@@ -32,8 +32,7 @@ void ReplayTransformations::handle(Split* s) {
   auto it = id_map_.find(id_in);
   if (it == id_map_.end()) {
     if (error_on_failure_) {
-      TORCH_INTERNAL_ASSERT(
-          false, "Transform traversal failed, dependencies not met.");
+      NVF_ERROR(false, "Transform traversal failed, dependencies not met.");
     } else {
       return;
     }
@@ -41,7 +40,7 @@ void ReplayTransformations::handle(Split* s) {
 
   auto mapped = it->second;
   // Make sure this ID is a leaf ID (meaning it has no uses we generated)
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       leaf_ids_.find(mapped) != leaf_ids_.end(),
       "Transform traversal failed, modified a node but it was not a leaf node.");
 
@@ -84,8 +83,7 @@ void ReplayTransformations::handle(Merge* m) {
     if (!(outer_found || inner_found) || (outer_found && !inner_bcast) ||
         (inner_found && !outer_bcast)) {
       if (error_on_failure_) {
-        TORCH_INTERNAL_ASSERT(
-            false, "Transform traversal failed, dependencies not met.");
+        NVF_ERROR(false, "Transform traversal failed, dependencies not met.");
       } else {
         return;
       }
@@ -108,7 +106,7 @@ void ReplayTransformations::handle(Merge* m) {
   const auto id_inner_mapped = it_inner->second;
 
   // Make sure these IDs are leaf IDs (meaning they have no uses we generated)
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       leaf_ids_.find(id_outer_mapped) != leaf_ids_.end() &&
           leaf_ids_.find(id_inner_mapped) != leaf_ids_.end(),
       "Transform traversal failed, tried to replay with ",
@@ -143,8 +141,7 @@ void ReplayTransformations::handle(Swizzle2D* swizzle_2d) {
 
   if (it_x == id_map_.end() || it_y == id_map_.end()) {
     if (error_on_failure_) {
-      TORCH_INTERNAL_ASSERT(
-          false, "Transform traversal failed, dependencies not met.");
+      NVF_ERROR(false, "Transform traversal failed, dependencies not met.");
     } else {
       return;
     }
@@ -154,7 +151,7 @@ void ReplayTransformations::handle(Swizzle2D* swizzle_2d) {
   auto mapped_y = it_y->second;
 
   // Make sure this ID is a leaf ID (meaning it has no uses we generated)
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       leaf_ids_.find(mapped_x) != leaf_ids_.end() &&
           leaf_ids_.find(mapped_y) != leaf_ids_.end(),
       "Transform traversal failed, modified a node but it was not a leaf node.");
@@ -185,8 +182,7 @@ void ReplayTransformations::handle(Resize* exp) {
   auto it = id_map_.find(id_in);
   if (it == id_map_.end()) {
     if (error_on_failure_) {
-      TORCH_INTERNAL_ASSERT(
-          false, "Transform traversal failed, dependencies not met.");
+      NVF_ERROR(false, "Transform traversal failed, dependencies not met.");
     } else {
       return;
     }
@@ -194,7 +190,7 @@ void ReplayTransformations::handle(Resize* exp) {
 
   auto mapped = it->second;
   // Make sure this ID is a leaf ID (meaning it has no uses we generated)
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       leaf_ids_.find(mapped) != leaf_ids_.end(),
       "Transform traversal failed, modified a node but it was not a leaf node.");
 
@@ -228,7 +224,7 @@ ReplayTransformations::ReplayTransformations(
 
 // Replays outputs that were generated from ids.first on ids.second
 void ReplayTransformations::runReplay() {
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !ran_replay_,
       "Cannot run replay twice without creating a new Replay Class.");
 
@@ -237,12 +233,12 @@ void ReplayTransformations::runReplay() {
     auto inps = IterVisitor::getInputsTo(
         std::vector<Val*>(target_domain_.begin(), target_domain_.end()));
     std::for_each(inps.begin(), inps.end(), [this](Val* val) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           val->getValType().value() == ValType::IterDomain,
           "Expected IterDomain only for Replay Transformations, but found ",
           val);
       IterDomain* id = val->as<IterDomain>();
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           id_map_.find(id) != id_map_.end(),
           "Could not find required input: ",
           id,
@@ -262,7 +258,7 @@ void ReplayTransformations::runReplay() {
   traverseTo(traversal_vals[0]->fusion(), traversal_vals);
 
   if (error_on_failure_) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         leaf_ids_.size() >= target_domain_.size(),
         "Transform traversal failed, did not find enough output IterDomains.");
   }
@@ -272,7 +268,7 @@ void ReplayTransformations::runReplay() {
     auto it_replayed = id_map_.find(out);
     if (it_replayed == id_map_.end()) {
       if (error_on_failure_) {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             false,
             "Transform traversal failed, could not find expected output.");
       }
@@ -281,7 +277,7 @@ void ReplayTransformations::runReplay() {
 
     auto id_replayed = it_replayed->second;
     auto it_leaf = leaf_ids_.find(id_replayed);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         it_leaf != leaf_ids_.end(),
         "Transform Traversal failed, expected a replayed dim for ",
         out,
@@ -351,7 +347,7 @@ BestEffortReplay::BestEffortReplay(
   std::unordered_map<IterDomain*, Expr*> replay_id2expr_map;
   for (auto replay_expr : replay_exprs) {
     for (auto id : ir_utils::filterByType<IterDomain>(replay_expr->inputs())) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           replay_id2expr_map.find(id) == replay_id2expr_map.end(),
           "Error trying to map rfactor root domain during replay.",
           " An IterDomain was found to be used in more than one expression.");
@@ -372,7 +368,7 @@ BestEffortReplay::BestEffortReplay(
   std::unordered_map<IterDomain*, Expr*> target_id2expr_map;
   for (auto target_expr : target_exprs) {
     for (auto id : ir_utils::filterByType<IterDomain>(target_expr->inputs())) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           target_id2expr_map.insert({id, target_expr}).second,
           "BestEffortReplay : Unexpected multi-use of id",
           id);
@@ -481,13 +477,13 @@ BestEffortReplay::BestEffortReplay(
       // target domain (broadcast) may contain broadcast ids that are not
       // present in the replay domain (view). In this case, we skip any target
       // expressions that contain broadcast ids.
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           no_missing_exprs || any_target_expr_contains_broadcast_id, err_str);
     }
 
     // If any inputs are missing, continue as this expr doesn't match.
     if (missing_replay_input) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !replay_has_rfactor_inp || any_target_expr_contains_broadcast_id,
           err_str);
       continue;
@@ -516,7 +512,7 @@ BestEffortReplay::BestEffortReplay(
     // If expressions of mapped inputs don't match, then continue to next target
     // expr
     if (mismatched_replay_exprs || replay_expr == nullptr) {
-      TORCH_INTERNAL_ASSERT(!replay_has_rfactor_inp, err_str);
+      NVF_ERROR(!replay_has_rfactor_inp, err_str);
       continue;
     }
 
@@ -529,14 +525,14 @@ BestEffortReplay::BestEffortReplay(
     // If there isn't an rfactor id in the replay's inputs and there's a
     // mismatched input, continue
     if (mismatched_inputs) {
-      TORCH_INTERNAL_ASSERT(!replay_has_rfactor_inp, err_str);
+      NVF_ERROR(!replay_has_rfactor_inp, err_str);
       continue;
     }
 
     // If there isn't an rfactor id in the replay's inputs and there's a
     // mismatch in replay_expr's and target_expr's outputs, continue
     if (target_expr->outputs().size() != replay_expr->outputs().size()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           !replay_has_rfactor_inp,
           err_str,
           ". Target: ",
@@ -549,7 +545,7 @@ BestEffortReplay::BestEffortReplay(
     // If there isn't an rfactor id in the replay's inputs and there's a
     // mismatch in replay_expr's and target_expr's expression type, continue
     if (typeid(*replay_expr) != typeid(*target_expr)) {
-      TORCH_INTERNAL_ASSERT(!replay_has_rfactor_inp, err_str);
+      NVF_ERROR(!replay_has_rfactor_inp, err_str);
       continue;
     }
 
@@ -563,7 +559,7 @@ BestEffortReplay::BestEffortReplay(
           r_split->innerSplit() != t_split->innerSplit() ||
           !r_split->startOffset()->sameAs(t_split->startOffset()) ||
           !r_split->stopOffset()->sameAs(t_split->stopOffset())) {
-        TORCH_INTERNAL_ASSERT(!replay_has_rfactor_inp, err_str);
+        NVF_ERROR(!replay_has_rfactor_inp, err_str);
         continue;
       }
     }
@@ -575,7 +571,7 @@ BestEffortReplay::BestEffortReplay(
       auto r_swizzle_2d = replay_expr->as<Swizzle2D>();
       auto t_swizzle_2d = target_expr->as<Swizzle2D>();
       if (!(r_swizzle_2d->swizzleType() == t_swizzle_2d->swizzleType())) {
-        TORCH_INTERNAL_ASSERT(!replay_has_rfactor_inp, err_str);
+        NVF_ERROR(!replay_has_rfactor_inp, err_str);
         continue;
       }
     }
@@ -585,7 +581,7 @@ BestEffortReplay::BestEffortReplay(
       auto t_resize = target_expr->as<Resize>();
       if (!r_resize->leftExpand()->sameAs(t_resize->leftExpand()) ||
           !r_resize->rightExpand()->sameAs(t_resize->rightExpand())) {
-        TORCH_INTERNAL_ASSERT(!replay_has_rfactor_inp, err_str);
+        NVF_ERROR(!replay_has_rfactor_inp, err_str);
         continue;
       }
     }
@@ -742,7 +738,7 @@ struct ForwardingInfo {
     // Collect which root ids are only in active_tv but not in the inactive
     // tensor.
     std::unordered_set<IterDomain*> forwarded_ids;
-    TORCH_INTERNAL_ASSERT(active_root_dom.size() == active_dim_flags->size());
+    NVF_ERROR(active_root_dom.size() == active_dim_flags->size());
     for (auto i : c10::irange(active_dim_flags->size())) {
       if (active_dim_flags->at(i)) {
         forwarded_ids.emplace(active_root_dom.at(i));
@@ -834,7 +830,7 @@ IterDomain* getSwizzleFinalOutput(
       if (id == expr->inX()) {
         id = expr->outX();
       } else {
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             id == expr->inY(),
             "unknown input to swizzle op",
             id->toString(),
@@ -892,7 +888,7 @@ void BestEffortReplay::addComplimentLeafIDs(
   std::vector<IterDomain*> compliments;
   for (auto forwarded_id : expanded_forwarded_ids) {
     auto compliment_map_it = compliment_map.find(forwarded_id);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         compliment_map_it != compliment_map.end(),
         "Issue tracking forwarded broadcast merges in best effort replay. ",
         forwarded_id->toString());
@@ -937,7 +933,7 @@ BestEffortReplay BestEffortReplay::replayCasP(
   if (producer_compute_at_axis < 0)
     producer_compute_at_axis += (int)producer->nDims() + 1;
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       producer_compute_at_axis >= 0 &&
           (unsigned int)producer_compute_at_axis <= producer->nDims(),
       "Invalid axis provided to BestEffortReplay::replayCasP.");
@@ -1002,7 +998,7 @@ BestEffortReplay BestEffortReplay::replayPasC(
     bool skip_resize) {
   if (consumer_compute_at_axis < 0)
     consumer_compute_at_axis += (int)consumer->nDims() + 1;
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       consumer_compute_at_axis >= 0 &&
           (unsigned int)consumer_compute_at_axis <= consumer->nDims(),
       "Invalid axis provided to BestEffortReplay::replayPasC.");
@@ -1072,7 +1068,7 @@ void BestEffortReplay::skipSwizzles(
         //  skipping all swizzles in between. We'd need to
         //  update the mapping and leaf ids to the final outputs.
         target2replay_id_map_.erase(it.first);
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             target2replay_id_map_.insert(std::make_pair(new_target, new_replay))
                 .second,
             "Unexpected replay leaf");
@@ -1128,7 +1124,7 @@ void BestEffortReplay::skipResizes(
       }
 
       target2replay_id_map_.erase(target_id);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           target2replay_id_map_
               .insert(std::make_pair(new_target_id, new_replay_id))
               .second,

--- a/csrc/transform_iter.h
+++ b/csrc/transform_iter.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <disjoint_set.h>
 #include <ir/all_nodes.h>

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -41,14 +41,14 @@ class ReplaySelf : public ReplayTransformations {
     auto it = id_map_.find(id_in);
 
     // Make sure it exists in the map
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         it != id_map_.end(),
         "Transform traversal failed, dependencies not met.");
     // Grab the ID we're going to replay on
     auto mapped = it->second;
 
     // This ID should be a leaf ID (meaning it has no uses we generated)
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         leaf_ids_.find(mapped) != leaf_ids_.end(),
         "Transform traversal failed, modified a node but it was not a leaf node.");
 
@@ -100,14 +100,14 @@ class ReplaySelf : public ReplayTransformations {
     auto it_outer = id_map_.find(id_outer);
     auto it_inner = id_map_.find(id_inner);
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         it_outer != id_map_.end() && it_inner != id_map_.end(),
         "Transform traversal failed, dependencies not met.");
 
     auto id_outer_mapped = it_outer->second;
     auto id_inner_mapped = it_inner->second;
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         leaf_ids_.find(id_outer_mapped) != leaf_ids_.end() &&
             leaf_ids_.find(id_inner_mapped) != leaf_ids_.end(),
         "Transform traversal failed, modified ",
@@ -138,21 +138,20 @@ class ReplaySelf : public ReplayTransformations {
   }
 
   void handle(Swizzle2D* swizzle) override {
-    TORCH_INTERNAL_ASSERT(
-        false, "Unexpected expr to self replay: ", swizzle->toString());
+    NVF_ERROR(false, "Unexpected expr to self replay: ", swizzle->toString());
   }
 
   void handle(Resize* resize) override {
     auto id_in = resize->in();
 
     auto it = id_map_.find(id_in);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         it != id_map_.end(),
         "Transform traversal failed, dependencies not met.");
 
     auto mapped = it->second;
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         leaf_ids_.find(mapped) != leaf_ids_.end(),
         "Transform traversal failed, modified a node but it was not a leaf node.");
 
@@ -188,7 +187,7 @@ TensorDomain* TransformReplay::fullSelfReplay(
     const TensorDomain* self) {
   FUSER_PERF_SCOPE("TransformReplay::fullSelfReplay");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       new_self_root->root().size() == self->root().size(),
       "Invalid number of IterDomains provided.");
 
@@ -197,7 +196,7 @@ TensorDomain* TransformReplay::fullSelfReplay(
   {
     size_t i = 0;
     for (auto id : self->root()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           new_self_root->root()[i]->isReduction() == id->isReduction() &&
               new_self_root->root()[i]->isRFactorProduct() ==
                   id->isRFactorProduct() &&
@@ -220,7 +219,7 @@ TensorDomain* TransformReplay::fullSelfReplay(
     size_t i = 0;
     for (auto id : self->leaf()) {
       auto it = replay.getReplay().find(id);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           it != replay.getReplay().end(),
           "Error during replay, didn't replay an axis.");
       new_domain[i++] = it->second;
@@ -232,7 +231,7 @@ TensorDomain* TransformReplay::fullSelfReplay(
       size_t i = 0;
       for (auto id : self->maybeRFactor()) {
         auto it = replay.getReplay().find(id);
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             it != replay.getReplay().end(),
             "Error during replay, didn't replay an axis.");
         new_rfactor_domain[i++] = it->second;
@@ -308,7 +307,7 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayPasC(
     consumer_pos += (int64_t)consumer->nDims() + 1;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       consumer_pos >= 0 && (size_t)consumer_pos <= consumer->nDims(),
       "Invalid axis in transform replayPasC.");
 
@@ -368,14 +367,14 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayPasC(
   for (auto c_id : target_consumer_ids) {
     auto it = replay_PasC.getReplay().find(c_id);
     if (it == replay_PasC.getReplay().end()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           maybe_unmapped_ids.count(c_id),
           "Could not find axis, ",
           c_id,
           ", requested in replay.");
       continue;
     }
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         producer_leaf_ids.find(it->second) != producer_leaf_ids.end(),
         "Replayed id to match consumer id ",
         c_id,
@@ -469,7 +468,7 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayPasC(
   for (auto c_id : target_consumer_ids) {
     auto it = replay_PasC.getReplay().find(c_id);
     if (it == replay_PasC.getReplay().end()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           maybe_unmapped_ids.count(c_id),
           "Could not find axis, ",
           c_id,
@@ -547,7 +546,7 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayPasC(
     new_allocation_domain.reserve(consumer->getAllocationDomain().size());
     for (auto id : consumer->getAllocationDomain()) {
       auto it = c2p_map.find(id);
-      TORCH_CHECK(
+      NVF_CHECK(
           it != c2p_map.end(),
           "Unable to replayPasC: can not map ",
           id->toString(),
@@ -580,7 +579,7 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayCasP(
     producer_pos += (int64_t)producer->nDims() + 1;
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       producer_pos >= 0 && (size_t)producer_pos <= producer->nDims(),
       "Invalid axis in transform replayCasP. Consumer: ",
       consumer->toString(),
@@ -645,7 +644,7 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayCasP(
   for (auto p_id : target_producer_ids) {
     auto it = replay_CasP.getReplay().find(p_id);
     if (it == replay_CasP.getReplay().end()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           maybe_unmapped_ids.count(p_id),
           "Could not find axis, ",
           p_id,
@@ -655,7 +654,7 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayCasP(
           producer);
       continue;
     }
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         consumer_leaf_ids.find(it->second) != consumer_leaf_ids.end(),
         "Replayed id to match producer id ",
         p_id,
@@ -741,7 +740,7 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayCasP(
   for (auto p_id : target_producer_ids) {
     auto it = replay_CasP.getReplay().find(p_id);
     if (it == replay_CasP.getReplay().end()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           maybe_unmapped_ids.count(p_id),
           "Could not find axis, ",
           p_id,
@@ -820,7 +819,7 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayCasP(
     new_allocation_domain.reserve(producer->getAllocationDomain().size());
     for (auto id : producer->getAllocationDomain()) {
       auto it = p2c_map.find(id);
-      TORCH_CHECK(
+      NVF_CHECK(
           it != p2c_map.end(),
           "Unable to replayCasP: can not map ",
           id->toString(),
@@ -1086,7 +1085,7 @@ void TransformPropagator::propagateC2P(TensorView* from, TensorView* to) {
   if (new_pos < 0) {
     auto replay = TransformReplay::replayPasC(
         to, from, pos, TransformReplayOptions().skipTargetSwizzle());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         validateDomain(to, replay.first),
         "Tried to set the domain of ",
         to,
@@ -1118,7 +1117,7 @@ void TransformPropagator::propagateP2C(TensorView* from, TensorView* to) {
   if (new_pos < 0) {
     auto replay = TransformReplay::replayCasP(
         to, from, pos, TransformReplayOptions().skipTargetSwizzle());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         validateDomain(to, replay.first),
         "Tried to set the domain of ",
         to,
@@ -1147,7 +1146,7 @@ void TransformPropagator::propagateSibling(TensorView* from, TensorView* to) {
   }
   if (!TransformReplay::fullSelfMatching(to, from)) {
     auto replay = TransformReplay::fullSelfReplay(to->domain(), from->domain());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         validateDomain(to, replay),
         "Tried to set the domain of ",
         to,
@@ -1168,7 +1167,7 @@ TransformPropagator::TransformPropagator(TensorView* from, int64_t pos) {
   if (pos < 0) {
     pos += (int64_t)from->nDims() + 1;
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       pos >= 0 && pos <= (int64_t)from->nDims(),
       "TransformPropagator called on an pos outside valid range.");
   replayed_pos_[from] = pos;
@@ -1190,7 +1189,7 @@ void MostInlinedTransformPropagator::propagateC2P(
   if (new_pos < 0) {
     auto replay = TransformReplay::replayPasC(
         to, from, pos, TransformReplayOptions().skipTargetSwizzle());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         validateDomain(to, replay.first),
         "Tried to set the domain of ",
         to,
@@ -1222,7 +1221,7 @@ void MostInlinedTransformPropagator::propagateP2C(
   if (new_pos < 0) {
     auto replay = TransformReplay::replayCasP(
         to, from, pos, TransformReplayOptions().skipTargetSwizzle());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         validateDomain(to, replay.first),
         "Tried to set the domain of ",
         to,
@@ -1250,7 +1249,7 @@ void MostInlinedTransformPropagator::propagateSibling(
   }
   if (!TransformReplay::fullSelfMatching(to, from)) {
     auto replay = TransformReplay::fullSelfReplay(to->domain(), from->domain());
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         validateDomain(to, replay),
         "Tried to set the domain of ",
         to,

--- a/csrc/transform_replay.h
+++ b/csrc/transform_replay.h
@@ -9,6 +9,7 @@
 
 #include <c10/macros/Export.h>
 #include <c10/util/Exception.h>
+#include <exceptions.h>
 #include <ir/internal_nodes.h>
 #include <maxinfo_propagator.h>
 

--- a/csrc/transform_rfactor.cpp
+++ b/csrc/transform_rfactor.cpp
@@ -62,13 +62,13 @@ class ReplayRFactor : public ReplayTransformations {
       IterDomain* replace1,
       IterDomain* with0,
       IterDomain* with1) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         with0 != nullptr,
         "The first provided IterDomain should be a real pointer,",
         " the second iter domain provided can be a nullptr.");
     auto pos =
         std::find(rfactor_domain_.begin(), rfactor_domain_.end(), replace0);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         pos != rfactor_domain_.end(),
         "Could not find iter domain: ",
         replace0->toString(),
@@ -82,7 +82,7 @@ class ReplayRFactor : public ReplayTransformations {
     rfactor_domain_.erase(pos);
     if (replace1 != nullptr) {
       pos = std::find(rfactor_domain_.begin(), rfactor_domain_.end(), replace1);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           pos != rfactor_domain_.end(),
           "Wanted to replace ",
           replace1->toString(),
@@ -98,13 +98,13 @@ class ReplayRFactor : public ReplayTransformations {
     // Grab our mapping of that ID to the one we're replaying
     auto it = id_map_.find(id_in);
     // Make sure it exists in the map
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         it != id_map_.end(),
         "Transform traversal failed, dependencies not met.");
     // Grab the ID we're going to replay on
     auto mapped = (*it).second;
     // This ID should be a leaf ID (meaning it has no uses we generated)
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         leaf_ids_.find(mapped) != leaf_ids_.end(),
         "Transform traversal failed, modified a node but it was not a leaf node.");
 
@@ -166,14 +166,14 @@ class ReplayRFactor : public ReplayTransformations {
     auto id_inner = m->inner();
     auto it_outer = id_map_.find(id_outer);
     auto it_inner = id_map_.find(id_inner);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         it_outer != id_map_.end() && it_inner != id_map_.end(),
         "Transform traversal failed, dependencies not met.");
 
     auto id_outer_mapped = (*it_outer).second;
     auto id_inner_mapped = (*it_inner).second;
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         leaf_ids_.find(id_outer_mapped) != leaf_ids_.end() &&
             leaf_ids_.find(id_inner_mapped) != leaf_ids_.end(),
         "Transform traversal failed, modified ",
@@ -209,7 +209,7 @@ class ReplayRFactor : public ReplayTransformations {
     // rfactor indicating this transofrmation is static.
     if (static_rfactor_ids_.count(m->inner()) ||
         static_rfactor_ids_.count(m->outer())) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           static_rfactor_ids_.count(m->inner()) ==
               static_rfactor_ids_.count(m->outer()),
           "If one input to a merge is a static rfactor id, the other must be as well.");
@@ -218,12 +218,11 @@ class ReplayRFactor : public ReplayTransformations {
   }
 
   void handle(Resize* resize) override {
-    TORCH_INTERNAL_ASSERT(false, "Unexpected expression: ", resize->toString());
+    NVF_ERROR(false, "Unexpected expression: ", resize->toString());
   }
 
   void handle(Swizzle2D* swizzle) override {
-    TORCH_INTERNAL_ASSERT(
-        false, "Unexpected expression: ", swizzle->toString());
+    NVF_ERROR(false, "Unexpected expression: ", swizzle->toString());
   }
 
   // The IterDomains in the original_domain that are being factored into the
@@ -266,13 +265,13 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
     std::vector<int> axes) {
   FUSER_PERF_SCOPE("TransformRFactor::runReplay");
 
-  TORCH_CHECK(!axes.empty(), "No axes provided to rfactor replay.");
+  NVF_CHECK(!axes.empty(), "No axes provided to rfactor replay.");
 
   int ndims = (int)original_td->nDims();
 
   // Adjust and check provided axes
   std::transform(axes.begin(), axes.end(), axes.begin(), [ndims](int i) {
-    TORCH_CHECK(
+    NVF_CHECK(
         i >= -ndims && i < ndims,
         "Rfactor replay received an axis outside the number of dims in the tensor, acceptable inclusive range is ",
         -ndims,
@@ -284,7 +283,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
   // remove duplicates, and put into a set for searching
   std::unordered_set<int> axes_set(axes.begin(), axes.end());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       std::all_of(
           axes_set.begin(),
           axes_set.end(),
@@ -309,7 +308,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
     }
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       found_non_rfactor_reduction,
       "Must have at least one reduction axis not marked as rfactor.");
 
@@ -324,7 +323,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
   std::unordered_set<IterDomain*> rfactor_root_axes(
       rfactor_root_ids.begin(), rfactor_root_ids.end());
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       std::none_of(
           rfactor_root_ids.begin(),
           rfactor_root_ids.end(),
@@ -388,7 +387,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
     for (auto i : c10::irange(original_td->nDims())) {
       auto orig_id = original_td->axis((int)i);
       auto replayed_id_it = original_to_producer_id_map.find(orig_id);
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           replayed_id_it != original_to_producer_id_map.end(),
           "Error during rfactor replay, missing an axis.");
       auto replayed_id = replayed_id_it->second;
@@ -410,7 +409,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
       std::back_inserter(new_producer_rfactor_domain),
       [&](IterDomain* id) {
         auto replayed_id_it = original_to_producer_id_map.find(id);
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             replayed_id_it != original_to_producer_id_map.end(),
             "Error during rfactor replay, missing an axis.");
         return replayed_id_it->second;
@@ -439,7 +438,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
       continue;
     }
     auto p2o_it = producer_to_original_map.find(p_root_id);
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         p2o_it != producer_to_original_map.end(),
         "Missing mapping from original tensor domain to producer tensor domain.");
     auto original_id = p2o_it->second;

--- a/csrc/transform_rfactor.h
+++ b/csrc/transform_rfactor.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/all_nodes.h>
 #include <transform_iter.h>

--- a/csrc/transform_view.h
+++ b/csrc/transform_view.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <exceptions.h>
 
 #include <ir/all_nodes.h>
 

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -19,7 +19,7 @@
 namespace nvfuser {
 
 StructType NotImplementedStruct::type() const {
-  TORCH_INTERNAL_ASSERT(false, "Not implemented");
+  NVF_ERROR(false, "Not implemented");
 }
 
 StructType globalTensorMetaData(
@@ -70,7 +70,7 @@ StructType globalTensorMetaData(
 
 DataType metaDataTypeOf(const Val* v) {
   auto tv = dynamic_cast<const TensorView*>(v);
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       tv != nullptr, "Currently, only supports getting metadata of TensorView");
   if (tv->getMemoryType() == MemoryType::Shared) {
     // Smem tensor is defined locally as a pointer
@@ -91,7 +91,7 @@ PrimDataType indexModeToDtype(KernelIndexMode index_mode) {
     case KernelIndexMode::INT64:
       return DataType::Int;
     default:
-      TORCH_CHECK(false, "Invalid kernel index mode type.");
+      NVF_CHECK(false, "Invalid kernel index mode type.");
   }
 }
 
@@ -138,7 +138,7 @@ DataType getTypeFromComplexType(DataType dtype) {
     case DataType::ComplexDouble:
       return DataType::Double;
     default:
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           false,
           "Only support ComplexFloat and ComplexDouble, current type:",
           dtype);
@@ -154,8 +154,7 @@ DataType getComplexTypeFromType(DataType dtype) {
     case DataType::ComplexDouble:
       return DataType::ComplexDouble;
     default:
-      TORCH_INTERNAL_ASSERT(
-          false, "Only support Float and Double, current type:", dtype);
+      NVF_ERROR(false, "Only support Float and Double, current type:", dtype);
   }
 }
 
@@ -192,7 +191,7 @@ ValType promoteType(const ValType& t1, const ValType& t2) {
   if (t1 == ValType::NamedScalar && t2 == ValType::NamedScalar) {
     return ValType::Others;
   }
-  TORCH_CHECK(false, "Expected promotable ValTypes but got: ", t1, " and ", t2);
+  NVF_CHECK(false, "Expected promotable ValTypes but got: ", t1, " and ", t2);
 }
 
 static std::string data_type2string(DataType t) {
@@ -228,7 +227,7 @@ static std::string data_type2string(DataType t) {
             case DataType::ComplexDouble:
               return "std::complex<double>";
             default:
-              TORCH_INTERNAL_ASSERT(false, "No string found for data type.");
+              NVF_ERROR(false, "No string found for data type.");
           }
         } else if constexpr (std::is_same_v<T, PointerType>) {
           return data_type2string(*dtype.type) + "*";
@@ -255,9 +254,9 @@ static std::string data_type2string(DataType t) {
             return dtype.type_info.get().name();
           }
         } else {
-          TORCH_INTERNAL_ASSERT(false, "No string found for data type.");
+          NVF_ERROR(false, "No string found for data type.");
         }
-        TORCH_INTERNAL_ASSERT(false, "No string found for data type.");
+        NVF_ERROR(false, "No string found for data type.");
       },
       t.type);
 }
@@ -281,7 +280,7 @@ static const char* val_type2string(ValType t) {
     case ValType::PipelineVal:
       return "PipelineVal";
     default:
-      TORCH_INTERNAL_ASSERT(false, "No string found for val type.");
+      NVF_ERROR(false, "No string found for val type.");
   }
 }
 
@@ -306,7 +305,7 @@ const char* predicate_type2string(PredicateType t) {
     case PredicateType::LoopRotation:
       return "LoopRotation";
     default:
-      TORCH_INTERNAL_ASSERT(false, "No string found for predicate type.");
+      NVF_ERROR(false, "No string found for predicate type.");
   }
 }
 
@@ -454,7 +453,7 @@ static const char* unary_op_type2string(UnaryOpType t) {
     case UnaryOpType::ToUnsignedSmemAddr:
       return "toSmem";
     default:
-      TORCH_INTERNAL_ASSERT(false, "No string found for unary op type.");
+      NVF_ERROR(false, "No string found for unary op type.");
   }
 }
 
@@ -552,7 +551,7 @@ static const char* binary_op_type2string(BinaryOpType t) {
     case BinaryOpType::NE:
       return "notEqual";
     default:
-      TORCH_INTERNAL_ASSERT(false, "No string found for binary op type.");
+      NVF_ERROR(false, "No string found for binary op type.");
   }
 }
 
@@ -656,7 +655,7 @@ static const char* ternary_op_type2string(TernaryOpType t) {
     case TernaryOpType::Where:
       return "where";
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unexpected TernaryOpType");
+      NVF_ERROR(false, "Unexpected TernaryOpType");
   }
 }
 
@@ -671,7 +670,7 @@ static const char* rng_op_type2string(RNGOpType t) {
     case RNGOpType::NormalGeneral:
       return "rng_normal_general";
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unexpected RNGOpType");
+      NVF_ERROR(false, "Unexpected RNGOpType");
   }
 }
 
@@ -704,7 +703,7 @@ static const char* parallel_type2string(ParallelType t) {
     case ParallelType::Serial:
       return "S";
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unexpected ParallelType");
+      NVF_ERROR(false, "Unexpected ParallelType");
   }
 }
 
@@ -739,7 +738,7 @@ static const char* memory_type2string(MemoryType t) {
     case MemoryType::Global:
       return "global";
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unexpected MemoryType");
+      NVF_ERROR(false, "Unexpected MemoryType");
   }
 }
 
@@ -755,7 +754,7 @@ static const char* id_map_mode_type2string(IdMappingMode t) {
       return "loop";
     default:
       // Don't try to print t as it would recursively call this function
-      TORCH_INTERNAL_ASSERT(false, "Unexpected IdMappingMode Type.");
+      NVF_ERROR(false, "Unexpected IdMappingMode Type.");
   }
 }
 
@@ -779,7 +778,7 @@ static const char* iter_type2string(IterType t) {
       return "?";
     default:
       // Don't try to print t as it would recursively call this function
-      TORCH_INTERNAL_ASSERT(false, "Unexpected IterType");
+      NVF_ERROR(false, "Unexpected IterType");
   }
 }
 
@@ -798,7 +797,7 @@ static const char* thread_size2string(ParallelType t) {
     case ParallelType::TIDx:
       return "blockDim.x";
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unexpected parallel type");
+      NVF_ERROR(false, "Unexpected parallel type");
   }
 }
 
@@ -817,7 +816,7 @@ const char* load_store_type2string(LoadStoreOpType t) {
     case LoadStoreOpType::CpAsyncCg:
       return "CpAsyncCg";
     default:
-      TORCH_INTERNAL_ASSERT(false, "Unexpected parallel type");
+      NVF_ERROR(false, "Unexpected parallel type");
   }
 }
 
@@ -1013,7 +1012,7 @@ at::ScalarType data_type_to_aten(const DataType& data_type) {
     case DataType::Int:
       return at::ScalarType::Long;
     case DataType::Index:
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           false,
           "Index is determined at compile time,",
           " to convert from an aten type you need to have the compiled information. ",
@@ -1026,7 +1025,7 @@ at::ScalarType data_type_to_aten(const DataType& data_type) {
     case DataType::ComplexDouble:
       return at::ScalarType::ComplexDouble;
     default:
-      TORCH_INTERNAL_ASSERT(false, "No data type found for scalar type.");
+      NVF_ERROR(false, "No data type found for scalar type.");
   }
 }
 
@@ -1054,7 +1053,7 @@ std::ostream& operator<<(std::ostream& out, const ScatterOpType sotype) {
   if (sotype == ScatterOpType::Set) {
     return out << "scatter";
   }
-  TORCH_INTERNAL_ASSERT(false, "No scatterOp type found for scatterOp.");
+  NVF_ERROR(false, "No scatterOp type found for scatterOp.");
 }
 
 std::ostream& operator<<(std::ostream& out, const TernaryOpType totype) {
@@ -1102,7 +1101,7 @@ std::ostream& operator<<(std::ostream& os, const Swizzle2DType& swizzle) {
       os << "CyclicShift";
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "undefined 2D swizzle");
+      NVF_ERROR(false, "undefined 2D swizzle");
       break;
   }
   return os;
@@ -1120,7 +1119,7 @@ std::ostream& operator<<(std::ostream& os, const SwizzleMode& swizzle) {
       os << "Data";
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "undefined 2D swizzle");
+      NVF_ERROR(false, "undefined 2D swizzle");
       break;
   }
   return os;
@@ -1135,7 +1134,7 @@ std::ostream& operator<<(std::ostream& os, const KernelIndexMode& index_mode) {
       os << "INT64";
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "undefined index mode");
+      NVF_ERROR(false, "undefined index mode");
       break;
   }
   return os;
@@ -1210,7 +1209,7 @@ std::string typePrefix(const DataType data_type) {
     case DataType::ComplexDouble:
       return "c";
     default:
-      TORCH_INTERNAL_ASSERT(false, "No data type found for scalar type.");
+      NVF_ERROR(false, "No data type found for scalar type.");
   }
 }
 
@@ -1262,14 +1261,14 @@ int64_t dataTypeSize(DataType type) {
         } else if constexpr (std::is_same_v<T, OpaqueType>) {
           return dtype.size;
         }
-        TORCH_INTERNAL_ASSERT(false, "Size undefined for data type.");
+        NVF_ERROR(false, "Size undefined for data type.");
       },
       type.type);
 }
 
 int64_t dataTypeSize(DataType type, DataType index_type) {
   if (type == DataType::Index) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         index_type == DataType::Int32 || index_type == DataType::Int,
         "Invalid index type of ",
         index_type);
@@ -1294,7 +1293,7 @@ std::ostream& operator<<(
       os << "{DoubleBufferEpilog}";
       break;
     default:
-      TORCH_INTERNAL_ASSERT(false, "unknown double buffer stage");
+      NVF_ERROR(false, "unknown double buffer stage");
   }
   return os;
 }
@@ -1320,7 +1319,7 @@ int max_digits10(DataType dtype) {
   } else if (dtype == DataType::BFloat16) {
     return 4;
   } else {
-    TORCH_CHECK(
+    NVF_CHECK(
         !isFloatingPointType(dtype),
         "Unhandled floating point type in max_digits10 ",
         dtype);

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <macros.h>
 
 #include <c10/core/ScalarType.h>
@@ -136,7 +137,7 @@ struct StructType {
         return *field.type;
       }
     }
-    TORCH_INTERNAL_ASSERT(false, "Field ", name, " not found in struct ", name);
+    NVF_ERROR(false, "Field ", name, " not found in struct ", name);
   }
 
   inline bool operator==(const StructType& other) const;
@@ -407,14 +408,14 @@ inline DataType getDataType(const PolymorphicValue& value) {
       if (value.is<T>()) {
         const auto& vec = value.as<T>();
         size_t size = vec.size();
-        TORCH_CHECK(size > 0, "Empty array is not supported");
+        NVF_CHECK(size > 0, "Empty array is not supported");
         dtype =
             ArrayType{std::make_shared<DataType>(getDataType(vec[0])), size};
       }
     } else if constexpr (std::is_same_v<T, Pointer>) {
       // For pointers in polymorphic value, we only store the data size of the
       // pointee, so it is impossible to infer the pointer type.
-      TORCH_CHECK(!value.is<T>(), "Can not infer pointer type.");
+      NVF_CHECK(!value.is<T>(), "Can not infer pointer type.");
     } else if constexpr (std::is_same_v<T, StructHandle>) {
       if (value.is<T>()) {
         dtype = value.as<T>().type();
@@ -427,7 +428,7 @@ inline DataType getDataType(const PolymorphicValue& value) {
       }
     }
   });
-  TORCH_CHECK(dtype.has_value(), "Unknown dtype for ", value.type().name());
+  NVF_CHECK(dtype.has_value(), "Unknown dtype for ", value.type().name());
   return dtype.value();
 }
 
@@ -817,8 +818,7 @@ inline DataType promoteType(const DataType& t1, const DataType& t2) {
   if (isFloatingPointType(t2)) {
     return t2;
   }
-  TORCH_CHECK(
-      false, "Expected promotable DataTypes but got: ", t1, " and ", t2);
+  NVF_CHECK(false, "Expected promotable DataTypes but got: ", t1, " and ", t2);
 }
 
 #undef HANDLE_TYPE_PROMOTION
@@ -833,7 +833,7 @@ inline DataType promoteType(
 }
 
 inline DataType promoteType(const std::vector<DataType>& types) {
-  TORCH_CHECK(!types.empty(), "Can not promote empty type vector")
+  NVF_CHECK(!types.empty(), "Can not promote empty type vector")
   DataType result = types.at(0);
   for (const auto& t : types) {
     result = promoteType(result, t);
@@ -912,7 +912,7 @@ constexpr inline size_t primDataTypeSize(PrimDataType type) {
     case DataType::BFloat16:
       return sizeof(at::BFloat16);
     case DataType::Index:
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           false, "The actual type of Index is only known at compile time.");
     case DataType::Int:
       return sizeof(uint64_t);
@@ -921,7 +921,7 @@ constexpr inline size_t primDataTypeSize(PrimDataType type) {
     case DataType::SMemAddress:
       return sizeof(unsigned);
     default:
-      TORCH_INTERNAL_ASSERT(false, "Size undefined for data type.");
+      NVF_ERROR(false, "Size undefined for data type.");
   }
 }
 

--- a/csrc/type_inference.cpp
+++ b/csrc/type_inference.cpp
@@ -24,8 +24,7 @@ namespace nvfuser {
 namespace {
 
 at::ScalarType toAccumulateType(const torch::jit::TensorTypePtr& op) {
-  TORCH_INTERNAL_ASSERT(
-      op->scalarType().has_value(), "Missing Type Information.");
+  NVF_ERROR(op->scalarType().has_value(), "Missing Type Information.");
   return at::toAccumulateType(op->scalarType().value(), true /* is_cuda */);
 }
 
@@ -40,7 +39,7 @@ void copyScalarTypeAndDeviceToOutput(
     torch::jit::Node* node,
     size_t index = 0) {
   auto out = node->output(index)->type()->cast<at::TensorType>();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       out != nullptr,
       "Expect target node's type pointer to be non-nullptr, but get nullptr");
   if (!hasTypeAndDevice(out)) {
@@ -81,7 +80,7 @@ at::TensorTypePtr getInputTensorType(
   }
 
   // (not optional) implies (tensor_type not equal nullptr)
-  TORCH_CHECK(
+  NVF_CHECK(
       optional || tensor_type != nullptr,
       "Input ",
       index,
@@ -89,7 +88,7 @@ at::TensorTypePtr getInputTensorType(
       node->kind().toDisplayString(),
       " needs to be a tensor.");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       hasTypeAndDevice(tensor_type),
       "Input ",
       index,
@@ -287,13 +286,13 @@ class NaiveTypePropagator {
             c10::Symbol::fromQualString("aten::native_batch_norm_backward")) {
           mask_index = 9;
         } else {
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               false, "unidentified node kind", node->kind().toDisplayString());
         }
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto out_mask_list =
             torch::jit::constant_as<c10::List<bool>>(node->input(mask_index));
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             out_mask_list.has_value(),
             "Missing output mask for batch_norm_backward");
         std::vector<int> output_mask;
@@ -366,7 +365,7 @@ class NaiveTypePropagator {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto out_mask_list =
             torch::jit::constant_as<c10::List<bool>>(node->input(7));
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             out_mask_list.has_value(), "output mask for layer_norm_backward");
         std::vector<int> output_mask;
         for (const auto value : out_mask_list->vec()) {
@@ -411,7 +410,7 @@ class NaiveTypePropagator {
 
         const auto half_to_float =
             torch::jit::constant_as<bool>(node->input(2));
-        TORCH_CHECK(
+        NVF_CHECK(
             half_to_float.has_value(),
             "half_to_float bool doesn't have a value.");
         if (half_to_float.value()) {
@@ -448,7 +447,7 @@ class NaiveTypePropagator {
         const auto dims =
             torch::jit::constant_as<c10::List<int64_t>>(node->input(1));
         const auto keepdim = torch::jit::constant_as<bool>(node->input(2));
-        TORCH_CHECK(
+        NVF_CHECK(
             dims.has_value() && keepdim.has_value(),
             "Shape inference cannot handle options.");
         unary_reduce_type(node, out_type, dims->vec(), keepdim.value());
@@ -460,7 +459,7 @@ class NaiveTypePropagator {
         const auto dims =
             torch::jit::constant_as<c10::List<int64_t>>(node->input(1));
         const auto keepdim = torch::jit::constant_as<bool>(node->input(3));
-        TORCH_CHECK(
+        NVF_CHECK(
             dims.has_value() && keepdim.has_value(),
             "Shape inference cannot handle options.");
         unary_reduce_type(node, out_type, dims->vec(), keepdim.value());
@@ -503,7 +502,7 @@ class NaiveTypePropagator {
           copyScalarTypeAndDeviceToOutput(
               type0->withScalarType(out_dtype->toScalarType()), node);
         } else {
-          TORCH_CHECK(
+          NVF_CHECK(
               !out_dtype.has_value() || out_dtype->isNone(),
               "dtype for cast unrecognized ",
               out_dtype->tagKind());
@@ -516,13 +515,13 @@ class NaiveTypePropagator {
         // const auto type1 = getInputTensorType(node, 1, true);
         // note: add_optional is supposed to replace an inplace add on input0,
         // so we just directly forward dtype
-        TORCH_CHECK(type0 != nullptr);
+        NVF_CHECK(type0 != nullptr);
         copyScalarTypeAndDeviceToOutput(type0, node);
         break;
       }
       case at::aten::_autocast_to_reduced_precision: {
         const auto in_type = node->input(0)->type()->cast<at::TensorType>();
-        TORCH_CHECK(
+        NVF_CHECK(
             hasTypeAndDevice(in_type),
             "Type and device propagation has failed, or was not provided enough information.");
         const auto in_device = in_type->device();
@@ -532,7 +531,7 @@ class NaiveTypePropagator {
             torch::jit::constant_as<c10::ScalarType>(node->input(3));
         const auto cpu_dtype =
             torch::jit::constant_as<c10::ScalarType>(node->input(4));
-        TORCH_CHECK(
+        NVF_CHECK(
             cuda_enabled.has_value() && cpu_enabled.has_value() &&
                 cuda_dtype.has_value() && cpu_dtype.has_value(),
             "_autocast_to_reduced_precision requires all scalar inputs to be constant.");
@@ -552,14 +551,14 @@ class NaiveTypePropagator {
       }
       case at::aten::_autocast_to_full_precision: {
         const auto in_type = node->input(0)->type()->cast<at::TensorType>();
-        TORCH_CHECK(
+        NVF_CHECK(
             hasTypeAndDevice(in_type),
             "Type and device propagation has failed, or was not provided enough information.");
         const auto in_scalar_type = in_type->scalarType();
         const auto in_device = in_type->device();
         const auto cuda_enabled = torch::jit::constant_as<bool>(node->input(1));
         const auto cpu_enabled = torch::jit::constant_as<bool>(node->input(2));
-        TORCH_CHECK(
+        NVF_CHECK(
             cuda_enabled.has_value() && cpu_enabled.has_value(),
             "_autocast_to_full_precision requires enable flag to be constant.");
 
@@ -575,7 +574,7 @@ class NaiveTypePropagator {
         break;
       }
       default:
-        TORCH_CHECK(
+        NVF_CHECK(
             false,
             "type inference failed, unrecognized operation encountered:",
             node->kind().toDisplayString());
@@ -608,7 +607,7 @@ class NaiveTypePropagator {
       const torch::jit::TensorTypePtr& op,
       const std::vector<int64_t>& dims,
       bool keepdim) {
-    TORCH_CHECK(
+    NVF_CHECK(
         hasTypeAndDevice(op),
         "Type and device propagation has failed, or was not provided enough information.");
     copyScalarTypeAndDeviceToOutput(op, node);
@@ -621,7 +620,7 @@ class NaiveTypePropagator {
     auto op1 = node->input(1)->type();
     auto op0_tensor_type = op0->cast<at::TensorType>();
     auto op1_tensor_type = op1->cast<at::TensorType>();
-    TORCH_CHECK(
+    NVF_CHECK(
         hasTypeAndDevice(op0_tensor_type) || hasTypeAndDevice(op1_tensor_type),
         "At least one operand must be a tensor.");
     auto ptr = (op0_tensor_type != nullptr) ? op0_tensor_type : op1_tensor_type;
@@ -636,14 +635,14 @@ class NaiveTypePropagator {
       torch::jit::TensorTypePtr const& op1,
       std::optional<at::ScalarType> scalar_type = std::nullopt) {
     torch::jit::TensorTypePtr out;
-    TORCH_CHECK(
+    NVF_CHECK(
         op0 != nullptr || op1 != nullptr,
         "Scalar operations on binary broadcast type, not supported yet.");
 
     c10::ScalarType promoted_scalar_type = c10::ScalarType::Undefined;
     c10::optional<c10::Device> device;
     if (op0 != nullptr && op1 != nullptr) {
-      TORCH_CHECK(
+      NVF_CHECK(
           hasTypeAndDevice(op0) && hasTypeAndDevice(op1),
           "Type and device propagation has failed, or was not provided enough information.");
       promoted_scalar_type = scalar_type.has_value()
@@ -652,7 +651,7 @@ class NaiveTypePropagator {
       device = *op0->device();
     } else {
       auto ptr = (op0 != nullptr) ? op0 : op1;
-      TORCH_CHECK(
+      NVF_CHECK(
           hasTypeAndDevice(ptr),
           "Type and device propagation has failed, or was not provided enough information.");
       promoted_scalar_type =

--- a/csrc/type_inference.h
+++ b/csrc/type_inference.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ATen/Context.h>
+#include <exceptions.h>
 #include <torch/csrc/jit/ir/ir.h>
 
 namespace nvfuser {

--- a/csrc/type_promotion.cpp
+++ b/csrc/type_promotion.cpp
@@ -108,7 +108,7 @@ DataType computeCommonDtype(const std::vector<OperandType>& operands) {
     }
   }
   auto common_dtype = resultType(state);
-  TORCH_INTERNAL_ASSERT(common_dtype != DataType::Null);
+  NVF_ERROR(common_dtype != DataType::Null);
   return common_dtype;
 }
 
@@ -141,7 +141,7 @@ DataType computeTypes(
 
   // Some ops like nextafter are not implemented for non-float types
   if (config.require_full_precision_promoted) {
-    TORCH_CHECK(
+    NVF_CHECK(
         common_dtype == DataType::Float || common_dtype == DataType::Double,
         "Promoted type must be single or double precision float but found ",
         common_dtype);
@@ -152,7 +152,7 @@ DataType computeTypes(
 
 OperandType getValueType(at::TypePtr type) {
   if (auto tensor_type = type->cast<at::TensorType>()) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         tensor_type->scalarType().has_value(),
         "Missing Scalar Type information");
     // TODO: Type Inference does not propagate Shape Information
@@ -168,7 +168,7 @@ OperandType getValueType(at::TypePtr type) {
 }
 
 OperandType getValueType(Val* type) {
-  TORCH_INTERNAL_ASSERT(type->getDataType().has_value());
+  NVF_ERROR(type->getDataType().has_value());
 
   if (type->isA<TensorView>()) {
     auto tensor_view = type->as<TensorView>();
@@ -225,7 +225,7 @@ std::vector<Val*> promoteValues(
     promoted_operands.push_back(optionalCast(common_type, op));
   }
 
-  TORCH_INTERNAL_ASSERT(operands.size() == promoted_operands.size());
+  NVF_ERROR(operands.size() == promoted_operands.size());
   return promoted_operands;
 }
 
@@ -236,7 +236,7 @@ std::vector<Val*> promoteValues(
 }
 
 Val* optionalCast(DataType dtype, Val* v) {
-  TORCH_INTERNAL_ASSERT(v->getDataType().has_value());
+  NVF_ERROR(v->getDataType().has_value());
   // Avoid casting Float/Int/ComplexDouble scalar to any corresponding
   // FloatingPoint/Integral/Double type in fusion. Instead, we cast them
   // directly. The exception is Bool, which is always cast to the desired
@@ -257,7 +257,7 @@ Val* optionalCast(DataType dtype, Val* v) {
 }
 
 Val* optionalCastStrict(DataType dtype, Val* v) {
-  TORCH_INTERNAL_ASSERT(v->getDataType().has_value());
+  NVF_ERROR(v->getDataType().has_value());
   const bool kSameDtype = v->getDataType().value() == dtype;
   return (kSameDtype) ? v : castOp(dtype, v);
 }

--- a/csrc/type_promotion.h
+++ b/csrc/type_promotion.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <exceptions.h>
 #include <ir/interface_nodes.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <type.h>

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -118,7 +118,7 @@ int8_t getCommonDeviceCUDA(
     if (device.is_cpu() && is_cpu_scalar(input.toTensor())) {
       continue;
     }
-    TORCH_CHECK(device.is_cuda(), "nvfuser only supports cuda device");
+    NVF_CHECK(device.is_cuda(), "nvfuser only supports cuda device");
     auto cur_index = device.index();
     if (found_device && index != cur_index) {
       return -1;
@@ -141,9 +141,9 @@ bool useFallback() {
 }
 
 std::vector<int64_t> getTensorSizes(at::TensorTypePtr const& tensor_type) {
-  TORCH_INTERNAL_ASSERT(tensor_type != nullptr, "Input must be a Tensor.");
+  NVF_ERROR(tensor_type != nullptr, "Input must be a Tensor.");
   auto optional_sizes = tensor_type->sizes().concrete_sizes();
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       optional_sizes.has_value(), "Missing size information for the tensor.");
   return optional_sizes.value();
 }

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -9,6 +9,7 @@
 
 #include <ATen/ATen.h>
 #include <c10/util/Exception.h>
+#include <exceptions.h>
 #include <torch/csrc/jit/ir/ir.h>
 
 #include <debug.h>
@@ -95,7 +96,7 @@ class PolymorphicBase {
     auto downcast_ptr = static_cast<T*>(this);
 #else
     auto downcast_ptr = dynamic_cast<T*>(this);
-    TORCH_INTERNAL_ASSERT(downcast_ptr != nullptr);
+    NVF_ERROR(downcast_ptr != nullptr);
 #endif
     return downcast_ptr;
   }
@@ -106,7 +107,7 @@ class PolymorphicBase {
     auto downcast_ptr = static_cast<const T*>(this);
 #else
     auto downcast_ptr = dynamic_cast<const T*>(this);
-    TORCH_INTERNAL_ASSERT(downcast_ptr != nullptr);
+    NVF_ERROR(downcast_ptr != nullptr);
 #endif
     return downcast_ptr;
   }
@@ -402,8 +403,7 @@ class KernelIndexTypeCompute {
   // Updates counters and returns current reqd mode
   inline PrimDataType addDim(int64_t size, int64_t stride) {
     if (size > 1) {
-      TORCH_INTERNAL_ASSERT(
-          stride >= 0, "Negative stride is not supported: ", stride);
+      NVF_ERROR(stride >= 0, "Negative stride is not supported: ", stride);
       if (stride > 0) {
         // Accumulate positive stride
         tensor_most_positive_index_ += (size - 1) * stride;

--- a/examples/sinh_libtorch/main.cpp
+++ b/examples/sinh_libtorch/main.cpp
@@ -1,3 +1,4 @@
+#include <csrc/exceptions.h>
 #include <executor.h>
 #include <ops/arith.h>
 #include <scheduler/all_schedulers.h>
@@ -37,6 +38,6 @@ int main() {
   auto output = sinh_nvfuser(t);
   std::cout << "Expected:" << std::endl << expected << std::endl;
   std::cout << "Output:" << std::endl << output << std::endl;
-  TORCH_CHECK(at::allclose(expected, output));
+  NVF_CHECK(at::allclose(expected, output));
   std::cout << "They match!" << std::endl;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,3 +1,4 @@
+#include <csrc/exceptions.h>
 #include <gtest/gtest.h>
 
 #include <torch/cuda.h>
@@ -19,7 +20,7 @@ std::string add_negative_flag(const std::string& flag) {
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
-  TORCH_CHECK(
+  NVF_CHECK(
       torch::cuda::is_available(),
       "nvfuser_tests requires CUDA device being available");
 

--- a/test/rng_kernels.cu
+++ b/test/rng_kernels.cu
@@ -10,6 +10,7 @@
 // dynamic_type.h with nvcc is not supported.
 
 #include <ATen/cuda/CUDAGeneratorImpl.h>
+#include <csrc/exceptions.h>
 #include <torch/torch.h>
 #include <ATen/cuda/CUDAGraphsUtils.cuh>
 
@@ -108,7 +109,7 @@ at::Tensor generate_random_numbers(
         at::cuda::getCurrentCUDAStream()>>>(
         result.data_ptr<float>(), size, rng_engine_inputs, rng_test);
   } else {
-    TORCH_CHECK(dtype == at::kDouble);
+    NVF_CHECK(dtype == at::kDouble);
     int64_t block = 128;
     int64_t block_elems = block * 2;
     int64_t grid = (size + block_elems - 1) / block_elems;

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -351,7 +351,7 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Stride mismatch with contiguity info")));
 
   auto cg_outputs = fe.runFusion({t0});
@@ -412,7 +412,7 @@ TEST_F(AllocationDomainTest, NHWC1d_To_NHWC4d_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "splitting one dimension into discontiguous dimensions is not allowed in allocation domain")));
 
   auto cg_outputs = fe.runFusion({t0});
@@ -468,7 +468,7 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC1d_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Stride mismatch with contiguity info")));
 
   auto cg_outputs = fe.runFusion({t0});
@@ -529,7 +529,7 @@ TEST_F(AllocationDomainTest, NHWC1d_To_NHWC1d_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "splitting one dimension into discontiguous dimensions is not")));
 
   auto cg_outputs = fe.runFusion({t0});
@@ -597,7 +597,7 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "splitting one dimension into discontiguous dimensions is not allowed in allocation domain")));
 
   auto cg_outputs = fe.runFusion({t0});
@@ -664,7 +664,7 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d_cacheBefore_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Stride mismatch with contiguity info")));
 
   auto cg_outputs = fe.runFusion({t0});
@@ -741,7 +741,7 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_cacheBefore_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "splitting one dimension into discontiguous dimensions is not allowed in allocation domain")));
 
   auto cg_outputs = fe.runFusion({t0});
@@ -808,7 +808,7 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d_cacheAfter_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Stride mismatch with contiguity info")));
 
   auto cg_outputs = fe.runFusion({t0});
@@ -879,7 +879,7 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_cacheAfter_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "merging of discontiguous dimensions is not allowed in allocation domain")));
 
   auto cg_outputs = fe.runFusion({t0});
@@ -953,7 +953,7 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d_cacheFork_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Stride mismatch with contiguity info")));
 
   auto cg_outputs = fe.runFusion({t0});
@@ -1043,7 +1043,7 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_cacheFork_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion({t0_wrong_format}); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "splitting one dimension into discontiguous dimensions is not allowed in allocation domain")));
 
   auto cg_outputs = fe.runFusion({t0});

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -1,3 +1,4 @@
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -423,7 +424,7 @@ TEST_F(NVFuserTest, CombinedSchedulerSharedConsumer_CUDA) {
       aten_out_linked = aten_out_linked.mul(0.5);
     }
     bool is_segmented = fec.getMostRecentKernelRuntime()->isSegmented();
-    TORCH_CHECK(is_segmented, "Fusion is not segmented");
+    NVF_CHECK(is_segmented, "Fusion is not segmented");
 
     testValidate(
         &fusion,
@@ -556,7 +557,7 @@ TEST_F(NVFuserTest, CombinedSchedulerSharedProducer_CUDA) {
         fusion.addOutput(use_producer_2);
       } break;
       default:
-        TORCH_INTERNAL_ASSERT(false, "Invalid case id");
+        NVF_ERROR(false, "Invalid case id");
     }
 
     fusion.addOutput(layer_norm_results.grad_input);
@@ -625,10 +626,10 @@ TEST_F(NVFuserTest, CombinedSchedulerSharedProducer_CUDA) {
         expected_segmented = true;
       } break;
       default:
-        TORCH_INTERNAL_ASSERT(false, "Invalid case id");
+        NVF_ERROR(false, "Invalid case id");
     }
     bool is_segmented = fec.getMostRecentKernelRuntime()->isSegmented();
-    TORCH_CHECK(
+    NVF_CHECK(
         is_segmented == expected_segmented,
         expected_segmented ? "Fusion should be segmented!"
                            : "Fusion should not be segmented!");

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -41,14 +42,14 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
   fusion.addOutput(tv3);
 
   // tv2 has symbolic axes as reshape is dynamic
-  TORCH_CHECK(
+  NVF_CHECK(
       tv2->domain()->hasSymbolicAxis(),
       "Expected to have symbolic axes: ",
       tv2->toString());
 
   // The symbolic axes of tv2 should not be propagated to tv3 as tv1
   // is fully concrete
-  TORCH_CHECK(
+  NVF_CHECK(
       !tv3->domain()->hasSymbolicAxis(),
       "Not expected to have symbolic axes: ",
       tv3->toString());
@@ -65,7 +66,7 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
 
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
     auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
-    TORCH_CHECK(
+    NVF_CHECK(
         info.getReshapeTransforms().size() == 1,
         "Expected to have one reshape transform: ",
         info.toString());
@@ -149,7 +150,7 @@ TEST_F(NVFuserTest, DynamicTransform2_CUDA) {
     auto initial_info = DynamicTransform::getInitialInfo(&fusion);
     auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         info.getReshapeTransforms().size() == 1,
         "Expected to have one reshape transform: ",
         info.toString());
@@ -191,7 +192,7 @@ TEST_F(NVFuserTest, DynamicTransform3_CUDA) {
   auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
   DynamicTransform::concretizeFusion(&fusion, &info);
-  TORCH_CHECK(
+  NVF_CHECK(
       !fusion.hasDynamicTransform(), "Expected to have no dynamic transform");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -257,7 +258,7 @@ TEST_F(NVFuserTest, DynamicTransform4_CUDA) {
 
     DynamicTransform::concretizeFusion(&fusion, &info);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         !fusion.hasDynamicTransform(), "Expected to have no dynamic transform");
   }
 }
@@ -305,7 +306,7 @@ TEST_F(NVFuserTest, DynamicTransform5_CUDA) {
 
     DynamicTransform::concretizeFusion(&fusion, &info);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         !fusion.hasDynamicTransform(), "Expected to have no dynamic transform");
   }
 }
@@ -358,7 +359,7 @@ TEST_F(NVFuserTest, DynamicTransform6_CUDA) {
 
     DynamicTransform::concretizeFusion(&fusion, &info);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         !fusion.hasDynamicTransform(), "Expected to have no dynamic transform");
   }
 }
@@ -438,7 +439,7 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
         DynamicTransformConcretizationInfo(&ref_initial_info, &ref_expr_eval);
 
     for (const auto& transform : pattern.equal_transforms) {
-      TORCH_CHECK(transform.shapes.size() == ref_transform.shapes.size());
+      NVF_CHECK(transform.shapes.size() == ref_transform.shapes.size());
       ExpressionEvaluator expr_eval;
       for (const auto i : c10::irange(transform.shapes.size())) {
         const auto& shape = transform.shapes.at(i);
@@ -451,7 +452,7 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
       auto initial_info = DynamicTransform::getInitialInfo(&fusion);
       auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
-      TORCH_CHECK(
+      NVF_CHECK(
           ref_info == info,
           "Expected to be equal: ",
           ref_info.toString(),
@@ -460,7 +461,7 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
     }
 
     for (const auto& transform : pattern.different_transforms) {
-      TORCH_CHECK(transform.shapes.size() == ref_transform.shapes.size());
+      NVF_CHECK(transform.shapes.size() == ref_transform.shapes.size());
       ExpressionEvaluator expr_eval;
       for (const auto i : c10::irange(transform.shapes.size())) {
         const auto& shape = transform.shapes.at(i);
@@ -473,7 +474,7 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
       auto initial_info = DynamicTransform::getInitialInfo(&fusion);
       auto info = DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
 
-      TORCH_CHECK(
+      NVF_CHECK(
           ref_info != info,
           "Expected to be different: ",
           ref_info.toString(),
@@ -496,7 +497,7 @@ TEST_F(NVFuserTest, DynamicTransform8_CUDA) {
   fusion.addOutput(tv1);
 
   // Make sure the reshape is recognized as a static reshape
-  TORCH_CHECK(
+  NVF_CHECK(
       !tv1->domain()->hasSymbolicAxis(),
       "Not expected to have symbolic axes: ",
       tv1->toString());
@@ -519,12 +520,12 @@ TEST_F(NVFuserTest, DynamicTransform9_CUDA) {
   fusion.addOutput(tv2);
 
   // The first reshape is static
-  TORCH_CHECK(
+  NVF_CHECK(
       !tv1->domain()->hasSymbolicAxis(),
       "Unexpected to have symblic axes: ",
       tv1->toString());
   // The second reshape is static
-  TORCH_CHECK(
+  NVF_CHECK(
       tv2->domain()->hasSymbolicAxis(),
       "Expected to have symblic axes: ",
       tv2->toString());
@@ -540,7 +541,7 @@ TEST_F(NVFuserTest, DynamicTransform9_CUDA) {
 
   // There must be only one dynamic reshape entry, and that must be
   // for tv2.
-  TORCH_CHECK(
+  NVF_CHECK(
       info.getReshapeTransforms().size() == 1,
       info.getReshapeTransforms().at(0).first == 0, // first and only reshape
       "Unexpected dynamic transform info:",
@@ -582,7 +583,7 @@ TEST_F(NVFuserTest, DynamicTransform10_CUDA) {
 
   DynamicTransform::concretizeFusion(&fusion, &info);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !fusion.hasDynamicTransform(), "Expected to have no dynamic transform");
 }
 
@@ -632,7 +633,7 @@ TEST_F(NVFuserTest, DynamicTransform11_CUDA) {
   // hashes, but in this case they should be different
   auto hash1 = std::hash<DynamicTransformConcretizationInfo>{}(info1);
   auto hash2 = std::hash<DynamicTransformConcretizationInfo>{}(info2);
-  TORCH_CHECK(
+  NVF_CHECK(
       hash1 != hash2,
       "Unexpected hash collision: ",
       hash1,
@@ -658,21 +659,21 @@ TEST_F(NVFuserTest, DynamicTransformFusionExecutorCache_CUDA) {
   fusion->addOutput(tv3);
 
   // tv2 has symbolic axes as reshape is dynamic
-  TORCH_CHECK(
+  NVF_CHECK(
       tv2->domain()->hasSymbolicAxis(),
       "Expected to have symbolic axes: ",
       tv2->toString());
 
   // The symbolic axes of tv2 should not be propagated to tv3 as tv1
   // is fully concrete
-  TORCH_CHECK(
+  NVF_CHECK(
       !tv3->domain()->hasSymbolicAxis(),
       "Not expected to have symbolic axes: ",
       tv3->toString());
 
   FusionExecutorCache executor_cache(std::move(fusion));
 
-  TORCH_CHECK(
+  NVF_CHECK(
       executor_cache.countRuntimes() == 0, "Expect to start with no runtimes");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -684,7 +685,7 @@ TEST_F(NVFuserTest, DynamicTransformFusionExecutorCache_CUDA) {
     auto ref = t0 + t1;
     testValidate(
         executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
-    TORCH_CHECK(
+    NVF_CHECK(
         executor_cache.countRuntimes() == 1,
         "Expect to create a single runtime");
   }
@@ -698,8 +699,8 @@ TEST_F(NVFuserTest, DynamicTransformFusionExecutorCache_CUDA) {
         executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
     auto num_rts = executor_cache.countRuntimes();
     auto num_concs = executor_cache.countConcretizations();
-    TORCH_CHECK(num_rts == 2, "Non-trivial reshape should create new runtime");
-    TORCH_CHECK(
+    NVF_CHECK(num_rts == 2, "Non-trivial reshape should create new runtime");
+    NVF_CHECK(
         num_concs == 2,
         "Non-trivial reshape should create new concretization cache level");
   }
@@ -713,10 +714,10 @@ TEST_F(NVFuserTest, DynamicTransformFusionExecutorCache_CUDA) {
         executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
     auto num_rts = executor_cache.countRuntimes();
     auto num_concs = executor_cache.countConcretizations();
-    TORCH_CHECK(
+    NVF_CHECK(
         num_rts == 2,
         "Second non-trivial reshape should not create new runtime");
-    TORCH_CHECK(
+    NVF_CHECK(
         num_concs == 2,
         "Second non-trivial reshape should not create new concretization cache level");
   }
@@ -790,8 +791,8 @@ void reductionDynamicViewAddFusion(
     auto output_shape = std::get<1>(inv);
     auto expect_miss = std::get<2>(inv);
 
-    TORCH_INTERNAL_ASSERT(input_shape.size() == input_dims);
-    TORCH_INTERNAL_ASSERT(output_shape.size() == output_dims);
+    NVF_ERROR(input_shape.size() == input_dims);
+    NVF_ERROR(output_shape.size() == output_dims);
 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
@@ -895,7 +896,7 @@ void reductionDynamicPadAddFusion(
 #define CHECK_CACHE(expect_miss, ...)                              \
   auto current = fusion_executor_cache.getKernelRuntimes().size(); \
   auto expected = num_concretizations + (size_t)expect_miss;       \
-  TORCH_CHECK(                                                     \
+  NVF_CHECK(                                                       \
       current == expected,                                         \
       "Expected cache size ",                                      \
       expected,                                                    \
@@ -916,8 +917,8 @@ void reductionDynamicPadAddFusion(
     auto pad_widths = std::get<1>(inv);
     auto expect_miss = std::get<2>(inv);
 
-    TORCH_INTERNAL_ASSERT(input_shape.size() == input_dims);
-    TORCH_INTERNAL_ASSERT(pad_widths.size() == num_pad_widths);
+    NVF_ERROR(input_shape.size() == input_dims);
+    NVF_ERROR(pad_widths.size() == num_pad_widths);
 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -90,7 +90,7 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
           auto info =
               DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
         },
-        ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+        ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
             "Values of -1 passed to reshape must be constant at definition")));
   }
 
@@ -111,7 +111,7 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
           auto info =
               DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
         },
-        ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+        ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
             "Total element counts across view operation must match.")));
   }
 }

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -418,7 +418,7 @@ TEST_F(ExprEvalTest, Validation) {
 
   EXPECT_THAT(
       [&]() { evaluator.bind(c, 4L, true); },
-      ::testing::ThrowsMessage<c10::Error>(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Tried to bind to a value: ")));
   EXPECT_EQ(evaluator.evaluate(c), 299792459L);
   evaluator.bind(d, 299792460L, true);

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -316,7 +317,7 @@ TEST_F(ExprEvalTest, Struct) {
       } else if (key == "b") {
         return [this]() { return PolymorphicValue(b); };
       } else {
-        TORCH_INTERNAL_ASSERT(false, "Invalid key");
+        NVF_ERROR(false, "Invalid key");
       }
     }
 
@@ -327,7 +328,7 @@ TEST_F(ExprEvalTest, Struct) {
       } else if (key == "b") {
         return [this](const PolymorphicValue& value) { b = (int64_t)value; };
       } else {
-        TORCH_INTERNAL_ASSERT(false, "Invalid key");
+        NVF_ERROR(false, "Invalid key");
       }
     }
   };

--- a/test/test_exceptions.cpp
+++ b/test/test_exceptions.cpp
@@ -1,5 +1,5 @@
 // This is a refactor of the tests used for PyTorch macros --
-// TORCH_INTERNAL_ASSERT and TORCH_CHECK.
+// NVF_ERROR and NVF_CHECK.
 
 #include <csrc/exceptions.h>
 #include <gtest/gtest.h>

--- a/test/test_external_src.cpp
+++ b/test/test_external_src.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -88,7 +89,7 @@ TEST_F(ExternalSrcExample, Reduction_CUDA) {
     auto fusion_out = t7.to(at::kFloat);
     std::cout << "Max diff: " << (ref - fusion_out).abs().max().item<float>()
               << std::endl;
-    TORCH_CHECK(ref.allclose(fusion_out, /*rtol*/ 0.005, /*atol*/ 0.5));
+    NVF_CHECK(ref.allclose(fusion_out, /*rtol*/ 0.005, /*atol*/ 0.5));
   }
 }
 
@@ -134,7 +135,7 @@ TEST_F(ExternalSrcExample, Matmul_CUDA) {
 
     std::cout << "Max diff: " << (at_output - output).abs().max().item<float>()
               << std::endl;
-    TORCH_CHECK(at_output.allclose(output, /*rtol*/ 0.005, /*atol*/ 0.5));
+    NVF_CHECK(at_output.allclose(output, /*rtol*/ 0.005, /*atol*/ 0.5));
   }
 }
 

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -68,9 +69,9 @@ TEST_F(NVFuserTest, FusionIrGraphGenerator_CUDA) {
   FusionGuard fg(&fusion);
 
   // Make sure we can handle empty IRs
-  TORCH_CHECK(!IrGraphGenerator::toGraphviz(
-                   &fusion, IrGraphGenerator::DetailLevel::Basic)
-                   .empty());
+  NVF_CHECK(!IrGraphGenerator::toGraphviz(
+                 &fusion, IrGraphGenerator::DetailLevel::Basic)
+                 .empty());
 
   // Construct an interesting IR
   TensorView* tv0 = makeSymbolicTensor(2);
@@ -85,9 +86,9 @@ TEST_F(NVFuserTest, FusionIrGraphGenerator_CUDA) {
   TensorView* tv6 = add(tv2, tv2);
 
   // Another checkpoint before adding outputs
-  TORCH_CHECK(!IrGraphGenerator::toGraphviz(
-                   &fusion, IrGraphGenerator::DetailLevel::Explicit)
-                   .empty());
+  NVF_CHECK(!IrGraphGenerator::toGraphviz(
+                 &fusion, IrGraphGenerator::DetailLevel::Explicit)
+                 .empty());
 
   fusion.addOutput(tv6);
 
@@ -99,9 +100,9 @@ TEST_F(NVFuserTest, FusionIrGraphGenerator_CUDA) {
   tv2->computeAt(tv6, 1);
 
   // Another checkpoint with more node types
-  TORCH_CHECK(!IrGraphGenerator::toGraphviz(
-                   &fusion, IrGraphGenerator::DetailLevel::ComputeOnly)
-                   .empty());
+  NVF_CHECK(!IrGraphGenerator::toGraphviz(
+                 &fusion, IrGraphGenerator::DetailLevel::ComputeOnly)
+                 .empty());
 
   for (Val* val : fusion.vals()) {
     if (!val->isFusionInput() &&
@@ -112,9 +113,9 @@ TEST_F(NVFuserTest, FusionIrGraphGenerator_CUDA) {
   }
 
   // Final IR graph
-  TORCH_CHECK(!IrGraphGenerator::toGraphviz(
-                   &fusion, IrGraphGenerator::DetailLevel::Verbose)
-                   .empty());
+  NVF_CHECK(!IrGraphGenerator::toGraphviz(
+                 &fusion, IrGraphGenerator::DetailLevel::Verbose)
+                 .empty());
 }
 
 TEST_F(NVFuserTest, FusionDispatch_CUDA) {
@@ -126,7 +127,7 @@ TEST_F(NVFuserTest, FusionDispatch_CUDA) {
   ss1 << f;
   ss2 << static_cast<Val*>(f);
   ss3 << static_cast<Statement*>(f);
-  TORCH_CHECK(
+  NVF_CHECK(
       ss1.str().compare(ss2.str()) == 0 && ss1.str().compare(ss3.str()) == 0,
       "Error with dispatch system where results differ by passing Val* vs Val* vs Statement*.");
 }
@@ -162,13 +163,13 @@ TEST_F(NVFuserTest, FusionClear_CUDA) {
 
   fusion.clear();
 
-  TORCH_CHECK(fusion.unordered_exprs().empty());
-  TORCH_CHECK(fusion.vals().empty());
+  NVF_CHECK(fusion.unordered_exprs().empty());
+  NVF_CHECK(fusion.vals().empty());
 
-  TORCH_CHECK(fusion.inputs().empty());
-  TORCH_CHECK(fusion.outputs().empty());
+  NVF_CHECK(fusion.inputs().empty());
+  NVF_CHECK(fusion.outputs().empty());
 
-  TORCH_CHECK(ir_utils::getReductionOps(&fusion).empty());
+  NVF_CHECK(ir_utils::getReductionOps(&fusion).empty());
 
   // 3. Rebuild the IR
 
@@ -206,7 +207,7 @@ TEST_F(NVFuserTest, FusionClear_CUDA) {
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
 
-  TORCH_CHECK(output_ref.equal(outputs[0]));
+  NVF_CHECK(output_ref.equal(outputs[0]));
 }
 
 TEST_F(NVFuserTest, FusionCopy_CUDA) {
@@ -325,10 +326,10 @@ TEST_F(NVFuserTest, FusionMove_CUDA) {
   //    standard library containers:
   //    https://en.cppreference.com/w/cpp/utility/move
   //
-  TORCH_CHECK(fusion.unordered_exprs().empty());
-  TORCH_CHECK(fusion.vals().empty());
-  TORCH_CHECK(fusion.inputs().empty());
-  TORCH_CHECK(fusion.outputs().empty());
+  NVF_CHECK(fusion.unordered_exprs().empty());
+  NVF_CHECK(fusion.vals().empty());
+  NVF_CHECK(fusion.inputs().empty());
+  NVF_CHECK(fusion.outputs().empty());
 
   // clear() has no pre-conditions so it's valid to call on a moved-from object
   fusion.clear();
@@ -377,7 +378,7 @@ TEST_F(NVFuserTest, FusionSimpleArith_CUDA) {
   IrBuilder::create<BinaryOp>(BinaryOpType::Add, d3, d1, d2);
   ss1 << fusion;
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ss1.str().compare(ss2.str()) == 0,
       "Error where explicit add nodes don't match implicit add nodes.");
 }
@@ -391,25 +392,25 @@ TEST_F(NVFuserTest, FusionScalarTypePromote_CUDA) {
   Val* i = IrBuilder::create<Val>(3L);
   Val* c = IrBuilder::create<Val>(std::complex<double>(1, 2));
 
-  TORCH_CHECK(add(b, b)->getDataType() == DataType::Bool);
-  TORCH_CHECK(add(b, d)->getDataType() == DataType::Double);
-  TORCH_CHECK(add(b, i)->getDataType() == DataType::Int);
-  TORCH_CHECK(add(b, c)->getDataType() == DataType::ComplexDouble);
+  NVF_CHECK(add(b, b)->getDataType() == DataType::Bool);
+  NVF_CHECK(add(b, d)->getDataType() == DataType::Double);
+  NVF_CHECK(add(b, i)->getDataType() == DataType::Int);
+  NVF_CHECK(add(b, c)->getDataType() == DataType::ComplexDouble);
 
-  TORCH_CHECK(add(d, b)->getDataType() == DataType::Double);
-  TORCH_CHECK(add(d, d)->getDataType() == DataType::Double);
-  TORCH_CHECK(add(d, i)->getDataType() == DataType::Double);
-  TORCH_CHECK(add(d, c)->getDataType() == DataType::ComplexDouble);
+  NVF_CHECK(add(d, b)->getDataType() == DataType::Double);
+  NVF_CHECK(add(d, d)->getDataType() == DataType::Double);
+  NVF_CHECK(add(d, i)->getDataType() == DataType::Double);
+  NVF_CHECK(add(d, c)->getDataType() == DataType::ComplexDouble);
 
-  TORCH_CHECK(add(i, b)->getDataType() == DataType::Int);
-  TORCH_CHECK(add(i, d)->getDataType() == DataType::Double);
-  TORCH_CHECK(add(i, i)->getDataType() == DataType::Int);
-  TORCH_CHECK(add(i, c)->getDataType() == DataType::ComplexDouble);
+  NVF_CHECK(add(i, b)->getDataType() == DataType::Int);
+  NVF_CHECK(add(i, d)->getDataType() == DataType::Double);
+  NVF_CHECK(add(i, i)->getDataType() == DataType::Int);
+  NVF_CHECK(add(i, c)->getDataType() == DataType::ComplexDouble);
 
-  TORCH_CHECK(add(c, b)->getDataType() == DataType::ComplexDouble);
-  TORCH_CHECK(add(c, d)->getDataType() == DataType::ComplexDouble);
-  TORCH_CHECK(add(c, i)->getDataType() == DataType::ComplexDouble);
-  TORCH_CHECK(add(c, c)->getDataType() == DataType::ComplexDouble);
+  NVF_CHECK(add(c, b)->getDataType() == DataType::ComplexDouble);
+  NVF_CHECK(add(c, d)->getDataType() == DataType::ComplexDouble);
+  NVF_CHECK(add(c, i)->getDataType() == DataType::ComplexDouble);
+  NVF_CHECK(add(c, c)->getDataType() == DataType::ComplexDouble);
 }
 
 TEST_F(NVFuserTest, FusionComplexAbsTypes_CUDA) {
@@ -425,10 +426,10 @@ TEST_F(NVFuserTest, FusionComplexAbsTypes_CUDA) {
   auto type_cd = at::TensorType::create(tensor_cd);
   auto tv_cd = IrBuilder::create<TensorView>(type_cd);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       tensor_cf.abs().scalar_type() ==
       data_type_to_aten(abs(tv_cf)->getDataType().value()));
-  TORCH_CHECK(
+  NVF_CHECK(
       tensor_cd.abs().scalar_type() ==
       data_type_to_aten(abs(tv_cd)->getDataType().value()));
 }
@@ -504,36 +505,36 @@ TEST_F(NVFuserTest, FusionTopoSort_CUDA) {
   fusion.addOutput(v2);
   fusion.addOutput(v3);
   auto exprs = fusion.exprs();
-  TORCH_CHECK(exprs.size() == 1, "Found ", exprs.size(), " but expecting 1");
-  TORCH_CHECK(exprs[0] == e0);
+  NVF_CHECK(exprs.size() == 1, "Found ", exprs.size(), " but expecting 1");
+  NVF_CHECK(exprs[0] == e0);
 
   fusion.addOutput(v5);
   exprs = fusion.exprs();
-  TORCH_CHECK(exprs.size() == 3, "Found ", exprs.size(), " but expecting 3");
-  TORCH_CHECK(exprs[0] == e0);
-  TORCH_CHECK(exprs[1] == e1);
-  TORCH_CHECK(exprs[2] == e2);
+  NVF_CHECK(exprs.size() == 3, "Found ", exprs.size(), " but expecting 3");
+  NVF_CHECK(exprs[0] == e0);
+  NVF_CHECK(exprs[1] == e1);
+  NVF_CHECK(exprs[2] == e2);
 
   fusion.addOutput(v4);
   exprs = fusion.exprs();
-  TORCH_CHECK(exprs.size() == 3, "Found ", exprs.size(), " but expecting 3");
-  TORCH_CHECK(exprs[0] == e0);
-  TORCH_CHECK(exprs[1] == e1);
-  TORCH_CHECK(exprs[2] == e2);
+  NVF_CHECK(exprs.size() == 3, "Found ", exprs.size(), " but expecting 3");
+  NVF_CHECK(exprs[0] == e0);
+  NVF_CHECK(exprs[1] == e1);
+  NVF_CHECK(exprs[2] == e2);
 
   fusion.addOutput(v6);
   exprs = fusion.exprs();
-  TORCH_CHECK(exprs.size() == 4, "Found ", exprs.size(), " but expecting 4");
-  TORCH_CHECK(exprs[0] == e0);
-  TORCH_CHECK(exprs[1] == e1);
-  TORCH_CHECK(exprs[2] == e2);
-  TORCH_CHECK(exprs[3] == e3);
+  NVF_CHECK(exprs.size() == 4, "Found ", exprs.size(), " but expecting 4");
+  NVF_CHECK(exprs[0] == e0);
+  NVF_CHECK(exprs[1] == e1);
+  NVF_CHECK(exprs[2] == e2);
+  NVF_CHECK(exprs[3] == e3);
 
-  TORCH_CHECK(v2->definition()->name() == 0);
-  TORCH_CHECK(v3->definition()->name() == 0);
-  TORCH_CHECK(v4->definition()->name() == 1);
-  TORCH_CHECK(v5->definition()->name() == 2);
-  TORCH_CHECK(v6->definition()->name() == 3);
+  NVF_CHECK(v2->definition()->name() == 0);
+  NVF_CHECK(v3->definition()->name() == 0);
+  NVF_CHECK(v4->definition()->name() == 1);
+  NVF_CHECK(v5->definition()->name() == 2);
+  NVF_CHECK(v6->definition()->name() == 3);
 }
 
 TEST_F(NVFuserTest, FusionTensor_CUDA) {
@@ -546,15 +547,15 @@ TEST_F(NVFuserTest, FusionTensor_CUDA) {
     auto tensor = at::randn({2, 3, 4, 5}, options);
     auto tensor_type = at::TensorType::create(tensor);
     auto fuser_tensor = IrBuilder::create<TensorView>(tensor_type);
-    TORCH_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
-    TORCH_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
-    TORCH_CHECK(fuser_tensor->domain() != nullptr);
+    NVF_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
+    NVF_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
+    NVF_CHECK(fuser_tensor->domain() != nullptr);
     for (const auto i : c10::irange(fuser_tensor->nDims())) {
       // size 1 dimension are makred as broadcast
-      TORCH_CHECK(
+      NVF_CHECK(
           fuser_tensor->axis(i)->isBroadcast() == (tensor.sizes()[i] == 1));
       // check contiguity information;
-      TORCH_CHECK(fuser_tensor->domain()->contiguity()[i]);
+      NVF_CHECK(fuser_tensor->domain()->contiguity()[i]);
     }
   }
 
@@ -569,16 +570,16 @@ TEST_F(NVFuserTest, FusionTensor_CUDA) {
 
     auto tensor_type = at::TensorType::create(sliced_tensor);
     auto fuser_tensor = IrBuilder::create<TensorView>(tensor_type);
-    TORCH_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
-    TORCH_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
-    TORCH_CHECK(fuser_tensor->domain() != nullptr);
+    NVF_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
+    NVF_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
+    NVF_CHECK(fuser_tensor->domain() != nullptr);
     for (const auto i : c10::irange(fuser_tensor->nDims())) {
       // size 1 dimension are makred as broadcast
-      TORCH_CHECK(fuser_tensor->axis(i)->isBroadcast() == false);
+      NVF_CHECK(fuser_tensor->axis(i)->isBroadcast() == false);
     }
-    TORCH_CHECK(*fuser_tensor->domain()->contiguity()[0]);
-    TORCH_CHECK(!*fuser_tensor->domain()->contiguity()[1]);
-    TORCH_CHECK(*fuser_tensor->domain()->contiguity()[2]);
+    NVF_CHECK(*fuser_tensor->domain()->contiguity()[0]);
+    NVF_CHECK(!*fuser_tensor->domain()->contiguity()[1]);
+    NVF_CHECK(*fuser_tensor->domain()->contiguity()[2]);
   }
 
   {
@@ -586,17 +587,17 @@ TEST_F(NVFuserTest, FusionTensor_CUDA) {
     auto permuted_tensor = tensor.permute({0, 3, 1, 2});
     auto tensor_type = at::TensorType::create(permuted_tensor);
     auto fuser_tensor = IrBuilder::create<TensorView>(tensor_type);
-    TORCH_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
-    TORCH_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
-    TORCH_CHECK(fuser_tensor->domain() != nullptr);
+    NVF_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
+    NVF_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
+    NVF_CHECK(fuser_tensor->domain() != nullptr);
     for (const auto i : c10::irange(fuser_tensor->nDims())) {
       // size 1 dimension are makred as broadcast
-      TORCH_CHECK(fuser_tensor->axis(i)->isBroadcast() == false);
+      NVF_CHECK(fuser_tensor->axis(i)->isBroadcast() == false);
     }
-    TORCH_CHECK(!*fuser_tensor->domain()->contiguity()[0]);
-    TORCH_CHECK(!*fuser_tensor->domain()->contiguity()[1]);
-    TORCH_CHECK(*fuser_tensor->domain()->contiguity()[2]);
-    TORCH_CHECK(!*fuser_tensor->domain()->contiguity()[3]);
+    NVF_CHECK(!*fuser_tensor->domain()->contiguity()[0]);
+    NVF_CHECK(!*fuser_tensor->domain()->contiguity()[1]);
+    NVF_CHECK(*fuser_tensor->domain()->contiguity()[2]);
+    NVF_CHECK(!*fuser_tensor->domain()->contiguity()[3]);
   }
 }
 
@@ -660,7 +661,7 @@ TEST_F(NVFuserTest, FusionTVMerge_CUDA) {
   tv = tv->merge(1);
   Expr* axisOp = tv->axis(1)->extent()->definition();
 
-  TORCH_CHECK(
+  NVF_CHECK(
       tv->nDims() == 2 && axisOp->isA<BinaryOp>() &&
       static_cast<BinaryOp*>(axisOp)->getBinaryOpType() == BinaryOpType::Mul &&
       static_cast<BinaryOp*>(axisOp)->lhs() ==
@@ -688,7 +689,7 @@ TEST_F(NVFuserTest, FusionTVReorder_CUDA) {
 
   tv->reorder(shift_left);
   for (const auto i : c10::irange(tv->nDims())) {
-    TORCH_CHECK(ref[i]->sameAs(tv->axis(i - 1)));
+    NVF_CHECK(ref[i]->sameAs(tv->axis(i - 1)));
   }
 
   tv = makeSymbolicTensor(3);
@@ -697,7 +698,7 @@ TEST_F(NVFuserTest, FusionTVReorder_CUDA) {
 
   tv->reorder(shift_left);
   for (const auto i : c10::irange(tv->nDims())) {
-    TORCH_CHECK(ref[i]->sameAs(tv->axis(i - 1)));
+    NVF_CHECK(ref[i]->sameAs(tv->axis(i - 1)));
   }
 
   tv = makeSymbolicTensor(3);
@@ -705,18 +706,18 @@ TEST_F(NVFuserTest, FusionTVReorder_CUDA) {
       tv->getLeafDomain().begin(), tv->getLeafDomain().end());
 
   tv->reorder(shift_right);
-  TORCH_CHECK(ref[ref.size() - 1]->sameAs(tv->axis(0)));
+  NVF_CHECK(ref[ref.size() - 1]->sameAs(tv->axis(0)));
   for (const auto i : c10::irange(1, tv->nDims())) {
-    TORCH_CHECK(ref[i - 1]->sameAs(tv->axis(i)));
+    NVF_CHECK(ref[i - 1]->sameAs(tv->axis(i)));
   }
 
   tv = makeSymbolicTensor(3);
   ref = std::vector<IterDomain*>(
       tv->getLeafDomain().begin(), tv->getLeafDomain().end());
   tv->reorder(swap);
-  TORCH_CHECK(ref[0]->sameAs(tv->axis(2)));
-  TORCH_CHECK(ref[2]->sameAs(tv->axis(0)));
-  TORCH_CHECK(ref[1]->sameAs(tv->axis(1)));
+  NVF_CHECK(ref[0]->sameAs(tv->axis(2)));
+  NVF_CHECK(ref[2]->sameAs(tv->axis(0)));
+  NVF_CHECK(ref[1]->sameAs(tv->axis(1)));
 }
 
 TEST_F(NVFuserTest, FusionEquality_CUDA) {
@@ -728,20 +729,20 @@ TEST_F(NVFuserTest, FusionEquality_CUDA) {
   Val* fval2 = IrBuilder::create<Val>(DataType::Double);
   Val* fone = IrBuilder::create<Val>(1.0);
 
-  TORCH_CHECK(fval1->sameAs(fval1_copy));
-  TORCH_CHECK(!fval1->sameAs(fval2));
-  TORCH_CHECK(!fone->sameAs(fval1));
-  TORCH_CHECK(fone->sameAs(IrBuilder::create<Val>(1.0)));
+  NVF_CHECK(fval1->sameAs(fval1_copy));
+  NVF_CHECK(!fval1->sameAs(fval2));
+  NVF_CHECK(!fone->sameAs(fval1));
+  NVF_CHECK(fone->sameAs(IrBuilder::create<Val>(1.0)));
 
   Val* ival1 = IrBuilder::create<Val>(DataType::Int);
   Val* ival1_copy = ival1;
   Val* ival2 = IrBuilder::create<Val>(DataType::Int);
   Val* ione = IrBuilder::create<Val>(1L);
 
-  TORCH_CHECK(ival1->sameAs(ival1_copy));
-  TORCH_CHECK(!ival1->sameAs(ival2));
-  TORCH_CHECK(!ione->sameAs(ival1));
-  TORCH_CHECK(ione->sameAs(IrBuilder::create<Val>(1L)));
+  NVF_CHECK(ival1->sameAs(ival1_copy));
+  NVF_CHECK(!ival1->sameAs(ival2));
+  NVF_CHECK(!ione->sameAs(ival1));
+  NVF_CHECK(ione->sameAs(IrBuilder::create<Val>(1L)));
 
   BinaryOp* add1 = IrBuilder::create<BinaryOp>(
       BinaryOpType::Add,
@@ -766,12 +767,12 @@ TEST_F(NVFuserTest, FusionEquality_CUDA) {
   UnaryOp* neg1_copy = IrBuilder::create<UnaryOp>(
       UnaryOpType::Neg, IrBuilder::create<Val>(DataType::Double), fval1);
 
-  TORCH_CHECK(add1->sameAs(add1_copy));
-  TORCH_CHECK(!add1->sameAs(sub1));
+  NVF_CHECK(add1->sameAs(add1_copy));
+  NVF_CHECK(!add1->sameAs(sub1));
 
-  TORCH_CHECK(neg1->sameAs(neg1_copy));
-  TORCH_CHECK(!static_cast<Expr*>(neg1)->sameAs(add1));
-  TORCH_CHECK(!neg1->sameAs(neg2));
+  NVF_CHECK(neg1->sameAs(neg1_copy));
+  NVF_CHECK(!static_cast<Expr*>(neg1)->sameAs(add1));
+  NVF_CHECK(!neg1->sameAs(neg2));
 }
 
 TEST_F(NVFuserTest, FusionDependency_CUDA) {
@@ -796,52 +797,52 @@ TEST_F(NVFuserTest, FusionDependency_CUDA) {
 
   auto d11 = add(d3, d10);
 
-  TORCH_CHECK(DependencyCheck::isDependencyOf(d0, d11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(d1, d11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(d2, d11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(d3, d11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(d6, d11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(d9, d11));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(d0, d2));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(d2, d3));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(d4, d6));
-  TORCH_CHECK(DependencyCheck::isDependencyOf(d8, d10));
+  NVF_CHECK(DependencyCheck::isDependencyOf(d0, d11));
+  NVF_CHECK(DependencyCheck::isDependencyOf(d1, d11));
+  NVF_CHECK(DependencyCheck::isDependencyOf(d2, d11));
+  NVF_CHECK(DependencyCheck::isDependencyOf(d3, d11));
+  NVF_CHECK(DependencyCheck::isDependencyOf(d6, d11));
+  NVF_CHECK(DependencyCheck::isDependencyOf(d9, d11));
+  NVF_CHECK(DependencyCheck::isDependencyOf(d0, d2));
+  NVF_CHECK(DependencyCheck::isDependencyOf(d2, d3));
+  NVF_CHECK(DependencyCheck::isDependencyOf(d4, d6));
+  NVF_CHECK(DependencyCheck::isDependencyOf(d8, d10));
 
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d0));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d1));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d2));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d3));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d4));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(d11, d5));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(d2, d0));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(d3, d2));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(d6, d4));
-  TORCH_CHECK(!DependencyCheck::isDependencyOf(d10, d8));
+  NVF_CHECK(!DependencyCheck::isDependencyOf(d11, d0));
+  NVF_CHECK(!DependencyCheck::isDependencyOf(d11, d1));
+  NVF_CHECK(!DependencyCheck::isDependencyOf(d11, d2));
+  NVF_CHECK(!DependencyCheck::isDependencyOf(d11, d3));
+  NVF_CHECK(!DependencyCheck::isDependencyOf(d11, d4));
+  NVF_CHECK(!DependencyCheck::isDependencyOf(d11, d5));
+  NVF_CHECK(!DependencyCheck::isDependencyOf(d2, d0));
+  NVF_CHECK(!DependencyCheck::isDependencyOf(d3, d2));
+  NVF_CHECK(!DependencyCheck::isDependencyOf(d6, d4));
+  NVF_CHECK(!DependencyCheck::isDependencyOf(d10, d8));
 
   auto dep_chain = DependencyCheck::getSingleDependencyChain(d0, d11);
-  TORCH_CHECK(dep_chain.back() == d11);
+  NVF_CHECK(dep_chain.back() == d11);
   dep_chain.pop_back();
-  TORCH_CHECK(dep_chain.back() == d3);
+  NVF_CHECK(dep_chain.back() == d3);
   dep_chain.pop_back();
-  TORCH_CHECK(dep_chain.back() == d2);
+  NVF_CHECK(dep_chain.back() == d2);
   dep_chain.pop_back();
 
   dep_chain = DependencyCheck::getSingleDependencyChain(d6, d11);
-  TORCH_CHECK(dep_chain.back() == d11);
+  NVF_CHECK(dep_chain.back() == d11);
   dep_chain.pop_back();
-  TORCH_CHECK(dep_chain.back() == d10);
+  NVF_CHECK(dep_chain.back() == d10);
   dep_chain.pop_back();
 
   dep_chain = DependencyCheck::getSingleDependencyChain(d4, d11);
-  TORCH_CHECK(dep_chain.back() == d11);
+  NVF_CHECK(dep_chain.back() == d11);
   dep_chain.pop_back();
-  TORCH_CHECK(dep_chain.back() == d10);
+  NVF_CHECK(dep_chain.back() == d10);
   dep_chain.pop_back();
-  TORCH_CHECK(dep_chain.back() == d6);
+  NVF_CHECK(dep_chain.back() == d6);
   dep_chain.pop_back();
 
   dep_chain = DependencyCheck::getSingleDependencyChain(d11, d2);
-  TORCH_CHECK(dep_chain.empty());
+  NVF_CHECK(dep_chain.empty());
 }
 
 TEST_F(NVFuserTest, FusionParser_CUDA) {
@@ -917,7 +918,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 1, 1> T0, Tensor<float, 1, 1> 
   fe.compileFusion(fusion.get(), {input1, input2}, lparams);
   auto outputs = fe.runFusion({input1, input2}, lparams);
   at::Tensor output_ref = input1 * input2 * input1;
-  TORCH_CHECK(output_ref.equal(outputs[0]));
+  NVF_CHECK(output_ref.equal(outputs[0]));
 }
 
 TEST_F(NVFuserTest, FusionOuterSplit_CUDA) {
@@ -958,7 +959,7 @@ TEST_F(NVFuserTest, FusionOuterSplit_CUDA) {
   at::Tensor output_ref = at::ones_like(output, options);
   output_ref = output_ref + 2.0 + 3.0;
 
-  TORCH_CHECK(output_ref.equal(output));
+  NVF_CHECK(output_ref.equal(output));
 }
 
 TEST_F(NVFuserTest, FusionCodeGen_CUDA) {
@@ -998,7 +999,7 @@ TEST_F(NVFuserTest, FusionCodeGen_CUDA) {
   at::Tensor output_ref = at::ones_like(output, options);
   output_ref = output_ref + 2.0 + 3.0;
 
-  TORCH_CHECK(output_ref.equal(output));
+  NVF_CHECK(output_ref.equal(output));
 }
 
 TEST_F(NVFuserTest, FusionCodeGen2_CUDA) {
@@ -1040,7 +1041,7 @@ TEST_F(NVFuserTest, FusionCodeGen2_CUDA) {
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
 
-  TORCH_CHECK(output_ref.equal(outputs[0]));
+  NVF_CHECK(output_ref.equal(outputs[0]));
 }
 
 TEST_F(NVFuserTest, FusionSimplePWise_CUDA) {
@@ -1097,7 +1098,7 @@ TEST_F(NVFuserTest, FusionSimplePWise_CUDA) {
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
 
-  TORCH_CHECK(output_ref.equal(output));
+  NVF_CHECK(output_ref.equal(output));
 }
 
 TEST_F(NVFuserTest, FusionSimplePWiseDtypeComplex_CUDA) {
@@ -1156,7 +1157,7 @@ TEST_F(NVFuserTest, FusionSimplePWiseDtypeComplex_CUDA) {
   at::Tensor tv2_ref = input2 + static_cast<c10::complex<double>>(scalar1);
   at::Tensor output_ref = input1 + tv2_ref;
 
-  TORCH_CHECK(output_ref.equal(output));
+  NVF_CHECK(output_ref.equal(output));
 }
 
 TEST_F(NVFuserTest, FusionExecKernel_CUDA) {
@@ -1206,7 +1207,7 @@ TEST_F(NVFuserTest, FusionExecKernel_CUDA) {
 
   at::Tensor check = at::full({1, 128}, 4, options);
   ;
-  TORCH_CHECK(outputs[0].equal(check));
+  NVF_CHECK(outputs[0].equal(check));
 }
 
 int ceilDiv_(int a, int b) {
@@ -1252,17 +1253,17 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt1_CUDA) {
   ComputeAtMap ca_map(&fusion);
 
   // The this-position of the last tensor should be zero.
-  TORCH_CHECK(
+  NVF_CHECK(
       tv7->nDims() == 3 && tv7->getComputeAtPosition() == 0 &&
       tv7->getMaxProducerPosition() == 1);
-  TORCH_CHECK(
+  NVF_CHECK(
       tv7->nDims() == 3 && tv6->getComputeAtPosition() == 0 &&
       tv6->getMaxProducerPosition() == 1);
   // The position of every other tensor should be 1.
   for (auto tv : {tv1, tv2, tv3, tv4, tv5}) {
-    TORCH_CHECK(tv->nDims() == 3 && tv->getComputeAtPosition() == 1);
+    NVF_CHECK(tv->nDims() == 3 && tv->getComputeAtPosition() == 1);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         ca_map.areMapped(tv7->axis(0), tv->axis(0), IdMappingMode::PERMISSIVE));
   }
 
@@ -1610,7 +1611,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt7_CUDA) {
   tv2->computeAt(tv4, -1);
 
   auto tv5_domain_current = tv5->getLeafDomain();
-  TORCH_CHECK(tv5_domain == tv5_domain_current, "Invalid TV5 domain");
+  NVF_CHECK(tv5_domain == tv5_domain_current, "Invalid TV5 domain");
 
   const int numel_x = 100;
   const int numel_y = 200;
@@ -1729,26 +1730,26 @@ TEST_F(NVFuserTest, FusionComputeAtMultiConsumers_CUDA) {
 
   TensorView* affected_tensors[] = {tv1, tv2, tv3};
   for (auto tv : affected_tensors) {
-    TORCH_CHECK(tv->nDims() == computeAtTarget->nDims());
+    NVF_CHECK(tv->nDims() == computeAtTarget->nDims());
   }
 
   GpuLower gpulw(&fusion);
 
-  TORCH_CHECK(tv1->getComputeAtPosition() == 1);
-  TORCH_CHECK(
+  NVF_CHECK(tv1->getComputeAtPosition() == 1);
+  NVF_CHECK(
       tv2->getComputeAtPosition() == 0 && tv2->getMaxProducerPosition() == 1);
-  TORCH_CHECK(
+  NVF_CHECK(
       tv3->getComputeAtPosition() == 0 && tv3->getMaxProducerPosition() == 1);
 
   ComputeAtMap ca_map(&fusion);
 
   // Note that tv2 is also computed at tv3.
   for (auto tv : {tv1, tv2}) {
-    TORCH_CHECK(ca_map.areMapped(
+    NVF_CHECK(ca_map.areMapped(
         tv->axis(0), computeAtTarget->axis(0), IdMappingMode::PERMISSIVE));
   }
 
-  TORCH_CHECK(tv3->getComputeAtPosition() == 0);
+  NVF_CHECK(tv3->getComputeAtPosition() == 0);
 
   computeAtTarget->axis(0)->parallelize(ParallelType::BIDx);
   for (auto tv : affected_tensors) {
@@ -1810,14 +1811,14 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer1_CUDA) {
 
   TensorView* affected_tensors[] = {tv1, tv2, tv3, tv4};
   for (auto tv : affected_tensors) {
-    TORCH_CHECK(tv->nDims() == computeAtTarget->nDims());
+    NVF_CHECK(tv->nDims() == computeAtTarget->nDims());
   }
 
-  TORCH_CHECK(tv1->getComputeAtPosition() == 1);
-  TORCH_CHECK(tv2->getComputeAtPosition() == 1);
-  TORCH_CHECK(tv3->getComputeAtPosition() == 1);
-  TORCH_CHECK(tv4->getComputeAtPosition() == 0);
-  TORCH_CHECK(tv5->getComputeAtPosition() == 0);
+  NVF_CHECK(tv1->getComputeAtPosition() == 1);
+  NVF_CHECK(tv2->getComputeAtPosition() == 1);
+  NVF_CHECK(tv3->getComputeAtPosition() == 1);
+  NVF_CHECK(tv4->getComputeAtPosition() == 0);
+  NVF_CHECK(tv5->getComputeAtPosition() == 0);
 
   computeAtTarget->axis(0)->parallelize(ParallelType::BIDx);
 
@@ -1901,11 +1902,11 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer2_CUDA) {
       continue;
     }
     TensorView* tv = val->as<TensorView>();
-    TORCH_CHECK(tv->nDims() == computeAtTarget->nDims());
+    NVF_CHECK(tv->nDims() == computeAtTarget->nDims());
     if (tv == tv5) {
-      TORCH_CHECK(tv->getComputeAtPosition() == 0);
+      NVF_CHECK(tv->getComputeAtPosition() == 0);
     } else {
-      TORCH_CHECK(tv->getComputeAtPosition() == 1);
+      NVF_CHECK(tv->getComputeAtPosition() == 1);
     }
   }
 
@@ -1985,12 +1986,12 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer3_CUDA) {
     if (tv->isFusionInput()) {
       continue;
     }
-    TORCH_CHECK(tv->nDims() == computeAtTarget->nDims());
+    NVF_CHECK(tv->nDims() == computeAtTarget->nDims());
     if (tv == tv5 || tv == tv6) {
-      TORCH_CHECK(tv->getComputeAtPosition() == 0);
-      TORCH_CHECK(tv->getMaxProducerPosition() == 1);
+      NVF_CHECK(tv->getComputeAtPosition() == 0);
+      NVF_CHECK(tv->getMaxProducerPosition() == 1);
     } else {
-      TORCH_CHECK(tv->getComputeAtPosition() == 1);
+      NVF_CHECK(tv->getComputeAtPosition() == 1);
     }
   }
 
@@ -2059,11 +2060,11 @@ TEST_F(NVFuserTest, FusionComputeAtNoCommonConsumer_CUDA) {
 
   TensorView* affected_tensors[] = {tv1, tv2, tv3, tv4, tv5, tv6};
   for (auto tv : affected_tensors) {
-    TORCH_CHECK(tv->nDims() == computeAtTarget->nDims());
+    NVF_CHECK(tv->nDims() == computeAtTarget->nDims());
     if (tv == tv6 || tv == tv5) {
-      TORCH_CHECK(tv->getComputeAtPosition() == 0);
+      NVF_CHECK(tv->getComputeAtPosition() == 0);
     } else {
-      TORCH_CHECK(tv->getComputeAtPosition() == 1);
+      NVF_CHECK(tv->getComputeAtPosition() == 1);
     }
   }
 
@@ -2109,7 +2110,7 @@ void checkIdMapped(
     IterDomain* id1,
     bool should_map) {
   if (should_map) {
-    TORCH_CHECK(
+    NVF_CHECK(
         root_map.canMap(v0->domain(), id0, v1->domain(), id1),
         "Should be mappable: ",
         id0,
@@ -2120,7 +2121,7 @@ void checkIdMapped(
         " of ",
         v1);
   } else {
-    TORCH_CHECK(
+    NVF_CHECK(
         !root_map.canMap(v0->domain(), id0, v1->domain(), id1),
         "Should not be mappable: ",
         id0,
@@ -2142,8 +2143,8 @@ void checkIdMapped(
     const std::vector<bool> should_map1) {
   ComputeAtRootDomainMap map;
   map.build();
-  TORCH_INTERNAL_ASSERT(root0.size() == should_map0.size());
-  TORCH_INTERNAL_ASSERT(root1.size() == should_map1.size());
+  NVF_ERROR(root0.size() == should_map0.size());
+  NVF_ERROR(root1.size() == should_map1.size());
   size_t idx0 = 0;
   for (const auto i : c10::irange(root0.size())) {
     size_t idx1 = 0;
@@ -2940,7 +2941,7 @@ TEST_F(NVFuserTest, FusionLoopUnroll_CUDA) {
   fe.compileFusion(&fusion, {input0, input1});
   auto outputs = fe.runFusion({input0, input1});
 
-  TORCH_CHECK(outputs[0].equal(input0.add(input1.add(2.0))));
+  NVF_CHECK(outputs[0].equal(input0.add(input1.add(2.0))));
 }
 
 /*
@@ -2960,10 +2961,10 @@ Val* gen_jit_operand(std::pair<ValType, DataType> desc) {
     } else if (desc.second == DataType::Int || desc.second == DataType::Int32) {
       return IrBuilder::create<Val>(DataType::Int);
     } else {
-      TORCH_CHECK(false, "Not currently supported type: ", desc.first);
+      NVF_CHECK(false, "Not currently supported type: ", desc.first);
     }
   } else {
-    TORCH_CHECK(false, "Not currently supported type: ", desc.first);
+    NVF_CHECK(false, "Not currently supported type: ", desc.first);
   }
   return nullptr;
 }
@@ -3013,7 +3014,7 @@ at::IValue gen_aten_operand(
         return at::IValue(at::empty({blocks, threads}, options));
       }
     } else {
-      TORCH_CHECK(false, "Not currently supported type: ", desc.second)
+      NVF_CHECK(false, "Not currently supported type: ", desc.second)
     }
   } else if (desc.first == ValType::Others) {
     // IValue scalars can only be double int64 or bool
@@ -3027,10 +3028,10 @@ at::IValue gen_aten_operand(
     } else if (desc.second == DataType::Int || desc.second == DataType::Int32) {
       return at::IValue(at::Scalar(1));
     } else {
-      TORCH_CHECK(false, "Not currently supported type: ", desc.first);
+      NVF_CHECK(false, "Not currently supported type: ", desc.first);
     }
   } else {
-    TORCH_CHECK(false, "Not currently supported type: ", desc.first);
+    NVF_CHECK(false, "Not currently supported type: ", desc.first);
   }
   return nullptr;
 }
@@ -3605,7 +3606,7 @@ TEST_F(NVFuserTest, FusionCastOps_CUDA) {
 
   ref_output = at::_cast_Half(at::_cast_Double(input1));
 
-  TORCH_CHECK(
+  NVF_CHECK(
       outputs[0].equal(ref_output),
       "\nOp Type: -- ",
       "cast FP16->FP32->FP16",
@@ -3630,7 +3631,7 @@ TEST_F(NVFuserTest, FusionReduction1_CUDA) {
       reductionOp(BinaryOpType::Add, {1}, IrBuilder::create<Val>(0.0), tv0);
   fusion.addOutput(tv1);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getReductionOps(&fusion).size(),
       "Could not detect reduction in fusion.");
 
@@ -3938,7 +3939,7 @@ TEST_F(NVFuserTest, FusionReduction6_CUDA) {
       reductionOp(BinaryOpType::Add, {1, 2}, IrBuilder::create<Val>(0.0), tv0);
   fusion.addOutput(tv1);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getReductionOps(&fusion).size(),
       "Could not detect reduction in fusion.");
 
@@ -4974,7 +4975,7 @@ TEST_F(NVFuserTest, FusionGridReduction1_CUDA) {
       reductionOp(BinaryOpType::Add, {1}, IrBuilder::create<Val>(0.0), tv0);
   fusion.addOutput(tv1);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getReductionOps(&fusion).size(),
       "Could not detect reduction in fusion.");
 
@@ -5035,7 +5036,7 @@ TEST_F(NVFuserTest, FusionGridReduction2_CUDA) {
       reductionOp(BinaryOpType::Add, {1}, IrBuilder::create<Val>(0.0), tv0);
   fusion.addOutput(tv1);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getReductionOps(&fusion).size(),
       "Could not detect reduction in fusion.");
 
@@ -5097,7 +5098,7 @@ TEST_F(NVFuserTest, FusionGridReduction3dim1_CUDA) {
       reductionOp(BinaryOpType::Add, {1}, IrBuilder::create<Val>(0.0), tv0);
   fusion.addOutput(tv1);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getReductionOps(&fusion).size(),
       "Could not detect reduction in fusion.");
 
@@ -5159,7 +5160,7 @@ TEST_F(NVFuserTest, FusionGridReduction3dim0_CUDA) {
       reductionOp(BinaryOpType::Add, {0}, IrBuilder::create<Val>(0.0), tv0);
   fusion.addOutput(tv1);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getReductionOps(&fusion).size(),
       "Could not detect reduction in fusion.");
 
@@ -5215,7 +5216,7 @@ TEST_F(NVFuserTest, FusionGridReduction4_CUDA) {
       reductionOp(BinaryOpType::Add, {1}, IrBuilder::create<Val>(0.0), tv0);
   fusion.addOutput(tv1);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getReductionOps(&fusion).size(),
       "Could not detect reduction in fusion.");
 
@@ -5283,7 +5284,7 @@ TEST_F(NVFuserTest, FusionGridReduction5_CUDA) {
       reductionOp(BinaryOpType::Add, {1}, IrBuilder::create<Val>(0.0), tv0);
   fusion.addOutput(tv1);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getReductionOps(&fusion).size(),
       "Could not detect reduction in fusion.");
 
@@ -5334,7 +5335,7 @@ TEST_F(NVFuserTest, FusionGridReduction6_CUDA) {
       reductionOp(BinaryOpType::Add, {1, 2}, IrBuilder::create<Val>(0.0), tv0);
   fusion.addOutput(tv1);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getReductionOps(&fusion).size(),
       "Could not detect reduction in fusion.");
 
@@ -5619,7 +5620,7 @@ TEST_F(NVFuserTest, FusionBCastInnerDim_CUDA) {
   auto tv1 = sum(tv0, {0});
   auto tv2 = broadcast(tv1, {false, true});
 
-  TORCH_CHECK(!tv2->axis(0)->isReduction() && tv2->axis(1)->isBroadcast());
+  NVF_CHECK(!tv2->axis(0)->isReduction() && tv2->axis(1)->isBroadcast());
 }
 
 TEST_F(NVFuserTest, FusionBCastReduce_CUDA) {
@@ -5631,7 +5632,7 @@ TEST_F(NVFuserTest, FusionBCastReduce_CUDA) {
 
   auto tv1 = broadcast(tv0, {true, false, false});
   auto tv2 = sum(tv1, {1});
-  TORCH_CHECK(
+  NVF_CHECK(
       tv2->axis(0)->isBroadcast() && tv2->axis(1)->isReduction() &&
       !tv2->axis(2)->isBroadcast() && !tv2->axis(2)->isReduction());
 }
@@ -5652,7 +5653,7 @@ TEST_F(NVFuserTest, FusionReductionMultiConsumer_CUDA) {
   fusion.addOutput(tv4);
   tv1->computeAt(tv2, -1, ComputeAtMode::BestEffort);
 
-  TORCH_CHECK(tv1->getComputeAtPosition() == 2);
+  NVF_CHECK(tv1->getComputeAtPosition() == 2);
 }
 
 TEST_F(NVFuserTest, FusionComputeAtExprOrder1_CUDA) {
@@ -5773,7 +5774,7 @@ TEST_F(NVFuserTest, FusionZeroDimComputeAt_CUDA) {
   auto tv1 = sum(tv0, {0});
   auto tv2 = add(tv1, IrBuilder::create<Val>(1.0));
   fusion.addOutput(tv2);
-  TORCH_CHECK(tv2->nDims() == 0);
+  NVF_CHECK(tv2->nDims() == 0);
   tv1->computeAt(tv2, 0);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -5796,7 +5797,7 @@ TEST_F(NVFuserTest, FusionZeroDimBroadcast_CUDA) {
   fusion.addInput(tv0);
 
   auto tv1 = broadcast(tv0, {true, true});
-  TORCH_CHECK(tv1->nDims() == 2);
+  NVF_CHECK(tv1->nDims() == 2);
 
   TensorView* tv2 = makeSymbolicTensor(2);
   fusion.addInput(tv2);
@@ -5997,7 +5998,7 @@ TEST_F(NVFuserTest, FusionReductionKeepDimScheduler_CUDA) {
 
   // Apply reduction heuristic
   auto reduction_params = getReductionHeuristics(&fusion, {aten_input});
-  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
   scheduleReduction(&fusion, *reduction_params);
 
   auto lparams = reduction_params->lparams;
@@ -6050,7 +6051,7 @@ TEST_F(NVFuserTest, FusionSumTo_CUDA) {
   fe.compileFusion(&fusion, {aten_input});
   auto cg_outputs = fe.runFusion({aten_input});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       cg_outputs[0].dim() == static_cast<int64_t>(sum_to_shape.size()),
       "sum_to not keeping the final dimension");
 
@@ -6094,7 +6095,7 @@ TEST_F(NVFuserTest, FusionSumToNoop_CUDA) {
   auto cg_outputs = fe.runFusion({aten_input});
   auto aten_output = at::sum_to(aten_input.to(at::kDouble), sum_to_shape_ref);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       cg_outputs[0].dim() == static_cast<int64_t>(sum_to_shape.size()),
       "sum_to not keeping the final dimension");
 
@@ -6126,7 +6127,7 @@ TEST_F(NVFuserTest, FusionReductionScheduler_CUDA) {
 
   // Apply reduction heuristic
   auto reduction_params = getReductionHeuristics(&fusion, {aten_input});
-  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
   scheduleReduction(&fusion, *reduction_params);
 
   auto lparams = reduction_params->lparams;
@@ -6301,7 +6302,7 @@ TEST_F(NVFuserTest, FusionReductionSchedulerMultiDimNonFastest_CUDA) {
 
   // Apply reduction heuristic
   auto reduction_params = getReductionHeuristics(&fusion, {aten_input});
-  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
   scheduleReduction(&fusion, *reduction_params);
   auto lparams = reduction_params->lparams;
 
@@ -6344,7 +6345,7 @@ TEST_F(NVFuserTest, FusionReductionSchedulerMultiDimFastest_CUDA) {
   auto aten_output = aten_input.to(at::kDouble).sum(red_dims64);
 
   auto reduction_params = getReductionHeuristics(&fusion, {aten_input});
-  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
   scheduleReduction(&fusion, *reduction_params);
   auto lparams = reduction_params->lparams;
 
@@ -6426,7 +6427,7 @@ TEST_F(NVFuserTest, FusionReductionSchedulerNoODimShmoo_CUDA) {
       auto aten_output = aten_input.to(at::kDouble).sum({0});
 
       auto reduction_params = getReductionHeuristics(&fusion, {aten_input});
-      TORCH_CHECK(reduction_params != nullptr, "Reduction is not found!");
+      NVF_CHECK(reduction_params != nullptr, "Reduction is not found!");
       scheduleReduction(&fusion, *reduction_params);
       auto lparams = reduction_params->lparams;
 
@@ -6514,7 +6515,7 @@ TEST_F(NVFuserTest, FusionReductionSchedulerDimShmoo_CUDA) {
                     : at::randn({rdim, odim}, options));
 
           auto reduction_params = getReductionHeuristics(&fusion, {aten_input});
-          TORCH_CHECK(reduction_params != nullptr, "Reduction is not found!");
+          NVF_CHECK(reduction_params != nullptr, "Reduction is not found!");
           scheduleReduction(&fusion, *reduction_params);
           auto lparams = reduction_params->lparams;
 
@@ -6868,7 +6869,7 @@ TEST_F(NVFuserTest, FusionSmem_CUDA) {
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
 
-  TORCH_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
+  NVF_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
 }
 
 TEST_F(NVFuserTest, FusionSmemReduce_CUDA) {
@@ -6916,7 +6917,7 @@ TEST_F(NVFuserTest, FusionSmemReduce_CUDA) {
 
   testValidate(
       &fusion, cg_outputs, {aten_input}, {aten_output}, __LINE__, __FILE__);
-  TORCH_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
+  NVF_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
 }
 
 TEST_F(NVFuserTest, FusionSmemBlockGemm_CUDA) {
@@ -6968,7 +6969,7 @@ TEST_F(NVFuserTest, FusionSmemBlockGemm_CUDA) {
 
   // Make sure BIDx is makred as exact (see issue #1119)
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(gpulw.parallelDimensionMap().isExact(ParallelType::BIDx));
+  NVF_CHECK(gpulw.parallelDimensionMap().isExact(ParallelType::BIDx));
 
   constexpr int M = 154, K = 45, N = 1524;
 
@@ -6986,7 +6987,7 @@ TEST_F(NVFuserTest, FusionSmemBlockGemm_CUDA) {
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
 
-  TORCH_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
+  NVF_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
 }
 
 TEST_F(NVFuserTest, FusionSmemBlockGemmCache_CUDA) {
@@ -7075,7 +7076,7 @@ TEST_F(NVFuserTest, FusionSmemBlockGemmCache_CUDA) {
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
 
-  TORCH_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
+  NVF_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
 }
 
 TEST_F(NVFuserTest, FusionSmemDynamicPersistentSoftmax2D_CUDA) {
@@ -7183,7 +7184,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerSoftmax_CUDA) {
         at::_softmax(aten_input.to(at::kDouble), kReductionAxis, false);
 
     auto reduction_params = getPersistentHeuristics(&fusion, {aten_input});
-    TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+    NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
 
     schedulePersistentKernel(&fusion, *reduction_params);
 
@@ -7251,7 +7252,7 @@ TEST_F(NVFuserTest, FusionTestMaskSoftmax_CUDA) {
 
   auto reduction_params =
       getPersistentHeuristics(&fusion, {aten_input, aten_mask});
-  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
 
   schedulePersistentKernel(&fusion, *reduction_params);
 
@@ -7527,7 +7528,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormalization_CUDA) {
   //// Check reduction axis is same for all reductions
   //// Generate Launch Parameters
   auto reduction_params = getPersistentHeuristics(&fusion, {aten_input});
-  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
 
   FusionExecutorCache fec(std::move(fusion_ptr));
   auto cg_outputs = fec.runFusionWithInputs({aten_input});
@@ -8323,7 +8324,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicReductionSymbolic_CUDA) {
       __FILE__,
       "",
       lparams);
-  TORCH_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
+  NVF_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
 }
 
 TEST_F(NVFuserTest, FusionSmemDynamicReductionSymbolicArg_CUDA) {
@@ -8387,7 +8388,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicReductionSymbolicArg_CUDA) {
       "",
       lparams);
 
-  TORCH_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
+  NVF_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 0);
 }
 
 TEST_F(NVFuserTest, FusionSmemDynamicPwiseMulSymbolicArgWAR_CUDA) {
@@ -8452,7 +8453,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicPwiseMulSymbolicArgWAR_CUDA) {
       "",
       lparams);
 
-  TORCH_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 1);
+  NVF_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 1);
 }
 
 TEST_F(NVFuserTest, FusionSmemDynamicTiledGemm_CUDA) {
@@ -8578,7 +8579,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicTiledGemm_CUDA) {
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
 
-  TORCH_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 1);
+  NVF_CHECK(fe.kernel()->summary().war_hazard_syncs_count == 1);
 }
 
 } // namespace nvfuser

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -5151,7 +5151,7 @@ TEST_F(NVFuserTest, FusionCheckedSymbolicShape_CUDA) {
   {
     EXPECT_THAT(
         [&]() { matched_add(a, c); },
-        ::testing::ThrowsMessage<c10::Error>(
+        ::testing::ThrowsMessage<nvfuser::nvfError>(
             ::testing::HasSubstr("Conflicting sizes")));
   }
 }
@@ -7817,7 +7817,7 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
           [&]() {
             fe.runFusion(large_inputs, launch_params, compile_opts_large);
           },
-          testing::ThrowsMessage<c10::Error>(testing::HasSubstr(
+          testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
               "Kernel index type and compilation index type don't match")));
     }
 
@@ -7831,7 +7831,7 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
             fe.compileFusion(
                 &fusion, large_inputs, LaunchParams(), compile_opts);
           },
-          testing::ThrowsMessage<c10::Error>(testing::HasSubstr(
+          testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
               "Compilation with int32 is requested but int64 is required for the arguments")));
     }
   }
@@ -8240,7 +8240,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteDifferentConcretizedDomains_CUDA) {
       // it should be segmented, if directly lowered, it should throw an error
       EXPECT_THAT(
           [&]() { GpuLower gpulw(&fusion); },
-          testing::ThrowsMessage<c10::Error>(testing::HasSubstr(
+          testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
               "Producer is required to be in Global Memory based on parallelization strategy. RAW flags: (blockIdx.x)")));
     } else {
       FusionExecutorCache fec(std::move(fusion_ptr));
@@ -8437,7 +8437,7 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
         ir_utils::validateDomainEquivalence(
             tv1->getRootDomain(), {tv1->axis(1), tv1->axis(2)});
       },
-      testing::ThrowsMessage<c10::Error>(
+      testing::ThrowsMessage<nvfuser::nvfError>(
           testing::HasSubstr("Invalid derived domain")));
 
   tv1->merge(0);
@@ -8463,7 +8463,7 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
             tv1->getRootDomain(),
             {tv1_intermediate_id, tv1->axis(0), tv1->axis(1), tv1->axis(2)});
       },
-      testing::ThrowsMessage<c10::Error>(
+      testing::ThrowsMessage<nvfuser::nvfError>(
           testing::HasSubstr("Invalid derived domain")));
 
   // Testing symbolic domains
@@ -8495,7 +8495,7 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
         ir_utils::validateDomainEquivalence(
             tv4->getRootDomain(), {tv4->axis(0), tv4->axis(1)});
       },
-      testing::ThrowsMessage<c10::Error>(
+      testing::ThrowsMessage<nvfuser::nvfError>(
           testing::HasSubstr("Invalid derived domain")));
 }
 
@@ -8563,7 +8563,7 @@ TEST_F(NVFuserTest, FusionIllegalParallelizeNonLeafDomain_CUDA) {
   // llegal, as I1 is not a leaf domain
   EXPECT_THAT(
       [&]() { root_domain[1]->parallelize(ParallelType::BIDy); },
-      testing::ThrowsMessage<c10::Error>(
+      testing::ThrowsMessage<nvfuser::nvfError>(
           testing::HasSubstr("Only allowed to parallelize a leaf domain")));
 }
 

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -85,20 +86,20 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit1_CUDA) {
   tv2->split(1, 2);
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToValidate().empty(),
       "There must be no split to validate");
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToPredicate().size() == 1,
       "Only tv1 should have a non-divisible predicate.");
   for (auto tv : {loweredTv(tv1, gpulw)}) {
     auto it = gpulw.nonDivisibleSplitInfo().splitsToPredicate().find(tv);
-    TORCH_CHECK(
+    NVF_CHECK(
         it != gpulw.nonDivisibleSplitInfo().splitsToPredicate().end(),
         "No info found for ",
         tv);
     const auto& splits_to_predicate = it->second;
-    TORCH_CHECK(
+    NVF_CHECK(
         splits_to_predicate.size() == 1,
         "There must be one split to predicate");
   }
@@ -138,20 +139,20 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit2_CUDA) {
   tv1->setMemoryType(MemoryType::Shared);
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToValidate().empty(),
       "There must be no split to validate");
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToPredicate().size() == 1,
       "Only tv2 should have a non-divisible predicate.");
   for (auto tv : {loweredTv(tv2, gpulw)}) {
     auto it = gpulw.nonDivisibleSplitInfo().splitsToPredicate().find(tv);
-    TORCH_CHECK(
+    NVF_CHECK(
         it != gpulw.nonDivisibleSplitInfo().splitsToPredicate().end(),
         "No info found for ",
         tv);
     const auto& splits_to_predicate = it->second;
-    TORCH_CHECK(
+    NVF_CHECK(
         splits_to_predicate.size() == 1,
         "There must be one split to predicate");
   }
@@ -188,20 +189,20 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit3_CUDA) {
   tv2->axis(0)->parallelize(ParallelType::Unswitch);
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToValidate().empty(),
       "There must be no split to validate");
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToPredicate().size() == 2,
       "Both tv1 and tv2 should have a non-divisible predicate.");
   for (auto tv : {loweredTv(tv1, gpulw), loweredTv(tv2, gpulw)}) {
     auto it = gpulw.nonDivisibleSplitInfo().splitsToPredicate().find(tv);
-    TORCH_CHECK(
+    NVF_CHECK(
         it != gpulw.nonDivisibleSplitInfo().splitsToPredicate().end(),
         "No info found for ",
         tv);
     const auto& splits_to_predicate = it->second;
-    TORCH_CHECK(
+    NVF_CHECK(
         splits_to_predicate.size() == 1,
         "There must be one split to predicate");
   }
@@ -237,20 +238,20 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit4_CUDA) {
   tv0->computeAt(tv2, -1);
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToValidate().empty(),
       "There must be no split to validate");
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToPredicate().size() == 2,
       "Both tv1 and tv2 should have a non-divisible predicate.");
   for (auto tv : {loweredTv(tv1, gpulw), loweredTv(tv2, gpulw)}) {
     auto it = gpulw.nonDivisibleSplitInfo().splitsToPredicate().find(tv);
-    TORCH_CHECK(
+    NVF_CHECK(
         it != gpulw.nonDivisibleSplitInfo().splitsToPredicate().end(),
         "No info found for ",
         tv);
     const auto& splits_to_predicate = it->second;
-    TORCH_CHECK(
+    NVF_CHECK(
         splits_to_predicate.size() == 1,
         "There must be one split to predicate");
   }
@@ -290,20 +291,20 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit5_CUDA) {
   tv0->computeAt(tv2, -1);
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToValidate().empty(),
       "There must be no split to validate");
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToPredicate().size() == 2,
       "Both tv1 and tv2 should have a non-divisible predicate.");
   for (auto tv : {loweredTv(tv1, gpulw), loweredTv(tv2, gpulw)}) {
     auto it = gpulw.nonDivisibleSplitInfo().splitsToPredicate().find(tv);
-    TORCH_CHECK(
+    NVF_CHECK(
         it != gpulw.nonDivisibleSplitInfo().splitsToPredicate().end(),
         "No info found for ",
         tv);
     const auto& splits_to_predicate = it->second;
-    TORCH_CHECK(
+    NVF_CHECK(
         splits_to_predicate.size() == 1,
         "There must be one split to predicate");
   }
@@ -337,12 +338,12 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplitVectorize1_CUDA) {
   tv1->axis(-1)->parallelize(ParallelType::Vectorize);
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToValidate().size() == 1,
       "There should be one split to validate");
   for (const auto& kv : gpulw.nonDivisibleSplitInfo().splitsToPredicate()) {
     const auto& splits_to_predicate = kv.second;
-    TORCH_CHECK(
+    NVF_CHECK(
         splits_to_predicate.empty(),
         "There must be no split to predicate, but tensor t",
         kv.first->name(),
@@ -390,12 +391,12 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplitVectorize2_CUDA) {
   tv1->axis(2)->parallelize(ParallelType::Vectorize);
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       gpulw.nonDivisibleSplitInfo().splitsToValidate().size() == 1,
       "There should be one split to validate");
   for (const auto& kv : gpulw.nonDivisibleSplitInfo().splitsToPredicate()) {
     const auto& splits_to_predicate = kv.second;
-    TORCH_CHECK(
+    NVF_CHECK(
         splits_to_predicate.empty(),
         "There must be no split to predicate, but tensor t",
         kv.first->name(),
@@ -446,8 +447,8 @@ TEST_F(NVFuserTest, FusionIssue1284Repro_CUDA) {
   auto t1 = at_in_1 + 2;
 
   auto runtime = fec.getMostRecentKernelRuntime();
-  TORCH_INTERNAL_ASSERT(runtime->isSegmented());
-  TORCH_INTERNAL_ASSERT(runtime->fusionSegments()->groups().size() == 2);
+  NVF_ERROR(runtime->isSegmented());
+  NVF_ERROR(runtime->fusionSegments()->groups().size() == 2);
 
   testValidate(
       &fusion, outputs, {at_in_0, at_in_1}, {at_in_0, t1}, __LINE__, __FILE__);
@@ -490,8 +491,8 @@ TEST_F(NVFuserTest, FusionIssue1284Repro2_CUDA) {
   auto t1 = at_in_0 + at_in_2;
 
   auto runtime = fec.getMostRecentKernelRuntime();
-  TORCH_INTERNAL_ASSERT(runtime->isSegmented());
-  TORCH_INTERNAL_ASSERT(runtime->fusionSegments()->groups().size() == 2);
+  NVF_ERROR(runtime->isSegmented());
+  NVF_ERROR(runtime->fusionSegments()->groups().size() == 2);
 
   testValidate(
       &fusion,
@@ -524,7 +525,7 @@ TEST_F(NVFuserTest, FusionIssue1305Repro_CUDA) {
 
   t3->computeAt(t7, -1, ComputeAtMode::MostInlined);
 
-  TORCH_INTERNAL_ASSERT(t3->getComputeAtPosition() == 1);
+  NVF_ERROR(t3->getComputeAtPosition() == 1);
 }
 
 TEST_F(NVFuserTest, FusionDoubleBuffering1_CUDA) {
@@ -983,7 +984,7 @@ TEST_F(NVFuserTest, FusionSmemBlockGemmCacheDoubleBuffer_CUDA) {
   //   insertion to ensure ordering of double buffered tensor access.
   // The check below makes sure that the sync is inserted so that the
   //   test isn't running on a race condition.
-  TORCH_CHECK(fe.kernel()->summary().war_hazard_syncs_count > 0);
+  NVF_CHECK(fe.kernel()->summary().war_hazard_syncs_count > 0);
 }
 
 TEST_F(NVFuserTest, FusionIntermediateTensorVectorize_CUDA) {
@@ -1057,9 +1058,9 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization1_CUDA) {
   }
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(!gpulw.concretizedBroadcastDomains()->isConcretized(
+  NVF_CHECK(!gpulw.concretizedBroadcastDomains()->isConcretized(
       loweredTv(tv4, gpulw)->axis(1)));
-  TORCH_CHECK(gpulw.concretizedBroadcastDomains()->isConcretized(
+  NVF_CHECK(gpulw.concretizedBroadcastDomains()->isConcretized(
       loweredTv(tv7, gpulw)->axis(1)));
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -1104,7 +1105,7 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization2_CUDA) {
   // no actual parallel broadcast
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       !gpulw.kernel()->summary().has_block_broadcasts &&
           !gpulw.kernel()->summary().has_grid_broadcasts,
       "There must be no parallel broadcast in this fusion");
@@ -1148,7 +1149,7 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization3_CUDA) {
   // be no parallel broadcast.
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       !gpulw.kernel()->summary().has_block_broadcasts &&
           !gpulw.kernel()->summary().has_grid_broadcasts,
       "There must be no parallel broadcast in this fusion");
@@ -1246,17 +1247,17 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization5_CUDA) {
 
   ConcretizedBroadcastDomains bcast_concretization_info(&fusion);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       bcast_concretization_info.maybeNonUniquelyConcretized(tv5->axis(1)),
       "Failed to detect non-unique concretization of ",
       tv5->toString());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       bcast_concretization_info.isUniquelyConcretized(tv11->axis(1)),
       "Failed to detect unique concretization of ",
       tv11->toString());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !bcast_concretization_info.isConcretized(tv17->axis(1)),
       "Failed to detect non-concretization of ",
       tv17->toString());
@@ -1417,7 +1418,7 @@ TEST_F(NVFuserTest, FusionCodegenAllocatedScalars_CUDA) {
                << indent << tk0_name << "[(0 + 1)]\n"
                << indent << indent << " = " << tk0_name << "[((0 + 1) + 1)];\n";
 
-  TORCH_CHECK(
+  NVF_CHECK(
       no_alloc_code.find(no_alloc_ref.str()) != std::string::npos,
       "Invalid code generation. Expected:",
       no_alloc_ref.str(),
@@ -1440,7 +1441,7 @@ TEST_F(NVFuserTest, FusionCodegenAllocatedScalars_CUDA) {
             << indent << indent << " = " << tk0_name << "[" << ks1_name
             << "];\n";
 
-  TORCH_CHECK(
+  NVF_CHECK(
       valid_code.find(valid_ref.str()) != std::string::npos,
       "Invalid code generation. Expected:",
       valid_ref.str(),
@@ -1504,13 +1505,13 @@ TEST_F(NVFuserTest, FusionIndexHoist1_CUDA) {
       innermost_loop = first_expr_loop;
     }
     const auto& exprs = innermost_loop->body().exprs();
-    TORCH_CHECK(!exprs.empty(), "No expression found");
-    TORCH_CHECK(
+    NVF_CHECK(!exprs.empty(), "No expression found");
+    NVF_CHECK(
         exprs.at(0)->isA<kir::Allocate>(),
         "Invalid expression: ",
         exprs.at(0)->toString());
     auto hoisted_index = exprs.at(0)->as<kir::Allocate>()->buffer();
-    TORCH_CHECK(
+    NVF_CHECK(
         hoisted_index->dtype() == DataType::Index,
         "Invalid data type of hoisted indices. Should be nvfuser_index_t but: ",
         hoisted_index->dtype());
@@ -1524,24 +1525,24 @@ TEST_F(NVFuserTest, FusionIndexHoist1_CUDA) {
           // Ref: T1[*, hoisted_index] = T0[*, hoisted_index * T0.stride];
           auto t1_index =
               out_ti->index()->definition()->as<BinaryOp>()->input(1);
-          TORCH_CHECK(
+          NVF_CHECK(
               t1_index == hoisted_index,
               "Invalid index: ",
               t1_index->toInlineString());
           // Pred: hoisted_index < T0.size[1]
-          TORCH_CHECK(
+          NVF_CHECK(
               pred->value()->definition()->as<BinaryOp>()->lhs() ==
                   hoisted_index,
               "Invalid predicate: ",
               pred->value()->toInlineString(),
               ", ",
               expr->toString());
-          TORCH_CHECK(arith_expr->inputs().size() == 1);
+          NVF_CHECK(arith_expr->inputs().size() == 1);
           auto in0 = arith_expr->inputs().front()->as<kir::TensorIndex>();
-          TORCH_CHECK(in0->view()->name() == 0);
+          NVF_CHECK(in0->view()->name() == 0);
           // hoisted_index * T0.stride[1]
           auto t0_index = in0->index()->definition()->as<BinaryOp>()->input(1);
-          TORCH_CHECK(
+          NVF_CHECK(
               is_index_times_ns(t0_index, hoisted_index, "T0.stride[1]"),
               "Invalid index: ",
               t0_index->toInlineString(),
@@ -1551,24 +1552,24 @@ TEST_F(NVFuserTest, FusionIndexHoist1_CUDA) {
           // Ref: T3[*, hoisted_index] = T2[*, hoisted_index];
           auto out_index =
               out_ti->index()->definition()->as<BinaryOp>()->input(1);
-          TORCH_CHECK(
+          NVF_CHECK(
               out_index == hoisted_index,
               "Invalid index: ",
               out_index->toInlineString(),
               ", ",
               expr->toString());
-          TORCH_CHECK(
+          NVF_CHECK(
               pred->value()->definition()->as<BinaryOp>()->lhs() ==
                   hoisted_index,
               "Invalid predicate: ",
               pred->value()->toInlineString(),
               ", ",
               expr->toString());
-          TORCH_CHECK(arith_expr->inputs().size() == 1);
+          NVF_CHECK(arith_expr->inputs().size() == 1);
           auto in0 = arith_expr->inputs().front()->as<kir::TensorIndex>();
-          TORCH_CHECK(in0->view()->name() == 1);
+          NVF_CHECK(in0->view()->name() == 1);
           auto in0_index = in0->index()->definition()->as<BinaryOp>()->input(1);
-          TORCH_CHECK(
+          NVF_CHECK(
               in0_index == hoisted_index,
               "Invalid index: ",
               in0_index->toInlineString(),
@@ -1577,24 +1578,24 @@ TEST_F(NVFuserTest, FusionIndexHoist1_CUDA) {
         } else if (out_ti->view()->name() == 3) {
           // Ref: T3[hoisted_index] = T2[hoisted_index];
           auto out_index = out_ti->index();
-          TORCH_CHECK(
+          NVF_CHECK(
               out_index == hoisted_index,
               "Invalid index: ",
               out_index->toInlineString(),
               ", ",
               expr->toString());
-          TORCH_CHECK(
+          NVF_CHECK(
               pred->value()->definition()->as<BinaryOp>()->lhs() ==
                   hoisted_index,
               "Invalid predicate: ",
               pred->value()->toInlineString(),
               ", ",
               expr->toString());
-          TORCH_CHECK(arith_expr->inputs().size() == 1);
+          NVF_CHECK(arith_expr->inputs().size() == 1);
           auto in0 = arith_expr->inputs().front()->as<kir::TensorIndex>();
-          TORCH_CHECK(in0->view()->name() == 2);
+          NVF_CHECK(in0->view()->name() == 2);
           auto in0_index = in0->index();
-          TORCH_CHECK(
+          NVF_CHECK(
               in0_index == hoisted_index,
               "Invalid index: ",
               in0_index->toInlineString(),
@@ -1602,18 +1603,18 @@ TEST_F(NVFuserTest, FusionIndexHoist1_CUDA) {
               expr->toString());
         } else if (out_ti->view()->name() == 4) {
           // Ref: T4[0] = T3[hoisted_index];
-          TORCH_CHECK(
+          NVF_CHECK(
               pred->value()->definition()->as<BinaryOp>()->lhs() ==
                   hoisted_index,
               "Invalid predicate: ",
               pred->value()->toInlineString(),
               ", ",
               expr->toString());
-          TORCH_CHECK(arith_expr->inputs().size() == 1);
+          NVF_CHECK(arith_expr->inputs().size() == 1);
           auto in0 = arith_expr->inputs().front()->as<kir::TensorIndex>();
-          TORCH_CHECK(in0->view()->name() == 3);
+          NVF_CHECK(in0->view()->name() == 3);
           auto in0_index = in0->index();
-          TORCH_CHECK(
+          NVF_CHECK(
               in0_index == hoisted_index,
               "Invalid index: ",
               in0_index->toInlineString(),
@@ -1622,13 +1623,13 @@ TEST_F(NVFuserTest, FusionIndexHoist1_CUDA) {
         } else if (out_ti->view()->name() == 5) {
           // Ref: T5[hoisted_index] = T4[0]
           auto out_index = out_ti->index();
-          TORCH_CHECK(
+          NVF_CHECK(
               out_index == hoisted_index,
               "Invalid index: ",
               out_index->toInlineString(),
               ", ",
               expr->toString());
-          TORCH_CHECK(
+          NVF_CHECK(
               pred->value()->definition()->as<BinaryOp>()->lhs() ==
                   hoisted_index,
               "Invalid predicate: ",
@@ -2068,7 +2069,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndex_CUDA) {
   fe.compileFusion(&fusion, {t0});
   auto cg_outputs = fe.runFusion({t0});
 
-  TORCH_CHECK(t0.equal(cg_outputs[0]));
+  NVF_CHECK(t0.equal(cg_outputs[0]));
 }
 
 // Make sure the same fusion as FusionVectorizeContigIndex fails if
@@ -2170,7 +2171,7 @@ TEST_F(NVFuserTest, FusionVectorizeInputToOutput_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, {t0});
   auto cg_outputs = fe.runFusion({t0});
-  TORCH_CHECK(t0.equal(cg_outputs[0]));
+  NVF_CHECK(t0.equal(cg_outputs[0]));
 
   // Pass misaligned input. This must fail.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
@@ -2380,7 +2381,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndexPointwiseSchedule_CUDA) {
   // vector word size should be 4. Broadcasting of tv1 should not
   // matter.
   for (const auto& vec_info : kernel->summary().vectorized_set_info) {
-    TORCH_CHECK(
+    NVF_CHECK(
         vec_info.word_size == 4,
         "Invalid vector word size: ",
         vec_info.word_size);
@@ -2634,7 +2635,7 @@ TEST_F(NVFuserTest, FusionRAWSyncInsertionPlace4_CUDA) {
     void handle(kir::BlockSync* bsync) final {
       // Make sure both shared memory modifying expressions
       //  have been observed at the sync insertion point.
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           number_of_writes_ == 2,
           "FusionRAWSyncInsertionPlace4 test fail:",
           "only 1 sync after the 2 shared mem writes is needed in this test,"
@@ -2929,7 +2930,7 @@ TEST_F(NVFuserTest, FusionDoubleBufferNoSync_CUDA) {
       flattened_exprs.begin(), flattened_exprs.end(), [](Expr* expr) {
         return expr->isA<kir::BlockSync>();
       });
-  TORCH_INTERNAL_ASSERT(!sync_inserted, "Un-expected block sync inserted");
+  NVF_ERROR(!sync_inserted, "Un-expected block sync inserted");
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, {t0, t1});
@@ -3029,7 +3030,7 @@ TEST_F(NVFuserTest, FusionPredRemovalCheck_CUDA) {
           return;
         }
         if (auto ite = dynamic_cast<kir::IfThenElse*>(scope_exprs_.back())) {
-          TORCH_INTERNAL_ASSERT(
+          NVF_ERROR(
               ite->predicate()->value()->isConst(),
               "redundant predicate on: ",
               expr);
@@ -3073,12 +3074,12 @@ TEST_F(NVFuserTest, FusionPropagateParallelTypesToSiblings_CUDA) {
       if (ref == sibling) {
         continue;
       }
-      TORCH_CHECK(
+      NVF_CHECK(
           ref->nDims() == sibling->nDims(),
           "Invalid sibling: ",
           sibling->toString());
       for (const auto i : c10::irange(ref->nDims())) {
-        TORCH_CHECK(
+        NVF_CHECK(
             ref->axis(i)->getParallelType() ==
                 sibling->axis(i)->getParallelType(),
             "Mismatched parallel types between siblings. ",
@@ -3128,7 +3129,7 @@ TEST_F(NVFuserTest, FusionExactRootDomainMap_CUDA) {
   auto tv2_bc = tv2->axis(1);
   auto tv3_bc = tv3->axis(0);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       exact_map.areMapped(tv2_bc, tv3_bc),
       "Invalid exact root domain map: ",
       exact_map.toString());
@@ -3139,11 +3140,11 @@ TEST_F(NVFuserTest, FusionExactRootDomainMap_CUDA) {
       if (root_id == tv2_bc || root_id == tv3_bc) {
         continue;
       }
-      TORCH_CHECK(
+      NVF_CHECK(
           !exact_map.areMapped(root_id, tv2_bc),
           "Invalid exact root domain map: ",
           exact_map.toString());
-      TORCH_CHECK(
+      NVF_CHECK(
           !exact_map.areMapped(root_id, tv3_bc),
           "Invalid exact root domain map: ",
           exact_map.toString());
@@ -3387,7 +3388,7 @@ TEST_F(NVFuserTest, FusionTestReEntrantGridWelford_CUDA) {
         auto alias_tv = alias_map_.at(out_tv);
         for (auto inp_ti : ir_utils::filterByType<kir::TensorIndex>(
                  gwop->welford_op()->inputs())) {
-          TORCH_CHECK(
+          NVF_CHECK(
               inp_ti->view() != alias_tv,
               "Invalid alias found between GridWelford input and output. Out tv: ",
               out_tv->toString(),
@@ -3465,7 +3466,7 @@ TEST_F(NVFuserTest, FusionRedundantPredSync_CUDA) {
       flattened_exprs.begin(), flattened_exprs.end(), [](Expr* expr) {
         return expr->isA<kir::BlockSync>();
       });
-  TORCH_INTERNAL_ASSERT(sync_inserted, "Expected block sync not inserted");
+  NVF_ERROR(sync_inserted, "Expected block sync not inserted");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
@@ -3532,8 +3533,7 @@ TEST_F(NVFuserTest, FusionRedundantPredSync2_CUDA) {
 
   GpuLower gpulw(&fusion);
   checker.handle(gpulw.kernel()->topLevelExprs());
-  TORCH_INTERNAL_ASSERT(
-      checker.result() < 2, "More syncs were inserted than expected");
+  NVF_ERROR(checker.result() < 2, "More syncs were inserted than expected");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
@@ -3615,7 +3615,7 @@ TEST_F(NVFuserTest, FusionRedundantPredSync3_CUDA) {
   //  where RAW hazards happen: one producing tv2 and the other
   //  producing tv3. This test case expect syncs in both of
   //  these places so we check that 2 RAW syncs are inserted.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       checker.result() == 2,
       "Exactly 2 RAW sync expected for the two shared memory transfers");
 
@@ -3679,7 +3679,7 @@ TEST_F(NVFuserTest, FusionRedundantUseCheck_CUDA) {
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       lowered_tv2 != nullptr && lowered_tv4 != nullptr,
       "tv2 or tv4 not lowered or mangled");
 
@@ -3689,14 +3689,14 @@ TEST_F(NVFuserTest, FusionRedundantUseCheck_CUDA) {
   // tv2 -> tv3 -> tv4 (shared) is the only use chain for tv2,
   //  and tv4 is redundantly written in tidx so tv2 is redundantly
   //  consumed in tidx.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       tv2_info.redundant_use_types.get(ParallelType::TIDx),
       "TV2 is redundantly used but not detected.");
 
   // tv4->tv5 (global) is a redundant use chain, but
   // tv4->tv6->tv7 is not, so tv4 should not be detected as
   // a redundant used tensor in tidx.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       !tv4_info.redundant_use_types.get(ParallelType::TIDx),
       "TV4 is not redundantly used but not detected.");
 }
@@ -3716,9 +3716,8 @@ TEST_F(NVFuserTest, FusionUnsqueeze1_CUDA) {
   auto tv2 = unsqueeze(tv1, -1);
   fusion.addOutput(tv2);
 
-  TORCH_CHECK(
-      tv2->nDims() == 2, "Unpected unsqueeze result: ", tv2->toString());
-  TORCH_CHECK(
+  NVF_CHECK(tv2->nDims() == 2, "Unpected unsqueeze result: ", tv2->toString());
+  NVF_CHECK(
       tv2->axis(1)->isBroadcast(),
       "Unexpected unsqueeze result: ",
       tv2->toString());
@@ -3756,8 +3755,7 @@ TEST_F(NVFuserTest, FusionSqueeze1_CUDA) {
   auto tv2 = squeeze(tv1, std::vector<int64_t>{shape[0], 1});
   fusion.addOutput(tv2);
 
-  TORCH_CHECK(
-      tv2->nDims() == 1, "Unexpected squeeze result: ", tv2->toString());
+  NVF_CHECK(tv2->nDims() == 1, "Unexpected squeeze result: ", tv2->toString());
 
   // [I, R]
   auto tv3 = sum(tv0, {1});
@@ -3795,7 +3793,7 @@ TEST_F(NVFuserTest, FusionContigPredicate_CUDA) {
   tv0->computeAt(tv2, -1);
 
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(PredicatedChecker::isPredicated(tv1, gpulw));
+  NVF_CHECK(PredicatedChecker::isPredicated(tv1, gpulw));
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({3, 4}, options);
@@ -3945,14 +3943,14 @@ TEST_F(NVFuserTest, FusionExpand_CUDA) {
   auto cg_outputs = executor_cache.runFusionWithInputs({t0, t3, t6, w});
   auto cg_out = cg_outputs[1];
 
-  TORCH_INTERNAL_ASSERT(cg_out.size(0) == w);
-  TORCH_INTERNAL_ASSERT(cg_out.size(1) == x);
-  TORCH_INTERNAL_ASSERT(cg_out.size(2) == y);
-  TORCH_INTERNAL_ASSERT(cg_out.size(3) == z);
-  TORCH_INTERNAL_ASSERT(cg_out.stride(0) == 0);
-  TORCH_INTERNAL_ASSERT(cg_out.stride(1) == 1);
-  TORCH_INTERNAL_ASSERT(cg_out.stride(2) == 0);
-  TORCH_INTERNAL_ASSERT(cg_out.stride(3) == 0);
+  NVF_ERROR(cg_out.size(0) == w);
+  NVF_ERROR(cg_out.size(1) == x);
+  NVF_ERROR(cg_out.size(2) == y);
+  NVF_ERROR(cg_out.size(3) == z);
+  NVF_ERROR(cg_out.stride(0) == 0);
+  NVF_ERROR(cg_out.stride(1) == 1);
+  NVF_ERROR(cg_out.stride(2) == 0);
+  NVF_ERROR(cg_out.stride(3) == 0);
 
   auto t10 = t0.unsqueeze(-1)
                  .expand({x, y})
@@ -4010,9 +4008,9 @@ TEST_F(NVFuserTest, FusionExpandIssue1751_CUDA) {
   auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   for (const auto& cg_out : cg_outputs) {
-    TORCH_INTERNAL_ASSERT(cg_out.size(0) == x);
-    TORCH_INTERNAL_ASSERT(cg_out.size(1) == y);
-    TORCH_INTERNAL_ASSERT(cg_out.size(2) == z);
+    NVF_ERROR(cg_out.size(0) == x);
+    NVF_ERROR(cg_out.size(1) == y);
+    NVF_ERROR(cg_out.size(2) == z);
   }
 
   auto t2 = t0.expand({x, y, z});
@@ -4047,8 +4045,8 @@ TEST_F(NVFuserTest, FusionExpandToConcrete_CUDA) {
   auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   for (const auto& cg_out : cg_outputs) {
-    TORCH_INTERNAL_ASSERT(cg_out.size(0) == x);
-    TORCH_INTERNAL_ASSERT(cg_out.size(1) == y);
+    NVF_ERROR(cg_out.size(0) == x);
+    NVF_ERROR(cg_out.size(1) == y);
   }
 
   auto t2 = t0.expand({x, y});
@@ -4129,7 +4127,7 @@ TEST_F(NVFuserTest, FusionTransformPropagateSibling_CUDA) {
   for (const auto& tensors : siblings) {
     for (auto t1 : tensors) {
       for (auto t2 : tensors) {
-        TORCH_CHECK(TransformReplay::fullSelfMatching(t1, t2));
+        NVF_CHECK(TransformReplay::fullSelfMatching(t1, t2));
       }
     }
   }
@@ -4190,7 +4188,7 @@ TEST_F(NVFuserTest, FusionTransformPropagateSelectorSibling_CUDA) {
     for (const auto& tensors : siblings) {
       for (auto t1 : tensors) {
         for (auto t2 : tensors) {
-          TORCH_CHECK(TransformReplay::fullSelfMatching(t1, t2));
+          NVF_CHECK(TransformReplay::fullSelfMatching(t1, t2));
         }
       }
     }
@@ -4219,7 +4217,7 @@ TEST_F(NVFuserTest, FusionTransformPropagatePosition_CUDA) {
   TransformPropagatorWithCheck propagator(tv0);
   MaxRootDomainInfoSpanningTree(tv0).traverse(&propagator);
 
-  TORCH_CHECK(tv1->nDims() == 4);
+  NVF_CHECK(tv1->nDims() == 4);
 }
 
 TEST_F(NVFuserTest, FusionIgnoreZeroDimReduction_CUDA) {
@@ -4236,7 +4234,7 @@ TEST_F(NVFuserTest, FusionIgnoreZeroDimReduction_CUDA) {
   fusion->addOutput(tv2);
 
   auto tv2_def = dynamic_cast<LoadStoreOp*>(tv2->definition());
-  TORCH_CHECK(
+  NVF_CHECK(
       tv2_def != nullptr,
       "Expected LoadStoreOp but found ",
       tv2->definition()->toString());
@@ -4331,11 +4329,11 @@ TEST_F(NVFuserTest, FusionTransformPropagatorSelector_CUDA) {
   TransformPropagatorWithCheck propagator(tv2);
   MaxRootDomainInfoSpanningTree(tv2, &selector).traverse(&propagator);
 
-  TORCH_CHECK(tv0->nDims() == 2);
-  TORCH_CHECK(tv1->nDims() == 1);
-  TORCH_CHECK(tv2->nDims() == 2);
-  TORCH_CHECK(tv3->nDims() == 2);
-  TORCH_CHECK(tv4->nDims() == 1);
+  NVF_CHECK(tv0->nDims() == 2);
+  NVF_CHECK(tv1->nDims() == 1);
+  NVF_CHECK(tv2->nDims() == 2);
+  NVF_CHECK(tv3->nDims() == 2);
+  NVF_CHECK(tv4->nDims() == 1);
 }
 
 TEST_F(NVFuserTest, FusionTransformPropagatorPos_CUDA) {
@@ -4357,7 +4355,7 @@ TEST_F(NVFuserTest, FusionTransformPropagatorPos_CUDA) {
 
   auto expect = makeConcreteTensor({22, 105});
   expect->split(0, 2);
-  TORCH_CHECK(TransformReplay::fullSelfMatching(expect, tv0));
+  NVF_CHECK(TransformReplay::fullSelfMatching(expect, tv0));
 }
 
 TEST_F(NVFuserTest, FusionMaxRootDomainInfoSpanningTreePrintTwice_CUDA) {
@@ -4407,8 +4405,8 @@ propagateP2C
 from: 1
 to: 2
 )ESCAPE";
-  TORCH_CHECK(printer1.ss.str() == expect);
-  TORCH_CHECK(printer2.ss.str() == expect);
+  NVF_CHECK(printer1.ss.str() == expect);
+  NVF_CHECK(printer2.ss.str() == expect);
 }
 
 TEST_F(NVFuserTest, FusionTransformPropagatorNoOverwrite_CUDA) {
@@ -4433,16 +4431,16 @@ TEST_F(NVFuserTest, FusionTransformPropagatorNoOverwrite_CUDA) {
   TransformPropagatorWithCheck propagator2(tv0);
   path2.traverse(&propagator2);
 
-  TORCH_CHECK(tv1->axis(0)->isBroadcast());
-  TORCH_CHECK(tv1->axis(1)->isBroadcast());
-  TORCH_CHECK(!tv1->axis(2)->isBroadcast());
-  TORCH_CHECK(!tv1->axis(3)->isBroadcast());
-  TORCH_CHECK(tv1->axis(4)->isBroadcast());
+  NVF_CHECK(tv1->axis(0)->isBroadcast());
+  NVF_CHECK(tv1->axis(1)->isBroadcast());
+  NVF_CHECK(!tv1->axis(2)->isBroadcast());
+  NVF_CHECK(!tv1->axis(3)->isBroadcast());
+  NVF_CHECK(tv1->axis(4)->isBroadcast());
 
   auto expect = makeSymbolicTensor(3);
   expect->split(1, 2);
   expect->split(0, 4);
-  TORCH_CHECK(TransformReplay::fullSelfMatching(expect, tv1));
+  NVF_CHECK(TransformReplay::fullSelfMatching(expect, tv1));
 }
 
 TEST_F(NVFuserTest, FusionIssue1785Repro_CUDA) {
@@ -4548,11 +4546,11 @@ TEST_F(NVFuserTest, FusionInlineRepro1803_CUDA) {
 
   tv0->computeAt(tvo, -1, ComputeAtMode::BestEffort);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       tvs.var_sum->getComputeAtPosition() == tvs.avg->getComputeAtPosition());
-  TORCH_CHECK(
+  NVF_CHECK(
       tvs.var_sum->getComputeAtPosition() == tvs.n->getComputeAtPosition());
-  TORCH_CHECK(tvs.var_sum->getComputeAtPosition() == 1);
+  NVF_CHECK(tvs.var_sum->getComputeAtPosition() == 1);
 }
 
 // Unit test for the transform selection logic
@@ -4575,7 +4573,7 @@ TEST_F(NVFuserTest, FusionBoundedDirectionSelection1_CUDA) {
       tv3, -1, {tv0, tv2});
 
   // Check that the splits are replayed on tv2
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       tv2->nDims() == tv3->nDims(),
       "Propagator didn't propagate to tv2: ",
       tv2->toString());
@@ -4583,7 +4581,7 @@ TEST_F(NVFuserTest, FusionBoundedDirectionSelection1_CUDA) {
   // Check that the splits are replayed on tv1 as well. Even though
   //  one of its consumers, tv2, is part of the boundary, another
   //  consumer is not a boundary, so tv1 should be transformed as well.
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       tv1->nDims() == tv3->nDims(),
       "Propagator didn't propagate to tv1: ",
       tv1->toString());
@@ -4669,7 +4667,7 @@ TEST_F(NVFuserTest, FusionInsertMagicZero1_CUDA) {
 
   // The predicate of tv2 should be protected with magic zero
   GpuLower gpulw(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       PredicateMagicZeroChecker::isProtected(tv2, gpulw),
       "Failed to protect the predicates of ",
       tv2->toString());
@@ -4924,11 +4922,11 @@ TEST_F(NVFuserTest, FusionInliningMismatchedDims1_CUDA) {
 
   inlineMost();
 
-  TORCH_CHECK(tv5->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv4->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv3->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv2->getComputeAtPosition() == 1);
-  TORCH_CHECK(tv1->getComputeAtPosition() == 3);
+  NVF_CHECK(tv5->getComputeAtPosition() == 3);
+  NVF_CHECK(tv4->getComputeAtPosition() == 3);
+  NVF_CHECK(tv3->getComputeAtPosition() == 3);
+  NVF_CHECK(tv2->getComputeAtPosition() == 1);
+  NVF_CHECK(tv1->getComputeAtPosition() == 3);
 
   const auto options =
       at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -4957,11 +4955,11 @@ TEST_F(NVFuserTest, FusionInliningMismatchedDims2_CUDA) {
 
   inlineAllAt(tv5, -1, true);
 
-  TORCH_CHECK(tv5->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv4->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv3->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv2->getComputeAtPosition() == 1);
-  TORCH_CHECK(tv1->getComputeAtPosition() == 1);
+  NVF_CHECK(tv5->getComputeAtPosition() == 3);
+  NVF_CHECK(tv4->getComputeAtPosition() == 3);
+  NVF_CHECK(tv3->getComputeAtPosition() == 3);
+  NVF_CHECK(tv2->getComputeAtPosition() == 1);
+  NVF_CHECK(tv1->getComputeAtPosition() == 1);
 
   const auto options =
       at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -4991,11 +4989,11 @@ TEST_F(NVFuserTest, FusionInliningMismatchedDims4_CUDA) {
   tv3->merge(1);
   inlineMost();
 
-  TORCH_CHECK(tv5->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv4->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv3->getComputeAtPosition() == 1);
-  TORCH_CHECK(tv2->getComputeAtPosition() == 1);
-  TORCH_CHECK(tv1->getComputeAtPosition() == 3);
+  NVF_CHECK(tv5->getComputeAtPosition() == 3);
+  NVF_CHECK(tv4->getComputeAtPosition() == 3);
+  NVF_CHECK(tv3->getComputeAtPosition() == 1);
+  NVF_CHECK(tv2->getComputeAtPosition() == 1);
+  NVF_CHECK(tv1->getComputeAtPosition() == 3);
 
   const auto options =
       at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -5030,10 +5028,10 @@ TEST_F(NVFuserTest, FusionInliningBroadcast_CUDA) {
 
   inlineMost();
 
-  TORCH_CHECK(tv4->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv3->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv2->getComputeAtPosition() == 3);
-  TORCH_CHECK(tv1->getComputeAtPosition() == 3);
+  NVF_CHECK(tv4->getComputeAtPosition() == 3);
+  NVF_CHECK(tv3->getComputeAtPosition() == 3);
+  NVF_CHECK(tv2->getComputeAtPosition() == 3);
+  NVF_CHECK(tv1->getComputeAtPosition() == 3);
 
   const auto options =
       at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -5063,13 +5061,13 @@ TEST_F(NVFuserTest, FusionMatchedLeafPosWithoutReplayBroadcast_CUDA) {
     tv->merge(2);
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       TransformReplay::getMatchedLeafPosWithoutReplayPasC(tv0, tv1, 3) == 3);
-  TORCH_CHECK(
+  NVF_CHECK(
       TransformReplay::getMatchedLeafPosWithoutReplayCasP(tv1, tv0, 3) == 3);
-  TORCH_CHECK(
+  NVF_CHECK(
       TransformReplay::getMatchedLeafPosWithoutReplayPasC(tv1, tv2, 3) == 3);
-  TORCH_CHECK(
+  NVF_CHECK(
       TransformReplay::getMatchedLeafPosWithoutReplayCasP(tv2, tv1, 3) == 3);
 }
 
@@ -5208,10 +5206,10 @@ TEST_F(NVFuserTest, FusionDependencyCheck_CUDA) {
     std::unordered_set<Val*> all_vals_set(all_vals.begin(), all_vals.end());
     std::vector<Val*> results({tv0, tv1, tv4, tv5, tv6, tv7, tv8});
     for (auto result : results) {
-      TORCH_CHECK(all_vals_set.count(result) > 0);
+      NVF_CHECK(all_vals_set.count(result) > 0);
       all_vals_set.erase(result);
     }
-    TORCH_CHECK(all_vals_set.empty());
+    NVF_CHECK(all_vals_set.empty());
   }
 
   auto tv10 = add(tv6, tv7);
@@ -5220,10 +5218,10 @@ TEST_F(NVFuserTest, FusionDependencyCheck_CUDA) {
     std::unordered_set<Val*> all_vals_set(all_vals.begin(), all_vals.end());
     std::vector<Val*> results({tv0, tv1, tv6, tv7, tv10});
     for (auto result : results) {
-      TORCH_CHECK(all_vals_set.count(result) > 0);
+      NVF_CHECK(all_vals_set.count(result) > 0);
       all_vals_set.erase(result);
     }
-    TORCH_CHECK(all_vals_set.empty());
+    NVF_CHECK(all_vals_set.empty());
   }
 }
 
@@ -5370,10 +5368,10 @@ TEST_F(NVFuserTest, AsyncCompilation_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation didn't happen");
-  TORCH_CHECK(
+  NVF_CHECK(
       executor_cache.getMostRecentKernelRuntime()
               ->fusionSegments()
               ->groups()
@@ -5448,7 +5446,7 @@ TEST_F(NVFuserTest, FusionNullScheduler_CUDA) {
 
   // Check that all groups on the resulting runtime are null.
   for (auto group : groups) {
-    TORCH_INTERNAL_ASSERT(group->heuristic() == ScheduleHeuristic::NoOp);
+    NVF_ERROR(group->heuristic() == ScheduleHeuristic::NoOp);
   }
 }
 
@@ -5482,7 +5480,7 @@ TEST_F(NVFuserTest, FusionNullScheduler2_CUDA) {
 
   // Check that all groups on the resulting runtime are null.
   for (auto group : groups) {
-    TORCH_INTERNAL_ASSERT(group->heuristic() == ScheduleHeuristic::NoOp);
+    NVF_ERROR(group->heuristic() == ScheduleHeuristic::NoOp);
   }
 }
 
@@ -5520,7 +5518,7 @@ TEST_F(NVFuserTest, FusionNullScheduler3_CUDA) {
 
   // Check that all groups on the resulting runtime are null.
   for (auto group : groups) {
-    TORCH_INTERNAL_ASSERT(group->heuristic() == ScheduleHeuristic::NoOp);
+    NVF_ERROR(group->heuristic() == ScheduleHeuristic::NoOp);
   }
 }
 
@@ -5582,7 +5580,7 @@ TEST_F(NVFuserTest, FusionEmpty_CUDA) {
 
   // Check that all groups on the resulting runtime are null.
   for (auto group : groups) {
-    TORCH_INTERNAL_ASSERT(group->heuristic() == ScheduleHeuristic::NoOp);
+    NVF_ERROR(group->heuristic() == ScheduleHeuristic::NoOp);
   }
 }
 
@@ -5612,9 +5610,9 @@ TEST_F(NVFuserTest, FusionMappingRelation_CUDA) {
   ComputeAtMap ca_map(fusion);
 
   auto tv4_inner_node = tv4->axis(0)->definition()->input(1)->as<IterDomain>();
-  TORCH_CHECK(
+  NVF_CHECK(
       ca_map.areMapped(tv2->axis(0), tv4_inner_node, IdMappingMode::EXACT));
-  TORCH_CHECK(ca_map.areMapped(
+  NVF_CHECK(ca_map.areMapped(
       tv2->axis(0), tv4_inner_node, IdMappingMode::PERMISSIVE));
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -5678,7 +5676,7 @@ TEST_F(NVFuserTest, FusionTrivialInputForwarding_CUDA) {
   testValidate(fusion, cg_outputs, {t0, t1}, {t0}, __LINE__, __FILE__);
 
   // Second run to ensure cache hit handles trivial forwarding properly
-  TORCH_CHECK(fec.isCompiled({t0, t1}));
+  NVF_CHECK(fec.isCompiled({t0, t1}));
   auto cg_outputs2 = fec.runFusionWithInputs({t0, t1});
   testValidate(fusion, cg_outputs2, {t0, t1}, {t0}, __LINE__, __FILE__);
 }
@@ -5701,7 +5699,7 @@ TEST_F(NVFuserTest, FusionTrivialInputForwarding2_CUDA) {
   testValidate(fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 
   // Second run to ensure cache hit handles trivial forwarding properly
-  TORCH_CHECK(fec.isCompiled({t0}));
+  NVF_CHECK(fec.isCompiled({t0}));
   auto cg_outputs2 = fec.runFusionWithInputs({t0});
   testValidate(fusion, cg_outputs2, {t0}, {t0}, __LINE__, __FILE__);
 }
@@ -5938,8 +5936,8 @@ TEST_F(NVFuserTest, FusionSimpleAmperePipeline_CUDA) {
 
     void handle(LoadStoreOp* ldst) final {
       if (ldst->opType() == LoadStoreOpType::CpAsyncCa) {
-        TORCH_INTERNAL_ASSERT(!within_ite_, "CPASYNC predicate not inlined");
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(!within_ite_, "CPASYNC predicate not inlined");
+        NVF_ERROR(
             ldst->predicate()->hasValue() &&
                 !ldst->predicate()->value()->isConst(),
             "CPASYNC predicate is not generated");
@@ -6377,9 +6375,9 @@ TEST_F(NVFuserTest, FusionSqueezeInlining_CUDA) {
     MaxRootDomainInfoSpanningTree tree(tv0);
     TransformPropagatorWithCheck tp(tv0);
     tree.traverse(&tp);
-    TORCH_CHECK(tv2->nDims() == 2);
-    TORCH_CHECK(tv1->nDims() == 2);
-    TORCH_CHECK(tv0->nDims() == 2);
+    NVF_CHECK(tv2->nDims() == 2);
+    NVF_CHECK(tv1->nDims() == 2);
+    NVF_CHECK(tv0->nDims() == 2);
   }
 
   {
@@ -6388,9 +6386,9 @@ TEST_F(NVFuserTest, FusionSqueezeInlining_CUDA) {
     MaxRootDomainInfoSpanningTree tree(tv2);
     TransformPropagatorWithCheck tp(tv2);
     tree.traverse(&tp);
-    TORCH_CHECK(tv2->nDims() == 2);
-    TORCH_CHECK(tv1->nDims() == 2);
-    TORCH_CHECK(tv0->nDims() == 2);
+    NVF_CHECK(tv2->nDims() == 2);
+    NVF_CHECK(tv1->nDims() == 2);
+    NVF_CHECK(tv0->nDims() == 2);
   }
 
   tv1->axis(0)->parallelize(ParallelType::BIDx);
@@ -6400,8 +6398,8 @@ TEST_F(NVFuserTest, FusionSqueezeInlining_CUDA) {
 
   inlineMost();
 
-  TORCH_CHECK(tv1->getComputeAtPosition() == 2);
-  TORCH_CHECK(tv2->getComputeAtPosition() == 2);
+  NVF_CHECK(tv1->getComputeAtPosition() == 2);
+  NVF_CHECK(tv2->getComputeAtPosition() == 2);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({1, 1024}, options);
@@ -6724,12 +6722,12 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
       if (ldst->out()->as<kir::TensorIndex>()->view()->name() == 2) {
         // Make sure the index of the inner loop isn't used in the
         // predicate of the tv2 expression
-        TORCH_INTERNAL_ASSERT(!scope_exprs_.empty());
-        TORCH_INTERNAL_ASSERT(scope_exprs_.back()->isA<kir::IfThenElse>());
+        NVF_ERROR(!scope_exprs_.empty());
+        NVF_ERROR(scope_exprs_.back()->isA<kir::IfThenElse>());
         auto ite = scope_exprs_.back()->as<kir::IfThenElse>();
         auto cond = ite->predicate()->value();
         // Make sure the index of the inner loop isn't used in the predicate
-        TORCH_INTERNAL_ASSERT(!for_loops_.empty());
+        NVF_ERROR(!for_loops_.empty());
         auto loop_index = for_loops_.back()->index();
         auto cond_inputs = InputsOf::output(cond->fusion(), cond);
         auto index_it =
@@ -6744,26 +6742,26 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
         // If vectorized, the predicate should use (vec_factor - 1) or
         // -(vec_factor - 1) rather than the loop index.
         if (vectorized_) {
-          TORCH_CHECK(
+          NVF_CHECK(
               index_it == cond_inputs.end(),
               "Not expected to have ",
               loop_index->toInlineString(),
               " in ",
               cond->toInlineString());
-          TORCH_CHECK(
+          NVF_CHECK(
               vec_factor_it != cond_inputs.end(),
               "Expected to have ",
               vec_factor - 1,
               " in ",
               cond->toInlineString());
         } else {
-          TORCH_CHECK(
+          NVF_CHECK(
               index_it != cond_inputs.end(),
               "Expected to have ",
               loop_index->toInlineString(),
               " in ",
               cond->toInlineString());
-          TORCH_CHECK(
+          NVF_CHECK(
               vec_factor_it == cond_inputs.end(),
               "Not expected to have ",
               vec_factor - 1,
@@ -6798,7 +6796,7 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
   fe.compileFusion(&fusion, {t0});
   auto cg_outputs = fe.runFusion({t0});
 
-  TORCH_CHECK(t0.equal(cg_outputs[0]));
+  NVF_CHECK(t0.equal(cg_outputs[0]));
 }
 
 TEST_F(NVFuserTest, FusionSqueezeOnlyWelford_CUDA) {
@@ -6926,48 +6924,48 @@ TEST_F(NVFuserTest, FusionFloatingPointType_CUDA) {
     fusion.addInput(tv0);
 
     auto f2 = IrBuilder::create<Val>(float_val, DataType::Float);
-    TORCH_CHECK(
+    NVF_CHECK(
         f2->getDataType() == DataType::Float,
         "Invalid data type: ",
         f2->getDataType().value());
 
     auto d3 = IrBuilder::create<Val>(double_val, DataType::Double);
-    TORCH_CHECK(
+    NVF_CHECK(
         d3->getDataType() == DataType::Double,
         "Invalid data type: ",
         d3->getDataType().value());
 
     // Adding two Floats produces a Float
     auto f4 = add(f2, f2);
-    TORCH_CHECK(
+    NVF_CHECK(
         f4->getDataType() == DataType::Float,
         "Invalid data type: ",
         f4->getDataType().value());
 
     // Adding a Double and a Float produces a Double
     auto d5 = add(f2, d3);
-    TORCH_CHECK(
+    NVF_CHECK(
         d5->getDataType() == DataType::Double,
         "Invalid data type: ",
         d5->getDataType().value());
 
     // Adding a Float and a Double produces a Double
     auto d6 = add(d3, f2);
-    TORCH_CHECK(
+    NVF_CHECK(
         d6->getDataType() == DataType::Double,
         "Invalid data type: ",
         d6->getDataType().value());
 
     // Adding two Doubles produce a Double
     auto d7 = add(d5, d6);
-    TORCH_CHECK(
+    NVF_CHECK(
         d7->getDataType() == DataType::Double,
         "Invalid data type: ",
         d7->getDataType().value());
 
     // Adding a Float to a Float tensor produces a Float tensor
     auto tv1 = add(tv0, f4);
-    TORCH_CHECK(
+    NVF_CHECK(
         tv1->getDataType() == DataType::Float,
         tv1->toString(),
         " has an invalid data type: ",
@@ -6975,7 +6973,7 @@ TEST_F(NVFuserTest, FusionFloatingPointType_CUDA) {
 
     // Adding a Double to a Float tensor still produces a Float tensor
     auto tv2 = add(tv1, d7);
-    TORCH_CHECK(
+    NVF_CHECK(
         tv2->getDataType() == DataType::Float,
         tv2->toString(),
         " has an invalid data type: ",
@@ -7021,28 +7019,28 @@ TEST_F(NVFuserTest, FusionIntegerType_CUDA) {
 
     // Adding two Ints produces an Int
     auto i4 = add(i2, i2);
-    TORCH_CHECK(
+    NVF_CHECK(
         i4->getDataType() == DataType::Int,
         "Invalid result: ",
         i4->toInlineString());
 
     // Adding two Int32s produces an Int32
     auto i5 = add(i3, i3);
-    TORCH_CHECK(
+    NVF_CHECK(
         i5->getDataType() == DataType::Int32,
         "Invalid result: ",
         i5->toInlineString());
 
     // Adding an Int and an Int32 produces an Int
     auto i6 = add(i4, i5);
-    TORCH_CHECK(
+    NVF_CHECK(
         i6->getDataType() == DataType::Int,
         "Invalid result: ",
         i6->toInlineString());
 
     // Adding an Int32 to an Int32 tensor produces an Int32 tensor
     auto tv1 = add(tv0, i4);
-    TORCH_CHECK(
+    NVF_CHECK(
         tv1->getDataType() == DataType::Int32,
         tv1->toString(),
         " has an invalid data type: ",
@@ -7050,7 +7048,7 @@ TEST_F(NVFuserTest, FusionIntegerType_CUDA) {
 
     // Adding an Int to an Int32 tensor still produces an Int32 tensor
     auto tv2 = add(tv1, i6);
-    TORCH_CHECK(
+    NVF_CHECK(
         tv2->getDataType() == DataType::Int32,
         tv2->toString(),
         " has an invalid data type: ",
@@ -7076,7 +7074,7 @@ TEST_F(NVFuserTest, FusionIntegerType_CUDA) {
   auto t1 = t0 + i4;
   auto t2 = t1 + i6;
 
-  TORCH_CHECK(cg_outputs.at(0).equal(t2));
+  NVF_CHECK(cg_outputs.at(0).equal(t2));
 }
 
 TEST_F(NVFuserTest, FusionVectorizeWelford1_CUDA) {
@@ -7110,7 +7108,7 @@ TEST_F(NVFuserTest, FusionVectorizeWelford1_CUDA) {
       std::count_if(all_exprs.begin(), all_exprs.end(), [](Expr* expr) {
         return expr->isStrictlyA<WelfordOp>();
       });
-  TORCH_CHECK(
+  NVF_CHECK(
       num_welford_ops == 0,
       "All WelfordOp exprs should be converted to VectorizedWelfordOp");
 
@@ -7118,7 +7116,7 @@ TEST_F(NVFuserTest, FusionVectorizeWelford1_CUDA) {
       std::count_if(all_exprs.begin(), all_exprs.end(), [](Expr* expr) {
         return expr->isStrictlyA<kir::VectorizedWelfordOp>();
       });
-  TORCH_CHECK(
+  NVF_CHECK(
       num_vectorized_welford_ops == 1,
       "There must be two VectorizedWelfordOp exprs");
 
@@ -7183,7 +7181,7 @@ TEST_F(NVFuserTest, FusionVectorizeWelford2_CUDA) {
       std::count_if(all_exprs.begin(), all_exprs.end(), [](Expr* expr) {
         return expr->isStrictlyA<WelfordOp>();
       });
-  TORCH_CHECK(
+  NVF_CHECK(
       num_welford_ops == 0,
       "All WelfordOp exprs should be converted to VectorizedWelfordOp");
 
@@ -7191,7 +7189,7 @@ TEST_F(NVFuserTest, FusionVectorizeWelford2_CUDA) {
       std::count_if(all_exprs.begin(), all_exprs.end(), [](Expr* expr) {
         return expr->isStrictlyA<kir::VectorizedWelfordOp>();
       });
-  TORCH_CHECK(
+  NVF_CHECK(
       num_vectorized_welford_ops == 2,
       "There must be two VectorizedWelfordOp exprs");
 
@@ -7303,17 +7301,17 @@ TEST_F(
           {aten_input, aten_weight, aten_bias});
   bool isTranslated =
       SegmentCandidateFinder::translateWelfordInFusion(&fusion, runtime_inputs);
-  TORCH_INTERNAL_ASSERT(isTranslated);
+  NVF_ERROR(isTranslated);
 
   // persistent buffer should be projected to input
   auto persistent_buffer_info = scheduler_utils::persistentBuffers(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       persistent_buffer_info.projectable_persistent_buffers.size() == 1,
       "should have only one projectable_persistent_buffer!");
-  TORCH_CHECK(
+  NVF_CHECK(
       persistent_buffer_info.projectable_buffer_inputs.size() == 1,
       "should have only one projectable_buffer_inputs!");
-  TORCH_CHECK(
+  NVF_CHECK(
       persistent_buffer_info.projectable_buffer_inputs[0] == input_half,
       "persistent buffer should be projected to input!");
 
@@ -7321,7 +7319,7 @@ TEST_F(
   // Generate Launch Parameters
   auto reduction_params =
       getPersistentHeuristics(&fusion, {aten_input, aten_weight, aten_bias});
-  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
 
   FusionExecutorCache fec(std::move(fusion_ptr));
   auto cg_outputs =
@@ -7417,7 +7415,7 @@ TEST_F(NVFuserTest, FusionFloatConstantWhere_CUDA) {
   auto ref = at::where(t0, (float)3.0, (float)5.0);
 
   // testValidate does not check that dtypes match
-  TORCH_CHECK(cg_outputs[0].dtype() == ref.dtype());
+  NVF_CHECK(cg_outputs[0].dtype() == ref.dtype());
   testValidate(&fusion, cg_outputs, inputs, {ref}, __LINE__, __FILE__);
 }
 
@@ -7626,7 +7624,7 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitShared_CUDA) {
   // threadIdx.x == 0
   GpuLower gpulw(&fusion);
   ParallelTypeBitmap predicated_types(ParallelType::TIDx);
-  TORCH_CHECK(
+  NVF_CHECK(
       ThreadPredChecker::isPredicatedBy(
           tv1->name(), predicated_types, gpulw.kernel()),
       "Validation of lowered kernel failed");
@@ -7680,7 +7678,7 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitGlobal_CUDA) {
   // threadIdx.x == 0 and blockIdx.x == 0
   GpuLower gpulw(&fusion);
   ParallelTypeBitmap predicated_types({ParallelType::TIDx, ParallelType::BIDx});
-  TORCH_CHECK(
+  NVF_CHECK(
       ThreadPredChecker::isPredicatedBy(
           tv1->name(), predicated_types, gpulw.kernel()),
       "Validation of lowered kernel failed");
@@ -7756,10 +7754,10 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
         at::randn({std::numeric_limits<int>::max()}, options).ge(0);
     std::vector<c10::IValue> large_inputs = {t0_large};
 
-    TORCH_CHECK(
+    NVF_CHECK(
         KernelArgumentHolder::createKernelArgumentHolder(large_inputs)
             .getSmallestIndexTypeOfArguments() == PrimDataType::Int);
-    TORCH_CHECK(
+    NVF_CHECK(
         KernelArgumentHolder::createKernelArgumentHolder(small_inputs)
             .getSmallestIndexTypeOfArguments() == PrimDataType::Int32);
 
@@ -7769,7 +7767,7 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
       CompileParams compile_opts = {.index_type = PrimDataType::Int};
       fe.compileFusion(&fusion, large_inputs, LaunchParams(), compile_opts);
 
-      TORCH_CHECK(
+      NVF_CHECK(
           fe.kernel()->indexType() == PrimDataType::Int,
           "Unexpected kernel index type: ",
           fe.kernel()->indexType());
@@ -7786,7 +7784,7 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
       CompileParams compile_opts = {.index_type = PrimDataType::Int};
       fe.compileFusion(&fusion, small_inputs, LaunchParams(), compile_opts);
 
-      TORCH_CHECK(
+      NVF_CHECK(
           fe.kernel()->indexType() == PrimDataType::Int,
           "Unexpected kernel index type: ",
           fe.kernel()->indexType());
@@ -7803,7 +7801,7 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
       CompileParams compile_opts = {.index_type = PrimDataType::Int32};
       fe.compileFusion(&fusion, small_inputs, launch_params, compile_opts);
 
-      TORCH_CHECK(
+      NVF_CHECK(
           fe.kernel()->indexType() == PrimDataType::Int32,
           "Unexpected kernel index type: ",
           fe.kernel()->indexType());
@@ -7874,7 +7872,7 @@ TEST_F(NVFuserTest, FusionExecutorCacheIndexType1_CUDA) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto kernel_runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(kernel_runtime->getIndexType() == PrimDataType::Int);
+  NVF_CHECK(kernel_runtime->getIndexType() == PrimDataType::Int);
 
   c10::cuda::CUDACachingAllocator::emptyCache();
 }
@@ -7914,12 +7912,12 @@ TEST_F(NVFuserTest, FusionExecutorCacheIndexType2_CUDA) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   executor_cache.runFusionWithInputs(aten_inputs);
   auto kernel_runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(kernel_runtime->getIndexType() == PrimDataType::Int);
+  NVF_CHECK(kernel_runtime->getIndexType() == PrimDataType::Int);
 
   // Running again with forced type of Int32
   executor_cache.runFusionWithInputs(aten_inputs, PrimDataType::Int32);
   kernel_runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(kernel_runtime->getIndexType() == PrimDataType::Int32);
+  NVF_CHECK(kernel_runtime->getIndexType() == PrimDataType::Int32);
 }
 
 //! Test whether we can create and use float16 scalars
@@ -7999,11 +7997,11 @@ TEST_F(NVFuserTest, IterVisitorTraverseAttributes_CUDA) {
   auto stmts = StmtSort::getStmts(&fusion, true, true);
 
   // Make sure the expansion parameters of tv1_resize are visited
-  TORCH_CHECK(
+  NVF_CHECK(
       std::find(stmts.begin(), stmts.end(), tv1_resize->leftExpand()) !=
           stmts.end(),
       "Resize left expand parameter not found");
-  TORCH_CHECK(
+  NVF_CHECK(
       std::find(stmts.begin(), stmts.end(), tv1_resize->rightExpand()) !=
           stmts.end(),
       "Resize right expand parameter not found");
@@ -8089,7 +8087,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteBroadcastedSoftmaxInput_CUDA) {
       const auto& thread_pred = thread_pred_map.getPredicateInfo(tv);
       bool predicted = thread_pred.redundant_types.get(ParallelType::BIDx) &&
           thread_pred.broadcast_rd_indices_map.count(ParallelType::BIDx);
-      TORCH_CHECK(
+      NVF_CHECK(
           predicted,
           "Tv15 should be predicted by ParallelType::BIDx with a broadcast_rd_indices_map!");
       break;
@@ -8149,7 +8147,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWrite_CUDA) {
         const auto& thread_pred = thread_pred_map.getPredicateInfo(tv);
         bool predicted = thread_pred.redundant_types.get(ParallelType::BIDx) &&
             thread_pred.broadcast_rd_indices_map.count(ParallelType::BIDx);
-        TORCH_CHECK(
+        NVF_CHECK(
             predicted,
             "Tv8 should be predicted by ParallelType::BIDx with a broadcast_rd_indices_map!");
         break;
@@ -8237,7 +8235,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteDifferentConcretizedDomains_CUDA) {
 
     if (direct_lowering) {
       auto heuristics_params = getReductionHeuristics(&fusion, inputs);
-      TORCH_CHECK(heuristics_params, "Reduction schedule was not generated!");
+      NVF_CHECK(heuristics_params, "Reduction schedule was not generated!");
       scheduleReduction(&fusion, *heuristics_params);
       // it should be segmented, if directly lowered, it should throw an error
       EXPECT_THAT(
@@ -8249,8 +8247,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteDifferentConcretizedDomains_CUDA) {
       auto cg_outputs = fec.runFusionWithInputs(inputs);
 
       auto optimized_fusion = fec.getMostRecentKernelRuntime();
-      TORCH_CHECK(
-          optimized_fusion->isSegmented(), "segmentation didn't happen!");
+      NVF_CHECK(optimized_fusion->isSegmented(), "segmentation didn't happen!");
 
       at::Tensor tb = t0;
       for (size_t i = 0; i < ndim; i++) {
@@ -8326,7 +8323,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteNonOutput_CUDA) {
       const auto& thread_pred = thread_pred_map.getPredicateInfo(tv);
       bool predicted = thread_pred.redundant_types.get(ParallelType::BIDx) &&
           thread_pred.broadcast_rd_indices_map.count(ParallelType::BIDx);
-      TORCH_CHECK(
+      NVF_CHECK(
           predicted,
           "TV5 and TV6 should be predicted by ParallelType::BIDx with a broadcast_rd_indices_map!");
     }
@@ -8396,7 +8393,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteNonNeighbor_CUDA) {
       const auto& thread_pred = thread_pred_map.getPredicateInfo(tv);
       bool predicted = thread_pred.redundant_types.get(ParallelType::BIDx) &&
           thread_pred.broadcast_rd_indices_map.count(ParallelType::BIDx);
-      TORCH_CHECK(
+      NVF_CHECK(
           predicted,
           "TV5 and TV6 should be predicted by ParallelType::BIDx with a broadcast_rd_indices_map!");
     }
@@ -8598,8 +8595,8 @@ TEST_F(NVFuserTest, FusionClearGmemBetweenSegments_CUDA) {
   auto optimized_fusion = executor_cache.getMostRecentKernelRuntime();
   auto args_num = optimized_fusion->getArgsNumAfterSegmentRuns();
 
-  TORCH_CHECK(optimized_fusion->isSegmented(), "segmentation didn't happen");
-  TORCH_CHECK(
+  NVF_CHECK(optimized_fusion->isSegmented(), "segmentation didn't happen");
+  NVF_CHECK(
       optimized_fusion->fusionSegments()->groups().size() == 3,
       "segmentation didn't happen as expected");
   // group-0: tv1 -> tv2
@@ -8613,7 +8610,7 @@ TEST_F(NVFuserTest, FusionClearGmemBetweenSegments_CUDA) {
   // after group-0, args: {t0, 32, 64, 8, 128, t2}
   // after group-1, args: {t0, 32, 64, 8, 128, t3} (t2 is erased)
   // after group-2, args: {t0, 32, 64, 8, 128, t4} (t3 is erased)
-  TORCH_CHECK(
+  NVF_CHECK(
       args_num[1] == args_num[0] && args_num[2] == args_num[0],
       "unused intermediate args should be deleted");
   testValidate(
@@ -8737,17 +8734,16 @@ TEST_F(NVFuserTest, FusionTestSegmenterHint_CUDA) {
 
   auto optimized_fusion = executor_cache.getMostRecentKernelRuntime();
 
-  TORCH_CHECK(optimized_fusion->isSegmented(), "segmentation didn't happen");
+  NVF_CHECK(optimized_fusion->isSegmented(), "segmentation didn't happen");
   auto groups = optimized_fusion->fusionSegments()->groups();
-  TORCH_CHECK(
-      groups.size() == 2, "segmentation hint isn't working as expected");
+  NVF_CHECK(groups.size() == 2, "segmentation hint isn't working as expected");
   // with the hint, segment_set should be grouped with its producer
   // [relu, segment_set], [neg]
   for (auto& group : groups) {
     // we only check the group with a single node
     if (group->exprs().size() == 1) {
       auto relu_expr = group->exprs()[0];
-      TORCH_CHECK(
+      NVF_CHECK(
           relu_expr->isA<UnaryOp>() &&
               relu_expr->as<UnaryOp>()->getUnaryOpType() == UnaryOpType::Neg,
           "segmentation result is not expected");
@@ -8786,7 +8782,7 @@ TEST_F(NVFuserTest, FusionTestWarnRegisterSpill_CUDA) {
   {
     // generate persistent kernel
     auto persistent_params = getPersistentHeuristics(&fusion, {aten_input});
-    TORCH_CHECK(persistent_params, "Persistent schedule was not generated!");
+    NVF_CHECK(persistent_params, "Persistent schedule was not generated!");
     schedulePersistentKernel(&fusion, *persistent_params);
 
     // compile and run persistent kernel
@@ -8811,7 +8807,7 @@ TEST_F(NVFuserTest, FusionTestWarnRegisterSpill_CUDA) {
         "");
   }
   std::string output = testing::internal::GetCapturedStdout();
-  TORCH_CHECK(
+  NVF_CHECK(
       output.find("Register spill detected") != std::string::npos,
       "Register spill is not captured!");
 }
@@ -8911,13 +8907,13 @@ TEST_F(NVFuserTest, FusionLayerNormFusedOpsRedundantCast_CUDA) {
   }
 
   auto persistent_buffer_info1 = scheduler_utils::persistentBuffers(fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       persistent_buffer_info1.persistent_buffers.size() == 2,
       "Before project to other buffers, should have two persistent buffers!");
 
   reduction_scheduler_utils::projectPersistentBuffers(fusion, false);
   auto persistent_buffer_info2 = scheduler_utils::persistentBuffers(fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       persistent_buffer_info2.persistent_buffers.size() == 1,
       "After project to other buffers, should have one persistent buffer!");
 
@@ -8960,7 +8956,7 @@ TEST_F(NVFuserTest, AlignedSyncReduction1_CUDA) {
       codegen::generateCudaKernel(GpuLower(&fusion).kernel());
 
   // The block reduction should use the aligned sync
-  TORCH_CHECK(
+  NVF_CHECK(
       kernel_string.find("blockReduce<true, false, false, true>(") !=
           std::string::npos,
       "blockReduce with aligned sync not found: ",
@@ -9147,13 +9143,13 @@ TEST_F(NVFuserTest, FusionRecomputePersistentBuffer_CUDA) {
   }
 
   auto persistent_buffer_info1 = scheduler_utils::persistentBuffers(fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       persistent_buffer_info1.persistent_buffers.size() == 2,
       "Before project to other buffers, should have two persistent buffers!");
 
   reduction_scheduler_utils::projectPersistentBuffers(fusion, false);
   auto persistent_buffer_info2 = scheduler_utils::persistentBuffers(fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       persistent_buffer_info2.persistent_buffers.size() == 1,
       "After project to other buffers, should have one persistent buffer!");
 
@@ -9338,10 +9334,10 @@ TEST_F(NVFuserTest, IterVisitorTraverseSiblings_CUDA) {
       /*traverse_siblings*/ true);
 
   // Make sure the expansion parameters of tv1_resize are visited
-  TORCH_CHECK(
+  NVF_CHECK(
       std::find(stmts.begin(), stmts.end(), wf.avg) != stmts.end(),
       "Welford avg not traversed");
-  TORCH_CHECK(
+  NVF_CHECK(
       std::find(stmts.begin(), stmts.end(), wf.n) != stmts.end(),
       "Welford n not traversed");
 
@@ -9353,10 +9349,10 @@ TEST_F(NVFuserTest, IterVisitorTraverseSiblings_CUDA) {
       /*traverse_attributes*/ false,
       /*traverse_siblings*/ true);
   // Make sure the expansion parameters of tv1_resize are visited
-  TORCH_CHECK(
+  NVF_CHECK(
       std::find(stmts.begin(), stmts.end(), wf.avg) != stmts.end(),
       "Welford avg not traversed in getStmtsTo({n})");
-  TORCH_CHECK(
+  NVF_CHECK(
       std::find(stmts.begin(), stmts.end(), wf.var_sum) != stmts.end(),
       "Welford var_sum not traversed in getStmtsTo({n})");
 }
@@ -9396,14 +9392,14 @@ TEST_F(NVFuserTest, FusionLayerNormSharedMemoryBuffer_CUDA) {
 
     auto persistent_params =
         getPersistentHeuristics(&fusion, {aten_input, aten_weight, aten_bias});
-    TORCH_CHECK(persistent_params, "Persistent schedule was not generated!");
+    NVF_CHECK(persistent_params, "Persistent schedule was not generated!");
     if (hidden_size * dataTypeSize(dtype) >
         scheduler_utils::register_file_size) {
-      TORCH_CHECK(
+      NVF_CHECK(
           persistent_params->shared_mem_persistent_buffer,
           "Should use shared memory buffer!");
     } else {
-      TORCH_CHECK(
+      NVF_CHECK(
           !persistent_params->shared_mem_persistent_buffer,
           "Shouldn't use shared memory buffer!");
     }
@@ -9550,7 +9546,7 @@ TEST_F(NVFuserTest, VectorizeWithBroadcastAndReshape1) {
   FusionExecutorCache executor_cache(std::move(fusion));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
-  TORCH_CHECK(!executor_cache.getMostRecentKernelRuntime()->isSegmented());
+  NVF_CHECK(!executor_cache.getMostRecentKernelRuntime()->isSegmented());
   auto heuristic_params = executor_cache.getMostRecentKernelRuntime()
                               ->schedulerHeuristics()
                               ->heuristicsList()
@@ -9604,7 +9600,7 @@ TEST_F(NVFuserTest, VectorizeWithBroadcastAndReshape2) {
   FusionExecutorCache executor_cache(std::move(fusion));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
-  TORCH_CHECK(!executor_cache.getMostRecentKernelRuntime()->isSegmented());
+  NVF_CHECK(!executor_cache.getMostRecentKernelRuntime()->isSegmented());
   auto heuristic_params = executor_cache.getMostRecentKernelRuntime()
                               ->schedulerHeuristics()
                               ->heuristicsList()

--- a/test/test_gpu_compute_with.cpp
+++ b/test/test_gpu_compute_with.cpp
@@ -154,7 +154,7 @@ TEST_F(NVFuserTest, FusionComputeWith1_CUDA) {
         consumer_of_tv1->toString());
     EXPECT_THAT(
         [&]() { consumer_of_tv1->split(-1, 4); },
-        ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+        ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
             "Cannot split axis within max producer position")));
   }
 

--- a/test/test_gpu_compute_with.cpp
+++ b/test/test_gpu_compute_with.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -79,19 +80,19 @@ void checkComputeWith(
     }
   }
 
-  TORCH_CHECK(
+  NVF_CHECK(
       kernel_tv != nullptr,
       "No corresponding TensorView found in lowered kernel: ",
       fusion_tv->toString());
 
-  TORCH_CHECK(
+  NVF_CHECK(
       kernel_tv->getComputeWithPosition() == pos,
       "Invalid computeWith positon: ",
       kernel_tv->toString(),
       ". Expected: ",
       pos);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       kernel_tv->getComputeWithConsumers().size() == target_tvs.size(),
       "Invalid number of computeWith consumers: ",
       kernel_tv->toString(),
@@ -99,7 +100,7 @@ void checkComputeWith(
       target_tvs.size());
 
   for (auto consumer : kernel_tv->getComputeWithConsumers()) {
-    TORCH_CHECK(
+    NVF_CHECK(
         std::find_if(
             target_tvs.begin(),
             target_tvs.end(),
@@ -147,7 +148,7 @@ TEST_F(NVFuserTest, FusionComputeWith1_CUDA) {
   // It is now illegal to modify the innermost ID of the consumers of
   // tv1.
   for (auto consumer_of_tv1 : ir_utils::consumerTvsOf(tv1)) {
-    TORCH_CHECK(
+    NVF_CHECK(
         consumer_of_tv1->getMaybeMaxProducerPosition() == 2,
         "Invalid producer position: ",
         consumer_of_tv1->toString());

--- a/test/test_gpu_fused_reduction.cpp
+++ b/test/test_gpu_fused_reduction.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gtest/gtest.h>
 
 #include <codegen.h>
@@ -63,7 +64,7 @@ void validateNoParallelBroadcastExist(kir::Kernel* kernel) {
     if (bc == nullptr) {
       continue;
     }
-    TORCH_CHECK(
+    NVF_CHECK(
         kernel->summary().broadcast_parallel_types.at(bc).none(),
         "Parallel broadcast should not exist but was found: ",
         bc->toString());
@@ -1380,7 +1381,7 @@ TEST_F(NVFuserTest, FusionPersistentBNBackwardAllreduce_CUDA) {
   const int bidy = 4;
   const int bidx = ceilDiv(shape[0], (int64_t)tidy);
   const int vec_width = 4;
-  TORCH_CHECK(
+  NVF_CHECK(
       (shape[2] * shape[3]) % vec_width == 0,
       "Invalid vector width: ",
       vec_width);
@@ -1390,7 +1391,7 @@ TEST_F(NVFuserTest, FusionPersistentBNBackwardAllreduce_CUDA) {
 
   grad_input->split(0, tidy);
   grad_input->split(2, bidy);
-  TORCH_CHECK(
+  NVF_CHECK(
       grad_input->nDims() == 6,
       "Unexpected number of dimensions: ",
       grad_input->toString());
@@ -1585,7 +1586,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionChannelsLastBatchNormLike_CUDA) {
   // Applies the outer-reduction schedule
   const int64_t num_channels = shape.back();
   const int64_t vector = 2;
-  TORCH_CHECK(num_channels % vector == 0);
+  NVF_CHECK(num_channels % vector == 0);
   // Use at most 32 TIDx threads
   const int64_t tidx = std::min<int64_t>(32l, num_channels / vector);
   const auto bidx = ceilDiv(num_channels, tidx * vector);
@@ -1715,7 +1716,7 @@ TEST_F(
   // Applies the outer-reduction schedule
   const int64_t num_channels = shape.back();
   const int64_t vector = 2;
-  TORCH_CHECK(num_channels % vector == 0);
+  NVF_CHECK(num_channels % vector == 0);
   // Use at most 32 TIDx threads
   const int64_t tidx = std::min<int64_t>(32l, num_channels / vector);
   ceilDiv(num_channels, tidx * vector);
@@ -1852,7 +1853,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce1_CUDA) {
     auto out = ir_utils::getTvOutput(grouped_grid_reduction);
     for (auto out_axis : out->getLeafDomain()) {
       auto out_axis_pt = out_axis->getParallelType();
-      TORCH_CHECK(
+      NVF_CHECK(
           isParallelTypeThread(out_axis_pt) ||
               out_axis_pt == ParallelType::Group,
           "Invalid parallel type of the reduction tensor: ",
@@ -1862,7 +1863,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce1_CUDA) {
     }
     validated = true;
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       validated, "Invalid lowered kernel. No GroupedGridReduction found.");
 
   std::vector<int64_t> shape({99, 101});
@@ -1932,7 +1933,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce2_CUDA) {
     auto out = ir_utils::getTvOutput(grouped_grid_reduction);
     for (auto out_axis : out->getLeafDomain()) {
       auto out_axis_pt = out_axis->getParallelType();
-      TORCH_CHECK(
+      NVF_CHECK(
           isParallelTypeThread(out_axis_pt) ||
               out_axis_pt == ParallelType::Group,
           "Invalid parallel type of the reduction tensor: ",
@@ -1942,7 +1943,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce2_CUDA) {
     }
     validated = true;
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       validated, "Invalid lowered kernel. No GroupedGridReduction found.");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -2014,7 +2015,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce3_CUDA) {
     auto out = ir_utils::getTvOutput(grouped_grid_reduction);
     for (auto out_axis : out->getLeafDomain()) {
       auto out_axis_pt = out_axis->getParallelType();
-      TORCH_CHECK(
+      NVF_CHECK(
           isParallelTypeThread(out_axis_pt) ||
               out_axis_pt == ParallelType::Group,
           "Invalid parallel type of the reduction tensor: ",
@@ -2024,7 +2025,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce3_CUDA) {
     }
     validated = true;
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       validated, "Invalid lowered kernel. No GroupedGridReduction found.");
 
   std::vector<int64_t> shape({99, 101});
@@ -2075,11 +2076,11 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce4_CUDA) {
   // This should avoid inlining the grouped domain
   tv0->computeAt(tv4, -1, ComputeAtMode::MostInlined);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       tv1->getComputeAtPosition() == 2,
       "Invalid computeAt position: ",
       tv1->toString());
-  TORCH_CHECK(
+  NVF_CHECK(
       tv2->getComputeAtPosition() == 2,
       "Invalid computeAt position: ",
       tv2->toString());
@@ -2106,7 +2107,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce4_CUDA) {
     auto out = ir_utils::getTvOutput(grouped_grid_reduction);
     for (auto out_axis : out->getLeafDomain()) {
       auto out_axis_pt = out_axis->getParallelType();
-      TORCH_CHECK(
+      NVF_CHECK(
           isParallelTypeThread(out_axis_pt) ||
               out_axis_pt == ParallelType::Group,
           "Invalid parallel type of the reduction tensor: ",
@@ -2116,7 +2117,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce4_CUDA) {
     }
     validated = true;
   }
-  TORCH_CHECK(
+  NVF_CHECK(
       validated, "Invalid lowered kernel. No GroupedGridReduction found.");
 
   std::vector<int64_t> shape({99, 101});
@@ -2178,8 +2179,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduceWelford1_CUDA) {
     }
     validated = true;
   }
-  TORCH_CHECK(
-      validated, "Invalid lowered kernel. No GroupedGridWelford found.");
+  NVF_CHECK(validated, "Invalid lowered kernel. No GroupedGridWelford found.");
 
   std::vector<int64_t> shape({99, 101});
 
@@ -2246,8 +2246,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduceWelford2_CUDA) {
     }
     validated = true;
   }
-  TORCH_CHECK(
-      validated, "Invalid lowered kernel. No GroupedGridWelford found.");
+  NVF_CHECK(validated, "Invalid lowered kernel. No GroupedGridWelford found.");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
@@ -2381,7 +2380,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduceWelfordShmoo_CUDA) {
       (void)expr; // Suppress unused variable warning
       validated = true;
     }
-    TORCH_CHECK(
+    NVF_CHECK(
         validated, "Invalid lowered kernel. No GroupedGridWelford found.");
 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -2496,7 +2495,7 @@ TEST_F(NVFuserTest, FusionGeluBwdReduction_CUDA) {
   // fusion values
   std::vector<int64_t> reduction_axes{0};
   auto reduction_params = getReductionHeuristics(&fusion, {at_grad, at_xvar});
-  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
   scheduleReduction(&fusion, *reduction_params);
 
   FusionExecutor fe;

--- a/test/test_gpu_indexing.cpp
+++ b/test/test_gpu_indexing.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -258,7 +259,7 @@ TEST_F(NVFuserTest, FusionIndexing6_CUDA) {
 
   std::vector<int64_t> reduction_axes{0, 1};
   auto reduction_params = getReductionHeuristics(&fusion, {input0, input1});
-  TORCH_CHECK(reduction_params, "Reduction schedule was not generated!");
+  NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
   scheduleReduction(&fusion, *reduction_params);
 
   FusionExecutor fe;
@@ -469,7 +470,7 @@ TEST_F(NVFuserTest, FusionIndexing10_CUDA) {
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
 
-  TORCH_CHECK(output_ref.equal(output));
+  NVF_CHECK(output_ref.equal(output));
 }
 
 TEST_F(NVFuserTest, FusionIndexing11_CUDA) {

--- a/test/test_gpu_indexing_ops.cpp
+++ b/test/test_gpu_indexing_ops.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gtest/gtest.h>
 
 #include <kernel_cache.h>
@@ -395,7 +396,7 @@ TEST_F(NVFuserTest, FusionIndexSelectCanSch_CUDA) {
   auto sch_pass = SchedulerEntry::canSchedule(
       ScheduleHeuristic::PointWise, &fusion_pass, runtime_info_pass);
 
-  TORCH_CHECK(sch_pass == true && sch_fail == false && sch_sum_fail == false);
+  NVF_CHECK(sch_pass == true && sch_fail == false && sch_sum_fail == false);
 }
 
 TEST_F(NVFuserTest, FusionIndexSelect_Sum_CUDA) {
@@ -441,7 +442,7 @@ TEST_F(NVFuserTest, FusionIndexSelect_Sum_CUDA) {
   at::Tensor output_add = tv2_ref + 17.0;
   at::Tensor output_ref = output_add.sum({1});
 
-  TORCH_CHECK(output_ref.allclose(output));
+  NVF_CHECK(output_ref.allclose(output));
 }
 
 TEST_F(NVFuserTest, FusionIndexSelectIdxTvFuseable_CUDA) {

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gtest/gtest.h>
 
 #include <codegen.h>
@@ -86,7 +87,7 @@ TEST_F(NVFuserTest, FusionVoltaMMATT_CUDA) {
                          .layout(MmaOptions::MmaLayout::TT);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -188,7 +189,7 @@ TEST_F(NVFuserTest, FusionVoltaMMATN_CUDA) {
                          .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -257,7 +258,7 @@ TEST_F(NVFuserTest, FusionVoltaMMANT_CUDA) {
                          .layout(MmaOptions::MmaLayout::NT);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -335,7 +336,7 @@ TEST_F(NVFuserTest, FusionVoltaMMANN_CUDA) {
                          .layout(MmaOptions::MmaLayout::NN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -422,7 +423,7 @@ TEST_F(NVFuserTest, FusionVoltaMatmul_CUDA) {
     auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
@@ -471,7 +472,7 @@ TEST_F(NVFuserTest, FusionVoltaMatmulRegDoubleBuffer_CUDA) {
     auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
@@ -509,7 +510,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATN_CUDA) {
           .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -586,7 +587,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATT_CUDA) {
           .layout(MmaOptions::MmaLayout::TT);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -667,7 +668,7 @@ TEST_F(NVFuserTest, FusionAmpereMMANT_CUDA) {
           .layout(MmaOptions::MmaLayout::NT);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -748,7 +749,7 @@ TEST_F(NVFuserTest, FusionAmpereMMANN_CUDA) {
           .layout(MmaOptions::MmaLayout::NN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -839,7 +840,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmul_CUDA) {
     auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
@@ -889,7 +890,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulBFloat16_CUDA) {
     auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
@@ -943,7 +944,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulPipelineGmem_CUDA) {
       auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
       auto tref = atMatmul(
           inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-      TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+      NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
     }
   }
 }
@@ -1012,7 +1013,7 @@ TEST_F(NVFuserTest, FusionAmpereSwizzle_CUDA) {
     auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    TORCH_CHECK(cg_outputs[0].allclose(tref, 0.01, 0.01));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.01, 0.01));
 
     int gdimx = fe.lastLaunchParams().gdimx();
     int gdimy = fe.lastLaunchParams().gdimy();
@@ -1021,8 +1022,8 @@ TEST_F(NVFuserTest, FusionAmpereSwizzle_CUDA) {
     int expected_gdimx = expected_gdim_unswizzled * swizzle;
     int expected_gdimy = (expected_gdim_unswizzled + swizzle - 1) / swizzle;
 
-    TORCH_CHECK(gdimx == expected_gdimx);
-    TORCH_CHECK(gdimy == expected_gdimy);
+    NVF_CHECK(gdimx == expected_gdimx);
+    NVF_CHECK(gdimy == expected_gdimy);
 
     runtime = fe.kernelTimeMs();
 
@@ -1037,7 +1038,7 @@ TEST_F(NVFuserTest, FusionAmpereSwizzle_CUDA) {
       void handle(MmaOp* uop) final {
         found_mma = true;
         for (auto expr : scope_exprs_) {
-          TORCH_CHECK(
+          NVF_CHECK(
               !expr->isA<kir::IfThenElse>() ||
                   expr->as<kir::IfThenElse>()->predicate()->isTrivial(),
               "MmaOp should't be predicated!",
@@ -1063,7 +1064,7 @@ TEST_F(NVFuserTest, FusionAmpereSwizzle_CUDA) {
 
       // GRID Swizzle requires further changes to work in main. So for now we
       // don't assert the perf benefit here.
-      // TORCH_CHECK(runtime4 < runtime1);
+      // NVF_CHECK(runtime4 < runtime1);
     }
   }
 }
@@ -1117,7 +1118,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulRegDoubleBuffer_CUDA) {
       auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
       auto tref = atMatmul(
           inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-      TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+      NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
     }
   }
 }
@@ -1185,7 +1186,7 @@ TEST_F(NVFuserTest, FusionMatmulMatmulAmpere_CUDA) {
           .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       2 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 2, got ",
       mma_ops.size());
@@ -1395,7 +1396,7 @@ TEST_F(NVFuserTest, FusionMatmulMatmulAmpere_CUDA) {
   auto cg_outputs = fe.runFusion({t0, t1, t2});
 
   // relaxed check for now, err accumulation is significant.
-  TORCH_CHECK(cg_outputs[0].allclose(tref, 0.1, 0.1));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.1, 0.1));
 }
 
 // Simplified Matmul-Softmax-Matmul test on Ampere
@@ -1485,7 +1486,7 @@ TEST_F(NVFuserTest, FusionMatmulSoftmaxMatmulAmpere_CUDA) {
           .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       2 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 2, got ",
       mma_ops.size());
@@ -1776,7 +1777,7 @@ TEST_F(NVFuserTest, FusionMatmulSoftmaxMatmulAmpere_CUDA) {
   auto sg1 = at::_softmax(g1, -1, false);
   auto gsg1 = sg1.matmul(t2.t().to(at::kFloat));
 
-  TORCH_CHECK(cg_outputs[0].allclose(gsg1, 0.001, 0.001));
+  NVF_CHECK(cg_outputs[0].allclose(gsg1, 0.001, 0.001));
 }
 
 // MMA unit test on Turing
@@ -1811,7 +1812,7 @@ TEST_F(NVFuserTest, FusionTuringMMATN_CUDA) {
           .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -1887,7 +1888,7 @@ TEST_F(NVFuserTest, FusionTuringMMATT_CUDA) {
           .layout(MmaOptions::MmaLayout::TT);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -1965,7 +1966,7 @@ TEST_F(NVFuserTest, FusionTuringMMANT_CUDA) {
           .layout(MmaOptions::MmaLayout::NT);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -2045,7 +2046,7 @@ TEST_F(NVFuserTest, FusionTuringMMANN_CUDA) {
           .layout(MmaOptions::MmaLayout::NN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -2126,7 +2127,7 @@ TEST_F(NVFuserTest, FusionTuringMatmul_CUDA) {
     auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
@@ -2164,7 +2165,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTNcpAsync_CUDA) {
           .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -2270,7 +2271,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTNcpAsync_CUDA) {
 
   auto tref = t0.to(at::kFloat).matmul(t1.t().to(at::kFloat));
 
-  TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 TEST_F(NVFuserTest, FusionAmpereStridedBatchedMatmulTN_CUDA) {
@@ -2307,7 +2308,7 @@ TEST_F(NVFuserTest, FusionAmpereStridedBatchedMatmulTN_CUDA) {
           .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -2448,7 +2449,7 @@ TEST_F(NVFuserTest, FusionAmpereStridedBatchedMatmulTN_CUDA) {
   auto ref = ref_permuted.view({B0, B1, M, N})
                  .permute({0, 2, 3, 1})
                  .contiguous(); // B0,M,N,B1
-  TORCH_CHECK(cg_outputs[0].allclose(ref, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(ref, 0.0001, 0.0001));
 }
 
 // Matmul test on Ampere with a reshape on prolog
@@ -2489,7 +2490,7 @@ TEST_F(NVFuserTest, FusionAmpereViewMatmulTN_CUDA) {
           .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -2611,7 +2612,7 @@ TEST_F(NVFuserTest, FusionAmpereViewMatmulTN_CUDA) {
   auto tref =
       at::native::view(t0, {M, K}).to(at::kFloat).matmul(t1.t().to(at::kFloat));
 
-  TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 // Initial test case for in-CTA split K with VoltaMMA
@@ -2649,7 +2650,7 @@ TEST_F(NVFuserTest, FusionVoltaMatmulTNCrossWarp_CUDA) {
                          .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -2772,7 +2773,7 @@ TEST_F(NVFuserTest, FusionVoltaMatmulTNCrossWarp_CUDA) {
   fe.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams);
   auto cg_outputs = fe.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat).t());
-  TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 // Initial test case for cross-CTA split K with VoltaMMA
@@ -2810,7 +2811,7 @@ TEST_F(NVFuserTest, FusionVoltaMatmulTNCrossCTA_CUDA) {
                          .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -2945,7 +2946,7 @@ TEST_F(NVFuserTest, FusionVoltaMatmulTNCrossCTA_CUDA) {
   fe.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams);
   auto cg_outputs = fe.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat).t());
-  TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 // Test an end-to-end matmul case with swizzled smem
@@ -2983,7 +2984,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTNSwizzled_CUDA) {
   fusion.addOutput(tv2);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -3125,7 +3126,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTNSwizzled_CUDA) {
 
   auto tref = t0.to(at::kFloat).matmul(t1.t().to(at::kFloat));
 
-  TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 // Matmul test on Ampere using ldmatrix.x4 to load operands
@@ -3174,7 +3175,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulLargeLoad_CUDA) {
     auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
@@ -3221,7 +3222,7 @@ TEST_F(NVFuserTest, FusionTuringMatmulLargeLoad_CUDA) {
     auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
@@ -3280,7 +3281,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTileCheck4warp_CUDA) {
         auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
         auto tref = atMatmul(
             inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-        TORCH_CHECK(
+        NVF_CHECK(
             cg_outputs[0].allclose(tref, 0.0001, 0.0001),
             "error :",
             (cg_outputs[0] - tref).abs().max(),
@@ -3352,7 +3353,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTileCheck8warp_CUDA) {
               inputs.first.to(at::kFloat),
               inputs.second.to(at::kFloat),
               layout);
-          TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+          NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
         }
       }
     }
@@ -3412,7 +3413,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTileCheck6warp_CUDA) {
       auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
       auto tref = atMatmul(
           inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-      TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+      NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
     }
   }
 }
@@ -3463,7 +3464,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulLargeLoadLargeK_CUDA) {
     auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    TORCH_CHECK(cg_outputs[0].allclose(tref, 0.001, 0.001));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.001, 0.001));
   }
 }
 
@@ -3504,7 +3505,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNAlpha_CUDA) {
           .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -3551,7 +3552,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNAlpha_CUDA) {
   auto t2 = t0.to(at::kFloat).matmul(t1.t().to(at::kFloat));
   auto tref = t2.mul(alpha);
 
-  TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 // MMA and alpha + beta unit test, for Ampere TN
@@ -3606,7 +3607,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNAlphaBeta_CUDA) {
           .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -3668,7 +3669,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNAlphaBeta_CUDA) {
   auto t5 = t2.to(at::kFloat).mul(beta);
   auto t6 = t4.add(t5);
 
-  TORCH_CHECK(cg_outputs[0].allclose(t6, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(t6, 0.0001, 0.0001));
 }
 
 // MMA and bias epilogue unit test, for Ampere TN
@@ -3715,7 +3716,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNBias_CUDA) {
           .layout(MmaOptions::MmaLayout::TN);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -3765,7 +3766,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNBias_CUDA) {
   auto t3 = t0.to(at::kFloat).matmul(t1.t().to(at::kFloat));
   auto t4 = atBiasEpilogue(t3, t2);
 
-  TORCH_CHECK(cg_outputs[0].allclose(t4, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(t4, 0.0001, 0.0001));
 }
 
 // Strided batch gemm with MMA unit test, for Ampere TN
@@ -3812,7 +3813,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNSplitKLikeStridedBatch_CUDA) {
           .layout(layout);
 
   auto mma_ops = ir_utils::getMmaOps(&fusion);
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
       mma_ops.size());
@@ -3853,7 +3854,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNSplitKLikeStridedBatch_CUDA) {
   auto cg_outputs = fe.runFusion({t0, t1});
   auto tref = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
 
-  TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 // Matmul test for Ampere MMA: across supported layouts
@@ -3900,7 +3901,7 @@ TEST_F(NVFuserTest, FusionAmpereSplitKLikeStridedBatchedMatmul_CUDA) {
     auto cg_outputs = fe.runFusion({t0, t1});
     auto tref =
         splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
-    TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
@@ -3956,7 +3957,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogue_CUDA) {
         num_shared_mem_tensors++;
       }
     }
-    TORCH_CHECK(
+    NVF_CHECK(
         num_shared_mem_tensors == expected_num_shared_mem_tensors,
         "Number of shared memory tensors doesn't match!",
         "Expected: ",
@@ -3983,7 +3984,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogue_CUDA) {
     // check bank conflicts
     ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
     // (0.001, 0.001) passed on local A100 but failed on CI A100
-    TORCH_CHECK(
+    NVF_CHECK(
         cg_outputs[0].allclose(tref, 0.01, 0.01),
         "Result validation failed. Max diff: ",
         (cg_outputs[0] - tref).abs().max());
@@ -4000,7 +4001,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogue_CUDA) {
     //   - use_smem_epilogue && !promote_prologue_smem_reuse : A + B + C
     //   - use_smem_epilogue && promote_prologue_smem_reuse : max(A + B, C)
     auto smem_allocs = fe.kernel()->summary().dynamic_smem_allocations;
-    TORCH_CHECK(smem_allocs.size() == 3);
+    NVF_CHECK(smem_allocs.size() == 3);
     if (params.promote_prologue_smem_reuse) {
       // Check prologue shared memory re-use
       // smem_allocs = {A, B, C} where C is the epilogue buffer
@@ -4084,7 +4085,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogueCast_CUDA) {
         num_shared_mem_tensors++;
       }
     }
-    TORCH_CHECK(
+    NVF_CHECK(
         num_shared_mem_tensors == expected_num_shared_mem_tensors,
         "Number of shared memory tensors doesn't match!",
         "Expected: ",
@@ -4111,7 +4112,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogueCast_CUDA) {
     // check bank conflicts
     ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
     // (0.001, 0.001) passed on local A100 but failed on CI A100
-    TORCH_CHECK(
+    NVF_CHECK(
         cg_outputs[0].allclose(tref, 0.01, 0.01),
         "Result validation failed. Max diff: ",
         (cg_outputs[0] - tref).abs().max());
@@ -4171,7 +4172,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogueRelu_CUDA) {
         num_shared_mem_tensors++;
       }
     }
-    TORCH_CHECK(
+    NVF_CHECK(
         num_shared_mem_tensors == expected_num_shared_mem_tensors,
         "Number of shared memory tensors doesn't match!",
         "Expected: ",
@@ -4199,7 +4200,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogueRelu_CUDA) {
     // check bank conflicts
     ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
     // (0.001, 0.001) passed on local A100 but failed on CI A100
-    TORCH_CHECK(
+    NVF_CHECK(
         cg_outputs[0].allclose(tref, 0.01, 0.01),
         "Result validation failed. Max diff: ",
         (cg_outputs[0] - tref).abs().max());

--- a/test/test_gpu_transpose.cpp
+++ b/test/test_gpu_transpose.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -626,7 +627,7 @@ TEST_F(NVFuserTest, FusionViewNoTranspose_CUDA) {
   auto tv1 = flatten(tv0, 1, 2);
   fusion.addOutput(tv1);
 
-  TORCH_CHECK(!hasAtLeastTwoValidGroups(&fusion));
+  NVF_CHECK(!hasAtLeastTwoValidGroups(&fusion));
 }
 
 TEST_F(NVFuserTest, FusionTransposeSelfMapping_CUDA) {
@@ -1051,7 +1052,7 @@ TEST_F(NVFuserTest, FusionTransposeBankConflict8_CUDA) {
   auto bank_conflict_info = fusion.bankConflictInfo();
 
   // no bank confliction
-  TORCH_CHECK(bank_conflict_info.empty());
+  NVF_CHECK(bank_conflict_info.empty());
 }
 
 TEST_F(NVFuserTest, FusionTransposeBankConflict9_CUDA) {
@@ -1120,11 +1121,11 @@ TEST_F(NVFuserTest, UnswitchPredicateIssueRepro667_CUDA) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+  NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
 
   auto ref = t0.transpose(1, 4).transpose(0, 3);
 
-  TORCH_CHECK(ref.equal(cg_outputs.at(0)));
+  NVF_CHECK(ref.equal(cg_outputs.at(0)));
 }
 
 // small transpose dimension with merge but no split
@@ -1150,23 +1151,23 @@ TEST_F(NVFuserTest, TransposeAggregatedVectorizationWidth_CUDA) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+  NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
   auto scheduler = runtime->schedulerHeuristics()->heuristicsList().at(0).get();
   auto heuristic = scheduler->heuristic();
-  TORCH_CHECK(
+  NVF_CHECK(
       heuristic == ScheduleHeuristic::Transpose,
       "Unexpected heuristic: ",
       heuristic);
-  TORCH_CHECK(
+  NVF_CHECK(
       scheduler->transposeParams().vectorize_factor1 == 4,
       "expecting vectorization for group 1 to be 4");
-  TORCH_CHECK(
+  NVF_CHECK(
       scheduler->transposeParams().vectorize_factor2 == 4,
       "expecting vectorization for group 2 to be 4");
 
   auto ref = t0.transpose(0, 4).transpose(1, 3);
 
-  TORCH_CHECK(ref.equal(cg_outputs.at(0)));
+  NVF_CHECK(ref.equal(cg_outputs.at(0)));
 }
 
 TEST_F(NVFuserTest, ViewTransposeReshape_CUDA) {
@@ -1192,13 +1193,13 @@ TEST_F(NVFuserTest, ViewTransposeReshape_CUDA) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+  NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
 
   auto t1 = at::native::view(t0, {1024, 2, 2, 3});
   auto t2 = t1.transpose(1, 2);
   auto ref = at::reshape(t2, {1024, 2, 6});
 
-  TORCH_CHECK(ref.equal(cg_outputs.at(0)));
+  NVF_CHECK(ref.equal(cg_outputs.at(0)));
 }
 
 TEST_F(NVFuserTest, ReshapePermuteTransposeScheduler_CUDA) {
@@ -1225,11 +1226,11 @@ TEST_F(NVFuserTest, ReshapePermuteTransposeScheduler_CUDA) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+  NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
 
   auto heuristic =
       runtime->schedulerHeuristics()->heuristicsList().at(0).get()->heuristic();
-  TORCH_CHECK(
+  NVF_CHECK(
       heuristic == ScheduleHeuristic::Transpose,
       "Unexpected heuristic: ",
       heuristic);
@@ -1274,11 +1275,11 @@ TEST_F(
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+  NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
 
   auto heuristic =
       runtime->schedulerHeuristics()->heuristicsList().at(0).get()->heuristic();
-  TORCH_CHECK(
+  NVF_CHECK(
       heuristic != ScheduleHeuristic::Transpose,
       "Unexpected heuristic: ",
       heuristic);
@@ -1324,11 +1325,11 @@ TEST_F(NVFuserTest, FusionReshapeSmallTransposeDimensionSchedule_CUDA) {
   executor_cache.profile(true);
   auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
-  TORCH_CHECK(!executor_cache.getMostRecentKernelRuntime()->isSegmented());
+  NVF_CHECK(!executor_cache.getMostRecentKernelRuntime()->isSegmented());
   // NOTE: Aggressive check. If a transpose scheduler can handle this, we should
   // just let it handle this
-  TORCH_CHECK(executor_cache.getMostRecentExecutorInfo()
-                  .params->isA<PointwiseParams>());
+  NVF_CHECK(executor_cache.getMostRecentExecutorInfo()
+                .params->isA<PointwiseParams>());
 
   testValidate(&fusion, cg_outputs, {t0}, {t1, t2}, __LINE__, __FILE__);
 }
@@ -1359,15 +1360,15 @@ TEST_F(NVFuserTest, ViewTransposeMergedInnermostOnGroupTwo_CUDA) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+  NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
 
   auto t1 = at::native::view(t0, {8, 64, 64, 16});
   auto t2 = t1.transpose(1, 2);
   auto t3 = at::reshape(t2, {8, 64, 1024});
   auto t4 = t1.transpose(0, 3);
 
-  TORCH_CHECK(t3.equal(cg_outputs.at(0)));
-  TORCH_CHECK(t4.equal(cg_outputs.at(1)));
+  NVF_CHECK(t3.equal(cg_outputs.at(0)));
+  NVF_CHECK(t4.equal(cg_outputs.at(1)));
 }
 
 // TODO: we don't yet support vectorization on split dimension
@@ -1394,18 +1395,18 @@ TEST_F(NVFuserTest, TransposeSplitAggregatedVectorizationWidth_CUDA) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+  NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
   // TODO: check on vectorization!
   auto heuristic =
       runtime->schedulerHeuristics()->heuristicsList().at(0).get()->heuristic();
-  TORCH_CHECK(
+  NVF_CHECK(
       heuristic == ScheduleHeuristic::Transpose,
       "Unexpected heuristic: ",
       heuristic);
 
   auto ref = t0.transpose(0, 2);
 
-  TORCH_CHECK(ref.equal(cg_outputs.at(0)));
+  NVF_CHECK(ref.equal(cg_outputs.at(0)));
 }
 
 } // namespace nvfuser

--- a/test/test_gpu_transpose.cpp
+++ b/test/test_gpu_transpose.cpp
@@ -296,7 +296,7 @@ TEST_F(NVFuserTest, FusionScheduleTransposeNoReference_CUDA) {
       [&]() {
         scheduleTranspose(&fusion, {input0, input1});
       },
-      testing::ThrowsMessage<c10::Error>(
+      testing::ThrowsMessage<nvfuser::nvfError>(
           testing::HasSubstr("reference tensor")));
 }
 
@@ -643,7 +643,7 @@ TEST_F(NVFuserTest, FusionTransposeSelfMapping_CUDA) {
 
   EXPECT_THAT(
       [&]() { IterDomainGraph(fusion_ptr.get()); },
-      testing::ThrowsMessage<c10::Error>(
+      testing::ThrowsMessage<nvfuser::nvfError>(
           testing::HasSubstr("Unsupported domain mapping detected")));
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -317,7 +317,7 @@ TEST_F(VectorizeHelperTest, BackwardMapper2_CUDA) {
 
   EXPECT_THAT(
       [&]() { mapper.getProjectedExtent(tv2->axis(0)); },
-      ::testing::ThrowsMessage<c10::Error>(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Not projected")));
   EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3);
   EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 4);
@@ -640,7 +640,7 @@ TEST_F(VectorizeHelperTest, ForwardMapper2_CUDA) {
 
   EXPECT_THAT(
       [&]() { mapper.getProjectedExtent(tv0->axis(0)); },
-      ::testing::ThrowsMessage<c10::Error>(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Not projected")));
   EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3);
   EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 4);
@@ -1074,7 +1074,8 @@ TEST_F(NVFuserTest, FusionSASSDumpError_CUDA) {
 
   EXPECT_THAT(
       [&]() { fe.disassembledKernelSASS(); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr("I am fake")));
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
+          ::testing::HasSubstr("I am fake")));
 
   auto cg_outputs = fe.runFusion({t0});
   testValidate(fe.kernel(), cg_outputs, {t0}, {t0}, __LINE__, __FILE__);

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -118,8 +119,7 @@ TEST_F(NVFuserTest, FusionDisjointViewSet_CUDA) {
 
   auto disjoint_exact = scheduler_utils::disjointRFactorSets(fusion.get());
 
-  TORCH_INTERNAL_ASSERT(
-      disjoint_exact.strictAreMapped(tv0->axis(1), tv0->axis(2)));
+  NVF_ERROR(disjoint_exact.strictAreMapped(tv0->axis(1), tv0->axis(2)));
 }
 
 TEST_F(NVFuserTest, FusionBroadcastViewMultiples_CUDA) {

--- a/test/test_gpu_view.cpp
+++ b/test/test_gpu_view.cpp
@@ -1335,7 +1335,7 @@ TEST_F(NVFuserTest, FusionIllegalReductionFlatten_CUDA) {
         auto tv2 = flatten(tv1, 0, 1);
         fusion->addOutput(tv2);
       },
-      testing::ThrowsMessage<c10::Error>(
+      testing::ThrowsMessage<nvfuser::nvfError>(
           testing::HasSubstr("Invalid end_dim")));
 }
 

--- a/test/test_matmul_sass.cpp
+++ b/test/test_matmul_sass.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gtest/gtest.h>
 
 #include <ops/arith.h>
@@ -87,7 +88,7 @@ sass::Container getSASSFor(
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
 
-  TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 
   return sass::parse(fe.disassembledKernelSASS());
 }
@@ -152,7 +153,7 @@ sass::Container getBinaryOpMulEpilogueSASSFor(
                   alpha)
                   .to(at::kFloat);
 
-  TORCH_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 
   return sass::parse(fe.disassembledKernelSASS());
 }
@@ -197,9 +198,9 @@ TEST_F(MatmulSASSTest, AmpereSanity_CUDA) {
           },
           inst);
     }
-    TORCH_CHECK(found_LDGSTS);
-    TORCH_CHECK(found_LDSM);
-    TORCH_CHECK(found_HMMA);
+    NVF_CHECK(found_LDGSTS);
+    NVF_CHECK(found_LDSM);
+    NVF_CHECK(found_HMMA);
   }
 }
 
@@ -239,7 +240,7 @@ TEST_F(MatmulSASSTest, AmpereModifiers_CUDA) {
               if (i.opCode() == "LDGSTS") {
                 const std::vector<std::string> expect = {
                     "E", "BYPASS", "LTC128B", "128"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for LDGSTS has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -250,7 +251,7 @@ TEST_F(MatmulSASSTest, AmpereModifiers_CUDA) {
                 found_LDGSTS = true;
               } else if (i.opCode() == "LDGDEPBAR") {
                 const std::vector<std::string> expect;
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for LDGDEPBAR has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -264,7 +265,7 @@ TEST_F(MatmulSASSTest, AmpereModifiers_CUDA) {
                 const std::vector<std::string> expect2 = {"16", "M88", "4"};
                 const std::vector<std::string> expect3 = {"16", "MT88", "2"};
                 const std::vector<std::string> expect4 = {"16", "MT88", "4"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect1 || i.modifiers() == expect2 ||
                         i.modifiers() == expect3 || i.modifiers() == expect4,
                     "Modifiers for LDGDEPBAR has changed. "
@@ -272,7 +273,7 @@ TEST_F(MatmulSASSTest, AmpereModifiers_CUDA) {
                 found_LDSM = true;
               } else if (i.opCode() == "HMMA") {
                 const std::vector<std::string> expect = {"16816", "F32"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for HMMA has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -284,7 +285,7 @@ TEST_F(MatmulSASSTest, AmpereModifiers_CUDA) {
               } else if (i.opCode() == "BAR") {
                 const std::vector<std::string> expect = {
                     "SYNC", "DEFER_BLOCKING"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for BAR has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -295,7 +296,7 @@ TEST_F(MatmulSASSTest, AmpereModifiers_CUDA) {
                 found_BAR = true;
               } else if (i.opCode() == "DEPBAR") {
                 const std::vector<std::string> expect = {"LE"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for DEPBAR has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -309,12 +310,12 @@ TEST_F(MatmulSASSTest, AmpereModifiers_CUDA) {
           },
           inst);
     }
-    TORCH_CHECK(found_LDGSTS);
-    TORCH_CHECK(found_LDSM);
-    TORCH_CHECK(found_HMMA);
-    TORCH_CHECK(found_LDGDEPBAR);
-    TORCH_CHECK(found_BAR);
-    TORCH_CHECK(found_DEPBAR);
+    NVF_CHECK(found_LDGSTS);
+    NVF_CHECK(found_LDSM);
+    NVF_CHECK(found_HMMA);
+    NVF_CHECK(found_LDGDEPBAR);
+    NVF_CHECK(found_BAR);
+    NVF_CHECK(found_DEPBAR);
   }
 }
 
@@ -376,7 +377,7 @@ TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue_CUDA) {
               if (i.opCode() == "LDGSTS") {
                 const std::vector<std::string> expect = {
                     "E", "BYPASS", "LTC128B", "128"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for LDGSTS has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -387,7 +388,7 @@ TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue_CUDA) {
                 found_LDGSTS = true;
               } else if (i.opCode() == "LDGDEPBAR") {
                 const std::vector<std::string> expect;
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for LDGDEPBAR has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -401,7 +402,7 @@ TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue_CUDA) {
                 const std::vector<std::string> expect2 = {"16", "M88", "4"};
                 const std::vector<std::string> expect3 = {"16", "MT88", "2"};
                 const std::vector<std::string> expect4 = {"16", "MT88", "4"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect1 || i.modifiers() == expect2 ||
                         i.modifiers() == expect3 || i.modifiers() == expect4,
                     "Modifiers for LDGDEPBAR has changed. "
@@ -409,7 +410,7 @@ TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue_CUDA) {
                 found_LDSM = true;
               } else if (i.opCode() == "HMMA") {
                 const std::vector<std::string> expect = {"16816", "F32"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for HMMA has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -421,7 +422,7 @@ TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue_CUDA) {
               } else if (i.opCode() == "BAR") {
                 const std::vector<std::string> expect = {
                     "SYNC", "DEFER_BLOCKING"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for BAR has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -432,7 +433,7 @@ TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue_CUDA) {
                 BAR_COUNT++;
               } else if (i.opCode() == "DEPBAR") {
                 const std::vector<std::string> expect = {"LE"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for DEPBAR has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -446,17 +447,17 @@ TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue_CUDA) {
           },
           inst);
     }
-    TORCH_CHECK(found_LDGSTS);
-    TORCH_CHECK(found_LDSM);
-    TORCH_CHECK(found_HMMA);
-    TORCH_CHECK(found_LDGDEPBAR);
-    TORCH_CHECK(
+    NVF_CHECK(found_LDGSTS);
+    NVF_CHECK(found_LDSM);
+    NVF_CHECK(found_HMMA);
+    NVF_CHECK(found_LDGDEPBAR);
+    NVF_CHECK(
         BAR_COUNT == EXPECTED_BAR_COUNT,
         "Expect ",
         EXPECTED_BAR_COUNT,
         " BARs, got ",
         BAR_COUNT);
-    TORCH_CHECK(found_DEPBAR);
+    NVF_CHECK(found_DEPBAR);
   }
 }
 
@@ -492,7 +493,7 @@ TEST_F(MatmulSASSTest, AmpereEpilogueBinaryOpMul_CUDA) {
               if (i.opCode() == "LDGSTS") {
                 const std::vector<std::string> expect = {
                     "E", "BYPASS", "LTC128B", "128"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for LDGSTS has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -503,7 +504,7 @@ TEST_F(MatmulSASSTest, AmpereEpilogueBinaryOpMul_CUDA) {
                 found_LDGSTS = true;
               } else if (i.opCode() == "LDGDEPBAR") {
                 const std::vector<std::string> expect;
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for LDGDEPBAR has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -517,7 +518,7 @@ TEST_F(MatmulSASSTest, AmpereEpilogueBinaryOpMul_CUDA) {
                 const std::vector<std::string> expect2 = {"16", "M88", "4"};
                 const std::vector<std::string> expect3 = {"16", "MT88", "2"};
                 const std::vector<std::string> expect4 = {"16", "MT88", "4"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect1 || i.modifiers() == expect2 ||
                         i.modifiers() == expect3 || i.modifiers() == expect4,
                     "Modifiers for LDGDEPBAR has changed. "
@@ -525,7 +526,7 @@ TEST_F(MatmulSASSTest, AmpereEpilogueBinaryOpMul_CUDA) {
                 found_LDSM = true;
               } else if (i.opCode() == "HMMA") {
                 const std::vector<std::string> expect = {"16816", "F32"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for HMMA has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -537,7 +538,7 @@ TEST_F(MatmulSASSTest, AmpereEpilogueBinaryOpMul_CUDA) {
               } else if (i.opCode() == "BAR") {
                 const std::vector<std::string> expect = {
                     "SYNC", "DEFER_BLOCKING"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for BAR has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -548,7 +549,7 @@ TEST_F(MatmulSASSTest, AmpereEpilogueBinaryOpMul_CUDA) {
                 found_BAR = true;
               } else if (i.opCode() == "DEPBAR") {
                 const std::vector<std::string> expect = {"LE"};
-                TORCH_CHECK(
+                NVF_CHECK(
                     i.modifiers() == expect,
                     "Modifiers for DEPBAR has changed. "
                     "Please manually check if the new modifiers makes sense and update this test. "
@@ -562,12 +563,12 @@ TEST_F(MatmulSASSTest, AmpereEpilogueBinaryOpMul_CUDA) {
           },
           inst);
     }
-    TORCH_CHECK(found_LDGSTS);
-    TORCH_CHECK(found_LDSM);
-    TORCH_CHECK(found_HMMA);
-    TORCH_CHECK(found_LDGDEPBAR);
-    TORCH_CHECK(found_BAR);
-    TORCH_CHECK(found_DEPBAR);
+    NVF_CHECK(found_LDGSTS);
+    NVF_CHECK(found_LDSM);
+    NVF_CHECK(found_HMMA);
+    NVF_CHECK(found_LDGDEPBAR);
+    NVF_CHECK(found_BAR);
+    NVF_CHECK(found_DEPBAR);
   }
 }
 
@@ -623,7 +624,7 @@ TEST_F(MatmulSASSTest, AmpereRegisterUsageLDSM_CUDA) {
                 return;
               }
               auto args = i.args();
-              TORCH_INTERNAL_ASSERT(args.size() == 2);
+              NVF_ERROR(args.size() == 2);
               std::string smem_address = args[1];
               // get base shared memory address
               std::string_view view(smem_address); // example: [R0+UR0+0x200]
@@ -649,7 +650,7 @@ TEST_F(MatmulSASSTest, AmpereRegisterUsageLDSM_CUDA) {
           inst);
     }
     for (auto& [base, offsets] : base_offsets) {
-      TORCH_CHECK(
+      NVF_CHECK(
           offsets.size() > 1,
           "Expect base addresses to be used multiple times, but ",
           base,

--- a/test/test_matmul_scheduler.cpp
+++ b/test/test_matmul_scheduler.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gtest/gtest.h>
 
 #include <fusion.h>
@@ -38,22 +39,22 @@ TEST_F(MatmulSchedulerTest, BasicMatmulStrictCheckTT_CUDA) {
   fusion->addInput(tv1);
   fusion->addOutput(tv2);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must be always TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -69,11 +70,11 @@ TEST_F(MatmulSchedulerTest, BasicMatmulStrictCheckTT_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "fusion got segmented, expected to match whole fusion with single segment");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       isSchedulerInUse(
           executor_cache.getMostRecentKernelRuntime(),
           ScheduleHeuristic::Matmul),
@@ -100,22 +101,22 @@ TEST_F(MatmulSchedulerTest, BasicMatmulRelaxedCheck_CUDA) {
     fusion->addInput(tv1);
     fusion->addOutput(tv2);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         1 == ir_utils::getMmaOps(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
         "input layout has not be set for MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         MatmulLayout::TN ==
             ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
         "the MmaOp layout of Ampere MMA must be always TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.isValid(),
         "failed to get decide matmul layout through fusion definition");
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.getData() == layout,
         "mismatch between test layout (",
         toString(layout),
@@ -131,17 +132,17 @@ TEST_F(MatmulSchedulerTest, BasicMatmulRelaxedCheck_CUDA) {
 
     auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
-    TORCH_CHECK(
+    NVF_CHECK(
         !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
         "fusion got segmented, expected to match whole fusion with single segment");
 
-    TORCH_CHECK(
+    NVF_CHECK(
         isSchedulerInUse(
             executor_cache.getMostRecentKernelRuntime(),
             ScheduleHeuristic::Matmul),
         "matmul scheduler was not used to handle prepared fusion");
 
-    TORCH_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
+    NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
   }
 }
 
@@ -164,22 +165,22 @@ TEST_F(MatmulSchedulerTest, BasicMatmulInputShuffledTT_CUDA) {
   fusion->addInput(tv0);
   fusion->addOutput(tv2);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must be always TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -195,17 +196,17 @@ TEST_F(MatmulSchedulerTest, BasicMatmulInputShuffledTT_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t1, t0});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "fusion got segmented, expected to match whole fusion with single segment");
 
-  TORCH_CHECK(
+  NVF_CHECK(
       isSchedulerInUse(
           executor_cache.getMostRecentKernelRuntime(),
           ScheduleHeuristic::Matmul),
       "matmul scheduler was not used to handle prepared fusion");
 
-  TORCH_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
+  NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
 }
 
 // Matmul test that relies on segmenter for 'C = float2half(A x B)' fusion, for
@@ -227,22 +228,22 @@ TEST_F(MatmulSchedulerTest, EpilogueOutputCast_CUDA) {
   fusion->addInput(tv1);
   fusion->addOutput(tv3);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -262,11 +263,11 @@ TEST_F(MatmulSchedulerTest, EpilogueOutputCast_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation did happen");
 
-  TORCH_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
+  NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
 }
 
 // Matmul test that relies on segmenter for 'C = alpha * (A x B)' fusion, for
@@ -290,22 +291,22 @@ TEST_F(MatmulSchedulerTest, EpilogueAlpha_CUDA) {
   fusion->addInput(s0);
   fusion->addOutput(tv3);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -326,11 +327,11 @@ TEST_F(MatmulSchedulerTest, EpilogueAlpha_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1, alpha});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation did happen");
 
-  TORCH_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
+  NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
 }
 
 // Matmul test that relies on segmenter for 'C = float2half(alpha * (A x B))'
@@ -355,22 +356,22 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaOutputCast_CUDA) {
   fusion->addInput(s0);
   fusion->addOutput(tv4);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -392,11 +393,11 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaOutputCast_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1, alpha});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation did happen");
 
-  TORCH_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
+  NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
 }
 
 // Matmul test that relies on segmenter for 'C = relu(A x B)' fusion, for
@@ -418,22 +419,22 @@ TEST_F(MatmulSchedulerTest, EpilogueRelu_CUDA) {
   fusion->addInput(tv1);
   fusion->addOutput(tv3);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -453,11 +454,11 @@ TEST_F(MatmulSchedulerTest, EpilogueRelu_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation did happen");
 
-  TORCH_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
+  NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
 }
 
 // Matmul test that relies on segmenter for 'C = gelu(A x B)' fusion, for
@@ -479,22 +480,22 @@ TEST_F(MatmulSchedulerTest, EpilogueGelu_CUDA) {
   fusion->addInput(tv1);
   fusion->addOutput(tv3);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -514,11 +515,11 @@ TEST_F(MatmulSchedulerTest, EpilogueGelu_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation did happen");
 
-  TORCH_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
+  NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
 }
 
 // Matmul test that relies on segmenter for fusion for Ampere:
@@ -551,22 +552,22 @@ TEST_F(MatmulSchedulerTest, EpilogueBeta_CUDA) {
   fusion->addInput(s0);
   fusion->addOutput(tv5);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -591,13 +592,13 @@ TEST_F(MatmulSchedulerTest, EpilogueBeta_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2, beta});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation did happen");
 
   // NOTE: increasted absolute tolerance to silence false negative verification
   //       caused by different way of calculating reference
-  TORCH_CHECK(outputs[0].allclose(t5, 0.01, 0.04));
+  NVF_CHECK(outputs[0].allclose(t5, 0.01, 0.04));
 }
 
 // Matmul test that relies on segmenter for fusion for Ampere:
@@ -633,22 +634,22 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBeta_CUDA) {
   fusion->addInput(s1);
   fusion->addOutput(tv6);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -675,13 +676,13 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBeta_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2, alpha, beta});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation did happen");
 
   // NOTE: increasted absolute tolerance to silence false negative verification
   //       caused by different way of calculating reference
-  TORCH_CHECK(outputs[0].allclose(t6, 0.001, 0.004));
+  NVF_CHECK(outputs[0].allclose(t6, 0.001, 0.004));
 }
 
 // Matmul test that relies on segmenter for fusion for Ampere:
@@ -721,22 +722,22 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaGeluOutputCast_CUDA) {
   fusion->addInput(s1);
   fusion->addOutput(tv8);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -766,13 +767,13 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaGeluOutputCast_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2, alpha, beta});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation did happen");
 
   // NOTE: increasted absolute tolerance to silence false negative verification
   //       caused by different way of calculating reference
-  TORCH_CHECK(outputs[0].allclose(t8, 0.01, 0.06));
+  NVF_CHECK(outputs[0].allclose(t8, 0.01, 0.06));
 }
 
 // Matmul test that relies on segmenter for fusion for Ampere:
@@ -800,22 +801,22 @@ TEST_F(MatmulSchedulerTest, EpilogueBias_CUDA) {
   fusion->addInput(tv2);
   fusion->addOutput(tv4);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -838,13 +839,13 @@ TEST_F(MatmulSchedulerTest, EpilogueBias_CUDA) {
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation did happen");
 
   // NOTE: increasted absolute tolerance to silence false negative verification
   //       caused by different way of calculating reference
-  TORCH_CHECK(outputs[0].allclose(t4, 0.001, 0.001));
+  NVF_CHECK(outputs[0].allclose(t4, 0.001, 0.001));
 }
 
 // Matmul test that relies on segmenter for fusion for Ampere:
@@ -885,22 +886,22 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias_CUDA) {
   fusion->addInput(s1);
   fusion->addOutput(tv8);
 
-  TORCH_CHECK(
+  NVF_CHECK(
       1 == ir_utils::getMmaOps(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
-  TORCH_CHECK(
+  NVF_CHECK(
       MatmulLayout::TN ==
           ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.isValid(),
       "failed to get decide matmul layout through fusion definition");
-  TORCH_CHECK(
+  NVF_CHECK(
       fusion_layout.getData() == layout,
       "mismatch between test layout (",
       toString(layout),
@@ -933,13 +934,13 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias_CUDA) {
   auto outputs =
       executor_cache.runFusionWithInputs({t0, t1, t2, t3, alpha, beta});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
       "segmentation did happen");
 
   // NOTE: increasted absolute tolerance to silence false negative verification
   //       caused by different way of calculating reference
-  TORCH_CHECK(outputs[0].allclose(t8, 0.01, 0.01));
+  NVF_CHECK(outputs[0].allclose(t8, 0.01, 0.01));
 }
 
 // Strided batch gemm test taht uses matmul scheduler, for Ampere:
@@ -962,22 +963,22 @@ TEST_F(MatmulSchedulerTest, StridedBatch_CUDA) {
     fusion->addInput(tv1);
     fusion->addOutput(tv2);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         1 == ir_utils::getMmaOps(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
         "input layout has not be set for MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         MatmulLayout::TN ==
             ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
         "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.isValid(),
         "failed to get decide matmul layout through fusion definition");
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.getData() == layout,
         "mismatch between test layout (",
         toString(layout),
@@ -994,14 +995,14 @@ TEST_F(MatmulSchedulerTest, StridedBatch_CUDA) {
 
     auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
-    TORCH_CHECK(
+    NVF_CHECK(
         !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
         "segmentation did happen");
 
     // NOTE: increasted absolute tolerance to silence false negative
     // verification
     //       caused by different way of calculating reference
-    TORCH_CHECK(outputs[0].allclose(t2, 0.0001, 0.0001));
+    NVF_CHECK(outputs[0].allclose(t2, 0.0001, 0.0001));
   }
 }
 
@@ -1040,22 +1041,22 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta_CUDA) {
     fusion->addInput(s1);
     fusion->addOutput(tv6);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         1 == ir_utils::getMmaOps(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
         "input layout has not be set for MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         MatmulLayout::TN ==
             ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
         "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.isValid(),
         "failed to get decide matmul layout through fusion definition");
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.getData() == layout,
         "mismatch between test layout (",
         toString(layout),
@@ -1081,13 +1082,13 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta_CUDA) {
     auto outputs =
         executor_cache.runFusionWithInputs({t0, t1, t2, alpha, beta});
 
-    TORCH_CHECK(
+    NVF_CHECK(
         !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
         "segmentation did happen");
 
     // NOTE: increasted absolute tolerance to silence false negative
     //  verification caused by different way of calculating reference
-    TORCH_CHECK(outputs[0].allclose(t6, 0.0001, 0.0001));
+    NVF_CHECK(outputs[0].allclose(t6, 0.0001, 0.0001));
   }
 }
 
@@ -1130,22 +1131,22 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta_CUDA) {
     fusion->addInput(s1);
     fusion->addOutput(tv7);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         1 == ir_utils::getMmaOps(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
         "input layout has not be set for MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         MatmulLayout::TN ==
             ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
         "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.isValid(),
         "failed to get decide matmul layout through fusion definition");
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.getData() == layout,
         "mismatch between test layout (",
         toString(layout),
@@ -1174,13 +1175,13 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta_CUDA) {
     auto outputs =
         executor_cache.runFusionWithInputs({t0, t1, t2, alpha, beta});
 
-    TORCH_CHECK(
+    NVF_CHECK(
         !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
         "segmentation did happen");
 
     // NOTE: increasted absolute tolerance to silence false negative
     //  verification caused by different way of calculating reference
-    TORCH_CHECK(outputs[0].allclose(t7, 0.0001, 0.0001));
+    NVF_CHECK(outputs[0].allclose(t7, 0.0001, 0.0001));
   }
 }
 
@@ -1209,22 +1210,22 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueBias_CUDA) {
     fusion->addInput(tv2);
     fusion->addOutput(tv4);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         1 == ir_utils::getMmaOps(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
         "input layout has not be set for MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         MatmulLayout::TN ==
             ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
         "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.isValid(),
         "failed to get decide matmul layout through fusion definition");
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.getData() == layout,
         "mismatch between test layout (",
         toString(layout),
@@ -1245,13 +1246,13 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueBias_CUDA) {
 
     auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
-    TORCH_CHECK(
+    NVF_CHECK(
         !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
         "segmentation did happen");
 
     // NOTE: increasted absolute tolerance to silence false negative
     //  verification caused by different way of calculating reference
-    TORCH_CHECK(outputs[0].allclose(t4, 0.0001, 0.0001));
+    NVF_CHECK(outputs[0].allclose(t4, 0.0001, 0.0001));
   }
 }
 
@@ -1281,22 +1282,22 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueSingleBias_CUDA) {
     fusion->addInput(tv2);
     fusion->addOutput(tv4);
 
-    TORCH_CHECK(
+    NVF_CHECK(
         1 == ir_utils::getMmaOps(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
         "input layout has not be set for MmaOp");
-    TORCH_CHECK(
+    NVF_CHECK(
         MatmulLayout::TN ==
             ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
         "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.isValid(),
         "failed to get decide matmul layout through fusion definition");
-    TORCH_CHECK(
+    NVF_CHECK(
         fusion_layout.getData() == layout,
         "mismatch between test layout (",
         toString(layout),
@@ -1318,13 +1319,13 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueSingleBias_CUDA) {
 
     auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
-    TORCH_CHECK(
+    NVF_CHECK(
         !executor_cache.getMostRecentKernelRuntime()->isSegmented(),
         "segmentation did happen");
 
     // NOTE: increasted absolute tolerance to silence false negative
     //  verification caused by different way of calculating reference
-    TORCH_CHECK(outputs[0].allclose(t4, 0.0001, 0.0001));
+    NVF_CHECK(outputs[0].allclose(t4, 0.0001, 0.0001));
   }
 }
 

--- a/test/test_optimization_pass.cpp
+++ b/test/test_optimization_pass.cpp
@@ -78,7 +78,7 @@ TEST_F(NVFuserTest, FusionCyclicGraph_CUDA) {
         [&]() {
           StmtSort::getStmtsBetween(fusion.get(), {}, fusion->outputs());
         },
-        ::testing::ThrowsMessage<c10::Error>(
+        ::testing::ThrowsMessage<nvfuser::nvfError>(
             ::testing::HasSubstr("cycle detected")));
   }
 
@@ -116,7 +116,7 @@ TEST_F(NVFuserTest, FusionCyclicGraph_CUDA) {
     // cycle should be detected, since dead branch is in our check path
     EXPECT_THAT(
         [&]() { StmtSort::getStmtsBetween(fusion.get(), {}, to); },
-        ::testing::ThrowsMessage<c10::Error>(
+        ::testing::ThrowsMessage<nvfuser::nvfError>(
             ::testing::HasSubstr("cycle detected")));
 
     // check for proper size of cycle detected

--- a/test/test_polymorphic_value.cpp
+++ b/test/test_polymorphic_value.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -47,7 +48,7 @@ TEST_F(PolymorphicValueTest, Struct) {
       } else if (key == "y") {
         return [this]() { return PolymorphicValue(y); };
       } else {
-        TORCH_INTERNAL_ASSERT(false, "Invalid key");
+        NVF_ERROR(false, "Invalid key");
       }
     }
 
@@ -58,7 +59,7 @@ TEST_F(PolymorphicValueTest, Struct) {
       } else if (key == "y") {
         return [this](const PolymorphicValue& value) { y = (double)value; };
       } else {
-        TORCH_INTERNAL_ASSERT(false, "Invalid key");
+        NVF_ERROR(false, "Invalid key");
       }
     }
   };

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -2199,7 +2199,7 @@ TEST_F(ResizeTest, FusionSqueezeSymbolic) {
       [&]() {
         fec.runFusionWithInputs({t0, 10});
       },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "must concretize to IterType::Broadcast but found")));
 }
 
@@ -2649,7 +2649,7 @@ TEST_F(ResizeTest, Slice3DVectorizeManual1) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion(aten_inputs); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "with word size 2 not possible due to invalid stride")));
 }
 
@@ -2692,7 +2692,7 @@ TEST_F(ResizeTest, Slice3DVectorizeManual2) {
 
   EXPECT_THAT(
       [&]() { fe.runFusion(aten_inputs); },
-      ::testing::ThrowsMessage<c10::Error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "with word size 4 not possible due to invalid stride")));
 }
 

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -1,3 +1,4 @@
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -39,7 +40,7 @@ TEST_F(ResizeTest, FusionResizePad1) {
 
   auto ref = at::pad(t0, {1, 1});
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // pad + split
@@ -68,7 +69,7 @@ TEST_F(ResizeTest, FusionResizePad2) {
 
   auto ref = at::pad(t0, {1, 1});
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // pad, merge + split, inlineMost
@@ -144,7 +145,7 @@ TEST_F(ResizeTest, FusionResizePad4) {
 
   auto ref = at::pad(t0, {1, 1});
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // pad + parallelization + RAW sync
@@ -166,14 +167,14 @@ TEST_F(ResizeTest, FusionResizePad5) {
 
   scheduler_utils::promoteProducerMemoryTypes(&fusion, {});
 
-  TORCH_CHECK(
+  NVF_CHECK(
       tv1->getMemoryType() == MemoryType::Shared,
       "tv1 should be on shared memory: ",
       tv1->getMemoryType());
 
   GpuLower gpulw(&fusion);
   auto all_lowered_exprs = KernelExprVisitor::getAllExprs(gpulw.kernel());
-  TORCH_CHECK(
+  NVF_CHECK(
       std::find_if(
           all_lowered_exprs.begin(),
           all_lowered_exprs.end(),
@@ -192,7 +193,7 @@ TEST_F(ResizeTest, FusionResizePad5) {
 
   auto ref = at::pad(t0, {1, 1});
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // pad + merge + split parallelization
@@ -357,7 +358,7 @@ TEST_F(ResizeTest, FusionResizePadScheduler1) {
 
   auto ref = at::pad(t0, {1, 1});
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 TEST_F(ResizeTest, FusionResizePadScheduler2) {
@@ -552,7 +553,7 @@ TEST_F(ResizeTest, FusionResizeCat1) {
 
   auto ref = at::cat({t0, t1}, 0);
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // Trivial 2D inner cat
@@ -584,7 +585,7 @@ TEST_F(ResizeTest, FusionResizeCat2) {
 
   auto ref = at::cat({t0, t1}, 0);
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // Trivial 2D outer cat
@@ -625,7 +626,7 @@ TEST_F(ResizeTest, FusionResizeCat3) {
 
   auto ref = at::cat({t0, t1}, 1);
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // Cat + merge + split + parallelization + inlineMost
@@ -669,7 +670,7 @@ TEST_F(ResizeTest, FusionResizeCat4) {
 
   auto ref = at::cat({t0, t1}, 1);
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // Cat + arith op
@@ -764,7 +765,7 @@ TEST_F(ResizeTest, FusionResizeCat6) {
 
   auto ref = at::cat({t0, t1, t2}, 0);
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // Cat many tensors
@@ -820,7 +821,7 @@ TEST_F(ResizeTest, FusionResizeCat7) {
 
     auto ref = at::cat(aten_inputs, concat_dim);
 
-    TORCH_CHECK(ref.equal(cg_outputs[0]));
+    NVF_CHECK(ref.equal(cg_outputs[0]));
   }
 }
 
@@ -853,7 +854,7 @@ TEST_F(ResizeTest, FusionResizeCatScheduler1) {
 
   auto ref = at::cat({t0, t1}, 0);
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // Auto scheduled version of Cat5
@@ -930,7 +931,7 @@ TEST_F(ResizeTest, FusionResizeCatScheduler3) {
 
   auto ref = at::cat({t0, t1, t2}, 0);
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // Trivial slice
@@ -961,7 +962,7 @@ TEST_F(ResizeTest, FusionResizeSlice1) {
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // Split a tensor to half and add them up
@@ -971,7 +972,7 @@ TEST_F(ResizeTest, FusionResizeSlice2) {
 
   std::vector<int64_t> shape({11, 30});
 
-  TORCH_CHECK(shape[1] % 2 == 0);
+  NVF_CHECK(shape[1] % 2 == 0);
 
   auto tv0 = makeConcreteTensor(shape);
   fusion.addInput(tv0);
@@ -1018,8 +1019,8 @@ TEST_F(ResizeTest, FusionResizeSlice3) {
   auto tv3 = add(tv1, tv2);
   fusion.addOutput(tv3);
 
-  TORCH_CHECK(tv1->definition()->isA<LoadStoreOp>());
-  TORCH_CHECK(tv2->definition()->isA<LoadStoreOp>());
+  NVF_CHECK(tv1->definition()->isA<LoadStoreOp>());
+  NVF_CHECK(tv2->definition()->isA<LoadStoreOp>());
 }
 
 // Partition an input, reduce each and concatenate them
@@ -1201,7 +1202,7 @@ TEST_F(ResizeTest, FusionResizeSliceScheduler1) {
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 TEST_F(ResizeTest, FusionResizePadReduceScheduler1) {
@@ -1635,7 +1636,7 @@ TEST_F(ResizeTest, FusionResizePadWithValue) {
 
   auto ref = at::pad(t0, {1, 1}, "constant", 2);
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // Test that padding Half tensor by Double does not promote output
@@ -1665,8 +1666,8 @@ TEST_F(ResizeTest, FusionResizePadHalfWithDoubleValue) {
 
   auto ref = at::pad(t0, {1, 1}, "constant", 2.5);
 
-  TORCH_CHECK(ref.dtype() == cg_outputs[0].dtype());
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.dtype() == cg_outputs[0].dtype());
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 TEST_F(ResizeTest, FusionSliceForNanoGPT1) {
@@ -1720,7 +1721,7 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT1) {
 
   auto kernel =
       executor_cache.getMostRecentKernelRuntime()->executors().at(0).kernel();
-  TORCH_CHECK(
+  NVF_CHECK(
       !kernel->summary().has_cooperative_grid_reduction,
       "Grid sync should not be used as slicing input should avoid input caching");
 
@@ -1803,7 +1804,7 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT2) {
     }
     auto out_tv = ir_utils::getTvOutput(expr);
     if (out_tv->name() == tv3->name() || out_tv->name() == tv5->name()) {
-      TORCH_CHECK(
+      NVF_CHECK(
           expr->isA<LoadStoreOp>(),
           "Unexpected defintion of slice output tensor: ",
           out_tv->toString(),
@@ -1818,7 +1819,7 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT2) {
       if (known_slice_producer == nullptr) {
         known_slice_producer = producer->view();
       } else {
-        TORCH_CHECK(
+        NVF_CHECK(
             known_slice_producer == producer->view(),
             "Expected to have the same tensor is used for the two slice ops. ",
             "Previously found producer: ",
@@ -1833,7 +1834,7 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT2) {
           binary_op->out()->isA<kir::TensorIndex>() &&
           binary_op->out()->as<kir::TensorIndex>()->view()->name() ==
               tv7->name()) {
-        TORCH_CHECK(
+        NVF_CHECK(
             binary_op->lhs()->as<kir::TensorIndex>()->view()->name() ==
                 tv2->name(),
             "Unexpected tv7 definition: ",
@@ -1842,10 +1843,10 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT2) {
     }
   }
 
-  TORCH_CHECK(known_slice_producer != nullptr, "Slice producer not found");
+  NVF_CHECK(known_slice_producer != nullptr, "Slice producer not found");
 
   // The slice producer must be a copy of tv2
-  TORCH_CHECK(
+  NVF_CHECK(
       known_slice_producer->definition() &&
           known_slice_producer->definition()->isA<LoadStoreOp>() &&
           known_slice_producer->definition()->as<LoadStoreOp>()->in()->name() ==
@@ -1918,10 +1919,10 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT3) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+  NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
 
   auto kernel = runtime->executors().at(0).kernel();
-  TORCH_CHECK(
+  NVF_CHECK(
       !kernel->summary().has_cooperative_grid_reduction,
       "Grid sync should not be used as slicing input should avoid input caching");
 
@@ -1942,9 +1943,9 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT3) {
   auto at_t5 = at_t2.reshape({16, 128, 16, 64});
   auto at_t6 = at_t3.reshape({16, 128, 16, 64});
 
-  TORCH_CHECK(cg_outputs.at(0).equal(at_t4));
-  TORCH_CHECK(cg_outputs.at(1).equal(at_t5));
-  TORCH_CHECK(cg_outputs.at(2).equal(at_t6));
+  NVF_CHECK(cg_outputs.at(0).equal(at_t4));
+  NVF_CHECK(cg_outputs.at(1).equal(at_t5));
+  NVF_CHECK(cg_outputs.at(2).equal(at_t6));
 }
 
 TEST_F(ResizeTest, ResizeReshapeAndSlice) {
@@ -1975,12 +1976,12 @@ TEST_F(ResizeTest, ResizeReshapeAndSlice) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+  NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
 
   auto ref = t0.reshape({8, 4}).index(
       {at::indexing::Slice(0, 2), at::indexing::Slice(0, 2)});
 
-  TORCH_CHECK(ref.equal(cg_outputs.at(0)));
+  NVF_CHECK(ref.equal(cg_outputs.at(0)));
 }
 
 // Make sure resize works with the transpose scheduler
@@ -2019,11 +2020,11 @@ TEST_F(ResizeTest, ResizePermuteAndSlice) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
-  TORCH_CHECK(!runtime->isSegmented(), "Segmentation not expected");
+  NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
 
   auto heuristic =
       runtime->schedulerHeuristics()->heuristicsList().at(0).get()->heuristic();
-  TORCH_CHECK(
+  NVF_CHECK(
       heuristic == ScheduleHeuristic::Transpose,
       "Unexpected heuristic: ",
       heuristic);
@@ -2108,12 +2109,12 @@ TEST_F(ResizeTest, FusionSizeZeroSliceSplitSchedule) {
   auto ref4 = t0.index({at::indexing::Slice(6, 6)});
   auto ref5 = t0.index({at::indexing::Slice(6, 8)});
 
-  TORCH_CHECK(ref0.equal(cg_outputs[0]));
-  TORCH_CHECK(ref1.equal(cg_outputs[1]));
-  TORCH_CHECK(ref2.equal(cg_outputs[2]));
-  TORCH_CHECK(ref3.equal(cg_outputs[3]));
-  TORCH_CHECK(ref4.equal(cg_outputs[4]));
-  TORCH_CHECK(ref5.equal(cg_outputs[5]));
+  NVF_CHECK(ref0.equal(cg_outputs[0]));
+  NVF_CHECK(ref1.equal(cg_outputs[1]));
+  NVF_CHECK(ref2.equal(cg_outputs[2]));
+  NVF_CHECK(ref3.equal(cg_outputs[3]));
+  NVF_CHECK(ref4.equal(cg_outputs[4]));
+  NVF_CHECK(ref5.equal(cg_outputs[5]));
 }
 
 // In this test, we split and merge with size-zero dimensions directly.
@@ -2153,7 +2154,7 @@ TEST_F(ResizeTest, FusionSizeZeroSliceSplit) {
 
   auto ref0 = t0.index({at::indexing::Slice(2, 2), at::indexing::Slice(0, 5)});
 
-  TORCH_CHECK(ref0.equal(cg_outputs[0]));
+  NVF_CHECK(ref0.equal(cg_outputs[0]));
 }
 
 // Test squeezing a symbolic dimension
@@ -2192,7 +2193,7 @@ TEST_F(ResizeTest, FusionSqueezeSymbolic) {
 
   auto ref0 = t0.flatten();
 
-  TORCH_CHECK(ref0.equal(cg_outputs[0]));
+  NVF_CHECK(ref0.equal(cg_outputs[0]));
 
   EXPECT_THAT(
       [&]() {
@@ -2241,8 +2242,8 @@ TEST_F(ResizeTest, FusionResizeMultiSliceEmpty) {
   auto ref0 = t0.index({at::indexing::Slice(0, 1)});
   auto ref1 = t0.index({at::indexing::Slice(0, 0)});
 
-  TORCH_CHECK(ref0.equal(cg_outputs[0]));
-  TORCH_CHECK(ref1.equal(cg_outputs[1]));
+  NVF_CHECK(ref0.equal(cg_outputs[0]));
+  NVF_CHECK(ref1.equal(cg_outputs[1]));
 
   // Check that tv2 is replaced by a FullOp
   const auto runtime = executor_cache.getMostRecentKernelRuntime();
@@ -2336,7 +2337,7 @@ TEST_F(ResizeTest, SliceAndReshape1) {
        at::indexing::Slice(1, shape[0] - 1)});
   auto ref = t1.reshape({-1});
 
-  TORCH_CHECK(ref.equal(cg_outputs[0]));
+  NVF_CHECK(ref.equal(cg_outputs[0]));
 }
 
 // An input is sliced and also separately reshaped
@@ -2372,8 +2373,8 @@ TEST_F(ResizeTest, SliceAndReshape2) {
        at::indexing::Slice(1, shape[0] - 1)});
   auto t2 = t0.reshape({-1});
 
-  TORCH_CHECK(t1.equal(cg_outputs[0]));
-  TORCH_CHECK(t2.equal(cg_outputs[1]));
+  NVF_CHECK(t1.equal(cg_outputs[0]));
+  NVF_CHECK(t2.equal(cg_outputs[1]));
 }
 
 // Trivial case of slice vectorization. Just slicing a fusion input

--- a/test/test_rng.cpp
+++ b/test/test_rng.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -140,10 +141,10 @@ TEST_F(RNGTest, BroadcastingRNG) {
 
     auto cg_outputs = fec.runFusionWithInputs({t0, t1});
     auto out = cg_outputs[0];
-    TORCH_CHECK((out.select(1, 0) == out.select(1, 1)).all().item<bool>())
-    TORCH_CHECK((out.select(1, 0) == out.select(1, 2)).all().item<bool>())
-    TORCH_CHECK((out.select(1, 0) == out.select(1, 3)).all().item<bool>())
-    TORCH_CHECK((out.select(1, 0) == out.select(1, 4)).all().item<bool>())
+    NVF_CHECK((out.select(1, 0) == out.select(1, 1)).all().item<bool>())
+    NVF_CHECK((out.select(1, 0) == out.select(1, 2)).all().item<bool>())
+    NVF_CHECK((out.select(1, 0) == out.select(1, 3)).all().item<bool>())
+    NVF_CHECK((out.select(1, 0) == out.select(1, 4)).all().item<bool>())
   }
 }
 
@@ -206,10 +207,10 @@ TEST_F(RNGTest, BroadcastingRNGSmem) {
     auto cg_outputs = fe.runFusion({t0, t1}, lparams);
     auto out = cg_outputs[0];
 
-    TORCH_CHECK((out.select(1, 0) == out.select(1, 1)).all().item<bool>())
-    TORCH_CHECK((out.select(1, 0) == out.select(1, 2)).all().item<bool>())
-    TORCH_CHECK((out.select(1, 0) == out.select(1, 3)).all().item<bool>())
-    TORCH_CHECK((out.select(1, 0) == out.select(1, 4)).all().item<bool>())
+    NVF_CHECK((out.select(1, 0) == out.select(1, 1)).all().item<bool>())
+    NVF_CHECK((out.select(1, 0) == out.select(1, 2)).all().item<bool>())
+    NVF_CHECK((out.select(1, 0) == out.select(1, 3)).all().item<bool>())
+    NVF_CHECK((out.select(1, 0) == out.select(1, 4)).all().item<bool>())
   }
 }
 
@@ -242,10 +243,10 @@ TEST_F(RNGTest, BroadcastingRNGSmemNonSquareTile) {
   auto cg_outputs = fe.runFusion({t0, t1});
   auto out = cg_outputs[0];
 
-  TORCH_CHECK((out.select(1, 0) == out.select(1, 1)).all().item<bool>());
-  TORCH_CHECK((out.select(1, 0) == out.select(1, 2)).all().item<bool>());
-  TORCH_CHECK((out.select(1, 0) == out.select(1, 3)).all().item<bool>());
-  TORCH_CHECK((out.select(1, 0) == out.select(1, 4)).all().item<bool>());
+  NVF_CHECK((out.select(1, 0) == out.select(1, 1)).all().item<bool>());
+  NVF_CHECK((out.select(1, 0) == out.select(1, 2)).all().item<bool>());
+  NVF_CHECK((out.select(1, 0) == out.select(1, 3)).all().item<bool>());
+  NVF_CHECK((out.select(1, 0) == out.select(1, 4)).all().item<bool>());
 }
 
 TEST_F(RNGTest, Uniform) {

--- a/test/test_smem_reuse.cpp
+++ b/test/test_smem_reuse.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -86,7 +87,7 @@ TEST_F(SmemReuseTest, SimpleCase) {
     int64_t smem_usage = 0;
     for (auto alloc : gpulw.kernel()->summary().dynamic_smem_allocations) {
       auto addr = ee.evaluate(alloc->address()).as<int64_t>();
-      TORCH_CHECK(
+      NVF_CHECK(
           addresses.insert(addr).second,
           "Smem addresses should not be re-used");
       auto size = ee.evaluate(alloc->size()).as<int64_t>() *
@@ -186,7 +187,7 @@ TEST_F(SmemReuseTest, NeedsReorderedPush) {
     for (auto alloc : gpulw.kernel()->summary().dynamic_smem_allocations) {
       EXPECT_NE(alloc->address(), nullptr);
       auto addr = ee.evaluate(alloc->address()).as<int64_t>();
-      TORCH_CHECK(
+      NVF_CHECK(
           addresses.insert(addr).second,
           "Smem addresses should not be re-used");
       auto size = ee.evaluate(alloc->size()).as<int64_t>() *
@@ -232,7 +233,7 @@ TEST_F(SmemReuseTest, PromoteReuse) {
     for (auto alloc : gpulw.kernel()->summary().dynamic_smem_allocations) {
       EXPECT_NE(alloc->address(), nullptr);
       auto addr = ee.evaluate(alloc->address()).as<int64_t>();
-      TORCH_CHECK(
+      NVF_CHECK(
           addresses.insert(addr).second,
           "Smem addresses should not be re-used");
       auto size = ee.evaluate(alloc->size()).as<int64_t>() *
@@ -300,7 +301,7 @@ TEST_F(SmemReuseTest, PromoteReuseMultipleDownstream) {
     for (auto alloc : gpulw.kernel()->summary().dynamic_smem_allocations) {
       EXPECT_NE(alloc->address(), nullptr);
       auto addr = ee.evaluate(alloc->address()).as<int64_t>();
-      TORCH_CHECK(
+      NVF_CHECK(
           addresses.insert(addr).second,
           "Smem addresses should not be re-used");
       auto size = ee.evaluate(alloc->size()).as<int64_t>() *
@@ -382,7 +383,7 @@ TEST_F(SmemReuseTest, MultiplePromoteReuse) {
     for (auto alloc : gpulw.kernel()->summary().dynamic_smem_allocations) {
       EXPECT_NE(alloc->address(), nullptr);
       auto addr = ee.evaluate(alloc->address()).as<int64_t>();
-      TORCH_CHECK(
+      NVF_CHECK(
           addresses.insert(addr).second,
           "Smem addresses should not be re-used");
       auto size = ee.evaluate(alloc->size()).as<int64_t>() *

--- a/test/test_tensor_factories.cpp
+++ b/test/test_tensor_factories.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -286,7 +287,7 @@ TEST_F(TensorFactoryTest, StandaloneIota) {
         break;
       }
       default:
-        TORCH_INTERNAL_ASSERT(false);
+        NVF_ERROR(false);
     }
   }
 }

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -59,7 +59,7 @@ void assertCUDAKernel(Fusion* fusion, const std::string& expected_kernel) {
     expected_mismatched_snippet = expected_mismatched_snippet.substr(0, 10);
     std::cerr << "First mismatch found at: " << actual_mismatched_snippet
               << ", expected: " << expected_mismatched_snippet << std::endl;
-    TORCH_CHECK(false);
+    NVF_CHECK(false);
   }
 }
 
@@ -258,7 +258,7 @@ Container parse(const std::string& nvdisasm_output) {
 } // namespace sass
 
 TensorView* matmulVolta(TensorView* a, TensorView* b, MatmulLayout layout) {
-  TORCH_CHECK(
+  NVF_CHECK(
       a->nDims() == 2 && b->nDims() == 2, "only pure matmuls for these tests");
   // Here, we canonicalize the mma output as M, N, K, but the position of K does
   // not really matter. So the implicit transpose is only required for NN.
@@ -295,7 +295,7 @@ TensorView* matmulVolta(TensorView* a, TensorView* b, MatmulLayout layout) {
       tv2->commitLeafToRFactor();
       break;
     default:
-      TORCH_CHECK(false, "unsupported data layout.");
+      NVF_CHECK(false, "unsupported data layout.");
   }
   return tv2;
 }
@@ -304,7 +304,7 @@ TensorView* matmulTuringOrLater(
     TensorView* a,
     TensorView* b,
     MatmulLayout layout) {
-  TORCH_CHECK(
+  NVF_CHECK(
       a->nDims() == 2 && b->nDims() == 2, "only pure matmuls for these tests");
   TensorView *tv2 = nullptr, *tv0t = nullptr, *tv1t = nullptr, *tv0b = nullptr,
              *tv1b = nullptr;
@@ -327,7 +327,7 @@ TensorView* matmulTuringOrLater(
       tv1t = b;
       break;
     default:
-      TORCH_CHECK(false, "unsupported data layout.");
+      NVF_CHECK(false, "unsupported data layout.");
   }
   tv0b = broadcast(tv0t, {false, true, false});
   tv1b = broadcast(tv1t, {true, false, false});
@@ -352,7 +352,7 @@ TensorView* splitkLikeBatchedMatmul(
     TensorView* a,
     TensorView* b,
     MatmulLayout layout) {
-  TORCH_CHECK(
+  NVF_CHECK(
       a->nDims() == 3 && b->nDims() == 3,
       "only splitk-like batched matmuls for these tests");
   TensorView *tv2 = nullptr, *tv0t = nullptr, *tv1t = nullptr, *tv0b = nullptr,
@@ -384,7 +384,7 @@ TensorView* splitkLikeBatchedMatmul(
       tv1t = transpose(b, 0, 1);
       break;
     default:
-      TORCH_CHECK(false, "unsupported data layout.");
+      NVF_CHECK(false, "unsupported data layout.");
   }
   tv0b = broadcast(tv0t, {false, false, true, false});
   tv1b = broadcast(tv1t, {false, true, false, false});
@@ -403,7 +403,7 @@ at::Tensor atMatmul(at::Tensor a, at::Tensor b, MatmulLayout layout) {
     case MatmulLayout::NN:
       return a.t().matmul(b.t());
     default:
-      TORCH_CHECK(false, "unsupported data layout.");
+      NVF_CHECK(false, "unsupported data layout.");
   }
   return at::Tensor();
 }
@@ -423,7 +423,7 @@ at::Tensor splitkLikeAtMatmul(at::Tensor a, at::Tensor b, MatmulLayout layout) {
       // [B, K, M] @ [N, B, K] -> [B, M, N]
       return a.transpose(1, 2).matmul(b.permute({1, 2, 0}));
     default:
-      TORCH_CHECK(false, "unsupported data layout.");
+      NVF_CHECK(false, "unsupported data layout.");
   }
   return at::Tensor();
 }
@@ -450,7 +450,7 @@ std::pair<at::Tensor, at::Tensor> matmulAtInput(
       return std::make_pair(
           at::randn({K, M}, options), at::randn({N, K}, options));
     default:
-      TORCH_CHECK(false, "unsupported data layout.");
+      NVF_CHECK(false, "unsupported data layout.");
   }
   return std::make_pair(at::Tensor(), at::Tensor());
 }
@@ -530,9 +530,9 @@ at::Tensor matmulAtInput(
       }
       break;
     default:
-      TORCH_CHECK(false, "unsupported data layout, got ", (size_t)layout);
+      NVF_CHECK(false, "unsupported data layout, got ", (size_t)layout);
   }
-  TORCH_CHECK(false, "unsupported tensor position, got ", (size_t)tensor);
+  NVF_CHECK(false, "unsupported tensor position, got ", (size_t)tensor);
 }
 
 bool isSchedulerInUse(
@@ -561,7 +561,7 @@ void validateSegmentation(
     const std::vector<ScheduleHeuristic>& expected_heuristics) {
   const auto& segment_groups = runtime->fusionSegments()->groups();
 
-  TORCH_CHECK(
+  NVF_CHECK(
       segment_groups.size() == expected_heuristics.size(),
       "Unexpected segments. Expected: ",
       expected_heuristics.size(),
@@ -569,12 +569,12 @@ void validateSegmentation(
       segment_groups.size());
 
   // Assumes up to two segments exist for simplicity
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       segment_groups.size() <= 2, "True segment order analysis is required");
 
   for (auto& group : segment_groups) {
     int segment_order = group->producer_edges.empty() ? 0 : 1;
-    TORCH_CHECK(
+    NVF_CHECK(
         group->heuristic() == expected_heuristics.at(segment_order),
         "Expected to use the ",
         expected_heuristics.at(segment_order),
@@ -585,13 +585,13 @@ void validateSegmentation(
 }
 
 TensorView* biasEpilogue(TensorView* tensor, TensorView* bias) {
-  TORCH_CHECK(
+  NVF_CHECK(
       tensor->dtype() == bias->dtype(),
       "bias vector must have the same type as tensor with two domains, bias: ",
       bias->dtype(),
       ", tensor: ",
       tensor->dtype());
-  TORCH_CHECK(
+  NVF_CHECK(
       tensor->nDims() >= 2,
       "Tensors to have bias applied needs to have 2 or more domains, got ",
       tensor->nDims());
@@ -604,7 +604,7 @@ TensorView* biasEpilogue(TensorView* tensor, TensorView* bias) {
   switch (concrete.size()) {
     case 2:
       // regular matmul (non-strided batch gemm)
-      TORCH_CHECK(
+      NVF_CHECK(
           bias->nDims() == 1,
           "bias vector must have one domain, got",
           bias->nDims());
@@ -619,7 +619,7 @@ TensorView* biasEpilogue(TensorView* tensor, TensorView* bias) {
         // case with dedicated bias for each problem in the batch
         biasb = broadcast(bias, {false, false, true});
       } else {
-        TORCH_CHECK(
+        NVF_CHECK(
             false,
             "bias vector must have one (single bias for batch) "
             "or two (bias for each batch entries)), got",
@@ -627,7 +627,7 @@ TensorView* biasEpilogue(TensorView* tensor, TensorView* bias) {
       }
       break;
     default:
-      TORCH_CHECK(
+      NVF_CHECK(
           false,
           "Only tensors with two (matmul) or three (strided batch matmul) "
           "concrete domains have support for bias epilogue enabled, got ",
@@ -641,19 +641,19 @@ TensorView* biasEpilogue(TensorView* tensor, TensorView* bias) {
 at::Tensor atBiasEpilogue(const at::Tensor& tensor, const at::Tensor& bias) {
   switch (tensor.dim()) {
     case 2:
-      TORCH_CHECK(
+      NVF_CHECK(
           bias.dim() == 1,
           "For single matmul problem bias must be a vector, got ",
           bias.dim());
       break;
     case 3:
-      TORCH_CHECK(
+      NVF_CHECK(
           (bias.dim() == 1 || bias.dim() == 2),
           "For strided batch matmul problem bias must be 1d or 2d tensor, got ",
           bias.dim());
       break;
     default:
-      TORCH_CHECK(
+      NVF_CHECK(
           false,
           "Only tensors with two (matmul) or three (strided batch matmul) "
           "concrete domains have support for bias epilogue enabled, got ",
@@ -664,7 +664,7 @@ at::Tensor atBiasEpilogue(const at::Tensor& tensor, const at::Tensor& bias) {
   const int64_t rows = bias.size(-1);
 
   // We skip number of columns and access directly dim for rows, hence '-2'
-  TORCH_CHECK(
+  NVF_CHECK(
       tensor.size(tensor.dim() - 2) == rows,
       "Tensor must have the same number of rows as bias vector");
 

--- a/test/utils.h
+++ b/test/utils.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <codegen.h>
+#include <csrc/exceptions.h>
 #include <device_lower/lower2device.h>
 #include <device_lower/pass/magic_zero.h>
 #include <executor.h>
@@ -117,7 +118,7 @@ inline TensorView* loweredTv(TensorView* tv, kir::Kernel* kernel) {
       matching_tv = lowered_tv;
     }
   }
-  TORCH_INTERNAL_ASSERT(matching_tv != nullptr);
+  NVF_ERROR(matching_tv != nullptr);
   return matching_tv;
 }
 
@@ -322,7 +323,7 @@ struct TransformPropagatorWithCheck : public TransformPropagator {
     TransformPropagator::propagateC2P(from, to);
     auto from_pos = replayed_pos_.at(from);
     auto to_pos = replayed_pos_.at(to);
-    TORCH_CHECK(
+    NVF_CHECK(
         TransformReplay::getMatchedLeafPosWithoutReplayPasC(
             to, from, from_pos) == (int)to_pos);
   }
@@ -330,7 +331,7 @@ struct TransformPropagatorWithCheck : public TransformPropagator {
     TransformPropagator::propagateP2C(from, to);
     auto from_pos = replayed_pos_.at(from);
     auto to_pos = replayed_pos_.at(to);
-    TORCH_CHECK(
+    NVF_CHECK(
         TransformReplay::getMatchedLeafPosWithoutReplayCasP(
             to, from, from_pos) == (int)to_pos);
   }
@@ -338,8 +339,8 @@ struct TransformPropagatorWithCheck : public TransformPropagator {
     TransformPropagator::propagateSibling(from, to);
     auto from_pos = replayed_pos_.at(from);
     auto to_pos = replayed_pos_.at(to);
-    TORCH_CHECK(from_pos == to_pos);
-    TORCH_CHECK(TransformReplay::fullSelfMatching(from, to));
+    NVF_CHECK(from_pos == to_pos);
+    NVF_CHECK(TransformReplay::fullSelfMatching(from, to));
   }
   using TransformPropagator::TransformPropagator;
 };

--- a/test/validator.h
+++ b/test/validator.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <csrc/exceptions.h>
 #include <device_lower/utils.h>
 #include <executor_utils.h>
 #include <expr_evaluator.h>
@@ -175,7 +176,7 @@ std::pair<double, double> getTolerance(
     case DataType::Bool:
       return {0.0, 0.0};
     default:
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           false, "Do not have tolerance computation for type ", dtype, ".");
   }
 }
@@ -224,7 +225,7 @@ class ReductionSizeMapper : private IterVisitor {
     for (auto id : tv->getMaybeRFactorDomain()) {
       if (id->isReduction()) {
         auto inferred_extent = expr_eval_.evaluate(id->extent());
-        TORCH_INTERNAL_ASSERT(
+        NVF_ERROR(
             inferred_extent.hasValue(),
             "Couldn't figure out what the dimensions of a tensorview is in evaluation for validation. ",
             id,
@@ -296,7 +297,7 @@ ExpressionEvaluator bindInputsAndLaunchParams(
 
       if (inferred_extent.hasValue()) {
         // This value could have been inferred, make sure it was set right.
-        TORCH_CHECK(
+        NVF_CHECK(
             inferred_extent == launch_constraints.getDim(p_type) ||
                 launch_constraints.getRawVal(p_type) == -1,
             "inferred that ",
@@ -349,25 +350,24 @@ void testValidate(
     }
   }
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       fusion_outputs.size() == aten_outputs.size() &&
           aten_outputs.size() ==
               fusion->outputs().size() - output_alias_indices.size(),
       "Number of outputs don't match.");
 
-  TORCH_INTERNAL_ASSERT(
+  NVF_ERROR(
       fusion->inputs().size() == aten_inputs.size(),
       "Number of inputs don't match.");
 
   for (size_t i = 0; i < fusion->inputs().size(); i++) {
     if (fusion->inputs()[i]->isA<TensorView>()) {
-      TORCH_INTERNAL_ASSERT(
-          aten_inputs[i].isTensor(), "Mismatch of tensor inputs.");
+      NVF_ERROR(aten_inputs[i].isTensor(), "Mismatch of tensor inputs.");
 
       auto fusion_input_tv = fusion->inputs()[i]->as<TensorView>();
       auto at_tensor = aten_inputs[i].toTensor();
 
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           at_tensor.dim() ==
               static_cast<int64_t>(TensorDomain::noReductions(
                                        fusion_input_tv->getMaybeRFactorDomain())
@@ -377,7 +377,7 @@ void testValidate(
   }
 
   for (size_t i = 0, j = 0; i < fusion->outputs().size(); i++) {
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         fusion->outputs()[i]->isA<TensorView>(), "Mismatch of tensor outputs.");
     if (output_alias_indices.count(i) != 0) {
       // this is an aliased output, let's not check this;
@@ -388,14 +388,14 @@ void testValidate(
     auto fusion_output_tv = fusion->outputs()[i]->as<TensorView>();
     auto aten_output_tensor = aten_outputs[j];
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         reduction_sizes.count(fusion_output_tv),
         "Missed reduction size count on fusion output at index: ",
         i);
 
     int64_t reduction_size = reduction_sizes.at(fusion_output_tv);
 
-    TORCH_INTERNAL_ASSERT(
+    NVF_ERROR(
         aten_output_tensor.dim() == fusion_output_tensor.dim() &&
             fusion_outputs[j].dim() ==
                 static_cast<int64_t>(
@@ -409,7 +409,7 @@ void testValidate(
 
     if (aten_output_tensor.is_floating_point() ||
         aten_output_tensor.is_complex()) {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           aten_output_tensor.allclose(
               fusion_output_tensor.to(aten_output_tensor.dtype()),
               tolerance_values.second,
@@ -434,7 +434,7 @@ void testValidate(
           "\n    and relative tolerance set to ",
           tolerance_values.second);
     } else {
-      TORCH_INTERNAL_ASSERT(
+      NVF_ERROR(
           aten_output_tensor.equal(
               fusion_output_tensor.to(aten_output_tensor.dtype())),
           "\n",


### PR DESCRIPTION
The macros `TORCH_CHECK` and `TORCH_INTERNAL_ASSERT` are replaced by NVFuser specific assert macros `NVF_CHECK` and `NVF_ERROR` respectively. 

This PR resolves #668. 