### PR TITLE
Print the alias analysis result when debugging.

### DIFF
--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -359,6 +359,17 @@ Layout AliasAnalysisResult::preferredLayout(const Val* v) const {
   return {tv->getMaybeAllocationDomain(), tv->getContiguity()};
 }
 
+std::string AliasAnalysisResult::toString(const int indent_size) const {
+  std::stringstream ss;
+  for (const auto& [alias, source_and_layout] : alias_to_source_) {
+    const auto& [source, layout] = source_and_layout;
+    indent(ss, indent_size)
+        << alias->toString() << " is an alias of " << source->toString()
+        << " if its layout is " << layout.toString() << std::endl;
+  }
+  return ss.str();
+}
+
 AliasAnalysisResult findAliases(Fusion* fusion) {
   AliasAnalysisResult analysis;
   AliasFinder finder(analysis);

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -40,6 +40,8 @@ class AliasAnalysisResult {
   // preferred layout.
   void add(const TensorView* alias, const TensorView* source, Layout&& layout);
 
+  std::string toString(int indent_size) const;
+
  private:
   // Maps aliases (e.g. the output of a View) to their direct sources (e.g. the
   // input of the same View). Also stores the preferred output layout for the

--- a/csrc/optimization/mark_alias.cpp
+++ b/csrc/optimization/mark_alias.cpp
@@ -15,6 +15,11 @@ namespace nvfuser::optimization {
 
 void MarkAliasPass::runPass(Fusion* fusion) {
   const AliasAnalysisResult alias_analysis = findAliases(fusion);
+  if (isDebugDumpEnabled(DebugDumpOption::PreSegmenterLogging)) {
+    debug() << "Alias analysis result:" << std::endl;
+    debug() << alias_analysis.toString(/*indent_size=*/1) << std::endl;
+  }
+
   for (TensorView* out :
        ir_utils::filterByType<TensorView>(fusion->outputs())) {
     // Lazy move: we could check compatibility and only give up when


### PR DESCRIPTION
Sample debug output:

```
$ NVFUSER_DUMP=pre_segmenter_logging bin/nvfuser_tests --gtest_filter=*AnotherOutput
...
Alias analysis result:
  T3_g[ iS13{5}, iS12{( 2 * 3 )} ] is an alias of T2_g[ iS11{( 2 * 3 )}rf, iS8{5} ] if its layout is <allocation=[iS12{( 2 * 3 )}, iS13{5}], contiguity=[t t]>
  T2_g[ iS11{( 2 * 3 )}rf, iS8{5} ] is an alias of T1_l[ iS3{2}, iS4{3}, iS5{5} ] if its layout is <allocation=[iS11{( 2 * 3 )}rf, iS8{5}], contiguity=[t t]>
```