### PR TITLE
Record GPU properties as context in nvfuser_bench

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -29,14 +29,39 @@ std::string getHostName() {
 #endif
 }
 
-std::string getDeviceName() {
-  int dev_idx;
+void addGPUBenchmarkContext() {
+  int dev_idx = 0;
   NVFUSER_CUDA_RT_SAFE_CALL(cudaGetDevice(&dev_idx));
 
   cudaDeviceProp prop;
   NVFUSER_CUDA_RT_SAFE_CALL(cudaGetDeviceProperties(&prop, dev_idx));
 
-  return std::string(prop.name);
+  ::benchmark::AddCustomContext("gpu_name", prop.name);
+  ::benchmark::AddCustomContext(
+      "gpu_gmem_bytes", std::to_string(prop.totalGlobalMem));
+  ::benchmark::AddCustomContext(
+      "gpu_smem_bytes_per_block", std::to_string(prop.sharedMemPerBlock));
+  ::benchmark::AddCustomContext(
+      "gpu_regs_per_block", std::to_string(prop.regsPerBlock));
+  ::benchmark::AddCustomContext(
+      "gpu_clock_khz", std::to_string(prop.clockRate));
+  ::benchmark::AddCustomContext(
+      "gpu_mem_clock_khz", std::to_string(prop.memoryClockRate));
+  ::benchmark::AddCustomContext(
+      "gpu_mem_bus_width_bits", std::to_string(prop.memoryBusWidth));
+  ::benchmark::AddCustomContext(
+      "gpu_compute_capability_major", std::to_string(prop.major));
+  ::benchmark::AddCustomContext(
+      "gpu_compute_capability_minor", std::to_string(prop.minor));
+  ::benchmark::AddCustomContext(
+      "gpu_sm_count", std::to_string(prop.multiProcessorCount));
+  ::benchmark::AddCustomContext(
+      "gpu_l2_bytes", std::to_string(prop.l2CacheSize));
+  ::benchmark::AddCustomContext(
+      "gpu_max_threads_per_sm",
+      std::to_string(prop.maxThreadsPerMultiProcessor));
+  ::benchmark::AddCustomContext(
+      "gpu_max_threads_per_block", std::to_string(prop.maxThreadsPerBlock));
 }
 
 } // namespace
@@ -48,8 +73,9 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  ::benchmark::AddCustomContext("Host", getHostName());
-  ::benchmark::AddCustomContext("GPU", getDeviceName());
+  ::benchmark::AddCustomContext("host", getHostName());
+
+  addGPUBenchmarkContext();
 
   // Disable kernel reuse during all benchmarks.
   // This is important since some benchmarks use FusionExecutorCache in order to


### PR DESCRIPTION
We currently record GPU name as the "GPU" field in additional context. This means it is printed when the benchmark runs, and it appears as an item in the "context" section when using `--benchmark_out_format=json`. This change simply extracts more fields and populates the context in the same way. Example output:
```
2023-10-24T09:10:50-04:00
Running build/nvfuser_bench
Run on (64 X 3579.95 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x32)
  L1 Instruction 32 KiB (x32)
  L2 Unified 512 KiB (x32)
  L3 Unified 16384 KiB (x8)
Load Average: 2.21, 1.29, 0.77
gpu_clock_khz: 1065000
gpu_compute_capability_major: 8
gpu_compute_capability_minor: 0
gpu_gmem_bytes: 84990623744
gpu_l2_bytes: 41943040
gpu_max_threads_per_block: 1024
gpu_max_threads_per_sm: 2048
gpu_mem_bus_width_bits: 5120
gpu_mem_clock_khz: 1512000
gpu_name: NVIDIA A100 80GB PCIe
gpu_regs_per_block: 65536
gpu_sm_count: 108
gpu_smem_bytes_per_block: 49152
host: nvdl-a112-d003
```

Particularly useful fields are the SM and Memory clock rates and memory limits. You can also compute peak bandwidth for the device from the memory clock rate and bus width fields, e.g. 1935.36 GB/s in this example (from `kernel_cache.cpp`):
```
// Peak bandwidth calculation:
// Bus width is given in bits, so dividing by 8 converts to bytes.
// Clock is given in kHz. 1 GB = 1e9 bytes (don't report GiB = 1024^3 bytes)
// A factor of 2 is multiplied to account for double data rate (DDR):
// (clock in kHz * width in bits) * (1000 Hz / kHz) * (1 GB / 8e9 bits) * 2
// factor = 2.5e-7
```

The GPU name is now called "gpu_name", and other GPU properties start with "gpu_*". To keep casing consistent with the default fields, "Host" is renamed to "host". JSON output:
```
{
  "context": {
    "date": "2023-10-24T09:14:32-04:00",
    "host_name": "nvdl-a112-d003",
    "executable": "build/nvfuser_bench",
    "num_cpus": 64,
    "mhz_per_cpu": 3611,
    "cpu_scaling_enabled": false,
    "caches": [
      {
        "type": "Data",
        "level": 1,
        "size": 32768,
        "num_sharing": 2
      },
      {
        "type": "Instruction",
        "level": 1,
        "size": 32768,
        "num_sharing": 2
      },
      {
        "type": "Unified",
        "level": 2,
        "size": 524288,
        "num_sharing": 2
      },
      {
        "type": "Unified",
        "level": 3,
        "size": 16777216,
        "num_sharing": 8
      }
    ],
    "load_avg": [0.127441,0.635254,0.61377],
    "library_build_type": "release",
    "gpu_clock_khz": "1065000",
    "gpu_compute_capability_major": "8",
    "gpu_compute_capability_minor": "0",
    "gpu_gmem_bytes": "84990623744",
    "gpu_l2_bytes": "41943040",
    "gpu_max_threads_per_block": "1024",
    "gpu_max_threads_per_sm": "2048",
    "gpu_mem_bus_width_bits": "5120",
    "gpu_mem_clock_khz": "1512000",
    "gpu_name": "NVIDIA A100 80GB PCIe",
    "gpu_regs_per_block": "65536",
    "gpu_sm_count": "108",
    "gpu_smem_bytes_per_block": "49152",
    "host": "nvdl-a112-d003"
  },
  "benchmarks": [
    {
      "name": "NvFuserScheduler_BatchNorm_fp32___GRAPH/NvFuserScheduler_BatchNorm_fp32/64/32/2/manual_time",
      "family_index": 0,
      "per_family_instance_index": 0,
      "run_name": "NvFuserScheduler_BatchNorm_fp32___GRAPH/NvFuserScheduler_BatchNorm_fp32/64/32/2/manual_time",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 68158,
      "real_time": 1.0332787504144044e+01,
      "cpu_time": 9.1385149740309274e+01,
      "time_unit": "us",
      "bytes_per_second": 6.4416305835483027e+09,
      "label": "Red On Fastest Dim // Persistent Kernel // 3D Schedule // Outer Reduction: cross block / persistent batch - 1 /  // Iteration Domain:  // Inner Reduction Domain: cross block reduction / persistent batch - 1 / vectorize / factor 4/Launch_Parameters[block(16/1/1)/grid(1/1/32)/64]"
    }
...
```