### PR TITLE
Fix printing a monostate (i.e. an empty variant).

### DIFF
--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -228,6 +228,8 @@ inline std::string toString(const PolymorphicValue& v) {
     ss << "Tensor(sizes=" << t.sizes() << ", "
        << "stride=" << t.strides() << ", " << t.dtype() << ", " << t.device()
        << ")";
+  } else if (v.is<std::monostate>()) {
+    ss << "std::monostate";
   } else {
     ss << v;
   }


### PR DESCRIPTION
Otherwise, toString on a monostate fails with "Can not print St9monostate : incompatible type".