### PR TITLE
AliasAnalysis handles `Set.Permute`. 

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2382,43 +2382,21 @@ LoadStoreOp::LoadStoreOp(
   addDataAttribute(cache_op);
 }
 
-namespace {
-// Returns the permutation from `in` to `out`, i.e., `out[i]==in[perm[i]]`. As a
-// precondition, `out` must be a permutation of `in` per the definition of
-// std::is_permutation.
-template <typename T>
-std::vector<int64_t> computePermutation(
-    const std::vector<T>& in,
-    const std::vector<T>& out) {
-  std::vector<int64_t> permutation;
-  permutation.reserve(out.size());
-  // O(n^2) is totally fine for the current use case of computing the
-  // root-to-rfactor permutation. If needed, this can be improved by requiring T
-  // to be hashable and/or comparable.
-  for (const T& out_element : out) {
-    permutation.push_back(std::distance(
-        in.begin(), std::find(in.begin(), in.end(), out_element)));
-  }
-  return permutation;
-}
-} // namespace
-
 std::vector<PolymorphicValue> LoadStoreOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   if (TensorView* out_tv = dynamic_cast<TensorView*>(out())) {
     if (out_tv->hasRFactor()) {
+      std::optional<std::vector<int64_t>> permutation =
+          ir_utils::computePermutation(
+              out_tv->getRootDomain(), out_tv->getRFactorDomain());
       NVF_ERROR(
-          std::is_permutation(
-              out_tv->getRootDomain().begin(),
-              out_tv->getRootDomain().end(),
-              out_tv->getRFactorDomain().begin()),
+          permutation.has_value(),
           "The rfactor domain of a Set.Permute is supposed to be a permutation of the root domain: ",
           out_tv->toString());
       NVF_ERROR(inputs.size() == 1);
       at::Tensor in_tensor = inputs[0].as<at::Tensor>();
-      at::Tensor out_tensor = in_tensor.permute(computePermutation(
-          out_tv->getRootDomain(), out_tv->getRFactorDomain()));
+      at::Tensor out_tensor = in_tensor.permute(*permutation);
       return {out_tensor};
     }
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3693,9 +3693,10 @@ std::vector<IterDomain*> TensorDomain::noBroadcasts(
   return noBroadcastDomain;
 }
 
-std::vector<std::optional<bool>> TensorDomain::getContiguityFilledWith(
-    const std::vector<IterDomain*>& rfactor_domain,
-    bool fill_value) {
+/*static*/ std::vector<std::optional<bool>> TensorDomain::
+    getContiguityFilledWith(
+        const std::vector<IterDomain*>& rfactor_domain,
+        bool fill_value) {
   std::vector<std::optional<bool>> contiguity;
   contiguity.reserve(rfactor_domain.size());
   for (auto id : rfactor_domain) {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -530,9 +530,8 @@ std::vector<Expr*> getAllTypesOfReductionOps(Fusion* fusion);
 //! Returns true if fusion has any reduction ops.
 bool hasAnyReductionOps(Fusion* fusion);
 
-// Returns the permutation from `in` to `out`, i.e., `out[i]==in[perm[i]]`. As a
-// precondition, `out` must be a permutation of `in` per the definition of
-// std::is_permutation.
+// Returns the permutation from `in` to `out`, i.e., `out[i]==in[perm[i]]`. If
+// `out` is not a permutation of `in`, returns nullopt.
 template <typename T>
 std::optional<std::vector<int64_t>> computePermutation(
     const std::vector<T>& in,

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -11,8 +11,10 @@
 #include <ir/all_nodes.h>
 #include <type.h>
 
+#include <algorithm>
 #include <iterator>
 #include <unordered_map>
+#include <vector>
 
 namespace nvfuser::ir_utils {
 
@@ -527,5 +529,28 @@ std::vector<Expr*> getAllTypesOfReductionOps(Fusion* fusion);
 
 //! Returns true if fusion has any reduction ops.
 bool hasAnyReductionOps(Fusion* fusion);
+
+// Returns the permutation from `in` to `out`, i.e., `out[i]==in[perm[i]]`. As a
+// precondition, `out` must be a permutation of `in` per the definition of
+// std::is_permutation.
+template <typename T>
+std::optional<std::vector<int64_t>> computePermutation(
+    const std::vector<T>& in,
+    const std::vector<T>& out) {
+  if (!std::is_permutation(in.begin(), in.end(), out.begin())) {
+    return std::nullopt;
+  }
+
+  std::vector<int64_t> permutation;
+  permutation.reserve(out.size());
+  // O(n^2) is totally fine for the current use case of computing the
+  // root-to-rfactor permutation. If needed, this can be improved by making T
+  // hashable and/or comparable.
+  for (const T& out_element : out) {
+    permutation.push_back(std::distance(
+        in.begin(), std::find(in.begin(), in.end(), out_element)));
+  }
+  return permutation;
+}
 
 } // namespace nvfuser::ir_utils

--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -81,8 +81,8 @@ bool transformsExpandedBroadcastIterDomain(TensorView* in, TensorView* out) {
 }
 
 // Finds aliases between `expr`'s inputs and outputs and stores the findings in
-// `alias_to_source`.
-void findAliasesFromExpr(Expr* expr, AliasAnalysisResult& alias_to_source) {
+// `analysis`.
+void findAliasesFromExpr(Expr* expr, AliasAnalysisResult& analysis) {
   // The current implementation does the bare minimum to detect some aliasing
   // that the codegen can use to generate a kernel skipping unnecessary
   // computation.
@@ -104,7 +104,7 @@ void findAliasesFromExpr(Expr* expr, AliasAnalysisResult& alias_to_source) {
       // `in`. Both `in` and `out` are allocated contiguously per the
       // rfactor domain. Also, the ViewOp can't transform any expanded broadcast
       // IterDomain.
-      alias_to_source.add(out, in);
+      analysis.add(out, in);
     }
   }
 }
@@ -141,17 +141,17 @@ const Val* AliasAnalysisResult::findRoot(const Val* alias) const {
 }
 
 AliasAnalysisResult findAliases(Fusion* fusion) {
-  AliasAnalysisResult alias_analysis;
+  AliasAnalysisResult analysis;
   // Fusion::exprs() returns topological order.
   for (Expr* expr : fusion->exprs()) {
     // A potential improvement suggested by @tfogal: Let findAliasesFromExpr
     // return the AliasAnalysisResult instead of taking a mutable
-    // `alias_analysis` arg. This might be somewhat easily parallelizable
+    // `analysis` arg. This might be somewhat easily parallelizable
     // (albeit with a serialized merge step afterwards that inserts the
     // results).
-    findAliasesFromExpr(expr, alias_analysis);
+    findAliasesFromExpr(expr, analysis);
   }
-  return alias_analysis;
+  return analysis;
 }
 
 } // namespace nvfuser::optimization

--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -113,20 +113,18 @@ std::optional<std::vector<int64_t>> computePermutation(
 // Many improvements are to be made. For example,
 // 1. It should handle more op types such as `Slice`.
 // 2. It should detect alias between non-packed tensors.
-//
-// FIXME: can we inherit from OptOutConstDispatch?
-class AliasFinder : public OptOutDispatch {
+class AliasFinder : public OptOutConstDispatch {
  public:
   AliasFinder(AliasAnalysisResult& analysis) : analysis_(analysis) {}
 
-  void handle(ViewOp* view) override;
-  void handle(LoadStoreOp* ldst) override;
+  void handle(const ViewOp* view) override;
+  void handle(const LoadStoreOp* ldst) override;
 
  private:
   AliasAnalysisResult& analysis_;
 };
 
-void AliasFinder::handle(ViewOp* view) {
+void AliasFinder::handle(const ViewOp* view) {
   TensorView* in = view->in();
   TensorView* out = view->out();
 
@@ -143,7 +141,7 @@ void AliasFinder::handle(ViewOp* view) {
   }
 }
 
-void AliasFinder::handle(LoadStoreOp* permute) {
+void AliasFinder::handle(const LoadStoreOp* permute) {
   TensorView* out = dynamic_cast<TensorView*>(permute->out());
   if (!out->hasRFactor()) {
     // Not a permute. It's actually an easier case to propagate aliases. I'm

--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -140,6 +140,21 @@ const Val* AliasAnalysisResult::findRoot(const Val* alias) const {
   return root;
 }
 
+std::vector<IterDomain*> AliasAnalysisResult::preferredAllocationDomain(
+    const Val* v) const {
+  const TensorView* tv = dynamic_cast<const TensorView*>(v);
+  NVF_CHECK(
+      tv != nullptr,
+      "`v` is expected to be a TensorView. Found: ",
+      v->toString());
+
+  if (auto i = preferred_allocation_domain_.find(tv);
+      i != preferred_allocation_domain_.end()) {
+    return i->second;
+  }
+  return tv->getMaybeAllocationDomain();
+}
+
 AliasAnalysisResult findAliases(Fusion* fusion) {
   AliasAnalysisResult analysis;
   // Fusion::exprs() returns topological order.

--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -82,27 +82,6 @@ bool transformsExpandedBroadcastIterDomain(TensorView* in, TensorView* out) {
   return false;
 }
 
-// FIXME: merge.
-template <typename T>
-std::optional<std::vector<int64_t>> computePermutation(
-    const std::vector<T>& in,
-    const std::vector<T>& out) {
-  if (!std::is_permutation(in.begin(), in.end(), out.begin())) {
-    return std::nullopt;
-  }
-
-  std::vector<int64_t> permutation;
-  permutation.reserve(out.size());
-  // O(n^2) is totally fine for the current use case of computing the
-  // root-to-rfactor permutation. If needed, this can be improved by requiring T
-  // to be hashable and/or comparable.
-  for (const T& out_element : out) {
-    permutation.push_back(std::distance(
-        in.begin(), std::find(in.begin(), in.end(), out_element)));
-  }
-  return permutation;
-}
-
 // Finds aliases between `expr`'s inputs and outputs and stores the findings in
 // `analysis`.
 //
@@ -158,7 +137,7 @@ void AliasFinder::handle(const LoadStoreOp* permute) {
   TensorView* in = permute->in()->as<TensorView>();
   // Look at the preferred layout not `in`'s current layout.
   Layout in_layout = analysis_.preferredLayout(in);
-  if (!computePermutation(
+  if (!ir_utils::computePermutation(
            in->getMaybeRFactorDomain(), in_layout.allocation_domain)
            .has_value()) {
     // Give up when `in`'s allocation domain is not an rfactor permutation.

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -24,6 +24,8 @@ class AliasAnalysisResult {
   // Returns itself if `alias` doesn't alias anything.
   const Val* findRoot(const Val* alias) const;
 
+  // Returns the preferred layout. If `alias` is not in `preferred_layout_`,
+  // returns the `TensorView`'s initial layout.
   Layout preferredLayout(const Val* alias) const;
 
   // Marks `source` as the immediate aliasing source of `alias`.
@@ -45,6 +47,7 @@ class AliasAnalysisResult {
   // an alias.
   std::unordered_map<const TensorView*, const TensorView*> alias_to_source_;
 
+  // Stores the preferred layout for aliasing.
   std::unordered_map<const TensorView*, Layout> preferred_layout_;
 };
 

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -48,7 +48,10 @@ class AliasAnalysisResult {
   std::unordered_map<const TensorView*, Layout> preferred_layout_;
 };
 
-// Finds aliases of the fusion inputs.
+// Finds aliases of the fusion inputs. The analysis should be conservative --
+// when the analysis says B is an alias of input A,
+// `ExpressionEvaluator::evaluate(B)` should produce an `at::Tensor` that's an
+// alias of the `at::Tensor` bound to A.
 AliasAnalysisResult findAliases(Fusion* fusion);
 
 } // namespace nvfuser::optimization

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -12,6 +12,11 @@
 
 namespace nvfuser::optimization {
 
+struct Layout {
+  std::vector<IterDomain*> allocation_domain;
+  std::vector<std::optional<bool>> contiguity;
+};
+
 class AliasAnalysisResult {
  public:
   AliasAnalysisResult() = default;
@@ -19,7 +24,7 @@ class AliasAnalysisResult {
   // Returns itself if `alias` doesn't alias anything.
   const Val* findRoot(const Val* alias) const;
 
-  std::vector<IterDomain*> preferredAllocationDomain(const Val* alias) const;
+  Layout preferredLayout(const Val* alias) const;
 
   // Marks `source` as the immediate aliasing source of `alias`.
   void add(const TensorView* alias, const TensorView* source);
@@ -36,8 +41,7 @@ class AliasAnalysisResult {
   // an alias.
   std::unordered_map<const TensorView*, const TensorView*> alias_to_source_;
 
-  std::unordered_map<const TensorView*, std::vector<IterDomain*>>
-      preferred_allocation_domain_;
+  std::unordered_map<const TensorView*, Layout> preferred_layout_;
 };
 
 // Finds aliases of the fusion inputs.

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -28,6 +28,10 @@ class AliasAnalysisResult {
 
   // Marks `source` as the immediate aliasing source of `alias`.
   void add(const TensorView* alias, const TensorView* source);
+  void add(
+      const TensorView* alias,
+      const TensorView* source,
+      const Layout& layout);
 
   AliasAnalysisResult(const AliasAnalysisResult&) = delete;
   AliasAnalysisResult& operator=(const AliasAnalysisResult&) = delete;

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -28,8 +28,8 @@ class AliasAnalysisResult {
   // returns the `TensorView`'s initial layout.
   Layout preferredLayout(const Val* alias) const;
 
-  // Marks `source` as the immediate aliasing source of `alias`.
-  void add(const TensorView* alias, const TensorView* source);
+  // Marks `source` as the immediate aliasing source of `alias` and sets the
+  // preferred layout.
   void add(
       const TensorView* alias,
       const TensorView* source,
@@ -42,13 +42,12 @@ class AliasAnalysisResult {
 
  private:
   // Maps aliases (e.g. the output of a View) to their direct sources (e.g. the
-  // input of the same View). Consider path compression, a common optimization
-  // used in disjoint-set data structure, so it's easy to figure out the root of
-  // an alias.
-  std::unordered_map<const TensorView*, const TensorView*> alias_to_source_;
-
-  // Stores the preferred layout for aliasing.
-  std::unordered_map<const TensorView*, Layout> preferred_layout_;
+  // input of the same View). Also stores the preferred output layout for the
+  // alias. Consider path compression, a common optimization used in
+  // disjoint-set data structure, so it's easy to figure out the root of an
+  // alias.
+  std::unordered_map<const TensorView*, std::pair<const TensorView*, Layout>>
+      alias_to_source_;
 };
 
 // Finds aliases of the fusion inputs. The analysis should be conservative --

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -19,6 +19,8 @@ class AliasAnalysisResult {
   // Returns itself if `alias` doesn't alias anything.
   const Val* findRoot(const Val* alias) const;
 
+  std::vector<IterDomain*> preferredAllocationDomain(const Val* alias) const;
+
   // Marks `source` as the immediate aliasing source of `alias`.
   void add(const TensorView* alias, const TensorView* source);
 
@@ -33,6 +35,9 @@ class AliasAnalysisResult {
   // used in disjoint-set data structure, so it's easy to figure out the root of
   // an alias.
   std::unordered_map<const TensorView*, const TensorView*> alias_to_source_;
+
+  std::unordered_map<const TensorView*, std::vector<IterDomain*>>
+      preferred_allocation_domain_;
 };
 
 // Finds aliases of the fusion inputs.

--- a/csrc/optimization/mark_alias.cpp
+++ b/csrc/optimization/mark_alias.cpp
@@ -5,9 +5,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <debug.h>
 #include <ir/utils.h>
 #include <optimization/alias_analysis.h>
 #include <optimization/mark_alias.h>
+#include <options.h>
 
 namespace nvfuser::optimization {
 
@@ -21,13 +23,29 @@ void MarkAliasPass::runPass(Fusion* fusion) {
           // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
           const_cast<Val*>(in),
           AliasType::PointerCast);
+      if (isDebugDumpEnabled(DebugDumpOption::PreSegmenterLogging)) {
+        debug() << "MarkAliasPass marked " << out->toString()
+                << " as an alias of " << in->toString() << std::endl;
+      }
 
       // A scalar `out` triggers a corner case that crashes
       // `validateDomainEquivalence`.
       if (!out->isZeroDim()) {
         const Layout out_layout = alias_analysis.preferredLayout(out);
+        if (isDebugDumpEnabled(DebugDumpOption::PreSegmenterLogging)) {
+          debug() << "MarkAliasPass changed the layout of " << out->toString()
+                  << std::endl;
+          debug() << "  Old TensorDomain:" << std::endl;
+          debug() << out->domain()->toString(4, /*leaf_only=*/false)
+                  << std::endl;
+        }
         out->setAllocationDomain(
             out_layout.allocation_domain, out_layout.contiguity);
+        if (isDebugDumpEnabled(DebugDumpOption::PreSegmenterLogging)) {
+          debug() << "  New TensorDomain:" << std::endl;
+          debug() << out->domain()->toString(4, /*leaf_only=*/false)
+                  << std::endl;
+        }
       }
     }
   }

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -130,6 +130,7 @@ std::unordered_map<DebugDumpOption, std::vector<std::string>> Options<
       {"occupancy", DebugDumpOption::Occupancy},
       {"parallel_dimensions", DebugDumpOption::ParallelDimensions},
       {"perf_debug_verbose", DebugDumpOption::PerfDebugVerbose},
+      {"pre_segmenter_logging", DebugDumpOption::PreSegmenterLogging},
       {"ptx", DebugDumpOption::Ptx},
       {"ptxas_verbose", DebugDumpOption::PrintPtxasLog},
       {"python_definition", DebugDumpOption::PythonDefinition},

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -50,6 +50,7 @@ enum class DebugDumpOption {
   Halo, //! Halo information of tensors
   PerfDebugVerbose, //! When running kernels, print verbose information
                     //! associated with what's running
+  PreSegmenterLogging,
   PythonDefinition, //! Python Frontend Fusion Definition.
   PythonFrontendDebug, //! Python Frontend debug information.
   TransformPropagator, //! When running TransformPropagator, print propagation

--- a/nvfuser/contrib/nn/normalization.py
+++ b/nvfuser/contrib/nn/normalization.py
@@ -23,7 +23,7 @@ def partially_contig_tensor(
     x: torch.Tensor,
 ) -> "nvfuser.Tensor":
     return fd.define_tensor(
-        shape=[-1] * x.ndim,
+        shape=[1 if dim_size == 1 else -1 for dim_size in x.size()],
         contiguity=nvfuser.compute_contiguity(x.size(), x.stride()),
         dtype=torch_dtype_to_nvfuser_dtype(x.dtype),
     )

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -128,10 +128,14 @@ TEST_F(AliasAnalysisTest, Permute) {
   TensorView* out = permute(in, {1, 2, 0});
   fusion.addOutput(out);
 
-  // We haven't handled `Set.Permute` yet.
   optimization::AliasAnalysisResult alias_analysis =
       optimization::findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.findRoot(out), out);
+  EXPECT_EQ(alias_analysis.findRoot(out), in);
+
+  const std::vector<IterDomain*>& out_rfactor = out->getMaybeRFactorDomain();
+  EXPECT_THAT(
+      alias_analysis.preferredLayout(out).allocation_domain,
+      ElementsAre(out_rfactor[2], out_rfactor[0], out_rfactor[1]));
 }
 
 TEST_F(AliasAnalysisTest, View_SplitExpandedBroadcast) {

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -206,7 +206,7 @@ TEST_F(AliasAnalysisTest, View_MergeExpandedBroadcast) {
 
 using AliasTest = NVFuserTest;
 
-TEST_F(AliasTest, ReinterpretCast) {
+TEST_F(AliasTest, View) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -234,6 +234,39 @@ TEST_F(AliasTest, ReinterpretCast) {
       {out_tensor},
       {in_tensor},
       {in_tensor.view({2, 12})},
+      __LINE__,
+      __FILE__);
+}
+
+TEST_F(AliasTest, ViewPermute) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  const std::vector<int64_t> in_shape({2, 3, 4});
+  const std::vector<int64_t> out_shape({2, 12});
+
+  TensorView* in = makeContigConcreteTensor(in_shape);
+  fusion->addInput(in);
+  TensorView* out = reshape(in, in_shape, out_shape);
+  out = permute(out, {1, 0});
+  fusion->addOutput(out);
+
+  FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor =
+      at::randn({2, 3, 4}, at::dtype(at::kFloat).device(at::kCUDA, 0));
+  std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
+  ASSERT_EQ(out_tensors.size(), 1);
+  at::Tensor out_tensor = out_tensors[0];
+
+  // Verify aliasing.
+  EXPECT_EQ(in_tensor.data_ptr(), out_tensor.data_ptr());
+
+  // Verify output values.
+  testValidate(
+      fec.fusion(),
+      {out_tensor},
+      {in_tensor},
+      {in_tensor.view({2, 12}).permute({1, 0})},
       __LINE__,
       __FILE__);
 }

--- a/test/test_gpu_transpose.cpp
+++ b/test/test_gpu_transpose.cpp
@@ -13,6 +13,7 @@
 #include <inlining.h>
 #include <kernel_cache.h>
 #include <ops/all_ops.h>
+#include <optimization/mark_alias.h>
 #include <scheduler/all_schedulers.h>
 #include <scheduler/transpose.h>
 #include <scheduler/utils.h>
@@ -42,12 +43,15 @@ TensorView* transposeMaybeInplace(
 class TransposeTest : public NVFuserTest {
   void SetUp() override {
     NVFuserTest::SetUp();
-    OptimizationPass<MarkAliasPass>::setEnabled(false);
+    // For convenience, disable MarkAliasPass. Many tests in this file run a
+    // fusion that consists of `transpose` only. MarkAliasPass would turn those
+    // fusions into a no-op, skipping the transpose scheduler.
+    optimization::MarkAliasPass::setEnabled(false);
   }
 
   void TearDown() override {
+    optimization::MarkAliasPass::setEnabled(true);
     NVFuserTest::TearDown();
-    OptimizationPass<MarkAliasPass>::setEnabled(true);
   }
 };
 

--- a/test/test_gpu_transpose.cpp
+++ b/test/test_gpu_transpose.cpp
@@ -39,7 +39,17 @@ TensorView* transposeMaybeInplace(
 
 } // namespace
 
-using TransposeTest = NVFuserTest;
+class TransposeTest : public NVFuserTest {
+  void SetUp() override {
+    NVFuserTest::SetUp();
+    OptimizationPass<MarkAliasPass>::setEnabled(false);
+  }
+
+  void TearDown() override {
+    NVFuserTest::TearDown();
+    OptimizationPass<MarkAliasPass>::setEnabled(true);
+  }
+};
 
 // x->sin->transpose->cos->y
 TEST_F(TransposeTest, FusionScheduleTransposeSimple) {

--- a/test/test_gpu_transpose.cpp
+++ b/test/test_gpu_transpose.cpp
@@ -41,8 +41,10 @@ TensorView* transposeMaybeInplace(
 } // namespace
 
 class TransposeTest : public NVFuserTest {
+ protected:
   void SetUp() override {
     NVFuserTest::SetUp();
+    previously_enabled_ = optimization::MarkAliasPass::getEnabled();
     // For convenience, disable MarkAliasPass. Many tests in this file run a
     // fusion that consists of `transpose` only. MarkAliasPass would turn those
     // fusions into a no-op, skipping the transpose scheduler.
@@ -50,9 +52,12 @@ class TransposeTest : public NVFuserTest {
   }
 
   void TearDown() override {
-    optimization::MarkAliasPass::setEnabled(true);
+    optimization::MarkAliasPass::setEnabled(previously_enabled_);
     NVFuserTest::TearDown();
   }
+
+ private:
+  bool previously_enabled_ = false;
 };
 
 // x->sin->transpose->cos->y


### PR DESCRIPTION
Other changes:
1. Move `computePermutation` to `ir/utils.h` so it can be reused. 
2. Use `OptOutConstDispatch` to simplify `findAliasesFromExpr`. 
3. `AliasAnalysis` computes the preferred allocation domain and contiguity for each potentially aliased tensor. `MarkAliasPass` enforces that when no conflicts. 
4. Fix transpose tests so the fusion is not intercepted by the no-op scheduler. 
5. Fix `normalization.py` so it doesn't produce a symbolic, broadcast, stride-1 IterDomain. This would fail `validateAllocationSizesAndStrides`. 