### PR TITLE
Use `getRaw` in `isExtentEqualToMaxParallelTypeExtent`

### DIFF
--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -813,7 +813,7 @@ bool isScalarExpr(Expr* expr) {
 
 bool isExtentEqualToMaxParallelTypeExtent(const IterDomain* id) {
   const auto& parallel_dim_map = GpuLower::current()->parallelDimensionMap();
-  auto* pdm_max_extent = parallel_dim_map.get(id->getParallelType());
+  auto* pdm_max_extent = parallel_dim_map.getRaw(id->getParallelType());
   if (nullptr == pdm_max_extent) {
     return false;
   }


### PR DESCRIPTION
Because `get` will return things like `blockDim.x` instead of the actual extent unless it is constant:
https://github.com/NVIDIA/Fuser/blob/4621129399550b8a6f3994d5092ddd0d581a6dc0/csrc/parallel_dimension_map.cpp#L150-L156
which is not desired behavior we want here.