### PR TITLE
Guard MarkAliasPass debug output

### DIFF
--- a/csrc/optimization/mark_alias.cpp
+++ b/csrc/optimization/mark_alias.cpp
@@ -20,7 +20,8 @@ void MarkAliasPass::runPass(Fusion* fusion) {
     // Lazy move: we could check compatibility and only give up when
     // the allocation domain is incompatible with what we prefer for
     // aliasing.
-    if (out->hasAllocation()) {
+    if (isDebugDumpEnabled(DebugDumpOption::PreSegmenterLogging) &&
+        out->hasAllocation()) {
       debug() << "MarkAliasPass skipped " << out->toString()
               << " because it already has an allocation domain:" << std::endl
               << out->domain()->toString(1, /*leaf_only=*/false) << std::endl;


### PR DESCRIPTION
This will hide `MarkAliasPass skipped ...` messages unless `NVFUSER_DUMP=pre_segmenter_logging` is enabled.