### PR TITLE
Generate fusion_cache_generated.h in clang-tidy CI job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,6 +75,10 @@ jobs:
           # Run cmake build
           python setup.py --cmake-only
 
+          # Generate csrc/serde/fusion_cache_generated.h
+          # NOTE: this might cause a compile of flatbuffers if it is missing
+          ninja -C build build_flatbuffer_config
+
           # Run lintrunner on all csrc files exclude benchmark and test folders
           this_commit=$(git rev-parse HEAD)
           git fetch origin main


### PR DESCRIPTION
See https://github.com/NVIDIA/Fuser/issues/965#issuecomment-1740862192