### PR TITLE
Update`dropout-layernorm/rmsnorm` benchmarks

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -8,7 +8,7 @@ import torch
 from torch.autograd import DeviceType
 from torch.profiler import profile, ProfilerActivity
 from typing import List, Callable, Union, Tuple
-
+import numpy as np
 
 def get_device_properties() -> Tuple[int, float]:
     """
@@ -144,6 +144,20 @@ def clear_cuda_cache() -> None:
 # Backward function for torch baseline benchmarks.
 def unary_bwd_torch(inputs: List):  # [output, grad_out]
     inputs[0].backward(inputs[1], retain_graph=True)
+
+
+def compute_total_iobytes(tensor_props: dict):
+    '''
+    Compute IObytes for baselines from given description:
+    Tensor_props has entries of the form: {'tensor_id': (size: tuple, dtype: torch.dtype)}
+    '''
+    iobytes = 0
+    for _, tensor_prop in tensor_props.items():
+        size, dtype = tensor_prop[0], tensor_prop[1]
+        if not isinstance(size, tuple):
+            size = (size)
+        iobytes += np.prod(size) * dtype.itemsize
+    return int(iobytes)
 
 
 class NVFBenchmark:

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -10,6 +10,7 @@ from torch.profiler import profile, ProfilerActivity
 from typing import List, Callable, Union, Tuple
 import numpy as np
 
+
 def get_device_properties() -> Tuple[int, float]:
     """
     Computes device properties using ctypes and cuda.
@@ -147,10 +148,10 @@ def unary_bwd_torch(inputs: List):  # [output, grad_out]
 
 
 def compute_total_iobytes(tensor_props: dict):
-    '''
+    """
     Compute IObytes for baselines from given description:
     Tensor_props has entries of the form: {'tensor_id': (size: tuple, dtype: torch.dtype)}
-    '''
+    """
     iobytes = 0
     for _, tensor_prop in tensor_props.items():
         size, dtype = tensor_prop[0], tensor_prop[1]

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -155,9 +155,10 @@ def compute_total_iobytes(tensor_props: dict):
     iobytes = 0
     for _, tensor_prop in tensor_props.items():
         size, dtype = tensor_prop[0], tensor_prop[1]
-        if not isinstance(size, tuple):
-            size = (size)
-        iobytes += np.prod(size) * dtype.itemsize
+        if isinstance(size, tuple):
+            iobytes += np.prod(size) * dtype.itemsize
+        else:
+            iobytes += size * dtype.itemsize
     return int(iobytes)
 
 

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -147,7 +147,9 @@ def unary_bwd_torch(inputs: List):  # [output, grad_out]
     inputs[0].backward(inputs[1], retain_graph=True)
 
 
-def compute_total_iobytes(tensor_props: dict):
+def compute_total_iobytes(
+    tensor_props: dict[str, tuple[int | tuple[int, ...], torch.dtype]]
+):
     """
     Compute IObytes for baselines from given description:
     Tensor_props has entries of the form: {'tensor_id': (size: tuple, dtype: torch.dtype)}

--- a/benchmarks/python/test_dropout_layernorm_bwd.py
+++ b/benchmarks/python/test_dropout_layernorm_bwd.py
@@ -112,7 +112,7 @@ def dropout_layernorm_bwd_fusion(
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_layernorm_bwd_benchmark(
+def test_layernorm_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,

--- a/benchmarks/python/test_dropout_layernorm_fwd.py
+++ b/benchmarks/python/test_dropout_layernorm_fwd.py
@@ -129,7 +129,7 @@ def test_dropout_layernorm_fwd_nvf_benchmark(
         dropout_mask = torch.ones(size, dtype=torch.bool, device="cuda")
 
         # dropout + add
-        x = inputs[2] + torch.nn.functional.dropout(inputs[1], p=0.0)
+        x = inputs[1] + torch.nn.functional.dropout(inputs[0], p=0.0)
         # layernorm
         eager_output = torch.nn.functional.layer_norm(
             x.to(torch.float),

--- a/benchmarks/python/test_dropout_layernorm_fwd.py
+++ b/benchmarks/python/test_dropout_layernorm_fwd.py
@@ -78,7 +78,7 @@ def dropout_layernorm_fwd_fn(inputs: list):  # [in_tensor1, in_tensor2, weights,
     )
 
 
-def dropout_ln_fwd_iobytes(size: tuple, dtype: torch.dtype):
+def dropout_layernorm_fwd_iobytes(size: tuple, dtype: torch.dtype):
     # Total IO bytes:
     # Inputs: in_tensor1 (size, dtype) + in_tensor2 (size, dtype), weights (size[1], dtype) + bias (size[1], dtype)
     # Outputs: mean (size[0], float) + invstd (size[0], float) + outputs (size, dtype) + dropout_mask (size, bool)

--- a/benchmarks/python/test_dropout_rmsnorm_fwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_fwd.py
@@ -130,7 +130,7 @@ def test_dropout_rmsnorm_fwd_nvf_benchmark(
         dropout_mask = torch.ones(size, dtype=torch.bool, device="cuda")
 
         x = input2.to(torch.double) + torch.nn.functional.dropout(
-            input1.to(torch.double), p=dropout_p
+            input1.to(torch.double), p=0.0
         )
         rms_eps = torch.sqrt(x.pow(2).mean(-1, keepdim=True) + eps)
         eager_output = weights.to(torch.double) * (x / rms_eps)


### PR DESCRIPTION
1. Update the fusion definition to have 2 distinct inputs: `layernorm/rmsnorm (inp2 + dropout(inp1))`.
2. Add torch baselines
3. Add iobyte computation based on input/output dict listing size and dtype. This should make the computation clearer to the users and less error-prone

Issue #1668 