### PR TITLE
Matmul default scheduling 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,7 +514,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/test/test_smem_reuse.cpp
   ${NVFUSER_ROOT}/test/test_swizzle.cpp
   ${NVFUSER_ROOT}/test/test_tensor_factories.cpp
-  ${NVFUSER_ROOT}/test/test_matmul_default.cpp
+  ${NVFUSER_ROOT}/test/test_matmul_aten_evaluation.cpp
 )
 
 if(BUILD_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,6 +514,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/test/test_smem_reuse.cpp
   ${NVFUSER_ROOT}/test/test_swizzle.cpp
   ${NVFUSER_ROOT}/test/test_tensor_factories.cpp
+  ${NVFUSER_ROOT}/test/test_matmul_default.cpp
 )
 
 if(BUILD_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,7 +514,6 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/test/test_smem_reuse.cpp
   ${NVFUSER_ROOT}/test/test_swizzle.cpp
   ${NVFUSER_ROOT}/test/test_tensor_factories.cpp
-  ${NVFUSER_ROOT}/test/test_matmul_aten_evaluation.cpp
 )
 
 if(BUILD_TEST)
@@ -583,6 +582,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/test/test_matmul_sass.cpp
     ${NVFUSER_ROOT}/test/test_matmul_scheduler.cpp
     ${NVFUSER_ROOT}/test/test_gpu_tensorcore.cpp
+    ${NVFUSER_ROOT}/test/test_matmul_aten_evaluation.cpp
   )
   add_test(test_matmul "${MATMUL_TEST_SRCS}" "")
   list(APPEND TEST_BINARIES test_matmul)

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -863,6 +863,8 @@ class PredicateChcker : public IterVisitor {
 } // namespace
 
 PredicateElimination::PredicateElimination(Fusion* fusion) {
+  // To avoid errors in analysis when using ATen evaluation for matmul, only use
+  // outputs that require codegen. See PR # 1775 and Issue #1812
   traverseTo(fusion->getFusionOutputsRequiringCodegen());
 }
 

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -863,18 +863,7 @@ class PredicateChcker : public IterVisitor {
 } // namespace
 
 PredicateElimination::PredicateElimination(Fusion* fusion) {
-  // TODO: Common code as in expr_sort.cpp.
-  // Move to a helper function
-  std::vector<Val*> outs_requiring_codegen;
-  outs_requiring_codegen.reserve(fusion->outputs().size());
-  std::copy_if(
-      fusion->outputs().begin(),
-      fusion->outputs().end(),
-      std::back_inserter(outs_requiring_codegen),
-      [&fusion](Val* out) {
-        return (fusion->getOutputAlias(out).type != AllocationType::Evaluate);
-      });
-  traverseTo(outs_requiring_codegen);
+  traverseTo(fusion->getFusionOutputsRequiringCodegen());
 }
 
 bool PredicateElimination::needsPredicate(Expr* expr) const {

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -865,7 +865,7 @@ class PredicateChcker : public IterVisitor {
 PredicateElimination::PredicateElimination(Fusion* fusion) {
   // To avoid errors in analysis when using ATen evaluation for matmul, only use
   // outputs that require codegen. See PR # 1775 and Issue #1812
-  traverseTo(fusion->getFusionOutputsRequiringCodegen());
+  traverseTo(lower_utils::getFusionOutputsRequiringCodegen(fusion));
 }
 
 bool PredicateElimination::needsPredicate(Expr* expr) const {

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -863,7 +863,18 @@ class PredicateChcker : public IterVisitor {
 } // namespace
 
 PredicateElimination::PredicateElimination(Fusion* fusion) {
-  traverseTo(fusion->outputs());
+  // TODO: Common code as in expr_sort.cpp.
+  // Move to a helper function
+  std::vector<Val*> outs_requiring_codegen;
+  outs_requiring_codegen.reserve(fusion->outputs().size());
+  std::copy_if(
+      fusion->outputs().begin(),
+      fusion->outputs().end(),
+      std::back_inserter(outs_requiring_codegen),
+      [&fusion](Val* out) {
+        return (fusion->getOutputAlias(out).type != AllocationType::Evaluate);
+      });
+  traverseTo(outs_requiring_codegen);
 }
 
 bool PredicateElimination::needsPredicate(Expr* expr) const {

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1516,7 +1516,9 @@ void ExprSegmentationSorter::sort() {
       std::back_inserter(non_pointer_arithmetic_outs),
       [this](Val* out) {
         return fusion_->getOutputAlias(out).type !=
-            AllocationType::PointerArithmetic;
+            AllocationType::PointerArithmetic &&
+            fusion_->getOutputAlias(out).type !=
+            AllocationType::Evaluate;
       });
 
   // Not putting the exprs between fusion inputs and allKnownVals() here

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1506,14 +1506,15 @@ void ExprSegmentationSorter::sort() {
   // Need this for initialization of the DAG that is processed
   std::unordered_map<Expr*, ExprGroup*> expr2group;
 
-  // We skip generating code that computes only pointer-arithmetic outputs.
+  // We skip generating code that computes only pointer-arithmetic outputs
+  // or any output marked for expression evaluator (AllocationType::Evaluate).
   // Those outputs will be computed by ExpressionEvaluator.
-  std::vector<Val*> non_pointer_arithmetic_outs;
-  non_pointer_arithmetic_outs.reserve(fusion_->outputs().size());
+  std::vector<Val*> non_expr_evaluator_outs;
+  non_expr_evaluator_outs.reserve(fusion_->outputs().size());
   std::copy_if(
       fusion_->outputs().begin(),
       fusion_->outputs().end(),
-      std::back_inserter(non_pointer_arithmetic_outs),
+      std::back_inserter(non_expr_evaluator_outs),
       [this](Val* out) {
         return (fusion_->getOutputAlias(out).type !=
             AllocationType::PointerArithmetic &&
@@ -1524,7 +1525,7 @@ void ExprSegmentationSorter::sort() {
   // Not putting the exprs between fusion inputs and allKnownVals() here
   // because they are computed using the expr evaluator.
   auto all_exprs = StmtSort::getExprsBetween(
-      GpuLower::current()->allKnownVals(), non_pointer_arithmetic_outs);
+      GpuLower::current()->allKnownVals(), non_expr_evaluator_outs);
 
   // Figure out all the values used as inputs to the expressions we're sorting
   // (to find terminating expressions). There could be branches of expressions

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1509,12 +1509,12 @@ void ExprSegmentationSorter::sort() {
   // We skip generating code that computes only pointer-arithmetic outputs
   // or any output marked for expression evaluator (AllocationType::Evaluate).
   // Those outputs will be computed by ExpressionEvaluator.
-  std::vector<Val*> non_expr_evaluator_outs;
-  non_expr_evaluator_outs.reserve(fusion_->outputs().size());
+  std::vector<Val*> outs_requiring_codegen;
+  outs_requiring_codegen.reserve(fusion_->outputs().size());
   std::copy_if(
       fusion_->outputs().begin(),
       fusion_->outputs().end(),
-      std::back_inserter(non_expr_evaluator_outs),
+      std::back_inserter(outs_requiring_codegen),
       [this](Val* out) {
         return (
             fusion_->getOutputAlias(out).type !=
@@ -1525,7 +1525,7 @@ void ExprSegmentationSorter::sort() {
   // Not putting the exprs between fusion inputs and allKnownVals() here
   // because they are computed using the expr evaluator.
   auto all_exprs = StmtSort::getExprsBetween(
-      GpuLower::current()->allKnownVals(), non_expr_evaluator_outs);
+      GpuLower::current()->allKnownVals(), outs_requiring_codegen);
 
   // Figure out all the values used as inputs to the expressions we're sorting
   // (to find terminating expressions). There could be branches of expressions

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1509,15 +1509,8 @@ void ExprSegmentationSorter::sort() {
   // We skip generating code that computes only pointer-arithmetic outputs
   // or any output marked for expression evaluator (AllocationType::Evaluate).
   // Those outputs will be computed by ExpressionEvaluator.
-  std::vector<Val*> outs_requiring_codegen;
-  outs_requiring_codegen.reserve(fusion_->outputs().size());
-  std::copy_if(
-      fusion_->outputs().begin(),
-      fusion_->outputs().end(),
-      std::back_inserter(outs_requiring_codegen),
-      [this](Val* out) {
-        return (fusion_->getOutputAlias(out).type != AllocationType::Evaluate);
-      });
+  std::vector<Val*> outs_requiring_codegen =
+      fusion_->getFusionOutputsRequiringCodegen();
 
   // Not putting the exprs between fusion inputs and allKnownVals() here
   // because they are computed using the expr evaluator.

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1516,10 +1516,10 @@ void ExprSegmentationSorter::sort() {
       fusion_->outputs().end(),
       std::back_inserter(non_expr_evaluator_outs),
       [this](Val* out) {
-        return (fusion_->getOutputAlias(out).type !=
-            AllocationType::PointerArithmetic &&
+        return (
             fusion_->getOutputAlias(out).type !=
-            AllocationType::Evaluate);
+                AllocationType::PointerArithmetic &&
+            fusion_->getOutputAlias(out).type != AllocationType::Evaluate);
       });
 
   // Not putting the exprs between fusion inputs and allKnownVals() here

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1518,8 +1518,7 @@ void ExprSegmentationSorter::sort() {
       [this](Val* out) {
         return (
             fusion_->getOutputAlias(out).type !=
-                AllocationType::PointerArithmetic &&
-            fusion_->getOutputAlias(out).type != AllocationType::Evaluate);
+                AllocationType::Evaluate);
       });
 
   // Not putting the exprs between fusion inputs and allKnownVals() here

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1516,9 +1516,7 @@ void ExprSegmentationSorter::sort() {
       fusion_->outputs().end(),
       std::back_inserter(outs_requiring_codegen),
       [this](Val* out) {
-        return (
-            fusion_->getOutputAlias(out).type !=
-                AllocationType::Evaluate);
+        return (fusion_->getOutputAlias(out).type != AllocationType::Evaluate);
       });
 
   // Not putting the exprs between fusion inputs and allKnownVals() here

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1515,10 +1515,10 @@ void ExprSegmentationSorter::sort() {
       fusion_->outputs().end(),
       std::back_inserter(non_pointer_arithmetic_outs),
       [this](Val* out) {
-        return fusion_->getOutputAlias(out).type !=
+        return (fusion_->getOutputAlias(out).type !=
             AllocationType::PointerArithmetic &&
             fusion_->getOutputAlias(out).type !=
-            AllocationType::Evaluate;
+            AllocationType::Evaluate);
       });
 
   // Not putting the exprs between fusion inputs and allKnownVals() here

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1510,7 +1510,7 @@ void ExprSegmentationSorter::sort() {
   // or any output marked for expression evaluator (AllocationType::Evaluate).
   // Those outputs will be computed by ExpressionEvaluator.
   std::vector<Val*> outs_requiring_codegen =
-      fusion_->getFusionOutputsRequiringCodegen();
+      lower_utils::getFusionOutputsRequiringCodegen(fusion_);
 
   // Not putting the exprs between fusion inputs and allKnownVals() here
   // because they are computed using the expr evaluator.

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -852,23 +852,6 @@ Val* getGridSyncBufferSize(const ParallelTypeBitmap& ptb) {
   return buffer_size;
 }
 
-std::vector<Expr*> getExprsToCodegen(Fusion* fusion) {
-  std::vector<Expr*> exprs_requiring_codegen;
-  exprs_requiring_codegen.reserve(fusion->exprs().size());
-
-  for (auto expr : fusion->exprs()) {
-    bool is_expr_codegen = std::none_of(
-        expr->outputs().begin(), expr->outputs().end(), [&fusion](Val* out) {
-          return fusion->getOutputAlias(out).type != AllocationType::Evaluate;
-        });
-
-    if (is_expr_codegen) {
-      exprs_requiring_codegen.emplace_back(expr);
-    }
-  }
-  return exprs_requiring_codegen;
-}
-
 std::vector<Val*> getFusionOutputsRequiringCodegen(Fusion* fusion) {
   std::vector<Val*> outs_requiring_codegen;
   outs_requiring_codegen.reserve(fusion->outputs().size());

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -307,6 +307,16 @@ NVF_API Val* u32IndexScalarSmemTv(TensorView* tv);
 //! each axis in bitmap.
 Val* getGridSyncBufferSize(const ParallelTypeBitmap& bitmap);
 
+//! Returns the expressions that require codegen.
+//! Expressions where all the outputs are marked to be computed through
+//! expression evaluator are filtered out.
+std::vector<Expr*> getExprsToCodegen(Fusion* fusion);
+
+//! Returns the fusion outputs that require codegen.
+//! The fusion outputs to be computed through expression evaluator are
+//! filtered out.
+std::vector<Val*> getFusionOutputsRequiringCodegen(Fusion* fusion);
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -307,11 +307,6 @@ NVF_API Val* u32IndexScalarSmemTv(TensorView* tv);
 //! each axis in bitmap.
 Val* getGridSyncBufferSize(const ParallelTypeBitmap& bitmap);
 
-//! Returns the expressions that require codegen.
-//! Expressions where all the outputs are marked to be computed through
-//! expression evaluator are filtered out.
-std::vector<Expr*> getExprsToCodegen(Fusion* fusion);
-
 //! Returns the fusion outputs that require codegen.
 //! The fusion outputs to be computed through expression evaluator are
 //! filtered out.

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -1006,7 +1006,7 @@ void validateSizeMemoryOp(LoadStoreOp* ldst) {
 //! Validate data format and GPU arch compatibility of scheduled
 //!  mma operators on the fusion.
 void validateMma(Fusion* fusion) {
-  auto exprs = StmtSort::getExprs(fusion);
+  auto exprs = fusion->getExprsToCodegen();
 
   for (auto expr : exprs) {
     if (auto mma = dynamic_cast<MmaOp*>(expr)) {

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -1008,7 +1008,10 @@ void validateSizeMemoryOp(LoadStoreOp* ldst) {
 void validateMma(Fusion* fusion) {
   // To avoid errors in analysis when using ATen evaluation for matmul, only
   // validate expressions that require codegen. See PR # 1775 and Issue #1812
-  auto exprs = lower_utils::getExprsToCodegen(fusion);
+  std::vector<Val*> outs_requiring_codegen =
+      lower_utils::getFusionOutputsRequiringCodegen(fusion);
+  auto exprs = StmtSort::getExprsBetween(
+      GpuLower::current()->allKnownVals(), outs_requiring_codegen);
 
   for (auto expr : exprs) {
     if (auto mma = dynamic_cast<MmaOp*>(expr)) {

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -1006,6 +1006,8 @@ void validateSizeMemoryOp(LoadStoreOp* ldst) {
 //! Validate data format and GPU arch compatibility of scheduled
 //!  mma operators on the fusion.
 void validateMma(Fusion* fusion) {
+  // To avoid errors in analysis when using ATen evaluation for matmul, only
+  // validate expressions that require codegen. See PR # 1775 and Issue #1812
   auto exprs = fusion->getExprsToCodegen();
 
   for (auto expr : exprs) {

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -1008,7 +1008,7 @@ void validateSizeMemoryOp(LoadStoreOp* ldst) {
 void validateMma(Fusion* fusion) {
   // To avoid errors in analysis when using ATen evaluation for matmul, only
   // validate expressions that require codegen. See PR # 1775 and Issue #1812
-  auto exprs = fusion->getExprsToCodegen();
+  auto exprs = lower_utils::getExprsToCodegen(fusion);
 
   for (auto expr : exprs) {
     if (auto mma = dynamic_cast<MmaOp*>(expr)) {

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1008,7 +1008,7 @@ at::Tensor allocateOutput(
     // would trigger non-trivial host computation.
     return aliased_io_tensor;
   }
-  
+
   // Outputs which are pointer arithmetic of input tensor.
   NVF_ERROR(alias_info.type == AllocationType::Evaluate);
   at::Tensor out_tensor = ee.evaluate(out_tv).as<at::Tensor>();

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -977,6 +977,12 @@ at::Tensor allocateOutput(
     return alloc_tensor;
   }
 
+  if (alias_info.type == AllocationType::Evaluate) {
+    // Compute non-aliased outputs that were marked for expr evaluator.
+    at::Tensor out_tensor = ee.evaluate(out_tv).as<at::Tensor>();
+    return out_tensor;
+  }
+
   Val* aliased_io = alias_info.aliased_io;
   NVF_ERROR(
       aliased_io != nullptr,

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -963,63 +963,60 @@ at::Tensor allocateOutput(
     return ee.evaluate(out_tv).as<at::Tensor>();
   }
 
-  if (alias_info.type == AllocationType::NoAlias) {
-    auto alloc_tensor = at::native::empty_strided_cuda(
-        out_info.sizes,
-        out_info.strides,
-        out_info.type,
-        c10::nullopt,
-        device,
-        c10::nullopt);
-    if (shouldFillAllocationWithNan()) {
-      fillTensorWithNan(alloc_tensor);
-    }
-    return alloc_tensor;
-  }
-
-  if (alias_info.type == AllocationType::Evaluate && !alias_info.aliased_io) {
-    // Compute non-aliased outputs that were marked for expr evaluator.
-    at::Tensor out_tensor = ee.evaluate(out_tv).as<at::Tensor>();
-    return out_tensor;
-  }
-
+  std::optional<at::Tensor> aliased_io_tensor = std::nullopt;
   Val* aliased_io = alias_info.aliased_io;
-  NVF_ERROR(
-      aliased_io != nullptr,
-      "Other cases of AllocationTypes currently must have an `aliased_io`.");
-  NVF_ERROR(
-      aliased_io->isFusionInput() || aliased_io->isFusionOutput(),
-      aliased_io->toInlineString(),
-      " is expected to be a fusion input/output. `ee.evaluate` ",
-      "an intermediate tensor may involve GPU computation to materialize it ",
-      "to global memory.");
-  const PolymorphicValue& aliased_io_val = ee.evaluate(aliased_io);
-  NVF_ERROR(
-      aliased_io_val.is<at::Tensor>(),
-      "Alias io only supports tensor. Found ",
-      PolymorphicValue_functions::toString(aliased_io_val));
-  auto aliased_io_tensor = aliased_io_val.as<at::Tensor>();
-
-  if (alias_info.type == AllocationType::InplaceUpdate) {
-    // Unlike for `AllocationType::Evaluate`, don't use
-    // ExpressionEvaluator to compute the output tensor. This is because
-    // the output tensor may hold different data from the input, e.g., an
-    // updated running mean.  `ExpressionEvaluator::evaluate(out_tv)`
-    // would trigger non-trivial host computation.
-    return aliased_io_tensor;
+  if (aliased_io != nullptr) {
+    NVF_ERROR(
+        aliased_io->isFusionInput() || aliased_io->isFusionOutput(),
+        aliased_io->toInlineString(),
+        " is expected to be a fusion input/output. `ee.evaluate` ",
+        "an intermediate tensor may involve GPU computation to materialize it ",
+        "to global memory.");
+    const PolymorphicValue& aliased_io_val = ee.evaluate(aliased_io);
+    NVF_ERROR(
+        aliased_io_val.is<at::Tensor>(),
+        "Alias io only supports tensor. Found ",
+        PolymorphicValue_functions::toString(aliased_io_val));
+    aliased_io_tensor = aliased_io_val.as<at::Tensor>();
   }
 
-  // Outputs which are pointer arithmetic of input tensor.
-  NVF_ERROR(alias_info.type == AllocationType::Evaluate);
-  at::Tensor out_tensor = ee.evaluate(out_tv).as<at::Tensor>();
-  NVF_ERROR(
-      out_tensor.is_alias_of(aliased_io_tensor),
-      "ExpressionEvaluator failed to evaluate ",
-      out_tv->toString(),
-      " as an alias of ",
-      aliased_io->toString());
-  inferAndValidateAllocationSizesAndStrides(out_tensor, out_tv, ee);
-  return out_tensor;
+  switch (alias_info.type) {
+    case AllocationType::NoAlias: {
+      auto alloc_tensor = at::native::empty_strided_cuda(
+          out_info.sizes,
+          out_info.strides,
+          out_info.type,
+          c10::nullopt,
+          device,
+          c10::nullopt);
+      if (shouldFillAllocationWithNan()) {
+        fillTensorWithNan(alloc_tensor);
+      }
+      return alloc_tensor;
+    }
+    case AllocationType::InplaceUpdate:
+      // Unlike for `AllocationType::Evaluate`, don't use
+      // ExpressionEvaluator to compute the output tensor. This is because
+      // the output tensor may hold different data from the input, e.g., an
+      // updated running mean.  `ExpressionEvaluator::evaluate(out_tv)`
+      // would trigger non-trivial host computation.
+      return aliased_io_tensor.value();
+    case AllocationType::Evaluate: {
+      auto out_tensor = ee.evaluate(out_tv).as<at::Tensor>();
+      if (aliased_io_tensor.has_value()) {
+        NVF_ERROR(
+            out_tensor.is_alias_of(aliased_io_tensor.value()),
+            "ExpressionEvaluator failed to evaluate ",
+            out_tv->toString(),
+            " as an alias of ",
+            aliased_io->toString());
+        inferAndValidateAllocationSizesAndStrides(out_tensor, out_tv, ee);
+      }
+      return out_tensor;
+    }
+    default:
+      NVF_ERROR(false, "Unrecognized AllocationType.");
+  }
 }
 
 // Allocate output tensors for a given kernel. Outputs may alias inputs, in

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -783,7 +783,7 @@ void Fusion::aliasOutputToInput(
         AliasInfo{.type = type, .aliased_io = input, .hide_output = false};
     return;
   }
-  
+
   NVF_ERROR(type == AllocationType::InplaceUpdate);
   // `input` can be a cast of a fusion input.
   if (!input->isFusionInput()) {

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -829,6 +829,7 @@ bool Fusion::hasDynamicTransform() {
 }
 
 void Fusion::markOutputForEvaluation(Val* output){
+  NVF_CHECK(output->isFusionOutput(), "Only fusion outputs can be expression evaluaed.");
   io_alias_[output] = AliasInfo{
     .type = AllocationType::Evaluate,
     .aliased_io = nullptr,

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -854,15 +854,15 @@ std::vector<Expr*> Fusion::getExprsToCodegen() {
   return exprs_requiring_codegen;
 }
 
-std::vector<Val*> getFusionOutputsRequiringCodegen() {
+std::vector<Val*> Fusion::getFusionOutputsRequiringCodegen() {
   std::vector<Val*> outs_requiring_codegen;
   outs_requiring_codegen.reserve(outputs().size());
   std::copy_if(
-      fusion_->outputs().begin(),
-      fusion_->outputs().end(),
+      outputs().begin(),
+      outputs().end(),
       std::back_inserter(outs_requiring_codegen),
       [this](Val* out) {
-        return (fusion_->getOutputAlias(out).type != AllocationType::Evaluate);
+        return (this->getOutputAlias(out).type != AllocationType::Evaluate);
       });
   return outs_requiring_codegen;
 }

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -775,51 +775,50 @@ void Fusion::aliasOutputToInput(
       type != AllocationType::NoAlias,
       "NoAlias is returned automatically for a missing key. Don't add it explicitly.");
 
-  if (type == AllocationType::InplaceUpdate) {
-    // `input` can be a cast of a fusion input.
-    if (!input->isFusionInput()) {
-      auto input_expr = input->definition();
-      NVF_ERROR(
-          input_expr->isA<UnaryOp>(), "expected unary op for aliased input");
-      auto input_uop = input_expr->as<UnaryOp>();
-      NVF_ERROR(
-          input_uop->getUnaryOpType() == UnaryOpType::Cast,
-          "expected aliased input to be output of cast op");
-      input = input_uop->in();
-    }
-    NVF_ERROR(
-        input->getDataType().has_value() && output->getDataType().has_value(),
-        "requires DataType to be available for aliased output to input");
-
-    if (input->getDataType().value() != output->getDataType().value()) {
-      output = castOp(input->getDataType().value(), output);
-    }
-
-    NVF_ERROR(
-        isAliasCompatible(input, output),
-        "The input and output values are not alias-compatible.");
-    // Let integration hide any output that wasn't a fusion output when
-    // `aliasOutputToInput` was called. For example, running mean and var for
-    // batch norm.
-    io_alias_[output] = AliasInfo{
-        .type = type,
-        .aliased_io = input,
-        .hide_output = !output->isFusionOutput()};
-
-    // TODO: output should be marked at the end of fusion definition #1488
-    if (!output->isFusionOutput()) {
-      addOutput(output);
-    }
+  if (type == AllocationType::Evaluate) {
+    NVF_CHECK(
+        output->isFusionOutput(),
+        "Only fusion outputs can be expression evaluated.");
+    io_alias_[output] =
+        AliasInfo{.type = type, .aliased_io = input, .hide_output = false};
     return;
   }
+  
+  NVF_ERROR(type == AllocationType::InplaceUpdate);
+  // `input` can be a cast of a fusion input.
+  if (!input->isFusionInput()) {
+    auto input_expr = input->definition();
+    NVF_ERROR(
+        input_expr->isA<UnaryOp>(), "expected unary op for aliased input");
+    auto input_uop = input_expr->as<UnaryOp>();
+    NVF_ERROR(
+        input_uop->getUnaryOpType() == UnaryOpType::Cast,
+        "expected aliased input to be output of cast op");
+    input = input_uop->in();
+  }
+  NVF_ERROR(
+      input->getDataType().has_value() && output->getDataType().has_value(),
+      "requires DataType to be available for aliased output to input");
 
-  // AllocationType::Evaluate
-  NVF_ERROR(type == AllocationType::Evaluate);
-  NVF_CHECK(
-      output->isFusionOutput(),
-      "Only fusion outputs can be expression evaluated.");
-  io_alias_[output] =
-      AliasInfo{.type = type, .aliased_io = input, .hide_output = false};
+  if (input->getDataType().value() != output->getDataType().value()) {
+    output = castOp(input->getDataType().value(), output);
+  }
+
+  NVF_ERROR(
+      isAliasCompatible(input, output),
+      "The input and output values are not alias-compatible.");
+  // Let integration hide any output that wasn't a fusion output when
+  // `aliasOutputToInput` was called. For example, running mean and var for
+  // batch norm.
+  io_alias_[output] = AliasInfo{
+      .type = type,
+      .aliased_io = input,
+      .hide_output = !output->isFusionOutput()};
+
+  // TODO: output should be marked at the end of fusion definition #1488
+  if (!output->isFusionOutput()) {
+    addOutput(output);
+  }
 }
 
 const AliasInfo& Fusion::getOutputAlias(const Val* output) const {

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -833,7 +833,7 @@ void Fusion::markOutputForEvaluation(Val* output){
   io_alias_[output] = AliasInfo{
     .type = AllocationType::Evaluate,
     .aliased_io = nullptr,
-    .hide_output = !output->isFusionOutput()
+    .hide_output = false
   };
 }
 

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -837,34 +837,4 @@ bool Fusion::hasDynamicTransform() {
   return !ir_utils::getTVsWithDynamicTransform(this).empty();
 }
 
-std::vector<Expr*> Fusion::getExprsToCodegen() {
-  std::vector<Expr*> exprs_requiring_codegen;
-  exprs_requiring_codegen.reserve(exprs().size());
-
-  for (auto expr : exprs()) {
-    bool is_expr_codegen = std::none_of(
-        expr->outputs().begin(), expr->outputs().end(), [this](Val* out) {
-          return this->getOutputAlias(out).type != AllocationType::Evaluate;
-        });
-
-    if (is_expr_codegen) {
-      exprs_requiring_codegen.emplace_back(expr);
-    }
-  }
-  return exprs_requiring_codegen;
-}
-
-std::vector<Val*> Fusion::getFusionOutputsRequiringCodegen() {
-  std::vector<Val*> outs_requiring_codegen;
-  outs_requiring_codegen.reserve(outputs().size());
-  std::copy_if(
-      outputs().begin(),
-      outputs().end(),
-      std::back_inserter(outs_requiring_codegen),
-      [this](Val* out) {
-        return (this->getOutputAlias(out).type != AllocationType::Evaluate);
-      });
-  return outs_requiring_codegen;
-}
-
 } // namespace nvfuser

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -828,13 +828,14 @@ bool Fusion::hasDynamicTransform() {
   return !ir_utils::getTVsWithDynamicTransform(this).empty();
 }
 
-void Fusion::markOutputForEvaluation(Val* output){
-  NVF_CHECK(output->isFusionOutput(), "Only fusion outputs can be expression evaluaed.");
+void Fusion::markOutputForEvaluation(Val* output) {
+  NVF_CHECK(
+      output->isFusionOutput(),
+      "Only fusion outputs can be expression evaluaed.");
   io_alias_[output] = AliasInfo{
-    .type = AllocationType::Evaluate,
-    .aliased_io = nullptr,
-    .hide_output = false
-  };
+      .type = AllocationType::Evaluate,
+      .aliased_io = nullptr,
+      .hide_output = false};
 }
 
 } // namespace nvfuser

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -796,8 +796,8 @@ void Fusion::aliasOutputToInput(
     }
 
     NVF_ERROR(
-      isAliasCompatible(input, output),
-      "The input and output values are not alias-compatible.");
+        isAliasCompatible(input, output),
+        "The input and output values are not alias-compatible.");
     // Let integration hide any output that wasn't a fusion output when
     // `aliasOutputToInput` was called. For example, running mean and var for
     // batch norm.
@@ -841,13 +841,12 @@ std::vector<Expr*> Fusion::getExprsToCodegen() {
   std::vector<Expr*> exprs_requiring_codegen;
   exprs_requiring_codegen.reserve(exprs().size());
 
-  for (auto expr: exprs()) {
+  for (auto expr : exprs()) {
     bool is_expr_codegen = std::none_of(
-        expr->outputs().begin(),
-        expr->outputs().end(),
-        [this](Val* out) { 
-          return this->getOutputAlias(out).type != AllocationType::Evaluate;});
-    
+        expr->outputs().begin(), expr->outputs().end(), [this](Val* out) {
+          return this->getOutputAlias(out).type != AllocationType::Evaluate;
+        });
+
     if (is_expr_codegen) {
       exprs_requiring_codegen.emplace_back(expr);
     }

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -828,11 +828,9 @@ bool Fusion::hasDynamicTransform() {
   return !ir_utils::getTVsWithDynamicTransform(this).empty();
 }
 
-void Fusion::markOutputForEvaluation(Val* output, const AllocationType type){
-  NVF_ERROR(type == AllocationType::Evaluate,
-    "Expected AllocationType to be Evaluate. For any other AllocationType, use aliasOutputToInput.");
+void Fusion::markOutputForEvaluation(Val* output){
   io_alias_[output] = AliasInfo{
-    .type = type,
+    .type = AllocationType::Evaluate,
     .aliased_io = nullptr,
     .hide_output = !output->isFusionOutput()
   };

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -828,4 +828,14 @@ bool Fusion::hasDynamicTransform() {
   return !ir_utils::getTVsWithDynamicTransform(this).empty();
 }
 
+void Fusion::markOutputForEvaluation(Val* output, const AllocationType type){
+  NVF_ERROR(type == AllocationType::Evaluate,
+    "Expected AllocationType to be Evaluate. For any other AllocationType, use aliasOutputToInput.");
+  io_alias_[output] = AliasInfo{
+    .type = type,
+    .aliased_io = nullptr,
+    .hide_output = !output->isFusionOutput()
+  };
+}
+
 } // namespace nvfuser

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -854,4 +854,17 @@ std::vector<Expr*> Fusion::getExprsToCodegen() {
   return exprs_requiring_codegen;
 }
 
+std::vector<Val*> getFusionOutputsRequiringCodegen() {
+  std::vector<Val*> outs_requiring_codegen;
+  outs_requiring_codegen.reserve(outputs().size());
+  std::copy_if(
+      fusion_->outputs().begin(),
+      fusion_->outputs().end(),
+      std::back_inserter(outs_requiring_codegen),
+      [this](Val* out) {
+        return (fusion_->getOutputAlias(out).type != AllocationType::Evaluate);
+      });
+  return outs_requiring_codegen;
+}
+
 } // namespace nvfuser

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -838,4 +838,22 @@ void Fusion::markOutputForEvaluation(Val* output) {
       .hide_output = false};
 }
 
+std::vector<Expr*> Fusion::getExprsToCodegen() {
+  std::vector<Expr*> exprs_requiring_codegen;
+  exprs_requiring_codegen.reserve(exprs().size());
+
+  for (auto expr: exprs()) {
+    bool is_expr_codegen = std::none_of(
+        expr->outputs().begin(),
+        expr->outputs().end(),
+        [this](Val* out) { 
+          return this->getOutputAlias(out).type != AllocationType::Evaluate;});
+    
+    if (is_expr_codegen) {
+      exprs_requiring_codegen.emplace_back(expr);
+    }
+  }
+  return exprs_requiring_codegen;
+}
+
 } // namespace nvfuser

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -261,16 +261,6 @@ class NVF_API Fusion : public IrContainer {
   //! aliased.
   const AliasInfo& getOutputAlias(const Val* output) const;
 
-  //! Returns the expressions that require codegen.
-  //! Expressions where all the outputs are marked to be computed through
-  //! expression evaluator are filtered out.
-  std::vector<Expr*> getExprsToCodegen();
-
-  //! Returns the fusion outputs that require codegen.
-  //! The fusion outputs to be computed through expression evaluator are
-  //! filtered out.
-  std::vector<Val*> getFusionOutputsRequiringCodegen();
-
   // mark input at index to be permuted by permutation
   void setPermutationOnInput(int index, std::vector<int64_t> permutation) {
     permuted_input_map_.insert({index, permutation});

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -94,6 +94,11 @@ enum class AllocationType : int {
   // input.  In this case, we use `ExpressionEvaluator` (instead of a kernel) to
   // cheaply compute the output tensor.
   PointerArithmetic,
+  // To evaluate outputs which are not aliases.
+  // TODO: This can be potentially merged with PointerArithmetic.
+  //       PointerArithmetic requires aliased_io != nullptr while for evaluating
+  //       a non-aliased output, aliased_io = nullptr. So keeping them separate initially.
+  Evaluate,
 };
 
 struct AliasInfo {
@@ -257,6 +262,10 @@ class NVF_API Fusion : public IrContainer {
   //! aliased.
   const AliasInfo& getOutputAlias(const Val* output) const;
 
+  // Marks an output (by adding to io_alias_ map) to be evaluated through 
+  // expression evaluator.
+  void markOutputForEvaluation(Val* output, const AllocationType type);
+  
   // mark input at index to be permuted by permutation
   void setPermutationOnInput(int index, std::vector<int64_t> permutation) {
     permuted_input_map_.insert({index, permutation});

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -262,9 +262,9 @@ class NVF_API Fusion : public IrContainer {
   //! aliased.
   const AliasInfo& getOutputAlias(const Val* output) const;
 
-  // Marks an output (by adding to io_alias_ map) to be evaluated through 
+  // Marks a non-aliased output to be evaluated through 
   // expression evaluator.
-  void markOutputForEvaluation(Val* output, const AllocationType type);
+  void markOutputForEvaluation(Val* output);
   
   // mark input at index to be permuted by permutation
   void setPermutationOnInput(int index, std::vector<int64_t> permutation) {

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -97,7 +97,8 @@ enum class AllocationType : int {
   // To evaluate outputs which are not aliases.
   // TODO: This can be potentially merged with PointerArithmetic.
   //       PointerArithmetic requires aliased_io != nullptr while for evaluating
-  //       a non-aliased output, aliased_io = nullptr. So keeping them separate initially.
+  //       a non-aliased output, aliased_io = nullptr. So keeping them separate
+  //       initially.
   Evaluate,
 };
 
@@ -262,10 +263,10 @@ class NVF_API Fusion : public IrContainer {
   //! aliased.
   const AliasInfo& getOutputAlias(const Val* output) const;
 
-  // Marks a non-aliased output to be evaluated through 
+  // Marks a non-aliased output to be evaluated through
   // expression evaluator.
   void markOutputForEvaluation(Val* output);
-  
+
   // mark input at index to be permuted by permutation
   void setPermutationOnInput(int index, std::vector<int64_t> permutation) {
     permuted_input_map_.insert({index, permutation});

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -95,7 +95,7 @@ enum class AllocationType : int {
   // cheaply compute the output tensor.
   PointerArithmetic,
   // To evaluate outputs which are not aliases.
-  // TODO: This can be potentially merged with PointerArithmetic.
+  // TODO: This will merged with PointerArithmetic in the next PR.
   //       PointerArithmetic requires aliased_io != nullptr while for evaluating
   //       a non-aliased output, aliased_io = nullptr. So keeping them separate
   //       initially.

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -261,7 +261,15 @@ class NVF_API Fusion : public IrContainer {
   //! aliased.
   const AliasInfo& getOutputAlias(const Val* output) const;
 
+  //! Returns the expressions that require codegen.
+  //! Expressions where all the outputs are marked to be computed through
+  //! expression evaluator are filtered out.
   std::vector<Expr*> getExprsToCodegen();
+
+  //! Returns the fusion outputs that require codegen.
+  //! The fusion outputs to be computed through expression evaluator are
+  //! filtered out.
+  std::vector<Val*> getFusionOutputsRequiringCodegen();
 
   // mark input at index to be permuted by permutation
   void setPermutationOnInput(int index, std::vector<int64_t> permutation) {

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -267,6 +267,8 @@ class NVF_API Fusion : public IrContainer {
   // expression evaluator.
   void markOutputForEvaluation(Val* output);
 
+  std::vector<Expr*> getExprsToCodegen();
+
   // mark input at index to be permuted by permutation
   void setPermutationOnInput(int index, std::vector<int64_t> permutation) {
     permuted_input_map_.insert({index, permutation});

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -157,7 +157,7 @@ std::unordered_map<EnableOption, std::vector<std::string>> Options<
       {"memory_promotion", EnableOption::MemoryPromotion},
       {"static_fusion_count", EnableOption::StaticFusionCount},
       {"warn_register_spill", EnableOption::WarnRegisterSpill},
-      {"matmul_expr_eval", EnableOption:MatmulExprEval}};
+      {"matmul_expr_eval", EnableOption::MatmulExprEval}};
 
   return parseEnvOptions("ENABLE", available_options);
 }

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -156,7 +156,8 @@ std::unordered_map<EnableOption, std::vector<std::string>> Options<
       {"kernel_profile", EnableOption::KernelProfile},
       {"memory_promotion", EnableOption::MemoryPromotion},
       {"static_fusion_count", EnableOption::StaticFusionCount},
-      {"warn_register_spill", EnableOption::WarnRegisterSpill}};
+      {"warn_register_spill", EnableOption::WarnRegisterSpill},
+      {"matmul_expr_eval", EnableOption:MatmulExprEval}};
 
   return parseEnvOptions("ENABLE", available_options);
 }

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -85,7 +85,8 @@ enum class EnableOption {
   MemoryPromotion, //! Enable promotion of memory types for non-pointwise ops
   StaticFusionCount, //! Enable using single static count in kernel name
   WarnRegisterSpill, //! Enable warnings of register spill
-  MatmulExprEval, //! Enable ATen evaluation for the entire fusion containing matmul
+  MatmulExprEval, //! Enable ATen evaluation for the entire fusion containing
+                  //! matmul
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -85,7 +85,7 @@ enum class EnableOption {
   MemoryPromotion, //! Enable promotion of memory types for non-pointwise ops
   StaticFusionCount, //! Enable using single static count in kernel name
   WarnRegisterSpill, //! Enable warnings of register spill
-  MatmulExprEval, //! Enable ATen evaluation for Matmul
+  MatmulExprEval, //! Enable ATen evaluation for the entire fusion containing matmul
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -85,7 +85,7 @@ enum class EnableOption {
   MemoryPromotion, //! Enable promotion of memory types for non-pointwise ops
   StaticFusionCount, //! Enable using single static count in kernel name
   WarnRegisterSpill, //! Enable warnings of register spill
-  MatmulExprEval, //! Enable ATen evaluation for Matmul 
+  MatmulExprEval, //! Enable ATen evaluation for Matmul
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -85,6 +85,7 @@ enum class EnableOption {
   MemoryPromotion, //! Enable promotion of memory types for non-pointwise ops
   StaticFusionCount, //! Enable using single static count in kernel name
   WarnRegisterSpill, //! Enable warnings of register spill
+  MatmulExprEval, //! Enable ATen evaluation for Matmul 
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -39,7 +39,7 @@ void markAliases(Fusion* fusion) {
     }
 
     fusion->aliasOutputToInput(
-        out, aliased_io, AllocationType::PointerArithmetic);
+        out, aliased_io, AllocationType::Evaluate);
     vlog(
         "Marked ",
         ir_utils::varName(out),

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -38,8 +38,7 @@ void markAliases(Fusion* fusion) {
       continue;
     }
 
-    fusion->aliasOutputToInput(
-        out, aliased_io, AllocationType::Evaluate);
+    fusion->aliasOutputToInput(out, aliased_io, AllocationType::Evaluate);
     vlog(
         "Marked ",
         ir_utils::varName(out),

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -33,7 +33,8 @@ void MatmulScheduler::schedule(Fusion* fusion) {
   // Skip scheduling if Matmul will be expression evaluated.
   if (isOptionEnabled(EnableOption::MatmulExprEval)) {
     NVF_CHECK(fusion->outputs().size() == 1)
-    fusion->markOutputForEvaluation(fusion->outputs()[0]);
+    fusion->aliasOutputToInput(
+        fusion->outputs()[0], nullptr, AllocationType::Evaluate);
     scheduler_debug_utils::log(
         __FILE__,
         ":",

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -713,6 +713,14 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       mma_ops.size() == 1,
       "scheduleMatmul supports fusion with single mma op in definition, got ",
       mma_ops.size());
+
+  // Skip scheduling if Matmul will be expression evaluated.
+  if (isOptionEnabled(EnableOption::MatmulExprEval)){
+    fusion->markOutputForEvaluation(mma_ops.front()->out(), AllocationType::Evaluate);
+    scheduler_debug_utils::log(__FUNCTION__, ": Matmul output to be computed through expression evaluator. Skipping codegen.");
+    return;
+  }
+
   const auto& roles_map_opt = mma_utils::getTensorsRoles(fusion);
 
   // NOTE: the contents of roles_map have been already validated during

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -715,12 +715,12 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       mma_ops.size());
 
   // Skip scheduling if Matmul will be expression evaluated.
-  // NOTE: This strictly evaluates only MmaOp.
-  // TODO: Add support to evaluate (MmaOp + cast).
-  if (isOptionEnabled(EnableOption::MatmulExprEval)){
-    NVF_CHECK (fusion->outputs().size() == 1)
+  if (isOptionEnabled(EnableOption::MatmulExprEval)) {
+    NVF_CHECK(fusion->outputs().size() == 1)
     fusion->markOutputForEvaluation(fusion->outputs()[0]);
-    scheduler_debug_utils::log(__FUNCTION__, ": Matmul output to be computed through expression evaluator. Skipping codegen.");
+    scheduler_debug_utils::log(
+        __FUNCTION__,
+        ": Matmul output to be computed through expression evaluator. Skipping codegen.");
     return;
   }
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -71,8 +71,8 @@ void MatmulScheduler::computeHeuristics(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     HeuristicSummary* data_cache) {
-    params_ = getMatmulHeuristics(fusion, runtime_info, data_cache);
-    NVF_ERROR(params_ != nullptr);
+  params_ = getMatmulHeuristics(fusion, runtime_info, data_cache);
+  NVF_ERROR(params_ != nullptr);
 }
 
 void moveInnerBroadcastLeft(TensorView* tv, int number_of_inner_pos) {
@@ -724,7 +724,6 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       mma_ops.size() == 1,
       "scheduleMatmul supports fusion with single mma op in definition, got ",
       mma_ops.size());
-
   const auto& roles_map_opt = mma_utils::getTensorsRoles(fusion);
 
   // NOTE: the contents of roles_map have been already validated during

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -719,8 +719,10 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
     NVF_CHECK(fusion->outputs().size() == 1)
     fusion->markOutputForEvaluation(fusion->outputs()[0]);
     scheduler_debug_utils::log(
-        __FUNCTION__,
-        ": Matmul output to be computed through expression evaluator. Skipping codegen.");
+        __FILE__,
+        ":",
+        __LINE__,
+        ", Matmul output to be computed through expression evaluator. Skipping codegen.");
     return;
   }
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -34,7 +34,7 @@ void MatmulScheduler::schedule(Fusion* fusion) {
   if (isOptionEnabled(EnableOption::MatmulExprEval)) {
     NVF_CHECK(fusion->outputs().size() == 1)
     fusion->aliasOutputToInput(
-        fusion->outputs()[0], nullptr, AllocationType::Evaluate);
+        fusion->outputs()[0], /*input=*/nullptr, AllocationType::Evaluate);
     scheduler_debug_utils::log(
         __FILE__,
         ":",

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -715,8 +715,11 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       mma_ops.size());
 
   // Skip scheduling if Matmul will be expression evaluated.
+  // NOTE: This strictly evaluates only MmaOp.
+  // TODO: Add support to evaluate (MmaOp + cast).
   if (isOptionEnabled(EnableOption::MatmulExprEval)){
-    fusion->markOutputForEvaluation(mma_ops.front()->out(), AllocationType::Evaluate);
+    NVF_CHECK (fusion->outputs().size() == 1)
+    fusion->markOutputForEvaluation(fusion->outputs()[0]);
     scheduler_debug_utils::log(__FUNCTION__, ": Matmul output to be computed through expression evaluator. Skipping codegen.");
     return;
   }

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -71,10 +71,8 @@ void MatmulScheduler::computeHeuristics(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     HeuristicSummary* data_cache) {
-  if (!isOptionEnabled(EnableOption::MatmulExprEval)) {
     params_ = getMatmulHeuristics(fusion, runtime_info, data_cache);
     NVF_ERROR(params_ != nullptr);
-  }
 }
 
 void moveInnerBroadcastLeft(TensorView* tv, int number_of_inner_pos) {

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -361,6 +361,13 @@ std::shared_ptr<MatmulParams> getMatmulHeuristics(
   (void)runtime_info;
   auto params = std::make_shared<MatmulParams>();
 
+  // Set kernel index mode
+  params->cparams.index_type = runtime_info.getIndexType();
+
+  if (isOptionEnabled(EnableOption::MatmulExprEval)) {
+    return params;
+  }
+
   // Check initial conditions
   auto mma_exprs = ir_utils::getOpsOfType<MmaOp>(fusion);
   mma_utils::CombineMulSum combiner(fusion);
@@ -382,9 +389,6 @@ std::shared_ptr<MatmulParams> getMatmulHeuristics(
   // Populate heuristic details
   auto status = initCoreHeuristics(params, mma_op.value(), problem_shape);
   NVF_ERROR(status, "Initialization of core part of heuristics failed.");
-
-  // Set kernel index mode
-  params->cparams.index_type = runtime_info.getIndexType();
 
   // Disable magic zero for matmul kernels
   params->cparams.enable_magic_zero = false;

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -47,12 +47,12 @@ TEST(MatmulATenEvaluationTest, SingleMmaOp) {
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1});
 
-  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+  EXPECT_EQ(fec.getMostRecentKernelRuntime()->executors().size(), 1);
 
   // Verify that the io_alias_ set has the correct entry
   auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
-  EXPECT_TRUE(
-      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+  EXPECT_EQ(
+      kernel->getOutputAlias(kernel->outputs()[0]).type,
       AllocationType::Evaluate);
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
@@ -86,12 +86,12 @@ TEST(MatmulATenEvaluationTest, MmaOpAndCast) {
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1});
 
-  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+  EXPECT_EQ(fec.getMostRecentKernelRuntime()->executors().size(), 1);
 
   // Verify that the io_alias_ set has the correct entry
   auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
-  EXPECT_TRUE(
-      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+  EXPECT_EQ(
+      kernel->getOutputAlias(kernel->outputs()[0]).type,
       AllocationType::Evaluate);
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
@@ -131,12 +131,12 @@ TEST(MatmulATenEvaluationTest, MatmulWithBias) {
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1, t2});
 
-  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+  EXPECT_EQ(fec.getMostRecentKernelRuntime()->executors().size(), 1);
 
   // Verify that the io_alias_ set has the correct entry
   auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
-  EXPECT_TRUE(
-      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+  EXPECT_EQ(
+      kernel->getOutputAlias(kernel->outputs()[0]).type,
       AllocationType::Evaluate);
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -15,10 +15,24 @@
 #include <scheduler/mma_utils.h>
 #include <test/utils.h>
 #include <test/validator.h>
+#include <preseg_passes/allocation_order_inference.h>
+#include <preseg_passes/optimization_pass.h>
 
 namespace nvfuser {
 
-using MatmulATenEvaluationTest = NVFuserTest;
+class MatmulATenEvaluationTest : public NVFuserTest {
+ protected:
+  void SetUp() override {
+    // allocation order set by the pass breaks matmul tests
+    // see issue https://github.com/NVIDIA/Fuser/issues/1810
+    guard_ = std::make_unique<nvfuser::preseg_passes::OptimizationPassGuard<
+        nvfuser::preseg_passes::AllocationDomainPass>>(false);
+  }
+  std::unique_ptr<nvfuser::preseg_passes::OptimizationPassGuard<
+      nvfuser::preseg_passes::AllocationDomainPass>>
+      guard_;
+};
+
 
 TEST(MatmulATenEvaluationTest, SingleMmaOp) {
   auto fusion = std::make_unique<Fusion>();

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -18,9 +18,9 @@
 
 namespace nvfuser {
 
-class MatmulDefaultTest : public NVFuserTest {};
+class MatmulATenEvaluationTest : public NVFuserTest {};
 
-TEST(MatmulDefaultTest, SingleMmaOp) {
+TEST(MatmulATenEvaluationTest, SingleMmaOp) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -50,7 +50,7 @@ TEST(MatmulDefaultTest, SingleMmaOp) {
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST(MatmulDefaultTest, MmaOpAndCast) {
+TEST(MatmulATenEvaluationTest, MmaOpAndCast) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -81,7 +81,7 @@ TEST(MatmulDefaultTest, MmaOpAndCast) {
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST(MatmulDefaultTest, MatmulWithBias) {
+TEST(MatmulATenEvaluationTest, MatmulWithBias) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -34,7 +34,7 @@ class MatmulATenEvaluationTest : public NVFuserTest {
 };
 
 
-TEST(MatmulATenEvaluationTest, SingleMmaOp) {
+TEST_F(MatmulATenEvaluationTest, SingleMmaOp) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -72,7 +72,7 @@ TEST(MatmulATenEvaluationTest, SingleMmaOp) {
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST(MatmulATenEvaluationTest, MmaOpAndCast) {
+TEST_F(MatmulATenEvaluationTest, MmaOpAndCast) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -111,7 +111,7 @@ TEST(MatmulATenEvaluationTest, MmaOpAndCast) {
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST(MatmulATenEvaluationTest, MatmulWithBias) {
+TEST_F(MatmulATenEvaluationTest, MatmulWithBias) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -47,6 +47,14 @@ TEST(MatmulATenEvaluationTest, SingleMmaOp) {
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1});
 
+  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+
+  // Verify that the io_alias_ set has the correct entry
+  auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
+  EXPECT_TRUE(
+      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+      AllocationType::Evaluate);
+
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
@@ -77,6 +85,14 @@ TEST(MatmulATenEvaluationTest, MmaOpAndCast) {
 
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1});
+
+  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+
+  // Verify that the io_alias_ set has the correct entry
+  auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
+  EXPECT_TRUE(
+      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+      AllocationType::Evaluate);
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -114,6 +130,14 @@ TEST(MatmulATenEvaluationTest, MatmulWithBias) {
 
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1, t2});
+
+  EXPECT_TRUE(fec.getMostRecentKernelRuntime()->executors().size() == 1);
+
+  // Verify that the io_alias_ set has the correct entry
+  auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
+  EXPECT_TRUE(
+      kernel->getOutputAlias(kernel->outputs()[0]).type ==
+      AllocationType::Evaluate);
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -11,12 +11,12 @@
 #include <fusion.h>
 #include <mma_type.h>
 #include <ops/all_ops.h>
+#include <preseg_passes/allocation_order_inference.h>
+#include <preseg_passes/optimization_pass.h>
 #include <scheduler/all_schedulers.h>
 #include <scheduler/mma_utils.h>
 #include <test/utils.h>
 #include <test/validator.h>
-#include <preseg_passes/allocation_order_inference.h>
-#include <preseg_passes/optimization_pass.h>
 
 namespace nvfuser {
 
@@ -32,7 +32,6 @@ class MatmulATenEvaluationTest : public NVFuserTest {
       nvfuser::preseg_passes::AllocationDomainPass>>
       guard_;
 };
-
 
 TEST_F(MatmulATenEvaluationTest, SingleMmaOp) {
   auto fusion = std::make_unique<Fusion>();

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -18,7 +18,7 @@
 
 namespace nvfuser {
 
-class MatmulATenEvaluationTest : public NVFuserTest {};
+using MatmulATenEvaluationTest = NVFuserTest;
 
 TEST(MatmulATenEvaluationTest, SingleMmaOp) {
   auto fusion = std::make_unique<Fusion>();
@@ -96,14 +96,14 @@ TEST(MatmulATenEvaluationTest, MatmulWithBias) {
   auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
   auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
   auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
-  auto tv3 = castOp(DataType::Half, tv2);
-  auto tv4 = makeConcreteTensor({m}, DataType::Half);
-  auto tv5 = biasEpilogue(tv3, tv4);
+  auto tv3 = makeConcreteTensor({m}, DataType::Half);
+  auto tv4 = castOp(DataType::Float, tv3);
+  auto tv5 = biasEpilogue(tv2, tv4);
   auto tv6 = castOp(DataType::Half, tv5);
 
   fusion->addInput(tv0);
   fusion->addInput(tv1);
-  fusion->addInput(tv4);
+  fusion->addInput(tv3);
   fusion->addOutput(tv6);
 
   at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();

--- a/test/test_matmul_default.cpp
+++ b/test/test_matmul_default.cpp
@@ -20,7 +20,7 @@ namespace nvfuser {
 
 class MatmulDefaultTest : public NVFuserTest {};
 
-TEST (MatmulDefaultTest, ComputeMmaThroughEE){
+TEST (MatmulDefaultTest, SingleMmaOp){
     auto fusion = std::make_unique<Fusion>();
     FusionGuard fg(fusion.get());
     EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
@@ -44,6 +44,69 @@ TEST (MatmulDefaultTest, ComputeMmaThroughEE){
 
     FusionExecutorCache fec(std::move(fusion));
     auto out = fec.runFusionWithInputs({t0, t1});
+
+    EXPECT_TRUE(at::allclose(out[0], out_ref));
+}
+
+TEST (MatmulDefaultTest, MmaOpAndCast){
+    auto fusion = std::make_unique<Fusion>();
+    FusionGuard fg(fusion.get());
+    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+
+    int64_t m = 2, k = 3, n = 4;
+    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+
+    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+    auto tv3 = castOp(DataType::Half, tv2);
+
+    fusion->addInput(tv0);
+    fusion->addInput(tv1);
+    fusion->addOutput(tv3);
+
+    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+    at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda();
+
+    FusionExecutorCache fec(std::move(fusion));
+    auto out = fec.runFusionWithInputs({t0, t1});
+
+    EXPECT_TRUE(at::allclose(out[0], out_ref));
+}
+
+TEST (MatmulDefaultTest, MatmulWithBias){
+    auto fusion = std::make_unique<Fusion>();
+    FusionGuard fg(fusion.get());
+    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+
+    int64_t m = 2, k = 3, n = 4;
+    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+
+    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+    auto tv3 = castOp(DataType::Half, tv2);
+    auto tv4 = makeConcreteTensor({m}, DataType::Half);
+    auto tv5 = biasEpilogue(tv3, tv4);
+    auto tv6 = castOp(DataType::Half, tv5);
+
+    fusion->addInput(tv0);
+    fusion->addInput(tv1);
+    fusion->addInput(tv4);
+    fusion->addOutput(tv6);
+
+    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+    at::Tensor t2 = at::randn({m}, at::kHalf).cuda();
+    at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda() + t2.unsqueeze(-1);
+
+    FusionExecutorCache fec(std::move(fusion));
+    auto out = fec.runFusionWithInputs({t0, t1, t2});
 
     EXPECT_TRUE(at::allclose(out[0], out_ref));
 }

--- a/test/test_matmul_default.cpp
+++ b/test/test_matmul_default.cpp
@@ -1,0 +1,51 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <csrc/exceptions.h>
+#include <gtest/gtest.h>
+
+#include <fusion.h>
+#include <mma_type.h>
+#include <ops/all_ops.h>
+#include <scheduler/all_schedulers.h>
+#include <scheduler/mma_utils.h>
+#include <test/utils.h>
+#include <test/validator.h>
+
+namespace nvfuser {
+
+class MatmulDefaultTest : public NVFuserTest {};
+
+TEST (MatmulDefaultTest, ComputeMmaThroughEE){
+    auto fusion = std::make_unique<Fusion>();
+    FusionGuard fg(fusion.get());
+    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+
+    int64_t m = 2, k = 3, n = 4;
+    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+
+    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+
+    fusion->addInput(tv0);
+    fusion->addInput(tv1);
+    fusion->addOutput(tv2);
+
+    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+    at::Tensor out_ref = at::full(out_shape, k, at::kFloat).cuda();
+
+    FusionExecutorCache fec(std::move(fusion));
+    auto out = fec.runFusionWithInputs({t0, t1});
+
+    EXPECT_TRUE(at::allclose(out[0], out_ref));
+}
+
+} // namespace nvfuser

--- a/test/test_matmul_default.cpp
+++ b/test/test_matmul_default.cpp
@@ -23,6 +23,8 @@ class MatmulDefaultTest : public NVFuserTest {};
 TEST(MatmulDefaultTest, SingleMmaOp) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
+
+  EnableOptionsGuard enable_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
   int64_t m = 2, k = 3, n = 4;
@@ -51,6 +53,8 @@ TEST(MatmulDefaultTest, SingleMmaOp) {
 TEST(MatmulDefaultTest, MmaOpAndCast) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
+
+  EnableOptionsGuard enable_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
   int64_t m = 2, k = 3, n = 4;
@@ -80,6 +84,8 @@ TEST(MatmulDefaultTest, MmaOpAndCast) {
 TEST(MatmulDefaultTest, MatmulWithBias) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
+
+  EnableOptionsGuard enable_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
   int64_t m = 2, k = 3, n = 4;

--- a/test/test_matmul_default.cpp
+++ b/test/test_matmul_default.cpp
@@ -20,95 +20,96 @@ namespace nvfuser {
 
 class MatmulDefaultTest : public NVFuserTest {};
 
-TEST (MatmulDefaultTest, SingleMmaOp){
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
-    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+TEST(MatmulDefaultTest, SingleMmaOp) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
-    int64_t m = 2, k = 3, n = 4;
-    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+  int64_t m = 2, k = 3, n = 4;
+  std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
 
-    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
-    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
-    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
-    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
-    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+  auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+  auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
 
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addOutput(tv2);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addOutput(tv2);
 
-    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
-    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
-    at::Tensor out_ref = at::full(out_shape, k, at::kFloat).cuda();
+  at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+  at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+  at::Tensor out_ref = at::full(out_shape, k, at::kFloat).cuda();
 
-    FusionExecutorCache fec(std::move(fusion));
-    auto out = fec.runFusionWithInputs({t0, t1});
+  FusionExecutorCache fec(std::move(fusion));
+  auto out = fec.runFusionWithInputs({t0, t1});
 
-    EXPECT_TRUE(at::allclose(out[0], out_ref));
+  EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST (MatmulDefaultTest, MmaOpAndCast){
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
-    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+TEST(MatmulDefaultTest, MmaOpAndCast) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
-    int64_t m = 2, k = 3, n = 4;
-    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+  int64_t m = 2, k = 3, n = 4;
+  std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
 
-    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
-    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
-    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
-    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
-    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
-    auto tv3 = castOp(DataType::Half, tv2);
+  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+  auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+  auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+  auto tv3 = castOp(DataType::Half, tv2);
 
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addOutput(tv3);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addOutput(tv3);
 
-    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
-    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
-    at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda();
+  at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+  at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+  at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda();
 
-    FusionExecutorCache fec(std::move(fusion));
-    auto out = fec.runFusionWithInputs({t0, t1});
+  FusionExecutorCache fec(std::move(fusion));
+  auto out = fec.runFusionWithInputs({t0, t1});
 
-    EXPECT_TRUE(at::allclose(out[0], out_ref));
+  EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST (MatmulDefaultTest, MatmulWithBias){
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
-    EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+TEST(MatmulDefaultTest, MatmulWithBias) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
 
-    int64_t m = 2, k = 3, n = 4;
-    std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+  int64_t m = 2, k = 3, n = 4;
+  std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
 
-    auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
-    auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
-    auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
-    auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
-    auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
-    auto tv3 = castOp(DataType::Half, tv2);
-    auto tv4 = makeConcreteTensor({m}, DataType::Half);
-    auto tv5 = biasEpilogue(tv3, tv4);
-    auto tv6 = castOp(DataType::Half, tv5);
+  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+  auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+  auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+  auto tv3 = castOp(DataType::Half, tv2);
+  auto tv4 = makeConcreteTensor({m}, DataType::Half);
+  auto tv5 = biasEpilogue(tv3, tv4);
+  auto tv6 = castOp(DataType::Half, tv5);
 
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addInput(tv4);
-    fusion->addOutput(tv6);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv4);
+  fusion->addOutput(tv6);
 
-    at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
-    at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
-    at::Tensor t2 = at::randn({m}, at::kHalf).cuda();
-    at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda() + t2.unsqueeze(-1);
+  at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+  at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+  at::Tensor t2 = at::randn({m}, at::kHalf).cuda();
+  at::Tensor out_ref =
+      at::full(out_shape, k, at::kHalf).cuda() + t2.unsqueeze(-1);
 
-    FusionExecutorCache fec(std::move(fusion));
-    auto out = fec.runFusionWithInputs({t0, t1, t2});
+  FusionExecutorCache fec(std::move(fusion));
+  auto out = fec.runFusionWithInputs({t0, t1, t2});
 
-    EXPECT_TRUE(at::allclose(out[0], out_ref));
+  EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
PR #1743 was reverted due to the following issues:
1. Matmul scheduler does not support all architectures: This caused some tests to fail on V100. This is fixed by returning early in `getMatmulHeuristics` and only setting the required parameters.
2. Errors in `GpuLower::analysis`: `validateMma` and `PredicateElimination` are modified to skip expressions and outputs marked for expression evaluator.