### PR TITLE
Fix bug in codediff for pytest

### DIFF
--- a/tools/codediff/compare_codegen.sh
+++ b/tools/codediff/compare_codegen.sh
@@ -6,11 +6,12 @@
 # compare_codegen.sh - compare generated CUDA kernels between git commits
 #
 # This script is made to compare generated kernels when making changes to
-# codegen. Invoking it without any arguments will checkout origin/main, as well
-# as this commit. For each, it will build the project in release mode then
-# invoke all binary and python tests, saving the generated cuda kernels to .cu
-# files. It will then diff these files and report which ones changed. The exit
-# code is 1 if there are differences.
+# codegen. Invoking it without any arguments will checkout the reference commit
+# as well as this commit. The default reference commit is the merge-base equal
+# to `git merge-base origin/main HEAD`. For each, it will build the project in
+# release mode then invoke all binary and python tests, saving the generated
+# cuda kernels to .cu files. It will then diff these files and report which
+# ones changed. The exit code is 1 if there are differences.
 #
 # The -r option controls the git ref to compare against. The -o option lets you
 # specify the output directory.
@@ -39,8 +40,10 @@
 set -e
 set -o pipefail
 
+comparetoref=$(git merge-base origin/main HEAD)
+
 usage() {
-  echo "Usage: $0 [-h] [-q] [-r origin/main] [-o codegen_comparison] [-- custom command to run]"
+  echo "Usage: $0 [-h] [-q] [-r ${comparetoref}] [-o codegen_comparison] [-- custom command to run]"
   echo -n "If given, the custom command should only run a single executable. "
   echo "If multiple executables are run, kernel files may be overwritten."
 }
@@ -48,7 +51,6 @@ usage() {
 # top-level directory of nvfuser repo
 nvfuserdir="$(dirname "$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")")"
 
-comparetoref=origin/main
 outdir=$nvfuserdir/codegen_comparison
 
 while getopts "r:o:hq" arg

--- a/tools/codediff/compare_codegen.sh
+++ b/tools/codediff/compare_codegen.sh
@@ -67,7 +67,7 @@ do
       outdir=$OPTARG
       ;;
     t)
-      commandtype=$(tr '[:lower:]' '[:upper:]' "$OPTARG")
+      commandtype=$(echo "$OPTARG" | tr '[:lower:]' '[:upper:]')
       ;;
     q)
       quiet=1

--- a/tools/codediff/compare_codegen.sh
+++ b/tools/codediff/compare_codegen.sh
@@ -150,7 +150,7 @@ collect_kernels() {
     binarytestdir=$outdir/$commit/binary_tests
     pyfrontenddir=$outdir/$commit/python_frontend_tests
     pyopsdir=$outdir/$commit/python_ops_tests
-    pyschedopsdir=$outdir/$commit/python_shedule_ops_tests
+    pyschedopsdir=$outdir/$commit/python_schedule_ops_tests
 
     # Test for output directories and return early if they exist. This
     # avoids rebuilds when we are changing code and comparing repeatedly to

--- a/tools/codediff/templates/test_diff_section.html
+++ b/tools/codediff/templates/test_diff_section.html
@@ -41,6 +41,10 @@ SPDX-License-Identifier: BSD-3-Clause
             {%- endif -%}
         {% endif %}
         <br>
+        {%- if test_diff.test1.kernels|length != test_diff.test2.kernels|length -%}
+        &nbsp;&nbsp;&nbsp;&nbsp;<span style="font-weight:bold; color: red">WARNING: Number of kernels in <i>{{ run1.name }}</i> ({{test_diff.test1.kernels|length}}) does not match number of kernels in <i>{{run2.name}}</i> ({{test_diff.test2.kernels|length}}). Kernels shown below might not correspond to one another, and no diffs might be shown if new kernels were introduced or removed from the end of the list.</span>
+        <br>
+        {%- endif -%}
         {% set outer_index = loop.index %}
         {% if test_diff.kernel_diffs is not none %}
           {% for kernel_diff in test_diff.kernel_diffs %}


### PR DESCRIPTION
This should fix the `assert self.current_test is not None` errors we see in CI sometimes.

Also, the default reference git ref was changed from `origin/main` to `git merge-base origin/main HEAD`. This can help when a branch is not up-to-date with upstream, since it prevents comparing against commits that have not yet been merged into the branch.

I also added a warning when the number of kernels in a test changes. We still compare the first N kernels where N is the minimum of the number of kernels between the two runs, but now if that number differs we give a warning. This helps alert us that we might not be comparing apples to apples and we should look at that specific test in more detail manually.