### PR TITLE
Pass allow_self_mapping to IterDomainGraph.

### DIFF
--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -766,8 +766,10 @@ void IterDomainGraph::initializeId(
   }
 }
 
-ComputeAtMap::ComputeAtMap(Fusion* fusion)
-    : id_graph_(fusion), concretized_bcasts_(fusion), fusion_(fusion) {
+ComputeAtMap::ComputeAtMap(Fusion* fusion, bool allow_self_mapping)
+    : id_graph_(fusion, allow_self_mapping),
+      concretized_bcasts_(fusion),
+      fusion_(fusion) {
   build(fusion);
 }
 

--- a/csrc/compute_at_map.h
+++ b/csrc/compute_at_map.h
@@ -186,7 +186,7 @@ class ComputeAtMap {
   ComputeAtMap& operator=(const ComputeAtMap&) = delete;
   ComputeAtMap(ComputeAtMap&&) = default;
   ComputeAtMap& operator=(ComputeAtMap&&) = default;
-  NVF_API ComputeAtMap(Fusion* fusion);
+  NVF_API ComputeAtMap(Fusion* fusion, bool allow_self_mapping = false);
 
   //! Run through disjoint sets in the LOOP map, make sure there's only one
   //! non-serial parallel type in each disjoint set, set the parallel type of

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -866,7 +866,7 @@ void IdModel::buildAllGraphs() {
   // supported currently (but work with IdModel). Make sure the
   // validator is only created when it is indeed requested
   if (validate_) {
-    validator = std::make_unique<IdModelValidator>(fusion);
+    validator = std::make_unique<IdModelValidator>(fusion, allow_self_mapping_);
   }
 
   FusionGuard fg(fusion);

--- a/csrc/id_model/validation_utils.cpp
+++ b/csrc/id_model/validation_utils.cpp
@@ -118,7 +118,8 @@ bool exprsMap(
 
 } // namespace
 
-IdModelValidator::IdModelValidator(Fusion* fusion) : ca_map_(fusion) {
+IdModelValidator::IdModelValidator(Fusion* fusion, bool allow_self_mapping)
+    : ca_map_(fusion, allow_self_mapping) {
   for (auto tv : ir_utils::allTvs(fusion)) {
     for (auto id : ir_utils::allIDsOf(tv)) {
       if (id->definition() && id->definition()->isA<Swizzle2D>()) {

--- a/csrc/id_model/validation_utils.h
+++ b/csrc/id_model/validation_utils.h
@@ -17,7 +17,7 @@ namespace nvfuser {
 // have private access
 class IdModelValidator {
  public:
-  IdModelValidator(Fusion* fusion);
+  IdModelValidator(Fusion* fusion, bool allow_self_mapping = false);
 
   // Validate a given exact graph of IdModel by comparing it with
   // ComputeAtMap. Their maps should

--- a/test/test_id_model.cpp
+++ b/test/test_id_model.cpp
@@ -920,4 +920,41 @@ TEST_F(IdModelTest, LoopPromotion8) {
   }
 }
 
+TEST_F(IdModelTest, SomeButNotAllArePermuted) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({2, 2, 10});
+  TensorView* s0 = slice(in, {0, 0, 0}, {2, 2, 2});
+  TensorView* s1 = slice(in, {0, 0, 2}, {2, 2, 5});
+  TensorView* s2 = slice(in, {0, 0, 5}, {2, 2, 10});
+  s0 = permute(s0, {1, 0, 2});
+  s2 = permute(s2, {1, 0, 2});
+  TensorView* out = cat({s0, s1, s2}, /*dim=*/-1);
+
+  fusion->addInput(in);
+  fusion->addOutput(out);
+
+  IdModel(fusion.get(), /*build_graphs=*/true, /*allow_self_mapping=*/true);
+}
+
+TEST_F(IdModelTest, PermutedDifferently) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({2, 2, 2, 10});
+  TensorView* s0 = slice(in, {0, 0, 0, 0}, {2, 2, 2, 2});
+  TensorView* s1 = slice(in, {0, 0, 0, 2}, {2, 2, 2, 5});
+  TensorView* s2 = slice(in, {0, 0, 0, 5}, {2, 2, 2, 10});
+  s0 = permute(s0, {2, 1, 0, 3});
+  s1 = permute(s1, {1, 0, 2, 3});
+  s2 = permute(s2, {2, 1, 0, 3});
+  TensorView* out = cat({s0, s1, s2}, /*dim=*/-1);
+
+  fusion->addInput(in);
+  fusion->addOutput(out);
+
+  IdModel(fusion.get(), /*build_graphs=*/true, /*allow_self_mapping=*/true);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Validation fails otherwise. Fixes #1791. 