### PR TITLE
TransformReplay::replayCasP sets the right contiguity.

### DIFF
--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -572,8 +572,9 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayCasP(
 
   // If this is a reduction operation, we may call transform_replay on the same
   // tensor view. When this happens, just return thet target view.
-  if (consumer == producer)
+  if (consumer == producer) {
     return {consumer->domain(), consumer->nDims()};
+  }
 
   if (producer_pos < 0) {
     producer_pos += (int64_t)producer->nDims() + 1;

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -805,8 +805,8 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayCasP(
       consumer->container(),
       consumer->getRootDomain(),
       consumer->getRFactorDomain(),
-      std::vector<IterDomain*>{},
-      new_IDs,
+      /*allocation=*/std::vector<IterDomain*>{},
+      /*leaf=*/new_IDs,
       consumer->domain()->contiguity());
 
   if (producer->hasAllocation()) {
@@ -829,7 +829,8 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayCasP(
           consumer->toString());
       new_allocation_domain.emplace_back(it->second);
     }
-    replayed->setAllocationDomain(std::move(new_allocation_domain), true);
+    replayed->setAllocationDomain(
+        std::move(new_allocation_domain), producer->getContiguity());
   }
   return {replayed, consumer_pos};
 }

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -554,9 +554,10 @@ std::pair<TensorDomain*, size_t> TransformReplay::replayPasC(
           consumer->toString(),
           " to producer tensor ",
           producer->toString());
-      new_allocation_domain.emplace_back(it->second);
+      new_allocation_domain.push_back(it->second);
     }
-    replayed->setAllocationDomain(std::move(new_allocation_domain), true);
+    replayed->setAllocationDomain(
+        std::move(new_allocation_domain), consumer->getContiguity());
   }
 
   return {replayed, producer_pos};

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1248,7 +1248,7 @@ TEST_F(AllocationDomainTest, VectorizeOverlappingTensor) {
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
-TEST_F(AllocationDomainTest, IntermediateGlobalOutput) {
+TEST_F(AllocationDomainTest, Issue1290) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -1269,6 +1269,9 @@ TEST_F(AllocationDomainTest, IntermediateGlobalOutput) {
   FusionExecutorCache fec(std::move(fusion));
   fec.runFusionWithInputs({in_tensor});
 
+  // The initial issue was detected in the pointwise scheduler, so I added these
+  // checks to make sure it's a valid regression test. The transpose scheduler
+  // could accept this but decided not to because of a small problem size.
   const std::vector<SegmentedGroup*>& groups =
       fec.getMostRecentKernelRuntime()->fusionSegments()->groups();
   ASSERT_EQ(groups.size(), 1);


### PR DESCRIPTION
Fixes #1290 