### PR TITLE
NVFUSER_DISTRIBUTED instead of USE_DISTRIBUTED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,11 @@ option(NVFUSER_BUILD_WITH_ASAN "Build nvFuser with asan" OFF)
 
 include(CMakeDependentOption)
 cmake_dependent_option(NVFUSER_DISTRIBUTED "" ON
-	"$ENV{USE_DISTRIBUTED}" OFF)
+	"USE_DISTRIBUTED" OFF)
 if (NVFUSER_DISTRIBUTED)
   add_compile_definitions(NVFUSER_DISTRIBUTED)
 endif()
+message(STATUS "Setting NVFUSER_DISTRIBUTED=${NVFUSER_DISTRIBUTED}")
 
 if(NOT NVFUSER_CPP_STANDARD)
   set(NVFUSER_CPP_STANDARD 20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ set(NVFUSER_THIRD_PARTY_DIR "${NVFUSER_ROOT}/third_party")
 option(NVFUSER_STANDALONE_BUILD_WITH_UCC "" OFF)
 option(NVFUSER_BUILD_WITH_ASAN "Build nvFuser with asan" OFF)
 
+include(CMakeDependentOption)
+cmake_dependent_option(NVFUSER_DISTRIBUTED "" ON
+	"$ENV{USE_DISTRIBUTED}" OFF)
+if (NVFUSER_DISTRIBUTED)
+  add_compile_definitions(NVFUSER_DISTRIBUTED)
+endif()
+
 if(NOT NVFUSER_CPP_STANDARD)
   set(NVFUSER_CPP_STANDARD 20)
 endif()
@@ -642,6 +649,7 @@ message(STATUS "******** Nvfuser configuration summary ********")
 message(STATUS "  UCC_FOUND: ${UCC_FOUND}")
 message(STATUS "  NVFUSER_STANDALONE_BUILD_WITH_UCC  : ${NVFUSER_STANDALONE_BUILD_WITH_UCC}")
 message(STATUS "  NVFUSER_BUILD_WITH_ASAN            : ${NVFUSER_BUILD_WITH_ASAN}")
+message(STATUS "  NVFUSER_DISTRIBUTED                : ${NVFUSER_DISTRIBUTED}")
 message(STATUS "  NVFUSER_CPP_STANDARD               : ${NVFUSER_CPP_STANDARD}")
 
 if(NVFUSER_STANDALONE_BUILD_WITH_UCC)

--- a/csrc/multidevice/allocator.cpp
+++ b/csrc/multidevice/allocator.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #include <executor.h>
 #include <fusion.h>
 #include <ir/cloner.h>

--- a/csrc/multidevice/allocator.h
+++ b/csrc/multidevice/allocator.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #pragma once
 
 #include <multidevice/multidevice.h>

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #ifdef USE_C10D_NCCL
 #include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
 #endif

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -6,7 +6,7 @@
  */
 // clang-format on
 #pragma once
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 
 #include <multidevice/communicator.h>
 #include <multidevice/multidevice.h>

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #include <netdb.h>
 
 #include <multidevice/communicator.h>

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -6,7 +6,7 @@
  */
 // clang-format on
 #pragma once
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 
 #include <exceptions.h>
 #include <multidevice/multidevice.h>

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #include <ir/utils.h>
 #include <multidevice/allocator.h>
 #include <multidevice/executor.h>

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #pragma once
 
 #include <exceptions.h>

--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #include <device_lower/utils.h>
 #include <ir/interface_nodes.h>
 #include <multidevice/device_mesh.h>
@@ -569,7 +569,7 @@ bool isLowerableToCommunication(Expr* expr) {
 
 } // namespace nvfuser
 
-#else // USE_DISTRIBUTED
+#else // USE_DISTRIBUTED && NVFUSER_DISTRIBUTED
 
 #include <ir/base_nodes.h>
 

--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -569,7 +569,7 @@ bool isLowerableToCommunication(Expr* expr) {
 
 } // namespace nvfuser
 
-#else // USE_DISTRIBUTED && NVFUSER_DISTRIBUTED
+#else // NVFUSER_DISTRIBUTED
 
 #include <ir/base_nodes.h>
 

--- a/csrc/multidevice/lower_communication.h
+++ b/csrc/multidevice/lower_communication.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #pragma once
 
 #include <multidevice/communication.h>
@@ -28,7 +28,7 @@ std::vector<std::shared_ptr<Communication>> lowerCommunication(
 
 } // namespace nvfuser
 
-#else
+#else // USE_DISTRIBTED && NVFUSER_DISTRIBUTED
 
 namespace nvfuser {
 

--- a/csrc/multidevice/lower_communication.h
+++ b/csrc/multidevice/lower_communication.h
@@ -28,7 +28,7 @@ std::vector<std::shared_ptr<Communication>> lowerCommunication(
 
 } // namespace nvfuser
 
-#else // USE_DISTRIBTED && NVFUSER_DISTRIBUTED
+#else // NVFUSER_DISTRIBUTED
 
 namespace nvfuser {
 

--- a/csrc/multidevice/pipeline.cpp
+++ b/csrc/multidevice/pipeline.cpp
@@ -156,13 +156,11 @@ class PipelineBuilder final {
         } else {
           // if the Val is a stage input but not a global input, it must be
           // defined by a "Set" operation
-#ifdef USE_DISTRIBUTED
           NVF_ERROR(
               isLowerableToCommunication(val->definition()),
               "A Val that is the input of a stage must be defined by a LoadStoreOp expression of type Set"
               " or a Reduction but here the definition is " +
                   val->definition()->toString());
-#endif
         }
       }
       // Create a PipelineVal for each stage's output

--- a/csrc/multidevice/runtime.cpp
+++ b/csrc/multidevice/runtime.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #include <ATen/cuda/CUDAContext.h>
 #include <device_lower/utils.h>
 #include <fusion_segmenter.h>

--- a/csrc/multidevice/runtime.h
+++ b/csrc/multidevice/runtime.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #pragma once
 
 #include <c10/core/DeviceType.h>

--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,10 @@ def cmake(install_prefix: str = "./nvfuser"):
     if not os.path.exists(cmake_build_dir):
         os.makedirs(cmake_build_dir)
 
-    from tools.gen_nvfuser_version import get_pytorch_cmake_prefix, get_pytorch_use_distributed
+    from tools.gen_nvfuser_version import (
+        get_pytorch_cmake_prefix,
+        get_pytorch_use_distributed,
+    )
 
     # this is used to suppress import error.
     # so we can get the right pytorch prefix for cmake

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@
 #   --build-with-ucc
 #     Build nvfuser with UCC support. You may need to specify environment variables of UCC_HOME, UCC_DIR, UCX_HOME, UCX_DIR.
 #
+#   --build-without-distributed
+#     Build nvfuser without multidevice support
+#
 #   --debug
 #     Building nvfuser in debug mode
 #
@@ -68,6 +71,7 @@ NO_BENCHMARK = False
 NO_NINJA = False
 BUILD_WITH_UCC = False
 BUILD_WITH_ASAN = False
+BUILD_WITHOUT_DISTRIBUTED = False
 PATCH_NVFUSER = True
 OVERWRITE_VERSION = False
 VERSION_TAG = None
@@ -99,6 +103,9 @@ for i, arg in enumerate(sys.argv):
         continue
     if arg == "--build-with-asan":
         BUILD_WITH_ASAN = True
+        continue
+    if arg == "--build-without-distributed":
+        BUILD_WITHOUT_DISTRIBUTED = True
         continue
     if arg == "--debug":
         BUILD_TYPE = "Debug"
@@ -321,6 +328,8 @@ def cmake(install_prefix: str = "./nvfuser"):
         cmd_str.append("-DBUILD_NVFUSER_BENCHMARK=ON")
     if BUILD_WITH_ASAN:
         cmd_str.append("-DNVFUSER_BUILD_WITH_ASAN=ON")
+    if BUILD_WITHOUT_DISTRIBUTED:
+        cmd_str.append("-DNVFUSER_DISTRIBUTED=OFF")
     cmd_str.append(".")
 
     print(f"Configuring CMake with {' '.join(cmd_str)}")

--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ def cmake(install_prefix: str = "./nvfuser"):
     if not os.path.exists(cmake_build_dir):
         os.makedirs(cmake_build_dir)
 
-    from tools.gen_nvfuser_version import get_pytorch_cmake_prefix
+    from tools.gen_nvfuser_version import get_pytorch_cmake_prefix, get_pytorch_use_distributed
 
     # this is used to suppress import error.
     # so we can get the right pytorch prefix for cmake
@@ -304,6 +304,8 @@ def cmake(install_prefix: str = "./nvfuser"):
 
     logger.setLevel(logger_level)
 
+    pytorch_use_distributed = get_pytorch_use_distributed()
+
     # generate cmake directory
     cmd_str = [
         get_cmake_bin(),
@@ -311,6 +313,7 @@ def cmake(install_prefix: str = "./nvfuser"):
         "-DCMAKE_BUILD_TYPE=" + BUILD_TYPE,
         f"-DCMAKE_INSTALL_PREFIX={install_prefix}",
         f"-DNVFUSER_CPP_STANDARD={CPP_STANDARD}",
+        f"-DUSE_DISTRIBUTED={pytorch_use_distributed}",
         "-B",
         cmake_build_dir,
     ]

--- a/test/multidevice.cpp
+++ b/test/multidevice.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #include <ir/all_nodes.h>
 #include <multidevice/pipeline_ir.h>
 #include <multidevice/runtime.h>

--- a/test/multidevice.h
+++ b/test/multidevice.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #pragma once
 
 #include <multidevice/communication.h>

--- a/test/test_multidevice_communications.cpp
+++ b/test/test_multidevice_communications.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #include <gtest/gtest.h>
 
 #include <multidevice/communication.h>

--- a/test/test_multidevice_pipeline.cpp
+++ b/test/test_multidevice_pipeline.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#ifdef USE_DISTRIBUTED
+#ifdef NVFUSER_DISTRIBUTED
 #include <gtest/gtest.h>
 
 #include <codegen.h>

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -44,6 +44,7 @@ def get_pytorch_cmake_prefix():
     stdout_msg, error_msg = process_torch_prefix.communicate()
     return stdout_msg.decode("utf-8").rstrip("\n")
 
+
 def get_pytorch_use_distributed():
     from subprocess import Popen, PIPE
 
@@ -58,6 +59,7 @@ def get_pytorch_use_distributed():
     )
     stdout_msg, error_msg = process_torch_prefix.communicate()
     return stdout_msg.decode("utf-8").rstrip("\n")
+
 
 if __name__ == "__main__":
     version_file = nvfuser_root / "nvfuser" / "version.py"

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -44,6 +44,20 @@ def get_pytorch_cmake_prefix():
     stdout_msg, error_msg = process_torch_prefix.communicate()
     return stdout_msg.decode("utf-8").rstrip("\n")
 
+def get_pytorch_use_distributed():
+    from subprocess import Popen, PIPE
+
+    # need to do this in a separate process so we are not going to delete nvfuser library while it's loaded by torch
+    process_torch_prefix = Popen(
+        [
+            sys.executable,
+            "-c",
+            "import torch; print(torch._C._has_distributed())",
+        ],
+        stdout=PIPE,
+    )
+    stdout_msg, error_msg = process_torch_prefix.communicate()
+    return stdout_msg.decode("utf-8").rstrip("\n")
 
 if __name__ == "__main__":
     version_file = nvfuser_root / "nvfuser" / "version.py"


### PR DESCRIPTION
Adds `NVFUSER_DISTRIBUTED` macro and updates multidevice #ifdef guards to use `NVFUSER_DISTRIBUTED` instead of `USE_DISTRIBUTED`.

This will decouple nvfuser's distributed support from from Pytorch's `USE_DISTRIBUTED` macro so that our CI can build nvfuser without multidevice support.  `NVFUSER_DISTRIBUTED` is dependent `USE_DISTRIBUTED` being defined. 

From `setup.py` add `--build-without-distributed` to build without multidevice support.

FYI @samnordmann 