### PR TITLE
Fix codediff ptx

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -171,7 +171,7 @@ std::string FusionExecutor::getStructuredCode(
   if (isDebugDumpEnabled(DebugDumpOption::CudaToFile) ||
       isDebugDumpEnabled(DebugDumpOption::DebugInfo)) {
     std::stringstream file_name;
-    file_name << "__tmp_kernel" << getGlobalFusionCount() << ".cu";
+    file_name << "__tmp_kernel_" << kernel_id_ << ".cu";
     debug() << "PRINTING: " << file_name.str() << std::endl;
     std::ofstream out(file_name.str());
     out << code << std::endl;

--- a/tools/codediff/diff_report.py
+++ b/tools/codediff/diff_report.py
@@ -579,7 +579,8 @@ class TestRun:
                         kern.index_type = m.groups()[0]
                 if not strip_preamble or i >= self.preamble_size_lines:
                     # replace kernel934 with kernel1 to facilitate diffing
-                    kern.code += re.sub(r"\bkernel\d+\b", "kernelN", line)
+                    # also match kernel_43 to handle new-style naming with static fusion count
+                    kern.code += re.sub(r"\bkernel_?\d+\b", "kernelN", line)
         kern.code = kern.code.rstrip()
         if strip_preamble and kern.code[-1] == "}":
             # trailing curly brace is close of namespace. This will clean it up so that we have just the kernel

--- a/tools/codediff/run_command.sh
+++ b/tools/codediff/run_command.sh
@@ -165,6 +165,8 @@ ensure_in_list() {
 # ensure some NVFUSER_DUMP options are enabled
 appended_dump=$(ensure_in_list "$NVFUSER_DUMP" cuda_to_file ptxas_verbose ptx)
 export NVFUSER_DUMP=$appended_dump
+appended_enable=$(ensure_in_list "$NVFUSER_ENABLE" static_fusion_count)
+export NVFUSER_ENABLE=$appended_enable
 
 # Allow command to fail, but record exit code
 set +e


### PR DESCRIPTION
The change of default kernel IDs broke the link between PTX and CUDA dumped filenames, e.g. for a given kernel we might have `__tmp_kernel5.cu` and `__tmp_kernel_pointwise_f0_c1_r0_g0.ptx`. Also this re-uses kernel names so we wound up with far fewer PTX files than .cu files when running code diffs. This can be avoided by setting `NVFUSER_ENABLE=static_fusion_count` which will revert to name very similar to the old behavior. This PR sets that in `run_command.sh` in order to fix the code diff script, and ensures the filenames match, i.e. `__tmp_kernel5.cu` is now `__tmp_kernel_5.cu`.