### PR TITLE
Unify `IterDomain::split` with `SplitTransform` and similar for merge

### DIFF
--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -120,8 +120,8 @@ class IterDomain : public Val {
   static std::vector<IterDomain*> clone(
       const std::vector<IterDomain*>& domains);
 
-  // When `rfactor_domain` is true, also set the `is_rfactor_domain_` flag of
-  // the result IterDomain.
+  //! When `rfactor_domain` is true, also set the `is_rfactor_domain_` flag of
+  //! the result IterDomain.
   static IterDomain* merge(
       IterDomain* outer,
       IterDomain* inner,
@@ -129,6 +129,8 @@ class IterDomain : public Val {
 
   //! start_offset and stop_offset defines partial split. Only root
   //! domains are allowed to have non-zero start and stop offsets.
+  //! When `rfactor_domain` is true, also set the `is_rfactor_domain_` flag of
+  //! both result IterDomains.
   static std::pair<IterDomain*, IterDomain*> split(
       IterDomain* in,
       Val* factor,

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -123,7 +123,7 @@ class IterDomain : public Val {
   static IterDomain* merge(
       IterDomain* outer,
       IterDomain* inner,
-      bool rfactor_domain);
+      bool rfactor_domain = false);
 
   //! start_offset and stop_offset defines partial split. Only root
   //! domains are allowed to have non-zero start and stop offsets.
@@ -132,7 +132,8 @@ class IterDomain : public Val {
       Val* factor,
       bool inner_split,
       Val* start_offset = nullptr,
-      Val* stop_offset = nullptr);
+      Val* stop_offset = nullptr,
+      bool rfactor_domain = false);
 
   //! trim_out_of_bounds controls how the values outside start and stop
   //! positions are treated. The option is only valid with root
@@ -144,7 +145,8 @@ class IterDomain : public Val {
       IterDomain* in,
       Val* factor,
       bool inner_split,
-      bool trim_out_of_bounds);
+      bool trim_out_of_bounds,
+      bool rfactor_domain = false);
 
   //! Resize an IterDomain by expanding both the left and right sides
   //! by given widths. The resulting IterDomain has an extent of

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -120,7 +120,8 @@ class IterDomain : public Val {
   static std::vector<IterDomain*> clone(
       const std::vector<IterDomain*>& domains);
 
-  // When `rfactor_domain` is true, also set the `is_rfactor_domain_` flag of the result IterDomain. 
+  // When `rfactor_domain` is true, also set the `is_rfactor_domain_` flag of
+  // the result IterDomain.
   static IterDomain* merge(
       IterDomain* outer,
       IterDomain* inner,

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -120,7 +120,10 @@ class IterDomain : public Val {
   static std::vector<IterDomain*> clone(
       const std::vector<IterDomain*>& domains);
 
-  static IterDomain* merge(IterDomain* outer, IterDomain* inner);
+  static IterDomain* merge(
+      IterDomain* outer,
+      IterDomain* inner,
+      bool rfactor_domain);
 
   //! start_offset and stop_offset defines partial split. Only root
   //! domains are allowed to have non-zero start and stop offsets.

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -120,6 +120,7 @@ class IterDomain : public Val {
   static std::vector<IterDomain*> clone(
       const std::vector<IterDomain*>& domains);
 
+  // When `rfactor_domain` is true, also set the `is_rfactor_domain_` flag of the result IterDomain. 
   static IterDomain* merge(
       IterDomain* outer,
       IterDomain* inner,

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2891,7 +2891,8 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
     Val* factor,
     bool inner_split,
     Val* start_offset,
-    Val* stop_offset) {
+    Val* stop_offset,
+    bool rfactor_domain) {
   NVF_CHECK(
       factor->isIntegralScalar(), "Cannot split by non-integer value ", factor);
 
@@ -2930,6 +2931,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
                                                       : nullptr)
           .parallel_type(in->getParallelType())
           .iter_type(in->getIterType())
+          .is_rfactor_domain(rfactor_domain)
           .build();
 
   IrBuilder::create<Split>(

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2811,7 +2811,15 @@ std::vector<IterDomain*> IterDomain::clone(
 // domains is enforced by predicates. Note that since only root
 // domains have valid start and stop, it's not possible to contiguous
 // predication.
-IterDomain* IterDomain::merge(IterDomain* outer, IterDomain* inner) {
+IterDomain* IterDomain::merge(
+    IterDomain* outer,
+    IterDomain* inner,
+    bool rfactor_domain) {
+  NVF_ERROR(
+      outer->start()->isZeroInt() && inner->start()->isZeroInt(),
+      "Didn't expect to apply view transformations on an iter domain",
+      " starting at a non-zero position.");
+
   NVF_CHECK(
       outer->isReduction() == inner->isReduction(),
       "Merging IterDomains requires that their iteration types match. ",
@@ -2872,6 +2880,7 @@ IterDomain* IterDomain::merge(IterDomain* outer, IterDomain* inner) {
           .parallel_type(outer->getParallelType())
           .expanded_extent(expanded_extent)
           .iter_type(itype)
+          .is_rfactor_domain(rfactor_domain)
           .build();
 
   IrBuilder::create<Merge>(outer->container(), merged_id, outer, inner);

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2815,11 +2815,6 @@ IterDomain* IterDomain::merge(
     IterDomain* outer,
     IterDomain* inner,
     bool rfactor_domain) {
-  NVF_ERROR(
-      outer->start()->isZeroInt() && inner->start()->isZeroInt(),
-      "Didn't expect to apply view transformations on an iter domain",
-      " starting at a non-zero position.");
-
   NVF_CHECK(
       outer->isReduction() == inner->isReduction(),
       "Merging IterDomains requires that their iteration types match. ",

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2920,6 +2920,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
                                                      : nullptr)
           .parallel_type(in->getParallelType())
           .iter_type(in->getIterType())
+          .is_rfactor_domain(rfactor_domain)
           .build();
 
   // inner loop IterDomain
@@ -2950,10 +2951,12 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
     IterDomain* in,
     Val* factor,
     bool inner_split,
-    bool trim_out_of_bounds) {
+    bool trim_out_of_bounds,
+    bool rfactor_domain) {
   auto start_offset = trim_out_of_bounds ? in->start() : nullptr;
   auto stop_offset = trim_out_of_bounds ? in->stopOffset() : nullptr;
-  return IterDomain::split(in, factor, inner_split, start_offset, stop_offset);
+  return IterDomain::split(
+      in, factor, inner_split, start_offset, stop_offset, rfactor_domain);
 }
 
 std::pair<IterDomain*, IterDomain*> IterDomain::stridedSplit(int64_t factor) {

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -206,19 +206,8 @@ class MergeTransform final : public ViewTransform {
       inner_id = replaceRootIdWithRFactor(root_domain, inner_id);
     }
 
-    NVF_ERROR(
-        outer_id->start()->isZeroInt() && inner_id->start()->isZeroInt(),
-        "Didn't expect to apply view transformations on an iter domain",
-        " starting at a non-zero position.");
-
-    auto merged_extent = mul(outer_id->extent(), inner_id->extent());
-
     auto new_merged_id =
-        IterDomainBuilder(FusionGuard::getCurFusion()->zeroVal(), merged_extent)
-            .is_rfactor_domain(true)
-            .build();
-
-    IrBuilder::create<Merge>(new_merged_id, outer_id, inner_id);
+        IterDomain::merge(outer_id, inner_id, /*rfactor_domain*/ true);
 
     current_transformed_domain.erase(
         current_transformed_domain.begin() + index_);

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -271,7 +271,7 @@ class SplitTransform final : public ViewTransform {
         "Didn't expect to apply view transformations on an iter domain",
         " starting at a non-zero position.");
 
-    auto& [factor_id, remainder_id] = IterDomain::split(
+    auto [factor_id, remainder_id] = IterDomain::split(
         id,
         factor,
         /*inner_split*/ false,

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -274,10 +274,10 @@ class SplitTransform final : public ViewTransform {
     auto [factor_id, remainder_id] = IterDomain::split(
         id,
         factor,
-        /*inner_split*/ false,
-        /*start_offset*/ nullptr,
-        /*stop_offset*/ nullptr,
-        /*rfactor_domain*/ true);
+        /*inner_split=*/false,
+        /*start_offset=*/nullptr,
+        /*stop_offset=*/nullptr,
+        /*rfactor_domain=*/true);
 
     current_transformed_domain.erase(
         current_transformed_domain.begin() + index_);


### PR DESCRIPTION
Currently, `MergeTransform` and `SplitTransform`, which are the classes used to perform reshape operations, do not re-use the splitting and merging operations used in scheduling, namely the static methods `IterDomain::{split,merge}`. This leads to needing to maintain changes in both as I recently found out when debugging #1174. We can actually already notice they have diverged with respect to `IndexType::GatherScatter` handling.

This PR simply calls the static `IterDomain` method from each of the reshape `*Transform` classes. Since those classes also need to set the rfactor-product flag on the produced `IterDomain`s, I added a flag to the static methods that is only used during reshape.