### PR TITLE
DeviceMesh helper functions

### DIFF
--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -35,7 +35,7 @@ class DeviceMesh final {
   std::string toString() const;
 
   // returns the number of devices in the mesh
-  int64_t size() {
+  int64_t size() const {
     return vector_.size();
   }
 
@@ -57,6 +57,11 @@ class DeviceMesh final {
       return std::distance(vector_.begin(), it);
     }
     return -1;
+  }
+
+  // Returns the device at a particular index in the mesh
+  DeviceIdxType at(int64_t index) const {
+    return vector_.at(index);
   }
 
   bool operator==(const DeviceMesh& other) const {

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -34,6 +34,11 @@ class DeviceMesh final {
 
   std::string toString() const;
 
+  // returns the number of devices in the mesh
+  int64_t size() {
+    return vector_.size();
+  }
+
   // returns a vector containing the device indices of the mesh
   const auto& vector() const {
     return vector_;
@@ -42,6 +47,17 @@ class DeviceMesh final {
   // returns whether a device is present in the mesh
   bool has(const DeviceIdxType device) const {
     return std::find(vector_.begin(), vector_.end(), device) != vector_.end();
+  }
+
+
+  // returns the index of device in the mesh.
+  // returns -1 if device is not present.
+  int64_t idxOf(const DeviceIdxType device) {
+    auto it = std::find(vector_.begin(), vector_.end(), device);
+    if (it != vector_.end()) {
+      return std::distance(vector_.begin(), it);
+    }
+    return -1;
   }
 
   bool operator==(const DeviceMesh& other) const {

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -49,10 +49,9 @@ class DeviceMesh final {
     return std::find(vector_.begin(), vector_.end(), device) != vector_.end();
   }
 
-
   // returns the index of device in the mesh.
   // returns -1 if device is not present.
-  int64_t idxOf(const DeviceIdxType device) {
+  int64_t idxOf(const DeviceIdxType device) const {
     auto it = std::find(vector_.begin(), vector_.end(), device);
     if (it != vector_.end()) {
       return std::distance(vector_.begin(), it);

--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -52,7 +52,7 @@ void MultiDeviceTest::SetUp() {
   auto sharded_dim = getShardedAxis(tv);
   int i = tv->getDeviceMesh().idxOf(deviceId);
   // TODO: returning slice 0 temporarily when device is not in the mesh.
-  i = (i < 0) : 0 ? i;
+  i = (i < 0) ? 0 : i;
   return tensor.slice(sharded_dim, i, i + 1).contiguous();
 }
 

--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -50,12 +50,9 @@ void MultiDeviceTest::SetUp() {
     return tensor;
   }
   auto sharded_dim = getShardedAxis(tv);
-  int i = 0;
-  const auto& devices = tv->getDeviceMesh().vector();
-  auto it = std::find(devices.begin(), devices.end(), deviceId);
-  if (it != devices.end()) {
-    i = std::distance(devices.begin(), it);
-  }
+  int i = tv->getDeviceMesh().idxOf(deviceId);
+  // TODO: returning slice 0 temporarily when device is not in the mesh.
+  i = (i < 0) : 0 ? i;
   return tensor.slice(sharded_dim, i, i + 1).contiguous();
 }
 

--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -97,7 +97,7 @@ void MultiDeviceTest::SetUp() {
     return tensor;
   }
   auto sharded_dim = getShardedAxis(tv);
-  int i = tv->getDeviceMesh().idxOf(deviceId);
+  auto i = tv->getDeviceMesh().idxOf(deviceId);
   // TODO: returning slice 0 temporarily when device is not in the mesh.
   i = (i < 0) ? 0 : i;
   return tensor.slice(sharded_dim, i, i + 1).contiguous();

--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -163,13 +163,13 @@ TEST_P(PipelineTestTwoStages, Communication) {
 
   std::vector<int64_t> unsharded_input_sizes = {3, 2, 3, 5};
   if (is_stage0_sharded) {
-    unsharded_input_sizes[sharded_dim] = mesh0.vector().size();
+    unsharded_input_sizes[sharded_dim] = mesh0.size();
   }
   if (is_stage1_sharded) {
-    unsharded_input_sizes[sharded_dim] = mesh1.vector().size();
+    unsharded_input_sizes[sharded_dim] = mesh1.size();
     if (do_reduction) {
-      ASSERT_EQ(mesh0.vector().size(), mesh1.vector().size());
-      unsharded_input_sizes[sharded_dim + 1] = mesh1.vector().size();
+      ASSERT_EQ(mesh0.size(), mesh1.size());
+      unsharded_input_sizes[sharded_dim + 1] = mesh1.size();
     }
   }
 


### PR DESCRIPTION
This PR introduces some common convenience helper functions for DeviceMesh include `size`, `at`, etc. so that we rely less on accessing the underlying vector of DeviceIdxType. There are still a few places in `csrc/multidevice/lower_communications.cpp` that access the vector directly. 

Eventually, these helper functions will be parameterized by the axis of the DeviceMesh.