### PR TITLE
More cleanups around trivial input forwarding and aliasing.

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1251,7 +1251,6 @@ std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::
     getOutputBufferInfo(
         const KernelArgumentHolder& args,
         ExpressionEvaluator& expr_eval,
-        const std::vector<std::pair<int, int>>& output_to_input_aliases,
         DataType index_dtype) {
   FUSER_PERF_SCOPE("FusionExecutor::getOutbufferInfo");
   const auto kernel = lowered_->kernel();
@@ -1479,8 +1478,7 @@ void FusionExecutor::initializeExecutorEntry(
   std::vector<GlobalBufferInfo> output_info;
 
   if (outputs.empty()) {
-    output_info = getOutputBufferInfo(
-        args, expr_eval, output_to_input_aliases, index_type);
+    output_info = getOutputBufferInfo(args, expr_eval, index_type);
   } else {
     // Need to save the information necessary for allocations as
     // future uses of this ExecutorEntry may not be provided with

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -309,7 +309,6 @@ class FusionExecutor : public NonCopyable {
   std::vector<GlobalBufferInfo> getOutputBufferInfo(
       const KernelArgumentHolder& args,
       ExpressionEvaluator& expr_eval,
-      const std::vector<std::pair<int, int>>& input_to_output_aliases,
       DataType index_dtype);
 
   void setUsedTVs();

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -191,19 +191,23 @@ class ArgumentManager {
         group_outputs.size() == group_runtime_outputs.size(),
         "Output size does not match.");
 
-    // Trivial forwarding outputs an empty tensor to save bandwidth. We skip
-    // updating the tensor_map because we want all future use of inputs on
-    // the original tensor input. See note [Trivial Forwarding]
     for (const size_t group_out_i : c10::irange(group_outputs.size())) {
-      if (!group_outputs[group_out_i]->isFusionInput()) {
-        if constexpr (std::is_pointer_v<
-                          decltype(group_runtime_outputs[group_out_i])>) {
-          fusion_args_.push(*group_runtime_outputs[group_out_i]);
-        } else {
-          fusion_args_.push(group_runtime_outputs[group_out_i]);
-        }
-        tensor_map_.emplace(group_outputs[group_out_i], fusion_args_.back());
+      Val* output = group_outputs[group_out_i];
+      const PolymorphicValue*& runtime_output = tensor_map_[output];
+      if (runtime_output != nullptr) {
+        // A trivial forwarding output shares the same `Val*` as an input, so we
+        // simply map it to the same runtime output. See note [Trivial
+        // Forwarding].
+        continue;
       }
+
+      if constexpr (std::is_pointer_v<
+                        decltype(group_runtime_outputs[group_out_i])>) {
+        fusion_args_.push(*group_runtime_outputs[group_out_i]);
+      } else {
+        fusion_args_.push(group_runtime_outputs[group_out_i]);
+      }
+      runtime_output = fusion_args_.back();
     }
   }
 };
@@ -1216,61 +1220,10 @@ std::vector<at::Tensor> FusionKernelRuntime::runWithInputs(
 
   // Produce final global output
   std::vector<at::Tensor> fusion_outputs;
-  for (auto output : segmented_fusion_->outputs()) {
-    const auto iter = tensor_map.find(output);
-    if (iter != tensor_map.end()) {
-      // Note [ trivial forwarding ]
-      //
-      // Background:
-      // NvFuser codegen does not handle aliases. When we have a fusion that
-      // forwards an input to output without any operations on it, this is
-      // a no-op for codegen and the output tensor is never written to. However,
-      // the codegen cannot "forward" an input to output, since all outputs are
-      // allocated in integration. If we do not special case it, we'll ended up
-      // having a "fresh" tensor allocated for the forwarded-input.
-      //
-      // Approach:
-      // There are two aspects of the support:
-      // 1) Codegen handles forwarding implicitly. Forwarded inputs do not
-      // have any producer in the IR, so the output argument is not used in
-      // the code. However, it is required to be a kernel argument, which acts
-      // as a place-holder, so we can map the arguments correctly.
-      //
-      // 2) Integration handles the trivial forwarding of inputs. When we put
-      // together `fusion_outputs` for a given fusion and the outputs are
-      // fusion inputs, we directly return the input tensor.
-      NVF_ERROR(iter->second->is<at::Tensor>());
-      fusion_outputs.push_back(iter->second->as<at::Tensor>());
-    } else {
-      bool empty_type_check = output->getDataType().has_value() &&
-          output->getDataType().value() == DataType::Float;
-
-      // Only support two cases of empty tensor here, since this is hot path.
-      auto out_tv = output->as<TensorView>();
-
-      // TODO: should be only one of the two once the "empty"
-      //  definition has been unified throughout the ops.
-      bool empty_tensor_check = out_tv->isZeroDim() || out_tv->isEmptyTensor();
-
-      // This is the check for an empty tensor;
-      NVF_ERROR(
-          empty_tensor_check && empty_type_check,
-          "Is empty tensor? ",
-          !empty_tensor_check,
-          " Is empty type check? ",
-          !empty_type_check,
-          " Output empty tensor check failed for tensor: ",
-          out_tv->toString(),
-          " In function: ",
-          __FUNCTION__);
-
-      // TODO: would need to clean up this part when
-      //   we have a unified and consistent way to generate
-      //   size-0 tensors.
-      const auto tensor_options =
-          at::TensorOptions().dtype(at::kFloat).device(device);
-      fusion_outputs.emplace_back(at::empty({0}, tensor_options));
-    }
+  fusion_outputs.reserve(segmented_fusion_->outputs().size());
+  for (Val* output : segmented_fusion_->outputs()) {
+    const PolymorphicValue* runtime_output = tensor_map.at(output);
+    fusion_outputs.push_back(runtime_output->as<at::Tensor>());
   }
   return fusion_outputs;
 }

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -5235,9 +5235,6 @@ TEST_F(NVFuserTest, FusionTrivialInputForwarding_FusionExecutor) {
   TensorView* tv1 = makeConcreteTensor({-1, -1});
   fusion.addInput(tv0);
   fusion.addInput(tv1);
-  // Note: output of add is not used. Kept it here since previously there was an
-  // assertion from sorting in codegen.
-  add(tv1, IrBuilder::create<Val>(3.141));
   fusion.addOutput(tv0);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -5249,7 +5249,6 @@ TEST_F(NVFuserTest, FusionTrivialInputForwarding_FusionExecutor) {
   at::Tensor t0_forward = fe.runFusion({t0, t1})[0];
 
   EXPECT_EQ(t0_forward.data_ptr(), t0.data_ptr());
-  testValidate(&fusion, {t0_forward}, {t0, t1}, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTrivialInputForwarding_FusionExecutorCache) {

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -5227,7 +5227,32 @@ TEST_F(NVFuserTest, FusionInlineAt_CUDA) {
   testValidate(fusion, {out}, {t0}, {t0.sin().cos()}, __LINE__, __FILE__);
 }
 
-TEST_F(NVFuserTest, FusionTrivialInputForwarding_CUDA) {
+TEST_F(NVFuserTest, FusionTrivialInputForwarding_FusionExecutor) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeConcreteTensor({-1, -1});
+  TensorView* tv1 = makeConcreteTensor({-1, -1});
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+  // Note: output of add is not used. Kept it here since previously there was an
+  // assertion from sorting in codegen.
+  add(tv1, IrBuilder::create<Val>(3.141));
+  fusion.addOutput(tv0);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({10, 4}, options);
+  at::Tensor t1 = at::randn({10, 4}, options);
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion, {t0, t1});
+  at::Tensor t0_forward = fe.runFusion({t0, t1})[0];
+
+  EXPECT_EQ(t0_forward.data_ptr(), t0.data_ptr());
+  testValidate(&fusion, {t0_forward}, {t0, t1}, {t0}, __LINE__, __FILE__);
+}
+
+TEST_F(NVFuserTest, FusionTrivialInputForwarding_FusionExecutorCache) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   auto fusion = fusion_ptr.get();
   FusionGuard fg(fusion);
@@ -5258,7 +5283,7 @@ TEST_F(NVFuserTest, FusionTrivialInputForwarding_CUDA) {
   testValidate(fusion, cg_outputs2, {t0, t1}, {t0}, __LINE__, __FILE__);
 }
 
-TEST_F(NVFuserTest, FusionTrivialInputForwarding2_CUDA) {
+TEST_F(NVFuserTest, FusionTrivialInputForwarding2_FusionExecutorCache) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   auto fusion = fusion_ptr.get();
   FusionGuard fg(fusion);


### PR DESCRIPTION
This PR removed several unnecessary special cases for trivial input forwarding and aliasing. In most cases, e.g. when computing tensor proxies, forwarded outputs and aliased outputs can simply be treated as regular outputs. 

Similar to #1141 , I verified the number of memory allocation requests for trivial input forwarding. 

```
$ PYTORCH_NO_CUDA_MEMORY_CACHING=1 nsys nvprof bin/nvfuser_tests --gtest_filter=*TrivialInputForwarding_FusionExecutor 2> /dev/null | grep cudaMalloc
      1.1            89400          2    44700.0    44700.0      3607     85793      58114.3  cudaMalloc
```