### PR TITLE
[DynamicType] Remove member SFINAE for compare ops

### DIFF
--- a/lib/dynamic_type/CMakeLists.txt
+++ b/lib/dynamic_type/CMakeLists.txt
@@ -29,8 +29,8 @@ if(BUILD_TEST)
     endfunction()
 
     add_test_for_standard(17)
+    add_test_for_standard(20)
 
-    # add_test_for_standard(20)
     # add_test_for_standard(23)
     # add_test_for_standard(26)
 endif()
@@ -49,8 +49,8 @@ if(BUILD_NVFUSER_BENCHMARK)
     endfunction()
 
     add_benchmark_for_standard(17)
+    add_benchmark_for_standard(20)
 
-    # add_benchmark_for_standard(20)
     # add_benchmark_for_standard(23)
     # add_benchmark_for_standard(26)
 endif()

--- a/lib/dynamic_type/README.md
+++ b/lib/dynamic_type/README.md
@@ -279,15 +279,3 @@ In file included from ../src/dynamic_type/dynamic_type.h:19:
 ../src/dynamic_type/type_traits.h:577:16: note: in instantiation of function template specialization 'dynamic_type::any<bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool>' requested here
         return any(std::apply(f, candidates)...);
 ```
-
-# Known issues
-
-On C++20, we would have to skip containers for our SFINAE of compare operators to avoid infinite recursion in
-template deduction. I believe this is a compiler bug:
-
-- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111316
-- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111504
-- https://github.com/llvm/llvm-project/issues/67056
-
-The impact of this workaround should be negligible if your container's compare ops are composed from its item type.
-If not, then we might be unable to dispatch compare ops to containers, you will have to manually cast the type to use these operators.

--- a/lib/dynamic_type/README.md
+++ b/lib/dynamic_type/README.md
@@ -279,3 +279,15 @@ In file included from ../src/dynamic_type/dynamic_type.h:19:
 ../src/dynamic_type/type_traits.h:577:16: note: in instantiation of function template specialization 'dynamic_type::any<bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool>' requested here
         return any(std::apply(f, candidates)...);
 ```
+
+# Known issues
+
+On C++20, we would have to skip containers for our SFINAE of compare operators to avoid infinite recursion in
+template deduction. I believe this is a compiler bug:
+
+- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111316
+- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111504
+- https://github.com/llvm/llvm-project/issues/67056
+
+The impact of this workaround should be negligible if your container's compare ops are composed from its item type.
+If not, then we might be unable to dispatch compare ops to containers, you will have to manually cast the type to use these operators.

--- a/lib/dynamic_type/meson.build
+++ b/lib/dynamic_type/meson.build
@@ -1,8 +1,7 @@
 project('dynamic_type', 'cpp')
 
 dynamic_type_dep = declare_dependency(
-    include_directories: include_directories('src'),
-    compile_args: '-std=c++17',
+    include_directories: include_directories('src')
 )
 
 install_subdir('src/dynamic_type', install_dir : 'include')
@@ -12,45 +11,53 @@ install_subdir('src/dynamic_type', install_dir : 'include')
 gtest_dep = dependency('gtest_main')
 gmock_dep = dependency('gmock')
 
-test_exe = executable('test_dynamic_type_17',
-    [
-        'test/ForAllTypes.cpp',
-        'test/assignment.cpp',
-        'test/binary_ops.cpp',
-        'test/container.cpp',
-        'test/examples.cpp',
-        'test/hash.cpp',
-        'test/member.cpp',
-        'test/move.cpp',
-        'test/null.cpp',
-        'test/opcheck.cpp',
-        'test/print.cpp',
-        'test/typing.cpp',
-        'test/unary_ops.cpp',
-    ],
-    dependencies: [
-        dynamic_type_dep,
-        gtest_dep,
-        gmock_dep,
-    ]
-)
+foreach standard : ['17', '20']
+    name = 'test_dynamic_type_' + standard
+    test_exe = executable(name,
+        [
+            'test/ForAllTypes.cpp',
+            'test/assignment.cpp',
+            'test/binary_ops.cpp',
+            'test/container.cpp',
+            'test/examples.cpp',
+            'test/hash.cpp',
+            'test/member.cpp',
+            'test/move.cpp',
+            'test/null.cpp',
+            'test/opcheck.cpp',
+            'test/print.cpp',
+            'test/typing.cpp',
+            'test/unary_ops.cpp',
+        ],
+        dependencies: [
+            dynamic_type_dep,
+            gtest_dep,
+            gmock_dep,
+        ],
+        override_options: 'cpp_std=c++' + standard,
+    )
 
-test('test_dynamic_type_17', test_exe)
+    test(name, test_exe)
+endforeach
 
 
 # benchmarks
 gbench_dep = dependency('benchmark')
 
-bench_exe = executable('bench_dynamic_type_17',
-    [
-        'benchmark/main.cpp',
-        'benchmark/knn.cpp',
-        'benchmark/sort.cpp',
-    ],
-    dependencies: [
-        dynamic_type_dep,
-        gbench_dep,
-    ],
-)
+foreach standard : ['17', '20']
+    name = 'bench_dynamic_type_' + standard
+    bench_exe = executable(name,
+        [
+            'benchmark/main.cpp',
+            'benchmark/knn.cpp',
+            'benchmark/sort.cpp',
+        ],
+        dependencies: [
+            dynamic_type_dep,
+            gbench_dep,
+        ],
+        override_options: 'cpp_std=c++' + standard,
+    )
 
-benchmark('bench_dynamic_type_17', bench_exe, timeout: 0)
+    benchmark(name, bench_exe, timeout: 0)
+endforeach

--- a/lib/dynamic_type/src/dynamic_type/dynamic_type.h
+++ b/lib/dynamic_type/src/dynamic_type/dynamic_type.h
@@ -588,151 +588,109 @@ DEFINE_BINARY_OP(rshift, >>);
 
 #undef DEFINE_BINARY_OP
 
-#define DEFINE_COMPARE_OP(opname, op)                                          \
-  /*TODO: we should inline the definition of lambdas into enable_if,*/         \
-  /*but I can only do this in C++20 */                                         \
-  constexpr auto opname##_defined_checker = [](auto x, auto y) constexpr {     \
-    using X = typename decltype(x)::type;                                      \
-    using Y = typename decltype(y)::type;                                      \
-    if constexpr (opcheck<X> op opcheck<Y>) {                                  \
-      return std::is_convertible_v<                                            \
-          decltype(std::declval<X>() op std::declval<Y>()),                    \
-          bool>;                                                               \
-    }                                                                          \
-    return false;                                                              \
-  };                                                                           \
-  template <                                                                   \
-      typename DT,                                                             \
-      typename = std::enable_if_t<                                             \
-          is_dynamic_type_v<DT> &&                                             \
-          any_check(                                                           \
-              opname##_defined_checker,                                        \
-              DT::type_identities_as_tuple,                                    \
-              DT::type_identities_as_tuple)>>                                  \
-  inline constexpr bool operator op(                                           \
-      const DT& x, const std::type_identity_t<DT>& y) {                        \
-    std::optional<bool> ret = std::nullopt;                                    \
-    DT::for_all_types([&ret, &x, &y](auto lhs) {                               \
-      using LHS = typename decltype(lhs)::type;                                \
-      DT::for_all_types([&ret, &x, &y](auto rhs) {                             \
-        using RHS = typename decltype(rhs)::type;                              \
-        if constexpr ((opcheck<LHS> op opcheck<RHS>)) {                        \
-          if constexpr (std::is_convertible_v<                                 \
-                            decltype(std::declval<LHS>()                       \
-                                         op std::declval<RHS>()),              \
-                            bool>) {                                           \
-            if (x.template is<LHS>() && y.template is<RHS>()) {                \
-              ret = x.template as<LHS>() op y.template as<RHS>();              \
-            }                                                                  \
-          }                                                                    \
-        }                                                                      \
-      });                                                                      \
-    });                                                                        \
-    DYNAMIC_TYPE_CHECK(                                                        \
-        ret.has_value(),                                                       \
-        "Cannot compute ",                                                     \
-        x.type().name(),                                                       \
-        " ",                                                                   \
-        #op,                                                                   \
-        " ",                                                                   \
-        y.type().name(),                                                       \
-        " : incompatible type");                                               \
-    return ret.value();                                                        \
-  }                                                                            \
-  /*TODO: we should inline the definition of lambdas into enable_if,*/         \
-  /*but I can only do this in C++20 */                                         \
-  template <typename T>                                                        \
-  constexpr auto opname##_rdefined_checker = [](auto x) constexpr {            \
-    using X = typename decltype(x)::type;                                      \
-    if constexpr (opcheck<X> op opcheck<T>) {                                  \
-      return std::is_convertible_v<                                            \
-          decltype(std::declval<X>() op std::declval<T>()),                    \
-          bool>;                                                               \
-    }                                                                          \
-    return false;                                                              \
-  };                                                                           \
-  template <                                                                   \
-      typename DT,                                                             \
-      typename RHS,                                                            \
-      typename = std::enable_if_t<                                             \
-          is_dynamic_type_v<DT> && !is_dynamic_type_v<RHS> &&                  \
-          any_check(                                                           \
-              opname##_rdefined_checker<RHS>, DT::type_identities_as_tuple)>>  \
-  inline constexpr bool operator op(const DT& x, const RHS& y) {               \
-    std::optional<bool> ret = std::nullopt;                                    \
-    DT::for_all_types([&ret, &x, &y](auto lhs) {                               \
-      using LHS = typename decltype(lhs)::type;                                \
-      if constexpr ((opcheck<LHS> op opcheck<RHS>)) {                          \
-        if constexpr (std::is_convertible_v<                                   \
-                          decltype(std::declval<LHS>()                         \
-                                       op std::declval<RHS>()),                \
-                          bool>) {                                             \
-          if (x.template is<LHS>()) {                                          \
-            ret = x.template as<LHS>() op y;                                   \
-          }                                                                    \
-        }                                                                      \
-      }                                                                        \
-    });                                                                        \
-    DYNAMIC_TYPE_CHECK(                                                        \
-        ret.has_value(),                                                       \
-        "Cannot compute ",                                                     \
-        x.type().name(),                                                       \
-        " ",                                                                   \
-        #op,                                                                   \
-        " ",                                                                   \
-        typeid(RHS).name(),                                                    \
-        " : incompatible type");                                               \
-    return ret.value();                                                        \
-  }                                                                            \
-  /*TODO: we should inline the definition of lambdas into enable_if,*/         \
-  /*but I can only do this in C++20 */                                         \
-  template <typename T>                                                        \
-  constexpr auto opname##_ldefined_checker = [](auto y) constexpr {            \
-    using Y = typename decltype(y)::type;                                      \
-    if constexpr (opcheck<T> op opcheck<Y>) {                                  \
-      return std::is_convertible_v<                                            \
-          decltype(std::declval<T>() op std::declval<Y>()),                    \
-          bool>;                                                               \
-    }                                                                          \
-    return false;                                                              \
-  };                                                                           \
-  template <typename LHS, typename DT>                                         \
-  inline constexpr std::enable_if_t<                                           \
-      is_dynamic_type_v<DT> && !is_dynamic_type_v<LHS> &&                      \
-          (opcheck<LHS>.hasExplicitCastTo(opcheck<DT>) ||                      \
-           any_check(                                                          \
-               opname##_ldefined_checker<LHS>, DT::type_identities_as_tuple)), \
-      bool>                                                                    \
-  operator op(const LHS& x, const DT& y) {                                     \
-    std::optional<bool> ret = std::nullopt;                                    \
-    DT::for_all_types([&ret, &x, &y](auto rhs) {                               \
-      using RHS = typename decltype(rhs)::type;                                \
-      if constexpr ((opcheck<LHS> op opcheck<RHS>)) {                          \
-        if constexpr (std::is_convertible_v<                                   \
-                          decltype(std::declval<LHS>()                         \
-                                       op std::declval<RHS>()),                \
-                          bool>) {                                             \
-          if (y.template is<RHS>()) {                                          \
-            ret = x op y.template as<RHS>();                                   \
-          }                                                                    \
-        }                                                                      \
-      }                                                                        \
-    });                                                                        \
-    if (ret.has_value()) {                                                     \
-      return ret.value();                                                      \
-    }                                                                          \
-    if constexpr (opcheck<LHS>.hasExplicitCastTo(opcheck<DT>)) {               \
-      return (DT)x op y;                                                       \
-    }                                                                          \
-    DYNAMIC_TYPE_CHECK(                                                        \
-        false,                                                                 \
-        "Cannot compute ",                                                     \
-        typeid(LHS).name(),                                                    \
-        " ",                                                                   \
-        #op,                                                                   \
-        " ",                                                                   \
-        y.type().name(),                                                       \
-        " : incompatible type");                                               \
+// std::monostate has definitions on compare operators, so DynamicType should
+// always define them as well. There is no need for any SFINAE about member type
+// here. https://en.cppreference.com/w/cpp/utility/variant/monostate
+#define DEFINE_COMPARE_OP(opname, op)                                         \
+  template <typename DT, typename = std::enable_if_t<is_dynamic_type_v<DT>>>  \
+  inline constexpr bool operator op(const DT& x, const DT& y) {               \
+    std::optional<bool> ret = std::nullopt;                                   \
+    DT::for_all_types([&ret, &x, &y](auto lhs) {                              \
+      using LHS = typename decltype(lhs)::type;                               \
+      DT::for_all_types([&ret, &x, &y](auto rhs) {                            \
+        using RHS = typename decltype(rhs)::type;                             \
+        if constexpr ((opcheck<LHS> op opcheck<RHS>)) {                       \
+          if constexpr (std::is_convertible_v<                                \
+                            decltype(std::declval<LHS>()                      \
+                                         op std::declval<RHS>()),             \
+                            bool>) {                                          \
+            if (x.template is<LHS>() && y.template is<RHS>()) {               \
+              ret = x.template as<LHS>() op y.template as<RHS>();             \
+            }                                                                 \
+          }                                                                   \
+        }                                                                     \
+      });                                                                     \
+    });                                                                       \
+    DYNAMIC_TYPE_CHECK(                                                       \
+        ret.has_value(),                                                      \
+        "Cannot compute ",                                                    \
+        x.type().name(),                                                      \
+        " ",                                                                  \
+        #op,                                                                  \
+        " ",                                                                  \
+        y.type().name(),                                                      \
+        " : incompatible type");                                              \
+    return ret.value();                                                       \
+  }                                                                           \
+  template <                                                                  \
+      typename DT,                                                            \
+      typename RHS,                                                           \
+      typename =                                                              \
+          std::enable_if_t<is_dynamic_type_v<DT> && !is_dynamic_type_v<RHS>>> \
+  inline constexpr bool operator op(const DT& x, const RHS& y) {              \
+    std::optional<bool> ret = std::nullopt;                                   \
+    DT::for_all_types([&ret, &x, &y](auto lhs) {                              \
+      using LHS = typename decltype(lhs)::type;                               \
+      if constexpr ((opcheck<LHS> op opcheck<RHS>)) {                         \
+        if constexpr (std::is_convertible_v<                                  \
+                          decltype(std::declval<LHS>()                        \
+                                       op std::declval<RHS>()),               \
+                          bool>) {                                            \
+          if (x.template is<LHS>()) {                                         \
+            ret = x.template as<LHS>() op y;                                  \
+          }                                                                   \
+        }                                                                     \
+      }                                                                       \
+    });                                                                       \
+    if (ret.has_value()) {                                                    \
+      return ret.value();                                                     \
+    }                                                                         \
+    if constexpr (opcheck<RHS>.hasExplicitCastTo(opcheck<DT>)) {              \
+      return x op(DT) y;                                                      \
+    }                                                                         \
+    DYNAMIC_TYPE_CHECK(                                                       \
+        false,                                                                \
+        "Cannot compute ",                                                    \
+        x.type().name(),                                                      \
+        " ",                                                                  \
+        #op,                                                                  \
+        " ",                                                                  \
+        typeid(RHS).name(),                                                   \
+        " : incompatible type");                                              \
+  }                                                                           \
+  template <typename LHS, typename DT>                                        \
+  inline constexpr std::                                                      \
+      enable_if_t<is_dynamic_type_v<DT> && !is_dynamic_type_v<LHS>, bool>     \
+      operator op(const LHS& x, const DT& y) {                                \
+    std::optional<bool> ret = std::nullopt;                                   \
+    DT::for_all_types([&ret, &x, &y](auto rhs) {                              \
+      using RHS = typename decltype(rhs)::type;                               \
+      if constexpr ((opcheck<LHS> op opcheck<RHS>)) {                         \
+        if constexpr (std::is_convertible_v<                                  \
+                          decltype(std::declval<LHS>()                        \
+                                       op std::declval<RHS>()),               \
+                          bool>) {                                            \
+          if (y.template is<RHS>()) {                                         \
+            ret = x op y.template as<RHS>();                                  \
+          }                                                                   \
+        }                                                                     \
+      }                                                                       \
+    });                                                                       \
+    if (ret.has_value()) {                                                    \
+      return ret.value();                                                     \
+    }                                                                         \
+    if constexpr (opcheck<LHS>.hasExplicitCastTo(opcheck<DT>)) {              \
+      return (DT)x op y;                                                      \
+    }                                                                         \
+    DYNAMIC_TYPE_CHECK(                                                       \
+        false,                                                                \
+        "Cannot compute ",                                                    \
+        typeid(LHS).name(),                                                   \
+        " ",                                                                  \
+        #op,                                                                  \
+        " ",                                                                  \
+        y.type().name(),                                                      \
+        " : incompatible type");                                              \
   }
 
 DEFINE_COMPARE_OP(eq, ==);

--- a/lib/dynamic_type/test/utils.h
+++ b/lib/dynamic_type/test/utils.h
@@ -40,7 +40,9 @@ using DoubleInt64BoolVec = DynamicType<
     bool,
     NonInstantiable>;
 struct DoubleInt64BoolVecTwo {
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L && defined(__GLIBCXX__) && __GLIBCXX__ >= 20230714
+  // For older versions of libstdc++, we can not make this constexpr. The reason
+  // is unknown.
   constexpr
 #endif
   operator DoubleInt64BoolVec() const {


### PR DESCRIPTION
Replacing https://github.com/NVIDIA/Fuser/pull/1037. Because `std::monostate` always define compare operators, `DynamicType` should do the same thing. There is no need for SFINAE. This PR also adds build on C++20. 

I suggest reviewing this PR hiding whitespaces:
![image](https://github.com/NVIDIA/Fuser/assets/1032377/892cfeff-f080-49a0-9846-319632538339)

