### PR TITLE
Minor cleanup.

### DIFF
--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -406,14 +406,16 @@ std::string ExprGroup::toString() const {
   os << " ca_ids {";
   for (size_t i = 0; i < payload()->ca_domains.size(); i++) {
     os << payload()->ca_domains[i];
-    if (i + 1 != payload()->ca_domains.size())
+    if (i + 1 != payload()->ca_domains.size()) {
       os << ", ";
+    }
   }
   os << "} pa_ids {";
   for (size_t i = 0; i < payload()->pa_domains.size(); i++) {
     os << payload()->pa_domains[i];
-    if (i + 1 != payload()->pa_domains.size())
+    if (i + 1 != payload()->pa_domains.size()) {
       os << ", ";
+    }
   }
   os << "}";
   os << "\nExprs {\n";

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1716,12 +1716,12 @@ std::vector<Expr*> ExprSegmentationSorter::getExprs() const {
   std::vector<Expr*> remaining_exprs; // Tensor expressions or scalar
                                       // expressions that has tensor dependency.
   for (auto& group : groups_) {
-    std::vector<Expr*>* active_exprs = &scalar_exprs_without_tv_dep;
-    for (auto expr : group->exprs()) {
-      if (!lower_utils::isScalarExpr(expr)) {
-        active_exprs = &remaining_exprs;
+    for (Expr* expr : group->exprs()) {
+      if (lower_utils::isScalarExpr(expr)) {
+        scalar_exprs_without_tv_dep.push_back(expr);
+      } else {
+        remaining_exprs.push_back(expr);
       }
-      active_exprs->emplace_back(expr);
     }
   }
   scalar_exprs_without_tv_dep.insert(


### PR DESCRIPTION
The indirection caused by `active_exprs` is not worthwhile.