### PR TITLE
Fix OOM errors in `batchnorm` and `instancenorm`

### DIFF
--- a/python_benchmarks/global_params.py
+++ b/python_benchmarks/global_params.py
@@ -23,14 +23,15 @@ def generate_input_sizes(dims: Union[int, List] = 2) -> List[Tuple]:
                 [(i, j, k) for i in dim_range for j in dim_range for k in dim_range]
             )
         elif dim == 4:
-            dim_range = [2**i for i in range(1, 10)]
+            batch_range = [2**i for i in range(1, 5)]
+            feature_range = [2**i for i in range(1, 10)]
             inputs.extend(
                 [
                     (i, j, k, l)
-                    for i in dim_range
-                    for j in dim_range
-                    for k in dim_range
-                    for l in dim_range
+                    for i in batch_range
+                    for j in feature_range
+                    for k in feature_range
+                    for l in feature_range
                 ]
             )
         else:

--- a/python_benchmarks/global_params.py
+++ b/python_benchmarks/global_params.py
@@ -9,7 +9,6 @@ def generate_input_sizes(dims: Union[int, List] = 2) -> List[Tuple]:
     if isinstance(dims, int):
         dims = [dims]
 
-    # TODO: Generate 3D input sizes.
     # TODO: Add more input sizes.
     for dim in dims:
         if dim == 2:
@@ -23,17 +22,36 @@ def generate_input_sizes(dims: Union[int, List] = 2) -> List[Tuple]:
                 [(i, j, k) for i in dim_range for j in dim_range for k in dim_range]
             )
         elif dim == 4:
-            batch_range = [2**i for i in range(1, 5)]
-            feature_range = [2**i for i in range(1, 10)]
+            batch_range = [2**i for i in range(6, 10)]  # {64, 512}
+            channel_range = [2**i for i in range(5, 8)]  # {32, 128}
+            spatial_range = [2**i for i in range(1, 7)]  # {2, 64}
+
             inputs.extend(
                 [
                     (i, j, k, l)
                     for i in batch_range
-                    for j in feature_range
-                    for k in feature_range
-                    for l in feature_range
+                    for j in channel_range
+                    for k in spatial_range
+                    for l in spatial_range
                 ]
             )
+
+            batch_range = [2**i for i in range(1, 7)]  # {2, 64}
+            channel_range = [2**i for i in range(1, 6)]  # {2, 32}
+            spatial_range = [2**i for i in range(1, 9)]  # {2, 256}
+
+            inputs.extend(
+                [
+                    (i, j, k, l)
+                    for i in batch_range
+                    for j in channel_range
+                    for k in spatial_range
+                    for l in spatial_range
+                ]
+            )
+
+        # TODO: Add ResNet/ResNext sizes.
+
         else:
             raise NotImplementedError(
                 f"Generating input sizes of dimension {dim} is not implemented"

--- a/python_benchmarks/normalization.py
+++ b/python_benchmarks/normalization.py
@@ -3,7 +3,7 @@ from .global_params import PROMOTE_DTYPES
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 import torch
 from .core import run_benchmark
-import gc
+
 
 def norm_fwd_fusion(
     fd: FusionDefinition,
@@ -257,14 +257,14 @@ def norm_fwd_benchmark(
         assert torch.allclose(
             nvf_output[0], eager_output, rtol=1e-3, atol=1e-3
         ), f"{torch.max(nvf_output[0] - eager_output)}"
-    
+
     if not disable_benchmarking:
         run_benchmark(
             benchmark, fd.execute, [inputs, weight, bias, running_mean, running_var]
         )
-    
+
     torch.cuda.empty_cache()
-    
+
 
 def norm_bwd_benchmark(
     benchmark,

--- a/python_benchmarks/normalization.py
+++ b/python_benchmarks/normalization.py
@@ -3,7 +3,7 @@ from .global_params import PROMOTE_DTYPES
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 import torch
 from .core import run_benchmark
-
+import gc
 
 def norm_fwd_fusion(
     fd: FusionDefinition,
@@ -257,12 +257,14 @@ def norm_fwd_benchmark(
         assert torch.allclose(
             nvf_output[0], eager_output, rtol=1e-3, atol=1e-3
         ), f"{torch.max(nvf_output[0] - eager_output)}"
-
+    
     if not disable_benchmarking:
         run_benchmark(
             benchmark, fd.execute, [inputs, weight, bias, running_mean, running_var]
         )
-
+    
+    torch.cuda.empty_cache()
+    
 
 def norm_bwd_benchmark(
     benchmark,
@@ -363,3 +365,5 @@ def norm_bwd_benchmark(
             fd.execute,
             [inputs, grads, weight, running_mean, running_var, mean, invstd],
         )
+
+    torch.cuda.empty_cache()

--- a/python_benchmarks/test_layernorm.py
+++ b/python_benchmarks/test_layernorm.py
@@ -164,6 +164,8 @@ def test_layernorm_fwd_benchmark(
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, inputs)
 
+    torch.cuda.empty_cache()
+
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
@@ -199,3 +201,5 @@ def test_layernorm_bwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [inputs, grads, mean, invstd, weights])
+
+    torch.cuda.empty_cache()

--- a/python_benchmarks/test_softmax.py
+++ b/python_benchmarks/test_softmax.py
@@ -118,6 +118,8 @@ def test_softmax_fwd_benchmark(
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, inputs)
 
+    torch.cuda.empty_cache()
+
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
@@ -149,3 +151,5 @@ def test_softmax_bwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, inputs)
+
+    torch.cuda.empty_cache()


### PR DESCRIPTION
- Uses `torch.cuda.empty_cache()` to avoid OOM errors when running a large number of benchmarks.
- Reduce maximum size of 4D tensor to run on A100 80GB.