### PR TITLE
add a test case testing non-persistent softmax

### DIFF
--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -22,8 +22,18 @@ Val* set(Val* v) {
   return out;
 }
 
+Val* set(Val* v, CacheOp cache_op) {
+  Val* out = ops::newValLike(v, v->getDataType().value());
+  IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, v, cache_op);
+  return out;
+}
+
 TensorView* set(TensorView* tv) {
   return set(tv->as<Val>())->as<TensorView>();
+}
+
+TensorView* set(TensorView* tv, CacheOp cache_op) {
+  return set(tv->as<Val>(), cache_op)->as<TensorView>();
 }
 
 Val* segment_set(Val* v) {

--- a/csrc/ops/alias.h
+++ b/csrc/ops/alias.h
@@ -24,6 +24,9 @@ namespace nvfuser {
 Val* set(Val*);
 TensorView* set(TensorView*);
 
+Val* set(Val*, CacheOp);
+TensorView* set(TensorView*, CacheOp);
+
 // segment_set hints segmenter to break kernel
 Val* segment_set(Val*);
 TensorView* segment_set(TensorView*);


### PR DESCRIPTION
Add a test case testing non-persistent softmax. In this non-persistent approach, the kernel is loading input from gmem 3 times without using registers or shared memory for persistence. Tested on ipp2-0123 with `nsys nvprof --print-gpu-trace ./nvfuser_tests --gtest_filter=NVFuserTest.NonPersistentSoftmax`, the reported latency is 0.94 ms, as a reference, the current persistent version is 1.0 ms.
fusion_ir and performance:
```
Inputs:
  T0_g[ iS0{i0}, iS70{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, iS72{( ceilDiv(256, 1) )}, iS73{1}, iS69{8} ], __half
Outputs:
  T18_g[ iblockIdx.x36{i0}, iS142{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x144{( ceilDiv(256, 1) )}_p, iUS145{1}, iV141{8} ] ca_pos( 4 ) produce_pos( 4 ), __half

%kernel_math {
T11_l[ iblockIdx.x22{i0}, iS160{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x162{( ceilDiv(256, 1) )}_p, iUS163{1}, iV159{8} ] ca_pos( 4 )
   = Set( T0_g[ iS0{i0}, iS70{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, iS72{( ceilDiv(256, 1) )}, iS73{1}, iS69{8} ], cache_op=Streaming )
T12_l[ iblockIdx.x24{i0}, iS106{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x108{( ceilDiv(256, 1) )}_p, iUS109{1}, iS105{8} ] ca_pos( 5 ) produce_pos( 4 )
   = __half2float(T11_l[ iblockIdx.x22{i0}, iS160{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x162{( ceilDiv(256, 1) )}_p, iUS163{1}, iV159{8} ] ca_pos( 4 ));
T1_l[ iblockIdx.x2{i0}, iS64{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x66{( ceilDiv(256, 1) )}_p, iUS67{1}, iV63{8} ] ca_pos( 4 )
   = Set( T0_g[ iS0{i0}, iS70{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, iS72{( ceilDiv(256, 1) )}, iS73{1}, iS69{8} ], cache_op=AllLevels )
T2_l[ iblockIdx.x4{i0}, iS58{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x60{( ceilDiv(256, 1) )}_p, iUS61{1}, iS57{8} ] ca_pos( 5 ) produce_pos( 4 )
   = __half2float(T1_l[ iblockIdx.x2{i0}, iS64{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x66{( ceilDiv(256, 1) )}_p, iUS67{1}, iV63{8} ] ca_pos( 4 ));
T19_l[ iblockIdx.x44{i0}, rS48{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}rf, ithreadIdx.x50{( ceilDiv(256, 1) )}_p, iUS51{1}, rS47{8}rf ] ca_pos( 1 ) produce_pos( 5 )
   = reduction( T2_l[ iblockIdx.x4{i0}, iS58{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x60{( ceilDiv(256, 1) )}_p, iUS61{1}, iS57{8} ] ca_pos( 5 ) produce_pos( 4 ), op = fmax, initial value = double(-inf), allreduce = false )
T3_l[ iblockIdx.x52{i0}, rthreadIdx.x54{( ceilDiv(256, 1) )}_p, rUS55{1} ] ca_pos( 1 ) produce_pos( 1 )
   = reduction( T19_l[ iblockIdx.x44{i0}, rS48{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}rf, ithreadIdx.x50{( ceilDiv(256, 1) )}_p, iUS51{1}, rS47{8}rf ] ca_pos( 1 ) produce_pos( 5 ), op = fmax, initial value = double(-inf), allreduce = false )
T4_l[ iblockIdx.x8{i0}, bS94{( ceilDiv(( ceilDiv(1, 8) ), 256) )}, bthreadIdx.x96{( ceilDiv(256, 1) )}_p, bUS97{1}, bS93{8} ] ca_pos( 1 ) produce_pos( 1 )
   = broadcast( T3_l[ iblockIdx.x52{i0}, rthreadIdx.x54{( ceilDiv(256, 1) )}_p, rUS55{1} ] ca_pos( 1 ) produce_pos( 1 ) )
T13_l[ iblockIdx.x26{i0}, iS100{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x102{( ceilDiv(256, 1) )}_p, iUS103{1}, iS99{8} ] ca_pos( 5 ) produce_pos( 5 )
   = T12_l[ iblockIdx.x24{i0}, iS106{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x108{( ceilDiv(256, 1) )}_p, iUS109{1}, iS105{8} ] ca_pos( 5 ) produce_pos( 4 )
   - T4_l[ iblockIdx.x8{i0}, bS94{( ceilDiv(( ceilDiv(1, 8) ), 256) )}, bthreadIdx.x96{( ceilDiv(256, 1) )}_p, bUS97{1}, bS93{8} ] ca_pos( 1 ) produce_pos( 1 );
T14_l[ iblockIdx.x28{i0}, iS112{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x114{( ceilDiv(256, 1) )}_p, iUS115{1}, iS111{8} ] ca_pos( 5 ) produce_pos( 5 )
   = expf(T13_l[ iblockIdx.x26{i0}, iS100{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x102{( ceilDiv(256, 1) )}_p, iUS103{1}, iS99{8} ] ca_pos( 5 ) produce_pos( 5 ));
T5_l[ iblockIdx.x10{i0}, iS76{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x78{( ceilDiv(256, 1) )}_p, iUS79{1}, iV75{8} ] ca_pos( 4 )
   = Set( T0_g[ iS0{i0}, iS70{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, iS72{( ceilDiv(256, 1) )}, iS73{1}, iS69{8} ], cache_op=AllLevels )
T6_l[ iblockIdx.x12{i0}, iS82{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x84{( ceilDiv(256, 1) )}_p, iUS85{1}, iS81{8} ] ca_pos( 5 ) produce_pos( 4 )
   = __half2float(T5_l[ iblockIdx.x10{i0}, iS76{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x78{( ceilDiv(256, 1) )}_p, iUS79{1}, iV75{8} ] ca_pos( 4 ));
T7_l[ iblockIdx.x14{i0}, iS88{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x90{( ceilDiv(256, 1) )}_p, iUS91{1}, iS87{8} ] ca_pos( 5 ) produce_pos( 5 )
   = T6_l[ iblockIdx.x12{i0}, iS82{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x84{( ceilDiv(256, 1) )}_p, iUS85{1}, iS81{8} ] ca_pos( 5 ) produce_pos( 4 )
   - T4_l[ iblockIdx.x8{i0}, bS94{( ceilDiv(( ceilDiv(1, 8) ), 256) )}, bthreadIdx.x96{( ceilDiv(256, 1) )}_p, bUS97{1}, bS93{8} ] ca_pos( 1 ) produce_pos( 1 );
T8_l[ iblockIdx.x16{i0}, iS148{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x150{( ceilDiv(256, 1) )}_p, iUS151{1}, iS147{8} ] ca_pos( 5 ) produce_pos( 5 )
   = expf(T7_l[ iblockIdx.x14{i0}, iS88{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x90{( ceilDiv(256, 1) )}_p, iUS91{1}, iS87{8} ] ca_pos( 5 ) produce_pos( 5 ));
T20_l[ iblockIdx.x164{i0}, rS168{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}rf, ithreadIdx.x170{( ceilDiv(256, 1) )}_p, iUS171{1}, rS167{8}rf ] ca_pos( 1 ) produce_pos( 5 )
   = reduction( T8_l[ iblockIdx.x16{i0}, iS148{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x150{( ceilDiv(256, 1) )}_p, iUS151{1}, iS147{8} ] ca_pos( 5 ) produce_pos( 5 ), op = add, initial value = float(0), allreduce = false )
T9_l[ iblockIdx.x172{i0}, rthreadIdx.x174{( ceilDiv(256, 1) )}_p, rUS175{1} ] ca_pos( 1 ) produce_pos( 1 )
   = reduction( T20_l[ iblockIdx.x164{i0}, rS168{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}rf, ithreadIdx.x170{( ceilDiv(256, 1) )}_p, iUS171{1}, rS167{8}rf ] ca_pos( 1 ) produce_pos( 5 ), op = add, initial value = float(0), allreduce = false )
T10_l[ iblockIdx.x20{i0}, bS130{( ceilDiv(( ceilDiv(1, 8) ), 256) )}, bthreadIdx.x132{( ceilDiv(256, 1) )}_p, bUS133{1}, bS129{8} ] ca_pos( 1 ) produce_pos( 1 )
   = broadcast( T9_l[ iblockIdx.x172{i0}, rthreadIdx.x174{( ceilDiv(256, 1) )}_p, rUS175{1} ] ca_pos( 1 ) produce_pos( 1 ) )
T15_l[ iblockIdx.x30{i0}, bS124{( ceilDiv(( ceilDiv(1, 8) ), 256) )}, bthreadIdx.x126{( ceilDiv(256, 1) )}_p, bUS127{1}, bS123{8} ] ca_pos( 1 ) produce_pos( 1 )
   = reciprocal(T10_l[ iblockIdx.x20{i0}, bS130{( ceilDiv(( ceilDiv(1, 8) ), 256) )}, bthreadIdx.x132{( ceilDiv(256, 1) )}_p, bUS133{1}, bS129{8} ] ca_pos( 1 ) produce_pos( 1 ));
T16_l[ iblockIdx.x32{i0}, iS118{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x120{( ceilDiv(256, 1) )}_p, iUS121{1}, iS117{8} ] ca_pos( 5 ) produce_pos( 5 )
   = T14_l[ iblockIdx.x28{i0}, iS112{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x114{( ceilDiv(256, 1) )}_p, iUS115{1}, iS111{8} ] ca_pos( 5 ) produce_pos( 5 )
   * T15_l[ iblockIdx.x30{i0}, bS124{( ceilDiv(( ceilDiv(1, 8) ), 256) )}, bthreadIdx.x126{( ceilDiv(256, 1) )}_p, bUS127{1}, bS123{8} ] ca_pos( 1 ) produce_pos( 1 );
T17_l[ iblockIdx.x34{i0}, iS136{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x138{( ceilDiv(256, 1) )}_p, iUS139{1}, iS135{8} ] ca_pos( 4 ) produce_pos( 5 )
   = __float2half(T16_l[ iblockIdx.x32{i0}, iS118{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x120{( ceilDiv(256, 1) )}_p, iUS121{1}, iS117{8} ] ca_pos( 5 ) produce_pos( 5 ));
T18_g[ iblockIdx.x36{i0}, iS142{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x144{( ceilDiv(256, 1) )}_p, iUS145{1}, iV141{8} ] ca_pos( 4 ) produce_pos( 4 )
   = Set( T17_l[ iblockIdx.x34{i0}, iS136{( ceilDiv(( ceilDiv(i2, 8) ), 256) )}, ithreadIdx.x138{( ceilDiv(256, 1) )}_p, iUS139{1}, iS135{8} ] ca_pos( 4 ) produce_pos( 5 ), cache_op=Streaming )
}

PRINTING: __tmp_kernel1.cu
ptxas info    : 3 bytes gmem
ptxas info    : Compiling entry function '_ZN11CudaCodeGen7kernel1ENS_6TensorINS_6__halfELi2ELi2EEES2_' for 'sm_90'
ptxas info    : Function properties for _ZN11CudaCodeGen7kernel1ENS_6TensorINS_6__halfELi2ELi2EEES2_
ptxas         .     0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 40 registers

Launch Parameters: BlockDim.x = 256, BlockDim.y = -1, BlockDim.z = -1, GridDim.x = 32768, GridDim.y = -1, GridDim.z = -1, Smem Size = 1024
blocks_per_sm= 6, warps_per_sm= 48, occupancy= 75.00%
kernel1 run in 0.939264 ms, achieved: 2572.14 GB/s
```