### PR TITLE
More cleanup on matmul schedule

### DIFF
--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -980,8 +980,10 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
 
   acr->setAllocationDomain(acr->getLeafDomain(), true);
   bcr->setAllocationDomain(bcr->getLeafDomain(), true);
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(acr);
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(bcr, true);
+  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(
+      acr, mma_builder.operand(MmaOptions::Operand::A).build());
+  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(
+      bcr, mma_builder.operand(MmaOptions::Operand::B).build());
 
   //  -5  -4   -3   -2   -1          or          -5  -4   -3   -2   -1
   //[8mi, 4k, 2ko, 2mo, 2ki]                   [8ni, 4k, 2ko, 1no, 2ki]

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -577,45 +577,7 @@ void checkDimSize(
   }
 }
 
-void WarpMmaSwizzler::scheduleMmaWarpOutput(
-    TensorView* tv,
-    MmaOptions options) {
-  auto macro = options.macro;
-  switch (macro) {
-    case MmaOptions::MacroType::Turing_16_8_16:
-    case MmaOptions::MacroType::Ampere_16_8_16:
-    case MmaOptions::MacroType::Turing_16_16_16:
-    case MmaOptions::MacroType::Ampere_16_16_16:
-      scheduleTuringMmaWarpOutput(tv, options);
-      if (tv->definition()->isA<MmaOp>()) {
-        setWarpMapped(tv, 7);
-      }
-      break;
-    default:
-      NVF_CHECK(
-          false, "scheduleMmaWarp: unsupported mma option ", toString(macro));
-      break;
-  }
-}
-
-void WarpMmaSwizzler::scheduleOperandRead(TensorView* tv, MmaOptions options) {
-  // Schedules operand for inner most 3 contiguous dimensions
-  // Assumes M, N, K
-
-  switch (options.macro) {
-    case MmaOptions::MacroType::Turing_16_8_16:
-    case MmaOptions::MacroType::Ampere_16_8_16:
-    case MmaOptions::MacroType::Turing_16_16_16:
-    case MmaOptions::MacroType::Ampere_16_16_16:
-      scheduleTuringOperandRead(tv);
-      break;
-    default:
-      NVF_CHECK(false, "WarpMmaSwizzler: please specify macro");
-      break;
-  }
-}
-
-void WarpMmaSwizzler::setWarpMapped(TensorView* tv, int number_of_dims) {
+static void setWarpMapped(TensorView* tv, int number_of_dims) {
   for (int id : c10::irange(number_of_dims)) {
     tv->axis(-id - 1)->toMmaSwizzled();
   }
@@ -710,154 +672,9 @@ std::unordered_set<IterDomain*> getMmaDomainSet(
   return {mma_domains.begin(), mma_domains.end()};
 }
 
-// [MMA dimension matching]
-// Returns all the axes that correspond to the given mma dimension. This is the
-//   first relaxation step on the mma check.
-// Mma operations concerns 3 dimensions, namely, the M, N,
-//  and K dimension, more details see [Operand Layout Convention] in mma_type.h.
-//  The current implementation, for best effort safety, supports the patterns
-//  where the root axes can be classified into one of the 3 dimension types.
-//  This is a helpful initial step into defining tensor contraction
-//  optimizations.
-//
-// A concrete example:
-//  T0 [I0, I1, I2, R3, I4, I5] = mma(T1[I01, B11, B21, I31, I41, B51], T2[B02,
-//  I12, B22, I32, I42, I52], {3};
-// In this case some example querries:
-//  K dimension of T0 = {R3}
-//  M dimension of T1 = {I01}
-//  N dimension of T2 = {I52}
-//  etc.
-std::vector<IterDomain*> getMmaRootDimensions(
-    TensorView* tv,
-    MmaOp* mma,
-    MmaDimension dimension) {
-  // Build a fusion-level root domain map
-  //  so we can use the mma swizzles on non-immediate tensor operands, for
-  //  example loadstore staging ops.
-  ComputeAtRootDomainMap root_map;
-  root_map.build();
-
-  // FIXME:
-  // Several optimization is possible at this stage but assuming we don't have
-  //  a lot of mma ops in a fusion this could be lower priority.
-  // First it'd be nice not having to build root map every time this function
-  //  is called. That'd require some explicit boundary where we "lock" the
-  //  compute in the fusion so the root map stays valid.
-  // Second it'd reduce complexity of the below matching by an order if we have
-  //  something similar to "disjointSetOf" in idGraph, for just the root domains
-  //  at scheduler composing time.
-  auto mma_root_dimensions = getMmaDomains(mma, dimension);
-  auto mma_accumulator_tv = mma->out()->as<TensorView>();
-
-  std::vector<IterDomain*> result;
-
-  // Need to use root domain for accumulator tv and maybe rfactor domain
-  //  otherwise. See [Use Root Domain in Accumulator TV].
-  auto is_mma_output =
-      tv->definition() != nullptr && tv->definition()->isA<MmaOp>();
-  const auto& tv_root_domain =
-      is_mma_output ? tv->getRootDomain() : tv->getMaybeRFactorDomain();
-
-  // Loop through tensorview's root domains and accumulate all the
-  //  root domain IterDomain's that maps to any of the collected
-  //  mma root dimension from the mma accumulator tv.
-  for (auto tv_id : tv_root_domain) {
-    if (std::any_of(
-            mma_root_dimensions.begin(),
-            mma_root_dimensions.end(),
-            [&](IterDomain* mma_id) {
-              return root_map.canMap(
-                  tv->domain(), tv_id, mma_accumulator_tv->domain(), mma_id);
-            })) {
-      result.push_back(tv_id);
-    }
-  }
-
-  return result;
-}
-
-//! Utility function to help check that the innermost 3 iterdomains
-//!  are also the corresponding innermost {m,n,k} dimensions of
-//!  the root id's that are participating in the mma operation.
-//! This is a format check before the warp mma swizzler applies mma
-//!  swizzles to make sure that the swizzler is applying the right
-//!  swizzles to the right axes.
-//! This check will be relaxed as we build out the mma usage patterns.
-void validateMmaRootInnerMNK(
-    TensorView* tv,
-    MmaOptions options,
-    int m,
-    int n,
-    int k) {
-  auto mma = options.mmaOp();
-  auto m_dims = getMmaRootDimensions(tv, mma, MmaDimension::M);
-  auto n_dims = getMmaRootDimensions(tv, mma, MmaDimension::N);
-  auto k_dims = getMmaRootDimensions(tv, mma, MmaDimension::K);
-
-  NVF_CHECK(
-      !m_dims.empty() && !n_dims.empty() && !k_dims.empty(),
-      "validateMmaRootInnerMNK: MMA Axes incomplete");
-
-  // Still check the innermost dims of each at the current state:
-  NVF_ERROR(tv->nDims() >= 3);
-  NVF_ERROR(
-      canValidateIsInnerDim(m_dims.back(), tv->axis(-3), m),
-      "MMA swizzle: requires instruction tile iterdomains on the innermost side of the tensordomain");
-  NVF_ERROR(
-      canValidateIsInnerDim(n_dims.back(), tv->axis(-2), n),
-      "MMA swizzle: requires instruction tile iterdomains on the innermost side of the tensordomain");
-  NVF_ERROR(
-      canValidateIsInnerDim(k_dims.back(), tv->axis(-1), k),
-      "MMA swizzle: requires instruction tile iterdomains on the innermost side of the tensordomain");
-}
-
-//! Utility function to help check that the innermost 3 iterdomains
-//!  are also the corresponding innermost {m,n} dimensions of
-//!  the root id's that are participating in the mma operation.
-//! This is a format check before the warp mma swizzler applies mma
-//!  swizzles to make sure that the swizzler is applying the right
-//!  swizzles to the right axes.
-//! This check will be relaxed as we build out the mma usage patterns.
-void validateMmaRootInnerMN(TensorView* tv, MmaOptions options, int m, int n) {
-  auto mma = options.mmaOp();
-  auto m_dims = getMmaRootDimensions(tv, mma, MmaDimension::M);
-  auto n_dims = getMmaRootDimensions(tv, mma, MmaDimension::N);
-
-  NVF_CHECK(
-      !m_dims.empty() && !n_dims.empty(),
-      "validateMmaRootInnerMNK: MMA Axes incomplete");
-
-  // Still check the innermost dims of each at the current state:
-  NVF_ERROR(tv->nDims() >= 2);
-  NVF_ERROR(
-      canValidateIsInnerDim(m_dims.back(), tv->axis(-2), m),
-      "MMA swizzle: requires instruction tile iterdomains on the innermost side of the tensordomain");
-  NVF_ERROR(
-      canValidateIsInnerDim(n_dims.back(), tv->axis(-1), n),
-      "MMA swizzle: requires instruction tile iterdomains on the innermost side of the tensordomain");
-}
-
 } // namespace
 
-void WarpMmaSwizzler::scheduleTuringOperandRead(TensorView* tv) {
-  NVF_ERROR(tv->nDims() >= 2);
-  //  -2   -1          or          -2   -1
-  //[16m, 16k]                    [8n, 16k]
-  tv->split(-2, 8);
-  tv->split(-1, 2);
-  tv->split(-2, 4);
-
-  // -5  -4  -3  -2  -1      or      -5  -4  -3  -2  -1
-  //[2m, 8m, 2k, 4k, 2k']           [1n, 8n, 2k, 4k, 2k']
-  tv->reorder({{-4, -5}, {-5, -2}, {-2, -4}});
-
-  // -5  -4   -3  -2  -1    or      -5  -4  -3  -2  -1
-  //[8m, 4k, 2k, 2m, 2k']          [8n, 4k, 2k, 1n, 2k']
-  tv->setAllocationDomain(tv->getLeafDomain(), true);
-}
-
-void WarpMmaSwizzler::scheduleLdMatrix(TensorView* tv, bool mn_major) {
+void WarpMmaSwizzler::scheduleLdMatrix(TensorView* tv, MmaOptions options) {
   bool transpose = tv->definition()->as<LoadStoreOp>()->opType() ==
       LoadStoreOpType::LdMatrixTranspose;
   //  -5   -4   -3   -2    -1          or          -5   -4   -3   -2   -1
@@ -873,11 +690,38 @@ void WarpMmaSwizzler::scheduleLdMatrix(TensorView* tv, bool mn_major) {
     //  -4   -3   -2   -1        or          -4    -3   -2   -1
     //[2ko, 2mno, 8k, 8mni]                 [2ko, 1mno, 8k, 8mni]
   }
+
+  // ldmatrix loads multiple 8x8 matrices from shared memory to registers in a
+  // swizzled memory format.
+  //   +--------+--------+
+  //   |        |        |
+  //   |  8x8   |  8x8   |
+  //   |        |        |
+  //   +--------+--------+
+  //   |        |        |
+  //   |  8x8   |  8x8   |
+  //   |        |        |
+  //   +--------+--------+
+  // If mn_major is true, these 8x8 matrices are visited in the order of:
+  // top left -> top right -> bottom left -> bottom right.
+  // If mn_major is false, these 8x8 matrices are visited in the order of:
+  // top left -> bottom left -> top right -> bottom right.
+  //
+  // In principle, only `mn_major = false` should be needed. But unfortunately,
+  // we are taking advantage of the ldmatrix large load in a pretty hacky way.
+  // For example, for Turing, only m16n8k8 is supported by hardware. But we are
+  // also using a fake m16n8k16 and m16n16k16, which uses a single large
+  // ldmatrix to load data to register, and run multiple mma instructions to
+  // consume these data. In the future, we should only keep the m16n8k8 macro,
+  // and schedule m16n8k16 and m16n16k16 more correctly than this current way.
+  bool mn_major =
+      options.operand == MmaOptions::Operand::B && getN(options.macro) > 8;
   if (mn_major) {
     tv->reorder({{-4, -3}, {-3, -4}});
     //  -4    -3  -2   -1        or           -4    -3  -2   -1
     //[2mno, 2ko, 8k, 8mni]                 [1mno, 2ko, 8k, 8mni]
   }
+
   tv->merge(-4);
   tv->merge(-3);
   // -2  -1         or          -2  -1
@@ -909,9 +753,27 @@ void WarpMmaSwizzler::scheduleLdMatrix(TensorView* tv, bool mn_major) {
   setWarpMapped(tv, 2);
 }
 
-void WarpMmaSwizzler::scheduleTuringMmaWarpOutput(
+void WarpMmaSwizzler::scheduleOperandRead(TensorView* tv, MmaOptions options) {
+  NVF_ERROR(tv->nDims() >= 2);
+
+  //  -2   -1          or          -2   -1
+  //[16m, 16k]                    [8n, 16k]
+  tv->split(-2, 8);
+  tv->split(-1, 2);
+  tv->split(-2, 4);
+
+  // -5  -4  -3  -2  -1      or      -5  -4  -3  -2  -1
+  //[2m, 8m, 2k, 4k, 2k']           [1n, 8n, 2k, 4k, 2k']
+  tv->reorder({{-4, -5}, {-5, -2}, {-2, -4}});
+
+  // -5  -4   -3  -2  -1    or      -5  -4  -3  -2  -1
+  //[8m, 4k, 2k, 2m, 2k']          [8n, 4k, 2k, 1n, 2k']
+  tv->setAllocationDomain(tv->getLeafDomain(), true);
+}
+
+void WarpMmaSwizzler::scheduleMmaWarpOutput(
     TensorView* tv,
-    const MmaOptions& options) {
+    MmaOptions options) {
   // Assume last 2 dims [M16, N8] or [M16, N8, R]
   // Locate instruction m
   bool is_reduction = tv->axis(-1)->isReduction();
@@ -960,49 +822,10 @@ void WarpMmaSwizzler::scheduleTuringMmaWarpOutput(
   }
 
   tv->axis(m_pos)->parallelize(ParallelType::TIDx);
-}
 
-namespace {
-
-bool isMmaInitLoop(const kir::Scope& loop_body) {
-  for (auto expr : loop_body.exprs()) {
-    if (auto inner_loop = dynamic_cast<kir::ForLoop*>(expr)) {
-      if (!isMmaInitLoop(inner_loop->body())) {
-        return false;
-      }
-    } else if (auto ldst = dynamic_cast<LoadStoreOp*>(expr)) {
-      if (!ir_utils::isTvOp(ldst)) {
-        return false;
-      }
-      if (auto ti = dynamic_cast<kir::TensorIndex*>(ldst->output(0))) {
-        if (!ti->view()->definition() ||
-            !ti->view()->definition()->isA<MmaOp>()) {
-          return false;
-        }
-      }
-      if (auto tv = dynamic_cast<TensorView*>(ldst->output(0))) {
-        if (!tv->definition() || !tv->definition()->isA<MmaOp>()) {
-          return false;
-        }
-      }
-    } else if (auto ite = dynamic_cast<kir::IfThenElse*>(expr)) {
-      if (!isMmaInitLoop(ite->thenBody())) {
-        return false;
-      }
-      if (!isMmaInitLoop(ite->elseBody())) {
-        return false;
-      }
-    } else {
-      return false;
-    }
+  if (tv->definition()->isA<MmaOp>()) {
+    setWarpMapped(tv, 7);
   }
-  return true;
-}
-
-} // namespace
-
-bool isMmaInitLoop(const kir::ForLoop* loop) {
-  return isMmaInitLoop(loop->body());
 }
 
 void canonicalizeMmaTvOrdering(TensorView* tv) {

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -162,13 +162,11 @@ class WarpMmaSwizzler {
   //! The rightmost iterdomains must follow the m,n,k convention before calling.
   static void scheduleMmaWarpOutput(TensorView* tv, MmaOptions options);
 
-  //! Applies the input mma swizzling to the given tv, should be used
-  //!  on mma input or tv's involved in any fusion before mma, but after smem
-  //!  read.
+  //! Applies the input mma swizzling to the given tv as its allocation domain,
+  //! should be used on mma input or tv's involved in any fusion before mma, but
+  //! after smem read.
   //! The rightmost iterdomains must follow the m,n,k convention before calling.
-  static void scheduleOperandRead(
-      TensorView* tv,
-      MmaOptions options = MmaOptions());
+  static void scheduleOperandRead(TensorView* tv, MmaOptions options);
 
   //! Note [schedule of ldmatrix]
   //! If you look at the doc of ldmatrix and mma for Turing and Ampere:
@@ -184,62 +182,13 @@ class WarpMmaSwizzler {
   //! leaf domain of the ldmatrix output. The allocation domain of the ldmatrix
   //! output and mma inputs are scheduled in scheduleOperandRead, which must be
   //! called before this function.
-  //!
-  //! ldmatrix loads multiple 8x8 matrices from shared memory to registers in a
-  //! swizzled memory format.
-  //!   +--------+--------+
-  //!   |        |        |
-  //!   |  8x8   |  8x8   |
-  //!   |        |        |
-  //!   +--------+--------+
-  //!   |        |        |
-  //!   |  8x8   |  8x8   |
-  //!   |        |        |
-  //!   +--------+--------+
-  //! If mn_major is true, these 8x8 matrices are visited in the order of:
-  //! top left -> top right -> bottom left -> bottom right.
-  //! If mn_major is false, these 8x8 matrices are visited in the order of:
-  //! top left -> bottom left -> top right -> bottom right.
-  //!
-  //! In principle, only `mn_major = false` should be needed. But unfortunately,
-  //! we are taking advantage of the ldmatrix large load in a pretty hacky way.
-  //! For example, for Turing, only m16n8k8 is supported by hardware. But we are
-  //! also using a fake m16n8k16 and m16n16k16, which uses a single large
-  //! ldmatrix to load data to register, and run multiple mma instructions to
-  //! consume these data. In the future, we should only keep the m16n8k8 macro,
-  //! and schedule m16n8k16 and m16n16k16 more correctly than this current way.
-  static void scheduleLdMatrix(TensorView* tv, bool mn_major = false);
-
- private:
-  //! Memory layout for MMA operand, see note [schedule of ldmatrix]
-  static void scheduleTuringOperandRead(TensorView* tv);
-
-  //! Accumulator swizzle implementation for Turing and Ampere mma.
-  static void scheduleTuringMmaWarpOutput(
-      TensorView* tv,
-      const MmaOptions& options);
-
-  //! Accumulator swizzle implementation for emulated 16x16x16 mma tile
-  //!  that enables using ldmatrix.x4.
-  //! Note:
-  //!   Keeping both this option and the ldmatrix.x2 variant above for
-  //! now for wider scheduler exploration space. Eventually both of
-  //! these can be unified with a single affine utility.
-  static void scheduleTuringM16N16K16MmaWarpOutput(
-      TensorView* tv,
-      const MmaOptions& options);
-
-  //! Utility to lock the transformed dimensions from further transforms.
-  static void setWarpMapped(TensorView* tv, int number_of_dims);
+  static void scheduleLdMatrix(TensorView* tv, MmaOptions options);
 };
 
 void checkDimSize(
     TensorView* tv,
     std::vector<int> axis,
     std::vector<int> expect);
-
-// Returns if the loopnest is initializing for an mma op.
-bool isMmaInitLoop(const kir::ForLoop* loop);
 
 //! A constant with minimum number of fusion inputs that could be MMA inputs.
 //!  TODO: update for square matmuls where both inputs are the same tensor

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1390,6 +1390,9 @@ void TensorView::applyMmaSwizzle(MmaOptions options) {
     case MmaOptions::Operand::A:
     case MmaOptions::Operand::B:
       mma_utils::WarpMmaSwizzler::scheduleOperandRead(this, options);
+      if (ir_utils::isLdMatrixOp(definition())) {
+        mma_utils::WarpMmaSwizzler::scheduleLdMatrix(this, options);
+      }
       break;
     default:
       NVF_ERROR(false, "unknown operand flag");

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -533,14 +533,12 @@ TEST_F(NVFuserTest, FusionMatmulMatmulAmpere_CUDA) {
   // Schedule gemm 2 mma input
   // ---------------------------------------------------------------------------
   tv3cr->applyMmaSwizzle(mma_builder2.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv3cr);
 
   // [... Mi, Ni, Ki] want [Ni, Mi, Ki]
   tv3b->reorder({{-2, -3}, {-3, -2}});
   tv3b->applyMmaSwizzle(mma_builder2.operand(MmaOptions::Operand::A).build());
 
   tv2cr->applyMmaSwizzle(mma_builder2.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv2cr, true);
   tv2b->applyMmaSwizzle(mma_builder2.operand(MmaOptions::Operand::B).build());
 
   // Schedule mma output
@@ -600,13 +598,11 @@ TEST_F(NVFuserTest, FusionMatmulMatmulAmpere_CUDA) {
   // Schedule mma input
   // ---------------------------------------------------------------------------
   tv0cr->applyMmaSwizzle(mma_builder1.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
   // [... Mi, Ni, Ki] want [Ni, Mi, Ki]
   tv0b->reorder({{-2, -3}, {-3, -2}});
   tv0b->applyMmaSwizzle(mma_builder1.operand(MmaOptions::Operand::A).build());
 
   tv1cr->applyMmaSwizzle(mma_builder1.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv1b->applyMmaSwizzle(mma_builder1.operand(MmaOptions::Operand::B).build());
 
   // Schedule mma output
@@ -839,13 +835,11 @@ TEST_F(NVFuserTest, FusionMatmulSoftmaxMatmulAmpere_CUDA) {
   // Schedule gemm 2 mma input
   // ---------------------------------------------------------------------------
   tv3cr->applyMmaSwizzle(mma_builder2.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv3cr);
   // [... Mi, Ni, Ki] want [Ni, Mi, Ki]
   tv3b->reorder({{-2, -3}, {-3, -2}});
   tv3b->applyMmaSwizzle(mma_builder2.operand(MmaOptions::Operand::A).build());
 
   tv2cr->applyMmaSwizzle(mma_builder2.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv2cr, true);
   tv2b->applyMmaSwizzle(mma_builder2.operand(MmaOptions::Operand::B).build());
 
   // Schedule mma output
@@ -913,13 +907,11 @@ TEST_F(NVFuserTest, FusionMatmulSoftmaxMatmulAmpere_CUDA) {
   // Schedule mma input
   // ---------------------------------------------------------------------------
   tv0cr->applyMmaSwizzle(mma_builder1.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
   // [... Mi, Ni, Ki] want [Ni, Mi, Ki]
   tv0b->reorder({{-2, -3}, {-3, -2}});
   tv0b->applyMmaSwizzle(mma_builder1.operand(MmaOptions::Operand::A).build());
 
   tv1cr->applyMmaSwizzle(mma_builder1.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv1b->applyMmaSwizzle(mma_builder1.operand(MmaOptions::Operand::B).build());
 
   // // Schedule mma output
@@ -1187,13 +1179,11 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTNcpAsync_CUDA) {
   // Schedule mma input
   // ---------------------------------------------------------------------------
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
   // [... Mi, Ni, Ki]
   tv0b->reorder({{-2, -3}, {-3, -2}});
   tv0b->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
 
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv1b->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
 
   // Schedule mma output
@@ -1355,14 +1345,12 @@ TEST_F(NVFuserTest, FusionAmpereStridedBatchedMatmulTN_CUDA) {
   // Schedule mma input
   // ---------------------------------------------------------------------------
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
 
   // [... Mi, Ni, Ki] want [Ni, Mi, Ki]
   tv0b->reorder({{-2, -3}, {-3, -2}});
   tv0b->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
 
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv1b->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
 
   // Schedule mma output
@@ -1525,14 +1513,12 @@ TEST_F(NVFuserTest, FusionAmpereViewMatmulTN_CUDA) {
   // Schedule mma input
   // ---------------------------------------------------------------------------
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
 
   // [... Mi, Ni, Ki] want [Ni, Mi, Ki]
   tv0b->reorder({{-2, -3}, {-3, -2}});
   tv0b->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
 
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv1b->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
 
   // Schedule mma output
@@ -1713,14 +1699,12 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTNSwizzled_CUDA) {
   tv1cw->setMemoryType(MemoryType::Shared);
   // Schedule mma input
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
 
   // [... Mi, Ni, Ki]
   tv0b->reorder({{-2, -3}, {-3, -2}});
   tv0b->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
 
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv1b->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
 
   // Schedule mma output

--- a/test/test_mma.cpp
+++ b/test/test_mma.cpp
@@ -77,9 +77,7 @@ TEST_F(TuringMmaTest, TN) {
   // [M, N, K] -> [N, M, K]
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -154,9 +152,7 @@ TEST_F(TuringMmaTest, TT) {
   // [M, N, K] -> [N, M, K]
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -233,9 +229,7 @@ TEST_F(TuringMmaTest, NT) {
   // [K,M,N] -> [N,M,K]
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -310,9 +304,7 @@ TEST_F(TuringMmaTest, NN) {
   // [M, N, K] -> [N, M, K]
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -394,8 +386,6 @@ TEST_F(AmpereMmaTest, TN) {
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -473,8 +463,6 @@ TEST_F(AmpereMmaTest, TT) {
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -556,8 +544,6 @@ TEST_F(AmpereMmaTest, NT) {
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -635,8 +621,6 @@ TEST_F(AmpereMmaTest, NN) {
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -711,8 +695,6 @@ TEST_F(AmpereMmaTest, LargeTN) {
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -790,8 +772,6 @@ TEST_F(AmpereMmaTest, LargeTT) {
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -873,8 +853,6 @@ TEST_F(AmpereMmaTest, LargeNT) {
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(
@@ -952,8 +930,6 @@ TEST_F(AmpereMmaTest, LargeNN) {
   tv0cr->reorder({{-2, -3}, {-3, -2}});
   tv0cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::A).build());
   tv1cr->applyMmaSwizzle(mma_builder.operand(MmaOptions::Operand::B).build());
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv0cr);
-  mma_utils::WarpMmaSwizzler::scheduleLdMatrix(tv1cr, true);
   tv2c->applyMmaSwizzle(
       mma_builder.operand(MmaOptions::Operand::Accumulator).build());
   tv2->applyMmaSwizzle(


### PR DESCRIPTION
There should be no behavioral change, just code movement and removal of unused code.
- `scheduleTuringMmaWarpOutput` is removed. Its code is moved to `scheduleMmaWarpOutput`. Because after reading the documentation of Hopper MMAs, I feel that Hopper can share the same schdule.
- `scheduleTuringOperandRead` is removed, and its code copied to `scheduleOperandRead`, similar as above.
- `scheduleLdMatrix` now takes an `MmaOptions`.
- `TensorView::applyMmaSwizzle` will call `WarpMmaSwizzler::scheduleLdMatrix` if the tensor is the consumer of ldmatrix, this removes the need for manually calling `WarpMmaSwizzler::scheduleLdMatrix` in unit tests.