### PR TITLE
Staged replacement of the use of evaluate* and get* with evaluate() and value() [3/N]

### DIFF
--- a/csrc/device_lower/analysis/bank_conflict.cpp
+++ b/csrc/device_lower/analysis/bank_conflict.cpp
@@ -36,7 +36,7 @@ int64_t getVectorizeSize(kir::TensorIndex* ti) {
         id->extent()->isConstInt(),
         "Could not evaluate constant value bound to vectorized dim.");
 
-    return id->extent()->evaluateInt();
+    return id->extent()->evaluate().as<int64_t>();
   }
   return 1;
 }

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -153,21 +153,20 @@ class PredicateAnalyzer : public OptOutDispatch {
   // axis. Otherwise, we can't skip predication as it might cause
   // out-bound accesses with the producer tensor
   void handle(Split* split) override {
-    auto factor = split->factor()->getInt();
-    if (!factor.has_value()) {
+    auto factor = split->factor()->value();
+    if (!factor.is<int64_t>()) {
       needs_predicate_ = true;
       return;
     }
 
-    if (factor.value() == 1) {
+    if (factor == 1) {
       // Trivial splits cannot cause out-of-bounds
       return;
     }
 
     auto in_extent = split->in()->extent();
 
-    if (!in_extent->isConstInt() ||
-        ((in_extent->evaluateInt() % factor.value()) != 0)) {
+    if (!in_extent->isConstInt() || ((in_extent->evaluate() % factor) != 0)) {
       needs_predicate_ = true;
       return;
     }

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -176,8 +176,7 @@ void GpuLower::collectPaddedParallelDims() {
             size_after_padding.value() == warp_size;
 
         if (id->extent()->isConstInt() &&
-            id->extent()->evaluateInt() > warp_size &&
-            !padding_to_single_warp) {
+            id->extent()->evaluate() > warp_size && !padding_to_single_warp) {
           // If we see any other TIDx binding that's larger than
           //  a warp or unknown, we shouldn't lower warp reduce
           //  to a single warp type.
@@ -186,7 +185,7 @@ void GpuLower::collectPaddedParallelDims() {
         } else if (can_be_single_warp) {
           if (padding_to_single_warp ||
               (id->extent()->isConstInt() &&
-               id->extent()->evaluateInt() == warp_size)) {
+               id->extent()->evaluate() == warp_size)) {
             warp_pad_info_.is_tidx_single_warp = true;
           }
         }

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -822,7 +822,7 @@ class AllocationInfoMap : private kir::IrVisitor {
             "Lower_alias_memory : dynamic sized register allocation");
         return;
       }
-      if (alloc->size()->evaluateInt() <= kRegisterSizeThreshold) {
+      if (alloc->size()->evaluate() <= kRegisterSizeThreshold) {
         should_try_alias = false;
       }
     }

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1122,8 +1122,8 @@ bool canUseOuterOptRuntimeKernel(const GroupedWelfordOp* grouped_wop) {
   if (!tidx_val->isConstInt() || !tidy_val->isConstInt()) {
     return false;
   }
-  auto tidx = static_cast<int>(tidx_val->evaluateInt());
-  auto tidy = static_cast<int>(tidy_val->evaluateInt());
+  auto tidx = static_cast<int>(tidx_val->evaluate());
+  auto tidy = static_cast<int>(tidy_val->evaluate());
 
   // TIDz and BIDz must be unused or just 1. This contraint can be
   // lifted if necessary.
@@ -1153,7 +1153,7 @@ bool canUseOuterOptRuntimeKernel(const GroupedWelfordOp* grouped_wop) {
           axis->extent()->isConstInt(),
           "Grouped IterDomain must have a static integer extent: ",
           axis->extent()->toInlineString());
-      num_grouped_iterations *= (int)axis->extent()->evaluateInt();
+      num_grouped_iterations *= (int)axis->extent()->evaluate();
     }
   }
 

--- a/csrc/device_lower/pass/unroll.cpp
+++ b/csrc/device_lower/pass/unroll.cpp
@@ -299,7 +299,7 @@ bool UnrollPass::canOmitElseClause(kir::ForLoop* fl) {
       visit_once = true;
     }
     if (!visit_once) {
-      if (loop->stop()->isConstInt() && loop->stop()->evaluateInt() == 1) {
+      if (loop->stop()->isConstInt() && loop->stop()->evaluate() == 1) {
         visit_once = true;
       }
     }

--- a/csrc/device_lower/pass/warp_reduce.cpp
+++ b/csrc/device_lower/pass/warp_reduce.cpp
@@ -365,13 +365,13 @@ class FuseBroadcastWithWarpReduce : private kir::IrVisitor {
       // not have
       //  a size of 1, since it would have required re-indexing.
       if (!reduction_allocate_it->second->size()->isConstInt() ||
-          reduction_allocate_it->second->size()->evaluateInt() != 1) {
+          reduction_allocate_it->second->size()->evaluate() != 1) {
         return;
       }
 
       auto broadcast_allocate = getActiveAllocateFor(out_tv);
       if (!broadcast_allocate->size()->isConstInt() ||
-          broadcast_allocate->size()->evaluateInt() != 1) {
+          broadcast_allocate->size()->evaluate() != 1) {
         return;
       }
 
@@ -401,7 +401,7 @@ class FuseBroadcastWithWarpReduce : private kir::IrVisitor {
     }
 
     if (id->extent()->isConstScalar()) {
-      return id->extent()->evaluateInt() == warp_size;
+      return id->extent()->evaluate() == warp_size;
     }
 
     return false;

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -341,7 +341,7 @@ std::optional<IterDomain*> getMaybeWarpReductionDim(
   }
 
   if (reduction_on_xdim->extent()->isConstInt()) {
-    auto extent_value = reduction_on_xdim->extent()->evaluateInt();
+    auto extent_value = reduction_on_xdim->extent()->evaluate();
     if (extent_value % at::cuda::warp_size() == 0) {
       return std::optional<IterDomain*>(reduction_on_xdim);
     }

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -433,7 +433,7 @@ class VectorizeValidator : public OptInDispatch {
         v_id->extent()->isConstInt(),
         "Vectorizing a domain requires a constant integer size.");
 
-    auto vector_word_size = v_id->extent()->evaluateInt();
+    auto vector_word_size = v_id->extent()->evaluate();
     auto vector_size =
         ((int64_t)dataTypeSize(
             tv->getDataType().value(), GpuLower::current()->indexType())) *
@@ -730,6 +730,7 @@ std::unordered_map<IterDomain*, std::pair<int64_t, int64_t>> getLiveRangeOffsets
             "Can't evaluate stop value of ",
             consumer_root->stopOffset());
         auto it = map.find(consumer_root);
+
         if (it == map.end() || consumer->isFusionOutput()) {
           // No range set for this root domain, which means this
           // consumer_tensor is an output tensor or the consumer_root
@@ -742,19 +743,17 @@ std::unordered_map<IterDomain*, std::pair<int64_t, int64_t>> getLiveRangeOffsets
           // is visible to outside of the fusion.
           map.insert(
               {consumer_root,
-               {consumer_root->start()->evaluateInt(),
-                consumer_root->stopOffset()->evaluateInt()}});
+               {consumer_root->start()->evaluate().as<int64_t>(),
+                consumer_root->stopOffset()->evaluate().as<int64_t>()}});
         } else {
           // When the range of this root domain is already set, it
           // must be set by its consumers. Make sure the required
           // range by the consumers is covered by the defined range of
           // this root domain.
           auto& consumer_range = it->second;
+          NVF_ERROR(consumer_root->start()->evaluate() <= consumer_range.first);
           NVF_ERROR(
-              consumer_root->start()->evaluateInt() <= consumer_range.first);
-          NVF_ERROR(
-              consumer_root->stopOffset()->evaluateInt() <=
-              consumer_range.second);
+              consumer_root->stopOffset()->evaluate() <= consumer_range.second);
         }
       }
 
@@ -810,11 +809,11 @@ void validateSplit(
       split_offset);
 
   NVF_ERROR(
-      split_offset->evaluateInt() <= domain_offset,
+      split_offset->evaluate() <= domain_offset,
       err_msg_prefix,
       ": Split offset is larger than the domain offset.",
       " Split offset: ",
-      split_offset->evaluateInt(),
+      split_offset->evaluate(),
       ". Domain offset: ",
       domain_offset);
 }
@@ -898,7 +897,7 @@ void validateMmaTensors(MmaOp* mma) {
           NVF_ERROR(
               lower_utils::isExtentEqualToMaxParallelTypeExtent(id) &&
                   paralel_dim_map.get(ptype)->isConstInt() &&
-                  paralel_dim_map.get(ptype)->evaluateInt() ==
+                  paralel_dim_map.get(ptype)->evaluate() ==
                       at::cuda::warp_size(),
               "TIDx is reserved for lane id in mma kernels, and it needs to be exactly a warp");
           tidx_validated = true;
@@ -1022,7 +1021,7 @@ void validateSizeMemoryOp(LoadStoreOp* ldst) {
   auto output = ldst->out()->as<TensorView>();
   for (auto id : output->getLeafDomain()) {
     if (id->getParallelType() == ParallelType::Vectorize) {
-      byte_size = (int)id->extent()->evaluateInt();
+      byte_size = static_cast<int>(id->extent()->evaluate());
       break;
     }
   }
@@ -1192,7 +1191,7 @@ void validateAndConvertIterDomainGrouping(Fusion* fusion) {
 
       // Extent must be static
       NVF_CHECK(
-          id->extent()->getInt().has_value(),
+          id->extent()->value().is<int64_t>(),
           "Invalid use of ParallelType::Group.",
           " IterDomain must have a static extent: ",
           id->toString());
@@ -1314,7 +1313,7 @@ void validateGroupedReductions(Fusion* fusion) {
       auto out_tv = ir_utils::getTvOutput(grouped_reduction_op);
       for (auto axis : out_tv->getLeafDomain()) {
         if (axis->getParallelType() == ParallelType::Group) {
-          num_grouped_iterations *= (int)axis->extent()->getInt().value();
+          num_grouped_iterations *= (int)axis->extent()->value();
         }
       }
       NVF_CHECK(

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -82,7 +82,7 @@ TensorView* tryStaticReshape(
     if (!id_size->isConstInt()) {
       return nullptr;
     }
-    inp_sizes[i] = id_size->evaluateInt();
+    inp_sizes[i] = id_size->evaluate().as<int64_t>();
   }
 
   std::vector<int64_t> out_sizes(new_sizes.size());
@@ -91,7 +91,7 @@ TensorView* tryStaticReshape(
     if (!id_size->isConstInt()) {
       return nullptr;
     }
-    out_sizes[i] = id_size->evaluateInt();
+    out_sizes[i] = id_size->evaluate().as<int64_t>();
   }
 
   // Both inputs are outputs are static. Just use the static version
@@ -125,7 +125,7 @@ TensorView* reshape(TensorView* inp_tv, const std::vector<Val*>& new_sizes) {
   bool found_neg_one = false;
   for (const auto i : c10::irange(new_sizes.size())) {
     auto new_size = new_sizes.at(i);
-    if (new_size->isConstScalar() && new_size->evaluateInt() == -1) {
+    if (new_size->isConstScalar() && new_size->evaluate() == -1) {
       // It is usually safe to use the provided scalars as the output shapes.
       // However, if -1 is provided for some position, it will not correspond to
       // the actual extent in that position.
@@ -228,7 +228,7 @@ TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
         NVF_CHECK(
             !id->hasExpandedExtent(), "Can not squeeze expanded dimension(s).");
         NVF_CHECK(
-            id->extent()->isConstScalar() && id->extent()->evaluateInt() == 1,
+            id->extent()->isConstScalar() && id->extent()->evaluate() == 1,
             "Can not squeeze dimension(s) with size != 1.");
       }
     } else {

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -354,13 +354,13 @@ TensorView* iota(Val* length, Val* start, Val* step, DataType dtype) {
 
   if (start->isConst() && start->isFloatingPointScalar()) {
     NVF_ERROR(
-        std::isfinite(start->getDouble().value()),
+        std::isfinite(start->value().as<double>()),
         "iota: length, start, step must be finite numbers.");
   }
 
   if (step->isConst() && step->isFloatingPointScalar()) {
     NVF_ERROR(
-        std::isfinite(step->getDouble().value()),
+        std::isfinite(step->value().as<double>()),
         "iota: length, start, step must be finite numbers.");
   }
 
@@ -1468,15 +1468,17 @@ TensorView* expand(TensorView* inp, const std::vector<Val*>& expanded_sizes) {
     auto out_id_builder = IterDomainBuilder(inp_id);
     maybe_expanded_sizes[i] = inp_domain[i]->extent();
 
-    auto expanded_size_int = expanded_sizes[i]->getInt();
+    auto expanded_size_int = expanded_sizes[i]->value();
 
     // If the expanded size is -1, let the input extent be propagated
     // as is
-    if (expanded_size_int == -1) {
+    if (expanded_size_int.hasValue() && expanded_size_int == -1) {
       // This is just done for clarity. It isn't necessary as it's
       // already done when constructing out_id_builder.
       out_id_builder.extent(inp_id->extent());
-    } else if (inp_id->isBroadcast() && expanded_size_int != 1) {
+    } else if (
+        inp_id->isBroadcast() &&
+        (!expanded_size_int.hasValue() || expanded_size_int != 1)) {
       // When input id is a broadcast, expand the extent to the given
       // size, which can be concrete or symbolic.
       expanded = true;
@@ -1493,8 +1495,8 @@ TensorView* expand(TensorView* inp, const std::vector<Val*>& expanded_sizes) {
       // Input id is non-expand and its extent is concrete. Nothing
       // to expand, but the input and expanded sizes should match if
       // the expanded size is also concrete.
-      auto inp_id_size_int = inp_id->extent()->evaluateInt();
-      if (expanded_size_int.has_value()) {
+      auto inp_id_size_int = inp_id->extent()->evaluate();
+      if (expanded_size_int.is<int64_t>()) {
         NVF_CHECK(
             inp_id_size_int == expanded_size_int,
             "Invalid expand size, ",
@@ -2379,7 +2381,7 @@ TensorView* gather(
         inp_axis->stopOffset()->isConstInt(),
         "Dynamic stop offset not supported: ",
         inp_axis);
-    const auto inp_stop_offset = inp_axis->stopOffset()->evaluateInt();
+    const auto inp_stop_offset = inp_axis->stopOffset()->evaluate();
     const auto extent_adjustment = window_dim - 1 - pad_left - pad_right;
     NVF_CHECK(
         extent_adjustment >= 0,


### PR DESCRIPTION
Replaces uses of evaluate(Int, Bool, Double) with evaluate which returns a PolymorphicValue.

This also replaces the uses of get(Int, Bool, Double) with value().

This PR is the third of a number of them to fix the issue. In the final PR, the older get* and evaluate* methods will be removed.

Fixes https://github.com/NVIDIA/Fuser/issues/643