### PR TITLE
Refactor `inferAndValidateAllocationSizesAndStrides`

### DIFF
--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -211,6 +211,66 @@ class BackwardTraverseFromRFactorToAlloc {
   }
 };
 
+void validateAllocationSizesAndStrides(
+    const std::vector<IterDomain*>& alloc_dom_no_reductions,
+    const std::vector<std::optional<bool>>& contiguity,
+    c10::IntArrayRef sizes,
+    c10::IntArrayRef strides) {
+  NVF_ERROR(sizes.size() == strides.size());
+
+  // Validate contiguity
+  int64_t contiguous_stride = 1;
+  auto contiguity_rev = contiguity.crbegin();
+  for (int64_t i = (int64_t)sizes.size() - 1; i >= 0; i--) {
+    if (alloc_dom_no_reductions.at(i)->isBroadcast()) {
+      continue;
+    }
+    while (!contiguity_rev->has_value()) {
+      contiguity_rev++;
+    }
+    auto size = sizes.at(i);
+    auto stride = strides.at(i);
+    NVF_ERROR(!contiguity.empty());
+    auto last_contiguity = *contiguity_rev;
+    NVF_ERROR(
+        last_contiguity.has_value(),
+        "I don't think this check makes sense, but unfortunately ",
+        "clang-tidy is not smart enough to infer from the context that this is always true.");
+    if (*last_contiguity) {
+      NVF_CHECK(
+          stride == contiguous_stride,
+          "Stride mismatch with contiguity info. ",
+          " allocation domain: ",
+          ir_utils::toString(alloc_dom_no_reductions),
+          " dim: ",
+          i,
+          " expected stride: ",
+          contiguous_stride,
+          " actual stride: ",
+          stride);
+    }
+    contiguous_stride = stride * size;
+    contiguity_rev++;
+  }
+  NVF_ERROR(
+      contiguity_rev == contiguity.crend(),
+      "The size of contiguity mismatch with the dimensionality of allocation domain");
+
+  // Validate that for expanded broadcast, the stride must be zero.
+  for (int64_t i : c10::irange((int64_t)strides.size())) {
+    if (auto alloc_id = alloc_dom_no_reductions.at(i);
+        alloc_id->hasExpandedExtent()) {
+      auto stride = strides.at(i);
+      NVF_CHECK(
+          stride == 0,
+          "Expecting an expanded dimension on dimension ",
+          i,
+          " but found stride ",
+          stride);
+    }
+  }
+}
+
 // Given an ATen tensor, whose sizes and strides are w.r.t to the rFactor domain
 // of its corresponding TensorView, compute the sizes and strides of the tensor
 // with respect to its allocation domain.
@@ -262,57 +322,8 @@ inferAndValidateAllocationSizesAndStrides(
     sizes.emplace_back(active_ids.at(id).first);
     strides.emplace_back(active_ids.at(id).second);
   }
-  // Validate final sizes and strides with contiguity
-  int64_t contiguous_stride = 1;
-  std::vector<std::optional<bool>> contiguity = tv->getContiguity();
-  for (int64_t i = (int64_t)sizes.size() - 1; i >= 0; i--) {
-    if (alloc.at(i)->isBroadcast()) {
-      continue;
-    }
-    while (!contiguity.back().has_value()) {
-      contiguity.pop_back();
-    }
-    auto size = sizes.at(i);
-    auto stride = strides.at(i);
-    NVF_ERROR(!contiguity.empty());
-    auto last_contiguity = contiguity.back();
-    NVF_ERROR(
-        last_contiguity.has_value(),
-        "I don't think this check makes sense, but unfortunately ",
-        "clang-tidy is not smart enough to infer from the context that this is always true.");
-    if (*last_contiguity) {
-      NVF_CHECK(
-          stride == contiguous_stride,
-          "Stride mismatch with contiguity info. ",
-          "tv: ",
-          tv->toString(),
-          " allocation domain: ",
-          ir_utils::toString(tv->getMaybeAllocationDomain()),
-          " dim: ",
-          i,
-          " expected stride: ",
-          contiguous_stride,
-          " actual stride: ",
-          stride);
-    }
-    contiguous_stride = stride * size;
-    contiguity.pop_back();
-  }
-  NVF_ERROR(
-      contiguity.empty(),
-      "The size of contiguity mismatch with the dimensionality of allocation domain");
-  // Validate that for expanded broadcast, the stride must be zero.
-  for (int64_t i : c10::irange((int64_t)strides.size())) {
-    if (auto alloc_id = alloc.at(i); alloc_id->hasExpandedExtent()) {
-      auto stride = strides.at(i);
-      NVF_CHECK(
-          stride == 0,
-          "Expecting an expanded dimension on dimension ",
-          i,
-          " but found stride ",
-          stride);
-    }
-  }
+  // Validate final sizes and strides
+  validateAllocationSizesAndStrides(alloc, tv->getContiguity(), sizes, strides);
   return {std::move(sizes), std::move(strides)};
 }
 
@@ -350,6 +361,7 @@ std::vector<PolymorphicValue> GetMetaData::evaluate(
   } else {
     metadata->alloc_size = input.sizes();
     metadata->alloc_stride = input.strides();
+    // TODO: validateAllocationSizesAndStrides
   }
   return {PolymorphicValue(std::move(struct_))};
 }


### PR DESCRIPTION
Move the validation part into a separate function. There should be no behavioral change, just code movement.