### PR TITLE
Remove --no-allow-shlib-undefined as our dependencies may not have correct dependencies, e.g., c10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(nvfuser)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-allow-shlib-undefined")
 
 # compensating the lack of PROJECT_IS_TOP_LEVEL for older cmake version
 if(CMAKE_VERSION VERSION_LESS 3.21)


### PR DESCRIPTION
See https://github.com/NVIDIA/Fuser/pull/1010#issuecomment-1747648452