### PR TITLE
Rename `AllocationTypes`

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1060,8 +1060,7 @@ std::vector<at::Tensor> allocateOutputs(
           const std::pair<int64_t, Val*>& lhs,
           const std::pair<int64_t, Val*>& rhs) {
         return (
-            kernel->getOutputAlias(lhs.second).type ==
-                AllocationType::New &&
+            kernel->getOutputAlias(lhs.second).type == AllocationType::New &&
             kernel->getOutputAlias(rhs.second).type != AllocationType::New);
       });
 

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -986,7 +986,7 @@ at::Tensor allocateOutput(
   }
 
   switch (alias_info.type) {
-    case AllocationType::NoAlias: {
+    case AllocationType::New: {
       auto alloc_tensor = at::native::empty_strided_cuda(
           out_info.sizes,
           out_info.strides,
@@ -999,7 +999,7 @@ at::Tensor allocateOutput(
       }
       return alloc_tensor;
     }
-    case AllocationType::InplaceUpdate:
+    case AllocationType::ReuseBuffer:
       // Unlike for `AllocationType::Evaluate`, don't use
       // ExpressionEvaluator to compute the output tensor. This is because
       // the output tensor may hold different data from the input, e.g., an
@@ -1061,8 +1061,8 @@ std::vector<at::Tensor> allocateOutputs(
           const std::pair<int64_t, Val*>& rhs) {
         return (
             kernel->getOutputAlias(lhs.second).type ==
-                AllocationType::NoAlias &&
-            kernel->getOutputAlias(rhs.second).type != AllocationType::NoAlias);
+                AllocationType::New &&
+            kernel->getOutputAlias(rhs.second).type != AllocationType::New);
       });
 
   std::vector<at::Tensor> out_tensors(num_outs);

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -772,8 +772,8 @@ void Fusion::aliasOutputToInput(
     Val* input,
     const AllocationType type) {
   NVF_CHECK(
-      type != AllocationType::NoAlias,
-      "NoAlias is returned automatically for a missing key. Don't add it explicitly.");
+      type != AllocationType::New,
+      "New is returned automatically for a missing key. Don't add it explicitly.");
 
   if (type == AllocationType::Evaluate) {
     NVF_CHECK(
@@ -784,7 +784,7 @@ void Fusion::aliasOutputToInput(
     return;
   }
 
-  NVF_ERROR(type == AllocationType::InplaceUpdate);
+  NVF_ERROR(type == AllocationType::ReuseBuffer);
   // `input` can be a cast of a fusion input.
   if (!input->isFusionInput()) {
     auto input_expr = input->definition();
@@ -823,7 +823,7 @@ void Fusion::aliasOutputToInput(
 
 const AliasInfo& Fusion::getOutputAlias(const Val* output) const {
   static AliasInfo no_alias_info{
-      .type = AllocationType::NoAlias,
+      .type = AllocationType::New,
       .aliased_io = nullptr,
       .hide_output = false};
   if (auto search = io_alias_.find(output); search != io_alias_.end()) {

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -823,9 +823,7 @@ void Fusion::aliasOutputToInput(
 
 const AliasInfo& Fusion::getOutputAlias(const Val* output) const {
   static AliasInfo no_alias_info{
-      .type = AllocationType::New,
-      .aliased_io = nullptr,
-      .hide_output = false};
+      .type = AllocationType::New, .aliased_io = nullptr, .hide_output = false};
   if (auto search = io_alias_.find(output); search != io_alias_.end()) {
     return search->second;
   }

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -86,10 +86,10 @@ class FusionGuard {
 // Set the enum base to `int` so it can be safely serialized as a part of
 // serde::InputOutputAlias.
 enum class AllocationType : int {
-  NoAlias,
-  // For example, the tensor storing BatchNorm's running mean. The output EMA is
-  // updated in place.
-  InplaceUpdate,
+  New, // Allocate a new buffer
+  // Reuse the buffer allocated to `aliased_io`. For example, the tensor storing
+  // BatchNorm's running mean. The output EMA is updated in place.
+  ReuseBuffer,
   // This is used to cheaply compute the output tensor using
   // `ExpressionEvaluator` (instead of a kernel) for:
   // 1. PointerArithmetics: For example, the output of a ViewOp is merely a
@@ -104,7 +104,7 @@ struct AliasInfo {
   AllocationType type;
   Val* aliased_io;
   // Whether integration should hide the output from users. This is currently
-  // only used for InplaceUpdate.
+  // only used for ReuseBuffer.
   bool hide_output;
 };
 
@@ -253,7 +253,7 @@ class NVF_API Fusion : public IrContainer {
   // TODO: alias should be made aware to segmentation, so we'll always include
   // the input tensor to the section where output is produced. Currently,
   // aliases of type `PointerArithmetics` are marked after segmentation, but
-  // those of type `InplaceUpdate` are marked in fusion definitions.
+  // those of type `ReuseBuffer` are marked in fusion definitions.
   NVF_API void aliasOutputToInput(Val* output, Val* input, AllocationType type);
 
   //! Returns the aliased input of a given output along with an `AliasInfo`

--- a/csrc/ops/normalization.cpp
+++ b/csrc/ops/normalization.cpp
@@ -560,19 +560,19 @@ ForwardNormResult batch_norm(
         auto cast_output = castOp(*rm_dtype, aliased_output);
 
         fusion->aliasOutputToInput(
-            cast_output, input_to_cast, AllocationType::InplaceUpdate);
+            cast_output, input_to_cast, AllocationType::ReuseBuffer);
       };
 
       if (running_mean->isFusionInput()) {
         fusion->aliasOutputToInput(
-            new_mean_hat, running_mean, AllocationType::InplaceUpdate);
+            new_mean_hat, running_mean, AllocationType::ReuseBuffer);
       } else {
         cast_to_input_dtype(running_mean, new_mean_hat);
       }
 
       if (running_var->isFusionInput()) {
         fusion->aliasOutputToInput(
-            new_var_hat, running_var, AllocationType::InplaceUpdate);
+            new_var_hat, running_var, AllocationType::ReuseBuffer);
       } else {
         cast_to_input_dtype(running_var, new_var_hat);
       }
@@ -816,7 +816,7 @@ ForwardNormResult instance_norm(
             castOp(running_mean->getDataType().value(), new_mean_channels_only);
       }
       fusion->aliasOutputToInput(
-          new_mean_channels_only, running_mean, AllocationType::InplaceUpdate);
+          new_mean_channels_only, running_mean, AllocationType::ReuseBuffer);
 
       auto num_feature_decrement = sub(N, x->container()->oneVal(N->dtype()));
       auto unbiased_var =
@@ -837,7 +837,7 @@ ForwardNormResult instance_norm(
             castOp(running_var->getDataType().value(), new_var_channels_only);
       }
       fusion->aliasOutputToInput(
-          new_var_channels_only, running_var, AllocationType::InplaceUpdate);
+          new_var_channels_only, running_var, AllocationType::ReuseBuffer);
     }
 
     mean = welford_out.avg;

--- a/csrc/preseg_passes/allocation_order_inference.cpp
+++ b/csrc/preseg_passes/allocation_order_inference.cpp
@@ -278,7 +278,7 @@ void AllocationDomainPass::runPass(Fusion* fusion) {
     //   semantical
     //   3. tensor output that's aliasing (Does aliased src matter?)
     if (out_tv == nullptr || out_tv->hasAllocation() ||
-        fusion->getOutputAlias(out_val).type != AllocationType::NoAlias) {
+        fusion->getOutputAlias(out_val).type != AllocationType::New) {
       continue;
     }
 

--- a/csrc/python_frontend/fusion_state.cpp
+++ b/csrc/python_frontend/fusion_state.cpp
@@ -162,8 +162,8 @@ void FusionState::addOutput(
 void FusionState::aliasOutputToInput(Val* output, Val* input) {
   NVF_CHECK(fusion_ != nullptr, "Fusion is undefined.");
   // We haven't exposed AllocationType to Python API. For now, use
-  // InplaceUpdate to preserve the old behavior.
-  fusion_->aliasOutputToInput(output, input, AllocationType::InplaceUpdate);
+  // ReuseBuffer to preserve the old behavior.
+  fusion_->aliasOutputToInput(output, input, AllocationType::ReuseBuffer);
 }
 
 } // namespace nvfuser::python_frontend

--- a/test/test_alias.cpp
+++ b/test/test_alias.cpp
@@ -1049,7 +1049,7 @@ TEST_F(AliasTest, SegmentBoundary) {
           HeuristicIs(ScheduleHeuristic::PointWise)));
 }
 
-TEST_F(AliasTest, InPlaceUpdateAliasAcrossSegments) {
+TEST_F(AliasTest, ReuseBufferAliasAcrossSegments) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -1069,7 +1069,7 @@ TEST_F(AliasTest, InPlaceUpdateAliasAcrossSegments) {
   TensorView* tv6 = add(tv5, tv2); //  Group 1 (Broadcast after reduce)
 
   // Note: test alias;
-  fusion->aliasOutputToInput(tv6, tv0, AllocationType::InplaceUpdate);
+  fusion->aliasOutputToInput(tv6, tv0, AllocationType::ReuseBuffer);
   // TODO: support output on aliased fusion #1488
   // remove tv7 after #1488
   // fusion->addOutput(tv6);


### PR DESCRIPTION
This PR renames the `AllocationTypes`:

1. `NoAlias` -> `New`
2. `InplaceUpdate` -> `ReuseBuffer`
~3. `PointerArithmetic` and `Evaluate`-> `Evaluate`~

~Logic for `PointerArithmetic` and `Evaluate` is merged which removes additional code (`markOutputForEvaluation`) used for adding outputs of type `Evaluate` in PR #1743.~. This was done in PR #1775 