### PR TITLE
calculate matmul ref using float

### DIFF
--- a/test/test_matmul_scheduler.cpp
+++ b/test/test_matmul_scheduler.cpp
@@ -833,7 +833,7 @@ TEST_F(MatmulSchedulerTest, EpilogueBias_CUDA) {
   auto t1 = matmulAtInput(layout, TensorMatmulPos::B, at::kHalf, M, N, K);
   auto t2 = matmulAtInput(layout, TensorMatmulPos::Bias, at::kFloat, M, N, K);
 
-  auto t3 = atMatmul(t0.to(at::kHalf), t1.to(at::kHalf), layout).to(at::kFloat);
+  auto t3 = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
 
   auto t4 = atBiasEpilogue(t3, t2).to(at::kFloat);
 


### PR DESCRIPTION
There is a negative false for case `MatmulSchedulerTest.EpilogueBias_CUDA` in a CI process. 
Change to calculate the reference value using float to avoid negative false and also keep consistent with other cases.