### PR TITLE
Generate a DOT representation of fusion transform.

### DIFF
--- a/csrc/ir/graphviz.h
+++ b/csrc/ir/graphviz.h
@@ -113,4 +113,7 @@ class IrGraphGenerator : private OptInConstDispatch {
   ExprColorMap* expr_color_map_ = nullptr;
 };
 
+// Generates a DOT graph representation of fusion transform
+std::string irTransformToDot(Fusion* fusion);
+
 } // namespace nvfuser


### PR DESCRIPTION
This is a simple debugging utility that I started using for IdModel. Thought it may be of useful in general.

I'm not a Graphviz expert but just tried a bunch of things to make it the output look reasonably good to me. Any suggestions would be appreciated.

Here's an example output. The fusion is from one of the reshape shmoo tests.

![transform](https://github.com/NVIDIA/Fuser/assets/363169/ab34c8c5-eff9-47c2-842e-3018627b8837)
