### PR TITLE
Canonicalize `dims` argument in `variance_mean` when `keepdim=True`

### DIFF
--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1166,28 +1166,6 @@ TensorView* reductionOpZeroDimTensor(TensorView* inp) {
 
 } // namespace
 
-std::vector<unsigned int> canonicalizeAxes(
-    const std::vector<int>& axes,
-    size_t ndims) {
-  std::vector<unsigned int> uint_axes;
-  for (int axis : axes) {
-    if (axis < 0) {
-      axis += (int)ndims;
-    }
-
-    NVF_CHECK(
-        axis >= 0 && axis < (int)ndims,
-        "Reduction on invalid axis, received: ",
-        axis,
-        " however tensor view only has ",
-        ndims,
-        " non-reduction dims.");
-
-    uint_axes.push_back((unsigned int)axis);
-  }
-  return uint_axes;
-}
-
 TensorView* reductionOpRaw(
     BinaryOpType reduction_op_type,
     const std::vector<int>& axes,
@@ -1217,7 +1195,7 @@ TensorView* reductionOpRaw(
   }
 
   std::vector<unsigned int> uint_axes =
-      canonicalizeAxes(axes, tv->domain()->noReductions().size());
+      ops::canonicalizeAxes(axes, tv->domain()->noReductions().size());
 
   TensorView* out = newForReduction(tv, uint_axes, dtype);
   const auto out_type = out->getDataType().value();
@@ -1319,7 +1297,7 @@ TensorView* reductionOp(
     return reductionOpZeroDimTensor(tv);
   }
 
-  std::vector<unsigned int> uint_axes = canonicalizeAxes(axes, ndims);
+  std::vector<unsigned int> uint_axes = ops::canonicalizeAxes(axes, ndims);
   std::sort(uint_axes.begin(), uint_axes.end());
 
   // In PyTorch, reduction of a size-0 tensor is effectively creating a tensor
@@ -1796,7 +1774,7 @@ WelfordResult WelfordRaw(
 
   // Check and collect reduction axes
   std::vector<unsigned int> uint_axes =
-      canonicalizeAxes(axes, tv->domain()->noReductions().size());
+      ops::canonicalizeAxes(axes, tv->domain()->noReductions().size());
   // Create tensor outputs
   TensorView* out_avg = newForReduction(tv, uint_axes);
   TensorView* out_var = newForReduction(tv, uint_axes);
@@ -1835,7 +1813,7 @@ WelfordResult Welford(
   // Check and collect reduction axes
   auto tv_root = tv->domain()->noReductions();
   const auto ndims = tv_root.size();
-  std::vector<unsigned int> uint_axes = canonicalizeAxes(axes, ndims);
+  std::vector<unsigned int> uint_axes = ops::canonicalizeAxes(axes, ndims);
   std::sort(uint_axes.begin(), uint_axes.end());
 
   // Squeeze before reduction
@@ -2668,7 +2646,7 @@ TensorView* fusedMultiplySum(
       axes.size() == 1, "Single axis reduction only for mma op instantiation.")
 
   std::vector<unsigned int> uint_axes =
-      canonicalizeAxes(axes, tv_a->domain()->noReductions().size());
+      ops::canonicalizeAxes(axes, tv_a->domain()->noReductions().size());
 
   TensorView* out = newForMma(tv_a, tv_b, uint_axes);
 

--- a/csrc/ops/normalization.cpp
+++ b/csrc/ops/normalization.cpp
@@ -8,6 +8,7 @@
 #include <ir/builder.h>
 #include <ops/arith.h>
 #include <ops/normalization.h>
+#include <ops/utils.h>
 
 namespace nvfuser {
 
@@ -125,7 +126,7 @@ VarMeanResult variance_mean(
 
   if (keepdim) {
     std::vector<bool> is_broadcast(kNumberOfDims, false);
-    for (auto dim : dims) {
+    for (auto dim : ops::canonicalizeAxes(dims, kNumberOfDims)) {
       is_broadcast[dim] = true;
     }
     var = broadcast(var, is_broadcast);

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -421,5 +421,28 @@ Val* getMaximumValue(DataType v) {
   return nullptr;
 }
 
+std::vector<unsigned int> canonicalizeAxes(
+    const std::vector<int>& axes,
+    size_t ndims) {
+  std::vector<unsigned int> uint_axes;
+  uint_axes.reserve(axes.size());
+  std::transform(
+      axes.begin(), axes.end(), std::back_inserter(uint_axes), [&](int axis) {
+        if (axis < 0) {
+          axis += (int)ndims;
+        }
+
+        NVF_CHECK(
+            axis >= 0 && axis < (int)ndims,
+            "Reduction on invalid axis, received: ",
+            axis,
+            " however tensor view only has ",
+            ndims,
+            " non-reduction dims.");
+        return axis;
+      });
+  return uint_axes;
+}
+
 } // namespace ops
 } // namespace nvfuser

--- a/csrc/ops/utils.h
+++ b/csrc/ops/utils.h
@@ -53,5 +53,9 @@ Val* getMinimumValue(DataType v);
 //   true for bool.
 Val* getMaximumValue(DataType v);
 
+std::vector<unsigned int> canonicalizeAxes(
+    const std::vector<int>& axes,
+    size_t ndims);
+
 } // namespace ops
 } // namespace nvfuser


### PR DESCRIPTION
**Problem:** The `variance_mean` function uses the `dims` argument directly, which can be a negative number. 
**Solution:** This PR canonicalizes the reduction dimensions when `keepdim=True`, and moves `canonicalizeAxes` function to utils.h