### PR TITLE
Remove legacy doc and rename variables in TMA indexing code

### DIFF
--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -3551,7 +3551,7 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
           striding_split->inner()->toString(),
           " is.");
       IterDomain* box_id = striding_split->in();
-      Split boxing_split = dynamic_cast<Split*>(box_id->definition());
+      Split* boxing_split = dynamic_cast<Split*>(box_id->definition());
       NVF_ERROR(
           boxing_split != nullptr && boxing_split->inner() == box_id,
           "Box IterDomain is not defined as the inner output of the boxing split.",

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -3291,205 +3291,6 @@ Val* Index::eye(
   return GpuLower::current()->commonScalarMap().hoistScalar(result, loops);
 }
 
-// Note [Schedule and indexing of TMA]
-//
-// TMA is a hardware feature that allows the GPU to load a tile from a tensor of
-// up to 5D. Note that the dimensionality of the tensor in the eyes of TMA is
-// not necessarily the same as the dimensionality of the tensor in the eyes of
-// the user. For example, it is possible that there is a 1D tensor of shape
-// 1000000 and the user wants to view it as (1000, 1000) and load a tile of (8,
-// 8) from it. Another example is, the user has a tensor of shape (1000, 1000),
-// and as long as the tensor is contiguous, the user can view it as a flattened
-// shape 1000000 tensor, and load a tile of 8 from it. The dimensionality of the
-// tensor in the eyes of TMA is determined by the schedule of the tensor.
-// However, the dimensionality of the tensor in the eyes of TMA can not be
-// smaller than the physical dimensionality of the tensor. For example, if the
-// user has a tensor of shape (128, 128, 128, 128, 128, 128), and the tensor is
-// fully discontiguous, then it is not possible to view it as a <= 5D tensor,
-// thus TMA can not be used to load/store a tile from it.
-//
-// The gmem tensor of TMA store, or the gmem tensor of TMA load when replayed as
-// consumer, must be scheduled like this:
-//
-//                         ---------------------
-//                         | Allocation Domain |
-//                         ---------------------
-//                           | | | | | | | | |
-//                         IterDomain Expressions
-//                             | | | | | | |
-//                         ---------------------
-//                         |  I1           I2  |
-//                         ---------------------
-//                            |            |
-//                          split        split
-//                          /   \        /   |
-//                         I3   I4      I5   I6
-//                         |    |       |    |
-//                        ...   |      ... split
-//                              |          /   |
-//                              |         I7   I8
-//                              |         |    |
-//                              |         |   ...
-//                              |         |
-//                         IterDomain Expressions
-//                          |    |    |    |    |
-//                         Bulk Bulk Bulk Bulk Bulk
-//
-// To schedule TMA, the overall process is:
-//
-// First, we need to specify how TMA should view the tensor. In the above
-// diagram, TMA view the tensor as a 2D tensor [I1, I2]. Note that the
-// IterDomain expressions between the allocation domain and [I1, I2] must be
-// compatible with the allocation domain, for example, we can not merge
-// discontiguous IterDomains, and we can not have indivisible splits either.
-// We call [I1, I2] the "TMA domain" of the tensor.
-//
-// Second, we need to tile each dimension of the TMA domain of the tensor. If we
-// want a contiguous box dim (see Definition 3: "boxId" below), then we do one
-// split to get the box. If we want a strided box dim, then we do two splits,
-// the first split is to get the box, and the second split is to get the stride.
-// In the above diagram, I1 has a contiguous box dim, and I2 has a strided box
-// dim.
-//
-// Third, we can schedule the "bulk" IterDomains (see Definition 1: "bulk"
-// below) and "non-bulk" IterDomains separately in whatever way we want.
-// However, the "bulk" IterDomains and "non-bulk" IterDomains can not be mixed
-// together, just like we not merge a IterType::Iteration IterDomain with a
-// IterType::Reduction IterDomain.
-//
-// Before further explain the schedule, let's define some terminologies:
-//
-// Definition 1: An IterDomain is "bulk" if any of the following is true:
-//  - It has parallel type "Bulk"
-//  - All its children are "bulk"
-//
-// In the above diagram, I4 and I7 are bulk IterDomains, but I1, I2, I3, I5, I6,
-// and I8 are not. Please note that the concept "bulk IterDomain" is different
-// from the concept "IterDomain parallelized as IterType::Bulk". Because we only
-// parallelize leaf domains, the set "IterDomain parallelized as IterType::Bulk"
-// and the set "bulk IterDomains" has the following relationship:
-// - IterDomains parallelized as IterType::Bulk <= bulk IterDomains
-// - bulk IterDomains = IterDomain parallelized as IterType::Bulk & leaf domain
-// where "<=" refers to subset, and "&" refers to set intersection.
-//
-// Definition 2: A bulk IterDomain is "originating" if its parents are not bulk.
-//
-// In the above diagram, I4 and I7 are originating bulk IterDomains.
-//
-// The number of originating bulk IterDomains is the dimensionality of the
-// tensor in the eyes of TMA.
-//
-// Note that an originating bulk IterDomains must be the output of a split from
-// another IterDomain. Most commonly, we load/store tiles "contiguously", that
-// is, for example, when we have a tile/box size (8, 8), we want all the 8*8=64
-// elements to to be transfered. If this is the case, then the originating bulk
-// IterDomains must be the inner of the split that defines it, and the outer of
-// the split must be non-bulk. For this case, the extents of the originating
-// bulk IterDomains are the tile/box sizes (the `boxDim` parameter in
-// `cuTensorMapEncodeTiled`).
-//
-// However, it is also possible to load/store tiles in a strided manner, that
-// is, for example, if we consider a box dim of (8, 8), and we want
-// every other element from it to be transferred, that is, items at (0, 0),
-// (0, 2), (0, 4), ..., (2, 0), (2, 2), (2, 4), ..., (6, 6). We will transfer
-// data as (4, 4) dense tile of elements. In this scenario, the `elementStrides`
-// in  `cuTensorMapEncodeTiled` will have a value [2, 2]. For this case, the
-// originating bulk IterDomains must be the outer of the split that defines it,
-// where the inner of this split must be non-bulk. The parent of the originating
-// bulk IterDomains must also be an output of a split and it must be the inner
-// of the split that defines it, and similarly, the outer of this split must be
-// non-bulk. For this case, the extents of the originating bulk IterDomains are
-// the tile sizes, and the extents of parents of the originating bulk
-// IterDomains are the box sizes (the `boxDim` parameter in
-// `cuTensorMapEncodeTiled`).
-//
-// With this understanding, we can now define more terminologies:
-//
-// Definition 3: "boxId" is a function that takes an originating bulk IterDomain
-// as its input, and returns an IterDomain. Given an originating bulk IterDomain
-// I1, the return value, boxId(I1) is:
-//   - I1 if I1 is the inner of the split that defines it
-//   - The parent of I1 if I1 is the outer of the split that defines it
-//
-// In the above diagram, boxId(I4) is I4, and boxId(I7) is I6.
-//
-// Definition 4: "partitionedId" is a function that takes an originating bulk
-// IterDomain as its input, and returns another IterDomain. Given an originating
-// bulk IterDomain I1, the return value, partitionedId(I1) is:
-//   - The parent of I1 if I1 is the inner of the split that defines it
-//   - The grandparent of I1 if I1 is the outer of the split that defines it
-//
-// In the above diagram, partitionedId(I4) is I1, and partitionedId(I7) is I2.
-//
-// Definition 5: "innerId" is a function that takes an originating bulk who is
-// the outer of the split that defines it, and returns its sibling IterDomain.
-//
-// In the above diagram, innerId(I7) is I8.
-//
-// Definition 6: An IterDomain I1 is "partitioned" if there exists an
-// originating bulk IterDomain I2 such that I1 == partitionedId(I2).
-//
-// In the above diagram, I1 and I2 are partitioned IterDomains.
-//
-// Note that the number of partitioned IterDomains should always be equal to the
-// number of originating bulk IterDomains, which should always be equal to the
-// dimensionality of the tensor in the eyes of TMA.
-//
-// Also note that partitioned IterDomains can not have dependencies between each
-// other, that is, no one partitioned IterDomains can be an ancestor or
-// descendant of another partitioned IterDomains. That is, schedules like this
-// is not allowed:
-//   I1 -> split -> Bulk (inner)
-//              \-> I2 (outer) -> split -> Bulk (inner)
-//                                     \-> I3 (outer)
-// Also note that the set of all partitioned IterDomains must be "equivalent" to
-// the allocation domain of the tensor (ignoring unrelated IterTypes like
-// broadcast and reduction), as defined in
-// `ir_utils::validateDomainEquivalence`.
-//
-// Definition 7: The "TMA domain" of a tensor is the set of all partitioned
-// IterDomains with a specific order. The order is determined by the order of
-// the allocation domain of the tensor.
-//
-//
-// Examples: (upper are inner)
-//
-// Example 1:
-//
-// I0 -> split -> I1 -> split -> I3 (Bulk)
-//           \               \-> I4
-//            \-> I2 -> split -> I5 (Bulk)
-//                           \-> I6
-//
-// Originating bulk IterDomains: { I3, I5 }
-// Box IterDomains: { I3, I5 }
-// Inner IterDomains: {}
-// partitioned IterDomains: { I1, I2 }
-// TMA domain: [I2, I1].
-//
-// Example 2:
-//
-// I0 -> split -> I1 -> split -> I3 (Bulk)
-//           \               \-> I4
-//            \-> I2 -> split -> I5 -> split -> I7
-//                           \-> I6         \-> I8 (Bulk)
-//
-// Originating bulk IterDomains: { I3, I8 }
-// Box IterDomains: { I3, I5 }
-// Inner IterDomains: { I7 }
-// partitioned IterDomains: { I1, I2 }
-// TMA domain: [I2, I1].
-//
-// Example 3:
-//
-// I0 -> merge -> I2 -> split -> I3 (Bulk)
-// I1 ---^                   \-> I4
-//
-// Originating bulk IterDomains: { I3 }
-// Box IterDomains: { I3 }
-// Inner IterDomains: {}
-// partitioned IterDomains: { I2 }
-// TMA domain: [I2].
 namespace {
 
 int64_t getCpAsyncBulkTensorSwizzleSize(TensorView* smem_tv) {
@@ -3508,21 +3309,23 @@ int64_t getCpAsyncBulkTensorSwizzleSize(TensorView* smem_tv) {
 
 } // namespace
 
+// TODO: we do not support "define box by compositing" yet.
+// WIP PR: https://github.com/NVIDIA/Fuser/pull/1991
+//
 // Analyze the schedule of the gmem tensor (for TMA load, it needs to be
 // replayed as its consumer) and create IR nodes that compute the N-dimensional
 // coordinate and the tensor map descriptor. Also return the byte of transfer.
-// We first need to find the TMA domain based on the schedule, which is done by
-// finding originating bulk IterDomains first and analyze their definitions.
-// After finding all these IterDomains we are interested in, we can compute the
-// quantities easily: The N-dimensional coordinate is just the indices of the
-// TMA domain in the index map. To compute the tensor map descriptor, we need to
-// find the box dims, the element strides, global dims, and global strides. The
-// box dims are the extents of the box IterDomains. The element strides are
-// either 1 or the extents of the inner IterDomains if any. The global dims are
-// the extents of IterDomains in the TMA domain. The global strides are inferred
-// based on IterDomain expressions between the allocation domain and TMA domain.
-// The byte of transfer is the product of extents of originating bulk
-// IterDomains.
+// We first need to infer the TMA domain based on the schedule, which is done by
+// finding tile IterDomains first and analyze their definitions. After finding
+// all these IterDomains we are interested in, we can compute the quantities
+// easily: The N-dimensional coordinate is just the indices of the TMA domain in
+// the index map. To compute the tensor map descriptor, we need to find the box
+// dims, the element strides, global dims, and global strides. The box dims are
+// the extents of the box IterDomains. The element strides are either implicitly
+// one or the extents of the stride IterDomains if any. The global dims are the
+// extents of partitioned IterDomains. The global strides are inferred based on
+// IterDomain expressions between the allocation domain and TMA domain. The byte
+// of transfer is the product of extents of tile IterDomains.
 std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
     TensorView* producer_tv,
     TensorView* consumer_tv,
@@ -3605,12 +3408,15 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
     indexing = std::make_unique<IndexCompute>(index_from_id_graph.index);
   }
 
-  // Step 1: Get all bulk IterDomains and originating bulk IterDomains
+  // Step 1: Get all bulk IterDomains and tile IterDomains.
+  // An IterDomain is considered "bulk" if it has parallel type "Bulk" or all
+  // its children are considered "bulk".
+  // A "tile" IterDomain is a bulk IterDomain whose parents are not bulk.
 
   // Get all bulk IterDomains
   std::unordered_set<IterDomain*> bulk_ids;
-  // Bulk IterDomains that we need to check its definition to see if it is an
-  // originating bulk IterDomain.
+  // Bulk IterDomains that we need to check its definition to see if it is a
+  // tile IterDomain.
   std::deque<IterDomain*> pending;
   pending.push_back(nullptr); // use nullptr as a checkpoint
   // Start from leaf domain, where all the bulk IterDomains in the leaf domain
@@ -3639,7 +3445,7 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
       } else {
         // We have visited all IterDomains in pending for one round, but nothing
         // has changed. This means that all IterDomains in pending are
-        // originating bulk IterDomains, so we can no longer propagate further.
+        // tile IterDomains, so we can no longer propagate further.
         break;
       }
     }
@@ -3673,19 +3479,19 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
       }
     } else {
       // Not all outputs of def are bulk IterDomains, this could be because:
-      // 1. id is an originating bulk IterDomain
-      // 2. id is not an originating bulk IterDomain, we just haven't visited
-      //    def's other outputs yet.
+      // 1. id is a tile IterDomain
+      // 2. id is not a tile IterDomain, we just haven't visited def's other
+      //    outputs yet.
       pending.push_back(id);
     }
   }
 
-  // Get originating bulk IterDomains. Use VectorOfUniqueEntries instead of
-  // std::unordered_set to make the algorithm deterministic. However, the
-  // order here has no meaning, especially, is is not the order specifying which
+  // Get tile IterDomains. Use VectorOfUniqueEntries instead of
+  // std::unordered_set to make the algorithm deterministic. However, the order
+  // here has no meaning, especially, is is not the order specifying which
   // IterDomain is inner and which is outer. The actual order must be determined
   // by propagating from the allocation domain.
-  VectorOfUniqueEntries<IterDomain*> originating_bulk_ids;
+  VectorOfUniqueEntries<IterDomain*> tile_ids;
   for (auto id : pending) {
     if (id == nullptr) {
       continue;
@@ -3693,13 +3499,13 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
     auto def = id->definition();
     NVF_ERROR(
         def != nullptr && def->isA<Split>(),
-        "An originating bulk IterDomain must be the output of a split, but ",
+        "A tile IterDomain must be the output of a split, but ",
         id->toString(),
         " is not.");
-    originating_bulk_ids.pushBack(id);
+    tile_ids.pushBack(id);
   }
 
-  // Step 2: Get boxId and partitionedId, and innerId for each originating bulk
+  // Step 2: Get the box, partitioned, and stride IterDomains from each tile
   // IterDomain. Similarily, the order of the `partitioned_ids` has no meaning.
   // So `partitioned_ids` contains the same set of IDs as the TMA domain, but
   // can be in different order. We are using a std::vector<Val*> just to make
@@ -3707,26 +3513,26 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
 
   std::vector<Val*> partitioned_ids;
   std::unordered_map<IterDomain*, IterDomain*> partitioned_id_to_box_id;
-  std::unordered_map<IterDomain*, IterDomain*> partitioned_id_to_orig_bulk_id;
-  std::unordered_map<IterDomain*, IterDomain*> partitioned_id_to_inner_id;
-  for (auto id : originating_bulk_ids) {
+  std::unordered_map<IterDomain*, IterDomain*> partitioned_id_to_tile_id;
+  std::unordered_map<IterDomain*, IterDomain*> partitioned_id_to_stride_id;
+  for (auto id : tile_ids) {
     auto def = id->definition()->as<Split>();
     if (id == def->inner()) {
       IterDomain* box_id = id;
       IterDomain* partitioned_id = def->in();
       partitioned_ids.push_back(partitioned_id);
       partitioned_id_to_box_id[partitioned_id] = box_id;
-      partitioned_id_to_orig_bulk_id[partitioned_id] = id;
+      partitioned_id_to_tile_id[partitioned_id] = id;
       NVF_ERROR(
           bulk_ids.count(def->outer()) == 0,
-          "When an originating bulk IterDomain is an inner of a split, ",
+          "When a tile IterDomain is an inner of a split, ",
           "the outer of this split must not be a bulk IterDomain, but ",
           def->outer()->toString(),
           " is.");
     } else {
       NVF_ERROR(
           bulk_ids.count(def->inner()) == 0,
-          "When an originating bulk IterDomain is an outer of a split, ",
+          "When a tile IterDomain is an outer of a split, ",
           "the inner of this split must not be a bulk IterDomain, but ",
           def->inner()->toString(),
           " is.");
@@ -3734,28 +3540,28 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
       auto def2 = dynamic_cast<Split*>(box_id->definition());
       NVF_ERROR(
           def2 != nullptr && def2->inner() == box_id,
-          "When an originating bulk IterDomain is an outer of a split, ",
-          "The parent of an originating bulk IterDomain must be an inner output of a split, but ",
+          "When a tile IterDomain is an outer of a split, ",
+          "The parent of a tile IterDomain must be an inner output of a split, but ",
           box_id->toString(),
           " is not.");
       NVF_ERROR(
           bulk_ids.count(def2->outer()) == 0,
-          "When an originating bulk IterDomain is an outer of a split, ",
+          "When a tile IterDomain is an outer of a split, ",
           "the outer of its parent's definition must not be a bulk IterDomain, but ",
           def2->outer()->toString(),
           " is.");
       IterDomain* partitioned_id = def2->in();
       partitioned_ids.push_back(partitioned_id);
       partitioned_id_to_box_id[partitioned_id] = box_id;
-      partitioned_id_to_orig_bulk_id[partitioned_id] = id;
-      partitioned_id_to_inner_id[partitioned_id] = def->inner();
+      partitioned_id_to_tile_id[partitioned_id] = id;
+      partitioned_id_to_stride_id[partitioned_id] = def->inner();
     }
   }
 
-  // Stpe 3: Propagate from the allocation domain to partitioned IterDomains,
-  // compute the order, contiguity, and stride of partitioned IterDomains. Note
-  // that this order is meaningful, and it is the order that defines which is
-  // inner and which is outer. The strides are also meaningful, and they are the
+  // Stpe 3: Propagate from the allocation domain to the TMA domain, compute the
+  // order, contiguity, and stride of partitioned IterDomains. Note that this
+  // order is meaningful, and it is the order that defines which is inner and
+  // which is outer. The strides are also meaningful, and they are the
   // `globalStrides` of the `cuTensorMapEncodeTiled`. After propagation,
   // `frontier` will be the TMA domain.
 
@@ -3847,11 +3653,11 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
 
   int64_t dim = (int64_t)frontier.size();
   NVF_ERROR(
-      dim == (int64_t)originating_bulk_ids.size(),
-      "The number of originating bulk IterDomains must be equivalent to the dimensionality of the tensor in the eyes of TMA, but ",
+      dim == (int64_t)tile_ids.size(),
+      "The number of tile IterDomains must be equivalent to the dimensionality of the tensor in the eyes of TMA, but ",
       dim,
       " is not equal to ",
-      originating_bulk_ids.size());
+      tile_ids.size());
 
   // Validate that frontier contains exactly the same IterDomains as
   // partitioned_ids, otherwise there is something wrong in the schedule.
@@ -3888,16 +3694,16 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
     box_sizes_inner_to_outer.push_back(
         partitioned_id_to_box_id.at(id)->extent());
 
-    auto inner_it = partitioned_id_to_inner_id.find(id);
+    auto stride_it = partitioned_id_to_stride_id.find(id);
     if (it == frontier.rbegin()) {
       NVF_ERROR(
-          inner_it == partitioned_id_to_inner_id.end(),
+          stride_it == partitioned_id_to_stride_id.end(),
           "When interleave is CU_TENSOR_MAP_INTERLEAVE_NONE ",
           "(this is always the case for nvFuser now)",
           ", the first element of elementStrides must be one.");
     }
-    if (inner_it != partitioned_id_to_inner_id.end()) {
-      element_strides_inner_to_outer.push_back(inner_it->second->extent());
+    if (stride_it != partitioned_id_to_stride_id.end()) {
+      element_strides_inner_to_outer.push_back(stride_it->second->extent());
     } else {
       element_strides_inner_to_outer.push_back(gmem_tv->fusion()->oneVal());
     }
@@ -3958,10 +3764,10 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
   // Step 5: Compute the expected bytes for the complete_tx mechanism
 
   Val* expected_bytes = IrBuilder::create<Val>(itemsize, DataType::Index);
-  // Note that we need to use the extents of the originating bulk IterDomains
+  // Note that we need to use the extents of the tile IterDomains
   // to compute the expected bytes, not the extents of the box IterDomains.
   // They are different when element strides are not 1.
-  for (auto id : originating_bulk_ids) {
+  for (auto id : tile_ids) {
     expected_bytes =
         SimplifyingIrBuilder::mulExpr(expected_bytes, id->extent());
   }

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -543,8 +543,7 @@ std::string testNameTMASimpleLdstTest(
   auto dtype = std::get<1>(info.param);
   auto dim = std::get<2>(info.param);
   std::stringstream ss;
-  ss << dim << "D"
-     << "_" << toString(swizzle) << "_" << dtype;
+  ss << dim << "D" << "_" << toString(swizzle) << "_" << dtype;
   return ss.str();
 }
 
@@ -1173,9 +1172,7 @@ TEST_F(TMARuntimeInvalidTest, SizeOfTransfer) {
       &fusion, cg_outputs, {t0, items_of_16_bytes}, {t0}, __LINE__, __FILE__);
 
   EXPECT_THAT(
-      [&]() {
-        fe.runFusion({t0, items_of_16_bytes / 2});
-      },
+      [&]() { fe.runFusion({t0, items_of_16_bytes / 2}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "The expected bytes must be a multiple of 16 bytes, but ")));
 }
@@ -1235,7 +1232,7 @@ TEST_F(TMARuntimeInvalidTest, InvalidView) {
           ::testing::HasSubstr("Invalid view in TMA: the extent of")));
 }
 
-TEST_F(TMACompileTimeInvalidTest, DependentBulkSplit1) {
+TEST_F(TMACompileTimeInvalidTest, DependentBoxingSplit1) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -1269,10 +1266,10 @@ TEST_F(TMACompileTimeInvalidTest, DependentBulkSplit1) {
         fe.compileFusion(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
-          "The set of all partitioned IterDomains must be equivalent to the allocation domain, but")));
+          "The TMA domain must be equivalent to the allocation domain, but")));
 }
 
-TEST_F(TMACompileTimeInvalidTest, DependentBulkSplit2) {
+TEST_F(TMACompileTimeInvalidTest, DependentBoxingSplit2) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -1306,8 +1303,7 @@ TEST_F(TMACompileTimeInvalidTest, DependentBulkSplit2) {
         fe.compileFusion(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
-          "When an originating bulk IterDomain is an outer of a split, "
-          "The parent of an originating bulk IterDomain must be an inner output of a split, but")));
+          "Box IterDomain is not defined as the inner output of the boxing split.")));
 }
 
 TEST_F(TMACompileTimeInvalidTest, InnermostDiscontiguous) {
@@ -1342,7 +1338,7 @@ TEST_F(TMACompileTimeInvalidTest, InnermostDiscontiguous) {
         fe.compileFusion(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
-          "The innermost IterDomain of the allocation domain must be contiguous")));
+          "The innermost IterDomain of the TMA domain must be contiguous")));
 }
 
 TEST_F(TMACompileTimeInvalidTest, MergeDiscontiguous) {
@@ -1458,7 +1454,7 @@ TEST_F(TMACompileTimeInvalidTest, SwizzleBulkWithNonBulk) {
         fe.compileFusion(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
-          "An originating bulk IterDomain must be the output of a split, but")));
+          "A tile IterDomain must be the output of a split, but")));
 }
 
 // End TMA tests

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -543,7 +543,8 @@ std::string testNameTMASimpleLdstTest(
   auto dtype = std::get<1>(info.param);
   auto dim = std::get<2>(info.param);
   std::stringstream ss;
-  ss << dim << "D" << "_" << toString(swizzle) << "_" << dtype;
+  ss << dim << "D"
+     << "_" << toString(swizzle) << "_" << dtype;
   return ss.str();
 }
 
@@ -1172,7 +1173,9 @@ TEST_F(TMARuntimeInvalidTest, SizeOfTransfer) {
       &fusion, cg_outputs, {t0, items_of_16_bytes}, {t0}, __LINE__, __FILE__);
 
   EXPECT_THAT(
-      [&]() { fe.runFusion({t0, items_of_16_bytes / 2}); },
+      [&]() {
+        fe.runFusion({t0, items_of_16_bytes / 2});
+      },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "The expected bytes must be a multiple of 16 bytes, but ")));
 }


### PR DESCRIPTION
Renames:
- originating bulk ID -> tile ID
- inner ID -> stride ID