### PR TITLE
Drop some const qualifiers to avoid `const_cast`s.

### DIFF
--- a/csrc/optimization/alias_analysis.cpp
+++ b/csrc/optimization/alias_analysis.cpp
@@ -336,7 +336,7 @@ void AliasFinder::handle(const SliceOp* slice) {
 
 void AliasAnalysisResult::add(
     const TensorView* alias,
-    const TensorView* source,
+    TensorView* source,
     Layout&& layout) {
   auto [i, inserted] = alias_to_source_.emplace(
       alias, std::make_pair(source, std::move(layout)));
@@ -351,8 +351,8 @@ void AliasAnalysisResult::add(
       i->second.first->toString());
 }
 
-const Val* AliasAnalysisResult::findRoot(const Val* alias) const {
-  const TensorView* root = dynamic_cast<const TensorView*>(alias);
+Val* AliasAnalysisResult::findRoot(Val* alias) const {
+  TensorView* root = dynamic_cast<TensorView*>(alias);
   if (root == nullptr) {
     return alias;
   }
@@ -365,7 +365,7 @@ const Val* AliasAnalysisResult::findRoot(const Val* alias) const {
   return root;
 }
 
-const TensorView* AliasAnalysisResult::getAliasedInput(
+TensorView* AliasAnalysisResult::getAliasedInput(
     const TensorView* fusion_out) const {
   const auto i = out_to_root_.find(fusion_out);
   return i == out_to_root_.end() ? nullptr : i->second;
@@ -388,7 +388,7 @@ void AliasAnalysisResult::finalize(
     const bool can_override_empty_allocation_domain) {
   for (TensorView* out :
        ir_utils::filterByType<TensorView>(fusion->outputs())) {
-    const Val* in = findRoot(out);
+    Val* in = findRoot(out);
     if (!in->isFusionInput()) {
       continue;
     }

--- a/csrc/optimization/alias_analysis.h
+++ b/csrc/optimization/alias_analysis.h
@@ -49,7 +49,7 @@ class AliasAnalysisResult {
 
   // Marks `source` as the immediate aliasing source of `alias` and sets the
   // preferred layout.
-  void add(const TensorView* alias, const TensorView* source, Layout&& layout);
+  void add(const TensorView* alias, TensorView* source, Layout&& layout);
 
   // See `findAliases` for the meaning of
   // `can_override_empty_allocation_domain`.
@@ -63,23 +63,23 @@ class AliasAnalysisResult {
 
   // Gets the aliased fusion input of a fusion output. Returns nullptr
   // when `fusion_out` is not a fusion output or does not alias a fusion input.
-  const TensorView* getAliasedInput(const TensorView* fusion_out) const;
+  TensorView* getAliasedInput(const TensorView* fusion_out) const;
 
  private:
   // Walks up `alias_to_source_` to find the root of the chain. Returns itself
   // if `alias` doesn't alias anything.
-  const Val* findRoot(const Val* alias) const;
+  Val* findRoot(Val* alias) const;
 
   // Maps aliases (e.g. the output of a View) to their direct sources (e.g. the
   // input of the same View). Also stores the preferred output layout for the
   // alias. Consider path compression, a common optimization used in
   // disjoint-set data structure, so it's easy to figure out the root of an
   // alias.
-  std::unordered_map<const TensorView*, std::pair<const TensorView*, Layout>>
+  std::unordered_map<const TensorView*, std::pair<TensorView*, Layout>>
       alias_to_source_;
 
   // Maps a fusion output to its aliased fusion input.
-  std::unordered_map<const TensorView*, const TensorView*> out_to_root_;
+  std::unordered_map<const TensorView*, TensorView*> out_to_root_;
 };
 
 // Finds aliases of the fusion inputs. The analysis should be conservative --

--- a/csrc/optimization/optimize_layout.cpp
+++ b/csrc/optimization/optimize_layout.cpp
@@ -22,7 +22,7 @@ void OptimizeLayoutPass::runPass(Fusion* fusion) {
 
   for (TensorView* out :
        ir_utils::filterByType<TensorView>(fusion->outputs())) {
-    const TensorView* in = analysis.getAliasedInput(out);
+    TensorView* in = analysis.getAliasedInput(out);
     if (in == nullptr) {
       continue;
     }

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -35,16 +35,12 @@ void markAliases(Fusion* fusion) {
 
   for (TensorView* out :
        ir_utils::filterByType<TensorView>(fusion->outputs())) {
-    const Val* in = analysis.getAliasedInput(out);
+    TensorView* in = analysis.getAliasedInput(out);
     if (in == nullptr) {
       continue;
     }
 
-    fusion->aliasOutputToInput(
-        out,
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-        const_cast<Val*>(in),
-        AliasType::PointerArithmetic);
+    fusion->aliasOutputToInput(out, in, AliasType::PointerArithmetic);
     vlog(
         "Marked ",
         ir_utils::varName(out),


### PR DESCRIPTION
This removes the `const` qualifier from map values but not keys. It's getting more often to retrieve the source of an alias and modifies it, e.g., #1503. 