### PR TITLE
Evaluate multiple ops together

### DIFF
--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -199,6 +199,11 @@ PolymorphicValue ExpressionEvaluator::evaluate(const Val* value) const {
   return evaluateHelper(value, known_values);
 }
 
+PolymorphicValue ExpressionEvaluator::evaluate(const Val* value, 
+  std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
+  return evaluateHelper(value, known_values);
+}
+
 const PolymorphicValue& ExpressionEvaluator::evaluateHelper(
     const Val* value,
     std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
@@ -213,16 +218,7 @@ const PolymorphicValue& ExpressionEvaluator::evaluateHelper(
   if (!maybe_concrete_value.get().hasValue()) {
     if (auto def = value->definition()) {
       FUSER_PERF_SCOPE("ExpressionEvaluator::evaluate");
-      std::vector<PolymorphicValue> inputs;
-      inputs.reserve(def->inputs().size());
-      for (auto i : def->inputs()) {
-        const auto& eval_i = evaluateHelper(i, known_values);
-        if (!eval_i.hasValue()) {
-          return null_;
-        }
-        inputs.emplace_back(eval_i);
-      }
-      auto outputs = def->evaluate(*this, inputs);
+      auto outputs = def->evaluate(*this, known_values);
       for (auto i : c10::irange(def->outputs().size())) {
         known_values[def->output(i)] = std::move(outputs[i]);
       }

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -199,8 +199,9 @@ PolymorphicValue ExpressionEvaluator::evaluate(const Val* value) const {
   return evaluateHelper(value, known_values);
 }
 
-PolymorphicValue ExpressionEvaluator::evaluate(const Val* value, 
-  std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
+PolymorphicValue ExpressionEvaluator::evaluate(
+    const Val* value,
+    std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
   return evaluateHelper(value, known_values);
 }
 

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -191,21 +191,15 @@ const PolymorphicValue& ExpressionEvaluator::evaluate(ParallelType pt) {
 }
 
 const PolymorphicValue& ExpressionEvaluator::evaluate(const Val* value) {
-  return evaluateHelper(value, known_values_);
+  return evaluate(value, known_values_);
 }
 
 PolymorphicValue ExpressionEvaluator::evaluate(const Val* value) const {
   std::unordered_map<const Val*, PolymorphicValue> known_values;
-  return evaluateHelper(value, known_values);
+  return evaluate(value, known_values);
 }
 
-PolymorphicValue ExpressionEvaluator::evaluate(
-    const Val* value,
-    std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
-  return evaluateHelper(value, known_values);
-}
-
-const PolymorphicValue& ExpressionEvaluator::evaluateHelper(
+const PolymorphicValue& ExpressionEvaluator::evaluate(
     const Val* value,
     std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
   if (precomputed_values_ && precomputed_values_->ready()) {

--- a/csrc/expr_evaluator.h
+++ b/csrc/expr_evaluator.h
@@ -59,9 +59,8 @@ class ExpressionEvaluator {
   //! Try to evaluate a value using const evaluator ref
   NVF_API PolymorphicValue evaluate(const Val* value) const;
 
-  //! Used  by Expr::evaluate when evaluating inputs to properly update the
-  //! known_values.
-  PolymorphicValue evaluate(
+  //! Base evaluate method called by other overloads and Expr::evaluate
+  const PolymorphicValue& evaluate(
       const Val* value,
       std::unordered_map<const Val*, PolymorphicValue>& known_values) const;
 
@@ -94,9 +93,6 @@ class ExpressionEvaluator {
       const Val* value,
       const std::unordered_map<const Val*, PolymorphicValue>&
           additional_known_values) const;
-  const PolymorphicValue& evaluateHelper(
-      const Val* value,
-      std::unordered_map<const Val*, PolymorphicValue>& known_values) const;
 
  private:
   // TODO: Consider make this const. It can't be const as bind() of

--- a/csrc/expr_evaluator.h
+++ b/csrc/expr_evaluator.h
@@ -106,6 +106,7 @@ class ExpressionEvaluator {
   PrecomputedValues* precomputed_values_ = nullptr;
   std::unordered_map<const Val*, PolymorphicValue> known_values_;
   std::unordered_map<std::string, PolymorphicValue> known_named_scalars_;
+  PolymorphicValue null_ = std::monostate{};
 };
 
 } // namespace nvfuser

--- a/csrc/expr_evaluator.h
+++ b/csrc/expr_evaluator.h
@@ -59,9 +59,11 @@ class ExpressionEvaluator {
   //! Try to evaluate a value using const evaluator ref
   NVF_API PolymorphicValue evaluate(const Val* value) const;
 
+  //! Used  by Expr::evaluate when evaluating inputs to properly update the
+  //! known_values.
   PolymorphicValue evaluate(
-    const Val* value, 
-    std::unordered_map<const Val*, PolymorphicValue>& known_values) const;
+      const Val* value,
+      std::unordered_map<const Val*, PolymorphicValue>& known_values) const;
 
   bool isKnown(const Val* value) const {
     return known_values_.count(value) > 0;

--- a/csrc/expr_evaluator.h
+++ b/csrc/expr_evaluator.h
@@ -56,10 +56,12 @@ class ExpressionEvaluator {
   //! Try to evaluate a parallel dimension
   const PolymorphicValue& evaluate(ParallelType pt);
 
-  //! Try to evaluate a value using const evaluator ref
+  //! Evaluates a value through a const evaluator reference.
+  //! Initializes a known_values map to store intermediate values in lieu of
+  //! known_values_.
   NVF_API PolymorphicValue evaluate(const Val* value) const;
 
-  //! Base evaluate method called by other overloads and Expr::evaluate
+  //! Base evaluate method called by other overloads and Expr::evaluate.
   const PolymorphicValue& evaluate(
       const Val* value,
       std::unordered_map<const Val*, PolymorphicValue>& known_values) const;
@@ -104,7 +106,6 @@ class ExpressionEvaluator {
   PrecomputedValues* precomputed_values_ = nullptr;
   std::unordered_map<const Val*, PolymorphicValue> known_values_;
   std::unordered_map<std::string, PolymorphicValue> known_named_scalars_;
-  PolymorphicValue null_ = std::monostate{};
 };
 
 } // namespace nvfuser

--- a/csrc/expr_evaluator.h
+++ b/csrc/expr_evaluator.h
@@ -59,6 +59,10 @@ class ExpressionEvaluator {
   //! Try to evaluate a value using const evaluator ref
   NVF_API PolymorphicValue evaluate(const Val* value) const;
 
+  PolymorphicValue evaluate(
+    const Val* value, 
+    std::unordered_map<const Val*, PolymorphicValue>& known_values) const;
+
   bool isKnown(const Val* value) const {
     return known_values_.count(value) > 0;
   }

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -409,7 +409,7 @@ std::vector<PolymorphicValue> Expr::evaluate(
   for (auto inp : inputs()) {
     const auto& eval_i = ee.evaluate(inp, known_values);
     if (!eval_i.hasValue()) {
-      return {null_};
+      return {std::monostate{}};
     }
     expr_inputs.emplace_back(eval_i);
   }

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -404,7 +404,6 @@ std::vector<PolymorphicValue> Expr::evaluate(
 std::vector<PolymorphicValue> Expr::evaluate(
     const ExpressionEvaluator& ee,
     std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
-
   std::vector<PolymorphicValue> expr_inputs;
   expr_inputs.reserve(inputs().size());
   for (auto inp : inputs()) {
@@ -414,7 +413,7 @@ std::vector<PolymorphicValue> Expr::evaluate(
     }
     expr_inputs.emplace_back(eval_i);
   }
-  return this->evaluate(ee, expr_inputs);  
+  return this->evaluate(ee, expr_inputs);
 }
 
 void Expr::addDataAttribute(PolymorphicValue attr) {

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -401,6 +401,22 @@ std::vector<PolymorphicValue> Expr::evaluate(
       "Please override the evaluate method");
 }
 
+std::vector<PolymorphicValue> Expr::evaluate(
+    const ExpressionEvaluator& ee,
+    std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
+
+  std::vector<PolymorphicValue> expr_inputs;
+  expr_inputs.reserve(inputs().size());
+  for (auto i : inputs()) {
+    const auto& eval_i = ee.evaluate(i, known_values);
+    if (!eval_i.hasValue()) {
+      return {std::monostate{}};
+    }
+    expr_inputs.emplace_back(eval_i);
+  }
+  return this->evaluate(ee, expr_inputs);  
+}
+
 void Expr::addDataAttribute(PolymorphicValue attr) {
   addAttribute(IrBuilder::create<Val>(container(), std::move(attr)));
 }

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -407,10 +407,10 @@ std::vector<PolymorphicValue> Expr::evaluate(
 
   std::vector<PolymorphicValue> expr_inputs;
   expr_inputs.reserve(inputs().size());
-  for (auto i : inputs()) {
-    const auto& eval_i = ee.evaluate(i, known_values);
+  for (auto inp : inputs()) {
+    const auto& eval_i = ee.evaluate(inp, known_values);
     if (!eval_i.hasValue()) {
-      return {std::monostate{}};
+      return {null_};
     }
     expr_inputs.emplace_back(eval_i);
   }

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -524,6 +524,10 @@ class NVF_API Expr : public Statement {
       const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const;
 
+  virtual std::vector<PolymorphicValue> evaluate(
+      const ExpressionEvaluator& ee,
+      std::unordered_map<const Val*, PolymorphicValue>& known_values) const;
+
   // Input/output accessors
   const auto& inputs() const {
     return inputs_;

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -526,11 +526,11 @@ class NVF_API Expr : public Statement {
 
   // This version allows evaluation of multiple ops together instead of one op
   // at a time by overriding and skipping computation of intermediate inputs
-  // that are not required. For example: 1. CatOp is internally preceded by
-  // PadOp but the ATen evaluation uses only the unpadded inputs
-  //                and the evaluation of padded inputs can be skipped.
-  //              2. Evaluating patterns in matmul fallback such as MmaOp +
-  //              Cast/ MmaOp + Bias + Cast
+  // that are not required. For example:
+  // 1. CatOp is internally preceded by PadOp but the ATen evaluation uses only
+  // the unpadded inputs and the evaluation of padded inputs can be skipped.
+  // 2. Evaluating patterns in matmul fallback such as MmaOp + Cast/ MmaOp +
+  // Bias + Cast
   virtual std::vector<PolymorphicValue> evaluate(
       const ExpressionEvaluator& ee,
       std::unordered_map<const Val*, PolymorphicValue>& known_values) const;

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -524,6 +524,13 @@ class NVF_API Expr : public Statement {
       const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const;
 
+  // This version allows evaluation of multiple ops together instead of one op
+  // at a time by overriding and skipping computation of intermediate inputs
+  // that are not required. For example: 1. CatOp is internally preceded by
+  // PadOp but the ATen evaluation uses only the unpadded inputs
+  //                and the evaluation of padded inputs can be skipped.
+  //              2. Evaluating patterns in matmul fallback such as MmaOp +
+  //              Cast/ MmaOp + Bias + Cast
   virtual std::vector<PolymorphicValue> evaluate(
       const ExpressionEvaluator& ee,
       std::unordered_map<const Val*, PolymorphicValue>& known_values) const;
@@ -635,8 +642,6 @@ class NVF_API Expr : public Statement {
   }
 
   std::vector<Statement*> attributes_;
-
-  PolymorphicValue null_ = std::monostate{};
 
  private:
   std::vector<Val*> inputs_;

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -636,6 +636,8 @@ class NVF_API Expr : public Statement {
 
   std::vector<Statement*> attributes_;
 
+  PolymorphicValue null_ = std::monostate{};
+
  private:
   std::vector<Val*> inputs_;
   std::vector<Val*> outputs_;

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2240,7 +2240,7 @@ class NVF_API CatOp : public Expr {
   std::string toInlineString(int indent_size = 0) const override;
   std::vector<PolymorphicValue> evaluate(
       const ExpressionEvaluator& ee,
-      const std::vector<PolymorphicValue>& inputs) const override;
+      std::unordered_map<const Val*, PolymorphicValue>& known_values) const override;
 
   int64_t concatenatedDim() const {
     return attribute<int64_t>(0);

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2240,7 +2240,8 @@ class NVF_API CatOp : public Expr {
   std::string toInlineString(int indent_size = 0) const override;
   std::vector<PolymorphicValue> evaluate(
       const ExpressionEvaluator& ee,
-      std::unordered_map<const Val*, PolymorphicValue>& known_values) const override;
+      std::unordered_map<const Val*, PolymorphicValue>& known_values)
+      const override;
 
   int64_t concatenatedDim() const {
     return attribute<int64_t>(0);

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4463,8 +4463,12 @@ std::vector<PolymorphicValue> CatOp::evaluate(
   // CatOp is preceded by a PadOp internally.
   // For ATen evaluation, directly compute the unpadded inputs.
   std::vector<at::Tensor> unpadded_inputs;
+  unpadded_inputs.reserve(inputs().size());
   int64_t concat_dim = concatenatedDim();
-  for (auto inp : inputs()) {
+  for (Val* inp : inputs()) {
+    NVF_CHECK(
+        inp->definition() != nullptr && inp->definition()->isA<PadOp>(),
+        "Expected CatOp to be preceded by a PadOp.");
     auto eval_i = ee.evaluate(inp->definition()->input(0), known_values);
     unpadded_inputs.push_back(eval_i.as<at::Tensor>());
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4460,6 +4460,8 @@ Val* CatOp::getPred(int input_idx) const {
 std::vector<PolymorphicValue> CatOp::evaluate(
     const ExpressionEvaluator& ee,
     std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
+  // CatOp is preceded by a PadOp internally.
+  // For ATen evaluation, directly compute the unpadded inputs.
   std::vector<at::Tensor> unpadded_inputs;
   int64_t concat_dim = concatenatedDim();
   for (auto inp : inputs()) {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4459,14 +4459,14 @@ Val* CatOp::getPred(int input_idx) const {
 
 std::vector<PolymorphicValue> CatOp::evaluate(
     const ExpressionEvaluator& ee,
-    const std::vector<PolymorphicValue>& inputs) const {
-  std::vector<at::Tensor> in;
+    std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
+  std::vector<at::Tensor> unpadded_inputs;
   int64_t concat_dim = concatenatedDim();
-  for (auto i : c10::irange(inputs.size())) {
-    auto unpadded_inp = ee.evaluate(input(i)->definition()->input(0));
-    in.push_back(unpadded_inp.as<at::Tensor>());
+  for (auto inp : inputs()) {
+    auto eval_i = ee.evaluate(inp->definition()->input(0), known_values);
+    unpadded_inputs.push_back(eval_i.as<at::Tensor>());
   }
-  return {at::cat(in, concat_dim)};
+  return {at::cat(unpadded_inputs, concat_dim)};
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
This PR is intended to add support for evaluating multiple ops together and skip evaluating intermediate inputs.
Current use cases:

1. CatOp: Currently, CatOp::evaluate uses the unpadded inputs, however the padded inputs are still evaluated.
2. Matmul Fallback path: We need the expression evaluator to evaluate patterns such as `MmaOp + Cast`, `MmaOp + Bias + Cast` in a single call instead of one op at a time.