### PR TITLE
Skip executing a kernel if it's empty.

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -330,7 +330,7 @@ void FusionExecutor::compileFusion(
   lowered_ = std::make_unique<GpuLower>(fusion, compile_params);
   lowered_->run();
 
-  const auto kernel = lowered_->kernel();
+  kir::Kernel* kernel = lowered_->kernel();
   for (const auto& hook : post_lowering_hooks_) {
     hook(kernel);
   }
@@ -378,7 +378,7 @@ void FusionExecutor::compileFusion(
     structured_code = getStructuredCode();
   }
 
-  const auto& kernel_summary = kernel->summary();
+  const kir::KernelSummary& kernel_summary = kernel->summary();
 
   // We currently shouldn't allocate any more shared mem
   //  tensors statically but could keep this path if
@@ -1816,7 +1816,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     timer.init();
   }
 
-  if (execute_kernel_) {
+  if (execute_kernel_ && !kernel()->topLevelExprs().empty()) {
     ensureAvailableDynamicSmemSize(executor_entry->launch_params.smem());
 
     std::vector<void*> arg_buffer_ptrs;

--- a/csrc/fusion_profiler.cpp
+++ b/csrc/fusion_profiler.cpp
@@ -628,15 +628,11 @@ void FusionProfiler::stop() {
     NVFUSER_CUPTI_SAFE_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_DRIVER));
     NVFUSER_CUPTI_SAFE_CALL(
         cuptiActivityDisable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION));
+    // This will be populated by the following `cuptiActivityFlushAll` call.
     fp->kernel_profiles_.reserve(fp->segments_.size());
-    fprof.kernel_profiles.resize(fp->segments_.size());
-
     NVFUSER_CUPTI_SAFE_CALL(cuptiActivityFlushAll(0));
 
-    NVF_CHECK(
-        fp->kernel_profiles_.size() >= fp->segments_.size(),
-        "All of the kernel profiles have not been recorded!");
-
+    fprof.kernel_profiles.resize(fp->segments_.size());
     for (auto& kprof : fp->kernel_profiles_) {
       auto corr_id = kprof.correlation_id;
       if (fp->corrid_2_segid_.count(corr_id) == 0) {


### PR DESCRIPTION
I could change `compileFusion` to skip compilation as well. It turned out to be more complicated than I expected, so I took the easier route to skip just execution, which is at least an incremental improvement. 