### PR TITLE
Evaluate extent for 1 check in squeeze and SqueezeOp

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -1189,7 +1189,7 @@ SqueezeOp::SqueezeOp(
         // Check concrete broadcast extent here. For Symbolic inputs, this check
         // will be deferred to concretization. See dynamic_transform.cpp
         NVF_ERROR(
-            id->extent()->isOneInt(),
+            id->extent()->isConstScalar() && id->extent()->evaluateInt() == 1,
             "Can not squeeze dimension(s) with size != 1.");
       }
     } else {

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -228,7 +228,7 @@ TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
         NVF_CHECK(
             !id->hasExpandedExtent(), "Can not squeeze expanded dimension(s).");
         NVF_CHECK(
-            id->extent()->isOneInt(),
+            id->extent()->isConstScalar() && id->extent()->evaluateInt() == 1,
             "Can not squeeze dimension(s) with size != 1.");
       }
     } else {


### PR DESCRIPTION
We currently use `isOneVal()` to test that a squeezed broadcast dimension has extent == 1. This change takes a deeper look to verify that it is a constant 1, but does not require it to be an immediate constant.

Fixes #963. Test omitted since it's included in #973 already.