### PR TITLE
Set autoincrementing index in FusionExecutor::compileRtc

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1865,13 +1865,15 @@ void FusionExecutor::compileRtc(
       index_type == PrimDataType::Int || index_type == PrimDataType::Int32 ||
           "Invalid index type: ",
       index_type);
+
+  fusion_id_ = ++fusion_id_counter_;
+
   std::string scode;
   if (!structured) {
     scode = getStructuredCode(code, index_type);
   } else {
     scode = code;
   }
-  fusion_id_ = 1;
 
   compiled_kernel_ =
       executor_utils::getCompiledKernel(std::nullopt, scode, name, fusion_id_);


### PR DESCRIPTION
compileRtc is used only in a few tests (seven currently) to test basic compilation functionality. Currently, calling compileRtc does not use fusion_id_counter_, and does not set fusion_id_ until after calling getStructuredCode. This means that if we print the kernel or compiled PTX, we get a file named like `__tmp_kernel-1.{cu,ptx}`. Here -1 is the default value of `fusion_id_`. This has caused a problem in codegen diff, which expects us to not overwrite these files, and for them to follow a somewhat regular naming scheme.

This change simply sets the ID before `getStructuredCode` using `fusion_id_counter_` to mimic what happens in `compileFusion`.