### PR TITLE
Revert "options should be thread local (#1913)"

### DIFF
--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -218,13 +218,18 @@ std::unordered_map<ProfilerOption, std::vector<std::string>> Options<
 
 namespace {
 
-thread_local DebugDumpOptions active_dump_options;
+// These may need to be thread local, or their modifications may need to
+// be protected by mutual exclusion for thread safety. At this
+// moment, the correctness of modifying option values has to be
+// guaranteed by the modifying code.
 
-thread_local EnableOptions active_enable_options;
+DebugDumpOptions active_dump_options;
 
-thread_local DisableOptions active_disable_options;
+EnableOptions active_enable_options;
 
-thread_local ProfilerOptions active_profiler_options;
+DisableOptions active_disable_options;
+
+ProfilerOptions active_profiler_options;
 
 } // namespace
 


### PR DESCRIPTION
This reverts commit ef4cae963b44c048f67db795ccc0b997f250ba38.