### PR TITLE
Fix ReplayTransformations to properly set isRFactorProduct. 

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2733,7 +2733,7 @@ IterDomain* IterDomain::cloneWithoutRFactor() const {
   return cloned;
 }
 
-std::vector<IterDomain*> IterDomain::clone(
+/*static*/ std::vector<IterDomain*> IterDomain::clone(
     const std::vector<IterDomain*>& domains) {
   std::vector<IterDomain*> cloned_domains;
   std::transform(

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -57,7 +57,7 @@ void ReplayTransformations::handle(Split* s) {
       s->innerSplit(),
       s->startOffset(),
       s->stopOffset(),
-      s->outer()->isRFactorProduct());
+      replay_rfactor_ && s->outer()->isRFactorProduct());
   // Remove mapped from the leaf IDs
   leaf_ids_.erase(mapped);
 
@@ -128,7 +128,9 @@ void ReplayTransformations::handle(Merge* m) {
 
   // Replay the merge operation
   auto out = IterDomain::merge(
-      id_outer_mapped, id_inner_mapped, m->out()->isRFactorProduct());
+      id_outer_mapped,
+      id_inner_mapped,
+      replay_rfactor_ && m->out()->isRFactorProduct());
 
   // Remove inputs from the leaf IDs
   leaf_ids_.erase(id_outer_mapped);
@@ -172,6 +174,7 @@ void ReplayTransformations::handle(Swizzle* swizzle) {
 
   if (replay_swizzle_) {
     // Replay the swizzle onto mapped
+    // FIXME: isRFactorProduct
     outs = IterDomain::swizzle(swizzle->swizzleType(), mapped_x, mapped_y);
 
     // Remove mapped from the leaf IDs
@@ -219,6 +222,7 @@ void ReplayTransformations::handle(Swizzle2D* swizzle_2d) {
 
   if (replay_swizzle_) {
     // Replay the swizzle onto mapped
+    // FIXME: isRFactorProduct
     outs = IterDomain::swizzle(swizzle_2d->swizzleType(), mapped_x, mapped_y);
 
     // Remove mapped from the leaf IDs
@@ -260,7 +264,7 @@ void ReplayTransformations::handle(Resize* exp) {
         mapped,
         exp->leftExpand(),
         exp->rightExpand(),
-        exp->out()->isRFactorProduct());
+        replay_rfactor_ && exp->out()->isRFactorProduct());
   }
 
   leaf_ids_.erase(mapped);

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -174,7 +174,6 @@ void ReplayTransformations::handle(Swizzle* swizzle) {
 
   if (replay_swizzle_) {
     // Replay the swizzle onto mapped
-    // FIXME: isRFactorProduct
     outs = IterDomain::swizzle(swizzle->swizzleType(), mapped_x, mapped_y);
 
     // Remove mapped from the leaf IDs
@@ -222,7 +221,6 @@ void ReplayTransformations::handle(Swizzle2D* swizzle_2d) {
 
   if (replay_swizzle_) {
     // Replay the swizzle onto mapped
-    // FIXME: isRFactorProduct
     outs = IterDomain::swizzle(swizzle_2d->swizzleType(), mapped_x, mapped_y);
 
     // Remove mapped from the leaf IDs

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -50,8 +50,14 @@ void ReplayTransformations::handle(Split* s) {
       "Transform traversal failed, modified a node but it was not a leaf node.");
 
   // Replay the split onto mapped
+  NVF_ERROR(s->outer()->isRFactorProduct() == s->inner()->isRFactorProduct());
   auto outs = IterDomain::split(
-      mapped, s->factor(), s->innerSplit(), s->startOffset(), s->stopOffset());
+      mapped,
+      s->factor(),
+      s->innerSplit(),
+      s->startOffset(),
+      s->stopOffset(),
+      s->outer()->isRFactorProduct());
   // Remove mapped from the leaf IDs
   leaf_ids_.erase(mapped);
 
@@ -121,7 +127,8 @@ void ReplayTransformations::handle(Merge* m) {
       " however one or both are not leaf nodes.");
 
   // Replay the merge operation
-  auto out = IterDomain::merge(id_outer_mapped, id_inner_mapped);
+  auto out = IterDomain::merge(
+      id_outer_mapped, id_inner_mapped, m->out()->isRFactorProduct());
 
   // Remove inputs from the leaf IDs
   leaf_ids_.erase(id_outer_mapped);
@@ -253,7 +260,7 @@ void ReplayTransformations::handle(Resize* exp) {
         mapped,
         exp->leftExpand(),
         exp->rightExpand(),
-        mapped->isRFactorProduct());
+        exp->out()->isRFactorProduct());
   }
 
   leaf_ids_.erase(mapped);

--- a/csrc/transform_iter.h
+++ b/csrc/transform_iter.h
@@ -67,6 +67,11 @@ class ReplayTransformations : public IterVisitor {
     return *this;
   }
 
+  ReplayTransformations& setReplayRFactor(bool replay_rfactor) {
+    replay_rfactor_ = replay_rfactor;
+    return *this;
+  }
+
   // Replays outputs that were generated from ids.first on ids.second
   void runReplay();
 
@@ -144,6 +149,8 @@ class ReplayTransformations : public IterVisitor {
   // Indicates if we want to replay resize ops on the replayed
   // tensor.
   bool replay_resize_ = false;
+
+  bool replay_rfactor_ = false;
 
   size_t counter_ = 0;
 

--- a/csrc/transform_iter.h
+++ b/csrc/transform_iter.h
@@ -150,6 +150,7 @@ class ReplayTransformations : public IterVisitor {
   // tensor.
   bool replay_resize_ = false;
 
+  // Whether to copy the `rf` flag from ops producing `target_domain`.
   bool replay_rfactor_ = false;
 
   size_t counter_ = 0;

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -1321,31 +1321,31 @@ Expr* replayExprWithNewInput(Expr* e, Val* new_in) {
   std::vector<Val*> new_outs;
   new_outs.reserve(e->outputs().size());
 
-  for (Val* old : e->outputs()) {
-    auto* old_tv = dynamic_cast<TensorView*>(old);
+  for (Val* old_out : e->outputs()) {
+    auto* old_out_tv = dynamic_cast<TensorView*>(old_out);
     NVF_CHECK(
-        old_tv != nullptr,
+        old_out_tv != nullptr,
         "This function doesn't support non-TensorView outputs yet: ",
-        old);
-    TensorDomain* old_domain = old_tv->domain();
+        old_out);
+    TensorDomain* old_domain = old_out_tv->domain();
 
-    std::vector<IterDomain*> new_root;
-    new_root.reserve(old_domain->root().size());
+    std::vector<IterDomain*> new_out_root;
+    new_out_root.reserve(old_domain->root().size());
     size_t i = 0;
     for (IterDomain* in_rfactor_id :
          TensorDomain::noReductions(new_in_tv->getMaybeRFactorDomain())) {
       // Copy the `rf` flag from `old_domain` and everything else from
       // `in_rfactor_id`.
-      new_root.push_back(
+      new_out_root.push_back(
           IterDomainBuilder(in_rfactor_id)
               .is_rfactor_domain(old_domain->root()[i]->isRFactorProduct())
               .build());
       i++;
     }
-    TensorDomain* new_domain = fullReplay(old_domain, new_root);
-    TensorView* new_tv =
-        IrBuilder::create<TensorView>(new_domain, *old->getDataType());
-    new_outs.push_back(new_tv);
+    TensorDomain* new_domain = fullReplay(old_domain, new_out_root);
+    TensorView* new_out_tv =
+        IrBuilder::create<TensorView>(new_domain, *old_out->getDataType());
+    new_outs.push_back(new_out_tv);
   }
 
   return e->newObjectFunc()(

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -1334,6 +1334,8 @@ Expr* replayExprWithNewInput(Expr* e, Val* new_in) {
     size_t i = 0;
     for (IterDomain* in_rfactor_id :
          TensorDomain::noReductions(new_in_tv->getMaybeRFactorDomain())) {
+      // Copy the `rf` flag from `old_domain` and everything else from
+      // `in_rfactor_id`.
       new_root.push_back(
           IterDomainBuilder(in_rfactor_id)
               .is_rfactor_domain(old_domain->root()[i]->isRFactorProduct())

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -1273,8 +1273,8 @@ TensorDomain* fullReplay(
       "leaf. So, when `old_domain` has allocation, it may be incorrect to "
       "use its leaf as the target domain: ",
       old_domain->toString(0, /*leaf_only=*/false));
-  auto replay = ReplayTransformations(old_domain->leaf(), old_root_to_new)
-                    .setReplayRFactor(true);
+  ReplayTransformations replay(old_domain->leaf(), old_root_to_new);
+  replay.setReplayRFactor(true);
 
   std::vector<IterDomain*> new_leaf;
   new_leaf.reserve(old_domain->nDims());

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -1269,9 +1269,12 @@ TensorDomain* fullReplay(
   }
   NVF_CHECK(
       !old_domain->hasAllocation(),
-      "Due to #986, the allocation domain may or may not be between root and leaf. So, when `old_domain` has allocation, it may be incorrect to use its leaf as the target domain: ",
+      "Due to #986, the allocation domain may or may not be between root and "
+      "leaf. So, when `old_domain` has allocation, it may be incorrect to "
+      "use its leaf as the target domain: ",
       old_domain->toString(0, /*leaf_only=*/false));
-  ReplayTransformations replay(old_domain->leaf(), old_root_to_new);
+  auto replay = ReplayTransformations(old_domain->leaf(), old_root_to_new)
+                    .setReplayRFactor(true);
 
   std::vector<IterDomain*> new_leaf;
   new_leaf.reserve(old_domain->nDims());

--- a/test/test_replay.cpp
+++ b/test/test_replay.cpp
@@ -60,8 +60,7 @@ TEST_F(ReplayTest, HorizontallyMergeReshapeAndPermute) {
   EXPECT_TRUE(at::equal(out_tensor, expected_out_tensor));
 }
 
-// Currently fails due to #1857.
-TEST_F(ReplayTest, DISABLED_HorizontallyMergeReshapeAndNeg) {
+TEST_F(ReplayTest, HorizontallyMergeReshapeAndNeg) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -93,7 +92,7 @@ TEST_F(ReplayTest, DISABLED_HorizontallyMergeReshapeAndNeg) {
 
   std::vector<at::Tensor> slices = at::split(in_tensor, {2, 3}, /*dim=*/-1);
   at::Tensor expected_out_tensor = at::cat(
-      {slices[0].view({2, 2, 2}), slices[1].view({2, 2, 3})},
+      {-slices[0].view({2, 2, 2}), -slices[1].view({2, 2, 3})},
       /*dim=*/-1);
 
   EXPECT_TRUE(at::equal(out_tensor, expected_out_tensor));


### PR DESCRIPTION
This PR adds a knob to copy isRFactorProduct from the IterDomain being replayed. I hate knobs but couldn't find a better way. Plenty of ReplayTransformations users (e.g. https://github.com/NVIDIA/Fuser/blob/a684e2a220ed6daa14673d4c492b8eb80c299ce0/csrc/scheduler/utils.cpp#L2171 triggered by https://github.com/NVIDIA/Fuser/blob/8226e61a2a843e8e4ad8c6c2801b019f654828d1/test/test_gpu3.cpp#L7320) replay rfactor transforms on a TensorView without rfactor. Therefore, ReplayTransformations cannot copy isRFactorProduct unconditionally. 

Fixes #1857. 