### PR TITLE
Print fusion IR with transforms after concretization.

### DIFF
--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -750,7 +750,7 @@ FusionKernelRuntime* FusionExecutorCache::getKernelRuntimeFor(
 
       if (isDebugDumpEnabled(DebugDumpOption::FusionIrConcretized)) {
         debug() << "Concretized Fusion:" << std::endl;
-        conc_fusion->printMath();
+        conc_fusion->print();
       }
     }
     FusionGuard fg(conc_fusion.get());


### PR DESCRIPTION
This is useful for debugging pre-segmenter optimizations.