### PR TITLE
Ignore .pre-commit-config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ nvfuser/cmake
 # debugging temporaries
 *.log
 foo.bin
+
+# Config for https://pre-commit.com/
+.pre-commit-config.yaml


### PR DESCRIPTION
This configures pre-commit hooks downloaded from https://pre-commit.com.