### PR TITLE
allow expand op and adjust vectorization check in memory alias

### DIFF
--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -1385,7 +1385,7 @@ class ReusableAllocationFinder : private kir::IrVisitor {
     }
   }
 
-  // Utility to capture broadcast and expand ops
+  // Utility to capture broadcast ops
   bool isBroadcastTvOp(const Expr* expr) {
     if (!ir_utils::isTvOp(expr)) {
       return false;

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -1344,8 +1344,8 @@ class ReusableAllocationFinder : private kir::IrVisitor {
           continue;
         }
         if (!ir_utils::isPointwiseTvOp(tv_def) &&
-            !ir_utils::isReductionTvOp(tv_def)) {
-          if (isBroadcastExpandTvOp(tv_def)) {
+            !ir_utils::isReductionTvOp(tv_def) && !tv_def->isA<ExpandOp>()) {
+          if (isBroadcastTvOp(tv_def)) {
             info.has_broadcast_between = true;
           } else {
             info.has_unsupported_op = true;
@@ -1386,11 +1386,11 @@ class ReusableAllocationFinder : private kir::IrVisitor {
   }
 
   // Utility to capture broadcast and expand ops
-  bool isBroadcastExpandTvOp(const Expr* expr) {
+  bool isBroadcastTvOp(const Expr* expr) {
     if (!ir_utils::isTvOp(expr)) {
       return false;
     }
-    return expr->isA<BroadcastOp>() || expr->isA<ExpandOp>();
+    return expr->isA<BroadcastOp>();
   }
 
  private:

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -1214,7 +1214,7 @@ class ReusableAllocationFinder : private kir::IrVisitor {
             if (this_tv_vectorized) {
               bool reuse_tv_vectorized = va.find(reuse_tv) != va.end();
               if (!reuse_tv_vectorized) {
-              return false;
+                return false;
               }
               int this_tv_alignment = va.at(this_tv);
               int reuse_tv_alignment = va.at(reuse_tv);

--- a/test/test_smem_reuse.cpp
+++ b/test/test_smem_reuse.cpp
@@ -598,7 +598,6 @@ TEST_F(SmemReuseTest, RegisterReuseWithDifferentVectorizationFactor) {
         if (expr->isA<kir::Allocate>()) {
           auto alloc = expr->as<kir::Allocate>();
           if (alloc->buffer()->name() == 3) {
-            std::cout << "alloc: " << alloc->toString() << std::endl;
             if (alloc->alias() && alloc->alias()->buffer()->name() == 1) {
               t3_alias_t1 = true;
             } else {


### PR DESCRIPTION
Fix shared memory reuse in softmax by:
(1) allow `expand` op and treat it similar to broadcast, that is `require matched iterdomains for reuse`
(2) Allow non-vectorized tv to reuse vectorized tv.

see https://github.com/NVIDIA/Fuser/issues/633 and https://github.com/NVIDIA/Fuser/issues/1562