### PR TITLE
Check that the reduced axis is sharded on producer in isLowerableToCommunication

### DIFF
--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -549,8 +549,8 @@ bool isLowerableToCommunication(Expr* expr) {
     // get the reduced axis
     std::vector<IterDomain*> reduction_axis;
     std::copy_if(
-        out->getMaybeRFactorDomain().begin(),
-        out->getMaybeRFactorDomain().end(),
+        out->getRootDomain().begin(),
+        out->getRootDomain().end(),
         std::back_inserter(reduction_axis),
         [](IterDomain* id) { return id->isReduction(); });
     // check whether the reduction involves only one axis

--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -539,9 +539,10 @@ std::vector<std::shared_ptr<Communication>> lowerCommunication(
 }
 
 bool isLowerableToCommunication(Expr* expr) {
-  NVF_ERROR(ir_utils::isTvOp(expr),
-        "Non-tv op is not supported yet: ",
-        expr->toString());
+  NVF_ERROR(
+      ir_utils::isTvOp(expr),
+      "Non-tv op is not supported yet: ",
+      expr->toString());
   if (expr->isA<ReductionOp>()) {
     auto in = expr->as<ReductionOp>()->in()->as<TensorView>();
     auto out = expr->as<ReductionOp>()->out()->as<TensorView>();

--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #ifdef USE_DISTRIBUTED
+#include <device_lower/utils.h>
 #include <ir/interface_nodes.h>
 #include <multidevice/device_mesh.h>
 #include <multidevice/lower_communication.h>
@@ -538,18 +539,27 @@ std::vector<std::shared_ptr<Communication>> lowerCommunication(
 }
 
 bool isLowerableToCommunication(Expr* expr) {
+  NVF_ERROR(ir_utils::isTvOp(expr),
+        "Non-tv op is not supported yet: ",
+        expr->toString());
   if (expr->isA<ReductionOp>()) {
-    auto out = expr->as<ReductionOp>()->out();
-    NVF_ERROR(out->isA<TensorView>(), "output is not a TensorView");
-    auto out_tv = out->as<TensorView>();
+    auto in = expr->as<ReductionOp>()->in()->as<TensorView>();
+    auto out = expr->as<ReductionOp>()->out()->as<TensorView>();
+    // get the reduced axis
     std::vector<IterDomain*> reduction_axis;
     std::copy_if(
-        out_tv->getMaybeRFactorDomain().begin(),
-        out_tv->getMaybeRFactorDomain().end(),
+        out->getMaybeRFactorDomain().begin(),
+        out->getMaybeRFactorDomain().end(),
         std::back_inserter(reduction_axis),
         [](IterDomain* id) { return id->isReduction(); });
-    // check if the reduction involves only one axis and that it is sharded
-    return reduction_axis.size() == 1 && reduction_axis[0]->isDeviceDim();
+    // check whether the reduction involves only one axis
+    if (reduction_axis.size() != 1) {
+      return false;
+    }
+    // We check whether the reduced axis is sharded on the input
+    const auto c2p_map = PairwiseRootDomainMap(in, out).mapConsumerToProducer();
+    auto c2p_map_it = c2p_map.find(reduction_axis.at(0));
+    return c2p_map_it != c2p_map.end() && c2p_map_it->second->isDeviceDim();
   } else {
     return expr->isA<LoadStoreOp>() &&
         (expr->as<LoadStoreOp>()->opType() == LoadStoreOpType::Set);


### PR DESCRIPTION
Currently, a reduction is lowerable to a communication iff only one axis is reduced and this axis is sharded across devices on the **producer** side.
Before this patch, we would mistakenly check that the axis is sharded on **consumer** side, which led to some runtime assert error. 