### PR TITLE
Matmul default scheduling [1]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,7 +425,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/test/test_id_model.cpp
   ${NVFUSER_ROOT}/test/test_double_buffering.cpp
   ${NVFUSER_ROOT}/test/test_segmentation.cpp
-  ${NVFUSER_ROOT}/test/test_matmul_default.cpp
+  ${NVFUSER_ROOT}/test/test_matmul_aten_evaluation.cpp
 )
 
 if(BUILD_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/test/test_id_model.cpp
   ${NVFUSER_ROOT}/test/test_double_buffering.cpp
   ${NVFUSER_ROOT}/test/test_segmentation.cpp
+  ${NVFUSER_ROOT}/test/test_matmul_default.cpp
 )
 
 if(BUILD_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,7 +425,6 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/test/test_id_model.cpp
   ${NVFUSER_ROOT}/test/test_double_buffering.cpp
   ${NVFUSER_ROOT}/test/test_segmentation.cpp
-  ${NVFUSER_ROOT}/test/test_matmul_aten_evaluation.cpp
 )
 
 if(BUILD_TEST)
@@ -484,6 +483,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/test/test_matmul_sass.cpp
     ${NVFUSER_ROOT}/test/test_matmul_scheduler.cpp
     ${NVFUSER_ROOT}/test/test_gpu_tensorcore.cpp
+    ${NVFUSER_ROOT}/test/test_matmul_aten_evaluation.cpp
   )
   add_test(test_matmul "${MATMUL_TEST_SRCS}" "")
   list(APPEND TEST_BINARIES test_matmul)

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1516,7 +1516,9 @@ void ExprSegmentationSorter::sort() {
       std::back_inserter(non_pointer_arithmetic_outs),
       [this](Val* out) {
         return fusion_->getOutputAlias(out).type !=
-            AllocationType::PointerArithmetic;
+            AllocationType::PointerArithmetic &&
+            fusion_->getOutputAlias(out).type !=
+            AllocationType::Evaluate;
       });
 
   // Not putting the exprs between fusion inputs and allKnownVals() here

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1506,14 +1506,15 @@ void ExprSegmentationSorter::sort() {
   // Need this for initialization of the DAG that is processed
   std::unordered_map<Expr*, ExprGroup*> expr2group;
 
-  // We skip generating code that computes only pointer-arithmetic outputs.
+  // We skip generating code that computes only pointer-arithmetic outputs
+  // or any output marked for expression evaluator (AllocationType::Evaluate).
   // Those outputs will be computed by ExpressionEvaluator.
-  std::vector<Val*> non_pointer_arithmetic_outs;
-  non_pointer_arithmetic_outs.reserve(fusion_->outputs().size());
+  std::vector<Val*> non_expr_evaluator_outs;
+  non_expr_evaluator_outs.reserve(fusion_->outputs().size());
   std::copy_if(
       fusion_->outputs().begin(),
       fusion_->outputs().end(),
-      std::back_inserter(non_pointer_arithmetic_outs),
+      std::back_inserter(non_expr_evaluator_outs),
       [this](Val* out) {
         return (fusion_->getOutputAlias(out).type !=
             AllocationType::PointerArithmetic &&
@@ -1524,7 +1525,7 @@ void ExprSegmentationSorter::sort() {
   // Not putting the exprs between fusion inputs and allKnownVals() here
   // because they are computed using the expr evaluator.
   auto all_exprs = StmtSort::getExprsBetween(
-      GpuLower::current()->allKnownVals(), non_pointer_arithmetic_outs);
+      GpuLower::current()->allKnownVals(), non_expr_evaluator_outs);
 
   // Figure out all the values used as inputs to the expressions we're sorting
   // (to find terminating expressions). There could be branches of expressions

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1509,12 +1509,12 @@ void ExprSegmentationSorter::sort() {
   // We skip generating code that computes only pointer-arithmetic outputs
   // or any output marked for expression evaluator (AllocationType::Evaluate).
   // Those outputs will be computed by ExpressionEvaluator.
-  std::vector<Val*> non_expr_evaluator_outs;
-  non_expr_evaluator_outs.reserve(fusion_->outputs().size());
+  std::vector<Val*> outs_requiring_codegen;
+  outs_requiring_codegen.reserve(fusion_->outputs().size());
   std::copy_if(
       fusion_->outputs().begin(),
       fusion_->outputs().end(),
-      std::back_inserter(non_expr_evaluator_outs),
+      std::back_inserter(outs_requiring_codegen),
       [this](Val* out) {
         return (
             fusion_->getOutputAlias(out).type !=
@@ -1525,7 +1525,7 @@ void ExprSegmentationSorter::sort() {
   // Not putting the exprs between fusion inputs and allKnownVals() here
   // because they are computed using the expr evaluator.
   auto all_exprs = StmtSort::getExprsBetween(
-      GpuLower::current()->allKnownVals(), non_expr_evaluator_outs);
+      GpuLower::current()->allKnownVals(), outs_requiring_codegen);
 
   // Figure out all the values used as inputs to the expressions we're sorting
   // (to find terminating expressions). There could be branches of expressions

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1516,10 +1516,10 @@ void ExprSegmentationSorter::sort() {
       fusion_->outputs().end(),
       std::back_inserter(non_expr_evaluator_outs),
       [this](Val* out) {
-        return (fusion_->getOutputAlias(out).type !=
-            AllocationType::PointerArithmetic &&
+        return (
             fusion_->getOutputAlias(out).type !=
-            AllocationType::Evaluate);
+                AllocationType::PointerArithmetic &&
+            fusion_->getOutputAlias(out).type != AllocationType::Evaluate);
       });
 
   // Not putting the exprs between fusion inputs and allKnownVals() here

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1515,10 +1515,10 @@ void ExprSegmentationSorter::sort() {
       fusion_->outputs().end(),
       std::back_inserter(non_pointer_arithmetic_outs),
       [this](Val* out) {
-        return fusion_->getOutputAlias(out).type !=
+        return (fusion_->getOutputAlias(out).type !=
             AllocationType::PointerArithmetic &&
             fusion_->getOutputAlias(out).type !=
-            AllocationType::Evaluate;
+            AllocationType::Evaluate);
       });
 
   // Not putting the exprs between fusion inputs and allKnownVals() here

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -953,6 +953,12 @@ at::Tensor allocateOutput(
     return alloc_tensor;
   }
 
+  if (alias_info.type == AllocationType::Evaluate) {
+    // Compute non-aliased outputs that were marked for expr evaluator.
+    at::Tensor out_tensor = ee.evaluate(out_tv).as<at::Tensor>();
+    return out_tensor;
+  }
+
   Val* aliased_io = alias_info.aliased_io;
   NVF_ERROR(
       aliased_io != nullptr,

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -834,7 +834,7 @@ void Fusion::markOutputForEvaluation(Val* output){
   io_alias_[output] = AliasInfo{
     .type = AllocationType::Evaluate,
     .aliased_io = nullptr,
-    .hide_output = !output->isFusionOutput()
+    .hide_output = false
   };
 }
 

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -829,13 +829,14 @@ bool Fusion::hasDynamicTransform() {
   return !ir_utils::getTVsWithDynamicTransform(this).empty();
 }
 
-void Fusion::markOutputForEvaluation(Val* output){
-  NVF_CHECK(output->isFusionOutput(), "Only fusion outputs can be expression evaluaed.");
+void Fusion::markOutputForEvaluation(Val* output) {
+  NVF_CHECK(
+      output->isFusionOutput(),
+      "Only fusion outputs can be expression evaluaed.");
   io_alias_[output] = AliasInfo{
-    .type = AllocationType::Evaluate,
-    .aliased_io = nullptr,
-    .hide_output = false
-  };
+      .type = AllocationType::Evaluate,
+      .aliased_io = nullptr,
+      .hide_output = false};
 }
 
 } // namespace nvfuser

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -830,6 +830,7 @@ bool Fusion::hasDynamicTransform() {
 }
 
 void Fusion::markOutputForEvaluation(Val* output){
+  NVF_CHECK(output->isFusionOutput(), "Only fusion outputs can be expression evaluaed.");
   io_alias_[output] = AliasInfo{
     .type = AllocationType::Evaluate,
     .aliased_io = nullptr,

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -829,4 +829,14 @@ bool Fusion::hasDynamicTransform() {
   return !ir_utils::getTVsWithDynamicTransform(this).empty();
 }
 
+void Fusion::markOutputForEvaluation(Val* output, const AllocationType type){
+  NVF_ERROR(type == AllocationType::Evaluate,
+    "Expected AllocationType to be Evaluate. For any other AllocationType, use aliasOutputToInput.");
+  io_alias_[output] = AliasInfo{
+    .type = type,
+    .aliased_io = nullptr,
+    .hide_output = !output->isFusionOutput()
+  };
+}
+
 } // namespace nvfuser

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -829,11 +829,9 @@ bool Fusion::hasDynamicTransform() {
   return !ir_utils::getTVsWithDynamicTransform(this).empty();
 }
 
-void Fusion::markOutputForEvaluation(Val* output, const AllocationType type){
-  NVF_ERROR(type == AllocationType::Evaluate,
-    "Expected AllocationType to be Evaluate. For any other AllocationType, use aliasOutputToInput.");
+void Fusion::markOutputForEvaluation(Val* output){
   io_alias_[output] = AliasInfo{
-    .type = type,
+    .type = AllocationType::Evaluate,
     .aliased_io = nullptr,
     .hide_output = !output->isFusionOutput()
   };

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -96,7 +96,7 @@ enum class AllocationType : int {
   // cheaply compute the output tensor.
   PointerArithmetic,
   // To evaluate outputs which are not aliases.
-  // TODO: This can be potentially merged with PointerArithmetic.
+  // TODO: This will merged with PointerArithmetic in the next PR.
   //       PointerArithmetic requires aliased_io != nullptr while for evaluating
   //       a non-aliased output, aliased_io = nullptr. So keeping them separate
   //       initially.

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -95,6 +95,11 @@ enum class AllocationType : int {
   // input.  In this case, we use `ExpressionEvaluator` (instead of a kernel) to
   // cheaply compute the output tensor.
   PointerArithmetic,
+  // To evaluate outputs which are not aliases.
+  // TODO: This can be potentially merged with PointerArithmetic.
+  //       PointerArithmetic requires aliased_io != nullptr while for evaluating
+  //       a non-aliased output, aliased_io = nullptr. So keeping them separate initially.
+  Evaluate,
 };
 
 struct AliasInfo {
@@ -255,6 +260,10 @@ class Fusion : public IrContainer {
   //! aliased.
   const AliasInfo& getOutputAlias(Val* output) const;
 
+  // Marks an output (by adding to io_alias_ map) to be evaluated through 
+  // expression evaluator.
+  void markOutputForEvaluation(Val* output, const AllocationType type);
+  
   // mark input at index to be permuted by permutation
   void setPermutationOnInput(int index, std::vector<int64_t> permutation) {
     permuted_input_map_.insert({index, permutation});

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -260,9 +260,9 @@ class Fusion : public IrContainer {
   //! aliased.
   const AliasInfo& getOutputAlias(Val* output) const;
 
-  // Marks an output (by adding to io_alias_ map) to be evaluated through 
+  // Marks a non-aliased output to be evaluated through 
   // expression evaluator.
-  void markOutputForEvaluation(Val* output, const AllocationType type);
+  void markOutputForEvaluation(Val* output);
   
   // mark input at index to be permuted by permutation
   void setPermutationOnInput(int index, std::vector<int64_t> permutation) {

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -98,7 +98,8 @@ enum class AllocationType : int {
   // To evaluate outputs which are not aliases.
   // TODO: This can be potentially merged with PointerArithmetic.
   //       PointerArithmetic requires aliased_io != nullptr while for evaluating
-  //       a non-aliased output, aliased_io = nullptr. So keeping them separate initially.
+  //       a non-aliased output, aliased_io = nullptr. So keeping them separate
+  //       initially.
   Evaluate,
 };
 
@@ -260,10 +261,10 @@ class Fusion : public IrContainer {
   //! aliased.
   const AliasInfo& getOutputAlias(Val* output) const;
 
-  // Marks a non-aliased output to be evaluated through 
+  // Marks a non-aliased output to be evaluated through
   // expression evaluator.
   void markOutputForEvaluation(Val* output);
-  
+
   // mark input at index to be permuted by permutation
   void setPermutationOnInput(int index, std::vector<int64_t> permutation) {
     permuted_input_map_.insert({index, permutation});

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -157,7 +157,7 @@ std::unordered_map<EnableOption, std::vector<std::string>> Options<
       {"memory_promotion", EnableOption::MemoryPromotion},
       {"static_fusion_count", EnableOption::StaticFusionCount},
       {"warn_register_spill", EnableOption::WarnRegisterSpill},
-      {"matmul_expr_eval", EnableOption:MatmulExprEval}};
+      {"matmul_expr_eval", EnableOption::MatmulExprEval}};
 
   return parseEnvOptions("ENABLE", available_options);
 }

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -156,7 +156,8 @@ std::unordered_map<EnableOption, std::vector<std::string>> Options<
       {"kernel_profile", EnableOption::KernelProfile},
       {"memory_promotion", EnableOption::MemoryPromotion},
       {"static_fusion_count", EnableOption::StaticFusionCount},
-      {"warn_register_spill", EnableOption::WarnRegisterSpill}};
+      {"warn_register_spill", EnableOption::WarnRegisterSpill},
+      {"matmul_expr_eval", EnableOption:MatmulExprEval}};
 
   return parseEnvOptions("ENABLE", available_options);
 }

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -86,7 +86,7 @@ enum class EnableOption {
   MemoryPromotion, //! Enable promotion of memory types for non-pointwise ops
   StaticFusionCount, //! Enable using single static count in kernel name
   WarnRegisterSpill, //! Enable warnings of register spill
-  MatmulExprEval, //! Enable ATen evaluation for Matmul 
+  MatmulExprEval, //! Enable ATen evaluation for Matmul
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -86,6 +86,7 @@ enum class EnableOption {
   MemoryPromotion, //! Enable promotion of memory types for non-pointwise ops
   StaticFusionCount, //! Enable using single static count in kernel name
   WarnRegisterSpill, //! Enable warnings of register spill
+  MatmulExprEval, //! Enable ATen evaluation for Matmul 
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -713,12 +713,12 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       mma_ops.size());
 
   // Skip scheduling if Matmul will be expression evaluated.
-  // NOTE: This strictly evaluates only MmaOp.
-  // TODO: Add support to evaluate (MmaOp + cast).
-  if (isOptionEnabled(EnableOption::MatmulExprEval)){
-    NVF_CHECK (fusion->outputs().size() == 1)
+  if (isOptionEnabled(EnableOption::MatmulExprEval)) {
+    NVF_CHECK(fusion->outputs().size() == 1)
     fusion->markOutputForEvaluation(fusion->outputs()[0]);
-    scheduler_debug_utils::log(__FUNCTION__, ": Matmul output to be computed through expression evaluator. Skipping codegen.");
+    scheduler_debug_utils::log(
+        __FUNCTION__,
+        ": Matmul output to be computed through expression evaluator. Skipping codegen.");
     return;
   }
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -711,6 +711,14 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       mma_ops.size() == 1,
       "scheduleMatmul supports fusion with single mma op in definition, got ",
       mma_ops.size());
+
+  // Skip scheduling if Matmul will be expression evaluated.
+  if (isOptionEnabled(EnableOption::MatmulExprEval)){
+    fusion->markOutputForEvaluation(mma_ops.front()->out(), AllocationType::Evaluate);
+    scheduler_debug_utils::log(__FUNCTION__, ": Matmul output to be computed through expression evaluator. Skipping codegen.");
+    return;
+  }
+
   const auto& roles_map_opt = mma_utils::getTensorsRoles(fusion);
 
   // NOTE: the contents of roles_map have been already validated during

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -717,8 +717,10 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
     NVF_CHECK(fusion->outputs().size() == 1)
     fusion->markOutputForEvaluation(fusion->outputs()[0]);
     scheduler_debug_utils::log(
-        __FUNCTION__,
-        ": Matmul output to be computed through expression evaluator. Skipping codegen.");
+        __FILE__,
+        ":",
+        __LINE__,
+        ", Matmul output to be computed through expression evaluator. Skipping codegen.");
     return;
   }
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -713,8 +713,11 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       mma_ops.size());
 
   // Skip scheduling if Matmul will be expression evaluated.
+  // NOTE: This strictly evaluates only MmaOp.
+  // TODO: Add support to evaluate (MmaOp + cast).
   if (isOptionEnabled(EnableOption::MatmulExprEval)){
-    fusion->markOutputForEvaluation(mma_ops.front()->out(), AllocationType::Evaluate);
+    NVF_CHECK (fusion->outputs().size() == 1)
+    fusion->markOutputForEvaluation(fusion->outputs()[0]);
     scheduler_debug_utils::log(__FUNCTION__, ": Matmul output to be computed through expression evaluator. Skipping codegen.");
     return;
   }

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -47,12 +47,12 @@ TEST(MatmulATenEvaluationTest, SingleMmaOp) {
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1});
 
-  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+  EXPECT_EQ(fec.getMostRecentKernelRuntime()->executors().size(), 1);
 
   // Verify that the io_alias_ set has the correct entry
   auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
-  EXPECT_TRUE(
-      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+  EXPECT_EQ(
+      kernel->getOutputAlias(kernel->outputs()[0]).type,
       AllocationType::Evaluate);
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
@@ -86,12 +86,12 @@ TEST(MatmulATenEvaluationTest, MmaOpAndCast) {
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1});
 
-  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+  EXPECT_EQ(fec.getMostRecentKernelRuntime()->executors().size(), 1);
 
   // Verify that the io_alias_ set has the correct entry
   auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
-  EXPECT_TRUE(
-      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+  EXPECT_EQ(
+      kernel->getOutputAlias(kernel->outputs()[0]).type,
       AllocationType::Evaluate);
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
@@ -131,12 +131,12 @@ TEST(MatmulATenEvaluationTest, MatmulWithBias) {
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1, t2});
 
-  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+  EXPECT_EQ(fec.getMostRecentKernelRuntime()->executors().size(), 1);
 
   // Verify that the io_alias_ set has the correct entry
   auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
-  EXPECT_TRUE(
-      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+  EXPECT_EQ(
+      kernel->getOutputAlias(kernel->outputs()[0]).type,
       AllocationType::Evaluate);
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -18,9 +18,9 @@
 
 namespace nvfuser {
 
-class MatmulDefaultTest : public NVFuserTest {};
+class MatmulATenEvaluationTest : public NVFuserTest {};
 
-TEST(MatmulDefaultTest, SingleMmaOp) {
+TEST(MatmulATenEvaluationTest, SingleMmaOp) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -50,7 +50,7 @@ TEST(MatmulDefaultTest, SingleMmaOp) {
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST(MatmulDefaultTest, MmaOpAndCast) {
+TEST(MatmulATenEvaluationTest, MmaOpAndCast) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -81,7 +81,7 @@ TEST(MatmulDefaultTest, MmaOpAndCast) {
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST(MatmulDefaultTest, MatmulWithBias) {
+TEST(MatmulATenEvaluationTest, MatmulWithBias) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -47,6 +47,14 @@ TEST(MatmulATenEvaluationTest, SingleMmaOp) {
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1});
 
+  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+
+  // Verify that the io_alias_ set has the correct entry
+  auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
+  EXPECT_TRUE(
+      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+      AllocationType::Evaluate);
+
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
@@ -77,6 +85,14 @@ TEST(MatmulATenEvaluationTest, MmaOpAndCast) {
 
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1});
+
+  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+
+  // Verify that the io_alias_ set has the correct entry
+  auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
+  EXPECT_TRUE(
+      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+      AllocationType::Evaluate);
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -114,6 +130,14 @@ TEST(MatmulATenEvaluationTest, MatmulWithBias) {
 
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1, t2});
+
+  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+
+  // Verify that the io_alias_ set has the correct entry
+  auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
+  EXPECT_TRUE(
+      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+      AllocationType::Evaluate);
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -18,7 +18,7 @@
 
 namespace nvfuser {
 
-class MatmulATenEvaluationTest : public NVFuserTest {};
+using MatmulATenEvaluationTest = NVFuserTest;
 
 TEST(MatmulATenEvaluationTest, SingleMmaOp) {
   auto fusion = std::make_unique<Fusion>();
@@ -96,14 +96,14 @@ TEST(MatmulATenEvaluationTest, MatmulWithBias) {
   auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
   auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
   auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
-  auto tv3 = castOp(DataType::Half, tv2);
-  auto tv4 = makeConcreteTensor({m}, DataType::Half);
-  auto tv5 = biasEpilogue(tv3, tv4);
+  auto tv3 = makeConcreteTensor({m}, DataType::Half);
+  auto tv4 = castOp(DataType::Float, tv3);
+  auto tv5 = biasEpilogue(tv2, tv4);
   auto tv6 = castOp(DataType::Half, tv5);
 
   fusion->addInput(tv0);
   fusion->addInput(tv1);
-  fusion->addInput(tv4);
+  fusion->addInput(tv3);
   fusion->addOutput(tv6);
 
   at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();

--- a/test/test_matmul_default.cpp
+++ b/test/test_matmul_default.cpp
@@ -20,7 +20,7 @@ namespace nvfuser {
 
 class MatmulDefaultTest : public NVFuserTest {};
 
-TEST (MatmulDefaultTest, ComputeMmaThroughEE){
+TEST (MatmulDefaultTest, SingleMmaOp){
     auto fusion = std::make_unique<Fusion>();
     FusionGuard fg(fusion.get());
     EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
@@ -44,6 +44,69 @@ TEST (MatmulDefaultTest, ComputeMmaThroughEE){
 
     FusionExecutorCache fec(std::move(fusion));
     auto out = fec.runFusionWithInputs({t0, t1});
+
+    EXPECT_TRUE(at::allclose(out[0], out_ref));
+}
+
+TEST (MatmulDefaultTest, MmaOpAndCast){
+    auto fusion = std::make_unique<Fusion>();
+    FusionGuard fg(fusion.get());
+    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+
+    int64_t m = 2, k = 3, n = 4;
+    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+
+    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+    auto tv3 = castOp(DataType::Half, tv2);
+
+    fusion->addInput(tv0);
+    fusion->addInput(tv1);
+    fusion->addOutput(tv3);
+
+    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+    at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda();
+
+    FusionExecutorCache fec(std::move(fusion));
+    auto out = fec.runFusionWithInputs({t0, t1});
+
+    EXPECT_TRUE(at::allclose(out[0], out_ref));
+}
+
+TEST (MatmulDefaultTest, MatmulWithBias){
+    auto fusion = std::make_unique<Fusion>();
+    FusionGuard fg(fusion.get());
+    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+
+    int64_t m = 2, k = 3, n = 4;
+    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+
+    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+    auto tv3 = castOp(DataType::Half, tv2);
+    auto tv4 = makeConcreteTensor({m}, DataType::Half);
+    auto tv5 = biasEpilogue(tv3, tv4);
+    auto tv6 = castOp(DataType::Half, tv5);
+
+    fusion->addInput(tv0);
+    fusion->addInput(tv1);
+    fusion->addInput(tv4);
+    fusion->addOutput(tv6);
+
+    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+    at::Tensor t2 = at::randn({m}, at::kHalf).cuda();
+    at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda() + t2.unsqueeze(-1);
+
+    FusionExecutorCache fec(std::move(fusion));
+    auto out = fec.runFusionWithInputs({t0, t1, t2});
 
     EXPECT_TRUE(at::allclose(out[0], out_ref));
 }

--- a/test/test_matmul_default.cpp
+++ b/test/test_matmul_default.cpp
@@ -1,0 +1,51 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <csrc/exceptions.h>
+#include <gtest/gtest.h>
+
+#include <fusion.h>
+#include <mma_type.h>
+#include <ops/all_ops.h>
+#include <scheduler/all_schedulers.h>
+#include <scheduler/mma_utils.h>
+#include <test/utils.h>
+#include <test/validator.h>
+
+namespace nvfuser {
+
+class MatmulDefaultTest : public NVFuserTest {};
+
+TEST (MatmulDefaultTest, ComputeMmaThroughEE){
+    auto fusion = std::make_unique<Fusion>();
+    FusionGuard fg(fusion.get());
+    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+
+    int64_t m = 2, k = 3, n = 4;
+    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+
+    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+
+    fusion->addInput(tv0);
+    fusion->addInput(tv1);
+    fusion->addOutput(tv2);
+
+    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+    at::Tensor out_ref = at::full(out_shape, k, at::kFloat).cuda();
+
+    FusionExecutorCache fec(std::move(fusion));
+    auto out = fec.runFusionWithInputs({t0, t1});
+
+    EXPECT_TRUE(at::allclose(out[0], out_ref));
+}
+
+} // namespace nvfuser

--- a/test/test_matmul_default.cpp
+++ b/test/test_matmul_default.cpp
@@ -23,6 +23,8 @@ class MatmulDefaultTest : public NVFuserTest {};
 TEST(MatmulDefaultTest, SingleMmaOp) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
+
+  EnableOptionsGuard enable_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
   int64_t m = 2, k = 3, n = 4;
@@ -51,6 +53,8 @@ TEST(MatmulDefaultTest, SingleMmaOp) {
 TEST(MatmulDefaultTest, MmaOpAndCast) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
+
+  EnableOptionsGuard enable_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
   int64_t m = 2, k = 3, n = 4;
@@ -80,6 +84,8 @@ TEST(MatmulDefaultTest, MmaOpAndCast) {
 TEST(MatmulDefaultTest, MatmulWithBias) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
+
+  EnableOptionsGuard enable_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
   int64_t m = 2, k = 3, n = 4;

--- a/test/test_matmul_default.cpp
+++ b/test/test_matmul_default.cpp
@@ -20,95 +20,96 @@ namespace nvfuser {
 
 class MatmulDefaultTest : public NVFuserTest {};
 
-TEST (MatmulDefaultTest, SingleMmaOp){
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
-    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+TEST(MatmulDefaultTest, SingleMmaOp) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
-    int64_t m = 2, k = 3, n = 4;
-    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+  int64_t m = 2, k = 3, n = 4;
+  std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
 
-    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
-    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
-    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
-    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
-    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+  auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+  auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
 
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addOutput(tv2);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addOutput(tv2);
 
-    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
-    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
-    at::Tensor out_ref = at::full(out_shape, k, at::kFloat).cuda();
+  at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+  at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+  at::Tensor out_ref = at::full(out_shape, k, at::kFloat).cuda();
 
-    FusionExecutorCache fec(std::move(fusion));
-    auto out = fec.runFusionWithInputs({t0, t1});
+  FusionExecutorCache fec(std::move(fusion));
+  auto out = fec.runFusionWithInputs({t0, t1});
 
-    EXPECT_TRUE(at::allclose(out[0], out_ref));
+  EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST (MatmulDefaultTest, MmaOpAndCast){
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
-    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+TEST(MatmulDefaultTest, MmaOpAndCast) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
-    int64_t m = 2, k = 3, n = 4;
-    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+  int64_t m = 2, k = 3, n = 4;
+  std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
 
-    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
-    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
-    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
-    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
-    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
-    auto tv3 = castOp(DataType::Half, tv2);
+  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+  auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+  auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+  auto tv3 = castOp(DataType::Half, tv2);
 
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addOutput(tv3);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addOutput(tv3);
 
-    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
-    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
-    at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda();
+  at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+  at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+  at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda();
 
-    FusionExecutorCache fec(std::move(fusion));
-    auto out = fec.runFusionWithInputs({t0, t1});
+  FusionExecutorCache fec(std::move(fusion));
+  auto out = fec.runFusionWithInputs({t0, t1});
 
-    EXPECT_TRUE(at::allclose(out[0], out_ref));
+  EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST (MatmulDefaultTest, MatmulWithBias){
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
-    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+TEST(MatmulDefaultTest, MatmulWithBias) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
-    int64_t m = 2, k = 3, n = 4;
-    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+  int64_t m = 2, k = 3, n = 4;
+  std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
 
-    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
-    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
-    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
-    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
-    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
-    auto tv3 = castOp(DataType::Half, tv2);
-    auto tv4 = makeConcreteTensor({m}, DataType::Half);
-    auto tv5 = biasEpilogue(tv3, tv4);
-    auto tv6 = castOp(DataType::Half, tv5);
+  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+  auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+  auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+  auto tv3 = castOp(DataType::Half, tv2);
+  auto tv4 = makeConcreteTensor({m}, DataType::Half);
+  auto tv5 = biasEpilogue(tv3, tv4);
+  auto tv6 = castOp(DataType::Half, tv5);
 
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addInput(tv4);
-    fusion->addOutput(tv6);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv4);
+  fusion->addOutput(tv6);
 
-    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
-    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
-    at::Tensor t2 = at::randn({m}, at::kHalf).cuda();
-    at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda() + t2.unsqueeze(-1);
+  at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+  at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+  at::Tensor t2 = at::randn({m}, at::kHalf).cuda();
+  at::Tensor out_ref =
+      at::full(out_shape, k, at::kHalf).cuda() + t2.unsqueeze(-1);
 
-    FusionExecutorCache fec(std::move(fusion));
-    auto out = fec.runFusionWithInputs({t0, t1, t2});
+  FusionExecutorCache fec(std::move(fusion));
+  auto out = fec.runFusionWithInputs({t0, t1, t2});
 
-    EXPECT_TRUE(at::allclose(out[0], out_ref));
+  EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
Initial PR for Issue #1669.

1. Adds a `EnableOption::MatmulExprEval` to turn on expression evaluation for matmul while the API in under progress.
2. Currently, we only evaluate the `MmaOp`. The next PRs will amend this to _look ahead_ and evaluate Mma + Cast, which is what we should see in the fusion definitions. See discussion [here](https://github.com/NVIDIA/Fuser/issues/1669#issuecomment-1918383315). In the absence of this we may have casts such as `bfloat->float->bfloat.`