### PR TITLE
`SliceOp::in` and `::out` return `TensorView*` instead of `Val*`.

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2067,12 +2067,12 @@ class SliceOp : public Expr {
       const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
-  Val* out() const {
-    return output(0);
+  TensorView* out() const {
+    return output(0)->as<TensorView>();
   }
 
-  Val* in() const {
-    return input(0);
+  TensorView* in() const {
+    return input(0)->as<TensorView>();
   }
 
   std::vector<Slice> getRanges() const;


### PR DESCRIPTION
I believe they are always `TensorView*` given how `SliceOp`s are created:
https://github.com/search?q=repo%3ANVIDIA%2FFuser+create%3Csliceop%3E&type=code