### PR TITLE
Set IOBytes for benchmarks

### DIFF
--- a/python_benchmarks/core.py
+++ b/python_benchmarks/core.py
@@ -240,7 +240,7 @@ class NVFBenchmark:
     ) -> None:
         """
         Utility function to compute metrics for the target function.
-        
+
         Args:
             inputs: Inputs to the target function
             outputs: Outputs of the target function

--- a/python_benchmarks/core.py
+++ b/python_benchmarks/core.py
@@ -240,6 +240,13 @@ class NVFBenchmark:
     ) -> None:
         """
         Utility function to compute metrics for the target function.
+        
+        Args:
+            inputs: Inputs to the target function
+            outputs: Outputs of the target function
+            iobytes (Optional): When given, IO bytes computation is skipped
+                and this is used to compute the metrics.
+
         Current metrics:
             IOBytes: Total bytes in inputs + outputs
             BytesPerSecond: IOBytes * total_rounds / total_time

--- a/python_benchmarks/test_softmax_bwd.py
+++ b/python_benchmarks/test_softmax_bwd.py
@@ -92,9 +92,7 @@ def test_softmax_bwd_nvf_benchmark(
         fd.validate([eager_output, inputs[1]], [inputs[0].grad])
 
     if not disable_benchmarking:
-        run_benchmark(
-            benchmark, fd.execute, inputs, iobytes=softmax_bwd_iobytes(size, dtype)
-        )
+        run_benchmark(benchmark, fd.execute, inputs)
 
 
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])

--- a/python_benchmarks/test_softmax_fwd.py
+++ b/python_benchmarks/test_softmax_fwd.py
@@ -77,9 +77,7 @@ def test_softmax_fwd_nvf_benchmark(
         fd.validate(inputs, [eager_output])
 
     if not disable_benchmarking:
-        run_benchmark(
-            benchmark, fd.execute, inputs, iobytes=softmax_fwd_iobytes(size, dtype)
-        )
+        run_benchmark(benchmark, fd.execute, inputs)
 
 
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])

--- a/python_benchmarks/test_softmax_fwd.py
+++ b/python_benchmarks/test_softmax_fwd.py
@@ -4,6 +4,7 @@ from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+import numpy as np
 
 
 def softmax_fwd_fusion(
@@ -48,6 +49,11 @@ def softmax_fwd_fn(inputs: list):  # [in_tensor, reduction_axis]
     return torch.nn.functional.softmax(inputs[0], inputs[1])
 
 
+def softmax_fwd_iobytes(size: tuple, dtype: torch.dtype):
+    # Total IO bytes = input + output
+    return int(np.prod(size) * dtype.itemsize * 2)
+
+
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0, 1])
@@ -71,7 +77,9 @@ def test_softmax_fwd_nvf_benchmark(
         fd.validate(inputs, [eager_output])
 
     if not disable_benchmarking:
-        run_benchmark(benchmark, fd.execute, inputs)
+        run_benchmark(
+            benchmark, fd.execute, inputs, iobytes=softmax_fwd_iobytes(size, dtype)
+        )
 
 
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
@@ -87,8 +95,10 @@ def test_softmax_fwd_baseline_benchmark(
 ):
     clear_cuda_cache()
     input = torch.randn(size, device="cuda", dtype=dtype)
+
     run_benchmark(
         benchmark,
         torch.compile(softmax_fwd_fn) if compile else softmax_fwd_fn,
         [input, reduction_axis],
+        iobytes=softmax_fwd_iobytes(size, dtype),
     )


### PR DESCRIPTION
For uniformity of IO bytes, and compairson between nvFuser and baselines of `eager` and `torch.compile` mode, set the IO bytes instead of computing based on inputs / outputs of the benchmarked function. 

The inputs / outputs to the torch functions may not always be the same as nvFuser.
For instance, in `layernorm fwd`, nvFuser definition returns the `mean` and `invstd`, but `torch.nn.functional.layer_norm` does not.
 
