### PR TITLE
[DynamicType] Add named comparison ops returning dynamic type

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -585,7 +585,6 @@ std::vector<PolymorphicValue> BinaryOp::evaluate(
       return {lhs * rhs};
       break;
     case BinaryOpType::Div:
-      NVF_CHECK(rhs != 0);
       return {lhs / rhs};
       break;
     case BinaryOpType::Mod:
@@ -612,22 +611,22 @@ std::vector<PolymorphicValue> BinaryOp::evaluate(
       return {lhs ^ rhs};
       break;
     case BinaryOpType::Eq:
-      return {lhs == rhs};
+      return {eq(lhs, rhs)};
       break;
     case BinaryOpType::NE:
-      return {lhs != rhs};
+      return {ne(lhs, rhs)};
       break;
     case BinaryOpType::GT:
-      return {lhs > rhs};
+      return {gt(lhs, rhs)};
       break;
     case BinaryOpType::GE:
-      return {lhs >= rhs};
+      return {ge(lhs, rhs)};
       break;
     case BinaryOpType::LT:
-      return {lhs < rhs};
+      return {lt(lhs, rhs)};
       break;
     case BinaryOpType::LE:
-      return {lhs <= rhs};
+      return {le(lhs, rhs)};
       break;
     case BinaryOpType::Max:
       return {max(lhs, rhs)};

--- a/lib/dynamic_type/src/dynamic_type/dynamic_type.h
+++ b/lib/dynamic_type/src/dynamic_type/dynamic_type.h
@@ -590,7 +590,7 @@ DEFINE_BINARY_OP(rshift, >>, operator>>);
 // overloading, because we want to leave the operator overloading for comparison
 // operators that returns bool. Instead, we give each operator a function name,
 // so that users can use the function name to call the operator. That is:
-//   dt1 < dt2 --> returns a bool
+//   dt1 < dt2 --> returns a bool (defined below by DEFINE_COMPARE_OP)
 //   lt(dt1, dt2) --> returns a DynamicType
 DEFINE_BINARY_OP(eq, ==, eq);
 DEFINE_BINARY_OP(neq, !=, ne);

--- a/lib/dynamic_type/src/dynamic_type/dynamic_type.h
+++ b/lib/dynamic_type/src/dynamic_type/dynamic_type.h
@@ -674,7 +674,7 @@ DEFINE_BINARY_OP(ge, >=, ge);
   template <typename LHS, typename DT>                                        \
   inline constexpr std::                                                      \
       enable_if_t<is_dynamic_type_v<DT> && !is_dynamic_type_v<LHS>, bool>     \
-      operator op(const LHS & x, const DT & y) {                              \
+      operator op(const LHS& x, const DT& y) {                                \
     std::optional<bool> ret = std::nullopt;                                   \
     DT::for_all_types([&ret, &x, &y](auto rhs) {                              \
       using RHS = typename decltype(rhs)::type;                               \
@@ -734,7 +734,7 @@ DEFINE_COMPARE_OP(ge, >=);
               opname##_helper<typename DT::VariantType>,                       \
               DT::type_identities_as_tuple),                                   \
       DT>                                                                      \
-  operator op(const DT & x) {                                                  \
+  operator op(const DT& x) {                                                   \
     DT ret(std::monostate{});                                                  \
     DT::for_all_types([&ret, &x](auto _) {                                     \
       using Type = typename decltype(_)::type;                                 \
@@ -853,7 +853,7 @@ std::ostream& operator<<(std::ostream& os, const DT& dt) {
       typename = std::enable_if_t<                                             \
           is_dynamic_type_v<DT> &&                                             \
           any_check(opname##_helper, DT::type_identities_as_tuple)>>           \
-  inline constexpr DT& operator op(DT & x) {                                   \
+  inline constexpr DT& operator op(DT& x) {                                    \
     bool computed = false;                                                     \
     DT::for_all_types([&computed, &x](auto _) {                                \
       using Type = typename decltype(_)::type;                                 \
@@ -901,7 +901,7 @@ DEFINE_LEFT_PPMM(lmm, --);
               opname##_helper<typename DT::VariantType>,                       \
               DT::type_identities_as_tuple),                                   \
       DT>                                                                      \
-  operator op(DT & x, int) {                                                   \
+  operator op(DT& x, int) {                                                    \
     DT ret;                                                                    \
     DT::for_all_types([&ret, &x](auto _) {                                     \
       using Type = typename decltype(_)::type;                                 \
@@ -935,7 +935,7 @@ DEFINE_RIGHT_PPMM(rmm, --);
       typename T,                                                \
       typename = std::enable_if_t<                               \
           is_dynamic_type_v<DT> && (opcheck<DT> op opcheck<T>)>> \
-  inline constexpr DT& operator assign_op(DT & x, const T & y) { \
+  inline constexpr DT& operator assign_op(DT& x, const T& y) {   \
     return x = x op y;                                           \
   }
 

--- a/lib/dynamic_type/test/binary_ops.cpp
+++ b/lib/dynamic_type/test/binary_ops.cpp
@@ -174,6 +174,79 @@ TEST_COMPARE_OP(Gt, >);
 TEST_COMPARE_OP(Le, <=);
 TEST_COMPARE_OP(Ge, >=);
 
+#define TEST_NAMED_COMPARE_OP(name, op, func)                                \
+  TEST_F(DynamicTypeTest, name) {                                            \
+    static_assert(                                                           \
+        func(DoubleInt64Bool(2L), DoubleInt64Bool(2.0)) == (2L op 2.0));     \
+    static_assert(                                                           \
+        func(DoubleInt64Bool(2L), DoubleInt64BoolTwo{}) == (2L op 2L));      \
+    static_assert(                                                           \
+        func(DoubleInt64Bool(1L), DoubleInt64BoolTwo{}) == (1L op 2L));      \
+    static_assert(                                                           \
+        func(DoubleInt64Bool(3L), DoubleInt64BoolTwo{}) == (3L op 2L));      \
+    static_assert(                                                           \
+        func(DoubleInt64BoolTwo{}, DoubleInt64Bool(2L)) == (2L op 2L));      \
+    static_assert(                                                           \
+        func(DoubleInt64BoolTwo{}, DoubleInt64Bool(1L)) == (2L op 1L));      \
+    static_assert(                                                           \
+        func(DoubleInt64BoolTwo{}, DoubleInt64Bool(3L)) == (2L op 3L));      \
+    EXPECT_EQ(                                                               \
+        func(DoubleInt64BoolVec(2L), DoubleInt64BoolVec(2.0)), (2L op 2.0)); \
+    EXPECT_EQ(                                                               \
+        func(DoubleInt64BoolVec(2L), DoubleInt64BoolVecTwo{}), (2L op 2L));  \
+    EXPECT_EQ(                                                               \
+        func(DoubleInt64BoolVec(1L), DoubleInt64BoolVecTwo{}), (1L op 2L));  \
+    EXPECT_EQ(                                                               \
+        func(DoubleInt64BoolVec(3L), DoubleInt64BoolVecTwo{}), (3L op 2L));  \
+    EXPECT_EQ(                                                               \
+        func(DoubleInt64BoolVecTwo{}, DoubleInt64BoolVec(2L)), (2L op 2L));  \
+    EXPECT_EQ(                                                               \
+        func(DoubleInt64BoolVecTwo{}, DoubleInt64BoolVec(1L)), (2L op 1L));  \
+    EXPECT_EQ(                                                               \
+        func(DoubleInt64BoolVecTwo{}, DoubleInt64BoolVec(3L)), (2L op 3L));  \
+    EXPECT_EQ(                                                               \
+        func(                                                                \
+            DoubleInt64BoolVec(std::vector<int64_t>{2}),                     \
+            DoubleInt64BoolVec(std::vector<double>{2.0})),                   \
+        (2L op 2.0));                                                        \
+    static_assert(                                                           \
+        func(DoubleInt64Bool(2L), DoubleInt64Bool(2.5)) == (2L op 2.5));     \
+    EXPECT_EQ(                                                               \
+        func(DoubleInt64BoolVec(2L), DoubleInt64BoolVec(2.5)), (2L op 2.5)); \
+    EXPECT_EQ(                                                               \
+        func(                                                                \
+            DoubleInt64BoolVec(std::vector<int64_t>{2L}),                    \
+            DoubleInt64BoolVec(std::vector<double>{2.5})),                   \
+        (2L op 2.5));                                                        \
+    static_assert(func(DoubleInt64Bool(3L), 2L) == (3L op 2L));              \
+    EXPECT_EQ(func(DoubleInt64BoolVec(3L), 2L), (3L op 2L));                 \
+    static_assert(func(3L, DoubleInt64Bool(2L)) == (3L op 2L));              \
+    EXPECT_EQ(func(3L, DoubleInt64BoolVec(2L)), (3L op 2L));                 \
+    EXPECT_THAT(                                                             \
+        [&]() { func(DoubleInt64Bool(), DoubleInt64Bool(2L)); },             \
+        ::testing::ThrowsMessage<std::runtime_error>(                        \
+            ::testing::HasSubstr("Cannot compute ")));                       \
+    EXPECT_THAT(                                                             \
+        [&]() {                                                              \
+          func(                                                              \
+              DoubleInt64BoolVec(std::vector<DoubleInt64BoolVec>{}),         \
+              DoubleInt64BoolVec(2L));                                       \
+        },                                                                   \
+        ::testing::ThrowsMessage<std::runtime_error>(                        \
+            ::testing::HasSubstr("Cannot compute ")));                       \
+    EXPECT_THAT(                                                             \
+        [&]() { func(IntSomeType(SomeType{}), IntSomeType(SomeType{})); },   \
+        ::testing::ThrowsMessage<std::runtime_error>(                        \
+            ::testing::HasSubstr("Cannot compute ")));                       \
+  }
+
+TEST_NAMED_COMPARE_OP(NamedEq, ==, eq);
+TEST_NAMED_COMPARE_OP(NamedNe, !=, ne);
+TEST_NAMED_COMPARE_OP(NamedLt, <, lt);
+TEST_NAMED_COMPARE_OP(NamedGt, >, gt);
+TEST_NAMED_COMPARE_OP(NamedLe, <=, le);
+TEST_NAMED_COMPARE_OP(NamedGe, >=, ge);
+
 #define TEST_BINARY_OP_INT_ONLY(name, op)                                      \
   TEST_F(DynamicTypeTest, name) {                                              \
     static_assert(opcheck<DoubleInt64Bool> op opcheck<DoubleInt64Bool>);       \

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -656,4 +656,21 @@ TEST_F(ExprEvalTest, Reshape_MergeBroadcast) {
   EXPECT_THAT(out_tensor.strides(), ElementsAre(1));
 }
 
+TEST_F(ExprEvalTest, SumDiv) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* in = makeContigTensor(2);
+  TensorView* s = sum(in, {0});
+  TensorView* out = div(in, s);
+  fusion.addInput(in);
+  fusion.addOutput(out);
+
+  at::Tensor in_tensor = at::randn({2, 3}).cuda();
+
+  ExpressionEvaluator evaluator;
+  evaluator.bind(in, in_tensor);
+  evaluator.evaluate(out);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/Fuser/issues/1570

This PR adds a variant of comparison operators that returns `DynamicType`. This new variant is not implemented as operator overloading, instead, users need to explicitly call its function. The reason for not overloading it as operators is because it makes more sense to make comparison operators return bool, so that code like
```C++
PolymorphicValue pv = 2;
if (pv > 0) {
  blabla();
}
```
will seamlessly work.