### PR TITLE
Add white background to all SVGs

### DIFF
--- a/doc/dev/tma/arbitrary-view.svg
+++ b/doc/dev/tma/arbitrary-view.svg
@@ -10,6 +10,7 @@
 <svg
    width="541mm"
    height="177mm"
+   style="background-color:white"
    viewBox="0 0 541 177"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/box-and-tile.svg
+++ b/doc/dev/tma/box-and-tile.svg
@@ -10,6 +10,7 @@
 <svg
    width="238mm"
    height="42mm"
+   style="background-color:white"
    viewBox="0 0 238 42"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/box-by-compositing.svg
+++ b/doc/dev/tma/box-by-compositing.svg
@@ -10,6 +10,7 @@
 <svg
    width="205mm"
    height="115mm"
+   style="background-color:white"
    viewBox="0 0 205 115"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/box-by-partitioning-and-compositing.svg
+++ b/doc/dev/tma/box-by-partitioning-and-compositing.svg
@@ -10,6 +10,7 @@
 <svg
    width="109mm"
    height="41mm"
+   style="background-color:white"
    viewBox="0 0 109 41"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/box-by-partitioning.svg
+++ b/doc/dev/tma/box-by-partitioning.svg
@@ -10,6 +10,7 @@
 <svg
    width="169mm"
    height="53mm"
+   style="background-color:white"
    viewBox="0 0 169 53"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/consumer-schedule.svg
+++ b/doc/dev/tma/consumer-schedule.svg
@@ -10,6 +10,7 @@
 <svg
    width="179.8mm"
    height="96.5mm"
+   style="background-color:white"
    viewBox="0 0 179.8 96.5"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/dense-and-strided-tile.svg
+++ b/doc/dev/tma/dense-and-strided-tile.svg
@@ -10,6 +10,7 @@
 <svg
    width="212mm"
    height="137mm"
+   style="background-color:white"
    viewBox="0 0 212 137"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/invalid-smem-discontiguous.svg
+++ b/doc/dev/tma/invalid-smem-discontiguous.svg
@@ -10,6 +10,7 @@
 <svg
    width="556mm"
    height="120mm"
+   style="background-color:white"
    viewBox="0 0 556 120"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/matmul-tma-domain.svg
+++ b/doc/dev/tma/matmul-tma-domain.svg
@@ -10,6 +10,7 @@
 <svg
    width="259mm"
    height="116mm"
+   style="background-color:white"
    viewBox="0 0 259 116"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/strided-tile.svg
+++ b/doc/dev/tma/strided-tile.svg
@@ -10,6 +10,7 @@
 <svg
    width="153mm"
    height="82mm"
+   style="background-color:white"
    viewBox="0 0 153 82"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/swizzle-schedule.svg
+++ b/doc/dev/tma/swizzle-schedule.svg
@@ -10,6 +10,7 @@
 <svg
    width="169mm"
    height="144mm"
+   style="background-color:white"
    viewBox="0 0 169 144"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/swizzle.svg
+++ b/doc/dev/tma/swizzle.svg
@@ -10,6 +10,7 @@
 <svg
    width="545mm"
    height="220mm"
+   style="background-color:white"
    viewBox="0 0 545 220"
    version="1.1"
    id="svg1"

--- a/doc/dev/tma/valid-smem-contig.svg
+++ b/doc/dev/tma/valid-smem-contig.svg
@@ -10,6 +10,7 @@
 <svg
    width="557mm"
    height="120mm"
+   style="background-color:white"
    viewBox="0 0 557 120"
    version="1.1"
    id="svg1"

--- a/doc/reading/divisibility-of-split/allocate-6-as-2,4.svg
+++ b/doc/reading/divisibility-of-split/allocate-6-as-2,4.svg
@@ -10,6 +10,7 @@
 <svg
    width="169mm"
    height="30mm"
+   style="background-color:white"
    viewBox="0 0 169 30"
    version="1.1"
    id="svg1"

--- a/doc/reading/divisibility-of-split/merge-split.svg
+++ b/doc/reading/divisibility-of-split/merge-split.svg
@@ -10,6 +10,7 @@
 <svg
    width="94mm"
    height="58mm"
+   style="background-color:white"
    viewBox="0 0 94 58"
    version="1.1"
    id="svg1"

--- a/doc/reading/divisibility-of-split/three-indivisible-splits.svg
+++ b/doc/reading/divisibility-of-split/three-indivisible-splits.svg
@@ -10,6 +10,7 @@
 <svg
    width="100mm"
    height="72mm"
+   style="background-color:white"
    viewBox="0 0 100 72"
    version="1.1"
    id="svg1"

--- a/doc/reading/tma-modeling-in-depth/no-strong-correctness-data.svg
+++ b/doc/reading/tma-modeling-in-depth/no-strong-correctness-data.svg
@@ -10,6 +10,7 @@
 <svg
    width="199mm"
    height="65mm"
+   style="background-color:white"
    viewBox="0 0 199 65"
    version="1.1"
    id="svg1"

--- a/doc/reading/tma-modeling-in-depth/no-strong-correctness-schedule.svg
+++ b/doc/reading/tma-modeling-in-depth/no-strong-correctness-schedule.svg
@@ -10,6 +10,7 @@
 <svg
    width="155mm"
    height="81mm"
+   style="background-color:white"
    viewBox="0 0 155 81"
    version="1.1"
    id="svg1"

--- a/doc/reading/tma-modeling-in-depth/strong-correctness-2.svg
+++ b/doc/reading/tma-modeling-in-depth/strong-correctness-2.svg
@@ -10,6 +10,7 @@
 <svg
    width="251mm"
    height="146mm"
+   style="background-color:white"
    viewBox="0 0 251 146"
    version="1.1"
    id="svg1"

--- a/doc/reading/tma-modeling-in-depth/strong-correctness.svg
+++ b/doc/reading/tma-modeling-in-depth/strong-correctness.svg
@@ -10,6 +10,7 @@
 <svg
    width="241mm"
    height="114mm"
+   style="background-color:white"
    viewBox="0 0 241 114"
    version="1.1"
    id="svg1"

--- a/doc/reading/tma-modeling-in-depth/weak-correctness-holes-nonzero.svg
+++ b/doc/reading/tma-modeling-in-depth/weak-correctness-holes-nonzero.svg
@@ -10,6 +10,7 @@
 <svg
    width="199mm"
    height="111mm"
+   style="background-color:white"
    viewBox="0 0 199 111"
    version="1.1"
    id="svg1"


### PR DESCRIPTION
So that it is no longer transparent. This is not the best for dark mode, but at least readable because previously, we will just have black lines and texts in a black background.