### PR TITLE
Replace uses of evaluate* and get* with evaluate() and value(). 

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1310,7 +1310,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
               id->extent()->isConstInt(),
               "Could not evaluate constant value bound to vectorized dim.");
 
-          vector_word_size = id->extent()->evaluateInt();
+          vector_word_size = id->extent()->evaluate().as<int64_t>();
 
           is_vector_op = true;
           break;
@@ -1587,8 +1587,9 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
               MemoryType::Global;
         });
 
-    auto pred_bool = wop->hoistedPredicate()->getBool();
-    bool is_predicated = !(pred_bool.has_value() && pred_bool.value());
+    auto pred_bool = wop->hoistedPredicate()->value();
+    bool is_predicated =
+        !(pred_bool.hasValue() && pred_bool.is<bool>() && pred_bool.as<bool>());
 
     ArgumentBuilder func_args;
     func_args.arg(gen(out_avg));
@@ -1918,7 +1919,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
     // Incrementally build a combinatorial set
     for (const auto loop : grouped_loops_) {
-      const auto iter_count = loop->stop()->evaluateInt();
+      const auto iter_count = loop->stop()->evaluate();
       std::vector<std::vector<int64_t>> new_combinations;
       // Append integers from 0 to iter_count to all the vectors built
       // so far

--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -154,11 +154,11 @@ bool IterDomainGraph::exprsMap(
 
     auto extent_0_match = extent_0o->sameAs(extent_1o) ||
         (extent_0o->isConstInt() && extent_1o->isConstInt() &&
-         extent_0o->evaluateInt() == extent_1o->evaluateInt());
+         extent_0o->evaluate() == extent_1o->evaluate());
 
     auto extent_1_match = extent_0i->sameAs(extent_1i) ||
         (extent_0i->isConstInt() && extent_1i->isConstInt() &&
-         extent_0i->evaluateInt() == extent_1i->evaluateInt());
+         extent_0i->evaluate() == extent_1i->evaluate());
 
     if (!(extent_0_match || extent_1_match)) {
       return false;

--- a/csrc/device_lower/analysis/bank_conflict.cpp
+++ b/csrc/device_lower/analysis/bank_conflict.cpp
@@ -36,7 +36,7 @@ int64_t getVectorizeSize(kir::TensorIndex* ti) {
         id->extent()->isConstInt(),
         "Could not evaluate constant value bound to vectorized dim.");
 
-    return id->extent()->evaluateInt();
+    return id->extent()->evaluate().as<int64_t>();
   }
   return 1;
 }

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -153,16 +153,15 @@ class PredicateAnalyzer : public OptOutDispatch {
   // axis. Otherwise, we can't skip predication as it might cause
   // out-bound accesses with the producer tensor
   void handle(Split* split) override {
-    auto factor = split->factor()->getInt();
-    if (!factor.has_value()) {
+    auto factor = split->factor()->value();
+    if (!factor.hasValue() || !factor.is<int64_t>()) {
       needs_predicate_ = true;
       return;
     }
 
     auto in_extent = split->in()->extent();
 
-    if (!in_extent->isConstInt() ||
-        ((in_extent->evaluateInt() % factor.value()) != 0)) {
+    if (!in_extent->isConstInt() || ((in_extent->evaluate() % factor) != 0)) {
       needs_predicate_ = true;
       return;
     }

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -176,8 +176,7 @@ void GpuLower::collectPaddedParallelDims() {
             size_after_padding.value() == warp_size;
 
         if (id->extent()->isConstInt() &&
-            id->extent()->evaluateInt() > warp_size &&
-            !padding_to_single_warp) {
+            id->extent()->evaluate() > warp_size && !padding_to_single_warp) {
           // If we see any other TIDx binding that's larger than
           //  a warp or unknown, we shouldn't lower warp reduce
           //  to a single warp type.
@@ -186,7 +185,7 @@ void GpuLower::collectPaddedParallelDims() {
         } else if (can_be_single_warp) {
           if (padding_to_single_warp ||
               (id->extent()->isConstInt() &&
-               id->extent()->evaluateInt() == warp_size)) {
+               id->extent()->evaluate() == warp_size)) {
             warp_pad_info_.is_tidx_single_warp = true;
           }
         }

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -822,7 +822,7 @@ class AllocationInfoMap : private kir::IrVisitor {
             "Lower_alias_memory : dynamic sized register allocation");
         return;
       }
-      if (alloc->size()->evaluateInt() <= kRegisterSizeThreshold) {
+      if (alloc->size()->evaluate() <= kRegisterSizeThreshold) {
         should_try_alias = false;
       }
     }

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1122,8 +1122,8 @@ bool canUseOuterOptRuntimeKernel(const GroupedWelfordOp* grouped_wop) {
   if (!tidx_val->isConstInt() || !tidy_val->isConstInt()) {
     return false;
   }
-  auto tidx = static_cast<int>(tidx_val->evaluateInt());
-  auto tidy = static_cast<int>(tidy_val->evaluateInt());
+  auto tidx = static_cast<int>(tidx_val->evaluate());
+  auto tidy = static_cast<int>(tidy_val->evaluate());
 
   // TIDz and BIDz must be unused or just 1. This contraint can be
   // lifted if necessary.
@@ -1153,7 +1153,7 @@ bool canUseOuterOptRuntimeKernel(const GroupedWelfordOp* grouped_wop) {
           axis->extent()->isConstInt(),
           "Grouped IterDomain must have a static integer extent: ",
           axis->extent()->toInlineString());
-      num_grouped_iterations *= (int)axis->extent()->evaluateInt();
+      num_grouped_iterations *= (int)axis->extent()->evaluate();
     }
   }
 

--- a/csrc/device_lower/pass/unroll.cpp
+++ b/csrc/device_lower/pass/unroll.cpp
@@ -299,7 +299,7 @@ bool UnrollPass::canOmitElseClause(kir::ForLoop* fl) {
       visit_once = true;
     }
     if (!visit_once) {
-      if (loop->stop()->isConstInt() && loop->stop()->evaluateInt() == 1) {
+      if (loop->stop()->isConstInt() && loop->stop()->evaluate() == 1) {
         visit_once = true;
       }
     }

--- a/csrc/device_lower/pass/warp_reduce.cpp
+++ b/csrc/device_lower/pass/warp_reduce.cpp
@@ -365,13 +365,13 @@ class FuseBroadcastWithWarpReduce : private kir::IrVisitor {
       // not have
       //  a size of 1, since it would have required re-indexing.
       if (!reduction_allocate_it->second->size()->isConstInt() ||
-          reduction_allocate_it->second->size()->evaluateInt() != 1) {
+          reduction_allocate_it->second->size()->evaluate() != 1) {
         return;
       }
 
       auto broadcast_allocate = getActiveAllocateFor(out_tv);
       if (!broadcast_allocate->size()->isConstInt() ||
-          broadcast_allocate->size()->evaluateInt() != 1) {
+          broadcast_allocate->size()->evaluate() != 1) {
         return;
       }
 
@@ -401,7 +401,7 @@ class FuseBroadcastWithWarpReduce : private kir::IrVisitor {
     }
 
     if (id->extent()->isConstScalar()) {
-      return id->extent()->evaluateInt() == warp_size;
+      return id->extent()->evaluate() == warp_size;
     }
 
     return false;

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -341,7 +341,7 @@ std::optional<IterDomain*> getMaybeWarpReductionDim(
   }
 
   if (reduction_on_xdim->extent()->isConstInt()) {
-    auto extent_value = reduction_on_xdim->extent()->evaluateInt();
+    auto extent_value = reduction_on_xdim->extent()->evaluate();
     if (extent_value % at::cuda::warp_size() == 0) {
       return std::optional<IterDomain*>(reduction_on_xdim);
     }

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -126,9 +126,10 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
   //! Detect possibly empty TensorViews and dynamic IterDomain transforms
   void handle(TensorView* tv) override {
     const auto& rfd = tv->getMaybeRFactorDomain();
+    ExpressionEvaluator ee;
     for (auto id : rfd) {
       if (!id->getMaybeExpandedExtent()->isConstScalar() ||
-          id->getMaybeExpandedExtent()->evaluateInt() == 0) {
+          id->getMaybeExpandedExtent()->evaluate() == 0) {
         info_.maybe_zero_extents_set_.insert(id->getMaybeExpandedExtent());
         leaf_dynamic_vals_.push_back(id->getMaybeExpandedExtent());
       }

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -190,15 +190,7 @@ void PrecomputedValues::initializeValueList(
     // Use an expression evaluator to test if value is const
     if (sorted_value_list[i]->isConstScalar()) {
       is_constant_[i] = true;
-      if (sorted_value_list[i]->isIntegralScalar()) {
-        values_[i] = PolymorphicValue(sorted_value_list[i]->evaluateInt());
-      }
-      if (sorted_value_list[i]->isFloatingPointScalar()) {
-        values_[i] = PolymorphicValue(sorted_value_list[i]->evaluateDouble());
-      }
-      if (sorted_value_list[i]->isABool()) {
-        values_[i] = PolymorphicValue(sorted_value_list[i]->evaluateBool());
-      }
+      values_[i] = sorted_value_list[i]->evaluate();
     }
     sorted_value_list[i]->setEvaluatorIndex(i);
   }

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -273,19 +273,7 @@ Val* foldConstants(Val* value) {
     return value;
   }
   if (value->isConstScalar()) {
-    if (value->isIntegralScalar()) {
-      return IrBuilder::create<Val>(
-          value->evaluateInt(), *value->getDataType());
-    }
-    if (value->isFloatingPointScalar()) {
-      return IrBuilder::create<Val>(
-          value->evaluateDouble(), *value->getDataType());
-    }
-    if (value->isABool()) {
-      return IrBuilder::create<Val>(
-          value->evaluateBool(), *value->getDataType());
-    }
-    // TODO: support complex double
+    return IrBuilder::create<Val>(value->evaluate(), *value->getDataType());
   }
   return value;
 }
@@ -488,14 +476,14 @@ inline bool isNoOpTerm(Val* v, BinaryOpType type) {
     case BinaryOpType::Mul:
       return v->isOne();
     case BinaryOpType::LogicalAnd:
-      return v->getBool() == true;
+      return v->value() == true;
     case BinaryOpType::LogicalOr:
-      return v->getBool() == false;
+      return v->value() == false;
     case BinaryOpType::BitwiseAnd:
-      return v->getInt() == -1;
+      return v->value() == -1;
     case BinaryOpType::BitwiseOr:
     case BinaryOpType::BitwiseXor:
-      return v->getInt() == 0;
+      return v->value() == 0;
     case BinaryOpType::Gcd:
       return v->isZeroInt();
     default:
@@ -514,15 +502,15 @@ inline bool isBlackhole(Val* v, BinaryOpType type) {
   }
   switch (type) {
     case BinaryOpType::Mul:
-      return v->getInt() == 0;
+      return v->value() == 0;
     case BinaryOpType::LogicalAnd:
-      return v->getBool() == false;
+      return v->value() == false;
     case BinaryOpType::LogicalOr:
-      return v->getBool() == true;
+      return v->value() == true;
     case BinaryOpType::BitwiseAnd:
-      return v->getInt() == 0;
+      return v->value() == 0;
     case BinaryOpType::BitwiseOr:
-      return v->getInt() == -1;
+      return v->value() == -1;
     case BinaryOpType::Gcd:
       return v->isOneInt();
     default:
@@ -1011,9 +999,9 @@ inline DataType dataTypeOrNull(Val* x) {
   return x == nullptr ? DataType::Null : x->dtype();
 }
 
-// If x is nullptr, return 1. Otherwise, return x->getInt().
+// If x is nullptr, return 1. Otherwise, return x->value().as<int64_t>.
 inline int64_t getIntOrOne(Val* x) {
-  return x == nullptr ? 1 : *x->getInt();
+  return x == nullptr ? 1 : x->value().as<int64_t>();
 }
 
 // If the data type is unknown, return nullptr. Otherwise, return a constant
@@ -1103,9 +1091,9 @@ std::pair<Val*, std::list<Val*>> getConstAndSymbolicFactors(Val* x) {
   std::list<Val*> symbolic_factors;
   for (auto f : factors) {
     f = foldConstants(f);
-    if (f->getInt().has_value()) {
+    if (f->value().hasValue() && f->value().is<int64_t>()) {
       const_dtype = promoteTypeWithNull(const_dtype, f->dtype());
-      const_factor *= *f->getInt();
+      const_factor *= f->value().as<int64_t>();
     } else {
       symbolic_factors.emplace_back(f);
     }
@@ -1131,7 +1119,7 @@ Val* productOfFactors(
     return assoc_comm::maybeFlattenedOpOf(
         BinaryOpType::Mul, std::move(symbolic_factors));
   }
-  if (*const_factor->getInt() != 1 || symbolic_factors.empty()) {
+  if (const_factor->value() != 1 || symbolic_factors.empty()) {
     symbolic_factors.emplace_back(const_factor);
   }
   return maybeFlattenedOpOf(BinaryOpType::Mul, std::move(symbolic_factors));
@@ -1490,10 +1478,7 @@ bool isPositiveHelper(Val* value, const Context& context) {
 
 bool isNonZero(Val* value, const Context& context) {
   value = foldConstants(value);
-  if (value->getInt().has_value() && *value->getInt() != 0) {
-    return true;
-  }
-  if (value->getDouble().has_value() && *value->getDouble() != 0.0) {
+  if (value->value().hasValue() && value->value() != 0) {
     return true;
   }
   if (isPositive(value, context)) {
@@ -1525,11 +1510,8 @@ bool hasCompatibleSign(Val* x, Val* y, const Context& context) {
 bool lessThan(Val* x, Val* y, const Context& context) {
   x = foldConstants(x);
   y = foldConstants(y);
-  if (x->getInt().has_value() && y->getInt().has_value()) {
-    return *x->getInt() < *y->getInt();
-  }
-  if (x->getDouble().has_value() && y->getDouble().has_value()) {
-    return *x->getDouble() < *y->getDouble();
+  if (x->value().hasValue() && y->value().hasValue()) {
+    return x->value() < y->value();
   }
   x = maybeUnwrapMagicZero(x);
   y = maybeUnwrapMagicZero(y);
@@ -1557,11 +1539,8 @@ bool lessThan(Val* x, Val* y, const Context& context) {
 bool lessEqual(Val* x, Val* y, const Context& context) {
   x = foldConstants(x);
   y = foldConstants(y);
-  if (x->getInt().has_value() && y->getInt().has_value()) {
-    return *x->getInt() <= *y->getInt();
-  }
-  if (x->getDouble().has_value() && y->getDouble().has_value()) {
-    return *x->getDouble() <= *y->getDouble();
+  if (x->value().hasValue() && y->value().hasValue()) {
+    return x->value() <= y->value();
   }
   x = maybeUnwrapMagicZero(x);
   y = maybeUnwrapMagicZero(y);
@@ -1887,7 +1866,8 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       // a / 1 -> a
       // 0 / a -> 0
       if (rhs->isOne() ||
-          (isValidDenominator(rhs, context) && lhs->getInt() == 0)) {
+          (isValidDenominator(rhs, context) && lhs->value().hasValue() &&
+           lhs->value().is<int64_t>() && lhs->value() == 0)) {
         return lhs;
       }
     }

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -315,7 +315,7 @@ bool Fusion::isNoOp() {
     auto root_dom = TensorDomain::noReductions(out_tv->getMaybeRFactorDomain());
     bool size_zero = false;
     for (auto id : root_dom) {
-      if (id->extent()->isConstScalar() && id->extent()->evaluateInt() == 0) {
+      if (id->extent()->isConstScalar() && id->extent()->evaluate() == 0) {
         size_zero = true;
         break;
       }

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -320,13 +320,13 @@ Val* getProducerIndexWithPartialSplit(
       diff->isConstScalar(),
       "Invalid partial split, must be a constant value.");
 
-  if (diff->evaluateInt() == 0) {
+  if (diff->evaluate() == 0) {
     return producer_index;
   }
 
   return SimplifyingIrBuilder::addExpr(
       producer_index,
-      SimplifyingIrBuilder::create<Val>(diff->evaluateInt(), DataType::Index));
+      SimplifyingIrBuilder::create<Val>(diff->evaluate(), DataType::Index));
 }
 
 Val* getTensorBaseAddress(TensorView* tv) {
@@ -2925,7 +2925,8 @@ bool canOmitStopPredicate(
     auto in_extent = IrBuilder::ltExpr(
         IrBuilder::create<Val>(lhs, *stop_index->getDataType()),
         contig_id->getMaybeExpandedExtent());
-    if (simplifyExpr(in_extent)->getBool() == true) {
+    auto expr_val = simplifyExpr(in_extent)->value();
+    if (expr_val.hasValue() && expr_val.is<bool>() && expr_val.as<bool>()) {
       return true;
     } else {
       return false;

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -206,115 +206,44 @@ bool Val::isConstInt() const {
   return ir_utils::dependenciesSatisfied(this) && isIntegralScalar();
 }
 
-int64_t Val::evaluateInt() {
-  NVF_ERROR(
-      ir_utils::dependenciesSatisfied(this),
-      "Cannot get Int of not const values through IR nodes, must use runtime ExpressionEvaluator.");
-
+PolymorphicValue Val::evaluate() {
   if (this->value().hasValue()) {
-    return this->value().as<int64_t>();
+    return this->value();
   }
 
   ExpressionEvaluator ee;
   auto evaluated_val = ee.evaluate(this);
   NVF_ERROR(
       evaluated_val.hasValue(),
-      "Detected a const integer but failed to infer its value: ",
+      "Detected a const value but failed to infer its value: ",
       toInlineString());
-  return evaluated_val.as<int64_t>();
-}
-
-double Val::evaluateDouble() {
-  NVF_ERROR(
-      ir_utils::dependenciesSatisfied(this),
-      "Cannot get Double of not const doubles through IR nodes, must use runtime ExpressionEvaluator.");
-
-  if (this->value().hasValue()) {
-    return this->value().as<double>();
-  }
-
-  ExpressionEvaluator ee;
-  auto evaluated_val = ee.evaluate(this);
-  NVF_ERROR(
-      evaluated_val.hasValue(),
-      "Detected a const integer but failed to infer its value.");
-  return evaluated_val.as<double>();
-}
-
-bool Val::evaluateBool() {
-  NVF_ERROR(
-      ir_utils::dependenciesSatisfied(this),
-      "Cannot get Bool of not const bools through IR nodes, must use runtime ExpressionEvaluator.");
-
-  if (this->value().hasValue()) {
-    return this->value().as<bool>();
-  }
-
-  ExpressionEvaluator ee;
-  auto evaluated_val = ee.evaluate(this);
-  NVF_ERROR(
-      evaluated_val.hasValue(),
-      "Detected a const integer but failed to infer its value.");
-  return evaluated_val.as<bool>();
-}
-
-std::optional<int64_t> Val::getInt() const {
-  if (isConstScalar() && isIntegralScalar()) {
-    auto val = this->value();
-    if (val.is<int64_t>()) {
-      return val.as<int64_t>();
-    }
-    return std::nullopt;
-  }
-  return std::nullopt;
-}
-
-std::optional<double> Val::getDouble() const {
-  if (isConstScalar() && isFloatingPointScalar()) {
-    auto val = this->value();
-    if (val.is<double>()) {
-      return val.as<double>();
-    }
-    return std::nullopt;
-  }
-  return std::nullopt;
-}
-
-std::optional<bool> Val::getBool() const {
-  if (isConstScalar() && isABool()) {
-    auto val = this->value();
-    if (val.is<bool>()) {
-      return val.as<bool>();
-    }
-    return std::nullopt;
-  }
-  return std::nullopt;
+  return evaluated_val;
 }
 
 bool Val::isZero() const {
-  return getInt() == 0 || getDouble() == 0.0;
+  return value().hasValue() &&
+      (value().is<double>() || value().is<int64_t>()) && value() == 0;
 }
 
 bool Val::isZeroInt() const {
-  auto int_val = getInt();
-  return int_val.has_value() && int_val.value() == 0;
+  return value().hasValue() && value().is<int64_t>() && value() == 0;
 }
 
 bool Val::isOne() const {
-  return getInt() == 1 || getDouble() == 1.0;
+  return value().hasValue() &&
+      (value().is<double>() || value().is<int64_t>()) && value() == 1;
 }
 
 bool Val::isOneInt() const {
-  auto int_val = getInt();
-  return int_val.has_value() && int_val.value() == 1;
+  return value().hasValue() && value().is<int64_t>() && value() == 1;
 }
 
 bool Val::isTrue() const {
-  return getBool() == true;
+  return value().hasValue() && value().is<bool>() && value().as<bool>();
 }
 
 bool Val::isFalse() const {
-  return getBool() == false;
+  return value().hasValue() && value().is<bool>() && !value().as<bool>();
 }
 
 std::optional<DataType> Val::getDataType() const {

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -326,38 +326,10 @@ class Val : public Statement {
     return isScalar() && dtype_ == DataType::Bool;
   }
 
-  // If this Val is an integer with a direct constant value associated with it,
-  // will return the value of that constant integer. If this integer has
-  // defining expressions it will return a std::nullopt. Those values should be
-  // infered using evaluateInt.
-  std::optional<int64_t> getInt() const;
-
-  // If this Val is a double with a direct constant value associated with it,
-  // will return the value of that constant double. If this double has
-  // defining expressions it will return a std::nullopt. Those values should be
-  // infered using evaluateDouble.
-  std::optional<double> getDouble() const;
-
-  // If this Val is a bool with a direct constant value associated with it,
-  // will return the value of that constant bool. If this bool has defining
-  // expressions it will return a std::nullopt. Those values should be infered
-  // using evaluateBool.
-  std::optional<bool> getBool() const;
-
-  // If this Val is a constant integer, and its history is comprised only of
-  // constant values, will return the value of that constant integer. Cannot
-  // make constant as expression evaluator takes non-constant Vals.
-  int64_t evaluateInt();
-
-  // If this Val is a constant double, and its history is comprised only of
-  // constant values, will return the value of that constant double. Cannot
-  // make constant as expression evaluator takes non-constant Vals.
-  double evaluateDouble();
-
-  // If this Val is a constant bool, and its history is comprised only of
-  // constant values, will return the value of that constant bool. Cannot
-  // make constant as expression evaluator takes non-constant Vals.
-  bool evaluateBool();
+  // If this Val's history is comprised only of constant values, will return a
+  // PolymorphicValue. Cannot make constant as expression evaluator takes
+  // non-constant Vals.
+  PolymorphicValue evaluate();
 
   // Returns if no dependencies and is a constant scalar.
   virtual bool isConst() const {

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -711,7 +711,7 @@ Val* SimplifyingIrBuilder::whereExpr(Val* pred, Val* lhs, Val* rhs) {
     return lhs; // return value is independent of predicate
   }
   if (pred->isConstScalar() && pred->isABool()) {
-    if (pred->evaluateBool()) {
+    if (pred->evaluate()) {
       return lhs;
     } else {
       return rhs;

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -1189,7 +1189,7 @@ SqueezeOp::SqueezeOp(
         // Check concrete broadcast extent here. For Symbolic inputs, this check
         // will be deferred to concretization. See dynamic_transform.cpp
         NVF_ERROR(
-            id->extent()->isConstScalar() && id->extent()->evaluateInt() == 1,
+            id->extent()->isConstScalar() && id->extent()->evaluate() == 1,
             "Can not squeeze dimension(s) with size != 1.");
       }
     } else {
@@ -2930,8 +2930,8 @@ IterDomain* IterDomain::resize(
       right_expansion->toString());
 
   if (left_expansion->isConstInt() && right_expansion->isConstInt()) {
-    auto left = left_expansion->evaluateInt();
-    auto right = right_expansion->evaluateInt();
+    auto left = left_expansion->evaluate();
+    auto right = right_expansion->evaluate();
     if (left == 0 && right == 0) {
       // This is a trivial resize. Check that we are not changing the IterType,
       // then return the input.
@@ -2983,11 +2983,11 @@ IterDomain* IterDomain::resize(
   if (iter_type_opt.has_value()) {
     iter_type = iter_type_opt.value();
   } else if (left_expansion->isConstInt() && right_expansion->isConstInt()) {
-    auto left = left_expansion->evaluateInt();
-    auto right = right_expansion->evaluateInt();
+    auto left = left_expansion->evaluate();
+    auto right = right_expansion->evaluate();
     if (resized_id_size->isConstInt()) {
       // Means input extent is also known
-      auto out_extent = resized_id_size->evaluateInt();
+      auto out_extent = resized_id_size->evaluate();
       iter_type = out_extent == 1 ? IterType::Broadcast : IterType::Iteration;
     } else if (left + right > 1) {
       // Input extent is non-negative, so we know out_extent > 1

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -160,8 +160,8 @@ class KernelIrScanner : private IrVisitor {
           tidy_val->isConstInt(),
           "TIDy is expected to be a const int: ",
           tidy_val->toInlineString());
-      auto tidx = static_cast<int>(tidx_val->evaluateInt());
-      auto tidy = static_cast<int>(tidy_val->evaluateInt());
+      auto tidx = static_cast<int>(tidx_val->evaluate());
+      auto tidy = static_cast<int>(tidy_val->evaluate());
       summary_.outer_grouped_grid_welford_largest_smem_size = std::max(
           summary_.outer_grouped_grid_welford_largest_smem_size,
           grid_welford->getSmemBufferSize(tidx, tidy, 1));

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -1207,9 +1207,8 @@ int GroupedGridWelford::getSmemBufferSize(int bdimx, int bdimy, int bdimz)
   for (auto axis : out_tv->getLeafDomain()) {
     auto pt = axis->getParallelType();
     if (pt == ParallelType::Group) {
-      auto extent_int = axis->extent()->getInt();
-      NVF_ERROR(extent_int.has_value());
-      group_count *= (int)extent_int.value();
+      auto extent_int = axis->extent()->value();
+      group_count *= (int)extent_int.as<int64_t>();
     }
   }
 

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -122,7 +122,8 @@ class Predicate final : public Val {
   }
 
   bool isTrivial() const {
-    return isConst() && value_->getBool() == true;
+    return isConst() && value_->value().hasValue() &&
+        value_->value().is<bool>() && value_->value().as<bool>();
   }
 
  private:

--- a/csrc/non_divisible_split.cpp
+++ b/csrc/non_divisible_split.cpp
@@ -103,12 +103,12 @@ void NonDivisibleSplitInfo::propagateReachability(
 Val* NonDivisibleSplitInfo::getMaybeNonDivisibleExtent(Split* split) const {
   std::optional<int64_t> in_extent;
   if (split->in()->extent()->isConstInt()) {
-    in_extent = split->in()->extent()->evaluateInt();
+    in_extent = split->in()->extent()->evaluate().as<int64_t>();
   }
 
   std::optional<int64_t> factor;
   if (split->factor()->isConstInt()) {
-    factor = split->factor()->evaluateInt();
+    factor = split->factor()->evaluate().as<int64_t>();
   }
 
   if (in_extent.has_value() && factor.has_value() &&

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -82,7 +82,7 @@ TensorView* tryStaticReshape(
     if (!id_size->isConstInt()) {
       return nullptr;
     }
-    inp_sizes[i] = id_size->evaluateInt();
+    inp_sizes[i] = id_size->evaluate().as<int64_t>();
   }
 
   std::vector<int64_t> out_sizes(new_sizes.size());
@@ -91,7 +91,7 @@ TensorView* tryStaticReshape(
     if (!id_size->isConstInt()) {
       return nullptr;
     }
-    out_sizes[i] = id_size->evaluateInt();
+    out_sizes[i] = id_size->evaluate().as<int64_t>();
   }
 
   // Both inputs are outputs are static. Just use the static version
@@ -125,7 +125,7 @@ TensorView* reshape(TensorView* inp_tv, const std::vector<Val*>& new_sizes) {
   bool found_neg_one = false;
   for (const auto i : c10::irange(new_sizes.size())) {
     auto new_size = new_sizes.at(i);
-    if (new_size->isConstScalar() && new_size->evaluateInt() == -1) {
+    if (new_size->isConstScalar() && new_size->evaluate() == -1) {
       // It is usually safe to use the provided scalars as the output shapes.
       // However, if -1 is provided for some position, it will not correspond to
       // the actual extent in that position.
@@ -228,7 +228,7 @@ TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
         NVF_CHECK(
             !id->hasExpandedExtent(), "Can not squeeze expanded dimension(s).");
         NVF_CHECK(
-            id->extent()->isConstScalar() && id->extent()->evaluateInt() == 1,
+            id->extent()->isConstScalar() && id->extent()->evaluate() == 1,
             "Can not squeeze dimension(s) with size != 1.");
       }
     } else {

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -64,7 +64,7 @@ Val* simplifiedInt(Val* val) {
   if (val->value().hasValue()) {
     return val;
   }
-  return IrBuilder::create<Val>(val->evaluateInt(), val->dtype());
+  return IrBuilder::create<Val>(val->evaluate(), val->dtype());
 }
 
 // If one size is nullptr, return the other. If both symbolic just return v1. If
@@ -88,15 +88,15 @@ Val* promoteSize(Val* v1, Val* v2) {
     return v1;
   } else if (v1->isConstInt() && v2->isConstInt()) {
     NVF_ERROR(
-        v1->evaluateInt() == v2->evaluateInt(),
+        v1->evaluate() == v2->evaluate(),
         "Expected sizes of, ",
         v1->toString(),
         " and ",
         v2->toString(),
         " to match but found ",
-        v1->evaluateInt(),
+        v1->evaluate(),
         " and ",
-        v2->evaluateInt(),
+        v2->evaluate(),
         ".");
     return simplifiedInt(v1);
   } else if (v1->isConstInt()) {
@@ -241,8 +241,9 @@ std::vector<IterDomain*> newOutputDomain(
           "Invalid IterDomain stop offset: ",
           stop_offset);
       start_offsets[i] =
-          std::max(start_offsets[i], start_offset->evaluateInt());
-      stop_offsets[i] = std::max(stop_offsets[i], stop_offset->evaluateInt());
+          std::max(start_offsets[i], start_offset->evaluate().as<int64_t>());
+      stop_offsets[i] =
+          std::max(stop_offsets[i], stop_offset->evaluate().as<int64_t>());
     }
   }
   for (const auto dim_i : c10::irange(out_domain.size())) {

--- a/csrc/optimization/remove_empty.cpp
+++ b/csrc/optimization/remove_empty.cpp
@@ -29,7 +29,7 @@ std::vector<int64_t> emptyAxes(const std::vector<IterDomain*>& domain) {
   for (auto ax : c10::irange(domain.size())) {
     auto id = domain.at(ax);
     if (id->getMaybeExpandedExtent()->isConst() &&
-        id->getMaybeExpandedExtent()->evaluateInt() == 0) {
+        id->getMaybeExpandedExtent()->evaluate() == 0) {
       empty_axes.push_back((int64_t)ax);
     }
   }
@@ -254,7 +254,7 @@ class EmptyTensorRemover : public DeadCodeRemover {
       auto cat_id =
           TensorDomain::noReductions(tv->getMaybeRFactorDomain()).at(dim);
       if (cat_id->getMaybeExpandedExtent()->isConst() &&
-          cat_id->getMaybeExpandedExtent()->evaluateInt() == 0) {
+          cat_id->getMaybeExpandedExtent()->evaluate() == 0) {
         continue;
       }
       non_empty_inputs.push_back(tv);

--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -74,9 +74,10 @@ void ParallelDimensionMap::build(Fusion* fusion) {
 
   // Compute exact_types_
   for (auto [ptype, concrete_id] : all_concrete_ids) {
-    if (simplifyExpr(SimplifyingIrBuilder::eqExpr(
-                         dim_map_.at(ptype), concrete_id->extent()))
-            ->getBool() != true) {
+    auto expr_val = simplifyExpr(SimplifyingIrBuilder::eqExpr(
+                                     dim_map_.at(ptype), concrete_id->extent()))
+                        ->value();
+    if (!expr_val.hasValue() || !expr_val.as<bool>()) {
       exact_types_.erase(ptype);
     }
   }
@@ -109,11 +110,14 @@ void ParallelDimensionMap::adjustMappingsForWarpPadding() {
     return;
   }
 
-  // If already multiple of warp, nothing to do
-  if (simplifyExpr(SimplifyingIrBuilder::eqExpr(
+  auto expr_val =
+      simplifyExpr(SimplifyingIrBuilder::eqExpr(
                        SimplifyingIrBuilder::modExpr(tidx_dim, warp_size_val),
                        tidx_dim->container()->zeroVal()))
-          ->getBool() == true) {
+          ->value();
+
+  // If already multiple of warp, nothing to do
+  if (expr_val.hasValue() && expr_val.is<bool>() && expr_val.as<bool>()) {
     return;
   }
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -150,9 +150,9 @@ void swizzleSharedMemory(
 
   // Extract the constant sizes of the swizzled tile
   const int64_t tile_size_x =
-      shared_mem_tv->axis(-2 - skip)->extent()->evaluateInt();
+      shared_mem_tv->axis(-2 - skip)->extent()->evaluate().as<int64_t>();
   const int64_t tile_size_y =
-      shared_mem_tv->axis(-1 - skip)->extent()->evaluateInt();
+      shared_mem_tv->axis(-1 - skip)->extent()->evaluate().as<int64_t>();
 
   if (isTuring(params.mma_macro) || isAmpere(params.mma_macro)) {
     // Only tested for (1) ldmatrix access with sizeof(T) == 16bit (i.e.
@@ -594,8 +594,8 @@ void scheduleOutputTensor(
   // input tensor is in the form of [Mo,No,cta_tile_m,cta_tile_n]
   checkConcreteStaticDim(c->axis(-2));
   checkConcreteStaticDim(c->axis(-1));
-  const int64_t tile_size_m = c->axis(-2)->extent()->evaluateInt();
-  const int64_t tile_size_n = c->axis(-1)->extent()->evaluateInt();
+  const int64_t tile_size_m = c->axis(-2)->extent()->evaluate().as<int64_t>();
+  const int64_t tile_size_n = c->axis(-1)->extent()->evaluate().as<int64_t>();
   NVF_ERROR(
       tile_size_m == gemm_tile.cta_tile.m,
       "Actual tile size at axis(-2) in output tensor is different from CTA tile size! Expected: ",

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -510,7 +510,7 @@ bool canValidateIsInnerDim(
   if (!leaf->extent()->isConstInt()) {
     return false;
   }
-  if (leaf->extent()->evaluateInt() != inner_dim_size) {
+  if (leaf->extent()->evaluate() != inner_dim_size) {
     return false;
   }
 
@@ -569,11 +569,11 @@ void checkDimSize(
         id->extent()->isConstInt(),
         "Mma warp mapping: instruction tile has to be constant");
     NVF_CHECK(
-        id->extent()->evaluateInt() == expect[axis_index],
+        id->extent()->evaluate() == expect[axis_index],
         "Mma warp mapping: unexpected tile size at",
         axis_index,
         ":",
-        id->extent()->evaluateInt(),
+        id->extent()->evaluate(),
         "vs",
         expect[axis_index],
         "\n for tv: ",

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -841,8 +841,8 @@ TensorView* TensorView::swizzle(
         x_id->extent()->isConstInt() && y_id->extent()->isConstInt(),
         "Only constant iterdomains supported on given swizzle type");
 
-    int in_x_size = (int)x_id->extent()->evaluateInt();
-    int in_y_size = (int)y_id->extent()->evaluateInt();
+    int in_x_size = (int)x_id->extent()->evaluate();
+    int in_y_size = (int)y_id->extent()->evaluate();
 
     // Check size constraints based on swizzle type
     if (swizzle_type == Swizzle2DType::XOR ||
@@ -1524,7 +1524,7 @@ TensorView* TensorViewBuilder::build() const {
           SimplifyingIrBuilder::maybeCastExpr(DataType::Index, shape_.at(i));
     }
     IterDomainBuilder builder(FusionGuard::getCurFusion()->zeroVal(), extent);
-    if (extent->isConstScalar() && extent->evaluateInt() == 1) {
+    if (extent->isConstScalar() && extent->evaluate() == 1) {
       builder.iter_type(IterType::Broadcast);
     }
     if (expanded_extent != nullptr) {

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -72,7 +72,7 @@ TEST_F(ExprEvalTest, Double) {
   auto three = IrBuilder::create<Val>(3.0);
   auto val = castOp(DataType::Int, ceilDiv(sub(ten, two), three));
   auto reference = static_cast<int64_t>(std::ceil((10.0 - 2.0) / 3.0));
-  EXPECT_EQ(reference, val->evaluateInt());
+  EXPECT_EQ(reference, val->evaluate());
 }
 
 // Evaluate basic scalar operations with bound values

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -7745,9 +7745,9 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap3_CUDA) {
   GpuLower gpulw(fusion.get());
   const auto& pdmap = gpulw.parallelDimensionMap();
   ASSERT_FALSE(pdmap.isExact(ParallelType::TIDx));
-  ASSERT_EQ(pdmap.get(ParallelType::TIDx)->getInt(), 20);
+  ASSERT_EQ(pdmap.get(ParallelType::TIDx)->value(), 20);
   ASSERT_TRUE(pdmap.isExact(ParallelType::TIDy));
-  ASSERT_EQ(pdmap.get(ParallelType::TIDy)->getInt(), 10);
+  ASSERT_EQ(pdmap.get(ParallelType::TIDy)->value(), 10);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor input1 = at::randn({13}, options);

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -6342,10 +6342,9 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
             std::find(cond_inputs.begin(), cond_inputs.end(), loop_index);
         auto vec_factor_it =
             std::find_if(cond_inputs.begin(), cond_inputs.end(), [](Val* inp) {
-              auto int_val = inp->getInt();
-              return int_val.has_value() &&
-                  (int_val.value() == vec_factor - 1 ||
-                   int_val.value() == -(vec_factor - 1));
+              auto int_val = inp->value();
+              return int_val.hasValue() &&
+                  (int_val == vec_factor - 1 || int_val == -(vec_factor - 1));
             });
         // If vectorized, the predicate should use (vec_factor - 1) or
         // -(vec_factor - 1) rather than the loop index.
@@ -8667,7 +8666,7 @@ TEST_F(NVFuserTest, Repro413_CUDA) {
       auto getVectorizationFactor = [](TensorView* tv) -> int64_t {
         for (auto i : tv->getLeafDomain()) {
           if (i->getParallelType() == ParallelType::Vectorize) {
-            return i->extent()->evaluateInt();
+            return i->extent()->evaluate().as<int64_t>();
           }
         }
         return 1;

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -4010,29 +4010,29 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogue_CUDA) {
       // also be allocated at address 0 with A stacked above it at position
       // 8192.
       EXPECT_EQ(
-          smem_allocs.at(0)->address()->evaluateInt(),
+          smem_allocs.at(0)->address()->evaluate(),
           // Assuming B numel times size(dtype) is a multiple of 16 so that
           // this address is aligned
-          smem_allocs.at(1)->size()->evaluateInt() *
+          smem_allocs.at(1)->size()->evaluate() *
               dataTypeSize(smem_allocs.at(1)->buffer()->dtype()));
-      EXPECT_EQ(smem_allocs.at(1)->address()->evaluateInt(), 0L);
-      EXPECT_EQ(smem_allocs.at(2)->address()->evaluateInt(), 0L);
+      EXPECT_EQ(smem_allocs.at(1)->address()->evaluate(), 0L);
+      EXPECT_EQ(smem_allocs.at(2)->address()->evaluate(), 0L);
     } else {
       // Prologue shared memory is not re-used. In this case, memory should
       // stack in C, B, A order.
       EXPECT_EQ(
-          smem_allocs.at(0)->address()->evaluateInt(),
+          smem_allocs.at(0)->address()->evaluate(),
           // Assuming for B and C that numel times size(dtype) is a multiple
           // of 16 so that this address is aligned
-          smem_allocs.at(1)->size()->evaluateInt() *
+          smem_allocs.at(1)->size()->evaluate() *
                   dataTypeSize(smem_allocs.at(1)->buffer()->dtype()) +
-              smem_allocs.at(2)->size()->evaluateInt() *
+              smem_allocs.at(2)->size()->evaluate() *
                   dataTypeSize(smem_allocs.at(2)->buffer()->dtype()));
       EXPECT_EQ(
-          smem_allocs.at(1)->address()->evaluateInt(),
-          smem_allocs.at(2)->size()->evaluateInt() *
+          smem_allocs.at(1)->address()->evaluate(),
+          smem_allocs.at(2)->size()->evaluate() *
               dataTypeSize(smem_allocs.at(2)->buffer()->dtype()));
-      EXPECT_EQ(smem_allocs.at(2)->address()->evaluateInt(), 0L);
+      EXPECT_EQ(smem_allocs.at(2)->address()->evaluate(), 0L);
     }
   }
 }

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -36,7 +36,7 @@ TEST_F(NVFuserTest, FusionSplitDims_CUDA) {
       tv, {{0, p(2)}, {0, p(1)}, {3, p(6)}, {6, p(10)}}, dims);
   EXPECT_EQ(tv->nDims(), 11);
   for (auto i : c10::irange(11)) {
-    EXPECT_EQ(tv->axis(i)->extent()->evaluateInt(), p(i));
+    EXPECT_EQ(tv->axis(i)->extent()->evaluate(), p(i));
   }
   std::vector<size_t> expect{0, 3, 4, 5, 7, 8, 9};
   EXPECT_EQ(dims, expect);
@@ -57,7 +57,7 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
       p(0), p(1), p(2) * p(3) * p(7) * p(8) * p(9), p(4), p(5), p(6), p(10)};
   EXPECT_EQ(tv->nDims(), expect_shape.size());
   for (auto i : c10::irange(expect_shape.size())) {
-    EXPECT_EQ(tv->axis(i)->extent()->evaluateInt(), expect_shape[i]);
+    EXPECT_EQ(tv->axis(i)->extent()->evaluate(), expect_shape[i]);
   }
   std::vector<size_t> expect_dims{0, 1, 2, 2, 3, 4, 5, 2, 2, 2, 6};
   EXPECT_EQ(dims, expect_dims);
@@ -281,7 +281,7 @@ TEST_F(VectorizeHelperTest, BackwardMapper1_CUDA) {
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(1)));
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 3);
   }
 
   {
@@ -293,10 +293,10 @@ TEST_F(VectorizeHelperTest, BackwardMapper1_CUDA) {
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 2);
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 2);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 3);
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 2 * 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 2 * 3);
   }
 }
 
@@ -319,21 +319,21 @@ TEST_F(VectorizeHelperTest, BackwardMapper2_CUDA) {
       [&]() { mapper.getProjectedExtent(tv2->axis(0)); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Not projected")));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluate(), 4);
   // Inner dim fully maps, outer dim of split partially maps
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(2)));
 
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 4);
   // Inner dim fully maps, outer dim of split partially maps
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
 
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 4 * 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 4 * 3);
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
 }
@@ -356,15 +356,15 @@ TEST_F(VectorizeHelperTest, BackwardMapper3_CUDA) {
   // Partial map forwarding
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluate(), 4);
 }
 
 // Test simple backward mapping through merge
@@ -397,10 +397,10 @@ TEST_F(VectorizeHelperTest, BackwardMapper4_CUDA) {
     EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 2);
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 2);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3);
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 2 * 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 2 * 3);
   }
 }
 
@@ -467,16 +467,16 @@ TEST_F(VectorizeHelperTest, BackwardMapper6_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 3 * 4);
 }
 
 // Test concrete exact inner dim mapping through merge
@@ -497,16 +497,16 @@ TEST_F(VectorizeHelperTest, BackwardMapper7_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 3 * 4);
 }
 
 // Test concrete partial inner dim mapping through merge
@@ -527,16 +527,16 @@ TEST_F(VectorizeHelperTest, BackwardMapper8_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 4);
 }
 
 // Test concrete partial inner dim mapping through merge
@@ -558,21 +558,21 @@ TEST_F(VectorizeHelperTest, BackwardMapper9_CUDA) {
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[2]->sameAs(tv0->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluate(), 1);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 5);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 5);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 5);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 7);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 5);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluate(), 7);
 }
 
 // Similar to BackwardMapper1_CUDA but in the reverse direction
@@ -604,7 +604,7 @@ TEST_F(VectorizeHelperTest, ForwardMapper1_CUDA) {
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3);
   }
 
   {
@@ -616,10 +616,10 @@ TEST_F(VectorizeHelperTest, ForwardMapper1_CUDA) {
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 2);
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 2);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3);
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 2 * 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 2 * 3);
   }
 }
 
@@ -642,21 +642,21 @@ TEST_F(VectorizeHelperTest, ForwardMapper2_CUDA) {
       [&]() { mapper.getProjectedExtent(tv0->axis(0)); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Not projected")));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluate(), 4);
   // Inner dim fully maps, outer dim of split partially maps
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(2)));
 
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 4);
   // Inner dim fully maps, outer dim of split partially maps
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
 
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 4 * 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 4 * 3);
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
 }
@@ -679,15 +679,15 @@ TEST_F(VectorizeHelperTest, ForwardMapper3_CUDA) {
   // Partial map forwarding
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluate(), 4);
 }
 
 // Similar to BackwardMapper4_CUDA but in the reverse direction
@@ -720,10 +720,10 @@ TEST_F(VectorizeHelperTest, ForwardMapper4_CUDA) {
     EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 2);
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 2);
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 2);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 3);
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 2 * 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 2 * 3);
   }
 }
 
@@ -790,16 +790,16 @@ TEST_F(VectorizeHelperTest, ForwardMapper6_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3 * 4);
 }
 
 // Similar to BackwardMapper7_CUDA but in the reverse direction
@@ -820,16 +820,16 @@ TEST_F(VectorizeHelperTest, ForwardMapper7_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3 * 4);
 }
 
 // Similar to BackwardMapper8_CUDA but in the reverse direction
@@ -850,16 +850,16 @@ TEST_F(VectorizeHelperTest, ForwardMapper8_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 4);
 }
 
 // Make sure partial mappings are mapped to gcd(combined, inner) for inner
@@ -882,21 +882,21 @@ TEST_F(VectorizeHelperTest, ForwardMapper9_CUDA) {
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[2]->sameAs(tv2->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluate(), 1);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 5);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 5);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 5);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 7);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 5);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluate(), 7);
 }
 
 // Test propogation doesn't proceed across missing dimensions
@@ -936,7 +936,7 @@ TEST_F(VectorizeHelperTest, MapperAdvanced_CUDA) {
         tv5, {tv5->axis(0), tv5->axis(1)});
     EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 6);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 6);
   }
 
   {
@@ -946,7 +946,7 @@ TEST_F(VectorizeHelperTest, MapperAdvanced_CUDA) {
         tv3, {tv3->axis(0), tv3->axis(1), tv3->axis(2), tv3->axis(3)});
     EXPECT_EQ(mapper.mappedRFactorIds(tv7).size(), 1);
     EXPECT_TRUE(mapper.mappedRFactorIds(tv7)[0]->sameAs(tv7->axis(1)));
-    EXPECT_EQ(mapper.getProjectedExtent(tv7->axis(1))->evaluateInt(), 6);
+    EXPECT_EQ(mapper.getProjectedExtent(tv7->axis(1))->evaluate(), 6);
   }
 }
 
@@ -1017,7 +1017,7 @@ TEST_F(VectorizeHelperTest, SpanningTree_CUDA) {
             continue;
           }
           for (auto axis : tv->getRootDomain()) {
-            EXPECT_EQ(mapper.getProjectedExtent(axis)->evaluateInt(), 2);
+            EXPECT_EQ(mapper.getProjectedExtent(axis)->evaluate(), 2);
           }
         }
       }

--- a/test/test_optimization_pass.cpp
+++ b/test/test_optimization_pass.cpp
@@ -655,7 +655,8 @@ TEST_F(NVFuserTest, FusionRemoveEmptyMatmul_CUDA) {
   EXPECT_NE(preseg_fusion->outputs()[0]->definition(), nullptr);
   auto rewritten_def = preseg_fusion->outputs()[0]->definition();
   EXPECT_TRUE(rewritten_def->isA<FullOp>());
-  EXPECT_EQ(rewritten_def->as<FullOp>()->getFillValue()->evaluateDouble(), 0.0);
+  ExpressionEvaluator ee;
+  EXPECT_EQ(rewritten_def->as<FullOp>()->getFillValue()->evaluate(), 0.0);
 
   runtime.compileFusionParallel(args);
   auto outputs = runtime.runWithInputs(args);

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -2348,7 +2348,7 @@ TEST_F(ResizeTest, SliceVectorization) {
   bool found_vectorize = false;
   for (auto id : fusion.outputs().at(0)->as<TensorView>()->getLeafDomain()) {
     if (id->getParallelType() == ParallelType::Vectorize) {
-      EXPECT_EQ(id->extent()->evaluateInt(), 4);
+      EXPECT_EQ(id->extent()->evaluate(), 4);
       found_vectorize = true;
       break;
     }


### PR DESCRIPTION
This replaces uses of evaluate(Int, Bool, Double) with evaluate which returns a PolymorphicValue.

This also replaces the uses of get(Int, Bool, Double) with value().

Fixes #643 