### PR TITLE
[WIP] Skip casting inputs to ops that operate on segment inputs

### DIFF
--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -434,6 +434,7 @@ class NVF_API TensorView : public Val {
   friend OptOutMutator;
   friend class InlineBatchingGuard;
   friend class ir_utils::TVDomainGuard;
+  friend class SegmentedFusion;
 
   // Inline the computation of this tensor into its consumer at the given
   // position. If this tensor is already inlined in a higher position, then this
@@ -548,6 +549,10 @@ class NVF_API TensorView : public Val {
  protected:
   void setDomain(TensorDomain* td) {
     domain_ = td;
+  }
+
+  void setDataType(DataType dtype) {
+    dtype_ = dtype;
   }
 
  private:


### PR DESCRIPTION
THIS IS INCOMPLETE

This is a better alternative to #1936, which merely skipped casting for a slice segment. That had the effect of removing all downcasting for that segment. Instead, we should allow some ops to operate on segment inputs but still cast their outputs, if needed. This PR implements that. If we encounter ops other than slice or select-based ops, we place a cast just before them, updating the dtypes of any intermediate tensors between the incoming segmentation edge and the op whose inputs we are upcasting.

Note that in the future we could use this to avoid upcasting for other lossless half-precision ops, like neg and abs (see https://github.com/NVIDIA/Fuser/issues/1557#issuecomment-1957833263).