### PR TITLE
Multi-dimensional DeviceMesh

### DIFF
--- a/csrc/multidevice/device_mesh.cpp
+++ b/csrc/multidevice/device_mesh.cpp
@@ -119,7 +119,7 @@ void DeviceMesh::setDevices(std::vector<DeviceIdxType> devices) {
   return DeviceMesh(devices);
 }
 
-/*static*/ DeviceMesh DeviceMesh::createForShape(std::vector<int64_t>& shape) {
+/*static*/ DeviceMesh DeviceMesh::createForShape(std::vector<int64_t> shape) {
   int64_t num_devices = 1;
   for (auto i : c10::irange(shape.size())) {
     num_devices *= shape[i];
@@ -127,17 +127,6 @@ void DeviceMesh::setDevices(std::vector<DeviceIdxType> devices) {
   std::vector<DeviceIdxType> devices(num_devices);
   std::iota(devices.begin(), devices.end(), 0);
   return DeviceMesh(devices, shape);
-}
-
-/*static*/ DeviceMesh DeviceMesh::createForShape(
-    std::initializer_list<int64_t> shape) {
-  int64_t num_devices = 1;
-  for (auto i : c10::irange(shape.size())) {
-    num_devices *= shape[i];
-  }
-  std::vector<DeviceIdxType> devices(num_devices);
-  std::iota(devices.begin(), devices.end(), 0);
-  return DeviceMesh(devices, std::vector<int64_t>(shape));
 }
 
 std::ostream& operator<<(std::ostream& out, const DeviceMesh& mesh) {

--- a/csrc/multidevice/device_mesh.cpp
+++ b/csrc/multidevice/device_mesh.cpp
@@ -7,7 +7,6 @@
 // clang-format on
 
 #include <multidevice/device_mesh.h>
-#include <iostream>
 
 #include <numeric>
 #include <unordered_set>

--- a/csrc/multidevice/device_mesh.cpp
+++ b/csrc/multidevice/device_mesh.cpp
@@ -7,21 +7,98 @@
 // clang-format on
 
 #include <multidevice/device_mesh.h>
+#include <iostream>
 
 #include <numeric>
 #include <unordered_set>
 
 // for operator<<(std::ostream&, const std::vector<T>&)
 #include <c10/util/Logging.h>
+#include <c10/util/irange.h>
 
 namespace nvfuser {
 
-DeviceMesh::DeviceMesh(std::vector<DeviceIdxType> devices) {
+DeviceMesh::DeviceMesh(
+    std::vector<DeviceIdxType> devices,
+    std::vector<int64_t> shape) {
+  if (shape.empty()) {
+    shape_ = {(int64_t)devices.size()};
+  } else {
+    int64_t num_devices = 1;
+    for (auto i : c10::irange(shape.size())) {
+      num_devices *= shape[i];
+    }
+    NVF_ERROR(
+        (int64_t)devices.size() == num_devices,
+        "Specified a list of device with ",
+        devices.size(),
+        " elements ",
+        " but shape contains ",
+        num_devices);
+    shape_ = std::move(shape);
+  }
   setDevices(std::move(devices));
 }
 
 DeviceMesh::DeviceMesh(std::initializer_list<DeviceIdxType> devices) {
   setDevices(std::vector<DeviceIdxType>(devices));
+}
+
+std::vector<int64_t> DeviceMesh::getLocalIndices(
+    const DeviceIdxType device) const {
+  auto global_idx = idxOf(device);
+  if (global_idx == -1) {
+    return {};
+  }
+  std::vector<int64_t> indices(shape_.size());
+  int64_t accumulated_size = 1;
+  for (int64_t i = (int64_t)shape_.size() - 1; i >= 0; i--) {
+    indices[i] = (global_idx / accumulated_size) % shape_[i];
+    accumulated_size *= shape_[i];
+  }
+  return indices;
+}
+
+std::pair<int64_t, int64_t> DeviceMesh::getTeamOffsetStride(
+    int64_t device,
+    int64_t axis) const {
+  int64_t offset = 0;
+  int64_t stride = 1;
+  int64_t accumulated_size = 1;
+  auto indices = getLocalIndices(device);
+  NVF_ERROR(!indices.empty(), "Device is not in DeviceMesh");
+  for (int64_t i = (int64_t)shape_.size() - 1; i >= 0; i--) {
+    if (i > axis) {
+      stride *= shape_[i];
+    }
+    if (i != axis) {
+      offset += indices[i] * accumulated_size;
+    }
+    accumulated_size *= shape_[i];
+  }
+  return std::make_pair(offset, stride);
+}
+
+std::vector<DeviceIdxType> DeviceMesh::getTeam(
+    DeviceIdxType device,
+    int64_t axis) const {
+  NVF_ERROR(
+      axis < (int64_t)shape_.size(),
+      "DeviceMesh has ",
+      shape_.size(),
+      " dimensions, but requesting team for ",
+      axis);
+
+  auto [offset, stride] = getTeamOffsetStride(device, axis);
+  std::vector<DeviceIdxType> team(shape_[axis]);
+  for (auto i : c10::irange(team.size())) {
+    team.at(i) = vector_.at(i * stride + offset);
+  }
+  return team;
+}
+
+DeviceIdxType DeviceMesh::maxDeviceIdx() const {
+  return *std::max_element(vector_.begin(), vector_.end());
 }
 
 void DeviceMesh::setDevices(std::vector<DeviceIdxType> devices) {
@@ -40,6 +117,27 @@ void DeviceMesh::setDevices(std::vector<DeviceIdxType> devices) {
   std::vector<DeviceIdxType> devices(num_devices);
   std::iota(devices.begin(), devices.end(), 0);
   return DeviceMesh(devices);
+}
+
+/*static*/ DeviceMesh DeviceMesh::createForShape(std::vector<int64_t>& shape) {
+  int64_t num_devices = 1;
+  for (auto i : c10::irange(shape.size())) {
+    num_devices *= shape[i];
+  }
+  std::vector<DeviceIdxType> devices(num_devices);
+  std::iota(devices.begin(), devices.end(), 0);
+  return DeviceMesh(devices, shape);
+}
+
+/*static*/ DeviceMesh DeviceMesh::createForShape(
+    std::initializer_list<int64_t> shape) {
+  int64_t num_devices = 1;
+  for (auto i : c10::irange(shape.size())) {
+    num_devices *= shape[i];
+  }
+  std::vector<DeviceIdxType> devices(num_devices);
+  std::iota(devices.begin(), devices.end(), 0);
+  return DeviceMesh(devices, std::vector<int64_t>(shape));
 }
 
 std::ostream& operator<<(std::ostream& out, const DeviceMesh& mesh) {

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -16,8 +16,8 @@
 
 namespace nvfuser {
 
-// DeviceMesh represents a set of (unique) devices arranged in a dense tensor
-// with a concrete shape.
+// DeviceMesh represents a set of (unique) devices arranged as a dense
+// n-dimensional tensor
 class DeviceMesh final {
  public:
   // https://google.github.io/styleguide/cppguide.html#Implicit_Conversions
@@ -76,7 +76,7 @@ class DeviceMesh final {
   }
 
   // Returns the global index of device in the mesh, or -1 if device is not
-  // present.
+  // present
   int64_t idxOf(const DeviceIdxType device) const {
     auto it = std::find(vector_.begin(), vector_.end(), device);
     if (it != vector_.end()) {
@@ -85,7 +85,8 @@ class DeviceMesh final {
     return -1;
   }
 
-  // Returns the indices of a multi-dimensional mesh
+  // Returns the indices of a multi-dimensional mesh, or an empty vector 
+  // if device is not present
   std::vector<int64_t> getLocalIndices(const DeviceIdxType device) const;
 
   // Returns the device at a particular global index in the mesh
@@ -105,7 +106,7 @@ class DeviceMesh final {
   //      [3 4 5]]
   // getTeam(4, 0) = {3, 4, 5}
   // getTeam(4, 1) = {1, 4}
-  // TODO: calculate this once and save it.
+  // TODO: calculate this once and save it
   std::vector<DeviceIdxType> getTeam(DeviceIdxType device, int64_t axis = 0)
       const;
 

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -16,9 +16,8 @@
 
 namespace nvfuser {
 
-// The class DeviceMesh represents a set of (unique) devices on which a Pipeline
-// Stage will be executed. For now, we only support flat meshes, but later we
-// will add support for n-dimensional meshes.
+// DeviceMesh represents a set of (unique) devices arranged in a dense tensor
+// with a concrete shape.
 class DeviceMesh final {
  public:
   // https://google.github.io/styleguide/cppguide.html#Implicit_Conversions
@@ -31,21 +30,40 @@ class DeviceMesh final {
   // There are no such contention for std::initializer_list so I chose to
   // allow implicit conversion for that. This allows users to write `DeviceMesh
   // mesh = {1, 2};`, which is more concise.
-  explicit DeviceMesh(std::vector<DeviceIdxType> devices = {});
+  // When no shape is specified, a 1D DeviceMesh is created by default.
+  explicit DeviceMesh(
+      std::vector<DeviceIdxType> devices = {},
+      std::vector<int64_t> shape = {});
   DeviceMesh(std::initializer_list<DeviceIdxType> devices);
   DeviceMesh(const DeviceMesh&) = default;
   DeviceMesh(DeviceMesh&&) = default;
   DeviceMesh& operator=(const DeviceMesh&) = default;
   DeviceMesh& operator=(DeviceMesh&&) = default;
 
-  // Creates a device mesh of [0 .. num_devices-1]. I didn't make it a
+  // Creates a device mesh of [0 ... num_devices-1]. I didn't make it a
   // constructor because single-element initializer lists would be directed to
   // use that instead of the constructor for vectors.
   static DeviceMesh createForNumDevices(int64_t num_devices);
 
-  // Returns the number of devices in the mesh
+  // Creates a device mesh with the specified shape made of devices from
+  // [0 ... size], where size is the total number of devices specified by the
+  // shape.
+  static DeviceMesh createForShape(std::vector<int64_t>& shape);
+  static DeviceMesh createForShape(std::initializer_list<int64_t> shape);
+
+  // Returns the total number of devices in the mesh
   int64_t size() const {
     return static_cast<int64_t>(vector_.size());
+  }
+
+  // Returns size of an axis in the mesh
+  int64_t size(int64_t axis) {
+    return shape_.at(axis);
+  }
+
+  // Returns the shape of the device mesh
+  const std::vector<int64_t>& shape() const {
+    return shape_;
   }
 
   // Returns a vector containing the device indices of the mesh
@@ -58,7 +76,8 @@ class DeviceMesh final {
     return std::find(vector_.begin(), vector_.end(), device) != vector_.end();
   }
 
-  // Returns the index of device in the mesh, or -1 if device is not present.
+  // Returns the global index of device in the mesh, or -1 if device is not
+  // present.
   int64_t idxOf(const DeviceIdxType device) const {
     auto it = std::find(vector_.begin(), vector_.end(), device);
     if (it != vector_.end()) {
@@ -67,20 +86,41 @@ class DeviceMesh final {
     return -1;
   }
 
-  // Returns the device at a particular index in the mesh
+  // Returns the indices of a multi-dimensional mesh
+  std::vector<int64_t> getLocalIndices(const DeviceIdxType device) const;
+
+  // Returns the device at a particular global index in the mesh
   DeviceIdxType at(int64_t index) const {
     return vector_.at(index);
   }
 
   bool operator==(const DeviceMesh& other) const {
-    return vector_ == other.vector();
+    return vector_ == other.vector() && shape_ == other.shape();
   }
+
+  // Returns the max device index in the DeviceMesh.
+  DeviceIdxType maxDeviceIdx() const;
+
+  // Returns devices of this device's team given which axis of the DeviceMesh
+  // Ex: [[0 1 2]
+  //      [3 4 5]]
+  // getTeam(4, 0) = {3, 4, 5}
+  // getTeam(4, 1) = {1, 4}
+  // TODO: calculate this once and save it.
+  std::vector<DeviceIdxType> getTeam(DeviceIdxType device, int64_t axis = 0)
+      const;
 
  private:
   void setDevices(std::vector<DeviceIdxType> devices);
+  // Calculates offset and stride used to iterate over
+  std::pair<int64_t, int64_t> getTeamOffsetStride(
+      int64_t global_idx,
+      int64_t axis) const;
 
-  // stores the list of device indices
+  // stores the flattened list of device indices
   std::vector<DeviceIdxType> vector_;
+  // stores the shape of the mesh
+  std::vector<int64_t> shape_;
 };
 
 std::ostream& operator<<(std::ostream& out, const DeviceMesh& mesh);

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -48,8 +48,7 @@ class DeviceMesh final {
   // Creates a device mesh with the specified shape made of devices from
   // [0 ... size], where size is the total number of devices specified by the
   // shape.
-  static DeviceMesh createForShape(std::vector<int64_t>& shape);
-  static DeviceMesh createForShape(std::initializer_list<int64_t> shape);
+  static DeviceMesh createForShape(std::vector<int64_t> shape);
 
   // Returns the total number of devices in the mesh
   int64_t size() const {

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -46,8 +46,7 @@ class DeviceMesh final {
   static DeviceMesh createForNumDevices(int64_t num_devices);
 
   // Creates a device mesh with the specified shape made of devices from
-  // [0 ... size], where size is the total number of devices specified by the
-  // shape.
+  // [0 ... size], where size is deduced from the shape.
   static DeviceMesh createForShape(std::vector<int64_t> shape);
 
   // Returns the total number of devices in the mesh
@@ -85,9 +84,9 @@ class DeviceMesh final {
     return -1;
   }
 
-  // Returns the indices of a multi-dimensional mesh, or an empty vector 
+  // Returns the indices of a multi-dimensional mesh, or an empty vector
   // if device is not present
-  std::vector<int64_t> getLocalIndices(const DeviceIdxType device) const;
+  std::vector<int64_t> getIndices(const DeviceIdxType device) const;
 
   // Returns the device at a particular global index in the mesh
   DeviceIdxType at(int64_t index) const {
@@ -101,14 +100,14 @@ class DeviceMesh final {
   // Returns the max device index in the DeviceMesh.
   DeviceIdxType maxDeviceIdx() const;
 
-  // Returns devices of this device's team given which axis of the DeviceMesh
-  // Ex: [[0 1 2]
+  // Returns a device's team for a particular device given an axis of the
+  // DeviceMesh. The team will be the group of devices involved in a
+  // communication (including device). Ex: [[0 1 2]
   //      [3 4 5]]
   // getTeam(4, 0) = {3, 4, 5}
   // getTeam(4, 1) = {1, 4}
   // TODO: calculate this once and save it
-  std::vector<DeviceIdxType> getTeam(DeviceIdxType device, int64_t axis = 0)
-      const;
+  Team getTeam(DeviceIdxType device, int64_t axis = 0) const;
 
  private:
   void setDevices(std::vector<DeviceIdxType> devices);

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -427,9 +427,7 @@ int64_t requestedNumberOfDevices(Fusion* fusion) {
   DeviceIdxType max_index = 0;
   for (auto tv : ir_utils::allTvs(fusion)) {
     if (tv->hasDeviceMesh()) {
-      for (auto d_id : tv->getDeviceMesh().vector()) {
-        max_index = std::max(max_index, d_id);
-      }
+      max_index = std::max(max_index, tv->getDeviceMesh().maxDeviceIdx());
     }
   }
   return static_cast<int64_t>(max_index + 1);

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -50,8 +50,8 @@ TEST_F(ShardingTest, DeviceMesh) {
 
   std::vector<int64_t> local_indices_8 = {1, 1};
   std::vector<int64_t> local_indices_1 = {0, 2};
-  EXPECT_EQ(mesh.getLocalIndices(8), local_indices_8);
-  EXPECT_EQ(mesh.getLocalIndices(1), local_indices_1);
+  EXPECT_EQ(mesh.getIndices(8), local_indices_8);
+  EXPECT_EQ(mesh.getIndices(1), local_indices_1);
 
   std::vector<DeviceIdxType> team_axis1_group0 = {3, 4, 1};
   std::vector<DeviceIdxType> team_axis0_group2 = {1, 2};

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -41,7 +41,7 @@ TEST_F(ShardingTest, IsSharded) {
   EXPECT_ANY_THROW(isSharded(c));
 }
 
-TEST_F(ShardingTest, DeviceMesh2D) {
+TEST_F(ShardingTest, DeviceMesh) {
   DeviceMesh mesh({3, 4, 1, 0, 8, 2}, {2, 3});
   // Sizes are not consistent with number of devices
   EXPECT_ANY_THROW(DeviceMesh({1, 2}, {2, 3}));


### PR DESCRIPTION
Allows DeviceMesh to be multi-dimensional. Devices are represented as a flattened list of device indices and a separate shape. 

Almost all calls to `vector` have been replaced with `getTeam` which returns the team (list of devices) for a device given the DeviceMesh axis. Note that `getTeam` creates a new vector each call which should be cached.