### PR TITLE
Compute validation reference in `double` [1]

### DIFF
--- a/python_benchmarks/normalization.py
+++ b/python_benchmarks/normalization.py
@@ -340,23 +340,23 @@ def norm_bwd_benchmark(
         # PyTorch expects running mean and variance to be of same type as input.
         if norm == "batch_norm":
             eager_output = torch.nn.functional.batch_norm(
-                at_inputs,
-                running_mean.to(dtype),
-                running_var.to(dtype),
-                weight=weight,
-                bias=bias,
+                at_inputs.to(torch.double),
+                running_mean.to(torch.double),
+                running_var.to(torch.double),
+                weight=weight.to(torch.double),
+                bias=bias.to(torch.double),
                 training=True,
             )
         elif norm == "instance_norm":
             eager_output = torch.nn.functional.instance_norm(
-                at_inputs,
-                running_mean.to(dtype),
-                running_var.to(dtype),
-                weight=weight,
-                bias=bias,
+                at_inputs.to(torch.double),
+                running_mean.to(torch.double),
+                running_var.to(torch.double),
+                weight=weight.to(torch.double),
+                bias=bias.to(torch.double),
             )
 
-        eager_output.backward(at_grads)
+        eager_output.backward(at_grads.to(torch.double))
 
         if channels_last:
             eager_grad = at_inputs.grad.permute((0, *range(2, num_dims), 1))

--- a/python_benchmarks/test_dropout_rmsnorm_bwd.py
+++ b/python_benchmarks/test_dropout_rmsnorm_bwd.py
@@ -120,7 +120,9 @@ def test_rmsnorm_bwd_benchmark(
         dropout_rmsnorm_bwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), dropout_p)
 
     if not disable_validation:
-        eager_output = weights.to(torch.double) * (x.to(torch.double) / rms_eps.to(torch.double))
+        eager_output = weights.to(torch.double) * (
+            x.to(torch.double) / rms_eps.to(torch.double)
+        )
         eager_output.backward(grads.to(torch.double))
         fd.validate(
             [inputs, dropout_mask, rms_eps, grads, weights], [inputs.grad, weights.grad]

--- a/python_benchmarks/test_dropout_rmsnorm_bwd.py
+++ b/python_benchmarks/test_dropout_rmsnorm_bwd.py
@@ -120,7 +120,7 @@ def test_rmsnorm_bwd_benchmark(
         dropout_rmsnorm_bwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), dropout_p)
 
     if not disable_validation:
-        eager_output = weights * (x / rms_eps)
+        eager_output = weights.to(torch.double) * (x.to(torch.double) / rms_eps.to(torch.double))
         eager_output.backward(grads.to(torch.double))
         fd.validate(
             [inputs, dropout_mask, rms_eps, grads, weights], [inputs.grad, weights.grad]

--- a/python_benchmarks/test_gelu_bwd.py
+++ b/python_benchmarks/test_gelu_bwd.py
@@ -71,8 +71,8 @@ def test_gelu_bwd_benchmark(
         gelu_bwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
 
     if not disable_validation:
-        eager_output = torch.nn.functional.gelu(inputs + bias, approximate="tanh")
-        eager_output.backward(grads)
+        eager_output = torch.nn.functional.gelu(inputs.to(torch.double) + bias.to(torch.double), approximate="tanh")
+        eager_output.backward(grads.to(torch.double))
         fd.validate([inputs, grads, bias], [inputs.grad])
 
     if not disable_benchmarking:

--- a/python_benchmarks/test_gelu_bwd.py
+++ b/python_benchmarks/test_gelu_bwd.py
@@ -71,7 +71,9 @@ def test_gelu_bwd_benchmark(
         gelu_bwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
 
     if not disable_validation:
-        eager_output = torch.nn.functional.gelu(inputs.to(torch.double) + bias.to(torch.double), approximate="tanh")
+        eager_output = torch.nn.functional.gelu(
+            inputs.to(torch.double) + bias.to(torch.double), approximate="tanh"
+        )
         eager_output.backward(grads.to(torch.double))
         fd.validate([inputs, grads, bias], [inputs.grad])
 

--- a/python_benchmarks/test_gelu_bwd_reduction.py
+++ b/python_benchmarks/test_gelu_bwd_reduction.py
@@ -75,10 +75,10 @@ def test_gelu_bwd_reduction_benchmark(
         )
 
     if not disable_validation:
-        eager_output = torch.nn.functional.gelu(inputs + bias, approximate="tanh")
-        eager_output.backward(grads)
-        reduction_out = inputs.grad.sum(reduction_axis)
-        fd.validate([inputs, grads, bias], [reduction_out])
+        eager_output = torch.nn.functional.gelu(inputs.to(torch.double) + bias.to(torch.double), approximate="tanh")
+        eager_output.backward(grads.to(torch.double))
+        reduction_out = inputs.grad.to(torch.double).sum(reduction_axis)
+        fd.validate([inputs, grads, bias], [reduction_out.to(dtype)])
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [inputs, grads, bias])

--- a/python_benchmarks/test_gelu_bwd_reduction.py
+++ b/python_benchmarks/test_gelu_bwd_reduction.py
@@ -75,7 +75,9 @@ def test_gelu_bwd_reduction_benchmark(
         )
 
     if not disable_validation:
-        eager_output = torch.nn.functional.gelu(inputs.to(torch.double) + bias.to(torch.double), approximate="tanh")
+        eager_output = torch.nn.functional.gelu(
+            inputs.to(torch.double) + bias.to(torch.double), approximate="tanh"
+        )
         eager_output.backward(grads.to(torch.double))
         reduction_out = inputs.grad.to(torch.double).sum(reduction_axis)
         fd.validate([inputs, grads, bias], [reduction_out.to(dtype)])

--- a/python_benchmarks/test_reduction.py
+++ b/python_benchmarks/test_reduction.py
@@ -41,8 +41,8 @@ def test_reduction_benchmark(
         reduction_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), reduction_axis)
 
     if not disable_validation:
-        eager_output = torch.sum(inputs[0], dim=reduction_axis)
-        fd.validate(inputs, [eager_output])
+        eager_output = torch.sum(inputs[0].to(torch.double), dim=reduction_axis)
+        fd.validate(inputs, [eager_output.to(dtype)])
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, inputs)


### PR DESCRIPTION
Issue #1765.

Compute references in `double`, starting with the benchmarks where we have existing validation errors in CI.