### PR TITLE
Emit type name in generated C++ for `TensorConstruct` and `ArrayConstruct`

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -605,7 +605,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     if (!print_inline_) {
       indent() << gen(sop->output(0)) << " = ";
     }
-    code_ << "{ ";
+    auto dtype = std::get<StructType>(sop->output(0)->dtype().type);
+    code_ << dtype.name << "{ ";
     for (auto i : c10::irange(sop->inputs().size())) {
       if (i > 0) {
         code_ << ", ";
@@ -941,7 +942,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       indent() << gen(aop->out()) << " = ";
     }
 
-    code_ << "{";
+    code_ << aop->out()->dtype() << "{";
     bool first = true;
     for (auto in : aop->inputs()) {
       if (!first) {


### PR DESCRIPTION
Generate type name for brace initializer

Change in `TensorFactoryTest.TensorConstruct`:

Before:
```C++
__global__ void kernel1(int64_t i0, int64_t i1, int64_t i2, int64_t i3, Tensor<int64_t, 2, 2> T0) {
  NVFUSER_DEFINE_MAGIC_ZERO;
  Array<int64_t, 2, 1> a4;
  a4 = {i2, i3};
  Array<int64_t, 2, 1> a5;
  a5 = {i0, i1};
  Array<Array<int64_t, 2, 1>, 2, 1> a6;
  a6 = {a5, a4};
  #pragma unroll
  for(nvfuser_index_t i7 = 0; i7 < 2; ++i7) {
    nvfuser_index_t i8;
    i8 = 2 * i7;
    #pragma unroll
    for(nvfuser_index_t i9 = 0; i9 < 2; ++i9) {
      nvfuser_index_t i10;
      i10 = i9 + nvfuser_zero;
      T0[(i8 + i10)] = a6[i7][i10];
    }
  }
  NVFUSER_UPDATE_MAGIC_ZERO;
}
```

After:
```C++
__global__ void kernel1(int64_t i0, int64_t i1, int64_t i2, int64_t i3, Tensor<int64_t, 2, 2> T0) {
  NVFUSER_DEFINE_MAGIC_ZERO;
  Array<int64_t, 2, 1> a4;
  a4 = Array<int64_t, 2, 1>{i2, i3};
  Array<int64_t, 2, 1> a5;
  a5 = Array<int64_t, 2, 1>{i0, i1};
  Array<Array<int64_t, 2, 1>, 2, 1> a6;
  a6 = Array<Array<int64_t, 2, 1>, 2, 1>{a5, a4};
  #pragma unroll
  for(nvfuser_index_t i7 = 0; i7 < 2; ++i7) {
    nvfuser_index_t i8;
    i8 = 2 * i7;
    #pragma unroll
    for(nvfuser_index_t i9 = 0; i9 < 2; ++i9) {
      nvfuser_index_t i10;
      i10 = i9 + nvfuser_zero;
      T0[(i8 + i10)] = a6[i7][i10];
    }
  }
  NVFUSER_UPDATE_MAGIC_ZERO;
}
```

