### PR TITLE
Rename `AliasType` -> `AllocationType`

### DIFF
--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1516,7 +1516,7 @@ void ExprSegmentationSorter::sort() {
       std::back_inserter(non_pointer_arithmetic_outs),
       [this](Val* out) {
         return fusion_->getOutputAlias(out).type !=
-            AliasType::PointerArithmetic;
+            AllocationType::PointerArithmetic;
       });
 
   // Not putting the exprs between fusion inputs and allKnownVals() here

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -939,7 +939,7 @@ at::Tensor allocateOutput(
     return ee.evaluate(out_tv).as<at::Tensor>();
   }
 
-  if (alias_info.type == AliasType::NoAlias) {
+  if (alias_info.type == AllocationType::NoAlias) {
     auto alloc_tensor = at::native::empty_strided_cuda(
         out_info.sizes,
         out_info.strides,
@@ -956,7 +956,7 @@ at::Tensor allocateOutput(
   Val* aliased_io = alias_info.aliased_io;
   NVF_ERROR(
       aliased_io != nullptr,
-      "The other two AliasTypes currently must have an `aliased_io`.");
+      "The other two AllocationTypes currently must have an `aliased_io`.");
   NVF_ERROR(
       aliased_io->isFusionInput() || aliased_io->isFusionOutput(),
       aliased_io->toInlineString(),
@@ -970,8 +970,8 @@ at::Tensor allocateOutput(
       PolymorphicValue_functions::toString(aliased_io_val));
   auto aliased_io_tensor = aliased_io_val.as<at::Tensor>();
 
-  if (alias_info.type == AliasType::InplaceUpdate) {
-    // Unlike for `AliasType::PointerArithmetic`, don't use
+  if (alias_info.type == AllocationType::InplaceUpdate) {
+    // Unlike for `AllocationType::PointerArithmetic`, don't use
     // ExpressionEvaluator to compute the output tensor. This is because
     // the output tensor may hold different data from the input, e.g., an
     // updated running mean.  `ExpressionEvaluator::evaluate(out_tv)`
@@ -979,7 +979,7 @@ at::Tensor allocateOutput(
     return aliased_io_tensor;
   }
 
-  NVF_ERROR(alias_info.type == AliasType::PointerArithmetic);
+  NVF_ERROR(alias_info.type == AllocationType::PointerArithmetic);
   at::Tensor out_tensor = ee.evaluate(out_tv).as<at::Tensor>();
   NVF_ERROR(
       out_tensor.is_alias_of(aliased_io_tensor),
@@ -1027,8 +1027,8 @@ std::vector<at::Tensor> allocateOutputs(
           const std::pair<int64_t, Val*>& lhs,
           const std::pair<int64_t, Val*>& rhs) {
         return (
-            kernel->getOutputAlias(lhs.second).type == AliasType::NoAlias &&
-            kernel->getOutputAlias(rhs.second).type != AliasType::NoAlias);
+            kernel->getOutputAlias(lhs.second).type == AllocationType::NoAlias &&
+            kernel->getOutputAlias(rhs.second).type != AllocationType::NoAlias);
       });
 
   std::vector<at::Tensor> out_tensors(num_outs);

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1027,7 +1027,8 @@ std::vector<at::Tensor> allocateOutputs(
           const std::pair<int64_t, Val*>& lhs,
           const std::pair<int64_t, Val*>& rhs) {
         return (
-            kernel->getOutputAlias(lhs.second).type == AllocationType::NoAlias &&
+            kernel->getOutputAlias(lhs.second).type ==
+                AllocationType::NoAlias &&
             kernel->getOutputAlias(rhs.second).type != AllocationType::NoAlias);
       });
 

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -768,7 +768,10 @@ bool Fusion::isAliasCompatible(Val* left, Val* right) {
   return true;
 }
 
-void Fusion::aliasOutputToInput(Val* output, Val* input, const AllocationType type) {
+void Fusion::aliasOutputToInput(
+    Val* output,
+    Val* input,
+    const AllocationType type) {
   NVF_CHECK(
       type != AllocationType::NoAlias,
       "NoAlias is returned automatically for a missing key. Don't add it explicitly.");
@@ -813,7 +816,9 @@ void Fusion::aliasOutputToInput(Val* output, Val* input, const AllocationType ty
 
 const AliasInfo& Fusion::getOutputAlias(Val* output) const {
   static AliasInfo no_alias_info{
-      .type = AllocationType::NoAlias, .aliased_io = nullptr, .hide_output = false};
+      .type = AllocationType::NoAlias,
+      .aliased_io = nullptr,
+      .hide_output = false};
   if (auto search = io_alias_.find(output); search != io_alias_.end()) {
     return search->second;
   }

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -768,12 +768,12 @@ bool Fusion::isAliasCompatible(Val* left, Val* right) {
   return true;
 }
 
-void Fusion::aliasOutputToInput(Val* output, Val* input, const AliasType type) {
+void Fusion::aliasOutputToInput(Val* output, Val* input, const AllocationType type) {
   NVF_CHECK(
-      type != AliasType::NoAlias,
+      type != AllocationType::NoAlias,
       "NoAlias is returned automatically for a missing key. Don't add it explicitly.");
 
-  if (type == AliasType::InplaceUpdate) {
+  if (type == AllocationType::InplaceUpdate) {
     // `input` can be a cast of a fusion input.
     if (!input->isFusionInput()) {
       auto input_expr = input->definition();
@@ -813,7 +813,7 @@ void Fusion::aliasOutputToInput(Val* output, Val* input, const AliasType type) {
 
 const AliasInfo& Fusion::getOutputAlias(Val* output) const {
   static AliasInfo no_alias_info{
-      .type = AliasType::NoAlias, .aliased_io = nullptr, .hide_output = false};
+      .type = AllocationType::NoAlias, .aliased_io = nullptr, .hide_output = false};
   if (auto search = io_alias_.find(output); search != io_alias_.end()) {
     return search->second;
   }

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -86,7 +86,7 @@ class FusionGuard {
 
 // Set the enum base to `int` so it can be safely serialized as a part of
 // serde::InputOutputAlias.
-enum class AliasType : int {
+enum class AllocationType : int {
   NoAlias,
   // For example, the tensor storing BatchNorm's running mean. The output EMA is
   // updated in place.
@@ -98,7 +98,7 @@ enum class AliasType : int {
 };
 
 struct AliasInfo {
-  AliasType type;
+  AllocationType type;
   Val* aliased_io;
   // Whether integration should hide the output from users. This is currently
   // only used for InplaceUpdate.
@@ -248,7 +248,7 @@ class Fusion : public IrContainer {
   // the input tensor to the section where output is produced. Currently,
   // aliases of type `PointerArithmetics` are marked after segmentation, but
   // those of type `InplaceUpdate` are marked in fusion definitions.
-  void aliasOutputToInput(Val* output, Val* input, AliasType type);
+  void aliasOutputToInput(Val* output, Val* input, AllocationType type);
 
   //! Returns the aliased input of a given output along with an `AliasInfo`
   //! describing how they alias. Returns <nullptr,nullptr> when `output` is not

--- a/csrc/ops/normalization.cpp
+++ b/csrc/ops/normalization.cpp
@@ -559,19 +559,19 @@ ForwardNormResult batch_norm(
         auto cast_output = castOp(*rm_dtype, aliased_output);
 
         fusion->aliasOutputToInput(
-            cast_output, input_to_cast, AliasType::InplaceUpdate);
+            cast_output, input_to_cast, AllocationType::InplaceUpdate);
       };
 
       if (running_mean->isFusionInput()) {
         fusion->aliasOutputToInput(
-            new_mean_hat, running_mean, AliasType::InplaceUpdate);
+            new_mean_hat, running_mean, AllocationType::InplaceUpdate);
       } else {
         cast_to_input_dtype(running_mean, new_mean_hat);
       }
 
       if (running_var->isFusionInput()) {
         fusion->aliasOutputToInput(
-            new_var_hat, running_var, AliasType::InplaceUpdate);
+            new_var_hat, running_var, AllocationType::InplaceUpdate);
       } else {
         cast_to_input_dtype(running_var, new_var_hat);
       }
@@ -809,7 +809,7 @@ ForwardNormResult instance_norm(
             castOp(running_mean->getDataType().value(), new_mean_channels_only);
       }
       fusion->aliasOutputToInput(
-          new_mean_channels_only, running_mean, AliasType::InplaceUpdate);
+          new_mean_channels_only, running_mean, AllocationType::InplaceUpdate);
 
       auto num_feature_decrement = sub(N, x->container()->oneVal(N->dtype()));
       auto unbiased_var =
@@ -828,7 +828,7 @@ ForwardNormResult instance_norm(
             castOp(running_var->getDataType().value(), new_var_channels_only);
       }
       fusion->aliasOutputToInput(
-          new_var_channels_only, running_var, AliasType::InplaceUpdate);
+          new_var_channels_only, running_var, AllocationType::InplaceUpdate);
     }
 
     mean = welford_out.avg;

--- a/csrc/python_frontend/fusion_state.cpp
+++ b/csrc/python_frontend/fusion_state.cpp
@@ -161,9 +161,9 @@ void FusionState::addOutput(
 
 void FusionState::aliasOutputToInput(Val* output, Val* input) {
   NVF_CHECK(fusion_ != nullptr, "Fusion is undefined.");
-  // We haven't exposed AliasType to Python API. For now, use
+  // We haven't exposed AllocationType to Python API. For now, use
   // InplaceUpdate to preserve the old behavior.
-  fusion_->aliasOutputToInput(output, input, AliasType::InplaceUpdate);
+  fusion_->aliasOutputToInput(output, input, AllocationType::InplaceUpdate);
 }
 
 } // namespace nvfuser::python_frontend

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -38,7 +38,8 @@ void markAliases(Fusion* fusion) {
       continue;
     }
 
-    fusion->aliasOutputToInput(out, aliased_io, AllocationType::PointerArithmetic);
+    fusion->aliasOutputToInput(
+        out, aliased_io, AllocationType::PointerArithmetic);
     vlog(
         "Marked ",
         ir_utils::varName(out),

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -38,7 +38,7 @@ void markAliases(Fusion* fusion) {
       continue;
     }
 
-    fusion->aliasOutputToInput(out, aliased_io, AliasType::PointerArithmetic);
+    fusion->aliasOutputToInput(out, aliased_io, AllocationType::PointerArithmetic);
     vlog(
         "Marked ",
         ir_utils::varName(out),

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -1066,7 +1066,7 @@ TEST_F(AliasTest, InPlaceUpdateAliasAcrossSegments) {
   TensorView* tv6 = add(tv5, tv2); //  Group 1 (Broadcast after reduce)
 
   // Note: test alias;
-  fusion->aliasOutputToInput(tv6, tv0, AliasType::InplaceUpdate);
+  fusion->aliasOutputToInput(tv6, tv0, AllocationType::InplaceUpdate);
   // TODO: support output on aliased fusion #1488
   // remove tv7 after #1488
   // fusion->addOutput(tv6);


### PR DESCRIPTION
This PR is strictly for renaming `AliasType` -> `AllocationType`.
Follows PR #1687.

The next PR will add `AllocationType::Evaluate` to mark Mma outputs to be evaluated through expression evaluator.
