### PR TITLE
Always validate dynamic smem usage for matmuls

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1674,6 +1674,17 @@ void FusionExecutor::validateDynamicSmemSize(int64_t dynamic_smem_size) {
       getStaticSmemSize() + dynamic_smem_size,
       ". Device limit size: ",
       device_smem_limit_);
+  // If specified, check that dynamic smem size matches what the scheduler
+  // expects
+  int64_t expected_dynamic_smem_size = fusion_->expectedDynamicSmemBytes();
+  if (expected_dynamic_smem_size >= 0) {
+    NVF_ERROR(
+        dynamic_smem_size == expected_dynamic_smem_size,
+        "Actual dynamic smem allocation ",
+        dynamic_smem_size,
+        " does not match expected size ",
+        expected_dynamic_smem_size);
+  }
 }
 
 int64_t FusionExecutor::ensureAvailableDynamicSmemSize(

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -117,6 +117,8 @@ IrCloner Fusion::copy(const Fusion* from, Fusion* to) {
     }
   }
 
+  to->expected_dynamic_smem_bytes_ = from->expected_dynamic_smem_bytes_;
+
   return ir_cloner;
 }
 

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -435,6 +435,17 @@ class NVF_API Fusion : public IrContainer {
 
   static IrCloner copy(const Fusion* from, Fusion* to);
 
+  //! During scheduling, this can be set to a non-negative value. If done, then
+  //! during execution by FusionExecutor, we will check that this value matches
+  //! the corresponding value in LaunchParams.
+  int64_t expectedDynamicSmemBytes() const {
+    return expected_dynamic_smem_bytes_;
+  }
+
+  void setExpectedDynamicSmemBytes(int64_t bytes) {
+    expected_dynamic_smem_bytes_ = bytes;
+  }
+
  protected:
   friend SegmentCandidateFinder;
   friend SegmentedFusion;
@@ -493,6 +504,10 @@ class NVF_API Fusion : public IrContainer {
   std::vector<std::pair<std::any, CloneFn>> managed_data_;
   std::unordered_map<std::string, std::pair<std::any, CloneFn>>
       managed_named_data_;
+
+  // If set to a non-negative value during scheduling, this will be checked by
+  // the executor.
+  int64_t expected_dynamic_smem_bytes_ = -1LL;
 };
 
 } // namespace nvfuser

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -1246,7 +1246,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
 
   NVF_ERROR(!cached_outputs.empty());
   mma_utils::MmaDataTypes data_types = {
-      a->dtype(), b->dtype(), cached_outputs.at(0).second->dtype()};
+      a->dtype(), b->dtype(), mma_result->dtype()};
   // NOTE: Batch split-K matmuls cannot currently re-use smem due to outer
   // batch loop
   bool guaranteed_operand_reuse = num_batch_dims == 0 || num_splitk_dims == 0;

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -1243,6 +1243,19 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
     scheduler_utils::rotateLoop(
         mma_result, num_batch_dims + 2 + num_splitk_dims, {acr, bcr});
   }
+
+  NVF_ERROR(!cached_outputs.empty());
+  mma_utils::MmaDataTypes data_types = {
+      a->dtype(), b->dtype(), cached_outputs.at(0).second->dtype()};
+  // NOTE: Batch split-K matmuls cannot currently re-use smem due to outer
+  // batch loop
+  bool guaranteed_operand_reuse = num_batch_dims == 0 || num_splitk_dims == 0;
+  int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
+      params,
+      data_types,
+      /*smem_a_reuse_guaranteed=*/guaranteed_operand_reuse,
+      /*smem_b_reuse_guaranteed=*/guaranteed_operand_reuse);
+  fusion->setExpectedDynamicSmemBytes(estimated_smem);
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_gpu_tensorcore.cpp
+++ b/tests/cpp/test_gpu_tensorcore.cpp
@@ -121,14 +121,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmul_CUDA) {
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-
-    // Check that computed smem matches actually allocated smem
-    mma_utils::MmaDataTypes data_types = {
-        DataType::Half, DataType::Half, DataType::Float};
-    int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-        params, data_types, true, true);
-    int64_t actual_smem = fe.lastLaunchParams().smem();
-    EXPECT_EQ(estimated_smem, actual_smem);
   }
 }
 
@@ -181,14 +173,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmperePrologueFusionBroadcast_CUDA) {
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-
-    // Check that computed smem matches actually allocated smem
-    mma_utils::MmaDataTypes data_types = {
-        DataType::Half, DataType::Half, DataType::Float};
-    int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-        params, data_types, true, true);
-    int64_t actual_smem = fe.lastLaunchParams().smem();
-    EXPECT_EQ(estimated_smem, actual_smem);
   }
 }
 
@@ -248,14 +232,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereProloguePointwise_CUDA) {
         inputs.second.sin().to(at::kFloat),
         layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-
-    // Check that computed smem matches actually allocated smem
-    mma_utils::MmaDataTypes data_types = {
-        DataType::Half, DataType::Half, DataType::Float};
-    int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-        params, data_types, true, true);
-    int64_t actual_smem = fe.lastLaunchParams().smem();
-    EXPECT_EQ(estimated_smem, actual_smem);
   }
 }
 
@@ -311,14 +287,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulBFloat16_CUDA) {
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-
-    // Check that computed smem matches actually allocated smem
-    mma_utils::MmaDataTypes data_types = {
-        DataType::Half, DataType::Half, DataType::Float};
-    int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-        params, data_types, true, true);
-    int64_t actual_smem = fe.lastLaunchParams().smem();
-    EXPECT_EQ(estimated_smem, actual_smem);
   }
 }
 
@@ -378,14 +346,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulPipelineGmem_CUDA) {
       auto tref = atMatmul(
           inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
       NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-
-      // Check that computed smem matches actually allocated smem
-      mma_utils::MmaDataTypes data_types = {
-          DataType::Half, DataType::Half, DataType::Float};
-      int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-          params, data_types, true, true);
-      int64_t actual_smem = fe.lastLaunchParams().smem();
-      ASSERT_EQ(estimated_smem, actual_smem);
     }
   }
 }
@@ -577,14 +537,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulRegDoubleBuffer_CUDA) {
       auto tref = atMatmul(
           inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
       NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-
-      // Check that computed smem matches actually allocated smem
-      mma_utils::MmaDataTypes data_types = {
-          DataType::Half, DataType::Half, DataType::Float};
-      int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-          params, data_types, true, true);
-      int64_t actual_smem = fe.lastLaunchParams().smem();
-      EXPECT_EQ(estimated_smem, actual_smem);
     }
   }
 }
@@ -1256,14 +1208,6 @@ TEST_F(GPUTTensorCoreTest, FusionTuringMatmul_CUDA) {
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-
-    // Check that computed smem matches actually allocated smem
-    mma_utils::MmaDataTypes data_types = {
-        DataType::Half, DataType::Half, DataType::Float};
-    int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-        params, data_types, true, true);
-    int64_t actual_smem = fe.lastLaunchParams().smem();
-    EXPECT_EQ(estimated_smem, actual_smem);
   }
 }
 
@@ -1950,14 +1894,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulLargeLoad_CUDA) {
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-
-    // Check that computed smem matches actually allocated smem
-    mma_utils::MmaDataTypes data_types = {
-        DataType::Half, DataType::Half, DataType::Float};
-    int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-        params, data_types, true, true);
-    int64_t actual_smem = fe.lastLaunchParams().smem();
-    EXPECT_EQ(estimated_smem, actual_smem);
   }
 }
 
@@ -2010,14 +1946,6 @@ TEST_F(GPUTTensorCoreTest, FusionTuringMatmulLargeLoad_CUDA) {
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-
-    // Check that computed smem matches actually allocated smem
-    mma_utils::MmaDataTypes data_types = {
-        DataType::Half, DataType::Half, DataType::Float};
-    int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-        params, data_types, true, true);
-    int64_t actual_smem = fe.lastLaunchParams().smem();
-    EXPECT_EQ(estimated_smem, actual_smem);
   }
 }
 
@@ -2093,11 +2021,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTileCheck4warp_CUDA) {
             mn_size,
             " ",
             k_size);
-        // Check that computed smem matches actually allocated smem
-        int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-            params, data_types, true, true);
-        int64_t actual_smem = fe.lastLaunchParams().smem();
-        EXPECT_EQ(estimated_smem, actual_smem);
       }
     }
   }
@@ -2170,11 +2093,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTileCheck8warp_CUDA) {
               inputs.second.to(at::kFloat),
               layout);
           NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-          // Check that computed smem matches actually allocated smem
-          int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-              params, data_types, true, true);
-          int64_t actual_smem = fe.lastLaunchParams().smem();
-          EXPECT_EQ(estimated_smem, actual_smem);
         }
       }
     }
@@ -2242,11 +2160,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTileCheck6warp_CUDA) {
       auto tref = atMatmul(
           inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
       NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-      // Check that computed smem matches actually allocated smem
-      int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-          params, data_types, true, true);
-      int64_t actual_smem = fe.lastLaunchParams().smem();
-      EXPECT_EQ(estimated_smem, actual_smem);
     }
   }
 }
@@ -2453,11 +2366,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSmemEpilogue_CUDA) {
           cg_outputs[0].allclose(tref, 0.01, 0.01),
           "Result validation failed. Max diff: ",
           (cg_outputs[0] - tref).abs().max());
-      // Check that computed smem matches actually allocated smem
-      int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-          params, data_types, true, true);
-      int64_t actual_smem = fe.lastLaunchParams().smem();
-      EXPECT_EQ(estimated_smem, actual_smem);
 
       if (!params.use_smem_epilogue) {
         GTEST_SKIP()
@@ -2587,11 +2495,6 @@ TEST_F(
       cg_outputs[0].allclose(tref, 0.01, 0.01),
       "Result validation failed. Max diff: ",
       (cg_outputs[0] - tref).abs().max());
-  // Check that computed smem matches actually allocated smem
-  int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-      params, data_types, true, true);
-  int64_t actual_smem = fe.lastLaunchParams().smem();
-  EXPECT_EQ(estimated_smem, actual_smem);
 
   if (!params.use_smem_epilogue) {
     GTEST_SKIP()
@@ -2685,12 +2588,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSmemEpilogueCast_CUDA) {
         cg_outputs[0].allclose(tref, 0.01, 0.01),
         "Result validation failed. Max diff: ",
         (cg_outputs[0] - tref).abs().max());
-
-    // Check that computed smem matches actually allocated smem
-    int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-        params, data_types, true, true);
-    int64_t actual_smem = fe.lastLaunchParams().smem();
-    EXPECT_EQ(estimated_smem, actual_smem);
 
     if (!params.use_smem_epilogue) {
       GTEST_SKIP()
@@ -2787,12 +2684,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSmemEpilogueRelu_CUDA) {
         "Result validation failed. Max diff: ",
         (cg_outputs[0] - tref).abs().max());
 
-    // Check that computed smem matches actually allocated smem
-    int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-        params, data_types, true, true);
-    int64_t actual_smem = fe.lastLaunchParams().smem();
-    EXPECT_EQ(estimated_smem, actual_smem);
-
     if (!params.use_smem_epilogue) {
       GTEST_SKIP()
           << "Test conducted without utilizing shared memory epilogue due to the device's constrained shared memory capacity.";
@@ -2871,14 +2762,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSplitK_CUDA) {
 
         // Relax tolerance for larger sum due to large K
         NVF_CHECK(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
-
-        // Check that computed smem matches actually allocated smem
-        mma_utils::MmaDataTypes data_types = {
-            DataType::Half, DataType::Half, DataType::Float};
-        int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-            params, data_types, true, true);
-        int64_t actual_smem = fe.lastLaunchParams().smem();
-        EXPECT_EQ(estimated_smem, actual_smem);
       }
     }
   }
@@ -2946,14 +2829,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSplitKBias_CUDA) {
 
         // Relax tolerance for larger sum due to large K
         NVF_CHECK(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
-
-        // Check that computed smem matches actually allocated smem
-        mma_utils::MmaDataTypes data_types = {
-            DataType::Half, DataType::Half, DataType::Float};
-        int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-            params, data_types, true, true);
-        int64_t actual_smem = fe.lastLaunchParams().smem();
-        EXPECT_EQ(estimated_smem, actual_smem);
       }
     }
   }
@@ -3017,19 +2892,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulBatchSplitK_CUDA) {
 
         // Relax tolerance for larger sum due to large K
         EXPECT_TRUE(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
-
-        // Check that computed smem matches actually allocated smem
-        mma_utils::MmaDataTypes data_types = {
-            DataType::Half, DataType::Half, DataType::Float};
-        int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-            params,
-            data_types,
-            // NOTE: Batch split-K matmuls cannot currently re-use smem due to
-            // outer batch loop
-            /*smem_a_reuse_guaranteed=*/false,
-            /*smem_b_reuse_guaranteed=*/false);
-        int64_t actual_smem = fe.lastLaunchParams().smem();
-        EXPECT_EQ(estimated_smem, actual_smem);
       }
     }
   }
@@ -3099,19 +2961,6 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulBatchSplitKBias_CUDA) {
 
         // Relax tolerance for larger sum due to large K
         EXPECT_TRUE(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
-
-        // Check that computed smem matches actually allocated smem
-        mma_utils::MmaDataTypes data_types = {
-            DataType::Half, DataType::Half, DataType::Float};
-        int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-            params,
-            data_types,
-            // NOTE: Batch split-K matmuls cannot currently re-use smem due to
-            // outer batch loop
-            /*smem_a_reuse_guaranteed=*/false,
-            /*smem_b_reuse_guaranteed=*/false);
-        int64_t actual_smem = fe.lastLaunchParams().smem();
-        EXPECT_EQ(estimated_smem, actual_smem);
       }
     }
   }
@@ -3171,14 +3020,6 @@ TEST_F(GPUTTensorCoreTest, ReproIssue1808) {
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-
-  // Check that computed smem matches actually allocated smem
-  mma_utils::MmaDataTypes data_types = {
-      DataType::Half, DataType::Half, DataType::Float};
-  int64_t estimated_smem = mma_utils::computeExpectedSharedMemoryUsage(
-      params, data_types, true, true);
-  int64_t actual_smem = fe.lastLaunchParams().smem();
-  EXPECT_EQ(estimated_smem, actual_smem);
 }
 
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD


### PR DESCRIPTION
This introduces a mechanism for schedulers to declare the expected dynamic shared memory usage by optionally calling
`fusion->setExpectedDynamicSmemBytes(n)`. During execution, when validating that the shared memory fits within device limits, we will also check that the dynamic smem matches this value.

This is debugging information, but since it's quick to check I have enabled it unconditionally. This will give us more confidence that `mma_utils::computeExpectedSharedMemoryUsage` is accurate. If that function is inaccurate, we would not necessarily hit an error but we might have suboptimal heuristics and occasional errors where we specify MatmulParams that cannot be launched on the current device.

Note that the smem is dynamic, so it could instead be a `Val*`, but it is compile-time constant in the case of matmul. If needed, we can extend this to be a `Val*` that we evaluate at execution, but there might be performance implications in such cases.

Also note that static smem (which is compile-time constant) is not checked currently. We could of course handle that in a similar manner if needed.