### PR TITLE
IdModel: Always require promotion to loop mapped domains

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -391,7 +391,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (true || isOptionEnabled(EnableOption::IdModel)) {
+  if (isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_);
   }
 

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -391,7 +391,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (isOptionEnabled(EnableOption::IdModel)) {
+  if (true || isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_);
   }
 

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -953,8 +953,6 @@ Expr* findMatchingExpr(
     if (getenv("NEW") || require_loop_mapped_promotion) {
       if (!loop_graph.disjointExprSets().permissiveAreMapped(
               iel_expr->front(), maybe_promoted_input_use_group->front())) {
-        std::cerr << "Skipping as loop_map required: "
-                  << maybe_promoted_input_use_group->front()->toString();
         continue;
       }
       // This is just an extra sanity check. Make sure all exprs in
@@ -971,14 +969,6 @@ Expr* findMatchingExpr(
           nvfuser::toString(iel_expr),
           "\n",
           nvfuser::toString(maybe_promoted_input_use_group));
-    }
-
-    {
-      std::cerr << "Candidates inputs: ";
-      for (const auto& e : *maybe_promoted_input_use_group) {
-        std::cerr << e->inputs().front()->name() << " ";
-      }
-      std::cerr << " -> " << maybe_promoted_input_use->inputs().front()->name() << std::endl;
     }
 
     return maybe_promoted_input_use;
@@ -1028,16 +1018,10 @@ bool hasUniqueInputLoopGroups(
   ValGroups inp_loop_groups;
   for (const ValGroup& iel_inp_group : iel_inp_groups) {
     inp_loop_groups.pushBack(loop_graph.toGroup(iel_inp_group->front()));
-    std::cerr << "inp: " << nvfuser::toString(iel_inp_group) << ", loop group: "
-              << nvfuser::toString(inp_loop_groups.back())
-              << std::endl;
   }
   ValGroups out_loop_groups;
   for (const ValGroup& iel_out_group : iel_out_groups) {
     out_loop_groups.pushBack(loop_graph.toGroup(iel_out_group->front()));
-    std::cerr << "out: " << nvfuser::toString(iel_out_group) << ", loop group: "
-              << nvfuser::toString(inp_loop_groups.back())
-              << std::endl;
   }
 
   // Check if input groups that are not included in the output group set
@@ -1061,8 +1045,6 @@ void IdModel::propagatePromotionsInIELGraph(
     const std::vector<ValGroup> iel_inp_groups =
         iel_graph.inputGroups(iel_expr);
 
-    std::cerr <<"Propagating through: " << iel_expr->front()->toString();
-
     // Check if any inputs need promotion indicating this expr group needs to
     // be replayed with promoted inputs
     bool an_input_was_promoted = false;
@@ -1073,8 +1055,6 @@ void IdModel::propagatePromotionsInIELGraph(
     // not in the same loop group.
     const bool loop_promote_inputs = !loop_graph_promotion_map.empty() &&
         hasUniqueInputLoopGroups(iel_expr, iel_graph, loop_graph);
-
-    std::cerr << "loop_promote_inputs: " << loop_promote_inputs << std::endl;
 
     for (const ValGroup& iel_inp_group : iel_inp_groups) {
       // Assumed all inputs are IterDomains
@@ -1107,11 +1087,8 @@ void IdModel::propagatePromotionsInIELGraph(
 
     if (!an_input_was_promoted) {
       // No inputs need promotion so just continue
-      std::cerr << "No input was promoted\n";
       continue;
     }
-
-    std::cerr << "Some input was promoted\n";
 
     Expr* promoted_expr = findMatchingExpr(
         iel_expr,
@@ -1120,16 +1097,11 @@ void IdModel::propagatePromotionsInIELGraph(
         require_loop_mapped_promotion,
         idGraph(IdMappingMode::LOOP));
 
-    if (promoted_expr) {
-      std::cerr << "Reusing: " << promoted_expr->toString();
-    }
-
     bool replayed = false;
 
     if (!promoted_expr) {
       promoted_expr = addReplayAs(maybe_promoted_inputs, iel_expr->front());
       replayed = true;
-      std::cerr << "Replayed: " << promoted_expr->toString();
     }
 
     // Mark outputs as having a promoted iter domain

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -944,11 +944,10 @@ Expr* findMatchingExpr(
       continue;
     }
 
-    // TODO: Update the comment
-    // For the final loop promotion map, we want to find
-    // promotions within the same loop groups. Note that that's
-    // guaranteed when a new domain is replayed instead of reusing an
-    // existing domain.
+    // We always want to find promotions within the same loop
+    // groups since we are looking for domains that represent actual
+    // loops. Note that that's guaranteed when a new domain is
+    // replayed instead of reusing an existing domain.
     if (!loop_graph.disjointExprSets().permissiveAreMapped(
             iel_expr->front(), maybe_promoted_input_use_group->front())) {
       continue;

--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -196,8 +196,7 @@ class IdModel : public PolymorphicBase {
   // in the loop graph as we are looking for domains that represent
   // the actual loops of the input and output domains of the IEL
   // expr. If no such expr is found, the IEL expr is replayed with the
-  // promoted inputs. require_loop_mapped_promotion is true when this
-  // function is used for step 3.
+  // promoted inputs.
   //
   // This is used twice when building the promotion map. The first time
   // it is used there's no loop graph promotion yet, so only the IEL

--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -187,6 +187,8 @@ class IdModel : public PolymorphicBase {
 
   // Helper function for building loop promotion map.
   //
+  // TODO: Update the comment regarding require_loop_mapped_promotion
+  //
   // Propagate promotion mappings from root IEL groups to intermediate
   // and leaf IEL groups by traversing IEL exprs. For each expr, if an
   // input is promoted, the output needs to be promoted too. If
@@ -215,8 +217,7 @@ class IdModel : public PolymorphicBase {
       const ValGraph& iel_graph,
       std::unordered_map<ValGroup, IterDomain*>& iel_promotion_map,
       const ValGraph& loop_graph,
-      const std::unordered_map<ValGroup, IterDomain*>& loop_promotion_map,
-      bool require_loop_mapped_promotion);
+      const std::unordered_map<ValGroup, IterDomain*>& loop_promotion_map);
 
   // Same as the other propagatePromotionsInIELGraph but without loop
   // graph map. This is used for step 2, where there's no loop

--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -187,18 +187,17 @@ class IdModel : public PolymorphicBase {
 
   // Helper function for building loop promotion map.
   //
-  // TODO: Update the comment regarding require_loop_mapped_promotion
-  //
   // Propagate promotion mappings from root IEL groups to intermediate
   // and leaf IEL groups by traversing IEL exprs. For each expr, if an
   // input is promoted, the output needs to be promoted too. If
   // there's already an equivalent expr that uses the promoted inputs,
   // create a mapping from the outputs of the IEL expr to the outputs
-  // of the equivalent expr. When require_loop_mapped_promotion is
-  // true, the equivalent expr needs to be already loop mapped. If no
-  // such expr is found, the IEL expr is replayed with the promoted
-  // inputs. require_loop_mapped_promotion is true when this function
-  // is used for step 3.
+  // of the equivalent expr. We only consider exprs that are mapped
+  // in the loop graph as we are looking for domains that represent
+  // the actual loops of the input and output domains of the IEL
+  // expr. If no such expr is found, the IEL expr is replayed with the
+  // promoted inputs. require_loop_mapped_promotion is true when this
+  // function is used for step 3.
   //
   // This is used twice when building the promotion map. The first time
   // it is used there's no loop graph promotion yet, so only the IEL

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -1603,22 +1603,22 @@ TEST_F(IdModelTest, LoopPromotion7) {
 
   // Check Step 3 results. See the design doc for the expected results
   std::vector<std::pair<std::unordered_set<Val*>, IterDomain*>>
-      s3_reference_map = {
-          // 3, 4, 5, 14, 6, 7, 8, -> 8
-          {std::unordered_set<Val*>{
-               tv2->getRootDomain().at(0),
-               tv3->getRootDomain().at(0),
-               tv3->getRootDomain().at(1),
-               getChildId(tv3->getRootDomain().at(0), 1),
-               tv4->getRootDomain().at(0),
-               tv4->getRootDomain().at(1),
-               id8},
-           id8},
-          // 9, 15, 17, 23 -> 9
-          {std::unordered_set<Val*>{tv2->axis(0), tv3->axis(0), tv4->axis(0), id23},
-           tv4->axis(0)},
-          // 16, 24 -> 24
-          {std::unordered_set<Val*>{tv3->axis(1), id24}, id24}};
+      s3_reference_map = {// 3, 4, 5, 14, 6, 7, 8, -> 8
+                          {std::unordered_set<Val*>{
+                               tv2->getRootDomain().at(0),
+                               tv3->getRootDomain().at(0),
+                               tv3->getRootDomain().at(1),
+                               getChildId(tv3->getRootDomain().at(0), 1),
+                               tv4->getRootDomain().at(0),
+                               tv4->getRootDomain().at(1),
+                               id8},
+                           id8},
+                          // 9, 15, 17, 23 -> 9
+                          {std::unordered_set<Val*>{
+                               tv2->axis(0), tv3->axis(0), tv4->axis(0), id23},
+                           tv4->axis(0)},
+                          // 16, 24 -> 24
+                          {std::unordered_set<Val*>{tv3->axis(1), id24}, id24}};
 
   checkStep3Results(
       tester.s3_loop_graph, tester.s3_loop_promotion_map, s3_reference_map);
@@ -1698,7 +1698,12 @@ TEST_F(IdModelTest, LoopPromotion8) {
 
   auto all_tvs = ir_utils::allTvs(&fusion);
 
+  fusion.printMath();
+  fusion.print();
+
   IdModelTester tester(&fusion);
+
+  tester.print(std::cerr);
 
   // Verify all tensors with root broadcast have correct resolutions
   for (auto tv : all_tvs) {
@@ -1745,81 +1750,108 @@ TEST_F(IdModelTest, LoopPromotion8) {
       tester.idGraph(IdMappingMode::LOOP),
       tester.s2_iel_promotion_map);
 
-  auto id29 = getParentId(tv7->axis(0), 1);
-  ASSERT_EQ(id29->name(), 29) << "Unexpected ID: " << id29->toString();
-  auto id42 = getParentId(tv7->axis(1), 1);
-  ASSERT_EQ(id42->name(), 42);
+  // tv7
+  auto id14 = tv7->getRootDomain().at(0);
+  auto id15 = tv7->getRootDomain().at(1);
+  auto id16 = tv7->getRootDomain().at(2);
+  auto id29 = getChildIdByName(id14, 29);
+  auto id30 = getChildIdByName(id29, 30);
+  auto id31 = getChildIdByName(id29, 31);
+  auto id43 = tv7->axis(1);
+
+  // tv2
+  auto id2 = tv2->getRootDomain().at(0);
+  auto id3 = tv2->getRootDomain().at(1);
+  auto id20 = getChildIdByName(id2, 20);
+  auto id21 = tv2->axis(0);
+  auto id22 = tv2->axis(1);
+  auto id45 = getChildIdByName(id29, 45);
+  auto id46 = getChildIdByName(id29, 46);
+
+  // tv5
+  auto id8 = tv5->getRootDomain().at(0);
+  auto id9 = tv5->getRootDomain().at(1);
+  auto id10 = tv5->getRootDomain().at(2);
+  auto id27 = tv5->axis(0);
+  auto id26 = getChildIdByName(id8, 26);
+  auto id28 = getChildIdByName(id26, 28);
+  auto id39 = getChildIdByName(id28, 39);
+  auto id40 = tv5->axis(1);
+  auto id41 = tv5->axis(2);
+  auto id42 = getChildIdByName(id16, 42);
+  auto id47 = getChildIdByName(id42, 47);
+  auto id48 = getChildIdByName(id42, 48);
+
+  // tv4
+  auto id6 = tv4->getRootDomain().at(0);
+  auto id7 = tv4->getRootDomain().at(1);
+  auto id17 = getChildIdByName(id6, 17);
+  auto id18 = tv4->axis(0);
+
+  // tv1
+  auto id1 = tv1->getRootDomain().at(0);
+  auto id35 = tv1->axis(0);
+  auto id36 = tv1->axis(1);
 
   // Check Step 3 results. See the design doc for the expected results
   std::vector<std::pair<std::unordered_set<Val*>, IterDomain*>>
       s3_reference_map = {
           // 1, 2, 3, 20, 6, 7, 17, 8, 9, 26, 14, 15, 29 -> 29
           {std::unordered_set<Val*>{
-               tv1->getRootDomain().at(0),
-               tv2->getRootDomain().at(0),
-               tv2->getRootDomain().at(1),
-               getChildId(tv2->getRootDomain().at(0), 1),
-               tv4->getRootDomain().at(0),
-               tv4->getRootDomain().at(1),
-               getChildId(tv4->getRootDomain().at(0), 1),
-               tv5->getRootDomain().at(0),
-               tv5->getRootDomain().at(1),
-               getChildId(tv5->getRootDomain().at(0), 1),
-               tv7->getRootDomain().at(0),
-               tv7->getRootDomain().at(1),
-               getChildId(tv7->getRootDomain().at(0), 1)},
-           getChildId(tv7->getRootDomain().at(0), 1)},
-          // 35, 21, 18, 27, 30 -> 30
-          {std::unordered_set<Val*>{
-               tv1->axis(0),
-               tv2->axis(0),
-               tv4->axis(0),
-               tv5->axis(0),
-               tv7->axis(0)},
-           tv7->axis(0)},
-          // 28, 10, 39, 31, 16, 42 -> 42
-          {std::unordered_set<Val*>{
-               getChildId(
-                   getChildId(tv5->getRootDomain().at(0), 1), 1, 1), // 28
-               tv5->getRootDomain().at(2), // 10
-               getChildId(tv5->getRootDomain().at(2), 1), // 39
-               getChildId(
-                   getChildId(tv7->getRootDomain().at(0), 1), 1, 1), // 31
-               tv7->getRootDomain().at(2), // 16
-               id42}, // 42
-           id42},
-          // 22 -> 19
-          {std::unordered_set<Val*>{tv2->axis(1)}, tv4->axis(1)},
-          // 40, 43 -> 43
-          {std::unordered_set<Val*>{tv5->axis(1), tv7->axis(1)}, tv7->axis(1)},
-          // 41 -> 44
-          {std::unordered_set<Val*>{tv5->axis(2)}, tv7->axis(2)},
-      };
+               id1,
+               id2,
+               id3,
+               id20,
+               id6,
+               id7,
+               id17,
+               id8,
+               id9,
+               id26,
+               id14,
+               id15,
+               id29},
+           id29},
+          // 18, 21, 27, 30, 35, 45 -> 30
+          {std::unordered_set<Val*>{id18, id21, id27, id30, id35, id45}, id30},
+          // 10, 16, 28, 31, 39, 42 -> 42
+          {std::unordered_set<Val*>{id10, id16, id28, id31, id39, id42}, id42},
+          // 22, 46 -> 46
+          {std::unordered_set<Val*>{id22, id46}, id46},
+          // 40, 43, 47 -> 43
+          {std::unordered_set<Val*>{id40, id43, id47}, id43},
+          // 41, 48 -> 48
+          {std::unordered_set<Val*>{id41, id48}, id48}};
 
   checkStep3Results(
       tester.s3_loop_graph, tester.s3_loop_promotion_map, s3_reference_map);
 
-  auto id49 = getChildIdByName(id29, 49);
-  auto id50 = getChildIdByName(id29, 50);
-  auto id51 = getChildIdByName(id29, 51);
-  auto id52 = getChildIdByName(id29, 52);
-  auto id63 = getChildIdByName(id42, 63);
-  auto id64 = getChildIdByName(id42, 64);
+  // tv1
+  auto id53 = getChildIdByName(id29, 53);
+  auto id54 = getChildIdByName(id29, 54);
+
+  // tv2
+  auto id55 = getChildIdByName(id29, 55);
+  auto id56 = getChildIdByName(id29, 56);
+
+  // tv5
+  auto id67 = getChildIdByName(id42, 67);
+  auto id68 = getChildIdByName(id42, 68);
 
   std::vector<std::pair<std::unordered_set<Val*>, IterDomain*>>
       s4_reference_map = {
-          // tv1: 35 -> 49
-          {std::unordered_set<Val*>{tv1->axis(0)}, id49},
-          // tv1: 36 -> 50
-          {std::unordered_set<Val*>{tv1->axis(1)}, id50},
-          // tv2: 21 -> 51
-          {std::unordered_set<Val*>{tv2->axis(0)}, id51},
-          // tv2: 22 -> 52
-          {std::unordered_set<Val*>{tv2->axis(1)}, id52},
-          // tv5: 40 -> 63
-          {std::unordered_set<Val*>{tv5->axis(1)}, id63},
-          // tv5: 41 -> 64
-          {std::unordered_set<Val*>{tv5->axis(2)}, id64},
+          // tv1: 35 -> 53
+          {std::unordered_set<Val*>{id35}, id53},
+          // tv1: 36 -> 54
+          {std::unordered_set<Val*>{id36}, id54},
+          // tv2: 21 -> 55
+          {std::unordered_set<Val*>{id21}, id55},
+          // tv2: 22 -> 56
+          {std::unordered_set<Val*>{id22}, id56},
+          // tv5: 40 -> 67
+          {std::unordered_set<Val*>{id40}, id67},
+          // tv5: 41 -> 68
+          {std::unordered_set<Val*>{id41}, id68},
       };
 
   checkStep4Results(

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -1157,9 +1157,6 @@ TEST_F(IdModelTest, LoopPromotion6) {
   FusionGuard fg(fusion.get());
   auto all_tvs = ir_utils::allTvs(fusion.get());
 
-  fusion->printMath();
-  fusion->print();
-
   IdModelTester tester(fusion.get());
 
   auto tv1 = getValByName(all_tvs, 1);
@@ -1480,9 +1477,6 @@ TEST_F(IdModelTest, LoopPromotion7) {
 
   auto all_tvs = ir_utils::allTvs(&fusion);
 
-  fusion.printMath();
-  fusion.print();
-
   IdModelTester tester(&fusion);
 
   // Verify all tensors with root broadcast have correct resolutions
@@ -1611,9 +1605,6 @@ TEST_F(IdModelTest, LoopPromotion8) {
   tv5->inlineAt(2);
 
   auto all_tvs = ir_utils::allTvs(&fusion);
-
-  fusion.printMath();
-  fusion.print();
 
   IdModelTester tester(&fusion);
 
@@ -1782,7 +1773,7 @@ TEST_F(IdModelTest, LoopPromotionPromoteToSameLoopGroup) {
   tv4->split(1, 2);
   // [I0, I1/2, 2]
   tv4->split(0, 8);
-  // [I0/8*I1/2, 8, 2]
+  // [I0/8, 8, I1/2, 2]
   tv4->merge(0, 2);
   // [I0/8*I1/2, 8*2]
   tv4->merge(1, 2);

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -1761,6 +1761,9 @@ TEST_F(IdModelTest, LoopPromotion8) {
   checkStep4Results(tester, s4_reference_map);
 }
 
+// A case to illustrate the effect of the below issue and RR.
+// https://github.com/NVIDIA/Fuser/issues/2027
+// https://github.com/NVIDIA/Fuser/pull/2059
 TEST_F(IdModelTest, LoopPromotionPromoteToSameLoopGroup) {
   Fusion fusion;
   FusionGuard fg(&fusion);

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -218,8 +218,6 @@ void validateIELResolution(
     ASSERT_TRUE(loop_graph.disjointValSets().strictAreMapped(id, promotion_id))
         << "Promotion of " << id->toString()
         << " not mapped in the loop graph: " << promotion_id->toString();
-    std::cerr << "Validated: " << id->toString() << ", "
-              << promotion_id->toString() << std::endl;
   } else {
     ASSERT_TRUE(iel_promotion_map_it == iel_promotion_map.end())
         << "Promotion should not exist for: " << nvfuser::toString(iel_group)
@@ -347,8 +345,6 @@ void checkStep3Results(
         << "No promotion found for: " << nvfuser::toString(loop_group);
     IterDomain* promotion_id = promotion_it->second;
 
-    std::cerr << "Loop group: " << nvfuser::toString(loop_group) << std::endl;
-
     auto ref_promotion_it = std::find_if(
         ref_promotion_map.begin(),
         ref_promotion_map.end(),
@@ -375,8 +371,6 @@ void checkStep3Results(
         << nvfuser::toString(loop_group)
         << ". Promotion: " << promotion_id->toString();
   }
-
-  std::cerr << "Step 3 validated\n";
 }
 
 void checkStep4Results(
@@ -950,11 +944,7 @@ TEST_F(IdModelTest, LoopPromotion4) {
     tv->inlineAt(-2);
   }
 
-  fusion.printMath();
-
   IdModelTester tester(&fusion);
-
-  tester.print(std::cerr);
 
   // Verify all tensors with root broadcast have correct resolutions
   for (auto tv : ir_utils::allTvs(&fusion)) {
@@ -1075,11 +1065,7 @@ TEST_F(IdModelTest, LoopPromotion5) {
 
   auto all_tvs = ir_utils::allTvs(&fusion);
 
-  fusion.printMath();
-
   IdModelTester tester(&fusion);
-
-  tester.print(std::cerr);
 
   // Check Step 1 results
   for (auto tv : all_tvs) {
@@ -1234,8 +1220,6 @@ TEST_F(IdModelTest, LoopPromotion6) {
   fusion->print();
 
   IdModelTester tester(fusion.get());
-
-  tester.print(std::cerr);
 
   auto tv1 = getValByName(all_tvs, 1);
   auto tv2 = getValByName(all_tvs, 2);
@@ -1567,8 +1551,6 @@ TEST_F(IdModelTest, LoopPromotion7) {
 
   IdModelTester tester(&fusion);
 
-  tester.print(std::cerr);
-
   // Verify all tensors with root broadcast have correct resolutions
   for (auto tv : all_tvs) {
     // Skip tensors with no broadcast or non-inlined
@@ -1708,8 +1690,6 @@ TEST_F(IdModelTest, LoopPromotion8) {
   fusion.print();
 
   IdModelTester tester(&fusion);
-
-  tester.print(std::cerr);
 
   // Verify all tensors with root broadcast have correct resolutions
   for (auto tv : all_tvs) {
@@ -1894,19 +1874,9 @@ TEST_F(IdModelTest, LoopPromotionPromoteToSameLoopGroup) {
     tv->inlineAt(1);
   }
 
-  fusion.printMath();
-  fusion.print();
-
   IdModelTester tester(&fusion);
 
-  tester.print(std::cerr);
-
-  std::cerr << "Loop graph:\n";
-  for (const auto& g :
-       tester.idGraph(IdMappingMode::LOOP).disjointValSets().disjointSets()) {
-    std::cerr << nvfuser::toString(g) << std::endl;
-  }
-
+  ASSERT_EQ(tester.s1_root_resolution_map.size(), 1);
   validateIELResolution(
       tv2->getRootDomain().at(0),
       tv4->getRootDomain().at(0),

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -162,8 +162,7 @@ class IdModelTester : public IdModel {
         iel_graph,
         s4_iel_promotion_map,
         idGraph(IdMappingMode::LOOP),
-        s3_original_loop_promotion_map,
-        true);
+        s3_original_loop_promotion_map);
   }
 
   void print(std::ostream& os) const {


### PR DESCRIPTION
This PR changes how Step 2 of the loop promotion analysis finds promotion domains. Loop promotion should be done to domains that are in the same loop group, but I thought this could be achieved by just checking the mapping for the final results at Step 5 and it wouldn't matter for intermediate results of promotion generated at Step 2. While that's probably the case, it also introduces some unexpected domain mappings and I found they were really confusing while working with some complex fusions. Besides, as suggested by @zasdfgbnm, the initial decision doesn't seem to buy much but just adds some extra complexity. 

The requirement flag is now removed. The change to the promotion code is pretty minimal, but unfortunately, it meant many of the promotion reference results needed to be updated for test validation. The design doc was also updated.

For a concrete example, see `IdModelTest.LoopPromotionPromoteToSameLoopGroup` and its corresponding section in the design doc.

Closes #2027
