### PR TITLE
Replace NVF_ERROR with EXPECT_TRUE.

### DIFF
--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -48,14 +48,10 @@ void CommunicationTest::SetUp() {
 }
 
 void CommunicationTest::validate(at::Tensor obtained, at::Tensor expected) {
-  NVF_ERROR(
-      obtained.equal(expected),
-      "Device ",
-      communicator->deviceId(),
-      " expected tensor:\n",
-      expected,
-      "\nbut obtained tensor:\n",
-      obtained);
+  EXPECT_TRUE(obtained.equal(expected))
+      << "Device " << communicator->deviceId() << " expected tensor:\n"
+      << expected << "\nbut obtained tensor:\n"
+      << obtained;
 }
 
 void CommunicationTest::resetDstBuffers() {


### PR DESCRIPTION
When the check fails, the latter fails gracefully and doesn't stop other tests from running.