### PR TITLE
add iter grouped grid reduction

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1816,18 +1816,91 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
              << ";\n";
   }
 
+  void generateIterGroupedGridReduction(
+      const int num_grouped_iterations,
+      const kir::GroupedGridReduction* grop) {
+    NVF_ERROR(grop->output(0)->isA<kir::TensorIndex>());
+    const auto output = grop->output(0)->as<kir::TensorIndex>();
+    const auto input = grop->input(0)->as<kir::TensorIndex>();
+    const auto op_type = grop->getReductionOpType(0);
+    const auto data_type = grop->output(0)->dtype();
+
+    const std::string flags_str =
+        generateGridReduceTemplateFlags2(grop, grop->threadPredicate());
+
+    const bool persistent_sync =
+        kernel_->summary().has_cooperative_grid_reduction;
+
+    // Since block-level reduction is already done, those dimensions
+    // with tidx/y/z being true do not participate in the grid
+    // reduction.
+    ArgumentBuilder template_args;
+    template_args.arg(flags_str)
+        .arg(persistent_sync)
+        .arg(isAligned())
+        .arg(num_grouped_iterations);
+
+    const auto work_buffer =
+        grop->reduction_buffers().at(0)->buffer()->as<TensorView>();
+    const auto sync_buffer = grop->sync_buffer()->buffer()->as<TensorView>();
+
+    ArgumentBuilder func_args(block_nest_level_ + 1, kTab);
+    auto output_tv = output->view();
+    auto va = kernel_->summary().vectorized_accesses;
+    if (va.find(output_tv) != va.end()) {
+      func_args.arg(genVariableName(output) + ".array");
+    } else {
+      func_args.arg(genVariableName(output));
+    }
+    func_args.arg(genVariableName(input));
+    func_args.arg(genReductionOp(op_type, data_type));
+    func_args.arg("&").append(genVariableName(work_buffer)).append("[0]");
+    func_args.arg("&").append(genVariableName(sync_buffer)).append("[0]");
+    func_args.arg(genCall("static_cast", ptrType(data_type), "shared_mem"));
+    // read and write predicates
+    NVF_ERROR(grop->predicate() != nullptr && grop->predicate()->hasValue());
+    const auto read_pred = genInline(grop->predicate());
+    func_args.arg(read_pred);
+    if (grop->writePredicate() != nullptr) {
+      NVF_ERROR(grop->writePredicate()->hasValue());
+      func_args.arg(genInline(grop->writePredicate()));
+    } else {
+      func_args.arg(read_pred);
+    }
+    // Init val
+    func_args.arg(genCall(data_type, genInline(grop->initVal(0))));
+    func_args.arg("0"); // entrance index is always 0
+    func_args.arg(genInline(grop->entrances()));
+
+    addProfileArguments(func_args, grop);
+
+    indent() << "reduction::iterGroupedGridReduce<" << template_args << ">(\n";
+    indent() << kTab << func_args << ");\n";
+  }
+
   void handle(const kir::GroupedGridReduction* grouped_grop) final {
     const auto out = ir_utils::getTvOutput(grouped_grop);
     const auto domain = out->domain();
     NVF_ERROR(domain->hasGridReduction());
-
     NVF_ERROR(grouped_grop->sync_buffer()->buffer()->isA<TensorView>());
     const auto sync_buffer =
         grouped_grop->sync_buffer()->buffer()->as<TensorView>();
-
     if (grouped_grop->isAllreduce()) {
       generateGroupedGridAllreduce(grouped_grop);
       return;
+    }
+
+    // iter domain grouped grid reduction, used for outer reduction
+    // where iter domain is vectorized.
+    if (grouped_grop->numHorizontallyGroupedExprs() == 1) {
+      const auto num_grouped_iterations =
+          getGroupedLoopIndexConcreteIntSets().size();
+      NVF_ERROR(
+          num_grouped_iterations > 1,
+          "num_grouped_iterations should be greater than 1. Got: ",
+          num_grouped_iterations);
+      return generateIterGroupedGridReduction(
+          (int)num_grouped_iterations, grouped_grop);
     }
 
     NVF_ERROR(

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1869,8 +1869,6 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     }
     // Init val
     func_args.arg(genCall(data_type, genInline(grop->initVal(0))));
-    func_args.arg("0"); // entrance index is always 0
-    func_args.arg(genInline(grop->entrances()));
 
     addProfileArguments(func_args, grop);
 

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -45,6 +45,22 @@ class KernelIrScanner : private IrVisitor {
   }
 
  private:
+  inline int getNumOfGroupedIterations(GroupedReductionOp* grouped_rop) {
+    int num_grouped_iterations = 1;
+    auto out_tv = ir_utils::getTvOutput(grouped_rop);
+    for (auto axis : out_tv->getLeafDomain()) {
+      if (axis->getParallelType() == ParallelType::Group) {
+        num_grouped_iterations *= (int)axis->extent()->value();
+      }
+    }
+    NVF_ERROR(
+        num_grouped_iterations == 2 || num_grouped_iterations == 4 ||
+            num_grouped_iterations == 8 || num_grouped_iterations == 16,
+        "Iteration grouped reduction only support grouping 2, 4, 8, or 16 iterations, but found ",
+        num_grouped_iterations);
+    return num_grouped_iterations;
+  }
+
   using IrVisitor::dispatch;
   using IrVisitor::handle;
   void dispatch(Expr* expr) final {
@@ -128,21 +144,9 @@ class KernelIrScanner : private IrVisitor {
     }
     // process iteration grouped reduction
     summary_.has_iter_grouped_reductions = true;
-    int num_grouped_iterations = 1;
-    auto out_tv = ir_utils::getTvOutput(grouped_rop);
-    for (auto axis : out_tv->getLeafDomain()) {
-      if (axis->getParallelType() == ParallelType::Group) {
-        num_grouped_iterations *= (int)axis->extent()->value();
-      }
-    }
+    int num_grouped_iterations = getNumOfGroupedIterations(grouped_rop);
     summary_.num_grouped_iterations =
         std::max(summary_.num_grouped_iterations, num_grouped_iterations);
-
-    NVF_ERROR(
-        num_grouped_iterations == 2 || num_grouped_iterations == 4 ||
-            num_grouped_iterations == 8 || num_grouped_iterations == 16,
-        "Iteration grouped reduction only support grouping 2, 4, 8, or 16 iterations, but found ",
-        num_grouped_iterations);
   }
 
   void handle(GridWelford* grid_welford) final {
@@ -169,6 +173,12 @@ class KernelIrScanner : private IrVisitor {
     summary_.has_grid_reductions = true;
     if (grid_reduction->isAllreduce()) {
       summary_.has_cooperative_grid_reduction = true;
+    } else if (grid_reduction->numHorizontallyGroupedExprs() == 1) {
+      // non-persistent iteration domain grouped reduction
+      summary_.has_iter_grouped_reductions = true;
+      summary_.num_grouped_iterations = std::max(
+          summary_.num_grouped_iterations,
+          getNumOfGroupedIterations(grid_reduction->as<GroupedReductionOp>()));
     }
   }
 

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -835,7 +835,7 @@ std::shared_ptr<ReductionParams> outerReductionHeuristic(
     debug() << "\n===== Reduction Stats ========\n"
             << "total_reduction_numel: " << total_reduction_numel << "\n"
             << "total_iteration_numel: " << total_iteration_numel << "\n"
-            << "vectorize_factor: " << vectorize_factor << "\n"
+            << "vectorize_factor: " << iter_unroll_factor << "\n"
             << "n_tensor_inputs: " << n_tensor_inputs << "\n"
             << "max_input_dtype_size: " << max_input_dtype_size << "\n"
             << "block(" << bdimx << ", " << bdimy << ", 1)" << std::endl;

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -1214,6 +1214,8 @@ void scheduleReduction(Fusion* fusion, const ReductionParams& rparams) {
   // TODO: the var name is confusing, should rename
   // [cross_grid/block_inner_reduction] to [cross_grid/block_reduction], see
   // https://github.com/NVIDIA/Fuser/issues/1863
+  // grouped welford is only enabled for grid persistent.
+  // see validateAndConvertIterDomainGrouping
   const bool has_welford = ir_utils::hasOpsOfType<WelfordOp>(fusion);
   const bool use_iter_grouped_reduction = !rparams.fastest_dim &&
       (has_welford

--- a/runtime/grid_reduction.cu
+++ b/runtime/grid_reduction.cu
@@ -667,4 +667,219 @@ __device__ void serialReductionStep(
   }
 }
 
+// vectorized reduction
+template <
+    bool X_THREAD,
+    bool Y_THREAD,
+    bool Z_THREAD,
+    bool Aligned,
+    int VECT_FACTOR,
+    typename T,
+    typename Func>
+__device__ void iterGroupedGridReduceLastBlock(
+    T* out,
+    const volatile T* in,
+    const nvfuser_index_t
+        grid_reduction_segment_size, // Number of reductions across
+                                     // grid reduce dimensions
+    const nvfuser_index_t
+        block_reduction_segment_size, // Number of reductions across the block
+    Func reduction_op,
+    T* shared_buf,
+    bool write_pred,
+    T init_val,
+    const nvfuser_index_t grid_segment_size,
+    const nvfuser_index_t idx_in_grid_segment) {
+  // We have to do num_reductions across reduction_size. The reductions are
+  // contiguous, but offset by reduction_size. There is an entry in "in" for
+  // every block, and every thread marked as true. Threads in dimensions marked
+  // as false can be used to parallelize the reduction.
+
+  // Find the reduction id of the participating threads
+  const auto block_reduction_segment_idx =
+      index_utils::maskedOffset<X_THREAD, Y_THREAD, Z_THREAD>(
+          threadIdx, blockDim);
+
+  // Find an id associated within a reduction segment for all
+  // "non-participating" threads, which will parallelize the reductions for the
+  // "participating" threads
+  const auto id_in_block_segment =
+      index_utils::maskedOffset<!X_THREAD, !Y_THREAD, !Z_THREAD>(
+          threadIdx, blockDim);
+
+  // Stride by the "non-participating" threads
+  const auto input_stride_for_thread_in_segment =
+      index_utils::maskedSize<!X_THREAD, !Y_THREAD, !Z_THREAD>(blockDim);
+
+  // T inp = init_val;
+  T inp[VECT_FACTOR];
+#pragma unroll
+  for (int i = 0; i < VECT_FACTOR; i++) {
+    inp[i] = init_val;
+  }
+  // Block stride across the reduction until we only have one value per thread
+  for (nvfuser_index_t reduction_i = id_in_block_segment;
+       reduction_i < grid_reduction_segment_size;
+       reduction_i += input_stride_for_thread_in_segment) {
+    auto work_buf_offset = reduction_i * block_reduction_segment_size +
+        block_reduction_segment_idx;
+#pragma unroll
+    for (int entrance_ind = 0; entrance_ind < VECT_FACTOR; entrance_ind++) {
+      const volatile T* my_work_buf = in +
+          (entrance_ind * grid_segment_size + idx_in_grid_segment) *
+              grid_reduction_segment_size * block_reduction_segment_size;
+      reduction_op(inp[entrance_ind], my_work_buf[work_buf_offset]);
+    }
+  }
+
+  // Block reduce the per thread values into per "participating" thread values
+  // T inp_tmp = init_val;
+  T inp_tmp[VECT_FACTOR];
+#pragma unroll
+  for (int i = 0; i < VECT_FACTOR; i++) {
+    inp_tmp[i] = init_val;
+  }
+  blockIterGroupedReduce<!X_THREAD, !Y_THREAD, !Z_THREAD, Aligned, VECT_FACTOR>(
+      inp_tmp, inp, reduction_op, shared_buf, true, init_val);
+  const bool should_write = (X_THREAD || threadIdx.x == 0) &&
+      (Y_THREAD || threadIdx.y == 0) && (Z_THREAD || threadIdx.z == 0);
+  if (should_write && write_pred) {
+#pragma unroll
+    for (int i = 0; i < VECT_FACTOR; i++) {
+      reduction_op(out[i], inp_tmp[i]);
+    }
+  }
+}
+
+template <
+    bool X_BLOCK,
+    bool Y_BLOCK,
+    bool Z_BLOCK,
+    bool X_THREAD,
+    bool Y_THREAD,
+    bool Z_THREAD,
+    bool PERSISTENT_REDUCTION,
+    bool Aligned,
+    int VECT_FACTOR,
+    typename T,
+    typename Func>
+__device__ void iterGroupedGridReduce(
+    T* out,
+    const T* inp_val,
+    Func reduction_op,
+    volatile T* work_buf,
+    int64_t* sync_flags,
+    T* shared_buf,
+    bool read_pred,
+    bool write_pred,
+    T init_val,
+    const nvfuser_index_t entrance_ind,
+    const nvfuser_index_t n_entrances) {
+  // inp or block reduction results
+  T block_reduction_val[VECT_FACTOR];
+
+  // Do block reduction when required
+  if (X_THREAD || Y_THREAD || Z_THREAD) {
+#pragma unroll
+    for (int i = 0; i < VECT_FACTOR; i++) {
+      block_reduction_val[i] = init_val;
+    }
+    blockIterGroupedReduce<X_THREAD, Y_THREAD, Z_THREAD, Aligned, VECT_FACTOR>(
+        block_reduction_val,
+        inp_val,
+        reduction_op,
+        shared_buf,
+        read_pred,
+        true,
+        init_val);
+  } else if (read_pred) {
+#pragma unroll
+    for (int i = 0; i < VECT_FACTOR; i++) {
+      block_reduction_val[i] = inp_val[i];
+    }
+  }
+
+  // Number of values to reduce in the reduction segment
+  const auto grid_reduction_segment_size =
+      index_utils::maskedSize<X_BLOCK, Y_BLOCK, Z_BLOCK>(gridDim);
+
+  // Index of the reduction we're performing out of the
+  // grid_reduction_segment_size
+  const auto idx_in_grid_segment =
+      index_utils::maskedOffset<!X_BLOCK, !Y_BLOCK, !Z_BLOCK>(
+          blockIdx, gridDim);
+
+  // Number of threads we can use in final reduction, Seems to assume all
+  // threads in the block participate
+  const auto block_reduction_segment_size =
+      index_utils::maskedSize<!X_THREAD, !Y_THREAD, !Z_THREAD>(blockDim);
+
+  // Number of reductions in the grid
+  const nvfuser_index_t grid_segment_size = PERSISTENT_REDUCTION
+      ? 1
+      : index_utils::maskedSize<!X_BLOCK, !Y_BLOCK, !Z_BLOCK>(gridDim);
+
+  // advance to the offset for this segment
+  // index of reduction * size of the reduction * size of threads
+  if ((!X_THREAD || threadIdx.x == 0) && (!Y_THREAD || threadIdx.y == 0) &&
+      (!Z_THREAD || threadIdx.z == 0)) {
+    auto block_offset =
+        index_utils::maskedOffset<X_BLOCK, Y_BLOCK, Z_BLOCK>(blockIdx, gridDim);
+    auto thread_offset =
+        index_utils::maskedOffset<!X_THREAD, !Y_THREAD, !Z_THREAD>(
+            threadIdx, blockDim);
+    auto work_buf_offset =
+        block_offset * block_reduction_segment_size + thread_offset;
+#pragma unroll
+    for (int entrance_ind = 0; entrance_ind < VECT_FACTOR; entrance_ind++) {
+      volatile T* my_work_buf = work_buf +
+          (entrance_ind * grid_segment_size + idx_in_grid_segment) *
+              grid_reduction_segment_size * block_reduction_segment_size;
+      my_work_buf[work_buf_offset] = block_reduction_val[entrance_ind];
+    }
+  }
+
+  if (PERSISTENT_REDUCTION) {
+    grid_sync::sync<X_BLOCK, Y_BLOCK, Z_BLOCK, PERSISTENT_REDUCTION, Aligned>(
+        sync_flags[idx_in_grid_segment], grid_reduction_segment_size);
+
+  } else {
+    // there is only one vectorized call, sync flag is entrance_ind independent
+    constexpr int entrance_ind = 0;
+    grid_sync::sync<X_BLOCK, Y_BLOCK, Z_BLOCK, PERSISTENT_REDUCTION, Aligned>(
+        sync_flags[entrance_ind * grid_segment_size + idx_in_grid_segment],
+        grid_reduction_segment_size);
+  }
+
+  bool last_block =
+      index_utils::maskedIsLast<X_BLOCK, Y_BLOCK, Z_BLOCK>(blockIdx, gridDim);
+
+  if (last_block) {
+    // Cleanup with block reduction
+    iterGroupedGridReduceLastBlock<
+        !X_THREAD,
+        !Y_THREAD,
+        !Z_THREAD,
+        Aligned,
+        VECT_FACTOR>(
+        out,
+        (T*)work_buf,
+        grid_reduction_segment_size,
+        block_reduction_segment_size,
+        reduction_op,
+        shared_buf,
+        write_pred,
+        init_val,
+        grid_segment_size,
+        idx_in_grid_segment);
+  }
+
+  if (PERSISTENT_REDUCTION) {
+    // Make sure we're done with global memory before we allow the kernel to
+    // continue
+    grid_sync::sync<X_BLOCK, Y_BLOCK, Z_BLOCK, PERSISTENT_REDUCTION, Aligned>(
+        sync_flags[idx_in_grid_segment], grid_reduction_segment_size);
+  }
+}
+
 } // namespace reduction

--- a/test/test_gpu_outer_reduction.cpp
+++ b/test/test_gpu_outer_reduction.cpp
@@ -2205,4 +2205,103 @@ TEST_F(OuterReductionTest, IterGroupedBlockReduction) {
       "",
       lparams);
 }
+
+TEST_F(OuterReductionTest, IterGroupedGridReduction) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  DataType dtype = DataType::Half;
+
+  auto tv0 = makeContigTensor(2, dtype);
+  fusion.addInput(tv0);
+
+  auto tv1 = castOp(DataType::Float, tv0);
+  auto tv2 = sum(tv1, {0});
+  auto tv3 = castOp(dtype, tv2);
+  fusion.addOutput(tv3);
+
+  std::vector<int64_t> shape({4096, 2048});
+
+  auto options =
+      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+  auto t0 = at::randn(shape, options);
+
+  std::vector<c10::IValue> aten_inputs({t0});
+
+  auto heuristics_params = getReductionHeuristics(&fusion, aten_inputs);
+  NVF_CHECK(heuristics_params, "Reduction schedule was not generated!");
+
+  // Enforce vectorization so we can group them
+  const int vect_factor = 8;
+  heuristics_params->vectorize_iter_dom = true;
+  heuristics_params->unroll_factor_iter_dom = vect_factor;
+  // Enforce grid reduction
+  heuristics_params->cross_grid_inner_reduction = true;
+  heuristics_params->split_grid_dim_inner_reduction = true;
+
+  scheduleReduction(&fusion, *heuristics_params);
+
+  // lowering & check iteration grouped reductions
+  GpuLower gpulw(&fusion);
+  gpulw.run();
+  NVF_CHECK(
+      gpulw.kernel()->summary().has_iter_grouped_reductions,
+      "There must be iter domain grouped reductions.");
+  NVF_CHECK(
+      gpulw.kernel()->summary().num_grouped_iterations == vect_factor,
+      "Expected ",
+      vect_factor,
+      " grouped iterations, found ",
+      gpulw.kernel()->summary().num_grouped_iterations);
+
+  FusionExecutor fe;
+  auto lparams = heuristics_params->lparams;
+  fe.compileFusion(&fusion, aten_inputs, lparams);
+  auto cg_outputs = fe.runFusion(aten_inputs, lparams);
+
+  testValidate(
+      &fusion,
+      cg_outputs,
+      aten_inputs,
+      {t0.to(at::kFloat).sum(0)},
+      __LINE__,
+      __FILE__,
+      "",
+      lparams);
+}
+
+// validation tests of outer reduction scheduler after
+// adding IterGroupedGridReduction
+TEST_F(OuterReductionTest, OuterReductionMagicScheduler) {
+  auto test = [](int dim0, int dim1) {
+    auto fusion = std::make_unique<Fusion>();
+    FusionGuard fg(fusion.get());
+    DataType dtype = DataType::Half;
+    auto tv0 = makeContigTensor(2, dtype);
+    fusion->addInput(tv0);
+    auto tv1 = castOp(DataType::Float, tv0);
+    auto tv2 = sum(tv1, {0});
+    auto tv3 = castOp(dtype, tv2);
+    fusion->addOutput(tv3);
+
+    std::vector<int64_t> shape({dim0, dim1});
+    auto options = at::TensorOptions()
+                       .dtype(data_type_to_aten(dtype))
+                       .device(at::kCUDA, 0);
+    auto t0 = at::randn(shape, options);
+    std::vector<c10::IValue> inputs({t0});
+    FusionExecutorCache executor_cache(std::move(fusion));
+    auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
+    auto ref = t0.to(at::kFloat).sum({0});
+    testValidate(
+        executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
+  };
+  maybeClearAllocator(0);
+  for (int dim0 = 1024; dim0 <= 32768; dim0 *= 2) {
+    for (int dim1 = 1024; dim1 <= 32768; dim1 *= 2) {
+      test(dim0, dim1);
+    }
+  }
+}
+
 } // namespace nvfuser

--- a/test/test_gpu_outer_reduction.cpp
+++ b/test/test_gpu_outer_reduction.cpp
@@ -2288,7 +2288,7 @@ TEST_F(OuterReductionTest, OuterReductionMagicScheduler) {
     auto options = at::TensorOptions()
                        .dtype(data_type_to_aten(dtype))
                        .device(at::kCUDA, 0);
-    auto t0 = at::randn(shape, options);
+    auto t0 = at::ones(shape, options);
     std::vector<c10::IValue> inputs({t0});
     FusionExecutorCache executor_cache(std::move(fusion));
     auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
@@ -2296,9 +2296,13 @@ TEST_F(OuterReductionTest, OuterReductionMagicScheduler) {
     testValidate(
         executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
   };
+
+  test(2048, 32768);
+
   maybeClearAllocator(0);
   for (int dim0 = 1024; dim0 <= 32768; dim0 *= 2) {
     for (int dim1 = 1024; dim1 <= 32768; dim1 *= 2) {
+      printf("Testing dim0=%d, dim1=%d\n", dim0, dim1);
       test(dim0, dim1);
     }
   }

--- a/test/test_gpu_outer_reduction.cpp
+++ b/test/test_gpu_outer_reduction.cpp
@@ -2297,12 +2297,9 @@ TEST_F(OuterReductionTest, OuterReductionMagicScheduler) {
         executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
   };
 
-  test(2048, 32768);
-
   maybeClearAllocator(0);
   for (int dim0 = 1024; dim0 <= 32768; dim0 *= 2) {
     for (int dim1 = 1024; dim1 <= 32768; dim1 *= 2) {
-      printf("Testing dim0=%d, dim1=%d\n", dim0, dim1);
       test(dim0, dim1);
     }
   }

--- a/test/test_serial_gridreduce.cpp
+++ b/test/test_serial_gridreduce.cpp
@@ -36,8 +36,8 @@ namespace nvfuser {
 using SerialGridReductionTest = NVFuserTest;
 
 TEST_F(SerialGridReductionTest, Scheduling) {
-  for (bool serial : {true}) {
-    for (int64_t num_warps : {4}) {
+  for (bool serial : {true, false}) {
+    for (int64_t num_warps : {4, 8}) {
       // B is size of inner serial loop. Outer loop is hardcoded at A=4
       // Here we set B to a small value of 8 instead of 32 (i.e. 128 elements
       // per thread), so that the non-serial compilation does not take too

--- a/test/test_serial_gridreduce.cpp
+++ b/test/test_serial_gridreduce.cpp
@@ -36,8 +36,8 @@ namespace nvfuser {
 using SerialGridReductionTest = NVFuserTest;
 
 TEST_F(SerialGridReductionTest, Scheduling) {
-  for (bool serial : {true, false}) {
-    for (int64_t num_warps : {4, 8}) {
+  for (bool serial : {true}) {
+    for (int64_t num_warps : {4}) {
       // B is size of inner serial loop. Outer loop is hardcoded at A=4
       // Here we set B to a small value of 8 instead of 32 (i.e. 128 elements
       // per thread), so that the non-serial compilation does not take too


### PR DESCRIPTION
Following #1800 
Add iteration domain grouped grid reduction.
**TODO:**
(1) revise outer reduction heuristics
(2) combine grouped with regular grid/block reduction function.

**Performance of outer reduction:**
(1) Reduction dim = 2048, iteration dim = 1 to 32K
![image](https://github.com/NVIDIA/Fuser/assets/116412316/72bfb135-1ae3-4aed-a343-b43684b36773)
(2) Reduction dim = 16K, iteration dim = 1 to 32K
![image](https://github.com/NVIDIA/Fuser/assets/116412316/2dce20ad-70c5-4751-b0e2-3d955fa3d827)

More results avialable in the [doc](https://docs.google.com/document/d/1YI0KX_vmBMJurxooN2_Ya89Niki6zvYCvGDwURTEVCs/edit#heading=h.6behzp60hcgm).