### PR TITLE
Hack to ensure cp.async is waited before smem reuse

### DIFF
--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -1971,6 +1971,20 @@ class PromoteReuseSyncModifier : private kir::ExprMutator {
         debug() << "Inserting block sync before position " << position
                 << std::endl;
       }
+      {
+        // TODO: This is a temporary HACK to work around
+        // https://github.com/NVIDIA/Fuser/issues/2000
+        // Instead, we should only insert these wait statements when we detect
+        // that there are corresponding unsynced async operations involving the
+        // buffers in question. We should also update dispatch(Expr*) to check
+        // not only hasBlockSync but also check if there already exist AsyncWait
+        // expressions in the interval (or in some cases before the interval but
+        // after the last write?).
+        auto new_async_wait =
+            IrBuilder::create<kir::AsyncWait>(AsyncOpType::CpAsync);
+        registerInsertBefore(expr, new_async_wait);
+      }
+
       auto new_sync = IrBuilder::create<kir::BlockSync>();
       inserted_syncs_.insert(new_sync);
       registerInsertBefore(expr, new_sync);


### PR DESCRIPTION
This is a work-around for #2000.

It seems to address the issue in the only current use case for smem reuse: matmul with `params.use_smem_epilogue == true`. It is not ideal: for example it will insert a `cp.async.wait_all` instruction even if circular buffering is not used in the kernel.

Fixes #1996 but since this is a hack, I will not mark #2000 as fixed yet.