### PR TITLE
Fix a regression due to #1218

### DIFF
--- a/csrc/options.h
+++ b/csrc/options.h
@@ -34,8 +34,6 @@ enum class DebugDumpOption {
   CudaToFile, //!< Dump CUDA Strings to File
   DebugInfo, //!< Embed line info and debug info to compiled kernel, and dump
              //!< the full CUDA C++ code
-  AssertMemoryViolation, //!< Assert in the kernel when accessing global tensor
-                         //!< out of bound. This might hurt performance.
   LaunchParam, //!< Dump the Launch parameters of kernel
   FusionSegments, //!< Dump Segmented Fusion Graph
   FusionSegmenterLog, //!< Dump Detailed Segmenter Logging
@@ -76,12 +74,8 @@ enum class DebugDumpOption {
 //! These can be set through the `NVFUSER_ENABLE` environment variable
 //!
 enum class EnableOption {
-  Complex, //! Enable complex support on python
-  ConvDecomposition, //! Enable conv-bias decomposition
-  GraphOp, //! Enable graphOps(index_select/gather/scatter)
   KernelDb, //! Enable Kernel Database
   KernelProfile, //! Enable intra-kernel performance profiling
-  LinearDecomposition, //! Enable linear-bias decomposition
   MemoryPromotion, //! Enable promotion of memory types for non-pointwise ops
   WarnRegisterSpill, //! Enable warnings of register spill
   EndOfOption //! Placeholder for counting the number of elements


### PR DESCRIPTION
The TOT fails as:

```
terminate called after throwing an instance of 'nvfuser::nvfError'
  what():  available_options.size() == static_cast<int>(OptionEnum::EndOfOption) INTERNAL ASSERT FAILED at "/raid/nmaruyama/debug2/csrc/options.cpp":24, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues. Invalid available option map
Exception raised from parseEnvOptions at /raid/nmaruyama/debug2/csrc/options.cpp:24 (most recent call first):
```

Unused options were removed in #1218. Those options need to be done with the structs as well.