### PR TITLE
ExpressionEvaluator validates allocation domain for Set.Permute. 

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2402,6 +2402,10 @@ std::vector<PolymorphicValue> LoadStoreOp::evaluate(
           out_tv->getRootDomain(), out_tv->getRFactorDomain()));
 
       inferAndValidateAllocationSizesAndStrides(out_tensor, out_tv, ee);
+      // TODO: When validation fails, relayout `out_tensor` to make it
+      // compatible with `out_tv`'s allocation domain and contiguity. I haven't
+      // quite figured out how to do that especially when the allocation domain
+      // is not a permutation of `out_tv`'s rfactor domain.
       return {out_tensor};
     }
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -17,6 +17,7 @@
 #include <kernel_ir.h>
 #include <ops/arith.h>
 #include <root_domain_map.h>
+#include <tensor_metadata.h>
 #include <transform_iter.h>
 #include <transform_rfactor.h>
 #include <transform_view.h>
@@ -2381,56 +2382,6 @@ std::vector<int64_t> computePermutation(
   }
   return permutation;
 }
-
-std::vector<int64_t> strideOrder(const at::Tensor& tensor) {
-  std::vector<std::pair<int64_t, int64_t>> stride_dim;
-  stride_dim.reserve(tensor.dim());
-  for (int64_t i = 0; i < tensor.dim(); i++) {
-    stride_dim.emplace_back(tensor.stride(i), i);
-  }
-
-  std::sort(
-      stride_dim.begin(),
-      stride_dim.end(),
-      std::greater<std::pair<int64_t, int64_t>>());
-
-  std::vector<int64_t> stride_order;
-  stride_order.reserve(tensor.dim());
-  for (const auto& [stride, dim] : stride_dim) {
-    stride_order.push_back(dim);
-  }
-  return stride_order;
-}
-
-bool strideOrdersAreCompatible(const TensorView& tv, const at::Tensor& tensor) {
-  const std::vector<IterDomain*>& rfactor = tv.getMaybeRFactorDomain();
-  const std::vector<IterDomain*>& allocation = tv.getMaybeAllocationDomain();
-
-  std::unordered_set<int64_t> rfactor_indices_to_ignore;
-  for (size_t i = 0; i < rfactor.size(); i++) {
-    if (rfactor[i]->isReduction() || rfactor[i]->isBroadcast()) {
-      rfactor_indices_to_ignore.insert(i);
-    }
-  }
-
-  std::vector<int64_t> tv_stride_order =
-      computePermutation(rfactor, allocation);
-  std::vector<int64_t> tensor_stride_order = strideOrder(tensor);
-
-  auto filter = [](const std::unordered_set<int64_t>& to_filter_out,
-                   std::vector<int64_t>& v) -> void {
-    v.erase(
-        std::remove_if(
-            v.begin(),
-            v.end(),
-            [&](const int64_t e) { return to_filter_out.count(e); }),
-        v.end());
-  };
-  filter(rfactor_indices_to_ignore, tv_stride_order);
-  filter(rfactor_indices_to_ignore, tensor_stride_order);
-  return tv_stride_order == tensor_stride_order;
-}
-
 } // namespace
 
 std::vector<PolymorphicValue> LoadStoreOp::evaluate(
@@ -2450,18 +2401,7 @@ std::vector<PolymorphicValue> LoadStoreOp::evaluate(
       at::Tensor out_tensor = in_tensor.permute(computePermutation(
           out_tv->getRootDomain(), out_tv->getRFactorDomain()));
 
-      // Check that `out_tv`'s allocation domain and `out_tensor.stride()` infer
-      // the same major-to-minor order. Otherwise, we need to apply `flatten`
-      // and `as_strided` on `out_tensor`, which is left as a todo.
-      NVF_ERROR(
-          strideOrdersAreCompatible(*out_tv, out_tensor),
-          out_tv->toString(),
-          " and ",
-          out_tensor.toString(),
-          out_tensor.sizes(),
-          ",strides=",
-          out_tensor.strides(),
-          " have incompatible strider orders.");
+      inferAndValidateAllocationSizesAndStrides(out_tensor, out_tv, ee);
       return {out_tensor};
     }
   }

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -218,13 +218,14 @@ void validateAllocationSizesAndStrides(
     c10::IntArrayRef strides) {
   NVF_ERROR(sizes.size() == strides.size());
 
-  // Validate contiguity
+  // Validate contiguity.
   int64_t contiguous_stride = 1;
   auto contiguity_rev = contiguity.crbegin();
   for (int64_t i = (int64_t)sizes.size() - 1; i >= 0; i--) {
     if (alloc_dom_no_reductions.at(i)->isBroadcast()) {
       continue;
     }
+
     while (!contiguity_rev->has_value()) {
       contiguity_rev++;
     }
@@ -259,6 +260,24 @@ void validateAllocationSizesAndStrides(
           [](auto c_flag) { return c_flag.has_value(); }),
       "The size of contiguity mismatch with the dimensionality of allocation domain");
 
+  // Validate that strides must be in decreasing order modulo reduction and
+  // broadcast.
+  int64_t last_stride = std::numeric_limits<int64_t>::max();
+  for (int64_t i : c10::irange((int64_t)strides.size())) {
+    if (alloc_dom_no_reductions.at(i)->isBroadcast()) {
+      continue;
+    }
+
+    NVF_ERROR(
+        strides[i] < last_stride,
+        "Strides must be in decreasing order modulo reduction and broadcast. Found ",
+        last_stride,
+        " before ",
+        strides[i]);
+
+    last_stride = strides[i];
+  }
+
   // Validate that for expanded broadcast, the stride must be zero.
   for (int64_t i : c10::irange((int64_t)strides.size())) {
     if (auto alloc_id = alloc_dom_no_reductions.at(i);
@@ -274,15 +293,8 @@ void validateAllocationSizesAndStrides(
   }
 }
 
-// Given an ATen tensor, whose sizes and strides are w.r.t to the rFactor domain
-// of its corresponding TensorView, compute the sizes and strides of the tensor
-// with respect to its allocation domain.
-// For example, if the rFactor domain is [I1, I2], and the allocation domain is
-// [I2*I1], and the tensor's size is [5, 3] and stride is [2, 10], then the
-// resulting size will be [15] and stride will be [2]
-// Another example, if the rFactor domain is [I1*I2] and the allocation domain
-// is [I1, I2], and the tensor's size is [15] and stride is [7], and the extent
-// of I2 is 5, then the resulting size will be [3, 5] and stride will be [35, 7]
+} // namespace
+
 std::pair<std::vector<int64_t>, std::vector<int64_t>>
 inferAndValidateAllocationSizesAndStrides(
     const at::Tensor& tensor,
@@ -329,8 +341,6 @@ inferAndValidateAllocationSizesAndStrides(
   validateAllocationSizesAndStrides(alloc, tv->getContiguity(), sizes, strides);
   return {std::move(sizes), std::move(strides)};
 }
-
-} // namespace
 
 std::vector<PolymorphicValue> GetMetaData::evaluate(
     const ExpressionEvaluator& ee,

--- a/csrc/tensor_metadata.h
+++ b/csrc/tensor_metadata.h
@@ -7,7 +7,12 @@
 // clang-format on
 #pragma once
 
+#include <utility>
+#include <vector>
+
 #include <exceptions.h>
+#include <expr_evaluator.h>
+#include <ir/interface_nodes.h>
 #include <polymorphic_value.h>
 #include <type.h>
 

--- a/csrc/tensor_metadata.h
+++ b/csrc/tensor_metadata.h
@@ -98,4 +98,19 @@ struct TensorMetaData : public Struct {
   }
 };
 
+// Given an ATen tensor, whose sizes and strides are w.r.t to the rFactor domain
+// of its corresponding TensorView, compute the sizes and strides of the tensor
+// with respect to its allocation domain.
+// For example, if the rFactor domain is [I1, I2], and the allocation domain is
+// [I2*I1], and the tensor's size is [5, 3] and stride is [2, 10], then the
+// resulting size will be [15] and stride will be [2]
+// Another example, if the rFactor domain is [I1*I2] and the allocation domain
+// is [I1, I2], and the tensor's size is [15] and stride is [7], and the extent
+// of I2 is 5, then the resulting size will be [3, 5] and stride will be [35, 7]
+std::pair<std::vector<int64_t>, std::vector<int64_t>>
+inferAndValidateAllocationSizesAndStrides(
+    const at::Tensor& tensor,
+    TensorView* tv,
+    ExpressionEvaluator ee);
+
 } // namespace nvfuser

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -546,7 +546,6 @@ TEST_F(ExprEvalTest, Permute_Alias) {
       TensorViewBuilder().shape({-1, -1, -1, 6}).dtype(DataType::Float).build();
   fusion.addInput(in);
   TensorView* out = permute(in, {0, 3, 1, 2});
-  out->setAllocationDomain(
   fusion.addOutput(out);
 
   at::Tensor in_tensor =
@@ -577,10 +576,9 @@ TEST_F(ExprEvalTest, Permute_NoAlias) {
 
   ExpressionEvaluator evaluator;
   evaluator.bind(in, in_tensor);
-  at::Tensor out_tensor = evaluator.evaluate(out).as<at::Tensor>();
-  EXPECT_NE(in_tensor.data_ptr(), out_tensor.data_ptr());
-  EXPECT_THAT(out_tensor.sizes(), ElementsAre(2, 6, 3, 4));
-  EXPECT_THAT(out_tensor.strides(), ElementsAre(128, 1, 8, 32));
+  EXPECT_THAT(
+      [&]() { evaluator.evaluate(out); },
+      ThrowsMessage<nvfError>(HasSubstr("decreasing order")));
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
This was a fun exercise. It's half done -- see my TODO. But I'm curious to hear your thoughts before I continue. 
1. Should ExpressionEvaluator guarantee to produce tensors that always respect allocation domain and contiguity? 
2. If so, should it guarantee that for just fusion outputs or every intermediate tensor as well? 
3. Is an empty allocation domain compatible with any stride order or with only row-major? 