### PR TITLE
Simplify the uses of OptimizationGuard.

### DIFF
--- a/test/test_gpu_transpose.cpp
+++ b/test/test_gpu_transpose.cpp
@@ -14,6 +14,7 @@
 #include <kernel_cache.h>
 #include <ops/all_ops.h>
 #include <preseg_passes/mark_aliases_prepare.h>
+#include <preseg_passes/optimization_pass.h>
 #include <scheduler/all_schedulers.h>
 #include <scheduler/transpose.h>
 #include <scheduler/utils.h>
@@ -42,22 +43,14 @@ TensorView* transposeMaybeInplace(
 
 class TransposeTest : public NVFuserTest {
  protected:
-  void SetUp() override {
-    NVFuserTest::SetUp();
-    previously_enabled_ = preseg_passes::MarkAliasesPreparePass::getEnabled();
-    // For convenience, disable MarkAliasesPreparePass. Many tests in this file
-    // run a fusion that consists of `transpose` only. MarkAliasesPreparePass
-    // would turn those fusions into a no-op, skipping the transpose scheduler.
-    preseg_passes::MarkAliasesPreparePass::setEnabled(false);
-  }
-
-  void TearDown() override {
-    preseg_passes::MarkAliasesPreparePass::setEnabled(previously_enabled_);
-    NVFuserTest::TearDown();
-  }
+  // For convenience, disable MarkAliasesPreparePass. Many tests in this file
+  // run a fusion that consists of `transpose` only. MarkAliasesPreparePass
+  // would turn those fusions into a no-op, skipping the transpose scheduler.
+  TransposeTest() : optimization_guard_(false) {}
 
  private:
-  bool previously_enabled_ = false;
+  preseg_passes::OptimizationPassGuard<preseg_passes::MarkAliasesPreparePass>
+      optimization_guard_;
 };
 
 // x->sin->transpose->cos->y

--- a/test/test_matmul_aten_evaluation.cpp
+++ b/test/test_matmul_aten_evaluation.cpp
@@ -22,15 +22,13 @@ namespace nvfuser {
 
 class MatmulATenEvaluationTest : public NVFuserTest {
  protected:
-  void SetUp() override {
-    // allocation order set by the pass breaks matmul tests
-    // see issue https://github.com/NVIDIA/Fuser/issues/1810
-    guard_ = std::make_unique<nvfuser::preseg_passes::OptimizationPassGuard<
-        nvfuser::preseg_passes::AllocationDomainPass>>(false);
-  }
-  std::unique_ptr<nvfuser::preseg_passes::OptimizationPassGuard<
-      nvfuser::preseg_passes::AllocationDomainPass>>
-      guard_;
+  // Allocation order set by the pass breaks matmul tests
+  // see issue https://github.com/NVIDIA/Fuser/issues/1810
+  MatmulATenEvaluationTest() : optimization_guard_(false) {}
+
+ private:
+  preseg_passes::OptimizationPassGuard<preseg_passes::AllocationDomainPass>
+      optimization_guard_;
 };
 
 TEST_F(MatmulATenEvaluationTest, MmaOpAndCast) {

--- a/test/test_matmul_scheduler.cpp
+++ b/test/test_matmul_scheduler.cpp
@@ -23,15 +23,13 @@ namespace nvfuser {
 namespace {
 class MatmulSchedulerTest : public NVFuserTest {
  protected:
-  void SetUp() override {
-    // allocation order set by the pass breaks matmul tests
-    // see issue https://github.com/NVIDIA/Fuser/issues/1810
-    guard_ = std::make_unique<nvfuser::preseg_passes::OptimizationPassGuard<
-        nvfuser::preseg_passes::AllocationDomainPass>>(false);
-  }
-  std::unique_ptr<nvfuser::preseg_passes::OptimizationPassGuard<
-      nvfuser::preseg_passes::AllocationDomainPass>>
-      guard_;
+  // Allocation order set by the pass breaks matmul tests
+  // see issue https://github.com/NVIDIA/Fuser/issues/1810
+  MatmulSchedulerTest() : optimization_guard_(false) {}
+
+ private:
+  preseg_passes::OptimizationPassGuard<preseg_passes::AllocationDomainPass>
+      optimization_guard_;
 };
 
 using PrecisionsDesc = std::tuple<PrimDataType, PrimDataType, PrimDataType>;
@@ -43,15 +41,13 @@ using TestCaseErrorThresholds = std::map<PrecisionsDesc, ErrorThresholds>;
 class PrecisionParametrizedTest
     : public NVFuserFixtureParamTest<PrecisionsDesc> {
  protected:
-  void SetUp() override {
-    // allocation order set by the pass breaks matmul tests
-    // see issue https://github.com/NVIDIA/Fuser/issues/1810
-    guard_ = std::make_unique<nvfuser::preseg_passes::OptimizationPassGuard<
-        nvfuser::preseg_passes::AllocationDomainPass>>(false);
-  }
-  std::unique_ptr<nvfuser::preseg_passes::OptimizationPassGuard<
-      nvfuser::preseg_passes::AllocationDomainPass>>
-      guard_;
+  // Allocation order set by the pass breaks matmul tests
+  // see issue https://github.com/NVIDIA/Fuser/issues/1810
+  PrecisionParametrizedTest() : optimization_guard_(false) {}
+
+ private:
+  preseg_passes::OptimizationPassGuard<preseg_passes::AllocationDomainPass>
+      optimization_guard_;
 };
 
 [[nodiscard]] auto get_type_letter(const PrimDataType& type) {


### PR DESCRIPTION
I realized some unnecessary complexity is copied here and there. 