### PR TITLE
revise comments in inner persistent heuristics

### DIFF
--- a/csrc/scheduler/normalization_inner.cpp
+++ b/csrc/scheduler/normalization_inner.cpp
@@ -185,12 +185,12 @@ namespace {
 // occupancy, we should be able to saturate the memory bandwidth. Within these
 // constraints, we try to maximize the number of registers each thread can use.
 // Para [target_warps_per_sm]: required occupancy to saturate memory bandwidth.
-// Para [free_registers]: registers except those for persistent buffers.
+// Para [register_overhead]: registers except those for persistent buffers.
 std::pair<int64_t, int64_t> getMaxRegisterCountPerThreadAndOccupancy(
     const int64_t buffer_size_per_thread,
     const int64_t threads_per_block,
     const int64_t target_warps_per_sm,
-    const int64_t free_registers) {
+    const int64_t register_overhead) {
   // convert [target_warps_per_sm] to [target_blocks_per_sm]
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
   const int64_t threads_per_warp = dev_prop->warpSize;
@@ -205,7 +205,7 @@ std::pair<int64_t, int64_t> getMaxRegisterCountPerThreadAndOccupancy(
   // minimum register each thread should use to avoid spills
   const int64_t register_per_thread_min =
       buffer_size_per_thread / scheduler_utils::bytes_per_register +
-      free_registers;
+      register_overhead;
 
   // (1) use register calculated from target occupancy
   int64_t threads_per_sm = threads_per_block * target_blocks_per_sm;
@@ -244,11 +244,11 @@ std::pair<int64_t, int64_t> getMaxRegisterCountPerThreadAndOccupancy(
 int64_t getMaxPersistentBatch(
     const int64_t buffer_bytes_per_batch,
     const int64_t target_threads_per_sm,
-    const int64_t free_registers) {
+    const int64_t register_overhead) {
   // (1) calculate the maximum register count given the target occupancy.
   int64_t total_register =
       getRegPerThreadGivenThreadsPerSM(target_threads_per_sm);
-  int64_t register_for_buffer = total_register - free_registers;
+  int64_t register_for_buffer = total_register - register_overhead;
 
   // (2) calculate the maximum persistent batch size using the register count.
   int64_t batch_from_register = scheduler_utils::safeDiv(
@@ -270,7 +270,7 @@ struct HeuristicParams {
   int64_t padded_bdimx = -1;
   int64_t persistent_batch_size = -1;
   int64_t register_per_thread = -1;
-  int64_t free_registers = -1;
+  int64_t non_buffer_registers = -1;
   int64_t occupancy = -1;
   int64_t n_persistent_tails = -1;
   bool is_pad_bdimx = false;
@@ -279,7 +279,7 @@ struct HeuristicParams {
               << ", padded_bdimx: " << padded_bdimx
               << ", persistent_batch_size: " << persistent_batch_size
               << ", register_per_thread: " << register_per_thread
-              << ", free_registers: " << free_registers
+              << ", non_buffer_registers: " << non_buffer_registers
               << ", occupancy: " << occupancy
               << ", n_persistent_tails: " << n_persistent_tails
               << ", is_pad_bdimx: " << is_pad_bdimx << std::endl;
@@ -293,7 +293,7 @@ HeuristicParams getHeuristicParamsGivenPerisisentBatchSize(
     const int64_t min_threads_per_block,
     const int64_t buffer_bytes_per_batch,
     const int64_t target_warps_per_sm,
-    const int64_t free_registers,
+    const int64_t register_overhead,
     const int64_t persistent_batch_size) {
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
   auto device_warp_size = dev_prop->warpSize;
@@ -329,10 +329,10 @@ HeuristicParams getHeuristicParamsGivenPerisisentBatchSize(
       persistent_buffer_size,
       threads_per_block,
       target_warps_per_sm,
-      free_registers);
+      register_overhead);
   params.register_per_thread = reg_occ.first;
   params.occupancy = reg_occ.second;
-  params.free_registers = params.register_per_thread -
+  params.non_buffer_registers = params.register_per_thread -
       persistent_buffer_size / scheduler_utils::bytes_per_register;
   // (4) Calculate other quantities reflecting the quality of the heuristic.
   // when [reduction_count_after_vectorize] is not divisible by
@@ -355,7 +355,7 @@ HeuristicParams getHeuristicParamsGivenPerisisentBatchSize(
 bool compareTwoHeuristics(
     const HeuristicParams& ha,
     const HeuristicParams& hb,
-    const int64_t target_register_overhead,
+    const int64_t min_non_buffer_registers,
     const int64_t target_warps_per_sm) {
   auto compare = [](int64_t a, int64_t b) -> int {
     return a > b ? 1 : (a < b ? -1 : 0);
@@ -376,16 +376,15 @@ bool compareTwoHeuristics(
     return score > 0;
   }
 
-  // Large register overhead leaves more registers for the compiler to
-  // optimize generated SASS code and avoids register spills. But don't want
-  // to use a very large block size which increaes inter-thread communication.
-  // This condition influence dropout_layer_norm at 7K and softmax_dropout at
-  // 6K and 16K.
-  constexpr int64_t opt_max_threads_per_block = 512l;
+  // Ensure the count of non buffer registers is larger than the min overhead.
+  // But don't want to achieve this goal at the cost of using a very large block
+  // size, it avoids using a small persistent batch with a large block size,
+  // which usually leads to 10% lower in performance.
+  constexpr int64_t opt_max_threads_per_block = 512;
   score = compare(
-      ha.free_registers > target_register_overhead &&
+      ha.non_buffer_registers > min_non_buffer_registers &&
           ha.padded_bdimx <= opt_max_threads_per_block,
-      hb.free_registers > target_register_overhead &&
+      hb.non_buffer_registers > min_non_buffer_registers &&
           hb.padded_bdimx <= opt_max_threads_per_block);
   if (score != 0) {
     return score > 0;
@@ -406,11 +405,11 @@ bool compareTwoHeuristics(
 // (1) If the maximum occupancy is less than the target occupancy, use the batch
 //     leads to the largest occupancy.
 // (2) sort the heuristics as follows:
-//     (a) Prioritize occupancy exceeding target.
+//     (a) Prefer occupancy exceeding target.
 //         Ensures minimum required occupancy is surpassed.
-//     (b) Favor divisibility by persistent batch size.
+//     (b) Prefer divisible by persistent batch size.
 //         Aims for even workload distribution.
-//     (c) Opt for more free registers.
+//     (c) Prefer non buffer register exceeds min overhead.
 //         Maximizes compiler optimization potential.
 //     (d) Seek larger occupancy.
 //         Exceeds the target minimum for better performance.
@@ -430,13 +429,13 @@ std::shared_ptr<ReductionParams> innerPersistentHeuristic2D(
     const PrimDataType index_type,
     const bool has_exp_op) {
   // Define two free parameters used in this heuristic.
-  // free_registers is all registers except those for the persistent
-  // buffers. The register in each thread = free_registers +
+  // register_overhead is all registers except those for the persistent
+  // buffers. The register in each thread = register_overhead +
   // persistent_buffer_size / bytes_per_register
   // Current values are based on tests of sofmax, layer_norm, softmax_dropout,
   // dropout_layer_norm on A100 & H100. It directly affects maxregcount passed
   // to NVRTC and influences the occupancy.
-  const int64_t free_registers = has_exp_op ? 32l : 16l;
+  const int64_t register_overhead = has_exp_op ? 32l : 16l;
 
   // Target occupancy required to hide memory latency.
   // Used to calculate the maximum register count each thread can use.
@@ -476,7 +475,7 @@ std::shared_ptr<ReductionParams> innerPersistentHeuristic2D(
   const int64_t target_threads_per_sm =
       std::min(target_warps_per_sm * threads_per_warp, max_threads_per_sm);
   const int64_t pbs_max_2 = getMaxPersistentBatch(
-      buffer_bytes_per_batch, target_threads_per_sm, free_registers);
+      buffer_bytes_per_batch, target_threads_per_sm, register_overhead);
   const int64_t batches_per_block_inner_reduction_max = std::max(
       batches_per_block_inner_reduction_min, std::min(pbs_max_1, pbs_max_2));
 
@@ -506,7 +505,7 @@ std::shared_ptr<ReductionParams> innerPersistentHeuristic2D(
         min_threads_per_block,
         buffer_bytes_per_batch,
         target_warps_per_sm,
-        free_registers,
+        register_overhead,
         pbs));
     if (all_heuristics.back().occupancy > current_max_occupancy) {
       current_max_occupancy = all_heuristics.back().occupancy;
@@ -523,9 +522,10 @@ std::shared_ptr<ReductionParams> innerPersistentHeuristic2D(
     std::stable_sort(
         all_heuristics.begin(),
         all_heuristics.end(),
-        [&free_registers](const HeuristicParams& a, const HeuristicParams& b) {
+        [&register_overhead](
+            const HeuristicParams& a, const HeuristicParams& b) {
           return compareTwoHeuristics(
-              a, b, free_registers, target_warps_per_sm);
+              a, b, register_overhead, target_warps_per_sm);
         });
     best_heuristic = all_heuristics.at(0);
   }
@@ -708,13 +708,13 @@ std::shared_ptr<ReductionParams> innerPersistentHeuristic(
   // TODO: clean and refactor the code into a separate function
 
   // Define two free parameters used in this heuristic.
-  // free_registers is all registers except those for the persistent
-  // buffers. The register in each thread = free_registers +
+  // register_overhead is all registers except those for the persistent
+  // buffers. The register in each thread = register_overhead +
   // persistent_buffer_size / bytes_per_register
   // Current values are based on tests of sofmax, layer_norm, softmax_dropout,
   // dropout_layer_norm on A100 & H100. It directly affects maxregcount passed
   // to NVRTC and influences the occupancy.
-  const int64_t free_registers = has_exp_op ? 32l : 16l;
+  const int64_t register_overhead = has_exp_op ? 32l : 16l;
 
   // Target occupancy required to hide memory latency
   // Current value is based on tests of sofmax, layer_norm, softmax_dropout,
@@ -937,7 +937,7 @@ std::shared_ptr<ReductionParams> innerPersistentHeuristic(
   const int64_t batches_per_block_inner_reduction_max = getMaxPersistentBatch(
       buffer_bytes_per_batch,
       target_warps_per_sm * dev_prop->warpSize,
-      free_registers);
+      register_overhead);
 
   // start from small block size to minimize expensive inter-threads reduction
   const int64_t threads_after_vectorize =
@@ -1112,7 +1112,7 @@ std::shared_ptr<ReductionParams> innerPersistentHeuristic(
                                     persistent_buffer_size,
                                     threads_per_block,
                                     target_warps_per_sm,
-                                    free_registers)
+                                    register_overhead)
                                     .first;
   }
 


### PR DESCRIPTION
Following #1849 
(1) rename `free_registers` to `register_overhead`
(2) use `non_buffer_registers` when compare heuristics
(3) revised code comments