### PR TITLE
Encode mma macro enum as `uint64_t` and define hopper macros

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1071,7 +1071,23 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     std::stringstream ss;
     auto macro = mma->macro();
     ss << genArchString(macro) << "::";
-    ss << toString(macro);
+
+    switch (macro) {
+      case MmaOptions::MacroType::NoMMA:
+        ss << "NoOp";
+        break;
+      case MmaOptions::MacroType::Turing_16_8_16:
+      case MmaOptions::MacroType::Ampere_16_8_16:
+        ss << "M16N8K16";
+        break;
+      case MmaOptions::MacroType::Turing_16_16_16:
+      case MmaOptions::MacroType::Ampere_16_16_16:
+        ss << "M16N16K16";
+        break;
+      default:
+        NVF_ERROR(false, "undefined mma type");
+        break;
+    }
 
     // clang-tidy: bugprone-unchecked-optional-access
     // clang-tidy assumes that function result is unstable, so we need a copy.

--- a/csrc/macros.h
+++ b/csrc/macros.h
@@ -15,3 +15,9 @@
 #if defined(__GLIBCXX__) && __GLIBCXX__ >= 20230714
 #define STD_UNORDERED_SET_SUPPORTS_INCOMPLETE_TYPE 1
 #endif
+
+#if __cplusplus < 202002L
+#define IS_CPP20 0
+#else
+#define IS_CPP20 1
+#endif

--- a/csrc/mma_type.cpp
+++ b/csrc/mma_type.cpp
@@ -142,20 +142,20 @@ std::string toString(const MatMulTileOptions& opts) {
 
 std::string toString(MmaOptions::MacroType macro) {
   std::stringstream ss;
-  auto underlying = static_cast<MmaMacroUnderlying>(macro);
+  auto underlying = static_cast<MmaMacroEncode>(macro);
   switch (underlying.arch) {
-    case MmaMacroUnderlying::Arch::NoMma:
+    case MmaMacroEncode::Arch::NoMma:
       return "NoOp";
-    case MmaMacroUnderlying::Arch::Volta:
+    case MmaMacroEncode::Arch::Volta:
       ss << "Volta";
       break;
-    case MmaMacroUnderlying::Arch::Turing:
+    case MmaMacroEncode::Arch::Turing:
       ss << "Turing";
       break;
-    case MmaMacroUnderlying::Arch::Ampere:
+    case MmaMacroEncode::Arch::Ampere:
       ss << "Ampere";
       break;
-    case MmaMacroUnderlying::Arch::Hopper:
+    case MmaMacroEncode::Arch::Hopper:
       ss << "Hopper";
       break;
   }

--- a/csrc/mma_type.cpp
+++ b/csrc/mma_type.cpp
@@ -104,6 +104,10 @@ bool isOperandTransposed(MmaOptions options) {
   return false;
 }
 
+GemmTile getMmaOpShape(MmaOptions::MacroType macro) {
+  return {getM(macro), getN(macro), getK(macro)};
+}
+
 std::string toString(MmaOptions::MmaLayout input_layout) {
   std::stringstream ss;
   switch (input_layout) {

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -183,10 +183,10 @@ constexpr MmaMacroEncode::MmaMacroEncode(MmaMacro macro) {
   // std::bit_cast for bit field is not supported by clang yet
   *this = std::bit_cast<MmaMacroEncode>(macro);
 #else
-  k = toUnderlying(macro) & 0xFFFF; // NOLINT(*-member-init)
-  n = (toUnderlying(macro) >> 16) & 0xFFFF; // NOLINT(*-member-init)
-  m = (toUnderlying(macro) >> 32) & 0xFFFF; // NOLINT(*-member-init)
-  arch = (Arch)(toUnderlying(macro) >> 48); // NOLINT(*-member-init)
+  k = toUnderlying(macro) & 0xFFFF; // NOLINT(*-member-init*)
+  n = (toUnderlying(macro) >> 16) & 0xFFFF; // NOLINT(*-member-init*)
+  m = (toUnderlying(macro) >> 32) & 0xFFFF; // NOLINT(*-member-init*)
+  arch = (Arch)(toUnderlying(macro) >> 48); // NOLINT(*-member-init*)
 #endif
 }
 

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -6,9 +6,19 @@
  */
 // clang-format on
 #pragma once
+
+#include <macros.h>
+
 #include <c10/macros/Export.h>
 #include <exceptions.h>
 #include <fusion.h>
+
+#include <cstring>
+
+#if IS_CPP20
+#include <bit>
+#endif
+#include <cstdint>
 
 namespace nvfuser {
 
@@ -71,26 +81,121 @@ struct MatMulTileOptions {
   }
 };
 
+enum class MmaMacro : uint64_t;
+
+struct MmaMacroUnderlying {
+  enum class Arch { NoMma, Volta, Turing, Ampere, Hopper } arch : 16;
+  unsigned m : 16;
+  unsigned n : 16;
+  unsigned k : 16;
+
+  constexpr operator uint64_t() {
+#if IS_CPP20 && !defined(__clang__)
+    // std::bit_cast for bit field is not supported by clang yet
+    return std::bit_cast<uint64_t>(*this);
+#else
+    return (uint64_t)arch << 48 | (uint64_t)m << 32 | (uint64_t)n << 16 |
+        (uint64_t)k;
+#endif
+  }
+
+  constexpr operator MmaMacro();
+
+  constexpr MmaMacroUnderlying(MmaMacro macro);
+
+  constexpr MmaMacroUnderlying(Arch arch, unsigned m, unsigned n, unsigned k)
+      : arch(arch), m(m), n(n), k(k) {}
+};
+
+static_assert(sizeof(MmaMacroUnderlying) == sizeof(uint64_t));
+
+//! Type of mma instrinsic macro to use
+//!  This will translate to which mma intrinsic from runtime string
+//!    to be generated to implement the mma op. The current plan
+//!    is to have exactly one macro for each
+//!  (arch, datatype, operand layout) triple, though there
+//!  exists multiple possibilities for some cases, e.g. for Turing and fp16
+//!  one can use 16_8_8 or 16_8_16.
+//! Will consider adding more choices that the scheduler can pick from
+//!  when our perf target becomes more fine grained, which is more likely in
+//!  latency bound kernels.
+
+#define MACRO(arch, m, n, k) \
+  arch##_##m##_##n##_##k =   \
+      MmaMacroUnderlying(MmaMacroUnderlying::Arch::arch, m, n, k)
+
+enum class MmaMacro : uint64_t {
+  NoMMA = 0,
+
+  MACRO(Turing, 16, 8, 16),
+  MACRO(Turing, 16, 16, 16),
+
+  MACRO(Ampere, 16, 8, 16),
+  MACRO(Ampere, 16, 16, 16),
+  MACRO(Ampere, 16, 8, 8),
+
+  MACRO(Hopper, 64, 8, 16),
+  MACRO(Hopper, 64, 16, 16),
+  MACRO(Hopper, 64, 24, 16),
+  MACRO(Hopper, 64, 32, 16),
+  MACRO(Hopper, 64, 40, 16),
+  MACRO(Hopper, 64, 48, 16),
+  MACRO(Hopper, 64, 56, 16),
+  MACRO(Hopper, 64, 64, 16),
+  MACRO(Hopper, 64, 72, 16),
+  MACRO(Hopper, 64, 80, 16),
+  MACRO(Hopper, 64, 88, 16),
+  MACRO(Hopper, 64, 96, 16),
+  MACRO(Hopper, 64, 104, 16),
+  MACRO(Hopper, 64, 112, 16),
+  MACRO(Hopper, 64, 120, 16),
+  MACRO(Hopper, 64, 128, 16),
+  MACRO(Hopper, 64, 136, 16),
+  MACRO(Hopper, 64, 144, 16),
+  MACRO(Hopper, 64, 152, 16),
+  MACRO(Hopper, 64, 160, 16),
+  MACRO(Hopper, 64, 168, 16),
+  MACRO(Hopper, 64, 176, 16),
+  MACRO(Hopper, 64, 184, 16),
+  MACRO(Hopper, 64, 192, 16),
+  MACRO(Hopper, 64, 200, 16),
+  MACRO(Hopper, 64, 208, 16),
+  MACRO(Hopper, 64, 216, 16),
+  MACRO(Hopper, 64, 224, 16),
+  MACRO(Hopper, 64, 232, 16),
+  MACRO(Hopper, 64, 240, 16),
+  MACRO(Hopper, 64, 248, 16),
+  MACRO(Hopper, 64, 256, 16),
+};
+
+#undef MACRO
+
+constexpr MmaMacroUnderlying::operator MmaMacro() {
+#if IS_CPP20 && !defined(__clang__)
+  // std::bit_cast for bit field is not supported by clang yet
+  return std::bit_cast<MacroType>(*this);
+#else
+  // clang-format off
+  return (MmaMacro)(uint64_t)*this;
+  // clang-format on
+#endif
+}
+
+constexpr MmaMacroUnderlying::MmaMacroUnderlying(MmaMacro macro) {
+#if IS_CPP20 && !defined(__clang__)
+  // std::bit_cast for bit field is not supported by clang yet
+  *this = std::bit_cast<MmaMacroUnderlying>(macro);
+#else
+  k = (uint64_t)macro & 0xFFFF;
+  n = ((uint64_t)macro >> 16) & 0xFFFF;
+  m = ((uint64_t)macro >> 32) & 0xFFFF;
+  arch = (Arch)((uint64_t)macro >> 48);
+#endif
+}
+
 //! Information for configuring and lowering mma ops
 struct MmaOptions {
-  //! Type of mma instrinsic macro to use
-  //!  This will translate to which mma intrinsic from runtime string
-  //!    to be generated to implement the mma op. The current plan
-  //!    is to have exactly one macro for each
-  //!  (arch, datatype, operand layout) triple, though there
-  //!  exists multiple possibilities for some cases, e.g. for Turing and fp16
-  //!  one can use 16_8_8 or 16_8_16.
-  //! Will consider adding more choices that the scheduler can pick from
-  //!  when our perf target becomes more fine grained, which is more likely in
-  //!  latency bound kernels.
-  enum class MacroType {
-    NoMMA = 0,
-    Ampere_16_8_16,
-    Ampere_16_16_16,
-    Turing_16_8_16,
-    Turing_16_16_16,
-    Ampere_16_8_8 // place holder for tf32
-  };
+  using MacroType = MmaMacro;
 
   //! [Operand Layout Convention]
   //! Operand layout, T=transposed/row_major, N=normal/col_major
@@ -187,8 +292,32 @@ class MmaBuilder {
 };
 
 //! GPU arch check for macro type
-bool isTuring(MmaOptions::MacroType macro);
-bool isAmpere(MmaOptions::MacroType macro);
+inline bool isTuring(MmaOptions::MacroType macro) {
+  return MmaMacroUnderlying(macro).arch == MmaMacroUnderlying::Arch::Turing;
+}
+
+inline bool isAmpere(MmaOptions::MacroType macro) {
+  return MmaMacroUnderlying(macro).arch == MmaMacroUnderlying::Arch::Ampere;
+}
+
+inline bool isHopper(MmaOptions::MacroType macro) {
+  return MmaMacroUnderlying(macro).arch == MmaMacroUnderlying::Arch::Hopper;
+}
+
+//! Get the m size from macro type
+inline int getM(MmaOptions::MacroType macro) {
+  return MmaMacroUnderlying(macro).m;
+}
+
+//! Get the n size from macro type
+inline int getN(MmaOptions::MacroType macro) {
+  return MmaMacroUnderlying(macro).n;
+}
+
+//! Get the k size from macro type
+inline int getK(MmaOptions::MacroType macro) {
+  return MmaMacroUnderlying(macro).k;
+}
 
 //! Returns true if the given option describes a transposed operand
 bool isOperandTransposed(MmaOptions options);
@@ -203,11 +332,10 @@ int getInputBRegisterSize(MmaOptions::MacroType macro);
 GemmTile getMmaOpShape(MmaOptions::MacroType macro);
 
 // MMA stringify utils
-std::string toString(MmaOptions::MacroType macro);
 std::string toString(MmaOptions::MmaLayout input_layout);
 std::string toString(const GemmTile& tile);
 std::string toString(const MatMulTileOptions& opts);
-std::string toString(MmaOptions::MacroType macro, bool);
+std::string toString(MmaOptions::MacroType macro);
 
 // MMA hash utils
 size_t hash(MmaOptions::MacroType macro);

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -173,11 +173,9 @@ enum class MmaMacro : uint64_t {
 constexpr MmaMacroUnderlying::operator MmaMacro() {
 #if IS_CPP20 && !defined(__clang__)
   // std::bit_cast for bit field is not supported by clang yet
-  return std::bit_cast<MacroType>(*this);
+  return std::bit_cast<MmaMacro>(*this);
 #else
-  // clang-format off
-  return (MmaMacro)(uint64_t)*this;
-  // clang-format on
+  return static_cast<MmaMacro>(static_cast<uint64_t>(*this));
 #endif
 }
 
@@ -186,10 +184,12 @@ constexpr MmaMacroUnderlying::MmaMacroUnderlying(MmaMacro macro) {
   // std::bit_cast for bit field is not supported by clang yet
   *this = std::bit_cast<MmaMacroUnderlying>(macro);
 #else
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
   k = (uint64_t)macro & 0xFFFF;
   n = ((uint64_t)macro >> 16) & 0xFFFF;
   m = ((uint64_t)macro >> 32) & 0xFFFF;
   arch = (Arch)((uint64_t)macro >> 48);
+  // NOLINTEND(cppcoreguidelines-pro-type-member-init)
 #endif
 }
 

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -184,12 +184,10 @@ constexpr MmaMacroUnderlying::MmaMacroUnderlying(MmaMacro macro) {
   // std::bit_cast for bit field is not supported by clang yet
   *this = std::bit_cast<MmaMacroUnderlying>(macro);
 #else
-  // NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
-  k = (uint64_t)macro & 0xFFFF;
-  n = ((uint64_t)macro >> 16) & 0xFFFF;
-  m = ((uint64_t)macro >> 32) & 0xFFFF;
-  arch = (Arch)((uint64_t)macro >> 48);
-  // NOLINTEND(cppcoreguidelines-pro-type-member-init)
+  k = (uint64_t)macro & 0xFFFF; // NOLINT
+  n = ((uint64_t)macro >> 16) & 0xFFFF; // NOLINT
+  m = ((uint64_t)macro >> 32) & 0xFFFF; // NOLINT
+  arch = (Arch)((uint64_t)macro >> 48); // NOLINT
 #endif
 }
 

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -184,10 +184,10 @@ constexpr MmaMacroUnderlying::MmaMacroUnderlying(MmaMacro macro) {
   // std::bit_cast for bit field is not supported by clang yet
   *this = std::bit_cast<MmaMacroUnderlying>(macro);
 #else
-  k = (uint64_t)macro & 0xFFFF; // NOLINT
-  n = ((uint64_t)macro >> 16) & 0xFFFF; // NOLINT
-  m = ((uint64_t)macro >> 32) & 0xFFFF; // NOLINT
-  arch = (Arch)((uint64_t)macro >> 48); // NOLINT
+  k = toUnderlying(macro) & 0xFFFF; // NOLINT(*-member-init)
+  n = (toUnderlying(macro) >> 16) & 0xFFFF; // NOLINT(*-member-init)
+  m = (toUnderlying(macro) >> 32) & 0xFFFF; // NOLINT(*-member-init)
+  arch = (Arch)(toUnderlying(macro) >> 48); // NOLINT(*-member-init)
 #endif
 }
 

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -178,17 +178,19 @@ constexpr MmaMacroEncode::operator MmaMacro() {
 #endif
 }
 
-constexpr MmaMacroEncode::MmaMacroEncode(MmaMacro macro) {
+constexpr MmaMacroEncode::MmaMacroEncode(MmaMacro macro)
 #if IS_CPP20 && !defined(__clang__)
+{
   // std::bit_cast for bit field is not supported by clang yet
   *this = std::bit_cast<MmaMacroEncode>(macro);
-#else
-  k = toUnderlying(macro) & 0xFFFF; // NOLINT(*-member-init*)
-  n = (toUnderlying(macro) >> 16) & 0xFFFF; // NOLINT(*-member-init*)
-  m = (toUnderlying(macro) >> 32) & 0xFFFF; // NOLINT(*-member-init*)
-  arch = (Arch)(toUnderlying(macro) >> 48); // NOLINT(*-member-init*)
-#endif
 }
+#else
+    : arch((Arch)(toUnderlying(macro) >> 48)),
+      m((toUnderlying(macro) >> 32) & 0xFFFF),
+      n((toUnderlying(macro) >> 16) & 0xFFFF),
+      k(toUnderlying(macro) & 0xFFFF) {
+}
+#endif
 
 //! Information for configuring and lowering mma ops
 struct MmaOptions {

--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -105,7 +105,7 @@ class MatmulParams : public HeuristicParams {
     std::stringstream ss;
     ss << "\n===== Matmul Parameters ========\n"
        << (tag.empty() ? "" : "Tag: ") << tag << "\n"
-       << "MMA macro: " << nvfuser::toString(mma_macro, true) << "\n"
+       << "MMA macro: " << nvfuser::toString(mma_macro) << "\n"
        << double_buffer_options.toString() << "\n"
        << nvfuser::toString(tile_sizes) << "\n"
        << "Rotate ldmatrix out of main loop: "


### PR DESCRIPTION
`MacroType` is a enum that specifies which mma instruction to use. In the past, the underlying type for this enum is just the default given by C++. This PR changes this to `uint64_t`, and explicitly specify a value for each macro, so that the first two bits represent arch, the second two bits represent `m`. This makes it possible to pull the information of an enum without using a `switch`. I am trying to avoid `switch` because hopper have a lot of macros, and having to write all of them down is so boring...

This PR also adds hopper macros, although they are not implemented yet.