### PR TITLE
Duplicated outputs patch

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1554,7 +1554,8 @@ std::unique_ptr<Fusion> SegmentedFusion::makeFusion(SegmentedGroup* sg) {
     }
   }
 
-  // note, we would want to keep output consistent and not artificially drop duplicates.
+  // note, we would want to keep output consistent and not artificially drop
+  // duplicates.
   for (auto out : sg->output_vals) {
     fusion_segment->addOutput(complete_to_segment_map.clone(out));
   }

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1554,7 +1554,8 @@ std::unique_ptr<Fusion> SegmentedFusion::makeFusion(SegmentedGroup* sg) {
     }
   }
 
-  for (auto out : getAllOutputs(sg)) {
+  // note, we would want to keep output consistent and not artificially drop duplicates.
+  for (auto out : sg->output_vals) {
     fusion_segment->addOutput(complete_to_segment_map.clone(out));
   }
 

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -292,11 +292,11 @@ TEST_F(AliasTest, DuplicateOutputs) {
         !fec.getMostRecentKernelRuntime()->isSegmented(),
         "segmentation is not supposed to happen");
 
-    at::Tensor out_tensor = in_tensor.add(3.141);
+    at::Tensor expected_out_tensor = in_tensor.add(3.141);
     // Verify output values.
     testValidate(
         fec.fusion(),
-        {out_tensor, out_tensor},
+        {expected_out_tensor, expected_out_tensor},
         {in_tensor},
         __LINE__,
         __FILE__);

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -294,7 +294,12 @@ TEST_F(AliasTest, DuplicateOutputs) {
 
     at::Tensor out_tensor = in_tensor.add(3.141);
     // Verify output values.
-    testValidate(fec.fusion(), {out_tensor, out_tensor}, {in_tensor}, __LINE__, __FILE__);
+    testValidate(
+        fec.fusion(),
+        {out_tensor, out_tensor},
+        {in_tensor},
+        __LINE__,
+        __FILE__);
   }
 
   {
@@ -308,8 +313,8 @@ TEST_F(AliasTest, DuplicateOutputs) {
     fusion->addInput(in);
     TensorView* intermediate_tv = add(in, IrBuilder::create<Val>(3.141));
     TensorView* segment_tv = segment_set(intermediate_tv);
-    TensorView* out = mul(segment_tv , IrBuilder::create<Val>(2.0));
-    
+    TensorView* out = mul(segment_tv, IrBuilder::create<Val>(2.0));
+
     fusion->addOutput(intermediate_tv);
     fusion->addOutput(intermediate_tv);
     fusion->addOutput(out);
@@ -333,16 +338,19 @@ TEST_F(AliasTest, DuplicateOutputs) {
         fec.getMostRecentKernelRuntime()->isSegmented(),
         "segmentation didn't happen");
     NVF_CHECK(
-        fec.getMostRecentKernelRuntime()
-                ->fusionSegments()
-                ->groups()
-                .size() == 2,
+        fec.getMostRecentKernelRuntime()->fusionSegments()->groups().size() ==
+            2,
         "segmentation didn't happen as expected");
 
     at::Tensor intermediate_tensor = in_tensor.add(3.141);
     at::Tensor out_tensor = intermediate_tensor.mul(2.0);
     // Verify output values.
-    testValidate(fec.fusion(), {intermediate_tensor, intermediate_tensor, out_tensor, out_tensor}, {in_tensor}, __LINE__, __FILE__);
+    testValidate(
+        fec.fusion(),
+        {intermediate_tensor, intermediate_tensor, out_tensor, out_tensor},
+        {in_tensor},
+        __LINE__,
+        __FILE__);
   }
 }
 

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -272,7 +272,7 @@ TEST_F(AliasTest, DuplicateOutputs) {
     const std::vector<int64_t> in_shape({2, 3, 4});
 
     TensorView* in = makeContigConcreteTensor(in_shape);
-    fusion->addInput(in)
+    fusion->addInput(in);
     TensorView* out = add(in, IrBuilder::create<Val>(3.141));
     fusion->addOutput(out);
     fusion->addOutput(out); // duplicated outputs

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -334,8 +334,7 @@ TEST_F(AliasTest, DuplicateOutputsSegmentedFusion) {
   EXPECT_TRUE(out_tensor_2.is_alias_of(out_tensor_3));
   // Verify segmentation
   NVF_CHECK(
-      fec.getMostRecentKernelRuntime()->fusionSegments()->groups().size() ==
-          2,
+      fec.getMostRecentKernelRuntime()->fusionSegments()->groups().size() == 2,
       "segmentation didn't happen as expected");
 
   at::Tensor intermediate_tensor = in_tensor.add(3.141);

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -301,10 +301,10 @@ TEST_F(AliasTest, DuplicateOutputs) {
     const std::vector<int64_t> in_shape({2, 3, 4});
 
     TensorView* in = makeContigConcreteTensor(in_shape);
-    fusion->addInput(in)
-    TensorView* intermediate = add(in, IrBuilder::create<Val>(3.141));
-    TensorView* segment_set = segment_set(tv1);
-    TensorView* out = mul(segment_set, IrBuilder::create<Val>(2.0));
+    fusion->addInput(in);
+    TensorView* intermediate_tv = add(in, IrBuilder::create<Val>(3.141));
+    TensorView* segment_tv = segment_set(intermediate_tv);
+    TensorView* out = mul(segment_tv , IrBuilder::create<Val>(2.0));
     
     fusion->addOutput(out);
     fusion->addOutput(out); // duplicated outputs

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -264,94 +264,89 @@ TEST_F(AliasTest, ViewPermute) {
 }
 
 TEST_F(AliasTest, DuplicateOutputs) {
-  {
-    // testing a complete fusion
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
+  // testing a complete fusion
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
 
-    const std::vector<int64_t> in_shape({2, 3, 4});
+  const std::vector<int64_t> in_shape({2, 3, 4});
 
-    TensorView* in = makeContigConcreteTensor(in_shape);
-    fusion->addInput(in);
-    TensorView* out = add(in, IrBuilder::create<Val>(3.141));
-    fusion->addOutput(out);
-    fusion->addOutput(out); // duplicated outputs
+  TensorView* in = makeContigConcreteTensor(in_shape);
+  fusion->addInput(in);
+  TensorView* out = add(in, IrBuilder::create<Val>(3.141));
+  fusion->addOutput(out);
+  fusion->addOutput(out); // duplicated outputs
 
-    FusionExecutorCache fec(std::move(fusion));
-    at::Tensor in_tensor =
-        at::randn(in_shape, at::dtype(at::kFloat).device(at::kCUDA, 0));
-    std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
-    ASSERT_EQ(out_tensors.size(), 2);
-    at::Tensor out_tensor_0 = out_tensors[0];
-    at::Tensor out_tensor_1 = out_tensors[1];
+  FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor =
+      at::randn(in_shape, at::dtype(at::kFloat).device(at::kCUDA, 0));
+  std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
+  ASSERT_EQ(out_tensors.size(), 2);
+  at::Tensor out_tensor_0 = out_tensors[0];
+  at::Tensor out_tensor_1 = out_tensors[1];
 
-    // Verify aliasing among duplicated outputs
-    EXPECT_TRUE(out_tensor_0.is_alias_of(out_tensor_1));
-    // Verify no segmentation
-    NVF_CHECK(
-        !fec.getMostRecentKernelRuntime()->isSegmented(),
-        "segmentation is not supposed to happen");
+  // Verify aliasing among duplicated outputs
+  EXPECT_TRUE(out_tensor_0.is_alias_of(out_tensor_1));
+  // Verify no segmentation
+  NVF_CHECK(
+      !fec.getMostRecentKernelRuntime()->isSegmented(),
+      "segmentation is not supposed to happen");
 
-    at::Tensor expected_out_tensor = in_tensor.add(3.141);
-    // Verify output values.
-    testValidate(
-        fec.fusion(),
-        {expected_out_tensor, expected_out_tensor},
-        {in_tensor},
-        __LINE__,
-        __FILE__);
-  }
+  at::Tensor expected_out_tensor = in_tensor.add(3.141);
+  // Verify output values.
+  testValidate(
+      fec.fusion(),
+      {expected_out_tensor, expected_out_tensor},
+      {in_tensor},
+      __LINE__,
+      __FILE__);
+}
 
-  {
-    // testing duplicated output in segmented fusion
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
+TEST_F(AliasTest, DuplicateOutputsSegmentedFusion) {
+  // testing duplicated output in segmented fusion
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
 
-    const std::vector<int64_t> in_shape({2, 3, 4});
+  const std::vector<int64_t> in_shape({2, 3, 4});
 
-    TensorView* in = makeContigConcreteTensor(in_shape);
-    fusion->addInput(in);
-    TensorView* intermediate_tv = add(in, IrBuilder::create<Val>(3.141));
-    TensorView* segment_tv = segment_set(intermediate_tv);
-    TensorView* out = mul(segment_tv, IrBuilder::create<Val>(2.0));
+  TensorView* in = makeContigConcreteTensor(in_shape);
+  fusion->addInput(in);
+  TensorView* intermediate_tv = add(in, IrBuilder::create<Val>(3.141));
+  TensorView* segment_tv = segment_set(intermediate_tv);
+  TensorView* out = mul(segment_tv, IrBuilder::create<Val>(2.0));
 
-    fusion->addOutput(intermediate_tv);
-    fusion->addOutput(intermediate_tv);
-    fusion->addOutput(out);
-    fusion->addOutput(out); // duplicated outputs
+  fusion->addOutput(intermediate_tv);
+  fusion->addOutput(intermediate_tv);
+  fusion->addOutput(out);
+  fusion->addOutput(out); // duplicated outputs
 
-    FusionExecutorCache fec(std::move(fusion));
-    at::Tensor in_tensor =
-        at::randn(in_shape, at::dtype(at::kFloat).device(at::kCUDA, 0));
-    std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
-    ASSERT_EQ(out_tensors.size(), 4);
-    at::Tensor out_tensor_0 = out_tensors[0];
-    at::Tensor out_tensor_1 = out_tensors[1];
-    at::Tensor out_tensor_2 = out_tensors[2];
-    at::Tensor out_tensor_3 = out_tensors[3];
+  FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor =
+      at::randn(in_shape, at::dtype(at::kFloat).device(at::kCUDA, 0));
+  std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
+  ASSERT_EQ(out_tensors.size(), 4);
+  at::Tensor out_tensor_0 = out_tensors[0];
+  at::Tensor out_tensor_1 = out_tensors[1];
+  at::Tensor out_tensor_2 = out_tensors[2];
+  at::Tensor out_tensor_3 = out_tensors[3];
 
-    // Verify aliasing among duplicated outputs
-    EXPECT_TRUE(out_tensor_0.is_alias_of(out_tensor_1));
-    EXPECT_TRUE(out_tensor_2.is_alias_of(out_tensor_3));
-    // Verify segmentation
-    NVF_CHECK(
-        fec.getMostRecentKernelRuntime()->isSegmented(),
-        "segmentation didn't happen");
-    NVF_CHECK(
-        fec.getMostRecentKernelRuntime()->fusionSegments()->groups().size() ==
-            2,
-        "segmentation didn't happen as expected");
+  // Verify aliasing among duplicated outputs
+  EXPECT_TRUE(out_tensor_0.is_alias_of(out_tensor_1));
+  EXPECT_TRUE(out_tensor_2.is_alias_of(out_tensor_3));
+  // Verify segmentation
+  NVF_CHECK(
+      fec.getMostRecentKernelRuntime()->fusionSegments()->groups().size() ==
+          2,
+      "segmentation didn't happen as expected");
 
-    at::Tensor intermediate_tensor = in_tensor.add(3.141);
-    at::Tensor out_tensor = intermediate_tensor.mul(2.0);
-    // Verify output values.
-    testValidate(
-        fec.fusion(),
-        {intermediate_tensor, intermediate_tensor, out_tensor, out_tensor},
-        {in_tensor},
-        __LINE__,
-        __FILE__);
-  }
+  at::Tensor intermediate_tensor = in_tensor.add(3.141);
+  at::Tensor out_tensor = intermediate_tensor.mul(2.0);
+  // Verify output values.
+  testValidate(
+      fec.fusion(),
+      {intermediate_tensor, intermediate_tensor, out_tensor, out_tensor},
+      {in_tensor},
+      __LINE__,
+      __FILE__);
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
Fixes #1305 
Patches duplicated outputs handling in segmenter.
Adding tests to verify proper behavior with aliasing handling for duplicated outputs.