### PR TITLE
Torch baselines for attention benchmarks

### DIFF
--- a/benchmarks/python/test_huggingface_attn_bwd.py
+++ b/benchmarks/python/test_huggingface_attn_bwd.py
@@ -76,7 +76,7 @@ def test_huggingface_attn_bwd_nvf_benchmark(
 
     batch_size, seq_len, nh, n_embd = size
 
-    dropout_p = 0.0 
+    dropout_p = 0.0
     inputs = torch.randn(
         batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype, requires_grad=True
     )
@@ -98,7 +98,7 @@ def test_huggingface_attn_bwd_nvf_benchmark(
 
     if not disable_validation:
         # Use dropout_mask instead of torch.nn.functional.dropout for validating results.
-        out = 1 / (1 - dropout_p) * dropout_mask * attn
+        out = torch.nn.functional.dropout(attn, p=dropout_p)
         out.backward(grads)
         fd.validate([grads, attn, dropout_mask], [inputs.grad])
 
@@ -118,7 +118,7 @@ def test_huggingface_attn_bwd_baseline_benchmark(
     clear_cuda_cache()
 
     batch_size, seq_len, nh, n_embd = size
-    dropout_p = 0.2
+    dropout_p = 0.0
     inputs = torch.randn(batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype, requires_grad=True)
     attention_mask = torch.zeros(
         batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype

--- a/benchmarks/python/test_huggingface_attn_bwd.py
+++ b/benchmarks/python/test_huggingface_attn_bwd.py
@@ -76,7 +76,7 @@ def test_huggingface_attn_bwd_nvf_benchmark(
 
     batch_size, seq_len, nh, n_embd = size
 
-    dropout_p = 0.0
+    dropout_p = 0.2
     inputs = torch.randn(
         batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype, requires_grad=True
     )
@@ -98,7 +98,7 @@ def test_huggingface_attn_bwd_nvf_benchmark(
 
     if not disable_validation:
         # Use dropout_mask instead of torch.nn.functional.dropout for validating results.
-        out = torch.nn.functional.dropout(attn, p=dropout_p)
+        out = attn * dropout_mask * 1 / (1 - dropout_p)
         out.backward(grads)
         fd.validate([grads, attn, dropout_mask], [inputs.grad])
 
@@ -118,8 +118,10 @@ def test_huggingface_attn_bwd_baseline_benchmark(
     clear_cuda_cache()
 
     batch_size, seq_len, nh, n_embd = size
-    dropout_p = 0.0
-    inputs = torch.randn(batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype, requires_grad=True)
+    dropout_p = 0.2
+    inputs = torch.randn(
+        batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype, requires_grad=True
+    )
     attention_mask = torch.zeros(
         batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype
     )

--- a/benchmarks/python/test_nanogpt_attn_bwd.py
+++ b/benchmarks/python/test_nanogpt_attn_bwd.py
@@ -68,6 +68,8 @@ def nanogpt_attn_bwd_fusion(
 
 
 def nanogpt_attn_bwd_iobytes(size: tuple, dtype: torch.dtype):
+    # Manual IOByte computation is required since nvFuser input/outputs (grad_out, attn, dropout_mask, bias_mask, grad_input]) differ from baseline input/outputs (output, grad_output).
+
     # Total IO bytes = grad_out ([bs, nh, seq_len, seq_len], dtype) + attn ([bs, nh, seq_len, seq_len], dtype) +
     #       dropout_mask ([bs, nh, seq_len, seq_len], bool) + bias_mask ([bs, nh, seq_len, seq_len], bool) + grad_in ([bs, nh, seq_len, seq_len], dtype)
     bs, seq_len, nh, n_embd = size

--- a/benchmarks/python/test_nanogpt_attn_bwd.py
+++ b/benchmarks/python/test_nanogpt_attn_bwd.py
@@ -148,6 +148,7 @@ def test_nanogpt_attn_bwd_baseline_benchmark(
 
     grads = torch.randn(batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype)
 
+    # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
         torch.compile(unary_bwd_torch) if compile else unary_bwd_torch,

--- a/benchmarks/python/test_nanogpt_attn_fwd.py
+++ b/benchmarks/python/test_nanogpt_attn_fwd.py
@@ -88,7 +88,7 @@ def nanogpt_attn_fwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_nanogpt_attn_fwd_benchmark(
+def test_nanogpt_attn_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,

--- a/benchmarks/python/test_nanogpt_attn_fwd.py
+++ b/benchmarks/python/test_nanogpt_attn_fwd.py
@@ -78,10 +78,10 @@ def nanogpt_attn_fwd(inputs: list):
 
 def nanogpt_attn_fwd_iobytes(size: tuple, dtype: torch.dtype):
     # Manual IOByte computation is required since nvFuser outputs (out, dropout_mask, attn, bias_mask) differ from baseline outputs (out).
-    
+
     # Total IO bytes = in_tensor ([bs, nh, seq_len, seq_len], dtype) + bias ([seq_len, seq_len], float) +
     #   output ([bs, nh, seq_len, seq_len], dtype) + attn ([bs, nh, seq_len, seq_len], dtype) + dropout_mask ([bs, nh, seq_len, seq_len], bool) + bias_mask ([bs, nh, seq_len, seq_len], bool)
-    
+
     bs, seq_len, nh, n_embd = size
 
     return int(
@@ -102,28 +102,36 @@ def test_nanogpt_attn_fwd_nvf_benchmark(
     clear_cuda_cache()
     batch_size, seq_len, nh, n_embd = size
     hs = n_embd // nh
-    dropout_p = 0.0
+    dropout_p = 0.2
     inputs = torch.randn(batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype)
     bias = torch.tril(torch.ones(seq_len, seq_len, device="cuda")).view(
         1, 1, seq_len, seq_len
     )
-    dropout_mask = torch.lt(
-        torch.rand(batch_size, nh, seq_len, seq_len, device="cuda"), 1 - dropout_p
-    )
+
     bias_mask = bias[:, :, :seq_len, :seq_len] == 0
     bias_mask = bias_mask.broadcast_to(batch_size, nh, seq_len, seq_len)
 
-    with FusionDefinition() as fd:
-        nanogpt_attn_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), hs, dropout_p)
-
     if not disable_validation:
+        # For validating use a fusion definition with dropout_p=0.0
+        with FusionDefinition() as val_fd:
+            nanogpt_attn_fwd_fusion(
+                val_fd, torch_dtype_to_nvfuser_dtype(dtype), hs, dropout_p=0.0
+            )
         attn = inputs / (hs**0.5)
+        dropout_mask = torch.ones(
+            batch_size, nh, seq_len, seq_len, dtype=torch.bool, device="cuda"
+        )
         attn = attn.masked_fill(bias[:, :, :seq_len, :seq_len] == 0, float("-inf"))
         attn = torch.nn.functional.softmax(attn, dim=-1)
-        out = torch.nn.functional.dropout(attn, p=dropout_p)
-        fd.validate([inputs, bias], [out, dropout_mask, attn, bias_mask])
+        out = torch.nn.functional.dropout(attn, p=0.0)
+
+        val_fd.validate([inputs, bias], [out, dropout_mask, attn, bias_mask])
 
     if not disable_benchmarking:
+        with FusionDefinition() as fd:
+            nanogpt_attn_fwd_fusion(
+                fd, torch_dtype_to_nvfuser_dtype(dtype), hs, dropout_p
+            )
         run_benchmark(benchmark, fd.execute, [inputs, bias])
 
 
@@ -139,7 +147,7 @@ def test_nanogpt_attn_fwd_baseline_benchmark(
     clear_cuda_cache()
 
     batch_size, seq_len, nh, n_embd = size
-    dropout_p = 0.0
+    dropout_p = 0.2
     inputs = torch.randn(batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype)
     bias = torch.tril(torch.ones(seq_len, seq_len, device="cuda")).view(
         1, 1, seq_len, seq_len


### PR DESCRIPTION
Issue #1668

The benchmarks use `dropout_p=0.2` for benchmarking. For validating in forward pass, to ensure the same dropout_mask is applied, this is set to 0.