### PR TITLE
Drain cp.async jobs after main loop

### DIFF
--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -1972,20 +1972,6 @@ class PromoteReuseSyncModifier : private kir::ExprMutator {
         debug() << "Inserting block sync before position " << position
                 << std::endl;
       }
-      {
-        // TODO: This is a temporary HACK to work around
-        // https://github.com/NVIDIA/Fuser/issues/2000
-        // Instead, we should only insert these wait statements when we detect
-        // that there are corresponding unsynced async operations involving the
-        // buffers in question. We should also update dispatch(Expr*) to check
-        // not only hasBlockSync but also check if there already exist AsyncWait
-        // expressions in the interval (or in some cases before the interval but
-        // after the last write?).
-        auto new_async_wait =
-            IrBuilder::create<kir::AsyncWait>(AsyncOpType::CpAsync);
-        registerInsertBefore(expr, new_async_wait);
-      }
-
       auto new_sync = IrBuilder::create<kir::BlockSync>();
       inserted_syncs_.insert(new_sync);
       registerInsertBefore(expr, new_sync);

--- a/tests/cpp/test_loop_rotation.cpp
+++ b/tests/cpp/test_loop_rotation.cpp
@@ -658,6 +658,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     T1[0LL]
        = T4[(3LL * ((1LL + i8) % 5LL))];
   }
+  asm volatile("cp.async.wait_all;\n");
 }
 )";
   assertCUDAKernel(&fusion, expected_kernel);


### PR DESCRIPTION
This just places a `cp.async.wait_group 0` instruction immediately after any circular buffer main loop which is the approach taken by CUTLASS for pipelining GEMMs: (see [mma_multistage.h#L664-L665](https://github.com/NVIDIA/cutlass/blob/c4e3e122e266644c61b4af33d0cc09f4c391a64b/include/cutlass/gemm/threadblock/mma_multistage.h#L664-L665)). The previous fix for #2000, #2001, is reverted.

This is an alternative to #2005.

Fixes #2000 