### PR TITLE
fix codegen diff failure when number of segments in a fusion is changed

### DIFF
--- a/tools/codediff/diff_report.py
+++ b/tools/codediff/diff_report.py
@@ -729,11 +729,14 @@ class TestDifferences:
 
             compiled_test2 = self.run2.kernel_map[testname]
 
-            if len(compiled_test1.kernels) != len(compiled_test2.kernels):
+            test1_kernel_count = len(compiled_test1.kernels)
+            test2_kernel_count = len(compiled_test2.kernels)
+            minimum_kernel_count = min(test1_kernel_count, test2_kernel_count)
+            if test1_kernel_count != test2_kernel_count:
                 print(
-                    f"WARNING: Test {testname} has different number of kernels "
-                    f"in {self.run1.directory} than in {self.run2.directory}. "
-                    "Not showing diffs for this test.",
+                    f"WARNING: Test {testname} has {test1_kernel_count} kernels "
+                    f"in {self.run1.directory} and {test2_kernel_count} kernels in {self.run2.directory}. "
+                    f"Only showing diffs for the first {minimum_kernel_count} kernels in this test.",
                     file=sys.stderr,
                 )
                 self.test_diffs.append(
@@ -746,7 +749,7 @@ class TestDifferences:
                 )
 
             kernel_diffs = []
-            for kernel_num in range(len(compiled_test1.kernels)):
+            for kernel_num in range(minimum_kernel_count):
                 kern1 = self.run1.get_kernel(testname, kernel_num, strip_preamble=True)
                 kern2 = self.run2.get_kernel(testname, kernel_num, strip_preamble=True)
                 assert kern1.code is not None

--- a/tools/codediff/templates/test_diff_section.html
+++ b/tools/codediff/templates/test_diff_section.html
@@ -42,7 +42,8 @@ SPDX-License-Identifier: BSD-3-Clause
         {% endif %}
         <br>
         {% set outer_index = loop.index %}
-        {% for kernel_diff in test_diff.kernel_diffs %}
+        {% if test_diff.kernel_diffs is not none %}
+          {% for kernel_diff in test_diff.kernel_diffs %}
             {% if loop_vars.total_diffs == max_diffs + 1 %}
                 <br>
                 <b>WARNING: Only showing {{ max_diffs }} out of {{ total_num_diffs }}
@@ -133,6 +134,7 @@ SPDX-License-Identifier: BSD-3-Clause
 {%- endif -%}
 {%- set loop_vars.total_diffs = loop_vars.total_diffs + 1 -%}
 {%- endfor -%}
+{%- endif -%}
 <br>
 {%- endif -%}
 {%- endfor -%}


### PR DESCRIPTION
Issue: When number of segments in a fusion is reduced from 2 to 1, the codegen diff script tries to compare 2 kernels.
Fix: only compare the first N kernels, where `N = min(number of kernels in old code, number of kernels in new code)`