### PR TITLE
WIP: Loop promotion with IEL

### DIFF
--- a/test/test_gpu_indexing.cpp
+++ b/test/test_gpu_indexing.cpp
@@ -910,10 +910,16 @@ TEST_F(NVFuserTest, FusionIndexing19_CUDA) {
   auto promotion_map_it = promotion_map.find(merge_loop_group);
   ASSERT_TRUE(promotion_map_it != promotion_map.end())
       << "Loop promotion not found for merge loop group";
+  auto merge_out_promotion_id = promotion_map_it->second;
   ASSERT_EQ(
-      id_model.idGraph(IdMappingMode::EXACT).toGroup(promotion_map_it->second),
+      id_model.idGraph(IdMappingMode::EXACT).toGroup(merge_out_promotion_id),
       id_model.idGraph(IdMappingMode::EXACT).toGroup(ref_merge_out))
       << "Merge loop group should be promoted to " << ref_merge_out->toString();
+  ASSERT_NE(
+      id_model.idGraph(IdMappingMode::LOOP).toGroup(merge_out_promotion_id),
+      id_model.idGraph(IdMappingMode::LOOP).toGroup(ref_merge_out))
+      << "Should not be loop-mapped with ref: "
+      << merge_out_promotion_id->toString();
 
   // Get the corresponding reference ID in tv10
   auto getRefId = [&](TensorView* tv, IterDomain* id) -> IterDomain* {
@@ -950,8 +956,16 @@ TEST_F(NVFuserTest, FusionIndexing19_CUDA) {
           << tv->toString()
           << ". Loop group: " << nvfuser::toString(loop_group);
 
-      auto promotion_exact_group = id_model.idGraph(IdMappingMode::EXACT)
-                                       .toGroup(promotion_map_it->second);
+      auto promotion_id = promotion_map_it->second;
+
+      // Promotion ID should be loop-mapped
+      ASSERT_TRUE(loop_group->has(promotion_id))
+          << "Loop promotion for " << id->toString() << " of " << tv->toString()
+          << " is promoted to an ID that isn't loop mapped: "
+          << promotion_id->toString() << std::endl;
+
+      auto promotion_exact_group =
+          id_model.idGraph(IdMappingMode::EXACT).toGroup(promotion_id);
 
       auto ref_id = getRefId(tv, id);
       auto ref_exact_group =
@@ -960,6 +974,13 @@ TEST_F(NVFuserTest, FusionIndexing19_CUDA) {
       ASSERT_EQ(promotion_exact_group, ref_exact_group)
           << "Invalid promotion: " << id->toString() << " of " << tv->toString()
           << ". Promotion group: " << nvfuser::toString(promotion_exact_group);
+
+      auto ref_loop_group =
+          id_model.idGraph(IdMappingMode::LOOP).toGroup(ref_id);
+      ASSERT_NE(loop_group, ref_loop_group)
+          << "Invalid promotion: " << id->toString() << " of " << tv->toString()
+          << ". Should not be loop-mapped with ref: "
+          << nvfuser::toString(loop_group);
     }
   }
 


### PR DESCRIPTION
When finding reusable promotion domains, make sure to reuse loop-mapped
domains since promotion domains should be part of mapped loop groups.

This should fix #1054. Additional checks are also added to the Indexing19 test.