### PR TITLE
clean normalization_outer

### DIFF
--- a/csrc/scheduler/normalization_outer.cpp
+++ b/csrc/scheduler/normalization_outer.cpp
@@ -32,11 +32,13 @@
 
 namespace nvfuser {
 
+constexpr auto schedule_heuristic = ScheduleHeuristic::OuterPersistent;
+
 OuterPersistentKernelScheduler::OuterPersistentKernelScheduler(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     HeuristicSummary* data_cache)
-    : SchedulerEntry(ScheduleHeuristic::OuterPersistent) {
+    : SchedulerEntry(schedule_heuristic) {
   computeHeuristics(fusion, runtime_info, data_cache);
 }
 
@@ -45,38 +47,64 @@ void OuterPersistentKernelScheduler::schedule(Fusion* fusion) {
   scheduleOuterPersistentKernel(fusion, reductionParams());
 }
 
+namespace {
+
+bool checkReductionPattern(
+    Fusion* fusion,
+    const std::vector<TensorView*>& reduction_tvs) {
+  // Use root domain map to check the reduction ops have the same axes
+  FusionGuard fg(fusion);
+  ComputeAtRootDomainMap root_map;
+  root_map.build(true);
+
+  for (const auto it : c10::irange(1, reduction_tvs.size())) {
+    if (!registry_utils::checkPatternEquivalence(
+            reduction_tvs[it - 1], reduction_tvs[it], root_map)) {
+      scheduler_debug_utils::canScheduleRejectReason(
+          schedule_heuristic,
+          "unmapped reduction ",
+          reduction_tvs[it - 1],
+          " and ",
+          reduction_tvs[it]);
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
 bool OuterPersistentKernelScheduler::canScheduleCompileTime(Fusion* fusion) {
   // Needs at least one reduction to consider.
   auto reduction_ops = ir_utils::getReductionOps(fusion);
   if (reduction_ops.empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent, "needs a reduction op");
+        schedule_heuristic, "needs a reduction op");
     return false;
   }
 
   if (ir_utils::filterByType<TensorView>(fusion->inputs()).empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
-        "Scheduling not supported with no input");
+        schedule_heuristic, "Scheduling not supported with no input");
     return false;
   }
 
   // Check that inputs of all select/gather-like ops are fusion inputs
   if (registry_utils::rejectScheduleForMemoryPromotion(
-          fusion, ScheduleHeuristic::OuterPersistent)) {
+          fusion, schedule_heuristic)) {
     return false;
   }
 
   // Fusions handled by persistent kernel scheduler cannot have MmaOp.
   if (!ir_utils::getMmaOps(fusion).empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent, "no support for mma ops.");
+        schedule_heuristic, "no support for mma ops.");
     return false;
   }
 
   if (registry_utils::hasNonUniqueBcast(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
+        schedule_heuristic,
         "Broadcasting dimension might be broadcasting to multiple sizes.");
     return false;
   }
@@ -86,54 +114,39 @@ bool OuterPersistentKernelScheduler::canScheduleCompileTime(Fusion* fusion) {
   if (reduction_tvs.empty()) {
     // Use pointwise logic
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent, "no reduction tv");
+        schedule_heuristic, "no reduction tv");
     return false;
   }
 
-  std::vector<TensorView*> inner_reduction_tvs;
-  std::vector<TensorView*> outer_reduction_tvs;
-  for (auto tv : reduction_tvs) {
-    if (scheduler_utils::isFastestDimReduction(tv)) {
-      inner_reduction_tvs.emplace_back(tv);
-    } else {
-      outer_reduction_tvs.emplace_back(tv);
-    }
-  }
-  bool combined_inner_outer =
-      !inner_reduction_tvs.empty() && !outer_reduction_tvs.empty();
+  auto reduction_type =
+      reduction_scheduler_utils::getReductionType(reduction_tvs);
 
-  if (!inner_reduction_tvs.empty() || outer_reduction_tvs.empty()) {
+  if (reduction_type != reduction_scheduler_utils::ReductionType::Outer) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
-        "ScheduleHeuristic::OuterPersistent requires outer reduction tvs without inner reduction tvs.");
+        schedule_heuristic,
+        "schedule_heuristic requires outer reduction tvs without inner reduction tvs.");
     return false;
   }
 
-  if (!checkReductionPattern(
-          fusion, inner_reduction_tvs, outer_reduction_tvs)) {
+  if (!checkReductionPattern(fusion, reduction_tvs)) {
     return false;
   }
-  // If there is both inner and outer reduction, we use the first inner
-  // reduction tv as reference, otherwise we use the first reduction tv,
-  // whether it is inner or outer.
-  TensorView* reference_tv =
-      combined_inner_outer ? inner_reduction_tvs[0] : reduction_tvs[0];
 
   if (!ir_utils::getViewOps(fusion).empty()) {
     ComputeAtMap ca_map(fusion);
     if (registry_utils::requiresForwardViewReplay(fusion, ca_map)) {
       scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::OuterPersistent,
-          "Fusion requires view being reversible.");
+          schedule_heuristic, "Fusion requires view being reversible.");
       return false;
     }
 
     // Persistent scheduler simply uses reference_tv as the reference, if
     // that changes, this needs to be changed.
+    TensorView* reference_tv = reduction_tvs[0];
     if (registry_utils::reductionInterferingView(
             fusion, ca_map, reference_tv)) {
       scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::OuterPersistent,
+          schedule_heuristic,
           "View may interfere with normalization scheduling.");
       return false;
     }
@@ -161,7 +174,7 @@ bool OuterPersistentKernelScheduler::canScheduleCompileTime(Fusion* fusion) {
     } else {
       if (reduction_root_size(red) != axis_count) {
         scheduler_debug_utils::canScheduleRejectReason(
-            ScheduleHeuristic::OuterPersistent,
+            schedule_heuristic,
             "inconsistent reduction root size: ",
             red->toString(),
             ", expected: ",
@@ -175,22 +188,21 @@ bool OuterPersistentKernelScheduler::canScheduleCompileTime(Fusion* fusion) {
   auto persistent_buffer_info = scheduler_utils::persistentBuffers(fusion);
   if (persistent_buffer_info.persistent_buffers.empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent, "no persistent buffer identified");
+        schedule_heuristic, "no persistent buffer identified");
     return false;
   }
 
   if (registry_utils::SchedulerTopologyChecker::
           hasNonNormalizePostReductionBCast(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
-        "unsupported post reduction normalization");
+        schedule_heuristic, "unsupported post reduction normalization");
     return false;
   }
 
   if (registry_utils::SchedulerTopologyChecker::
           hasGatherToBroadcastBeforeReduction(fusion, reduction_tvs)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
+        schedule_heuristic,
         "has unsupported gather-like ops before normalization");
     return false;
   }
@@ -211,290 +223,9 @@ bool OuterPersistentKernelScheduler::canScheduleRunTime(
           });
 
   auto& reduction_tvs = reduction_tv_entry.get();
-  bool inner_reduction = false;
-  bool outer_reduction = false;
-  TensorView* first_inner_reduction_tv = nullptr;
-  for (auto tv : reduction_tvs) {
-    if (scheduler_utils::isFastestDimReduction(tv)) {
-      first_inner_reduction_tv = tv;
-      inner_reduction = true;
-    } else {
-      outer_reduction = true;
-    }
-  }
-
-  // If there is both inner and outer reduction, we use the first inner
-  // reduction tv to get properties, otherwise we use the first reduction tv,
-  // whether it is inner or outer.
-  auto reference_tv = inner_reduction && outer_reduction
-      ? first_inner_reduction_tv
-      : reduction_tvs[0];
 
   auto properties = scheduler_utils::getReductionProperties(
-      fusion, runtime_info, reference_tv);
-
-  const int64_t warp_size = at::cuda::getCurrentDeviceProperties()->warpSize;
-
-  if (!properties.fastest_dim_reduction) {
-    return canScheduleRunTimeOuter(
-        fusion, runtime_info, data_cache, reduction_tvs, properties);
-  }
-
-  // pair of persistent_buffer_size and available_persistent_buffer_size
-  const std::pair<int64_t, int64_t> buffer_size =
-      getPersistentBufferSize(fusion, runtime_info, data_cache, reduction_tvs);
-  const int64_t persistent_buffer_size = buffer_size.first;
-  const int64_t available_persistent_buffer_size = buffer_size.second;
-
-  const int64_t device_multiprocessor_count =
-      (int64_t)at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-
-  if (persistent_buffer_size > available_persistent_buffer_size) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
-        "not enough registers or shared memory for persistence");
-    return false;
-  }
-
-  if (inner_reduction && outer_reduction) {
-    // get vectorize_factor, same process to that in
-    // getOuterPersistentHeuristics
-    auto reduced_tv = ir_utils::getSoleProducerTv(reference_tv);
-    const auto vectorize_factor = vectorize_helper::getVectorizationFactor(
-        runtime_info,
-        reduced_tv,
-        data_cache,
-        (int)(reduced_tv->nDims() - properties.inner_most_dimension_ndims));
-    // check if we can schedule the combined reductions with a reasonable
-    // batch size without register spills.
-    if (!normalization_scheduler_utils::
-             getOptionalInnerOuterPersistentBufferBatches(
-                 properties.total_reduction_numel,
-                 properties.total_iteration_numel,
-                 persistent_buffer_size,
-                 (int64_t)vectorize_factor,
-                 warp_size,
-                 false)
-                 .first.has_value()) {
-      scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::OuterPersistent,
-          "Required batch number is larger than available batch number! Will cause register spills!");
-      return false;
-    }
-  }
-
-  const int64_t device_max_threads_per_multiprocessor =
-      (int64_t)at::cuda::getCurrentDeviceProperties()
-          ->maxThreadsPerMultiProcessor;
-
-  // Maximum number of iteration dimensions we can have and still be
-  // persistent.
-  const int64_t max_multi_reduction_factor = scheduler_utils::safeDiv(
-      available_persistent_buffer_size, persistent_buffer_size);
-
-  const int64_t required_sm_per_norm =
-      ceilDiv(persistent_buffer_size, scheduler_utils::register_file_size);
-
-  // If the persistence requires over half the device don't do grid
-  // persistence as we can't overlap the grid comms.
-  if (required_sm_per_norm >
-      scheduler_utils::safeDiv(device_multiprocessor_count, 3)) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
-        "requires over half GPU persistence.");
-    return false;
-  }
-
-  const int64_t norm_per_sm =
-      ceilDiv(scheduler_utils::register_file_size, persistent_buffer_size);
-
-  // If outer reduction, don't go persistent if we can't fit half a warp in
-  // the iter domain of the persistent reduction.
-  if (!properties.fastest_dim_reduction &&
-      !(norm_per_sm >= warp_size / 2 ||
-        max_multi_reduction_factor >= warp_size)) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent, "not enough threads");
-    return false;
-  }
-
-  // Don't go persistent if we can't use a small fraction of the
-  // available SMs yet have a large reduction size.
-  if ( // Large reduction dim
-      properties.total_reduction_numel >=
-          device_max_threads_per_multiprocessor * 4 &&
-      properties.total_iteration_numel <
-          (properties.fastest_dim_reduction
-               ? scheduler_utils::safeDiv(device_multiprocessor_count, 8)
-               // Make sure we at least use a quarter of the device * a
-               // half warp
-               : (warp_size / 8) * device_multiprocessor_count)) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent, "not enough blocks");
-    return false;
-  }
-
-  return true;
-}
-
-void OuterPersistentKernelScheduler::computeHeuristics(
-    Fusion* fusion,
-    SchedulerRuntimeInfo& runtime_info,
-    HeuristicSummary* data_cache) {
-  params_ = getOuterPersistentHeuristics(fusion, runtime_info, data_cache);
-  NVF_ERROR(params_ != nullptr);
-}
-
-bool OuterPersistentKernelScheduler::checkReductionPattern(
-    Fusion* fusion,
-    const std::vector<TensorView*>& inner_reduction_tvs,
-    const std::vector<TensorView*>& outer_reduction_tvs) {
-  // Use root domain map to check the reduction ops have the same axes
-  FusionGuard fg(fusion);
-  ComputeAtRootDomainMap root_map;
-  root_map.build(true);
-
-  // check inner and outer reductions seperately
-  for (const auto& rtvs : {inner_reduction_tvs, outer_reduction_tvs}) {
-    for (const auto it : c10::irange(1, rtvs.size())) {
-      if (!registry_utils::checkPatternEquivalence(
-              rtvs[it - 1], rtvs[it], root_map)) {
-        scheduler_debug_utils::canScheduleRejectReason(
-            ScheduleHeuristic::OuterPersistent,
-            "unmapped reduction ",
-            rtvs[it - 1],
-            " and ",
-            rtvs[it]);
-        return false;
-      }
-    }
-  }
-  // combined inner and outer reduction is of general purpose but only tested
-  // for layer norm backward
-  if (!inner_reduction_tvs.empty() && !outer_reduction_tvs.empty()) {
-    if (!normalization_scheduler_utils::checkIfReductionsAreInnerOuter(
-            inner_reduction_tvs, outer_reduction_tvs)) {
-      scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::OuterPersistent,
-          "to use combined reduction, inner reduction tensor should be [I,I,...,R,R] and outer reduction tensor should be [R,R,...,I,I]");
-      return false;
-    }
-
-    if (!normalization_scheduler_utils::hasSharedInput(
-            inner_reduction_tvs, outer_reduction_tvs)) {
-      scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::OuterPersistent,
-          "to use combined reduction, inner reduction and outer reduction should have shared input.");
-      return false;
-    }
-
-    if (!normalization_scheduler_utils::isConnectedOnlyThroughReductionProducer(
-            inner_reduction_tvs, outer_reduction_tvs)) {
-      scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::OuterPersistent,
-          "to use combined reduction, inner reduction and outer reduction should not have shared consumer, their consumers should not have shared non-outer-reduction producer.");
-      return false;
-    }
-  }
-  return true;
-}
-
-std::pair<int64_t, int64_t> OuterPersistentKernelScheduler::
-    getPersistentBufferSize(
-        Fusion* fusion,
-        SchedulerRuntimeInfo& runtime_info,
-        HeuristicSummary* data_cache,
-        const std::vector<TensorView*>& reduction_tvs) {
-  auto persistent_buffer_info_entry =
-      HeuristicSummaryEntry<HeuristicCompileTime::PersistentBufferInfo>(
-          data_cache, [&fusion]() {
-            return std::make_unique<scheduler_utils::PersistentBufferInfo>(
-                scheduler_utils::persistentBuffers(fusion));
-          });
-
-  auto& persistent_buffer_info = persistent_buffer_info_entry.get();
-
-  auto persistent_buffer_size_info = scheduler_utils::persistentBufferSize(
-      fusion, runtime_info, persistent_buffer_info, data_cache);
-
-  // Note that projected buffer size can be zero
-  auto persistent_buffer_size =
-      persistent_buffer_size_info.projected_persistent_buffer_size == 0
-      ? persistent_buffer_size_info.persistent_buffer_size
-      : std::min(
-            persistent_buffer_size_info.persistent_buffer_size,
-            persistent_buffer_size_info.projected_persistent_buffer_size);
-
-  // in combined_inner_outer_reduction, the partial results of outer
-  // reductions must be persistent, allow register spill avoid segmentation
-  int64_t inner_reduction_count = 0;
-  int64_t outer_reduction_count = 0;
-  std::vector<TensorView*> outer_reduction_tvs;
-  for (auto tv : reduction_tvs) {
-    if (scheduler_utils::isFastestDimReduction(tv)) {
-      inner_reduction_count++;
-    } else {
-      outer_reduction_count++;
-      outer_reduction_tvs.emplace_back(tv);
-    }
-  }
-  const bool combined_inner_outer_reduction =
-      inner_reduction_count && outer_reduction_count;
-  if (combined_inner_outer_reduction) {
-    persistent_buffer_size +=
-        normalization_scheduler_utils::partialReductionBufferSize(
-            outer_reduction_tvs, runtime_info);
-  }
-
-  // At this point, we use the full register file size only for the
-  // inner-outer case. It does not mean the full size shouldn't be used
-  // otherwise, but more detailed tuning of the heuristics would be required.
-  int64_t available_persistent_buffer_size = combined_inner_outer_reduction
-      ? scheduler_utils::register_file_size_full
-      : scheduler_utils::register_file_size;
-
-  // Use shared memory for persistent buffer is only tested for inner
-  // reduction
-  // TODO: extend to outer reduction and combined reduction
-  const bool allow_shared_memory =
-      inner_reduction_count > 0 && outer_reduction_count == 0;
-  if (allow_shared_memory) {
-    const auto dev_prop = at::cuda::getCurrentDeviceProperties();
-    const int64_t max_shared_memory_size =
-        (int64_t)dev_prop->sharedMemPerBlockOptin;
-    // Some shared memories are reserved for kernel launch overhead and
-    // reduction_broadcast_workspace. Estimation is conservative, but should
-    // be good enough. The actual threads per block is set in the heuristics
-    // and it may be smaller than maxThreadsPerBlock.
-    // TODO: More accurate estimation of available shared memory size.
-    const int64_t kernel_overhead =
-        (int64_t)dev_prop->reservedSharedMemPerBlock;
-    int64_t max_buffer_dtype_size = 1;
-    for (auto tv : persistent_buffer_info.persistent_buffers) {
-      max_buffer_dtype_size = std::max(
-          max_buffer_dtype_size,
-          dataTypeSize(tv->getDataType().value(), runtime_info.getIndexType()));
-    }
-    const int64_t reduction_broadcast_workspace =
-        (int64_t)(dev_prop->maxThreadsPerBlock) * max_buffer_dtype_size;
-    const int64_t available_shared_memory_size = max_shared_memory_size -
-        kernel_overhead - reduction_broadcast_workspace;
-    available_persistent_buffer_size = std::max(
-        available_persistent_buffer_size, available_shared_memory_size);
-  }
-
-  return std::make_pair(
-      persistent_buffer_size, available_persistent_buffer_size);
-}
-
-bool OuterPersistentKernelScheduler::canScheduleRunTimeOuter(
-    Fusion* fusion,
-    SchedulerRuntimeInfo& runtime_info,
-    HeuristicSummary* data_cache,
-    const std::vector<TensorView*>& reduction_tvs,
-    const scheduler_utils::ReductionTvProperties& properties) {
-  FUSER_PERF_SCOPE("OuterPersistentKernelScheduler::canScheduleRuntimeOuter");
-  FusionGuard fg(fusion);
+      fusion, runtime_info, reduction_tvs[0]);
 
   const auto device_prop = at::cuda::getCurrentDeviceProperties();
 
@@ -529,8 +260,7 @@ bool OuterPersistentKernelScheduler::canScheduleRunTimeOuter(
 
   if (persistent_buffer_size > available_persistent_buffer_size) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
-        "not enough registers for persistence");
+        schedule_heuristic, "not enough registers for persistence");
     return false;
   }
 
@@ -557,7 +287,7 @@ bool OuterPersistentKernelScheduler::canScheduleRunTimeOuter(
   if (required_sm_per_norm >
       scheduler_utils::safeDiv(device_multiprocessor_count, 2)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
+        schedule_heuristic,
         "requires over half GPU persistence.",
         " required SMs per normalization: ",
         required_sm_per_norm);
@@ -575,7 +305,7 @@ bool OuterPersistentKernelScheduler::canScheduleRunTimeOuter(
     // TODO: Is this necessary for block persistence as well?
     if (vectorization_factor < 4) {
       scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::OuterPersistent, "not enough vectorized");
+          schedule_heuristic, "not enough vectorized");
       return false;
     }
 
@@ -589,7 +319,7 @@ bool OuterPersistentKernelScheduler::canScheduleRunTimeOuter(
 
     if (!cross_grid_params.has_value()) {
       scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::OuterPersistent, "no valid launch config found");
+          schedule_heuristic, "no valid launch config found");
       return false;
     }
   }
@@ -606,7 +336,7 @@ bool OuterPersistentKernelScheduler::canScheduleRunTimeOuter(
   // factor
   if (max_multi_reduction_factor < min_multi_reduction_factor) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
+        schedule_heuristic,
         "Not enough threads.",
         " Multi reduction factor, ",
         max_multi_reduction_factor,
@@ -631,9 +361,7 @@ bool OuterPersistentKernelScheduler::canScheduleRunTimeOuter(
   if (is_cross_grid &&
       max_used_sms < scheduler_utils::safeDiv(device_multiprocessor_count, 2)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent,
-        "cross grid - not enough used SMs: ",
-        max_used_sms);
+        schedule_heuristic, "cross grid - not enough used SMs: ", max_used_sms);
     return false;
   }
 
@@ -645,7 +373,7 @@ bool OuterPersistentKernelScheduler::canScheduleRunTimeOuter(
           device_max_threads_per_multiprocessor * 4 && // Large reduction dim
       max_used_sms < min_fraction_of_sms) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent, "not enough used SMs");
+        schedule_heuristic, "not enough used SMs");
     return false;
   }
 
@@ -662,7 +390,7 @@ bool OuterPersistentKernelScheduler::canScheduleRunTimeOuter(
             return !reduction_tv->definition()->isA<WelfordOp>();
           })) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent, "non-Welford not enabled yet");
+        schedule_heuristic, "non-Welford not enabled yet");
     return false;
   }
 
@@ -679,11 +407,19 @@ bool OuterPersistentKernelScheduler::canScheduleRunTimeOuter(
        0) &&
       device_prop->major == 7) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::OuterPersistent, "iteration not evenly divided");
+        schedule_heuristic, "iteration not evenly divided");
     return false;
   }
 
   return true;
+}
+
+void OuterPersistentKernelScheduler::computeHeuristics(
+    Fusion* fusion,
+    SchedulerRuntimeInfo& runtime_info,
+    HeuristicSummary* data_cache) {
+  params_ = getOuterPersistentHeuristics(fusion, runtime_info, data_cache);
+  NVF_ERROR(params_ != nullptr);
 }
 
 namespace {
@@ -724,873 +460,6 @@ class HeuristicParameterWrapper {
 } // namespace
 
 namespace {
-
-// The innerOuterPersistentHeuristic is tuned for layer_norm backward on A100
-// ======= Method if hidden_size > 1024 =======
-// (1) Inner reduction is one reduction per block. Reduction domain is
-// parallelized by TIDx and TIDy, Iteration domain is parallelized by BIDy. (2)
-// Outer reduction is done in two-steps. The first step is partial reduction,
-// reduction domain is parallelized by BIDy, iteration domain is parallelized by
-// TIDx and TIDy. The partial results are written to gmem followed by a grid
-// sync. The second step is block reduction, the reduction domain is
-// parallelized by TIDy, the iteration domain is parallelized by TIDx and BIDy.
-// ======= Method if hidden_size <= 1024 =======
-// (1) Inner reduction is multi-reductions per blocks. Reduction domain is
-// parallelized by TIDx, Iteration domain is parallelized by BIDy and TIDy
-// (2) Outer reduction is same to cases where hidden_size > 1024 except the
-// second step where in this case, the reduction domain is parallelized by TIDx
-// and the iteration domain is parallelized by TIDy and BIDy. This switch
-// between TIDx and TIDy is because (a) We can do warp reduction with TIDx and
-// (b) TIDx*BIDy is usually much larger than hidden_size, e.g. 128*216 = 1024*27
-// this means without switch only 1/27 of the threads is used.
-std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
-    const int64_t outer_dim_numel,
-    const int64_t inner_dim_numel,
-    const int64_t max_persistent_buffer_size,
-    const size_t tmp_gmem_dtype_size,
-    const size_t vectorize_factor) {
-  auto rparams = std::make_shared<ReductionParams>();
-  // Parameters for inner reduction:
-  // Reduction dim: inner_vect, inner_batch, bdimx and bdimy
-  // Iteration dim: gdimy
-
-  // Parameters for outer reduction:
-  // Reduction dim: bdimy
-  // Iteration dim: vectorization_factor_outer, bdimx, gdimy
-  struct InnerOuterParams {
-    int64_t inner_vect = -1;
-    int64_t inner_batch = -1;
-    int64_t bdimx = -1;
-    int64_t bdimy = -1;
-    int64_t gdimy = -1;
-    int64_t tmp_gmem_write_vect = -1;
-    int64_t vectorization_factor_outer = -1;
-
-    void verify() {
-      NVF_ERROR(inner_vect != -1, "inner_vect is not set.");
-      NVF_ERROR(inner_batch != -1, "inner_batch is not set.");
-      NVF_ERROR(bdimx != -1, "bdimx is not set.");
-      NVF_ERROR(bdimy != -1, "bdimy is not set.");
-      NVF_ERROR(gdimy != -1, "gdimy is not set.");
-      NVF_ERROR(tmp_gmem_write_vect != -1, "tmp_gmem_write_vect is not set.");
-      NVF_ERROR(
-          vectorization_factor_outer != -1,
-          "vectorization_factor_outer is not set.");
-    }
-  };
-
-  InnerOuterParams iop;
-
-  // Estimate register per thread based on buffer size, since inner reduction
-  // dim is fully parallelized, the buffer size of each thread equals the total
-  // buffer size divide by inner_dim_numel.
-  auto getEstimatedRegisterUsage = [&](int64_t batch_mul_vect) {
-    constexpr int64_t bytes_per_register = 4;
-    const int64_t persistent_buffer_size =
-        max_persistent_buffer_size / inner_dim_numel * batch_mul_vect;
-    const int64_t estimated_register_count =
-        persistent_buffer_size / bytes_per_register +
-        scheduler_utils::register_overhead;
-    return std::min(
-        estimated_register_count, scheduler_utils::max_registers_per_thread);
-  };
-
-  auto getBlocksPerSM = [&](const int64_t threads_per_sm,
-                            const int64_t threads_per_block,
-                            const int64_t warp_size) {
-    constexpr int64_t warp_allocation_granularity = 4;
-    const int64_t allocated_warps_per_block =
-        ceilDiv(
-            ceilDiv(threads_per_block, warp_size),
-            warp_allocation_granularity) *
-        warp_allocation_granularity;
-    return scheduler_utils::safeDiv(
-        threads_per_sm / warp_size, allocated_warps_per_block);
-  };
-
-  const auto dev_prop = at::cuda::getCurrentDeviceProperties();
-  const int64_t device_multiprocessor_count =
-      (int64_t)dev_prop->multiProcessorCount;
-
-  // Step-1, set InnerParams reduction dim: inner_vect, inner_batch,
-  // threads_per_block (bdimx * bdimy). Start threads_per_block from a quarter
-  // warp, gradually increase it. Runtime checkCombinedReductionShape ensures
-  // inner_dim_numel is dividable by the multiplication of a quarter warp and
-  // vectorize_factor.
-  iop.inner_vect = (int64_t)vectorize_factor;
-
-  // ignore_register_size_limit will return a valid batch size.
-  // This is needed because we enforced projection for fp32 if the feature size
-  // is less or equal 14K. It leads to register spills but still faster than the
-  // unprojected version due to the reuse of a input para in this grid
-  // persistent kernel. However, when we do register usage check in
-  // canScheduleRuntime, the enforced projection is not considered. Thus,
-  // max_persistent_buffer_size used here is larger than the value used in
-  // canScheduleRuntime.
-  // This is a tmp solution before we have a new persistent heuristics, where
-  // the projection is not solely based on size of buffers. The enforced buffer
-  // projection is not considered in canScheduleRuntime Thus,
-  constexpr bool ignore_register_size_limit = true;
-  const auto& batch_and_block_size = normalization_scheduler_utils::
-      getOptionalInnerOuterPersistentBufferBatches(
-          inner_dim_numel,
-          outer_dim_numel,
-          max_persistent_buffer_size,
-          iop.inner_vect,
-          dev_prop->warpSize,
-          ignore_register_size_limit);
-  auto opt_inner_batch = batch_and_block_size.first;
-  NVF_ERROR(opt_inner_batch.has_value());
-  iop.inner_batch = opt_inner_batch.value();
-  int64_t threads_per_block = batch_and_block_size.second;
-
-  NVF_ERROR(
-      iop.inner_vect * iop.inner_batch * threads_per_block >= inner_dim_numel,
-      " iop.inner_vect * iop.inner_batch * threads_per_block should >= inner_dim_numel.");
-
-  // Step-2, set InnerParams Iteration dim: gdimy. reg_per_thread is estimated
-  // from buffer size, then it is used to calculate threads_per_sm and gdimy.
-  // gdimy_max ensures each block processes at least 8 rows to
-  // reduce the workload of the final outer reduction.
-  int64_t reg_per_thread =
-      getEstimatedRegisterUsage(iop.inner_vect * iop.inner_batch);
-  int64_t threads_per_sm = getThreadsPerSMGivenRegPerThread(reg_per_thread);
-  int64_t blocks_per_sm =
-      getBlocksPerSM(threads_per_sm, threads_per_block, dev_prop->warpSize);
-  iop.gdimy = blocks_per_sm * device_multiprocessor_count;
-  const int64_t outer_iter_min = 8;
-  const int64_t gdimy_max = scheduler_utils::roundUpToN(
-      ceilDiv(outer_dim_numel, outer_iter_min), device_multiprocessor_count);
-  while (iop.gdimy > gdimy_max && blocks_per_sm > 1) {
-    blocks_per_sm -= 1;
-    iop.gdimy = blocks_per_sm * device_multiprocessor_count;
-  }
-
-  // set the vectorization factor for the write to tmp gmem, may be different
-  // from inner_vect due to different data types, e.g. input is half and
-  // tmp_gmem is float
-  constexpr int64_t max_gmem_vect_access_bytes = 16;
-  const int64_t max_tmp_gmem_vect_factor = std::min(
-      max_gmem_vect_access_bytes / (int64_t)tmp_gmem_dtype_size,
-      iop.inner_vect);
-  iop.tmp_gmem_write_vect = max_tmp_gmem_vect_factor;
-
-  // Step-3, set OuterParams Iteration dim: vectorization_factor_outer, bdimx,
-  // gdimy (already done) The partial outer reduction result is stored in tmp
-  // gmem, set the vectorization factor for write and read
-  const int64_t workload_per_thread = inner_dim_numel >= 4096 ? 4l : 2l;
-  iop.vectorization_factor_outer =
-      std::min(workload_per_thread, max_tmp_gmem_vect_factor);
-  // For widely used hidden sizes, threads_per_block has factor of 8, roundup to
-  // increase the probability of bdimx * bdimy == threads_per_block.
-  iop.bdimx = scheduler_utils::roundUpPow2Or8(
-      ceilDiv(inner_dim_numel / iop.vectorization_factor_outer, iop.gdimy));
-  // if still not divisible, e.g. threads_per_block = 256, bdimx = 40.
-  // increase bdimx to make it divisible. Under worst case, bdimx equals to
-  // threads_per_block.
-  while (threads_per_block % iop.bdimx) {
-    iop.bdimx = std::min(iop.bdimx + 8, threads_per_block);
-  }
-  // Step-4, set OuterParams Reduction dim: bdimy.
-  iop.bdimy = threads_per_block / iop.bdimx;
-  NVF_ERROR(
-      iop.bdimy * iop.bdimx == threads_per_block,
-      " threads_per_block must be divisible by bdimx and bdimy.");
-  // Step-5, special case, when inner_dim_numel <= 1024, bdimx is usually small
-  // after divide by inner_vect and inner_batch. In this case, bdimy is used to
-  // parallelize outer_dim instead of inner_dim. This pattern is named multi
-  // reductions per block (mrpb).
-  if (inner_dim_numel <= 1024) {
-    rparams->multiple_reds_per_blk = true;
-    rparams->tidx_for_outer_reduction = true;
-    constexpr int64_t threads_per_block_mrpb = 512;
-
-    // Step-1, InnerParams, Reduction dim: inner_vect(reuse),
-    // inner_batch(reuse), bdimx
-    iop.bdimx = ceilDiv(inner_dim_numel, iop.inner_vect * iop.inner_batch);
-
-    // Step-2, InnerParams, Iteration dim: gdimy, bdimy (in next step)
-    reg_per_thread =
-        getEstimatedRegisterUsage(iop.inner_vect * iop.inner_batch);
-    threads_per_sm = getThreadsPerSMGivenRegPerThread(reg_per_thread);
-    blocks_per_sm = getBlocksPerSM(
-        threads_per_sm, threads_per_block_mrpb, dev_prop->warpSize);
-    iop.gdimy = blocks_per_sm * device_multiprocessor_count;
-
-    // Step-3, OuterParams, Iteration dim: vectorization_factor_outer(reuse),
-    // bdimy, gdimy (in previous step). We prefer bdimy to be larger enough to
-    // cover what is left in both the outer_dim and inner_dim. However, it
-    // should not exceed the limitation set by threads_per_block_mrpb.
-    int64_t bdimy_tmp = std::max(
-        ceilDiv(outer_dim_numel, iop.gdimy),
-        ceilDiv(inner_dim_numel, iop.vectorization_factor_outer * iop.gdimy));
-    iop.bdimy = std::min(threads_per_block_mrpb / iop.bdimx, bdimy_tmp);
-
-    // Step-4, OuterParams, Reduction dim: bdimx (already done)
-
-    if (iop.bdimx % dev_prop->warpSize == 0) {
-      rparams->pad_inner_reduction_to_warp = true;
-      rparams->pad_outer_reduction_to_warp = true;
-    }
-    rparams->block_dim_iter_dom = ParallelType::TIDy;
-  } else {
-    rparams->block_dim_inner_reduction_extra = ParallelType::TIDy;
-  }
-
-  // check all the parameters in InnerOuterParams are set.
-  iop.verify();
-
-  rparams->persistent_kernel = true;
-  rparams->fastest_dim = true;
-  rparams->combined_inner_outer = true;
-  // tmp_gmem is the intermediate result of outer reduction, its dtype is float,
-  // so the maximum vectorization factor is 4.
-  rparams->vectorization_factor_outer = iop.vectorization_factor_outer;
-  rparams->vectorization_factor_tmp_gmem_write = iop.tmp_gmem_write_vect;
-  rparams->cparams.maxrregcount = (int)getRegPerThreadGivenThreadsPerSM(
-      iop.bdimx * iop.bdimy * blocks_per_sm);
-  rparams->unroll_factor_inner_reduction = iop.inner_vect;
-  rparams->batches_per_block_inner_reduction = iop.inner_batch;
-  rparams->block_dim_inner_reduction = ParallelType::TIDx;
-  rparams->vectorize_inner_reduction = iop.inner_vect > 1;
-  rparams->split_grid_dim_iter_dom_outer = true;
-  rparams->grid_dim_iter_dom = ParallelType::BIDy;
-  rparams->lparams = LaunchParams(
-      LaunchParams::UNINITIALIZED_VAL,
-      iop.gdimy,
-      LaunchParams::UNINITIALIZED_VAL,
-      iop.bdimx,
-      iop.bdimy,
-      LaunchParams::UNINITIALIZED_VAL);
-
-  rparams->tag = "InnerOuter Persistent Heuristic.\n";
-
-  if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    debug() << "\n===== Combined InnerOuter Reduction Stats ========\n"
-            << "outer_dim_numel: " << outer_dim_numel << "\n"
-            << "inner_dim_numel: " << inner_dim_numel << "\n"
-            << "max_persistent_buffer_size: " << max_persistent_buffer_size
-            << "\n"
-            << "vectorize_factor_input: " << iop.inner_vect << "\n"
-            << "vectorization_factor_tmp_gmem_write: "
-            << iop.tmp_gmem_write_vect << "\n"
-            << "vectorization_factor_outer: " << iop.vectorization_factor_outer
-            << "\n"
-            << "multiple_reds_per_blk: " << rparams->multiple_reds_per_blk
-            << "\n"
-            << "threads_per_sm: " << threads_per_sm << "\n"
-            << "gdimy: " << iop.gdimy << "\n"
-            << "block(" << (iop.bdimx) << ", " << iop.bdimy << ", " << 1 << ")";
-    debug() << rparams->toString() << std::endl;
-  }
-  return rparams;
-}
-// Copied from reduction scheduler, should generalize. Simply needed to take out
-// grid reductions.
-std::shared_ptr<ReductionParams> innerPersistentHeuristicSharedMemory(
-    const int64_t total_reduction_numel,
-    const int64_t total_iteration_numel,
-    const int64_t inner_most_dimension_numel,
-    const int64_t n_tensor_inputs,
-    const int64_t max_input_dtype_size,
-    const int64_t max_persistent_buffer_size,
-    const size_t max_vectorize_factor) {
-  const auto dev_prop = at::cuda::getCurrentDeviceProperties();
-  auto rparams = std::make_shared<ReductionParams>();
-  rparams->shared_mem_persistent_buffer = true;
-  rparams->persistent_kernel = true;
-  rparams->fastest_dim = true;
-  // Inner reduction domain
-  // This heuristic is only used for cases with large total_reduction_numel.
-  // e.g. layer_norm with hidden size larger than 64K for fp16 or 32K for fp32.
-  // fully vectorized, use maxThreadsPerBlock to reduce workload per threads
-  int64_t vectorize_factor = (int64_t)max_vectorize_factor;
-  int64_t bdimx = dev_prop->maxThreadsPerBlock;
-  NVF_ERROR(
-      total_reduction_numel >= vectorize_factor * bdimx,
-      "total_reduction_numel should be larger than or equal to vectorize_factor * bdimx.\n",
-      "total_reduction_numel= ",
-      total_reduction_numel,
-      ", vectorize_factor= ",
-      vectorize_factor,
-      ", bdimx= ",
-      bdimx);
-  int64_t persistent_batch =
-      ceilDiv(total_reduction_numel, vectorize_factor * bdimx);
-  rparams->cross_block_inner_reduction = true;
-  rparams->block_dim_inner_reduction = ParallelType::TIDx;
-  rparams->pad_inner_reduction_to_warp = true;
-  rparams->batches_per_block_inner_reduction = persistent_batch;
-  rparams->unroll_factor_inner_reduction = vectorize_factor;
-  rparams->vectorize_inner_reduction = vectorize_factor > 1;
-
-  // Iter
-  rparams->multiple_reds_per_blk = false;
-  rparams->grid_dim_iter_dom = ParallelType::BIDx;
-  rparams->unroll_factor_iter_dom = 1;
-  rparams->lparams = LaunchParams(
-      LaunchParams::UNINITIALIZED_VAL,
-      LaunchParams::UNINITIALIZED_VAL,
-      LaunchParams::UNINITIALIZED_VAL,
-      LaunchParams::UNINITIALIZED_VAL,
-      LaunchParams::UNINITIALIZED_VAL,
-      LaunchParams::UNINITIALIZED_VAL);
-
-  rparams->tag = "Inner Shared Memory Persistent Heuristic.\n";
-
-  if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    debug() << "\n===== Reduction Stats ========\n"
-            << "total_reduction_numel: " << total_reduction_numel << "\n"
-            << "total_iteration_numel: " << total_iteration_numel << "\n"
-            << "inner_most_dimension_numel: " << inner_most_dimension_numel
-            << "\n"
-            << "vectorize_factor: " << vectorize_factor << "\n"
-            << "n_tensor_inputs: " << n_tensor_inputs << "\n"
-            << "max_input_dtype_size: " << max_input_dtype_size << "\n"
-            << "max_persistent_buffer_size: " << max_persistent_buffer_size
-            << "\n";
-    debug() << rparams->toString() << std::endl;
-  }
-
-  return rparams;
-}
-std::shared_ptr<ReductionParams> innerPersistentHeuristic(
-    const int64_t total_reduction_numel,
-    const int64_t total_iteration_numel,
-    const int64_t inner_most_dimension_numel,
-    const int64_t n_tensor_inputs,
-    const int64_t max_input_dtype_size,
-    const int64_t max_persistent_buffer_size,
-    const size_t vectorize_factor) {
-  if (max_persistent_buffer_size > scheduler_utils::register_file_size) {
-    // use shared memory for persistent buffer
-    return innerPersistentHeuristicSharedMemory(
-        total_reduction_numel,
-        total_iteration_numel,
-        inner_most_dimension_numel,
-        (int64_t)n_tensor_inputs,
-        (int64_t)max_input_dtype_size,
-        max_persistent_buffer_size,
-        vectorize_factor);
-  }
-
-  // Set some targets for parallelization
-  const int64_t n_elems = total_reduction_numel * total_iteration_numel;
-
-  const int64_t outer_reduction_numel =
-      total_reduction_numel / inner_most_dimension_numel;
-
-  const auto dev_prop = at::cuda::getCurrentDeviceProperties();
-  // WARNING: At some point we may want to generate heuristics for another
-  // device that is not the current device.
-  const int64_t device_max_threads_per_multiprocessor =
-      (int64_t)dev_prop->maxThreadsPerMultiProcessor;
-
-  const int64_t device_multiprocessor_count =
-      (int64_t)dev_prop->multiProcessorCount;
-
-  auto const max_unroll = ceilDiv(
-      // Available unrolling based on size of data type
-      16l / max_input_dtype_size,
-      // Reduce unrolling if we have many inputs, start reduction at 4 inputs
-      scheduler_utils::lastPow2(std::max(n_tensor_inputs >> 2, 1l)));
-
-  // Conservative value, could be set to larger based on arch if necessary.
-  constexpr int64_t l1_cache = 32l * 1024l;
-  // Could change per generation, but for l1 we want to consider active threads,
-  // not resident
-  constexpr int64_t active_threads = 1024;
-
-  // if data fits in l2 and we need more parallelization in the reduction dim,
-  // we can use a smaller warp size. While thread local data fits in l1, and
-  // reduction dim is really small, we can use <32 threads per warp.
-  const bool fits_in_l2 =
-      n_elems * max_input_dtype_size * n_tensor_inputs < dev_prop->l2CacheSize;
-
-  // If it fits in l2, we just want to make sure each warp uses 32Bytes. Set
-  // minimum warp as 16 threads instead of 32 as if we have a small reduction
-  // dim going a bit smaller than 32 usually helps.
-  const int64_t warp_size_based_on_l2 =
-      fits_in_l2 ? 32l / max_input_dtype_size : 16l;
-
-  // Check how many elements it would take per thread to start thrashing l1
-  // set that to minimum number we want to reduce per thread.
-  const int64_t warp_size_based_on_l1 = std::min(
-      ceilDiv(
-          total_reduction_numel,
-          scheduler_utils::safeDiv(
-              l1_cache,
-              n_tensor_inputs * max_input_dtype_size * active_threads)),
-      16l);
-
-  // Take the smaller, warp_size may be a odd number, e.g. 15
-  // Tracked at https://github.com/NVIDIA/Fuser/issues/107
-  const int64_t warp_size =
-      std::min(warp_size_based_on_l1, warp_size_based_on_l2);
-
-  // Initialization
-  int64_t target_blocks = 1;
-  int64_t target_unroll = 1;
-  int64_t target_iterations = 1;
-
-  // Try to set a minmum amount of work for each thread, as cross thread
-  // communication is slow so it shouldn't be done for every element in the
-  // reduction.
-  int64_t min_target_iterations =
-      scheduler_utils::safeDiv(32, max_input_dtype_size);
-
-  // Start trying to break parallelization up across threads,
-  // unrolling/iterations, and blocks.
-
-  // max_threads_in_block is the cap on a thread block, the minimum is based on
-  // warp_size
-  int64_t max_threads_in_block = std::max(
-      warp_size, ceilDiv(total_reduction_numel, min_target_iterations));
-
-  // If we have one warp per block, check if that's enough to saturate the SMs
-  target_blocks = ceilDiv(n_elems, warp_size);
-
-  // If we have more than a wave of blocks, put parallelism into unrolling and
-  // target iterations
-  if (target_blocks > device_multiprocessor_count) {
-    auto available_unroll = scheduler_utils::safeDiv(
-        n_elems, warp_size * device_multiprocessor_count);
-
-    // Spread across unrolling and iterations, want a balance of the two so flip
-    // back and forth to alternate adding to them.
-    bool flip = true;
-
-    while (available_unroll > 1 &&
-           (target_unroll < max_unroll ||
-            // Prefer unrolling
-            target_iterations < max_unroll)) {
-      if (target_unroll * 2 <= max_unroll && flip) {
-        target_unroll *= 2;
-      }
-
-      if (target_iterations * 2 <= max_unroll && !flip) {
-        target_iterations *= 2;
-      }
-
-      available_unroll = scheduler_utils::safeDiv(
-          n_elems,
-          warp_size * device_multiprocessor_count * target_unroll *
-              target_iterations);
-      flip = !flip;
-    }
-
-    // Recompute target blocks
-    target_blocks =
-        ceilDiv(n_elems, warp_size * target_unroll * target_iterations);
-  }
-
-  // Cap target blocks to 4 waves
-  target_blocks = std::min(target_blocks, device_multiprocessor_count * 4);
-
-  if (target_blocks * target_unroll * target_iterations < n_elems) {
-    if (outer_reduction_numel == 1) {
-      // set to hardware limit to use small persistent buffer for large
-      // reductions
-      max_threads_in_block = std::min(
-          ceilDiv(n_elems, target_blocks * target_unroll),
-          (int64_t)dev_prop->maxThreadsPerBlock);
-    } else {
-      // targetting 4 waves, so try to use a quarter of available threads
-      max_threads_in_block = std::min(
-          ceilDiv(n_elems, target_blocks * target_unroll),
-          ceilDiv(device_max_threads_per_multiprocessor, (int64_t)4));
-    }
-  }
-
-  // Round up to nearest warp.
-  if (max_threads_in_block % warp_size != 0) {
-    max_threads_in_block += warp_size - max_threads_in_block % warp_size;
-    max_threads_in_block =
-        std::min(max_threads_in_block, (int64_t)dev_prop->maxThreadsPerBlock);
-  }
-  // Compute maximum number of reductions we could do in the same kernel based
-  // on persistent buffer size. Bounded by the wave count for utilization of
-  // SMs.
-  const int64_t max_multi_reduction_factor = std::min(
-      scheduler_utils::safeDiv(
-          scheduler_utils::register_file_size, max_persistent_buffer_size),
-      ceilDiv(total_iteration_numel, device_multiprocessor_count));
-  // To get to target threads:
-  // Prioritize
-  // (1) x dim in reduction
-  // (2) unrolling in reduction
-  // (3) y in output
-  // To get target blocks:
-  // Prioritize
-  // (1) x dim in multiple outputs
-  // (2) y dim in multiple reductions
-
-  // Blocks for outputs
-  int64_t godim = 1;
-
-  // Threads for reduction
-  int64_t bdimx = 1;
-  // Threads for outputs
-  int64_t bdimy = 1;
-  // Threads for outer reduction dimension
-  int64_t bdimz = 1;
-
-  // Unroll amount
-  int64_t inner_reduction_unroll_factor = 1;
-  int64_t outer_reduction_unroll_factor = 1;
-  int64_t iter_unroll_factor = 1;
-
-  inner_reduction_unroll_factor =
-      vectorize_factor > 1 ? (int64_t)vectorize_factor : 1;
-
-  // Grab what we can out of reduction domain, but don't go over a warp size yet
-  bdimx = std::min(
-      std::max(
-          ceilDiv(inner_most_dimension_numel, inner_reduction_unroll_factor),
-          (int64_t)warp_size),
-      max_threads_in_block);
-
-  // If we're not just barely covering the dimension, round to a more friendly
-  // number
-  if (bdimx * inner_reduction_unroll_factor != inner_most_dimension_numel) {
-    bdimx = bdimx > warp_size ? bdimx - bdimx % warp_size
-                              : scheduler_utils::lastPow2(bdimx);
-
-    // Round bdimx down to multiple of warp size or power 2
-    if (bdimx < warp_size) {
-      bdimx = scheduler_utils::lastPow2(bdimx);
-    } else {
-      bdimx = bdimx - bdimx % warp_size;
-    }
-  }
-
-  // Put everything else in bdimy for now
-  bdimy = std::min(
-      scheduler_utils::safeDiv(warp_size, bdimx), max_multi_reduction_factor);
-  // If 3D fill the rest of the threads into bdimz
-  bdimz = std::min(
-      std::min(
-          scheduler_utils::safeDiv(max_threads_in_block, bdimx * bdimy),
-          outer_reduction_numel),
-      scheduler_utils::z_block_limit);
-
-  bool vectorize = false;
-
-  // Move unrolling factor into vectorization upto vectorization limit.
-  if (vectorize_factor > 1 && inner_reduction_unroll_factor > 1) {
-    vectorize = true;
-    inner_reduction_unroll_factor = std::min(
-        scheduler_utils::lastPow2(inner_reduction_unroll_factor),
-        (int64_t)vectorize_factor);
-  }
-
-  // start from small block size to minimize expensive inter-threads reduction
-  const int64_t threads_after_vectorize =
-      inner_most_dimension_numel / inner_reduction_unroll_factor;
-
-  // Test min_threads_per_block using 3 values:
-  // (1) One warp, so we can use single warp reduction and sync.
-  // (2) Two warps, so we can achieve 100% occupancy since most GPUs allow 32
-  //     blocks per SM.
-  // (3) Four warps, number recommended by the cuda-c-best-practices-guide.
-  const int64_t min_threads_per_block = 4l * dev_prop->warpSize;
-
-  // start bdimx with min_threads_per_block then increase if we have too many
-  // persistent buffer batches per block
-  if (outer_reduction_numel == 1 && vectorize) {
-    bdimx = std::min(min_threads_per_block, threads_after_vectorize);
-  }
-
-  // If we don't have enough threads, let's do multiple reductions per block.
-  // Multiple reductions per block shows better performance than unroll
-  // iterations. Still keep vectorization as it is important for performance
-  // since V100.
-  if (bdimx * bdimy * bdimz < min_threads_per_block) {
-    bdimy = std::min(
-        scheduler_utils::safeDiv(min_threads_per_block, bdimx * bdimz),
-        max_multi_reduction_factor);
-  }
-
-  // Set size of persistent per thread buffer on inner reduction buffer
-  // if too large, will be reduced later to reduce register usage
-  int64_t batches_per_block_inner_reduction = ceilDiv(
-      inner_most_dimension_numel, bdimx * inner_reduction_unroll_factor);
-
-  // Attempt to put some unrolling into the outer reduction if inner hasn't
-  // taken the max unrolling
-  if (inner_reduction_unroll_factor < max_unroll) {
-    outer_reduction_unroll_factor = std::min(
-        ceilDiv(max_unroll, inner_reduction_unroll_factor),
-        ceilDiv(outer_reduction_numel, bdimz));
-  }
-
-  godim = ceilDiv(total_iteration_numel, bdimy);
-
-  // Prefer putting iterations into unrolling over having a very large
-  // persistent buffer.
-  while (!vectorize && inner_reduction_unroll_factor < max_unroll &&
-         batches_per_block_inner_reduction >= 2) {
-    inner_reduction_unroll_factor *= 2;
-    batches_per_block_inner_reduction = scheduler_utils::roundUpPow2Or8(ceilDiv(
-        inner_most_dimension_numel, bdimx * inner_reduction_unroll_factor));
-  }
-
-  // Set size of persistent per thread buffer on outer reduction buffer
-  int64_t batches_per_block_outer_reduction =
-      scheduler_utils::roundUpPow2Or8(ceilDiv(
-          ceilDiv(total_reduction_numel, inner_most_dimension_numel),
-          bdimz * outer_reduction_unroll_factor));
-
-  // Prefer putting iterations into unrolling over having a very large
-  // persistent buffer.
-  while (outer_reduction_unroll_factor < max_unroll &&
-         batches_per_block_outer_reduction >= 2) {
-    outer_reduction_unroll_factor *= 2;
-    batches_per_block_outer_reduction = scheduler_utils::roundUpPow2Or8(
-        ceilDiv(outer_reduction_numel, bdimz * outer_reduction_unroll_factor));
-  }
-
-  // Adjust bdimx based on batches_per_block and unroll factor set as they could
-  // have moved a bit since they're the free variables, not the buffers
-  bdimx = ceilDiv(
-      inner_most_dimension_numel,
-      inner_reduction_unroll_factor * batches_per_block_inner_reduction);
-  bdimz = ceilDiv(
-      outer_reduction_numel,
-      outer_reduction_unroll_factor * batches_per_block_outer_reduction);
-
-  // Try moving persistent buffer factors into threads until we have too many
-  // threads.
-  constexpr int batches_per_block_inner_reduction_max = 10;
-  while (
-      // If block size can be doubled
-      bdimx * bdimy * bdimz * 2 <= max_threads_in_block &&
-      // And batches_per_block_inner_reduction can be divided by two
-      (batches_per_block_inner_reduction >
-           batches_per_block_inner_reduction_max ||
-       batches_per_block_outer_reduction >= 2)) {
-    // Try to decrease per thread register allocation persistence size on inner
-    // reduction by double bdimx.
-    if (batches_per_block_inner_reduction >
-        batches_per_block_inner_reduction_max) {
-      bdimx *= 2;
-      batches_per_block_inner_reduction = ceilDiv(
-          inner_most_dimension_numel, inner_reduction_unroll_factor * bdimx);
-      continue;
-    }
-
-    // Try to decrease per thread register allocation persistence size on outer
-    // reduction
-    if (batches_per_block_outer_reduction >= 2 &&
-        batches_per_block_outer_reduction !=
-            scheduler_utils::roundUpPow2Or8(
-                batches_per_block_outer_reduction / 2) &&
-        bdimz * 2 <= scheduler_utils::z_block_limit) {
-      batches_per_block_outer_reduction = scheduler_utils::roundUpPow2Or8(
-          batches_per_block_outer_reduction / 2);
-      bdimz = ceilDiv(
-          outer_reduction_numel,
-          batches_per_block_outer_reduction * outer_reduction_unroll_factor);
-      continue;
-    }
-    break;
-  }
-
-  // Register pressure is really high per thread, which could lead to local
-  // memory leaks, if using less than maximum threads, decrease batches per
-  // block by a factor of 2
-  if (batches_per_block_outer_reduction * batches_per_block_inner_reduction *
-              inner_reduction_unroll_factor * outer_reduction_unroll_factor *
-              4l >
-          scheduler_utils::max_registers_per_thread * 3l &&
-      bdimx * bdimy * bdimz * 2l <= max_threads_in_block &&
-      batches_per_block_inner_reduction >
-          batches_per_block_inner_reduction_max) {
-    batches_per_block_inner_reduction = batches_per_block_inner_reduction / 2;
-  }
-
-  // Do the same on the outer reduction dimension
-  if (batches_per_block_outer_reduction * batches_per_block_inner_reduction *
-              inner_reduction_unroll_factor * outer_reduction_unroll_factor *
-              4l >
-          scheduler_utils::max_registers_per_thread * 3l &&
-      bdimx * bdimy * bdimz * 2l <= device_max_threads_per_multiprocessor &&
-      batches_per_block_outer_reduction >= 2l) {
-    batches_per_block_outer_reduction /= 2l;
-  }
-
-  auto device_warp_size = (int64_t)at::cuda::warp_size();
-  auto padded_bdimx = bdimx % device_warp_size == 0
-      ? bdimx
-      : bdimx + (device_warp_size - bdimx % device_warp_size);
-
-  bool pad_bdimx = bdimx > 16 &&
-      padded_bdimx * bdimy * bdimz < (int64_t)dev_prop->maxThreadsPerBlock;
-
-  // estimate register usage and occupancy raito.
-  // If occupancy raito is less than a preset occupancy_ratio, reduce register
-  // usage register per thread is estimated as overhead + buffer_size /
-  // bytes_per_register
-  int64_t nvrtc_register_per_thread = scheduler_utils::max_registers_per_thread;
-  const int64_t blocksPerKernel = godim;
-  // register estimation is only valid for vectorized gmem access
-  // we've seen unexpectedly high register counts with vectorization factor less
-  // than 4, which would make the below estimate inaccurate.
-  // TODO: support the non vectorized case. consider shmem.
-  // only need to balance register and occupancy ratio if there are enough
-  // blocks and buffers
-  if (vectorize && blocksPerKernel > device_multiprocessor_count &&
-      batches_per_block_inner_reduction > 1) {
-    // Estimate register per thread based on buffer size, since inner reduction
-    // dim is fully parallelized, the buffer size of each element equals the
-    // total buffer size divide by inner_most_dimension_numel. Each thread will
-    // hold batches_per_block_inner_reduction * inner_reduction_unroll_factor
-    // elements.
-    const int64_t persistent_buffer_size = max_persistent_buffer_size /
-        inner_most_dimension_numel * batches_per_block_inner_reduction *
-        inner_reduction_unroll_factor;
-
-    // persistent_buffer_size = 4*2, 8*2, 32*2, 64*2, 128*2
-    // register_used_on_a100  = 27,  40,  62,   73,   105
-    // register_used_on_v100  = xx,  xx,  45,   62,   93
-    // estimated_register_num = 42,  44,  56,   72,   104
-    // safe for both v100 & a100
-    constexpr int64_t bytes_per_register = 4;
-    int64_t estimated_register_count =
-        persistent_buffer_size / bytes_per_register +
-        scheduler_utils::register_overhead;
-
-    // check occupancy using blocks per sm
-    const int64_t threads_per_block =
-        pad_bdimx ? padded_bdimx * bdimy * bdimz : bdimx * bdimy * bdimz;
-    const int64_t blocks_per_sm_estimated =
-        getThreadsPerSMGivenRegPerThread(estimated_register_count) /
-        threads_per_block;
-    // only allow adjust to 90% of estimated_register_count to avoid too much
-    // spills. initially we used 80%, however, the drop from 160 to 128 leads to
-    // too much spills in Layer Norm with fused ops, see
-    // https://github.com/NVIDIA/Fuser/issues/335
-    // 90% allows edge cases, e.g. 72 to 64 which is important for 32K fp16
-    // where batch = 8. With this change, however, we lost 10 % performance on
-    // Softmax_Inner_fp16/16384/4096, where the perf is best when using 64
-    // registers with 232 bytes spill stores and 276 bytes spill loads. The
-    // estimated register for this case is 104 adjusting it to 64 is too
-    // aggressive.
-    constexpr double max_adjust_fraction = 0.9;
-    int64_t register_count_minimum = static_cast<int64_t>(
-        max_adjust_fraction * static_cast<double>(estimated_register_count));
-    const int64_t blocks_per_sm_maximum =
-        getThreadsPerSMGivenRegPerThread(register_count_minimum) /
-        threads_per_block;
-    register_count_minimum = getRegPerThreadGivenThreadsPerSM(
-        blocks_per_sm_maximum * threads_per_block);
-
-    // minimum occupancy we want to achieve
-    constexpr double occupancy_ratio = 0.4;
-    const int64_t blocks_per_sm_wanted = ceilDiv(
-        static_cast<int64_t>(
-            dev_prop->maxThreadsPerMultiProcessor * occupancy_ratio),
-        threads_per_block);
-
-    // if estimated blocks is smaller than wanted and decrease register usage
-    // can increase blocks per sm, try to decrease register usage to increase
-    // occupancy but don't go below register_count_minimum
-    if (blocks_per_sm_estimated < blocks_per_sm_wanted &&
-        blocks_per_sm_maximum > blocks_per_sm_estimated) {
-      const int64_t register_count_occupancy = getRegPerThreadGivenThreadsPerSM(
-          blocks_per_sm_wanted * threads_per_block);
-
-      nvrtc_register_per_thread =
-          std::max(register_count_minimum, register_count_occupancy);
-    } else {
-      // recalculate estimated_register_count using blocks_per_sm_estimated
-      // this may increase estimated_register_count due to allocation
-      // granularity e.g. 104 -> 128
-      nvrtc_register_per_thread = getRegPerThreadGivenThreadsPerSM(
-          blocks_per_sm_estimated * threads_per_block);
-    }
-  }
-
-  // Will be used once supporting inter-block persistence
-  int64_t gdimx = LaunchParams::UNINITIALIZED_VAL;
-  int64_t gdimy = LaunchParams::UNINITIALIZED_VAL;
-  int64_t gdimz = LaunchParams::UNINITIALIZED_VAL;
-
-  auto rparams = std::make_shared<ReductionParams>();
-  rparams->cparams.maxrregcount = (int)nvrtc_register_per_thread;
-  rparams->persistent_kernel = true;
-  rparams->fastest_dim = true;
-
-  // Inner reduction domain
-  rparams->cross_block_inner_reduction = true;
-  rparams->block_dim_inner_reduction = ParallelType::TIDx;
-  rparams->pad_inner_reduction_to_warp = pad_bdimx;
-  rparams->batches_per_block_inner_reduction =
-      batches_per_block_inner_reduction;
-
-  // For persistent schedules always have to mark the reduction unrolled
-  // otherwise rfactor can fail
-  rparams->unroll_factor_inner_reduction = inner_reduction_unroll_factor;
-  rparams->vectorize_inner_reduction = vectorize;
-
-  // Iter domain
-  rparams->multiple_reds_per_blk = bdimy > 1;
-  if (rparams->multiple_reds_per_blk) {
-    rparams->block_dim_iter_dom = ParallelType::TIDy;
-  }
-
-  if (godim > 1) {
-    rparams->grid_dim_iter_dom = ParallelType::BIDx;
-    if (godim > scheduler_utils::x_grid_limit) {
-      rparams->split_grid_dim_iter_dom_outer = true;
-      gdimx = scheduler_utils::x_grid_limit;
-    }
-  }
-
-  if (iter_unroll_factor > 1) {
-    rparams->unroll_factor_iter_dom = iter_unroll_factor;
-  }
-
-  // Outer reduction domain
-  rparams->schedule_3D = total_reduction_numel != inner_most_dimension_numel;
-  if (rparams->schedule_3D) {
-    rparams->batches_per_block_outer_reduction =
-        batches_per_block_outer_reduction;
-    rparams->block_dim_outer_reduction = ParallelType::TIDz;
-    rparams->cross_block_outer_reduction = true;
-    rparams->unroll_factor_outer_reduction = outer_reduction_unroll_factor;
-  }
-
-  rparams->lparams = LaunchParams(
-      gdimx,
-      gdimy,
-      gdimz,
-      LaunchParams::UNINITIALIZED_VAL,
-      bdimy,
-      LaunchParams::UNINITIALIZED_VAL);
-
-  rparams->tag = "Inner Persistent Heuristic.\n";
-
-  if (isDebugDumpEnabled(DebugDumpOption::SchedulerDebug)) {
-    debug() << "\n===== Reduction Stats ========\n"
-            << "total_reduction_numel: " << total_reduction_numel << "\n"
-            << "total_iteration_numel: " << total_iteration_numel << "\n"
-            << "inner_most_dimension_numel: " << inner_most_dimension_numel
-            << "\n"
-            << "vectorize_factor: " << vectorize_factor << "\n"
-            << "n_tensor_inputs: " << n_tensor_inputs << "\n"
-            << "max_input_dtype_size: " << max_input_dtype_size << "\n"
-            << "max_persistent_buffer_size: " << max_persistent_buffer_size
-            << "\n"
-            << "max_multi_reduction_factor: " << max_multi_reduction_factor
-            << "\n"
-            << "block(" << (pad_bdimx ? padded_bdimx : bdimx) << ", " << bdimy
-            << ", " << bdimz << ")";
-    debug() << rparams->toString() << std::endl;
-  }
-
-  return rparams;
-}
 
 // Heuristics for grid outer normalizations
 std::shared_ptr<ReductionParams> gridOuterPersistentHeuristic(
@@ -1931,43 +800,21 @@ std::shared_ptr<ReductionParams> outerPersistentHeuristic(
 std::shared_ptr<ReductionParams> persistentHeuristic(
     const int64_t total_reduction_numel,
     const int64_t total_iteration_numel,
-    const int64_t inner_most_dimension_numel,
-    const bool fastest_dim_reduction,
     const size_t n_tensor_inputs,
     const size_t max_input_dtype_size,
-    const size_t tmp_gmem_dtype_size,
     const int64_t max_persistent_buffer_size,
     size_t vectorize_factor,
-    bool project_persistent_buffers,
-    const bool combined_inner_outer_reduction) {
+    bool project_persistent_buffers) {
   std::shared_ptr<ReductionParams> rparams;
-  if (combined_inner_outer_reduction) {
-    const int64_t outer_dim_numel = total_iteration_numel;
-    const int64_t inner_dim_numel = inner_most_dimension_numel;
-    rparams = innerOuterPersistentHeuristic(
-        outer_dim_numel,
-        inner_dim_numel,
-        max_persistent_buffer_size,
-        tmp_gmem_dtype_size,
-        vectorize_factor);
-  } else if (fastest_dim_reduction) {
-    rparams = innerPersistentHeuristic(
-        total_reduction_numel,
-        total_iteration_numel,
-        inner_most_dimension_numel,
-        (int64_t)n_tensor_inputs,
-        (int64_t)max_input_dtype_size,
-        max_persistent_buffer_size,
-        vectorize_factor);
-  } else {
-    rparams = outerPersistentHeuristic(
-        total_reduction_numel,
-        total_iteration_numel,
-        (int64_t)n_tensor_inputs,
-        (int64_t)max_input_dtype_size,
-        max_persistent_buffer_size,
-        vectorize_factor);
-  }
+
+  rparams = outerPersistentHeuristic(
+      total_reduction_numel,
+      total_iteration_numel,
+      (int64_t)n_tensor_inputs,
+      (int64_t)max_input_dtype_size,
+      max_persistent_buffer_size,
+      vectorize_factor);
+
   rparams->project_persistent_buffers = project_persistent_buffers;
   return rparams;
 }
@@ -1992,26 +839,7 @@ std::shared_ptr<ReductionParams> getOuterPersistentHeuristics(
 
   NVF_ERROR(!reduction_tvs.empty(), "Need reduction tensor views to schedule.");
 
-  int64_t n_tensor_inner_reduction = 0;
-  int64_t n_tensor_outer_reduction = 0;
-  TensorView* first_inner_reduction_tv = nullptr;
-  std::vector<TensorView*> outer_reduction_tvs;
-  for (auto tv : reduction_tvs) {
-    if (scheduler_utils::isFastestDimReduction(tv)) {
-      if (!first_inner_reduction_tv) {
-        first_inner_reduction_tv = tv;
-      }
-      n_tensor_inner_reduction++;
-    } else {
-      n_tensor_outer_reduction++;
-      outer_reduction_tvs.emplace_back(tv);
-    }
-  }
-  const bool combined_inner_outer_reduction =
-      n_tensor_inner_reduction && n_tensor_outer_reduction;
-
-  auto ref_red_tv = combined_inner_outer_reduction ? first_inner_reduction_tv
-                                                   : reduction_tvs[0];
+  auto ref_red_tv = reduction_tvs[0];
 
   NVF_ERROR(ref_red_tv != nullptr, "Reduction TensorView wasn't found.");
 
@@ -2074,45 +902,6 @@ std::shared_ptr<ReductionParams> getOuterPersistentHeuristics(
       ? persistent_buffer_size_info.projected_persistent_buffer_size
       : persistent_buffer_size_info.persistent_buffer_size;
 
-  if (can_project && combined_inner_outer_reduction) {
-    // In combined_inner_outer_reduction, we have additional buffers for partial
-    // results of outer reductions.
-    int64_t outer_reduction_buffer_size =
-        normalization_scheduler_utils::partialReductionBufferSize(
-            outer_reduction_tvs, runtime_info);
-
-    // for layer_norm backward, enable project to input can reuse weight shared
-    // among different rows. Although it increased register usage and may lead
-    // to register spills, the overall performance is increased. The following
-    // code will check if we can do this projection by allowing more registers.
-    // This is a temporary solution, the issue is tracked by
-    // https://github.com/csarofeen/pytorch/issues/2525
-    if (!project_persistent_buffers) {
-      int64_t total_projected_buffer_size =
-          persistent_buffer_size_info.projected_persistent_buffer_size +
-          outer_reduction_buffer_size;
-      // allow 10% more to allow project to input, 14K float should do project
-      // and 16K float should't do. more_register_factor >= 14*1024*5(three
-      // inputs, two outer reduction results)*sizeof(float) /
-      // register_file_size_full
-      constexpr float more_register_factor = 1.1;
-      const int64_t avilable_register_file_size = static_cast<int64_t>(
-          scheduler_utils::register_file_size_full * more_register_factor);
-      if (avilable_register_file_size >= total_projected_buffer_size) {
-        project_persistent_buffers = true;
-      }
-    }
-    // now we have the final decision on whether we project to input or not.
-    if (project_persistent_buffers) {
-      max_persistent_size =
-          persistent_buffer_size_info.projected_persistent_buffer_size +
-          outer_reduction_buffer_size;
-    } else {
-      max_persistent_size = persistent_buffer_size_info.persistent_buffer_size +
-          outer_reduction_buffer_size;
-    }
-  }
-
   auto reduced_tv = ir_utils::getSoleProducerTv(ref_red_tv);
 
   auto unrollable_inputs_outputs_entry =
@@ -2151,26 +940,17 @@ std::shared_ptr<ReductionParams> getOuterPersistentHeuristics(
     n_tensor_inputs++;
   }
 
-  // dtype used to store partial outer reduction in combined reduction
-  const int64_t tmp_gmem_dtype_size = combined_inner_outer_reduction
-      ? dataTypeSize(outer_reduction_tvs[0]->getDataType().value())
-      : dataTypeSize(ref_red_tv->getDataType().value());
-
   // Protect heuristics div by 0:
   n_tensor_inputs = std::max(n_tensor_inputs, (int64_t)1);
 
   auto heuristic = persistentHeuristic(
       properties.total_reduction_numel,
       properties.total_iteration_numel,
-      properties.inner_most_dimension_numel,
-      properties.fastest_dim_reduction,
       n_tensor_inputs,
       max_dtype_size,
-      tmp_gmem_dtype_size,
       max_persistent_size,
       vectorize_factor,
-      project_persistent_buffers,
-      combined_inner_outer_reduction);
+      project_persistent_buffers);
   heuristic->cparams.index_type = runtime_info.getIndexType();
   return heuristic;
 }
@@ -2254,8 +1034,7 @@ TensorView* scheduleReductionGeneral(
   }
 
   if (rparams.persistent_kernel && rparams.cross_grid_inner_reduction &&
-      !rparams.fastest_dim && reduction_tvs.size() > 1 &&
-      !rparams.combined_inner_outer) {
+      reduction_tvs.size() > 1) {
     groupReductions(reduction_tvs, false);
   }
 
@@ -2278,280 +1057,14 @@ TensorView* scheduleReductionGeneral(
       rparams, reduction_tv, has_iter_axis);
 }
 
-void scheduleReductionCombinedOuter(
-    Fusion* fusion,
-    const ReductionParams& rparams,
-    const std::vector<TensorView*>& outer_reduction_tvs,
-    std::vector<TensorView*>& cached_gmem,
-    std::vector<TensorView*>& cached_gmem_reload,
-    std::vector<TensorView*>& outer_reference_tvs,
-    std::unordered_set<TensorView*>& boundaryNodesSet) {
-  auto mergeReductionOrIterDomains = [](TensorView* tv, bool mergeReduction) {
-    int prev_i = -1;
-    for (int i = static_cast<int>(tv->nDims()) - 1; i >= 0; i--) {
-      if (mergeReduction == tv->axis(i)->isReduction()) {
-        if (prev_i == -1) {
-          prev_i = i;
-        } else {
-          tv->merge(i, prev_i);
-          prev_i = i;
-        }
-      }
-    }
-  };
-  for (auto& outer_reduction_tv : outer_reduction_tvs) {
-    // merge tensorview to [reduction, iteraiton] domains
-    mergeReductionOrIterDomains(outer_reduction_tv, true);
-    mergeReductionOrIterDomains(outer_reduction_tv, false);
-    if (rparams.multiple_reds_per_blk) {
-      outer_reduction_tv->split(
-          0, NamedScalar::getParallelDim(rparams.block_dim_iter_dom));
-    }
-    outer_reduction_tv->split(
-        0, NamedScalar::getParallelDim(rparams.grid_dim_iter_dom), false);
-
-    if (rparams.multiple_reds_per_blk) {
-      outer_reduction_tv->rFactor({1});
-    }
-    TensorView* partialResult = outer_reduction_tv->rFactor({1});
-    partialResult->cacheBefore();
-    partialResult->setMemoryType(MemoryType::Global);
-    TensorView* partialResultReload = partialResult->cacheAfter();
-
-    boundaryNodesSet.insert(partialResultReload);
-    cached_gmem.emplace_back(partialResult);
-    cached_gmem_reload.emplace_back(partialResultReload);
-
-    if (rparams.multiple_reds_per_blk) {
-      if (rparams.tidx_for_outer_reduction) {
-        outer_reduction_tv->split(
-            0, NamedScalar::getParallelDim(ParallelType::TIDx));
-        outer_reduction_tv->axis(1)->parallelize(ParallelType::TIDx);
-        // to use warp reduction
-        if (rparams.pad_outer_reduction_to_warp) {
-          outer_reduction_tv->axis(1)->padToMultipleOfWarp();
-        }
-      } else {
-        outer_reduction_tv->split(
-            0, NamedScalar::getParallelDim(ParallelType::TIDy));
-        outer_reduction_tv->axis(1)->parallelize(ParallelType::TIDy);
-      }
-      // iteration domain
-      int axisID = -1;
-      if (rparams.vectorization_factor_outer > 1) {
-        outer_reduction_tv->split(axisID, rparams.vectorization_factor_outer);
-        outer_reduction_tv->axis(axisID--)->parallelize(
-            ParallelType::Vectorize);
-      }
-
-      if (rparams.tidx_for_outer_reduction) {
-        outer_reduction_tv->split(
-            axisID, NamedScalar::getParallelDim(ParallelType::TIDy));
-        outer_reduction_tv->axis(axisID--)->parallelize(ParallelType::TIDy);
-      } else {
-        outer_reduction_tv->split(
-            axisID, NamedScalar::getParallelDim(ParallelType::TIDx));
-        outer_reduction_tv->axis(axisID--)->parallelize(ParallelType::TIDx);
-      }
-
-      outer_reduction_tv->split(
-          axisID, NamedScalar::getParallelDim(ParallelType::BIDy));
-      outer_reduction_tv->axis(axisID--)->parallelize(ParallelType::BIDy);
-
-    } else {
-      // reduction domain
-      outer_reduction_tv->split(
-          0, NamedScalar::getParallelDim(ParallelType::TIDy));
-      outer_reduction_tv->axis(1)->parallelize(ParallelType::TIDy);
-
-      // iteration domain
-      int axisID = -1;
-      if (rparams.vectorization_factor_outer > 1) {
-        outer_reduction_tv->split(axisID, rparams.vectorization_factor_outer);
-        outer_reduction_tv->axis(axisID--)->parallelize(
-            ParallelType::Vectorize);
-      }
-
-      if (rparams.lparams.bdimx() > 1) {
-        outer_reduction_tv->split(
-            axisID, NamedScalar::getParallelDim(ParallelType::TIDx));
-        outer_reduction_tv->axis(axisID--)->parallelize(ParallelType::TIDx);
-      }
-
-      outer_reduction_tv->split(
-          axisID, NamedScalar::getParallelDim(ParallelType::BIDy));
-
-      outer_reduction_tv->axis(axisID--)->parallelize(ParallelType::BIDy);
-    }
-    auto outer_reference_tv =
-        reduction_scheduler_utils::sortAndRFactor(outer_reduction_tv);
-    outer_reference_tvs.emplace_back(outer_reference_tv);
-  }
-}
-
-void scheduleInnerOuterPersistentKernelInnerOuter(
-    Fusion* fusion,
-    const ReductionParams& rparams) {
-  FUSER_PERF_SCOPE("scheduleInnerOuterPersistentKernelInnerOuter");
-
-  FusionGuard fg(fusion);
-
-  // Grab the reduction, input, and output tensor views. dummy_outputs are
-  // helper tensors for persistent buffer projection.
-  std::vector<TensorView*> dummy_outputs, cached_inputs, reduction_tvs;
-  std::vector<std::pair<TensorView*, TensorView*>> cached_outputs;
-  beforeSchedule(
-      fusion,
-      rparams,
-      dummy_outputs,
-      cached_inputs,
-      reduction_tvs,
-      cached_outputs);
-
-  // split reduction_tvs into inner and outer reduction_tvs
-  std::vector<TensorView*> inner_reduction_tvs, outer_reduction_tvs;
-  for (auto tv : reduction_tvs) {
-    if (scheduler_utils::isFastestDimReduction(tv)) {
-      inner_reduction_tvs.emplace_back(tv);
-    } else {
-      outer_reduction_tvs.emplace_back(tv);
-    }
-  }
-  NVF_ERROR(
-      !inner_reduction_tvs.empty(),
-      "schedulePersistentKernelInnerOuter is called but no inner reduction is found.");
-  NVF_ERROR(
-      !outer_reduction_tvs.empty(),
-      "schedulePersistentKernelInnerOuter is called but no outer reduction is found.");
-
-  // schedule inner reduction, only schedule the first inner reduction tv, then
-  // will be propagated to other inner reduction tvs.
-  TensorView* inner_reference_tv =
-      scheduleReductionGeneral(fusion, rparams, inner_reduction_tvs);
-
-  // schedule outer reduction, schedule all the outer reduction tvs since we
-  // need to store the intermediate results.
-  std::vector<TensorView*> cached_gmem;
-  std::vector<TensorView*> cached_gmem_reload;
-  std::vector<TensorView*> outer_reference_tvs;
-  std::unordered_set<TensorView*> boundaryNodesSet;
-  scheduleReductionCombinedOuter(
-      fusion,
-      rparams,
-      outer_reduction_tvs,
-      cached_gmem,
-      cached_gmem_reload,
-      outer_reference_tvs,
-      boundaryNodesSet);
-
-  // Propagate inner reduction and outer reductions
-  for (auto output : dummy_outputs) {
-    fusion->addOutput(output);
-  }
-
-  const bool unroll = rparams.isUnrolled();
-  const bool vectorize =
-      rparams.vectorize_inner_reduction || rparams.vectorize_iter_dom;
-  const bool is_outer_grid_persistence = rparams.persistent_kernel &&
-      rparams.cross_grid_inner_reduction && !rparams.fastest_dim;
-
-  // Propagate inner reduction. There is a cutoff at boundaryNodesSet, so this
-  // propagation will not propagate to the final outer reduction.
-  reduction_scheduler_utils::propagateTransformation(
-      inner_reference_tv, boundaryNodesSet);
-  reduction_scheduler_utils::propagateRFactor(
-      inner_reference_tv, inner_reduction_tvs[0], inner_reduction_tvs);
-
-  // Don't allow parallelization propagation goes through boundaryNodesSet
-  const auto& selected_tvs_inner =
-      scheduler_utils::getAllTvsFrom(inner_reduction_tvs, boundaryNodesSet);
-  reduction_scheduler_utils::propagateParallelization(
-      fusion,
-      inner_reduction_tvs[0],
-      inner_reference_tv,
-      unroll,
-      vectorize,
-      is_outer_grid_persistence,
-      inner_reduction_tvs,
-      cached_inputs,
-      cached_outputs,
-      {selected_tvs_inner.begin(), selected_tvs_inner.end()});
-
-  // Propagate outer reduction. Each outer reduction is connected with its
-  // cached_gmem and output, since we added all the cached_gmem to the
-  // boundaryNodesSet, the transformation from one outer reduction can't
-  // propagate to other outer reductions due to the cutoff at boundaryNodesSet.
-  // Thus, we need a loop to initiate the propagation from each outer reduction.
-  // Don't allow parallelization propagation goes through cached_gmem, see issue
-  // 246.
-  for (long unsigned int i = 0; i < outer_reference_tvs.size(); i++) {
-    const auto& selected_tvs_outer = scheduler_utils::getAllTvsFrom(
-        {outer_reduction_tvs[i]}, {cached_gmem[i]});
-    reduction_scheduler_utils::propagateTransformation(
-        outer_reference_tvs[i], boundaryNodesSet);
-    reduction_scheduler_utils::propagateParallelization(
-        fusion,
-        outer_reduction_tvs[i],
-        outer_reference_tvs[i],
-        unroll,
-        vectorize,
-        is_outer_grid_persistence,
-        outer_reduction_tvs,
-        cached_inputs,
-        cached_outputs,
-        {selected_tvs_outer.begin(), selected_tvs_outer.end()});
-  }
-
-  // special vectorization of temp gmem, vectorization_factor_tmp_gmem_write is
-  // guaranteed to be smaller or equal to input vectorization factor.
-  if (rparams.vectorization_factor_tmp_gmem_write > 1) {
-    for (auto tv : cached_gmem) {
-      NVF_ERROR(
-          rparams.vectorization_factor_tmp_gmem_write <=
-              rparams.unroll_factor_inner_reduction,
-          "vectorization factor of temp gmem write should be smaller than that of inner reduction.")
-      if (rparams.vectorization_factor_tmp_gmem_write <
-          rparams.unroll_factor_inner_reduction) {
-        tv->split(-1, rparams.vectorization_factor_tmp_gmem_write);
-      }
-      tv->axis(-1)->parallelize(ParallelType::Vectorize);
-    }
-  }
-  // vectorization propagate through propagateParallelization only works for
-  // input and output tensors. propagate vectorization to cached_gmem_reload
-  // directly from output tv using parallelizeAllLike. must propagate seperaely
-  // for different tvs as outer reductions are transformed seperately.
-  if (rparams.vectorization_factor_outer > 1) {
-    for (auto tv : cached_gmem_reload) {
-      auto output_tvs = ir_utils::outputTvsOf(tv);
-      NVF_ERROR(
-          !output_tvs.empty(),
-          "cached_gmem_reload should have at least one output tensor.")
-      scheduler_utils::parallelizeAllLike(
-          output_tvs[0],
-          -1,
-          {cached_gmem_reload.begin(), cached_gmem_reload.end()},
-          {ParallelType::Vectorize});
-    }
-  }
-
-  // Remove dummy outputs as they can inadvertently affect CA positions
-  for (auto output : dummy_outputs) {
-    fusion->removeOutput(output);
-  }
-  inlineMost();
-}
-
 } // namespace
 
 // fusion is the input IR that will be modified by this function
 void scheduleOuterPersistentKernel(
     Fusion* fusion,
     const ReductionParams& rparams) {
-  FUSER_PERF_SCOPE("schedulePersistentKernel");
-  if (rparams.combined_inner_outer) {
-    return scheduleInnerOuterPersistentKernelInnerOuter(fusion, rparams);
-  }
+  FUSER_PERF_SCOPE("scheduleOuterPersistentKernel");
+
   FusionGuard fg(fusion);
 
   // Grab the reduction, input, and output tensor views. dummy_outputs are

--- a/csrc/scheduler/normalization_outer.h
+++ b/csrc/scheduler/normalization_outer.h
@@ -45,24 +45,6 @@ class OuterPersistentKernelScheduler : public SchedulerEntry {
       Fusion* fusion,
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr);
-
-  static bool checkReductionPattern(
-      Fusion* fusion,
-      const std::vector<TensorView*>& inner_reduction_tvs,
-      const std::vector<TensorView*>& outer_reduction_tvs);
-
-  static std::pair<int64_t, int64_t> getPersistentBufferSize(
-      Fusion* fusion,
-      SchedulerRuntimeInfo& runtime_info,
-      HeuristicSummary* data_cache,
-      const std::vector<TensorView*>& reduction_tvs);
-
-  static bool canScheduleRunTimeOuter(
-      Fusion* fusion,
-      SchedulerRuntimeInfo& runtime_info,
-      HeuristicSummary* data_cache,
-      const std::vector<TensorView*>& reduction_tvs,
-      const scheduler_utils::ReductionTvProperties& properties);
 };
 
 std::shared_ptr<ReductionParams> getOuterPersistentHeuristics(


### PR DESCRIPTION
similar to #923
(1) Transformed private static functions in the OuterPersistentKernelScheduler class into utility functions within an anonymous namespace.
(2) Removed checks/calculations that are unrelated to outer persistent scheduler.