### PR TITLE
Skip tests using FusionProfiler when compute-sanitizer is used

### DIFF
--- a/csrc/sys_utils.cpp
+++ b/csrc/sys_utils.cpp
@@ -192,7 +192,7 @@ bool detectComputeSanitizer() {
 
 } // namespace nvfuser
 
-#else
+#else // #if defined(__linux__)
 
 namespace nvfuser {
 
@@ -220,4 +220,4 @@ bool detectComputeSanitizer() {
 
 } // namespace nvfuser
 
-#endif
+#endif // #if defined(__linux__)

--- a/csrc/sys_utils.cpp
+++ b/csrc/sys_utils.cpp
@@ -5,6 +5,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+// dl_iterate_phdr is only defined when _GNU_SOURCE is defined. The
+// macro needs to be defined before any header file is included. See
+// the man page for more info.
+#define _GNU_SOURCE
+#endif
+
 #include <exceptions.h>
 #include <executor_utils.h>
 #include <sys_utils.h>
@@ -18,16 +25,11 @@
 #include <vector>
 
 #include <dlfcn.h>
+#include <link.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <cstdio>
 #include <cstdlib>
-// dl_iterate_phdr is only defined when _GNU_SOURCE is defined. See
-// the man page for more info.
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-#include <link.h>
 
 namespace nvfuser {
 

--- a/csrc/sys_utils.cpp
+++ b/csrc/sys_utils.cpp
@@ -22,6 +22,8 @@
 #include <unistd.h>
 #include <cstdio>
 #include <cstdlib>
+// dl_iterate_phdr is only defined when _GNU_SOURCE is defined. See
+// the man page for more info.
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif

--- a/csrc/sys_utils.cpp
+++ b/csrc/sys_utils.cpp
@@ -185,7 +185,7 @@ int detectComputeSanitizerCallback(
 } // namespace
 
 bool detectComputeSanitizer() {
-  return dl_iterate_phdr(detectComputeSanitizerCallback, NULL) != 0;
+  return dl_iterate_phdr(detectComputeSanitizerCallback, nullptr) != 0;
 }
 
 } // namespace nvfuser

--- a/csrc/sys_utils.cpp
+++ b/csrc/sys_utils.cpp
@@ -177,11 +177,7 @@ int detectComputeSanitizerCallback(
     size_t size,
     void* data) {
   std::string lib_name = info->dlpi_name;
-  if (lib_name.find("compute-sanitizer") != std::string::npos) {
-    return 1;
-  } else {
-    return 0;
-  }
+  return lib_name.find("compute-sanitizer") != std::string::npos;
 }
 
 } // namespace

--- a/csrc/sys_utils.h
+++ b/csrc/sys_utils.h
@@ -34,4 +34,7 @@ class LibraryLoader : public NonCopyable {
   void* handle_ = nullptr;
 };
 
+// Return true if compute-sanitizer is attached
+NVF_API bool detectComputeSanitizer();
+
 } // namespace nvfuser

--- a/csrc/sys_utils.h
+++ b/csrc/sys_utils.h
@@ -35,6 +35,6 @@ class LibraryLoader : public NonCopyable {
 };
 
 // Return true if compute-sanitizer is attached
-NVF_API bool detectComputeSanitizer();
+bool detectComputeSanitizer();
 
 } // namespace nvfuser

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -1111,7 +1111,7 @@ TEST_F(AliasTest, ReuseBufferAliasAcrossSegments) {
 
 TEST_F(AliasTest, AliasOnlyKernelsAreNotLaunched) {
   if (detectComputeSanitizer()) {
-    GTEST_SKIP() << "Skipped as compute-sanitzer conflicts with FusionProfiler";
+    GTEST_SKIP() << "Skipped because compute-sanitizer is detected, which conflicts with FusionProfiler";
   }
 
   ProfilerOptionsGuard options_guard;

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -1111,7 +1111,8 @@ TEST_F(AliasTest, ReuseBufferAliasAcrossSegments) {
 
 TEST_F(AliasTest, AliasOnlyKernelsAreNotLaunched) {
   if (detectComputeSanitizer()) {
-    GTEST_SKIP() << "Skipped because compute-sanitizer is detected, which conflicts with FusionProfiler";
+    GTEST_SKIP()
+        << "Skipped because compute-sanitizer is detected, which conflicts with FusionProfiler";
   }
 
   ProfilerOptionsGuard options_guard;
@@ -1185,7 +1186,8 @@ TEST_F(AliasTest, PerfDebugVerboseWhenSomeKernelsNotLaunched) {
 
 TEST_F(AliasTest, NoKernelsAreLaunched) {
   if (detectComputeSanitizer()) {
-    GTEST_SKIP() << "Skipped as compute-sanitzer conflicts with FusionProfiler";
+    GTEST_SKIP()
+        << "Skipped because compute-sanitizer is detected, which conflicts with FusionProfiler";
   }
 
   ProfilerOptionsGuard option_guard;

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -17,6 +17,7 @@
 #include <ir/utils.h>
 #include <ops/alias.h>
 #include <ops/arith.h>
+#include <sys_utils.h>
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
 
@@ -1109,6 +1110,10 @@ TEST_F(AliasTest, ReuseBufferAliasAcrossSegments) {
 }
 
 TEST_F(AliasTest, AliasOnlyKernelsAreNotLaunched) {
+  if (detectComputeSanitizer()) {
+    GTEST_SKIP() << "Skipped as compute-sanitzer conflicts with FusionProfiler";
+  }
+
   ProfilerOptionsGuard options_guard;
   ProfilerOptionsGuard::getCurOptions().set(ProfilerOption::Enable);
   FusionProfiler::start();
@@ -1179,6 +1184,10 @@ TEST_F(AliasTest, PerfDebugVerboseWhenSomeKernelsNotLaunched) {
 }
 
 TEST_F(AliasTest, NoKernelsAreLaunched) {
+  if (detectComputeSanitizer()) {
+    GTEST_SKIP() << "Skipped as compute-sanitzer conflicts with FusionProfiler";
+  }
+
   ProfilerOptionsGuard option_guard;
   ProfilerOptionsGuard::getCurOptions().set(ProfilerOption::Enable);
   FusionProfiler::start();


### PR DESCRIPTION
`FusionProfiler` and compute-sanitizer both use CUPTI, and running multiple CUPTI tools is not supported. Disabling two tests using FusionProfiler when compute-sanitizer is detected. Since using compute-sanitizer is supplemental and there are only two of affected tests, just disabling seems fine to me.

I didn't know about `dl_iterate_phdr` but just learned from Perplexity. 