### PR TITLE
Weekly Benchmarks Input Range

### DIFF
--- a/python_benchmarks/global_params.py
+++ b/python_benchmarks/global_params.py
@@ -4,6 +4,12 @@ from nvfuser import DataType
 from .core import DEVICE_PROPERTIES
 import numpy as np
 import itertools
+import os
+
+# BENCHMARK_MODE = weekly/nightly.
+BENCHMARK_MODE = os.getenv("BENCHMARK_MODE")
+if not BENCHMARK_MODE:
+    BENCHMARK_MODE = "nightly"
 
 # Datatypes to benchmark
 FLOAT_DTYPES = [torch.float32]
@@ -51,12 +57,16 @@ def generate_input_sizes(dims: Union[int, List] = 2) -> List[Tuple]:
     for dim in dims:
         if dim == 2:
             input_ranges = []
-            step_size = 256
 
+            step_size = 256
             # max_batch_range: set according to max size that fits in GPU memory
             batch_range = [2**i for i in range(4, 14)]  # {16, 8192}
-            # max_hidden_size = 4 * d_model_max (max hidden size in feedforward layers)
 
+            if BENCHMARK_MODE == "weekly":
+                step_size = 8
+                batch_range = [32, 1024, 2048]
+
+            # max_hidden_size = 4 * d_model_max (max hidden size in feedforward layers)
             # NOTE: Numpy arrays are not JSON serializable so convert them to enable storing benchmark data.
             hidden_range = np.arange(
                 D_MODEL_MIN, 4 * D_MODEL_MAX + 1, step_size

--- a/python_benchmarks/global_params.py
+++ b/python_benchmarks/global_params.py
@@ -50,6 +50,18 @@ LLM_CONFIGS = [
 
 # Utility function to generate input sizes for benchmarks
 def generate_input_sizes(dims: Union[int, List] = 2) -> List[Tuple]:
+    """
+    The weekly vs nightly input ranges only differ for 2D inputs currently.
+    Nightly input range:
+        Batch size: [16->16384] Hidden size: [768, 4*18432] (step size = 256)
+    Weekly input range:
+        Batch size:
+            [16]: Latency bound state
+            [512, 1024]: Just filled the machine
+            [16384]: Steady state (full machine)
+        Hidden size: [768, 4*18432] (step size = 8)
+    Note: The hidden size is restricted to 2 * 18432 for the batch size 16384 to avoid OOM.
+    """
     inputs = []
     if isinstance(dims, int):
         dims = [dims]
@@ -64,7 +76,7 @@ def generate_input_sizes(dims: Union[int, List] = 2) -> List[Tuple]:
 
             if BENCHMARK_MODE == "weekly":
                 step_size = 8
-                batch_range = [32, 1024, 2048]
+                batch_range = [16, 512, 1024]
 
             # max_hidden_size = 4 * d_model_max (max hidden size in feedforward layers)
             # NOTE: Numpy arrays are not JSON serializable so convert them to enable storing benchmark data.


### PR DESCRIPTION
For weekly benchmarks, we will focus on 3 states:

1. Steady-State - full machine
2. Just filled the machine
3. Latency limited

The batch sizes are selected to cover these 3 states and the hidden sizes will be varied at a finer granuarity of `step_size=8`.

No major changes are required in our setup for weekly benchmarks. However, pytest is memory intensive and we may need to split the tests in each file to avoid CPU OOM.
~As a solution, we can use `pytest-split` when integrating these into the CI.~
CI uses `pytest-shard` which should work well.

**Running weekly benchmark coverage:**
`BENCHMARK_MODE=weekly pytest <options> <benchmark_file.py>`

CC: @xwang233 @kevinstephano 