### PR TITLE
Temporarily disable ExprEvalTest.MmaOp.

### DIFF
--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -695,7 +695,8 @@ TEST_F(ExprEvalTest, SumDiv) {
   evaluator.evaluate(out);
 }
 
-TEST_F(ExprEvalTest, MmaOp) {
+// TODO(Priya2698): re-enable this test with the cast added.
+TEST_F(ExprEvalTest, DISABLED_MmaOp) {
   int64_t m = 2, k = 3, n = 4;
 
   Fusion fusion;


### PR DESCRIPTION
I believe this test got broken by #1874. 