### PR TITLE
Print the number of multiprocessors for performance debugging.

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1874,21 +1874,25 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
           compiled_kernel_->function,
           launch_params_.nThreads(),
           launch_params_.smem()));
+
       const int64_t device_id =
           static_cast<unsigned char>(options_.device.index());
       const auto prop =
           at::cuda::getDeviceProperties((c10::DeviceIndex)device_id);
       const int64_t warps_per_sm =
           ceilDiv(blocks_per_sm * launch_params_.nThreads(), prop->warpSize);
+
       const int hw_max_warps =
           prop->maxThreadsPerMultiProcessor / prop->warpSize;
       const float occupancy = (float)warps_per_sm / (float)hw_max_warps * 100.f;
       setKernelOccupancy(occupancy);
       std::ostringstream oss;
       oss << std::fixed << std::setprecision(2) << occupancy << "%";
-      debug() << "blocks_per_sm= " << blocks_per_sm
-              << ", warps_per_sm= " << warps_per_sm
-              << ", occupancy= " << oss.str() << std::endl;
+
+      debug() << "num_sms=" << prop->multiProcessorCount
+              << ", blocks_per_sm=" << blocks_per_sm
+              << ", warps_per_sm=" << warps_per_sm
+              << ", occupancy=" << oss.str() << std::endl;
     }
 
     if (measure_kernel_time) {


### PR DESCRIPTION
Our vectorization strategy depends on the number of multiprocessors (aka SMs).