### PR TITLE
move part of persistent tensors to shared memory if register is insufficient

### DIFF
--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -1341,6 +1341,7 @@ std::shared_ptr<ReductionParams> persistentHeuristic(
         vectorize_factor);
   }
   rparams->project_persistent_buffers = project_persistent_buffers;
+  rparams->smem_tvs = std::move(smem_tvs);
   return rparams;
 }
 

--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -1523,8 +1523,8 @@ void beforeSchedule(
   scheduler_utils::prepareForMemoryTypePromotion(fusion);
 
   // Transfer the persistent buffer tensors to shared memory. These tensors are
-  // housed in smem_tvs. Some of these are inputs, hence, only their
-  // associated cached tensors should be relocated.
+  // housed in smem_tvs. If a candidate tensor is input, move its associated
+  // cached tensors.
   if (rparams.shared_mem_persistent_buffer) {
     const auto& persistent_buffers =
         scheduler_utils::persistentBuffers(fusion).persistent_buffers;

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -921,12 +921,19 @@ PersistentBufferStorageParams getPersistentBufferStorageParams(
     // Determine the least number of buffers to transfer to shared memory
     // to ensure the register buffer size doesn't exceed the available limit.
     int64_t n_smem_buffer = -1;
-    for (int i = 1; i <= n_buffers; i++) {
-      if (buffer_params.regs_buffer_size - acc_regs_buffer_sizes[i] <=
-          available_regs) {
-        n_smem_buffer = i;
-        break;
+    if (buffer_params.combined_reduction) {
+      for (int i = 1; i <= n_buffers; i++) {
+        if (buffer_params.regs_buffer_size - acc_regs_buffer_sizes[i] <=
+            available_regs) {
+          n_smem_buffer = i;
+          break;
+        }
       }
+    } else {
+      // move all buffers to shared memory for inner reduction
+      // TODO: allow moving a subset of buffers to shared memory for inner
+      // reduction
+      n_smem_buffer = n_buffers;
     }
 
     // Can't be scheduled if n_smem_buffer is not set or requested shared memory

--- a/csrc/scheduler/reduction_heuristic.h
+++ b/csrc/scheduler/reduction_heuristic.h
@@ -135,11 +135,13 @@ class ReductionParams : public HeuristicParams {
   // block_dim_inner_reduction_extra (usually TIDy)
   ParallelType block_dim_inner_reduction_extra = ParallelType::Serial;
 
-  // use shared memory for persistent buffer, if false, will use registers.
-  // For innerOuterPersistentHeuristic, shared memory buffer is only used for
-  // the persistent tensors in the original fusion definition, the intermediate
+  // Use shared memory for persistent buffer, if false, will use registers.
+  // For innerOuterPersistentHeuristic, only the persistent tensors in the
+  // original fusion definition may be moved to shared memory, the intermediate
   // persistent tensors which are creased by the scheduler to store the partial
-  // outer reduction results are always stored in registers.
+  // outer reduction results are always stored in registers. The code can be
+  // extended to allow the move of these intermediate persistent tensors to
+  // shared memory when the shared memory is larger than the register file.
   bool shared_mem_persistent_buffer = false;
   std::vector<TensorView*> smem_tvs;
 

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -30,6 +30,25 @@ namespace scheduler_utils {
 // but it's hard to get a better one.
 constexpr int64_t register_file_size_full = (int64_t)256 * 1024;
 constexpr int64_t register_file_size = register_file_size_full / 2;
+
+//! register file size allowed for persistent buffers in
+//! innerOuterPersistentHeuristic. May cause register spills but still improves
+//! the overall performance. Here 54 = (1-overhead/255) * 64, reduce to 48 if
+//! not vectorized.
+constexpr int64_t register_file_size_combined =
+    register_file_size_full / 64 * 54;
+constexpr int64_t register_file_size_combined_unvectorized =
+    register_file_size_full / 64 * 48;
+// max threads per block for combined scheduler uses
+// innerOuterPersistentHeuristic. Combined scheduler creates additional
+// persistent tensors to store intermediate outer reduction results. It also
+// have both inner and outer reductions, the register pressure is very high.
+// Limit the max threads per block to 256, allows each thread to use 255
+// registers. If not vectorized, more gmem access ops is required, increase to
+// 512 for higher occupancy to hide gmem access latency.
+constexpr int64_t max_threads_per_block_combined = 256l;
+constexpr int64_t max_threads_per_block_combined_unvectorized = 512l;
+
 // Empirically observed number. Not guaranteed to be a good estimate
 constexpr int64_t register_overhead = 40l;
 constexpr int64_t max_registers_per_thread = 255l;
@@ -600,6 +619,12 @@ TORCH_CUDA_CU_API void promoteProducerMemoryTypes(
 TORCH_CUDA_CU_API std::unordered_set<TensorView*> getAllTvsFrom(
     const std::vector<TensorView*>& from_tvs,
     const std::unordered_set<TensorView*>& cutoff_tv_set);
+
+//! Get the persistent buffer size of the given tensor
+TORCH_CUDA_CU_API int64_t getOnePersistentBufferSize(
+    const TensorView* buffer,
+    SchedulerRuntimeInfo& runtime_info,
+    const PersistentBufferInfo& persistent_buffer_info);
 
 } // namespace scheduler_utils
 } // namespace nvfuser

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -214,8 +214,8 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
       {1600},
       {1984},
       {1987},
-      {16384}, // use shared memory for persistent
-      {32768}, // Float: segment and the inner reduction part has 2 persistent tensors
+      {16384}, //! use shared memory for persistent
+      {32768}, //! segment and the inner reduction part has 2 persistent tensors
       {65536}};
   for (auto dtype : data_types) {
     for (auto batch_shape : batch_sizes) {

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -26,29 +26,13 @@ namespace nvfuser {
 
 using namespace at::indexing;
 
-// mean & var
-std::tuple<float, float> getMeanVar(const std::vector<float>& v) {
-  const int nele = v.size();
-  float mean = std::accumulate(v.begin(), v.end(), 0.0f) / nele;
-  std::vector<float> sub_mean(nele);
-  std::transform(v.begin(), v.end(), sub_mean.begin(), [mean](float x) {
-    return x - mean;
-  });
-  float sq_sum = std::inner_product(
-      sub_mean.begin(), sub_mean.end(), sub_mean.begin(), 0.0);
-  float stdev = std::sqrt(sq_sum / nele);
-  return {mean, stdev};
-}
-
 // This case is to test the correctness of the combined inner and outer
 // scheduler used in layer norm backward. It can also be configured to test the
 // performance using different data types.
 TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
   auto runTest = [](const std::vector<int64_t>& batch_shape,
                     const std::vector<int64_t>& norm_shape,
-                    DataType dtype,
-                    bool isBenchmark,
-                    int verbose) {
+                    DataType dtype) {
     std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
     Fusion& fusion = *fusion_ptr.get();
     FusionGuard fg(&fusion);
@@ -178,70 +162,42 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
          std::get<2>(aten_gradients).mul(scale_back_factor)},
         __LINE__,
         __FILE__);
-    if (isBenchmark) {
-      FusionKernelRuntime* fkr = fec.getMostRecentKernelRuntime();
-      fkr->enableKernelTimeMeasurement();
 
-      constexpr int nwarm = 5;
-      constexpr int niter = 10;
-      std::vector<float> bw(niter, 0.f);
-      std::vector<float> timeus(niter, 0.f);
+    //  should use shared memory if the register file is insufficient but there
+    //  is ample space in shared memory.
+    int64_t hidden_size = 1l;
+    for (int64_t dim : norm_shape) {
+      hidden_size *= dim;
+    }
 
-      size_t read_write_bytes = 0;
-      const std::vector<at::Tensor> aten_inputs_tmp = {
-          aten_grad_out,
-          aten_input,
-          aten_mean,
-          aten_rstd,
-          aten_weight,
-          aten_bias};
-      const std::vector<at::Tensor> aten_output_tmp = {
-          std::get<0>(aten_gradients),
-          std::get<1>(aten_gradients),
-          std::get<2>(aten_gradients)};
-      for (auto input : aten_inputs_tmp) {
-        read_write_bytes += input.numel() * input.element_size();
-      }
-      for (auto output : aten_output_tmp) {
-        read_write_bytes += output.numel() * output.element_size();
-      }
+    int64_t persistent_buffer_size = hidden_size *
+        (dtype == DataType::Half ? 14l : (dtype == DataType::Float ? 20l : 0l));
+    ASSERT_TRUE(persistent_buffer_size) << "Unsupported data type!";
 
-      for (int i = 0; i < nwarm + niter; i++) {
-        clearL2Cache();
-        // fe.runFusion(inputs, outputs, launch_constraints);
-        auto cg_outputs = fec.runFusionWithInputs(aten_inputs);
-        if (i >= nwarm) {
-          float runTimeus = 0.0f;
-          int num_kernels = fkr->executors().size();
-          for (int i = 0; i < num_kernels; i++) {
-            const FusionExecutor& fe = fkr->executors()[i];
-            runTimeus += fe.kernelTimeMs() * 1e3;
-          }
-          float bandwidth = read_write_bytes / 1e9 / (runTimeus * 1e-6);
-          timeus[i - nwarm] = runTimeus;
-          bw[i - nwarm] = bandwidth;
-          if (verbose == 2)
-            std::cout << "iter= " << i << ", bandwidth= " << bandwidth << "GB/s"
-                      << ", time= " << runTimeus << " us" << std::endl;
-        }
+    if (persistent_buffer_size > scheduler_utils::register_file_size_combined) {
+      auto dev_prop = at::cuda::getCurrentDeviceProperties();
+      int64_t available_smem =
+          (int64_t)dev_prop->sharedMemPerBlockOptin -
+          normalization_scheduler_utils::getSharedMemoryOverheadPerBlock(
+              &fusion,
+              scheduler_utils::getReductionTvs(&fusion),
+              scheduler_utils::max_threads_per_block_combined);
+
+      if (available_smem >= persistent_buffer_size) {
+        const auto& kernel_runtime = fec.getMostRecentKernelRuntime();
+        ASSERT_TRUE(!kernel_runtime->isSegmented())
+            << "Should not segment! hidden_size: " << hidden_size
+            << ", dataTypeSize: " << dataTypeSize(dtype);
+        auto heuristic_params = kernel_runtime->schedulerHeuristics()
+                                    ->heuristicsList()
+                                    .at(0)
+                                    ->params();
+        ASSERT_TRUE(heuristic_params->isA<ReductionParams>());
+        auto rparams = heuristic_params->as<ReductionParams>();
+        ASSERT_TRUE(rparams->shared_mem_persistent_buffer)
+            << "Should use shared memory buffer! hidden_size: " << hidden_size
+            << ", dataTypeSize: " << dataTypeSize(dtype);
       }
-      return getMeanVar(timeus);
-    } else {
-      if (verbose == 1) {
-        std::stringstream sdim0, sdim1;
-        std::for_each(
-            batch_shape.begin(), batch_shape.end(), [&sdim0](int64_t n) {
-              sdim0 << n << " x ";
-            });
-        std::for_each(
-            norm_shape.begin(), norm_shape.end(), [&sdim1](int64_t n) {
-              sdim1 << n << " x ";
-            });
-        std::string str1 = sdim1.str();
-        str1.erase(str1.end() - 2);
-        std::cout << "passed, shape= " << sdim0.str() << str1 << std::endl;
-      }
-      return std::make_tuple(-1.0f, -1.0f);
     }
   };
 
@@ -258,37 +214,14 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
       {1600},
       {1984},
       {1987},
+      {16384},
       {65536}};
-  bool isBenchmark = false;
-  bool onlyTestFirstCase = false;
-  int verbose = 0;
   for (auto dtype : data_types) {
     for (auto batch_shape : batch_sizes) {
       for (auto norm_shape : hidden_sizes) {
-        std::tuple<float, float> avg_var =
-            runTest(batch_shape, norm_shape, dtype, isBenchmark, verbose);
-        if (isBenchmark) {
-          std::stringstream sdim0, sdim1;
-          std::for_each(
-              batch_shape.begin(), batch_shape.end(), [&sdim0](int64_t n) {
-                sdim0 << n << " x ";
-              });
-          std::for_each(
-              norm_shape.begin(), norm_shape.end(), [&sdim1](int64_t n) {
-                sdim1 << n << " x ";
-              });
-          std::cout << "shape= " << sdim0.str() << sdim1.str()
-                    << ", time_us mean(var)= " << std::get<0>(avg_var) << " ("
-                    << std::get<1>(avg_var) << ")" << std::endl;
-        }
-        if (onlyTestFirstCase)
-          break;
+        runTest(batch_shape, norm_shape, dtype);
       }
-      if (onlyTestFirstCase)
-        break;
     }
-    if (onlyTestFirstCase)
-      break;
   }
 }
 

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -214,7 +214,8 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
       {1600},
       {1984},
       {1987},
-      {16384},
+      {16384}, // use shared memory for persistent
+      {32768}, // Float: segment and the inner reduction part has 2 persistent tensors
       {65536}};
   for (auto dtype : data_types) {
     for (auto batch_shape : batch_sizes) {


### PR DESCRIPTION
initially implemented in #666 , the detailed description can be found is the original PR.
A short description of this PR:
(1) start moving to smem when register is insufficient to hold the persistent buffers
(2) Prioritize moving buffers that are directly used by broadcast ops.
(3) Move N buffers until the register buffer size is below the available limit.

The algorithm is implemented in `getPersistentBufferStorageParams`. It is called twice:
(1) called from `canScheduleRunTime` to check if can persistent
(2) called from  `getPersistentHeuristics`  to get the buffers on register and smem.
The shared memory tvs are stored as `std::vector<TensorView*> smem_tvs;` in `ReductionParams` to avoid calling  `getPersistentBufferStorageParams` again from `schedulePersistentKernel`.