### PR TITLE
Disable a test when distributed is off.

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -18,6 +18,15 @@
 #include <c10/util/irange.h>
 
 namespace nvfuser {
+
+NVF_API bool distributedEnabled() {
+#ifdef NVFUSER_DISTRIBUTED
+  return true;
+#else
+  return false;
+#endif
+}
+
 namespace {
 
 std::vector<IterDomain*> getShardedIterDomains(TensorView* tv) {

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -14,6 +14,9 @@
 
 namespace nvfuser {
 
+// Returns true iff nvFuser was compiled with distributed APIs enabled.
+NVF_API bool distributedEnabled();
+
 // Returns whether a TensorView has its first non-reduction axis parallelized
 // on Didx
 // Checks that the other non-reduction axis are not parallelized on Didx

--- a/tests/cpp/test_multidevice_resharding.cpp
+++ b/tests/cpp/test_multidevice_resharding.cpp
@@ -228,6 +228,9 @@ class automaticReshardingTest
 };
 
 TEST_P(automaticReshardingTest, setInsertion) {
+  if (!distributedEnabled()) { // Test only works with distributed
+    return;
+  }
   auto
       [mesh0,
        mesh1,

--- a/tests/cpp/test_multidevice_resharding.cpp
+++ b/tests/cpp/test_multidevice_resharding.cpp
@@ -229,7 +229,7 @@ class automaticReshardingTest
 
 TEST_P(automaticReshardingTest, setInsertion) {
   if (!distributedEnabled()) { // Test only works with distributed
-    return;
+    GTEST_SKIP() << "Requires distributed API";
   }
   auto
       [mesh0,


### PR DESCRIPTION
The test requires the distributed mode components to be compiled in, so cannot pass in single-GPU mode.