### PR TITLE
Add variants of `slice` that takes `int64_t`s.

### DIFF
--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -804,4 +804,28 @@ TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges) {
   return out;
 }
 
+TensorView* slice(
+    TensorView* inp,
+    const std::vector<int64_t>& starts,
+    const std::vector<int64_t>& stops) {
+  std::vector<int64_t> steps(starts.size(), 1);
+  return slice(inp, starts, stops, steps);
+}
+
+TensorView* slice(
+    TensorView* inp,
+    const std::vector<int64_t>& starts,
+    const std::vector<int64_t>& stops,
+    const std::vector<int64_t>& steps) {
+  std::vector<Slice> slices;
+  slices.reserve(starts.size());
+  for (size_t i = 0; i < starts.size(); i++) {
+    slices.push_back(
+        {IrBuilder::create<Val>(starts[i]),
+         IrBuilder::create<Val>(stops[i]),
+         IrBuilder::create<Val>(steps[i])});
+  }
+  return slice(inp, slices);
+}
+
 } // namespace nvfuser

--- a/csrc/ops/alias.h
+++ b/csrc/ops/alias.h
@@ -96,4 +96,17 @@ TensorView* cat(
 //! PyTorch.
 TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges);
 
+//! A variant of the above `slice` function. This is closer to the Python API.
+TensorView* slice(
+    TensorView* inp,
+    const std::vector<int64_t>& starts,
+    const std::vector<int64_t>& stops,
+    const std::vector<int64_t>& steps);
+
+//! Same as above except that `steps` are all 1.
+TensorView* slice(
+    TensorView* inp,
+    const std::vector<int64_t>& starts,
+    const std::vector<int64_t>& stops);
+
 } // namespace nvfuser

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1963,19 +1963,8 @@ struct SliceOpRecord : RecordFunctor {
   }
 
   void operator()(FusionState& fd) final {
-    auto ndims = start_indices_.size();
-    std::vector<Slice> ranges;
-    ranges.reserve(ndims);
-    for (const auto i : c10::irange(ndims)) {
-      Slice tmp;
-      tmp.start = IrBuilder::create<nvfuser::Val>(start_indices_[i]);
-      tmp.stop = IrBuilder::create<nvfuser::Val>(end_indices_[i]);
-      tmp.step = IrBuilder::create<nvfuser::Val>(strides_[i]);
-      ranges.emplace_back(tmp);
-    }
-
     auto arg = fd.getFusionState(args_.at(0).index)->as<TensorView>();
-    auto output = slice(arg, ranges);
+    TensorView* output = slice(arg, start_indices_, end_indices_, strides_);
     fd.setFusionState(outputs_.at(0).index, output);
   }
 

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -2344,8 +2344,8 @@ void initNvFuserPythonBindings(PyObject* module) {
       "slice",
       [](FusionDefinition::Operators& self,
          Tensor arg,
-         std::vector<int64_t>& start_indices,
-         std::vector<int64_t>& end_indices,
+         const std::vector<int64_t>& start_indices,
+         const std::vector<int64_t>& end_indices,
          // NOTE: Tried to use std::reference_wrapper to a vector and during
          // testing, I was not getting the proper value back.  It was like
          // like the code was referencing the strides vector that holds the
@@ -2356,7 +2356,7 @@ void initNvFuserPythonBindings(PyObject* module) {
         NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
 
-        std::vector<int64_t> strides(start_indices.size(), int64_t(1));
+        std::vector<int64_t> strides;
         if (opt_strides.has_value()) {
           NVF_CHECK(
               start_indices.size() == opt_strides.value().size(),
@@ -2366,7 +2366,10 @@ void initNvFuserPythonBindings(PyObject* module) {
               opt_strides.value().size());
           strides.assign(
               opt_strides.value().begin(), opt_strides.value().end());
+        } else {
+          strides.resize(start_indices.size(), 1);
         }
+
         NVF_CHECK(
             arg.dims == start_indices.size(),
             "Number of tensor dimensions does not match slice dimensions! Tensor-dims: ",

--- a/test/test_resize.cpp
+++ b/test/test_resize.cpp
@@ -944,11 +944,8 @@ TEST_F(ResizeTest, FusionResizeSlice2) {
   auto tv0 = makeConcreteTensor(shape);
   fusion.addInput(tv0);
 
-  auto tv1 = slice(
-      tv0,
-      {Slice(),
-       {IrBuilder::create<Val>(0L), IrBuilder::create<Val>(shape[1] / 2)}});
-  auto tv2 = slice(tv0, {Slice(), {IrBuilder::create<Val>(shape[1] / 2)}});
+  auto tv1 = slice(tv0, {0, 0}, {shape[0], shape[1] / 2});
+  auto tv2 = slice(tv0, {0, shape[1] / 2}, {shape[0], shape[1]});
   auto tv3 = add(tv1, tv2);
   fusion.addOutput(tv3);
 


### PR DESCRIPTION
This is easier for C++ unit tests to use and is closer to the Python API. I also moved some error checking code from `python_bindings.cpp` to the new variants.