### PR TITLE
Fix #1646, a bug introduced by #1579.

### DIFF
--- a/csrc/optimization/mark_aliases_prepare.cpp
+++ b/csrc/optimization/mark_aliases_prepare.cpp
@@ -23,10 +23,10 @@ void MarkAliasesPreparePass::runPass(Fusion* fusion) {
     debug() << analysis.toString(/*indent_size=*/1) << std::endl;
   }
 
-  // Fusion outputs that are (1) aliased by others, (2) not aliases
-  // themselves, and (3) not fusion inputs (yes, a fusion may trivially forward
-  // an input). Code will later add `segment_set` before them so aliases are
-  // separated from non-aliases and more likely to be accepted by the no-op
+  // Fusion outputs that are (1) aliased by another fusion output, (2) not
+  // aliases themselves, and (3) not fusion inputs (yes, a fusion may trivially
+  // forward an input). Code will later add `segment_set` before them so aliases
+  // are separated from non-aliases and more likely to be accepted by the no-op
   // scheduler.
   std::unordered_set<TensorView*> aliased_outs;
 
@@ -36,7 +36,8 @@ void MarkAliasesPreparePass::runPass(Fusion* fusion) {
       continue;
     }
 
-    if (aliased_io->isFusionOutput() && !aliased_io->isFusionInput() &&
+    if (tv->isFusionOutput() && aliased_io->isFusionOutput() &&
+        !aliased_io->isFusionInput() &&
         analysis.getNearestAliasedIo(aliased_io) == nullptr) {
       aliased_outs.insert(aliased_io);
     }

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -853,6 +853,30 @@ TEST_F(AliasTest, OutputAliasesAnotherOutput) {
   EXPECT_TRUE(permute_out_tensor.is_alias_of(reshape_out_tensor));
 }
 
+TEST_F(AliasTest, OutputNotAliasedByAnotherOutputShouldNotBeSegmented) {
+  // Reproduces #1646.
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({2, 3, 5});
+  TensorView* add_out = add(in, in);
+  TensorView* reshape_out = reshape(add_out, {2, 3, 5}, {6, 5});
+  TensorView* permute_out = permute(reshape_out, {1, 0});
+  TensorView* mul_out = mul(permute_out, permute_out);
+
+  fusion->addInput(in);
+  fusion->addOutput(reshape_out);
+  fusion->addOutput(mul_out);
+
+  FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor = at::randn({2, 3, 5}).cuda();
+  std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
+  testValidate(fec.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
+
+  FusionKernelRuntime* runtime = fec.getMostRecentKernelRuntime();
+  EXPECT_FALSE(runtime->isSegmented());
+}
+
 TEST_F(AliasTest, ManyAliasesBetweenOutputs) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());


### PR DESCRIPTION
In #1579, I should have checked `tv` is a fusion output as well so the behavior remained the same. 