### PR TITLE
`Expr::evaluate` method for `PadOp`

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1976,6 +1976,10 @@ class TORCH_CUDA_CU_API PadOp : public Expr {
   std::string toString(int indent_size = 0) const override;
   std::string toInlineString(int indent_size = 0) const override;
 
+  std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
+      const std::vector<PolymorphicValue>& inputs) const override;
+
   Val* out() const {
     return output(0);
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3903,6 +3903,27 @@ std::pair<Val*, Val*> PadOp::getPadWidths(int axis) const {
       (*(getPadWidthInputBegin() + offset_odd))->as<Val>());
 }
 
+std::vector<PolymorphicValue> PadOp::evaluate(
+    const ExpressionEvaluator& ee,
+    const std::vector<PolymorphicValue>& inputs) const {
+
+      const auto& in = inputs.at(0).as<at::Tensor>();
+      double value = (double) inputs.at(1);
+
+      std::vector<int64_t> pad_widths;
+      auto pad_width_offset = getPadWidthInputOffset();
+      auto num_dims = in.dim();
+
+      for (auto i = num_dims-1; i > -1; i--){
+        auto left_pad = (int64_t) inputs.at(pad_width_offset + 2*i);
+        auto right_pad = (int64_t) inputs.at(pad_width_offset + 2*i + 1);
+        pad_widths.push_back(left_pad);
+        pad_widths.push_back(right_pad);
+      }
+
+      return {at::pad(in, pad_widths, "constant", value)};
+}
+
 SliceOp::SliceOp(
     IrBuilderPasskey passkey,
     TensorView* out,

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3906,22 +3906,21 @@ std::pair<Val*, Val*> PadOp::getPadWidths(int axis) const {
 std::vector<PolymorphicValue> PadOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
+  const auto& in = inputs.at(0).as<at::Tensor>();
+  double value = (double)inputs.at(1);
 
-      const auto& in = inputs.at(0).as<at::Tensor>();
-      double value = (double) inputs.at(1);
+  std::vector<int64_t> pad_widths;
+  auto pad_width_offset = getPadWidthInputOffset();
+  auto num_dims = in.dim();
 
-      std::vector<int64_t> pad_widths;
-      auto pad_width_offset = getPadWidthInputOffset();
-      auto num_dims = in.dim();
+  for (auto i = num_dims - 1; i > -1; i--) {
+    auto left_pad = (int64_t)inputs.at(pad_width_offset + 2 * i);
+    auto right_pad = (int64_t)inputs.at(pad_width_offset + 2 * i + 1);
+    pad_widths.push_back(left_pad);
+    pad_widths.push_back(right_pad);
+  }
 
-      for (auto i = num_dims-1; i > -1; i--){
-        auto left_pad = (int64_t) inputs.at(pad_width_offset + 2*i);
-        auto right_pad = (int64_t) inputs.at(pad_width_offset + 2*i + 1);
-        pad_widths.push_back(left_pad);
-        pad_widths.push_back(right_pad);
-      }
-
-      return {at::pad(in, pad_widths, "constant", value)};
+  return {at::pad(in, pad_widths, "constant", value)};
 }
 
 SliceOp::SliceOp(

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -113,9 +113,6 @@ TEST_F(ResizeTest, FusionResizePad3) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  auto t3 = at::pad(t0, {1, 1});
-  auto ref = t3 + t1;
-
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
@@ -235,10 +232,6 @@ TEST_F(ResizeTest, FusionResizePad6) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  auto t2 = t0 + 1;
-  auto t3 = at::pad(t2, {1, 1});
-  auto ref = t3 + t1;
-
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
@@ -282,8 +275,6 @@ TEST_F(ResizeTest, FusionResizePad7) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
-
-  auto ref = at::pad(t0, {1, 1});
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -387,9 +378,6 @@ TEST_F(ResizeTest, FusionResizePadScheduler2) {
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-
-  auto t3 = at::pad(t0, {1, 1});
-  auto ref = t3 + t1;
 
   testValidate(
       executor_cache.fusion(),
@@ -511,8 +499,6 @@ TEST_F(ResizeTest, FusionResizePadBroadcastInput) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-
-  auto t1 = at::pad(t0, {1, 0, 0, 0});
 
   testValidate(
       executor_cache.fusion(),

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -380,11 +380,7 @@ TEST_F(ResizeTest, FusionResizePadScheduler2) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   testValidate(
-      executor_cache.fusion(),
-      cg_outputs,
-      aten_inputs,
-      __LINE__,
-      __FILE__);
+      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Disabled due to the same reason as Pad8
@@ -501,11 +497,7 @@ TEST_F(ResizeTest, FusionResizePadBroadcastInput) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   testValidate(
-      executor_cache.fusion(),
-      cg_outputs,
-      aten_inputs,
-      __LINE__,
-      __FILE__);
+      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Trivial cat

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -116,7 +116,7 @@ TEST_F(ResizeTest, FusionResizePad3) {
   auto t3 = at::pad(t0, {1, 1});
   auto ref = t3 + t1;
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // pad + parallelization
@@ -239,7 +239,7 @@ TEST_F(ResizeTest, FusionResizePad6) {
   auto t3 = at::pad(t2, {1, 1});
   auto ref = t3 + t1;
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // pad + unswitch. Having different extents in an unswitched loop nest
@@ -285,7 +285,7 @@ TEST_F(ResizeTest, FusionResizePad7) {
 
   auto ref = at::pad(t0, {1, 1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Disable for now. Unclear what would be the best way to handle
@@ -395,7 +395,6 @@ TEST_F(ResizeTest, FusionResizePadScheduler2) {
       executor_cache.fusion(),
       cg_outputs,
       aten_inputs,
-      {ref},
       __LINE__,
       __FILE__);
 }
@@ -519,7 +518,6 @@ TEST_F(ResizeTest, FusionResizePadBroadcastInput) {
       executor_cache.fusion(),
       cg_outputs,
       aten_inputs,
-      {t1},
       __LINE__,
       __FILE__);
 }


### PR DESCRIPTION
Implements the `Expr::evaluate` method for `PadOp`. This is a part of resolving issue #670.