### PR TITLE
Refine cache policy of global-to-local vector loads. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/root_domain_map.cpp
   ${NVFUSER_SRCS_DIR}/serde/polymorphic_value_serde.cpp
   ${NVFUSER_SRCS_DIR}/serde/utils.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/cache_policy_refiner.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/heuristic_types.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/pointwise.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/pointwise_utils.cpp

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1659,6 +1659,10 @@ class LoadStoreOp : public Expr {
       attribute<CacheOp>(1) = CacheOp::Unspecified;
     }
   }
+
+  void setCacheOp(CacheOp cache_op) {
+    attribute<CacheOp>(1) = cache_op;
+  }
 };
 
 //! Representation a split on an IterDomain by "factor"

--- a/csrc/scheduler/cache_policy_refiner.cpp
+++ b/csrc/scheduler/cache_policy_refiner.cpp
@@ -22,15 +22,15 @@ static bool expands(const Expr* expr, const TensorView* in_tv) {
   }
   const auto* out_tv = out->as<TensorView>();
 
-  const size_t n_dims = in_tv->nDims();
-  if (n_dims != out_tv->nDims()) {
+  const size_t n_dims = in_tv->getRootDomain().size();
+  if (n_dims != out_tv->getRootDomain().size()) {
     return false;
   }
 
   int num_expands = 0;
   for (size_t i = 0; i < n_dims; i++) {
-    const Val* in_extent = in_tv->axis(i)->extent();
-    const Val* out_extent = out_tv->axis(i)->extent();
+    const Val* in_extent = in_tv->getRootDomain()[i]->extent();
+    const Val* out_extent = out_tv->getRootDomain()[i]->extent();
     if (in_extent->isOneInt() && !out_extent->isOneInt()) {
       num_expands++;
     }

--- a/csrc/scheduler/cache_policy_refiner.cpp
+++ b/csrc/scheduler/cache_policy_refiner.cpp
@@ -1,0 +1,124 @@
+#include <fusion.h>
+#include <ir/base_nodes.h>
+#include <ir/internal_nodes.h>
+#include <ir/utils.h>
+#include <scheduler/cache_policy_refiner.h>
+#include <scheduler/debug_utils.h>
+
+namespace nvfuser {
+
+static bool expands(const Expr* expr, const TensorView* in_tv) {
+  if (expr->isA<ExpandOp>()) {
+    return true;
+  }
+
+  if (expr->outputs().size() != 1) {
+    return false;
+  }
+
+  const Val* out = expr->output(0);
+  if (!out->isA<TensorView>()) {
+    return false;
+  }
+  const auto* out_tv = out->as<TensorView>();
+
+  const size_t n_dims = in_tv->nDims();
+  if (n_dims != out_tv->nDims()) {
+    return false;
+  }
+
+  int num_expands = 0;
+  for (size_t i = 0; i < n_dims; i++) {
+    const Val* in_extent = in_tv->axis(i)->extent();
+    const Val* out_extent = out_tv->axis(i)->extent();
+    if (in_extent->isOneInt() && !out_extent->isOneInt()) {
+      num_expands++;
+    }
+  }
+  return num_expands > 0;
+}
+
+// Head of the def-use chain.
+static const Expr* findExpand(const LoadStoreOp* ldst) {
+  std::queue<const Expr*> q;
+  std::unordered_set<const Expr*> visited;
+
+  auto enqueueIfNotVisited = [&q, &visited](const Expr* expr) {
+    if (visited.insert(expr).second) {
+      q.push(expr);
+    }
+  };
+
+  enqueueIfNotVisited(ldst);
+  while (!q.empty()) {
+    const Expr* def = q.front();
+    q.pop();
+    for (const Val* def_out : def->outputs()) {
+      if (!def_out->isA<TensorView>()) {
+        continue;
+      }
+      for (const Expr* use : def_out->uses()) {
+        if (expands(use, def_out->as<TensorView>())) {
+          return use;
+        }
+
+        if (use->isOneOf<UnaryOp, BinaryOp, TernaryOp, BroadcastOp>() ||
+            (use->isA<LoadStoreOp>() &&
+             use->as<LoadStoreOp>()->out()->as<TensorView>()->getMemoryType() !=
+                 MemoryType::Global)) {
+          enqueueIfNotVisited(use);
+        }
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+// Returns true if the cache policy is changed.
+static bool refineCachePolicy(LoadStoreOp* ldst) {
+  scheduler_debug_utils::log("Processing ", ldst->toString());
+
+  if (ldst->opType() != LoadStoreOpType::Set) {
+    return false;
+  }
+
+  // Currently, we only change cache policy for global->local loads.
+  if (ldst->in()->as<TensorView>()->getMemoryType() != MemoryType::Global) {
+    return false;
+  }
+  if (ldst->out()->as<TensorView>()->getMemoryType() != MemoryType::Local) {
+    return false;
+  }
+
+  const Expr* expand = findExpand(ldst);
+  if (expand == nullptr) {
+    scheduler_debug_utils::log(
+        "Skipped ",
+        ldst->toString(),
+        " because we cannot find the using expand.");
+    return false;
+  }
+
+  scheduler_debug_utils::log(
+      "Changed the cache op of ",
+      ldst->toString(),
+      " from ",
+      ldst->cacheOp(),
+      " to ",
+      CacheOp::AllLevels,
+      " because it is expanded by ",
+      expand->toString());
+  ldst->setCacheOp(CacheOp::AllLevels);
+  return true;
+}
+
+void refineCachePolicy(Fusion* fusion) {
+  for (Expr* expr : fusion->exprs()) {
+    if (expr->isA<LoadStoreOp>()) {
+      refineCachePolicy(expr->as<LoadStoreOp>());
+    }
+  }
+}
+
+} // namespace nvfuser

--- a/csrc/scheduler/cache_policy_refiner.cpp
+++ b/csrc/scheduler/cache_policy_refiner.cpp
@@ -16,9 +16,11 @@
 
 namespace nvfuser {
 
+namespace {
+
 // Returns whether a pointwise expression `expr` expands its input operand
 // `in_tv`.
-static bool pointwiseExpands(const Expr* expr, const TensorView* in_tv) {
+bool pointwiseExpands(const Expr* expr, const TensorView* in_tv) {
   NVF_CHECK(
       expr->outputs().size() == 1,
       "A pointwise expression is expected to have one output: ",
@@ -45,7 +47,7 @@ static bool pointwiseExpands(const Expr* expr, const TensorView* in_tv) {
 
 // Finds the first expanding use of `ldst`'s output, bypassing all pointwise
 // operations.
-static const Expr* findExpand(const LoadStoreOp* ldst) {
+const Expr* findExpand(const LoadStoreOp* ldst) {
   std::queue<const Expr*> q;
   std::unordered_set<const Expr*> visited;
 
@@ -86,7 +88,7 @@ static const Expr* findExpand(const LoadStoreOp* ldst) {
 }
 
 // Returns true if the cache policy is changed.
-static bool refineCachePolicy(LoadStoreOp* ldst) {
+bool refineCachePolicy(LoadStoreOp* ldst) {
   scheduler_debug_utils::log("Processing ", ldst->toString());
 
   if (ldst->opType() != LoadStoreOpType::Set) {
@@ -122,6 +124,8 @@ static bool refineCachePolicy(LoadStoreOp* ldst) {
   ldst->setCacheOp(CacheOp::AllLevels);
   return true;
 }
+
+} // namespace
 
 void refineCachePolicy(Fusion* fusion) {
   for (Expr* expr : fusion->exprs()) {

--- a/csrc/scheduler/cache_policy_refiner.cpp
+++ b/csrc/scheduler/cache_policy_refiner.cpp
@@ -37,7 +37,8 @@ static bool pointwiseExpands(const Expr* expr, const TensorView* in_tv) {
   return num_expands > 0;
 }
 
-// Head of the def-use chain.
+// Finds the first expanding use of `ldst`'s output, bypassing all pointwise
+// operations.
 static const Expr* findExpand(const LoadStoreOp* ldst) {
   std::queue<const Expr*> q;
   std::unordered_set<const Expr*> visited;

--- a/csrc/scheduler/cache_policy_refiner.cpp
+++ b/csrc/scheduler/cache_policy_refiner.cpp
@@ -26,15 +26,15 @@ static bool pointwiseExpands(const Expr* expr, const TensorView* in_tv) {
     return false;
   }
 
-  int num_expands = 0;
   for (size_t i = 0; i < n_dims; i++) {
     const Val* in_extent = in_tv->getRootDomain()[i]->extent();
     const Val* out_extent = out_tv->getRootDomain()[i]->extent();
     if (in_extent->isOneInt() && !out_extent->isOneInt()) {
-      num_expands++;
+      // Found an expanding IterDomain.
+      return true;
     }
   }
-  return num_expands > 0;
+  return false;
 }
 
 // Finds the first expanding use of `ldst`'s output, bypassing all pointwise

--- a/csrc/scheduler/cache_policy_refiner.h
+++ b/csrc/scheduler/cache_policy_refiner.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <fusion.h>
+
+namespace nvfuser {
+
+void refineCachePolicy(Fusion* fusion);
+
+} // namespace nvfuser

--- a/csrc/scheduler/cache_policy_refiner.h
+++ b/csrc/scheduler/cache_policy_refiner.h
@@ -4,6 +4,8 @@
 
 namespace nvfuser {
 
+// Visits all global-to-local vector loads in `fusion` and refines their cache
+// policies.
 void refineCachePolicy(Fusion* fusion);
 
 } // namespace nvfuser

--- a/csrc/scheduler/cache_policy_refiner.h
+++ b/csrc/scheduler/cache_policy_refiner.h
@@ -1,3 +1,10 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
 #pragma once
 
 #include <fusion.h>

--- a/csrc/scheduler/normalization_inner.cpp
+++ b/csrc/scheduler/normalization_inner.cpp
@@ -1230,8 +1230,6 @@ void scheduleInnerPersistentKernel(
     fusion->addOutput(output);
   }
 
-  refineCachePolicy(fusion);
-
   const bool unroll = rparams.isUnrolled();
   const bool vectorize =
       rparams.vectorize_inner_reduction || rparams.vectorize_iter_dom;
@@ -1259,6 +1257,8 @@ void scheduleInnerPersistentKernel(
   }
 
   scheduler_utils::promoteProducerMemoryTypes(fusion, cached_inputs);
+
+  refineCachePolicy(fusion);
 }
 
 } // namespace nvfuser

--- a/csrc/scheduler/normalization_inner.cpp
+++ b/csrc/scheduler/normalization_inner.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <ATen/cuda/CUDAContext.h>
 #include <instrumentation.h>
+#include <scheduler/cache_policy_refiner.h>
 #include <scheduler/debug_utils.h>
 #include <scheduler/normalization_inner.h>
 #include <scheduler/reduction_utils.h>
@@ -1228,6 +1229,8 @@ void scheduleInnerPersistentKernel(
   for (auto output : dummy_outputs) {
     fusion->addOutput(output);
   }
+
+  refineCachePolicy(fusion);
 
   const bool unroll = rparams.isUnrolled();
   const bool vectorize =

--- a/csrc/scheduler/normalization_outer.cpp
+++ b/csrc/scheduler/normalization_outer.cpp
@@ -2580,8 +2580,6 @@ void scheduleOuterPersistentKernel(
     fusion->addOutput(output);
   }
 
-  refineCachePolicy(fusion);
-
   const bool unroll = rparams.isUnrolled();
   const bool vectorize =
       rparams.vectorize_inner_reduction || rparams.vectorize_iter_dom;
@@ -2609,6 +2607,8 @@ void scheduleOuterPersistentKernel(
   }
 
   scheduler_utils::promoteProducerMemoryTypes(fusion, cached_inputs);
+
+  refineCachePolicy(fusion);
 }
 
 } // namespace nvfuser

--- a/csrc/scheduler/normalization_outer.cpp
+++ b/csrc/scheduler/normalization_outer.cpp
@@ -16,6 +16,7 @@
 #include <ir/iostream.h>
 #include <ir/utils.h>
 #include <options.h>
+#include <scheduler/cache_policy_refiner.h>
 #include <scheduler/debug_utils.h>
 #include <scheduler/normalization_outer.h>
 #include <scheduler/normalization_utils.h>
@@ -2578,6 +2579,8 @@ void scheduleOuterPersistentKernel(
   for (auto output : dummy_outputs) {
     fusion->addOutput(output);
   }
+
+  refineCachePolicy(fusion);
 
   const bool unroll = rparams.isUnrolled();
   const bool vectorize =

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -10,6 +10,7 @@
 #include <debug.h>
 #include <inlining.h>
 #include <instrumentation.h>
+#include <scheduler/cache_policy_refiner.h>
 #include <scheduler/debug_utils.h>
 #include <scheduler/pointwise.h>
 #include <scheduler/reduction_utils.h>
@@ -518,6 +519,8 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
   auto cached_outputs = scheduler_utils::cacheAndForkOutputs(fusion, true);
 
   scheduler_utils::prepareForMemoryTypePromotion(fusion);
+
+  refineCachePolicy(fusion);
 
   std::vector<TensorView*> input_tvs;
   {

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -129,11 +129,8 @@ TEST_F(MemoryTest, RefineCachePolicy) {
   fusion.addOutput(tv_c2);
 
   tv_a2->merge(0);
-  tv_a2->split(0, 4); // Vector.
-  tv_a2->split(0, 32); // Thread.
-  // TODO: can the propagator automatically split tv_b2?
-  tv_b2->split(0, 4); // Vector.
-  tv_b2->split(0, 32); // Thread.
+  tv_a2->split(0, 4);
+  tv_a2->split(0, 32);
   TransformPropagatorWithCheck propagator(tv_a2);
   MaxRootDomainInfoSpanningTree(tv_a2).traverse(&propagator);
 

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -19,6 +19,7 @@
 #include <ops/arith.h>
 #include <ops/utils.h>
 #include <options.h>
+#include <scheduler/cache_policy_refiner.h>
 #include <test/utils.h>
 #include <test/validator.h>
 #include <type.h>
@@ -27,7 +28,19 @@ namespace nvfuser {
 
 class MemoryTest
     : public NVFuserTest,
-      public testing::WithParamInterface<std::tuple<CacheOp, std::string>> {};
+      public testing::WithParamInterface<std::tuple<CacheOp, std::string>> {
+ protected:
+  void expectMatchCount(
+      const std::string& text,
+      const std::string& pattern,
+      const int num_matches) {
+    std::regex regex(pattern);
+    std::smatch match;
+    std::regex_search(text, match, regex);
+    EXPECT_EQ(match.size(), num_matches)
+        << "Expect " << pattern << " to occur " << num_matches << " time(s).";
+  }
+};
 
 TEST_P(MemoryTest, LoadCache) {
   CacheOp cache_op = std::get<0>(GetParam());
@@ -88,7 +101,7 @@ TEST_P(MemoryTest, LoadCache) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    MemoryTests,
+    CacheGlobalLoads,
     MemoryTest,
     testing::Values(
         std::make_tuple(CacheOp::AllLevels, "ca"),
@@ -99,6 +112,70 @@ INSTANTIATE_TEST_SUITE_P(
       os << std::get<0>(info.param);
       return os.str();
     });
+
+// Use ld.cs when loading streaming data and ld.ca otherwise.
+TEST_F(MemoryTest, RefineCachePolicy) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv_a = makeContigTensor(2);
+  TensorView* tv_b = makeContigTensor(1);
+  fusion.addInput(tv_a);
+  fusion.addInput(tv_b);
+  TensorView* tv_a2 = set(tv_a);
+  TensorView* tv_b2 = set(tv_b);
+  TensorView* tv_c = add(tv_a2, tv_b2);
+  TensorView* tv_c2 = set(tv_c);
+  fusion.addOutput(tv_c2);
+
+  tv_a2->split(1, 4); // Vector.
+  tv_a2->split(1, 32); // Thread.
+  // TODO: can the propagator automatically split tv_b2?
+  tv_b2->split(0, 4); // Vector.
+  tv_b2->split(0, 32); // Thread.
+  TransformPropagatorWithCheck propagator(tv_a2);
+  MaxRootDomainInfoSpanningTree(tv_a2).traverse(&propagator);
+
+  tv_a2->axis(0)->parallelize(ParallelType::BIDy);
+  tv_a2->axis(1)->parallelize(ParallelType::BIDx);
+  tv_a2->axis(2)->parallelize(ParallelType::TIDx);
+  tv_a2->axis(3)->parallelize(ParallelType::Vectorize);
+  // TODO: can parallelizeAllLike parallelize b2 automatically?
+  tv_b2->axis(0)->parallelize(ParallelType::BIDx);
+  tv_b2->axis(1)->parallelize(ParallelType::TIDx);
+  tv_b2->axis(2)->parallelize(ParallelType::Vectorize);
+  scheduler_utils::parallelizeAllLike(tv_a2, {tv_c2});
+
+  refineCachePolicy(&fusion);
+
+  inlineMost();
+
+  at::Tensor a = at::randn(
+      {1024, 1024}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+  at::Tensor b = at::randn(
+      {1024}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+  at::Tensor c = a + b;
+
+  FusionExecutor fe;
+  {
+    DebugDumpOptionsGuard debug_dump_options_guard;
+    DebugDumpOptionsGuard::getCurOptions().set(DebugDumpOption::Ptx);
+    fe.compileFusion(&fusion, {a, b});
+  }
+
+  // Verify PTX.
+  const executor_utils::CompiledKernel compiled_kernel = fe.compiledKernel();
+  std::string ptx(compiled_kernel.ptx.begin(), compiled_kernel.ptx.end());
+  expectMatchCount(ptx, R"(ld\.global\.ca\.v4\.\S+)", 1);
+  expectMatchCount(ptx, R"(ld\.global\.cs\.v4\.\S+)", 1);
+
+  // Clean up the dumped PTX file.
+  debug() << "Removing " << compiled_kernel.ptx_filename << std::endl;
+  std::filesystem::remove(compiled_kernel.ptx_filename);
+
+  std::vector<at::Tensor> actual_outputs = fe.runFusion({a, b});
+  testValidate(&fusion, actual_outputs, {a, b}, {c}, __LINE__, __FILE__);
+}
 
 class TMATest : public NVFuserTest {
   void SetUp() override {

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -128,23 +128,20 @@ TEST_F(MemoryTest, RefineCachePolicy) {
   TensorView* tv_c2 = set(tv_c);
   fusion.addOutput(tv_c2);
 
-  tv_a2->split(1, 4); // Vector.
-  tv_a2->split(1, 32); // Thread.
+  tv_a2->merge(0);
+  tv_a2->split(0, 4); // Vector.
+  tv_a2->split(0, 32); // Thread.
   // TODO: can the propagator automatically split tv_b2?
   tv_b2->split(0, 4); // Vector.
   tv_b2->split(0, 32); // Thread.
   TransformPropagatorWithCheck propagator(tv_a2);
   MaxRootDomainInfoSpanningTree(tv_a2).traverse(&propagator);
 
-  tv_a2->axis(0)->parallelize(ParallelType::BIDy);
-  tv_a2->axis(1)->parallelize(ParallelType::BIDx);
-  tv_a2->axis(2)->parallelize(ParallelType::TIDx);
-  tv_a2->axis(3)->parallelize(ParallelType::Vectorize);
-  // TODO: can parallelizeAllLike parallelize b2 automatically?
-  tv_b2->axis(0)->parallelize(ParallelType::BIDx);
-  tv_b2->axis(1)->parallelize(ParallelType::TIDx);
+  tv_a2->axis(0)->parallelize(ParallelType::BIDx);
+  tv_a2->axis(1)->parallelize(ParallelType::TIDx);
+  tv_a2->axis(2)->parallelize(ParallelType::Vectorize);
   tv_b2->axis(2)->parallelize(ParallelType::Vectorize);
-  scheduler_utils::parallelizeAllLike(tv_a2, {tv_c2});
+  tv_c2->axis(2)->parallelize(ParallelType::Vectorize);
 
   refineCachePolicy(&fusion);
 


### PR DESCRIPTION
This change improves #775. I observed >20% speed up for some layer normalization and broadcasting benchmarks. I manually verified the top five regressions and found they are noise. 

```
Top 5 improvements:
  Benchmark NvFuserScheduler_LayerNorm_fp16___GRAPH/NvFuserScheduler_LayerNorm_fp16/16/2097152/manual_time changed from 235.70649740466797 seconds 173.04190461790853 (0.73x)
  Benchmark NvFuserScheduler_LayerNorm_fp16___GRAPH/NvFuserScheduler_LayerNorm_fp16/8/2097152/manual_time changed from 138.39395947220675 seconds 102.51789488799382 (0.74x)
  Benchmark NvFuserScheduler_Broadcast_Outer_fp16___GRAPH/NvFuserScheduler_Broadcast_Outer_fp16/8/2097152/manual_time changed from 66.96629544563652 seconds 50.55804438076262 (0.75x)
  Benchmark NvFuserScheduler_Broadcast_Outer_fp16___GRAPH/NvFuserScheduler_Broadcast_Outer_fp16/16/2097152/manual_time changed from 115.90680760401582 seconds 91.29062974831477 (0.79x)
  Benchmark NvFuserScheduler_LayerNorm_LargeHiddenSize_fp32___GRAPH/NvFuserScheduler_LayerNorm_LargeHiddenSize_fp32/8192/34816/manual_time changed from 1788.1167894834052 seconds 1567.6858208396222 (0.88x)

Top 5 regressions:
  Benchmark NvFuserScheduler_Reduction_Outer_fp32___GRAPH/NvFuserScheduler_Reduction_Outer_fp32/1024/8/manual_time changed from 9.868966872637673 seconds 10.735423786849232 (1.09x)
  Benchmark NvFuserScheduler_Broadcast_Outer_fp16___GRAPH/NvFuserScheduler_Broadcast_Outer_fp16/1/320/manual_time changed from 5.658855892095212 seconds 6.134677312527026 (1.08x)
  Benchmark NvFuserScheduler_Reduction_Inner_fp16___GRAPH/NvFuserScheduler_Reduction_Inner_fp16/8/320/manual_time changed from 6.313002350175524 seconds 6.8305892441798015 (1.08x)
  Benchmark NvFuserScheduler_Reduction_Outer_fp16___GRAPH/NvFuserScheduler_Reduction_Outer_fp16/2/4096/manual_time changed from 6.264241068695716 seconds 6.77447848660655 (1.08x)
  Benchmark NvFuserScheduler_BatchNorm_nhwc_fp16___GRAPH/NvFuserScheduler_BatchNorm_nhwc_fp16/2/8/2/manual_time changed from 7.216345496261045 seconds 7.765639299028032 (1.08x)

Saved the histogram of time changes to /home/me/workspace/ca_cs_root_comparison.png.
```

![ca_cs_root_comparison](https://github.com/NVIDIA/Fuser/assets/2772612/a4b4fd1e-1a92-48cd-85dd-dcce0d473789)
