### PR TITLE
Fix mapping propagations through uses

### DIFF
--- a/csrc/id_model/id_graph.cpp
+++ b/csrc/id_model/id_graph.cpp
@@ -743,11 +743,10 @@ void IdGraph::mapIds(IterDomain* id0, IterDomain* id1) {
   // Propagate on uses
   if (!orig_uses0.empty() && !orig_uses1.empty()) {
     for (const ExprGroup& use_group_1 : orig_uses1) {
-      if (orig_uses0.has(use_group_1)) {
-        continue;
-      }
-
       for (const ExprGroup& use_group_0 : orig_uses0) {
+        if (use_group_0 == use_group_1) {
+          continue;
+        }
         Expr* use0 = use_group_0->front();
         Expr* use1 = use_group_1->front();
         maybeMapThroughExprs(use0, use1, true);


### PR DESCRIPTION
This doesn't seem necessary at this moment but required to stop using ALMOST_EXACT for permissive mappings.

Suppose domains A and B have uses as:

A: ExprGroup X and ExprGroup Y
B: ExprGroup X and ExprGroup Y

i.e., both have the same set of expr groups. Before this propagation, there's nothing to allow map X and Y. When A and B are mapped, we should map the uses of A and B, which means X and Y should be mapped. The check removed in this PR prevents the propagation.