### PR TITLE
Do not map broadcast and non-broadcast domains in EXACT

### DIFF
--- a/csrc/id_model/id_graphs.cpp
+++ b/csrc/id_model/id_graphs.cpp
@@ -679,8 +679,9 @@ void IterDomainGraphs::buildExactMap(const std::vector<Expr*>& exprs) {
       // For exact mapings do not map any broadcast dimensions to
       // non-broadcast dimensions. Prevent any broadcasted axes being mapped
       // to non-broadcasted axes.
-      auto exact_c2p_root_map =
-          PairwiseRootDomainMap(p_tv, c_tv).mapConsumerToProducer();
+      auto exact_c2p_root_map = PairwiseRootDomainMap(p_tv, c_tv)
+                                    .mapBroadcast(false)
+                                    .mapConsumerToProducer();
 
       for (auto c_id : getSortedKeys(exact_c2p_root_map, Statement::lessThan)) {
         auto p_id = exact_c2p_root_map.at(c_id);


### PR DESCRIPTION
`PairwiseRootDomainMap` by default allows mapping of broadcast and non-broadcast domains. We should probably disable that too.

The validation in the Indexing19 test passes. Some other tests are failing but that is the case without this PR too.

Fixes #1052 