### PR TITLE
Multidevice tests with unsharded inputs

### DIFF
--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -443,13 +443,6 @@ std::vector<std::shared_ptr<Communication>> lowerCommunication(
           static_cast<size_t>(output_tensor.size(0)) == 1,
       "Sharded dimension should have allocation size 1, but is ",
       output_tensor.size(0));
-  NVF_ERROR(!sender_mesh.vector().empty(), "sender mesh is empty");
-  NVF_ERROR(!receiver_mesh.vector().empty(), "receiver mesh is empty");
-
-  if (!isDeviceInvolved(my_device_index, sender_mesh, receiver_mesh)) {
-    return {};
-  }
-
   if (is_reduction) {
     BinaryOpType op_type =
         output_tv->definition()->as<ReductionOp>()->getReductionOpType();

--- a/test/multidevice.cpp
+++ b/test/multidevice.cpp
@@ -89,237 +89,95 @@ void CommunicationTest::resetDstBuffers() {
   }
 }
 
-namespace {
-
-void unshardTv(TensorView* tv) {
-  for (IterDomain* id : tv->getLeafDomain()) {
-    if (id->isDeviceDim()) {
-      id->parallelize(ParallelType::Serial);
-    }
-  }
-}
-
-void doSendRecv(
-    DeviceIdxType sender,
-    DeviceIdxType receiver,
-    at::Tensor send_buf,
-    at::Tensor recv_buf,
-    Communicator* communicator) {
-  CommParams params;
-  params.root = sender;
-  if (sender == receiver) {
-    params.team = {sender};
-  } else {
-    params.team = {sender, receiver};
-  }
-  if (send_buf.numel()) {
-    params.src_bufs = {send_buf};
-  }
-  if (recv_buf.numel()) {
-    params.dst_bufs = {recv_buf};
-  }
-  auto work = SendRecv(params).post(*communicator);
-  if (work) {
-    work->wait();
-  }
-}
-
-// Send a possibly sharded tensor to one "tester" device
-void SendToTester(
-    TensorView* tv,
-    at::Tensor tensor,
-    at::Tensor tester_tensor,
-    DeviceIdxType tester,
-    Communicator* communicator) {
-  auto mesh = tv->getDeviceMesh();
-  if (isSharded(tv)) {
-    for (DeviceIdxType j : c10::irange(mesh.vector().size())) {
-      at::Tensor send_buf, recv_buf;
-      auto sender = mesh.vector().at(j);
-      if (communicator->deviceId() == sender ||
-          communicator->deviceId() == tester) {
-        if (communicator->deviceId() == sender) {
-          send_buf = tensor.index({0, "..."});
-        }
-        if (communicator->deviceId() == tester) {
-          recv_buf = tester_tensor.index({j, "..."});
-        }
-        doSendRecv(sender, tester, send_buf, recv_buf, communicator);
-      }
-    }
-  } else {
-    at::Tensor send_buf, recv_buf;
-    auto sender = mesh.vector().at(0);
-    if (communicator->deviceId() == sender ||
-        communicator->deviceId() == tester) {
-      if (communicator->deviceId() == sender) {
-        send_buf = tensor;
-      }
-      if (communicator->deviceId() == tester) {
-        recv_buf = tester_tensor;
-      }
-      doSendRecv(sender, tester, send_buf, recv_buf, communicator);
-    }
-  }
-}
-
-c10::IValue allocate_unsharded_input(
-    DeviceIdxType tester,
-    TensorView* tv,
-    at::Tensor sharded_input) {
-  std::vector<int64_t> unsharded_sizes;
-  for (size_t i = 0; i < tv->nDims(); i++) {
-    if (tv->axis(i)->isDeviceDim()) {
-      unsharded_sizes.push_back(tv->getDeviceMesh().vector().size());
-    } else {
-      unsharded_sizes.push_back(sharded_input.size(i));
-    }
-  }
-  at::Tensor unsharded_input =
-      at::rand(unsharded_sizes, sharded_input.options());
-  unsharded_input.index_put_({tester, "..."}, sharded_input.index({0, "..."}));
-  return unsharded_input;
-}
-
 // Utility function used for validation in the tests
 // It compares the given (possibly sharded) output with the result of the Fusion
 // run on a single device with the given (possibly sharded) inputs
-void testValidateMultidevice(
-    MultiDeviceExecutor& runtime,
-    const at::ArrayRef<c10::IValue>& inputs,
-    const std::vector<at::Tensor>& outputs,
-    bool print,
-    DeviceIdxType tester = 0,
-    bool validate = true,
-    bool set_mem_type_to_global = true,
-    bool auto_schedule = false) {
-  // gathering all the inputs at tester
-  std::vector<c10::IValue> unsharded_inputs;
-  for (auto i : c10::irange(inputs.size())) {
-    TensorView* tv = runtime.completeFusion()->inputs().at(i)->as<TensorView>();
-    c10::IValue unsharded_input = isSharded(tv)
-        ? allocate_unsharded_input(tester, tv, inputs.at(i).toTensor())
-        : inputs.at(i).deepcopy();
-    unsharded_inputs.push_back(unsharded_input);
-    SendToTester(
-        tv,
-        inputs.at(i).toTensor(),
-        unsharded_inputs.at(i).toTensor(),
-        tester,
-        runtime.comm());
+void PipelineTest::validate() {
+  // execute the fusion on one device without pipeline scheduling
+  auto fusion_copy = std::make_unique<Fusion>(*runtime->completeFusion());
+  unshard(fusion_copy.get());
+  FusionExecutorCache unsharded_fec(std::move(fusion_copy));
+  auto ref_unsharded_outputs =
+      unsharded_fec.runFusionWithInputs(unsharded_inputs);
+
+  if (debug_print) {
+    std::stringstream ss;
+    std::string indent = "  ";
+    ss << "Device " << communicator->deviceId()
+       << "'s expected (unsharded) outputs:{\n";
+    for (auto& t : ref_unsharded_outputs) {
+      ss << indent << t;
+    }
+    ss << "\n}";
+    std::cout << ss.str() << std::endl;
   }
 
-  // allocate output buffers for the tester
-  std::vector<at::Tensor> unsharded_outputs;
-  if (runtime.comm()->deviceId() == tester) {
-    std::unique_ptr<Fusion> fusion_copy = std::make_unique<Fusion>();
-    auto original_to_copy_cloner =
-        Fusion::copy(runtime.completeFusion(), fusion_copy.get());
-
-    for (auto tv : ir_utils::filterByType<TensorView>(fusion_copy->vals())) {
-      unshardTv(tv);
-      tv->setMemoryType(MemoryType::Global);
+  GTEST_ASSERT_EQ(ref_unsharded_outputs.size(), outputs.size());
+  for (int i : c10::irange(runtime->completeFusion()->outputs().size())) {
+    GTEST_ASSERT_TRUE(
+        runtime->completeFusion()->outputs().at(i)->isA<TensorView>());
+    auto output_tv =
+        runtime->completeFusion()->outputs().at(i)->as<TensorView>();
+    if (!output_tv->getDeviceMesh().has(communicator->deviceId())) {
+      continue;
     }
-
-    FusionExecutor fe;
-    fe.compileFusion(fusion_copy.get(), unsharded_inputs);
-    unsharded_outputs = fe.allocOutputSpace(unsharded_inputs);
-  } else {
-    // On non-tester devices, these tensors won't be used.
-    // we copy the local outputs for convenience
-    unsharded_outputs = outputs;
-  }
-
-  // gathering all the outputs at tester
-  for (auto i : c10::irange(outputs.size())) {
-    SendToTester(
-        runtime.completeFusion()->outputs().at(i)->as<TensorView>(),
-        outputs.at(i),
-        unsharded_outputs.at(i),
-        tester,
-        runtime.comm());
-  }
-
-  if (runtime.comm()->deviceId() == tester) {
-    if (print) {
-      std::stringstream ss;
-      std::string indent = "  ";
-      ss << "Obtained final outputs:{\n";
-      for (auto& t : unsharded_outputs) {
-        ss << indent << t;
-      }
-      ss << "\n}\n";
-      ss << "Reference (unsharded) input:{\n";
-      for (auto& t : unsharded_inputs) {
-        ss << indent << t;
-      }
-      ss << "\n}";
-      std::cout << ss.str() << std::endl;
-    }
-
-    // sets all the memory type to global to avoid an execution error
-    auto fusion_ptr = runtime.completeFusion();
-    for (auto tv : ir_utils::filterByType<TensorView>(fusion_ptr->vals())) {
-      unshardTv(tv);
-      if (set_mem_type_to_global) {
-        tv->setMemoryType(MemoryType::Global);
-      }
-    }
-
-    // execute the fusion on one device without pipeline scheduling
-    std::vector<at::Tensor> ref_outputs;
-    if (auto_schedule) {
-      auto fusion_unique_ptr = std::make_unique<Fusion>(*fusion_ptr);
-      FusionExecutorCache fec(std::move(fusion_unique_ptr));
-      ref_outputs = fec.runFusionWithInputs(unsharded_inputs);
-    } else {
-      FusionExecutor fe;
-      fe.compileFusion(fusion_ptr, unsharded_inputs);
-      ref_outputs = fe.runFusion(unsharded_inputs);
-    }
-
-    if (print) {
-      std::stringstream ss;
-      std::string indent = "  ";
-      ss << "Expected outputs:{\n";
-      for (auto& t : ref_outputs) {
-        ss << indent << t;
-      }
-      ss << "\n}";
-      std::cout << ss.str() << std::endl;
-    }
-
-    if (validate) {
-      testValidate(
-          fusion_ptr,
-          unsharded_outputs,
-          unsharded_inputs,
-          ref_outputs,
-          __LINE__,
-          __FILE__);
-    }
+    auto ref_output = isSharded(output_tv) ? shardTensor(
+                                                 ref_unsharded_outputs.at(i),
+                                                 output_tv->getDeviceMesh(),
+                                                 communicator->deviceId())
+                                           : ref_unsharded_outputs.at(i);
+    auto obtained_output = outputs.at(i);
+    GTEST_EXPECT_TRUE(torch::allclose(ref_output, obtained_output))
+        << "Device " << communicator->deviceId() << " has unexpected output "
+        << i << " corresponding to tv " << output_tv
+        << ". Expected values: " << ref_output
+        << ", obtained values: " << obtained_output;
   }
 }
 
 // Run and validate a pipeline
 // with given (possibly sharded) inputs
-void executeAndValidateMultiDeviceFusion(
-    std::unique_ptr<Fusion> fusion_ptr,
-    std::vector<c10::IValue>& inputs,
-    Communicator* communicator,
-    bool print) {
-  if (print && !communicator->deviceId()) {
-    fusion_ptr->printKernel();
+void PipelineTest::execute() {
+  GTEST_ASSERT_EQ(unsharded_inputs.size(), fusion->inputs().size());
+  for (int i : c10::irange(fusion->inputs().size())) {
+    GTEST_ASSERT_TRUE(fusion->inputs().at(i)->isA<TensorView>());
+    auto input_tv = fusion->inputs().at(i)->as<TensorView>();
+    auto input = isSharded(input_tv) ? shardTensor(
+                                           unsharded_inputs.at(i).toTensor(),
+                                           input_tv->getDeviceMesh(),
+                                           communicator->deviceId())
+                                     : unsharded_inputs.at(i).toTensor();
+    inputs.push_back(input);
   }
 
-  MultiDeviceExecutor runtime(std::move(fusion_ptr), *communicator);
-  if (auto error_msg = runtime.validate(); error_msg != "") {
+  if (debug_print) {
+    if (!communicator->deviceId()) {
+      fusion->printKernel();
+    }
+    std::stringstream ss;
+    std::string indent = "  ";
+    ss << "Device " << communicator->deviceId() << "'s inputs:{\n";
+    for (auto& t : inputs) {
+      ss << indent << t;
+    }
+    ss << "\n}";
+    std::cout << ss.str() << std::endl;
+  }
+
+  runtime =
+      std::make_unique<MultiDeviceExecutor>(std::move(fusion), *communicator);
+  auto error_msg = runtime->validate();
+  if (error_msg != "") {
     GTEST_SKIP() << error_msg;
   }
+  if (debug_print) {
+    if (!communicator->deviceId()) {
+      runtime->print();
+    }
+  }
+  outputs = runtime->runWithInput(inputs);
 
-  auto outputs = runtime.runWithInput(inputs);
-
-  if (print) {
+  if (debug_print) {
     std::stringstream ss;
     std::string indent = "  ";
     ss << "Device " << communicator->deviceId() << "'s outputs:{\n";
@@ -329,21 +187,12 @@ void executeAndValidateMultiDeviceFusion(
     ss << "\n}";
     std::cout << ss.str() << std::endl;
   }
-
-  testValidateMultidevice(runtime, inputs, outputs, print);
 }
-
-} // namespace
 
 void PipelineTest::SetUp() {
   MultiDeviceTest::SetUp();
   fusion = std::make_unique<Fusion>();
   communicator->setDefaultBackend(CommunicatorBackend::nccl);
-}
-
-void PipelineTest::validate() {
-  executeAndValidateMultiDeviceFusion(
-      std::move(fusion), inputs, communicator, debug_print);
 }
 
 } // namespace nvfuser

--- a/test/multidevice.h
+++ b/test/multidevice.h
@@ -89,9 +89,16 @@ class PipelineTest : public MultiDeviceTest {
  protected:
   void SetUp() override;
   void validate();
+  void execute();
+  void executeAndValidate() {
+    execute();
+    validate();
+  }
   std::unique_ptr<MultiDeviceExecutor> runtime;
   std::unique_ptr<Fusion> fusion;
   std::vector<c10::IValue> inputs;
+  std::vector<c10::IValue> unsharded_inputs;
+  std::vector<at::Tensor> outputs;
 };
 
 } // namespace nvfuser


### PR DESCRIPTION
In this pr, we simplify the multidevice test validation implementation and make it run faster.

Before, we would allocate a shard of the inputs at each rank. Then, for validation, we needed to gather at a tester rank all the inputs and outputs shards, and compare them with the unsharded output obtained from running the Fusion on a single device with the unsharded inputs. This flow could be summarized as follows:
```
execution:
for all RANK k
- allocate input's shard k
- run Fusion on multidevice with input's shard k  --> get output's shard k

validation:
TESTER RANK:
- gather all input shards from other ranks 
- run Fusion on single device with unsharded input --> get unsharded output
- gather all outputs shards slices from other ranks
- compare all output shards with unsharded outputs
```
This flow is somehow cumbersome to implement and is not scalable because it requires a lot of network communications and synchronizations.

With this patch, we get rid of all network communication at test validation. All ranks initialize the same unsharded input, even though only their corresponding slice is used in the Multidevice Execution. Then they compare the output obtained through multidevice execution with the one obtained through single device execution with unsharded input. This way, validation requires no network communication, which improve the logic and the perf by a lot. 
```
execution:
for all RANK k
allocate global input (identitical accross ranks)
run Fusion with input's shard k --> get output's shard k

validation:
for all RANK k
- run Fusion on a single device with unsharded input --> get unsharded output
- compare output shard k and with a slice of unsharded outputs
```
The only "drawback" of this method is that we make the assumption that, in the tests, all ranks initialize identical inputs. However, that sounds like a much reasonable assumption. This assumption is ensured by taking the same random seed accross ranks.