### PR TITLE
Disable failing multidevice unit tests

### DIFF
--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -302,7 +302,7 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(false),
         testing::Values(true),
         testing::Values(0, 1),
-        testing::Bool()));
+        testing::Values(false)));
 
 INSTANTIATE_TEST_SUITE_P(
     ReduceScatter,
@@ -315,8 +315,38 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(true),
         testing::Values(true),
         testing::Values(0, 1),
-        testing::Bool()));
+        testing::Values(false)));
 
+// TODO: Distributed reduction tests using fusion executor cache are failing
+// AllocationDomainPass might be re-ordering compute
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_FusionExecutorCache_Reduce,
+    PipelineTestTwoStages,
+    testing::Combine(
+        testing::Values(CommunicatorBackend::nccl),
+        all_nontrivial_meshes,
+        all_meshes,
+        testing::Values(true),
+        testing::Values(false),
+        testing::Values(true),
+        testing::Values(0, 1),
+        testing::Values(true)));
+
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_FusionExecutorCache_ReduceScatter,
+    PipelineTestTwoStages,
+    testing::Combine(
+        testing::Values(CommunicatorBackend::nccl),
+        all_nontrivial_meshes,
+        testing::Values(mesh_null), // the same mesh is used for all tensors
+        testing::Values(true),
+        testing::Values(true),
+        testing::Values(true),
+        testing::Values(0, 1),
+        testing::Values(true)));
+
+// TODO: UCC PipelineTestTwoStages are hanging in UCC barrier
+// when number of processes > number of gpus required by test.
 INSTANTIATE_TEST_SUITE_P(
     DISABLED_UCC_Gather,
     PipelineTestTwoStages,

--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -230,7 +230,7 @@ INSTANTIATE_TEST_SUITE_P(
     Gather,
     PipelineTestTwoStages,
     testing::Combine(
-        all_backends,
+        testing::Values(CommunicatorBackend::nccl),
         all_meshes,
         all_meshes,
         testing::Values(true),
@@ -243,7 +243,7 @@ INSTANTIATE_TEST_SUITE_P(
     Scatter,
     PipelineTestTwoStages,
     testing::Combine(
-        all_backends,
+        testing::Values(CommunicatorBackend::nccl),
         all_meshes,
         all_meshes,
         testing::Values(false),
@@ -256,7 +256,7 @@ INSTANTIATE_TEST_SUITE_P(
     Bcast,
     PipelineTestTwoStages,
     testing::Combine(
-        all_backends,
+        testing::Values(CommunicatorBackend::nccl),
         all_meshes,
         all_meshes,
         testing::Values(false),
@@ -269,7 +269,7 @@ INSTANTIATE_TEST_SUITE_P(
     Bcast_sharded,
     PipelineTestTwoStages,
     testing::Combine(
-        all_backends,
+        testing::Values(CommunicatorBackend::nccl),
         testing::Values(mesh3, mesh4),
         testing::Values(mesh3, mesh4),
         testing::Values(true),
@@ -282,7 +282,7 @@ INSTANTIATE_TEST_SUITE_P(
     Bcast_sharded_same_mesh,
     PipelineTestTwoStages,
     testing::Combine(
-        all_backends,
+        testing::Values(CommunicatorBackend::nccl),
         testing::Values(mesh0, mesh1),
         testing::Values(mesh_null), // the same mesh is used for all tensors
         testing::Values(true),
@@ -295,7 +295,7 @@ INSTANTIATE_TEST_SUITE_P(
     Reduce,
     PipelineTestTwoStages,
     testing::Combine(
-        all_backends,
+        testing::Values(CommunicatorBackend::nccl),
         all_nontrivial_meshes,
         all_meshes,
         testing::Values(true),
@@ -308,7 +308,98 @@ INSTANTIATE_TEST_SUITE_P(
     ReduceScatter,
     PipelineTestTwoStages,
     testing::Combine(
-        all_backends,
+        testing::Values(CommunicatorBackend::nccl),
+        all_nontrivial_meshes,
+        testing::Values(mesh_null), // the same mesh is used for all tensors
+        testing::Values(true),
+        testing::Values(true),
+        testing::Values(true),
+        testing::Values(0, 1),
+        testing::Bool()));
+
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_UCC_Gather,
+    PipelineTestTwoStages,
+    testing::Combine(
+        testing::Values(CommunicatorBackend::ucc),
+        all_meshes,
+        all_meshes,
+        testing::Values(true),
+        testing::Values(false),
+        testing::Values(false),
+        testing::Values(0, 1),
+        testing::Bool()));
+
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_UCC_Scatter,
+    PipelineTestTwoStages,
+    testing::Combine(
+        testing::Values(CommunicatorBackend::ucc),
+        all_meshes,
+        all_meshes,
+        testing::Values(false),
+        testing::Values(true),
+        testing::Values(false),
+        testing::Values(0, 1),
+        testing::Bool()));
+
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_UCC_Bcast,
+    PipelineTestTwoStages,
+    testing::Combine(
+        testing::Values(CommunicatorBackend::ucc),
+        all_meshes,
+        all_meshes,
+        testing::Values(false),
+        testing::Values(false),
+        testing::Values(false),
+        testing::Values(0, 1),
+        testing::Bool()));
+
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_UCC_Bcast_sharded,
+    PipelineTestTwoStages,
+    testing::Combine(
+        testing::Values(CommunicatorBackend::ucc),
+        testing::Values(mesh3, mesh4),
+        testing::Values(mesh3, mesh4),
+        testing::Values(true),
+        testing::Values(true),
+        testing::Values(false),
+        testing::Values(0, 1),
+        testing::Bool()));
+
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_UCC_Bcast_sharded_same_mesh,
+    PipelineTestTwoStages,
+    testing::Combine(
+        testing::Values(CommunicatorBackend::ucc),
+        testing::Values(mesh0, mesh1),
+        testing::Values(mesh_null), // the same mesh is used for all tensors
+        testing::Values(true),
+        testing::Values(true),
+        testing::Values(false),
+        testing::Values(0, 1),
+        testing::Bool()));
+
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_UCC_Reduce,
+    PipelineTestTwoStages,
+    testing::Combine(
+        testing::Values(CommunicatorBackend::ucc),
+        all_nontrivial_meshes,
+        all_meshes,
+        testing::Values(true),
+        testing::Values(false),
+        testing::Values(true),
+        testing::Values(0, 1),
+        testing::Bool()));
+
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_UCC_ReduceScatter,
+    PipelineTestTwoStages,
+    testing::Combine(
+        testing::Values(CommunicatorBackend::ucc),
         all_nontrivial_meshes,
         testing::Values(mesh_null), // the same mesh is used for all tensors
         testing::Values(true),


### PR DESCRIPTION
Disabling failing multidevice unit tests until they are fixed.

1. PipelineTestTwoStage test with UCC backend.
`mpirun -np N test_multidevice_test --gtest_filter='*DISABLED_UCC_*' --gtest_also_run_disabled_tests` where N > 4
These tests cause UCC barrier to hang when the tests are run with more than 4 processes. Still investigating the cause and whether the bug is potentially in UCCProcessGroup. 

2. Distributed reduction tests that execute with FusionExecutorCache. 
`mpirun -np 4 test_multidevice_test --gtest_filter='*DISABLED_FusionExecutorCache_*' --gtest_also_run_disabled_tests`
These tests are failing because of the new `AllocationDomainPass`. @jjsjann123  Hopefully, this is a simple fix to ignore reordering reductions on a DeviceDim axis. 