### PR TITLE
Bulk entire dim

### DIFF
--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -3473,12 +3473,12 @@ Val* Index::eye(
 //
 // Example 1:
 //
-// I0 -> split -> I1 -> split -> I3 (Bulk)
-//           \               \-> I4
-//            \-> I2 -> split -> I5 (Bulk)
-//                           \-> I6
-// I7
-// I8 (Bulk)
+// -> I0 -> split -> I1 -> split -> I3 (Bulk)
+//              \               \-> I4
+//               \-> I2 -> split -> I5 (Bulk)
+//                              \-> I6
+// -> I7
+// -> I8 (Bulk)
 //
 // Originating bulk IterDomains: { I3, I5, I8 }
 // Box IterDomains: { I3, I5, I8 }
@@ -3490,10 +3490,10 @@ Val* Index::eye(
 //
 // Example 2:
 //
-// I0 -> split -> I1 -> split -> I3 (Bulk)
-//           \               \-> I4
-//            \-> I2 -> split -> I5 -> split -> I7
-//                           \-> I6         \-> I8 (Bulk)
+// -> I0 -> split -> I1 -> split -> I3 (Bulk)
+//              \               \-> I4
+//               \-> I2 -> split -> I5 -> split -> I7
+//                              \-> I6         \-> I8 (Bulk)
 //
 // Originating bulk IterDomains: { I3, I8 }
 // Box IterDomains: { I3, I5 }
@@ -3505,8 +3505,8 @@ Val* Index::eye(
 //
 // Example 3:
 //
-// I0 -> merge -> I2 -> split -> I3 (Bulk)
-// I1 ---^                   \-> I4
+// -> I0 -> merge -> I2 -> split -> I3 (Bulk)
+// -> I1 ---^                   \-> I4
 //
 // Originating bulk IterDomains: { I3 }
 // Box IterDomains: { I3 }

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -3898,7 +3898,7 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
     auto box_id_it = tma_global_id_to_box_id.find(id);
     if (box_id_it == tma_global_id_to_box_id.end()) {
       // non-TMA-global ID
-      bool should_create_new_dim = !(state == PENDING_NON_BULK && contiguous);
+      bool should_create_new_dim = !(state != START && contiguous);
       if (should_create_new_dim) {
         tensor_sizes_inner_to_outer.push_back(id->extent());
         if (it != frontier.rbegin()) {

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -3348,11 +3348,11 @@ Val* Index::eye(
 // want a contiguous box dim (see Definition 3: "boxId" below), then we do one
 // split to get the box. If we want a strided box dim, then we do two splits,
 // the first split is to get the box, and the second split is to get the stride.
-// Note that if the tile size is 1, we can skip tiling, for this case, we call
-// it "implicitly one tiled". In the above diagram, I0 is implicitly one tiled,
-// I1 has a contiguous box dim, and I2 has a strided box dim. If we want to
-// treat the entire dimension as a tile, we can also skip tiling, for this case,
-// we call it "whole tiled". In the above diagram, I3 is whole tiled.
+// Note that if a box dimension has size 1, we can skip tiling, for this case,
+// we call it "implicitly one tiled". In the above diagram, I0 is implicitly one
+// tiled, I1 has a contiguous box dim, and I2 has a strided box dim. If we want
+// to treat the entire dimension as a tile, we can also skip tiling, for this
+// case, we call it "whole tiled". In the above diagram, I3 is whole tiled.
 //
 // Third, we can schedule the "bulk" IterDomains (see Definition 1: "bulk"
 // below) and "non-bulk" IterDomains separately in whatever way we want.

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -174,9 +174,9 @@ TEST_F(MemoryTest, RefineCachePolicy) {
 class TMATest : public NVFuserTest {
  protected:
   void SetUp() override {
-    // if (cudaArchGuardShouldSkip(9, 0)) {
-    //   GTEST_SKIP() << "skipping tests on pre-Hopper GPUs";
-    // }
+    if (cudaArchGuardShouldSkip(9, 0)) {
+      GTEST_SKIP() << "skipping tests on pre-Hopper GPUs";
+    }
     NVFuserTest::SetUp();
   }
 };
@@ -720,7 +720,7 @@ TEST_F(TMAIndexingTest, BulkEntireDim) {
   // tv2->axis(1)->parallelize(ParallelType::TIDx);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  auto t0 = at::randn({4, 32, 2, 8, 8, 8, 32, 8, 4}, options);
+  auto t0 = at::randn({32, 4, 2, 8, 8, 8, 2, 8, 4}, options);
   FusionExecutor fe;
   fe.compileFusion(&fusion, {t0}, {}, matmul_cparams);
 


### PR DESCRIPTION
This PR is stacked on https://github.com/NVIDIA/Fuser/pull/1991.

Besides https://github.com/NVIDIA/Fuser/pull/1991, another point that I feel very inconvenient when using TMA is, I am forced to do a split even if I want to treat the entire dimension as a box.

For example, if I want to load a shape `[100000000, 4]` tensor using a `[8, 4]` box, currently, I am required to schedule the tensor like `[100000000/8, 8 (bulk), 4/4, 4 (bulk)]`. This is inconvenient. This PR allows me to instead more conveniently schedule the fusion like `[100000000/8, 8 (bulk), 4 (bulk)]`.

Enabling this feature creates some complexity to the analysis in indexing. For example, if we have a contiguous tensor of shape `[1024, 4, 8, 16]`, if I schedule it like `[1024, 4, 8, 16(bulk)]`, I should be able to know that I wanted a 1D TMA. But if I instead scheduled like `[1024, 4(bulk), 8, 16(bulk)]`, I should be able to know that I need a 2D TMA. And if I scheduled it like `[1024, 4(bulk), 8(bulk), 16(bulk)]`, then I should be able to figure out that the inner 3 dims are mergable, so I will be using a 1D TMA. This requires me to extend the 2-state state machine built in https://github.com/NVIDIA/Fuser/pull/1991 into 3-state. Besides this, I also need to change the definition of `boxId` and `tmaGlobalId` to handle box without a split.

I suggest reviewing this PR hiding whitespaces:
![image](https://github.com/NVIDIA/Fuser/assets/1032377/892cfeff-f080-49a0-9846-319632538339)