### PR TITLE
getFusionStateVector returns a const&.

### DIFF
--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1618,7 +1618,7 @@ Val* size(TensorView* inp, int64_t dim) {
   return iter_domains.at(idx)->getMaybeExpandedExtent();
 }
 
-Val* at(std::vector<Val*>& inp, int64_t index) {
+Val* at(const std::vector<Val*>& inp, int64_t index) {
   auto idx = index;
   if (idx < 0) {
     idx = static_cast<int64_t>(inp.size()) + idx;

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -408,7 +408,7 @@ std::vector<Val*> tensor_sizes(TensorView* inp);
 std::vector<Val*> shape(TensorView* inp);
 // Get the symbolic size of a specific dimension of a tensor
 Val* size(TensorView* inp, int64_t dim);
-Val* at(std::vector<Val*>& inp, int64_t index);
+Val* at(const std::vector<Val*>& inp, int64_t index);
 
 // BINARY OPERATIONS
 // add

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -726,7 +726,8 @@ struct BroadcastInDimOpRecord : RecordFunctor {
 
   void operator()(FusionState& fd) final {
     auto arg = fd.getFusionState(args_.at(0).index)->template as<TensorView>();
-    const auto& output_shape = fd.getFusionStateVector(args_.at(1).index);
+    const std::vector<Val*>& output_shape =
+        fd.getFusionStateVector(args_.at(1).index);
 
     const auto& arg_domains_nr = arg->domain()->noReductions();
     const auto arg_ndims = arg_domains_nr.size();
@@ -2378,7 +2379,7 @@ struct AtOpRecord : RecordFunctor {
   void operator()(FusionState& fd) final {
     NVF_CHECK(
         args_.at(0).stype == serde::StateType_Vector, "Expected Vector State!");
-    auto arg = fd.getFusionStateVector(args_.at(0).index);
+    const std::vector<Val*>& arg = fd.getFusionStateVector(args_.at(0).index);
     auto result = at(arg, index_);
     fd.setFusionState(outputs_.at(0).index, result);
   }

--- a/csrc/python_frontend/fusion_state.cpp
+++ b/csrc/python_frontend/fusion_state.cpp
@@ -119,7 +119,7 @@ Val* FusionState::getFusionState(size_t index) const {
   return ret[0];
 }
 
-std::vector<Val*> FusionState::getFusionStateVector(size_t index) const {
+const std::vector<Val*>& FusionState::getFusionStateVector(size_t index) const {
   return fusion_state_.at(index);
 }
 

--- a/csrc/python_frontend/fusion_state.h
+++ b/csrc/python_frontend/fusion_state.h
@@ -54,7 +54,7 @@ class FusionState {
   //! Gets a Fusion IR Tensor/Scalar object
   Val* getFusionState(size_t index) const;
   //! Gets a Fusion IR Vector of Scalars
-  std::vector<Val*> getFusionStateVector(size_t index) const;
+  const std::vector<Val*>& getFusionStateVector(size_t index) const;
   //! Number of fusion states
   size_t numFusionStates() const;
   //! Sets a Fusion IR Tensor/Scalar object


### PR DESCRIPTION
This fixes a bug where we said

```
const auto& output_shape = fd.getFusionStateVector(...);
```

`output_shape` became a reference to a temporary object.