### PR TITLE
Revert "Remove NVFUSER_DISTRIBUTED.  (#2155)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,13 @@ set(NVFUSER_THIRD_PARTY_DIR "${NVFUSER_ROOT}/third_party")
 option(NVFUSER_STANDALONE_BUILD_WITH_UCC "" OFF)
 option(NVFUSER_BUILD_WITH_ASAN "Build nvFuser with asan" OFF)
 
+include(CMakeDependentOption)
+cmake_dependent_option(NVFUSER_DISTRIBUTED "" ON "USE_DISTRIBUTED" OFF)
+if (NVFUSER_DISTRIBUTED)
+  add_compile_definitions(NVFUSER_DISTRIBUTED)
+endif()
+message(STATUS "Setting NVFUSER_DISTRIBUTED=${NVFUSER_DISTRIBUTED}")
+
 # We try to update which C++ standard we use together in lockstep across all
 # built libraries, and these variables control which that is. Generally we are
 # on C++20, but we still support a version of CUDA (11) that does not recognize
@@ -763,6 +770,7 @@ message(STATUS "******** Nvfuser configuration summary ********")
 message(STATUS "  UCC_FOUND: ${UCC_FOUND}")
 message(STATUS "  NVFUSER_STANDALONE_BUILD_WITH_UCC  : ${NVFUSER_STANDALONE_BUILD_WITH_UCC}")
 message(STATUS "  NVFUSER_BUILD_WITH_ASAN            : ${NVFUSER_BUILD_WITH_ASAN}")
+message(STATUS "  NVFUSER_DISTRIBUTED                : ${NVFUSER_DISTRIBUTED}")
 message(STATUS "  NVFUSER_CPP_STANDARD               : ${NVFUSER_CPP_STANDARD}")
 
 if(NVFUSER_STANDALONE_BUILD_WITH_UCC)

--- a/csrc/multidevice/c10d_mock.h
+++ b/csrc/multidevice/c10d_mock.h
@@ -1,0 +1,134 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <ATen/core/TensorBody.h>
+#include <ATen/core/ivalue.h>
+#include <c10/util/intrusive_ptr.h>
+
+namespace c10d {
+class Work : public torch::CustomClassHolder {
+ public:
+  void wait() {}
+};
+
+struct ReduceOp : torch::CustomClassHolder {
+  enum RedOpType {
+    SUM,
+    AVG,
+    PRODUCT,
+    MIN,
+    MAX,
+    BAND,
+    BOR,
+    BXOR,
+    UNUSED,
+  };
+
+  ReduceOp() = default;
+  ReduceOp(RedOpType op) : op_(op) {}
+
+  RedOpType op_ = UNUSED;
+};
+
+struct ReduceScatterOptions {
+  ReduceOp reduceOp = ReduceOp::UNUSED;
+};
+
+struct ScatterOptions {
+  int64_t rootRank = 0;
+};
+
+struct AllgatherOptions {};
+
+struct GatherOptions {
+  int64_t rootRank = 0;
+};
+
+struct BroadcastOptions {
+  int64_t rootRank = 0;
+};
+
+struct AllreduceOptions {
+  ReduceOp reduceOp = ReduceOp::UNUSED;
+};
+
+struct ReduceOptions {
+  ReduceOp reduceOp = ReduceOp::UNUSED;
+  int64_t rootRank = 0;
+};
+
+class Backend : public torch::CustomClassHolder {
+ public:
+  c10::intrusive_ptr<Work> barrier() {
+    return c10::make_intrusive<Work>();
+  }
+
+  c10::intrusive_ptr<Work> send(
+      std::vector<at::Tensor>& tensors,
+      int dstRank,
+      int tag) {
+    return c10::make_intrusive<Work>();
+  }
+
+  c10::intrusive_ptr<Work> recv(
+      std::vector<at::Tensor>& tensors,
+      int srcRank,
+      int tag) {
+    return c10::make_intrusive<Work>();
+  }
+
+  c10::intrusive_ptr<Work> allgather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllgatherOptions& opts = AllgatherOptions()) {
+    return c10::make_intrusive<Work>();
+  }
+
+  c10::intrusive_ptr<Work> gather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const GatherOptions& opts = GatherOptions()) {
+    return c10::make_intrusive<Work>();
+  }
+
+  c10::intrusive_ptr<Work> reduce_scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) {
+    return c10::make_intrusive<Work>();
+  }
+  c10::intrusive_ptr<Work> scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ScatterOptions& opts = ScatterOptions()) {
+    return c10::make_intrusive<Work>();
+  }
+
+  c10::intrusive_ptr<Work> broadcast(
+      std::vector<at::Tensor>& tensors,
+      const BroadcastOptions& opts = BroadcastOptions()) {
+    return c10::make_intrusive<Work>();
+  }
+
+  c10::intrusive_ptr<Work> allreduce(
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) {
+    return c10::make_intrusive<Work>();
+  }
+
+  c10::intrusive_ptr<Work> reduce(
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) {
+    return c10::make_intrusive<Work>();
+  }
+};
+
+class TCPStore : public torch::CustomClassHolder {};
+
+} // namespace c10d

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -6,7 +6,7 @@
  */
 // clang-format on
 #include <multidevice/communication.h>
-#if defined(USE_C10D_NCCL)
+#if defined(NVFUSER_DISTRIBUTED) && defined(USE_C10D_NCCL)
 #include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
 #endif
 #include <utils.h>
@@ -229,7 +229,7 @@ c10::intrusive_ptr<c10d::Work> Reduce::post(
   c10d::ReduceOptions options = {
       .reduceOp = params_.redOp, .rootRank = root_relative_index_};
   auto team_backend = comm.getBackendForTeam(params_.team, backend);
-#if defined(USE_C10D_NCCL)
+#if defined(NVFUSER_DISTRIBUTED) && defined(USE_C10D_NCCL)
   auto nccl_backend = dynamic_cast<c10d::ProcessGroupNCCL*>(team_backend.get());
   if (nccl_backend) {
 #if NVF_TORCH_VERSION_NO_LESS(2, 3, 0)

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -9,7 +9,11 @@
 
 #include <multidevice/communicator.h>
 #include <multidevice/multidevice.h>
+#ifdef NVFUSER_DISTRIBUTED
 #include <torch/csrc/distributed/c10d/Types.hpp>
+#else
+#include <multidevice/c10d_mock.h>
+#endif
 #include <type.h>
 #include <visibility.h>
 

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -10,25 +10,32 @@
 #include <ATen/core/TensorBody.h>
 #include <ATen/core/ivalue.h>
 #include <c10/util/intrusive_ptr.h>
-#include <torch/csrc/distributed/c10d/Backend.hpp>
-#include <torch/csrc/distributed/c10d/TCPStore.hpp>
-#include <torch/csrc/distributed/c10d/Work.hpp>
 
 #include <exceptions.h>
 #include <multidevice/multidevice.h>
+#ifdef NVFUSER_DISTRIBUTED
+#include <torch/csrc/distributed/c10d/Backend.hpp>
+#include <torch/csrc/distributed/c10d/TCPStore.hpp>
+#include <torch/csrc/distributed/c10d/Work.hpp>
+#else
+#include <multidevice/c10d_mock.h>
+#endif
 #include <visibility.h>
 
 namespace nvfuser {
 
-// This file implements the class Communicator which sets up the inter-process
-// Backend. This class contains inter-process information, such as the rank, the
-// world size, as well as the Process Group that can be called to perform
-// inter-process communications.
-//
-// Each process is associated with a unique deviceId and device. The actual MPI
-// rank remains private to the class and should not be used by the user. The
-// communicator class holds privately the mappings ranks <-> device IDs <->
-// device.
+/*
+   This file implements the class Communicator which sets up the inter-process
+   Backend. This class contains inter-process information, such as the rank, the
+   world size, as well as the Process Group that can be called to perform
+   inter-process communications.
+
+   Each process is associated with a unique deviceId and device. The actual MPI
+   rank remains private to the class and should not be used by the user. The
+   communicator class holds privately the mappings ranks <-> device IDs <->
+   device.
+
+*/
 
 using RankType = DeviceIdxType;
 

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -20,6 +20,14 @@
 
 namespace nvfuser {
 
+NVF_API bool distributedEnabled() {
+#ifdef NVFUSER_DISTRIBUTED
+  return true;
+#else
+  return false;
+#endif
+}
+
 namespace {
 
 std::unordered_set<IterDomain*> getShardedIterDomains(TensorView* tv) {

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -15,6 +15,9 @@
 
 namespace nvfuser {
 
+// Returns true iff nvFuser was compiled with distributed APIs enabled.
+NVF_API bool distributedEnabled();
+
 // Returns whether a TensorView has a non-reduction axis parallelized Didx
 // Checks that the other non-reduction axis are not parallelized on Didx
 NVF_API bool isSharded(TensorView*);

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@
 #   --build-with-ucc
 #     Build nvfuser with UCC support. You may need to specify environment variables of UCC_HOME, UCC_DIR, UCX_HOME, UCX_DIR.
 #
+#   --build-without-distributed
+#     Build nvfuser without multidevice support
+#
 #   --debug
 #     Building nvfuser in debug mode
 #
@@ -71,6 +74,7 @@ NO_BENCHMARK = False
 NO_NINJA = False
 BUILD_WITH_UCC = False
 BUILD_WITH_ASAN = False
+BUILD_WITHOUT_DISTRIBUTED = False
 OVERWRITE_VERSION = False
 VERSION_TAG = None
 BUILD_TYPE = "Release"
@@ -101,6 +105,9 @@ for i, arg in enumerate(sys.argv):
         continue
     if arg == "--build-with-asan":
         BUILD_WITH_ASAN = True
+        continue
+    if arg == "--build-without-distributed":
+        BUILD_WITHOUT_DISTRIBUTED = True
         continue
     if arg == "--debug":
         BUILD_TYPE = "Debug"
@@ -299,10 +306,7 @@ def cmake(install_prefix: str = "./nvfuser"):
 
     logger.setLevel(logger_level)
 
-    if not get_pytorch_use_distributed():
-        raise RuntimeError(
-            "nvFuser requires PyTorch to be built with USE_DISTRIBUTED on."
-        )
+    pytorch_use_distributed = get_pytorch_use_distributed()
 
     # generate cmake directory
     cmd_str = [
@@ -311,6 +315,7 @@ def cmake(install_prefix: str = "./nvfuser"):
         "-DCMAKE_BUILD_TYPE=" + BUILD_TYPE,
         f"-DCMAKE_INSTALL_PREFIX={install_prefix}",
         f"-DNVFUSER_CPP_STANDARD={CPP_STANDARD}",
+        f"-DUSE_DISTRIBUTED={pytorch_use_distributed}",
         "-B",
         cmake_build_dir,
     ]
@@ -328,6 +333,8 @@ def cmake(install_prefix: str = "./nvfuser"):
         cmd_str.append("-DBUILD_NVFUSER_BENCHMARK=ON")
     if BUILD_WITH_ASAN:
         cmd_str.append("-DNVFUSER_BUILD_WITH_ASAN=ON")
+    if BUILD_WITHOUT_DISTRIBUTED:
+        cmd_str.append("-DNVFUSER_DISTRIBUTED=OFF")
     cmd_str.append(".")
 
     print(f"Configuring CMake with {' '.join(cmd_str)}")

--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -42,7 +42,8 @@ using namespace torch::jit::fuser::cuda;
 using namespace at::indexing;
 
 // To run the following tests on several devices, pytorch must be installed with
-// the flag USE_DISTRIBUTED=1 and nccl support. Then, on a node with at least 6
+// the flag USE_DISTRIBUTED=1 and nccl support. With that, nvFuser is built by
+// default with NVFUSER_DISTRIBUTED defined. Then, on a node with at least 6
 // GPUs, run the test using mpirun: `mpirun -np 6 build/test_multidevice
 // --gtest_filter=PipelineTestTwoStages*`.
 

--- a/tests/cpp/test_resharding.cpp
+++ b/tests/cpp/test_resharding.cpp
@@ -320,6 +320,9 @@ TEST_F(ReshardingTest, InsertShardedAxisReordering) {
 }
 
 TEST_P(ReshardingTest, Insert) {
+  if (!distributedEnabled()) { // Test only works with distributed
+    GTEST_SKIP() << "Requires distributed API";
+  }
   auto
       [mesh0,
        mesh1,

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
-import ast
 import subprocess
 import sys
 from pathlib import Path
@@ -31,32 +30,35 @@ def get_version() -> str:
 
 
 def get_pytorch_cmake_prefix():
+    from subprocess import Popen, PIPE
+
     # need to do this in a separate process so we are not going to delete nvfuser library while it's loaded by torch
-    process_torch_prefix = subprocess.Popen(
+    process_torch_prefix = Popen(
         [
             sys.executable,
             "-c",
             "import torch.utils; print(torch.utils.cmake_prefix_path)",
         ],
-        stdout=subprocess.PIPE,
+        stdout=PIPE,
     )
     stdout_msg, error_msg = process_torch_prefix.communicate()
     return stdout_msg.decode("utf-8").rstrip("\n")
 
 
-def get_pytorch_use_distributed() -> bool:
+def get_pytorch_use_distributed():
+    from subprocess import Popen, PIPE
+
     # need to do this in a separate process so we are not going to delete nvfuser library while it's loaded by torch
-    process_torch_prefix = subprocess.Popen(
+    process_torch_prefix = Popen(
         [
             sys.executable,
             "-c",
             "import torch; print(torch._C._has_distributed())",
         ],
-        stdout=subprocess.PIPE,
+        stdout=PIPE,
     )
-    stdout_msg, _ = process_torch_prefix.communicate()
-    stdout_msg = stdout_msg.decode("utf-8").rstrip("\n")
-    return ast.literal_eval(stdout_msg)
+    stdout_msg, error_msg = process_torch_prefix.communicate()
+    return stdout_msg.decode("utf-8").rstrip("\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR reverts #2155.

The reason for that is we are hitting the following error on Jetson:
```
Traceback (most recent call last):
  File "/opt/pytorch/fuser/setup.py", line 423, in <module>
    main()
  File "/opt/pytorch/fuser/setup.py", line 365, in main
    cmake()
  File "/opt/pytorch/fuser/setup.py", line 303, in cmake
    raise RuntimeError(
RuntimeError: nvFuser requires PyTorch to be built with USE_DISTRIBUTED on.
```

cc @wujingyue @xwang233 
