### PR TITLE
`evaluate` method for `ReductionOp`

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -883,6 +883,9 @@ class ReductionOp : public Expr {
 
   std::string toString(int indent_size = 0) const override;
   std::string toInlineString(int indent_size = 0) const override;
+  std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
+      const std::vector<PolymorphicValue>& inputs) const override;
 
   Val* out() const {
     return output(0);

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -1345,10 +1345,11 @@ std::vector<PolymorphicValue> ReductionOp::evaluate(
       "Evaluation for rFactored reductions is not supported.");
 
   std::vector<int64_t> reduction_axes;
-  for (const auto i : c10::irange(output->getRootDomain().size())) {
+  for (const auto i : c10::irange(int64_t(output->getRootDomain().size()))) {
     auto ax = output->getRootDomain().at(i);
-    if (ax->isReduction())
+    if (ax->isReduction()) {
       reduction_axes.push_back(i);
+    }
   }
   switch (getReductionOpType()) {
     case BinaryOpType::Add:
@@ -2643,8 +2644,9 @@ std::string IterDomain::toString(int indent_size) const {
     ss << extent()->toInlineString();
   }
   ss << "}";
-  if (isRFactorProduct())
+  if (isRFactorProduct()) {
     ss << "rf";
+  }
   if (hasPaddingToMultipleOfWarp()) {
     ss << "_p";
   }
@@ -3273,12 +3275,14 @@ bool TensorDomain::sameAs(const Statement* const other) const {
 bool TensorDomain::sameAs(
     const std::vector<IterDomain*>& lhs,
     const std::vector<IterDomain*>& rhs) {
-  if (lhs.size() != rhs.size())
+  if (lhs.size() != rhs.size()) {
     return false;
+  }
   size_t i = 0;
   for (auto td_lhs : lhs) {
-    if (!td_lhs->sameAs(rhs[i++]))
+    if (!td_lhs->sameAs(rhs[i++])) {
       return false;
+    }
   }
   return true;
 }
@@ -3393,8 +3397,9 @@ int64_t TensorDomain::posOf(IterDomain* id) const {
   NVF_ERROR(nDims() > 0, "Tried to find an axis in a 0-dim domain");
   int64_t i = 0;
   while (i < (int64_t)leaf_domain_.size()) {
-    if (leaf_domain_[i] == id)
+    if (leaf_domain_[i] == id) {
       return i;
+    }
     i++;
   }
   NVF_CHECK(false, "Provided id is not part of this domain.");
@@ -3415,8 +3420,9 @@ void TensorDomain::split(
     bool inner_split,
     bool trim_out_of_bounds) {
   NVF_ERROR(nDims() > 0, "Tried to do split on a 0-dim domain");
-  if (axis_ < 0)
+  if (axis_ < 0) {
     axis_ += (int)nDims();
+  }
 
   NVF_ERROR(
       axis_ >= 0 && (unsigned int)axis_ < nDims(),
@@ -3446,11 +3452,13 @@ void TensorDomain::split(
 // Merge "axis_o" and "axis_i" into 1 dimension
 void TensorDomain::merge(int axis_o, int axis_i) {
   NVF_ERROR(nDims() > 0, "Tried to do merge on a 0-dim domain");
-  if (axis_o < 0)
+  if (axis_o < 0) {
     axis_o += (int)nDims();
+  }
 
-  if (axis_i < 0)
+  if (axis_i < 0) {
     axis_i += (int)nDims();
+  }
 
   NVF_CHECK(
       axis_o >= 0 && (unsigned int)axis_o < nDims() && axis_i >= 0 &&

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -1341,7 +1341,7 @@ std::vector<PolymorphicValue> ReductionOp::evaluate(
   const auto output = out()->as<TensorView>();
 
   NVF_ERROR(
-      output->hasRFactor(),
+      !output->hasRFactor(),
       "Evaluation for rFactored reductions is not supported.");
 
   std::vector<int64_t> reduction_axes;

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -142,8 +142,6 @@ TEST_F(NVFuserTest, FusionGlobalIntermediateDefaultSchedule_CUDA) {
   at::Tensor t2 = at::randn({M, N}, options);
   at::Tensor t3 = at::randn({M, N}, options);
 
-  at::Tensor aten_output = (t1 + (t2 - t3)) - t0;
-
   std::vector<c10::IValue> aten_inputs = {t0, t1, t2, t3};
 
   FusionExecutor fe;
@@ -151,7 +149,7 @@ TEST_F(NVFuserTest, FusionGlobalIntermediateDefaultSchedule_CUDA) {
   auto cg_outputs = fe.runFusion({t0, t1, t2, t3});
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionConstCheck_CUDA) {
@@ -288,7 +286,7 @@ TEST_F(NVFuserTest, FusionComputeAtNonterminatingOutput_CUDA) {
 
   std::vector<at::Tensor> aten_outputs = {t2, t4, t3};
   testValidate(
-      &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder1_CUDA) {
@@ -329,7 +327,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder1_CUDA) {
   fe.compileFusion(&fusion, {aten_input});
   fe.runFusion({aten_input}, cg_outputs);
   testValidate(
-      &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder2_CUDA) {
@@ -376,7 +374,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder2_CUDA) {
   fe.runFusion({aten_input}, cg_outputs);
 
   testValidate(
-      &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder3_CUDA) {
@@ -436,7 +434,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder3_CUDA) {
     fe.runFusion({aten_input}, cg_outputs);
 
     testValidate(
-        &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
+        &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
   }
 }
 
@@ -489,7 +487,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder4_CUDA) {
   fe.runFusion(aten_inputs, cg_outputs);
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, aten_outputs, __LINE__, __FILE__);
+      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder5_CUDA) {
@@ -531,7 +529,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder5_CUDA) {
   std::vector<at::Tensor> aten_outputs = {t1, t3, t5};
 
   testValidate(
-      &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder6_CUDA) {
@@ -571,7 +569,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder6_CUDA) {
   fe.runFusion({aten_input}, {cg_output});
 
   testValidate(
-      &fusion, {cg_output}, {aten_input}, {aten_output}, __LINE__, __FILE__);
+      &fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder7_CUDA) {
@@ -618,7 +616,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder7_CUDA) {
   fe.runFusion({aten_input}, {cg_output});
 
   testValidate(
-      &fusion, {cg_output}, {aten_input}, {aten_output}, __LINE__, __FILE__);
+      &fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
 
 // Test predication of grid reduction
@@ -801,7 +799,7 @@ TEST_F(NVFuserTest, FusionReductionHalf_CUDA) {
       &fusion,
       cg_outputs,
       {aten_input},
-      {aten_output},
+{aten_output},
       __LINE__,
       __FILE__,
       "",
@@ -830,7 +828,7 @@ TEST_F(NVFuserTest, FusionReduceSingle_CUDA) {
 
   auto aten_output = aten_input.to(at::kDouble).sum({1});
   testValidate(
-      &fusion, cg_outputs, {aten_input}, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionReduceImplicitBroadcast_CUDA) {
@@ -869,7 +867,7 @@ TEST_F(NVFuserTest, FusionReduceImplicitBroadcast_CUDA) {
       &fusion,
       cg_outputs,
       {aten_input},
-      {aten_output},
+{aten_output},
       __LINE__,
       __FILE__,
       "",
@@ -916,7 +914,7 @@ TEST_F(NVFuserTest, FusionReduceImplicitBroadcast2_CUDA) {
       &fusion,
       cg_outputs,
       {aten_input},
-      {aten_output},
+{aten_output},
       __LINE__,
       __FILE__,
       "",
@@ -959,7 +957,7 @@ TEST_F(NVFuserTest, FusionReduceImplicitBroadcast3_CUDA) {
       &fusion,
       cg_outputs,
       {aten_input},
-      {aten_output},
+{aten_output},
       __LINE__,
       __FILE__,
       "",
@@ -991,7 +989,7 @@ TEST_F(NVFuserTest, FusionTrivialReduction_CUDA) {
   auto aten_output = aten_input.to(at::kDouble).sum({2});
 
   testValidate(
-      &fusion, cg_outputs, {aten_input}, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTrivialReduction2_CUDA) {
@@ -1025,7 +1023,7 @@ TEST_F(NVFuserTest, FusionTrivialReduction2_CUDA) {
   auto cg_outputs = fe.runFusion(aten_inputs, lparams);
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTrivialReduction3_CUDA) {
@@ -1058,7 +1056,7 @@ TEST_F(NVFuserTest, FusionTrivialReduction3_CUDA) {
   auto cg_outputs = fe.runFusion(aten_inputs, lparams);
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionInputsIdLookup_CUDA) {
@@ -1392,7 +1390,7 @@ TEST_F(NVFuserTest, FusionBiasGeluFwd_CUDA) {
       &fusion,
       cg_outputs,
       aten_inputs,
-      {aten_output_double},
+{aten_output_double},
       __LINE__,
       __FILE__);
 }
@@ -1482,7 +1480,7 @@ TEST_F(NVFuserTest, FusionBiasGeluBwd_CUDA) {
       &fusion,
       cg_outputs,
       aten_inputs,
-      aten_outputs,
+aten_outputs,
       __LINE__,
       __FILE__,
       "",
@@ -1540,7 +1538,6 @@ TEST_F(NVFuserTest, FusionIssue459_CUDA) {
       &fusion,
       cg_outputs,
       aten_inputs,
-      {aten_output, aten_output},
       __LINE__,
       __FILE__);
 }
@@ -1574,7 +1571,7 @@ TEST_F(NVFuserTest, FusionSmemIndexingSimple_CUDA) {
   auto cg_outputs = fe.runFusion({aten_input});
 
   testValidate(
-      &fusion, cg_outputs, {aten_input}, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSmemIndexing_CUDA) {
@@ -1723,7 +1720,7 @@ TEST_F(NVFuserTest, FusionCacheBeforeReduction_CUDA) {
   fe.runFusion({aten_input}, {cg_output});
 
   testValidate(
-      &fusion, {cg_output}, {aten_input}, {aten_output}, __LINE__, __FILE__);
+      &fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionCacheBeforeReduction2_CUDA) {
@@ -1764,7 +1761,7 @@ TEST_F(NVFuserTest, FusionCacheBeforeReduction2_CUDA) {
   auto cg_outputs = fe.runFusion({aten_input});
 
   testValidate(
-      &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue367_CUDA) {
@@ -1898,7 +1895,7 @@ TEST_F(NVFuserTest, FusionIssue468_CUDA) {
   auto cg_outputs = fe.runFusion({aten_input});
 
   testValidate(
-      &fusion, cg_outputs, {aten_input}, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue363_CUDA) {
@@ -1953,7 +1950,7 @@ TEST_F(NVFuserTest, FusionIssue363_CUDA) {
   auto cg_outputs = fe.runFusion(aten_inputs);
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue484_CUDA) {
@@ -1981,7 +1978,7 @@ TEST_F(NVFuserTest, FusionIssue484_CUDA) {
   auto cg_outputs = fe.runFusion({aten_input});
 
   testValidate(
-      &fusion, cg_outputs, {aten_input}, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue329_CUDA) {
@@ -2011,7 +2008,7 @@ TEST_F(NVFuserTest, FusionIssue329_CUDA) {
   auto cg_outputs = fe.runFusion({aten_input});
 
   testValidate(
-      &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue382_CUDA) {
@@ -2054,7 +2051,7 @@ TEST_F(NVFuserTest, FusionIssue382_CUDA) {
   auto cg_outputs = fe.runFusion(aten_inputs);
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue507_CUDA) {
@@ -2086,7 +2083,7 @@ TEST_F(NVFuserTest, FusionIssue507_CUDA) {
   auto cg_outputs = fe.runFusion({aten_input});
 
   testValidate(
-      &fusion, cg_outputs, {aten_input}, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue532_CUDA) {
@@ -2127,7 +2124,7 @@ TEST_F(NVFuserTest, FusionIssue532_CUDA) {
   at::Tensor aten_output = t0 + 1 + 1;
 
   testValidate(
-      &fusion, outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionLoopUnswitch_CUDA) {
@@ -2159,7 +2156,7 @@ TEST_F(NVFuserTest, FusionLoopUnswitch_CUDA) {
   at::Tensor aten_output = t0 + 1 + 1;
 
   testValidate(
-      &fusion, outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue549_CUDA) {
@@ -3822,7 +3819,7 @@ TEST_F(NVFuserTest, FusionGridPersistence_CUDA) {
 
   auto aten_output = input.sum({0}).unsqueeze(-1).add(input);
 
-  testValidate(&fusion, out, {input}, {aten_output}, __LINE__, __FILE__);
+  testValidate(&fusion, out, {input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionGridPersistence2_CUDA) {
@@ -3857,7 +3854,7 @@ TEST_F(NVFuserTest, FusionGridPersistence2_CUDA) {
 
   auto aten_output = input.sum({0}).unsqueeze(0).add(input);
 
-  testValidate(&fusion, out, {input}, {aten_output}, __LINE__, __FILE__);
+  testValidate(&fusion, out, {input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionWelfordPersistence_CUDA) {
@@ -3972,7 +3969,7 @@ TEST_F(NVFuserTest, FusionIssue633_CUDA) {
   auto aten_output = t0 + t1;
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBroadcastAcrossComputeAt_CUDA) {
@@ -4007,7 +4004,7 @@ TEST_F(NVFuserTest, FusionBroadcastAcrossComputeAt_CUDA) {
 
   auto t3 = t0.unsqueeze(-1).expand(shape) + t1;
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {t3}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwise_CUDA) {
@@ -4058,7 +4055,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwise_CUDA) {
 
   auto aten_output = t0 + t1;
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeContig_CUDA) {

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -148,8 +148,7 @@ TEST_F(NVFuserTest, FusionGlobalIntermediateDefaultSchedule_CUDA) {
   fe.compileFusion(&fusion, {t0, t1, t2, t3});
   auto cg_outputs = fe.runFusion({t0, t1, t2, t3});
 
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionConstCheck_CUDA) {
@@ -284,9 +283,7 @@ TEST_F(NVFuserTest, FusionComputeAtNonterminatingOutput_CUDA) {
   fe.compileFusion(&fusion, {aten_input});
   auto cg_outputs = fe.runFusion({aten_input});
 
-  std::vector<at::Tensor> aten_outputs = {t2, t4, t3};
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder1_CUDA) {
@@ -311,13 +308,6 @@ TEST_F(NVFuserTest, FusionTraversalOrder1_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor aten_input = at::randn({10, 10}, options);
 
-  auto t1 = aten_input + 1;
-  auto t2 = aten_input + 2;
-  auto t3 = t1 + 3;
-  auto t4 = t1 + 4;
-
-  std::vector<at::Tensor> aten_outputs = {t2, t3, t4};
-
   std::vector<at::Tensor> cg_outputs = {
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options),
@@ -326,8 +316,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder1_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   fe.runFusion({aten_input}, cg_outputs);
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder2_CUDA) {
@@ -356,14 +345,6 @@ TEST_F(NVFuserTest, FusionTraversalOrder2_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor aten_input = at::randn({10, 10}, options);
 
-  auto t1 = aten_input + 1;
-  auto t2 = t1 + 2;
-  auto t3 = aten_input + 3;
-  auto t4 = t3 + 4;
-  auto t5 = t1 + t3;
-
-  std::vector<at::Tensor> aten_outputs = {t2, t4, t5};
-
   std::vector<at::Tensor> cg_outputs = {
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options),
@@ -373,8 +354,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder2_CUDA) {
   fe.compileFusion(&fusion, {aten_input});
   fe.runFusion({aten_input}, cg_outputs);
 
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder3_CUDA) {
@@ -416,13 +396,6 @@ TEST_F(NVFuserTest, FusionTraversalOrder3_CUDA) {
 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     at::Tensor aten_input = at::randn({100}, options);
-    auto t1 = aten_input + 1;
-    auto t2 = t1 + 2;
-    auto t3 = aten_input + 3;
-    auto t4 = t3 + 4;
-    auto t5 = t1 + t3;
-
-    std::vector<at::Tensor> aten_outputs = {t2, t4, t5};
 
     std::vector<at::Tensor> cg_outputs = {
         at::empty_like(aten_input, options),
@@ -433,8 +406,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder3_CUDA) {
     fe.compileFusion(&fusion, {aten_input});
     fe.runFusion({aten_input}, cg_outputs);
 
-    testValidate(
-        &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+    testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
   }
 }
 
@@ -467,14 +439,6 @@ TEST_F(NVFuserTest, FusionTraversalOrder4_CUDA) {
   at::Tensor t0 = at::randn({100}, options);
   at::Tensor t4 = at::rand_like(t0, options);
 
-  auto t1 = t0 + 1;
-  auto t2 = t1 + 2;
-  auto t3 = t1 + 3;
-  auto t5 = t4 + 5;
-  auto t6 = t5 + 6;
-  auto t7 = t5 + 7;
-
-  std::vector<at::Tensor> aten_outputs = {t2, t3, t6, t7};
   std::vector<c10::IValue> aten_inputs = {t0, t4};
   std::vector<at::Tensor> cg_outputs = {
       at::empty_like(t0, options),
@@ -486,8 +450,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder4_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   fe.runFusion(aten_inputs, cg_outputs);
 
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder5_CUDA) {
@@ -528,8 +491,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder5_CUDA) {
 
   std::vector<at::Tensor> aten_outputs = {t1, t3, t5};
 
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder6_CUDA) {
@@ -557,19 +519,13 @@ TEST_F(NVFuserTest, FusionTraversalOrder6_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor aten_input = at::randn({100}, options);
 
-  auto t1 = aten_input + 1;
-  auto t2 = aten_input + 2;
-  auto t3 = t1 + t2;
-  auto aten_output = t3 + 4;
-
   at::Tensor cg_output = at::empty_like(aten_input, options);
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   fe.runFusion({aten_input}, {cg_output});
 
-  testValidate(
-      &fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder7_CUDA) {
@@ -603,20 +559,13 @@ TEST_F(NVFuserTest, FusionTraversalOrder7_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor aten_input = at::randn({100}, options);
 
-  auto t1 = aten_input + 1;
-  auto t2 = t1 + 2;
-  auto t3 = aten_input + 3;
-  auto t4 = t3 + 4;
-  auto aten_output = t2 + t4;
-
   at::Tensor cg_output = at::empty_like(aten_input, options);
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   fe.runFusion({aten_input}, {cg_output});
 
-  testValidate(
-      &fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
 
 // Test predication of grid reduction
@@ -799,7 +748,7 @@ TEST_F(NVFuserTest, FusionReductionHalf_CUDA) {
       &fusion,
       cg_outputs,
       {aten_input},
-{aten_output},
+      {aten_output},
       __LINE__,
       __FILE__,
       "",
@@ -826,9 +775,7 @@ TEST_F(NVFuserTest, FusionReduceSingle_CUDA) {
   // no broadcasting needed, omitting the last optional argument;
   auto cg_outputs = fe.runFusion({aten_input});
 
-  auto aten_output = aten_input.to(at::kDouble).sum({1});
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionReduceImplicitBroadcast_CUDA) {
@@ -867,7 +814,7 @@ TEST_F(NVFuserTest, FusionReduceImplicitBroadcast_CUDA) {
       &fusion,
       cg_outputs,
       {aten_input},
-{aten_output},
+      {aten_output},
       __LINE__,
       __FILE__,
       "",
@@ -914,7 +861,7 @@ TEST_F(NVFuserTest, FusionReduceImplicitBroadcast2_CUDA) {
       &fusion,
       cg_outputs,
       {aten_input},
-{aten_output},
+      {aten_output},
       __LINE__,
       __FILE__,
       "",
@@ -957,7 +904,7 @@ TEST_F(NVFuserTest, FusionReduceImplicitBroadcast3_CUDA) {
       &fusion,
       cg_outputs,
       {aten_input},
-{aten_output},
+      {aten_output},
       __LINE__,
       __FILE__,
       "",
@@ -986,10 +933,8 @@ TEST_F(NVFuserTest, FusionTrivialReduction_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   auto cg_outputs = fe.runFusion({aten_input});
-  auto aten_output = aten_input.to(at::kDouble).sum({2});
 
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTrivialReduction2_CUDA) {
@@ -1012,7 +957,6 @@ TEST_F(NVFuserTest, FusionTrivialReduction2_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({y, z}, options);
   at::Tensor t1 = at::randn({w, x, y, z}, options);
-  auto aten_output = t1.to(at::kDouble).sum({0}).sum({0}).add(t0);
 
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
@@ -1022,8 +966,7 @@ TEST_F(NVFuserTest, FusionTrivialReduction2_CUDA) {
   fe.compileFusion(&fusion, aten_inputs, lparams);
   auto cg_outputs = fe.runFusion(aten_inputs, lparams);
 
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTrivialReduction3_CUDA) {
@@ -1045,7 +988,6 @@ TEST_F(NVFuserTest, FusionTrivialReduction3_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({y, z}, options);
   at::Tensor t1 = at::randn({v, w, x, y, z}, options);
-  auto aten_output = t1.sum({0, 1, 2}).add(t0);
 
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
@@ -1055,8 +997,7 @@ TEST_F(NVFuserTest, FusionTrivialReduction3_CUDA) {
   fe.compileFusion(&fusion, aten_inputs, lparams);
   auto cg_outputs = fe.runFusion(aten_inputs, lparams);
 
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionInputsIdLookup_CUDA) {
@@ -1390,7 +1331,7 @@ TEST_F(NVFuserTest, FusionBiasGeluFwd_CUDA) {
       &fusion,
       cg_outputs,
       aten_inputs,
-{aten_output_double},
+      {aten_output_double},
       __LINE__,
       __FILE__);
 }
@@ -1480,7 +1421,7 @@ TEST_F(NVFuserTest, FusionBiasGeluBwd_CUDA) {
       &fusion,
       cg_outputs,
       aten_inputs,
-aten_outputs,
+      aten_outputs,
       __LINE__,
       __FILE__,
       "",
@@ -1526,7 +1467,6 @@ TEST_F(NVFuserTest, FusionIssue459_CUDA) {
   const int numel_y = 20;
   auto t0 = at::randn({numel_x}, options);
   auto t1 = at::randn({numel_y, numel_x}, options);
-  auto aten_output = (t0 + 1).unsqueeze(0) + t1 + 1;
 
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
@@ -1534,12 +1474,7 @@ TEST_F(NVFuserTest, FusionIssue459_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  testValidate(
-      &fusion,
-      cg_outputs,
-      aten_inputs,
-      __LINE__,
-      __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSmemIndexingSimple_CUDA) {
@@ -1564,14 +1499,12 @@ TEST_F(NVFuserTest, FusionSmemIndexingSimple_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto aten_input = at::randn({12, 34}, options);
-  at::Tensor aten_output = aten_input + 1.0 + 1.0 + 1.0;
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   auto cg_outputs = fe.runFusion({aten_input});
 
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSmemIndexing_CUDA) {
@@ -1713,14 +1646,11 @@ TEST_F(NVFuserTest, FusionCacheBeforeReduction_CUDA) {
   at::Tensor aten_input = at::randn({numel_x, numel_y}, options);
   at::Tensor cg_output = at::empty({numel_x}, options);
 
-  auto aten_output = (aten_input + 1).to(at::kDouble).sum({1});
-
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   fe.runFusion({aten_input}, {cg_output});
 
-  testValidate(
-      &fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionCacheBeforeReduction2_CUDA) {
@@ -1752,16 +1682,12 @@ TEST_F(NVFuserTest, FusionCacheBeforeReduction2_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   at::Tensor aten_input = at::randn({numel_x, numel_y, numel_z}, options);
-  auto t2 = (aten_input + 1).to(at::kDouble).sum({1});
-  auto t3 = t2 + 1;
-  std::vector<at::Tensor> aten_outputs = {t2, t3};
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   auto cg_outputs = fe.runFusion({aten_input});
 
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue367_CUDA) {
@@ -1888,14 +1814,12 @@ TEST_F(NVFuserTest, FusionIssue468_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor aten_input = at::randn({10, 100}, options);
-  at::Tensor aten_output = aten_input.to(at::kDouble).sum({1}).sum({0});
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   auto cg_outputs = fe.runFusion({aten_input});
 
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue363_CUDA) {
@@ -1940,8 +1864,6 @@ TEST_F(NVFuserTest, FusionIssue363_CUDA) {
 
   at::Tensor t0 = at::randn({M, K}, options);
   at::Tensor t1 = at::randn({K, N}, options);
-  at::Tensor aten_output =
-      mul(t0.unsqueeze(2), t1.unsqueeze(0)).to(at::kDouble).sum(1);
 
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
@@ -1949,8 +1871,7 @@ TEST_F(NVFuserTest, FusionIssue363_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue484_CUDA) {
@@ -1971,14 +1892,12 @@ TEST_F(NVFuserTest, FusionIssue484_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   at::Tensor aten_input = at::randn({M, M}, options);
-  at::Tensor aten_output = aten_input.to(at::kDouble).sum({1});
 
   nvfuser::FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   auto cg_outputs = fe.runFusion({aten_input});
 
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue329_CUDA) {
@@ -1999,16 +1918,12 @@ TEST_F(NVFuserTest, FusionIssue329_CUDA) {
 
   std::vector<int64_t> t0_shape{17, 19};
   auto aten_input = at::randn(t0_shape, options);
-  auto t2 = (aten_input + 1).to(at::kDouble).sum({1});
-  auto t3 = (aten_input + 1).to(at::kDouble).sum({1});
-  std::vector<at::Tensor> aten_outputs = {t2, t3};
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   auto cg_outputs = fe.runFusion({aten_input});
 
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue382_CUDA) {
@@ -2044,14 +1959,12 @@ TEST_F(NVFuserTest, FusionIssue382_CUDA) {
   auto t3 = at::randn({numel_x, numel_y, numel_z}, options);
 
   std::vector<c10::IValue> aten_inputs = {t0, t3};
-  auto aten_output = (t0 + 1).unsqueeze(-1) + t3;
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue507_CUDA) {
@@ -2075,15 +1988,12 @@ TEST_F(NVFuserTest, FusionIssue507_CUDA) {
 
   std::vector<int64_t> t0_shape{17, 19};
   auto aten_input = at::randn(t0_shape, options);
-  auto t1 = (aten_input + 1);
-  auto aten_output = (t1 + 1);
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input});
   auto cg_outputs = fe.runFusion({aten_input});
 
-  testValidate(
-      &fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue532_CUDA) {
@@ -2121,10 +2031,7 @@ TEST_F(NVFuserTest, FusionIssue532_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  at::Tensor aten_output = t0 + 1 + 1;
-
-  testValidate(
-      &fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionLoopUnswitch_CUDA) {
@@ -2153,10 +2060,7 @@ TEST_F(NVFuserTest, FusionLoopUnswitch_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  at::Tensor aten_output = t0 + 1 + 1;
-
-  testValidate(
-      &fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue549_CUDA) {
@@ -3533,11 +3437,6 @@ TEST_F(NVFuserTest, FusionSegmentReducePointwise_CUDA) {
   at::Tensor t1 = at::randn({65}, options);
   at::Tensor t2 = at::randn({128, 65}, options);
 
-  auto t3 = t0.add(1.0);
-  auto t4 = std::get<0>(at::max(t3, 0));
-  auto t5 = t4.add(t1);
-  auto t6 = t5.add(t2);
-
   FusionExecutorCache executor_cache(std::move(fusion));
 
   auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
@@ -3553,7 +3452,7 @@ TEST_F(NVFuserTest, FusionSegmentReducePointwise_CUDA) {
       "segmentation didn't happen as expected");
 
   testValidate(
-      executor_cache.fusion(), outputs, {t0, t1, t2}, {t6}, __LINE__, __FILE__);
+      executor_cache.fusion(), outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionMultipleVectorize_CUDA) {
@@ -3817,8 +3716,6 @@ TEST_F(NVFuserTest, FusionGridPersistence_CUDA) {
   fe.compileFusion(&fusion, {input});
   auto out = fe.runFusion({input});
 
-  auto aten_output = input.sum({0}).unsqueeze(-1).add(input);
-
   testValidate(&fusion, out, {input}, __LINE__, __FILE__);
 }
 
@@ -3851,8 +3748,6 @@ TEST_F(NVFuserTest, FusionGridPersistence2_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, {input});
   auto out = fe.runFusion({input});
-
-  auto aten_output = input.sum({0}).unsqueeze(0).add(input);
 
   testValidate(&fusion, out, {input}, __LINE__, __FILE__);
 }
@@ -3966,10 +3861,7 @@ TEST_F(NVFuserTest, FusionIssue633_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  auto aten_output = t0 + t1;
-
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBroadcastAcrossComputeAt_CUDA) {
@@ -4001,8 +3893,6 @@ TEST_F(NVFuserTest, FusionBroadcastAcrossComputeAt_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
-
-  auto t3 = t0.unsqueeze(-1).expand(shape) + t1;
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4053,9 +3943,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwise_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  auto aten_output = t0 + t1;
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeContig_CUDA) {
@@ -4111,9 +3999,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeContig_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  auto aten_output = t0 + t1;
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicPass_CUDA) {
@@ -4174,9 +4060,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicPass_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  auto aten_output = t0 + t1;
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicFail_CUDA) {
@@ -4385,9 +4269,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStride_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  auto aten_output = t0 + t1;
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedStrideFail_CUDA) {
@@ -4488,9 +4370,7 @@ TEST_F(NVFuserTest, FusionVectorization1_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  auto aten_output = t0 + t1;
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorization2_CUDA) {
@@ -4588,9 +4468,7 @@ TEST_F(NVFuserTest, FusionVectorization3_CUDA) {
   aten_inputs = {t0, t1};
   auto cg_outputs = fe.runFusion(aten_inputs);
 
-  auto aten_output = t0 + t1;
-  testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizationRFactor_CUDA) {
@@ -4705,9 +4583,8 @@ TEST_F(NVFuserTest, FusionSizeOneLoop1_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
-  auto t6 = (t0.unsqueeze(-1) + t1).unsqueeze(0) + t2;
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {t6}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // The unswitched loop has extent one but inner loops don't. The else
@@ -4739,9 +4616,8 @@ TEST_F(NVFuserTest, FusionSizeOneLoop2_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
-  auto t1 = t0 + 1;
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {t1}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionValidateParallelize1_CUDA) {
@@ -4982,10 +4858,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize8_CUDA) {
   fe.compileFusion(&fusion, {input0, input1});
   auto outputs = fe.runFusion({input0, input1});
 
-  auto tv_ref = input0 + input1.unsqueeze(1);
-
-  testValidate(
-      &fusion, outputs, {input0, input1}, {tv_ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {input0, input1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionValidateParallelize9_CUDA) {
@@ -5074,9 +4947,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize10_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto tv_ref = t0.unsqueeze(-1) + t1;
-
-  testValidate(&fusion, outputs, aten_inputs, {tv_ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Similar to ValidateParallelize10, tv2 has a shared leaf axis
@@ -5122,9 +4993,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize11_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto tv_ref = t0.unsqueeze(-1) + t1;
-
-  testValidate(&fusion, outputs, aten_inputs, {tv_ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionDAGMerging_CUDA) {
@@ -5199,15 +5068,6 @@ TEST_F(NVFuserTest, FusionDAGScalarMerging_CUDA) {
   at::Tensor t0 = at::randn({16, 16, 16}, options);
   double s0 = 0.5;
 
-  auto s1 = s0 + 1.0;
-  auto s2 = s1 * s1;
-  auto s3 = s2 + s1;
-  auto t1 = t0.sum({0});
-  auto t2 = t1 + s2;
-  auto t3 = sum(t2, {0});
-  auto t4 = t3 + s3;
-  auto t5 = t4 + s0;
-
   auto outputs = executor_cache.runFusionWithInputs({t0, s0});
 
   NVF_CHECK(
@@ -5220,8 +5080,7 @@ TEST_F(NVFuserTest, FusionDAGScalarMerging_CUDA) {
               .size() == 2,
       "segmentation didn't happen as expected");
 
-  testValidate(
-      executor_cache.fusion(), outputs, {t0, s0}, {t5}, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), outputs, {t0, s0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBlockReduceInSerialLoop_CUDA) {
@@ -5247,9 +5106,7 @@ TEST_F(NVFuserTest, FusionBlockReduceInSerialLoop_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
-  at::Tensor aten_output = t0.sum({1, 2});
-  testValidate(
-      &fusion, outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBlockWelfordInSerialLoop_CUDA) {
@@ -5415,11 +5272,7 @@ TEST_F(NVFuserTest, FusionIssue757_CUDA) {
   fe.compileFusion(&fusion, inputs);
   auto outputs = fe.runFusion(inputs);
 
-  auto t1 = t0.sum({1});
-  auto t2 = t1.unsqueeze(-1).expand({numel_x, numel_y});
-  auto t4 = t2 + t3;
-
-  testValidate(&fusion, outputs, inputs, {t4}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
 
 // See issue #759
@@ -5457,11 +5310,7 @@ TEST_F(NVFuserTest, FusionPredicatedBlockBroadcast_CUDA) {
   fe.compileFusion(&fusion, inputs);
   auto outputs = fe.runFusion(inputs);
 
-  auto t1 = t0.sum({1});
-  auto t2 = t1.unsqueeze(-1).expand({numel_x, numel_y});
-  auto t4 = t2 + t3;
-
-  testValidate(&fusion, outputs, inputs, {t4}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSegmentVerticalMerge_CUDA) {
@@ -5673,10 +5522,7 @@ TEST_F(NVFuserTest, FusionSingleElement_CUDA) {
   fe.compileFusion(&fusion, {input}, lparams);
   fe.runFusion({input}, {cg_output}, lparams);
 
-  auto aten_output = input.add(2.5).add(3.5);
-
-  testValidate(
-      &fusion, {cg_output}, {input}, {aten_output}, __LINE__, __FILE__);
+  testValidate(&fusion, {cg_output}, {input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBNBackwardRepro_CUDA) {
@@ -6738,13 +6584,10 @@ TEST_F(NVFuserTest, FusionPadNoWarpReduce_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor input1 = at::randn({16, 31}, options);
 
-  auto at_output = input1.sum({1}, true).add(input1);
-
   FusionExecutor fe;
   fe.compileFusion(fusion.get(), {input1});
   auto outputs = fe.runFusion({input1});
-  testValidate(
-      fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
+  testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionWarpMutipleThreadDim_CUDA) {
@@ -6921,15 +6764,11 @@ TEST_F(NVFuserTest, FusionSegfaultReduction_CUDA) {
   at::Tensor input0 = at::randn({batch, c, h, w}, options);
   at::Tensor input1 = at::randn({batch, c, h, w}, options);
 
-  auto at_output0 = input0.mul(input1);
-  auto at_output1 = at_output0.sum(at_sum_axes);
-
   FusionExecutorCache fec(std::move(fusion_ptr));
   std::vector<c10::IValue> inputs = {input0, input1};
   auto outputs = fec.runFusionWithInputs(inputs);
 
-  testValidate(
-      &fusion, outputs, inputs, {at_output0, at_output1}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionPredicateElimination1_CUDA) {
@@ -7188,9 +7027,7 @@ TEST_F(NVFuserTest, FusionPredicateElimination6_CUDA) {
   fe.compileFusion(&fusion, {t0});
   auto cg_outputs = fe.runFusion({t0});
 
-  auto ref = t0 + 4;
-
-  testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionPredicateElimination7_CUDA) {
@@ -7225,9 +7062,7 @@ TEST_F(NVFuserTest, FusionPredicateElimination7_CUDA) {
   fe.compileFusion(&fusion, {t0});
   auto cg_outputs = fe.runFusion({t0});
 
-  auto ref = t0 + 3;
-
-  testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Repro of failing to eliminate predicates due to
@@ -7343,7 +7178,7 @@ TEST_F(NVFuserTest, FusionPredicateElimination9_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(fusion.get(), {t0});
   auto cg_outputs = fe.runFusion({t0});
-  testValidate(fusion.get(), cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
+  testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionForceFp16Simple_CUDA) {
@@ -7566,12 +7401,11 @@ TEST_F(NVFuserTest, FusionBufferReuseBroadCastMultiVisit_CUDA) {
   auto in0 = at::randn({2, 2}, options);
   auto in1 = at::randn({2, 2, 2}, options);
 
-  auto at_output = ((in0 * 2).unsqueeze(2) + in1) * 3;
   FusionExecutor fe;
   fe.compileFusion(fusion, {in0, in1});
   auto outputs = fe.runFusion({in0, in1});
 
-  testValidate(fusion, outputs, {in0, in1}, {at_output}, __LINE__, __FILE__);
+  testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBufferReuseStressTest_CUDA) {
@@ -7610,23 +7444,13 @@ TEST_F(NVFuserTest, FusionBufferReuseStressTest_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto in0 = at::randn({2, 2}, options);
   auto in1 = at::randn({2, 2, 2}, options);
-  auto t2 = in0 * 2;
-  auto t3 = in0 * 3;
-  auto t4 = t2 * t3;
-  auto t5 = t4.unsqueeze(0);
-  auto t6 = t5 * 5;
-  auto t7 = t6 * in1;
-  auto t8 = t7 * 7;
-  auto t9 = t4.unsqueeze(0);
-  auto t10 = t9 * 9;
-  auto t11 = t5 + t9;
+
   FusionExecutor fe;
   fe.compileFusion(fusion, {in0, in1});
 
-  auto at_output = ((in0 * 2).unsqueeze(2) + in1) * 3;
   auto outputs = fe.runFusion({in0, in1});
 
-  testValidate(fusion, outputs, {in0, in1}, {t7, t11}, __LINE__, __FILE__);
+  testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBufferReuseLargeBuffer_CUDA) {
@@ -7657,9 +7481,7 @@ TEST_F(NVFuserTest, FusionBufferReuseLargeBuffer_CUDA) {
   fe.compileFusion(fusion, {in0});
   auto outputs = fe.runFusion({in0});
 
-  auto at_out = in0.mul(2).mul(2).mul(2).mul(2).mul(2).mul(2);
-
-  testValidate(fusion, outputs, {in0}, {at_out}, __LINE__, __FILE__);
+  testValidate(fusion, outputs, {in0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBufferReuseNo2hop_CUDA) {
@@ -7691,9 +7513,7 @@ TEST_F(NVFuserTest, FusionBufferReuseNo2hop_CUDA) {
   fe.compileFusion(fusion, {in0, in1});
   auto outputs = fe.runFusion({in0, in1});
 
-  auto at_out = (in0.mul(2.0).unsqueeze(2) + in1).mul(3.0).mul(3.0);
-
-  testValidate(fusion, outputs, {in0, in1}, {at_out}, __LINE__, __FILE__);
+  testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBufferReuseAllocationOrder_CUDA) {
@@ -7727,9 +7547,7 @@ TEST_F(NVFuserTest, FusionBufferReuseAllocationOrder_CUDA) {
   fe.compileFusion(fusion, {in0});
   auto outputs = fe.runFusion({in0});
 
-  auto at_out = in0.sum(1).mul(2).mul(2);
-
-  testValidate(fusion, outputs, {in0}, {at_out}, __LINE__, __FILE__);
+  testValidate(fusion, outputs, {in0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBufferReuseLiveInterval_CUDA) {
@@ -7758,10 +7576,7 @@ TEST_F(NVFuserTest, FusionBufferReuseLiveInterval_CUDA) {
   fe.compileFusion(fusion, {in0});
   auto cg_outputs = fe.runFusion({in0});
 
-  auto at_t0 = in0 * 3.0;
-  auto at_out = at_t0 * 2.0 * 2.0 * at_t0;
-
-  testValidate(fusion, cg_outputs, {in0}, {at_out}, __LINE__, __FILE__);
+  testValidate(fusion, cg_outputs, {in0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBufferReuseNoAcrossBroadcast_CUDA) {
@@ -7795,13 +7610,7 @@ TEST_F(NVFuserTest, FusionBufferReuseNoAcrossBroadcast_CUDA) {
   fe.compileFusion(fusion, {in0, in1});
   auto outputs = fe.runFusion({in0, in1});
 
-  auto t2 = in0 * 2;
-  auto t3 = in0 * 3;
-  auto t4 = t2 * t3;
-  auto t5 = t4.unsqueeze(2);
-  auto t6 = t5 * in1;
-  auto t7 = t6 * 7;
-  testValidate(fusion, outputs, {in0, in1}, {t7}, __LINE__, __FILE__);
+  testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue970_CUDA) {
@@ -7827,9 +7636,7 @@ TEST_F(NVFuserTest, FusionIssue970_CUDA) {
   fe.compileFusion(&fusion, {t0});
   auto outputs = fe.runFusion({t0});
 
-  auto ref = sum(t0, {1}).unsqueeze(-1).expand({nelm, nelm}) + t0;
-
-  testValidate(&fusion, outputs, {t0}, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Reproducer of #1016
@@ -7860,9 +7667,7 @@ TEST_F(NVFuserTest, FusionIssue1016_CUDA) {
   fe.compileFusion(&fusion, inputs);
   auto outputs = fe.runFusion(inputs);
 
-  auto ref = t0 + 1 + 2;
-
-  testValidate(&fusion, outputs, {t0}, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Reproducer of #1021
@@ -7893,9 +7698,7 @@ TEST_F(NVFuserTest, FusionIssue1021_CUDA) {
   fe.compileFusion(&fusion, inputs);
   auto outputs = fe.runFusion(inputs);
 
-  auto ref = (t0 + 1).unsqueeze(-1);
-
-  testValidate(&fusion, outputs, inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
 
 // Reproducer of issue #1053
@@ -7966,13 +7769,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap1_CUDA) {
   fe.compileFusion(fusion.get(), {input1});
   auto outputs = fe.runFusion({input1});
 
-  testValidate(
-      fusion.get(),
-      outputs,
-      {input1},
-      {input1 + 1, input1 + 1},
-      __LINE__,
-      __FILE__);
+  testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionParallelDimensionMap2_CUDA) {
@@ -8008,10 +7805,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap2_CUDA) {
   fe.compileFusion(fusion.get(), {input1, input2});
   auto outputs = fe.runFusion({input1, input2});
 
-  auto ref = input1.unsqueeze(-1) + input2;
-
-  testValidate(
-      fusion.get(), outputs, {input1, input2}, {ref}, __LINE__, __FILE__);
+  testValidate(fusion.get(), outputs, {input1, input2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionParallelDimensionMap3_CUDA) {
@@ -8058,13 +7852,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap3_CUDA) {
   fe.compileFusion(fusion.get(), {input1});
   auto outputs = fe.runFusion({input1});
 
-  testValidate(
-      fusion.get(),
-      outputs,
-      {input1},
-      {input1 + 1, input1 + 1, input1 + 1, input1 + 1},
-      __LINE__,
-      __FILE__);
+  testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
 }
 
 // Parallelizing merged broadcast domains
@@ -8109,9 +7897,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap4_CUDA) {
   fe.compileFusion(&fusion, {input1, input2});
   auto outputs = fe.runFusion({input1, input2});
 
-  auto ref = (input1 + 1).unsqueeze(0) + input2;
-
-  testValidate(&fusion, outputs, {input1, input2}, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {input1, input2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionParallelDimensionMap5_CUDA) {
@@ -8154,9 +7940,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap5_CUDA) {
   fe.compileFusion(&fusion, {input1, input2});
   auto outputs = fe.runFusion({input1, input2});
 
-  auto ref = (input1).unsqueeze(-1) + input2;
-
-  testValidate(&fusion, outputs, {input1, input2}, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {input1, input2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSegmenterCombineReductionsCycleRepro_CUDA) {
@@ -8309,10 +8093,7 @@ TEST_F(NVFuserTest, FusionSerialAndParallelIndexing_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto ref = t0 + 2;
-
-  testValidate(
-      &fusion, outputs, aten_inputs, {ref, ref, ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Repro of issue #1105
@@ -8365,9 +8146,7 @@ TEST_F(NVFuserTest, FusionWARSyncAliasedSmem_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto ref1 = t0 + 4;
-
-  testValidate(&fusion, outputs, aten_inputs, {ref1}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue1099_CUDA) {
@@ -8418,11 +8197,7 @@ TEST_F(NVFuserTest, FusionIssue1099_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto ref_t2 = t0 + 2;
-  auto ref_t3 = t3 + 3;
-
-  testValidate(
-      &fusion, outputs, aten_inputs, {ref_t2, ref_t3}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Repro of issue #1080
@@ -8464,9 +8239,7 @@ TEST_F(NVFuserTest, FusionUnswitchPredicate_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto ref = t0 + 2;
-
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue1189_CUDA) {
@@ -8505,9 +8278,7 @@ TEST_F(NVFuserTest, FusionIssue1189_CUDA) {
   fe.compileFusion(&fusion, {t0, t1});
   auto outputs = fe.runFusion({t0, t1});
 
-  auto ref = (t0 + t1).sum({1});
-
-  testValidate(&fusion, outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue1052_CUDA) {
@@ -8540,11 +8311,7 @@ TEST_F(NVFuserTest, FusionIssue1052_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto ref_t2 = t0 + 1;
-  auto ref_t3 = t1 + 1;
-
-  testValidate(
-      &fusion, outputs, aten_inputs, {ref_t2, ref_t3}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Repro of issue #1115
@@ -8658,10 +8425,7 @@ TEST_F(NVFuserTest, FusionSmemAliasSerial_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto ref1 = t0 + 3;
-  auto ref2 = t4 + 1;
-
-  testValidate(&fusion, outputs, aten_inputs, {ref1, ref2}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions_CUDA) {
@@ -8691,10 +8455,7 @@ TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto ref1 = t0 + 1;
-  auto ref2 = sum(t2);
-
-  testValidate(&fusion, outputs, aten_inputs, {ref1, ref2}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionGridWelfordWithNonExactParallelDimensions_CUDA) {
@@ -8771,12 +8532,7 @@ TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions2_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t2, t4};
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto ref1 = t0.sum(at::IntArrayRef{0, 1});
-  auto ref2 = t2 + 1;
-  auto ref3 = t4 + 1;
-
-  testValidate(
-      &fusion, outputs, aten_inputs, {ref1, ref2, ref3}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionGridWelfordWithNonExactParallelDimensions2_CUDA) {
@@ -8945,10 +8701,7 @@ TEST_F(NVFuserTest, FusionSmemPredicateUnswitch_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto ref1 = t0 + 4;
-  auto ref2 = t1 + 3;
-
-  testValidate(&fusion, outputs, aten_inputs, {ref1, ref2}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 // Repro of issue #1136
@@ -9172,9 +8925,7 @@ TEST_F(NVFuserTest, FusionThreadPredicateUnswitch_CUDA) {
   fe.compileFusion(&fusion, aten_inputs);
   auto outputs = fe.runFusion(aten_inputs);
 
-  auto ref = sum(t0, {1}) + 2;
-
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionNonContigOutputs_CUDA) {
@@ -9203,9 +8954,7 @@ TEST_F(NVFuserTest, FusionNonContigOutputs_CUDA) {
   NVF_CHECK(returned_outputs[0].is_same(at_output));
   NVF_CHECK(!returned_outputs[0].is_contiguous());
 
-  auto at_ref = at_input + 1;
-
-  testValidate(&fusion, {at_output}, {at_input}, {at_ref}, __LINE__, __FILE__);
+  testValidate(&fusion, {at_output}, {at_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTestWarpSoftMax_CUDA) {
@@ -9686,12 +9435,7 @@ TEST_F(NVFuserTest, FusionPersistentBufferProjection_CUDA) {
   FusionExecutorCache fec(std::move(fusion_ptr));
   auto cg_outputs = fec.runFusionWithInputs({aten_t0});
 
-  auto aten_t1 = aten_t0.to(c10::kDouble);
-  auto aten_t3 = aten_t1.sum({1});
-  auto aten_t4 = aten_t3.unsqueeze(1);
-  auto aten_t7 = aten_t4.add(aten_t1).add(aten_t1);
-
-  testValidate(&fusion, cg_outputs, {aten_t0}, {aten_t7}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {aten_t0}, __LINE__, __FILE__);
 }
 
 // Repro of issue #2381

--- a/test/test_gpu_indexing_ops.cpp
+++ b/test/test_gpu_indexing_ops.cpp
@@ -75,8 +75,7 @@ TEST_F(NVFuserTest, FusionSelectOpReduction_CUDA) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
 
-  testValidate(
-      &fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSelectOpPersistent_CUDA) {
@@ -114,8 +113,7 @@ TEST_F(NVFuserTest, FusionSelectOpPersistent_CUDA) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
 
-  testValidate(
-      &fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIndexSelectSimple_CUDA) {

--- a/test/test_gpu_indexing_ops.cpp
+++ b/test/test_gpu_indexing_ops.cpp
@@ -37,9 +37,6 @@ TEST_F(NVFuserTest, FusionSelectOpPointwise_CUDA) {
   int x = 31, y = 65, z = 103, idx = 21;
 
   at::Tensor t0 = at::randn({x, y, z}, options);
-  auto t1 = t0.select(0, idx);
-  auto t2 = t0.select(1, idx);
-  auto t3 = t0.select(2, idx);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
@@ -74,15 +71,12 @@ TEST_F(NVFuserTest, FusionSelectOpReduction_CUDA) {
   int x = 31, y = 65, z = 103, idx = 21;
 
   at::Tensor t0 = at::randn({x, y, z}, options);
-  auto t4 = t0.select(0, idx).sum(0);
-  auto t5 = t0.select(1, idx).sum(1);
-  auto t6 = t0.select(2, idx).sum(at::IntArrayRef{0, 1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
 
   testValidate(
-      &fusion, cg_outputs, {t0, idx}, {t4, t5, t6}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSelectOpPersistent_CUDA) {
@@ -116,21 +110,12 @@ TEST_F(NVFuserTest, FusionSelectOpPersistent_CUDA) {
   int x = 31, y = 65, z = 103, idx = 21;
 
   at::Tensor t0 = at::randn({x, y, z}, options);
-  auto t1 = t0.select(0, idx);
-  auto t2 = t0.select(1, idx);
-  auto t3 = t0.select(2, idx);
-  auto t4 = t1.sum(0, true);
-  auto t5 = t2.sum(1, true);
-  auto t6 = t3.sum(at::IntArrayRef{0, 1}, true);
-  auto t7 = t1 + t4;
-  auto t8 = t2 + t5;
-  auto t9 = t3 + t6;
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
 
   testValidate(
-      &fusion, cg_outputs, {t0, idx}, {t7, t8, t9}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIndexSelectSimple_CUDA) {
@@ -162,10 +147,8 @@ TEST_F(NVFuserTest, FusionIndexSelectSimple_CUDA) {
 
     at::Tensor input0 = at::randn({nElem, nFeat}, options); // lookup
     at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-    at::Tensor output = at::zeros({nElem_select, nFeat}, options);
 
     std::vector<c10::IValue> aten_inputs = {input0, input_idx};
-    auto output_ref = at::index_select(input0, 0, input_idx);
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
     auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -202,12 +185,8 @@ TEST_F(NVFuserTest, FusionIndexSelect_CUDA) {
       at::randn({nElem_select, nFeat}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-  at::Tensor output = at::zeros({nElem_select, nFeat}, options);
 
   std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
-  auto tv0_ref = at::index_select(input0, 0, input_idx);
-  at::Tensor tv2_ref = tv0_ref * input1;
-  at::Tensor output_ref = tv2_ref + 17.0;
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -244,12 +223,8 @@ TEST_F(NVFuserTest, FusionIndexSelect1DSch_CUDA) {
       at::randn({nElem_select, nFeat}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-  at::Tensor output = at::zeros({nElem_select, nFeat}, options);
 
   std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
-  auto tv0_ref = at::index_select(input0, 0, input_idx);
-  at::Tensor tv2_ref = tv0_ref * input1;
-  at::Tensor output_ref = tv2_ref + 17.0;
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -285,12 +260,8 @@ TEST_F(NVFuserTest, FusionIndexSelect3DTv_CUDA) {
       at::randn({nElem_select, nFeat0, nFeat1}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-  at::Tensor output = at::zeros({nElem_select, nFeat0, nFeat1}, options);
 
   std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
-  auto tv0_ref = at::index_select(input0, 0, input_idx);
-  at::Tensor tv2_ref = tv0_ref * input1;
-  at::Tensor output_ref = tv2_ref + 27.0;
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -472,13 +443,9 @@ TEST_F(NVFuserTest, FusionIndexSelectIdxTvFuseable_CUDA) {
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
   auto input_idx_pre = at::zeros({nElem_select}, options_i);
-  at::Tensor output = at::zeros({nElem_select, nFeat}, options);
 
   std::vector<c10::IValue> aten_inputs = {
       input1, input0, input_idx, input_idx_pre};
-  auto tv0_ref = at::index_select(input0, 0, input_idx);
-  at::Tensor tv2_ref = tv0_ref * input1;
-  at::Tensor output_ref = tv2_ref + 17.0;
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -518,12 +485,8 @@ TEST_F(NVFuserTest, FusionIndexSelectDim1InRank2_CUDA) {
         at::randn({nFeat, nElem_select}, options); // output&elemwise
     auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
     at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-    at::Tensor output = at::zeros({nFeat, nElem_select}, options);
 
     std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
-    auto tv0_ref = at::index_select(input0, 1, input_idx);
-    at::Tensor tv2_ref = tv0_ref * input1;
-    at::Tensor output_ref = tv2_ref + 17.0;
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
     auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -560,12 +523,8 @@ TEST_F(NVFuserTest, FusionIndexSelectDim2InRank3_CUDA) {
       at::randn({nFeat0, nFeat1, nElem_select}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-  at::Tensor output = at::zeros({nFeat0, nFeat1, nElem_select}, options);
 
   std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
-  auto tv0_ref = at::index_select(input0, 2, input_idx);
-  at::Tensor tv2_ref = tv0_ref * input1;
-  at::Tensor output_ref = tv2_ref + 17.0;
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -601,12 +560,8 @@ TEST_F(NVFuserTest, FusionIndexSelectDim1InRank3_CUDA) {
       at::randn({nFeat0, nElem_select, nFeat1}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-  at::Tensor output = at::zeros({nFeat0, nElem_select, nFeat1}, options);
 
   std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
-  auto tv0_ref = at::index_select(input0, 1, input_idx);
-  at::Tensor tv2_ref = tv0_ref * input1;
-  at::Tensor output_ref = tv2_ref + 17.0;
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -644,13 +599,8 @@ TEST_F(NVFuserTest, FusionIndexSelectDim2InRank4_CUDA) {
       {nFeat0, nElem_select, nFeat1, nFeat2}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-  at::Tensor output =
-      at::zeros({nFeat0, nElem_select, nFeat1, nFeat2}, options);
 
   std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
-  auto tv0_ref = at::index_select(input0, 1, input_idx);
-  at::Tensor tv2_ref = tv0_ref * input1;
-  at::Tensor output_ref = tv2_ref + 17.0;
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);


### PR DESCRIPTION
This is a part of resolving Issue #670. Addresses https://github.com/NVIDIA/Fuser/pull/899#discussion_r1330908237. 