### PR TITLE
Rename `PredicateAnalyzer` -> `ProducerConsumerPairAnalyzer`

### DIFF
--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -59,7 +59,7 @@ bool isExactParallelSharedMemAccess(TensorView* tv) {
   return true;
 }
 
-class PredicateAnalyzer : public OptOutDispatch {
+class ProducerConsumerPairAnalyzer : public OptOutDispatch {
  public:
   //! Checks if a predicate is needed to avoid out-of-bound accesses.
   //!
@@ -85,7 +85,7 @@ class PredicateAnalyzer : public OptOutDispatch {
         BestEffortReplay::replayPasC(producer, consumer, -1, pairwise_map)
             .getReplay();
 
-    PredicateAnalyzer analyzer(c2p);
+    ProducerConsumerPairAnalyzer analyzer(c2p);
 
     for (auto id : consumer->getLeafDomain()) {
       if (analyzer.needsPredicate(id)) {
@@ -97,7 +97,8 @@ class PredicateAnalyzer : public OptOutDispatch {
   }
 
  private:
-  PredicateAnalyzer(const std::unordered_map<IterDomain*, IterDomain*>& c2p)
+  ProducerConsumerPairAnalyzer(
+      const std::unordered_map<IterDomain*, IterDomain*>& c2p)
       : c2p_(c2p) {}
 
   // Returns true if no out-of-bound accesses could occur with a
@@ -351,7 +352,7 @@ class PredicateChcker : public IterVisitor {
   bool predicateProducerConsumerPair(Expr* expr) const {
     for (auto output : ir_utils::filterByType<TensorView>(expr->outputs())) {
       for (auto input : ir_utils::filterByType<TensorView>(expr->inputs())) {
-        if (PredicateAnalyzer::needsPredicate(input, output)) {
+        if (ProducerConsumerPairAnalyzer::needsPredicate(input, output)) {
           return true;
         }
       }


### PR DESCRIPTION
Right now, we have `PredicateChcker` and `PredicateAnalyzer`. From their name, we can not tell which is doing what. After reading the code, we can tell that, `PredicateChcker` is the global entry point for predicate elimination, and `PredicateAnalyzer` is a helper class for `predicateProducerConsumerPair`, which is only one condition of `PredicateChcker`: https://github.com/NVIDIA/Fuser/blob/638bfe00a29f582a337042c04a63c13410b8b17f/csrc/device_lower/analysis/predicate_elimination.cpp#L222
So I do this rename to indicate this fact.
