### PR TITLE
Make nvfuser matmul benchmarks HSH instead of HSS

### DIFF
--- a/benchmark/matmul.cpp
+++ b/benchmark/matmul.cpp
@@ -593,7 +593,7 @@ static std::vector<std::tuple<T, T, T>> sizeProduct(
 static void MatmulShapeEager(
     benchmark::internal::Benchmark* b,
     std::vector<std::tuple<long int, long int, long int>> sizes) {
-  b->ArgNames({"M", "N", "K", "FP16Reduction"});
+  b->ArgNames({"M", "N", "K", "half_reduction"});
   for (auto [m, n, k] : sizes) {
     for (bool allow_half_reduction : {false, true}) {
       b->Args({m, n, k, allow_half_reduction});

--- a/benchmark/matmul.cpp
+++ b/benchmark/matmul.cpp
@@ -55,9 +55,13 @@ void setupMatmul(
 
   auto c = matmul(a, b, layout, turing_or_later);
 
+  // Cast the output so that we perform an HSH matmul, which is what at::matmul
+  // will perform
+  auto d = castOp(DataType::Half, c);
+
   fusion->addInput(a);
   fusion->addInput(b);
-  fusion->addOutput(c);
+  fusion->addOutput(d);
 
   scheduleMatmul(fusion, params);
 }
@@ -207,6 +211,10 @@ static void Baseline_Matmul(
 
   auto inputs =
       matmulAtInput(input_mnk.at(0), input_mnk.at(1), input_mnk.at(2), layout);
+
+  // Disable reduced-precision reduction for fair comparison since we do not use
+  // it in nvFuser
+  at::globalContext().setAllowFP16ReductionCuBLAS(false);
 
   // warm up run
   auto outputs = atMatmul(inputs.first, inputs.second, layout);
@@ -496,7 +504,24 @@ static void NvFuserScheduler_MatmulSplitKReduction(
     {784, 72, 8},        \
     {784, 8, 72},        \
     /* {1, 1, 2048}, */  \
-    {1024, 1024, 1024}   \
+    {1024, 1024, 1024},  \
+    /* NanoGPT bwd sizes */  \
+    {1024, 2048, 4096},      \
+    {1024, 2048, 50304}     \
+  }
+
+#define SplitKSpecificShapes \
+  {                          \
+    /* NanoGPT bwd sizes */  \
+    {1024, 2048, 4096},      \
+    {1024, 2048, 50304},     \
+    /* Symmetric M,N to make comparison in TN/NT fair with eager due to transpose/swap */ \
+    {1024, 1024, 4096},     \
+    {1024, 1024, 50304},     \
+    /* Sizes mentioned by Michel */ \
+    {136, 184, 175704},     \
+    /* Other */ \
+    {128, 128, 262144}     \
   }
 // clang-format on
 
@@ -527,7 +552,7 @@ static std::vector<long int> splitKNs(long int tileN = 128) {
 #define NumWarps \
   { 4, 8 }
 #define NumStages \
-  { 3, 4 }
+  { 3, 4, 5 }
 
 //! Simple cartesian product of three integers. Used to emulate ArgsProduct
 template <typename T>
@@ -597,6 +622,22 @@ static void MatmulShapeWarpStageAutoSplitK(benchmark::internal::Benchmark* b) {
       for (long int n : splitKNs()) {
         for (long int k : SplitKKs) {
           b->Args({m, n, k, num_warps, num_stages});
+        }
+      }
+    }
+  }
+}
+
+// Use this for manual splitk.
+static void MatmulShapeWarpStageSpecificSplitK(
+    benchmark::internal::Benchmark* b) {
+  b->ArgNames({"M", "N", "K", "warps", "stages", "splitk_factor"});
+  for (long int num_warps : NumWarps) {
+    for (long int num_stages : NumStages) {
+      for (auto [m, n, k] :
+           std::vector<std::tuple<int, int, int>>(SplitKSpecificShapes)) {
+        for (auto splitk_factor : {2, 3, 4, 5, 6}) {
+          b->Args({m, n, k, num_warps, num_stages, splitk_factor});
         }
       }
     }
@@ -683,9 +724,27 @@ static void MatmulShapeWarpStageAutoSplitK(benchmark::internal::Benchmark* b) {
       ->UseManualTime()                   \
       ->Apply(MatmulShapeWarpStageAutoSplitK);
 
+static void NvFuserScheduler_Matmul_Manual(
+    benchmark::State& benchmark_state,
+    MmaLayout layout) {
+  int splitk_factor = benchmark_state.range(5);
+  NvFuserScheduler_Matmul(
+      benchmark_state, layout, splitk_factor, /*partitionedk=*/false);
+}
+
+#define SpecificSplitKBenchmark(layout) \
+  BENCHMARK_CAPTURE(                    \
+      NvFuserScheduler_Matmul_Manual,   \
+      nvfuser_splitk_##layout,          \
+      MmaLayout::layout)                \
+      ->Unit(benchmark::kMicrosecond)   \
+      ->UseManualTime()                 \
+      ->Apply(MatmulShapeWarpStageSpecificSplitK);
+
 ForAllLayouts(EagerModeBenchmark);
 ForAllLayouts(NvfuserMatmulBenchmark);
 ForAllLayouts(AutoSplitKBenchmark);
+ForAllLayouts(SpecificSplitKBenchmark);
 ForAllLayouts(AutoPartitionedKBenchmark);
 
 // Note: SplitK Reduction benchmarks are parametrized only by M, N. The splitk


### PR DESCRIPTION
This matches the `at::matmul` baselines.

This PR also adds a few more problem sizes, and runs each eagermode baseline with and without FP16 reduction allowed.