### PR TITLE
Rename and move test_multidevice_sharding.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,6 +511,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_predicate_elimination.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_preseg_passes.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_replay.cpp
+  ${NVFUSER_ROOT}/tests/cpp/test_resharding.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_resize.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_reduction_pointwise.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_scalar_hoisting.cpp
@@ -575,7 +576,6 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/tests/cpp/multidevice.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_communications.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_pipeline.cpp
-    ${NVFUSER_ROOT}/tests/cpp/test_multidevice_resharding.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_sharding.cpp
   )
   add_test(test_multidevice "${MULTIDEVICE_TEST_SRCS}" "")

--- a/tests/cpp/test_multidevice_sharding.cpp
+++ b/tests/cpp/test_multidevice_sharding.cpp
@@ -16,13 +16,13 @@
 namespace nvfuser {
 
 // params: concrete vs symbolic input, sharded axis
-class ShardingTest : public MultiDeviceTest,
-                     public testing::WithParamInterface<std::tuple<bool, int>> {
-};
+class MultideviceShardingTest
+    : public MultiDeviceTest,
+      public testing::WithParamInterface<std::tuple<bool, int>> {};
 
 // Test memory allocation of multidevice fusion with unsharded inputs
 // and sharded intermediates, outputs.
-TEST_P(ShardingTest, UnshardedGlobalInput) {
+TEST_P(MultideviceShardingTest, UnshardedGlobalInput) {
   auto [creates_concrete_tensor, sharded_dim] = GetParam();
   std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
@@ -74,7 +74,7 @@ TEST_P(ShardingTest, UnshardedGlobalInput) {
 
 // Test memory allocation of multidevice fusion with sharded input
 // and replicated intermediates and output.
-TEST_P(ShardingTest, ShardGlobalInput) {
+TEST_P(MultideviceShardingTest, ShardGlobalInput) {
   auto [creates_concrete_tensor, sharded_dim] = GetParam();
   std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
@@ -113,12 +113,12 @@ TEST_P(ShardingTest, ShardGlobalInput) {
 
 INSTANTIATE_TEST_SUITE_P(
     OutermostShard,
-    ShardingTest,
+    MultideviceShardingTest,
     testing::Combine(testing::Bool(), testing::Values(0)));
 
 INSTANTIATE_TEST_SUITE_P(
     InnermostShard,
-    ShardingTest,
+    MultideviceShardingTest,
     testing::Combine(testing::Bool(), testing::Values(1)));
 
 } // namespace nvfuser

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -15,11 +15,11 @@
 
 namespace nvfuser {
 
-using MultiDeviceUtilsTest = NVFuserTest;
+using ShardingTest = NVFuserFixtureParamTest<bool>;
 
 // TODO: This test checks that isSharded generates an error when a split/merged
 // axis is parallelized with DIDx. Update when this restriction is lifted.
-TEST_F(MultiDeviceUtilsTest, IsSharded) {
+TEST_F(ShardingTest, IsSharded) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -39,7 +39,7 @@ TEST_F(MultiDeviceUtilsTest, IsSharded) {
   EXPECT_ANY_THROW(isSharded(c));
 }
 
-TEST_F(MultiDeviceUtilsTest, PropagateSharding) {
+TEST_F(ShardingTest, PropagateSharding) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -63,9 +63,7 @@ TEST_F(MultiDeviceUtilsTest, PropagateSharding) {
   EXPECT_TRUE(c->axis(2)->getParallelType() == ParallelType::Serial);
 }
 
-using ShardedComputeTest = NVFuserFixtureParamTest<bool>;
-
-TEST_P(ShardedComputeTest, ComputeIndex) {
+TEST_P(ShardingTest, ComputeIndex) {
   const bool creates_concrete_tensor = GetParam();
   std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
@@ -101,6 +99,6 @@ TEST_P(ShardedComputeTest, ComputeIndex) {
   testValidate(fusion.get(), outputs, {a_tensor}, __LINE__, __FILE__);
 }
 
-INSTANTIATE_TEST_SUITE_P(, ShardedComputeTest, testing::Bool());
+INSTANTIATE_TEST_SUITE_P(ShardedComputeTest, ShardingTest, testing::Bool());
 
 } // namespace nvfuser


### PR DESCRIPTION
1. Rename it to test_sharding.
2. Move it from binary test_multidevice to binary nvfuser_tests.

This is a follow-up to https://github.com/NVIDIA/Fuser/pull/2096.

CI: https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/pipelines/14326655