### PR TITLE
Early terminate test suite if there are CUDA errors

### DIFF
--- a/python_tests/pytest_framework.py
+++ b/python_tests/pytest_framework.py
@@ -23,7 +23,9 @@ def _instantiate_opinfo_test_template(
             try:
                 torch.cuda.synchronize()
             except RuntimeError as rte:
-                pytest.exit("TEST SUITE EARLY TERMINATION due to torch.cuda.synchronize() failure")
+                pytest.exit(
+                    "TEST SUITE EARLY TERMINATION due to torch.cuda.synchronize() failure"
+                )
 
         return template(opinfo, dtype)
 


### PR DESCRIPTION
Early terminate test suite if there are CUDA errors

Ref: https://github.com/pytorch/pytorch/blob/aa8ea1d787a9d21b064b664c5344376265feea6c/torch/testing/_internal/common_utils.py#L2251-L2263

> CUDA device side error will cause subsequence test cases to fail.
> stop entire test suite if catches RuntimeError during torch.cuda.synchronize().

This can be verified locally with 
```
pytest python_tests/pytest_ops.py -v -k 'test_correctness_atan2 or test_correctness_div'
```
using today's build 20230829


Side note: most of our test_X.py tests inherit TestCase from pytorch, which already has this early termination feature.