### PR TITLE
Remove unnecessary code.

### DIFF
--- a/csrc/scheduler/registry_utils.cpp
+++ b/csrc/scheduler/registry_utils.cpp
@@ -229,13 +229,6 @@ bool isConnectedFusionGraph(Fusion* fusion) {
     }
   }
 
-  // Map aliased outputs
-  for (Val* out : fusion->outputs()) {
-    if (Val* in = fusion->getOutputAlias(out).first; in != nullptr) {
-      component_sets.mapEntries(out, in);
-    }
-  }
-
   // Check connected-ness:
   //  If there is no independent compute flow
   // on this fusion graph, all outputs will be


### PR DESCRIPTION
I don't know why it was added, but it looks unnecessary. An alias TV (whether it's a pointer arithmetic or an in-place update) should be connected to some input TV via Exprs.