### PR TITLE
Renaming IterDomainGraphs to IdModel

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -311,7 +311,7 @@ void GpuLower::lower(Fusion* fusion) {
   replaceSymbolicSizes(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "replaceSymbolicSizes");
 
-  IterDomainGraphs test(fusion_);
+  IdModel test(fusion_);
 
   // Build what's refered to as the compute at map. This map contains the
   // mappings of all iteration domains across the fusion. There are three types

--- a/csrc/id_model/id_graphs.h
+++ b/csrc/id_model/id_graphs.h
@@ -82,21 +82,19 @@ struct StatefulLoweringInfo;
 //          PERMISSIVE)
 //   Forward through split one axes, i.e. id{ceilDiv(i0, 1)}, id{i0} are mapped
 //
-class IterDomainGraphs : public PolymorphicBase {
+class IdModel : public PolymorphicBase {
  public:
-  IterDomainGraphs(
+  IdModel(
       const std::vector<Expr*>& exprs,
       const std::vector<TensorView*>& additional_tvs,
       bool allow_self_mapping = false);
 
-  IterDomainGraphs(
-      const std::vector<Expr*>& exprs,
-      bool allow_self_mapping = false);
+  IdModel(const std::vector<Expr*>& exprs, bool allow_self_mapping = false);
 
   // Same as the above constructor with fusion->exprs() excpet fusion may have
   // some dangling inputs/outputs that are expected to have IterDomain entries
   // even though there's no possible connections from them.
-  IterDomainGraphs(Fusion* fusion, bool allow_self_mapping = false);
+  IdModel(Fusion* fusion, bool allow_self_mapping = false);
 
   // Returns iter domain graph of provided mode.
   const IdGraph& idGraph(IdMappingMode mode) const;

--- a/test/test_gpu_indexing.cpp
+++ b/test/test_gpu_indexing.cpp
@@ -879,7 +879,7 @@ TEST_F(NVFuserTest, FusionIndexing19_CUDA) {
     tensor->inlineAt(1);
   }
 
-  IterDomainGraphs id_model(&fusion);
+  IdModel id_model(&fusion);
 
   // All of the IDs that are generated with merge operations from the
   // root domains should be mapped to the single group.


### PR DESCRIPTION
I prefer to have `IdGraph` and `IdModel`, rather than `IdGraph` and `IdGraphs`