### PR TITLE
Suppress NVRTC warnings about unused functions

### DIFF
--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -968,6 +968,10 @@ void fillCompileOptions(
     std::optional<int64_t> opt_block_size) {
   nvrtc_compile_driver.setOption("--std=c++17");
 
+  // Suppress warnings for functions that are defined but unused, since we have
+  // many unused functions in the preamble.
+  nvrtc_compile_driver.setOption("--diag-suppress=177");
+
   // CUDA 11.1 allows going directly to SASS (sm_) instead of PTX (compute_)
   // which gives better backwards compatibility to work on older driver,
   // (since older driver doesn't necessarily recognize PTX emitted by new


### PR DESCRIPTION
When we encounter a compilation error, or if we use `NVFUSER_DUMP=ptxas_verbose`, we get a ton of warnings printed to screen like 
```
__tmp_kernel_none_f0_c0_r0_g0.cu(2586): warning #177-D: function "<unnamed>::max(int, <unnamed>::int64_t)" was declared but
 never referenced                                                                                                          
  __device__ constexpr int64_t max(int a, int64_t b) {
```
There are of course a ton of unused functions in the preamble so these are not particularly useful warnings. This PR just turns them off.