### PR TITLE
Make it easier to `gdb` an `mpirun`.

### DIFF
--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -44,6 +44,11 @@ class MultiDeviceTest : public NVFuserTest {
   // and timeout later.
   bool do_barrier_at_test;
   bool disable_skip;
+
+ private:
+  // If NVFUSER_MPI_DEBUG_RANK is set, that rank will attempt to wait for the
+  // debugger.
+  void waitForDebugger();
 };
 
 class PipelineTest : public MultiDeviceTest {

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -46,9 +46,7 @@ class MultiDeviceTest : public NVFuserTest {
   bool disable_skip;
 
  private:
-  // If NVFUSER_MULTIDEVICE_WAIT_DEBUGGER_AT_RANK is set, that rank will
-  // attempt to wait for the debugger.
-  void waitForDebugger();
+  void waitForDebuggerAtRank(DeviceIdxType rank);
 };
 
 class PipelineTest : public MultiDeviceTest {

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -46,8 +46,8 @@ class MultiDeviceTest : public NVFuserTest {
   bool disable_skip;
 
  private:
-  // If NVFUSER_MPI_DEBUG_RANK is set, that rank will attempt to wait for the
-  // debugger.
+  // If NVFUSER_MULTIDEVICE_WAIT_DEBUGGER_AT_RANK is set, that rank will
+  // attempt to wait for the debugger.
   void waitForDebugger();
 };
 


### PR DESCRIPTION
This implements https://www.sci.utah.edu/~tfogal/academic/Fogal-ParallelDebugging.pdf, authored by @tfogal.

I tested this manually.

stdout from the test being debugged:
```
Process 16662 is waiting for debugger. To continue debugging, start gdb, `attach 16662`, `set var waiting=false`, and `fini`.
Process 16662 finished waiting.
```

stdout from gdb:
```
(gdb) attach 16662
Attaching to program: /opt/pytorch/nvfuser/build/test_multidevice, process 16662
[New LWP 16667]
`/opt/pytorch/nvfuser/build/test_multidevice' has changed; re-reading symbols.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/x86_64-linux-gnu/libthread_db.so.1".
0x000056388b5e7fc5 in nvfuser::MultiDeviceTest::waitForDebugger (this=0x7f7e2c41d800) at /opt/pytorch/nvfuser/tests/cpp/multidevice.cpp:66
66          while (waiting) { // Please change `waiting` in the debugger.
(gdb) set var waiting=false
(gdb) fini
Run till exit from #0  0x000056388b5e7fc5 in nvfuser::MultiDeviceTest::waitForDebugger (this=0x7f7e2c41d800) at /opt/pytorch/nvfuser/tests/cpp/multidevice.cpp:66
[New Thread 0x7f7e2bd84000 (LWP 16706)]
[New Thread 0x7f7e20f7b000 (LWP 16707)]
[New Thread 0x7f7e0bf7b000 (LWP 16708)]
[New Thread 0x7f7e0b77a000 (LWP 16709)]
[New Thread 0x7f7e02fff000 (LWP 16710)]
[New Thread 0x7f7df0fde000 (LWP 16711)]
[New Thread 0x7f7db4fff000 (LWP 16713)]
[New Thread 0x7f7db47fe000 (LWP 16719)]
[New Thread 0x7f7db38fc000 (LWP 16722)]
[Thread 0x7f7df0fde000 (LWP 16711) exited]
nvfuser::MultiDeviceTest::MultiDeviceTest (this=0x7f7e2c41d800) at /opt/pytorch/nvfuser/tests/cpp/multidevice.cpp:37
37      }
```