### PR TITLE
Evaluate `Matmul+Bias`

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -321,8 +321,9 @@ class NVF_API UnaryOp : public Expr {
   }
 
   std::vector<PolymorphicValue> evaluate(
-    const ExpressionEvaluator& ee,
-    std::unordered_map<const Val*, PolymorphicValue>& known_values) const override;
+      const ExpressionEvaluator& ee,
+      std::unordered_map<const Val*, PolymorphicValue>& known_values)
+      const override;
 
   std::string toString(int indent_size = 0) const override;
   std::string toInlineString(int indent_size = 0) const override;

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -321,8 +321,8 @@ class NVF_API UnaryOp : public Expr {
   }
 
   std::vector<PolymorphicValue> evaluate(
-      const ExpressionEvaluator& ee,
-      const std::vector<PolymorphicValue>& inputs) const override;
+    const ExpressionEvaluator& ee,
+    std::unordered_map<const Val*, PolymorphicValue>& known_values) const override;
 
   std::string toString(int indent_size = 0) const override;
   std::string toInlineString(int indent_size = 0) const override;
@@ -1447,10 +1447,6 @@ class NVF_API MmaOp : public Expr {
   const auto& batchAxes() const {
     return attribute<AxesData>(ATTR_POS_BATCH_AXES);
   }
-
-  std::vector<PolymorphicValue> evaluate(
-      const ExpressionEvaluator& ee,
-      const std::vector<PolymorphicValue>& inputs) const override;
 
  private:
   // Predefined idexes of attributes stored for this IR node, to avoid

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -392,12 +392,17 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
     std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
   using namespace PolymorphicValue_functions;
 
-  // If the UnaryOp is CastOp, check if the preceding pattern of 
-  // operators matches with matmul (MmaOp(Broadcast (A), Broadcast(B)) -> Cast) or matmul + bias 
-  // (BinaryOp::Add (MmaOp(Broadcast (A), Broadcast(B), Broadcast(bias)) -> Cast)
-  // If not, evaluate UnaryOp::CastOp along with the other types by evaluating the immediate input. 
+  // If the UnaryOp is CastOp, check if the preceding pattern of
+  / operators matches with matmul (MmaOp(Broadcast (A), Broadcast(B)) -> Cast) 
+  // r matmul + bias
+ inaryOp::Add (MmaOp(Broadcast (A), Broadcast(B), B
+  // oadcast(bias)) -> Cast)
+   not, evaluate UnaryOp::CastOp along with the o
+  // her types by evaluating the immediate input.
 
-  auto has_matmul_and_bias = [](Val* in) -> bool {
+
+
+  o has_matmul_and_bias = [](Val* in) -> bool {
     if (auto* binary = dynamic_cast<BinaryOp*>(in->definition())) {
       if (binary->getBinaryOpType() == BinaryOpType::Add) {
         if (binary->input(0)->definition()->isA<MmaOp>()) {
@@ -408,18 +413,24 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
     return false;
   };
 
-  if ((getUnaryOpType() == UnaryOpType::Cast) && input(0)->definition() != nullptr){ 
-    // Case 1: MmaOp + Cast (Matmul)
+  if ((getUnaryOpType() == UnaryOpType::Cast) && in
+      ut(0)->definition() != nullptr){
+   
+    ase 1: MmaOp + Cast (Matmul)
     if (auto* mma = dynamic_cast<MmaOp*>(input(0)->definition())) {
       MmaOpUtils::verifyMmaOpForEvaluation(mma, out()->getDataType().value());
-      
-      std::vector<at::Tensor> mma_inputs;
-      for (Val* inp: mma->inputs()) {
+
+  
+
+      r<at::Tensor> mma_inputs;
+      for (Val* inp: mma->inp uts()) {
         auto eval_i = ee.evaluate(inp, known_values);
         mma_inputs.push_back(eval_i.as<at::Tensor>());
       }
-      
-      const auto a = mma_inputs.at(0).squeeze(-1);
+
+      co
+
+      ma_inputs.at(0).squeeze(-1);
       const auto b = mma_inputs.at(1).squeeze(0);
 
       // After removing the broadcast dimensions, the format should be
@@ -433,29 +444,38 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
       MmaOp* mma = binary->input(0)->definition()->as<MmaOp>();
 
       MmaOpUtils::verifyMmaOpForEvaluation(mma, out()->getDataType().value());
-      MmaOpUtils::verifyBiasForEvaluation(binary->input(1), out()->getDataType().value());
-      
-      // BinaryOp <- Broadcast <- CastOp <- Bias
-      const Val* bias = binary->input(1)->definition()->input(0)->definition()->input(0);
-      const auto bias_tensor = ee.evaluate(bias, known_values).as<at::Tensor>().unsqueeze(-1);
+      MmaOpUtils::verifyBiasForEvaluation(binary->input(1)
+          , out()->getDataType().value());
+
+      // Binar
+
+      st <- CastOp <- Bias
+      const Val* bias = binary->input(1)->def
+          nition()->input(0)->definition()->input(0);
+      const auto bias_tensor = ee.evaluate(bias, kno
+          n_values).as<at::Tensor>().unsqueeze(-1);
 
       std::vector<at::Tensor> mma_inputs;
       for (Val* inp: mma->inputs()) {
-        auto eval_i = ee.evaluate(inp, known_values);
+         auto eval_i = ee.evaluate(inp, known_values);
         mma_inputs.push_back(eval_i.as<at::Tensor>());
       }
-      
-      const auto a = mma_inputs.at(0).squeeze(-1);
+
+      const auto a =
+
+      (0).squeeze(-1);
       const auto b = mma_inputs.at(1).squeeze(0);
 
       return {at::addmm(bias_tensor, a, b)};
     }
   }
 
-  const auto& in = ee.evaluate(inputs().at(0), known_values);
+  // If there is not a preceding MmaOp, evaluate immediate inputs and compute the output for unary ops.
+ 
+  // const auto& in = ee.evaluate(inputs().at(0), known_values);
   if (!in.hasValue()) {
-      return {std::monostate{}};
-  }
+      return {std::monostat
+     }
 
   switch (getUnaryOpType()) {
     case UnaryOpType::Neg:
@@ -4470,3 +4490,4 @@ std::vector<PolymorphicValue> CatOp::evaluate(
 }
 
 } // namespace nvfuser
+                            

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -393,16 +393,12 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
   using namespace PolymorphicValue_functions;
 
   // If the UnaryOp is CastOp, check if the preceding pattern of
-  / operators matches with matmul (MmaOp(Broadcast (A), Broadcast(B)) -> Cast) 
-  // r matmul + bias
- inaryOp::Add (MmaOp(Broadcast (A), Broadcast(B), B
-  // oadcast(bias)) -> Cast)
-   not, evaluate UnaryOp::CastOp along with the o
-  // her types by evaluating the immediate input.
+  // operators matches with matmul (MmaOp(Broadcast (A), Broadcast(B)) -> Cast)
+  // or matmul + bias (BinaryOp::Add (MmaOp(Broadcast (A), Broadcast(B),
+  // Broadcast(bias)) -> Cast) If not, evaluate UnaryOp::CastOp along with the
+  // other types by evaluating the immediate input.
 
-
-
-  o has_matmul_and_bias = [](Val* in) -> bool {
+  auto has_matmul_and_bias = [](Val* in) -> bool {
     if (auto* binary = dynamic_cast<BinaryOp*>(in->definition())) {
       if (binary->getBinaryOpType() == BinaryOpType::Add) {
         if (binary->input(0)->definition()->isA<MmaOp>()) {
@@ -413,24 +409,19 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
     return false;
   };
 
-  if ((getUnaryOpType() == UnaryOpType::Cast) && in
-      ut(0)->definition() != nullptr){
-   
-    ase 1: MmaOp + Cast (Matmul)
+  if ((getUnaryOpType() == UnaryOpType::Cast) &&
+      input(0)->definition() != nullptr) {
+    // Case 1: MmaOp + Cast (Matmul)
     if (auto* mma = dynamic_cast<MmaOp*>(input(0)->definition())) {
       MmaOpUtils::verifyMmaOpForEvaluation(mma, out()->getDataType().value());
 
-  
-
-      r<at::Tensor> mma_inputs;
-      for (Val* inp: mma->inp uts()) {
+      std::vector<at::Tensor> mma_inputs;
+      for (Val* inp : mma->inputs()) {
         auto eval_i = ee.evaluate(inp, known_values);
         mma_inputs.push_back(eval_i.as<at::Tensor>());
       }
 
-      co
-
-      ma_inputs.at(0).squeeze(-1);
+      const auto a = mma_inputs.at(0).squeeze(-1);
       const auto b = mma_inputs.at(1).squeeze(0);
 
       // After removing the broadcast dimensions, the format should be
@@ -444,38 +435,34 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
       MmaOp* mma = binary->input(0)->definition()->as<MmaOp>();
 
       MmaOpUtils::verifyMmaOpForEvaluation(mma, out()->getDataType().value());
-      MmaOpUtils::verifyBiasForEvaluation(binary->input(1)
-          , out()->getDataType().value());
+      MmaOpUtils::verifyBiasForEvaluation(
+          binary->input(1), out()->getDataType().value());
 
-      // Binar
-
-      st <- CastOp <- Bias
-      const Val* bias = binary->input(1)->def
-          nition()->input(0)->definition()->input(0);
-      const auto bias_tensor = ee.evaluate(bias, kno
-          n_values).as<at::Tensor>().unsqueeze(-1);
+      // BinaryOp <- Broadcast <- CastOp <- Bias
+      const Val* bias =
+          binary->input(1)->definition()->input(0)->definition()->input(0);
+      const auto bias_tensor =
+          ee.evaluate(bias, known_values).as<at::Tensor>().unsqueeze(-1);
 
       std::vector<at::Tensor> mma_inputs;
-      for (Val* inp: mma->inputs()) {
-         auto eval_i = ee.evaluate(inp, known_values);
+      for (Val* inp : mma->inputs()) {
+        auto eval_i = ee.evaluate(inp, known_values);
         mma_inputs.push_back(eval_i.as<at::Tensor>());
       }
 
-      const auto a =
-
-      (0).squeeze(-1);
+      const auto a = mma_inputs.at(0).squeeze(-1);
       const auto b = mma_inputs.at(1).squeeze(0);
 
       return {at::addmm(bias_tensor, a, b)};
     }
   }
 
-  // If there is not a preceding MmaOp, evaluate immediate inputs and compute the output for unary ops.
- 
-  // const auto& in = ee.evaluate(inputs().at(0), known_values);
+  // If there is not a preceding MmaOp, evaluate immediate inputs and compute
+  // the output for unary ops.
+  const auto& in = ee.evaluate(inputs().at(0), known_values);
   if (!in.hasValue()) {
-      return {std::monostat
-     }
+    return {std::monostate{}};
+  }
 
   switch (getUnaryOpType()) {
     case UnaryOpType::Neg:
@@ -4490,4 +4477,3 @@ std::vector<PolymorphicValue> CatOp::evaluate(
 }
 
 } // namespace nvfuser
-                            

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1319,14 +1319,17 @@ void verifyMmaOpForEvaluation(MmaOp* mma_op, DataType final_out_dtype) {
   const Val* in_a = mma_op->inA();
   const Val* in_b = mma_op->inB();
 
+  const auto tv_a = in_a->as<TensorView>();
+  const auto tv_b = in_b->as<TensorView>();
+
   NVF_ERROR(
-      in_a->as<TensorView>()->nDims() == in_b->as<TensorView>()->nDims(),
+      tv_a->nDims() == tv_b->nDims(),
       "Either both or none of A and B should be batch");
   // Verify that the broadcasted size is 3.
   NVF_ERROR(
-      in_a->as<TensorView>()->nDims() == 3,
+      tv_a->nDims() == 3,
       "MmaOp::evaluate is not implemented for size: ",
-      in_a->as<TensorView>()->nDims());
+      tv_a->nDims());
 
   NVF_ERROR(
       in_a->definition() != nullptr && in_a->definition()->isA<BroadcastOp>(),
@@ -1335,10 +1338,10 @@ void verifyMmaOpForEvaluation(MmaOp* mma_op, DataType final_out_dtype) {
       in_b->definition() != nullptr && in_b->definition()->isA<BroadcastOp>(),
       "Currently, MmaOp::evaluate assumes the preceding op to be a broadcast.");
   NVF_ERROR(
-      in_a->as<TensorView>()->getRootDomain().back()->isBroadcast(),
+      tv_a->getRootDomain().back()->isBroadcast(),
       "Expected last dimension to be broadcasted for first operand.");
   NVF_ERROR(
-      in_b->as<TensorView>()->getRootDomain().front()->isBroadcast(),
+      tv_b->getRootDomain().front()->isBroadcast(),
       "Expected first dimension to be broadcasted for second operand.");
 
   // ATen preserves the dtype of MmaOp inputs whereas MmaOp generates float
@@ -1352,7 +1355,7 @@ void verifyMmaOpForEvaluation(MmaOp* mma_op, DataType final_out_dtype) {
   // occur.
 
   NVF_ERROR(
-      in_a->as<TensorView>()->getDataType().value() == final_out_dtype,
+      tv_a->getDataType().value() == final_out_dtype,
       "CastOp should cast to the same final datatype as the input datatype.");
 }
 

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1367,14 +1367,15 @@ void verifyMmaOpForEvaluation(
 }
 
 bool matchMatmulCast(const UnaryOp* cast_op, Val*& mma_lhs, Val*& mma_rhs) {
-  if (auto* mma = dynamic_cast<MmaOp*>(cast_op->input(0)->definition())) {
-    MmaOpUtils::verifyMmaOpForEvaluation(
-        mma, cast_op->out()->getDataType().value());
-    mma_lhs = mma->inA();
-    mma_rhs = mma->inB();
-    return true;
+  auto* mma = dynamic_cast<MmaOp*>(
+      cast_op->input(0)->definition()) if (mma == nullptr) {
+    return false;
   }
-  return false;
+  MmaOpUtils::verifyMmaOpForEvaluation(
+      mma, cast_op->out()->getDataType().value());
+  mma_lhs = mma->inA();
+  mma_rhs = mma->inB();
+  return true;
 }
 
 bool matchMatmulBiasCast(

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1367,8 +1367,8 @@ void verifyMmaOpForEvaluation(
 }
 
 bool matchMatmulCast(const UnaryOp* cast_op, Val*& mma_lhs, Val*& mma_rhs) {
-  auto* mma = dynamic_cast<MmaOp*>(
-      cast_op->input(0)->definition()) if (mma == nullptr) {
+  auto* mma = dynamic_cast<MmaOp*>(cast_op->input(0)->definition());
+  if (mma == nullptr) {
     return false;
   }
   MmaOpUtils::verifyMmaOpForEvaluation(

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -58,11 +58,16 @@ MmaOpDetails getMmaOpDetails(
     TensorView* in_a,
     TensorView* in_b);
 
-// std::vector<PolymorphicValue> evaluateAsMatmul(MmaOp* mma_op, DataType
-// castop_out_dtype);
-
 void verifyMmaOpForEvaluation(MmaOp* mma_op, DataType castop_out_dtype);
-void verifyBiasForEvaluation(Val* bias, DataType final_out_dtype);
+
+bool matchMatmulCast(const UnaryOp* cast_op, Val*& mma_lhs, Val*& mma_rhs);
+
+bool matchMatmulBiasCast(
+    const UnaryOp* cast_op,
+    Val*& mma_lhs,
+    Val*& mma_rhs,
+    Val*& bias);
+
 } // namespace nvfuser::MmaOpUtils
 
 namespace nvfuser::ir_utils {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -63,6 +63,9 @@ MmaOpDetails getMmaOpDetails(
 void verifyMmaOpForEvaluation(
   MmaOp* mma_op, DataType castop_out_dtype
 );
+void verifyBiasForEvaluation(
+  Val* bias,
+  DataType final_out_dtype);
 } // namespace nvfuser::MmaOpUtils
 
 namespace nvfuser::ir_utils {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -58,7 +58,9 @@ MmaOpDetails getMmaOpDetails(
     TensorView* in_a,
     TensorView* in_b);
 
-void verifyMmaOpForEvaluation(MmaOp* mma_op, DataType castop_out_dtype);
+void verifyMmaOpForEvaluation(
+    MmaOp* mma_op,
+    const DataType expected_input_dtype);
 
 bool matchMatmulCast(const UnaryOp* cast_op, Val*& mma_lhs, Val*& mma_rhs);
 

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -58,6 +58,11 @@ MmaOpDetails getMmaOpDetails(
     TensorView* in_a,
     TensorView* in_b);
 
+// std::vector<PolymorphicValue> evaluateAsMatmul(MmaOp* mma_op, DataType castop_out_dtype);
+
+void verifyMmaOpForEvaluation(
+  MmaOp* mma_op, DataType castop_out_dtype
+);
 } // namespace nvfuser::MmaOpUtils
 
 namespace nvfuser::ir_utils {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -58,9 +58,7 @@ MmaOpDetails getMmaOpDetails(
     TensorView* in_a,
     TensorView* in_b);
 
-void verifyMmaOpForEvaluation(
-    MmaOp* mma_op,
-    const DataType expected_input_dtype);
+void verifyMmaOpForEvaluation(MmaOp* mma_op, DataType expected_input_dtype);
 
 bool matchMatmulCast(const UnaryOp* cast_op, Val*& mma_lhs, Val*& mma_rhs);
 

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -58,14 +58,11 @@ MmaOpDetails getMmaOpDetails(
     TensorView* in_a,
     TensorView* in_b);
 
-// std::vector<PolymorphicValue> evaluateAsMatmul(MmaOp* mma_op, DataType castop_out_dtype);
+// std::vector<PolymorphicValue> evaluateAsMatmul(MmaOp* mma_op, DataType
+// castop_out_dtype);
 
-void verifyMmaOpForEvaluation(
-  MmaOp* mma_op, DataType castop_out_dtype
-);
-void verifyBiasForEvaluation(
-  Val* bias,
-  DataType final_out_dtype);
+void verifyMmaOpForEvaluation(MmaOp* mma_op, DataType castop_out_dtype);
+void verifyBiasForEvaluation(Val* bias, DataType final_out_dtype);
 } // namespace nvfuser::MmaOpUtils
 
 namespace nvfuser::ir_utils {

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -107,7 +107,7 @@ TEST_F(MatmulATenEvaluationTest, MulSumAndCast) {
 
 // Disabled until at::addmm support is add.
 // See https://github.com/NVIDIA/Fuser/pull/1874#discussion_r1516991574
-TEST_F(MatmulATenEvaluationTest, DISABLED_MatmulWithBias) {
+TEST_F(MatmulATenEvaluationTest, MatmulWithBias) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -132,7 +132,7 @@ TEST_F(MatmulATenEvaluationTest, DISABLED_MatmulWithBias) {
   at::Tensor t0 = at::randn(a_shape, at::kHalf).cuda();
   at::Tensor t1 = at::randn(b_shape, at::kHalf).cuda();
   at::Tensor t2 = at::randn({m}, at::kHalf).cuda();
-  at::Tensor out_ref = at::matmul(t0, t1) + t2.unsqueeze(-1);
+  at::Tensor out_ref = at::addmm(t2.unsqueeze(-1), t0, t1);
 
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs({t0, t1, t2});


### PR DESCRIPTION
Adds ATen evaluation for Matmul and Matmul + Bias. Based on PR #1921, when evaluating a `castOp`, we _look back_ to see if there is a preceding MmaOp and evaluate them together.

Issue #1775.