### PR TITLE
Forbid non-tensor outputs.

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -249,10 +249,6 @@ void FusionExecutor::compileFusion(
       !fusion->outputs().empty(), "No output found for this kernel, aborting.");
 
   for (auto out : fusion->outputs()) {
-    NVF_ERROR(
-        out->getValType() == ValType::TensorView,
-        "Output types from fusions that are not tensors are not supported at this point.");
-
     const auto maybe_rfactor_domain =
         out->as<TensorView>()->getMaybeRFactorDomain();
     // walking through outputs to see if output shapes are dependent on

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -243,10 +243,12 @@ void Fusion::addOutput(Val* output) {
   // NVF_CHECK(io_alias_.count(output) == 0,
   //     "can't register aliased output as real output");
   assertInContainer(output, "Cannot register output ");
-  if (output->getValType().value() == ValType::TensorView) {
-    auto tv = output->as<TensorView>();
-    tv->setMemoryType(MemoryType::Global);
-  }
+  NVF_CHECK(
+      output->getValType() == ValType::TensorView,
+      "Non-TensorView outputs are not supported at this point.");
+
+  auto tv = output->as<TensorView>();
+  tv->setMemoryType(MemoryType::Global);
   outputs_.push_back(output);
   output->setIsFusionOutput(true);
 

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -243,12 +243,16 @@ void Fusion::addOutput(Val* output) {
   // NVF_CHECK(io_alias_.count(output) == 0,
   //     "can't register aliased output as real output");
   assertInContainer(output, "Cannot register output ");
-  NVF_CHECK(
-      output->getValType() == ValType::TensorView,
-      "Non-TensorView outputs are not supported at this point.");
+  if (output->isA<TensorView>()) {
+    output->as<TensorView>()->setMemoryType(MemoryType::Global);
+  } else {
+    NVF_CHECK(
+        output->isA<PipelineVal>() &&
+            output->as<PipelineVal>()->getOriginalVal()->isA<TensorView>(),
+        "Non-TensorView outputs are not supported at this point: ",
+        output->toString());
+  }
 
-  auto tv = output->as<TensorView>();
-  tv->setMemoryType(MemoryType::Global);
   outputs_.push_back(output);
   output->setIsFusionOutput(true);
 

--- a/csrc/multidevice/pipeline_ir.cpp
+++ b/csrc/multidevice/pipeline_ir.cpp
@@ -119,8 +119,10 @@ NVFUSER_DEFINE_CLONE(PipelineVal)
 std::string PipelineVal::toString(int indent_size) const {
   std::stringstream ss;
   ss << "PipelineVal representing Val "
-     << getOriginalVal()->toString(indent_size) << " on stage "
-     << getStage()->descriptor()->unique_id;
+     << getOriginalVal()->toString(indent_size);
+  if (getStage() != nullptr) {
+    ss << " on stage " << getStage()->descriptor()->unique_id;
+  }
   return ss.str();
 }
 

--- a/test/test_gpu1.cpp
+++ b/test/test_gpu1.cpp
@@ -482,13 +482,13 @@ TEST_F(NVFuserTest, FusionTopoSort_CUDA) {
   // e1: v4     =   add(v3, v2)
   // e2: v5     =   add(v2, v4)
   // e3: v6     =   add(v5, v5)
-  Val* v0 = IrBuilder::create<Val>(DataType::Double);
-  Val* v1 = IrBuilder::create<Val>(DataType::Double);
-  Val* v2 = IrBuilder::create<Val>(DataType::Double);
-  Val* v3 = IrBuilder::create<Val>(DataType::Double);
-  Val* v4 = IrBuilder::create<Val>(DataType::Double);
-  Val* v5 = IrBuilder::create<Val>(DataType::Double);
-  Val* v6 = IrBuilder::create<Val>(DataType::Double);
+  Val* v0 = makeContigTensor(0, DataType::Double);
+  Val* v1 = makeContigTensor(0, DataType::Double);
+  Val* v2 = makeContigTensor(0, DataType::Double);
+  Val* v3 = makeContigTensor(0, DataType::Double);
+  Val* v4 = makeContigTensor(0, DataType::Double);
+  Val* v5 = makeContigTensor(0, DataType::Double);
+  Val* v6 = makeContigTensor(0, DataType::Double);
 
   std::vector<Val*> inputs = {v0, v1};
   for (auto val : inputs) {


### PR DESCRIPTION
Previously, the check was done only at `FusionExecutor::compileFusion`. However, the segmenter [skips non-tensor
outputs](https://github.com/NVIDIA/Fuser/blob/bce26ef4589066bd9765cea2ca61254031cd26a3/csrc/fusion_segmenter.cpp#L3286) before `FusionExecutor::compileFusion` sees them. This happens for users of the higher-level `FusionExecutorCache`.

The only exception is that we allow PipelineVal whose original value is a TensorView. 

Fixes #1172.