### PR TITLE
Insert squeeze before trivial reductions at concretization

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -424,6 +424,9 @@ void GpuLower::analysis(Fusion* fusion) {
   validateResize(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "validateResize");
 
+  validateReductions(fusion_);
+  dumpExprsIfEnabled(fusion_->exprs(), "validateReductions");
+
   // Compute thread predicates. Depends on parallel_dimension_map_
   thread_pred_map_.build(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "build thread_pred_map_");

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -1291,22 +1291,24 @@ void validateResize(Fusion* fusion) {
 }
 
 void validateReductions(Fusion* fusion) {
-  for (auto expr : fusion->exprs()) {
-    if (auto rop = dynamic_cast<ReductionOp*>(expr)) {
-      const std::vector<IterDomain*> in_rfactor = TensorDomain::noReductions(
-          rop->in()->as<TensorView>()->getMaybeRFactorDomain());
-      const std::vector<IterDomain*>& out_root =
-          rop->out()->as<TensorView>()->getRootDomain();
-
-      NVF_ERROR(in_rfactor.size() == out_root.size());
-      for (auto i : c10::irange(in_rfactor.size())) {
-        if (out_root[i]->isReduction()) {
-          IterDomain* in_id = in_rfactor[i];
-          NVF_ERROR(
-              !in_id->isBroadcast() || in_id->hasExpandedExtent(),
-              "Reductions of unexpanded broadcast domains should be ",
-              "converted to squeeze before lowering.");
-        }
+  for (auto rop : ir_utils::getOpsOfType<ReductionOp>(fusion)) {
+    auto in = rop->in()->as<TensorView>();
+    auto out = rop->out()->as<TensorView>();
+    PairwiseRootDomainMap c2p_map(in, out);
+    c2p_map.mapBroadcast(true);
+    auto c2p = c2p_map.mapConsumerToProducer();
+    for (auto out_id : out->getRootDomain()) {
+      if (out_id->isReduction()) {
+        auto in_it = c2p.find(out_id);
+        NVF_ERROR(
+            in_it != c2p.end(),
+            "Could not find producer IterDomain mapped to ",
+            out_id->toString());
+        IterDomain* in_id = in_it->second;
+        NVF_ERROR(
+            !in_id->isBroadcast() || in_id->hasExpandedExtent(),
+            "Reductions of unexpanded broadcast domains should be ",
+            "converted to squeeze before lowering.");
       }
     }
   }

--- a/csrc/device_lower/validation.h
+++ b/csrc/device_lower/validation.h
@@ -80,4 +80,7 @@ void validateLookupTV(Fusion* fusion);
 //! Validate resize usage
 void validateResize(Fusion* fusion);
 
+//! Check that there are no reductions over unexpanded broadcasts
+void validateReductions(Fusion* fusion);
+
 } // namespace nvfuser

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -958,21 +958,21 @@ static bool hasTrivialReduction(
   // We need to map broadcasts in order to detect reductions of broadcasts
   p2c_map.mapBroadcast(true);
   auto p2c = p2c_map.mapProducerToConsumer();
-  auto pos = 0;
+  int pos = -1;
   for (IterDomain* in_id :
        TensorDomain::noReductions(in->getMaybeRFactorDomain())) {
+    ++pos;
     auto out_it = p2c.find(in_id);
     if (out_it == p2c.end()) {
       continue;
     }
     IterDomain* out_id = out_it->second;
     if (out_id->isReduction()) {
-      reduction_axes.push_back((int)pos);
+      reduction_axes.push_back(pos);
       if (in_id->isBroadcast() && !in_id->hasExpandedExtent()) {
         has_trivial_reduction = true;
       }
     }
-    ++pos;
   }
   return has_trivial_reduction;
 }

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -965,11 +965,11 @@ void DynamicTransformConcretizer::mutate(Expr* expr) {
     NVF_ERROR(in_rfactor.size() == orig_out_root.size());
     bool has_trivial_reduction = false;
     std::vector<int> reduction_axes;
-    for (int i : c10::irange(in_rfactor.size())) {
+    for (size_t i : c10::irange(in_rfactor.size())) {
       if (!orig_out_root[i]->isReduction()) {
         continue;
       }
-      reduction_axes.push_back(i);
+      reduction_axes.push_back((int)i);
       IterDomain* in_id = in_rfactor[i];
       if (in_id->isBroadcast() && !in_id->hasExpandedExtent()) {
         has_trivial_reduction = true;
@@ -987,7 +987,7 @@ void DynamicTransformConcretizer::mutate(Expr* expr) {
           reduction_axes,
           rop->init(),
           in,
-          /*keepdim=*/false,
+          /*keep_dim=*/false,
           orig_out->dtype());
       mutateAndReplaceInOutputs(orig_out, new_out);
     }
@@ -1002,11 +1002,11 @@ void DynamicTransformConcretizer::mutate(Expr* expr) {
     NVF_ERROR(in_rfactor.size() == orig_avg_root.size());
     bool has_trivial_reduction = false;
     std::vector<int> reduction_axes;
-    for (int i : c10::irange(in_rfactor.size())) {
+    for (size_t i : c10::irange(in_rfactor.size())) {
       if (!orig_avg_root[i]->isReduction()) {
         continue;
       }
-      reduction_axes.push_back(i);
+      reduction_axes.push_back((int)i);
       IterDomain* in_id = in_rfactor[i];
       if (in_id->isBroadcast() && !in_id->hasExpandedExtent()) {
         has_trivial_reduction = true;

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -1389,7 +1389,7 @@ TEST_F(NVFuserTest, ConcretizeConstantExtents) {
 // properly.
 // See https://github.com/NVIDIA/Fuser/issues/1667
 TEST_F(NVFuserTest, DynamicSqueezeTrivialReduction) {
-  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+  auto fusion_ptr = std::make_unique<Fusion>();
   Fusion* fusion = fusion_ptr.get();
   FusionGuard fg(fusion);
 

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -1385,4 +1385,78 @@ TEST_F(NVFuserTest, ConcretizeConstantExtents) {
   testValidate(fusion, outputs, inputs, __LINE__, __FILE__);
 }
 
+// Test that dynamic reductions that should result in squeezes are handled
+// properly.
+// See https://github.com/NVIDIA/Fuser/issues/1667
+TEST_F(NVFuserTest, DynamicSqueezeTrivialReduction) {
+  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+  Fusion* fusion = fusion_ptr.get();
+  FusionGuard fg(fusion);
+
+  auto tv0 = makeSymbolicTensor(3);
+  fusion->addInput(tv0);
+
+  // Explicitly cast Int to Index, so that these extents are not immediate
+  // constants
+  auto tv1 = reshape(
+      tv0,
+      {
+          castOp(DataType::Index, IrBuilder::create<Val>(1, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(2, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(2, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(1, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(3, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(3, DataType::Int)),
+      });
+  auto tv2 = sum(tv1, {0, 2, 3, 4});
+  fusion->addOutput(tv2);
+
+  FusionExecutorCache fec(std::move(fusion_ptr));
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({2, 2, 9}, options);
+  std::vector<c10::IValue> inputs = {t0};
+
+  auto outputs = fec.runFusionWithInputs(inputs);
+
+  testValidate(fusion, outputs, inputs, __LINE__, __FILE__);
+}
+
+// Same as above but for Welford ops
+// See https://github.com/NVIDIA/Fuser/issues/1667
+TEST_F(NVFuserTest, DynamicSqueezeTrivialWelford) {
+  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+  Fusion* fusion = fusion_ptr.get();
+  FusionGuard fg(fusion);
+
+  auto tv0 = makeSymbolicTensor(3);
+  fusion->addInput(tv0);
+
+  // Explicitly cast Int to Index, so that these extents are not immediate
+  // constants
+  auto tv1 = reshape(
+      tv0,
+      {
+          castOp(DataType::Index, IrBuilder::create<Val>(1, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(2, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(2, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(1, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(3, DataType::Int)),
+          castOp(DataType::Index, IrBuilder::create<Val>(3, DataType::Int)),
+      });
+  auto res = variance_mean(tv1, {0, 2, 3, 4}, /*unbiased=*/true, /*keepdim=*/false);
+  fusion->addOutput(res.mean);
+  fusion->addOutput(res.var);
+
+  FusionExecutorCache fec(std::move(fusion_ptr));
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({2, 2, 9}, options);
+  std::vector<c10::IValue> inputs = {t0};
+
+  auto outputs = fec.runFusionWithInputs(inputs);
+
+  testValidate(fusion, outputs, inputs, __LINE__, __FILE__);
+}
+
 } // namespace nvfuser

--- a/test/test_dynamic_transform.cpp
+++ b/test/test_dynamic_transform.cpp
@@ -1444,7 +1444,8 @@ TEST_F(NVFuserTest, DynamicSqueezeTrivialWelford) {
           castOp(DataType::Index, IrBuilder::create<Val>(3, DataType::Int)),
           castOp(DataType::Index, IrBuilder::create<Val>(3, DataType::Int)),
       });
-  auto res = variance_mean(tv1, {0, 2, 3, 4}, /*unbiased=*/true, /*keepdim=*/false);
+  auto res =
+      variance_mean(tv1, {0, 2, 3, 4}, /*unbiased=*/true, /*keepdim=*/false);
   fusion->addOutput(res.mean);
   fusion->addOutput(res.var);
 


### PR DESCRIPTION
This change inspects expressions at concretization to check for reductions and Welford ops. When finding those, we look for unexpanded broadcasts in the axes being reduced. If we find any, we re-run the appropriate op with the concretized input, to ensure that the output is squeezed exactly as it would be were the fusion not dynamic.

Fixes #1667 