### PR TITLE
Check expected smem size before device limit

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1669,17 +1669,6 @@ int64_t FusionExecutor::getStaticSmemSize() {
 }
 
 void FusionExecutor::validateDynamicSmemSize(int64_t dynamic_smem_size) {
-  NVF_ERROR(
-      getStaticSmemSize() + dynamic_smem_size < device_smem_limit_,
-      "The total shared memory allocation is larger than available memory.",
-      " Dynamic size: ",
-      dynamic_smem_size,
-      ". Static size: ",
-      getStaticSmemSize(),
-      ". Required total size: ",
-      getStaticSmemSize() + dynamic_smem_size,
-      ". Device limit size: ",
-      device_smem_limit_);
   // If specified, check that dynamic smem size matches what the scheduler
   // expects
   int64_t expected_dynamic_smem_size = fusion_->expectedDynamicSmemBytes();
@@ -1691,6 +1680,17 @@ void FusionExecutor::validateDynamicSmemSize(int64_t dynamic_smem_size) {
         " does not match expected size ",
         expected_dynamic_smem_size);
   }
+  NVF_ERROR(
+      getStaticSmemSize() + dynamic_smem_size < device_smem_limit_,
+      "The total shared memory allocation is larger than available memory.",
+      " Dynamic size: ",
+      dynamic_smem_size,
+      ". Static size: ",
+      getStaticSmemSize(),
+      ". Required total size: ",
+      getStaticSmemSize() + dynamic_smem_size,
+      ". Device limit size: ",
+      device_smem_limit_);
 }
 
 int64_t FusionExecutor::ensureAvailableDynamicSmemSize(


### PR DESCRIPTION
This just checks that our smem usage matches the expected amount that was optionally set during scheduling before checking that it falls within device limits. This helps debugging in some cases since it can tell us that we are overrunning our smem because of misestimation or because of a heuristic decision that misused a correct estimate. This was helpful in discovering #2111.