### PR TITLE
clean up registry.cpp after schedulers are moved

### DIFF
--- a/csrc/scheduler/heuristic_types.h
+++ b/csrc/scheduler/heuristic_types.h
@@ -55,10 +55,8 @@ enum class ScheduleHeuristic {
   Matmul
 };
 
-//! Define a schedule table to loop over all the schedule heuristics.
-//! The order reflects the priority of the heuristics and shouldn't be changed
-//! without a good reason.
-constexpr std::array<ScheduleHeuristic, 6> all_schedule_heuristics = {
+//! Define a schedule table to loop over all the heuristics in priority order.
+constexpr std::array<ScheduleHeuristic, 6> all_heuristics_in_priority_order = {
     ScheduleHeuristic::NoOp,
     ScheduleHeuristic::Reduction,
     ScheduleHeuristic::Transpose,

--- a/csrc/scheduler/heuristic_types.h
+++ b/csrc/scheduler/heuristic_types.h
@@ -7,10 +7,43 @@
 // clang-format on
 #pragma once
 
+#include <array>
 #include <ostream>
 #include <string>
 
 namespace nvfuser {
+
+//! Each ScheduleHeuristic maps to a scheduler in distinct CPP files.
+//! For instance, ScheduleHeuristic::PointWise maps to PointWiseScheduler in
+//! pointwise.cpp.
+//!
+//!    Each of the scheduler needs to provide 3 interface functions:
+//!
+//!      1. canScheduleCompileTime(Fusion* fusion) :
+//!
+//!        This function contains compiled-time checks on the graph itself
+//!        without runtime input information. Only `fusion` is given in the
+//!        argument to make sure only compile-time available info is needed in
+//!        the check.
+//!
+//!        This function is to be called exactly once on each segmented group
+//!        created in a segmented fusion so this part will not contribute to
+//!        dynamic shape latency.
+//!
+//!     2. canScheduleRunTime(
+//!            Fusion* fusion,
+//!            SchedulerRuntimeInfo& runtime_info,
+//!           HeuristicSummary* data_cache = nullptr):
+//!        This function contains all canSchedule checks that will have to
+//!        involve runtime input information, and will be run both by the
+//!        segmenter and the kernel cache. The latency of this function will
+//!        contribute to dynamic shape latency so `data_cache` should be used as
+//!        much as possible to save re-computation.
+//!
+//!     3. schedule(fusion):
+//!
+//!        This function will be called when compiling a kernel. It should apply
+//!        scheduling to the given fusion
 
 enum class ScheduleHeuristic {
   None,
@@ -21,6 +54,17 @@ enum class ScheduleHeuristic {
   Transpose,
   Matmul
 };
+
+//! Define a schedule table to loop over all the schedule heuristics.
+//! The order reflects the priority of the heuristics and shouldn't be changed
+//! without a good reason.
+constexpr std::array<ScheduleHeuristic, 6> all_schedule_heuristics = {
+    ScheduleHeuristic::NoOp,
+    ScheduleHeuristic::Reduction,
+    ScheduleHeuristic::Transpose,
+    ScheduleHeuristic::PointWise,
+    ScheduleHeuristic::Persistent,
+    ScheduleHeuristic::Matmul};
 
 std::string toString(ScheduleHeuristic sh);
 

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -240,7 +240,7 @@ std::unique_ptr<SchedulerEntry> SchedulerEntry::makeEntry(
 std::optional<ScheduleHeuristic> SchedulerEntry::proposeHeuristics(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info) {
-  for (const auto& sh : all_schedule_heuristics) {
+  for (const auto& sh : all_heuristics_in_priority_order) {
     if (canSchedule(sh, fusion, runtime_info)) {
       scheduler_debug_utils::canScheduleMessage("***Accepted*** as: ", sh);
       return sh;


### PR DESCRIPTION
This PR cleans up registry.cpp after schedulers are moved to their own files as described in #864.
It did: 
(1) move comments and list of schedulers to heuristic_types.cpp
(2) clean up header inclusions in registry.cpp.
(3) rename to `all_heuristics_in_priority_order` to convey the intent that order matters.