### PR TITLE
MultiDeviceExecutor: use at::Tensor instead of c10::IValue

### DIFF
--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -90,7 +90,7 @@ class MultiDeviceExecutor {
       MultiDeviceExecutorParams params = MultiDeviceExecutorParams());
 
   // Run the fusion on several devices with the given global inputs
-  std::vector<at::Tensor> runWithInput(const std::vector<c10::IValue>& inputs);
+  std::vector<at::Tensor> runWithInput(const at::ArrayRef<c10::IValue>& inputs);
 
   // Returns the Communicator
   Communicator* comm() const {
@@ -117,7 +117,7 @@ class MultiDeviceExecutor {
   void postCommunication(SegmentedGroup* group);
 
   // Stores concrete computed values,
-  std::unordered_map<Val*, c10::IValue> val_to_IValue_;
+  std::unordered_map<Val*, at::Tensor> val_to_IValue_;
 
   // holds the Communicator to be used for execution
   Communicator& comm_;


### PR DESCRIPTION
Change suggested by @wujingyue in https://github.com/NVIDIA/Fuser/pull/1900#discussion_r1523675221

I have one doubt though: for now we don't support Scalars input, but once we do, will it be ok with this patch?
in general, what is the benefit of using IValue over Tensor?