### PR TITLE
[Hopper] MBarrier storage scope update

### DIFF
--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -876,10 +876,10 @@ class AllocationInfoMap : private kir::IrVisitor {
       alloc_info->outer_live_interval->markWrite(write_pos);
     } else if (auto inval = dynamic_cast<kir::MBarrierInvalidate*>(expr)) {
       auto alloc_info = getAllocInfoFromTV(inval->mbarrier()->as<TensorView>());
-      alloc_info->inner_live_interval->markWrite(expr_pos);
+      alloc_info->inner_live_interval->markRead(expr_pos);
       auto outer_loop_info = ascendLoopNestToSameLevelAs(alloc_info);
       auto write_pos = outer_loop_info ? outer_loop_info->start_pos : expr_pos;
-      alloc_info->outer_live_interval->markWrite(write_pos);
+      alloc_info->outer_live_interval->markRead(write_pos);
     }
   }
 


### PR DESCRIPTION
The purpose of this change is to update the expected scope in which smem placeholder for mbarrier objects are alive before the memory can be reused. Life of such variable starts with its initialization, and ends with its invalidation.

The core change is switching from last write to last read for mbarrier invalidate helper function call.