### PR TITLE
[matmul] Merge batch dims with BIDx tile dim

### DIFF
--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -923,11 +923,11 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       mma_result->nDims() == 3 || mma_result->nDims() == 4,
       "Currently, we only support B, M, N and K being a single dimension.",
       " More general tensor contraction is not supported yet.");
-  const int64_t num_batch_dims = mma_result->nDims() - 3;
+  int64_t num_batch_dims = mma_result->nDims() - 3;
 
   // [... M,N,K]
   mma_utils::makeTile(mma_result, gemm_tile.cta_tile.toVector());
-  // [..., Mo, No, Ko, Mi, Ni, Ki]
+  // [BMo, No, Ko, Mi, Ni, Ki]
 
   // Unswizzle mma result in shared memory
   // Note that if we are using split-K, we will set up this buffer after
@@ -956,13 +956,24 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
     }
   }
 
-  // [..., iMo, iNo, rKo, iMi, iNi, rKi]
+  // Combine all batch dims with Mo or No. Depending on cta_order, either Mo or
+  // No will be parallelized BIDx. We combine batch dimensions so that they are
+  // included in BIDx.
+  int64_t bidx_dim =
+      params.cta_order == MatmulParams::TileRasterizationOrder::RowMajor ? -6
+                                                                         : -5;
+  while (mma_result->nDims() > 6) {
+    mma_result->merge(-7, bidx_dim);
+  }
+  num_batch_dims = 0;
+
+  // [iBMo, iNo, rKo, iMi, iNi, rKi]
   int num_splitk_dims = 0;
   TensorView* splitk_sum = nullptr;
   if (params.splitk_factor != 1) {
     // Split Ko -> [rKf, rKg]
     mma_result->split(-4, params.splitk_factor, /*inner*/ false);
-    // After split [..., iMo, iNo, rKf, rKg, iMi, iNi, rKi]
+    // After split [iBMo, iNo, rKf, rKg, iMi, iNi, rKi]
     // rFactor converts
     //   mma_result = mma(A, B, {/*Kf*/-5, /*Kg*/-4, /*Ki*/-1});
     // to
@@ -978,10 +989,10 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
 
   // At this point we have the following schedule:
   //   No split-K
-  //     mma_result      [..., iMo, iNo, rKo, iMi, iNi, rKi]
+  //     mma_result      [iBMo, iNo, rKo, iMi, iNi, rKi]
   //   Split-K
-  //     mma_result      [..., iMo, iNo, iKf, rKg, iMi, iNi, rKi]
-  //     splitk_sum      [..., iMo, iNo, rKf, iMi, iNi]
+  //     mma_result      [iBMo, iNo, iKf, rKg, iMi, iNi, rKi]
+  //     splitk_sum      [iBMo, iNo, rKf, iMi, iNi]
 
   if (params.use_smem_epilogue) {
     // Note that for split-K
@@ -990,7 +1001,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
     //   smem_epilogue = set(mma_result)
     //   splitk_sum = sum(smem_epilogue)
     smem_epilogue = mma_result->cacheAfter();
-    // smem_epilogue = [..., iMo, iNo, iKf, iMi, iNi]
+    // smem_epilogue = [iBMo, iNo, iKf, iMi, iNi]
   }
 
   // Propagate tiling globally
@@ -1023,7 +1034,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       mma_result, -1, {acw_smem, bcw_smem}, {smem_epilogue});
 
   // No (cross-CTA) split-K
-  //   mma_result      [..., iMo iNo rKo rKwo iMwo iNwo iMw iNw iMin iNin rKin]
+  //   mma_result      [iBMo iNo rKo rKwo iMwo iNwo iMw iNw iMin iNin rKin]
   //   smem_epilogue   (unscheduled, same as original or current mma_result)
   //   splitk_sum      (nullptr)
   //
@@ -1125,10 +1136,10 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   //
   // With split-K:
   //   mma_result
-  //     nbatch +   1    2    3    4    5    6   7   8
-  //              -15  -14  -13  -12  -11  -10  -9  -8
-  //     [... iMo iNo (iKf) rKg rKwo iMwo iNwo iMw iNw     ...
-  //          iBx iBy  iBz   rS   rS  iTz  iTy  iS  iS
+  //         0   1    2    3    4    5    6   7   8
+  //       -16 -15  -14  -13  -12  -11  -10  -9  -8
+  //     [iBMo iNo (iKf) rKg rKwo iMwo iNwo iMw iNw     ...
+  //       iBx iBy  iBz   rS   rS  iTz  iTy  iS  iS
   //                              9    10    11    12    13    14    15
   //                             -7    -6    -5    -4    -3    -2    -1
   //                    ...   iMino iNino iMin2 iNin2 rKino rKin4 rKin2]
@@ -1138,10 +1149,10 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   //
   // Without split-K:
   //   mma_result
-  //     nbatch +   1   2    3    4    5   6   7    8
-  //              -14 -13  -12  -11  -10  -9  -8   -7
-  //     [... iMo iNo rKg rKwo iMwo iNwo iMw iNw iMino
-  //    (iBz) iBx iBy  rS   rS  iTz  iTy  iS  iS  iTx
+  //         0   1   2    3    4    5   6   7     8
+  //       -15 -14 -13  -12  -11  -10  -9  -8    -7
+  //     [iBMo iNo rKg rKwo iMwo iNwo iMw iNw iMino
+  //       iBx iBy  rS   rS  iTz  iTy  iS  iS   iTx
   //                                   9    10    11     12    13    14
   //                                  -6    -5    -4     -3    -2    -1
   //                               iNino iMin2 iNin2  rKino rKin4 rKin2]
@@ -1154,8 +1165,6 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   // If we only have batch dim, parallelize the batch dim.
   if (num_splitk_dims != 0) {
     mma_result->axis(num_batch_dims + 2)->parallelize(ParallelType::BIDz);
-  } else if (num_batch_dims != 0) {
-    mma_result->axis(0)->parallelize(ParallelType::BIDz);
   }
   switch (params.cta_order) {
     case MatmulParams::TileRasterizationOrder::RowMajor:


### PR DESCRIPTION
Previously, we parallelized batch dimension as BIDz except when split-K was enabled in which case we looped over the batch dim.That is suboptimal for split-K, see #1726 and #1899. This PR removes those loops in all matmul kernels.

Instead of looping over batch dimensions, this PR merges batch dims with either the Mo or No dimensions (the outer tile dimensions), depending on cta order. We choose the dim to merge with that is parallelized as BIDx, so that we can support larger batch dims (BIDx is limited to 2^31-1 while other dims are limited to 2^16-1).

Note that this changes the CTA order for non-splitK bmms, which were previously parallelized BIDz and are now an outer dim merged into BIDx (i.e. inserted between BIDx and BIDy). If that's not ideal we could potentially merge Mo and No and parallelize those as BIDx, then leave BIDy and BIDz for split-K and batch dim, respectively.

Fixes #1726. Fixes #1899 