### PR TITLE
Add test that external matmul plugin is loaded properly

### DIFF
--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2376,6 +2376,23 @@ TEST_F(MatmulSchedulerPluginTest, BasicMatmul) {
       executor_cache.fusion(), outputs, {t0, t1}, {tref}, __LINE__, __FILE__);
 }
 
+// This test can be used to check that an external plugin has been loaded. It
+// is DISABLED_ so that the test suite will pass even if the user has not
+// provided a plugin via NVFUSER_MATMUL_HEURISTIC_PLUGIN. To check that a
+// plugin can be loaded properly, invoke the test suite like so:
+//
+//   export NVFUSER_MATMUL_HEURISTIC_PLUGIN=/path/to/plugin.so
+//   build/test_matmul --gtest_also_run_disabled_tests
+//
+TEST_F(MatmulSchedulerTest, DISABLED_RequireExternalPlugin) {
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().unset(DisableOption::MatmulExprEval);
+
+  EXPECT_TRUE(matmul_heuristic_plugin::hasPlugin());
+
+  MatmulParams params;
+}
+
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD
 
 } // namespace nvfuser


### PR DESCRIPTION
This adds a C++ test that checks that an external matmul heuristic plugin is loaded. This is useful in automated jobs where we build a matmul heuristic plugin and run some benchmarks. Without this test it is possible to improperly prepare the environment and wind up running benchmarks with the default core heuristics. Instead we can first run this test and fail the job early if it does not succeed. The test is disabled by default so that it does not cause default builds to fail. To run it use a command sequence like this:
```
export NVFUSER_MATMUL_HEURISTIC_PLUGIN=/path/to/plugin.so
build/test_matmul --gtest_also_run_disabled_tests --gtest_filter='MatmulSchedulerTest.DISABLED_RequireExternalPlugin`
```