### PR TITLE
Remove unnecessary input binding.

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -922,8 +922,6 @@ at::Tensor allocateOutput(
     ExpressionEvaluator& ee) {
   TensorView* out_tv = out_info.tv;
 
-  // Note: aliased output is not returned as output. But we still need it
-  // for kernel execution, so would need to push them to args
   if (aliased_in != nullptr) {
     const PolymorphicValue& aliased_in_val = ee.evaluate(aliased_in);
     NVF_ERROR(


### PR DESCRIPTION
Inputs are already bound at
https://github.com/NVIDIA/Fuser/blob/6b9e5b65f413338519dabd8e00c6ee3ec85c526e/csrc/executor.cpp#L1656 and
https://github.com/NVIDIA/Fuser/blob/6b9e5b65f413338519dabd8e00c6ee3ec85c526e/csrc/executor.cpp#L1268.

Cleanup for #1401 