### PR TITLE
Update known values correctly

### DIFF
--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -216,7 +216,7 @@ const PolymorphicValue& ExpressionEvaluator::evaluateHelper(
       std::vector<PolymorphicValue> inputs;
       inputs.reserve(def->inputs().size());
       for (auto i : def->inputs()) {
-        const auto& eval_i = evaluate(i);
+        const auto& eval_i = evaluateHelper(i, known_values);
         if (!eval_i.hasValue()) {
           return null_;
         }

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -139,7 +139,7 @@ TEST_F(ExprEvalTest, ConstReference) {
   checkConstEvaluate(evaluator, add(tv0, neg(tv1)), t0 - t1);
 }
 
-// Evaluate known values with const expression evaluator reference
+// Verify intermediate values are added to the known_values_ map.
 TEST_F(ExprEvalTest, KnownValUpdate) {
   Fusion fusion;
   FusionGuard fg(&fusion);

--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -139,6 +139,28 @@ TEST_F(ExprEvalTest, ConstReference) {
   checkConstEvaluate(evaluator, add(tv0, neg(tv1)), t0 - t1);
 }
 
+// Evaluate known values with const expression evaluator reference
+TEST_F(ExprEvalTest, KnownValUpdate) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  ExpressionEvaluator evaluator;
+  auto tv0 = makeContigTensor(1);
+  auto tv1 = makeContigTensor(1);
+  auto tv2 = add(tv0, tv1);
+  auto tv3 = cat({tv2, tv1}, 0);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({3}, options);
+  auto t1 = at::randn({3}, options);
+
+  evaluator.bind(tv0, t0);
+  evaluator.bind(tv1, t1);
+
+  evaluator.evaluate(tv3);
+  NVF_CHECK(evaluator.isKnown(tv2));
+}
+
 // Evaluate expressions in a simple IR
 TEST_F(ExprEvalTest, Basic) {
   Fusion fusion;


### PR DESCRIPTION
This fixes a bug which would cause the intermediate values to be updated to `known_values`.