### PR TITLE
make castOp part of matmul API

### DIFF
--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -57,8 +57,9 @@ namespace {
 
 // This function will be used by both matmul and linear.
 // Matmul will add a castOp to the output of this function
-// whereas linear will skip the cast and add the bias.
-TensorView* matmulImpl(TensorView* a, TensorView* b) {
+// whereas linear will skip the cast (set cast flag as false) 
+// and add the bias.
+TensorView* matmulImpl(TensorView* a, TensorView* b, bool cast = true) {
   NVF_CHECK(
       a->nDims() == b->nDims(),
       "The number of dimension of A and B do not match");
@@ -66,9 +67,6 @@ TensorView* matmulImpl(TensorView* a, TensorView* b) {
   NVF_CHECK(
       a->nDims() == 2,
       "Only 2-D Tensors are supported, in the future we'll support 3-D as well!");
-  NVF_CHECK(
-      a->getDataType().value() == b->getDataType().value(),
-      "data types of inputs to matmul don't match");
 
   std::vector<bool> bcast_dims(a->nDims() + 1, false);
   // A: [M, K, Bcast]
@@ -78,14 +76,22 @@ TensorView* matmulImpl(TensorView* a, TensorView* b) {
   bcast_dims.at(bcast_dims.size() - 1) = false;
   bcast_dims.at(bcast_dims.size() - 3) = true;
   auto* tv1b = broadcast(b, bcast_dims);
+
+  NVF_CHECK(
+      a->getDataType().value() == b->getDataType().value(),
+      "data types of inputs to matmul don't match");
+  if (cast) {
+    // For matmul, the output dtype should match input.
+    return maybeCastOp(
+        a->getDataType().value(), fusedMultiplySum(tv0b, tv1b, {-2}));
+  }
   return fusedMultiplySum(tv0b, tv1b, {-2});
 }
 
 } // namespace
 
 TensorView* matmul(TensorView* a, TensorView* b) {
-  auto* tv = matmulImpl(a, b);
-  return castOp(a->getDataType().value(), tv);
+  return matmulImpl(a, b);
 }
 
 LstmResult lstm(

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -53,16 +53,10 @@ TensorView* dropout_backward(TensorView* dy, TensorView* mask, Val* scale) {
   return dx;
 }
 
-namespace {
-
-// This function will be used by both matmul and linear.
-// Matmul will add a castOp to the output of this function
-// whereas linear will skip the cast (set cast flag as false)
-// and add the bias.
-TensorView* matmulImpl(
-    TensorView* a,
-    TensorView* b,
-    bool cast_output_to_input) {
+// This function will add a castOp to the output of the matrix multiplication
+// The implementation of linear can use this but will skip the cast (set cast
+// flag as false) and add the bias.
+TensorView* matmul(TensorView* a, TensorView* b, bool cast_output_to_input) {
   NVF_CHECK(
       a->nDims() == b->nDims(),
       "The number of dimension of A and B do not match");
@@ -91,10 +85,8 @@ TensorView* matmulImpl(
   return output;
 }
 
-} // namespace
-
 TensorView* matmul(TensorView* a, TensorView* b) {
-  return matmulImpl(a, b, true /* cast output to input dtype */);
+  return matmul(a, b, true /* cast output to input dtype */);
 }
 
 LstmResult lstm(

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -57,7 +57,7 @@ namespace {
 
 // This function will be used by both matmul and linear.
 // Matmul will add a castOp to the output of this function
-// whereas linear will skip the cast (set cast flag as false) 
+// whereas linear will skip the cast (set cast flag as false)
 // and add the bias.
 TensorView* matmulImpl(TensorView* a, TensorView* b, bool cast = true) {
   NVF_CHECK(

--- a/csrc/ops/composite.h
+++ b/csrc/ops/composite.h
@@ -52,6 +52,10 @@ NVF_API LstmResult lstm(
 // via strides. All restrictions from the matmul APIs also
 // apply here.
 TensorView* matmul(TensorView* a, TensorView* b);
+// This second matmul function is not exposed via
+// the Python interface, but it does the guts of the work and
+// can be used to create mamtuls without a cast operation following it.
+TensorView* matmul(TensorView* a, TensorView* b, bool cast_output_to_input);
 
 NVF_API TensorView* sign(TensorView* x);
 NVF_API Val* sign(Val* x);

--- a/tests/python/pytest_opinfos.py
+++ b/tests/python/pytest_opinfos.py
@@ -1113,7 +1113,7 @@ matmul_opinfo = OpInfo(
     dtypes=(
         (torch.float16, torch.bfloat16)
         if torch.cuda.get_device_properties(torch.cuda.current_device()).major >= 8
-        else (torch.float16)
+        else (torch.float16,)
     ),
     sample_input_generator=matmul_input_generator,
     reference=torch.matmul,

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -2394,8 +2394,7 @@ class TestNvFuserFrontend(TestCase):
             t0 = fd.from_pytorch(inps[0])
             t1 = fd.from_pytorch(inps[1])
             t2 = fd.ops.matmul(t0, t1)
-            t3 = fd.ops.cast(t2, dtype=DataType.Half)
-            fd.add_output(t3)
+            fd.add_output(t2)
 
         for inps in [inputs_tt, inputs_tn, inputs_nt, inputs_nn]:
             nvf_out, _ = self.exec_nvfuser(partial(fusion_func, inps=inps), inps)


### PR DESCRIPTION
This commit refactors the matmul API so that:
1. The CastOp is part of the matmul interface. (based on discussions with @kevinstephano, @Priya2698 and @jacobhinkle )
2. The Matmul Impl function will be reused by the API for linear. (follow-up commit)