### PR TITLE
s/PointerCast/PointerArithmetic.

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -945,14 +945,14 @@ at::Tensor allocateOutput(
 
     switch (alias_it->second.second.type) {
       case AliasType::InplaceUpdate:
-        // Unlike for `AliasType::PointerCast`, don't use
+        // Unlike for `AliasType::PointerArithmetic`, don't use
         // ExpressionEvaluator to compute the output tensor. This is because
         // the output tensor may hold different data from the input, e.g., an
         // updated running mean.  `ExpressionEvaluator::evaluate(out_tv)`
         // would trigger non-trivial host computation.
         return in_tensor;
 
-      case AliasType::PointerCast:
+      case AliasType::PointerArithmetic:
         auto* in_tv = kernel->inputs()[aliased_in_index]->as<TensorView>();
         ee.bind(in_tv, in_tensor);
         at::Tensor out_tensor = ee.evaluate(out_tv).as<at::Tensor>();

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -334,14 +334,14 @@ std::vector<Expr*> Fusion::exprs() {
 
 namespace {
 
-bool allOutputsArePointerCasts(Fusion* fusion) {
+bool allOutputsArePointerArithmetics(Fusion* fusion) {
   for (Val* out : fusion->outputs()) {
     const auto& [in, info] = fusion->getOutputAlias(out);
     if (in == nullptr) {
       return false;
     }
     NVF_ERROR(info != nullptr);
-    if (info->type != AliasType::PointerCast) {
+    if (info->type != AliasType::PointerArithmetic) {
       return false;
     }
   }
@@ -355,7 +355,7 @@ bool Fusion::isNoOp() {
     return true;
   }
 
-  if (allOutputsArePointerCasts(this)) {
+  if (allOutputsArePointerArithmetics(this)) {
     return true;
   }
 

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -90,10 +90,10 @@ enum class AliasType : int {
   // For example, the tensor storing BatchNorm's running mean. The output EMA is
   // updated in place.
   InplaceUpdate,
-  // For example, the output of a ViewOp is merely a pointer cast of the input.
-  // In this case, we use `ExpressionEvaluator` (instead of a kernel) to compute
-  // the output tensor.
-  PointerCast,
+  // For example, the output of a ViewOp is merely a pointer arithmetic of the
+  // input.  In this case, we use `ExpressionEvaluator` (instead of a kernel) to
+  // cheaply compute the output tensor.
+  PointerArithmetic,
 };
 
 struct AliasInfo {

--- a/csrc/optimization/mark_alias.cpp
+++ b/csrc/optimization/mark_alias.cpp
@@ -29,7 +29,7 @@ void MarkAliasPass::runPass(Fusion* fusion) {
           out,
           // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
           const_cast<Val*>(in),
-          AliasType::PointerCast);
+          AliasType::PointerArithmetic);
       if (isDebugDumpEnabled(DebugDumpOption::PreSegmenterLogging)) {
         debug() << "MarkAliasPass marked " << out->toString()
                 << " as an alias of " << in->toString() << std::endl;


### PR DESCRIPTION
With slices, the pointer address might not be the same. PointerArithmetic is more accurate.