### PR TITLE
Enable clang-format.

### DIFF
--- a/test/test_iter_visitor.cpp
+++ b/test/test_iter_visitor.cpp
@@ -4,11 +4,12 @@
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
-#include <iter_visitor.h>
 #include <fusion.h>
+#include <iter_visitor.h>
 #include <ops/all_ops.h>
 #include <test/utils.h>
 
@@ -38,8 +39,10 @@ TEST_F(IterVisitorTest, IterVisitorTraverseAttributes) {
   auto stmts = StmtSort::getStmts(&fusion, true, true);
 
   // Make sure the expansion parameters of tv1_resize are visited
-  EXPECT_THAT(stmts, Contains(tv1_resize->leftExpand())) << "Resize left expand parameter not found";
-  EXPECT_THAT(stmts, Contains(tv1_resize->rightExpand())) << "Resize right expand parameter not found";
+  EXPECT_THAT(stmts, Contains(tv1_resize->leftExpand()))
+      << "Resize left expand parameter not found";
+  EXPECT_THAT(stmts, Contains(tv1_resize->rightExpand()))
+      << "Resize right expand parameter not found";
 }
 
 // Test that traversing siblings with IterVisitor visits "orphans", i.e. unused
@@ -71,8 +74,10 @@ TEST_F(IterVisitorTest, IterVisitorTraverseSiblings) {
       /*traverse_all_paths=*/false,
       /*traverse_attributes=*/false,
       /*traverse_siblings=*/true);
-  EXPECT_THAT(stmts, Contains(wf.avg)) << "Welford avg not traversed in getStmtsTo({n})";
-  EXPECT_THAT(stmts, Contains(wf.var_sum)) << "Welford var_sum not traversed in getStmtsTo({n})";
+  EXPECT_THAT(stmts, Contains(wf.avg))
+      << "Welford avg not traversed in getStmtsTo({n})";
+  EXPECT_THAT(stmts, Contains(wf.var_sum))
+      << "Welford var_sum not traversed in getStmtsTo({n})";
 }
 
 TEST_F(IterVisitorTest, IterVisitorGetInputsTo) {
@@ -115,7 +120,9 @@ TEST_F(IterVisitorTest, NonTerminatingOutput) {
   // Even though `c` is a non-terminating output, `d` and `e` should still be
   // considered in between. This is because `StmtSort::getExprsBetween`
   // traverses from `to` along use-def chains until it hits `from`.
-  EXPECT_THAT(StmtSort::getExprsBetween({a}, {c, e}), IsSupersetOf({d->definition(), e->definition()}));
+  EXPECT_THAT(
+      StmtSort::getExprsBetween({a}, {c, e}),
+      IsSupersetOf({d->definition(), e->definition()}));
 }
 
 } // namespace nvfuser

--- a/test/test_segmentation.cpp
+++ b/test/test_segmentation.cpp
@@ -14,6 +14,7 @@
 #include <test/validator.h>
 
 namespace nvfuser {
+
 using SegmentationTest = NVFuserTest;
 
 TEST_F(SegmentationTest, Issue1284_Repro1) {

--- a/test/test_segmentation.cpp
+++ b/test/test_segmentation.cpp
@@ -4,6 +4,7 @@
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+// clang-format on
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -11,7 +12,6 @@
 #include <ops/all_ops.h>
 #include <test/utils.h>
 #include <test/validator.h>
-
 
 namespace nvfuser {
 using SegmentationTest = NVFuserTest;
@@ -102,7 +102,6 @@ TEST_F(SegmentationTest, Issue1284_Repro2) {
       __FILE__);
 }
 
-
 // Test forced segmentation hint
 TEST_F(SegmentationTest, SegmenterHint) {
   auto fusion = std::make_unique<Fusion>();
@@ -144,6 +143,5 @@ TEST_F(SegmentationTest, SegmenterHint) {
   testValidate(
       executor_cache.fusion(), outputs, {at_x}, {ref_out}, __LINE__, __FILE__);
 }
-
 
 } // namespace nvfuser


### PR DESCRIPTION
I forgot to `// clang-format on` after the license.