### PR TITLE
ensure coalesced access to shared memory in block reduction

### DIFF
--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -954,6 +954,7 @@ void fillCompileOptions(
     const CompileParams& compile_params,
     std::optional<int64_t> opt_block_size) {
   nvrtc_compile_driver.setOption("--std=c++17");
+  nvrtc_compile_driver.setOption("--generate-line-info");
 
   // Suppress warnings for functions that are defined but unused, since we have
   // many unused functions in the preamble.

--- a/csrc/executor_utils.cpp
+++ b/csrc/executor_utils.cpp
@@ -954,7 +954,6 @@ void fillCompileOptions(
     const CompileParams& compile_params,
     std::optional<int64_t> opt_block_size) {
   nvrtc_compile_driver.setOption("--std=c++17");
-  nvrtc_compile_driver.setOption("--generate-line-info");
 
   // Suppress warnings for functions that are defined but unused, since we have
   // many unused functions in the preamble.

--- a/runtime/block_reduction.cu
+++ b/runtime/block_reduction.cu
@@ -75,6 +75,7 @@ __device__ void blockReduce(
   // column (with the same TIDx) are considered peers of each other. The
   // distance between an element and its nearest peer is blockDim.x.
   constexpr int num_redu_dims = (int)X_REDUCE + (int)Y_REDUCE + (int)Z_REDUCE;
+  constexpr bool xz_reduce = (num_redu_dims == 2 && !Y_REDUCE);
   // reduction in 3 dimensions, XYZ, stride is 1
   unsigned int peer_stride = 1;
   if (num_redu_dims == 1) {
@@ -91,15 +92,15 @@ __device__ void blockReduce(
     // Reduction in 2 dimensions, only one dimension is not reduced, !X, !Y, !Z
     // If !Z_REDUCE, merge XY, reducing neighbor cols, peer_stride is 1
     // If !X_REDUCE, merge ZY, reducing neighbor rows, peer_stride is blockDim.x
-    // If !Y_REDUCE, if blockDim.y == 1, merge XZ, peer_stride is 1, otherwise
-    //               different strides for different reduction stages, change
-    //               smem layout based on reduction_idx and reduction_tid, may
-    //               have stride access and bank conflict, rare case, may happen
-    //               for batch norm doing multiple reductions per block.
+    // If !Y_REDUCE, if blockDim.y == 1, merge XZ, peer_stride is 1.
+    // otherwise, needs carefully calculate offset to the reduction peer:
+    // (1) redu_offset = reduction_tid + tree_fold_factor
+    // (2) idz = redu_offset / blockDim.x
+    // (3) idx = redu_offset % blockDim.x
+    // (4) smem_offset = idx + threadIdx.y * blockDim.x + idz * blockDim.x *
+    // blockDim.y
     if (!Y_REDUCE) {
-      smem_offset = blockDim.y > 1
-          ? reduction_idx * reduction_size + reduction_tid
-          : smem_offset;
+      peer_stride = 1;
     } else {
       peer_stride = !Z_REDUCE ? 1 : blockDim.x;
     }
@@ -111,23 +112,39 @@ __device__ void blockReduce(
   } else {
     shared_mem[smem_offset] = init_val;
   }
-
   block_sync::sync<Aligned>();
+
   // Reduce down to nearest power of 2 for the tree reduction:
   int np2 = 1 << (31 - __clz(reduction_size));
-
   if (reduction_tid < np2 && reduction_tid + np2 < reduction_size) {
-    reduction_op(
-        shared_mem[smem_offset], shared_mem[smem_offset + np2 * peer_stride]);
+    int peer_offset = smem_offset + np2 * peer_stride;
+    if constexpr (xz_reduce) {
+      if (blockDim.y > 1) {
+        int redu_offset = reduction_tid + np2;
+        int idz = redu_offset / blockDim.x;
+        int idx = redu_offset % blockDim.x;
+        peer_offset =
+            idx + threadIdx.y * blockDim.x + idz * blockDim.x * blockDim.y;
+      }
+    }
+    reduction_op(shared_mem[smem_offset], shared_mem[peer_offset]);
   }
   block_sync::sync<Aligned>();
 
   // loop peel the final iteration to save one syncthread for the end
   for (int factor = np2 / 2; factor > 1; factor >>= 1) {
     if (reduction_tid < factor) {
-      reduction_op(
-          shared_mem[smem_offset],
-          shared_mem[smem_offset + factor * peer_stride]);
+      int peer_offset = smem_offset + factor * peer_stride;
+      if constexpr (xz_reduce) {
+        if (blockDim.y > 1) {
+          int redu_offset = reduction_tid + factor;
+          int idz = redu_offset / blockDim.x;
+          int idx = redu_offset % blockDim.x;
+          peer_offset =
+              idx + threadIdx.y * blockDim.x + idz * blockDim.x * blockDim.y;
+        }
+      }
+      reduction_op(shared_mem[smem_offset], shared_mem[peer_offset]);
     }
     block_sync::sync<Aligned>();
   }

--- a/runtime/block_reduction.cu
+++ b/runtime/block_reduction.cu
@@ -48,6 +48,10 @@ __device__ void blockReduce(
       index_utils::maskedOffset<!X_REDUCE, !Y_REDUCE, !Z_REDUCE>(
           threadIdx, blockDim);
 
+  // number of reductions per block
+  unsigned int reduction_num =
+      index_utils::maskedSize<!X_REDUCE, !Y_REDUCE, !Z_REDUCE>(blockDim);
+
   // smem_offset is the offset into shared memory for the current thread.
   // To ensure coalesced access to shared memory, we need to ensure
   // each transaction is accessing a contiguous block of 128 bytes.
@@ -64,6 +68,39 @@ __device__ void blockReduce(
   unsigned int smem_offset = threadIdx.x + threadIdx.y * blockDim.x +
       threadIdx.z * blockDim.x * blockDim.y;
 
+  // The peer stride is the distance between the current element and its
+  // reduction peer, it depends on the reduction dimension.
+  constexpr int num_redu_dims = (int)X_REDUCE + (int)Y_REDUCE + (int)Z_REDUCE;
+  // reduction in 3 dimensions, XYZ, stride is 1
+  unsigned int peer_stride = 1;
+  if (num_redu_dims == 1) {
+    // Reduction only in 1 dimension, X or Y or Z
+    // e.g. inner or outer reduction
+    // If X_REDUCE, reducing in neighbor cols in smem, peer_stride is 1
+    // If Y_REDUCE, reducing in neighbor rows in smem, peer_stride is blockDim.x
+    // If Z_REDUCE, reducing in neighbor planes in smem, peer_stride is
+    // blockDim.x * blockDim.y
+    peer_stride = X_REDUCE ? 1
+        : Y_REDUCE         ? blockDim.x
+                           : blockDim.x * blockDim.y;
+  } else if (num_redu_dims == 2) {
+    // Reduction in 2 dimensions, only one dimension is not reduced, !X, !Y, !Z
+    // If !Z_REDUCE, merge XY, reducing neighbor cols, peer_stride is 1
+    // If !X_REDUCE, merge ZY, reducing neighbor rows, peer_stride is blockDim.x
+    // If !Y_REDUCE, if blockDim.y == 1, merge XZ, peer_stride is 1, otherwise
+    //               different strides for different reduction stages, change
+    //               smem layout based on reduction_idx and reduction_tid, may
+    //               have stride access and bank conflict, rare case, may happen
+    //               for batch norm doing multiple reductions per block.
+    if (!Y_REDUCE) {
+      smem_offset = blockDim.y > 1
+          ? reduction_idx * reduction_size + reduction_tid
+          : smem_offset;
+    } else {
+      peer_stride = !Z_REDUCE ? 1 : blockDim.x;
+    }
+  }
+
   // Initialize shared memory
   if (read_pred) {
     shared_mem[smem_offset] = inp_val;
@@ -76,14 +113,17 @@ __device__ void blockReduce(
   int np2 = 1 << (31 - __clz(reduction_size));
 
   if (reduction_tid < np2 && reduction_tid + np2 < reduction_size) {
-    reduction_op(shared_mem[smem_offset], shared_mem[smem_offset + np2]);
+    reduction_op(
+        shared_mem[smem_offset], shared_mem[smem_offset + np2 * peer_stride]);
   }
   block_sync::sync<Aligned>();
 
   // loop peel the final iteration to save one syncthread for the end
   for (int factor = np2 / 2; factor > 1; factor >>= 1) {
     if (reduction_tid < factor) {
-      reduction_op(shared_mem[smem_offset], shared_mem[smem_offset + factor]);
+      reduction_op(
+          shared_mem[smem_offset],
+          shared_mem[smem_offset + factor * peer_stride]);
     }
     block_sync::sync<Aligned>();
   }
@@ -92,7 +132,7 @@ __device__ void blockReduce(
     T result = out;
     reduction_op(result, shared_mem[smem_offset]);
     if (reduction_size > 1) {
-      reduction_op(result, shared_mem[smem_offset + 1]);
+      reduction_op(result, shared_mem[smem_offset + peer_stride]);
     }
     out = result;
   }

--- a/runtime/block_reduction.cu
+++ b/runtime/block_reduction.cu
@@ -68,8 +68,12 @@ __device__ void blockReduce(
   unsigned int smem_offset = threadIdx.x + threadIdx.y * blockDim.x +
       threadIdx.z * blockDim.x * blockDim.y;
 
-  // The peer stride is the distance between the current element and its
-  // reduction peer, it depends on the reduction dimension.
+  // The peer stride represents the distance between the current element and its
+  // nearest reduction peer. It depends on the reduction dimension. A reduction
+  // peer refers to elements that belong to the same reduction segment. For
+  // example, if the reduction is across TIDy, all the elements in the same
+  // column (with the same TIDx) are considered peers of each other. The
+  // distance between an element and its nearest peer is blockDim.x.
   constexpr int num_redu_dims = (int)X_REDUCE + (int)Y_REDUCE + (int)Z_REDUCE;
   // reduction in 3 dimensions, XYZ, stride is 1
   unsigned int peer_stride = 1;

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -8160,10 +8160,13 @@ TEST_F(NVFuserTest, BlockReduction3D) {
     testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
   };
   // tested locally with i,j,k +=2, change to i,j,k *=2 to reduce CI time.
+  auto properties = at::cuda::getDeviceProperties(
+      c10::Device(c10::DeviceType::CUDA, 0).index());
+  int max_threads_per_blk = (int)properties->maxThreadsPerBlock;  
   for (int i = 2; i <= 32; i *= 2) {
     for (int j = 2; j <= 32; j *= 2) {
       for (int k = 2; k <= 32; k *= 2) {
-        if (i * j * k <= 1024) {
+        if (i * j * k <= max_threads_per_blk) {
           test(i, j, k);
         }
       }

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -8162,7 +8162,7 @@ TEST_F(NVFuserTest, BlockReduction3D) {
   // tested locally with i,j,k +=2, change to i,j,k *=2 to reduce CI time.
   auto properties = at::cuda::getDeviceProperties(
       c10::Device(c10::DeviceType::CUDA, 0).index());
-  int max_threads_per_blk = (int)properties->maxThreadsPerBlock;  
+  int max_threads_per_blk = (int)properties->maxThreadsPerBlock;
   for (int i = 2; i <= 32; i *= 2) {
     for (int j = 2; j <= 32; j *= 2) {
       for (int k = 2; k <= 32; k *= 2) {

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -8134,34 +8134,41 @@ TEST_F(NVFuserTest, TemplateFunctionTypeMismatch) {
 
 // Test block reduction across TIDx and TIDz
 TEST_F(NVFuserTest, BlockReduction3D) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  auto test = [](const int tidx, const int tidy, const int tidz) {
+    Fusion fusion;
+    FusionGuard fg(&fusion);
+    std::vector<int64_t> shape({tidz, tidy, tidx});
 
-  const int tidx = 8;
-  const int tidy = 4;
-  const int tidz = 2;
-  std::vector<int64_t> shape({tidz, tidy, tidx});
+    auto tv0 = makeConcreteTensor(shape);
+    fusion.addInput(tv0);
+    auto tv1 = sum(tv0, {0, 2});
+    fusion.addOutput(tv1);
 
-  auto tv0 = makeConcreteTensor(shape);
-  fusion.addInput(tv0);
-  auto tv1 = sum(tv0, {0, 2});
-  fusion.addOutput(tv1);
+    tv1->axis(0)->parallelize(ParallelType::TIDz);
+    tv1->axis(1)->parallelize(ParallelType::TIDy);
+    tv1->axis(2)->parallelize(ParallelType::TIDx);
 
+    scheduler_utils::parallelizeAllLike(tv1);
 
-  tv1->axis(0)->parallelize(ParallelType::TIDz);
-  tv1->axis(1)->parallelize(ParallelType::TIDy);
-  tv1->axis(2)->parallelize(ParallelType::TIDx);
+    auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+    at::Tensor t0 = at::randn(shape, options);
 
-  scheduler_utils::parallelizeAllLike(tv1);
-
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor t0 = at::randn(shape, options);
-
-  FusionExecutor fe;
-  fe.compileFusion(&fusion, {t0});
-  auto cg_outputs = fe.runFusion({t0});
-  auto ref = t0.sum(0).sum(-1);
-  testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
+    FusionExecutor fe;
+    fe.compileFusion(&fusion, {t0});
+    auto cg_outputs = fe.runFusion({t0});
+    auto ref = t0.sum(0).sum(-1);
+    testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
+  };
+  // tested locally with i,j,k +=2, change to i,j,k *=2 to reduce CI time.
+  for (int i = 2; i <= 32; i *= 2) {
+    for (int j = 2; j <= 32; j *= 2) {
+      for (int k = 2; k <= 32; k *= 2) {
+        if (i * j * k <= 1024) {
+          test(i, j, k);
+        }
+      }
+    }
+  }
 }
 
 // Test file size should be up to 10K LoC. Create a new file for more tests.


### PR DESCRIPTION
**Issue:**  smem_offset is the offset into shared memory for the current thread. It is calculated as:
` offset = reduction_idx * reduction_size + reduction_tid`.
For outer reduction where TIDy is in the reduction dimension and TIDx is in the iteration dimension and TIDz is not used.
We have `reduction_tid = TIDy` and `reduction_idx = TIDx`. The offset leads to stride access to shared memory since it equivalent to: `offset = TIDx * blockDim.y + TIDy`
**Fix:** To avoid this, we should use the offset based on the indexing of threads within a block.
`offset= threadIdx.x + threadIdx.y * blockDim.x + threadIdx.z * blockDim.x * blockDim.y;`
After this change, the index of the reduction peer element is no longer a simple offset with a stride of 1, it depends on the reduction dim. See code change for details. 

**Results:** 
(1) removes bank conflicts. baseline is main branch, 99% of bank conflicts are removed, smem access efficiency
 `requests  /  wave fronts= 16000 / 16189 = 99%`
![image](https://github.com/NVIDIA/Fuser/assets/116412316/130dbc82-f09b-410d-a573-ee2105ffb68a)
(2) This fix achieved 10% performance increase for outer reduction with small inputs compared with main branch. For large inputs, the iter grouped version is used, will be addressed in another PR.
![image](https://github.com/NVIDIA/Fuser/assets/116412316/8fdcaf6d-f3c8-4346-82e9-263d66347db5)


