### PR TITLE
Don't predicate trivial splits

### DIFF
--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -159,6 +159,11 @@ class PredicateAnalyzer : public OptOutDispatch {
       return;
     }
 
+    if (factor.value() == 1) {
+      // Trivial splits cannot cause out-of-bounds
+      return;
+    }
+
     auto in_extent = split->in()->extent();
 
     if (!in_extent->isConstInt() ||
@@ -437,17 +442,17 @@ class PredicateChcker : public IterVisitor {
           id->getParallelType() == ParallelType::Unswitch) {
         return true;
       }
+    }
 
-      // TODO: （Enable in a follow up)
-      //  This cannot yet be removed since smem initialization needs to be
-      //  handled specially, e.g. as in smem_reduce test. Will be able to
-      //  lift this one once the generic pred removal pass with fusion
-      //  traversal is ready.
-      auto consumer_def = consumer->definition();
-      if (ir_utils::isReductionOp(consumer_def)) {
-        if (producer->getMemoryType() == MemoryType::Shared) {
-          return true;
-        }
+    // TODO: (Enable in a follow up)
+    //  This cannot yet be removed since smem initialization needs to be
+    //  handled specially, e.g. as in smem_reduce test. Will be able to
+    //  lift this one once the generic pred removal pass with fusion
+    //  traversal is ready.
+    auto consumer_def = consumer->definition();
+    if (ir_utils::isReductionOp(consumer_def)) {
+      if (producer->getMemoryType() == MemoryType::Shared) {
+        return true;
       }
     }
 


### PR DESCRIPTION
This small change just avoids adding predicates when an `IterDomain` is split by a constant factor of 1. The predicate is not needed in this case since 1 evenly divides any extent. It also moves a repeated independent check outside a loop.