### PR TITLE
No alias when an expanded broadcast IterDomain is transformed. 

### DIFF
--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -881,6 +881,8 @@ FusionKernelRuntime::FusionKernelRuntime(
     std::optional<PrimDataType> forced_index_type) {
   FUSER_PERF_SCOPE("FusionKernelRuntime::FusionKernelRuntime");
 
+  fusion->print();
+
   NVF_ERROR(
       !fusion->hasDynamicTransform(),
       "Fusion must be concretized before constructing FusionKernelRuntime");

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -881,8 +881,6 @@ FusionKernelRuntime::FusionKernelRuntime(
     std::optional<PrimDataType> forced_index_type) {
   FUSER_PERF_SCOPE("FusionKernelRuntime::FusionKernelRuntime");
 
-  fusion->print();
-
   NVF_ERROR(
       !fusion->hasDynamicTransform(),
       "Fusion must be concretized before constructing FusionKernelRuntime");

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -20,6 +20,6 @@ using AliasAnalysisResult =
     std::unordered_map<const TensorView*, const TensorView*>;
 
 // Finds aliases of the fusion inputs.
-AliasAnalysisResult findAliases(const Fusion& fusion);
+AliasAnalysisResult findAliases(Fusion* fusion);
 
 } // namespace nvfuser::optimization

--- a/test/test_alias_analysis.cpp
+++ b/test/test_alias_analysis.cpp
@@ -20,6 +20,7 @@
 namespace nvfuser {
 
 using AliasAnalysisTest = NVFuserTest;
+using testing::ElementsAre;
 using testing::IsEmpty;
 using testing::Pair;
 using testing::UnorderedElementsAre;
@@ -117,7 +118,7 @@ TEST_F(AliasAnalysisTest, Permute) {
   EXPECT_THAT(alias_analysis, IsEmpty());
 }
 
-TEST_F(AliasAnalysisTest, View_ExpandedBroadcast) {
+TEST_F(AliasAnalysisTest, View_SplitExpandedBroadcast) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -129,13 +130,69 @@ TEST_F(AliasAnalysisTest, View_ExpandedBroadcast) {
       {IrBuilder::create<Val>(4),
        IrBuilder::create<Val>(5),
        IrBuilder::create<Val>(6)});
-  // tryStaticReshape failed to get the expanded extent, which is 6.
+  // tryStaticReshape used to fail to get the expanded extent, which is 6.
   out = reshape(out, {IrBuilder::create<Val>(40), IrBuilder::create<Val>(3)});
   fusion.addOutput(out);
 
   optimization::AliasAnalysisResult alias_analysis =
       optimization::findAliases(&fusion);
   EXPECT_THAT(alias_analysis, IsEmpty());
+}
+
+TEST_F(AliasAnalysisTest, View_ForwardExpandedBroadcast) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* in = makeContigConcreteTensor({4, 5});
+  fusion.addInput(in);
+  TensorView* broadcast_out = broadcast(in, {false, false, true});
+  TensorView* expand_out = expand(
+      broadcast_out,
+      {IrBuilder::create<Val>(4),
+       IrBuilder::create<Val>(5),
+       IrBuilder::create<Val>(6)});
+  TensorView* out = reshape(expand_out, {4, 5, 6}, {20, -1});
+  fusion.addOutput(out);
+
+  optimization::AliasAnalysisResult alias_analysis =
+      optimization::findAliases(&fusion);
+  EXPECT_THAT(alias_analysis, UnorderedElementsAre(Pair(out, expand_out)));
+
+  FusionExecutor fe;
+  at::Tensor in_tensor =
+      at::randn({4, 5}, at::dtype(at::kFloat).device(at::kCUDA, 0));
+  fe.compileFusion(&fusion, {in_tensor});
+  at::Tensor out_tensor = fe.runFusion({in_tensor})[0];
+
+  std::cerr << out_tensor.strides() << std::endl;
+  EXPECT_THAT(out_tensor.strides(), ElementsAre(1, 0));
+}
+
+TEST_F(AliasAnalysisTest, View_MergeExpandedBroadcast) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* in = makeContigConcreteTensor({4, 5});
+  fusion.addInput(in);
+  TensorView* out = broadcast(in, {false, false, true});
+  out = expand(
+      out,
+      {IrBuilder::create<Val>(4),
+       IrBuilder::create<Val>(5),
+       IrBuilder::create<Val>(6)});
+  out = reshape(out, {4, 5, 6}, {4, -1});
+  fusion.addOutput(out);
+
+  optimization::AliasAnalysisResult alias_analysis =
+      optimization::findAliases(&fusion);
+  EXPECT_THAT(alias_analysis, IsEmpty());
+
+  FusionExecutor fe;
+  at::Tensor in_tensor =
+      at::randn({4, 5}, at::dtype(at::kFloat).device(at::kCUDA, 0));
+  fe.compileFusion(&fusion, {in_tensor});
+  at::Tensor out_tensor = fe.runFusion({in_tensor})[0];
+  EXPECT_THAT(out_tensor.strides(), ElementsAre(30, 1));
 }
 
 } // namespace nvfuser

--- a/test/test_alias_analysis.cpp
+++ b/test/test_alias_analysis.cpp
@@ -165,7 +165,6 @@ TEST_F(AliasAnalysisTest, View_ForwardExpandedBroadcast) {
   fe.compileFusion(&fusion, {in_tensor});
   at::Tensor out_tensor = fe.runFusion({in_tensor})[0];
 
-  std::cerr << out_tensor.strides() << std::endl;
   EXPECT_THAT(out_tensor.strides(), ElementsAre(1, 0));
 }
 

--- a/test/test_alias_analysis.cpp
+++ b/test/test_alias_analysis.cpp
@@ -159,6 +159,7 @@ TEST_F(AliasAnalysisTest, View_ForwardExpandedBroadcast) {
       optimization::findAliases(&fusion);
   EXPECT_THAT(alias_analysis, UnorderedElementsAre(Pair(out, expand_out)));
 
+  // Verify the last dimension isn't expanded physically.
   FusionExecutor fe;
   at::Tensor in_tensor =
       at::randn({4, 5}, at::dtype(at::kFloat).device(at::kCUDA, 0));
@@ -186,13 +187,6 @@ TEST_F(AliasAnalysisTest, View_MergeExpandedBroadcast) {
   optimization::AliasAnalysisResult alias_analysis =
       optimization::findAliases(&fusion);
   EXPECT_THAT(alias_analysis, IsEmpty());
-
-  FusionExecutor fe;
-  at::Tensor in_tensor =
-      at::randn({4, 5}, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  fe.compileFusion(&fusion, {in_tensor});
-  at::Tensor out_tensor = fe.runFusion({in_tensor})[0];
-  EXPECT_THAT(out_tensor.strides(), ElementsAre(30, 1));
 }
 
 } // namespace nvfuser

--- a/test/test_alias_analysis.cpp
+++ b/test/test_alias_analysis.cpp
@@ -16,6 +16,7 @@
 #include <ops/arith.h>
 #include <optimization/alias_analysis.h>
 #include <test/utils.h>
+#include <test/validator.h>
 
 namespace nvfuser {
 


### PR DESCRIPTION
This is a follow up to #1097. See code comments and unit tests for why it's needed. 

This PR also changed the way we traverse `Expr`s in a fusion. Previously, we traverse from only fusion inputs and collect only `TensorView`s that alias an input. Now, we traverse each Expr and capture all local aliases even if they are not an alias of any input. This change gives us more test coverage. 