### PR TITLE
`Expr::evaluate` method for `ScatterOp` and `TorchGatherOp`

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -151,6 +151,9 @@ class TORCH_CUDA_CU_API TorchGatherOp : public Expr {
 
   std::string toString(int indent_size = 0) const override;
   std::string toInlineString(int indent_size = 0) const override;
+  std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
+      const std::vector<PolymorphicValue>& inputs) const override;
 
   TensorView* lookupTv() const {
     return input(0)->as<TensorView>();
@@ -193,6 +196,9 @@ class TORCH_CUDA_CU_API ScatterOp : public Expr {
 
   std::string toString(int indent_size = 0) const override;
   std::string toInlineString(int indent_size = 0) const override;
+  std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
+      const std::vector<PolymorphicValue>& inputs) const override;
 
   TensorView* selfTv() const {
     return input(0)->as<TensorView>();

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -204,6 +204,15 @@ IterDomain* TorchGatherOp::getConsumerOfIndexedID() const {
   return ir_utils::getTvOutput(this)->getRootDomain().at(dim());
 }
 
+std::vector<PolymorphicValue> TorchGatherOp::evaluate(
+    const ExpressionEvaluator& ee,
+    const std::vector<PolymorphicValue>& inputs) const {
+  const auto& input = inputs.at(0).as<at::Tensor>();
+  const auto& index = inputs.at(1).as<at::Tensor>();
+  auto dimension = dim();
+  return {at::gather(input, dimension, index)};
+}
+
 NVFUSER_DEFINE_CLONE_AND_CREATE(TorchGatherOp)
 
 ScatterOp::ScatterOp(
@@ -240,6 +249,16 @@ std::string ScatterOp::toInlineString(int indent_size) const {
 
 IterDomain* ScatterOp::getIndexedID() const {
   return ir_utils::getTvOutput(this)->getRootDomain().at(dim());
+}
+
+std::vector<PolymorphicValue> ScatterOp::evaluate(
+    const ExpressionEvaluator& ee,
+    const std::vector<PolymorphicValue>& inputs) const {
+  const auto& input = inputs.at(0).as<at::Tensor>();
+  const auto& index = inputs.at(1).as<at::Tensor>();
+  const auto& src = inputs.at(2).as<at::Tensor>();
+  auto dimension = dim();
+  return {at::scatter(input, dimension, index, src)};
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(ScatterOp)

--- a/test/test_gather.cpp
+++ b/test/test_gather.cpp
@@ -123,7 +123,7 @@ TEST_F(IndexingOpTest, Scatter1DIndexZerosSelfTvSameShape_CUDA) {
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
     auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
     testValidate(
-        &fusion, cg_outputs, aten_inputs, {out_ref}, __LINE__, __FILE__);
+        &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
   }
 }
 
@@ -164,7 +164,7 @@ TEST_F(IndexingOpTest, TorchGatherAllRankAllSelectedDim_CUDA) {
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
         auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
         testValidate(
-            &fusion, cg_outputs, aten_inputs, {tv_out_ref}, __LINE__, __FILE__);
+            &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
       }
     }
   }
@@ -209,7 +209,7 @@ TEST_F(IndexingOpTest, TorchGatherAddMul_CUDA) {
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
         auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
         testValidate(
-            &fusion, cg_outputs, aten_inputs, {tv_out_ref}, __LINE__, __FILE__);
+            &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
       }
     }
   }
@@ -257,7 +257,7 @@ TEST_F(IndexingOpTest, AddGatherSumAdd_CUDA) {
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
         auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
         testValidate(
-            &fusion, cg_outputs, aten_inputs, {t_out}, __LINE__, __FILE__);
+            &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
       }
     }
   }
@@ -358,7 +358,7 @@ TEST_F(IndexingOpTest, TorchGatherAddMulHugeSize_CUDA) {
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
         auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
         testValidate(
-            &fusion, cg_outputs, aten_inputs, {tv_out_ref}, __LINE__, __FILE__);
+            &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
       }
     }
   }
@@ -627,7 +627,7 @@ TEST_F(IndexingOpTest, TakeAlongAxisIntermediateTensorPointwise1_CUDA) {
 
   auto ref = at::take_along_dim(t0 + 1, t1.unsqueeze(-1), 1);
 
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Same as the above but with the pointwise scheduler
@@ -665,7 +665,7 @@ TEST_F(IndexingOpTest, TakeAlongAxisIntermediateTensorPointwise2_CUDA) {
 
   auto ref = at::take_along_dim(t0 + 1, t1.unsqueeze(-1), 1);
 
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Reduction then take_along_axis. This is currently segmented due to

--- a/test/test_gather.cpp
+++ b/test/test_gather.cpp
@@ -122,8 +122,7 @@ TEST_F(IndexingOpTest, Scatter1DIndexZerosSelfTvSameShape_CUDA) {
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
     auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-    testValidate(
-        &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+    testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
   }
 }
 
@@ -163,8 +162,7 @@ TEST_F(IndexingOpTest, TorchGatherAllRankAllSelectedDim_CUDA) {
 
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
         auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-        testValidate(
-            &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
       }
     }
   }
@@ -208,8 +206,7 @@ TEST_F(IndexingOpTest, TorchGatherAddMul_CUDA) {
 
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
         auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-        testValidate(
-            &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
       }
     }
   }
@@ -256,8 +253,7 @@ TEST_F(IndexingOpTest, AddGatherSumAdd_CUDA) {
         std::vector<c10::IValue> aten_inputs = {t_lookup, t_idx_1, t_idx_2};
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
         auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-        testValidate(
-            &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
       }
     }
   }
@@ -357,8 +353,7 @@ TEST_F(IndexingOpTest, TorchGatherAddMulHugeSize_CUDA) {
 
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
         auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-        testValidate(
-            &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
       }
     }
   }

--- a/test/test_gather.cpp
+++ b/test/test_gather.cpp
@@ -115,8 +115,6 @@ TEST_F(IndexingOpTest, Scatter1DIndexZerosSelfTvSameShape_CUDA) {
     at::Tensor idx_2 = idx - idx_1;
     at::Tensor input = at::randn(input_dims[test_id], options);
     at::Tensor src = at::randn(src_dims[test_id], options);
-    auto t_index = at::add(idx_1, idx_2);
-    auto out_ref = at::scatter(input, 0, t_index, src);
 
     std::vector<c10::IValue> aten_inputs = {input, idx_1, idx_2, src};
 
@@ -157,7 +155,6 @@ TEST_F(IndexingOpTest, TorchGatherAllRankAllSelectedDim_CUDA) {
             at::randint(0, input_dims[dim], index_dims, options_i);
         at::Tensor output = at::zeros(index_dims, options);
 
-        auto tv_out_ref = at::gather(input, dim, input_idx);
         std::vector<c10::IValue> aten_inputs = {input, input_idx};
 
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
@@ -196,11 +193,6 @@ TEST_F(IndexingOpTest, TorchGatherAddMul_CUDA) {
         at::Tensor input = at::randn(input_dims, options); // lookup
         at::Tensor input_idx =
             at::randint(0, input_dims[dim], index_dims, options_i);
-        at::Tensor output = at::zeros(index_dims, options);
-
-        auto t_gather = at::gather(input, dim, input_idx);
-        auto t_add = at::add(t_gather, t_gather);
-        auto tv_out_ref = at::mul(t_gather, t_add);
 
         std::vector<c10::IValue> aten_inputs = {input, input_idx};
 
@@ -246,9 +238,6 @@ TEST_F(IndexingOpTest, AddGatherSumAdd_CUDA) {
             at::randint(0, input_dims[dim] / 2, index_dims, options_i);
         at::Tensor t_idx_2 =
             at::randint(0, input_dims[dim] / 2, index_dims, options_i);
-
-        auto t_index = at::add(t_idx_1, t_idx_2);
-        auto t_out = at::gather(t_lookup, dim, t_index);
 
         std::vector<c10::IValue> aten_inputs = {t_lookup, t_idx_1, t_idx_2};
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
@@ -343,11 +332,6 @@ TEST_F(IndexingOpTest, TorchGatherAddMulHugeSize_CUDA) {
         at::Tensor input = at::randn(input_dims, options); // lookup
         at::Tensor input_idx =
             at::randint(0, input_dims[dim], index_dims, options_i);
-        at::Tensor output = at::zeros(index_dims, options);
-
-        auto t_gather = at::gather(input, dim, input_idx);
-        auto t_add = at::add(t_gather, t_gather);
-        auto tv_out_ref = at::mul(t_gather, t_add);
 
         std::vector<c10::IValue> aten_inputs = {input, input_idx};
 


### PR DESCRIPTION
This is a part of resolving #670 