### PR TITLE
Clear CUDA cache before running a test

### DIFF
--- a/python_benchmarks/core.py
+++ b/python_benchmarks/core.py
@@ -5,6 +5,7 @@ from typing import List, Callable, Union, Tuple
 from torch.autograd import DeviceType
 import gc
 
+
 def get_device_properties() -> Tuple[int, float]:
     """
     Computes device properties using ctypes and cuda.
@@ -123,12 +124,14 @@ def clear_l2_cache() -> None:
     x = torch.empty(n_elements, dtype=torch.float32, device="cuda", requires_grad=False)
     y = torch.clone(x)
 
+
 def clear_cuda_cache() -> None:
     """
     Utility function to clear any unused allocated CUDA memory before tests.
     """
     gc.collect()
     torch.cuda.empty_cache()
+
 
 class NVFBenchmark:
     """

--- a/python_benchmarks/core.py
+++ b/python_benchmarks/core.py
@@ -127,10 +127,14 @@ def clear_l2_cache() -> None:
 
 def clear_cuda_cache() -> None:
     """
-    Utility function to clear any unused allocated CUDA memory before tests.
+    Utility function to clear CUDA cache before running a test.
     """
-    gc.collect()
-    torch.cuda.empty_cache()
+    if (
+        torch.cuda.memory_allocated()
+        or torch.cuda.memory_reserved() > 0.8 * DEVICE_PROPERTIES["gpu_gmem_bytes"]
+    ):
+        gc.collect()
+        torch.cuda.empty_cache()
 
 
 class NVFBenchmark:

--- a/python_benchmarks/core.py
+++ b/python_benchmarks/core.py
@@ -125,7 +125,7 @@ def clear_l2_cache() -> None:
 
 def clear_cuda_cache() -> None:
     """
-    Clear any unused allocated CUDA memory.
+    Utility function to clear any unused allocated CUDA memory before tests.
     """
     gc.collect()
     torch.cuda.empty_cache()

--- a/python_benchmarks/core.py
+++ b/python_benchmarks/core.py
@@ -3,7 +3,7 @@ import torch
 from torch.profiler import profile, ProfilerActivity
 from typing import List, Callable, Union, Tuple
 from torch.autograd import DeviceType
-
+import gc
 
 def get_device_properties() -> Tuple[int, float]:
     """
@@ -123,6 +123,12 @@ def clear_l2_cache() -> None:
     x = torch.empty(n_elements, dtype=torch.float32, device="cuda", requires_grad=False)
     y = torch.clone(x)
 
+def clear_cuda_cache() -> None:
+    """
+    Clear any unused allocated CUDA memory.
+    """
+    gc.collect()
+    torch.cuda.empty_cache()
 
 class NVFBenchmark:
     """

--- a/python_benchmarks/normalization.py
+++ b/python_benchmarks/normalization.py
@@ -2,7 +2,7 @@ from nvfuser import FusionDefinition, DataType
 from .global_params import PROMOTE_DTYPES
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 import torch
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 
 
 def norm_fwd_fusion(
@@ -201,6 +201,9 @@ def norm_fwd_benchmark(
     """
     Common benchmark setup for batchnorm/instance forward call in training mode.
     """
+
+    clear_cuda_cache()
+
     assert norm in ["batch_norm", "instance_norm"], NotImplementedError
 
     # Size is assumed to be in the order N, C, ...
@@ -271,8 +274,6 @@ def norm_fwd_benchmark(
             benchmark, fd.execute, [inputs, weight, bias, running_mean, running_var]
         )
 
-    torch.cuda.empty_cache()
-
 
 def norm_bwd_benchmark(
     benchmark,
@@ -288,6 +289,8 @@ def norm_bwd_benchmark(
     Common benchmark setup for batchnorm/instance forward call in training mode.
     """
 
+    clear_cuda_cache()
+    
     assert norm in ["batch_norm", "instance_norm"], NotImplementedError
 
     # Size is assumed to be in the order N, C, ...
@@ -371,5 +374,3 @@ def norm_bwd_benchmark(
             fd.execute,
             [inputs, grads, weight, running_mean, running_var, mean, invstd],
         )
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/normalization.py
+++ b/python_benchmarks/normalization.py
@@ -290,7 +290,7 @@ def norm_bwd_benchmark(
     """
 
     clear_cuda_cache()
-    
+
     assert norm in ["batch_norm", "instance_norm"], NotImplementedError
 
     # Size is assumed to be in the order N, C, ...

--- a/python_benchmarks/test_gelu_bwd.py
+++ b/python_benchmarks/test_gelu_bwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -62,6 +62,8 @@ def test_gelu_bwd_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
+    clear_cuda_cache()
+
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
@@ -75,5 +77,3 @@ def test_gelu_bwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [inputs, grads, bias])
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/test_gelu_fwd.py
+++ b/python_benchmarks/test_gelu_fwd.py
@@ -48,7 +48,7 @@ def test_gelu_fwd_benchmark(
     disable_benchmarking: bool,
 ):
     clear_cuda_cache()
-    
+
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     with FusionDefinition() as fd:

--- a/python_benchmarks/test_gelu_fwd.py
+++ b/python_benchmarks/test_gelu_fwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -47,6 +47,8 @@ def test_gelu_fwd_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
+    clear_cuda_cache()
+    
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     with FusionDefinition() as fd:
@@ -56,5 +58,3 @@ def test_gelu_fwd_benchmark(
         fd.validate([inputs, bias], [eager_output])
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [inputs, bias])
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/test_layernorm_bwd.py
+++ b/python_benchmarks/test_layernorm_bwd.py
@@ -102,7 +102,7 @@ def test_layernorm_bwd_benchmark(
     eps: float = 1e-5,
 ):
     clear_cuda_cache()
-    
+
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)

--- a/python_benchmarks/test_layernorm_bwd.py
+++ b/python_benchmarks/test_layernorm_bwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -101,6 +101,8 @@ def test_layernorm_bwd_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
+    clear_cuda_cache()
+    
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
@@ -128,5 +130,3 @@ def test_layernorm_bwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [inputs, grads, mean, invstd, weights])
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/test_layernorm_fwd.py
+++ b/python_benchmarks/test_layernorm_fwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -61,6 +61,8 @@ def test_layernorm_fwd_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
+    clear_cuda_cache()
+
     inputs = [
         torch.randn(*size, device="cuda", dtype=dtype),
         torch.randn(size[1], device="cuda", dtype=dtype),
@@ -83,5 +85,3 @@ def test_layernorm_fwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, inputs)
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/test_rmsnorm_bwd.py
+++ b/python_benchmarks/test_rmsnorm_bwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -76,6 +76,8 @@ def test_rmsnorm_bwd_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
+    clear_cuda_cache()
+
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
@@ -95,5 +97,3 @@ def test_rmsnorm_bwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [inputs, rms_eps, grads, weights])
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/test_rmsnorm_fwd.py
+++ b/python_benchmarks/test_rmsnorm_fwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -51,6 +51,8 @@ def test_rmsnorm_fwd_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
+    clear_cuda_cache()
+
     inputs = torch.randn(*size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype)
 
@@ -65,5 +67,3 @@ def test_rmsnorm_fwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [inputs, weights])
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/test_scale_bias_relu_bwd.py
+++ b/python_benchmarks/test_scale_bias_relu_bwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -49,6 +49,8 @@ def test_sbr_bwd_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
+    clear_cuda_cache()
+
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
     scale = torch.ones(size[-1], device="cuda", dtype=dtype)
@@ -65,5 +67,3 @@ def test_sbr_bwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [scale, bool_mask, grads])
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/test_scale_bias_relu_fwd.py
+++ b/python_benchmarks/test_scale_bias_relu_fwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -51,6 +51,8 @@ def test_sbr_fwd_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
+    clear_cuda_cache()
+    
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     scale = torch.ones(size[-1], device="cuda", dtype=dtype)
@@ -64,5 +66,3 @@ def test_sbr_fwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [bias, scale, inputs])
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/test_scale_bias_relu_fwd.py
+++ b/python_benchmarks/test_scale_bias_relu_fwd.py
@@ -52,7 +52,7 @@ def test_sbr_fwd_benchmark(
     disable_benchmarking: bool,
 ):
     clear_cuda_cache()
-    
+
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     scale = torch.ones(size[-1], device="cuda", dtype=dtype)

--- a/python_benchmarks/test_softmax_bwd.py
+++ b/python_benchmarks/test_softmax_bwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES
 
@@ -65,6 +65,8 @@ def test_softmax_bwd_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
+    clear_cuda_cache()
+
     inputs = [
         torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True),
         torch.randn(*size, device="cuda", dtype=dtype),
@@ -80,5 +82,3 @@ def test_softmax_bwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, inputs)
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/test_softmax_fwd.py
+++ b/python_benchmarks/test_softmax_fwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -55,6 +55,8 @@ def test_softmax_fwd_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
+    clear_cuda_cache()
+    
     inputs = [torch.randn(*size, device="cuda", dtype=dtype)]
 
     with FusionDefinition() as fd:
@@ -66,5 +68,3 @@ def test_softmax_fwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, inputs)
-
-    torch.cuda.empty_cache()

--- a/python_benchmarks/test_softmax_fwd.py
+++ b/python_benchmarks/test_softmax_fwd.py
@@ -56,7 +56,7 @@ def test_softmax_fwd_benchmark(
     disable_benchmarking: bool,
 ):
     clear_cuda_cache()
-    
+
     inputs = [torch.randn(*size, device="cuda", dtype=dtype)]
 
     with FusionDefinition() as fd:

--- a/python_benchmarks/test_transpose.py
+++ b/python_benchmarks/test_transpose.py
@@ -47,7 +47,7 @@ def test_transpose_benchmark(
     disable_benchmarking: bool,
 ):
     clear_cuda_cache()
-    
+
     input1 = torch.randn(*size, device="cuda", dtype=dtype)
     input2 = torch.randn(*size, device="cuda", dtype=dtype)
     permute_axes = list(range(len(size)))

--- a/python_benchmarks/test_transpose.py
+++ b/python_benchmarks/test_transpose.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark
+from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -46,6 +46,8 @@ def test_transpose_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
+    clear_cuda_cache()
+    
     input1 = torch.randn(*size, device="cuda", dtype=dtype)
     input2 = torch.randn(*size, device="cuda", dtype=dtype)
     permute_axes = list(range(len(size)))
@@ -65,5 +67,3 @@ def test_transpose_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [input1, input2])
-
-    torch.cuda.empty_cache()


### PR DESCRIPTION
This PR clears CUDA cache at the start of each test instead of at the end. This avoids CUDA OOM errors in tests due to any remaining allocated memory from the previous test.

Cache is only cleared when reserved memory is greater than 80% of GPU memory or there is allocated memory at the start of the test. This significantly reduces the overhead associated with gc collection/clearing cache.
Credit: @jacobhinkle.


Resolves GPU OOM errors in Issue #1537.