### PR TITLE
Multidevice utils: haveDifferentSharding and isResharding

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -6,7 +6,9 @@
  */
 // clang-format on
 
+#include <compute_at_map.h>
 #include <ir/internal_base_nodes.h>
+#include <ir/utils.h>
 #include <multidevice/utils.h>
 
 #include <c10/util/irange.h>
@@ -26,6 +28,68 @@ bool isSharded(TensorView* tv) {
         "only the outmost dimension can be device-parallelized");
   }
   return is_sharded.empty() ? false : is_sharded.at(0);
+}
+
+namespace {
+
+std::vector<IterDomain*> getShardedIterDomains(TensorView* tv) {
+  std::vector<IterDomain*> sharded_ids;
+  std::copy_if(tv->getLeafDomain().begin(), 
+              tv->getLeafDomain().end(), 
+              std::back_inserter(sharded_ids), [](auto id){return id->isDeviceDim();});
+  return sharded_ids;
+}
+
+} // namespace
+
+std::unordered_set<TensorView*> haveDifferentSharding(TensorView* ref, std::unordered_set<TensorView*> tvs) {
+  std::unordered_set<TensorView*> ret;
+
+  const auto& reference_dom = ref->getLeafDomain();
+  FusionGuard fg(ref->fusion());
+  auto ca_map = ComputeAtMap(FusionGuard::getCurFusion());
+  std::unordered_map<IterDomain*, IterDomain*> concrete_to_reference_map;
+  for (auto id : reference_dom) {
+    auto ca_id =
+        ca_map.getConcreteMappedID(id, IdMappingMode::PERMISSIVE_RESIZE);
+    concrete_to_reference_map[ca_id] = id;
+  }
+
+  for (auto tv: tvs) {
+    if (!(ref->getDeviceMesh().vector() == tv->getDeviceMesh().vector())) {
+      ret.insert(tv);
+      continue;
+    }
+    for (auto id : tv->getLeafDomain()) {
+      auto ca_id = ca_map.getConcreteMappedID(
+          id, IdMappingMode::PERMISSIVE_RESIZE);
+      if (concrete_to_reference_map.count(ca_id) > 0) {
+        auto ref_id = concrete_to_reference_map.at(ca_id);
+        if ((ref_id->isDeviceDim() || id->isDeviceDim())
+            && ref_id->getParallelType() != id->getParallelType()) {
+          ret.insert(tv);
+          break;
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+bool isResharding(Expr* expr) {
+  std::unordered_set<TensorView*> tvs;
+  for (auto tv: ir_utils::filterByType<TensorView>(expr->inputs())) {
+    tvs.insert(tv);
+  }
+  for (auto tv: ir_utils::filterByType<TensorView>(expr->outputs())) {
+    tvs.insert(tv);
+  }
+  if (tvs.empty()) {
+    return false;
+  }
+  auto tv_ref = *tvs.begin();
+  tvs.erase(tv_ref);
+  return !haveDifferentSharding(tv_ref, tvs).empty();
 }
 
 } // namespace nvfuser

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -34,15 +34,19 @@ namespace {
 
 std::vector<IterDomain*> getShardedIterDomains(TensorView* tv) {
   std::vector<IterDomain*> sharded_ids;
-  std::copy_if(tv->getLeafDomain().begin(), 
-              tv->getLeafDomain().end(), 
-              std::back_inserter(sharded_ids), [](auto id){return id->isDeviceDim();});
+  std::copy_if(
+      tv->getLeafDomain().begin(),
+      tv->getLeafDomain().end(),
+      std::back_inserter(sharded_ids),
+      [](auto id) { return id->isDeviceDim(); });
   return sharded_ids;
 }
 
 } // namespace
 
-std::unordered_set<TensorView*> haveDifferentSharding(TensorView* ref, std::unordered_set<TensorView*> tvs) {
+std::unordered_set<TensorView*> haveDifferentSharding(
+    TensorView* ref,
+    std::unordered_set<TensorView*> tvs) {
   std::unordered_set<TensorView*> ret;
 
   const auto& reference_dom = ref->getLeafDomain();
@@ -55,18 +59,18 @@ std::unordered_set<TensorView*> haveDifferentSharding(TensorView* ref, std::unor
     concrete_to_reference_map[ca_id] = id;
   }
 
-  for (auto tv: tvs) {
+  for (auto tv : tvs) {
     if (!(ref->getDeviceMesh().vector() == tv->getDeviceMesh().vector())) {
       ret.insert(tv);
       continue;
     }
     for (auto id : tv->getLeafDomain()) {
-      auto ca_id = ca_map.getConcreteMappedID(
-          id, IdMappingMode::PERMISSIVE_RESIZE);
+      auto ca_id =
+          ca_map.getConcreteMappedID(id, IdMappingMode::PERMISSIVE_RESIZE);
       if (concrete_to_reference_map.count(ca_id) > 0) {
         auto ref_id = concrete_to_reference_map.at(ca_id);
-        if ((ref_id->isDeviceDim() || id->isDeviceDim())
-            && ref_id->getParallelType() != id->getParallelType()) {
+        if ((ref_id->isDeviceDim() || id->isDeviceDim()) &&
+            ref_id->getParallelType() != id->getParallelType()) {
           ret.insert(tv);
           break;
         }
@@ -78,10 +82,10 @@ std::unordered_set<TensorView*> haveDifferentSharding(TensorView* ref, std::unor
 
 bool isResharding(Expr* expr) {
   std::unordered_set<TensorView*> tvs;
-  for (auto tv: ir_utils::filterByType<TensorView>(expr->inputs())) {
+  for (auto tv : ir_utils::filterByType<TensorView>(expr->inputs())) {
     tvs.insert(tv);
   }
-  for (auto tv: ir_utils::filterByType<TensorView>(expr->outputs())) {
+  for (auto tv : ir_utils::filterByType<TensorView>(expr->outputs())) {
     tvs.insert(tv);
   }
   if (tvs.empty()) {

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -16,7 +16,8 @@ namespace nvfuser {
 // Checks that the other non-reduction axis are not parallelized on Didx
 bool isSharded(TensorView*);
 
-// Returns the subset of tvs which elements have the same multi-device sharding as ref
+// Returns the subset of tvs which elements have the same multi-device sharding
+// as ref
 std::unordered_set<TensorView*> haveDifferentSharding(
     TensorView* ref,
     std::unordered_set<TensorView*> tvs);

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -16,4 +16,12 @@ namespace nvfuser {
 // Checks that the other non-reduction axis are not parallelized on Didx
 bool isSharded(TensorView*);
 
+// Returns the subset of tvs which elements have the same multi-device sharding as ref
+std::unordered_set<TensorView*> haveDifferentSharding(
+    TensorView* ref,
+    std::unordered_set<TensorView*> tvs);
+
+// Returns whether an Expr embbeds multi-device resharding
+bool isResharding(Expr* expr);
+
 } // namespace nvfuser

--- a/test/test_pipeline.cpp
+++ b/test/test_pipeline.cpp
@@ -11,6 +11,7 @@
 #include <ir/all_nodes.h>
 #include <ir/builder.h>
 #include <multidevice/pipeline.h>
+#include <multidevice/utils.h>
 #include <ops/all_ops.h>
 #include <test/utils.h>
 
@@ -199,6 +200,165 @@ TEST_F(NVFuserTest, Pipeline_CUDA) {
   std::sort(ref_string.begin(), ref_string.end());
 
   EXPECT_EQ(obtained_string, ref_string);
+}
+
+TEST_F(NVFuserTest, ReshardingDetection) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  DeviceMesh mesh0, mesh1, mesh2;
+  mesh0 = {0, 1};
+  mesh1 = {0, 2};
+  mesh2 = {0, 1, 2};
+
+  TensorView* tv0 = makeContigTensor(3);
+  fusion->addInput(tv0);
+  tv0->setDeviceMesh(mesh0);
+
+  TensorView* tv1 = set(tv0);
+  tv1->setDeviceMesh(mesh0);
+
+  TensorView* tv2 = set(tv1); // resharding
+  tv2->setDeviceMesh(mesh1);
+
+  TensorView* tv3 = set(tv2);
+  tv3->setDeviceMesh(mesh1);
+
+  TensorView* tv4 = set(tv3); // resharding
+  tv4->setDeviceMesh(mesh2);
+
+  TensorView* tv5 = set(tv4); // resharding
+  tv5->setDeviceMesh(mesh2);
+  tv5->axis(0)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv6 = set(tv5);
+  tv6->setDeviceMesh(mesh2);
+  tv6->axis(0)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv7 = set(tv6); // resharding
+  tv7->setDeviceMesh(mesh2);
+
+  TensorView* tv8 = sum(tv0, {0});
+  tv8->setDeviceMesh(mesh0);
+
+  TensorView* tv9 = sum(tv0, {0}); // resharding, but seems invalid
+  tv9->setDeviceMesh(mesh0);
+  tv9->axis(0)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv10 = sum(tv0, {0}); // resharding,
+  tv10->setDeviceMesh(mesh0);
+  tv10->axis(1)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv11 = sum(tv0, {0}); // resharding,
+  tv11->setDeviceMesh(mesh1);
+
+  TensorView* tv12 = sum(tv5, {0}); // not resharding
+  tv12->setDeviceMesh(mesh2);
+  tv12->axis(0)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv13 = sum(tv5, {0}); // resharding
+  tv13->setDeviceMesh(mesh2);
+  tv13->axis(1)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv14 = sum(tv5, {0}); // resharding
+  tv14->setDeviceMesh(mesh2);
+  tv14->axis(0)->parallelize(ParallelType::DIDx);
+  tv14->axis(1)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv15 = add(tv0, tv1);
+  tv15->setDeviceMesh(mesh0);
+
+  TensorView* tv16 = add(tv0, tv1); // resharding
+  tv16->setDeviceMesh(mesh1);
+
+  TensorView* tv17 = add(tv0, tv1); // resharding
+  tv17->setDeviceMesh(mesh0);
+  tv17->axis(0)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv18 = add(tv5, tv6);
+  tv18->setDeviceMesh(mesh2);
+  tv18->axis(0)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv19 = add(tv5, tv7); // resharding
+  tv19->setDeviceMesh(mesh2);
+  tv19->axis(0)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv20 = add(tv5, tv7); // resharding
+  tv20->setDeviceMesh(mesh2);
+
+  TensorView* tv21 = add(tv0, tv7); // resharding
+  tv21->setDeviceMesh(mesh2);
+
+  TensorView* tv22 = sum(tv5, {1});
+  tv22->setDeviceMesh(mesh2);
+  tv22->axis(0)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv23 = sum(tv5, {1}); // resharding
+  tv23->setDeviceMesh(mesh2);
+
+  TensorView* tv24 = sum(tv7, {0});
+  tv24->setDeviceMesh(mesh2);
+
+  TensorView* tv25 = sum(tv7, {0}); // not resharding but invalid
+  tv25->setDeviceMesh(mesh2);
+  tv22->axis(0)->parallelize(ParallelType::DIDx);
+
+  TensorView* tv26 = add(tv5, tv6); // resharding
+  tv26->setDeviceMesh(mesh2);
+
+  fusion->addOutput(tv1);
+  fusion->addOutput(tv2);
+  fusion->addOutput(tv3);
+  fusion->addOutput(tv4);
+  fusion->addOutput(tv5);
+  fusion->addOutput(tv6);
+  fusion->addOutput(tv7);
+  fusion->addOutput(tv8);
+  fusion->addOutput(tv9);
+  fusion->addOutput(tv10);
+  fusion->addOutput(tv11);
+  fusion->addOutput(tv12);
+  fusion->addOutput(tv13);
+  fusion->addOutput(tv14);
+  fusion->addOutput(tv15);
+  fusion->addOutput(tv16);
+  fusion->addOutput(tv17);
+  fusion->addOutput(tv18);
+  fusion->addOutput(tv19);
+  fusion->addOutput(tv20);
+  fusion->addOutput(tv21);
+  fusion->addOutput(tv22);
+  fusion->addOutput(tv23);
+  fusion->addOutput(tv24);
+  fusion->addOutput(tv25);
+  fusion->addOutput(tv26);
+
+  GTEST_EXPECT_TRUE(!isResharding(tv1->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv2->definition()));
+  GTEST_EXPECT_TRUE(!isResharding(tv3->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv4->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv5->definition()));
+  GTEST_EXPECT_TRUE(!isResharding(tv6->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv7->definition()));
+  GTEST_EXPECT_TRUE(!isResharding(tv8->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv9->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv10->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv11->definition()));
+  GTEST_EXPECT_TRUE(!isResharding(tv12->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv13->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv14->definition()));
+  GTEST_EXPECT_TRUE(!isResharding(tv15->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv16->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv17->definition()));
+  GTEST_EXPECT_TRUE(!isResharding(tv18->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv19->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv20->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv21->definition()));
+  GTEST_EXPECT_TRUE(!isResharding(tv22->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv23->definition()));
+  GTEST_EXPECT_TRUE(!isResharding(tv24->definition()));
+  GTEST_EXPECT_TRUE(!isResharding(tv25->definition()));
+  GTEST_EXPECT_TRUE(isResharding(tv26->definition()));
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
Add two utils functions and tests:
```
// Returns the subset of tvs which elements have the same multi-device sharding
// as ref
std::unordered_set<TensorView*> haveDifferentSharding(
    TensorView* ref,
    std::unordered_set<TensorView*> tvs);

// Returns whether an Expr embbeds multi-device resharding
bool isResharding(Expr* expr);
```
