### PR TITLE
Sync after mbarrier init

### DIFF
--- a/test/test_mbarrier.cpp
+++ b/test/test_mbarrier.cpp
@@ -96,11 +96,14 @@ TEST_F(MBarrierTest, Simple) {
     ASSERT_NE(smem_alloc_it, top_level_exprs.end());
     auto init = IrBuilder::create<kir::MBarrierInit>(
         mbarrier_index, IrBuilder::create<Val>(1024, DataType::UInt32));
+    auto sync = IrBuilder::create<kir::BlockSync>();
+    top_level_exprs.insert(smem_alloc_it, sync);
     top_level_exprs.insert(smem_alloc_it, init);
+    smem_alloc_it += 2;
 
     // Arrive and wait
     auto sync_it = std::find_if(
-        top_level_exprs.begin(), top_level_exprs.end(), [](Expr* expr) {
+        smem_alloc_it, top_level_exprs.end(), [](Expr* expr) {
           return expr->isA<kir::BlockSync>();
         });
     ASSERT_NE(sync_it, top_level_exprs.end());

--- a/test/test_mbarrier.cpp
+++ b/test/test_mbarrier.cpp
@@ -102,8 +102,8 @@ TEST_F(MBarrierTest, Simple) {
     smem_alloc_it += 2;
 
     // Arrive and wait
-    auto sync_it = std::find_if(
-        smem_alloc_it, top_level_exprs.end(), [](Expr* expr) {
+    auto sync_it =
+        std::find_if(smem_alloc_it, top_level_exprs.end(), [](Expr* expr) {
           return expr->isA<kir::BlockSync>();
         });
     ASSERT_NE(sync_it, top_level_exprs.end());


### PR DESCRIPTION
Tentatively fixes https://github.com/NVIDIA/Fuser/issues/1552. I can not reproduce it locally, but I think it does make sense to have the sync, so adding it.

```C++
__global__ void nvfuser_none_f0_c0_r0_g0(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T2) {
  alignas(16) extern __shared__ char array[];
  const unsigned smem_offset = 0;
  nvfuser_index_t i0;
  i0 = ((nvfuser_index_t)threadIdx.y) + (32LL * ((nvfuser_index_t)threadIdx.x));
  nvfuser_index_t i1;
  i1 = ((nvfuser_index_t)threadIdx.x) + (32LL * ((nvfuser_index_t)threadIdx.y));
  float* T1 = reinterpret_cast<float*>(array + smem_offset + 0LL);
  uint64_t* T3 = reinterpret_cast<uint64_t*>(array + smem_offset + 4096LL);
  mbarrier::init(toSmem(T3), 1024U);
  __syncthreads();
  T1[i0]
     = T0[i0];
  uint64_t i2;
  i2 = mbarrier::arrive(toSmem(T3));
  mbarrier::wait(toSmem(T3), i2);
  T2[i1]
     = T1[i1];
  mbarrier::inval(toSmem(T3));
}
```