### PR TITLE
Associate each fusion cache with its local rank in distributed setting.

### DIFF
--- a/csrc/python_frontend/fusion_cache.h
+++ b/csrc/python_frontend/fusion_cache.h
@@ -118,7 +118,7 @@ struct TrieNode {
 class FusionCache {
   //! The constructor is private given the FusionCache is only constructed
   //! as a singleton.
-  FusionCache(size_t max_fusions);
+  FusionCache(size_t max_fusions, std::optional<int64_t> selected_device);
 
  public:
   //! Copy and Assignment of the FusionCache is not supported
@@ -131,9 +131,12 @@ class FusionCache {
   //! Gets a pointer to the singleton and creates a new one if necessary
   static FusionCache* get(
       size_t max_fusions = 8192,
+      std::optional<int64_t> selected_device = std::nullopt,
       bool load_from_default_workspace = true);
   //! Number of fusions cached
   size_t numFusions() const;
+  //! Get device associated with this FusionCache
+  int64_t deviceId() const;
   //! print cache contents
   void print(std::ostream& os) const;
   //! print cache stats
@@ -184,6 +187,9 @@ class FusionCache {
 
   //! The max allowed number of fusions in the cache
   size_t max_fusions_;
+  //! A separate process is created for each device in a distributed setting.
+  //! Each FusionCache becomes associated with a device.
+  int64_t device_id_;
   //! The root (start) of the prefix tree to start a cache look up of a given
   //! fusion definition.
   std::unique_ptr<TrieNode> root_;

--- a/csrc/python_frontend/fusion_cache.h
+++ b/csrc/python_frontend/fusion_cache.h
@@ -136,7 +136,7 @@ class FusionCache {
   //! Number of fusions cached
   size_t numFusions() const;
   //! Get device associated with this FusionCache
-  int64_t deviceId() const;
+  std::optional<int64_t> deviceId() const;
   //! print cache contents
   void print(std::ostream& os) const;
   //! print cache stats
@@ -189,7 +189,7 @@ class FusionCache {
   size_t max_fusions_;
   //! A separate process is created for each device in a distributed setting.
   //! Each FusionCache becomes associated with a device.
-  int64_t device_id_;
+  std::optional<int64_t> device_id_;
   //! The root (start) of the prefix tree to start a cache look up of a given
   //! fusion definition.
   std::unique_ptr<TrieNode> root_;

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -419,6 +419,7 @@ void initNvFuserPythonBindings(PyObject* module) {
           "get",
           &FusionCache::get,
           py::arg("max_fusions") = int(8192),
+          py::arg("selected_device") = int(-1),
           py::arg("load_from_default_workspace") = true,
           py::return_value_policy::reference)
       .def("num_fusions", &FusionCache::numFusions)

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -39,6 +39,13 @@ def enable_automatic_serialization():
 
     atexit.register(_C.serialize)
 
+    # A separate process is created for each device in a distributed setting.
+    # Each FusionCache becomes associated with a single device.
+    # Automatic serialization saves a separate cache for each device.
+    # Set the FusionCache id to the ddp local rank.
+    ddp_local_rank = int(os.environ.get("LOCAL_RANK", -1))
+    _C.FusionCache.get(max_fusions := 8192, ddp_local_rank)
+
 
 # Unregister automatic serialization of Nvfuser cache hierarchy and cuda kernels.
 def disable_automatic_serialization():


### PR DESCRIPTION
### Problem:
Currently, automatic serialization saves a single cache regardless of the number of devices. In a distributed setting, each process restores its fusion cache from the same common workspace. However, this workspace only contains the CUDA kernels for a single device. The remaining processes must recompile the kernels for their devices.

### Solution:
A separate process is created for each device with `ddp` or `fsdp` and each process contains a separate `FusionCache`. This PR associates each fusion cache with its local rank in a distributed setting, allowing automatic serialization to create a separate workspace for each device. During deserialization, each process loads the workspace associated with its local rank.