### PR TITLE
Relax the allocation domain constraint. 

### DIFF
--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -392,10 +392,10 @@ void AliasAnalysisResult::finalize(Fusion* fusion) {
 
 Layout AliasAnalysisResult::preferredLayout(const Val* v) const {
   const TensorView* tv = dynamic_cast<const TensorView*>(v);
-  NVF_CHECK(
+  NVF_ERROR(
       tv != nullptr,
       "`v` is expected to be a TensorView. Found: ",
-      v->toString());
+      v == nullptr ? "<null>" : v->toString());
 
   if (auto i = alias_to_source_.find(tv); i != alias_to_source_.end()) {
     return i->second.second;

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -19,6 +19,7 @@ struct Layout {
   std::vector<std::optional<bool>> contiguity;
 
   std::string toString(int indent_size = 0) const;
+  bool isCompatibleWith(const Layout& other) const;
 };
 
 // Holds aliases found in a fusion. The expected user flow is

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -19,7 +19,11 @@ struct Layout {
   std::vector<std::optional<bool>> contiguity;
 
   std::string toString(int indent_size = 0) const;
-  bool isCompatibleWith(const Layout& other) const;
+
+  // Returns whether this layout is compliant with `required`. This is
+  // uni-directional. For example, `contiguity=[t,t]` is compliant with
+  // `contiguity=[f,f]` but not vice versa.
+  bool isCompliantWith(const Layout& required) const;
 };
 
 // Holds aliases found in a fusion. The expected user flow is
@@ -75,10 +79,10 @@ class AliasAnalysisResult {
 };
 
 // Finds aliases of the fusion inputs. The analysis should be conservative --
-// when the analysis says B is an alias of input A and that B's layout
-// (allocation domain and contiguity) is compatible with the preferred layout,
-// `ExpressionEvaluator::evaluate(B)` should produce an `at::Tensor` that's an
-// alias of the `at::Tensor` bound to A.
+// when the analysis says B is an alias of input A and that B's preferred layout
+// is compliant with the required layout, `ExpressionEvaluator::evaluate(B)`
+// should produce an `at::Tensor` that's an alias of the `at::Tensor` bound to
+// A.
 //
 // Currently, for implementation convenience, AliasAnalysis ignores allocation
 // domains of non-fusion-input TensorViews. It produces preferred layouts for

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -299,7 +299,7 @@ TEST_F(AliasTest, View) {
   testValidate(fec.fusion(), {out_tensor}, {in_tensor}, __LINE__, __FILE__);
 }
 
-TEST_F(AliasTest, View_AliasForCompatibleLayout) {
+TEST_F(AliasTest, View_AliasForSameLayout) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -326,7 +326,31 @@ TEST_F(AliasTest, View_AliasForCompatibleLayout) {
   EXPECT_TRUE(out_tensor.is_alias_of(in_tensor));
 }
 
-TEST_F(AliasTest, View_NoAliasForIncompatibleLayout) {
+TEST_F(AliasTest, View_AliasForCompliantLayout) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  const std::vector<int64_t> in_shape({2, 3, 4});
+  const std::vector<int64_t> out_shape({2, 12});
+
+  TensorView* in = makeContigConcreteTensor(in_shape);
+  fusion->addInput(in);
+  TensorView* out = reshape(in, in_shape, out_shape);
+  fusion->addOutput(out);
+
+  out->setAllocationDomain({out->axis(0), out->axis(1)}, {false, false});
+
+  FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor = at::randn({2, 3, 4}).cuda();
+  std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
+  ASSERT_EQ(out_tensors.size(), 1);
+  at::Tensor out_tensor = out_tensors[0];
+  testValidate(fec.fusion(), {out_tensor}, {in_tensor}, __LINE__, __FILE__);
+
+  EXPECT_TRUE(out_tensor.is_alias_of(in_tensor));
+}
+
+TEST_F(AliasTest, View_NoAliasForIncompliantLayout) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 


### PR DESCRIPTION
Currently, `MarkAliasPass` skips an output when its allocation domain is set at all. This PR makes it smarter to check compliance.

This PR prepares #1478 for landing. Before segmentation, we'll run alias analysis on the un-segmented fusion and mark layouts for aliasing. During scheduling, we'll run alias analysis again on segmented fusions and have to recognize the preferred layout is compliant with the previously marked layout. 