### PR TITLE
Don't include pytorch in `rng_kernels.cu`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,6 +435,7 @@ if(BUILD_TEST)
   # CUDA 11 does not support C++20, so hard code C++17 here
   set_property(TARGET ${NVFUSER_TESTS_KERNELS} PROPERTY CXX_STANDARD 17)
   target_link_libraries(${NVFUSER_TESTS_KERNELS} PRIVATE torch ${TORCH_LIBRARIES} ${NVFUSER_CODEGEN})
+  target_include_directories(${NVFUSER_TESTS_KERNELS} PRIVATE "${NVFUSER_ROOT}")
 
   add_executable(${NVFUSER_TESTS} ${JIT_TEST_SRCS})
   set_property(TARGET ${NVFUSER_TESTS} PROPERTY CXX_STANDARD ${NVFUSER_CPP_STANDARD})

--- a/test/rng_helper.h
+++ b/test/rng_helper.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace at {
+struct PhiloxCudaState;
+}
+
+namespace nvfuser {
+
+enum RNGTest_t {
+  Uniform,
+  Normal,
+};
+
+template <typename T>
+void launch_generate_random_numbers_kernel(
+    cudaStream_t stream,
+    T* output,
+    int64_t size,
+    at::PhiloxCudaState philox_args,
+    RNGTest_t rng_test);
+}

--- a/test/rng_helper.h
+++ b/test/rng_helper.h
@@ -1,3 +1,11 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
 #pragma once
 
 namespace at {
@@ -18,4 +26,5 @@ void launch_generate_random_numbers_kernel(
     int64_t size,
     at::PhiloxCudaState philox_args,
     RNGTest_t rng_test);
-}
+
+} // namespace nvfuser

--- a/test/rng_kernels.cu
+++ b/test/rng_kernels.cu
@@ -83,7 +83,7 @@ __global__ void generate_random_numbers_kernel(
 }
 
 template <typename T>
-void lanuch_generate_random_numbers_kernel(
+void launch_generate_random_numbers_kernel(
     cudaStream_t stream,
     T* output,
     int64_t size,

--- a/test/rng_kernels.cu
+++ b/test/rng_kernels.cu
@@ -6,8 +6,9 @@
  */
 // clang-format on
 
-// Warning: this file should not include any header from nvFuser. Compiling
-// dynamic_type.h with nvcc is not supported.
+// Warning: this file should not include any header from nvFuser or pytorch
+// (except raw headers). Compiling dynamic_type.h with nvcc is not supported.
+// Compiling pytorch with nvcc is not supported either.
 
 #include <cassert>
 #include <cstdint>

--- a/test/rng_kernels.cu
+++ b/test/rng_kernels.cu
@@ -10,6 +10,8 @@
 // (except raw headers). Compiling dynamic_type.h with nvcc is not supported.
 // Compiling pytorch with nvcc is not supported either.
 
+#include <test/rng_helper.h>
+
 #include <cassert>
 #include <cstdint>
 #include <type_traits>
@@ -22,11 +24,6 @@
 #include <curand_philox4x32_x.h>
 
 namespace nvfuser {
-
-enum RNGTest_t {
-  Uniform,
-  Normal,
-};
 
 template <typename T>
 __global__ void generate_random_numbers_kernel(

--- a/test/rng_kernels.cu
+++ b/test/rng_kernels.cu
@@ -9,17 +9,16 @@
 // Warning: this file should not include any header from nvFuser. Compiling
 // dynamic_type.h with nvcc is not supported.
 
-#include <ATen/cuda/CUDAGeneratorImpl.h>
-#include <exceptions.h>
-#include <torch/torch.h>
-#include <ATen/cuda/CUDAGraphsUtils.cuh>
+#include <cassert>
+#include <cstdint>
+#include <type_traits>
+
+#include <ATen/cuda/detail/PhiloxCudaStateRaw.cuh>
+#include <ATen/cuda/detail/UnpackRaw.cuh>
 
 #include <curand.h>
 #include <curand_kernel.h>
 #include <curand_philox4x32_x.h>
-
-#include <cassert>
-#include <type_traits>
 
 namespace nvfuser {
 
@@ -82,53 +81,33 @@ __global__ void generate_random_numbers_kernel(
   }
 }
 
-at::Tensor generate_random_numbers(
+template <typename T>
+void lanuch_generate_random_numbers_kernel(
+    cudaStream_t stream,
+    T* output,
     int64_t size,
-    at::ScalarType dtype,
+    at::PhiloxCudaState philox_args,
     RNGTest_t rng_test) {
-  auto options = at::TensorOptions().dtype(dtype).device(at::kCUDA, 0);
-  auto result = at::empty({size}, options);
-
-  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-      c10::nullopt, at::cuda::detail::getDefaultCUDAGenerator());
-  at::PhiloxCudaState rng_engine_inputs;
-  {
-    // See Note [Acquire lock when using random generators]
-    std::lock_guard<std::mutex> lock(gen->mutex_);
-    rng_engine_inputs = gen->philox_cuda_state(4);
-  }
-
-  if (dtype == at::kFloat) {
-    int64_t block = 128;
-    int64_t block_elems = block * 4;
-    int64_t grid = (size + block_elems - 1) / block_elems;
-    generate_random_numbers_kernel<<<
-        grid,
-        block,
-        0,
-        at::cuda::getCurrentCUDAStream()>>>(
-        result.data_ptr<float>(), size, rng_engine_inputs, rng_test);
-  } else {
-    NVF_CHECK(dtype == at::kDouble);
-    int64_t block = 128;
-    int64_t block_elems = block * 2;
-    int64_t grid = (size + block_elems - 1) / block_elems;
-    generate_random_numbers_kernel<<<
-        grid,
-        block,
-        0,
-        at::cuda::getCurrentCUDAStream()>>>(
-        result.data_ptr<double>(), size, rng_engine_inputs, rng_test);
-  }
-  return result;
+  int64_t block = 128;
+  int64_t block_elems = block * 16 / sizeof(T);
+  int64_t grid = (size + block_elems - 1) / block_elems;
+  generate_random_numbers_kernel<<<grid, block, 0, stream>>>(
+      output, size, philox_args, rng_test);
+  cudaDeviceSynchronize();
 }
 
-at::Tensor generate_uniform(int64_t size, at::ScalarType dtype) {
-  return generate_random_numbers(size, dtype, RNGTest_t::Uniform);
-}
+template void lanuch_generate_random_numbers_kernel<float>(
+    cudaStream_t stream,
+    float* output,
+    int64_t size,
+    at::PhiloxCudaState philox_args,
+    RNGTest_t rng_test);
 
-at::Tensor generate_normal(int64_t size, at::ScalarType dtype) {
-  return generate_random_numbers(size, dtype, RNGTest_t::Normal);
-}
+template void lanuch_generate_random_numbers_kernel<double>(
+    cudaStream_t stream,
+    double* output,
+    int64_t size,
+    at::PhiloxCudaState philox_args,
+    RNGTest_t rng_test);
 
 } // namespace nvfuser

--- a/test/rng_kernels.cu
+++ b/test/rng_kernels.cu
@@ -97,14 +97,14 @@ void lanuch_generate_random_numbers_kernel(
   cudaDeviceSynchronize();
 }
 
-template void lanuch_generate_random_numbers_kernel<float>(
+template void launch_generate_random_numbers_kernel<float>(
     cudaStream_t stream,
     float* output,
     int64_t size,
     at::PhiloxCudaState philox_args,
     RNGTest_t rng_test);
 
-template void lanuch_generate_random_numbers_kernel<double>(
+template void launch_generate_random_numbers_kernel<double>(
     cudaStream_t stream,
     double* output,
     int64_t size,

--- a/test/test_rng.cpp
+++ b/test/test_rng.cpp
@@ -28,7 +28,7 @@ enum RNGTest_t {
 };
 
 template <typename T>
-void lanuch_generate_random_numbers_kernel(
+void launch_generate_random_numbers_kernel(
     cudaStream_t stream,
     T* output,
     int64_t size,
@@ -52,7 +52,7 @@ at::Tensor generate_random_numbers(
   }
 
   if (dtype == at::kFloat) {
-    lanuch_generate_random_numbers_kernel(
+    launch_generate_random_numbers_kernel(
         at::cuda::getCurrentCUDAStream(),
         result.data_ptr<float>(),
         size,
@@ -60,7 +60,7 @@ at::Tensor generate_random_numbers(
         rng_test);
   } else {
     NVF_CHECK(dtype == at::kDouble);
-    lanuch_generate_random_numbers_kernel(
+    launch_generate_random_numbers_kernel(
         at::cuda::getCurrentCUDAStream(),
         result.data_ptr<double>(),
         size,

--- a/test/test_rng.cpp
+++ b/test/test_rng.cpp
@@ -22,9 +22,61 @@
 
 namespace nvfuser {
 
-at::Tensor generate_uniform(int64_t size, at::ScalarType dtype);
+enum RNGTest_t {
+  Uniform,
+  Normal,
+};
 
-at::Tensor generate_normal(int64_t size, at::ScalarType dtype);
+template <typename T>
+void lanuch_generate_random_numbers_kernel(
+    cudaStream_t stream,
+    T* output,
+    int64_t size,
+    at::PhiloxCudaState philox_args,
+    RNGTest_t rng_test);
+
+at::Tensor generate_random_numbers(
+    int64_t size,
+    at::ScalarType dtype,
+    RNGTest_t rng_test) {
+  auto options = at::TensorOptions().dtype(dtype).device(at::kCUDA, 0);
+  auto result = at::empty({size}, options);
+
+  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      c10::nullopt, at::cuda::detail::getDefaultCUDAGenerator());
+  at::PhiloxCudaState rng_engine_inputs;
+  {
+    // See Note [Acquire lock when using random generators]
+    std::lock_guard<std::mutex> lock(gen->mutex_);
+    rng_engine_inputs = gen->philox_cuda_state(4);
+  }
+
+  if (dtype == at::kFloat) {
+    lanuch_generate_random_numbers_kernel(
+        at::cuda::getCurrentCUDAStream(),
+        result.data_ptr<float>(),
+        size,
+        rng_engine_inputs,
+        rng_test);
+  } else {
+    NVF_CHECK(dtype == at::kDouble);
+    lanuch_generate_random_numbers_kernel(
+        at::cuda::getCurrentCUDAStream(),
+        result.data_ptr<double>(),
+        size,
+        rng_engine_inputs,
+        rng_test);
+  }
+  return result;
+}
+
+at::Tensor generate_uniform(int64_t size, at::ScalarType dtype) {
+  return generate_random_numbers(size, dtype, RNGTest_t::Uniform);
+}
+
+at::Tensor generate_normal(int64_t size, at::ScalarType dtype) {
+  return generate_random_numbers(size, dtype, RNGTest_t::Normal);
+}
 
 class RNGTest : public NVFuserTest {};
 

--- a/test/test_rng.cpp
+++ b/test/test_rng.cpp
@@ -14,6 +14,7 @@
 #include <kernel_cache.h>
 #include <ops/all_ops.h>
 #include <scheduler/all_schedulers.h>
+#include <test/rng_helper.h>
 #include <test/utils.h>
 #include <test/validator.h>
 
@@ -21,19 +22,6 @@
 #include <ATen/cuda/CUDAGraphsUtils.cuh>
 
 namespace nvfuser {
-
-enum RNGTest_t {
-  Uniform,
-  Normal,
-};
-
-template <typename T>
-void launch_generate_random_numbers_kernel(
-    cudaStream_t stream,
-    T* output,
-    int64_t size,
-    at::PhiloxCudaState philox_args,
-    RNGTest_t rng_test);
 
 at::Tensor generate_random_numbers(
     int64_t size,


### PR DESCRIPTION
Just move more code from `rng_kernels.cu` to `test_rng.cpp`.

Because nvcc can not build pytorch:

```CUDA
[5/8] Building CUDA object CMakeFiles/nvfuser_tests_kernels.dir/test/rng_kernels.cu.o
FAILED: CMakeFiles/nvfuser_tests_kernels.dir/test/rng_kernels.cu.o 
/opt/cuda/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/usr/bin/clang -DUSE_C10D_GLOO -DUSE_C10D_NCCL -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dnvfuser_tests_kernels_EXPORTS -I/home/gaoxiang/Fuser3/cmake/../third_party/benchmark/include -I/home/gaoxiang/Fuser3/csrc -isystem /home/gaoxiang/Fuser3/cmake/../third_party/googletest/googlemock/include -isystem /home/gaoxiang/Fuser3/cmake/../third_party/googletest/googletest/include -isystem /home/gaoxiang/Fuser3/cmake/../third_party/flatbuffers/include -isystem /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include -isystem /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -isystem /opt/cuda/include -DONNX_NAMESPACE=onnx_c2 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -Xcudafe --diag_suppress=cc_clobber_ignored,--diag_suppress=field_without_dll_interface,--diag_suppress=base_class_has_different_dll_interface,--diag_suppress=dll_interface_conflict_none_assumed,--diag_suppress=dll_interface_conflict_dllexport_assumed,--diag_suppress=bad_friend_decl --expt-relaxed-constexpr --expt-extended-lambda -O2 -g -DNDEBUG -std=c++17 -Xcompiler=-fPIC -D_GLIBCXX_USE_CXX11_ABI=0 -MD -MT CMakeFiles/nvfuser_tests_kernels.dir/test/rng_kernels.cu.o -MF CMakeFiles/nvfuser_tests_kernels.dir/test/rng_kernels.cu.o.d -x cu -c /home/gaoxiang/Fuser3/test/rng_kernels.cu -o CMakeFiles/nvfuser_tests_kernels.dir/test/rng_kernels.cu.o
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/core/SymBool.h:66:8: error: no viable conversion from returned value of type 'optional<typename std::decay<const bool &>::type>' to function return type 'optional<bool>'
return c10::make_optional(data_); 
       ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:628:11: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const bool &>::type>' (aka 'optional<const bool>') to 'c10::nullopt_t' for 1st argument
constexpr optional(c10::nullopt_t) noexcept : OptionalBase< T> () { } 
          ^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:630:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const bool &>::type>' (aka 'optional<const bool>') to 'const optional<bool> &' for 1st argument
optional(const optional & rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:631:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const bool &>::type>' (aka 'optional<const bool>') to 'optional<bool> &&' for 1st argument
optional(optional && rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:646:1: note: candidate template ignored: requirement 'std::is_convertible<c10::optional<const bool> &&, bool>::value' was not satisfied [with U = optional<typename std::decay<const bool &>::type>]
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:656:1: note: explicit constructor is not a candidate
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:659:1: note: explicit constructor is not a candidate
optional(c10::in_place_t, Args &&...args) : OptionalBase< T> (c10::in_place_t{}, constexpr_forward< Args> (args)...) 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/core/SymInt.h:229:8: error: no viable conversion from returned value of type 'optional<typename std::decay<const long &>::type>' to function return type 'optional<long>'
return c10::make_optional(data_); 
       ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:628:11: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const long &>::type>' (aka 'optional<const long>') to 'c10::nullopt_t' for 1st argument
constexpr optional(c10::nullopt_t) noexcept : OptionalBase< T> () { } 
          ^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:630:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const long &>::type>' (aka 'optional<const long>') to 'const optional<long> &' for 1st argument
optional(const optional & rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:631:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const long &>::type>' (aka 'optional<const long>') to 'optional<long> &&' for 1st argument
optional(optional && rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:646:1: note: candidate template ignored: requirement 'std::is_constructible<long, c10::optional<const long> &&>::value' was not satisfied [with U = optional<typename std::decay<const long &>::type>]
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:656:1: note: explicit constructor is not a candidate
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:659:1: note: explicit constructor is not a candidate
optional(c10::in_place_t, Args &&...args) : OptionalBase< T> (c10::in_place_t{}, constexpr_forward< Args> (args)...) 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/core/TensorOptions.h:284:8: error: no viable conversion from returned value of type 'optional<typename std::decay<const Device &>::type>' to function return type 'optional<Device>'
return ((has_device_) ? c10::make_optional(device_) : c10::nullopt); 
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:628:11: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const Device &>::type>' (aka 'optional<const c10::Device>') to 'c10::nullopt_t' for 1st argument
constexpr optional(c10::nullopt_t) noexcept : OptionalBase< T> () { } 
          ^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:630:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const Device &>::type>' (aka 'optional<const c10::Device>') to 'const optional<Device> &' for 1st argument
optional(const optional & rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:631:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const Device &>::type>' (aka 'optional<const c10::Device>') to 'optional<Device> &&' for 1st argument
optional(optional && rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:646:1: note: candidate template ignored: requirement 'std::is_constructible<c10::Device, c10::optional<const c10::Device> &&>::value' was not satisfied [with U = optional<typename std::decay<const Device &>::type>]
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:656:1: note: explicit constructor is not a candidate
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:659:1: note: explicit constructor is not a candidate
optional(c10::in_place_t, Args &&...args) : OptionalBase< T> (c10::in_place_t{}, constexpr_forward< Args> (args)...) 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/core/TensorOptions.h:305:8: error: no viable conversion from returned value of type 'optional<typename std::decay<const TypeMeta &>::type>' to function return type 'optional<caffe2::TypeMeta>'
return ((has_dtype_) ? c10::make_optional(dtype_) : c10::nullopt); 
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:628:11: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const TypeMeta &>::type>' (aka 'optional<const caffe2::TypeMeta>') to 'c10::nullopt_t' for 1st argument
constexpr optional(c10::nullopt_t) noexcept : OptionalBase< T> () { } 
          ^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:630:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const TypeMeta &>::type>' (aka 'optional<const caffe2::TypeMeta>') to 'const optional<TypeMeta> &' for 1st argument
optional(const optional & rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:631:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const TypeMeta &>::type>' (aka 'optional<const caffe2::TypeMeta>') to 'optional<TypeMeta> &&' for 1st argument
optional(optional && rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:646:1: note: candidate template ignored: requirement 'std::is_constructible<caffe2::TypeMeta, c10::optional<const caffe2::TypeMeta> &&>::value' was not satisfied [with U = optional<typename std::decay<const TypeMeta &>::type>]
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:656:1: note: explicit constructor is not a candidate
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:659:1: note: explicit constructor is not a candidate
optional(c10::in_place_t, Args &&...args) : OptionalBase< T> (c10::in_place_t{}, constexpr_forward< Args> (args)...) 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/core/TensorOptions.h:321:8: error: no viable conversion from returned value of type 'optional<typename std::decay<const Layout &>::type>' to function return type 'optional<Layout>'
return ((has_layout_) ? c10::make_optional(layout_) : c10::nullopt); 
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:628:11: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const Layout &>::type>' (aka 'optional<const c10::Layout>') to 'c10::nullopt_t' for 1st argument
constexpr optional(c10::nullopt_t) noexcept : OptionalBase< T> () { } 
          ^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:630:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const Layout &>::type>' (aka 'optional<const c10::Layout>') to 'const optional<Layout> &' for 1st argument
optional(const optional & rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:631:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const Layout &>::type>' (aka 'optional<const c10::Layout>') to 'optional<Layout> &&' for 1st argument
optional(optional && rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:646:1: note: candidate template ignored: requirement 'std::is_constructible<c10::Layout, c10::optional<const c10::Layout> &&>::value' was not satisfied [with U = optional<typename std::decay<const Layout &>::type>]
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:656:1: note: explicit constructor is not a candidate
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:659:1: note: explicit constructor is not a candidate
optional(c10::in_place_t, Args &&...args) : OptionalBase< T> (c10::in_place_t{}, constexpr_forward< Args> (args)...) 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/core/TensorOptions.h:337:8: error: no viable conversion from returned value of type 'optional<typename std::decay<const bool &>::type>' to function return type 'optional<bool>'
return ((has_requires_grad_) ? c10::make_optional(requires_grad_) : c10::nullopt); 
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:628:11: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const bool &>::type>' (aka 'optional<const bool>') to 'c10::nullopt_t' for 1st argument
constexpr optional(c10::nullopt_t) noexcept : OptionalBase< T> () { } 
          ^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:630:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const bool &>::type>' (aka 'optional<const bool>') to 'const optional<bool> &' for 1st argument
optional(const optional & rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:631:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const bool &>::type>' (aka 'optional<const bool>') to 'optional<bool> &&' for 1st argument
optional(optional && rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:646:1: note: candidate template ignored: requirement 'std::is_convertible<c10::optional<const bool> &&, bool>::value' was not satisfied [with U = optional<typename std::decay<const bool &>::type>]
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:656:1: note: explicit constructor is not a candidate
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:659:1: note: explicit constructor is not a candidate
optional(c10::in_place_t, Args &&...args) : OptionalBase< T> (c10::in_place_t{}, constexpr_forward< Args> (args)...) 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/core/TensorOptions.h:369:8: error: no viable conversion from returned value of type 'optional<typename std::decay<const bool &>::type>' to function return type 'optional<bool>'
return ((has_pinned_memory_) ? c10::make_optional(pinned_memory_) : c10::nullopt); 
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:628:11: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const bool &>::type>' (aka 'optional<const bool>') to 'c10::nullopt_t' for 1st argument
constexpr optional(c10::nullopt_t) noexcept : OptionalBase< T> () { } 
          ^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:630:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const bool &>::type>' (aka 'optional<const bool>') to 'const optional<bool> &' for 1st argument
optional(const optional & rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:631:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const bool &>::type>' (aka 'optional<const bool>') to 'optional<bool> &&' for 1st argument
optional(optional && rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:646:1: note: candidate template ignored: requirement 'std::is_convertible<c10::optional<const bool> &&, bool>::value' was not satisfied [with U = optional<typename std::decay<const bool &>::type>]
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:656:1: note: explicit constructor is not a candidate
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:659:1: note: explicit constructor is not a candidate
optional(c10::in_place_t, Args &&...args) : OptionalBase< T> (c10::in_place_t{}, constexpr_forward< Args> (args)...) 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/core/TensorOptions.h:384:8: error: no viable conversion from returned value of type 'optional<typename std::decay<const MemoryFormat &>::type>' to function return type 'optional<MemoryFormat>'
return ((has_memory_format_) ? c10::make_optional(memory_format_) : c10::nullopt); 
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:628:11: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const MemoryFormat &>::type>' (aka 'optional<const c10::MemoryFormat>') to 'c10::nullopt_t' for 1st argument
constexpr optional(c10::nullopt_t) noexcept : OptionalBase< T> () { } 
          ^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:630:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const MemoryFormat &>::type>' (aka 'optional<const c10::MemoryFormat>') to 'const optional<MemoryFormat> &' for 1st argument
optional(const optional & rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:631:1: note: candidate constructor not viable: no known conversion from 'optional<typename std::decay<const MemoryFormat &>::type>' (aka 'optional<const c10::MemoryFormat>') to 'optional<MemoryFormat> &&' for 1st argument
optional(optional && rhs) = default;
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:646:1: note: candidate template ignored: requirement 'std::is_constructible<c10::MemoryFormat, c10::optional<const c10::MemoryFormat> &&>::value' was not satisfied [with U = optional<typename std::decay<const MemoryFormat &>::type>]
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:656:1: note: explicit constructor is not a candidate
optional(U &&u) : OptionalBase< T> (std::forward< U> (u)) { } 
^
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/include/c10/util/Optional.h:659:1: note: explicit constructor is not a candidate
optional(c10::in_place_t, Args &&...args) : OptionalBase< T> (c10::in_place_t{}, constexpr_forward< Args> (args)...) 
^
8 errors generated.
```
Not sure if this is a pytorch bug or nvcc bug, but whatever, I don't want to look into it.