### PR TITLE
Evaluate `MmaOp + Cast` in a single call

### DIFF
--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -33,44 +33,6 @@ class MatmulATenEvaluationTest : public NVFuserTest {
       guard_;
 };
 
-TEST_F(MatmulATenEvaluationTest, SingleMmaOp) {
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-
-  EnableOptionsGuard enable_guard;
-  EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
-
-  int64_t m = 2, k = 3, n = 4;
-  std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
-
-  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
-  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
-  auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
-  auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
-  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
-
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addOutput(tv2);
-
-  at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
-  at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
-  at::Tensor out_ref = at::full(out_shape, k, at::kFloat).cuda();
-
-  FusionExecutorCache fec(std::move(fusion));
-  auto out = fec.runFusionWithInputs({t0, t1});
-
-  EXPECT_EQ(fec.getMostRecentKernelRuntime()->executors().size(), 1);
-
-  // Verify that the io_alias_ set has the correct entry
-  auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
-  EXPECT_EQ(
-      kernel->getOutputAlias(kernel->outputs()[0]).type,
-      AllocationType::Evaluate);
-
-  EXPECT_TRUE(at::allclose(out[0], out_ref));
-}
-
 TEST_F(MatmulATenEvaluationTest, MmaOpAndCast) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
@@ -110,7 +72,9 @@ TEST_F(MatmulATenEvaluationTest, MmaOpAndCast) {
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST_F(MatmulATenEvaluationTest, MatmulWithBias) {
+// Disabled until at::addmm support is add.
+// See https://github.com/NVIDIA/Fuser/pull/1874#discussion_r1516991574
+TEST_F(MatmulATenEvaluationTest, DISABLED_MatmulWithBias) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 


### PR DESCRIPTION
Since PyTorch matmul maintains the input data type, we expect to see fusions of type `MmaOp + Cast`. To avoid roundtrip casts, we look ahead and skip casting the ATen output to float whenever MmaOp is followed by cast.

Nsys profiles for the test: `MmaOpAndCast`:

Main branch:
```
Start (ns)  Duration (ns)  CorrId  GrdX  GrdY  GrdZ  BlkX  BlkY  BlkZ  Reg/Trd  StcSMem (MB)  DymSMem (MB)  Bytes (MB)  Throughput (MB/s)  SrcMemKd  DstMemKd            Device             Ctx  GreenCtx  Strm                                                  Name                                                
 ----------  -------------  ------  ----  ----  ----  ----  ----  ----  -------  ------------  ------------  ----------  -----------------  --------  --------  ---------------------------  ---  --------  ----  ----------------------------------------------------------------------------------------------------
  586509701            640     136                                                                                0.000             18.750  Pageable  Device    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Host-to-Device]                                                                        
  586557445            353     150                                                                                0.000             67.989  Pageable  Device    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Host-to-Device]                                                                        
  586584709            384     164                                                                                0.000             41.667  Pageable  Device    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Host-to-Device]                                                                        
  688414636           2272    1631     1     1     1   128     1     1       57         0.000         0.005                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void cutlass::Kernel2<cutlass_75_wmma_tensorop_f16_s161616gemm_f16_32x32_32x1_nn_align1>(T1::Params)
  702497302           2048    1644     1     1     1   128     1     1       32         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::unrolled_elementwise_kernel<at::native::direct_copy_kernel_cuda(at::TensorIterator…
  702586486           1248    1658     1     1     1   128     1     1       32         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::unrolled_elementwise_kernel<at::native::direct_copy_kernel_cuda(at::TensorIterator…
  713771070           1184    1671     1     1     1   128     1     1       22         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<c10::Half, c10::Ha…
  718786401           1056    1681     1     1     1   128     1     1       17         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AUnaryFunctor<c10::Half, c10::Ha…
  720615906           1120    1701     1     1     1   128     1     1       18         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AbsFunctor<c10::Half>, at::detai…
  728717384           1152    1711     1     1     1   128     1     1       20         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::CUDAFunctorOnSelf_add<c10::Half>…
  728761672           1056    1721     1     1     1   128     1     1       22         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::CUDAFunctor_add<c10::Half>, at::…
  728775048           1024    1741     1     1     1   128     1     1       18         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AbsFunctor<c10::Half>, at::detai…
  728794536            992    1761     1     1     1   128     1     1       18         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AbsFunctor<c10::Half>, at::detai…
  728834440           1056    1771     1     1     1   128     1     1       19         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AUnaryFunctor<c10::Half, c10::Ha…
  728844232           1088    1781     1     1     1   128     1     1       22         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<c10::Half, c10::Ha…
  728866184           1216    1791     1     1     1   128     1     1       20         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<bool, bool, bool, …
  733362859           1312    1801     1     1     1   128     1     1       22         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::<unnamed>::CompareFunctor<c10::H…
  740977616           1216    1807     1     1     1   128     1     1       20         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<bool, bool, bool, …
  741023184           1088    1813     1     1     1   128     1     1       23         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<bool, bool, bool, …
  748730166           2112    1827     1     1     1     8     1     1       32         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::reduce_kernel<(int)512, (int)1, at::native::ReduceOp<bool, at::native::func_wrappe…
  749799223           1727    1839                                                                                0.000              0.579  Device    Pinned    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Device-to-Host]                                                                        
```

This branch:
```
Start (ns)  Duration (ns)  CorrId  GrdX  GrdY  GrdZ  BlkX  BlkY  BlkZ  Reg/Trd  StcSMem (MB)  DymSMem (MB)  Bytes (MB)  Throughput (MB/s)  SrcMemKd  DstMemKd            Device             Ctx  GreenCtx  Strm                                                  Name                                                
 ----------  -------------  ------  ----  ----  ----  ----  ----  ----  -------  ------------  ------------  ----------  -----------------  --------  --------  ---------------------------  ---  --------  ----  ----------------------------------------------------------------------------------------------------
  573374330            769     136                                                                                0.000             15.605  Pageable  Device    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Host-to-Device]                                                                        
  573429690            353     150                                                                                0.000             67.989  Pageable  Device    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Host-to-Device]                                                                        
  573457787            352     164                                                                                0.000             45.455  Pageable  Device    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Host-to-Device]                                                                        
  676276859           2272    1631     1     1     1   128     1     1       57         0.000         0.005                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void cutlass::Kernel2<cutlass_75_wmma_tensorop_f16_s161616gemm_f16_32x32_32x1_nn_align1>(T1::Params)
  691458602           1856    1643     1     1     1   128     1     1       22         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<c10::Half, c10::Ha…
  696694638           1057    1653     1     1     1   128     1     1       17         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AUnaryFunctor<c10::Half, c10::Ha…
  698517552           1120    1673     1     1     1   128     1     1       18         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AbsFunctor<c10::Half>, at::detai…
  706948024           1152    1683     1     1     1   128     1     1       20         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::CUDAFunctorOnSelf_add<c10::Half>…
  707000024           1024    1693     1     1     1   128     1     1       22         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::CUDAFunctor_add<c10::Half>, at::…
  707017464           1056    1713     1     1     1   128     1     1       18         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AbsFunctor<c10::Half>, at::detai…
  707037624           1024    1733     1     1     1   128     1     1       18         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AbsFunctor<c10::Half>, at::detai…
  707088408           1088    1743     1     1     1   128     1     1       19         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AUnaryFunctor<c10::Half, c10::Ha…
  707100248           1088    1753     1     1     1   128     1     1       22         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<c10::Half, c10::Ha…
  707120568           1248    1763     1     1     1   128     1     1       20         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<bool, bool, bool, …
  711613949           1312    1773     1     1     1   128     1     1       22         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::<unnamed>::CompareFunctor<c10::H…
  719774596           1280    1779     1     1     1   128     1     1       20         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<bool, bool, bool, …
  719823204           1184    1785     1     1     1   128     1     1       23         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<bool, bool, bool, …
  730395694           2464    1799     1     1     1     8     1     1       32         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::reduce_kernel<(int)512, (int)1, at::native::ReduceOp<bool, at::native::func_wrappe…
  731443855           1696    1811                                                                                0.000              0.590  Device    Pinned    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Device-to-Host]                                                                        
```

For reference, the nsys profile for the MmaOp alone (SingleMmaOp test):
```
Start (ns)  Duration (ns)  CorrId  GrdX  GrdY  GrdZ  BlkX  BlkY  BlkZ  Reg/Trd  StcSMem (MB)  DymSMem (MB)  Bytes (MB)  Throughput (MB/s)  SrcMemKd  DstMemKd            Device             Ctx  GreenCtx  Strm                                                  Name                                                
 ----------  -------------  ------  ----  ----  ----  ----  ----  ----  -------  ------------  ------------  ----------  -----------------  --------  --------  ---------------------------  ---  --------  ----  ----------------------------------------------------------------------------------------------------
  583502109            672     136                                                                                0.000             17.857  Pageable  Device    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Host-to-Device]                                                                        
  583549533            352     150                                                                                0.000             68.182  Pageable  Device    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Host-to-Device]                                                                        
  583577949            352     164                                                                                0.000             90.909  Pageable  Device    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Host-to-Device]                                                                        
  684288833           2272    1631     1     1     1   128     1     1       57         0.000         0.005                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void cutlass::Kernel2<cutlass_75_wmma_tensorop_f16_s161616gemm_f16_32x32_32x1_nn_align1>(T1::Params)
  698291457           2112    1644     1     1     1   128     1     1       32         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::unrolled_elementwise_kernel<at::native::direct_copy_kernel_cuda(at::TensorIterator…
  708948825           1056    1657     1     1     1   128     1     1       24         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<float, float, bool…
  714311589           1024    1667     1     1     1   128     1     1       16         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AUnaryFunctor<float, float, floa…
  716180425           1024    1687     1     1     1   128     1     1       16         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AbsFunctor<float>, at::detail::A…
  724816349           1024    1697     1     1     1   128     1     1       16         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::CUDAFunctorOnSelf_add<float>, at…
  724860989           1024    1707     1     1     1   128     1     1       22         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::CUDAFunctor_add<float>, at::deta…
  724875549           1024    1727     1     1     1   128     1     1       16         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AbsFunctor<float>, at::detail::A…
  724895965           1024    1747     1     1     1   128     1     1       16         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AbsFunctor<float>, at::detail::A…
  724935133           1024    1757     1     1     1   128     1     1       16         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::AUnaryFunctor<float, float, bool…
  724945885           1056    1767     1     1     1   128     1     1       24         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<float, float, bool…
  724966845           1248    1777     1     1     1   128     1     1       20         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<bool, bool, bool, …
  729533799           1248    1787     1     1     1   128     1     1       22         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::<unnamed>::CompareFunctor<float>…
  738022394           1185    1793     1     1     1   128     1     1       20         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<bool, bool, bool, …
  738068187           1088    1799     1     1     1   128     1     1       23         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::vectorized_elementwise_kernel<(int)4, at::native::BinaryFunctor<bool, bool, bool, …
  745858252           2144    1813     1     1     1     8     1     1       32         0.000         0.000                                                     NVIDIA GeForce RTX 4090 (0)    1               7  void at::native::reduce_kernel<(int)512, (int)1, at::native::ReduceOp<bool, at::native::func_wrappe…
  746932079           1536    1825                                                                                0.000              0.651  Device    Pinned    NVIDIA GeForce RTX 4090 (0)    1               7  [CUDA memcpy Device-to-Host]                                                                        
```

The two elementwise kernels following the CUTLASS matmul kernel are no longer present with this update in the test `MmaOpAndCast`.

Issue #1669 