### PR TITLE
Fix sinh_extension example compile error

### DIFF
--- a/examples/sinh_extension/main.cpp
+++ b/examples/sinh_extension/main.cpp
@@ -12,7 +12,7 @@
 
 #include <memory>
 
-using namespace torch::jit::fuser::cuda;
+using namespace nvfuser;
 
 at::Tensor sinh_nvfuser(const at::Tensor& input) {
   Fusion fusion;

--- a/examples/sinh_extension/main.cpp
+++ b/examples/sinh_extension/main.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <arith.h>
+#include <ops/arith.h>
 #include <executor.h>
 #include <scheduler/all_schedulers.h>
 #include <torch/extension.h>

--- a/examples/sinh_extension/main.cpp
+++ b/examples/sinh_extension/main.cpp
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <ops/arith.h>
 #include <executor.h>
+#include <ops/arith.h>
 #include <scheduler/all_schedulers.h>
 #include <torch/extension.h>
 

--- a/examples/sinh_extension/setup.py
+++ b/examples/sinh_extension/setup.py
@@ -9,6 +9,17 @@ import os
 nvfuser_csrc_dir = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "..", "csrc"
 )
+dynamic_type_dir = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", "lib", "dynamic_type", "src"
+)
+flatbuffers_dir = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "..",
+    "third_party",
+    "flatbuffers",
+    "include",
+)
 
 setup(
     name="nvfuser_extension",
@@ -16,7 +27,7 @@ setup(
         CUDAExtension(
             name="nvfuser_extension",
             pkg="nvfuser_extension",
-            include_dirs=[nvfuser_csrc_dir],
+            include_dirs=[nvfuser_csrc_dir, dynamic_type_dir, flatbuffers_dir],
             libraries=["nvfuser_codegen"],
             sources=["main.cpp"],
         )


### PR DESCRIPTION
Example still has `#include <arith.h>`. Changed to `#include <ops/arith.h>`. Also we still used `using namespace torch::jit::fuser::cuda` and we were missing include dirs for flatbuffers and dynamic_type.