### PR TITLE
Enable ftrace only without `NDEBUG`, ftrace `EncodeTensorMapTiled`

### DIFF
--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -10,10 +10,11 @@
 #include <macros.h>
 
 #include <exceptions.h>
-#include <fusion.h>
+#include <type.h>
 #include <visibility.h>
 
 #include <cstring>
+#include <ostream>
 
 #if IS_CPP20
 #include <bit>
@@ -265,6 +266,12 @@ std::string toString(const GemmTile& tile);
 NVF_API std::string toString(const MatMulTileOptions& opts);
 NVF_API std::string toString(MmaMacro macro);
 NVF_API std::string toString(MmaInputSmemSwizzle swizzle);
+inline std::ostream& operator<<(
+    std::ostream& os,
+    MmaInputSmemSwizzle input_layout) {
+  os << toString(input_layout);
+  return os;
+}
 
 // MMA hash utils
 NVF_API size_t hash(MmaMacro macro);

--- a/csrc/tma.cpp
+++ b/csrc/tma.cpp
@@ -229,6 +229,30 @@ std::vector<PolymorphicValue> kir::EncodeTensorMapTiled::evaluate(
   CUtensorMapL2promotion l2_promotion =
       getCUtensorMapL2Promotion(l2Promotion());
   CUtensorMapFloatOOBfill oob_fill = getCUtensorMapFloatOOBfill(oobFill());
+  DEBUG_PRINT_SCOPE_NAME(
+      "EncodeTensorMapTiled",
+      "global_address=",
+      global_address,
+      "global_dim=",
+      global_dim,
+      "global_strides=",
+      global_strides,
+      "box_dim=",
+      box_dim,
+      "element_strides=",
+      element_strides,
+      "data_type=",
+      data_type,
+      "interleave=",
+      interleave,
+      "swizzle=",
+      swizzle,
+      "l2_promotion=",
+      l2_promotion,
+      "oob_fill=",
+      oob_fill,
+      "tensor_rank=",
+      tensor_rank);
 
   // Checks based on the documentation of cuTensorMapEncodeTiled, error messages
   // are mostly directly copied from the doc

--- a/csrc/tma.cpp
+++ b/csrc/tma.cpp
@@ -222,13 +222,6 @@ std::vector<PolymorphicValue> kir::EncodeTensorMapTiled::evaluate(
   NVF_ERROR(inputs.at(4).is<std::vector>());
   auto element_strides = (std::vector<cuuint32_t>)inputs.at(4);
 
-  CUtensorMapDataType data_type = getCUtensorMapDataType(dataType());
-  CUtensorMapInterleave interleave =
-      getCUtensorMapInterleave(this->interleave());
-  CUtensorMapSwizzle swizzle = getCUtensorMapSwizzle(this->swizzle());
-  CUtensorMapL2promotion l2_promotion =
-      getCUtensorMapL2Promotion(l2Promotion());
-  CUtensorMapFloatOOBfill oob_fill = getCUtensorMapFloatOOBfill(oobFill());
   DEBUG_PRINT_SCOPE_NAME(
       "EncodeTensorMapTiled",
       "global_address=",
@@ -242,17 +235,25 @@ std::vector<PolymorphicValue> kir::EncodeTensorMapTiled::evaluate(
       "element_strides=",
       element_strides,
       "data_type=",
-      data_type,
+      dataType(),
       "interleave=",
-      interleave,
+      this->interleave(),
       "swizzle=",
-      swizzle,
+      this->swizzle(),
       "l2_promotion=",
-      l2_promotion,
+      l2Promotion(),
       "oob_fill=",
-      oob_fill,
+      oobFill(),
       "tensor_rank=",
       tensor_rank);
+
+  CUtensorMapDataType data_type = getCUtensorMapDataType(dataType());
+  CUtensorMapInterleave interleave =
+      getCUtensorMapInterleave(this->interleave());
+  CUtensorMapSwizzle swizzle = getCUtensorMapSwizzle(this->swizzle());
+  CUtensorMapL2promotion l2_promotion =
+      getCUtensorMapL2Promotion(l2Promotion());
+  CUtensorMapFloatOOBfill oob_fill = getCUtensorMapFloatOOBfill(oobFill());
 
   // Checks based on the documentation of cuTensorMapEncodeTiled, error messages
   // are mostly directly copied from the doc

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -432,6 +432,8 @@ class DebugPrintScope {
   int64_t line_ = -1;
 };
 
+#ifdef NDEBUG
+
 // Debug printing the entering and leaving of a function. The given arguments
 // will be printed when entering the function.
 //
@@ -461,6 +463,14 @@ class DebugPrintScope {
     _debug_print_scope->setReturn(ret, __FILE__, __LINE__); \
   }                                                         \
   return ret
+
+#else
+
+#define DEBUG_PRINT_SCOPE_NAME(name, ...)
+#define DEBUG_PRINT_SCOPE(...)
+#define RECORD_AND_RETURN(ret) return ret
+
+#endif
 
 // Computes the index type required.
 // Made into a class w/ state to allow reuse with

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -444,7 +444,7 @@ class DebugPrintScope {
   int64_t line_ = -1;
 };
 
-#ifdef NDEBUG
+#ifndef NDEBUG
 
 // Debug printing the entering and leaving of a function. The given arguments
 // will be printed when entering the function.

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -14,6 +14,8 @@
 #include <visibility.h>
 
 #include <debug.h>
+#include <mma_type.h>
+#include <tma.h>
 #include <type.h>
 
 #include <c10/core/thread_pool.h>
@@ -291,6 +293,10 @@ SPECIALIZE_PRINTER(BinaryOpType);
 SPECIALIZE_PRINTER(TernaryOpType);
 SPECIALIZE_PRINTER(LoadStoreOpType);
 SPECIALIZE_PRINTER(DoubleBufferLoopStage);
+SPECIALIZE_PRINTER(tma::TensorMapInterleave);
+SPECIALIZE_PRINTER(tma::TensorMapL2Promotion);
+SPECIALIZE_PRINTER(tma::TensorMapFloatOOBFill);
+SPECIALIZE_PRINTER(MmaInputSmemSwizzle);
 SPECIALIZE_PRINTER(SwizzleType);
 SPECIALIZE_PRINTER(Swizzle2DType);
 SPECIALIZE_PRINTER(SwizzleMode);

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -279,7 +279,11 @@ SPECIALIZE_PRINTER(int);
 SPECIALIZE_PRINTER(std::string);
 using ConstCharStar = const char*;
 SPECIALIZE_PRINTER(ConstCharStar);
+using VoidStar = void*;
+SPECIALIZE_PRINTER(VoidStar);
+SPECIALIZE_PRINTER(uint32_t);
 SPECIALIZE_PRINTER(int64_t);
+SPECIALIZE_PRINTER(uint64_t);
 SPECIALIZE_PRINTER(DataType);
 SPECIALIZE_PRINTER(MemoryType);
 SPECIALIZE_PRINTER(UnaryOpType);
@@ -291,7 +295,9 @@ SPECIALIZE_PRINTER(SwizzleType);
 SPECIALIZE_PRINTER(Swizzle2DType);
 SPECIALIZE_PRINTER(SwizzleMode);
 SPECIALIZE_PRINTER(std::vector<int>);
+SPECIALIZE_PRINTER(std::vector<uint32_t>);
 SPECIALIZE_PRINTER(std::vector<int64_t>);
+SPECIALIZE_PRINTER(std::vector<uint64_t>);
 SPECIALIZE_PRINTER(std::optional<bool>);
 
 #undef SPECIALIZE_PRINTER

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -461,7 +461,7 @@ class DebugPrintScope {
       std::regex re(pattern);                                             \
       if (std::regex_match(name, re)) {                                   \
         _debug_print_scope =                                              \
-            std::make_unique<DebugPrintScope>(__func__, ##__VA_ARGS__);   \
+            std::make_unique<DebugPrintScope>(name, ##__VA_ARGS__);       \
         break;                                                            \
       }                                                                   \
     }                                                                     \

--- a/tests/cpp/test_gpu_utils.cpp
+++ b/tests/cpp/test_gpu_utils.cpp
@@ -35,6 +35,7 @@ int myFavoriteFunction(int a, int b) {
 }
 
 TEST_F(NVFuserTest, FunctionTrace1) {
+#ifdef NDEBUG
   std::stringstream ss;
   DebugStreamGuard g(ss);
   DebugDumpOptionsGuard gg;
@@ -46,9 +47,13 @@ TEST_F(NVFuserTest, FunctionTrace1) {
       ss.str(),
       ::testing::HasSubstr("Leaving myFavoriteFunction returning 3 at "));
   EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_gpu_utils.cpp:31"));
+#else
+  GTEST_SKIP() << "Test only runs in debug mode";
+#endif
 }
 
 TEST_F(NVFuserTest, FunctionTrace2) {
+#ifdef NDEBUG
   std::stringstream ss;
   DebugStreamGuard g(ss);
   DebugDumpOptionsGuard gg;
@@ -60,6 +65,9 @@ TEST_F(NVFuserTest, FunctionTrace2) {
       ss.str(),
       ::testing::HasSubstr("Leaving myFavoriteFunction returning -3 at "));
   EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_gpu_utils.cpp:33"));
+#else
+  GTEST_SKIP() << "Test only runs in debug mode";
+#endif
 }
 
 TEST_F(NVFuserTest, FusionSplitDims_CUDA) {

--- a/tests/cpp/test_gpu_utils.cpp
+++ b/tests/cpp/test_gpu_utils.cpp
@@ -35,7 +35,7 @@ int myFavoriteFunction(int a, int b) {
 }
 
 TEST_F(NVFuserTest, FunctionTrace1) {
-#ifdef NDEBUG
+#ifndef NDEBUG
   std::stringstream ss;
   DebugStreamGuard g(ss);
   DebugDumpOptionsGuard gg;
@@ -53,7 +53,7 @@ TEST_F(NVFuserTest, FunctionTrace1) {
 }
 
 TEST_F(NVFuserTest, FunctionTrace2) {
-#ifdef NDEBUG
+#ifndef NDEBUG
   std::stringstream ss;
   DebugStreamGuard g(ss);
   DebugDumpOptionsGuard gg;


### PR DESCRIPTION
Example print:
```C++
[ RUN      ] TMALdstTest/TMALdstTest.LoadCompleteTensor/4D_NoSwizzle_float
Entering EncodeTensorMapTiled(global_address=, 0x7ffd19e00000, global_dim=, 4 4 4 4, global_strides=, 16 64 256, box_dim=, 4 4 4 4, element_strides=, 1 1 1 1, data_type=, float, interleave=, NoInterleave, swizzle=, NoSwizzle, l2_promotion=, NoL2Promotion, oob_fill=, NoOOBFill, tensor_rank=, 4)
Leaving EncodeTensorMapTiled
[       OK ] TMALdstTest/TMALdstTest.LoadCompleteTensor/4D_NoSwizzle_float (299 ms)
```