### PR TITLE
Prevent replacing constant extents with non-const in concretization

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -540,7 +540,12 @@ void DynamicTransformConcretizer::concretizeReshape() {
       // If the old extent did not have a definition, we don't need to replace
       // it, since it will get bound whenever this tensor is a segmentation
       // edge.
-      if (old_extent->definition() && !new_extent->sameAs(old_extent)) {
+      //
+      // Also, if the old extent is already a constant, don't replace it with a
+      // non-constant, since this could cause downstream extents to become
+      // non-constant. See https://github.com/NVIDIA/Fuser/issues/1572
+      if (old_extent->definition() && !new_extent->sameAs(old_extent) &&
+          (!old_extent->isConstScalar() || new_extent->isConstScalar())) {
         registerConcretization(old_extent, new_extent);
       }
     }

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -1295,4 +1295,51 @@ TEST_F(NVFuserTest, SymbolicSqueeze) {
           " must concretize to IterType::Broadcast but found")));
 }
 
+// Test that constant zero extents are not overwritten during concretization
+// with non-constant extents.
+// See https://github.com/NVIDIA/Fuser/issues/1572
+TEST_F(NVFuserTest, ConcretizeConstantExtents) {
+  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+  Fusion* fusion = fusion_ptr.get();
+  FusionGuard fg(fusion);
+
+  auto tv0 = makeSymbolicTensor(2);
+  fusion->addInput(tv0);
+
+  // Explicitly cast Int to Index, so that these extents are not immediate
+  // constants
+  auto tv1 = reshape(
+      tv0,
+      {
+          castOp(DataType::Index, IrBuilder::create<Val>(4096, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(32, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(3, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(128, DataType::Int)),
+      });
+  auto tv2 = permute(tv1, {1, 2, 0, 3});
+  auto tv3 = slice(tv2, {0, 0, 0, 0}, {32, 1, 4096, 128});
+  auto tv4 = reshape(
+      tv3,
+      {
+          castOp(DataType::Index, IrBuilder::create<Val>(32, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(4096, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(128, DataType::Int)),
+      });
+  // Note this slice has zero extent in last dimension. RemoveEmptyPass should
+  // recognize this and replace with full()
+  auto tv5 = slice(tv4, {0, 0, 0}, {32, 4096, 0});
+
+  fusion->addOutput(tv5);
+
+  FusionExecutorCache fec(std::move(fusion_ptr));
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({4096, 12288}, options);
+  std::vector<c10::IValue> inputs = {t0};
+
+  auto outputs = fec.runFusionWithInputs(inputs);
+
+  testValidate(fusion, outputs, inputs, __LINE__, __FILE__);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Fixes #1572

In that case, `concretizeReshape` is replacing some extents in the new shape, such as `(nvfuser_index_t)16` with non-constant values like `i0`. This leads to a downstream expression that originally was constant `0` to be non-constant, so it cannot be picked up by `RemoveEmptyPass`. This PR avoids concretizing constant extents with non-constants. This should be safe since even if those tensors are segmentation edges, we will not lose any scalars because the extent is constant so there are no free scalars to lose.