### PR TITLE
Double the size of the fusion cache to workaround a CI issue.

### DIFF
--- a/csrc/python_frontend/fusion_cache.h
+++ b/csrc/python_frontend/fusion_cache.h
@@ -130,7 +130,7 @@ class FusionCache {
 
   //! Gets a pointer to the singleton and creates a new one if necessary
   static FusionCache* get(
-      size_t max_fusions = 8192,
+      size_t max_fusions = 16384,
       bool load_from_default_workspace = true);
   //! Number of fusions cached
   size_t numFusions() const;

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -418,7 +418,7 @@ void initNvFuserPythonBindings(PyObject* module) {
       .def_static(
           "get",
           &FusionCache::get,
-          py::arg("max_fusions") = int(8192),
+          py::arg("max_fusions") = int(16384),
           py::arg("load_from_default_workspace") = true,
           py::return_value_policy::reference)
       .def("num_fusions", &FusionCache::numFusions)


### PR DESCRIPTION
By just removing entries when it fills up.