### PR TITLE
Fix TensorView::clearReductionIterDomains specifies wrong contiguity flag

### DIFF
--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1198,8 +1198,8 @@ void TensorView::clearReductionIterDomains() {
       getLeafDomain() == getRootDomain(),
       "should not call clearReductionIterDomains on already transformed TensorDomains");
 
-  std::vector<IterDomain*> root = getRootDomain();
-  std::vector<IterDomain*> alloc = getMaybeAllocationDomain();
+  const std::vector<IterDomain*>& root = getRootDomain();
+  const std::vector<IterDomain*>& alloc = getMaybeAllocationDomain();
 
   NVF_ERROR(
       std::is_permutation(root.begin(), root.end(), alloc.begin(), alloc.end()),
@@ -1208,13 +1208,13 @@ void TensorView::clearReductionIterDomains() {
   std::vector<IterDomain*> new_root;
   std::vector<IterDomain*> new_alloc;
   std::vector<std::optional<bool>> new_contig;
-  for (const auto i : c10::irange(getRootDomain().size())) {
-    auto root_i = getRootDomain().at(i);
+  for (const auto i : c10::irange(root.size())) {
+    auto root_i = root.at(i);
     if (!root_i->isReduction()) {
       new_root.push_back(root_i);
     }
     // contig flag is specified for on allocation domain
-    auto alloc_i = getAllocationDomain().at(i);
+    auto alloc_i = alloc.at(i);
     if (!alloc_i->isReduction()) {
       new_alloc.push_back(alloc_i);
       new_contig.push_back(domain()->contiguity().at(i));

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1200,8 +1200,11 @@ void TensorView::clearReductionIterDomains() {
 
   if (domain()->hasAllocation()) {
     NVF_ERROR(
-        std::is_permutation(getRootDomain().begin(), getRootDomain().end(),
-                            getAllocationDomain().begin(), getAllocationDomain().end()),
+        std::is_permutation(
+            getRootDomain().begin(),
+            getRootDomain().end(),
+            getAllocationDomain().begin(),
+            getAllocationDomain().end()),
         "should not call clearReductionIterDomains on transformed allocation domain");
     std::vector<IterDomain*> new_root;
     std::vector<IterDomain*> new_alloc;
@@ -1218,7 +1221,13 @@ void TensorView::clearReductionIterDomains() {
       }
     }
 
-    setDomain(IrBuilder::create<TensorDomain>(container(), new_root, std::vector<IterDomain*>(), new_alloc, new_root, new_contig));
+    setDomain(IrBuilder::create<TensorDomain>(
+        container(),
+        new_root,
+        std::vector<IterDomain*>(),
+        new_alloc,
+        new_root,
+        new_contig));
   } else {
     std::vector<IterDomain*> new_root;
     std::vector<std::optional<bool>> new_contig;
@@ -1230,7 +1239,8 @@ void TensorView::clearReductionIterDomains() {
       }
     }
 
-    setDomain(IrBuilder::create<TensorDomain>(container(), new_root, new_contig));
+    setDomain(
+        IrBuilder::create<TensorDomain>(container(), new_root, new_contig));
   }
 }
 

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1214,7 +1214,7 @@ void TensorView::clearReductionIterDomains() {
       if (!root_i->isReduction()) {
         new_root.push_back(root_i);
       }
-      auto alloc_i = getAllocatoinDomain().at(i);
+      auto alloc_i = getAllocationDomain().at(i);
       if (!alloc_i->isReduction()) {
         new_alloc.push_back(alloc_i);
         new_contig.push_back(domain()->contiguity().at(i));

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1198,29 +1198,35 @@ void TensorView::clearReductionIterDomains() {
       getLeafDomain() == getRootDomain(),
       "should not call clearReductionIterDomains on already transformed TensorDomains");
 
-  if (domain()->hasAllocation()) {
-    NVF_ERROR(
-        std::is_permutation(
-            getRootDomain().begin(),
-            getRootDomain().end(),
-            getAllocationDomain().begin(),
-            getAllocationDomain().end()),
-        "should not call clearReductionIterDomains on transformed allocation domain");
-    std::vector<IterDomain*> new_root;
-    std::vector<IterDomain*> new_alloc;
-    std::vector<std::optional<bool>> new_contig;
-    for (const auto i : c10::irange(getRootDomain().size())) {
-      auto root_i = getRootDomain().at(i);
-      if (!root_i->isReduction()) {
-        new_root.push_back(root_i);
-      }
-      auto alloc_i = getAllocationDomain().at(i);
-      if (!alloc_i->isReduction()) {
-        new_alloc.push_back(alloc_i);
-        new_contig.push_back(domain()->contiguity().at(i));
-      }
-    }
+  std::vector<IterDomain*> root = getRootDomain();
+  std::vector<IterDomain*> alloc = getMaybeAllocationDomain();
 
+  NVF_ERROR(
+      std::is_permutation(root.begin(), root.end(), alloc.begin(), alloc.end()),
+      "should not call clearReductionIterDomains on transformed allocation domain");
+
+  std::vector<IterDomain*> new_root;
+  std::vector<IterDomain*> new_alloc;
+  std::vector<std::optional<bool>> new_contig;
+  for (const auto i : c10::irange(getRootDomain().size())) {
+    auto root_i = getRootDomain().at(i);
+    if (!root_i->isReduction()) {
+      new_root.push_back(root_i);
+    }
+    // contig flag is specified for on allocation domain
+    auto alloc_i = getAllocationDomain().at(i);
+    if (!alloc_i->isReduction()) {
+      new_alloc.push_back(alloc_i);
+      new_contig.push_back(domain()->contiguity().at(i));
+    }
+  }
+
+  if (new_alloc == new_root) {
+    // if new allocation domain is identical to new root domain, we don't need
+    // to specify allocation domain
+    setDomain(
+        IrBuilder::create<TensorDomain>(container(), new_root, new_contig));
+  } else {
     setDomain(IrBuilder::create<TensorDomain>(
         container(),
         new_root,
@@ -1228,20 +1234,8 @@ void TensorView::clearReductionIterDomains() {
         new_alloc,
         new_root,
         new_contig));
-  } else {
-    std::vector<IterDomain*> new_root;
-    std::vector<std::optional<bool>> new_contig;
-    for (const auto i : c10::irange(getRootDomain().size())) {
-      auto root_i = getRootDomain().at(i);
-      if (!root_i->isReduction()) {
-        new_root.push_back(root_i);
-        new_contig.push_back(domain()->contiguity().at(i));
-      }
-    }
-
-    setDomain(
-        IrBuilder::create<TensorDomain>(container(), new_root, new_contig));
   }
+}
 }
 
 void TensorView::doubleBuffer() {

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1236,7 +1236,6 @@ void TensorView::clearReductionIterDomains() {
         new_contig));
   }
 }
-}
 
 void TensorView::doubleBuffer() {
   // Early correctness checking. May miss eventual errors as the

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1200,8 +1200,8 @@ void TensorView::clearReductionIterDomains() {
 
   if (domain()->hasAllocation()) {
     NVF_ERROR(
-        std::is_permutation(getLeafDomain().begin(), getRootDomain().end(),
-                            getAllocationDomain().begin(), getAllocationDomain().end(),
+        std::is_permutation(getRootDomain().begin(), getRootDomain().end(),
+                            getAllocationDomain().begin(), getAllocationDomain().end()),
         "should not call clearReductionIterDomains on transformed allocation domain");
     std::vector<IterDomain*> new_root;
     std::vector<IterDomain*> new_alloc;
@@ -1211,14 +1211,14 @@ void TensorView::clearReductionIterDomains() {
       if (!root_i->isReduction()) {
         new_root.push_back(root_i);
       }
-      auto alloc_i = getRootDomain().at(i);
+      auto alloc_i = getAllocatoinDomain().at(i);
       if (!alloc_i->isReduction()) {
-        new_alloc.push_back(root_i);
+        new_alloc.push_back(alloc_i);
         new_contig.push_back(domain()->contiguity().at(i));
       }
     }
 
-    setDomain(IrBuilder::create<TensorDomain>(container(), new_root, {}, new_alloc, {}, new_contig));
+    setDomain(IrBuilder::create<TensorDomain>(container(), new_root, std::vector<IterDomain*>(), new_alloc, new_root, new_contig));
   } else {
     std::vector<IterDomain*> new_root;
     std::vector<std::optional<bool>> new_contig;

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -1432,7 +1432,9 @@ TEST_F(AllocationDomainTest, ClearReductionIterDomainsPatch) {
                  .contiguity({true, std::nullopt, true})
                  .build();
   auto tv1 = sum(tv0, {0});
-  tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, {std::nullopt, true, std::nullopt});
+  tv1->setAllocationDomain(
+      {tv1->axis(0), tv1->axis(2), tv1->axis(1)},
+      {std::nullopt, true, std::nullopt});
   tv1->clearReductionIterDomains();
 }
 

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -1429,8 +1429,8 @@ TEST_F(AllocationDomainTest, ClearReductionIterDomainsPatch) {
   auto tv0 = TensorViewBuilder()
                  .ndims(3)
                  .shape({-1, 1, -1})
-                 .contiguity({true, std::nullopt, true})
-                 .strideOrder({0, 2, 1})
+                 .contiguity({true, true, std::nullopt})
+                 .strideOrder({2, 0, 1})
                  .build();
   auto tv1 = sum(tv0, {0});
   tv1->clearReductionIterDomains();

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -1429,10 +1429,10 @@ TEST_F(AllocationDomainTest, ClearReductionIterDomainsPatch) {
   auto tv0 = TensorViewBuilder()
                  .ndims(3)
                  .shape({-1, 1, -1})
-                 .contiguity({true, true, std::nullopt})
-                 .strideOrder({2, 0, 1})
+                 .contiguity({true, std::nullopt, true})
                  .build();
   auto tv1 = sum(tv0, {0});
+  tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, {true, true, std::nullopt});
   tv1->clearReductionIterDomains();
 }
 

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -1432,7 +1432,7 @@ TEST_F(AllocationDomainTest, ClearReductionIterDomainsPatch) {
                  .contiguity({true, std::nullopt, true})
                  .build();
   auto tv1 = sum(tv0, {0});
-  tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, {true, true, std::nullopt});
+  tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, {std::nullopt, true, std::nullopt});
   tv1->clearReductionIterDomains();
 }
 

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -1423,4 +1423,17 @@ TEST_F(AllocationDomainTest, ReductionVectorization) {
   testValidate(executor_cache.fusion(), cg_outputs, inputs, __LINE__, __FILE__);
 }
 
+TEST_F(AllocationDomainTest, ClearReductionIterDomainsPatch) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  auto tv0 = TensorViewBuilder()
+                 .ndims(3)
+                 .shape({-1, 1, -1})
+                 .contiguity({true, std::nullopt, true})
+                 .strideOrder({0, 2, 1})
+                 .build();
+  auto tv1 = sum(tv0, {0});
+  tv1->clearReductionIterDomains();
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
`TensorView::clearReductionIterDomains` constructs new contiguity vector on root domain, causing validation assert when output's allocation domain is not identical to its root domain.

This PR patches the logic and adds a test.