### PR TITLE
Add a perf scope for pre-segmenter passes.

### DIFF
--- a/csrc/preseg_passes/pre_segmenter.cpp
+++ b/csrc/preseg_passes/pre_segmenter.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <preseg_passes/pre_segmenter.h>
 
+#include <instrumentation.h>
 #include <preseg_passes/add_axioms.h>
 #include <preseg_passes/allocation_order_inference.h>
 #include <preseg_passes/consecutive_cast.h>
@@ -17,7 +18,9 @@
 
 namespace nvfuser::preseg_passes {
 
-void PreSegmenter::runPass(Fusion* fusion) {
+/*static*/ void PreSegmenter::runPass(Fusion* fusion) {
+  FUSER_PERF_SCOPE("PreSegmenter::runPass");
+
   // Replace TensorViews with zero extent. Outputs and inputs may still be empty
   OptimizationPass<RemoveEmptyPass>::runPass(fusion);
   // removes consecutive cast operations


### PR DESCRIPTION
As a follow up to #1789.