### PR TITLE
Reusable zeroed memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/evaluator_common.cpp
   ${NVFUSER_SRCS_DIR}/executor_utils.cpp
   ${NVFUSER_SRCS_DIR}/fusion.cpp
+  ${NVFUSER_SRCS_DIR}/global_allocator.cpp
   ${NVFUSER_SRCS_DIR}/grouped_reduction.cpp
   ${NVFUSER_SRCS_DIR}/id_model/id_model.cpp
   ${NVFUSER_SRCS_DIR}/id_model/to_string.cpp

--- a/csrc/global_allocator.cpp
+++ b/csrc/global_allocator.cpp
@@ -22,6 +22,8 @@ namespace {
 // high-water mark for their particular device until the thread terminates.
 class Arena {
  public:
+  // Mark allocated_bytes_ as 0, allowing all available zeroed memory to be
+  // reused on subsequent calls to getTensor().
   void reset() {
     if (isDebugDumpEnabled(DebugDumpOption::GlobalZeroedMemory)) {
       debug() << "[global zeroed memory] Resetting allocated bytes to 0"
@@ -121,6 +123,8 @@ at::Tensor contigZeroTensor(
   return arenas[device_num].getTensor(sizes, aten_dtype, device);
 }
 
+// Note that this does not free allocated zeroed memory, but rather it marks all
+// zeroed memory as available for re-use.
 void releaseZeroedMemory() {
   for (Arena& a : arenas) {
     a.reset();

--- a/csrc/global_allocator.cpp
+++ b/csrc/global_allocator.cpp
@@ -108,10 +108,12 @@ at::Tensor contigZeroTensor(
     const c10::ScalarType& aten_dtype,
     const c10::Device& device) {
   NVF_ERROR(device.is_cuda(), "contigZeroTensor requires CUDA device");
-  int64_t device_num = device.index();
+  // Intermediate cast from int8_t to uint8_t for clarity:
+  // https://clang.llvm.org/extra/clang-tidy/checks/bugprone/signed-char-misuse.html
+  size_t device_num = (uint8_t)device.index();
 
   // get arena from device number, resizing arenas if needed
-  if ((size_t)device_num >= arenas.size()) {
+  if (device_num >= arenas.size()) {
     arenas.resize(device_num + 1);
   }
 

--- a/csrc/global_allocator.cpp
+++ b/csrc/global_allocator.cpp
@@ -1,0 +1,96 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <global_allocator.h>
+#include <type.h>
+
+#include <ATen/ATen.h>
+
+namespace nvfuser {
+
+namespace {
+
+// For each device, we maintain an arena tensor which we will slice to provide
+// individual tensors. These tensors will grow in size and remain at the
+// high-water mark for their particular device until the thread terminates.
+class Arena {
+ public:
+  void reset() {
+    allocated_bytes_ = 0LL;
+  }
+
+  at::Tensor getTensor(
+      const std::vector<int64_t>& sizes,
+      const c10::ScalarType& aten_dtype,
+      const c10::Device& device) {
+    // determine number of bytes needed for this tensor
+    int64_t new_bytes = dataTypeSize(aten_to_data_type(aten_dtype));
+    for (auto sz : sizes) {
+      new_bytes *= sz;
+    }
+
+    // align at 16 bytes regardless of requested dtype
+    int64_t aligned_allocated_bytes = (allocated_bytes_ + 15) & (~ 15);
+    
+    // after this function returns this will be the allocated size
+    int64_t new_allocated_bytes = aligned_allocated_bytes + new_bytes;
+
+    // resize tensor_ if needed
+    int64_t new_used_bytes = tensor_.numel();
+    while (new_used_bytes < new_allocated_bytes) {
+      new_used_bytes *= 2;
+    }
+    if (new_used_bytes > tensor_.numel()) {
+      tensor_ = at::zeros(
+          {new_used_bytes},
+          at::TensorOptions().dtype(at::kByte).device(device));
+    }
+
+    allocated_bytes_ = new_allocated_bytes;
+
+    // slice and view tensor
+    return tensor_
+        .index({at::indexing::Slice(
+            aligned_allocated_bytes, new_allocated_bytes, 1)})
+        .view(aten_dtype);
+  }
+
+ private:
+  at::Tensor tensor_;
+  int64_t allocated_bytes_ = 0LL;
+};
+
+// We hold one Arena for each device
+thread_local std::vector<Arena> arenas;
+
+} // namespace
+
+at::Tensor contigZeroTensor(
+    const std::vector<int64_t>& sizes,
+    const c10::ScalarType& aten_dtype,
+    const c10::Device& device) {
+  NVF_ERROR(device.is_cuda(), "contigZeroTensor requires CUDA device");
+  int64_t device_num = device.index();
+
+  // get arena from device number, resizing arenas if needed
+  if ((size_t)device_num >= arenas.size()) {
+    arenas.resize(device_num + 1);
+  }
+ 
+  // request tensor from arena
+  return arenas[device_num].getTensor(sizes, aten_dtype, device);
+}
+
+void releaseZeroedMemory() {
+  for (Arena& a : arenas) {
+    a.reset();
+  }
+}
+
+} // namespace nvfuser
+

--- a/csrc/global_allocator.cpp
+++ b/csrc/global_allocator.cpp
@@ -79,7 +79,8 @@ class Arena {
     return tensor_
         .index({at::indexing::Slice(
             aligned_allocated_bytes, new_allocated_bytes, 1)})
-        .view(aten_dtype);
+        .view(aten_dtype)
+        .view(sizes);
   }
 
  private:

--- a/csrc/global_allocator.h
+++ b/csrc/global_allocator.h
@@ -20,7 +20,8 @@ at::Tensor contigZeroTensor(
     const c10::Device& device);
 
 //! This should be called after each kernel launch to allow subsequent launches
-//! to re-use allocated memory.
+//! to re-use allocated memory. Note that it does not free allocated zeroed
+//! memory, but rather it marks all zeroed memory as available for re-use.
 void releaseZeroedMemory();
 
 } // namespace nvfuser

--- a/csrc/global_allocator.h
+++ b/csrc/global_allocator.h
@@ -1,0 +1,26 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace nvfuser {
+
+//! This returns a slice of a thread local at::Tensor that is zeroed. Uses of
+//! this memory should always "clean up" by resetting the memory to zero at the
+//! end of the kernel.
+at::Tensor contigZeroTensor(
+    const std::vector<int64_t>& sizes,
+    const c10::ScalarType& aten_dtype,
+    const c10::Device& device);
+
+//! This should be called after each kernel launch to allow subsequent launches
+//! to re-use allocated memory.
+void releaseZeroedMemory();
+
+} // namespace nvfuser

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -122,6 +122,7 @@ std::unordered_map<DebugDumpOption, std::vector<std::string>> Options<
       {"fusion_ir_presched", DebugDumpOption::FusionIrPresched},
       {"fusion_ir", DebugDumpOption::FusionIr},
       {"fusion_ir_math", DebugDumpOption::FusionIrMath},
+      {"global_zeroed_memory", DebugDumpOption::GlobalZeroedMemory},
       {"halo", DebugDumpOption::Halo},
       {"index_type", DebugDumpOption::IndexType},
       {"kernel_args", DebugDumpOption::KernelArgs},

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -157,6 +157,7 @@ std::unordered_map<EnableOption, std::vector<std::string>> Options<
       {"kernel_db", EnableOption::KernelDb},
       {"kernel_profile", EnableOption::KernelProfile},
       {"memory_promotion", EnableOption::MemoryPromotion},
+      {"reuse_zeroed_memory", EnableOption::ReuseZeroedMemory},
       {"static_fusion_count", EnableOption::StaticFusionCount},
       {"warn_register_spill", EnableOption::WarnRegisterSpill},
       {"io_to_lower_precision", EnableOption::IoToLowerPrecision},

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -52,6 +52,7 @@ enum class DebugDumpOption {
   FusionSegments, //!< Dump Segmented Fusion Graph
   FusionSegmenterLog, //!< Dump Detailed Segmenter Logging
   FusionArgs, //!< Print the runtime fusion arguments
+  GlobalZeroedMemory, //!< Print the log for zeroed global memory allocator
   KernelArgs, //!< Print the runtime kernel arguments when launching kernels
   EffectiveBandwidth, //! Measure kernel performance and print effective
                       //! bandwidth

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -95,6 +95,7 @@ enum class EnableOption {
   KernelProfile, //! Enable intra-kernel performance profiling
   MemoryPromotion, //! Enable promotion of memory types for non-pointwise ops
   StaticFusionCount, //! Enable using single static count in kernel name
+  ReuseZeroedMemory, //! Re-use zeroed memory used for grid synchronization
   WarnRegisterSpill, //! Enable warnings of register spill
   IoToLowerPrecision, //! Enable castInputOutputToLowerPrecision. #1889 explains
                       //! why we disabled it by default.

--- a/tests/cpp/test_serial_gridreduce.cpp
+++ b/tests/cpp/test_serial_gridreduce.cpp
@@ -37,91 +37,110 @@ using SerialGridReductionTest = NVFuserTest;
 
 TEST_F(SerialGridReductionTest, Scheduling) {
   for (bool serial : {true, false}) {
-    for (int64_t num_warps : {4, 8}) {
-      // B is size of inner serial loop. Outer loop is hardcoded at A=4
-      // Here we set B to a small value of 8 instead of 32 (i.e. 128 elements
-      // per thread), so that the non-serial compilation does not take too
-      // long.
-      for (int64_t B : {8}) {
-        std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
-        auto fusion = fusion_ptr.get();
-        FusionGuard fg(fusion);
+    // For serial grid reduction we test that re-using semaphore buffers works
+    // properly. This will cause a failure if serial grid reduction does not
+    // properly clean up its semaphores.
+    std::vector<bool> reuse_zeroed_memory_values{false};
+    if (serial) {
+      reuse_zeroed_memory_values.push_back(true);
+    }
+    for (bool reuse_zeroed_memory : reuse_zeroed_memory_values) {
+      EnableOptionsGuard eog;
+      if (reuse_zeroed_memory) {
+        EnableOptionsGuard::getCurOptions().set(
+            EnableOption::ReuseZeroedMemory);
+      } else {
+        EnableOptionsGuard::getCurOptions().unset(
+            EnableOption::ReuseZeroedMemory);
+      }
+      for (int64_t num_warps : {4, 8}) {
+        // B is size of inner serial loop. Outer loop is hardcoded at A=4
+        // Here we set B to a small value of 8 instead of 32 (i.e. 128 elements
+        // per thread), so that the non-serial compilation does not take too
+        // long.
+        for (int64_t B : {8}) {
+          std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+          auto fusion = fusion_ptr.get();
+          FusionGuard fg(fusion);
 
-        int64_t blocks_x = 8;
-        int64_t blocks_y = 8;
-        int64_t blocks_z = 5;
-        int64_t A = 4; // Size of outer serial loop
-        int64_t H = blocks_z;
-        int64_t W = A * B * blocks_x * blocks_y * num_warps * 32;
+          int64_t blocks_x = 8;
+          int64_t blocks_y = 8;
+          int64_t blocks_z = 5;
+          int64_t A = 4; // Size of outer serial loop
+          int64_t H = blocks_z;
+          int64_t W = A * B * blocks_x * blocks_y * num_warps * 32;
 
-        // Unreduced dimensions should be concrete. Reduced dimension could be
-        // symbolic, but is concrete here so that we can read tv0 to registers
-        TensorView* tv0 = TensorViewBuilder()
-                              .shape({H, W})
-                              .dtype(DataType::Float)
-                              .contiguity(true)
-                              .build();
-        fusion->addInput(tv0);
+          // Unreduced dimensions should be concrete. Reduced dimension could be
+          // symbolic, but is concrete here so that we can read tv0 to registers
+          TensorView* tv0 = TensorViewBuilder()
+                                .shape({H, W})
+                                .dtype(DataType::Float)
+                                .contiguity(true)
+                                .build();
+          fusion->addInput(tv0);
 
-        auto tv1 = sum(tv0, {0});
-        fusion->addOutput(tv1);
+          auto tv1 = sum(tv0, {0});
+          fusion->addOutput(tv1);
 
-        // Start with
-        //   [ rS{H}, iS{W} ]
-        // We are grid reducing the H dimension and we want to coalesce
-        // accesses in the W dimension. So we first reorder to
-        //   [ iS{W}, rS{H} ]
-        // then schedule as
-        //   [ iBIDx{blocks_x}, iBIDy{blocks_y}, iS{A}, iS{B}, iTIDy{num_warps},
-        //   iTIDx{32}, rBIDz{blocks_z} ]
-        auto tv2 = tv0->cacheAfter();
-        auto tv3 = tv1->cacheBefore();
+          // Start with
+          //   [ rS{H}, iS{W} ]
+          // We are grid reducing the H dimension and we want to coalesce
+          // accesses in the W dimension. So we first reorder to
+          //   [ iS{W}, rS{H} ]
+          // then schedule as
+          //   [ iBIDx{blocks_x}, iBIDy{blocks_y}, iS{A}, iS{B},
+          //   iTIDy{num_warps}, iTIDx{32}, rBIDz{blocks_z} ]
+          auto tv2 = tv0->cacheAfter();
+          auto tv3 = tv1->cacheBefore();
 
-        tv3->reorder({{1, 0}, {0, 1}}); // blocks_x*blocks_y*A*B*num_warps*32, H
-        tv3->split(0, 32); // blocks_x*blocks_y*A*B*num_warps, 32, H
-        tv3->split(0, num_warps); // blocks_x*blocks_y*A*B, num_warps, 32, H
-        tv3->split(0, B); // blocks_x*blocks_y*A, B, num_warps, 32, H
-        tv3->split(0, A); // blocks_x*blocks_y, A, B, num_warps, 32, H
-        tv3->split(0, blocks_y); // blocks_x, blocks_y, A, B, num_warps, 32, H
-        tv3->axis(0)->parallelize(ParallelType::BIDx);
-        tv3->axis(1)->parallelize(ParallelType::BIDy);
-        tv3->axis(4)->parallelize(ParallelType::TIDy);
-        tv3->axis(5)->parallelize(ParallelType::TIDx);
-        tv3->axis(6)->parallelize(ParallelType::BIDz);
-        // Reorder to put parallel dims first for better inlining
-        tv3->reorder({
-            {4, 2},
-            {5, 3},
-            {2, 4},
-            {3, 5},
-        });
+          tv3->reorder(
+              {{1, 0}, {0, 1}}); // blocks_x*blocks_y*A*B*num_warps*32, H
+          tv3->split(0, 32); // blocks_x*blocks_y*A*B*num_warps, 32, H
+          tv3->split(0, num_warps); // blocks_x*blocks_y*A*B, num_warps, 32, H
+          tv3->split(0, B); // blocks_x*blocks_y*A, B, num_warps, 32, H
+          tv3->split(0, A); // blocks_x*blocks_y, A, B, num_warps, 32, H
+          tv3->split(0, blocks_y); // blocks_x, blocks_y, A, B, num_warps, 32, H
+          tv3->axis(0)->parallelize(ParallelType::BIDx);
+          tv3->axis(1)->parallelize(ParallelType::BIDy);
+          tv3->axis(4)->parallelize(ParallelType::TIDy);
+          tv3->axis(5)->parallelize(ParallelType::TIDx);
+          tv3->axis(6)->parallelize(ParallelType::BIDz);
+          // Reorder to put parallel dims first for better inlining
+          tv3->reorder({
+              {4, 2},
+              {5, 3},
+              {2, 4},
+              {3, 5},
+          });
 
-        TransformPropagator propagator(tv3);
-        MaxRootDomainInfoSpanningTree(tv3).traverse(&propagator);
-        scheduler_utils::parallelizeAllLike(tv3);
+          TransformPropagator propagator(tv3);
+          MaxRootDomainInfoSpanningTree(tv3).traverse(&propagator);
+          scheduler_utils::parallelizeAllLike(tv3);
 
-        // Here we just transpose A and B in tv2, so that it will be partially
-        // inlined with tv3, resulting in a separate loop to load tv0 into
-        // registers (tv2).
-        tv2->reorder({
-            {-2, -3},
-            {-3, -2},
-        });
+          // Here we just transpose A and B in tv2, so that it will be partially
+          // inlined with tv3, resulting in a separate loop to load tv0 into
+          // registers (tv2).
+          tv2->reorder({
+              {-2, -3},
+              {-3, -2},
+          });
 
-        inlineMost();
+          inlineMost();
 
-        FusionExecutor fe;
-        if (serial) {
-          tv3->definition()->as<ReductionOp>()->requestSerialGridReduction();
-        }
-        fe.compileFusion(fusion);
+          FusionExecutor fe;
+          if (serial) {
+            tv3->definition()->as<ReductionOp>()->requestSerialGridReduction();
+          }
+          fe.compileFusion(fusion);
 
-        auto input = at::randn(
-            {H, W}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
-        auto outputs = fe.runFusion({input});
+          auto input = at::randn(
+              {H, W},
+              at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+          auto outputs = fe.runFusion({input});
 
-        if (serial) {
-          testValidate(fusion, outputs, {input}, __LINE__, __FILE__);
+          if (serial) {
+            testValidate(fusion, outputs, {input}, __LINE__, __FILE__);
+          }
         }
       }
     }


### PR DESCRIPTION
This introduces a thread-local global memory allocator for each device and uses it whenever there is an intermediate tensor needed which requires zero-initialization.

To enable use `NVFUSER_ENABLE=reuse_zeroed_memory`. You can monitor the allocator using `NVFUSER_DUMP=global_zeroed_memory`.

Before we enable this feature by default, we need to have high confidence that every kernel using zero-initialized memory will always clean up their semaphores. This is currently only the case for serial grid reductions, as far as I know.

This enables the basic functionality of #1829. However, it does not modify existing algorithms to clean up their memory. See `NVFUSER_ENABLE=reuse_zeroed_memory NVFUSER_DUMP=global_zeroed_memory build/nvfuser_tests --gtest_filter=SerialGridReductionTest.Scheduling`, which succeeds when using serial grid reduction, but fails (in debug mode) when using `gridReduce` (note that this test is updated to behave differently in this PR):
```
# NVFUSER_ENABLE=reuse_zeroed_memory NVFUSER_DUMP=global_zeroed_memory build/nvfuser_tests --gtest_filter=SerialGridReductionTest.Scheduling                                                       
Running main() from /opt/pytorch/nvfuser/third_party/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = SerialGridReductionTest.Scheduling
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SerialGridReductionTest
[ RUN      ] SerialGridReductionTest.Scheduling
[global zeroed memory] Resizing arena to 512 bytes
[global zeroed memory] Allocating byte range: 0 to 512 bytes
[global zeroed memory] Resetting allocated bytes to 0
[global zeroed memory] Allocating byte range: 0 to 512 bytes
[global zeroed memory] Resetting allocated bytes to 0
[global zeroed memory] Resizing arena to 16384 bytes
[global zeroed memory] Allocating byte range: 0 to 16384 bytes
[global zeroed memory] Resetting allocated bytes to 0
[global zeroed memory] Allocating byte range: 0 to 16384 bytes
unknown file: Failure
C++ exception with description "nnz.equal(0) INTERNAL ASSERT FAILED at "/opt/pytorch/nvfuser/csrc/global_allocator.cpp":88, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues. Global memory arena was not properly zeroed. Found 2048 bytes that are not zero
Exception raised from checkZeroed at /opt/pytorch/nvfuser/csrc/global_allocator.cpp:88 (most recent call first):
frame #0: <unknown function> + 0x2fde9e (0x556cdb95de9e in build/nvfuser_tests)
frame #1: <unknown function> + 0x2fe0df (0x556cdb95e0df in build/nvfuser_tests)
frame #2: <unknown function> + 0x3f3720 (0x556cdba53720 in build/nvfuser_tests)
frame #3: <unknown function> + 0x3f33df (0x556cdba533df in build/nvfuser_tests)
frame #4: <unknown function> + 0x3f38ed (0x556cdba538ed in build/nvfuser_tests)
frame #5: <unknown function> + 0x315e67 (0x556cdb975e67 in build/nvfuser_tests)
frame #6: <unknown function> + 0x7c5780 (0x556cdbe25780 in build/nvfuser_tests)
frame #7: <unknown function> + 0x7c5877 (0x556cdbe25877 in build/nvfuser_tests)
frame #8: <unknown function> + 0x138f8cc (0x556cdc9ef8cc in build/nvfuser_tests)
frame #9: <unknown function> + 0x1457f0b (0x556cdcab7f0b in build/nvfuser_tests)
frame #10: <unknown function> + 0x14519fd (0x556cdcab19fd in build/nvfuser_tests)
frame #11: <unknown function> + 0x142de24 (0x556cdca8de24 in build/nvfuser_tests)
frame #12: <unknown function> + 0x142e93f (0x556cdca8e93f in build/nvfuser_tests)
frame #13: <unknown function> + 0x142f345 (0x556cdca8f345 in build/nvfuser_tests)
frame #14: <unknown function> + 0x143f86c (0x556cdca9f86c in build/nvfuser_tests)
frame #15: <unknown function> + 0x1458e98 (0x556cdcab8e98 in build/nvfuser_tests)
frame #16: <unknown function> + 0x1452ac7 (0x556cdcab2ac7 in build/nvfuser_tests)
frame #17: <unknown function> + 0x143de6d (0x556cdca9de6d in build/nvfuser_tests)
frame #18: <unknown function> + 0x1407ca0 (0x556cdca67ca0 in build/nvfuser_tests)
frame #19: <unknown function> + 0x1407c19 (0x556cdca67c19 in build/nvfuser_tests)
frame #20: <unknown function> + 0x29d90 (0x7f616c7d4d90 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #21: __libc_start_main + 0x80 (0x7f616c7d4e40 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #22: <unknown function> + 0x11e9d5 (0x556cdb77e9d5 in build/nvfuser_tests)
" thrown in the test body.

To reproduce: NVFUSER_TEST_RANDOM_SEED=1711120799 NVFUSER_TEST_ATEN_RANDOM_SEED=0 nvfuser_tests --gtest_filter='SerialGridReductionTest.Scheduling'
[  FAILED  ] SerialGridReductionTest.Scheduling (5669 ms)
[----------] 1 test from SerialGridReductionTest (5669 ms total)
```
This test runs with serial grid reduction, then with `gridReduce`. Each time it runs two grid reductions. Both serial grid reductions succeed because the semaphore buffer is properly zeroed. The `gridReduce` succeeds the first time since the memory pool calls `at::zeros` again to request a larger buffer size (`gridReduce` requires more semaphores since there is one per thread segment vs one for each each block segment). However, the second call to `gridReduce` fails because it has not cleaned up its semaphores. Hacking that function to force `PERSISTENT=1` would clean up the semaphores resulting in success in this case. I'm leaving those kind of modifications for a follow-up.