### PR TITLE
Fix squeeze-related errors

### DIFF
--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -232,7 +232,10 @@ TensorView* squeeze(
         to_squeeze.size(),
         " Dim: ",
         dim);
-    to_squeeze[dim] = true;
+    // If a squeeze is attempted on a non-broadcast dimension
+    // just don't do it!  This conforms with Pytorch.
+    IterDomain* id = x_dom[dim];
+    to_squeeze[dim] = id->isBroadcast() && !id->hasExpandedExtent();
   }
 
   return squeeze(x, to_squeeze, squeeze_expanded);

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -204,10 +204,7 @@ TensorView* flatten(TensorView* x, int64_t start_dim, int64_t end_dim) {
   return out;
 }
 
-TensorView* squeeze(
-    TensorView* x,
-    const std::vector<int64_t>& dims,
-    bool squeeze_expanded) {
+TensorView* squeeze(TensorView* x, const std::vector<int64_t>& dims) {
   NVF_ERROR(x != nullptr, "Input is invalid.");
   auto x_dom = x->domain()->noReductions();
   const auto ndims = static_cast<int>(x_dom.size());
@@ -232,14 +229,10 @@ TensorView* squeeze(
         to_squeeze.size(),
         " Dim: ",
         dim);
-    // If a squeeze is attempted on a non-broadcast dimension
-    // just don't do it!  This conforms with Pytorch.
-    IterDomain* id = x_dom[dim];
-    to_squeeze[dim] =
-        id->isSymbolic() || (id->isBroadcast() && !id->hasExpandedExtent());
+    to_squeeze[dim] = true;
   }
 
-  return squeeze(x, to_squeeze, squeeze_expanded);
+  return squeeze(x, to_squeeze);
 }
 
 TensorView* squeeze(

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -235,7 +235,8 @@ TensorView* squeeze(
     // If a squeeze is attempted on a non-broadcast dimension
     // just don't do it!  This conforms with Pytorch.
     IterDomain* id = x_dom[dim];
-    to_squeeze[dim] = id->isBroadcast() && !id->hasExpandedExtent();
+    to_squeeze[dim] =
+        id->isSymbolic() || (id->isBroadcast() && !id->hasExpandedExtent());
   }
 
   return squeeze(x, to_squeeze, squeeze_expanded);

--- a/csrc/ops/alias.h
+++ b/csrc/ops/alias.h
@@ -43,22 +43,17 @@ TensorView* reshape(TensorView* x, const std::vector<Val*>& new_sizes);
 
 TensorView* flatten(TensorView* x, int64_t start_dim = 0, int64_t end_dim = -1);
 
-//! Squeeze the selected dimensions. This function matches PyTorch semantics
-//! when squeeze_expanded=False; that is, if any of the dimensions provided are
-//! non-Broadcast or are expanded Broadcast IterDomains they are ignored and not
-//! squeezed. If squeeze_expanded is true then expanded Broadcast IterDomains
-//! will be squeezed as if the dimension was not expanded.
-TensorView* squeeze(
-    TensorView* x,
-    const std::vector<int64_t>& dims,
-    bool squeeze_expanded = false);
+//! Squeeze the selected dimensions.
+//!
+//! NOTE: This function throws an error when encountering an unsqueezable
+//! dimension. This behavior differs from PyTorch.
+TensorView* squeeze(TensorView* x, const std::vector<int64_t>& dims);
 
 //! Squeeze the dimensions corresponding to "true" in to_squeeze, i.e. remove
 //! those broadcasted dimensions.
 //!
 //! NOTE: This function throws an error when encountering an unsqueezable
-//! dimension, unlike the signature above which will silently ignore such
-//! dimensions.
+//! dimension. This behavior differs from PyTorch.
 //!
 //! If squeeze_expanded is true, then expanded Broadcasts will be removed just
 //! as if they were not expanded. If squeeze_expanded is false, then it is an

--- a/csrc/ops/alias.h
+++ b/csrc/ops/alias.h
@@ -43,22 +43,27 @@ TensorView* reshape(TensorView* x, const std::vector<Val*>& new_sizes);
 
 TensorView* flatten(TensorView* x, int64_t start_dim = 0, int64_t end_dim = -1);
 
-//! This implementation differs from Pytorch where if you attempt to squeeze
-//! a non-broadcast dimension, the squeeze does not do anything to that
-//! dimension and does not trigger an error. Here, we will raise an exception in
-//! such cases. It is also an error to request a squeeze of an expanded
-//! dimension; however, if squeeze_expanded is true then this is allowed and
-//! works just like if the dimension was not expanded.
+//! Squeeze the selected dimensions. This function matches PyTorch semantics
+//! when squeeze_expanded=False; that is, if any of the dimensions provided are
+//! non-Broadcast or are expanded Broadcast IterDomains they are ignored and not
+//! squeezed. If squeeze_expanded is true then expanded Broadcast IterDomains
+//! will be squeezed as if the dimension was not expanded.
 TensorView* squeeze(
     TensorView* x,
     const std::vector<int64_t>& dims,
     bool squeeze_expanded = false);
 
 //! Squeeze the dimensions corresponding to "true" in to_squeeze, i.e. remove
-//! those broadcasted dimension. If squeeze_expanded is true, then expanded
-//! Broadcasts will be removed just as if they were not expanded. If
-//! squeeze_expanded is false, then it is an error for an expanded broadcast to
-//! have a corresponding "true" value in to_squeeze.
+//! those broadcasted dimensions.
+//!
+//! NOTE: This function throws an error when encountering an unsqueezable
+//! dimension, unlike the signature above which will silently ignore such
+//! dimensions.
+//!
+//! If squeeze_expanded is true, then expanded Broadcasts will be removed just
+//! as if they were not expanded. If squeeze_expanded is false, then it is an
+//! error for an expanded broadcast to have a corresponding "true" value in
+//! to_squeeze.
 TensorView* squeeze(
     TensorView* x,
     const std::vector<bool>& to_squeeze,

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1317,11 +1317,8 @@ TensorView* reductionOp(
   for (unsigned int axis : uint_axes) {
     auto id = tv_root[axis];
     if (id->isBroadcast()) {
-      if (!keep_dim || id->hasExpandedExtent()) {
-        // If keep_dim=True, then we will leave this broadcast dimension alone.
-        is_squeeze[axis] = true;
-        offset--;
-      }
+      is_squeeze[axis] = true;
+      offset--;
     } else {
       reduction_axes.push_back((int)axis + offset);
     }
@@ -1363,7 +1360,7 @@ TensorView* reductionOp(
   }
 
   if (keep_dim && offset < 0) {
-    // There were expanded dimensions removed via squeeze that will not be
+    // There were squeezed dimension removed from squeeze that will not be
     // restored by reductionOpRaw above, so we restore them here
     out = broadcast(out, is_squeeze);
   }

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1359,10 +1359,17 @@ TensorView* reductionOp(
     }
   }
 
+  if (keep_dim && offset < 0) {
+    // There were squeezed dimension removed from squeeze that will not be
+    // restored by reductionOpRaw above, so we restore them here
+    out = broadcast(out, is_squeeze);
+  }
+
   if (out == tv) {
     // makes sure that a new tensor is created
     return set(tv);
   }
+
   return out;
 }
 

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1362,6 +1362,12 @@ TensorView* reductionOp(
     }
   }
 
+  if (keep_dim && offset < 0) {
+    // There were expanded dimensions removed via squeeze that will not be
+    // restored by reductionOpRaw above, so we restore them here
+    out = broadcast(out, is_squeeze);
+  }
+
   if (out == tv) {
     // makes sure that a new tensor is created
     return set(tv);

--- a/python_tests/pytest_input_generators.py
+++ b/python_tests/pytest_input_generators.py
@@ -1255,8 +1255,12 @@ def squeeze_generator(
         ((1, 1, 1), (0, 1, 2)),
         ((1, 1, 1), (-3, -2, -1)),
         # No-op test cases
-        ((5, 5, 5), (0, 1, 2)),
-        ((5, 5, 5), (-3, -2, -1)),
+        # NOTE: These are skipped. We diverge from PyTorch behavior for squeeze
+        # in nvFuser. Our squeeze op will throw an exception if we pass a
+        # squeeze dimension that cannot be squeezed.
+        # See https://github.com/NVIDIA/Fuser/pull/1717
+        #((5, 5, 5), (0, 1, 2)),
+        #((5, 5, 5), (-3, -2, -1)),
         ((), ()),
     )
 

--- a/python_tests/pytest_input_generators.py
+++ b/python_tests/pytest_input_generators.py
@@ -1259,8 +1259,8 @@ def squeeze_generator(
         # in nvFuser. Our squeeze op will throw an exception if we pass a
         # squeeze dimension that cannot be squeezed.
         # See https://github.com/NVIDIA/Fuser/pull/1717
-        #((5, 5, 5), (0, 1, 2)),
-        #((5, 5, 5), (-3, -2, -1)),
+        # ((5, 5, 5), (0, 1, 2)),
+        # ((5, 5, 5), (-3, -2, -1)),
         ((), ()),
     )
 

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -3200,20 +3200,22 @@ class TestNvFuserFrontend(TestCase):
     def test_expanded_reduction(self):
         inputs = [torch.tensor(1.0, device="cuda").as_strided((2, 3), (0, 0))]
 
-        def fusion_func(fd: FusionDefinition) -> None:
-            T0 = fd.define_tensor(
-                shape=[-1, -1],
-                contiguity=[None, None],
-                dtype=DataType.Float,
-                is_cpu=False,
-                stride_order=[1, 0],
-            )
-            T1 = fd.ops.sum(T0, axes=[0], keepdim=False, dtype=DataType.Null)
-            fd.add_output(T1)
+        for keepdim in [False, True]:
 
-        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
+            def fusion_func(fd: FusionDefinition) -> None:
+                T0 = fd.define_tensor(
+                    shape=[-1, -1],
+                    contiguity=[None, None],
+                    dtype=DataType.Float,
+                    is_cpu=False,
+                    stride_order=[1, 0],
+                )
+                T1 = fd.ops.sum(T0, axes=[0], keepdim=keepdim, dtype=DataType.Null)
+                fd.add_output(T1)
 
-        self.assertEqual(nvf_out[0], inputs[0].sum(dim=0))
+            nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
+
+            self.assertEqual(nvf_out[0], inputs[0].sum(dim=0, keepdim=keepdim))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes current failures in `pytest_ops.py -k squeeze` and some integration failues.

This restores our previous semantics for squeeze, which **do not match PyTorch**. Namely, if squeeze is provided a dimension that cannot be squeezed, we will always raise an error.