### PR TITLE
sameIterDomainTransforms clones IdGraph.

### DIFF
--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -42,14 +42,6 @@ StatefulInliningInfo buildStatefulInliningInfo(
     const ValGraph& exact_graph,
     const ValGraph& permissive_graph);
 
-struct SelfMapping {
-  IterDomain* id1;
-  IterDomain* id2;
-  // For debugging, records which domain `id1` and `id2` belong to. This value
-  // is either "Root", "RFactor", or "Leaf". Consider making it an enum.
-  std::string where;
-};
-
 // A collection of ValGraphs that are built from a fusion or series of
 // expressions. These graphs are related, but have some distinct features based
 // on the IdMappingMode.
@@ -125,18 +117,6 @@ class IdModel : public PolymorphicBase {
   const std::unordered_set<IterDomain*>& viewRfactorIds() const {
     return view_rfactor_ids_;
   }
-
-  // Returns if a self mapping was detected that would invalidate assumptions of
-  // the overall lowering system.
-  //
-  // It is assumed that for any tensor represented by a list of domains,
-  // those domains should never be mapped with each other. It may be
-  // possible to lift this assumption, but it's unclear if it could
-  // matter in practice.
-  //
-  // TODO: Can we make this more of an alias analysis?
-  // Ref: https://github.com/csarofeen/pytorch/pull/1954#discussion_r961940498
-  std::optional<SelfMapping> hasSelfMapping(const TensorView* tv) const;
 
   std::string toString() const;
 

--- a/csrc/preseg_passes/move_split_cat.cpp
+++ b/csrc/preseg_passes/move_split_cat.cpp
@@ -29,13 +29,8 @@ class CancelSplitCat {
         id_model_(
             fusion,
             /*build_graphs=*/false,
-            /*allow_self_mapping=*/true),
-        id_model_for_merging_(
-            fusion,
-            /*build_graphs=*/false,
             /*allow_self_mapping=*/true) {
     id_model_.buildExactGraph();
-    id_model_for_merging_.buildExactGraph();
   }
 
   // Finds all cancellable <split,cat> pairs, cancels them and horizontallly
@@ -146,11 +141,6 @@ class CancelSplitCat {
   // `id_model_` is supposed to be read-only and reflect the
   // original fusion.
   IdModel id_model_;
-
-  // `id_model_for_merging_` is used for
-  // `sameIterDomainTransforms`, which unionizes IterDomains in slices and
-  // checks IterDomains in pads are unionized in the same way.
-  IdModel id_model_for_merging_;
 };
 
 bool sameOp(const std::vector<Expr*>& frontier) {
@@ -167,7 +157,7 @@ bool CancelSplitCat::sameIterDomainTransforms(
   NVF_ERROR(slices.size() == pads.size());
   NVF_ERROR(!slices.empty());
 
-  ValGraph& exact_graph = id_model_for_merging_.idGraph(IdMappingMode::EXACT);
+  ValGraph exact_graph = id_model_.idGraph(IdMappingMode::EXACT);
   {
     // Map pads[i0].root[cat_axis] and pads[i1].root[cat_axis]. Other axes were
     // already mapped due to the `cat` when the IdModel was built.
@@ -186,7 +176,7 @@ bool CancelSplitCat::sameIterDomainTransforms(
   // diffrently between two chains. See
   // MoveSplitCatTest.Noncancellable_PermutedDifferently for an example.
   for (auto* slice : slices) {
-    if (id_model_for_merging_.hasSelfMapping(slice->out())) {
+    if (hasSelfMapping(slice->out(), exact_graph)) {
       return false;
     }
   }

--- a/csrc/preseg_passes/move_split_cat.cpp
+++ b/csrc/preseg_passes/move_split_cat.cpp
@@ -157,6 +157,10 @@ bool CancelSplitCat::sameIterDomainTransforms(
   NVF_ERROR(slices.size() == pads.size());
   NVF_ERROR(!slices.empty());
 
+  // This clones the exact graph so that `mapVals` are done without affecting
+  // other split/cat pairs in consideration. See
+  // MoveSplitCatTest.MultipleCatsOnSameSplit for why this independence is
+  // important.
   ValGraph exact_graph = id_model_.idGraph(IdMappingMode::EXACT);
   {
     // Map pads[i0].root[cat_axis] and pads[i1].root[cat_axis]. Other axes were
@@ -182,6 +186,7 @@ bool CancelSplitCat::sameIterDomainTransforms(
   }
 
   {
+    // Check slices[i0][j] and slices[i1][j] are mapped.
     const std::vector<IterDomain*>& first_rfactor =
         slices[0]->out()->getMaybeRFactorDomain();
     size_t num_dims = first_rfactor.size();

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -343,4 +343,66 @@ class ValGraph {
   std::unordered_map<ValGroup, ExprGroups> unique_uses_;
 };
 
+// Returns the first pair of id's in ids detected to match each other on the
+// given ID graph. TODO: what this is really looking for is if
+// there's any overlapping between the iter domains in the provided set.
+//
+// i.e. if we have:
+// tv0 = arange(6).reshape({3, 2})
+// tv1 = tv0[3, 2].t()
+// tv2 = tv0[3, 2].reshape({2, 3})
+// tv3 = tv1 + tv2
+//
+// Then we can see this overlap in the tv3 expression as:
+//
+// tv0 = { {0, 1, 2},
+//         {3, 4, 5} }
+//
+// tv1 = { {0, 3},
+//         {1, 4},
+//         {2, 5} }
+//
+// tv2 = { {0, 1},
+//         {2, 3},
+//         {4, 5} }
+//
+// The elements in tv1 {3, 1, 4, 2}, map respectively to the elements in tv2
+// {1, 2, 3, 4}. The reason this is so important is it means that generating
+// tv3 is no longer a trivially parallelizable problem (if we include the dag
+// all the way to tv0). So tv0's axes cannot be inlined across both the tv0
+// and tv1 path. This breaks some assumptions we have today in schedulers that
+// will assume tv2 can be trivially inlined/parallelized. Instead we'd need to
+// take into consideration the effective communication going on here, so that
+// we pull multiple values of tv0 to compute tv3.
+//
+// Note, however, that the above example is not detectable at this
+// moment as the self mapping is partial through reshape. The analysis
+// below would need to be extended to consider producer and consumers
+// of domains as well rather than just root, rfactor and leaf domains.
+std::optional<std::pair<IterDomain*, IterDomain*>> detectSelfMapping(
+    const std::vector<IterDomain*>& ids,
+    const ValGraph& id_graph);
+
+struct SelfMapping {
+  IterDomain* id1;
+  IterDomain* id2;
+  // For debugging, records which domain `id1` and `id2` belong to. This value
+  // is either "Root", "RFactor", or "Leaf". Consider making it an enum.
+  std::string where;
+};
+
+// Returns if a self mapping was detected that would invalidate assumptions of
+// the overall lowering system.
+//
+// It is assumed that for any tensor represented by a list of domains,
+// those domains should never be mapped with each other. It may be
+// possible to lift this assumption, but it's unclear if it could
+// matter in practice.
+//
+// TODO: Can we make this more of an alias analysis?
+// Ref: https://github.com/csarofeen/pytorch/pull/1954#discussion_r961940498
+std::optional<SelfMapping> hasSelfMapping(
+    const TensorView* tv,
+    const ValGraph& id_graph);
+
 } // namespace nvfuser

--- a/test/test_id_model.cpp
+++ b/test/test_id_model.cpp
@@ -57,8 +57,9 @@ TEST_F(IdModelTest, PerTensorSelfMapping) {
   fusion.addOutput(y1);
 
   IdModel id_model(&fusion, /*build_graphs=*/true, /*allow_self_mapping=*/true);
-  EXPECT_TRUE(id_model.hasSelfMapping(y0).has_value());
-  EXPECT_FALSE(id_model.hasSelfMapping(y1).has_value());
+  const ValGraph& exact_graph = id_model.idGraph(IdMappingMode::EXACT);
+  EXPECT_TRUE(hasSelfMapping(y0, exact_graph).has_value());
+  EXPECT_FALSE(hasSelfMapping(y1, exact_graph).has_value());
 }
 
 namespace {

--- a/test/test_move_split_cat.cpp
+++ b/test/test_move_split_cat.cpp
@@ -525,11 +525,14 @@ TEST_F(MoveSplitCatTest, MultipleCatsOnSameSplit) {
     t0 = reshape(t0, {2, 2}, {4});
     TensorView* t1 = permute(s1, {1, 0});
     t1 = reshape(t1, {2, 2}, {4});
+    // This cat doesn't cancel the split because the above transforms introduce
+    // a self-mapping when the catted dimension is mapped.
     return cat({t0, t1}, /*dim=*/0);
   }();
   TensorView* alias_out = [&]() {
     TensorView* t0 = set(s0);
     TensorView* t1 = set(s1);
+    // This cat cancels the split.
     return cat({t0, t1}, /*dim=*/0);
   }();
 


### PR DESCRIPTION
As a follow up to https://github.com/NVIDIA/Fuser/pull/1799#discussion_r1513976524. This PR comes with a refactor that moves hasSelfMapping from IdModel to ValGraph, so it can be applied on cloned ValGraphs. 