### PR TITLE
Remove FusionExecutor::isExprEval.

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1772,7 +1772,7 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     inputBytesProcessed(args);
   }
 
-  if (isExprEval()) {
+  if (!hasCompiledKernel()) {
     outputs = evaluateFusionOutputs(args, outputs, expr_eval);
     if (measure_kernel_time) {
       outputBytesProcessed(outputs);
@@ -1780,7 +1780,6 @@ std::vector<at::Tensor> FusionExecutor::runFusion(
     return outputs;
   }
 
-  NVF_ERROR(hasCompiledKernel());
   NVF_ERROR(validKernelId(), "Invalid kernel id for FusionExecutor.");
   NVF_ERROR(
       !args.getCacheId().has_value() || outputs.empty(),
@@ -2184,7 +2183,7 @@ flatbuffers::Offset<serde::FusionExecutor> FusionExecutor::serialize(
 
   // When compilation is skipped, avoid serializing cubin because it doesn't
   // exist. The remaining fields are also not necessary in this case.
-  if (isExprEval()) {
+  if (!hasCompiledKernel()) {
     return serde::CreateFusionExecutorDirect(builder);
   }
 

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -421,14 +421,6 @@ class FusionExecutor : public NonCopyable {
       int64_t runtime_id,
       int64_t group_id);
 
-  //! Check if compilation was skipped (fusion segment marked for EE).
-  bool isExprEval() const {
-    NVF_ERROR(
-        fusion_ == nullptr || !lowered_,
-        "Expected GPU lowering to be skipped.");
-    return fusion_ != nullptr;
-  }
-
  private:
   LaunchParams computeLaunchParams(
       const LaunchParams& launch_constraints,

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -61,7 +61,7 @@ TEST_F(MatmulATenEvaluationTest, MmaOpAndCast) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isExprEval());
+  EXPECT_FALSE(executors.front().hasCompiledKernel());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -97,7 +97,7 @@ TEST_F(MatmulATenEvaluationTest, TransposeMmaOpAndCast) {
       fec.getMostRecentKernelRuntime()->executors();
   ASSERT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isExprEval());
+  EXPECT_FALSE(executors.front().hasCompiledKernel());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -131,7 +131,7 @@ TEST_F(MatmulATenEvaluationTest, MulSumAndCast) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isExprEval());
+  EXPECT_FALSE(executors.front().hasCompiledKernel());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -171,7 +171,7 @@ TEST_F(MatmulATenEvaluationTest, MatmulWithBias) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isExprEval());
+  EXPECT_FALSE(executors.front().hasCompiledKernel());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -220,7 +220,7 @@ TEST_F(MatmulATenEvaluationTest, MatmulBiasAlphaBeta) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isExprEval());
+  EXPECT_FALSE(executors.front().hasCompiledKernel());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -269,7 +269,7 @@ TEST_F(MatmulATenEvaluationTest, MatmulBiasBeta) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isExprEval());
+  EXPECT_FALSE(executors.front().hasCompiledKernel());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -315,7 +315,7 @@ TEST_F(MatmulATenEvaluationTest, MatmulBiasAlpha) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isExprEval());
+  EXPECT_FALSE(executors.front().hasCompiledKernel());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -350,7 +350,7 @@ TEST_F(MatmulATenEvaluationTest, Linear) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isExprEval());
+  EXPECT_FALSE(executors.front().hasCompiledKernel());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
@@ -389,7 +389,7 @@ TEST_F(MatmulATenEvaluationTest, LinearWithBias) {
       fec.getMostRecentKernelRuntime()->executors();
   EXPECT_EQ(executors.size(), 1);
   // Verify that fusion compilation was skipped.
-  EXPECT_TRUE(executors.front().isExprEval());
+  EXPECT_FALSE(executors.front().hasCompiledKernel());
 
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }


### PR DESCRIPTION
It seems to be unnecessary given `hasCompiledKernel`. Wdyt? 