### PR TITLE
avoid assert when consumer_innermost_ndims == 0

### DIFF
--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -945,6 +945,12 @@ int64_t getVectorizationBreakPointOfReductionProducer(
   // break point, there must be only the producer innermost IDs or
   // reduction IDs
   int64_t break_point = (int64_t)(reduction_producer->nDims());
+
+  // short-cut to to return break point when producer_innermost_ids is empty
+  if (producer_innermost_ids.size() == 0) {
+    return break_point;
+  }
+
   int num_detected_producer_innermost_ids = 0;
   for (auto it = reduction_producer->getMaybeRFactorDomain().rbegin();
        it != reduction_producer->getMaybeRFactorDomain().rend();

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -927,7 +927,8 @@ int64_t getVectorizationBreakPointOfReductionProducer(
   // reduction IDs
   int64_t break_point = (int64_t)(reduction_producer->nDims());
 
-  // short-cut to to return break point when no c2p mapping is going to be performed
+  // short-cut to to return break point when no c2p mapping is going to be
+  // performed
   if (consumer_innermost_ndims == 0) {
     return break_point;
   }

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -947,7 +947,7 @@ int64_t getVectorizationBreakPointOfReductionProducer(
   int64_t break_point = (int64_t)(reduction_producer->nDims());
 
   // short-cut to to return break point when producer_innermost_ids is empty
-  if (producer_innermost_ids.size() == 0) {
+  if (producer_innermost_ids.empty()) {
     return break_point;
   }
 

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -922,6 +922,16 @@ int64_t getVectorizationBreakPointOfReductionProducer(
       ". ",
       reduction_producer->toString());
 
+  // Find the conrresponding producer break point. To the right of the
+  // break point, there must be only the producer innermost IDs or
+  // reduction IDs
+  int64_t break_point = (int64_t)(reduction_producer->nDims());
+
+  // short-cut to to return break point when no c2p mapping is going to be performed
+  if (consumer_innermost_ndims == 0) {
+    return break_point;
+  }
+
   const auto c2p = PairwiseRootDomainMap(reduction_producer, reduction_consumer)
                        .mapConsumerToProducer();
 
@@ -939,16 +949,6 @@ int64_t getVectorizationBreakPointOfReductionProducer(
     NVF_ERROR(c2p_it != c2p.end());
     auto producer_id = c2p_it->second;
     producer_innermost_ids.insert(producer_id);
-  }
-
-  // Find the conrresponding producer break point. To the right of the
-  // break point, there must be only the producer innermost IDs or
-  // reduction IDs
-  int64_t break_point = (int64_t)(reduction_producer->nDims());
-
-  // short-cut to to return break point when producer_innermost_ids is empty
-  if (producer_innermost_ids.empty()) {
-    return break_point;
   }
 
   int num_detected_producer_innermost_ids = 0;

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1341,4 +1341,47 @@ TEST_F(AllocationDomainTest, EmptyAllocationDomainApi) {
   tv0->setAllocationDomain({}, true);
 }
 
+TEST_F(NVFuserTest, ReductionSchedulerIssue1895) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  long x = 2L, y = 8L, z = 8L, w = 16L, h = 512L;
+  auto tv0 = TensorViewBuilder()
+                 .ndims(5)
+                 .shape({-1, -1, -1, -1, -1})
+                 .contiguity({true, true, true, true, true})
+                 .strideOrder({4, 3, 2, 0, 1})
+                 .build();
+  fusion->addInput(tv0);
+  auto tv1 = full(
+      {IrBuilder::create<Val>(x),
+       IrBuilder::create<Val>(y),
+       IrBuilder::create<Val>(z),
+       IrBuilder::create<Val>(w),
+       IrBuilder::create<Val>(h)},
+      fusion->oneVal(),
+      DataType::Float);
+  auto tv2 = mul(tv0, tv1);
+  auto tv3 = sum(tv2, {2, 4});
+  fusion->addOutput(tv3);
+  std::vector<IterDomain*> tv3_dom = {
+      tv3->axis(0), tv3->axis(1), tv3->axis(2), tv3->axis(4), tv3->axis(3)};
+  tv3->setAllocationDomain(tv3_dom, true);
+
+  // tv1 is a constant tensor, and its domains are constant.
+  // Its constant domains are used in ExactMappedExtentSubstitutionPass
+  // to substitute the domains of tv0.
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 =
+      at::randn({x, y, z, w, h}, options)
+          .as_strided({x, y, z, w, h}, {w * h * z * y, w * h * z, w * h, 1, w});
+  std::vector<c10::IValue> inputs({t0});
+
+  FusionExecutorCache executor_cache(std::move(fusion));
+  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
+
+  auto ref = t0.to(at::kDouble).sum({2, 4});
+  testValidate(
+      executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Fixes #1895

In `getVectorizationBreakPointOfReductionProducer`, the existing logic walks through mapped innermost iterdomain on reduction producer to find break_point. However, it doesn't account for case where no innermost iterdomain is mapped (i.e. `consumer_innermost_ndims == 0`) and triggers a false assert.