### PR TITLE
Fix build error and merge PR #1190 and #1022

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1264,26 +1264,11 @@ std::vector<at::Tensor> FusionExecutor::allocOutputSpace(
   auto expr_eval =
       executor_utils::bindInputs(kernel_inputs, lowered_->kernel());
 
-  auto input_output_aliases_entry =
-      executor_utils::caching::ExecutorCompileTimeEntry<
-          executor_utils::caching::InputOutputAliases>(
-          compileTimeDataCache(), [&]() {
-            return std::make_unique<std::vector<InputOutputAlias>>(
-                fusion_->getOutputToInputAliasIndices());
-          });
-
-  const auto& output_to_input_aliases = input_output_aliases_entry.get();
-
   auto output_info =
       getOutputBufferInfo(kernel_inputs, expr_eval, kernel()->indexType());
 
   return allocOutputs(
-      kernel(),
-      output_info,
-      output_to_input_aliases,
-      kernel_inputs,
-      options_.device,
-      expr_eval);
+      kernel(), output_info, kernel_inputs, options_.device, expr_eval);
 }
 
 std::vector<FusionExecutor::GlobalBufferInfo> FusionExecutor::


### PR DESCRIPTION
The signature of `allocOutputs` has changed in #1190 just before #1022 was merged. This PR fixes the merge