### PR TITLE
Index compute with non-outermost sharding

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -39,9 +39,9 @@ bool isSharded(TensorView* tv) {
       "Cannot shard multiple tensorview axes on the same mesh axis");
   // Currently, we do not allow split/merge if tv is sharded.
   NVF_ERROR(
-      sharded_domains.size() == 0 ||
+      sharded_domains.empty() ||
       tv->getMaybeRFactorDomain() == tv->getLeafDomain());
-  return sharded_domains.size() > 0;
+  return !sharded_domains.empty();
 }
 
 template <typename TvIterator>


### PR DESCRIPTION
Updates strided index computation to properly handle non-outermost device parallel axes.
Specifically, it updates stride calculations so that the sharded extents are treated as size 1 instead of the unsharded extents.

This PR only updates index computations. A later PR will update communication lowering to handle non-outermost sharded axes. 