### PR TITLE
Accomodate Reduction IterDomains when concretizing reshape extents

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -647,8 +647,10 @@ void DynamicTransformConcretizer::concretizeReshape() {
     // Extent expressions often change when concretizing a reshape. Here we
     // replace these in all downstream expressions so that the Fusion looks just
     // like it would have if we had used a static reshape instead.
-    auto old_rfactor = incomplete_out_tv->getMaybeRFactorDomain();
-    auto new_rfactor = concrete_reshape_out_tv->getMaybeRFactorDomain();
+    auto old_rfactor =
+        TensorDomain::noReductions(incomplete_out_tv->getMaybeRFactorDomain());
+    auto new_rfactor = TensorDomain::noReductions(
+        concrete_reshape_out_tv->getMaybeRFactorDomain());
     NVF_ERROR(
         old_rfactor.size() == new_rfactor.size(),
         "Concretized reshape rfactor size does not match symbolic rfactor");

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -673,8 +673,7 @@ void DynamicTransformConcretizer::concretizeReshape() {
     // We also replace the extent i2 from the dynamic reshape output T2 with i0,
     // which is what the code below implements. Since T1 includes a Reduction
     // IterDomain, we must ignore it in order to match ?S4{i2} with iS2{i0}.
-    auto old_rfactor =
-        TensorDomain::noReductions(incomplete_out_tv->getMaybeRFactorDomain());
+    auto old_rfactor = incomplete_out_tv->getMaybeRFactorDomain();
     auto new_rfactor = TensorDomain::noReductions(
         concrete_reshape_out_tv->getMaybeRFactorDomain());
     NVF_ERROR(


### PR DESCRIPTION
We register extents for concretization when we concretize reshape. In order to do that, we line up `IterDomain`s in the symbolic reshaped TV and the new, concretized one. In cases where the concretized reshape is trivial, such as when the output shape is the same as the input, we do not create a new TV. In those cases, we will have the input to the original `ViewOp` as the concretized output. That input TV might have reduction domains, as in the provided test, in which case we need to filter those out when doing this alignment. This small PR just implements that filtering.

Fixes #1691.