### PR TITLE
remove unnecessary fusion print from test

### DIFF
--- a/test/test_combined_inner_outer_reduction.cpp
+++ b/test/test_combined_inner_outer_reduction.cpp
@@ -1024,8 +1024,6 @@ TEST_F(NVFuserTest, CombinedSchedulerInnerOuterMismatch) {
     fusion.addOutput(tv3);
     fusion.addOutput(tv4);
 
-    fusion.printMath();
-
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     at::Tensor t0 = at::randn({x, y, z}, options);
     std::vector<c10::IValue> aten_inputs = {t0};


### PR DESCRIPTION
remove unnecessary fusion print from test