### PR TITLE
Temporary hopper case for getMmaOp

### DIFF
--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -59,6 +59,7 @@ inline std::optional<MmaMacro> getMmaOp(
     case 80:
     case 86:
     case 89:
+    case 90: // NOTE: temp use ampere matmul for hopper
       return (use_small_n) ? MacroType::Ampere_16_8_16
                            : MacroType::Ampere_16_16_16;
     default:


### PR DESCRIPTION
Temporarily have Hopper use Ampere matmul schedules in getMmaOp. 
This is so that distributed matmul tests can pass CI on H100s. 