### PR TITLE
Fix mapping propagation through backward merge

### DIFF
--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -1072,6 +1072,10 @@ void IdModel::build(
   }
 
   buildPermissiveMap(tv_exprs);
+  if (validate) {
+    validator->checkPermissiveGraphEquivalence(
+        idGraph(IdMappingMode::PERMISSIVE));
+  }
 
   // Permissive graph needs the trivial exprs from the almost exact graph to
   // build correctly. Once built though we can remove the trivial expressions

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -802,7 +802,9 @@ void IdModel::buildPermissiveMap(const std::vector<Expr*>& exprs) {
       // TODO: Should this just get rolled up in the forwarding map now?
       for (const auto& entry : permissive_forwarding.producer_compliment_map) {
         for (auto entry_2 : entry.second) {
-          idGraph(IdMappingMode::PERMISSIVE).mapVals(entry.first, entry_2);
+          if (getenv("COMP")) {
+            idGraph(IdMappingMode::PERMISSIVE).mapVals(entry.first, entry_2);
+          }
         }
       }
 
@@ -814,7 +816,9 @@ void IdModel::buildPermissiveMap(const std::vector<Expr*>& exprs) {
       // TODO: Why should IDs be mapped to their compliments? Is this right?
       for (const auto& entry : permissive_forwarding.consumer_compliment_map) {
         for (auto entry_2 : entry.second) {
-          idGraph(IdMappingMode::PERMISSIVE).mapVals(entry.first, entry_2);
+          if (getenv("COMP")) {
+            idGraph(IdMappingMode::PERMISSIVE).mapVals(entry.first, entry_2);
+          }
         }
       }
 

--- a/csrc/id_model/validation_utils.cpp
+++ b/csrc/id_model/validation_utils.cpp
@@ -196,4 +196,23 @@ void IdModelValidator::checkAlmostExactGraphEquivalence(
   compareDisjointSets(ca_map_sets, almost_exact_graph.disjointValSets());
 }
 
+void IdModelValidator::checkPermissiveGraphEquivalence(
+    const ValGraph& permissive_graph) {
+  if (has_swizzle_) {
+    // Ignoring a fusion with swizzle
+    return;
+  }
+
+  // Empty graph
+  if (permissive_graph.disjointValSets().disjointSets().empty()) {
+    return;
+  }
+
+  DisjointSets<IterDomain*> ca_map_sets = ca_map_.id_graph_.permissive_nodes_;
+
+  fullyPropagateMappings(ca_map_sets);
+
+  compareDisjointSets(ca_map_sets, permissive_graph.disjointValSets());
+}
+
 } // namespace nvfuser

--- a/csrc/id_model/validation_utils.h
+++ b/csrc/id_model/validation_utils.h
@@ -40,6 +40,8 @@ class IdModelValidator {
 
   void checkAlmostExactGraphEquivalence(const ValGraph& almost_exact_graph);
 
+  void checkPermissiveGraphEquivalence(const ValGraph& permissive_graph);
+
  private:
   // Propagate mappings in a ComputeAtMap as is done in IdModel
   static void fullyPropagateMappings(DisjointSets<IterDomain*>& id_sets);


### PR DESCRIPTION
While working on comparing the Permissive graph with the CA Permissive map, I found one thing that I think should be considered inconsistency. When backward propagating mappings through a Merge expr, we require at least one of the input domain pairs should be already mapped or have equal extents, which makes sense, but the current code only checks the extents of one ID out of each ID group, which is fine with the Exact graph but in the case of the Permissive graph, each ID group may consist of domains that have different extents, so I think we would also need to check all domains in the group, and if there's one matching pair, we should allow propagation. 

This PR also adds the validation of the Permissive graph. It does not pass yet as the CA map does not map the compliment IDs.