### PR TITLE
Do barrier at test unconditionally.

### DIFF
--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -21,14 +21,11 @@ MultiDeviceTest::MultiDeviceTest() {
   tensor_options =
       at::TensorOptions().dtype(at::kFloat).device(communicator->device());
   debug_print = getNvFuserEnv("MULTIDEVICE_DEBUG_PRINT") != nullptr;
-  do_barrier_at_test =
-      (getNvFuserEnv("MULTIDEVICE_DEBUG_BARRIER") != nullptr &&
-       communicator->is_available());
   disable_skip = getNvFuserEnv("MULTIDEVICE_DISABLE_SKIP") != nullptr;
 }
 
 MultiDeviceTest::~MultiDeviceTest() {
-  if (do_barrier_at_test && communicator->is_available()) {
+  if (communicator->is_available()) {
     communicator->barrier();
   }
 }

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -36,13 +36,6 @@ class MultiDeviceTest : public NVFuserTest {
   Communicator* communicator;
   c10::TensorOptions tensor_options;
   bool debug_print;
-  // This is a knob that forces all processes to synchronize at a barrier
-  // between tests. It slows the tests down so that's why it's default turned
-  // off.  Without the barrier, isolating a failing test can be hard so that's
-  // we turn on the flag for CI. Specifically, if a test fails such that a
-  // subset of processes fail, then some processes will move onto another tests
-  // and timeout later.
-  bool do_barrier_at_test;
   bool disable_skip;
 };
 


### PR DESCRIPTION
On dgx1v-loki-21, the wall-time difference is merely 132 seconds vs 136 seconds.