### PR TITLE
Target arch validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/kernel_ir.cpp
   ${NVFUSER_SRCS_DIR}/kernel_ir_dispatch.cpp
   ${NVFUSER_SRCS_DIR}/device_lower/analysis/index_compute.cpp
+  ${NVFUSER_SRCS_DIR}/device_lower/analysis/device_version.cpp
   ${NVFUSER_SRCS_DIR}/device_lower/analysis/divisible_split.cpp
   ${NVFUSER_SRCS_DIR}/device_lower/analysis/fused_reduction.cpp
   ${NVFUSER_SRCS_DIR}/device_lower/analysis/predicate_elimination.cpp

--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -22,7 +22,7 @@ void MinimumDeviceVersion::dispatch(Val* val) {
 
 void MinimumDeviceVersion::handle(MmaOp* mma_op) {
   if (isTuring(mma_op->macro())) {
-    ensureVersion({7, 0}, "Fusion contains a Turing MMA macro");
+    ensureVersion({7, 5}, "Fusion contains a Turing MMA macro");
   } else if (isAmpere(mma_op->macro())) {
     ensureVersion({8, 0}, "Fusion contains an Ampere MMA macro");
   } else if (isHopper(mma_op->macro())) {

--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -11,12 +11,13 @@
 
 namespace nvfuser {
 
-void MinimumDeviceVersion::handle(Val* val) {
+void MinimumDeviceVersion::dispatch(Val* val) {
   if (val->dtype() == DataType::BFloat16) {
     ensureVersion(
         {8, 0},
         "Fusion contains BFloat16 values which was introduced in Ampere (8.0)");
   }
+  IterVisitor::dispatch(val);
 }
 
 void MinimumDeviceVersion::handle(MmaOp* mma_op) {

--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -1,0 +1,38 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <device_lower/analysis/device_version.h>
+#include <device_lower/lower2device.h>
+#include <mma_type.h>
+
+namespace nvfuser {
+
+void MinimumDeviceVersion::handle(Val* val) {
+  if (val->dtype() == DataType::BFloat16) {
+    ensureVersion({7, 0});
+  }
+}
+
+void MinimumDeviceVersion::handle(MmaOp* mma_op) {
+  if (isTuring(mma_op->macro())) {
+    ensureVersion({7, 0});
+  } else if (isAmpere(mma_op->macro())) {
+    ensureVersion({8, 0});
+  } else if (isHopper(mma_op->macro())) {
+    ensureVersion({9, 0});
+  } else {
+    NVF_ERROR("MmaOp ", mma_op->toString(), " has macro ", toString(mma_op->macro()), " which does not appear to be Turing, Ampere, or Hopper");
+  }
+}
+
+void MinimumDeviceVersion::ensureVersion(std::pair<int, int> version) {
+  if (version > min_version_) {
+    min_version_ = version;
+  }
+}
+
+} // namespace nvfuser

--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -39,9 +39,12 @@ void MinimumDeviceVersion::handle(MmaOp* mma_op) {
 
 void MinimumDeviceVersion::handle(LoadStoreOp* ls_op) {
   if (ls_op->opType() == LoadStoreOpType::CpAsync) {
-    ensureVersion({8, 0}, "LoadStoreOpType::CpAsync requires Ampere (8.0) or newer");
+    ensureVersion(
+        {8, 0}, "LoadStoreOpType::CpAsync requires Ampere (8.0) or newer");
   } else if (ls_op->opType() == LoadStoreOpType::CpAsyncBulkTensorTile) {
-    ensureVersion({9, 0}, "LoadStoreOpType::CpAsyncBulkTensorTile requires Hopper (9.0) or newer");
+    ensureVersion(
+        {9, 0},
+        "LoadStoreOpType::CpAsyncBulkTensorTile requires Hopper (9.0) or newer");
   }
 }
 

--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -13,25 +13,35 @@ namespace nvfuser {
 
 void MinimumDeviceVersion::handle(Val* val) {
   if (val->dtype() == DataType::BFloat16) {
-    ensureVersion({7, 0});
+    ensureVersion(
+        {8, 0},
+        "Fusion contains BFloat16 values which was introduced in Ampere (8.0)");
   }
 }
 
 void MinimumDeviceVersion::handle(MmaOp* mma_op) {
   if (isTuring(mma_op->macro())) {
-    ensureVersion({7, 0});
+    ensureVersion({7, 0}, "Fusion contains a Turing MMA macro");
   } else if (isAmpere(mma_op->macro())) {
-    ensureVersion({8, 0});
+    ensureVersion({8, 0}, "Fusion contains an Ampere MMA macro");
   } else if (isHopper(mma_op->macro())) {
-    ensureVersion({9, 0});
+    ensureVersion({9, 0}, "Fusion contains a Hopper MMA macro");
   } else {
-    NVF_ERROR("MmaOp ", mma_op->toString(), " has macro ", toString(mma_op->macro()), " which does not appear to be Turing, Ampere, or Hopper");
+    NVF_ERROR(
+        "MmaOp ",
+        mma_op->toString(),
+        " has macro ",
+        toString(mma_op->macro()),
+        " which does not appear to be Turing, Ampere, or Hopper");
   }
 }
 
-void MinimumDeviceVersion::ensureVersion(std::pair<int, int> version) {
+void MinimumDeviceVersion::ensureVersion(
+    std::pair<int, int> version,
+    std::string reason) {
   if (version > min_version_) {
     min_version_ = version;
+    reason_ = reason;
   }
 }
 

--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -37,6 +37,14 @@ void MinimumDeviceVersion::handle(MmaOp* mma_op) {
   }
 }
 
+void MinimumDeviceVersion::handle(LoadStoreOp* ls_op) {
+  if (ls_op->opType() == LoadStoreOpType::CpAsync) {
+    ensureVersion({8, 0}, "LoadStoreOpType::CpAsync requires Ampere (8.0) or newer");
+  } else if (ls_op->opType() == LoadStoreOpType::CpAsyncBulkTensorTile) {
+    ensureVersion({9, 0}, "LoadStoreOpType::CpAsyncBulkTensorTile requires Hopper (9.0) or newer");
+  }
+}
+
 void MinimumDeviceVersion::ensureVersion(
     std::pair<int, int> version,
     std::string reason) {

--- a/csrc/device_lower/analysis/device_version.h
+++ b/csrc/device_lower/analysis/device_version.h
@@ -24,7 +24,7 @@ class ComputeAtMap;
 
 //! Traverses a Fusion to find the minimum supported CUDA compute capability
 //! that will be able to run the generated kernel.
-class MinimumDeviceVersion : IterVisitor {
+class MinimumDeviceVersion : private IterVisitor {
  public:
   static std::pair<std::pair<int, int>, std::string> compute(Fusion* fusion) {
     MinimumDeviceVersion mdv;

--- a/csrc/device_lower/analysis/device_version.h
+++ b/csrc/device_lower/analysis/device_version.h
@@ -1,0 +1,53 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <c10/macros/Export.h>
+#include <exceptions.h>
+
+#include <compute_at_map.h>
+#include <dispatch.h>
+#include <ir/all_nodes.h>
+#include <kernel_ir.h>
+
+#include <vector>
+
+namespace nvfuser {
+
+class LoopIndexing;
+class ComputeAtMap;
+
+//! Traverses a Fusion to find the minimum supported CUDA compute capability
+//! that will be able to run the generated kernel.
+class MinimumDeviceVersion : IterVisitor {
+ public:
+  static std::pair<int, int> compute(Fusion* fusion) {
+    MinimumDeviceVersion mdv;
+    mdv.traverse(fusion);
+    return mdv.min_version_;
+  }
+
+ private:
+  using IterVisitor::traverse;
+  using IterVisitor::handle;
+
+  //! Check dtypes of all Vals. BFloat16 requires Ampere (8.0+)
+  void handle(Val* v) final;
+
+  //! MmaOp currently supports Turing and newer (7.0+) depending on macro
+  void handle(MmaOp* mma_op) final;
+
+  //! bump min_version_ to at least this value
+  void ensureVersion(std::pair<int, int> version);
+
+ private:
+  std::pair<int, int> min_version_ = {0, 0};
+};
+
+} // namespace nvfuser
+

--- a/csrc/device_lower/analysis/device_version.h
+++ b/csrc/device_lower/analysis/device_version.h
@@ -26,15 +26,15 @@ class ComputeAtMap;
 //! that will be able to run the generated kernel.
 class MinimumDeviceVersion : IterVisitor {
  public:
-  static std::pair<int, int> compute(Fusion* fusion) {
+  static std::pair<std::pair<int, int>, std::string> compute(Fusion* fusion) {
     MinimumDeviceVersion mdv;
     mdv.traverse(fusion);
-    return mdv.min_version_;
+    return {mdv.min_version_, mdv.reason_};
   }
 
  private:
-  using IterVisitor::traverse;
   using IterVisitor::handle;
+  using IterVisitor::traverse;
 
   //! Check dtypes of all Vals. BFloat16 requires Ampere (8.0+)
   void handle(Val* v) final;
@@ -43,11 +43,11 @@ class MinimumDeviceVersion : IterVisitor {
   void handle(MmaOp* mma_op) final;
 
   //! bump min_version_ to at least this value
-  void ensureVersion(std::pair<int, int> version);
+  void ensureVersion(std::pair<int, int> version, std::string reason);
 
  private:
   std::pair<int, int> min_version_ = {0, 0};
+  std::string reason_;
 };
 
 } // namespace nvfuser
-

--- a/csrc/device_lower/analysis/device_version.h
+++ b/csrc/device_lower/analysis/device_version.h
@@ -51,8 +51,9 @@ class MinimumDeviceVersion : IterVisitor {
   void ensureVersion(std::pair<int, int> version, std::string reason);
 
  private:
-  std::pair<int, int> min_version_ = {0, 0};
-  std::string reason_;
+  std::pair<int, int> min_version_ = {7, 0};
+  std::string reason_ =
+      "nvFuser supports Volta and above (compute capability 7.0+)";
 };
 
 } // namespace nvfuser

--- a/csrc/device_lower/analysis/device_version.h
+++ b/csrc/device_lower/analysis/device_version.h
@@ -43,6 +43,10 @@ class MinimumDeviceVersion : IterVisitor {
   //! MmaOp currently supports Turing and newer (7.0+) depending on macro
   void handle(MmaOp* mma_op) final;
 
+  //! LoadStoreOpType::CpAsync requires Ampere (8.0+)
+  //! https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async
+  void handle(LoadStoreOp* ls_op) final;
+
   //! bump min_version_ to at least this value
   void ensureVersion(std::pair<int, int> version, std::string reason);
 

--- a/csrc/device_lower/analysis/device_version.h
+++ b/csrc/device_lower/analysis/device_version.h
@@ -33,11 +33,12 @@ class MinimumDeviceVersion : IterVisitor {
   }
 
  private:
+  using IterVisitor::dispatch;
   using IterVisitor::handle;
   using IterVisitor::traverse;
 
   //! Check dtypes of all Vals. BFloat16 requires Ampere (8.0+)
-  void handle(Val* v) final;
+  void dispatch(Val* v) final;
 
   //! MmaOp currently supports Turing and newer (7.0+) depending on macro
   void handle(MmaOp* mma_op) final;

--- a/csrc/device_lower/analysis/device_version.h
+++ b/csrc/device_lower/analysis/device_version.h
@@ -40,7 +40,7 @@ class MinimumDeviceVersion : IterVisitor {
   //! Check dtypes of all Vals. BFloat16 requires Ampere (8.0+)
   void dispatch(Val* v) final;
 
-  //! MmaOp currently supports Turing and newer (7.0+) depending on macro
+  //! MmaOp currently supports Turing and newer (7.5+) depending on macro
   void handle(MmaOp* mma_op) final;
 
   //! LoadStoreOpType::CpAsync requires Ampere (8.0+)

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -367,7 +367,7 @@ void GpuLower::analysis(Fusion* fusion) {
   dumpExprsIfEnabled(fusion_->exprs(), "validateIr");
 
   // Determines minimum device version necessary to compile and run this fusion.
-  std::tie(min_device_version, min_device_version_reason) =
+  std::tie(min_device_version_, min_device_version_reason_) =
       MinimumDeviceVersion::compute(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "MinimumDeviceVersion");
 

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -9,6 +9,7 @@
 
 #include <ATen/cuda/CUDAContext.h>
 #include <debug.h>
+#include <device_lower/analysis/device_version.h>
 #include <device_lower/analysis/divisible_split.h>
 #include <device_lower/analysis/shift.h>
 #include <device_lower/pass/alias_memory.h>
@@ -364,6 +365,10 @@ void GpuLower::analysis(Fusion* fusion) {
   // prepare for lowering
   validateIr(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "validateIr");
+
+  // Determines minimum device version necessary to compile and run this fusion.
+  min_device_version_ = MinimumDeviceVersion::compute(fusion_);
+  dumpExprsIfEnabled(fusion_->exprs(), "MinimumDeviceVersion");
 
   // Checks if any TIDx dim is marked as padded to a warp. Also checks if we can
   // determine the padding is explicitly a single warp.

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -367,7 +367,8 @@ void GpuLower::analysis(Fusion* fusion) {
   dumpExprsIfEnabled(fusion_->exprs(), "validateIr");
 
   // Determines minimum device version necessary to compile and run this fusion.
-  min_device_version_ = MinimumDeviceVersion::compute(fusion_);
+  std::tie(min_device_version, min_device_version_reason) =
+      MinimumDeviceVersion::compute(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "MinimumDeviceVersion");
 
   // Checks if any TIDx dim is marked as padded to a warp. Also checks if we can

--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -85,6 +85,10 @@ class GpuLower : public NonCopyable {
     return min_device_version_;
   }
 
+  const std::string& minDeviceVersionReason() const {
+    return min_device_version_reason_;
+  }
+
   std::shared_ptr<const ConcretizedBroadcastDomains>
   concretizedBroadcastDomains() {
     return concretized_broadcast_domains_;
@@ -257,6 +261,7 @@ class GpuLower : public NonCopyable {
   // interface and default constructor. That way they couldn't be accessed
   // without being initialized.
   std::pair<int, int> min_device_version_;
+  std::string min_device_version_reason_;
   std::shared_ptr<const ConcretizedBroadcastDomains>
       concretized_broadcast_domains_;
   ThreadPredicateMap thread_pred_map_;

--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -81,6 +81,10 @@ class GpuLower : public NonCopyable {
     return cparams_.index_type.value();
   }
 
+  const std::pair<int, int>& minDeviceVersion() const {
+    return min_device_version_;
+  }
+
   std::shared_ptr<const ConcretizedBroadcastDomains>
   concretizedBroadcastDomains() {
     return concretized_broadcast_domains_;
@@ -252,6 +256,7 @@ class GpuLower : public NonCopyable {
   // would be safer to wrap all of these in unique pointers and remove the build
   // interface and default constructor. That way they couldn't be accessed
   // without being initialized.
+  std::pair<int, int> min_device_version_;
   std::shared_ptr<const ConcretizedBroadcastDomains>
       concretized_broadcast_domains_;
   ThreadPredicateMap thread_pred_map_;

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -336,17 +336,17 @@ void FusionExecutor::compileFusion(
 
   // TODO: this replicates the target GPU version computation from
   // executor_utils.
-  int major = 0, minor = 0;
+  std::pair<int, int> target_arch;
   bool compile_to_sass = false;
   executor_utils::queryTargetGPUVersion(
-      properties, major, minor, compile_to_sass);
+      properties, target_arch.first, target_arch.second, compile_to_sass);
 
   NVF_CHECK(
-      std::pair<int, int>(major, minor) >= kernel_summary.min_device_version,
+      target_arch >= kernel_summary.min_device_version,
       "Target compute capability is ",
-      major,
+      target_arch.first,
       ".",
-      minor,
+      target_arch.second,
       " but this fusion requires at least ",
       kernel_summary.min_device_version.first,
       ".",

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -339,7 +339,10 @@ void FusionExecutor::compileFusion(
   std::pair<int, int> target_arch;
   bool compile_to_sass = false;
   executor_utils::queryTargetGPUVersion(
-      properties, target_arch.first, target_arch.second, compile_to_sass);
+      properties,
+      std::ref(target_arch.first),
+      std::ref(target_arch.second),
+      compile_to_sass);
 
   NVF_CHECK(
       target_arch >= kernel_summary.min_device_version,

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1435,7 +1435,8 @@ void validateCooperativeLaunch(
   auto grid_size =
       launch_params.gdimx() * launch_params.gdimy() * launch_params.gdimz();
   auto max_active_blocks = num_blocks_per_SM *
-      at::cuda::getDeviceProperties((c10::DeviceIndex)device_index)->multiProcessorCount;
+      at::cuda::getDeviceProperties((c10::DeviceIndex)device_index)
+          ->multiProcessorCount;
   NVF_ERROR(
       (int64_t)(max_active_blocks) >= grid_size,
       "Wanted to launch a cooperative kernel, however the number of blocks is greater than ",
@@ -1857,7 +1858,8 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
           launch_params_.smem()));
       const int64_t device_id =
           static_cast<unsigned char>(options_.device.index());
-      const auto prop = at::cuda::getDeviceProperties((c10::DeviceIndex)device_id);
+      const auto prop =
+          at::cuda::getDeviceProperties((c10::DeviceIndex)device_id);
       const int64_t warps_per_sm =
           ceilDiv(blocks_per_sm * launch_params_.nThreads(), prop->warpSize);
       const int hw_max_warps =

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -342,7 +342,7 @@ void FusionExecutor::compileFusion(
       properties, major, minor, compile_to_sass);
 
   NVF_CHECK(
-      std::pair<int, int>{major, minor} >= kernel_summary.min_device_version,
+      std::pair<int, int>(major, minor) >= kernel_summary.min_device_version,
       "Target compute capability is ",
       major,
       ".",

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -338,7 +338,8 @@ void FusionExecutor::compileFusion(
   // executor_utils.
   int major = 0, minor = 0;
   bool compile_to_sass = false;
-  queryTargetGPUVersion(properties, major, minor, compile_to_sass);
+  executor_utils::queryTargetGPUVersion(
+      properties, major, minor, compile_to_sass);
 
   NVF_CHECK(
       major < kernel_summary.min_device_version.first ||

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -342,9 +342,7 @@ void FusionExecutor::compileFusion(
       properties, major, minor, compile_to_sass);
 
   NVF_CHECK(
-      major < kernel_summary.min_device_version.first ||
-          (major == kernel_summary.min_device_version.first &&
-           minor < kernel_summary.min_device_version.second),
+      std::pair<int, int>{major, minor} >= kernel_summary.min_device_version,
       "Target compute capability is ",
       major,
       ".",

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -332,31 +332,6 @@ void FusionExecutor::compileFusion(
 
   kir::Kernel* kernel = lowered_->kernel();
 
-  const kir::KernelSummary& kernel_summary = kernel->summary();
-
-  // TODO: this replicates the target GPU version computation from
-  // executor_utils.
-  std::pair<int, int> target_arch;
-  bool compile_to_sass = false;
-  executor_utils::queryTargetGPUVersion(
-      properties,
-      std::ref(target_arch.first),
-      std::ref(target_arch.second),
-      compile_to_sass);
-
-  NVF_CHECK(
-      target_arch >= kernel_summary.min_device_version,
-      "Target compute capability is ",
-      target_arch.first,
-      ".",
-      target_arch.second,
-      " but this fusion requires at least ",
-      kernel_summary.min_device_version.first,
-      ".",
-      kernel_summary.min_device_version.second,
-      ". Reason: ",
-      kernel_summary.min_device_version_reason);
-
   for (const auto& hook : post_lowering_hooks_) {
     hook(kernel);
   }
@@ -403,6 +378,31 @@ void FusionExecutor::compileFusion(
   if (structured_code.empty()) {
     structured_code = getStructuredCode();
   }
+
+  const kir::KernelSummary& kernel_summary = kernel->summary();
+
+  // TODO: this replicates the target GPU version computation from
+  // executor_utils.
+  std::pair<int, int> target_arch;
+  bool compile_to_sass = false;
+  executor_utils::queryTargetGPUVersion(
+      properties,
+      std::ref(target_arch.first),
+      std::ref(target_arch.second),
+      compile_to_sass);
+
+  NVF_CHECK(
+      target_arch >= kernel_summary.min_device_version,
+      "Target compute capability is ",
+      target_arch.first,
+      ".",
+      target_arch.second,
+      " but this fusion requires at least ",
+      kernel_summary.min_device_version.first,
+      ".",
+      kernel_summary.min_device_version.second,
+      ". Reason: ",
+      kernel_summary.min_device_version_reason);
 
   // We currently shouldn't allocate any more shared mem
   //  tensors statically but could keep this path if

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1435,7 +1435,7 @@ void validateCooperativeLaunch(
   auto grid_size =
       launch_params.gdimx() * launch_params.gdimy() * launch_params.gdimz();
   auto max_active_blocks = num_blocks_per_SM *
-      at::cuda::getDeviceProperties(device_index)->multiProcessorCount;
+      at::cuda::getDeviceProperties((c10::DeviceIndex)device_index)->multiProcessorCount;
   NVF_ERROR(
       (int64_t)(max_active_blocks) >= grid_size,
       "Wanted to launch a cooperative kernel, however the number of blocks is greater than ",
@@ -1857,7 +1857,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
           launch_params_.smem()));
       const int64_t device_id =
           static_cast<unsigned char>(options_.device.index());
-      const auto prop = at::cuda::getDeviceProperties(device_id);
+      const auto prop = at::cuda::getDeviceProperties((c10::DeviceIndex)device_id);
       const int64_t warps_per_sm =
           ceilDiv(blocks_per_sm * launch_params_.nThreads(), prop->warpSize);
       const int hw_max_warps =

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -108,8 +108,6 @@ std::string kernelPreamble() {
   return ss.str();
 }
 
-namespace {
-
 // Query the target GPU version number NVRTC compiles CUDA kernels for
 void queryTargetGPUVersion(
     const cudaDeviceProp* const prop,
@@ -159,6 +157,8 @@ void queryTargetGPUVersion(
     compile_to_sass = true;
   }
 }
+
+namespace {
 
 // Return true if all the tensors have the same stride, assumes all tensors are
 // contiguous

--- a/csrc/executor_utils.h
+++ b/csrc/executor_utils.h
@@ -296,5 +296,12 @@ class CudaKernelTimer {
   float kernel_time_ms_ = 0;
 };
 
+//! Query the target GPU version number NVRTC compiles CUDA kernels for
+void queryTargetGPUVersion(
+    const cudaDeviceProp* const prop,
+    int& major,
+    int& minor,
+    bool& compile_to_sass);
+
 } // namespace executor_utils
 } // namespace nvfuser

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -323,8 +323,8 @@ void Kernel::finalize(std::vector<Expr*> top_level_exprs) {
   summary_.sync_map = GpuLower::current()->syncMap();
   summary_.parallel_dimension_map_ =
       GpuLower::current()->parallelDimensionMap();
-  summary_.min_device_version_ = GpuLower::current()->minDeviceVersion();
-  summary_.min_device_version_reason_ =
+  summary_.min_device_version = GpuLower::current()->minDeviceVersion();
+  summary_.min_device_version_reason =
       GpuLower::current()->minDeviceVersionReason();
   parameters_ = GpuLower::current()->allKnownVals();
   parameters_.insert(parameters_.end(), outputs().begin(), outputs().end());

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -323,6 +323,7 @@ void Kernel::finalize(std::vector<Expr*> top_level_exprs) {
   summary_.sync_map = GpuLower::current()->syncMap();
   summary_.parallel_dimension_map_ =
       GpuLower::current()->parallelDimensionMap();
+  summary_.min_device_version_ = GpuLower::current()->minDeviceVersion();
   parameters_ = GpuLower::current()->allKnownVals();
   parameters_.insert(parameters_.end(), outputs().begin(), outputs().end());
   for (auto alloc : summary_.global_allocations) {

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -324,6 +324,8 @@ void Kernel::finalize(std::vector<Expr*> top_level_exprs) {
   summary_.parallel_dimension_map_ =
       GpuLower::current()->parallelDimensionMap();
   summary_.min_device_version_ = GpuLower::current()->minDeviceVersion();
+  summary_.min_device_version_reason_ =
+      GpuLower::current()->minDeviceVersionReason();
   parameters_ = GpuLower::current()->allKnownVals();
   parameters_.insert(parameters_.end(), outputs().begin(), outputs().end());
   for (auto alloc : summary_.global_allocations) {

--- a/csrc/kernel.h
+++ b/csrc/kernel.h
@@ -109,7 +109,10 @@ struct KernelSummary {
   std::vector<VectorizedSetInfo> vectorized_set_info;
 
   //! Minimum compute capability of device that can execute this kernel
-  std::pair<int, int> min_device_version_;
+  std::pair<int, int> min_device_version;
+
+  //! Plain text description of why min_device_version_ is required
+  std::string min_device_version_reason;
 };
 
 class KernelPerformanceProfile {

--- a/csrc/kernel.h
+++ b/csrc/kernel.h
@@ -107,6 +107,9 @@ struct KernelSummary {
 
   //! Track information on vectorized set operations for runtime validation
   std::vector<VectorizedSetInfo> vectorized_set_info;
+
+  //! Minimum compute capability of device that can execute this kernel
+  std::pair<int, int> min_device_version_;
 };
 
 class KernelPerformanceProfile {

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -1176,7 +1176,9 @@ class TestNvFuserFrontend(TestCase):
             return fd.execute((pred, a, b))[0]
 
         pred = torch.testing.make_tensor((5,), device="cuda", dtype=torch.bool)
-        list_of_dtype = [torch.float16, torch.bfloat16, torch.float32]
+        list_of_dtype = [torch.float16, torch.float32]
+        if not is_pre_ampere():
+            list_of_dtype.append(torch.bfloat16)
         for atype in list_of_dtype:
             for btype in list_of_dtype:
                 a = torch.randn((5,), device="cuda", dtype=atype)

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -5696,23 +5696,37 @@ TEST_F(NVFuserTest, FusionFloatConstantWhere_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionCpAsyncCommitWait_CUDA) {
-  if (at::cuda::getCurrentDeviceProperties()->major >= 8) {
-    GTEST_SKIP() << "Requires GPU capability below 8.0 to run.\n";
-  }
-
+  // Repro for https://github.com/csarofeen/pytorch/issues/2463
+  NVFUSER_TEST_CUDA_ARCH_GUARD(8, 0);
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto tv0 = makeContigConcreteTensor({2, 3}, DataType::BFloat16);
+  auto tv0 = makeContigConcreteTensor({12800, 8, 8, 8}, DataType::Half);
   auto tv1 = set(tv0);
   fusion.addInput(tv0);
   fusion.addOutput(tv1);
 
+  tv1->axis(1)->parallelize(ParallelType::TIDy);
+  tv1->axis(2)->parallelize(ParallelType::TIDx);
+
+  auto tv2 = tv0->cacheAfter(LoadStoreOpType::CpAsync);
+  tv2->axis(-1)->parallelize(ParallelType::Vectorize);
+  tv2->axis(1)->parallelize(ParallelType::TIDx);
+  tv2->axis(2)->parallelize(ParallelType::TIDy);
+  tv2->setMemoryType(MemoryType::Shared);
+
+  tv2->inlineAt(1);
+  tv2->circularBuffer(8);
+
+  auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
+
+  at::Tensor t0 = at::randn({12800, 8, 8, 8}, options);
+
   FusionExecutor fe;
-  EXPECT_THAT(
-      [&]() { GpuLower(&fusion).run(); },
-      testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
-          "Producer is required to be in Global Memory based on parallelization strategy. RAW flags: (blockIdx.x)")));
+  fe.compileFusion(&fusion, {t0});
+
+  auto cg_outputs = fe.runFusion({t0});
+  testValidate(fe.kernel(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Repro of issue #2459

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -1841,12 +1841,15 @@ TEST_F(NVFuserTest, FusionSimpleCpAsync_CUDA) {
 
   // requires ampere+ GPU
   if (!deviceMajorMinorCheck(8)) {
-    EXPECT_THAT(
+    ASSERT_THAT(
         [&]() {
           fe.compileFusion(&fusion, {t0, t1});
         },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
+    GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
+  } else {
+    fe.compileFusion(&fusion, {t0, t1});
   }
   fe.compileFusion(&fusion, {t0, t1});
   auto cg_outputs = fe.runFusion({t0, t1});
@@ -1884,10 +1887,13 @@ TEST_F(NVFuserTest, FusionCpAsyncPredicate_CUDA) {
 
   FusionExecutor fe;
   if (!deviceMajorMinorCheck(8)) {
-    EXPECT_THAT(
+    ASSERT_THAT(
         [&]() { fe.compileFusion(&fusion, {t0}); },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
+    GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
+  } else {
+    fe.compileFusion(&fusion, {t0});
   }
 
   fe.compileFusion(&fusion, {t0});
@@ -3836,10 +3842,11 @@ TEST_F(NVFuserTest, FusionCheckedSymbolicShape_CUDA) {
   }
 
   {
-    EXPECT_THAT(
+    ASSERT_THAT(
         [&]() { matched_add(a, c); },
         ::testing::ThrowsMessage<nvfuser::nvfError>(
             ::testing::HasSubstr("Conflicting sizes")));
+    GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
   }
 }
 
@@ -4250,11 +4257,15 @@ TEST_F(NVFuserTest, FusionSimpleAmperePipeline_CUDA) {
   FusionExecutor fe;
   // requires ampere+ GPU
   if (!deviceMajorMinorCheck(8)) {
-    EXPECT_THAT(
+    ASSERT_THAT(
         [&]() { fe.compileFusion(&fusion, {input1}); },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
+    GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
+  } else {
+    fe.compileFusion(&fusion, {input1});
   }
+
   auto cg_outputs = fe.runFusion({input1});
 
   testValidate(&fusion, cg_outputs, {input1}, __LINE__, __FILE__);
@@ -5729,10 +5740,13 @@ TEST_F(NVFuserTest, FusionCpAsyncCommitWait_CUDA) {
 
   FusionExecutor fe;
   if (!deviceMajorMinorCheck(8)) {
-    EXPECT_THAT(
+    ASSERT_THAT(
         [&]() { fe.compileFusion(&fusion, {t0}); },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
+    GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
+  } else {
+    fe.compileFusion(&fusion, {t0});
   }
 
   auto cg_outputs = fe.runFusion({t0});

--- a/test/test_gpu3.cpp
+++ b/test/test_gpu3.cpp
@@ -8743,8 +8743,8 @@ TEST_F(NVFuserTest, UnsupportedBFloat) {
   FusionExecutor fe;
   EXPECT_THAT(
       [&]() { GpuLower(&fusion).run(); },
-      testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
-          "Producer is required to be in Global Memory based on parallelization strategy. RAW flags: (blockIdx.x)")));
+      testing::ThrowsMessage<nvfuser::nvfError>(
+          testing::HasSubstr("Reason: Fusion contains BFloat16")));
 }
 // Test file size should be up to 10K LoC. Create a new file for more tests.
 


### PR DESCRIPTION
This introduces a minimum device version attribute to the kernel summary and populates it by traversing the fusion early in lowering to find ops or data types introduced after sm70. This version constraint is checked in FusionExecutor::compileFusion and if the target arch doesn't satisfy the constraint then an informative error message is given. Currently BFloat16, cp.async and cp.async.bulk are checked, as are the various MMA macros.

Fixes #1760