### PR TITLE
add a static member function in each scheduler to return heuristics type

### DIFF
--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -24,7 +24,7 @@ MatmulScheduler::MatmulScheduler(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     HeuristicSummary* data_cache)
-    : SchedulerEntry(ScheduleHeuristic::Matmul) {
+    : SchedulerEntry(heuristicType()) {
   computeHeuristics(fusion, runtime_info);
 }
 
@@ -36,8 +36,7 @@ void MatmulScheduler::schedule(Fusion* fusion) {
 bool MatmulScheduler::canScheduleCompileTime(Fusion* fusion) {
   const auto msg = getMatmulCompileTimeRejectReason(fusion);
   if (!msg.empty()) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::Matmul, msg);
+    scheduler_debug_utils::canScheduleRejectReason(heuristicType(), msg);
     return false;
   }
 
@@ -51,8 +50,7 @@ bool MatmulScheduler::canScheduleRunTime(
   FUSER_PERF_SCOPE("MatmulScheduler::canSchedule");
   auto reason = getMatmulRunTimeRejectReason(fusion, data_cache, runtime_info);
   if (!reason.empty()) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::Matmul, reason);
+    scheduler_debug_utils::canScheduleRejectReason(heuristicType(), reason);
     return false;
   }
   return true;

--- a/csrc/scheduler/matmul.h
+++ b/csrc/scheduler/matmul.h
@@ -33,6 +33,9 @@ class MatmulScheduler : public SchedulerEntry {
       Fusion* fusion,
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr);
+  constexpr static ScheduleHeuristic heuristicType() {
+    return ScheduleHeuristic::Matmul;
+  }
 
  private:
   void computeHeuristics(

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -16,7 +16,7 @@ NoOpScheduler::NoOpScheduler(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     HeuristicSummary* data_cache)
-    : SchedulerEntry(ScheduleHeuristic::NoOp) {
+    : SchedulerEntry(heuristicType()) {
   params_ = std::make_shared<NoOpHeuristic>("", runtime_info.getIndexType());
 }
 
@@ -37,8 +37,7 @@ bool NoOpScheduler::canScheduleCompileTime(Fusion* fusion) {
           [](IterDomain* id) { return id->extent()->isZeroInt(); });
       if (all_nonzero) {
         scheduler_debug_utils::canScheduleRejectReason(
-            ScheduleHeuristic::NoOp,
-            "reduction of non-zero elements is not supported");
+            heuristicType(), "reduction of non-zero elements is not supported");
         return false;
       }
     }
@@ -50,14 +49,14 @@ bool NoOpScheduler::canScheduleCompileTime(Fusion* fusion) {
         TensorDomain::noBroadcasts(out_tv->getLeafDomain()));
     if (!concrete_dimension.empty()) {
       scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::NoOp, "output has a concrete dimension");
+          heuristicType(), "output has a concrete dimension");
       return false;
     }
   }
 
   // Check that inputs of all select/gather-like ops are fusion inputs
   if (registry_utils::rejectScheduleForMemoryPromotion(
-          fusion, ScheduleHeuristic::NoOp)) {
+          fusion, heuristicType())) {
     return false;
   }
 

--- a/csrc/scheduler/no_op.h
+++ b/csrc/scheduler/no_op.h
@@ -38,6 +38,10 @@ class NoOpScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr);
 
+  constexpr static ScheduleHeuristic heuristicType() {
+    return ScheduleHeuristic::NoOp;
+  }
+
   void schedule(Fusion* fusion) override;
 
  private:

--- a/csrc/scheduler/normalization_inner.h
+++ b/csrc/scheduler/normalization_inner.h
@@ -40,6 +40,10 @@ class InnerPersistentKernelScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr);
 
+  constexpr static ScheduleHeuristic heuristicType() {
+    return ScheduleHeuristic::NoOp;
+  }
+
  private:
   void computeHeuristics(
       Fusion* fusion,

--- a/csrc/scheduler/normalization_inner.h
+++ b/csrc/scheduler/normalization_inner.h
@@ -41,7 +41,7 @@ class InnerPersistentKernelScheduler : public SchedulerEntry {
       HeuristicSummary* data_cache = nullptr);
 
   constexpr static ScheduleHeuristic heuristicType() {
-    return ScheduleHeuristic::NoOp;
+    return ScheduleHeuristic::InnerPersistent;
   }
 
  private:

--- a/csrc/scheduler/normalization_inner_outer.h
+++ b/csrc/scheduler/normalization_inner_outer.h
@@ -40,6 +40,10 @@ class InnerOuterPersistentKernelScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr);
 
+  constexpr static ScheduleHeuristic heuristicType() {
+    return ScheduleHeuristic::InnerOuterPersistent;
+  }
+
  private:
   void computeHeuristics(
       Fusion* fusion,

--- a/csrc/scheduler/normalization_outer.h
+++ b/csrc/scheduler/normalization_outer.h
@@ -39,6 +39,7 @@ class OuterPersistentKernelScheduler : public SchedulerEntry {
       Fusion* fusion,
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr);
+
   constexpr static ScheduleHeuristic heuristicType() {
     return ScheduleHeuristic::OuterPersistent;
   }

--- a/csrc/scheduler/normalization_outer.h
+++ b/csrc/scheduler/normalization_outer.h
@@ -39,6 +39,9 @@ class OuterPersistentKernelScheduler : public SchedulerEntry {
       Fusion* fusion,
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr);
+  constexpr static ScheduleHeuristic heuristicType() {
+    return ScheduleHeuristic::OuterPersistent;
+  }
 
  private:
   void computeHeuristics(

--- a/csrc/scheduler/pointwise.h
+++ b/csrc/scheduler/pointwise.h
@@ -190,6 +190,9 @@ class PointWiseScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr);
 
+  constexpr static ScheduleHeuristic heuristicType() {
+    return ScheduleHeuristic::PointWise;
+  }
   void schedule(Fusion* fusion) override;
 
   void computeHeuristics(

--- a/csrc/scheduler/reduction.h
+++ b/csrc/scheduler/reduction.h
@@ -46,6 +46,10 @@ class ReductionScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr);
 
+  constexpr static ScheduleHeuristic heuristicType() {
+    return ScheduleHeuristic::Reduction;
+  }
+
  private:
   void computeHeuristics(
       Fusion* fusion,

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -156,9 +156,14 @@ bool checkCanSchedule(
   //  fusion.
   if (!data_cache) {
     if (!registry_utils::isConnectedFusionGraph(fusion)) {
+      scheduler_debug_utils::canScheduleRejectReason(
+          SchedulerType::heuristicType(),
+          "Connected fusion graph check failed!");
       return false;
     }
     if (IterDomainGraph(fusion, /*allow_self_mapping=*/true).hasSelfMapping()) {
+      scheduler_debug_utils::canScheduleRejectReason(
+          SchedulerType::heuristicType(), "Iter domain graph check failed!");
       return false;
     }
     if (!SchedulerType::canScheduleCompileTime(fusion)) {

--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -23,21 +23,21 @@ TransposeScheduler::TransposeScheduler(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     HeuristicSummary* data_cache)
-    : SchedulerEntry(ScheduleHeuristic::Transpose) {
+    : SchedulerEntry(heuristicType()) {
   computeHeuristics(fusion, runtime_info, data_cache);
 }
 
 bool TransposeScheduler::canScheduleCompileTime(Fusion* fusion) {
   // Check that inputs of all select/gather-like ops are fusion inputs
   if (registry_utils::rejectScheduleForMemoryPromotion(
-          fusion, ScheduleHeuristic::Transpose)) {
+          fusion, heuristicType())) {
     return false;
   }
 
   // Fusions handled by transpose scheduler cannot have MmaOp.
   if (ir_utils::hasOpsOfType<MmaOp>(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::Transpose, "no support for mma ops.");
+        heuristicType(), "no support for mma ops.");
     return false;
   }
 
@@ -46,7 +46,7 @@ bool TransposeScheduler::canScheduleCompileTime(Fusion* fusion) {
         select->input(0)->as<TensorView>()->getMaybeAllocationDomain());
     if (select->getIndexedID() == inner[inner.size() - 1]) {
       scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::Transpose,
+          heuristicType(),
           "SelectOp on inner dim is not supported by transpose scheduler yet."
           "In transpose scheduler, we want to leave the select dim alone, instead of creating a tile for it.");
       return false;
@@ -57,7 +57,7 @@ bool TransposeScheduler::canScheduleCompileTime(Fusion* fusion) {
         idx_sel->input(0)->as<TensorView>()->getMaybeAllocationDomain());
     if (idx_sel->getIndexedID() == inner[inner.size() - 1]) {
       scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::Transpose,
+          heuristicType(),
           "IndexSelectOp on inner dim is not supported by transpose scheduler yet."
           "In transpose scheduler, we want to leave the select dim alone, instead of creating a tile for it.");
       return false;
@@ -68,7 +68,7 @@ bool TransposeScheduler::canScheduleCompileTime(Fusion* fusion) {
         torch_gather->input(0)->as<TensorView>()->getMaybeAllocationDomain());
     if (torch_gather->getIndexedID() == inner[inner.size() - 1]) {
       scheduler_debug_utils::canScheduleRejectReason(
-          ScheduleHeuristic::Transpose,
+          heuristicType(),
           "TorchGatherOp on inner dim is not supported by transpose scheduler yet."
           "In transpose scheduler, we want to leave the select dim alone, instead of creating a tile for it.");
       return false;
@@ -77,20 +77,19 @@ bool TransposeScheduler::canScheduleCompileTime(Fusion* fusion) {
 
   if (!hasAtLeastTwoValidGroups(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::Transpose,
-        "cannot find two mismatching inner most dimensions");
+        heuristicType(), "cannot find two mismatching inner most dimensions");
     return false;
   }
 
   if (ir_utils::hasAnyReductionOps(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::Transpose, "no support for reduction ops");
+        heuristicType(), "no support for reduction ops");
     return false;
   }
 
   if (registry_utils::hasNonUniqueBcast(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::Transpose,
+        heuristicType(),
         "Broadcasting dimension might be broadcasting to multiple sizes.");
     return false;
   }
@@ -107,8 +106,7 @@ bool TransposeScheduler::canScheduleRunTime(
   auto reason =
       getTransposeRuntimeRejectReason(fusion, data_cache, runtime_info);
   if (!reason.empty()) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        ScheduleHeuristic::Transpose, reason);
+    scheduler_debug_utils::canScheduleRejectReason(heuristicType(), reason);
     return false;
   }
   return true;

--- a/csrc/scheduler/transpose.h
+++ b/csrc/scheduler/transpose.h
@@ -126,6 +126,10 @@ class TransposeScheduler : public SchedulerEntry {
       SchedulerRuntimeInfo& runtime_info,
       HeuristicSummary* data_cache = nullptr);
 
+  constexpr static ScheduleHeuristic heuristicType() {
+    return ScheduleHeuristic::Transpose;
+  }
+
   void schedule(Fusion* fusion) override;
 
  private:


### PR DESCRIPTION
(1) add a static member function in each scheduler to return heuristics type avoiding the use of hard coded heuristics types.
(2) Add failed reason when scheduling non-connected graph.