### PR TITLE
Move `aliased_io` into `AliasInfo`. 

### DIFF
--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1515,9 +1515,8 @@ void ExprSegmentationSorter::sort() {
       fusion_->outputs().end(),
       std::back_inserter(non_pointer_arithmetic_outs),
       [this](Val* out) {
-        auto [in, alias_info] = fusion_->getOutputAlias(out);
-        return in == nullptr ||
-            alias_info->type != AliasType::PointerArithmetic;
+        return fusion_->getOutputAlias(out).type !=
+            AliasType::PointerArithmetic;
       });
 
   // Not putting the exprs between fusion inputs and allKnownVals() here

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -85,10 +85,13 @@ IrCloner Fusion::copy(const Fusion* from, Fusion* to) {
   }
 
   // TODO: put this into ir_cloner instead
-  for (const auto& entry : from->io_alias_) {
-    Val* copied_output = ir_cloner.clone(entry.first);
-    Val* copied_input = ir_cloner.clone(entry.second.first);
-    to->io_alias_[copied_output] = {copied_input, entry.second.second};
+  for (const auto& [output, alias_info] : from->io_alias_) {
+    Val* copied_output = ir_cloner.clone(output);
+    Val* copied_input = ir_cloner.clone(alias_info.aliased_io);
+    to->io_alias_[copied_output] = {
+        .type = alias_info.type,
+        .aliased_io = copied_input,
+        .hide_output = alias_info.hide_output};
   }
 
   to->permuted_input_map_ = from->permuted_input_map_;
@@ -766,6 +769,10 @@ bool Fusion::isAliasCompatible(Val* left, Val* right) {
 }
 
 void Fusion::aliasOutputToInput(Val* output, Val* input, const AliasType type) {
+  NVF_CHECK(
+      type != AliasType::NoAlias,
+      "NoAlias is returned automatically for a missing key. Don't add it explicitly.");
+
   if (type == AliasType::InplaceUpdate) {
     // `input` can be a cast of a fusion input.
     if (!input->isFusionInput()) {
@@ -793,7 +800,10 @@ void Fusion::aliasOutputToInput(Val* output, Val* input, const AliasType type) {
   // Let integration hide any output that wasn't a fusion output when
   // `aliasOutputToInput` was called. For example, running mean and var for
   // batch norm.
-  io_alias_[output] = {input, AliasInfo{type, !output->isFusionOutput()}};
+  io_alias_[output] = AliasInfo{
+      .type = type,
+      .aliased_io = input,
+      .hide_output = !output->isFusionOutput()};
 
   // TODO: output should be marked at the end of fusion definition #1488
   if (!output->isFusionOutput()) {
@@ -801,12 +811,13 @@ void Fusion::aliasOutputToInput(Val* output, Val* input, const AliasType type) {
   }
 }
 
-std::pair<Val*, const AliasInfo*> Fusion::getOutputAlias(Val* output) const {
+const AliasInfo& Fusion::getOutputAlias(Val* output) const {
+  static AliasInfo no_alias_info{
+      .type = AliasType::NoAlias, .aliased_io = nullptr, .hide_output = false};
   if (auto search = io_alias_.find(output); search != io_alias_.end()) {
-    const std::pair<Val*, AliasInfo>& in_val_and_info = search->second;
-    return {in_val_and_info.first, &in_val_and_info.second};
+    return search->second;
   }
-  return {nullptr, nullptr};
+  return no_alias_info;
 }
 
 bool Fusion::hasDynamicTransform() {

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -329,8 +329,9 @@ void SegmentedGroup::finalize() {
   // alias aware segmentation. we add inputs that are aliased by output
   // generated in this SegmentedGroup
   for (Val* output : output_vals) {
-    if (Val* aliased_input =
-            segmented_fusion_->completeFusion()->getOutputAlias(output).first) {
+    if (Val* aliased_input = segmented_fusion_->completeFusion()
+                                 ->getOutputAlias(output)
+                                 .aliased_io) {
       // aliasing currently only supported as output to input
       NVF_ERROR(
           aliased_input->isFusionInput(),

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -522,9 +522,7 @@ std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
   NVF_ERROR(fusion->outputs().size() == outputs.size());
   size_t new_size = 0;
   for (size_t out_index = 0; out_index < outputs.size(); out_index++) {
-    const AliasInfo* alias_info =
-        fusion->getOutputAlias(fusion->outputs()[out_index]).second;
-    if (alias_info == nullptr || !alias_info->hide_output) {
+    if (fusion->getOutputAlias(fusion->outputs()[out_index]).hide_output) {
       outputs[new_size] = outputs[out_index];
       new_size++;
     }

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -522,7 +522,8 @@ std::vector<at::Tensor> FusionExecutorCache::runFusionWithInputs(
   NVF_ERROR(fusion->outputs().size() == outputs.size());
   size_t new_size = 0;
   for (size_t out_index = 0; out_index < outputs.size(); out_index++) {
-    if (fusion->getOutputAlias(fusion->outputs()[out_index]).hide_output) {
+    Val* out = fusion->outputs()[out_index];
+    if (!fusion->getOutputAlias(out).hide_output) {
       outputs[new_size] = outputs[out_index];
       new_size++;
     }

--- a/test/validator.h
+++ b/test/validator.h
@@ -44,11 +44,7 @@ void testValidate(
         // Returns true when `out` is **not** an aliased output that's hidden
         // from integration. Hidden outputs won't show up in `fusion_outputs`
         // for us to compare, so we skip them.
-        const AliasInfo* alias_info = fusion->getOutputAlias(out).second;
-        if (alias_info == nullptr) {
-          return true;
-        }
-        return !alias_info->hide_output;
+        return !fusion->getOutputAlias(out).hide_output;
       });
 
   auto expr_eval = bindInputsAndLaunchParams(fusion, aten_inputs, lparams);


### PR DESCRIPTION
This makes `getOutputAlias` easier to use. This will eventually help #1669 represent outputs that require evaluation but are not an alias. For that, we'll need to
1. Rename `Alias*` to `Allocation*`.
2. Rename `AllocationType::PointerArithmetic` to `AllocationType::Evaluate`. 
3. When a MmaOp segment needs ATen evaluation, set its output allocation to `.type=AllocationType::Evaluate,aliased_io=nullptr`. 