### PR TITLE
Allow some unmapped producers in `DynamicTransform::propagateProducerToConsumer`

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -825,12 +825,13 @@ bool DynamicTransformConcretizer::propagateFromProducerToConsumer(
 
     std::optional<IterType> id_type;
 
+    bool found = false;
     for (const auto& c2p : c2p_maps) {
       auto p_it = c2p.find(root_id);
-      NVF_ERROR(
-          p_it != c2p.end(),
-          "No input ID found to map with output ID: ",
-          root_id->toString());
+      if (p_it == c2p.end()) {
+        continue;
+      }
+      found = true;
       auto input_id = p_it->second;
       NVF_ERROR(
           input_id == maybeMutated(input_id),
@@ -851,6 +852,10 @@ bool DynamicTransformConcretizer::propagateFromProducerToConsumer(
         id_type = input_id->getIterType();
       }
     }
+    NVF_ERROR(
+        found,
+        "No input ID found to map with output ID: ",
+        root_id->toString());
 
     NVF_ERROR(
         id_type.has_value(),

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -828,6 +828,14 @@ bool DynamicTransformConcretizer::propagateFromProducerToConsumer(
     bool found = false;
     for (const auto& c2p : c2p_maps) {
       auto p_it = c2p.find(root_id);
+      // In some cases, we can exact map to one producer, but not to another.
+      // This is the case for index_select, for example, whose first input is
+      // the tensor to look up values in and whose second input gives the
+      // indices to use for the lookup. In the selected dimension, the first
+      // input will not exact map to the output, but the second input will.
+      // Here we just require at least one input to map to root_id so that we
+      // can propagate an IterType.
+      // See https://github.com/NVIDIA/Fuser/issues/1192 for an example
       if (p_it == c2p.end()) {
         continue;
       }


### PR DESCRIPTION
Fixes #1192.

In that repro we had the following dynamic Fusion:
```
Fusion before concretization:                                                                                                                              
Inputs:                                                                                                                                                    
  T0_g[ iS0{i0}, iS1{i1} ], int64_t                                                                                                                        
  T1_g[ iS2{i3}, iS3{i4} ], float                                                                                                                          
Outputs:                                                                                                                                                   
  T5_g[ ?S13{( (nvfuser_index_t)(5) )}rf, ?S14{( (nvfuser_index_t)(5) )}rf, ?S15{( (nvfuser_index_t)(64) )}rf ], float                                     
                                                                             
%kernel_math {                                                                                                                                             
T2_l[ ?S6{( (nvfuser_index_t)(25) )}rf ] = view( T0_g[ iS0{i0}, iS1{i1} ] )  
T4_l[ ?S9{( (nvfuser_index_t)(25) )}, bS10{1} ]                                                                                                            
   = broadcast( T2_l[ ?S6{( (nvfuser_index_t)(25) )}rf ] )                                                                                                 
T3_l[ ?S7{( (nvfuser_index_t)(25) )}, iS8{i4} ]                              
   = index_select( T1_g[ iS2{i3}, iS3{i4} ], dim = 0, T4_l[ ?S9{( (nvfuser_index_t)(25) )}, bS10{1} ] )                                                    T5_g[ ?S13{( (nvfuser_index_t)(5) )}rf, ?S14{( (nvfuser_index_t)(5) )}rf, ?S15{( (nvfuser_index_t)(64) )}rf ] = view( T3_l[ ?S7{( (nvfuser_index_t)(25) )},
 iS8{i4} ] )                                                                                                                                               
}
```
The `index_select` caused an error since `propagateProducerToConsumer` expects a mapping from each `Symbolic` consumer root ID to each producer rfactor. In the case of `index_select`, only the second argument will have an exact mapped first axis. The fix is to require at least one mapping, instead of requiring all producers to map.