### PR TITLE
Add kir::Allocate::resetsToZero()

### DIFF
--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -1458,6 +1458,7 @@ class AllocationAliasModifier : private kir::ExprMutator {
         old_alloc->memoryType(),
         old_alloc->shape(),
         old_alloc->zeroInit(),
+        /*reset_to_zero=*/false,
         alloc_expr_to);
 
     registerReplace(old_alloc, new_alloc);

--- a/csrc/device_lower/pass/grid_serialization.cpp
+++ b/csrc/device_lower/pass/grid_serialization.cpp
@@ -127,7 +127,8 @@ class GridSerializationSyncInserter : kir::ExprMutator {
     kir::Allocate* alloc = lower_utils::allocGlobalBufferForGridComm(
         lower_utils::getGridSyncBufferSize(cur_expr_sync_pattern_.value()),
         DataType::Int,
-        true);
+        /*zero_init=*/true,
+        /*resets_to_zero=*/true);
     auto wait = IrBuilder::create<kir::BlockSerializeWait>(
         cur_expr_sync_pattern_.value(), alloc->buffer());
     registerInsertBefore(cur_top_level_expr_, alloc);

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -694,7 +694,8 @@ bool hasBlockSync(const Expr* expr, const ThreadPredicateMap& pred_map) {
 kir::Allocate* allocGlobalBufferForGridComm(
     Val* buffer_size,
     DataType dtype,
-    bool zero_init) {
+    bool zero_init,
+    bool resets_to_zero) {
   const std::vector<IterDomain*> new_buffer_ids = {
       IrBuilder::create<IterDomain>(IterDomainBuilder(
           GpuLower::current()->kernel()->zeroVal(), buffer_size))};
@@ -702,7 +703,11 @@ kir::Allocate* allocGlobalBufferForGridComm(
   const auto buffer_tv =
       IrBuilder::create<TensorView>(buffer_domain, dtype, MemoryType::Global);
   return IrBuilder::create<kir::Allocate>(
-      buffer_tv, buffer_tv->getMemoryType(), nullptr, zero_init);
+      buffer_tv,
+      buffer_tv->getMemoryType(),
+      nullptr,
+      zero_init,
+      resets_to_zero);
 }
 
 BasicAllocInfo getAllocInformation(

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -257,7 +257,8 @@ bool hasBlockSync(const Expr* expr, const ThreadPredicateMap& pred_map);
 kir::Allocate* allocGlobalBufferForGridComm(
     Val* buffer_size,
     DataType dtype,
-    bool zero_init);
+    bool zero_init,
+    bool resets_to_zero = false);
 
 struct BasicAllocInfo {
   // The for loop that the initialization of this allocation must be

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1818,7 +1818,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
           // Allow access to reusable zeroed memory if buffer is guaranteed
           // to reset to zero upon completion of the kernel, or if we have
           // enabled the option (unsafe)
-          intermediate_buffer = contigZeroTensor(
+          intermediate_buffer = contigZeroedTensor(
               unexpanded_sizes, buf_info.type, options_.device);
         } else {
           intermediate_buffer = at::zeros(

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -2258,6 +2258,7 @@ flatbuffers::Offset<serde::GlobalBufferInfo> FusionExecutor::serialize(
       &data.strides,
       nvfuser::toUnderlying(data.type),
       data.zero_init,
+      data.resets_to_zero,
       data.is_profile_buffer,
       is_fusion_output);
 }
@@ -2392,7 +2393,7 @@ FusionExecutor::GlobalBufferInfo FusionExecutor::deserialize(
 
   info.type = serde::mapToAtenDtype(buffer->dtype());
   info.zero_init = buffer->zero_init();
-  info.resets_to_zero = buffer->zero_init();
+  info.resets_to_zero = buffer->resets_to_zero();
   info.is_profile_buffer = buffer->is_profile_buffer();
   return info;
 }

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -50,6 +50,7 @@ class FusionExecutor : public NonCopyable {
     std::vector<int64_t> strides;
     at::ScalarType type = at::ScalarType::Undefined;
     bool zero_init = false;
+    bool resets_to_zero = false;
     bool is_profile_buffer = false;
   };
 

--- a/csrc/global_allocator.cpp
+++ b/csrc/global_allocator.cpp
@@ -105,7 +105,7 @@ thread_local std::vector<Arena> arenas;
 
 } // namespace
 
-at::Tensor contigZeroTensor(
+at::Tensor contigZeroedTensor(
     const std::vector<int64_t>& sizes,
     const c10::ScalarType& aten_dtype,
     const c10::Device& device) {

--- a/csrc/global_allocator.h
+++ b/csrc/global_allocator.h
@@ -11,10 +11,10 @@
 
 namespace nvfuser {
 
-//! This returns a slice of a thread local at::Tensor that is zeroed. Uses of
-//! this memory should always "clean up" by resetting the memory to zero at the
-//! end of the kernel.
-at::Tensor contigZeroTensor(
+//! This returns a slice of a thread local at::Tensor that contains all zeroes.
+//! Uses of this memory should always "clean up" by resetting the memory to zero
+//! at the end of the kernel.
+at::Tensor contigZeroedTensor(
     const std::vector<int64_t>& sizes,
     const c10::ScalarType& aten_dtype,
     const c10::Device& device);

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -135,6 +135,7 @@ Allocate::Allocate(
     MemoryType memory_type,
     std::vector<Val*> shape,
     bool zero_init,
+    bool resets_to_zero,
     Allocate* alias)
     : Expr(passkey) {
   NVF_ERROR(passkey.ir_container_ != nullptr);
@@ -178,6 +179,7 @@ Allocate::Allocate(
   addAttribute(buffer);
   addDataAttribute(memory_type);
   addDataAttribute(zero_init);
+  addDataAttribute(resets_to_zero);
   addAttribute(alias);
   // Always initialize shared memory address to nullptr
   addAttribute(nullptr);
@@ -192,13 +194,15 @@ Allocate::Allocate(
     Val* buffer,
     MemoryType memory_type,
     Val* size,
-    bool zero_init)
+    bool zero_init,
+    bool resets_to_zero)
     : Allocate(
           passkey,
           buffer,
           memory_type,
           size == nullptr ? std::vector<Val*>{} : std::vector<Val*>{size},
-          zero_init) {}
+          zero_init,
+          resets_to_zero) {}
 
 std::string Allocate::toString(int indent_size) const {
   std::stringstream ss;
@@ -206,9 +210,9 @@ std::string Allocate::toString(int indent_size) const {
   ss << " = ALLOCATE("
      << "buffer=" << buffer()->toString() << ", "
      << "mem_type=" << memoryType() << ", "
-     << "size=" << size()->toInlineString();
-  ss << ", "
-     << "zero_init=" << boolLiteral(zeroInit()) << ")\n";
+     << "size=" << size()->toInlineString() << ", "
+     << "zero_init=" << boolLiteral(zeroInit()) << ", "
+     << "resets_to_zero=" << boolLiteral(resetsToZero()) << ")\n";
   if (alias() != nullptr) {
     indent(ss, indent_size) << kTab << ".alias=";
     ss << alias()->buffer()->toString() << "\n";

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -212,6 +212,7 @@ table GlobalBufferInfo {
   strides : [long];
   dtype : long;
   zero_init : bool;
+  resets_to_zero : bool;
   is_profile_buffer : bool;
   is_fusion_output : bool;
 }

--- a/tests/cpp/test_serial_gridreduce.cpp
+++ b/tests/cpp/test_serial_gridreduce.cpp
@@ -37,110 +37,91 @@ using SerialGridReductionTest = NVFuserTest;
 
 TEST_F(SerialGridReductionTest, Scheduling) {
   for (bool serial : {true, false}) {
-    // For serial grid reduction we test that re-using semaphore buffers works
-    // properly. This will cause a failure if serial grid reduction does not
-    // properly clean up its semaphores.
-    std::vector<bool> reuse_zeroed_memory_values{false};
-    if (serial) {
-      reuse_zeroed_memory_values.push_back(true);
-    }
-    for (bool reuse_zeroed_memory : reuse_zeroed_memory_values) {
-      EnableOptionsGuard eog;
-      if (reuse_zeroed_memory) {
-        EnableOptionsGuard::getCurOptions().set(
-            EnableOption::ReuseZeroedMemory);
-      } else {
-        EnableOptionsGuard::getCurOptions().unset(
-            EnableOption::ReuseZeroedMemory);
-      }
-      for (int64_t num_warps : {4, 8}) {
-        // B is size of inner serial loop. Outer loop is hardcoded at A=4
-        // Here we set B to a small value of 8 instead of 32 (i.e. 128 elements
-        // per thread), so that the non-serial compilation does not take too
-        // long.
-        for (int64_t B : {8}) {
-          std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
-          auto fusion = fusion_ptr.get();
-          FusionGuard fg(fusion);
+    for (int64_t num_warps : {4, 8}) {
+      // B is size of inner serial loop. Outer loop is hardcoded at A=4
+      // Here we set B to a small value of 8 instead of 32 (i.e. 128 elements
+      // per thread), so that the non-serial compilation does not take too
+      // long.
+      for (int64_t B : {8}) {
+        std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+        auto fusion = fusion_ptr.get();
+        FusionGuard fg(fusion);
 
-          int64_t blocks_x = 8;
-          int64_t blocks_y = 8;
-          int64_t blocks_z = 5;
-          int64_t A = 4; // Size of outer serial loop
-          int64_t H = blocks_z;
-          int64_t W = A * B * blocks_x * blocks_y * num_warps * 32;
+        int64_t blocks_x = 8;
+        int64_t blocks_y = 8;
+        int64_t blocks_z = 5;
+        int64_t A = 4; // Size of outer serial loop
+        int64_t H = blocks_z;
+        int64_t W = A * B * blocks_x * blocks_y * num_warps * 32;
 
-          // Unreduced dimensions should be concrete. Reduced dimension could be
-          // symbolic, but is concrete here so that we can read tv0 to registers
-          TensorView* tv0 = TensorViewBuilder()
-                                .shape({H, W})
-                                .dtype(DataType::Float)
-                                .contiguity(true)
-                                .build();
-          fusion->addInput(tv0);
+        // Unreduced dimensions should be concrete. Reduced dimension could be
+        // symbolic, but is concrete here so that we can read tv0 to registers
+        TensorView* tv0 = TensorViewBuilder()
+                              .shape({H, W})
+                              .dtype(DataType::Float)
+                              .contiguity(true)
+                              .build();
+        fusion->addInput(tv0);
 
-          auto tv1 = sum(tv0, {0});
-          fusion->addOutput(tv1);
+        auto tv1 = sum(tv0, {0});
+        fusion->addOutput(tv1);
 
-          // Start with
-          //   [ rS{H}, iS{W} ]
-          // We are grid reducing the H dimension and we want to coalesce
-          // accesses in the W dimension. So we first reorder to
-          //   [ iS{W}, rS{H} ]
-          // then schedule as
-          //   [ iBIDx{blocks_x}, iBIDy{blocks_y}, iS{A}, iS{B},
-          //   iTIDy{num_warps}, iTIDx{32}, rBIDz{blocks_z} ]
-          auto tv2 = tv0->cacheAfter();
-          auto tv3 = tv1->cacheBefore();
+        // Start with
+        //   [ rS{H}, iS{W} ]
+        // We are grid reducing the H dimension and we want to coalesce
+        // accesses in the W dimension. So we first reorder to
+        //   [ iS{W}, rS{H} ]
+        // then schedule as
+        //   [ iBIDx{blocks_x}, iBIDy{blocks_y}, iS{A}, iS{B},
+        //   iTIDy{num_warps}, iTIDx{32}, rBIDz{blocks_z} ]
+        auto tv2 = tv0->cacheAfter();
+        auto tv3 = tv1->cacheBefore();
 
-          tv3->reorder(
-              {{1, 0}, {0, 1}}); // blocks_x*blocks_y*A*B*num_warps*32, H
-          tv3->split(0, 32); // blocks_x*blocks_y*A*B*num_warps, 32, H
-          tv3->split(0, num_warps); // blocks_x*blocks_y*A*B, num_warps, 32, H
-          tv3->split(0, B); // blocks_x*blocks_y*A, B, num_warps, 32, H
-          tv3->split(0, A); // blocks_x*blocks_y, A, B, num_warps, 32, H
-          tv3->split(0, blocks_y); // blocks_x, blocks_y, A, B, num_warps, 32, H
-          tv3->axis(0)->parallelize(ParallelType::BIDx);
-          tv3->axis(1)->parallelize(ParallelType::BIDy);
-          tv3->axis(4)->parallelize(ParallelType::TIDy);
-          tv3->axis(5)->parallelize(ParallelType::TIDx);
-          tv3->axis(6)->parallelize(ParallelType::BIDz);
-          // Reorder to put parallel dims first for better inlining
-          tv3->reorder({
-              {4, 2},
-              {5, 3},
-              {2, 4},
-              {3, 5},
-          });
+        tv3->reorder({{1, 0}, {0, 1}}); // blocks_x*blocks_y*A*B*num_warps*32, H
+        tv3->split(0, 32); // blocks_x*blocks_y*A*B*num_warps, 32, H
+        tv3->split(0, num_warps); // blocks_x*blocks_y*A*B, num_warps, 32, H
+        tv3->split(0, B); // blocks_x*blocks_y*A, B, num_warps, 32, H
+        tv3->split(0, A); // blocks_x*blocks_y, A, B, num_warps, 32, H
+        tv3->split(0, blocks_y); // blocks_x, blocks_y, A, B, num_warps, 32, H
+        tv3->axis(0)->parallelize(ParallelType::BIDx);
+        tv3->axis(1)->parallelize(ParallelType::BIDy);
+        tv3->axis(4)->parallelize(ParallelType::TIDy);
+        tv3->axis(5)->parallelize(ParallelType::TIDx);
+        tv3->axis(6)->parallelize(ParallelType::BIDz);
+        // Reorder to put parallel dims first for better inlining
+        tv3->reorder({
+            {4, 2},
+            {5, 3},
+            {2, 4},
+            {3, 5},
+        });
 
-          TransformPropagator propagator(tv3);
-          MaxRootDomainInfoSpanningTree(tv3).traverse(&propagator);
-          scheduler_utils::parallelizeAllLike(tv3);
+        TransformPropagator propagator(tv3);
+        MaxRootDomainInfoSpanningTree(tv3).traverse(&propagator);
+        scheduler_utils::parallelizeAllLike(tv3);
 
-          // Here we just transpose A and B in tv2, so that it will be partially
-          // inlined with tv3, resulting in a separate loop to load tv0 into
-          // registers (tv2).
-          tv2->reorder({
-              {-2, -3},
-              {-3, -2},
-          });
+        // Here we just transpose A and B in tv2, so that it will be partially
+        // inlined with tv3, resulting in a separate loop to load tv0 into
+        // registers (tv2).
+        tv2->reorder({
+            {-2, -3},
+            {-3, -2},
+        });
 
-          inlineMost();
+        inlineMost();
 
-          FusionExecutor fe;
-          if (serial) {
-            tv3->definition()->as<ReductionOp>()->requestSerialGridReduction();
-          }
-          fe.compileFusion(fusion);
+        FusionExecutor fe;
+        if (serial) {
+          tv3->definition()->as<ReductionOp>()->requestSerialGridReduction();
+        }
+        fe.compileFusion(fusion);
 
-          auto input = at::randn(
-              {H, W},
-              at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
-          auto outputs = fe.runFusion({input});
+        auto input = at::randn(
+            {H, W}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+        auto outputs = fe.runFusion({input});
 
-          if (serial) {
-            testValidate(fusion, outputs, {input}, __LINE__, __FILE__);
-          }
+        if (serial) {
+          testValidate(fusion, outputs, {input}, __LINE__, __FILE__);
         }
       }
     }


### PR DESCRIPTION
As suggested by @naoyam, this will allow us to incrementally enable reuse of zeroed memory (see #1984) on a case-by-case basis. To do so, when creating an `Allocate` node, if it is guaranteed to be "cleaned up" (i.e. reset to all zero values) by the end of the kernel, then you can pass `true` for the `resets_to_zero` argument in the `kir::Allocate` constructor. This will automatically enable reuse of zeroed memory for this buffer and avoid a memset call, regardless of whether
`EnableOption::ReuseZeroedMemory` is enabled or not. Eventually this will let us get rid of that option entirely, once all of our global memory semaphores are guaranteed to be reset.