### PR TITLE
IdModel: cleanup almost exact

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -381,7 +381,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (isOptionEnabled(EnableOption::IdModel)) {
+  if (true || isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_, false, true);
   }
 

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -824,6 +824,12 @@ void IdModel::buildAlmostExactMap() {
     // Map through trivial expressions
     for (auto mapped_id_group : mapped_ids) {
       for (auto id : mapped_id_group) {
+#if 0
+        std::cerr << "IdModel: almost exact map: "
+                  << mapped_id_group.front()->name()
+                  << ", " << id->name()
+                  << std::endl;
+#endif
         almost_exact_graph.mapVals(mapped_id_group.front(), id);
       }
     }
@@ -1054,16 +1060,12 @@ void IdModel::build(
   idGraph(IdMappingMode::EXACT) = initializeIdGraph();
 
   buildExactGraph(tv_exprs);
+  buildAlmostExactMap();
 
   if (validate) {
-    IdModelValidator::checkExactGraphEquivalence(idGraph(IdMappingMode::EXACT));
+    IdModelValidator::checkExactGraphEquivalence(*this);
   }
 
-  if (getenv("EXACT_ONLY")) {
-    return;
-  }
-
-  buildAlmostExactMap();
   buildPermissiveMap(tv_exprs);
 
   // Permissive graph needs the trivial exprs from the almost exact graph to

--- a/csrc/id_model/validation_utils.cpp
+++ b/csrc/id_model/validation_utils.cpp
@@ -13,123 +13,24 @@
 
 namespace nvfuser {
 
-#if 0
-void IdModelValidator::fullyPropagateMappings(Fusion* fusion, ComputeAtMap& ca_map) {
-
-  DisjointSets<IterDomain*>& exact_sets = ca_map.id_graph_.exact_nodes_;
-  DisjointSets<IterDomain*>& almost_exact_sets = ca_map.id_graph_.almost_exact_nodes_;
-  
-  // Propagate mappings through expressions in ComputeAtMap. Since we
-  // want to traverse and update ca_map_exact_sets, once updated, the
-  // traversal of the ID groups cannot continue and needs to be
-  // restarted. The algorithm seems terriblly inefficient, but
-  // shuldn't matter as this is just for transitory validations
-  bool updated = true;
-  while (updated) {
-    updated = false;
-    for (const auto& set : exact_sets.disjointSets()) {
-      auto uses = ca_map.uniqueExactUses(set->vector().front());
-      auto use_count = uses.size();
-      // Note that it should be fine to continue updating the map with
-      // the loop below as it should only modify output domain groups
-      for (size_t i = 0; i < use_count; ++i) {
-        auto use_i = uses.at(i);
-        for (size_t j = i + 1; j < use_count; ++j) {
-          auto use_j = uses.at(j);
-          if (!IterDomainGraph::exprsMap(
-                  use_i, use_j, true, exact_sets)) {
-            continue;
-          }
-          auto num_outputs = use_i->outputs().size();
-          NVF_ERROR(use_j->outputs().size() == num_outputs);
-          for (size_t output_i = 0; output_i < num_outputs; ++output_i) {
-            auto out_i = use_i->output(output_i)->as<IterDomain>();
-            auto out_j = use_j->output(output_i)->as<IterDomain>();
-            if (!exact_sets.strictAreMapped(out_i, out_j)) {
-              std::cerr << "Mapping " << out_i->name() << " and " << out_j->name() << std::endl;
-              exact_sets.mapEntries(out_i, out_j);
-              almost_exact_sets.mapEntries(out_i, out_j);
-              updated = true;
-            }
-          }
-        }
-      }
-      // If updated, the previous sets returned by
-      // ca_map_exact_sets.disjointSets() may contain stale sets
-      if (updated) {
-        ca_map.build(fusion);
-        break;
-      }
-    }
-  }
-}
-#endif
-
 void IdModelValidator::fullyPropagateMappings(
     Fusion* fusion,
     ComputeAtMap& ca_map,
     DisjointSets<IterDomain*>& id_sets) {
-  // Propagate mappings through expressions in ComputeAtMap. Since we
-  // want to traverse and update ca_map_exact_sets, once updated, the
-  // traversal of the ID groups cannot continue and needs to be
-  // restarted. The algorithm seems terriblly inefficient, but
-  // shuldn't matter as this is just for transitory validations
-  bool updated = true;
-  while (updated) {
-    updated = false;
-    for (const auto& set : id_sets.disjointSets()) {
-      auto uses = ca_map.uniqueExactUses(set->vector().front());
-      auto use_count = uses.size();
-      // Note that it should be fine to continue updating the map with
-      // the loop below as it should only modify output domain groups
-      for (size_t i = 0; i < use_count; ++i) {
-        auto use_i = uses.at(i);
-        for (size_t j = i + 1; j < use_count; ++j) {
-          auto use_j = uses.at(j);
-          if (!IterDomainGraph::exprsMap(use_i, use_j, true, id_sets)) {
-            continue;
-          }
-          auto num_outputs = use_i->outputs().size();
-          NVF_ERROR(use_j->outputs().size() == num_outputs);
-          for (size_t output_i = 0; output_i < num_outputs; ++output_i) {
-            auto out_i = use_i->output(output_i)->as<IterDomain>();
-            auto out_j = use_j->output(output_i)->as<IterDomain>();
-            if (!id_sets.strictAreMapped(out_i, out_j)) {
-              std::cerr << "Mapping " << out_i->name() << " and "
-                        << out_j->name() << std::endl;
-              id_sets.mapEntries(out_i, out_j);
-              updated = true;
-            }
-          }
-        }
-      }
-      // If updated, the previous sets returned by
-      // ca_map_exact_sets.disjointSets() may contain stale sets
-      if (updated) {
-        ca_map.build(fusion);
-        break;
-      }
-    }
-  }
-}
-
-void IdModelValidator::fullyPropagateMappings2(
-    Fusion* fusion,
-    ComputeAtMap& ca_map,
-    DisjointSets<IterDomain*>& id_sets) {
-  // Propagate mappings through expressions in ComputeAtMap. Since we
-  // want to traverse and update ca_map_exact_sets, once updated, the
-  // traversal of the ID groups cannot continue and needs to be
-  // restarted. The algorithm seems terriblly inefficient, but
-  // shuldn't matter as this is just for transitory validations
+  // This algorithm seems terriblly inefficient but shuldn't matter as
+  // this is just for transitory validations
   while (true) {
+    // Grab all pairs of domains to map
     std::vector<std::pair<IterDomain*, IterDomain*>> ids_to_map;
-
     for (const auto& set : id_sets.disjointSets()) {
+      // Propagate both forward and backward
       for (bool is_forward : {true, false}) {
-        // Grab all uses of this ID set
+        // Grab all use exprs of this ID set
         std::vector<Expr*> all_exprs;
         for (auto id : *set) {
+          // In the case of forward propagation, the uses() exprs may
+          // not be actually used for IterDomain. Make sure to pick
+          // only those whose outputs are in the map
           if (is_forward) {
             for (auto use : id->uses()) {
               if (std::all_of(
@@ -147,9 +48,10 @@ void IdModelValidator::fullyPropagateMappings2(
           }
         }
 
-        // Look at all combinatorial pairs of the uses. If they are
-        // mapped, i.e., their input domains are mapped and the expr
-        // properties are equivalent, map the outputs as well
+        // Look at all combinatorial pairs of the uses of
+        // definitions. If they are mapped, i.e., their input or
+        // output domains are mapped and the expr
+        // properties are equivalent, map the outputs or inputs as well
         auto count = all_exprs.size();
         for (size_t i = 0; i < count; ++i) {
           auto expr_i = all_exprs.at(i);
@@ -169,8 +71,8 @@ void IdModelValidator::fullyPropagateMappings2(
               auto id_i = prop_target_i.at(target_i)->as<IterDomain>();
               auto id_j = prop_target_j.at(target_i)->as<IterDomain>();
               if (!id_sets.strictAreMapped(id_i, id_j)) {
-                // std::cerr << "Mapping " << out_i->name() << " and " <<
-                // out_j->name() << std::endl; id_sets.mapEntries(out_i, out_j);
+                // Don't actually map them yet as it would invalidate
+                // the loop over id_sets
                 ids_to_map.emplace_back(id_i, id_j);
               }
             }
@@ -200,12 +102,12 @@ void compareDisjointSets(
     ss << "Mismatched number of groups: " << id_model_sets.size() << ", "
        << ca_map_sets.size() << "\n";
 
-    ss << "IdModel exact sets:\n";
+    ss << "IdModel sets:\n";
     for (const auto& id_set : id_model_sets.disjointSets()) {
       ss << "\t" << nvfuser::toString(id_set->vector()) << "\n";
     }
 
-    ss << "ComputeAtMap exact sets:\n";
+    ss << "ComputeAtMap sets:\n";
     for (const auto& id_set : ca_map_sets.disjointSets()) {
       ss << "\t" << nvfuser::toString(id_set->vector()) << "\n";
     }
@@ -264,134 +166,26 @@ void IdModelValidator::checkExactGraphEquivalence(const IdModel& id_model) {
                        ->fusion();
   ComputeAtMap ca_map(fusion);
 
-  // fusion->print();
-
   DisjointSets<IterDomain*>& ca_map_exact_sets = ca_map.id_graph_.exact_nodes_;
 
-#if 0
-  // Propagate mappings through expressions in ComputeAtMap. Since we
-  // want to traverse and update ca_map_exact_sets, once updated, the
-  // traversal of the ID groups cannot continue and needs to be
-  // restarted. The algorithm seems terriblly inefficient, but
-  // shuldn't matter as this is just for transitory validations
-  bool updated = true;
-  while (updated) {
-    updated = false;
-    for (const auto& set : ca_map_exact_sets.disjointSets()) {
-      auto uses = ca_map.uniqueExactUses(set->vector().front());
-      auto use_count = uses.size();
-      // Note that it should be fine to continue updating the map with
-      // the loop below as it should only modify output domain groups
-      for (size_t i = 0; i < use_count; ++i) {
-        auto use_i = uses.at(i);
-        for (size_t j = i + 1; j < use_count; ++j) {
-          auto use_j = uses.at(j);
-          if (!IterDomainGraph::exprsMap(
-                  use_i, use_j, true, ca_map_exact_sets)) {
-            continue;
-          }
-          auto num_outputs = use_i->outputs().size();
-          NVF_ERROR(use_j->outputs().size() == num_outputs);
-          for (size_t output_i = 0; output_i < num_outputs; ++output_i) {
-            auto out_i = use_i->output(output_i)->as<IterDomain>();
-            auto out_j = use_j->output(output_i)->as<IterDomain>();
-            if (!ca_map_exact_sets.strictAreMapped(out_i, out_j)) {
-              ca_map_exact_sets.mapEntries(out_i, out_j);
-              updated = true;
-            }
-          }
-        }
-      }
-      // If updated, the previous sets returned by
-      // ca_map_exact_sets.disjointSets() may contain stale sets
-      if (updated) {
-        ca_map.build(fusion);
-        break;
-      }
-    }
-  }
-#endif
-
+  // IdModel propagates mappings forward and backward more
+  // consistently, which is not the case with ComputeAt. To compare
+  // the two mappings, augment the ComputeAt mappings with the same
+  // propagation. This might potentially hide some subtle differences
+  // between the two mappings, but I think this is still a reasonable
+  // way to validate IdModel
   fullyPropagateMappings(fusion, ca_map, ca_map_exact_sets);
 
   const DisjointSets<Val*>& id_model_exact_sets = exact_graph.disjointValSets();
 
-#if 0
-  if (id_model_exact_sets.size() != ca_map_exact_sets.size()) {
-    std::stringstream ss;
-    ss << "Mismatched number of groups: " << id_model_exact_sets.size() << ", "
-       << ca_map_exact_sets.size() << "\n";
-
-    ss << "IdModel exact sets:\n";
-    for (const auto& id_set : id_model_exact_sets.disjointSets()) {
-      ss << "\t" << nvfuser::toString(id_set->vector()) << "\n";
-    }
-
-    ss << "ComputeAtMap exact sets:\n";
-    for (const auto& id_set : ca_map_exact_sets.disjointSets()) {
-      ss << "\t" << nvfuser::toString(id_set->vector()) << "\n";
-    }
-
-    NVF_ERROR(false, ss.str());
-  }
-
-  for (const auto& id_model_id_set : id_model_exact_sets.disjointSets()) {
-    NVF_ERROR(!id_model_id_set->empty());
-    NVF_ERROR(
-        ca_map_exact_sets.mappingExists(
-            id_model_id_set->front()->as<IterDomain>()),
-        "Not found in ComputeAtMap: ",
-        id_model_id_set->front()->toString());
-
-    const auto& ca_map_id_set = ca_map_exact_sets.getDisjointSetOf(
-        id_model_id_set->front()->as<IterDomain>());
-
-    std::unordered_set<Val*> ca_map_id_set_cast;
-    std::copy(
-        ca_map_id_set.begin(),
-        ca_map_id_set.end(),
-        std::inserter(ca_map_id_set_cast, ca_map_id_set_cast.end()));
-
-    NVF_ERROR(
-        id_model_id_set->set() == ca_map_id_set_cast,
-        "Mismatched ID set: ",
-        nvfuser::toString(id_model_id_set->vector()),
-        ", ",
-        nvfuser::toString(ca_map_id_set.vector()));
-  }
-#endif
-
+  // Similarly, update the almost exact CA map for the comparison
   compareDisjointSets(ca_map_exact_sets, id_model_exact_sets);
 
-  if (getenv("ALMOST_EXACT")) {
-#if 0
-    std::stringstream ss;
-    ss << "IdModel exact sets:\n";
-    for (const auto& id_set : id_model_exact_sets.disjointSets()) {
-      ss << "\t" << nvfuser::toString(id_set->vector()) << "\n";
-      for (auto id: *id_set) {
-        if (id->name() == 28 || id->name() == 34) {
-          std::cerr << "ID: " << id->toString() << std::endl;
-        }
-      }
-    }
+  fullyPropagateMappings(fusion, ca_map, ca_map.id_graph_.almost_exact_nodes_);
 
-    //ss << "ComputeAtMap exact sets:\n";
-    //for (const auto& id_set : ca_map_exact_sets.disjointSets()) {
-    //ss << "\t" << nvfuser::toString(id_set->vector()) << "\n";
-    //}
-
-    std::cerr << ss.str();
-#endif
-
-    fullyPropagateMappings2(
-        fusion, ca_map, ca_map.id_graph_.almost_exact_nodes_);
-
-    std::cerr << "Comparing AlmostExact\n";
-    compareDisjointSets(
-        ca_map.id_graph_.almost_exact_nodes_,
-        id_model.idGraph(IdMappingMode::ALMOSTEXACT).disjointValSets());
-  }
+  compareDisjointSets(
+      ca_map.id_graph_.almost_exact_nodes_,
+      id_model.idGraph(IdMappingMode::ALMOSTEXACT).disjointValSets());
 }
 
 } // namespace nvfuser

--- a/csrc/id_model/validation_utils.cpp
+++ b/csrc/id_model/validation_utils.cpp
@@ -13,7 +13,236 @@
 
 namespace nvfuser {
 
-void IdModelValidator::checkExactGraphEquivalence(const ValGraph& exact_graph) {
+#if 0
+void IdModelValidator::fullyPropagateMappings(Fusion* fusion, ComputeAtMap& ca_map) {
+
+  DisjointSets<IterDomain*>& exact_sets = ca_map.id_graph_.exact_nodes_;
+  DisjointSets<IterDomain*>& almost_exact_sets = ca_map.id_graph_.almost_exact_nodes_;
+  
+  // Propagate mappings through expressions in ComputeAtMap. Since we
+  // want to traverse and update ca_map_exact_sets, once updated, the
+  // traversal of the ID groups cannot continue and needs to be
+  // restarted. The algorithm seems terriblly inefficient, but
+  // shuldn't matter as this is just for transitory validations
+  bool updated = true;
+  while (updated) {
+    updated = false;
+    for (const auto& set : exact_sets.disjointSets()) {
+      auto uses = ca_map.uniqueExactUses(set->vector().front());
+      auto use_count = uses.size();
+      // Note that it should be fine to continue updating the map with
+      // the loop below as it should only modify output domain groups
+      for (size_t i = 0; i < use_count; ++i) {
+        auto use_i = uses.at(i);
+        for (size_t j = i + 1; j < use_count; ++j) {
+          auto use_j = uses.at(j);
+          if (!IterDomainGraph::exprsMap(
+                  use_i, use_j, true, exact_sets)) {
+            continue;
+          }
+          auto num_outputs = use_i->outputs().size();
+          NVF_ERROR(use_j->outputs().size() == num_outputs);
+          for (size_t output_i = 0; output_i < num_outputs; ++output_i) {
+            auto out_i = use_i->output(output_i)->as<IterDomain>();
+            auto out_j = use_j->output(output_i)->as<IterDomain>();
+            if (!exact_sets.strictAreMapped(out_i, out_j)) {
+              std::cerr << "Mapping " << out_i->name() << " and " << out_j->name() << std::endl;
+              exact_sets.mapEntries(out_i, out_j);
+              almost_exact_sets.mapEntries(out_i, out_j);
+              updated = true;
+            }
+          }
+        }
+      }
+      // If updated, the previous sets returned by
+      // ca_map_exact_sets.disjointSets() may contain stale sets
+      if (updated) {
+        ca_map.build(fusion);
+        break;
+      }
+    }
+  }
+}
+#endif
+
+void IdModelValidator::fullyPropagateMappings(
+    Fusion* fusion,
+    ComputeAtMap& ca_map,
+    DisjointSets<IterDomain*>& id_sets) {
+  // Propagate mappings through expressions in ComputeAtMap. Since we
+  // want to traverse and update ca_map_exact_sets, once updated, the
+  // traversal of the ID groups cannot continue and needs to be
+  // restarted. The algorithm seems terriblly inefficient, but
+  // shuldn't matter as this is just for transitory validations
+  bool updated = true;
+  while (updated) {
+    updated = false;
+    for (const auto& set : id_sets.disjointSets()) {
+      auto uses = ca_map.uniqueExactUses(set->vector().front());
+      auto use_count = uses.size();
+      // Note that it should be fine to continue updating the map with
+      // the loop below as it should only modify output domain groups
+      for (size_t i = 0; i < use_count; ++i) {
+        auto use_i = uses.at(i);
+        for (size_t j = i + 1; j < use_count; ++j) {
+          auto use_j = uses.at(j);
+          if (!IterDomainGraph::exprsMap(use_i, use_j, true, id_sets)) {
+            continue;
+          }
+          auto num_outputs = use_i->outputs().size();
+          NVF_ERROR(use_j->outputs().size() == num_outputs);
+          for (size_t output_i = 0; output_i < num_outputs; ++output_i) {
+            auto out_i = use_i->output(output_i)->as<IterDomain>();
+            auto out_j = use_j->output(output_i)->as<IterDomain>();
+            if (!id_sets.strictAreMapped(out_i, out_j)) {
+              std::cerr << "Mapping " << out_i->name() << " and "
+                        << out_j->name() << std::endl;
+              id_sets.mapEntries(out_i, out_j);
+              updated = true;
+            }
+          }
+        }
+      }
+      // If updated, the previous sets returned by
+      // ca_map_exact_sets.disjointSets() may contain stale sets
+      if (updated) {
+        ca_map.build(fusion);
+        break;
+      }
+    }
+  }
+}
+
+void IdModelValidator::fullyPropagateMappings2(
+    Fusion* fusion,
+    ComputeAtMap& ca_map,
+    DisjointSets<IterDomain*>& id_sets) {
+  // Propagate mappings through expressions in ComputeAtMap. Since we
+  // want to traverse and update ca_map_exact_sets, once updated, the
+  // traversal of the ID groups cannot continue and needs to be
+  // restarted. The algorithm seems terriblly inefficient, but
+  // shuldn't matter as this is just for transitory validations
+  while (true) {
+    std::vector<std::pair<IterDomain*, IterDomain*>> ids_to_map;
+
+    for (const auto& set : id_sets.disjointSets()) {
+      for (bool is_forward : {true, false}) {
+        // Grab all uses of this ID set
+        std::vector<Expr*> all_exprs;
+        for (auto id : *set) {
+          if (is_forward) {
+            for (auto use : id->uses()) {
+              if (std::all_of(
+                      use->outputs().begin(),
+                      use->outputs().end(),
+                      [&](Val* output) {
+                        return output->isA<IterDomain>() &&
+                            id_sets.mappingExists(output->as<IterDomain>());
+                      })) {
+                all_exprs.push_back(use);
+              }
+            }
+          } else {
+            all_exprs.push_back(id->definition());
+          }
+        }
+
+        // Look at all combinatorial pairs of the uses. If they are
+        // mapped, i.e., their input domains are mapped and the expr
+        // properties are equivalent, map the outputs as well
+        auto count = all_exprs.size();
+        for (size_t i = 0; i < count; ++i) {
+          auto expr_i = all_exprs.at(i);
+          for (size_t j = i + 1; j < count; ++j) {
+            auto expr_j = all_exprs.at(j);
+            if (!IterDomainGraph::exprsMap(
+                    expr_i, expr_j, is_forward, id_sets)) {
+              continue;
+            }
+            const auto& prop_target_i =
+                is_forward ? expr_i->outputs() : expr_i->inputs();
+            const auto& prop_target_j =
+                is_forward ? expr_j->outputs() : expr_j->inputs();
+            auto num_target = prop_target_i.size();
+            NVF_ERROR(num_target == prop_target_j.size());
+            for (size_t target_i = 0; target_i < num_target; ++target_i) {
+              auto id_i = prop_target_i.at(target_i)->as<IterDomain>();
+              auto id_j = prop_target_j.at(target_i)->as<IterDomain>();
+              if (!id_sets.strictAreMapped(id_i, id_j)) {
+                // std::cerr << "Mapping " << out_i->name() << " and " <<
+                // out_j->name() << std::endl; id_sets.mapEntries(out_i, out_j);
+                ids_to_map.emplace_back(id_i, id_j);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // No additional domains to map. Nothing to do further
+    if (ids_to_map.empty()) {
+      return;
+    }
+
+    for (const auto& [id1, id2] : ids_to_map) {
+      id_sets.mapEntries(id1, id2);
+    }
+  }
+}
+
+namespace {
+
+void compareDisjointSets(
+    const DisjointSets<IterDomain*>& ca_map_sets,
+    const DisjointSets<Val*>& id_model_sets) {
+  if (id_model_sets.size() != ca_map_sets.size()) {
+    std::stringstream ss;
+    ss << "Mismatched number of groups: " << id_model_sets.size() << ", "
+       << ca_map_sets.size() << "\n";
+
+    ss << "IdModel exact sets:\n";
+    for (const auto& id_set : id_model_sets.disjointSets()) {
+      ss << "\t" << nvfuser::toString(id_set->vector()) << "\n";
+    }
+
+    ss << "ComputeAtMap exact sets:\n";
+    for (const auto& id_set : ca_map_sets.disjointSets()) {
+      ss << "\t" << nvfuser::toString(id_set->vector()) << "\n";
+    }
+
+    NVF_ERROR(false, ss.str());
+  }
+
+  for (const auto& id_model_id_set : id_model_sets.disjointSets()) {
+    NVF_ERROR(!id_model_id_set->empty());
+    NVF_ERROR(
+        ca_map_sets.mappingExists(id_model_id_set->front()->as<IterDomain>()),
+        "Not found in ComputeAtMap: ",
+        id_model_id_set->front()->toString());
+
+    const auto& ca_map_id_set = ca_map_sets.getDisjointSetOf(
+        id_model_id_set->front()->as<IterDomain>());
+
+    std::unordered_set<Val*> ca_map_id_set_cast;
+    std::copy(
+        ca_map_id_set.begin(),
+        ca_map_id_set.end(),
+        std::inserter(ca_map_id_set_cast, ca_map_id_set_cast.end()));
+
+    NVF_ERROR(
+        id_model_id_set->set() == ca_map_id_set_cast,
+        "Mismatched ID set: ",
+        nvfuser::toString(id_model_id_set->vector()),
+        ", ",
+        nvfuser::toString(ca_map_id_set.vector()));
+  }
+}
+
+} // namespace
+
+void IdModelValidator::checkExactGraphEquivalence(const IdModel& id_model) {
+  const ValGraph& exact_graph = id_model.idGraph(IdMappingMode::EXACT);
+
   // Empty graph
   if (exact_graph.disjointValSets().disjointSets().empty()) {
     return;
@@ -35,10 +264,13 @@ void IdModelValidator::checkExactGraphEquivalence(const ValGraph& exact_graph) {
                        ->fusion();
   ComputeAtMap ca_map(fusion);
 
+  // fusion->print();
+
   DisjointSets<IterDomain*>& ca_map_exact_sets = ca_map.id_graph_.exact_nodes_;
 
-  // Propgate mappings through expressions in ComputeAtMap. Since we
-  // want to traverse and update ca_map_exact_sets, once  updated, the
+#if 0
+  // Propagate mappings through expressions in ComputeAtMap. Since we
+  // want to traverse and update ca_map_exact_sets, once updated, the
   // traversal of the ID groups cannot continue and needs to be
   // restarted. The algorithm seems terriblly inefficient, but
   // shuldn't matter as this is just for transitory validations
@@ -78,9 +310,13 @@ void IdModelValidator::checkExactGraphEquivalence(const ValGraph& exact_graph) {
       }
     }
   }
+#endif
+
+  fullyPropagateMappings(fusion, ca_map, ca_map_exact_sets);
 
   const DisjointSets<Val*>& id_model_exact_sets = exact_graph.disjointValSets();
 
+#if 0
   if (id_model_exact_sets.size() != ca_map_exact_sets.size()) {
     std::stringstream ss;
     ss << "Mismatched number of groups: " << id_model_exact_sets.size() << ", "
@@ -122,6 +358,39 @@ void IdModelValidator::checkExactGraphEquivalence(const ValGraph& exact_graph) {
         nvfuser::toString(id_model_id_set->vector()),
         ", ",
         nvfuser::toString(ca_map_id_set.vector()));
+  }
+#endif
+
+  compareDisjointSets(ca_map_exact_sets, id_model_exact_sets);
+
+  if (getenv("ALMOST_EXACT")) {
+#if 0
+    std::stringstream ss;
+    ss << "IdModel exact sets:\n";
+    for (const auto& id_set : id_model_exact_sets.disjointSets()) {
+      ss << "\t" << nvfuser::toString(id_set->vector()) << "\n";
+      for (auto id: *id_set) {
+        if (id->name() == 28 || id->name() == 34) {
+          std::cerr << "ID: " << id->toString() << std::endl;
+        }
+      }
+    }
+
+    //ss << "ComputeAtMap exact sets:\n";
+    //for (const auto& id_set : ca_map_exact_sets.disjointSets()) {
+    //ss << "\t" << nvfuser::toString(id_set->vector()) << "\n";
+    //}
+
+    std::cerr << ss.str();
+#endif
+
+    fullyPropagateMappings2(
+        fusion, ca_map, ca_map.id_graph_.almost_exact_nodes_);
+
+    std::cerr << "Comparing AlmostExact\n";
+    compareDisjointSets(
+        ca_map.id_graph_.almost_exact_nodes_,
+        id_model.idGraph(IdMappingMode::ALMOSTEXACT).disjointValSets());
   }
 }
 

--- a/csrc/id_model/validation_utils.h
+++ b/csrc/id_model/validation_utils.h
@@ -37,10 +37,11 @@ class IdModelValidator {
   static void checkExactGraphEquivalence(const IdModel& id_model);
 
  private:
-  static void fullyPropagateMappings(Fusion* fusion, ComputeAtMap& ca_map,
-                                     DisjointSets<IterDomain*>& id_sets);
-  static void fullyPropagateMappings2(Fusion* fusion, ComputeAtMap& ca_map,
-                                      DisjointSets<IterDomain*>& id_sets);
+  // Propagate mappings in a ComputeAtMap as is done in IdModel
+  static void fullyPropagateMappings(
+      Fusion* fusion,
+      ComputeAtMap& ca_map,
+      DisjointSets<IterDomain*>& id_sets);
 };
 
 } // namespace nvfuser

--- a/csrc/id_model/validation_utils.h
+++ b/csrc/id_model/validation_utils.h
@@ -34,7 +34,13 @@ class IdModelValidator {
   // swizzle is used we give up validating the exact graph. The second
   // difference is whether mappings are propagated, which can be
   // accounted for by updating the ComputeAtMap as is done in IdModel.
-  static void checkExactGraphEquivalence(const ValGraph& exact_graph);
+  static void checkExactGraphEquivalence(const IdModel& id_model);
+
+ private:
+  static void fullyPropagateMappings(Fusion* fusion, ComputeAtMap& ca_map,
+                                     DisjointSets<IterDomain*>& id_sets);
+  static void fullyPropagateMappings2(Fusion* fusion, ComputeAtMap& ca_map,
+                                      DisjointSets<IterDomain*>& id_sets);
 };
 
 } // namespace nvfuser

--- a/csrc/id_model/validation_utils.h
+++ b/csrc/id_model/validation_utils.h
@@ -17,6 +17,8 @@ namespace nvfuser {
 // have private access
 class IdModelValidator {
  public:
+  IdModelValidator(Fusion* fusion);
+
   // Validate a given exact graph of IdModel by comparing it with
   // ComputeAtMap. Their maps should
   // be almost the same but there are some differences.
@@ -34,14 +36,18 @@ class IdModelValidator {
   // swizzle is used we give up validating the exact graph. The second
   // difference is whether mappings are propagated, which can be
   // accounted for by updating the ComputeAtMap as is done in IdModel.
-  static void checkExactGraphEquivalence(const IdModel& id_model);
+  void checkExactGraphEquivalence(const ValGraph& exact_graph);
+
+  void checkAlmostExactGraphEquivalence(const ValGraph& almost_exact_graph);
 
  private:
   // Propagate mappings in a ComputeAtMap as is done in IdModel
-  static void fullyPropagateMappings(
-      Fusion* fusion,
-      ComputeAtMap& ca_map,
-      DisjointSets<IterDomain*>& id_sets);
+  static void fullyPropagateMappings(DisjointSets<IterDomain*>& id_sets);
+
+ private:
+  ComputeAtMap ca_map_;
+  // Validation is not enabled if swizzle is found. See the comment above
+  bool has_swizzle_ = false;
 };
 
 } // namespace nvfuser

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -155,10 +155,6 @@ class ValGraph {
 
   std::string toString() const;
 
-  // Checks if the expression is a trivial operation where an input is simply an
-  // output of the transformation. Returns the mapped iter domains if found.
-  static std::vector<std::vector<Val*>> isTrivialExpr(Expr* expr);
-
   // Returns if all atributes of the ID transforms first and second are the same
   static bool transformAtributesMatch(Expr* first, Expr* second);
 
@@ -204,10 +200,6 @@ class ValGraph {
   // when the forward parameter is true. This should
   // be the only call in ValGraph to mapThroughExpr.
   void maybeMapThroughExprs(Expr* expr0, Expr* expr1, bool forward);
-
-  // Maps iter domain pairs returned by calling that return mappings from
-  // IdGraph::isTrivialExpr on every expression in the graph.
-  void mapThroughTrivialExprs();
 
   // Removes expressions from unique_definitions_ and unique_uses_ that return
   // mappings from IdGraph::isTrivialExpr


### PR DESCRIPTION
Refactoring the almost exact graph construction. 

- The main logic is moved from ValGraph to IdModel
- Extended the validator to support the almost exact graph