### PR TITLE
Kill `MmaOp::layout`

### DIFF
--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1645,8 +1645,8 @@ void IndexLowering::handle(const MmaOp* mma) {
   }
   const auto out = lowerDstIndex(
       mma->out(), {}, false, getMmaOutType(mma->out()->as<TensorView>()));
-  auto mma_indexed = IrBuilder::create<MmaOp>(
-      out, a, b, mma->init(), mma->macro());
+  auto mma_indexed =
+      IrBuilder::create<MmaOp>(out, a, b, mma->init(), mma->macro());
   pushBack(mma_indexed);
   GpuLower::current()->propagateExprInfo(mma, back());
   if (mma->isHopper()) {

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1593,7 +1593,7 @@ void IndexLowering::handle(const MmaOp* mma) {
         /*number of core matrices, rounded up to handle padding */
         roundUpToMultiple(inner_size * /*bytes per item*/ 2L,
                           getBytesFromSwizzle(swizzle));
-    if (swizzle == MmaInputSmemSwizzle::None && layout[0] == UnitDim::M_or_N) {
+    if (swizzle == MmaInputSmemSwizzle::None && unitdim_a == UnitDim::M_or_N) {
       // tnspA and tnspB is ignored for NoSwizzle mode
       std::swap(leading_bytes, stride_bytes);
     }
@@ -1625,7 +1625,7 @@ void IndexLowering::handle(const MmaOp* mma) {
         /*number of core matrices, rounded up to handle padding */
         roundUpToMultiple(inner_size * /*bytes per item*/ 2L,
                           getBytesFromSwizzle(swizzle));
-    if (swizzle == MmaInputSmemSwizzle::None && layout[1] == UnitDim::M_or_N) {
+    if (swizzle == MmaInputSmemSwizzle::None && unitdim_b == UnitDim::M_or_N) {
       // tnspA and tnspB is ignored for NoSwizzle mode
       std::swap(leading_bytes, stride_bytes);
     }

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1578,7 +1578,7 @@ void IndexLowering::handle(const MmaOp* mma) {
   constexpr int64_t core_matrix_outer_size = 8;
   Val* a = nullptr;
   Val* b = nullptr;
-  auto layout = lower_utils::getMmaLayout(mma);
+  const auto& [unitdim_a, unitdim_b] = lower_utils::getMmaLayout(mma);
   if (mma->inA()->as<TensorView>()->getMemoryType() == MemoryType::Shared) {
     // TODO: This is a temporary solution and only supports a single tile in
     // smem.
@@ -1588,7 +1588,7 @@ void IndexLowering::handle(const MmaOp* mma) {
     int64_t leading_bytes = core_matrix_outer_size *
         getBytesFromSwizzle(swizzle); // swizzle period in bytes
     int64_t inner_size =
-        layout[0] == UnitDim::K ? getK(mma->macro()) : getM(mma->macro());
+        unitdim_a == UnitDim::K ? getK(mma->macro()) : getM(mma->macro());
     int64_t stride_bytes = core_matrix_outer_size *
         /*number of core matrices, rounded up to handle padding */
         roundUpToMultiple(inner_size * /*bytes per item*/ 2L,
@@ -1620,7 +1620,7 @@ void IndexLowering::handle(const MmaOp* mma) {
     int64_t leading_bytes = core_matrix_outer_size *
         getBytesFromSwizzle(swizzle); // swizzle period in bytes
     int64_t inner_size =
-        layout[1] == UnitDim::K ? getK(mma->macro()) : getN(mma->macro());
+        unitdim_b == UnitDim::K ? getK(mma->macro()) : getN(mma->macro());
     int64_t stride_bytes = core_matrix_outer_size *
         /*number of core matrices, rounded up to handle padding */
         roundUpToMultiple(inner_size * /*bytes per item*/ 2L,

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -221,17 +221,17 @@ class LowerToInlinePtx : public kir::ExprMutator {
         /*scaleD=*/IrBuilder::create<Val>(true),
         /*scaleA=*/IrBuilder::create<Val>(1, DataType::Int32),
         /*scaleB=*/IrBuilder::create<Val>(1, DataType::Int32)};
-    auto layout = *mma->layout();
+    auto layout = lower_utils::getMmaLayout(mma);
     if (a_on_smem) {
       // tnspA
-      if (layout == MmaLayout::TT || layout == MmaLayout::TN) {
+      if (layout[0] == UnitDim::K) {
         inputs.push_back(IrBuilder::create<Val>(0, DataType::Int32));
       } else {
         inputs.push_back(IrBuilder::create<Val>(1, DataType::Int32));
       }
     }
     // tnspB
-    if (layout == MmaLayout::TN || layout == MmaLayout::NN) {
+    if (layout[1] == UnitDim::K) {
       inputs.push_back(IrBuilder::create<Val>(0, DataType::Int32));
     } else {
       inputs.push_back(IrBuilder::create<Val>(1, DataType::Int32));

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -891,12 +891,13 @@ std::array<UnitDim, 2> getMmaLayout(const MmaOp* expr) {
 
   auto out_tv = ir_utils::getTv(expr->out());
   IterDomain* reduction_id = nullptr;
-  for (auto id : out_tv->getLeafDomain()) {
+  for (auto id : out_tv->getMaybeAllocationDomain()) {
     if (id->isReduction()) {
       reduction_id = id;
       break;
     }
   }
+  NVF_ERROR(reduction_id != nullptr);
 
   std::array<TensorView*, 2> inputs = {
       ir_utils::getTv(expr->inA()), ir_utils::getTv(expr->inB())};

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -891,7 +891,7 @@ std::array<UnitDim, 2> getMmaLayout(const MmaOp* expr) {
 
   auto out_tv = ir_utils::getTv(expr->out());
   IterDomain* reduction_id = nullptr;
-  for (auto id : out_tv->getMaybeAllocationDomain()) {
+  for (auto id : out_tv->getRootDomain()) {
     if (id->isReduction()) {
       reduction_id = id;
       break;

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -603,8 +603,7 @@ class ReplaceExprInput : private kir::ExprMutator {
           replaced_inputs->at(node->inA()),
           replaced_inputs->at(node->inB()),
           node->init(),
-          node->macro(),
-          node->layout());
+          node->macro());
       registerReplaceWithPredicate(node, replacement);
     }
   }
@@ -880,6 +879,44 @@ Val* getNumThreadsInTensorView(TensorView* tv) {
     }
   }
   return num_threads;
+}
+
+std::array<UnitDim, 2> getMmaLayout(const MmaOp* expr) {
+  if (isAmpere(expr->macro()) || isTuring(expr->macro())) {
+    return {UnitDim::K, UnitDim::K};
+  }
+  NVF_ERROR(isHopper(expr->macro()));
+
+  std::array<UnitDim, 2> layout;
+
+  auto out_tv = ir_utils::getTv(expr->out());
+  IterDomain* reduction_id = nullptr;
+  for (auto id : out_tv->getLeafDomain()) {
+    if (id->isReduction()) {
+      reduction_id = id;
+      break;
+    }
+  }
+
+  std::array<TensorView*, 2> inputs = {
+      ir_utils::getTv(expr->inA()), ir_utils::getTv(expr->inB())};
+  for (auto i : c10::irange(2)) {
+    auto in_tv = inputs.at(i);
+    if (in_tv->getMemoryType() == MemoryType::Local) {
+      layout[i] = UnitDim::K;
+      continue;
+    }
+    NVF_ERROR(in_tv->getMemoryType() == MemoryType::Shared);
+    auto out2in = PairwiseRootDomainMap(in_tv, out_tv).mapConsumerToProducer();
+    auto reduction_id_in = out2in.at(reduction_id);
+    auto inner_id = in_tv->getMaybeAllocationDomain().back();
+    while (inner_id != reduction_id_in && inner_id->definition() != nullptr) {
+      inner_id = inner_id->definition()->inputs().back()->as<IterDomain>();
+    }
+    layout[i] = inner_id == reduction_id_in ? UnitDim::K : UnitDim::M_or_N;
+  }
+
+  return layout;
 }
 
 } // namespace lower_utils

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -887,6 +887,7 @@ std::array<UnitDim, 2> getMmaLayout(const MmaOp* expr) {
   }
   NVF_ERROR(isHopper(expr->macro()));
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   std::array<UnitDim, 2> layout;
 
   auto out_tv = ir_utils::getTv(expr->out());

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -319,6 +319,7 @@ std::vector<Val*> getFusionOutputsRequiringCodegen(Fusion* fusion);
 //! fusion has blockDim.x = 128, this function will return 3 instead of 128.
 Val* getNumThreadsInTensorView(TensorView* tv);
 
+//! Get the unit dimensions of A and B for the given MmaOp.
 std::array<UnitDim, 2> getMmaLayout(const MmaOp* expr);
 
 } // namespace lower_utils

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -319,6 +319,8 @@ std::vector<Val*> getFusionOutputsRequiringCodegen(Fusion* fusion);
 //! fusion has blockDim.x = 128, this function will return 3 instead of 128.
 Val* getNumThreadsInTensorView(TensorView* tv);
 
+std::array<UnitDim, 2> getMmaLayout(const MmaOp* expr);
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1360,7 +1360,6 @@ class GroupedWelfordOp : public Expr {
 class NVF_API MmaOp : public Expr {
  public:
   using AxesData = std::vector<int64_t>;
-  using MmaLayoutOpt = std::optional<MmaLayout>;
   using Expr::Expr;
 
   MmaOp(IrBuilderPasskey, Val* out, Val* in_a, Val* in_b, Val* init);
@@ -1371,8 +1370,7 @@ class NVF_API MmaOp : public Expr {
       Val* in_a,
       Val* in_b,
       Val* init,
-      const MmaMacro& options,
-      const MmaLayoutOpt& input_layout);
+      const MmaMacro& options);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
@@ -1429,10 +1427,6 @@ class NVF_API MmaOp : public Expr {
 
   void setMacro(MmaMacro options);
 
-  auto layout() const {
-    return attribute<MmaLayoutOpt>(ATTR_POS_INPUT_LAYOUT);
-  }
-
   const auto& mAxes() const {
     return attribute<AxesData>(ATTR_POS_M_AXES);
   }
@@ -1459,7 +1453,6 @@ class NVF_API MmaOp : public Expr {
   static constexpr size_t ATTR_POS_N_AXES = 3;
   static constexpr size_t ATTR_POS_K_AXES = 4;
   static constexpr size_t ATTR_POS_BATCH_AXES = 5;
-  static constexpr size_t ATTR_POS_INPUT_LAYOUT = 6;
 };
 
 //! The semantics are identical to torch.broadcast_to.

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2082,8 +2082,6 @@ MmaOp::MmaOp(
   addDataAttribute(AxesData{});
   // ATTR_POS_BATCH_AXES
   addDataAttribute(AxesData{});
-  // ATTR_POS_INPUT_LAYOUT
-  addDataAttribute(MmaLayoutOpt{});
 
   MmaOpUtils::MmaOpDetails mma_details;
   // Detailed consistency checks for use case with TensorViews as
@@ -2098,7 +2096,6 @@ MmaOp::MmaOp(
   attribute<AxesData>(ATTR_POS_N_AXES) = std::move(mma_details.n_axes);
   attribute<AxesData>(ATTR_POS_K_AXES) = std::move(mma_details.k_axes);
   attribute<AxesData>(ATTR_POS_BATCH_AXES) = std::move(mma_details.batch_axes);
-  attribute<MmaLayoutOpt>(ATTR_POS_INPUT_LAYOUT) = mma_details.input_layout;
 }
 
 MmaOp::MmaOp(
@@ -2107,24 +2104,9 @@ MmaOp::MmaOp(
     Val* in_a,
     Val* in_b,
     Val* init,
-    const MmaMacro& macro,
-    const MmaLayoutOpt& input_layout)
+    const MmaMacro& macro)
     : MmaOp(passkey, out, in_a, in_b, init) {
   attribute<MmaMacro>(ATTR_POS_MACRO) = macro;
-
-  const auto input_layout_ = attribute<MmaLayoutOpt>(ATTR_POS_INPUT_LAYOUT);
-  if (input_layout_.has_value()) {
-    NVF_ERROR(input_layout.has_value());
-    NVF_ERROR(
-        input_layout_.value() == input_layout.value(),
-        "Input layout mismatch, infered attribute (",
-        nvfuser::toString(input_layout_.value()),
-        "), provided attribute (",
-        nvfuser::toString(input_layout.value()),
-        ")");
-  } else {
-    attribute<MmaLayoutOpt>(ATTR_POS_INPUT_LAYOUT) = input_layout;
-  }
 }
 
 std::string MmaOp::toString(int indent_size) const {

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -203,6 +203,7 @@ constexpr MmaMacroEncode::MmaMacroEncode(MmaMacro macro)
 //! TN : M,K X N,K -> M,N
 //! NN : K,M X N,K -> M,N
 enum class MmaLayout { NT = 0, TT, TN, NN };
+enum class UnitDim { K, M_or_N };
 
 //! Utility to annotate which input of mma this option struct describes
 enum class MmaOperand { Accumulator = 0, A, B };

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -203,6 +203,8 @@ constexpr MmaMacroEncode::MmaMacroEncode(MmaMacro macro)
 //! TN : M,K X N,K -> M,N
 //! NN : K,M X N,K -> M,N
 enum class MmaLayout { NT = 0, TT, TN, NN };
+
+//! Indicates which dimension is innermost in the allocation domain of an operand
 enum class UnitDim { K, M_or_N };
 
 //! Utility to annotate which input of mma this option struct describes

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -204,7 +204,8 @@ constexpr MmaMacroEncode::MmaMacroEncode(MmaMacro macro)
 //! NN : K,M X N,K -> M,N
 enum class MmaLayout { NT = 0, TT, TN, NN };
 
-//! Indicates which dimension is innermost in the allocation domain of an operand
+//! Indicates which dimension is innermost in the allocation domain of an
+//! operand
 enum class UnitDim { K, M_or_N };
 
 //! Utility to annotate which input of mma this option struct describes
@@ -281,4 +282,5 @@ NVF_API size_t hash(MmaMacro macro);
 size_t hash(MmaLayout input_layout);
 size_t hash(const GemmTile& tile);
 NVF_API size_t hash(const MatMulTileOptions& opts);
+
 } // namespace nvfuser

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -787,10 +787,6 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
 
   // Collect mma swizzle info
   auto mma = mma_ops.front();
-  const auto mma_layout_opt = mma->layout();
-  NVF_ERROR(
-      mma_layout_opt.has_value(), "fusion mma op has undefined input layout");
-  const auto mma_layout = mma_layout_opt.value();
   const auto fusion_layout = mma_utils::getMmaLayout(fusion);
   NVF_ERROR(fusion_layout.isValid(), fusion_layout.getErrorMsg());
 
@@ -910,12 +906,6 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   } else {
     bcr = bcw_smem->cacheAfter(LoadStoreOpType::LdMatrix);
   }
-
-  // For Turing and Ampere, the layout of the MmaOp is always TN
-  NVF_ERROR(
-      mma_layout == MmaLayout::TN,
-      "MMAs in Turing and Ampere are TN only, transpose is handled either "
-      "via ldmatrix.trans for fp16 or explicitly for other types.");
 
   // Make a CTA tile
   // ------------------------------------------------------------------

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -565,19 +565,6 @@ TensorView* TensorView::merge(int64_t axis_o, int64_t axis_i) {
   return this;
 }
 
-TensorView* TensorView::flatten(int64_t from, int64_t to) {
-  NVF_ERROR(nDims() > 0, "Tried to do flatten on a 0-dim TensorView");
-  from = wrapDim(from);
-  to = wrapDim(to);
-  NVF_CHECK(from <= to, "Invalid flatten range. From: ", from, " To: ", to);
-  int64_t num_merges = to - from;
-  for (auto _ : c10::irange(num_merges)) {
-    (void)_;
-    merge(from);
-  }
-  return this;
-}
-
 TensorView* TensorView::reorder(
     const std::unordered_map<int64_t, int64_t>& old2new_) {
   NVF_ERROR(
@@ -828,8 +815,7 @@ TensorView* TensorView::rFactor(const std::vector<int64_t>& axes) {
         this_mma->inA(),
         this_mma->inB(),
         this_mma->init(),
-        this_mma->macro(),
-        this_mma->layout());
+        this_mma->macro());
 
     // Remaining reduction that can be scheduled cross
     //  warp or cta.

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -565,6 +565,19 @@ TensorView* TensorView::merge(int64_t axis_o, int64_t axis_i) {
   return this;
 }
 
+TensorView* TensorView::flatten(int64_t from, int64_t to) {
+  NVF_ERROR(nDims() > 0, "Tried to do flatten on a 0-dim TensorView");
+  from = wrapDim(from);
+  to = wrapDim(to);
+  NVF_CHECK(from <= to, "Invalid flatten range. From: ", from, " To: ", to);
+  int64_t num_merges = to - from;
+  for (auto _ : c10::irange(num_merges)) {
+    (void)_;
+    merge(from);
+  }
+  return this;
+}
+
 TensorView* TensorView::reorder(
     const std::unordered_map<int64_t, int64_t>& old2new_) {
   NVF_ERROR(

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -156,13 +156,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueBias) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -255,13 +248,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueRelu) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -360,13 +346,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasRelu) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -461,13 +440,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueReluAux) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -574,13 +546,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasReluAux) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -675,13 +640,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueGelu) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -769,13 +727,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueGeluAux) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -876,13 +827,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasGelu) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -991,13 +935,6 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasGeluAux) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -1121,13 +1058,6 @@ TEST_F(MatmulSchedulerTest, BasicMatmulStrictCheckTT) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must be always TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -1186,19 +1116,6 @@ TEST_F(MatmulSchedulerTest, BasicMatmulRelaxedCheck) {
     NVF_CHECK(
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    NVF_CHECK(
-        ir_utils::getOpsOfType<MmaOp>(fusion.get())
-            .front()
-            ->layout()
-            .has_value(),
-        "input layout has not be set for MmaOp");
-    NVF_CHECK(
-        MmaLayout::TN ==
-            ir_utils::getOpsOfType<MmaOp>(fusion.get())
-                .front()
-                ->layout()
-                .value(),
-        "the MmaOp layout of Ampere MMA must be always TN");
 
     const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
     NVF_CHECK(
@@ -1259,13 +1176,6 @@ TEST_F(MatmulSchedulerTest, BasicMatmulInputShuffledTT) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must be always TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -1324,13 +1234,6 @@ TEST_F(MatmulSchedulerTest, EpilogueOutputCast) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -1389,13 +1292,6 @@ TEST_F(MatmulSchedulerTest, EpilogueAlpha) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -1456,13 +1352,6 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaOutputCast) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -1532,13 +1421,6 @@ TEST_F(MatmulSchedulerTest, EpilogueBeta) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -1616,13 +1498,6 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBeta) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -1706,13 +1581,6 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaGeluOutputCast) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -1800,13 +1668,6 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias) {
   NVF_CHECK(
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
-  NVF_CHECK(
-      ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().has_value(),
-      "input layout has not be set for MmaOp");
-  NVF_CHECK(
-      MmaLayout::TN ==
-          ir_utils::getOpsOfType<MmaOp>(fusion.get()).front()->layout().value(),
-      "the MmaOp layout of Ampere MMA must always be TN");
 
   const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
   NVF_CHECK(
@@ -1879,19 +1740,6 @@ TEST_F(MatmulSchedulerTest, StridedBatch) {
     NVF_CHECK(
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    NVF_CHECK(
-        ir_utils::getOpsOfType<MmaOp>(fusion.get())
-            .front()
-            ->layout()
-            .has_value(),
-        "input layout has not be set for MmaOp");
-    NVF_CHECK(
-        MmaLayout::TN ==
-            ir_utils::getOpsOfType<MmaOp>(fusion.get())
-                .front()
-                ->layout()
-                .value(),
-        "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
     NVF_CHECK(
@@ -1967,19 +1815,6 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta) {
     NVF_CHECK(
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    NVF_CHECK(
-        ir_utils::getOpsOfType<MmaOp>(fusion.get())
-            .front()
-            ->layout()
-            .has_value(),
-        "input layout has not be set for MmaOp");
-    NVF_CHECK(
-        MmaLayout::TN ==
-            ir_utils::getOpsOfType<MmaOp>(fusion.get())
-                .front()
-                ->layout()
-                .value(),
-        "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
     NVF_CHECK(
@@ -2068,19 +1903,6 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta) {
     NVF_CHECK(
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    NVF_CHECK(
-        ir_utils::getOpsOfType<MmaOp>(fusion.get())
-            .front()
-            ->layout()
-            .has_value(),
-        "input layout has not be set for MmaOp");
-    NVF_CHECK(
-        MmaLayout::TN ==
-            ir_utils::getOpsOfType<MmaOp>(fusion.get())
-                .front()
-                ->layout()
-                .value(),
-        "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
     NVF_CHECK(
@@ -2157,19 +1979,6 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueBias) {
     NVF_CHECK(
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    NVF_CHECK(
-        ir_utils::getOpsOfType<MmaOp>(fusion.get())
-            .front()
-            ->layout()
-            .has_value(),
-        "input layout has not be set for MmaOp");
-    NVF_CHECK(
-        MmaLayout::TN ==
-            ir_utils::getOpsOfType<MmaOp>(fusion.get())
-                .front()
-                ->layout()
-                .value(),
-        "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
     NVF_CHECK(
@@ -2239,19 +2048,6 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueSingleBias) {
     NVF_CHECK(
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
-    NVF_CHECK(
-        ir_utils::getOpsOfType<MmaOp>(fusion.get())
-            .front()
-            ->layout()
-            .has_value(),
-        "input layout has not be set for MmaOp");
-    NVF_CHECK(
-        MmaLayout::TN ==
-            ir_utils::getOpsOfType<MmaOp>(fusion.get())
-                .front()
-                ->layout()
-                .value(),
-        "the MmaOp layout of Ampere MMA must always be TN");
 
     const auto fusion_layout = mma_utils::getMmaLayout(fusion.get());
     NVF_CHECK(


### PR DESCRIPTION
Besides, using `enum class UnitDim { K, M_or_N };` for representing what is the inner dim is a less confusing term.