### PR TITLE
Remove the special handling for trivial forwarding.

### DIFF
--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -197,8 +197,7 @@ class ArgumentManager {
       const PolymorphicValue*& runtime_output = tensor_map_[output];
       if (runtime_output != nullptr) {
         // A trivial forwarding output shares the same `Val*` as an input, so we
-        // simply map it to the same runtime output. See note [Trivial
-        // Forwarding].
+        // simply map it to the same runtime output.
         continue;
       }
 

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -5059,27 +5059,6 @@ TEST_F(NVFuserTest, FusionInlineAt_CUDA) {
   testValidate(fusion, {out}, {t0}, {t0.sin().cos()}, __LINE__, __FILE__);
 }
 
-TEST_F(NVFuserTest, FusionTrivialInputForwarding_FusionExecutor) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
-
-  TensorView* tv0 = makeConcreteTensor({-1, -1});
-  TensorView* tv1 = makeConcreteTensor({-1, -1});
-  fusion.addInput(tv0);
-  fusion.addInput(tv1);
-  fusion.addOutput(tv0);
-
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor t0 = at::randn({10, 4}, options);
-  at::Tensor t1 = at::randn({10, 4}, options);
-
-  FusionExecutor fe;
-  fe.compileFusion(&fusion, {t0, t1});
-  at::Tensor t0_forward = fe.runFusion({t0, t1})[0];
-
-  EXPECT_EQ(t0_forward.data_ptr(), t0.data_ptr());
-}
-
 TEST_F(NVFuserTest, FusionTrivialInputForwarding_FusionExecutorCache) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   auto fusion = fusion_ptr.get();


### PR DESCRIPTION
Trivial forwarding is merely a special case of aliasing.

This PR removes the FusionExecutor-level test for trivial forwarding. FusionExecutor doesn't run MarkAliasPass, which calls `aliasOutputToInput` to mark aliases. This however shouldn't be a problem for integration.