### PR TITLE
Pass `None` as selected device default value

### DIFF
--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -416,7 +416,7 @@ void initNvFuserPythonBindings(PyObject* module) {
           "get",
           &FusionCache::get,
           py::arg("max_fusions") = int(16384),
-          py::arg("selected_device") = int(-1),
+          py::arg("selected_device") = py::none(),
           py::arg("load_from_default_workspace") = true,
           py::return_value_policy::reference)
       .def("num_fusions", &FusionCache::numFusions)

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -43,8 +43,10 @@ def enable_automatic_serialization():
     # Each FusionCache becomes associated with a single device.
     # Automatic serialization saves a separate cache for each device.
     # Set the FusionCache id to the ddp local rank.
-    ddp_local_rank = int(os.environ.get("LOCAL_RANK", -1))
-    _C.FusionCache.get(max_fusions := 8192, ddp_local_rank)
+    env_var_ddp_local_rank = os.environ.get("LOCAL_RANK", None)
+    if env_var_ddp_local_rank is not None:
+        env_var_ddp_local_rank = int(env_var_ddp_local_rank)
+    _C.FusionCache.get(max_fusions := 8192, env_var_ddp_local_rank)
 
 
 # Unregister automatic serialization of Nvfuser cache hierarchy and cuda kernels.


### PR DESCRIPTION
This PR changes the `selected_device` default from `-1` to `None`.

Related to https://github.com/NVIDIA/Fuser/pull/1699