### PR TITLE
Remove function test/utils.h/matmul

### DIFF
--- a/benchmark/matmul.cpp
+++ b/benchmark/matmul.cpp
@@ -48,7 +48,9 @@ void setupMatmul(Fusion* fusion, MmaLayout layout, MatmulParams params) {
   auto a = makeContigTensor(2, DataType::Half);
   auto b = makeContigTensor(2, DataType::Half);
 
-  auto c = matmul(a, b, layout);
+  a = canonicalizeInputToBMNK(a, layout, MmaOperand::A);
+  b = canonicalizeInputToBMNK(b, layout, MmaOperand::B);
+  auto c = fusedMultiplySum(a, b, {-1});
 
   // Cast the output so that we perform an HSH matmul, which is what at::matmul
   // will perform
@@ -315,7 +317,9 @@ static void SingleMatmulPartitionedK(
   fusion->addInput(b);
 
   // batch matmul
-  auto c = matmul(a, b, layout);
+  a = canonicalizeInputToBMNK(a, layout, MmaOperand::A);
+  b = canonicalizeInputToBMNK(b, layout, MmaOperand::B);
+  auto c = fusedMultiplySum(a, b, {-1});
 
   fusion->addOutput(c);
 

--- a/benchmark/matmul.cpp
+++ b/benchmark/matmul.cpp
@@ -47,6 +47,8 @@ void setupMatmul(Fusion* fusion, MmaLayout layout, MatmulParams params) {
   // Only hgemm on the initial setup
   auto a = makeContigTensor(2, DataType::Half);
   auto b = makeContigTensor(2, DataType::Half);
+  fusion->addInput(a);
+  fusion->addInput(b);
 
   a = canonicalizeInputToBMNK(a, layout, MmaOperand::A);
   b = canonicalizeInputToBMNK(b, layout, MmaOperand::B);
@@ -56,8 +58,6 @@ void setupMatmul(Fusion* fusion, MmaLayout layout, MatmulParams params) {
   // will perform
   auto d = castOp(DataType::Half, c);
 
-  fusion->addInput(a);
-  fusion->addInput(b);
   fusion->addOutput(d);
 
   scheduleMatmul(fusion, params);

--- a/test/test_combine_mul_sum.cpp
+++ b/test/test_combine_mul_sum.cpp
@@ -59,34 +59,29 @@ class CombineMulSumAsMmaTest : public NVFuserTest {
 // Test checks to see that the combiner can correctly replace
 // the mul-sum pair with a mma op.
 TEST_F(CombineMulSumAsMmaTest, AmpereMulSumToMatmul_Pass) {
-  // Assumes layout is kAllSupportedMmaLayout::NT;
-  Fusion fusion;
-  FusionGuard fg(&fusion);
-  auto tv0 = makeContigTensor(2, DataType::Half);
-  auto tv1 = makeContigTensor(2, DataType::Half);
+  for (auto layout : kAllSupportedMmaLayout) {
+    Fusion fusion;
+    FusionGuard fg(&fusion);
+    auto tv0 = makeContigTensor(2, DataType::Half);
+    auto tv1 = makeContigTensor(2, DataType::Half);
 
-  fusion.addInput(tv0);
-  fusion.addInput(tv1);
+    fusion.addInput(tv0);
+    fusion.addInput(tv1);
 
-  auto tv0t = transpose(tv0, 0, 1);
-  auto tv1t = transpose(tv1, 0, 1);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = mul(tv0, tv1);
+    auto tv3 = sum(tv2, {-1});
 
-  std::vector<bool> bcast_dims(tv0->nDims() + 1, false);
-  bcast_dims.at(bcast_dims.size() - 2) = true;
-  auto tv0b = broadcast(tv0t, bcast_dims);
-  bcast_dims.at(bcast_dims.size() - 2) = false;
-  bcast_dims.at(bcast_dims.size() - 3) = true;
-  auto tv1b = broadcast(tv1t, bcast_dims);
-  auto tv2 = mul(tv0b, tv1b);
-  auto tv3 = sum(tv2, {-1});
-  fusion.addOutput(tv3);
+    fusion.addOutput(tv3);
 
-  ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
+    ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
 
-  nvfuser::mma_utils::CombineMulSum combiner(&fusion);
-  combiner.replaceWithMmaOp();
+    nvfuser::mma_utils::CombineMulSum combiner(&fusion);
+    combiner.replaceWithMmaOp();
 
-  ASSERT_FALSE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
+    ASSERT_FALSE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
+  }
 }
 
 // This test checks that the combiner does not incorrectly
@@ -163,7 +158,10 @@ TEST_F(CombineMulSumAsMmaTest, AmpereMulSumToMatmul_Schedule) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout, true);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = sum(mul(tv0, tv1), {-1});
+
     fusion.addOutput(tv2);
     ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
 
@@ -210,8 +208,10 @@ TEST_F(CombineMulSumAsMmaTest, UseMatmulScheduler) {
 
     fusion->addInput(tv0);
     fusion->addInput(tv1);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = sum(mul(tv0, tv1), {-1});
 
-    auto tv2 = matmul(tv0, tv1, layout, true);
     fusion->addOutput(tv2);
     ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(fusion.get()).empty());
 

--- a/test/test_gpu_tensorcore.cpp
+++ b/test/test_gpu_tensorcore.cpp
@@ -72,7 +72,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmul_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -133,7 +135,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulBFloat16_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -198,7 +202,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulPipelineGmem_CUDA) {
       fusion.addInput(tv0);
       fusion.addInput(tv1);
 
-      auto tv2 = matmul(tv0, tv1, layout);
+      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+      auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
       fusion.addOutput(tv2);
 
@@ -270,7 +276,9 @@ TEST_F(NVFuserTest, FusionAmpereSwizzle_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -393,7 +401,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulRegDoubleBuffer_CUDA) {
       fusion.addInput(tv0);
       fusion.addInput(tv1);
 
-      auto tv2 = matmul(tv0, tv1, layout);
+      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+      auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
       fusion.addOutput(tv2);
 
@@ -1080,7 +1090,9 @@ TEST_F(NVFuserTest, FusionTuringMatmul_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -1763,7 +1775,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulLargeLoad_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -1824,7 +1838,9 @@ TEST_F(NVFuserTest, FusionTuringMatmulLargeLoad_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -1887,7 +1903,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTileCheck4warp_CUDA) {
         fusion.addInput(tv0);
         fusion.addInput(tv1);
 
-        auto tv2 = matmul(tv0, tv1, layout);
+        tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+        tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+        auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
         fusion.addOutput(tv2);
 
@@ -1965,7 +1983,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTileCheck8warp_CUDA) {
           fusion.addInput(tv0);
           fusion.addInput(tv1);
 
-          auto tv2 = matmul(tv0, tv1, layout);
+          tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+          tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+          auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
           fusion.addOutput(tv2);
 
@@ -2038,7 +2058,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulTileCheck6warp_CUDA) {
       fusion.addInput(tv0);
       fusion.addInput(tv1);
 
-      auto tv2 = matmul(tv0, tv1, layout);
+      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+      auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
       fusion.addOutput(tv2);
 
@@ -2105,7 +2127,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulLargeLoadLargeK_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -2156,7 +2180,9 @@ TEST_F(NVFuserTest, FusionAmpereSplitKLikeStridedBatchedMatmul_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -2209,7 +2235,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogue_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -2351,7 +2379,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogueCast_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
     auto tv3 = castOp(DataType::Half, tv2);
 
     fusion.addOutput(tv3);
@@ -2449,7 +2479,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSmemEpilogueRelu_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
     auto tv3 = relu(tv2);
 
     fusion.addOutput(tv3);
@@ -2553,7 +2585,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSplitK_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -2615,7 +2649,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulSplitKBias_CUDA) {
     fusion.addInput(tv1);
     fusion.addInput(tv2);
 
-    auto tv3 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
     auto tv4 = broadcast(tv2, {false, true});
     auto tv5 = add(tv3, tv4); // bias
 
@@ -2677,7 +2713,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulBatchSplitK_CUDA) {
     fusion.addInput(tv0);
     fusion.addInput(tv1);
 
-    auto tv2 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
     fusion.addOutput(tv2);
 
@@ -2740,7 +2778,9 @@ TEST_F(NVFuserTest, FusionAmpereMatmulBatchSplitKBias_CUDA) {
     fusion.addInput(tv1);
     fusion.addInput(tv2);
 
-    auto tv3 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
     auto tv4 = broadcast(tv2, {true, false, true});
     auto tv5 = add(tv3, tv4);
 

--- a/test/test_matmul_sass.cpp
+++ b/test/test_matmul_sass.cpp
@@ -60,7 +60,9 @@ sass::Container getSASSFor(
   fusion.addInput(tv0);
   fusion.addInput(tv1);
 
-  auto tv2 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
   fusion.addOutput(tv2);
 
@@ -119,7 +121,9 @@ sass::Container getBinaryOpMulEpilogueSASSFor(
   fusion.addInput(tv1);
   fusion.addInput(s0);
 
-  auto tv2 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
   auto tv3 = mul(s0, tv2);
 
   fusion.addOutput(tv3);

--- a/test/test_matmul_scheduler.cpp
+++ b/test/test_matmul_scheduler.cpp
@@ -126,9 +126,14 @@ TEST_P(PrecisionParametrizedTest, EpilogueBias) {
   auto tv0 = makeContigTensor(2, in_type);
   auto tv1 = makeContigTensor(2, in_type);
   auto tv2 = makeContigTensor(1, out_type);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
 
   // tv3 := A x B
-  auto tv3 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
   // tv4 := cast(bias)
   auto tv4 = maybeCastOp(accu_type, tv2);
 
@@ -137,9 +142,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueBias) {
   // tv6 := cast(tv5)
   auto tv6 = maybeCastOp(out_type, tv5);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addInput(tv2);
   fusion->addOutput(tv6);
 
   NVF_CHECK(
@@ -229,13 +231,16 @@ TEST_P(PrecisionParametrizedTest, EpilogueRelu) {
   // A - tv0, B - tv1
   auto tv0 = makeContigTensor(2, in_type);
   auto tv1 = makeContigTensor(2, in_type);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
 
-  auto tv2 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+
   auto tv3 = relu(tv2);
   auto tv4 = maybeCastOp(out_type, tv3);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
   fusion->addOutput(tv4);
 
   NVF_CHECK(
@@ -322,9 +327,14 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasRelu) {
   auto tv0 = makeContigTensor(2, in_type);
   auto tv1 = makeContigTensor(2, in_type);
   auto tv2 = makeContigTensor(1, out_type);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
 
   // tv3 := A x B
-  auto tv3 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
 
   // tv4 := cast(bias)
   auto tv4 = maybeCastOp(accu_type, tv2);
@@ -336,9 +346,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasRelu) {
   auto tv6 = relu(tv5);
   auto tv7 = maybeCastOp(out_type, tv6);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addInput(tv2);
   fusion->addOutput(tv7);
 
   NVF_CHECK(
@@ -429,14 +436,16 @@ TEST_P(PrecisionParametrizedTest, EpilogueReluAux) {
   // A - tv0, B - tv1
   auto tv0 = makeContigTensor(2, in_type);
   auto tv1 = makeContigTensor(2, in_type);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
 
-  auto tv2 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
   auto tv3 = maybeCastOp(out_type, tv2);
   auto tv4 = relu(tv2);
   auto tv5 = maybeCastOp(out_type, tv4);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
   fusion->addOutput(tv3);
   fusion->addOutput(tv5);
 
@@ -529,9 +538,14 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasReluAux) {
   auto tv0 = makeContigTensor(2, in_type);
   auto tv1 = makeContigTensor(2, in_type);
   auto tv2 = makeContigTensor(1, out_type);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
 
   // tv3 := A x B
-  auto tv3 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
   // tv4 := cast(bias)
   auto tv4 = maybeCastOp(accu_type, tv2);
 
@@ -545,9 +559,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasReluAux) {
   auto tv7 = relu(tv5);
   auto tv8 = maybeCastOp(out_type, tv7);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addInput(tv2);
   fusion->addOutput(tv6);
   fusion->addOutput(tv8);
 
@@ -641,13 +652,15 @@ TEST_P(PrecisionParametrizedTest, EpilogueGelu) {
   // A - tv0, B - tv1
   auto tv0 = makeContigTensor(2, in_type);
   auto tv1 = makeContigTensor(2, in_type);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
 
-  auto tv2 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
   auto tv3 = gelu(tv2);
   auto tv4 = maybeCastOp(out_type, tv3);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
   fusion->addOutput(tv4);
 
   NVF_CHECK(
@@ -731,14 +744,16 @@ TEST_P(PrecisionParametrizedTest, EpilogueGeluAux) {
   // A - tv0, B - tv1
   auto tv0 = makeContigTensor(2, in_type);
   auto tv1 = makeContigTensor(2, in_type);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
 
-  auto tv2 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
   auto tv3 = maybeCastOp(out_type, tv2);
   auto tv4 = gelu(tv2);
   auto tv5 = maybeCastOp(out_type, tv4);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
   fusion->addOutput(tv3);
   fusion->addOutput(tv5);
 
@@ -829,9 +844,14 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasGelu) {
   auto tv0 = makeContigTensor(2, in_type);
   auto tv1 = makeContigTensor(2, in_type);
   auto tv2 = makeContigTensor(1, out_type);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
 
   // tv3 := A x B
-  auto tv3 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
   // tv4 := cast(bias)
   auto tv4 = maybeCastOp(accu_type, tv2);
 
@@ -842,9 +862,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasGelu) {
   auto tv6 = gelu(tv5);
   auto tv7 = maybeCastOp(out_type, tv6);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addInput(tv2);
   fusion->addOutput(tv7);
 
   NVF_CHECK(
@@ -939,9 +956,14 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasGeluAux) {
   auto tv0 = makeContigTensor(2, in_type);
   auto tv1 = makeContigTensor(2, in_type);
   auto tv2 = makeContigTensor(1, out_type);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
 
   // tv3 := A x B
-  auto tv3 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
   // tv4 := cast(bias)
   auto tv4 = maybeCastOp(accu_type, tv2);
 
@@ -954,9 +976,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasGeluAux) {
   auto tv7 = gelu(tv5);
   auto tv8 = maybeCastOp(out_type, tv7);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addInput(tv2);
   fusion->addOutput(tv6);
   fusion->addOutput(tv8);
 
@@ -1038,10 +1057,13 @@ TEST_F(MatmulSchedulerTest, BasicMatmulStrictCheckTT) {
 
   auto tv0 = makeContigTensor(2, DataType::Half);
   auto tv1 = makeContigTensor(2, DataType::Half);
-  auto tv2 = matmul(tv0, tv1, layout);
-
   fusion->addInput(tv0);
   fusion->addInput(tv1);
+
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+
   fusion->addOutput(tv2);
 
   NVF_CHECK(
@@ -1100,10 +1122,13 @@ TEST_F(MatmulSchedulerTest, BasicMatmulRelaxedCheck) {
 
     auto tv0 = makeContigTensor(2, DataType::Half);
     auto tv1 = makeContigTensor(2, DataType::Half);
-    auto tv2 = matmul(tv0, tv1, layout);
-
     fusion->addInput(tv0);
     fusion->addInput(tv1);
+
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+
     fusion->addOutput(tv2);
 
     NVF_CHECK(
@@ -1170,10 +1195,13 @@ TEST_F(MatmulSchedulerTest, BasicMatmulInputShuffledTT) {
 
   auto tv0 = makeContigTensor(2, DataType::Half);
   auto tv1 = makeContigTensor(2, DataType::Half);
-  auto tv2 = matmul(tv0, tv1, layout);
-
   fusion->addInput(tv1);
   fusion->addInput(tv0);
+
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+
   fusion->addOutput(tv2);
 
   NVF_CHECK(
@@ -1231,12 +1259,14 @@ TEST_F(MatmulSchedulerTest, EpilogueOutputCast) {
   // A - tv0, B - tv1
   auto tv0 = makeContigTensor(2, DataType::Half);
   auto tv1 = makeContigTensor(2, DataType::Half);
-
-  auto tv2 = matmul(tv0, tv1, layout);
-  auto tv3 = castOp(DataType::Half, tv2);
-
   fusion->addInput(tv0);
   fusion->addInput(tv1);
+
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  auto tv3 = castOp(DataType::Half, tv2);
+
   fusion->addOutput(tv3);
 
   NVF_CHECK(
@@ -1293,13 +1323,15 @@ TEST_F(MatmulSchedulerTest, EpilogueAlpha) {
   auto s0 = IrBuilder::create<Val>(DataType::Double);
   auto tv0 = makeContigTensor(2, DataType::Half);
   auto tv1 = makeContigTensor(2, DataType::Half);
-
-  auto tv2 = matmul(tv0, tv1, layout);
-  auto tv3 = mul(s0, tv2);
-
   fusion->addInput(tv0);
   fusion->addInput(tv1);
   fusion->addInput(s0);
+
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  auto tv3 = mul(s0, tv2);
+
   fusion->addOutput(tv3);
 
   NVF_CHECK(
@@ -1357,14 +1389,16 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaOutputCast) {
   auto s0 = IrBuilder::create<Val>(DataType::Double);
   auto tv0 = makeContigTensor(2, DataType::Half);
   auto tv1 = makeContigTensor(2, DataType::Half);
-
-  auto tv2 = matmul(tv0, tv1, layout);
-  auto tv3 = mul(s0, tv2);
-  auto tv4 = castOp(DataType::Half, tv3);
-
   fusion->addInput(tv0);
   fusion->addInput(tv1);
   fusion->addInput(s0);
+
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  auto tv3 = mul(s0, tv2);
+  auto tv4 = castOp(DataType::Half, tv3);
+
   fusion->addOutput(tv4);
 
   NVF_CHECK(
@@ -1426,19 +1460,21 @@ TEST_F(MatmulSchedulerTest, EpilogueBeta) {
   auto tv0 = makeContigTensor(2, DataType::Half);
   auto tv1 = makeContigTensor(2, DataType::Half);
   auto tv2 = makeContigTensor(2, DataType::Half);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
+  fusion->addInput(s0);
 
   // tv3 := A x B
-  auto tv3 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
 
   // tv4 := beta * C
   auto tv4 = mul(s0, tv2);
   // tv5 := A x B + beta * C
   auto tv5 = add(tv3, tv4);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addInput(tv2);
-  fusion->addInput(s0);
   fusion->addOutput(tv5);
 
   NVF_CHECK(
@@ -1506,8 +1542,15 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBeta) {
   auto tv0 = makeContigTensor(2, DataType::Half);
   auto tv1 = makeContigTensor(2, DataType::Half);
   auto tv2 = makeContigTensor(2, DataType::Half);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
+  fusion->addInput(s0);
+  fusion->addInput(s1);
 
-  auto tv3 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
   // tv4 := alpha * (A x B)
   auto tv4 = mul(s0, tv3);
 
@@ -1516,11 +1559,6 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBeta) {
   // tv6 := alpha * (A x B) + beta * C
   auto tv6 = add(tv4, tv5);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addInput(tv2);
-  fusion->addInput(s0);
-  fusion->addInput(s1);
   fusion->addOutput(tv6);
 
   NVF_CHECK(
@@ -1590,8 +1628,15 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaGeluOutputCast) {
   auto tv0 = makeContigTensor(2, DataType::Half);
   auto tv1 = makeContigTensor(2, DataType::Half);
   auto tv2 = makeContigTensor(2, DataType::Half);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
+  fusion->addInput(s0);
+  fusion->addInput(s1);
 
-  auto tv3 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
   // tv4 := alpha * (A x B)
   auto tv4 = mul(s0, tv3);
 
@@ -1604,11 +1649,6 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaGeluOutputCast) {
   // tv8 := half(gelu(alpha * (A x B) + beta * C))
   auto tv8 = castOp(DataType::Half, tv7);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addInput(tv2);
-  fusion->addInput(s0);
-  fusion->addInput(s1);
   fusion->addOutput(tv8);
 
   NVF_CHECK(
@@ -1683,8 +1723,16 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias) {
   auto tv1 = makeContigTensor(2, DataType::Half);
   auto tv2 = makeContigTensor(2, DataType::Half);
   auto tv3 = makeContigTensor(1, DataType::Float);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
+  fusion->addInput(tv3);
+  fusion->addInput(s0);
+  fusion->addInput(s1);
 
-  auto tv4 = matmul(tv0, tv1, layout);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv4 = fusedMultiplySum(tv0, tv1, {-1});
 
   // tv5 := (A x B) + bias
   auto tv5 = biasEpilogue(tv4, tv3);
@@ -1695,12 +1743,6 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias) {
   // tv8 := (alpha * ((A x B) + bias)) + (beta * C)
   auto tv8 = add(tv6, tv7);
 
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addInput(tv2);
-  fusion->addInput(tv3);
-  fusion->addInput(s0);
-  fusion->addInput(s1);
   fusion->addOutput(tv8);
 
   NVF_CHECK(
@@ -1772,12 +1814,14 @@ TEST_F(MatmulSchedulerTest, StridedBatch) {
     // A - tv0, B - tv1
     auto tv0 = makeContigTensor(3, DataType::Half);
     auto tv1 = makeContigTensor(3, DataType::Half);
-
-    // tv2 := A x B
-    auto tv2 = matmul(tv0, tv1, layout);
-
     fusion->addInput(tv0);
     fusion->addInput(tv1);
+
+    // tv2 := A x B
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+
     fusion->addOutput(tv2);
 
     NVF_CHECK(
@@ -1849,9 +1893,16 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta) {
     auto tv0 = makeContigTensor(3, DataType::Half);
     auto tv1 = makeContigTensor(3, DataType::Half);
     auto tv2 = makeContigTensor(3, DataType::Float);
+    fusion->addInput(tv0);
+    fusion->addInput(tv1);
+    fusion->addInput(tv2);
+    fusion->addInput(s0);
+    fusion->addInput(s1);
 
     // tv3 := A x B
-    auto tv3 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
     // tv4 := alpha * (A x B)
     auto tv4 = mul(s0, tv3);
     // tv5 := beta * C
@@ -1859,11 +1910,6 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta) {
     // tv6 := alpha * (A x B) + beta * C
     auto tv6 = add(tv4, tv5);
 
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addInput(tv2);
-    fusion->addInput(s0);
-    fusion->addInput(s1);
     fusion->addOutput(tv6);
 
     NVF_CHECK(
@@ -1945,9 +1991,16 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta) {
     auto tv0 = makeContigTensor(3, DataType::Half);
     auto tv1 = makeContigTensor(3, DataType::Half);
     auto tv2 = makeContigTensor(2, DataType::Float);
+    fusion->addInput(tv0);
+    fusion->addInput(tv1);
+    fusion->addInput(tv2);
+    fusion->addInput(s0);
+    fusion->addInput(s1);
 
     // tv3 := A x B
-    auto tv3 = matmul(tv0, tv1, layout);
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
     // tv4 := alpha * (A x B)
     auto tv4 = mul(s0, tv3);
     // tv5 := beta * C
@@ -1958,11 +2011,6 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta) {
     // tv7 := alpha * (A x B) + beta * C
     auto tv7 = add(tv4, tv6);
 
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addInput(tv2);
-    fusion->addInput(s0);
-    fusion->addInput(s1);
     fusion->addOutput(tv7);
 
     NVF_CHECK(
@@ -2041,15 +2089,17 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueBias) {
     auto tv0 = makeContigTensor(3, DataType::Half);
     auto tv1 = makeContigTensor(3, DataType::Half);
     auto tv2 = makeContigTensor(2, DataType::Float);
-
-    // tv3 := A x B
-    auto tv3 = matmul(tv0, tv1, layout);
-    // tv4 := (A x B) + bias
-    auto tv4 = biasEpilogue(tv3, tv2);
-
     fusion->addInput(tv0);
     fusion->addInput(tv1);
     fusion->addInput(tv2);
+
+    // tv3 := A x B
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
+    // tv4 := (A x B) + bias
+    auto tv4 = biasEpilogue(tv3, tv2);
+
     fusion->addOutput(tv4);
 
     NVF_CHECK(
@@ -2121,15 +2171,17 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueSingleBias) {
     auto tv0 = makeContigTensor(3, DataType::Half);
     auto tv1 = makeContigTensor(3, DataType::Half);
     auto tv2 = makeContigTensor(1, DataType::Float);
-
-    // tv3 := A x B
-    auto tv3 = matmul(tv0, tv1, layout);
-    // tv4 := (A x B) + bias
-    auto tv4 = biasEpilogue(tv3, tv2);
-
     fusion->addInput(tv0);
     fusion->addInput(tv1);
     fusion->addInput(tv2);
+
+    // tv3 := A x B
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
+    // tv4 := (A x B) + bias
+    auto tv4 = biasEpilogue(tv3, tv2);
+
     fusion->addOutput(tv4);
 
     NVF_CHECK(

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -256,20 +256,6 @@ Container parse(const std::string& nvdisasm_output) {
 
 } // namespace sass
 
-TensorView* matmul(
-    TensorView* a,
-    TensorView* b,
-    MmaLayout layout,
-    bool as_mul_sum) {
-  a = canonicalizeInputToBMNK(a, layout, MmaOperand::A);
-  b = canonicalizeInputToBMNK(b, layout, MmaOperand::B);
-  if (as_mul_sum) {
-    return sum(mul(a, b), {-1});
-  } else {
-    return fusedMultiplySum(a, b, {-1});
-  }
-}
-
 // matmulAtInput2D provides batched inputs in a splitk-like ordering. It
 // provides contiguous tensors with these shapes
 //   TT: [M, B, K] [B, K, N]

--- a/test/utils.h
+++ b/test/utils.h
@@ -596,15 +596,6 @@ static auto kAllSmemSwizzleModes = testing::Values(
     MmaInputSmemSwizzle::B64,
     MmaInputSmemSwizzle::B32);
 
-// Generic interface to get matmul op with the given layout.
-// The as_mul_sum flags creates a mul and sum ops instead of mma
-// to express matmuls. This flag only works for Ampere.
-TensorView* matmul(
-    TensorView* a,
-    TensorView* b,
-    MmaLayout layout,
-    bool as_mul_sum = false);
-
 // Utility to generate matmul input tensors based on given layout
 at::Tensor atMatmul(at::Tensor a, at::Tensor b, MmaLayout layout);
 


### PR DESCRIPTION
This PR removes the `matmul` function in `test/utils.h`. In all unit tests and benchmarks, I am replacing code like
```C++
auto c = matmul(a, b, layout);
```
with
```C++
a = canonicalizeInputToBMNK(a, layout, MmaOperand::A);
b = canonicalizeInputToBMNK(b, layout, MmaOperand::B);
auto c = fusedMultiplySum(a, b, {-1});
```
I believe the latter is better because it is more explicit about how the fusion looks like, therefore more readable.

Besides, with this new coding style, it will be easier to define supported prologue fusions for matmul. For example, if I want to do `sin(A) x sin(B)`, I can just do:
```
a = canonicalizeInputToBMNK(a, layout, MmaOperand::A);
b = canonicalizeInputToBMNK(b, layout, MmaOperand::B);
auto c = fusedMultiplySum(sin(a), sin(b), {-1});
```
In the past, this was not possible (`auto c = matmul(sin(a), sin(b), layout)` will not work, because of our current limitation that the transposes must be acting on the fusion input tensor, because this transpose will be converted to `ldmatrix.trans`)