### PR TITLE
ensure coalesced gmem access when each thread has 32 bytes

### DIFF
--- a/runtime/grid_reduction.cu
+++ b/runtime/grid_reduction.cu
@@ -741,7 +741,7 @@ __device__ void iterGroupedGridReduceLastBlock(
   // bytes.
   constexpr int total_bytes = vec_size * sizeof(T);
   constexpr int n_loads = total_bytes <= 16 ? 1 : total_bytes / 16;
-  constexpr int n_elements = total_bytes <= 16 ? vec_size : 16 / sizeof(T);
+  constexpr int n_elements_per_transaction = total_bytes <= 16 ? vec_size : 16 / sizeof(T);
 
   // offset between different sections
   // each thread holds [n_elements], threads count in each section is:

--- a/runtime/grid_reduction.cu
+++ b/runtime/grid_reduction.cu
@@ -725,6 +725,17 @@ __device__ void iterGroupedGridReduceLastBlock(
   for (int i = 0; i < vec_size; i++) {
     inp[i] = init_val;
   }
+
+  constexpr int total_bytes = vec_size * sizeof(T);
+  constexpr int n_loads = total_bytes <= 16 ? 1 : total_bytes / 16;
+  constexpr int n_elements = total_bytes <= 16 ? vec_size : 16 / sizeof(T);
+  // split into multiple sections to ensure each thread occupies 16 bytes at
+  // most. For example, if each thread occupies 32 bytes, each transaction only
+  // get 16/32 * 128 = 64 bytes. define offset between different sections, each
+  // thread holds [n_elements] each section has [grid_reduction_segment_size *
+  // block_reduction_segment_size * grid_segment_size] threads.
+  unsigned int gmem_offset_inter = grid_reduction_segment_size *
+      block_reduction_segment_size * grid_segment_size * n_elements;
   // Block stride across the reduction until we only have one value per thread
   for (nvfuser_index_t reduction_i = id_in_block_segment;
        reduction_i < grid_reduction_segment_size;
@@ -733,18 +744,15 @@ __device__ void iterGroupedGridReduceLastBlock(
     auto work_buf_offset =
         reduction_i * (block_reduction_segment_size * grid_segment_size) +
         block_reduction_segment_size * idx_in_grid_segment + thread_offset;
-    work_buf_offset *= vec_size;
+    unsigned int gmem_offset_intra = work_buf_offset * n_elements;
 
-    // vectorized load from global memory
-    constexpr int total_bytes = vec_size * sizeof(T);
-    constexpr int n_loads = total_bytes <= 16 ? 1 : total_bytes / 16;
-    constexpr int n_elements = total_bytes <= 16 ? vec_size : 16 / sizeof(T);
 #pragma unroll
     for (int i = 0; i < n_loads; i++) {
       int i_offset = i * n_elements;
       T in_reg[n_elements];
       loadGlobalToLocal<T, n_elements, true, CacheOp::Global>(
-          &in_reg[0], const_cast<T*>(in + work_buf_offset + i_offset));
+          &in_reg[0],
+          const_cast<T*>(in + gmem_offset_inter * i + gmem_offset_intra));
 #pragma unroll
       for (int j = 0; j < n_elements; j++) {
         reduction_op(inp[i_offset + j], in_reg[j]);
@@ -857,6 +865,18 @@ __device__ void iterGroupedGridReduce(
         index_utils::maskedOffset<!X_THREAD, !Y_THREAD, !Z_THREAD>(
             threadIdx, blockDim);
 
+    constexpr int total_bytes = vec_size * sizeof(T);
+    constexpr int n_loads = total_bytes <= 16 ? 1 : total_bytes / 16;
+    constexpr int n_elements = total_bytes <= 16 ? vec_size : 16 / sizeof(T);
+    // split into multiple sections to ensure each thread occupies 16 bytes at
+    // most. For example, if each thread occupies 32 bytes, each transaction
+    // only get 16/32 * 128 = 64 bytes. define offset between different
+    // sections, each thread holds [n_elements] each section has
+    // [grid_reduction_segment_size * block_reduction_segment_size *
+    // grid_segment_size] threads.
+    unsigned int gmem_offset_inter = grid_reduction_segment_size *
+        block_reduction_segment_size * grid_segment_size * n_elements;
+
     // index to the right position in [work_buf] to store block reduction
     // results. Consider a typical outer reduction case where iteration dim is
     // TIDx and BIDx and reduction dim is TIDy and BIDy. block_offset = BIDy
@@ -867,15 +887,12 @@ __device__ void iterGroupedGridReduce(
     auto work_buf_offset =
         block_offset * (block_reduction_segment_size * grid_segment_size) +
         block_reduction_segment_size * idx_in_grid_segment + thread_offset;
-    work_buf_offset *= vec_size;
+    unsigned int gmem_offset_intra = work_buf_offset * n_elements;
 
-    constexpr int total_bytes = vec_size * sizeof(T);
-    constexpr int n_loads = total_bytes <= 16 ? 1 : total_bytes / 16;
-    constexpr int n_elements = total_bytes <= 16 ? vec_size : 16 / sizeof(T);
 #pragma unroll
     for (int i = 0; i < n_loads; i++) {
       loadLocalToGlobal<T, n_elements, true>(
-          &work_buf[work_buf_offset + i * n_elements],
+          &work_buf[gmem_offset_inter * i + gmem_offset_intra],
           &block_reduction_val[i * n_elements]);
     }
   }

--- a/runtime/grid_reduction.cu
+++ b/runtime/grid_reduction.cu
@@ -740,7 +740,7 @@ __device__ void iterGroupedGridReduceLastBlock(
   // This layout ensures coalesced access to gmem and each transaction loads 128
   // bytes.
   constexpr int total_bytes = vec_size * sizeof(T);
-  constexpr int n_loads = total_bytes <= 16 ? 1 : total_bytes / 16;
+  constexpr int n_transactions = total_bytes <= 16 ? 1 : total_bytes / 16;
   constexpr int n_elements_per_transaction = total_bytes <= 16 ? vec_size : 16 / sizeof(T);
 
   // offset between different sections


### PR DESCRIPTION
In iter grouped grid reduction,threads with `TIDy == 0` in each block, write block reduction results to global memory for final grid reduction. 
When vectorized by 8, each thread writes 8 x sizeof(fp32) = 32 bytes, which exceeds the max vect write width of 16 bytes. In current main branch, the write is split into 2 vectoried writes without changing the data layout in global memory. It leads to a problem similar to using AoS. As shown in the figure, to serve these 256 bytes of data, the main branch needs 4 transactions but if we change to the bottom version, only needs 2 transactions.
![image](https://github.com/NVIDIA/Fuser/assets/116412316/acf911af-b96f-49a0-bb78-dba2248e4524)

After this change, the gmem store transaction is reduced but **no apparent influence on performance** since the memory bandwidth is dominated by the loading of the input tensor. The cache also helps the transaction in the approach used in the current main branch. ncu shows the store transactions is reduced by half.
![image](https://github.com/NVIDIA/Fuser/assets/116412316/f0710c82-c850-481c-8473-ba1a3d025941)


