### PR TITLE
Set device index during deserialization.

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -2210,6 +2210,7 @@ void FusionExecutor::deserialize(
 
   // Initialize CompileOptions
   options_.device = c10::Device(c10::DeviceType::CUDA, device_index);
+  c10::DeviceGuard dg(options_.device);
 
   // Initialize internal fields
   device_smem_limit_ = buffer->device_smem_limit();

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -2184,6 +2184,7 @@ flatbuffers::Offset<serde::GlobalBufferInfo> FusionExecutor::serialize(
 void FusionExecutor::deserialize(
     const serde::FusionExecutor* buffer,
     Fusion* fusion,
+    int8_t device_index,
     CompileParams compile_params,
     ScheduleHeuristic heuristic,
     int64_t fusion_id,
@@ -2206,6 +2207,9 @@ void FusionExecutor::deserialize(
       group_id == buffer->group_id(),
       "Expected given group_id to match serde group_id.");
   NVF_ERROR(toUnderlying(heuristic) == buffer->heuristic());
+
+  // Initialize CompileOptions
+  options_.device = c10::Device(c10::DeviceType::CUDA, device_index);
 
   // Initialize internal fields
   device_smem_limit_ = buffer->device_smem_limit();

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -372,6 +372,7 @@ class FusionExecutor : public NonCopyable {
   void deserialize(
       const serde::FusionExecutor* buffer,
       Fusion* fusion,
+      int8_t device_index,
       CompileParams compile_params,
       ScheduleHeuristic heuristic,
       int64_t fusion_id,

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -926,7 +926,8 @@ void FusionExecutorCache::deserialize(
 
       // 3. For FusionKernelRuntime, we have a separate deserialize function
       // to create the FusionExecutor objects.
-      device_runtimes.back()->deserialize(fb_fusion_kernel_runtime);
+      device_runtimes.back()->deserialize(
+          fb_fusion_kernel_runtime, args.getDeviceIndex());
 
       all_runtimes.emplace_back(device_runtimes.back().get());
     }
@@ -1056,7 +1057,8 @@ flatbuffers::Offset<serde::FusionKernelRuntime> FusionKernelRuntime::serialize(
 }
 
 void FusionKernelRuntime::deserialize(
-    const serde::FusionKernelRuntime* buffer) {
+    const serde::FusionKernelRuntime* buffer,
+    int8_t device_index) {
   // See table definition in FusionKernelRuntime in serde/fusion_cache.fbs
 
   NVF_ERROR(buffer != nullptr, "serde::FusionKernelRuntime is nullptr.");
@@ -1088,6 +1090,7 @@ void FusionKernelRuntime::deserialize(
     executors_.at(group_id).deserialize(
         buffer->executors()->Get(group_id),
         fusion_to_run.get(),
+        device_index,
         scheduler_entry->params()->cparams,
         scheduler_entry->heuristic(),
         fusion_id_,

--- a/csrc/kernel_cache.h
+++ b/csrc/kernel_cache.h
@@ -129,7 +129,9 @@ class FusionKernelRuntime {
       flatbuffers::FlatBufferBuilder& builder) const;
 
   //! Deserialize Fusion Kernel Runtime using flatbuffers
-  void deserialize(const serde::FusionKernelRuntime* buffer);
+  void deserialize(
+      const serde::FusionKernelRuntime* buffer,
+      int8_t device_index);
 
   //! Note that all heuristics use the same index type.
   PrimDataType getIndexType() const {

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -111,7 +111,9 @@ class TestNvFuserFrontend(TestCase):
     # definition based on the FusionDefinition is executable and matches the
     # original definition
     @serde_check
-    def exec_nvfuser(self, fusion_func, inputs, *, new_fusion_expected=True):
+    def exec_nvfuser(
+        self, fusion_func, inputs, *, new_fusion_expected=True, device=None
+    ):
         inputs_cap = deepcopy(inputs)
         fc = FusionCache.get()
         before_fusions = fc.num_fusions()
@@ -2246,10 +2248,8 @@ class TestNvFuserFrontend(TestCase):
             t4 = fd.ops.mul(t3, s2)
             fd.add_output(t4)
 
-        with FusionDefinition() as fd:
-            fusion_func(fd)
-
-        nvf_out = fd.execute([2.0, 3.0], device="cuda:1")
+        inputs = [2.0, 3.0]
+        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs, device="cuda:1")
         eager_out = torch.full([2, 2], 1.0, device="cuda:1") * 5.0
         self.assertEqual(eager_out, nvf_out[0])
 

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -123,7 +123,7 @@ class TestNvFuserFrontend(TestCase):
             fusion_func(fd)
         fd_str = fd.__repr__()
         torch.manual_seed(0)
-        out = fd.execute(inputs)
+        out = fd.execute(inputs, device=device)
 
         # Execute the python definition that was captured
         try:
@@ -132,7 +132,7 @@ class TestNvFuserFrontend(TestCase):
             with FusionDefinition() as fd_cap:
                 eval(func_name)(fd_cap)
             torch.manual_seed(0)
-            out_cap = fd_cap.execute(inputs_cap)
+            out_cap = fd_cap.execute(inputs_cap, device=device)
         except Exception as err:
             print("\nException For Printed FusionDefinition:")
             print(


### PR DESCRIPTION
This PR sets the `CompileOptions` in the `FusionExecutor` during deserialization to the appropriate device. It fixes errors encountered in a distributed setting.