### PR TITLE
Set random seeds in examples

### DIFF
--- a/examples/sinh_extension/test.py
+++ b/examples/sinh_extension/test.py
@@ -4,6 +4,7 @@
 import torch
 import nvfuser_extension  # noqa: F401
 
+torch.manual_seed(0)
 t = torch.randn((5, 5), device="cuda")
 expected = torch.sinh(t)
 output = torch.ops.myop.sinh_nvfuser(t)

--- a/examples/sinh_libtorch/main.cpp
+++ b/examples/sinh_libtorch/main.cpp
@@ -33,6 +33,7 @@ at::Tensor sinh_nvfuser(const at::Tensor& input) {
 }
 
 int main() {
+  at::manual_seed(0);
   auto t = at::randn({5, 5}, at::kCUDA);
   auto expected = at::sinh(t);
   auto output = sinh_nvfuser(t);


### PR DESCRIPTION
This should cut down on more false positives in CI.

See this failing test for example that recently failed: https://github.com/NVIDIA/Fuser/actions/runs/6710458836