### PR TITLE
Switch to 2D tensors in `gelu` and `scale-bias-relu` benchmarks.

### DIFF
--- a/python_benchmarks/test_gelu.py
+++ b/python_benchmarks/test_gelu.py
@@ -11,7 +11,7 @@ def gelu_fwd_fusion(
     dtype: DataType,
 ) -> None:
     input = fd.define_tensor(
-        shape=[-1, -1, -1], contiguity=[True, True, True], dtype=dtype, is_cpu=False
+        shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
     )
     bias = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
     if dtype in PROMOTE_DTYPES:
@@ -19,8 +19,8 @@ def gelu_fwd_fusion(
         bias = fd.ops.cast(bias, dtype=DataType.Float)
     S_079 = fd.define_scalar(0.79788456)
     S_004 = fd.define_scalar(0.044715)
-    V1 = fd.define_vector([1, 1, input.size(-1)], dtype=DataType.Int)
-    bias = fd.ops.broadcast_in_dim(bias, shape=V1, broadcast_dims=[2])
+    V1 = fd.define_vector([1, input.size(-1)], dtype=DataType.Int)
+    bias = fd.ops.broadcast_in_dim(bias, shape=V1, broadcast_dims=[1])
     T1 = fd.ops.add(input, bias)
     T2 = fd.ops.mul(S_079, T1)
     T3 = fd.ops.mul(S_004, T1)
@@ -43,10 +43,10 @@ def gelu_bwd_fusion(
     dtype: DataType,
 ) -> None:
     input = fd.define_tensor(
-        shape=[-1, -1, -1], contiguity=[True, True, True], dtype=dtype, is_cpu=False
+        shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
     )
     grad = fd.define_tensor(
-        shape=[-1, -1, -1], contiguity=[True, True, True], dtype=dtype, is_cpu=False
+        shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
     )
     bias = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
     if dtype in PROMOTE_DTYPES:
@@ -56,8 +56,8 @@ def gelu_bwd_fusion(
     S_079 = fd.define_scalar(0.79788456)
     S_004 = fd.define_scalar(0.044715)
     S_010 = fd.define_scalar(0.1070322243)
-    V1 = fd.define_vector([1, 1, input.size(-1)], dtype=DataType.Int)
-    bias = fd.ops.broadcast_in_dim(bias, shape=V1, broadcast_dims=[2])
+    V1 = fd.define_vector([1, input.size(-1)], dtype=DataType.Int)
+    bias = fd.ops.broadcast_in_dim(bias, shape=V1, broadcast_dims=[1])
     T1 = fd.ops.add(input, bias)
     T2 = fd.ops.mul(T1, S_079)
     T3 = fd.ops.mul(T1, S_004)
@@ -85,7 +85,7 @@ def gelu_bwd_fusion(
     fd.add_output(T20)
 
 
-@pytest.mark.parametrize("size", generate_input_sizes(dims=3))
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_gelu_fwd_benchmark(
     benchmark,
@@ -107,7 +107,7 @@ def test_gelu_fwd_benchmark(
     torch.cuda.empty_cache()
 
 
-@pytest.mark.parametrize("size", generate_input_sizes(dims=3))
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_gelu_bwd_benchmark(
     benchmark,

--- a/python_benchmarks/test_scale_bias_relu.py
+++ b/python_benchmarks/test_scale_bias_relu.py
@@ -13,8 +13,8 @@ def sbr_fwd_fusion(
     T0 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
     T1 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
     T2 = fd.define_tensor(
-        shape=[-1, -1, -1, -1],
-        contiguity=[True, True, True, True],
+        shape=[-1, -1],
+        contiguity=[True, True],
         dtype=dtype,
         is_cpu=False,
     )
@@ -25,10 +25,10 @@ def sbr_fwd_fusion(
         T2 = fd.ops.cast(T2, dtype=DataType.Float)
 
     V7 = T2.shape()
-    T8 = fd.ops.broadcast_in_dim(T1, shape=V7, broadcast_dims=[3])
+    T8 = fd.ops.broadcast_in_dim(T1, shape=V7, broadcast_dims=[1])
     T11 = fd.ops.mul(T2, T8)
 
-    T18 = fd.ops.broadcast_in_dim(T0, shape=V7, broadcast_dims=[3])
+    T18 = fd.ops.broadcast_in_dim(T0, shape=V7, broadcast_dims=[1])
     T20 = fd.ops.add(T11, T18)
 
     if dtype in PROMOTE_DTYPES:
@@ -48,14 +48,14 @@ def sbr_bwd_fusion(
 ):
     T0 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
     T1 = fd.define_tensor(
-        shape=[-1, -1, -1, -1],
-        contiguity=[True, True, True, True],
+        shape=[-1, -1],
+        contiguity=[True, True],
         dtype=DataType.Bool,
         is_cpu=False,
     )
     T2 = fd.define_tensor(
-        shape=[-1, -1, -1, -1],
-        contiguity=[True, True, True, True],
+        shape=[-1, -1],
+        contiguity=[True, True],
         dtype=dtype,
         is_cpu=False,
     )
@@ -65,7 +65,7 @@ def sbr_bwd_fusion(
         T2 = fd.ops.cast(T2, dtype=DataType.Float)
 
     V7 = T2.shape()
-    T8 = fd.ops.broadcast_in_dim(T0, shape=V7, broadcast_dims=[3])
+    T8 = fd.ops.broadcast_in_dim(T0, shape=V7, broadcast_dims=[1])
 
     S10 = fd.define_scalar(0.00000, dtype=DataType.Double)
     T11 = fd.ops.where(T1, T2, S10)
@@ -76,7 +76,7 @@ def sbr_bwd_fusion(
     fd.add_output(T15)
 
 
-@pytest.mark.parametrize("size", generate_input_sizes(dims=4))
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_sbr_fwd_benchmark(
     benchmark,
@@ -102,7 +102,7 @@ def test_sbr_fwd_benchmark(
     torch.cuda.empty_cache()
 
 
-@pytest.mark.parametrize("size", generate_input_sizes(dims=4))
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_sbr_bwd_benchmark(
     benchmark,


### PR DESCRIPTION
The current benchmarks use 3D and 4D tensor (for parity with CPP benchmarks), however for benchmarking purposes, there is no specific requirements for the inputs to be 3D/4D. 
Switching to 2D tensors will also reduce time as we start to increase the number of inputs as pointed by @jacobhinkle earlier (https://github.com/NVIDIA/Fuser/pull/1199#discussion_r1387385506).

