### PR TITLE
dynamic_type target, build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,16 +221,18 @@ target_link_libraries(${NVFUSER_CODEGEN} PRIVATE flatbuffers)
 
 # For kernel_db, linking STL Filesystem Library for backward compatability with C++14
 target_link_libraries(${NVFUSER_CODEGEN} PRIVATE stdc++fs)
-target_link_libraries(${NVFUSER_CODEGEN} PRIVATE dynamic_type)
+# target_link_libraries(${NVFUSER_CODEGEN} PRIVATE dynamic_type)
 target_link_libraries(${NVFUSER_CODEGEN} PRIVATE ${CUDA_NVRTC_LIB} ${LIBNVTOOLSEXT})
 target_include_directories(${NVFUSER_CODEGEN} PRIVATE ${CUDA_INCLUDE_DIRS})
 
 # TODO: we should guard the include of gloo
 target_include_directories(${NVFUSER_CODEGEN} PRIVATE ${PROJECT_SOURCE_DIR}/third_party/gloo)
+target_include_directories(${NVFUSER_CODEGEN} PUBLIC ${PROJECT_SOURCE_DIR}/lib/dynamic_type/src)
 target_include_directories(${NVFUSER_CODEGEN} PUBLIC
   "$<BUILD_INTERFACE:${NVFUSER_SRCS_DIR}>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/nvfuser>"
 )
+
 set_property(TARGET ${NVFUSER_CODEGEN} PROPERTY CXX_STANDARD 17)
 
 if(PROJECT_IS_TOP_LEVEL)
@@ -352,7 +354,7 @@ if(BUILD_PYTHON)
     target_compile_options(${NVFUSER} PRIVATE -Wall -Wno-unused-function)
     target_link_libraries(${NVFUSER} PRIVATE ${TORCH_LIBRARIES})
     target_link_libraries(${NVFUSER} PRIVATE "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so")
-    target_link_libraries(${NVFUSER} PRIVATE dynamic_type)
+    # target_link_libraries(${NVFUSER} PRIVATE dynamic_type)
     target_link_libraries(${NVFUSER} PRIVATE pybind11::pybind11)
     set_target_properties(${NVFUSER} PROPERTIES INSTALL_RPATH "$ORIGIN/../torch/lib")
     install(TARGETS ${NVFUSER} DESTINATION lib)
@@ -362,7 +364,7 @@ if(BUILD_PYTHON)
     target_link_libraries(${NVFUSER} PRIVATE torch torch_python ${TORCHLIB_FLAVOR})
     target_include_directories(${NVFUSER} PRIVATE ${TORCH_ROOT})
 
-    target_link_libraries(${NVFUSER} PRIVATE dynamic_type)
+    # target_link_libraries(${NVFUSER} PRIVATE dynamic_type)
     target_link_libraries(${NVFUSER} PRIVATE pybind::pybind11)
     target_compile_options(${NVFUSER} PRIVATE ${TORCH_PYTHON_COMPILE_OPTIONS})
 
@@ -448,7 +450,8 @@ if(BUILD_TEST)
     ${JIT_TEST_CU_SRCS})
   set_property(TARGET ${NVFUSER_TESTS} PROPERTY CXX_STANDARD 17)
   target_compile_definitions(${NVFUSER_TESTS} PRIVATE USE_GTEST)
-  target_link_libraries(${NVFUSER_TESTS} PRIVATE ${NVFUSER_CODEGEN} dynamic_type gtest_main gmock_main flatbuffers)
+  target_link_libraries(${NVFUSER_TESTS} PRIVATE ${NVFUSER_CODEGEN} gtest_main gmock_main flatbuffers)
+  # target_link_libraries(${NVFUSER_TESTS} PRIVATE ${NVFUSER_CODEGEN} dynamic_type gtest_main gmock_main flatbuffers)
   target_include_directories(${NVFUSER_TESTS} PRIVATE "${NVFUSER_ROOT}")
 
   if(PROJECT_IS_TOP_LEVEL)
@@ -507,10 +510,11 @@ if(BUILD_NVFUSER_BENCHMARK)
   set(NVFUSER_BENCHMARK "${PROJECT_NAME}_bench")
   add_executable(${NVFUSER_BENCHMARK} ${BENCHMARK_SRCS})
   set_property(TARGET ${NVFUSER_BENCHMARK} PROPERTY CXX_STANDARD 17)
+  target_include_directories(${NVFUSER_CODEGEN} PRIVATE ${PROJECT_SOURCE_DIR}/lib/dynamic_type/src)
 
   if(PROJECT_IS_TOP_LEVEL)
     target_compile_options(${NVFUSER_BENCHMARK} PRIVATE -Wall -Wno-unused-function)
-    target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE dynamic_type)
+    # target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE dynamic_type)
     target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE ${TORCH_LIBRARIES})
     target_link_libraries(${NVFUSER_BENCHMARK} PRIVATE benchmark::benchmark)
 

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -889,7 +889,7 @@ int64_t getVectorizationFactorTransposeGroup(
   for (auto tv : vec_tv) {
     auto inner_size_it = contig_inner_map.find(tv);
     auto tv_vectorize_factor_opt = inner_size_it == contig_inner_map.end()
-        ? 1
+        ? 1L
         : runtime_info.expressionEvaluator().evaluate(inner_size_it->second);
     // TODO: Do not assert here. we can just reduce vectorization size to 1 if
     // we can't infer an inner size.

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -2494,8 +2494,8 @@ TEST_F(ResizeTest, Slice1DVectorizeManual4) {
 
   auto tv1 = slice(
       tv0,
-      {{IrBuilder::create<Val>(1),
-        sub(tv0->axis(0)->extent(), IrBuilder::create<Val>(3))}});
+      {{IrBuilder::create<Val>(1L),
+        sub(tv0->axis(0)->extent(), IrBuilder::create<Val>(3L))}});
   fusion.addOutput(tv1);
 
   tv1->split(0, 4);
@@ -2538,7 +2538,7 @@ TEST_F(ResizeTest, Slice2DVectorizeManual1) {
       tv0,
       {{IrBuilder::create<Val>(slice_offset),
         sub(tv0->axis(0)->extent(), IrBuilder::create<Val>(slice_offset))},
-       {IrBuilder::create<Val>(0), tv0->axis(1)->extent()}});
+       {IrBuilder::create<Val>(0L), tv0->axis(1)->extent()}});
   fusion.addOutput(tv1);
 
   tv1->merge(0);
@@ -2577,9 +2577,9 @@ TEST_F(ResizeTest, Slice3DVectorizeManual1) {
 
   auto tv1 = slice(
       tv0,
-      {{IrBuilder::create<Val>(0), tv0->axis(0)->extent()},
-       {IrBuilder::create<Val>(4), IrBuilder::create<Val>(6)},
-       {IrBuilder::create<Val>(0), tv0->axis(2)->extent()}});
+      {{IrBuilder::create<Val>(0L), tv0->axis(0)->extent()},
+       {IrBuilder::create<Val>(4L), IrBuilder::create<Val>(6L)},
+       {IrBuilder::create<Val>(0L), tv0->axis(2)->extent()}});
   fusion.addOutput(tv1);
 
   // Vectorize tv1 by a factor of 2. The sliced domain and the
@@ -2626,10 +2626,10 @@ TEST_F(ResizeTest, Slice3DVectorizeManual2) {
 
   auto tv1 = slice(
       tv0,
-      {{IrBuilder::create<Val>(0), tv0->axis(0)->extent()},
-       {IrBuilder::create<Val>(0), tv0->axis(1)->extent()},
-       {IrBuilder::create<Val>(0), IrBuilder::create<Val>(1024)},
-       {IrBuilder::create<Val>(0), tv0->axis(3)->extent()}});
+      {{IrBuilder::create<Val>(0L), tv0->axis(0)->extent()},
+       {IrBuilder::create<Val>(0L), tv0->axis(1)->extent()},
+       {IrBuilder::create<Val>(0L), IrBuilder::create<Val>(1024L)},
+       {IrBuilder::create<Val>(0L), tv0->axis(3)->extent()}});
   fusion.addOutput(tv1);
 
   // [4, 1, 1024, 3]
@@ -2668,19 +2668,19 @@ TEST_F(ResizeTest, SliceAndReshapeRepro540Manual) {
 
   auto tv1 = slice(
       tv0,
-      {{IrBuilder::create<Val>(0), tv0->axis(0)->extent()},
-       {IrBuilder::create<Val>(0), tv0->axis(1)->extent()},
-       {IrBuilder::create<Val>(0), IrBuilder::create<Val>(1024)}});
+      {{IrBuilder::create<Val>(0L), tv0->axis(0)->extent()},
+       {IrBuilder::create<Val>(0L), tv0->axis(1)->extent()},
+       {IrBuilder::create<Val>(0L), IrBuilder::create<Val>(1024L)}});
   auto tv2 = slice(
       tv0,
-      {{IrBuilder::create<Val>(0), tv0->axis(0)->extent()},
-       {IrBuilder::create<Val>(0), tv0->axis(1)->extent()},
-       {IrBuilder::create<Val>(1024), IrBuilder::create<Val>(2048)}});
+      {{IrBuilder::create<Val>(0L), tv0->axis(0)->extent()},
+       {IrBuilder::create<Val>(0L), tv0->axis(1)->extent()},
+       {IrBuilder::create<Val>(1024L), IrBuilder::create<Val>(2048L)}});
   auto tv3 = slice(
       tv0,
-      {{IrBuilder::create<Val>(0), tv0->axis(0)->extent()},
-       {IrBuilder::create<Val>(0), tv0->axis(1)->extent()},
-       {IrBuilder::create<Val>(2048), IrBuilder::create<Val>(3072)}});
+      {{IrBuilder::create<Val>(0L), tv0->axis(0)->extent()},
+       {IrBuilder::create<Val>(0L), tv0->axis(1)->extent()},
+       {IrBuilder::create<Val>(2048L), IrBuilder::create<Val>(3072L)}});
 
   auto tv4 = reshape(tv1, {16, 128, 1024}, {16, 128, 16, 64});
   auto tv5 = reshape(tv2, {16, 128, 1024}, {16, 128, 16, 64});


### PR DESCRIPTION
The scope of this PR:
- include path to dynamic_type top level CMake file,
- add interface from dynamic_type to codegen and benchmark,
- fix a number of gcc 9.4 issues,