### PR TITLE
Support ATen evaluation for matmul represented as `mul-sum`

### DIFF
--- a/test/test_evaluator.cpp
+++ b/test/test_evaluator.cpp
@@ -695,36 +695,4 @@ TEST_F(ExprEvalTest, SumDiv) {
   evaluator.evaluate(out);
 }
 
-// TODO(Priya2698): re-enable this test with the cast added.
-TEST_F(ExprEvalTest, DISABLED_MmaOp) {
-  int64_t m = 2, k = 3, n = 4;
-
-  Fusion fusion;
-  FusionGuard fg(&fusion);
-
-  // The matmul API will expect inputs in the shape [M,K] x [K,N].
-  // This is compatible with PyTorch,
-  std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
-
-  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
-  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
-  fusion.addInput(tv0);
-  fusion.addInput(tv1);
-
-  auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
-  auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
-  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
-
-  fusion.addOutput(tv2);
-
-  at::Tensor in_a = at::ones(a_shape, at::kHalf).cuda();
-  at::Tensor in_b = at::ones(b_shape, at::kHalf).cuda();
-  at::Tensor out_ref = at::full(out_shape, k, at::kFloat).cuda();
-
-  ExpressionEvaluator evaluator;
-  evaluator.bind(tv0, in_a);
-  evaluator.bind(tv1, in_b);
-  at::Tensor out = evaluator.evaluate(tv2).as<at::Tensor>();
-  EXPECT_TRUE(at::allclose(out, out_ref));
-}
 } // namespace nvfuser

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -72,6 +72,45 @@ TEST_F(MatmulATenEvaluationTest, MmaOpAndCast) {
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
+TEST_F(MatmulATenEvaluationTest, MulSumAndCast) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  EnableOptionsGuard enable_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::MatmulExprEval);
+
+  int64_t m = 2, k = 3, n = 4;
+  std::vector<int64_t> a_shape{m, k}, b_shape{k, n}, out_shape{m, n};
+
+  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+  auto tv0b = broadcast(tv0, {false, false, true}); // [M, K, 1]
+  auto tv1b = broadcast(tv1, {true, false, false}); // [1, K, N]
+  auto tv2 = sum(mul(tv0b, tv1b), {1});
+  auto tv3 = castOp(DataType::Half, tv2);
+
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addOutput(tv3);
+
+  at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
+  at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+  at::Tensor out_ref = at::full(out_shape, k, at::kHalf).cuda();
+
+  FusionExecutorCache fec(std::move(fusion));
+  auto out = fec.runFusionWithInputs({t0, t1});
+
+  EXPECT_EQ(fec.getMostRecentKernelRuntime()->executors().size(), 1);
+
+  // Verify that the io_alias_ set has the correct entry
+  auto kernel = fec.getMostRecentKernelRuntime()->executors().at(0).kernel();
+  EXPECT_EQ(
+      kernel->getOutputAlias(kernel->outputs()[0]).type,
+      AllocationType::Evaluate);
+
+  EXPECT_TRUE(at::allclose(out[0], out_ref));
+}
+
 // Disabled until at::addmm support is add.
 // See https://github.com/NVIDIA/Fuser/pull/1874#discussion_r1516991574
 TEST_F(MatmulATenEvaluationTest, DISABLED_MatmulWithBias) {

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -94,8 +94,8 @@ TEST_F(MatmulATenEvaluationTest, MulSumAndCast) {
   fusion->addInput(tv1);
   fusion->addOutput(tv3);
 
-  at::Tensor t0 = at::ones(a_shape, at::kHalf).cuda();
-  at::Tensor t1 = at::ones(b_shape, at::kHalf).cuda();
+  at::Tensor t0 = at::randn(a_shape, at::kHalf).cuda();
+  at::Tensor t1 = at::randn(b_shape, at::kHalf).cuda();
   at::Tensor out_ref = at::matmul(t0, t1);
 
   FusionExecutorCache fec(std::move(fusion));


### PR DESCRIPTION
This PR skips matmul scheduling after combining a valid `mul-sum` pair to `MmaOp`.