### PR TITLE
Rename cache_op to op_type.

### DIFF
--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -362,16 +362,16 @@ class TORCH_CUDA_CU_API TensorView : public Val {
   //! write results into shared memory or registers before moving to global
   //! memory. Analogous to TVM Cache_Write
   //!
-  //! @param cache_op: memory operator to use for the inserted op between
+  //! @param op_type: memory operator to use for the inserted op between
   //!   the the data tensor and the cache tensor
-  TensorView* cacheBefore(LoadStoreOpType cache_op = LoadStoreOpType::Set);
+  TensorView* cacheBefore(LoadStoreOpType op_type = LoadStoreOpType::Set);
 
   //! Create a TensorView after the original tensor. A common use case is to
   //! read tensor into shared memory or registers. Analogous to TVM Cache_Read
   //!
-  //! @param cache_op: memory operator to use for the inserted op between
+  //! @param op_type: memory operator to use for the inserted op between
   //!   the the data tensor and the cache tensor
-  TensorView* cacheAfter(LoadStoreOpType cache_op = LoadStoreOpType::Set);
+  TensorView* cacheAfter(LoadStoreOpType op_type = LoadStoreOpType::Set);
 
   // For a fusion output with other uses, we want to avoid writing to global
   // memory and then reading the output again. We write to global memory

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1094,7 +1094,7 @@ std::vector<TensorView*> TensorView::rFactor(
   return rf_tvs;
 }
 
-TensorView* TensorView::cacheBefore(LoadStoreOpType cache_op) {
+TensorView* TensorView::cacheBefore(LoadStoreOpType op_type) {
   NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
@@ -1165,7 +1165,7 @@ TensorView* TensorView::cacheBefore(LoadStoreOpType cache_op) {
   }
   ir_utils::transferDefinitionToNewOutputs(definition(), replaced_siblings);
 
-  IrBuilder::create<LoadStoreOp>(container(), cache_op, consumer, producer);
+  IrBuilder::create<LoadStoreOp>(container(), op_type, consumer, producer);
 
   // definition_ is no longer valid
   // setDefinition(nullptr);
@@ -1228,7 +1228,7 @@ TensorView* TensorView::cacheFork() {
   return new_output;
 }
 
-TensorView* TensorView::cacheAfter(LoadStoreOpType cache_op) {
+TensorView* TensorView::cacheAfter(LoadStoreOpType op_type) {
   NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
@@ -1298,7 +1298,7 @@ TensorView* TensorView::cacheAfter(LoadStoreOpType cache_op) {
   }
 
   // Expr* consumer_definition =
-  IrBuilder::create<LoadStoreOp>(container(), cache_op, consumer, producer);
+  IrBuilder::create<LoadStoreOp>(container(), op_type, consumer, producer);
 
   auto replayed_consumer_pair = TransformReplay::replayCasP(
       consumer, producer, -1, TransformReplayOptions().replayAllocation());


### PR DESCRIPTION
So we distinguish it from the real cache operator, e.g., .ca and .cg.