### PR TITLE
Minor cleanups. 

### DIFF
--- a/test/test_linked_hash_map.cpp
+++ b/test/test_linked_hash_map.cpp
@@ -12,6 +12,51 @@
 
 #include <linked_hash_map.h>
 
+namespace {
+class Key {
+ public:
+  explicit Key(std::string data) : data_(std::move(data)) {}
+
+  size_t hash() const {
+    return std::hash<std::string>()(data_);
+  }
+
+  bool operator==(const Key& other) const {
+    return data_ == other.data_;
+  }
+
+ private:
+  std::string data_;
+};
+
+class Value {
+ public:
+  explicit Value(int data) : data_(data) {}
+
+  Value(const Value&) = delete;
+  Value& operator=(const Value&) = delete;
+
+  Value(Value&&) = default;
+  Value& operator=(Value&&) = default;
+
+  int data() const {
+    return data_;
+  }
+
+ private:
+  int data_;
+};
+} // namespace
+
+namespace std {
+template <>
+struct hash<Key> {
+  size_t operator()(const Key& key) const {
+    return key.hash();
+  }
+};
+} // namespace std
+
 namespace nvfuser {
 
 using testing::ElementsAre;
@@ -72,54 +117,6 @@ TEST(LinkedHashMapTest, EraseThenPushBack) {
   map.pushBack("b", 4);
   EXPECT_THAT(map, ElementsAre(Pair("a", 1), Pair("b", 4)));
 }
-
-namespace {
-class Key {
- public:
-  explicit Key(std::string data) : data_(std::move(data)) {}
-
-  size_t hash() const {
-    return std::hash<std::string>()(data_);
-  }
-
-  bool operator==(const Key& other) const {
-    return data_ == other.data_;
-  }
-
- private:
-  std::string data_;
-};
-
-class Value {
- public:
-  explicit Value(int data) : data_(data) {}
-
-  Value(const Value&) = delete;
-  Value& operator=(const Value&) = delete;
-
-  Value(Value&&) = default;
-  Value& operator=(Value&&) = default;
-
-  int data() const {
-    return data_;
-  }
-
- private:
-  int data_;
-};
-} // namespace
-} // namespace nvfuser
-
-namespace std {
-template <>
-struct hash<nvfuser::Key> {
-  size_t operator()(const nvfuser::Key& key) const {
-    return key.hash();
-  }
-};
-} // namespace std
-
-namespace nvfuser {
 
 namespace {
 MATCHER_P(DataIs, data, "") {

--- a/test/test_linked_hash_map.cpp
+++ b/test/test_linked_hash_map.cpp
@@ -100,10 +100,6 @@ class Value {
   Value(Value&&) = default;
   Value& operator=(Value&&) = default;
 
-  bool operator==(const Value& other) const {
-    return data_ == other.data_;
-  }
-
   int data() const {
     return data_;
   }

--- a/test/test_linked_hash_map.cpp
+++ b/test/test_linked_hash_map.cpp
@@ -13,15 +13,15 @@
 #include <linked_hash_map.h>
 
 namespace {
-class Key {
+class CopyableKey {
  public:
-  explicit Key(std::string data) : data_(std::move(data)) {}
+  explicit CopyableKey(std::string data) : data_(std::move(data)) {}
 
   size_t hash() const {
     return std::hash<std::string>()(data_);
   }
 
-  bool operator==(const Key& other) const {
+  bool operator==(const CopyableKey& other) const {
     return data_ == other.data_;
   }
 
@@ -29,15 +29,15 @@ class Key {
   std::string data_;
 };
 
-class Value {
+class MovableValue {
  public:
-  explicit Value(int data) : data_(data) {}
+  explicit MovableValue(int data) : data_(data) {}
 
-  Value(const Value&) = delete;
-  Value& operator=(const Value&) = delete;
+  MovableValue(const MovableValue&) = delete;
+  MovableValue& operator=(const MovableValue&) = delete;
 
-  Value(Value&&) = default;
-  Value& operator=(Value&&) = default;
+  MovableValue(MovableValue&&) = default;
+  MovableValue& operator=(MovableValue&&) = default;
 
   int data() const {
     return data_;
@@ -50,8 +50,8 @@ class Value {
 
 namespace std {
 template <>
-struct hash<Key> {
-  size_t operator()(const Key& key) const {
+struct hash<CopyableKey> {
+  size_t operator()(const CopyableKey& key) const {
     return key.hash();
   }
 };
@@ -125,12 +125,12 @@ MATCHER_P(DataIs, data, "") {
 } // namespace
 
 TEST(LinkedHashMapTest, MovableValue) {
-  LinkedHashMap<Key, Value> map;
-  map.pushBack(Key("a"), Value(1));
-  map.pushBack(Key("b"), Value(2));
-  map.erase(Key("b"));
+  LinkedHashMap<CopyableKey, MovableValue> map;
+  map.pushBack(CopyableKey("a"), MovableValue(1));
+  map.pushBack(CopyableKey("b"), MovableValue(2));
+  map.erase(CopyableKey("b"));
 
-  EXPECT_THAT(map, ElementsAre(Pair(Key("a"), DataIs(1))));
+  EXPECT_THAT(map, ElementsAre(Pair(CopyableKey("a"), DataIs(1))));
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
1. Move `Key` and `Value` out of the `nvfuser::{anonymous}` namespace. 
2. Call them `CopyableKey` and `MovableValue` to clarify their properties.
3. Move the unused `MovableValue::operator==` method. 