### PR TITLE
Minor cleanup of transform_iter

### DIFF
--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -705,7 +705,7 @@ ForwardingInfo::ForwardingInfo(
         TensorDomain::noReductions(producer->getMaybeRFactorDomain());
     active_tv = producer;
   } else {
-    return;
+    NVF_ERROR(false, "Should not be reachable");
   }
 
   NVF_ERROR(active_root_dom.size() == active_dim_flags->size());

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -5,10 +5,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <ir/builder.h>
+#include <ir/utils.h>
+#include <root_domain_map.h>
 #include <transform_iter.h>
 
 #include <c10/util/irange.h>
-#include <ir/utils.h>
 
 #include <typeinfo>
 
@@ -665,139 +667,118 @@ int BestEffortReplay::findFirstMismatchedID(
   return (int)std::min(td1->nDims(), td2->nDims());
 }
 
-namespace {
+ForwardingInfo::ForwardingInfo(
+    const TensorView* producer,
+    const TensorView* consumer) {
+  // No forwarding unless this is broadcast or squeeze
+  if (!dynamic_cast<BroadcastOp*>(consumer->definition()) &&
+      !dynamic_cast<SqueezeOp*>(consumer->definition())) {
+    return;
+  }
 
-// Maps that track information relevant to best effort replay about newly added
-// or squeezed broadcast axes
-//
-// For example if we have consumer: T0[i0, b1, b2, i3] and producer:
-// T1[i0, i3]
-//
-// If consumer transformations are:
-// -> T[i0, b1o, b1i, b2o, b2i, i3]
-// -> T[i0*b1i, b1o, b2o, b2i, i3]
-// -> T[i0*b1i*b2o, b1o, b2i, i3]
-// -> T[i0*b1i*b2o*i3, b1o, b2i]
-//
-// forwarding_map would forward i0->i0*b1i and i0*b1i->i0*b1i*b2o
-// compliment_map would have the entry i0->b1i and i0*b1i->b2o
-//
-// The first is to fast forward transformations in consumer involving broadcast
-// axes not in producer. The compliment map is to use later to compute what leaf
-// nodes we may have after the forwarding process is finished. Leaf nodes are
-// only important for replayCasP, so look there to see how this is done. Forward
-// map is used for replayCasP and replayPasC.
-struct ForwardingInfo {
- public:
-  // Map IterDomain* axes that can safely be forwarded to their output.
-  std::unordered_map<IterDomain*, IterDomain*> producer_forwarding_map;
-  std::unordered_map<IterDomain*, IterDomain*> consumer_forwarding_map;
+  // Active indicates the TV that has axes the other TV does not. For
+  // broadcast this is the consumer squeeze the producer.
+  //
+  // Either producer or consumer maps depending on operation
+  std::unordered_map<IterDomain*, IterDomain*>* active_forwarding_map = nullptr;
+  std::unordered_map<IterDomain*, std::vector<IterDomain*>>*
+      active_compliment_map = nullptr;
 
-  // Given a forward id map id_input -> id_forwarded
-  // Track the other inputs in the expr that id_input is an input to. These will
-  // be used to adjust the replay's leaf tracking. Don't need to track one to
-  // many as currently transformations on IterDomains can only have maximum 2
-  // inputs, but maybe in the future we'll have more.
-  std::unordered_map<IterDomain*, std::vector<IterDomain*>>
-      producer_compliment_map;
-  std::unordered_map<IterDomain*, std::vector<IterDomain*>>
-      consumer_compliment_map;
+  // Either squeeze or broadcast dimension flags depending on operation
+  const std::vector<bool>* active_dim_flags = nullptr;
 
-  ForwardingInfo(const TensorView* producer, const TensorView* consumer) {
-    // Either producer or consumer maps depending on operation
-    std::unordered_map<IterDomain*, IterDomain*>* active_forwarding_map =
-        nullptr;
-    std::unordered_map<IterDomain*, std::vector<IterDomain*>>*
-        active_compliment_map = nullptr;
+  // Either producer or consumer depending on operation
+  std::vector<IterDomain*> active_root_dom;
+  const TensorView* active_tv = nullptr;
 
-    // Either squeeze or broadcast dimension flags depending on operation
-    const std::vector<bool>* active_dim_flags = nullptr;
+  if (auto bop = dynamic_cast<BroadcastOp*>(consumer->definition())) {
+    active_forwarding_map = &consumer_forwarding_map;
+    active_compliment_map = &consumer_compliment_map;
+    active_dim_flags = &bop->getBroadcastDimFlags();
+    active_root_dom = consumer->getRootDomain();
+    active_tv = consumer;
+  } else if (auto sop = dynamic_cast<SqueezeOp*>(consumer->definition())) {
+    active_forwarding_map = &producer_forwarding_map;
+    active_compliment_map = &producer_compliment_map;
+    active_dim_flags = &sop->getSqueezeDimFlags();
+    active_root_dom =
+        TensorDomain::noReductions(producer->getMaybeRFactorDomain());
+    active_tv = producer;
+  } else {
+    return;
+  }
 
-    // Either producer or consumer depending on operation
-    std::vector<IterDomain*> active_root_dom;
-    const TensorView* active_tv = nullptr;
+  NVF_ERROR(active_root_dom.size() == active_dim_flags->size());
 
-    if (auto bop = dynamic_cast<BroadcastOp*>(consumer->definition())) {
-      active_forwarding_map = &consumer_forwarding_map;
-      active_compliment_map = &consumer_compliment_map;
-      active_dim_flags = &bop->getBroadcastDimFlags();
-      active_root_dom = consumer->getRootDomain();
-      active_tv = consumer;
-    } else if (auto sop = dynamic_cast<SqueezeOp*>(consumer->definition())) {
-      active_forwarding_map = &producer_forwarding_map;
-      active_compliment_map = &producer_compliment_map;
-      active_dim_flags = &sop->getSqueezeDimFlags();
-      active_root_dom =
-          TensorDomain::noReductions(producer->getMaybeRFactorDomain());
-      active_tv = producer;
-    } else {
-      return;
-    }
-
-    // Collect which root ids are only in active_tv but not in the inactive
-    // tensor.
-    std::unordered_set<IterDomain*> forwarded_ids;
-    NVF_ERROR(active_root_dom.size() == active_dim_flags->size());
-    for (auto i : c10::irange(active_dim_flags->size())) {
-      if (active_dim_flags->at(i)) {
-        forwarded_ids.emplace(active_root_dom.at(i));
-      }
-    }
-
-    // We have root axes in active_tv that don't exist in the inactive tensor,
-    // now forward those to include all id's in active_tv comprised of only axes
-    // not in the inactive tensor.
-    std::vector<Expr*> active_tv_history = StmtSort::getExprsTo(
-        {active_tv->getLeafDomain().begin(), active_tv->getLeafDomain().end()});
-
-    auto isIdOnlyInActiveTv = [&forwarded_ids](IterDomain* input_id) {
-      return forwarded_ids.count(input_id) > 0;
-    };
-
-    for (auto expr : active_tv_history) {
-      auto input_ids = ir_utils::filterByType<IterDomain>(expr->inputs());
-      // If expr inputs are all in forwarded_ids, then so are all outputs
-      if (std::all_of(input_ids.begin(), input_ids.end(), isIdOnlyInActiveTv)) {
-        for (auto output_ids :
-             ir_utils::filterByType<IterDomain>(expr->outputs())) {
-          forwarded_ids.emplace(output_ids);
-        }
-      } else if (
-          expr->isA<Merge>() &&
-          std::any_of(input_ids.begin(), input_ids.end(), isIdOnlyInActiveTv)) {
-        auto merge_expr = expr->as<Merge>();
-        // If
-        // - one of the inputs is made of id's in active_tv that don't map to
-        //   the inactive tensor,
-        // - && the other input maps to an id in both the active and inactive
-        //   tensor
-        // - && this is a merge
-        //
-        // For the sake of BestEffortReplay we can forward the input mapping
-        //   to both the active and inactive tensor to the output of the
-        //   expression
-        std::vector<IterDomain*> forwarded_ids;
-        std::vector<IterDomain*> compliment_ids;
-
-        for (auto input_id : input_ids) {
-          if (!isIdOnlyInActiveTv(input_id)) {
-            forwarded_ids.emplace_back(input_id);
-            active_forwarding_map->emplace(
-                std::make_pair(input_id, merge_expr->out()));
-          } else {
-            compliment_ids.push_back(input_id);
-          }
-        }
-
-        // Set up compliment map
-        for (auto forwarded_id : forwarded_ids) {
-          active_compliment_map->emplace(
-              std::make_pair(forwarded_id, compliment_ids));
-        }
-      }
+  // Collect which root ids are only in active_tv but not in the inactive
+  // tensor.
+  //
+  // Initialize which id's should beforwarded.
+  std::unordered_set<IterDomain*> forwarded_ids;
+  for (auto i : c10::irange(active_dim_flags->size())) {
+    if (active_dim_flags->at(i)) {
+      forwarded_ids.emplace(active_root_dom.at(i));
     }
   }
-};
+
+  // We have root axes in active_tv that don't exist in the inactive tensor,
+  // now forward those to include all id's in active_tv comprised of only axes
+  // not in the inactive tensor.
+  auto active_tv_history = StmtSort::getExprsTo(std::vector<Val*>(
+      active_tv->domain()->leaf().begin(), active_tv->domain()->leaf().end()));
+
+  auto isInForwardIdSet = [&forwarded_ids](IterDomain* input_id) {
+    return forwarded_ids.count(input_id) > 0;
+  };
+
+  for (auto expr : active_tv_history) {
+    auto input_ids = ir_utils::filterByType<IterDomain>(expr->inputs());
+    // If expr inputs are all in forwarded_ids, then so are all outputs
+    if (std::all_of(input_ids.begin(), input_ids.end(), isInForwardIdSet)) {
+      for (auto output_ids :
+           ir_utils::filterByType<IterDomain>(expr->outputs())) {
+        forwarded_ids.emplace(output_ids);
+      }
+    } else if (
+        expr->isA<Merge>() &&
+        std::any_of(input_ids.begin(), input_ids.end(), isInForwardIdSet)) {
+      auto merge_expr = expr->as<Merge>();
+      // If
+      // - one of the inputs is made of id's in active_tv that don't map to
+      //   the inactive tensor,
+      // - && the other input maps to an id in both the active and inactive
+      //   tensor
+      // - && this is a merge
+      //
+      // For the sake of BestEffortReplay we can forward the input mapping
+      //   to both the active and inactive tensor to the output of the
+      //   expression
+      IterDomain* forwarded_id = nullptr;
+      IterDomain* compliment_id = nullptr;
+
+      for (auto input_id : input_ids) {
+        if (!isInForwardIdSet(input_id)) {
+          NVF_ERROR(forwarded_id == nullptr);
+          forwarded_id = input_id;
+          active_forwarding_map->emplace(
+              std::make_pair(input_id, merge_expr->out()));
+        } else {
+          NVF_ERROR(compliment_id == nullptr);
+          compliment_id = input_id;
+        }
+      }
+
+      NVF_ERROR(forwarded_id != nullptr);
+      NVF_ERROR(compliment_id != nullptr);
+
+      // Set up compliment map
+      active_compliment_map->emplace(
+          forwarded_id, std::vector<IterDomain*>{compliment_id});
+    }
+  }
+}
+
+namespace {
 
 // Trace chain of swizzles until reaching
 //  an IterDomain that's either a leaf or
@@ -805,13 +786,11 @@ struct ForwardingInfo {
 IterDomain* getSwizzleFinalOutput(
     IterDomain* id,
     const std::unordered_map<IterDomain*, Expr*>& id2expr) {
-  bool is_swizzle_input = true;
-
   // Note: currently not supporting swizzling consumer of another
   //  swizzle id, so this should terminate in 1 iter, but eventually
   //  will try to support stacked swizzles so keeping this pass
   //  generic.
-  while (is_swizzle_input) {
+  while (true) {
     auto expr_it = id2expr.find(id);
 
     // This means id is a leaf that doesn't
@@ -836,7 +815,7 @@ IterDomain* getSwizzleFinalOutput(
     } else {
       // Probably unreachable but if the expression
       //  is unknown type assume it is not a swizzle op.
-      is_swizzle_input = false;
+      break;
     }
   }
 

--- a/csrc/transform_iter.h
+++ b/csrc/transform_iter.h
@@ -12,13 +12,13 @@
 
 #include <disjoint_set.h>
 #include <ir/all_nodes.h>
-#include <ir/iostream.h>
 #include <iter_visitor.h>
-#include <root_domain_map.h>
 #include <unordered_map>
 #include <vector>
 
 namespace nvfuser {
+
+class RootDomainMap;
 
 namespace {
 
@@ -151,7 +151,77 @@ class ReplayTransformations : public IterVisitor {
   bool ran_replay_ = false; // Mark if replay has been run
 };
 
+// Maps that track information relevant to best effort replay about newly added
+// or squeezed broadcast axes
+//
+// For example if we have consumer: T0[i0, b1, b2, i3] and producer:
+// T1[i0, i3]
+//
+// If consumer transformations are:
+// -> T[i0, b1o, b1i, b2o, b2i, i3]
+// -> T[i0*b1i, b1o, b2o, b2i, i3]
+// -> T[i0*b1i*b2o, b1o, b2i, i3]
+// -> T[i0*b1i*b2o*i3, b1o, b2i]
+//
+// forwarding_map would forward i0->i0*b1i and i0*b1i->i0*b1i*b2o
+// compliment_map would have the entry i0->b1i and i0*b1i->b2o
+//
+// The first is to fast forward transformations in consumer involving broadcast
+// axes not in producer. The compliment map is to use later to compute what leaf
+// nodes we may have after the forwarding process is finished. Leaf nodes are
+// only important for replayCasP, so look there to see how this is done. Forward
+// map is used for replayCasP and replayPasC.
+//
+// The producer forwarding map is filled when producer broadcast
+// domains are squeezed.
+class ForwardingInfo {
+ public:
+  // Map IterDomain* axes that can safely be forwarded to their output.
+  std::unordered_map<IterDomain*, IterDomain*> producer_forwarding_map;
+  std::unordered_map<IterDomain*, IterDomain*> consumer_forwarding_map;
+
+  // Given a forward id map id_input -> id_forwarded
+  // Track the other inputs in the expr that id_input is an input to. These will
+  // be used to adjust the replay's leaf tracking. Don't need to track one to
+  // many as currently transformations on IterDomains can only have maximum 2
+  // inputs, but maybe in the future we'll have more.
+  std::unordered_map<IterDomain*, std::vector<IterDomain*>>
+      producer_compliment_map;
+  std::unordered_map<IterDomain*, std::vector<IterDomain*>>
+      consumer_compliment_map;
+
+  ForwardingInfo(const TensorView* producer, const TensorView* consumer);
+
+  ForwardingInfo() = delete;
+};
+
 /*
+ * Short Description:
+ *
+ * Given an Expr in target_domain, check if its inputs are in replay_map. If so,
+ * check if the mapped domain in replay_map are recorded to be transformed by an
+ * "equivelent" operation in replay_domain's history. If so, forward the
+ * operation and update replay_map to map the outputs of the expressions across
+ * target_domain and reference_domain.
+ *
+ * Long Description:
+ *
+ * replay_map maps root IDs in the history of target_domain to root IDs in the
+ * history replay_domain. PasC and CasP is just a convenient mechanism to have
+ * BestEffortReplay make this base root mapping.
+ *
+ * Note: See ForwardingInfo in transform_iter.cpp for more information on
+ * forwarding.
+ *
+ * Side note potentially for the future: In theory we could actually disconnect
+ * T4's view from it's rfactor domain. This would allow rfactor domains to be
+ * "reversible". The way this would have to be implemented is that there just
+ * needs to be a path of transformations from a tensors leaf domains, to its
+ * root domains, and its rfactor domain. It shouldn't really matter if those
+ * connections are forward or backward through transformations. The only thing
+ * that really matters is they're connected. This is left for future work as it
+ * could have significant impact on other parts of the system like how loops are
+ * generated and expressions are sorted.
  * Motivation:
  *
  * Consider the following program:
@@ -166,44 +236,73 @@ class ReplayTransformations : public IterVisitor {
  * T1[I0, R1i] = T4[I0, R1orf, I1irf]
  * T2[I0] = T1[I0, R1i]
  *
- * There's an issue when we call replayCasP on
- * T4[I0, R1o, I1i] = T0[I0, I1]
+ * There's an issue when we want to replay T4 to have transformations similar to
+ * those on T0. Primarily T0's "rfactor" domain has a strict match requirement
+ * on T4's root domain. If transformations on top of T0 don't match T4's
+ * transformations (from T4's root domain to T4's rfactor domain), T4 cannot be
+ * replayed like T0 on those domains as they would generate incorrect code in
+ * the system today.
  *
- * This would try to replay T4 as T0, and it could include the rfactor domains.
- * For example we compute T0 inline with T4. The way computeAt is setup this
- * would call replayPasC(T0, T4, -1) then repalyCasP(T4, T0, -1)
+ * T0 doesn't have this constraint if we want to replay T0 as T4, so this is
+ * directional based on rfactor. Therefore to replay T0 transformations onto T4
+ * we want to make sure those transformations are consistent with T4 (between
+ * T4's root and rfactor domain). Best Effort Replay does not actually add any
+ * transformations to the tensors provided. However, it will provide information
+ * to determine producers's transformations are consistent with consumers
+ * transformations (or the other way around). Best Effort Replay will return
+ * discovered mappings between tensors that it detects to be matching based on
+ * provided initial information (or just through p2c/c2p root domain mappings).
  *
- * We might assume that the only way we will hit this is if we call
- * T4->computeAt(T0...) so it might be safe to assume that the right
- * transformations would be replayed. However, we want to preserve the rfactor
- * domain, so since it would replay T4 at root, it would produce iterdomains
- * that wouldn't corresopnd to those in rfactor. Also, I don't know if this
- * assumption is correct.
+ * Transformations have a concept of "permissiveness" used for broadcast and
+ * squeeze. For example:
  *
- * Therefore, we will assume it is not correct, and we will validate here that
- * if we replay a domain that it would transform it in a way consistent with
- * any defined RFactor domains, then we will update the replay map so that
- * RFactor roots are mapped to intermediate IterDomains  in the target and start
- * replay from there.
+ * T1[I0, B1] = T0[I0]
+ * T2[I0, I1] = T1[I0, B1]
  *
+ * We may want to replay T1 and T0 based on transformations on T2. These
+ * transformations may involve B1. We could even have:
  *
- * SHORT DESCRIPTION:
+ * T2->merge(0, 1)->split(0, 128)
  *
- * This class will validate/do the above. It will also run through
- * transformations in target according to replay_map. If equal transformations
+ * resulting in:
+ *
+ * T2[(I0*I1)/128, 128]
+ *
+ * T0 doesn't have I1 so it can't technicaly be transformed in an exactly
+ * consistent way. However, it may still be desired to "inline" T0 into T1 and
+ * in result T1 into T2. It may further be desired to bind BIDx and TIDx to the
+ * two dimensions in the problem. This example doesn't "technically" result in
+ * thread to thread communication, but since our scope in mind is a shared
+ * global memory it results in duplicate reads. These duplicate reads are
+ * automatically cached in our memory hierarchy. So in a way there is implicit
+ * communication in that a memory location is read by multiple threads.
+ *
+ * This is where forwarding and permissiveness come into play. When we transform
+ * T1 with the first merge, we will mark the result I0*B1 of T1 to be
+ * "permissively" mapped to I0 of T0, so when we perform the split, we split
+ * T0's I0 dimension to I0/128 and 128. This is to help us mark inlining and
+ * paralellization across these dimensions so we can effectively reason about
+ * the "not full" dimension in T0. This is where the concept of forward map in
+ * BestEffortReplay comes in.
+ *
+ * Permissiveness can also be considered "symmetric" across broadcast and
+ * squeeze as they are similar operations, however broadcast and squeeze do have
+ * different implications since squeeze doesn't result in the implicit
+ * communication described in the previous paragraph. However, as far as
+ * forwarding is concerned they're symmetric. Indexing/parallelization has
+ * significant logic dedicated to broadcast resolutions (unlike squeeze).
+ *
+ * This class provides a mechanism to annalyze all of the above concepts. It
+ * can also run through transformations in target according to a manually
+ * specified IterDomain to IterDomain replay_map. If equal transformations
  * already exist in replay_domain history, we will not redo those
  * transformations, but instead update replay_map to reflect forwarding the
- * existing transformations. This later part is the "best effort" replay. Though
- * we include rfactor replay and validation here.
- *
- * Given an Expr in target_domain, check if its inputs are in replay_map. If so,
- * check if the mapped domain in replay_map are recorded to be transformed by an
- * equivelent operation in replay_domain's history. If so, "forward" the
- * operation and update replay_map to the outputs of target_domain's output(s),
- * to the output of the equivlent expr's outputs in relpay_domain's history.
- *
- * replay_map maps root IDs in the history of target_domain to root IDs in the
- * history replay_domain
+ * existing transformations based on a notion of expresions being "equal" (input
+ * IterDomains mapped and transformation expression parameters matching, or the
+ * iter domain that doesn't match is in a forwarding map). The replay map is the
+ * "best effort" part of BestEffortReplay, it doesn't actually perform new
+ * transformations to enforce matching, it just detects existing matching
+ * transforms. However, we still include rfactor validation within.
  */
 
 class BestEffortReplay {
@@ -215,17 +314,20 @@ class BestEffortReplay {
   std::vector<IterDomain*> forwarded_ids_;
   std::unordered_map<IterDomain*, IterDomain*> skipped_resize_id_map_;
 
-  // Need to track which id's have been forwarded. Later need to make sure leaf
-  // nodes to produce compliment axes are properly tracked. i.e.
+  // Need to track which id's have been forwarded. Later will need to make sure
+  // leaf nodes to produce "compliment" axes are properly tracked. i.e.
   // T[i0, b1, b2, i3]
   // -> T[i0, b1o, b1i, b2o, b2i, i3]
   // -> T[i0*b1i*b2o, b1o, b2i, i3]
   // -> T[i0*b1i*b2o*i3, b1o, b2i]
   // If we forwarded i0 -> i0*b1i*b2o*i3, we need to know that b1o and b2i
-  // are leaf nodes even though their split wasn't part of targets replay.
+  // are leaf nodes even though their split wasn't part of targets replay. These
+  // are important IterDomains to track for transformation replays as otherwise
+  // we could easily drop axes we need by accident
 
   // Counter to make sure best effort replay leaf_ids can be grabbed
-  // deterministicly
+  // deterministicly, important to make sure replays are run to run
+  // deterministic.
   size_t counter = 0;
 
   // Determine if current replay will ignore swizzle ops.
@@ -263,6 +365,10 @@ class BestEffortReplay {
   //    I02->I12
   //  }
   //
+  // TODO: Reevaluate swizzle and transform replays. We have some concepts on
+  // iter domain mapping we should formalize. It would be good to have these
+  // options accessible while specified in a consistent manner.
+  // https://github.com/ftxj/pytorch/pull/1#pullrequestreview-1210168522
   bool skip_replay_swizzle_ = true;
   bool skip_target_swizzle_ = true;
 
@@ -338,8 +444,9 @@ class BestEffortReplay {
   // Returned ordered set of IDs in getUnorderedLeafIDs
   std::vector<IterDomain*> getLeafIDs() {
     std::set<std::pair<IterDomain*, size_t>, id_int_lt> ordered_set;
-    for (auto entry : leaf_ids_)
+    for (auto entry : leaf_ids_) {
       ordered_set.emplace(entry);
+    }
 
     std::vector<IterDomain*> leaf_vec_;
     leaf_vec_.resize(ordered_set.size());

--- a/csrc/transform_iter.h
+++ b/csrc/transform_iter.h
@@ -213,15 +213,6 @@ class ForwardingInfo {
  * Note: See ForwardingInfo in transform_iter.cpp for more information on
  * forwarding.
  *
- * Side note potentially for the future: In theory we could actually disconnect
- * T4's view from it's rfactor domain. This would allow rfactor domains to be
- * "reversible". The way this would have to be implemented is that there just
- * needs to be a path of transformations from a tensors leaf domains, to its
- * root domains, and its rfactor domain. It shouldn't really matter if those
- * connections are forward or backward through transformations. The only thing
- * that really matters is they're connected. This is left for future work as it
- * could have significant impact on other parts of the system like how loops are
- * generated and expressions are sorted.
  * Motivation:
  *
  * Consider the following program:
@@ -242,6 +233,16 @@ class ForwardingInfo {
  * transformations (from T4's root domain to T4's rfactor domain), T4 cannot be
  * replayed like T0 on those domains as they would generate incorrect code in
  * the system today.
+ *
+ * Side note potentially for the future: In theory we could actually disconnect
+ * T4's view from it's rfactor domain. This would allow rfactor domains to be
+ * "reversible". The way this would have to be implemented is that there just
+ * needs to be a path of transformations from a tensors leaf domains, to its
+ * root domains, and its rfactor domain. It shouldn't really matter if those
+ * connections are forward or backward through transformations. The only thing
+ * that really matters is they're connected. This is left for future work as it
+ * could have significant impact on other parts of the system like how loops are
+ * generated and expressions are sorted.
  *
  * T0 doesn't have this constraint if we want to replay T0 as T4, so this is
  * directional based on rfactor. Therefore to replay T0 transformations onto T4


### PR DESCRIPTION
Taken out of #32. The `ForwardingInfo` class is going to be used from `IdModel`, so it's moved to the header file