### PR TITLE
Standardize mangled kernel name in ptx

### DIFF
--- a/tools/codediff/diff_report.py
+++ b/tools/codediff/diff_report.py
@@ -633,6 +633,23 @@ class TestDiff:
     kernel_diffs: list[KernelDiff] | None = None
 
 
+def sanitize_ptx_lines(lines: list[str]) -> list[str]:
+    """Remove comments and translate kernel38 to kernelN"""
+    sanitary_lines = []
+    for l in lines:
+        # Replace mangled kernel names like
+        #   _ZN11CudaCodeGen10kernel1271ENS_6TensorIfLi2ELi2EEENS0_IfLi3ELi3EEES2_
+        # with
+        #   _ZN11CudaCodeGen7kernelNENS_6TensorIfLi2ELi2EEENS0_IfLi3ELi3EEES2_
+        l = re.sub(r"CudaCodeGen\d+kernel\d+ENS", "CudaCodeGen7kernelNENS", l)
+
+        # Remove comments. This is important for
+        l = re.sub(r"//.*$", "", l)
+        sanitary_lines.append(l)
+        print("Sanitized:", l.rstrip())
+    return sanitary_lines
+
+
 @dataclass
 class TestDifferences:
     run1: TestRun
@@ -706,14 +723,10 @@ class TestDifferences:
 
                 ptx_diff_lines = None
                 if kern1.ptx is not None and kern2.ptx is not None:
-
-                    def strip_comments(l: str) -> str:
-                        return re.sub(r"//.*$", "", l)
-
                     ptx_diff_lines = list(
                         difflib.unified_diff(
-                            [strip_comments(l) for l in kern1.ptx.splitlines()],
-                            [strip_comments(l) for l in kern2.ptx.splitlines()],
+                            sanitize_ptx_lines(kern1.ptx.splitlines()),
+                            sanitize_ptx_lines(kern2.ptx.splitlines()),
                             fromfile=self.run1.name,
                             tofile=self.run2.name,
                             n=5,


### PR DESCRIPTION
This should reduce false positives like those seen in http://nv/e5M/nvfuser_github_ci/codegen_diff_p10551865_j73238023_1698902733422536803_codediff_f450ece_ed879b8_custom_command_20231101_213723.html associated with #1176.