### PR TITLE
Move `TensorMapSwizzle` to `mma_type.h` and rename as `MmaInputSmemSwizzle`

### DIFF
--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -3285,7 +3285,7 @@ Val* Index::cpAsyncBulkIndex(
       box_dim,
       element_strides,
       TensorMapInterleave::NoInterleave,
-      TensorMapSwizzle::NoSwizzle,
+      MmaInputSmemSwizzle::None,
       TensorMapL2Promotion::NoL2Promotion,
       TensorMapFloatOOBFill::NoOOBFill);
 

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -1579,7 +1579,7 @@ EncodeTensorMapTiled::EncodeTensorMapTiled(
     Val* box_dim,
     Val* element_strides,
     tma::TensorMapInterleave interleave,
-    tma::TensorMapSwizzle swizzle,
+    MmaInputSmemSwizzle swizzle,
     tma::TensorMapL2Promotion l2_promotion,
     tma::TensorMapFloatOOBFill oob_fill)
     : Expr(passkey) {
@@ -1633,7 +1633,7 @@ std::string EncodeTensorMapTiled::toString(int indent_size) const {
                           << ", element_strides="
                           << elementStrides()->toString()
                           << ", interleave=" << interleave()
-                          << ", swizzle=" << swizzle()
+                          << ", swizzle=" << nvfuser::toString(swizzle())
                           << ", l2_promotion=" << l2Promotion()
                           << ", oob_fill=" << oobFill() << ")\n";
   return ss.str();
@@ -1647,7 +1647,8 @@ std::string EncodeTensorMapTiled::toInlineString(int indent_size) const {
      << ", global_strides=" << globalStrides()->toInlineString()
      << ", box_dim=" << boxDim()->toInlineString()
      << ", element_strides=" << elementStrides()->toInlineString()
-     << ", interleave=" << interleave() << ", swizzle=" << swizzle()
+     << ", interleave=" << interleave()
+     << ", swizzle=" << nvfuser::toString(swizzle())
      << ", l2_promotion=" << l2Promotion() << ", oob_fill=" << oobFill() << ")";
   return ss.str();
 }

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -10,6 +10,7 @@
 #include <exceptions.h>
 #include <ir/all_nodes.h>
 #include <ir/base_nodes.h>
+#include <mma_type.h>
 #include <parallel_type_bitmap.h>
 #include <tma.h>
 #include <type.h>
@@ -1392,7 +1393,7 @@ class EncodeTensorMapTiled : public Expr {
       Val* box_dim,
       Val* element_strides,
       tma::TensorMapInterleave interleave,
-      tma::TensorMapSwizzle swizzle,
+      MmaInputSmemSwizzle swizzle,
       tma::TensorMapL2Promotion l2_promotion,
       tma::TensorMapFloatOOBFill oob_fill);
 
@@ -1437,8 +1438,8 @@ class EncodeTensorMapTiled : public Expr {
     return attribute<tma::TensorMapInterleave>(2);
   }
 
-  const tma::TensorMapSwizzle& swizzle() const {
-    return attribute<tma::TensorMapSwizzle>(3);
+  const MmaInputSmemSwizzle& swizzle() const {
+    return attribute<MmaInputSmemSwizzle>(3);
   }
 
   const tma::TensorMapL2Promotion& l2Promotion() const {

--- a/csrc/mma_type.cpp
+++ b/csrc/mma_type.cpp
@@ -75,6 +75,22 @@ std::string toString(MmaMacro macro) {
   return ss.str();
 }
 
+std::string toString(MmaInputSmemSwizzle swizzle) {
+  switch (swizzle) {
+    case MmaInputSmemSwizzle::None:
+      return "NoSwizzle";
+    case MmaInputSmemSwizzle::B32:
+      return "32B";
+    case MmaInputSmemSwizzle::B64:
+      return "64B";
+    case MmaInputSmemSwizzle::B128:
+      return "128B";
+    default:
+      NVF_CHECK(false, "Unknown tensor map swizzle type!");
+      break;
+  }
+}
+
 size_t hash(MmaMacro macro) {
   return std::hash<size_t>{}(static_cast<size_t>(macro));
 }

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -243,11 +243,23 @@ int getInputBRegisterSize(MmaMacro macro);
 // Unpack MMA op shape
 GemmTile getMmaOpShape(MmaMacro macro);
 
+// Warning: The values of the enum class must match the matrix descriptor as
+// specified in:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#asynchronous-warpgroup-level-matrix-shared-memory-layout-matrix-descriptor
+// Do not edit the values of the enum class unless you know what you are doing.
+enum class MmaInputSmemSwizzle {
+  None = 0,
+  B128 = 1,
+  B64 = 2,
+  B32 = 3,
+};
+
 // MMA stringify utils
 std::string toString(MmaLayout input_layout);
 std::string toString(const GemmTile& tile);
 std::string toString(const MatMulTileOptions& opts);
 std::string toString(MmaMacro macro);
+std::string toString(MmaInputSmemSwizzle swizzle);
 
 // MMA hash utils
 size_t hash(MmaMacro macro);

--- a/csrc/tma.cpp
+++ b/csrc/tma.cpp
@@ -58,15 +58,15 @@ inline CUtensorMapInterleave getCUtensorMapInterleave(
   }
 }
 
-inline CUtensorMapSwizzle getCUtensorMapSwizzle(TensorMapSwizzle swizzle) {
+inline CUtensorMapSwizzle getCUtensorMapSwizzle(MmaInputSmemSwizzle swizzle) {
   switch (swizzle) {
-    case TensorMapSwizzle::NoSwizzle:
+    case MmaInputSmemSwizzle::None:
       return CU_TENSOR_MAP_SWIZZLE_NONE;
-    case TensorMapSwizzle::B32:
+    case MmaInputSmemSwizzle::B32:
       return CU_TENSOR_MAP_SWIZZLE_32B;
-    case TensorMapSwizzle::B64:
+    case MmaInputSmemSwizzle::B64:
       return CU_TENSOR_MAP_SWIZZLE_64B;
-    case TensorMapSwizzle::B128:
+    case MmaInputSmemSwizzle::B128:
       return CU_TENSOR_MAP_SWIZZLE_128B;
     default:
       NVF_ERROR(false, "Unknown tensor map swizzle type!");
@@ -130,27 +130,6 @@ std::ostream& operator<<(std::ostream& os, TensorMapInterleave interleave) {
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, TensorMapSwizzle swizzle) {
-  switch (swizzle) {
-    case TensorMapSwizzle::NoSwizzle:
-      os << "NoSwizzle";
-      break;
-    case TensorMapSwizzle::B32:
-      os << "32B";
-      break;
-    case TensorMapSwizzle::B64:
-      os << "64B";
-      break;
-    case TensorMapSwizzle::B128:
-      os << "128B";
-      break;
-    default:
-      NVF_CHECK(false, "Unknown tensor map swizzle type!");
-      break;
-  }
-  return os;
-}
-
 std::ostream& operator<<(std::ostream& os, TensorMapL2Promotion l2_promotion) {
   switch (l2_promotion) {
     case TensorMapL2Promotion::NoL2Promotion:
@@ -195,7 +174,7 @@ Val* encodeTensorMapTiled(
     Val* box_dim,
     Val* element_strides,
     TensorMapInterleave interleave,
-    TensorMapSwizzle swizzle,
+    MmaInputSmemSwizzle swizzle,
     TensorMapL2Promotion l2_promotion,
     TensorMapFloatOOBFill oob_fill) {
   auto output = IrBuilder::create<Val>(

--- a/csrc/tma.h
+++ b/csrc/tma.h
@@ -10,6 +10,7 @@
 
 #include <ostream>
 
+#include <mma_type.h>
 #include <type.h>
 
 // Note: [TMA support in nvFuser]
@@ -84,12 +85,10 @@ namespace nvfuser {
 namespace tma {
 
 enum class TensorMapInterleave { NoInterleave, B16, B32 };
-enum class TensorMapSwizzle { NoSwizzle, B32, B64, B128 };
 enum class TensorMapL2Promotion { NoL2Promotion, B64, B128, B256 };
 enum class TensorMapFloatOOBFill { NoOOBFill, NaN_Request_Zero_FMA };
 
 std::ostream& operator<<(std::ostream& os, TensorMapInterleave interleave);
-std::ostream& operator<<(std::ostream& os, TensorMapSwizzle swizzle);
 std::ostream& operator<<(std::ostream& os, TensorMapL2Promotion l2_promotion);
 std::ostream& operator<<(std::ostream& os, TensorMapFloatOOBFill oob_fill);
 
@@ -117,7 +116,7 @@ Val* encodeTensorMapTiled(
     Val* box_dim,
     Val* element_strides,
     TensorMapInterleave interleave,
-    TensorMapSwizzle swizzle,
+    MmaInputSmemSwizzle swizzle,
     TensorMapL2Promotion l2_promotion,
     TensorMapFloatOOBFill oob_fill);
 


### PR DESCRIPTION
Because it is used not only in TMA