### PR TITLE
Add utilities for debugging MMA

### DIFF
--- a/test/test_mma.cpp
+++ b/test/test_mma.cpp
@@ -19,6 +19,49 @@
 
 namespace nvfuser {
 
+namespace debug {
+
+// Utilities for debugging MMA ops
+
+// Set a tensor as identity, for example
+//  [1, 0, 0]
+//  [0, 1, 0]
+//  [0, 0, 1]
+//  [0, 0, 0]
+//  [0, 0, 0]
+// This is helpful for debugging because mathematically, an identity matrix
+// multiplies any matrix to itself. For example, if you are seeing a wrong
+// result, but you don't know if it's because of the input B's memory format is
+// not scheduled correctly, you can set the input A to identity and print the
+// output. By reading the output, you can tell how the memory layout of input B
+// looks like.
+void setAsIdentity(at::Tensor tensor) {
+  tensor.zero_();
+  for (auto i : c10::irange(tensor.size(0))) {
+    for (auto j : c10::irange(tensor.size(1))) {
+      if (i == j) {
+        tensor[i][j] = 1;
+      }
+    }
+  }
+}
+
+// Set a tensor as a range, for example
+//  [0, 1, 2]
+//  [3, 4, 5]
+//  [6, 7, 8]
+// This makes the tensor easier to read if you print it out.
+void setAsARange(at::Tensor tensor) {
+  tensor.zero_();
+  for (auto i : c10::irange(tensor.size(0))) {
+    for (auto j : c10::irange(tensor.size(1))) {
+      tensor[i][j] = i * tensor.size(1) + j;
+    }
+  }
+}
+
+} // namespace debug
+
 using MmaTestParams = std::tuple<MmaMacro, PrimDataType, MmaLayout>;
 
 class MmaTest : public NVFuserFixtureParamTest<MmaTestParams> {

--- a/test/test_mma.cpp
+++ b/test/test_mma.cpp
@@ -60,7 +60,7 @@ void setAsARange(at::Tensor tensor) {
   }
 }
 
-} // namespace debug
+} // namespace debugging
 
 using MmaTestParams = std::tuple<MmaMacro, PrimDataType, MmaLayout>;
 

--- a/test/test_mma.cpp
+++ b/test/test_mma.cpp
@@ -19,7 +19,7 @@
 
 namespace nvfuser {
 
-namespace debug {
+namespace debugging {
 
 // Utilities for debugging MMA ops
 


### PR DESCRIPTION
During development, I feel that it is super helpful to set one matrix as identity, and set another matrix as arange, and print out the result. By reading the result, I can easily tell the memory layout. I think this debugging technique is so helpful that it worth committing it to our codebase for future reference.