### PR TITLE
Refactor matmul benchmarks for better code reuse

### DIFF
--- a/benchmark/matmul.cpp
+++ b/benchmark/matmul.cpp
@@ -374,7 +374,7 @@ static void MatmulShapeWarpStage(
       ->Unit(benchmark::kMicrosecond)                                         \
       ->UseManualTime()                                                       \
       ->Apply([](benchmark::internal::Benchmark* b) {                         \
-        return MatmulShape(                                                   \
+        MatmulShape(                                                   \
             b, sizeProduct<long int>(LegacyMs, LegacyNs, LegacyKs));          \
       });                                                                     \
   BENCHMARK_CAPTURE(                                                          \

--- a/benchmark/matmul.cpp
+++ b/benchmark/matmul.cpp
@@ -374,15 +374,14 @@ static void MatmulShapeWarpStage(
       ->Unit(benchmark::kMicrosecond)                                         \
       ->UseManualTime()                                                       \
       ->Apply([](benchmark::internal::Benchmark* b) {                         \
-        MatmulShape(                                                   \
-            b, sizeProduct<long int>(LegacyMs, LegacyNs, LegacyKs));          \
+        MatmulShape(b, sizeProduct<long int>(LegacyMs, LegacyNs, LegacyKs));  \
       });                                                                     \
   BENCHMARK_CAPTURE(                                                          \
       Baseline_Matmul, eagermode_timmshapes_##layout, MatmulLayout::layout)   \
       ->Unit(benchmark::kMicrosecond)                                         \
       ->UseManualTime()                                                       \
       ->Apply([](benchmark::internal::Benchmark* b) {                         \
-        MatmulShape(b, TIMMShapes);                                    \
+        MatmulShape(b, TIMMShapes);                                           \
       });
 
 #define NvfuserMatmulBenchmark(layout)                               \
@@ -393,7 +392,7 @@ static void MatmulShapeWarpStage(
       ->Unit(benchmark::kMicrosecond)                                \
       ->UseManualTime()                                              \
       ->Apply([](benchmark::internal::Benchmark* b) {                \
-        MatmulShapeWarpStage(                                 \
+        MatmulShapeWarpStage(                                        \
             b, sizeProduct<long int>(LegacyMs, LegacyNs, LegacyKs)); \
       });                                                            \
   BENCHMARK_CAPTURE(                                                 \
@@ -403,7 +402,7 @@ static void MatmulShapeWarpStage(
       ->Unit(benchmark::kMicrosecond)                                \
       ->UseManualTime()                                              \
       ->Apply([](benchmark::internal::Benchmark* b) {                \
-        MatmulShapeWarpStage(b, TIMMShapes);                  \
+        MatmulShapeWarpStage(b, TIMMShapes);                         \
       });
 
 #define ForAllLayouts(run) \

--- a/benchmark/matmul.cpp
+++ b/benchmark/matmul.cpp
@@ -382,7 +382,7 @@ static void MatmulShapeWarpStage(
       ->Unit(benchmark::kMicrosecond)                                         \
       ->UseManualTime()                                                       \
       ->Apply([](benchmark::internal::Benchmark* b) {                         \
-        return MatmulShape(b, TIMMShapes);                                    \
+        MatmulShape(b, TIMMShapes);                                    \
       });
 
 #define NvfuserMatmulBenchmark(layout)                               \
@@ -393,7 +393,7 @@ static void MatmulShapeWarpStage(
       ->Unit(benchmark::kMicrosecond)                                \
       ->UseManualTime()                                              \
       ->Apply([](benchmark::internal::Benchmark* b) {                \
-        return MatmulShapeWarpStage(                                 \
+        MatmulShapeWarpStage(                                 \
             b, sizeProduct<long int>(LegacyMs, LegacyNs, LegacyKs)); \
       });                                                            \
   BENCHMARK_CAPTURE(                                                 \
@@ -403,7 +403,7 @@ static void MatmulShapeWarpStage(
       ->Unit(benchmark::kMicrosecond)                                \
       ->UseManualTime()                                              \
       ->Apply([](benchmark::internal::Benchmark* b) {                \
-        return MatmulShapeWarpStage(b, TIMMShapes);                  \
+        MatmulShapeWarpStage(b, TIMMShapes);                  \
       });
 
 #define ForAllLayouts(run) \


### PR DESCRIPTION
This refactors the matmul benchmarks. Currently we have separate functions for each combination of number of warps per block and number of double-buffering stages. Instead, these are now parameters passed along in `benchmark_state`. This PR also provides names for the args so that instead of `Baseline_Matmul/no_quant_eagermode_TT_Legacy/2048/3456/512/manual_time ` we have
`Baseline_Matmul/eagermode_legacyshapes_TT/M:2048/N:3456/K:512/manual_time` and instead of `NvFuserScheduler_Matmul_4warp4stage/no_quant_nvfuser_4warp_NT_TIMM/512/2048/128/manual_time` we have `NvFuserScheduler_Matmul/nvfuser_timmshapes_NT/M:512/N:2048/K:128/warps:4/stages:4/manual_time `