### PR TITLE
Updated the usage of TensorMap in generated kernels

### DIFF
--- a/csrc/tma.cpp
+++ b/csrc/tma.cpp
@@ -177,8 +177,8 @@ Val* encodeTensorMapTiled(
     MmaInputSmemSwizzle swizzle,
     TensorMapL2Promotion l2_promotion,
     TensorMapFloatOOBFill oob_fill) {
-  auto output = IrBuilder::create<Val>(
-      OpaqueType::make<TensorMap>("const __grid_constant__ TensorMap"));
+  auto output =
+      IrBuilder::create<Val>(OpaqueType::make<TensorMap>("TensorMap"));
   IrBuilder::create<kir::EncodeTensorMapTiled>(
       output,
       data_type,


### PR DESCRIPTION
The scope of introduced changes:
- modify the string representation of TensorMap object type for kernel
  lowering phase,
- fix the type of TensorMap local variables in kernel (aliases),
- add local helper tool to detect TensorMap data type,