### PR TITLE
Make Communications IRs inheriting from Expr.

### DIFF
--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -106,7 +106,8 @@ class Val;
   f(Merge);                       \
   f(Swizzle);                     \
   f(Swizzle2D);                   \
-  f(Resize);
+  f(Resize);                      \
+  f(Communication);
 #define DISPATCH_FOR_ALL_KIR_EXPRS(f) \
   f(Allocate);                        \
   f(Asm);                             \

--- a/csrc/ir/all_nodes.h
+++ b/csrc/ir/all_nodes.h
@@ -11,3 +11,4 @@
 #include <ir/interface_nodes.h>
 #include <ir/internal_nodes.h>
 #include <kernel_ir.h>
+#include <multidevice/communication.h>

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -490,7 +490,7 @@ using newObjectFuncType = Expr*(
 //!      - Constructors need to register with the Fusion after inputs/outputs
 //!         are defined
 //!      - Implementation of bool sameAs(...)
-//!  2) dispatch.h/.cpp must be updated to include dispatch of the new Val
+//!  2) dispatch.h/.cpp must be updated to include dispatch of the new Expr
 //!  3) Default mutator function should be added to mutator.h/.cpp
 //!  4) Printing functions should be added to ir/iostream.h/.cpp
 //!  5) Lower case convenience functions should be added to arith.h/.cpp (If

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -168,7 +168,7 @@ inline void assertValid(
 // pytorch's process group expects the root to be specified
 // as an integer between 0 and world_size-1. We choose it to be
 // the device's relative index within the team
-DeviceIdxType getRootRelativeIndex(const CommParams& params) {
+int64_t getRootRelativeIndex(const CommParams& params) {
   auto it = std::find(params.team.begin(), params.team.end(), params.root);
   return std::distance(params.team.begin(), it);
 }

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -155,7 +155,7 @@ std::string Communication::toString(const int indent_size) const {
                           << std::endl;
 
   if (hasRoot(params_.type)) {
-    indent(ss, indent_size + 1) << "root: " << params_.root << ",\n";
+    indent(ss, indent_size + 1) << "root: " << params_.root << "," << std::endl;
   }
   indent(ss, indent_size + 1) << "team: " << params_.team << "," << std::endl;
   indent(ss, indent_size) << "}";

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -28,6 +28,8 @@ enum class CommunicationType {
   SendRecv
 };
 
+std::ostream& operator<<(std::ostream& os, const CommunicationType& type);
+
 /*
   This struct gathers all the parameters necessary for the
   construction a communication
@@ -137,7 +139,7 @@ case of a local copy)
 buffer
 */
 
-class NVF_API Communication : public Expr {
+class Communication : public Expr {
  public:
   using Expr::Expr;
   Communication(IrBuilderPasskey passkey, CommParams params);
@@ -169,7 +171,7 @@ class NVF_API Communication : public Expr {
 
 // Triggers the execution of the communication. This is a non-blocking call.
 // The communication can be posted multiple times
-c10::intrusive_ptr<c10d::Work> postCommunication(
+c10::intrusive_ptr<c10d::Work> postSingleCommunication(
     Communication* communication,
     DeviceIdxType my_device_index,
     c10::intrusive_ptr<c10d::Backend> backend);

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -7,6 +7,8 @@
 // clang-format on
 #pragma once
 
+#include <ir/base_nodes.h>
+#include <ir/builder.h>
 #include <multidevice/communicator.h>
 #include <multidevice/multidevice.h>
 #include <torch/csrc/distributed/c10d/Types.hpp>
@@ -15,11 +17,23 @@
 
 namespace nvfuser {
 
+enum class CommunicationType {
+  Gather,
+  Allgather,
+  Scatter,
+  Reduce,
+  Allreduce,
+  ReduceScatter,
+  Broadcast,
+  SendRecv
+};
+
 /*
   This struct gathers all the parameters necessary for the
   construction a communication
 */
 struct CommParams {
+  CommunicationType type;
   DeviceIdxType root = -1;
   std::vector<at::Tensor> src_bufs;
   std::vector<at::Tensor> dst_bufs;
@@ -50,160 +64,64 @@ otherwise an error is thrown.
 
 NOTE: pytorch's NCCL process group API needs <team_size> buffers on root for
 scatter/gather operation.
-*/
 
-class Communication {
- public:
-  virtual ~Communication() = default;
-
-  std::string toString(int indent = 0) const;
-
-  const auto& params() const {
-    return params_;
-  }
-
-  // Triggers the execution of the communication. This is a non-blocking call.
-  // The communication can be posted multiple times
-  virtual c10::intrusive_ptr<c10d::Work> post(
-      Communicator& comm,
-      std::optional<CommunicatorBackend> backend = std::nullopt) = 0;
-
- protected:
-  // argument "name" is only used for printing
-  // argument "has_root" indicates if the communication is rooted
-  Communication(CommParams params, std::string name, bool has_root = true);
-
-  // store the arguments of the communication
-  CommParams params_;
-  // stores the relative index of the root in the team
-  DeviceIdxType root_relative_index_ = -1;
-
- private:
-  // used for printing
-  std::string collective_type_;
-  // indicates if the communication is rooted
-  bool has_root_ = true;
-};
-
-/*
+(*) Broadcast
 Copies the root's src buffer to each device's dst buffer
-
 Requirements:
   - the root is set and belongs to the team
   - the root has one src buffer, and no or one dst buffer
   - non-roots have no src buffer and one dst buffer
   - all buffers have the same size
-*/
-class Broadcast : public Communication {
- public:
-  Broadcast(CommParams params);
-  c10::intrusive_ptr<c10d::Work> post(
-      Communicator& comm,
-      std::optional<CommunicatorBackend> backend = std::nullopt) override;
-};
 
-/*
+
+(*) Gather
 Copies each device's source buffer to the root's respective src
 buffer. The order of the sender devices matches the order of the
 root's buffers.
-
 Requirements:
   - the root is set and belongs to the team
   - the root has one src buffer and <team_size> dst buffers
   - non-roots have one src buffer and no dst buffer
   - all buffers have the same size
-*/
-class Gather : public Communication {
- public:
-  Gather(CommParams params);
-  c10::intrusive_ptr<c10d::Work> post(
-      Communicator& comm,
-      std::optional<CommunicatorBackend> backend = std::nullopt) override;
-};
 
-/*
+(*) Allgather
 Copies each device's src buffer to each device's respective src
 buffer. The order of the devices matches the order of the
 buffers
-
 Requirements:
   - all device have one src buffer and <team_size> dst buffers
   - all buffers have the same size
-*/
-class Allgather : public Communication {
- public:
-  Allgather(CommParams params);
-  c10::intrusive_ptr<c10d::Work> post(
-      Communicator& comm,
-      std::optional<CommunicatorBackend> backend = std::nullopt) override;
-};
 
-/*
+(*) Scatter
 Copies each root's src buffer to each device's dst buffer.
 The order of the buffers matches the order of the receiver devices
-
 Requirements:
   - the root is set and belongs to the team
   - the root has <team_size> src buffers and one dst buffer
   - non-roots have no src buffer and one dst buffer
   - all buffers have the same size
-*/
-class Scatter : public Communication {
- public:
-  Scatter(CommParams params);
-  c10::intrusive_ptr<c10d::Work> post(
-      Communicator& comm,
-      std::optional<CommunicatorBackend> backend = std::nullopt) override;
-};
 
-/*
+(*) Reduce
 Reduce the src buffers to the root's dst buffer.
-
 Requirements:
   - the root is set and belongs to the team
   - the root has one src buffers and one dst buffer
   - non-roots have one src buffer and no dst buffer
   - all buffers have the same size
-*/
-class Reduce : public Communication {
- public:
-  Reduce(CommParams params);
-  c10::intrusive_ptr<c10d::Work> post(
-      Communicator& comm,
-      std::optional<CommunicatorBackend> backend = std::nullopt) override;
-};
 
-/*
+(*) Allreduce
 Reduce the src buffers to the dst buffer.
-
 Requirements:
   - all devices have one src buffer and one dst buffer
   - all buffers have the same size
-*/
-class Allreduce : public Communication {
- public:
-  Allreduce(CommParams params);
-  c10::intrusive_ptr<c10d::Work> post(
-      Communicator& comm,
-      std::optional<CommunicatorBackend> backend = std::nullopt) override;
-};
 
-/*
+(*) ReduceScatter
 Reduce all the src buffers and shard the result to the dst buffers.
-
 Requirements:
   - all devices have <team_size> src buffer and one dst buffer
   - all buffers have the same size
-*/
-class ReduceScatter : public Communication {
- public:
-  ReduceScatter(CommParams params);
-  c10::intrusive_ptr<c10d::Work> post(
-      Communicator& comm,
-      std::optional<CommunicatorBackend> backend = std::nullopt) override;
-};
 
-/*
+(*) SendRecv
 Copies the sender's src buffers to the receiver's dst buffer
 It is equivalent to a Broadcast with a team of size == 2
 
@@ -218,12 +136,42 @@ case of a local copy)
   - If team is of size 2, the unique non-root have no src buffer and one dst
 buffer
 */
-class SendRecv : public Communication {
+
+class NVF_API Communication : public Expr {
  public:
-  SendRecv(CommParams params);
-  c10::intrusive_ptr<c10d::Work> post(
-      Communicator& comm,
-      std::optional<CommunicatorBackend> backend = std::nullopt) override;
+  using Expr::Expr;
+  Communication(IrBuilderPasskey passkey, CommParams params);
+  Communication(const Communication* src, IrCloner* ir_cloner);
+
+  Communication(const Communication& other) = delete;
+  Communication& operator=(const Communication& other) = delete;
+  Communication(Communication&& other) = delete;
+  Communication& operator=(Communication&& other) = delete;
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+  const char* getOpString() const override {
+    return "Communication";
+  }
+
+  bool sameAs(const Statement* other) const override;
+
+  auto params() const {
+    return params_;
+  }
+
+ private:
+  // store the arguments of the communication
+  CommParams params_;
 };
+
+// Triggers the execution of the communication. This is a non-blocking call.
+// The communication can be posted multiple times
+c10::intrusive_ptr<c10d::Work> postCommunication(
+    Communication* communication,
+    DeviceIdxType my_device_index,
+    c10::intrusive_ptr<c10d::Backend> backend);
 
 } // namespace nvfuser

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -234,24 +234,6 @@ c10::intrusive_ptr<c10d::Backend> Communicator::getBackendForTeam(
   return backends_.at(team_key);
 }
 
-c10::intrusive_ptr<c10d::Work> Communicator::sendRecv(
-    DeviceIdxType receiver,
-    DeviceIdxType sender,
-    std::vector<at::Tensor>& tensors,
-    std::optional<CommunicatorBackend> backend,
-    int tag) {
-  NVF_ERROR(
-      deviceId() == sender || deviceId() == receiver,
-      "only sender or receiver should post the sendRecv");
-  NVF_ERROR(sender != receiver, "cannot send to self");
-
-  auto world = getWorld(backend);
-  if (deviceId() == sender) {
-    return world->send(tensors, static_cast<int>(dIdToRank(receiver)), tag);
-  }
-  return world->recv(tensors, static_cast<int>(dIdToRank(sender)), tag);
-}
-
 c10::intrusive_ptr<c10d::Backend> Communicator::getWorld(
     std::optional<CommunicatorBackend> backend) {
   std::vector<RankType> all_ranks(size_);

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -73,14 +73,6 @@ class Communicator {
     default_backend_ = backend;
   }
 
-  // performs a send/receive p2p data transfer
-  c10::intrusive_ptr<c10d::Work> sendRecv(
-      DeviceIdxType receiver,
-      DeviceIdxType sender,
-      std::vector<at::Tensor>& tensor,
-      std::optional<CommunicatorBackend> backend = std::nullopt,
-      int tag = 0);
-
   // performs a blocking barrier in the communicator
   void barrier(std::optional<CommunicatorBackend> backend = std::nullopt) {
     getWorld(backend)->barrier()->wait();

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -149,7 +149,7 @@ void MultiDeviceExecutor::postKernel(
   }
 }
 
-void MultiDeviceExecutor::postResharding(SegmentedGroup* group) {
+void MultiDeviceExecutor::postCommunication(SegmentedGroup* group) {
   // Lower the group into a vector of Communications
   NVF_ERROR(
       group->exprs().size() == 1,
@@ -177,7 +177,8 @@ void MultiDeviceExecutor::postResharding(SegmentedGroup* group) {
   for (auto communication : communications) {
     auto backend =
         comm_.getBackendForTeam(communication->params().team, std::nullopt);
-    auto work = postCommunication(communication, comm_.deviceId(), backend);
+    auto work =
+        postSingleCommunication(communication, comm_.deviceId(), backend);
     if (work) {
       work->wait();
     }
@@ -215,7 +216,7 @@ std::vector<at::Tensor> MultiDeviceExecutor::runWithInput(
     if (!is_resharding_.at(group)) {
       postKernel(group, launch_params);
     } else {
-      postResharding(group);
+      postCommunication(group);
     }
   }
 

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -149,7 +149,7 @@ void MultiDeviceExecutor::postKernel(
   }
 }
 
-void MultiDeviceExecutor::postCommunication(SegmentedGroup* group) {
+void MultiDeviceExecutor::postResharding(SegmentedGroup* group) {
   // Lower the group into a vector of Communications
   NVF_ERROR(
       group->exprs().size() == 1,
@@ -174,8 +174,10 @@ void MultiDeviceExecutor::postCommunication(SegmentedGroup* group) {
       lowerCommunication(comm_.deviceId(), expr, input_tensor, output_tensor);
 
   // post and wait communications
-  for (auto& communication : communications) {
-    auto work = communication->post(comm_);
+  for (auto communication : communications) {
+    auto backend =
+        comm_.getBackendForTeam(communication->params().team, std::nullopt);
+    auto work = postCommunication(communication, comm_.deviceId(), backend);
     if (work) {
       work->wait();
     }
@@ -213,7 +215,7 @@ std::vector<at::Tensor> MultiDeviceExecutor::runWithInput(
     if (!is_resharding_.at(group)) {
       postKernel(group, launch_params);
     } else {
-      postCommunication(group);
+      postResharding(group);
     }
   }
 

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -116,7 +116,7 @@ class MultiDeviceExecutor {
   // params_.use_fusion_executor_cache = false
   void postKernel(SegmentedGroup* group, const LaunchParams& launch_params);
   // execute a SegmentedGroup representing inter-device communication
-  void postResharding(SegmentedGroup* group);
+  void postCommunication(SegmentedGroup* group);
 
   // Stores concrete computed values,
   std::unordered_map<Val*, c10::IValue> val_to_IValue_;

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -116,7 +116,7 @@ class MultiDeviceExecutor {
   // params_.use_fusion_executor_cache = false
   void postKernel(SegmentedGroup* group, const LaunchParams& launch_params);
   // execute a SegmentedGroup representing inter-device communication
-  void postCommunication(SegmentedGroup* group);
+  void postResharding(SegmentedGroup* group);
 
   // Stores concrete computed values,
   std::unordered_map<Val*, c10::IValue> val_to_IValue_;

--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <device_lower/utils.h>
+#include <ir/builder.h>
 #include <ir/interface_nodes.h>
 #include <multidevice/device_mesh.h>
 #include <multidevice/lower_communication.h>
@@ -106,6 +107,8 @@ CommParams createParamsForGatherScatter(
     bool is_scatter) {
   const DeviceMesh& mesh = root_tv->getDeviceMesh();
   CommParams params;
+  params.type =
+      is_scatter ? CommunicationType::Scatter : CommunicationType::Gather;
   params.root = root;
   params.team = mesh.vector();
   bool is_root_in_mesh = mesh.has(root);
@@ -142,7 +145,7 @@ void lowerToScatter(
     TensorView* output_tv,
     at::Tensor input_tensor,
     at::Tensor output_tensor,
-    std::vector<std::shared_ptr<Communication>>& comms) {
+    std::vector<Communication*>& comms) {
   // we arbitrarily choose the first device of the sender mesh to be the root
   const DeviceMesh& receiver_mesh = output_tv->getDeviceMesh();
   auto root = input_tv->getDeviceMesh().vector().at(0);
@@ -151,7 +154,7 @@ void lowerToScatter(
   }
   auto params = createParamsForGatherScatter(
       my_device_index, root, output_tv, input_tensor, output_tensor, true);
-  comms.push_back(std::make_shared<Scatter>(std::move(params)));
+  comms.push_back(IrBuilder::create<Communication>(std::move(params)));
 }
 
 /*
@@ -166,7 +169,7 @@ void lowerToGather(
     TensorView* output_tv,
     at::Tensor input_tensor,
     at::Tensor output_tensor,
-    std::vector<std::shared_ptr<Communication>>& comms) {
+    std::vector<Communication*>& comms) {
   // we create as many 'Gathers' as there are devices in the receiver mesh
   const DeviceMesh& sender_mesh = input_tv->getDeviceMesh();
   for (auto root : output_tv->getDeviceMesh().vector()) {
@@ -175,7 +178,7 @@ void lowerToGather(
     }
     auto params = createParamsForGatherScatter(
         my_device_index, root, input_tv, output_tensor, input_tensor, false);
-    comms.push_back(std::make_shared<Gather>(std::move(params)));
+    comms.push_back(IrBuilder::create<Communication>(std::move(params)));
   }
 }
 
@@ -186,13 +189,14 @@ void lowerToAllgather(
     TensorView* output_tv,
     at::Tensor input_tensor,
     at::Tensor output_tensor,
-    std::vector<std::shared_ptr<Communication>>& comms) {
+    std::vector<Communication*>& comms) {
   const DeviceMesh& mesh = input_tv->getDeviceMesh();
   if (!mesh.has(my_device_index)) {
     return;
   }
 
   CommParams params;
+  params.type = CommunicationType::Allgather;
   params.team = mesh.vector();
   for (auto i : c10::irange(mesh.vector().size())) {
     params.dst_bufs.push_back(
@@ -200,7 +204,7 @@ void lowerToAllgather(
   }
   params.src_bufs = {input_tensor};
 
-  comms.push_back(std::make_shared<Allgather>(std::move(params)));
+  comms.push_back(IrBuilder::create<Communication>(std::move(params)));
 }
 
 // Creates and set the CommParams for a Broadcast or Send/Recv communication
@@ -216,6 +220,7 @@ CommParams createParamsForBroadcastOrP2P(
   if (!mesh.has(root)) {
     params.team.push_back(root);
   }
+  params.type = CommunicationType::Broadcast;
 
   if (my_device_index == root) {
     params.src_bufs = {input_tensor};
@@ -234,19 +239,13 @@ void lowerToBroadcastOrP2P(
     const DeviceMesh& mesh, // receiver devices
     at::Tensor input_tensor,
     at::Tensor output_tensor,
-    std::vector<std::shared_ptr<Communication>>& comms) {
+    std::vector<Communication*>& comms) {
   if (!isDeviceInvolved(my_device_index, root, mesh)) {
     return;
   }
   auto params = createParamsForBroadcastOrP2P(
       my_device_index, root, mesh, input_tensor, output_tensor);
-  std::shared_ptr<Communication> comm;
-  if (mesh.vector().size() == 1) {
-    comm = std::make_shared<SendRecv>(std::move(params));
-  } else {
-    comm = std::make_shared<Broadcast>(std::move(params));
-  }
-  comms.push_back(comm);
+  comms.push_back(IrBuilder::create<Communication>(std::move(params)));
 }
 
 // Adds several Broadcast or Send/Recv communications to the vector 'comms'
@@ -260,7 +259,7 @@ void lowerToBroadcastOrP2P(
     at::Tensor input_tensor,
     at::Tensor output_tensor,
     bool is_sharded,
-    std::vector<std::shared_ptr<Communication>>& comms) {
+    std::vector<Communication*>& comms) {
   const DeviceMesh& sender_mesh = input_tv->getDeviceMesh();
   const DeviceMesh& receiver_mesh = output_tv->getDeviceMesh();
   if (is_sharded) {
@@ -300,6 +299,7 @@ CommParams createParamsForReduce(
     BinaryOpType op_type) {
   const DeviceMesh& mesh = input_tv->getDeviceMesh();
   CommParams params;
+  params.type = CommunicationType::Reduce;
   params.root = root;
   params.redOp = getC10dReduceOpType(op_type);
   params.team = mesh.vector();
@@ -333,7 +333,7 @@ void lowerToReduce(
     at::Tensor input_tensor,
     at::Tensor output_tensor,
     BinaryOpType op_type,
-    std::vector<std::shared_ptr<Communication>>& comms) {
+    std::vector<Communication*>& comms) {
   const DeviceMesh& receiver_mesh = output_tv->getDeviceMesh();
   const DeviceMesh& sender_mesh = input_tv->getDeviceMesh();
   // we create as many Reduces as there are devices in the receiver mesh
@@ -349,7 +349,7 @@ void lowerToReduce(
         input_tensor,
         output_tensor,
         op_type);
-    comms.push_back(std::make_shared<Reduce>(std::move(params)));
+    comms.push_back(IrBuilder::create<Communication>(std::move(params)));
   }
 }
 
@@ -360,17 +360,18 @@ void lowerToAllreduce(
     at::Tensor input_tensor,
     at::Tensor output_tensor,
     BinaryOpType op_type,
-    std::vector<std::shared_ptr<Communication>>& comms) {
+    std::vector<Communication*>& comms) {
   const DeviceMesh& mesh = input_tv->getDeviceMesh();
   if (!mesh.has(my_device_index)) {
     return;
   }
   CommParams params;
+  params.type = CommunicationType::Allreduce;
   params.redOp = getC10dReduceOpType(op_type);
   params.team = mesh.vector();
   params.dst_bufs = {output_tensor};
   params.src_bufs = {input_tensor.view(output_tensor.sizes())};
-  comms.push_back(std::make_shared<Allreduce>(params));
+  comms.push_back(IrBuilder::create<Communication>(params));
 }
 
 void lowerToReduceScatter(
@@ -380,12 +381,13 @@ void lowerToReduceScatter(
     at::Tensor input_tensor,
     at::Tensor output_tensor,
     BinaryOpType op_type,
-    std::vector<std::shared_ptr<Communication>>& comms) {
+    std::vector<Communication*>& comms) {
   const DeviceMesh& mesh = input_tv->getDeviceMesh();
   if (!mesh.has(my_device_index)) {
     return;
   }
   CommParams params;
+  params.type = CommunicationType::ReduceScatter;
   params.redOp = getC10dReduceOpType(op_type);
   params.team = mesh.vector();
   params.dst_bufs = {output_tensor};
@@ -404,7 +406,7 @@ void lowerToReduceScatter(
     params.src_bufs.push_back(slice);
   }
 
-  comms.push_back(std::make_shared<ReduceScatter>(params));
+  comms.push_back(IrBuilder::create<Communication>(params));
 }
 
 } // namespace
@@ -418,12 +420,12 @@ TODO:
    sources
 *) Leverage the topology to ensure that the senders and recerivers are close
 */
-std::vector<std::shared_ptr<Communication>> lowerCommunication(
+std::vector<Communication*> lowerCommunication(
     DeviceIdxType my_device_index,
     Expr* c,
     at::Tensor input_tensor,
     at::Tensor output_tensor) {
-  std::vector<std::shared_ptr<Communication>> comms;
+  std::vector<Communication*> comms;
   NVF_ERROR(
       c->inputs().size() == 1 && c->inputs().at(0)->isA<TensorView>() &&
           c->outputs().size() == 1 && c->outputs().at(0)->isA<TensorView>(),

--- a/csrc/multidevice/lower_communication.h
+++ b/csrc/multidevice/lower_communication.h
@@ -19,7 +19,7 @@ bool isLowerableToCommunication(Expr* expr);
 
 // Lower a PipelineCommunication into a series of Communication, given a
 // device_index.
-std::vector<std::shared_ptr<Communication>> lowerCommunication(
+std::vector<Communication*> lowerCommunication(
     DeviceIdxType device_index,
     Expr* c,
     at::Tensor input_tensor,

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -83,8 +83,8 @@ TEST_P(CommunicationTest, Gather) {
         at::arange(tensor_size, tensor_options) +
         (communicator->deviceId() + 1) * j);
 
-    auto work =
-        postCommunication(communication, communicator->deviceId(), backend);
+    auto work = postSingleCommunication(
+        communication, communicator->deviceId(), backend);
     work->wait();
 
     if (communicator->deviceId() == root) {
@@ -113,8 +113,8 @@ TEST_P(CommunicationTest, Allgather) {
         at::arange(tensor_size, tensor_options) +
         (communicator->deviceId() + 1) * j);
 
-    auto work =
-        postCommunication(communication, communicator->deviceId(), backend);
+    auto work = postSingleCommunication(
+        communication, communicator->deviceId(), backend);
     work->wait();
 
     for (int i : c10::irange(communicator->size())) {
@@ -145,8 +145,8 @@ TEST_P(CommunicationTest, Scatter) {
           at::arange(tensor_size, tensor_options) + (i + 1) * j);
     }
 
-    auto work =
-        postCommunication(communication, communicator->deviceId(), backend);
+    auto work = postSingleCommunication(
+        communication, communicator->deviceId(), backend);
     work->wait();
 
     auto obtained = params.dst_bufs.at(0);
@@ -173,8 +173,8 @@ TEST_P(CommunicationTest, Broadcast) {
       params.src_bufs.at(0).copy_(at::arange(tensor_size, tensor_options) + j);
     }
 
-    auto work =
-        postCommunication(communication, communicator->deviceId(), backend);
+    auto work = postSingleCommunication(
+        communication, communicator->deviceId(), backend);
     if (communicator->size() > 1) {
       work->wait();
     }
@@ -215,8 +215,8 @@ TEST_P(CommunicationTest, SendRecv) {
       params.src_bufs.at(0).copy_(at::arange(tensor_size, tensor_options) + j);
     }
 
-    auto work =
-        postCommunication(communication, communicator->deviceId(), backend);
+    auto work = postSingleCommunication(
+        communication, communicator->deviceId(), backend);
     work->wait();
 
     if (communicator->deviceId() == receiver) {
@@ -244,7 +244,7 @@ TEST_P(CommunicationTest, SendRecvToSelf) {
     resetDstBuffers();
     params.src_bufs.at(0).copy_(at::arange(tensor_size, tensor_options) + j);
 
-    postCommunication(communication, communicator->deviceId(), backend);
+    postSingleCommunication(communication, communicator->deviceId(), backend);
 
     auto obtained = params.dst_bufs.at(0);
     auto ref = at::arange(tensor_size, tensor_options) + j;
@@ -269,8 +269,8 @@ TEST_P(CommunicationTest, Reduce) {
         at::arange(tensor_size, tensor_options) +
         (communicator->deviceId() + 1) * j);
 
-    auto work =
-        postCommunication(communication, communicator->deviceId(), backend);
+    auto work = postSingleCommunication(
+        communication, communicator->deviceId(), backend);
     work->wait();
 
     if (communicator->deviceId() == root) {
@@ -297,8 +297,8 @@ TEST_P(CommunicationTest, Allreduce) {
         at::arange(tensor_size, tensor_options) +
         (communicator->deviceId() + 1) * j);
 
-    auto work =
-        postCommunication(communication, communicator->deviceId(), backend);
+    auto work = postSingleCommunication(
+        communication, communicator->deviceId(), backend);
     work->wait();
 
     auto obtained = params.dst_bufs.at(0);
@@ -328,8 +328,8 @@ TEST_P(CommunicationTest, ReduceScatter) {
           (communicator->deviceId() + 1) * (i + j));
     }
 
-    auto work =
-        postCommunication(communication, communicator->deviceId(), backend);
+    auto work = postSingleCommunication(
+        communication, communicator->deviceId(), backend);
     work->wait();
 
     auto obtained = params.dst_bufs.at(0);


### PR DESCRIPTION
This PR makes the "Communication" class a proper IR inheriting from Expr. This patch is needed for implementing Host Irs. It is also one step towards making the Communications (and more generally the multidevice module) fully symbolic.

By the way, we proceed to a couple of refactoring, and remove `Communicator::sendRecv` method.

Remarks:
1) This IR will be used for now in the context of Host Irs. Later, they could also serve as kernel IR (backed by device-side communication APIs at runtime).
2) Before this patch, we had a base class `Communication` and one derived class per collective type (Allgather, Allreduce, Broadcast, etc.). Now, there is only the class `Communication`, and the collective type is encoded through an enum class `CollectiveType` added to the parameter member `CommParams`
3) the `Communication::post` method was replaced by a standalone function `postCollective`. The motivation is to scoop out the runtime execution from the symbolic representation of the collective.
4) Note that step 3) is only implented halfway here since a `Collective` is instantiated with concrete device Idx and concrete at::Tensor, while it should be instantiated with symbolic representations and binded to actual device indices and Aten buffers at runtime. This will be added in a future PR.

CI: https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/pipelines/14923305