### PR TITLE
Prevent matmul benchmarks from using ATen eval

### DIFF
--- a/benchmarks/cpp/matmul.cpp
+++ b/benchmarks/cpp/matmul.cpp
@@ -380,6 +380,9 @@ static void NvFuserScheduler_Matmul(
   NVFUSER_BENCHMARK_ARCH_SMEM_GUARD(
       8, 0, getSmemSize(cta_tile, number_of_stage), benchmark_state);
 
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().set(DisableOption::MatmulExprEval);
+
   // Run benchmark:
   if (partitionedk) {
     SingleMatmulPartitionedK(benchmark_state, layout, params, splitk_factor);


### PR DESCRIPTION
These were broken by #1927, but the fix is simple.