### PR TITLE
add toString to CompileParams

### DIFF
--- a/csrc/executor_params.cpp
+++ b/csrc/executor_params.cpp
@@ -12,6 +12,20 @@
 
 namespace nvfuser {
 
+std::string CompileParams::toString() const {
+  std::stringstream ss;
+  ss << "Compile Parameters: index_type = ";
+  if (index_type.has_value()) {
+    ss << index_type.value() << ", ";
+  } else {
+    ss << "NotSet, ";
+  }
+  ss << "maxrregcount = " << maxrregcount << ", "
+     << "enable_magic_zero = " << enable_magic_zero << ", "
+     << "enable_ptxas_verbose = " << enable_ptxas_verbose << "\n";
+  return ss.str();
+}
+
 void LaunchParams::assertValid() {
   NVF_ERROR(
       bdimx() * bdimy() * bdimz() > 0 &&

--- a/csrc/executor_params.h
+++ b/csrc/executor_params.h
@@ -37,6 +37,8 @@ struct CompileParams {
   bool operator!=(const CompileParams& other) const {
     return !(*this == other);
   }
+
+  std::string toString() const;
 };
 
 class LaunchParams {

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -370,9 +370,11 @@ std::shared_ptr<ReductionParams> innerOuterPersistentHeuristic(
     const int64_t max_persistent_buffer_size,
     const size_t tmp_gmem_dtype_size,
     const size_t vectorize_factor,
-    const bool project_to_input) {
+    const bool project_to_input,
+    const PrimDataType index_type) {
   auto rparams = std::make_shared<ReductionParams>();
   rparams->project_persistent_buffers = project_to_input;
+  rparams->cparams.index_type = index_type;
   // Parameters for inner reduction:
   // Reduction dim: inner_vect, inner_batch, bdimx and bdimy
   // Iteration dim: gdimy
@@ -615,17 +617,18 @@ std::shared_ptr<ReductionParams> persistentHeuristic(
     const size_t tmp_gmem_dtype_size,
     const int64_t max_persistent_buffer_size,
     size_t vectorize_factor,
-    bool project_persistent_buffers) {
-  std::shared_ptr<ReductionParams> rparams;
+    bool project_persistent_buffers,
+    const PrimDataType index_type) {
   const int64_t outer_dim_numel = total_iteration_numel;
   const int64_t inner_dim_numel = inner_most_dimension_numel;
-  rparams = innerOuterPersistentHeuristic(
+  auto rparams = innerOuterPersistentHeuristic(
       outer_dim_numel,
       inner_dim_numel,
       max_persistent_buffer_size,
       tmp_gmem_dtype_size,
       vectorize_factor,
-      project_persistent_buffers);
+      project_persistent_buffers,
+      index_type);
   return rparams;
 }
 
@@ -772,8 +775,8 @@ std::shared_ptr<ReductionParams> getInnerOuterPersistentHeuristics(
       tmp_gmem_dtype_size,
       max_persistent_size,
       vectorize_factor,
-      project_persistent_buffers);
-  heuristic->cparams.index_type = runtime_info.getIndexType();
+      project_persistent_buffers,
+      runtime_info.getIndexType());
   return heuristic;
 }
 

--- a/csrc/scheduler/reduction_heuristic.h
+++ b/csrc/scheduler/reduction_heuristic.h
@@ -273,7 +273,8 @@ class ReductionParams : public HeuristicParams {
       ss << "\ncomputeWith persistent buffers";
     }
 
-    ss << "\n" << lparams.toString() << "\n";
+    ss << "\n" << lparams.toString();
+    ss << cparams.toString() << "\n";
     ss << "====================================\n";
     return ss.str();
   }


### PR DESCRIPTION
Issue: compile para is not printed when run with `NVFUSER_DUMP=scheduler_params`, missing the info of register count and index type which are important info to check the scheulder.

Fix:
Add method `toString` to `CompileParams` and use it to print scheduler paras.
Sample output when `NVFUSER_DUMP=scheduler_params`:
```
Launch Parameters: BlockDim.x = 96, BlockDim.y = 4, BlockDim.z = -1, GridDim.x = -1, GridDim.y = 108, GridDim.z = -1, Smem Size = 0
Compile Parameters: index_type = int, maxrregcount = 168, enable_magic_zero = 1, enable_ptxas_verbose = 0
```