### PR TITLE
Globally enable IdModel

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -381,19 +381,16 @@ void GpuLower::analysis(Fusion* fusion) {
   replaceSymbolicSizes(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "replaceSymbolicSizes");
 
-  // Build what's refered to as the compute at map. This map contains the
-  // mappings of all iteration domains across the fusion. There are three types
-  // of mappings Permissive, Exact, and Loop, see compute_at_map.h/cpp for more
-  // information.
+  // Build what's refered to as the IterDomain Model. This data structure
+  // contains the mappings of all iteration domains across the fusion, and their
+  // graph structure. There are multiple types of mappings: Permissive, Exact,
+  // Loop, etc. See the id_model directory for more information.
+  id_model_ = std::make_unique<IdModel>(
+      fusion_, isOptionEnabled(EnableOption::ValidateIdModel));
+  // Also build the legacy compute at map.
+  // TODO: to save compilation time, should we refactor ComputeAtMap to make a
+  // thin wrapper of IdModel?
   compute_at_map_ = std::make_shared<ComputeAtMap>(fusion_);
-
-  // Transitory testing of IdModel if enabled. No existing
-  // functionality should be affected. New IterDomains may be created,
-  // so it is expected that generated code may use diffrent variable
-  // names
-  if (isOptionEnabled(EnableOption::IdModel)) {
-    IdModel id_model(fusion_);
-  }
 
   resolveComputeWith(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "resolveComputeWith");

--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -110,6 +110,10 @@ class GpuLower : public NonCopyable {
     return std::const_pointer_cast<const ComputeAtMap>(compute_at_map_);
   }
 
+  const IdModel& idModel() const {
+    return *id_model_
+  }
+
   std::shared_ptr<const HaloInfo> haloInfo() const {
     return std::const_pointer_cast<const HaloInfo>(halo_info_);
   }
@@ -294,6 +298,7 @@ class GpuLower : public NonCopyable {
   ThreadPredicateMap thread_pred_map_;
   std::unique_ptr<PredicateElimination> pred_elimination_;
   std::shared_ptr<ComputeAtMap> compute_at_map_;
+  std::unique_ptr<IdModel> id_model_;
   std::shared_ptr<HaloInfo> halo_info_;
   LocalAllocationInfoMap local_allocation_info_map_;
   WarpPaddedParallelInfo warp_pad_info_;

--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -111,7 +111,9 @@ class GpuLower : public NonCopyable {
     return std::const_pointer_cast<const ComputeAtMap>(compute_at_map_);
   }
 
-  const IdModel& idModel() const {return *id_model_}
+  const IdModel& idModel() const {
+    return *id_model_;
+  }
 
   std::shared_ptr<const HaloInfo> haloInfo() const {
     return std::const_pointer_cast<const HaloInfo>(halo_info_);

--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -24,6 +24,7 @@
 #include <exceptions.h>
 #include <executor_params.h>
 #include <expr_simplifier.h>
+#include <id_model/id_model.h>
 #include <ir/all_nodes.h>
 #include <kernel.h>
 #include <kernel_ir.h>
@@ -110,9 +111,7 @@ class GpuLower : public NonCopyable {
     return std::const_pointer_cast<const ComputeAtMap>(compute_at_map_);
   }
 
-  const IdModel& idModel() const {
-    return *id_model_
-  }
+  const IdModel& idModel() const {return *id_model_}
 
   std::shared_ptr<const HaloInfo> haloInfo() const {
     return std::const_pointer_cast<const HaloInfo>(halo_info_);

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -99,9 +99,9 @@ IdModel::IdModel(
 
 IdModel::IdModel(
     Fusion* fusion,
+    bool validate,
     bool build_graphs,
-    bool allow_self_mapping,
-    bool validate)
+    bool allow_self_mapping)
     : allow_self_mapping_(allow_self_mapping), validate_(validate) {
   auto all_exprs = fusion->exprs();
   std::copy_if(

--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -104,9 +104,9 @@ class IdModel : public PolymorphicBase {
   // transition from the current ComputeAtMap.
   IdModel(
       Fusion* fusion,
+      bool validate = false,
       bool build_graphs = true,
-      bool allow_self_mapping = false,
-      bool validate = true);
+      bool allow_self_mapping = false);
 
   // Returns iter domain graph of provided mode. The graph must have
   // been already built.

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -154,7 +154,7 @@ template <>
 std::unordered_map<EnableOption, std::vector<std::string>> Options<
     EnableOption>::getOptionsFromEnv() {
   const std::unordered_map<std::string, EnableOption> available_options = {
-      {"id_model", EnableOption::IdModel},
+      {"validate_id_model", EnableOption::ValidateIdModel},
       {"kernel_db", EnableOption::KernelDb},
       {"kernel_profile", EnableOption::KernelProfile},
       {"memory_promotion", EnableOption::MemoryPromotion},

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -91,7 +91,7 @@ enum class DebugDumpOption {
 //! These can be set through the `NVFUSER_ENABLE` environment variable
 //!
 enum class EnableOption {
-  IdModel, //! Enable IdModel
+  ValidateIdModel, //! Enable validation on IdModel
   KernelDb, //! Enable Kernel Database
   KernelProfile, //! Enable intra-kernel performance profiling
   MemoryPromotion, //! Enable promotion of memory types for non-pointwise ops

--- a/csrc/preseg_passes/move_split_cat.cpp
+++ b/csrc/preseg_passes/move_split_cat.cpp
@@ -28,6 +28,7 @@ class CancelSplitCat {
       : fusion_(fusion),
         id_model_(
             fusion,
+            /*validate=*/false,
             /*build_graphs=*/false,
             /*allow_self_mapping=*/true) {
     id_model_.buildExactGraph();

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -220,7 +220,8 @@ void validateIELResolution(
     auto promotion_id = iel_promotion_map_it->second;
     ASSERT_TRUE(
         exact_graph.disjointValSets().strictAreMapped(promotion_id, ref_id))
-        << "Unexpected promotion. " << "Expected: " << ref_id->toString()
+        << "Unexpected promotion. "
+        << "Expected: " << ref_id->toString()
         << ". Actual: " << promotion_id->toString();
     ASSERT_TRUE(loop_graph.disjointValSets().strictAreMapped(id, promotion_id))
         << "Promotion of " << id->toString()
@@ -358,9 +359,9 @@ void checkStep4Results(
   const auto& iel_promotion_map = tester.s4_iel_promotion_map;
 
   EXPECT_EQ(iel_promotion_map.size(), ref_promotion_map.size())
-      << "Mismatched Step-4 result map. " << "Expected to have "
-      << ref_promotion_map.size() << " mappings but found "
-      << iel_promotion_map.size();
+      << "Mismatched Step-4 result map. "
+      << "Expected to have " << ref_promotion_map.size()
+      << " mappings but found " << iel_promotion_map.size();
 
   for (const auto& ref_promotion_pair : ref_promotion_map) {
     const auto& ref_promotion_group = ref_promotion_pair.first;

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -121,7 +121,8 @@ IterDomain* getChildIdByName(IterDomain* id, StmtNameType name) {
 class IdModelTester : public IdModel {
  public:
   // Do not automatically build the graphs
-  IdModelTester(Fusion* fusion) : IdModel(fusion, /*build_graphs=*/false) {
+  IdModelTester(Fusion* fusion)
+      : IdModel(fusion, /*validation=*/true, /*build_graphs=*/false) {
     // Make sure the depedent graphs are already built
     maybeBuildGraph(IdMappingMode::EXACT);
     maybeBuildGraph(IdMappingMode::PERMISSIVE);
@@ -213,8 +214,7 @@ void validateIELResolution(
     auto promotion_id = iel_promotion_map_it->second;
     ASSERT_TRUE(
         exact_graph.disjointValSets().strictAreMapped(promotion_id, ref_id))
-        << "Unexpected promotion. "
-        << "Expected: " << ref_id->toString()
+        << "Unexpected promotion. " << "Expected: " << ref_id->toString()
         << ". Actual: " << promotion_id->toString();
     ASSERT_TRUE(loop_graph.disjointValSets().strictAreMapped(id, promotion_id))
         << "Promotion of " << id->toString()
@@ -352,9 +352,9 @@ void checkStep4Results(
   const auto& iel_promotion_map = tester.s4_iel_promotion_map;
 
   EXPECT_EQ(iel_promotion_map.size(), ref_promotion_map.size())
-      << "Mismatched Step-4 result map. "
-      << "Expected to have " << ref_promotion_map.size()
-      << " mappings but found " << iel_promotion_map.size();
+      << "Mismatched Step-4 result map. " << "Expected to have "
+      << ref_promotion_map.size() << " mappings but found "
+      << iel_promotion_map.size();
 
   for (const auto& ref_promotion_pair : ref_promotion_map) {
     const auto& ref_promotion_group = ref_promotion_pair.first;


### PR DESCRIPTION
Per the title.

## Why?

I am looking at refactoring the indexing of TMA into two parts: one part that does the analysis to get TMA domain, tile IterDomain, etc., and another part that uses the result of part 1 to do indexing. This split allows us to do more advanced lowering, for example, implementing the strategy described at [TMA Modeling In Depth](https://github.com/NVIDIA/Fuser/blob/main/doc/reading/tma-modeling-in-depth.md).

When I am working on this refactor, I realize that I need to replay the producer as consumer for TMA load, so that I can propagate from gmem's allocation domain to consumer's TMA domain. `BestEffortReplay` could do the job of course, but considering the current status of `IdModel`, I believe it's better to just not use `BestEffortReplay` and base this on `IdModel`.

## Impact

This will increase compilation time for all fusions, I did not measure how much. But considering that we have to do this step to enable incremental development, I believe this PR would be fine.

Measured a single test:

Before:
```
[       OK ] GPUTTensorCoreTest.FusionAmpereMatmul_CUDA (3916 ms)
```

After:
```
[       OK ] GPUTTensorCoreTest.FusionAmpereMatmul_CUDA (3998 ms)
```

About 2% slow down.