### PR TITLE
Fix test_deterministic_random

### DIFF
--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -2558,20 +2558,17 @@ class TestNvFuserFrontend(TestCase):
                 torch.manual_seed(seed)
 
                 stateful_sequence = [fd_stoch.execute(inputs) for _ in range(10)]
-                # Each call to uniform with DataType::Float will advance the offset by 4
+                # Each call to uniform with DataType::Float will advance the offset by one
+                # See Note [Divide offset by 4] in rng.cpp for more information
                 stateless_sequence = [
                     fd_det.execute([inputs[0], seed, rng_offset])
-                    for rng_offset in range(0, 10 * 4, 4)
+                    for rng_offset in range(10)
                 ]
 
                 for i, (sful, sless) in enumerate(
                     zip(stateful_sequence, stateless_sequence)
                 ):
-                    try:
-                        torch.testing.assert_close(sful[0], sless[0])
-                    except AssertionError as e:
-                        print(f"Assertion failed for iteration {i} with seed {seed}")
-                        print(e)
+                    torch.testing.assert_close(sful[0], sless[0])
 
     # Test expand to zero is replaced with expanded extent and not 1
     # see https://github.com/NVIDIA/Fuser/issues/603


### PR DESCRIPTION
The python frontend test `test_deterministic_random` was originally introduced in #546. It actually printed mismatches, but did not fail the test in those cases. It turns out it has been failing but it went unnoticed. This change unmasks that allclose check.

The test had assumed the offset should be advanced by 4 for every 4-byte RNG op. This is how PyTorch handles offsets. However, we base our offset on uint4, so our offset corresponds to 1/4 the pytorch offset. This means we should only advance by one for each op in the test. Doing this silences the warnings (which are now errors).

See https://github.com/NVIDIA/Fuser/blob/main/csrc/rng.cpp#L54-L64 for more info on our offsets and their equivalents in PyTorch.