### PR TITLE
DeviceMesh printing utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/maxinfo_propagator.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/communication.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/communicator.cpp
+  ${NVFUSER_SRCS_DIR}/multidevice/device_mesh.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/executor.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/lower_communication.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/pipeline.cpp

--- a/csrc/multidevice/device_mesh.cpp
+++ b/csrc/multidevice/device_mesh.cpp
@@ -1,0 +1,27 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <multidevice/device_mesh.h>
+
+namespace nvfuser {
+
+std::string DeviceMesh::toString() const {
+  std::stringstream ss;
+  ss << "DeviceMesh{";
+  for (auto i : vector_) {
+    ss << i << ", ";
+  }
+  ss << "}";
+  return ss.str();
+}
+
+std::ostream& operator<<(std::ostream& out, const DeviceMesh& mesh) {
+  return out << mesh.toString();
+}
+
+} // namespace nvfuser

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -23,6 +23,8 @@ class DeviceMesh final {
     setDevices(devices);
   }
 
+  std::string toString() const;
+
   DeviceMesh& operator=(const std::vector<DeviceIdxType>& devices) {
     setDevices(devices);
     return *this;
@@ -59,5 +61,7 @@ class DeviceMesh final {
   // stores the list of device indices
   std::vector<DeviceIdxType> vector_;
 };
+
+std::ostream& operator<<(std::ostream& out, const DeviceMesh& mesh);
 
 } // namespace nvfuser


### PR DESCRIPTION
add printing utilities for DeviceMesh, which is really useful for debug.
We define the method `std::string toString() const` as usually done. This class will later inherit from Val and so this function is required anyway
We define the `operator<<` so that gtest can print the DeviceMesh on which there is failure