### PR TITLE
Add a variant of TensorDomain::toString to print all domains.

### DIFF
--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -482,8 +482,10 @@ class TensorDomain : public Val {
       const std::vector<IterDomain*>& lhs,
       const std::vector<IterDomain*>& rhs);
 
+  // When `leaf_only` is false, prints also the root, rfactor and allocation
+  // domain if not empty.
+  std::string toString(int indent_size, bool leaf_only) const;
   std::string toString(int indent_size = 0) const override;
-
   std::string toInlineString(int indent_size = 0) const override;
 
   // Note: [Contiguity]

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3287,14 +3287,34 @@ bool TensorDomain::sameAs(
   return true;
 }
 
-std::string TensorDomain::toString(int indent_size) const {
+std::string TensorDomain::toString(const int indent_size, const bool leaf_only)
+    const {
   std::stringstream ss;
   if (nDims() == 0) {
-    ss << "[ 0 ]";
+    indent(ss, indent_size) << "[ ]";
     return ss.str();
   }
-  ss << "[ " << toDelimitedString(leaf()) << " ]";
+  indent(ss, indent_size) << "[ " << toDelimitedString(leaf()) << " ]";
+  if (!leaf_only) {
+    ss << "," << std::endl;
+    indent(ss, indent_size + 1)
+        << "root=[ " << toDelimitedString(root()) << " ]";
+    if (hasRFactor()) {
+      ss << "," << std::endl;
+      indent(ss, indent_size + 1)
+          << "rfactor=[ " << toDelimitedString(rfactor()) << " ]";
+    }
+    if (!allocation_domain_.empty()) {
+      ss << "," << std::endl;
+      indent(ss, indent_size + 1)
+          << "allocation=[ " << toDelimitedString(allocation()) << " ]";
+    }
+  }
   return ss.str();
+}
+
+std::string TensorDomain::toString(const int indent_size) const {
+  return toString(indent_size, /*leaf_only=*/true);
 }
 
 std::string TensorDomain::toInlineString(int indent_size) const {


### PR DESCRIPTION
This makes it easier to debug TensorDomain, and happens to fix a bug where `indent_size` was ignored. 