### PR TITLE
Patch out of bound access in `getVectorizationFactor`

### DIFF
--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -825,7 +825,7 @@ int64_t getVectorizationFactor(
   }
 
   // break point is beyond the range of vectorize_maps_entry, no vectorization.
-  if (break_point >= vectorize_maps_entry->size()) {
+  if (break_point >= vectorize_maps_entry.get().size()) {
     return 1;
   }
 

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -825,7 +825,7 @@ int64_t getVectorizationFactor(
   }
 
   // break point is beyond the range of vectorize_maps_entry, no vectorization.
-  if (break_point >= vectorize_maps_entry.get().size()) {
+  if (break_point >= static_cast<int64_t>(vectorize_maps_entry.get().size())) {
     return 1;
   }
 

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -825,7 +825,7 @@ int64_t getVectorizationFactor(
   }
 
   // break point is beyond the range of vectorize_maps_entry, no vectorization.
-  if (break_point >= vectorize_maps_entry.size()) {
+  if (break_point >= vectorize_maps_entry->size()) {
     return 1;
   }
 

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -824,6 +824,11 @@ int64_t getVectorizationFactor(
     return 1;
   }
 
+  // break point is beyond the range of vectorize_maps_entry, no vectorization.
+  if (break_point >= vectorize_maps_entry.size()) {
+    return 1;
+  }
+
   int64_t max_vec_size = SchedulerRuntimeInfo::max_alignment_size_in_byte;
   const auto& tv_to_inner_size_map = vectorize_maps_entry.get().at(break_point);
 

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1420,8 +1420,7 @@ TEST_F(NVFuserTest, ReductionVectorization) {
   FusionExecutorCache executor_cache(std::move(fusion));
   auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, inputs, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1420,7 +1420,7 @@ TEST_F(NVFuserTest, ReductionVectorization) {
   FusionExecutorCache executor_cache(std::move(fusion));
   auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
 
-  auto ref = t0.add(t1).sum({2});
+  auto ref = t0.mul(t1).sum({2});
   testValidate(
       executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
 }

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1420,9 +1420,8 @@ TEST_F(NVFuserTest, ReductionVectorization) {
   FusionExecutorCache executor_cache(std::move(fusion));
   auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
 
-  auto ref = t0.mul(t1).sum({2});
   testValidate(
-      executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, inputs, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1406,19 +1406,15 @@ TEST_F(NVFuserTest, ReductionVectorization) {
   auto tv3 = mul(tv2, tv1);
   auto tv4 = sum(tv3, {2});
   fusion->addOutput(tv4);
-  std::vector<IterDomain*> tv4_dom = {
-      tv4->axis(2), tv4->axis(1), tv4->axis(0)};
+  std::vector<IterDomain*> tv4_dom = {tv4->axis(2), tv4->axis(1), tv4->axis(0)};
   tv4->setAllocationDomain(tv4_dom, true);
 
   // tv1 is a constant tensor, and its domains are constant.
   // Its constant domains are used in ExactMappedExtentSubstitutionPass
   // to substitute the domains of tv0.
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  auto t0 =
-      at::randn({x, 1, z}, options);
-  auto t1 =
-      at::randn({x, y, z}, options)
-          .as_strided({x, y, z}, {1, x, x * y});
+  auto t0 = at::randn({x, 1, z}, options);
+  auto t1 = at::randn({x, y, z}, options).as_strided({x, y, z}, {1, x, x * y});
   std::vector<c10::IValue> inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion));

--- a/test/test_allocation_domain.cpp
+++ b/test/test_allocation_domain.cpp
@@ -1384,4 +1384,49 @@ TEST_F(NVFuserTest, ReductionSchedulerIssue1895) {
       executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
 }
 
+TEST_F(NVFuserTest, ReductionVectorization) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  long x = 2L, y = 2L, z = 2L;
+  auto tv0 = TensorViewBuilder()
+                 .ndims(3)
+                 .shape({-1, 1, -1})
+                 .contiguity({true, std::nullopt, true})
+                 .build();
+  fusion->addInput(tv0);
+  auto tv1 = TensorViewBuilder()
+                 .ndims(3)
+                 .shape({-1, -1, -1})
+                 .contiguity({true, true, true})
+                 .strideOrder({0, 1, 2})
+                 .build();
+  fusion->addInput(tv1);
+  auto s0 = IrBuilder::create<Val>(2);
+  auto tv2 = expand(tv0, {s0, s0, s0});
+  auto tv3 = mul(tv2, tv1);
+  auto tv4 = sum(tv3, {2});
+  fusion->addOutput(tv4);
+  std::vector<IterDomain*> tv4_dom = {
+      tv4->axis(2), tv4->axis(1), tv4->axis(0)};
+  tv4->setAllocationDomain(tv4_dom, true);
+
+  // tv1 is a constant tensor, and its domains are constant.
+  // Its constant domains are used in ExactMappedExtentSubstitutionPass
+  // to substitute the domains of tv0.
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 =
+      at::randn({x, 1, z}, options);
+  auto t1 =
+      at::randn({x, y, z}, options)
+          .as_strided({x, y, z}, {1, x, x * y});
+  std::vector<c10::IValue> inputs({t0, t1});
+
+  FusionExecutorCache executor_cache(std::move(fusion));
+  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
+
+  auto ref = t0.add(t1).sum({2});
+  testValidate(
+      executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Follow up on a previous fix #1896 

When break_point is at the boundary, added a short-cut to return 1 for vectorization factor.
Since existing vectorization analysis assumed to have a non-trivial break_point, which result in an out of bound access.