### PR TITLE
getOutputAlias also returns the AliasInfo.

### DIFF
--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -773,15 +773,12 @@ void Fusion::aliasOutputToInput(Val* output, Val* input, const AliasType type) {
   }
 }
 
-Val* Fusion::getOutputAlias(Val* output, AliasInfo* info) {
+std::pair<Val*, const AliasInfo*> Fusion::getOutputAlias(Val* output) {
   if (auto search = io_alias_.find(output); search != io_alias_.end()) {
-    const auto& [in_val, alias_info] = search->second;
-    if (info != nullptr) {
-      *info = alias_info;
-    }
-    return in_val;
+    const std::pair<Val*, AliasInfo>& in_val_and_info = search->second;
+    return {in_val_and_info.first, &in_val_and_info.second};
   }
-  return nullptr;
+  return {nullptr, nullptr};
 }
 
 std::vector<InputOutputAlias> Fusion::getOutputToInputAliasIndices() const {

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -773,9 +773,13 @@ void Fusion::aliasOutputToInput(Val* output, Val* input, const AliasType type) {
   }
 }
 
-Val* Fusion::getOutputAlias(Val* output) {
+Val* Fusion::getOutputAlias(Val* output, AliasInfo* info) {
   if (auto search = io_alias_.find(output); search != io_alias_.end()) {
-    return search->second.first;
+    const auto& [in_val, alias_info] = search->second;
+    if (info != nullptr) {
+      *info = alias_info;
+    }
+    return in_val;
   }
   return nullptr;
 }

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -247,9 +247,10 @@ class Fusion : public IrContainer {
   // the input tensor to the section where output is produced.
   void aliasOutputToInput(Val* output, Val* input, AliasType type);
 
-  //! Returns the aliased input of a given output or nullptr if not aliased.
-  //! If aliased, `info` (if not nullptr) will contain how they are aliased.
-  Val* getOutputAlias(Val* output, AliasInfo* info = nullptr);
+  //! Returns the aliased input of a given output along with an `AliasInfo`
+  //! describing how they alias. Returns <nullptr,nullptr> when `output` is not
+  //! aliased.
+  std::pair<Val*, const AliasInfo*> getOutputAlias(Val* output);
 
   //! Get alias mappings from fusion outputs to inputs
   //

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -247,8 +247,9 @@ class Fusion : public IrContainer {
   // the input tensor to the section where output is produced.
   void aliasOutputToInput(Val* output, Val* input, AliasType type);
 
-  //! Return the aliased input of a given output or nullptr if not aliased
-  Val* getOutputAlias(Val* output);
+  //! Returns the aliased input of a given output or nullptr if not aliased.
+  //! If aliased, `info` (if not nullptr) will contain how they are aliased.
+  Val* getOutputAlias(Val* output, AliasInfo* info = nullptr);
 
   //! Get alias mappings from fusion outputs to inputs
   //

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -324,7 +324,7 @@ class SegmentedFusion {
   }
 
   Val* findAlias(Val* val) const {
-    return complete_fusion_->getOutputAlias(val);
+    return complete_fusion_->getOutputAlias(val).first;
   }
 
   //! Make a clone of the group and convert to fusion


### PR DESCRIPTION
This is separated out from #1203 to keep the PR small. 