### PR TITLE
Print better test names.

### DIFF
--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -270,9 +270,8 @@ TEST_P(CommunicationTest, Communication_ReduceScatter) {
 INSTANTIATE_TEST_SUITE_P(
     CommunicatorBackend,
     CommunicationTest,
-    testing::Values(CommunicatorBackend::nccl, CommunicatorBackend::ucc)
-
-);
+    testing::Values(CommunicatorBackend::nccl, CommunicatorBackend::ucc),
+    testing::PrintToStringParamName());
 
 } // namespace nvfuser
 


### PR DESCRIPTION
Before:
```
[ RUN      ] CommunicationTest.Communication_ReduceScatter/0
[       OK ] CommunicationTest.Communication_ReduceScatter/0 (0 ms)
[ RUN      ] CommunicationTest.Communication_ReduceScatter/1
[       OK ] CommunicationTest.Communication_ReduceScatter/1 (0 ms)
```

After:
```
[ RUN      ] CommunicationTest.Communication_ReduceScatter/NCCL
[       OK ] CommunicationTest.Communication_ReduceScatter/NCCL (0 ms)
[ RUN      ] CommunicationTest.Communication_ReduceScatter/UCC
[       OK ] CommunicationTest.Communication_ReduceScatter/UCC (0 ms)
```