### PR TITLE
Skip compiling fusion segments when using expression evaluator

### DIFF
--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -890,9 +890,7 @@ class PredicateChcker : public IterVisitor {
 } // namespace
 
 PredicateElimination::PredicateElimination(Fusion* fusion) {
-  // To avoid errors in analysis when using ATen evaluation for matmul, only use
-  // outputs that require codegen. See PR # 1775 and Issue #1812
-  traverseTo(lower_utils::getFusionOutputsRequiringCodegen(fusion));
+  traverseTo(fusion->outputs());
 }
 
 bool PredicateElimination::needsPredicate(Expr* expr) const {

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -1029,12 +1029,7 @@ void validateSizeMemoryOp(LoadStoreOp* ldst) {
 //! Validate data format and GPU arch compatibility of scheduled
 //!  mma operators on the fusion.
 void validateMma(Fusion* fusion) {
-  // To avoid errors in analysis when using ATen evaluation for matmul, only
-  // validate expressions that require codegen. See PR # 1775 and Issue #1812
-  std::vector<Val*> outs_requiring_codegen =
-      lower_utils::getFusionOutputsRequiringCodegen(fusion);
-  auto exprs = StmtSort::getExprsBetween(
-      GpuLower::current()->allKnownVals(), outs_requiring_codegen);
+  auto exprs = StmtSort::getExprs(fusion);
 
   for (auto expr : exprs) {
     if (auto mma = dynamic_cast<MmaOp*>(expr)) {

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -264,8 +264,12 @@ void FusionExecutor::compileFusion(
       return fusion->getOutputAlias(out).type == AllocationType::Evaluate;
     });
   
+  // Set fusion_ if skipping compilation.
+  std::unique_ptr<Fusion> fusion_copy = std::make_unique<Fusion>();
+  IrCloner cloner = Fusion::copy(fusion, fusion_copy.get());
   if (skip_compilation) {
-    // Set fusion_ here. What is the right way?
+    fusion_ = fusion_copy.get();
+    // fusion_ = std::move(fusion);
     return;
   }
 
@@ -1751,6 +1755,7 @@ std::vector<at::Tensor> FusionExecutor::runAtenFusion(
 
   return outputs;
 }
+
 std::vector<at::Tensor> FusionExecutor::runFusion(
     KernelArgumentHolder& args,
     const LaunchParams& launch_constraints,

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -264,7 +264,7 @@ void FusionExecutor::compileFusion(
     });
   
   if (skip_compilation) {
-    fusion_ = std::make_unique<Fusion>(std::move(*fusion));
+    fusion_ = std::make_unique<Fusion>(*fusion);
     return;
   }
 

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -264,12 +264,9 @@ void FusionExecutor::compileFusion(
       return fusion->getOutputAlias(out).type == AllocationType::Evaluate;
     });
   
-  // Set fusion_ if skipping compilation.
-  std::unique_ptr<Fusion> fusion_copy = std::make_unique<Fusion>();
-  IrCloner cloner = Fusion::copy(fusion, fusion_copy.get());
   if (skip_compilation) {
-    fusion_ = fusion_copy.get();
-    // fusion_ = std::move(fusion);
+    fusion_ptr_ = std::make_unique<Fusion>(std::move(*fusion));
+    fusion_ = fusion_ptr_.get();
     return;
   }
 

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1649,7 +1649,8 @@ void FusionExecutor::recompileKernel(
 
 int64_t FusionExecutor::getAvailableDynamicSmemSize() {
   NVF_ERROR(
-      hasCompiledKernel(), "Cannot get dynamic smem size unless kernel is compiled");
+      hasCompiledKernel(),
+      "Cannot get dynamic smem size unless kernel is compiled");
   if (!available_dynamic_smem_size_.has_value()) {
     int size = 0;
     NVFUSER_CUDA_SAFE_CALL(cuFuncGetAttribute(
@@ -1663,7 +1664,8 @@ int64_t FusionExecutor::getAvailableDynamicSmemSize() {
 
 int64_t FusionExecutor::getStaticSmemSize() {
   NVF_ERROR(
-      hasCompiledKernel(), "Cannot get static smem size unless kernel is compiled");
+      hasCompiledKernel(),
+      "Cannot get static smem size unless kernel is compiled");
   if (!static_smem_size_.has_value()) {
     int size = 0;
     // Is this really a costly operation worth caching?
@@ -1704,7 +1706,8 @@ void FusionExecutor::validateDynamicSmemSize(int64_t dynamic_smem_size) {
 int64_t FusionExecutor::ensureAvailableDynamicSmemSize(
     int64_t dynamic_smem_size) {
   NVF_ERROR(
-      hasCompiledKernel(), "Cannot set dynamic smem size unless kernel is compiled");
+      hasCompiledKernel(),
+      "Cannot set dynamic smem size unless kernel is compiled");
   if (dynamic_smem_size > getAvailableDynamicSmemSize()) {
     validateDynamicSmemSize(dynamic_smem_size);
     NVFUSER_CUDA_SAFE_CALL(cuFuncSetAttribute(
@@ -2338,7 +2341,7 @@ void FusionExecutor::deserialize(
   bool is_expr_eval = std::all_of(
       fusion->outputs().begin(), fusion->outputs().end(), [&fusion](Val* out) {
         return fusion->getOutputAlias(out).type == AllocationType::Evaluate;
-  });
+      });
   if (is_expr_eval) {
     fusion_ = std::make_unique<Fusion>(*fusion);
     NVF_ERROR(!hasCompiledKernel(), "Failed to deserialize FusionExecutor");
@@ -2403,9 +2406,7 @@ void FusionExecutor::deserialize(
   compiled_kernel_ = executor_utils::getCompiledKernel(
       buffer->compiled_kernel(), compile_params);
 
-  NVF_ERROR(
-      hasCompiledKernel() && !isExprEval(),
-      "Failed to deserialize FusionExecutor");
+  NVF_ERROR(hasCompiledKernel(), "Failed to deserialize FusionExecutor");
 }
 
 FusionExecutor::ExecutorEntry FusionExecutor::deserialize(

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -257,12 +257,10 @@ void FusionExecutor::compileFusion(
       !fusion->outputs().empty(), "No output found for this kernel, aborting.");
 
   bool skip_compilation = std::all_of(
-    fusion->outputs().begin(),
-    fusion->outputs().end(),
-    [&fusion](Val* out) {
-      return fusion->getOutputAlias(out).type == AllocationType::Evaluate;
-    });
-  
+      fusion->outputs().begin(), fusion->outputs().end(), [&fusion](Val* out) {
+        return fusion->getOutputAlias(out).type == AllocationType::Evaluate;
+      });
+
   if (skip_compilation) {
     fusion_ = std::make_unique<Fusion>(*fusion);
     return;
@@ -1724,14 +1722,14 @@ void FusionExecutor::resetCompiledKernelProperties() {
 }
 
 std::vector<at::Tensor> FusionExecutor::evaluateFusionOutputs(
-  KernelArgumentHolder& args,
-  std::vector<at::Tensor> outputs,
-  ExpressionEvaluator& expr_eval) {
-  
+    KernelArgumentHolder& args,
+    std::vector<at::Tensor> outputs,
+    ExpressionEvaluator& expr_eval) {
   // TODO: Add relevant profiling code.
   if (outputs.empty()) {
-    for (const auto& out_val: fusion()->outputs()) {
-      auto out_tensor = expr_eval.evaluate(out_val->as<TensorView>()).as<at::Tensor>();
+    for (const auto& out_val : fusion()->outputs()) {
+      auto out_tensor =
+          expr_eval.evaluate(out_val->as<TensorView>()).as<at::Tensor>();
       outputs.emplace_back(out_tensor);
     }
   }
@@ -1745,13 +1743,13 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     CompileParams compile_params,
     std::vector<at::Tensor> outputs) {
   FUSER_PERF_SCOPE("FusionExecutor::runFusion");
-  
+
   NVF_ERROR(
-        outputs.empty() || (outputs.size() == fusion()->outputs().size()),
-        __func__,
-        " provided number of outputs does not match fusion output");
-  
-  // Bind fusion inputs 
+      outputs.empty() || (outputs.size() == fusion()->outputs().size()),
+      __func__,
+      " provided number of outputs does not match fusion output");
+
+  // Bind fusion inputs
   ExpressionEvaluator expr_eval;
   const auto& inputs = fusion()->inputs();
   for (const auto i : c10::irange(inputs.size())) {

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -215,7 +215,6 @@ void FusionExecutor::debugCompileFusionFromStr(
   lowered_ = std::make_unique<GpuLower>(fusion);
   lowered_->run();
   const auto kernel = lowered_->kernel();
-  // fusion_ = lowered_->kernel();
   createKernelId(
       ScheduleHeuristic::None, fusion_id, concrete_id, runtime_id, group_id);
   setUsedTVs();
@@ -265,7 +264,7 @@ void FusionExecutor::compileFusion(
     });
   
   if (skip_compilation) {
-    fusion_ptr_ = std::make_unique<Fusion>(std::move(*fusion));
+    fusion_ = std::make_unique<Fusion>(std::move(*fusion));
     return;
   }
 
@@ -351,7 +350,6 @@ void FusionExecutor::compileFusion(
   for (const auto& hook : post_lowering_hooks_) {
     hook(kernel);
   }
-  // fusion_ = lowered_->kernel()->as<Fusion>();
   createKernelId(heuristic, fusion_id, concrete_id, runtime_id, group_id);
   setUsedTVs();
 
@@ -1725,21 +1723,22 @@ void FusionExecutor::resetCompiledKernelProperties() {
   static_smem_size_.reset();
 }
 
-std::vector<at::Tensor> FusionExecutor::runAtenFusion(
+std::vector<at::Tensor> FusionExecutor::evaluateFusionOutputs(
   KernelArgumentHolder& args,
   std::vector<at::Tensor> outputs) {
-  ExpressionEvaluator expr_eval;
+  ExpressionEvaluator ee;
 
-  // TODO: Add profiling code.
+  // TODO: Add relevant profiling code.
   const auto& inputs = fusion()->inputs();
   for (const auto i : c10::irange(inputs.size())) {
-    expr_eval.bind(inputs[i], *args[i]);
+    ee.bind(inputs[i], *args[i]);
   }
 
-  // TODO: Replace with allocateOutputs.
   if (outputs.empty()) {
-    auto output_info = getOutputBufferInfo(args, expr_eval, PrimDataType::Int, fusion());
-    outputs = allocateOutputs(fusion(), output_info, options_.device, expr_eval);
+    for (const auto& out_val: fusion()->outputs()) {
+      auto out_tensor = ee.evaluate(out_val->as<TensorView>()).as<at::Tensor>();
+      outputs.emplace_back(out_tensor);
+    }
   } else {
     NVF_ERROR(
         outputs.size() == fusion()->outputs().size(),
@@ -1758,8 +1757,8 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     std::vector<at::Tensor> outputs) {
   FUSER_PERF_SCOPE("FusionExecutor::runFusion");
   
-  if (fusion_ptr_.get()) {
-    return runAtenFusion(args, outputs);
+  if (isCompilationSkipped()) {
+    return evaluateFusionOutputs(args, outputs);
   }
 
   NVF_ERROR(isCompiled());
@@ -2376,7 +2375,6 @@ void FusionExecutor::deserialize(
   lowered_->run();
 
   // Replace integers that are tensor sizes by named scalars like "T0.size[0]"
-  // fusion_ = lowered_->kernel()->as<Fusion>();
   createKernelId(
       heuristic,
       buffer->fusion_id(),

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1679,7 +1679,7 @@ int64_t FusionExecutor::getStaticSmemSize() {
 void FusionExecutor::validateDynamicSmemSize(int64_t dynamic_smem_size) {
   // If specified, check that dynamic smem size matches what the scheduler
   // expects
-  int64_t expected_dynamic_smem_size = fusion_->expectedDynamicSmemBytes();
+  int64_t expected_dynamic_smem_size = fusion()->expectedDynamicSmemBytes();
   if (expected_dynamic_smem_size >= 0) {
     NVF_ERROR(
         dynamic_smem_size == expected_dynamic_smem_size,

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -2178,8 +2178,15 @@ flatbuffers::Offset<serde::FusionExecutor> FusionExecutor::serialize(
     executor_entry_lookup_values_fb.push_back(serialize(builder, value));
   }
 
+  // When compilation is skipped, avoid serializing cubin because it doesn't
+  // exist. The remaining fields are also not necessary in this case.
+  if (isCompilationSkipped()) {
+    return serde::CreateFusionExecutorDirect(builder, isCompilationSkipped());
+  }
+
   return serde::CreateFusionExecutorDirect(
       builder,
+      isCompilationSkipped(),
       device_smem_limit_,
       block_size_high_water_mark_,
       maxrregcount_high_water_mark_,
@@ -2325,6 +2332,15 @@ void FusionExecutor::deserialize(
   // See table definition for FusionExecutor in serde/fusion_cache.fbs
 
   NVF_ERROR(buffer != nullptr, "serde::FusionExecutor is nullptr.");
+
+  // TODO Should we set fusion_id, concrete_id, runtime_id, and group_id when we
+  // skip compilation?
+  if (buffer->is_compilation_skipped()) {
+    fusion_ = std::make_unique<Fusion>(*fusion);
+    NVF_ERROR(!isCompiled(), "Failed to deserialize FusionExecutor");
+    return;
+  }
+
   NVF_ERROR(
       fusion_id == buffer->fusion_id(),
       "Expected given fusion_id to match serde fusion_id.");
@@ -2383,7 +2399,9 @@ void FusionExecutor::deserialize(
   compiled_kernel_ = executor_utils::getCompiledKernel(
       buffer->compiled_kernel(), compile_params);
 
-  NVF_ERROR(isCompiled(), "Failed to deserialize FusionExecutor");
+  NVF_ERROR(
+      isCompiled() && !isCompilationSkipped(),
+      "Failed to deserialize FusionExecutor");
 }
 
 FusionExecutor::ExecutorEntry FusionExecutor::deserialize(

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1744,6 +1744,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     std::vector<at::Tensor> outputs) {
   FUSER_PERF_SCOPE("FusionExecutor::runFusion");
 
+  NVF_ERROR(isCompiled() || isCompilationSkipped());
   NVF_ERROR(
       outputs.empty() || (outputs.size() == fusion()->outputs().size()),
       __func__,

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -412,7 +412,7 @@ class FusionExecutor : public NonCopyable {
   //! Check if compilation was skipped (fusion segment marked for EE).
   bool isCompilationSkipped() const{
     if (!fusion_) {
-      NVF_ERROR(!lowered_, "Expected a lowered kernel to be initialized.");
+      NVF_ERROR(lowered_, "Expected a lowered kernel to be initialized.");
       return false;
     }
     NVF_ERROR(!lowered_, "Expected GPU lowering to be skipped.");

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -411,9 +411,7 @@ class FusionExecutor : public NonCopyable {
 
   //! Check if compilation was skipped (fusion segment marked for EE).
   bool isCompilationSkipped() const {
-    if (fusion_ != nullptr) {
-      NVF_ERROR(!lowered_, "Expected GPU lowering to be skipped.");
-    }
+    NVF_ERROR(fusion_ == nullptr || !lowered_, "Expected GPU lowering to be skipped.");
     return fusion_ != nullptr;
   }
 

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -206,7 +206,7 @@ class FusionExecutor : public NonCopyable {
   }
 
   Fusion* fusion() const {
-    NVF_ERROR(lowered_ || fusion_);
+    NVF_ERROR(lowered_ ^ fusion_);
     return lowered_ ? lowered_->kernel()->as<Fusion>() : fusion_.get();
   }
 

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -123,9 +123,11 @@ class FusionExecutor : public NonCopyable {
         concrete_id);
   }
 
-  std::vector<at::Tensor> runAtenFusion(
+  //! Computes fusion outputs through expression evaluator.
+  std::vector<at::Tensor> evaluateFusionOutputs(
     KernelArgumentHolder& args,
-    std::vector<at::Tensor> outputs);
+    std::vector<at::Tensor> outputs,
+    ExpressionEvaluator& expr_eval);
 
   NVF_API std::vector<at::Tensor> runFusion(
       KernelArgumentHolder& args,
@@ -407,6 +409,16 @@ class FusionExecutor : public NonCopyable {
       int64_t runtime_id,
       int64_t group_id);
 
+  //! Check if compilation was skipped (fusion segment marked for EE).
+  bool isCompilationSkipped() {
+    if (!fusion_) {
+      NVF_ERROR(!lowered_, "Expected a lowered kernel to be initialized.");
+      return false;
+    }
+    NVF_ERROR(!lowered_, "Expected GPU lowering to be skipped.");
+    return true;
+  }
+
  private:
   LaunchParams computeLaunchParams(
       const LaunchParams& launch_constraints,
@@ -498,15 +510,6 @@ class FusionExecutor : public NonCopyable {
 
   //! Clear the cached properties of the compiled kernel
   void resetCompiledKernelProperties();
-
-  bool isCompilationSkipped() {
-    if (!fusion_) {
-      NVF_ERROR(!lowered_, "Expected a lowered kernel to be initialized.");
-      return false;
-    }
-    NVF_ERROR(!lowered_, "Expected GPU lowering to be skipped.");
-    return true;
-  }
 
  private:
   CompileOptions options_;

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -123,6 +123,10 @@ class FusionExecutor : public NonCopyable {
         concrete_id);
   }
 
+  std::vector<at::Tensor> runAtenFusion(
+    KernelArgumentHolder& args,
+    std::vector<at::Tensor> outputs);
+
   NVF_API std::vector<at::Tensor> runFusion(
       KernelArgumentHolder& args,
       const LaunchParams& launch_constraints = LaunchParams(),

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -173,8 +173,12 @@ class FusionExecutor : public NonCopyable {
   // Function to query whether compilation was attempted for a `FusionExecutor`
   bool isCompiled() const {
     // Check atmost one of fusion_ and lowered_ is null.
-    NVF_ERROR(fusion_  == nullptr || !lowered_, "Expected GPU lowering to be skipped.");
-    NVF_ERROR(lowered_ == nullptr || !fusion_, "fusion_ should only be initializaed when using expression evaluator.");
+    NVF_ERROR(
+        fusion_ == nullptr || !lowered_,
+        "Expected GPU lowering to be skipped.");
+    NVF_ERROR(
+        lowered_ == nullptr || !fusion_,
+        "fusion_ should only be initializaed when using expression evaluator.");
     return fusion_ || lowered_;
   };
 
@@ -183,7 +187,9 @@ class FusionExecutor : public NonCopyable {
   bool hasCompiledKernel() const {
     if (compiled_kernel_ != nullptr) {
       NVF_ERROR(compiled_kernel_->function != nullptr);
-      NVF_ERROR(!fusion_, "fusion_ should only be initializaed when using expression evaluator.");
+      NVF_ERROR(
+          !fusion_,
+          "fusion_ should only be initializaed when using expression evaluator.");
     }
     return validKernelId() && lowered_ && compiled_kernel_ != nullptr;
   };

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -410,7 +410,7 @@ class FusionExecutor : public NonCopyable {
       int64_t group_id);
 
   //! Check if compilation was skipped (fusion segment marked for EE).
-  bool isCompilationSkipped() {
+  bool isCompilationSkipped() const{
     if (!fusion_) {
       NVF_ERROR(!lowered_, "Expected a lowered kernel to be initialized.");
       return false;

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -172,13 +172,8 @@ class FusionExecutor : public NonCopyable {
 
   // Function to query whether compilation was attempted for a `FusionExecutor`
   bool isCompiled() const {
-    // Check atmost one of fusion_ and lowered_ is null.
-    NVF_ERROR(
-        fusion_ == nullptr || !lowered_,
-        "Expected GPU lowering to be skipped.");
-    NVF_ERROR(
-        lowered_ == nullptr || !fusion_,
-        "fusion_ should only be initializaed when using expression evaluator.");
+    // Check at most one of fusion_ and lowered_ is null.
+    NVF_ERROR(!(fusion_ && lowered_));
     return fusion_ || lowered_;
   };
 
@@ -189,7 +184,7 @@ class FusionExecutor : public NonCopyable {
       NVF_ERROR(compiled_kernel_->function != nullptr);
       NVF_ERROR(
           !fusion_,
-          "fusion_ should only be initializaed when using expression evaluator.");
+          "fusion_ should only be initialized when using expression evaluator.");
     }
     return validKernelId() && lowered_ && compiled_kernel_ != nullptr;
   };
@@ -221,7 +216,9 @@ class FusionExecutor : public NonCopyable {
   }
 
   Fusion* fusion() const {
-    NVF_ERROR((lowered_ && !fusion_) || (!lowered_ && fusion_));
+    NVF_ERROR(
+        (lowered_ && !fusion_) || (!lowered_ && fusion_),
+        "Expected one and only one of fusion_ and lowered_ to be initialized.");
     return lowered_ ? lowered_->kernel()->as<Fusion>() : fusion_.get();
   }
 

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -170,9 +170,14 @@ class FusionExecutor : public NonCopyable {
     post_lowering_hooks_.push_back(std::move(hook));
   }
 
+  // Function to query whether compilation was attempted for a `FusionExecutor`
+  bool isCompiled() const {
+    return hasCompiledKernel() || isCompilationSkipped();
+  };
+
   // function to query whether a `FusionExecutor` has a compiled kernel to
   // execute
-  bool isCompiled() const {
+  bool hasCompiledKernel() const {
     if (compiled_kernel_ != nullptr) {
       NVF_ERROR(compiled_kernel_->function != nullptr);
     }
@@ -411,7 +416,9 @@ class FusionExecutor : public NonCopyable {
 
   //! Check if compilation was skipped (fusion segment marked for EE).
   bool isCompilationSkipped() const {
-    NVF_ERROR(fusion_ == nullptr || !lowered_, "Expected GPU lowering to be skipped.");
+    NVF_ERROR(
+        fusion_ == nullptr || !lowered_,
+        "Expected GPU lowering to be skipped.");
     return fusion_ != nullptr;
   }
 

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -544,6 +544,7 @@ class FusionExecutor : public NonCopyable {
   std::unique_ptr<GpuLower> lowered_;
   // Copy of lowered_->kernel()
   Fusion* fusion_ = nullptr;
+  std::unique_ptr<Fusion> fusion_ptr_;
 
   // Track the block size this kernel was compiled with. If the block size
   // increases, recompile to adjust maxregister count.

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -206,7 +206,7 @@ class FusionExecutor : public NonCopyable {
   }
 
   Fusion* fusion() const {
-    NVF_ERROR(lowered_ ^ fusion_);
+    NVF_ERROR((lowered_ && !fusion_) || (!lowered_ && fusion_));
     return lowered_ ? lowered_->kernel()->as<Fusion>() : fusion_.get();
   }
 

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -204,8 +204,8 @@ class FusionExecutor : public NonCopyable {
   }
 
   Fusion* fusion() const {
-    NVF_ERROR(lowered_ || fusion_ptr_);
-    return lowered_? lowered_->kernel()->as<Fusion>() : fusion_ptr_.get();
+    NVF_ERROR(lowered_ || fusion_);
+    return lowered_? lowered_->kernel()->as<Fusion>() : fusion_.get();
   }
 
   const ThreadPredicateMap& threadPredMap() const {
@@ -499,6 +499,15 @@ class FusionExecutor : public NonCopyable {
   //! Clear the cached properties of the compiled kernel
   void resetCompiledKernelProperties();
 
+  bool isCompilationSkipped() {
+    if (!fusion_) {
+      NVF_ERROR(!lowered_, "Expected a lowered kernel to be initialized.");
+      return false;
+    }
+    NVF_ERROR(!lowered_, "Expected GPU lowering to be skipped.");
+    return true;
+  }
+
  private:
   CompileOptions options_;
 
@@ -549,7 +558,7 @@ class FusionExecutor : public NonCopyable {
   std::unique_ptr<GpuLower> lowered_;
 
   // Initialized for non-compiled fusions
-  std::unique_ptr<Fusion> fusion_ptr_;
+  std::unique_ptr<Fusion> fusion_;
 
   // Track the block size this kernel was compiled with. If the block size
   // increases, recompile to adjust maxregister count.

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -411,12 +411,10 @@ class FusionExecutor : public NonCopyable {
 
   //! Check if compilation was skipped (fusion segment marked for EE).
   bool isCompilationSkipped() const {
-    if (!fusion_) {
-      NVF_ERROR(lowered_, "Expected a lowered kernel to be initialized.");
-      return false;
+    if (fusion_ != nullptr) {
+      NVF_ERROR(!lowered_, "Expected GPU lowering to be skipped.");
     }
-    NVF_ERROR(!lowered_, "Expected GPU lowering to be skipped.");
-    return true;
+    return fusion_ != nullptr;
   }
 
  private:

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -203,6 +203,11 @@ class FusionExecutor : public NonCopyable {
     return lowered_->kernel();
   }
 
+  Fusion* fusion() const {
+    NVF_ERROR(lowered_ || fusion_ptr_);
+    return lowered_? lowered_->kernel()->as<Fusion>() : fusion_ptr_.get();
+  }
+
   const ThreadPredicateMap& threadPredMap() const {
     return lowered_->threadPredMap();
   }
@@ -542,8 +547,8 @@ class FusionExecutor : public NonCopyable {
   std::string kernel_id_;
 
   std::unique_ptr<GpuLower> lowered_;
-  // Copy of lowered_->kernel()
-  Fusion* fusion_ = nullptr;
+
+  // Initialized for non-compiled fusions
   std::unique_ptr<Fusion> fusion_ptr_;
 
   // Track the block size this kernel was compiled with. If the block size

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -125,9 +125,9 @@ class FusionExecutor : public NonCopyable {
 
   //! Computes fusion outputs through expression evaluator.
   std::vector<at::Tensor> evaluateFusionOutputs(
-    KernelArgumentHolder& args,
-    std::vector<at::Tensor> outputs,
-    ExpressionEvaluator& expr_eval);
+      KernelArgumentHolder& args,
+      std::vector<at::Tensor> outputs,
+      ExpressionEvaluator& expr_eval);
 
   NVF_API std::vector<at::Tensor> runFusion(
       KernelArgumentHolder& args,
@@ -207,7 +207,7 @@ class FusionExecutor : public NonCopyable {
 
   Fusion* fusion() const {
     NVF_ERROR(lowered_ || fusion_);
-    return lowered_? lowered_->kernel()->as<Fusion>() : fusion_.get();
+    return lowered_ ? lowered_->kernel()->as<Fusion>() : fusion_.get();
   }
 
   const ThreadPredicateMap& threadPredMap() const {
@@ -410,7 +410,7 @@ class FusionExecutor : public NonCopyable {
       int64_t group_id);
 
   //! Check if compilation was skipped (fusion segment marked for EE).
-  bool isCompilationSkipped() const{
+  bool isCompilationSkipped() const {
     if (!fusion_) {
       NVF_ERROR(lowered_, "Expected a lowered kernel to be initialized.");
       return false;

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -1215,7 +1215,7 @@ std::vector<at::Tensor> FusionKernelRuntime::runKernelWithInput(
   kernel_time_ms_ += executor.kernelTimeMs();
 
   // Print relevant information all at once for easy debuging of perf
-  if (isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose)) {
+  if (isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose) && executor.isCompiled()) {
     debug() << "\nRun kernel:\n";
     if (sg) {
       auto local_fusion = segmented_fusion_->makeFusion(sg).second;

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -1394,7 +1394,7 @@ std::pair<LaunchParams, CompileParams> FusionKernelRuntime::getKernelConfig(
 
   // Check that the heuristics are matched, in the case of segmented fusion
   NVF_ERROR(!sg || scheduler_entry->heuristic() == sg->heuristic());
-  // NVF_ERROR(executors_.at(group_id).isCompiled());
+  NVF_ERROR(executors_.at(group_id).isCompiled() || executors_.at(group_id).isCompilationSkipped());
 
   return std::make_pair(
       scheduler_entry->params()->lparams, scheduler_entry->params()->cparams);

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -1216,7 +1216,7 @@ std::vector<at::Tensor> FusionKernelRuntime::runKernelWithInput(
 
   // Print relevant information all at once for easy debuging of perf
   if (isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose) &&
-      executor.isCompiled()) {
+      executor.hasCompiledKernel()) {
     debug() << "\nRun kernel:\n";
     if (sg) {
       auto local_fusion = segmented_fusion_->makeFusion(sg).second;
@@ -1395,9 +1395,6 @@ std::pair<LaunchParams, CompileParams> FusionKernelRuntime::getKernelConfig(
 
   // Check that the heuristics are matched, in the case of segmented fusion
   NVF_ERROR(!sg || scheduler_entry->heuristic() == sg->heuristic());
-  NVF_ERROR(
-      executors_.at(group_id).isCompiled() ||
-      executors_.at(group_id).isCompilationSkipped());
 
   return std::make_pair(
       scheduler_entry->params()->lparams, scheduler_entry->params()->cparams);

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -1394,7 +1394,7 @@ std::pair<LaunchParams, CompileParams> FusionKernelRuntime::getKernelConfig(
 
   // Check that the heuristics are matched, in the case of segmented fusion
   NVF_ERROR(!sg || scheduler_entry->heuristic() == sg->heuristic());
-  NVF_ERROR(executors_.at(group_id).isCompiled());
+  // NVF_ERROR(executors_.at(group_id).isCompiled());
 
   return std::make_pair(
       scheduler_entry->params()->lparams, scheduler_entry->params()->cparams);

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -1394,7 +1394,9 @@ std::pair<LaunchParams, CompileParams> FusionKernelRuntime::getKernelConfig(
 
   // Check that the heuristics are matched, in the case of segmented fusion
   NVF_ERROR(!sg || scheduler_entry->heuristic() == sg->heuristic());
-  NVF_ERROR(executors_.at(group_id).isCompiled() || executors_.at(group_id).isCompilationSkipped());
+  NVF_ERROR(
+      executors_.at(group_id).isCompiled() ||
+      executors_.at(group_id).isCompilationSkipped());
 
   return std::make_pair(
       scheduler_entry->params()->lparams, scheduler_entry->params()->cparams);

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -1215,7 +1215,8 @@ std::vector<at::Tensor> FusionKernelRuntime::runKernelWithInput(
   kernel_time_ms_ += executor.kernelTimeMs();
 
   // Print relevant information all at once for easy debuging of perf
-  if (isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose) && executor.isCompiled()) {
+  if (isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose) &&
+      executor.isCompiled()) {
     debug() << "\nRun kernel:\n";
     if (sg) {
       auto local_fusion = segmented_fusion_->makeFusion(sg).second;

--- a/csrc/kernel_cache.h
+++ b/csrc/kernel_cache.h
@@ -124,7 +124,7 @@ class FusionKernelRuntime {
     std::lock_guard<std::mutex> guard(mutex_);
     return std::all_of(
         executors_.begin(), executors_.end(), [](const auto& executor) {
-          return executor.isCompiled();
+          return executor.isCompiled() || executor.isCompilationSkipped();
         });
   }
 

--- a/csrc/kernel_cache.h
+++ b/csrc/kernel_cache.h
@@ -119,12 +119,12 @@ class FusionKernelRuntime {
     }
   }
 
-  //! query if we already have a compiled kernel for execution
+  //! query if we have already attempted compilation
   bool isCompiled() {
     std::lock_guard<std::mutex> guard(mutex_);
     return std::all_of(
         executors_.begin(), executors_.end(), [](const auto& executor) {
-          return executor.isCompiled() || executor.isCompilationSkipped();
+          return executor.isCompiled();
         });
   }
 

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -345,7 +345,6 @@ table CudaKernel {
 
 // Each Fusion Executor maps to a lowered and compiled kernel.
 table FusionExecutor {
-  is_compilation_skipped : bool;
   device_smem_limit: long;
   block_size_high_water_mark: long;
   maxrregcount_high_water_mark: long;

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -345,6 +345,7 @@ table CudaKernel {
 
 // Each Fusion Executor maps to a lowered and compiled kernel.
 table FusionExecutor {
+  is_compilation_skipped : bool;
   device_smem_limit: long;
   block_size_high_water_mark: long;
   maxrregcount_high_water_mark: long;

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -31,6 +31,8 @@
 #include <kernel_ir.h>
 #include <kernel_ir_dispatch.h>
 #include <ops/all_ops.h>
+#include <preseg_passes/mark_aliases_prepare.h>
+#include <preseg_passes/optimization_pass.h>
 #include <root_domain_map.h>
 #include <scheduler/all_schedulers.h>
 #include <scheduler/reduction_utils.h>
@@ -39,8 +41,6 @@
 #include <tests/cpp/validator.h>
 #include <transform_replay.h>
 #include <transform_rfactor.h>
-#include <preseg_passes/mark_aliases_prepare.h>
-#include <preseg_passes/optimization_pass.h>
 
 #include <torch/csrc/jit/api/function_impl.h>
 #include <torch/csrc/jit/codegen/cuda/interface.h>

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -39,6 +39,8 @@
 #include <tests/cpp/validator.h>
 #include <transform_replay.h>
 #include <transform_rfactor.h>
+#include <preseg_passes/mark_aliases_prepare.h>
+#include <preseg_passes/optimization_pass.h>
 
 #include <torch/csrc/jit/api/function_impl.h>
 #include <torch/csrc/jit/codegen/cuda/interface.h>
@@ -8050,7 +8052,7 @@ TEST_F(NVFuserTest, AvoidCachingSliceInput) {
   const auto num_segments = kernel_runtime->fusionSegments()->groups().size();
   NVF_CHECK(num_segments == 3, "Expect 3 segments, got: ", num_segments);
   for (const auto& fe : kernel_runtime->executors()) {
-    for (auto expr : fe.kernel()->exprs()) {
+    for (auto expr : fe.fusion()->exprs()) {
       if (expr->isA<SliceOp>()) {
         auto slice = expr->as<SliceOp>();
         NVF_CHECK(

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -31,8 +31,6 @@
 #include <kernel_ir.h>
 #include <kernel_ir_dispatch.h>
 #include <ops/all_ops.h>
-#include <preseg_passes/mark_aliases_prepare.h>
-#include <preseg_passes/optimization_pass.h>
 #include <root_domain_map.h>
 #include <scheduler/all_schedulers.h>
 #include <scheduler/reduction_utils.h>

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -349,11 +349,8 @@ TEST_F(MatmulATenEvaluationTest, Linear) {
   const std::vector<FusionExecutor>& executors =
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
-  // Verify that the io_alias_ set has the correct entry
-  kir::Kernel* kernel = executors.front().kernel();
-  EXPECT_EQ(
-      kernel->getOutputAlias(kernel->outputs()[0]).type,
-      AllocationType::Evaluate);
+  // Verify that fusion compilation was skipped.
+  EXPECT_TRUE(executors.front().isCompilationSkipped());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -391,11 +388,8 @@ TEST_F(MatmulATenEvaluationTest, LinearWithBias) {
   const std::vector<FusionExecutor>& executors =
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
-  // Verify that the io_alias_ set has the correct entry
-  kir::Kernel* kernel = executors.front().kernel();
-  EXPECT_EQ(
-      kernel->getOutputAlias(kernel->outputs()[0]).type,
-      AllocationType::Evaluate);
+  // Verify that fusion compilation was skipped.
+  EXPECT_TRUE(executors.front().isCompilationSkipped());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -61,7 +61,7 @@ TEST_F(MatmulATenEvaluationTest, MmaOpAndCast) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isCompilationSkipped());
+  EXPECT_TRUE(executors.front().isExprEval());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -97,7 +97,7 @@ TEST_F(MatmulATenEvaluationTest, TransposeMmaOpAndCast) {
       fec.getMostRecentKernelRuntime()->executors();
   ASSERT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isCompilationSkipped());
+  EXPECT_TRUE(executors.front().isExprEval());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -131,7 +131,7 @@ TEST_F(MatmulATenEvaluationTest, MulSumAndCast) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isCompilationSkipped());
+  EXPECT_TRUE(executors.front().isExprEval());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -171,7 +171,7 @@ TEST_F(MatmulATenEvaluationTest, MatmulWithBias) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isCompilationSkipped());
+  EXPECT_TRUE(executors.front().isExprEval());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -220,7 +220,7 @@ TEST_F(MatmulATenEvaluationTest, MatmulBiasAlphaBeta) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isCompilationSkipped());
+  EXPECT_TRUE(executors.front().isExprEval());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -269,7 +269,7 @@ TEST_F(MatmulATenEvaluationTest, MatmulBiasBeta) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isCompilationSkipped());
+  EXPECT_TRUE(executors.front().isExprEval());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -315,7 +315,7 @@ TEST_F(MatmulATenEvaluationTest, MatmulBiasAlpha) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isCompilationSkipped());
+  EXPECT_TRUE(executors.front().isExprEval());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -350,7 +350,7 @@ TEST_F(MatmulATenEvaluationTest, Linear) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isCompilationSkipped());
+  EXPECT_TRUE(executors.front().isExprEval());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -389,7 +389,7 @@ TEST_F(MatmulATenEvaluationTest, LinearWithBias) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isCompilationSkipped());
+  EXPECT_TRUE(executors.front().isExprEval());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -60,11 +60,8 @@ TEST_F(MatmulATenEvaluationTest, MmaOpAndCast) {
   const std::vector<FusionExecutor>& executors =
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
-  // Verify that the io_alias_ set has the correct entry
-  kir::Kernel* kernel = executors.front().kernel();
-  EXPECT_EQ(
-      kernel->getOutputAlias(kernel->outputs()[0]).type,
-      AllocationType::Evaluate);
+  // Verify that fusion compilation was skipped.
+  EXPECT_TRUE(executors.front().isCompilationSkipped());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -99,11 +96,8 @@ TEST_F(MatmulATenEvaluationTest, TransposeMmaOpAndCast) {
   const std::vector<FusionExecutor>& executors =
       fec.getMostRecentKernelRuntime()->executors();
   ASSERT_EQ(executors.size(), 1);
-  // Verify that the io_alias_ set has the correct entry
-  kir::Kernel* kernel = executors.front().kernel();
-  EXPECT_EQ(
-      kernel->getOutputAlias(kernel->outputs()[0]).type,
-      AllocationType::Evaluate);
+  // Verify that fusion compilation was skipped.
+  EXPECT_TRUE(executors.front().isCompilationSkipped());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -136,11 +130,8 @@ TEST_F(MatmulATenEvaluationTest, MulSumAndCast) {
   const std::vector<FusionExecutor>& executors =
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
-  // Verify that the io_alias_ set has the correct entry
-  kir::Kernel* kernel = executors.front().kernel();
-  EXPECT_EQ(
-      kernel->getOutputAlias(kernel->outputs()[0]).type,
-      AllocationType::Evaluate);
+  // Verify that fusion compilation was skipped.
+  EXPECT_TRUE(executors.front().isCompilationSkipped());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -179,11 +170,8 @@ TEST_F(MatmulATenEvaluationTest, MatmulWithBias) {
   const std::vector<FusionExecutor>& executors =
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
-  // Verify that the io_alias_ set has the correct entry
-  kir::Kernel* kernel = executors.front().kernel();
-  EXPECT_EQ(
-      kernel->getOutputAlias(kernel->outputs()[0]).type,
-      AllocationType::Evaluate);
+  // Verify that fusion compilation was skipped.
+  EXPECT_TRUE(executors.front().isCompilationSkipped());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -231,11 +219,8 @@ TEST_F(MatmulATenEvaluationTest, MatmulBiasAlphaBeta) {
   const std::vector<FusionExecutor>& executors =
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
-  // Verify that the io_alias_ set has the correct entry
-  kir::Kernel* kernel = executors.front().kernel();
-  EXPECT_EQ(
-      kernel->getOutputAlias(kernel->outputs()[0]).type,
-      AllocationType::Evaluate);
+  // Verify that fusion compilation was skipped.
+  EXPECT_TRUE(executors.front().isCompilationSkipped());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -283,11 +268,8 @@ TEST_F(MatmulATenEvaluationTest, MatmulBiasBeta) {
   const std::vector<FusionExecutor>& executors =
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
-  // Verify that the io_alias_ set has the correct entry
-  kir::Kernel* kernel = executors.front().kernel();
-  EXPECT_EQ(
-      kernel->getOutputAlias(kernel->outputs()[0]).type,
-      AllocationType::Evaluate);
+  // Verify that fusion compilation was skipped.
+  EXPECT_TRUE(executors.front().isCompilationSkipped());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -332,11 +314,8 @@ TEST_F(MatmulATenEvaluationTest, MatmulBiasAlpha) {
   const std::vector<FusionExecutor>& executors =
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
-  // Verify that the io_alias_ set has the correct entry
-  kir::Kernel* kernel = executors.front().kernel();
-  EXPECT_EQ(
-      kernel->getOutputAlias(kernel->outputs()[0]).type,
-      AllocationType::Evaluate);
+  // Verify that fusion compilation was skipped.
+  EXPECT_TRUE(executors.front().isCompilationSkipped());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -1902,6 +1902,8 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT2) {
 
 // C++ version of TestNvFuserFrontend.test_nanogpt_split_mha_linears
 TEST_F(ResizeTest, FusionSliceForNanoGPT3) {
+  // To verify input caching condition in this test, disable aliasing as that
+  // will skip compilation and no kernel will exist.
   preseg_passes::OptimizationPassGuard<preseg_passes::MarkAliasesPreparePass>
       optimization_guard(false);
 

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -15,11 +15,11 @@
 #include <inlining.h>
 #include <kernel_cache.h>
 #include <ops/all_ops.h>
+#include <preseg_passes/mark_aliases_prepare.h>
+#include <preseg_passes/optimization_pass.h>
 #include <scheduler/utils.h>
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
-#include <preseg_passes/mark_aliases_prepare.h>
-#include <preseg_passes/optimization_pass.h>
 
 namespace nvfuser {
 
@@ -1902,7 +1902,8 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT2) {
 
 // C++ version of TestNvFuserFrontend.test_nanogpt_split_mha_linears
 TEST_F(ResizeTest, FusionSliceForNanoGPT3) {
-  preseg_passes::OptimizationPassGuard<preseg_passes::MarkAliasesPreparePass> optimization_guard(false);
+  preseg_passes::OptimizationPassGuard<preseg_passes::MarkAliasesPreparePass>
+      optimization_guard(false);
 
   auto fusion_ptr = std::make_unique<Fusion>();
   auto& fusion = *fusion_ptr;

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -18,6 +18,8 @@
 #include <scheduler/utils.h>
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
+#include <preseg_passes/mark_aliases_prepare.h>
+#include <preseg_passes/optimization_pass.h>
 
 namespace nvfuser {
 
@@ -1900,6 +1902,8 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT2) {
 
 // C++ version of TestNvFuserFrontend.test_nanogpt_split_mha_linears
 TEST_F(ResizeTest, FusionSliceForNanoGPT3) {
+  preseg_passes::OptimizationPassGuard<preseg_passes::MarkAliasesPreparePass> optimization_guard(false);
+
   auto fusion_ptr = std::make_unique<Fusion>();
   auto& fusion = *fusion_ptr;
   FusionGuard fg(fusion_ptr.get());


### PR DESCRIPTION
This PR resolves Issue #1812.
1. Removes the workarounds added to support ATen evaluation for matmuls in PR #1775 (in `predicate_elimination.cpp` and `validation.cpp` (see comments in the PR)
2. `FusionExecutor::fusion_` is initialized only when compilation is skipped. So only one of `lowered_` or `fusion_` is non-null.
3. `FusionKernelRuntime/FusionExecutorCache/FusionExecutor::isCompiled()` indicates whether compilation was attempted (either marked for EE or via nvFuser).