### PR TITLE
Add `cstdint` header

### DIFF
--- a/csrc/exceptions.h
+++ b/csrc/exceptions.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <deque>
 #include <fstream>
 #include <optional>


### PR DESCRIPTION
Fixes gcc 13.2.1 error for PR #811 .