### PR TITLE
Device index patch

### DIFF
--- a/test/utils.h
+++ b/test/utils.h
@@ -392,7 +392,14 @@ inline bool maybeClearAllocator(int64_t max_bytes = ((int64_t)1 << 32)) {
   TORCH_VERSION_MAJOR > major ||                                      \
       (TORCH_VERSION_MAJOR == major && TORCH_VERSION_MINOR > minor || \
        (TORCH_VERSION_MINOR == minor && TORCH_VERSION_PATCH > patch))
-#if TORCH_VERSION_GREATER(2, 0, 1)
+
+#if TORCH_VERSION_GREATER(2, 2, 0)
+    // c10::cuda uses DeviceIndex instead of int
+    // https://github.com/pytorch/pytorch/pull/119142
+    c10::DeviceIndex device_index;
+    c10::cuda::GetDevice(&device_index);
+    device = static_cast<int>(device_index);
+#elif TORCH_VERSION_GREATER(2, 0, 1)
     // GetDevice was introduced in https://github.com/pytorch/pytorch/pull/94864
     // in order to properly handle new CUDA 112 behavior
     c10::cuda::GetDevice(&device);
@@ -400,7 +407,7 @@ inline bool maybeClearAllocator(int64_t max_bytes = ((int64_t)1 << 32)) {
     cudaGetDevice(&device);
 #endif
 
-    auto device_stats = allocator->getDeviceStats(0);
+    auto device_stats = allocator->getDeviceStats(device);
     // allocated_bytes[] holds multiple statistics but the first is sum across
     // both small and large blocks
     if (uint64_t(device_stats.reserved_bytes[0].current) >

--- a/test/utils.h
+++ b/test/utils.h
@@ -395,16 +395,12 @@ inline bool maybeClearAllocator(int64_t max_bytes = ((int64_t)1 << 32)) {
 #if TORCH_VERSION_GREATER(2, 0, 1)
     // GetDevice was introduced in https://github.com/pytorch/pytorch/pull/94864
     // in order to properly handle new CUDA 112 behavior
-    // c10::cuda uses DeviceIndex instead of int
-    // https://github.com/pytorch/pytorch/pull/119142
-    c10::DeviceIndex device_index;
-    c10::cuda::GetDevice(&device_index);
-    device = static_cast<int>(device_index);
+    c10::cuda::GetDevice(&device);
 #else
     cudaGetDevice(&device);
 #endif
 
-    auto device_stats = allocator->getDeviceStats(device);
+    auto device_stats = allocator->getDeviceStats(0);
     // allocated_bytes[] holds multiple statistics but the first is sum across
     // both small and large blocks
     if (uint64_t(device_stats.reserved_bytes[0].current) >


### PR DESCRIPTION
Fixes #1748 

guard c10::cuda::GetDevice API change on TORCH_VERSION

with this change, it ensures that we can build against stable release `< 2.2.0`, as well as TOT after  https://github.com/pytorch/pytorch/pull/119142

For 2.3.0 nightly, if someone accidentally checkout a commit before the patch, the build will still fail.
