### PR TITLE
Add `NVFUSER_DUMP="ftrace(regex)"`

### DIFF
--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -101,6 +101,7 @@ template <>
 std::unordered_map<DebugDumpOption, std::vector<std::string>> Options<
     DebugDumpOption>::getOptionsFromEnv() {
   const std::unordered_map<std::string, DebugDumpOption> available_options = {
+      {"!", DebugDumpOption::CallStack},
       {"bank_conflict", DebugDumpOption::BankConflictInfo},
       {"buffer_reuse_verbose", DebugDumpOption::BufferReuseInfo},
       {"ca_map", DebugDumpOption::ComputeAtMap},

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -101,7 +101,6 @@ template <>
 std::unordered_map<DebugDumpOption, std::vector<std::string>> Options<
     DebugDumpOption>::getOptionsFromEnv() {
   const std::unordered_map<std::string, DebugDumpOption> available_options = {
-      {"!", DebugDumpOption::CallStack},
       {"bank_conflict", DebugDumpOption::BankConflictInfo},
       {"buffer_reuse_verbose", DebugDumpOption::BufferReuseInfo},
       {"ca_map", DebugDumpOption::ComputeAtMap},
@@ -115,6 +114,7 @@ std::unordered_map<DebugDumpOption, std::vector<std::string>> Options<
       {"expr_simplify", DebugDumpOption::ExprSimplification},
       {"expr_sort", DebugDumpOption::ExprSort},
       {"expr_sort_verbose", DebugDumpOption::ExprSortVerbose},
+      {"ftrace", DebugDumpOption::FunctionTrace},
       {"fusion_args", DebugDumpOption::FusionArgs},
       {"fusion_ir_original", DebugDumpOption::FusionIrOriginal},
       {"fusion_ir_concretized", DebugDumpOption::FusionIrConcretized},

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -24,11 +24,13 @@ enum class DebugDumpOption {
   FunctionTrace, //!< Dump the function trace of selected internal function. The
                  //!< function of interest needs to be instrumented with
                  //!< DEBUG_PRINT_SCOPE and optionally RECORD_AND_RETURN before
-                 //!< it can be traced. If you are interested in tracing a
-                 //!< specific function while developing a PR, you are
-                 //!< recommended to keep the instrumentation code in your PR
-                 //!< and so later people can use it after committed to the main
-                 //!< branch.
+                 //!< it can be traced. If RECORD_AND_RETURN is not used,
+                 //!< function tracing will still work, but it will not be able
+                 //!< to print the return value and the line of the return
+                 //!< statement. If you are interested in tracing a specific
+                 //!< function while developing a PR, you are recommended to
+                 //!< keep the instrumentation code in your PR and so later
+                 //!< people can use it after committed to the main branch.
   FusionIrOriginal, //!< Dump the original fusion IR built by the Python API
   FusionIrConcretized, //!< Dump the Fusion IR after concretization
   FusionIrPreseg, //!< Dump the Fusion IR after pre-segmenter optimization and

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -21,7 +21,7 @@ namespace nvfuser {
 //! These can be set through the `NVFUSER_DUMP` environment variable
 //!
 enum class DebugDumpOption {
-  CallStack, //!< Dump the call stack of selected internal function
+  FunctionTrace, //!< Dump the function trace of selected internal function
   FusionIrOriginal, //!< Dump the original fusion IR built by the Python API
   FusionIrConcretized, //!< Dump the Fusion IR after concretization
   FusionIrPreseg, //!< Dump the Fusion IR after pre-segmenter optimization and

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -21,6 +21,7 @@ namespace nvfuser {
 //! These can be set through the `NVFUSER_DUMP` environment variable
 //!
 enum class DebugDumpOption {
+  CallStack, //!< Dump the call stack of selected internal function
   FusionIrOriginal, //!< Dump the original fusion IR built by the Python API
   FusionIrConcretized, //!< Dump the Fusion IR after concretization
   FusionIrPreseg, //!< Dump the Fusion IR after pre-segmenter optimization and

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -21,7 +21,14 @@ namespace nvfuser {
 //! These can be set through the `NVFUSER_DUMP` environment variable
 //!
 enum class DebugDumpOption {
-  FunctionTrace, //!< Dump the function trace of selected internal function
+  FunctionTrace, //!< Dump the function trace of selected internal function. The
+                 //!< function of interest needs to be instrumented with
+                 //!< DEBUG_PRINT_SCOPE and optionally RECORD_AND_RETURN before
+                 //!< it can be traced. If you are interested in tracing a
+                 //!< specific function while developing a PR, you are
+                 //!< recommended to keep the instrumentation code in your PR
+                 //!< and so later people can use it after committed to the main
+                 //!< branch.
   FusionIrOriginal, //!< Dump the original fusion IR built by the Python API
   FusionIrConcretized, //!< Dump the Fusion IR after concretization
   FusionIrPreseg, //!< Dump the Fusion IR after pre-segmenter optimization and

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -18,7 +18,9 @@
 
 #include <c10/core/thread_pool.h>
 #include <deque>
+#include <memory>
 #include <optional>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -386,28 +388,66 @@ std::string toDelimitedInlineString(
   return ss.str();
 }
 
-template <typename... Args>
 class DebugPrintScope {
  public:
+  template <typename... Args>
   DebugPrintScope(std::string name, Args... args) : name_(std::move(name)) {
     debug() << "Entering " << name_ << "("
             << toDelimitedString(std::forward_as_tuple(args...)) << ")"
             << std::endl;
   }
+
   ~DebugPrintScope() {
-    debug() << "Leaving " << name_ << std::endl;
+    debug() << "Leaving " << name_;
+    if (!return_.empty()) {
+      debug() << " returning " << return_;
+    }
+    if (!file_.empty()) {
+      debug() << " at " << file_;
+    }
+    if (line_ >= 0) {
+      debug() << ":" << line_;
+    }
+    debug() << std::endl;
+  }
+
+  template <typename T>
+  void setReturn(const T& ret, std::string file = "", int64_t line = -1) {
+    return_ = Printer<std::decay_t<T>>::toString(ret);
+    file_ = std::move(file);
+    line_ = line;
   }
 
  private:
   std::string name_;
+  std::string return_;
+  std::string file_;
+  int64_t line_ = -1;
 };
 
 // Note: ##__VA_ARGS__ is not C++ stardard, but it should work on gcc and clang.
 // Compared to __VA_ARGS__, ##__VA_ARGS__ automatically remove the preceding
 // comma when empty, allowing empty variadic parameters. If using other
 // compiler, please use DebugPrintScope directly without this macro.
-#define DEBUG_PRINT_SCOPE(...) \
-  DebugPrintScope _debug_print_scope(__func__, ##__VA_ARGS__)
+#define DEBUG_PRINT_SCOPE(...)                                          \
+  std::unique_ptr<DebugPrintScope> _debug_print_scope;                  \
+  if (isDebugDumpEnabled(DebugDumpOption::CallStack)) {                 \
+    auto enabled = getDebugDumpArguments(DebugDumpOption::CallStack);   \
+    for (auto pattern : enabled) {                                      \
+      std::regex re(pattern);                                           \
+      if (std::regex_match(__func__, re)) {                             \
+        _debug_print_scope =                                            \
+            std::make_unique<DebugPrintScope>(__func__, ##__VA_ARGS__); \
+        break;                                                          \
+      }                                                                 \
+    }                                                                   \
+  }
+
+#define RECORD_AND_RETURN(ret)                              \
+  if (_debug_print_scope) {                                 \
+    _debug_print_scope->setReturn(ret, __FILE__, __LINE__); \
+  }                                                         \
+  return ret
 
 // Computes the index type required.
 // Made into a class w/ state to allow reuse with

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -419,6 +419,8 @@ class DebugPrintScope {
   }
 
  private:
+  // The name of the scope, as specified as the first argument of
+  // DEBUG_PRINT_SCOPE_NAME. If using DEBUG_PRINT_SCOPE, then this is __func__.
   std::string name_;
 
   // Return value and location of the return statement.
@@ -437,19 +439,21 @@ class DebugPrintScope {
 // Compared to __VA_ARGS__, ##__VA_ARGS__ automatically remove the preceding
 // comma when empty, allowing empty variadic parameters. If using other
 // compiler, please use DebugPrintScope directly without this macro.
-#define DEBUG_PRINT_SCOPE(...)                                            \
+#define DEBUG_PRINT_SCOPE_NAME(name, ...)                                 \
   std::unique_ptr<DebugPrintScope> _debug_print_scope;                    \
   if (isDebugDumpEnabled(DebugDumpOption::FunctionTrace)) {               \
     auto enabled = getDebugDumpArguments(DebugDumpOption::FunctionTrace); \
     for (auto pattern : enabled) {                                        \
       std::regex re(pattern);                                             \
-      if (std::regex_match(__func__, re)) {                               \
+      if (std::regex_match(name, re)) {                                   \
         _debug_print_scope =                                              \
             std::make_unique<DebugPrintScope>(__func__, ##__VA_ARGS__);   \
         break;                                                            \
       }                                                                   \
     }                                                                     \
   }
+
+#define DEBUG_PRINT_SCOPE(...) DEBUG_PRINT_SCOPE_NAME(__func__, ##__VA_ARGS__)
 
 // Record the return value and return it.
 #define RECORD_AND_RETURN(ret)                              \

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -420,6 +420,11 @@ class DebugPrintScope {
 
  private:
   std::string name_;
+
+  // Return value and location of the return statement.
+  // Note that the recording of the return value is not automatic. The function
+  // needs to be manually instrumented to replace `return XXX;` with
+  // `RECORD_AND_RETURN(XXX)` to record the return value.
   std::string return_;
   std::string file_;
   int64_t line_ = -1;
@@ -432,18 +437,18 @@ class DebugPrintScope {
 // Compared to __VA_ARGS__, ##__VA_ARGS__ automatically remove the preceding
 // comma when empty, allowing empty variadic parameters. If using other
 // compiler, please use DebugPrintScope directly without this macro.
-#define DEBUG_PRINT_SCOPE(...)                                          \
-  std::unique_ptr<DebugPrintScope> _debug_print_scope;                  \
-  if (isDebugDumpEnabled(DebugDumpOption::CallStack)) {                 \
-    auto enabled = getDebugDumpArguments(DebugDumpOption::CallStack);   \
-    for (auto pattern : enabled) {                                      \
-      std::regex re(pattern);                                           \
-      if (std::regex_match(__func__, re)) {                             \
-        _debug_print_scope =                                            \
-            std::make_unique<DebugPrintScope>(__func__, ##__VA_ARGS__); \
-        break;                                                          \
-      }                                                                 \
-    }                                                                   \
+#define DEBUG_PRINT_SCOPE(...)                                            \
+  std::unique_ptr<DebugPrintScope> _debug_print_scope;                    \
+  if (isDebugDumpEnabled(DebugDumpOption::FunctionTrace)) {               \
+    auto enabled = getDebugDumpArguments(DebugDumpOption::FunctionTrace); \
+    for (auto pattern : enabled) {                                        \
+      std::regex re(pattern);                                             \
+      if (std::regex_match(__func__, re)) {                               \
+        _debug_print_scope =                                              \
+            std::make_unique<DebugPrintScope>(__func__, ##__VA_ARGS__);   \
+        break;                                                            \
+      }                                                                   \
+    }                                                                     \
   }
 
 // Record the return value and return it.

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -425,6 +425,9 @@ class DebugPrintScope {
   int64_t line_ = -1;
 };
 
+// Debug printing the entering and leaving of a function. The given arguments
+// will be printed when entering the function.
+//
 // Note: ##__VA_ARGS__ is not C++ stardard, but it should work on gcc and clang.
 // Compared to __VA_ARGS__, ##__VA_ARGS__ automatically remove the preceding
 // comma when empty, allowing empty variadic parameters. If using other
@@ -443,6 +446,7 @@ class DebugPrintScope {
     }                                                                   \
   }
 
+// Record the return value and return it.
 #define RECORD_AND_RETURN(ret)                              \
   if (_debug_print_scope) {                                 \
     _debug_print_scope->setReturn(ret, __FILE__, __LINE__); \

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -34,33 +34,32 @@ int myFavoriteFunction(int a, int b) {
   }
 }
 
-TEST_F(NVFuserTest, FunctionTrace) {
-  {
-    std::stringstream ss;
-    DebugStreamGuard g(ss);
-    DebugDumpOptionsGuard gg;
-    gg.getCurOptions().set(DebugDumpOption::FunctionTrace, {".*Favorite.*"});
-    EXPECT_EQ(myFavoriteFunction(1, 2), 3);
-    EXPECT_THAT(
-        ss.str(), ::testing::HasSubstr("Entering myFavoriteFunction(1, 2)"));
-    EXPECT_THAT(
-        ss.str(),
-        ::testing::HasSubstr("Leaving myFavoriteFunction returning 3 at "));
-    EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_gpu_utils.cpp:31"));
-  }
-  {
-    std::stringstream ss;
-    DebugStreamGuard g(ss);
-    DebugDumpOptionsGuard gg;
-    gg.getCurOptions().set(DebugDumpOption::FunctionTrace, {".*Favorite.*"});
-    EXPECT_EQ(myFavoriteFunction(-1, 2), -3);
-    EXPECT_THAT(
-        ss.str(), ::testing::HasSubstr("Entering myFavoriteFunction(-1, 2)"));
-    EXPECT_THAT(
-        ss.str(),
-        ::testing::HasSubstr("Leaving myFavoriteFunction returning -3 at "));
-    EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_gpu_utils.cpp:33"));
-  }
+TEST_F(NVFuserTest, FunctionTrace1) {
+  std::stringstream ss;
+  DebugStreamGuard g(ss);
+  DebugDumpOptionsGuard gg;
+  gg.getCurOptions().set(DebugDumpOption::FunctionTrace, {".*Favorite.*"});
+  EXPECT_EQ(myFavoriteFunction(1, 2), 3);
+  EXPECT_THAT(
+      ss.str(), ::testing::HasSubstr("Entering myFavoriteFunction(1, 2)"));
+  EXPECT_THAT(
+      ss.str(),
+      ::testing::HasSubstr("Leaving myFavoriteFunction returning 3 at "));
+  EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_gpu_utils.cpp:31"));
+}
+
+TEST_F(NVFuserTest, FunctionTrace2) {
+  std::stringstream ss;
+  DebugStreamGuard g(ss);
+  DebugDumpOptionsGuard gg;
+  gg.getCurOptions().set(DebugDumpOption::FunctionTrace, {".*Favorite.*"});
+  EXPECT_EQ(myFavoriteFunction(-1, 2), -3);
+  EXPECT_THAT(
+      ss.str(), ::testing::HasSubstr("Entering myFavoriteFunction(-1, 2)"));
+  EXPECT_THAT(
+      ss.str(),
+      ::testing::HasSubstr("Leaving myFavoriteFunction returning -3 at "));
+  EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_gpu_utils.cpp:33"));
 }
 
 TEST_F(NVFuserTest, FusionSplitDims_CUDA) {

--- a/test/test_gpu_utils.cpp
+++ b/test/test_gpu_utils.cpp
@@ -25,6 +25,44 @@
 
 namespace nvfuser {
 
+int myFavoriteFunction(int a, int b) {
+  DEBUG_PRINT_SCOPE(a, b);
+  if (a > 0) {
+    RECORD_AND_RETURN(a + b);
+  } else {
+    RECORD_AND_RETURN(a - b);
+  }
+}
+
+TEST_F(NVFuserTest, FunctionTrace) {
+  {
+    std::stringstream ss;
+    DebugStreamGuard g(ss);
+    DebugDumpOptionsGuard gg;
+    gg.getCurOptions().set(DebugDumpOption::FunctionTrace, {".*Favorite.*"});
+    EXPECT_EQ(myFavoriteFunction(1, 2), 3);
+    EXPECT_THAT(
+        ss.str(), ::testing::HasSubstr("Entering myFavoriteFunction(1, 2)"));
+    EXPECT_THAT(
+        ss.str(),
+        ::testing::HasSubstr("Leaving myFavoriteFunction returning 3 at "));
+    EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_gpu_utils.cpp:31"));
+  }
+  {
+    std::stringstream ss;
+    DebugStreamGuard g(ss);
+    DebugDumpOptionsGuard gg;
+    gg.getCurOptions().set(DebugDumpOption::FunctionTrace, {".*Favorite.*"});
+    EXPECT_EQ(myFavoriteFunction(-1, 2), -3);
+    EXPECT_THAT(
+        ss.str(), ::testing::HasSubstr("Entering myFavoriteFunction(-1, 2)"));
+    EXPECT_THAT(
+        ss.str(),
+        ::testing::HasSubstr("Leaving myFavoriteFunction returning -3 at "));
+    EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_gpu_utils.cpp:33"));
+  }
+}
+
 TEST_F(NVFuserTest, FusionSplitDims_CUDA) {
   Fusion fusion;
   FusionGuard fg(&fusion);


### PR DESCRIPTION
This PR adds a new debug dump option `NVFUSER_DUMP="ftrace(regex)"`, which will print the call traces of functions satisfying the provided `regex`. In order for this to work, the function needs to be updated by putting a `DEBUG_PRINT_SCOPE(arguments...)` at the top of the function, and change the `return XXX;` into `RECORD_AND_RETURN(XXX);`. For this PR, I am adding this feature only for conditions in predicate elimination, see example output here:

<details>

<summary>example output</summary>

```C++
❯ NVFUSER_DUMP="ftrace(predicate.*)" ./bin/nvfuser_tests --gtest_filter=*PredicateEliminationTest.1*
Running main() from /home/gaoxiang/Fuser3/third_party/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *PredicateEliminationTest.1*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from PredicateEliminationTest
[ RUN      ] PredicateEliminationTest.1
Entering predicateSharedMemAccess(T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   = T0_g[ iS10{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS11{32} ]
   + double(1);
)
Leaving predicateSharedMemAccess returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:388
Entering predicateIntDiv(T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   = T0_g[ iS10{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS11{32} ]
   + double(1);
)
Leaving predicateIntDiv returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:266
Entering predicateMisalignedVectorize(T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   = T0_g[ iS10{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS11{32} ]
   + double(1);
)
Leaving predicateMisalignedVectorize returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:341
Entering predicateShift(T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   = T0_g[ iS10{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS11{32} ]
   + double(1);
)
Leaving predicateShift returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:349
Entering predicateProducerConsumerPair(T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   = T0_g[ iS10{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS11{32} ]
   + double(1);
)
Leaving predicateProducerConsumerPair returning 1 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:364
Entering predicateSharedMemAccess(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateSharedMemAccess returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:388
Entering predicateIntDiv(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateIntDiv returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:266
Entering predicateMisalignedVectorize(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateMisalignedVectorize returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:341
Entering predicateShift(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateShift returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:349
Entering predicateProducerConsumerPair(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateProducerConsumerPair returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:368
Entering predicateNonDivisibleRootDomains(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateNonDivisibleRootDomains returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:572
Entering predicateNonDivisibleSplit(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateNonDivisibleSplit returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:588
Entering predicateExpandReduce(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateExpandReduce returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:280
Entering predicateRNGOp(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateRNGOp returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:257
Entering predicateSharedMemAccess(T3_g[ iS4{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS5{32} ] produce_pos( 1 )
   = T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   + double(3);
)
Leaving predicateSharedMemAccess returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:388
Entering predicateIntDiv(T3_g[ iS4{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS5{32} ] produce_pos( 1 )
   = T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   + double(3);
)
Leaving predicateIntDiv returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:266
Entering predicateMisalignedVectorize(T3_g[ iS4{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS5{32} ] produce_pos( 1 )
   = T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   + double(3);
)
Leaving predicateMisalignedVectorize returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:341
Entering predicateShift(T3_g[ iS4{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS5{32} ] produce_pos( 1 )
   = T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   + double(3);
)
Leaving predicateShift returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:349
Entering predicateProducerConsumerPair(T3_g[ iS4{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS5{32} ] produce_pos( 1 )
   = T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iUS7{32} ] ca_pos( 1 ) produce_pos( 1 )
   + double(3);
)
Leaving predicateProducerConsumerPair returning 1 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:364
Entering predicateSharedMemAccess(T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   = T0_g[ iS10{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS11{32} ]
   + double(1);
)
Leaving predicateSharedMemAccess returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:388
Entering predicateIntDiv(T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   = T0_g[ iS10{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS11{32} ]
   + double(1);
)
Leaving predicateIntDiv returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:266
Entering predicateMisalignedVectorize(T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   = T0_g[ iS10{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS11{32} ]
   + double(1);
)
Leaving predicateMisalignedVectorize returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:341
Entering predicateShift(T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   = T0_g[ iS10{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS11{32} ]
   + double(1);
)
Leaving predicateShift returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:349
Entering predicateProducerConsumerPair(T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   = T0_g[ iS10{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS11{32} ]
   + double(1);
)
Leaving predicateProducerConsumerPair returning 1 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:364
Entering predicateSharedMemAccess(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS12{( ceilDiv(32, 5) )}, iS13{5} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateSharedMemAccess returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:388
Entering predicateIntDiv(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS12{( ceilDiv(32, 5) )}, iS13{5} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateIntDiv returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:266
Entering predicateMisalignedVectorize(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS12{( ceilDiv(32, 5) )}, iS13{5} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateMisalignedVectorize returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:341
Entering predicateShift(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS12{( ceilDiv(32, 5) )}, iS13{5} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateShift returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:349
Entering predicateProducerConsumerPair(T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS12{( ceilDiv(32, 5) )}, iS13{5} ] ca_pos( 1 ) produce_pos( 1 )
   = T1_l[ iS8{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS9{32} ] ca_pos( 1 )
   + double(2);
)
Leaving predicateProducerConsumerPair returning 1 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:364
Entering predicateSharedMemAccess(T3_g[ iS4{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS5{32} ] produce_pos( 1 )
   = T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS12{( ceilDiv(32, 5) )}, iS13{5} ] ca_pos( 1 ) produce_pos( 1 )
   + double(3);
)
Leaving predicateSharedMemAccess returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:388
Entering predicateIntDiv(T3_g[ iS4{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS5{32} ] produce_pos( 1 )
   = T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS12{( ceilDiv(32, 5) )}, iS13{5} ] ca_pos( 1 ) produce_pos( 1 )
   + double(3);
)
Leaving predicateIntDiv returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:266
Entering predicateMisalignedVectorize(T3_g[ iS4{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS5{32} ] produce_pos( 1 )
   = T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS12{( ceilDiv(32, 5) )}, iS13{5} ] ca_pos( 1 ) produce_pos( 1 )
   + double(3);
)
Leaving predicateMisalignedVectorize returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:341
Entering predicateShift(T3_g[ iS4{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS5{32} ] produce_pos( 1 )
   = T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS12{( ceilDiv(32, 5) )}, iS13{5} ] ca_pos( 1 ) produce_pos( 1 )
   + double(3);
)
Leaving predicateShift returning 0 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:349
Entering predicateProducerConsumerPair(T3_g[ iS4{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS5{32} ] produce_pos( 1 )
   = T2_l[ iS6{( ceilDiv(( (( (( getMetaData(T0) )).logical_size ))[0] ), 32) )}, iS12{( ceilDiv(32, 5) )}, iS13{5} ] ca_pos( 1 ) produce_pos( 1 )
   + double(3);
)
Leaving predicateProducerConsumerPair returning 1 at /home/gaoxiang/Fuser3/csrc/device_lower/analysis/predicate_elimination.cpp:364
[       OK ] PredicateEliminationTest.1 (41 ms)
[----------] 1 test from PredicateEliminationTest (41 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (41 ms total)
[  PASSED  ] 1 test.
```
</details>

In the future, if a nvFuser developer feels that this feature is useful for some function, they are encouraged to add this feature to that function and leave the changed function in their PR, instead of reverting that change. This allows us to incrementally enable this feature in our entire codebase, so that future debugging can use `ftrace(regex)` a lot.