### PR TITLE
Lowering hook for `FusionExecutor`

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -328,6 +328,9 @@ void FusionExecutor::compileFusion(
   warp_size_ = properties->warpSize;
 
   lowered_ = std::make_unique<GpuLower>(fusion, compile_params);
+  for (const auto& hook : lowering_hooks_) {
+    hook(lowered_.get());
+  }
   lowered_->run();
 
   kir::Kernel* kernel = lowered_->kernel();

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -141,6 +141,13 @@ class FusionExecutor : public NonCopyable {
     return runFusion(inputs, {}, launch_constraints, compile_params, opt_code);
   }
 
+  // Register a lowering hooks that are called to modify the GpuLower object
+  // before running lowering passes. The main use case is for unit tests to
+  // modify the lowering process.
+  void registerLoweringHook(std::function<void(GpuLower*)> hook) {
+    lowering_hooks_.push_back(std::move(hook));
+  }
+
   // Register a post-lowering hooks that are called to modify the kernel after
   // lowering. The main use case is for unit tests to modify the kernel.
   void registerPostLoweringHook(std::function<void(kir::Kernel*)> hook) {
@@ -589,6 +596,11 @@ class FusionExecutor : public NonCopyable {
 
   // Profiling support: kept copy of the cuda kernel
   std::string kernel_code_;
+
+  // Lowering hooks that are called after the GpuLower instance is created
+  // before running lowering passes.
+  // The main use case is for unit tests to modify the lowering process.
+  std::vector<std::function<void(GpuLower*)>> lowering_hooks_;
 
   // Post-lowering hooks that are called to modify the kernel after lowering.
   // The main use case is for unit tests to modify the kernel.


### PR DESCRIPTION
Example use case:

```C++
TEST_F(PredicateEliminationTest, ExtentEqualToMaxParallelTypeExtent) {
  Fusion fusion;
  FusionGuard fg(&fusion);

  auto tv0 = makeContigTensor(1);
  fusion.addInput(tv0);
  auto tv1 = set(tv0);
  auto tv2 = set(tv1);
  fusion.addOutput(tv2);

  tv1->setMemoryType(MemoryType::Shared);

  std::vector<TensorView*> tvs = {tv1, tv2};
  for (auto tv : tvs) {
    tv->split(0, 32);
    tv->axis(0)->parallelize(ParallelType::TIDx);
  }
  fusion.manage("interested_tvs", tvs);

  auto validate_smem_predicate_elimination =
      [](const std::vector<Expr*>& exprs) -> std::vector<Expr*> {
    kir::Kernel* kernel = GpuLower::current()->kernel();
    auto kernel_tvs =
        kernel->getManaged<std::vector<TensorView*>>("interested_tvs");
    for (auto tv : kernel_tvs) {
      EXPECT_TRUE(
          lower_utils::isExtentEqualToMaxParallelTypeExtent(tv->axis(0)));
    }
    return exprs;
  };

  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
  auto t0 = at::randn({10 * 32}, options);
  FusionExecutor fe;
  fe.registerLoweringHook([&](GpuLower* lower) {
    lower->passes().insert(
        lower->passes().begin(),
        {"validate_smem_predicate_elimination",
         validate_smem_predicate_elimination});
  });
  fe.compileFusion(&fusion, {t0}, {}, matmul_cparams);

  auto cg_outputs = fe.runFusion({t0});
  testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
}
```