### PR TITLE
Add CLI options for benchmarking, update test name printing

### DIFF
--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -28,15 +28,17 @@ def pytest_addoption(parser):
         help="Benchmarks torch.compile mode.",
     )
 
+    # pytest-benchmark does not have CLI options to set rounds/warmup_rounds for benchmark.pedantic.
+    # The following two options are used to overwrite the default values through CLI.
     parser.addoption(
-        "--rounds",
+        "--benchmark-rounds",
         action="store",
         default=10,
         help="Number of rounds for each benchmark.",
     )
 
     parser.addoption(
-        "--warmup-rounds",
+        "--benchmark-warmup-rounds",
         action="store",
         default=1,
         help="Number of warmup rounds for each benchmark.",
@@ -64,8 +66,10 @@ def pytest_benchmark_update_machine_info(config, machine_info):
 
 
 def pytest_configure(config):
-    BENCHMARK_CONFIG["rounds"] = int(config.getoption("--rounds"))
-    BENCHMARK_CONFIG["warmup_rounds"] = int(config.getoption("--warmup-rounds"))
+    BENCHMARK_CONFIG["rounds"] = int(config.getoption("--benchmark-rounds"))
+    BENCHMARK_CONFIG["warmup_rounds"] = int(
+        config.getoption("--benchmark-warmup-rounds")
+    )
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -287,7 +287,7 @@ class NVFBenchmark:
 
 
 # These variables can be overwritten through CLI commands
-# --rounds=rounds --warmup-rounds=warmup_rounds
+# --benchmark-rounds=rounds --benchmark-warmup-rounds=warmup_rounds
 BENCHMARK_CONFIG = {"rounds": 10, "warmup_rounds": 1}
 
 

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -286,12 +286,15 @@ class NVFBenchmark:
         )
 
 
+# These variables can be overwritten through CLI commands
+# --rounds=rounds --warmup-rounds=warmup_rounds
+BENCHMARK_CONFIG = {"rounds": 10, "warmup_rounds": 1}
+
+
 def run_benchmark(
     benchmark: pytest_benchmark.fixture.BenchmarkFixture,
     benchmark_fn: Callable,
     inputs: Union[torch.Tensor, List],
-    rounds: int = 10,
-    warmup_rounds: int = 1,
     iobytes: int = None,
 ) -> Union[torch.Tensor, List]:
     """
@@ -306,13 +309,18 @@ def run_benchmark(
         outputs: Output of the target function
     """
 
+    # These variables are updated based on CLI options
+
     def setup():
         clear_l2_cache()
         return [inputs], {}
 
     nvf_benchmark = NVFBenchmark(benchmark)
     outputs = nvf_benchmark.pedantic(
-        benchmark_fn, setup=setup, rounds=rounds, warmup_rounds=warmup_rounds
+        benchmark_fn,
+        setup=setup,
+        rounds=BENCHMARK_CONFIG["rounds"],
+        warmup_rounds=BENCHMARK_CONFIG["warmup_rounds"],
     )
     nvf_benchmark.set_metrics(inputs, outputs, iobytes)
     nvf_benchmark.cleanup()

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -309,8 +309,6 @@ def run_benchmark(
         outputs: Output of the target function
     """
 
-    # These variables are updated based on CLI options
-
     def setup():
         clear_l2_cache()
         return [inputs], {}


### PR DESCRIPTION
1. Adds CLI options for controlling number of `warmup_rounds/rounds`: This will be useful when we run python benchmarks on the Github CI to control the total time required to run the benchmark suite.
2. Updates how complete test names are printed to allow for better filtering: Closes Issue #1693. The new format of test names is:
`test_name[argname=value]`. 
For example: `test_transpose_nvf_benchmark[axes=[0_1]-dtype=torch.float32-size=[2_2_16]]`. 
The tuple values are `_` joined to allow filtering.