### PR TITLE
fix order of compile time checks in normalization scheduler

### DIFF
--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -40,7 +40,7 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     return false;
   }
 
-  // check reduction types and pattern
+  // check reduction type
   auto reduction_tvs = scheduler_utils::getReductionTvs(fusion);
   if (reduction_tvs.empty()) {
     scheduler_debug_utils::canScheduleRejectReason(
@@ -64,13 +64,6 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     } else {
       outer_reduction_tvs.emplace_back(tv);
     }
-  }
-  if (!normalization_scheduler_utils::checkReductionPattern(
-          fusion,
-          schedule_heuristic,
-          inner_reduction_tvs,
-          outer_reduction_tvs)) {
-    return false;
   }
 
   // check connections between inner reduction and outer reduction tvs.
@@ -147,6 +140,14 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
         return false;
       }
     }
+  }
+
+  if (!normalization_scheduler_utils::checkReductionPattern(
+          fusion,
+          schedule_heuristic,
+          inner_reduction_tvs,
+          outer_reduction_tvs)) {
+    return false;
   }
 
   // Only accept persistent kernels

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -849,9 +849,6 @@ bool compileTimeCheck(Fusion* fusion, ScheduleHeuristic schedule_heuristic) {
         "schedule_heuristic doesn't match with reduction type.");
     return false;
   }
-  if (!checkReductionPattern(fusion, schedule_heuristic, reduction_tvs)) {
-    return false;
-  }
 
   if (!ir_utils::getViewOps(fusion).empty()) {
     ComputeAtMap ca_map(fusion);
@@ -903,6 +900,10 @@ bool compileTimeCheck(Fusion* fusion, ScheduleHeuristic schedule_heuristic) {
         return false;
       }
     }
+  }
+
+  if (!checkReductionPattern(fusion, schedule_heuristic, reduction_tvs)) {
+    return false;
   }
 
   // Only accept persistent kernels


### PR DESCRIPTION
This PR fixes the following issue:
The `canScheduleCompileTime` function in normalization schedulers should call `checkReductionPattern` after checking the reduction axis, not before. It avoids building root domain map in easier cases, aligns with the reduction scheduler's order, and follows the principle of performing simpler checks first. This mistake has been present since the repository's first commit.