### PR TITLE
switch to TensorDomain constructor to set allocation_domain

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1503,7 +1503,7 @@ void convertInputRfactorsToRoots(Fusion* fusion) {
         bool found_match = false;
         for (auto j : c10::irange(rank)) {
           if (alloc[i] == rfactor[j]) {
-            stride_order[j] = rank - 1 - i;
+            stride_order[j] = static_cast<int64_t>(rank - 1 - i);
             found_match = true;
             break;
           }

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1504,7 +1504,7 @@ void convertInputRfactorsToRoots(Fusion* fusion) {
         for (auto j : c10::irange(rank)) {
           if (alloc[i] == rfactor[j]) {
             // new_alloc_domain[i] = new_root_domain[j];
-	    stride_order[j] = rank - 1 - i;
+            stride_order[j] = rank - 1 - i;
             found_match = true;
             break;
           }
@@ -1515,7 +1515,6 @@ void convertInputRfactorsToRoots(Fusion* fusion) {
       }
       new_td = IrBuilder::create<TensorDomain>(
           new_root_domain, stride_order, tv->domain()->contiguity());
-      // new_td->setAllocationDomain(new_alloc_domain, new_td->contiguity());
     } else {
       new_td = IrBuilder::create<TensorDomain>(
           new_root_domain, tv->domain()->contiguity());

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1503,7 +1503,6 @@ void convertInputRfactorsToRoots(Fusion* fusion) {
         bool found_match = false;
         for (auto j : c10::irange(rank)) {
           if (alloc[i] == rfactor[j]) {
-            // new_alloc_domain[i] = new_root_domain[j];
             stride_order[j] = rank - 1 - i;
             found_match = true;
             break;

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1177,7 +1177,7 @@ TEST_F(NVFuserTest, AllocationDomainContiguityForExplicitBroadcast) {
                  .ndims(3)
                  .shape({-1, -1, -1})
                  .contiguity({true, true, std::nullopt})
-                .expanded({true, false, false})
+                 .expanded({true, false, false})
                  .strideOrder({0, 1, 2})
                  .build();
   fusion->addInput(tv0);

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1168,4 +1168,31 @@ TEST_F(NVFuserTest, AllocationDomainContiguityForBroadcast) {
   testValidate(fusion, outputs, {t0}, {t1}, __LINE__, __FILE__);
 }
 
+TEST_F(NVFuserTest, AllocationDomainContiguityForExplicitBroadcast) {
+  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+  Fusion* fusion = fusion_ptr.get();
+  FusionGuard fg(fusion);
+
+  auto tv0 = TensorViewBuilder()
+                 .ndims(3)
+                 .shape({-1, -1, -1})
+                 .contiguity({true, true, std::nullopt})
+                .expanded({true, false, false})
+                 .strideOrder({0, 1, 2})
+                 .build();
+  fusion->addInput(tv0);
+
+  auto s0 = IrBuilder::create<Val>(5, DataType::Float);
+  auto tv1 = add(tv0, s0);
+  fusion->addOutput(tv1);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({4, 8}, options).as_strided({3, 8, 4}, {0, 1, 8});
+  FusionExecutorCache fec(std::move(fusion_ptr));
+  auto outputs = fec.runFusionWithInputs({t0});
+
+  auto t1 = t0.add(5.0);
+  testValidate(fusion, outputs, {t0}, {t1}, __LINE__, __FILE__);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Existing code relies on setAllocationDomain to update the allocation domain after tensor creation in `convertInputRfactorsToRoots`. However the initial contiguity flag isn't consistent with the root domain, which triggers assert.