### PR TITLE
Meson build for dynamic-type library

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
           cd lib/dynamic_type
           meson setup build
           meson compile -C build
-          meson test -C build
+          meson test --verbose -C build
 
   clang-tidy:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,8 +40,9 @@ jobs:
       - name: Run meson build of dynamic type library
         working-directory: ${{ env.working_directory }}
         run: |
-          pip install meson
-          pip install ninja
+          apt update && apt install -y libgtest-dev libgmock-dev libbenchmark-dev &
+          pip install meson ninja &
+          wait
           cd lib/dynamic_type
           meson setup build
           meson compile -C build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run meson build of dynamic type library
         working-directory: ${{ env.working_directory }}
         run: |
-          apt update && apt install -y libgtest-dev libgmock-dev libbenchmark-dev &
+          sudo apt update && sudo apt install -y libgtest-dev libgmock-dev libbenchmark-dev &
           pip install meson ninja &
           wait
           cd lib/dynamic_type

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,25 @@ jobs:
           wait
           python setup.py build
 
+  dynamic-type-meson:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Run meson build of dynamic type library
+        working-directory: ${{ env.working_directory }}
+        run: |
+          pip install meson
+          pip install ninja
+          cd lib/dynamic_type
+          meson setup build
+          meson compile -C build
+          meson test -C build
+
   clang-tidy:
     runs-on: ubuntu-latest
     steps:

--- a/lib/dynamic_type/benchmark/knn.cpp
+++ b/lib/dynamic_type/benchmark/knn.cpp
@@ -70,7 +70,7 @@ static double kNN_Native(
     double dy = point.y - query_point.y;
     double dz = point.z - query_point.z;
     double distance = std::sqrt(dx * dx + dy * dy + dz * dz);
-    if (distances_and_values.size() < k) {
+    if ((int64_t)distances_and_values.size() < k) {
       distances_and_values.push({distance, value});
     } else if (distance < distances_and_values.top().first) {
       distances_and_values.pop();
@@ -131,7 +131,7 @@ static StructVecDouble kNN_Dictionary(
     StructVecDouble dz = point["z"] - query_point["z"];
     StructVecDouble distance =
         std::sqrt((dx * dx + dy * dy + dz * dz).as<double>());
-    if (distances_and_values.size() < k) {
+    if ((int64_t)distances_and_values.size() < k) {
       distances_and_values.push({distance, value});
     } else if (distance < distances_and_values.top().first) {
       distances_and_values.pop();

--- a/lib/dynamic_type/meson.build
+++ b/lib/dynamic_type/meson.build
@@ -1,0 +1,56 @@
+project('dynamic_type', 'cpp')
+
+dynamic_type_dep = declare_dependency(
+    include_directories: include_directories('src'),
+    compile_args: '-std=c++17',
+)
+
+install_subdir('src/dynamic_type', install_dir : 'include')
+
+
+# test
+gtest_dep = dependency('gtest_main')
+gmock_dep = dependency('gmock')
+
+test_exe = executable('test_dynamic_type_17',
+    [
+        'test/ForAllTypes.cpp',
+        'test/assignment.cpp',
+        'test/binary_ops.cpp',
+        'test/container.cpp',
+        'test/examples.cpp',
+        'test/hash.cpp',
+        'test/member.cpp',
+        'test/move.cpp',
+        'test/null.cpp',
+        'test/opcheck.cpp',
+        'test/print.cpp',
+        'test/typing.cpp',
+        'test/unary_ops.cpp',
+    ],
+    dependencies: [
+        dynamic_type_dep,
+        gtest_dep,
+        gmock_dep,
+    ]
+)
+
+test('test_dynamic_type_17', test_exe)
+
+
+# benchmarks
+gbench_dep = dependency('benchmark')
+
+bench_exe = executable('bench_dynamic_type_17',
+    [
+        'benchmark/main.cpp',
+        'benchmark/knn.cpp',
+        'benchmark/sort.cpp',
+    ],
+    dependencies: [
+        dynamic_type_dep,
+        gbench_dep,
+    ],
+)
+
+test('bench_dynamic_type_17', bench_exe)

--- a/lib/dynamic_type/meson.build
+++ b/lib/dynamic_type/meson.build
@@ -53,4 +53,4 @@ bench_exe = executable('bench_dynamic_type_17',
     ],
 )
 
-test('bench_dynamic_type_17', bench_exe)
+test('bench_dynamic_type_17', bench_exe, timeout: 0)

--- a/lib/dynamic_type/meson.build
+++ b/lib/dynamic_type/meson.build
@@ -53,4 +53,4 @@ bench_exe = executable('bench_dynamic_type_17',
     ],
 )
 
-test('bench_dynamic_type_17', bench_exe, timeout: 0)
+benchmark('bench_dynamic_type_17', bench_exe, timeout: 0)


### PR DESCRIPTION
We may or may not want to eventually decide to be committed to meson, but for now, since I already have a working `meson.build` for `dynamic-type`, let me just add it. Using OSS CI because this test is fast enough.