### PR TITLE
Staged replacement of the use of evaluate* and get* with evaluate() and value() [1/N] 

### DIFF
--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -291,30 +291,42 @@ std::optional<bool> Val::getBool() const {
   return std::nullopt;
 }
 
+PolymorphicValue Val::evaluate() {
+  if (this->value().hasValue()) {
+    return this->value();
+  }
+
+  ExpressionEvaluator ee;
+  auto evaluated_val = ee.evaluate(this);
+  NVF_ERROR(
+      evaluated_val.hasValue(),
+      "Detected a const value but failed to infer its value: ",
+      toInlineString());
+  return evaluated_val;
+}
+
 bool Val::isZero() const {
-  return getInt() == 0 || getDouble() == 0.0;
+  return value().hasValue() && value() == 0;
 }
 
 bool Val::isZeroInt() const {
-  auto int_val = getInt();
-  return int_val.has_value() && int_val.value() == 0;
+  return value().hasValue() && value().is<int64_t>() && value() == 0;
 }
 
 bool Val::isOne() const {
-  return getInt() == 1 || getDouble() == 1.0;
+  return value().hasValue() && value() == 1;
 }
 
 bool Val::isOneInt() const {
-  auto int_val = getInt();
-  return int_val.has_value() && int_val.value() == 1;
+  return value().hasValue() && value().is<int64_t>() && value() == 1;
 }
 
 bool Val::isTrue() const {
-  return getBool() == true;
+  return value().hasValue() && value().is<bool>() && value().as<bool>();
 }
 
 bool Val::isFalse() const {
-  return getBool() == false;
+  return value().hasValue() && value().is<bool>() && !value().as<bool>();
 }
 
 std::optional<DataType> Val::getDataType() const {

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -359,6 +359,11 @@ class Val : public Statement {
   // make constant as expression evaluator takes non-constant Vals.
   bool evaluateBool();
 
+  // If this Val's history is comprised only of constant values, will return a
+  // PolymorphicValue. Cannot make constant as expression evaluator takes
+  // non-constant Vals.
+  PolymorphicValue evaluate();
+
   // Returns if no dependencies and is a constant scalar.
   virtual bool isConst() const {
     return value_.hasValue() && definition() == nullptr;

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -711,7 +711,7 @@ Val* SimplifyingIrBuilder::whereExpr(Val* pred, Val* lhs, Val* rhs) {
     return lhs; // return value is independent of predicate
   }
   if (pred->isConstScalar() && pred->isABool()) {
-    if (pred->evaluateBool()) {
+    if (pred->evaluate()) {
       return lhs;
     } else {
       return rhs;

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -1189,7 +1189,7 @@ SqueezeOp::SqueezeOp(
         // Check concrete broadcast extent here. For Symbolic inputs, this check
         // will be deferred to concretization. See dynamic_transform.cpp
         NVF_ERROR(
-            id->extent()->isConstScalar() && id->extent()->evaluateInt() == 1,
+            id->extent()->isConstScalar() && id->extent()->evaluate() == 1,
             "Can not squeeze dimension(s) with size != 1.");
       }
     } else {
@@ -2930,8 +2930,8 @@ IterDomain* IterDomain::resize(
       right_expansion->toString());
 
   if (left_expansion->isConstInt() && right_expansion->isConstInt()) {
-    auto left = left_expansion->evaluateInt();
-    auto right = right_expansion->evaluateInt();
+    auto left = left_expansion->evaluate();
+    auto right = right_expansion->evaluate();
     if (left == 0 && right == 0) {
       // This is a trivial resize. Check that we are not changing the IterType,
       // then return the input.
@@ -2983,11 +2983,11 @@ IterDomain* IterDomain::resize(
   if (iter_type_opt.has_value()) {
     iter_type = iter_type_opt.value();
   } else if (left_expansion->isConstInt() && right_expansion->isConstInt()) {
-    auto left = left_expansion->evaluateInt();
-    auto right = right_expansion->evaluateInt();
+    auto left = left_expansion->evaluate();
+    auto right = right_expansion->evaluate();
     if (resized_id_size->isConstInt()) {
       // Means input extent is also known
-      auto out_extent = resized_id_size->evaluateInt();
+      auto out_extent = resized_id_size->evaluate();
       iter_type = out_extent == 1 ? IterType::Broadcast : IterType::Iteration;
     } else if (left + right > 1) {
       // Input extent is non-negative, so we know out_extent > 1

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -72,7 +72,7 @@ TEST_F(ExprEvalTest, Double) {
   auto three = IrBuilder::create<Val>(3.0);
   auto val = castOp(DataType::Int, ceilDiv(sub(ten, two), three));
   auto reference = static_cast<int64_t>(std::ceil((10.0 - 2.0) / 3.0));
-  EXPECT_EQ(reference, val->evaluateInt());
+  EXPECT_EQ(reference, val->evaluate());
 }
 
 // Evaluate basic scalar operations with bound values

--- a/test/test_gpu2.cpp
+++ b/test/test_gpu2.cpp
@@ -7745,9 +7745,9 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap3_CUDA) {
   GpuLower gpulw(fusion.get());
   const auto& pdmap = gpulw.parallelDimensionMap();
   ASSERT_FALSE(pdmap.isExact(ParallelType::TIDx));
-  ASSERT_EQ(pdmap.get(ParallelType::TIDx)->getInt(), 20);
+  ASSERT_EQ(pdmap.get(ParallelType::TIDx)->value(), 20);
   ASSERT_TRUE(pdmap.isExact(ParallelType::TIDy));
-  ASSERT_EQ(pdmap.get(ParallelType::TIDy)->getInt(), 10);
+  ASSERT_EQ(pdmap.get(ParallelType::TIDy)->value(), 10);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor input1 = at::randn({13}, options);

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -6342,10 +6342,9 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
             std::find(cond_inputs.begin(), cond_inputs.end(), loop_index);
         auto vec_factor_it =
             std::find_if(cond_inputs.begin(), cond_inputs.end(), [](Val* inp) {
-              auto int_val = inp->getInt();
-              return int_val.has_value() &&
-                  (int_val.value() == vec_factor - 1 ||
-                   int_val.value() == -(vec_factor - 1));
+              auto int_val = inp->value();
+              return int_val.hasValue() &&
+                  (int_val == vec_factor - 1 || int_val == -(vec_factor - 1));
             });
         // If vectorized, the predicate should use (vec_factor - 1) or
         // -(vec_factor - 1) rather than the loop index.
@@ -8667,7 +8666,7 @@ TEST_F(NVFuserTest, Repro413_CUDA) {
       auto getVectorizationFactor = [](TensorView* tv) -> int64_t {
         for (auto i : tv->getLeafDomain()) {
           if (i->getParallelType() == ParallelType::Vectorize) {
-            return i->extent()->evaluateInt();
+            return i->extent()->evaluate().as<int64_t>();
           }
         }
         return 1;

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -4010,29 +4010,29 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogue_CUDA) {
       // also be allocated at address 0 with A stacked above it at position
       // 8192.
       EXPECT_EQ(
-          smem_allocs.at(0)->address()->evaluateInt(),
+          smem_allocs.at(0)->address()->evaluate(),
           // Assuming B numel times size(dtype) is a multiple of 16 so that
           // this address is aligned
-          smem_allocs.at(1)->size()->evaluateInt() *
+          smem_allocs.at(1)->size()->evaluate() *
               dataTypeSize(smem_allocs.at(1)->buffer()->dtype()));
-      EXPECT_EQ(smem_allocs.at(1)->address()->evaluateInt(), 0L);
-      EXPECT_EQ(smem_allocs.at(2)->address()->evaluateInt(), 0L);
+      EXPECT_EQ(smem_allocs.at(1)->address()->evaluate(), 0L);
+      EXPECT_EQ(smem_allocs.at(2)->address()->evaluate(), 0L);
     } else {
       // Prologue shared memory is not re-used. In this case, memory should
       // stack in C, B, A order.
       EXPECT_EQ(
-          smem_allocs.at(0)->address()->evaluateInt(),
+          smem_allocs.at(0)->address()->evaluate(),
           // Assuming for B and C that numel times size(dtype) is a multiple
           // of 16 so that this address is aligned
-          smem_allocs.at(1)->size()->evaluateInt() *
+          smem_allocs.at(1)->size()->evaluate() *
                   dataTypeSize(smem_allocs.at(1)->buffer()->dtype()) +
-              smem_allocs.at(2)->size()->evaluateInt() *
+              smem_allocs.at(2)->size()->evaluate() *
                   dataTypeSize(smem_allocs.at(2)->buffer()->dtype()));
       EXPECT_EQ(
-          smem_allocs.at(1)->address()->evaluateInt(),
-          smem_allocs.at(2)->size()->evaluateInt() *
+          smem_allocs.at(1)->address()->evaluate(),
+          smem_allocs.at(2)->size()->evaluate() *
               dataTypeSize(smem_allocs.at(2)->buffer()->dtype()));
-      EXPECT_EQ(smem_allocs.at(2)->address()->evaluateInt(), 0L);
+      EXPECT_EQ(smem_allocs.at(2)->address()->evaluate(), 0L);
     }
   }
 }

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -36,7 +36,7 @@ TEST_F(NVFuserTest, FusionSplitDims_CUDA) {
       tv, {{0, p(2)}, {0, p(1)}, {3, p(6)}, {6, p(10)}}, dims);
   EXPECT_EQ(tv->nDims(), 11);
   for (auto i : c10::irange(11)) {
-    EXPECT_EQ(tv->axis(i)->extent()->evaluateInt(), p(i));
+    EXPECT_EQ(tv->axis(i)->extent()->evaluate(), p(i));
   }
   std::vector<size_t> expect{0, 3, 4, 5, 7, 8, 9};
   EXPECT_EQ(dims, expect);
@@ -57,7 +57,7 @@ TEST_F(NVFuserTest, FusionMergeDims_CUDA) {
       p(0), p(1), p(2) * p(3) * p(7) * p(8) * p(9), p(4), p(5), p(6), p(10)};
   EXPECT_EQ(tv->nDims(), expect_shape.size());
   for (auto i : c10::irange(expect_shape.size())) {
-    EXPECT_EQ(tv->axis(i)->extent()->evaluateInt(), expect_shape[i]);
+    EXPECT_EQ(tv->axis(i)->extent()->evaluate(), expect_shape[i]);
   }
   std::vector<size_t> expect_dims{0, 1, 2, 2, 3, 4, 5, 2, 2, 2, 6};
   EXPECT_EQ(dims, expect_dims);
@@ -281,7 +281,7 @@ TEST_F(VectorizeHelperTest, BackwardMapper1_CUDA) {
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(1)));
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 3);
   }
 
   {
@@ -293,10 +293,10 @@ TEST_F(VectorizeHelperTest, BackwardMapper1_CUDA) {
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 2);
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 2);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 3);
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 2 * 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 2 * 3);
   }
 }
 
@@ -319,21 +319,21 @@ TEST_F(VectorizeHelperTest, BackwardMapper2_CUDA) {
       [&]() { mapper.getProjectedExtent(tv2->axis(0)); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Not projected")));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluate(), 4);
   // Inner dim fully maps, outer dim of split partially maps
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(2)));
 
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 4);
   // Inner dim fully maps, outer dim of split partially maps
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
 
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 4 * 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 4 * 3);
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
 }
@@ -356,15 +356,15 @@ TEST_F(VectorizeHelperTest, BackwardMapper3_CUDA) {
   // Partial map forwarding
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluate(), 4);
 }
 
 // Test simple backward mapping through merge
@@ -397,10 +397,10 @@ TEST_F(VectorizeHelperTest, BackwardMapper4_CUDA) {
     EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 2);
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 2);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3);
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 2 * 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 2 * 3);
   }
 }
 
@@ -467,16 +467,16 @@ TEST_F(VectorizeHelperTest, BackwardMapper6_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 3 * 4);
 }
 
 // Test concrete exact inner dim mapping through merge
@@ -497,16 +497,16 @@ TEST_F(VectorizeHelperTest, BackwardMapper7_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 3 * 4);
 }
 
 // Test concrete partial inner dim mapping through merge
@@ -527,16 +527,16 @@ TEST_F(VectorizeHelperTest, BackwardMapper8_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 4);
 }
 
 // Test concrete partial inner dim mapping through merge
@@ -558,21 +558,21 @@ TEST_F(VectorizeHelperTest, BackwardMapper9_CUDA) {
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[2]->sameAs(tv0->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluate(), 1);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 5);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 5);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 5);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 7);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 5);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluate(), 7);
 }
 
 // Similar to BackwardMapper1_CUDA but in the reverse direction
@@ -604,7 +604,7 @@ TEST_F(VectorizeHelperTest, ForwardMapper1_CUDA) {
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3);
   }
 
   {
@@ -616,10 +616,10 @@ TEST_F(VectorizeHelperTest, ForwardMapper1_CUDA) {
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(1)));
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 2);
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 2);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3);
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 2 * 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 2 * 3);
   }
 }
 
@@ -642,21 +642,21 @@ TEST_F(VectorizeHelperTest, ForwardMapper2_CUDA) {
       [&]() { mapper.getProjectedExtent(tv0->axis(0)); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Not projected")));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluate(), 4);
   // Inner dim fully maps, outer dim of split partially maps
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(2)));
 
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 4);
   // Inner dim fully maps, outer dim of split partially maps
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
 
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 4 * 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 4 * 3);
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
 }
@@ -679,15 +679,15 @@ TEST_F(VectorizeHelperTest, ForwardMapper3_CUDA) {
   // Partial map forwarding
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluate(), 4);
 }
 
 // Similar to BackwardMapper4_CUDA but in the reverse direction
@@ -720,10 +720,10 @@ TEST_F(VectorizeHelperTest, ForwardMapper4_CUDA) {
     EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 2);
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
     EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 2);
-    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 2);
+    EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 3);
 
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluateInt(), 2 * 3);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(0))->evaluate(), 2 * 3);
   }
 }
 
@@ -790,16 +790,16 @@ TEST_F(VectorizeHelperTest, ForwardMapper6_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 3);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 3);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3 * 4);
 }
 
 // Similar to BackwardMapper7_CUDA but in the reverse direction
@@ -820,16 +820,16 @@ TEST_F(VectorizeHelperTest, ForwardMapper7_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 3 * 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 3 * 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 3 * 4);
 }
 
 // Similar to BackwardMapper8_CUDA but in the reverse direction
@@ -850,16 +850,16 @@ TEST_F(VectorizeHelperTest, ForwardMapper8_CUDA) {
   EXPECT_EQ(mapper.mappedRFactorIds(tv2).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 4);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 4);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 4);
 }
 
 // Make sure partial mappings are mapped to gcd(combined, inner) for inner
@@ -882,21 +882,21 @@ TEST_F(VectorizeHelperTest, ForwardMapper9_CUDA) {
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[0]->sameAs(tv2->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[1]->sameAs(tv2->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv2)[2]->sameAs(tv2->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluateInt(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(1))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv2->axis(2))->evaluate(), 1);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv1).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[0]->sameAs(tv1->axis(0)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv1)[1]->sameAs(tv1->axis(1)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluateInt(), 1);
-  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluateInt(), 5);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(0))->evaluate(), 1);
+  EXPECT_EQ(mapper.getProjectedExtent(tv1->axis(1))->evaluate(), 5);
 
   EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 2);
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
   EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[1]->sameAs(tv0->axis(2)));
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 5);
-  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluateInt(), 7);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 5);
+  EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(2))->evaluate(), 7);
 }
 
 // Test propogation doesn't proceed across missing dimensions
@@ -936,7 +936,7 @@ TEST_F(VectorizeHelperTest, MapperAdvanced_CUDA) {
         tv5, {tv5->axis(0), tv5->axis(1)});
     EXPECT_EQ(mapper.mappedRFactorIds(tv0).size(), 1);
     EXPECT_TRUE(mapper.mappedRFactorIds(tv0)[0]->sameAs(tv0->axis(1)));
-    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluateInt(), 6);
+    EXPECT_EQ(mapper.getProjectedExtent(tv0->axis(1))->evaluate(), 6);
   }
 
   {
@@ -946,7 +946,7 @@ TEST_F(VectorizeHelperTest, MapperAdvanced_CUDA) {
         tv3, {tv3->axis(0), tv3->axis(1), tv3->axis(2), tv3->axis(3)});
     EXPECT_EQ(mapper.mappedRFactorIds(tv7).size(), 1);
     EXPECT_TRUE(mapper.mappedRFactorIds(tv7)[0]->sameAs(tv7->axis(1)));
-    EXPECT_EQ(mapper.getProjectedExtent(tv7->axis(1))->evaluateInt(), 6);
+    EXPECT_EQ(mapper.getProjectedExtent(tv7->axis(1))->evaluate(), 6);
   }
 }
 
@@ -1017,7 +1017,7 @@ TEST_F(VectorizeHelperTest, SpanningTree_CUDA) {
             continue;
           }
           for (auto axis : tv->getRootDomain()) {
-            EXPECT_EQ(mapper.getProjectedExtent(axis)->evaluateInt(), 2);
+            EXPECT_EQ(mapper.getProjectedExtent(axis)->evaluate(), 2);
           }
         }
       }

--- a/test/test_optimization_pass.cpp
+++ b/test/test_optimization_pass.cpp
@@ -655,7 +655,7 @@ TEST_F(NVFuserTest, FusionRemoveEmptyMatmul_CUDA) {
   EXPECT_NE(preseg_fusion->outputs()[0]->definition(), nullptr);
   auto rewritten_def = preseg_fusion->outputs()[0]->definition();
   EXPECT_TRUE(rewritten_def->isA<FullOp>());
-  EXPECT_EQ(rewritten_def->as<FullOp>()->getFillValue()->evaluateDouble(), 0.0);
+  EXPECT_EQ(rewritten_def->as<FullOp>()->getFillValue()->evaluate(), 0.0);
 
   runtime.compileFusionParallel(args);
   auto outputs = runtime.runWithInputs(args);

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -2348,7 +2348,7 @@ TEST_F(ResizeTest, SliceVectorization) {
   bool found_vectorize = false;
   for (auto id : fusion.outputs().at(0)->as<TensorView>()->getLeafDomain()) {
     if (id->getParallelType() == ParallelType::Vectorize) {
-      EXPECT_EQ(id->extent()->evaluateInt(), 4);
+      EXPECT_EQ(id->extent()->evaluate(), 4);
       found_vectorize = true;
       break;
     }


### PR DESCRIPTION
This replaces uses of evaluate(Int, Bool, Double) with evaluate which returns a PolymorphicValue.

This also replaces the uses of get(Int, Bool, Double) with value().

This PR is the first of a number of them to fix the issue. In the final PR, the older get* and evaluate* methods will be removed.

Fixes https://github.com/NVIDIA/Fuser/issues/643