### PR TITLE
Fill the final loop promotion map 

### DIFF
--- a/csrc/id_model/id_graphs.h
+++ b/csrc/id_model/id_graphs.h
@@ -167,6 +167,10 @@ class TORCH_CUDA_CU_API IterDomainGraphs : public PolymorphicBase {
   // not have any registered uses or definitions.
   IterDomain* cloneIterDomain(IterDomain* id);
 
+  const std::unordered_map<IdGroup, IterDomain*> loopPromotionMap() const {
+    return loop_promotion_map_;
+  }
+
   // TODO: Should this not be private?
  protected:
   // Sometimes fusion inputs or outputs are disconnected from expressions, in

--- a/csrc/id_model/utils.h
+++ b/csrc/id_model/utils.h
@@ -1,0 +1,65 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include "utils.h"
+
+#include <functional>
+#include <iostream>
+#include <sstream>
+
+#define VERBOSE() verbose(__LINE__)
+#define WARN() warn(__LINE__)
+
+namespace nvfuser {
+
+// Temporary logging utility
+class DebugStream {
+ public:
+  DebugStream()
+      : enabled_(getNvFuserEnv("ID_MODEL_VERBOSE")), out_(std::cerr) {}
+
+  virtual ~DebugStream() {
+    // std::cerr << "\n[DTOR]\n";
+    // if (enabled_) {
+    // ss_ << " [end-of-line]" << std::endl;
+    // std::cerr << ss_.str();
+    // }
+  }
+
+  template <typename T>
+  DebugStream& operator<<(const T& v) {
+    // std::cerr << "\nDEBUG:::" << v << std::endl;
+    // std::cerr << "Enabled:::" << enabled_ << std::endl;
+    if (enabled_) {
+      out_ << v;
+    }
+    return *this;
+  }
+
+  DebugStream& operator<<(std::ostream& (*endl)(std::ostream&)) {
+    if (enabled_) {
+      out_ << endl;
+    }
+    return *this;
+  }
+
+ private:
+  bool enabled_ = false;
+  std::ostream& out_;
+};
+
+inline DebugStream verbose(int line) {
+  return DebugStream() << "[DEBUG@" << line << "] ";
+}
+
+inline DebugStream warn(int line) {
+  return DebugStream() << "[WARN@" << line << "] ";
+}
+
+} // namespace nvfuser

--- a/csrc/id_model/utils.h
+++ b/csrc/id_model/utils.h
@@ -24,18 +24,8 @@ class DebugStream {
   DebugStream()
       : enabled_(getNvFuserEnv("ID_MODEL_VERBOSE")), out_(std::cerr) {}
 
-  virtual ~DebugStream() {
-    // std::cerr << "\n[DTOR]\n";
-    // if (enabled_) {
-    // ss_ << " [end-of-line]" << std::endl;
-    // std::cerr << ss_.str();
-    // }
-  }
-
   template <typename T>
   DebugStream& operator<<(const T& v) {
-    // std::cerr << "\nDEBUG:::" << v << std::endl;
-    // std::cerr << "Enabled:::" << enabled_ << std::endl;
     if (enabled_) {
       out_ << v;
     }


### PR DESCRIPTION
This PR adds structural validations of loop graphs and promotions of one of the most important tests, `Indexing19`. In order to do so, it introduces a minimal set of changes as follows:

- Enable building loop graphs and promotion mappings even for `Fusion`
- Populate a map from loop ID groups to their promotion domains, which is temporarily done at the very end of `buildLoopPromotionMap`.

Some cleanups are needed, but I will iteratively work on cleanups as well as functional changes. This PR severs as the baseline for forthcoming PRs as well as making sure my understanding is correct.