### PR TITLE
[WIP] Peel off epilogue loop for circular buffering

### DIFF
--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -612,15 +612,24 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(BlockSerializeRelease)
 AsyncWait::AsyncWait(
     IrBuilderPasskey passkey,
     AsyncOpType async_op_type,
-    int64_t keep_stages)
+    Val* keep_stages)
     : Expr(passkey) {
   NVF_ERROR(passkey.ir_container_ != nullptr);
   NVF_ERROR(
       passkey.ir_container_->isA<kir::Kernel>(),
       "IR type only valid for Kernel container.");
   addDataAttribute(async_op_type);
-  addDataAttribute(keep_stages);
+  addAttribute(keep_stages);
 }
+
+AsyncWait::AsyncWait(
+    IrBuilderPasskey passkey,
+    AsyncOpType async_op_type,
+    int64_t keep_stages)
+    : AsyncWait(
+          passkey,
+          async_op_type,
+          IrBuilder::create<Val>(keep_stages, DataType::Int)) {}
 
 std::string AsyncWait::toString(int indent_size) const {
   std::stringstream ss;

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -633,7 +633,8 @@ AsyncWait::AsyncWait(
 
 std::string AsyncWait::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << ptx() << " " << keepStages() << "\n";
+  indent(ss, indent_size) << ptx() << " " << keepStages()->toInlineString()
+                          << "\n";
   return ss.str();
 }
 

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -631,7 +631,16 @@ class AsyncWait final : public Expr {
   explicit AsyncWait(
       IrBuilderPasskey passkey,
       AsyncOpType async_op_type,
-      int64_t keep_stages = 0);
+      Val* keep_stages);
+
+  explicit AsyncWait(
+      IrBuilderPasskey passkey,
+      AsyncOpType async_op_type,
+      int64_t keep_stages = 0)
+      : AsyncWait(
+            passkey,
+            async_op_type,
+            IrBuilder::create<Val>(keep_stages, DataType::Int)) {}
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
@@ -651,8 +660,8 @@ class AsyncWait final : public Expr {
 
   //! Returns the remaining number of stages that are not synchronized
   //!  after this op.
-  int64_t keepStages() const {
-    return attribute<int64_t>(1);
+  Val* keepStages() const {
+    return attributeVal(1);
   }
 };
 

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -636,11 +636,7 @@ class AsyncWait final : public Expr {
   explicit AsyncWait(
       IrBuilderPasskey passkey,
       AsyncOpType async_op_type,
-      int64_t keep_stages = 0)
-      : AsyncWait(
-            passkey,
-            async_op_type,
-            IrBuilder::create<Val>(keep_stages, DataType::Int)) {}
+      int64_t keep_stages = 0);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 


### PR DESCRIPTION
Currently, when a `TensorView` is circular buffered, we convert a loop like
```
for i in 0..N
  for j in ...
    ... = y[i, j]
```
to 
```
allocate x[S*D] // if S is the single-buffered size of the TensorView
for i in 0..D-1 // prologue
  for j in ...
    if pred:
      x[i*S + j] = y[i, j]
  cp.async.commit
cp.async.wait D-2 // Block until all but the last D-2 transactions complete
for i in 0..N // main loop
  for j in ...
    if pred:
      x[(((i+D-1)%D)*S+j)] = y[i+D-1, j]
    ... = x[((i%D)*S+j)]
    cp.async.commit
    cp.async.wait D-2
    __syncthreads()
```
As mentioned in #2000, the way we do the predicated load for circular buffering means that we actually have "in-flight" committed `cp.async` calls which will store zeros into smem. Since we allow `D-2` many of those to remain in flight after the end of this flight, they are never waited on, leading to the data race encountered in #2000.

This PR instead adds an epilogue loop, so that we now lower a circular buffered TV like this:
```
allocate x[S*D] // if S is the single-buffered size of the TensorView
for i in 0..D-1 // prologue
  for j in ...
    x[i*S + j] = y[i, j]
  cp.async.commit
cp.async.wait D-2 // Block until all but the last D-2 transactions complete
for i in 0..(N-(D-1)) // main loop
  for j in ...
    if pred:
      x[(((i+D-1)%D)*S+j)] = y[i+D-1, j]
    ... = x[((i%D)*S+j)]
    cp.async.commit
    cp.async.wait D-2
    __syncthreads()
for i in (N-(D-1))..N // epilogue
  cp.async.wait N-1-i
  for j in ...
    ... = x[((i%D)*S+j)]
```
Note that we have shortened the main loop and peeled it into the new "epilogue" loop which is identical to the main loop but without any additional async loads.

### Challenges encountered so far

This is going reasonably well, but there is a limitation I didn't notice at first: as mentioned [in the PTX docs](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-wait-group) the `N` argument in `cp.async.wait_group N` must be integer constant.