### PR TITLE
[IdModel] valgraph cleanup

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -382,7 +382,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (true || isOptionEnabled(EnableOption::IdModel)) {
+  if (isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_, false, true);
   }
 

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -382,7 +382,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (isOptionEnabled(EnableOption::IdModel)) {
+  if (true || isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_, false, true);
   }
 

--- a/csrc/id_model/to_string.cpp
+++ b/csrc/id_model/to_string.cpp
@@ -308,10 +308,8 @@ std::string definitionsString(
     bool with_ptr) {
   ExprGroups all_defs;
   for (const ValGroup& id_group : id_graph.disjointValSets().disjointSets()) {
-    if (auto definition = id_graph.getDefinitions(id_group); definition) {
-      for (const ExprGroup& expr_group : *definition) {
-        all_defs.pushBack(expr_group);
-      }
+    for (const ExprGroup& expr_group : id_graph.getDefinitions(id_group)) {
+      all_defs.pushBack(expr_group);
     }
   }
   return toString(id_graph, all_defs, indent_size, with_ptr);
@@ -323,10 +321,8 @@ std::string usesString(
     bool with_ptr) {
   ExprGroups all_uses;
   for (const ValGroup& id_group : id_graph.disjointValSets().disjointSets()) {
-    if (const ExprGroups* uses = id_graph.getUses(id_group); uses) {
-      for (const ExprGroup& expr_group : *uses) {
-        all_uses.pushBack(expr_group);
-      }
+    for (const ExprGroup& expr_group : id_graph.getUses(id_group)) {
+      all_uses.pushBack(expr_group);
     }
   }
   return toString(id_graph, all_uses, indent_size, with_ptr);

--- a/csrc/val_graph.cpp
+++ b/csrc/val_graph.cpp
@@ -312,7 +312,7 @@ const ExprGroups& ValGraph::getDefinitions(const ValGroup& val_group) const {
 
 const ExprGroups& ValGraph::getUses(const ValGroup& val_group) const {
   NVF_ERROR(val_group, "Nullptr not allowed");
-  auto it = unique_uses_.find(val_group);
+  const auto it = unique_uses_.find(val_group);
   NVF_ERROR(
       it != unique_uses_.end(),
       "Use group not found for ",

--- a/csrc/val_graph.cpp
+++ b/csrc/val_graph.cpp
@@ -302,7 +302,7 @@ bool ValGraph::exprsMap(Expr* first, Expr* second, bool forward) const {
 
 const ExprGroups& ValGraph::getDefinitions(const ValGroup& val_group) const {
   NVF_ERROR(val_group, "Nullptr not allowed");
-  auto it = unique_definitions_.find(val_group);
+  const auto it = unique_definitions_.find(val_group);
   NVF_ERROR(
       it != unique_definitions_.end(),
       "Definition group not found for ",

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -103,18 +103,18 @@ class ValGraph {
   // ExprGroups used in this history of defining the 'of' IdGroups.
   ExprGroups allDefinitionsOf(const ValGroups& of) const;
 
-  //! Returns the pointer to expressions associated with the
-  //! definitions of the provided ValGroup. Nullptr is returned otherwise.
+  //! Returns the expressions associated with the
+  //! definitions of the provided ValGroup.
   //!
-  //! The returned pointer is to a vector of vector of expressions. The
-  //! inner vector is proven to be equivalent. The
-  //! outer vector are expression groups that are not equivalent, but
-  //! produce one of the ValGroups within the same disjoint Val set.
-  const ExprGroups* getDefinitions(const ValGroup& val_group) const;
+  //! Each ExprGroup of the returned ExprGroup vector is proven to be
+  //! equivalent. The ExprGroup vector holds expression groups that are not
+  //! equivalent, but produce one of the ValGroups within the same disjoint Val
+  //! set.
+  const ExprGroups& getDefinitions(const ValGroup& val_group) const;
 
   //! Same as getDefinitions but for uses instead of
   //! definitions
-  const ExprGroups* getUses(const ValGroup& val_group) const;
+  const ExprGroups& getUses(const ValGroup& val_group) const;
 
   bool hasDefinitions(const ValGroup& val_group) const;
 


### PR DESCRIPTION
This is just code simplification as `getDefinitions` and `getUses` don't need to return pointers as there should always be mapped `ExprGroup`.