### PR TITLE
Add sanitize link option to final object, too.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,12 +294,13 @@ target_link_libraries(codegen_internal PUBLIC
   dl
 )
 
+add_library(nvfuser_codegen SHARED $<TARGET_OBJECTS:codegen_internal>)
 if(NVFUSER_BUILD_WITH_ASAN)
   target_compile_options(codegen_internal PRIVATE -fsanitize=address)
   target_link_options(codegen_internal PRIVATE -fsanitize=address)
+  target_link_options(nvfuser_codegen PRIVATE -fsanitize=address)
 endif()
 
-add_library(nvfuser_codegen SHARED $<TARGET_OBJECTS:codegen_internal>)
 target_include_directories(nvfuser_codegen PUBLIC
   "$<BUILD_INTERFACE:${NVFUSER_SRCS_DIR}>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/nvfuser>"


### PR DESCRIPTION
CMake does not forward private flags.