### PR TITLE
[WIP] Translate serial grid reduction to kernel IR

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -265,7 +265,7 @@ GpuLower::GpuLower(Fusion* fusion, const CompileParams& cparams)
           // const std::vector<Expr*>& and return a std::vector<Expr*>.
           {{"LoopNestGenerator", LoopNestGenerator::loweredExprs},
            {"loadStoreOpInserter", loadStoreOpInserter},
-           {"insertGridSerializationSyncs", insertGridSerializationSyncs},
+           {"translateSerialGridReduction", translateSerialGridReduction},
            {"insertAllocations", insertAllocations},
            {"insertRawThreadSynchronization", insertRawThreadSynchronization},
            {"reuseMemoryAllocations", reuseMemoryAllocations},

--- a/csrc/device_lower/pass/grid_serialization.cpp
+++ b/csrc/device_lower/pass/grid_serialization.cpp
@@ -13,6 +13,7 @@
 #include <ir/utils.h>
 #include <kernel_ir.h>
 #include <kernel_ir_dispatch.h>
+#include <ops/arith.h>
 
 #include <unordered_set>
 
@@ -53,45 +54,156 @@ class GridSerializationSyncInserter : kir::ExprMutator {
   using kir::ExprMutator::dispatch;
   using kir::ExprMutator::handle;
 
-  //! Record cur_expr_sync_pattern_ if this is a serial grid reduction
+  //! If this is a serial grid reduction, replace it with a sequence of IR
+  //! nodes to effect the reduction step.
   void handle(ReductionOp* rop) override {
     if (rop->serialGridReductionRequested()) {
-      ParallelTypeBitmap sync_pattern;
-      auto out = rop->out()->as<TensorView>();
-      NVF_ERROR(out != nullptr);
-      for (int i : c10::irange((int)out->nDims())) {
-        IterDomain* ax = out->axis(i);
-        if (!ax->isReduction()) {
-          continue;
-        }
-        NVF_ERROR(
-            !ax->isThreadDim(),
-            "Serial grid reduction cannot be applied with block reductions: ",
-            rop->toString());
-        if (ax->isBlockDim()) {
-          sync_pattern.set(ax->getParallelType());
-        }
-      }
+      recordSyncPattern(rop);
 
-      if (!sync_pattern.hasBID()) {
-        // Don't set cur_expr_sync_pattern_ since this is not actually a grid
-        // reduction
-        return;
-      }
+      replaceReductionOp(rop);
+    }
+  }
 
-      if (cur_expr_sync_pattern_.has_value()) {
-        NVF_ERROR(
-            cur_expr_sync_pattern_.value() == sync_pattern,
-            "Reduction op ",
-            rop->toString(),
-            " has requested serial grid reduction, but pattern ",
-            sync_pattern.toString(),
-            " conflicts with previous pattern: ",
-            cur_expr_sync_pattern_.value().toString());
-      } else {
-        cur_expr_sync_pattern_ = sync_pattern;
+  //! Record the grid sync pattern so that we can check compatibility in case
+  //! multiple serial grid reductions occur within the same non-trivial loop.
+  void recordSyncPattern(ReductionOp* rop) {
+    ParallelTypeBitmap sync_pattern;
+    auto out = rop->out()->as<TensorView>();
+    NVF_ERROR(out != nullptr);
+    for (int i : c10::irange((int)out->nDims())) {
+      IterDomain* ax = out->axis(i);
+      if (!ax->isReduction()) {
+        continue;
+      }
+      NVF_ERROR(
+          !ax->isThreadDim(),
+          "Serial grid reduction cannot be applied with block reductions: ",
+          rop->toString());
+      if (ax->isBlockDim()) {
+        sync_pattern.set(ax->getParallelType());
       }
     }
+
+    if (!sync_pattern.hasBID()) {
+      // Don't set cur_expr_sync_pattern_ since this is not actually a grid
+      // reduction
+      return;
+    }
+
+    if (cur_expr_sync_pattern_.has_value()) {
+      NVF_ERROR(
+          cur_expr_sync_pattern_.value() == sync_pattern,
+          "Reduction op ",
+          rop->toString(),
+          " has requested serial grid reduction, but pattern ",
+          sync_pattern.toString(),
+          " conflicts with previous pattern: ",
+          cur_expr_sync_pattern_.value().toString());
+    } else {
+      cur_expr_sync_pattern_ = sync_pattern;
+    }
+  }
+
+  //! Replace a serial reduction op with an IR representation of the update
+  //! step. This mimics the helper function
+  //!
+  //!   template <typename T, typename Func>
+  //!   __device__ void serialReductionStep(
+  //!       T& out,
+  //!       T in,
+  //!       T init,
+  //!       volatile T& work,
+  //!       Func reduction_op,
+  //!       bool first_step,
+  //!       bool last_step,
+  //!       bool read_pred,
+  //!       bool write_pred) {
+  //!     if (!write_pred) {
+  //!       return;
+  //!     }
+  //!     out = read_pred ? in : init;
+  //!     if (!first_step) {
+  //!       reduction_op(out, work);
+  //!     }
+  //!     if (!last_step) {
+  //!       work = out;
+  //!     }
+  //!   }
+  void replaceReductionOp(ReductionOp* rop) {
+    NVF_ERROR(rop->serialGridReductionRequested());
+    NVF_ERROR(cur_expr_sync_pattern_.has_value());
+
+    Val* is_first_step = nullptr;
+    Val* is_last_step = nullptr;
+    for (auto pt : kParallelTypeBIDs) {
+      if (cur_expr_sync_pattern_.value().get(pt)) {
+        // && BID == 0
+        is_first_step = SimplifyingIrBuilder::logicalAndExpr(
+            is_first_step,
+            IrBuilder::eqExpr(
+                NamedScalar::getParallelIndex(pt),
+                FusionGuard::getCurFusion()->zeroVal(DataType::Index)));
+        // && BID == BDIM - 1
+        is_last_step = SimplifyingIrBuilder::logicalAndExpr(
+            is_last_step,
+            IrBuilder::eqExpr(
+                NamedScalar::getParallelIndex(pt),
+                IrBuilder::subExpr(
+                    NamedScalar::getParallelDim(pt),
+                    FusionGuard::getCurFusion()->oneVal(DataType::Index))));
+      }
+    }
+    is_first_step = GpuLower::current()->commonScalarMap().hoistScalar(
+        is_first_step, for_loops_);
+    is_last_step = GpuLower::current()->commonScalarMap().hoistScalar(
+        is_last_step, for_loops_);
+    NVF_ERROR(is_first_step != nullptr);
+    NVF_ERROR(is_last_step != nullptr);
+
+    auto in = rop->in()->as<TensorView>();
+    auto out = rop->out()->as<TensorView>();
+
+    // Create a work buffer
+    TensorView* work_buffer_in = IrBuilder::create<TensorView>(
+        out->domain(), out->dtype(), MemoryType::Global);
+
+    TensorView* loaded_work_buffer =
+        work_buffer_in->cacheAfter(LoadStoreOpType::Set, CacheOp::Global);
+    // INTERNAL ASSERT FAILED at
+    // "/opt/pytorch/nvfuser/csrc/tensor_view.cpp":1278 Function invalid for
+    // kernel container.
+    // TODO: caching is not meant to work on kernel IR, so we'll have to work
+    // around that
+
+    TensorView* in_plus_work =
+        binaryOp(rop->getReductionOpType(), in, loaded_work_buffer);
+    TensorView* result = where(is_first_step, in, in_plus_work);
+
+    // work_buffer_out is dead code (it has no uses). This means we won't
+    // automatically insert new Allocate nodes for it in subsequent lowering
+    // passes, so it is safe for us to create one here.
+    TensorView* work_buffer_out =
+        result->cacheAfter(LoadStoreOpType::Set, CacheOp::Global);
+    work_buffer_out->setMemoryType(MemoryType::Global);
+    // TODO: we cannot force aliasing work_buffer_out => work_buffer_in yet,
+    // since that is done with Allocate. Since we _do_ want automatic insertion
+    // of work_buffer_in's Allocate, it is unclear how we can effectively set
+    // this alias.
+
+    // Insert expressions
+    // use with{Write}Predicate for global load and store expressions
+    registerInsertBefore(
+        rop,
+        loaded_work_buffer->definition()->withPredicate(
+            IrBuilder::create<kir::Predicate>(
+                IrBuilder::logicalNotExpr(is_first_step))));
+    registerInsertBefore(rop, in_plus_work->definition());
+    registerInsertBefore(
+        rop,
+        work_buffer_out->definition()->withWritePredicate(
+            IrBuilder::create<kir::Predicate>(
+                IrBuilder::logicalNotExpr(is_last_step))));
+    registerInsertBefore(rop, result->definition());
   }
 
   void dispatch(Expr* expr) override {
@@ -173,9 +285,9 @@ class GridSerializationSyncInserter : kir::ExprMutator {
 
 } // namespace
 
-std::vector<Expr*> insertGridSerializationSyncs(
+std::vector<Expr*> translateSerialGridReduction(
     const std::vector<Expr*>& exprs) {
-  FUSER_PERF_SCOPE("GpuLower::Lower::insertGridSerializationSyncs");
+  FUSER_PERF_SCOPE("GpuLower::Lower::translateSerialGridReduction");
   return GridSerializationSyncInserter::insert(exprs);
 }
 

--- a/csrc/device_lower/pass/grid_serialization.h
+++ b/csrc/device_lower/pass/grid_serialization.h
@@ -19,8 +19,9 @@ namespace nvfuser {
 
 //! Detect ReductionOps that have serialGridReductionRequested() == true. When
 //! found, confirm that no conflicting operations exist, then place sync nodes
-//! before and after outer-most non-parallelized loop.
-std::vector<Expr*> insertGridSerializationSyncs(
+//! before and after outer-most non-parallelized loop. Finally, translate the
+//! reduction op itself into a sequence of set and add ops.
+std::vector<Expr*> translateSerialGridReduction(
     const std::vector<Expr*>& exprs);
 
 } // namespace nvfuser


### PR DESCRIPTION
This removes the need for special handling of serial grid reductions in codegen.cpp and the `serialReductionStep` runtime helper function. Instead, we translate those expressions into regular IR expressions and let lowering passes handle allocation of the work buffer and indexing.