### PR TITLE
Baseline benchmarks for GeLU fwd, bwd and reduction.

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -138,6 +138,10 @@ def clear_cuda_cache() -> None:
         torch.cuda.empty_cache()
 
 
+def unary_bwd_torch(inputs: List):  # [output, grad_out]
+    inputs[0].backward(inputs[1], retain_graph=True)
+
+
 class NVFBenchmark:
     """
     A wrapper class around pytest-benchmark to support

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -137,7 +137,7 @@ def clear_cuda_cache() -> None:
         gc.collect()
         torch.cuda.empty_cache()
 
-
+# Backward function for torch baseline benchmarks.
 def unary_bwd_torch(inputs: List):  # [output, grad_out]
     inputs[0].backward(inputs[1], retain_graph=True)
 

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -137,6 +137,7 @@ def clear_cuda_cache() -> None:
         gc.collect()
         torch.cuda.empty_cache()
 
+
 # Backward function for torch baseline benchmarks.
 def unary_bwd_torch(inputs: List):  # [output, grad_out]
     inputs[0].backward(inputs[1], retain_graph=True)

--- a/benchmarks/python/test_gelu_bwd.py
+++ b/benchmarks/python/test_gelu_bwd.py
@@ -1,9 +1,10 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache
+from .core import run_benchmark, clear_cuda_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+import numpy as np
 
 
 def gelu_bwd_fusion(
@@ -53,9 +54,14 @@ def gelu_bwd_fusion(
     fd.add_output(T20)
 
 
+def gelu_bwd_iobytes(size: tuple, dtype: torch.dtype):
+    # Total IO bytes = in_tensor + grad_out + bias + grad_input
+    return int(dtype.itemsize * (3 * np.prod(size) + size[1]))
+
+
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_gelu_bwd_benchmark(
+def test_gelu_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
@@ -64,8 +70,8 @@ def test_gelu_bwd_benchmark(
 ):
     clear_cuda_cache()
 
-    inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
-    grads = torch.randn(*size, device="cuda", dtype=dtype)
+    inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
+    grads = torch.randn(size, device="cuda", dtype=dtype)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     with FusionDefinition() as fd:
         gelu_bwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
@@ -79,3 +85,25 @@ def test_gelu_bwd_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [inputs, grads, bias])
+
+
+@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_gelu_bwd_baseline_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    compile: bool,
+):
+    clear_cuda_cache()
+    inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
+    bias = torch.ones(size[-1], device="cuda", dtype=dtype)
+    grads = torch.randn(size, device="cuda", dtype=dtype)
+    eager_output = torch.nn.functional.gelu(inputs + bias, approximate="tanh")
+    run_benchmark(
+        benchmark,
+        torch.compile(unary_bwd_torch) if compile else unary_bwd_torch,
+        [eager_output, grads],
+        iobytes=gelu_bwd_iobytes(size, dtype),
+    )

--- a/benchmarks/python/test_gelu_bwd_reduction.py
+++ b/benchmarks/python/test_gelu_bwd_reduction.py
@@ -4,6 +4,7 @@ from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_cuda_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+import numpy as np
 
 
 def gelu_bwd_reduction_fusion(
@@ -53,10 +54,25 @@ def gelu_bwd_reduction_fusion(
     fd.add_output(T21)
 
 
+def gelu_bwd_reduction_torch(
+    inputs: list,
+):  # [output, grad_out, in_tensor, reduction_axis]
+    eager_output, grad_out, in_tensor, reduction_axis = inputs
+    eager_output.backward(grad_out, retain_graph=True)
+    return in_tensor.grad.sum(reduction_axis)
+
+
+def gelu_bwd_reduction_iobytes(size: tuple, dtype: torch.dtype, reduction_axis: int):
+    # Total IO bytes = in_tensor + grad_out + bias + grad_input
+    return int(
+        dtype.itemsize * (2 * np.prod(size) + size[1] + size[1 - reduction_axis])
+    )
+
+
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0, 1])
-def test_gelu_bwd_reduction_benchmark(
+def test_gelu_bwd_reduction_nvf_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
@@ -84,3 +100,29 @@ def test_gelu_bwd_reduction_benchmark(
 
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, [inputs, grads, bias])
+
+
+@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("reduction_axis", [0, 1])
+def test_gelu_bwd_reduction_baseline_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    reduction_axis: int,
+    compile: bool,
+):
+    clear_cuda_cache()
+    inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
+    bias = torch.ones(size[-1], device="cuda", dtype=dtype)
+    grads = torch.randn(size, device="cuda", dtype=dtype)
+    eager_output = torch.nn.functional.gelu(inputs + bias, approximate="tanh")
+    run_benchmark(
+        benchmark,
+        torch.compile(gelu_bwd_reduction_torch)
+        if compile
+        else gelu_bwd_reduction_torch,
+        [eager_output, grads, inputs, reduction_axis],
+        iobytes=gelu_bwd_reduction_iobytes(size, dtype, reduction_axis),
+    )

--- a/benchmarks/python/test_gelu_fwd.py
+++ b/benchmarks/python/test_gelu_fwd.py
@@ -37,10 +37,13 @@ def gelu_fwd_fusion(
         T10 = fd.ops.cast(T10, dtype=dtype)
     fd.add_output(T10)
 
+def gelu_fwd_fn(inputs: list):  # [in_tensor, bias]
+    return torch.nn.functional.gelu(inputs[0] + inputs[1], approximate="tanh")
+
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_gelu_fwd_benchmark(
+def test_gelu_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
@@ -49,12 +52,34 @@ def test_gelu_fwd_benchmark(
 ):
     clear_cuda_cache()
 
-    inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
-    bias = torch.ones(size[-1], device="cuda", dtype=dtype)
+    inputs = [torch.randn(size, device="cuda", dtype=dtype, requires_grad=True), #in_tensor
+              torch.ones(size[-1], device="cuda", dtype=dtype) # bias
+            ]
     with FusionDefinition() as fd:
         gelu_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
     if not disable_validation:
-        eager_output = torch.nn.functional.gelu(inputs + bias, approximate="tanh")
-        fd.validate([inputs, bias], [eager_output])
+        eager_output = gelu_fwd_fn(inputs)
+        fd.validate(inputs, [eager_output])
     if not disable_benchmarking:
-        run_benchmark(benchmark, fd.execute, [inputs, bias])
+        run_benchmark(benchmark, fd.execute, inputs)
+
+
+@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_gelu_fwd_baseline_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    compile: bool,
+):
+    clear_cuda_cache()
+    inputs = [torch.randn(size, device="cuda", dtype=dtype, requires_grad=True), #in_tensor
+              torch.ones(size[-1], device="cuda", dtype=dtype) # bias
+            ]
+    # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
+    run_benchmark(
+        benchmark,
+        torch.compile(gelu_fwd_fn) if compile else gelu_fwd_fn,
+        inputs
+    )

--- a/benchmarks/python/test_gelu_fwd.py
+++ b/benchmarks/python/test_gelu_fwd.py
@@ -37,6 +37,7 @@ def gelu_fwd_fusion(
         T10 = fd.ops.cast(T10, dtype=dtype)
     fd.add_output(T10)
 
+
 def gelu_fwd_fn(inputs: list):  # [in_tensor, bias]
     return torch.nn.functional.gelu(inputs[0] + inputs[1], approximate="tanh")
 
@@ -52,9 +53,10 @@ def test_gelu_fwd_nvf_benchmark(
 ):
     clear_cuda_cache()
 
-    inputs = [torch.randn(size, device="cuda", dtype=dtype, requires_grad=True), #in_tensor
-              torch.ones(size[-1], device="cuda", dtype=dtype) # bias
-            ]
+    inputs = [
+        torch.randn(size, device="cuda", dtype=dtype, requires_grad=True),  # in_tensor
+        torch.ones(size[-1], device="cuda", dtype=dtype),  # bias
+    ]
     with FusionDefinition() as fd:
         gelu_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
     if not disable_validation:
@@ -74,12 +76,11 @@ def test_gelu_fwd_baseline_benchmark(
     compile: bool,
 ):
     clear_cuda_cache()
-    inputs = [torch.randn(size, device="cuda", dtype=dtype, requires_grad=True), #in_tensor
-              torch.ones(size[-1], device="cuda", dtype=dtype) # bias
-            ]
+    inputs = [
+        torch.randn(size, device="cuda", dtype=dtype, requires_grad=True),  # in_tensor
+        torch.ones(size[-1], device="cuda", dtype=dtype),  # bias
+    ]
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
-        benchmark,
-        torch.compile(gelu_fwd_fn) if compile else gelu_fwd_fn,
-        inputs
+        benchmark, torch.compile(gelu_fwd_fn) if compile else gelu_fwd_fn, inputs
     )


### PR DESCRIPTION
Part of resolving #1668.
Adds IObytes computation for bwd and bwd-reduction benchmarks for parity with nvFuser.