### PR TITLE
Sharding propagation pass

### DIFF
--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -41,6 +41,10 @@ class DeviceMesh final {
     return std::find(vector_.begin(), vector_.end(), device) != vector_.end();
   }
 
+  bool operator==(const DeviceMesh& other) const {
+    return vector_ == other.vector();
+  }
+
  private:
   void setDevices(std::vector<DeviceIdxType> devices) {
     vector_ = devices;

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -51,6 +51,7 @@ MultiDeviceExecutor::MultiDeviceExecutor(
     Communicator& comm,
     MultiDeviceExecutorParams params)
     : comm_(comm), params_(params) {
+  propagateShardings(fusion.get());
   insertReshardings(fusion.get());
   insertShardedAxisReordering(fusion.get());
   SegmentCandidateFinderOptions options{

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -229,14 +229,15 @@ void propagateShardings(Fusion* fusion) {
   for (auto expr : fusion->exprs()) {
     auto inputs = ir_utils::filterByType<TensorView>(expr->inputs());
     auto outputs = ir_utils::filterByType<TensorView>(expr->outputs());
-    std::vector<TensorView*> input_with_mesh;
+    TensorView* input_with_mesh = nullptr;
     for (auto tv : inputs) {
       if (tv->hasDeviceMesh()) {
-        input_with_mesh.push_back(tv);
+        input_with_mesh = tv;
+        break;
       }
     }
     NVF_ERROR(
-        !input_with_mesh.empty(),
+        input_with_mesh != nullptr,
         "At least one input requires a DeviceMesh ",
         expr->toString());
     std::vector<TensorView*> outputs_without_mesh;
@@ -245,7 +246,7 @@ void propagateShardings(Fusion* fusion) {
         outputs_without_mesh.push_back(tv);
       }
     }
-    shardAllLike(input_with_mesh[0], outputs_without_mesh);
+    shardAllLike(input_with_mesh, outputs_without_mesh);
   }
 }
 

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -225,6 +225,30 @@ void shardAllLike(TensorView* ref, std::vector<TensorView*> tvs) {
 }
 } // namespace
 
+void propagateShardings(Fusion* fusion) {
+  for (auto expr : fusion->exprs()) {
+    auto inputs = ir_utils::filterByType<TensorView>(expr->inputs());
+    auto outputs = ir_utils::filterByType<TensorView>(expr->outputs());
+    std::vector<TensorView*> input_with_mesh;
+    for (auto tv : inputs) {
+      if (tv->hasDeviceMesh()) {
+        input_with_mesh.push_back(tv);
+      }
+    }
+    NVF_ERROR(
+        !input_with_mesh.empty(),
+        "At least one input requires a DeviceMesh ",
+        expr->toString());
+    std::vector<TensorView*> outputs_without_mesh;
+    for (auto tv : outputs) {
+      if (!tv->hasDeviceMesh()) {
+        outputs_without_mesh.push_back(tv);
+      }
+    }
+    shardAllLike(input_with_mesh[0], outputs_without_mesh);
+  }
+}
+
 void insertReshardings(Fusion* fusion) {
   // Remove this after we refactor this as a pre-segmenter pass.
   FusionGuard fg(fusion);

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -45,6 +45,14 @@ int64_t requestedNumberOfDevices(Fusion*);
 void unshard(Fusion*);
 void unshard(TensorView*);
 
+// TODO: Re-implement a robust and smatert sharding propagation pass.
+// Very simple sharding propagation pass that identifies tvs without
+// a DeviceMesh and shards it like its first producer tv with a sharding.
+// This assumes that all global inputs are sharded.
+// This cannot be done when the Op is inserted into the fusion, because
+// the multidevice shcheduling hasn't been applied.
+void propagateShardings(Fusion* fusion);
+
 // Runs through the fusion and inserts a resharding Set Op before any resharding
 // Expr that is not directly lowerable to a series of communications
 // TODO: add an option to rather insert the Set AFTER the resharding Expr

--- a/tests/cpp/test_multidevice_sharding.cpp
+++ b/tests/cpp/test_multidevice_sharding.cpp
@@ -40,6 +40,30 @@ TEST_F(NVFuserTest, TestIsSharded) {
   EXPECT_ANY_THROW(isSharded(c));
 }
 
+TEST_F(NVFuserTest, TestPropagateSharding) {
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* a = makeSymbolicTensor(3);
+  TensorView* b = makeSymbolicTensor(3);
+  TensorView* c = add(a, b);
+
+  DeviceMesh mesh({0, 1, 2});
+  a->setDeviceMesh(mesh);
+  b->setDeviceMesh(mesh);
+  a->axis(0)->parallelize(ParallelType::DIDx);
+  b->axis(2)->parallelize(ParallelType::DIDx);
+  fusion->addInput(a);
+  fusion->addInput(b);
+  fusion->addOutput(c);
+  propagateShardings(fusion.get());
+
+  EXPECT_TRUE(mesh == c->getDeviceMesh());
+  EXPECT_TRUE(c->axis(0)->getParallelType() == ParallelType::DIDx);
+  EXPECT_TRUE(c->axis(1)->getParallelType() == ParallelType::Serial);
+  EXPECT_TRUE(c->axis(2)->getParallelType() == ParallelType::Serial);
+}
+
 class ShardedComputeTest : public NVFuserTest,
                            public testing::WithParamInterface<bool> {};
 

--- a/tests/cpp/test_multidevice_sharding.cpp
+++ b/tests/cpp/test_multidevice_sharding.cpp
@@ -18,11 +18,13 @@
 
 namespace nvfuser {
 
+using MultiDeviceUtilsTest = NVFuserTest;
+
 // TODO: This test checks that isSharded generates an error when a split/merged
 // axis is parallelized with DIDx. Update when this restriction is lifted.
-TEST_F(NVFuserTest, TestIsSharded) {
-  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
+TEST_F(MultiDeviceUtilsTest, TestIsSharded) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
   TensorView* a = makeSymbolicTensor(3);
   a->axis(2)->parallelize(ParallelType::DIDx);
@@ -40,9 +42,9 @@ TEST_F(NVFuserTest, TestIsSharded) {
   EXPECT_ANY_THROW(isSharded(c));
 }
 
-TEST_F(NVFuserTest, TestPropagateSharding) {
-  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
+TEST_F(MultiDeviceUtilsTest, TestPropagateSharding) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
   TensorView* a = makeSymbolicTensor(3);
   TensorView* b = makeSymbolicTensor(3);
@@ -53,10 +55,10 @@ TEST_F(NVFuserTest, TestPropagateSharding) {
   b->setDeviceMesh(mesh);
   a->axis(0)->parallelize(ParallelType::DIDx);
   b->axis(2)->parallelize(ParallelType::DIDx);
-  fusion->addInput(a);
-  fusion->addInput(b);
-  fusion->addOutput(c);
-  propagateShardings(fusion.get());
+  fusion.addInput(a);
+  fusion.addInput(b);
+  fusion.addOutput(c);
+  propagateShardings(&fusion);
 
   EXPECT_TRUE(mesh == c->getDeviceMesh());
   EXPECT_TRUE(c->axis(0)->getParallelType() == ParallelType::DIDx);


### PR DESCRIPTION
A simple sharding propagation pass that shards TensorViews without a DeviceMesh like it's first producer TensorView with a DeviceMesh.
Assumes global TensorViews are manually sharded. 