### PR TITLE
Python error printing: compute strided size properly

### DIFF
--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -144,14 +144,21 @@ class FusionDefinition(_C._FusionDefinition):
             )
             for i in inputs:
                 if isinstance(i, torch.Tensor):
+                    # max linear index determines number of elements to generate
+                    sz = 1
+                    for szi, stri in zip(i.size(), i.stride()):
+                        if szi == 0:
+                            sz = 0
+                            break
+                        sz += (szi - 1) * stri
                     if i.dtype.is_floating_point:
                         msg += (
-                            f"    torch.randn({tuple(i.size())}, dtype={i.dtype}, device='{i.device}')"
+                            f"    torch.randn(({sz},), dtype={i.dtype}, device='{i.device}')"
                             f".as_strided({tuple(i.size())}, {tuple(i.stride())}),\n"
                         )
                     else:
                         msg += (
-                            f"    torch.randint(0, 10, {tuple(i.size())}, dtype={i.dtype}, device='{i.device}')"
+                            f"    torch.randint(0, 10, ({sz},), dtype={i.dtype}, device='{i.device}')"
                             f".as_strided({tuple(i.size())}, {tuple(i.stride())}),\n"
                         )
                 else:


### PR DESCRIPTION
This originally sized tensor does not work for `as_strided` usage because the first tensor is only sized for 3 elements when, `as_strided` is attempting to access up to a 7th element.  `as_strided`, therefore, would hit an error.
```python
    torch.randn((3, 1), dtype=torch.float32, device='cuda:0').as_strided((3, 1), (3, 1)),                                                                            
    torch.randn((3, 2), dtype=torch.float32, device='cuda:0').as_strided((3, 2), (3, 1)),
```
we will now print
```python
    torch.randn((7,), dtype=torch.float32, device='cuda:0').as_strided((3, 1), (3, 1)),                                                                            
    torch.randn((8,), dtype=torch.float32, device='cuda:0').as_strided((3, 2), (3, 1)),
```

Fixes #844