### PR TITLE
Skip stride_order when it is a canonical row-major storage.

### DIFF
--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1256,7 +1256,7 @@ struct TensorRecord : RecordFunctor {
     // stride_order_, but currently alloc_domain support isn't ideal and could
     // prevent vectorization. Adding this workaround to restore performance.
     std::vector<int64_t> stride_order;
-    for (auto i = c10::range(stride_order_.size())) {
+    for (auto i : c10::range(stride_order_.size())) {
       if (stride_order_[i] != stride_order_.size() - i - 1) {
         // detect permutation in stride_order_, apply stride_order and break;
         stride_order = stride_order_;

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1257,7 +1257,7 @@ struct TensorRecord : RecordFunctor {
     // prevent vectorization. Adding this workaround to restore performance.
     std::vector<int64_t> stride_order;
     for (auto i : c10::irange(stride_order_.size())) {
-      if (stride_order_[i] != stride_order_.size() - i - 1) {
+      if (stride_order_[i] != (int64_t)(rank - 1 - i)) {
         // detect permutation in stride_order_, apply stride_order and break;
         stride_order = stride_order_;
         break;

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1251,13 +1251,26 @@ struct TensorRecord : RecordFunctor {
       is_expand[index] = is_broadcast && has_non_broadcast_size;
     }
 
+    // skip stride_order if it's alloc_domain is in the same order as with root
+    // domain. We don't need this and we should be able to just use
+    // stride_order_, but currently alloc_domain support isn't ideal and could
+    // prevent vectorization. Adding this workaround to restore performance.
+    std::vector<int64_t> stride_order;
+    for (auto i = c10::range(stride_order_.size())) {
+      if (stride_order_[i] != stride_order_.size() - i - 1) {
+        // detect permutation in stride_order_, apply stride_order and break;
+        stride_order = stride_order_;
+        break;
+      }
+    }
+
     auto tv = TensorViewBuilder()
                   .ndims(shape_.size())
                   .contiguity(contiguity_)
                   .shape(shape_)
                   .dtype(dtype_)
                   .expanded(std::move(is_expand))
-                  .strideOrder(stride_order_)
+                  .strideOrder(stride_order)
                   .build();
 
     if (shape_.empty() && is_cpu_) {

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1256,7 +1256,7 @@ struct TensorRecord : RecordFunctor {
     // stride_order_, but currently alloc_domain support isn't ideal and could
     // prevent vectorization. Adding this workaround to restore performance.
     std::vector<int64_t> stride_order;
-    for (auto i : c10::range(stride_order_.size())) {
+    for (auto i : c10::irange(stride_order_.size())) {
       if (stride_order_[i] != stride_order_.size() - i - 1) {
         // detect permutation in stride_order_, apply stride_order and break;
         stride_order = stride_order_;


### PR DESCRIPTION
This would allow us to temporarily ignore the performance issue resulted from the lack of support on alloc_domain in vectorization support.