### PR TITLE
Add `GpuLower::validations()`

### DIFF
--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -238,6 +238,14 @@ class GpuLower : public NonCopyable {
     return passes_;
   }
 
+  const std::vector<std::pair<const Val*, std::string>>& validations() const {
+    return validations_;
+  }
+
+  std::vector<std::pair<const Val*, std::string>>& validations() {
+    return validations_;
+  }
+
  private:
   void analysis(Fusion* fusion);
 
@@ -292,8 +300,13 @@ class GpuLower : public NonCopyable {
   // precomputed values
   std::vector<Val*> all_known_vals_;
 
-  // keep track of the mbarrier used for each load/store operation
+  // Keep track of the mbarrier used for each load/store operation
   std::unordered_map<const Expr*, TensorView*> ldst_mbarrier_map_;
+
+  // Keep track of validations needed at runtime. For example, a pair of
+  //! "extent mod split_factor == 0" and an error message for divisibility check
+  //! for vectorization.
+  std::vector<std::pair<const Val*, std::string>> validations_;
 
   Fusion* fusion_ = nullptr;
 };

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -7,8 +7,6 @@
 // clang-format on
 #include <debug.h>
 #include <device_lower/lower2device.h>
-#include <expr_evaluator.h>
-#include <expr_simplifier.h>
 #include <instrumentation.h>
 #include <ir/iostream.h>
 #include <ir/utils.h>
@@ -33,21 +31,6 @@ class KernelIrScanner : private IrVisitor {
   explicit KernelIrScanner(const Kernel* kernel) {
     index_type_ = kernel->indexType();
     IrVisitor::handle(kernel->topLevelExprs());
-    const auto gpu_lower = GpuLower::current();
-    for (auto split : gpu_lower->nonDivisibleSplitInfo().splitsToValidate()) {
-      auto extent = split->in()->extent();
-      auto factor = split->factor();
-      auto is_divisible = simplifyExpr(SimplifyingIrBuilder::eqExpr(
-          SimplifyingIrBuilder::modExpr(extent, factor),
-          extent->fusion()->zeroVal()));
-      NVF_ERROR(
-          !is_divisible->isFalse(), "Non-divisible split detected: ", split);
-      if (!is_divisible->isTrue()) {
-        std::stringstream ss;
-        ss << "Non-divisible split detected: " << split;
-        summary_.validations.emplace_back(is_divisible, ss.str());
-      }
-    }
   }
 
   const auto& summary() const {
@@ -365,6 +348,7 @@ void Kernel::finalize(std::vector<Expr*> top_level_exprs) {
   ValidateAllocation::validate(this);
   analyze();
   // Make sure this is after analyze as it sets summary_
+  summary_.validations = GpuLower::current()->validations();
   summary_.vectorized_accesses = GpuLower::current()->vectorizedAccesses();
   summary_.vectorized_set_info = GpuLower::current()->vectorizedSetInfo();
   summary_.sync_map = GpuLower::current()->syncMap();

--- a/csrc/non_divisible_split.h
+++ b/csrc/non_divisible_split.h
@@ -68,6 +68,9 @@ class NVF_API NonDivisibleSplitInfo : public IterVisitor {
   //! run time
   void removeRedundancy();
 
+  //! Add validations to GpuLower::current()->validations()
+  void addValidations();
+
  private:
   //! Split expressions whose input domain must be predicated
   std::unordered_map<TensorView*, std::vector<Split*>> splits_to_predicate_;


### PR DESCRIPTION
Now `KernelSummary::validations` is just a copy of `GpuLower::validations()`. The validations for non-divisible split is now added by `NonDivisibleSplitInfo`, instead of in `KernelIrScanner`. By refactoring this way, we can add other validations during lowering.