### PR TITLE
Reset semaphore in grid sync

### DIFF
--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -154,6 +154,7 @@ class IndexLowering : private OptOutConstDispatch {
       Val* buffer_size,
       DataType dtype,
       bool zero_init,
+      bool resets_to_zero,
       TensorView* out_tv,
       std::unordered_map<TensorView*, kir::Allocate*>& alloc_map);
 

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -465,7 +465,8 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         maybe_alloc = lower_utils::allocGlobalBufferForGridComm(
             lower_utils::getGridSyncBufferSize(sync_bitmap),
             DataType::Int,
-            true);
+            /*zero_init=*/true,
+            /*resets_to_zero=*/true);
         sync_expr = IrBuilder::create<kir::GridSync>(
             sync_bitmap, maybe_alloc->buffer());
       } else {

--- a/runtime/grid_sync.cu
+++ b/runtime/grid_sync.cu
@@ -75,6 +75,10 @@ __device__ void sync(
       }
 #endif
     }
+    if (last_block) {
+      // Clean up semaphore for re-use in next iteration
+      semaphore = 0ULL;
+    }
   }
 
   // Sync block to make sure all other threads are waiting on the sync
@@ -141,6 +145,8 @@ __device__ void sync(
         }
 #endif
       }
+      // Clean up semaphore for reuse
+      semaphore = 0ULL;
     } else {
       auto old = atomicAdd(reinterpret_cast<uint64_t*>(&semaphore), 1);
     }


### PR DESCRIPTION
This is a follow-up to #1984. Previously we only reused semaphores for serial grid reductions. This change extends reusable zeroed memory to all grid syncs and grid reductions including welfords. Grid reductions and grid Welfords only interact with the semaphore through `grid_sync::sync`, so we only need to take care to reset the semaphore in that function.

After this change, I believe all global semaphores in nvFuser will be reused without needing a memset.