### PR TITLE
Optimize split->reshape/permute->cat.

### DIFF
--- a/csrc/preseg_passes/move_split_cat.cpp
+++ b/csrc/preseg_passes/move_split_cat.cpp
@@ -282,7 +282,7 @@ TensorView* slicesFormSplit(
 int64_t CancelSplitCat::computeCatAxisAfterZipping(
     const std::vector<IterDomain*>& slice_rfactor,
     IterDomain* cat_id) {
-  ValGraph& exact_graph = id_model_.idGraph(IdMappingMode::EXACT);
+  const ValGraph& exact_graph = id_model_.idGraph(IdMappingMode::EXACT);
   ValGroup cat_group = exact_graph.toGroup(cat_id);
   while (cat_group != nullptr) {
     // If `cat_group` contains a slice rfactor ID, return the index of that ID.

--- a/csrc/preseg_passes/move_split_cat.cpp
+++ b/csrc/preseg_passes/move_split_cat.cpp
@@ -46,14 +46,72 @@ class CancelSplitCat {
   void run();
 
  private:
-  // Returns true when Exprs between `slices` and `pads` can be horizontally
-  // merged and applied on the input of the split.
-  bool horizontallyMergeable(
+  // Returns true when the def-use chain from slices[i] to pads[i] apply the
+  // same IterDomain transforms as the one from slices[j] to pads[j]. This is a
+  // necessary condition for horizontally merging the chains.
+  //
+  // Pre-condition: this is called after findPairingSplit so we know these
+  // chains contain the same sequence of op types and attributes.
+  bool sameIterDomainTransforms(
       const std::vector<SliceOp*>& slices,
       const std::vector<PadOp*>& pads);
 
-  int64_t computeSplitAxis(
-      const std::vector<IterDomain*>& source,
+  // Imagine we "zip" the cat upwards as following:
+  //
+  //   s0, s1 = split(in)
+  //   s0 = unary_0(s0)
+  //   s1 = unary_0(s1)
+  //   ...
+  //   s0 = unary_k(s0)
+  //   s1 = unary_k(s1)
+  //   s = cat({s0, s1})
+  //
+  //   ==>
+  //
+  //   s0, s1 = split(in)
+  //   s = cat({s0, s1})
+  //   s = unary_0(s)
+  //   ...
+  //   s = unary_k(s)
+  //
+  // This function returns the concatenated axis of the new cat so the above
+  // transform preserves the semantics. This axis will then be compared with the
+  // split axis to determine whether the split and the cat cancel out.
+  //
+  // If we can't zip the cat up to the split outputs (see one of the following
+  // examples), this function returns -1.
+  //
+  // Before calling this function, we already checked the chains contain the
+  // same sequence of op type and attributes and transform IterDomains in the
+  // same way. So this function takes the rfactor domain of any one of the
+  // slices and the catted IterDomain at the end of that chain.
+  //
+  // Example 1:
+  //   t = permute(slice, {1, 2, 0})
+  //   out = cat({t, ...}, 1)
+  //
+  // Returns 2 because the catted dimension (dimension 1 of `t1`) is permuted
+  // from dimension 2 of `slice`.
+  //
+  // Example 2:
+  //   t = reshape(slice, {2, 3, 5}, {6, 5})
+  //   out = cat({t, ...}, 1}
+  //
+  // Returns 2 because the catted dimension comes from dimension 2 of `slice`.
+  //
+  // Example 3:
+  //   t = reshape(slice, {2, 3}, {6})
+  //   out = cat({t, ...}, 0}
+  //
+  // Returns 0 because `slice`'s dimension 0 is the outer dimension.
+  //
+  // Example 4:
+  //   t = reshape(slice, {6}, {2, 3})
+  //   out = cat({t, ...}, 1}
+  //
+  // Returns -1 because `out`'s dimension 1 is the inner dimension.
+  int64_t computeCatAxisAfterZipping(
+      const std::vector<IterDomain*>& slice_rfactor,
       IterDomain* cat_id);
 
   // Finds the canceling split of `cat` and returns the input TensorView of the
@@ -75,9 +133,9 @@ class CancelSplitCat {
   //   out = cat([t0, t1], dim=0)
   //
   // In addition to returning `in`, findCancelingSplit(out) puts `t0`'s defining
-  // `permute` into `use_def_chain` so the caller can reconstruct `out` by
-  // replaying `use_def_chain` (in reverse order) on `in`.
-  TensorView* findCancelingSplit(CatOp* cat, std::vector<Expr*>& use_def_chain);
+  // `permute` into `def_use_chain` so the caller can reconstruct `out` by
+  // replaying `def_use_chain` on `in`.
+  TensorView* findCancelingSplit(CatOp* cat, std::vector<Expr*>& def_use_chain);
 
   Fusion* fusion_;
 
@@ -100,7 +158,7 @@ bool sameOp(const std::vector<Expr*>& frontier) {
              }) == frontier.end();
 }
 
-bool CancelSplitCat::horizontallyMergeable(
+bool CancelSplitCat::sameIterDomainTransforms(
     const std::vector<SliceOp*>& slices,
     const std::vector<PadOp*>& pads) {
   NVF_ERROR(slices.size() == pads.size());
@@ -225,50 +283,66 @@ TensorView* slicesFormSplit(
   return split_in;
 }
 
-int64_t CancelSplitCat::computeSplitAxis(
-    const std::vector<IterDomain*>& source,
+int64_t CancelSplitCat::computeCatAxisAfterZipping(
+    const std::vector<IterDomain*>& slice_rfactor,
     IterDomain* cat_id) {
   ValGroup cat_group = exact_graph_->toGroup(cat_id);
-  while (std::none_of(source.begin(), source.end(), [&](IterDomain* source_id) {
-    return exact_graph_->toGroup(source_id) == cat_group;
-  })) {
-    const ExprGroups& defining_groups = exact_graph_->getDefinitions(cat_group);
-    if (defining_groups.size() != 1) {
-      return -1;
+  while (cat_group != nullptr) {
+    // If `cat_group` contains a slice rfactor ID, return the index of that ID.
+    auto i = std::find_if(
+        slice_rfactor.begin(), slice_rfactor.end(), [&](IterDomain* id) {
+          return exact_graph_->toGroup(id) == cat_group;
+        });
+    if (i != slice_rfactor.end()) {
+      return i - slice_rfactor.begin();
     }
-    ExprGroup defining_group = defining_groups.front();
-    Expr* def = defining_group->front();
-    // FIXME: make this a function so we can early return.
-    if (Split* split = dynamic_cast<Split*>(def)) {
-      if (exact_graph_->toGroup(split->outer()) == cat_group) {
-        cat_group = exact_graph_->toGroup(split->in());
-      } else {
-        return -1;
+
+    // Conceptually zip `cat_group` over its definition.
+    auto cat_group_after_zipping = [&](ValGroup cat_group) -> ValGroup {
+      const ExprGroups& defining_groups =
+          exact_graph_->getDefinitions(cat_group);
+      if (defining_groups.size() != 1) {
+        return nullptr;
       }
-    } else if (Merge* merge = dynamic_cast<Merge*>(def)) {
-      cat_group = exact_graph_->toGroup(merge->outer());
-    } else {
-      return -1;
-    }
+      ExprGroup defining_group = defining_groups.front();
+      // Pick an arbitrary Expr from defining_group as the representative.
+      Expr* def = defining_group->front();
+
+      if (Split* split = dynamic_cast<Split*>(def)) {
+        if (exact_graph_->toGroup(split->outer()) == cat_group) {
+          return exact_graph_->toGroup(split->in());
+        }
+        return nullptr;
+      }
+
+      if (Merge* merge = dynamic_cast<Merge*>(def)) {
+        return exact_graph_->toGroup(merge->outer());
+      }
+
+      return nullptr;
+    };
+    cat_group = cat_group_after_zipping(cat_group);
   }
 
-  return std::find_if(
-             source.begin(),
-             source.end(),
-             [&](IterDomain* source_id) {
-               return exact_graph_->toGroup(source_id) == cat_group;
-             }) -
-      source.begin();
+  return -1;
 }
 
-TensorView* CancelSplitCat::findCancelingSplit(
-    CatOp* cat,
-    std::vector<Expr*>& use_def_chain) {
+// Finds the pairing split of `cat` by traversing the use-def chains. If found,
+// returns the slices of the pairing split and `cat`'s preceding `PadOp`s. This
+// function does some basic checks like:
+// 1. Ops between the chains must have the same op type and attributes.
+// 2. Chains must end with slices.
+// However, these checks are necessary but not sufficient to guarantee the
+// pairing split is canceling. To make that decision, the caller has to further
+// inspect the ops in between.
+std::optional<std::pair<std::vector<SliceOp*>, std::vector<PadOp*>>>
+findPairingSplit(CatOp* cat) {
   NVF_CHECK(!cat->inputs().empty(), "`cat` has zero inputs: ", cat);
 
   // `PadOp`s that produce `cat`'s inputs.
   std::vector<PadOp*> pads;
   pads.reserve(cat->inputs().size());
+
   // `frontier` initially contains the `Expr`s that precede `pads`. Then, we
   // repeatedly try to move the frontier up in lockstep as long as Exprs in the
   // frontier can be horizontally merged and applied on the unsplit tensor.
@@ -285,9 +359,12 @@ TensorView* CancelSplitCat::findCancelingSplit(
     return e == nullptr || e->isA<SliceOp>();
   })) {
     if (!sameOp(frontier)) {
-      return nullptr;
+      return std::nullopt;
     }
 
+    // We can probably extend this list to include many other unary ops.
+    // Currently, I limit this to only reshapes and permutes to reduce blast
+    // radius.
     auto supported = [](Expr* e) -> bool {
       if (e->isA<ViewOp>()) {
         return true;
@@ -300,10 +377,8 @@ TensorView* CancelSplitCat::findCancelingSplit(
       return false;
     };
     if (!supported(frontier[0])) {
-      return nullptr;
+      return std::nullopt;
     }
-
-    use_def_chain.push_back(frontier[0]);
 
     // Advance the frontier in lockstep.
     for (Expr*& e : frontier) {
@@ -320,41 +395,60 @@ TensorView* CancelSplitCat::findCancelingSplit(
   for (Expr* e : frontier) {
     auto* slice = dynamic_cast<SliceOp*>(e);
     if (slice == nullptr) {
-      return nullptr;
+      return std::nullopt;
     }
     slices.push_back(slice);
   }
 
-  if (!horizontallyMergeable(slices, pads)) {
+  return std::make_pair(slices, pads);
+}
+
+TensorView* CancelSplitCat::findCancelingSplit(
+    CatOp* cat,
+    std::vector<Expr*>& def_use_chain) {
+  auto heads_and_tails = findPairingSplit(cat);
+  if (!heads_and_tails.has_value()) {
+    return nullptr;
+  }
+  std::vector<SliceOp*> slices;
+  std::vector<PadOp*> pads;
+  std::tie(slices, pads) = *heads_and_tails;
+
+  if (!sameIterDomainTransforms(slices, pads)) {
     return nullptr;
   }
 
-  // Compute the corresponding split_axis.
-  const int64_t cat_axis = cat->concatenatedDim();
-  const int64_t split_axis = computeSplitAxis(
+  int64_t cat_axis = cat->concatenatedDim();
+  cat_axis = computeCatAxisAfterZipping(
       slices[0]->out()->getMaybeRFactorDomain(),
       pads[0]->out()->as<TensorView>()->getRootDomain()[cat_axis]);
-  if (split_axis == -1) {
+  if (cat_axis == -1) {
     return nullptr;
   }
 
-  TensorView* split_in = slicesFormSplit(slices, split_axis);
+  TensorView* split_in = slicesFormSplit(slices, cat_axis);
+  if (split_in == nullptr) {
+    return nullptr;
+  }
+
+  std::vector<Expr*> first_chain =
+      StmtSort::getExprsBetween({slices[0]->out()}, {pads[0]->in()});
+  def_use_chain.swap(first_chain);
   return split_in;
 }
 
 void CancelSplitCat::run() {
   std::vector<Expr*> exprs = fusion_->exprs();
   for (auto* cat : ir_utils::filterByType<CatOp>(exprs)) {
-    std::vector<Expr*> use_def_chain;
-    TensorView* split_in = findCancelingSplit(cat, std::ref(use_def_chain));
+    std::vector<Expr*> def_use_chain;
+    TensorView* split_in = findCancelingSplit(cat, std::ref(def_use_chain));
     if (split_in == nullptr) {
       continue;
     }
 
     Val* merged_out = split_in;
-    for (auto i = use_def_chain.rbegin(), end = use_def_chain.rend(); i != end;
-         i++) {
-      Expr* merged = replayExprWithNewInput(*i, merged_out);
+    for (Expr* e : def_use_chain) {
+      Expr* merged = replayExprWithNewInput(e, merged_out);
       NVF_ERROR(
           merged->outputs().size() == 1,
           "Currently, we merge only unary ops, so it would be a programming "

--- a/csrc/preseg_passes/move_split_cat.cpp
+++ b/csrc/preseg_passes/move_split_cat.cpp
@@ -101,8 +101,14 @@ class CancelSplitCat {
   //   out = cat({t, ...}, 0}
   //
   // Returns 0 because `slice`'s dimension 0 is the outer dimension.
-  //
+
   // Example 4:
+  //   t = reshape(slice, {6}, {2, 3})
+  //   out = cat({t, ...}, 0}
+  //
+  // Returns 0 because `out`'s dimension 0 is the outer dimension.
+  //
+  // Example 5:
   //   t = reshape(slice, {6}, {2, 3})
   //   out = cat({t, ...}, 1}
   //

--- a/csrc/preseg_passes/move_split_cat.cpp
+++ b/csrc/preseg_passes/move_split_cat.cpp
@@ -99,11 +99,11 @@ bool CancelSplitCat::horizontallyMergeable(
   ValGraph& exact_graph = id_model_for_merging_.idGraph(IdMappingMode::EXACT);
   {
     const std::vector<IterDomain*>& first_rfactor =
-        slices[0]->output(0)->as<TensorView>()->getMaybeRFactorDomain();
+        slices[0]->out()->getMaybeRFactorDomain();
     size_t num_dims = first_rfactor.size();
     for (size_t i = 1; i < slices.size(); i++) {
       const std::vector<IterDomain*>& rfactor =
-          slices[i]->output(0)->as<TensorView>()->getMaybeRFactorDomain();
+          slices[i]->out()->getMaybeRFactorDomain();
       if (rfactor.size() != num_dims) {
         return false;
       }

--- a/test/test_move_split_cat.cpp
+++ b/test/test_move_split_cat.cpp
@@ -364,7 +364,7 @@ TEST_F(MoveSplitCatTest, Cancellable_Issue1768) {
   FusionGuard fg(fusion.get());
 
   TensorView* sdpa_backward_out =
-      makeContigConcreteTensor({b, h * 3, s, f}, DataType::BFloat16);
+      makeContigConcreteTensor({b, h * 3, s, f}, DataType::Half);
   sdpa_backward_out->setAllocationDomain(
       {sdpa_backward_out->axis(0),
        sdpa_backward_out->axis(2),
@@ -384,7 +384,7 @@ TEST_F(MoveSplitCatTest, Cancellable_Issue1768) {
   TensorView* cat_out = cat({dq, dk, dv}, /*dim=*/-1);
   TensorView* sum_out = castOp(DataType::Float, cat_out);
   sum_out = sum(sum_out, {0, 1});
-  sum_out = castOp(DataType::BFloat16, sum_out);
+  sum_out = castOp(DataType::Half, sum_out);
   TensorView* view_out =
       reshape(cat_out, {b, s, h * f * 3}, {b * s, h * f * 3});
   TensorView* permute_out = permute(view_out, {1, 0});
@@ -394,7 +394,7 @@ TEST_F(MoveSplitCatTest, Cancellable_Issue1768) {
   fusion->addOutput(view_out);
   fusion->addOutput(permute_out);
 
-  auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0);
+  auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor in_tensor =
       at::randn({b * h * 3 * s * f}, options)
           .as_strided({b, h * 3, s, f}, {h * 3 * s * f, f, h * 3 * f, 1});

--- a/test/test_move_split_cat.cpp
+++ b/test/test_move_split_cat.cpp
@@ -299,4 +299,112 @@ TEST_F(MoveSplitCatTest, Noncancellable_UnsupportedOps) {
   EXPECT_FALSE(out_tensors[0].is_alias_of(in_tensor));
 }
 
+TEST_F(MoveSplitCatTest, Cancellable_ReshapeInBetween) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({4, 10});
+  TensorView* s0 = slice(in, {0, 0}, {4, 2});
+  TensorView* s1 = slice(in, {0, 2}, {4, 5});
+  TensorView* s2 = slice(in, {0, 5}, {4, 10});
+  s0 = reshape(s0, {4, 2}, {2, 2, 2});
+  s1 = reshape(s1, {4, 3}, {2, 2, 3});
+  s2 = reshape(s2, {4, 5}, {2, 2, 5});
+  TensorView* out = cat({s0, s1, s2}, /*dim=*/-1);
+
+  fusion->addInput(in);
+  fusion->addOutput(out);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor in_tensor = at::randn({4, 10}, options);
+
+  FusionExecutorCache fec(std::move(fusion));
+  auto out_tensors = fec.runFusionWithInputs({in_tensor});
+  testValidate(fec.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
+
+  EXPECT_TRUE(out_tensors[0].is_alias_of(in_tensor));
+}
+
+TEST_F(MoveSplitCatTest, Cancellable_ReshapeAndPermuteInBetween) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({6, 10});
+  TensorView* s0 = slice(in, {0, 0}, {6, 2});
+  TensorView* s1 = slice(in, {0, 2}, {6, 5});
+  TensorView* s2 = slice(in, {0, 5}, {6, 10});
+  s0 = reshape(s0, {6, 2}, {2, 3, 2});
+  s1 = reshape(s1, {6, 3}, {2, 3, 3});
+  s2 = reshape(s2, {6, 5}, {2, 3, 5});
+  s0 = permute(s0, {1, 0, 2});
+  s1 = permute(s1, {1, 0, 2});
+  s2 = permute(s2, {1, 0, 2});
+  TensorView* out = cat({s0, s1, s2}, /*dim=*/-1);
+
+  fusion->addInput(in);
+  fusion->addOutput(out);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor in_tensor = at::randn({6, 10}, options);
+
+  FusionExecutorCache fec(std::move(fusion));
+  auto out_tensors = fec.runFusionWithInputs({in_tensor});
+  testValidate(fec.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
+
+  EXPECT_TRUE(out_tensors[0].is_alias_of(in_tensor));
+}
+
+TEST_F(MoveSplitCatTest, Cancellable_Issue1768) {
+  constexpr int b = 16; // batch size
+  constexpr int h = 12; // number of heads
+  constexpr int s = 128; // sequence length
+  constexpr int f = 64; // feature size per head
+
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* sdpa_backward_out =
+      makeContigConcreteTensor({b, h * 3, s, f}, DataType::BFloat16);
+  sdpa_backward_out->setAllocationDomain(
+      {sdpa_backward_out->axis(0),
+       sdpa_backward_out->axis(2),
+       sdpa_backward_out->axis(1),
+       sdpa_backward_out->axis(3)},
+      true);
+  TensorView* dq = slice(sdpa_backward_out, {0, 0, 0, 0}, {b, h, s, f});
+  TensorView* dk = slice(sdpa_backward_out, {0, h, 0, 0}, {b, h * 2, s, f});
+  TensorView* dv = slice(sdpa_backward_out, {0, h * 2, 0, 0}, {b, h * 3, s, f});
+  // Swap the head dimension and the sequence length dimension.
+  dq = permute(dq, {0, 2, 1, 3});
+  dk = permute(dk, {0, 2, 1, 3});
+  dv = permute(dv, {0, 2, 1, 3});
+  dq = reshape(dq, {b, s, h, f}, {b, s, h * f});
+  dk = reshape(dk, {b, s, h, f}, {b, s, h * f});
+  dv = reshape(dv, {b, s, h, f}, {b, s, h * f});
+  TensorView* cat_out = cat({dq, dk, dv}, /*dim=*/-1);
+  TensorView* sum_out = castOp(DataType::Float, cat_out);
+  sum_out = sum(sum_out, {0, 1});
+  sum_out = castOp(DataType::BFloat16, sum_out);
+  TensorView* view_out =
+      reshape(cat_out, {b, s, h * f * 3}, {b * s, h * f * 3});
+  TensorView* permute_out = permute(view_out, {1, 0});
+
+  fusion->addInput(sdpa_backward_out);
+  fusion->addOutput(sum_out);
+  fusion->addOutput(view_out);
+  fusion->addOutput(permute_out);
+
+  auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0);
+  at::Tensor in_tensor =
+      at::randn({b * h * 3 * s * f}, options)
+          .as_strided({b, h * 3, s, f}, {h * 3 * s * f, f, h * 3 * f, 1});
+
+  FusionExecutorCache fec(std::move(fusion));
+  auto out_tensors = fec.runFusionWithInputs({in_tensor});
+  testValidate(fec.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
+
+  EXPECT_TRUE(out_tensors[1].is_alias_of(in_tensor));
+  EXPECT_TRUE(out_tensors[2].is_alias_of(in_tensor));
+}
+
 } // namespace nvfuser

--- a/test/test_move_split_cat.cpp
+++ b/test/test_move_split_cat.cpp
@@ -407,4 +407,6 @@ TEST_F(MoveSplitCatTest, Cancellable_Issue1768) {
   EXPECT_TRUE(out_tensors[2].is_alias_of(in_tensor));
 }
 
+// FIXME: test multiple split+cat pairs.
+
 } // namespace nvfuser


### PR DESCRIPTION
Extends the optimization to ViewOp. This PR uses IdModel to (1) check equivalence between ID transforms and (2) compute the concatenated dimension after zipping. 

Unit tests are passing: https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/pipelines/13280916

For #1768 