### PR TITLE
Set allocation domains of intermediate tensors for aliasing.

### DIFF
--- a/csrc/alias_analysis.h
+++ b/csrc/alias_analysis.h
@@ -38,7 +38,7 @@ struct Layout {
 // analysis.add(...);
 // ...
 // analysis.add(...);
-// analysis.finalize(fusion, ...);
+// analysis.finalize(...);
 //
 // // The user can now call const methods to retrieve information.
 // ```
@@ -54,9 +54,10 @@ class AliasAnalysisResult {
   // preferred layout.
   void add(const TensorView* alias, TensorView* source, Layout&& layout);
 
+  // Computes transitive aliases and caches them in `alias_to_root_`.
   // See `findAliases` for the meaning of
   // `can_override_empty_allocation_domain`.
-  void finalize(Fusion* fusion, bool can_override_empty_allocation_domain);
+  void finalize(bool can_override_empty_allocation_domain);
 
   // Returns the preferred layout. If `alias` is not in `preferred_layout_`,
   // returns the `TensorView`'s initial layout.
@@ -64,25 +65,23 @@ class AliasAnalysisResult {
 
   std::string toString(int indent_size) const;
 
-  // Gets the nearest aliased fusion input/output of a `fusion_out` other than
-  // `fusion_out` itself. Returns null if that doesn't exist.
-  TensorView* getNearestAliasedIo(const TensorView* fusion_out) const;
+  // Returns the mapped value in `alias_to_root_` or null.
+  TensorView* getNearestAliasedIo(const TensorView* alias) const;
 
  private:
-  // Same as `getNearestAliasedIo` except that the `get` method returns the
-  // cached result.
-  TensorView* findNearestAliasedIo(TensorView* fusion_out) const;
-
-  // Maps aliases (e.g. the output of a View) to their direct sources (e.g. the
-  // input of the same View). Also stores the preferred output layout for the
-  // alias. Consider path compression, a common optimization used in
+  // Maps an alias (e.g. the output of a `ViewOp`) to its direct source (e.g.
+  // the input of the same `ViewOp`). Also stores the preferred output layout
+  // for the alias. Consider path compression, a common optimization used in
   // disjoint-set data structure, so it's easy to figure out the root of an
   // alias.
   std::unordered_map<const TensorView*, std::pair<TensorView*, Layout>>
       alias_to_source_;
 
-  // Maps a fusion output to its nearest aliased fusion input/output.
-  std::unordered_map<const TensorView*, TensorView*> out_to_root_;
+  // Maps an alias to its nearest, transitively aliased fusion input/output, if
+  // its preferred layout is compliant with its actual layout.
+  //
+  // TODO(wujingyue): consider to merge `alias_to_source_` and `alias_to_root_`.
+  std::unordered_map<const TensorView*, TensorView*> alias_to_root_;
 };
 
 // Finds aliases of the fusion inputs. The analysis should be conservative --

--- a/csrc/optimization/mark_aliases_prepare.cpp
+++ b/csrc/optimization/mark_aliases_prepare.cpp
@@ -43,7 +43,7 @@ void MarkAliasesPreparePass::runPass(Fusion* fusion) {
 
     // `AliasAnalysisResult::finalize` already checked the alias-enabling layout
     // is compliant with `tv`'s existing layout before adding `tv` to
-    // `out_to_root_`. So the existing layout can remain unchanged.
+    // `alias_to_root_`. So the existing layout can remain unchanged.
     if (tv->hasAllocation()) {
       continue;
     }

--- a/csrc/optimization/mark_aliases_prepare.cpp
+++ b/csrc/optimization/mark_aliases_prepare.cpp
@@ -28,37 +28,37 @@ void MarkAliasesPreparePass::runPass(Fusion* fusion) {
   // an input). Code will later add `segment_set` before them so aliases are
   // separated from non-aliases and more likely to be accepted by the no-op
   // scheduler.
-  std::vector<TensorView*> aliased_outs;
-  aliased_outs.reserve(fusion->outputs().size());
+  std::unordered_set<TensorView*> aliased_outs;
 
-  for (TensorView* out :
-       ir_utils::filterByType<TensorView>(fusion->outputs())) {
-    TensorView* aliased_io = analysis.getNearestAliasedIo(out);
+  for (TensorView* tv : ir_utils::allTvs(fusion)) {
+    TensorView* aliased_io = analysis.getNearestAliasedIo(tv);
     if (aliased_io == nullptr) {
       continue;
     }
 
     if (aliased_io->isFusionOutput() && !aliased_io->isFusionInput() &&
         analysis.getNearestAliasedIo(aliased_io) == nullptr) {
-      aliased_outs.push_back(aliased_io);
+      aliased_outs.insert(aliased_io);
     }
 
-    // We already checked it's compatible; no need to change.
-    if (out->hasAllocation()) {
+    // `AliasAnalysisResult::finalize` already checked the alias-enabling layout
+    // is compliant with `tv`'s existing layout before adding `tv` to
+    // `out_to_root_`. So the existing layout can remain unchanged.
+    if (tv->hasAllocation()) {
       continue;
     }
 
-    // A scalar `out` triggers a corner case that crashes
+    // A scalar `tv` triggers a corner case that crashes
     // `validateDomainEquivalence`.
-    if (out->isZeroDim()) {
+    if (tv->isZeroDim()) {
       continue;
     }
 
-    const Layout preferred_layout = analysis.preferredLayout(out);
-    out->setAllocationDomain(
+    const Layout preferred_layout = analysis.preferredLayout(tv);
+    tv->setAllocationDomain(
         preferred_layout.allocation_domain, preferred_layout.contiguity);
     if (isDebugDumpEnabled(DebugDumpOption::PreSegmenterLogging)) {
-      debug() << "Set the layout of " << ir_utils::varName(out) << " to "
+      debug() << "Set the layout of " << ir_utils::varName(tv) << " to "
               << preferred_layout.toString() << std::endl;
     }
   }

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -30,6 +30,7 @@ using testing::IsTrue;
 using testing::Not;
 using testing::Optional;
 using testing::Pair;
+using testing::UnorderedElementsAre;
 
 using AliasAnalysisTest = NVFuserTest;
 
@@ -529,7 +530,6 @@ TEST_F(AliasTest, SliceViewPermute) {
 }
 
 TEST_F(AliasTest, DuplicateOutputsSegmentedFusion) {
-  // testing duplicated output in segmented fusion
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -537,37 +537,29 @@ TEST_F(AliasTest, DuplicateOutputsSegmentedFusion) {
 
   TensorView* in = makeContigConcreteTensor(in_shape);
   fusion->addInput(in);
-  TensorView* intermediate_tv = add(in, IrBuilder::create<Val>(3.141));
-  TensorView* segment_tv = segment_set(intermediate_tv);
-  TensorView* out = mul(segment_tv, IrBuilder::create<Val>(2.0));
+  TensorView* mid = add(in, IrBuilder::create<Val>(3.141));
+  mid = segment_set(mid);
+  TensorView* out = mul(mid, IrBuilder::create<Val>(2.0));
 
-  fusion->addOutput(intermediate_tv);
-  fusion->addOutput(intermediate_tv);
+  fusion->addOutput(mid);
+  fusion->addOutput(mid);
   fusion->addOutput(out);
-  fusion->addOutput(out); // duplicated outputs
+  fusion->addOutput(out);
 
   FusionExecutorCache fec(std::move(fusion));
   at::Tensor in_tensor =
       at::randn(in_shape, at::dtype(at::kFloat).device(at::kCUDA, 0));
   std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
-  ASSERT_EQ(out_tensors.size(), 4);
-  at::Tensor out_tensor_0 = out_tensors[0];
-  at::Tensor out_tensor_1 = out_tensors[1];
-  at::Tensor out_tensor_2 = out_tensors[2];
-  at::Tensor out_tensor_3 = out_tensors[3];
+  testValidate(fec.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
   // Verify aliasing among duplicated outputs
-  EXPECT_TRUE(out_tensor_0.is_alias_of(out_tensor_1));
-  EXPECT_TRUE(out_tensor_2.is_alias_of(out_tensor_3));
-  // Verify segmentation
-  NVF_CHECK(
-      fec.getMostRecentKernelRuntime()->fusionSegments()->groups().size() == 2,
-      "segmentation didn't happen as expected");
+  EXPECT_TRUE(out_tensors[0].is_alias_of(out_tensors[1]));
+  EXPECT_TRUE(out_tensors[2].is_alias_of(out_tensors[3]));
 
-  at::Tensor intermediate_tensor = in_tensor.add(3.141);
-  at::Tensor out_tensor = intermediate_tensor.mul(2.0);
-  // Verify output values.
-  testValidate(fec.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
+  // Verify segmentation
+  EXPECT_EQ(
+      fec.getMostRecentKernelRuntime()->fusionSegments()->groups().size(), 2)
+      << "segmentation didn't happen as expected";
 }
 
 namespace {
@@ -920,6 +912,34 @@ TEST_F(AliasTest, SourceIsBothInputAndOutput) {
 
   EXPECT_EQ(in_tensor.data_ptr(), out_tensors[0].data_ptr());
   EXPECT_EQ(in_tensor.data_ptr(), out_tensors[1].data_ptr());
+}
+
+MATCHER_P(HeuristicIs, heuristic, "") {
+  return arg->heuristic() == heuristic;
+}
+
+TEST_F(AliasTest, SegmentBoundary) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({2, 3});
+  TensorView* out = permute(in, {1, 0});
+  out = slice(out, {0, 0}, {2, 2});
+  out = add(out, out);
+  fusion->addInput(in);
+  fusion->addOutput(out);
+
+  FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor = at::randn({2, 3}).cuda();
+  at::Tensor out_tensor = fec.runFusionWithInputs({in_tensor})[0];
+  testValidate(fec.fusion(), {out_tensor}, {in_tensor}, __LINE__, __FILE__);
+
+  FusionKernelRuntime* runtime = fec.getMostRecentKernelRuntime();
+  EXPECT_THAT(
+      runtime->fusionSegments()->groups(),
+      UnorderedElementsAre(
+          HeuristicIs(ScheduleHeuristic::NoOp),
+          HeuristicIs(ScheduleHeuristic::PointWise)));
 }
 
 } // namespace nvfuser

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -924,6 +924,9 @@ TEST_F(AliasTest, SegmentBoundary) {
 
   TensorView* in = makeContigConcreteTensor({2, 3});
   TensorView* out = permute(in, {1, 0});
+  // With the current segmentation algorithm, `slice` has to be the start of a
+  // fusion. So we expect `permute` to form a meta-op-only segment and the rest
+  // a pointwise segment.
   out = slice(out, {0, 0}, {2, 2});
   out = add(out, out);
   fusion->addInput(in);


### PR DESCRIPTION
This PR also refactors `AliasAnalysisResult::finalize` so that the `fusion` parameter is unnecessary. 

Question to reviewers: is it OK to leave alias-enabling allocation domains on intermediate tensors? I could remove them but would need to distinguish those added by users from those by `MarkAliasPreparePass`. 