### PR TITLE
`torch.compile` and `eager` benchmarks for `softmax`

### DIFF
--- a/python_benchmarks/conftest.py
+++ b/python_benchmarks/conftest.py
@@ -45,6 +45,11 @@ def pytest_benchmark_update_machine_info(config, machine_info):
 
 
 def pytest_collection_modifyitems(session, config, items):
+    """
+    The baseline benchmarks use `compile` parameter:
+        compile = false: Eager mode benchmark
+        compile = true: torch.compile benchmark
+    """
     run_eager = config.getoption("--benchmark-eager")
     run_torchcompile = config.getoption("--benchmark-torchcompile")
 

--- a/python_benchmarks/conftest.py
+++ b/python_benchmarks/conftest.py
@@ -6,26 +6,22 @@ def pytest_addoption(parser):
     parser.addoption(
         "--disable-validation",
         action="store_true",
-        default=False,
         help="Disable output validation in benchmarks.",
     )
     parser.addoption(
         "--disable-benchmarking",
         action="store_true",
-        default=False,
         help="Disable benchmarking.",
     )
     parser.addoption(
         "--benchmark-eager",
         action="store_true",
-        default=False,
         help="Benchmarks torch eager mode.",
     )
 
     parser.addoption(
         "--benchmark-torchcompile",
         action="store_true",
-        default=False,
         help="Benchmarks torch.compile mode.",
     )
 

--- a/python_benchmarks/test_softmax_bwd.py
+++ b/python_benchmarks/test_softmax_bwd.py
@@ -73,8 +73,8 @@ def test_softmax_bwd_nvf_benchmark(
     clear_cuda_cache()
 
     inputs = [
-        torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True),
-        torch.randn(*size, device="cuda", dtype=dtype),
+        torch.randn(size, device="cuda", dtype=dtype, requires_grad=True),
+        torch.randn(size, device="cuda", dtype=dtype),
     ]
 
     with FusionDefinition() as fd:
@@ -101,8 +101,8 @@ def test_softmax_bwd_baseline_benchmark(
     compile: bool,
 ):
     clear_cuda_cache()
-    input = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
-    grads = torch.randn(*size, device="cuda", dtype=dtype)
+    input = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
+    grads = torch.randn(size, device="cuda", dtype=dtype)
     output = torch.nn.functional.softmax(input, dim=reduction_axis)
     run_benchmark(
         benchmark,

--- a/python_benchmarks/test_softmax_bwd.py
+++ b/python_benchmarks/test_softmax_bwd.py
@@ -54,7 +54,7 @@ def softmax_bwd_fusion(
     fd.add_output(T19)
 
 
-def softmax_bwd_fn(inputs: list):  # [in_tensor, output, grads]
+def unary_bwd_torch(inputs: list):  # [in_tensor, output, grads]
     inputs[1].backward(inputs[2], retain_graph=True)
     return inputs[0].grad
 
@@ -89,34 +89,23 @@ def test_softmax_bwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, inputs)
 
 
+@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0, 1])
-def test_softmax_bwd_eager_benchmark(
+def test_softmax_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     reduction_axis: int,
-):
-    clear_cuda_cache()
-    input = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
-    grads = torch.randn(*size, device="cuda", dtype=dtype)
-
-    output = torch.nn.functional.softmax(input, dim=reduction_axis)
-    run_benchmark(benchmark, softmax_bwd_fn, [input, output, grads])
-
-
-@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-@pytest.mark.parametrize("reduction_axis", [0, 1])
-def test_softmax_bwd_compile_benchmark(
-    benchmark,
-    size: tuple,
-    dtype: torch.dtype,
-    reduction_axis: int,
+    compile: bool,
 ):
     clear_cuda_cache()
     input = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
     output = torch.nn.functional.softmax(input, dim=reduction_axis)
-    run_benchmark(benchmark, torch.compile(softmax_bwd_fn), [input, output, grads])
+    run_benchmark(
+        benchmark,
+        torch.compile(unary_bwd_torch) if compile else unary_bwd_torch,
+        [input, output, grads],
+    )

--- a/python_benchmarks/test_softmax_fwd.py
+++ b/python_benchmarks/test_softmax_fwd.py
@@ -61,7 +61,7 @@ def test_softmax_fwd_nvf_benchmark(
 ):
     clear_cuda_cache()
 
-    inputs = [torch.randn(*size, device="cuda", dtype=dtype)]
+    inputs = [torch.randn(size, device="cuda", dtype=dtype)]
 
     with FusionDefinition() as fd:
         softmax_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), reduction_axis)
@@ -86,7 +86,7 @@ def test_softmax_fwd_baseline_benchmark(
     compile: bool,
 ):
     clear_cuda_cache()
-    input = torch.randn(*size, device="cuda", dtype=dtype)
+    input = torch.randn(size, device="cuda", dtype=dtype)
     run_benchmark(
         benchmark,
         torch.compile(softmax_fwd_fn) if compile else softmax_fwd_fn,

--- a/python_benchmarks/test_softmax_fwd.py
+++ b/python_benchmarks/test_softmax_fwd.py
@@ -74,29 +74,21 @@ def test_softmax_fwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, inputs)
 
 
-@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("size", [(128, 768)])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0, 1])
-def test_softmax_fwd_eager_benchmark(
+def test_softmax_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     reduction_axis: int,
+    compile: bool,
 ):
     clear_cuda_cache()
     input = torch.randn(*size, device="cuda", dtype=dtype)
-    run_benchmark(benchmark, softmax_fwd_fn, [input, reduction_axis])
-
-
-@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-@pytest.mark.parametrize("reduction_axis", [0, 1])
-def test_softmax_fwd_compile_benchmark(
-    benchmark,
-    size: tuple,
-    dtype: torch.dtype,
-    reduction_axis: int,
-):
-    clear_cuda_cache()
-    input = torch.randn(*size, device="cuda", dtype=dtype)
-    run_benchmark(benchmark, torch.compile(softmax_fwd_fn), [input, reduction_axis])
+    run_benchmark(
+        benchmark,
+        torch.compile(softmax_fwd_fn) if compile else softmax_fwd_fn,
+        [input, reduction_axis],
+    )

--- a/python_benchmarks/test_softmax_fwd.py
+++ b/python_benchmarks/test_softmax_fwd.py
@@ -75,7 +75,7 @@ def test_softmax_fwd_nvf_benchmark(
 
 
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
-@pytest.mark.parametrize("size", [(128, 768)])
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0, 1])
 def test_softmax_fwd_baseline_benchmark(


### PR DESCRIPTION
Adds `torch.compile` and `eager` baseline benchmarks to be used in weekly benchmark runs.
Issue #1668.

Update:
Building off of @jacobhinkle's suggestion:
1. `torch.compile` and `eager` mode are combined in a single benchmark function using parametrization.
2. By default, only nvfuser benchmarks are run. To enable eager/compile, the flags `--benchmark-eager` and `benchmark-torchcompile` are used. 

I'll update the wiki to describe and detail benchmarking options.

Future changes:
In a separate PR, I plan on renaming `disable-benchmarking` to `disable-nvf-benchmarking` since we are adding more executors. 