### PR TITLE
fix 'print before set' in norm para

### DIFF
--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -365,8 +365,10 @@ std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
     const int64_t inner_dim_numel,
     const int64_t max_persistent_buffer_size,
     const size_t tmp_gmem_dtype_size,
-    const size_t vectorize_factor) {
+    const size_t vectorize_factor,
+    const bool project_to_input) {
   auto rparams = std::make_shared<ReductionParams>();
+  rparams->project_persistent_buffers = project_to_input;
   // Parameters for inner reduction:
   // Reduction dim: inner_vect, inner_batch, bdimx and bdimy
   // Iteration dim: gdimy
@@ -618,8 +620,8 @@ std::shared_ptr<ReductionParams> persistentHeuristic(
       inner_dim_numel,
       max_persistent_buffer_size,
       tmp_gmem_dtype_size,
-      vectorize_factor);
-  rparams->project_persistent_buffers = project_persistent_buffers;
+      vectorize_factor,
+      project_persistent_buffers);
   return rparams;
 }
 

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -928,7 +928,8 @@ PersistentKernelProperties getPersistentKernelProperties(
       .n_tensor_inputs = n_tensor_inputs,
       .max_dtype_size = max_dtype_size,
       .vectorize_factor = vectorize_factor,
-      .project_persistent_buffers = project_persistent_buffers};
+      .project_persistent_buffers = project_persistent_buffers,
+      .index_type = runtime_info.getIndexType()};
 }
 
 bool checkOpsAndInputs(Fusion* fusion, ScheduleHeuristic schedule_heuristic) {

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -230,6 +230,7 @@ struct PersistentKernelProperties {
   int64_t max_dtype_size;
   int64_t vectorize_factor;
   bool project_persistent_buffers;
+  PrimDataType index_type;
 };
 PersistentKernelProperties getPersistentKernelProperties(
     Fusion* fusion,


### PR DESCRIPTION
Issue: `ReductionParams` was printed before its member variable `project_persistent_buffers` was set.
Fix: set `project_persistent_buffers` before print.