### PR TITLE
Clean up SegmentCandidateFinder::forwardInputs()

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -3482,36 +3482,40 @@ void SegmentCandidateFinder::forwardInputs() {
   // treated as complete fusion inputs.
   VectorOfUniqueEntries<Val*> forwarded_inputs;
   {
-    std::deque<Expr*> to_visit;
+    std::deque<UnaryOp*> to_visit;
     for (auto inp : completeFusion()->inputs()) {
+      // Add all uses of input if all of those uses are UnaryOps
+      // If any of these ops are not UnaryOps then we
       if (std::all_of(inp->uses().begin(), inp->uses().end(), [](Expr* expr) {
             return expr->isA<UnaryOp>();
           })) {
-        to_visit.insert(to_visit.end(), inp->uses().begin(), inp->uses().end());
+        for (auto use : inp->uses()) {
+          to_visit.push_back(use->as<UnaryOp>());
+        }
       }
     }
 
     while (!to_visit.empty()) {
-      auto expr = to_visit.front();
+      UnaryOp* uop = to_visit.front();
       to_visit.pop_front();
-      if (!expr->isA<UnaryOp>() || expr->output(0)->isFusionOutput()) {
+      if (uop->out()->isFusionOutput()) {
         continue;
       }
 
-      // expr is a unary op so there is a single output. Here we look at that
+      // uop is a UnaryOp so there is a single output. Here we look at that
       // output's further uses
-      const auto& output_uses = expr->output(0)->uses();
+      const auto& output_uses = uop->out()->uses();
 
       if (output_uses.size() == 1 && output_uses[0]->isA<UnaryOp>()) {
-        // If there is a single use, visit it to try and extend the chain of
-        // unaryOps
-        to_visit.emplace_back(output_uses.at(0));
+        // If there is a single use which is also a UnaryOp, visit it to try
+        // and extend the chain of unaryOps
+        to_visit.emplace_back(output_uses[0]->as<UnaryOp>());
       } else {
-        // If there are either no more uses, or more than one use, we cannot
-        // extend the chain of unary Ops. In either case, finalize this chain by
-        // saving the expr and its output.
-        excluded_inp_unary_exprs_.pushBack(expr);
-        forwarded_inputs.pushBack(expr->output(0));
+        // If there are either no more uses, more than one use, or one use that
+        // is not a UnaryOp, then we cannot extend the chain of unary Ops. In
+        // these cases we finalize this chain by saving the uop and its output.
+        excluded_inp_unary_exprs_.pushBack(uop);
+        forwarded_inputs.pushBack(uop->out());
       }
     }
   }


### PR DESCRIPTION
This change removes a redundant check and makes it explicit that `to_visit` includes only `UnaryOp`s. The comments are slightly modified for clarity as well.