### PR TITLE
ATen evaluation for linear primitive

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -427,9 +427,9 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
       // Matmul/Addmm: n_pos=2, k_pos=1
       // Linear: n_pos=1, k_pos=2
       const int k_pos =
-          matmul_inp.mma_dims_pos.value()[(size_t)MatmulDomain::K];
+          std::get<(size_t)MatmulDomain::K>(matmul_inp.mma_dims_pos);
       const int n_pos =
-          matmul_inp.mma_dims_pos.value()[(size_t)MatmulDomain::N];
+          std::get<(size_t)MatmulDomain::N>(matmul_inp.mma_dims_pos);
 
       if (matmul_inp.bias == nullptr) {
         auto out = k_pos < n_pos ? alpha * a.matmul(b) : at::linear(a, b);

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -437,9 +437,10 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
       if (bias.dim() != a.dim() && matmul_inp.input_layout == MmaLayout::TT) {
         // Unsqueeze the broadcast dimensions.
         // For 2D inputs to the pattern, bias is of shape [M,1]/[1,N]
-        for (auto dim : c10::irange(matmul_inp.bias_bcast_flags.size())) {
-          if (matmul_inp.bias_bcast_flags[dim])
+        for (int64_t dim : c10::irange(matmul_inp.bias_bcast_flags.size())) {
+          if (matmul_inp.bias_bcast_flags[dim]){
             bias = bias.unsqueeze(dim);
+          }
         }
       }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -430,12 +430,12 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
             : at::linear(a, b);
         return {out};
       }
-      
+
       auto bias = ee.evaluate(matmul_inp.bias, known_values).as<at::Tensor>();
+
+      // Linear takes 1D bias. Unsqueeze for 1D bias in matmul/addmm. 
       if (bias.dim() != a.dim() && matmul_inp.input_layout == MmaLayout::TT) {
-        // Bias is of shape [M,].
-        NVF_ERROR(bias.dim() == a.dim() - 1);
-        bias = bias.unsqueeze(-1);
+        bias = bias.unsqueeze(*matmul_inp.bias_bcast_axis); // Bias is of shape [M,1]/[1,N]
       }
 
       const c10::Scalar beta = matmul_inp.beta

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -433,9 +433,10 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
 
       auto bias = ee.evaluate(matmul_inp.bias, known_values).as<at::Tensor>();
 
-      // Linear takes 1D bias. Unsqueeze for 1D bias in matmul/addmm. 
+      // Linear takes 1D bias. Unsqueeze for 1D bias in matmul/addmm.
       if (bias.dim() != a.dim() && matmul_inp.input_layout == MmaLayout::TT) {
-        bias = bias.unsqueeze(*matmul_inp.bias_bcast_axis); // Bias is of shape [M,1]/[1,N]
+        bias = bias.unsqueeze(
+            *matmul_inp.bias_bcast_axis); // Bias is of shape [M,1]/[1,N]
       }
 
       const c10::Scalar beta = matmul_inp.beta

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1337,15 +1337,20 @@ void verifyMmaOpForEvaluation(
       tv_a->nDims());
 
   NVF_ERROR(
-      tv_b->getRootDomain().front()->isBroadcast(),
-      "Expected first dimension to be broadcasted for second operand.");
-
-  NVF_ERROR(
       in_a->definition() != nullptr && in_a->definition()->isA<BroadcastOp>(),
       "Currently, MmaOp::evaluate assumes the preceding op to be a broadcast.");
   NVF_ERROR(
       in_b->definition() != nullptr && in_b->definition()->isA<BroadcastOp>(),
       "Currently, MmaOp::evaluate assumes the preceding op to be a broadcast.");
+
+        
+  NVF_ERROR(
+      tv_a->getRootDomain().back()->isBroadcast() || tv_a->getRootDomain()[1]->isBroadcast(),
+      "Expected middle/last dimension to be broadcasted for first operand.");
+
+  NVF_ERROR(
+      tv_b->getRootDomain().front()->isBroadcast(),
+      "Expected first dimension to be broadcasted for second operand.");
 
   // ATen preserves the dtype of MmaOp inputs whereas MmaOp generates float
   // outputs. To preserve numerical equivalence and precision, the output of
@@ -1448,7 +1453,7 @@ bool matchMatmulPatterns(const UnaryOp* cast_op, MatmulInputs* matmul_inp) {
 
   // Check if bias was broadcasted
   auto* bcast = dynamic_cast<BroadcastOp*>(matmul_inp->bias->definition());
-  if (bcast != nullptr) { // mma_lhs is broadcasted
+  if (bcast != nullptr) {
     // Bias of shape [M, 1]
     matmul_inp->bias = bcast->input(0); // Bias tensor in fp32
   }

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1343,9 +1343,9 @@ void verifyMmaOpForEvaluation(
       in_b->definition() != nullptr && in_b->definition()->isA<BroadcastOp>(),
       "Currently, MmaOp::evaluate assumes the preceding op to be a broadcast.");
 
-        
   NVF_ERROR(
-      tv_a->getRootDomain().back()->isBroadcast() || tv_a->getRootDomain()[1]->isBroadcast(),
+      tv_a->getRootDomain().back()->isBroadcast() ||
+          tv_a->getRootDomain()[1]->isBroadcast(),
       "Expected middle/last dimension to be broadcasted for first operand.");
 
   NVF_ERROR(
@@ -1454,7 +1454,9 @@ bool matchMatmulPatterns(const UnaryOp* cast_op, MatmulInputs* matmul_inp) {
   auto bias_ndims = matmul_inp->bias->as<TensorView>()->nDims();
   auto inp_ndims = matmul_inp->mma_lhs->as<TensorView>()->nDims();
 
-  NVF_ERROR((bias_ndims == inp_ndims - 1) || (bias_ndims == inp_ndims), "Bias should be 1D / 2D tensor.");
+  NVF_ERROR(
+      (bias_ndims == inp_ndims - 1) || (bias_ndims == inp_ndims),
+      "Bias should be 1D / 2D tensor.");
 
   // Check if bias was broadcasted
   auto* bcast = dynamic_cast<BroadcastOp*>(matmul_inp->bias->definition());

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1462,8 +1462,7 @@ bool matchMatmulPatterns(const UnaryOp* cast_op, MatmulInputs* matmul_inp) {
   auto* bcast = dynamic_cast<BroadcastOp*>(matmul_inp->bias->definition());
   if (bcast != nullptr) {
     // Bias of shape [M, 1] / [1, N]
-    // TODO: Allow multiple bcast axes for batched GEMMs
-    matmul_inp->bias_bcast_axis = bcast->isBroadcastDim(0) ? 0 : 1;
+    matmul_inp->bias_bcast_flags = bcast->getBroadcastDimFlags();
     matmul_inp->bias = bcast->input(0); // Bias tensor in fp32
   }
 

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1335,7 +1335,8 @@ void verifyMmaOpForEvaluation(
       "MmaOp::evaluate is not implemented for size: ",
       tv_a->nDims());
 
-  NVF_ERROR(*mma_op->layout() == MmaLayout::TT || *mma_op->layout() == MmaLayout::TN);
+  NVF_ERROR(
+      *mma_op->layout() == MmaLayout::TT || *mma_op->layout() == MmaLayout::TN);
 
   NVF_ERROR(
       in_a->definition() != nullptr && in_a->definition()->isA<BroadcastOp>(),

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -66,19 +66,23 @@ struct MatmulInputs {
   Val* bias = nullptr;
   Val* alpha = nullptr;
   Val* beta = nullptr;
-  // Input layout based on ordering of axes M,N,K, valid values.
-  // Determined based on broadcast axes.
-  std::optional<MmaLayout> input_layout = std::nullopt;
+  // Ordering of dimensions M,N,K in inputs.
+  // Determined based on position of iterdomains.
+  // For addmm/matmul ([M,K] x [K,N]): M=0, N=2, K=1
+  // For linear ([M,K] x [N,K]): M=0, N=1, K=2
+  // mma_dims_pos = {m_pos, n_pos, k_pos}
+  std::optional<std::vector<int>> mma_dims_pos = std::nullopt;
   std::vector<bool> bias_bcast_flags = {};
 };
 
 //! Matches the following matmul patterns.
 //! Matmul: A x B, alpha * A x B
-//! Matmul + Bias: A x B + C,  alpha * A x B + C, A x B + beta * C,
+//! Matmul + Bias (addmm): A x B + C,  alpha * A x B + C, A x B + beta * C,
 //!   alpha * A x B  + beta * C
+//! Linear: A x B / A x B + C
 //! Assumptions:
 //! 1. For simplicity, we assume the MmaOp to be in the first operand.
-//! 2. If mma layout is TN ([M, K], [N, K]), alpha, beta parameters are ignored
+//! 2. For linear ([M, K], [N, K]), alpha, beta parameters are ignored
 //! in evaluation.
 bool matchMatmulPatterns(const UnaryOp* cast_op, MatmulInputs* matmul_inp);
 

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -66,7 +66,9 @@ struct MatmulInputs {
   Val* bias = nullptr;
   Val* alpha = nullptr;
   Val* beta = nullptr;
-  MmaLayout mma_layout;
+  // Input layout based on ordering of axes M,N,K, valid values.
+  // Determined based on broadcast axes.
+  std::optional<MmaLayout> input_layout = std::nullopt;
 };
 
 //! Matches the following matmul patterns.

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -71,7 +71,10 @@ struct MatmulInputs {
   // For addmm/matmul ([M,K] x [K,N]): M=0, N=2, K=1
   // For linear ([M,K] x [N,K]): M=0, N=1, K=2
   // mma_dims_pos = {m_pos, n_pos, k_pos}
-  std::optional<std::vector<int>> mma_dims_pos = std::nullopt;
+  std::tuple<int, int, int> mma_dims_pos = {};
+  // The elements denote if the corresponding iterdomain in the bias was a new
+  // broadcast dimension. This is used to broadcast the bias for matmul/addmm
+  // during evaluation.
   std::vector<bool> bias_bcast_flags = {};
 };
 

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -66,7 +66,7 @@ struct MatmulInputs {
   Val* bias = nullptr;
   Val* alpha = nullptr;
   Val* beta = nullptr;
-  // Ordering of dimensions M,N,K in inputs.
+  // Ordering of dimensions M,N,K in MmaOp's output TensorView's root domain. 
   // Determined based on position of iterdomains.
   // For addmm/matmul ([M,K] x [K,N]): M=0, N=2, K=1
   // For linear ([M,K] x [N,K]): M=0, N=1, K=2

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -66,6 +66,7 @@ struct MatmulInputs {
   Val* bias = nullptr;
   Val* alpha = nullptr;
   Val* beta = nullptr;
+  MmaLayout mma_layout;
 };
 
 //! Matches the following matmul patterns.

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -73,7 +73,10 @@ struct MatmulInputs {
 //! Matmul: A x B, alpha * A x B
 //! Matmul + Bias: A x B + C,  alpha * A x B + C, A x B + beta * C,
 //!   alpha * A x B  + beta * C
-//! Note: For simplicity, we assume the MmaOp to be in the first operand.
+//! Assumptions:
+//! 1. For simplicity, we assume the MmaOp to be in the first operand.
+//! 2. If mma layout is TN ([M, K], [N, K]), alpha, beta parameters are ignored
+//! in evaluation.
 bool matchMatmulPatterns(const UnaryOp* cast_op, MatmulInputs* matmul_inp);
 
 } // namespace nvfuser::MmaOpUtils

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -82,8 +82,7 @@ struct MatmulInputs {
 //! Linear: A x B / A x B + C
 //! Assumptions:
 //! 1. For simplicity, we assume the MmaOp to be in the first operand.
-//! 2. For linear ([M, K], [N, K]), alpha, beta parameters are ignored
-//! in evaluation.
+//! 2. For linear ([M, K], [N, K]), alpha, beta parameters are nullptr.
 bool matchMatmulPatterns(const UnaryOp* cast_op, MatmulInputs* matmul_inp);
 
 } // namespace nvfuser::MmaOpUtils

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -66,7 +66,7 @@ struct MatmulInputs {
   Val* bias = nullptr;
   Val* alpha = nullptr;
   Val* beta = nullptr;
-  // Ordering of dimensions M,N,K in MmaOp's output TensorView's root domain. 
+  // Ordering of dimensions M,N,K in MmaOp's output TensorView's root domain.
   // Determined based on position of iterdomains.
   // For addmm/matmul ([M,K] x [K,N]): M=0, N=2, K=1
   // For linear ([M,K] x [N,K]): M=0, N=1, K=2

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -69,7 +69,7 @@ struct MatmulInputs {
   // Input layout based on ordering of axes M,N,K, valid values.
   // Determined based on broadcast axes.
   std::optional<MmaLayout> input_layout = std::nullopt;
-  std::optional<int> bias_bcast_axis = std::nullopt;
+  std::vector<bool> bias_bcast_flags = {};
 };
 
 //! Matches the following matmul patterns.

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -69,6 +69,7 @@ struct MatmulInputs {
   // Input layout based on ordering of axes M,N,K, valid values.
   // Determined based on broadcast axes.
   std::optional<MmaLayout> input_layout = std::nullopt;
+  std::optional<int> bias_bcast_axis = std::nullopt;
 };
 
 //! Matches the following matmul patterns.

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1236,12 +1236,12 @@ RolesMapOpt getTensorsRoles(
         roles_map[MatmulRole::INPUT_B].push_back(entry.first);
         continue;
       }
-      if (has_m && has_n && !has_k) {
-        roles_map[MatmulRole::INPUT_C].push_back(entry.first);
-        continue;
-      }
+      // if (has_m && has_n && !has_k) {
+      //   roles_map[MatmulRole::INPUT_C].push_back(entry.first);
+      //   continue;
+      // }
       // Bias vectors are assigned to INPUT_C role
-      if (has_m && !has_n && !has_k) {
+      if (!has_k) {
         roles_map[MatmulRole::INPUT_C].push_back(entry.first);
         continue;
       }

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1236,10 +1236,6 @@ RolesMapOpt getTensorsRoles(
         roles_map[MatmulRole::INPUT_B].push_back(entry.first);
         continue;
       }
-      // if (has_m && has_n && !has_k) {
-      //   roles_map[MatmulRole::INPUT_C].push_back(entry.first);
-      //   continue;
-      // }
       // Bias vectors are assigned to INPUT_C role
       if (!has_k) {
         roles_map[MatmulRole::INPUT_C].push_back(entry.first);

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -334,4 +334,83 @@ TEST_F(MatmulATenEvaluationTest, MatmulBiasAlpha) {
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
+
+TEST_F(MatmulATenEvaluationTest, Linear) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  int64_t m = 32, n = 64, k = 128;
+  std::vector<int64_t> a_shape{m, k}, b_shape{n, k}, out_shape{m, n};
+
+  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+  auto tv0b = broadcast(tv0, {false, true, false}); // [M, 1, K]
+  auto tv1b = broadcast(tv1, {true, false, false}); // [1, N, K]
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+  auto tv3 = castOp(DataType::Half, tv2);
+
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addOutput(tv3);
+
+  at::Tensor t0 = at::randn(a_shape, at::kHalf).cuda();
+  at::Tensor t1 = at::randn(b_shape, at::kHalf).cuda();
+  at::Tensor out_ref = at::linear(t0, t1);
+
+  FusionExecutorCache fec(std::move(fusion));
+  auto out = fec.runFusionWithInputs({t0, t1});
+
+  const std::vector<FusionExecutor>& executors =
+      fec.getMostRecentKernelRuntime()->executors();
+  EXPECT_EQ(executors.size(), 1);
+  // Verify that the io_alias_ set has the correct entry
+  kir::Kernel* kernel = executors.front().kernel();
+  EXPECT_EQ(
+      kernel->getOutputAlias(kernel->outputs()[0]).type,
+      AllocationType::Evaluate);
+
+  EXPECT_TRUE(at::allclose(out[0], out_ref));
+}
+
+TEST_F(MatmulATenEvaluationTest, LinearWithBias) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  int64_t m = 32, n = 64, k = 128;
+  std::vector<int64_t> a_shape{m, k}, b_shape{n, k}, out_shape{m, n};
+
+  auto tv0 = makeConcreteTensor(a_shape, DataType::Half);
+  auto tv1 = makeConcreteTensor(b_shape, DataType::Half);
+  auto tv0b = broadcast(tv0, {false, true, false}); // [M, 1, K]
+  auto tv1b = broadcast(tv1, {true, false, false}); // [1, N, K]
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+  auto tv3 = makeConcreteTensor({m}, DataType::Half);
+  auto tv4 = castOp(DataType::Float, tv3);
+  auto tv5 = biasEpilogue(tv2, tv4);
+  auto tv6 = castOp(DataType::Half, tv5);
+
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv3);
+  fusion->addOutput(tv6);
+
+  at::Tensor t0 = at::randn(a_shape, at::kHalf).cuda();
+  at::Tensor t1 = at::randn(b_shape, at::kHalf).cuda();
+  at::Tensor t2 = at::randn({m}, at::kHalf).cuda();
+  at::Tensor out_ref = at::linear(t0, t1, t2.unsqueeze(-1));
+
+  FusionExecutorCache fec(std::move(fusion));
+  auto out = fec.runFusionWithInputs({t0, t1, t2});
+
+  const std::vector<FusionExecutor>& executors =
+      fec.getMostRecentKernelRuntime()->executors();
+  EXPECT_EQ(executors.size(), 1);
+  // Verify that the io_alias_ set has the correct entry
+  kir::Kernel* kernel = executors.front().kernel();
+  EXPECT_EQ(
+      kernel->getOutputAlias(kernel->outputs()[0]).type,
+      AllocationType::Evaluate);
+
+  EXPECT_TRUE(at::allclose(out[0], out_ref));
+}
 } // namespace nvfuser


### PR DESCRIPTION
1. `fd.ops.linear` will take input shapes `[M, K] x [N, K]`. This is evaluated through `at::linear` for parity with PyTorch.
2. Fix the segmenter issue with Linear + Bias. See #2057.

Issue #1669 