### PR TITLE
Fixing `NVFUSER_PROF` printing after kernel name change.

### DIFF
--- a/csrc/fusion_profiler.cpp
+++ b/csrc/fusion_profiler.cpp
@@ -48,7 +48,7 @@ void record_cupti_activity(CUpti_Activity* pRecord, FILE* pFileHandle) {
       if (start != std::string::npos) {
         size_t end = prof.name.find('(', start);
         prof.name = prof.name.substr(start, end - start);
-      } 
+      }
       prof.device = (int)pKARecord->deviceId;
       prof.stream = pKARecord->streamId;
       prof.correlation_id = pKARecord->correlationId;
@@ -397,30 +397,12 @@ void FusionProfile::reset() {
 }
 
 std::array<const char*, 25> column_strs{
-    "Fus#",
-    "NSegs",
-    "CuEvtTm(ms)",
-    "HstTm(ms)",
-    "CmpTm(ms)",
-    "KerTm(ms)",
-    "EffBw(GB/s)",
-    "%PeakBw",
-    "S-Seg#",
-    "S-KerTm(ms)",
-    "S-CmpTm(ms)",
-    "S-EffBw(GB/s)",
-    "S-%PeakBw",
-    "S-In(MB)",
-    "S-Out(MB)",
-    "S-Smem[Dyn,Stat]",
-    "S-Regs",
-    "S-Grid",
-    "S-Block",
-    "S-Cluster",
-    "S-Dev",
-    "S-Stm",
-    "S-PkBw(GB/s)",
-    "S-DeviceName",
+    "Fus#",      "NSegs",       "CuEvtTm(ms)",  "HstTm(ms)",
+    "CmpTm(ms)", "KerTm(ms)",   "EffBw(GB/s)",  "%PeakBw",
+    "S-Seg#",    "S-KerTm(ms)", "S-CmpTm(ms)",  "S-EffBw(GB/s)",
+    "S-%PeakBw", "S-In(MB)",    "S-Out(MB)",    "S-Smem[Dyn,Stat]",
+    "S-Regs",    "S-Grid",      "S-Block",      "S-Cluster",
+    "S-Dev",     "S-Stm",       "S-PkBw(GB/s)", "S-DeviceName",
     "S-KerName"};
 
 std::ostream& operator<<(std::ostream& os, const FusionProfile& fp) {
@@ -437,7 +419,7 @@ std::ostream& operator<<(std::ostream& os, const FusionProfile& fp) {
          << std::get<7>(column_strs);
 
       os << " " << std::setw(6) << std::get<8>(column_strs) << " "
-         << std::setw(9) << std::get<9>(column_strs); 
+         << std::setw(9) << std::get<9>(column_strs);
 
       if (fp.verbose) {
         os << " " << std::setw(11) << std::get<10>(column_strs);


### PR DESCRIPTION
The kernel name change that was recently introduced made the kernel name printing ugly.  Therefore, I fixed it.

Here is an example:

```bash
Benchmarking nanogpt-GPTConfig(name='', block_size=1024, seq_len=128, vocab_size=50304, n_layer=48, n_head=25, n_embd=1600, dropout=0.1, bias=True)-block
Fus#  NSegs CuEvtTm(ms) HstTm(ms) CmpTm(ms) KerTm(ms) EffBw(GB/s) %PeakBw   S-Seg# S-KerTm(ms) S-EffBw(GB/s) S-%PeakBw S-In(MB)  S-Out(MB) S-Smem[Dyn,Stat] S-Regs S-Grid           S-Block          S-KerName
    0     1     307.870   307.861   260.239     0.021     1846.41     95.40      0       0.021       1846.41     95.40    13.120    26.231        [512, 16]     41     [2048, 1, 1]      [128, 1, 1] nvfuser_inner_persistent_f0_c1_r0_g0
    1     1      81.898    81.887    79.508     0.011     2288.27    118.23      0       0.011       2288.27    118.23    13.107    13.107           [0, 0]     16     [6400, 1, 1]      [128, 1, 1] nvfuser_pointwise_f1_c1_r0_g0
    2     1    1041.419  1041.396   981.268     0.047     1462.45     75.56      0       0.047       1462.45     75.56    26.227    42.615        [512, 16]     54     [2048, 1, 1]      [128, 1, 1] nvfuser_inner_persistent_f2_c1_r0_g0
    3     1     126.311   126.268   116.405     0.055     1900.66     98.21      0       0.055       1900.66     98.21    52.429    52.429           [0, 0]     16    [25600, 1, 1]      [128, 1, 1] nvfuser_pointwise_f3_c1_r0_g0
    4     1     269.764   269.758   262.584     0.018     2343.66    121.10      0       0.018       2343.66    121.10    26.214    16.384           [0, 4]     34     [6400, 1, 1]      [128, 1, 1] nvfuser_pointwise_f4_c1_r0_g0
    5     1     227.590   227.580   221.870     0.021     1433.59     74.07      0       0.021       1433.59     74.07    16.384    13.114       [2048, 16]     39      [100, 3, 1]      [16, 32, 1] nvfuser_reduction_f5_c1_r0_g0
    6     1     360.764   360.676   344.230     0.107     1467.45     75.82      0       0.107       1467.45     75.82   104.858    52.454       [2048, 16]     47      [100, 8, 1]       [64, 8, 1] nvfuser_reduction_f6_c1_r0_g0
    7     1    1154.260  1154.204  1050.212     0.093      877.45     45.34      0       0.093        877.45     45.34    55.728    26.234        [512, 16]    133      [1, 324, 1]       [4, 32, 1] nvfuser_inner_outer_persistent_f7_c1_r0_g0
    8     1      80.981    80.967    78.710     0.012     2238.06    115.64      0       0.012       2238.06    115.64    13.107    13.107           [0, 0]     16     [6400, 1, 1]      [128, 1, 1] nvfuser_pointwise_f8_c1_r0_g0
    9     1     141.495   141.472   140.260     0.036     1092.80     56.46      0       0.036       1092.80     56.46    39.322     0.019       [2048, 16]     32      [75, 11, 1]       [64, 8, 1] nvfuser_reduction_f9_c1_r0_g0
   10     3    1029.540  1029.542   509.445     0.091      717.47     37.07      0       0.042        619.41     32.00    26.223     0.021       [2048, 16]     56      [100, 3, 1]      [16, 32, 1] nvfuser_reduction_f10_c1_r0_g0
    -     -           -         -         -         -           -         -      1       0.024       1659.61     85.75    26.229    13.124        [1600, 0]     32     [2048, 1, 1]      [400, 1, 1] nvfuser_reduction_f10_c1_r0_g1
    -     -           -         -         -         -           -         -      2       0.025       2072.60    107.09    39.354    13.107       [9216, 16]     53     [3200, 1, 1]      [128, 1, 1] nvfuser_transpose_f10_c1_r0_g2
```