### PR TITLE
Modified `uniform` and `normal`'s Python APIs to fully support Dynamic Shape Definitions

### DIFF
--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -2657,9 +2657,9 @@ struct RandomDistOpRecord : RecordFunctor {
     static_assert(
         (RType == serde::RecordType::NormalDistOp) ||
         (RType == serde::RecordType::UniformDistOp));
-    if constexpr (RType == serde::RecordType_UniformDistOp) {
+    if constexpr (RType == serde::RecordType::UniformDistOp) {
       name_ = "ops.uniform";
-    } else if constexpr (RType == serde::RecordType_NormalDistOp) {
+    } else if constexpr (RType == serde::RecordType::NormalDistOp) {
       name_ = "ops.normal";
     }
     setArgName(2, "shape");
@@ -2729,7 +2729,7 @@ struct RandomDistOpRecord : RecordFunctor {
   std::pair<serde::RecordData, flatbuffers::Offset<void>> recordData(
       flatbuffers::FlatBufferBuilder& builder) const final {
     return {
-        serde::RecordData_TensorCreationSymbolic,
+        serde::RecordData::TensorCreationSymbolic,
         serde::CreateTensorCreationSymbolic(builder, toUnderlying(dtype_))
             .Union()};
   }

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -2654,13 +2654,14 @@ struct RandomDistOpRecord : RecordFunctor {
       PrimDataType dtype)
       : RecordFunctor(std::move(_args), std::move(_outputs), "", RType),
         dtype_(dtype) {
-    static_assert(
-        (RType == serde::RecordType::NormalDistOp) ||
-        (RType == serde::RecordType::UniformDistOp));
     if constexpr (RType == serde::RecordType::UniformDistOp) {
       name_ = "ops.uniform";
     } else if constexpr (RType == serde::RecordType::NormalDistOp) {
       name_ = "ops.normal";
+    } else {
+      static_assert(
+          (RType == serde::RecordType::NormalDistOp) ||
+          (RType == serde::RecordType::UniformDistOp));
     }
     setArgName(2, "shape");
     if (args_.size() == 5) {
@@ -2713,6 +2714,10 @@ struct RandomDistOpRecord : RecordFunctor {
         auto offset = fd.getFusionState(args_.at(4).index);
         output = normal(output_shape, arg1, arg2, dtype_, seed, offset);
       }
+    } else {
+      static_assert(
+          (RType == serde::RecordType::NormalDistOp) ||
+          (RType == serde::RecordType::UniformDistOp));
     }
 
     fd.setFusionState(outputs_.at(0).index, output);

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -2651,15 +2651,11 @@ struct RandomDistOpRecord : RecordFunctor {
       std::vector<State> _args,
       std::vector<State> _outputs,
       PrimDataType dtype)
-      : RecordFunctor(
-            std::move(_args),
-            std::move(_outputs),
-            "",
-            RType),
+      : RecordFunctor(std::move(_args), std::move(_outputs), "", RType),
         dtype_(dtype) {
     static_assert(
-      (RType == serde::RecordType_NormalDistOp) ||
-      (RType == serde::RecordType_UniformDistOp));
+        (RType == serde::RecordType_NormalDistOp) ||
+        (RType == serde::RecordType_UniformDistOp));
     if constexpr (RType == serde::RecordType_UniformDistOp) {
       name_ = "ops.uniform";
     } else if constexpr (RType == serde::RecordType_NormalDistOp) {
@@ -2700,7 +2696,7 @@ struct RandomDistOpRecord : RecordFunctor {
         fd.getFusionStateVector(args_.at(2).index);
 
     Val* output = nullptr;
-    if constexpr (RType ==  serde::RecordType_UniformDistOp) {
+    if constexpr (RType == serde::RecordType_UniformDistOp) {
       if (args_.size() == 3) { // stochastic uniform
         output = uniform(output_shape, arg1, arg2, dtype_);
       } else if (args_.size() == 5) { // provided seed and offset

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -153,15 +153,15 @@ template <class ShapeType, serde::RecordType RType>
 Tensor random_dist_op_fn(FusionDefinition::Operators& self,
    Scalar minval,
    Scalar maxval,
-   ShapeType shape,
-   PrimDataType dtype,
+   ShapeType generic_new_shape,
    std::optional<Scalar> rng_seed,
-   std::optional<Scalar> rng_offset) {
+   std::optional<Scalar> rng_offset,
+   PrimDataType dtype) {
   static_assert((RType == serde::RecordType_NormalDistOp) || (RType == serde::RecordType_UniformDistOp));
   NVF_CHECK(
       self.validUse(), "Attempting to add to a completed definition!");
   FusionDefinition* fd = self.fusion_definition;
-  Vector new_shape = ShapeAsVector(shape, *fd);
+  Vector new_shape = ShapeAsVector(generic_new_shape, *fd);
 
   Tensor output = fd->defineTensor(new_shape.size);
   std::vector<State> arg_states = {
@@ -1997,10 +1997,10 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::arg("minval"), \
       py::arg("maxval"), \
       py::arg("shape"), \
-      py::arg("dtype") = DataType::Float, \
       py::kw_only(), \
       py::arg("rng_seed") = py::none(), \
       py::arg("rng_offset") = py::none(), \
+      py::arg("dtype") = DataType::Float, \
       py::return_value_policy::reference); \
   nvf_ops.def( \
       op_str, \
@@ -2008,10 +2008,10 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::arg("minval"), \
       py::arg("maxval"), \
       py::arg("shape"), \
-      py::arg("dtype") = DataType::Float, \
       py::kw_only(), \
       py::arg("rng_seed") = py::none(), \
       py::arg("rng_offset") = py::none(), \
+      py::arg("dtype") = DataType::Float, \
       py::return_value_policy::reference); \
   nvf_ops.def( \
       op_str, \
@@ -2019,10 +2019,10 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::arg("minval"), \
       py::arg("maxval"), \
       py::arg("shape"), \
-      py::arg("dtype") = DataType::Float, \
       py::kw_only(), \
       py::arg("rng_seed") = py::none(), \
       py::arg("rng_offset") = py::none(), \
+      py::arg("dtype") = DataType::Float, \
       py::return_value_policy::reference);
 
   NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP("normal", serde::RecordType_NormalDistOp)

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -160,6 +160,7 @@ Tensor random_dist_op_fn(FusionDefinition::Operators& self,
   static_assert((RType == serde::RecordType_NormalDistOp) || (RType == serde::RecordType_UniformDistOp));
   NVF_CHECK(
       self.validUse(), "Attempting to add to a completed definition!");
+  NVF_CHECK(isFloatingPointType(dtype), "Random distributions only create floating point types! ", dtype);
   FusionDefinition* fd = self.fusion_definition;
   Vector new_shape = ShapeAsVector(generic_new_shape, *fd);
 

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -2032,9 +2032,9 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::return_value_policy::reference);
 
   NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP(
-      "normal", serde::RecordType_NormalDistOp, "mean", "std")
+      "normal", serde::RecordType::NormalDistOp, "mean", "std")
   NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP(
-      "uniform", serde::RecordType_UniformDistOp, "minval", "maxval")
+      "uniform", serde::RecordType::UniformDistOp, "minval", "maxval")
 #undef NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP
 
   nvf_ops.def(

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -151,8 +151,8 @@ Tensor reshape_fn(
 
 template <class ShapeType, serde::RecordType RType>
 Tensor random_dist_op_fn(FusionDefinition::Operators& self,
-   Scalar minval,
-   Scalar maxval,
+   Scalar arg1,
+   Scalar arg2,
    ShapeType generic_new_shape,
    std::optional<Scalar> rng_seed,
    std::optional<Scalar> rng_offset,
@@ -165,8 +165,8 @@ Tensor random_dist_op_fn(FusionDefinition::Operators& self,
 
   Tensor output = fd->defineTensor(new_shape.size);
   std::vector<State> arg_states = {
-      fd->recordingState(minval()),
-      fd->recordingState(maxval()),
+      fd->recordingState(arg1()),
+      fd->recordingState(arg2()),
       fd->recordingState(new_shape()),
   };
   if (rng_seed.has_value()) {
@@ -1990,12 +1990,12 @@ void initNvFuserPythonBindings(PyObject* module) {
   NVFUSER_PYTHON_BINDING_CAST_OP("cast", castOp)
 #undef NVFUSER_PYTHON_BINDING_CAST_OP
 
-#define NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP(op_str, op_type)                       \
+#define NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP(op_str, op_type, arg1_str, arg2_str) \
   nvf_ops.def( \
       op_str, \
       random_dist_op_fn<Vector, op_type>, \
-      py::arg("minval"), \
-      py::arg("maxval"), \
+      py::arg(arg1_str), \
+      py::arg(arg2_str), \
       py::arg("shape"), \
       py::kw_only(), \
       py::arg("rng_seed") = py::none(), \
@@ -2005,8 +2005,8 @@ void initNvFuserPythonBindings(PyObject* module) {
   nvf_ops.def( \
       op_str, \
       random_dist_op_fn<py::list, op_type>, \
-      py::arg("minval"), \
-      py::arg("maxval"), \
+      py::arg(arg1_str), \
+      py::arg(arg2_str), \
       py::arg("shape"), \
       py::kw_only(), \
       py::arg("rng_seed") = py::none(), \
@@ -2016,8 +2016,8 @@ void initNvFuserPythonBindings(PyObject* module) {
   nvf_ops.def( \
       op_str, \
       random_dist_op_fn<py::tuple, op_type>, \
-      py::arg("minval"), \
-      py::arg("maxval"), \
+      py::arg(arg1_str), \
+      py::arg(arg2_str), \
       py::arg("shape"), \
       py::kw_only(), \
       py::arg("rng_seed") = py::none(), \
@@ -2025,8 +2025,8 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::arg("dtype") = DataType::Float, \
       py::return_value_policy::reference);
 
-  NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP("normal", serde::RecordType_NormalDistOp)
-  NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP("uniform", serde::RecordType_UniformDistOp)
+  NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP("normal", serde::RecordType_NormalDistOp, "mean", "std")
+  NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP("uniform", serde::RecordType_UniformDistOp, "minval", "maxval")
 #undef NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP
 
   nvf_ops.def(

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -2010,9 +2010,9 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::arg(arg2_str),                           \
       py::arg("shape"),                            \
       py::kw_only(),                               \
-      py::arg("rng_seed").none(true) = py::none(),            \
-      py::arg("rng_offset").none(true) = py::none(),          \
-      py::arg("dtype").none(true) = DataType::Float,          \
+      py::arg("rng_seed") = py::none(),            \
+      py::arg("rng_offset") = py::none(),          \
+      py::arg("dtype") = DataType::Float,          \
       py::return_value_policy::reference);
 
 #define NVFUSER_PYTHON_BINDING_RANDOM_DIST_OP(...) \

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -84,12 +84,12 @@ enum RecordType: int {
     Ternary_Alpha_VAL_VAL_TV,
     Ternary_Alpha_TV_VAL_VAL,
     Ternary_Alpha_VAL_TV_VAL,
+    NormalDistOp,
     OutputTv,
     OutputVal,
     PadOp,
     PermuteOp,
     StrideOrderOp,
-    RandomOp,
     ReductionMax,
     ReductionMin,
     ReductionProd,
@@ -103,6 +103,7 @@ enum RecordType: int {
     Start,
     Tensor,
     TensorSizes,
+    UniformDistOp,
     VarianceOp,
     VarianceMeanOp,
     Vector,
@@ -336,10 +337,9 @@ table TensorCreation {
   dtype: DataType;
 }
 
-// Data for RandomOpRecord
+// Data for RandomDistOpRecord
 // The shape is symbolic.
 table TensorCreationSymbolic {
-  shape: [State];
   dtype: DataType;
 }
 

--- a/csrc/serde/fusion_record_serde.cpp
+++ b/csrc/serde/fusion_record_serde.cpp
@@ -525,16 +525,23 @@ void RecordFunctorFactory::registerAllParsers() {
   };
   registerParser(serde::RecordType_StrideOrderOp, deserializeStrideOrderRecord);
 
-  auto deserializeRandomRecord = [](const serde::RecordFunctor* buffer) {
+  auto deserializeNormalDistRecord = [](const serde::RecordFunctor* buffer) {
     auto data = buffer->data_as_TensorCreationSymbolic();
-    return new python_frontend::RandomOpRecord(
+    return new python_frontend::RandomDistOpRecord<serde::RecordType_NormalDistOp>(
         parseStateArgs(buffer->args()),
         parseStateArgs(buffer->outputs()),
-        parseStateArgs(data->shape()),
-        buffer->name()->str(),
         mapToNvfuserDtype(data->dtype()));
   };
-  registerParser(serde::RecordType_RandomOp, deserializeRandomRecord);
+  registerParser(serde::RecordType_NormalDistOp, deserializeNormalDistRecord);
+  
+  auto deserializeUniformDistRecord = [](const serde::RecordFunctor* buffer) {
+    auto data = buffer->data_as_TensorCreationSymbolic();
+    return new python_frontend::RandomDistOpRecord<serde::RecordType_UniformDistOp>(
+        parseStateArgs(buffer->args()),
+        parseStateArgs(buffer->outputs()),
+        mapToNvfuserDtype(data->dtype()));
+  };
+  registerParser(serde::RecordType_UniformDistOp, deserializeUniformDistRecord);
 
   auto deserializeReshapeRecord = [](const serde::RecordFunctor* buffer) {
     return new python_frontend::ReshapeOpRecord(

--- a/csrc/serde/fusion_record_serde.cpp
+++ b/csrc/serde/fusion_record_serde.cpp
@@ -527,16 +527,18 @@ void RecordFunctorFactory::registerAllParsers() {
 
   auto deserializeNormalDistRecord = [](const serde::RecordFunctor* buffer) {
     auto data = buffer->data_as_TensorCreationSymbolic();
-    return new python_frontend::RandomDistOpRecord<serde::RecordType_NormalDistOp>(
+    return new python_frontend::RandomDistOpRecord<
+        serde::RecordType_NormalDistOp>(
         parseStateArgs(buffer->args()),
         parseStateArgs(buffer->outputs()),
         mapToNvfuserDtype(data->dtype()));
   };
   registerParser(serde::RecordType_NormalDistOp, deserializeNormalDistRecord);
-  
+
   auto deserializeUniformDistRecord = [](const serde::RecordFunctor* buffer) {
     auto data = buffer->data_as_TensorCreationSymbolic();
-    return new python_frontend::RandomDistOpRecord<serde::RecordType_UniformDistOp>(
+    return new python_frontend::RandomDistOpRecord<
+        serde::RecordType_UniformDistOp>(
         parseStateArgs(buffer->args()),
         parseStateArgs(buffer->outputs()),
         mapToNvfuserDtype(data->dtype()));

--- a/csrc/serde/fusion_record_serde.cpp
+++ b/csrc/serde/fusion_record_serde.cpp
@@ -491,8 +491,7 @@ void RecordFunctorFactory::registerAllParsers() {
 
   auto deserializeNormalDistRecord = [](const RecordFunctor* buffer) {
     auto data = buffer->data_as_TensorCreationSymbolic();
-    return new python_frontend::RandomDistOpRecord<
-        RecordType::NormalDistOp>(
+    return new python_frontend::RandomDistOpRecord<RecordType::NormalDistOp>(
         parseStateArgs(buffer->args()),
         parseStateArgs(buffer->outputs()),
         mapToNvfuserDtype(data->dtype()));
@@ -501,8 +500,7 @@ void RecordFunctorFactory::registerAllParsers() {
 
   auto deserializeUniformDistRecord = [](const RecordFunctor* buffer) {
     auto data = buffer->data_as_TensorCreationSymbolic();
-    return new python_frontend::RandomDistOpRecord<
-        RecordType::UniformDistOp>(
+    return new python_frontend::RandomDistOpRecord<RecordType::UniformDistOp>(
         parseStateArgs(buffer->args()),
         parseStateArgs(buffer->outputs()),
         mapToNvfuserDtype(data->dtype()));

--- a/python_tests/pytest_input_generators.py
+++ b/python_tests/pytest_input_generators.py
@@ -21,6 +21,7 @@ from pytest_utils import (
     complex_dtypes,
 )
 from nvfuser import DataType
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 
 MINIMUM_SYMBOLIC_SIZE = -1
 INT64_MAX = 2**63 - 1
@@ -1009,6 +1010,18 @@ def permute_error_generator(
     yield SampleInput(
         make_arg(input_shape), [0, 1, 2, 3, 4]
     ), RuntimeError, "argument to have the same length as input"
+
+
+def random_dist_error_generator(
+    op: OpInfo, dtype: torch.dtype, requires_grad: bool = False, **kwargs
+):
+    # Checking that non-supported dtypes fail
+    yield SampleInput(
+        make_number(torch.float),
+        make_number(torch.float),
+        [2, 2],
+        dtype=torch_dtype_to_nvfuser_dtype(dtype),
+    ), RuntimeError, "Random distributions only create floating point types"
 
 
 def reduction_generator(

--- a/python_tests/pytest_opinfos.py
+++ b/python_tests/pytest_opinfos.py
@@ -1076,7 +1076,7 @@ uniform_opinfo = OpInfo(
     dtypes=(bool_int_dtypes + complex_dtypes),
     error_input_generator=random_dist_error_generator,
     symbolic_parameter_list=(
-        ArgumentType.ConstantScalar, 
+        ArgumentType.ConstantScalar,
         ArgumentType.ConstantScalar,
         ArgumentType.Constant,
     ),
@@ -1092,7 +1092,7 @@ uniform_opinfo = OpInfo(
     dtypes=(bool_int_dtypes + complex_dtypes),
     error_input_generator=random_dist_error_generator,
     symbolic_parameter_list=(
-        ArgumentType.ConstantScalar, 
+        ArgumentType.ConstantScalar,
         ArgumentType.ConstantScalar,
         ArgumentType.Constant,
     ),

--- a/python_tests/pytest_opinfos.py
+++ b/python_tests/pytest_opinfos.py
@@ -35,6 +35,7 @@ from pytest_input_generators import (
     pad_error_generator,
     permute_generator,
     permute_error_generator,
+    random_dist_error_generator,
     reduction_error_generator,
     reshape_generator,
     reshape_error_generator,
@@ -49,8 +50,10 @@ from pytest_input_generators import (
 )
 from pytest_utils import (
     bool_int_dtypes,
-    int_dtypes,
+    complex_dtypes,
+    float_dtypes,
     full_precision_float_dtypes,
+    int_dtypes,
     int_float_dtypes,
     float_complex_dtypes,
     ArgumentType,
@@ -1063,6 +1066,38 @@ iota_opinfo = OpInfo(
     ),
 )
 tensor_creation_ops.append(iota_opinfo)
+
+# NOTE: normal's python API does not produce value based errors given most parameters are
+# symbolic as Scalar or Vector parameters.  The dtype parameter is checked to make sure the
+# user does not ask for non-floating point random numbers.
+uniform_opinfo = OpInfo(
+    lambda fd: fd.ops.normal,
+    "normal",
+    dtypes=(bool_int_dtypes + complex_dtypes),
+    error_input_generator=random_dist_error_generator,
+    symbolic_parameter_list=(
+        ArgumentType.ConstantScalar, 
+        ArgumentType.ConstantScalar,
+        ArgumentType.Constant,
+    ),
+)
+tensor_creation_ops.append(uniform_opinfo)
+
+# NOTE: uniform's python API does not produce value based errors given most parameters are
+# symbolic as Scalar or Vector parameters.  The dtype parameter is checked to make sure the
+# user does not ask for non-floating point random numbers.
+uniform_opinfo = OpInfo(
+    lambda fd: fd.ops.uniform,
+    "uniform",
+    dtypes=(bool_int_dtypes + complex_dtypes),
+    error_input_generator=random_dist_error_generator,
+    symbolic_parameter_list=(
+        ArgumentType.ConstantScalar, 
+        ArgumentType.ConstantScalar,
+        ArgumentType.Constant,
+    ),
+)
+tensor_creation_ops.append(uniform_opinfo)
 
 """ End Tensor Creation """
 

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2472,14 +2472,13 @@ class TestNvFuserFrontend(TestCase):
                 t1 = fd.from_pytorch(inputs[0])
                 a = fd.define_scalar(0.3, DataType.Float)
                 b = fd.define_scalar(1.7, DataType.Float)
-                shape = [fd.define_scalar(5), fd.define_scalar(9)]
                 randop = getattr(fd.ops, randopname)
                 if deterministic:
                     rng_seed = fd.define_scalar(DataType.Int)
                     rng_offset = fd.define_scalar(DataType.Int)
-                    u = randop(a, b, shape, rng_seed=rng_seed, rng_offset=rng_offset)
+                    u = randop(a, b, input_size, rng_seed=rng_seed, rng_offset=rng_offset)
                 else:
-                    u = randop(a, b, shape)
+                    u = randop(a, b, input_size)
                 t2 = t1 * u
                 fd.add_output(t2)
 
@@ -2516,7 +2515,6 @@ class TestNvFuserFrontend(TestCase):
                     except AssertionError as e:
                         print(f"Assertion failed for iteration {i} with seed {seed}")
                         print(e)
-                        break
 
     # Test expand to zero is replaced with expanded extent and not 1
     # see https://github.com/NVIDIA/Fuser/issues/603

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2474,9 +2474,11 @@ class TestNvFuserFrontend(TestCase):
                 if deterministic:
                     rng_seed = fd.define_scalar(DataType.Int)
                     rng_offset = fd.define_scalar(DataType.Int)
-                    u = eval("fd.ops." + randopname)(a, b, shape=[5, 9], rng_seed=rng_seed, rng_offset=rng_offset)
+                    u = randop(
+                        a, b, shape=[5, 9], rng_seed=rng_seed, rng_offset=rng_offset
+                    )
                 else:
-                    u = eval("fd.ops." + randopname)(a, b, shape=[5,9])
+                    u = randop(a, b, shape=[5, 9])
                 t2 = t1 * u
                 fd.add_output(t2)
 

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -954,8 +954,7 @@ class TestNvFuserFrontend(TestCase):
             t0 = fd.from_pytorch(inputs[0])
             s_mean = fd.define_scalar(mean)
             s_std = fd.define_scalar(std)
-            size = fd.ops.tensor_sizes(t0)
-            t1 = fd.ops.normal(s_mean, s_std, size, DataType.Double)
+            t1 = fd.ops.normal(s_mean, s_std, t0.shape(), dtype=DataType.Double)
             fd.add_output(t1)
 
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
@@ -992,8 +991,7 @@ class TestNvFuserFrontend(TestCase):
             t0 = fd.from_pytorch(inputs[0])
             s_lo = fd.define_scalar(lo)
             s_hi = fd.define_scalar(hi)
-            size = fd.ops.tensor_sizes(t0)
-            t1 = fd.ops.uniform(s_lo, s_hi, size, DataType.Double)
+            t1 = fd.ops.uniform(s_lo, s_hi, t0.shape(), dtype=DataType.Double)
             fd.add_output(t1)
 
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
@@ -2476,9 +2474,9 @@ class TestNvFuserFrontend(TestCase):
                 if deterministic:
                     rng_seed = fd.define_scalar(DataType.Int)
                     rng_offset = fd.define_scalar(DataType.Int)
-                    u = randop(a, b, input_size, rng_seed=rng_seed, rng_offset=rng_offset)
+                    u = eval("fd.ops." + randopname)(a, b, shape=[5, 9], rng_seed=rng_seed, rng_offset=rng_offset)
                 else:
-                    u = randop(a, b, input_size)
+                    u = eval("fd.ops." + randopname)(a, b, shape=[5,9])
                 t2 = t1 * u
                 fd.add_output(t2)
 


### PR DESCRIPTION
I modified the two APIs that have a `shape` parameter to take either a `Vector`, `py::list`, or `py::tuple` such that the user can specify the shape as a combination of `Scalar`s, Python Integers, or a `Vector` in order to utilize the output of nvFuser's shape ops.  The API was partially already there by allowing the user to specify the output shape with just a List of `Scalar`s.  I also cleaned up the API such that each Random Distribution has its own Record Type instead of relying on distinguishing each type by a string.  I also made the code more modular so the same code is used to handle each distribution.

Old syntax:
```python
ops.uniform(minval: Scalar, maxval: Scalar, shape: List[Scalar], dtype: DataType, *, rng_seed: Scalar, rng_offset: Scalar) -> Tensor
ops.normal(mean: Scalar, std: Scalar, shape: List[Scalar], dtype: DataType, *, rng_seed: Scalar, rng_offset: Scalar) -> Tensor
```
New Syntax:
```python
ops.uniform(minval: Scalar, maxval: Scalar, shape: Union[Vector, List[Union[Scalar, int]]], *, rng_seed: Scalar, rng_offset: Scalar, dtype: DataType) -> Tensor
ops.normal(mean: Scalar, std: Scalar, shape: Union[Vector, List[Union[Scalar, int]]], *, rng_seed: Scalar, rng_offset: Scalar, dtype: DataType) -> Tensor
```
