### PR TITLE
Split `fwd` and `bwd` benchmarks into different files

### DIFF
--- a/python_benchmarks/test_batchnorm_bwd.py
+++ b/python_benchmarks/test_batchnorm_bwd.py
@@ -1,0 +1,27 @@
+import pytest
+import torch
+from .global_params import generate_input_sizes, FLOAT_DTYPES
+from .normalization import norm_bwd_benchmark
+
+
+@pytest.mark.parametrize("size", generate_input_sizes(dims=4))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("channels_last", [True, False])
+def test_batchnorm_bwd_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    channels_last: bool,
+    disable_validation: bool,
+    disable_benchmarking: bool,
+    eps: float = 1e-5,
+):
+    norm_bwd_benchmark(
+        benchmark,
+        size,
+        dtype,
+        "batch_norm",
+        channels_last,
+        disable_validation,
+        disable_benchmarking,
+    )

--- a/python_benchmarks/test_batchnorm_fwd.py
+++ b/python_benchmarks/test_batchnorm_fwd.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES
-from .normalization import norm_fwd_benchmark, norm_bwd_benchmark
+from .normalization import norm_fwd_benchmark
 
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
@@ -16,29 +16,6 @@ def test_batchnorm_fwd_benchmark(
     disable_benchmarking: bool,
 ):
     norm_fwd_benchmark(
-        benchmark,
-        size,
-        dtype,
-        "batch_norm",
-        channels_last,
-        disable_validation,
-        disable_benchmarking,
-    )
-
-
-@pytest.mark.parametrize("size", generate_input_sizes(dims=4))
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-@pytest.mark.parametrize("channels_last", [True, False])
-def test_batchnorm_bwd_benchmark(
-    benchmark,
-    size: tuple,
-    dtype: torch.dtype,
-    channels_last: bool,
-    disable_validation: bool,
-    disable_benchmarking: bool,
-    eps: float = 1e-5,
-):
-    norm_bwd_benchmark(
         benchmark,
         size,
         dtype,

--- a/python_benchmarks/test_gelu_bwd.py
+++ b/python_benchmarks/test_gelu_bwd.py
@@ -6,38 +6,6 @@ import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
 
-def gelu_fwd_fusion(
-    fd: FusionDefinition,
-    dtype: DataType,
-) -> None:
-    input = fd.define_tensor(
-        shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
-    )
-    bias = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
-    if dtype in PROMOTE_DTYPES:
-        input = fd.ops.cast(input, dtype=DataType.Float)
-        bias = fd.ops.cast(bias, dtype=DataType.Float)
-    S_079 = fd.define_scalar(0.79788456)
-    S_004 = fd.define_scalar(0.044715)
-    V1 = fd.define_vector([1, input.size(-1)], dtype=DataType.Int)
-    bias = fd.ops.broadcast_in_dim(bias, shape=V1, broadcast_dims=[1])
-    T1 = fd.ops.add(input, bias)
-    T2 = fd.ops.mul(S_079, T1)
-    T3 = fd.ops.mul(S_004, T1)
-    T4 = fd.ops.mul(T3, T1)
-    S1 = fd.define_scalar(1.0)
-    T5 = fd.ops.add(T4, S1)
-    T6 = fd.ops.mul(T2, T5)
-    T7 = fd.ops.tanh(T6)
-    T8 = fd.ops.add(S1, T7)
-    T9 = fd.ops.mul(T8, T1)
-    S2 = fd.define_scalar(0.50)
-    T10 = fd.ops.mul(S2, T9)
-    if dtype in PROMOTE_DTYPES:
-        T10 = fd.ops.cast(T10, dtype=dtype)
-    fd.add_output(T10)
-
-
 def gelu_bwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,
@@ -83,28 +51,6 @@ def gelu_bwd_fusion(
     if dtype in PROMOTE_DTYPES:
         T20 = fd.ops.cast(T20, dtype=dtype)
     fd.add_output(T20)
-
-
-@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_gelu_fwd_benchmark(
-    benchmark,
-    size: tuple,
-    dtype: torch.dtype,
-    disable_validation: bool,
-    disable_benchmarking: bool,
-):
-    inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
-    bias = torch.ones(size[-1], device="cuda", dtype=dtype)
-    with FusionDefinition() as fd:
-        gelu_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
-    if not disable_validation:
-        eager_output = torch.nn.functional.gelu(inputs + bias, approximate="tanh")
-        fd.validate([inputs, bias], [eager_output])
-    if not disable_benchmarking:
-        run_benchmark(benchmark, fd.execute, [inputs, bias])
-
-    torch.cuda.empty_cache()
 
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))

--- a/python_benchmarks/test_gelu_fwd.py
+++ b/python_benchmarks/test_gelu_fwd.py
@@ -1,0 +1,60 @@
+import pytest
+from nvfuser import FusionDefinition, DataType
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from .core import run_benchmark
+import torch
+from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+
+
+def gelu_fwd_fusion(
+    fd: FusionDefinition,
+    dtype: DataType,
+) -> None:
+    input = fd.define_tensor(
+        shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
+    )
+    bias = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
+    if dtype in PROMOTE_DTYPES:
+        input = fd.ops.cast(input, dtype=DataType.Float)
+        bias = fd.ops.cast(bias, dtype=DataType.Float)
+    S_079 = fd.define_scalar(0.79788456)
+    S_004 = fd.define_scalar(0.044715)
+    V1 = fd.define_vector([1, input.size(-1)], dtype=DataType.Int)
+    bias = fd.ops.broadcast_in_dim(bias, shape=V1, broadcast_dims=[1])
+    T1 = fd.ops.add(input, bias)
+    T2 = fd.ops.mul(S_079, T1)
+    T3 = fd.ops.mul(S_004, T1)
+    T4 = fd.ops.mul(T3, T1)
+    S1 = fd.define_scalar(1.0)
+    T5 = fd.ops.add(T4, S1)
+    T6 = fd.ops.mul(T2, T5)
+    T7 = fd.ops.tanh(T6)
+    T8 = fd.ops.add(S1, T7)
+    T9 = fd.ops.mul(T8, T1)
+    S2 = fd.define_scalar(0.50)
+    T10 = fd.ops.mul(S2, T9)
+    if dtype in PROMOTE_DTYPES:
+        T10 = fd.ops.cast(T10, dtype=dtype)
+    fd.add_output(T10)
+
+
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_gelu_fwd_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    disable_validation: bool,
+    disable_benchmarking: bool,
+):
+    inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
+    bias = torch.ones(size[-1], device="cuda", dtype=dtype)
+    with FusionDefinition() as fd:
+        gelu_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
+    if not disable_validation:
+        eager_output = torch.nn.functional.gelu(inputs + bias, approximate="tanh")
+        fd.validate([inputs, bias], [eager_output])
+    if not disable_benchmarking:
+        run_benchmark(benchmark, fd.execute, [inputs, bias])
+
+    torch.cuda.empty_cache()

--- a/python_benchmarks/test_instancenorm_bwd.py
+++ b/python_benchmarks/test_instancenorm_bwd.py
@@ -1,29 +1,7 @@
 import pytest
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES
-from .normalization import norm_bwd_benchmark, norm_fwd_benchmark
-
-
-@pytest.mark.parametrize("size", generate_input_sizes(dims=4))
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-@pytest.mark.parametrize("channels_last", [True, False])
-def test_instancenorm_fwd_benchmark(
-    benchmark,
-    size: tuple,
-    dtype: torch.dtype,
-    channels_last: bool,
-    disable_validation: bool,
-    disable_benchmarking: bool,
-):
-    norm_fwd_benchmark(
-        benchmark,
-        size,
-        dtype,
-        "instance_norm",
-        channels_last,
-        disable_validation,
-        disable_benchmarking,
-    )
+from .normalization import norm_bwd_benchmark
 
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))

--- a/python_benchmarks/test_instancenorm_fwd.py
+++ b/python_benchmarks/test_instancenorm_fwd.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+from .global_params import generate_input_sizes, FLOAT_DTYPES
+from .normalization import norm_fwd_benchmark
+
+
+@pytest.mark.parametrize("size", generate_input_sizes(dims=4))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("channels_last", [True, False])
+def test_instancenorm_fwd_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    channels_last: bool,
+    disable_validation: bool,
+    disable_benchmarking: bool,
+):
+    norm_fwd_benchmark(
+        benchmark,
+        size,
+        dtype,
+        "instance_norm",
+        channels_last,
+        disable_validation,
+        disable_benchmarking,
+    )

--- a/python_benchmarks/test_layernorm_bwd.py
+++ b/python_benchmarks/test_layernorm_bwd.py
@@ -6,51 +6,6 @@ import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
 
-def layernorm_fwd_fusion(
-    fd: FusionDefinition,
-    dtype: DataType,
-    eps: float = 1e-5,
-) -> None:
-    T0 = fd.define_tensor(
-        shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
-    )
-    T1 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
-    T2 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
-
-    if dtype in PROMOTE_DTYPES:
-        T0 = fd.ops.cast(T0, dtype=DataType.Float)
-        T1 = fd.ops.cast(T1, dtype=DataType.Float)
-        T2 = fd.ops.cast(T2, dtype=DataType.Float)
-
-    T3, T4 = fd.ops.var_mean(T0, axes=[1], correction=0, keepdim=False)
-
-    V6 = fd.define_vector([T0.size(0), 1], dtype=DataType.Int)
-    T7 = fd.ops.broadcast_in_dim(T3, shape=V6, broadcast_dims=[0])
-    T11 = fd.ops.broadcast_in_dim(T4, shape=V6, broadcast_dims=[0])
-
-    S12 = fd.define_scalar(eps, dtype=DataType.Double)
-    T13 = fd.ops.add(T7, S12)
-    T14 = fd.ops.rsqrt(T13)
-
-    V17 = T0.shape()
-    T18 = fd.ops.broadcast_in_dim(T11, shape=V17, broadcast_dims=[0, 1])
-    T19 = fd.ops.sub(T0, T18)
-    T23 = fd.ops.broadcast_in_dim(T14, shape=V17, broadcast_dims=[0, 1])
-    T24 = fd.ops.mul(T19, T23)
-
-    T25 = fd.ops.broadcast_in_dim(T1, shape=V17, broadcast_dims=[1])
-    T26 = fd.ops.mul(T24, T25)
-    T27 = fd.ops.broadcast_in_dim(T2, shape=V17, broadcast_dims=[1])
-    T28 = fd.ops.add(T26, T27)
-
-    if dtype in PROMOTE_DTYPES:
-        T28 = fd.ops.cast(T28, dtype=dtype)
-
-    fd.add_output(T28)
-    fd.add_output(T4)
-    fd.add_output(T14)
-
-
 def layernorm_bwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,
@@ -134,42 +89,6 @@ def layernorm_bwd_fusion(
     fd.add_output(T90)
     fd.add_output(T32)
     fd.add_output(T28)
-
-
-@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_layernorm_fwd_benchmark(
-    benchmark,
-    size: tuple,
-    dtype: torch.dtype,
-    disable_validation: bool,
-    disable_benchmarking: bool,
-    eps: float = 1e-5,
-):
-    inputs = [
-        torch.randn(*size, device="cuda", dtype=dtype),
-        torch.randn(size[1], device="cuda", dtype=dtype),
-        torch.randn(size[1], device="cuda", dtype=dtype),
-    ]
-
-    with FusionDefinition() as fd:
-        layernorm_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
-
-    if not disable_validation:
-        eager_output = torch.nn.functional.layer_norm(
-            inputs[0], inputs[0].shape[1:], weight=inputs[1], bias=inputs[2]
-        )
-
-        mean = inputs[0].to(torch.float).mean(dim=-1)
-        variance = inputs[0].to(torch.float).var(dim=-1, unbiased=False)
-        invstd = (1.0 / torch.sqrt(variance + eps)).unsqueeze(1)
-
-        fd.validate(inputs, [eager_output, mean, invstd])
-
-    if not disable_benchmarking:
-        run_benchmark(benchmark, fd.execute, inputs)
-
-    torch.cuda.empty_cache()
 
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))

--- a/python_benchmarks/test_layernorm_fwd.py
+++ b/python_benchmarks/test_layernorm_fwd.py
@@ -1,0 +1,87 @@
+import pytest
+from nvfuser import FusionDefinition, DataType
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from .core import run_benchmark
+import torch
+from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+
+
+def layernorm_fwd_fusion(
+    fd: FusionDefinition,
+    dtype: DataType,
+    eps: float = 1e-5,
+) -> None:
+    T0 = fd.define_tensor(
+        shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
+    )
+    T1 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
+    T2 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
+
+    if dtype in PROMOTE_DTYPES:
+        T0 = fd.ops.cast(T0, dtype=DataType.Float)
+        T1 = fd.ops.cast(T1, dtype=DataType.Float)
+        T2 = fd.ops.cast(T2, dtype=DataType.Float)
+
+    T3, T4 = fd.ops.var_mean(T0, axes=[1], correction=0, keepdim=False)
+
+    V6 = fd.define_vector([T0.size(0), 1], dtype=DataType.Int)
+    T7 = fd.ops.broadcast_in_dim(T3, shape=V6, broadcast_dims=[0])
+    T11 = fd.ops.broadcast_in_dim(T4, shape=V6, broadcast_dims=[0])
+
+    S12 = fd.define_scalar(eps, dtype=DataType.Double)
+    T13 = fd.ops.add(T7, S12)
+    T14 = fd.ops.rsqrt(T13)
+
+    V17 = T0.shape()
+    T18 = fd.ops.broadcast_in_dim(T11, shape=V17, broadcast_dims=[0, 1])
+    T19 = fd.ops.sub(T0, T18)
+    T23 = fd.ops.broadcast_in_dim(T14, shape=V17, broadcast_dims=[0, 1])
+    T24 = fd.ops.mul(T19, T23)
+
+    T25 = fd.ops.broadcast_in_dim(T1, shape=V17, broadcast_dims=[1])
+    T26 = fd.ops.mul(T24, T25)
+    T27 = fd.ops.broadcast_in_dim(T2, shape=V17, broadcast_dims=[1])
+    T28 = fd.ops.add(T26, T27)
+
+    if dtype in PROMOTE_DTYPES:
+        T28 = fd.ops.cast(T28, dtype=dtype)
+
+    fd.add_output(T28)
+    fd.add_output(T4)
+    fd.add_output(T14)
+
+
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_layernorm_fwd_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    disable_validation: bool,
+    disable_benchmarking: bool,
+    eps: float = 1e-5,
+):
+    inputs = [
+        torch.randn(*size, device="cuda", dtype=dtype),
+        torch.randn(size[1], device="cuda", dtype=dtype),
+        torch.randn(size[1], device="cuda", dtype=dtype),
+    ]
+
+    with FusionDefinition() as fd:
+        layernorm_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
+
+    if not disable_validation:
+        eager_output = torch.nn.functional.layer_norm(
+            inputs[0], inputs[0].shape[1:], weight=inputs[1], bias=inputs[2]
+        )
+
+        mean = inputs[0].to(torch.float).mean(dim=-1)
+        variance = inputs[0].to(torch.float).var(dim=-1, unbiased=False)
+        invstd = (1.0 / torch.sqrt(variance + eps)).unsqueeze(1)
+
+        fd.validate(inputs, [eager_output, mean, invstd])
+
+    if not disable_benchmarking:
+        run_benchmark(benchmark, fd.execute, inputs)
+
+    torch.cuda.empty_cache()

--- a/python_benchmarks/test_rmsnorm_bwd.py
+++ b/python_benchmarks/test_rmsnorm_bwd.py
@@ -6,41 +6,6 @@ import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
 
-def rmsnorm_fwd_fusion(
-    fd: FusionDefinition,
-    dtype: DataType,
-    eps: float = 1e-5,
-):
-    T0 = fd.define_tensor(
-        shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
-    )
-    T1 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
-    if dtype in PROMOTE_DTYPES:
-        T0 = fd.ops.cast(T0, dtype=DataType.Float)
-        T1 = fd.ops.cast(T1, dtype=DataType.Float)
-    S3 = fd.define_scalar(2.00000, dtype=DataType.Double)
-    T4 = fd.ops.pow(T0, S3)
-    T5 = fd.ops.sum(T4, axes=[1], keepdim=False, dtype=DataType.Null)
-    V8 = fd.define_vector([T0.size(0), 1], dtype=DataType.Int)
-    T9 = fd.ops.broadcast_in_dim(T5, shape=V8, broadcast_dims=[0])
-    S11 = fd.ops.reciprocal(T0.size(1))
-    T12 = fd.ops.mul(T9, S11)
-    S13 = fd.define_scalar(eps, dtype=DataType.Double)
-    T14 = fd.ops.add(T12, S13)
-    T15 = fd.ops.sqrt(T14)
-
-    T20 = fd.ops.broadcast_in_dim(T15, shape=T0.shape(), broadcast_dims=[0, 1])
-    T22 = fd.ops.reciprocal(T20)
-    T23 = fd.ops.mul(T0, T22)
-    T27 = fd.ops.broadcast_in_dim(T1, shape=T0.shape(), broadcast_dims=[1])
-    T29 = fd.ops.mul(T27, T23)
-    if dtype in PROMOTE_DTYPES:
-        T29 = fd.ops.cast(T29, dtype=dtype)
-
-    fd.add_output(T29)
-    fd.add_output(T15)
-
-
 def rmsnorm_bwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,
@@ -99,34 +64,6 @@ def rmsnorm_bwd_fusion(
 
     fd.add_output(T63)
     fd.add_output(T25)
-
-
-@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_rmsnorm_fwd_benchmark(
-    benchmark,
-    size: tuple,
-    dtype: torch.dtype,
-    disable_validation: bool,
-    disable_benchmarking: bool,
-    eps: float = 1e-5,
-):
-    inputs = torch.randn(*size, device="cuda", dtype=dtype)
-    weights = torch.randn(size[1], device="cuda", dtype=dtype)
-
-    with FusionDefinition() as fd:
-        rmsnorm_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
-
-    if not disable_validation:
-        squared_mean = (inputs.to(torch.float) ** 2).mean(1, keepdim=True)
-        rms_eps = torch.sqrt(squared_mean + eps)
-        eager_output = weights * (inputs / rms_eps)
-        fd.validate([inputs, weights], [eager_output.to(dtype), rms_eps])
-
-    if not disable_benchmarking:
-        run_benchmark(benchmark, fd.execute, [inputs, weights])
-
-    torch.cuda.empty_cache()
 
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))

--- a/python_benchmarks/test_rmsnorm_fwd.py
+++ b/python_benchmarks/test_rmsnorm_fwd.py
@@ -1,0 +1,69 @@
+import pytest
+from nvfuser import FusionDefinition, DataType
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from .core import run_benchmark
+import torch
+from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+
+
+def rmsnorm_fwd_fusion(
+    fd: FusionDefinition,
+    dtype: DataType,
+    eps: float = 1e-5,
+):
+    T0 = fd.define_tensor(
+        shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
+    )
+    T1 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
+    if dtype in PROMOTE_DTYPES:
+        T0 = fd.ops.cast(T0, dtype=DataType.Float)
+        T1 = fd.ops.cast(T1, dtype=DataType.Float)
+    S3 = fd.define_scalar(2.00000, dtype=DataType.Double)
+    T4 = fd.ops.pow(T0, S3)
+    T5 = fd.ops.sum(T4, axes=[1], keepdim=False, dtype=DataType.Null)
+    V8 = fd.define_vector([T0.size(0), 1], dtype=DataType.Int)
+    T9 = fd.ops.broadcast_in_dim(T5, shape=V8, broadcast_dims=[0])
+    S11 = fd.ops.reciprocal(T0.size(1))
+    T12 = fd.ops.mul(T9, S11)
+    S13 = fd.define_scalar(eps, dtype=DataType.Double)
+    T14 = fd.ops.add(T12, S13)
+    T15 = fd.ops.sqrt(T14)
+
+    T20 = fd.ops.broadcast_in_dim(T15, shape=T0.shape(), broadcast_dims=[0, 1])
+    T22 = fd.ops.reciprocal(T20)
+    T23 = fd.ops.mul(T0, T22)
+    T27 = fd.ops.broadcast_in_dim(T1, shape=T0.shape(), broadcast_dims=[1])
+    T29 = fd.ops.mul(T27, T23)
+    if dtype in PROMOTE_DTYPES:
+        T29 = fd.ops.cast(T29, dtype=dtype)
+
+    fd.add_output(T29)
+    fd.add_output(T15)
+
+
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_rmsnorm_fwd_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    disable_validation: bool,
+    disable_benchmarking: bool,
+    eps: float = 1e-5,
+):
+    inputs = torch.randn(*size, device="cuda", dtype=dtype)
+    weights = torch.randn(size[1], device="cuda", dtype=dtype)
+
+    with FusionDefinition() as fd:
+        rmsnorm_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
+
+    if not disable_validation:
+        squared_mean = (inputs.to(torch.float) ** 2).mean(1, keepdim=True)
+        rms_eps = torch.sqrt(squared_mean + eps)
+        eager_output = weights * (inputs / rms_eps)
+        fd.validate([inputs, weights], [eager_output.to(dtype), rms_eps])
+
+    if not disable_benchmarking:
+        run_benchmark(benchmark, fd.execute, [inputs, weights])
+
+    torch.cuda.empty_cache()

--- a/python_benchmarks/test_scale_bias_relu_bwd.py
+++ b/python_benchmarks/test_scale_bias_relu_bwd.py
@@ -6,42 +6,6 @@ import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
 
-def sbr_fwd_fusion(
-    fd: FusionDefinition,
-    dtype: DataType,
-):
-    T0 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
-    T1 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
-    T2 = fd.define_tensor(
-        shape=[-1, -1],
-        contiguity=[True, True],
-        dtype=dtype,
-        is_cpu=False,
-    )
-
-    if dtype in PROMOTE_DTYPES:
-        T0 = fd.ops.cast(T0, dtype=DataType.Float)
-        T1 = fd.ops.cast(T1, dtype=DataType.Float)
-        T2 = fd.ops.cast(T2, dtype=DataType.Float)
-
-    V7 = T2.shape()
-    T8 = fd.ops.broadcast_in_dim(T1, shape=V7, broadcast_dims=[1])
-    T11 = fd.ops.mul(T2, T8)
-
-    T18 = fd.ops.broadcast_in_dim(T0, shape=V7, broadcast_dims=[1])
-    T20 = fd.ops.add(T11, T18)
-
-    if dtype in PROMOTE_DTYPES:
-        T20 = fd.ops.cast(T20, dtype=dtype)
-
-    S22 = fd.define_scalar(0.00000, dtype=DataType.Double)
-    T23 = fd.ops.gt(T20, S22)
-    T25 = fd.ops.where(T23, T20, S22)
-
-    fd.add_output(T23)
-    fd.add_output(T25)
-
-
 def sbr_bwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,
@@ -74,32 +38,6 @@ def sbr_bwd_fusion(
     if dtype in PROMOTE_DTYPES:
         T15 = fd.ops.cast(T15, dtype=dtype)
     fd.add_output(T15)
-
-
-@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_sbr_fwd_benchmark(
-    benchmark,
-    size: tuple,
-    dtype: torch.dtype,
-    disable_validation: bool,
-    disable_benchmarking: bool,
-):
-    inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
-    bias = torch.ones(size[-1], device="cuda", dtype=dtype)
-    scale = torch.ones(size[-1], device="cuda", dtype=dtype)
-
-    with FusionDefinition() as fd:
-        sbr_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
-    if not disable_validation:
-        eager_output = torch.nn.functional.relu(inputs * scale + bias)
-        bool_mask = torch.gt(inputs * scale + bias, 0.0)
-        fd.validate([bias, scale, inputs], [bool_mask, eager_output])
-
-    if not disable_benchmarking:
-        run_benchmark(benchmark, fd.execute, [bias, scale, inputs])
-
-    torch.cuda.empty_cache()
 
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))

--- a/python_benchmarks/test_scale_bias_relu_fwd.py
+++ b/python_benchmarks/test_scale_bias_relu_fwd.py
@@ -1,0 +1,68 @@
+import pytest
+from nvfuser import FusionDefinition, DataType
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from .core import run_benchmark
+import torch
+from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+
+
+def sbr_fwd_fusion(
+    fd: FusionDefinition,
+    dtype: DataType,
+):
+    T0 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
+    T1 = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
+    T2 = fd.define_tensor(
+        shape=[-1, -1],
+        contiguity=[True, True],
+        dtype=dtype,
+        is_cpu=False,
+    )
+
+    if dtype in PROMOTE_DTYPES:
+        T0 = fd.ops.cast(T0, dtype=DataType.Float)
+        T1 = fd.ops.cast(T1, dtype=DataType.Float)
+        T2 = fd.ops.cast(T2, dtype=DataType.Float)
+
+    V7 = T2.shape()
+    T8 = fd.ops.broadcast_in_dim(T1, shape=V7, broadcast_dims=[1])
+    T11 = fd.ops.mul(T2, T8)
+
+    T18 = fd.ops.broadcast_in_dim(T0, shape=V7, broadcast_dims=[1])
+    T20 = fd.ops.add(T11, T18)
+
+    if dtype in PROMOTE_DTYPES:
+        T20 = fd.ops.cast(T20, dtype=dtype)
+
+    S22 = fd.define_scalar(0.00000, dtype=DataType.Double)
+    T23 = fd.ops.gt(T20, S22)
+    T25 = fd.ops.where(T23, T20, S22)
+
+    fd.add_output(T23)
+    fd.add_output(T25)
+
+
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_sbr_fwd_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    disable_validation: bool,
+    disable_benchmarking: bool,
+):
+    inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
+    bias = torch.ones(size[-1], device="cuda", dtype=dtype)
+    scale = torch.ones(size[-1], device="cuda", dtype=dtype)
+
+    with FusionDefinition() as fd:
+        sbr_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
+    if not disable_validation:
+        eager_output = torch.nn.functional.relu(inputs * scale + bias)
+        bool_mask = torch.gt(inputs * scale + bias, 0.0)
+        fd.validate([bias, scale, inputs], [bool_mask, eager_output])
+
+    if not disable_benchmarking:
+        run_benchmark(benchmark, fd.execute, [bias, scale, inputs])
+
+    torch.cuda.empty_cache()

--- a/python_benchmarks/test_softmax_bwd.py
+++ b/python_benchmarks/test_softmax_bwd.py
@@ -3,7 +3,7 @@ from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark
 import torch
-from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+from .global_params import generate_input_sizes, FLOAT_DTYPES
 
 
 def softmax_bwd_fusion(

--- a/python_benchmarks/test_softmax_bwd.py
+++ b/python_benchmarks/test_softmax_bwd.py
@@ -6,44 +6,6 @@ import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
 
-def softmax_fwd_fusion(
-    fd: FusionDefinition, dtype: DataType, reduction_axis: int
-) -> None:
-    T0 = fd.define_tensor(
-        shape=[-1, -1],
-        contiguity=[True, True],
-        dtype=dtype,
-        is_cpu=False,
-    )
-    if dtype in PROMOTE_DTYPES:
-        T0 = fd.ops.cast(T0, dtype=DataType.Float)
-    T2 = fd.ops.max(T0, axes=[reduction_axis], keepdim=False, dtype=DataType.Null)
-
-    if reduction_axis:
-        V6 = fd.define_vector([T0.size(0), 1], dtype=DataType.Int)
-    else:
-        V6 = fd.define_vector([1, T0.size(1)], dtype=DataType.Int)
-    bcast_dim = 1 - reduction_axis
-
-    T7 = fd.ops.broadcast_in_dim(T2, shape=V6, broadcast_dims=[bcast_dim])
-
-    V11 = T0.shape()
-    T12 = fd.ops.broadcast_in_dim(T7, shape=V11, broadcast_dims=[0, 1])
-    T13 = fd.ops.sub(T0, T12)
-    T14 = fd.ops.exp(T13)
-    T15 = fd.ops.sum(T14, axes=[reduction_axis], keepdim=False, dtype=DataType.Null)
-
-    T20 = fd.ops.broadcast_in_dim(T15, shape=V6, broadcast_dims=[bcast_dim])
-    T25 = fd.ops.broadcast_in_dim(T20, shape=V11, broadcast_dims=[0, 1])
-
-    T26 = fd.ops.reciprocal(T25)
-    T27 = fd.ops.mul(T14, T26)
-
-    if dtype in PROMOTE_DTYPES:
-        T27 = fd.ops.cast(T27, dtype=dtype)
-    fd.add_output(T27)
-
-
 def softmax_bwd_fusion(
     fd: FusionDefinition, dtype: DataType, reduction_axis: int
 ) -> None:
@@ -90,32 +52,6 @@ def softmax_bwd_fusion(
     if dtype is not DataType.Float:
         T19 = fd.ops.cast(T19, dtype=dtype)
     fd.add_output(T19)
-
-
-@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-@pytest.mark.parametrize("reduction_axis", [0, 1])
-def test_softmax_fwd_benchmark(
-    benchmark,
-    size: tuple,
-    dtype: torch.dtype,
-    reduction_axis: int,
-    disable_validation: bool,
-    disable_benchmarking: bool,
-):
-    inputs = [torch.randn(*size, device="cuda", dtype=dtype)]
-
-    with FusionDefinition() as fd:
-        softmax_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), reduction_axis)
-
-    if not disable_validation:
-        eager_output = torch.nn.functional.softmax(inputs[0], dim=reduction_axis)
-        fd.validate(inputs, [eager_output])
-
-    if not disable_benchmarking:
-        run_benchmark(benchmark, fd.execute, inputs)
-
-    torch.cuda.empty_cache()
 
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))

--- a/python_benchmarks/test_softmax_fwd.py
+++ b/python_benchmarks/test_softmax_fwd.py
@@ -1,0 +1,70 @@
+import pytest
+from nvfuser import FusionDefinition, DataType
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from .core import run_benchmark
+import torch
+from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+
+
+def softmax_fwd_fusion(
+    fd: FusionDefinition, dtype: DataType, reduction_axis: int
+) -> None:
+    T0 = fd.define_tensor(
+        shape=[-1, -1],
+        contiguity=[True, True],
+        dtype=dtype,
+        is_cpu=False,
+    )
+    if dtype in PROMOTE_DTYPES:
+        T0 = fd.ops.cast(T0, dtype=DataType.Float)
+    T2 = fd.ops.max(T0, axes=[reduction_axis], keepdim=False, dtype=DataType.Null)
+
+    if reduction_axis:
+        V6 = fd.define_vector([T0.size(0), 1], dtype=DataType.Int)
+    else:
+        V6 = fd.define_vector([1, T0.size(1)], dtype=DataType.Int)
+    bcast_dim = 1 - reduction_axis
+
+    T7 = fd.ops.broadcast_in_dim(T2, shape=V6, broadcast_dims=[bcast_dim])
+
+    V11 = T0.shape()
+    T12 = fd.ops.broadcast_in_dim(T7, shape=V11, broadcast_dims=[0, 1])
+    T13 = fd.ops.sub(T0, T12)
+    T14 = fd.ops.exp(T13)
+    T15 = fd.ops.sum(T14, axes=[reduction_axis], keepdim=False, dtype=DataType.Null)
+
+    T20 = fd.ops.broadcast_in_dim(T15, shape=V6, broadcast_dims=[bcast_dim])
+    T25 = fd.ops.broadcast_in_dim(T20, shape=V11, broadcast_dims=[0, 1])
+
+    T26 = fd.ops.reciprocal(T25)
+    T27 = fd.ops.mul(T14, T26)
+
+    if dtype in PROMOTE_DTYPES:
+        T27 = fd.ops.cast(T27, dtype=dtype)
+    fd.add_output(T27)
+
+
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("reduction_axis", [0, 1])
+def test_softmax_fwd_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    reduction_axis: int,
+    disable_validation: bool,
+    disable_benchmarking: bool,
+):
+    inputs = [torch.randn(*size, device="cuda", dtype=dtype)]
+
+    with FusionDefinition() as fd:
+        softmax_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), reduction_axis)
+
+    if not disable_validation:
+        eager_output = torch.nn.functional.softmax(inputs[0], dim=reduction_axis)
+        fd.validate(inputs, [eager_output])
+
+    if not disable_benchmarking:
+        run_benchmark(benchmark, fd.execute, inputs)
+
+    torch.cuda.empty_cache()


### PR DESCRIPTION
Tests within the same pytest file run in the same process. Pytest memory consumption increases with the number of tests, so splitting the individual benchmarks to different files to control memory usage.