### PR TITLE
Turn on CXX_STANDARD_REQUIRED.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ target_include_directories(${NVFUSER_CODEGEN} PUBLIC
   "$<BUILD_INTERFACE:${NVFUSER_SRCS_DIR}>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/nvfuser>"
 )
+set_property(TARGET ${NVFUSER_CODEGEN} PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET ${NVFUSER_CODEGEN} PROPERTY CXX_STANDARD ${NVFUSER_CPP_STANDARD})
 
 # Ensure we don't link against libcuda; we'll dlopen it ourselves.


### PR DESCRIPTION
Without this, I couldn't build nvFuser with Clang 14, which doesn't enable c++17 by default unlike gcc 11.4. I don't understand why I had to turn it on. I expected cmake would automatically figure out the default C++ standard and omit `-std=c++17` only when it's safe.

Wdyt?