### PR TITLE
Python API (FusionDefinition::execute) to support tuple for vector inputs

### DIFF
--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -543,7 +543,8 @@ void initNvFuserPythonBindings(PyObject* module) {
             std::vector<c10::IValue> inputs;
             for (py::handle obj : iter) {
               // Allows for a Vector of Sizes to be inputed as a list
-              if (py::isinstance<py::list>(obj)) {
+              if (py::isinstance<py::list>(obj) ||
+                  py::isinstance<py::tuple>(obj)) {
                 for (py::handle item : obj) {
                   inputs.push_back(
                       torch::jit::toIValue(item, c10::AnyType::get()));

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -542,7 +542,7 @@ void initNvFuserPythonBindings(PyObject* module) {
              bool capture_debug_output) {
             std::vector<c10::IValue> inputs;
             for (py::handle obj : iter) {
-              // Allows for a Vector of Sizes to be inputed as a list
+              // Allows for a Vector of Sizes to be inputed as a list/tuple
               if (py::isinstance<py::list>(obj) ||
                   py::isinstance<py::tuple>(obj)) {
                 for (py::handle item : obj) {

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -543,7 +543,8 @@ class TestNvFuserFrontend(TestCase):
         shape = [2, 3, 4]
         new_shape = [6, 4]
 
-        inputs_with_list = [torch.randn(shape, device="cuda"), new_shape]
+        tensor = torch.randn(shape, device="cuda")
+        inputs_with_list = [tensor, new_shape]
 
         def fusion_func(fd: FusionDefinition):
             t0 = fd.from_pytorch(inputs_with_list[0])
@@ -559,8 +560,9 @@ class TestNvFuserFrontend(TestCase):
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs_with_list)
         self.assertEqual(eager_out, nvf_out[0])
 
-        inputs_with_tuple = [torch.randn(shape, device="cuda"), tuple(new_shape)]
-        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs_with_tuple)
+        inputs_with_tuple = [tensor, tuple(new_shape)]
+        # expect to reuse fusion
+        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs_with_tuple, new_fusion_expected=False)
         self.assertEqual(eager_out, nvf_out[0])
 
     # Testing a scenario where a broadcast requires a symbolic output shape

--- a/python_tests/test_python_frontend.py
+++ b/python_tests/test_python_frontend.py
@@ -562,7 +562,9 @@ class TestNvFuserFrontend(TestCase):
 
         inputs_with_tuple = [tensor, tuple(new_shape)]
         # expect to reuse fusion
-        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs_with_tuple, new_fusion_expected=False)
+        nvf_out, _ = self.exec_nvfuser(
+            fusion_func, inputs_with_tuple, new_fusion_expected=False
+        )
         self.assertEqual(eager_out, nvf_out[0])
 
     # Testing a scenario where a broadcast requires a symbolic output shape


### PR DESCRIPTION
Changing the FusionDefinition's execute method to support both`List` and `Tuple` for vector of scalars.