### PR TITLE
Reorder compare codegen

### DIFF
--- a/tools/codediff/compare_codegen.sh
+++ b/tools/codediff/compare_codegen.sh
@@ -223,8 +223,8 @@ do
     # Note we use nvfuserdir here instead of scriptdir since we should be back on
     # original commit by now
     if ! python "$nvfuserdir/tools/codediff/diff_report.py" \
-        "$outdir/$origcommit/$b" "$outdir/$comparecommit/$b" \
-        -o "$outdir/codediff_${origcommit}_${comparecommit}_${b}.html" \
+        "$outdir/$comparecommit/$b" "$outdir/$origcommit/$b" \
+        -o "$outdir/codediff_${comparecommit}_${origcommit}_${b}.html" \
         --html --hide-diffs;
     then
         found_diffs=1

--- a/tools/codediff/templates/command_env_info.html
+++ b/tools/codediff/templates/command_env_info.html
@@ -11,7 +11,6 @@
                 {% if run1.gpu_names != run2.gpu_names %}{{ run1.name }}{% endif %}
                 GPUs:
                 <pre><code>{{run1.gpu_names | e}}</code></pre>
-                %}
             {%- else -%}
                 {% if run1.gpu_names != run2.gpu_names %}{{ run1.name }}{% endif %}
                 GPU: {{ run1.gpu_names[0] | e }}


### PR DESCRIPTION
I previously put the order backwards so that the left-hand (should be old) commit was actually the new commit. That means that currently we show improvements in red and regressions in blue or green, for example. This change just reverses those to have more sane behavior.