### PR TITLE
Switch benchmarking mode in `pytest-benchmark`

### DIFF
--- a/python_benchmarks/core.py
+++ b/python_benchmarks/core.py
@@ -193,7 +193,11 @@ class NVFBenchmark:
 
 
 def run_benchmark(
-    benchmark, benchmark_fn: Callable, inputs: Union[torch.Tensor, List], rounds:int = 10
+    benchmark,
+    benchmark_fn: Callable,
+    inputs: Union[torch.Tensor, List],
+    rounds: int = 10,
+    warmup_rounds: int = 0,
 ) -> Union[torch.Tensor, List]:
     """
     Benchmarks the target function using torchprofiler and stores metrics as extra information.
@@ -210,9 +214,11 @@ def run_benchmark(
     def setup():
         clear_l2_cache()
         return [inputs], {}
-    
+
     nvf_benchmark = NVFBenchmark(benchmark)
-    outputs = nvf_benchmark.pedantic(benchmark_fn, setup=setup, rounds=rounds)
+    outputs = nvf_benchmark.pedantic(
+        benchmark_fn, setup=setup, rounds=rounds, warmup_rounds=warmup_rounds
+    )
     nvf_benchmark.set_metrics(inputs, outputs)
     nvf_benchmark.cleanup()
     return outputs

--- a/python_benchmarks/core.py
+++ b/python_benchmarks/core.py
@@ -197,7 +197,7 @@ def run_benchmark(
     benchmark_fn: Callable,
     inputs: Union[torch.Tensor, List],
     rounds: int = 10,
-    warmup_rounds: int = 0,
+    warmup_rounds: int = 1,
 ) -> Union[torch.Tensor, List]:
     """
     Benchmarks the target function using torchprofiler and stores metrics as extra information.

--- a/python_benchmarks/core.py
+++ b/python_benchmarks/core.py
@@ -193,7 +193,7 @@ class NVFBenchmark:
 
 
 def run_benchmark(
-    benchmark, benchmark_fn: Callable, inputs: Union[torch.Tensor, List]
+    benchmark, benchmark_fn: Callable, inputs: Union[torch.Tensor, List], rounds:int = 10
 ) -> Union[torch.Tensor, List]:
     """
     Benchmarks the target function using torchprofiler and stores metrics as extra information.
@@ -206,9 +206,13 @@ def run_benchmark(
     Returns:
         outputs: Output of the target function
     """
+
+    def setup():
+        clear_l2_cache()
+        return [inputs], {}
+    
     nvf_benchmark = NVFBenchmark(benchmark)
-    clear_l2_cache()
-    outputs = nvf_benchmark(benchmark_fn, inputs)
+    outputs = nvf_benchmark.pedantic(benchmark_fn, setup=setup, rounds=rounds)
     nvf_benchmark.set_metrics(inputs, outputs)
     nvf_benchmark.cleanup()
     return outputs


### PR DESCRIPTION
The current benchmarks use the default mode in `pytest-benchmark` which determines the number of rounds and iterations the target function is run based on the minimum and maximum time allowed per benchmark. In this mode, smaller benchmarks can take a long time to run if the maximum time is not set properly.

This PR switches the benchmarks to use `benchmark.pedantic` which allows us to control the number of rounds each benchmark is run for. This change also supports running a setup function before each round that allows us to clear L2 cache everytime before the target function is executed instead of only before running the benchmark.
This is important for smaller input sizes where L2 cache impacts the measured timings.

For example: The following timings show that in the previous mode, the measured timings are shorter than the actual timings expected.

<img width="1403" alt="default_benchmark" src="https://github.com/NVIDIA/Fuser/assets/52657555/97fe4dd0-7cd5-4474-a618-b3a54841e0e3">

With the pedantic mode, we get accurate results.

<img width="1413" alt="pedantic_benchmark" src="https://github.com/NVIDIA/Fuser/assets/52657555/578b983f-2b38-40b0-8563-717f729fc7dd">

The exposed interface for running benchmarks remains same as detailed in PR #982 . The number of rounds/warmup rounds for the target function can be modified by passing the arguments `rounds`/ `warmup_rounds `to `run_benchmark`.