### PR TITLE
disable innerOuter schedule if iteration domain in inner reduction tv is not mapped to reduction domain in outer reduction tv

### DIFF
--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -40,12 +40,6 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     return false;
   }
 
-  if (ir_utils::hasOpsOfType<ExpandOp>(fusion)) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        schedule_heuristic, "ExpandOp is not supported.");
-    return false;
-  }
-
   // check reduction type
   auto reduction_tvs = scheduler_utils::getReductionTvs(fusion);
   if (reduction_tvs.empty()) {
@@ -94,6 +88,14 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     scheduler_debug_utils::canScheduleRejectReason(
         schedule_heuristic,
         "to use combined reduction, inner reduction and outer reduction should not have shared consumer, their consumers should not have shared non-outer-reduction producer.");
+    return false;
+  }
+
+  if (!normalization_scheduler_utils::checkProducersOfReductionTvs(
+          inner_reduction_tvs, outer_reduction_tvs)) {
+    scheduler_debug_utils::canScheduleRejectReason(
+        schedule_heuristic,
+        "to use combined reduction, reduction tv shouldn't be produced directly or indirectly by other reduction tvs.");
     return false;
   }
 

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -91,7 +91,7 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     return false;
   }
 
-  if (!normalization_scheduler_utils::checkProducersOfReductionTvs(
+  if (normalization_scheduler_utils::isChainedReduction(
           inner_reduction_tvs, outer_reduction_tvs)) {
     scheduler_debug_utils::canScheduleRejectReason(
         schedule_heuristic,

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -142,7 +142,7 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     }
   }
 
-  // the reduction axis of outer reduction tv should math to the iteration axis
+  // the reduction axis of outer reduction tv should match to the iteration axis
   // of the inner reduction tv.
   if (!normalization_scheduler_utils::isReductionIterationAxisMatched(
           inner_reduction_tvs, outer_reduction_tvs)) {

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -142,7 +142,7 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     }
   }
 
-  // the reduction axis of outer reduction tv should equal to the iteration axis
+  // the reduction axis of outer reduction tv should math to the iteration axis
   // of the inner reduction tv.
   if (!normalization_scheduler_utils::isReductionIterationAxisMatched(
           inner_reduction_tvs, outer_reduction_tvs)) {

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -91,11 +91,10 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     return false;
   }
 
-  if (normalization_scheduler_utils::isChainedReduction(
-          inner_reduction_tvs, outer_reduction_tvs)) {
+  if (normalization_scheduler_utils::isChainedReduction(inner_reduction_tvs) ||
+      normalization_scheduler_utils::isChainedReduction(outer_reduction_tvs)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        schedule_heuristic,
-        "to use combined reduction, reduction tv shouldn't be produced directly or indirectly by other reduction tvs.");
+        schedule_heuristic, "chained reduction is not supported.");
     return false;
   }
 

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -40,6 +40,12 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     return false;
   }
 
+  if (ir_utils::hasOpsOfType<ExpandOp>(fusion)) {
+    scheduler_debug_utils::canScheduleRejectReason(
+        schedule_heuristic, "ExpandOp is not supported.");
+    return false;
+  }
+
   // check reduction type
   auto reduction_tvs = scheduler_utils::getReductionTvs(fusion);
   if (reduction_tvs.empty()) {

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -901,8 +901,6 @@ void scheduleReductionCombinedOuter(
     // merge tensorview to [reduction, iteraiton] domains
     mergeReductionOrIterDomains(outer_reduction_tv, true);
     mergeReductionOrIterDomains(outer_reduction_tv, false);
-    std::cout << "outer_reduction_tv: " << outer_reduction_tv->toString()
-              << std::endl;
     if (rparams.multiple_reds_per_blk) {
       outer_reduction_tv->split(
           0, NamedScalar::getParallelDim(rparams.block_dim_iter_dom));
@@ -1060,19 +1058,8 @@ void scheduleInnerOuterPersistentKernel(
 
   // Propagate inner reduction. There is a cutoff at boundaryNodesSet, so this
   // propagation will not propagate to the final outer reduction.
-  std::cout << "\npropagateTransformation with inner_reference_tv: "
-            << inner_reference_tv->toString() << std::endl;
-  for (auto tv : boundaryNodesSet) {
-    std::cout << "boundaryNodesSet: " << tv->toString() << std::endl;
-  }
-  fusion->print();
-
   reduction_scheduler_utils::propagateTransformation(
       inner_reference_tv, boundaryNodesSet);
-
-  std::cout << "\npropagateRFactor with inner_reduction_tvs[0]: "
-            << inner_reduction_tvs[0]->toString() << std::endl;
-
   reduction_scheduler_utils::propagateRFactor(
       inner_reference_tv, inner_reduction_tvs[0], inner_reduction_tvs);
 

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -611,7 +611,11 @@ bool isReductionIterationAxisMatched(
   std::vector<bool> is_reduction(reference_tv->nDims(), false);
   for (const auto i : c10::irange(reference_tv->nDims())) {
     auto id = reference_tv->axis((int)i);
-    NVF_CHECK(!id->isBroadcast(), "Shouldn't have a broadcast domain.");
+    NVF_CHECK(
+        id->getIterType() == IterType::Iteration ||
+            id->getIterType() == IterType::Reduction,
+        "Invalid iteration type: ",
+        id->getIterType());
     if (id->isReduction()) {
       is_reduction[i] = true;
     }
@@ -622,7 +626,12 @@ bool isReductionIterationAxisMatched(
     auto tv = inner_reduction_tvs[i];
     for (const auto i : c10::irange(tv->nDims())) {
       auto id = tv->axis((int)i);
-      NVF_CHECK(!id->isBroadcast(), "Shouldn't have a broadcast domain.");
+      NVF_CHECK(
+          id->getIterType() == IterType::Iteration ||
+              id->getIterType() == IterType::Reduction,
+          "Invalid iteration type: ",
+          id->getIterType());
+
       if (id->isReduction() != is_reduction.at(i)) {
         return false;
       }
@@ -632,7 +641,12 @@ bool isReductionIterationAxisMatched(
   for (auto tv : outer_reduction_tvs) {
     for (const auto i : c10::irange(tv->nDims())) {
       auto id = tv->axis((int)i);
-      NVF_CHECK(!id->isBroadcast(), "Shouldn't have a broadcast domain.");
+      NVF_CHECK(
+          id->getIterType() == IterType::Iteration ||
+              id->getIterType() == IterType::Reduction,
+          "Invalid iteration type: ",
+          id->getIterType());
+
       if (id->isIteration() != is_reduction.at(i)) {
         return false;
       }

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -619,7 +619,7 @@ bool isReductionIterationAxisMatched(
   for (auto i : c10::irange(1, inner_reduction_tvs.size())) {
     auto tv = inner_reduction_tvs[i];
     for (const auto i : c10::irange(tv->nDims())) {
-      if (tv->axis((int)i)->isReduction() != is_reduction[i]) {
+      if (tv->axis((int)i)->isReduction() != is_reduction.at(i)) {
         return false;
       }
     }

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -604,7 +604,9 @@ bool isConnectedOnlyThroughReductionProducer(
 bool isReductionIterationAxisMatched(
     const std::vector<TensorView*>& inner_reduction_tvs,
     const std::vector<TensorView*>& outer_reduction_tvs) {
-  // set up reference
+  // set up reference, checkIfReductionsAreInnerOuter already ensures all the
+  // iteration domains are either iteration or reduction, so we can just use a
+  // vector of bool.
   auto reference_tv = inner_reduction_tvs[0];
   std::vector<bool> is_reduction(reference_tv->nDims(), false);
   for (const auto i : c10::irange(reference_tv->nDims())) {
@@ -612,7 +614,7 @@ bool isReductionIterationAxisMatched(
       is_reduction[i] = true;
     }
   }
-  // check other inner reduction tvs, , the corresponding axis should be
+  // check other inner reduction tvs, the corresponding axis should be
   // reduction.
   for (auto i : c10::irange(1, inner_reduction_tvs.size())) {
     auto tv = inner_reduction_tvs[i];

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -605,7 +605,7 @@ bool isReductionIterationAxisMatched(
     const std::vector<TensorView*>& inner_reduction_tvs,
     const std::vector<TensorView*>& outer_reduction_tvs) {
   // set up reference, checkIfReductionsAreInnerOuter already ensures all the
-  // iteration domains are either iteration or reduction, so we can just use a
+  // tensor domains are either iteration or reduction, so we can just use a
   // vector of bool.
   auto reference_tv = inner_reduction_tvs[0];
   std::vector<bool> is_reduction(reference_tv->nDims(), false);

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -610,7 +610,9 @@ bool isReductionIterationAxisMatched(
   auto reference_tv = inner_reduction_tvs[0];
   std::vector<bool> is_reduction(reference_tv->nDims(), false);
   for (const auto i : c10::irange(reference_tv->nDims())) {
-    if (reference_tv->axis((int)i)->isReduction()) {
+    auto id = reference_tv->axis((int)i);
+    NVF_CHECK(!id->isBroadcast(), "Shouldn't have a broadcast domain.");
+    if (id->isReduction()) {
       is_reduction[i] = true;
     }
   }
@@ -619,7 +621,9 @@ bool isReductionIterationAxisMatched(
   for (auto i : c10::irange(1, inner_reduction_tvs.size())) {
     auto tv = inner_reduction_tvs[i];
     for (const auto i : c10::irange(tv->nDims())) {
-      if (tv->axis((int)i)->isReduction() != is_reduction.at(i)) {
+      auto id = tv->axis((int)i);
+      NVF_CHECK(!id->isBroadcast(), "Shouldn't have a broadcast domain.");
+      if (id->isReduction() != is_reduction.at(i)) {
         return false;
       }
     }
@@ -627,7 +631,9 @@ bool isReductionIterationAxisMatched(
   // check outer reduction tvs, the corresponding axis should be iteration.
   for (auto tv : outer_reduction_tvs) {
     for (const auto i : c10::irange(tv->nDims())) {
-      if (tv->axis((int)i)->isIteration() != is_reduction[i]) {
+      auto id = tv->axis((int)i);
+      NVF_CHECK(!id->isBroadcast(), "Shouldn't have a broadcast domain.");
+      if (id->isIteration() != is_reduction.at(i)) {
         return false;
       }
     }

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -632,14 +632,14 @@ bool hasReductionInAllProducers(
 }
 } // namespace
 
-bool checkProducersOfReductionTvs(
+bool isChainedReduction(
     const std::vector<TensorView*>& inner_reduction_tvs,
     const std::vector<TensorView*>& outer_reduction_tvs) {
   // check producers of inner_reduction_tvs
   std::unordered_set<TensorView*> visited_tvs_inner;
   for (auto tv : inner_reduction_tvs) {
     if (hasReductionInAllProducers(tv, visited_tvs_inner)) {
-      return false;
+      return true;
     }
   }
 
@@ -647,11 +647,11 @@ bool checkProducersOfReductionTvs(
   std::unordered_set<TensorView*> visited_tvs_outer;
   for (auto tv : outer_reduction_tvs) {
     if (hasReductionInAllProducers(tv, visited_tvs_outer)) {
-      return false;
+      return true;
     }
   }
 
-  return true;
+  return false;
 }
 
 int64_t partialReductionBufferSize(

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -179,11 +179,8 @@ bool isConnectedOnlyThroughReductionProducer(
     const std::vector<TensorView*>& inner_reduction_tvs,
     const std::vector<TensorView*>& outer_reduction_tvs);
 
-// Checks if any outer reduction tensor is produced directly or indirectly
-// by inner reduction tensor, and vice-versa.
-bool isChainedReduction(
-    const std::vector<TensorView*>& inner_reduction_tvs,
-    const std::vector<TensorView*>& outer_reduction_tvs);
+// Returns true if a reduction tv depends on another reduction tv.
+bool isChainedReduction(const std::vector<TensorView*>& reduction_tvs);
 
 //! in combined_inner_outer_reduction, the partial results of outer reductions
 //! must be persistent, calculate the size of these buffers when estimate

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -179,6 +179,12 @@ bool isConnectedOnlyThroughReductionProducer(
     const std::vector<TensorView*>& inner_reduction_tvs,
     const std::vector<TensorView*>& outer_reduction_tvs);
 
+// Checks if any outer reduction tensor is produced directly or indirectly
+// by inner reduction tensor, and vice-versa.
+bool checkProducersOfReductionTvs(
+    const std::vector<TensorView*>& inner_reduction_tvs,
+    const std::vector<TensorView*>& outer_reduction_tvs);
+
 //! in combined_inner_outer_reduction, the partial results of outer reductions
 //! must be persistent, calculate the size of these buffers when estimate
 //! register usage

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -179,8 +179,11 @@ bool isConnectedOnlyThroughReductionProducer(
     const std::vector<TensorView*>& inner_reduction_tvs,
     const std::vector<TensorView*>& outer_reduction_tvs);
 
-// Returns true if a reduction tv depends on another reduction tv.
-bool isChainedReduction(const std::vector<TensorView*>& reduction_tvs);
+// Returns true if every iteration domain in inner reduction tv is a reduction
+// domain in outer reduction tv.
+bool isReductionIterationAxisMatched(
+    const std::vector<TensorView*>& inner_reduction_tvs,
+    const std::vector<TensorView*>& outer_reduction_tvs);
 
 //! in combined_inner_outer_reduction, the partial results of outer reductions
 //! must be persistent, calculate the size of these buffers when estimate

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -181,7 +181,7 @@ bool isConnectedOnlyThroughReductionProducer(
 
 // Checks if any outer reduction tensor is produced directly or indirectly
 // by inner reduction tensor, and vice-versa.
-bool checkProducersOfReductionTvs(
+bool isChainedReduction(
     const std::vector<TensorView*>& inner_reduction_tvs,
     const std::vector<TensorView*>& outer_reduction_tvs);
 

--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -1033,7 +1033,6 @@ TEST_F(NVFuserTest, CombinedSchedulerInnerOuterMismatch) {
     FusionExecutorCache fec(std::move(fusion_ptr));
     auto cg_outputs = fec.runFusionWithInputs(aten_inputs);
 
-    // combined scheduler can sill schedule as an un-segmented fusion
     bool is_segmented = fec.getMostRecentKernelRuntime()->isSegmented();
     if (outer_reduction_axis.size() == 2) {
       NVF_ERROR(!is_segmented, "Fusion should NOT be segmented!");


### PR DESCRIPTION
In #1023, the iteration domain in inner reduction tv is not mapped to reduction domain in outer reduction tv.
I can reproduce the error with a simple fusion:
```
Inputs:
  T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ], float
Outputs:
  T3_g[ iS9{i0}, iS10{i2}, iS11{i3} ], float
  T4_g[ rS12{i0}, iS13{i2}, iS14{i3} ], float

%kernel_math {
T1_l[ iS3{i0}, iS4{i2}, rS5{i3} ]
   = reduction( T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ], op = add, initial value = float(0), allreduce = false )
T2_l[ iS6{i0}, iS7{i2}, bS8{1} ]
   = broadcast( T1_l[ iS3{i0}, iS4{i2}, rS5{i3} ] )
T3_g[ iS9{i0}, iS10{i2}, iS11{i3} ]
   = T2_l[ iS6{i0}, iS7{i2}, bS8{1} ]
   + T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ];
T4_g[ rS12{i0}, iS13{i2}, iS14{i3} ]
   = reduction( T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ], op = add, initial value = float(0), allreduce = false )
}
}
```
In this fusion, inner reduction is `T1_g[ iS3{i0}, iS4{i2}, rS5{i3} ]`, outer reduction is `T4_g[ rS12{i0}, iS13{i2}, iS14{i3} ]`, The axis `iS4{i2}` in `T1_g` should be a reduction in `T4_g`, otherwise we can't do a partial outer reduction while iterating the iteration domain of inner reduction. 