### PR TITLE
Disabling duplicated inputs

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -984,6 +984,8 @@ std::vector<at::Tensor> allocateOutputs(
 
   for (const auto output_idx : c10::irange(output_info.size())) {
     Val* out = kernel->outputs()[output_idx];
+    // TODO: remove the else block and outputs_map when output aliasing is
+    // handled properly
     auto iter = outputs_map.find(out);
     if (iter == outputs_map.end()) {
       auto [aliased_in, alias_info] = kernel->getOutputAlias(out);

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -979,26 +979,36 @@ std::vector<at::Tensor> allocateOutputs(
 
   std::vector<at::Tensor> outputs;
   outputs.reserve(output_info.size());
+
+  std::unordered_map<Val*, at::Tensor> outputs_map;
+
   for (const auto output_idx : c10::irange(output_info.size())) {
     Val* out = kernel->outputs()[output_idx];
-    auto [aliased_in, alias_info] = kernel->getOutputAlias(out);
-    at::Tensor aliased_in_tensor;
-    if (aliased_in != nullptr) {
-      const PolymorphicValue& aliased_in_val =
-          *inputs[IndexOfFusionInput(aliased_in, kernel)];
-      NVF_ERROR(
-          aliased_in_val.is<at::Tensor>(),
-          "Alias io only supports tensor. Found ",
-          PolymorphicValue_functions::toString(aliased_in_val));
-      aliased_in_tensor = aliased_in_val.as<at::Tensor>();
+    auto iter = outputs_map.find(out);
+    if (iter == outputs_map.end()) {
+      auto [aliased_in, alias_info] = kernel->getOutputAlias(out);
+      at::Tensor aliased_in_tensor;
+      if (aliased_in != nullptr) {
+        const PolymorphicValue& aliased_in_val =
+            *inputs[IndexOfFusionInput(aliased_in, kernel)];
+        NVF_ERROR(
+            aliased_in_val.is<at::Tensor>(),
+            "Alias io only supports tensor. Found ",
+            PolymorphicValue_functions::toString(aliased_in_val));
+        aliased_in_tensor = aliased_in_val.as<at::Tensor>();
+      }
+      auto output = allocateOutput(
+          output_info[output_idx],
+          aliased_in,
+          alias_info,
+          aliased_in_tensor,
+          device,
+          ee);
+      outputs_map[out] = output;
+      outputs.push_back(output);
+    } else {
+      outputs.push_back(iter->second);
     }
-    outputs.push_back(allocateOutput(
-        output_info[output_idx],
-        aliased_in,
-        alias_info,
-        aliased_in_tensor,
-        device,
-        ee));
   }
   return outputs;
 }

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -242,6 +242,11 @@ void Fusion::addInput(Val* input) {
         "Immediate scalar value cannot be added as an input. It is not necessary to pass it as an input.");
   }
 
+  NVF_CHECK(
+      std::find(inputs_.begin(), inputs_.end(), input) == inputs_.end(),
+      "Val: ",
+      input->toString(),
+      " is already registered as input, duplicated inputs is not allowed");
   inputs_.push_back(input);
   input->setIsFusionInput(true);
 

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -243,7 +243,7 @@ void Fusion::addInput(Val* input) {
   }
 
   NVF_CHECK(
-      std::find(inputs_.begin(), inputs_.end(), input) == inputs_.end(),
+      !input->isFusionInput(),
       "Val: ",
       input->toString(),
       " is already registered as input, duplicated inputs is not allowed");

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -625,4 +625,13 @@ TEST_F(AliasTest, DuplicatedOutputs) {
       __FILE__);
 }
 
+TEST_F(AliasTest, DuplicatedInputs) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({2, 3, 5});
+  fusion->addInput(in);
+  fusion->addInput(in);
+}
+
 } // namespace nvfuser

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -626,12 +626,17 @@ TEST_F(AliasTest, DuplicatedOutputs) {
 }
 
 TEST_F(AliasTest, DuplicatedInputs) {
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
+  EXPECT_THAT(
+      []() {
+        auto fusion = std::make_unique<Fusion>();
+        FusionGuard fg(fusion.get());
 
-  TensorView* in = makeContigConcreteTensor({2, 3, 5});
-  fusion->addInput(in);
-  fusion->addInput(in);
+        TensorView* in = makeContigConcreteTensor({2, 3, 5});
+        fusion->addInput(in);
+        fusion->addInput(in);
+      },
+      testing::ThrowsMessage<nvfuser::nvfError>(
+          testing::HasSubstr("duplicated inputs is not allowed")));
 }
 
 } // namespace nvfuser

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -633,7 +633,7 @@ TEST_F(AliasTest, DuplicatedInputs) {
 
   // duplicated input is not allowed
   EXPECT_THAT(
-      []() {
+      [&]() {
         fusion->addInput(in);
       },
       testing::ThrowsMessage<nvfuser::nvfError>(

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -382,12 +382,7 @@ TEST_F(AliasTest, DuplicateOutputs) {
 
   at::Tensor expected_out_tensor = in_tensor.add(3.141);
   // Verify output values.
-  testValidate(
-      fec.fusion(),
-      out_tensors,
-      {in_tensor},
-      __LINE__,
-      __FILE__);
+  testValidate(fec.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 }
 
 TEST_F(AliasTest, SliceToSizeOne_Issue1353) {
@@ -529,12 +524,7 @@ TEST_F(AliasTest, DuplicateOutputsSegmentedFusion) {
   at::Tensor intermediate_tensor = in_tensor.add(3.141);
   at::Tensor out_tensor = intermediate_tensor.mul(2.0);
   // Verify output values.
-  testValidate(
-      fec.fusion(),
-      out_tensors,
-      {in_tensor},
-      __LINE__,
-      __FILE__);
+  testValidate(fec.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 }
 
 TEST_F(AliasTest, NotAllOutputsAlias) {
@@ -589,7 +579,7 @@ TEST_F(AliasTest, Set_NoAliasForIncompatibleLayout) {
 }
 
 // Verifying that duplicated outputs are properly alised
-TEST_F(AliasTest, DuplicatedOutputs) {
+TEST_F(AliasTest, DuplicateOutputsComplex) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -616,16 +606,11 @@ TEST_F(AliasTest, DuplicatedOutputs) {
   EXPECT_TRUE(out_tensors[0].is_alias_of(out_tensors[3]));
 
   // Verify output values.
-  testValidate(
-      fec.fusion(),
-      out_tensors,
-      {in_tensor},
-      __LINE__,
-      __FILE__);
+  testValidate(fec.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 }
 
 // test verifying that duplicated input is not allowed in nvfuser
-TEST_F(AliasTest, DuplicatedInputs) {
+TEST_F(AliasTest, DuplicateInputs) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
   TensorView* in = makeContigConcreteTensor({2, 3, 5});
@@ -633,9 +618,7 @@ TEST_F(AliasTest, DuplicatedInputs) {
 
   // duplicated input is not allowed
   EXPECT_THAT(
-      [&]() {
-        fusion->addInput(in);
-      },
+      [&]() { fusion->addInput(in); },
       testing::ThrowsMessage<nvfuser::nvfError>(
           testing::HasSubstr("duplicated inputs is not allowed")));
 }

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -985,7 +985,7 @@ TEST_F(VectorizeHelperTest, SpanningTree_CUDA) {
         }
         auto fusion_inps = fusion.inputs();
         for (auto inp : fusion_inps) {
-          fusion.removeOutput(inp);
+          fusion.removeInput(inp);
         }
       }
 


### PR DESCRIPTION
1. disabling duplicated inputs (user registering input multiple times). It's scary to think about what the expectation is, when user register a single input tensor multiple times. Disabling it for now.
2. adding a test case to verify the proper behavior for duplicated output, which is supported by codegen.
