### PR TITLE
Alloc patch follow up

### DIFF
--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1251,26 +1251,13 @@ struct TensorRecord : RecordFunctor {
       is_expand[index] = is_broadcast && has_non_broadcast_size;
     }
 
-    // skip stride_order if it's alloc_domain is in the same order as with root
-    // domain. We don't need this and we should be able to just use
-    // stride_order_, but currently alloc_domain support isn't ideal and could
-    // prevent vectorization. Adding this workaround to restore performance.
-    std::vector<int64_t> stride_order;
-    for (auto i : c10::irange(stride_order_.size())) {
-      if (stride_order_[i] != (int64_t)(rank - 1 - i)) {
-        // detect permutation in stride_order_, apply stride_order and break;
-        stride_order = stride_order_;
-        break;
-      }
-    }
-
     auto tv = TensorViewBuilder()
                   .ndims(shape_.size())
                   .contiguity(contiguity_)
                   .shape(shape_)
                   .dtype(dtype_)
                   .expanded(std::move(is_expand))
-                  .strideOrder(stride_order)
+                  .strideOrder(stride_order_)
                   .build();
 
     if (shape_.empty() && is_cpu_) {

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1490,7 +1490,21 @@ TensorViewBuilder& TensorViewBuilder::strideOrder(
     NVF_CHECK(ndims_ == 0 || ndims_ == stride_order.size());
     ndims_ = stride_order.size();
   }
-  stride_order_ = std::move(stride_order);
+
+  // TODO: this shouldn't be necessary. For details see issue
+  // https://github.com/NVIDIA/Fuser/issues/1399
+  //
+  // skip stride_order if its alloc_domain is in the same order as with rfactor
+  // domain. We don't need this and we should be able to just use stride_order_,
+  // but currently alloc_domain support isn't ideal and could prevent
+  // vectorization. Adding this workaround to restore performance.
+  if (std::adjacent_find(
+          stride_order.begin(), stride_order.end(), [](int64_t l, int64_t r) {
+            return l != r + 1;
+          }) != stride_order.end()) {
+    // stride_order is not in descending order, we cannot skip it.
+    stride_order_ = std::move(stride_order);
+  }
   return *this;
 }
 

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1500,7 +1500,7 @@ TensorViewBuilder& TensorViewBuilder::strideOrder(
   // vectorization. Adding this workaround to restore performance.
   if (std::adjacent_find(
           stride_order.begin(), stride_order.end(), [](int64_t l, int64_t r) {
-            return l != r + 1;
+            return l <= r;
           }) != stride_order.end()) {
     // stride_order is not in descending order, we cannot skip it.
     stride_order_ = std::move(stride_order);

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1303,9 +1303,9 @@ TEST_F(AllocationDomainTest, TrivialStrideOrderTensorViewBuilder) {
   Fusion fusion;
   FusionGuard fg(&fusion);
   TensorView* tv0 = TensorViewBuilder().ndims(2).strideOrder({0, 1}).build();
-  ASSERT_TRUE(tv0->hasAllocation());
+  EXPECT_TRUE(tv0->hasAllocation());
   tv0 = TensorViewBuilder().ndims(2).strideOrder({1, 0}).build();
-  ASSERT_TRUE(!tv0->hasAllocation());
+  EXPECT_TRUE(!tv0->hasAllocation());
 }
 
 } // namespace nvfuser

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1299,4 +1299,13 @@ TEST_F(AllocationDomainTest, Issue1290_ReplayCasPFailedDueToDifferentRanks) {
   EXPECT_THAT(out_tensor.sizes(), ElementsAre(2));
 }
 
+TEST_F(AllocationDomainTest, TrivialStrideOrderTensorViewBuilder) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  TensorView* tv0 = TensorViewBuilder().ndims(2).strideOrder({0, 1}).build();
+  ASSERT_TRUE(tv0.hasAllocation());
+  tv0 = TensorViewBuilder().ndims(2).strideOrder({1, 0}).build();
+  ASSERT_TRUE(!tv0.hasAllocation());
+}
+
 } // namespace nvfuser

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1303,9 +1303,9 @@ TEST_F(AllocationDomainTest, TrivialStrideOrderTensorViewBuilder) {
   Fusion fusion;
   FusionGuard fg(&fusion);
   TensorView* tv0 = TensorViewBuilder().ndims(2).strideOrder({0, 1}).build();
-  ASSERT_TRUE(tv0.hasAllocation());
+  ASSERT_TRUE(tv0->hasAllocation());
   tv0 = TensorViewBuilder().ndims(2).strideOrder({1, 0}).build();
-  ASSERT_TRUE(!tv0.hasAllocation());
+  ASSERT_TRUE(!tv0->hasAllocation());
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
1. moved the skip trivial allocation logic on inputs from `TensorRecord` to `TensorViewBuilder`;
2. updated comment with issue/TODO linked.
3. Added c++ test coverage