### PR TITLE
Label runs by git commit in compare_codegen.sh

### DIFF
--- a/tools/codediff/compare_codegen.sh
+++ b/tools/codediff/compare_codegen.sh
@@ -183,7 +183,9 @@ collect_kernels() {
 
     mkdir -p "$outdir/$commit"
 
-    bashcmd=("bash" "$scriptdir/run_command.sh" "-f" "$nvfuserdir")
+    # Name each run with commit abbrev, tell it where nvfuser lives since the
+    # run_command script was copied to $scriptdir before git operations.
+    bashcmd=("bash" "$scriptdir/run_command.sh" "-f" "$nvfuserdir" "-n" "$commit")
 
     if [[ -n $quiet ]]
     then


### PR DESCRIPTION
The run name argument to `run_command.sh` is missing in the current version so the outputs are named like `custom_command_20231030_212134` instead of something more informative. This change uses the short commit like `17e4d4f` instead of the `custom_command` string.