### PR TITLE
Use Development.Module for find_python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 string(APPEND CMAKE_CXX_FLAGS " -Wno-psabi")
 
 find_package(Torch REQUIRED)
-find_package(Python REQUIRED Development Interpreter)
+find_package(Python REQUIRED Development.Module Interpreter)
 find_package(pybind11 REQUIRED)
 
 # need this since the pytorch execution uses a different name


### PR DESCRIPTION
We'll migrate python binary to those provided in pypa manylinux images. This change in CMakeLists.txt is needed because some libpython developer library is not included.

Ref for similar changes: https://github.com/pypa/manylinux/issues/484, https://github.com/NVIDIA/TransformerEngine/pull/586