### PR TITLE
Tiny build changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,8 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/register_interface.cpp
   ${NVFUSER_SRCS_DIR}/rng.cpp
   ${NVFUSER_SRCS_DIR}/root_domain_map.cpp
+  ${NVFUSER_SRCS_DIR}/serde/polymorphic_value_serde.cpp
+  ${NVFUSER_SRCS_DIR}/serde/utils.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/heuristic_types.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/pointwise.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/pointwise_utils.cpp
@@ -206,8 +208,7 @@ if(BUILD_PYTHON)
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_definition.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_state.cpp
     ${NVFUSER_SRCS_DIR}/serde/fusion_record_serde.cpp
-    ${NVFUSER_SRCS_DIR}/serde/polymorphic_value_serde.cpp
-    ${NVFUSER_SRCS_DIR}/serde/utils.cpp)
+  )
 endif()
 
 set(NVFUSER_CODEGEN ${PROJECT_NAME}_codegen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(PROJECT_IS_TOP_LEVEL)
   set(ATEN_CUDA_ROOT "${TORCH_INSTALL_PREFIX}/include/ATen")
 
   # CXX flags is necessary since https://github.com/pytorch/pytorch/issues/98093
-  string(APPEND CMAKE_CXX_FLAGS ${TORCH_CXX_FLAGS})
+  string(APPEND CMAKE_CXX_FLAGS " ${TORCH_CXX_FLAGS}")
   include(cmake/FlatBuffers.cmake)
 
   if(BUILD_NVFUSER_BENCHMARK)


### PR DESCRIPTION
Even when BUILD_PYTHON doesn't get set, we still need to be able to serialize things. Without this change we have undefined references when BUILD_PYTHON is false or unset.

The second issue is that we couldn't actually set custom flags at cmake invocation time, unless those flags happened to end in a separator.