### PR TITLE
Add a fence before TMA store

### DIFF
--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1440,6 +1440,11 @@ void IndexLowering::handleCpAsyncBulkLoad(const LoadStoreOp* ldst) {
 }
 
 void IndexLowering::handleCpAsyncBulkStore(const LoadStoreOp* ldst) {
+  pushBack(IrBuilder::create<kir::Asm>(
+      "fence.proxy.async",
+      std::vector<Val*>{},
+      std::vector<Val*>{},
+      kir::Asm::Options{/*volatile=*/true}));
   auto in = lowerSrcIndex(ldst->in(), ldst->out(), {}, true);
   auto in_tv = ldst->in()->as<TensorView>();
   auto out_tv = ldst->out()->as<TensorView>();


### PR DESCRIPTION
https://github.com/NVIDIA/Fuser/pull/1962#pullrequestreview-1947575870

Example kernel:

```CUDA
__global__ void nvfuser_none_f0_c0_r0_g0(Tensor<__half, 1, 1> T0, const __grid_constant__ TensorMap var0, Tensor<__half, 1, 1> T2) {
  alignas(16) extern __shared__ char array[];
  const unsigned smem_offset = 0;
  nvfuser_index_t i1;
  i1 = 8LL * ((nvfuser_index_t)blockIdx.x);
  nvfuser_index_t i2;
  i2 = (-T0.logical_size[0LL]) + i1;
  __half* T1 = reinterpret_cast<__half*>(array + smem_offset + 0);
  #pragma unroll
  for(nvfuser_index_t i3 = 0; i3 < 8; ++i3) {
    T1[i3] = 0;
  }
  #pragma unroll
  for(nvfuser_index_t i3 = 0; i3 < 8; ++i3) {
    if ((i2 < (-i3))) {
      T1[i3]
         = T0[(i1 + i3)];
    }
  }
  asm volatile("fence.proxy.async;\n");
  Hopper::cpAsyncBulkTensorTileS2G((Hopper::CpAsyncBulkTensorTileS2GIndex<1>{ (&var0), Array<nvfuser_index_t, 1, 1>{ 0} }), toSmem(T1));
  asm volatile("cp.async.bulk.commit_group;\n");
  asm volatile("cp.async.bulk.wait_group.read %0;\n"::"n"(0LL):"memory");
}
```