### PR TITLE
Simplify `WarpMmaSwizzler::scheduleOperandRead` for Hopper

### DIFF
--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -812,37 +812,27 @@ void WarpMmaSwizzler::scheduleOperandRead(
     }
   } else {
     auto swizzle_size = getBytesFromSwizzle(swizzle) / 16;
+    // For example, [K, M]
     if (transpose2) {
-      // For example, [K, M]
       tv->reorder({{-2, -1}});
       // [M, K]
-      tv->split(-2, 8);
-      tv->split(-1, 8);
-      // [Mo, M8, Ko, K8]
-      tv->split(-3, 8 / swizzle_size);
-      // For example swizzle_size = 2
-      // [Mo, M2, M4, Ko, K8]
-      tv->split(-2, swizzle_size);
-      // [Mo, M2, M4, Koo, K2, K8]
-      tv->swizzle(SwizzleType::XOR, -5, -2);
-    } else {
-      // For example, [K, M]
-      tv->split(-2, 8);
-      tv->split(-1, 8);
-      // [Ko, K8, Mo, M8]
-      tv->reorder({{-2, -3}});
-      // [Ko, Mo, K8, M8]
-      // Note: the extent of Mo may not be a multiple of swizzle_size, but we
-      // still split swizzle_size. If this is the case, effectively we are
-      // padding it to a multiple of swizzle_size.
-      tv->split(-3, swizzle_size);
-      // For example, swizzle_size = 2
-      // [Ko, Moo, Mo2, K8, M8]
-      tv->reorder({{-2, -3}});
-      // [Ko, Moo, K8, Mo2, M8]
-      tv->split(-3, 8 / swizzle_size);
+    }
+    tv->split(-2, 8);
+    tv->split(-1, 8);
+    // For example transpose2 == false
+    // [Ko, K8, Mo, M8]
+    // Note: the extent of Mo may not be a multiple of swizzle_size, but we
+    // still split swizzle_size. If this is the case, effectively we are
+    // padding it to a multiple of swizzle_size.
+    tv->split(-2, swizzle_size);
+    // For example, swizzle_size = 2
+    // [Ko, K8, Moo, Mo2, M8]
+    tv->split(-4, 8 / swizzle_size);
+    // [Ko, K2, K4, Moo, Mo2, M8]
+    tv->swizzle(SwizzleType::XOR, -5, -2);
+    if (!transpose2) {
+      tv->reorder({{-3, -5}});
       // [Ko, Moo, K2, K4, Mo2, M8]
-      tv->swizzle(SwizzleType::XOR, -4, -2);
     }
   }
   tv->setAllocationDomain(tv->getLeafDomain(), true);


### PR DESCRIPTION
This PR should have no behavioral change, it is just better code organization. Currently, in the main branch, for Hopper MMA operand B, `transpose2` is handled like
```C++
if (transpose2) {
  // code A
} else {
  // code B
}
```
this PR refactors this part to pull out the code that can be shared between code A and B.