### PR TITLE
Support allocation domain in the matmul scheduler

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2481,7 +2481,7 @@ std::string LoadStoreOp::toInlineString(int indent_size) const {
 bool LoadStoreOp::hasInnerTranspose() const {
   if (auto out_tv = dynamic_cast<TensorView*>(out())) {
     return out_tv->hasRFactor() &&
-        out_tv->getRootDomain().back() != out_tv->getRFactorDomain().back();
+        out_tv->getMaybeAllocationDomain().back() != out_tv->getRFactorDomain().back();
   }
   return false;
 }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2480,11 +2480,8 @@ std::string LoadStoreOp::toInlineString(int indent_size) const {
 
 bool LoadStoreOp::hasInnerTranspose() const {
   if (auto out_tv = dynamic_cast<TensorView*>(out())) {
-    auto use_root_or_alloc = out_tv->hasAllocation()
-        ? out_tv->getAllocationDomain()
-        : out_tv->getRootDomain();
     return out_tv->hasRFactor() &&
-        use_root_or_alloc.back() != out_tv->getRFactorDomain().back();
+        out_tv->getRootDomain().back() != out_tv->getRFactorDomain().back();
   }
   return false;
 }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2480,8 +2480,11 @@ std::string LoadStoreOp::toInlineString(int indent_size) const {
 
 bool LoadStoreOp::hasInnerTranspose() const {
   if (auto out_tv = dynamic_cast<TensorView*>(out())) {
+    auto use_root_or_alloc = out_tv->hasAllocation()
+        ? out_tv->getAllocationDomain()
+        : out_tv->getRootDomain();
     return out_tv->hasRFactor() &&
-        out_tv->getMaybeAllocationDomain().back() != out_tv->getRFactorDomain().back();
+        use_root_or_alloc.back() != out_tv->getRFactorDomain().back();
   }
   return false;
 }

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -734,6 +734,13 @@ void scheduleSplitKSum(
   splitk_sum->axis(-1)->parallelize(ParallelType::Vectorize);
 }
 
+bool hasInnerTranspose(TensorView* out_tv) {
+  auto use_root_or_alloc = out_tv->hasAllocation()
+      ? out_tv->getAllocationDomain()
+      : out_tv->getRootDomain();
+  return use_root_or_alloc.back() != out_tv->getMaybeRFactorDomain().back();
+}
+
 } // namespace
 
 void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
@@ -898,7 +905,11 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       ldst->setOpType(LoadStoreOpType::LdMatrix);
     }
   } else {
-    acr = acw_smem->cacheAfter(LoadStoreOpType::LdMatrix);
+    if (hasInnerTranspose(acw_smem)) {
+      acr = acw_smem->cacheAfter(LoadStoreOpType::LdMatrixTranspose);
+    } else {
+      acr = acw_smem->cacheAfter(LoadStoreOpType::LdMatrix);
+    }
   }
   if (auto ldst = dynamic_cast<LoadStoreOp*>(bcw_smem->uses().at(0))) {
     bcr = ldst->out()->as<TensorView>();
@@ -908,7 +919,11 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       ldst->setOpType(LoadStoreOpType::LdMatrix);
     }
   } else {
-    bcr = bcw_smem->cacheAfter(LoadStoreOpType::LdMatrix);
+    if (hasInnerTranspose(bcw_smem)) {
+      bcr = bcw_smem->cacheAfter(LoadStoreOpType::LdMatrixTranspose);
+    } else {
+      bcr = bcw_smem->cacheAfter(LoadStoreOpType::LdMatrix);
+    }
   }
 
   // We remove this test for now and add something if required.

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -734,11 +734,15 @@ void scheduleSplitKSum(
   splitk_sum->axis(-1)->parallelize(ParallelType::Vectorize);
 }
 
-bool hasInnerTranspose(TensorView* out_tv) {
-  auto use_root_or_alloc = out_tv->hasAllocation()
-      ? out_tv->getAllocationDomain()
-      : out_tv->getRootDomain();
-  return use_root_or_alloc.back() != out_tv->getMaybeRFactorDomain().back();
+bool needsTranposedLoad(TensorView* out_tv) {
+  if (out_tv->hasRFactor()) {
+    auto use_root_or_alloc = out_tv->hasAllocation()
+        ? out_tv->getAllocationDomain()
+        : out_tv->getRootDomain();
+    return use_root_or_alloc.back() != out_tv->getRFactorDomain().back();
+  }
+  return out_tv->getRootDomain().back() !=
+      out_tv->getMaybeAllocationDomain().back();
 }
 
 } // namespace
@@ -897,41 +901,20 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   bcw_smem->definition()->as<LoadStoreOp>()->setCacheOp(cache_op_b);
   NVF_ERROR(acw_smem->uses().size() == 1);
   NVF_ERROR(bcw_smem->uses().size() == 1);
-  if (auto ldst = dynamic_cast<LoadStoreOp*>(acw_smem->uses().at(0))) {
-    acr = ldst->out()->as<TensorView>();
-    if (ldst->hasInnerTranspose()) {
-      ldst->setOpType(LoadStoreOpType::LdMatrixTranspose);
-    } else {
-      ldst->setOpType(LoadStoreOpType::LdMatrix);
-    }
-  } else {
-    if (hasInnerTranspose(acw_smem)) {
-      acr = acw_smem->cacheAfter(LoadStoreOpType::LdMatrixTranspose);
-    } else {
-      acr = acw_smem->cacheAfter(LoadStoreOpType::LdMatrix);
-    }
-  }
-  if (auto ldst = dynamic_cast<LoadStoreOp*>(bcw_smem->uses().at(0))) {
-    bcr = ldst->out()->as<TensorView>();
-    if (ldst->hasInnerTranspose()) {
-      ldst->setOpType(LoadStoreOpType::LdMatrixTranspose);
-    } else {
-      ldst->setOpType(LoadStoreOpType::LdMatrix);
-    }
-  } else {
-    if (hasInnerTranspose(bcw_smem)) {
-      bcr = bcw_smem->cacheAfter(LoadStoreOpType::LdMatrixTranspose);
-    } else {
-      bcr = bcw_smem->cacheAfter(LoadStoreOpType::LdMatrix);
-    }
-  }
 
-  // We remove this test for now and add something if required.
-  // For Turing and Ampere, the layout of the MmaOp is always TN
-  // NVF_ERROR(
-  //     mma_layout == MmaLayout::TN,
-  //     "MMAs in Turing and Ampere are TN only, transpose is handled either "
-  //     "via ldmatrix.trans for fp16 or explicitly for other types.");
+  for (auto [tv_smem, tv_r] :
+       {std::make_pair(acw_smem, &acr), std::make_pair(bcw_smem, &bcr)}) {
+    if (auto ldst = dynamic_cast<LoadStoreOp*>(tv_smem->uses().at(0))) {
+      *tv_r = ldst->out()->as<TensorView>();
+      ldst->setOpType(
+          needsTranposedLoad(*tv_r) ? LoadStoreOpType::LdMatrixTranspose
+                                   : LoadStoreOpType::LdMatrix);
+    } else {
+      *tv_r = tv_smem->cacheAfter(
+          needsTranposedLoad(tv_smem) ? LoadStoreOpType::LdMatrixTranspose
+                                      : LoadStoreOpType::LdMatrix);
+    }
+  }
 
   // Make a CTA tile
   // ------------------------------------------------------------------

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -550,7 +550,7 @@ void scheduleProlog(
     shared_mem_tv->promoteReuse();
   }
 
-  mma_utils::orderTiledConcreteIdAsRoot(shared_mem_tv);
+  mma_utils::orderTiledConcreteIdAsMaybeAllocationDomain(shared_mem_tv);
 
   // Swizzle the shared memory data layout
   swizzleSharedMemory(shared_mem_tv);
@@ -790,7 +790,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   const auto mma_layout_opt = mma->layout();
   NVF_ERROR(
       mma_layout_opt.has_value(), "fusion mma op has undefined input layout");
-  const auto mma_layout = mma_layout_opt.value();
+  // const auto mma_layout = mma_layout_opt.value();
   const auto fusion_layout = mma_utils::getMmaLayout(fusion);
   NVF_ERROR(fusion_layout.isValid(), fusion_layout.getErrorMsg());
 
@@ -911,11 +911,12 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
     bcr = bcw_smem->cacheAfter(LoadStoreOpType::LdMatrix);
   }
 
+  // We remove this test for now and add something if required.
   // For Turing and Ampere, the layout of the MmaOp is always TN
-  NVF_ERROR(
-      mma_layout == MmaLayout::TN,
-      "MMAs in Turing and Ampere are TN only, transpose is handled either "
-      "via ldmatrix.trans for fp16 or explicitly for other types.");
+  // NVF_ERROR(
+  //     mma_layout == MmaLayout::TN,
+  //     "MMAs in Turing and Ampere are TN only, transpose is handled either "
+  //     "via ldmatrix.trans for fp16 or explicitly for other types.");
 
   // Make a CTA tile
   // ------------------------------------------------------------------

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -474,7 +474,8 @@ void orderTiledConcreteIdAsMaybeAllocationDomain(TensorView* tv) {
       // Found an innermost id, add them to the
       //  axes to reorder.
       NVF_ERROR(
-          id_to_inner_leaf_pos.insert(std::make_pair(maybe_alloc_domain.value(), i))
+          id_to_inner_leaf_pos
+              .insert(std::make_pair(maybe_alloc_domain.value(), i))
               .second,
           "Multiple \"innermost\" id seen for id :",
           maybe_alloc_domain.value()->toString(),

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -57,11 +57,11 @@ void makeTile(TensorView* tv, std::vector<int64_t> tile_sizes);
 
 //! Order the inner tile dimensions as the original order in
 //!  root domain. Also putting broadcast domains on the left.
-//! Eg. A[I0o,I1o,B2o,I0i,I1i,B2i] (root domain: I1,B,I0)
+//! Eg. A[I0o,I1o,B2o,I0i,I1i,B2i] (maybe allocation domain: I1,B,I0)
 //! -> A[I0o, I1o, B2o, B2i, I1i, I0i]
 //! This is used to facilitate data layout swizzling and
 //!  defining vectorized loads.
-void orderTiledConcreteIdAsRoot(TensorView* tv);
+void orderTiledConcreteIdAsMaybeAllocationDomain(TensorView* tv);
 
 //! Orders the root id ordering of the given tv as
 //! [Device, Batch, Previous Reduction, M, N, K]

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2941,6 +2941,116 @@ TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTranspose) {
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
+TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTransposeWithAllocDomainForA) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
+  const int M = 128, N = 256, K = 512;
+  // const auto layout = MmaLayout::TT;
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
+  tv0->setAllocationDomain({tv0->axis(1), tv0->axis(0)}, true);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+
+  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
+  
+  // tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
+  // [M, N, K]
+  auto tv0b = broadcast(tv0, {false, true, false});
+  auto tv1b = broadcast(tv1t, {true, false, false});
+  // Propagate the allocation domain post-broadcast.
+  // Don't set it in the test, but make this part of the scheduler.
+  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
+
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+
+  fusion->addOutput(tv2);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
+  auto t0 = at::randn({M, K}, options).as_strided({M, K}, {1, M});
+  auto t1 = at::randn({K, N}, options);
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.double_buffer_options.double_buffer_smem_write = true;
+  params.double_buffer_options.double_buffer_smem_read = true;
+  params.double_buffer_options.smem_double_buffer_stage = 4;
+  scheduleMatmul(fusion.get(), params);
+
+  FusionExecutor fe;
+  fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
+TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTransposeWithAllocDomainForAandB) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
+  const int M = 128, N = 256, K = 512;
+  // const auto layout = MmaLayout::TT;
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
+  tv0->setAllocationDomain({tv0->axis(1), tv0->axis(0)}, true);
+  tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+
+  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
+  tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
+  
+  // tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
+  // [M, N, K]
+  auto tv0b = broadcast(tv0, {false, true, false});
+  auto tv1b = broadcast(tv1t, {true, false, false});
+  // Propagate the allocation domain post-broadcast.
+  // Don't set it in the test, but make this part of the scheduler.
+  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
+
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+
+  fusion->addOutput(tv2);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
+  auto t0 = at::randn({M, K}, options).as_strided({M, K}, {1, M});
+  auto t1 = at::randn({K, N}, options).as_strided({K, N}, {1, K});
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.double_buffer_options.double_buffer_smem_write = true;
+  params.double_buffer_options.double_buffer_smem_read = true;
+  params.double_buffer_options.smem_double_buffer_stage = 4;
+  scheduleMatmul(fusion.get(), params);
+
+  FusionExecutor fe;
+  fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD
 
 } // namespace nvfuser

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2852,6 +2852,7 @@ class AllocationDomainTest
 // [M, K] and [K, N], and all possible combinations of allocation domains.
 // Please note that inpout in B is transposed prior to creating a Mma op.
 TEST_P(AllocationDomainTest, BasicMatmul) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   bool a_has_allocation = std::get<0>(GetParam());
   bool b_has_allocation = std::get<0>(GetParam());
 

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2884,6 +2884,7 @@ TEST_P(AllocationDomainTest, BasicMatmul) {
 
     MatmulParams params;
     params.mma_macro = MmaMacro::Ampere_16_8_16;
+    params.supported_vec_size = {8, 8, 4};
     params.tile_sizes = gemm_tile;
     params.async_gmem_load_operands = true;
     params.double_buffer_options.double_buffer_smem_write = true;

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2832,6 +2832,61 @@ TEST_F(MatmulSchedulerTest, DISABLED_RequireExternalPlugin) {
   MatmulParams params;
 }
 
+TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTransposeAndAlloc) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
+  const int M = 128, N = 256, K = 512;
+  // const auto layout = MmaLayout::TT;
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
+  // Input -B.
+  tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+
+  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
+  tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
+  // [M, N, K]
+  auto tv0b = broadcast(tv0, {false, true, false});
+  auto tv1b = broadcast(tv1t, {true, false, false});
+  // Propagate the allocation domain post-broadcast.
+  // Don't set it in the test, but make this part of the scheduler.
+  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
+
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+
+  fusion->addOutput(tv2);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
+  auto t0 = at::randn({M, K}, options);
+  auto t1 = at::randn({K, N}, options);
+  t1 = t1.as_strided(t1.sizes(), {1, K});
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.double_buffer_options.double_buffer_smem_write = true;
+  params.double_buffer_options.double_buffer_smem_read = true;
+  params.double_buffer_options.smem_double_buffer_stage = 4;
+  scheduleMatmul(fusion.get(), params);
+
+  FusionExecutor fe;
+  fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD
 
 } // namespace nvfuser


### PR DESCRIPTION
![image](https://github.com/NVIDIA/Fuser/assets/10635897/5c166046-bf7e-46ca-91e0-4ff6d3e2f45d)






In this discussion when we say the matmul scheduler, we’ll mean the [scheduleMatmul function.](https://github.com/NVIDIA/Fuser/blob/d214286b2e75f59abeba03d5a06ce9fdb93ddc0d/csrc/scheduler/matmul.cpp#L739)

We will also assume that the implementation of the above is tied to the Matmul and Linear Op recently developed. In this note, we’ll focus on the matmul op. 

As shown in the figure above, we will convert the matmul op, which takes in inputs A and B with root domains [M, K] and [M, K] respectively, to a collection of transpose, broadcasts and Mma ops. Please note that the inputs A and B can both have allocation domains (transposed memory layouts - we do not place restrictions on that).

The task at hand focuses on how this collection of ops is handled in the scheduleMatmul function when the inputs have allocation domains. The table below outlines the configuration of inputs A and B we want to support.


<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-87592f69-7fff-92c4-e002-f34db17ce287"><div dir="ltr" style="margin-left:0pt;" align="center">
Root Domain A | Root Domain B | Allocation Domain A | Allocation Domain B
-- | -- | -- | --
[M, K] | [K, N] | [] | []
[M, K] | [K, N] | [] | [N, K]
[M, K] | [K, N] | [K, M] | []
[M, K] | [K, N] | [K, M] | [N, K]

</div></b>




Discussion with @jacobhinkle  and @zasdfgbnm led us to identifying the following issues to get the above cases running:

- Propagate allocation domain from gmem operands to their smem consumers.
   This was solved by Xiang a while back in commit [PR]. 
   (https://github.com/NVIDIA/Fuser/commit/626a405272263978c86f7c4f7d9898d14f494cf4).
- Update mma_utils::orderTiledConcreteIdAsRoot to use allocation domain instead of root.
- Detect transpose properly in scheduleLdMatrix
   This refers to the bit of code [here.](https://github.com/NVIDIA/Fuser/blob/d214286b2e75f59abeba03d5a06ce9fdb93ddc0d/csrc/scheduler/matmul.cpp#L893-L912)
We have to modify how we set LdMatrix vs. LdMatrix based not only on the comparison between rfactorDomain and root domain, but also takes into account the allocation domains of both shared memory or A and B. What I took this to mean is, for the shared memory TV of B, bcw_smem, since it's transposed, we will compare it's rfactor domain and alloction domain or the root domain (if allocation domain isn't there) to decide whether to transpose. And for input A, acw_smem, we'll compare the allocation domain and the root domain to see if we need to transpose. Please correct me if I have this wrong. 
- Update inline_ptx.cpp to detect when to append .trans instead of using a different LoadStoreOpType (optional)
@jacobhinkle  also pointed out that optionally, we may get rid of the enum LdMatrix/LdMatrixTrans and handle the transpose when lowering. 

In this  PR, I prototyped the steps mentioned in the first three bullets above. 
The code here is able to handle all the cases mentioned in the table above.
In a follow-up PR I can handle LdMatrix/LdMatrixTrans.