### PR TITLE
Make `MmaOp::evaluate` return output of the same dtype as `MmaOp`

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2111,7 +2111,11 @@ std::vector<PolymorphicValue> MmaOp::evaluate(
 
   // After removing the broadcast dimensions, the format should be
   // [M, K] x [K, N] compatible with aten::matmul format.
-  return {in_a.matmul(in_b)};
+  auto output = in_a.matmul(in_b);
+  if (tv_a->getDataType() != out()->getDataType().value()) {
+    output = output.to(data_type_to_aten(out()->getDataType().value()));
+  }
+  return {output};
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(MmaOp)

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2115,6 +2115,11 @@ std::vector<PolymorphicValue> MmaOp::evaluate(
 
   // ATen preserves the input dtype whereas MmaOP generates float outputs.
   // Cast to the dtype of the MmaOp output for consistency.
+  // NOTE: MmaOp returns the float output, whereas in the evaluate method,
+  //      we are casting from float -> input_dtype -> float. This will lead
+  //      to loss of precision.
+  //      MmaOp::evaluate should be modified to effectively handle cast(MmaOp(H,
+  //      H), H) This will avoid the above cast chain and precision issue.
   if (tv_a->getDataType() != out()->getDataType().value()) {
     output = output.to(data_type_to_aten(out()->getDataType().value()));
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2112,6 +2112,9 @@ std::vector<PolymorphicValue> MmaOp::evaluate(
   // After removing the broadcast dimensions, the format should be
   // [M, K] x [K, N] compatible with aten::matmul format.
   auto output = in_a.matmul(in_b);
+
+  // ATen preserves the input dtype whereas MmaOP generates float outputs.
+  // Cast to the dtype of the MmaOp output for consistency.
   if (tv_a->getDataType() != out()->getDataType().value()) {
     output = output.to(data_type_to_aten(out()->getDataType().value()));
   }

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -696,15 +696,13 @@ TEST_F(ExprEvalTest, MmaOp) {
 
   at::Tensor in_a = at::ones(a_shape, at::kHalf).cuda();
   at::Tensor in_b = at::ones(b_shape, at::kHalf).cuda();
-  at::Tensor out_ref = k * at::ones(out_shape, at::kHalf).cuda();
+  auto out_dtype = data_type_to_aten(tv2->getDataType().value());
+  at::Tensor out_ref = k * at::ones(out_shape, out_dtype).cuda();
 
   ExpressionEvaluator evaluator;
   evaluator.bind(tv0, in_a);
   evaluator.bind(tv1, in_b);
   at::Tensor out = evaluator.evaluate(tv2).as<at::Tensor>();
-  NVF_CHECK(out_ref.equal(out));
-
-  auto ref_dtype = data_type_to_aten(tv2->getDataType().value());
-  NVF_CHECK(out.dtype() == ref_dtype);
+  EXPECT_TRUE(at::allclose(out, out_ref));
 }
 } // namespace nvfuser

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -703,5 +703,8 @@ TEST_F(ExprEvalTest, MmaOp) {
   evaluator.bind(tv1, in_b);
   at::Tensor out = evaluator.evaluate(tv2).as<at::Tensor>();
   NVF_CHECK(out_ref.equal(out));
+
+  auto ref_dtype = data_type_to_aten(tv2->getDataType().value());
+  NVF_CHECK(out.dtype() == ref_dtype);
 }
 } // namespace nvfuser

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -696,8 +696,7 @@ TEST_F(ExprEvalTest, MmaOp) {
 
   at::Tensor in_a = at::ones(a_shape, at::kHalf).cuda();
   at::Tensor in_b = at::ones(b_shape, at::kHalf).cuda();
-  auto out_dtype = data_type_to_aten(tv2->getDataType().value());
-  at::Tensor out_ref = k * at::ones(out_shape, out_dtype).cuda();
+  at::Tensor out_ref = at::full(out_shape, k, at::kFloat).cuda();
 
   ExpressionEvaluator evaluator;
   evaluator.bind(tv0, in_a);


### PR DESCRIPTION
`MmaOp::evaluate` should return output with the same dtype as the `MmaOp->out()` for consistency.
