### PR TITLE
Avoid contradicting assumptions from empty loops

### DIFF
--- a/csrc/device_lower/pass/scalar_hoist.cpp
+++ b/csrc/device_lower/pass/scalar_hoist.cpp
@@ -347,7 +347,7 @@ std::vector<Val*> getAssumptions(const std::vector<kir::ForLoop*>& loops) {
       // important to simplify its index. However, it is important that we avoid
       // contradicting assumptions, so we omit the index < stop assumption in
       // these cases.
-      TORCH_WARN(
+      TORCH_WARN_ONCE(
           "Encountered loop with no iterations. Stop value ",
           stop->toInlineString(),
           " is same as start value ",

--- a/csrc/device_lower/pass/scalar_hoist.cpp
+++ b/csrc/device_lower/pass/scalar_hoist.cpp
@@ -339,9 +339,16 @@ std::vector<Val*> getAssumptions(const std::vector<kir::ForLoop*>& loops) {
     if (loop->isTrivial()) {
       continue;
     }
-    assumptions.push_back(
-        IrBuilder::ltExpr(loop->index(), loop->simplifiedStop()));
-    assumptions.push_back(IrBuilder::geExpr(loop->index(), loop->start()));
+    Val* start = loop->start();
+    assumptions.push_back(IrBuilder::geExpr(loop->index(), start));
+    Val* stop = loop->simplifiedStop();
+    if (!stop->sameAs(start)) {
+      // If stop = start, then this loop will not be computed, so it's not
+      // important to simplify its index. However, it is important that we avoid
+      // contradicting assumptions, so we omit the index < stop assumption in
+      // these cases.
+      assumptions.push_back(IrBuilder::ltExpr(loop->index(), stop));
+    }
   }
   return assumptions;
 }


### PR DESCRIPTION
This detects when a loop has zero iterations and avoids contradictions when simplifying included expressions.

Fixes #1808