### PR TITLE
Shortest path between ValGroups in ValGraph

### DIFF
--- a/csrc/val_graph_visitor.cpp
+++ b/csrc/val_graph_visitor.cpp
@@ -450,7 +450,7 @@ ExprPath ValGraphBFS::getShortestExprPath() {
   }
 
   // At this point, we have the reverse path, but it may have multiple exprs
-  // that need to be filtered out. Let's say theare are domains 0, 1 and 2, and
+  // that need to be filtered out. Let's say there are domains 0, 1 and 2, and
   // domains 1 and 2 are merged to produce domain 3, and then domains
   // 0 and 3 are merged to produce domain 4.
   //

--- a/csrc/val_graph_visitor.cpp
+++ b/csrc/val_graph_visitor.cpp
@@ -149,4 +149,387 @@ void ValGraphVisitor::traverse() {
   }
 }
 
+std::ostream& operator<<(std::ostream& os, const Direction direction) {
+  switch (direction) {
+    case Direction::Forward:
+      os << "Forward";
+      break;
+    case Direction::Backward:
+      os << "Backward";
+      break;
+    case Direction::Undefined:
+      os << "Undefined";
+      break;
+  }
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const ExprPath& path) {
+  for (const auto& [expr_group, direction] : path) {
+    NVF_ERROR(!expr_group->empty());
+    Expr* expr = expr_group->front();
+    NVF_ERROR(expr != nullptr);
+    os << direction << " " << expr->toString();
+  }
+  return os;
+}
+
+ExprPath ValGraphBFS::getExprsBetween(
+    const ValGraph& graph,
+    const ValGroups& from,
+    const ValGroups& to) {
+  ValGraphBFS bfs(
+      graph,
+      {from.vector().begin(), from.vector().end()},
+      {to.vector().begin(), to.vector().end()});
+
+  bfs.traverse();
+
+  return bfs.getShortestExprPath();
+}
+
+namespace {
+
+std::string toString(const ValGraphBFS::GroupType& g) {
+  if (const ExprGroup* eg = std::get_if<ExprGroup>(&g)) {
+    std::stringstream ss;
+    ss << nvfuser::toString(*eg)
+       << ", input: " << (*eg)->front()->input(0)->name();
+    return ss.str();
+  } else if (const ValGroup* vg = std::get_if<ValGroup>(&g)) {
+    return nvfuser::toString(*vg);
+  } else {
+    NVF_ERROR(false);
+  }
+}
+
+} // namespace
+
+bool ValGraphBFS::allToGroupsVisited() const {
+  return std::all_of(
+      to_groups_.begin(),
+      to_groups_.end(),
+      [&](const GroupType& group) -> bool { return isVisited(group); });
+};
+
+void ValGraphBFS::traverse() {
+  for (const auto& g : from_groups_) {
+    setVisited(g);
+    addNewNeighbors(g);
+  }
+
+  while (!allToGroupsVisited()) {
+    bool something_was_processed = false;
+    std::deque<GroupType> not_ready_;
+    while (!allToGroupsVisited() && !to_visit_.empty()) {
+      const auto g = to_visit_.front();
+      to_visit_.pop_front();
+
+      if (isVisited(g)) {
+        continue;
+      }
+
+      auto ready_direction = isReady(g);
+      if (!ready_direction.has_value()) {
+        // To stop an infinite loop, the not-ready group is not moved
+        // back to the to_visit_ queue but kept in the separate
+        // queue. This way, if all groups in to_visit_ are not ready,
+        // the queue would eventually become empty, which would then
+        // break the inner while loop. The something_was_processed
+        // flag is used to remember if there's any progress.
+        not_ready_.emplace_back(g);
+        continue;
+      }
+
+      // Visit this group and add its neighbors to to_visit if not
+      // visited yet
+      setVisited(g);
+      setPrevGroups(g, *ready_direction);
+      addNewNeighbors(g);
+      something_was_processed = true;
+    }
+
+    // If nothing was processed, break out of the loop
+    if (!something_was_processed) {
+      break;
+    }
+
+    // Something was processed. Redo the traversal.
+    to_visit_.insert(to_visit_.end(), not_ready_.begin(), not_ready_.end());
+  };
+
+  if (!allToGroupsVisited()) {
+    std::stringstream ss;
+    for (const auto& to_group : to_groups_) {
+      if (!isVisited(to_group)) {
+        ss << " " << toString(to_group);
+        if (const ExprGroup* eg = std::get_if<ExprGroup>(&to_group)) {
+          ss << " " << (*eg)->front()->toString();
+        }
+      }
+    }
+    NVF_ERROR(false, "BFS traversal could not visit some nodes: ", ss.str());
+  }
+}
+
+std::optional<std::pair<Direction, std::vector<ValGraphBFS::GroupType>>>
+ValGraphBFS::isReady(const GroupType& group) const {
+  if (const ExprGroup* eg = std::get_if<ExprGroup>(&group)) {
+    return isReady(*eg);
+  } else if (const ValGroup* vg = std::get_if<ValGroup>(&group)) {
+    return isReady(*vg);
+  } else {
+    NVF_ERROR(false);
+  }
+}
+
+std::optional<std::pair<Direction, std::vector<ValGraphBFS::GroupType>>>
+ValGraphBFS::isReady(const ExprGroup& expr_group) const {
+  // Either all inputs or all outputs must have been visited
+  auto inputs = graph_.inputGroups(expr_group);
+  if (!inputs.empty() &&
+      std::all_of(
+          inputs.begin(), inputs.end(), [&](const ValGroup& input) -> bool {
+            return isDependencySatisfied(input);
+          })) {
+    std::vector<GroupType> prev_groups;
+    std::copy_if(
+        inputs.begin(),
+        inputs.end(),
+        std::back_inserter(prev_groups),
+        [&](const ValGroup& input) -> bool { return isVisited(input); });
+    return std::make_pair(Direction::Forward, prev_groups);
+  }
+
+  auto outputs = graph_.outputGroups(expr_group);
+  if (!outputs.empty() &&
+      std::all_of(
+          outputs.begin(), outputs.end(), [&](const ValGroup& output) -> bool {
+            return isDependencySatisfied(output);
+          })) {
+    std::vector<GroupType> prev_groups;
+    std::copy_if(
+        outputs.begin(),
+        outputs.end(),
+        std::back_inserter(prev_groups),
+        [&](const ValGroup& output) -> bool { return isVisited(output); });
+
+    return std::make_pair(Direction::Backward, prev_groups);
+  }
+
+  return std::nullopt;
+}
+
+std::optional<std::pair<Direction, std::vector<ValGraphBFS::GroupType>>>
+ValGraphBFS::isReady(const ValGroup& val_group) const {
+  // In the case of Val, requires one def or use expr.
+  // Check if any use is visited
+  if (!graph_.getUses(val_group).empty()) {
+    auto it = std::find_if(
+        graph_.getUses(val_group).begin(),
+        graph_.getUses(val_group).end(),
+        [&](const ExprGroup& use_eg) -> bool {
+          return isDependencySatisfied(use_eg);
+        });
+    if (it != graph_.getUses(val_group).end()) {
+      return std::make_pair(Direction::Backward, std::vector<GroupType>{*it});
+    }
+  }
+  // Check if all defs are visited
+  if (!graph_.getDefinitions(val_group).empty()) {
+    auto it = std::find_if(
+        graph_.getDefinitions(val_group).begin(),
+        graph_.getDefinitions(val_group).end(),
+        [&](const ExprGroup& def_eg) -> bool {
+          return isDependencySatisfied(def_eg);
+        });
+    if (it != graph_.getDefinitions(val_group).end()) {
+      return std::make_pair(Direction::Forward, std::vector<GroupType>{*it});
+    }
+  }
+
+  return std::nullopt;
+}
+
+bool ValGraphBFS::isDependencySatisfied(const GroupType& group) const {
+  return isVisited(group);
+}
+
+bool ValGraphBFS::isVisited(const GroupType& g) const {
+  return visited_.find(g) != visited_.end();
+}
+
+void ValGraphBFS::setVisited(const GroupType& g) {
+  visited_.emplace(g);
+}
+
+void ValGraphBFS::addNewNeighbors(const GroupType& g) {
+  auto add_to_visit_list = [&](const GroupType& g) -> void {
+    if (isVisited(g)) {
+      return;
+    }
+    to_visit_.emplace_back(g);
+  };
+
+  if (const ExprGroup* eg = std::get_if<ExprGroup>(&g)) {
+    for (const auto& vg : graph_.inputGroups(*eg)) {
+      add_to_visit_list(vg);
+    }
+    for (const auto& vg : graph_.outputGroups(*eg)) {
+      add_to_visit_list(vg);
+    }
+  } else if (const ValGroup* vg = std::get_if<ValGroup>(&g)) {
+    for (const auto& eg : graph_.getUses(*vg)) {
+      add_to_visit_list(eg);
+    }
+    for (const auto& eg : graph_.getDefinitions(*vg)) {
+      add_to_visit_list(eg);
+    }
+  } else {
+    NVF_ERROR(false);
+  }
+}
+
+void ValGraphBFS::setPrevGroups(
+    const GroupType& group,
+    const std::pair<Direction, std::vector<GroupType>>& prev_groups) {
+  NVF_ERROR(
+      prev_groups_.emplace(group, prev_groups).second,
+      "Previous group already set for ",
+      toString(group));
+}
+
+} // namespace nvfuser
+
+namespace std {
+template <>
+struct hash<pair<nvfuser::ExprGroup, nvfuser::Direction>> {
+  std::size_t operator()(
+      const std::pair<nvfuser::ExprGroup, nvfuser::Direction>& directed_group)
+      const {
+    using std::hash;
+    return hash<nvfuser::ExprGroup>()(directed_group.first);
+  }
+};
+} // namespace std
+
+namespace nvfuser {
+
+// Going backwards from to_groups_ to from_groups_ to discover the
+// shortest path.
+ExprPath ValGraphBFS::getShortestExprPath() {
+  NVF_ERROR(allToGroupsVisited(), "Traveral is either not done or failed");
+
+  ExprPath path;
+
+  std::deque<std::pair<GroupType, Direction>> to_visit;
+  for (const GroupType& to_group : to_groups_) {
+    to_visit.emplace_back(to_group, Direction::Undefined);
+  }
+
+  while (!to_visit.empty()) {
+    const auto [group, direction] = to_visit.front();
+    to_visit.pop_front();
+
+    if (const ExprGroup* eg = std::get_if<ExprGroup>(&group)) {
+      path.emplace_back(*eg, direction);
+    }
+
+    if (std::find(from_groups_.begin(), from_groups_.end(), group) !=
+        from_groups_.end()) {
+      continue;
+    }
+
+    auto prev_groups_it = prev_groups_.find(group);
+    NVF_ERROR(prev_groups_it != prev_groups_.end());
+
+    const Direction dir = prev_groups_it->second.first;
+    for (const auto& prev_group : prev_groups_it->second.second) {
+      to_visit.emplace_back(prev_group, dir);
+    }
+  }
+
+  // At this point, we have the reverse path, but it may have multiple exprs
+  // that need to be filtered out. Let's say theare are domains 0, 1 and 2, and
+  // domains 1 and 2 are merged to produce domain 3, and then domains
+  // 0 and 3 are merged to produce domain 4.
+  //
+  // 0       1         2
+  //
+  // |       |         |
+  // |       |         |
+  // |       +-->   <--+
+  // |            3
+  // |            |
+  // |            |
+  // +----> 4 <---+
+  //
+  // Suppose we want to find the shortest path from {4} to {0, 1,
+  // 2}. The correct answer should be:
+  //
+  //   Backward merge of 0, 3 -> 4
+  //   Backward merge of 1, 2 -> 3
+  //
+  // However, the above traversal would produce a path of:
+  //
+  //   Backward merge of 0, 3 -> 4
+  //   Backward merge of 1, 2 -> 3
+  //   Backward merge of 1, 2 -> 3
+  //   Backward merge of 0, 3 -> 4
+  //
+  // This is because, since nodes 0, 1 and 2 are the starting nodes,
+  // we would first visit 4 from 0, and then 3 from 1 and again 3 from
+  // 2. Since node 3 would be visited twice, the path from 3 to 4
+  // would be traversed twice as well. Obviously, just reversing this
+  // path wouldn't give the correct path. There are two issues here:
+  //
+  // - The first visit to node 4 from node 0 should not be taken since
+  //   node 4 must appear after node 3
+  // - Visiting the same node multiple times is redundant and should
+  //   be removed
+  //
+  // Both problems could be solved by taking into considerations if
+  // nodes are ready to visit and also are already visited, just like
+  // done in the forward traversal. However, there's an additional
+  // complexity in this case because the following graph is also valid:
+  //
+  //         1         2
+  //
+  // |       |         |
+  // |       |         |
+  // |       +-->   <--+
+  // |            3
+  // |            |
+  // |            |
+  // +----> 4 <---+
+  //
+  // Notice that node 0 is missing, meaning the shortest path problem
+  // in this case is  from node 4 to nodes 1 and 2, and node 0 is not
+  // of interest. The correct path is still the same, i.e., first
+  // backward merge of 0 and 3 and then another backward merge of 1
+  // and 2. It is just node 0 is discarded as it is not of
+  // interest. In this case, however, if the
+  // traversal was enforced to honor the dependency of each node,
+  // it would not be able to visit the backward merge of 0 and 3 as
+  // node 0 is missing.
+  //
+  // A straightforward solution here is simply first generating the
+  // path as above and for each node, take the last visit only. Note
+  // that the last visit is always guaranteed to satisfy its
+  // dependencies.
+  //
+  // Here, instead of finding the last appearance of each node, the
+  // path is first reversed and then only the first appearance is
+  // taken since the path needs to be reversed anyway.
+  //
+  // See the ValGraphBFS2 test for a concrete example.
+
+  std::reverse(path.begin(), path.end());
+
+  VectorOfUniqueEntries<std::pair<ExprGroup, Direction>> unique_path(
+      path.begin(), path.end());
+
+  return unique_path.vector();
+}
+
 } // namespace nvfuser

--- a/csrc/val_graph_visitor.cpp
+++ b/csrc/val_graph_visitor.cpp
@@ -518,16 +518,16 @@ ExprPath ValGraphBFS::getShortestExprPath() {
   // that the last visit is always guaranteed to satisfy its
   // dependencies.
   //
-  // Here, instead of finding the last appearance of each node, the
-  // path is first reversed and then only the first appearance is
-  // taken since the path needs to be reversed anyway.
+  // Recall that the final path needs to be reversed, so instead of
+  // finding the last appearance of each node, the final path can be
+  // obtained by first reversing the current path and then only taking
+  // the first appearance of each ExprGroup. Or, more simply, we can
+  // just use VectorOfUniqueEntries with the reverse iterator.
   //
   // See the ValGraphBFS2 test for a concrete example.
 
-  std::reverse(path.begin(), path.end());
-
   VectorOfUniqueEntries<std::pair<ExprGroup, Direction>> unique_path(
-      path.begin(), path.end());
+      path.rbegin(), path.rend());
 
   return unique_path.vector();
 }

--- a/csrc/val_graph_visitor.cpp
+++ b/csrc/val_graph_visitor.cpp
@@ -322,7 +322,7 @@ ValGraphBFS::isReady(const ExprGroup& expr_group) const {
 
 std::optional<std::pair<Direction, std::vector<ValGraphBFS::GroupType>>>
 ValGraphBFS::isReady(const ValGroup& val_group) const {
-  // In the case of Val, requires one def or use expr.
+  // In the case of Val, requires just one def or use expr.
   // Check if any use is visited
   if (!graph_.getUses(val_group).empty()) {
     auto it = std::find_if(
@@ -335,7 +335,7 @@ ValGraphBFS::isReady(const ValGroup& val_group) const {
       return std::make_pair(Direction::Backward, std::vector<GroupType>{*it});
     }
   }
-  // Check if all defs are visited
+  // Check if any def is visited
   if (!graph_.getDefinitions(val_group).empty()) {
     auto it = std::find_if(
         graph_.getDefinitions(val_group).begin(),

--- a/csrc/val_graph_visitor.h
+++ b/csrc/val_graph_visitor.h
@@ -11,6 +11,8 @@
 #include <ir/all_nodes.h>
 #include <val_graph.h>
 
+#include <variant>
+
 namespace nvfuser {
 
 // Iterates through a Val Graph in topological order, calling handle on
@@ -116,6 +118,111 @@ class ValGraphStmtSort : public ValGraphVisitor {
 
   ExprGroups sorted_exprs_;
   ValGroups sorted_vals_;
+};
+
+enum class Direction { Forward, Backward, Undefined };
+
+std::ostream& operator<<(std::ostream&, const Direction);
+
+using ExprPath = std::vector<std::pair<ExprGroup, Direction>>;
+
+std::ostream& operator<<(std::ostream& os, const ExprPath& path);
+
+inline Direction reverse(Direction direction) {
+  if (direction == Direction::Forward) {
+    return Direction::Backward;
+  } else if (direction == Direction::Backward) {
+    return Direction::Forward;
+  } else {
+    return Direction::Undefined;
+  }
+}
+
+inline ExprPath reverse(const ExprPath& path) {
+  auto rev = path;
+  std::reverse(rev.begin(), rev.end());
+  for (auto& [eg, direction] : rev) {
+    direction = reverse(direction);
+  }
+  return rev;
+}
+
+class ValGraphBFS {
+ public:
+  using GroupType = std::variant<ExprGroup, ValGroup>;
+
+  // Find the shortest path from the from_groups_ to to_groups_ on a
+  // given graph. Dependency between vals and exprs must be satisfied.
+  // It is an error if no valid path is found.
+  static ExprPath getExprsBetween(
+      const ValGraph& graph,
+      const ValGroups& from,
+      const ValGroups& to);
+
+  virtual ~ValGraphBFS() = default;
+
+ protected:
+  ValGraphBFS(
+      const ValGraph& graph,
+      std::vector<GroupType> from_groups,
+      std::vector<GroupType> to_groups)
+      : graph_(graph),
+        from_groups_(std::move(from_groups)),
+        to_groups_(std::move(to_groups)) {}
+
+  // Traverse from from_groups_ to to_groups_, recording each taken
+  // path to generate the shortest path after the travesal
+  virtual void traverse();
+
+  // Find the shortest path from the from_groups_ to to_groups_. This
+  // must be only used once traversal is completed.
+  virtual ExprPath getShortestExprPath();
+
+  // Check if a group is ready to visit
+  virtual std::optional<std::pair<Direction, std::vector<GroupType>>> isReady(
+      const GroupType& group) const;
+
+  // Check if an ExprGroup is ready to visit. Either all of its inputs
+  // or all of outputs must have their dependencies satisfied
+  virtual std::optional<std::pair<Direction, std::vector<GroupType>>> isReady(
+      const ExprGroup& expr_group) const;
+
+  // Check if a ValGroup is ready to visit. Eithre its defining or use
+  // ExprGroup must have its dependency satisfied
+  virtual std::optional<std::pair<Direction, std::vector<GroupType>>> isReady(
+      const ValGroup& val_group) const;
+
+  // If another group depends on a given group, check if that
+  // dependency is considered satisfied. If the given group is already
+  // visited, that should mean the dependency is satisfied.
+  virtual bool isDependencySatisfied(const GroupType& dependency) const;
+
+  // Check if a given group is already visited
+  virtual bool isVisited(const GroupType& group) const;
+
+  // Mark a group as visited
+  virtual void setVisited(const GroupType& group);
+
+  // Add new neighbors of a given group to the to_visit list
+  virtual void addNewNeighbors(const GroupType& group);
+
+  // Check if all to_groups_ are visited
+  virtual bool allToGroupsVisited() const;
+
+  // Set the previous group of a given group that is visited in a
+  // given direction
+  virtual void setPrevGroups(
+      const GroupType& group,
+      const std::pair<Direction, std::vector<GroupType>>& prev_groups);
+
+ protected:
+  const ValGraph& graph_;
+  const std::vector<GroupType> from_groups_;
+  const std::vector<GroupType> to_groups_;
+  std::deque<GroupType> to_visit_;
+  std::unordered_set<GroupType> visited_;
+  std::unordered_map<GroupType, std::pair<Direction, std::vector<GroupType>>>
+      prev_groups_;
 };
 
 } // namespace nvfuser

--- a/csrc/val_graph_visitor.h
+++ b/csrc/val_graph_visitor.h
@@ -147,6 +147,21 @@ inline ExprPath reverse(const ExprPath& path) {
   return rev;
 }
 
+// Traversal for finding the shortest path from ValGroups to another
+// ValGroups. The algorithm is based on the standard BFS traversal,
+// however, since ValGraph is not an undirected graph, the
+// dependencies of ValGroups and ExprGroups need to be
+// satisfied. Specifically, when visiting an ExprGroup, either its
+// inputs or outputs must be visited before. Similarly, when visiting
+// a ValGroup, there must be at least one defining ExprGroup or one
+// use ExprGroup that is already visited.
+//
+// The main use case is tensor indexing, where a typical traversal
+// would be from loop domains to allocation domains. Some
+// indexing-specific specialization would be needed, for example,
+// dependencies with broadcast domains can be ignored as their index
+// is always just zero. The indexing shortest-path traversal would be
+// implemented by subclassing this class.
 class ValGraphBFS {
  public:
   using GroupType = std::variant<ExprGroup, ValGroup>;

--- a/csrc/val_graph_visitor.h
+++ b/csrc/val_graph_visitor.h
@@ -193,17 +193,26 @@ class ValGraphBFS {
   // must be only used once traversal is completed.
   virtual ExprPath getShortestExprPath();
 
-  // Check if a group is ready to visit
+  // Check if a group is ready to visit. If yes, return the direction
+  // and the prev nodes that should be visited before the given group
+  // is visited.
   virtual std::optional<std::pair<Direction, std::vector<GroupType>>> isReady(
       const GroupType& group) const;
 
   // Check if an ExprGroup is ready to visit. Either all of its inputs
-  // or all of outputs must have their dependencies satisfied
+  // or all of outputs must have their dependencies satisfied. If
+  // ready because the inputs are already visited, return
+  // Direction::Forward and all the input groups. If ready because the
+  // outputs are ready, return Direction::Backward and all the output groups.
   virtual std::optional<std::pair<Direction, std::vector<GroupType>>> isReady(
       const ExprGroup& expr_group) const;
 
-  // Check if a ValGroup is ready to visit. Eithre its defining or use
-  // ExprGroup must have its dependency satisfied
+  // Check if a ValGroup is ready to visit. Either its defining or use
+  // ExprGroup must have its dependency satisfied. If ready because
+  // there's a visited defining expr, return Direction::Forward and
+  // the group of the defining expr. If ready because there's a
+  // visited use expr, return Direction::Backward and the group of the
+  // use expr.
   virtual std::optional<std::pair<Direction, std::vector<GroupType>>> isReady(
       const ValGroup& val_group) const;
 

--- a/csrc/val_graph_visitor.h
+++ b/csrc/val_graph_visitor.h
@@ -233,7 +233,7 @@ class ValGraphBFS {
   // Check if all to_groups_ are visited
   virtual bool allToGroupsVisited() const;
 
-  // Set the previous group of a given group that is visited in a
+  // Set the previous groups of a given group that is visited in a
   // given direction
   virtual void setPrevGroups(
       const GroupType& group,

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -2174,8 +2174,6 @@ TEST_F(IdModelTest, ValGraphBFS1) {
   const IdModel id_model(fusion.get());
   const ValGraph& graph = id_model.idGraph(IdMappingMode::EXACT);
 
-  std::cerr << idGroupsString(graph) << std::endl;
-
   ValGroups tv0_leaf_groups = graph.toGroups(tv0->getLeafDomain());
   ValGroups tv1_leaf_groups = graph.toGroups(tv1->getLeafDomain());
   ValGroups tv2_leaf_groups = graph.toGroups(tv2->getLeafDomain());

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -2146,4 +2146,222 @@ TEST_F(IdModelTest, PermutedDifferently) {
   EXPECT_TRUE(iterDomainsAreMapped(id_model, s1->axis(2), t1->axis(2)));
 }
 
+// BFS traversal test with a simple exact graph
+TEST_F(IdModelTest, ValGraphBFS1) {
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeSymbolicTensor(2);
+  fusion->addInput(tv0);
+  auto tv1 = set(tv0);
+  auto tv2 = set(tv1);
+  fusion->addOutput(tv2);
+
+  // tv0: [i0, i1]
+  // tv1: [i0, i1]
+  // tv2: [i0, i1]
+
+  // Schedule tv0 and tv1 in the same way
+  tv0->merge(0, 1)->split(0, 4);
+  tv1->merge(0, 1)->split(0, 4);
+  // Schedule tv1 similarly but with a reordered merge
+  tv2->merge(1, 0)->split(0, 4);
+
+  // tv0: [i0*i1/4, 4]
+  // tv1: [i0*i1/4, 4]
+  // tv2: [i1*i0/4, 4]
+
+  const IdModel id_model(fusion.get());
+  const ValGraph& graph = id_model.idGraph(IdMappingMode::EXACT);
+
+  std::cerr << idGroupsString(graph) << std::endl;
+
+  ValGroups tv0_leaf_groups = graph.toGroups(tv0->getLeafDomain());
+  ValGroups tv1_leaf_groups = graph.toGroups(tv1->getLeafDomain());
+  ValGroups tv2_leaf_groups = graph.toGroups(tv2->getLeafDomain());
+
+  // Since the leaf domains of tv0 and tv1 are grouped together, the
+  // path between them is empty
+  ExprPath tv1_to_tv0 =
+      ValGraphBFS::getExprsBetween(graph, tv1_leaf_groups, tv0_leaf_groups);
+  EXPECT_TRUE(tv1_to_tv0.empty());
+
+  // Traversal should fail if not all dependencies are met
+  ValGroups incomplete_tv1_leaf_groups;
+  incomplete_tv1_leaf_groups.pushBack(
+      graph.toGroup(tv1->getLeafDomain().at(0)));
+  EXPECT_THAT(
+      [&]() {
+        ValGraphBFS::getExprsBetween(
+            graph, incomplete_tv1_leaf_groups, tv0_leaf_groups);
+      },
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
+          ::testing::HasSubstr("BFS traversal could not visit some nodes")));
+
+  // On the other hand, the leaf domains of tv2 are produced through
+  // the reverse merge, so they aren't mapped with the tv1 leaf
+  // domains. The path between them should look like traversing from
+  // tv2 leaves backward to its root and then forward from tv1 root to
+  // tv1 leaves.
+  ExprPath tv2_to_tv1 =
+      ValGraphBFS::getExprsBetween(graph, tv2_leaf_groups, tv1_leaf_groups);
+
+  ExprPath tv2_to_tv1_ref;
+  tv2_to_tv1_ref.emplace_back(
+      graph.toGroup(tv2->axis(0)->definition()), Direction::Backward);
+  tv2_to_tv1_ref.emplace_back(
+      graph.toGroup(tv2->axis(0)->definition()->input(0)->definition()),
+      Direction::Backward);
+  tv2_to_tv1_ref.emplace_back(
+      graph.toGroup(tv1->axis(0)->definition()->input(0)->definition()),
+      Direction::Forward);
+  tv2_to_tv1_ref.emplace_back(
+      graph.toGroup(tv1->axis(0)->definition()), Direction::Forward);
+
+  EXPECT_EQ(tv2_to_tv1, tv2_to_tv1_ref);
+}
+
+// Traversal to partial reachable nodes. See also the comment in
+// ValGraphBFS::getShortestExprPath.
+TEST_F(IdModelTest, ValGraphBFS2) {
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeSymbolicTensor(3);
+  fusion->addInput(tv0);
+  auto tv1 = set(tv0);
+  fusion->addOutput(tv1);
+
+  // tv1: [i0, i1, i2]
+  // tv1: [i0, i1, i2]
+
+  tv1->merge(1, 2)->merge(0, 1);
+
+  // tv0: [i0, i1, i2]
+  // tv1: [i0*(i1*i2)]
+
+  const IdModel id_model(fusion.get());
+  const ValGraph& graph = id_model.idGraph(IdMappingMode::EXACT);
+
+  ValGroups tv0_leaf_groups = graph.toGroups(tv0->getLeafDomain());
+  ValGroups tv1_leaf_groups = graph.toGroups(tv1->getLeafDomain());
+
+  // Since the leaf domains of tv0 and tv1 are grouped together, the
+  // path between them is empty
+  ExprPath tv1_to_tv0 =
+      ValGraphBFS::getExprsBetween(graph, tv1_leaf_groups, tv0_leaf_groups);
+
+  ExprPath tv1_to_tv0_ref;
+  tv1_to_tv0_ref.emplace_back(
+      graph.toGroup(tv1->axis(0)->definition()), Direction::Backward);
+  tv1_to_tv0_ref.emplace_back(
+      graph.toGroup(tv1->axis(0)->definition()->input(1)->definition()),
+      Direction::Backward);
+
+  EXPECT_EQ(tv1_to_tv0, tv1_to_tv0_ref);
+
+  // Grab the path from tv1 to only the i1 and i2 domains of tv0
+  // without i0. The path should still be the same.
+  ValGroups tv0_partial_groups;
+  tv0_partial_groups.pushBack(graph.toGroup(tv0->axis(1)));
+  tv0_partial_groups.pushBack(graph.toGroup(tv0->axis(2)));
+  ExprPath tv1_to_tv0_partial =
+      ValGraphBFS::getExprsBetween(graph, tv1_leaf_groups, tv0_partial_groups);
+
+  EXPECT_EQ(tv1_to_tv0_partial, tv1_to_tv0_ref);
+}
+
+// Check if a shorter path is taken
+TEST_F(IdModelTest, ValGraphBFS3) {
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeConcreteTensor({16});
+  fusion->addInput(tv0);
+
+  // shorter path
+  auto tv1 = reshape(tv0, {16}, {4, 4});
+
+  // longer path
+  auto tv2 = reshape(tv0, {16}, {8, 2});
+  auto tv3 = reshape(tv2, {8, 2}, {4, 4});
+
+  auto tv4 = add(tv1, tv3);
+
+  fusion->addOutput(tv4);
+
+  // tv0: [i0]
+  // tv1: [i0/4, 4]
+  // tv2: [i0/8, 2]
+  // tv3: [i0/8*2/4, 4]
+  // tv4: [i0/4, 4]
+
+  // Traversal from tv4 to tv0 can be {tv4 -> tv1 -> tv0} or {tv4 ->
+  // tv3 -> tv2 -> tv0}. The former should be seletected as it's shorter
+
+  const IdModel id_model(fusion.get());
+  const ValGraph& graph = id_model.idGraph(IdMappingMode::EXACT);
+
+  ValGroups tv4_groups = graph.toGroups(tv4->getLeafDomain());
+  ValGroups tv0_groups = graph.toGroups(tv0->getLeafDomain());
+
+  ExprPath tv4_to_tv0 =
+      ValGraphBFS::getExprsBetween(graph, tv4_groups, tv0_groups);
+  ExprPath tv4_to_tv0_ref;
+  tv4_to_tv0_ref.emplace_back(
+      graph.toGroup(tv1->axis(0)->definition()), Direction::Backward);
+
+  ASSERT_EQ(tv4_to_tv0, tv4_to_tv0_ref);
+}
+
+// BFS traversal of a graph with a cycle
+TEST_F(IdModelTest, ValGraphBFS4) {
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeConcreteTensor({2, 8});
+  fusion->addInput(tv0);
+
+  auto tv1 = reshape(tv0, {2, 8}, {16});
+  auto tv2 = reshape(tv1, {16}, {4, 4});
+  auto tv3 = reshape(tv2, {4, 4}, {16});
+  auto tv4 = add(tv1, tv3);
+
+  fusion->addOutput(tv4);
+
+  // tv0: [i0, i1]
+  // tv1: [i2] // i2 = merge(i0, i1)
+  // tv2: [i3, i4] // i3, i4 = split(i2)
+  // tv3: [i5] // merge(i3, i4)
+  // tv4: [i6] // i6 = i5
+
+  // The tv4 addition makes the sole domain of tv4 mapped with those of
+  // tv3 and tv1, i.e., these domains are grouped together:
+  //
+  // i2, i5, i6
+  //
+  // Since there's a path from i2 to i5 (a merge and a split), this
+  // means the graph is no longer a DAG.
+
+  // Make sure the BFS traversal should still work even with a cycle.
+
+  const IdModel id_model(fusion.get());
+  const ValGraph& graph = id_model.idGraph(IdMappingMode::EXACT);
+
+  ValGroups tv4_groups = graph.toGroups(tv4->getLeafDomain());
+  ValGroups tv0_groups = graph.toGroups(tv0->getLeafDomain());
+
+  // Traversal from tv4 to tv0 can go through the reshape ops of tv2
+  // and tv3, but the shortest path should be just one merge for tv1
+
+  ExprPath tv4_to_tv0 =
+      ValGraphBFS::getExprsBetween(graph, tv4_groups, tv0_groups);
+
+  ExprPath tv4_to_tv0_ref;
+  tv4_to_tv0_ref.emplace_back(
+      graph.toGroup(tv1->axis(0)->definition()), Direction::Backward);
+
+  ASSERT_EQ(tv4_to_tv0, tv4_to_tv0_ref);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
(Extracted from #2238)

Traversal for finding the shortest path from ValGroups to another ValGroups. The algorithm is based on the standard BFS traversal, however, since ValGraph is not an undirected graph, the dependencies of ValGroups and ExprGroups need to be
satisfied. Specifically, when visiting an ExprGroup, either its inputs or outputs must be visited before. Similarly, when visiting
a ValGroup, there must be at least one defining ExprGroup or one use ExprGroup that is already visited.

The main use case is tensor indexing (#2238), where a typical traversal would be from loop domains to allocation domains. Some indexing-specific specialization would be needed, for example, dependencies with broadcast domains can be ignored as their index is always just zero. The indexing shortest-path traversal would be implemented by subclassing this class.

Please see the new unit tests for concrete examples.