### PR TITLE
remove reductionOps checks from schedulePointwise

### DIFF
--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -511,12 +511,6 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
   // fusion segmentation
   scheduler_utils::clearMemorySpace(fusion);
 
-  // maybe has_reduction for scheduling should be done on a per output tensor
-  // basis.
-  NVF_ERROR(
-      ir_utils::getReductionOps(fusion).empty(),
-      "This scheduler only handles pointwise ops.");
-
   // Cache inputs
   auto cached_inputs = scheduler_utils::cacheInputs(fusion, true);
 


### PR DESCRIPTION
Part of #891 to remove redundant nontrivial checks in getHeuristics and scheduleKernel.
In this PR, the check of reduction ops is removed from `schedulePointwise` because:
(1) the same check is already done in `canScheduleCompileTime`
and 
(2) the check is nontrivial as it requires iterating through all the expressions in the fusion.