### PR TITLE
LoadStoreOp takes a CacheOp. Second try.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,6 +445,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/test/test_pipeline.cpp
     ${NVFUSER_ROOT}/test/test_rng.cpp
     ${NVFUSER_ROOT}/test/test_smem_reuse.cpp
+    ${NVFUSER_ROOT}/test/test_memory.cpp
   )
 
   if(BUILD_PYTHON)

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1353,7 +1353,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           } else if (globalToLocal) {
             indent() << "loadGlobalToLocal<" << ldst->out()->dtype() << ", "
                      << vector_word_size << ", "
-                     << (is_volatile_from ? "true" : "false") << ">(&"
+                     << (is_volatile_from ? "true" : "false") << ", "
+                     << "CacheOp::" << ldst->cacheOp() << ">(&"
                      << gen(ldst->out()) << ", ";
             code_ << " &" << gen(ldst->in()) << ");\n";
           } else if (globalToGlobal) {

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1289,8 +1289,9 @@ void IndexLowering::handle(const LoadStoreOp* ldst) {
       {},
       ir_utils::isLdMatrixOp(ldst) || ir_utils::isCpAsyncOp(ldst));
   const auto out = lowerDstIndex(ldst->out(), {}, ir_utils::isCpAsyncOp(ldst));
-  auto new_ldst = IrBuilder::create<LoadStoreOp>(ldst->opType(), out, in)
-                      ->withPredicate(ldst->predicate());
+  auto new_ldst =
+      IrBuilder::create<LoadStoreOp>(ldst->opType(), out, in, ldst->cacheOp())
+          ->withPredicate(ldst->predicate());
   pushBack(new_ldst);
   GpuLower::current()->propagateExprInfo(ldst, back());
 }

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -575,7 +575,7 @@ class ReplaceExprInput : private kir::ExprMutator {
     auto replaced_inputs = getMaybeInputReplacementMap(node);
     if (replaced_inputs.has_value()) {
       auto replacement = IrBuilder::create<LoadStoreOp>(
-          node->opType(), node->out(), node->in());
+          node->opType(), node->out(), node->in(), node->cacheOp());
       registerReplaceWithPredicate(node, replacement);
     }
   }

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -416,8 +416,6 @@ void FusionExecutor::compileFusion(
       compile_params,
       block_size,
       save_compiled_binary_ || isDebugDumpEnabled(DebugDumpOption::Sass));
-  std::cerr << "[jingyue] ptx size = " << compiled_kernel_.ptx.size() << std::endl;
-  std::cerr << "[jingyue] cubin size = " << compiled_kernel_.cubin.size() << std::endl;
   NVF_ERROR(fusion_id_ > 0, "failed to assign a fusion_id_ after compilation.");
 
   // These should be nullopt at this point, but reset just in case

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -416,6 +416,8 @@ void FusionExecutor::compileFusion(
       compile_params,
       block_size,
       save_compiled_binary_ || isDebugDumpEnabled(DebugDumpOption::Sass));
+  std::cerr << "[jingyue] ptx size = " << compiled_kernel_.ptx.size() << std::endl;
+  std::cerr << "[jingyue] cubin size = " << compiled_kernel_.cubin.size() << std::endl;
   NVF_ERROR(fusion_id_ > 0, "failed to assign a fusion_id_ after compilation.");
 
   // These should be nullopt at this point, but reset just in case

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -226,13 +226,8 @@ void FusionExecutor::debugCompileFusionFromStr(
         "The static shared memory allocation is larger than available memory.");
   }
 
-  // TODO: store compiled_kernel directly.
-  executor_utils::CompiledKernel compiled_kernel =
+  compiled_kernel_ =
       executor_utils::getCompiledKernel(std::nullopt, code, name, fusion_id_);
-  compiled_kernel_ = compiled_kernel.nvrtc_func;
-  last_compiler_log_ = compiled_kernel.compile_log;
-  last_compiled_binary_ =
-      compiled_kernel.ptx.empty() ? compiled_kernel.cubin : compiled_kernel.ptx;
   NVF_ERROR(fusion_id_ > 0, "assign a fusion_id_ <= 0 is not accepted.");
 }
 
@@ -413,19 +408,14 @@ void FusionExecutor::compileFusion(
       (block_size.has_value() ? block_size.value() : 1),
       block_size_high_water_mark_);
   maxrregcount_high_water_mark_ = compile_params.maxrregcount;
-  executor_utils::CompiledKernel compiled_kernel =
-      executor_utils::getCompiledKernel(
-          kernel_code_,
-          structured_code,
-          getCanonicalKernelName(),
-          fusion_id_,
-          compile_params,
-          block_size,
-          save_compiled_binary_ || isDebugDumpEnabled(DebugDumpOption::Sass));
-  compiled_kernel_ = compiled_kernel.nvrtc_func;
-  last_compiler_log_ = compiled_kernel.compile_log;
-  last_compiled_binary_ =
-      compiled_kernel.ptx.empty() ? compiled_kernel.cubin : compiled_kernel.ptx;
+  compiled_kernel_ = executor_utils::getCompiledKernel(
+      kernel_code_,
+      structured_code,
+      getCanonicalKernelName(),
+      fusion_id_,
+      compile_params,
+      block_size,
+      save_compiled_binary_ || isDebugDumpEnabled(DebugDumpOption::Sass));
   NVF_ERROR(fusion_id_ > 0, "failed to assign a fusion_id_ after compilation.");
 
   // These should be nullopt at this point, but reset just in case
@@ -1530,19 +1520,14 @@ void FusionExecutor::recompileKernel(
   block_size_high_water_mark_ = new_launch_params.nThreads();
   maxrregcount_high_water_mark_ = new_compile_params.maxrregcount;
 
-  executor_utils::CompiledKernel compiled_kernel =
-      executor_utils::getCompiledKernel(
-          kernel_code_,
-          structured_code,
-          getCanonicalKernelName(),
-          fusion_id_,
-          new_compile_params,
-          block_size_high_water_mark_,
-          save_compiled_binary_);
-  compiled_kernel_ = compiled_kernel.nvrtc_func;
-  last_compiler_log_ = compiled_kernel.compile_log;
-  last_compiled_binary_ =
-      compiled_kernel.ptx.empty() ? compiled_kernel.cubin : compiled_kernel.ptx;
+  compiled_kernel_ = executor_utils::getCompiledKernel(
+      kernel_code_,
+      structured_code,
+      getCanonicalKernelName(),
+      fusion_id_,
+      new_compile_params,
+      block_size_high_water_mark_,
+      save_compiled_binary_);
 
   resetCompiledKernelProperties();
 
@@ -1896,12 +1881,8 @@ void FusionExecutor::compileRtc(
   }
   fusion_id_ = 1;
 
-  executor_utils::CompiledKernel compiled_kernel =
+  compiled_kernel_ =
       executor_utils::getCompiledKernel(std::nullopt, scode, name, fusion_id_);
-  compiled_kernel_ = compiled_kernel.nvrtc_func;
-  last_compiler_log_ = compiled_kernel.compile_log;
-  last_compiled_binary_ =
-      compiled_kernel.ptx.empty() ? compiled_kernel.cubin : compiled_kernel.ptx;
 }
 
 float FusionExecutor::runRtc(
@@ -2116,19 +2097,14 @@ void FusionExecutor::deserialize(
         deserialize(buffer->executor_entry_lookup_values()->Get(idx)));
   }
 
-  executor_utils::CompiledKernel compiled_kernel =
-      executor_utils::getCompiledKernel(
-          kernel_code_,
-          getStructuredCode(),
-          getCanonicalKernelName(),
-          fusion_id_,
-          compile_params,
-          block_size_high_water_mark_,
-          save_compiled_binary_);
-  compiled_kernel_ = compiled_kernel.nvrtc_func;
-  last_compiler_log_ = compiled_kernel.compile_log;
-  last_compiled_binary_ =
-      compiled_kernel.ptx.empty() ? compiled_kernel.cubin : compiled_kernel.ptx;
+  compiled_kernel_ = executor_utils::getCompiledKernel(
+      kernel_code_,
+      getStructuredCode(),
+      getCanonicalKernelName(),
+      fusion_id_,
+      compile_params,
+      block_size_high_water_mark_,
+      save_compiled_binary_);
 
   NVF_ERROR(isCompiled(), "Failed to deserialize FusionExecutor");
 }

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -196,14 +196,9 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
 
   std::string getStructuredCode() const;
 
-  //! Returns the latest compile log
-  std::string compilerLog() const {
-    return compiled_kernel_.compile_log;
-  }
-
-  //! Returns the latest compiled PTX.
-  std::vector<char> compiledPtx() const {
-    return compiled_kernel_.ptx;
+  //! Returns a const reference to the latest compiled kernel.
+  const executor_utils::CompiledKernel& compiledKernel() const {
+    return compiled_kernel_;
   }
 
   //! Returns the disassembled latest compiled binary

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -198,24 +198,24 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
 
   //! Returns the latest compile log
   std::string compilerLog() const {
-    return last_compiler_log_;
+    return compiled_kernel_.compile_log;
   }
 
-  //! Returns the latest compiled binary
-  std::vector<char> compiledBinary() const {
-    return last_compiled_binary_;
+  //! Returns the latest compiled PTX.
+  std::vector<char> compiledPtx() const {
+    return compiled_kernel_.ptx;
   }
 
   //! Returns the disassembled latest compiled binary
   std::string disassembledBinary(const std::string& nvdisasm_args = "") const {
     return executor_utils::disassembleBinary(
-        last_compiled_binary_, nvdisasm_args);
+        compiled_kernel_.cubin, nvdisasm_args);
   }
 
   //! Returns the disassembled latest compiled binary
   std::string disassembledKernelSASS() const {
     return executor_utils::disassembleBinary(
-        last_compiled_binary_, "-fun 1 -c");
+        compiled_kernel_.cubin, "-fun 1 -c");
   }
 
   std::string getCanonicalKernelName() const {
@@ -382,7 +382,7 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
   const int64_t max_static_smem_ = 48 << 10;
 
   int64_t warp_size_ = 0;
-  executor_utils::NvrtcFunction compiled_kernel_;
+  executor_utils::CompiledKernel compiled_kernel_;
 
   // TensorViews actually used in the kernel.
   std::vector<TensorView*> used_tvs_;
@@ -439,14 +439,8 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
   // Profiling support: kept copy of the cuda kernel
   std::string kernel_code_;
 
-  // Profiling support: nvrtc log for debugging
-  std::string last_compiler_log_;
-
   // save compiled binary
   bool save_compiled_binary_ = false;
-
-  // nvrtc compiled binary
-  std::vector<char> last_compiled_binary_;
 };
 
 } // namespace nvfuser

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -1142,16 +1142,14 @@ CompiledKernel compileSource(
   if (compile_to_sass) {
     compiled_kernel.cubin = nvrtcGetCode(program, /*compile_to_sass=*/true);
     if (isDebugDumpEnabled(DebugDumpOption::Cubin)) {
-      dumpCompiledCodeToFile(
-          compiled_kernel.cubin, id, /*dump_cubin=*/true);
+      dumpCompiledCodeToFile(compiled_kernel.cubin, id, /*dump_cubin=*/true);
     }
   }
 
   if (!compile_to_sass || isDebugDumpEnabled(DebugDumpOption::Ptx)) {
     compiled_kernel.ptx = nvrtcGetCode(program, /*compile_to_sass=*/false);
     if (isDebugDumpEnabled(DebugDumpOption::Ptx)) {
-      dumpCompiledCodeToFile(
-          compiled_kernel.ptx, id, /*dump_cubin=*/false);
+      dumpCompiledCodeToFile(compiled_kernel.ptx, id, /*dump_cubin=*/false);
     }
   }
 

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -762,7 +762,7 @@ std::vector<char> nvrtcGetCode(
   return code;
 }
 
-void dumpCompiledCodeToFile(
+std::string dumpCompiledCodeToFile(
     const std::vector<char>& code,
     int64_t fusion_id,
     bool dump_cubin) {
@@ -774,6 +774,7 @@ void dumpCompiledCodeToFile(
   NVF_ERROR(out.is_open());
   out.write(code.data(), (std::streamsize)code.size());
   out.close();
+  return file_name.str();
 }
 
 // Get the max register count passed as -maxrregcount ptxas
@@ -1142,14 +1143,16 @@ CompiledKernel compileSource(
   if (compile_to_sass) {
     compiled_kernel.cubin = nvrtcGetCode(program, /*compile_to_sass=*/true);
     if (isDebugDumpEnabled(DebugDumpOption::Cubin)) {
-      dumpCompiledCodeToFile(compiled_kernel.cubin, id, /*dump_cubin=*/true);
+      compiled_kernel.cubin_filename = dumpCompiledCodeToFile(
+          compiled_kernel.cubin, id, /*dump_cubin=*/true);
     }
   }
 
   if (!compile_to_sass || isDebugDumpEnabled(DebugDumpOption::Ptx)) {
     compiled_kernel.ptx = nvrtcGetCode(program, /*compile_to_sass=*/false);
     if (isDebugDumpEnabled(DebugDumpOption::Ptx)) {
-      dumpCompiledCodeToFile(compiled_kernel.ptx, id, /*dump_cubin=*/false);
+      compiled_kernel.ptx_filename =
+          dumpCompiledCodeToFile(compiled_kernel.ptx, id, /*dump_cubin=*/false);
     }
   }
 

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -1258,7 +1258,7 @@ CompiledKernel getCompiledKernel(
   }
 
   log << module_load_driver.invoke(
-             compiled_kernel.nvrtc_func.module,
+             compiled_kernel.module,
              (compile_to_sass ? compiled_kernel.cubin.data()
                               : compiled_kernel.ptx.data()))
       << std::endl;
@@ -1270,8 +1270,8 @@ CompiledKernel getCompiledKernel(
   }
 
   NVFUSER_CUDA_SAFE_CALL(cuModuleGetFunction(
-      &(compiled_kernel.nvrtc_func.function),
-      compiled_kernel.nvrtc_func.module,
+      &(compiled_kernel.function),
+      compiled_kernel.module,
       compiled_kernel.kernel_name.c_str()));
 
   if (!return_compiled_binary) {

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -1262,10 +1262,11 @@ CompiledKernel getCompiledKernel(
              (compile_to_sass ? compiled_kernel.cubin.data()
                               : compiled_kernel.ptx.data()))
       << std::endl;
+  compiled_kernel.compile_log = log.str();
 
   if (isOptionEnabled(EnableOption::WarnRegisterSpill) ||
       compile_params.enable_ptxas_verbose) {
-    warnRegisterSpill(log.str());
+    warnRegisterSpill(compiled_kernel.compile_log);
   }
 
   NVFUSER_CUDA_SAFE_CALL(cuModuleGetFunction(

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -1257,7 +1257,6 @@ CompiledKernel getCompiledKernel(
     }
   }
 
-  NvrtcFunction compiled_function;
   log << module_load_driver.invoke(
              compiled_kernel.nvrtc_func.module,
              (compile_to_sass ? compiled_kernel.cubin.data()

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -48,8 +48,16 @@ struct NvrtcFunction {
   CUfunction function = nullptr;
 };
 
+struct CompiledKernel {
+  NvrtcFunction nvrtc_func;
+  std::string compile_log;
+  std::vector<char> ptx;
+  std::vector<char> cubin;
+  std::string kernel_name;
+};
+
 // Returns executable function and the ptxas log from compilation
-std::tuple<NvrtcFunction, std::string, std::vector<char>> getCompiledKernel(
+CompiledKernel getCompiledKernel(
     std::optional<std::reference_wrapper<const std::string>> kernel_code,
     const std::string& code,
     const std::string& func_name,

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -48,7 +48,9 @@ struct CompiledKernel {
   CUfunction function = nullptr;
   std::string compile_log;
   std::vector<char> ptx;
+  std::string ptx_filename;
   std::vector<char> cubin;
+  std::string cubin_filename;
   std::string kernel_name;
 };
 

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -43,13 +43,9 @@ std::string disassembleBinary(
     const std::vector<char>& cubin,
     const std::string& nvdisasm_args);
 
-struct NvrtcFunction {
+struct CompiledKernel {
   CUmodule module = nullptr;
   CUfunction function = nullptr;
-};
-
-struct CompiledKernel {
-  NvrtcFunction nvrtc_func;
   std::string compile_log;
   std::vector<char> ptx;
   std::vector<char> cubin;

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1601,7 +1601,12 @@ class TORCH_CUDA_CU_API LoadStoreOp : public Expr {
  public:
   using Expr::Expr;
 
-  LoadStoreOp(IrBuilderPasskey, LoadStoreOpType op_type, Val* out, Val* in);
+  LoadStoreOp(
+      IrBuilderPasskey,
+      LoadStoreOpType op_type,
+      Val* out,
+      Val* in,
+      CacheOp cache_op = CacheOp::Streaming);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
@@ -1626,6 +1631,10 @@ class TORCH_CUDA_CU_API LoadStoreOp : public Expr {
 
   LoadStoreOpType opType() const {
     return attribute<LoadStoreOpType>(0);
+  }
+
+  CacheOp cacheOp() const {
+    return attribute<CacheOp>(1);
   }
 
   bool hasInnerTranspose() const;

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2244,11 +2244,13 @@ LoadStoreOp::LoadStoreOp(
     IrBuilderPasskey passkey,
     LoadStoreOpType op_type,
     Val* out,
-    Val* in)
+    Val* in,
+    CacheOp cache_op)
     : Expr(passkey) {
   addOutput(out);
   addInput(in);
   addDataAttribute(op_type);
+  addDataAttribute(cache_op);
 }
 
 std::vector<PolymorphicValue> LoadStoreOp::evaluate(

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -1016,7 +1016,8 @@ std::vector<at::Tensor> FusionKernelRuntime::runKernelWithInput(
     for (auto i : c10::irange(args.size())) {
       debug() << "  " << args[i] << std::endl;
     }
-    debug() << "Compiler log: " << executor.compilerLog() << "\n";
+    debug() << "Compiler log: " << executor.compiledKernel().compile_log
+            << "\n";
     debug() << scheduler_entry->params()->toString() << "\n";
     debug() << "With arguments: " << executor.lastLaunchParams().toString();
     debug() << executor.kernelName() << " " << executor.bytesProcessed()

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1140,6 +1140,21 @@ std::ostream& operator<<(std::ostream& os, const KernelIndexMode& index_mode) {
   return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const CacheOp& cache_op) {
+  switch (cache_op) {
+    case CacheOp::AllLevels:
+      os << "AllLevels";
+      break;
+    case CacheOp::Streaming:
+      os << "Streaming";
+      break;
+    default:
+      NVF_ERROR(false, "undefined cache operator");
+      break;
+  }
+  return os;
+}
+
 std::optional<std::string> inline_op_str(const UnaryOpType uotype) {
   const char* str = unary_op_type_inline_op2string(uotype);
   return str != nullptr ? std::optional<std::string>(std::string(str))

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -713,6 +713,15 @@ static constexpr std::array<IdMappingMode, 6> kIdMappingModes = {
     IdMappingMode::PERMISSIVE_RESIZE,
     IdMappingMode::INNERMOST};
 
+// See
+// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#cache-operators
+// for what each option means. Will also consider .L1::no_allocate because .cs
+// still pollutes cache to some extent.
+enum class CacheOp {
+  AllLevels,
+  Streaming,
+};
+
 //! Used to annotate the special memory intrinsics that a loadstore op will be
 //!  lowered to.
 //!
@@ -880,6 +889,7 @@ TORCH_CUDA_CU_API std::ostream& operator<<(std::ostream&, const SwizzleMode&);
 TORCH_CUDA_CU_API std::ostream& operator<<(
     std::ostream&,
     const KernelIndexMode&);
+TORCH_CUDA_CU_API std::ostream& operator<<(std::ostream&, const CacheOp&);
 
 std::string stringifyThreadSize(const ParallelType);
 std::string stringifyThread(const ParallelType);

--- a/runtime/array.cu
+++ b/runtime/array.cu
@@ -170,7 +170,16 @@ __device__ void loadLocalToGlobal(
   }
 }
 
-template <typename scalar_t, int vec_size, bool is_volatile>
+// This is copied from csrc/type.h and should be kept consistent.
+enum class CacheOp {
+  AllLevels,
+  Streaming,
+};
+
+// For simplicity, cache_op is only used for non-volatile loads written in
+// inline assembly. Other loads are done with the default cache operator --
+// cache all levels. ld.volatile doesn't accept cache operator anyway.
+template <typename scalar_t, int vec_size, bool is_volatile, CacheOp cache_op>
 __device__ void loadGlobalToLocal(
     scalar_t* to,
     typename MaybeVolatile<scalar_t, is_volatile>::type* from) {
@@ -189,9 +198,18 @@ __device__ void loadGlobalToLocal(
         break;
       } else {
         uint2& data = *reinterpret_cast<uint2*>(to);
-        asm volatile("ld.global.cs.v2.s32 {%0,%1}, [%2];"
-                     : "=r"(data.x), "=r"(data.y)
-                     : "l"((uint2*)from));
+        switch (cache_op) {
+          case CacheOp::AllLevels:
+            asm volatile("ld.global.ca.v2.s32 {%0,%1}, [%2];"
+                         : "=r"(data.x), "=r"(data.y)
+                         : "l"((uint2*)from));
+            break;
+          case CacheOp::Streaming:
+            asm volatile("ld.global.cs.v2.s32 {%0,%1}, [%2];"
+                         : "=r"(data.x), "=r"(data.y)
+                         : "l"((uint2*)from));
+            break;
+        }
       }
       break;
     }
@@ -203,9 +221,20 @@ __device__ void loadGlobalToLocal(
                      : "l"((uint4*)from));
       } else {
         uint4& data = *reinterpret_cast<uint4*>(to);
-        asm volatile("ld.global.cs.v4.s32 {%0,%1,%2,%3}, [%4];"
-                     : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
-                     : "l"((uint4*)from));
+        switch (cache_op) {
+          case CacheOp::AllLevels:
+            asm volatile(
+                "ld.global.ca.v4.s32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
+                : "l"((uint4*)from));
+            break;
+          case CacheOp::Streaming:
+            asm volatile(
+                "ld.global.cs.v4.s32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
+                : "l"((uint4*)from));
+            break;
+        }
       }
       break;
     }
@@ -232,7 +261,11 @@ __device__ void loadGlobalToGlobal(
       break;
     case 12: {
       uint3 local_intermediate;
-      loadGlobalToLocal<scalar_t, vec_size, is_volatile_from>(
+      loadGlobalToLocal<
+          scalar_t,
+          vec_size,
+          is_volatile_from,
+          CacheOp::Streaming>(
           reinterpret_cast<scalar_t*>(&local_intermediate), from);
       loadLocalToGlobal<scalar_t, vec_size, is_volatile_to>(
           to, reinterpret_cast<scalar_t*>(&local_intermediate));
@@ -240,7 +273,11 @@ __device__ void loadGlobalToGlobal(
     }
     case 16: {
       uint4 local_intermediate;
-      loadGlobalToLocal<scalar_t, vec_size, is_volatile_from>(
+      loadGlobalToLocal<
+          scalar_t,
+          vec_size,
+          is_volatile_from,
+          CacheOp::Streaming>(
           reinterpret_cast<scalar_t*>(&local_intermediate), from);
       loadLocalToGlobal<scalar_t, vec_size, is_volatile_to>(
           to, reinterpret_cast<scalar_t*>(&local_intermediate));

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -16,6 +16,7 @@
 #include <ops/alias.h>
 #include <ops/arith.h>
 #include <ops/utils.h>
+#include <options.h>
 #include <test/utils.h>
 #include <test/validator.h>
 #include <type.h>
@@ -57,7 +58,11 @@ TEST_F(MemoryTest, LoadCache) {
 
   FusionExecutor fe;
   fe.setSaveCompiledBinaryFlag(true);
-  fe.compileFusion(&fusion, {input});
+  {
+    DebugDumpOptionsGuard debug_dump_options_guard;
+    DebugDumpOptionsGuard::getCurOptions().set(DebugDumpOption::Ptx);
+    fe.compileFusion(&fusion, {input});
+  }
   std::vector<char> compiled_ptx = fe.compiledPtx();
   std::string ptx(compiled_ptx.begin(), compiled_ptx.end());
 

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -1,0 +1,74 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <regex>
+
+#include <fusion.h>
+#include <inlining.h>
+#include <ir/utils.h>
+#include <ops/alias.h>
+#include <ops/arith.h>
+#include <ops/utils.h>
+#include <test/utils.h>
+#include <test/validator.h>
+#include <type.h>
+
+namespace nvfuser {
+
+class MemoryTest : public NVFuserTest {};
+
+TEST_F(MemoryTest, LoadCache) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeContigTensor(1);
+  fusion.addInput(tv0);
+  TensorView* tv1 =
+      ops::newValLike(tv0, tv0->getDataType().value())->as<TensorView>();
+  IrBuilder::create<LoadStoreOp>(
+      LoadStoreOpType::Set, tv1, tv0, CacheOp::AllLevels);
+  TensorView* tv2 = add(tv1, IrBuilder::create<Val>(1.0));
+  TensorView* tv3 = set(tv2);
+  fusion.addOutput(tv3);
+
+  tv1->split(0, 4);
+  tv1->split(0, 32);
+  TransformPropagatorWithCheck propagator(tv1);
+  MaxRootDomainInfoSpanningTree(tv1).traverse(&propagator);
+
+  // Parallelize LoadStoreOps. Other TensorViews don't support vectorization.
+  tv1->axis(0)->parallelize(ParallelType::BIDx);
+  tv1->axis(1)->parallelize(ParallelType::TIDx);
+  tv1->axis(2)->parallelize(ParallelType::Vectorize);
+  scheduler_utils::parallelizeAllLike(tv1, {tv3});
+
+  inlineMost();
+
+  at::Tensor input = at::randn(
+      {1024}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+  at::Tensor expected_output = input + 1.0f;
+
+  FusionExecutor fe;
+  fe.setSaveCompiledBinaryFlag(true);
+  fe.compileFusion(&fusion, {input});
+  std::vector<char> compiled_ptx = fe.compiledPtx();
+  std::string ptx(compiled_ptx.begin(), compiled_ptx.end());
+
+  std::regex regex(R"(ld\.global\.ca\.\S+)");
+  std::smatch match;
+  std::regex_search(ptx, match, regex);
+  EXPECT_EQ(match.size(), 1);
+
+  std::vector<at::Tensor> actual_ts = fe.runFusion({input});
+  testValidate(
+      &fusion, actual_ts, {input}, {expected_output}, __LINE__, __FILE__);
+}
+
+} // namespace nvfuser

--- a/test/test_pipeline.cpp
+++ b/test/test_pipeline.cpp
@@ -81,7 +81,7 @@ TEST_F(NVFuserTest, Pipeline_CUDA) {
       " PipelineVal representing Val T0_g[ iS0{i0}, iS1{i2} ] on stage " +
       std::to_string(stage0.unique_id) +
       "\n"
-      " PipelineVal representing Val T4_g[ iS6{i12}, iS7{i13}, iS8{i14} ] on stage " +
+      " PipelineVal representing Val T4_g[ iS6{i13}, iS7{i14}, iS8{i15} ] on stage " +
       std::to_string(stage2.unique_id) +
       "\n"
       "}\n"
@@ -105,88 +105,88 @@ TEST_F(NVFuserTest, Pipeline_CUDA) {
       ".Inputs={T2_l[ iS4{i2} ], }. Outputs={T3_g[ rS5{i2} ], }.\n"
       "  PipelineStage representing Stage " +
       std::to_string(stage2.unique_id) +
-      ".Inputs={T4_g[ iS6{i12}, iS7{i13}, iS8{i14} ], }. Outputs={T5_l[ rS9{i12}, iS10{i13}, iS11{i14} ], }.\n"
-      "  PipelineVal representing Val T5_l[ rS9{i12}, iS10{i13}, iS11{i14} ] on stage " +
+      ".Inputs={T4_g[ iS6{i13}, iS7{i14}, iS8{i15} ], }. Outputs={T5_l[ rS9{i13}, iS10{i14}, iS11{i15} ], }.\n"
+      "  PipelineVal representing Val T5_l[ rS9{i13}, iS10{i14}, iS11{i15} ] on stage " +
       std::to_string(stage2.unique_id) +
       "\n"
-      "  PipelineCommunication that transfers PipelineVal representing Val T5_l[ rS9{i12}, iS10{i13}, iS11{i14} ] on stage " +
+      "  PipelineCommunication that transfers PipelineVal representing Val T5_l[ rS9{i13}, iS10{i14}, iS11{i15} ] on stage " +
       std::to_string(stage2.unique_id) +
-      " to PipelineVal representing Val T6_l[ iS12{i13}, iS13{i14} ] on stage " +
+      " to PipelineVal representing Val T6_l[ iS12{i14}, iS13{i15} ] on stage " +
       std::to_string(stage3.unique_id) +
       "\n"
-      "  PipelineVal representing Val T6_l[ iS12{i13}, iS13{i14} ] on stage " +
+      "  PipelineVal representing Val T6_l[ iS12{i14}, iS13{i15} ] on stage " +
       std::to_string(stage3.unique_id) +
       "\n"
       "  PipelineStage representing Stage " +
       std::to_string(stage3.unique_id) +
-      ".Inputs={T6_l[ iS12{i13}, iS13{i14} ], }. Outputs={T7_l[ iS14{i13}, iS15{i14} ], T8_l[ rS16{i13}, iS17{i14} ], }.\n"
-      "  PipelineVal representing Val T7_l[ iS14{i13}, iS15{i14} ] on stage " +
+      ".Inputs={T6_l[ iS12{i14}, iS13{i15} ], }. Outputs={T7_l[ iS14{i14}, iS15{i15} ], T8_l[ rS16{i14}, iS17{i15} ], }.\n"
+      "  PipelineVal representing Val T7_l[ iS14{i14}, iS15{i15} ] on stage " +
       std::to_string(stage3.unique_id) +
       "\n"
-      "  PipelineCommunication that transfers PipelineVal representing Val T7_l[ iS14{i13}, iS15{i14} ] on stage " +
+      "  PipelineCommunication that transfers PipelineVal representing Val T7_l[ iS14{i14}, iS15{i15} ] on stage " +
       std::to_string(stage3.unique_id) +
-      " to PipelineVal representing Val T12_l[ iS24{i13}, iS25{i14} ] on stage " +
+      " to PipelineVal representing Val T12_l[ iS24{i14}, iS25{i15} ] on stage " +
       std::to_string(stage5.unique_id) +
       "\n"
-      "  PipelineVal representing Val T12_l[ iS24{i13}, iS25{i14} ] on stage " +
+      "  PipelineVal representing Val T12_l[ iS24{i14}, iS25{i15} ] on stage " +
       std::to_string(stage5.unique_id) +
       "\n"
       "  PipelineStage representing Stage " +
       std::to_string(stage5.unique_id) +
-      ".Inputs={T12_l[ iS24{i13}, iS25{i14} ], }. Outputs={T13_g[ rS26{i13}, iS27{i14} ], }.\n"
-      "  PipelineVal representing Val T8_l[ rS16{i13}, iS17{i14} ] on stage " +
+      ".Inputs={T12_l[ iS24{i14}, iS25{i15} ], }. Outputs={T13_g[ rS26{i14}, iS27{i15} ], }.\n"
+      "  PipelineVal representing Val T8_l[ rS16{i14}, iS17{i15} ] on stage " +
       std::to_string(stage3.unique_id) +
       "\n"
-      "  PipelineCommunication that transfers PipelineVal representing Val T8_l[ rS16{i13}, iS17{i14} ] on stage " +
+      "  PipelineCommunication that transfers PipelineVal representing Val T8_l[ rS16{i14}, iS17{i15} ] on stage " +
       std::to_string(stage3.unique_id) +
-      " to PipelineVal representing Val T14_l[ iS28{i14} ] on stage " +
+      " to PipelineVal representing Val T14_l[ iS28{i15} ] on stage " +
       std::to_string(stage6.unique_id) +
       "\n"
-      "  PipelineVal representing Val T14_l[ iS28{i14} ] on stage " +
+      "  PipelineVal representing Val T14_l[ iS28{i15} ] on stage " +
       std::to_string(stage6.unique_id) +
       "\n"
-      "  PipelineCommunication that transfers PipelineVal representing Val T5_l[ rS9{i12}, iS10{i13}, iS11{i14} ] on stage " +
+      "  PipelineCommunication that transfers PipelineVal representing Val T5_l[ rS9{i13}, iS10{i14}, iS11{i15} ] on stage " +
       std::to_string(stage2.unique_id) +
-      " to PipelineVal representing Val T9_l[ iS18{i13}, iS19{i14} ] on stage " +
+      " to PipelineVal representing Val T9_l[ iS18{i14}, iS19{i15} ] on stage " +
       std::to_string(stage4.unique_id) +
       "\n"
-      "  PipelineVal representing Val T9_l[ iS18{i13}, iS19{i14} ] on stage " +
+      "  PipelineVal representing Val T9_l[ iS18{i14}, iS19{i15} ] on stage " +
       std::to_string(stage4.unique_id) +
       "\n"
       "  PipelineStage representing Stage " +
       std::to_string(stage4.unique_id) +
-      ".Inputs={T9_l[ iS18{i13}, iS19{i14} ], }. Outputs={T11_l[ rS22{i13}, iS23{i14} ], }.\n"
-      "  PipelineVal representing Val T11_l[ rS22{i13}, iS23{i14} ] on stage " +
+      ".Inputs={T9_l[ iS18{i14}, iS19{i15} ], }. Outputs={T11_l[ rS22{i14}, iS23{i15} ], }.\n"
+      "  PipelineVal representing Val T11_l[ rS22{i14}, iS23{i15} ] on stage " +
       std::to_string(stage4.unique_id) +
       "\n"
-      "  PipelineCommunication that transfers PipelineVal representing Val T11_l[ rS22{i13}, iS23{i14} ] on stage " +
+      "  PipelineCommunication that transfers PipelineVal representing Val T11_l[ rS22{i14}, iS23{i15} ] on stage " +
       std::to_string(stage4.unique_id) +
-      " to PipelineVal representing Val T15_l[ iS29{i14} ] on stage " +
+      " to PipelineVal representing Val T15_l[ iS29{i15} ] on stage " +
       std::to_string(stage6.unique_id) +
       "\n"
-      "  PipelineVal representing Val T15_l[ iS29{i14} ] on stage " +
+      "  PipelineVal representing Val T15_l[ iS29{i15} ] on stage " +
       std::to_string(stage6.unique_id) +
       "\n"
-      "  PipelineCommunication that transfers PipelineVal representing Val T13_g[ rS26{i13}, iS27{i14} ] on stage " +
+      "  PipelineCommunication that transfers PipelineVal representing Val T13_g[ rS26{i14}, iS27{i15} ] on stage " +
       std::to_string(stage5.unique_id) +
-      " to PipelineVal representing Val T16_l[ iS30{i14} ] on stage " +
+      " to PipelineVal representing Val T16_l[ iS30{i15} ] on stage " +
       std::to_string(stage6.unique_id) +
       "\n"
-      "  PipelineVal representing Val T16_l[ iS30{i14} ] on stage " +
+      "  PipelineVal representing Val T16_l[ iS30{i15} ] on stage " +
       std::to_string(stage6.unique_id) +
       "\n"
       "  PipelineStage representing Stage " +
       std::to_string(stage6.unique_id) +
-      ".Inputs={T14_l[ iS28{i14} ], T15_l[ iS29{i14} ], T16_l[ iS30{i14} ], }. Outputs={T19_g[ rS33{i14} ], }.\n"
+      ".Inputs={T14_l[ iS28{i15} ], T15_l[ iS29{i15} ], T16_l[ iS30{i15} ], }. Outputs={T19_g[ rS33{i15} ], }.\n"
       "}\n"
       "Pipeline's outputs:{\n"
       " PipelineVal representing Val T3_g[ rS5{i2} ] on stage " +
       std::to_string(stage1.unique_id) +
       "\n"
-      " PipelineVal representing Val T13_g[ rS26{i13}, iS27{i14} ] on stage " +
+      " PipelineVal representing Val T13_g[ rS26{i14}, iS27{i15} ] on stage " +
       std::to_string(stage5.unique_id) +
       "\n"
-      " PipelineVal representing Val T19_g[ rS33{i14} ] on stage " +
+      " PipelineVal representing Val T19_g[ rS33{i15} ] on stage " +
       std::to_string(stage6.unique_id) +
       "\n"
       "}"};


### PR DESCRIPTION
This reverts commit b3edc818037a48624caa94d096ef3ed903bbe5bc and modifies `compileSource` to decouple `compile_to_sass` and `DebugDumpOption::Ptx`. With this PR, `compileSource` performs a regular compilation according to `compile_to_sass` and if PTX is requested runs another `nvrtcGetProgram` just to get PTX. Other parts of the PR is identical to #843 except that `test_memory.cpp` now requests PTX by enabling `DebugDumpOption::Ptx`. 