### PR TITLE
Guard test_issue1953 for Ampere+

### DIFF
--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -3536,6 +3536,7 @@ class TestNvFuserFrontend(TestCase):
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
 
     # https://github.com/NVIDIA/Fuser/issues/1953
+    @unittest.skipIf(is_pre_ampere(), "Only supported on Ampere and newer devices.")
     def test_issue1953(self):
         inputs = [
             128,


### PR DESCRIPTION
We could alternatively use Half to cover Volta as well, but since the original issue uses BFloat16, I decided to keep it intact and just skip the test on Volta.