### PR TITLE
fixing typo in range

### DIFF
--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -804,7 +804,7 @@ std::vector<std::pair<int, int>> Fusion::getOutputToInputAliasIndices() const {
   for (const auto input_idx : c10::irange(inputs_.size())) {
     in_val_index[inputs_[input_idx]] = input_idx;
   }
-  for (const auto output_idx : c10::irange(inputs_.size())) {
+  for (const auto output_idx : c10::irange(outputs_.size())) {
     out_val_index[outputs_[output_idx]] = output_idx;
   }
 

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -116,7 +116,7 @@ TEST_F(NVFuserTest, DynamicTransform1_CUDA) {
               DynamicTransformConcretizationInfo(&initial_info, &expr_eval);
         },
         ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
-            "Total element counts across view operation must match.")));
+            "Total element counts across view operation must match:")));
   }
 }
 


### PR DESCRIPTION
1. Fixing typo which causes alias error in #1109 
2. updating error message checking in test in #1114 