### PR TITLE
Revert "don't project to inputs if calculate persistent buffer requires rng op"

### DIFF
--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -828,9 +828,8 @@ bool projectBufferToInputs(
   }
 
   // check ops between persistent buffer and inputs.
-  // TODO: check more ops
+  // TODO: check more ops, e.g. RNGOp
   bool has_exp_op = false;
-  bool has_rng_op = false;
   const auto& projectable_buffers =
       persistent_buffer_info.projectable_persistent_buffers;
   auto all_inputs = ir_utils::inputTvsOf(projectable_buffers);
@@ -842,15 +841,7 @@ bool projectBufferToInputs(
         expr->as<UnaryOp>()->getUnaryOpType() == UnaryOpType::Exp) {
       has_exp_op = true;
     }
-    if (expr->isA<RNGOp>()) {
-      has_rng_op = true;
-    }
   }
-  // don't project if calculate persistent buffer requires very expensive rng op
-  if (has_rng_op) {
-    return false;
-  }
-
   if (!has_exp_op) {
     return true;
   }


### PR DESCRIPTION
Reverts NVIDIA/Fuser#1796

(1) when disable project to inputs should check do we still have enough register or smem for persistent buffers
(2) Need to eavaluate do we want to disable project to inputs at the cost of segment.