### PR TITLE
Make sure stdout capture is stopped at the end of each test

### DIFF
--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -8412,7 +8412,7 @@ TEST_F(NVFuserTest, FusionTestWarnRegisterSpill_CUDA) {
         __FILE__,
         "");
   }
-  std::string output = stopCaptureStdout();
+  std::string output = getCapturedStdout();
   NVF_CHECK(
       output.find("Register spill detected") != std::string::npos,
       "Register spill is not captured!");
@@ -8808,7 +8808,7 @@ TEST_F(NVFuserTest, FusionOptionsGuard_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input}, lparams, compile_opts);
 
-  std::string output = stopCaptureStdout();
+  std::string output = getCapturedStdout();
   ASSERT_NE(output.find("Register spill detected"), std::string::npos)
       << "Register spill is not captured!";
 }
@@ -9691,19 +9691,6 @@ TEST_F(NVFuserTest, PredicateRNGOps) {
 
   at::manual_seed(0);
   auto cg_outputs = fe.runFusion({t0});
-}
-
-// Dummy tests to reproduce the issue. Will be deleted
-TEST_F(NVFuserTest, CaptureTest1) {
-  captureStdout();
-  NVF_ERROR(false);
-  stopCaptureStdout();
-}
-
-// Dummy tests to reproduce the issue. Will be deleted
-TEST_F(NVFuserTest, CaptureTest2) {
-  captureStdout();
-  stopCaptureStdout();
 }
 
 // Test file size should be up to 10K LoC. Create a new file for more tests.

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -9692,6 +9692,20 @@ TEST_F(NVFuserTest, PredicateRNGOps) {
   at::manual_seed(0);
   auto cg_outputs = fe.runFusion({t0});
 }
+
+// Dummy tests to reproduce the issue. Will be deleted
+TEST_F(NVFuserTest, CaptureTest1) {
+  captureStdout();
+  NVF_ERROR(false);
+  stopCaptureStdout();
+}
+
+// Dummy tests to reproduce the issue. Will be deleted
+TEST_F(NVFuserTest, CaptureTest2) {
+  captureStdout();
+  stopCaptureStdout();
+}
+
 // Test file size should be up to 10K LoC. Create a new file for more tests.
 
 } // namespace nvfuser

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -8383,7 +8383,7 @@ TEST_F(NVFuserTest, FusionTestWarnRegisterSpill_CUDA) {
       aten_input, norm_shape, aten_weight, aten_bias, kEps);
 
   // capture stdout and check stdout contains register spill warning
-  testing::internal::CaptureStdout();
+  captureStdout();
   {
     // generate persistent kernel
     auto persistent_params =
@@ -8412,7 +8412,7 @@ TEST_F(NVFuserTest, FusionTestWarnRegisterSpill_CUDA) {
         __FILE__,
         "");
   }
-  std::string output = testing::internal::GetCapturedStdout();
+  std::string output = stopCaptureStdout();
   NVF_CHECK(
       output.find("Register spill detected") != std::string::npos,
       "Register spill is not captured!");
@@ -8795,7 +8795,7 @@ TEST_F(NVFuserTest, FusionOptionsGuard_CUDA) {
   scheduleInnerPersistentKernel(&fusion, *persistent_params);
 
   // capture stdout and check stdout contains register spill warning
-  testing::internal::CaptureStdout();
+  captureStdout();
 
   // compile and run persistent kernel
   // intentionally set maxrregcount to 32 to trigger register spill
@@ -8808,7 +8808,7 @@ TEST_F(NVFuserTest, FusionOptionsGuard_CUDA) {
   FusionExecutor fe;
   fe.compileFusion(&fusion, {aten_input}, lparams, compile_opts);
 
-  std::string output = testing::internal::GetCapturedStdout();
+  std::string output = stopCaptureStdout();
   ASSERT_NE(output.find("Register spill detected"), std::string::npos)
       << "Register spill is not captured!";
 }

--- a/test/utils.h
+++ b/test/utils.h
@@ -450,7 +450,32 @@ class NVFuserTest : public ::testing::Test {
                 << test_info->test_suite_name() << "." << test_info->name()
                 << "'" << std::endl;
     }
+
+    // Make sure capturing of stdout is stopped
+    stopCaptureStdout();
   }
+
+  // Start capturing of stdout if not already started
+  void captureStdout() {
+    if (!capturing_) {
+      testing::internal::CaptureStdout();
+      capturing_ = true;
+    }
+  }
+
+  // Stop capturing of stdout if being captured
+  std::string stopCaptureStdout() {
+    if (capturing_) {
+      auto str = testing::internal::GetCapturedStdout();
+      capturing_ = false;
+      return str;
+    } else {
+      return "";
+    }
+  }
+
+ private:
+  bool capturing_ = false;
 };
 
 // assert that the given fusion lowers to the given CUDA kernel

--- a/test/utils.h
+++ b/test/utils.h
@@ -452,7 +452,7 @@ class NVFuserTest : public ::testing::Test {
     }
 
     // Make sure capturing of stdout is stopped
-    stopCaptureStdout();
+    ensureStopCaptureStdout();
   }
 
   // Start capturing of stdout if not already started
@@ -464,14 +464,19 @@ class NVFuserTest : public ::testing::Test {
   }
 
   // Stop capturing of stdout if being captured
-  std::string stopCaptureStdout() {
+  void ensureStopCaptureStdout() {
     if (capturing_) {
-      auto str = testing::internal::GetCapturedStdout();
+      testing::internal::GetCapturedStdout();
       capturing_ = false;
-      return str;
-    } else {
-      return "";
     }
+  }
+
+  // Get capturing stdout
+  std::string getCapturedStdout() {
+    NVF_ERROR(capturing_, "Not captured");
+    auto str = testing::internal::GetCapturedStdout();
+    capturing_ = false;
+    return str;
   }
 
  private:


### PR DESCRIPTION
Fixes #1142 

To make it easy to understand why this fix is necessary, I temporarily added two new tests just to expose the issue.

```
 ./bin/nvfuser_tests --gtest_filter="*CaptureTest*"
```

This should run `CaptureTest1` and then `CaptureTest2`. The former fails before stopping the capture, so with the current TOT, the issue of #1142 should happen. This PR makes sure the capture is stopped no matter if the test itself succeeds.