### PR TITLE
[DynamicType] Fix automatic conversion to `DynamicType`

### DIFF
--- a/lib/dynamic_type/src/dynamic_type/dynamic_type.h
+++ b/lib/dynamic_type/src/dynamic_type/dynamic_type.h
@@ -449,7 +449,7 @@ constexpr bool is_dynamic_type_v = is_dynamic_type<T>::value;
               DT::type_identities_as_tuple,                                \
               DT::type_identities_as_tuple),                               \
       DT>                                                                  \
-  operator op(const DT& x, const DT& y) {                                  \
+  operator op(const DT & x, const std::type_identity_t<DT>& y) {           \
     DT ret(std::monostate{});                                              \
     DT::for_all_types([&ret, &x, &y](auto lhs) {                           \
       using LHS = typename decltype(lhs)::type;                            \
@@ -497,7 +497,7 @@ constexpr bool is_dynamic_type_v = is_dynamic_type<T>::value;
               opname##_rdefined_checker<RHS, typename DT::VariantType>,    \
               DT::type_identities_as_tuple),                               \
       DT>                                                                  \
-  operator op(const DT& x, const RHS& y) {                                 \
+  operator op(const DT & x, const RHS & y) {                               \
     DT ret(std::monostate{});                                              \
     DT::for_all_types([&ret, &x, &y](auto lhs) {                           \
       using LHS = typename decltype(lhs)::type;                            \
@@ -542,7 +542,7 @@ constexpr bool is_dynamic_type_v = is_dynamic_type<T>::value;
               opname##_ldefined_checker<LHS, typename DT::VariantType>,    \
               DT::type_identities_as_tuple),                               \
       DT>                                                                  \
-  operator op(const LHS& x, const DT& y) {                                 \
+  operator op(const LHS & x, const DT & y) {                               \
     DT ret(std::monostate{});                                              \
     DT::for_all_types([&ret, &x, &y](auto rhs) {                           \
       using RHS = typename decltype(rhs)::type;                            \
@@ -697,7 +697,7 @@ DEFINE_BINARY_OP(rshift, >>);
           any_check(                                                          \
               opname##_ldefined_checker<LHS>, DT::type_identities_as_tuple),  \
       bool>                                                                   \
-  operator op(const LHS& x, const DT& y) {                                    \
+  operator op(const LHS & x, const DT & y) {                                  \
     std::optional<bool> ret = std::nullopt;                                   \
     DT::for_all_types([&ret, &x, &y](auto rhs) {                              \
       using RHS = typename decltype(rhs)::type;                               \
@@ -752,7 +752,7 @@ DEFINE_COMPARE_OP(ge, >=);
               opname##_helper<typename DT::VariantType>,                       \
               DT::type_identities_as_tuple),                                   \
       DT>                                                                      \
-  operator op(const DT& x) {                                                   \
+  operator op(const DT & x) {                                                  \
     DT ret(std::monostate{});                                                  \
     DT::for_all_types([&ret, &x](auto _) {                                     \
       using Type = typename decltype(_)::type;                                 \
@@ -871,7 +871,7 @@ std::ostream& operator<<(std::ostream& os, const DT& dt) {
       typename = std::enable_if_t<                                             \
           is_dynamic_type_v<DT> &&                                             \
           any_check(opname##_helper, DT::type_identities_as_tuple)>>           \
-  inline constexpr DT& operator op(DT& x) {                                    \
+  inline constexpr DT& operator op(DT & x) {                                   \
     bool computed = false;                                                     \
     DT::for_all_types([&computed, &x](auto _) {                                \
       using Type = typename decltype(_)::type;                                 \
@@ -919,7 +919,7 @@ DEFINE_LEFT_PPMM(lmm, --);
               opname##_helper<typename DT::VariantType>,                       \
               DT::type_identities_as_tuple),                                   \
       DT>                                                                      \
-  operator op(DT& x, int) {                                                    \
+  operator op(DT & x, int) {                                                   \
     DT ret;                                                                    \
     DT::for_all_types([&ret, &x](auto _) {                                     \
       using Type = typename decltype(_)::type;                                 \
@@ -953,7 +953,7 @@ DEFINE_RIGHT_PPMM(rmm, --);
       typename T,                                                \
       typename = std::enable_if_t<                               \
           is_dynamic_type_v<DT> && (opcheck<DT> op opcheck<T>)>> \
-  inline constexpr DT& operator assign_op(DT& x, const T& y) {   \
+  inline constexpr DT& operator assign_op(DT & x, const T & y) { \
     return x = x op y;                                           \
   }
 

--- a/lib/dynamic_type/src/dynamic_type/dynamic_type.h
+++ b/lib/dynamic_type/src/dynamic_type/dynamic_type.h
@@ -449,7 +449,7 @@ constexpr bool is_dynamic_type_v = is_dynamic_type<T>::value;
               DT::type_identities_as_tuple,                                \
               DT::type_identities_as_tuple),                               \
       DT>                                                                  \
-  operator op(const DT & x, const std::type_identity_t<DT>& y) {           \
+  operator op(const DT& x, const std::type_identity_t<DT>& y) {            \
     DT ret(std::monostate{});                                              \
     DT::for_all_types([&ret, &x, &y](auto lhs) {                           \
       using LHS = typename decltype(lhs)::type;                            \
@@ -497,7 +497,7 @@ constexpr bool is_dynamic_type_v = is_dynamic_type<T>::value;
               opname##_rdefined_checker<RHS, typename DT::VariantType>,    \
               DT::type_identities_as_tuple),                               \
       DT>                                                                  \
-  operator op(const DT & x, const RHS & y) {                               \
+  operator op(const DT& x, const RHS& y) {                                 \
     DT ret(std::monostate{});                                              \
     DT::for_all_types([&ret, &x, &y](auto lhs) {                           \
       using LHS = typename decltype(lhs)::type;                            \
@@ -543,7 +543,7 @@ constexpr bool is_dynamic_type_v = is_dynamic_type<T>::value;
                opname##_ldefined_checker<LHS, typename DT::VariantType>,   \
                DT::type_identities_as_tuple)),                             \
       DT>                                                                  \
-  operator op(const LHS & x, const DT & y) {                               \
+  operator op(const LHS& x, const DT& y) {                                 \
     DT ret(std::monostate{});                                              \
     DT::for_all_types([&ret, &x, &y](auto rhs) {                           \
       using RHS = typename decltype(rhs)::type;                            \
@@ -706,7 +706,7 @@ DEFINE_BINARY_OP(rshift, >>);
            any_check(                                                          \
                opname##_ldefined_checker<LHS>, DT::type_identities_as_tuple)), \
       bool>                                                                    \
-  operator op(const LHS & x, const DT & y) {                                   \
+  operator op(const LHS& x, const DT& y) {                                     \
     std::optional<bool> ret = std::nullopt;                                    \
     DT::for_all_types([&ret, &x, &y](auto rhs) {                               \
       using RHS = typename decltype(rhs)::type;                                \
@@ -766,7 +766,7 @@ DEFINE_COMPARE_OP(ge, >=);
               opname##_helper<typename DT::VariantType>,                       \
               DT::type_identities_as_tuple),                                   \
       DT>                                                                      \
-  operator op(const DT & x) {                                                  \
+  operator op(const DT& x) {                                                   \
     DT ret(std::monostate{});                                                  \
     DT::for_all_types([&ret, &x](auto _) {                                     \
       using Type = typename decltype(_)::type;                                 \
@@ -885,7 +885,7 @@ std::ostream& operator<<(std::ostream& os, const DT& dt) {
       typename = std::enable_if_t<                                             \
           is_dynamic_type_v<DT> &&                                             \
           any_check(opname##_helper, DT::type_identities_as_tuple)>>           \
-  inline constexpr DT& operator op(DT & x) {                                   \
+  inline constexpr DT& operator op(DT& x) {                                    \
     bool computed = false;                                                     \
     DT::for_all_types([&computed, &x](auto _) {                                \
       using Type = typename decltype(_)::type;                                 \
@@ -933,7 +933,7 @@ DEFINE_LEFT_PPMM(lmm, --);
               opname##_helper<typename DT::VariantType>,                       \
               DT::type_identities_as_tuple),                                   \
       DT>                                                                      \
-  operator op(DT & x, int) {                                                   \
+  operator op(DT& x, int) {                                                    \
     DT ret;                                                                    \
     DT::for_all_types([&ret, &x](auto _) {                                     \
       using Type = typename decltype(_)::type;                                 \
@@ -967,7 +967,7 @@ DEFINE_RIGHT_PPMM(rmm, --);
       typename T,                                                \
       typename = std::enable_if_t<                               \
           is_dynamic_type_v<DT> && (opcheck<DT> op opcheck<T>)>> \
-  inline constexpr DT& operator assign_op(DT & x, const T & y) { \
+  inline constexpr DT& operator assign_op(DT& x, const T& y) {   \
     return x = x op y;                                           \
   }
 

--- a/lib/dynamic_type/src/dynamic_type/dynamic_type.h
+++ b/lib/dynamic_type/src/dynamic_type/dynamic_type.h
@@ -605,7 +605,8 @@ DEFINE_BINARY_OP(rshift, >>);
               opname##_defined_checker,                                       \
               DT::type_identities_as_tuple,                                   \
               DT::type_identities_as_tuple)>>                                 \
-  inline constexpr bool operator op(const DT& x, const DT& y) {               \
+  inline constexpr bool operator op(                                          \
+      const DT& x, const std::type_identity_t<DT>& y) {                       \
     std::optional<bool> ret = std::nullopt;                                   \
     DT::for_all_types([&ret, &x, &y](auto lhs) {                              \
       using LHS = typename decltype(lhs)::type;                               \

--- a/lib/dynamic_type/src/dynamic_type/type_traits.h
+++ b/lib/dynamic_type/src/dynamic_type/type_traits.h
@@ -212,7 +212,7 @@ struct OperatorChecker {
 #define DEFINE_UNARY_OP(op)                                 \
   template <typename T1>                                    \
   constexpr auto operator op(OperatorChecker<T1>)           \
-      -> decltype(op std::declval<T1>(), true) {            \
+      ->decltype(op std::declval<T1>(), true) {             \
     return true;                                            \
   }                                                         \
                                                             \
@@ -223,7 +223,7 @@ struct OperatorChecker {
 #define DEFINE_UNARY_SUFFIX_OP(op)                               \
   template <typename T1>                                         \
   constexpr auto operator op(OperatorChecker<T1>, int)           \
-      -> decltype(std::declval<T1>() op, true) {                 \
+      ->decltype(std::declval<T1>() op, true) {                  \
     return true;                                                 \
   }                                                              \
                                                                  \
@@ -234,7 +234,7 @@ struct OperatorChecker {
 #define DEFINE_BINARY_OP(op)                                           \
   template <typename T1, typename T2>                                  \
   constexpr auto operator op(OperatorChecker<T1>, OperatorChecker<T2>) \
-      -> decltype((std::declval<T1>() op std::declval<T2>()), true) {  \
+      ->decltype((std::declval<T1>() op std::declval<T2>()), true) {   \
     return true;                                                       \
   }                                                                    \
                                                                        \

--- a/lib/dynamic_type/test/binary_ops.cpp
+++ b/lib/dynamic_type/test/binary_ops.cpp
@@ -129,9 +129,9 @@ TEST_BINARY_OP_ALLTYPE(LogicalOr, ||);
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVecTwo {} op DoubleInt64BoolVec(2L)), (2L op 2L));     \
     EXPECT_EQ(                                                                 \
-        (DoubleInt64BoolVecTwo {} op DoubleInt64BoolVec(1L)), (1L op 2L));     \
+        (DoubleInt64BoolVecTwo {} op DoubleInt64BoolVec(1L)), (2L op 1L));     \
     EXPECT_EQ(                                                                 \
-        (DoubleInt64BoolVecTwo {} op DoubleInt64BoolVec(3L)), (3L op 2L));     \
+        (DoubleInt64BoolVecTwo {} op DoubleInt64BoolVec(3L)), (2L op 3L));     \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(std::vector<int64_t>{2})                           \
              op DoubleInt64BoolVec(std::vector<double>{2.0})),                 \

--- a/lib/dynamic_type/test/binary_ops.cpp
+++ b/lib/dynamic_type/test/binary_ops.cpp
@@ -25,15 +25,25 @@
     static_assert(opcheck<DoubleInt64BoolVec> op opcheck<DoubleInt64BoolVec>); \
     static_assert(opcheck<DoubleInt64Bool> op opcheck<int>);                   \
     static_assert(opcheck<DoubleInt64BoolVec> op opcheck<int>);                \
+    static_assert(opcheck<DoubleInt64Bool> op opcheck<DoubleInt64BoolTwo>);    \
+    static_assert(                                                             \
+        opcheck<DoubleInt64BoolVec> op opcheck<DoubleInt64BoolVecTwo>);        \
     static_assert(opcheck<int> op opcheck<DoubleInt64Bool>);                   \
     static_assert(opcheck<int> op opcheck<DoubleInt64BoolVec>);                \
     static_assert(                                                             \
         (DoubleInt64Bool(2L) op DoubleInt64Bool(2.5))                          \
             .as<decltype(2L op 2.5)>() == (2L op 2.5));                        \
+    static_assert(                                                             \
+        (DoubleInt64Bool(2L) op DoubleInt64BoolTwo{})                          \
+            .as<decltype(2L op 2L)>() == (2L op 2L));                          \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(2L) op DoubleInt64BoolVec(2.5))                    \
             .as<decltype(2L op 2.5)>(),                                        \
         (2L op 2.5));                                                          \
+    EXPECT_EQ(                                                                 \
+        (DoubleInt64BoolVec(2L) op DoubleInt64BoolVecTwo{})                    \
+            .as<decltype(2L op 2L)>(),                                         \
+        (2L op 2L));                                                           \
     static_assert(                                                             \
         (DoubleInt64Bool(3L) op 2L).as<decltype((3L op 2L))>() == (3L op 2L)); \
     EXPECT_EQ(                                                                 \

--- a/lib/dynamic_type/test/binary_ops.cpp
+++ b/lib/dynamic_type/test/binary_ops.cpp
@@ -94,25 +94,19 @@ TEST_BINARY_OP_ALLTYPE(LogicalOr, ||);
     static_assert(                                                             \
         (DoubleInt64Bool(2L) op DoubleInt64Bool(2.0)) == (2L op 2.0));         \
     static_assert(                                                             \
-        (DoubleInt64Bool(2L) op DoubleInt64BoolTwo{}).as<bool>() ==            \
-        (2L op 2L));                                                           \
+        (DoubleInt64Bool(2L) op DoubleInt64BoolTwo{}) == (2L op 2L));          \
     static_assert(                                                             \
-        (DoubleInt64Bool(1L) op DoubleInt64BoolTwo{}).as<bool>() ==            \
-        (1L op 2L));                                                           \
+        (DoubleInt64Bool(1L) op DoubleInt64BoolTwo{}) == (1L op 2L));          \
     static_assert(                                                             \
-        (DoubleInt64Bool(3L) op DoubleInt64BoolTwo{}).as<bool>() ==            \
-        (3L op 2L));                                                           \
+        (DoubleInt64Bool(3L) op DoubleInt64BoolTwo{}) == (3L op 2L));          \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(2L) op DoubleInt64BoolVec(2.0)), (2L op 2.0));     \
     EXPECT_EQ(                                                                 \
-        (DoubleInt64BoolVec(2L) op DoubleInt64BoolVecTwo{}).as<bool>(),        \
-        (2L op 2L));                                                           \
+        (DoubleInt64BoolVec(2L) op DoubleInt64BoolVecTwo{}), (2L op 2L));      \
     EXPECT_EQ(                                                                 \
-        (DoubleInt64BoolVec(1L) op DoubleInt64BoolVecTwo{}).as<bool>(),        \
-        (1L op 2L));                                                           \
+        (DoubleInt64BoolVec(1L) op DoubleInt64BoolVecTwo{}), (1L op 2L));      \
     EXPECT_EQ(                                                                 \
-        (DoubleInt64BoolVec(3L) op DoubleInt64BoolVecTwo{}).as<bool>(),        \
-        (3L op 2L));                                                           \
+        (DoubleInt64BoolVec(3L) op DoubleInt64BoolVecTwo{}), (3L op 2L));      \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(std::vector<int64_t>{2})                           \
              op DoubleInt64BoolVec(std::vector<double>{2.0})),                 \

--- a/lib/dynamic_type/test/binary_ops.cpp
+++ b/lib/dynamic_type/test/binary_ops.cpp
@@ -30,11 +30,17 @@
         opcheck<DoubleInt64BoolVec> op opcheck<DoubleInt64BoolVecTwo>);        \
     static_assert(opcheck<int> op opcheck<DoubleInt64Bool>);                   \
     static_assert(opcheck<int> op opcheck<DoubleInt64BoolVec>);                \
+    static_assert(opcheck<DoubleInt64BoolTwo> op opcheck<DoubleInt64Bool>);    \
+    static_assert(                                                             \
+        opcheck<DoubleInt64BoolVecTwo> op opcheck<DoubleInt64BoolVec>);        \
     static_assert(                                                             \
         (DoubleInt64Bool(2L) op DoubleInt64Bool(2.5))                          \
             .as<decltype(2L op 2.5)>() == (2L op 2.5));                        \
     static_assert(                                                             \
         (DoubleInt64Bool(2L) op DoubleInt64BoolTwo{})                          \
+            .as<decltype(2L op 2L)>() == (2L op 2L));                          \
+    static_assert(                                                             \
+        (DoubleInt64BoolTwo {} op DoubleInt64Bool(2L))                         \
             .as<decltype(2L op 2L)>() == (2L op 2L));                          \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(2L) op DoubleInt64BoolVec(2.5))                    \
@@ -42,6 +48,10 @@
         (2L op 2.5));                                                          \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(2L) op DoubleInt64BoolVecTwo{})                    \
+            .as<decltype(2L op 2L)>(),                                         \
+        (2L op 2L));                                                           \
+    EXPECT_EQ(                                                                 \
+        (DoubleInt64BoolVecTwo {} op DoubleInt64BoolVec(2L))                   \
             .as<decltype(2L op 2L)>(),                                         \
         (2L op 2L));                                                           \
     static_assert(                                                             \
@@ -91,6 +101,9 @@ TEST_BINARY_OP_ALLTYPE(LogicalOr, ||);
         opcheck<DoubleInt64BoolVec> op opcheck<DoubleInt64BoolVecTwo>);        \
     static_assert(opcheck<int> op opcheck<DoubleInt64Bool>);                   \
     static_assert(opcheck<int> op opcheck<DoubleInt64BoolVec>);                \
+    static_assert(opcheck<DoubleInt64BoolTwo> op opcheck<DoubleInt64Bool>);    \
+    static_assert(                                                             \
+        opcheck<DoubleInt64BoolVecTwo> op opcheck<DoubleInt64BoolVec>);        \
     static_assert(                                                             \
         (DoubleInt64Bool(2L) op DoubleInt64Bool(2.0)) == (2L op 2.0));         \
     static_assert(                                                             \
@@ -99,6 +112,12 @@ TEST_BINARY_OP_ALLTYPE(LogicalOr, ||);
         (DoubleInt64Bool(1L) op DoubleInt64BoolTwo{}) == (1L op 2L));          \
     static_assert(                                                             \
         (DoubleInt64Bool(3L) op DoubleInt64BoolTwo{}) == (3L op 2L));          \
+    static_assert(                                                             \
+        (DoubleInt64BoolTwo {} op DoubleInt64Bool(2L)) == (2L op 2L));         \
+    static_assert(                                                             \
+        (DoubleInt64BoolTwo {} op DoubleInt64Bool(1L)) == (2L op 1L));         \
+    static_assert(                                                             \
+        (DoubleInt64BoolTwo {} op DoubleInt64Bool(3L)) == (2L op 3L));         \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(2L) op DoubleInt64BoolVec(2.0)), (2L op 2.0));     \
     EXPECT_EQ(                                                                 \
@@ -107,6 +126,12 @@ TEST_BINARY_OP_ALLTYPE(LogicalOr, ||);
         (DoubleInt64BoolVec(1L) op DoubleInt64BoolVecTwo{}), (1L op 2L));      \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(3L) op DoubleInt64BoolVecTwo{}), (3L op 2L));      \
+    EXPECT_EQ(                                                                 \
+        (DoubleInt64BoolVecTwo {} op DoubleInt64BoolVec(2L)), (2L op 2L));     \
+    EXPECT_EQ(                                                                 \
+        (DoubleInt64BoolVecTwo {} op DoubleInt64BoolVec(1L)), (1L op 2L));     \
+    EXPECT_EQ(                                                                 \
+        (DoubleInt64BoolVecTwo {} op DoubleInt64BoolVec(3L)), (3L op 2L));     \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(std::vector<int64_t>{2})                           \
              op DoubleInt64BoolVec(std::vector<double>{2.0})),                 \
@@ -160,12 +185,18 @@ TEST_COMPARE_OP(Ge, >=);
         opcheck<DoubleInt64BoolVec> op opcheck<DoubleInt64BoolVecTwo>);        \
     static_assert(opcheck<int64_t> op opcheck<DoubleInt64Bool>);               \
     static_assert(opcheck<int64_t> op opcheck<DoubleInt64BoolVec>);            \
+    static_assert(opcheck<DoubleInt64BoolTwo> op opcheck<DoubleInt64Bool>);    \
+    static_assert(                                                             \
+        opcheck<DoubleInt64BoolVecTwo> op opcheck<DoubleInt64BoolVec>);        \
     static_assert(                                                             \
         (DoubleInt64Bool(3L) op DoubleInt64Bool(2L)).as<int64_t>() ==          \
         (3L op 2L));                                                           \
     static_assert(                                                             \
         (DoubleInt64Bool(3L) op DoubleInt64BoolTwo{})                          \
             .as<decltype(3L op 2L)>() == (3L op 2L));                          \
+    static_assert(                                                             \
+        (DoubleInt64BoolTwo {} op DoubleInt64Bool(3L))                         \
+            .as<decltype(2L op 3L)>() == (2L op 3L));                          \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(3L) op DoubleInt64BoolVec(2L)).as<int64_t>(),      \
         (3L op 2L));                                                           \
@@ -173,6 +204,10 @@ TEST_COMPARE_OP(Ge, >=);
         (DoubleInt64BoolVec(3L) op DoubleInt64BoolVecTwo{})                    \
             .as<decltype(3L op 2L)>(),                                         \
         (3L op 2L));                                                           \
+    EXPECT_EQ(                                                                 \
+        (DoubleInt64BoolVecTwo {} op DoubleInt64BoolVec(3L))                   \
+            .as<decltype(2L op 3L)>(),                                         \
+        (2L op 3L));                                                           \
     static_assert((DoubleInt64Bool(3L) op 2L).as<int64_t>() == (3L op 2L));    \
     EXPECT_EQ((DoubleInt64BoolVec(3L) op 2L).as<int64_t>(), (3L op 2L));       \
     static_assert((3L op DoubleInt64Bool(2L)).as<int64_t>() == (3L op 2L));    \

--- a/lib/dynamic_type/test/binary_ops.cpp
+++ b/lib/dynamic_type/test/binary_ops.cpp
@@ -86,12 +86,33 @@ TEST_BINARY_OP_ALLTYPE(LogicalOr, ||);
     static_assert(opcheck<DoubleInt64BoolVec> op opcheck<DoubleInt64BoolVec>); \
     static_assert(opcheck<DoubleInt64Bool> op opcheck<int>);                   \
     static_assert(opcheck<DoubleInt64BoolVec> op opcheck<int>);                \
+    static_assert(opcheck<DoubleInt64Bool> op opcheck<DoubleInt64BoolTwo>);    \
+    static_assert(                                                             \
+        opcheck<DoubleInt64BoolVec> op opcheck<DoubleInt64BoolVecTwo>);        \
     static_assert(opcheck<int> op opcheck<DoubleInt64Bool>);                   \
     static_assert(opcheck<int> op opcheck<DoubleInt64BoolVec>);                \
     static_assert(                                                             \
         (DoubleInt64Bool(2L) op DoubleInt64Bool(2.0)) == (2L op 2.0));         \
+    static_assert(                                                             \
+        (DoubleInt64Bool(2L) op DoubleInt64BoolTwo{}).as<bool>() ==            \
+        (2L op 2L));                                                           \
+    static_assert(                                                             \
+        (DoubleInt64Bool(1L) op DoubleInt64BoolTwo{}).as<bool>() ==            \
+        (1L op 2L));                                                           \
+    static_assert(                                                             \
+        (DoubleInt64Bool(3L) op DoubleInt64BoolTwo{}).as<bool>() ==            \
+        (3L op 2L));                                                           \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(2L) op DoubleInt64BoolVec(2.0)), (2L op 2.0));     \
+    EXPECT_EQ(                                                                 \
+        (DoubleInt64BoolVec(2L) op DoubleInt64BoolVecTwo{}).as<bool>(),        \
+        (2L op 2L));                                                           \
+    EXPECT_EQ(                                                                 \
+        (DoubleInt64BoolVec(1L) op DoubleInt64BoolVecTwo{}).as<bool>(),        \
+        (1L op 2L));                                                           \
+    EXPECT_EQ(                                                                 \
+        (DoubleInt64BoolVec(3L) op DoubleInt64BoolVecTwo{}).as<bool>(),        \
+        (3L op 2L));                                                           \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(std::vector<int64_t>{2})                           \
              op DoubleInt64BoolVec(std::vector<double>{2.0})),                 \
@@ -140,13 +161,23 @@ TEST_COMPARE_OP(Ge, >=);
     static_assert(opcheck<DoubleInt64BoolVec> op opcheck<DoubleInt64BoolVec>); \
     static_assert(opcheck<DoubleInt64Bool> op opcheck<int64_t>);               \
     static_assert(opcheck<DoubleInt64BoolVec> op opcheck<int64_t>);            \
+    static_assert(opcheck<DoubleInt64Bool> op opcheck<DoubleInt64BoolTwo>);    \
+    static_assert(                                                             \
+        opcheck<DoubleInt64BoolVec> op opcheck<DoubleInt64BoolVecTwo>);        \
     static_assert(opcheck<int64_t> op opcheck<DoubleInt64Bool>);               \
     static_assert(opcheck<int64_t> op opcheck<DoubleInt64BoolVec>);            \
     static_assert(                                                             \
         (DoubleInt64Bool(3L) op DoubleInt64Bool(2L)).as<int64_t>() ==          \
         (3L op 2L));                                                           \
+    static_assert(                                                             \
+        (DoubleInt64Bool(3L) op DoubleInt64BoolTwo{})                          \
+            .as<decltype(3L op 2L)>() == (3L op 2L));                          \
     EXPECT_EQ(                                                                 \
         (DoubleInt64BoolVec(3L) op DoubleInt64BoolVec(2L)).as<int64_t>(),      \
+        (3L op 2L));                                                           \
+    EXPECT_EQ(                                                                 \
+        (DoubleInt64BoolVec(3L) op DoubleInt64BoolVecTwo{})                    \
+            .as<decltype(3L op 2L)>(),                                         \
         (3L op 2L));                                                           \
     static_assert((DoubleInt64Bool(3L) op 2L).as<int64_t>() == (3L op 2L));    \
     EXPECT_EQ((DoubleInt64BoolVec(3L) op 2L).as<int64_t>(), (3L op 2L));       \

--- a/lib/dynamic_type/test/opcheck.cpp
+++ b/lib/dynamic_type/test/opcheck.cpp
@@ -188,7 +188,9 @@ static_assert(opcheck<SomeType>.canCastTo(opcheck<SomeType>));
 
 static_assert(!opcheck<float>.hasExplicitCastTo(opcheck<double>));
 struct A {
-  operator int() const { return 0; }
+  operator int() const {
+    return 0;
+  }
 };
 struct B {
   B(const A&) {}

--- a/lib/dynamic_type/test/opcheck.cpp
+++ b/lib/dynamic_type/test/opcheck.cpp
@@ -185,3 +185,13 @@ static_assert(opcheck<int>.canCastTo(opcheck<float>));
 static_assert(!opcheck<SomeType>.canCastTo(opcheck<float>));
 static_assert(!opcheck<float>.canCastTo(opcheck<SomeType>));
 static_assert(opcheck<SomeType>.canCastTo(opcheck<SomeType>));
+
+static_assert(!opcheck<float>.hasExplicitCastTo(opcheck<double>));
+struct A {
+  operator int() const { return 0; }
+};
+struct B {
+  B(const A&) {}
+};
+static_assert(opcheck<A>.hasExplicitCastTo(opcheck<int>));
+static_assert(!opcheck<A>.hasExplicitCastTo(opcheck<B>));

--- a/lib/dynamic_type/test/utils.h
+++ b/lib/dynamic_type/test/utils.h
@@ -27,7 +27,6 @@ struct NonInstantiable {
 using DoubleInt64Bool =
     DynamicType<NoContainers, double, int64_t, bool, NonInstantiable>;
 struct DoubleInt64BoolTwo {
-  constexpr DoubleInt64BoolTwo() = default;
   constexpr operator DoubleInt64Bool() const {
     return {2L};
   }
@@ -41,7 +40,6 @@ using DoubleInt64BoolVec = DynamicType<
     bool,
     NonInstantiable>;
 struct DoubleInt64BoolVecTwo {
-  constexpr DoubleInt64BoolVecTwo() = default;
 #if __cplusplus >= 202002L
   constexpr
 #endif

--- a/lib/dynamic_type/test/utils.h
+++ b/lib/dynamic_type/test/utils.h
@@ -26,6 +26,12 @@ struct NonInstantiable {
 // member types when not necessary.
 using DoubleInt64Bool =
     DynamicType<NoContainers, double, int64_t, bool, NonInstantiable>;
+struct DoubleInt64BoolTwo {
+  constexpr DoubleInt64BoolTwo() = default;
+  constexpr operator DoubleInt64Bool() const {
+    return {2L};
+  }
+};
 // Note: because std::vector does not has trivial destructor, we can not
 // static_assert to test the following class:
 using DoubleInt64BoolVec = DynamicType<
@@ -34,6 +40,15 @@ using DoubleInt64BoolVec = DynamicType<
     int64_t,
     bool,
     NonInstantiable>;
+struct DoubleInt64BoolVecTwo {
+  constexpr DoubleInt64BoolVecTwo() = default;
+#if __cplusplus >= 202002L
+  constexpr
+#endif
+  operator DoubleInt64BoolVec() const {
+    return {2L};
+  }
+};
 using IntSomeType = DynamicType<NoContainers, int, SomeType, NonInstantiable>;
 using BoolSomeType = DynamicType<NoContainers, bool, SomeType, NonInstantiable>;
 using SomeTypes =

--- a/test/test_polymorphic_value.cpp
+++ b/test/test_polymorphic_value.cpp
@@ -125,12 +125,12 @@ TEST_F(PolymorphicValueTest, Struct) {
     PolymorphicValue b = type.create();
     b->*"x" = 2788;
     b->*"y" = 2.71828;
-    EXPECT_EQ((PolymorphicValue)(b->*"x"), 2788);
-    EXPECT_EQ((PolymorphicValue)(b->*"y"), 2.71828);
+    EXPECT_EQ(b->*"x", PolymorphicValue(2788));
+    EXPECT_EQ(b->*"y", PolymorphicValue(2.71828));
     b->*"x" = 299792458;
     b->*"y" = 3.1415926;
-    EXPECT_EQ((PolymorphicValue)(b->*"x"), 299792458);
-    EXPECT_EQ((PolymorphicValue)(b->*"y"), 3.1415926);
+    EXPECT_EQ(b->*"x", PolymorphicValue(299792458));
+    EXPECT_EQ(b->*"y", PolymorphicValue(3.1415926));
 
     EXPECT_EQ(type, (b->*&StructHandle::type)());
   }


### PR DESCRIPTION
`PolymorphicValue->*something` returns an accessor of `PolymorphicValue`, instead of returning just `PolymorphicValue`:
https://github.com/NVIDIA/Fuser/blob/0b85a578d968285f3e430c32de90708cc164bfda/csrc/polymorphic_value.h#L202

 The accessor has defined automatic conversion operator to `PolymorphicValue`, however, that automatic conversion does not work for operators. For example:
```C++
PolymorphicValue x = ...;
PolymorphicValue y = ...;
x + (y->*"field");  // does not compile
```
This behavior does not make sense.

The root cause for this behavior is because, when we have
```C++
template<typename T>
T f(T x, T y) {
  ...
}
```
Then `f(2, 2L)` does not work, because `2` and `2L` are different type, so there is no way for C++ to know whether it should choose `f<int>` or `f<int64_t>`. For this case, automatic type conversion totally fails. The correct way to implement  `f` is to use a non-deductible environment (the `type_identity` trick, see, https://levelup.gitconnected.com/c-templates-type-identity-technique-f2b427759403):
```C++
template<typename T>
T f(T x, std::type_identity_t<T> y) {
  ...
}
```
This way, the type of `y` will not participate in template deduction, and instead, it will be converted to whatever type x has. So `f(2, 2L)` is equivalent to `f<int>(2, 2L)`. Always forcing the dtype of the first arg is not the best behavior, but it does provide what we need: to make accessors behave more like `PolymorphicValue` so it can be more seamlessly used in our codebase. 