### PR TITLE
IdModel: Add the Permissive graph

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -381,7 +381,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (isOptionEnabled(EnableOption::IdModel)) {
+  if (true || isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_, false, true);
   }
 

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -381,7 +381,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (true || isOptionEnabled(EnableOption::IdModel)) {
+  if (isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_, false, true);
   }
 

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -528,8 +528,8 @@ void IdModel::build(
 
   buildPermissiveMap(tv_exprs);
   if (validate) {
-    // validator->checkPermissiveGraphEquivalence(
-    // idGraph(IdMappingMode::PERMISSIVE));
+    validator->checkPermissiveGraphEquivalence(
+        idGraph(IdMappingMode::PERMISSIVE));
   }
 
   // Make sure there's no self mapping in TensorView's during lowering

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -442,8 +442,6 @@ void IdModel::buildPermissiveMap(const std::vector<Expr*>& exprs) {
   for (auto expr : exprs) {
     // Multiple outputs are already mapped, we can ignore all but the first
     // consumer given they have to be replayed in the same exact way
-    // Multiple outputs are already mapped, we can ignore all but the first
-    // consumer given they have to be replayed in the same exact way
     TensorView* c_tv = ir_utils::getTvOutput(expr);
 
     auto tv_inputs = ir_utils::filterByType<TensorView>(expr->inputs());

--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -46,6 +46,17 @@ class ValGraph;
 // IdMappingMode::EXACT
 //   Don't map any broadcast axes to non-broadcast axes
 //   Do not forward through any broadcast IDs
+// IdMappingMode::PERMISSIVE
+//   Forward broadcast axes in replay
+//   Map all iteration domains
+//   Always contain root mappings (otherwise they could have been forwarded in
+//   broadcast)
+// IdMappingMode::AlmostExact
+//   Forward through broadcast axes, but not through to a non-broadcast axis
+//     i.e. id{b1*i0}, id{i0} are mapped
+//          id{i1*i0}, id{i0} are not mapped (this part is the difference from
+//          PERMISSIVE)
+//   Forward through split one axes, i.e. id{ceilDiv(i0, 1)}, id{i0} are mapped
 //
 class IdModel : public PolymorphicBase {
  public:

--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -115,6 +115,10 @@ class IdModel : public PolymorphicBase {
   // split by a size-1 dimension.
   void buildAlmostExactMap();
 
+  // Fills disjoint_ids_[IdMappingMode::PERMISSIVE]. Initialize it as
+  // Exact entries, then map through broadcasts
+  void buildPermissiveMap(const std::vector<Expr*>& exprs);
+
   // Errors if self mapping occurs
   void assertNoSelfMapping();
 

--- a/csrc/id_model/validation_utils.cpp
+++ b/csrc/id_model/validation_utils.cpp
@@ -15,6 +15,8 @@
 
 namespace nvfuser {
 
+namespace {
+
 // Same as IterDomain::exprsMap but uses
 // ValGraph::mapMergeBackward. Copying the funciton here isn't ideal,
 // but it doesn't make sense to change the ComputeAtMap code just for

--- a/csrc/id_model/validation_utils.cpp
+++ b/csrc/id_model/validation_utils.cpp
@@ -78,7 +78,7 @@ bool exprsMap(
   }
 
   if (first->isA<Merge>() && !forward) {
-    if (!ValGraph::mapMergeBackward<IterDomain>(
+    if (!ValGraph::shouldMapMergeBackward<IterDomain>(
             first->as<Merge>(), second->as<Merge>(), id_map)) {
       return false;
     }

--- a/csrc/id_model/validation_utils.cpp
+++ b/csrc/id_model/validation_utils.cpp
@@ -196,4 +196,23 @@ void IdModelValidator::checkAlmostExactGraphEquivalence(
   compareDisjointSets(ca_map_sets, almost_exact_graph.disjointValSets());
 }
 
+void IdModelValidator::checkPermissiveGraphEquivalence(
+    const ValGraph& permissive_graph) {
+  if (has_swizzle_) {
+    // Ignoring a fusion with swizzle
+    return;
+  }
+
+  // Empty graph
+  if (permissive_graph.disjointValSets().disjointSets().empty()) {
+    return;
+  }
+
+  DisjointSets<IterDomain*> ca_map_sets = ca_map_.id_graph_.permissive_nodes_;
+
+  fullyPropagateMappings(ca_map_sets);
+
+  compareDisjointSets(ca_map_sets, permissive_graph.disjointValSets());
+}
+
 } // namespace nvfuser

--- a/csrc/id_model/validation_utils.cpp
+++ b/csrc/id_model/validation_utils.cpp
@@ -35,8 +35,9 @@ bool exprsMap(
   }
 
   NVF_ERROR(
-      first->isA<Merge>() || first->isA<Split>() || first->isA<Resize>(),
-      "Merge, split and resize are the only expressions supported through rfactor operations in compute at map, but found:\n",
+      first->isA<Merge>() || first->isA<Split>() || first->isA<Resize>() ||
+          first->isA<Swizzle>(),
+      "Merge, split, resize and swizzle are the only expressions supported here, but found:\n",
       first->toString());
 
   auto first_ids = ir_utils::filterByType<IterDomain>(
@@ -100,6 +101,14 @@ bool exprsMap(
     auto second_resize = second->as<Resize>();
     if (!first_resize->leftExpand()->sameAs(second_resize->leftExpand()) ||
         !first_resize->rightExpand()->sameAs(second_resize->rightExpand())) {
+      return false;
+    }
+  }
+
+  if (first->isA<Swizzle>()) {
+    auto swizzle_1 = first->as<Swizzle>();
+    auto swizzle_2 = first->as<Swizzle>();
+    if (swizzle_1->swizzleType() != swizzle_2->swizzleType()) {
       return false;
     }
   }

--- a/csrc/id_model/validation_utils.h
+++ b/csrc/id_model/validation_utils.h
@@ -40,6 +40,8 @@ class IdModelValidator {
 
   void checkAlmostExactGraphEquivalence(const ValGraph& almost_exact_graph);
 
+  void checkPermissiveGraphEquivalence(const ValGraph& permissive_graph);
+
  private:
   // Propagate mappings in a ComputeAtMap as is done in IdModel
   static void fullyPropagateMappings(DisjointSets<IterDomain*>& id_sets);

--- a/csrc/val_graph.cpp
+++ b/csrc/val_graph.cpp
@@ -256,7 +256,7 @@ bool ValGraph::exprsMap(Expr* first, Expr* second, bool forward) const {
 
   // Special handling for backprop of merge
   if (first->isA<Merge>() && !forward) {
-    if (!ValGraph::mapMergeBackward<Val>(
+    if (!shouldMapMergeBackward<Val>(
             first->as<Merge>(), second->as<Merge>(), this->disjointValSets())) {
       return false;
     }

--- a/csrc/val_graph.cpp
+++ b/csrc/val_graph.cpp
@@ -227,78 +227,6 @@ void ValGraph::initializeVal(Val* val) {
   initializeVal(val, defs, uses);
 }
 
-namespace {
-
-// Can't back prop through merge without making sure one input actually
-// matches. This can be done on a map or extent basis.
-bool mapMergeBackward(Merge* merge0, Merge* merge1, const ValGraph& graph) {
-  auto extent_match = [](IterDomain* id0, IterDomain* id1) -> bool {
-    return id0->extent()->sameAs(id1->extent()) ||
-        (id0->extent()->isConstInt() && id1->extent()->isConstInt() &&
-         id0->extent()->evaluate() == id1->extent()->evaluate());
-  };
-
-  // If one pair of the domains are mapped in the given graph, the
-  // backward merge is considered mapped
-  if (graph.disjointValSets().permissiveAreMapped(
-          merge0->outer(), merge1->outer()) ||
-      graph.disjointValSets().permissiveAreMapped(
-          merge0->inner(), merge1->inner())) {
-    return true;
-  }
-
-  // Considered mapped if the extents are equal
-  if (extent_match(merge0->outer(), merge1->outer()) ||
-      extent_match(merge0->inner(), merge1->inner())) {
-    return true;
-  }
-
-  // The mapped ID group may have different extents depending on the
-  // mapping conditions. For example, the Permissive graph may have a
-  // symbolic extent as well as an extent of 1 for broadcast
-  // domains. Those other mapped domains need to be checked as well.
-
-  // First, the outer groups
-  ValGroup outer0_group = graph.hasGroup(merge0->outer())
-      ? graph.toGroup(merge0->outer())
-      : std::make_shared<VectorOfUniqueEntries<Val*>>(
-            VectorOfUniqueEntries<Val*>{merge0->outer()});
-  ValGroup outer1_group = graph.hasGroup(merge1->outer())
-      ? graph.toGroup(merge1->outer())
-      : std::make_shared<VectorOfUniqueEntries<Val*>>(
-            VectorOfUniqueEntries<Val*>{merge1->outer()});
-
-  for (Val* outer0 : *outer0_group) {
-    for (Val* outer1 : *outer1_group) {
-      if (extent_match(outer0->as<IterDomain>(), outer1->as<IterDomain>())) {
-        return true;
-      }
-    }
-  }
-
-  // Check the inner groups as well if not already matched
-  ValGroup inner0_group = graph.hasGroup(merge0->inner())
-      ? graph.toGroup(merge0->inner())
-      : std::make_shared<VectorOfUniqueEntries<Val*>>(
-            VectorOfUniqueEntries<Val*>{merge0->inner()});
-  ValGroup inner1_group = graph.hasGroup(merge1->inner())
-      ? graph.toGroup(merge1->inner())
-      : std::make_shared<VectorOfUniqueEntries<Val*>>(
-            VectorOfUniqueEntries<Val*>{merge1->inner()});
-
-  for (Val* inner0 : *inner0_group) {
-    for (Val* inner1 : *inner1_group) {
-      if (extent_match(inner0->as<IterDomain>(), inner1->as<IterDomain>())) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
-} // namespace
-
 bool ValGraph::exprsMap(Expr* first, Expr* second, bool forward) const {
   NVF_ERROR(first);
   NVF_ERROR(second);
@@ -328,7 +256,8 @@ bool ValGraph::exprsMap(Expr* first, Expr* second, bool forward) const {
 
   // Special handling for backprop of merge
   if (first->isA<Merge>() && !forward) {
-    if (!mapMergeBackward(first->as<Merge>(), second->as<Merge>(), *this)) {
+    if (!ValGraph::mapMergeBackward<Val>(
+            first->as<Merge>(), second->as<Merge>(), this->disjointValSets())) {
       return false;
     }
   }

--- a/csrc/val_graph.cpp
+++ b/csrc/val_graph.cpp
@@ -227,6 +227,78 @@ void ValGraph::initializeVal(Val* val) {
   initializeVal(val, defs, uses);
 }
 
+namespace {
+
+// Can't back prop through merge without making sure one input actually
+// matches. This can be done on a map or extent basis.
+bool mapMergeBackward(Merge* merge0, Merge* merge1, const ValGraph& graph) {
+  auto extent_match = [](IterDomain* id0, IterDomain* id1) -> bool {
+    return id0->extent()->sameAs(id1->extent()) ||
+        (id0->extent()->isConstInt() && id1->extent()->isConstInt() &&
+         id0->extent()->evaluate() == id1->extent()->evaluate());
+  };
+
+  // If one pair of the domains are mapped in the given graph, the
+  // backward merge is considered mapped
+  if (graph.disjointValSets().permissiveAreMapped(
+          merge0->outer(), merge1->outer()) ||
+      graph.disjointValSets().permissiveAreMapped(
+          merge0->inner(), merge1->inner())) {
+    return true;
+  }
+
+  // Considered mapped if the extents are equal
+  if (extent_match(merge0->outer(), merge1->outer()) ||
+      extent_match(merge0->inner(), merge1->inner())) {
+    return true;
+  }
+
+  // The mapped ID group may have different extents depending on the
+  // mapping conditions. For example, the Permissive graph may have a
+  // symbolic extent as well as an extent of 1 for broadcast
+  // domains. Those other mapped domains need to be checked as well.
+
+  // First, the outer groups
+  ValGroup outer0_group = graph.hasGroup(merge0->outer())
+      ? graph.toGroup(merge0->outer())
+      : std::make_shared<VectorOfUniqueEntries<Val*>>(
+            VectorOfUniqueEntries<Val*>{merge0->outer()});
+  ValGroup outer1_group = graph.hasGroup(merge1->outer())
+      ? graph.toGroup(merge1->outer())
+      : std::make_shared<VectorOfUniqueEntries<Val*>>(
+            VectorOfUniqueEntries<Val*>{merge1->outer()});
+
+  for (Val* outer0 : *outer0_group) {
+    for (Val* outer1 : *outer1_group) {
+      if (extent_match(outer0->as<IterDomain>(), outer1->as<IterDomain>())) {
+        return true;
+      }
+    }
+  }
+
+  // Check the inner groups as well if not already matched
+  ValGroup inner0_group = graph.hasGroup(merge0->inner())
+      ? graph.toGroup(merge0->inner())
+      : std::make_shared<VectorOfUniqueEntries<Val*>>(
+            VectorOfUniqueEntries<Val*>{merge0->inner()});
+  ValGroup inner1_group = graph.hasGroup(merge1->inner())
+      ? graph.toGroup(merge1->inner())
+      : std::make_shared<VectorOfUniqueEntries<Val*>>(
+            VectorOfUniqueEntries<Val*>{merge1->inner()});
+
+  for (Val* inner0 : *inner0_group) {
+    for (Val* inner1 : *inner1_group) {
+      if (extent_match(inner0->as<IterDomain>(), inner1->as<IterDomain>())) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+} // namespace
+
 bool ValGraph::exprsMap(Expr* first, Expr* second, bool forward) const {
   NVF_ERROR(first);
   NVF_ERROR(second);
@@ -256,27 +328,7 @@ bool ValGraph::exprsMap(Expr* first, Expr* second, bool forward) const {
 
   // Special handling for backprop of merge
   if (first->isA<Merge>() && !forward) {
-    // Can't back prop through merge without making sure one input actually
-    // matches. This can be done on a map or extent basis.
-    auto merge0 = first->as<Merge>();
-    auto merge1 = second->as<Merge>();
-
-    auto extent_0o = merge0->outer()->extent();
-    auto extent_0i = merge0->inner()->extent();
-    auto extent_1o = merge1->outer()->extent();
-    auto extent_1i = merge1->inner()->extent();
-
-    auto extent_o_match = extent_0o->sameAs(extent_1o) ||
-        (extent_0o->isConstInt() && extent_1o->isConstInt() &&
-         extent_0o->evaluate() == extent_1o->evaluate()) ||
-        disjointValSets().permissiveAreMapped(merge0->outer(), merge1->outer());
-
-    auto extent_i_match = extent_0i->sameAs(extent_1i) ||
-        (extent_0i->isConstInt() && extent_1i->isConstInt() &&
-         extent_0i->evaluate() == extent_1i->evaluate()) ||
-        disjointValSets().permissiveAreMapped(merge0->inner(), merge1->inner());
-
-    if (!(extent_o_match || extent_i_match)) {
+    if (!mapMergeBackward(first->as<Merge>(), second->as<Merge>(), *this)) {
       return false;
     }
   }

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -159,6 +159,82 @@ class ValGraph {
   // be the only call in ValGraph to mapThroughExpr.
   void maybeMapThroughExprs(Expr* expr0, Expr* expr1, bool forward);
 
+  // Can't back prop through merge without making sure one input actually
+  // matches. This can be done on a map or extent basis.
+  // TODO: Move this to val_graph.cpp once validation_utils.cpp is
+  // retired.
+  template <typename T>
+  static bool mapMergeBackward(
+      Merge* merge0,
+      Merge* merge1,
+      const DisjointSets<T*>& id_sets) {
+    auto extent_match = [](IterDomain* id0, IterDomain* id1) -> bool {
+      return id0->extent()->sameAs(id1->extent()) ||
+          (id0->extent()->isConstInt() && id1->extent()->isConstInt() &&
+           id0->extent()->evaluate() == id1->extent()->evaluate());
+    };
+
+    // If one pair of the domains are mapped in the given graph, the
+    // backward merge is considered mapped
+    if (id_sets.permissiveAreMapped(merge0->outer(), merge1->outer()) ||
+        id_sets.permissiveAreMapped(merge0->inner(), merge1->inner())) {
+      return true;
+    }
+
+    // Considered mapped if the extents are equal
+    if (extent_match(merge0->outer(), merge1->outer()) ||
+        extent_match(merge0->inner(), merge1->inner())) {
+      return true;
+    }
+
+    // The mapped ID group may have different extents depending on the
+    // mapping conditions. For example, the Permissive graph may have a
+    // symbolic extent as well as an extent of 1 for broadcast
+    // domains. Those other mapped domains need to be checked as well.
+
+    // First, the outer groups
+    auto outer0_group = id_sets.mappingExists(merge0->outer())
+        ? id_sets.disjointSetMap().at(merge0->outer())
+        : std::make_shared<VectorOfUniqueEntries<T*>>(
+              VectorOfUniqueEntries<T*>{merge0->outer()});
+    auto outer1_group = id_sets.mappingExists(merge1->outer())
+        ? id_sets.disjointSetMap().at(merge1->outer())
+        : std::make_shared<VectorOfUniqueEntries<T*>>(
+              VectorOfUniqueEntries<T*>{merge1->outer()});
+
+    for (T* outer0 : *outer0_group) {
+      for (T* outer1 : *outer1_group) {
+        if (extent_match(
+                outer0->template as<IterDomain>(),
+                outer1->template as<IterDomain>())) {
+          return true;
+        }
+      }
+    }
+
+    // Check the inner groups as well if not already matched
+    auto inner0_group = id_sets.mappingExists(merge0->inner())
+        ? id_sets.disjointSetMap().at(merge0->inner())
+        : std::make_shared<VectorOfUniqueEntries<T*>>(
+              VectorOfUniqueEntries<T*>{merge0->inner()});
+    auto inner1_group = id_sets.mappingExists(merge1->inner())
+        ? id_sets.disjointSetMap().at(merge1->inner())
+        : std::make_shared<VectorOfUniqueEntries<T*>>(
+              VectorOfUniqueEntries<T*>{merge1->inner()});
+
+    for (T* inner0 : *inner0_group) {
+      for (T* inner1 : *inner1_group) {
+        if (extent_match(
+                inner0->template as<IterDomain>(),
+                inner1->template as<IterDomain>())) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
  private:
   // Map expr0 and expr1 with each other, update unique_definitions_
   // unique_uses_

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -164,7 +164,7 @@ class ValGraph {
   // TODO: Move this to val_graph.cpp once validation_utils.cpp is
   // retired.
   template <typename T>
-  static bool mapMergeBackward(
+  static bool shouldMapMergeBackward(
       Merge* merge0,
       Merge* merge1,
       const DisjointSets<T*>& id_sets) {


### PR DESCRIPTION
Added the Permissive graph. The main logic is at `IdModel::buildPermissiveMap`. 

While validating the generated graphs by comparing them with the corresponding ComputeAtMap Permissive maps, some mismatches were found. It turned out that `ValGraph::exprsMap` needed more thorough comparisons when back propagating Merge expressions. See `ValGraph::mapMergeBackward`.