### PR TITLE
Convert benchmark output to JSON serializable format

### DIFF
--- a/python_benchmarks/global_params.py
+++ b/python_benchmarks/global_params.py
@@ -56,15 +56,17 @@ def generate_input_sizes(dims: Union[int, List] = 2) -> List[Tuple]:
             # max_batch_range: set according to max size that fits in GPU memory
             batch_range = [2**i for i in range(4, 14)]  # {16, 8192}
             # max_hidden_size = 4 * d_model_max (max hidden size in feedforward layers)
+
+            # NOTE: Numpy arrays are not JSON serializable so convert them to enable storing benchmark data.
             hidden_range = np.arange(
                 D_MODEL_MIN, 4 * D_MODEL_MAX + 1, step_size
-            )  # (768, 4*18432)
+            ).tolist()  # (768, 4*18432)
             input_ranges.append((batch_range, hidden_range))
 
             # Reduce max hidden size for largest batch size (16384) to avoid OOM in RMSNorm.
             hidden_range = np.arange(
                 D_MODEL_MIN, 2 * D_MODEL_MAX + 1, step_size
-            )  # (768, 2*18432)
+            ).tolist()  # (768, 2*18432)
             input_ranges.append(([16384], hidden_range))
             for batch_range, hidden_range in input_ranges:
                 inputs.extend(list(itertools.product(batch_range, hidden_range)))


### PR DESCRIPTION
Numpy ints are not JSON serializable. The 2D inputs use numpy array for the hidden range which was causing the benchmark data to not be stored in the database with the error:
```
{
  "status": "Bad Request",
  "validation-failures": {
    "l_sizes_GtsMcQ": [
      16384,
      "UNSERIALIZABLE[36864]"
    ]
  }
}

```