### PR TITLE
print has segment hints

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1877,6 +1877,8 @@ std::unique_ptr<SegmentedFusion> SegmentCandidateFinder::segment(
     }
   }
   if (fusion) {
+    scheduler_debug_utils::canScheduleMessage(
+        "***Runtime***: Has segment hints, try to schedule fusion segmented:\n");
     return SegmentCandidateFinder::segment(std::move(fusion), inputs);
   } else {
     NVF_ERROR(false, "unreachable!");


### PR DESCRIPTION
when segmented due to `hasSegmentHints`, print out why.