### PR TITLE
`Expr::evaluate` method for `CatOp` and `SliceOp`

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2071,6 +2071,9 @@ class SliceOp : public Expr {
 
   std::string toString(int indent_size = 0) const override;
   std::string toInlineString(int indent_size = 0) const override;
+  std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
+      const std::vector<PolymorphicValue>& inputs) const override;
 
   Val* out() const {
     return output(0);
@@ -2127,6 +2130,9 @@ class CatOp : public Expr {
 
   std::string toString(int indent_size = 0) const override;
   std::string toInlineString(int indent_size = 0) const override;
+  std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
+      const std::vector<PolymorphicValue>& inputs) const override;
 
   int64_t concatenatedDim() const {
     return attribute<int64_t>(0);

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4071,7 +4071,7 @@ std::vector<PolymorphicValue> SliceOp::evaluate(
     auto start = (int64_t)inputs.at(ranges_offset + 3 * i);
     auto stop = (int64_t)inputs.at(ranges_offset + 3 * i + 1);
     auto step = (int64_t)inputs.at(ranges_offset + 3 * i + 2);
-    ranges.push_back(at::indexing::Slice(start, stop, step));
+    ranges.emplace_back(at::indexing::Slice(start, stop, step));
   }
   return {in.index(ranges)};
 }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4060,6 +4060,22 @@ std::vector<Slice> SliceOp::getRanges() const {
   return ranges;
 }
 
+std::vector<PolymorphicValue> SliceOp::evaluate(
+    const ExpressionEvaluator& ee,
+    const std::vector<PolymorphicValue>& inputs) const {
+  const auto& in = inputs.at(0).as<at::Tensor>();
+  std::vector<at::indexing::TensorIndex> ranges;
+  auto ranges_offset = getRangeInputOffset();
+  auto num_dims = in.dim();
+  for (const auto i : c10::irange(num_dims)) {
+    auto start = (int64_t)inputs.at(ranges_offset + 3 * i);
+    auto stop = (int64_t)inputs.at(ranges_offset + 3 * i + 1);
+    auto step = (int64_t)inputs.at(ranges_offset + 3 * i + 2);
+    ranges.push_back(at::indexing::Slice(start, stop, step));
+  }
+  return {in.index(ranges)};
+}
+
 CatOp::CatOp(
     IrBuilderPasskey passkey,
     Val* out,
@@ -4153,6 +4169,18 @@ Val* CatOp::getPred(int input_idx) const {
       attr->toInlineString());
   auto pred = attr;
   return pred;
+}
+
+std::vector<PolymorphicValue> CatOp::evaluate(
+    const ExpressionEvaluator& ee,
+    const std::vector<PolymorphicValue>& inputs) const {
+  std::vector<at::Tensor> in;
+  int64_t concat_dim = concatenatedDim();
+  for (auto i : c10::irange(inputs.size())) {
+    auto unpadded_inp = ee.evaluate(input(i)->definition()->input(0));
+    in.push_back(unpadded_inp.as<at::Tensor>());
+  }
+  return {at::cat(in, concat_dim)};
 }
 
 } // namespace nvfuser

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -16,8 +16,6 @@
 #include <fusion.h>
 #include <ops/all_ops.h>
 
-#include <typeinfo>
-
 namespace nvfuser {
 
 class ExprEvalTest : public NVFuserTest {};

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -16,6 +16,8 @@
 #include <fusion.h>
 #include <ops/all_ops.h>
 
+#include <typeinfo>
+
 namespace nvfuser {
 
 class ExprEvalTest : public NVFuserTest {};

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -695,7 +695,7 @@ TEST_F(ResizeTest, FusionResizeCat5) {
 
   auto ref = at::cat({t0, t1}, 1) + t2;
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Cat 3 tensors
@@ -867,12 +867,7 @@ TEST_F(ResizeTest, FusionResizeCatScheduler2) {
   auto ref = at::cat({t0, t1}, 1) + t2;
 
   testValidate(
-      executor_cache.fusion(),
-      cg_outputs,
-      aten_inputs,
-      {ref},
-      __LINE__,
-      __FILE__);
+      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Auto scheduled version of Cat6
@@ -978,7 +973,7 @@ TEST_F(ResizeTest, FusionResizeSlice2) {
        at::indexing::Slice(shape[1] / 2)});
   auto ref = t1 + t2;
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // "Trivial" slice is converted to Set
@@ -1709,12 +1704,7 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT1) {
   auto aten_t3 = torch::add(aten_t0_slice, t1);
 
   testValidate(
-      executor_cache.fusion(),
-      cg_outputs,
-      aten_inputs,
-      {aten_t3, aten_t3},
-      __LINE__,
-      __FILE__);
+      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Similar to FusionSliceForNanoGPT1 but the input to slice is an
@@ -1838,12 +1828,7 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT2) {
   auto aten_t7 = aten_t2 + 1;
 
   testValidate(
-      executor_cache.fusion(),
-      cg_outputs,
-      aten_inputs,
-      {aten_t4, aten_t4, aten_t7},
-      __LINE__,
-      __FILE__);
+      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // C++ version of TestNvFuserFrontend.test_nanogpt_split_mha_linears


### PR DESCRIPTION
Implements the `Expr::evaluate` method for `CatOp` and `SliceOp`. This is a part of resolving issue #670.