### PR TITLE
Correct typo in MultiDeviceExecutor::print

### DIFF
--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -268,7 +268,7 @@ std::ostream& MultiDeviceExecutor::print() {
   int communication_counter = 0;
   for (auto group : workspace.group_run_order) {
     if (is_resharding_[group]) {
-      debug() << "Communication " << compute_segment_counter << ":{\n";
+      debug() << "Communication " << communication_counter << ":{\n";
       for (const auto& comm :
            lowerCommunication(comm_.deviceId(), group->exprs().at(0), {}, {})) {
         debug() << comm->toString(2) << "\n";


### PR DESCRIPTION
fix build error
```
csrc/multidevice/executor.cpp:268:7: error: variable 'communication_counter' set but not used [-Werror,-Wunused-but-set-variable]
  int communication_counter = 0;
      ^
```

Thanks @naoyam 