### PR TITLE
Cleanup sync_information.cpp

### DIFF
--- a/csrc/device_lower/analysis/sync_information.cpp
+++ b/csrc/device_lower/analysis/sync_information.cpp
@@ -27,14 +27,6 @@ void validateParallelizationOfTensor(TensorView* tv) {
       continue;
     }
 
-    // It doesn't matter if this axis is a non-concretized broadcast
-    // TODO: merging broadcast and non-broadcast
-    if (axis->isBroadcast() &&
-        !GpuLower::current()->concretizedBroadcastDomains()->isConcretized(
-            axis)) {
-      continue;
-    }
-
     NVF_ERROR(
         !pt_map.get(ptype),
         "Multiple use of ",


### PR DESCRIPTION
I understand that if it is a broadcast, it does not matter, but why are we interested in duplicate parallelizing it?