### PR TITLE
Don't link `libcuda.so`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,8 @@ if(NVFUSER_BUILD_WITH_ASAN)
   add_link_options(-fsanitize=address)
 endif()
 
+list(FILTER TORCH_LIBRARIES EXCLUDE REGEX "libcuda\.so")
+
 if(PROJECT_IS_TOP_LEVEL)
   target_link_libraries(${NVFUSER_CODEGEN} PRIVATE torch ${TORCH_LIBRARIES})
 

--- a/csrc/driver_api.cpp
+++ b/csrc/driver_api.cpp
@@ -114,20 +114,7 @@ class CUDADriverAPIDynamicLoader {
 
 namespace nvfuser {
 
-DEFINE_DRIVER_API_WRAPPER(cuGetErrorName);
-DEFINE_DRIVER_API_WRAPPER(cuGetErrorString);
-DEFINE_DRIVER_API_WRAPPER(cuModuleLoadDataEx);
-DEFINE_DRIVER_API_WRAPPER(cuModuleGetFunction);
-DEFINE_DRIVER_API_WRAPPER(cuOccupancyMaxActiveBlocksPerMultiprocessor);
-DEFINE_DRIVER_API_WRAPPER(cuFuncGetAttribute);
-DEFINE_DRIVER_API_WRAPPER(cuLaunchKernel);
-DEFINE_DRIVER_API_WRAPPER(cuLaunchCooperativeKernel);
-DEFINE_DRIVER_API_WRAPPER(cuDeviceGetAttribute);
-DEFINE_DRIVER_API_WRAPPER(cuDeviceGetName);
-
-#if (CUDA_VERSION >= 12000)
-DEFINE_DRIVER_API_WRAPPER(cuTensorMapEncodeTiled);
-#endif
+ALL_DRIVER_API_WRAPPER(DEFINE_DRIVER_API_WRAPPER);
 
 } // namespace nvfuser
 

--- a/csrc/driver_api.h
+++ b/csrc/driver_api.h
@@ -20,20 +20,28 @@ namespace nvfuser {
   extern decltype(::funcName)* funcName;
 
 // List of driver APIs that you want the magic to happen.
-DECLARE_DRIVER_API_WRAPPER(cuGetErrorName);
-DECLARE_DRIVER_API_WRAPPER(cuGetErrorString);
-DECLARE_DRIVER_API_WRAPPER(cuModuleLoadDataEx);
-DECLARE_DRIVER_API_WRAPPER(cuModuleGetFunction);
-DECLARE_DRIVER_API_WRAPPER(cuOccupancyMaxActiveBlocksPerMultiprocessor);
-DECLARE_DRIVER_API_WRAPPER(cuFuncGetAttribute);
-DECLARE_DRIVER_API_WRAPPER(cuLaunchKernel);
-DECLARE_DRIVER_API_WRAPPER(cuLaunchCooperativeKernel);
-DECLARE_DRIVER_API_WRAPPER(cuDeviceGetAttribute);
-DECLARE_DRIVER_API_WRAPPER(cuDeviceGetName);
+#define ALL_DRIVER_API_WRAPPER_CUDA11(fn)          \
+  fn(cuGetErrorName);                              \
+  fn(cuGetErrorString);                            \
+  fn(cuModuleLoadDataEx);                          \
+  fn(cuModuleGetFunction);                         \
+  fn(cuOccupancyMaxActiveBlocksPerMultiprocessor); \
+  fn(cuFuncGetAttribute);                          \
+  fn(cuFuncSetAttribute);                          \
+  fn(cuLaunchKernel);                              \
+  fn(cuLaunchCooperativeKernel);                   \
+  fn(cuDeviceGetAttribute);                        \
+  fn(cuDeviceGetName)
 
 #if (CUDA_VERSION >= 12000)
-DECLARE_DRIVER_API_WRAPPER(cuTensorMapEncodeTiled);
+#define ALL_DRIVER_API_WRAPPER(fn)   \
+  ALL_DRIVER_API_WRAPPER_CUDA11(fn); \
+  fn(cuTensorMapEncodeTiled)
+#else
+#define ALL_DRIVER_API_WRAPPER ALL_DRIVER_API_WRAPPER_CUDA11
 #endif
+
+ALL_DRIVER_API_WRAPPER(DECLARE_DRIVER_API_WRAPPER);
 
 #undef DECLARE_DRIVER_API_WRAPPER
 


### PR DESCRIPTION
Added `cuFuncSetAttribute`. Also, we are not linking with `libcuda.so` anymore.

```C++
❯ ldd build/libnvfuser_codegen.so
        linux-vdso.so.1 (0x00007ffe4699d000)
        libnvrtc.so.12 => /opt/cuda/lib/libnvrtc.so.12 (0x00007f61b7600000)
        libnvToolsExt.so.1 => /opt/cuda/lib/libnvToolsExt.so.1 (0x00007f61b7200000)
        libtorch.so => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libtorch.so (0x00007f61bbc02000)
        libc10.so => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libc10.so (0x00007f61bb124000)
        libcudart.so.12 => /opt/cuda/lib/libcudart.so.12 (0x00007f61b6e00000)
        libc10_cuda.so => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libc10_cuda.so (0x00007f61b74e2000)
        libtorch_cpu.so => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so (0x00007f619f600000)
        libtorch_cuda.so => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so (0x00007f6156a00000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f6156600000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007f61b7113000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f61bbb95000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f6156200000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x00007f61bbc23000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f61bbb8e000)
        librt.so.1 => /usr/lib/librt.so.1 (0x00007f61bbb89000)
        libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f61bbb84000)
        libgomp-a34b3233.so.1 => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libgomp-a34b3233.so.1 (0x00007f6155e00000)
        libcudart-9335f6a2.so.12 => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libcudart-9335f6a2.so.12 (0x00007f6155a00000)
        libnvToolsExt-847d78f2.so.1 => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libnvToolsExt-847d78f2.so.1 (0x00007f6155600000)
        libcudnn.so.8 => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libcudnn.so.8 (0x00007f6155200000)
        libcublas.so.12 => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libcublas.so.12 (0x00007f614e800000)
        libcublasLt.so.12 => /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libcublasLt.so.12 (0x00007f612c800000)
```