### PR TITLE
Call maybeClearAllocator in FusionReshapeVectorize

### DIFF
--- a/test/test_gpu_view.cpp
+++ b/test/test_gpu_view.cpp
@@ -1190,6 +1190,12 @@ TEST_F(GpuViewTest, FusionReshapeVectorize) {
   fusion.addOutput(tv4);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+
+  // This test allocates about 1GB of memory, so in order to avoid an OOM during
+  // this test, we manually clear the allocator after it's reached a certain
+  // threshold.
+  maybeClearAllocator();
+
   at::Tensor input = at::randn({256, 1024, 1024}, options);
 
   auto lparams = schedulePointwise(&fusion, {input});


### PR DESCRIPTION
This avoids an OOM when running this test in CI on V100, which allocates 1GB of memory. See here for a job that failed in this way: https://github.com/NVIDIA/Fuser/actions/runs/7005955828/job/19056753333.