### PR TITLE
Don't serialize I/O aliases for FusionCache. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/optimization/add_axioms.cpp
   ${NVFUSER_SRCS_DIR}/optimization/alias_analysis.cpp
   ${NVFUSER_SRCS_DIR}/optimization/consecutive_cast.cpp
+  ${NVFUSER_SRCS_DIR}/optimization/mark_alias.cpp
   ${NVFUSER_SRCS_DIR}/optimization/pre_segmenter.cpp
   ${NVFUSER_SRCS_DIR}/optimization/remove_empty.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/test/test_tutorial.cpp
     ${NVFUSER_ROOT}/test/test_alias_analysis.cpp
     ${NVFUSER_ROOT}/test/test_scalar_hoisting.cpp
+    ${NVFUSER_ROOT}/test/test_no_op.cpp
   )
 
   if(BUILD_PYTHON)

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -905,6 +905,12 @@ at::Tensor transformOutputFromAllocationToRFactor(
   return tensor.permute(dims);
 }
 
+int64_t IndexOfFusionInput(const Val* in, const Fusion* fusion) {
+  auto i = std::find(fusion->inputs().begin(), fusion->inputs().end(), in);
+  NVF_ERROR(i != fusion->inputs().end());
+  return std::distance(fusion->inputs().begin(), i);
+}
+
 } // namespace
 
 // Allocate output tensors for a given kernel. Outputs may alias inputs, in
@@ -912,7 +918,6 @@ at::Tensor transformOutputFromAllocationToRFactor(
 std::vector<at::Tensor> allocOutputs(
     const kir::Kernel* kernel,
     const std::vector<FusionExecutor::GlobalBufferInfo>& output_info,
-    const std::vector<InputOutputAlias>& input_output_aliases,
     const KernelArgumentHolder& inputs,
     const c10::Device& device,
     ExpressionEvaluator& ee) {
@@ -923,23 +928,18 @@ std::vector<at::Tensor> allocOutputs(
   for (const auto output_idx : c10::irange(output_info.size())) {
     const auto& buf_info = output_info.at(output_idx);
 
-    auto alias_it = std::find_if(
-        input_output_aliases.begin(),
-        input_output_aliases.end(),
-        [&](const InputOutputAlias& input_output_alias) {
-          return input_output_alias.out == static_cast<int64_t>(output_idx);
-        });
-
+    auto alias_it = kernel->ioAlias().find(kernel->outputs()[output_idx]);
     // Note: aliased output is not returned as output. But we still need it
     // for kernel execution, so would need to push them to args
-    if (alias_it != input_output_aliases.end()) {
-      const auto aliased_input_index = alias_it->in;
+    if (alias_it != kernel->ioAlias().end()) {
+      const auto aliased_input_index =
+          IndexOfFusionInput(alias_it->second.first, kernel);
       NVF_ERROR(
           inputs[aliased_input_index]->is<at::Tensor>(),
           "alias io only supports tensor");
       at::Tensor input_tensor = inputs[aliased_input_index]->as<at::Tensor>();
 
-      switch (alias_it->info.type) {
+      switch (alias_it->second.second.type) {
         case AliasType::InplaceUpdate:
           // Unlike for `AliasType::PointerCast`, don't use
           // ExpressionEvaluator to compute the output tensor. This is because
@@ -983,14 +983,8 @@ std::vector<at::Tensor> allocOutputs(
       // A trivial forwarding output can be "allocated" similarly to an output
       // alias. TODO: we can teach alias analysis to mark trivial forwarding so
       // we can consolidate this case with the case above.
-      auto alias_it = std::find(
-          kernel->inputs().begin(),
-          kernel->inputs().end(),
-          kernel->outputs().at(output_idx));
-      NVF_ERROR(alias_it != kernel->inputs().end());
-
       const auto aliased_input_index =
-          std::distance(kernel->inputs().begin(), alias_it);
+          IndexOfFusionInput(kernel->outputs().at(output_idx), kernel);
       NVF_ERROR(
           inputs[aliased_input_index]->is<at::Tensor>(),
           "alias io only supports tensor");
@@ -1468,16 +1462,6 @@ void FusionExecutor::initializeExecutorEntry(
   executor_utils::validateVectorizedTensors(
       kernel(), args, outputs, compileTimeDataCache(), expr_eval);
 
-  auto input_output_aliases_entry =
-      executor_utils::caching::ExecutorCompileTimeEntry<
-          executor_utils::caching::InputOutputAliases>(
-          compileTimeDataCache(), [&]() {
-            return std::make_unique<std::vector<InputOutputAlias>>(
-                fusion_->getOutputToInputAliasIndices());
-          });
-
-  const auto& input_output_aliases = input_output_aliases_entry.get();
-
   std::vector<GlobalBufferInfo> output_info;
 
   if (outputs.empty()) {
@@ -1495,7 +1479,6 @@ void FusionExecutor::initializeExecutorEntry(
 
   // All information is gathered. Save it to ExecutorEntry
   executor_entry.launch_params = launch_params;
-  executor_entry.input_output_aliases = input_output_aliases;
   executor_entry.outputs = output_info;
   executor_entry.intermediates = intermediates;
   executor_entry.init = true;
@@ -1660,12 +1643,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
   // only allocate outputs when not given
   if (outputs.empty()) {
     outputs = allocOutputs(
-        kernel(),
-        executor_entry->outputs,
-        executor_entry->input_output_aliases,
-        args,
-        options_.device,
-        expr_eval);
+        kernel(), executor_entry->outputs, args, options_.device, expr_eval);
   } else {
     // TODO: Use validateKernelOutputs
     NVF_ERROR(
@@ -2020,28 +1998,10 @@ flatbuffers::Offset<serde::CudaKernel> FusionExecutor::serialize(
   return ckb.Finish();
 }
 
-flatbuffers::Offset<serde::InputOutputAlias> FusionExecutor::serialize(
-    flatbuffers::FlatBufferBuilder& builder,
-    const InputOutputAlias& alias) const {
-  return serde::CreateInputOutputAlias(
-      builder,
-      alias.out,
-      alias.in,
-      toUnderlying(alias.info.type),
-      alias.info.hide_output);
-}
-
 flatbuffers::Offset<serde::ExecutorEntry> FusionExecutor::serialize(
     flatbuffers::FlatBufferBuilder& builder,
     const ExecutorEntry& data) const {
   // See table definition for ExecutorEntry in serde/fusion_cache.fbs
-
-  using fb_input_output_alias = flatbuffers::Offset<serde::InputOutputAlias>;
-  std::vector<fb_input_output_alias> input_output_alias_fb;
-  input_output_alias_fb.reserve(data.input_output_aliases.size());
-  for (const InputOutputAlias& input_output_alias : data.input_output_aliases) {
-    input_output_alias_fb.push_back(serialize(builder, input_output_alias));
-  }
 
   // Serialize GlobalBufferInfo for outputs.
   // We map the output TensorView pointer to its corresponding position in
@@ -2086,7 +2046,6 @@ flatbuffers::Offset<serde::ExecutorEntry> FusionExecutor::serialize(
       builder,
       data.init,
       data.launch_params.serialize(builder),
-      &input_output_alias_fb,
       &outputs_fb,
       &intermediates_fb);
 }
@@ -2162,10 +2121,6 @@ FusionExecutor::ExecutorEntry FusionExecutor::deserialize(
 
   entry.launch_params.deserialize(buffer->launch_params());
 
-  for (auto output_buffer : *buffer->input_output_alias()) {
-    entry.input_output_aliases.push_back(deserialize(output_buffer));
-  }
-
   for (auto output_buffer : *buffer->outputs()) {
     entry.outputs.push_back(deserialize(output_buffer));
   }
@@ -2175,15 +2130,6 @@ FusionExecutor::ExecutorEntry FusionExecutor::deserialize(
   }
 
   return entry;
-}
-
-// FIXME: Can InputOutputAlias take Val* instead? Even better, just be a map.
-InputOutputAlias FusionExecutor::deserialize(
-    const serde::InputOutputAlias* buffer) {
-  return InputOutputAlias{
-      buffer->out(),
-      buffer->in(),
-      AliasInfo{static_cast<AliasType>(buffer->type()), buffer->hide_output()}};
 }
 
 FusionExecutor::GlobalBufferInfo FusionExecutor::deserialize(

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -141,8 +141,6 @@ class FusionExecutor : public NonCopyable {
   struct ExecutorEntry {
     bool init = false;
     LaunchParams launch_params;
-    // Aliased output and input mappings
-    std::vector<InputOutputAlias> input_output_aliases;
     std::vector<GlobalBufferInfo> outputs;
     // Temporary work buffers and intemediate global-memory tensors
     std::vector<GlobalBufferInfo> intermediates;
@@ -364,12 +362,6 @@ class FusionExecutor : public NonCopyable {
 
   //! Deserialize GlobalBufferInfo using flatbuffers
   GlobalBufferInfo deserialize(const serde::GlobalBufferInfo* buffer);
-
-  flatbuffers::Offset<serde::InputOutputAlias> serialize(
-      flatbuffers::FlatBufferBuilder& builder,
-      const InputOutputAlias& input_output_alias) const;
-
-  InputOutputAlias deserialize(const serde::InputOutputAlias* buffer);
 
   //! Get the current dynamic shared memory size
   int64_t getAvailableDynamicSmemSize();

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -1433,7 +1433,6 @@ ExecutorCompileTimeEntry<EntryClass>::ExecutorCompileTimeEntry(
 template class ExecutorCompileTimeEntry<ParallelBindingIterDomains>;
 template class ExecutorCompileTimeEntry<ParallelIterExtentMap>;
 template class ExecutorCompileTimeEntry<VectorizedTensorValidation>;
-template class ExecutorCompileTimeEntry<InputOutputAliases>;
 
 } // namespace caching
 

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -146,16 +146,6 @@ class VectorizedTensorValidation {
       CompileTimeEntryType::VECTORIZED_TENSOR_VALIDATION;
 };
 
-//! Compile-time info to be cached in each FusionExecutor:
-//!  InputOutputAliases
-//!    Stores position info of aliased input tensors
-class InputOutputAliases {
- public:
-  using DataType = std::vector<InputOutputAlias>;
-  static const CompileTimeEntryType EntryType =
-      CompileTimeEntryType::INPUT_ALIAS_INDICES;
-};
-
 //! Base abstract class for unified storage in `ExecutorCompileTimeInfoCache`,
 //!  each entry in `ExecutorCompileTimeInfoCache` will be a subclass.
 class CompileTimeInfoBase : public PolymorphicBase {

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -803,40 +803,6 @@ std::pair<Val*, const AliasInfo*> Fusion::getOutputAlias(Val* output) {
   return {nullptr, nullptr};
 }
 
-std::vector<InputOutputAlias> Fusion::getOutputToInputAliasIndices() const {
-  if (io_alias_.empty()) {
-    return {};
-  }
-
-  std::unordered_map<const Val*, size_t> in_val_index, out_val_index;
-  for (const auto input_idx : c10::irange(inputs_.size())) {
-    in_val_index[inputs_[input_idx]] = input_idx;
-  }
-  for (const auto output_idx : c10::irange(outputs_.size())) {
-    out_val_index[outputs_[output_idx]] = output_idx;
-  }
-
-  std::vector<InputOutputAlias> input_output_aliases;
-  input_output_aliases.reserve(io_alias_.size());
-  for (const auto& [out, in_info] : io_alias_) {
-    if (!out_val_index.count(out)) {
-      // Can't assert false here. We may have segmented fusion where not all
-      // alias outputs are present.
-      continue;
-    }
-    const Val* in = in_info.first;
-    NVF_ERROR(
-        in_val_index.count(in),
-        in->toString(),
-        " is marked as an input alias but isn't a fusion input.");
-    input_output_aliases.push_back(InputOutputAlias{
-        static_cast<int>(out_val_index.at(out)),
-        static_cast<int>(in_val_index.at(in)),
-        in_info.second});
-  }
-  return input_output_aliases;
-}
-
 bool Fusion::hasDynamicTransform() {
   return !ir_utils::getTVsWithDynamicTransform(this).empty();
 }

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -318,18 +318,17 @@ bool Fusion::isNoOp() {
     return true;
   }
   for (auto out_tv : ir_utils::filterByType<TensorView>(outputs())) {
-    auto root_dom = TensorDomain::noReductions(out_tv->getMaybeRFactorDomain());
-    bool size_zero = false;
-    for (auto id : root_dom) {
-      if (id->extent()->isConstScalar() && id->extent()->evaluate() == 0) {
-        size_zero = true;
-        break;
-      }
-    }
+    const std::vector<IterDomain*>& root_dom =
+        TensorDomain::noReductions(out_tv->getMaybeRFactorDomain());
+    const bool size_zero =
+        std::any_of(root_dom.begin(), root_dom.end(), [](IterDomain* id) {
+          return id->extent()->isConstScalar() && id->extent()->evaluate() == 0;
+        });
     if (!size_zero) {
       return false;
     }
   }
+
   return true;
 }
 

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -102,12 +102,6 @@ struct AliasInfo {
   bool hide_output;
 };
 
-struct InputOutputAlias {
-  int64_t out;
-  int64_t in;
-  AliasInfo info;
-};
-
 //! Fusion is mutable but unique. Nodes cannot be copied in any way from one
 //! Fusion to another. If anything like that is desired, it would require
 //! duplicating all associated values and exprs. Fusion is considered to be SSA,
@@ -251,13 +245,6 @@ class Fusion : public IrContainer {
   //! describing how they alias. Returns <nullptr,nullptr> when `output` is not
   //! aliased.
   std::pair<Val*, const AliasInfo*> getOutputAlias(Val* output);
-
-  //! Get alias mappings from fusion outputs to inputs
-  //
-  // TODO: this method is only used for serialization. We should be able to get
-  // rid of it and serialize the alias map to
-  // `serde::ExecutorEntry::input_output_alias` directly.
-  std::vector<InputOutputAlias> getOutputToInputAliasIndices() const;
 
   // mark input at index to be permuted by permutation
   void setPermutationOnInput(int index, std::vector<int64_t> permutation) {

--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -132,8 +132,9 @@ const Val* AliasAnalysisResult::findRoot(const Val* alias) const {
     return nullptr;
   }
 
-  for (; alias_to_source_.count(root); root = alias_to_source_.at(root))
-    ;
+  while (alias_to_source_.count(root)) {
+    root = alias_to_source_.at(root);
+  }
   return root;
 }
 

--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -132,6 +132,8 @@ const Val* AliasAnalysisResult::findRoot(const Val* alias) const {
     return nullptr;
   }
 
+  // This can be made faster by path compression at the cost of losing
+  // the potentially useful immediate sources. Go simple for now.
   while (alias_to_source_.count(root)) {
     root = alias_to_source_.at(root);
   }

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -19,6 +19,7 @@ class AliasAnalysisResult {
   // Returns itself if `alias` doesn't alias anything.
   const Val* findRoot(const Val* alias) const;
 
+  // Marks `source` as the immediate aliasing source of `alias`.
   void add(const TensorView* alias, const TensorView* source);
 
   AliasAnalysisResult(const AliasAnalysisResult&) = delete;

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -12,12 +12,27 @@
 
 namespace nvfuser::optimization {
 
-// Maps aliases (e.g. the output of a View) to their direct sources (e.g. the
-// input of the same View). Consider path compression, a common optimization
-// used in disjoint-set data structure, so it's easy to figure out the root of
-// an alias.
-using AliasAnalysisResult =
-    std::unordered_map<const TensorView*, const TensorView*>;
+class AliasAnalysisResult {
+ public:
+  AliasAnalysisResult() {}
+
+  // Returns itself if `alias` doesn't alias anything.
+  const Val* findRoot(const Val* alias) const;
+
+  void add(const TensorView* alias, const TensorView* source);
+
+  AliasAnalysisResult(const AliasAnalysisResult&) = delete;
+  AliasAnalysisResult& operator=(const AliasAnalysisResult&) = delete;
+  AliasAnalysisResult(AliasAnalysisResult&&) = default;
+  AliasAnalysisResult& operator=(AliasAnalysisResult&&) = default;
+
+ private:
+  // Maps aliases (e.g. the output of a View) to their direct sources (e.g. the
+  // input of the same View). Consider path compression, a common optimization
+  // used in disjoint-set data structure, so it's easy to figure out the root of
+  // an alias.
+  std::unordered_map<const TensorView*, const TensorView*> alias_to_source_;
+};
 
 // Finds aliases of the fusion inputs.
 AliasAnalysisResult findAliases(Fusion* fusion);

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -14,7 +14,7 @@ namespace nvfuser::optimization {
 
 class AliasAnalysisResult {
  public:
-  AliasAnalysisResult() {}
+  AliasAnalysisResult() = default;
 
   // Returns itself if `alias` doesn't alias anything.
   const Val* findRoot(const Val* alias) const;

--- a/csrc/optimization/mark_alias.cpp
+++ b/csrc/optimization/mark_alias.cpp
@@ -16,9 +16,12 @@ void MarkAliasPass::runPass(Fusion* fusion) {
 
   const AliasAnalysisResult alias_analysis = findAliases(fusion);
   for (Val* out : fusion->outputs()) {
-    if (Val* in = const_cast<Val*>(alias_analysis.findRoot(out));
-        in->isFusionInput()) {
-      fusion->aliasOutputToInput(out, in, AliasType::PointerCast);
+    if (const Val* in = alias_analysis.findRoot(out); in->isFusionInput()) {
+      fusion->aliasOutputToInput(
+          out,
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          const_cast<Val*>(in),
+          AliasType::PointerCast);
     }
   }
 }

--- a/csrc/optimization/mark_alias.cpp
+++ b/csrc/optimization/mark_alias.cpp
@@ -1,0 +1,26 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <ir/utils.h>
+#include <optimization/alias_analysis.h>
+#include <optimization/mark_alias.h>
+
+namespace nvfuser::optimization {
+
+void MarkAliasPass::runPass(Fusion* fusion) {
+  fusion->print();
+
+  const AliasAnalysisResult alias_analysis = findAliases(fusion);
+  for (Val* out : fusion->outputs()) {
+    if (Val* in = const_cast<Val*>(alias_analysis.findRoot(out));
+        in->isFusionInput()) {
+      fusion->aliasOutputToInput(out, in, AliasType::PointerCast);
+    }
+  }
+}
+
+} // namespace nvfuser::optimization

--- a/csrc/optimization/mark_alias.h
+++ b/csrc/optimization/mark_alias.h
@@ -9,6 +9,7 @@
 
 namespace nvfuser::optimization {
 
+// Marks aliases between fusion inputs and outputs.
 class MarkAliasPass : public OptimizationPass<MarkAliasPass> {
   friend class OptimizationPass<MarkAliasPass>;
 

--- a/csrc/optimization/mark_alias.h
+++ b/csrc/optimization/mark_alias.h
@@ -1,0 +1,19 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <optimization/optimization_pass.h>
+
+namespace nvfuser::optimization {
+
+class MarkAliasPass : public OptimizationPass<MarkAliasPass> {
+  friend class OptimizationPass<MarkAliasPass>;
+
+ protected:
+  static void runPass(Fusion* fusion);
+};
+
+} // namespace nvfuser::optimization

--- a/csrc/optimization/pre_segmenter.cpp
+++ b/csrc/optimization/pre_segmenter.cpp
@@ -9,6 +9,7 @@
 
 #include <optimization/add_axioms.h>
 #include <optimization/consecutive_cast.h>
+#include <optimization/mark_alias.h>
 #include <optimization/remove_empty.h>
 
 namespace nvfuser::optimization {
@@ -19,6 +20,7 @@ void PreSegmenter::runPass(Fusion* fusion) {
   // removes consecutive cast operations
   OptimizationPass<ConsecutiveCastPass>::runPass(fusion);
   OptimizationPass<AddAxiomsPass>::runPass(fusion);
+  OptimizationPass<MarkAliasPass>::runPass(fusion);
 }
 
 } // namespace nvfuser::optimization

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -25,6 +25,7 @@ bool NoOpScheduler::canScheduleCompileTime(Fusion* fusion) {
   if (fusion->isNoOp()) {
     return true;
   }
+
   // Check there're no non-trivial reduction ops.
   for (auto reduction : ir_utils::getAllTypesOfReductionOps(fusion)) {
     for (auto output :

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -230,18 +230,10 @@ table GlobalBufferInfo {
   is_fusion_output : bool;
 }
 
-table InputOutputAlias {
-  out: long;
-  in: long;
-  type: int;
-  hide_output: bool;
-}
-
 // This table describes the cached ExecutorEntry for a kernel.
 table ExecutorEntry {
   init : bool;
   launch_params : LaunchParams;
-  input_output_alias: [InputOutputAlias];
   outputs : [GlobalBufferInfo];
   intermediates : [GlobalBufferInfo];
 }

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2641,8 +2641,9 @@ class TestNvFuserFrontend(TestCase):
         )
         self.assertEqual(nvf_out[0], torch_ref)
 
-    # This test exercises serialization/deserialization of Fusion::io_alias_.
-    def test_alias(self):
+    # This test verifies aliases added by MarkAliasPass are still in effect
+    # after serialization and deserialization.
+    def test_mark_alias_pass(self):
         def reshape(fd: FusionDefinition) -> None:
             x = fd.define_tensor([2, 3, 4], contiguity=[True, True, True],
                                  dtype=DataType.Float)

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2645,8 +2645,9 @@ class TestNvFuserFrontend(TestCase):
     # after serialization and deserialization.
     def test_mark_alias_pass(self):
         def reshape(fd: FusionDefinition) -> None:
-            x = fd.define_tensor([2, 3, 4], contiguity=[True, True, True],
-                                 dtype=DataType.Float)
+            x = fd.define_tensor(
+                [2, 3, 4], contiguity=[True, True, True], dtype=DataType.Float
+            )
             y = fd.ops.reshape(x, [2, 12])
             fd.add_output(y)
 

--- a/test/test_no_op.cpp
+++ b/test/test_no_op.cpp
@@ -201,33 +201,22 @@ TEST_F(NoOpTest, View) {
   fusion->addInput(in);
   TensorView* out = reshape(in, in_shape, out_shape);
   fusion->addOutput(out);
-  fusion->aliasOutputToInput(out, in, AliasType::PointerCast);
-
-  FusionExecutor fe;
-  at::Tensor in_tensor =
-      at::randn({2, 3, 4}, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  fe.compileFusion(fusion.get(), {in_tensor});
-  at::Tensor out_tensor = fe.runFusion({in_tensor})[0];
-  EXPECT_EQ(in_tensor.data_ptr<float>(), out_tensor.data_ptr<float>());
-  testValidate(
-      fusion.get(),
-      {out_tensor},
-      {in_tensor},
-      {in_tensor.view({2, 12})},
-      __LINE__,
-      __FILE__);
 
   FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor =
+      at::randn({2, 3, 4}, at::dtype(at::kFloat).device(at::kCUDA, 0));
   std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
-  out_tensor = out_tensors[0];
-  EXPECT_EQ(in_tensor.data_ptr<float>(), out_tensor.data_ptr<float>());
+  at::Tensor out_tensor = out_tensors[0];
 
+  // Verify aliasing.
+  EXPECT_EQ(in_tensor.data_ptr(), out_tensor.data_ptr());
+
+  // Verify the NoOp scheduler was kicked in.
   const std::vector<SegmentedGroup*>& groups =
       fec.getMostRecentKernelRuntime()->fusionSegments()->groups();
   ASSERT_EQ(groups.size(), 1);
   SegmentedGroup* group = groups[0];
-
   EXPECT_EQ(group->heuristic(), ScheduleHeuristic::NoOp);
 }
 


### PR DESCRIPTION
Instead, use `kernel->ioAlias()`. I believe this doesn't break anything: 
1. Aliases added when building `FusionDefinition`s (e.g. by calling `fd.ops.batch_norm` or `fd.add_output(..., alias_input=...)`) are replayed by `RecordFunctors`. 
2. Aliases added during scheduling or later (e.g. by `MarkAliasPass`) are re-added by optimization passes or schedulers.

We already have `test_alias_output_to_input` for case 1, and this PR added `test_mark_alias_pass` for case 2. 