### PR TITLE
Preserve expanded broadcasts in reshape

### DIFF
--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -225,7 +225,8 @@ class MergeTransform final : public ViewTransform {
         "Didn't expect to apply view transformations on an iter domain",
         " starting at a non-zero position.");
 
-    auto merged_extent = mul(outer_id->extent(), inner_id->extent());
+    auto merged_extent = SimplifyingIrBuilder::mulExpr(outer_id->extent(),
+        inner_id->extent());
     // Note: SimplifyingIrBuilder handles properly the cases where one or both
     // of the IDs has a null expanded extent: if both are null, the result is
     // null, and if either is null the result is the non-null argument.
@@ -236,7 +237,7 @@ class MergeTransform final : public ViewTransform {
         IterDomainBuilder(FusionGuard::getCurFusion()->zeroVal(), merged_extent)
             .iter_type(iter_type)
             .extent(merged_extent)
-            .extent(merged_expanded_extent)
+            .expanded_extent(merged_expanded_extent)
             .is_rfactor_domain(true)
             .build();
 


### PR DESCRIPTION
Currently, we always "realize" expanded broadcasts (replace them with `Iteration` domains) during reshape if they appear in a split or merge transform. This is not always necessary, for example we never need to do this for a `SplitTransform`, and we can avoid it for a `MergeTransform` if both inner and outer IDs are `Broadcast`. This PR makes that a reality.

Fixes #1126.