### PR TITLE
Generate an empty kernel when all outputs are aliases.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/optimization/add_axioms.cpp
   ${NVFUSER_SRCS_DIR}/optimization/alias_analysis.cpp
   ${NVFUSER_SRCS_DIR}/optimization/consecutive_cast.cpp
+  ${NVFUSER_SRCS_DIR}/optimization/mark_alias.cpp
   ${NVFUSER_SRCS_DIR}/optimization/pre_segmenter.cpp
   ${NVFUSER_SRCS_DIR}/optimization/remove_empty.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/test/test_tutorial.cpp
     ${NVFUSER_ROOT}/test/test_alias_analysis.cpp
     ${NVFUSER_ROOT}/test/test_scalar_hoisting.cpp
+    ${NVFUSER_ROOT}/test/test_no_op.cpp
   )
 
   if(BUILD_PYTHON)

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -318,18 +318,17 @@ bool Fusion::isNoOp() {
     return true;
   }
   for (auto out_tv : ir_utils::filterByType<TensorView>(outputs())) {
-    auto root_dom = TensorDomain::noReductions(out_tv->getMaybeRFactorDomain());
-    bool size_zero = false;
-    for (auto id : root_dom) {
-      if (id->extent()->isConstScalar() && id->extent()->evaluate() == 0) {
-        size_zero = true;
-        break;
-      }
-    }
+    const std::vector<IterDomain*>& root_dom =
+        TensorDomain::noReductions(out_tv->getMaybeRFactorDomain());
+    const bool size_zero =
+        std::any_of(root_dom.begin(), root_dom.end(), [](IterDomain* id) {
+          return id->extent()->isConstScalar() && id->extent()->evaluate() == 0;
+        });
     if (!size_zero) {
       return false;
     }
   }
+
   return true;
 }
 

--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -132,8 +132,9 @@ const Val* AliasAnalysisResult::findRoot(const Val* alias) const {
     return nullptr;
   }
 
-  for (; alias_to_source_.count(root); root = alias_to_source_.at(root))
-    ;
+  while (alias_to_source_.count(root)) {
+    root = alias_to_source_.at(root);
+  }
   return root;
 }
 

--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -132,6 +132,8 @@ const Val* AliasAnalysisResult::findRoot(const Val* alias) const {
     return nullptr;
   }
 
+  // This can be made faster by path compression at the cost of losing
+  // the potentially useful immediate sources. Go simple for now.
   while (alias_to_source_.count(root)) {
     root = alias_to_source_.at(root);
   }

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -19,6 +19,7 @@ class AliasAnalysisResult {
   // Returns itself if `alias` doesn't alias anything.
   const Val* findRoot(const Val* alias) const;
 
+  // Marks `source` as the immediate aliasing source of `alias`.
   void add(const TensorView* alias, const TensorView* source);
 
   AliasAnalysisResult(const AliasAnalysisResult&) = delete;

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -12,12 +12,27 @@
 
 namespace nvfuser::optimization {
 
-// Maps aliases (e.g. the output of a View) to their direct sources (e.g. the
-// input of the same View). Consider path compression, a common optimization
-// used in disjoint-set data structure, so it's easy to figure out the root of
-// an alias.
-using AliasAnalysisResult =
-    std::unordered_map<const TensorView*, const TensorView*>;
+class AliasAnalysisResult {
+ public:
+  AliasAnalysisResult() {}
+
+  // Returns itself if `alias` doesn't alias anything.
+  const Val* findRoot(const Val* alias) const;
+
+  void add(const TensorView* alias, const TensorView* source);
+
+  AliasAnalysisResult(const AliasAnalysisResult&) = delete;
+  AliasAnalysisResult& operator=(const AliasAnalysisResult&) = delete;
+  AliasAnalysisResult(AliasAnalysisResult&&) = default;
+  AliasAnalysisResult& operator=(AliasAnalysisResult&&) = default;
+
+ private:
+  // Maps aliases (e.g. the output of a View) to their direct sources (e.g. the
+  // input of the same View). Consider path compression, a common optimization
+  // used in disjoint-set data structure, so it's easy to figure out the root of
+  // an alias.
+  std::unordered_map<const TensorView*, const TensorView*> alias_to_source_;
+};
 
 // Finds aliases of the fusion inputs.
 AliasAnalysisResult findAliases(Fusion* fusion);

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -14,7 +14,7 @@ namespace nvfuser::optimization {
 
 class AliasAnalysisResult {
  public:
-  AliasAnalysisResult() {}
+  AliasAnalysisResult() = default;
 
   // Returns itself if `alias` doesn't alias anything.
   const Val* findRoot(const Val* alias) const;

--- a/csrc/optimization/mark_alias.cpp
+++ b/csrc/optimization/mark_alias.cpp
@@ -16,9 +16,12 @@ void MarkAliasPass::runPass(Fusion* fusion) {
 
   const AliasAnalysisResult alias_analysis = findAliases(fusion);
   for (Val* out : fusion->outputs()) {
-    if (Val* in = const_cast<Val*>(alias_analysis.findRoot(out));
-        in->isFusionInput()) {
-      fusion->aliasOutputToInput(out, in, AliasType::PointerCast);
+    if (const Val* in = alias_analysis.findRoot(out); in->isFusionInput()) {
+      fusion->aliasOutputToInput(
+          out,
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          const_cast<Val*>(in),
+          AliasType::PointerCast);
     }
   }
 }

--- a/csrc/optimization/mark_alias.cpp
+++ b/csrc/optimization/mark_alias.cpp
@@ -1,0 +1,26 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <ir/utils.h>
+#include <optimization/alias_analysis.h>
+#include <optimization/mark_alias.h>
+
+namespace nvfuser::optimization {
+
+void MarkAliasPass::runPass(Fusion* fusion) {
+  fusion->print();
+
+  const AliasAnalysisResult alias_analysis = findAliases(fusion);
+  for (Val* out : fusion->outputs()) {
+    if (Val* in = const_cast<Val*>(alias_analysis.findRoot(out));
+        in->isFusionInput()) {
+      fusion->aliasOutputToInput(out, in, AliasType::PointerCast);
+    }
+  }
+}
+
+} // namespace nvfuser::optimization

--- a/csrc/optimization/mark_alias.h
+++ b/csrc/optimization/mark_alias.h
@@ -9,6 +9,7 @@
 
 namespace nvfuser::optimization {
 
+// Marks aliases between fusion inputs and outputs.
 class MarkAliasPass : public OptimizationPass<MarkAliasPass> {
   friend class OptimizationPass<MarkAliasPass>;
 

--- a/csrc/optimization/mark_alias.h
+++ b/csrc/optimization/mark_alias.h
@@ -1,0 +1,19 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <optimization/optimization_pass.h>
+
+namespace nvfuser::optimization {
+
+class MarkAliasPass : public OptimizationPass<MarkAliasPass> {
+  friend class OptimizationPass<MarkAliasPass>;
+
+ protected:
+  static void runPass(Fusion* fusion);
+};
+
+} // namespace nvfuser::optimization

--- a/csrc/optimization/pre_segmenter.cpp
+++ b/csrc/optimization/pre_segmenter.cpp
@@ -9,6 +9,7 @@
 
 #include <optimization/add_axioms.h>
 #include <optimization/consecutive_cast.h>
+#include <optimization/mark_alias.h>
 #include <optimization/remove_empty.h>
 
 namespace nvfuser::optimization {
@@ -19,6 +20,7 @@ void PreSegmenter::runPass(Fusion* fusion) {
   // removes consecutive cast operations
   OptimizationPass<ConsecutiveCastPass>::runPass(fusion);
   OptimizationPass<AddAxiomsPass>::runPass(fusion);
+  OptimizationPass<MarkAliasPass>::runPass(fusion);
 }
 
 } // namespace nvfuser::optimization

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -25,6 +25,7 @@ bool NoOpScheduler::canScheduleCompileTime(Fusion* fusion) {
   if (fusion->isNoOp()) {
     return true;
   }
+
   // Check there're no non-trivial reduction ops.
   for (auto reduction : ir_utils::getAllTypesOfReductionOps(fusion)) {
     for (auto output :

--- a/test/test_no_op.cpp
+++ b/test/test_no_op.cpp
@@ -201,33 +201,22 @@ TEST_F(NoOpTest, View) {
   fusion->addInput(in);
   TensorView* out = reshape(in, in_shape, out_shape);
   fusion->addOutput(out);
-  fusion->aliasOutputToInput(out, in, AliasType::PointerCast);
-
-  FusionExecutor fe;
-  at::Tensor in_tensor =
-      at::randn({2, 3, 4}, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  fe.compileFusion(fusion.get(), {in_tensor});
-  at::Tensor out_tensor = fe.runFusion({in_tensor})[0];
-  EXPECT_EQ(in_tensor.data_ptr<float>(), out_tensor.data_ptr<float>());
-  testValidate(
-      fusion.get(),
-      {out_tensor},
-      {in_tensor},
-      {in_tensor.view({2, 12})},
-      __LINE__,
-      __FILE__);
 
   FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor =
+      at::randn({2, 3, 4}, at::dtype(at::kFloat).device(at::kCUDA, 0));
   std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
-  out_tensor = out_tensors[0];
-  EXPECT_EQ(in_tensor.data_ptr<float>(), out_tensor.data_ptr<float>());
+  at::Tensor out_tensor = out_tensors[0];
 
+  // Verify aliasing.
+  EXPECT_EQ(in_tensor.data_ptr(), out_tensor.data_ptr());
+
+  // Verify the NoOp scheduler was kicked in.
   const std::vector<SegmentedGroup*>& groups =
       fec.getMostRecentKernelRuntime()->fusionSegments()->groups();
   ASSERT_EQ(groups.size(), 1);
   SegmentedGroup* group = groups[0];
-
   EXPECT_EQ(group->heuristic(), ScheduleHeuristic::NoOp);
 }
 


### PR DESCRIPTION
Summary of changes: 
1. Made `Fusion::isNoOp` return true when all outputs are aliases. When `Fusion::isNoOp` returns true, device lowering emits no expressions, leading to an empty kernel. 
2. Made `AliasAnalysisResult` a class with `add` and `findRoot`. 
3. Added a pre-segmentation pass (`MarkAliasPass`) to call `aliasOutputToInput` for aliases detected by `AliasAnalysis`. 
4. Added unit tests. 