### PR TITLE
change from at::ones to at::randn in test of OuterReductionMagicScheduler

### DIFF
--- a/tests/cpp/test_gpu_outer_reduction.cpp
+++ b/tests/cpp/test_gpu_outer_reduction.cpp
@@ -2363,7 +2363,7 @@ TEST_F(OuterReductionTest, OuterReductionMagicScheduler) {
     auto options = at::TensorOptions()
                        .dtype(data_type_to_aten(dtype))
                        .device(at::kCUDA, 0);
-    auto t0 = at::ones(shape, options);
+    auto t0 = at::randn(shape, options);
     std::vector<c10::IValue> inputs({t0});
     FusionExecutorCache executor_cache(std::move(fusion));
     auto cg_outputs = executor_cache.runFusionWithInputs(inputs);


### PR DESCRIPTION
should use `at::randn` instead of `at::ones` to generate inputs for tests