### PR TITLE
Issue #1748

### DIFF
--- a/test/utils.h
+++ b/test/utils.h
@@ -402,7 +402,7 @@ inline bool maybeClearAllocator(int64_t max_bytes = ((int64_t)1 << 32)) {
     cudaGetDevice(&device);
 #endif
 
-    auto device_stats = allocator->getDeviceStats(0);
+    auto device_stats = allocator->getDeviceStats(device);
     // allocated_bytes[] holds multiple statistics but the first is sum across
     // both small and large blocks
     if (uint64_t(device_stats.reserved_bytes[0].current) >

--- a/test/utils.h
+++ b/test/utils.h
@@ -397,7 +397,9 @@ inline bool maybeClearAllocator(int64_t max_bytes = ((int64_t)1 << 32)) {
     // in order to properly handle new CUDA 112 behavior
     // c10::cuda uses DeviceIndex instead of int
     // https://github.com/pytorch/pytorch/pull/119142
-    c10::cuda::GetDevice(reinterpret_cast<c10::DeviceIndex*>(&device));
+    c10::DeviceIndex device_index;
+    c10::cuda::GetDevice(&device_index);
+    device = static_cast<int>(device_index);
 #else
     cudaGetDevice(&device);
 #endif

--- a/test/utils.h
+++ b/test/utils.h
@@ -395,7 +395,7 @@ inline bool maybeClearAllocator(int64_t max_bytes = ((int64_t)1 << 32)) {
 #if TORCH_VERSION_GREATER(2, 0, 1)
     // GetDevice was introduced in https://github.com/pytorch/pytorch/pull/94864
     // in order to properly handle new CUDA 112 behavior
-    // c10::cuda uses DeviceIndex instead of int 
+    // c10::cuda uses DeviceIndex instead of int
     // https://github.com/pytorch/pytorch/pull/119142
     c10::cuda::GetDevice(reinterpret_cast<c10::DeviceIndex*>(&device));
 #else

--- a/test/utils.h
+++ b/test/utils.h
@@ -395,7 +395,8 @@ inline bool maybeClearAllocator(int64_t max_bytes = ((int64_t)1 << 32)) {
 #if TORCH_VERSION_GREATER(2, 0, 1)
     // GetDevice was introduced in https://github.com/pytorch/pytorch/pull/94864
     // in order to properly handle new CUDA 112 behavior
-    c10::cuda::GetDevice(&device);
+    // c10::cuda uses DeviceIndex instead of int https://github.com/pytorch/pytorch/pull/119142
+    c10::cuda::GetDevice(reinterpret_cast<c10::DeviceIndex*>(&device));
 #else
     cudaGetDevice(&device);
 #endif

--- a/test/utils.h
+++ b/test/utils.h
@@ -395,7 +395,8 @@ inline bool maybeClearAllocator(int64_t max_bytes = ((int64_t)1 << 32)) {
 #if TORCH_VERSION_GREATER(2, 0, 1)
     // GetDevice was introduced in https://github.com/pytorch/pytorch/pull/94864
     // in order to properly handle new CUDA 112 behavior
-    // c10::cuda uses DeviceIndex instead of int https://github.com/pytorch/pytorch/pull/119142
+    // c10::cuda uses DeviceIndex instead of int 
+    // https://github.com/pytorch/pytorch/pull/119142
     c10::cuda::GetDevice(reinterpret_cast<c10::DeviceIndex*>(&device));
 #else
     cudaGetDevice(&device);


### PR DESCRIPTION
Closes Issue #1748.
Apart from `c10::cuda::GetDevice`, no other functionality seems affected.