### PR TITLE
Fix a crash when a FusionDefinition is executed with a NaN tensor.

### DIFF
--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -234,15 +234,37 @@ inline std::string toString(const PolymorphicValue& v) {
   return ss.str();
 }
 
+template <typename T>
+inline bool isSameNanSensitive(const T& a, const T& b) {
+  if (std::isnan(a) && std::isnan(b)) {
+    return true;
+  }
+  return a == b;
+}
+
+template <typename T>
+inline bool isSameNanSensitive(
+    const std::complex<T>& a,
+    const std::complex<T>& b) {
+  return isSameNanSensitive(a.real(), b.real()) &&
+      isSameNanSensitive(a.imag(), b.imag());
+}
+
 inline bool isSame(const PolymorphicValue& a, const PolymorphicValue& b) {
   if (a.type() != b.type()) {
     return false;
   }
-  if (a.is<at::Tensor>() && b.is<at::Tensor>()) {
+  if (a.is<at::Tensor>()) {
     return (a.as<at::Tensor>().is_same(b.as<at::Tensor>()));
-  } else {
-    return (a == b);
   }
+  if (a.is<double>()) {
+    return isSameNanSensitive(a.as<double>(), b.as<double>());
+  }
+  if (a.is<std::complex<double>>()) {
+    return isSameNanSensitive(
+        a.as<std::complex<double>>(), b.as<std::complex<double>>());
+  }
+  return a == b;
 }
 
 inline PolymorphicValue ceildiv(

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -234,6 +234,7 @@ inline std::string toString(const PolymorphicValue& v) {
   return ss.str();
 }
 
+// NaNs are treated equal.
 template <typename T>
 inline bool isSameNanSensitive(const T& a, const T& b) {
   if (std::isnan(a) && std::isnan(b)) {

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -234,21 +234,26 @@ inline std::string toString(const PolymorphicValue& v) {
   return ss.str();
 }
 
+template <typename T>
+inline bool isNan(const T& a) {
+  return std::isnan(a);
+}
+
+// For example, `nan+i` and `nan-i` are treated equal because both are NaNs.
+// This is consistent with pytorch's implementation:
+// https://github.com/pytorch/pytorch/blob/6d8e0c4b5a3be8201cab731dfd1e6513162cf25c/c10/util/complex_utils.h#L43.
+template <typename T>
+inline bool isNan(const std::complex<T>& a) {
+  return std::isnan(a.real()) || std::isnan(a.imag());
+}
+
 // NaNs are treated equal.
 template <typename T>
 inline bool isSameNanSensitive(const T& a, const T& b) {
-  if (std::isnan(a) && std::isnan(b)) {
+  if (isNan(a) && isNan(b)) {
     return true;
   }
   return a == b;
-}
-
-template <typename T>
-inline bool isSameNanSensitive(
-    const std::complex<T>& a,
-    const std::complex<T>& b) {
-  return isSameNanSensitive(a.real(), b.real()) &&
-      isSameNanSensitive(a.imag(), b.imag());
 }
 
 inline bool isSame(const PolymorphicValue& a, const PolymorphicValue& b) {

--- a/python_tests/test_nan.py
+++ b/python_tests/test_nan.py
@@ -6,17 +6,27 @@ from nvfuser import FusionDefinition, DataType
 def test_validate_precomputed_values():
     def compare() -> FusionDefinition:
         with FusionDefinition() as fd:
-            T0 = fd.define_tensor(shape=[-1, -1], contiguity=[True, True], dtype=DataType.Float, is_cpu=False)
+            T0 = fd.define_tensor(
+                shape=[-1, -1],
+                contiguity=[True, True],
+                dtype=DataType.Float,
+                is_cpu=False,
+            )
+
             S1 = fd.define_scalar(None, dtype=DataType.Double)
             T2 = fd.ops.ge(T0, S1)
             fd.add_output(T2)
         return fd
 
     fd = compare()
-    outs = fd.execute([
-        torch.randn((10,), dtype=torch.float32, device='cuda:0').as_strided((2, 5), (5, 1)),
-        float("nan"),
-    ])
+    outs = fd.execute(
+        [
+            torch.randn((10,), dtype=torch.float32, device="cuda:0").as_strided(
+                (2, 5), (5, 1)
+            ),
+            float("nan"),
+        ]
+    )
     # Cmoparing any number to NaN results in False.
     torch.testing.assert_close(outs[0].cpu(), torch.full((2, 5), False))
 

--- a/python_tests/test_nan.py
+++ b/python_tests/test_nan.py
@@ -1,0 +1,25 @@
+import pytest
+import torch
+from nvfuser import FusionDefinition, DataType
+
+
+def test_validate_precomputed_values():
+    def compare() -> FusionDefinition:
+        with FusionDefinition() as fd:
+            T0 = fd.define_tensor(shape=[-1, -1], contiguity=[True, True], dtype=DataType.Float, is_cpu=False)
+            S1 = fd.define_scalar(None, dtype=DataType.Double)
+            T2 = fd.ops.ge(T0, S1)
+            fd.add_output(T2)
+        return fd
+
+    fd = compare()
+    outs = fd.execute([
+        torch.randn((10,), dtype=torch.float32, device='cuda:0').as_strided((2, 5), (5, 1)),
+        float("nan"),
+    ])
+    # Cmoparing any number to NaN results in False.
+    torch.testing.assert_close(outs[0].cpu(), torch.full((2, 5), False))
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/pytorch/nvfuser/nvfuser/__init__.py", line 122, in execute
    result = self._execute(
RuntimeError: isSame(values_[it.first], it.second) INTERNAL ASSERT FAILED at "/opt/pytorch/nvfuser/csrc/evaluator_common.cpp":314, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues. Precomputed values failed to validate.
Something unexpected changed between the compilation and execution.
nan != nan
Exception raised from validate at /opt/pytorch/nvfuser/csrc/evaluator_common.cpp:314 (most recent call first):
frame #0: nvfuser::nvfCheckFail(char const*, char const*, unsigned int, std::string const&) + 0x8d (0x7fdc9919fe3b in /usr/local/lib/python3.10/site-packages/torch/lib/libnvfuser_codegen.so)
frame #1: nvfuser::nvfErrorFail(char const*, char const*, unsigned int, char const*, std::string const&) + 0x53 (0x7fdc992ded63 in /usr/local/lib/python3.10/site-packages/torch/lib/libnvfuser_codegen.so)
frame #2: nvfuser::PrecomputedValues::validate() + 0x172 (0x7fdc993190f2 in /usr/local/lib/python3.10/site-packages/torch/lib/libnvfuser_codegen.so)
frame #3: nvfuser::PrecomputedValues::evaluate() + 0x66 (0x7fdc9931fde6 in /usr/local/lib/python3.10/site-packages/torch/lib/libnvfuser_codegen.so)
frame #4: nvfuser::FusionExecutor::inferOutputSizes(nvfuser::Fusion*, nvfuser::KernelArgumentHolder const&) + 0x8d (0x7fdc992ea12d in /usr/local/lib/python3.10/site-packages/torch/lib/libnvfuser_codegen.so)
frame #5: nvfuser::FusionKernelRuntime::compileFusionParallel(nvfuser::KernelArgumentHolder) + 0x46d (0x7fdc9943a6ad in /usr/local/lib/python3.10/site-packages/torch/lib/libnvfuser_codegen.so)
frame #6: nvfuser::FusionExecutorCache::runFusionWithInputs(c10::ArrayRef<c10::IValue> const&, std::optional<nvfuser::PrimDataType>, std::optional<signed char>) + 0xa8d (0x7fdc99443c9d in /usr/local/lib/python3.10/site-packages/torch/lib/libnvfuser_codegen.so)
frame #7: nvfuser::python_frontend::FusionDefinition::execute(c10::ArrayRef<c10::IValue> const&, bool, bool, std::optional<signed char>) const + 0x331 (0x7fdc997450e1 in /usr/local/lib/python3.10/site-packages/torch/lib/libnvfuser_codegen.so)
frame #8: <unknown function> + 0xeec2e (0x7fdbe8274c2e in /opt/pytorch/nvfuser/nvfuser/_C.cpython-310-x86_64-linux-gnu.so)
frame #9: <unknown function> + 0x16e137 (0x7fdbe82f4137 in /opt/pytorch/nvfuser/nvfuser/_C.cpython-310-x86_64-linux-gnu.so)
<omitting python frames>
frame #38: <unknown function> + 0x29d90 (0x7fdd26ea0d90 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #39: __libc_start_main + 0x80 (0x7fdd26ea0e40 in /usr/lib/x86_64-linux-gnu/libc.so.6)
```