### PR TITLE
Replace `c10::irange` with `std::views::iota`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -111,4 +111,4 @@ jobs:
           sudo apt install -y libtinfo5
 
           # Run lintrunner except clang-tidy
-          lintrunner --force-color --take FLAKE8,MYPY,CLANGFORMAT,NOQA,TYPEIGNORE,NEWLINE,MYPYSTRICT,TABS,SPACES,EXEC,BLACK,TORCH_INTERNAL_ASSERT,TORCH_CHECK,C10_ERROR,TORCH_CUDA_CU_API,irange --all-files
+          lintrunner --force-color --take FLAKE8,MYPY,CLANGFORMAT,NOQA,TYPEIGNORE,NEWLINE,MYPYSTRICT,TABS,SPACES,EXEC,BLACK,TORCH_INTERNAL_ASSERT,TORCH_CHECK,C10_ERROR,TORCH_CUDA_CU_API,c10irange,irangeheader --all-files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -111,4 +111,4 @@ jobs:
           sudo apt install -y libtinfo5
 
           # Run lintrunner except clang-tidy
-          lintrunner --force-color --take FLAKE8,MYPY,CLANGFORMAT,NOQA,TYPEIGNORE,NEWLINE,MYPYSTRICT,TABS,SPACES,EXEC,BLACK,TORCH_INTERNAL_ASSERT,TORCH_CHECK,C10_ERROR,TORCH_CUDA_CU_API --all-files
+          lintrunner --force-color --take FLAKE8,MYPY,CLANGFORMAT,NOQA,TYPEIGNORE,NEWLINE,MYPYSTRICT,TABS,SPACES,EXEC,BLACK,TORCH_INTERNAL_ASSERT,TORCH_CHECK,C10_ERROR,TORCH_CUDA_CU_API,irange --all-files

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -159,6 +159,34 @@ command = [
 ]
 is_formatter = true
 
+[[linter]]
+code = 'irange'
+include_patterns = [
+    '**/*.h',
+    '**/*.cpp',
+    '**/*.cu',
+    '**/*.inl',
+]
+exclude_patterns = [
+    'pytorch/**/*.cpp',
+    'third_party/**',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=irange',
+    '--linter-name=irange',
+    '--error-name=using c10::irange, use std::views::iota instead',
+    '--replace-pattern=s/irange/std::views::iota/',
+    """--error-description=\
+        using c10::irange in nvfuser code base is deprecated, \
+        use std::views::iota instead\
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]
+is_formatter = true
+
 
 [[linter]]
 code = 'CLANGTIDY'

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -160,7 +160,7 @@ command = [
 is_formatter = true
 
 [[linter]]
-code = 'irange'
+code = 'c10irange'
 include_patterns = [
     '**/*.h',
     '**/*.cpp',
@@ -174,13 +174,42 @@ exclude_patterns = [
 command = [
     'python3',
     'tools/linter/adapters/grep_linter.py',
-    '--pattern=irange',
+    '--pattern=c10::irange',
     '--linter-name=irange',
-    '--error-name=using c10::irange, use std::views::iota instead',
-    '--replace-pattern=s/irange/std::views::iota/',
+    '--error-name=using c10::irange, use nvfuser::irange instead',
+    '--replace-pattern=s/c10::irange/nvfuser::irange/',
     """--error-description=\
         using c10::irange in nvfuser code base is deprecated, \
-        use std::views::iota instead\
+        use nvfuser::irange instead\
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]
+is_formatter = true
+
+
+[[linter]]
+code = 'irangeheader'
+include_patterns = [
+    '**/*.h',
+    '**/*.cpp',
+    '**/*.cu',
+    '**/*.inl',
+]
+exclude_patterns = [
+    'pytorch/**/*.cpp',
+    'third_party/**',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=irange.h',
+    '--linter-name=irange',
+    '--error-name=including c10/util/irange.h, use nvfuser::irange instead',
+    '--replace-pattern=s/c10\/util\/irange/ranges/',
+    """--error-description=\
+        including c10/util/irange.h in nvfuser code base is deprecated, \
+        use nvfuser::irange instead\
     """,
     '--',
     '@{{PATHSFILE}}'

--- a/benchmark/transpose.cpp
+++ b/benchmark/transpose.cpp
@@ -20,6 +20,8 @@
 #include <benchmark/utils.h>
 #include <test/utils.h>
 
+#include <C++20/ranges>
+
 using namespace nvfuser;
 
 #define TRANSPOSE_CONFIG \
@@ -58,10 +60,10 @@ std::vector<at::Tensor> generateInputs(
   // Vectorization | Unroll - Add 1 to sizes
   // Shift axis by 1 to disable vectorize loads
   if (non_vectorize_offset) {
-    for (auto idx : c10::irange(transpose_shape.size())) {
+    for (auto idx : std::views::iota((size_t)0, transpose_shape.size())) {
       transpose_shape[idx] += 1;
     }
-    for (auto idx : c10::irange(non_transpose_shape.size())) {
+    for (auto idx : std::views::iota((size_t)0, non_transpose_shape.size())) {
       non_transpose_shape[idx] += 1;
     }
   }

--- a/benchmark/transpose.cpp
+++ b/benchmark/transpose.cpp
@@ -20,7 +20,7 @@
 #include <benchmark/utils.h>
 #include <test/utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 using namespace nvfuser;
 
@@ -60,10 +60,10 @@ std::vector<at::Tensor> generateInputs(
   // Vectorization | Unroll - Add 1 to sizes
   // Shift axis by 1 to disable vectorize loads
   if (non_vectorize_offset) {
-    for (auto idx : std::views::iota((size_t)0, transpose_shape.size())) {
+    for (auto idx : irange(transpose_shape.size())) {
       transpose_shape[idx] += 1;
     }
-    for (auto idx : std::views::iota((size_t)0, non_transpose_shape.size())) {
+    for (auto idx : irange(non_transpose_shape.size())) {
       non_transpose_shape[idx] += 1;
     }
   }

--- a/csrc/C++20/ranges
+++ b/csrc/C++20/ranges
@@ -11,6 +11,8 @@
 
 // This is backport of C++20 ranges library to C++17.
 
+namespace std {
+
 namespace ranges {
 
 template <typename W, typename Bound>
@@ -72,6 +74,7 @@ constexpr iota_view<W, Bound> iota(W&& value, Bound&& bound) {
 
 } // namespace views
 } // namespace ranges
+} // namespace std
 
 namespace std {
 namespace views = ranges::views;

--- a/csrc/C++20/ranges
+++ b/csrc/C++20/ranges
@@ -61,9 +61,6 @@ class iota_view {
   std::decay_t<Bound> bound_;
 };
 
-// template <typename W>
-// iota_view(W&&) -> iota_view<W>;
-
 namespace views {
 
 template <typename W, typename Bound>

--- a/csrc/C++20/ranges
+++ b/csrc/C++20/ranges
@@ -11,6 +11,8 @@
 
 // This is backport of C++20 ranges library to C++17.
 
+#if __cplusplus < 202002L
+
 namespace std {
 
 namespace ranges {
@@ -76,3 +78,5 @@ constexpr iota_view<W, Bound> iota(W&& value, Bound&& bound) {
 namespace std {
 namespace views = ranges::views;
 }
+
+#endif

--- a/csrc/C++20/ranges
+++ b/csrc/C++20/ranges
@@ -1,0 +1,78 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <type_traits>
+
+// This is backport of C++20 ranges library to C++17.
+
+namespace ranges {
+
+template <typename W, typename Bound>
+class iota_view {
+  static_assert(
+      std::is_same_v<std::decay_t<W>, std::decay_t<Bound>>,
+      "W != Bound not supported yet");
+
+ public:
+  constexpr iota_view(W&& value, Bound&& bound)
+      : value_(std::forward<W>(value)), bound_(std::forward<Bound>(bound)) {}
+
+  struct iterator {
+    std::decay_t<W> value_;
+    std::decay_t<Bound> bound_;
+    constexpr std::decay_t<W> operator*() const {
+      return value_;
+    }
+    constexpr iterator& operator++() {
+      ++value_;
+      return *this;
+    }
+    constexpr iterator operator++(int) {
+      auto tmp = *this;
+      ++*this;
+      return tmp;
+    }
+    constexpr bool operator==(const iterator& other) const {
+      return value_ == other.value_;
+    }
+    constexpr bool operator!=(const iterator& other) const {
+      return !(*this == other);
+    }
+  };
+
+  constexpr iterator begin() const {
+    return {value_, bound_};
+  }
+
+  constexpr iterator end() const {
+    return {bound_, bound_};
+  }
+
+ private:
+  std::decay_t<W> value_;
+  std::decay_t<Bound> bound_;
+};
+
+// template <typename W>
+// iota_view(W&&) -> iota_view<W>;
+
+namespace views {
+
+template <typename W, typename Bound>
+constexpr iota_view<W, Bound> iota(W&& value, Bound&& bound) {
+  return iota_view<W, Bound>(
+      std::forward<W>(value), std::forward<Bound>(bound));
+}
+
+} // namespace views
+} // namespace ranges
+
+namespace std {
+namespace views = ranges::views;
+}

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1825,8 +1825,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     ArgumentBuilder func_args(block_nest_level_ + 1, kTab);
 
     // Append arguments for each reduction
-    for (const auto i : std::views::iota(
-             (size_t)0, grouped_grop->numHorizontallyGroupedExprs())) {
+    for (const auto i : irange(grouped_grop->numHorizontallyGroupedExprs())) {
       NVF_ERROR(
           grouped_grop->reduction_buffers().at(i)->buffer()->isA<TensorView>());
       const auto work_buffer =
@@ -1998,8 +1997,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     ArgumentBuilder read_preds;
     ArgumentBuilder write_preds;
 
-    for (const auto expr_index : std::views::iota(
-             (size_t)0, grouped_grop->numHorizontallyGroupedExprs())) {
+    for (const auto expr_index :
+         irange(grouped_grop->numHorizontallyGroupedExprs())) {
       const auto data_type = grouped_grop->outputs().at(expr_index)->dtype();
       NVF_ERROR(grouped_grop->reduction_buffers()
                     .at(expr_index)
@@ -2138,8 +2137,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     auto input_vals = grouped_gwop->inputVals();
     auto init_vals = grouped_gwop->initVals();
 
-    for (const auto expr_index : std::views::iota(
-             (size_t)0, grouped_gwop->numHorizontallyGroupedExprs())) {
+    for (const auto expr_index :
+         irange(grouped_gwop->numHorizontallyGroupedExprs())) {
       const auto& output = output_vals.at(expr_index);
       const auto& input = input_vals.at(expr_index);
       const auto& init = init_vals.at(expr_index);
@@ -2632,8 +2631,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const GroupedReductionOp* grouped_rop) final {
-    for (const auto i : std::views::iota(
-             (size_t)0, grouped_rop->numHorizontallyGroupedExprs())) {
+    for (const auto i : irange(grouped_rop->numHorizontallyGroupedExprs())) {
       NVF_ERROR(grouped_rop->output(i)->isA<kir::TensorIndex>());
 
       const auto output = grouped_rop->output(i)->as<kir::TensorIndex>();

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1998,8 +1998,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     ArgumentBuilder read_preds;
     ArgumentBuilder write_preds;
 
-    for (const auto expr_index :
-         std::views::iota((size_t)0, grouped_grop->numHorizontallyGroupedExprs())) {
+    for (const auto expr_index : std::views::iota(
+             (size_t)0, grouped_grop->numHorizontallyGroupedExprs())) {
       const auto data_type = grouped_grop->outputs().at(expr_index)->dtype();
       NVF_ERROR(grouped_grop->reduction_buffers()
                     .at(expr_index)

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -16,7 +16,7 @@
 #include <type.h>
 #include <utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <array>
 #include <cmath>
 #include <sstream>
@@ -44,7 +44,7 @@ class ArgumentBuilder {
   //! Build an argument list where each argument has its own line
   ArgumentBuilder(int indent_level, const char* tab) {
     std::stringstream ss;
-    for (const auto i : std::views::iota(0, indent_level)) {
+    for (const auto i : irange(indent_level)) {
       (void)i; // Suppress unused variable warning
       ss << tab;
     }
@@ -240,7 +240,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     // Generate parameter declarations
     kernel_params_.reserve(kernel_->parameters().size());
     unsigned int duplicate_counter = 0;
-    for (auto i : std::views::iota((size_t)0, kernel_->parameters().size())) {
+    for (auto i : irange(kernel_->parameters().size())) {
       std::stringstream var_name_ss;
       auto param = kernel_->parameters().at(i);
       kernel_params_.insert(param);
@@ -403,7 +403,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   std::ostream& indent() {
-    for (const auto i : std::views::iota(0, block_nest_level_)) {
+    for (const auto i : irange(block_nest_level_)) {
       (void)i; // Suppress unused variable warning
       code_ << kTab;
     }
@@ -630,7 +630,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     }
     auto dtype = std::get<StructType>(sop->output(0)->dtype().type);
     code_ << dtype.name << "{ ";
-    for (auto i : std::views::iota((size_t)0, sop->inputs().size())) {
+    for (auto i : irange(sop->inputs().size())) {
       if (i > 0) {
         code_ << ", ";
       }
@@ -1940,7 +1940,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     for (const auto& index_values : index_val_sets) {
       NVF_ERROR(loop_indices.size() == index_values.size());
       std::unordered_map<const Val*, int64_t> index_val_map;
-      for (const auto i : std::views::iota((size_t)0, loop_indices.size())) {
+      for (const auto i : irange(loop_indices.size())) {
         auto loop_index = loop_indices.at(i);
         auto index_val = index_values.at(i);
         index_val_map.emplace(loop_index, index_val);
@@ -2006,8 +2006,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
                     ->buffer()
                     ->isA<TensorView>());
 
-      for (const auto& group_index :
-           std::views::iota((size_t)0, index_replacement_maps.size())) {
+      for (const auto& group_index : irange(index_replacement_maps.size())) {
         // Set the index replacement map with the concrete values of
         // indices of grouped loops.
         index_replacement_map_ = index_replacement_maps.at(group_index);
@@ -2145,8 +2144,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       const auto& input = input_vals.at(expr_index);
       const auto& init = init_vals.at(expr_index);
 
-      for (const auto& group_index :
-           std::views::iota((size_t)0, index_replacement_maps.size())) {
+      for (const auto& group_index : irange(index_replacement_maps.size())) {
         // Set the index replacement map with the concrete values of
         // indices of grouped loops.
         index_replacement_map_ = index_replacement_maps.at(group_index);
@@ -2160,7 +2158,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
                std::to_string(group_index));
 
         // Setup arguments for avg, var, and N
-        for (const auto i : std::views::iota(0, 3)) {
+        for (const auto i : irange(3)) {
           out_args[i].arg(gen(output.get(i)));
           in_args[i].arg(gen(input.get(i)));
           init_args[i].arg(gen(init.get(i)));
@@ -2302,7 +2300,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_args.arg(genVariableName(input.get(2))).append("[0]");
 
     // global buf
-    for (const auto i : std::views::iota(0, 3)) {
+    for (const auto i : irange(3)) {
       const auto work_buffer = grouped_gwop->reduction_buffers()[i]
                                    .at(0)
                                    ->buffer()
@@ -2913,7 +2911,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     //   consumer[consumer_idx] = produce_3[producer_idx3];
     // }
 
-    for (const auto i : std::views::iota((size_t)0, cat->inputs().size())) {
+    for (const auto i : irange(cat->inputs().size())) {
       auto inp = cat->input(i)->as<kir::TensorIndex>();
       auto inp_str = gen(inp);
       if (i < cat->inputs().size() - 1) {

--- a/csrc/compute_at.cpp
+++ b/csrc/compute_at.cpp
@@ -14,7 +14,7 @@
 #include <root_domain_map.h>
 #include <transform_iter.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -65,7 +65,7 @@ std::set<T> set_intersection(const std::set<T>& set1, const std::set<T>& set2) {
 std::deque<std::deque<TensorView*>> tvChains(
     std::deque<std::deque<Val*>> val_chains) {
   std::deque<std::deque<TensorView*>> tv_chains(val_chains.size());
-  for (const auto i : std::views::iota((size_t)0, val_chains.size())) {
+  for (const auto i : irange(val_chains.size())) {
     auto tv_iterable = ir_utils::filterByType<TensorView>(val_chains[i]);
     tv_chains[i] =
         std::deque<TensorView*>(tv_iterable.begin(), tv_iterable.end());

--- a/csrc/compute_at.cpp
+++ b/csrc/compute_at.cpp
@@ -14,7 +14,7 @@
 #include <root_domain_map.h>
 #include <transform_iter.h>
 
-#include <c10/util/irange.h>
+#include <C++20/ranges>
 
 namespace nvfuser {
 
@@ -65,7 +65,7 @@ std::set<T> set_intersection(const std::set<T>& set1, const std::set<T>& set2) {
 std::deque<std::deque<TensorView*>> tvChains(
     std::deque<std::deque<Val*>> val_chains) {
   std::deque<std::deque<TensorView*>> tv_chains(val_chains.size());
-  for (const auto i : c10::irange(val_chains.size())) {
+  for (const auto i : std::views::iota((size_t)0, val_chains.size())) {
     auto tv_iterable = ir_utils::filterByType<TensorView>(val_chains[i]);
     tv_chains[i] =
         std::deque<TensorView*>(tv_iterable.begin(), tv_iterable.end());

--- a/csrc/compute_at.cpp
+++ b/csrc/compute_at.cpp
@@ -126,8 +126,9 @@ TensorView* getCommonConsumer(TensorView* producer, TensorView* consumer) {
   // after consumer
   for (const auto& tv_chain : all_chains) {
     for (auto tv : tv_chain) {
-      if (tv != consumer)
+      if (tv != consumer) {
         common_consumers.erase(tv);
+      }
     }
   }
 

--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -13,6 +13,7 @@
 #include <root_domain_map.h>
 #include <transform_iter.h>
 
+#include <C++20/ranges>
 #include <tuple>
 #include <typeinfo>
 
@@ -217,7 +218,7 @@ void IterDomainGraph::mapThroughExpr(Expr* first, Expr* second, bool forward) {
       first->toString(),
       "\nand\n",
       second->toString());
-  for (auto out_i : c10::irange(first_ids.size())) {
+  for (auto out_i : std::views::iota((size_t)0, first_ids.size())) {
     exact_nodes_.mapEntries(first_ids[out_i], second_ids[out_i]);
     permissive_nodes_.mapEntries(first_ids[out_i], second_ids[out_i]);
     permissive_resize_nodes_.mapEntries(first_ids[out_i], second_ids[out_i]);
@@ -392,8 +393,8 @@ void IterDomainGraph::build(Fusion* fusion) {
             "Only supported case is welford op where all outputs tvs have identical domains.");
         // p->f, c->c
         std::unordered_map<IterDomain*, IterDomain*> c2f_root_map;
-        for (const auto i :
-             c10::irange(first_output_tv->getRootDomain().size())) {
+        for (const auto i : std::views::iota(
+                 (size_t)0, first_output_tv->getRootDomain().size())) {
           c2f_root_map.insert(std::make_pair(
               c_tv->getRootDomain()[i], first_output_tv->getRootDomain()[i]));
         }
@@ -500,7 +501,7 @@ void IterDomainGraph::build(Fusion* fusion) {
 
         for (auto& dset : permissive_disjoint_sets.disjointSets()) {
           auto& vec = dset->vector();
-          for (auto i : c10::irange(vec.size())) {
+          for (auto i : std::views::iota((size_t)0, vec.size())) {
             auto id1 = vec[i];
             permissive_nodes_.mapEntries(id1, vec[0]);
 
@@ -509,7 +510,7 @@ void IterDomainGraph::build(Fusion* fusion) {
             //  or p_id is swizzle output.
             mapMaybeSwizzleOp(permissive_nodes_, id1);
 
-            for (auto j : c10::irange(i + 1, vec.size())) {
+            for (auto j : std::views::iota(i + 1, vec.size())) {
               auto id2 = vec[j];
               if (p_ids.count(id1) && c_ids.count(id2)) {
                 if (idIsAComputeAtLeafDomain(id1, p_tv, c_tv) &&
@@ -534,11 +535,11 @@ void IterDomainGraph::build(Fusion* fusion) {
         // permissive-resize mappings.
         for (auto& dset : permissive_resize_disjoint_sets.disjointSets()) {
           auto& vec = dset->vector();
-          for (auto i : c10::irange(vec.size())) {
+          for (auto i : std::views::iota((size_t)0, vec.size())) {
             auto id1 = vec[i];
             permissive_resize_nodes_.mapEntries(id1, vec[0]);
             mapMaybeSwizzleOp(permissive_resize_nodes_, id1);
-            for (auto j : c10::irange(i + 1, vec.size())) {
+            for (auto j : std::views::iota(i + 1, vec.size())) {
               auto id2 = vec[j];
               if (p_ids.count(id1) && c_ids.count(id2)) {
                 consumers_.at(id1).pushBack(id2);
@@ -643,7 +644,8 @@ void IterDomainGraph::build(Fusion* fusion) {
   for (auto prop_forward : {true, false}) {
     std::unordered_set<Expr*> visited_exprs;
 
-    for (auto rfactor_id_i : c10::irange(rfactor_id_order.size())) {
+    for (auto rfactor_id_i :
+         std::views::iota((size_t)0, rfactor_id_order.size())) {
       auto first_rfactor_id = prop_forward
           ? rfactor_id_order[rfactor_id_i]
           : rfactor_id_order[rfactor_id_order.size() - 1 - rfactor_id_i];
@@ -1222,7 +1224,7 @@ bool ComputeAtMap::areExactExprs(Expr* expr_1, Expr* expr_2) {
           expr_1->outputs().size() == expr_2->outputs().size(),
       "Expr traversal doesn't support variable number of inputs and outputs.");
 
-  for (auto input_i : c10::irange(expr_1->inputs().size())) {
+  for (auto input_i : std::views::iota((size_t)0, expr_1->inputs().size())) {
     if (expr_1->inputs()[input_i]->isA<IterDomain>() &&
         !areMapped(
             expr_1->inputs()[input_i]->as<IterDomain>(),
@@ -1233,7 +1235,7 @@ bool ComputeAtMap::areExactExprs(Expr* expr_1, Expr* expr_2) {
     }
   }
 
-  for (auto output_i : c10::irange(expr_1->outputs().size())) {
+  for (auto output_i : std::views::iota((size_t)0, expr_1->outputs().size())) {
     if (expr_1->outputs()[output_i]->isA<IterDomain>() &&
         !areMapped(
             expr_1->outputs()[output_i]->as<IterDomain>(),

--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -393,8 +393,7 @@ void IterDomainGraph::build(Fusion* fusion) {
             "Only supported case is welford op where all outputs tvs have identical domains.");
         // p->f, c->c
         std::unordered_map<IterDomain*, IterDomain*> c2f_root_map;
-        for (const auto i : std::views::iota(
-                 (size_t)0, first_output_tv->getRootDomain().size())) {
+        for (const auto i : irange(first_output_tv->getRootDomain().size())) {
           c2f_root_map.insert(std::make_pair(
               c_tv->getRootDomain()[i], first_output_tv->getRootDomain()[i]));
         }

--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -13,7 +13,7 @@
 #include <root_domain_map.h>
 #include <transform_iter.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <tuple>
 #include <typeinfo>
 
@@ -218,7 +218,7 @@ void IterDomainGraph::mapThroughExpr(Expr* first, Expr* second, bool forward) {
       first->toString(),
       "\nand\n",
       second->toString());
-  for (auto out_i : std::views::iota((size_t)0, first_ids.size())) {
+  for (auto out_i : irange(first_ids.size())) {
     exact_nodes_.mapEntries(first_ids[out_i], second_ids[out_i]);
     permissive_nodes_.mapEntries(first_ids[out_i], second_ids[out_i]);
     permissive_resize_nodes_.mapEntries(first_ids[out_i], second_ids[out_i]);
@@ -501,7 +501,7 @@ void IterDomainGraph::build(Fusion* fusion) {
 
         for (auto& dset : permissive_disjoint_sets.disjointSets()) {
           auto& vec = dset->vector();
-          for (auto i : std::views::iota((size_t)0, vec.size())) {
+          for (auto i : irange(vec.size())) {
             auto id1 = vec[i];
             permissive_nodes_.mapEntries(id1, vec[0]);
 
@@ -535,7 +535,7 @@ void IterDomainGraph::build(Fusion* fusion) {
         // permissive-resize mappings.
         for (auto& dset : permissive_resize_disjoint_sets.disjointSets()) {
           auto& vec = dset->vector();
-          for (auto i : std::views::iota((size_t)0, vec.size())) {
+          for (auto i : irange(vec.size())) {
             auto id1 = vec[i];
             permissive_resize_nodes_.mapEntries(id1, vec[0]);
             mapMaybeSwizzleOp(permissive_resize_nodes_, id1);
@@ -644,8 +644,7 @@ void IterDomainGraph::build(Fusion* fusion) {
   for (auto prop_forward : {true, false}) {
     std::unordered_set<Expr*> visited_exprs;
 
-    for (auto rfactor_id_i :
-         std::views::iota((size_t)0, rfactor_id_order.size())) {
+    for (auto rfactor_id_i : irange(rfactor_id_order.size())) {
       auto first_rfactor_id = prop_forward
           ? rfactor_id_order[rfactor_id_i]
           : rfactor_id_order[rfactor_id_order.size() - 1 - rfactor_id_i];
@@ -1224,7 +1223,7 @@ bool ComputeAtMap::areExactExprs(Expr* expr_1, Expr* expr_2) {
           expr_1->outputs().size() == expr_2->outputs().size(),
       "Expr traversal doesn't support variable number of inputs and outputs.");
 
-  for (auto input_i : std::views::iota((size_t)0, expr_1->inputs().size())) {
+  for (auto input_i : irange(expr_1->inputs().size())) {
     if (expr_1->inputs()[input_i]->isA<IterDomain>() &&
         !areMapped(
             expr_1->inputs()[input_i]->as<IterDomain>(),
@@ -1235,7 +1234,7 @@ bool ComputeAtMap::areExactExprs(Expr* expr_1, Expr* expr_2) {
     }
   }
 
-  for (auto output_i : std::views::iota((size_t)0, expr_1->outputs().size())) {
+  for (auto output_i : irange(expr_1->outputs().size())) {
     if (expr_1->outputs()[output_i]->isA<IterDomain>() &&
         !areMapped(
             expr_1->outputs()[output_i]->as<IterDomain>(),

--- a/csrc/contiguity.cpp
+++ b/csrc/contiguity.cpp
@@ -11,6 +11,8 @@
 
 #include <contiguity.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 OrderedIdInformation::OrderedIdInformation(
@@ -23,7 +25,7 @@ OrderedIdInformation::OrderedIdInformation(
   }
 
   // Grab allocation ids and initialize them.
-  for (const auto alloc_i : c10::irange(alloc_domain.size())) {
+  for (const auto alloc_i : std::views::iota((size_t)0, alloc_domain.size())) {
     auto alloc_id = alloc_domain[alloc_i]->as<IterDomain>();
 
     // Initialize id_to_alloc_ids to map allocs to themselves
@@ -513,7 +515,8 @@ void ContigIDs::build(const std::vector<IterDomain*>& ids) {
       " != ",
       alloc_contiguity_.size());
 
-  for (const auto alloc_domain_i : c10::irange(alloc_domain_.size())) {
+  for (const auto alloc_domain_i :
+       std::views::iota((size_t)0, alloc_domain_.size())) {
     auto alloc_domain_id = alloc_domain_.at(alloc_domain_i);
     if (alloc_domain_id->isBroadcast()) {
       NVF_ERROR(!alloc_contiguity_.at(alloc_domain_i).has_value());
@@ -608,7 +611,7 @@ void ContigIDs::handle(Merge* merge) {
   bool is_indexing_pass = !ignore_consistent_ordering_;
 
   IterDomain* last_alloc = nullptr;
-  for (auto alloc_id_i : c10::irange(alloc_domain_.size())) {
+  for (auto alloc_id_i : std::views::iota((size_t)0, alloc_domain_.size())) {
     auto alloc_id = alloc_domain_[alloc_id_i];
     if (alloc_id->isBroadcast()) {
       NVF_ERROR(!alloc_contiguity_.at(alloc_id_i).has_value());

--- a/csrc/contiguity.cpp
+++ b/csrc/contiguity.cpp
@@ -11,7 +11,7 @@
 
 #include <contiguity.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -25,7 +25,7 @@ OrderedIdInformation::OrderedIdInformation(
   }
 
   // Grab allocation ids and initialize them.
-  for (const auto alloc_i : std::views::iota((size_t)0, alloc_domain.size())) {
+  for (const auto alloc_i : irange(alloc_domain.size())) {
     auto alloc_id = alloc_domain[alloc_i]->as<IterDomain>();
 
     // Initialize id_to_alloc_ids to map allocs to themselves
@@ -515,8 +515,7 @@ void ContigIDs::build(const std::vector<IterDomain*>& ids) {
       " != ",
       alloc_contiguity_.size());
 
-  for (const auto alloc_domain_i :
-       std::views::iota((size_t)0, alloc_domain_.size())) {
+  for (const auto alloc_domain_i : irange(alloc_domain_.size())) {
     auto alloc_domain_id = alloc_domain_.at(alloc_domain_i);
     if (alloc_domain_id->isBroadcast()) {
       NVF_ERROR(!alloc_contiguity_.at(alloc_domain_i).has_value());
@@ -611,7 +610,7 @@ void ContigIDs::handle(Merge* merge) {
   bool is_indexing_pass = !ignore_consistent_ordering_;
 
   IterDomain* last_alloc = nullptr;
-  for (auto alloc_id_i : std::views::iota((size_t)0, alloc_domain_.size())) {
+  for (auto alloc_id_i : irange(alloc_domain_.size())) {
     auto alloc_id = alloc_domain_[alloc_id_i];
     if (alloc_id->isBroadcast()) {
       NVF_ERROR(!alloc_contiguity_.at(alloc_id_i).has_value());

--- a/csrc/device_lower/analysis/bank_conflict.cpp
+++ b/csrc/device_lower/analysis/bank_conflict.cpp
@@ -14,6 +14,7 @@
 #include <polymorphic_value.h>
 #include <type.h>
 
+#include <C++20/ranges>
 #include <unordered_set>
 
 namespace nvfuser {
@@ -116,7 +117,7 @@ std::vector<int64_t> evaluateAddressesOnFirstPhase(
   int64_t phase_size =
       std::min(num_threads, getPhaseSize((int64_t)word_size_bytes));
 
-  for (int64_t linear_tidx : c10::irange(phase_size)) {
+  for (int64_t linear_tidx : std::views::iota((int64_t)0, phase_size)) {
     int64_t tidx = linear_tidx;
     int64_t tidy = 0;
     int64_t tidz = 0;

--- a/csrc/device_lower/analysis/bank_conflict.cpp
+++ b/csrc/device_lower/analysis/bank_conflict.cpp
@@ -14,7 +14,7 @@
 #include <polymorphic_value.h>
 #include <type.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <unordered_set>
 
 namespace nvfuser {
@@ -117,7 +117,7 @@ std::vector<int64_t> evaluateAddressesOnFirstPhase(
   int64_t phase_size =
       std::min(num_threads, getPhaseSize((int64_t)word_size_bytes));
 
-  for (int64_t linear_tidx : std::views::iota((int64_t)0, phase_size)) {
+  for (int64_t linear_tidx : irange(phase_size)) {
     int64_t tidx = linear_tidx;
     int64_t tidy = 0;
     int64_t tidz = 0;

--- a/csrc/device_lower/analysis/fused_reduction.cpp
+++ b/csrc/device_lower/analysis/fused_reduction.cpp
@@ -12,6 +12,7 @@
 
 #include <device_lower/analysis/fused_reduction.h>
 
+#include <C++20/ranges>
 #include <algorithm>
 
 namespace nvfuser {
@@ -256,7 +257,7 @@ class FusionTransformer {
     NVF_ERROR(
         info.reductions().size() == 1, "Horizontal fusion not supported yet");
 
-    for (const auto i : c10::irange(info.reductions().size())) {
+    for (const auto i : std::views::iota((size_t)0, info.reductions().size())) {
       const auto expr = info.reductions().at(i);
       const auto with_broadcast = info.withBroadcast().at(i);
       Expr* fused_expr = nullptr;

--- a/csrc/device_lower/analysis/fused_reduction.cpp
+++ b/csrc/device_lower/analysis/fused_reduction.cpp
@@ -12,7 +12,7 @@
 
 #include <device_lower/analysis/fused_reduction.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 
 namespace nvfuser {
@@ -257,7 +257,7 @@ class FusionTransformer {
     NVF_ERROR(
         info.reductions().size() == 1, "Horizontal fusion not supported yet");
 
-    for (const auto i : std::views::iota((size_t)0, info.reductions().size())) {
+    for (const auto i : irange(info.reductions().size())) {
       const auto expr = info.reductions().at(i);
       const auto with_broadcast = info.withBroadcast().at(i);
       Expr* fused_expr = nullptr;

--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -15,7 +15,7 @@
 #include <ir/utils.h>
 #include <transform_iter.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -121,7 +121,7 @@ IndexingParameters getLinearIndexParameters(
   auto& loop_domain = loop_indexing.loopDomains();
   auto& loop_index_map = index_parameters.initial_concrete_id_index;
 
-  for (auto loop_idx : std::views::iota((size_t)0, loops.size())) {
+  for (auto loop_idx : irange(loops.size())) {
     auto loop = loops[loop_idx];
     auto index_domain = GpuLower::current()->caMap()->getConcreteMappedID(
         loop_domain[loop_idx], IdMappingMode::EXACT);
@@ -150,7 +150,7 @@ IndexingParameters getLinearIndexParameters(
         GpuLower::current()->doubleBufferInfo().getDoubleBufferLoop(
             loop_indexing.consumerTv(), loops, true);
 
-    for (auto loop_idx : std::views::iota((size_t)0, loops.size())) {
+    for (auto loop_idx : irange(loops.size())) {
       auto loop = loops[loop_idx];
       if (loop == double_buffer_loop) {
         auto loop_id = loop_indexing.loopDomains()[loop_idx];
@@ -224,7 +224,7 @@ IndexingParameters getNonGlobalInitialIndexParameters(
       loops.size() <= loop_domains.size(),
       "Loop domain didn't replay all loops");
 
-  for (auto loop_idx : std::views::iota((size_t)0, loops.size())) {
+  for (auto loop_idx : irange(loops.size())) {
     auto loop = loops[loop_idx];
     auto loop_domain = loop_domains[loop_idx];
 
@@ -384,7 +384,7 @@ IndexingParameters getPredicateInitialIndexParameters(
 
   bool within_unswitch = false;
 
-  for (const auto loop_i : std::views::iota((size_t)0, loops.size())) {
+  for (const auto loop_i : irange(loops.size())) {
     auto loop = loops[loop_i];
     auto loop_id = loop->iter_domain();
     auto loop_pt = loop_id->getParallelType();
@@ -501,7 +501,7 @@ IndexingParameters getPredicateInitialIndexParameters(
   }
 
   // Convert loop-to-ind map to concrete-to-ind map
-  for (auto loop_idx : std::views::iota((size_t)0, loops.size())) {
+  for (auto loop_idx : irange(loops.size())) {
     auto loop = loops.at(loop_idx);
     auto concrete_loop_domain =
         GpuLower::current()->caMap()->getConcreteMappedID(

--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -15,6 +15,8 @@
 #include <ir/utils.h>
 #include <transform_iter.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 IndexFromIdGraph::IndexFromIdGraph(
@@ -119,7 +121,7 @@ IndexingParameters getLinearIndexParameters(
   auto& loop_domain = loop_indexing.loopDomains();
   auto& loop_index_map = index_parameters.initial_concrete_id_index;
 
-  for (auto loop_idx : c10::irange(loops.size())) {
+  for (auto loop_idx : std::views::iota((size_t)0, loops.size())) {
     auto loop = loops[loop_idx];
     auto index_domain = GpuLower::current()->caMap()->getConcreteMappedID(
         loop_domain[loop_idx], IdMappingMode::EXACT);
@@ -148,7 +150,7 @@ IndexingParameters getLinearIndexParameters(
         GpuLower::current()->doubleBufferInfo().getDoubleBufferLoop(
             loop_indexing.consumerTv(), loops, true);
 
-    for (auto loop_idx : c10::irange(loops.size())) {
+    for (auto loop_idx : std::views::iota((size_t)0, loops.size())) {
       auto loop = loops[loop_idx];
       if (loop == double_buffer_loop) {
         auto loop_id = loop_indexing.loopDomains()[loop_idx];
@@ -222,7 +224,7 @@ IndexingParameters getNonGlobalInitialIndexParameters(
       loops.size() <= loop_domains.size(),
       "Loop domain didn't replay all loops");
 
-  for (auto loop_idx : c10::irange(loops.size())) {
+  for (auto loop_idx : std::views::iota((size_t)0, loops.size())) {
     auto loop = loops[loop_idx];
     auto loop_domain = loop_domains[loop_idx];
 
@@ -382,7 +384,7 @@ IndexingParameters getPredicateInitialIndexParameters(
 
   bool within_unswitch = false;
 
-  for (const auto loop_i : c10::irange(loops.size())) {
+  for (const auto loop_i : std::views::iota((size_t)0, loops.size())) {
     auto loop = loops[loop_i];
     auto loop_id = loop->iter_domain();
     auto loop_pt = loop_id->getParallelType();
@@ -499,7 +501,7 @@ IndexingParameters getPredicateInitialIndexParameters(
   }
 
   // Convert loop-to-ind map to concrete-to-ind map
-  for (auto loop_idx : c10::irange(loops.size())) {
+  for (auto loop_idx : std::views::iota((size_t)0, loops.size())) {
     auto loop = loops.at(loop_idx);
     auto concrete_loop_domain =
         GpuLower::current()->caMap()->getConcreteMappedID(

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -673,8 +673,7 @@ class PredicateChcker : public IterVisitor {
   }
 
   void handle(GroupedReductionOp* grouped_rop) final {
-    for (const auto i : std::views::iota(
-             (size_t)0, grouped_rop->numHorizontallyGroupedExprs())) {
+    for (const auto i : irange(grouped_rop->numHorizontallyGroupedExprs())) {
       auto input = grouped_rop->input(i)->as<TensorView>();
       auto input_def = input->definition();
       // When input_def is null, input must be an input to the fusion,
@@ -736,8 +735,8 @@ class PredicateChcker : public IterVisitor {
   }
 
   void handle(GroupedWelfordOp* grouped_wop) final {
-    for (const auto expr_idx : std::views::iota(
-             (size_t)0, grouped_wop->numHorizontallyGroupedExprs())) {
+    for (const auto expr_idx :
+         irange(grouped_wop->numHorizontallyGroupedExprs())) {
       for (const auto val_idx : irange(3)) {
         auto init = grouped_wop->initVals().at(expr_idx).get(val_idx);
 

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -19,7 +19,7 @@
 #include <transform_iter.h>
 #include <transform_replay.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -292,7 +292,7 @@ class PredicateChcker : public IterVisitor {
         "Was expecting matching number of inputs and outputs for expression: ",
         expr->toString());
 
-    for (auto i : std::views::iota((size_t)0, tv_inputs.size())) {
+    for (auto i : irange(tv_inputs.size())) {
       const auto root_p2c = PairwiseRootDomainMap(tv_inputs[i], tv_outputs[i])
                                 .mapProducerToConsumer();
       for (auto entry : root_p2c) {
@@ -463,7 +463,7 @@ class PredicateChcker : public IterVisitor {
         tv->toString());
     bool is_shared_mem = tv->getMemoryType() == MemoryType::Shared;
     std::vector<Val*> zero_leaf_ids;
-    for (const auto i : std::views::iota((size_t)0, tv->nDims())) {
+    for (const auto i : irange(tv->nDims())) {
       auto leaf_id = tv->axis((int)i);
       if (is_shared_mem && leaf_id->isThreadDim()) {
         // Thread parallel axes on shared mem are never
@@ -622,7 +622,7 @@ class PredicateChcker : public IterVisitor {
 
   // Welford. See FusionPredicateElimination5.
   void handle(WelfordOp* wop) final {
-    for (const auto i : std::views::iota(0, 3)) {
+    for (const auto i : irange(3)) {
       auto init = wop->getInitVals()[i];
 
       // Welford input can be a scalar. Predicate is required unless
@@ -738,7 +738,7 @@ class PredicateChcker : public IterVisitor {
   void handle(GroupedWelfordOp* grouped_wop) final {
     for (const auto expr_idx : std::views::iota(
              (size_t)0, grouped_wop->numHorizontallyGroupedExprs())) {
-      for (const auto val_idx : std::views::iota(0, 3)) {
+      for (const auto val_idx : irange(3)) {
         auto init = grouped_wop->initVals().at(expr_idx).get(val_idx);
 
         // Welford input can be a scalar. Predicate is required unless
@@ -876,7 +876,7 @@ void PredicateElimination::dispatch(Expr* expr) {
 
   // Ensure all inputs have some values set at the out-of-bound
   // regions
-  for (const auto i : std::views::iota((size_t)0, expr->inputs().size())) {
+  for (const auto i : irange(expr->inputs().size())) {
     auto input = dynamic_cast<TensorView*>(expr->inputs()[i]);
     if (input == nullptr) {
       continue;

--- a/csrc/device_lower/analysis/shift.cpp
+++ b/csrc/device_lower/analysis/shift.cpp
@@ -19,6 +19,7 @@
 #include <ops/arith.h>
 #include <options.h>
 
+#include <C++20/ranges>
 #include <functional>
 
 namespace nvfuser {
@@ -120,7 +121,7 @@ void AxisHaloInfo::merge(int pos, int other) {
 }
 
 void AxisHaloInfo::merge(const AxisHaloInfo& other) {
-  for (const auto i : c10::irange(widths_.size())) {
+  for (const auto i : std::views::iota((size_t)0, widths_.size())) {
     merge((int)i, other.width((int)i));
   }
 }
@@ -244,7 +245,7 @@ void HaloInfo::propagateRootAxisInfo(
 
   const auto& c_root = consumer->getRootDomain();
 
-  for (const auto i : c10::irange(c_root.size())) {
+  for (const auto i : std::views::iota((size_t)0, c_root.size())) {
     auto c_id = c_root[i];
     auto it = c2p.find(c_id);
     if (it == c2p.end()) {
@@ -740,7 +741,7 @@ bool HaloInfo::needsShiftPredicate(Expr* expr) const {
   auto consumer_td = tv_out->domain();
   auto shift_expr = dynamic_cast<ShiftOp*>(tv_out->definition());
   auto gather_expr = dynamic_cast<GatherOp*>(tv_out->definition());
-  for (const auto i : c10::irange(consumer_td->root().size())) {
+  for (const auto i : std::views::iota((size_t)0, consumer_td->root().size())) {
     auto consumer_id = consumer_td->root()[i];
     const auto consumer_halo_info = getRootAxisInfo(consumer_id);
     if (consumer_halo_info.hasHalo() ||

--- a/csrc/device_lower/analysis/shift.cpp
+++ b/csrc/device_lower/analysis/shift.cpp
@@ -19,7 +19,7 @@
 #include <ops/arith.h>
 #include <options.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <functional>
 
 namespace nvfuser {
@@ -121,7 +121,7 @@ void AxisHaloInfo::merge(int pos, int other) {
 }
 
 void AxisHaloInfo::merge(const AxisHaloInfo& other) {
-  for (const auto i : std::views::iota((size_t)0, widths_.size())) {
+  for (const auto i : irange(widths_.size())) {
     merge((int)i, other.width((int)i));
   }
 }
@@ -245,7 +245,7 @@ void HaloInfo::propagateRootAxisInfo(
 
   const auto& c_root = consumer->getRootDomain();
 
-  for (const auto i : std::views::iota((size_t)0, c_root.size())) {
+  for (const auto i : irange(c_root.size())) {
     auto c_id = c_root[i];
     auto it = c2p.find(c_id);
     if (it == c2p.end()) {
@@ -741,7 +741,7 @@ bool HaloInfo::needsShiftPredicate(Expr* expr) const {
   auto consumer_td = tv_out->domain();
   auto shift_expr = dynamic_cast<ShiftOp*>(tv_out->definition());
   auto gather_expr = dynamic_cast<GatherOp*>(tv_out->definition());
-  for (const auto i : std::views::iota((size_t)0, consumer_td->root().size())) {
+  for (const auto i : irange(consumer_td->root().size())) {
     auto consumer_id = consumer_td->root()[i];
     const auto consumer_halo_info = getRootAxisInfo(consumer_id);
     if (consumer_halo_info.hasHalo() ||

--- a/csrc/device_lower/analysis/sync_information.cpp
+++ b/csrc/device_lower/analysis/sync_information.cpp
@@ -12,7 +12,7 @@
 
 #include <device_lower/analysis/sync_information.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -22,7 +22,7 @@ namespace {
 void validateParallelizationOfTensor(TensorView* tv) {
   // Each ParallelType can be used only once.
   ParallelTypeBitmap pt_map;
-  for (auto i : std::views::iota((size_t)0, tv->nDims())) {
+  for (auto i : irange(tv->nDims())) {
     auto axis = tv->axis((int)i);
     auto ptype = axis->getParallelType();
     if (!isParallelTypeThread(ptype)) {
@@ -496,8 +496,7 @@ SyncMap::SyncMap(Fusion* fusion) {
       producer_redundant_types =
           producer_redundant_types & (~producer_redundant_use_types);
 
-      for (const auto producer_i :
-           std::views::iota((size_t)0, producer->nDims())) {
+      for (const auto producer_i : irange(producer->nDims())) {
         auto producer_axis = producer->axis((int)producer_i);
         auto producer_ptype =
             ca_map->getConcreteMappedID(producer_axis, IdMappingMode::LOOP)
@@ -523,8 +522,7 @@ SyncMap::SyncMap(Fusion* fusion) {
         std::vector<IterDomain*> consumer_parallel_ids(
             ParallelTypeBitmap::kNumParallelTypes, nullptr);
         ParallelTypeBitmap consumer_parallel_bitmap;
-        for (const auto consumer_i :
-             std::views::iota((size_t)0, consumer->nDims())) {
+        for (const auto consumer_i : irange(consumer->nDims())) {
           auto consumer_axis = consumer->axis((int)consumer_i);
           auto consumer_ptype =
               ca_map->getConcreteMappedID(consumer_axis, IdMappingMode::LOOP)

--- a/csrc/device_lower/analysis/sync_information.cpp
+++ b/csrc/device_lower/analysis/sync_information.cpp
@@ -12,6 +12,8 @@
 
 #include <device_lower/analysis/sync_information.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 namespace {
@@ -20,7 +22,7 @@ namespace {
 void validateParallelizationOfTensor(TensorView* tv) {
   // Each ParallelType can be used only once.
   ParallelTypeBitmap pt_map;
-  for (auto i : c10::irange(tv->nDims())) {
+  for (auto i : std::views::iota((size_t)0, tv->nDims())) {
     auto axis = tv->axis((int)i);
     auto ptype = axis->getParallelType();
     if (!isParallelTypeThread(ptype)) {
@@ -494,7 +496,8 @@ SyncMap::SyncMap(Fusion* fusion) {
       producer_redundant_types =
           producer_redundant_types & (~producer_redundant_use_types);
 
-      for (const auto producer_i : c10::irange(producer->nDims())) {
+      for (const auto producer_i :
+           std::views::iota((size_t)0, producer->nDims())) {
         auto producer_axis = producer->axis((int)producer_i);
         auto producer_ptype =
             ca_map->getConcreteMappedID(producer_axis, IdMappingMode::LOOP)
@@ -520,7 +523,8 @@ SyncMap::SyncMap(Fusion* fusion) {
         std::vector<IterDomain*> consumer_parallel_ids(
             ParallelTypeBitmap::kNumParallelTypes, nullptr);
         ParallelTypeBitmap consumer_parallel_bitmap;
-        for (const auto consumer_i : c10::irange(consumer->nDims())) {
+        for (const auto consumer_i :
+             std::views::iota((size_t)0, consumer->nDims())) {
           auto consumer_axis = consumer->axis((int)consumer_i);
           auto consumer_ptype =
               ca_map->getConcreteMappedID(consumer_axis, IdMappingMode::LOOP)
@@ -694,8 +698,8 @@ SyncMap::SyncMap(Fusion* fusion) {
             std::unordered_set<Val*> shifted_rfactor_ids;
             if (expr->isA<GatherOp>()) {
               auto gather_op = expr->as<GatherOp>();
-              for (auto root_i :
-                   c10::irange(producer->getMaybeRFactorDomain().size())) {
+              for (auto root_i : std::views::iota(
+                       (size_t)0, producer->getMaybeRFactorDomain().size())) {
                 auto rfactor_id = producer->getMaybeRFactorDomain()[root_i];
                 // If the window shape is 1, it just copies the
                 // producer to the consumer
@@ -705,8 +709,8 @@ SyncMap::SyncMap(Fusion* fusion) {
               }
             } else if (expr->isA<ShiftOp>()) {
               auto shift_op = expr->as<ShiftOp>();
-              for (auto root_i :
-                   c10::irange(producer->getMaybeRFactorDomain().size())) {
+              for (auto root_i : std::views::iota(
+                       (size_t)0, producer->getMaybeRFactorDomain().size())) {
                 auto rfactor_id = producer->getMaybeRFactorDomain()[root_i];
                 // If the shift offset is 0, it doesn't actually shift
                 if (shift_op->offsets()[root_i] != 0) {

--- a/csrc/device_lower/analysis/sync_information.cpp
+++ b/csrc/device_lower/analysis/sync_information.cpp
@@ -696,8 +696,8 @@ SyncMap::SyncMap(Fusion* fusion) {
             std::unordered_set<Val*> shifted_rfactor_ids;
             if (expr->isA<GatherOp>()) {
               auto gather_op = expr->as<GatherOp>();
-              for (auto root_i : std::views::iota(
-                       (size_t)0, producer->getMaybeRFactorDomain().size())) {
+              for (auto root_i :
+                   irange(producer->getMaybeRFactorDomain().size())) {
                 auto rfactor_id = producer->getMaybeRFactorDomain()[root_i];
                 // If the window shape is 1, it just copies the
                 // producer to the consumer
@@ -707,8 +707,8 @@ SyncMap::SyncMap(Fusion* fusion) {
               }
             } else if (expr->isA<ShiftOp>()) {
               auto shift_op = expr->as<ShiftOp>();
-              for (auto root_i : std::views::iota(
-                       (size_t)0, producer->getMaybeRFactorDomain().size())) {
+              for (auto root_i :
+                   irange(producer->getMaybeRFactorDomain().size())) {
                 auto rfactor_id = producer->getMaybeRFactorDomain()[root_i];
                 // If the shift offset is 0, it doesn't actually shift
                 if (shift_op->offsets()[root_i] != 0) {

--- a/csrc/device_lower/analysis/thread_predicate.cpp
+++ b/csrc/device_lower/analysis/thread_predicate.cpp
@@ -239,8 +239,9 @@ void ThreadPredicateMap::updateBitSet(const Expr* expr) {
 
   // Run through inputs and update bitsets
   for (const auto* inp : expr->inputs()) {
-    if (!ir_utils::isTV(inp))
+    if (!ir_utils::isTV(inp)) {
       continue;
+    }
 
     auto tv_inp = inp->as<TensorView>();
 

--- a/csrc/device_lower/analysis/thread_predicate.cpp
+++ b/csrc/device_lower/analysis/thread_predicate.cpp
@@ -15,7 +15,7 @@
 #include <ir/utils.h>
 #include <ops/arith.h>
 
-#include <c10/util/irange.h>
+#include <C++20/ranges>
 #include <algorithm>
 #include <numeric>
 namespace nvfuser {
@@ -279,7 +279,8 @@ void ThreadPredicateMap::updateBitSet(const Expr* expr) {
     }
 
     // Validate the combination of ptypes, reductions, bcasts
-    for (const auto i : c10::irange(ParallelTypeBitmap::kNumParallelTypes)) {
+    for (const auto i :
+         std::views::iota(0, ParallelTypeBitmap::kNumParallelTypes)) {
       if (input_reductions[i]) {
         if (id_ptypes[i]) {
           NVF_ERROR(

--- a/csrc/device_lower/analysis/thread_predicate.cpp
+++ b/csrc/device_lower/analysis/thread_predicate.cpp
@@ -15,7 +15,7 @@
 #include <ir/utils.h>
 #include <ops/arith.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <numeric>
 namespace nvfuser {
@@ -280,8 +280,7 @@ void ThreadPredicateMap::updateBitSet(const Expr* expr) {
     }
 
     // Validate the combination of ptypes, reductions, bcasts
-    for (const auto i :
-         std::views::iota(0, ParallelTypeBitmap::kNumParallelTypes)) {
+    for (const auto i : irange(ParallelTypeBitmap::kNumParallelTypes)) {
       if (input_reductions[i]) {
         if (id_ptypes[i]) {
           NVF_ERROR(

--- a/csrc/device_lower/analysis/trivial_broadcast.cpp
+++ b/csrc/device_lower/analysis/trivial_broadcast.cpp
@@ -11,7 +11,7 @@
 
 #include <device_lower/analysis/trivial_broadcast.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -81,8 +81,7 @@ void ConcretizedBroadcastDomains::handle(TensorView* tv) {
 void ConcretizedBroadcastDomains::handle(BroadcastOp* bop) {
   // Create a new entry for each of new broadcast domains
   auto out = bop->out()->as<TensorView>();
-  for (const auto i :
-       std::views::iota((size_t)0, out->getRootDomain().size())) {
+  for (const auto i : irange(out->getRootDomain().size())) {
     if (bop->getBroadcastDimFlags().at(i)) {
       auto new_bcast_id = out->getRootDomain().at(i);
       broadcast_origin_map_.emplace(

--- a/csrc/device_lower/analysis/trivial_broadcast.cpp
+++ b/csrc/device_lower/analysis/trivial_broadcast.cpp
@@ -11,6 +11,8 @@
 
 #include <device_lower/analysis/trivial_broadcast.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 ConcretizedBroadcastDomains::ConcretizedBroadcastDomains(Fusion* fusion) {
@@ -79,7 +81,8 @@ void ConcretizedBroadcastDomains::handle(TensorView* tv) {
 void ConcretizedBroadcastDomains::handle(BroadcastOp* bop) {
   // Create a new entry for each of new broadcast domains
   auto out = bop->out()->as<TensorView>();
-  for (const auto i : c10::irange(out->getRootDomain().size())) {
+  for (const auto i :
+       std::views::iota((size_t)0, out->getRootDomain().size())) {
     if (bop->getBroadcastDimFlags().at(i)) {
       auto new_bcast_id = out->getRootDomain().at(i);
       broadcast_origin_map_.emplace(

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -19,6 +19,7 @@
 #include <ops/arith.h>
 #include <options.h>
 
+#include <C++20/ranges>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -302,7 +303,7 @@ class BufferReuseDebugPrinter {
   void printAllocInfo(const kir::Allocate* alloc);
 
   std::stringstream& indent() {
-    for (const auto i : c10::irange(indent_level_)) {
+    for (const auto i : std::views::iota(0, indent_level_)) {
       (void)i; // Suppress unused variable warning
       os_ << "  ";
     }
@@ -947,7 +948,8 @@ class AllocationInfoMap : private kir::IrVisitor {
       return nullptr;
     }
 
-    for (const auto idx : c10::irange(current_stack_.size() - 1)) {
+    for (const auto idx :
+         std::views::iota((size_t)0, current_stack_.size() - 1)) {
       if (current_stack_[idx] == allocate_loop_info) {
         return current_stack_[idx + 1];
       }
@@ -1343,7 +1345,7 @@ class ReusableAllocationFinder : private kir::IrVisitor {
     }
 
     // Check index map for the corresponding axes.
-    for (const auto id_it : c10::irange(alloc_domains.size())) {
+    for (const auto id_it : std::views::iota((size_t)0, alloc_domains.size())) {
       if (!GpuLower::current()->caMap()->areMapped(
               alloc_domains[id_it],
               reuse_domains[id_it],

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -19,7 +19,7 @@
 #include <ops/arith.h>
 #include <options.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -303,7 +303,7 @@ class BufferReuseDebugPrinter {
   void printAllocInfo(const kir::Allocate* alloc);
 
   std::stringstream& indent() {
-    for (const auto i : std::views::iota(0, indent_level_)) {
+    for (const auto i : irange(indent_level_)) {
       (void)i; // Suppress unused variable warning
       os_ << "  ";
     }
@@ -948,8 +948,7 @@ class AllocationInfoMap : private kir::IrVisitor {
       return nullptr;
     }
 
-    for (const auto idx :
-         std::views::iota((size_t)0, current_stack_.size() - 1)) {
+    for (const auto idx : irange(current_stack_.size() - 1)) {
       if (current_stack_[idx] == allocate_loop_info) {
         return current_stack_[idx + 1];
       }
@@ -1345,7 +1344,7 @@ class ReusableAllocationFinder : private kir::IrVisitor {
     }
 
     // Check index map for the corresponding axes.
-    for (const auto id_it : std::views::iota((size_t)0, alloc_domains.size())) {
+    for (const auto id_it : irange(alloc_domains.size())) {
       if (!GpuLower::current()->caMap()->areMapped(
               alloc_domains[id_it],
               reuse_domains[id_it],

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -14,7 +14,7 @@
 #include <kernel_ir.h>
 #include <kernel_ir_dispatch.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <unordered_set>
 
 namespace nvfuser {
@@ -72,7 +72,7 @@ class AllocationInserter : public kir::ExprMutator {
     info.alloc_pos = loop_alloc_info.alloc_pos;
 
     auto next_fl = [](kir::ForLoop* fl, const std::vector<kir::ForLoop*> fls) {
-      for (auto i : std::views::iota((size_t)0, fls.size())) {
+      for (auto i : irange(fls.size())) {
         if (fl == fls[i]) {
           if (i + 1 < fls.size()) {
             return fls[i + 1];
@@ -333,8 +333,7 @@ class AllocationInserter : public kir::ExprMutator {
 
     info.allocation_domains = std::make_unique<std::vector<IterDomain*>>();
 
-    for (const auto axis_i :
-         std::views::iota((size_t)0, info.buffer->nDims())) {
+    for (const auto axis_i : irange(info.buffer->nDims())) {
       const auto local_id = info.buffer->axis((int)axis_i);
 
       // Don't use reduction/stride/broadcast axis in the allocation
@@ -451,7 +450,7 @@ class AllocationInserter : public kir::ExprMutator {
 
     // // Found where the allocation needs to be inserted
 
-    for (const auto i : std::views::iota((size_t)0, expr->outputs().size())) {
+    for (const auto i : irange(expr->outputs().size())) {
       auto out = expr->output(i);
       if (!out->isA<TensorView>()) {
         continue;

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -14,6 +14,7 @@
 #include <kernel_ir.h>
 #include <kernel_ir_dispatch.h>
 
+#include <C++20/ranges>
 #include <unordered_set>
 
 namespace nvfuser {
@@ -71,7 +72,7 @@ class AllocationInserter : public kir::ExprMutator {
     info.alloc_pos = loop_alloc_info.alloc_pos;
 
     auto next_fl = [](kir::ForLoop* fl, const std::vector<kir::ForLoop*> fls) {
-      for (auto i : c10::irange(fls.size())) {
+      for (auto i : std::views::iota((size_t)0, fls.size())) {
         if (fl == fls[i]) {
           if (i + 1 < fls.size()) {
             return fls[i + 1];
@@ -120,7 +121,7 @@ class AllocationInserter : public kir::ExprMutator {
 
     std::vector<IterDomain*> init_dims;
     for (const auto axis_i :
-         c10::irange(info.alloc_pos, info.buffer->nDims())) {
+         std::views::iota(info.alloc_pos, info.buffer->nDims())) {
       if (info.buffer->axis((int)axis_i)->isReduction() ||
           info.buffer->axis((int)axis_i)->isBroadcast()) {
         continue;
@@ -332,7 +333,8 @@ class AllocationInserter : public kir::ExprMutator {
 
     info.allocation_domains = std::make_unique<std::vector<IterDomain*>>();
 
-    for (const auto axis_i : c10::irange(info.buffer->nDims())) {
+    for (const auto axis_i :
+         std::views::iota((size_t)0, info.buffer->nDims())) {
       const auto local_id = info.buffer->axis((int)axis_i);
 
       // Don't use reduction/stride/broadcast axis in the allocation
@@ -449,7 +451,7 @@ class AllocationInserter : public kir::ExprMutator {
 
     // // Found where the allocation needs to be inserted
 
-    for (const auto i : c10::irange(expr->outputs().size())) {
+    for (const auto i : std::views::iota((size_t)0, expr->outputs().size())) {
       auto out = expr->output(i);
       if (!out->isA<TensorView>()) {
         continue;

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -670,8 +670,7 @@ ExprGroup* ExprSegmentationSorter::makeEmptyGroup(
       // Each non-terminating TV expr should at least have the kernel
       // scope to enforce the global dependency
       group->payload()->ca_domains.push_back(kernelScopeDomain());
-      for (const auto tv_i : std::views::iota(
-               0u,
+      for (const auto tv_i : irange(
                out_tv->hasResolvedComputeWith()
                    ? out_tv->getComputeWithPosition()
                    : out_tv->getComputeAtPosition())) {
@@ -937,10 +936,9 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
       auto consumer_of_consumer_edge =
           dynamic_cast<TensorView*>(consumer_group_edge->consumer_val);
       NVF_ERROR(consumer_of_consumer_edge != nullptr);
-      for (const auto tv_i : std::views::iota(
-               0u,
-               producer_of_consumer_edge->getComputePosition(
-                   consumer_of_consumer_edge))) {
+      for (const auto tv_i :
+           irange(producer_of_consumer_edge->getComputePosition(
+               consumer_of_consumer_edge))) {
         ca_ids.emplace(
             getConcreteID(producer_of_consumer_edge->axis((int)tv_i)));
       }

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -18,7 +18,7 @@
 #include <options.h>
 #include <utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <deque>
 #include <list>
 #include <sstream>
@@ -495,7 +495,7 @@ std::vector<ExprGroup*> ExprGroup::getMergeCandidates(
 
   // Find neighbors with a level that is only 1 different than this group's
   // level
-  for (const auto i : std::views::iota((size_t)0, neighbors.size())) {
+  for (const auto i : irange(neighbors.size())) {
     if (std::abs(neighbors[i]->payload()->level - payload()->level) > 1) {
       can_merge.at(i) = false;
       if (isDebugDumpEnabled(DebugDumpOption::ExprSortVerbose)) {
@@ -508,7 +508,7 @@ std::vector<ExprGroup*> ExprGroup::getMergeCandidates(
   // Check neighbor of neighbors we're considering, if any of them are merged
   // with another node, make sure the resulting edge wouldn't have a level
   // difference of 1
-  for (const auto i : std::views::iota((size_t)0, neighbors.size())) {
+  for (const auto i : irange(neighbors.size())) {
     if (!can_merge.at(i)) {
       continue;
     }
@@ -572,7 +572,7 @@ std::vector<ExprGroup*> ExprGroup::getMergeCandidates(
   }
 
   std::vector<ExprGroup*> merge_candidates;
-  for (const auto i : std::views::iota((size_t)0, neighbors.size())) {
+  for (const auto i : irange(neighbors.size())) {
     if ((can_merge.at(i) && !fallback_mode_enabled) ||
         (!can_merge.at(i) && fallback_mode_enabled)) {
       auto neighbor = neighbors.at(i);

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -18,6 +18,7 @@
 #include <options.h>
 #include <utils.h>
 
+#include <C++20/ranges>
 #include <deque>
 #include <list>
 #include <sstream>
@@ -492,7 +493,7 @@ std::vector<ExprGroup*> ExprGroup::getMergeCandidates(
 
   // Find neighbors with a level that is only 1 different than this group's
   // level
-  for (const auto i : c10::irange(neighbors.size())) {
+  for (const auto i : std::views::iota((size_t)0, neighbors.size())) {
     if (std::abs(neighbors[i]->payload()->level - payload()->level) > 1) {
       can_merge.at(i) = false;
       if (isDebugDumpEnabled(DebugDumpOption::ExprSortVerbose)) {
@@ -505,7 +506,7 @@ std::vector<ExprGroup*> ExprGroup::getMergeCandidates(
   // Check neighbor of neighbors we're considering, if any of them are merged
   // with another node, make sure the resulting edge wouldn't have a level
   // difference of 1
-  for (const auto i : c10::irange(neighbors.size())) {
+  for (const auto i : std::views::iota((size_t)0, neighbors.size())) {
     if (!can_merge.at(i)) {
       continue;
     }
@@ -569,7 +570,7 @@ std::vector<ExprGroup*> ExprGroup::getMergeCandidates(
   }
 
   std::vector<ExprGroup*> merge_candidates;
-  for (const auto i : c10::irange(neighbors.size())) {
+  for (const auto i : std::views::iota((size_t)0, neighbors.size())) {
     if ((can_merge.at(i) && !fallback_mode_enabled) ||
         (!can_merge.at(i) && fallback_mode_enabled)) {
       auto neighbor = neighbors.at(i);
@@ -667,7 +668,8 @@ ExprGroup* ExprSegmentationSorter::makeEmptyGroup(
       // Each non-terminating TV expr should at least have the kernel
       // scope to enforce the global dependency
       group->payload()->ca_domains.push_back(kernelScopeDomain());
-      for (const auto tv_i : c10::irange(
+      for (const auto tv_i : std::views::iota(
+               0u,
                out_tv->hasResolvedComputeWith()
                    ? out_tv->getComputeWithPosition()
                    : out_tv->getComputeAtPosition())) {
@@ -682,7 +684,8 @@ ExprGroup* ExprSegmentationSorter::makeEmptyGroup(
         })) {
       group->payload()->pa_domains.push_back(kernelScopeDomain());
     }
-    for (const auto tv_i : c10::irange(out_tv->getMaxProducerPosition())) {
+    for (const auto tv_i :
+         std::views::iota(0u, out_tv->getMaxProducerPosition())) {
       auto concrete_id = getConcreteID(out_tv->axis((int)tv_i));
       group->payload()->pa_domains.push_back(concrete_id);
     }
@@ -933,9 +936,10 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
       auto consumer_of_consumer_edge =
           dynamic_cast<TensorView*>(consumer_group_edge->consumer_val);
       NVF_ERROR(consumer_of_consumer_edge != nullptr);
-      for (const auto tv_i :
-           c10::irange(producer_of_consumer_edge->getComputePosition(
-               consumer_of_consumer_edge))) {
+      for (const auto tv_i : std::views::iota(
+               0u,
+               producer_of_consumer_edge->getComputePosition(
+                   consumer_of_consumer_edge))) {
         ca_ids.emplace(
             getConcreteID(producer_of_consumer_edge->axis((int)tv_i)));
       }
@@ -956,7 +960,8 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
         pa_ids.emplace(kernelScopeDomain());
       }
       auto tv = consumer_of_producer_edge->as<TensorView>();
-      for (const auto tv_i : c10::irange(tv->getMaxProducerPosition())) {
+      for (const auto tv_i :
+           std::views::iota(0u, tv->getMaxProducerPosition())) {
         pa_ids.emplace(getConcreteID(tv->axis((int)tv_i)));
       }
     }
@@ -1035,7 +1040,8 @@ bool ExprSegmentationSorter::canReducePA(ExprGroup* group) const {
     // If this consumer_tv doesn't map to the last producer domain of this group
     // it can't decide if it can be reduced
     bool has_matching_pa = false;
-    for (const auto i : c10::irange(consumer_tv->getMaxProducerPosition())) {
+    for (const auto i :
+         std::views::iota(0u, consumer_tv->getMaxProducerPosition())) {
       if (areMapped(consumer_tv->axis((int)i), group_pa_last_id)) {
         has_matching_pa = true;
         break;

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -407,14 +407,16 @@ std::string ExprGroup::toString() const {
   os << " ca_ids {";
   for (size_t i = 0; i < payload()->ca_domains.size(); i++) {
     os << payload()->ca_domains[i];
-    if (i + 1 != payload()->ca_domains.size())
+    if (i + 1 != payload()->ca_domains.size()) {
       os << ", ";
+    }
   }
   os << "} pa_ids {";
   for (size_t i = 0; i < payload()->pa_domains.size(); i++) {
     os << payload()->pa_domains[i];
-    if (i + 1 != payload()->pa_domains.size())
+    if (i + 1 != payload()->pa_domains.size()) {
       os << ", ";
+    }
   }
   os << "}";
   os << "\nExprs {\n";

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -686,8 +686,7 @@ ExprGroup* ExprSegmentationSorter::makeEmptyGroup(
         })) {
       group->payload()->pa_domains.push_back(kernelScopeDomain());
     }
-    for (const auto tv_i :
-         std::views::iota(0u, out_tv->getMaxProducerPosition())) {
+    for (const auto tv_i : irange(out_tv->getMaxProducerPosition())) {
       auto concrete_id = getConcreteID(out_tv->axis((int)tv_i));
       group->payload()->pa_domains.push_back(concrete_id);
     }
@@ -962,8 +961,7 @@ ExprGroup* ExprSegmentationSorter::makeMergedNode(
         pa_ids.emplace(kernelScopeDomain());
       }
       auto tv = consumer_of_producer_edge->as<TensorView>();
-      for (const auto tv_i :
-           std::views::iota(0u, tv->getMaxProducerPosition())) {
+      for (const auto tv_i : irange(tv->getMaxProducerPosition())) {
         pa_ids.emplace(getConcreteID(tv->axis((int)tv_i)));
       }
     }
@@ -1042,8 +1040,7 @@ bool ExprSegmentationSorter::canReducePA(ExprGroup* group) const {
     // If this consumer_tv doesn't map to the last producer domain of this group
     // it can't decide if it can be reduced
     bool has_matching_pa = false;
-    for (const auto i :
-         std::views::iota(0u, consumer_tv->getMaxProducerPosition())) {
+    for (const auto i : irange(consumer_tv->getMaxProducerPosition())) {
       if (areMapped(consumer_tv->axis((int)i), group_pa_last_id)) {
         has_matching_pa = true;
         break;

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -706,8 +706,7 @@ void IndexLowering::handle(const GroupedReductionOp* grouped_rop) {
   std::vector<Val*> indexed_outputs(grouped_rop->numHorizontallyGroupedExprs());
   std::vector<Val*> indexed_inputs(grouped_rop->numHorizontallyGroupedExprs());
 
-  for (const auto i : std::views::iota(
-           (size_t)0, grouped_rop->numHorizontallyGroupedExprs())) {
+  for (const auto i : irange(grouped_rop->numHorizontallyGroupedExprs())) {
     indexed_outputs.at(i) = lowerDstIndex(grouped_rop->output(i));
     indexed_inputs.at(i) =
         lowerSrcIndex(grouped_rop->input(i), grouped_rop->output(i));
@@ -718,8 +717,7 @@ void IndexLowering::handle(const GroupedReductionOp* grouped_rop) {
   } else if (has_block_reduce) {
     handleBlockReduction(grouped_rop, indexed_outputs, indexed_inputs);
   } else {
-    for (const auto i : std::views::iota(
-             (size_t)0, grouped_rop->numHorizontallyGroupedExprs())) {
+    for (const auto i : irange(grouped_rop->numHorizontallyGroupedExprs())) {
       pushBack(IrBuilder::create<BinaryOp>(
           grouped_rop->getReductionOpType(i),
           indexed_outputs.at(i),
@@ -1031,8 +1029,7 @@ void IndexLowering::handle(const GroupedWelfordOp* grouped_wop) {
   auto output_vals = grouped_wop->outputVals();
   auto input_vals = grouped_wop->inputVals();
 
-  for (const auto i : std::views::iota(
-           (size_t)0, grouped_wop->numHorizontallyGroupedExprs())) {
+  for (const auto i : irange(grouped_wop->numHorizontallyGroupedExprs())) {
     const auto& output = output_vals.at(i);
     const auto& input = input_vals.at(i);
     WelfordTriplet indexed_output;

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -16,7 +16,7 @@
 
 #include <device_lower/pass/index.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -252,7 +252,7 @@ void IndexLowering::handle(const ArrayConstruct* aop) {
 
 void IndexLowering::handle(const StructConstruct* sop) {
   std::vector<std::pair<std::string, Val*>> lowered_named_inputs;
-  for (auto i : std::views::iota((size_t)0, sop->inputs().size())) {
+  for (auto i : irange(sop->inputs().size())) {
     lowered_named_inputs.emplace_back(
         sop->fieldName(i), lowerSrcIndex(sop->inputs().at(i), sop->out()));
   }
@@ -1037,7 +1037,7 @@ void IndexLowering::handle(const GroupedWelfordOp* grouped_wop) {
     const auto& input = input_vals.at(i);
     WelfordTriplet indexed_output;
     WelfordTriplet indexed_input;
-    for (const auto j : std::views::iota(0, 3)) {
+    for (const auto j : irange(3)) {
       indexed_output.get(j) = lowerDstIndex(output.get(j));
       indexed_input.get(j) = lowerSrcIndex(input.get(j), output.get(j));
     }
@@ -1532,7 +1532,7 @@ void IndexLowering::handle(const CatOp* cat) {
   std::vector<Val*> preds(cat->inputs().size());
   Val* cur_extent = GpuLower::current()->kernel()->zeroVal();
 
-  for (const auto i : std::views::iota((size_t)0, cat->inputs().size())) {
+  for (const auto i : irange(cat->inputs().size())) {
     const auto inp = lowerSrcIndex(cat->input(i), cat->output(0));
     inputs.at(i) = inp;
 

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -14,7 +14,7 @@
 #include <kernel_ir.h>
 #include <kernel_ir_dispatch.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <unordered_set>
 
 namespace nvfuser {

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -14,6 +14,7 @@
 #include <kernel_ir.h>
 #include <kernel_ir_dispatch.h>
 
+#include <C++20/ranges>
 #include <unordered_set>
 
 namespace nvfuser {
@@ -187,7 +188,7 @@ class WarSyncInserter : private kir::ExprMutator {
     auto fl_i = std::distance(for_loops_.begin(), fl_it) + 1;
 
     // Start at that index and see if there's syncs within that for loop
-    for (auto i : c10::irange(fl_i, sync_hit_.size())) {
+    for (auto i : std::views::iota((size_t)fl_i, sync_hit_.size())) {
       if (sync_hit_[i]) {
         return true;
       }

--- a/csrc/device_lower/pass/magic_zero.cpp
+++ b/csrc/device_lower/pass/magic_zero.cpp
@@ -14,6 +14,8 @@
 #include <ir/utils.h>
 #include <kernel_ir_dispatch.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 namespace {
@@ -130,7 +132,7 @@ void protectNonPredicateIndexWithMagicZero(
 
   // Search for proper magic zero insertion point,
   //  prefer innermost.
-  for (auto idx : c10::irange(loops.size())) {
+  for (auto idx : std::views::iota((size_t)0, loops.size())) {
     auto loop = loops[idx];
     auto concrete_loop_id = GpuLower::current()->caMap()->getConcreteMappedID(
         loop_domains[idx], IdMappingMode::EXACT);

--- a/csrc/device_lower/pass/magic_zero.cpp
+++ b/csrc/device_lower/pass/magic_zero.cpp
@@ -14,7 +14,7 @@
 #include <ir/utils.h>
 #include <kernel_ir_dispatch.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -132,7 +132,7 @@ void protectNonPredicateIndexWithMagicZero(
 
   // Search for proper magic zero insertion point,
   //  prefer innermost.
-  for (auto idx : std::views::iota((size_t)0, loops.size())) {
+  for (auto idx : irange(loops.size())) {
     auto loop = loops[idx];
     auto concrete_loop_id = GpuLower::current()->caMap()->getConcreteMappedID(
         loop_domains[idx], IdMappingMode::EXACT);

--- a/csrc/device_lower/pass/scalar_hoist.cpp
+++ b/csrc/device_lower/pass/scalar_hoist.cpp
@@ -14,6 +14,8 @@
 
 #include <device_lower/pass/scalar_hoist.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 namespace {
@@ -29,7 +31,7 @@ bool shouldHoistToHost(Val* value) {
 // Get the position of the innermost non-trivial loop
 int64_t getInnermostNonTrivialLoop(const std::vector<kir::ForLoop*>& loops) {
   int64_t position = -1;
-  for (auto i : c10::irange(loops.size())) {
+  for (auto i : std::views::iota((size_t)0, loops.size())) {
     if (!loops.at(i)->isTrivial()) {
       position = (int64_t)i;
     }
@@ -63,7 +65,7 @@ int64_t findOutermostPosWithSatisfiedDependency(
   // variable or something like named scalar or constant
   if (def == nullptr) {
     // Check if `value` is a loop variable
-    for (auto i : c10::irange(loops.size())) {
+    for (auto i : std::views::iota((size_t)0, loops.size())) {
       auto loop = loops.at(i);
       // We skip trivial loop here because it is never materialized, so its loop
       // variable is accessible everywhere. For example, if the trivial loop is
@@ -439,7 +441,7 @@ std::pair<int64_t, bool> findAllocPointFromDataDependency(
                                      // the hoisted value should be inserted
     Val* value) {
   int64_t pos = -1;
-  for (auto i : c10::irange(exprs.size())) {
+  for (auto i : std::views::iota((size_t)0, exprs.size())) {
     auto expr = exprs[i];
     NVF_ERROR(expr != nullptr);
     if (auto alloc = dynamic_cast<kir::Allocate*>(expr)) {

--- a/csrc/device_lower/pass/scalar_hoist.cpp
+++ b/csrc/device_lower/pass/scalar_hoist.cpp
@@ -14,7 +14,7 @@
 
 #include <device_lower/pass/scalar_hoist.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -31,7 +31,7 @@ bool shouldHoistToHost(Val* value) {
 // Get the position of the innermost non-trivial loop
 int64_t getInnermostNonTrivialLoop(const std::vector<kir::ForLoop*>& loops) {
   int64_t position = -1;
-  for (auto i : std::views::iota((size_t)0, loops.size())) {
+  for (auto i : irange(loops.size())) {
     if (!loops.at(i)->isTrivial()) {
       position = (int64_t)i;
     }
@@ -65,7 +65,7 @@ int64_t findOutermostPosWithSatisfiedDependency(
   // variable or something like named scalar or constant
   if (def == nullptr) {
     // Check if `value` is a loop variable
-    for (auto i : std::views::iota((size_t)0, loops.size())) {
+    for (auto i : irange(loops.size())) {
       auto loop = loops.at(i);
       // We skip trivial loop here because it is never materialized, so its loop
       // variable is accessible everywhere. For example, if the trivial loop is
@@ -441,7 +441,7 @@ std::pair<int64_t, bool> findAllocPointFromDataDependency(
                                      // the hoisted value should be inserted
     Val* value) {
   int64_t pos = -1;
-  for (auto i : std::views::iota((size_t)0, exprs.size())) {
+  for (auto i : irange(exprs.size())) {
     auto expr = exprs[i];
     NVF_ERROR(expr != nullptr);
     if (auto alloc = dynamic_cast<kir::Allocate*>(expr)) {

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -287,9 +287,11 @@ TensorView* getTvInput(const Expr* expr) {
 }
 
 bool isScalarOp(const Expr* expr) {
-  for (auto out : expr->outputs())
-    if (!out->isScalar())
+  for (auto out : expr->outputs()) {
+    if (!out->isScalar()) {
       return false;
+    }
+  }
   return true;
 }
 

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -8,7 +8,6 @@
 #include <device_lower/utils.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/util/irange.h>
 #include <device_lower/analysis/thread_predicate.h>
 #include <device_lower/lower2device.h>
 #include <ir/iostream.h>

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -242,8 +242,7 @@ void checkContiguity(
 
   std::unordered_map<IterDomain*, std::optional<bool>>
       producer_domain_contiguity;
-  for (const auto idx : std::views::iota(
-           (size_t)0, producer->getMaybeAllocationDomain().size())) {
+  for (const auto idx : irange(producer->getMaybeAllocationDomain().size())) {
     auto alloc = producer->getMaybeAllocationDomain().at(idx);
     auto contiguity = producer->domain()->contiguity().at(idx);
     producer_domain_contiguity.insert({alloc, contiguity});

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -20,7 +20,7 @@
 
 #include <ATen/cuda/CUDAContext.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <limits>
 
 namespace nvfuser {
@@ -70,11 +70,11 @@ class ValidateSiblings : public IterVisitor {
           ". Sibling: ",
           sibling->toString());
 
-      for (const auto i : std::views::iota((size_t)0, ref_ndims)) {
+      for (const auto i : irange(ref_ndims)) {
         validateParallelTypes(ref_output->axis((int)i), sibling->axis((int)i));
       }
 
-      for (const auto i : std::views::iota((size_t)0, ref_root.size())) {
+      for (const auto i : irange(ref_root.size())) {
         id_map[ref_root[i]] = sibling->getRootDomain().at(i);
       }
 
@@ -83,7 +83,7 @@ class ValidateSiblings : public IterVisitor {
               sibling->getLeafDomain(), ref_output->getLeafDomain(), id_map)
               .getIterDomainEquivalence();
 
-      for (const auto i : std::views::iota((size_t)0, ref_ndims)) {
+      for (const auto i : irange(ref_ndims)) {
         NVF_ERROR(
             replay.strictAreMapped(ref_output->axis(i), sibling->axis(i)),
             "Matching sibling ID not found. Expr: ",
@@ -203,8 +203,7 @@ void checkContiguity(
     TensorView* tv) {
   NVF_ERROR(tv->getMemoryType() == MemoryType::Global);
 
-  for (const auto idx :
-       std::views::iota((size_t)0, tv->getMaybeAllocationDomain().size())) {
+  for (const auto idx : irange(tv->getMaybeAllocationDomain().size())) {
     auto alloc = tv->getMaybeAllocationDomain()[idx];
     if (domains.find(alloc) != domains.end()) {
       NVF_ERROR(
@@ -547,7 +546,7 @@ void validateAndCollectVectorizeInfo(Fusion* fusion) {
     bool has_vectorize_dim = false;
     bool has_misaligned_vectorize_dim = false;
 
-    for (const auto i : std::views::iota((size_t)0, tv->nDims())) {
+    for (const auto i : irange(tv->nDims())) {
       IterDomain* id = tv->axis((int)i);
       IterDomain* concrete_id =
           GpuLower::current()->caMap()->getConcreteMappedID(
@@ -1170,7 +1169,7 @@ void validateSwizzle(Fusion* fusion) {
 void validateAndConvertIterDomainGrouping(Fusion* fusion) {
   for (auto tv : ir_utils::allTvs(fusion)) {
     bool is_grouped = false;
-    for (const auto id_idx : std::views::iota((size_t)0, tv->nDims())) {
+    for (const auto id_idx : irange(tv->nDims())) {
       const auto id = tv->axis((int)id_idx);
       auto ptype = GpuLower::current()
                        ->caMap()

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -17,6 +17,7 @@
 #include <transform_view.h>
 #include <utils.h>
 
+#include <C++20/ranges>
 #include <optional>
 
 namespace nvfuser {
@@ -154,7 +155,8 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
     // Vals. These will be the inputs that are explicitly used in the cache ID
     // for KernelArgumentHolder.
     auto dyn_vals = info_.getRootDynamicVals();
-    for (const auto i : c10::irange(info_.fusion()->inputs().size())) {
+    for (const auto i :
+         std::views::iota((size_t)0, info_.fusion()->inputs().size())) {
       auto input = info_.fusion()->inputs().at(i);
       if (dyn_vals.find(input) != dyn_vals.end()) {
         info_.scalar_inputs_affecting_concretization_.insert(i);
@@ -201,7 +203,7 @@ DynamicTransformConcretizationInfo::DynamicTransformConcretizationInfo(
   analyzeResizes(expr_eval);
 
   auto maybe_zero_extents = initial_info_->getMaybeZeroExtents();
-  for (auto i : c10::irange(maybe_zero_extents.size())) {
+  for (auto i : std::views::iota((size_t)0, maybe_zero_extents.size())) {
     auto ext = maybe_zero_extents.at(i);
     auto ext_opt = expr_eval->evaluate(ext);
     NVF_ERROR(
@@ -217,7 +219,7 @@ DynamicTransformConcretizationInfo::DynamicTransformConcretizationInfo(
 void DynamicTransformConcretizationInfo::analyzeReshapes(
     ExpressionEvaluator* expr_eval) {
   const auto& reshape_tvs = initial_info_->getDynamicReshapedTensorViews();
-  for (const auto tv_index : c10::irange(reshape_tvs.size())) {
+  for (const auto tv_index : std::views::iota((size_t)0, reshape_tvs.size())) {
     auto out_tv = reshape_tvs.at(tv_index);
     auto op = out_tv->definition()->as<ViewOp>();
     auto inp_tv = op->in()->as<TensorView>();
@@ -237,7 +239,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
 
     // Determine input shape using expr evaluator
     std::vector<int64_t> inp_shape(inp_dom.size(), 0);
-    for (const auto i : c10::irange(inp_dom.size())) {
+    for (const auto i : std::views::iota((size_t)0, inp_dom.size())) {
       auto inp_id = inp_dom.at(i);
       // This should have been validated when initially creating reshape
       // op, but just in case
@@ -266,7 +268,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
     // Determine output shape using expr evaluator. Note there may be
     // one domain of extent -1
     std::vector<int64_t> out_shape(out_dom.size(), 0);
-    for (const auto i : c10::irange(out_dom.size())) {
+    for (const auto i : std::views::iota((size_t)0, out_dom.size())) {
       auto out_id = out_dom.at(i);
       auto extent_val = expr_eval->evaluate(out_id->extent());
       NVF_ERROR(
@@ -296,7 +298,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
 void DynamicTransformConcretizationInfo::analyzeResizes(
     ExpressionEvaluator* expr_eval) {
   const auto& resize_ids = initial_info_->getDynamicResizedIterDomains();
-  for (const auto id_index : c10::irange(resize_ids.size())) {
+  for (const auto id_index : std::views::iota((size_t)0, resize_ids.size())) {
     auto out_id = resize_ids.at(id_index);
     auto op = out_id->definition()->as<Resize>();
 
@@ -341,7 +343,7 @@ bool DynamicTransformConcretizationInfo::operator==(
     return false;
   }
 
-  for (const auto i : c10::irange(reshape_transforms_.size())) {
+  for (const auto i : std::views::iota((size_t)0, reshape_transforms_.size())) {
     const auto& analysis = reshape_transforms_.at(i);
     const auto& other_analysis = other.reshape_transforms_.at(i);
     if (analysis != other_analysis) {
@@ -349,7 +351,7 @@ bool DynamicTransformConcretizationInfo::operator==(
     }
   }
 
-  for (const auto i : c10::irange(resize_itertypes_.size())) {
+  for (const auto i : std::views::iota((size_t)0, resize_itertypes_.size())) {
     const auto& itertype = resize_itertypes_.at(i);
     const auto& other_itertype = other.resize_itertypes_.at(i);
     if (itertype != other_itertype) {
@@ -357,7 +359,7 @@ bool DynamicTransformConcretizationInfo::operator==(
     }
   }
 
-  for (const auto i : c10::irange(empty_extents_.size())) {
+  for (const auto i : std::views::iota((size_t)0, empty_extents_.size())) {
     const auto& ee = empty_extents_.at(i);
     const auto& other_ee = other.empty_extents_.at(i);
     if (ee != other_ee) {
@@ -533,7 +535,7 @@ void DynamicTransformConcretizer::concretizeReshape() {
     NVF_ERROR(
         old_rfactor.size() == new_rfactor.size(),
         "Concretized reshape rfactor size does not match symbolic rfactor");
-    for (auto idx : c10::irange(new_rfactor.size())) {
+    for (auto idx : std::views::iota((size_t)0, new_rfactor.size())) {
       auto old_extent = old_rfactor.at(idx)->extent();
       auto new_extent = new_rfactor.at(idx)->extent();
       // If the old extent did not have a definition, we don't need to replace
@@ -657,7 +659,7 @@ void DynamicTransformConcretizer::mutate(TensorView* tv) {
       IterType iter_type = IterType::Symbolic;
       const auto input_ids =
           ir_utils::filterByType<IterDomain>(expr->inputs()).vector();
-      for (auto i : c10::irange(input_ids.size())) {
+      for (auto i : std::views::iota((size_t)0, input_ids.size())) {
         auto inp_id = input_ids.at(i);
         auto updated_id = maybeMutated(inp_id)->as<IterDomain>();
         NVF_CHECK(
@@ -760,7 +762,7 @@ void DynamicTransformConcretizer::mutate(TensorDomain* td) {
   // Update the contiguity vector. Drop the contig val if mutated to broadcast
   auto contig = td->contiguity();
 
-  for (const auto i : c10::irange(td->maybeRFactor().size())) {
+  for (const auto i : std::views::iota((size_t)0, td->maybeRFactor().size())) {
     auto original_id = td->maybeRFactor().at(i);
     if (original_id->getIterType() != IterType::Symbolic) {
       continue;
@@ -813,7 +815,7 @@ bool DynamicTransformConcretizer::propagateFromProducerToConsumer(
 
   bool is_concretized = false;
 
-  for (const auto i : c10::irange(root_domain.size())) {
+  for (const auto i : std::views::iota((size_t)0, root_domain.size())) {
     auto root_id = root_domain.at(i);
     if (root_id->getIterType() != IterType::Symbolic) {
       continue;

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -14,7 +14,7 @@
 #include <instrumentation.h>
 #include <ir/utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <optional>
 
 namespace nvfuser {
@@ -163,7 +163,7 @@ void PrecomputedValues::bindInputs(const KernelArgumentHolder& args) {
   NVF_ERROR(
       args.size() == inputs.size(), "kernel inputs size does not match args");
 
-  for (const auto i : std::views::iota((int64_t)0, (int64_t)inputs.size())) {
+  for (const auto i : irange((int64_t)inputs.size())) {
     const auto input = inputs[i];
     NVF_ERROR(input != nullptr);
     if (auto tensor_input = dynamic_cast<TensorView*>(input)) {
@@ -186,7 +186,7 @@ void PrecomputedValues::initializeValueList(
   values_ = std::vector<PolymorphicValue>(num_of_values_, PolymorphicValue());
 
   // Fill in constants and assign evaluator indices
-  for (const auto i : std::views::iota(0, num_of_values_)) {
+  for (const auto i : irange(num_of_values_)) {
     // Use an expression evaluator to test if value is const
     if (sorted_value_list[i]->isConstScalar()) {
       is_constant_[i] = true;
@@ -218,7 +218,7 @@ const PolymorphicValue& PrecomputedValues::getMaybeValueFor(
 
 void PrecomputedValues::print() const {
   debug() << "Precomputed Values:\n";
-  for (auto i : std::views::iota((size_t)0, symbols_.size())) {
+  for (auto i : irange(symbols_.size())) {
     if (defined_[i]) {
       debug() << symbols_[i]->toInlineString() << " = " << values_[i]
               << std::endl;
@@ -264,7 +264,7 @@ PrecomputedValues PrecomputedValues::clone(IrCloner& ir_cloner) const {
       pv.binding_log_.end(), binding_log_.begin(), binding_log_.end());
 
   pv.symbols_.resize(symbols_.size());
-  for (const auto i : std::views::iota((size_t)0, symbols_.size())) {
+  for (const auto i : irange(symbols_.size())) {
     pv.symbols_[i] = ir_cloner.clone(symbols_[i]);
   }
 
@@ -331,7 +331,7 @@ void PrecomputedValues::bindTensorMetaData(
       tensor.dim() == static_cast<int64_t>(root_domain.size()),
       "Something went wrong configuring launch. Inputs do not match.");
 
-  for (const auto dim : std::views::iota((size_t)0, root_domain.size())) {
+  for (const auto dim : irange(root_domain.size())) {
     auto value = tensor.size((int64_t)dim);
     if (root_domain[dim]->hasExpandedExtent()) {
       auto extent = root_domain[dim]->extent();
@@ -394,7 +394,7 @@ void NaiveValueMachine::copyFrom(const NaiveValueMachine& other) {
 }
 
 void NaiveValueMachine::run() {
-  for (const auto i : std::views::iota(0, num_of_instructions_)) {
+  for (const auto i : irange(num_of_instructions_)) {
     // Skip this instruction if the dest location
     //  has already been computed or is constant.
     if (precomputed_values_.defined_[dest_[i]] ||

--- a/csrc/exceptions.cpp
+++ b/csrc/exceptions.cpp
@@ -1,12 +1,13 @@
 // This is a refactor of the NVF_ERROR and NVF_CHECK macros
 // from PyTorch for implementing NVFuser specific macros.
 
-#include <c10/util/irange.h>
 #include <cxxabi.h>
 #include <exceptions.h>
 #include <execinfo.h>
 
+#include <C++20/ranges>
 #include <cstdlib>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -189,7 +190,8 @@ std::string _get_backtrace(
   // Toggles to true after the first skipped python frame.
   bool has_skipped_python_frames = false;
 
-  for (const auto frame_number : c10::irange(callstack.size())) {
+  for (const auto frame_number :
+       std::views::iota((size_t)0, callstack.size())) {
     const auto frame = parse_frame_information(symbols[frame_number]);
 
     if (skip_python_frames && frame && is_python_frame(*frame)) {

--- a/csrc/exceptions.cpp
+++ b/csrc/exceptions.cpp
@@ -5,7 +5,7 @@
 #include <exceptions.h>
 #include <execinfo.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <cstdlib>
 #include <functional>
 #include <iostream>
@@ -190,8 +190,7 @@ std::string _get_backtrace(
   // Toggles to true after the first skipped python frame.
   bool has_skipped_python_frames = false;
 
-  for (const auto frame_number :
-       std::views::iota((size_t)0, callstack.size())) {
+  for (const auto frame_number : irange(callstack.size())) {
     const auto frame = parse_frame_information(symbols[frame_number]);
 
     if (skip_python_frames && frame && is_python_frame(*frame)) {

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -32,7 +32,7 @@
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/cuda/CUDAStream.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <cmath>
 #include <fstream>
 
@@ -524,7 +524,7 @@ std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShape(
 
   std::vector<int64_t> concrete_sizes(symbolic_sizes.size(), 0);
 
-  for (const auto i : std::views::iota((size_t)0, symbolic_sizes.size())) {
+  for (const auto i : irange(symbolic_sizes.size())) {
     auto symbolic_size = symbolic_sizes.at(i);
     const auto inferred_val = expr_eval.evaluate(symbolic_size);
     NVF_ERROR(
@@ -631,7 +631,7 @@ class ForwardTraverseFromAllocToRFactor {
     // view tensor
     int64_t dim = std::distance(frontier_.begin(), in_it);
     std::vector<int64_t> new_shape;
-    for (auto i : std::views::iota((int64_t)0, tensor_.dim())) {
+    for (auto i : irange(tensor_.dim())) {
       if (i == dim) {
         new_shape.emplace_back(-1);
         new_shape.emplace_back(factor);
@@ -685,7 +685,7 @@ class ForwardTraverseFromAllocToRFactor {
       tensor_ = tensor_.permute(dims);
     }
     std::vector<int64_t> new_shape;
-    for (auto i : std::views::iota((int64_t)0, tensor_.dim())) {
+    for (auto i : irange(tensor_.dim())) {
       if (i == left) {
         new_shape.emplace_back(-1);
       } else if (i != left + 1) {
@@ -782,7 +782,7 @@ class BackwardTraverseFromAllocToRFactor {
       tensor_ = tensor_.permute(dims);
     }
     std::vector<int64_t> new_shape;
-    for (auto i : std::views::iota((int64_t)0, tensor_.dim())) {
+    for (auto i : irange(tensor_.dim())) {
       if (i == left) {
         new_shape.emplace_back(-1);
       } else if (i != left + 1) {
@@ -816,7 +816,7 @@ class BackwardTraverseFromAllocToRFactor {
     // view tensor
     int64_t dim = std::distance(frontier_.begin(), out_it);
     std::vector<int64_t> new_shape;
-    for (auto i : std::views::iota((int64_t)0, tensor_.dim())) {
+    for (auto i : irange(tensor_.dim())) {
       if (i == dim) {
         new_shape.emplace_back(-1);
         new_shape.emplace_back(factor);
@@ -921,8 +921,7 @@ std::vector<at::Tensor> allocOutputs(
 
   std::vector<at::Tensor> outputs;
 
-  for (const auto output_idx :
-       std::views::iota((size_t)0, output_info.size())) {
+  for (const auto output_idx : irange(output_info.size())) {
     const auto& buf_info = output_info.at(output_idx);
 
     auto alias_it = std::find_if(
@@ -1233,8 +1232,7 @@ std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::
   NVF_ERROR(
       args.size() == kernel->inputs().size(),
       "kernel arguments length does not match runtime arguments.");
-  for (const auto out_i :
-       std::views::iota((size_t)0, kernel->outputs().size())) {
+  for (const auto out_i : irange(kernel->outputs().size())) {
     GlobalBufferInfo info;
     auto out_val = kernel->outputs()[out_i];
     info.tv = dynamic_cast<TensorView*>(out_val);
@@ -1296,8 +1294,7 @@ KernelArgumentHolder FusionExecutor::inferOutputSizes(
   KernelArgumentHolder ret;
   ret.setDeviceIndex(args.getDeviceIndex());
 
-  for (const auto out_i :
-       std::views::iota((size_t)0, fusion->outputs().size())) {
+  for (const auto out_i : irange(fusion->outputs().size())) {
     // If the output is just trivially the input, just "copy" it over.
     // See note [trivial forwarding]
     if (fusion->outputs()[out_i]->isFusionInput()) {
@@ -1407,7 +1404,7 @@ void dumpFusionArgs(
     const std::vector<at::Tensor>& outputs) {
   debug() << "Arguments for fusion" << fusion_id << ":" << std::endl
           << "Inputs:" << std::endl;
-  for (auto i : std::views::iota((size_t)0, args.size())) {
+  for (auto i : irange(args.size())) {
     debug() << "  " << args[i] << std::endl;
   }
   debug() << "Outputs:" << std::endl;
@@ -1434,7 +1431,7 @@ void dumpKernelArgs(
   using namespace PolymorphicValue_functions;
   debug() << "Arguments for kernel" << fusion_id << ":" << std::endl
           << "Inputs:" << std::endl;
-  for (auto i : std::views::iota((size_t)0, num_inputs)) {
+  for (auto i : irange(num_inputs)) {
     debug() << "  " << toString(*args[i]) << std::endl;
   }
   debug() << "Outputs:" << std::endl;
@@ -1445,7 +1442,7 @@ void dumpKernelArgs(
             << ", address = " << output.data_ptr() << ")" << std::endl;
   }
   debug() << "Intermediate global buffers:" << std::endl;
-  for (const auto i : std::views::iota((size_t)0, intermediates.size())) {
+  for (const auto i : irange(intermediates.size())) {
     const auto& buffer = intermediates.at(i);
     const auto& zero_init = intermediates_info.at(i).zero_init;
     debug() << "  " << buffer.scalar_type() << " " << buffer.sizes()
@@ -1669,7 +1666,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   ExpressionEvaluator expr_eval;
   const auto& inputs = kernel()->inputs();
 
-  for (const auto i : std::views::iota((size_t)0, inputs.size())) {
+  for (const auto i : irange(inputs.size())) {
     expr_eval.bind(inputs[i], *args[i]);
   }
 
@@ -1691,7 +1688,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   }
   args.push(outputs);
 
-  for (const auto i : std::views::iota((size_t)0, outputs.size())) {
+  for (const auto i : irange(outputs.size())) {
     auto output = kernel()->outputs()[i];
     if (std::any_of(
             kernel()->inputs().begin(),
@@ -1707,8 +1704,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   at::Tensor profile_buffer;
   {
     FUSER_PERF_SCOPE("ExecutorRunFusion::IntermediateBufferAlloc");
-    for (const auto i :
-         std::views::iota((size_t)0, executor_entry->intermediates.size())) {
+    for (const auto i : irange(executor_entry->intermediates.size())) {
       const auto& buf_info = executor_entry->intermediates.at(i);
       at::Tensor intermediate_buffer;
       if (buf_info.zero_init) {
@@ -1845,7 +1841,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
 
       bytes_processed_per_input_.resize(num_inputs, 0);
       // Figure how many bytes are inputs, outputs, and temporary buffers
-      for (auto i : std::views::iota((size_t)0, num_inputs)) {
+      for (auto i : irange(num_inputs)) {
         if (args[i]->is<at::Tensor>()) {
           auto t = args[i]->as<at::Tensor>();
           auto num_bytes = t.numel() *
@@ -1854,7 +1850,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
         }
       }
       bytes_processed_per_output_.resize(outputs.size(), 0);
-      for (auto i : std::views::iota((size_t)0, outputs.size())) {
+      for (auto i : irange(outputs.size())) {
         const auto& output = outputs.at(i);
         // NOTE: this assumes that all output elements correspond to a single
         // store

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -2145,8 +2145,7 @@ void FusionExecutor::deserialize(
   setUsedTVs();
 
   // GlobalBufferInfo requires lowered kernel before deserialization
-  for (auto idx :
-       std::views::iota(0u, buffer->executor_entry_lookup_keys()->size())) {
+  for (auto idx : irange(buffer->executor_entry_lookup_keys()->size())) {
     executor_entry_lookup_.emplace(
         buffer->executor_entry_lookup_keys()->Get(idx),
         deserialize(buffer->executor_entry_lookup_values()->Get(idx)));
@@ -2170,7 +2169,7 @@ FusionExecutor::ExecutorEntry FusionExecutor::deserialize(
 
   entry.launch_params.deserialize(buffer->launch_params());
 
-  for (auto idx : std::views::iota(0u, buffer->output_aliases()->size())) {
+  for (auto idx : irange(buffer->output_aliases()->size())) {
     entry.output_to_input_aliases.emplace_back(
         buffer->output_aliases()->Get(idx), buffer->input_aliases()->Get(idx));
   }

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -2149,8 +2149,8 @@ void FusionExecutor::deserialize(
   setUsedTVs();
 
   // GlobalBufferInfo requires lowered kernel before deserialization
-  for (auto idx : std::views::iota(
-           0u, buffer->executor_entry_lookup_keys()->size())) {
+  for (auto idx :
+       std::views::iota(0u, buffer->executor_entry_lookup_keys()->size())) {
     executor_entry_lookup_.emplace(
         buffer->executor_entry_lookup_keys()->Get(idx),
         deserialize(buffer->executor_entry_lookup_values()->Get(idx)));
@@ -2174,8 +2174,7 @@ FusionExecutor::ExecutorEntry FusionExecutor::deserialize(
 
   entry.launch_params.deserialize(buffer->launch_params());
 
-  for (auto idx :
-       std::views::iota(0u, buffer->output_aliases()->size())) {
+  for (auto idx : std::views::iota(0u, buffer->output_aliases()->size())) {
     entry.output_to_input_aliases.emplace_back(
         buffer->output_aliases()->Get(idx), buffer->input_aliases()->Get(idx));
   }

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -59,7 +59,7 @@ PolymorphicValue IValueToPolymorphicValue(const c10::IValue& val) {
 
 PrimDataType getSmallestIndexType(const at::Tensor& tensor) {
   KernelIndexTypeCompute index_type_helper;
-  for (const auto dim_i : std::views::iota((int64_t)0, tensor.ndimension())) {
+  for (const auto dim_i : irange(tensor.ndimension())) {
     auto size = tensor.size(dim_i);
     auto stride = tensor.stride(dim_i);
     if (index_type_helper.addDim(size, stride) == PrimDataType::Int) {

--- a/csrc/executor_kernel_arg.cpp
+++ b/csrc/executor_kernel_arg.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <c10/util/irange.h>
 
 // Extract size and strides
 #include <kernel_cache.h>
@@ -60,7 +59,7 @@ PolymorphicValue IValueToPolymorphicValue(const c10::IValue& val) {
 
 PrimDataType getSmallestIndexType(const at::Tensor& tensor) {
   KernelIndexTypeCompute index_type_helper;
-  for (const auto dim_i : c10::irange(tensor.ndimension())) {
+  for (const auto dim_i : std::views::iota((int64_t)0, tensor.ndimension())) {
     auto size = tensor.size(dim_i);
     auto stride = tensor.stride(dim_i);
     if (index_type_helper.addDim(size, stride) == PrimDataType::Int) {

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -53,7 +53,7 @@
 #include <nvfuser_resources/warp.h>
 #include <nvfuser_resources/welford.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <cstdlib>
 #include <fstream>
 #include <variant>
@@ -165,7 +165,7 @@ bool checkSameStride(const std::vector<c10::IValue>& tensors) {
   if (tensors.size() < 2) {
     return true;
   }
-  for (const auto idx : std::views::iota((size_t)0, tensors.size() - 1)) {
+  for (const auto idx : irange(tensors.size() - 1)) {
     auto current = tensors[idx];
     auto next = tensors[idx + 1];
     if (!current.isTensor() || !next.isTensor()) {
@@ -178,8 +178,7 @@ bool checkSameStride(const std::vector<c10::IValue>& tensors) {
       return false;
     }
 
-    for (const auto i :
-         std::views::iota((int64_t)0, current_tensor.ndimension())) {
+    for (const auto i : irange(current_tensor.ndimension())) {
       if (current_tensor.stride(i) != next_tensor.stride(i)) {
         return false;
       }
@@ -440,7 +439,7 @@ getTensorOffsets(
     const auto slice_info = slice->getRanges();
 
     size_t offset = 0;
-    for (const auto i : std::views::iota((size_t)0, root_ids.size())) {
+    for (const auto i : irange(root_ids.size())) {
       auto slice_start_eval = eval.evaluate(slice_info.at(i).start);
       NVF_ERROR(slice_start_eval.hasValue());
       auto slice_stop_eval = eval.evaluate(slice_info.at(i).stop);
@@ -484,8 +483,7 @@ void validateAlignedVectorizedFusionInputOutput(
       is_sliced ? tv->getMaybeRFactorDomain() : tv->getMaybeAllocationDomain();
 
   std::vector<int64_t> no_reduction_to_full;
-  for (int64_t i :
-       std::views::iota((int64_t)0, (int64_t)domain_to_validate.size())) {
+  for (int64_t i : irange((int64_t)domain_to_validate.size())) {
     auto alloc_id = domain_to_validate.at(i);
     if (!alloc_id->isReduction()) {
       no_reduction_to_full.emplace_back(i);
@@ -723,7 +721,7 @@ ExpressionEvaluator bindInputs(
 
   ExpressionEvaluator expr_eval;
   const auto& inputs = kernel->inputs();
-  for (const auto i : std::views::iota((size_t)0, inputs.size())) {
+  for (const auto i : irange(inputs.size())) {
     expr_eval.bind(inputs[i], *args[i], true);
   }
 
@@ -855,7 +853,7 @@ class NvrtcCompileDriver {
   // Get options that can be passed to nvrtcCompileProgram
   std::vector<const char*> getOptions() const {
     std::vector<const char*> opts(options_.size());
-    for (const auto i : std::views::iota((size_t)0, options_.size())) {
+    for (const auto i : irange(options_.size())) {
       opts.at(i) = options_.at(i).c_str();
     }
     return opts;
@@ -930,7 +928,7 @@ class CuModuleLoadDataDriver {
     // matrixMulDynlinkJIT sample
     // https://github.com/NVIDIA/cuda-samples/blob/master/Samples/0_Introduction/matrixMulDynlinkJIT/matrixMulDynlinkJIT.cpp#L169-L204.
     std::vector<void*> opt_val_voidp(opt_vals.size());
-    for (const auto i : std::views::iota((size_t)0, opt_vals.size())) {
+    for (const auto i : irange(opt_vals.size())) {
       auto opt_val = opt_vals.at(i);
       if (std::holds_alternative<int>(opt_val)) {
         // NOLINTNEXTLINE(performance-no-int-to-ptr)

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -9,8 +9,6 @@
 #include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <ATen/native/cuda/jit_utils.h>
 
-#include <c10/util/irange.h>
-
 #include <contiguity.h>
 #include <debug.h>
 #include <driver_api.h>
@@ -55,6 +53,7 @@
 #include <nvfuser_resources/warp.h>
 #include <nvfuser_resources/welford.h>
 
+#include <C++20/ranges>
 #include <cstdlib>
 #include <fstream>
 #include <variant>
@@ -166,7 +165,7 @@ bool checkSameStride(const std::vector<c10::IValue>& tensors) {
   if (tensors.size() < 2) {
     return true;
   }
-  for (const auto idx : c10::irange(tensors.size() - 1)) {
+  for (const auto idx : std::views::iota((size_t)0, tensors.size() - 1)) {
     auto current = tensors[idx];
     auto next = tensors[idx + 1];
     if (!current.isTensor() || !next.isTensor()) {
@@ -179,7 +178,8 @@ bool checkSameStride(const std::vector<c10::IValue>& tensors) {
       return false;
     }
 
-    for (const auto i : c10::irange(current_tensor.ndimension())) {
+    for (const auto i :
+         std::views::iota((int64_t)0, current_tensor.ndimension())) {
       if (current_tensor.stride(i) != next_tensor.stride(i)) {
         return false;
       }
@@ -202,7 +202,8 @@ bool checkSameContiguity(const std::vector<c10::IValue>& tensors) {
   // Determine if the reference tensor is contiguous
   const auto& reference_tensor = reference.toTensor();
   int64_t expected_stride = 1;
-  for (const auto i : c10::irange(1, reference_tensor.ndimension() + 1)) {
+  for (const auto i :
+       std::views::iota((int64_t)1, reference_tensor.ndimension() + 1)) {
     int64_t ind = reference_tensor.ndimension() - i;
     if (reference_tensor.size(ind) == 1) {
       continue;
@@ -439,7 +440,7 @@ getTensorOffsets(
     const auto slice_info = slice->getRanges();
 
     size_t offset = 0;
-    for (const auto i : c10::irange(root_ids.size())) {
+    for (const auto i : std::views::iota((size_t)0, root_ids.size())) {
       auto slice_start_eval = eval.evaluate(slice_info.at(i).start);
       NVF_ERROR(slice_start_eval.hasValue());
       auto slice_stop_eval = eval.evaluate(slice_info.at(i).stop);
@@ -483,7 +484,8 @@ void validateAlignedVectorizedFusionInputOutput(
       is_sliced ? tv->getMaybeRFactorDomain() : tv->getMaybeAllocationDomain();
 
   std::vector<int64_t> no_reduction_to_full;
-  for (int64_t i : c10::irange((int64_t)domain_to_validate.size())) {
+  for (int64_t i :
+       std::views::iota((int64_t)0, (int64_t)domain_to_validate.size())) {
     auto alloc_id = domain_to_validate.at(i);
     if (!alloc_id->isReduction()) {
       no_reduction_to_full.emplace_back(i);
@@ -721,7 +723,7 @@ ExpressionEvaluator bindInputs(
 
   ExpressionEvaluator expr_eval;
   const auto& inputs = kernel->inputs();
-  for (const auto i : c10::irange(inputs.size())) {
+  for (const auto i : std::views::iota((size_t)0, inputs.size())) {
     expr_eval.bind(inputs[i], *args[i], true);
   }
 
@@ -853,7 +855,7 @@ class NvrtcCompileDriver {
   // Get options that can be passed to nvrtcCompileProgram
   std::vector<const char*> getOptions() const {
     std::vector<const char*> opts(options_.size());
-    for (const auto i : c10::irange(options_.size())) {
+    for (const auto i : std::views::iota((size_t)0, options_.size())) {
       opts.at(i) = options_.at(i).c_str();
     }
     return opts;
@@ -928,7 +930,7 @@ class CuModuleLoadDataDriver {
     // matrixMulDynlinkJIT sample
     // https://github.com/NVIDIA/cuda-samples/blob/master/Samples/0_Introduction/matrixMulDynlinkJIT/matrixMulDynlinkJIT.cpp#L169-L204.
     std::vector<void*> opt_val_voidp(opt_vals.size());
-    for (const auto i : c10::irange(opt_vals.size())) {
+    for (const auto i : std::views::iota((size_t)0, opt_vals.size())) {
       auto opt_val = opt_vals.at(i);
       if (std::holds_alternative<int>(opt_val)) {
         // NOLINTNEXTLINE(performance-no-int-to-ptr)

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -15,7 +15,7 @@
 #include <ir/utils.h>
 #include <root_domain_map.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <functional>
 #include <iostream>
 
@@ -124,7 +124,7 @@ void ExpressionEvaluator::bind_(
         rfactor_domain.size(),
         ", but got a tensor of rank ",
         t.dim());
-    for (auto i : std::views::iota((int64_t)0, t.dim())) {
+    for (auto i : irange(t.dim())) {
       bind_(
           rfactor_domain[i]->getMaybeExpandedExtent(),
           t.size(i),
@@ -200,7 +200,7 @@ const PolymorphicValue& ExpressionEvaluator::evaluateHelper(
         inputs.emplace_back(eval_i);
       }
       auto outputs = def->evaluate(*this, inputs);
-      for (auto i : std::views::iota((size_t)0, def->outputs().size())) {
+      for (auto i : irange(def->outputs().size())) {
         known_values[def->output(i)] = std::move(outputs[i]);
       }
       maybe_concrete_value = getValue(value, known_values);

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -15,6 +15,7 @@
 #include <ir/utils.h>
 #include <root_domain_map.h>
 
+#include <C++20/ranges>
 #include <functional>
 #include <iostream>
 
@@ -123,7 +124,7 @@ void ExpressionEvaluator::bind_(
         rfactor_domain.size(),
         ", but got a tensor of rank ",
         t.dim());
-    for (auto i : c10::irange(t.dim())) {
+    for (auto i : std::views::iota((int64_t)0, t.dim())) {
       bind_(
           rfactor_domain[i]->getMaybeExpandedExtent(),
           t.size(i),
@@ -199,7 +200,7 @@ const PolymorphicValue& ExpressionEvaluator::evaluateHelper(
         inputs.emplace_back(eval_i);
       }
       auto outputs = def->evaluate(*this, inputs);
-      for (auto i : c10::irange(def->outputs().size())) {
+      for (auto i : std::views::iota((size_t)0, def->outputs().size())) {
         known_values[def->output(i)] = std::move(outputs[i]);
       }
       maybe_concrete_value = getValue(value, known_values);

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -225,8 +225,9 @@ const PolymorphicValue& ExpressionEvaluator::getValue(
   }
 
   auto it = known_values_.find(value);
-  if (it != known_values_.end())
+  if (it != known_values_.end()) {
     return it->second;
+  }
 
   if (&additional_known_values != &known_values_) {
     it = additional_known_values.find(value);

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -17,7 +17,7 @@
 #include <options.h>
 #include <utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <cmath>
 #include <functional>
 #include <list>
@@ -1747,7 +1747,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
     }
     if (op == BinaryOpType::Add) { // a + (-a) -> 0
       std::vector<std::tuple<Val*, Val*, size_t>> inv_inputs;
-      for (size_t idx : std::views::iota((size_t)0, fop->inputs().size())) {
+      for (size_t idx : irange(fop->inputs().size())) {
         auto inp = fop->input(idx);
         auto def = inp->definition();
         if (auto inv = dynamic_cast<UnaryOp*>(def)) {
@@ -1758,7 +1758,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       }
       std::unordered_set<size_t> remove;
       for (auto [orig, inv, idx] : inv_inputs) {
-        for (size_t idx2 : std::views::iota((size_t)0, fop->inputs().size())) {
+        for (size_t idx2 : irange(fop->inputs().size())) {
           auto inp = fop->input(idx2);
           if (remove.count(idx) || remove.count(idx2)) {
             continue;
@@ -1771,7 +1771,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       }
       if (!remove.empty()) {
         std::vector<Val*> new_inputs;
-        for (size_t idx : std::views::iota((size_t)0, fop->inputs().size())) {
+        for (size_t idx : irange(fop->inputs().size())) {
           if (!remove.count(idx)) {
             new_inputs.emplace_back(fop->input(idx));
           }
@@ -2109,14 +2109,14 @@ Val* distributeDivisibleDivMod(Val* value, const Context& context) {
   if (!fop) {
     return value;
   }
-  for (auto i : std::views::iota((size_t)0, fop->inputs().size())) {
+  for (auto i : irange(fop->inputs().size())) {
     Val* divisible_term = fop->input(i);
     if (!prove::isMultipleOf(divisible_term, rhs)) {
       continue;
     }
     std::vector<Val*> other_terms;
     other_terms.reserve(fop->inputs().size() - 1);
-    for (auto j : std::views::iota((size_t)0, fop->inputs().size())) {
+    for (auto j : irange(fop->inputs().size())) {
       if (j == i) {
         continue;
       }
@@ -2492,7 +2492,7 @@ Val* fundamentalDivisionWithRemainderProperty(
     if (fmul == nullptr) {
       return result;
     }
-    for (auto j : std::views::iota((size_t)0, fmul->inputs().size())) {
+    for (auto j : irange(fmul->inputs().size())) {
       auto vmul = fmul->input(j);
       if (!isIntegralType(*vmul->getDataType())) {
         continue;
@@ -2505,7 +2505,7 @@ Val* fundamentalDivisionWithRemainderProperty(
         auto a = bop->lhs();
         auto b = bop->rhs();
         std::vector<Val*> other_terms;
-        for (auto k : std::views::iota((size_t)0, fmul->inputs().size())) {
+        for (auto k : irange(fmul->inputs().size())) {
           if (j == k) {
             continue;
           }
@@ -2529,7 +2529,7 @@ Val* fundamentalDivisionWithRemainderProperty(
   };
   // Find a / b * b or a / b * (b*c)
   std::vector<std::tuple<size_t, Val*, Val*, Val*>> divmuls;
-  for (auto i : std::views::iota((size_t)0, fadd->inputs().size())) {
+  for (auto i : irange(fadd->inputs().size())) {
     auto vadd = fadd->input(i);
     if (!isIntegralType(*vadd->getDataType())) {
       continue;
@@ -2540,7 +2540,7 @@ Val* fundamentalDivisionWithRemainderProperty(
   }
   // Find a % b or a % b * c
   std::vector<std::tuple<size_t, Val*, Val*, Val*>> modmuls;
-  for (auto i : std::views::iota((size_t)0, fadd->inputs().size())) {
+  for (auto i : irange(fadd->inputs().size())) {
     auto vadd = fadd->input(i);
     if (!isIntegralType(*vadd->getDataType())) {
       continue;
@@ -2584,7 +2584,7 @@ Val* fundamentalDivisionWithRemainderProperty(
         // As: [1] + [2] + a * c ... + ...  + ...
         Val* ac = maybeFlattenedOpOf(BinaryOpType::Mul, {a1, c});
         std::vector<Val*> terms{ac};
-        for (auto k : std::views::iota((size_t)0, fadd->inputs().size())) {
+        for (auto k : irange(fadd->inputs().size())) {
           if (k == i || k == j) {
             continue;
           }
@@ -2630,8 +2630,8 @@ Val* cancelTermsInPredicate(Val* value, const Context& context) {
 
   std::vector<bool> common_lhs_terms(lhs_terms.size(), false);
   std::vector<bool> common_rhs_terms(rhs_terms.size(), false);
-  for (const auto lhs_i : std::views::iota((size_t)0, lhs_terms.size())) {
-    for (const auto rhs_i : std::views::iota((size_t)0, rhs_terms.size())) {
+  for (const auto lhs_i : irange(lhs_terms.size())) {
+    for (const auto rhs_i : irange(rhs_terms.size())) {
       // Make sure no multiple LHS terms are removed for the same RHS term
       if (common_rhs_terms.at(rhs_i)) {
         continue;
@@ -2652,14 +2652,14 @@ Val* cancelTermsInPredicate(Val* value, const Context& context) {
   }
 
   std::vector<Val*> new_lhs_terms;
-  for (const auto i : std::views::iota((size_t)0, lhs_terms.size())) {
+  for (const auto i : irange(lhs_terms.size())) {
     if (!common_lhs_terms.at(i)) {
       new_lhs_terms.push_back(lhs_terms[i]);
     }
   }
 
   std::vector<Val*> new_rhs_terms;
-  for (const auto i : std::views::iota((size_t)0, rhs_terms.size())) {
+  for (const auto i : irange(rhs_terms.size())) {
     if (!common_rhs_terms.at(i)) {
       new_rhs_terms.push_back(rhs_terms[i]);
     }

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -17,6 +17,7 @@
 #include <options.h>
 #include <utils.h>
 
+#include <C++20/ranges>
 #include <cmath>
 #include <functional>
 #include <list>
@@ -1746,7 +1747,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
     }
     if (op == BinaryOpType::Add) { // a + (-a) -> 0
       std::vector<std::tuple<Val*, Val*, size_t>> inv_inputs;
-      for (size_t idx : c10::irange(fop->inputs().size())) {
+      for (size_t idx : std::views::iota((size_t)0, fop->inputs().size())) {
         auto inp = fop->input(idx);
         auto def = inp->definition();
         if (auto inv = dynamic_cast<UnaryOp*>(def)) {
@@ -1757,7 +1758,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       }
       std::unordered_set<size_t> remove;
       for (auto [orig, inv, idx] : inv_inputs) {
-        for (size_t idx2 : c10::irange(fop->inputs().size())) {
+        for (size_t idx2 : std::views::iota((size_t)0, fop->inputs().size())) {
           auto inp = fop->input(idx2);
           if (remove.count(idx) || remove.count(idx2)) {
             continue;
@@ -1770,7 +1771,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       }
       if (!remove.empty()) {
         std::vector<Val*> new_inputs;
-        for (size_t idx : c10::irange(fop->inputs().size())) {
+        for (size_t idx : std::views::iota((size_t)0, fop->inputs().size())) {
           if (!remove.count(idx)) {
             new_inputs.emplace_back(fop->input(idx));
           }
@@ -2108,14 +2109,14 @@ Val* distributeDivisibleDivMod(Val* value, const Context& context) {
   if (!fop) {
     return value;
   }
-  for (auto i : c10::irange(fop->inputs().size())) {
+  for (auto i : std::views::iota((size_t)0, fop->inputs().size())) {
     Val* divisible_term = fop->input(i);
     if (!prove::isMultipleOf(divisible_term, rhs)) {
       continue;
     }
     std::vector<Val*> other_terms;
     other_terms.reserve(fop->inputs().size() - 1);
-    for (auto j : c10::irange(fop->inputs().size())) {
+    for (auto j : std::views::iota((size_t)0, fop->inputs().size())) {
       if (j == i) {
         continue;
       }
@@ -2491,7 +2492,7 @@ Val* fundamentalDivisionWithRemainderProperty(
     if (fmul == nullptr) {
       return result;
     }
-    for (auto j : c10::irange(fmul->inputs().size())) {
+    for (auto j : std::views::iota((size_t)0, fmul->inputs().size())) {
       auto vmul = fmul->input(j);
       if (!isIntegralType(*vmul->getDataType())) {
         continue;
@@ -2504,7 +2505,7 @@ Val* fundamentalDivisionWithRemainderProperty(
         auto a = bop->lhs();
         auto b = bop->rhs();
         std::vector<Val*> other_terms;
-        for (auto k : c10::irange(fmul->inputs().size())) {
+        for (auto k : std::views::iota((size_t)0, fmul->inputs().size())) {
           if (j == k) {
             continue;
           }
@@ -2528,7 +2529,7 @@ Val* fundamentalDivisionWithRemainderProperty(
   };
   // Find a / b * b or a / b * (b*c)
   std::vector<std::tuple<size_t, Val*, Val*, Val*>> divmuls;
-  for (auto i : c10::irange(fadd->inputs().size())) {
+  for (auto i : std::views::iota((size_t)0, fadd->inputs().size())) {
     auto vadd = fadd->input(i);
     if (!isIntegralType(*vadd->getDataType())) {
       continue;
@@ -2539,7 +2540,7 @@ Val* fundamentalDivisionWithRemainderProperty(
   }
   // Find a % b or a % b * c
   std::vector<std::tuple<size_t, Val*, Val*, Val*>> modmuls;
-  for (auto i : c10::irange(fadd->inputs().size())) {
+  for (auto i : std::views::iota((size_t)0, fadd->inputs().size())) {
     auto vadd = fadd->input(i);
     if (!isIntegralType(*vadd->getDataType())) {
       continue;
@@ -2583,7 +2584,7 @@ Val* fundamentalDivisionWithRemainderProperty(
         // As: [1] + [2] + a * c ... + ...  + ...
         Val* ac = maybeFlattenedOpOf(BinaryOpType::Mul, {a1, c});
         std::vector<Val*> terms{ac};
-        for (auto k : c10::irange(fadd->inputs().size())) {
+        for (auto k : std::views::iota((size_t)0, fadd->inputs().size())) {
           if (k == i || k == j) {
             continue;
           }
@@ -2629,8 +2630,8 @@ Val* cancelTermsInPredicate(Val* value, const Context& context) {
 
   std::vector<bool> common_lhs_terms(lhs_terms.size(), false);
   std::vector<bool> common_rhs_terms(rhs_terms.size(), false);
-  for (const auto lhs_i : c10::irange(lhs_terms.size())) {
-    for (const auto rhs_i : c10::irange(rhs_terms.size())) {
+  for (const auto lhs_i : std::views::iota((size_t)0, lhs_terms.size())) {
+    for (const auto rhs_i : std::views::iota((size_t)0, rhs_terms.size())) {
       // Make sure no multiple LHS terms are removed for the same RHS term
       if (common_rhs_terms.at(rhs_i)) {
         continue;
@@ -2651,14 +2652,14 @@ Val* cancelTermsInPredicate(Val* value, const Context& context) {
   }
 
   std::vector<Val*> new_lhs_terms;
-  for (const auto i : c10::irange(lhs_terms.size())) {
+  for (const auto i : std::views::iota((size_t)0, lhs_terms.size())) {
     if (!common_lhs_terms.at(i)) {
       new_lhs_terms.push_back(lhs_terms[i]);
     }
   }
 
   std::vector<Val*> new_rhs_terms;
-  for (const auto i : c10::irange(rhs_terms.size())) {
+  for (const auto i : std::views::iota((size_t)0, rhs_terms.size())) {
     if (!common_rhs_terms.at(i)) {
       new_rhs_terms.push_back(rhs_terms[i]);
     }

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -22,7 +22,7 @@
 #include <kernel.h>
 #include <ops/arith.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <iterator>
 
 namespace nvfuser {
@@ -787,7 +787,7 @@ std::unordered_set<int> Fusion::getIndicesOfAliasedOutputs() const {
 
   std::unordered_set<int> alias_indices;
 
-  for (const auto i : std::views::iota((size_t)0, outputs_.size())) {
+  for (const auto i : irange(outputs_.size())) {
     if (io_alias_.count(outputs_[i]) != 0) {
       alias_indices.insert((int)i);
     }
@@ -801,10 +801,10 @@ std::vector<std::pair<int, int>> Fusion::getOutputToInputAliasIndices() const {
   }
 
   std::vector<std::pair<int, int>> alias_indices;
-  for (const auto output_idx : std::views::iota((size_t)0, outputs_.size())) {
+  for (const auto output_idx : irange(outputs_.size())) {
     if (io_alias_.count(outputs_[output_idx]) != 0) {
       bool found = false;
-      for (const auto input_idx : std::views::iota((size_t)0, inputs_.size())) {
+      for (const auto input_idx : irange(inputs_.size())) {
         if (io_alias_.at(outputs_[output_idx]) == inputs_[input_idx]) {
           alias_indices.emplace_back(output_idx, input_idx);
           found = true;

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -22,6 +22,7 @@
 #include <kernel.h>
 #include <ops/arith.h>
 
+#include <C++20/ranges>
 #include <iterator>
 
 namespace nvfuser {
@@ -785,7 +786,7 @@ std::unordered_set<int> Fusion::getIndicesOfAliasedOutputs() const {
 
   std::unordered_set<int> alias_indices;
 
-  for (const auto i : c10::irange(outputs_.size())) {
+  for (const auto i : std::views::iota((size_t)0, outputs_.size())) {
     if (io_alias_.count(outputs_[i]) != 0) {
       alias_indices.insert((int)i);
     }
@@ -799,10 +800,10 @@ std::vector<std::pair<int, int>> Fusion::getOutputToInputAliasIndices() const {
   }
 
   std::vector<std::pair<int, int>> alias_indices;
-  for (const auto output_idx : c10::irange(outputs_.size())) {
+  for (const auto output_idx : std::views::iota((size_t)0, outputs_.size())) {
     if (io_alias_.count(outputs_[output_idx]) != 0) {
       bool found = false;
-      for (const auto input_idx : c10::irange(inputs_.size())) {
+      for (const auto input_idx : std::views::iota((size_t)0, inputs_.size())) {
         if (io_alias_.at(outputs_[output_idx]) == inputs_[input_idx]) {
           alias_indices.emplace_back(output_idx, input_idx);
           found = true;

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -201,8 +201,9 @@ void Fusion::removeVal(Val* val) {
       "Cannot remove val as it is an output of the fusion.");
 
   Expr* orig = val->definition();
-  if (orig != nullptr)
+  if (orig != nullptr) {
     removeExpr(val->definition());
+  }
 
   for (Expr* use : unordered_uses(val)) {
     removeExpr(use);

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -18,7 +18,7 @@
 #include <scheduler/debug_utils.h>
 #include <scheduler/normalization_utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <sstream>
 
 namespace nvfuser {
@@ -96,7 +96,7 @@ std::vector<SegmentedGroup::NeighborGroup> SegmentedGroup::
   std::vector<bool> can_merge(neighbors.size(), true);
 
   // Find neighbors with a level that is only 1 differant than this groups level
-  for (const auto i : std::views::iota((size_t)0, neighbors.size())) {
+  for (const auto i : irange(neighbors.size())) {
     if (std::abs(neighbors[i].group->level_ - level_) > 1) {
       can_merge[i] = false;
     }
@@ -105,7 +105,7 @@ std::vector<SegmentedGroup::NeighborGroup> SegmentedGroup::
   // Check neighbor of neighbors we're considering, if any of them are merged
   // with another node, make sure the resulting edge wouldn't have a level
   // difference of 1
-  for (const auto i : std::views::iota((size_t)0, neighbors.size())) {
+  for (const auto i : irange(neighbors.size())) {
     if (!can_merge[i]) {
       continue;
     }
@@ -139,7 +139,7 @@ std::vector<SegmentedGroup::NeighborGroup> SegmentedGroup::
   }
 
   std::vector<NeighborGroup> merge_candidates;
-  for (const auto i : std::views::iota((size_t)0, neighbors.size())) {
+  for (const auto i : irange(neighbors.size())) {
     if (can_merge[i]) {
       merge_candidates.push_back(neighbors[i]);
     }
@@ -232,7 +232,7 @@ std::ostream& operator<<(std::ostream& os, const SegmentedGroup* group) {
       [](auto expr_a, auto expr_b) -> bool {
         return expr_a->name() < expr_b->name();
       });
-  for (const auto i : std::views::iota((size_t)0, expr_to_print.size())) {
+  for (const auto i : irange(expr_to_print.size())) {
     os << expr_to_print[i]->name();
     if (i + 1 != expr_to_print.size()) {
       os << ", ";
@@ -750,7 +750,7 @@ void detailGroupPrint(std::ostream& os, const SegmentedGroup* group) {
 
   auto expr_to_print = groupExprPrintSorting(group->exprs());
 
-  for (const auto i : std::views::iota((size_t)0, expr_to_print.size())) {
+  for (const auto i : irange(expr_to_print.size())) {
     os << expr_to_print[i]->toString();
     os << "(" << expr_to_print[i]->name() << ")\n";
   }
@@ -1397,8 +1397,7 @@ std::ostream& operator<<(
 
   // Do a reverse look up to check the order of sorted groups
   std::unordered_map<SegmentedGroup*, size_t> group_order;
-  for (const auto i :
-       std::views::iota((size_t)0, sorted_groups_to_print.size())) {
+  for (const auto i : irange(sorted_groups_to_print.size())) {
     group_order[sorted_groups_to_print[i]] = i;
   }
 
@@ -2455,7 +2454,7 @@ bool TranslateApplicableWelford::wouldTranslateToPersistent(
     // If only average is used from welford, we should still translate, but we
     // might not detect persistence if variance isn't actually used/marked as an
     // output in the test.
-    for (auto outs_i : std::views::iota((size_t)0, welford_avgs.size())) {
+    for (auto outs_i : irange(welford_avgs.size())) {
       auto avg = welford_avgs[outs_i];
       auto var = welford_vars[outs_i];
       if (avg->uses().empty()) {
@@ -2520,7 +2519,7 @@ void TranslateApplicableWelford::translateSingleWelford(WelfordOp* welford) {
   //  counting.
   Val* num_features = IrBuilder::create<Val>(1.0);
   std::vector<bool> broadcast_mask(in_root.size(), false);
-  for (const auto i : std::views::iota((size_t)0, in_root.size())) {
+  for (const auto i : irange(in_root.size())) {
     if (out_root.at(i)->isReduction()) {
       red_axes.push_back((int)i);
       broadcast_mask[i] = true;
@@ -2625,7 +2624,7 @@ class CombineReductions {
       // Merge one pair of reduction groups at a time, and need
       //  the pass to update dependency info along the way to avoid cycles
       for (const auto first_group_index :
-           std::views::iota((size_t)0, groups_with_reductions_.size())) {
+           irange(groups_with_reductions_.size())) {
         if (merged_groups) {
           // Need to break and re-enter this loop because
           // groups_with_reductions_ will be updated
@@ -2986,7 +2985,7 @@ class CombineReductions {
         return false;
       }
 
-      for (const auto i : std::views::iota((size_t)0, reduction_axes_.size())) {
+      for (const auto i : irange(reduction_axes_.size())) {
         if (reduction_axes_[i] != reduction_signature->reduction_axes_[i]) {
           return false;
         }
@@ -3037,7 +3036,7 @@ class CombineReductions {
       auto& root_domain = out_tv->getRootDomain();
       root_domain_size_ = root_domain.size();
 
-      for (const auto i : std::views::iota((size_t)0, root_domain_size_)) {
+      for (const auto i : irange(root_domain_size_)) {
         if (root_domain[i]->isReduction()) {
           reduction_axes_.push_back((int)i);
         }

--- a/csrc/graph_fuser.cpp
+++ b/csrc/graph_fuser.cpp
@@ -173,8 +173,9 @@ struct CudaGraphFuser {
     auto defining_node = producer->node();
     for (auto o : defining_node->outputs()) {
       for (auto u : o->uses()) {
-        if (u.user != consumer && !calculatesSize(u.user))
+        if (u.user != consumer && !calculatesSize(u.user)) {
           return false;
+        }
       }
     }
     return true;
@@ -237,8 +238,9 @@ struct CudaGraphFuser {
       auto outputs = node->outputs();
       for (const auto i : std::views::iota((size_t)0, outputs.size())) {
         auto output = outputs[i];
-        if (output->uses().empty())
+        if (output->uses().empty()) {
           continue;
+        }
         consumer_subgraph->registerOutput(merged->outputs()[i]);
         auto new_output = consumer_group->addOutput();
         output->replaceAllUsesWith(new_output);
@@ -263,8 +265,9 @@ struct CudaGraphFuser {
     size_t tensor_insert_idx = 0;
     for (auto input : group->inputs()) {
       inputs_map[input] = subgraph.inputs()[i++];
-      if (input->type()->isSubtypeOf(*at::TensorType::get()))
+      if (input->type()->isSubtypeOf(*at::TensorType::get())) {
         tensor_insert_idx = i;
+      }
     }
     // add n's inputs to the fusion group's input list if we don't already have
     // them
@@ -599,8 +602,9 @@ struct CudaGraphFuser {
     // is the output from a chunk/bchunk node?
     auto* chunk = producer->node();
     if (chunk->kind() != at::prim::ConstantChunk &&
-        chunk->kind() != at::prim::BroadcastingChunk)
+        chunk->kind() != at::prim::BroadcastingChunk) {
       return false;
+    }
 
     // try to find a producer to move after the chunk/bchunk. The producer must
     // be fusable into the consumer.
@@ -622,8 +626,9 @@ struct CudaGraphFuser {
     // all uses of the chunk must be in this consumer
     for (auto s : chunk->outputs()) {
       for (auto u : s->uses()) {
-        if (u.user != consumer)
+        if (u.user != consumer) {
           return false;
+        }
       }
     }
     // multiple return operators
@@ -662,8 +667,9 @@ struct CudaGraphFuser {
       // XXX: we only work with pointwise ops in here, so we know it is valid to
       // push the concat only through tensor arguments (and all other args can
       // be safely ignored).
-      if (!input->type()->isSubtypeOf(*at::TensorType::get()))
+      if (!input->type()->isSubtypeOf(*at::TensorType::get())) {
         continue;
+      }
 
       // if 'input' is already an input to the bchunk, reuse it.
       auto bchunk_inputs = bchunk->inputs();
@@ -934,8 +940,9 @@ struct CudaGraphFuser {
     auto soutputs = subgraph->outputs();
     AT_ASSERT(outputs.size() == soutputs.size());
     for (const auto i : std::views::iota((size_t)0, outputs.size())) {
-      if (usedOnlyInDtypeAndSize(outputs[i]))
+      if (usedOnlyInDtypeAndSize(outputs[i])) {
         continue;
+      }
       if (soutputs[i]->type()->isSubtypeOf(at::TensorType::get())) {
         shape_of[soutputs[i]] = graph->insert(at::aten::size, {outputs[i]});
       }
@@ -1181,8 +1188,9 @@ struct CudaGraphFuser {
   }
 
   void removeOutputsUsedOnlyInSize(torch::jit::Node* fusion_group) {
-    if (fusion_group->kind() != at::prim::CudaFusionGroup)
+    if (fusion_group->kind() != at::prim::CudaFusionGroup) {
       return;
+    }
     auto subgraph = fusion_group->g(at::attr::Subgraph);
 
     // TODO: failure in buildShapeExpressions should not break fusion execution,

--- a/csrc/grouped_reduction.cpp
+++ b/csrc/grouped_reduction.cpp
@@ -12,6 +12,8 @@
 
 #include <grouped_reduction.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 namespace {
@@ -30,7 +32,8 @@ namespace {
 // Return if ref and other are transformed in the same way.
 bool hasMatchingTransformations(TensorView* ref, TensorView* other) {
   std::unordered_map<IterDomain*, IterDomain*> ref_2_other;
-  for (const auto i : c10::irange(ref->getRootDomain().size())) {
+  for (const auto i :
+       std::views::iota((size_t)0, ref->getRootDomain().size())) {
     ref_2_other.emplace(
         ref->getRootDomain().at(i), other->getRootDomain().at(i));
   }
@@ -39,7 +42,7 @@ bool hasMatchingTransformations(TensorView* ref, TensorView* other) {
                     other->getLeafDomain(), ref->getLeafDomain(), ref_2_other)
                     .getIterDomainEquivalence();
 
-  for (const auto i : c10::irange(ref->nDims())) {
+  for (const auto i : std::views::iota((size_t)0, ref->nDims())) {
     if (!replay.permissiveAreMapped(ref->axis((int)i), other->axis((int)i))) {
       return false;
     }
@@ -76,7 +79,7 @@ bool validateReductionGrouping(
   // condition and could be made more flexible
   const auto uses_of_ref =
       ref_tv->hasComputeWith() ? ref_tv->uses() : std::vector<Expr*>();
-  for (const auto i : c10::irange(inputs.size())) {
+  for (const auto i : std::views::iota((size_t)0, inputs.size())) {
     auto output_tv = outputs.at(i)->as<TensorView>();
     const auto& output_domain = output_tv->getRootDomain();
     if (ref_tv == output_tv) {
@@ -102,7 +105,7 @@ bool validateReductionGrouping(
         output_tv->nDims(),
         ". Invalid output tensor: ",
         output_tv->toString());
-    for (const auto i : c10::irange(num_root_dims)) {
+    for (const auto i : std::views::iota((size_t)0, num_root_dims)) {
       auto ref_id = ref_domain.at(i);
       auto output_id = output_domain.at(i);
       // If an IterDomain is broadcast, require the other
@@ -216,7 +219,7 @@ bool groupReductions(
   std::vector<Val*> outputs(num_reductions);
   std::vector<Val*> inputs(num_reductions);
 
-  for (const auto i : c10::irange(num_reductions)) {
+  for (const auto i : std::views::iota((size_t)0, num_reductions)) {
     auto reduction_out = reduction_outputs.at(i);
     GROUP_REDUCTION_CHECK(
         error_on_failure,

--- a/csrc/grouped_reduction.cpp
+++ b/csrc/grouped_reduction.cpp
@@ -12,7 +12,7 @@
 
 #include <grouped_reduction.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -32,8 +32,7 @@ namespace {
 // Return if ref and other are transformed in the same way.
 bool hasMatchingTransformations(TensorView* ref, TensorView* other) {
   std::unordered_map<IterDomain*, IterDomain*> ref_2_other;
-  for (const auto i :
-       std::views::iota((size_t)0, ref->getRootDomain().size())) {
+  for (const auto i : irange(ref->getRootDomain().size())) {
     ref_2_other.emplace(
         ref->getRootDomain().at(i), other->getRootDomain().at(i));
   }
@@ -42,7 +41,7 @@ bool hasMatchingTransformations(TensorView* ref, TensorView* other) {
                     other->getLeafDomain(), ref->getLeafDomain(), ref_2_other)
                     .getIterDomainEquivalence();
 
-  for (const auto i : std::views::iota((size_t)0, ref->nDims())) {
+  for (const auto i : irange(ref->nDims())) {
     if (!replay.permissiveAreMapped(ref->axis((int)i), other->axis((int)i))) {
       return false;
     }
@@ -79,7 +78,7 @@ bool validateReductionGrouping(
   // condition and could be made more flexible
   const auto uses_of_ref =
       ref_tv->hasComputeWith() ? ref_tv->uses() : std::vector<Expr*>();
-  for (const auto i : std::views::iota((size_t)0, inputs.size())) {
+  for (const auto i : irange(inputs.size())) {
     auto output_tv = outputs.at(i)->as<TensorView>();
     const auto& output_domain = output_tv->getRootDomain();
     if (ref_tv == output_tv) {
@@ -105,7 +104,7 @@ bool validateReductionGrouping(
         output_tv->nDims(),
         ". Invalid output tensor: ",
         output_tv->toString());
-    for (const auto i : std::views::iota((size_t)0, num_root_dims)) {
+    for (const auto i : irange(num_root_dims)) {
       auto ref_id = ref_domain.at(i);
       auto output_id = output_domain.at(i);
       // If an IterDomain is broadcast, require the other
@@ -219,7 +218,7 @@ bool groupReductions(
   std::vector<Val*> outputs(num_reductions);
   std::vector<Val*> inputs(num_reductions);
 
-  for (const auto i : std::views::iota((size_t)0, num_reductions)) {
+  for (const auto i : irange(num_reductions)) {
     auto reduction_out = reduction_outputs.at(i);
     GROUP_REDUCTION_CHECK(
         error_on_failure,

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -28,7 +28,7 @@
 #include <transform_iter.h>
 #include <transform_replay.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <memory>
 
 namespace nvfuser {
@@ -228,7 +228,7 @@ Val* getProducerIndexWithGather(
 
   // Consumer axis that corresponds to the producer axis
   int64_t consumer_axis = -1;
-  for (const auto i : std::views::iota((size_t)0, producer_root_axis + 1)) {
+  for (const auto i : irange(producer_root_axis + 1)) {
     if (producer_tv->getMaybeRFactorDomain()[i]->isReduction() ||
         producer_tv->getMaybeRFactorDomain()[i]->isStride()) {
       continue;
@@ -1533,7 +1533,7 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
   std::vector<Val*> strides(alloc_dom.size(), nullptr);
   {
     int stride_i = 0;
-    for (const auto i : std::views::iota((size_t)0, alloc_dom.size())) {
+    for (const auto i : irange(alloc_dom.size())) {
       if (alloc_dom[i]->isReduction()) {
         strides[i] = GpuLower::current()->kernel()->oneVal();
         continue;
@@ -1547,7 +1547,7 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
 
   NVF_ERROR(alloc_dom.size() == producer_tv->domain()->contiguity().size());
   Val* cur_contig_stride = GpuLower::current()->kernel()->oneVal();
-  for (const auto i : std::views::iota((size_t)0, alloc_dom.size())) {
+  for (const auto i : irange(alloc_dom.size())) {
     auto dim = alloc_dom.size() - i - 1;
     if (alloc_dom[dim]->isReduction()) {
       continue;
@@ -1583,7 +1583,7 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
   // Global striding
   std::vector<Val*> strided_inds(
       alloc_dom.size(), GpuLower::current()->kernel()->zeroVal());
-  for (const auto i : std::views::iota((size_t)0, alloc_dom.size())) {
+  for (const auto i : irange(alloc_dom.size())) {
     Val* alloc_ind = alloc_indices.at(i);
 
     if (alloc_ind->isZeroInt()) {
@@ -1759,7 +1759,7 @@ std::vector<Val*> Index::getNonGlobalProducerStridedIndices(
 
   std::vector<Val*> strided_inds(
       alloc_dom.size(), GpuLower::current()->kernel()->zeroVal());
-  for (const auto i : std::views::iota((size_t)0, alloc_dom.size())) {
+  for (const auto i : irange(alloc_dom.size())) {
     if (skip_indexing.count(alloc_dom[i])) {
       continue;
     }
@@ -1889,7 +1889,7 @@ std::vector<Val*> Index::getStrides(TensorView* tv) {
       alloc_dom.size(), GpuLower::current()->kernel()->oneVal());
   {
     int stride_i = 0;
-    for (const auto i : std::views::iota((size_t)0, alloc_dom.size())) {
+    for (const auto i : irange(alloc_dom.size())) {
       if (alloc_dom[i]->isReduction() || alloc_dom[i]->isStride()) {
         strides[i] = GpuLower::current()->kernel()->oneVal();
         continue;
@@ -1902,7 +1902,7 @@ std::vector<Val*> Index::getStrides(TensorView* tv) {
 
   NVF_ERROR(alloc_dom.size() == tv->domain()->contiguity().size());
   Val* cur_contig_stride = GpuLower::current()->kernel()->oneVal();
-  for (const auto i : std::views::iota((size_t)0, alloc_dom.size())) {
+  for (const auto i : irange(alloc_dom.size())) {
     auto dim = alloc_dom.size() - i - 1;
     if (alloc_dom[dim]->isReduction() || alloc_dom[dim]->isStride()) {
       continue;
@@ -1942,7 +1942,7 @@ std::vector<Val*> Index::getConsumerAllocationIndices(
 
   std::vector<Val*> alloc_inds(
       alloc_dom.size(), GpuLower::current()->kernel()->zeroVal());
-  for (const auto i : std::views::iota((size_t)0, alloc_dom.size())) {
+  for (const auto i : irange(alloc_dom.size())) {
     // See a comment in indexing to allocation domains in
     // getGlobalProducerIndex.
     if (alloc_dom[i]->isReduction() || alloc_dom[i]->isBroadcast() ||
@@ -2048,7 +2048,7 @@ std::vector<Val*> Index::getProducerAllocationIndices(
   std::vector<Val*> alloc_inds(
       alloc_dom.size(), GpuLower::current()->kernel()->zeroVal());
 
-  for (const auto i : std::views::iota((size_t)0, alloc_dom.size())) {
+  for (const auto i : irange(alloc_dom.size())) {
     if (alloc_dom[i]->isReduction() || alloc_dom[i]->isBroadcast()) {
       continue;
     }
@@ -2113,7 +2113,7 @@ std::vector<Val*> Index::getGlobalConsumerStridedIndices(
       loops.empty() ? nullptr : loops.back()->vectorize_shift();
   std::vector<Val*> strided_inds(
       alloc_inds.size(), GpuLower::current()->kernel()->zeroVal());
-  for (const auto i : std::views::iota((size_t)0, alloc_inds.size())) {
+  for (const auto i : irange(alloc_inds.size())) {
     auto override_it = override_index.find((int)i);
     if (override_it != override_index.end()) {
       alloc_inds[i] = override_it->second;
@@ -2177,7 +2177,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
   const auto& alloc_dom = consumer_tv->getMaybeAllocationDomain();
   std::vector<Val*> strided_inds(
       alloc_dom.size(), GpuLower::current()->kernel()->zeroVal());
-  for (const auto i : std::views::iota((size_t)0, alloc_dom.size())) {
+  for (const auto i : irange(alloc_dom.size())) {
     if (alloc_dom[i]->isReduction() || alloc_dom[i]->isBroadcast() ||
         alloc_dom[i]->isStride()) {
       continue;
@@ -2466,7 +2466,7 @@ std::vector<PredicateDomainInfo> getPredicateContigIds(
   }
 
   std::unordered_set<IterDomain*> final_ids;
-  for (auto root_i : std::views::iota((size_t)0, consumer_root_domain.size())) {
+  for (auto root_i : irange(consumer_root_domain.size())) {
     auto root_id = consumer_root_domain[root_i];
     if (root_id->maybePartial()) {
       final_ids.insert(root_id);
@@ -3203,7 +3203,7 @@ Val* Index::cpAsyncBulkIndex(
     // element size to convert to bytes, and remove fastest dim as it is assumed
     // to be one.
     std::vector<Val*> strides;
-    for (auto i : std::views::iota((int64_t)0, dim - 1)) {
+    for (auto i : irange(dim - 1)) {
       strides.push_back(SimplifyingIrBuilder::mulExpr(
           IrBuilder::getItemExpr(global_strides, dim - 2 - i), itemsize));
     }

--- a/csrc/inlining.cpp
+++ b/csrc/inlining.cpp
@@ -10,6 +10,7 @@
 #include <root_domain_map.h>
 #include <transform_iter.h>
 
+#include <C++20/ranges>
 #include <utility>
 
 namespace nvfuser {
@@ -124,7 +125,7 @@ size_t MaxPosCalculator::getMaxProducerPosFromConsumer(
       BestEffortReplay::replayCasP(consumer, producer, -1, pairwise_root_map);
   auto p2c_replay_map = replay_CasP.getReplay();
 
-  for (const auto producer_pos : c10::irange(producer->nDims())) {
+  for (const auto producer_pos : std::views::iota((size_t)0, producer->nDims())) {
     // If the producer position is mismatching with the consumer, then we can
     // not inline into this position, otherwise the max producer position of
     // the consumer will become invalid and expression sort will fail.

--- a/csrc/inlining.cpp
+++ b/csrc/inlining.cpp
@@ -10,7 +10,7 @@
 #include <root_domain_map.h>
 #include <transform_iter.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <utility>
 
 namespace nvfuser {
@@ -125,8 +125,7 @@ size_t MaxPosCalculator::getMaxProducerPosFromConsumer(
       BestEffortReplay::replayCasP(consumer, producer, -1, pairwise_root_map);
   auto p2c_replay_map = replay_CasP.getReplay();
 
-  for (const auto producer_pos :
-       std::views::iota((size_t)0, producer->nDims())) {
+  for (const auto producer_pos : irange(producer->nDims())) {
     // If the producer position is mismatching with the consumer, then we can
     // not inline into this position, otherwise the max producer position of
     // the consumer will become invalid and expression sort will fail.

--- a/csrc/inlining.cpp
+++ b/csrc/inlining.cpp
@@ -125,7 +125,8 @@ size_t MaxPosCalculator::getMaxProducerPosFromConsumer(
       BestEffortReplay::replayCasP(consumer, producer, -1, pairwise_root_map);
   auto p2c_replay_map = replay_CasP.getReplay();
 
-  for (const auto producer_pos : std::views::iota((size_t)0, producer->nDims())) {
+  for (const auto producer_pos :
+       std::views::iota((size_t)0, producer->nDims())) {
     // If the producer position is mismatching with the consumer, then we can
     // not inline into this position, otherwise the max producer position of
     // the consumer will become invalid and expression sort will fail.

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -21,7 +21,7 @@
 
 #include <c10/util/Exception.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -156,7 +156,7 @@ bool Val::sameAs(const Statement* other) const {
     }
     // For definition with multiple outputs, only outputs at the same position
     // could be the same
-    for (auto i : std::views::iota((size_t)0, definition_->outputs().size())) {
+    for (auto i : irange(definition_->outputs().size())) {
       if ((definition_->output(i) == this) !=
           (other_val->definition_->output(i) == other_val)) {
         return false;
@@ -408,12 +408,12 @@ bool Expr::sameAs(const Statement* other) const {
       attributes().size() != other_expr->attributes().size()) {
     return false;
   }
-  for (const auto i : std::views::iota((size_t)0, inputs().size())) {
+  for (const auto i : irange(inputs().size())) {
     if (!input(i)->sameAs(other_expr->input(i))) {
       return false;
     }
   }
-  for (const auto i : std::views::iota((size_t)0, attributes().size())) {
+  for (const auto i : irange(attributes().size())) {
     if (!attribute(i)->sameAs(other_expr->attribute(i))) {
       return false;
     }

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -20,8 +20,8 @@
 #include <torch/csrc/jit/ir/ir.h>
 
 #include <c10/util/Exception.h>
-#include <c10/util/irange.h>
 
+#include <C++20/ranges>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -156,7 +156,7 @@ bool Val::sameAs(const Statement* other) const {
     }
     // For definition with multiple outputs, only outputs at the same position
     // could be the same
-    for (auto i : c10::irange(definition_->outputs().size())) {
+    for (auto i : std::views::iota((size_t)0, definition_->outputs().size())) {
       if ((definition_->output(i) == this) !=
           (other_val->definition_->output(i) == other_val)) {
         return false;
@@ -408,12 +408,12 @@ bool Expr::sameAs(const Statement* other) const {
       attributes().size() != other_expr->attributes().size()) {
     return false;
   }
-  for (const auto i : c10::irange(inputs().size())) {
+  for (const auto i : std::views::iota((size_t)0, inputs().size())) {
     if (!input(i)->sameAs(other_expr->input(i))) {
       return false;
     }
   }
-  for (const auto i : c10::irange(attributes().size())) {
+  for (const auto i : std::views::iota((size_t)0, attributes().size())) {
     if (!attribute(i)->sameAs(other_expr->attribute(i))) {
       return false;
     }

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -16,6 +16,8 @@
 #include <mma_type.h>
 #include <parallel_type_bitmap.h>
 
+#include <C++20/ranges>
+
 //! Nodes in here should generally not be used by users. They should be behind
 //! the scenes and users shouldn't have to be aware of what they do to use the
 //! code generator
@@ -940,7 +942,7 @@ class GroupedReductionOp : public Expr {
     auto size = numHorizontallyGroupedExprs();
     std::vector<Val*> result;
     result.reserve(size);
-    for (auto i : c10::irange(2, 2 + size)) {
+    for (auto i : std::views::iota((size_t)2, 2 + size)) {
       result.emplace_back(attribute(i)->as<Val>());
     }
     return result;
@@ -1236,7 +1238,7 @@ class GroupedWelfordOp : public Expr {
     std::vector<WelfordTriplet> result;
     auto size = outputs().size() / 3;
     result.reserve(size);
-    for (auto i : c10::irange(size)) {
+    for (auto i : std::views::iota((size_t)0, size)) {
       result.emplace_back(outAvg(i), outVar(i), outN(i));
     }
     return result;
@@ -1246,7 +1248,7 @@ class GroupedWelfordOp : public Expr {
     std::vector<WelfordTriplet> result;
     auto size = inputs().size() / 3;
     result.reserve(size);
-    for (auto i : c10::irange(size)) {
+    for (auto i : std::views::iota((size_t)0, size)) {
       result.emplace_back(inAvg(i), inVar(i), inN(i));
     }
     return result;
@@ -1256,7 +1258,7 @@ class GroupedWelfordOp : public Expr {
     std::vector<WelfordTriplet> result;
     auto size = inputs().size() / 3;
     result.reserve(size);
-    for (auto i : c10::irange(size)) {
+    for (auto i : std::views::iota((size_t)0, size)) {
       result.emplace_back(initAvg(i), initVar(i), initN(i));
     }
     return result;

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -16,7 +16,7 @@
 #include <mma_type.h>
 #include <parallel_type_bitmap.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 //! Nodes in here should generally not be used by users. They should be behind
 //! the scenes and users shouldn't have to be aware of what they do to use the
@@ -1238,7 +1238,7 @@ class GroupedWelfordOp : public Expr {
     std::vector<WelfordTriplet> result;
     auto size = outputs().size() / 3;
     result.reserve(size);
-    for (auto i : std::views::iota((size_t)0, size)) {
+    for (auto i : irange(size)) {
       result.emplace_back(outAvg(i), outVar(i), outN(i));
     }
     return result;
@@ -1248,7 +1248,7 @@ class GroupedWelfordOp : public Expr {
     std::vector<WelfordTriplet> result;
     auto size = inputs().size() / 3;
     result.reserve(size);
-    for (auto i : std::views::iota((size_t)0, size)) {
+    for (auto i : irange(size)) {
       result.emplace_back(inAvg(i), inVar(i), inN(i));
     }
     return result;
@@ -1258,7 +1258,7 @@ class GroupedWelfordOp : public Expr {
     std::vector<WelfordTriplet> result;
     auto size = inputs().size() / 3;
     result.reserve(size);
-    for (auto i : std::views::iota((size_t)0, size)) {
+    for (auto i : irange(size)) {
       result.emplace_back(initAvg(i), initVar(i), initN(i));
     }
     return result;

--- a/csrc/ir/iostream.cpp
+++ b/csrc/ir/iostream.cpp
@@ -16,8 +16,6 @@
 #include <kernel.h>
 #include <utils.h>
 
-#include <c10/util/irange.h>
-
 namespace nvfuser {
 
 // Make sure we can inline something, before we attempt to.

--- a/csrc/ir/iostream.h
+++ b/csrc/ir/iostream.h
@@ -12,8 +12,7 @@
 
 #include <dispatch.h>
 
-#include <c10/util/irange.h>
-
+#include <C++20/ranges>
 #include <iostream>
 
 namespace nvfuser {
@@ -29,7 +28,7 @@ static constexpr char const* kTab = "  ";
 
 // Indent the generated code
 inline std::ostream& indent(std::ostream& os, int indent_size) {
-  for (const auto _ : c10::irange(indent_size)) {
+  for (const auto _ : std::views::iota(0, indent_size)) {
     (void)_; // Suppress unused variable warning
     os << "  ";
   }

--- a/csrc/ir/iostream.h
+++ b/csrc/ir/iostream.h
@@ -12,7 +12,7 @@
 
 #include <dispatch.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <iostream>
 
 namespace nvfuser {
@@ -28,7 +28,7 @@ static constexpr char const* kTab = "  ";
 
 // Indent the generated code
 inline std::ostream& indent(std::ostream& os, int indent_size) {
-  for (const auto _ : std::views::iota(0, indent_size)) {
+  for (const auto _ : irange(indent_size)) {
     (void)_; // Suppress unused variable warning
     os << "  ";
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2613,8 +2613,9 @@ std::string IterDomain::toString(int indent_size) const {
     ss << extent()->toInlineString();
   }
   ss << "}";
-  if (isRFactorProduct())
+  if (isRFactorProduct()) {
     ss << "rf";
+  }
   if (hasPaddingToMultipleOfWarp()) {
     ss << "_p";
   }
@@ -3243,12 +3244,14 @@ bool TensorDomain::sameAs(const Statement* const other) const {
 bool TensorDomain::sameAs(
     const std::vector<IterDomain*>& lhs,
     const std::vector<IterDomain*>& rhs) {
-  if (lhs.size() != rhs.size())
+  if (lhs.size() != rhs.size()) {
     return false;
+  }
   size_t i = 0;
   for (auto td_lhs : lhs) {
-    if (!td_lhs->sameAs(rhs[i++]))
+    if (!td_lhs->sameAs(rhs[i++])) {
       return false;
+    }
   }
   return true;
 }
@@ -3363,8 +3366,9 @@ int64_t TensorDomain::posOf(IterDomain* id) const {
   NVF_ERROR(nDims() > 0, "Tried to find an axis in a 0-dim domain");
   int64_t i = 0;
   while (i < (int64_t)leaf_domain_.size()) {
-    if (leaf_domain_[i] == id)
+    if (leaf_domain_[i] == id) {
       return i;
+    }
     i++;
   }
   NVF_CHECK(false, "Provided id is not part of this domain.");
@@ -3385,8 +3389,9 @@ void TensorDomain::split(
     bool inner_split,
     bool trim_out_of_bounds) {
   NVF_ERROR(nDims() > 0, "Tried to do split on a 0-dim domain");
-  if (axis_ < 0)
+  if (axis_ < 0) {
     axis_ += (int)nDims();
+  }
 
   NVF_ERROR(
       axis_ >= 0 && (unsigned int)axis_ < nDims(),
@@ -3416,11 +3421,13 @@ void TensorDomain::split(
 // Merge "axis_o" and "axis_i" into 1 dimension
 void TensorDomain::merge(int axis_o, int axis_i) {
   NVF_ERROR(nDims() > 0, "Tried to do merge on a 0-dim domain");
-  if (axis_o < 0)
+  if (axis_o < 0) {
     axis_o += (int)nDims();
+  }
 
-  if (axis_i < 0)
+  if (axis_i < 0) {
     axis_i += (int)nDims();
+  }
 
   NVF_CHECK(
       axis_o >= 0 && (unsigned int)axis_o < nDims() && axis_i >= 0 &&

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -22,7 +22,7 @@
 #include <transform_view.h>
 #include <type.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <complex>
 #include <iterator>
 #include <numeric>
@@ -49,7 +49,7 @@ std::string FullOp::toString(int indent_size) const {
   indent(ss, indent_size) << output(0)->toString() << "\n";
   indent_size++;
   indent(ss, indent_size) << " = full({";
-  for (auto i : std::views::iota((size_t)0, inputs().size())) {
+  for (auto i : irange(inputs().size())) {
     if (i == inputs().size() - 1) {
       ss << "}";
     }
@@ -850,7 +850,7 @@ StructConstruct::StructConstruct(
 std::string StructConstruct::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << out()->toString() << " = { ";
-  for (int64_t i : std::views::iota((int64_t)0, (int64_t)inputs().size())) {
+  for (int64_t i : irange((int64_t)inputs().size())) {
     if (i > 0) {
       ss << ", ";
     }
@@ -863,7 +863,7 @@ std::string StructConstruct::toString(int indent_size) const {
 std::string StructConstruct::toInlineString(int indent_size) const {
   std::stringstream ss;
   ss << "{ ";
-  for (int64_t i : std::views::iota((int64_t)0, (int64_t)inputs().size())) {
+  for (int64_t i : irange((int64_t)inputs().size())) {
     if (i > 0) {
       ss << ", ";
     }
@@ -883,7 +883,7 @@ std::vector<PolymorphicValue> StructConstruct::evaluate(
       " inputs");
   PolymorphicValue struct_ =
       std::get<StructType>(output(0)->dtype().type).create();
-  for (int64_t i : std::views::iota((int64_t)0, (int64_t)inputs.size())) {
+  for (int64_t i : irange((int64_t)inputs.size())) {
     struct_->*attribute<std::string>(i) = inputs.at(i);
   }
   return {std::move(struct_)};
@@ -1080,7 +1080,7 @@ BroadcastOp::BroadcastOp(
 
     auto out_size = is_broadcast_dims.size();
     auto num_new_broadcasts = 0;
-    for (const auto i : std::views::iota((size_t)0, out_size)) {
+    for (const auto i : irange(out_size)) {
       if (is_broadcast_dims[i]) {
         num_new_broadcasts++;
         auto id = out_dom[i];
@@ -1174,7 +1174,7 @@ SqueezeOp::SqueezeOp(
 
   auto in_size = is_squeeze_dims.size();
   auto num_removed_broadcasts = 0;
-  for (const auto i : std::views::iota((size_t)0, is_squeeze_dims.size())) {
+  for (const auto i : irange(is_squeeze_dims.size())) {
     if (is_squeeze_dims[i]) {
       num_removed_broadcasts++;
       auto id = in_dom[i];
@@ -1229,8 +1229,7 @@ std::vector<PolymorphicValue> SqueezeOp::evaluate(
   NVF_ERROR(
       (int64_t)is_squeeze_dims.size() == in.dim(),
       "The dimensions of input tensor and does not match with is_squeeze_dims");
-  for (int64_t i :
-       std::views::iota((int64_t)0, (int64_t)is_squeeze_dims.size())) {
+  for (int64_t i : irange((int64_t)is_squeeze_dims.size())) {
     if (!is_squeeze_dims[i]) {
       out_shape.push_back(in.sizes()[i]);
     }
@@ -1260,7 +1259,7 @@ void SqueezeOp::checkConcretization(Val* old_val, Val* new_val) const {
       " but expected ",
       old_tv->getMaybeRFactorDomain().size());
   auto flags = getSqueezeDimFlags();
-  for (auto i : std::views::iota((size_t)0, flags.size())) {
+  for (auto i : irange(flags.size())) {
     if (!flags.at(i)) {
       continue;
     }
@@ -1364,8 +1363,7 @@ std::string GroupedReductionOp::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "GroupedReductionOp(\n";
   ++indent_size;
-  for (const auto i :
-       std::views::iota((size_t)0, numHorizontallyGroupedExprs())) {
+  for (const auto i : irange(numHorizontallyGroupedExprs())) {
     indent(ss, indent_size)
         << output(i)->toString() << " = reduction( " << input(i)->toString()
         << ", op = " << getReductionOpType(i)
@@ -1416,7 +1414,7 @@ std::vector<WelfordTriplet> WelfordTriplet::clone(
     const std::vector<WelfordTriplet>& src,
     IrCloner* ir_cloner) {
   std::vector<WelfordTriplet> cloned(src.size());
-  for (const auto i : std::views::iota((size_t)0, src.size())) {
+  for (const auto i : irange(src.size())) {
     cloned.at(i) = src.at(i).clone(ir_cloner);
   }
   return cloned;
@@ -1595,7 +1593,7 @@ GroupedWelfordOp::GroupedWelfordOp(
       ", Given: ",
       init_vals.size());
 
-  for (const auto i : std::views::iota((size_t)0, num_grouped_ops)) {
+  for (const auto i : irange(num_grouped_ops)) {
     // Check output type
     NVF_ERROR(
         output_vals[i].avg()->getValType().value() == ValType::TensorView ||
@@ -1671,7 +1669,7 @@ GroupedWelfordOp::GroupedWelfordOp(
   }
 
   addDataAttribute(is_allreduce);
-  for (const auto i : std::views::iota((size_t)0, num_grouped_ops)) {
+  for (const auto i : irange(num_grouped_ops)) {
     addOutput(output_vals[i].avg());
     addOutput(output_vals[i].var());
     addOutput(output_vals[i].N());
@@ -1688,8 +1686,7 @@ std::string GroupedWelfordOp::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "GroupedWelford(\n";
   ++indent_size;
-  for (const auto i :
-       std::views::iota((size_t)0, numHorizontallyGroupedExprs())) {
+  for (const auto i : irange(numHorizontallyGroupedExprs())) {
     indent(ss, indent_size) << outAvg(i)->toString() << " (Avg),\n";
     indent(ss, indent_size) << outVar(i)->toString() << " (Var),\n";
     indent(ss, indent_size) << outN(i)->toString() << " (Count)\n";
@@ -1715,8 +1712,7 @@ std::string GroupedWelfordOp::toInlineString(int indent_size) const {
 }
 
 int GroupedWelfordOp::getExprIndexOfOutput(Val* output_val) const {
-  for (const auto expr_idx :
-       std::views::iota((size_t)0, numHorizontallyGroupedExprs())) {
+  for (const auto expr_idx : irange(numHorizontallyGroupedExprs())) {
     if (outputVals().at(expr_idx).getNameOf(output_val).has_value()) {
       return (int)expr_idx;
     }
@@ -1777,7 +1773,7 @@ struct TensorViewDetails {
 // A helper for gathering details about TensorView object
 TensorViewDetails getDetailsFor(const std::vector<IterDomain*>& dims) {
   TensorViewDetails details;
-  for (auto pos : std::views::iota((int64_t)0, (int64_t)dims.size())) {
+  for (auto pos : irange((int64_t)dims.size())) {
     const auto axis = dims.at(pos);
     if (axis->isReduction()) {
       details.rdomains.push_back(pos);
@@ -3018,7 +3014,7 @@ void validateContiguity(
       contiguity.size(),
       " but needed one of size ",
       allocation_domain.size());
-  for (auto i : std::views::iota((size_t)0, contiguity.size())) {
+  for (auto i : irange(contiguity.size())) {
     bool expect_null =
         (allocation_domain.at(i)->isBroadcast() ||
          allocation_domain.at(i)->isReduction());
@@ -3208,31 +3204,31 @@ bool TensorDomain::sameAs(const Statement* const other) const {
     return false;
   }
 
-  for (const auto i : std::views::iota((size_t)0, nDims())) {
+  for (const auto i : irange(nDims())) {
     if (!(axis((int)i)->sameAs(other_td->axis((int)i)))) {
       return false;
     }
   }
 
-  for (const auto i : std::views::iota((size_t)0, root().size())) {
+  for (const auto i : irange(root().size())) {
     if (!(root()[i]->sameAs(other_td->root()[i]))) {
       return false;
     }
   }
 
-  for (const auto i : std::views::iota((size_t)0, rfactor().size())) {
+  for (const auto i : irange(rfactor().size())) {
     if (!(rfactor()[i]->sameAs(other_td->rfactor()[i]))) {
       return false;
     }
   }
 
-  for (const auto i : std::views::iota((size_t)0, allocation().size())) {
+  for (const auto i : irange(allocation().size())) {
     if (!(allocation()[i]->sameAs(other_td->allocation()[i]))) {
       return false;
     }
   }
 
-  for (const auto i : std::views::iota((size_t)0, leaf().size())) {
+  for (const auto i : irange(leaf().size())) {
     if (!(leaf()[i]->sameAs(other_td->leaf()[i]))) {
       return false;
     }
@@ -3275,7 +3271,7 @@ void TensorDomain::setContiguity(
   NVF_ERROR(
       maybeAllocation().size() == contig.size(),
       "Invalid size of contiguity vector");
-  for (auto i : std::views::iota((size_t)0, contig.size())) {
+  for (auto i : irange(contig.size())) {
     NVF_CHECK(
         maybeAllocation().at(i)->isBroadcast() != contig.at(i).has_value(),
         "The contiguity of a broadcast dimension must be None. "
@@ -3596,7 +3592,7 @@ TensorDomain* TensorDomain::flatten(int64_t start_dim, int64_t end_dim) {
 
   std::vector<IterDomain*> new_root_domain;
   new_root_domain.reserve(inp_domain.size());
-  for (auto i : std::views::iota((size_t)0, inp_domain.size())) {
+  for (auto i : irange(inp_domain.size())) {
     bool is_rfactor_dim = i >= size_t(start_dim) && i <= size_t(end_dim);
     auto inp_id = inp_domain[i];
     auto out_id = IterDomainBuilder(inp_id)
@@ -3615,7 +3611,7 @@ TensorDomain* TensorDomain::flatten(int64_t start_dim, int64_t end_dim) {
 
   std::vector<IterDomain*> rfactor_domain;
   rfactor_domain.reserve(new_root_domain.size() - (end_dim - start_dim));
-  for (auto i : std::views::iota((int64_t)0, start_dim)) {
+  for (auto i : irange(start_dim)) {
     rfactor_domain.push_back(new_root_domain[i]);
   }
 
@@ -3947,7 +3943,7 @@ std::string PadOp::toInlineString(int indent_size) const {
 std::vector<int> PadOp::getPaddedAxes() const {
   auto num_dims = out()->as<TensorView>()->getRootDomain().size();
   std::vector<int> padded_axes;
-  for (const auto i : std::views::iota((size_t)0, num_dims)) {
+  for (const auto i : irange(num_dims)) {
     auto [left_pad, right_pad] = getPadWidths((int)i);
     // Filter out non-padded dimension
     if (left_pad->isZeroInt() && right_pad->isZeroInt()) {
@@ -4074,7 +4070,7 @@ std::vector<PolymorphicValue> SliceOp::evaluate(
   std::vector<at::indexing::TensorIndex> ranges;
   auto ranges_offset = getRangeInputOffset();
   auto num_dims = in.dim();
-  for (const auto i : std::views::iota((int64_t)0, num_dims)) {
+  for (const auto i : irange(num_dims)) {
     auto start = (int64_t)inputs.at(ranges_offset + 3 * i);
     auto stop = (int64_t)inputs.at(ranges_offset + 3 * i + 1);
     auto step = (int64_t)inputs.at(ranges_offset + 3 * i + 2);
@@ -4183,7 +4179,7 @@ std::vector<PolymorphicValue> CatOp::evaluate(
     const std::vector<PolymorphicValue>& inputs) const {
   std::vector<at::Tensor> in;
   int64_t concat_dim = concatenatedDim();
-  for (auto i : std::views::iota((size_t)0, inputs.size())) {
+  for (auto i : irange(inputs.size())) {
     auto unpadded_inp = ee.evaluate(input(i)->definition()->input(0));
     in.push_back(unpadded_inp.as<at::Tensor>());
   }

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -14,7 +14,7 @@
 #include <iter_visitor.h>
 #include <ops/arith.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <limits>
 #include <set>
 
@@ -206,7 +206,7 @@ Expr* transferDefinitionToNewOutputs(
       new_outputs.size() == expr->outputs().size(),
       "Number of new outputs must match old outputs");
   OptOutMutator mutator;
-  for (const auto i : std::views::iota((size_t)0, new_outputs.size())) {
+  for (const auto i : irange(new_outputs.size())) {
     auto old_output = expr->outputs().at(i);
     auto new_output = new_outputs.at(i);
     if (new_output == old_output) {
@@ -665,7 +665,7 @@ bool isSqueezeInput(const TensorView* tv) {
 bool isSqueezedID(const TensorView* tv, const IterDomain* id) {
   auto root_dom = TensorDomain::noReductions(tv->getMaybeRFactorDomain());
   auto squeezes = ir_utils::filterByType<SqueezeOp>(tv->uses());
-  for (auto i : std::views::iota((size_t)0, root_dom.size())) {
+  for (auto i : irange(root_dom.size())) {
     if (root_dom[i] != id) {
       continue;
     }

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -14,6 +14,7 @@
 #include <iter_visitor.h>
 #include <ops/arith.h>
 
+#include <C++20/ranges>
 #include <limits>
 #include <set>
 
@@ -204,7 +205,7 @@ Expr* transferDefinitionToNewOutputs(
       new_outputs.size() == expr->outputs().size(),
       "Number of new outputs must match old outputs");
   OptOutMutator mutator;
-  for (const auto i : c10::irange(new_outputs.size())) {
+  for (const auto i : std::views::iota((size_t)0, new_outputs.size())) {
     auto old_output = expr->outputs().at(i);
     auto new_output = new_outputs.at(i);
     if (new_output == old_output) {
@@ -663,7 +664,7 @@ bool isSqueezeInput(const TensorView* tv) {
 bool isSqueezedID(const TensorView* tv, const IterDomain* id) {
   auto root_dom = TensorDomain::noReductions(tv->getMaybeRFactorDomain());
   auto squeezes = ir_utils::filterByType<SqueezeOp>(tv->uses());
-  for (auto i : c10::irange(root_dom.size())) {
+  for (auto i : std::views::iota((size_t)0, root_dom.size())) {
     if (root_dom[i] != id) {
       continue;
     }

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -135,8 +135,9 @@ std::vector<int> normalizeOld2New(
 
   // All available new positions
   std::set<int> all_positions;
-  for (decltype(ndims) i{0}; i < ndims; i++)
+  for (decltype(ndims) i{0}; i < ndims; i++) {
     all_positions.insert((int)i);
+  }
 
   // Check what positions haven't been specified.
   std::set<int> positions_left;

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -873,8 +873,7 @@ void FusionExecutorCache::deserialize(
   }
 
   // 2. Rebuild input id to kernel cache
-  for (auto idx :
-       std::views::iota(0u, buffer->kernel_cache_keys()->size())) {
+  for (auto idx : std::views::iota(0u, buffer->kernel_cache_keys()->size())) {
     size_t key = buffer->kernel_cache_keys()->Get(idx);
     size_t value_id = buffer->kernel_cache_values()->Get(idx);
     id_to_kernel_runtime_.emplace(key, all_runtimes.at(value_id));
@@ -1069,7 +1068,7 @@ void FusionKernelRuntime::prepareRuntimeOrder() {
 
     // Find the first segment with all inputs available to run
     for (const size_t group_i :
-         std::views::iota(0u, segmented_fusion_->groups().size())) {
+         std::views::iota((size_t)0, segmented_fusion_->groups().size())) {
       auto& group = segmented_fusion_->groups()[group_i];
       if (group_ran[group_i]) {
         continue;

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -261,8 +261,7 @@ void InputsIdLookup::deserialize(const serde::InputsIdLookup* buffer) {
     used_entry_iterators.emplace_back(std::prev(used_entry_.end()));
   }
 
-  for (auto idx :
-       std::views::iota(0u, buffer->encoding_lookup_keys()->size())) {
+  for (auto idx : irange(buffer->encoding_lookup_keys()->size())) {
     auto fb_encoding_lookup_str = buffer->encoding_lookup_keys()->Get(idx);
     auto fb_encoding_entry = buffer->encoding_lookup_values()->Get(idx);
 
@@ -871,7 +870,7 @@ void FusionExecutorCache::deserialize(
   }
 
   // 2. Rebuild input id to kernel cache
-  for (auto idx : std::views::iota(0u, buffer->kernel_cache_keys()->size())) {
+  for (auto idx : irange(buffer->kernel_cache_keys()->size())) {
     size_t key = buffer->kernel_cache_keys()->Get(idx);
     size_t value_id = buffer->kernel_cache_values()->Get(idx);
     id_to_kernel_runtime_.emplace(key, all_runtimes.at(value_id));
@@ -956,7 +955,7 @@ void FusionKernelRuntime::deserialize(
   NVF_ERROR(runtime_workspace_.group_run_order.size() == executors_.size());
 
   // 1. Deserialize FusionExecutor objects
-  for (auto idx : std::views::iota(0u, buffer->executors()->size())) {
+  for (auto idx : irange(buffer->executors()->size())) {
     auto sg = runtime_workspace_.group_run_order.at(idx);
 
     // Create and schedule Fusion for this SegmentedGroup

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -16,6 +16,7 @@
 #include <kernel_ir.h>
 #include <type.h>
 
+#include <C++20/ranges>
 #include <iostream>
 
 namespace nvfuser {
@@ -824,7 +825,8 @@ std::string GroupedGridReduction::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "GroupedGridReduction(\n";
   ++indent_size;
-  for (const auto i : c10::irange(numHorizontallyGroupedExprs())) {
+  for (const auto i :
+       std::views::iota((size_t)0, numHorizontallyGroupedExprs())) {
     indent(ss, indent_size)
         << output(i)->toString() << " = reduction( " << input(i)->toString()
         << ", op = " << getReductionOpType(i)
@@ -1020,7 +1022,7 @@ GroupedGridWelford::GroupedGridWelford(
   addDataAttribute(ParallelTypeBitmap{});
   NVF_ERROR(reduction_buffers[0].size() == reduction_buffers[1].size());
   NVF_ERROR(reduction_buffers[0].size() == reduction_buffers[2].size());
-  for (auto i : c10::irange(reduction_buffers[0].size())) {
+  for (auto i : std::views::iota((size_t)0, reduction_buffers[0].size())) {
     addAttribute(reduction_buffers[0].at(i));
     addAttribute(reduction_buffers[1].at(i));
     addAttribute(reduction_buffers[2].at(i));
@@ -1073,7 +1075,8 @@ std::string GroupedGridWelford::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "GroupedGridWelford(\n";
   ++indent_size;
-  for (const auto i : c10::irange(numHorizontallyGroupedExprs())) {
+  for (const auto i :
+       std::views::iota((size_t)0, numHorizontallyGroupedExprs())) {
     indent(ss, indent_size) << outAvg(i)->toString() << " (Avg),\n";
     indent(ss, indent_size) << outVar(i)->toString() << " (Var),\n";
     indent(ss, indent_size) << outN(i)->toString() << " (Count)\n";

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -16,7 +16,7 @@
 #include <kernel_ir.h>
 #include <type.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <iostream>
 
 namespace nvfuser {
@@ -825,8 +825,7 @@ std::string GroupedGridReduction::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "GroupedGridReduction(\n";
   ++indent_size;
-  for (const auto i :
-       std::views::iota((size_t)0, numHorizontallyGroupedExprs())) {
+  for (const auto i : irange(numHorizontallyGroupedExprs())) {
     indent(ss, indent_size)
         << output(i)->toString() << " = reduction( " << input(i)->toString()
         << ", op = " << getReductionOpType(i)
@@ -1022,7 +1021,7 @@ GroupedGridWelford::GroupedGridWelford(
   addDataAttribute(ParallelTypeBitmap{});
   NVF_ERROR(reduction_buffers[0].size() == reduction_buffers[1].size());
   NVF_ERROR(reduction_buffers[0].size() == reduction_buffers[2].size());
-  for (auto i : std::views::iota((size_t)0, reduction_buffers[0].size())) {
+  for (auto i : irange(reduction_buffers[0].size())) {
     addAttribute(reduction_buffers[0].at(i));
     addAttribute(reduction_buffers[1].at(i));
     addAttribute(reduction_buffers[2].at(i));
@@ -1075,8 +1074,7 @@ std::string GroupedGridWelford::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "GroupedGridWelford(\n";
   ++indent_size;
-  for (const auto i :
-       std::views::iota((size_t)0, numHorizontallyGroupedExprs())) {
+  for (const auto i : irange(numHorizontallyGroupedExprs())) {
     indent(ss, indent_size) << outAvg(i)->toString() << " (Avg),\n";
     indent(ss, indent_size) << outVar(i)->toString() << " (Var),\n";
     indent(ss, indent_size) << outN(i)->toString() << " (Count)\n";

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -17,6 +17,7 @@
 
 #include <c10/macros/Export.h>
 
+#include <C++20/ranges>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
@@ -748,7 +749,7 @@ class GroupedGridReduction final : public GroupedReductionOp {
     auto size = outputs().size();
     std::vector<Allocate*> result;
     result.reserve(size);
-    for (auto i : c10::irange(offset, offset + size)) {
+    for (auto i : std::views::iota(offset, offset + size)) {
       result.emplace_back(attribute(i)->as<Allocate>());
     }
     return result;
@@ -952,7 +953,7 @@ class GroupedGridWelford final : public GroupedWelfordOp {
     result[0].reserve(size);
     result[1].reserve(size);
     result[2].reserve(size);
-    for (auto i : c10::irange(size)) {
+    for (auto i : std::views::iota(0UL, size)) {
       result[0].emplace_back(attribute(offset + i * 3)->as<Allocate>());
       result[1].emplace_back(attribute(offset + i * 3 + 1)->as<Allocate>());
       result[2].emplace_back(attribute(offset + i * 3 + 2)->as<Allocate>());

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -17,7 +17,7 @@
 
 #include <c10/macros/Export.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <cstdint>
 #include <string>
 #include <unordered_map>

--- a/csrc/manager.cpp
+++ b/csrc/manager.cpp
@@ -25,7 +25,6 @@
 
 #include <ATen/DimVector.h>
 #include <c10/core/DeviceType.h>
-#include <c10/util/irange.h>
 
 #include <unordered_map>
 

--- a/csrc/maxinfo_propagator.cpp
+++ b/csrc/maxinfo_propagator.cpp
@@ -8,7 +8,7 @@
 #include <maxinfo_propagator.h>
 #include <root_domain_map.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -427,11 +427,11 @@ std::shared_ptr<MaxInfoSpanningTree::Information> MaxRootDomainInfoSpanningTree:
   NVF_ERROR(from_rfactor_dom.size() == to_rfactor_dom.size());
 
   std::unordered_map<IterDomain*, IterDomain*> id_map;
-  for (auto i : std::views::iota((size_t)0, from_root_dom.size())) {
+  for (auto i : irange(from_root_dom.size())) {
     id_map[from_root_dom.at(i)] = to_root_dom.at(i);
   }
   if (from->hasRFactor()) {
-    for (auto i : std::views::iota((size_t)0, from_rfactor_dom.size())) {
+    for (auto i : irange(from_rfactor_dom.size())) {
       id_map[from_rfactor_dom.at(i)] = to_rfactor_dom.at(i);
     }
   }

--- a/csrc/maxinfo_propagator.cpp
+++ b/csrc/maxinfo_propagator.cpp
@@ -8,6 +8,8 @@
 #include <maxinfo_propagator.h>
 #include <root_domain_map.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 bool MaxInfoSpanningTree::Information::operator>(const Information& r) const {
@@ -425,11 +427,11 @@ std::shared_ptr<MaxInfoSpanningTree::Information> MaxRootDomainInfoSpanningTree:
   NVF_ERROR(from_rfactor_dom.size() == to_rfactor_dom.size());
 
   std::unordered_map<IterDomain*, IterDomain*> id_map;
-  for (auto i : c10::irange(from_root_dom.size())) {
+  for (auto i : std::views::iota((size_t)0, from_root_dom.size())) {
     id_map[from_root_dom.at(i)] = to_root_dom.at(i);
   }
   if (from->hasRFactor()) {
-    for (auto i : c10::irange(from_rfactor_dom.size())) {
+    for (auto i : std::views::iota((size_t)0, from_rfactor_dom.size())) {
       id_map[from_rfactor_dom.at(i)] = to_rfactor_dom.at(i);
     }
   }

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -10,7 +10,7 @@
 #include <multidevice/executor.h>
 #include <multidevice/pipeline.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -48,7 +48,7 @@ void PipelineExecutor::handle(PipelineStage* stage) {
       : fec_[stage]->allocOutputSpace(stage_input_IValues);
 
   // Store the outputs or placeholders in the context
-  for (auto output_idx : std::views::iota((size_t)0, stage->outputs().size())) {
+  for (auto output_idx : irange(stage->outputs().size())) {
     val_to_IValue_[stage->outputs().at(output_idx)] = outputs.at(output_idx);
   }
 }
@@ -87,7 +87,7 @@ void PipelineExecutor::handle(PipelineCommunication* c) {
     auto nbr_dests_per_comm = receivers.size() / nbr_srcs;
     auto remainder = receivers.size() % nbr_srcs;
     auto j = 0;
-    for (size_t i : std::views::iota((size_t)0, nbr_srcs)) {
+    for (size_t i : irange(nbr_srcs)) {
       SendRecvDescriptor communication;
       auto src = senders.at(i);
       communication.team = {src};
@@ -132,7 +132,7 @@ std::vector<at::Tensor> PipelineExecutor::runWithInput(
       "Wrong number of inputs");
 
   // process input values input values:
-  for (auto input_idx : std::views::iota((size_t)0, inputs.size())) {
+  for (auto input_idx : irange(inputs.size())) {
     val_to_IValue_[runtime_.pipeline_->inputs().at(input_idx)] =
         inputs.at(input_idx);
   }

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -10,6 +10,8 @@
 #include <multidevice/executor.h>
 #include <multidevice/pipeline.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 bool PipelineExecutor::shouldRun(PipelineStage* stage) {
@@ -46,7 +48,7 @@ void PipelineExecutor::handle(PipelineStage* stage) {
       : fec_[stage]->allocOutputSpace(stage_input_IValues);
 
   // Store the outputs or placeholders in the context
-  for (auto output_idx : c10::irange(stage->outputs().size())) {
+  for (auto output_idx : std::views::iota((size_t)0, stage->outputs().size())) {
     val_to_IValue_[stage->outputs().at(output_idx)] = outputs.at(output_idx);
   }
 }
@@ -85,7 +87,7 @@ void PipelineExecutor::handle(PipelineCommunication* c) {
     auto nbr_dests_per_comm = receivers.size() / nbr_srcs;
     auto remainder = receivers.size() % nbr_srcs;
     auto j = 0;
-    for (size_t i : c10::irange(nbr_srcs)) {
+    for (size_t i : std::views::iota((size_t)0, nbr_srcs)) {
       SendRecvDescriptor communication;
       auto src = senders.at(i);
       communication.team = {src};
@@ -129,7 +131,7 @@ std::vector<at::Tensor> PipelineExecutor::runWithInput(
       "Wrong number of inputs");
 
   // process input values input values:
-  for (auto input_idx : c10::irange(inputs.size())) {
+  for (auto input_idx : std::views::iota((size_t)0, inputs.size())) {
     val_to_IValue_[runtime_.pipeline_->inputs().at(input_idx)] =
         inputs.at(input_idx);
   }

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -115,8 +115,9 @@ void PipelineExecutor::handle(PipelineCommunication* c) {
     for (auto receiver_rank : communication.team) {
       if ((sender_rank == receiver_rank) ||
           !(runtime_.comm_.deviceId() == sender_rank ||
-            runtime_.comm_.deviceId() == receiver_rank))
+            runtime_.comm_.deviceId() == receiver_rank)) {
         continue;
+      }
       runtime_.comm_.sendRecv(receiver_rank, sender_rank, tensor);
     }
   }

--- a/csrc/mutator.cpp
+++ b/csrc/mutator.cpp
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <c10/util/irange.h>
 #include <exceptions.h>
 #include <fusion.h>
 #include <ir/all_nodes.h>
 #include <ir/builder.h>
 
+#include <C++20/ranges>
 #include <vector>
 
 /*
@@ -196,19 +196,19 @@ Expr* OptOutMutator::mutateExpr(
   }
 
   bool all_same = true;
-  for (auto i : c10::irange(op->outputs().size())) {
+  for (auto i : std::views::iota((size_t)0, op->outputs().size())) {
     if (!all_same) {
       break;
     }
     all_same = all_same && mutated_outputs[i] == op->output(i);
   }
-  for (auto i : c10::irange(op->inputs().size())) {
+  for (auto i : std::views::iota((size_t)0, op->inputs().size())) {
     if (!all_same) {
       break;
     }
     all_same = all_same && mutated_inputs[i] == op->input(i);
   }
-  for (auto i : c10::irange(op->attributes().size())) {
+  for (auto i : std::views::iota((size_t)0, op->attributes().size())) {
     if (!all_same) {
       break;
     }

--- a/csrc/mutator.cpp
+++ b/csrc/mutator.cpp
@@ -10,7 +10,7 @@
 #include <ir/all_nodes.h>
 #include <ir/builder.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <vector>
 
 /*
@@ -196,19 +196,19 @@ Expr* OptOutMutator::mutateExpr(
   }
 
   bool all_same = true;
-  for (auto i : std::views::iota((size_t)0, op->outputs().size())) {
+  for (auto i : irange(op->outputs().size())) {
     if (!all_same) {
       break;
     }
     all_same = all_same && mutated_outputs[i] == op->output(i);
   }
-  for (auto i : std::views::iota((size_t)0, op->inputs().size())) {
+  for (auto i : irange(op->inputs().size())) {
     if (!all_same) {
       break;
     }
     all_same = all_same && mutated_inputs[i] == op->input(i);
   }
-  for (auto i : std::views::iota((size_t)0, op->attributes().size())) {
+  for (auto i : irange(op->attributes().size())) {
     if (!all_same) {
       break;
     }

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -14,7 +14,7 @@
 #include <transform_view.h>
 #include <type_promotion.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -78,7 +78,7 @@ TensorView* tryStaticReshape(
     const std::vector<IterDomain*>& inp_dom,
     const std::vector<Val*>& new_sizes) {
   std::vector<int64_t> inp_sizes(inp_dom.size());
-  for (const auto i : std::views::iota((size_t)0, inp_dom.size())) {
+  for (const auto i : irange(inp_dom.size())) {
     auto id = inp_dom.at(i);
     auto id_size = id->extent()->getInt();
     if (!id_size.has_value()) {
@@ -88,7 +88,7 @@ TensorView* tryStaticReshape(
   }
 
   std::vector<int64_t> out_sizes(new_sizes.size());
-  for (const auto i : std::views::iota((size_t)0, new_sizes.size())) {
+  for (const auto i : irange(new_sizes.size())) {
     auto id_size = new_sizes.at(i)->getInt();
     if (!id_size.has_value()) {
       return nullptr;
@@ -125,7 +125,7 @@ TensorView* reshape(TensorView* inp_tv, const std::vector<Val*>& new_sizes) {
   // domain.
   std::vector<IterDomain*> rfactor_domain(new_sizes.size(), nullptr);
   bool found_neg_one = false;
-  for (const auto i : std::views::iota((size_t)0, new_sizes.size())) {
+  for (const auto i : irange(new_sizes.size())) {
     auto new_size = new_sizes.at(i);
     if (new_size->isConstScalar() && new_size->evaluateInt() == -1) {
       // It is usually safe to use the provided scalars as the output shapes.
@@ -139,10 +139,10 @@ TensorView* reshape(TensorView* inp_tv, const std::vector<Val*>& new_sizes) {
 
       Val* numel = FusionGuard::getCurFusion()->oneVal();
       Val* other_new_numel = FusionGuard::getCurFusion()->oneVal();
-      for (const auto j : std::views::iota((size_t)0, inp_dom.size())) {
+      for (const auto j : irange(inp_dom.size())) {
         numel = mul(numel, inp_dom.at(j)->extent());
       }
-      for (const auto j : std::views::iota((size_t)0, new_sizes.size())) {
+      for (const auto j : irange(new_sizes.size())) {
         if (i == j) {
           continue;
         }
@@ -220,7 +220,7 @@ TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
       x->toString());
 
   std::vector<IterDomain*> out_domain;
-  for (const auto idx : std::views::iota(0, ndims)) {
+  for (const auto idx : irange(ndims)) {
     auto id = x_dom[idx];
     if (to_squeeze[idx]) {
       if (!id->isSymbolic()) {
@@ -260,7 +260,7 @@ TensorView* squeeze(TensorView* x, const std::vector<int64_t>& sizes) {
       x->toString());
 
   std::vector<bool> to_squeeze(ndims);
-  for (const auto idx : std::views::iota((size_t)0, sizes.size())) {
+  for (const auto idx : irange(sizes.size())) {
     to_squeeze[idx] = (sizes[idx] == 1);
   }
   return squeeze(x, to_squeeze);
@@ -423,7 +423,7 @@ TensorView* transpose(TensorView* x, int64_t dim0, int64_t dim1) {
       dim1 >= 0 && dim1 <= ndims, "Invalid transpose dimension 1: ", dim1);
 
   std::vector<int64_t> new2old(ndims);
-  for (const auto i : std::views::iota(0, ndims)) {
+  for (const auto i : irange(ndims)) {
     if (i == dim0) {
       new2old[i] = dim1;
     } else if (i == dim1) {
@@ -512,7 +512,7 @@ TensorView* pad(
   std::vector<Val*> normalized_pad_widths;
 
   // Fill zero for non padded dimensions
-  for (const auto i : std::views::iota((size_t)0, num_non_padded_dims)) {
+  for (const auto i : irange(num_non_padded_dims)) {
     (void)i;
     normalized_pad_widths.push_back(FusionGuard::getCurFusion()->zeroVal());
     normalized_pad_widths.push_back(FusionGuard::getCurFusion()->zeroVal());
@@ -520,7 +520,7 @@ TensorView* pad(
 
   // torch.pad has padding widths of inner dimensions before outer
   // dimensions
-  for (const auto i : std::views::iota((size_t)0, num_padded_dims)) {
+  for (const auto i : irange(num_padded_dims)) {
     auto left_pad = pad_widths.at(num_padded_dims * 2 - (i + 1) * 2);
     auto right_pad = pad_widths.at(num_padded_dims * 2 - (i + 1) * 2 + 1);
     normalized_pad_widths.push_back(maybeCastOp(DataType::Index, left_pad));
@@ -530,7 +530,7 @@ TensorView* pad(
   // Indicates if any dimension is actually padded. Can be false even
   // when non-empty padding width vector is passed
   bool is_padded_any = false;
-  for (const auto idx : std::views::iota((size_t)0, ndims)) {
+  for (const auto idx : irange(ndims)) {
     auto inp_root_id = inp_dom.at(idx);
     IterDomain* out_root_id = nullptr;
     IterDomain* out_rf_id = nullptr;
@@ -621,7 +621,7 @@ TensorView* cat(
 
   Val* concat_ext = nullptr;
 
-  for (const auto i : std::views::iota((size_t)0, inputs.size())) {
+  for (const auto i : irange(inputs.size())) {
     auto input_dim_extent =
         inp_doms.at(i).at(cat_dim)->getMaybeExpandedExtent();
     concat_ext = SimplifyingIrBuilder::addExpr(concat_ext, input_dim_extent);
@@ -634,10 +634,10 @@ TensorView* cat(
   Val* left_pad = FusionGuard::getCurFusion()->zeroVal();
   Val* right_pad = concat_ext;
   std::vector<Val*> resized_inputs(inputs.size());
-  for (const auto input_idx : std::views::iota((size_t)0, inputs.size())) {
+  for (const auto input_idx : irange(inputs.size())) {
     const auto& inp_dom = inp_doms.at(input_idx);
     std::vector<Val*> pad_widths(ndims * 2);
-    for (const auto dim : std::views::iota((int64_t)0, ndims)) {
+    for (const auto dim : irange(ndims)) {
       auto inp_root_id = inp_dom.at(dim);
       Val* left_pad_i = nullptr;
       Val* right_pad_i = nullptr;
@@ -763,7 +763,7 @@ TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges) {
   std::vector<Slice> normalized_ranges(ndims);
 
   bool needs_real_slicing = false;
-  for (const auto idx : std::views::iota(0, ndims)) {
+  for (const auto idx : irange(ndims)) {
     auto inp_root_id = inp_dom[idx];
     auto range = normalize_slice_range(ranges.at(idx), inp_root_id->extent());
     normalized_ranges.at(idx) = range;

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -19,7 +19,7 @@
 #include <type.h>
 #include <type_promotion.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <cfloat>
 
 namespace nvfuser {
@@ -1078,7 +1078,7 @@ static TensorView* newForReduction(
       "). Keep in mind reductions are relative to root domains, not modified views.");
 
   auto axis_iter = axes_set.begin();
-  for (const auto dim : std::views::iota((size_t)0, orig_domain.size())) {
+  for (const auto dim : irange(orig_domain.size())) {
     bool isReduction = false;
     if (axis_iter != axes_set.end() && *axis_iter == dim) {
       isReduction = true;
@@ -1218,7 +1218,7 @@ TensorView* maybeFullInsteadOfReduction(
       std::vector<IterDomain*> new_root;
       new_root.reserve(keep_dim ? ndims : ndims - axes.size());
       int cur_pos = 0;
-      for (auto j : std::views::iota((size_t)0, ndims)) {
+      for (auto j : irange(ndims)) {
         bool is_reduction = cur_pos < (int)axes.size() && axes.at(cur_pos) == j;
         if (is_reduction) {
           cur_pos++;
@@ -1464,7 +1464,7 @@ TensorView* expand(TensorView* inp, const std::vector<Val*>& expanded_sizes) {
   bool expanded = false;
 
   std::vector<IterDomain*> out_domain;
-  for (auto i : std::views::iota((size_t)0, inp_domain.size())) {
+  for (auto i : irange(inp_domain.size())) {
     auto inp_id = inp_domain[i];
     auto out_id_builder = IterDomainBuilder(inp_id);
     maybe_expanded_sizes[i] = inp_domain[i]->extent();
@@ -1537,7 +1537,7 @@ TensorView* expand_as(TensorView* inp, TensorView* other) {
   std::vector<IterDomain*> out_domain;
   std::vector<Val*> maybe_expanded_sizes;
   bool expanded = false;
-  for (auto i : std::views::iota((size_t)0, inp_domain.size())) {
+  for (auto i : irange(inp_domain.size())) {
     auto inp_id = inp_domain[i];
     auto other_id = other_domain[i];
 
@@ -1583,7 +1583,7 @@ std::vector<Val*> tensor_sizes(TensorView* inp) {
   auto iter_domains = TensorDomain::noReductions(inp->getMaybeRFactorDomain());
   std::vector<Val*> sizes(iter_domains.size(), nullptr);
 
-  for (auto idx : std::views::iota((size_t)0, iter_domains.size())) {
+  for (auto idx : irange(iter_domains.size())) {
     sizes[idx] = iter_domains[idx]->getMaybeExpandedExtent();
   }
 
@@ -2146,7 +2146,7 @@ TensorView* shift(TensorView* inp, const std::vector<int>& offsets, bool pad) {
   // input domains.
   std::vector<int> pad_width(offsets.size(), 0);
   if (pad) {
-    for (const auto i : std::views::iota((size_t)0, offsets.size())) {
+    for (const auto i : irange(offsets.size())) {
       pad_width[i] = std::abs(offsets[i]);
     }
   }
@@ -2190,7 +2190,7 @@ TensorView* shift(
   TensorView* out = nullptr;
 
   std::vector<IterDomain*> out_dom;
-  for (const auto i : std::views::iota((size_t)0, ndims)) {
+  for (const auto i : irange(ndims)) {
     const auto inp_axis = inp_dom[i];
     const auto offset = offsets[i];
     const auto pad = pad_width[i];
@@ -2293,7 +2293,7 @@ TensorDomain* generateTensorDomainWithStrides(
         TensorDomain::getContiguityFilledWith(root_domains, true));
   }
 
-  for (const auto i : std::views::iota((size_t)0, root_domains.size())) {
+  for (const auto i : irange(root_domains.size())) {
     auto root_dom = root_domains.at(i);
 
     if (i >= strides.size() || (skip_unit_stride && strides[i] == 1)) {
@@ -2369,7 +2369,7 @@ TensorView* gather(
   std::vector<IterDomain*> out_root_domains;
   std::vector<IterDomain*> out_gather_dom;
 
-  for (const auto i : std::views::iota((size_t)0, ndims)) {
+  for (const auto i : irange(ndims)) {
     const auto inp_axis = inp_dom[i];
     const auto window_dim = window_shape[i];
     const auto pad_left = pad_width[i][0];
@@ -2493,7 +2493,7 @@ static TensorView* newForMma(
       "). Keep in mind reductions are relative to root domains, not modified views.");
 
   auto axis_iter = axes_set.begin();
-  for (const auto dim : std::views::iota((size_t)0, orig_domain_a.size())) {
+  for (const auto dim : irange(orig_domain_a.size())) {
     bool isReduction = false;
     if (axis_iter != axes_set.end() && *axis_iter == dim) {
       isReduction = true;

--- a/csrc/ops/indexing.cpp
+++ b/csrc/ops/indexing.cpp
@@ -18,7 +18,7 @@
 #include <c10/util/Exception.h>
 #include <c10/util/Half.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -41,7 +41,7 @@ TensorView* select(TensorView* tv, int dim, Val* index) {
       dom.size(),
       " non-reduction dims.");
 
-  for (auto i : std::views::iota((size_t)0, dom.size())) {
+  for (auto i : irange(dom.size())) {
     if ((int)i != dim) {
       new_root.emplace_back(dom[i]->cloneWithoutRFactor());
     }
@@ -86,7 +86,7 @@ TensorView* index_select(TensorView* lookup_tv, int dim, TensorView* index_tv) {
       lookup_dom.size(),
       " non-reduction dims.");
 
-  for (auto i : std::views::iota((size_t)0, lookup_dom.size())) {
+  for (auto i : irange(lookup_dom.size())) {
     if ((int)i != dim) {
       new_root.emplace_back(lookup_dom[i]->cloneWithoutRFactor());
     } else {
@@ -174,7 +174,7 @@ TensorView* scatterOp(
 
   // The shape of output tensor is same as self tensor.
   std::vector<IterDomain*> out_domain;
-  for (const auto i : std::views::iota((size_t)0, self_dom.size())) {
+  for (const auto i : irange(self_dom.size())) {
     out_domain.push_back(
         IterDomainBuilder(self_dom[i])
             .iter_type(
@@ -227,7 +227,7 @@ TensorView* take_along_axis(TensorView* inp, TensorView* index, int64_t dim) {
 
   std::vector<IterDomain*> out_domain(idx_domain.size());
 
-  for (const auto i : std::views::iota((size_t)0, idx_domain.size())) {
+  for (const auto i : irange(idx_domain.size())) {
     auto inp_id = inp_domain.at(i);
     auto idx_id = idx_domain.at(i);
 

--- a/csrc/ops/indexing.cpp
+++ b/csrc/ops/indexing.cpp
@@ -17,7 +17,8 @@
 #include <c10/util/BFloat16.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Half.h>
-#include <c10/util/irange.h>
+
+#include <C++20/ranges>
 
 namespace nvfuser {
 
@@ -40,7 +41,7 @@ TensorView* select(TensorView* tv, int dim, Val* index) {
       dom.size(),
       " non-reduction dims.");
 
-  for (auto i : c10::irange(dom.size())) {
+  for (auto i : std::views::iota((size_t)0, dom.size())) {
     if ((int)i != dim) {
       new_root.emplace_back(dom[i]->cloneWithoutRFactor());
     }
@@ -85,7 +86,7 @@ TensorView* index_select(TensorView* lookup_tv, int dim, TensorView* index_tv) {
       lookup_dom.size(),
       " non-reduction dims.");
 
-  for (auto i : c10::irange(lookup_dom.size())) {
+  for (auto i : std::views::iota((size_t)0, lookup_dom.size())) {
     if ((int)i != dim) {
       new_root.emplace_back(lookup_dom[i]->cloneWithoutRFactor());
     } else {
@@ -173,7 +174,7 @@ TensorView* scatterOp(
 
   // The shape of output tensor is same as self tensor.
   std::vector<IterDomain*> out_domain;
-  for (const auto i : c10::irange(self_dom.size())) {
+  for (const auto i : std::views::iota((size_t)0, self_dom.size())) {
     out_domain.push_back(
         IterDomainBuilder(self_dom[i])
             .iter_type(
@@ -226,7 +227,7 @@ TensorView* take_along_axis(TensorView* inp, TensorView* index, int64_t dim) {
 
   std::vector<IterDomain*> out_domain(idx_domain.size());
 
-  for (const auto i : c10::irange(idx_domain.size())) {
+  for (const auto i : std::views::iota((size_t)0, idx_domain.size())) {
     auto inp_id = inp_domain.at(i);
     auto idx_id = idx_domain.at(i);
 

--- a/csrc/ops/normalization.cpp
+++ b/csrc/ops/normalization.cpp
@@ -9,7 +9,7 @@
 #include <ops/arith.h>
 #include <ops/normalization.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -253,13 +253,13 @@ auto norm_properties_from_num_dims(
   std::vector<int> inner_reduction_axes(kNormShapeNumDims);
   std::vector<bool> inner_broadcast_mask(kNumberOfDims, false);
 
-  for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
+  for (const auto idx : irange(kOuterNumDims)) {
     outer_reduction_axes[idx] = (int)idx;
     outer_broadcast_mask[idx] = true;
   }
 
   Val* num_features = IrBuilder::create<Val>(x->container(), 1.0);
-  for (const auto idx : std::views::iota((size_t)0, kNormShapeNumDims)) {
+  for (const auto idx : irange(kNormShapeNumDims)) {
     const size_t axis = kNumberOfDims - 1 - idx;
     inner_reduction_axes[idx] = (int)axis;
     inner_broadcast_mask[axis] = true;
@@ -506,7 +506,7 @@ ForwardNormResult batch_norm(
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   Val* num_features = IrBuilder::create<Val>(x->container(), 1.0);
 
-  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
+  for (const auto axis : irange(kNumberOfDims)) {
     if (axis != c_axis) {
       reduction_axes.push_back((int)axis);
       broadcast_mask[axis] = true;
@@ -649,7 +649,7 @@ BackwardNormResult batch_norm_backward(
   std::vector<int> reduction_axes;
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   Val* num_features = nullptr;
-  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
+  for (const auto axis : irange(kNumberOfDims)) {
     if (axis != c_axis) {
       reduction_axes.push_back((int)axis);
       broadcast_mask[axis] = true;
@@ -756,7 +756,7 @@ ForwardNormResult instance_norm(
   std::vector<int> x_reduction_axes;
   std::vector<bool> x_broadcast_mask(kNumberOfDims, false);
   Val* N = IrBuilder::create<Val>(x->container(), 1.0);
-  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
+  for (const auto axis : irange(kNumberOfDims)) {
     if (axis != kBatchDim && axis != kChannelsDim) {
       x_reduction_axes.push_back((int)axis);
       x_broadcast_mask[axis] = true;
@@ -767,7 +767,7 @@ ForwardNormResult instance_norm(
   B = mul(B, x->getLeafDomain()[kBatchDim]->extent());
 
   std::vector<bool> channels_only_broadcast_mask(kNumberOfDims, false);
-  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
+  for (const auto axis : irange(kNumberOfDims)) {
     if (axis != kChannelsDim) {
       channels_only_broadcast_mask[axis] = true;
     }
@@ -908,7 +908,7 @@ BackwardNormResult instance_norm_backward(
   // mean/var
   std::vector<bool> weight_broadcast_mask(kNumberOfDims, false);
   Val* num_features = nullptr;
-  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
+  for (const auto axis : irange(kNumberOfDims)) {
     if (axis != c_axis) {
       weight_broadcast_mask[axis] = true;
       if (axis != b_axis) {

--- a/csrc/ops/normalization.cpp
+++ b/csrc/ops/normalization.cpp
@@ -9,6 +9,8 @@
 #include <ops/arith.h>
 #include <ops/normalization.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 int nonNegativeAxis(int axis, size_t ndims) {
@@ -251,13 +253,13 @@ auto norm_properties_from_num_dims(
   std::vector<int> inner_reduction_axes(kNormShapeNumDims);
   std::vector<bool> inner_broadcast_mask(kNumberOfDims, false);
 
-  for (const auto idx : c10::irange(kOuterNumDims)) {
+  for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
     outer_reduction_axes[idx] = (int)idx;
     outer_broadcast_mask[idx] = true;
   }
 
   Val* num_features = IrBuilder::create<Val>(x->container(), 1.0);
-  for (const auto idx : c10::irange(kNormShapeNumDims)) {
+  for (const auto idx : std::views::iota((size_t)0, kNormShapeNumDims)) {
     const size_t axis = kNumberOfDims - 1 - idx;
     inner_reduction_axes[idx] = (int)axis;
     inner_broadcast_mask[axis] = true;
@@ -504,7 +506,7 @@ ForwardNormResult batch_norm(
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   Val* num_features = IrBuilder::create<Val>(x->container(), 1.0);
 
-  for (const auto axis : c10::irange(kNumberOfDims)) {
+  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
     if (axis != c_axis) {
       reduction_axes.push_back((int)axis);
       broadcast_mask[axis] = true;
@@ -647,7 +649,7 @@ BackwardNormResult batch_norm_backward(
   std::vector<int> reduction_axes;
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   Val* num_features = nullptr;
-  for (const auto axis : c10::irange(kNumberOfDims)) {
+  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
     if (axis != c_axis) {
       reduction_axes.push_back((int)axis);
       broadcast_mask[axis] = true;
@@ -754,7 +756,7 @@ ForwardNormResult instance_norm(
   std::vector<int> x_reduction_axes;
   std::vector<bool> x_broadcast_mask(kNumberOfDims, false);
   Val* N = IrBuilder::create<Val>(x->container(), 1.0);
-  for (const auto axis : c10::irange(kNumberOfDims)) {
+  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
     if (axis != kBatchDim && axis != kChannelsDim) {
       x_reduction_axes.push_back((int)axis);
       x_broadcast_mask[axis] = true;
@@ -765,7 +767,7 @@ ForwardNormResult instance_norm(
   B = mul(B, x->getLeafDomain()[kBatchDim]->extent());
 
   std::vector<bool> channels_only_broadcast_mask(kNumberOfDims, false);
-  for (const auto axis : c10::irange(kNumberOfDims)) {
+  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
     if (axis != kChannelsDim) {
       channels_only_broadcast_mask[axis] = true;
     }
@@ -906,7 +908,7 @@ BackwardNormResult instance_norm_backward(
   // mean/var
   std::vector<bool> weight_broadcast_mask(kNumberOfDims, false);
   Val* num_features = nullptr;
-  for (const auto axis : c10::irange(kNumberOfDims)) {
+  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
     if (axis != c_axis) {
       weight_broadcast_mask[axis] = true;
       if (axis != b_axis) {

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -11,6 +11,7 @@
 
 #include <c10/util/Exception.h>
 
+#include <C++20/ranges>
 #include <algorithm>
 #include <limits>
 
@@ -213,7 +214,7 @@ std::vector<IterDomain*> newOutputDomain(
         dom.size(),
         " dimensions but expected ",
         out_domain.size());
-    for (const auto i : c10::irange(dom.size())) {
+    for (const auto i : std::views::iota((size_t)0, dom.size())) {
       if (dom[i]->isBroadcast()) {
         if (dom[i]->hasExpandedExtent()) {
           expanded_extent_vals[i] =
@@ -245,7 +246,7 @@ std::vector<IterDomain*> newOutputDomain(
       stop_offsets[i] = std::max(stop_offsets[i], stop_offset->evaluateInt());
     }
   }
-  for (const auto dim_i : c10::irange(out_domain.size())) {
+  for (const auto dim_i : std::views::iota((size_t)0, out_domain.size())) {
     if (extent_vals[dim_i] != nullptr) {
       NVF_ERROR(
           iter_types[dim_i].has_value(),
@@ -292,7 +293,7 @@ std::vector<Val*> maybeBroadcast(const std::vector<Val*>& vals) {
     }
   }
 
-  for (const auto i : c10::irange(vals.size())) {
+  for (const auto i : std::views::iota((size_t)0, vals.size())) {
     if (vals[i]->getValType().value() == ValType::TensorView) {
       auto tv = vals[i]->as<TensorView>();
       out_vals[i] = maybe_broadcast_inner_to_rank(tv, n_dims);

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -11,7 +11,7 @@
 
 #include <c10/util/Exception.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <limits>
 
@@ -214,7 +214,7 @@ std::vector<IterDomain*> newOutputDomain(
         dom.size(),
         " dimensions but expected ",
         out_domain.size());
-    for (const auto i : std::views::iota((size_t)0, dom.size())) {
+    for (const auto i : irange(dom.size())) {
       if (dom[i]->isBroadcast()) {
         if (dom[i]->hasExpandedExtent()) {
           expanded_extent_vals[i] =
@@ -246,7 +246,7 @@ std::vector<IterDomain*> newOutputDomain(
       stop_offsets[i] = std::max(stop_offsets[i], stop_offset->evaluateInt());
     }
   }
-  for (const auto dim_i : std::views::iota((size_t)0, out_domain.size())) {
+  for (const auto dim_i : irange(out_domain.size())) {
     if (extent_vals[dim_i] != nullptr) {
       NVF_ERROR(
           iter_types[dim_i].has_value(),
@@ -293,7 +293,7 @@ std::vector<Val*> maybeBroadcast(const std::vector<Val*>& vals) {
     }
   }
 
-  for (const auto i : std::views::iota((size_t)0, vals.size())) {
+  for (const auto i : irange(vals.size())) {
     if (vals[i]->getValType().value() == ValType::TensorView) {
       auto tv = vals[i]->as<TensorView>();
       out_vals[i] = maybe_broadcast_inner_to_rank(tv, n_dims);

--- a/csrc/optimization/remove_empty.cpp
+++ b/csrc/optimization/remove_empty.cpp
@@ -12,7 +12,7 @@
 #include <ops/alias.h>
 #include <ops/arith.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <limits>
 #include <unordered_set>
@@ -27,7 +27,7 @@ namespace {
 //! `emptyAxes(TensorDomain::noReductions(tv->getMaybeRFactorDomain()))`
 std::vector<int64_t> emptyAxes(const std::vector<IterDomain*>& domain) {
   std::vector<int64_t> empty_axes;
-  for (auto ax : std::views::iota((size_t)0, domain.size())) {
+  for (auto ax : irange(domain.size())) {
     auto id = domain.at(ax);
     if (id->getMaybeExpandedExtent()->isConst() &&
         id->getMaybeExpandedExtent()->evaluateInt() == 0) {

--- a/csrc/optimization/remove_empty.cpp
+++ b/csrc/optimization/remove_empty.cpp
@@ -12,6 +12,7 @@
 #include <ops/alias.h>
 #include <ops/arith.h>
 
+#include <C++20/ranges>
 #include <algorithm>
 #include <limits>
 #include <unordered_set>
@@ -26,7 +27,7 @@ namespace {
 //! `emptyAxes(TensorDomain::noReductions(tv->getMaybeRFactorDomain()))`
 std::vector<int64_t> emptyAxes(const std::vector<IterDomain*>& domain) {
   std::vector<int64_t> empty_axes;
-  for (auto ax : c10::irange(domain.size())) {
+  for (auto ax : std::views::iota((size_t)0, domain.size())) {
     auto id = domain.at(ax);
     if (id->getMaybeExpandedExtent()->isConst() &&
         id->getMaybeExpandedExtent()->evaluateInt() == 0) {

--- a/csrc/parser.cpp
+++ b/csrc/parser.cpp
@@ -24,6 +24,7 @@
 
 #include <c10/util/CallOnce.h>
 
+#include <C++20/ranges>
 #include <complex>
 #include <unordered_map>
 #include <utility>
@@ -231,7 +232,7 @@ struct MemoryFormat {
     permuted_order_ = stride_order;
     bool has_permutation = false;
     permutation_ = 0;
-    for (const auto i : c10::irange(rank)) {
+    for (const auto i : std::views::iota((size_t)0, rank)) {
       permutation_ = permutation_ * 10 + stride_order[i];
       if (!has_permutation && stride_order[i] != (int)rank - 1 - (int)i) {
         has_permutation = true;
@@ -347,7 +348,7 @@ struct MemoryFormat {
     auto rank = permuted_order_.size();
 
     if (rank > 2 && permuted_order_[0] == 1 && permuted_order_[rank - 1] == 0) {
-      for (const auto i : c10::irange(rank - 2)) {
+      for (const auto i : std::views::iota((size_t)0, rank - 2)) {
         if (permuted_order_[i + 1] != (int)rank - 1 - (int)i) {
           return false;
         }
@@ -375,7 +376,7 @@ struct MemoryFormat {
     if (hasPermutation()) {
       auto rank = permuted_order_.size();
       ret.resize(rank);
-      for (const auto i : c10::irange(rank)) {
+      for (const auto i : std::views::iota((size_t)0, rank)) {
         ret[permuted_order_[i]] = (int64_t)rank - 1 - (int64_t)i;
       }
     }
@@ -787,13 +788,14 @@ class IrParser {
       }
     }
 
-    for (const auto& i : c10::irange(fusion->inputs().size())) {
+    for (const auto& i : std::views::iota((size_t)0, fusion->inputs().size())) {
       const auto& entry = permuted_tensors.find(fusion->inputs()[i]);
       if (entry != permuted_tensors.end()) {
         fusion->setPermutationOnInput((int)i, entry->second.apply());
       }
     }
-    for (const auto& i : c10::irange(fusion->outputs().size())) {
+    for (const auto& i :
+         std::views::iota((size_t)0, fusion->outputs().size())) {
       const auto& entry = permuted_tensors.find(fusion->outputs()[i]);
       if (entry != permuted_tensors.end()) {
         fusion->setPermutationOnOutput((int)i, entry->second.restore());
@@ -3718,7 +3720,7 @@ class IrParser {
 
       MemoryFormat format;
       std::vector<int> stride_index;
-      for (const auto i : c10::irange(n_dim)) {
+      for (const auto i : std::views::iota((size_t)0, n_dim)) {
         const auto& stride_property_i = tensor_type->stride_properties()[i];
         if (stride_property_i->stride_index_.has_value()) {
           stride_index.emplace_back(stride_property_i->stride_index_.value());
@@ -3737,7 +3739,7 @@ class IrParser {
         std::vector<c10::ShapeSymbol> s_vec = opt_s_vec.value();
         // apply permutation
         auto permutation = format.apply();
-        for (auto new_axis : c10::irange(permutation.size())) {
+        for (auto new_axis : std::views::iota((size_t)0, permutation.size())) {
           auto old_axis = permutation.at(new_axis);
           s_vec[new_axis] = opt_s_vec.value()[old_axis];
         }
@@ -3750,7 +3752,7 @@ class IrParser {
         // Note that we are only updating stride_properties.stride_index, since
         // contiguous_ and stride_ value should remain the same after
         // permutation
-        for (const auto i : c10::irange(n_dim)) {
+        for (const auto i : std::views::iota((size_t)0, n_dim)) {
           nhwc_stride_vec[i]->stride_index_ = n_dim - i - 1;
         }
 
@@ -4704,7 +4706,7 @@ void insertProfileNodesForCUDAFuser_(
     torch::jit::Block* block,
     torch::jit::ProfilingRecord* pr) {
   for (const auto& n : block->nodes()) {
-    for (const auto offset : c10::irange(n->inputs().size())) {
+    for (const auto offset : std::views::iota((size_t)0, n->inputs().size())) {
       insertProfileIValue(pr, n, offset);
     }
 

--- a/csrc/parser.cpp
+++ b/csrc/parser.cpp
@@ -24,7 +24,7 @@
 
 #include <c10/util/CallOnce.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <complex>
 #include <unordered_map>
 #include <utility>
@@ -232,7 +232,7 @@ struct MemoryFormat {
     permuted_order_ = stride_order;
     bool has_permutation = false;
     permutation_ = 0;
-    for (const auto i : std::views::iota((size_t)0, rank)) {
+    for (const auto i : irange(rank)) {
       permutation_ = permutation_ * 10 + stride_order[i];
       if (!has_permutation && stride_order[i] != (int)rank - 1 - (int)i) {
         has_permutation = true;
@@ -348,7 +348,7 @@ struct MemoryFormat {
     auto rank = permuted_order_.size();
 
     if (rank > 2 && permuted_order_[0] == 1 && permuted_order_[rank - 1] == 0) {
-      for (const auto i : std::views::iota((size_t)0, rank - 2)) {
+      for (const auto i : irange(rank - 2)) {
         if (permuted_order_[i + 1] != (int)rank - 1 - (int)i) {
           return false;
         }
@@ -376,7 +376,7 @@ struct MemoryFormat {
     if (hasPermutation()) {
       auto rank = permuted_order_.size();
       ret.resize(rank);
-      for (const auto i : std::views::iota((size_t)0, rank)) {
+      for (const auto i : irange(rank)) {
         ret[permuted_order_[i]] = (int64_t)rank - 1 - (int64_t)i;
       }
     }
@@ -788,14 +788,13 @@ class IrParser {
       }
     }
 
-    for (const auto& i : std::views::iota((size_t)0, fusion->inputs().size())) {
+    for (const auto& i : irange(fusion->inputs().size())) {
       const auto& entry = permuted_tensors.find(fusion->inputs()[i]);
       if (entry != permuted_tensors.end()) {
         fusion->setPermutationOnInput((int)i, entry->second.apply());
       }
     }
-    for (const auto& i :
-         std::views::iota((size_t)0, fusion->outputs().size())) {
+    for (const auto& i : irange(fusion->outputs().size())) {
       const auto& entry = permuted_tensors.find(fusion->outputs()[i]);
       if (entry != permuted_tensors.end()) {
         fusion->setPermutationOnOutput((int)i, entry->second.restore());
@@ -3720,7 +3719,7 @@ class IrParser {
 
       MemoryFormat format;
       std::vector<int> stride_index;
-      for (const auto i : std::views::iota((size_t)0, n_dim)) {
+      for (const auto i : irange(n_dim)) {
         const auto& stride_property_i = tensor_type->stride_properties()[i];
         if (stride_property_i->stride_index_.has_value()) {
           stride_index.emplace_back(stride_property_i->stride_index_.value());
@@ -3739,7 +3738,7 @@ class IrParser {
         std::vector<c10::ShapeSymbol> s_vec = opt_s_vec.value();
         // apply permutation
         auto permutation = format.apply();
-        for (auto new_axis : std::views::iota((size_t)0, permutation.size())) {
+        for (auto new_axis : irange(permutation.size())) {
           auto old_axis = permutation.at(new_axis);
           s_vec[new_axis] = opt_s_vec.value()[old_axis];
         }
@@ -3752,7 +3751,7 @@ class IrParser {
         // Note that we are only updating stride_properties.stride_index, since
         // contiguous_ and stride_ value should remain the same after
         // permutation
-        for (const auto i : std::views::iota((size_t)0, n_dim)) {
+        for (const auto i : irange(n_dim)) {
           nhwc_stride_vec[i]->stride_index_ = n_dim - i - 1;
         }
 
@@ -4706,7 +4705,7 @@ void insertProfileNodesForCUDAFuser_(
     torch::jit::Block* block,
     torch::jit::ProfilingRecord* pr) {
   for (const auto& n : block->nodes()) {
-    for (const auto offset : std::views::iota((size_t)0, n->inputs().size())) {
+    for (const auto offset : irange(n->inputs().size())) {
       insertProfileIValue(pr, n, offset);
     }
 

--- a/csrc/partition.cpp
+++ b/csrc/partition.cpp
@@ -9,12 +9,13 @@
 
 #include <ATen/core/jit_type.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/util/irange.h>
 #include <instrumentation.h>
 #include <options.h>
 #include <parser.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <utils.h>
+
+#include <C++20/ranges>
 
 namespace nvfuser {
 
@@ -199,7 +200,7 @@ bool compatibleType(const torch::jit::Value* val) {
 }
 
 bool checkInputTensorTypes(const torch::jit::Node* node) {
-  for (const auto i : c10::irange(node->inputs().size())) {
+  for (const auto i : std::views::iota((size_t)0, node->inputs().size())) {
     if (!compatibleType(node->inputs().at(i))) {
       // special case on aten::_batch_norm_impl_index_backward, the 11th output
       // is going to be discarded, so no need to check data type there.
@@ -216,7 +217,7 @@ bool checkInputTensorTypes(const torch::jit::Node* node) {
 }
 
 bool checkOutputTensorTypes(const torch::jit::Node* node) {
-  for (const auto i : c10::irange(node->outputs().size())) {
+  for (const auto i : std::views::iota((size_t)0, node->outputs().size())) {
     if (!compatibleType(node->outputs().at(i))) {
       // special case on aten::_batch_norm_impl_index, the 4th output
       // is going to be discarded, so no need to check data type there.

--- a/csrc/partition.cpp
+++ b/csrc/partition.cpp
@@ -15,7 +15,7 @@
 #include <torch/csrc/jit/jit_log.h>
 #include <utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -200,7 +200,7 @@ bool compatibleType(const torch::jit::Value* val) {
 }
 
 bool checkInputTensorTypes(const torch::jit::Node* node) {
-  for (const auto i : std::views::iota((size_t)0, node->inputs().size())) {
+  for (const auto i : irange(node->inputs().size())) {
     if (!compatibleType(node->inputs().at(i))) {
       // special case on aten::_batch_norm_impl_index_backward, the 11th output
       // is going to be discarded, so no need to check data type there.
@@ -217,7 +217,7 @@ bool checkInputTensorTypes(const torch::jit::Node* node) {
 }
 
 bool checkOutputTensorTypes(const torch::jit::Node* node) {
-  for (const auto i : std::views::iota((size_t)0, node->outputs().size())) {
+  for (const auto i : irange(node->outputs().size())) {
     if (!compatibleType(node->outputs().at(i))) {
       // special case on aten::_batch_norm_impl_index, the 4th output
       // is going to be discarded, so no need to check data type there.

--- a/csrc/partition.cpp
+++ b/csrc/partition.cpp
@@ -234,8 +234,9 @@ bool checkOutputTensorTypes(const torch::jit::Node* node) {
 
 inline bool isFusibleNode(const torch::jit::Node* node) {
   // Check if already part of a fusion group
-  if (node->kind() == at::prim::CudaFusionGroup)
+  if (node->kind() == at::prim::CudaFusionGroup) {
     return true;
+  }
   // Check we have a parsing rule
   if (!isNodeParsible(node)) {
     // ignoring profile nodes & constant nodes to avoid noise from debugging

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -16,8 +16,9 @@
 #include <ops/arith.h>
 #include <transform_iter.h>
 
-#include <c10/util/irange.h>
 #include <device_lower/utils.h>
+
+#include <C++20/ranges>
 
 namespace nvfuser {
 
@@ -146,7 +147,7 @@ ParallelizedDomainPredicate::getPredicateMap(
   bool within_unswitch = false;
   std::unordered_set<Val*> non_unswitched_root_domains;
 
-  for (const auto i : c10::irange(loops.size())) {
+  for (const auto i : std::views::iota((size_t)0, loops.size())) {
     auto loop = loops[i];
 
     // Parallel dimensions need not be predicated if fully unswitched.
@@ -424,7 +425,7 @@ Val* PredicateCompute::getInlinePredicate(
   }
 
   Val* cond = preds[0];
-  for (const auto i : c10::irange(1, preds.size())) {
+  for (const auto i : std::views::iota((size_t)1, preds.size())) {
     cond = SimplifyingIrBuilder::logicalAndExpr(cond, preds[i]);
   }
 

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -18,7 +18,7 @@
 
 #include <device_lower/utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -147,7 +147,7 @@ ParallelizedDomainPredicate::getPredicateMap(
   bool within_unswitch = false;
   std::unordered_set<Val*> non_unswitched_root_domains;
 
-  for (const auto i : std::views::iota((size_t)0, loops.size())) {
+  for (const auto i : irange(loops.size())) {
     auto loop = loops[i];
 
     // Parallel dimensions need not be predicated if fully unswitched.

--- a/csrc/python_frontend/fusion_cache.cpp
+++ b/csrc/python_frontend/fusion_cache.cpp
@@ -12,7 +12,7 @@
 #include <serde/fusion_record_serde.h>
 #include <utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <filesystem>
 
 namespace fs = std::filesystem;
@@ -524,7 +524,7 @@ void FusionCache::deserialize(std::string filename) {
   }
 
   // Deserialize terminal_nodes field in the FusionCache table
-  for (auto idx : std::views::iota((size_t)0, fusions_.size())) {
+  for (auto idx : irange(fusions_.size())) {
     auto node_idx = fusion_cache_buffer->terminal_nodes()->Get(idx);
     auto trie_node = bfs_order.at(node_idx);
     terminal_nodes_.push_back(trie_node);

--- a/csrc/python_frontend/fusion_cache.cpp
+++ b/csrc/python_frontend/fusion_cache.cpp
@@ -12,7 +12,9 @@
 #include <serde/fusion_record_serde.h>
 #include <utils.h>
 
+#include <C++20/ranges>
 #include <filesystem>
+
 namespace fs = std::filesystem;
 
 namespace nvfuser::python_frontend {
@@ -522,7 +524,7 @@ void FusionCache::deserialize(std::string filename) {
   }
 
   // Deserialize terminal_nodes field in the FusionCache table
-  for (auto idx : c10::irange(fusions_.size())) {
+  for (auto idx : std::views::iota((size_t)0, fusions_.size())) {
     auto node_idx = fusion_cache_buffer->terminal_nodes()->Get(idx);
     auto trie_node = bfs_order.at(node_idx);
     terminal_nodes_.push_back(trie_node);

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -19,7 +19,7 @@
 #include <serde/utils.h>
 #include <utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <complex>
 #include <variant>
@@ -586,7 +586,7 @@ struct DimsOpRecord : RecordFunctor {
       auto output = set(arg);
       int rank = static_cast<int>(dims_.size());
       std::vector<IterDomain*> allocation_domain(rank);
-      for (int i : std::views::iota(0, rank)) {
+      for (int i : irange(rank)) {
         allocation_domain[rank - 1 - static_cast<int>(dims_[i])] =
             output->axis(i);
       }
@@ -819,7 +819,7 @@ struct BroadcastInDimOpRecord : RecordFunctor {
         broadcast_dims_.size());
 
     std::vector<bool> is_broadcast_dim(output_ndims_, true);
-    for (const auto idx : std::views::iota((size_t)0, broadcast_dims_.size())) {
+    for (const auto idx : irange(broadcast_dims_.size())) {
       if (idx > 0) {
         NVF_CHECK(
             broadcast_dims_[idx - 1] < broadcast_dims_[idx],
@@ -1245,7 +1245,7 @@ struct TensorRecord : RecordFunctor {
     auto rank = shape_.size();
     std::vector<bool> is_expand(rank);
 
-    for (const auto index : std::views::iota((size_t)0, rank)) {
+    for (const auto index : irange(rank)) {
       bool is_broadcast = !contiguity_[index].has_value();
       bool has_symbolic_size = (shape_[index] == -1);
       is_expand[index] = is_broadcast && has_symbolic_size;
@@ -1374,7 +1374,7 @@ struct OutputRecord : RecordFunctor {
   //! | stride_order hash                              |
   size_t hash() const final {
     size_t stride_order_hash = 0;
-    for (auto i : std::views::iota((size_t)0, stride_order_.size())) {
+    for (auto i : irange(stride_order_.size())) {
       stride_order_hash = (stride_order_hash << 4) | stride_order_[i];
     }
     return RecordFunctor::hash() | (stride_order_hash & 0xffffffff);
@@ -1422,7 +1422,7 @@ struct OutputRecord : RecordFunctor {
         if (!stride_order_.empty()) {
           size_t rank = stride_order_.size();
           std::vector<IterDomain*> allocation_domain(rank);
-          for (auto i : std::views::iota((size_t)0, rank)) {
+          for (auto i : irange(rank)) {
             allocation_domain[rank - 1 - stride_order_[i]] = tv_output->axis(i);
           }
           tv_output->setAllocationDomain(allocation_domain, true);
@@ -1505,7 +1505,7 @@ struct ReductionOpRecord : RecordFunctor {
     size_t axes_hash = 0;
     // Normally I would make a little endian hash of the axes but I do not
     // know the size of the tensor based on just the record information.
-    for (auto i : std::views::iota((size_t)0, axes_.size())) {
+    for (auto i : irange(axes_.size())) {
       axes_hash |= (1 << axes_[i]);
     }
 
@@ -1959,7 +1959,7 @@ struct SliceOpRecord : RecordFunctor {
     auto ndims = start_indices_.size();
     std::vector<Slice> ranges;
     ranges.reserve(ndims);
-    for (const auto i : std::views::iota((size_t)0, ndims)) {
+    for (const auto i : irange(ndims)) {
       Slice tmp;
       tmp.start = IrBuilder::create<nvfuser::Val>(start_indices_[i]);
       tmp.stop = IrBuilder::create<nvfuser::Val>(end_indices_[i]);
@@ -2088,7 +2088,7 @@ struct NormOpRecord : RecordFunctor {
     size_t axes_hash = 0;
     // Normally I would make a little endian hash of the axes but I do not
     // know the size of the tensor based on just the record information.
-    for (auto i : std::views::iota((size_t)0, axes_.size())) {
+    for (auto i : irange(axes_.size())) {
       axes_hash |= (1 << axes_[i]);
     }
     return result | (static_cast<size_t>(keep_dim_) << 28) |
@@ -2327,7 +2327,7 @@ struct TensorSizesRecord : RecordFunctor {
   void operator()(FusionState& fd) final {
     auto arg = fd.getFusionState(args_.at(0).index)->as<TensorView>();
     auto sizes = tensor_sizes(arg);
-    for (const auto idx : std::views::iota((size_t)0, sizes.size())) {
+    for (const auto idx : irange(sizes.size())) {
       fd.setFusionState(outputs_.at(idx).index, sizes[idx]);
     }
   }
@@ -2522,7 +2522,7 @@ struct FullOpRecord : RecordFunctor {
     auto arg = fd.getFusionState(args_.at(0).index);
 
     std::vector<Val*> nvf_shape(shape_.size(), nullptr);
-    for (const auto idx : std::views::iota((size_t)0, shape_.size())) {
+    for (const auto idx : irange(shape_.size())) {
       nvf_shape[idx] = IrBuilder::create<nvfuser::Val>(shape_.at(idx));
     }
     auto output = full(nvf_shape, arg, dtype_);

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -18,7 +18,7 @@
 #include <python_frontend/python_bindings.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <complex>
 #include <iostream>
 #include <optional>
@@ -552,7 +552,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             // Translate to TensorViewBuilder's view of the world.
             std::vector<int64_t> dim_sizes;
             dim_sizes.reserve(sizes.size());
-            for (const auto i : std::views::iota((size_t)0, sizes.size())) {
+            for (const auto i : irange(sizes.size())) {
               NVF_ERROR(
                   sizes[i] >= 0,
                   "Size of ",
@@ -2241,7 +2241,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             end_indices.size(),
             " Strides: ",
             strides.size());
-        for (const auto i : std::views::iota((size_t)0, arg.dims)) {
+        for (const auto i : irange(arg.dims)) {
           auto start_idx = start_indices[i];
           auto end_idx = end_indices[i];
           auto stride = strides[i];
@@ -2316,7 +2316,7 @@ void initNvFuserPythonBindings(PyObject* module) {
         FusionDefinition* fd = self.fusion_definition;
         std::vector<Scalar> outputs;
         std::vector<State> output_state;
-        for (const auto idx : std::views::iota((size_t)0, arg.dims)) {
+        for (const auto idx : irange(arg.dims)) {
           outputs.push_back(fd->defineScalar());
           output_state.push_back(fd->recordingState(outputs[idx]()));
         }

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -8,7 +8,6 @@
 #include <python_frontend/python_bindings.h>
 
 #include <c10/util/ArrayRef.h>
-#include <c10/util/irange.h>
 #include <instrumentation.h>
 #include <ir/all_nodes.h>
 #include <ir/builder.h>
@@ -18,6 +17,8 @@
 #include <python_frontend/fusion_record.h>
 #include <python_frontend/python_bindings.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
+
+#include <C++20/ranges>
 #include <complex>
 #include <iostream>
 #include <optional>
@@ -551,7 +552,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             // Translate to TensorViewBuilder's view of the world.
             std::vector<int64_t> dim_sizes;
             dim_sizes.reserve(sizes.size());
-            for (const auto i : c10::irange(sizes.size())) {
+            for (const auto i : std::views::iota((size_t)0, sizes.size())) {
               NVF_ERROR(
                   sizes[i] >= 0,
                   "Size of ",
@@ -2240,7 +2241,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             end_indices.size(),
             " Strides: ",
             strides.size());
-        for (const auto i : c10::irange(arg.dims)) {
+        for (const auto i : std::views::iota((size_t)0, arg.dims)) {
           auto start_idx = start_indices[i];
           auto end_idx = end_indices[i];
           auto stride = strides[i];
@@ -2315,7 +2316,7 @@ void initNvFuserPythonBindings(PyObject* module) {
         FusionDefinition* fd = self.fusion_definition;
         std::vector<Scalar> outputs;
         std::vector<State> output_state;
-        for (const auto idx : c10::irange(arg.dims)) {
+        for (const auto idx : std::views::iota((size_t)0, arg.dims)) {
           outputs.push_back(fd->defineScalar());
           output_state.push_back(fd->recordingState(outputs[idx]()));
         }

--- a/csrc/ranges.h
+++ b/csrc/ranges.h
@@ -1,0 +1,21 @@
+
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <C++20/ranges>
+
+namespace nvfuser {
+
+template <typename T>
+auto irange(T&& t) {
+  using TT = std::decay_t<T>;
+  return std::views::iota(TT(0), std::forward<T>(t));
+}
+
+} // namespace nvfuser

--- a/csrc/register_interface.cpp
+++ b/csrc/register_interface.cpp
@@ -18,7 +18,7 @@
 #include <torch/csrc/jit/runtime/profiling_record.h>
 #include <torch/csrc/jit/runtime/register_ops_utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 /*
  * Registers function pointers in interface.h
@@ -118,7 +118,7 @@ bool complyWith(
   const auto& t_sizes = tensor.sizes();
   const auto& t_strides = tensor.strides();
   int inner_dim = -1;
-  for (const auto j : std::views::iota((size_t)0, *guard_tensor_type->dim())) {
+  for (const auto j : irange(*guard_tensor_type->dim())) {
     // check b. for stride check, we go along dimensions from fastest stride to
     // slowest stride
     int sorted_index = stride_properties[j]->stride_index_
@@ -234,7 +234,7 @@ torch::jit::RegisterOperators size_eq_guard({
                   return;
                 }
 
-                for (const auto i : std::views::iota((size_t)0, inp.size())) {
+                for (const auto i : nvfuser::irange(inp.size())) {
                   if (((inp[i] == 1) != (ref[i] == 1))) {
                     ret = false;
                     break;
@@ -284,7 +284,7 @@ torch::jit::RegisterOperators reg_guard({
               return;
             }
 
-            for (const auto i : std::views::iota((size_t)0, num_inputs)) {
+            for (const auto i : nvfuser::irange(num_inputs)) {
               const c10::TensorTypePtr& guard_tensor_type =
                   types[i]->cast<at::TensorType>();
 
@@ -313,7 +313,7 @@ bool inferViewShape(
     c10::List<int64_t> view_sizes) {
   int64_t dynamic_index = -1;
   size_t view_size_num_elements = 1;
-  for (auto idx : std::views::iota((size_t)0, view_sizes.size())) {
+  for (auto idx : nvfuser::irange(view_sizes.size())) {
     if (view_sizes[idx] == -1) {
       NVF_ERROR(dynamic_index == -1, "Only one dimension can by inferred.")
       dynamic_index = (int64_t)idx;

--- a/csrc/register_interface.cpp
+++ b/csrc/register_interface.cpp
@@ -14,10 +14,11 @@
 #include <ATen/native/NonSymbolicBC.h>
 #include <ATen/native/TensorShape.h>
 #include <c10/util/CallOnce.h>
-#include <c10/util/irange.h>
 #include <torch/csrc/jit/runtime/custom_operator.h>
 #include <torch/csrc/jit/runtime/profiling_record.h>
 #include <torch/csrc/jit/runtime/register_ops_utils.h>
+
+#include <C++20/ranges>
 
 /*
  * Registers function pointers in interface.h
@@ -117,7 +118,7 @@ bool complyWith(
   const auto& t_sizes = tensor.sizes();
   const auto& t_strides = tensor.strides();
   int inner_dim = -1;
-  for (const auto j : c10::irange(*guard_tensor_type->dim())) {
+  for (const auto j : std::views::iota((size_t)0, *guard_tensor_type->dim())) {
     // check b. for stride check, we go along dimensions from fastest stride to
     // slowest stride
     int sorted_index = stride_properties[j]->stride_index_
@@ -233,7 +234,7 @@ torch::jit::RegisterOperators size_eq_guard({
                   return;
                 }
 
-                for (const auto i : c10::irange(inp.size())) {
+                for (const auto i : std::views::iota((size_t)0, inp.size())) {
                   if (((inp[i] == 1) != (ref[i] == 1))) {
                     ret = false;
                     break;
@@ -283,7 +284,7 @@ torch::jit::RegisterOperators reg_guard({
               return;
             }
 
-            for (const auto i : c10::irange(num_inputs)) {
+            for (const auto i : std::views::iota((size_t)0, num_inputs)) {
               const c10::TensorTypePtr& guard_tensor_type =
                   types[i]->cast<at::TensorType>();
 
@@ -312,7 +313,7 @@ bool inferViewShape(
     c10::List<int64_t> view_sizes) {
   int64_t dynamic_index = -1;
   size_t view_size_num_elements = 1;
-  for (auto idx : c10::irange(view_sizes.size())) {
+  for (auto idx : std::views::iota((size_t)0, view_sizes.size())) {
     if (view_sizes[idx] == -1) {
       NVF_ERROR(dynamic_index == -1, "Only one dimension can by inferred.")
       dynamic_index = (int64_t)idx;

--- a/csrc/root_domain_map.cpp
+++ b/csrc/root_domain_map.cpp
@@ -11,6 +11,7 @@
 #include <iter_visitor.h>
 #include <root_domain_map.h>
 
+#include <C++20/ranges>
 #include <sstream>
 
 namespace nvfuser {
@@ -864,7 +865,7 @@ bool ComputeAtRootDomainMapBuilder::isInvalid(
   // Next, check if any pair is invalid to map.
   const auto num_keys = domains.size();
   const std::vector<DomainKey> domains_vec({domains.begin(), domains.end()});
-  for (const auto i : c10::irange(num_keys)) {
+  for (const auto i : std::views::iota((size_t)0, num_keys)) {
     const auto& key_i = domains_vec[i];
     // If no invalid keys found for key_i, it can be skipped.
     const auto invalid_key_map_it = invalid_key_map.find(key_i);
@@ -877,7 +878,7 @@ bool ComputeAtRootDomainMapBuilder::isInvalid(
 
     // If any other key in domains is identified mappable with any of
     // the keys in this set, the mapping with key_i is invalid.
-    for (const auto j : c10::irange(i + 1, num_keys)) {
+    for (const auto j : std::views::iota(i + 1, num_keys)) {
       const auto& key_j = domains_vec[j];
       if (std::any_of(
               invalid_keys_for_i.begin(),
@@ -1117,13 +1118,13 @@ void ComputeAtRootDomainMapBuilder::handle(GatherOp* op) {
   const auto& out_root = out_td->root();
 
   // Only maps the input root axes. Do not map the new window axes.
-  for (const auto it : c10::irange(in_root.size())) {
+  for (const auto it : std::views::iota((size_t)0, in_root.size())) {
     setMaybeMapped(in_td, in_root[it], out_td, out_root[it]);
   }
 
   // Keep track of window axes so that they can be skipped when
   // mapping root domains
-  for (const auto it : c10::irange(in_root.size(), out_root.size())) {
+  for (const auto it : std::views::iota(in_root.size(), out_root.size())) {
     root_map_.window_axes_.insert(out_root[it]);
   }
 }

--- a/csrc/root_domain_map.cpp
+++ b/csrc/root_domain_map.cpp
@@ -11,7 +11,7 @@
 #include <iter_visitor.h>
 #include <root_domain_map.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <sstream>
 
 namespace nvfuser {
@@ -865,7 +865,7 @@ bool ComputeAtRootDomainMapBuilder::isInvalid(
   // Next, check if any pair is invalid to map.
   const auto num_keys = domains.size();
   const std::vector<DomainKey> domains_vec({domains.begin(), domains.end()});
-  for (const auto i : std::views::iota((size_t)0, num_keys)) {
+  for (const auto i : irange(num_keys)) {
     const auto& key_i = domains_vec[i];
     // If no invalid keys found for key_i, it can be skipped.
     const auto invalid_key_map_it = invalid_key_map.find(key_i);
@@ -1118,7 +1118,7 @@ void ComputeAtRootDomainMapBuilder::handle(GatherOp* op) {
   const auto& out_root = out_td->root();
 
   // Only maps the input root axes. Do not map the new window axes.
-  for (const auto it : std::views::iota((size_t)0, in_root.size())) {
+  for (const auto it : irange(in_root.size())) {
     setMaybeMapped(in_td, in_root[it], out_td, out_root[it]);
   }
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -18,7 +18,7 @@
 #include <executor_utils.h>
 #include "mma_type.h"
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -84,7 +84,7 @@ void moveInnerBroadcastLeft(TensorView* tv, int number_of_inner_pos = 3) {
   std::vector<int> broadcast_pos;
   std::vector<int> nonbroadcast_pos;
 
-  for (auto i : std::views::iota(0, number_of_inner_pos)) {
+  for (auto i : irange(number_of_inner_pos)) {
     auto axis_idx = i - number_of_inner_pos;
     auto id = tv->axis(axis_idx);
     if (id->isBroadcast()) {
@@ -99,7 +99,7 @@ void moveInnerBroadcastLeft(TensorView* tv, int number_of_inner_pos = 3) {
       combined_pos_vec.end(), nonbroadcast_pos.begin(), nonbroadcast_pos.end());
 
   std::unordered_map<int, int> order_map;
-  for (auto i : std::views::iota(0, number_of_inner_pos)) {
+  for (auto i : irange(number_of_inner_pos)) {
     order_map[combined_pos_vec.at(i)] = i - number_of_inner_pos;
   }
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -18,6 +18,8 @@
 #include <executor_utils.h>
 #include "mma_type.h"
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 MatmulScheduler::MatmulScheduler(
@@ -82,7 +84,7 @@ void moveInnerBroadcastLeft(TensorView* tv, int number_of_inner_pos = 3) {
   std::vector<int> broadcast_pos;
   std::vector<int> nonbroadcast_pos;
 
-  for (auto i : c10::irange(number_of_inner_pos)) {
+  for (auto i : std::views::iota(0, number_of_inner_pos)) {
     auto axis_idx = i - number_of_inner_pos;
     auto id = tv->axis(axis_idx);
     if (id->isBroadcast()) {
@@ -97,7 +99,7 @@ void moveInnerBroadcastLeft(TensorView* tv, int number_of_inner_pos = 3) {
       combined_pos_vec.end(), nonbroadcast_pos.begin(), nonbroadcast_pos.end());
 
   std::unordered_map<int, int> order_map;
-  for (auto i : c10::irange(number_of_inner_pos)) {
+  for (auto i : std::views::iota(0, number_of_inner_pos)) {
     order_map[combined_pos_vec.at(i)] = i - number_of_inner_pos;
   }
 

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -15,7 +15,7 @@
 #include <scheduler/utils.h>
 #include "mma_type.h"
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <variant>
 namespace nvfuser {
 
@@ -325,7 +325,7 @@ void makeTile(TensorView* tv, std::vector<int> tile_sizes) {
   const int64_t tile_dimension_size = (int64_t)tile_sizes.size();
 
   // Split the inner dimensions:
-  for (int64_t idx : std::views::iota((int64_t)0, tile_dimension_size)) {
+  for (int64_t idx : irange(tile_dimension_size)) {
     // Using negative indexing to accomodate potential batching
     //  dimensions on the further left. Eg.:
     //  0, 1, 2   ->         -3,-2,-1
@@ -343,7 +343,7 @@ void makeTile(TensorView* tv, std::vector<int> tile_sizes) {
 
   // Number of tiled inner dimensions after we split.
   const auto split_tile_dimension_size = 2 * tile_dimension_size;
-  for (auto idx : std::views::iota((int64_t)0, split_tile_dimension_size)) {
+  for (auto idx : irange(split_tile_dimension_size)) {
     // We want to reorder as follows:
     //           Before
     //
@@ -558,7 +558,7 @@ void checkDimSize(
   NVF_ERROR(
       axis.size() == expect.size(),
       "CheckDimSize: Mismatched axis and expect size");
-  for (auto axis_index : std::views::iota((size_t)0, axis.size())) {
+  for (auto axis_index : irange(axis.size())) {
     NVF_ERROR(
         ((axis[axis_index] + static_cast<int>(tv->nDims())) >= 0) &&
             (axis[axis_index] < (int)tv->nDims()),
@@ -636,7 +636,7 @@ void WarpMmaSwizzler::scheduleOperandRead(TensorView* tv, MmaOptions options) {
 }
 
 void WarpMmaSwizzler::setWarpMapped(TensorView* tv, int number_of_dims) {
-  for (int id : std::views::iota(0, number_of_dims)) {
+  for (int id : irange(number_of_dims)) {
     tv->axis(-id - 1)->toMmaSwizzled();
   }
 }
@@ -684,7 +684,7 @@ std::vector<IterDomain*> getMmaDomains(MmaOp* mma, MmaDimension dimension) {
 
   std::vector<IterDomain*> result;
 
-  for (auto id_idx : std::views::iota((size_t)0, a_domain.size())) {
+  for (auto id_idx : irange(a_domain.size())) {
     // checks if this id should be included in the result
     bool include_this_id = false;
     bool is_broadcast_in_a = a_domain[id_idx]->isBroadcast();
@@ -1179,7 +1179,7 @@ void WarpMmaSwizzler::scheduleVoltaM16N16K4Fp32Output(
 
   if (is_reduction && tv->definition()->isA<MmaOp>()) {
     // Set instruction loops for mma reduce output
-    for (int pos : std::views::iota(0, 5)) {
+    for (int pos : irange(5)) {
       if (!tv->axis(-pos - 1)->isThread()) {
         tv->axis(-pos - 1)->parallelize(ParallelType::Mma);
       }
@@ -1226,7 +1226,7 @@ void WarpMmaSwizzler::scheduleTuringM16N8K16MmaWarpOutput(
 
   if (is_reduction && tv->definition()->isA<MmaOp>()) {
     // Set instruction loops for mma reduce
-    for (int pos : std::views::iota(0, 4)) {
+    for (int pos : irange(4)) {
       tv->axis(-pos - 1)->parallelize(ParallelType::Mma);
     }
   }
@@ -1272,7 +1272,7 @@ void WarpMmaSwizzler::scheduleTuringM16N16K16MmaWarpOutput(
 
   if (is_reduction && tv->definition()->isA<MmaOp>()) {
     // Set instruction loops for mma reduce
-    for (int pos : std::views::iota(0, 5)) {
+    for (int pos : irange(5)) {
       tv->axis(-pos - 1)->parallelize(ParallelType::Mma);
     }
   }
@@ -1339,7 +1339,7 @@ void canonicalizeMmaTvOrdering(TensorView* tv) {
 
   int ndims = (int)tv->nDims();
 
-  for (auto idx : std::views::iota(0, ndims)) {
+  for (auto idx : irange(ndims)) {
     auto id = tv->axis(idx);
     NVF_CHECK(root_id_set.count(id), id->toString(), " not a root id.");
 

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -16,7 +16,7 @@
 
 #include <ATen/cuda/CUDAContext.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 namespace normalization_scheduler_utils {

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -14,6 +14,9 @@
 #include <utils.h>
 
 #include <ATen/cuda/CUDAContext.h>
+
+#include <C++20/ranges>
+
 namespace nvfuser {
 namespace normalization_scheduler_utils {
 
@@ -791,7 +794,7 @@ bool checkReductionPattern(
 
   // Helper function to check the pattern equivalence for a list of TensorViews
   auto checkPattern = [&](const std::vector<TensorView*>& rtvs) -> bool {
-    for (const auto it : c10::irange(1, rtvs.size())) {
+    for (const auto it : std::views::iota((size_t)1, rtvs.size())) {
       if (!registry_utils::checkPatternEquivalence(
               rtvs[it - 1], rtvs[it], root_map)) {
         scheduler_debug_utils::canScheduleRejectReason(

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -19,7 +19,7 @@
 #include <scheduler/utils.h>
 #include <scheduler/vectorize_helper.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -332,7 +332,7 @@ std::shared_ptr<PointwiseParams> getPointwiseHeuristics(
     // How much would this transfer cost if it was done as a 1-D schedule
     int64_t transfer_size_1d = 1;
 
-    for (const auto i : std::views::iota((size_t)0, ref_root.size())) {
+    for (const auto i : irange(ref_root.size())) {
       transfer_size_1d = transfer_size_1d * elem_counts[i] * dtype_sum;
     }
 
@@ -342,8 +342,7 @@ std::shared_ptr<PointwiseParams> getPointwiseHeuristics(
 
       // Don't check the inner most dimension, scheduler assumes there's always
       // an rhs
-      for (const auto break_point_i :
-           std::views::iota((size_t)0, ref_root.size())) {
+      for (const auto break_point_i : irange(ref_root.size())) {
         // If break point is incoherent with view, don't consider breaking here.
         if (!scheduler_utils::breakIsDisjoint(
                 view_disjoint_sets, (int)break_point_i)) {
@@ -372,7 +371,7 @@ std::shared_ptr<PointwiseParams> getPointwiseHeuristics(
         int64_t cur_transfer_size = 1;
         int64_t right_transfer_size = 1;
 
-        for (const auto left_i : std::views::iota((size_t)0, break_point_i)) {
+        for (const auto left_i : irange(break_point_i)) {
           cur_transfer_size =
               cur_transfer_size * elem_counts[left_i] * lhs_byte_multiple;
         }
@@ -608,7 +607,7 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
     IterDomain* rhs_id = nullptr;
     IterDomain* lhs_id = nullptr;
     auto ndims = reference_tv->nDims();
-    for (auto i : std::views::iota((size_t)0, ndims)) {
+    for (auto i : irange(ndims)) {
       // Merge from right to left
       auto pos = ndims - 1 - i;
       auto id = reference_tv->axis((int)pos);

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -17,7 +17,7 @@
 #include <scheduler/utils.h>
 #include <transform_replay.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -276,7 +276,7 @@ TensorView* scheduleReductionTV(
   if (is_outer_grid_persistence) {
     int vec_id_cur_pos = -1;
     std::unordered_map<int, int> vec_reorder_map;
-    for (const auto i : std::views::iota(0, (int)reduction_rf_tv->nDims())) {
+    for (const auto i : irange((int)reduction_rf_tv->nDims())) {
       auto id = reduction_rf_tv->axis(i);
       if (id->getParallelType() == ParallelType::Vectorize) {
         vec_id_cur_pos = i;
@@ -303,7 +303,7 @@ std::vector<int> addBackBroadcasts(
   // convert non-broadcast positions to raw positions
   std::vector<int> axes;
   int non_broadcast_pos = 0;
-  for (const auto i : std::views::iota((size_t)0, tv->nDims())) {
+  for (const auto i : irange(tv->nDims())) {
     if (tv->axis((int)i)->isBroadcast()) {
       continue;
     }
@@ -411,7 +411,7 @@ void propagateRFactor(
   // position in other reduction TVs.
   std::unordered_set<int> non_broadcast_rfactor_axes_ir;
   int non_broadcast_pos_ir = 0;
-  for (const auto i : std::views::iota((size_t)0, reference_tv->nDims())) {
+  for (const auto i : irange(reference_tv->nDims())) {
     if (reference_tv->axis((int)i)->isBroadcast()) {
       continue;
     }
@@ -518,7 +518,7 @@ void propagateParallelization(
 
     for (auto tv : rfactor_and_reduction_tvs) {
       if (are_unrolled.count(tv) == 0) {
-        for (const auto i : std::views::iota((size_t)0, tv->nDims())) {
+        for (const auto i : irange(tv->nDims())) {
           auto id = tv->axis((int)i);
           // Use Group only for grid reductions (i.e., not for rfactor'ed
           // reductions)
@@ -726,8 +726,7 @@ class PersistentBufferProjector {
     if (project_to_inputs_) {
       // Iterate through projected buffers, tracking which index it corresponds
       // too since there's a resolution point entry for every buffer.
-      for (auto buffer_i :
-           std::views::iota((size_t)0, persistent_buffers.size())) {
+      for (auto buffer_i : irange(persistent_buffers.size())) {
         auto buffer = persistent_buffers[buffer_i];
         if (std::find(
                 projectable_persistent_buffers.begin(),
@@ -741,8 +740,7 @@ class PersistentBufferProjector {
     } else {
       std::unordered_set<TensorView*> persistent_buffer_set(
           persistent_buffers.begin(), persistent_buffers.end());
-      for (auto buffer_i :
-           std::views::iota((size_t)0, persistent_buffers.size())) {
+      for (auto buffer_i : irange(persistent_buffers.size())) {
         auto buffer = persistent_buffers[buffer_i];
         // skip reduction buffers
         if (buffer->hasReduction()) {

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -17,6 +17,8 @@
 #include <scheduler/utils.h>
 #include <transform_replay.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 namespace reduction_scheduler_utils {
@@ -274,7 +276,7 @@ TensorView* scheduleReductionTV(
   if (is_outer_grid_persistence) {
     int vec_id_cur_pos = -1;
     std::unordered_map<int, int> vec_reorder_map;
-    for (const auto i : c10::irange((int)reduction_rf_tv->nDims())) {
+    for (const auto i : std::views::iota(0, (int)reduction_rf_tv->nDims())) {
       auto id = reduction_rf_tv->axis(i);
       if (id->getParallelType() == ParallelType::Vectorize) {
         vec_id_cur_pos = i;
@@ -301,7 +303,7 @@ std::vector<int> addBackBroadcasts(
   // convert non-broadcast positions to raw positions
   std::vector<int> axes;
   int non_broadcast_pos = 0;
-  for (const auto i : c10::irange(tv->nDims())) {
+  for (const auto i : std::views::iota((size_t)0, tv->nDims())) {
     if (tv->axis((int)i)->isBroadcast()) {
       continue;
     }
@@ -409,7 +411,7 @@ void propagateRFactor(
   // position in other reduction TVs.
   std::unordered_set<int> non_broadcast_rfactor_axes_ir;
   int non_broadcast_pos_ir = 0;
-  for (const auto i : c10::irange(reference_tv->nDims())) {
+  for (const auto i : std::views::iota((size_t)0, reference_tv->nDims())) {
     if (reference_tv->axis((int)i)->isBroadcast()) {
       continue;
     }
@@ -516,7 +518,7 @@ void propagateParallelization(
 
     for (auto tv : rfactor_and_reduction_tvs) {
       if (are_unrolled.count(tv) == 0) {
-        for (const auto i : c10::irange(tv->nDims())) {
+        for (const auto i : std::views::iota((size_t)0, tv->nDims())) {
           auto id = tv->axis((int)i);
           // Use Group only for grid reductions (i.e., not for rfactor'ed
           // reductions)
@@ -724,7 +726,8 @@ class PersistentBufferProjector {
     if (project_to_inputs_) {
       // Iterate through projected buffers, tracking which index it corresponds
       // too since there's a resolution point entry for every buffer.
-      for (auto buffer_i : c10::irange(persistent_buffers.size())) {
+      for (auto buffer_i :
+           std::views::iota((size_t)0, persistent_buffers.size())) {
         auto buffer = persistent_buffers[buffer_i];
         if (std::find(
                 projectable_persistent_buffers.begin(),
@@ -738,7 +741,8 @@ class PersistentBufferProjector {
     } else {
       std::unordered_set<TensorView*> persistent_buffer_set(
           persistent_buffers.begin(), persistent_buffers.end());
-      for (auto buffer_i : c10::irange(persistent_buffers.size())) {
+      for (auto buffer_i :
+           std::views::iota((size_t)0, persistent_buffers.size())) {
         auto buffer = persistent_buffers[buffer_i];
         // skip reduction buffers
         if (buffer->hasReduction()) {

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -15,6 +15,8 @@
 #include <scheduler/utils.h>
 #include <tensor_metadata.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 SchedulerRuntimeInfo::SchedulerRuntimeInfo(
@@ -40,7 +42,8 @@ SchedulerRuntimeInfo::SchedulerRuntimeInfo(
         *expression_evaluator_);
   }
 
-  for (auto inp_i : c10::irange(static_cast<int64_t>(args.size()))) {
+  for (auto inp_i :
+       std::views::iota((int64_t)0, static_cast<int64_t>(args.size()))) {
     auto fusion_inp = complete_fusion_->inputs().at(inp_i);
     auto input_tv = dynamic_cast<TensorView*>(fusion_inp);
     // Note: we are skipping CpuScalar tensor here

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -15,7 +15,7 @@
 #include <scheduler/utils.h>
 #include <tensor_metadata.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -42,8 +42,7 @@ SchedulerRuntimeInfo::SchedulerRuntimeInfo(
         *expression_evaluator_);
   }
 
-  for (auto inp_i :
-       std::views::iota((int64_t)0, static_cast<int64_t>(args.size()))) {
+  for (auto inp_i : irange(static_cast<int64_t>(args.size()))) {
     auto fusion_inp = complete_fusion_->inputs().at(inp_i);
     auto input_tv = dynamic_cast<TensorView*>(fusion_inp);
     // Note: we are skipping CpuScalar tensor here

--- a/csrc/scheduler/registry_utils.cpp
+++ b/csrc/scheduler/registry_utils.cpp
@@ -12,6 +12,8 @@
 #include <scheduler/registry_utils.h>
 #include <scheduler/utils.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 namespace registry_utils {
@@ -77,7 +79,7 @@ namespace {
 std::deque<std::deque<TensorView*>> tvChains(
     std::deque<std::deque<Val*>> val_chains) {
   std::deque<std::deque<TensorView*>> tv_chains(val_chains.size());
-  for (const auto i : c10::irange(val_chains.size())) {
+  for (const auto i : std::views::iota((size_t)0, val_chains.size())) {
     auto tv_iterable = ir_utils::filterByType<TensorView>(val_chains[i]);
     tv_chains[i] =
         std::deque<TensorView*>(tv_iterable.begin(), tv_iterable.end());
@@ -431,14 +433,14 @@ bool reductionInterferingView(
   std::vector<std::vector<IterDomain*>> groups;
 
   // Do this three times as we could have a 3D scheduler at maximum
-  for (auto dimension : c10::irange(3)) {
+  for (auto dimension : std::views::iota(0, 3)) {
     // Tracker for this group
     std::vector<IterDomain*> current_dims;
 
     // Tracker of what we've already processed to remove from dims
     std::unordered_set<IterDomain*> processed;
 
-    for (auto i : c10::irange(dims.size())) {
+    for (auto i : std::views::iota((size_t)0, dims.size())) {
       auto dim_i = dims.size() - i - 1;
       if (dims[dim_i]->isReduction() != dims[dims.size() - 1]->isReduction()) {
         if (dimension == 0) {
@@ -499,7 +501,7 @@ bool reductionInterferingView(
   // since it should be relatively small int vectors of a small total nDims,
   // not too worried about it now.
 
-  for (auto first_dim_i : c10::irange(disjoint_groups.size())) {
+  for (auto first_dim_i : std::views::iota((size_t)0, disjoint_groups.size())) {
     for (auto second_dim_i = first_dim_i + 1;
          second_dim_i < disjoint_groups.size();
          ++second_dim_i) {

--- a/csrc/scheduler/registry_utils.cpp
+++ b/csrc/scheduler/registry_utils.cpp
@@ -12,7 +12,7 @@
 #include <scheduler/registry_utils.h>
 #include <scheduler/utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -79,7 +79,7 @@ namespace {
 std::deque<std::deque<TensorView*>> tvChains(
     std::deque<std::deque<Val*>> val_chains) {
   std::deque<std::deque<TensorView*>> tv_chains(val_chains.size());
-  for (const auto i : std::views::iota((size_t)0, val_chains.size())) {
+  for (const auto i : irange(val_chains.size())) {
     auto tv_iterable = ir_utils::filterByType<TensorView>(val_chains[i]);
     tv_chains[i] =
         std::deque<TensorView*>(tv_iterable.begin(), tv_iterable.end());
@@ -433,14 +433,14 @@ bool reductionInterferingView(
   std::vector<std::vector<IterDomain*>> groups;
 
   // Do this three times as we could have a 3D scheduler at maximum
-  for (auto dimension : std::views::iota(0, 3)) {
+  for (auto dimension : irange(3)) {
     // Tracker for this group
     std::vector<IterDomain*> current_dims;
 
     // Tracker of what we've already processed to remove from dims
     std::unordered_set<IterDomain*> processed;
 
-    for (auto i : std::views::iota((size_t)0, dims.size())) {
+    for (auto i : irange(dims.size())) {
       auto dim_i = dims.size() - i - 1;
       if (dims[dim_i]->isReduction() != dims[dims.size() - 1]->isReduction()) {
         if (dimension == 0) {
@@ -501,7 +501,7 @@ bool reductionInterferingView(
   // since it should be relatively small int vectors of a small total nDims,
   // not too worried about it now.
 
-  for (auto first_dim_i : std::views::iota((size_t)0, disjoint_groups.size())) {
+  for (auto first_dim_i : irange(disjoint_groups.size())) {
     for (auto second_dim_i = first_dim_i + 1;
          second_dim_i < disjoint_groups.size();
          ++second_dim_i) {

--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -17,6 +17,8 @@
 #include <scheduler/utils.h>
 #include <scheduler/vectorize_helper.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 TransposeScheduler::TransposeScheduler(
@@ -198,7 +200,7 @@ class DomainMap : public pointwise_utils::DomainMap {
     // Find the id mapped to `Allocation Domain`
     const auto& alloc_dom = tv->getMaybeAllocationDomain();
     IterDomain* mapped_id = nullptr;
-    for (auto i : c10::irange(alloc_dom.size())) {
+    for (auto i : std::views::iota((size_t)0, alloc_dom.size())) {
       if (ca_map_.areMapped(alloc_dom[i], root_dim, IdMappingMode::INNERMOST)) {
         mapped_id = alloc_dom[i];
         break;
@@ -272,7 +274,7 @@ class DomainMap : public pointwise_utils::DomainMap {
     }
     // Find the position of the leaf id
     const auto& dom = tv->getLeafDomain();
-    for (auto i : c10::irange(dom.size())) {
+    for (auto i : std::views::iota((size_t)0, dom.size())) {
       if (dom[i] == mapped_id) {
         return static_cast<int64_t>(i);
       }

--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -17,7 +17,7 @@
 #include <scheduler/utils.h>
 #include <scheduler/vectorize_helper.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -200,7 +200,7 @@ class DomainMap : public pointwise_utils::DomainMap {
     // Find the id mapped to `Allocation Domain`
     const auto& alloc_dom = tv->getMaybeAllocationDomain();
     IterDomain* mapped_id = nullptr;
-    for (auto i : std::views::iota((size_t)0, alloc_dom.size())) {
+    for (auto i : irange(alloc_dom.size())) {
       if (ca_map_.areMapped(alloc_dom[i], root_dim, IdMappingMode::INNERMOST)) {
         mapped_id = alloc_dom[i];
         break;
@@ -274,7 +274,7 @@ class DomainMap : public pointwise_utils::DomainMap {
     }
     // Find the position of the leaf id
     const auto& dom = tv->getLeafDomain();
-    for (auto i : std::views::iota((size_t)0, dom.size())) {
+    for (auto i : irange(dom.size())) {
       if (dom[i] == mapped_id) {
         return static_cast<int64_t>(i);
       }

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -19,7 +19,7 @@
 #include <transform_iter.h>
 #include <transform_replay.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <queue>
 
@@ -302,8 +302,7 @@ void parallelizeAllLike(
     if (tv->isFusionInput()) {
       continue;
     }
-    for (const auto i :
-         std::views::iota((size_t)0, tv->getLeafDomain().size())) {
+    for (const auto i : irange(tv->getLeafDomain().size())) {
       auto ca_id = ca_map.getConcreteMappedID(
           tv->axis((int)i), IdMappingMode::PERMISSIVE_RESIZE);
       if (concrete_to_reference_map.count(ca_id) > 0) {
@@ -687,8 +686,7 @@ getScopePersistenceFactors(
       projectable_buffer_inputs.begin(),
       projectable_buffer_inputs.end());
 
-  for (auto persistent_buffer_i :
-       std::views::iota((size_t)0, persistent_buffers.size())) {
+  for (auto persistent_buffer_i : irange(persistent_buffers.size())) {
     auto persistent_buffer = persistent_buffers[persistent_buffer_i];
     // All expressions between tv and its resolution points must have tv's
     // persistent buffer allocated. This is an optimistic view on how many
@@ -733,7 +731,7 @@ getScopePersistenceFactors(
   // Offset into the bool vector
   size_t bool_vector_offset = persistent_buffers.size();
   for (auto projectable_persistent_buffer_i :
-       std::views::iota((size_t)0, projectable_persistent_buffers.size())) {
+       irange(projectable_persistent_buffers.size())) {
     auto projectable_persistent_buffer =
         projectable_persistent_buffers[projectable_persistent_buffer_i];
     auto inputs = ir_utils::inputTvsOf(projectable_persistent_buffer);
@@ -814,7 +812,7 @@ PersistentBufferSizeReturn persistentBufferSize(
 
   std::vector<int64_t> persistent_buffer_sizes(all_buffers.size(), -1);
 
-  for (auto buffer_i : std::views::iota((size_t)0, all_buffers.size())) {
+  for (auto buffer_i : irange(all_buffers.size())) {
     bool is_input = buffer_i >= persistent_buffers.size();
     auto buffer = all_buffers[buffer_i];
 
@@ -851,14 +849,14 @@ PersistentBufferSizeReturn persistentBufferSize(
   // Buffers involved in normal persistence
   std::vector<bool> persistent_mask(all_buffers.size(), false);
 
-  for (auto buffer_i : std::views::iota((size_t)0, persistent_buffers.size())) {
+  for (auto buffer_i : irange(persistent_buffers.size())) {
     persistent_mask[buffer_i] = true;
   }
 
   // Buffers involved in projected to inputs
   std::vector<bool> projected_mask(all_buffers.size(), true);
 
-  for (auto buffer_i : std::views::iota((size_t)0, persistent_buffers.size())) {
+  for (auto buffer_i : irange(persistent_buffers.size())) {
     auto buffer = persistent_buffers[buffer_i];
     // Not a projectable buffer, or an input of a projectable buffer
     if (std::find(
@@ -883,7 +881,7 @@ PersistentBufferSizeReturn persistentBufferSize(
     // that are both a persistent buffer and an input to a projectable
     // buffer
     std::unordered_set<TensorView*> active_buffers;
-    for (auto buffer_i : std::views::iota((size_t)0, sizes.size())) {
+    for (auto buffer_i : irange(sizes.size())) {
       if (mask0[buffer_i] && mask1[buffer_i] &&
           active_buffers.count(all_buffers[buffer_i]) == 0) {
         buffer_size += sizes[buffer_i];
@@ -1276,7 +1274,7 @@ void FindAllMappedDims::propagateSibling(TensorView* from, TensorView* to) {
   if (from_id == nullptr) {
     mapped_root_ids_[to] = nullptr;
   } else {
-    for (auto i : std::views::iota((size_t)0, from->getRootDomain().size())) {
+    for (auto i : irange(from->getRootDomain().size())) {
       if (from_id == from->getRootDomain()[i]) {
         mapped_root_ids_[to] = to->getRootDomain()[i];
         break;
@@ -1287,8 +1285,7 @@ void FindAllMappedDims::propagateSibling(TensorView* from, TensorView* to) {
   if (from_id == nullptr) {
     mapped_root_ids_[to] = nullptr;
   } else {
-    for (auto i :
-         std::views::iota((size_t)0, from->getMaybeRFactorDomain().size())) {
+    for (auto i : irange(from->getMaybeRFactorDomain().size())) {
       if (from_id == from->getMaybeRFactorDomain()[i]) {
         mapped_rfactor_ids_[to] = to->getMaybeRFactorDomain()[i];
         return;
@@ -1517,8 +1514,7 @@ BroadcastMultipleInformation getBroadcastMultiples(
     auto in_out_tv_domain_list = std::list<IterDomain*>(
         in_out_tv_domain.begin(), in_out_tv_domain.end());
 
-    for (const auto ref_i :
-         std::views::iota((size_t)0, ref_root_domain.size())) {
+    for (const auto ref_i : irange(ref_root_domain.size())) {
       auto ref_id = ref_root_domain[ref_i];
 
       if (ref_id->isBroadcast()) {
@@ -1577,8 +1573,7 @@ BroadcastMultipleInformation getBroadcastMultiples(
       bool lhs = false;
       auto dtype_size =
           dataTypeSize(in_out_tv->getDataType().value(), index_type);
-      for (auto mapped_axes_i :
-           std::views::iota((size_t)0, mapped_axes.size())) {
+      for (auto mapped_axes_i : irange(mapped_axes.size())) {
         auto lhs_i = mapped_axes_i;
         auto rhs_i = mapped_axes.size() - 1 - mapped_axes_i;
 
@@ -1948,7 +1943,7 @@ std::unordered_map<int, int> domainReorderAsRfactorMap(TensorView* tv) {
   }
 
   std::unordered_map<int, int> old2new;
-  for (auto id_i : std::views::iota(0, (int)tv->getLeafDomain().size())) {
+  for (auto id_i : irange((int)tv->getLeafDomain().size())) {
     auto leaf_id = tv->axis(id_i);
     auto find_it =
         std::find(reordered_ids.begin(), reordered_ids.end(), leaf_id);

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2238,8 +2238,8 @@ void promoteProducerMemoryTypes(
                                  .mapConsumerToProducer())
                              .getReplay();
 
-    for (const auto i : std::views::iota(
-             (size_t)0, producer->nDims() - producer->getComputeAtPosition())) {
+    for (const auto i :
+         irange(producer->nDims() - producer->getComputeAtPosition())) {
       auto producer_non_ca_id =
           producer->axis((int)(i + producer->getComputeAtPosition()));
       auto producer_non_ca_id_ptype = producer_non_ca_id->getParallelType();

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1948,8 +1948,7 @@ std::unordered_map<int, int> domainReorderAsRfactorMap(TensorView* tv) {
   }
 
   std::unordered_map<int, int> old2new;
-  for (auto id_i :
-       std::views::iota(0, (int)tv->getLeafDomain().size())) {
+  for (auto id_i : std::views::iota(0, (int)tv->getLeafDomain().size())) {
     auto leaf_id = tv->axis(id_i);
     auto find_it =
         std::find(reordered_ids.begin(), reordered_ids.end(), leaf_id);

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -16,7 +16,7 @@
 #include <iter_visitor.h>
 #include <scheduler/registry.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <unordered_set>
 
 namespace nvfuser {
@@ -469,7 +469,7 @@ ContiguousInnerDimensionsMapper::computeInfoC2P(
   if (to->hasBroadcast()) {
     // Find the last broadcast dimension resolved in consumers root domain
     int clear_pos = -1;
-    for (auto i : std::views::iota((size_t)0, from->getRootDomain().size())) {
+    for (auto i : irange(from->getRootDomain().size())) {
       auto c_id = from->getRootDomain()[i];
       auto c_it = c2p_map.find(c_id);
       if (c_it == c2p_map.end()) {
@@ -542,8 +542,7 @@ ContiguousInnerDimensionsMapper::computeInfoP2C(
   if (!from->isFusionInput() && from->hasReduction()) {
     // Find the last reduction dimension in the rfactor domain.
     int clear_pos = -1;
-    for (auto i :
-         std::views::iota((size_t)0, from->getMaybeRFactorDomain().size())) {
+    for (auto i : irange(from->getMaybeRFactorDomain().size())) {
       if (from->getMaybeRFactorDomain()[i]->isReduction()) {
         clear_pos = (int)i;
       }
@@ -703,7 +702,7 @@ Val* ContiguousInnerDimensionsMapper::getContigMergeOfInnerSize(
   if (contiguity.size() == of_tv_root.size() &&
       contiguity.size() != of_tv_root_no_reductions.size()) {
     std::vector<std::optional<bool>> new_contiguity;
-    for (auto i : std::views::iota((size_t)0, of_tv_root.size())) {
+    for (auto i : irange(of_tv_root.size())) {
       if (!of_tv_root[i]->isReduction()) {
         new_contiguity.push_back(contiguity[i]);
       }
@@ -729,7 +728,7 @@ Val* ContiguousInnerDimensionsMapper::getContigMergeOfInnerSize(
   // vectorize dimension.
   size_t projected_dims_i = projected_dims.size();
 
-  for (auto i : std::views::iota((size_t)0, of_tv_root_no_reductions_size)) {
+  for (auto i : irange(of_tv_root_no_reductions_size)) {
     if (projected_dims_i == 0) {
       break;
     }

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -16,8 +16,7 @@
 #include <iter_visitor.h>
 #include <scheduler/registry.h>
 
-#include <c10/util/irange.h>
-
+#include <C++20/ranges>
 #include <unordered_set>
 
 namespace nvfuser {
@@ -470,7 +469,7 @@ ContiguousInnerDimensionsMapper::computeInfoC2P(
   if (to->hasBroadcast()) {
     // Find the last broadcast dimension resolved in consumers root domain
     int clear_pos = -1;
-    for (auto i : c10::irange(from->getRootDomain().size())) {
+    for (auto i : std::views::iota((size_t)0, from->getRootDomain().size())) {
       auto c_id = from->getRootDomain()[i];
       auto c_it = c2p_map.find(c_id);
       if (c_it == c2p_map.end()) {
@@ -543,7 +542,8 @@ ContiguousInnerDimensionsMapper::computeInfoP2C(
   if (!from->isFusionInput() && from->hasReduction()) {
     // Find the last reduction dimension in the rfactor domain.
     int clear_pos = -1;
-    for (auto i : c10::irange(from->getMaybeRFactorDomain().size())) {
+    for (auto i :
+         std::views::iota((size_t)0, from->getMaybeRFactorDomain().size())) {
       if (from->getMaybeRFactorDomain()[i]->isReduction()) {
         clear_pos = (int)i;
       }
@@ -703,7 +703,7 @@ Val* ContiguousInnerDimensionsMapper::getContigMergeOfInnerSize(
   if (contiguity.size() == of_tv_root.size() &&
       contiguity.size() != of_tv_root_no_reductions.size()) {
     std::vector<std::optional<bool>> new_contiguity;
-    for (auto i : c10::irange(of_tv_root.size())) {
+    for (auto i : std::views::iota((size_t)0, of_tv_root.size())) {
       if (!of_tv_root[i]->isReduction()) {
         new_contiguity.push_back(contiguity[i]);
       }
@@ -729,7 +729,7 @@ Val* ContiguousInnerDimensionsMapper::getContigMergeOfInnerSize(
   // vectorize dimension.
   size_t projected_dims_i = projected_dims.size();
 
-  for (auto i : c10::irange(of_tv_root_no_reductions_size)) {
+  for (auto i : std::views::iota((size_t)0, of_tv_root_no_reductions_size)) {
     if (projected_dims_i == 0) {
       break;
     }

--- a/csrc/serde/Serde.md
+++ b/csrc/serde/Serde.md
@@ -277,7 +277,7 @@ while (!queue.empty()) {
 }
 
 // Deserialize terminal_nodes field in the FusionCache table
-for (auto idx : c10::irange(fusions_.size())) {
+for (auto idx : std::views::iota((size_t)0, fusions_.size())) {
   // Add trie_node from bfs_order to terminal_nodes_
   // Get FusionExecutorCache for terminal TrieNode
   // Deserialize FusionExecutorCache

--- a/csrc/serde/Serde.md
+++ b/csrc/serde/Serde.md
@@ -277,7 +277,7 @@ while (!queue.empty()) {
 }
 
 // Deserialize terminal_nodes field in the FusionCache table
-for (auto idx : std::views::iota((size_t)0, fusions_.size())) {
+for (auto idx : irange(fusions_.size())) {
   // Add trie_node from bfs_order to terminal_nodes_
   // Get FusionExecutorCache for terminal TrieNode
   // Deserialize FusionExecutorCache

--- a/csrc/serde/polymorphic_value_serde.cpp
+++ b/csrc/serde/polymorphic_value_serde.cpp
@@ -10,6 +10,8 @@
 #include <serde/polymorphic_value_serde.h>
 #include <serde/utils.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser::serde {
 
 namespace {
@@ -139,14 +141,14 @@ flatbuffers::Offset<serde::PolymorphicValue> serializePolymorphicValue(
       // Convert IntArrayRef to std::vector for flatbuffer compatibility
       std::vector<int64_t> sizes_fb;
       sizes_fb.reserve(tensor.ndimension());
-      for (auto dim : c10::irange(tensor.ndimension())) {
+      for (auto dim : std::views::iota((int64_t)0, tensor.ndimension())) {
         sizes_fb.push_back(tensor.size(dim));
       }
 
       // Convert IntArrayRef to std::vector for flatbuffer compatibility
       std::vector<int64_t> strides_fb;
       strides_fb.reserve(tensor.ndimension());
-      for (auto dim : c10::irange(tensor.ndimension())) {
+      for (auto dim : std::views::iota((int64_t)0, tensor.ndimension())) {
         strides_fb.push_back(tensor.stride(dim));
       }
 

--- a/csrc/serde/polymorphic_value_serde.cpp
+++ b/csrc/serde/polymorphic_value_serde.cpp
@@ -10,7 +10,7 @@
 #include <serde/polymorphic_value_serde.h>
 #include <serde/utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser::serde {
 
@@ -141,14 +141,14 @@ flatbuffers::Offset<serde::PolymorphicValue> serializePolymorphicValue(
       // Convert IntArrayRef to std::vector for flatbuffer compatibility
       std::vector<int64_t> sizes_fb;
       sizes_fb.reserve(tensor.ndimension());
-      for (auto dim : std::views::iota((int64_t)0, tensor.ndimension())) {
+      for (auto dim : irange(tensor.ndimension())) {
         sizes_fb.push_back(tensor.size(dim));
       }
 
       // Convert IntArrayRef to std::vector for flatbuffer compatibility
       std::vector<int64_t> strides_fb;
       strides_fb.reserve(tensor.ndimension());
-      for (auto dim : std::views::iota((int64_t)0, tensor.ndimension())) {
+      for (auto dim : irange(tensor.ndimension())) {
         strides_fb.push_back(tensor.stride(dim));
       }
 

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -230,7 +230,7 @@ inferAndValidateAllocationSizesAndStrides(
     // strides should already be in the target format. So nothing to do here.
     std::vector<int64_t> sizes;
     std::vector<int64_t> strides;
-    for (auto i : c10::irange(tensor.dim())) {
+    for (auto i : std::views::iota((int64_t)0, tensor.dim())) {
       sizes.emplace_back(tensor.size(i));
       strides.emplace_back(tensor.stride(i));
     }
@@ -243,7 +243,7 @@ inferAndValidateAllocationSizesAndStrides(
   // active IDs and their shape and stride
   std::unordered_map<IterDomain*, std::pair<int64_t, int64_t>> active_ids;
   NVF_ERROR((int64_t)rfactor.size() == tensor.dim());
-  for (int64_t i : c10::irange((int64_t)rfactor.size())) {
+  for (int64_t i : std::views::iota((int64_t)0, (int64_t)rfactor.size())) {
     auto rf_id = rfactor.at(i);
     active_ids[rf_id] = {tensor.size(i), tensor.stride(i)};
   }
@@ -257,7 +257,7 @@ inferAndValidateAllocationSizesAndStrides(
   std::vector<int64_t> strides;
   sizes.reserve(alloc.size());
   strides.reserve(alloc.size());
-  for (auto i : c10::irange(alloc.size())) {
+  for (auto i : std::views::iota((size_t)0, alloc.size())) {
     auto id = alloc.at(i);
     sizes.emplace_back(active_ids.at(id).first);
     strides.emplace_back(active_ids.at(id).second);
@@ -302,7 +302,7 @@ inferAndValidateAllocationSizesAndStrides(
       contiguity.empty(),
       "The size of contiguity mismatch with the dimensionality of allocation domain");
   // Validate that for expanded broadcast, the stride must be zero.
-  for (int64_t i : c10::irange((int64_t)strides.size())) {
+  for (int64_t i : std::views::iota((int64_t)0, (int64_t)strides.size())) {
     if (auto alloc_id = alloc.at(i); alloc_id->hasExpandedExtent()) {
       auto stride = strides.at(i);
       NVF_CHECK(

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -230,7 +230,7 @@ inferAndValidateAllocationSizesAndStrides(
     // strides should already be in the target format. So nothing to do here.
     std::vector<int64_t> sizes;
     std::vector<int64_t> strides;
-    for (auto i : std::views::iota((int64_t)0, tensor.dim())) {
+    for (auto i : irange(tensor.dim())) {
       sizes.emplace_back(tensor.size(i));
       strides.emplace_back(tensor.stride(i));
     }
@@ -243,7 +243,7 @@ inferAndValidateAllocationSizesAndStrides(
   // active IDs and their shape and stride
   std::unordered_map<IterDomain*, std::pair<int64_t, int64_t>> active_ids;
   NVF_ERROR((int64_t)rfactor.size() == tensor.dim());
-  for (int64_t i : std::views::iota((int64_t)0, (int64_t)rfactor.size())) {
+  for (int64_t i : irange((int64_t)rfactor.size())) {
     auto rf_id = rfactor.at(i);
     active_ids[rf_id] = {tensor.size(i), tensor.stride(i)};
   }
@@ -257,7 +257,7 @@ inferAndValidateAllocationSizesAndStrides(
   std::vector<int64_t> strides;
   sizes.reserve(alloc.size());
   strides.reserve(alloc.size());
-  for (auto i : std::views::iota((size_t)0, alloc.size())) {
+  for (auto i : irange(alloc.size())) {
     auto id = alloc.at(i);
     sizes.emplace_back(active_ids.at(id).first);
     strides.emplace_back(active_ids.at(id).second);
@@ -302,7 +302,7 @@ inferAndValidateAllocationSizesAndStrides(
       contiguity.empty(),
       "The size of contiguity mismatch with the dimensionality of allocation domain");
   // Validate that for expanded broadcast, the stride must be zero.
-  for (int64_t i : std::views::iota((int64_t)0, (int64_t)strides.size())) {
+  for (int64_t i : irange((int64_t)strides.size())) {
     if (auto alloc_id = alloc.at(i); alloc_id->hasExpandedExtent()) {
       auto stride = strides.at(i);
       NVF_CHECK(

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -24,7 +24,7 @@
 #include <transform_iter.h>
 #include <transform_replay.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -80,7 +80,7 @@ TensorView::TensorView(
 
   std::vector<bool> is_stride_zero(*tensor_type->dim(), false);
   std::vector<bool> is_size_one(*tensor_type->dim(), false);
-  for (const auto i : std::views::iota((size_t)0, tensor_type->dim().value())) {
+  for (const auto i : irange(tensor_type->dim().value())) {
     is_size_one.at(i) = tensor_type->sizes()[i].has_value() &&
         tensor_type->sizes()[i].value() == 1;
     const auto& stride_property_i = tensor_type->stride_properties()[i];
@@ -95,7 +95,7 @@ TensorView::TensorView(
   std::vector<IterDomain*> sizes;
   sizes.reserve(*tensor_type->dim());
 
-  for (const auto i : std::views::iota((size_t)0, tensor_type->dim().value())) {
+  for (const auto i : irange(tensor_type->dim().value())) {
     if (is_stride_zero.at(i) || is_size_one.at(i)) {
       // If stride is known to be 0, assuem it needs to be broadcasted.
       auto builder =
@@ -135,7 +135,7 @@ TensorView::TensorView(
   // dimension to slowest, instead of iterating through sizes. This allows
   // easier contiguity check;
   bool found_innermost_non_broadcast = false;
-  for (const auto i : std::views::iota((size_t)0, tensor_type->dim().value())) {
+  for (const auto i : irange(tensor_type->dim().value())) {
     // if we don't have contiguous dimension at current stride index, don't
     // bother;
     const auto& stride_property_i = tensor_type->stride_properties()[i];
@@ -960,7 +960,7 @@ TensorView* TensorView::multiOutputRfactorHelper(
 
     // construct a trivial root domain map
     std::unordered_map<IterDomain*, IterDomain*> id_map;
-    for (const auto i : std::views::iota((size_t)0, root.size())) {
+    for (const auto i : irange(root.size())) {
       id_map[this_root[i]] = root[i];
     }
 
@@ -1019,7 +1019,7 @@ std::vector<TensorView*> TensorView::rFactor(
       definition()->outputs().size() == tvs.size(),
       "Rfactor of a multi-output reduction not used correctly");
 
-  for (const auto i : std::views::iota((size_t)0, tvs.size())) {
+  for (const auto i : irange(tvs.size())) {
     NVF_CHECK(
         definition()->output(i) == tvs.at(i),
         "Rfactor of a multi-output reduction not used correctly");
@@ -1038,13 +1038,13 @@ std::vector<TensorView*> TensorView::rFactor(
 
   // Make sure this gets rfactored last so everybody gets
   //  replayed correctly
-  for (const auto i : std::views::iota((size_t)0, tvs.size())) {
+  for (const auto i : irange(tvs.size())) {
     if (this != tvs.at(i)) {
       rf_tvs.at(i) = multiOutputRfactorHelper(tvs.at(i), axes);
     }
   }
 
-  for (const auto i : std::views::iota((size_t)0, tvs.size())) {
+  for (const auto i : irange(tvs.size())) {
     if (this == tvs.at(i)) {
       rf_tvs.at(i) = multiOutputRfactorHelper(tvs.at(i), axes);
     }
@@ -1334,7 +1334,7 @@ void TensorView::clearReductionIterDomains() {
 
   std::vector<IterDomain*> new_root;
   std::vector<std::optional<bool>> new_contig;
-  for (const auto i : std::views::iota((size_t)0, getRootDomain().size())) {
+  for (const auto i : irange(getRootDomain().size())) {
     auto root_i = getRootDomain().at(i);
     if (!root_i->isReduction()) {
       new_root.push_back(root_i);
@@ -1487,7 +1487,7 @@ TensorViewBuilder& TensorViewBuilder::expanded(std::vector<bool> expanded) {
 TensorView* TensorViewBuilder::build() const {
   // Build the domain
   std::vector<IterDomain*> domain(ndims_, nullptr);
-  for (const auto i : std::views::iota((size_t)0, ndims_)) {
+  for (const auto i : irange(ndims_)) {
     bool is_expanded = false;
     Val* extent = nullptr;
     Val* expanded_extent = nullptr;
@@ -1527,7 +1527,7 @@ TensorView* TensorViewBuilder::build() const {
       contiguity_.empty() || contiguity_.size() == domain.size(),
       "The size of contiguity must equal to the number of non-broadcasting IterDomains");
 
-  for (auto i : std::views::iota((size_t)0, contiguity_.size())) {
+  for (auto i : irange(contiguity_.size())) {
     NVF_CHECK(
         domain.at(i)->isBroadcast() != contiguity_.at(i).has_value(),
         "The contiguity of a broadcast dimension must be None. "

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -269,8 +269,9 @@ void TensorView::setCpuScalar(bool is_cpu_scalar) {
 
 IterDomain* TensorView::axis(int pos) const {
   NVF_ERROR(nDims() > 0, "Tried to access an axis in a 0-dim TensorView");
-  if (pos < 0)
+  if (pos < 0) {
     pos += (int)domain()->nDims();
+  }
   NVF_CHECK(
       pos >= 0 && (unsigned int)pos < domain()->nDims(),
       "Tried to access position ",
@@ -632,8 +633,9 @@ TensorView* TensorView::split(
       "Tensor: ",
       toString());
 
-  if (axis_ < 0)
+  if (axis_ < 0) {
     axis_ += (int)domain()->nDims();
+  }
 
   NVF_ERROR(
       axis_ >= 0,
@@ -693,11 +695,13 @@ TensorView* TensorView::split(
 TensorView* TensorView::merge(int axis_o, int axis_i) {
   NVF_ERROR(nDims() > 0, "Tried to do merge on a 0-dim TensorView");
 
-  if (axis_o < 0)
+  if (axis_o < 0) {
     axis_o += (int)domain()->nDims();
+  }
 
-  if (axis_i < 0)
+  if (axis_i < 0) {
     axis_i += (int)domain()->nDims();
+  }
 
   NVF_CHECK(
       axis_o >= (int)getMaxComputePosition() &&

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -80,8 +80,7 @@ TensorView::TensorView(
 
   std::vector<bool> is_stride_zero(*tensor_type->dim(), false);
   std::vector<bool> is_size_one(*tensor_type->dim(), false);
-  for (const auto i :
-       std::views::iota((size_t)0, tensor_type->dim().value())) {
+  for (const auto i : std::views::iota((size_t)0, tensor_type->dim().value())) {
     is_size_one.at(i) = tensor_type->sizes()[i].has_value() &&
         tensor_type->sizes()[i].value() == 1;
     const auto& stride_property_i = tensor_type->stride_properties()[i];
@@ -96,8 +95,7 @@ TensorView::TensorView(
   std::vector<IterDomain*> sizes;
   sizes.reserve(*tensor_type->dim());
 
-  for (const auto i :
-       std::views::iota((size_t)0, tensor_type->dim().value())) {
+  for (const auto i : std::views::iota((size_t)0, tensor_type->dim().value())) {
     if (is_stride_zero.at(i) || is_size_one.at(i)) {
       // If stride is known to be 0, assuem it needs to be broadcasted.
       auto builder =
@@ -137,8 +135,7 @@ TensorView::TensorView(
   // dimension to slowest, instead of iterating through sizes. This allows
   // easier contiguity check;
   bool found_innermost_non_broadcast = false;
-  for (const auto i :
-       std::views::iota((size_t)0, tensor_type->dim().value())) {
+  for (const auto i : std::views::iota((size_t)0, tensor_type->dim().value())) {
     // if we don't have contiguous dimension at current stride index, don't
     // bother;
     const auto& stride_property_i = tensor_type->stride_properties()[i];

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -9,7 +9,7 @@
 
 #include <ir/utils.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <typeinfo>
 
 namespace nvfuser {
@@ -439,7 +439,7 @@ BestEffortReplay::BestEffortReplay(
     bool missing_replay_input = false;
 
     // Map target_expr inputs to replay domain directly
-    for (const auto t_i : std::views::iota((size_t)0, target_id_inps.size())) {
+    for (const auto t_i : irange(target_id_inps.size())) {
       // There might not be a mapping, that could be okay (depends on rfactor
       // checking).
       auto it = target2replay_id_map_.find(target_id_inps[t_i]);
@@ -588,7 +588,7 @@ BestEffortReplay::BestEffortReplay(
     }
 
     // Take replay expr inputs out of map:
-    for (const auto t_i : std::views::iota((size_t)0, target_id_inps.size())) {
+    for (const auto t_i : irange(target_id_inps.size())) {
       auto t_inp = target_id_inps[t_i];
       auto r_orig_inp = target2replay_id_map_.at(t_inp);
       auto r_maybe_forwarded_inp = replay_inps[t_i];
@@ -605,8 +605,7 @@ BestEffortReplay::BestEffortReplay(
     }
 
     // Add outputs to map.
-    for (const auto i :
-         std::views::iota((size_t)0, target_expr->outputs().size())) {
+    for (const auto i : irange(target_expr->outputs().size())) {
       auto t_out = target_expr->output(i);
       auto r_out = replay_expr->output(i);
       if (t_out->getValType() == ValType::IterDomain &&
@@ -741,7 +740,7 @@ struct ForwardingInfo {
     // tensor.
     std::unordered_set<IterDomain*> forwarded_ids;
     NVF_ERROR(active_root_dom.size() == active_dim_flags->size());
-    for (auto i : std::views::iota((size_t)0, active_dim_flags->size())) {
+    for (auto i : irange(active_dim_flags->size())) {
       if (active_dim_flags->at(i)) {
         forwarded_ids.emplace(active_root_dom.at(i));
       }

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -7,9 +7,9 @@
 // clang-format on
 #include <transform_iter.h>
 
-#include <c10/util/irange.h>
 #include <ir/utils.h>
 
+#include <C++20/ranges>
 #include <typeinfo>
 
 namespace nvfuser {
@@ -438,7 +438,7 @@ BestEffortReplay::BestEffortReplay(
     bool missing_replay_input = false;
 
     // Map target_expr inputs to replay domain directly
-    for (const auto t_i : c10::irange(target_id_inps.size())) {
+    for (const auto t_i : std::views::iota((size_t)0, target_id_inps.size())) {
       // There might not be a mapping, that could be okay (depends on rfactor
       // checking).
       auto it = target2replay_id_map_.find(target_id_inps[t_i]);
@@ -587,7 +587,7 @@ BestEffortReplay::BestEffortReplay(
     }
 
     // Take replay expr inputs out of map:
-    for (const auto t_i : c10::irange(target_id_inps.size())) {
+    for (const auto t_i : std::views::iota((size_t)0, target_id_inps.size())) {
       auto t_inp = target_id_inps[t_i];
       auto r_orig_inp = target2replay_id_map_.at(t_inp);
       auto r_maybe_forwarded_inp = replay_inps[t_i];
@@ -604,7 +604,8 @@ BestEffortReplay::BestEffortReplay(
     }
 
     // Add outputs to map.
-    for (const auto i : c10::irange(target_expr->outputs().size())) {
+    for (const auto i :
+         std::views::iota((size_t)0, target_expr->outputs().size())) {
       auto t_out = target_expr->output(i);
       auto r_out = replay_expr->output(i);
       if (t_out->getValType() == ValType::IterDomain &&
@@ -652,8 +653,8 @@ int BestEffortReplay::findFirstMismatchedID(
   }
 
   BestEffortReplay ber(td2->leaf(), td1->leaf(), id_map);
-  for (const auto i :
-       c10::irange(std::max(td1->leaf().size(), td2->leaf().size()))) {
+  for (const auto i : std::views::iota(
+           (size_t)0, std::max(td1->leaf().size(), td2->leaf().size()))) {
     if (ber.getReplay().find(td1->axis((int)i)) == ber.getReplay().end()) {
       return (int)i;
     }
@@ -739,7 +740,7 @@ struct ForwardingInfo {
     // tensor.
     std::unordered_set<IterDomain*> forwarded_ids;
     NVF_ERROR(active_root_dom.size() == active_dim_flags->size());
-    for (auto i : c10::irange(active_dim_flags->size())) {
+    for (auto i : std::views::iota((size_t)0, active_dim_flags->size())) {
       if (active_dim_flags->at(i)) {
         forwarded_ids.emplace(active_root_dom.at(i));
       }

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -653,8 +653,8 @@ int BestEffortReplay::findFirstMismatchedID(
   }
 
   BestEffortReplay ber(td2->leaf(), td1->leaf(), id_map);
-  for (const auto i : std::views::iota(
-           (size_t)0, std::max(td1->leaf().size(), td2->leaf().size()))) {
+  for (const auto i :
+       irange(std::max(td1->leaf().size(), td2->leaf().size()))) {
     if (ber.getReplay().find(td1->axis((int)i)) == ber.getReplay().end()) {
       return (int)i;
     }

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -287,8 +287,9 @@ void ReplayTransformations::runReplay() {
   // Populate leaf_vec_ in a deterministic manner. This is deterministic
   // because size_t in leaf_ids is filled based on operation order.
   std::set<std::pair<IterDomain*, size_t>, id_int_lt> ordered_set;
-  for (auto entry : leaf_ids_)
+  for (auto entry : leaf_ids_) {
     ordered_set.emplace(entry);
+  }
 
   leaf_vec_.clear();
   leaf_vec_.resize(ordered_set.size());
@@ -931,8 +932,9 @@ BestEffortReplay BestEffortReplay::replayCasP(
     bool skip_consumer_swizzle,
     bool skip_producer_swizzle,
     bool skip_resize) {
-  if (producer_compute_at_axis < 0)
+  if (producer_compute_at_axis < 0) {
     producer_compute_at_axis += (int)producer->nDims() + 1;
+  }
 
   NVF_ERROR(
       producer_compute_at_axis >= 0 &&
@@ -997,8 +999,9 @@ BestEffortReplay BestEffortReplay::replayPasC(
     bool skip_producer_swizzle,
     bool skip_consumer_swizzle,
     bool skip_resize) {
-  if (consumer_compute_at_axis < 0)
+  if (consumer_compute_at_axis < 0) {
     consumer_compute_at_axis += (int)consumer->nDims() + 1;
+  }
   NVF_ERROR(
       consumer_compute_at_axis >= 0 &&
           (unsigned int)consumer_compute_at_axis <= consumer->nDims(),

--- a/csrc/transform_rfactor.cpp
+++ b/csrc/transform_rfactor.cpp
@@ -15,7 +15,7 @@
 #include <iter_visitor.h>
 #include <ops/arith.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -339,7 +339,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
   std::unordered_map<IterDomain*, IterDomain*> original_to_producer_root_map;
 
   {
-    for (auto i : std::views::iota((size_t)0, original_td_root.size())) {
+    for (auto i : irange(original_td_root.size())) {
       auto id = original_td_root[i];
       // If this is an rfactor root, it will be a reduction in this stage
       if (rfactor_root_axes.find(id) != rfactor_root_axes.end()) {
@@ -386,7 +386,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
 
   std::vector<IterDomain*> new_producer_domain(original_td->nDims(), nullptr);
   {
-    for (auto i : std::views::iota((size_t)0, original_td->nDims())) {
+    for (auto i : irange(original_td->nDims())) {
       auto orig_id = original_td->axis((int)i);
       auto replayed_id_it = original_to_producer_id_map.find(orig_id);
       NVF_ERROR(
@@ -463,7 +463,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
 
   {
     // Construct the new consumer domain
-    for (auto i : std::views::iota((size_t)0, original_td->nDims())) {
+    for (auto i : irange(original_td->nDims())) {
       auto orig_id = original_td->axis((int)i);
       auto replayed_id_it = original_to_consumer_map.find(orig_id);
       if (replayed_id_it != original_to_consumer_map.end()) {

--- a/csrc/transform_rfactor.cpp
+++ b/csrc/transform_rfactor.cpp
@@ -15,6 +15,8 @@
 #include <iter_visitor.h>
 #include <ops/arith.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 namespace {
@@ -337,7 +339,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
   std::unordered_map<IterDomain*, IterDomain*> original_to_producer_root_map;
 
   {
-    for (auto i : c10::irange(original_td_root.size())) {
+    for (auto i : std::views::iota((size_t)0, original_td_root.size())) {
       auto id = original_td_root[i];
       // If this is an rfactor root, it will be a reduction in this stage
       if (rfactor_root_axes.find(id) != rfactor_root_axes.end()) {
@@ -384,7 +386,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
 
   std::vector<IterDomain*> new_producer_domain(original_td->nDims(), nullptr);
   {
-    for (auto i : c10::irange(original_td->nDims())) {
+    for (auto i : std::views::iota((size_t)0, original_td->nDims())) {
       auto orig_id = original_td->axis((int)i);
       auto replayed_id_it = original_to_producer_id_map.find(orig_id);
       NVF_ERROR(
@@ -461,7 +463,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
 
   {
     // Construct the new consumer domain
-    for (auto i : c10::irange(original_td->nDims())) {
+    for (auto i : std::views::iota((size_t)0, original_td->nDims())) {
       auto orig_id = original_td->axis((int)i);
       auto replayed_id_it = original_to_consumer_map.find(orig_id);
       if (replayed_id_it != original_to_consumer_map.end()) {

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -380,7 +380,8 @@ class AnalyzeViewTransformation {
     AnalyzeViewConstraint constraint;
     constraint.original_constraint =
         std::vector<int64_t>(original_view_.begin(), original_view_.end());
-    for (auto i : c10::irange(constraint.original_constraint.size())) {
+    for (auto i :
+         std::views::iota((size_t)0, constraint.original_constraint.size())) {
       if (constraint.original_constraint[i] != 1) {
         constraint.original_constraint[i] = 0;
       }
@@ -388,7 +389,8 @@ class AnalyzeViewTransformation {
 
     constraint.new_constraint =
         std::vector<int64_t>(new_view_.begin(), new_view_.end());
-    for (auto i : c10::irange(constraint.new_constraint.size())) {
+    for (auto i :
+         std::views::iota((size_t)0, constraint.new_constraint.size())) {
       if (constraint.new_constraint[i] != 1) {
         constraint.new_constraint[i] = 0;
       }
@@ -699,7 +701,7 @@ TensorDomain* createViewDomain(
       TensorDomain::noReductions(original_domain->maybeRFactor());
 
   // Apply squeeze.
-  for (auto id_i : c10::irange(orig_root_domain.size())) {
+  for (auto id_i : std::views::iota((size_t)0, orig_root_domain.size())) {
     if (!view_analysis.squeeze_axes.at(id_i)) {
       auto id = orig_root_domain.at(id_i);
       new_root_domain.push_back(id->cloneWithoutRFactor());
@@ -851,7 +853,7 @@ bool AnalyzeViewResult::operator==(const AnalyzeViewResult& other) const {
     return false;
   }
 
-  for (const auto i : c10::irange(transforms.size())) {
+  for (const auto i : std::views::iota((size_t)0, transforms.size())) {
     auto transform = transforms.at(i);
     auto other_transform = other.transforms.at(i);
     if (transform->isA<SplitTransform>()) {
@@ -878,7 +880,7 @@ bool AnalyzeViewResult::operator==(const AnalyzeViewResult& other) const {
 size_t AnalyzeViewResult::hash() const {
   auto bool_vec_hash = [](const std::vector<bool>& vec) -> size_t {
     size_t hash = 0;
-    for (const auto i : c10::irange(vec.size())) {
+    for (const auto i : std::views::iota((size_t)0, vec.size())) {
       hash = (hash << 1) + static_cast<size_t>(vec.at(i));
     }
     return hash;

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -380,8 +380,7 @@ class AnalyzeViewTransformation {
     AnalyzeViewConstraint constraint;
     constraint.original_constraint =
         std::vector<int64_t>(original_view_.begin(), original_view_.end());
-    for (auto i :
-         std::views::iota((size_t)0, constraint.original_constraint.size())) {
+    for (auto i : irange(constraint.original_constraint.size())) {
       if (constraint.original_constraint[i] != 1) {
         constraint.original_constraint[i] = 0;
       }
@@ -389,8 +388,7 @@ class AnalyzeViewTransformation {
 
     constraint.new_constraint =
         std::vector<int64_t>(new_view_.begin(), new_view_.end());
-    for (auto i :
-         std::views::iota((size_t)0, constraint.new_constraint.size())) {
+    for (auto i : irange(constraint.new_constraint.size())) {
       if (constraint.new_constraint[i] != 1) {
         constraint.new_constraint[i] = 0;
       }
@@ -701,7 +699,7 @@ TensorDomain* createViewDomain(
       TensorDomain::noReductions(original_domain->maybeRFactor());
 
   // Apply squeeze.
-  for (auto id_i : std::views::iota((size_t)0, orig_root_domain.size())) {
+  for (auto id_i : irange(orig_root_domain.size())) {
     if (!view_analysis.squeeze_axes.at(id_i)) {
       auto id = orig_root_domain.at(id_i);
       new_root_domain.push_back(id->cloneWithoutRFactor());
@@ -853,7 +851,7 @@ bool AnalyzeViewResult::operator==(const AnalyzeViewResult& other) const {
     return false;
   }
 
-  for (const auto i : std::views::iota((size_t)0, transforms.size())) {
+  for (const auto i : irange(transforms.size())) {
     auto transform = transforms.at(i);
     auto other_transform = other.transforms.at(i);
     if (transform->isA<SplitTransform>()) {
@@ -880,7 +878,7 @@ bool AnalyzeViewResult::operator==(const AnalyzeViewResult& other) const {
 size_t AnalyzeViewResult::hash() const {
   auto bool_vec_hash = [](const std::vector<bool>& vec) -> size_t {
     size_t hash = 0;
-    for (const auto i : std::views::iota((size_t)0, vec.size())) {
+    for (const auto i : irange(vec.size())) {
       hash = (hash << 1) + static_cast<size_t>(vec.at(i));
     }
     return hash;

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -17,7 +17,7 @@
 
 #include <polymorphic_value.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <array>
 #include <complex>
 #include <cstdint>
@@ -207,7 +207,7 @@ bool StructType::operator==(const StructType& other) const {
   if (fields.size() != other.fields.size()) {
     return false;
   }
-  for (auto i : std::views::iota((size_t)0, fields.size())) {
+  for (auto i : irange(fields.size())) {
     if (fields[i].name != other.fields[i].name ||
         *fields[i].type != *other.fields[i].type ||
         fields[i].used_in_kernel != other.fields[i].used_in_kernel) {
@@ -465,7 +465,7 @@ inline bool isCompatibleDataType(DataType dtype, DataType dtype2) {
     if (struct_type.fields.size() != struct_type2.fields.size()) {
       return false;
     }
-    for (auto i : std::views::iota((size_t)0, struct_type.fields.size())) {
+    for (auto i : irange(struct_type.fields.size())) {
       if (struct_type.fields[i].name != struct_type2.fields[i].name ||
           !isCompatibleDataType(
               *struct_type.fields[i].type, *struct_type2.fields[i].type)) {

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -17,6 +17,7 @@
 
 #include <polymorphic_value.h>
 
+#include <C++20/ranges>
 #include <array>
 #include <complex>
 #include <cstdint>
@@ -206,7 +207,7 @@ bool StructType::operator==(const StructType& other) const {
   if (fields.size() != other.fields.size()) {
     return false;
   }
-  for (auto i : c10::irange(fields.size())) {
+  for (auto i : std::views::iota((size_t)0, fields.size())) {
     if (fields[i].name != other.fields[i].name ||
         *fields[i].type != *other.fields[i].type ||
         fields[i].used_in_kernel != other.fields[i].used_in_kernel) {
@@ -464,7 +465,7 @@ inline bool isCompatibleDataType(DataType dtype, DataType dtype2) {
     if (struct_type.fields.size() != struct_type2.fields.size()) {
       return false;
     }
-    for (auto i : c10::irange(struct_type.fields.size())) {
+    for (auto i : std::views::iota((size_t)0, struct_type.fields.size())) {
       if (struct_type.fields[i].name != struct_type2.fields[i].name ||
           !isCompatibleDataType(
               *struct_type.fields[i].type, *struct_type2.fields[i].type)) {

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -18,6 +18,8 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAStream.h>
+
+#include <C++20/ranges>
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -62,10 +64,10 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
     const size_t kN = norm_shape.size();
     const size_t kOuterNumDims = kM - kN;
     std::vector<int64_t> outer_shape;
-    for (const auto idx : c10::irange(kOuterNumDims)) {
+    for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
       outer_shape.push_back(input_shape[idx]);
     }
-    for (const auto idx : c10::irange(kOuterNumDims, kM)) {
+    for (const auto idx : std::views::iota(kOuterNumDims, kM)) {
       // just to avoid unused variable warning
       outer_shape.push_back(1 + idx - idx);
     }
@@ -316,10 +318,10 @@ TEST_F(NVFuserTest, CombinedSchedulerSharedConsumer_CUDA) {
     const size_t kN = norm_shape.size();
     const size_t kOuterNumDims = kM - kN;
     std::vector<int64_t> outer_shape;
-    for (const auto idx : c10::irange(kOuterNumDims)) {
+    for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
       outer_shape.push_back(input_shape[idx]);
     }
-    for (const auto idx : c10::irange(kOuterNumDims, kM)) {
+    for (const auto idx : std::views::iota(kOuterNumDims, kM)) {
       // just to avoid unused variable warning
       outer_shape.push_back(1 + idx - idx);
     }
@@ -465,10 +467,10 @@ TEST_F(NVFuserTest, CombinedSchedulerSharedProducer_CUDA) {
     const size_t kN = norm_shape.size();
     const size_t kOuterNumDims = kM - kN;
     std::vector<int64_t> outer_shape;
-    for (const auto idx : c10::irange(kOuterNumDims)) {
+    for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
       outer_shape.push_back(input_shape[idx]);
     }
-    for (const auto idx : c10::irange(kOuterNumDims, kM)) {
+    for (const auto idx : std::views::iota(kOuterNumDims, kM)) {
       // just to avoid unused variable warning
       outer_shape.push_back(1 + idx - idx);
     }

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -19,7 +19,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAStream.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -64,7 +64,7 @@ TEST_F(NVFuserTest, CombinedSchedulerLayerNormBackward_CUDA) {
     const size_t kN = norm_shape.size();
     const size_t kOuterNumDims = kM - kN;
     std::vector<int64_t> outer_shape;
-    for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
+    for (const auto idx : irange(kOuterNumDims)) {
       outer_shape.push_back(input_shape[idx]);
     }
     for (const auto idx : std::views::iota(kOuterNumDims, kM)) {
@@ -318,7 +318,7 @@ TEST_F(NVFuserTest, CombinedSchedulerSharedConsumer_CUDA) {
     const size_t kN = norm_shape.size();
     const size_t kOuterNumDims = kM - kN;
     std::vector<int64_t> outer_shape;
-    for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
+    for (const auto idx : irange(kOuterNumDims)) {
       outer_shape.push_back(input_shape[idx]);
     }
     for (const auto idx : std::views::iota(kOuterNumDims, kM)) {
@@ -467,7 +467,7 @@ TEST_F(NVFuserTest, CombinedSchedulerSharedProducer_CUDA) {
     const size_t kN = norm_shape.size();
     const size_t kOuterNumDims = kM - kN;
     std::vector<int64_t> outer_shape;
-    for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
+    for (const auto idx : irange(kOuterNumDims)) {
       outer_shape.push_back(input_shape[idx]);
     }
     for (const auto idx : std::views::iota(kOuterNumDims, kM)) {

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -17,7 +17,7 @@
 #include <test/utils.h>
 #include <test/validator.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <functional>
 
 namespace nvfuser {
@@ -240,7 +240,7 @@ TEST_F(NVFuserTest, DynamicTransform4_CUDA) {
     fusion.addInput(tv1);
 
     std::vector<Val*> shape_arg;
-    for (const auto i : std::views::iota((size_t)0, after_shape.size())) {
+    for (const auto i : irange(after_shape.size())) {
       (void)i;
       shape_arg.push_back(IrBuilder::create<Val>(DataType::Int));
     }
@@ -255,11 +255,11 @@ TEST_F(NVFuserTest, DynamicTransform4_CUDA) {
 
     ExpressionEvaluator expr_eval;
 
-    for (const auto i : std::views::iota((size_t)0, before_shape.size())) {
+    for (const auto i : irange(before_shape.size())) {
       expr_eval.bind(tv0->axis((int)i)->extent(), before_shape.at(i));
     }
 
-    for (const auto i : std::views::iota((size_t)0, after_shape.size())) {
+    for (const auto i : irange(after_shape.size())) {
       expr_eval.bind(tv2->axis((int)i)->extent(), after_shape.at(i));
       // We must bind tv1's extents, since they cannot be inferred until after
       // concretization. Because tv2 is a dynamic reshape both its IterDomains
@@ -352,7 +352,7 @@ TEST_F(NVFuserTest, DynamicTransform6_CUDA) {
     for (auto it = reshape_list.begin() + 1; it != reshape_list.end(); ++it) {
       auto shape = *it;
       std::vector<Val*> shape_arg;
-      for (const auto i : std::views::iota((size_t)0, shape.size())) {
+      for (const auto i : irange(shape.size())) {
         (void)i;
         shape_arg.push_back(IrBuilder::create<Val>(DataType::Int));
       }
@@ -364,9 +364,9 @@ TEST_F(NVFuserTest, DynamicTransform6_CUDA) {
 
     ExpressionEvaluator expr_eval;
 
-    for (const auto i : std::views::iota((size_t)0, reshape_list.size())) {
+    for (const auto i : irange(reshape_list.size())) {
       const auto& shape = reshape_list.at(i);
-      for (const auto j : std::views::iota((size_t)0, shape.size())) {
+      for (const auto j : irange(shape.size())) {
         expr_eval.bind(reshape_tvs.at(i)->axis((int)j)->extent(), shape.at(j));
       }
     }
@@ -431,7 +431,7 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
          ++it) {
       const auto& shape = *it;
       std::vector<Val*> shape_arg;
-      for (const auto i : std::views::iota((size_t)0, shape.size())) {
+      for (const auto i : irange(shape.size())) {
         (void)i;
         shape_arg.push_back(IrBuilder::create<Val>(DataType::Int));
       }
@@ -443,10 +443,9 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
 
     ExpressionEvaluator ref_expr_eval;
 
-    for (const auto i :
-         std::views::iota((size_t)0, ref_transform.shapes.size())) {
+    for (const auto i : irange(ref_transform.shapes.size())) {
       const auto& shape = ref_transform.shapes.at(i);
-      for (const auto j : std::views::iota((size_t)0, shape.size())) {
+      for (const auto j : irange(shape.size())) {
         ref_expr_eval.bind(
             reshape_tvs.at(i)->axis((int)j)->extent(), shape.at(j));
       }
@@ -459,10 +458,9 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
     for (const auto& transform : pattern.equal_transforms) {
       NVF_CHECK(transform.shapes.size() == ref_transform.shapes.size());
       ExpressionEvaluator expr_eval;
-      for (const auto i :
-           std::views::iota((size_t)0, transform.shapes.size())) {
+      for (const auto i : irange(transform.shapes.size())) {
         const auto& shape = transform.shapes.at(i);
-        for (const auto j : std::views::iota((size_t)0, shape.size())) {
+        for (const auto j : irange(shape.size())) {
           expr_eval.bind(
               reshape_tvs.at(i)->axis((int)j)->extent(), shape.at(j));
         }
@@ -482,10 +480,9 @@ TEST_F(NVFuserTest, DynamicTransform7_CUDA) {
     for (const auto& transform : pattern.different_transforms) {
       NVF_CHECK(transform.shapes.size() == ref_transform.shapes.size());
       ExpressionEvaluator expr_eval;
-      for (const auto i :
-           std::views::iota((size_t)0, transform.shapes.size())) {
+      for (const auto i : irange(transform.shapes.size())) {
         const auto& shape = transform.shapes.at(i);
-        for (const auto j : std::views::iota((size_t)0, shape.size())) {
+        for (const auto j : irange(shape.size())) {
           expr_eval.bind(
               reshape_tvs.at(i)->axis((int)j)->extent(), shape.at(j));
         }
@@ -780,7 +777,7 @@ void reductionDynamicViewAddFusion(
       (reshape_before_reduction) ? add(x, bias) : sum(x, {kReductionAxis});
   // create vectors of input scalars describing this reshape
   std::vector<Val*> output_shape(output_dims);
-  for (size_t i : std::views::iota((size_t)0, output_dims)) {
+  for (size_t i : irange(output_dims)) {
     output_shape[i] = IrBuilder::create<Val>(DataType::Int);
     fusion.addInput(output_shape[i]);
   }
@@ -823,7 +820,7 @@ void reductionDynamicViewAddFusion(
       // concretize bias_shape so that we can properly initialize at_bias
       size_t other_numel = 1;
       ssize_t negone_dim = -1; // negative if no -1 shape is provided
-      for (auto i : std::views::iota((size_t)0, bias_shape.size())) {
+      for (auto i : irange(bias_shape.size())) {
         if (bias_shape[i] == -1) {
           ASSERT_EQ(negone_dim, -1); // test cases should not have multiple -1s
           negone_dim = -1;
@@ -838,7 +835,7 @@ void reductionDynamicViewAddFusion(
     at::Tensor at_bias = at::randn(bias_shape, options);
     std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
     // Add input scalars describing the reshape size for concretization
-    for (size_t i : std::views::iota((size_t)0, output_dims)) {
+    for (size_t i : irange(output_dims)) {
       aten_inputs.emplace_back(output_shape[i]);
     }
 
@@ -900,7 +897,7 @@ void reductionDynamicPadAddFusion(
   fusion.addInput(x);
 
   std::vector<Val*> pad_width_vals(num_pad_widths);
-  for (auto i : std::views::iota((size_t)0, num_pad_widths)) {
+  for (auto i : irange(num_pad_widths)) {
     pad_width_vals[i] = IrBuilder::create<Val>(DataType::Int);
     fusion.addInput(pad_width_vals[i]);
   }
@@ -945,7 +942,7 @@ void reductionDynamicPadAddFusion(
     at::Tensor at_x = at::randn(input_shape, options);
     std::vector<c10::IValue> aten_inputs = {at_x};
     // Add input scalars describing the reshape size for concretization
-    for (size_t i : std::views::iota((size_t)0, pad_widths.size())) {
+    for (size_t i : irange(pad_widths.size())) {
       aten_inputs.emplace_back(pad_widths[i]);
     }
 

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -16,7 +16,7 @@
 #include <fusion.h>
 #include <ops/all_ops.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -508,7 +508,7 @@ TEST_F(ExprEvalTest, TernaryOps) {
   auto* f = IrBuilder::create<Val>(false);
 
   // Run once without PrecomputedValues, then once with
-  for ([[maybe_unused]] auto i : std::views::iota(0, 2)) {
+  for ([[maybe_unused]] auto i : irange(2)) {
     EXPECT_EQ(evaluator.evaluate(clamp(b, c, a)), b->value());
     EXPECT_EQ(evaluator.evaluate(clamp(a, c, b)), b->value());
     EXPECT_EQ(evaluator.evaluate(clamp(d, c, b)), c->value());

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -16,6 +16,8 @@
 #include <fusion.h>
 #include <ops/all_ops.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 class ExprEvalTest : public NVFuserTest {};
@@ -506,7 +508,7 @@ TEST_F(ExprEvalTest, TernaryOps) {
   auto* f = IrBuilder::create<Val>(false);
 
   // Run once without PrecomputedValues, then once with
-  for ([[maybe_unused]] auto i : c10::irange(2)) {
+  for ([[maybe_unused]] auto i : std::views::iota(0, 2)) {
     EXPECT_EQ(evaluator.evaluate(clamp(b, c, a)), b->value());
     EXPECT_EQ(evaluator.evaluate(clamp(a, c, b)), b->value());
     EXPECT_EQ(evaluator.evaluate(clamp(d, c, b)), c->value());

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -50,6 +50,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
+#include <C++20/ranges>
 #include <algorithm>
 #include <complex>
 #include <iostream>
@@ -550,7 +551,7 @@ TEST_F(NVFuserTest, FusionTensor_CUDA) {
     NVF_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
     NVF_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
     NVF_CHECK(fuser_tensor->domain() != nullptr);
-    for (const auto i : c10::irange(fuser_tensor->nDims())) {
+    for (const auto i : std::views::iota((size_t)0, fuser_tensor->nDims())) {
       // size 1 dimension are makred as broadcast
       NVF_CHECK(
           fuser_tensor->axis(i)->isBroadcast() == (tensor.sizes()[i] == 1));
@@ -573,7 +574,7 @@ TEST_F(NVFuserTest, FusionTensor_CUDA) {
     NVF_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
     NVF_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
     NVF_CHECK(fuser_tensor->domain() != nullptr);
-    for (const auto i : c10::irange(fuser_tensor->nDims())) {
+    for (const auto i : std::views::iota((size_t)0, fuser_tensor->nDims())) {
       // size 1 dimension are makred as broadcast
       NVF_CHECK(fuser_tensor->axis(i)->isBroadcast() == false);
     }
@@ -590,7 +591,7 @@ TEST_F(NVFuserTest, FusionTensor_CUDA) {
     NVF_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
     NVF_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
     NVF_CHECK(fuser_tensor->domain() != nullptr);
-    for (const auto i : c10::irange(fuser_tensor->nDims())) {
+    for (const auto i : std::views::iota((size_t)0, fuser_tensor->nDims())) {
       // size 1 dimension are makred as broadcast
       NVF_CHECK(fuser_tensor->axis(i)->isBroadcast() == false);
     }
@@ -688,7 +689,7 @@ TEST_F(NVFuserTest, FusionTVReorder_CUDA) {
       tv->getLeafDomain().begin(), tv->getLeafDomain().end());
 
   tv->reorder(shift_left);
-  for (const auto i : c10::irange(tv->nDims())) {
+  for (const auto i : std::views::iota((size_t)0, tv->nDims())) {
     NVF_CHECK(ref[i]->sameAs(tv->axis(i - 1)));
   }
 
@@ -697,7 +698,7 @@ TEST_F(NVFuserTest, FusionTVReorder_CUDA) {
       tv->getLeafDomain().begin(), tv->getLeafDomain().end());
 
   tv->reorder(shift_left);
-  for (const auto i : c10::irange(tv->nDims())) {
+  for (const auto i : std::views::iota((size_t)0, tv->nDims())) {
     NVF_CHECK(ref[i]->sameAs(tv->axis(i - 1)));
   }
 
@@ -707,7 +708,7 @@ TEST_F(NVFuserTest, FusionTVReorder_CUDA) {
 
   tv->reorder(shift_right);
   NVF_CHECK(ref[ref.size() - 1]->sameAs(tv->axis(0)));
-  for (const auto i : c10::irange(1, tv->nDims())) {
+  for (const auto i : std::views::iota((size_t)1, tv->nDims())) {
     NVF_CHECK(ref[i - 1]->sameAs(tv->axis(i)));
   }
 
@@ -2146,9 +2147,9 @@ void checkIdMapped(
   NVF_ERROR(root0.size() == should_map0.size());
   NVF_ERROR(root1.size() == should_map1.size());
   size_t idx0 = 0;
-  for (const auto i : c10::irange(root0.size())) {
+  for (const auto i : std::views::iota((size_t)0, root0.size())) {
     size_t idx1 = 0;
-    for (const auto j : c10::irange(root1.size())) {
+    for (const auto j : std::views::iota((size_t)0, root1.size())) {
       if (should_map0[i] && should_map1[j] && idx0 == idx1) {
         checkIdMapped(map, v0, root0[i], v1, root1[j], true);
       } else {
@@ -5657,7 +5658,7 @@ TEST_F(NVFuserTest, FusionReductionMultiConsumer_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionComputeAtExprOrder1_CUDA) {
-  for (const auto i : c10::irange(2)) {
+  for (const auto i : std::views::iota(0, 2)) {
     Fusion fusion;
     FusionGuard fg(&fusion);
 
@@ -7286,10 +7287,10 @@ TEST_F(NVFuserTest, FusionMagicSchedulerLayerNormBackward_CUDA) {
   const size_t kOuterNumDims = kM - kN;
 
   std::vector<int64_t> outer_shape;
-  for (const auto idx : c10::irange(kOuterNumDims)) {
+  for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
     outer_shape.push_back(shape[idx]);
   }
-  for (const auto i : c10::irange(kOuterNumDims, kM)) {
+  for (const auto i : std::views::iota(kOuterNumDims, kM)) {
     (void)i; // Suppress unused variable warning
     outer_shape.push_back(1);
   }
@@ -7375,10 +7376,10 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormBackward_CUDA) {
   const size_t kOuterNumDims = kM - kN;
 
   std::vector<int64_t> outer_shape;
-  for (const auto idx : c10::irange(kOuterNumDims)) {
+  for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
     outer_shape.push_back(shape[idx]);
   }
-  for (const auto i : c10::irange(kOuterNumDims, kM)) {
+  for (const auto i : std::views::iota(kOuterNumDims, kM)) {
     (void)i; // Suppress unused variable warning
     outer_shape.push_back(1);
   }

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -50,7 +50,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <complex>
 #include <iostream>
@@ -551,7 +551,7 @@ TEST_F(NVFuserTest, FusionTensor_CUDA) {
     NVF_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
     NVF_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
     NVF_CHECK(fuser_tensor->domain() != nullptr);
-    for (const auto i : std::views::iota((size_t)0, fuser_tensor->nDims())) {
+    for (const auto i : irange(fuser_tensor->nDims())) {
       // size 1 dimension are makred as broadcast
       NVF_CHECK(
           fuser_tensor->axis(i)->isBroadcast() == (tensor.sizes()[i] == 1));
@@ -574,7 +574,7 @@ TEST_F(NVFuserTest, FusionTensor_CUDA) {
     NVF_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
     NVF_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
     NVF_CHECK(fuser_tensor->domain() != nullptr);
-    for (const auto i : std::views::iota((size_t)0, fuser_tensor->nDims())) {
+    for (const auto i : irange(fuser_tensor->nDims())) {
       // size 1 dimension are makred as broadcast
       NVF_CHECK(fuser_tensor->axis(i)->isBroadcast() == false);
     }
@@ -591,7 +591,7 @@ TEST_F(NVFuserTest, FusionTensor_CUDA) {
     NVF_CHECK((int64_t)fuser_tensor->nDims() == tensor.dim());
     NVF_CHECK(fuser_tensor->getDataType().value() == DataType::Float);
     NVF_CHECK(fuser_tensor->domain() != nullptr);
-    for (const auto i : std::views::iota((size_t)0, fuser_tensor->nDims())) {
+    for (const auto i : irange(fuser_tensor->nDims())) {
       // size 1 dimension are makred as broadcast
       NVF_CHECK(fuser_tensor->axis(i)->isBroadcast() == false);
     }
@@ -689,7 +689,7 @@ TEST_F(NVFuserTest, FusionTVReorder_CUDA) {
       tv->getLeafDomain().begin(), tv->getLeafDomain().end());
 
   tv->reorder(shift_left);
-  for (const auto i : std::views::iota((size_t)0, tv->nDims())) {
+  for (const auto i : irange(tv->nDims())) {
     NVF_CHECK(ref[i]->sameAs(tv->axis(i - 1)));
   }
 
@@ -698,7 +698,7 @@ TEST_F(NVFuserTest, FusionTVReorder_CUDA) {
       tv->getLeafDomain().begin(), tv->getLeafDomain().end());
 
   tv->reorder(shift_left);
-  for (const auto i : std::views::iota((size_t)0, tv->nDims())) {
+  for (const auto i : irange(tv->nDims())) {
     NVF_CHECK(ref[i]->sameAs(tv->axis(i - 1)));
   }
 
@@ -2147,9 +2147,9 @@ void checkIdMapped(
   NVF_ERROR(root0.size() == should_map0.size());
   NVF_ERROR(root1.size() == should_map1.size());
   size_t idx0 = 0;
-  for (const auto i : std::views::iota((size_t)0, root0.size())) {
+  for (const auto i : irange(root0.size())) {
     size_t idx1 = 0;
-    for (const auto j : std::views::iota((size_t)0, root1.size())) {
+    for (const auto j : irange(root1.size())) {
       if (should_map0[i] && should_map1[j] && idx0 == idx1) {
         checkIdMapped(map, v0, root0[i], v1, root1[j], true);
       } else {
@@ -5658,7 +5658,7 @@ TEST_F(NVFuserTest, FusionReductionMultiConsumer_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionComputeAtExprOrder1_CUDA) {
-  for (const auto i : std::views::iota(0, 2)) {
+  for (const auto i : irange(2)) {
     Fusion fusion;
     FusionGuard fg(&fusion);
 
@@ -7287,7 +7287,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerLayerNormBackward_CUDA) {
   const size_t kOuterNumDims = kM - kN;
 
   std::vector<int64_t> outer_shape;
-  for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
+  for (const auto idx : irange(kOuterNumDims)) {
     outer_shape.push_back(shape[idx]);
   }
   for (const auto i : std::views::iota(kOuterNumDims, kM)) {
@@ -7376,7 +7376,7 @@ TEST_F(NVFuserTest, FusionMagicSchedulerRMSNormBackward_CUDA) {
   const size_t kOuterNumDims = kM - kN;
 
   std::vector<int64_t> outer_shape;
-  for (const auto idx : std::views::iota((size_t)0, kOuterNumDims)) {
+  for (const auto idx : irange(kOuterNumDims)) {
     outer_shape.push_back(shape[idx]);
   }
   for (const auto i : std::views::iota(kOuterNumDims, kM)) {

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -51,6 +51,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
+#include <C++20/ranges>
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -380,7 +381,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder2_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder3_CUDA) {
-  for (const auto i : c10::irange(2)) {
+  for (const auto i : std::views::iota(0, 2)) {
     Fusion fusion;
     FusionGuard fg(&fusion);
 
@@ -691,7 +692,7 @@ TEST_F(NVFuserTest, FusionLSTMCell_CUDA) {
   FusionGuard fg(&fusion);
 
   TensorView* tvs[16];
-  for (const auto i : c10::irange(16)) {
+  for (const auto i : std::views::iota(0, 16)) {
     tvs[i] = makeSymbolicTensor(2);
     fusion.addInput(tvs[i]);
   }
@@ -1287,8 +1288,8 @@ TEST_F(NVFuserTest, FusionDisjointSet_CUDA) {
 
   // Now each of the three groups should be equivalent within each
   // group
-  for (const auto gi : c10::irange(groups.size())) {
-    for (const auto gj : c10::irange(groups.size())) {
+  for (const auto gi : std::views::iota((size_t)0, groups.size())) {
+    for (const auto gj : std::views::iota((size_t)0, groups.size())) {
       for (auto i : groups[gi]) {
         for (auto j : groups[gj]) {
           NVF_CHECK(
@@ -4142,7 +4143,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicPass_CUDA) {
   tv2->cacheBefore();
 
   // Merge all dimensions together except inner-most dim
-  for (const auto i : c10::irange(kNumDims - 2)) {
+  for (const auto i : std::views::iota(0, kNumDims - 2)) {
     (void)i; // Suppress unused variable warning
     tv2->merge(0);
   }
@@ -5613,7 +5614,7 @@ TEST_F(NVFuserTest, FusionSBAR_CUDA) {
 
   const size_t kNumberOfDims = x->nDims();
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
-  for (const auto axis : c10::irange(kNumberOfDims - 1)) {
+  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims - 1)) {
     broadcast_mask[axis] = true;
   }
 
@@ -6906,7 +6907,7 @@ TEST_F(NVFuserTest, FusionSegfaultReduction_CUDA) {
   std::vector<int> outer_reduction_axes;
   std::vector<bool> outer_broadcast_mask(numDims, false);
   Val* N = IrBuilder::create<Val>(1.0);
-  for (const auto axis : c10::irange(numDims)) {
+  for (const auto axis : std::views::iota(0, numDims)) {
     if (axis != 1) {
       outer_reduction_axes.push_back(axis);
       at_sum_axes.push_back(axis);
@@ -8258,7 +8259,7 @@ TEST_F(NVFuserTest, FusionSegmenterCombineReductionsCycleRepro_CUDA) {
   args.push(aten_inputs);
   args.push(at_d56);
 
-  for (auto i : c10::irange(5)) {
+  for (auto i : std::views::iota(0, 5)) {
     (void)i; // Suppress unused variable warning
     auto segmented_fusion =
         SegmentCandidateFinder::segment(fusion_ptr.get(), args);

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -51,7 +51,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -381,7 +381,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder2_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder3_CUDA) {
-  for (const auto i : std::views::iota(0, 2)) {
+  for (const auto i : irange(2)) {
     Fusion fusion;
     FusionGuard fg(&fusion);
 
@@ -692,7 +692,7 @@ TEST_F(NVFuserTest, FusionLSTMCell_CUDA) {
   FusionGuard fg(&fusion);
 
   TensorView* tvs[16];
-  for (const auto i : std::views::iota(0, 16)) {
+  for (const auto i : irange(16)) {
     tvs[i] = makeSymbolicTensor(2);
     fusion.addInput(tvs[i]);
   }
@@ -1288,8 +1288,8 @@ TEST_F(NVFuserTest, FusionDisjointSet_CUDA) {
 
   // Now each of the three groups should be equivalent within each
   // group
-  for (const auto gi : std::views::iota((size_t)0, groups.size())) {
-    for (const auto gj : std::views::iota((size_t)0, groups.size())) {
+  for (const auto gi : irange(groups.size())) {
+    for (const auto gj : irange(groups.size())) {
       for (auto i : groups[gi]) {
         for (auto j : groups[gj]) {
           NVF_CHECK(
@@ -4143,7 +4143,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicPass_CUDA) {
   tv2->cacheBefore();
 
   // Merge all dimensions together except inner-most dim
-  for (const auto i : std::views::iota(0, kNumDims - 2)) {
+  for (const auto i : irange(kNumDims - 2)) {
     (void)i; // Suppress unused variable warning
     tv2->merge(0);
   }
@@ -5614,7 +5614,7 @@ TEST_F(NVFuserTest, FusionSBAR_CUDA) {
 
   const size_t kNumberOfDims = x->nDims();
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
-  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims - 1)) {
+  for (const auto axis : irange(kNumberOfDims - 1)) {
     broadcast_mask[axis] = true;
   }
 
@@ -6907,7 +6907,7 @@ TEST_F(NVFuserTest, FusionSegfaultReduction_CUDA) {
   std::vector<int> outer_reduction_axes;
   std::vector<bool> outer_broadcast_mask(numDims, false);
   Val* N = IrBuilder::create<Val>(1.0);
-  for (const auto axis : std::views::iota(0, numDims)) {
+  for (const auto axis : irange(numDims)) {
     if (axis != 1) {
       outer_reduction_axes.push_back(axis);
       at_sum_axes.push_back(axis);
@@ -8259,7 +8259,7 @@ TEST_F(NVFuserTest, FusionSegmenterCombineReductionsCycleRepro_CUDA) {
   args.push(aten_inputs);
   args.push(at_d56);
 
-  for (auto i : std::views::iota(0, 5)) {
+  for (auto i : irange(5)) {
     (void)i; // Suppress unused variable warning
     auto segmented_fusion =
         SegmentCandidateFinder::segment(fusion_ptr.get(), args);

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -49,7 +49,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <cmath>
 #include <iostream>
@@ -1318,7 +1318,7 @@ TEST_F(NVFuserTest, FusionIssue1430_CUDA) {
 
   for (auto tv : ir_utils::allTvs(&fusion)) {
     if (tv != tv1 || tv != tv3) {
-      for (auto i : std::views::iota((size_t)0, tv->nDims())) {
+      for (auto i : irange(tv->nDims())) {
         if (isParallelTypeVectorize(tv->axis((int)i)->getParallelType())) {
           tv->axis((int)i)->parallelize(ParallelType::Serial);
         }
@@ -2761,7 +2761,7 @@ TEST_F(NVFuserTest, FusionPropagateParallelTypesToSiblings_CUDA) {
           ref->nDims() == sibling->nDims(),
           "Invalid sibling: ",
           sibling->toString());
-      for (const auto i : std::views::iota((size_t)0, ref->nDims())) {
+      for (const auto i : irange(ref->nDims())) {
         NVF_CHECK(
             ref->axis(i)->getParallelType() ==
                 sibling->axis(i)->getParallelType(),
@@ -2871,7 +2871,7 @@ graph(%x.1 : Tensor,
     auto x = torch::rand({32, 32}, at::TensorOptions(at::kCUDA));
     auto y = torch::rand({32, 32}, at::TensorOptions(at::kCUDA));
     std::vector<c10::IValue> results;
-    for (const auto& i : std::views::iota(0, 10)) {
+    for (const auto& i : irange(10)) {
       (void)i; // Suppress unused variable warning
       auto stack = createStack({x.clone(), y.clone()});
       fn.run(stack);
@@ -2918,7 +2918,7 @@ TEST_F(NVFuserMultithreadedTest, MultipleFunctions_CUDA) {
     auto y = torch::rand({32, 32}, at::TensorOptions(at::kCUDA));
     std::vector<c10::IValue> results;
     constexpr size_t numRuns = 10;
-    for (const auto& i : std::views::iota((size_t)0, numRuns)) {
+    for (const auto& i : irange(numRuns)) {
       (void)i; // Suppress unused variable warning
       auto stack = createStack({x.clone(), y.clone()});
       fn.run(stack);
@@ -4371,7 +4371,7 @@ TEST_F(NVFuserTest, FusionExpandRepro1860_CUDA) {
   fusion.addInput(tv2);
 
   std::vector<IterDomain*> domain1(3, nullptr);
-  for (const auto i : std::views::iota(0, 3)) {
+  for (const auto i : irange(3)) {
     if (i == 0) {
       domain1[i] = IterDomainBuilder(
                        FusionGuard::getCurFusion()->zeroVal(),

--- a/test/test_gpu_fused_reduction.cpp
+++ b/test/test_gpu_fused_reduction.cpp
@@ -42,6 +42,7 @@
 #include <c10/cuda/CUDAStream.h>
 #include <torch/csrc/jit/codegen/cuda/interface.h>
 
+#include <C++20/ranges>
 #include <algorithm>
 #include <iostream>
 
@@ -1308,7 +1309,7 @@ TEST_F(NVFuserTest, FusionPersistentBNBackwardAllreduce_CUDA) {
   std::vector<int> reduction_axes;
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   Val* num_features = nullptr;
-  for (const auto axis : c10::irange(kNumberOfDims)) {
+  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
     if (axis != c_axis) {
       reduction_axes.push_back(axis);
       broadcast_mask[axis] = true;

--- a/test/test_gpu_fused_reduction.cpp
+++ b/test/test_gpu_fused_reduction.cpp
@@ -42,7 +42,7 @@
 #include <c10/cuda/CUDAStream.h>
 #include <torch/csrc/jit/codegen/cuda/interface.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <iostream>
 
@@ -1309,7 +1309,7 @@ TEST_F(NVFuserTest, FusionPersistentBNBackwardAllreduce_CUDA) {
   std::vector<int> reduction_axes;
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   Val* num_features = nullptr;
-  for (const auto axis : std::views::iota((size_t)0, kNumberOfDims)) {
+  for (const auto axis : irange(kNumberOfDims)) {
     if (axis != c_axis) {
       reduction_axes.push_back(axis);
       broadcast_mask[axis] = true;

--- a/test/test_gpu_outer_reduction.cpp
+++ b/test/test_gpu_outer_reduction.cpp
@@ -25,6 +25,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
+#include <C++20/ranges>
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -514,7 +515,7 @@ void scheduleNormalization(Fusion& fusion, const OuterReductionParams& params) {
   // Make sure the vectorized domain placed at the innermost position
   int vec_id_cur_pos = -1;
   std::unordered_map<int, int> vec_reorder_map;
-  for (const auto i : c10::irange(reduction_tv_rf->nDims())) {
+  for (const auto i : std::views::iota((size_t)0, reduction_tv_rf->nDims())) {
     auto id = reduction_tv_rf->axis(i);
     if (id->getParallelType() == ParallelType::Vectorize) {
       vec_id_cur_pos = i;

--- a/test/test_gpu_outer_reduction.cpp
+++ b/test/test_gpu_outer_reduction.cpp
@@ -25,7 +25,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -515,7 +515,7 @@ void scheduleNormalization(Fusion& fusion, const OuterReductionParams& params) {
   // Make sure the vectorized domain placed at the innermost position
   int vec_id_cur_pos = -1;
   std::unordered_map<int, int> vec_reorder_map;
-  for (const auto i : std::views::iota((size_t)0, reduction_tv_rf->nDims())) {
+  for (const auto i : irange(reduction_tv_rf->nDims())) {
     auto id = reduction_tv_rf->axis(i);
     if (id->getParallelType() == ParallelType::Vectorize) {
       vec_id_cur_pos = i;

--- a/test/test_gpu_shift.cpp
+++ b/test/test_gpu_shift.cpp
@@ -39,7 +39,7 @@
 #include <c10/cuda/CUDAStream.h>
 #include <torch/csrc/jit/codegen/cuda/interface.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <iostream>
 
@@ -2798,7 +2798,7 @@ TEST_F(NVFuserTest, FusionGather8_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   std::vector<int64_t> size({s1, s2});
   at::Tensor t0 = at::randn(size, options);
-  for (const auto i : std::views::iota((size_t)0, size.size())) {
+  for (const auto i : irange(size.size())) {
     size[i] = ceilDiv(
         size[i] - window_shape[i] + 1 + padding_width[i][0] +
             padding_width[i][1],
@@ -2865,7 +2865,7 @@ TEST_F(NVFuserTest, FusionGather9_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   std::vector<int64_t> size({s1, s2});
   at::Tensor t0 = at::randn(size, options);
-  for (const auto i : std::views::iota((size_t)0, size.size())) {
+  for (const auto i : irange(size.size())) {
     size[i] = ceilDiv(
         size[i] - window_shape[i] + 1 + padding_width[i][0] +
             padding_width[i][1],
@@ -4610,7 +4610,7 @@ TEST_F(NVFuserTest, FusionGatherStrided1_CUDA) {
 
   // Each output dimension should be: ceilDiv(input_size + padding_width -
   // window, stride).
-  for (const auto i : std::views::iota((size_t)0, window_shape.size())) {
+  for (const auto i : irange(window_shape.size())) {
     auto valid_dim = ceilDiv(
         t0.size(i) + padding_width[i][0] + padding_width[i][1] -
             window_shape[i] + 1,

--- a/test/test_gpu_shift.cpp
+++ b/test/test_gpu_shift.cpp
@@ -39,6 +39,7 @@
 #include <c10/cuda/CUDAStream.h>
 #include <torch/csrc/jit/codegen/cuda/interface.h>
 
+#include <C++20/ranges>
 #include <algorithm>
 #include <iostream>
 
@@ -2797,7 +2798,7 @@ TEST_F(NVFuserTest, FusionGather8_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   std::vector<int64_t> size({s1, s2});
   at::Tensor t0 = at::randn(size, options);
-  for (const auto i : c10::irange(size.size())) {
+  for (const auto i : std::views::iota((size_t)0, size.size())) {
     size[i] = ceilDiv(
         size[i] - window_shape[i] + 1 + padding_width[i][0] +
             padding_width[i][1],
@@ -2864,7 +2865,7 @@ TEST_F(NVFuserTest, FusionGather9_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   std::vector<int64_t> size({s1, s2});
   at::Tensor t0 = at::randn(size, options);
-  for (const auto i : c10::irange(size.size())) {
+  for (const auto i : std::views::iota((size_t)0, size.size())) {
     size[i] = ceilDiv(
         size[i] - window_shape[i] + 1 + padding_width[i][0] +
             padding_width[i][1],
@@ -4609,7 +4610,7 @@ TEST_F(NVFuserTest, FusionGatherStrided1_CUDA) {
 
   // Each output dimension should be: ceilDiv(input_size + padding_width -
   // window, stride).
-  for (const auto i : c10::irange(window_shape.size())) {
+  for (const auto i : std::views::iota((size_t)0, window_shape.size())) {
     auto valid_dim = ceilDiv(
         t0.size(i) + padding_width[i][0] + padding_width[i][1] -
             window_shape[i] + 1,

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -18,6 +18,7 @@
 #include <test/utils.h>
 #include <test/validator.h>
 
+#include <C++20/ranges>
 #include <cstdlib>
 #include <filesystem>
 #include <system_error>
@@ -35,7 +36,7 @@ TEST_F(NVFuserTest, FusionSplitDims_CUDA) {
   scheduler_utils::splitDims(
       tv, {{0, p(2)}, {0, p(1)}, {3, p(6)}, {6, p(10)}}, dims);
   EXPECT_EQ(tv->nDims(), 11);
-  for (auto i : c10::irange(11)) {
+  for (auto i : std::views::iota(0, 11)) {
     EXPECT_EQ(tv->axis(i)->extent()->evaluateInt(), p(i));
   }
   std::vector<size_t> expect{0, 3, 4, 5, 7, 8, 9};
@@ -56,7 +57,7 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
   std::vector<int64_t> expect_shape{
       p(0), p(1), p(2) * p(3) * p(7) * p(8) * p(9), p(4), p(5), p(6), p(10)};
   EXPECT_EQ(tv->nDims(), expect_shape.size());
-  for (auto i : c10::irange(expect_shape.size())) {
+  for (auto i : std::views::iota((size_t)0, expect_shape.size())) {
     EXPECT_EQ(tv->axis(i)->extent()->evaluateInt(), expect_shape[i]);
   }
   std::vector<size_t> expect_dims{0, 1, 2, 2, 3, 4, 5, 2, 2, 2, 6};
@@ -64,7 +65,7 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
   auto root_domain = tv->getRootDomain();
   auto num_merged_dim = to_merge.size();
   auto inputs = IterVisitor::getInputsTo({tv->axis(2)});
-  for (auto index : c10::irange(num_merged_dim)) {
+  for (auto index : std::views::iota((size_t)0, num_merged_dim)) {
     EXPECT_TRUE(root_domain[to_merge[num_merged_dim - 1 - index]]->sameAs(
         inputs[index]));
   }
@@ -964,7 +965,7 @@ TEST_F(VectorizeHelperTest, SpanningTree_CUDA) {
   inputs.push_back(bcast_inp);
   auto bcast = broadcast(bcast_inp, {false, true});
 
-  for (auto i : c10::irange(10)) {
+  for (auto i : std::views::iota(0, 10)) {
     auto resolution_inp = makeContigConcreteTensor({2, 2});
     inputs.push_back(resolution_inp);
     auto intermediate = add(bcast, resolution_inp);

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -18,7 +18,7 @@
 #include <test/utils.h>
 #include <test/validator.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <cstdlib>
 #include <filesystem>
 #include <system_error>
@@ -36,7 +36,7 @@ TEST_F(NVFuserTest, FusionSplitDims_CUDA) {
   scheduler_utils::splitDims(
       tv, {{0, p(2)}, {0, p(1)}, {3, p(6)}, {6, p(10)}}, dims);
   EXPECT_EQ(tv->nDims(), 11);
-  for (auto i : std::views::iota(0, 11)) {
+  for (auto i : irange(11)) {
     EXPECT_EQ(tv->axis(i)->extent()->evaluateInt(), p(i));
   }
   std::vector<size_t> expect{0, 3, 4, 5, 7, 8, 9};
@@ -57,7 +57,7 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
   std::vector<int64_t> expect_shape{
       p(0), p(1), p(2) * p(3) * p(7) * p(8) * p(9), p(4), p(5), p(6), p(10)};
   EXPECT_EQ(tv->nDims(), expect_shape.size());
-  for (auto i : std::views::iota((size_t)0, expect_shape.size())) {
+  for (auto i : irange(expect_shape.size())) {
     EXPECT_EQ(tv->axis(i)->extent()->evaluateInt(), expect_shape[i]);
   }
   std::vector<size_t> expect_dims{0, 1, 2, 2, 3, 4, 5, 2, 2, 2, 6};
@@ -65,7 +65,7 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
   auto root_domain = tv->getRootDomain();
   auto num_merged_dim = to_merge.size();
   auto inputs = IterVisitor::getInputsTo({tv->axis(2)});
-  for (auto index : std::views::iota((size_t)0, num_merged_dim)) {
+  for (auto index : irange(num_merged_dim)) {
     EXPECT_TRUE(root_domain[to_merge[num_merged_dim - 1 - index]]->sameAs(
         inputs[index]));
   }
@@ -965,7 +965,7 @@ TEST_F(VectorizeHelperTest, SpanningTree_CUDA) {
   inputs.push_back(bcast_inp);
   auto bcast = broadcast(bcast_inp, {false, true});
 
-  for (auto i : std::views::iota(0, 10)) {
+  for (auto i : irange(10)) {
     auto resolution_inp = makeContigConcreteTensor({2, 2});
     inputs.push_back(resolution_inp);
     auto intermediate = add(bcast, resolution_inp);

--- a/test/test_gpu_view.cpp
+++ b/test/test_gpu_view.cpp
@@ -48,6 +48,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
+#include <C++20/ranges>
 #include <algorithm>
 #include <iostream>
 
@@ -269,7 +270,7 @@ void reductionViewAddFusion(
     const auto kAxis = (kReductionAxis < 0)
         ? (kReductionAxis + input_shape.size())
         : kReductionAxis;
-    for (auto i : c10::irange(input_shape.size())) {
+    for (auto i : std::views::iota((size_t)0, input_shape.size())) {
       if (reshape_before_reduction || i != kAxis) {
         reshape_shape.push_back(input_shape[i]);
       }
@@ -1391,7 +1392,7 @@ TEST_F(NVFuserTest, FusionPwiseViewSchedule_CUDA) {
     MaxRootDomainInfoSpanningTree(tv4).traverse(&propagator);
   }
 
-  for (auto i : c10::irange(tv5->nDims() - 1)) {
+  for (auto i : std::views::iota((size_t)0, tv5->nDims() - 1)) {
     (void)i; // Suppress unused variable warning
     tv5->merge(0);
   }

--- a/test/test_gpu_view.cpp
+++ b/test/test_gpu_view.cpp
@@ -48,7 +48,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <iostream>
 
@@ -270,7 +270,7 @@ void reductionViewAddFusion(
     const auto kAxis = (kReductionAxis < 0)
         ? (kReductionAxis + input_shape.size())
         : kReductionAxis;
-    for (auto i : std::views::iota((size_t)0, input_shape.size())) {
+    for (auto i : irange(input_shape.size())) {
       if (reshape_before_reduction || i != kAxis) {
         reshape_shape.push_back(input_shape[i]);
       }
@@ -1392,7 +1392,7 @@ TEST_F(NVFuserTest, FusionPwiseViewSchedule_CUDA) {
     MaxRootDomainInfoSpanningTree(tv4).traverse(&propagator);
   }
 
-  for (auto i : std::views::iota((size_t)0, tv5->nDims() - 1)) {
+  for (auto i : irange(tv5->nDims() - 1)) {
     (void)i; // Suppress unused variable warning
     tv5->merge(0);
   }

--- a/test/test_multidevice.cpp
+++ b/test/test_multidevice.cpp
@@ -44,7 +44,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <algorithm>
 #include <iostream>
 
@@ -67,7 +67,7 @@ void testValidateMultidevice(
 
   // gathering all the inputs at tester
   std::vector<c10::IValue> input_tensors;
-  for (auto i : std::views::iota((size_t)0, inputs.size())) {
+  for (auto i : irange(inputs.size())) {
     auto sender = runtime.pipeline()
                       ->inputs()
                       .at(i)
@@ -86,7 +86,7 @@ void testValidateMultidevice(
 
   // gathering all the outputs at tester
   std::vector<at::Tensor> output_tensors;
-  for (auto i : std::views::iota((size_t)0, outputs.size())) {
+  for (auto i : irange(outputs.size())) {
     auto sender = runtime.pipeline()
                       ->outputs()
                       .at(i)

--- a/test/test_multidevice.cpp
+++ b/test/test_multidevice.cpp
@@ -44,6 +44,7 @@
 #include <ATen/cuda/Exceptions.h>
 #include <c10/cuda/CUDAStream.h>
 
+#include <C++20/ranges>
 #include <algorithm>
 #include <iostream>
 
@@ -66,7 +67,7 @@ void testValidateMultidevice(
 
   // gathering all the inputs at tester
   std::vector<c10::IValue> input_tensors;
-  for (auto i : c10::irange(inputs.size())) {
+  for (auto i : std::views::iota((size_t)0, inputs.size())) {
     auto sender = runtime.pipeline()
                       ->inputs()
                       .at(i)
@@ -85,7 +86,7 @@ void testValidateMultidevice(
 
   // gathering all the outputs at tester
   std::vector<at::Tensor> output_tensors;
-  for (auto i : c10::irange(outputs.size())) {
+  for (auto i : std::views::iota((size_t)0, outputs.size())) {
     auto sender = runtime.pipeline()
                       ->outputs()
                       .at(i)

--- a/test/test_multidevice_communications.cpp
+++ b/test/test_multidevice_communications.cpp
@@ -12,7 +12,7 @@
 #include <multidevice/communicator.h>
 #include <test/multidevice.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 #include <iostream>
 
 namespace nvfuser {
@@ -40,7 +40,7 @@ TEST_F(MultiDeviceTest, Communication_Gather) {
   }
   auto communication = Gather(params);
 
-  for (int j : std::views::iota(0, number_of_repetitions)) {
+  for (int j : irange(number_of_repetitions)) {
     params.src_bufs.at(0).copy_(
         at::arange(tensor_size, options) + (comm.deviceId() + 1) * j);
     for (auto& buf : params.dst_bufs) {
@@ -51,7 +51,7 @@ TEST_F(MultiDeviceTest, Communication_Gather) {
     work->wait();
 
     if (comm.deviceId() == root) {
-      for (int i : std::views::iota((int64_t)0, comm.size())) {
+      for (int i : irange(comm.size())) {
         auto obtained = params.dst_bufs.at(i);
         auto ref = at::arange(tensor_size, options) + (i + 1) * j;
         NVF_ERROR(
@@ -84,7 +84,7 @@ TEST_F(MultiDeviceTest, Communication_Allgather) {
   }
   auto communication = Allgather(params);
 
-  for (int j : std::views::iota(0, number_of_repetitions)) {
+  for (int j : irange(number_of_repetitions)) {
     params.src_bufs.at(0).copy_(
         at::arange(tensor_size, options) + (comm.deviceId() + 1) * j);
     for (auto& buf : params.dst_bufs) {
@@ -94,7 +94,7 @@ TEST_F(MultiDeviceTest, Communication_Allgather) {
     auto work = communication.post(comm);
     work->wait();
 
-    for (int i : std::views::iota((int64_t)0, comm.size())) {
+    for (int i : irange(comm.size())) {
       auto obtained = params.dst_bufs.at(i);
       auto ref = at::arange(tensor_size, options) + (i + 1) * j;
       NVF_ERROR(
@@ -129,9 +129,9 @@ TEST_F(MultiDeviceTest, Communication_Scatter) {
   params.dst_bufs = {at::empty(tensor_size, options)};
   auto communication = Scatter(params);
 
-  for (int j : std::views::iota(0, number_of_repetitions)) {
+  for (int j : irange(number_of_repetitions)) {
     params.dst_bufs.at(0).copy_(at::zeros(tensor_size, options));
-    for (int i : std::views::iota((size_t)0, params.src_bufs.size())) {
+    for (int i : irange(params.src_bufs.size())) {
       params.src_bufs.at(i).copy_(
           at::arange(tensor_size, options) + (i + 1) * j);
     }
@@ -171,7 +171,7 @@ TEST_F(MultiDeviceTest, Communication_Broadcast) {
 
   auto communication = Broadcast(params);
 
-  for (int j : std::views::iota(0, number_of_repetitions)) {
+  for (int j : irange(number_of_repetitions)) {
     if (comm.deviceId() == root) {
       params.src_bufs.at(0).copy_(at::arange(tensor_size, options) + j);
     }
@@ -219,7 +219,7 @@ TEST_F(MultiDeviceTest, Communication_SendRecv) {
   }
   auto communication = SendRecv(params);
 
-  for (int j : std::views::iota(0, number_of_repetitions)) {
+  for (int j : irange(number_of_repetitions)) {
     if (comm.deviceId() == sender) {
       params.src_bufs.at(0).copy_(at::arange(tensor_size, options) + j);
     } else {
@@ -264,7 +264,7 @@ TEST_F(MultiDeviceTest, Communication_SendRecvToSelf) {
   params.dst_bufs.push_back(at::empty(tensor_size, options));
   auto communication = SendRecv(params);
 
-  for (int j : std::views::iota(0, number_of_repetitions)) {
+  for (int j : irange(number_of_repetitions)) {
     params.src_bufs.at(0).copy_(at::arange(tensor_size, options) + j);
     params.dst_bufs.at(0).copy_(at::zeros(tensor_size, options));
 

--- a/test/test_multidevice_communications.cpp
+++ b/test/test_multidevice_communications.cpp
@@ -12,6 +12,7 @@
 #include <multidevice/communicator.h>
 #include <test/multidevice.h>
 
+#include <C++20/ranges>
 #include <iostream>
 
 namespace nvfuser {
@@ -39,7 +40,7 @@ TEST_F(MultiDeviceTest, Communication_Gather) {
   }
   auto communication = Gather(params);
 
-  for (int j : c10::irange(number_of_repetitions)) {
+  for (int j : std::views::iota(0, number_of_repetitions)) {
     params.src_bufs.at(0).copy_(
         at::arange(tensor_size, options) + (comm.deviceId() + 1) * j);
     for (auto& buf : params.dst_bufs) {
@@ -50,7 +51,7 @@ TEST_F(MultiDeviceTest, Communication_Gather) {
     work->wait();
 
     if (comm.deviceId() == root) {
-      for (int i : c10::irange(comm.size())) {
+      for (int i : std::views::iota((int64_t)0, comm.size())) {
         auto obtained = params.dst_bufs.at(i);
         auto ref = at::arange(tensor_size, options) + (i + 1) * j;
         NVF_ERROR(
@@ -83,7 +84,7 @@ TEST_F(MultiDeviceTest, Communication_Allgather) {
   }
   auto communication = Allgather(params);
 
-  for (int j : c10::irange(number_of_repetitions)) {
+  for (int j : std::views::iota(0, number_of_repetitions)) {
     params.src_bufs.at(0).copy_(
         at::arange(tensor_size, options) + (comm.deviceId() + 1) * j);
     for (auto& buf : params.dst_bufs) {
@@ -93,7 +94,7 @@ TEST_F(MultiDeviceTest, Communication_Allgather) {
     auto work = communication.post(comm);
     work->wait();
 
-    for (int i : c10::irange(comm.size())) {
+    for (int i : std::views::iota((int64_t)0, comm.size())) {
       auto obtained = params.dst_bufs.at(i);
       auto ref = at::arange(tensor_size, options) + (i + 1) * j;
       NVF_ERROR(
@@ -128,9 +129,9 @@ TEST_F(MultiDeviceTest, Communication_Scatter) {
   params.dst_bufs = {at::empty(tensor_size, options)};
   auto communication = Scatter(params);
 
-  for (int j : c10::irange(number_of_repetitions)) {
+  for (int j : std::views::iota(0, number_of_repetitions)) {
     params.dst_bufs.at(0).copy_(at::zeros(tensor_size, options));
-    for (int i : c10::irange(params.src_bufs.size())) {
+    for (int i : std::views::iota((size_t)0, params.src_bufs.size())) {
       params.src_bufs.at(i).copy_(
           at::arange(tensor_size, options) + (i + 1) * j);
     }
@@ -170,7 +171,7 @@ TEST_F(MultiDeviceTest, Communication_Broadcast) {
 
   auto communication = Broadcast(params);
 
-  for (int j : c10::irange(number_of_repetitions)) {
+  for (int j : std::views::iota(0, number_of_repetitions)) {
     if (comm.deviceId() == root) {
       params.src_bufs.at(0).copy_(at::arange(tensor_size, options) + j);
     }
@@ -218,7 +219,7 @@ TEST_F(MultiDeviceTest, Communication_SendRecv) {
   }
   auto communication = SendRecv(params);
 
-  for (int j : c10::irange(number_of_repetitions)) {
+  for (int j : std::views::iota(0, number_of_repetitions)) {
     if (comm.deviceId() == sender) {
       params.src_bufs.at(0).copy_(at::arange(tensor_size, options) + j);
     } else {
@@ -263,7 +264,7 @@ TEST_F(MultiDeviceTest, Communication_SendRecvToSelf) {
   params.dst_bufs.push_back(at::empty(tensor_size, options));
   auto communication = SendRecv(params);
 
-  for (int j : c10::irange(number_of_repetitions)) {
+  for (int j : std::views::iota(0, number_of_repetitions)) {
     params.src_bufs.at(0).copy_(at::arange(tensor_size, options) + j);
     params.dst_bufs.at(0).copy_(at::zeros(tensor_size, options));
 

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -12,7 +12,7 @@
 #include <test/utils.h>
 #include <test/validator.h>
 
-#include <C++20/ranges>
+#include <ranges.h>
 
 namespace nvfuser {
 
@@ -754,7 +754,7 @@ TEST_F(ResizeTest, FusionResizeCat7) {
     FusionGuard fg(&fusion);
 
     std::vector<TensorView*> inputs;
-    for (const auto i : std::views::iota(0, num_tensors_to_concat)) {
+    for (const auto i : irange(num_tensors_to_concat)) {
       (void)i;
       // concrete shapes to avoid dynamic Fusion
       auto shape = base_shape;
@@ -782,7 +782,7 @@ TEST_F(ResizeTest, FusionResizeCat7) {
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
     std::vector<at::Tensor> aten_inputs;
-    for (const auto i : std::views::iota(0, num_tensors_to_concat)) {
+    for (const auto i : irange(num_tensors_to_concat)) {
       auto shape = base_shape;
       shape[concat_dim] = 10 + (i % 5);
       aten_inputs.emplace_back(at::randn(shape, options));
@@ -2430,7 +2430,7 @@ TEST_F(NVFuserTest, ResizePadToBroadcastStatic_CUDA) {
                      ->definition()
                      ->inputs()[1]
                      ->as<TensorView>();
-  for (auto i : std::views::iota((size_t)0, expected_itertypes.size())) {
+  for (auto i : irange(expected_itertypes.size())) {
     EXPECT_EQ(conc_t2->axis(i)->getIterType(), expected_itertypes.at(i));
   }
 
@@ -3029,7 +3029,7 @@ TEST_F(ResizeTest, SliceAndReshapeRepro540Manual) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  for (const auto i : std::views::iota(0, 3)) {
+  for (const auto i : irange(3)) {
     auto slice_out_ref = t0.index(
         {at::indexing::Slice(0, at::indexing::None),
          at::indexing::Slice(0, at::indexing::None),

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -12,6 +12,8 @@
 #include <test/utils.h>
 #include <test/validator.h>
 
+#include <C++20/ranges>
+
 namespace nvfuser {
 
 class ResizeTest : public NVFuserTest {};
@@ -752,7 +754,7 @@ TEST_F(ResizeTest, FusionResizeCat7) {
     FusionGuard fg(&fusion);
 
     std::vector<TensorView*> inputs;
-    for (const auto i : c10::irange(num_tensors_to_concat)) {
+    for (const auto i : std::views::iota(0, num_tensors_to_concat)) {
       (void)i;
       // concrete shapes to avoid dynamic Fusion
       auto shape = base_shape;
@@ -780,7 +782,7 @@ TEST_F(ResizeTest, FusionResizeCat7) {
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
     std::vector<at::Tensor> aten_inputs;
-    for (const auto i : c10::irange(num_tensors_to_concat)) {
+    for (const auto i : std::views::iota(0, num_tensors_to_concat)) {
       auto shape = base_shape;
       shape[concat_dim] = 10 + (i % 5);
       aten_inputs.emplace_back(at::randn(shape, options));
@@ -2428,7 +2430,7 @@ TEST_F(NVFuserTest, ResizePadToBroadcastStatic_CUDA) {
                      ->definition()
                      ->inputs()[1]
                      ->as<TensorView>();
-  for (auto i : c10::irange(expected_itertypes.size())) {
+  for (auto i : std::views::iota((size_t)0, expected_itertypes.size())) {
     EXPECT_EQ(conc_t2->axis(i)->getIterType(), expected_itertypes.at(i));
   }
 
@@ -3027,7 +3029,7 @@ TEST_F(ResizeTest, SliceAndReshapeRepro540Manual) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  for (const auto i : c10::irange(3)) {
+  for (const auto i : std::views::iota(0, 3)) {
     auto slice_out_ref = t0.index(
         {at::indexing::Slice(0, at::indexing::None),
          at::indexing::Slice(0, at::indexing::None),


### PR DESCRIPTION
Backporting a small piece of C++20 ranges into C++17. Not perfect, but the used behavior should be identical. In the future, `TensorDomain::noReductions` and `ir_utils::filterByType` will also be ported as ranges. `TensorDomain::noReductions` is needed in a hot path, I want to avoid making a copy for it.