### PR TITLE
`KernelSummary::validations`

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1566,6 +1566,10 @@ void FusionExecutor::initializeExecutorEntry(
   auto launch_params = computeLaunchParams(
       launch_constraints, expr_eval, warp_size_, index_type);
 
+  for (auto entry : kernel()->summary().validations) {
+    NVF_CHECK(expr_eval.evaluate(entry.first).as<bool>(), entry.second);
+  }
+
   executor_utils::validateVectorizedTensors(
       kernel(), args, outputs, compileTimeDataCache(), expr_eval);
 

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1566,7 +1566,7 @@ void FusionExecutor::initializeExecutorEntry(
   auto launch_params = computeLaunchParams(
       launch_constraints, expr_eval, warp_size_, index_type);
 
-  for (auto entry : kernel()->summary().validations) {
+  for (const auto& entry : kernel()->summary().validations) {
     NVF_CHECK(expr_eval.evaluate(entry.first).as<bool>(), entry.second);
   }
 

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -671,25 +671,6 @@ void validateMisalignedVectorizedTensors(
       "All global tensors must have the same stride for misaligned vectorization.");
 }
 
-// Check if there's any split that is non-divisible and vectorized. If
-// found, Vectorize is illegal.
-void validateVectorizedSplits(
-    kir::Kernel* kernel,
-    ExpressionEvaluator& expr_eval) {
-  for (const auto& extent_factor : kernel->summary().splits_to_validate) {
-    auto input_extent = expr_eval.evaluate(extent_factor.first);
-    auto split_factor = expr_eval.evaluate(extent_factor.second);
-    auto divisible = (input_extent % split_factor == 0);
-    NVF_ERROR(
-        divisible,
-        "Non-divisible split with vectorization is detected. ",
-        "Extent: ",
-        input_extent,
-        ". Factor: ",
-        split_factor);
-  }
-}
-
 } // namespace
 
 void validateVectorizedTensors(
@@ -705,8 +686,6 @@ void validateVectorizedTensors(
 
   validateMisalignedVectorizedTensors(
       kernel, args, outputs, data_cache, expr_eval);
-
-  validateVectorizedSplits(kernel, expr_eval);
 }
 
 ExpressionEvaluator bindInputs(

--- a/csrc/kernel.h
+++ b/csrc/kernel.h
@@ -92,7 +92,9 @@ struct KernelSummary {
   //! Only used for debugging.
   std::vector<const kir::Allocate*> dynamic_lmem_allocations;
 
-  //! Validations needed and information about them. For example, a pair of "extent mod split_factor == 0" and an error message for divisibility check for vectorization.
+  //! Validations needed and information about them. For example, a pair of
+  //! "extent mod split_factor == 0" and an error message for divisibility check
+  //! for vectorization.
   std::vector<std::pair<const Val*, std::string>> validations;
 
   //! Effective ParallelTypes of broadcast ops

--- a/csrc/kernel.h
+++ b/csrc/kernel.h
@@ -92,8 +92,8 @@ struct KernelSummary {
   //! Only used for debugging.
   std::vector<const kir::Allocate*> dynamic_lmem_allocations;
 
-  //! ceilDiv extents that must be divisible
-  std::vector<std::pair<const Val*, const Val*>> splits_to_validate;
+  //! Validations needed and information about them
+  std::vector<std::pair<const Val*, std::string>> validations;
 
   //! Effective ParallelTypes of broadcast ops
   std::unordered_map<const BroadcastOp*, ParallelTypeBitmap>

--- a/csrc/kernel.h
+++ b/csrc/kernel.h
@@ -92,7 +92,7 @@ struct KernelSummary {
   //! Only used for debugging.
   std::vector<const kir::Allocate*> dynamic_lmem_allocations;
 
-  //! Validations needed and information about them
+  //! Validations needed and information about them. For example, a pair of "extent mod split_factor == 0" and an error message for divisibility check for vectorization.
   std::vector<std::pair<const Val*, std::string>> validations;
 
   //! Effective ParallelTypes of broadcast ops


### PR DESCRIPTION
This PR adds `KernelSummary::validations`, a vector of `(boolean_expr, string_reason)` pairs. This field will serve as a unified framework for validations, and will also be used for validating TMA. The previous `KernelSummary::splits_to_validate` is removed and the corresponding validations are moved to this new framework.