### PR TITLE
fix compute at root domain map

### DIFF
--- a/csrc/root_domain_map.cpp
+++ b/csrc/root_domain_map.cpp
@@ -447,12 +447,32 @@ bool UnmappableReductionDomains::isReductionOutputMapped(
               input_keys.end();
         });
     // None of the consumer domains is used for the reduction
-    // domain. They should be safe with respect to this reduction
-    // domain
+    // domain.
+    if (it == consumer_domains.end()) {
+      // Further check if any consumer domain is mapped with the reduction input
+      // domains
+      it = std::find_if(
+          consumer_domains.begin(),
+          consumer_domains.end(),
+          [&](const auto& consumer_domain) {
+            return std::any_of(
+                input_keys.begin(),
+                input_keys.end(),
+                [&](const auto& input_key) {
+                  return root_map.canMap(
+                      consumer_domain.td(),
+                      consumer_domain.id(),
+                      input_key.td(),
+                      input_key.id());
+                });
+          });
+    }
+    // None of the consumer domains is used for the reduction.
+    // None of the consumer domains is mapped with the reduction input domains.
+    // Safe to map.
     if (it == consumer_domains.end()) {
       continue;
     }
-
     // A consumer domain that is an input to the reduction domain
     const DomainKey& input_to_reduction = *it;
 

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -8738,6 +8738,48 @@ TEST_F(NVFuserTest, AvoidCachingSliceInput) {
     }
   }
 }
+
+// Step-1 to fix https://github.com/NVIDIA/Fuser/issues/1631
+// Needs to check consumer mapped with reduction inputs in
+// isReductionOutputMapped(), otherwise compute at root domain map
+// is wrong then leads to wrong compute at position and finally
+// expr sort failed.
+// After fix, there are two persistent buffers and can be further
+// reduced to one with a following step-2 to fix the issue in resolution
+// points detection.
+TEST_F(NVFuserTest, CaRootDomainMapConsumerMappedWithReductionInput) {
+  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+  auto fusion = fusion_ptr.get();
+  FusionGuard fg(fusion);
+
+  const int batch_size = 128;
+  const int hidden_size = 10240;
+  DataType input_dtype = DataType::Half;
+  auto tv0 = makeContigTensor(2, input_dtype);
+  auto tv1 = makeContigTensor(2, DataType::Float);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  auto tv2 = castOp(DataType::Float, tv0);
+  auto tv3 = sum(tv2, {1});
+  auto tv4 = broadcast(tv3, {false, true});
+  auto tv5 = div(tv2, tv4);
+  auto tv6 = add(tv1, tv5);
+  auto tv7 = add(tv2, tv1);
+  fusion->addOutput(tv6);
+  fusion->addOutput(tv7);
+
+  auto options = at::TensorOptions()
+                     .dtype(data_type_to_aten(input_dtype))
+                     .device(at::kCUDA, 0);
+  auto options_fp32 = at::TensorOptions()
+                          .dtype(data_type_to_aten(DataType::Float))
+                          .device(at::kCUDA, 0);
+  auto t0 = at::randn({batch_size, hidden_size}, options);
+  auto t1 = at::randn({batch_size, hidden_size}, options_fp32);
+  FusionExecutorCache fec(std::move(fusion_ptr));
+  auto cg_outputs = fec.runFusionWithInputs({t0, t1});
+}
+
 // Test file size should be up to 10K LoC. Create a new file for more tests.
 
 } // namespace nvfuser


### PR DESCRIPTION
First step to fix #1631 
For more details, see the [doc](https://docs.google.com/document/d/1tZoJKmyX6EFf1OZipaIg2Ts3fm7LN6BuuyfQa94_oQg/edit?usp=sharing).

**Issue:** expr sort failed in #1631 due to the wrong computeAt position, which is due to the wrong compute at root domain map, which is due to the bug in `isReductionOutputMapped()`. The bug happens when map `11` to its consumers `13` and `12` during the build of `ComputeAtRootDomainMap`. As shown in the figure, we already have two sets:
- Post-reduction set: {4, 5, 12, 6, 8}
- Pre-reduction set: {2, 14, 13, 7}

Consumer `12` is in the post-reduction set while consumer `13` is in the pre-reduction set. So, this map is illegal!
Current check in `isReductionOutputMapped` just ignores this scenario since neither `13` nor `12` is a producer of the reduction op.
![image](https://github.com/NVIDIA/Fuser/assets/116412316/614fc831-a21e-4a51-a98c-ca50d79a517b)

**Fix:** 
1. should further check if any of the consumers (`12` and `13`) is mapped to any of the domains in the reduction input set {2, 14, 13, 7}.
2. After step-1, `T11` becomes a persistent buffer, another better fix is to recompute `T13` from `T10`. Then, `T13` is no longer in the pre-reduction set. It will be put into the post-reduction set. see #1676 

 