### PR TITLE
Revert "Enable the newly added OuterPersistent scheduler"

### DIFF
--- a/benchmark/softmax.cpp
+++ b/benchmark/softmax.cpp
@@ -98,9 +98,9 @@ static void Softmax_WarpReduceReference(benchmark::State& benchmark_state) {
   // Schedule through magic scheduler:
   SchedulerRuntimeInfo runtime_info(fusion, aten_inputs);
   NVF_ERROR(SchedulerEntry::canSchedule(
-      ScheduleHeuristic::InnerPersistent, fusion, runtime_info));
+      ScheduleHeuristic::Persistent, fusion, runtime_info));
   auto scheduler = SchedulerEntry::makeEntry(
-      ScheduleHeuristic::InnerPersistent, fusion, runtime_info);
+      ScheduleHeuristic::Persistent, fusion, runtime_info);
   scheduler->schedule(fusion);
 
   FusionExecutor fe;

--- a/csrc/scheduler/all_schedulers.h
+++ b/csrc/scheduler/all_schedulers.h
@@ -11,7 +11,6 @@
 #include <scheduler/normalization.h>
 #include <scheduler/normalization_inner.h>
 #include <scheduler/normalization_inner_outer.h>
-#include <scheduler/normalization_outer.h>
 #include <scheduler/pointwise.h>
 #include <scheduler/reduction.h>
 #include <scheduler/transpose.h>

--- a/csrc/scheduler/heuristic_types.cpp
+++ b/csrc/scheduler/heuristic_types.cpp
@@ -21,8 +21,6 @@ std::string toString(ScheduleHeuristic sh) {
       return "reduction";
     case ScheduleHeuristic::InnerPersistent:
       return "inner_persistent";
-    case ScheduleHeuristic::OuterPersistent:
-      return "outer_persistent";
     case ScheduleHeuristic::InnerOuterPersistent:
       return "inner_outer_persistent";
     case ScheduleHeuristic::Persistent:

--- a/csrc/scheduler/heuristic_types.h
+++ b/csrc/scheduler/heuristic_types.h
@@ -53,19 +53,17 @@ enum class ScheduleHeuristic {
   InnerPersistent,
   InnerOuterPersistent,
   Persistent,
-  OuterPersistent,
   Transpose,
   Matmul
 };
 
 //! Define a schedule table to loop over all the heuristics in priority order.
-constexpr std::array<ScheduleHeuristic, 9> all_heuristics_in_priority_order = {
+constexpr std::array<ScheduleHeuristic, 8> all_heuristics_in_priority_order = {
     ScheduleHeuristic::NoOp,
     ScheduleHeuristic::Reduction,
     ScheduleHeuristic::Transpose,
     ScheduleHeuristic::PointWise,
     ScheduleHeuristic::InnerPersistent,
-    ScheduleHeuristic::OuterPersistent,
     ScheduleHeuristic::InnerOuterPersistent,
     ScheduleHeuristic::Persistent,
     ScheduleHeuristic::Matmul};

--- a/csrc/scheduler/normalization.cpp
+++ b/csrc/scheduler/normalization.cpp
@@ -46,10 +46,6 @@ void PersistentKernelScheduler::schedule(Fusion* fusion) {
 }
 
 bool PersistentKernelScheduler::canScheduleCompileTime(Fusion* fusion) {
-  // This scheduler is being divided into three separate schedulers and should
-  // be deleted. Disable the use of this scheduler for now.
-  return false;
-
   // Needs at least one reduction to consider.
   auto reduction_ops = ir_utils::getReductionOps(fusion);
   if (reduction_ops.empty()) {

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -185,9 +185,6 @@ bool SchedulerEntry::canSchedule(
     case ScheduleHeuristic::InnerPersistent:
       return checkCanSchedule<InnerPersistentKernelScheduler>(
           fusion, runtime_info, data_cache);
-    case ScheduleHeuristic::OuterPersistent:
-      return checkCanSchedule<OuterPersistentKernelScheduler>(
-          fusion, runtime_info, data_cache);
     case ScheduleHeuristic::InnerOuterPersistent:
       return checkCanSchedule<InnerOuterPersistentKernelScheduler>(
           fusion, runtime_info, data_cache);
@@ -228,10 +225,6 @@ std::unique_ptr<SchedulerEntry> SchedulerEntry::makeEntry(
       break;
     case ScheduleHeuristic::InnerPersistent:
       scheduler_entry = std::make_unique<InnerPersistentKernelScheduler>(
-          fusion, runtime_info, data_cache);
-      break;
-    case ScheduleHeuristic::OuterPersistent:
-      scheduler_entry = std::make_unique<OuterPersistentKernelScheduler>(
           fusion, runtime_info, data_cache);
       break;
     case ScheduleHeuristic::InnerOuterPersistent:
@@ -318,11 +311,6 @@ HeuristicSummary::HeuristicSummary(
       InnerPersistentKernelScheduler::canScheduleRunTime(
           fusion, runtime_info, this);
       break;
-    case ScheduleHeuristic::OuterPersistent:
-      getOuterPersistentHeuristics(fusion, runtime_info, this);
-      OuterPersistentKernelScheduler::canScheduleRunTime(
-          fusion, runtime_info, this);
-      break;
     case ScheduleHeuristic::InnerOuterPersistent:
       getInnerOuterPersistentHeuristics(fusion, runtime_info, this);
       InnerOuterPersistentKernelScheduler::canScheduleRunTime(
@@ -394,7 +382,6 @@ void HeuristicSummary::validate() const {
       break;
     }
     case ScheduleHeuristic::InnerPersistent:
-    case ScheduleHeuristic::OuterPersistent:
     case ScheduleHeuristic::InnerOuterPersistent: {
       NVF_ERROR(entry_type_map_.count(EntryType::REDUCTION_TVS));
       NVF_ERROR(

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -6059,10 +6059,9 @@ TEST_F(NVFuserTest, FusionZeroSizeTensorNormalization_CUDA) {
   at::Tensor input0 = at::randn({2, 4}, options);
   at::Tensor input1 = at::randn({0}, options);
 
-  auto reduction_params =
-      getOuterPersistentHeuristics(&fusion, {input0, input1});
+  auto reduction_params = getPersistentHeuristics(&fusion, {input0, input1});
   NVF_CHECK(reduction_params, "Reduction schedule was not generated!");
-  scheduleOuterPersistentKernel(&fusion, *reduction_params);
+  schedulePersistentKernel(&fusion, *reduction_params);
 
   auto lparams = reduction_params->lparams;
   FusionExecutor fe;
@@ -9229,9 +9228,9 @@ TEST_F(NVFuserTest, FusionTestWarpSoftMax_CUDA) {
   // Schedule through magic scheduler
   SchedulerRuntimeInfo runtime_info(&fusion, aten_inputs);
   NVF_CHECK(SchedulerEntry::canSchedule(
-      ScheduleHeuristic::InnerPersistent, &fusion, runtime_info));
+      ScheduleHeuristic::Persistent, &fusion, runtime_info));
   auto scheduler = SchedulerEntry::makeEntry(
-      ScheduleHeuristic::InnerPersistent, &fusion, runtime_info);
+      ScheduleHeuristic::Persistent, &fusion, runtime_info);
   scheduler->schedule(&fusion);
 
   // Modify the schedule to use warp reduction

--- a/test/test_gpu_outer_reduction.cpp
+++ b/test/test_gpu_outer_reduction.cpp
@@ -1464,7 +1464,7 @@ void grid_persistent_reduction_outer_norm_like_scheduler(
     const auto& scheduler_entry =
         runtime->schedulerHeuristics()->heuristicsList().at(0);
     NVF_CHECK(
-        scheduler_entry->heuristic() == ScheduleHeuristic::OuterPersistent,
+        scheduler_entry->heuristic() == ScheduleHeuristic::Persistent,
         "Unexpected heuristic was chosen: ",
         scheduler_entry->heuristic());
 
@@ -1622,7 +1622,7 @@ void grid_persistent_welford_outer_norm_like_scheduler(
     const auto& scheduler_entry =
         runtime->schedulerHeuristics()->heuristicsList().at(0);
     NVF_CHECK(
-        scheduler_entry->heuristic() == ScheduleHeuristic::OuterPersistent,
+        scheduler_entry->heuristic() == ScheduleHeuristic::Persistent,
         "Unexpected heuristic was chosen: ",
         scheduler_entry->heuristic());
 
@@ -1801,7 +1801,7 @@ void grid_persistent_batchnorm_scheduler(
     const auto& scheduler_entry =
         runtime->schedulerHeuristics()->heuristicsList().at(0);
     NVF_CHECK(
-        scheduler_entry->heuristic() == ScheduleHeuristic::OuterPersistent,
+        scheduler_entry->heuristic() == ScheduleHeuristic::Persistent,
         "Unexpected heuristic was chosen: ",
         scheduler_entry->heuristic());
 
@@ -1938,7 +1938,7 @@ void grid_persistent_reduction_outer_norm_bwd_like_scheduler(
     const auto& scheduler_entry =
         runtime->schedulerHeuristics()->heuristicsList().at(0);
     NVF_CHECK(
-        scheduler_entry->heuristic() == ScheduleHeuristic::OuterPersistent,
+        scheduler_entry->heuristic() == ScheduleHeuristic::Persistent,
         "Unexpected heuristic was chosen: ",
         scheduler_entry->heuristic());
 
@@ -2128,7 +2128,7 @@ void grid_persistent_batchnorm_bwd_scheduler(
     const auto& scheduler_entry =
         runtime->schedulerHeuristics()->heuristicsList().at(0);
     NVF_CHECK(
-        scheduler_entry->heuristic() == ScheduleHeuristic::OuterPersistent,
+        scheduler_entry->heuristic() == ScheduleHeuristic::Persistent,
         "Unexpected heuristic was chosen: ",
         scheduler_entry->heuristic());
 


### PR DESCRIPTION
Reverts NVIDIA/Fuser#916

The persistentScheduler has been deactivated but `BENCHMARK(Softmax_WarpReduce)` still uses it. It should use 
`ScheduleHeuristic::InnerPersistent` instead of ScheduleHeuristic::Persistent.

The err if runs `./nvfuser_bench --benchmark_min_time=0 --benchmark_filter=Softmax_WarpReduce`
```
Host: ipp2-0123
terminate called after throwing an instance of 'nvfuser::nvfError'
  what():  SchedulerEntry::canSchedule( ScheduleHeuristic::Persistent, fusion, runtime_info) INTERNAL ASSERT FAILED at "/opt/pytorch/nvfuser/benchmark/softmax.cpp":135, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues. 
Exception raised from Softmax_WarpReduce at /opt/pytorch/nvfuser/benchmark/softmax.cpp:135 (most recent call first):
frame #0: nvfuser::nvfCheckFail(char const*, char const*, unsigned int, char const*) + 0xe8 (0x7f8fd09d16dd in /opt/pytorch/nvfuser/build/libnvfuser_codegen.so)
frame #1: <unknown function> + 0xd82cf (0x56159424e2cf in ./nvfuser_bench)
frame #2: <unknown function> + 0x1520e8 (0x5615942c80e8 in ./nvfuser_bench)
```