### PR TITLE
In generated CUDA code, put comments before constants.

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1366,22 +1366,26 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
               kernel_->summary().sync_map->needsRawSync(in_tv).hasBID();
 
           if (localToGlobal) {
-            indent() << "loadLocalToGlobal<" << ldst->out()->dtype() << ", "
-                     << vector_word_size << ", "
+            indent() << "loadLocalToGlobal<" << ldst->out()->dtype()
+                     << ", /*vec_size=*/" << vector_word_size
+                     << ", /*is_volatile=*/"
                      << (is_volatile_to ? "true" : "false") << ">(";
             code_ << " &" << gen(ldst->out()) << ", &" << gen(ldst->in())
                   << ");\n";
           } else if (globalToLocal) {
-            indent() << "loadGlobalToLocal<" << ldst->out()->dtype() << ", "
-                     << vector_word_size << ", "
+            indent() << "loadGlobalToLocal<" << ldst->out()->dtype()
+                     << ", /*vec_size=*/" << vector_word_size
+                     << ", /*is_volatile=*/"
                      << (is_volatile_from ? "true" : "false") << ", "
                      << "CacheOp::" << ldst->cacheOp() << ">(&"
                      << gen(ldst->out()) << ", ";
             code_ << " &" << gen(ldst->in()) << ");\n";
           } else if (globalToGlobal) {
-            indent() << "loadGlobalToGlobal<" << ldst->out()->dtype() << ", "
-                     << vector_word_size << ", "
-                     << (is_volatile_to ? "true" : "false") << ", "
+            indent() << "loadGlobalToGlobal<" << ldst->out()->dtype()
+                     << ", /*vec_size=*/" << vector_word_size
+                     << ", /*is_volatile_to=*/"
+                     << (is_volatile_to ? "true" : "false")
+                     << ", /*is_volatile_from=*/"
                      << (is_volatile_from ? "true" : "false") << ">(";
             code_ << " &" << gen(ldst->out()) << ", ";
             code_ << " &" << gen(ldst->in()) << ");\n";


### PR DESCRIPTION
So readers know what they refer to. Example output: 

```
[ RUN      ] CacheGlobalLoads/MemoryTest.LoadCache/Streaming

======= Codegen output for kernel: kernel4 =======

__global__ void kernel4(Tensor<float, 1, 1> T0, Tensor<float, 1, 1> T3) {
  nvfuser_index_t i0;
  i0 = 4 * ((nvfuser_index_t)threadIdx.x);
  nvfuser_index_t i1;
  i1 = 128 * ((nvfuser_index_t)blockIdx.x);
  nvfuser_index_t i2;
  i2 = i0 + i1;
  bool b3;
  b3 = ((3 + i0) + i1) < T0.logical_size[0];
  Array<float, 4, 4> T1;
  T1.set(float(0));
  if (b3) {
    loadGlobalToLocal<float, /*vec_size=*/4, /*is_volatile=*/false, CacheOp::Streaming>(&T1[0],  &T0[i2]);
  }
  Array<float, 4, 4> T2;
  #pragma unroll
  for(nvfuser_index_t i4 = 0; i4 < 4; ++i4) {
    T2[i4]
      = T1[i4]
      + (float) 1.00000000000000000e+00;
  }
  if (b3) {
    loadLocalToGlobal<float, /*vec_size=*/4, /*is_volatile=*/false>( &T3[i2], &T2[0]);
  }
}

======================================

PRINTING: __tmp_kernel4.ptx
Removing __tmp_kernel4.ptx
[       OK ] CacheGlobalLoads/MemoryTest.LoadCache/Streaming (68 ms)
```