### PR TITLE
Support boolean inputs for `kir::Asm` and lower `cp.async` as `kir::Asm`

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -2864,7 +2864,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       for (auto input : asm_->inputs()) {
         if (input->dtype() == DataType::Bool) {
           indent() << "\"  .reg .pred p" << boolean_counter << "; \\n\"\n";
-          indent() << "\"  setp.ne.b32 p" << boolean_counter << ", %" << counter << ", 0;\\n\"\n";
+          indent() << "\"  setp.ne.b32 p" << boolean_counter << ", %" << counter
+                   << ", 0;\\n\"\n";
           boolean_counter++;
         }
         if (std::holds_alternative<ArrayType>(input->dtype().type)) {

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -577,28 +577,6 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     code_ << genVariableName(tv);
   }
 
-  // Utility function to emit a cp.async intrinsic
-  void genCpAsync(const LoadStoreOp* ldst, size_t vec_size) {
-    auto dtype = ldst->in()->getDataType().value();
-
-    bool is_cg = ldst->opType() == LoadStoreOpType::CpAsync &&
-        ldst->cacheOp() == CacheOp::Global;
-    std::string name = (is_cg ? "Ampere::cpAsyncCg" : "Ampere::cpAsyncCa");
-
-    ArgumentBuilder template_args;
-    template_args.arg(dtype);
-    template_args.arg(vec_size);
-
-    ArgumentBuilder func_args;
-    func_args.arg(genInline(ldst->out()));
-    func_args.arg(genInline(ldst->in()));
-    if (ldst->predicate() != nullptr) {
-      func_args.arg(genInline(ldst->predicate()));
-    }
-
-    indent() << genCall(name, template_args, func_args) << ";\n";
-  }
-
   void genCpAsyncBulkTensorTile(const LoadStoreOp* ldst) {
     auto in = ldst->in()->as<kir::TensorIndex>();
     auto out = ldst->out()->as<kir::TensorIndex>();
@@ -1307,8 +1285,9 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     auto optype = ldst->opType();
     NVF_ERROR(
         optype != LoadStoreOpType::LdMatrix &&
-            optype != LoadStoreOpType::LdMatrixTranspose,
-        "ldmatrix should be lowered as kir::Asm");
+            optype != LoadStoreOpType::LdMatrixTranspose &&
+            optype != LoadStoreOpType::CpAsync,
+        "ldmatrix and cp.async should be lowered as kir::Asm");
 
     if (ldst->out()->isA<kir::TensorIndex>()) {
       auto out_ti = ldst->out()->as<kir::TensorIndex>();
@@ -1335,17 +1314,6 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         NVF_ERROR(
             ldst->out()->dtype() == ldst->in()->dtype(),
             "Vectorized store/load requires input and output datatypes match.");
-      }
-
-      // dispatch cp.async
-      if (optype == LoadStoreOpType::CpAsync) {
-        if (ldst->cacheOp() == CacheOp::Global) {
-          NVF_ERROR(
-              is_vector_op && vector_word_size == 8,
-              "cp.async.cg only support vectorize 8");
-        }
-        genCpAsync(ldst, vector_word_size);
-        return;
       }
 
       // dispatch cp.async.bulk.tensor.tile
@@ -2865,7 +2833,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     if (asm_->volatile_()) {
       code_ << " volatile";
     }
-    bool multiline =
+    bool multiline = asm_->hasBooleanInput() ||
         (asm_->code().size() +
              (asm_->inputs().size() + asm_->outputs().size()) * 5 >
          80);
@@ -2889,12 +2857,36 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       indent();
     }
 
+    if (asm_->hasBooleanInput()) {
+      code_ << "\"{\\n\"\n";
+      int64_t boolean_counter = 0;
+      int64_t counter = 0;
+      for (auto input : asm_->inputs()) {
+        if (input->dtype() == DataType::Bool) {
+          indent() << "\"  .reg .pred p" << boolean_counter << "; \\n\"\n";
+          indent() << "\"  setp.ne.b32 p" << boolean_counter << ", %" << counter << ", 0;\\n\"\n";
+          boolean_counter++;
+        }
+        if (std::holds_alternative<ArrayType>(input->dtype().type)) {
+          counter += std::get<ArrayType>(input->dtype().type).size;
+        } else {
+          counter++;
+        }
+      }
+      indent() << "  ";
+    }
+
     code_ << "\"" << asm_->code();
     auto parameters = asm_->parameters();
     if (!parameters.empty()) {
       code_ << " " << parameters;
     }
     code_ << ";\\n\"";
+
+    if (asm_->hasBooleanInput()) {
+      code_ << "\n";
+      indent() << "\"}\\n\"";
+    }
 
     auto next_section = [&]() {
       if (multiline) {
@@ -2930,7 +2922,15 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
                       << ")";
               }
             } else {
-              code_ << "\"" << constraint << "\"(" << gen(register_) << ")";
+              code_ << "\"" << constraint << "\"(";
+              if (register_->dtype() == DataType::Bool) {
+                code_ << "(uint32_t)(";
+              }
+              code_ << gen(register_);
+              if (register_->dtype() == DataType::Bool) {
+                code_ << ")";
+              }
+              code_ << ")";
             }
           }
         };

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -2869,7 +2869,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           boolean_counter++;
         }
         if (std::holds_alternative<ArrayType>(input->dtype().type)) {
-          counter += std::get<ArrayType>(input->dtype().type).size;
+          counter += (int64_t)std::get<ArrayType>(input->dtype().type).size;
         } else {
           counter++;
         }
@@ -2882,11 +2882,11 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     if (!parameters.empty()) {
       code_ << " " << parameters;
     }
-    code_ << ";\\n\"";
+    code_ << R"(;\n")";
 
     if (asm_->hasBooleanInput()) {
       code_ << "\n";
-      indent() << "\"}\\n\"";
+      indent() << R"("}\n")";
     }
 
     auto next_section = [&]() {

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -2874,10 +2874,11 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           counter++;
         }
       }
-      indent() << "  ";
+      indent() << "\"  " << asm_->code();
+    } else {
+      code_ << "\"" << asm_->code();
     }
 
-    code_ << "\"" << asm_->code();
     auto parameters = asm_->parameters();
     if (!parameters.empty()) {
       code_ << " " << parameters;
@@ -2902,10 +2903,12 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           bool first = true;
           for (auto [constraint, register_] : constraints_and_registers) {
             auto next_line = [&]() {
-              code_ << ", ";
+              code_ << ",";
               if (multiline) {
                 code_ << "\n";
                 indent() << " ";
+              } else {
+                code_ << " ";
               }
             };
             if (!first) {

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -99,7 +99,8 @@ class LowerToInlinePtx : public kir::ExprMutator {
         ss << "ca";
       } else {
         ss << "cg";
-        NVF_ERROR(vec_size == 16, "cp.async.cg only support vectorize 16 bytes");
+        NVF_ERROR(
+            vec_size == 16, "cp.async.cg only support vectorize 16 bytes");
       }
       ss << ".shared.global";
       registerReplace(

--- a/csrc/device_lower/pass/predicate.cpp
+++ b/csrc/device_lower/pass/predicate.cpp
@@ -89,54 +89,24 @@ class ConditionalFromPredicateModifier : public kir::ExprMutator {
       setWritePredicate(expr);
     }
 
-    // Note: [Predicate Inversion for CpAsync]
-    // Today for vectorized support the pattern is:
-    // Initialize buffer -> predicated load
-    // For memcpy async:
-    //    If we initialized and then loaded (without sync) it would be undefined
-    //    behavior.
-    // Initialize only the "virtual out of boundary" accesses.
-    //  Memory allocated, but outside the virtual tensor space.
-    //  Virtual tensor space today is effectively what would be allocated in
-    //  global memory. Then only copy the "within bound" accesses.
-    // This is a WAR today based on how our system is set up.
-    //    We would want to have a separate concept of SMEM space from Virtual or
-    //    GMEM space, so that we know we're only working with the allocated
-    //    SMEM.
-    //  If we hit outside the allocated SMEM bad things happen.
-    // Today asserting in predicate removal making sure that the virtual and
-    // SMEM boundaries line up based on the IterDomains.
-    //
-    // TODO: in a follow up we need to extend the predicate
-    //  infrastructure to generate predicate for both gmem
-    //  and smem, and the predicate removal will need to
-    //  be extended as well for the perf critical regions.
-    if (isPredicatedInitForCpAsync(expr)) {
-      invertPredicateForGmemToSharedMemInitialize(expr);
+    // According to:
+    // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async
+    // cp.async has a built-in mechanism `ignore-src` to ignore the source and
+    // fill zero. We can just invert the predicate and use it as `ignore-src`.
+    if (ir_utils::isCpAsyncOp(expr)) {
+      invertPredicate(expr);
     }
 
     kir::ExprMutator::dispatch(expr);
   }
 
   // Invert the predicate of given expr.
-  void invertPredicateForGmemToSharedMemInitialize(Expr* expr) {
+  void invertPredicate(Expr* expr) {
     auto pred = expr->predicate()->value();
     Val* invert = SimplifyingIrBuilder::logicalNotExpr(pred);
     invert =
         GpuLower::current()->commonScalarMap().hoistScalar(invert, for_loops_);
     expr->predicate()->setValue(invert);
-  }
-
-  // Detect if this expr is an initialization for vectorized
-  //  cp asyc with predicates.
-  bool isPredicatedInitForCpAsync(Expr* expr) {
-    // Match the pattern:
-    //  If(pred)
-    //    TV = 0;
-    //  where TV is the output of cp async.
-    auto maybe_init = ir_utils::getMaybePredicatedSingleton(expr);
-    return maybe_init.has_value() &&
-        ir_utils::isCpAsyncInit(maybe_init.value());
   }
 
   void setWritePredicate(Expr* expr) {

--- a/csrc/device_lower/pass/predicate.cpp
+++ b/csrc/device_lower/pass/predicate.cpp
@@ -102,6 +102,7 @@ class ConditionalFromPredicateModifier : public kir::ExprMutator {
 
   // Invert the predicate of given expr.
   void invertPredicate(Expr* expr) {
+    NVF_ERROR(expr->predicate() != nullptr);
     auto pred = expr->predicate()->value();
     Val* invert = SimplifyingIrBuilder::logicalNotExpr(pred);
     invert =

--- a/csrc/device_lower/pass/predicate.cpp
+++ b/csrc/device_lower/pass/predicate.cpp
@@ -102,7 +102,7 @@ class ConditionalFromPredicateModifier : public kir::ExprMutator {
 
   // Invert the predicate of given expr.
   void invertPredicate(Expr* expr) {
-    NVF_ERROR(expr->predicate() != nullptr);
+    NVF_ERROR(expr != nullptr);
     auto pred = expr->predicate()->value();
     Val* invert = SimplifyingIrBuilder::logicalNotExpr(pred);
     invert =

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -229,6 +229,15 @@ class Asm final : public Expr {
     return options().memory;
   }
 
+  bool hasBooleanInput() const {
+    for (auto input : inputs()) {
+      if (input->dtype() == DataType::Bool) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   std::vector<std::pair<std::string, Val*>> constraintsAndOutputs() const;
   std::vector<std::pair<std::string, Val*>> constraintsAndInputs() const;
 

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -455,13 +455,7 @@ void UnswitchPredicate::predicateOn(Expr* tv_expr) {
 
   const auto gpu_lower = GpuLower::current();
 
-  // FIXME:
-  //   Needed to keep the predicate of cp.async initialization to get the
-  //   inverted predicate,
-  // see [Predicate Inversion for CpAsync]. In a follow up both this part and
-  // the [Predicate Inversion for CpAsync] should be cleaned up together.
-  if (gpu_lower->predicateElimination().canOmitPredicate(tv_expr) &&
-      !ir_utils::isCpAsyncInit(tv_expr)) {
+  if (gpu_lower->predicateElimination().canOmitPredicate(tv_expr)) {
     return;
   }
 

--- a/runtime/memory.cu
+++ b/runtime/memory.cu
@@ -61,68 +61,6 @@ __device__ inline void adjustPartialLdMatrixAddrInTuring(
 
 #endif // Arch 75
 
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
-
-namespace Ampere {
-
-// MMA instruction wrappers (sm_80+):
-
-// Global to SMEM load that is asynchronous,
-// not guaranteed to be completed until cpAsyncBarrier() is called.
-// if predicate is set to false, then gmem_ptr won't be read and smem_addr will
-// be zero-initialized gmem_ptr must be `sizeof(dtype) * len` aligned
-template <typename dtype, int len>
-__device__ inline void cpAsyncCa(
-    unsigned smem_addr,
-    void const* gmem_ptr,
-    bool predicate) {
-  constexpr int byte_size = sizeof(dtype) * len;
-
-  static_assert(
-      byte_size == 4 || byte_size == 8 || byte_size == 16,
-      "cp_async : unsupported byte size");
-
-  asm volatile(
-      "{\n"
-      "  .reg .pred p;\n"
-      "  setp.eq.b32 p, %3, 0;\n"
-      "  cp.async.ca.shared.global [%0], [%1], %2, p;\n"
-      "}\n" ::"r"(smem_addr),
-      "l"(gmem_ptr),
-      "n"(byte_size),
-      "r"((int)predicate));
-}
-
-// Global to SMEM load that is asynchronous,
-//  The cache global variant, i.e. skip L1 caching.
-// more details see:
-// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#cache-operators
-// not guaranteed to be completed until cpAsyncBarrier() is called.
-// if predicate is set to false, then gmem_ptr won't be read and smem_addr will
-// be zero-initialized gmem_ptr must be 16B aligned
-template <typename dtype, int len>
-__device__ inline void cpAsyncCg(
-    unsigned smem_addr,
-    void const* gmem_ptr,
-    bool predicate) {
-  constexpr int byte_size = sizeof(dtype) * len;
-
-  static_assert(byte_size == 16, "cp_async : unsupported byte size");
-
-  asm volatile(
-      "{\n"
-      "  .reg .pred p;\n"
-      "  setp.eq.b32 p, %2, 0;\n"
-      "  cp.async.cg.shared.global [%0], [%1], 16, p;\n"
-      "}\n" ::"r"(smem_addr),
-      "l"(gmem_ptr),
-      "r"((int)predicate));
-}
-
-} // namespace Ampere
-
-#endif // Arch 80
-
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
 
 namespace Hopper {

--- a/test/test_loop_rotation.cpp
+++ b/test/test_loop_rotation.cpp
@@ -578,9 +578,22 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     i3 = toSmem(T4) + (12LL * i1);
     bool b4;
     b4 = (i1 + nvfuser_zero) < T0.logical_size[0LL];
+    bool b5;
+    b5 = !b4;
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
-      Ampere::cpAsyncCa<float, 1>((uint32_t)((i3 + (4LL * i5))), (ptr2 + (T0.alloc_stride[1LL] * (i5 + nvfuser_zero))), b4);
+    for(nvfuser_index_t i6 = 0; i6 < 3LL; ++i6) {
+      asm volatile(
+        "{\n"
+        "  .reg .pred p0; \n"
+        "  setp.ne.b32 p0, %3, 0;\n"
+        "  cp.async.ca.shared.global [%0], [%1], %2, p0;\n"
+        "}\n"
+        :
+        :"r"((uint32_t)((i3 + (4LL * i6)))),
+         "l"((ptr2 + (T0.alloc_stride[1LL] * (i6 + nvfuser_zero)))),
+         "n"(4LL),
+         "r"((uint32_t)(b5))
+      );
     }
     asm volatile("cp.async.commit_group;\n");
   }
@@ -590,45 +603,58 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   T1[0LL]
      = T4[0LL];
   #pragma unroll 1
-  for(nvfuser_index_t i6 = 0; i6 < T0.logical_size[0LL]; ++i6) {
-    float* ptr7;
-    ptr7 = ptr0 + (T0.alloc_stride[0LL] * i6);
-    nvfuser_index_t i8;
-    i8 = 4LL + i6;
-    unsigned i9;
-    i9 = toSmem(T4) + (12LL * (i8 % 5LL));
-    nvfuser_index_t i10;
-    i10 = 1LL + (3LL * (i6 % 5LL));
+  for(nvfuser_index_t i7 = 0; i7 < T0.logical_size[0LL]; ++i7) {
+    float* ptr8;
+    ptr8 = ptr0 + (T0.alloc_stride[0LL] * i7);
+    nvfuser_index_t i9;
+    i9 = 4LL + i7;
+    unsigned i10;
+    i10 = toSmem(T4) + (12LL * (i9 % 5LL));
     nvfuser_index_t i11;
-    i11 = 3LL * i6;
-    bool b12;
-    b12 = i8 < T0.logical_size[0LL];
+    i11 = 1LL + (3LL * (i7 % 5LL));
+    nvfuser_index_t i12;
+    i12 = 3LL * i7;
+    bool b13;
+    b13 = i9 < T0.logical_size[0LL];
+    bool b14;
+    b14 = !b13;
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
-      Ampere::cpAsyncCa<float, 1>((uint32_t)((i9 + (4LL * i5))), (ptr7 + (T0.alloc_stride[1LL] * (i5 + nvfuser_zero))), b12);
+    for(nvfuser_index_t i6 = 0; i6 < 3LL; ++i6) {
+      asm volatile(
+        "{\n"
+        "  .reg .pred p0; \n"
+        "  setp.ne.b32 p0, %3, 0;\n"
+        "  cp.async.ca.shared.global [%0], [%1], %2, p0;\n"
+        "}\n"
+        :
+        :"r"((uint32_t)((i10 + (4LL * i6)))),
+         "l"((ptr8 + (T0.alloc_stride[1LL] * (i6 + nvfuser_zero)))),
+         "n"(4LL),
+         "r"((uint32_t)(b14))
+      );
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     asm volatile("cp.async.commit_group;\n");
     #pragma unroll
-    for(nvfuser_index_t i13 = 0; i13 < 2LL; ++i13) {
-      T1[((1LL + i13) % 2LL)]
-         = T4[(i10 + i13)];
+    for(nvfuser_index_t i15 = 0; i15 < 2LL; ++i15) {
+      T1[((1LL + i15) % 2LL)]
+         = T4[(i11 + i15)];
       float T2[1LL];
       T2[0LL]
-         = T1[(i13 % 2LL)];
-      T3[(i11 + (i13 + nvfuser_zero))]
+         = T1[(i15 % 2LL)];
+      T3[(i12 + (i15 + nvfuser_zero))]
          = T2[0LL];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     float T2[1LL];
     T2[0LL]
        = T1[0LL];
-    T3[(2LL + i11)]
+    T3[(2LL + i12)]
        = T2[0LL];
     NVFUSER_UPDATE_MAGIC_ZERO;
     asm volatile("cp.async.wait_group %0;\n"::"n"(3LL));
     T1[0LL]
-       = T4[(3LL * ((1LL + i6) % 5LL))];
+       = T4[(3LL * ((1LL + i7) % 5LL))];
   }
 }
 )";


### PR DESCRIPTION
Inline PTX does not have a builtin constraint for boolean values, we have to convert the boolean to int first, and use `setp.ne.b32` to put this int to predicate register. With this new feature added, we can now lower `cp.async` as `kir::Asm`. This feature is also needed for supporting Hopper MMA.