### PR TITLE
Staged replacement of the use of evaluate* and get* with evaluate() and value() [2/N]

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1310,7 +1310,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
               id->extent()->isConstInt(),
               "Could not evaluate constant value bound to vectorized dim.");
 
-          vector_word_size = id->extent()->evaluateInt();
+          vector_word_size = id->extent()->evaluate().as<int64_t>();
 
           is_vector_op = true;
           break;
@@ -1587,8 +1587,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
               MemoryType::Global;
         });
 
-    auto pred_bool = wop->hoistedPredicate()->getBool();
-    bool is_predicated = !(pred_bool.has_value() && pred_bool.value());
+    auto pred_bool = wop->hoistedPredicate()->value();
+    bool is_predicated = !(pred_bool.hasValue() && pred_bool.as<bool>());
 
     ArgumentBuilder func_args;
     func_args.arg(gen(out_avg));
@@ -1918,7 +1918,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
     // Incrementally build a combinatorial set
     for (const auto loop : grouped_loops_) {
-      const auto iter_count = loop->stop()->evaluateInt();
+      const auto iter_count = loop->stop()->evaluate();
       std::vector<std::vector<int64_t>> new_combinations;
       // Append integers from 0 to iter_count to all the vectors built
       // so far

--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -154,11 +154,11 @@ bool IterDomainGraph::exprsMap(
 
     auto extent_0_match = extent_0o->sameAs(extent_1o) ||
         (extent_0o->isConstInt() && extent_1o->isConstInt() &&
-         extent_0o->evaluateInt() == extent_1o->evaluateInt());
+         extent_0o->evaluate() == extent_1o->evaluate());
 
     auto extent_1_match = extent_0i->sameAs(extent_1i) ||
         (extent_0i->isConstInt() && extent_1i->isConstInt() &&
-         extent_0i->evaluateInt() == extent_1i->evaluateInt());
+         extent_0i->evaluate() == extent_1i->evaluate());
 
     if (!(extent_0_match || extent_1_match)) {
       return false;

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -126,9 +126,10 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
   //! Detect possibly empty TensorViews and dynamic IterDomain transforms
   void handle(TensorView* tv) override {
     const auto& rfd = tv->getMaybeRFactorDomain();
+    ExpressionEvaluator ee;
     for (auto id : rfd) {
       if (!id->getMaybeExpandedExtent()->isConstScalar() ||
-          id->getMaybeExpandedExtent()->evaluateInt() == 0) {
+          id->getMaybeExpandedExtent()->evaluate() == 0) {
         info_.maybe_zero_extents_set_.insert(id->getMaybeExpandedExtent());
         leaf_dynamic_vals_.push_back(id->getMaybeExpandedExtent());
       }

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -190,15 +190,7 @@ void PrecomputedValues::initializeValueList(
     // Use an expression evaluator to test if value is const
     if (sorted_value_list[i]->isConstScalar()) {
       is_constant_[i] = true;
-      if (sorted_value_list[i]->isIntegralScalar()) {
-        values_[i] = PolymorphicValue(sorted_value_list[i]->evaluateInt());
-      }
-      if (sorted_value_list[i]->isFloatingPointScalar()) {
-        values_[i] = PolymorphicValue(sorted_value_list[i]->evaluateDouble());
-      }
-      if (sorted_value_list[i]->isABool()) {
-        values_[i] = PolymorphicValue(sorted_value_list[i]->evaluateBool());
-      }
+      values_[i] = sorted_value_list[i]->evaluate();
     }
     sorted_value_list[i]->setEvaluatorIndex(i);
   }

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -273,19 +273,7 @@ Val* foldConstants(Val* value) {
     return value;
   }
   if (value->isConstScalar()) {
-    if (value->isIntegralScalar()) {
-      return IrBuilder::create<Val>(
-          value->evaluateInt(), *value->getDataType());
-    }
-    if (value->isFloatingPointScalar()) {
-      return IrBuilder::create<Val>(
-          value->evaluateDouble(), *value->getDataType());
-    }
-    if (value->isABool()) {
-      return IrBuilder::create<Val>(
-          value->evaluateBool(), *value->getDataType());
-    }
-    // TODO: support complex double
+    return IrBuilder::create<Val>(value->evaluate(), *value->getDataType());
   }
   return value;
 }
@@ -488,14 +476,14 @@ inline bool isNoOpTerm(Val* v, BinaryOpType type) {
     case BinaryOpType::Mul:
       return v->isOne();
     case BinaryOpType::LogicalAnd:
-      return v->getBool() == true;
+      return v->value() == true;
     case BinaryOpType::LogicalOr:
-      return v->getBool() == false;
+      return v->value() == false;
     case BinaryOpType::BitwiseAnd:
-      return v->getInt() == -1;
+      return v->value() == -1;
     case BinaryOpType::BitwiseOr:
     case BinaryOpType::BitwiseXor:
-      return v->getInt() == 0;
+      return v->value() == 0;
     case BinaryOpType::Gcd:
       return v->isZeroInt();
     default:
@@ -514,15 +502,15 @@ inline bool isBlackhole(Val* v, BinaryOpType type) {
   }
   switch (type) {
     case BinaryOpType::Mul:
-      return v->getInt() == 0;
+      return v->value() == 0;
     case BinaryOpType::LogicalAnd:
-      return v->getBool() == false;
+      return v->value() == false;
     case BinaryOpType::LogicalOr:
-      return v->getBool() == true;
+      return v->value() == true;
     case BinaryOpType::BitwiseAnd:
-      return v->getInt() == 0;
+      return v->value() == 0;
     case BinaryOpType::BitwiseOr:
-      return v->getInt() == -1;
+      return v->value() == -1;
     case BinaryOpType::Gcd:
       return v->isOneInt();
     default:
@@ -1011,9 +999,9 @@ inline DataType dataTypeOrNull(Val* x) {
   return x == nullptr ? DataType::Null : x->dtype();
 }
 
-// If x is nullptr, return 1. Otherwise, return x->getInt().
+// If x is nullptr, return 1. Otherwise, return x->value().as<int64_t>.
 inline int64_t getIntOrOne(Val* x) {
-  return x == nullptr ? 1 : *x->getInt();
+  return x == nullptr ? 1 : x->value().as<int64_t>();
 }
 
 // If the data type is unknown, return nullptr. Otherwise, return a constant
@@ -1103,9 +1091,9 @@ std::pair<Val*, std::list<Val*>> getConstAndSymbolicFactors(Val* x) {
   std::list<Val*> symbolic_factors;
   for (auto f : factors) {
     f = foldConstants(f);
-    if (f->getInt().has_value()) {
+    if (f->value().hasValue() && f->value().is<int64_t>()) {
       const_dtype = promoteTypeWithNull(const_dtype, f->dtype());
-      const_factor *= *f->getInt();
+      const_factor *= f->value().as<int64_t>();
     } else {
       symbolic_factors.emplace_back(f);
     }
@@ -1131,7 +1119,7 @@ Val* productOfFactors(
     return assoc_comm::maybeFlattenedOpOf(
         BinaryOpType::Mul, std::move(symbolic_factors));
   }
-  if (*const_factor->getInt() != 1 || symbolic_factors.empty()) {
+  if (const_factor->value() != 1 || symbolic_factors.empty()) {
     symbolic_factors.emplace_back(const_factor);
   }
   return maybeFlattenedOpOf(BinaryOpType::Mul, std::move(symbolic_factors));
@@ -1490,10 +1478,7 @@ bool isPositiveHelper(Val* value, const Context& context) {
 
 bool isNonZero(Val* value, const Context& context) {
   value = foldConstants(value);
-  if (value->getInt().has_value() && *value->getInt() != 0) {
-    return true;
-  }
-  if (value->getDouble().has_value() && *value->getDouble() != 0.0) {
+  if (value->value().hasValue() && value->value() != 0) {
     return true;
   }
   if (isPositive(value, context)) {
@@ -1525,11 +1510,8 @@ bool hasCompatibleSign(Val* x, Val* y, const Context& context) {
 bool lessThan(Val* x, Val* y, const Context& context) {
   x = foldConstants(x);
   y = foldConstants(y);
-  if (x->getInt().has_value() && y->getInt().has_value()) {
-    return *x->getInt() < *y->getInt();
-  }
-  if (x->getDouble().has_value() && y->getDouble().has_value()) {
-    return *x->getDouble() < *y->getDouble();
+  if (x->value().hasValue() && y->value().hasValue()) {
+    return x->value() < y->value();
   }
   x = maybeUnwrapMagicZero(x);
   y = maybeUnwrapMagicZero(y);
@@ -1557,11 +1539,8 @@ bool lessThan(Val* x, Val* y, const Context& context) {
 bool lessEqual(Val* x, Val* y, const Context& context) {
   x = foldConstants(x);
   y = foldConstants(y);
-  if (x->getInt().has_value() && y->getInt().has_value()) {
-    return *x->getInt() <= *y->getInt();
-  }
-  if (x->getDouble().has_value() && y->getDouble().has_value()) {
-    return *x->getDouble() <= *y->getDouble();
+  if (x->value().hasValue() && y->value().hasValue()) {
+    return x->value() <= y->value();
   }
   x = maybeUnwrapMagicZero(x);
   y = maybeUnwrapMagicZero(y);
@@ -1887,7 +1866,8 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       // a / 1 -> a
       // 0 / a -> 0
       if (rhs->isOne() ||
-          (isValidDenominator(rhs, context) && lhs->getInt() == 0)) {
+          (isValidDenominator(rhs, context) && lhs->value().hasValue() &&
+           lhs->value().is<int64_t>() && lhs->value() == 0)) {
         return lhs;
       }
     }

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -315,7 +315,7 @@ bool Fusion::isNoOp() {
     auto root_dom = TensorDomain::noReductions(out_tv->getMaybeRFactorDomain());
     bool size_zero = false;
     for (auto id : root_dom) {
-      if (id->extent()->isConstScalar() && id->extent()->evaluateInt() == 0) {
+      if (id->extent()->isConstScalar() && id->extent()->evaluate() == 0) {
         size_zero = true;
         break;
       }

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -320,13 +320,13 @@ Val* getProducerIndexWithPartialSplit(
       diff->isConstScalar(),
       "Invalid partial split, must be a constant value.");
 
-  if (diff->evaluateInt() == 0) {
+  if (diff->evaluate() == 0) {
     return producer_index;
   }
 
   return SimplifyingIrBuilder::addExpr(
       producer_index,
-      SimplifyingIrBuilder::create<Val>(diff->evaluateInt(), DataType::Index));
+      SimplifyingIrBuilder::create<Val>(diff->evaluate(), DataType::Index));
 }
 
 Val* getTensorBaseAddress(TensorView* tv) {
@@ -2925,7 +2925,8 @@ bool canOmitStopPredicate(
     auto in_extent = IrBuilder::ltExpr(
         IrBuilder::create<Val>(lhs, *stop_index->getDataType()),
         contig_id->getMaybeExpandedExtent());
-    if (simplifyExpr(in_extent)->getBool() == true) {
+    auto expr_val = simplifyExpr(in_extent)->value();
+    if (expr_val.hasValue() && expr_val.is<bool>() && expr_val.as<bool>()) {
       return true;
     } else {
       return false;

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -160,8 +160,8 @@ class KernelIrScanner : private IrVisitor {
           tidy_val->isConstInt(),
           "TIDy is expected to be a const int: ",
           tidy_val->toInlineString());
-      auto tidx = static_cast<int>(tidx_val->evaluateInt());
-      auto tidy = static_cast<int>(tidy_val->evaluateInt());
+      auto tidx = static_cast<int>(tidx_val->evaluate());
+      auto tidy = static_cast<int>(tidy_val->evaluate());
       summary_.outer_grouped_grid_welford_largest_smem_size = std::max(
           summary_.outer_grouped_grid_welford_largest_smem_size,
           grid_welford->getSmemBufferSize(tidx, tidy, 1));

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -1207,9 +1207,8 @@ int GroupedGridWelford::getSmemBufferSize(int bdimx, int bdimy, int bdimz)
   for (auto axis : out_tv->getLeafDomain()) {
     auto pt = axis->getParallelType();
     if (pt == ParallelType::Group) {
-      auto extent_int = axis->extent()->getInt();
-      NVF_ERROR(extent_int.has_value());
-      group_count *= (int)extent_int.value();
+      auto extent_int = axis->extent()->value();
+      group_count *= (int)extent_int;
     }
   }
 

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -122,7 +122,8 @@ class Predicate final : public Val {
   }
 
   bool isTrivial() const {
-    return isConst() && value_->getBool() == true;
+    return isConst() && value_->value().is<bool>() &&
+        value_->value().as<bool>();
   }
 
  private:

--- a/csrc/non_divisible_split.cpp
+++ b/csrc/non_divisible_split.cpp
@@ -103,12 +103,12 @@ void NonDivisibleSplitInfo::propagateReachability(
 Val* NonDivisibleSplitInfo::getMaybeNonDivisibleExtent(Split* split) const {
   std::optional<int64_t> in_extent;
   if (split->in()->extent()->isConstInt()) {
-    in_extent = split->in()->extent()->evaluateInt();
+    in_extent = split->in()->extent()->evaluate().as<int64_t>();
   }
 
   std::optional<int64_t> factor;
   if (split->factor()->isConstInt()) {
-    factor = split->factor()->evaluateInt();
+    factor = split->factor()->evaluate().as<int64_t>();
   }
 
   if (in_extent.has_value() && factor.has_value() &&

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -841,8 +841,8 @@ TensorView* TensorView::swizzle(
         x_id->extent()->isConstInt() && y_id->extent()->isConstInt(),
         "Only constant iterdomains supported on given swizzle type");
 
-    int in_x_size = (int)x_id->extent()->evaluateInt();
-    int in_y_size = (int)y_id->extent()->evaluateInt();
+    int in_x_size = (int)x_id->extent()->evaluate();
+    int in_y_size = (int)y_id->extent()->evaluate();
 
     // Check size constraints based on swizzle type
     if (swizzle_type == Swizzle2DType::XOR ||
@@ -1524,7 +1524,7 @@ TensorView* TensorViewBuilder::build() const {
           SimplifyingIrBuilder::maybeCastExpr(DataType::Index, shape_.at(i));
     }
     IterDomainBuilder builder(FusionGuard::getCurFusion()->zeroVal(), extent);
-    if (extent->isConstScalar() && extent->evaluateInt() == 1) {
+    if (extent->isConstScalar() && extent->evaluate() == 1) {
       builder.iter_type(IterType::Broadcast);
     }
     if (expanded_extent != nullptr) {


### PR DESCRIPTION
This replaces uses of evaluate(Int, Bool, Double) with evaluate which returns a PolymorphicValue.

This also replaces the uses of get(Int, Bool, Double) with value().

This PR is the second  of a number of them to fix the issue. In the final PR, the older get* and evaluate* methods will be removed.

Fixes #643