### PR TITLE
fix debug info of segment hints

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1934,10 +1934,13 @@ std::unique_ptr<SegmentedFusion> SegmentCandidateFinder::segment(
       return SegmentedFusion::fromCompleteFusion(
           std::move(fusion), maybe_complete_fusion_heuristic.value(), *inputs);
     }
+  } else {
+    scheduler_debug_utils::canScheduleMessage(
+        "***Runtime***: Has segment hints, skip un-segmented scheduling.\n");
   }
   if (fusion) {
     scheduler_debug_utils::canScheduleMessage(
-        "***Runtime***: Has segment hints, try to schedule fusion segmented:\n");
+        "\n***Runtime***: Try to schedule fusion segmented:\n");
     return SegmentCandidateFinder::segment(std::move(fusion), inputs);
   } else {
     NVF_ERROR(false, "unreachable!");


### PR DESCRIPTION
(1) If segmented without hint:
```
***Runtime***: Try to schedule fusion un-segmented:

Scheduler _no_op_ ***rejected*** because : reduction of non-zero elements is not supported
Scheduler _matmul_ ***rejected*** because : Matmul scheduler supports fusions only with a single mma opor supports a mul-sum pair which can be replaced with a mma op
Scheduler _reduction_ ***rejected*** because : Inconsistent reduction axes 0x7fb74625f080is not 2
Scheduler _transpose_ ***rejected*** because : cannot find two mismatching inner most dimensions
Scheduler _pointwise_ ***rejected*** because : no support for reduction ops
Scheduler _inner_persistent_ ***rejected*** because : inconsistent reduction root size: T30_g[ rS55{i0} ], expected: 2
Scheduler _outer_persistent_ ***rejected*** because : schedule_heuristic doesn't match with reduction type.
Scheduler _inner_outer_persistent_ ***rejected*** because : heuristicType() doesn't match with reduction type.
***Runtime***: Try to schedule fusion segmented:
```

(2) If segmented with hint:
```
***Runtime***: Has segment hints, skip un-segmented scheduling.

***Runtime***: Try to schedule fusion segmented:
```

(3) not segmented
```
***Runtime***: Try to schedule fusion un-segmented:

Scheduler _no_op_ ***rejected*** because : reduction of non-zero elements is not supported
Scheduler _matmul_ ***rejected*** because : Matmul scheduler supports fusions only with a single mma opor supports a mul-sum pair which can be replaced with a mma op
Scheduler _reduction_ ***rejected*** because : need persistent buffers that reduction scheduler doesn't handle
Scheduler _transpose_ ***rejected*** because : no support for reduction ops
Scheduler _pointwise_ ***rejected*** because : no support for reduction ops
***Accepted*** as: inner_persistent
```