### PR TITLE
Matmul scheduler - tests for forward fusions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ include(cmake/FlatBuffers.cmake)
 include(cmake/Dependencies.cmake)
 
 # set CUDA_ARCH for cu tests.
-if(EXISTS ${TORCH_CUDA_ARCH_LIST})
+if(TORCH_CUDA_ARCH_LIST)
   set(ARCH_FLAGS)
   cuda_select_nvcc_arch_flags(ARCH_FLAGS ${TORCH_CUDA_ARCH_LIST})
   list(APPEND CUDA_NVCC_FLAGS ${ARCH_FLAGS})

--- a/test/test_fusion_profiler.cpp
+++ b/test/test_fusion_profiler.cpp
@@ -21,11 +21,10 @@
 
 namespace nvfuser {
 
-namespace {
-
-class ProfilingOptsManager {
- public:
-  ProfilingOptsManager() {
+class FusionProfilerTest : public NVFuserTest {
+ protected:
+  void SetUp() override {
+    NVFuserTest::SetUp();
     if (ProfilerOptionsGuard::getCurOptions().hasAny()) {
       const auto& current_profiling_opts =
           ProfilerOptionsGuard::getCurOptions();
@@ -41,7 +40,8 @@ class ProfilingOptsManager {
       }
     }
   }
-  ~ProfilingOptsManager() {
+
+  void TearDown() override {
     if (ProfilerOptionsGuard::getCurOptions().hasAny() ||
         !stored_data_.empty()) {
       auto& current_profiling_opts = ProfilerOptionsGuard::getCurOptions();
@@ -59,6 +59,7 @@ class ProfilingOptsManager {
         }
       }
     }
+    NVFuserTest::TearDown();
   }
 
  private:
@@ -66,14 +67,9 @@ class ProfilingOptsManager {
   // NOTE: the same type as the type of storage in nvfuser::Options
   std::map<ProfilerOption, std::vector<std::string>> stored_data_;
 };
-} // anonymous namespace
-
-class FusionProfilerTest : public NVFuserTest {};
 
 // RUN CMD: bin/nvfuser_tests --gtest_filter="*Profile1Segment*"
 TEST_F(FusionProfilerTest, Profile1Segment) {
-  ProfilingOptsManager prof_opts_mngr;
-  (void)prof_opts_mngr;
   try {
     auto fusion = std::make_unique<Fusion>();
     FusionGuard fg(fusion.get());
@@ -127,8 +123,6 @@ TEST_F(FusionProfilerTest, Profile1Segment) {
 }
 
 TEST_F(FusionProfilerTest, ProfileNocupti1Segment) {
-  ProfilingOptsManager prof_opts_mngr;
-  (void)prof_opts_mngr;
   try {
     auto fusion = std::make_unique<Fusion>();
     FusionGuard fg(fusion.get());
@@ -169,8 +163,6 @@ TEST_F(FusionProfilerTest, ProfileNocupti1Segment) {
 }
 
 TEST_F(FusionProfilerTest, Profile3Segments) {
-  ProfilingOptsManager prof_opts_mngr;
-  (void)prof_opts_mngr;
   try {
     auto fusion = std::make_unique<Fusion>();
     FusionGuard fg(fusion.get());

--- a/test/test_matmul_scheduler.cpp
+++ b/test/test_matmul_scheduler.cpp
@@ -32,19 +32,19 @@ using TestCaseErrorThresholds = std::map<PrecisionsDesc, ErrorThresholds>;
 class PrecisionParametrizedTest
     : public NVFuserFixtureParamTest<PrecisionsDesc> {};
 
-[[nodiscard]] auto getAtType(const PrimDataType& type) {
+[[nodiscard]] auto get_type_letter(const PrimDataType& type) {
   switch (type) {
     case PrimDataType::Half:
-      return at::kHalf;
+      return "H";
     case PrimDataType::Float:
-      return at::kFloat;
+      return "S";
     case PrimDataType::BFloat16:
-      return at::kBFloat16;
+      return "T";
     default:
       break;
   }
   NVF_ERROR(false, "Unsupported conversion of PrimDataType");
-  return at::kHalf;
+  return "*";
 }
 
 static const PrecisionsDesc HSH =
@@ -81,8 +81,8 @@ TEST_P(PrecisionParametrizedTest, EpilogueBias) {
   const auto default_out_type = (PrimDataType::Float == out_prim_type);
   const auto in_type = DataType(in_prim_type);
   const auto out_type = DataType(out_prim_type);
-  const auto at_in_type = getAtType(in_prim_type);
-  const auto at_out_type = getAtType(out_prim_type);
+  const auto at_in_type = data_type_to_aten(in_prim_type);
+  const auto at_out_type = data_type_to_aten(out_prim_type);
 
   // NOTE: bfloat16 is not supported on pre-Ampere archs
   if (DataType::BFloat16 == in_type || DataType::BFloat16 == out_type) {
@@ -183,8 +183,8 @@ TEST_P(PrecisionParametrizedTest, EpilogueRelu) {
   const auto default_out_type = (PrimDataType::Float == out_prim_type);
   const auto in_type = DataType(in_prim_type);
   const auto out_type = DataType(out_prim_type);
-  const auto at_in_type = getAtType(in_prim_type);
-  const auto at_out_type = getAtType(out_prim_type);
+  const auto at_in_type = data_type_to_aten(in_prim_type);
+  const auto at_out_type = data_type_to_aten(out_prim_type);
 
   // NOTE: bfloat16 is not supported on pre-Ampere archs
   if (DataType::BFloat16 == in_type || DataType::BFloat16 == out_type) {
@@ -275,8 +275,8 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasRelu) {
   const auto default_out_type = (PrimDataType::Float == out_prim_type);
   const auto in_type = DataType(in_prim_type);
   const auto out_type = DataType(out_prim_type);
-  const auto at_in_type = getAtType(in_prim_type);
-  const auto at_out_type = getAtType(out_prim_type);
+  const auto at_in_type = data_type_to_aten(in_prim_type);
+  const auto at_out_type = data_type_to_aten(out_prim_type);
 
   // NOTE: bfloat16 is not supported on pre-Ampere archs
   if (DataType::BFloat16 == in_type || DataType::BFloat16 == out_type) {
@@ -382,8 +382,8 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueReluAux) {
   const auto default_out_type = (PrimDataType::Float == out_prim_type);
   const auto in_type = DataType(in_prim_type);
   const auto out_type = DataType(out_prim_type);
-  const auto at_in_type = getAtType(in_prim_type);
-  const auto at_out_type = getAtType(out_prim_type);
+  const auto at_in_type = data_type_to_aten(in_prim_type);
+  const auto at_out_type = data_type_to_aten(out_prim_type);
 
   // NOTE: bfloat16 is not supported on pre-Ampere archs
   if (DataType::BFloat16 == in_type || DataType::BFloat16 == out_type) {
@@ -481,8 +481,8 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueBiasReluAux) {
   const auto default_out_type = (PrimDataType::Float == out_prim_type);
   const auto in_type = DataType(in_prim_type);
   const auto out_type = DataType(out_prim_type);
-  const auto at_in_type = getAtType(in_prim_type);
-  const auto at_out_type = getAtType(out_prim_type);
+  const auto at_in_type = data_type_to_aten(in_prim_type);
+  const auto at_out_type = data_type_to_aten(out_prim_type);
 
   // NOTE: bfloat16 is not supported on pre-Ampere archs
   if (DataType::BFloat16 == in_type || DataType::BFloat16 == out_type) {
@@ -590,8 +590,8 @@ TEST_P(PrecisionParametrizedTest, EpilogueGelu) {
   const auto default_out_type = (PrimDataType::Float == out_prim_type);
   const auto in_type = DataType(in_prim_type);
   const auto out_type = DataType(out_prim_type);
-  const auto at_in_type = getAtType(in_prim_type);
-  const auto at_out_type = getAtType(out_prim_type);
+  const auto at_in_type = data_type_to_aten(in_prim_type);
+  const auto at_out_type = data_type_to_aten(out_prim_type);
 
   // NOTE: bfloat16 is not supported on pre-Ampere archs
   if (DataType::BFloat16 == in_type || DataType::BFloat16 == out_type) {
@@ -682,8 +682,8 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueGeluAux) {
   const auto default_out_type = (PrimDataType::Float == out_prim_type);
   const auto in_type = DataType(in_prim_type);
   const auto out_type = DataType(out_prim_type);
-  const auto at_in_type = getAtType(in_prim_type);
-  const auto at_out_type = getAtType(out_prim_type);
+  const auto at_in_type = data_type_to_aten(in_prim_type);
+  const auto at_out_type = data_type_to_aten(out_prim_type);
 
   // NOTE: bfloat16 is not supported on pre-Ampere archs
   if (DataType::BFloat16 == in_type || DataType::BFloat16 == out_type) {
@@ -779,8 +779,8 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasGelu) {
   const auto default_out_type = (PrimDataType::Float == out_prim_type);
   const auto in_type = DataType(in_prim_type);
   const auto out_type = DataType(out_prim_type);
-  const auto at_in_type = getAtType(in_prim_type);
-  const auto at_out_type = getAtType(out_prim_type);
+  const auto at_in_type = data_type_to_aten(in_prim_type);
+  const auto at_out_type = data_type_to_aten(out_prim_type);
 
   // NOTE: bfloat16 is not supported on pre-Ampere archs
   if (DataType::BFloat16 == in_type || DataType::BFloat16 == out_type) {
@@ -886,8 +886,8 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueBiasGeluAux) {
   const auto default_out_type = (PrimDataType::Float == out_prim_type);
   const auto in_type = DataType(in_prim_type);
   const auto out_type = DataType(out_prim_type);
-  const auto at_in_type = getAtType(in_prim_type);
-  const auto at_out_type = getAtType(out_prim_type);
+  const auto at_in_type = data_type_to_aten(in_prim_type);
+  const auto at_out_type = data_type_to_aten(out_prim_type);
 
   // NOTE: bfloat16 is not supported on pre-Ampere archs
   if (DataType::BFloat16 == in_type || DataType::BFloat16 == out_type) {
@@ -972,10 +972,17 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueBiasGeluAux) {
 
 } // namespace
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     MatmulSchedulerTest,
     PrecisionParametrizedTest,
-    ::testing::Values(HSS, HSH, TSS, TST));
+    ::testing::Values(HSS, HSH, TSS, TST),
+    [](const testing::TestParamInfo<PrecisionsDesc>& info) {
+      std::ostringstream os;
+      os << get_type_letter(std::get<0>(info.param));
+      os << get_type_letter(PrimDataType::Float);
+      os << get_type_letter(std::get<1>(info.param));
+      return os.str();
+    });
 
 // Matmul test that uses segmenter for 'C = A x B' fusion,
 //   for Ampere with strict ref check, hence single layout check

--- a/test/test_matmul_scheduler.cpp
+++ b/test/test_matmul_scheduler.cpp
@@ -979,7 +979,7 @@ INSTANTIATE_TEST_CASE_P(
 
 // Matmul test that uses segmenter for 'C = A x B' fusion,
 //   for Ampere with strict ref check, hence single layout check
-TEST_F(MatmulSchedulerTest, BasicMatmulStrictCheckTT_CUDA) {
+TEST_F(MatmulSchedulerTest, BasicMatmulStrictCheckTT) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
   const int M = 128, N = 256, K = 512;
   const auto layout = MatmulLayout::TT;
@@ -1040,7 +1040,7 @@ TEST_F(MatmulSchedulerTest, BasicMatmulStrictCheckTT_CUDA) {
 }
 
 // Matmul test that reslies on segmenter for 'C = A x B' fusion, for Ampere
-TEST_F(MatmulSchedulerTest, BasicMatmulRelaxedCheck_CUDA) {
+TEST_F(MatmulSchedulerTest, BasicMatmulRelaxedCheck) {
   // skip until we have Hopper support
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 2048;
@@ -1110,7 +1110,7 @@ TEST_F(MatmulSchedulerTest, BasicMatmulRelaxedCheck_CUDA) {
 // Matmul test that reslies on segmenter for 'C = A x B' fusion, for Ampere
 //  MMA first input is passed as second fusion parameter.
 //  MMA second input is passed as first fusion parameter.
-TEST_F(MatmulSchedulerTest, BasicMatmulInputShuffledTT_CUDA) {
+TEST_F(MatmulSchedulerTest, BasicMatmulInputShuffledTT) {
   // skip until we have Hopper support
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 2048;
@@ -1172,7 +1172,7 @@ TEST_F(MatmulSchedulerTest, BasicMatmulInputShuffledTT_CUDA) {
 
 // Matmul test that uses segmenter for 'C = float2half(A x B)' fusion, for
 //  Ampere
-TEST_F(MatmulSchedulerTest, EpilogueOutputCast_CUDA) {
+TEST_F(MatmulSchedulerTest, EpilogueOutputCast) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const auto layout = MatmulLayout::TT;
   auto fusion = std::make_unique<Fusion>();
@@ -1233,7 +1233,7 @@ TEST_F(MatmulSchedulerTest, EpilogueOutputCast_CUDA) {
 
 // Matmul test that uses segmenter for 'C = alpha * (A x B)' fusion, for
 //  Ampere
-TEST_F(MatmulSchedulerTest, EpilogueAlpha_CUDA) {
+TEST_F(MatmulSchedulerTest, EpilogueAlpha) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const auto layout = MatmulLayout::TT;
   auto fusion = std::make_unique<Fusion>();
@@ -1297,7 +1297,7 @@ TEST_F(MatmulSchedulerTest, EpilogueAlpha_CUDA) {
 
 // Matmul test that uses segmenter for 'C = float2half(alpha * (A x B))'
 //  fusion, for Ampere
-TEST_F(MatmulSchedulerTest, EpilogueAlphaOutputCast_CUDA) {
+TEST_F(MatmulSchedulerTest, EpilogueAlphaOutputCast) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const auto layout = MatmulLayout::TT;
   auto fusion = std::make_unique<Fusion>();
@@ -1363,7 +1363,7 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaOutputCast_CUDA) {
 
 // Matmul test that uses segmenter for fusion for Ampere:
 //  D = (A x B) + beta * C
-TEST_F(MatmulSchedulerTest, EpilogueBeta_CUDA) {
+TEST_F(MatmulSchedulerTest, EpilogueBeta) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const auto layout = MatmulLayout::TT;
   auto fusion = std::make_unique<Fusion>();
@@ -1442,7 +1442,7 @@ TEST_F(MatmulSchedulerTest, EpilogueBeta_CUDA) {
 
 // Matmul test that uses segmenter for fusion for Ampere:
 //  D = alpha * (A x B) + beta * C
-TEST_F(MatmulSchedulerTest, EpilogueAlphaBeta_CUDA) {
+TEST_F(MatmulSchedulerTest, EpilogueAlphaBeta) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const auto layout = MatmulLayout::TT;
   auto fusion = std::make_unique<Fusion>();
@@ -1526,7 +1526,7 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBeta_CUDA) {
 
 // Matmul test that uses segmenter for fusion for Ampere:
 //  D = gelu(alpha * (A x B) + beta * C)
-TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaGeluOutputCast_CUDA) {
+TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaGeluOutputCast) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const auto layout = MatmulLayout::TT;
   auto fusion = std::make_unique<Fusion>();
@@ -1617,7 +1617,7 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaGeluOutputCast_CUDA) {
 
 // Matmul test that uses segmenter for fusion for Ampere:
 //  D = alpha * ((A x B) + bias) + beta * C
-TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias_CUDA) {
+TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias) {
   // NOTE: test skips Turing arch, the relative error was too big
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   const auto layout = MatmulLayout::TT;
@@ -1712,7 +1712,7 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias_CUDA) {
 
 // Strided batch gemm test taht uses matmul scheduler, for Ampere:
 //   D = (A x B)
-TEST_F(MatmulSchedulerTest, StridedBatch_CUDA) {
+TEST_F(MatmulSchedulerTest, StridedBatch) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 248, B = 2;
   for (auto layout : kAllSupportedMatmulLayout) {
@@ -1782,7 +1782,7 @@ TEST_F(MatmulSchedulerTest, StridedBatch_CUDA) {
 // Strided batch gemm test with alpha and beta that uses matmul scheduler,
 //  for Ampere architecture:
 //   D = alpha * (A x B) + beta * C
-TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta_CUDA) {
+TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 248, B = 2;
 
@@ -1875,7 +1875,7 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta_CUDA) {
 // scheduler,
 //  there is only single C tensor for whole batch; test for Ampere architecture:
 //   D = alpha * (A x B) + beta * C
-TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta_CUDA) {
+TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 248, B = 2;
 
@@ -1972,7 +1972,7 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta_CUDA) {
 
 // Strided batch gemm test with bias that uses matmul scheduler, for Ampere:
 //   D = (A x B) + bias
-TEST_F(MatmulSchedulerTest, StridedBatchEpilogueBias_CUDA) {
+TEST_F(MatmulSchedulerTest, StridedBatchEpilogueBias) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 248, B = 2;
 
@@ -2050,7 +2050,7 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueBias_CUDA) {
 // Strided batch gemm test with single bias vector that uses matmul
 // scheduler, for Ampere:
 //   D = (A x B) + bias
-TEST_F(MatmulSchedulerTest, StridedBatchEpilogueSingleBias_CUDA) {
+TEST_F(MatmulSchedulerTest, StridedBatchEpilogueSingleBias) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 248, B = 2;
 

--- a/test/test_matmul_scheduler.cpp
+++ b/test/test_matmul_scheduler.cpp
@@ -171,7 +171,7 @@ TEST_P(PrecisionParametrizedTest, EpilogueBias) {
 //   D = relu(A x B)
 //  Target architectures: Turing, Ampere
 TEST_P(PrecisionParametrizedTest, EpilogueRelu) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   const auto layout = MatmulLayout::TT;
 
   static TestCaseErrorThresholds errs = {
@@ -370,7 +370,7 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasRelu) {
 //   Aux = relu(D)
 //  Target architectures: Turing, Ampere
 TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueReluAux) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   const auto layout = MatmulLayout::TT;
 
   static TestCaseErrorThresholds errs = {
@@ -581,7 +581,7 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueBiasReluAux) {
 //   D = gelu(A x B)
 //  Target architectures: Turing, Ampere
 TEST_P(PrecisionParametrizedTest, EpilogueGelu) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   const auto layout = MatmulLayout::TT;
 
   static TestCaseErrorThresholds errs = {
@@ -671,7 +671,7 @@ TEST_P(PrecisionParametrizedTest, EpilogueGelu) {
 //   Aux = gelu(D)
 //  Target architectures: Turing, Ampere
 TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueGeluAux) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   const auto layout = MatmulLayout::TT;
 
   static TestCaseErrorThresholds errs = {
@@ -766,7 +766,7 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueGeluAux) {
 //   D = gelu((A x B) + bias)
 //  Target architectures: Turing, Ampere
 TEST_P(PrecisionParametrizedTest, EpilogueBiasGelu) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   const auto layout = MatmulLayout::TT;
 
   static TestCaseErrorThresholds errs = {

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -26,9 +26,9 @@
 
 namespace nvfuser {
 
-class MemoryTest
-    : public NVFuserTest,
-      public testing::WithParamInterface<std::tuple<CacheOp, std::string>> {
+using MemoryTestParams = std::tuple<CacheOp, std::string>;
+
+class MemoryTest : public NVFuserFixtureParamTest<MemoryTestParams> {
  protected:
   void expectMatchCount(
       const std::string& text,
@@ -107,7 +107,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(CacheOp::AllLevels, "ca"),
         std::make_tuple(CacheOp::Global, "cg"),
         std::make_tuple(CacheOp::Streaming, "cs")),
-    [](const testing::TestParamInfo<std::tuple<CacheOp, std::string>>& info) {
+    [](const testing::TestParamInfo<MemoryTestParams>& info) {
       std::ostringstream os;
       os << std::get<0>(info.param);
       return os.str();

--- a/test/utils.h
+++ b/test/utils.h
@@ -483,6 +483,72 @@ class NVFuserTest : public ::testing::Test {
   bool capturing_ = false;
 };
 
+// Fixture with param class must be uniquely identified, i.e., can't be in an
+// anonymous namespace
+template <typename tParam>
+class NVFuserFixtureParamTest : public ::testing::TestWithParam<tParam> {
+ protected:
+  void SetUp() override {
+    // requires PASCAL or newer
+    if (!deviceMajorMinorCheck(6)) {
+      GTEST_SKIP() << "skipping tests on pre-PASCAL GPUs";
+    }
+    setFillAllocationWithNan(true);
+
+    maybeClearAllocator();
+
+    // If NVFUSER_TEST_RANDOM_SEED is provided, use that for the C random seed.
+    // Otherwise, use system time. If a test fails, this seed will be printed.
+    at::manual_seed(getATenRandomSeed());
+
+    // If NVFUSER_TEST_ATEN_RANDOM_SEED is provided, use that for the ATen
+    // random seed. Otherwise, use zero. If a test fails, this seed will be
+    // printed.
+    std::srand(getCRandomSeed());
+  }
+
+  void TearDown() override {
+    if (::testing::Test::HasFailure()) {
+      auto test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+      std::cerr << "To reproduce: NVFUSER_TEST_RANDOM_SEED=" << getCRandomSeed()
+                << " NVFUSER_TEST_ATEN_RANDOM_SEED=" << getATenRandomSeed()
+                << " nvfuser_tests --gtest_filter='"
+                << test_info->test_suite_name() << "." << test_info->name()
+                << "'" << std::endl;
+    }
+
+    // Make sure capturing of stdout is stopped
+    ensureStopCaptureStdout();
+  }
+
+  // Start capturing of stdout if not already started
+  void captureStdout() {
+    if (!capturing_) {
+      testing::internal::CaptureStdout();
+      capturing_ = true;
+    }
+  }
+
+  // Stop capturing of stdout if being captured
+  void ensureStopCaptureStdout() {
+    if (capturing_) {
+      testing::internal::GetCapturedStdout();
+      capturing_ = false;
+    }
+  }
+
+  // Get capturing stdout
+  std::string getCapturedStdout() {
+    NVF_ERROR(capturing_, "Not captured");
+    auto str = testing::internal::GetCapturedStdout();
+    capturing_ = false;
+    return str;
+  }
+
+ private:
+  bool capturing_ = false;
+};
+
 // assert that the given fusion lowers to the given CUDA kernel
 void assertCUDAKernel(Fusion* fusion, const std::string& expected_kernel);
 


### PR DESCRIPTION
Add forward epilogue fusions tests for HSS/HSH/TSS/TST precisions:
- bias
- relu, relu+bias,
- relu+aux, relu+aux+bias,
- gelu, gelu+bias
- gelu+aux, gelu+aux+bias,

Some tests are disabled (aux) due to missing support. To be added in a follow up PR.

Other changes:
- update tolerance and reduced problem size, k 1024 -> 248,
- update arch ranges for new tests,
- fix issue with test env being left dirty after profiler option tests,