### PR TITLE
Remove `LegacyStruct` and move everything to the new struct approach

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -20,6 +20,7 @@
 #include <kernel_ir.h>
 #include <options.h>
 #include <serde/utils.h>
+#include <tensor_metadata.h>
 #include <utils.h>
 
 #include <ATen/core/LegacyTypeDispatch.h>
@@ -1913,18 +1914,21 @@ float FusionExecutor::runRtc(
   std::vector<void*> pointers;
 
   for (const auto& input : args) {
-    DataType metadata_type = globalTensorMetaData(
-        std::get<PrimDataType>(aten_to_data_type(input.scalar_type()).type),
-        input.dim());
+    auto dtype =
+        std::get<PrimDataType>(aten_to_data_type(input.scalar_type()).type);
+    DataType metadata_type = globalTensorMetaData(dtype, input.dim());
 
-    LegacyStruct<PolymorphicValue> concrete_value;
-    concrete_value["data"] = PolymorphicValue(
-        Pointer(input.data_ptr(), aten_to_data_type(input.scalar_type())));
-    concrete_value["logical_size"] = PolymorphicValue(input.sizes().vec());
-    concrete_value["alloc_stride"] = PolymorphicValue(input.strides().vec());
+    std::shared_ptr<Struct> struct_ = std::make_shared<TensorMetaData>();
+    TensorMetaData* metadata = (TensorMetaData*)struct_.get();
+    metadata->dtype = dtype;
+    metadata->data = input.data_ptr();
+    metadata->logical_size = input.sizes();
+    metadata->logical_stride = input.strides();
+    metadata->alloc_size = input.sizes();
+    metadata->alloc_stride = input.strides();
 
-    data.emplace_back(
-        polymorphicValueToBytes(concrete_value, metadata_type, index_type));
+    data.emplace_back(polymorphicValueToBytes(
+        PolymorphicValue(std::move(struct_)), metadata_type, index_type));
     pointers.emplace_back(data.back().data());
   }
 

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -20,6 +20,7 @@
 #include <ir/utils.h>
 #include <kernel_db/kernel_db.h>
 #include <options.h>
+#include <tensor_metadata.h>
 #include <torch/csrc/jit/resource_guard.h>
 #include <utils.h>
 
@@ -414,7 +415,7 @@ namespace {
 std::pair<std::unordered_set<size_t>, std::unordered_set<IterDomain*>>
 getTensorOffsets(
     TensorView* tv,
-    const std::vector<int64_t>& logical_strides,
+    c10::IntArrayRef logical_strides,
     ExpressionEvaluator& eval) {
   if (!tv->isFusionInput()) {
     return {{0}, {}};
@@ -473,8 +474,8 @@ void validateAlignedVectorizedFusionInputOutput(
   eval.bind(tv, aten_tensor);
   const auto& metadata = eval.evaluate(IrBuilder::metadataExpr(tv));
 
-  const auto [offsets, sliced_domains] = getTensorOffsets(
-      tv, std::vector<int64_t>(metadata["logical_stride"]), eval);
+  const auto [offsets, sliced_domains] =
+      getTensorOffsets(tv, metadata->*&TensorMetaData::logical_stride, eval);
   const bool is_sliced = !sliced_domains.empty();
 
   const auto& domain_to_validate =
@@ -488,10 +489,10 @@ void validateAlignedVectorizedFusionInputOutput(
     }
   }
 
-  const auto& sizes = is_sliced ? metadata["logical_size"].as<std::vector>()
-                                : metadata["alloc_size"].as<std::vector>();
-  const auto& strides = is_sliced ? metadata["logical_stride"].as<std::vector>()
-                                  : metadata["alloc_stride"].as<std::vector>();
+  const auto& sizes = is_sliced ? metadata->*&TensorMetaData::logical_size
+                                : metadata->*&TensorMetaData::alloc_size;
+  const auto& strides = is_sliced ? metadata->*&TensorMetaData::logical_stride
+                                  : metadata->*&TensorMetaData::alloc_stride;
   TORCH_INTERNAL_ASSERT(sizes.size() == no_reduction_to_full.size());
   TORCH_INTERNAL_ASSERT(strides.size() == no_reduction_to_full.size());
 
@@ -520,8 +521,8 @@ void validateAlignedVectorizedFusionInputOutput(
   bool still_rightmost = true;
   bool non_contig_due_to_slice = false;
   for (int64_t i = (int64_t)sizes.size() - 1; i >= 0; --i) {
-    const auto size = sizes.at(i).as<int64_t>();
-    const auto stride = strides.at(i).as<int64_t>();
+    const auto size = sizes.at(i);
+    const auto stride = strides.at(i);
     auto id = domain_to_validate.at(no_reduction_to_full.at(i));
     const auto is_expanded_broadcasting =
         id->isBroadcast() && id->hasExpandedExtent();

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -835,11 +835,11 @@ std::vector<PolymorphicValue> StructConstruct::evaluate(
       "StructConstruct expects ",
       this->inputs().size(),
       " inputs");
-  LegacyStruct<PolymorphicValue> result;
+  PolymorphicValue struct_ = std::get<StructType>(output(0)->dtype().type).create();
   for (int64_t i : c10::irange((int64_t)inputs.size())) {
-    result[attribute<std::string>(i)] = inputs.at(i);
+    struct_->*attribute<std::string>(i) = inputs.at(i);
   }
-  return {std::move(result)};
+  return {std::move(struct_)};
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(StructConstruct)
@@ -876,7 +876,7 @@ std::vector<PolymorphicValue> GetAttr::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   TORCH_INTERNAL_ASSERT(inputs.size() == 1, "GetAttr expects 1 input");
-  return {inputs.at(0)[attr()]};
+  return {inputs.at(0)->*attr()};
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(GetAttr)

--- a/csrc/serde/polymorphic_value_serde.cpp
+++ b/csrc/serde/polymorphic_value_serde.cpp
@@ -117,7 +117,7 @@ flatbuffers::Offset<serde::PolymorphicValue> serializePolymorphicValue(
   TORCH_INTERNAL_ASSERT(
       !v->is<std::monostate>(), "PolymorphicValue is a std::monostate.");
   TORCH_INTERNAL_ASSERT(
-      !v->is<nvfuser::LegacyStruct>(),
+      !v->is<StructHandle>(),
       "Serialization of arbitrary struct is not implemented.");
   TORCH_INTERNAL_ASSERT(
       !v->is<nvfuser::Opaque>(),

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -13,6 +13,7 @@
 #include <ir/iostream.h>
 #include <ir/utils.h>
 #include <polymorphic_value.h>
+#include <tensor_metadata.h>
 
 namespace nvfuser {
 
@@ -334,21 +335,25 @@ std::vector<PolymorphicValue> GetMetaData::evaluate(
       input.is_cuda() || input.is_meta(),
       "GetMetaData expects a CUDA tensor as input, but got undefined tensor");
 
-  LegacyStruct<PolymorphicValue> concrete_value;
-  concrete_value["data"] = PolymorphicValue(
-      Pointer(input.data_ptr(), aten_to_data_type(input.scalar_type())));
-  concrete_value["logical_size"] = PolymorphicValue(input.sizes().vec());
-  concrete_value["logical_stride"] = PolymorphicValue(input.strides().vec());
+  std::shared_ptr<Struct> struct_ = std::make_shared<TensorMetaData>();
+  TensorMetaData* metadata = (TensorMetaData*)struct_.get();
+  metadata->dtype =
+      std::get<PrimDataType>(aten_to_data_type(input.scalar_type()).type);
+  metadata->data = input.data_ptr();
+  metadata->logical_size = input.sizes();
+  metadata->logical_stride = input.strides();
   if (tv->hasAllocation()) {
     auto allocation_data =
         inferAndValidateAllocationSizesAndStrides(input, tv, ee);
-    concrete_value["alloc_size"] = std::move(allocation_data.first);
-    concrete_value["alloc_stride"] = std::move(allocation_data.second);
+    metadata->alloc_size_data = std::move(allocation_data.first);
+    metadata->alloc_size = c10::makeArrayRef(metadata->alloc_size_data);
+    metadata->alloc_stride_data = std::move(allocation_data.second);
+    metadata->alloc_stride = c10::makeArrayRef(metadata->alloc_stride_data);
   } else {
-    concrete_value["alloc_size"] = PolymorphicValue(input.sizes().vec());
-    concrete_value["alloc_stride"] = PolymorphicValue(input.strides().vec());
+    metadata->alloc_size = input.sizes();
+    metadata->alloc_stride = input.strides();
   }
-  return {PolymorphicValue(std::move(concrete_value))};
+  return {PolymorphicValue(std::move(struct_))};
 }
 
 } // namespace nvfuser

--- a/csrc/tensor_metadata.h
+++ b/csrc/tensor_metadata.h
@@ -1,0 +1,102 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <polymorphic_value.h>
+#include <type.h>
+
+namespace nvfuser {
+
+struct TensorMetaData : public Struct {
+  PrimDataType dtype;
+  void* data;
+  c10::IntArrayRef logical_size;
+  c10::IntArrayRef logical_stride;
+  c10::IntArrayRef alloc_size;
+  c10::IntArrayRef alloc_stride;
+  std::vector<int64_t> logical_size_data;
+  std::vector<int64_t> logical_stride_data;
+  std::vector<int64_t> alloc_size_data;
+  std::vector<int64_t> alloc_stride_data;
+
+  // bool operator==(const TensorMetaData& other) const {
+  //   return data == other.data && logical_size == other.logical_size &&
+  //       logical_stride == other.logical_stride &&
+  //       alloc_size == other.alloc_size && alloc_stride == other.alloc_stride;
+  // }
+
+  std::function<PolymorphicValue()> getter(
+      const std::string& key) const override {
+    if (key == "data") {
+      return [this]() { return PolymorphicValue(Pointer(data, dtype)); };
+    } else if (key == "logical_size") {
+      if (!logical_size_data.empty()) {
+        return [this]() { return PolymorphicValue(logical_size_data); };
+      } else {
+        return [this]() { return PolymorphicValue(logical_size.vec()); };
+      }
+    } else if (key == "logical_stride") {
+      if (!logical_stride_data.empty()) {
+        return [this]() { return PolymorphicValue(logical_stride_data); };
+      } else {
+        return [this]() { return PolymorphicValue(logical_stride.vec()); };
+      }
+    } else if (key == "alloc_size") {
+      if (!alloc_size_data.empty()) {
+        return [this]() { return PolymorphicValue(alloc_size_data); };
+      } else {
+        return [this]() { return PolymorphicValue(alloc_size.vec()); };
+      }
+    } else if (key == "alloc_stride") {
+      if (!alloc_stride_data.empty()) {
+        return [this]() { return PolymorphicValue(alloc_stride_data); };
+      } else {
+        return [this]() { return PolymorphicValue(alloc_stride.vec()); };
+      }
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "Unknown key ", key);
+    }
+  }
+
+  std::function<void(const PolymorphicValue&)> setter(
+      const std::string& key) override {
+    if (key == "data") {
+      return [this](const PolymorphicValue& value) { data = (void*)value; };
+    } else if (key == "logical_size") {
+      return [this](const PolymorphicValue& value) {
+        logical_size_data = (std::vector<int64_t>)value;
+        logical_size = c10::makeArrayRef(logical_size_data);
+      };
+    } else if (key == "logical_stride") {
+      return [this](const PolymorphicValue& value) {
+        logical_stride_data = (std::vector<int64_t>)value;
+        logical_stride = c10::makeArrayRef(logical_stride_data);
+      };
+    } else if (key == "alloc_size") {
+      return [this](const PolymorphicValue& value) {
+        alloc_size_data = (std::vector<int64_t>)value;
+        alloc_size = c10::makeArrayRef(alloc_size_data);
+      };
+    } else if (key == "alloc_stride") {
+      return [this](const PolymorphicValue& value) {
+        alloc_stride_data = (std::vector<int64_t>)value;
+        alloc_stride = c10::makeArrayRef(alloc_stride_data);
+      };
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "Unknown key ", key);
+    }
+  }
+
+  StructType type() const override {
+    TORCH_INTERNAL_ASSERT(logical_size.size() == logical_stride.size());
+    TORCH_INTERNAL_ASSERT(alloc_size.size() == alloc_stride.size());
+    return globalTensorMetaData(dtype, logical_size.size(), alloc_size.size());
+  }
+};
+
+} // namespace nvfuser

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -14,6 +14,7 @@
 #include <unordered_map>
 
 #include <ir/all_nodes.h>
+#include <tensor_metadata.h>
 
 namespace nvfuser {
 
@@ -58,7 +59,7 @@ StructType globalTensorMetaData(
       ArrayType{std::make_shared<DataType>(DataType::Index), alloc_dim});
   alloc_stride_field.used_in_kernel = true;
 
-  return StructType::make<NotImplementedStruct>(
+  return StructType::make<TensorMetaData>(
       {data_field,
        logical_size_field,
        logical_stride_field,

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -411,22 +411,14 @@ inline DataType getDataType(const PolymorphicValue& value) {
         dtype =
             ArrayType{std::make_shared<DataType>(getDataType(vec[0])), size};
       }
-    } else if constexpr (std::is_same_v<T, LegacyStruct<PolymorphicValue>>) {
-      if (value.is<T>()) {
-        const auto& struct_ = value.as<T>();
-        std::vector<StructType::FieldInfo> fields_info;
-        for (const auto& [name, value] : struct_.fields) {
-          fields_info.push_back(
-              {name,
-               std::make_shared<DataType>(
-                   getDataType(NVFUSER_MAYBE_STAR value))});
-        }
-        dtype = StructType::make<NotImplementedStruct>(std::move(fields_info));
-      }
     } else if constexpr (std::is_same_v<T, Pointer>) {
       // For pointers in polymorphic value, we only store the data size of the
       // pointee, so it is impossible to infer the pointer type.
       TORCH_CHECK(!value.is<T>(), "Can not infer pointer type.");
+    } else if constexpr (std::is_same_v<T, StructHandle>) {
+      if (value.is<T>()) {
+        dtype = value.as<T>().type();
+      }
     } else if constexpr (std::is_same_v<T, Opaque>) {
       if (value.is<T>()) {
         const auto& opaque = value.as<T>();

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -298,10 +298,44 @@ TEST_F(ExprEvalTest, Struct) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
+  struct A : public Struct {
+    int64_t a;
+    int64_t b;
+
+    StructType type() const override {
+      std::vector<StructType::FieldInfo> fields(2);
+      fields.at(0) = {"a", std::make_shared<DataType>(DataType::Int), true};
+      fields.at(1) = {"b", std::make_shared<DataType>(DataType::Int), false};
+      return StructType::make<A>(fields, "A");
+    }
+
+    std::function<PolymorphicValue()> getter(
+        const std::string& key) const override {
+      if (key == "a") {
+        return [this]() { return PolymorphicValue(a); };
+      } else if (key == "b") {
+        return [this]() { return PolymorphicValue(b); };
+      } else {
+        TORCH_INTERNAL_ASSERT(false, "Invalid key");
+      }
+    }
+
+    std::function<void(const PolymorphicValue&)> setter(
+        const std::string& key) override {
+      if (key == "a") {
+        return [this](const PolymorphicValue& value) { a = (int64_t)value; };
+      } else if (key == "b") {
+        return [this](const PolymorphicValue& value) { b = (int64_t)value; };
+      } else {
+        TORCH_INTERNAL_ASSERT(false, "Invalid key");
+      }
+    }
+  };
+
   auto* a = IrBuilder::create<Val>(DataType::Int);
   auto* b = IrBuilder::create<Val>(DataType::Int);
 
-  auto struct_ = IrBuilder::structExpr<NotImplementedStruct>(
+  auto struct_ = IrBuilder::structExpr<A>(
       {{"a", a}, {"b", b}}, "test_struct");
 
   auto aa = IrBuilder::getAttrExpr(struct_, "a");
@@ -311,8 +345,9 @@ TEST_F(ExprEvalTest, Struct) {
   evaluator.bind(a, 2L);
   evaluator.bind(b, 5L);
 
-  LegacyStruct<PolymorphicValue> expect({{"a", 2L}, {"b", 5L}});
-  EXPECT_EQ(evaluator.evaluate(struct_), expect);
+  auto eval_struct = evaluator.evaluate(struct_);
+  EXPECT_EQ((PolymorphicValue)(eval_struct->*"a"), 2L);
+  EXPECT_EQ((PolymorphicValue)(eval_struct->*"b"), 5L);
   EXPECT_EQ(evaluator.evaluate(aa), 2L);
   EXPECT_EQ(evaluator.evaluate(bb), 5L);
 }


### PR DESCRIPTION
Perf (vs https://github.com/NVIDIA/Fuser/issues/749):

```C++
Benchmark                                                 Time             CPU   Iterations
-------------------------------------------------------------------------------------------
LayerNormBackward_ShapeInference                       82.6 us         82.5 us         8526
LayerNormForward_ShapeInference                        20.9 us         20.9 us        33419
LayerNormBackward_NoShapeInferenceCachedBaseline       37.3 us         37.2 us        18987
LayerNormForward_NoShapeInferenceCachedBaseline        13.6 us         13.6 us        52101
``` 

```python
[------------------  -----------------]
           |  nvfuser 0.0.19+git2b8aef8
1 threads: ----------------------------
      2    |             16.3          
      4    |             20.0          
      8    |             32.1          
      16   |             49.2          
      32   |             94.2          
      64   |            179.9          
      128  |            350.9          

Times are in microseconds (us).
```