### PR TITLE
Strip comments in PTX before diffing

### DIFF
--- a/tools/codediff/diff_report.py
+++ b/tools/codediff/diff_report.py
@@ -706,10 +706,14 @@ class TestDifferences:
 
                 ptx_diff_lines = None
                 if kern1.ptx is not None and kern2.ptx is not None:
+
+                    def strip_comments(l: str) -> str:
+                        return re.sub(r"//.*$", "", l)
+
                     ptx_diff_lines = list(
                         difflib.unified_diff(
-                            kern1.ptx.splitlines(),
-                            kern2.ptx.splitlines(),
+                            [strip_comments(l) for l in kern1.ptx.splitlines()],
+                            [strip_comments(l) for l in kern2.ptx.splitlines()],
                             fromfile=self.run1.name,
                             tofile=self.run2.name,
                             n=5,


### PR DESCRIPTION
Note that this leaves comments for the purposes of viewing each PTX, but will not highlight differences in lines where only comments changed. This should avoid false positives in cases where CUDA code for both kernel and preamble is not changing but PTX is (cf. https://github.com/NVIDIA/Fuser/issues/1186#issuecomment-1787599192).