### PR TITLE
Add benchmarks for RoPE.

### DIFF
--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -718,13 +718,15 @@ struct BroadcastInDimOpRecord : RecordFunctor {
     const auto arg_ndims = arg_domains_nr.size();
     NVF_CHECK(
         output_ndims_ >= arg_ndims,
-        "The new shape is expected to be greater-then-or-equal to the input",
+        "The new shape is expected to be greater-then-or-equal to the input: ",
         output_ndims_,
+        " vs ",
         arg_ndims);
     NVF_CHECK(
         arg_ndims == broadcast_dims_.size(),
-        "The broadcast dimensions should match the input dimensions.",
+        "The broadcast dimensions should match the input dimensions: ",
         arg_ndims,
+        " vs ",
         broadcast_dims_.size());
 
     std::vector<bool> is_broadcast_dim(output_ndims_, true);

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -738,7 +738,7 @@ void initNvFuserPythonBindings(PyObject* module) {
                 if (dim_size == 1) {
                   contiguity.emplace_back(std::nullopt);
                 } else {
-                  contiguity.emplace_back(true);
+                  contiguity.emplace_back(false);
                 }
               }
             }

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -713,10 +713,10 @@ void initNvFuserPythonBindings(PyObject* module) {
       .def(
           "define_tensor",
           [](FusionDefinition& self,
-             std::vector<int64_t>& shape,
-             std::vector<std::optional<bool>>& contiguity,
-             PrimDataType dtype = DataType::Float,
-             bool is_cpu = false,
+             const std::vector<int64_t>& shape,
+             std::vector<std::optional<bool>> contiguity = {},
+             const PrimDataType dtype = DataType::Float,
+             const bool is_cpu = false,
              std::vector<int64_t> stride_order = {}) -> Tensor {
             FUSER_PERF_SCOPE("FusionDefinition.define_tensor (default)");
             NVF_CHECK(
@@ -733,6 +733,16 @@ void initNvFuserPythonBindings(PyObject* module) {
                   " was neither symbolic(-1), zero_element(0), broadcast(1), or static(>1).");
             }
 
+            if (contiguity.empty()) {
+              for (const auto dim_size : shape) {
+                if (dim_size == 1) {
+                  contiguity.push_back(std::nullopt);
+                } else {
+                  contiguity.emplace_back(true);
+                }
+              }
+            }
+
             Tensor out = self.defineTensor(shape.size());
             self.defineRecord(new TensorRecord(
                 {self.recordingState(out())},
@@ -745,7 +755,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             return out;
           },
           py::arg("shape"),
-          py::arg("contiguity"),
+          py::arg("contiguity") = py::list(),
           py::arg("dtype") = DataType::Float,
           py::arg("is_cpu") = false,
           py::arg("stride_order") = py::list(),

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -736,7 +736,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             if (contiguity.empty()) {
               for (const auto dim_size : shape) {
                 if (dim_size == 1) {
-                  contiguity.push_back(std::nullopt);
+                  contiguity.emplace_back(std::nullopt);
                 } else {
                   contiguity.emplace_back(true);
                 }

--- a/python_benchmarks/test_rope.py
+++ b/python_benchmarks/test_rope.py
@@ -1,0 +1,94 @@
+import pytest
+from nvfuser import FusionDefinition, DataType
+from .core import run_benchmark, clear_cuda_cache
+import torch
+
+
+def rope_fusion(fd: FusionDefinition) -> None:
+    q = fd.define_tensor(
+        shape=[32, 4096, 32, 128],
+        dtype=DataType.BFloat16,
+    )
+    cos = fd.define_tensor(
+        shape=[4096, 128],
+        dtype=DataType.BFloat16,
+    )
+    sin = fd.define_tensor(
+        shape=[4096, 128],
+        dtype=DataType.BFloat16,
+    )
+
+    q = fd.ops.permute(q, dims=[0, 2, 1, 3])
+    q_left = fd.ops.slice(
+        q,
+        start_indices=[0, 0, 0, 0],
+        end_indices=[32, 32, 4096, 64],
+        strides=[1, 1, 1, 1],
+    )
+    q_right = fd.ops.slice(
+        q,
+        start_indices=[0, 0, 0, 64],
+        end_indices=[32, 32, 4096, 128],
+        strides=[1, 1, 1, 1],
+    )
+
+    q_right = fd.ops.cast(q_right, dtype=DataType.Float)
+    q_right = -q_right
+    q_right = fd.ops.cast(q_right, dtype=DataType.BFloat16)
+
+    q_rotated = fd.ops.cat([q_right, q_left], dim=-1)
+
+    cos = fd.ops.broadcast_in_dim(
+        cos, shape=[1, 1, 4096, 128], broadcast_dims=[2, 3]
+    )
+    sin = fd.ops.broadcast_in_dim(
+        sin, shape=[1, 1, 4096, 128], broadcast_dims=[2, 3]
+    )
+    fd.add_output(q * cos + q_rotated * sin)
+
+
+# Idea from @nikitaved. We `cat` (or `stack` to be precise) the embeddings, which are constant, and don't `cat` in the fusion.
+def rope_without_cat_fusion(fd: FusionDefinition) -> None:
+    q = fd.define_tensor(
+        shape=[32, 4096, 32, 128],
+        dtype=DataType.BFloat16,
+    )
+    cos_sin_matrix = fd.define_tensor(
+        shape=[4096, 2, 64, 2],
+        dtype=DataType.BFloat16,
+    )
+
+    q = fd.ops.reshape(q, new_shape=[32, 4096, 32, 2, 64])
+    q = fd.ops.permute(q, dims=[0, 2, 1, 4, 3])
+    q = fd.ops.broadcast_in_dim(q, shape=[32, 32, 4096, 1, 64, 2], broadcast_dims=[0, 1, 2, 4, 5])
+
+    cos_sin_matrix = fd.ops.broadcast_in_dim(cos_sin_matrix, shape=[32, 32, 4096, 2, 64, 2], broadcast_dims=[2, 3, 4, 5])
+
+    out = fd.ops.sum(q * cos_sin_matrix, [-1])
+    out = fd.ops.reshape(out, new_shape=[32, 32, 4096, 128])
+    fd.add_output(out)
+
+
+def test_rope_benchmark(benchmark, disable_validation: bool, disable_benchmarking: bool):
+    clear_cuda_cache()
+
+    with FusionDefinition() as fd:
+        rope_fusion(fd)
+
+    q = torch.randn(32, 4096, 32, 128, dtype=torch.bfloat16, device="cuda:0")
+    freqs = torch.randn(4096, 64, dtype=torch.bfloat16, device="cuda:0")
+    emb = torch.concat([freqs, freqs], dim=-1)
+    inputs = [q, emb.cos(), emb.sin()]
+
+    if not disable_validation:
+        with FusionDefinition() as fd_ref:
+            rope_without_cat_fusion(fd_ref)
+
+        cos_and_minus_sin = torch.stack([freqs.cos(), -freqs.sin()], dim=-1)
+        sin_and_cos = torch.stack([freqs.sin(), freqs.cos()], dim=-1)
+        cos_sin_matrix = torch.stack([cos_and_minus_sin, sin_and_cos], dim=1)
+        rope_without_cat_out = fd_ref.execute([q, cos_sin_matrix])
+        fd.validate(inputs, rope_without_cat_out)
+
+    if not disable_benchmarking:
+        run_benchmark(benchmark, fd.execute, inputs)

--- a/python_benchmarks/test_rope.py
+++ b/python_benchmarks/test_rope.py
@@ -4,91 +4,181 @@ from .core import run_benchmark, clear_cuda_cache
 import torch
 
 
-def rope_fusion(fd: FusionDefinition) -> None:
+# Mimic the Hugging Face implementation:
+# https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L216
+def rope_with_cat_fusion(
+    fd: FusionDefinition,
+    batch_size: int,
+    seq_len: int,
+    num_heads: int,
+    features_per_head: int,
+) -> None:
     q = fd.define_tensor(
-        shape=[32, 4096, 32, 128],
+        shape=[batch_size, seq_len, num_heads, features_per_head],
         dtype=DataType.BFloat16,
     )
     cos = fd.define_tensor(
-        shape=[4096, 128],
+        shape=[seq_len, features_per_head],
         dtype=DataType.BFloat16,
     )
     sin = fd.define_tensor(
-        shape=[4096, 128],
+        shape=[seq_len, features_per_head],
         dtype=DataType.BFloat16,
     )
 
     q = fd.ops.permute(q, dims=[0, 2, 1, 3])
-    q_left = fd.ops.slice(
+    q_real = fd.ops.slice(
         q,
         start_indices=[0, 0, 0, 0],
-        end_indices=[32, 32, 4096, 64],
+        end_indices=[batch_size, num_heads, seq_len, features_per_head // 2],
         strides=[1, 1, 1, 1],
     )
-    q_right = fd.ops.slice(
+    q_image = fd.ops.slice(
         q,
-        start_indices=[0, 0, 0, 64],
-        end_indices=[32, 32, 4096, 128],
+        start_indices=[0, 0, 0, features_per_head // 2],
+        end_indices=[batch_size, num_heads, seq_len, features_per_head],
         strides=[1, 1, 1, 1],
     )
 
-    q_right = fd.ops.cast(q_right, dtype=DataType.Float)
-    q_right = -q_right
-    q_right = fd.ops.cast(q_right, dtype=DataType.BFloat16)
+    # nvFuser has problems generating negation for bfloat.
+    q_image = fd.ops.cast(q_image, dtype=DataType.Float)
+    q_image = -q_image
+    q_image = fd.ops.cast(q_image, dtype=DataType.BFloat16)
 
-    q_rotated = fd.ops.cat([q_right, q_left], dim=-1)
+    q_rotated = fd.ops.cat([q_image, q_real], dim=-1)
 
     cos = fd.ops.broadcast_in_dim(
-        cos, shape=[1, 1, 4096, 128], broadcast_dims=[2, 3]
+        cos, shape=[1, 1, seq_len, features_per_head], broadcast_dims=[2, 3]
     )
     sin = fd.ops.broadcast_in_dim(
-        sin, shape=[1, 1, 4096, 128], broadcast_dims=[2, 3]
-    )
-    fd.add_output(q * cos + q_rotated * sin)
-
-
-# Idea from @nikitaved. We `cat` (or `stack` to be precise) the embeddings, which are constant, and don't `cat` in the fusion.
-def rope_without_cat_fusion(fd: FusionDefinition) -> None:
-    q = fd.define_tensor(
-        shape=[32, 4096, 32, 128],
-        dtype=DataType.BFloat16,
-    )
-    cos_sin_matrix = fd.define_tensor(
-        shape=[4096, 2, 64, 2],
-        dtype=DataType.BFloat16,
+        sin, shape=[1, 1, seq_len, features_per_head], broadcast_dims=[2, 3]
     )
 
-    q = fd.ops.reshape(q, new_shape=[32, 4096, 32, 2, 64])
-    q = fd.ops.permute(q, dims=[0, 2, 1, 4, 3])
-    q = fd.ops.broadcast_in_dim(q, shape=[32, 32, 4096, 1, 64, 2], broadcast_dims=[0, 1, 2, 4, 5])
-
-    cos_sin_matrix = fd.ops.broadcast_in_dim(cos_sin_matrix, shape=[32, 32, 4096, 2, 64, 2], broadcast_dims=[2, 3, 4, 5])
-
-    out = fd.ops.sum(q * cos_sin_matrix, [-1])
-    out = fd.ops.reshape(out, new_shape=[32, 32, 4096, 128])
+    out = q * cos + q_rotated * sin
+    out = fd.ops.cast(out, DataType.BFloat16)
     fd.add_output(out)
 
 
-def test_rope_benchmark(benchmark, disable_validation: bool, disable_benchmarking: bool):
+# Idea from @nikitaved: we split and concatenate the embeddings instead of `q`.
+# The embeddings are constant that can be precomputed. So we pay the overhead
+# of split and concatenation only once. The actual forward pass is merely
+# elementwise+reduction surrounded by some meta ops.
+def rope_without_cat_fusion(
+    fd: FusionDefinition,
+    batch_size: int,  # B
+    seq_len: int,  # S
+    num_heads: int,  # H
+    features_per_head: int,  # F
+) -> None:
+    q = fd.define_tensor(
+        shape=[batch_size, seq_len, num_heads, features_per_head],
+        dtype=DataType.BFloat16,
+    )
+    # `cos_sin_matrix` is essentially a batch (of size S*F/2) of 2x2 matrices
+    # laid out in a special way to keep computation simple.
+    #
+    # Using the notations in Figure 1 in https://arxiv.org/pdf/2104.09864.pdf,
+    # cos_sin_matrix[0] contains the following:
+    #
+    #   cos(θ_1),   -sin(θ1)
+    #   cos(θ_2),   -sin(θ2)
+    #   ...
+    #   cos(θ_F/2), -sin(θ_F/2)
+    #   ------------------------
+    #   sin(θ_1),   cos(θ_1)
+    #   sin(θ_2),   cos(θ_2)
+    #   ...
+    #   sin(θ_F/2), cos(θ_F/2)
+    #
+    # cos_sin_matrix[i] is similar but each θ is multiplied by `i+1`.
+    cos_sin_matrix = fd.define_tensor(
+        shape=[seq_len, 2, features_per_head // 2, 2],
+        dtype=DataType.BFloat16,
+    )
+
+    q = fd.ops.reshape(
+        q, new_shape=[batch_size, seq_len, num_heads, 2, features_per_head // 2]
+    )
+    q = fd.ops.permute(q, dims=[0, 2, 1, 4, 3])
+    q = fd.ops.broadcast_in_dim(
+        q,
+        shape=[batch_size, num_heads, seq_len, 1, features_per_head // 2, 2],
+        broadcast_dims=[0, 1, 2, 4, 5],
+    )
+
+    cos_sin_matrix = fd.ops.broadcast_in_dim(
+        cos_sin_matrix,
+        shape=[batch_size, num_heads, seq_len, 2, features_per_head // 2, 2],
+        broadcast_dims=[2, 3, 4, 5],
+    )
+
+    out = fd.ops.sum(q * cos_sin_matrix, [-1])
+    out = fd.ops.cast(out, DataType.BFloat16)
+    out = fd.ops.reshape(
+        out, new_shape=[batch_size, num_heads, seq_len, features_per_head]
+    )
+    fd.add_output(out)
+
+
+@pytest.mark.parametrize("use_cat", [True, False], ids=["with_cat", "without_cat"])
+def test_rope_benchmark(
+    benchmark, use_cat: bool, disable_validation: bool, disable_benchmarking: bool
+):
     clear_cuda_cache()
 
-    with FusionDefinition() as fd:
-        rope_fusion(fd)
+    batch_size = 32
+    seq_len = 4096
+    num_heads = 32
+    features_per_head = 128
 
-    q = torch.randn(32, 4096, 32, 128, dtype=torch.bfloat16, device="cuda:0")
-    freqs = torch.randn(4096, 64, dtype=torch.bfloat16, device="cuda:0")
-    emb = torch.concat([freqs, freqs], dim=-1)
-    inputs = [q, emb.cos(), emb.sin()]
+    # torch.manual_seed(0)
+    q = torch.randn(
+        batch_size,
+        seq_len,
+        num_heads,
+        features_per_head,
+        dtype=torch.bfloat16,
+        device="cuda:0",
+    )
+    freqs = torch.randn(
+        seq_len, features_per_head // 2, dtype=torch.bfloat16, device="cuda:0"
+    )
+    cos = freqs.cos()
+    sin = freqs.sin()
+
+    if use_cat:
+        with FusionDefinition() as fd:
+            rope_with_cat_fusion(fd, batch_size, seq_len, num_heads, features_per_head)
+        inputs = [q, torch.cat([cos, cos], dim=-1), torch.cat([sin, sin], dim=-1)]
+    else:
+        with FusionDefinition() as fd:
+            rope_without_cat_fusion(
+                fd, batch_size, seq_len, num_heads, features_per_head
+            )
+        # [S, F/2, 2]
+        cos_and_minus_sin = torch.stack([cos, -sin], dim=-1)
+        # [S, F/2, 2]
+        sin_and_cos = torch.stack([sin, cos], dim=-1)
+        # [S, 2, F/2, 2]
+        cos_sin_matrix = torch.stack([cos_and_minus_sin, sin_and_cos], dim=1)
+        inputs = [q, cos_sin_matrix]
 
     if not disable_validation:
-        with FusionDefinition() as fd_ref:
-            rope_without_cat_fusion(fd_ref)
-
-        cos_and_minus_sin = torch.stack([freqs.cos(), -freqs.sin()], dim=-1)
-        sin_and_cos = torch.stack([freqs.sin(), freqs.cos()], dim=-1)
-        cos_sin_matrix = torch.stack([cos_and_minus_sin, sin_and_cos], dim=1)
-        rope_without_cat_out = fd_ref.execute([q, cos_sin_matrix])
-        fd.validate(inputs, rope_without_cat_out)
+        q_real, q_image = q.permute([0, 2, 1, 3]).split(features_per_head // 2, dim=-1)
+        q_real = q_real.to(torch.float32)
+        q_image = q_image.to(torch.float32)
+        ref_out = torch.cat(
+            [q_real * cos - q_image * sin, q_image * cos + q_real * sin], dim=-1
+        ).to(torch.bfloat16)
+        nvf_out = fd.execute(inputs)
+        if use_cat:
+            # For unknown reasons, rope_with_cat_fusion produces slightly off
+            # numbers. It looks like a problem with cast-to-bfloat, because when
+            # I removed the fd.ops.cast in the end of that fusion, the results
+            # were bit-exact as the reference output.
+            torch.testing.assert_close(nvf_out, [ref_out], atol=0.01, rtol=0.01)
+        else:
+            torch.testing.assert_close(nvf_out, [ref_out], atol=0, rtol=0)
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, inputs)


### PR DESCRIPTION
This PR adds two implementations of the RoPE module and benchmarks them for #1597.

`rope_with_cat_fusion` mimics the Hugging Face implementation. `rope_without_cat_fusion` implements an idea from @nikitaved to avoid concatenation. Even though it looks difficult for the compiler to do it all automatically, it's still useful to keep a record of the idea. 

As a side change, I made `fd.define_tensor` to accept empty contiguity. 