### PR TITLE
Check allocation domain and contiguity of aliased tensors.

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -955,6 +955,7 @@ at::Tensor allocateOutput(
             out_tv->toString(),
             " as an alias of ",
             in_tv->toString());
+        inferAndValidateAllocationSizesAndStrides(out_tensor, out_tv, ee);
         return out_tensor;
     }
   }

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -274,15 +274,8 @@ void validateAllocationSizesAndStrides(
   }
 }
 
-// Given an ATen tensor, whose sizes and strides are w.r.t to the rFactor domain
-// of its corresponding TensorView, compute the sizes and strides of the tensor
-// with respect to its allocation domain.
-// For example, if the rFactor domain is [I1, I2], and the allocation domain is
-// [I2*I1], and the tensor's size is [5, 3] and stride is [2, 10], then the
-// resulting size will be [15] and stride will be [2]
-// Another example, if the rFactor domain is [I1*I2] and the allocation domain
-// is [I1, I2], and the tensor's size is [15] and stride is [7], and the extent
-// of I2 is 5, then the resulting size will be [3, 5] and stride will be [35, 7]
+} // namespace
+
 std::pair<std::vector<int64_t>, std::vector<int64_t>>
 inferAndValidateAllocationSizesAndStrides(
     const at::Tensor& tensor,
@@ -329,8 +322,6 @@ inferAndValidateAllocationSizesAndStrides(
   validateAllocationSizesAndStrides(alloc, tv->getContiguity(), sizes, strides);
   return {std::move(sizes), std::move(strides)};
 }
-
-} // namespace
 
 std::vector<PolymorphicValue> GetMetaData::evaluate(
     const ExpressionEvaluator& ee,

--- a/csrc/tensor_metadata.h
+++ b/csrc/tensor_metadata.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <exceptions.h>
+#include <expr_evaluator.h>
+#include <ir/interface_nodes.h>
 #include <polymorphic_value.h>
 #include <type.h>
 

--- a/csrc/tensor_metadata.h
+++ b/csrc/tensor_metadata.h
@@ -98,4 +98,19 @@ struct TensorMetaData : public Struct {
   }
 };
 
+// Given an ATen tensor, whose sizes and strides are w.r.t to the rFactor domain
+// of its corresponding TensorView, compute the sizes and strides of the tensor
+// with respect to its allocation domain.
+// For example, if the rFactor domain is [I1, I2], and the allocation domain is
+// [I2*I1], and the tensor's size is [5, 3] and stride is [2, 10], then the
+// resulting size will be [15] and stride will be [2]
+// Another example, if the rFactor domain is [I1*I2] and the allocation domain
+// is [I1, I2], and the tensor's size is [15] and stride is [7], and the extent
+// of I2 is 5, then the resulting size will be [3, 5] and stride will be [35, 7]
+std::pair<std::vector<int64_t>, std::vector<int64_t>>
+inferAndValidateAllocationSizesAndStrides(
+    const at::Tensor& tensor,
+    TensorView* tv,
+    ExpressionEvaluator ee);
+
 } // namespace nvfuser


### PR DESCRIPTION
This requires to expose inferAndValidateAllocationSizesAndStrides from csrc/tensor_metadata.h.

The check should trivially pass **at this moment**, because `MarkAliasPass` doesn't proactively change allocation domains. However, it'll be more useful with changes staged in https://github.com/NVIDIA/Fuser/compare/wjy/slice. 

I could combine this PR into `wjy/slice` but figured sending small PRs probably makes code review easier. Let me know otherwise! 