### PR TITLE
Remove obselete note in `dynamic_type.h`

### DIFF
--- a/lib/dynamic_type/src/dynamic_type/dynamic_type.h
+++ b/lib/dynamic_type/src/dynamic_type/dynamic_type.h
@@ -88,9 +88,6 @@ struct DynamicType {
       typename Containers::template VariantType<DynamicType, Ts...>;
   VariantType value;
 
-  // TODO: Not supporting operators for containers for now, because containers
-  // has nested DynamicType, trying to support operators for containers will
-  // make the template deduction an infinite loop.
   using TypeIdentitiesAsTuple =
       typename Containers::template TypeIdentitiesAsTuple<DynamicType, Ts...>;
   static constexpr TypeIdentitiesAsTuple type_identities_as_tuple{};


### PR DESCRIPTION
It is supported, see:
https://github.com/NVIDIA/Fuser/blob/ace12da951cdcf9b806e93387bc905752b165ab0/lib/dynamic_type/test/binary_ops.cpp#L135-L138