### PR TITLE
multidevice debug disableSkip option

### DIFF
--- a/test/multidevice.cpp
+++ b/test/multidevice.cpp
@@ -28,6 +28,9 @@ void MultiDeviceEnvironment::SetUp() {
   if (getNvFuserEnv("MULTIDEVICE_DEBUG_BARRIER")) {
     do_barrier_at_test_ = true;
   }
+  if (getNvFuserEnv("MULTIDEVICE_DISABLE_SKIP")) {
+    disable_skip_ = true;
+  }
 }
 
 void MultiDeviceEnvironment::TearDown() {
@@ -40,14 +43,17 @@ void MultiDeviceEnvironment::TearDown() {
 void MultiDeviceTest::SetUp() {
   NVFuserTest::SetUp();
   communicator = multidevice_env->communicator();
-  if (!communicator->is_available() || communicator->size() < 2 ||
-      torch::cuda::device_count() < 2) {
+  debug_print = multidevice_env->debugPrint();
+  do_barrier_at_test =
+      multidevice_env->doBarrierAtTest() && communicator->is_available();
+  disable_skip = multidevice_env->disableSkip();
+  if (!disable_skip &&
+      (!communicator->is_available() || communicator->size() < 2 ||
+       torch::cuda::device_count() < 2)) {
     GTEST_SKIP() << "This test needs at least 2 GPUs and 2 ranks";
   }
   tensor_options =
       at::TensorOptions().dtype(at::kFloat).device(communicator->device());
-  debug_print = multidevice_env->debugPrint();
-  do_barrier_at_test = multidevice_env->doBarrierAtTest();
 }
 
 void MultiDeviceTest::TearDown() {

--- a/test/multidevice.h
+++ b/test/multidevice.h
@@ -33,10 +33,15 @@ class MultiDeviceEnvironment : public testing::Environment {
     return do_barrier_at_test_;
   }
 
+  bool disableSkip() const {
+    return disable_skip_;
+  }
+
  private:
   std::unique_ptr<Communicator> communicator_ = nullptr;
   bool debug_print_ = false;
   bool do_barrier_at_test_ = false;
+  bool disable_skip_ = false;
 };
 
 class MultiDeviceTest : public NVFuserTest {
@@ -47,6 +52,7 @@ class MultiDeviceTest : public NVFuserTest {
   c10::TensorOptions tensor_options;
   bool debug_print;
   bool do_barrier_at_test;
+  bool disable_skip;
 };
 
 class CommunicationTest


### PR DESCRIPTION
# What
option to disable GTEST_SKIP() in multidevice tests if the multidevice setting is not available
This option doesn't modify nvFuser itself but only the multidevice tests

# How
this option is switched on by setting the env variable `NVFUSER_MULTIDEVICE_DISABLE_SKIP=1`

# Why
It is a very useful tool for debugging since it allows to run the test from gdb on a single process. Many of the debug deal with the IR lowering and thus do not involve multi-device operation per say