### PR TITLE
Specify supported gcc versions as the officially supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,23 @@ PyPI: [https://pypi.org/project/nvfuser/](https://pypi.org/search/?q=nvfuser)
 Docs: https://github.com/NVIDIA/Fuser/wiki
 
 Supported compilers:
-- gcc 11.4+
-- clang14+
+
+**GCC:**
+
+We support all "supported releases" of gcc as specified in [the official site](https://gcc.gnu.org/).
+Currently, they are:
+
+- gcc 11.4
+- gcc 12.3
+- gcc 13.2
+- gcc 14.1
+
+**Clang:**
+
+- clang 14+
 
 Supported C++ standard:
+
 - C++17
 - C++20
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Supported compilers:
 **GCC:**
 
 We support all "supported releases" of gcc as specified in [the official site](https://gcc.gnu.org/).
-Currently, they are:
+As of 5/3/2024, they are:
 
 - gcc 11.4
 - gcc 12.3


### PR DESCRIPTION
GCC officially provides a list of versions being supported. We should use the same list. This list will be a guidance for our decisions on things like, should we upgrade C++20?