### PR TITLE
Hash getEmptyExtents() in DynamicTransformConcretizationInfo

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -893,6 +893,9 @@ size_t DynamicTransformConcretizationInfo::hash() const {
   for (const auto& [tv, view_result] : getReshapeTransforms()) {
     hashCombine(hash, view_result.hash());
   }
+  for (const auto& extent_idx : getEmptyExtents()) {
+    hashCombine(hash, (size_t)extent_idx);
+  }
   for (const auto& [id, iter_type] : getResizeIterTypes()) {
     hashCombine(hash, (size_t)iter_type);
   }

--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -132,6 +132,9 @@ class DynamicTransformConcretizationInfo {
       const DynamicTransformInitialInfo* initial_info,
       ExpressionEvaluator* expr_eval);
 
+  //! Return a vector of integers each corresponding to the position in
+  //! initialInfo()->getMaybeZeroExtents() of an extent Val which is guaranteed
+  //! to be zero.
   const std::vector<size_t>& getEmptyExtents() const {
     return empty_extents_;
   }


### PR DESCRIPTION
This would only improve latency when a Fusion has a lot of invocations with different patterns of emptiness. I would expect that to be very rare.