### PR TITLE
Matmul scheduler - support for fusion with aux output tensors

### DIFF
--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -30,9 +30,9 @@ enum class MatmulDomain { M = 0, N, K };
 //! Named descriptors of TensorView roles in fusion
 //!  INPUT_A - a producer of MMA input A
 //!  INPUT_B - a producer of MMA input B
-//!  OUTPUT_D - the main consumer of MMA op results
 //!  INPUT_C - a producer of a tensor used in fusion epilogue,
 //!            for example tensor used in beta scaling fusion
+//!  OUTPUT_D - the main consumer of MMA op results
 //!
 //! Naming convention is based on the following formula:
 //!    D = alpha * A x B + beta * C

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -33,11 +33,13 @@ enum class MatmulDomain { M = 0, N, K };
 //!  INPUT_C - a producer of a tensor used in fusion epilogue,
 //!            for example tensor used in beta scaling fusion
 //!  OUTPUT_D - the main consumer of MMA op results
+//!  OUTPUT_AUX - fusion outputs that are consumers of OUTPUT_D
 //!
 //! Naming convention is based on the following formula:
 //!    D = alpha * A x B + beta * C
+//!    AUX = relu(D)
 //!  Note: bias vector tensors will be assigned to INPUT_C role.
-enum class MatmulRole { INPUT_A = 0, INPUT_B, OUTPUT_D, INPUT_C };
+enum class MatmulRole { INPUT_A = 0, INPUT_B, OUTPUT_D, INPUT_C, OUTPUT_AUX };
 
 //! The expected number of occurances of core TensorView roles in fusion
 static constexpr size_t MATMUL_CORE_ROLES_EXPECTED_COUNT = 1;

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -253,6 +253,12 @@ std::string isMatmulFusionDefinitionSupported(
       tvs_with_roles.insert(entry->second.begin(), entry->second.end());
     }
 
+    // Non-core output roles are optional, no requirements for definitions
+    entry = roles_map.find(MatmulRole::OUTPUT_AUX);
+    if (entry != roles_map.end()) {
+      tvs_with_roles.insert(entry->second.begin(), entry->second.end());
+    }
+
     const auto in_out_tvs_count =
         fusion_inputs_tvs.size() + fusion_outputs_tvs.size();
     if (in_out_tvs_count != tvs_with_roles.size()) {

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -182,7 +182,6 @@ std::string isMatmulFusionDefinitionSupported(
       ir_utils::filterByType<TensorView>(fusion_outputs).vector();
 
   constexpr size_t minimal_number_of_inputs = 2;
-  constexpr size_t expected_number_of_outputs = 1;
 
   // Quick checks - MmaOp
   {
@@ -206,11 +205,6 @@ std::string isMatmulFusionDefinitionSupported(
     // Fusion should contain at least two inputs (for now)
     if (minimal_number_of_inputs > fusion_inputs.size()) {
       return "Fusion inputs contain at least one non-TensorView object";
-    }
-
-    // Fusion has only TVs as outputs, and we expect only one object in the list
-    if ((expected_number_of_outputs != fusion_outputs_tvs.size())) {
-      return "Fusion has more than a single TensorView object in its outputs";
     }
   }
 
@@ -248,16 +242,12 @@ std::string isMatmulFusionDefinitionSupported(
 
     entry = roles_map.find(MatmulRole::OUTPUT_D);
     if (entry != roles_map.end()) {
-      if (MATMUL_CORE_ROLES_EXPECTED_COUNT == entry->second.size()) {
-        tvs_with_roles.insert(entry->second.begin(), entry->second.end());
-      } else {
-        return "There is more than a single fusion output that can be MMA output";
-      }
+      tvs_with_roles.insert(entry->second.begin(), entry->second.end());
     } else {
       return "No candidate in fusion outputs MMA output";
     }
 
-    // Non-core roles are optional, no requirements for their presence
+    // Non-core input roles are optional, no requirements for definitions
     entry = roles_map.find(MatmulRole::INPUT_C);
     if (entry != roles_map.end()) {
       tvs_with_roles.insert(entry->second.begin(), entry->second.end());

--- a/test/test_matmul_scheduler.cpp
+++ b/test/test_matmul_scheduler.cpp
@@ -369,7 +369,7 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasRelu) {
 //   D = A x B;
 //   Aux = relu(D)
 //  Target architectures: Turing, Ampere
-TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueReluAux) {
+TEST_P(PrecisionParametrizedTest, EpilogueReluAux) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const auto layout = MatmulLayout::TT;
 
@@ -377,7 +377,7 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueReluAux) {
       {HSS, std::make_pair(0.001, 0.001)},
       {HSH, std::make_pair(0.001, 0.001)},
       {TSS, std::make_pair(0.001, 0.001)},
-      {TST, std::make_pair(0.001, 0.001)},
+      {TST, std::make_pair(0.01, 0.001)},
   };
 
   NVF_CHECK(
@@ -465,7 +465,7 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueReluAux) {
 //   D = (A x B) + bias
 //   Aux = relu(D)
 //  Target architectures: Ampere
-TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueBiasReluAux) {
+TEST_P(PrecisionParametrizedTest, EpilogueBiasReluAux) {
   // NOTE: test skips Turing arch, the relative error was too big
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const auto layout = MatmulLayout::TT;
@@ -474,7 +474,7 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueBiasReluAux) {
       {HSS, std::make_pair(0.001, 0.001)},
       {HSH, std::make_pair(0.001, 0.001)},
       {TSS, std::make_pair(0.001, 0.001)},
-      {TST, std::make_pair(0.001, 0.001)},
+      {TST, std::make_pair(0.01, 0.001)},
   };
 
   NVF_CHECK(
@@ -502,7 +502,7 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueBiasReluAux) {
   // A - tv0, B - tv1, C - tv2
   auto tv0 = makeContigTensor(2, in_type);
   auto tv1 = makeContigTensor(2, in_type);
-  auto tv2 = makeContigTensor(1, in_type);
+  auto tv2 = makeContigTensor(1, out_type);
 
   // tv3 := A x B
   auto tv3 = matmul(tv0, tv1, layout, true);
@@ -670,7 +670,7 @@ TEST_P(PrecisionParametrizedTest, EpilogueGelu) {
 //   D = A x B
 //   Aux = gelu(D)
 //  Target architectures: Turing, Ampere
-TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueGeluAux) {
+TEST_P(PrecisionParametrizedTest, EpilogueGeluAux) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const auto layout = MatmulLayout::TT;
 
@@ -678,7 +678,7 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueGeluAux) {
       {HSS, std::make_pair(0.001, 0.001)},
       {HSH, std::make_pair(0.001, 0.001)},
       {TSS, std::make_pair(0.001, 0.001)},
-      {TST, std::make_pair(0.001, 0.001)},
+      {TST, std::make_pair(0.01, 0.001)},
   };
 
   NVF_CHECK(
@@ -873,7 +873,7 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasGelu) {
 //   D = (A x B) + bias
 //   Aux = gelu(D)
 //  Target architectures: Ampere
-TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueBiasGeluAux) {
+TEST_P(PrecisionParametrizedTest, EpilogueBiasGeluAux) {
   // NOTE: test skips Turing arch, the relative error was too big
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const auto layout = MatmulLayout::TT;
@@ -882,7 +882,7 @@ TEST_P(PrecisionParametrizedTest, DISABLED_EpilogueBiasGeluAux) {
       {HSS, std::make_pair(0.001, 0.001)},
       {HSH, std::make_pair(0.01, 0.001)},
       {TSS, std::make_pair(0.001, 0.001)},
-      {TST, std::make_pair(0.001, 0.001)},
+      {TST, std::make_pair(0.01, 0.001)},
   };
 
   NVF_CHECK(


### PR DESCRIPTION
Enable support for forward epilogue fusions with aux output tensor
for HSS/HSH/TSS/TST precisions:

- relu+aux,
- relu+aux+bias,
- gelu+aux,
- gelu+aux+bias,

Enable tests prepared in https://github.com/NVIDIA/Fuser/pull/1191

Verified on: a100, ad102, ad104, tu102, and tu104