### PR TITLE
Revert "Clean unit tests"

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -400,9 +400,6 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
     case UnaryOpType::Exp:
       return {at::exp(in.as<at::Tensor>())};
       break;
-    case UnaryOpType::Sin:
-      return {in.as<at::Tensor>().sin()};
-      break;
     default:
       NVF_CHECK(
           false,

--- a/test/test_no_op.cpp
+++ b/test/test_no_op.cpp
@@ -44,7 +44,8 @@ TEST_F(NoOpTest, FusionNullScheduler) {
   std::cerr << cg_outputs[0].sizes() << std::endl;
   std::cerr << t1.sizes() << std::endl;
 
-  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
+  testValidate(
+      executor_cache.fusion(), cg_outputs, {t0}, {t1}, __LINE__, __FILE__);
 
   auto groups =
       executor_cache.getMostRecentKernelRuntime()->fusionSegments()->groups();
@@ -75,7 +76,10 @@ TEST_F(NoOpTest, FusionNullScheduler2) {
   FusionExecutorCache executor_cache(std::move(fusion));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
-  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
+  auto t1 = t0.sum({1, 2});
+
+  testValidate(
+      executor_cache.fusion(), cg_outputs, {t0}, {t1}, __LINE__, __FILE__);
 
   auto groups =
       executor_cache.getMostRecentKernelRuntime()->fusionSegments()->groups();
@@ -108,7 +112,12 @@ TEST_F(NoOpTest, FusionNullScheduler3) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
+      executor_cache.fusion(),
+      cg_outputs,
+      {t0, t1},
+      {t0 + t1},
+      __LINE__,
+      __FILE__);
 
   auto groups =
       executor_cache.getMostRecentKernelRuntime()->fusionSegments()->groups();
@@ -138,7 +147,10 @@ TEST_F(NoOpTest, FusionReducingZeroElements) {
   FusionExecutorCache executor_cache(std::move(fusion));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
-  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
+  auto t1 = t0.sum({0, 1, 2});
+
+  testValidate(
+      executor_cache.fusion(), cg_outputs, {t0}, {t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NoOpTest, FusionEmpty) {
@@ -162,7 +174,12 @@ TEST_F(NoOpTest, FusionEmpty) {
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
+      executor_cache.fusion(),
+      cg_outputs,
+      {t0, t1},
+      {t0, t1},
+      __LINE__,
+      __FILE__);
 
   auto groups =
       executor_cache.getMostRecentKernelRuntime()->fusionSegments()->groups();

--- a/test/test_swizzle.cpp
+++ b/test/test_swizzle.cpp
@@ -54,9 +54,10 @@ TEST_F(SwizzleTest, SimpleSwizzle0) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 32}, options);
+  auto t2 = t0 + 2.0;
   auto cg_outputs = fe.runFusion({t0});
 
-  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, {t2}, __LINE__, __FILE__);
 }
 
 // Test swizzle inlining
@@ -93,9 +94,10 @@ TEST_F(SwizzleTest, SimpleSwizzle1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 32}, options);
+  auto t3 = t0 + 3.0;
   auto cg_outputs = fe.runFusion({t0});
 
-  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, {t3}, __LINE__, __FILE__);
 }
 
 // Test sync insertion and memory check in parallelized swizzles.
@@ -150,9 +152,10 @@ TEST_F(SwizzleTest, SimpleSwizzle2) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({32, 32}, options);
+  auto t2 = t0 + 2.0;
   auto cg_outputs = fe.runFusion({t0});
 
-  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, {t2}, __LINE__, __FILE__);
 }
 
 // Test BestEffortReplay behavior with swizzle op
@@ -279,9 +282,10 @@ TEST_F(SwizzleTest, LoopSwizzle0) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 32}, options);
+  auto t2 = t0 + 2.0;
   auto cg_outputs = fe.runFusion({t0});
 
-  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, {t2}, __LINE__, __FILE__);
 }
 
 // Outer block zshape pattern
@@ -314,9 +318,10 @@ TEST_F(SwizzleTest, LoopSwizzle1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({45, 77}, options);
+  auto t2 = t0 + 2.0;
   auto cg_outputs = fe.runFusion({t0});
 
-  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, {t2}, __LINE__, __FILE__);
 }
 
 // Test assertion in unsupported pattern: non-leaf loop swizzle.
@@ -614,7 +619,7 @@ TEST_F(SwizzleTest, SwizzleIndexing170) {
   fe.compileFusion(&fusion);
   auto outputs = fe.runFusion({t});
 
-  testValidate(&fusion, outputs, {t}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t}, {t}, __LINE__, __FILE__);
 }
 
 TEST_F(SwizzleTest, TransformPropagatorSkipSwizzleOnTarget) {


### PR DESCRIPTION
Reverts NVIDIA/Fuser#1315. Some tests require `FullOp` and `IotaOp` implemented in #1299. 