### PR TITLE
Fix MultiDeviceExecutor::requestedNumberOfDevices

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -151,16 +151,15 @@ void insertReshardings(Fusion* fusion) {
 }
 
 int64_t requestedNumberOfDevices(Fusion* fusion) {
-  std::set<DeviceIdxType> device_indices;
+  DeviceIdxType max_index = 0;
   for (auto tv : ir_utils::allTvs(fusion)) {
     if (tv->hasDeviceMesh()) {
-      std::copy(
-          tv->getDeviceMesh().vector().begin(),
-          tv->getDeviceMesh().vector().end(),
-          std::inserter(device_indices, device_indices.begin()));
+      for (auto d_id : tv->getDeviceMesh().vector()) {
+        max_index = std::max(max_index, d_id);
+      }
     }
   }
-  return static_cast<int64_t>(device_indices.size());
+  return static_cast<int64_t>(max_index + 1);
 }
 
 void unshard(TensorView* tv) {


### PR DESCRIPTION
A small fix to avoid some hangs in the tests in case the runtime doesn't match the required multi-device setting.

More precisely, imagine we shard a tensor on the device mesh [0,2], and that, at runtime, the communicator is of size 2, then, there will be no device with index 2, so the runtime is incompatible.

Before this patch, the above situation would not be detected as an error. 