### PR TITLE
Set the allocation domain of mma output as leaf domain and remove `accumulator_stride`

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1094,10 +1094,6 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           "via ldmatrix.trans for fp16 or explicitly for other types.");
     }
     ss << toString(mma_layout_opt.value());
-    // TODO: additional parameter could be removed by swizzling iterdomain
-    auto acc_stride = mma->accStride();
-    NVF_ERROR(acc_stride > 0);
-    ss << "<" << acc_stride << ">";
     return ss.str();
   }
 

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1093,7 +1093,9 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           "MMAs in Turing and Ampere are TN only, transpose is handled either "
           "via ldmatrix.trans for fp16 or explicitly for other types.");
     }
-    ss << toString(mma_layout_opt.value());
+    if (!init) {
+      ss << toString(mma_layout_opt.value());
+    }
     return ss.str();
   }
 

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1377,7 +1377,7 @@ void IndexLowering::handle(const MmaOp* mma) {
   const auto b = lowerSrcIndex(mma->inB(), mma->out());
   const auto out = lowerDstIndex(mma->out());
   auto mma_indexed = IrBuilder::create<MmaOp>(
-      out, a, b, mma->init(), mma->options(), mma->layout());
+      out, a, b, mma->init(), mma->macro(), mma->layout());
   pushBack(mma_indexed);
   GpuLower::current()->propagateExprInfo(mma, back());
 }

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -605,7 +605,7 @@ class ReplaceExprInput : private kir::ExprMutator {
           replaced_inputs->at(node->inA()),
           replaced_inputs->at(node->inB()),
           node->init(),
-          node->options(),
+          node->macro(),
           node->layout());
       registerReplaceWithPredicate(node, replacement);
     }

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -1066,7 +1066,7 @@ void validateMma(Fusion* fusion) {
     if (auto mma = dynamic_cast<MmaOp*>(expr)) {
       validateMmaTensors(mma);
 
-      switch (mma->options().macro) {
+      switch (mma->macro()) {
         case MmaOptions::MacroType::Volta_16_16_4:
           break;
         case MmaOptions::MacroType::Turing_16_8_16:

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -57,9 +57,6 @@ int getProducerHaloOffset(
   // producer tensors, where reduction axes are skipped, producer_id
   // should never be a reduction axis.
   if (it == p2c.end()) {
-    TORCH_WARN(
-        "getProducerHaloOffset p2c mapping has failed. See "
-        "https://github.com/NVIDIA/Fuser/issues/1122");
     return 0;
   }
   IterDomain* consumer_id = it->second;

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1364,7 +1364,7 @@ class MmaOp : public Expr {
     return attributeVal(0);
   }
 
-  const auto& options() const {
+  const auto& macro() const {
     return attribute<MmaOptions::MacroType>(ATTR_POS_MACRO);
   }
 

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1324,21 +1324,6 @@ class GroupedWelfordOp : public Expr {
 //! Fused Matmul operation
 class MmaOp : public Expr {
  public:
-  // This is a temporary data structure to for the
-  //  scheduling specific parameters that we still need
-  //  to store on an mma node. Eventually will only be
-  //  the mma macro type that will stay on the IR node
-  //  after additional cleaning ups.
-  struct OptionsInMma {
-    MmaOptions::MacroType macro = MmaOptions::MacroType::NoMMA;
-    int accumulator_stride = 0;
-
-    bool operator==(const OptionsInMma& other) const {
-      return macro == other.macro &&
-          accumulator_stride == other.accumulator_stride;
-    }
-  };
-
   using AxesData = std::vector<int64_t>;
   using MmaLayoutOpt = std::optional<MmaOptions::MmaLayout>;
   using Expr::Expr;
@@ -1351,7 +1336,7 @@ class MmaOp : public Expr {
       Val* in_a,
       Val* in_b,
       Val* init,
-      const OptionsInMma& options,
+      const MmaOptions::MacroType& options,
       const MmaLayoutOpt& input_layout);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
@@ -1380,11 +1365,7 @@ class MmaOp : public Expr {
   }
 
   const auto& options() const {
-    return attribute<OptionsInMma>(ATTR_POS_OPTS);
-  }
-
-  auto accStride() const {
-    return options().accumulator_stride;
+    return attribute<MmaOptions::MacroType>(ATTR_POS_MACRO);
   }
 
   void configureOptions(MmaOptions options);
@@ -1414,7 +1395,7 @@ class MmaOp : public Expr {
   //  magic numbers, based on order in which attributes are initialized
   //  in constructor
   static constexpr size_t ATTR_POS_INIT = 0;
-  static constexpr size_t ATTR_POS_OPTS = 1;
+  static constexpr size_t ATTR_POS_MACRO = 1;
   static constexpr size_t ATTR_POS_M_AXES = 2;
   static constexpr size_t ATTR_POS_N_AXES = 3;
   static constexpr size_t ATTR_POS_K_AXES = 4;

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2078,10 +2078,10 @@ MmaOp::MmaOp(
     Val* in_a,
     Val* in_b,
     Val* init,
-    const MmaOptions::MacroType& options,
+    const MmaOptions::MacroType& macro,
     const MmaLayoutOpt& input_layout)
     : MmaOp(passkey, out, in_a, in_b, init) {
-  attribute<MmaOptions::MacroType>(ATTR_POS_MACRO) = options;
+  attribute<MmaOptions::MacroType>(ATTR_POS_MACRO) = macro;
 
   const auto input_layout_ = attribute<MmaLayoutOpt>(ATTR_POS_INPUT_LAYOUT);
   if (input_layout_.has_value()) {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2043,8 +2043,8 @@ MmaOp::MmaOp(
   addInput(in_b);
   // ATTR_POS_INIT
   addAttribute(init);
-  // ATTR_POS_OPTS
-  addDataAttribute(OptionsInMma{});
+  // ATTR_POS_MACRO
+  addDataAttribute(MmaOptions::MacroType::NoMMA);
   // ATTR_POS_M_AXES
   addDataAttribute(AxesData{});
   // ATTR_POS_N_AXES
@@ -2078,10 +2078,10 @@ MmaOp::MmaOp(
     Val* in_a,
     Val* in_b,
     Val* init,
-    const OptionsInMma& options,
+    const MmaOptions::MacroType& options,
     const MmaLayoutOpt& input_layout)
     : MmaOp(passkey, out, in_a, in_b, init) {
-  attribute<OptionsInMma>(ATTR_POS_OPTS) = options;
+  attribute<MmaOptions::MacroType>(ATTR_POS_MACRO) = options;
 
   const auto input_layout_ = attribute<MmaLayoutOpt>(ATTR_POS_INPUT_LAYOUT);
   if (input_layout_.has_value()) {
@@ -2111,14 +2111,11 @@ std::string MmaOp::toInlineString(int indent_size) const {
 }
 
 void MmaOp::configureOptions(MmaOptions options) {
-  OptionsInMma& opt = attribute<OptionsInMma>(ATTR_POS_OPTS);
+  MmaOptions::MacroType& macro = attribute<MmaOptions::MacroType>(ATTR_POS_MACRO);
   NVF_ERROR(
-      options.macro != MmaOptions::MacroType::NoMMA,
+      macro != MmaOptions::MacroType::NoMMA,
       "Un-configured mma type from options.");
-  NVF_ERROR(
-      options.accumulator_stride > 0, "Un-configured accumulator stride.");
-  opt.accumulator_stride = options.accumulator_stride;
-  opt.macro = options.macro;
+  macro = options.macro;
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(MmaOp)

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2111,9 +2111,10 @@ std::string MmaOp::toInlineString(int indent_size) const {
 }
 
 void MmaOp::configureOptions(MmaOptions options) {
-  MmaOptions::MacroType& macro = attribute<MmaOptions::MacroType>(ATTR_POS_MACRO);
+  MmaOptions::MacroType& macro =
+      attribute<MmaOptions::MacroType>(ATTR_POS_MACRO);
   NVF_ERROR(
-      macro != MmaOptions::MacroType::NoMMA,
+      options.macro != MmaOptions::MacroType::NoMMA,
       "Un-configured mma type from options.");
   macro = options.macro;
 }

--- a/csrc/mma_type.cpp
+++ b/csrc/mma_type.cpp
@@ -25,25 +25,6 @@ MmaBuilder::MmaBuilder(
     MmaOptions::MacroType macro,
     MatMulTileOptions gemm_tile) {
   option_.macro = macro;
-  // Calculate accumulator stride, will be removed once transpose swizzle ready
-  int outer_stride = gemm_tile.warp_tile.n / gemm_tile.instruction_tile.n;
-  switch (macro) {
-    // Numbers depend on actual output layout of mma instruction
-    case MmaOptions::MacroType::Volta_16_16_4:
-      option_.accumulator_stride = outer_stride * 4;
-      break;
-    case MmaOptions::MacroType::Turing_16_8_16:
-    case MmaOptions::MacroType::Ampere_16_8_16:
-      option_.accumulator_stride = outer_stride * 2;
-      break;
-    case MmaOptions::MacroType::Ampere_16_16_16:
-    case MmaOptions::MacroType::Turing_16_16_16:
-      option_.accumulator_stride = outer_stride * 4;
-      break;
-    default:
-      NVF_CHECK(false, "unsupported macro");
-      break;
-  }
 }
 
 MmaBuilder& MmaBuilder::layout(MmaOptions::MmaLayout layout) {

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -115,14 +115,9 @@ struct MmaOptions {
   //! Utility to annotate which input of mma this option struct describes
   Operand operand = Operand::A;
 
-  //! Accumulator register stride, will be removed when the swizzle op
-  //!  is introduced and the output can be labeled with a transpose swizzle.
-  int accumulator_stride = 0;
-
   bool operator==(const MmaOptions& other) const {
     return macro == other.macro && layout == other.layout &&
-        operand == other.operand &&
-        accumulator_stride == other.accumulator_stride;
+        operand == other.operand;
   }
 
   // The accumulator tensorview register supplied by the

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1173,6 +1173,9 @@ void WarpMmaSwizzler::scheduleVoltaM16N16K4Fp32Output(
 
   //  m-2   m-1   m     m+1   m+2
   //[Warp, Mio2, Nio2, Niii2, (R)]
+  tv->reorder({{m_pos - 1, m_pos}});
+  //  m-2   m-1   m     m+1   m+2
+  //[Warp, Nio2, Mio2, Niii2, (R)]
   tv->axis(m_pos - 2)->parallelize(ParallelType::TIDx);
 
   if (is_reduction && tv->definition()->isA<MmaOp>()) {

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1379,7 +1379,9 @@ void TensorView::applyMmaSwizzle(MmaOptions options) {
   switch (options.operand) {
     case MmaOptions::Operand::Accumulator:
       mma_utils::WarpMmaSwizzler::scheduleMmaWarpOutput(this, options);
-      setAllocationDomain(getLeafDomain(), true);
+      if (definition()->isA<MmaOp>()) {
+        setAllocationDomain(getLeafDomain(), true);
+      }
       break;
     case MmaOptions::Operand::A:
     case MmaOptions::Operand::B:

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1379,6 +1379,7 @@ void TensorView::applyMmaSwizzle(MmaOptions options) {
   switch (options.operand) {
     case MmaOptions::Operand::Accumulator:
       mma_utils::WarpMmaSwizzler::scheduleMmaWarpOutput(this, options);
+      setAllocationDomain(getLeafDomain(), true);
       break;
     case MmaOptions::Operand::A:
     case MmaOptions::Operand::B:

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -928,7 +928,7 @@ TensorView* TensorView::rFactor(const std::vector<int>& axes) {
         this_mma->inA(),
         this_mma->inB(),
         this_mma->init(),
-        this_mma->options(),
+        this_mma->macro(),
         this_mma->layout());
 
     // Remaining reduction that can be scheduled cross

--- a/runtime/tensorcore.cu
+++ b/runtime/tensorcore.cu
@@ -258,6 +258,23 @@ __device__ inline void M16N8K16TN(
         "r"(_D[3]));
 }
 
+__device__ inline void initM16N16K16(Array<float, 8, 8>* accumulator) {
+  auto* _C = reinterpret_cast<Array<float, 4, 4>*>(accumulator);
+  initM16N8K16(&_C[0]);
+  initM16N8K16(&_C[1]);
+}
+
+template <typename T>
+__device__ inline void M16N16K16TN(
+    Array<float, 8, 8>* C,
+    Array<T, 8, 8>* A,
+    Array<T, 8, 8>* B) {
+  auto* _C = reinterpret_cast<Array<float, 4, 4>*>(C);
+  auto* _B = reinterpret_cast<Array<T, 4, 4>*>(B);
+  M16N8K16TN(&_C[0], A, &_B[0]);
+  M16N8K16TN(&_C[1], A, &_B[1]);
+}
+
 } // namespace Ampere
 
 #endif // Arch 80

--- a/runtime/tensorcore.cu
+++ b/runtime/tensorcore.cu
@@ -167,7 +167,7 @@ __device__ inline void initM16N16K4(Array<float, 8, 8>* accumulator) {
 
 namespace Turing {
 
-__device__ inline void initM16N8K16TN(Array<float, 4, 4>* accumulator) {
+__device__ inline void initM16N8K16(Array<float, 4, 4>* accumulator) {
   accumulator->set(0);
 }
 
@@ -198,6 +198,22 @@ __device__ inline void M16N8K16TN(
         "r"(_D[1]),
         "r"(_D[2]),
         "r"(_D[3]));
+}
+
+__device__ inline void initM16N16K16(Array<float, 8, 8>* accumulator) {
+  auto* _C = reinterpret_cast<Array<float, 4, 4>*>(accumulator);
+  initM16N8K16(&_C[0]);
+  initM16N8K16(&_C[1]);
+}
+
+__device__ inline void M16N16K16TN(
+    Array<float, 8, 8>* C,
+    Array<__half, 8, 8>* A,
+    Array<__half, 8, 8>* B) {
+  auto* _C = reinterpret_cast<Array<float, 4, 4>*>(C);
+  auto* _B = reinterpret_cast<Array<__half, 4, 4>*>(B);
+  M16N8K16TN(&_C[0], A, &_B[0]);
+  M16N8K16TN(&_C[1], A, &_B[1]);
 }
 
 } // namespace Turing

--- a/runtime/tensorcore.cu
+++ b/runtime/tensorcore.cu
@@ -6,7 +6,6 @@
  */
 // clang-format on
 // Utility macro for this file
-#define DEVICE_INLINE __device__ inline
 
 // MMA instruction wrappers:
 //  The wrappers are subroutines that implement matrix of size
@@ -22,7 +21,6 @@
 //   notation.
 namespace Volta {
 
-namespace util {
 // MMA instruction wrappers (sm_70+):
 // The instruction wrappers below are quarter-warp macros, which currently
 //  nvfuser doesn't explicitly model.
@@ -32,7 +30,8 @@ namespace util {
 //  8x8x4 mma instruction, per quarter warp (8 threads), fp32 accumulate
 //  per thread register:
 //   A[4] x B[4] -> C[8]
-DEVICE_INLINE void mmaM8n8k4tt(
+
+__device__ inline void M16N16K4TT(
     Array<float, 8, 8>* C,
     Array<__half, 4, 4>* A,
     Array<__half, 4, 4>* B) {
@@ -63,7 +62,7 @@ DEVICE_INLINE void mmaM8n8k4tt(
         "r"(_C[7]));
 }
 
-DEVICE_INLINE void mmaM8n8k4tn(
+__device__ inline void M16N16K4TN(
     Array<float, 8, 8>* C,
     Array<__half, 4, 4>* A,
     Array<__half, 4, 4>* B) {
@@ -94,7 +93,7 @@ DEVICE_INLINE void mmaM8n8k4tn(
         "r"(_C[7]));
 }
 
-DEVICE_INLINE void mmaM8n8k4nt(
+__device__ inline void M16N16K4NT(
     Array<float, 8, 8>* C,
     Array<__half, 4, 4>* A,
     Array<__half, 4, 4>* B) {
@@ -125,7 +124,7 @@ DEVICE_INLINE void mmaM8n8k4nt(
         "r"(_C[7]));
 }
 
-DEVICE_INLINE void mmaM8n8k4nn(
+__device__ inline void M16N16K4NN(
     Array<float, 8, 8>* C,
     Array<__half, 4, 4>* A,
     Array<__half, 4, 4>* B) {
@@ -156,112 +155,10 @@ DEVICE_INLINE void mmaM8n8k4nn(
         "r"(_C[7]));
 }
 
-// TODO: in a follow up,
-//    lift this part onto iterdomain ops, once the
-//    swizzle ops are ready.
-template <int acc_stride>
-DEVICE_INLINE Array<float, 8, 8> accToMma(float* _C) {
-  float C_data[8] = {
-      _C[0],
-      _C[1],
-      _C[acc_stride],
-      _C[acc_stride + 1],
-      _C[2],
-      _C[3],
-      _C[acc_stride + 2],
-      _C[acc_stride + 3],
-  };
-
-  return *reinterpret_cast<Array<float, 8, 8>*>(&C_data[0]);
-}
-
-template <int acc_stride>
-DEVICE_INLINE void mmaToAcc(float* _C, Array<float, 8, 8>& C) {
-  float* C_data = reinterpret_cast<float*>(&C);
-  _C[0] = C_data[0];
-  _C[1] = C_data[1];
-  _C[acc_stride] = C_data[2];
-  _C[acc_stride + 1] = C_data[3];
-  _C[2] = C_data[4];
-  _C[3] = C_data[5];
-  _C[acc_stride + 2] = C_data[6];
-  _C[acc_stride + 3] = C_data[7];
-}
-
-// Should be able to lift this with transpose op as well.
-template <int acc_stride>
-DEVICE_INLINE void initM16N16K4(Array<float, 8, 8>& accumulator) {
-  float* _C = reinterpret_cast<float*>(&accumulator);
-  float zeros[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-  mmaToAcc<acc_stride>(_C, *reinterpret_cast<Array<float, 8, 8>*>(&zeros[0]));
-}
-
-} // namespace util
-
-template <int acc_stride>
-DEVICE_INLINE void M16N16K4TT(
-    Array<float, 8, 8>* C,
-    Array<__half, 4, 4>* A,
-    Array<__half, 4, 4>* B) {
-  float* _C = reinterpret_cast<float*>(C);
-  Array<float, 8, 8> C_data = util::accToMma<acc_stride>(_C);
-  util::mmaM8n8k4tt(&C_data, A, B);
-  util::mmaToAcc<acc_stride>(_C, C_data);
-}
-
-template <int acc_stride>
-DEVICE_INLINE void M16N16K4TN(
-    Array<float, 8, 8>* C,
-    Array<__half, 4, 4>* A,
-    Array<__half, 4, 4>* B) {
-  float* _C = reinterpret_cast<float*>(C);
-  Array<float, 8, 8> C_data = util::accToMma<acc_stride>(_C);
-  util::mmaM8n8k4tn(&C_data, A, B);
-  util::mmaToAcc<acc_stride>(_C, C_data);
-}
-
-template <int acc_stride>
-DEVICE_INLINE void M16N16K4NT(
-    Array<float, 8, 8>* C,
-    Array<__half, 4, 4>* A,
-    Array<__half, 4, 4>* B) {
-  float* _C = reinterpret_cast<float*>(C);
-  Array<float, 8, 8> C_data = util::accToMma<acc_stride>(_C);
-  util::mmaM8n8k4nt(&C_data, A, B);
-  util::mmaToAcc<acc_stride>(_C, C_data);
-}
-
-template <int acc_stride>
-DEVICE_INLINE void M16N16K4NN(
-    Array<float, 8, 8>* C,
-    Array<__half, 4, 4>* A,
-    Array<__half, 4, 4>* B) {
-  float* _C = reinterpret_cast<float*>(C);
-  Array<float, 8, 8> C_data = util::accToMma<acc_stride>(_C);
-  util::mmaM8n8k4nn(&C_data, A, B);
-  util::mmaToAcc<acc_stride>(_C, C_data);
-}
-
 // Same initialization for now, will be different in interleaved
 //   macros
-template <int acc_stride>
-DEVICE_INLINE void initM16N16K4TT(Array<float, 8, 8>* accumulator) {
-  util::initM16N16K4<acc_stride>(*accumulator);
-}
-
-template <int acc_stride>
-DEVICE_INLINE void initM16N16K4TN(Array<float, 8, 8>* accumulator) {
-  util::initM16N16K4<acc_stride>(*accumulator);
-}
-
-template <int acc_stride>
-DEVICE_INLINE void initM16N16K4NT(Array<float, 8, 8>* accumulator) {
-  util::initM16N16K4<acc_stride>(*accumulator);
-}
-
-template <int acc_stride>
-DEVICE_INLINE void initM16N16K4NN(Array<float, 8, 8>* accumulator) {
-  util::initM16N16K4<acc_stride>(*accumulator);
+__device__ inline void initM16N16K4(Array<float, 8, 8>* accumulator) {
+  accumulator->set(0);
 }
 
 } // namespace Volta
@@ -270,9 +167,11 @@ DEVICE_INLINE void initM16N16K4NN(Array<float, 8, 8>* accumulator) {
 
 namespace Turing {
 
-namespace util {
-// MMA instruction wrappers (sm_75+):
-DEVICE_INLINE void m16n8k16TN(
+__device__ inline void initM16N8K16TN(Array<float, 4, 4>* accumulator) {
+  accumulator->set(0);
+}
+
+__device__ inline void M16N8K16TN(
     Array<float, 4, 4>* C,
     Array<__half, 8, 8>* A,
     Array<__half, 4, 4>* B) {
@@ -301,59 +200,6 @@ DEVICE_INLINE void m16n8k16TN(
         "r"(_D[3]));
 }
 
-} // namespace util
-
-template <int acc_stride>
-DEVICE_INLINE void initM16N8K16TN(Array<float, 4, 4>* accumulator) {
-  float* _C = reinterpret_cast<float*>(accumulator);
-  _C[0] = 0;
-  _C[1] = 0;
-  _C[acc_stride] = 0;
-  _C[acc_stride + 1] = 0;
-}
-
-template <int acc_stride = 2>
-DEVICE_INLINE void M16N8K16TN(
-    Array<float, 4, 4>* C,
-    Array<__half, 8, 8>* A,
-    Array<__half, 4, 4>* B) {
-  // TODO: in a follow up,
-  //    lift this fused swizzle onto iterdomain
-  float* _C = reinterpret_cast<float*>(C);
-  float C_data[4] = {_C[0], _C[1], _C[acc_stride], _C[acc_stride + 1]};
-
-  util::m16n8k16TN(reinterpret_cast<Array<float, 4, 4>*>(&C_data[0]), A, B);
-
-  _C[0] = C_data[0];
-  _C[1] = C_data[1];
-  _C[acc_stride] = C_data[2];
-  _C[acc_stride + 1] = C_data[3];
-}
-
-template <int acc_stride>
-DEVICE_INLINE void initM16N16K16TN(Array<float, 8, 8>* accumulator) {
-  float* _C = reinterpret_cast<float*>(accumulator);
-  initM16N8K16TN<acc_stride>(reinterpret_cast<Array<float, 4, 4>*>(&_C[0]));
-  initM16N8K16TN<acc_stride>(reinterpret_cast<Array<float, 4, 4>*>(&_C[2]));
-}
-
-template <int acc_stride = 2>
-DEVICE_INLINE void M16N16K16TN(
-    Array<float, 8, 8>* C,
-    Array<__half, 8, 8>* A,
-    Array<__half, 8, 8>* B) {
-  float* _C = reinterpret_cast<float*>(C);
-  __half* _B = reinterpret_cast<__half*>(B);
-  M16N8K16TN<acc_stride>(
-      reinterpret_cast<Array<float, 4, 4>*>(&_C[0]),
-      A,
-      reinterpret_cast<Array<__half, 4, 4>*>(&_B[0]));
-  M16N8K16TN<acc_stride>(
-      reinterpret_cast<Array<float, 4, 4>*>(&_C[2]),
-      A,
-      reinterpret_cast<Array<__half, 4, 4>*>(&_B[4]));
-}
-
 } // namespace Turing
 
 #endif // Arch 75
@@ -362,9 +208,11 @@ DEVICE_INLINE void M16N16K16TN(
 
 namespace Ampere {
 
-namespace util {
-// MMA instruction wrappers (sm_75+):
-DEVICE_INLINE void m16n8k16TN(
+__device__ inline void initM16N8K16TN(Array<float, 4, 4>* accumulator) {
+  accumulator->set(0);
+}
+
+__device__ inline void M16N8K16TN(
     Array<float, 4, 4>* C,
     Array<__half, 8, 8>* A,
     Array<__half, 4, 4>* B) {
@@ -387,7 +235,7 @@ DEVICE_INLINE void m16n8k16TN(
         "r"(_D[3]));
 }
 
-DEVICE_INLINE void m16n8k16TN(
+__device__ inline void M16N8K16TN(
     Array<float, 4, 4>* C,
     Array<__bfloat, 8, 8>* A,
     Array<__bfloat, 4, 4>* B) {
@@ -410,61 +258,6 @@ DEVICE_INLINE void m16n8k16TN(
         "r"(_D[3]));
 }
 
-} // namespace util
-
-template <int acc_stride>
-DEVICE_INLINE void initM16N8K16TN(Array<float, 4, 4>* accumulator) {
-  float* _C = reinterpret_cast<float*>(accumulator);
-  _C[0] = 0;
-  _C[1] = 0;
-  _C[acc_stride] = 0;
-  _C[acc_stride + 1] = 0;
-}
-
-template <int acc_stride = 2, typename T = __half>
-DEVICE_INLINE void M16N8K16TN(
-    Array<float, 4, 4>* C,
-    Array<T, 8, 8>* A,
-    Array<T, 4, 4>* B) {
-  // TODO: in a follow up,
-  //    lift this fused swizzle onto iterdomain
-  float* _C = reinterpret_cast<float*>(C);
-  float C_data[4] = {_C[0], _C[1], _C[acc_stride], _C[acc_stride + 1]};
-
-  util::m16n8k16TN(reinterpret_cast<Array<float, 4, 4>*>(&C_data[0]), A, B);
-
-  _C[0] = C_data[0];
-  _C[1] = C_data[1];
-  _C[acc_stride] = C_data[2];
-  _C[acc_stride + 1] = C_data[3];
-}
-
-template <int acc_stride>
-DEVICE_INLINE void initM16N16K16TN(Array<float, 8, 8>* accumulator) {
-  float* _C = reinterpret_cast<float*>(accumulator);
-  initM16N8K16TN<acc_stride>(reinterpret_cast<Array<float, 4, 4>*>(&_C[0]));
-  initM16N8K16TN<acc_stride>(reinterpret_cast<Array<float, 4, 4>*>(&_C[2]));
-}
-
-template <int acc_stride = 2, typename T = __half>
-DEVICE_INLINE void M16N16K16TN(
-    Array<float, 8, 8>* C,
-    Array<T, 8, 8>* A,
-    Array<T, 8, 8>* B) {
-  float* _C = reinterpret_cast<float*>(C);
-  T* _B = reinterpret_cast<T*>(B);
-  M16N8K16TN<acc_stride>(
-      reinterpret_cast<Array<float, 4, 4>*>(&_C[0]),
-      A,
-      reinterpret_cast<Array<T, 4, 4>*>(&_B[0]));
-  M16N8K16TN<acc_stride>(
-      reinterpret_cast<Array<float, 4, 4>*>(&_C[2]),
-      A,
-      reinterpret_cast<Array<T, 4, 4>*>(&_B[4]));
-}
-
 } // namespace Ampere
 
 #endif // Arch 80
-
-#undef DEVICE_INLINE

--- a/runtime/tensorcore.cu
+++ b/runtime/tensorcore.cu
@@ -208,7 +208,7 @@ __device__ inline void M16N8K16TN(
 
 namespace Ampere {
 
-__device__ inline void initM16N8K16TN(Array<float, 4, 4>* accumulator) {
+__device__ inline void initM16N8K16(Array<float, 4, 4>* accumulator) {
   accumulator->set(0);
 }
 


### PR DESCRIPTION
Matmul support was initially developed before we invented the concept "allocation domain". Without the concept of "allocation domain", our codegen has lots of limitations. One limitation is, the allocation is always based on the order of the rFactor domain, even for tensors allocated on shared memory or local memory. For example, if I have a tenor `[M, N]`, and I do some splits and reorder to get `[BIDx{M/2}, TIDx{N/3/5}, 3, 2, 5]` and the memory layout of the register will always be `[2, 3, 5]`, regardless of how we reorder these three numbers in leaf domain.

Due to this limitation, scheduling the layout of MMA output was fundamentally impossible. For example, in the [memory layout for Volta MMA](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m8n8k4-with-f16-floating-point-type):
![](https://docs.nvidia.com/cuda/parallel-thread-execution/_images/mma-884-C-f32-1.png)
the memory layout of register should be:
```
N --(splits)--> [N/8, 2*, 2**, 2***]
M --(splits)--> [M/4, 2', 2'']
register layout: [2*, 2', 2***]
```
which has interleaved M and N.

The workaround? If you look at the code in `tensorcore.cu`, each MMA op has a template argument `acc_stride`. For example, in this function:
```CUDA
template <int acc_stride>
DEVICE_INLINE void initM16N8K16TN(Array<float, 4, 4>* accumulator) {
  float* _C = reinterpret_cast<float*>(accumulator);
  _C[0] = 0;
  _C[1] = 0;
  _C[acc_stride] = 0;
  _C[acc_stride + 1] = 0;
}
```
we accept an array[4] as a parameter, however, we are intentionally doing out of boundary access inside this function, instead of using the four items passed as arguments. This approach in practice works, but is definitely not the correct way of doing engineering.

In the original design, there would be a "transpose swizzle" which takes care of this, but that never got implemented. Today, we have a better solution: we can just set the allocation domain to the desired order we want, and the `accumulator` passed in will automatically contain the elements we want. The `accumulator_stride` hack is no longer needed.

The major change of this PR is actually just three lines, see the change in `csrc/tensor_view.cpp::TensorView::applyMmaSwizzle`, the rest of this PR are just clean ups. These three lines just set the allocation domain to leaf domain, which has the correct memory layout.

cc: @jjsjann123 @wujingyue who may be interested in this PR because this is the first time that allocation domain get used in a scheduler to do some serious work. Feel free to ask questions or leave comments.
cc: @naoyam as always 