### PR TITLE
Add CacheOp::Global.

### DIFF
--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1148,6 +1148,9 @@ std::ostream& operator<<(std::ostream& os, const CacheOp& cache_op) {
     case CacheOp::Streaming:
       os << "Streaming";
       break;
+    case CacheOp::Global:
+      os << "Global";
+      break;
     default:
       NVF_ERROR(false, "undefined cache operator");
       break;

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -720,6 +720,7 @@ static constexpr std::array<IdMappingMode, 6> kIdMappingModes = {
 enum class CacheOp {
   AllLevels,
   Streaming,
+  Global,
 };
 
 //! Used to annotate the special memory intrinsics that a loadstore op will be

--- a/runtime/array.cu
+++ b/runtime/array.cu
@@ -174,6 +174,7 @@ __device__ void loadLocalToGlobal(
 enum class CacheOp {
   AllLevels,
   Streaming,
+  Global,
 };
 
 // For simplicity, cache_op is only used for non-volatile loads written in
@@ -209,6 +210,11 @@ __device__ void loadGlobalToLocal(
                          : "=r"(data.x), "=r"(data.y)
                          : "l"((uint2*)from));
             break;
+          case CacheOp::Global:
+            asm volatile("ld.global.cg.v2.s32 {%0,%1}, [%2];"
+                         : "=r"(data.x), "=r"(data.y)
+                         : "l"((uint2*)from));
+            break;
         }
       }
       break;
@@ -231,6 +237,12 @@ __device__ void loadGlobalToLocal(
           case CacheOp::Streaming:
             asm volatile(
                 "ld.global.cs.v4.s32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
+                : "l"((uint4*)from));
+            break;
+          case CacheOp::Global:
+            asm volatile(
+                "ld.global.cg.v4.s32 {%0,%1,%2,%3}, [%4];"
                 : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
                 : "l"((uint4*)from));
             break;

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -26,7 +26,8 @@
 namespace nvfuser {
 
 class MemoryTest
-    : public testing::TestWithParam<std::tuple<CacheOp, std::string>> {};
+    : public NVFuserTest,
+      public testing::WithParamInterface<std::tuple<CacheOp, std::string>> {};
 
 TEST_P(MemoryTest, LoadCache) {
   CacheOp cache_op = std::get<0>(GetParam());


### PR DESCRIPTION
As a follow up to #865, add `CacheOp::Global` so we can emit `ld.global.cg` as well. This provides more ammunition to investigate #775. 