### PR TITLE
Fix dangling dead uses in Fusion::removeVal

### DIFF
--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -205,7 +205,6 @@ void Fusion::removeVal(Val* val) {
     removeExpr(orig);
   }
 
-  const std::unordered_set<Expr*> exprs = exprs_;
   std::vector<Expr*> exprs_to_remove;
   for (Expr* e : exprs_) {
     if (!inContainer(e)) {

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -205,7 +205,14 @@ void Fusion::removeVal(Val* val) {
     removeExpr(orig);
   }
 
-  // We previously first looped over val->uses() and removed them all from the Fusion. This seems correct at first glance, but it is incomplete since `val->uses()` actually only gives all live uses. When there is dead code in the Fusion that includes some uses of a val that is to be removed, we can wind up with an expression that holds an invalid pointer to the removed value in its inputs(). In https://github.com/NVIDIA/Fuser/issues/1270 this caused a segfault when the fusion was cloned since that will clone not only live objects but also these dangerous dangling dead ones.
+  // We previously first looped over val->uses() and removed them all from the
+  // Fusion. This seems correct at first glance, but it is incomplete since
+  // `val->uses()` actually only gives all live uses. When there is dead code in
+  // the Fusion that includes some uses of a val that is to be removed, we can
+  // wind up with an expression that holds an invalid pointer to the removed
+  // value in its inputs(). In https://github.com/NVIDIA/Fuser/issues/1270 this
+  // caused a segfault when the fusion was cloned since that will clone not only
+  // live objects but also these dangerous dangling dead ones.
   std::vector<Expr*> exprs_to_remove;
   for (Expr* e : exprs_) {
     if (!inContainer(e)) {

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -205,6 +205,7 @@ void Fusion::removeVal(Val* val) {
     removeExpr(orig);
   }
 
+  // We previously first looped over val->uses() and removed them all from the Fusion. This seems correct at first glance, but it is incomplete since `val->uses()` actually only gives all live uses. When there is dead code in the Fusion that includes some uses of a val that is to be removed, we can wind up with an expression that holds an invalid pointer to the removed value in its inputs(). In https://github.com/NVIDIA/Fuser/issues/1270 this caused a segfault when the fusion was cloned since that will clone not only live objects but also these dangerous dangling dead ones.
   std::vector<Expr*> exprs_to_remove;
   for (Expr* e : exprs_) {
     if (!inContainer(e)) {

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -205,8 +205,20 @@ void Fusion::removeVal(Val* val) {
     removeExpr(orig);
   }
 
-  for (Expr* use : unordered_uses(val)) {
-    removeExpr(use);
+  const std::unordered_set<Expr*> exprs = exprs_;
+  std::vector<Expr*> exprs_to_remove;
+  for (Expr* e : exprs_) {
+    if (!inContainer(e)) {
+      continue;
+    }
+    if (std::find(e->inputs().begin(), e->inputs().end(), val) !=
+        e->inputs().end()) {
+      // Avoid removing until after we've looped through exprs_
+      exprs_to_remove.push_back(e);
+    }
+  }
+  for (auto e : exprs_to_remove) {
+    removeExpr(e);
   }
   IrContainer::removeVal(val);
 }

--- a/csrc/iter_visitor.cpp
+++ b/csrc/iter_visitor.cpp
@@ -1046,13 +1046,6 @@ void DeadCodeRemover::handle(TensorView* tv) {
 }
 
 bool DeadCodeRemover::registerReplacement(Val* old_val, Val* new_val) {
-  // Mark new val live
-  markLiveRecursive(new_val);
-
-  if (old_val->isFusionOutput()) {
-    fusion_->replaceOutput(old_val, new_val);
-  }
-
   vals_to_replace_.emplace_back(old_val, new_val);
 
   if (old_val->isFusionInput()) {

--- a/csrc/iter_visitor.cpp
+++ b/csrc/iter_visitor.cpp
@@ -1046,6 +1046,13 @@ void DeadCodeRemover::handle(TensorView* tv) {
 }
 
 bool DeadCodeRemover::registerReplacement(Val* old_val, Val* new_val) {
+  // Mark new val live
+  markLiveRecursive(new_val);
+
+  if (old_val->isFusionOutput()) {
+    fusion_->replaceOutput(old_val, new_val);
+  }
+
   vals_to_replace_.emplace_back(old_val, new_val);
 
   if (old_val->isFusionInput()) {

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2664,6 +2664,52 @@ class TestNvFuserFrontend(TestCase):
 
         self.assertEqual(y.data_ptr(), x.data_ptr())
 
+    # This tests no dead code at definition does not cause a problem due to
+    # removal of empty tensors
+    # See https://github.com/NVIDIA/Fuser/pull/1270
+    def test_issue1270(self):
+        inputs = [
+            torch.randn(5, 0, device="cuda", dtype=torch.bfloat16),
+            torch.randn(5, 0, device="cuda", dtype=torch.bfloat16),
+        ]
+
+        def fusion_func(fd: FusionDefinition) -> None:
+            T0 = fd.define_tensor(
+                shape=[-1, -1],
+                contiguity=[True, None],
+                dtype=DataType.BFloat16,
+                is_cpu=False,
+            )
+            T1 = fd.define_tensor(
+                shape=[-1, -1],
+                contiguity=[None, True],
+                dtype=DataType.BFloat16,
+                is_cpu=False,
+            )
+            T2 = fd.ops.cast(T1, dtype=DataType.Float)
+            S3 = fd.define_scalar(1.00000, dtype=DataType.Double)
+            T4 = fd.ops.full(fill_value=S3, shape=[5, 0], dtype=DataType.BFloat16)
+            T5 = fd.ops.cast(T4, dtype=DataType.Float)
+            T6 = fd.ops.mul(T2, T5)
+            T7 = fd.ops.cast(T0, dtype=DataType.Float)
+            T8 = fd.ops.mul(T7, T5)
+            T24 = fd.ops.sum(T6, axes=[1], keepdim=False, dtype=DataType.Null)
+            T11 = fd.ops.sum(T8, axes=[0], keepdim=False, dtype=DataType.Null)
+            fd.add_output(T24)
+            fd.add_output(T11)
+
+        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
+        t2 = inputs[1].type(torch.float32)
+        t4 = torch.full([5, 0], 1.0, dtype=torch.bfloat16, device="cuda")
+        t5 = t4.type(torch.float32)
+        t6 = t2 * t5
+        t7 = inputs[0].type(torch.float32)
+        t8 = t7 * t5
+        t24 = t6.sum([1])
+        t11 = t8.sum([0])
+        self.assertEqual(nvf_out[0], t24)
+        self.assertEqual(nvf_out[1], t11)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Fixes #1270.

When a `Val` is removed from the `Fusion`, we currently first loop over `val->uses()` and remove them all from the Fusion. This seems correct at first glance, but it is incomplete since `val->uses()` actually only gives all **live** uses. When there is dead code in the `Fusion` that includes some uses of a val that is to be removed, we can wind up with an expression that holds an invalid pointer to the removed value in its `inputs()`. In #1270 this caused a segfault when the fusion was cloned since that will clone not only live objects but also these dangerous dangling dead ones.

This PR iterates over `exprs_` in `Fusion::removeVal()` in order to definitively find uses, dead or alive. Note that we still do not check attributes for the presence of an `attributeVal` equal to `val` so we could probably still contrive a case that would lead to dangling references. If we do check such attributes we should maybe produce an error instead of silenlty removing the `Expr`. I am not sure how prevalent `Val` attributes are or what would be preferred in those cases.