### PR TITLE
Combine a mul-sum pair to a mma op

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/test/test_multidevice_pipeline.cpp
     ${NVFUSER_ROOT}/test/test_multidevice_communications.cpp
     ${NVFUSER_ROOT}/test/test_combined_inner_outer_reduction.cpp
+    ${NVFUSER_ROOT}/test/test_combine_mul_sum.cpp
     ${NVFUSER_ROOT}/test/test_optimization_pass.cpp
     ${NVFUSER_ROOT}/test/test_pipeline.cpp
     ${NVFUSER_ROOT}/test/test_rng.cpp

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1229,6 +1229,163 @@ RolesMapOpt getTensorsRoles(Fusion* fusion) {
   return roles_map;
 }
 
+namespace {
+
+void addMMAOp(Fusion* fusion_, std::vector<MulSumAsMmaProps>& props) {
+  auto* init = IrBuilder::create<Val>(0.0);
+  for (auto prop : props) {
+    IrBuilder::create<MmaOp>(prop.out, prop.a, prop.b, init);
+  }
+}
+
+// Check the val (in) is the output of broadcast.
+// Then check the output of the broadcast is 3D (4D for bmm).
+bool hasValidBroadcastOp(TensorView* bcast_out) {
+  // First check the tensorsview is 3D (4D)
+  // and has one broadcast dim.
+  auto dims = bcast_out->domain()->nDims();
+  if (!((dims == 3 || dims == 4) &&
+        bcast_out->domain()->noBroadcasts().size() == dims - 1)) {
+    return false;
+  }
+
+  // Check if the definition is a broadcast op.
+  if (dynamic_cast<BroadcastOp*>(bcast_out->definition())) {
+    return true;
+  }
+
+  return false;
+}
+
+// This function checks if the mul-sum can be replace with a mma op. The checks
+// are:
+// 1. The inputs to the muls are broadcast ops.
+// 2. The broadcasts have 2D or 3D(bmm) inputs.
+// 3. The broadcasts only broadcast one dim and the dims are different for the 2
+// muls.
+// 4. There is a single reduction dim, and that dim that is not either of the
+// broadcast dims.
+bool broadcastsAreValid(
+    TensorView* left,
+    TensorView* right,
+    unsigned int reduction_axis) {
+  if (!(hasValidBroadcastOp(left) && hasValidBroadcastOp(right))) {
+    return false;
+  }
+
+  auto bcast_l = dynamic_cast<BroadcastOp*>(left->definition());
+  auto bcast_r = dynamic_cast<BroadcastOp*>(right->definition());
+
+  // Ensure that only one dim is getting broadcast.
+  auto bcastFlags_l = bcast_l->getBroadcastDimFlags();
+  auto bcastFlags_r = bcast_r->getBroadcastDimFlags();
+  auto count_l = std::count(bcastFlags_l.begin(), bcastFlags_l.end(), true);
+  auto count_r = std::count(bcastFlags_r.begin(), bcastFlags_r.end(), true);
+  if ((count_l != 1) || (count_l != count_r)) {
+    return false;
+  }
+
+  // Also ensure that it's not the same dim for the two muls. that's
+  // getting broadcast.
+  auto idx_l = std::find(bcastFlags_l.begin(), bcastFlags_l.end(), true) -
+      bcastFlags_l.begin();
+  auto idx_r = std::find(bcastFlags_r.begin(), bcastFlags_r.end(), true) -
+      bcastFlags_r.begin();
+  if (idx_l == idx_r) {
+    return false;
+  }
+
+  // Also ensure that the reduction dim is not either of the broadcast dim.
+  if (reduction_axis == idx_l || reduction_axis == idx_r) {
+    return false;
+  }
+
+  // Check different dimensions are the broadcast dims.
+  return true;
+}
+
+// If the tensorview is a output of a cast operation, then
+// return the input to the cast operation, else return the tensorview.
+TensorView* getTensorviewPriorToCast(TensorView* in) {
+  if (auto uCastOp = dynamic_cast<UnaryOp*>(in->definition());
+      uCastOp && uCastOp->getUnaryOpType() == UnaryOpType::Cast) {
+    return static_cast<TensorView*>(uCastOp->in());
+  }
+  return in;
+}
+
+// Check if the Mul-Sum pair represents a matmul. If so, add the properties
+// of the mma op which can be a tentatice substitue. This checks that the output
+// of sum has on reduction axis, and the inputs to mul are valid broadcasts.
+std::optional<MulSumAsMmaProps> getMulSumInsOutsBcasts(
+    BinaryOp* mop,
+    ReductionOp* redop) {
+  auto a = getTensorviewPriorToCast(static_cast<TensorView*>(mop->lhs()));
+  auto b = getTensorviewPriorToCast(static_cast<TensorView*>(mop->rhs()));
+
+  // Get the dimension of the reduction in the output. If not present, bail.
+  // Also ensure there is only only reduction axis.
+  auto red_axis = static_cast<TensorView*>(redop->out())->getReductionAxis();
+  auto num_reduction_dims =
+      static_cast<TensorView*>(redop->out())->domain()->nDims() -
+      static_cast<TensorView*>(redop->out())->domain()->noReductions().size();
+  if (!red_axis.has_value() || num_reduction_dims > 1) {
+    return std::nullopt;
+  }
+
+  if (broadcastsAreValid(a, b, *red_axis)) {
+    return MulSumAsMmaProps(
+        mop,
+        redop,
+        a,
+        b,
+        static_cast<TensorView*>(redop->output(0)),
+        dynamic_cast<BroadcastOp*>(a->definition()),
+        dynamic_cast<BroadcastOp*>(b->definition()));
+  }
+  return std::nullopt;
+}
+} // namespace
+
+void CombineMulSum::handle(ReductionOp* stmt) {
+  // Check if operation is a sum.
+  if (stmt->getReductionOpType() == BinaryOpType::Add) {
+    auto* inputOfSum = stmt->in();
+    if (inputOfSum != nullptr) {
+      auto* expr = inputOfSum->definition();
+      // Then check if the prodcer of the sum is a mul.
+      if (auto bOp = dynamic_cast<BinaryOp*>(expr)) {
+        // If it'a mul followed by a sum, put this in a list.
+        if (bOp->getBinaryOpType() == BinaryOpType::Mul) {
+          // If the Mul-Sum is a valid representation of a matmul,
+          // then get the properties of the replacement Mma op.
+          auto props = getMulSumInsOutsBcasts(bOp, stmt);
+          if (props.has_value()) {
+            mul_sum_props_.push_back(*props);
+          }
+        }
+      }
+    }
+  }
+};
+
+std::vector<MulSumAsMmaProps> CombineMulSum::generateMulSumCanidates(
+    bool use_cached_results) {
+  if (use_cached_results && !mul_sum_props_.empty()) {
+    return mul_sum_props_;
+  }
+  traverse(fusion_);
+  return mul_sum_props_;
+}
+
+void CombineMulSum::replaceWithMmaOp() {
+  // Recreate the mul-sum pairs since someone
+  // may run this function more than once.
+  generateMulSumCanidates();
+  addMMAOp(fusion_, mul_sum_props_);
+  return;
+}
+
 } // namespace mma_utils
 
 } // namespace nvfuser

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -300,6 +300,63 @@ std::pair<bool, bool> generateSharedMemoryEpilogueHeuristics(
     bool smem_b_reuse_guaranteed = false,
     bool ignore_occupancy_drop = false);
 
+struct MulSumAsMmaProps {
+  MulSumAsMmaProps(
+      BinaryOp* m,
+      ReductionOp* r,
+      TensorView* at = nullptr,
+      TensorView* bt = nullptr,
+      TensorView* out_t = nullptr,
+      BroadcastOp* bc_a = nullptr,
+      BroadcastOp* bc_b = nullptr)
+      : mop(m),
+        redop(r),
+        a(at),
+        b(bt),
+        out(out_t),
+        bcast_a(bc_a),
+        bcast_b(bc_b){};
+
+  BinaryOp* mop;
+  ReductionOp* redop;
+  TensorView* a;
+  TensorView* b;
+  TensorView* out;
+  BroadcastOp* bcast_a;
+  BroadcastOp* bcast_b;
+};
+
+//! Go through the fusion IR to find combinations of mul-sum
+//! which can be replaced with a mma op. This class operates
+//! in two phases. It can go through the graph and find the mul-sum
+//! pairs which can be replaced by a mma op. This phase returns a vector
+//! of properties of the mma op (MulSumAsMmaProps) which would replace the
+//! the mul-sum pair. It then exposes a function to replace with mma ops.
+class CombineMulSum : public IterVisitor {
+ public:
+  CombineMulSum(Fusion* fusion) : IterVisitor(), fusion_(fusion){};
+
+  //! Goes through the fusion to find mul-sum pairs.
+  //! If user sets the caching flags and properties have been previously
+  //! computed, then just return cached results.
+  std::vector<MulSumAsMmaProps> generateMulSumCanidates(
+      bool use_cached_results = false);
+
+  //! Replaces the candidate mul-sum pairs with mma ops.
+  //! Please not this will run generateMulSumCandidates again.
+  void replaceWithMmaOp();
+
+ protected:
+  void handle(ReductionOp* stmt) override;
+
+ private:
+  Fusion* fusion_;
+  //! This is the list of mul-sum pairs and the properties
+  //! of the mma op which can replace it. This is only populated
+  //! if the mul-sum pair is a valid replacement candidate.
+  std::vector<MulSumAsMmaProps> mul_sum_props_ = {};
+};
+
 } // namespace mma_utils
 
 } // namespace nvfuser

--- a/test/test_combine_mul_sum.cpp
+++ b/test/test_combine_mul_sum.cpp
@@ -1,0 +1,190 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION &
+ * AFFILIATES. All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <macros.h>
+
+#include <csrc/exceptions.h>
+#include <gtest/gtest.h>
+
+#include <codegen.h>
+#include <device_lower/analysis/bank_conflict.h>
+#include <device_lower/lower2device.h>
+#include <disjoint_set.h>
+#include <executor.h>
+#include <executor_params.h>
+#include <expr_evaluator.h>
+#include <fusion.h>
+#include <fusion_segmenter.h>
+#include <ir/all_nodes.h>
+#include <ir/iostream.h>
+#include <ir/printer.h>
+#include <ir/utils.h>
+#include <iter_visitor.h>
+#include <kernel_cache.h>
+#include <kernel_ir.h>
+#include <mma_type.h>
+#include <ops/all_ops.h>
+#include <root_domain_map.h>
+#include <scheduler/all_schedulers.h>
+#include <scheduler/matmul.h>
+#include <scheduler/mma_utils.h>
+#include <scheduler/reduction_utils.h>
+#include <scheduler/utils.h>
+#include <test/utils.h>
+#include <test/validator.h>
+
+namespace nvfuser {
+
+class CombineMulSumAsMmaTest : public NVFuserTest {};
+
+// Test checks to see that the combiner can correctly replace
+// the mul-sum pair with a mma op.
+TEST_F(CombineMulSumAsMmaTest, AmpereMulSumToMatmul_Pass) {
+  // Assumes layout is kAllSupportedMmaLayout::NT;
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  auto tv0 = makeContigTensor(2, DataType::Half);
+  auto tv1 = makeContigTensor(2, DataType::Half);
+
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  auto tv0t = transpose(tv0, 0, 1);
+  auto tv1t = transpose(tv1, 0, 1);
+
+  std::vector<bool> bcast_dims(tv0->nDims() + 1, false);
+  bcast_dims.at(bcast_dims.size() - 2) = true;
+  auto tv0b = broadcast(tv0t, bcast_dims);
+  bcast_dims.at(bcast_dims.size() - 2) = false;
+  bcast_dims.at(bcast_dims.size() - 3) = true;
+  auto tv1b = broadcast(tv1t, bcast_dims);
+  auto tv2 = mul(tv0b, tv1b);
+  auto tv3 = sum(tv2, {-1});
+  fusion.addOutput(tv3);
+
+  ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
+
+  nvfuser::mma_utils::CombineMulSum combiner(&fusion);
+  combiner.replaceWithMmaOp();
+
+  ASSERT_FALSE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
+}
+
+// This test checks that the combiner does not incorrectly
+// replace this mul-sum pair, and the mul is not fed by broadcasts ops.
+TEST_F(CombineMulSumAsMmaTest, AmpereMulSumToMatmul_Fail1) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  auto tv0 = makeContigTensor(3, DataType::Half);
+  auto tv1 = makeContigTensor(3, DataType::Half);
+
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  auto tv2 = mul(tv0, tv1);
+  auto tv3 = sum(tv2, {-1});
+  fusion.addOutput(tv3);
+
+  nvfuser::mma_utils::CombineMulSum combiner(&fusion);
+  combiner.replaceWithMmaOp();
+
+  ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
+}
+
+// This test checks to see that the mul-sum combiner does not
+// combine a mul-sum which does not have appropriate broadcasts.
+TEST_F(CombineMulSumAsMmaTest, AmpereMulSumToMatmul_Fail2) {
+  // Assumes layout is kAllSupportedMmaLayout::NT;
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  auto tv0 = makeContigTensor(2, DataType::Half);
+  auto tv1 = makeContigTensor(2, DataType::Half);
+
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  auto tv0t = transpose(tv0, 0, 1);
+  auto tv1t = transpose(tv1, 0, 1);
+
+  // We are broadcating to a tensor that will have too many dims
+  // to be valid for a mma op.
+  std::vector<bool> bcast_dims(tv0->nDims() + 2, false);
+  bcast_dims.at(bcast_dims.size() - 2) = true;
+  bcast_dims.at(bcast_dims.size() - 3) = true;
+  auto tv0b = broadcast(tv0t, bcast_dims);
+  bcast_dims.at(bcast_dims.size() - 2) = false;
+  bcast_dims.at(bcast_dims.size() - 3) = true;
+  bcast_dims.at(bcast_dims.size() - 4) = true;
+  auto tv1b = broadcast(tv1t, bcast_dims);
+  auto tv2 = mul(tv0b, tv1b);
+  auto tv3 = sum(tv2, {-1});
+  fusion.addOutput(tv3);
+
+  ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
+
+  nvfuser::mma_utils::CombineMulSum combiner(&fusion);
+  combiner.replaceWithMmaOp();
+
+  ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
+}
+
+// As a sanity check we test that after replacing a mul-sum
+// pair with a mma op, we are able to schedule it as we did with
+// a fusion that had a mma op to begin with.
+TEST_F(CombineMulSumAsMmaTest, AmpereMulSumToMatmul_Schedule) {
+  // Keep multiples of 8 to keep vectorizable.
+  int M = 504, N = 136, K = 248;
+
+  for (auto layout : kAllSupportedMmaLayout) {
+    Fusion fusion;
+    FusionGuard fg(&fusion);
+    auto tv0 = makeContigTensor(2, DataType::Half);
+    auto tv1 = makeContigTensor(2, DataType::Half);
+
+    fusion.addInput(tv0);
+    fusion.addInput(tv1);
+
+    auto tv2 = matmul(tv0, tv1, layout, true, true);
+    fusion.addOutput(tv2);
+    ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
+
+    nvfuser::mma_utils::CombineMulSum combiner(&fusion);
+    combiner.replaceWithMmaOp();
+    ASSERT_FALSE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
+
+    MatMulTileOptions gemm_tile;
+    gemm_tile.cta_tile = GemmTile(128, 128, 32);
+    gemm_tile.warp_tile = GemmTile(64, 64, 32);
+    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+    MatmulParams params;
+    params.mma_macro = MmaMacro::Ampere_16_8_16;
+    params.tile_sizes = gemm_tile;
+    params.async_gmem_load_operands = true;
+    params.double_buffer_options.double_buffer_smem_write = true;
+    params.double_buffer_options.double_buffer_smem_read = true;
+    params.double_buffer_options.smem_double_buffer_stage = 4;
+    scheduleMatmul(&fusion, params);
+
+    auto inputs = matmulAtInput(M, N, K, layout);
+
+    FusionExecutor fe;
+    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+        8,
+        0,
+        fe.compileFusion(
+            &fusion,
+            {inputs.first, inputs.second},
+            LaunchParams(),
+            matmul_cparams));
+    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+    auto tref = atMatmul(
+        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+  }
+}
+
+} // namespace nvfuser

--- a/test/utils.h
+++ b/test/utils.h
@@ -589,12 +589,14 @@ static constexpr std::array<MmaLayout, 4> kAllSupportedMmaLayout = {
     MmaLayout::NN};
 
 // Generic interface to get matmul op with the given layout.
+// The as_mul_sum flags creates a mul and sum ops instead of mma
+// to express matmuls. This flag only works for Ampere.
 TensorView* matmul(
     TensorView* a,
     TensorView* b,
     MmaLayout layout,
-    bool turing_or_later // TODO: This is a temporary solution. Remove this!
-);
+    bool turing_or_later, // TODO: This is a temporary solution. Remove this!
+    bool as_mul_sum = false);
 
 // Generic interface to get splitK-like batched matmul op with the given layout.
 // For splitK like batched matmul, there is only one batch dimension, and that


### PR DESCRIPTION
Adding a stand alone pass to combine a mul-sum pair to a mma op.
There's an unit test case to try it out.

The next step will be to invoke this pass from the matmul scheduler. 