### PR TITLE
use getMaybeAllocationDomain instead of getMaybeRFactorDomain 

### DIFF
--- a/benchmark/transpose.cpp
+++ b/benchmark/transpose.cpp
@@ -247,7 +247,7 @@ static void NvFuserScheduler_Transpose(
       ->Unit(benchmark::kMicrosecond)
 
 NVFUSER_TRANSPOSE_SQUARE_RUN(
-    NF_Transpose_Random_fp32_Inner_2D_01_Axis,
+    NvFuserScheduler_Transpose_Random_fp32_Inner_2D_01_Axis,
     DataType::Float,
     2 /* num_dims */,
     0 /* axis1 */,
@@ -255,7 +255,7 @@ NVFUSER_TRANSPOSE_SQUARE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_SQUARE_RUN(
-    NF_Transpose_Random_fp32_Inner_3D_02_Axis,
+    NvFuserScheduler_Transpose_Random_fp32_Inner_3D_02_Axis,
     DataType::Float,
     3 /* num_dims */,
     0 /* axis1 */,
@@ -263,7 +263,7 @@ NVFUSER_TRANSPOSE_SQUARE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_SQUARE_RUN(
-    NF_Transpose_Random_fp32_Inner_3D_12_Axis,
+    NvFuserScheduler_Transpose_Random_fp32_Inner_3D_12_Axis,
     DataType::Float,
     3 /* num_dims */,
     1 /* axis1 */,
@@ -271,7 +271,7 @@ NVFUSER_TRANSPOSE_SQUARE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_SQUARE_RUN(
-    NF_Transpose_Random_fp32_Outer_3D_01_Axis,
+    NvFuserScheduler_Transpose_Random_fp32_Outer_3D_01_Axis,
     DataType::Float,
     3 /* num_dims */,
     0 /* axis1 */,
@@ -281,7 +281,7 @@ NVFUSER_TRANSPOSE_SQUARE_RUN(
 //------------------------------------------------------------------------------
 
 NVFUSER_TRANSPOSE_SQUARE_RUN(
-    NF_Transpose_Random_fp16_Inner_2D_01_Axis,
+    NvFuserScheduler_Transpose_Random_fp16_Inner_2D_01_Axis,
     DataType::Half,
     2 /* num_dims */,
     0 /* axis1 */,
@@ -289,7 +289,7 @@ NVFUSER_TRANSPOSE_SQUARE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_SQUARE_RUN(
-    NF_Transpose_Random_fp16_Inner_3D_02_Axis,
+    NvFuserScheduler_Transpose_Random_fp16_Inner_3D_02_Axis,
     DataType::Half,
     3 /* num_dims */,
     0 /* axis1 */,
@@ -297,7 +297,7 @@ NVFUSER_TRANSPOSE_SQUARE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_SQUARE_RUN(
-    NF_Transpose_Random_fp16_Inner_3D_12_Axis,
+    NvFuserScheduler_Transpose_Random_fp16_Inner_3D_12_Axis,
     DataType::Half,
     3 /* num_dims */,
     1 /* axis1 */,
@@ -305,7 +305,7 @@ NVFUSER_TRANSPOSE_SQUARE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_SQUARE_RUN(
-    NF_Transpose_Random_fp16_Outer_3D_01_Axis,
+    NvFuserScheduler_Transpose_Random_fp16_Outer_3D_01_Axis,
     DataType::Half,
     3 /* num_dims */,
     0 /* axis1 */,

--- a/benchmark/transpose.cpp
+++ b/benchmark/transpose.cpp
@@ -330,7 +330,7 @@ NVFUSER_TRANSPOSE_SQUARE_RUN(
       ->Unit(benchmark::kMicrosecond)
 
 NVFUSER_TRANSPOSE_RUN(
-    NF_Transpose_fp32_Inner_2D_01_Axis,
+    NvFuserScheduler_Transpose_fp32_Inner_2D_01_Axis,
     DataType::Float,
     2 /* num_dims */,
     0 /* axis1 */,
@@ -338,7 +338,7 @@ NVFUSER_TRANSPOSE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_RUN(
-    NF_Transpose_fp32_Inner_3D_02_Axis,
+    NvFuserScheduler_Transpose_fp32_Inner_3D_02_Axis,
     DataType::Float,
     3 /* num_dims */,
     0 /* axis1 */,
@@ -346,7 +346,7 @@ NVFUSER_TRANSPOSE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_RUN(
-    NF_Transpose_fp32_Inner_3D_12_Axis,
+    NvFuserScheduler_Transpose_fp32_Inner_3D_12_Axis,
     DataType::Float,
     3 /* num_dims */,
     1 /* axis1 */,
@@ -354,7 +354,7 @@ NVFUSER_TRANSPOSE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_RUN(
-    NF_Transpose_fp32_Outer_3D_01_Axis,
+    NvFuserScheduler_Transpose_fp32_Outer_3D_01_Axis,
     DataType::Float,
     3 /* num_dims */,
     0 /* axis1 */,
@@ -364,7 +364,7 @@ NVFUSER_TRANSPOSE_RUN(
 //------------------------------------------------------------------------------
 
 NVFUSER_TRANSPOSE_RUN(
-    NF_Transpose_fp16_Inner_2D_01_Axis,
+    NvFuserScheduler_Transpose_fp16_Inner_2D_01_Axis,
     DataType::Half,
     2 /* num_dims */,
     0 /* axis1 */,
@@ -372,7 +372,7 @@ NVFUSER_TRANSPOSE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_RUN(
-    NF_Transpose_fp16_Inner_3D_02_Axis,
+    NvFuserScheduler_Transpose_fp16_Inner_3D_02_Axis,
     DataType::Half,
     3 /* num_dims */,
     0 /* axis1 */,
@@ -380,7 +380,7 @@ NVFUSER_TRANSPOSE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_RUN(
-    NF_Transpose_fp16_Inner_3D_12_Axis,
+    NvFuserScheduler_Transpose_fp16_Inner_3D_12_Axis,
     DataType::Half,
     3 /* num_dims */,
     1 /* axis1 */,
@@ -388,7 +388,7 @@ NVFUSER_TRANSPOSE_RUN(
     TransposeConfig(TRANSPOSE_CONFIG));
 
 NVFUSER_TRANSPOSE_RUN(
-    NF_Transpose_fp16_Outer_3D_01_Axis,
+    NvFuserScheduler_Transpose_fp16_Outer_3D_01_Axis,
     DataType::Half,
     3 /* num_dims */,
     0 /* axis1 */,

--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -196,13 +196,13 @@ class DomainMap : public pointwise_utils::DomainMap {
     return result;
   }
 
-  IterDomain* getMappedRootDimIn(TensorView* tv, IterDomain* root_dim) const {
-    // Find the root id mapped to `root_dim`
-    const auto& root_dom = tv->getRootDomain();
+  IterDomain* getMappedAllocDimIn(TensorView* tv, IterDomain* root_dim) const {
+    // Find the id mapped to `Allocation Domain`
+    const auto& alloc_dom = tv->getMaybeAllocationDomain();
     IterDomain* mapped_id = nullptr;
-    for (auto i : c10::irange(root_dom.size())) {
-      if (ca_map_.areMapped(root_dom[i], root_dim, IdMappingMode::INNERMOST)) {
-        mapped_id = root_dom[i];
+    for (auto i : c10::irange(alloc_dom.size())) {
+      if (ca_map_.areMapped(alloc_dom[i], root_dim, IdMappingMode::INNERMOST)) {
+        mapped_id = alloc_dom[i];
         break;
       }
     }
@@ -224,7 +224,7 @@ class DomainMap : public pointwise_utils::DomainMap {
     // reference 1 is the global reference, so it must have dim mapped the
     // innermost dim of both groups
     auto innermost2 = scheduler_utils::innerMostRootDim(ref2);
-    return domain_map.getMappedRootDimIn(ref1, innermost2) != nullptr;
+    return domain_map.getMappedAllocDimIn(ref1, innermost2) != nullptr;
   }
 
   // scheduler assumes inner leaf dimension on tv is an exact mapping, when the
@@ -235,7 +235,7 @@ class DomainMap : public pointwise_utils::DomainMap {
     // transformed. So the mapping here would require a new compute at map to be
     // constructed from the updated fusion. We'll revisit this once our id graph
     // refactor is done.
-    auto mapped_id = getMappedRootDimIn(tv, root_dim);
+    auto mapped_id = getMappedAllocDimIn(tv, root_dim);
     NVF_ERROR(
         mapped_id != nullptr,
         "Can not find ID mapped to ",

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1330,9 +1330,9 @@ bool hasInnerDim(
   auto alloc_dom = tv->getMaybeAllocationDomain();
 
   auto root_pos_it = std::find_if(
-      alloc_dom.begin(),
-      alloc_dom.end(),
-      [&inner_most_dim](IterDomain* id) { return inner_most_dim == id; });
+      alloc_dom.begin(), alloc_dom.end(), [&inner_most_dim](IterDomain* id) {
+        return inner_most_dim == id;
+      });
 
   if (root_pos_it == alloc_dom.end()) {
     return false;

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1202,7 +1202,7 @@ IterDomain* projectIdToRFactor(
 } // namespace
 
 IterDomain* innerMostRootDim(TensorView* tv) {
-  const auto& root_domain = tv->getMaybeRFactorDomain();
+  const auto& root_domain = tv->getMaybeAllocationDomain();
 
   if (tv->nDims() == 0) {
     return nullptr;

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -269,9 +269,9 @@ TORCH_CUDA_CU_API std::vector<TensorView*> cacheInputs(
 TORCH_CUDA_CU_API std::vector<std::pair<TensorView*, TensorView*>>
 cacheAndForkOutputs(Fusion* fusion, bool unroll);
 
-// Ignores broadcast and reduction, returns iter domain in root domain that's
-// "inner most".
-IterDomain* innerMostRootDim(TensorView* tv);
+// Ignores broadcast and reduction, returns iter domain in allocation domain
+// that's "inner most".
+IterDomain* innerMostAllocDim(TensorView* tv);
 
 // Looks through fusion and finds all dims that match to the one provided in
 // the tensorview provided. Iter domain must be a root domain. If inner_only,


### PR DESCRIPTION
Fixes #902 

1. for inner most dimension query, we should be using allocation domain instead of rfactor domain.
2. renamed transpose benchmark from `NF_Transpose_XXX` to `NvFuserScheduler_Transpose_XXX`