### PR TITLE
Replace bitwise assignment ops on bools

### DIFF
--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -299,10 +299,10 @@ class PredicateChcker : public IterVisitor {
         "Should never have a reduction op without a tensor view input.");
     bool found_expand = false;
     for (auto tv_input : tv_inputs) {
-      found_expand |= std::any_of(
-          tv_input->getMaybeRFactorDomain().begin(),
-          tv_input->getMaybeRFactorDomain().end(),
-          [](IterDomain* id) { return id->hasExpandedExtent(); });
+      found_expand = found_expand ||
+          std::any_of(tv_input->getMaybeRFactorDomain().begin(),
+                      tv_input->getMaybeRFactorDomain().end(),
+                      [](IterDomain* id) { return id->hasExpandedExtent(); });
     }
 
     if (!found_expand) {

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -1263,7 +1263,8 @@ bool DynamicTransformConcretizer::propagateFromProducerToConsumer(
           "Producer ID not concretized: ",
           input_id->toString());
 
-      has_expanded_producer |= input_id->hasExpandedExtent();
+      has_expanded_producer =
+          has_expanded_producer || input_id->hasExpandedExtent();
 
       if (id_type.has_value()) {
         id_type = ops::promoteIterType(*id_type, input_id->getIterType());

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -817,10 +817,11 @@ struct BroadcastOpRecord : RecordFunctor {
     auto result = false;
     if (auto child_ptr = dynamic_cast<const BroadcastOpRecord*>(&other)) {
       result = RecordFunctor::operator==(other);
-      result &= std::equal(
-          is_broadcast_dim_.begin(),
-          is_broadcast_dim_.end(),
-          child_ptr->is_broadcast_dim_.begin());
+      result = result &&
+          std::equal(
+                   is_broadcast_dim_.begin(),
+                   is_broadcast_dim_.end(),
+                   child_ptr->is_broadcast_dim_.begin());
     }
     return result;
   }


### PR DESCRIPTION
Thanks to the suggestion by @zasdfgbnm while reviewing #2272, I found some additional cases where we took a short-cut to updating bools using the bitwise assignment ops. This is not ideal since its behavior is undefined (there's no guarantee that the underlying representation of `true` is `b1` and not `b10` or any other non-zero value). More importantly, writing `a |= b` as `a = a || b` allows us to short-circuit if `a == true`. Using bitwise `a |= b`, `b` will always be evaluated.