### PR TITLE
Fixed torch profiler API changes in python benchmarks

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -237,7 +237,8 @@ class NVFBenchmark:
         elapsed_cuda_time = (
             sum(
                 [
-                    event.self_device_time_total
+                    # Re: torch profiler API changes in https://github.com/pytorch/pytorch/pull/123247
+                    (event.self_device_time_total if hasattr(event, 'self_device_time_total') else event.self_cuda_time_total)
                     for event in prof_averages
                     if event.device_type == DeviceType.CUDA
                 ]

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -237,7 +237,7 @@ class NVFBenchmark:
         elapsed_cuda_time = (
             sum(
                 [
-                    event.self_cuda_time_total
+                    event.self_device_time_total
                     for event in prof_averages
                     if event.device_type == DeviceType.CUDA
                 ]

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -238,7 +238,11 @@ class NVFBenchmark:
             sum(
                 [
                     # Re: torch profiler API changes in https://github.com/pytorch/pytorch/pull/123247
-                    (event.self_device_time_total if hasattr(event, 'self_device_time_total') else event.self_cuda_time_total)
+                    (
+                        event.self_device_time_total
+                        if hasattr(event, "self_device_time_total")
+                        else event.self_cuda_time_total
+                    )
                     for event in prof_averages
                     if event.device_type == DeviceType.CUDA
                 ]


### PR DESCRIPTION
Re: https://github.com/pytorch/pytorch/pull/123247

This PR changed `self_cuda_time_total` to `self_device_time_total` in API calls.