### PR TITLE
call clear allocator in gather test to avoid OOM

### DIFF
--- a/tests/cpp/test_gather.cpp
+++ b/tests/cpp/test_gather.cpp
@@ -135,6 +135,9 @@ TEST_F(IndexingOpTest, TorchGatherAllRankAllSelectedDim_CUDA) {
   for (const auto is_take_along : {false, true}) {
     for (int rank = 1; rank <= 5; ++rank) {
       for (int dim = 0; dim < rank; ++dim) {
+        // this test uses a random input shape, clear the allocator to avoid
+        // OOM.
+        maybeClearAllocator();
         auto fusion_ptr = std::make_unique<Fusion>();
         Fusion& fusion = *fusion_ptr.get();
         FusionGuard fg(&fusion);


### PR DESCRIPTION
Avoid potential OOM errors caught in https://github.com/NVIDIA/Fuser/pull/1961 in V100 test https://nv/e2E/87216881

The test uses a random input shape with a maximum size of 64^5 = 1G elements, 2 inputs and 1 output, the max requested mem can be 3 tensors  x 1G elments per tensor x 4 bytes per element = 12 GB.