### PR TITLE
Handle duplicated outputs using ExpressionEvaluator.

### DIFF
--- a/csrc/expr_evaluator.h
+++ b/csrc/expr_evaluator.h
@@ -59,6 +59,10 @@ class ExpressionEvaluator {
   //! Try to evaluate a known value using const evaluator ref
   PolymorphicValue evaluate(const Val* value) const;
 
+  bool isKnown(const Val* value) const {
+    return known_values_.count(value) > 0;
+  }
+
   //! Debugging helper, prints all the currently known values
   void print() const;
 

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -739,4 +739,55 @@ TEST_F(AliasTest, DuplicateInputs) {
           testing::HasSubstr("duplicated inputs is not allowed")));
 }
 
+TEST_F(AliasTest, TrivialInputForwarding) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* tv0 = makeConcreteTensor({-1, -1});
+  TensorView* tv1 = makeConcreteTensor({-1, -1});
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  // Note: output of add is not used. Kept it here since previously there was an
+  // assertion from sorting in codegen.
+  add(tv1, IrBuilder::create<Val>(3.141));
+  fusion->addOutput(tv0);
+
+  at::Tensor t0 = at::randn({10, 4}).cuda();
+  at::Tensor t1 = at::randn({10, 4}).cuda();
+
+  FusionExecutorCache fec(std::move(fusion));
+  std::vector<at::Tensor> cg_outputs = fec.runFusionWithInputs({t0, t1});
+
+  EXPECT_EQ(cg_outputs[0].data_ptr(), t0.data_ptr());
+  testValidate(fec.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
+
+  // Second run to ensure cache hit handles trivial forwarding properly
+  NVF_CHECK(fec.isCompiled({t0, t1}));
+  auto cg_outputs2 = fec.runFusionWithInputs({t0, t1});
+  EXPECT_EQ(cg_outputs2[0].data_ptr(), t0.data_ptr());
+  testValidate(fec.fusion(), cg_outputs2, {t0, t1}, __LINE__, __FILE__);
+}
+
+TEST_F(AliasTest, TrivialInputForwarding_ScalarTensor) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* tv0 = makeSymbolicTensor(0);
+  fusion->addInput(tv0);
+  fusion->addOutput(tv0);
+
+  at::Tensor t0 = at::randn({}).cuda();
+
+  FusionExecutorCache fec(std::move(fusion));
+  auto cg_outputs = fec.runFusionWithInputs({t0});
+  EXPECT_EQ(cg_outputs[0].data_ptr(), t0.data_ptr());
+  testValidate(fec.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
+
+  // Second run to ensure cache hit handles trivial forwarding properly
+  NVF_CHECK(fec.isCompiled({t0}));
+  auto cg_outputs2 = fec.runFusionWithInputs({t0});
+  EXPECT_EQ(cg_outputs2[0].data_ptr(), t0.data_ptr());
+  testValidate(fec.fusion(), cg_outputs2, {t0}, __LINE__, __FILE__);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
I also tried using output-to-output aliases to handle this. It didn't work well because `getOutputAlias` couldn't distinguish the same `Val*` at different indices. To allocate a tensor for the first output but not the second, I would still end up with something like `outputs_map`.

This PR removes the ad-hoc `outputs_map` in favor of `ExpressionEvaluator`. It also moves trivial-input-forwarding tests to `test_alias.cpp` to make `test_gpu3.cpp` (slightly) smaller. 