### PR TITLE
add template function getOpsOfType

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -3353,9 +3353,8 @@ void SegmentCandidateFinder::findSegments() {
 
   segmented_fusion_->validateIfDebug();
 
-  auto reduction_ops =
-      ir_utils::getReductionOps(segmented_fusion_->completeFusion());
-  auto welford_ops = ir_utils::filterByType<WelfordOp>(reduction_ops);
+  auto welford_ops =
+      ir_utils::getOpsOfType<WelfordOp>(segmented_fusion_->completeFusion());
 
   if (options_.run_translate_welford &&
       (welford_ops.begin() != welford_ops.end())) {

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -430,7 +430,7 @@ std::vector<TensorView*> allTvsExcept(
   return result;
 }
 
-std::vector<Expr*> getReductionOps(Fusion* fusion) {
+std::vector<Expr*> getAllTypesOfReductionOps(Fusion* fusion) {
   std::vector<Expr*> red_ops;
 
   for (auto expr : fusion->exprs()) {
@@ -441,53 +441,6 @@ std::vector<Expr*> getReductionOps(Fusion* fusion) {
   }
 
   return red_ops;
-}
-
-std::vector<IndexSelectOp*> getIndexSelectOps(Fusion* fusion) {
-  std::vector<IndexSelectOp*> idx_sel_ops;
-
-  for (auto expr : fusion->exprs()) {
-    if (expr->isA<IndexSelectOp>()) {
-      idx_sel_ops.push_back(expr->as<IndexSelectOp>());
-    }
-  }
-
-  return idx_sel_ops;
-}
-
-std::vector<TorchGatherOp*> getTorchGatherOps(Fusion* fusion) {
-  std::vector<TorchGatherOp*> torch_gather_ops;
-
-  for (auto expr : fusion->exprs()) {
-    if (expr->isA<TorchGatherOp>()) {
-      torch_gather_ops.push_back(expr->as<TorchGatherOp>());
-    }
-  }
-
-  return torch_gather_ops;
-}
-
-std::vector<SelectOp*> getSelectOps(Fusion* fusion) {
-  std::vector<SelectOp*> select_ops;
-
-  for (auto expr : fusion->exprs()) {
-    if (expr->isA<SelectOp>()) {
-      select_ops.push_back(expr->as<SelectOp>());
-    }
-  }
-
-  return select_ops;
-}
-
-std::vector<MmaOp*> getMmaOps(Fusion* fusion) {
-  std::vector<MmaOp*> mma_ops;
-  for (auto expr : fusion->exprs()) {
-    if (expr->isA<MmaOp>()) {
-      mma_ops.push_back(expr->as<MmaOp>());
-    }
-  }
-
-  return mma_ops;
 }
 
 namespace {

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -431,16 +431,7 @@ std::vector<TensorView*> allTvsExcept(
 }
 
 std::vector<Expr*> getAllTypesOfReductionOps(Fusion* fusion) {
-  std::vector<Expr*> red_ops;
-
-  for (auto expr : fusion->exprs()) {
-    if (expr->isA<ReductionOp>() || expr->isA<GroupedReductionOp>() ||
-        expr->isA<WelfordOp>()) {
-      red_ops.push_back(expr);
-    }
-  }
-
-  return red_ops;
+  return getOpsOfType<ReductionOp, GroupedReductionOp, WelfordOp>(fusion);
 }
 
 namespace {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -317,16 +317,6 @@ std::vector<TensorView*> allTvsExcept(
     Fusion* fusion,
     const std::unordered_set<TensorView*>& except);
 
-std::vector<Expr*> getReductionOps(Fusion* fusion);
-
-std::vector<IndexSelectOp*> getIndexSelectOps(Fusion* fusion);
-
-std::vector<TorchGatherOp*> getTorchGatherOps(Fusion* fusion);
-
-std::vector<MmaOp*> getMmaOps(Fusion* fusion);
-
-std::vector<SelectOp*> getSelectOps(Fusion* fusion);
-
 // Returns the initialization value of tv or nullptr if not initialized.
 Val* getReductionInitValOf(TensorView* tv);
 
@@ -504,5 +494,25 @@ bool isTensorSize(const Val* val);
 
 //! Check if a Val is a tensor stride;
 bool isTensorStride(const Val* val);
+
+//! This is a simple template function that returns a vector of the given op
+//! type. Directly implemented in the header file to avoid explicit
+//! instantiation.
+template <typename OpType>
+std::vector<OpType*> getOpsOfType(Fusion* fusion) {
+  std::vector<OpType*> ops;
+  for (auto expr : fusion->exprs()) {
+    if (expr->isA<OpType>()) {
+      ops.push_back(expr->as<OpType>());
+    }
+  }
+  return ops;
+}
+
+//! Returns expressions that are of type ReductionOp, GroupedReductionOp, or
+//! WelfordOp. A variadic template approach was considered but was ruled out to
+//! avoid requiring the caller to be aware of all individual reduction operation
+//! types.
+std::vector<Expr*> getAllTypesOfReductionOps(Fusion* fusion);
 
 } // namespace nvfuser::ir_utils

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -716,7 +716,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   NVF_ERROR(roles_map_opt.isValid(), roles_map_opt.getErrorMsg());
   const auto roles_map = roles_map_opt.getData();
 
-  auto mma_ops = ir_utils::getMmaOps(fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(fusion);
   NVF_ERROR(
       mma_ops.size() == 1,
       "scheduleMatmul supports fusion with single mma op in definition, got ",

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -322,7 +322,7 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
   //    scheduler
 
   // #1
-  auto mma_exprs = ir_utils::getMmaOps(fusion);
+  auto mma_exprs = ir_utils::getOpsOfType<MmaOp>(fusion);
   if (mma_exprs.size() != 1) {
     std::stringstream ss;
     ss << "Matmul scheduler supports fusions only with a single MMA op, got: "
@@ -361,7 +361,7 @@ std::shared_ptr<MatmulParams> getMatmulHeuristics(
   auto params = std::make_shared<MatmulParams>();
 
   // Check initial conditions
-  auto mma_exprs = ir_utils::getMmaOps(fusion);
+  auto mma_exprs = ir_utils::getOpsOfType<MmaOp>(fusion);
   NVF_ERROR(mma_exprs.size() == 1, "Support only fusion with a single mma op.");
 
   const auto problem_shape =

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1421,7 +1421,7 @@ inline void resolveTvToMatmulDomainsMapping(
 } // anonymous namespace
 
 ProblemIterDomainsOpt getProblemIterDomains(Fusion* fusion) {
-  auto mma_exprs = ir_utils::getMmaOps(fusion);
+  auto mma_exprs = ir_utils::getOpsOfType<MmaOp>(fusion);
   if (mma_exprs.size() != 1) {
     std::stringstream ss;
     ss << "Invalid number of MmaOp instances in fusion, expected 1, got "

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -26,7 +26,7 @@ bool NoOpScheduler::canScheduleCompileTime(Fusion* fusion) {
     return true;
   }
   // Check there're no non-trivial reduction ops.
-  for (auto reduction : ir_utils::getReductionOps(fusion)) {
+  for (auto reduction : ir_utils::getAllTypesOfReductionOps(fusion)) {
     for (auto output :
          ir_utils::filterByType<TensorView>(reduction->outputs())) {
       auto concrete_dimension =

--- a/csrc/scheduler/normalization_inner.cpp
+++ b/csrc/scheduler/normalization_inner.cpp
@@ -115,7 +115,7 @@ std::pair<int64_t, int64_t> getPersistentBufferSize(
 
 bool InnerPersistentKernelScheduler::canScheduleCompileTime(Fusion* fusion) {
   // Needs at least one reduction to consider.
-  auto reduction_ops = ir_utils::getReductionOps(fusion);
+  auto reduction_ops = ir_utils::getAllTypesOfReductionOps(fusion);
   if (reduction_ops.empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
         schedule_heuristic, "needs a reduction op");
@@ -135,7 +135,7 @@ bool InnerPersistentKernelScheduler::canScheduleCompileTime(Fusion* fusion) {
   }
 
   // Fusions handled by persistent kernel scheduler cannot have MmaOp.
-  if (!ir_utils::getMmaOps(fusion).empty()) {
+  if (!ir_utils::getOpsOfType<MmaOp>(fusion).empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
         schedule_heuristic, "no support for mma ops.");
     return false;

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -48,7 +48,7 @@ void InnerOuterPersistentKernelScheduler::schedule(Fusion* fusion) {
 bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     Fusion* fusion) {
   // Needs at least one reduction to consider.
-  auto reduction_ops = ir_utils::getReductionOps(fusion);
+  auto reduction_ops = ir_utils::getAllTypesOfReductionOps(fusion);
   if (reduction_ops.empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
         ScheduleHeuristic::InnerOuterPersistent, "needs a reduction op");
@@ -69,7 +69,7 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
   }
 
   // Fusions handled by persistent kernel scheduler cannot have MmaOp.
-  if (!ir_utils::getMmaOps(fusion).empty()) {
+  if (!ir_utils::getOpsOfType<MmaOp>(fusion).empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
         ScheduleHeuristic::InnerOuterPersistent, "no support for mma ops.");
     return false;

--- a/csrc/scheduler/normalization_outer.cpp
+++ b/csrc/scheduler/normalization_outer.cpp
@@ -76,7 +76,7 @@ bool checkReductionPattern(
 
 bool OuterPersistentKernelScheduler::canScheduleCompileTime(Fusion* fusion) {
   // Needs at least one reduction to consider.
-  auto reduction_ops = ir_utils::getReductionOps(fusion);
+  auto reduction_ops = ir_utils::getAllTypesOfReductionOps(fusion);
   if (reduction_ops.empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
         schedule_heuristic, "needs a reduction op");
@@ -96,7 +96,7 @@ bool OuterPersistentKernelScheduler::canScheduleCompileTime(Fusion* fusion) {
   }
 
   // Fusions handled by persistent kernel scheduler cannot have MmaOp.
-  if (!ir_utils::getMmaOps(fusion).empty()) {
+  if (!ir_utils::getOpsOfType<MmaOp>(fusion).empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
         schedule_heuristic, "no support for mma ops.");
     return false;

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -45,7 +45,7 @@ bool PointWiseScheduler::canScheduleCompileTime(Fusion* fusion) {
   }
 
   // Fusions handled by pointwise scheduler cannot have MmaOp.
-  if (!ir_utils::getMmaOps(fusion).empty()) {
+  if (!ir_utils::getOpsOfType<MmaOp>(fusion).empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
         ScheduleHeuristic::PointWise, "no support for mma ops.");
     return false;
@@ -61,7 +61,7 @@ bool PointWiseScheduler::canScheduleCompileTime(Fusion* fusion) {
     }
   }
 
-  auto reduction_ops = ir_utils::getReductionOps(fusion);
+  auto reduction_ops = ir_utils::getAllTypesOfReductionOps(fusion);
 
   if (!reduction_ops.empty()) {
     scheduler_debug_utils::canScheduleRejectReason(

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -869,7 +869,7 @@ void ReductionScheduler::schedule(Fusion* fusion) {
 //! Check if the reduction heuristics apply in given fusion
 bool ReductionScheduler::canScheduleCompileTime(Fusion* fusion) {
   // Needs at least one reduction to consider.
-  if (ir_utils::getReductionOps(fusion).empty()) {
+  if (ir_utils::getAllTypesOfReductionOps(fusion).empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
         ScheduleHeuristic::Reduction, "No reduction op to schedule");
     return false;
@@ -888,7 +888,7 @@ bool ReductionScheduler::canScheduleCompileTime(Fusion* fusion) {
   }
 
   // Fusions handled by reduction scheduler cannot have MmaOp.
-  if (!ir_utils::getMmaOps(fusion).empty()) {
+  if (!ir_utils::getOpsOfType<MmaOp>(fusion).empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
         ScheduleHeuristic::Reduction, "no support for mma ops.");
     return false;
@@ -929,7 +929,7 @@ bool ReductionScheduler::canScheduleCompileTime(Fusion* fusion) {
   }
 
   // Make sure reduction axes are consistent through the fusion
-  auto reduction_ops = ir_utils::getReductionOps(fusion);
+  auto reduction_ops = ir_utils::getAllTypesOfReductionOps(fusion);
   if (reduction_ops.size() > 1) {
     // Before examining the reduction axes want to quickly
     //   check the reductions have the same axis width

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -169,7 +169,7 @@ TEST_F(NVFuserTest, FusionClear_CUDA) {
   NVF_CHECK(fusion.inputs().empty());
   NVF_CHECK(fusion.outputs().empty());
 
-  NVF_CHECK(ir_utils::getReductionOps(&fusion).empty());
+  NVF_CHECK(ir_utils::getOpsOfType<ReductionOp>(&fusion).empty());
 
   // 3. Rebuild the IR
 
@@ -3632,7 +3632,7 @@ TEST_F(NVFuserTest, FusionReduction1_CUDA) {
   fusion.addOutput(tv1);
 
   NVF_CHECK(
-      ir_utils::getReductionOps(&fusion).size(),
+      ir_utils::getOpsOfType<ReductionOp>(&fusion).size(),
       "Could not detect reduction in fusion.");
 
   tv1->split(1, 128);
@@ -3940,7 +3940,7 @@ TEST_F(NVFuserTest, FusionReduction6_CUDA) {
   fusion.addOutput(tv1);
 
   NVF_CHECK(
-      ir_utils::getReductionOps(&fusion).size(),
+      ir_utils::getOpsOfType<ReductionOp>(&fusion).size(),
       "Could not detect reduction in fusion.");
 
   tv1->split(2, bdimx);
@@ -4976,7 +4976,7 @@ TEST_F(NVFuserTest, FusionGridReduction1_CUDA) {
   fusion.addOutput(tv1);
 
   NVF_CHECK(
-      ir_utils::getReductionOps(&fusion).size(),
+      ir_utils::getOpsOfType<ReductionOp>(&fusion).size(),
       "Could not detect reduction in fusion.");
 
   tv1->split(1, bdimx);
@@ -5037,7 +5037,7 @@ TEST_F(NVFuserTest, FusionGridReduction2_CUDA) {
   fusion.addOutput(tv1);
 
   NVF_CHECK(
-      ir_utils::getReductionOps(&fusion).size(),
+      ir_utils::getOpsOfType<ReductionOp>(&fusion).size(),
       "Could not detect reduction in fusion.");
 
   tv1->split(1, bdimx);
@@ -5099,7 +5099,7 @@ TEST_F(NVFuserTest, FusionGridReduction3dim1_CUDA) {
   fusion.addOutput(tv1);
 
   NVF_CHECK(
-      ir_utils::getReductionOps(&fusion).size(),
+      ir_utils::getOpsOfType<ReductionOp>(&fusion).size(),
       "Could not detect reduction in fusion.");
 
   tv1->split(1, gdimy);
@@ -5161,7 +5161,7 @@ TEST_F(NVFuserTest, FusionGridReduction3dim0_CUDA) {
   fusion.addOutput(tv1);
 
   NVF_CHECK(
-      ir_utils::getReductionOps(&fusion).size(),
+      ir_utils::getOpsOfType<ReductionOp>(&fusion).size(),
       "Could not detect reduction in fusion.");
 
   tv1->split(0, gdimy);
@@ -5217,7 +5217,7 @@ TEST_F(NVFuserTest, FusionGridReduction4_CUDA) {
   fusion.addOutput(tv1);
 
   NVF_CHECK(
-      ir_utils::getReductionOps(&fusion).size(),
+      ir_utils::getOpsOfType<ReductionOp>(&fusion).size(),
       "Could not detect reduction in fusion.");
 
   tv1->split(1, gdimx);
@@ -5285,7 +5285,7 @@ TEST_F(NVFuserTest, FusionGridReduction5_CUDA) {
   fusion.addOutput(tv1);
 
   NVF_CHECK(
-      ir_utils::getReductionOps(&fusion).size(),
+      ir_utils::getOpsOfType<ReductionOp>(&fusion).size(),
       "Could not detect reduction in fusion.");
 
   tv1->split(1, bdimx);
@@ -5336,7 +5336,7 @@ TEST_F(NVFuserTest, FusionGridReduction6_CUDA) {
   fusion.addOutput(tv1);
 
   NVF_CHECK(
-      ir_utils::getReductionOps(&fusion).size(),
+      ir_utils::getOpsOfType<ReductionOp>(&fusion).size(),
       "Could not detect reduction in fusion.");
 
   // Splitting for TID

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -978,7 +978,7 @@ TEST_F(NVFuserTest, FusionTrivialReduction_CUDA) {
   fusion.addOutput(tv1);
 
   NVF_CHECK(
-      ir_utils::getReductionOps(&fusion).empty(),
+      ir_utils::getOpsOfType<ReductionOp>(&fusion).empty(),
       "Trivial reduction not converted to squeeze.");
 
   const auto options =

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -86,7 +86,7 @@ TEST_F(NVFuserTest, FusionVoltaMMATT_CUDA) {
   auto mma_builder = MmaBuilder(MmaOptions::MacroType::Volta_16_16_4, gemm_tile)
                          .layout(MmaOptions::MmaLayout::TT);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -188,7 +188,7 @@ TEST_F(NVFuserTest, FusionVoltaMMATN_CUDA) {
   auto mma_builder = MmaBuilder(MmaOptions::MacroType::Volta_16_16_4, gemm_tile)
                          .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -257,7 +257,7 @@ TEST_F(NVFuserTest, FusionVoltaMMANT_CUDA) {
   auto mma_builder = MmaBuilder(MmaOptions::MacroType::Volta_16_16_4, gemm_tile)
                          .layout(MmaOptions::MmaLayout::NT);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -335,7 +335,7 @@ TEST_F(NVFuserTest, FusionVoltaMMANN_CUDA) {
   auto mma_builder = MmaBuilder(MmaOptions::MacroType::Volta_16_16_4, gemm_tile)
                          .layout(MmaOptions::MmaLayout::NN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -509,7 +509,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATN_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -586,7 +586,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATT_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TT);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -667,7 +667,7 @@ TEST_F(NVFuserTest, FusionAmpereMMANT_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::NT);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -748,7 +748,7 @@ TEST_F(NVFuserTest, FusionAmpereMMANN_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::NN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -1185,7 +1185,7 @@ TEST_F(NVFuserTest, FusionMatmulMatmulAmpere_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile2)
           .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       2 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 2, got ",
@@ -1485,7 +1485,7 @@ TEST_F(NVFuserTest, FusionMatmulSoftmaxMatmulAmpere_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       2 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 2, got ",
@@ -1811,7 +1811,7 @@ TEST_F(NVFuserTest, FusionTuringMMATN_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Turing_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -1887,7 +1887,7 @@ TEST_F(NVFuserTest, FusionTuringMMATT_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Turing_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TT);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -1965,7 +1965,7 @@ TEST_F(NVFuserTest, FusionTuringMMANT_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Turing_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::NT);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -2045,7 +2045,7 @@ TEST_F(NVFuserTest, FusionTuringMMANN_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Turing_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::NN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -2164,7 +2164,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTNcpAsync_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -2307,7 +2307,7 @@ TEST_F(NVFuserTest, FusionAmpereStridedBatchedMatmulTN_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -2489,7 +2489,7 @@ TEST_F(NVFuserTest, FusionAmpereViewMatmulTN_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -2649,7 +2649,7 @@ TEST_F(NVFuserTest, FusionVoltaMatmulTNCrossWarp_CUDA) {
   auto mma_builder = MmaBuilder(MmaOptions::MacroType::Volta_16_16_4, gemm_tile)
                          .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -2810,7 +2810,7 @@ TEST_F(NVFuserTest, FusionVoltaMatmulTNCrossCTA_CUDA) {
   auto mma_builder = MmaBuilder(MmaOptions::MacroType::Volta_16_16_4, gemm_tile)
                          .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -2983,7 +2983,7 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTNSwizzled_CUDA) {
 
   fusion.addOutput(tv2);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -3504,7 +3504,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNAlpha_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -3606,7 +3606,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNAlphaBeta_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -3715,7 +3715,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNBias_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(MmaOptions::MmaLayout::TN);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
@@ -3812,7 +3812,7 @@ TEST_F(NVFuserTest, FusionAmpereMMATNSplitKLikeStridedBatch_CUDA) {
       MmaBuilder(MmaOptions::MacroType::Ampere_16_8_16, gemm_tile)
           .layout(layout);
 
-  auto mma_ops = ir_utils::getMmaOps(&fusion);
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
   NVF_CHECK(
       1 == mma_ops.size(),
       "Invalid number of MmaOp instances in fusion definition, expected 1, got ",

--- a/test/test_matmul_scheduler.cpp
+++ b/test/test_matmul_scheduler.cpp
@@ -40,14 +40,14 @@ TEST_F(MatmulSchedulerTest, BasicMatmulStrictCheckTT_CUDA) {
   fusion->addOutput(tv2);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must be always TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -102,14 +102,20 @@ TEST_F(MatmulSchedulerTest, BasicMatmulRelaxedCheck_CUDA) {
     fusion->addOutput(tv2);
 
     NVF_CHECK(
-        1 == ir_utils::getMmaOps(fusion.get()).size(),
+        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
     NVF_CHECK(
-        ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+        ir_utils::getOpsOfType<MmaOp>(fusion.get())
+            .front()
+            ->layout()
+            .has_value(),
         "input layout has not be set for MmaOp");
     NVF_CHECK(
         MatmulLayout::TN ==
-            ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+            ir_utils::getOpsOfType<MmaOp>(fusion.get())
+                .front()
+                ->layout()
+                .value(),
         "the MmaOp layout of Ampere MMA must be always TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -166,14 +172,14 @@ TEST_F(MatmulSchedulerTest, BasicMatmulInputShuffledTT_CUDA) {
   fusion->addOutput(tv2);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must be always TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -229,14 +235,14 @@ TEST_F(MatmulSchedulerTest, EpilogueOutputCast_CUDA) {
   fusion->addOutput(tv3);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -292,14 +298,14 @@ TEST_F(MatmulSchedulerTest, EpilogueAlpha_CUDA) {
   fusion->addOutput(tv3);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -357,14 +363,14 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaOutputCast_CUDA) {
   fusion->addOutput(tv4);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -420,14 +426,14 @@ TEST_F(MatmulSchedulerTest, EpilogueRelu_CUDA) {
   fusion->addOutput(tv3);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -481,14 +487,14 @@ TEST_F(MatmulSchedulerTest, EpilogueGelu_CUDA) {
   fusion->addOutput(tv3);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -553,14 +559,14 @@ TEST_F(MatmulSchedulerTest, EpilogueBeta_CUDA) {
   fusion->addOutput(tv5);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -635,14 +641,14 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBeta_CUDA) {
   fusion->addOutput(tv6);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -723,14 +729,14 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaGeluOutputCast_CUDA) {
   fusion->addOutput(tv8);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -802,14 +808,14 @@ TEST_F(MatmulSchedulerTest, EpilogueBias_CUDA) {
   fusion->addOutput(tv4);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -887,14 +893,14 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias_CUDA) {
   fusion->addOutput(tv8);
 
   NVF_CHECK(
-      1 == ir_utils::getMmaOps(fusion.get()).size(),
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
   NVF_CHECK(
-      ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
       "input layout has not be set for MmaOp");
   NVF_CHECK(
       MatmulLayout::TN ==
-          ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
       "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -964,14 +970,20 @@ TEST_F(MatmulSchedulerTest, StridedBatch_CUDA) {
     fusion->addOutput(tv2);
 
     NVF_CHECK(
-        1 == ir_utils::getMmaOps(fusion.get()).size(),
+        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
     NVF_CHECK(
-        ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+        ir_utils::getOpsOfType<MmaOp>(fusion.get())
+            .front()
+            ->layout()
+            .has_value(),
         "input layout has not be set for MmaOp");
     NVF_CHECK(
         MatmulLayout::TN ==
-            ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+            ir_utils::getOpsOfType<MmaOp>(fusion.get())
+                .front()
+                ->layout()
+                .value(),
         "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -1042,14 +1054,20 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta_CUDA) {
     fusion->addOutput(tv6);
 
     NVF_CHECK(
-        1 == ir_utils::getMmaOps(fusion.get()).size(),
+        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
     NVF_CHECK(
-        ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+        ir_utils::getOpsOfType<MmaOp>(fusion.get())
+            .front()
+            ->layout()
+            .has_value(),
         "input layout has not be set for MmaOp");
     NVF_CHECK(
         MatmulLayout::TN ==
-            ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+            ir_utils::getOpsOfType<MmaOp>(fusion.get())
+                .front()
+                ->layout()
+                .value(),
         "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -1132,14 +1150,20 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta_CUDA) {
     fusion->addOutput(tv7);
 
     NVF_CHECK(
-        1 == ir_utils::getMmaOps(fusion.get()).size(),
+        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
     NVF_CHECK(
-        ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+        ir_utils::getOpsOfType<MmaOp>(fusion.get())
+            .front()
+            ->layout()
+            .has_value(),
         "input layout has not be set for MmaOp");
     NVF_CHECK(
         MatmulLayout::TN ==
-            ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+            ir_utils::getOpsOfType<MmaOp>(fusion.get())
+                .front()
+                ->layout()
+                .value(),
         "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -1211,14 +1235,20 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueBias_CUDA) {
     fusion->addOutput(tv4);
 
     NVF_CHECK(
-        1 == ir_utils::getMmaOps(fusion.get()).size(),
+        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
     NVF_CHECK(
-        ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+        ir_utils::getOpsOfType<MmaOp>(fusion.get())
+            .front()
+            ->layout()
+            .has_value(),
         "input layout has not be set for MmaOp");
     NVF_CHECK(
         MatmulLayout::TN ==
-            ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+            ir_utils::getOpsOfType<MmaOp>(fusion.get())
+                .front()
+                ->layout()
+                .value(),
         "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());
@@ -1283,14 +1313,20 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueSingleBias_CUDA) {
     fusion->addOutput(tv4);
 
     NVF_CHECK(
-        1 == ir_utils::getMmaOps(fusion.get()).size(),
+        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
     NVF_CHECK(
-        ir_utils::getMmaOps(fusion.get()).front()->layout().has_value(),
+        ir_utils::getOpsOfType<MmaOp>(fusion.get())
+            .front()
+            ->layout()
+            .has_value(),
         "input layout has not be set for MmaOp");
     NVF_CHECK(
         MatmulLayout::TN ==
-            ir_utils::getMmaOps(fusion.get()).front()->layout().value(),
+            ir_utils::getOpsOfType<MmaOp>(fusion.get())
+                .front()
+                ->layout()
+                .value(),
         "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMatmulLayout(fusion.get());


### PR DESCRIPTION
This is the first step to solve #946 : Refactor the existing getXops functions into a single templated function to centralize the operation retrieval logic.