### PR TITLE
schedulerDebug shouldn't print why matmul scheduler is not used.

### DIFF
--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -344,9 +344,6 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
     std::stringstream ss;
     ss << "Matmul scheduler supports fusions only with a single MMA op, got: "
        << mma_exprs.size();
-    if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-      debug() << MATMUL_LOG_PREFIX << ss.str() << std::endl;
-    }
     return ss.str();
   }
 
@@ -354,10 +351,6 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
   {
     const auto input_layout_opt = mma_utils::getMatmulLayout(fusion);
     if (!input_layout_opt.isValid()) {
-      if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-        debug() << MATMUL_LOG_PREFIX << input_layout_opt.getErrorMsg()
-                << std::endl;
-      }
       return input_layout_opt.getErrorMsg();
     }
   }
@@ -367,9 +360,6 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
     for (auto mma_expr : mma_exprs) {
       auto support_status = isMatmulFusionDefinitionSupported(fusion, mma_expr);
       if (!support_status.empty()) {
-        if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-          debug() << MATMUL_LOG_PREFIX << support_status << std::endl;
-        }
         return support_status;
       }
     }


### PR DESCRIPTION
Issue: When I ran normalization cases with `schedulerDebug`, there are redundant output from matmul scheduler telling me why matmul scheduler is not used. This info should be printed with `{"segmenter_logging", DebugDumpOption::FusionSegmenterLog},` and  schedulerDebug is used to print the parameters of the heuristics.

Fix: remove cout in `getMatmulCompileTimeRejectReason`

Result: MatmulCompileTimeRejectReason will only be printed out if `NVFUSER_DUMP=segmenter_logging`