### PR TITLE
Convert reduction of expanded dims to squeeze

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -1309,8 +1309,6 @@ SqueezeOp::SqueezeOp(
           id->isBroadcast() || id->isSymbolic(),
           "Squeeze dimension should be either Symbolic or Broadcast. Found ",
           id->getIterType());
-      NVF_ERROR(
-          !id->hasExpandedExtent(), "Can not squeeze expanded dimension(s).");
       if (id->isBroadcast()) {
         // Check concrete broadcast extent here. For Symbolic inputs, this check
         // will be deferred to concretization. See dynamic_transform.cpp

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2101,7 +2101,7 @@ std::vector<PolymorphicValue> ExpandOp::evaluate(
   for (auto i : c10::irange(1, inputs.size())) {
     expanded_size.push_back((int64_t)inputs.at(i));
   }
-  return {at::expand_copy(in, expanded_size)};
+  return {in.expand(expanded_size)};
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(ExpandOp)

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -245,8 +245,6 @@ TensorView* squeeze(TensorView* x, const std::vector<int64_t>& dims) {
           continue;
         }
         NVF_CHECK(
-            !id->hasExpandedExtent(), "Can not squeeze expanded dimension(s).");
-        NVF_CHECK(
             id->extent()->isConstScalar() && id->extent()->evaluate() == 1,
             "Can not squeeze dimension(s) with size != 1.");
       }
@@ -291,8 +289,6 @@ TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
         NVF_CHECK(
             id->isBroadcast(),
             "Can not squeeze non-broadcasting dimension(s).");
-        NVF_CHECK(
-            !id->hasExpandedExtent(), "Can not squeeze expanded dimension(s).");
         NVF_CHECK(
             id->extent()->isConstScalar() && id->extent()->evaluate() == 1,
             "Can not squeeze dimension(s) with size != 1.");

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -204,7 +204,10 @@ TensorView* flatten(TensorView* x, int64_t start_dim, int64_t end_dim) {
   return out;
 }
 
-TensorView* squeeze(TensorView* x, const std::vector<int64_t>& dims) {
+TensorView* squeeze(
+    TensorView* x,
+    const std::vector<int64_t>& dims,
+    bool squeeze_expanded) {
   NVF_ERROR(x != nullptr, "Input is invalid.");
   auto x_dom = x->domain()->noReductions();
   const auto ndims = static_cast<int>(x_dom.size());
@@ -232,44 +235,13 @@ TensorView* squeeze(TensorView* x, const std::vector<int64_t>& dims) {
     to_squeeze[dim] = true;
   }
 
-  std::vector<IterDomain*> out_domain;
-  for (const auto idx : c10::irange(ndims)) {
-    auto id = x_dom[idx];
-    if (to_squeeze[idx]) {
-      if (!id->isSymbolic()) {
-        // If a squeeze is attempted on a non-broadcast dimension
-        // just don't do it!  This conforms with Pytorch.
-        if (!id->isBroadcast()) {
-          to_squeeze[idx] = false;
-          out_domain.push_back(id->cloneWithoutRFactor());
-          continue;
-        }
-        NVF_CHECK(
-            id->extent()->isConstScalar() && id->extent()->evaluate() == 1,
-            "Can not squeeze dimension(s) with size != 1.");
-      }
-    } else {
-      out_domain.push_back(id->cloneWithoutRFactor());
-    }
-  }
-
-  auto out = IrBuilder::create<TensorView>(
-      IrBuilder::create<TensorDomain>(
-          out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
-      *x->getDataType());
-
-  std::vector<bool> all_false(to_squeeze.size(), false);
-  // If a squeeze does not perform a squeeze, create a no-op
-  if (to_squeeze == all_false) {
-    IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, x);
-  } else {
-    IrBuilder::create<SqueezeOp>(x->container(), out, x, to_squeeze);
-  }
-
-  return out;
+  return squeeze(x, to_squeeze, squeeze_expanded);
 }
 
-TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
+TensorView* squeeze(
+    TensorView* x,
+    const std::vector<bool>& to_squeeze,
+    bool squeeze_expanded) {
   NVF_ERROR(x != nullptr, "Input is invalid.");
   auto x_dom = x->domain()->noReductions();
   const auto ndims = static_cast<int>(x_dom.size());
@@ -290,6 +262,11 @@ TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
             id->isBroadcast(),
             "Can not squeeze non-broadcasting dimension(s).");
         NVF_CHECK(
+            squeeze_expanded || !id->hasExpandedExtent(),
+            "Refusing to squeeze expanded IterDomain ",
+            id->toString(),
+            ". To force removal of this axis, use squeeze_expanded=true.");
+        NVF_CHECK(
             id->extent()->isConstScalar() && id->extent()->evaluate() == 1,
             "Can not squeeze dimension(s) with size != 1.");
       }
@@ -303,7 +280,13 @@ TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze) {
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       *x->getDataType());
 
-  IrBuilder::create<SqueezeOp>(x->container(), out, x, to_squeeze);
+  if (std::none_of(
+          to_squeeze.begin(), to_squeeze.end(), [](bool b) { return b; })) {
+    // If we did not squeeze any axes, this is just set()
+    IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, x);
+  } else {
+    IrBuilder::create<SqueezeOp>(x->container(), out, x, to_squeeze);
+  }
 
   return out;
 }

--- a/csrc/ops/alias.h
+++ b/csrc/ops/alias.h
@@ -43,12 +43,26 @@ TensorView* reshape(TensorView* x, const std::vector<Val*>& new_sizes);
 
 TensorView* flatten(TensorView* x, int64_t start_dim = 0, int64_t end_dim = -1);
 
-// This implementation is specific to Pytorch where if you attempt to squeeze
-// a non-broadcast dimension, the squeeze does not do anything to that
-// dimension and does not trigger an error.
-TensorView* squeeze(TensorView* x, const std::vector<int64_t>& dims);
+//! This implementation differs from Pytorch where if you attempt to squeeze
+//! a non-broadcast dimension, the squeeze does not do anything to that
+//! dimension and does not trigger an error. Here, we will raise an exception in
+//! such cases. It is also an error to request a squeeze of an expanded
+//! dimension; however, if squeeze_expanded is true then this is allowed and
+//! works just like if the dimension was not expanded.
+TensorView* squeeze(
+    TensorView* x,
+    const std::vector<int64_t>& dims,
+    bool squeeze_expanded = false);
 
-TensorView* squeeze(TensorView* x, const std::vector<bool>& to_squeeze);
+//! Squeeze the dimensions corresponding to "true" in to_squeeze, i.e. remove
+//! those broadcasted dimension. If squeeze_expanded is true, then expanded
+//! Broadcasts will be removed just as if they were not expanded. If
+//! squeeze_expanded is false, then it is an error for an expanded broadcast to
+//! have a corresponding "true" value in to_squeeze.
+TensorView* squeeze(
+    TensorView* x,
+    const std::vector<bool>& to_squeeze,
+    bool squeeze_expanded = false);
 
 TensorView* unsqueeze(TensorView* x, int dim);
 

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1299,17 +1299,20 @@ TensorView* reductionOp(
   //   Add -> multiplication by i0
   //   Mul -> raise to power i0
   //   Min/Max -> squeeze
-  //   {Logical,Bitwise}{And,Or,Xor} -> squeeze
+  //   {Logical,Bitwise}{And,Or} -> squeeze
+  //   BitwiseXor -> 0 if i0 is even, else squeeze
   //   Eq -> squeeze
   //   Gcd -> squeeze
   // Other op-types are non-commutative, so we ignore them here as they should
-  // not be used in reductions. We can see that the only two that require
-  // special consideration are Add and Mul. We treat all others as trivial (i.e.
+  // not be used in reductions. We can see that the only two common ops that
+  // require special consideration are Add and Mul. Currently Xor is not
+  // supported for expanded reduction. We treat all others as trivial (i.e.
   // squeeze).
   std::vector<int> reduction_axes;
   std::vector<bool> is_broadcast_reduction(ndims, false);
   bool expand_reductions_are_trivial = reduction_op_type != BinaryOpType::Add &&
-      reduction_op_type != BinaryOpType::Mul;
+      reduction_op_type != BinaryOpType::Mul &&
+      reduction_op_type != BinaryOpType::BitwiseXor;
   int offset = 0;
   for (unsigned int axis : uint_axes) {
     auto id = tv_root[axis];

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1309,7 +1309,7 @@ TensorView* reductionOp(
   // supported for expanded reduction. We treat all others as trivial (i.e.
   // squeeze).
   std::vector<int> reduction_axes;
-  std::vector<bool> is_broadcast_reduction(ndims, false);
+  std::vector<bool> is_squeeze(ndims, false);
   bool expand_reductions_are_trivial = reduction_op_type != BinaryOpType::Add &&
       reduction_op_type != BinaryOpType::Mul &&
       reduction_op_type != BinaryOpType::BitwiseXor;
@@ -1317,7 +1317,7 @@ TensorView* reductionOp(
   for (unsigned int axis : uint_axes) {
     auto id = tv_root[axis];
     if (id->isBroadcast()) {
-      is_broadcast_reduction[axis] = true;
+      is_squeeze[axis] = true;
       offset--;
     } else {
       reduction_axes.push_back((int)axis + offset);
@@ -1327,7 +1327,7 @@ TensorView* reductionOp(
   TensorView* squeezed = tv;
   if (offset < 0) {
     // There are some broadcast dims being reduced. We squeeze them all first.
-    squeezed = squeeze(tv, is_broadcast_reduction, /*squeeze_expanded=*/true);
+    squeezed = squeeze(tv, is_squeeze, /*squeeze_expanded=*/true);
   }
 
   TensorView* out = squeezed;

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1327,7 +1327,7 @@ TensorView* reductionOp(
   TensorView* squeezed = tv;
   if (offset < 0) {
     // There are some broadcast dims being reduced. We squeeze them all first.
-    squeezed = squeeze(tv, is_broadcast_reduction);
+    squeezed = squeeze(tv, is_broadcast_reduction, /*squeeze_expanded=*/true);
   }
 
   TensorView* out = squeezed;
@@ -1809,7 +1809,7 @@ WelfordResult Welford(
 
   TensorView* squeezed = tv;
   if (offset < 0) {
-    squeezed = squeeze(tv, is_trivial_reduction);
+    squeezed = squeeze(tv, is_trivial_reduction, /*squeeze_expanded=*/true);
   }
 
   if (!reduction_axes.empty()) {

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -3151,6 +3151,26 @@ class TestNvFuserFrontend(TestCase):
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
         # self.assertEqual(nvf_out[0], t24)
 
+    # Test that expanded dimensions can be reduced properly
+    # See https://github.com/NVIDIA/Fuser/issues/1678
+    def test_expanded_reduction(self):
+        inputs = [torch.tensor(1.0, device="cuda").as_strided((2, 3), (0, 0))]
+
+        def fusion_func(fd: FusionDefinition) -> None:
+            T0 = fd.define_tensor(
+                shape=[-1, -1],
+                contiguity=[None, None],
+                dtype=DataType.Float,
+                is_cpu=False,
+                stride_order=[1, 0],
+            )
+            T1 = fd.ops.sum(T0, axes=[0], keepdim=False, dtype=DataType.Null)
+            fd.add_output(T1)
+
+        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
+
+        self.assertEqual(nvf_out[0], inputs[0].sum(dim=0))
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
See comment in arith.cpp for details.

One controversial change here is to allow squeezing expanded dimensions, both in our IR's `SqueezeOp` and in the user-facing functions `squeeze`. This results in actually removing those dimensions. This behavior diverges from PyTorch, whose `squeeze` command will ignore requested squeezes if the size is not 1 regardless of whether that dimension is expanded. I'm happy to discuss this change and potentially take another course, but I think we do need to be able to remove expanded axes (see https://github.com/NVIDIA/Fuser/issues/1174#issuecomment-1851998818 for another case where I encountered this limitation).

Fixes #1678