### PR TITLE
A test that surrounds a sharding expression with `segment_set`s.

### DIFF
--- a/test/test_segmentation.cpp
+++ b/test/test_segmentation.cpp
@@ -154,4 +154,56 @@ TEST_F(SegmentationTest, SegmentHintOnNonTerminatingOutput) {
   EXPECT_EQ(runtime->fusionSegments()->groups().size(), 2);
 }
 
+TEST_F(SegmentationTest, EnforceSegmentationByCachingBeforeAndAfter) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* tv0 = makeContigTensor(2);
+  TensorView* tv1 = sum(tv0, {0});
+  TensorView* tv2 = div(tv0, tv1);
+  fusion->addInput(tv0);
+  fusion->addOutput(tv2);
+
+  // A fake proxy for the real isSharding check.
+  auto is_sharding = [](Expr* expr) -> bool {
+    return expr->isA<ReductionOp>();
+  };
+
+  // I'd put this in a pre-segmenter pass.
+  std::vector<Expr*> sharding_exprs;
+  for (Expr* expr : fusion->exprs()) {
+    if (is_sharding(expr)) {
+      sharding_exprs.push_back(expr);
+    }
+  }
+  for (Expr* sharding_expr : sharding_exprs) {
+    for (TensorView* in_tv :
+         ir_utils::filterByType<TensorView>(sharding_expr->inputs())) {
+      if (!in_tv->isFusionInput()) {
+        in_tv->cacheBefore(LoadStoreOpType::SegmenterSet);
+      }
+    }
+    for (TensorView* out_tv :
+         ir_utils::filterByType<TensorView>(sharding_expr->outputs())) {
+      if (!out_tv->isFusionOutput()) {
+        out_tv->cacheAfter(LoadStoreOpType::SegmenterSet);
+      }
+    }
+  }
+
+  FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor = at::randn({2, 3}).cuda();
+  std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
+  testValidate(
+      fec.fusion(),
+      out_tensors,
+      {in_tensor},
+      {in_tensor / in_tensor.sum({0})},
+      __LINE__,
+      __FILE__);
+
+  FusionKernelRuntime* runtime = fec.getMostRecentKernelRuntime();
+  EXPECT_EQ(runtime->fusionSegments()->groups().size(), 2);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
As a follow-up to our previous meeting about segmentation for multi-device, I wrote this PR showing how to surround a sharding expression with `segment_set`s. This way, a sharding expression becomes its own segment without changing the current segmentation algorithm. I expect a pre-segmenter pass to add such `segment_set`s. See [`MarkAliasPreparePass`](https://github.com/NVIDIA/Fuser/blob/101530ec09a7eab9937f277715be0e3ecc1478b6/csrc/optimization/mark_aliases_prepare.cpp) for an example. I believe this is good enough for segmenting out CPU-initiated communication. 