### PR TITLE
Fix a bug in input forwarding. 

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -3889,10 +3889,13 @@ void SegmentCandidateFinder::forwardInputs() {
       } else {
         // If there are either no more uses, more than one use, or one use that
         // is not a UnaryOp, then we cannot extend the chain of unary Ops. In
-        // these cases we finalize this chain by saving the uop and its output.
-        excluded_inp_unary_exprs_.pushBack(uop);
+        // these cases we finalize this chain by saving its output as a
+        // forwarded input.
         forwarded_inputs.pushBack(uop->out());
       }
+      // Either way, `uop` is excluded from merging until `resolveInputsInGroup`
+      // adds it back to one of the segments.
+      excluded_inp_unary_exprs_.pushBack(uop);
     }
   }
 

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -2483,6 +2483,12 @@ std::optional<ScheduleHeuristic> tryMerge(
     SegmentedGroup* b = nullptr) {
   FusionSegmentGuard fsg(segmented_fusion, a, b);
 
+  NVF_ERROR(
+      !segmented_fusion->completeFusion()->unordered_exprs().empty(),
+      "We shouldn't attempt to merge empty fusions. "
+      "This might not indicate a bug, "
+      "but it's definitely a change of world view that we should be aware of.");
+
   scheduler_debug_utils::canScheduleMessage(
       "\n**Segmenter** Considering fusion:\n",
       segmented_fusion->completeFusion());
@@ -2498,6 +2504,13 @@ std::optional<ScheduleHeuristic> tryMerge(
     SchedulerRuntimeInfo& runtime_info,
     const std::vector<SegmentedGroup*>& segmented_groups) {
   FusionSegmentGuard fsg(segmented_fusion, segmented_groups);
+
+  NVF_ERROR(
+      !segmented_fusion->completeFusion()->unordered_exprs().empty(),
+      "We shouldn't attempt to merge empty fusions. "
+      "This might not indicate a bug, "
+      "but it's definitely a change of world view that we should be aware of.");
+
   scheduler_debug_utils::canScheduleMessage(
       "\n**Segmenter** Considering fusion:\n",
       segmented_fusion->completeFusion());


### PR DESCRIPTION
It causes unnecessary edges between segments and confusing debugging output. For example, 

```
$ NVFUSER_DUMP=segmenter_logging bin/nvfuser_tests --gtest_filter=SegmentationTest.InputForwardingViaUnaryOps

...
**Segmenter** Considering fusion:

***Accepted*** as: no_op
...
```

The empty fusion considered is produced by merging an unnecessary edge between two segments before forwarded inputs. 