### PR TITLE
Only forward inputs whose single use is UnaryOp (segmentation)

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -883,7 +883,7 @@ std::vector<SegmentedEdge*> SegmentedFusion::castInputOutputToLowerPrecision(
   //
   // To avoid this discrepancy, when this is done with virtual merged
   // groups, bundle all edges to the merged groups and process them
-  // together. This way, only one instane of the cast-back expr should
+  // together. This way, only one instance of the cast-back expr should
   // be inserted.
   //
   // Note that this analysis and replacement would be much simpler if we
@@ -3502,7 +3502,7 @@ void SegmentCandidateFinder::forwardInputs() {
       // output's further uses
       const auto& output_uses = expr->output(0)->uses();
 
-      if (output_uses.size() == 1) {
+      if (output_uses.size() == 1 && output_uses[0]->isA<UnaryOp>()) {
         // If there is a single use, visit it to try and extend the chain of
         // unaryOps
         to_visit.emplace_back(output_uses.at(0));


### PR DESCRIPTION
Fixes #1301 

That issue demonstrated a case where `forwardInputs` could skip an expression, then also fail to add its outputs as a new input; the result is a segment without any input including the original unforwarded one. This change follows `UnaryOp` output uses only if those uses are themselves `UnaryOps`; otherwise we terminate and add that output as a new forwarded input.