### PR TITLE
`MmaOp::evaluate` method

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1445,6 +1445,10 @@ class MmaOp : public Expr {
     return attribute<AxesData>(ATTR_POS_BATCH_AXES);
   }
 
+  std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
+      const std::vector<PolymorphicValue>& inputs) const override;
+
  private:
   // Predefined idexes of attributes stored for this IR node, to avoid
   //  magic numbers, based on order in which attributes are initialized

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2066,6 +2066,7 @@ void MmaOp::setMacro(MmaMacro macro) {
 std::vector<PolymorphicValue> MmaOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
+
   auto& a = inputs.at(0).as<at::Tensor>();
   auto& b = inputs.at(1).as<at::Tensor>();
   NVF_CHECK(
@@ -2075,7 +2076,9 @@ std::vector<PolymorphicValue> MmaOp::evaluate(
       "Must have either zero or one batch dimensions");
 
   // Squeeze the inputs to remove the broadcasted dimensions.
-  // TODO: This is assuming the broadcast dimensions but may be variable?
+  // TODO: This is assuming the broadcast dimensions to be the last dim for the first operand
+  //      and the first dim for the second operand. If this is variable, using the inputs of the
+  //      broadcast instead of the immediate inputs may be better.
   auto in_a = a.squeeze(-1);
   auto in_b = b.squeeze(0);
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2075,6 +2075,7 @@ std::vector<PolymorphicValue> MmaOp::evaluate(
       "Must have either zero or one batch dimensions");
 
   // Squeeze the inputs to remove the broadcasted dimensions.
+  // TODO: This is assuming the broadcast dimensions but may be variable?
   auto in_a = a.squeeze(-1);
   auto in_b = b.squeeze(0);
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2081,7 +2081,7 @@ std::vector<PolymorphicValue> MmaOp::evaluate(
   // fusedMultiplySum assumes [B, M, K] [B, N, K]
   // Transpose them to aten::matmul format.
   if (in_a.dim() == 3) { // bmm
-    return {in_a.transpose(0, 1).matmul(in_b.transpose(0, 1).transpose(1, 2))};
+    return {in_a.matmul(in_b.transpose(1, 2))};
   } else {
     return {in_a.matmul(in_b.t())};
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2063,6 +2063,26 @@ void MmaOp::setMacro(MmaMacro macro) {
   attribute<MmaMacro>(ATTR_POS_MACRO) = macro;
 }
 
+std::vector<PolymorphicValue> MmaOp::evaluate(
+    const ExpressionEvaluator& ee,
+    const std::vector<PolymorphicValue>& inputs) const {
+  const auto& a = inputs.at(0).as<at::Tensor>();
+  const auto& b = inputs.at(1).as<at::Tensor>();
+  MmaLayout mma_layout = layout().value();
+  switch (mma_layout) {
+      case MmaLayout::TT:
+        return a.matmul(b);
+      case MmaLayout::TN:
+        return a.matmul(b.t());
+      case MmaLayout::NT:
+        return a.t().matmul(b);
+      case MmaLayout::NN:
+        return a.t().matmul(b.t());
+      default:
+        NVF_CHECK(false, "unsupported data layout.");
+    }
+}
+
 NVFUSER_DEFINE_CLONE_AND_CREATE(MmaOp)
 
 ExpandOp::ExpandOp(

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2071,9 +2071,9 @@ std::vector<PolymorphicValue> MmaOp::evaluate(
   //    broadcast. The inputs to MmaOp are broadcasted as the last dim for the
   //    first operand and the first dim for the second operand.
 
-  NVF_CHECK(input(0)->definition()->isA<BroadcastOp>(), 
+  NVF_CHECK(input(0)->definition() != nullptr && input(0)->definition()->isA<BroadcastOp>(), 
       "Currently, MmaOp::evaluate assumes the preceding op to be a broadcast.");
-  NVF_CHECK(input(1)->definition()->isA<BroadcastOp>(), 
+  NVF_CHECK(input(1)->definition() != nullptr && input(1)->definition()->isA<BroadcastOp>(), 
       "Currently, MmaOp::evaluate assumes the preceding op to be a broadcast.");
 
   NVF_CHECK(inA()->as<TensorView>()->getRootDomain().back()->isBroadcast(),

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2066,30 +2066,37 @@ void MmaOp::setMacro(MmaMacro macro) {
 std::vector<PolymorphicValue> MmaOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  
   const auto tv_a = inA()->as<TensorView>();
   const auto tv_b = inB()->as<TensorView>();
   NVF_CHECK(
-    tv_a->nDims() == tv_b->nDims(), 
-    "Either both or none of A and B should be batch");
-  // Verify that the broadcasted size is 3. 
+
+      tv_a->nDims() == tv_b->nDims(),
+      "Either both or none of A and B should be batch");
+  // Verify that the broadcasted size is 3.
   NVF_CHECK(
-    tv_a->nDims() == 3,
-    "MmaOp::evaluate is not implemented for size: ", tv_a->nDims());
+      tv_a->nDims() == 3,
+      "MmaOp::evaluate is not implemented for size: ",
+      tv_a->nDims());
 
   // Assumptions:
   //    Currently, the evaluate method assumes that the MmaOp is preceded by a
   //    broadcast. The inputs to MmaOp are broadcasted as the last dim for the
   //    first operand and the first dim for the second operand.
   //    The inputs here will be [M, K, 1] x [1, K, N].
-  NVF_CHECK(input(0)->definition() != nullptr && input(0)->definition()->isA<BroadcastOp>(), 
+  NVF_CHECK(
+      input(0)->definition() != nullptr &&
+          input(0)->definition()->isA<BroadcastOp>(),
       "Currently, MmaOp::evaluate assumes the preceding op to be a broadcast.");
-  NVF_CHECK(input(1)->definition() != nullptr && input(1)->definition()->isA<BroadcastOp>(), 
+  NVF_CHECK(
+      input(1)->definition() != nullptr &&
+          input(1)->definition()->isA<BroadcastOp>(),
       "Currently, MmaOp::evaluate assumes the preceding op to be a broadcast.");
 
-  NVF_CHECK(tv_a->getRootDomain().back()->isBroadcast(),
+  NVF_CHECK(
+      tv_a->getRootDomain().back()->isBroadcast(),
       "Expected last dimension to be broadcasted for first operand.");
-  NVF_CHECK(tv_b->getRootDomain().front()->isBroadcast(),
+  NVF_CHECK(
+      tv_b->getRootDomain().front()->isBroadcast(),
       "Expected first dimension to be broadcasted for second operand.");
 
   // Squeeze the inputs to remove the broadcasted dimensions.
@@ -2099,7 +2106,6 @@ std::vector<PolymorphicValue> MmaOp::evaluate(
   // After removing the broadcast dimensions, the format should be
   // [M, K] x [K, N] compatible with aten::matmul format.
   return {in_a.matmul(in_b)};
-
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(MmaOp)

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -677,7 +677,7 @@ TEST_F(ExprEvalTest, MmaOp) {
   int64_t m = 2, k = 3, n = 4;
 
   Fusion fusion;
-  FusionGuard fg(&fusion);    
+  FusionGuard fg(&fusion);
 
   // The matmul API will expect inputs in the shape [M,K] x [K,N].
   // This is compatible with PyTorch,
@@ -703,5 +703,5 @@ TEST_F(ExprEvalTest, MmaOp) {
   evaluator.bind(tv1, in_b);
   at::Tensor out = evaluator.evaluate(tv2).as<at::Tensor>();
   NVF_CHECK(out_ref.equal(out));
-  } 
+}
 } // namespace nvfuser

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -684,7 +684,7 @@ TEST_F(ExprEvalTest, MmaOp) {
     bool transpose_a = (layout == MmaLayout::NT || layout == MmaLayout::NN);
     bool transpose_b = (layout == MmaLayout::TT || layout == MmaLayout::NT);
 
-    int64_t M = 2, K = 3, N = 4;
+    int64_t m = 2, k = 3, n = 4;
     std::vector<int64_t> A_shape{M, K}, B_shape{N, K};
 
     if (transpose_a) {
@@ -717,9 +717,9 @@ TEST_F(ExprEvalTest, MmaOp) {
 
     fusion.addOutput(tv2);
 
-    at::Tensor in_a = at::ones({M, K}, at::kHalf).cuda();
-    at::Tensor in_b = at::ones({N, K}, at::kHalf).cuda();
-    at::Tensor out_ref = K * at::ones({M, N}, at::kHalf).cuda();
+    at::Tensor in_a = at::ones({m, k}, at::kHalf).cuda();
+    at::Tensor in_b = at::ones({n, k}, at::kHalf).cuda();
+    at::Tensor out_ref = k * at::ones({m, n}, at::kHalf).cuda();
 
     ExpressionEvaluator evaluator;
     evaluator.bind(tv0, in_a);

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -673,59 +673,33 @@ TEST_F(ExprEvalTest, SumDiv) {
   evaluator.evaluate(out);
 }
 
-TEST_F(ExprEvalTest, MmaOp) {
+TEST_F(ExprEvalTest, MmaOp2D) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  std::vector<MmaLayout> all_mma_layouts{
-      MmaLayout::NT, MmaLayout::NN, MmaLayout::TT, MmaLayout::TN};
+  int64_t m = 2, k = 3, n = 4;
+  std::vector<int64_t> A_shape{m, k}, B_shape{n, k};
+  
+  auto tv0 = makeConcreteTensor(A_shape, DataType::Half);
+  auto tv1 = makeConcreteTensor(B_shape, DataType::Half);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-  for (auto layout : all_mma_layouts) {
-    bool transpose_a = (layout == MmaLayout::NT || layout == MmaLayout::NN);
-    bool transpose_b = (layout == MmaLayout::TT || layout == MmaLayout::NT);
+  auto tv0b = broadcast(tv0, {false, false, true});
+  auto tv1b = broadcast(tv1, {true, false, false});
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
 
-    int64_t m = 2, k = 3, n = 4;
-    std::vector<int64_t> A_shape{M, K}, B_shape{N, K};
+  fusion.addOutput(tv2);
 
-    if (transpose_a) {
-      std::swap(A_shape[0], A_shape[1]);
-    }
-    if (transpose_b) {
-      std::swap(B_shape[0], B_shape[1]);
-    }
+  at::Tensor in_a = at::ones({m, k}, at::kHalf).cuda();
+  at::Tensor in_b = at::ones({n, k}, at::kHalf).cuda();
+  at::Tensor out_ref = k * at::ones({m, n}, at::kHalf).cuda();
 
-    auto tv0 = makeConcreteTensor(A_shape, DataType::Half);
-    auto tv1 = makeConcreteTensor(B_shape, DataType::Half);
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
-
-    // [M, K]
-    if (transpose_a) {
-      tv0 = transpose(tv0, 0, 1);
-    }
-
-    // [N, K]
-    if (transpose_b) {
-      tv1 = transpose(tv1, 0, 1);
-    }
-
-    // [M, N, K]
-    auto tv0b = broadcast(tv0, {false, true, false});
-    auto tv1b = broadcast(tv1, {true, false, false});
-
-    auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
-
-    fusion.addOutput(tv2);
-
-    at::Tensor in_a = at::ones({m, k}, at::kHalf).cuda();
-    at::Tensor in_b = at::ones({n, k}, at::kHalf).cuda();
-    at::Tensor out_ref = k * at::ones({m, n}, at::kHalf).cuda();
-
-    ExpressionEvaluator evaluator;
-    evaluator.bind(tv0, in_a);
-    evaluator.bind(tv1, in_b);
-    at::Tensor out = evaluator.evaluate(tv2).as<at::Tensor>();
-    NVF_CHECK(out_ref.equal(out));
+  ExpressionEvaluator evaluator;
+  evaluator.bind(tv0, in_a);
+  evaluator.bind(tv1, in_b);
+  at::Tensor out = evaluator.evaluate(tv2).as<at::Tensor>();
+  NVF_CHECK(out_ref.equal(out));
   }
-}
+
 } // namespace nvfuser

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -673,33 +673,50 @@ TEST_F(ExprEvalTest, SumDiv) {
   evaluator.evaluate(out);
 }
 
-TEST_F(ExprEvalTest, MmaOp2D) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+TEST_F(ExprEvalTest, MmaOp) {
+  std::vector<bool> has_batch_dim {false};
+  int64_t b = 5, m = 2, k = 3, n = 4;
 
-  int64_t m = 2, k = 3, n = 4;
-  std::vector<int64_t> A_shape{m, k}, B_shape{n, k};
-  
-  auto tv0 = makeConcreteTensor(A_shape, DataType::Half);
-  auto tv1 = makeConcreteTensor(B_shape, DataType::Half);
-  fusion.addInput(tv0);
-  fusion.addInput(tv1);
+  for (bool is_bmm: has_batch_dim){
+    Fusion fusion;
+    FusionGuard fg(&fusion);    
 
-  auto tv0b = broadcast(tv0, {false, false, true});
-  auto tv1b = broadcast(tv1, {true, false, false});
-  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+    // int ndims = is_bmm ? 3 : 2;
+    std::vector<int64_t> a_shape, b_shape, out_shape;
+    if (is_bmm){
+      a_shape = {b, n, k};
+      b_shape = {b, n, k};
+      out_shape = {b, m, n};
+    } else {
+      a_shape = {m, k};
+      b_shape = {n, k};
+      out_shape = {m, n};
+    }
 
-  fusion.addOutput(tv2);
+    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+    fusion.addInput(tv0);
+    fusion.addInput(tv1);
 
-  at::Tensor in_a = at::ones({m, k}, at::kHalf).cuda();
-  at::Tensor in_b = at::ones({n, k}, at::kHalf).cuda();
-  at::Tensor out_ref = k * at::ones({m, n}, at::kHalf).cuda();
+    std::vector<bool> bcast_dima (tv0->nDims() + 1, false);
+    std::vector<bool> bcast_dimb (tv1->nDims() + 1, false);
+    bcast_dima.at(bcast_dima.size() - 1) = true;
+    bcast_dimb.at(bcast_dimb.size() - 3) = true;
+    auto tv0b = broadcast(tv0, bcast_dima);
+    auto tv1b = broadcast(tv1, bcast_dimb);
+    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
 
-  ExpressionEvaluator evaluator;
-  evaluator.bind(tv0, in_a);
-  evaluator.bind(tv1, in_b);
-  at::Tensor out = evaluator.evaluate(tv2).as<at::Tensor>();
-  NVF_CHECK(out_ref.equal(out));
-  }
+    fusion.addOutput(tv2);
 
+    at::Tensor in_a = at::ones(a_shape, at::kHalf).cuda();
+    at::Tensor in_b = at::ones(b_shape, at::kHalf).cuda();
+    at::Tensor out_ref = k * at::ones(out_shape, at::kHalf).cuda();
+
+    ExpressionEvaluator evaluator;
+    evaluator.bind(tv0, in_a);
+    evaluator.bind(tv1, in_b);
+    at::Tensor out = evaluator.evaluate(tv2).as<at::Tensor>();
+    NVF_CHECK(out_ref.equal(out));
+    }
+  } 
 } // namespace nvfuser


### PR DESCRIPTION
Implements the `evaluate` method for `MmaOp`. 
The `evaluate` method assumes:

1. `MmaOp` is preceded by `broadcast`.
2. The inputs (non-broadcasted) are 2D.
3. The inputs to the `matmul` API and the broadcasts will be `[M, K] x [K, N]` which is the same as PyTorch.

This is intended to be used in default matmul scheduling .
(Issue #1669)