### PR TITLE
Add blank impl of isLowerableToCommunication.

### DIFF
--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -558,4 +558,18 @@ bool isLowerableToCommunication(Expr* expr) {
 
 } // namespace nvfuser
 
+#else // USE_DISTRIBUTED
+
+#include <ir/base_nodes.h>
+
+namespace nvfuser {
+
+// This is just here so that things can compile even when/if USE_DISTRIBUTED is
+// not defined. The code paths aren't intended to be hit ever in such cases, so
+// the implementation is unimportant.
+bool isLowerableToCommunication(Expr*) {
+  return false;
+}
+
+} // namespace nvfuser
 #endif

--- a/csrc/multidevice/lower_communication.h
+++ b/csrc/multidevice/lower_communication.h
@@ -28,4 +28,12 @@ std::vector<std::shared_ptr<Communication>> lowerCommunication(
 
 } // namespace nvfuser
 
+#else
+
+namespace nvfuser {
+
+bool isLowerableToCommunication(Expr*);
+
+}
+
 #endif


### PR DESCRIPTION
isLowerableToCommunication is used in a few places to print error messages or short-circuit loops. Those places appear to be places that are intended to largely be used behind the distributed path. It's easier to just define the API instead of trying to conditionalize all the use sites and invent non-USE_DISTRIBUTED behavior.