### PR TITLE
Add LL suffix to Int literals

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -175,12 +175,18 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   std::string getLiteralSuffix(DataType dtype) {
-    // The type of an integer literal is automatically picked from
-    // int, long int, and long long int, so no suffix should be
-    // required. https://en.cppreference.com/w/cpp/language/integer_literal
     switch (std::get<PrimDataType>(dtype.type)) {
       case DataType::Float:
         return "f";
+      case DataType::Int:
+        // We use the LL suffix for int64_t literals
+        // See https://en.cppreference.com/w/cpp/language/integer_literal
+        // and https://en.cppreference.com/w/cpp/language/types
+        // For 64-bit Unix systems, int is 32-bit, long and long long are 64-bit
+        // For 64-bit Windows, int and long are 32-bit, long long are 64-bit
+        return "LL";
+      case DataType::Index:
+        return getLiteralSuffix(kernel_->indexType());
       default:
         return "";
     }

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -888,26 +888,26 @@ TEST_F(NVFuserTest, FusionParser_CUDA) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 1, 1> T0, Tensor<float, 1, 1> T1, Tensor<float, 1, 1> T3) {
   nvfuser_index_t i0;
-  i0 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)blockIdx.x));
-  if ((i0 < T0.logical_size[0])) {
-    float T5[1];
-    T5[0] = 0;
-    T5[0]
+  i0 = ((nvfuser_index_t)threadIdx.x) + (128LL * ((nvfuser_index_t)blockIdx.x));
+  if ((i0 < T0.logical_size[0LL])) {
+    float T5[1LL];
+    T5[0LL] = 0LL;
+    T5[0LL]
        = T1[i0];
-    float T4[1];
-    T4[0] = 0;
-    T4[0]
+    float T4[1LL];
+    T4[0LL] = 0LL;
+    T4[0LL]
        = T0[i0];
-    float T2[1];
-    T2[0]
-      = T4[0]
-      * T5[0];
-    float T6[1];
-    T6[0]
-      = T2[0]
-      * T4[0];
+    float T2[1LL];
+    T2[0LL]
+      = T4[0LL]
+      * T5[0LL];
+    float T6[1LL];
+    T6[0LL]
+      = T2[0LL]
+      * T4[0LL];
     T3[i0]
-       = T6[0];
+       = T6[0LL];
   }
 }
 )";

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -9095,47 +9095,47 @@ TEST_F(NVFuserTest, FusionChannelsLastParser_CUDA) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<__half, 4, 4> T0, Tensor<__half, 4, 4> T2, Tensor<__half, 4, 4> T7) {
   nvfuser_index_t i0;
-  i0 = T0.logical_size[2] * T0.logical_size[1];
+  i0 = T0.logical_size[2LL] * T0.logical_size[1LL];
   nvfuser_index_t i1;
-  i1 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)blockIdx.x));
+  i1 = ((nvfuser_index_t)threadIdx.x) + (128LL * ((nvfuser_index_t)blockIdx.x));
   nvfuser_index_t i2;
-  i2 = (T0.logical_size[1] * T0.logical_size[2]) * T0.logical_size[3];
+  i2 = (T0.logical_size[1LL] * T0.logical_size[2LL]) * T0.logical_size[3LL];
   nvfuser_index_t i3;
   i3 = i1 % i2;
   nvfuser_index_t i4;
-  i4 = T0.logical_size[2] * T0.logical_size[3];
+  i4 = T0.logical_size[2LL] * T0.logical_size[3LL];
   nvfuser_index_t i5;
   i5 = i3 % i4;
-  if ((i1 < (((T0.logical_size[0] * T0.logical_size[1]) * T0.logical_size[2]) * T0.logical_size[3]))) {
-    __half T9[1];
-    T9[0] = 0;
-    T9[0]
-       = T2[(((((i0 * T0.logical_size[3]) * (i1 / i2)) + (i0 * (i5 % T0.logical_size[3]))) + (T0.logical_size[2] * (i3 / i4))) + (i5 / T0.logical_size[3]))];
-    __half T8[1];
-    T8[0] = 0;
-    T8[0]
+  if ((i1 < (((T0.logical_size[0LL] * T0.logical_size[1LL]) * T0.logical_size[2LL]) * T0.logical_size[3LL]))) {
+    __half T9[1LL];
+    T9[0LL] = 0LL;
+    T9[0LL]
+       = T2[(((((i0 * T0.logical_size[3LL]) * (i1 / i2)) + (i0 * (i5 % T0.logical_size[3LL]))) + (T0.logical_size[2LL] * (i3 / i4))) + (i5 / T0.logical_size[3LL]))];
+    __half T8[1LL];
+    T8[0LL] = 0LL;
+    T8[0LL]
        = T0[i1];
-    float T3[1];
-    T3[0]
-       = __half2float(T9[0]);
-    float T4[1];
-    T4[0]
-       = T3[0];
-    float T1[1];
-    T1[0]
-       = __half2float(T8[0]);
-    float T5[1];
-    T5[0]
-      = T1[0]
-      * T4[0];
-    float T6[1];
-    T6[0]
-       = relu(T5[0]);
-    __half T10[1];
-    T10[0]
-       = __float2half(T6[0]);
+    float T3[1LL];
+    T3[0LL]
+       = __half2float(T9[0LL]);
+    float T4[1LL];
+    T4[0LL]
+       = T3[0LL];
+    float T1[1LL];
+    T1[0LL]
+       = __half2float(T8[0LL]);
+    float T5[1LL];
+    T5[0LL]
+      = T1[0LL]
+      * T4[0LL];
+    float T6[1LL];
+    T6[0LL]
+       = relu(T5[0LL]);
+    __half T10[1LL];
+    T10[0LL]
+       = __float2half(T6[0LL]);
     T7[i1]
-       = T10[0];
+       = T10[0LL];
   }
 }
 )";

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -1415,8 +1415,9 @@ TEST_F(NVFuserTest, FusionCodegenAllocatedScalars_CUDA) {
   // t0[(0 + 1)] = t0[((0 + 1) + 1)]
   std::stringstream no_alloc_ref;
   no_alloc_ref << "\n"
-               << indent << tk0_name << "[(0 + 1)]\n"
-               << indent << indent << " = " << tk0_name << "[((0 + 1) + 1)];\n";
+               << indent << tk0_name << "[(0LL + 1LL)]\n"
+               << indent << indent << " = " << tk0_name
+               << "[((0LL + 1LL) + 1LL)];\n";
 
   NVF_CHECK(
       no_alloc_code.find(no_alloc_ref.str()) != std::string::npos,

--- a/test/test_loop_rotation.cpp
+++ b/test/test_loop_rotation.cpp
@@ -36,35 +36,35 @@ TEST_F(LoopRotationTest, RotateInner) {
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i0 = 0; i0 < T0.logical_size[0]; ++i0) {
+  for(nvfuser_index_t i0 = 0; i0 < T0.logical_size[0LL]; ++i0) {
     nvfuser_index_t i1;
-    i1 = T0.alloc_stride[0] * i0;
+    i1 = T0.alloc_stride[0LL] * i0;
     nvfuser_index_t i2;
-    i2 = 3 * i0;
-    float T1[1];
-    float T2[1];
-    T1[0] = 0;
-    T1[0]
+    i2 = 3LL * i0;
+    float T1[1LL];
+    float T2[1LL];
+    T1[0LL] = 0LL;
+    T1[0LL]
        = T0[i1];
-    T2[0]
-       = T1[0];
+    T2[0LL]
+       = T1[0LL];
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+    for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
       nvfuser_index_t i4;
-      i4 = (1 + i3) + nvfuser_zero;
-      float T3[1];
-      T3[0]
-         = T2[0];
+      i4 = (1LL + i3) + nvfuser_zero;
+      float T3[1LL];
+      T3[0LL]
+         = T2[0LL];
       T4[(i2 + (i3 + nvfuser_zero))]
-         = T3[0];
-      T1[0] = 0;
-      if ((i4 < 3)) {
-        T1[0]
-           = T0[(i1 + (T0.alloc_stride[1] * i4))];
+         = T3[0LL];
+      T1[0LL] = 0LL;
+      if ((i4 < 3LL)) {
+        T1[0LL]
+           = T0[(i1 + (T0.alloc_stride[1LL] * i4))];
       }
-      T2[0]
-         = T1[0];
+      T2[0LL]
+         = T1[0LL];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
   }
@@ -101,62 +101,62 @@ TEST_F(LoopRotationTest, RotateOuter) {
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
-  float T1[3];
-  float T2[3];
+  float T1[3LL];
+  float T2[3LL];
   #pragma unroll
-  for(nvfuser_index_t i0 = 0; i0 < 3; ++i0) {
-    T1[i0] = 0;
+  for(nvfuser_index_t i0 = 0; i0 < 3LL; ++i0) {
+    T1[i0] = 0LL;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i0 = 0; i0 < 3; ++i0) {
+  for(nvfuser_index_t i0 = 0; i0 < 3LL; ++i0) {
     T1[i0]
-       = T0[(T0.alloc_stride[1] * (i0 + nvfuser_zero))];
+       = T0[(T0.alloc_stride[1LL] * (i0 + nvfuser_zero))];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i1 = 0; i1 < 3; ++i1) {
+  for(nvfuser_index_t i1 = 0; i1 < 3LL; ++i1) {
     T2[i1]
        = T1[i1];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i2 = 0; i2 < T0.logical_size[0]; ++i2) {
+  for(nvfuser_index_t i2 = 0; i2 < T0.logical_size[0LL]; ++i2) {
     nvfuser_index_t i3;
-    i3 = 3 * i2;
+    i3 = 3LL * i2;
     nvfuser_index_t i4;
-    i4 = T0.alloc_stride[0] + (T0.alloc_stride[0] * i2);
+    i4 = T0.alloc_stride[0LL] + (T0.alloc_stride[0LL] * i2);
     bool b5;
-    b5 = (1 + i2) < T0.logical_size[0];
+    b5 = (1LL + i2) < T0.logical_size[0LL];
     // Alias Allocation - register
     auto& T3 = T1;
     #pragma unroll
-    for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
+    for(nvfuser_index_t i6 = 0; i6 < 3LL; ++i6) {
       T3[i6]
          = T2[i6];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i7 = 0; i7 < 3; ++i7) {
+    for(nvfuser_index_t i7 = 0; i7 < 3LL; ++i7) {
       T4[(i3 + (i7 + nvfuser_zero))]
          = T3[i7];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i0 = 0; i0 < 3; ++i0) {
-      T1[i0] = 0;
+    for(nvfuser_index_t i0 = 0; i0 < 3LL; ++i0) {
+      T1[i0] = 0LL;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i0 = 0; i0 < 3; ++i0) {
+    for(nvfuser_index_t i0 = 0; i0 < 3LL; ++i0) {
       if (b5) {
         T1[i0]
-           = T0[(i4 + (T0.alloc_stride[1] * (i0 + nvfuser_zero)))];
+           = T0[(i4 + (T0.alloc_stride[1LL] * (i0 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i1 = 0; i1 < 3; ++i1) {
+    for(nvfuser_index_t i1 = 0; i1 < 3LL; ++i1) {
       T2[i1]
          = T1[i1];
     }
@@ -199,28 +199,28 @@ TEST_F(LoopRotationTest, NonDivisibleSplit) {
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   nvfuser_index_t i0;
-  i0 = T0.logical_size[0] * T0.logical_size[1];
+  i0 = T0.logical_size[0LL] * T0.logical_size[1LL];
   nvfuser_index_t i1;
-  i1 = ceilDiv(i0, 5);
-  float T1[5];
-  float T2[5];
+  i1 = ceilDiv(i0, 5LL);
+  float T1[5LL];
+  float T2[5LL];
   #pragma unroll
-  for(nvfuser_index_t i2 = 0; i2 < 5; ++i2) {
-    T1[i2] = 0;
+  for(nvfuser_index_t i2 = 0; i2 < 5LL; ++i2) {
+    T1[i2] = 0LL;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i2 = 0; i2 < 5; ++i2) {
+  for(nvfuser_index_t i2 = 0; i2 < 5LL; ++i2) {
     nvfuser_index_t i3;
     i3 = i2 + nvfuser_zero;
     if ((i3 < i0)) {
       T1[i2]
-         = T0[((T0.alloc_stride[0] * (i3 / T0.logical_size[1])) + (T0.alloc_stride[1] * (i3 % T0.logical_size[1])))];
+         = T0[((T0.alloc_stride[0LL] * (i3 / T0.logical_size[1LL])) + (T0.alloc_stride[1LL] * (i3 % T0.logical_size[1LL])))];
     }
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i4 = 0; i4 < 5; ++i4) {
+  for(nvfuser_index_t i4 = 0; i4 < 5LL; ++i4) {
     T2[i4]
        = T1[i4];
   }
@@ -228,19 +228,19 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   #pragma unroll 1
   for(nvfuser_index_t i5 = 0; i5 < i1; ++i5) {
     nvfuser_index_t i6;
-    i6 = 5 * i5;
+    i6 = 5LL * i5;
     nvfuser_index_t i7;
-    i7 = 5 + i6;
+    i7 = 5LL + i6;
     // Alias Allocation - register
     auto& T3 = T1;
     #pragma unroll
-    for(nvfuser_index_t i8 = 0; i8 < 5; ++i8) {
+    for(nvfuser_index_t i8 = 0; i8 < 5LL; ++i8) {
       T3[i8]
          = T2[i8];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i9 = 0; i9 < 5; ++i9) {
+    for(nvfuser_index_t i9 = 0; i9 < 5LL; ++i9) {
       nvfuser_index_t i10;
       i10 = i6 + (i9 + nvfuser_zero);
       if ((i10 < i0)) {
@@ -250,22 +250,22 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i2 = 0; i2 < 5; ++i2) {
-      T1[i2] = 0;
+    for(nvfuser_index_t i2 = 0; i2 < 5LL; ++i2) {
+      T1[i2] = 0LL;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i2 = 0; i2 < 5; ++i2) {
+    for(nvfuser_index_t i2 = 0; i2 < 5LL; ++i2) {
       nvfuser_index_t i11;
       i11 = i7 + (i2 + nvfuser_zero);
       if ((i11 < i0)) {
         T1[i2]
-           = T0[((T0.alloc_stride[0] * (i11 / T0.logical_size[1])) + (T0.alloc_stride[1] * (i11 % T0.logical_size[1])))];
+           = T0[((T0.alloc_stride[0LL] * (i11 / T0.logical_size[1LL])) + (T0.alloc_stride[1LL] * (i11 % T0.logical_size[1LL])))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i4 = 0; i4 < 5; ++i4) {
+    for(nvfuser_index_t i4 = 0; i4 < 5LL; ++i4) {
       T2[i4]
          = T1[i4];
     }
@@ -305,78 +305,78 @@ TEST_F(LoopRotationTest, DoubleBuffered) {
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   nvfuser_index_t i0;
-  i0 = 4 * T0.alloc_stride[0];
-  float T1[15];
+  i0 = 4LL * T0.alloc_stride[0LL];
+  float T1[15LL];
   #pragma unroll
-  for(nvfuser_index_t i1 = 0; i1 < 4; ++i1) {
+  for(nvfuser_index_t i1 = 0; i1 < 4LL; ++i1) {
     nvfuser_index_t i2;
-    i2 = 3 * i1;
+    i2 = 3LL * i1;
     nvfuser_index_t i3;
-    i3 = T0.alloc_stride[0] * i1;
+    i3 = T0.alloc_stride[0LL] * i1;
     bool b4;
-    b4 = (i1 + nvfuser_zero) < T0.logical_size[0];
+    b4 = (i1 + nvfuser_zero) < T0.logical_size[0LL];
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
-      T1[(i2 + i5)] = 0;
+    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
+      T1[(i2 + i5)] = 0LL;
     }
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
+    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
       if (b4) {
         T1[(i2 + i5)]
-           = T0[(i3 + (T0.alloc_stride[1] * (i5 + nvfuser_zero)))];
+           = T0[(i3 + (T0.alloc_stride[1LL] * (i5 + nvfuser_zero)))];
       }
     }
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
-  float T2[3];
+  float T2[3LL];
   #pragma unroll
-  for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
+  for(nvfuser_index_t i6 = 0; i6 < 3LL; ++i6) {
     T2[i6]
        = T1[i6];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i7 = 0; i7 < T0.logical_size[0]; ++i7) {
+  for(nvfuser_index_t i7 = 0; i7 < T0.logical_size[0LL]; ++i7) {
     nvfuser_index_t i8;
-    i8 = 4 + i7;
+    i8 = 4LL + i7;
     nvfuser_index_t i9;
-    i9 = 3 * (i8 % 5);
+    i9 = 3LL * (i8 % 5LL);
     nvfuser_index_t i10;
-    i10 = i0 + (T0.alloc_stride[0] * i7);
+    i10 = i0 + (T0.alloc_stride[0LL] * i7);
     nvfuser_index_t i11;
-    i11 = 3 * i7;
+    i11 = 3LL * i7;
     nvfuser_index_t i12;
-    i12 = 3 * ((1 + i7) % 5);
+    i12 = 3LL * ((1LL + i7) % 5LL);
     bool b13;
-    b13 = i8 < T0.logical_size[0];
+    b13 = i8 < T0.logical_size[0LL];
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
-      T1[(i9 + i5)] = 0;
+    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
+      T1[(i9 + i5)] = 0LL;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
+    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
       if (b13) {
         T1[(i9 + i5)]
-           = T0[(i10 + (T0.alloc_stride[1] * (i5 + nvfuser_zero)))];
+           = T0[(i10 + (T0.alloc_stride[1LL] * (i5 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
-    float T3[3];
+    float T3[3LL];
     #pragma unroll
-    for(nvfuser_index_t i14 = 0; i14 < 3; ++i14) {
+    for(nvfuser_index_t i14 = 0; i14 < 3LL; ++i14) {
       T3[i14]
          = T2[i14];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i15 = 0; i15 < 3; ++i15) {
+    for(nvfuser_index_t i15 = 0; i15 < 3LL; ++i15) {
       T4[(i11 + (i15 + nvfuser_zero))]
          = T3[i15];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i6 = 0; i6 < 3; ++i6) {
+    for(nvfuser_index_t i6 = 0; i6 < 3LL; ++i6) {
       T2[i6]
          = T1[(i12 + i6)];
     }
@@ -416,104 +416,104 @@ TEST_F(LoopRotationTest, SelectDoubleBufferLoad) {
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   nvfuser_index_t i0;
-  i0 = 4 * T0.alloc_stride[0];
+  i0 = 4LL * T0.alloc_stride[0LL];
   nvfuser_index_t i1;
-  i1 = 5 * T0.alloc_stride[0];
+  i1 = 5LL * T0.alloc_stride[0LL];
   bool b2;
-  b2 = 4 < T0.logical_size[0];
-  float T1[15];
+  b2 = 4LL < T0.logical_size[0LL];
+  float T1[15LL];
   #pragma unroll
-  for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
-    T1[i3] = 0;
+  for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+    T1[i3] = 0LL;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+  for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
     T1[i3]
-       = T0[(T0.alloc_stride[1] * (i3 + nvfuser_zero))];
+       = T0[(T0.alloc_stride[1LL] * (i3 + nvfuser_zero))];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i4 = 0; i4 < 4; ++i4) {
+  for(nvfuser_index_t i4 = 0; i4 < 4LL; ++i4) {
     nvfuser_index_t i5;
-    i5 = 3 + (3 * i4);
+    i5 = 3LL + (3LL * i4);
     nvfuser_index_t i6;
-    i6 = T0.alloc_stride[0] + (T0.alloc_stride[0] * i4);
+    i6 = T0.alloc_stride[0LL] + (T0.alloc_stride[0LL] * i4);
     bool b7;
-    b7 = ((1 + i4) + nvfuser_zero) < T0.logical_size[0];
+    b7 = ((1LL + i4) + nvfuser_zero) < T0.logical_size[0LL];
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
-      T1[(i5 + i3)] = 0;
+    for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+      T1[(i5 + i3)] = 0LL;
     }
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+    for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
       if (b7) {
         T1[(i5 + i3)]
-           = T0[(i6 + (T0.alloc_stride[1] * (i3 + nvfuser_zero)))];
+           = T0[(i6 + (T0.alloc_stride[1LL] * (i3 + nvfuser_zero)))];
       }
     }
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
-  float T2[3];
+  float T2[3LL];
   #pragma unroll
-  for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
-    T1[(12 + i3)] = 0;
+  for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+    T1[(12LL + i3)] = 0LL;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+  for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
     if (b2) {
-      T1[(12 + i3)]
-         = T0[(i0 + (T0.alloc_stride[1] * (i3 + nvfuser_zero)))];
+      T1[(12LL + i3)]
+         = T0[(i0 + (T0.alloc_stride[1LL] * (i3 + nvfuser_zero)))];
     }
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i8 = 0; i8 < 3; ++i8) {
+  for(nvfuser_index_t i8 = 0; i8 < 3LL; ++i8) {
     T2[i8]
        = T1[i8];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i9 = 0; i9 < T0.logical_size[0]; ++i9) {
+  for(nvfuser_index_t i9 = 0; i9 < T0.logical_size[0LL]; ++i9) {
     nvfuser_index_t i10;
-    i10 = 3 * i9;
+    i10 = 3LL * i9;
     nvfuser_index_t i11;
-    i11 = 3 * (i9 % 5);
+    i11 = 3LL * (i9 % 5LL);
     nvfuser_index_t i12;
-    i12 = i1 + (T0.alloc_stride[0] * i9);
+    i12 = i1 + (T0.alloc_stride[0LL] * i9);
     nvfuser_index_t i13;
-    i13 = 3 * ((1 + i9) % 5);
+    i13 = 3LL * ((1LL + i9) % 5LL);
     bool b14;
-    b14 = (5 + i9) < T0.logical_size[0];
-    float T3[3];
+    b14 = (5LL + i9) < T0.logical_size[0LL];
+    float T3[3LL];
     #pragma unroll
-    for(nvfuser_index_t i15 = 0; i15 < 3; ++i15) {
+    for(nvfuser_index_t i15 = 0; i15 < 3LL; ++i15) {
       T3[i15]
          = T2[i15];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i16 = 0; i16 < 3; ++i16) {
+    for(nvfuser_index_t i16 = 0; i16 < 3LL; ++i16) {
       T4[(i10 + (i16 + nvfuser_zero))]
          = T3[i16];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
-      T1[(i11 + i3)] = 0;
+    for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+      T1[(i11 + i3)] = 0LL;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3; ++i3) {
+    for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
       if (b14) {
         T1[(i11 + i3)]
-           = T0[(i12 + (T0.alloc_stride[1] * (i3 + nvfuser_zero)))];
+           = T0[(i12 + (T0.alloc_stride[1LL] * (i3 + nvfuser_zero)))];
       }
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i8 = 0; i8 < 3; ++i8) {
+    for(nvfuser_index_t i8 = 0; i8 < 3LL; ++i8) {
       T2[i8]
          = T1[(i13 + i8)];
     }
@@ -568,67 +568,67 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   const unsigned smem_offset = 0;
   NVFUSER_DEFINE_MAGIC_ZERO;
   float* ptr0;
-  ptr0 = T0.data + (4 * T0.alloc_stride[0]);
-  float* T4 = reinterpret_cast<float*>(array + smem_offset + 0);
+  ptr0 = T0.data + (4LL * T0.alloc_stride[0LL]);
+  float* T4 = reinterpret_cast<float*>(array + smem_offset + 0LL);
   #pragma unroll
-  for(nvfuser_index_t i1 = 0; i1 < 4; ++i1) {
+  for(nvfuser_index_t i1 = 0; i1 < 4LL; ++i1) {
     float* ptr2;
-    ptr2 = T0.data + (T0.alloc_stride[0] * i1);
+    ptr2 = T0.data + (T0.alloc_stride[0LL] * i1);
     unsigned i3;
-    i3 = toSmem(T4) + (12 * i1);
+    i3 = toSmem(T4) + (12LL * i1);
     bool b4;
-    b4 = (i1 + nvfuser_zero) < T0.logical_size[0];
+    b4 = (i1 + nvfuser_zero) < T0.logical_size[0LL];
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
-      Ampere::cpAsyncCa<float, 1>((i3 + (4 * i5)), (ptr2 + (T0.alloc_stride[1] * (i5 + nvfuser_zero))), b4);
+    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
+      Ampere::cpAsyncCa<float, 1>((i3 + (4LL * i5)), (ptr2 + (T0.alloc_stride[1LL] * (i5 + nvfuser_zero))), b4);
     }
     Ampere::cpAsyncCommit();
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   Ampere::cpAsyncPartialBarrier<3>();
-  float T1[2];
-  T1[0]
-     = T4[0];
+  float T1[2LL];
+  T1[0LL]
+     = T4[0LL];
   #pragma unroll 1
-  for(nvfuser_index_t i6 = 0; i6 < T0.logical_size[0]; ++i6) {
+  for(nvfuser_index_t i6 = 0; i6 < T0.logical_size[0LL]; ++i6) {
     float* ptr7;
-    ptr7 = ptr0 + (T0.alloc_stride[0] * i6);
+    ptr7 = ptr0 + (T0.alloc_stride[0LL] * i6);
     nvfuser_index_t i8;
-    i8 = 4 + i6;
+    i8 = 4LL + i6;
     unsigned i9;
-    i9 = toSmem(T4) + (12 * (i8 % 5));
+    i9 = toSmem(T4) + (12LL * (i8 % 5LL));
     nvfuser_index_t i10;
-    i10 = 1 + (3 * (i6 % 5));
+    i10 = 1LL + (3LL * (i6 % 5LL));
     nvfuser_index_t i11;
-    i11 = 3 * i6;
+    i11 = 3LL * i6;
     bool b12;
-    b12 = i8 < T0.logical_size[0];
+    b12 = i8 < T0.logical_size[0LL];
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3; ++i5) {
-      Ampere::cpAsyncCa<float, 1>((i9 + (4 * i5)), (ptr7 + (T0.alloc_stride[1] * (i5 + nvfuser_zero))), b12);
+    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
+      Ampere::cpAsyncCa<float, 1>((i9 + (4LL * i5)), (ptr7 + (T0.alloc_stride[1LL] * (i5 + nvfuser_zero))), b12);
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     Ampere::cpAsyncCommit();
     #pragma unroll
-    for(nvfuser_index_t i13 = 0; i13 < 2; ++i13) {
-      T1[((1 + i13) % 2)]
+    for(nvfuser_index_t i13 = 0; i13 < 2LL; ++i13) {
+      T1[((1LL + i13) % 2LL)]
          = T4[(i10 + i13)];
-      float T2[1];
-      T2[0]
-         = T1[(i13 % 2)];
+      float T2[1LL];
+      T2[0LL]
+         = T1[(i13 % 2LL)];
       T3[(i11 + (i13 + nvfuser_zero))]
-         = T2[0];
+         = T2[0LL];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
-    float T2[1];
-    T2[0]
-       = T1[0];
-    T3[(2 + i11)]
-       = T2[0];
+    float T2[1LL];
+    T2[0LL]
+       = T1[0LL];
+    T3[(2LL + i11)]
+       = T2[0LL];
     NVFUSER_UPDATE_MAGIC_ZERO;
     Ampere::cpAsyncPartialBarrier<3>();
-    T1[0]
-       = T4[(3 * ((1 + i6) % 5))];
+    T1[0LL]
+       = T4[(3LL * ((1LL + i6) % 5LL))];
   }
 }
 )";


### PR DESCRIPTION
In https://github.com/NVIDIA/Fuser/issues/973#issuecomment-1741343225, it was mentioned that expressions on `DataType::Int` constants are not necessarily safe from overflow. For example, an `exp` expression on `Int` constants currently prints like the example `2 ** 30`. Integer literals that are not very large will be compiled as 32-bit ints, so this arithmetic will be taking place at too low precision. This PR addresses this issue by adding a suffix of `LL` for `Int` constants so that these will translate to long long, which is 64-bit (see comment in code and second reference below on why we don't use `L` instead).

References:
- https://en.cppreference.com/w/cpp/language/integer_literal
- https://en.cppreference.com/w/cpp/language/types