### PR TITLE
Fix: invalid TensorDomain after reordered merge

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3663,9 +3663,14 @@ void TensorDomain::merge(int64_t axis_o, int64_t axis_i) {
 
   IterDomain* merged_id = IterDomain::merge(first, second);
 
-  leaf_domain_.erase(leaf_domain_.begin() + axis_i);
-  leaf_domain_.erase(leaf_domain_.begin() + axis_o);
-  leaf_domain_.insert(leaf_domain_.begin() + axis_o, merged_id);
+  // axis_o is the outer input of this merge but does not
+  // automatically mean it's an outer domain in TensorDomain.
+  auto td_outer_pos = axis_o < axis_i ? axis_o : axis_i;
+  auto td_inner_pos = axis_o < axis_i ? axis_i : axis_o;
+
+  leaf_domain_.erase(leaf_domain_.begin() + td_inner_pos);
+  leaf_domain_.erase(leaf_domain_.begin() + td_outer_pos);
+  leaf_domain_.insert(leaf_domain_.begin() + td_outer_pos, merged_id);
   resetDomains();
 }
 


### PR DESCRIPTION
`TensorDomain::merge(i, j)` used to enforce merging outer and inner domains as the outer and inner input to the `Merge` expr. This changed a while ago to allow reordered merge, but the change was not enough.

This part assumes `axis_i` is larger than `axis_o`, which is not the case when `i` refers to an outer domain like below:

```
  auto tv0 = makeSymbolicTensor(2);
  fusion.addInput(tv0);

  auto tv1 = set(tv0);
  fusion.addOutput(tv1);

  tv1->merge(1, 0);
```