### PR TITLE
FusionProfiler - fixes in implementation and tests

### DIFF
--- a/csrc/fusion_profiler.cpp
+++ b/csrc/fusion_profiler.cpp
@@ -694,11 +694,16 @@ void FusionProfiler::stop() {
           "All Segment profiles must be on the same device!");
     }
     fprof.kernel_time_ms = kernel_time_ms;
-    fprof.effective_bandwidth_gbs =
-        (double)(fprof.input_bytes + fprof.output_bytes) / kernel_time_ms *
-        mb_divider;
-    fprof.percentage_peak_bandwidth = fprof.effective_bandwidth_gbs /
-        fp->device_descriptors_[segment(0).device()].peak_bandwidth_gbs * 100.0;
+    if (!fp->kernel_profiles_.empty()) {
+      fprof.effective_bandwidth_gbs =
+          (double)(fprof.input_bytes + fprof.output_bytes) / kernel_time_ms *
+          mb_divider;
+    }
+    if (!fp->segments_.empty()) {
+      fprof.percentage_peak_bandwidth = fprof.effective_bandwidth_gbs /
+          fp->device_descriptors_[segment(0).device()].peak_bandwidth_gbs *
+          100.0;
+    }
   }
   fprof.compile_time_ms = fp->compile_timer_.time();
 

--- a/test/test_fusion_profiler.cpp
+++ b/test/test_fusion_profiler.cpp
@@ -26,10 +26,14 @@ class FusionProfilerTest : public NVFuserTest {
   void SetUp() override {
     NVFuserTest::SetUp();
     saved_ = ProfilerOptionsGuard::getCurOptions();
+    FusionProfiler::reset();
   }
 
   void TearDown() override {
     ProfilerOptionsGuard::getCurOptions() = saved_;
+    if (ProfilerState::Running == FusionProfiler::state()) {
+      FusionProfiler::stop();
+    }
     NVFuserTest::TearDown();
   }
 


### PR DESCRIPTION
The scope of changes:
- implementation fix: `stop()` won't now access uninitialized data,
- tests fix: make sure that profiler state is defined at the beginning and at the end of each test case,