### PR TITLE
patch setAllocationDomain on rank-0 TensorView

### DIFF
--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -959,6 +959,10 @@ std::vector<Statement*> next(Statement* stmt) {
 void validateDomainEquivalence(
     const std::vector<IterDomain*>& initial_domain,
     const std::vector<IterDomain*>& derived_domain) {
+  // empty domain are equivalent.
+  if (initial_domain.empty() && derived_domain.empty()) {
+    return;
+  }
   ValidateDomainEquivalence(initial_domain, derived_domain);
 }
 

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -827,6 +827,10 @@ class ValidateDomainEquivalence : private IterVisitor {
       : initial_domain_({initial_domain.begin(), initial_domain.end()}),
         derived_domain_({derived_domain.begin(), derived_domain.end()}),
         frontier_({initial_domain.begin(), initial_domain.end()}) {
+    // empty domain are equivalent.
+    if (initial_domain.empty() && derived_domain.empty()) {
+      return;
+    }
     NVF_ERROR(!initial_domain.empty());
     NVF_ERROR(!derived_domain.empty());
     // Make sure there's no duplicate in the parameter vectors
@@ -959,10 +963,6 @@ std::vector<Statement*> next(Statement* stmt) {
 void validateDomainEquivalence(
     const std::vector<IterDomain*>& initial_domain,
     const std::vector<IterDomain*>& derived_domain) {
-  // empty domain are equivalent.
-  if (initial_domain.empty() && derived_domain.empty()) {
-    return;
-  }
   ValidateDomainEquivalence(initial_domain, derived_domain);
 }
 

--- a/csrc/optimization/mark_aliases_prepare.cpp
+++ b/csrc/optimization/mark_aliases_prepare.cpp
@@ -49,12 +49,6 @@ void MarkAliasesPreparePass::runPass(Fusion* fusion) {
       continue;
     }
 
-    // A scalar `tv` triggers a corner case that crashes
-    // `validateDomainEquivalence`.
-    if (tv->isZeroDim()) {
-      continue;
-    }
-
     const Layout preferred_layout = analysis.preferredLayout(tv);
     tv->setAllocationDomain(
         preferred_layout.allocation_domain, preferred_layout.contiguity);

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1333,4 +1333,12 @@ TEST_F(AllocationDomainTest, Issue1524) {
   fec.runFusionWithInputs({in_tensor});
 }
 
+TEST_F(AllocationDomainTest, EmptyAllocationDomainApi) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = TensorViewBuilder().ndims(0).build();
+  tv0->setAllocationDomain({}, true);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Setting empyt allocatoin domain on rank-0 tensor shouldn't trigger assert.