### PR TITLE
Wrap CompiledKernel in unique_ptr and add a proper destructor.

### DIFF
--- a/csrc/driver_api.h
+++ b/csrc/driver_api.h
@@ -20,18 +20,19 @@ namespace nvfuser {
   extern decltype(::funcName)* funcName;
 
 // List of driver APIs that you want the magic to happen.
-#define ALL_DRIVER_API_WRAPPER_CUDA11(fn)          \
-  fn(cuGetErrorName);                              \
-  fn(cuGetErrorString);                            \
-  fn(cuModuleLoadDataEx);                          \
-  fn(cuModuleGetFunction);                         \
-  fn(cuOccupancyMaxActiveBlocksPerMultiprocessor); \
-  fn(cuFuncGetAttribute);                          \
-  fn(cuFuncSetAttribute);                          \
-  fn(cuLaunchKernel);                              \
-  fn(cuLaunchCooperativeKernel);                   \
-  fn(cuDeviceGetAttribute);                        \
-  fn(cuDeviceGetName)
+#define ALL_DRIVER_API_WRAPPER_CUDA11(fn) \
+  fn(cuDeviceGetAttribute);               \
+  fn(cuDeviceGetName);                    \
+  fn(cuFuncGetAttribute);                 \
+  fn(cuFuncSetAttribute);                 \
+  fn(cuGetErrorName);                     \
+  fn(cuGetErrorString);                   \
+  fn(cuLaunchCooperativeKernel);          \
+  fn(cuLaunchKernel);                     \
+  fn(cuModuleGetFunction);                \
+  fn(cuModuleLoadDataEx);                 \
+  fn(cuModuleUnload);                     \
+  fn(cuOccupancyMaxActiveBlocksPerMultiprocessor)
 
 #if (CUDA_VERSION >= 12000)
 #define ALL_DRIVER_API_WRAPPER(fn)   \

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1543,7 +1543,7 @@ void FusionExecutor::recompileKernel(
     // false positives
     ensureAvailableDynamicSmemSize(new_launch_params.smem());
     validateCooperativeLaunch(
-        compiled_kernel_.function, new_launch_params, options_.device.index());
+        compiled_kernel_->function, new_launch_params, options_.device.index());
   }
 }
 
@@ -1555,7 +1555,7 @@ int64_t FusionExecutor::getAvailableDynamicSmemSize() {
     NVFUSER_CUDA_SAFE_CALL(cuFuncGetAttribute(
         &size,
         CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-        compiled_kernel_.function));
+        compiled_kernel_->function));
     available_dynamic_smem_size_ = size;
   }
   return available_dynamic_smem_size_.value();
@@ -1568,7 +1568,9 @@ int64_t FusionExecutor::getStaticSmemSize() {
     int size = 0;
     // Is this really a costly operation worth caching?
     NVFUSER_CUDA_SAFE_CALL(cuFuncGetAttribute(
-        &size, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, compiled_kernel_.function));
+        &size,
+        CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES,
+        compiled_kernel_->function));
     static_smem_size_ = size;
   }
   return static_smem_size_.value();
@@ -1595,7 +1597,7 @@ int64_t FusionExecutor::ensureAvailableDynamicSmemSize(
   if (dynamic_smem_size > getAvailableDynamicSmemSize()) {
     validateDynamicSmemSize(dynamic_smem_size);
     NVFUSER_CUDA_SAFE_CALL(cuFuncSetAttribute(
-        compiled_kernel_.function,
+        compiled_kernel_->function,
         CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
         dynamic_smem_size));
     available_dynamic_smem_size_ = dynamic_smem_size;
@@ -1783,7 +1785,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
       int blocks_per_sm = -1;
       NVFUSER_CUDA_SAFE_CALL(cuOccupancyMaxActiveBlocksPerMultiprocessor(
           &blocks_per_sm,
-          compiled_kernel_.function,
+          compiled_kernel_->function,
           launch_params_.nThreads(),
           launch_params_.smem()));
       const int64_t device_id =
@@ -1808,7 +1810,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     if (!kernel()->summary().has_cooperative_grid_reduction) {
       FUSER_PERF_SCOPE("ExecutorRunFusion::cuLaunchKernel");
       NVFUSER_CUDA_SAFE_CALL(cuLaunchKernel(
-          compiled_kernel_.function,
+          compiled_kernel_->function,
           launch_params_.gdimx(),
           launch_params_.gdimy(),
           launch_params_.gdimz(),
@@ -1822,7 +1824,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     } else {
       FUSER_PERF_SCOPE("ExecutorRunFusion::cuLaunchCooperativeKernel");
       NVFUSER_CUDA_SAFE_CALL(cuLaunchCooperativeKernel(
-          compiled_kernel_.function,
+          compiled_kernel_->function,
           launch_params_.gdimx(),
           launch_params_.gdimy(),
           launch_params_.gdimz(),
@@ -1935,7 +1937,7 @@ float FusionExecutor::runRtc(
   }
 
   NVFUSER_CUDA_SAFE_CALL(cuLaunchKernel(
-      compiled_kernel_.function,
+      compiled_kernel_->function,
       launch_params.gdimx(),
       launch_params.gdimy(),
       launch_params.gdimz(),
@@ -1986,7 +1988,7 @@ flatbuffers::Offset<serde::FusionExecutor> FusionExecutor::serialize(
       &executor_entry_lookup_keys_fb,
       &executor_entry_lookup_values_fb,
       serde::mapToSerdeDtype(kernel()->indexType()),
-      serialize(builder, compiled_kernel_));
+      serialize(builder, *compiled_kernel_));
 }
 
 flatbuffers::Offset<serde::CudaKernel> FusionExecutor::serialize(
@@ -2016,7 +2018,7 @@ flatbuffers::Offset<serde::CudaKernel> FusionExecutor::serialize(
     uint8_t* ptx_ptr = nullptr;
     fb_ptx =
         builder.CreateUninitializedVector(compiled_kernel.ptx.size(), &ptx_ptr);
-    std::copy(compiled_kernel_.ptx.begin(), compiled_kernel.ptx.end(), ptx_ptr);
+    std::copy(compiled_kernel.ptx.begin(), compiled_kernel.ptx.end(), ptx_ptr);
     fb_ptx_filename = builder.CreateString(compiled_kernel.ptx_filename);
   }
 

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -114,7 +114,10 @@ class FusionExecutor : public NonCopyable {
   // function to query whether a `FusionExecutor` has a compiled kernel to
   // execute
   bool isCompiled() const {
-    return fusion_id_ != -1 && lowered_ && compiled_kernel_.function != nullptr;
+    if (compiled_kernel_ != nullptr) {
+      NVF_ERROR(compiled_kernel_->function != nullptr);
+    }
+    return fusion_id_ != -1 && lowered_ && compiled_kernel_ != nullptr;
   };
 
   void evictCache(size_t cache_id) {
@@ -210,19 +213,19 @@ class FusionExecutor : public NonCopyable {
 
   //! Returns a const reference to the latest compiled kernel.
   const executor_utils::CompiledKernel& compiledKernel() const {
-    return compiled_kernel_;
+    return *compiled_kernel_;
   }
 
   //! Returns the disassembled latest compiled binary
   std::string disassembledBinary(const std::string& nvdisasm_args = "") const {
     return executor_utils::disassembleBinary(
-        compiled_kernel_.cubin, nvdisasm_args);
+        compiled_kernel_->cubin, nvdisasm_args);
   }
 
   //! Returns the disassembled latest compiled binary
   std::string disassembledKernelSASS() const {
     return executor_utils::disassembleBinary(
-        compiled_kernel_.cubin, "-fun 1 -c");
+        compiled_kernel_->cubin, "-fun 1 -c");
   }
 
   std::string getCanonicalKernelName() const {
@@ -394,7 +397,7 @@ class FusionExecutor : public NonCopyable {
   const int64_t max_static_smem_ = 48 << 10;
 
   int64_t warp_size_ = 0;
-  executor_utils::CompiledKernel compiled_kernel_;
+  std::unique_ptr<executor_utils::CompiledKernel> compiled_kernel_;
 
   // TensorViews actually used in the kernel.
   std::vector<TensorView*> used_tvs_;

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -1101,7 +1101,7 @@ void createNvrtcProgram(
 }
 
 // Compile the given source code with the NVRTC compiler driver.
-CompiledKernel compileSource(
+std::unique_ptr<CompiledKernel> compileSource(
     const std::string& full_src_code,
     const std::string& func_name,
     const int64_t id,
@@ -1120,26 +1120,26 @@ CompiledKernel compileSource(
   NVFUSER_NVRTC_SAFE_CALL(nvrtcAddNameExpression(program, func_name.c_str()));
   log << nvrtc_compile.invoke(program, full_src_code) << std::endl;
 
-  CompiledKernel compiled_kernel;
+  auto compiled_kernel = std::make_unique<CompiledKernel>();
   const char* lowered_kernel_name = nullptr;
   NVFUSER_NVRTC_SAFE_CALL(
       nvrtcGetLoweredName(program, func_name.c_str(), &lowered_kernel_name));
-  compiled_kernel.kernel_name = lowered_kernel_name;
-  compiled_kernel.compile_log = log.str();
+  compiled_kernel->kernel_name = lowered_kernel_name;
+  compiled_kernel->compile_log = log.str();
 
   if (compile_to_sass) {
-    compiled_kernel.cubin = compileNvrtcProgramToCubin(program);
+    compiled_kernel->cubin = compileNvrtcProgramToCubin(program);
     if (isDebugDumpEnabled(DebugDumpOption::Cubin)) {
-      compiled_kernel.cubin_filename =
-          dumpCompiledCodeToFile(compiled_kernel.cubin, id, ".cubin");
+      compiled_kernel->cubin_filename =
+          dumpCompiledCodeToFile(compiled_kernel->cubin, id, ".cubin");
     }
   }
 
   if (!compile_to_sass || isDebugDumpEnabled(DebugDumpOption::Ptx)) {
-    compiled_kernel.ptx = compileNvrtcProgramToPtx(program);
+    compiled_kernel->ptx = compileNvrtcProgramToPtx(program);
     if (isDebugDumpEnabled(DebugDumpOption::Ptx)) {
-      compiled_kernel.ptx_filename =
-          dumpCompiledCodeToFile(compiled_kernel.ptx, id, ".ptx");
+      compiled_kernel->ptx_filename =
+          dumpCompiledCodeToFile(compiled_kernel->ptx, id, ".ptx");
     }
   }
 
@@ -1148,8 +1148,14 @@ CompiledKernel compileSource(
 
 } // namespace
 
+CompiledKernel::~CompiledKernel() {
+  if (module != nullptr) {
+    NVFUSER_CUDA_SAFE_CALL(cuModuleUnload(module));
+  }
+}
+
 // Compile the source if no existing compiled binary is found in KernelDB
-CompiledKernel getCompiledKernel(
+std::unique_ptr<CompiledKernel> getCompiledKernel(
     std::optional<std::reference_wrapper<const std::string>> kernel_code,
     const std::string& full_src_code,
     const std::string& func_name,
@@ -1211,7 +1217,7 @@ CompiledKernel getCompiledKernel(
     }
   }
 
-  CompiledKernel compiled_kernel;
+  auto compiled_kernel = std::make_unique<CompiledKernel>();
   const auto compile_args =
       toDelimitedString(nvrtc_compile_driver.options(), " ");
 
@@ -1223,52 +1229,53 @@ CompiledKernel getCompiledKernel(
         kernel_db.query(
             kernel_code.value(),
             compile_args,
-            compiled_kernel.kernel_name,
-            (compile_to_sass ? compiled_kernel.cubin : compiled_kernel.ptx)))) {
+            compiled_kernel->kernel_name,
+            (compile_to_sass ? compiled_kernel->cubin
+                             : compiled_kernel->ptx)))) {
     compiled_kernel = compileSource(
         full_src_code, func_name, id, compile_to_sass, nvrtc_compile_driver);
-    log << compiled_kernel.compile_log << std::endl;
+    log << compiled_kernel->compile_log << std::endl;
     if (use_kernel_db) {
       auto result = kernel_db.write(
           kernel_code.value(),
           compile_args,
-          compiled_kernel.kernel_name,
-          (compile_to_sass ? compiled_kernel.cubin : compiled_kernel.ptx));
+          compiled_kernel->kernel_name,
+          (compile_to_sass ? compiled_kernel->cubin : compiled_kernel->ptx));
       if (!result) {
         TORCH_WARN(
             "kernel_db was unable to write kernel: ",
-            compiled_kernel.kernel_name);
+            compiled_kernel->kernel_name);
       }
     }
   }
 
   log << module_load_driver.invoke(
-             compiled_kernel.module,
-             (compile_to_sass ? compiled_kernel.cubin.data()
-                              : compiled_kernel.ptx.data()))
+             compiled_kernel->module,
+             (compile_to_sass ? compiled_kernel->cubin.data()
+                              : compiled_kernel->ptx.data()))
       << std::endl;
-  compiled_kernel.compile_log = log.str();
-  compiled_kernel.compile_args = compile_args;
+  compiled_kernel->compile_log = log.str();
+  compiled_kernel->compile_args = compile_args;
 
   if (isOptionEnabled(EnableOption::WarnRegisterSpill) ||
       compile_params.enable_ptxas_verbose) {
-    warnRegisterSpill(compiled_kernel.compile_log);
+    warnRegisterSpill(compiled_kernel->compile_log);
   }
 
   NVFUSER_CUDA_SAFE_CALL(cuModuleGetFunction(
-      &(compiled_kernel.function),
-      compiled_kernel.module,
-      compiled_kernel.kernel_name.c_str()));
+      &(compiled_kernel->function),
+      compiled_kernel->module,
+      compiled_kernel->kernel_name.c_str()));
 
   // Store block size used to generate compile arguments
   if (opt_block_size.has_value()) {
-    compiled_kernel.block_size = opt_block_size.value();
+    compiled_kernel->block_size = opt_block_size.value();
   }
 
   return compiled_kernel;
 }
 
-CompiledKernel getCompiledKernel(
+std::unique_ptr<CompiledKernel> getCompiledKernel(
     const serde::CudaKernel* buffer,
     const CompileParams& compile_params) {
   FUSER_PERF_SCOPE("executor_utils::serde_NVRTC");
@@ -1276,27 +1283,27 @@ CompiledKernel getCompiledKernel(
   NVF_ERROR(buffer != nullptr, "serde::CudaKernel is nullptr.");
 
   // Deserialize flatbuffer into CompiledKernel
-  CompiledKernel compiled_kernel;
-  compiled_kernel.kernel_name = buffer->kernel_name()->str();
-  compiled_kernel.compile_args = buffer->compile_args()->str();
-  compiled_kernel.block_size = buffer->block_size();
+  auto compiled_kernel = std::make_unique<CompiledKernel>();
+  compiled_kernel->kernel_name = buffer->kernel_name()->str();
+  compiled_kernel->compile_args = buffer->compile_args()->str();
+  compiled_kernel->block_size = buffer->block_size();
 
   if (buffer->cubin() != nullptr) {
-    compiled_kernel.cubin.reserve(buffer->cubin()->size());
+    compiled_kernel->cubin.reserve(buffer->cubin()->size());
     std::copy(
         buffer->cubin()->begin(),
         buffer->cubin()->end(),
-        std::back_inserter(compiled_kernel.cubin));
-    compiled_kernel.cubin_filename = buffer->cubin_filename()->str();
+        std::back_inserter(compiled_kernel->cubin));
+    compiled_kernel->cubin_filename = buffer->cubin_filename()->str();
   }
 
   if (buffer->ptx() != nullptr) {
-    compiled_kernel.ptx.reserve(buffer->ptx()->size());
+    compiled_kernel->ptx.reserve(buffer->ptx()->size());
     std::copy(
         buffer->ptx()->begin(),
         buffer->ptx()->end(),
-        std::back_inserter(compiled_kernel.ptx));
-    compiled_kernel.ptx_filename = buffer->ptx_filename()->str();
+        std::back_inserter(compiled_kernel->ptx));
+    compiled_kernel->ptx_filename = buffer->ptx_filename()->str();
   }
 
   at::cuda::jit::initializeCudaContext();
@@ -1324,8 +1331,8 @@ CompiledKernel getCompiledKernel(
   queryTargetGPUVersion(prop, major, minor, compile_to_sass);
 
   std::optional<int64_t> opt_block_size;
-  if (compiled_kernel.block_size >= -1) {
-    opt_block_size = compiled_kernel.block_size;
+  if (compiled_kernel->block_size >= -1) {
+    opt_block_size = compiled_kernel->block_size;
   }
 
   fillCompileOptions(
@@ -1340,33 +1347,33 @@ CompiledKernel getCompiledKernel(
   const auto latest_compile_args =
       toDelimitedString(nvrtc_compile_driver.options(), " ");
   NVF_ERROR(
-      latest_compile_args == compiled_kernel.compile_args,
+      latest_compile_args == compiled_kernel->compile_args,
       "The compile arguments for the serialized cuda kernel does not ",
       "match the latest generated compile args.\t",
       latest_compile_args,
       "\t",
-      compiled_kernel.compile_args);
+      compiled_kernel->compile_args);
 
   NVF_ERROR(
-      !compile_to_sass || !compiled_kernel.cubin.empty(),
+      !compile_to_sass || !compiled_kernel->cubin.empty(),
       "Expected compiled cubin after deserializing CompiledKernel.");
 
   NVF_ERROR(
-      compile_to_sass || !compiled_kernel.ptx.empty(),
+      compile_to_sass || !compiled_kernel->ptx.empty(),
       "Expected compiled ptx after deserializing CompiledKernel.");
 
   std::stringstream log;
   log << module_load_driver.invoke(
-             compiled_kernel.module,
-             (compile_to_sass ? compiled_kernel.cubin.data()
-                              : compiled_kernel.ptx.data()))
+             compiled_kernel->module,
+             (compile_to_sass ? compiled_kernel->cubin.data()
+                              : compiled_kernel->ptx.data()))
       << std::endl;
-  compiled_kernel.compile_log = log.str();
+  compiled_kernel->compile_log = log.str();
 
   NVFUSER_CUDA_SAFE_CALL(cuModuleGetFunction(
-      &(compiled_kernel.function),
-      compiled_kernel.module,
-      compiled_kernel.kernel_name.c_str()));
+      &(compiled_kernel->function),
+      compiled_kernel->module,
+      compiled_kernel->kernel_name.c_str()));
 
   return compiled_kernel;
 }

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -44,19 +44,8 @@ std::string disassembleBinary(
     const std::vector<char>& cubin,
     const std::string& nvdisasm_args);
 
-struct CompiledKernel {
-  CompiledKernel() {
-    std::cerr << "[jingyue] CompiledKernel::CompiledKernel\n";
-  }
-
-  ~CompiledKernel() {
-    std::cerr << "[jingyue] CompiledKernel::~CompiledKernel\n";
-  }
-
-  CompiledKernel(const CompiledKernel&) = delete;
-  CompiledKernel& operator=(const CompiledKernel&) = delete;
-  CompiledKernel(CompiledKernel&&) = default;
-  CompiledKernel& operator=(CompiledKernel&&) = default;
+struct CompiledKernel : public NonCopyable {
+  ~CompiledKernel();
 
   CUmodule module = nullptr;
   CUfunction function = nullptr;
@@ -71,7 +60,7 @@ struct CompiledKernel {
 };
 
 // Returns executable function and the ptxas log from compilation
-CompiledKernel getCompiledKernel(
+std::unique_ptr<CompiledKernel> getCompiledKernel(
     std::optional<std::reference_wrapper<const std::string>> kernel_code,
     const std::string& code,
     const std::string& func_name,
@@ -80,7 +69,7 @@ CompiledKernel getCompiledKernel(
     std::optional<int64_t> opt_block_size = std::nullopt);
 
 // Returns executable function using flatbuffer object
-CompiledKernel getCompiledKernel(
+std::unique_ptr<CompiledKernel> getCompiledKernel(
     const serde::CudaKernel* buffer,
     const CompileParams& compile_params);
 

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -45,6 +45,19 @@ std::string disassembleBinary(
     const std::string& nvdisasm_args);
 
 struct CompiledKernel {
+  CompiledKernel() {
+    std::cerr << "[jingyue] CompiledKernel::CompiledKernel\n";
+  }
+
+  ~CompiledKernel() {
+    std::cerr << "[jingyue] CompiledKernel::~CompiledKernel\n";
+  }
+
+  CompiledKernel(const CompiledKernel&) = delete;
+  CompiledKernel& operator=(const CompiledKernel&) = delete;
+  CompiledKernel(CompiledKernel&&) = default;
+  CompiledKernel& operator=(CompiledKernel&&) = default;
+
   CUmodule module = nullptr;
   CUfunction function = nullptr;
   std::string compile_log;

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -44,6 +44,8 @@ std::string disassembleBinary(
     const std::vector<char>& cubin,
     const std::string& nvdisasm_args);
 
+// I'm not happy with CompiledKernel being a struct exposing all the fields.
+// This could be refactored.
 struct CompiledKernel : public NonCopyable {
   ~CompiledKernel();
 


### PR DESCRIPTION
This fixes potential memory leaks where `CUmodule`s are never destroyed. It doesn't matter at this point because we never (?) evict `FusionKernelRuntime` from `FusionExecutorCache` (according to https://github.com/search?q=repo%3ANVIDIA%2FFuser%20evictcache%20&type=code). 