### PR TITLE
mark used scheduler in python benchmarks

### DIFF
--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -70,7 +70,9 @@ def pytest_configure(config):
     BENCHMARK_CONFIG["warmup_rounds"] = int(
         config.getoption("--benchmark-warmup-rounds")
     )
-
+    config.addinivalue_line(
+        "markers", "inner_outer_persistent: mark tests using inner_outer_persistent scheduler."
+    )
 
 def pytest_collection_modifyitems(session, config, items):
     """

--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -72,7 +72,7 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "inner_outer_persistent: mark tests using inner_outer_persistent scheduler.",
+        "inner_outer_persistent: mark tests using inner_outer_persistent scheduler if not being segmented.",
     )
 
 

--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -71,8 +71,10 @@ def pytest_configure(config):
         config.getoption("--benchmark-warmup-rounds")
     )
     config.addinivalue_line(
-        "markers", "inner_outer_persistent: mark tests using inner_outer_persistent scheduler."
+        "markers",
+        "inner_outer_persistent: mark tests using inner_outer_persistent scheduler.",
     )
+
 
 def pytest_collection_modifyitems(session, config, items):
     """

--- a/benchmarks/python/test_dropout_layernorm_bwd.py
+++ b/benchmarks/python/test_dropout_layernorm_bwd.py
@@ -140,6 +140,7 @@ def dropout_layernorm_bwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.inner_outer_persistent
 def test_dropout_layernorm_bwd_nvf_benchmark(
     benchmark,
     size: tuple,

--- a/benchmarks/python/test_dropout_rmsnorm_bwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_bwd.py
@@ -126,6 +126,7 @@ def dropout_rmsnorm_bwd_iobytes(size, dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.inner_outer_persistent
 def test_dropout_rmsnorm_bwd_nvf_benchmark(
     benchmark,
     size: tuple,

--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -108,6 +108,7 @@ def layernorm_bwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.inner_outer_persistent
 def test_layernorm_bwd_nvf_benchmark(
     benchmark,
     size: tuple,

--- a/benchmarks/python/test_rmsnorm_bwd.py
+++ b/benchmarks/python/test_rmsnorm_bwd.py
@@ -82,6 +82,7 @@ def rmsnorm_bwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.inner_outer_persistent
 def test_rmsnorm_bwd_nvf_benchmark(
     benchmark,
     size: tuple,


### PR DESCRIPTION
Marke the used scheduler in python benchmarks, so when a scheduler is changed, we can select which benchmark to run.
For example, this PR marked 4 cases as inner_outer_persistent.
If `inner_outer_persistent` scheduler is changed, we can select the corresponding benchmarks with `pytest /opt/pytorch/nvfuser/benchmarks/python/  -m inner_outer_persistent`