### PR TITLE
Use the EXACT map as the starting map of the PERMISSIVE map

### DIFF
--- a/csrc/id_model/id_graphs.cpp
+++ b/csrc/id_model/id_graphs.cpp
@@ -694,7 +694,10 @@ void IterDomainGraphs::buildExactMap(const std::vector<Expr*>& exprs) {
 }
 
 void IterDomainGraphs::buildPermissiveMap(const std::vector<Expr*>& exprs) {
-  idGraph(IdMappingMode::PERMISSIVE) = idGraph(IdMappingMode::ALMOSTEXACT);
+  // Use the exact map as the starting map rather than the
+  // almost-exact map. Almost exact is useful for index hoisting but
+  // not necessary for permissive and loop maps
+  idGraph(IdMappingMode::PERMISSIVE) = idGraph(IdMappingMode::EXACT);
 
   for (auto expr : exprs) {
     // Multiple outputs are already mapped, we can ignore all but the first


### PR DESCRIPTION
ALMOST_EXACT should not be necessary for PERMISSIVE and LOOP

Related: #1053 
