### PR TITLE
Transpose benchmark

### DIFF
--- a/python_benchmarks/test_transpose.py
+++ b/python_benchmarks/test_transpose.py
@@ -1,0 +1,78 @@
+import pytest
+from nvfuser import FusionDefinition, DataType
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from .core import run_benchmark
+import torch
+from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+
+def transpose_fusion(
+    fd: FusionDefinition,
+    dtype: DataType,
+    config: dict,
+    axes: list,
+):
+    T0 = fd.define_tensor(shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False)
+    T1 = fd.define_tensor(shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False)
+
+    if dtype in PROMOTE_DTYPES:
+        T0 = fd.ops.cast(T0, dtype=DataType.Float)
+        T1 = fd.ops.cast(T1, dtype=DataType.Float)
+    
+    if config['transpose_input1']:
+        T0 = fd.ops.permute(T0, dims=axes)
+    
+    if config['transpose_input2']:
+        T1 = fd.ops.permute(T1, dims=axes)
+        
+    T4 = fd.ops.add(T0, T1)
+
+    if config['transpose_intermediate']:
+        T4 = fd.ops.permute(T4, dims=axes)
+    
+    if dtype in PROMOTE_DTYPES:
+        T4 = fd.ops.cast(T4, dtype=dtype)
+
+    S6 = fd.define_scalar(0.00000, dtype=DataType.Double)
+    T7 = fd.ops.gt(T4, S6)
+    T9 = fd.ops.where(T7, T4, S6)
+
+    if config['transpose_output']:
+        T7 = fd.ops.permute(T7, dims=axes)
+        T9 = fd.ops.permute(T9, dims=axes)
+
+    fd.add_output(T7)
+    fd.add_output(T9)
+
+@pytest.mark.parametrize("size", [(128, 64)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+# @pytest.mark.parametrize("axes", [()])
+def test_transpose_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    disable_validation: bool,
+    disable_benchmarking: bool,
+):
+    input1 = torch.randn(*size, device="cuda", dtype=dtype)
+    input2 = torch.randn(*size, device="cuda", dtype=dtype)
+    config = {'transpose_input1': False,
+              'transpose_input2': False,
+              'transpose_intermediate': False,
+              'transpose_output': True}
+    
+    with FusionDefinition() as fd:
+        transpose_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), config, (0, 1))
+    
+    if not disable_validation:
+        nvf_output = fd.execute([input1, input2])
+        eager_output = torch.nn.functional.relu(input1 + input2)
+        print(eager_output.shape)
+        print(nvf_output[1].shape)
+
+        assert torch.allclose(
+            nvf_output[1], eager_output, rtol=1e-3, atol=1e-3
+        ), f"{torch.max(nvf_output[1] - eager_output)}"
+
+    if not disable_benchmarking:
+        run_benchmark(benchmark, fd.execute, [input1, input2])
+

--- a/python_benchmarks/test_transpose.py
+++ b/python_benchmarks/test_transpose.py
@@ -59,15 +59,12 @@ def test_transpose_benchmark(
         transpose_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), permute_axes)
 
     if not disable_validation:
-        nvf_output = fd.execute([input1, input2])
         eager_output = torch.nn.functional.relu(
             torch.transpose(input1 + input2, axes[0], axes[1])
         )
-        assert torch.allclose(
-            nvf_output[1], eager_output, rtol=1e-3, atol=1e-3
-        ), f"{torch.max(nvf_output[1] - eager_output)}"
+        fd.validate([input1, input2], [eager_output])
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [input1, input2])
-    
+
     torch.cuda.empty_cache()

--- a/python_benchmarks/test_transpose.py
+++ b/python_benchmarks/test_transpose.py
@@ -69,3 +69,5 @@ def test_transpose_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [input1, input2])
+    
+    torch.cuda.empty_cache()

--- a/python_benchmarks/test_transpose.py
+++ b/python_benchmarks/test_transpose.py
@@ -32,7 +32,6 @@ def transpose_fusion(
     T7 = fd.ops.gt(T5, S6)
     T9 = fd.ops.where(T7, T5, S6)
 
-    fd.add_output(T7)
     fd.add_output(T9)
 
 

--- a/python_benchmarks/test_transpose.py
+++ b/python_benchmarks/test_transpose.py
@@ -5,74 +5,67 @@ from .core import run_benchmark
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
+
 def transpose_fusion(
     fd: FusionDefinition,
     dtype: DataType,
-    config: dict,
     axes: list,
 ):
-    T0 = fd.define_tensor(shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False)
-    T1 = fd.define_tensor(shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False)
+    T0 = fd.define_tensor(
+        shape=[-1, -1, -1], contiguity=[True, True, True], dtype=dtype, is_cpu=False
+    )
+    T1 = fd.define_tensor(
+        shape=[-1, -1, -1], contiguity=[True, True, True], dtype=dtype, is_cpu=False
+    )
 
     if dtype in PROMOTE_DTYPES:
         T0 = fd.ops.cast(T0, dtype=DataType.Float)
         T1 = fd.ops.cast(T1, dtype=DataType.Float)
-    
-    if config['transpose_input1']:
-        T0 = fd.ops.permute(T0, dims=axes)
-    
-    if config['transpose_input2']:
-        T1 = fd.ops.permute(T1, dims=axes)
-        
-    T4 = fd.ops.add(T0, T1)
 
-    if config['transpose_intermediate']:
-        T4 = fd.ops.permute(T4, dims=axes)
-    
+    T4 = fd.ops.add(T0, T1)
+    T5 = fd.ops.permute(T4, dims=axes)
+
     if dtype in PROMOTE_DTYPES:
-        T4 = fd.ops.cast(T4, dtype=dtype)
+        T5 = fd.ops.cast(T5, dtype=dtype)
 
     S6 = fd.define_scalar(0.00000, dtype=DataType.Double)
-    T7 = fd.ops.gt(T4, S6)
-    T9 = fd.ops.where(T7, T4, S6)
-
-    if config['transpose_output']:
-        T7 = fd.ops.permute(T7, dims=axes)
-        T9 = fd.ops.permute(T9, dims=axes)
+    T7 = fd.ops.gt(T5, S6)
+    T9 = fd.ops.where(T7, T5, S6)
 
     fd.add_output(T7)
     fd.add_output(T9)
 
-@pytest.mark.parametrize("size", [(128, 64)])
+
+@pytest.mark.parametrize("size", generate_input_sizes(dims=3))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-# @pytest.mark.parametrize("axes", [()])
+@pytest.mark.parametrize("axes", [(0, 1), (0, 2), (1, 2)])
 def test_transpose_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
+    axes: list,
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
     input1 = torch.randn(*size, device="cuda", dtype=dtype)
     input2 = torch.randn(*size, device="cuda", dtype=dtype)
-    config = {'transpose_input1': False,
-              'transpose_input2': False,
-              'transpose_intermediate': False,
-              'transpose_output': True}
-    
+    permute_axes = list(range(len(size)))
+    permute_axes[axes[0]], permute_axes[axes[1]] = (
+        permute_axes[axes[1]],
+        permute_axes[axes[0]],
+    )
+
     with FusionDefinition() as fd:
-        transpose_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), config, (0, 1))
-    
+        transpose_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), permute_axes)
+
     if not disable_validation:
         nvf_output = fd.execute([input1, input2])
-        eager_output = torch.nn.functional.relu(input1 + input2)
-        print(eager_output.shape)
-        print(nvf_output[1].shape)
-
+        eager_output = torch.nn.functional.relu(
+            torch.transpose(input1 + input2, axes[0], axes[1])
+        )
         assert torch.allclose(
             nvf_output[1], eager_output, rtol=1e-3, atol=1e-3
         ), f"{torch.max(nvf_output[1] - eager_output)}"
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [input1, input2])
-


### PR DESCRIPTION
Ports the `transpose` benchmark at: https://github.com/NVIDIA/Fuser/blob/main/benchmark/transpose.cpp
As compared to the CPP benchmark, the intermediate output is transposed instead of the input. 
The fusion definition when one of the inputs/output is transposed does not include the `transpose` op in the fusion due to optimizations. 