### PR TITLE
`eager` and `torch.compile` benchmarks for `layernorm`

### DIFF
--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -93,6 +93,7 @@ def layernorm_bwd_fusion(
 
 
 def layernorm_bwd_iobytes(size: tuple, dtype: torch.dtype):
+    # Manual IOBytes computation since nvfuser input/outputs (in_tensor, grad_out, mean, invstd, weigts) differ from baselines (out, grad_out)
     # Total IO bytes = in_tensor (size, dtype) + grad_out (size, dtype) + mean (size[0], float) +
     #       invstd (size[0], float) + weights (size[1], dtype) +
     #       grad_in (size, dtype) + grad_weights (size[1], dtype)+ grad_bias (size[1], dtype)
@@ -164,6 +165,7 @@ def test_layernorm_bwd_baseline_benchmark(
         bias=bias,
     )
 
+    # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
         torch.compile(unary_bwd_torch) if compile else unary_bwd_torch,

--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -1,7 +1,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache
+from .core import run_benchmark, clear_cuda_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
@@ -90,10 +90,6 @@ def layernorm_bwd_fusion(
     fd.add_output(T90)
     fd.add_output(T32)
     fd.add_output(T28)
-
-
-def unary_bwd_torch(inputs: list):  # [output, grad_out]
-    inputs[0].backward(inputs[1], retain_graph=True)
 
 
 def layernorm_bwd_iobytes(size: tuple, dtype: torch.dtype):

--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -98,7 +98,7 @@ def unary_bwd_torch(inputs: list): #[in_tensor, output, grads, weight, bias]
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_layernorm_bwd_benchmark(
+def test_layernorm_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
@@ -139,7 +139,7 @@ def test_layernorm_bwd_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_layernorm_bwd_benchmark(
+def test_layernorm_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -94,7 +94,7 @@ def test_layernorm_fwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_layernorm_fwd_nvf_benchmark(
+def test_layernorm_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -51,9 +51,17 @@ def layernorm_fwd_fusion(
     fd.add_output(T14)
 
 
+def layernorm_fwd_fn(inputs: list): #[in_tensor, weights, bias]
+    return torch.nn.functional.layer_norm(
+        inputs[0],
+        normalized_shape=inputs[0].shape[1:], 
+        weight=inputs[1],
+        bias=inputs[2] 
+    )
+
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_layernorm_fwd_benchmark(
+def test_layernorm_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
@@ -64,7 +72,7 @@ def test_layernorm_fwd_benchmark(
     clear_cuda_cache()
 
     inputs = [
-        torch.randn(*size, device="cuda", dtype=dtype),
+        torch.randn(size, device="cuda", dtype=dtype),
         torch.randn(size[1], device="cuda", dtype=dtype),
         torch.randn(size[1], device="cuda", dtype=dtype),
     ]
@@ -73,10 +81,7 @@ def test_layernorm_fwd_benchmark(
         layernorm_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
 
     if not disable_validation:
-        eager_output = torch.nn.functional.layer_norm(
-            inputs[0], inputs[0].shape[1:], weight=inputs[1], bias=inputs[2]
-        )
-
+        eager_output = layernorm_fwd_fn(inputs)
         mean = inputs[0].to(torch.float).mean(dim=-1)
         variance = inputs[0].to(torch.float).var(dim=-1, unbiased=False)
         invstd = (1.0 / torch.sqrt(variance + eps)).unsqueeze(1)
@@ -85,3 +90,24 @@ def test_layernorm_fwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, inputs)
+
+@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_layernorm_fwd_nvf_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    compile: bool,
+):
+    clear_cuda_cache()
+    inputs = [
+        torch.randn(size, device="cuda", dtype=dtype),
+        torch.randn(size[1], device="cuda", dtype=dtype),
+        torch.randn(size[1], device="cuda", dtype=dtype),
+    ]
+    run_benchmark(
+        benchmark,
+        torch.compile(layernorm_fwd_fn) if compile else layernorm_fwd_fn,
+        inputs
+    )

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -121,7 +121,7 @@ def test_layernorm_fwd_baseline_benchmark(
         torch.randn(hidden_size, device="cuda", dtype=dtype),
         torch.randn(hidden_size, device="cuda", dtype=dtype),
     ]
-    
+
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,


### PR DESCRIPTION
Issue #1668.

Adds IOByte computation and benchmarking for Layernorm baselines (eager & torchcompile)