### PR TITLE
Select CompileParams for TMA operations automatically at compile-time

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -357,7 +357,8 @@ void FusionExecutor::compileFusion(
     NVF_ERROR(
         !has_cp_async_bulk ||
             (compile_params.index_type.value() == PrimDataType::Int32),
-        "Compilation with int64 is requested but int32 is required because of TMA operations");
+        "Compilation with int64 is requested but int32 is required because ",
+        "of TMA operations.");
 
   } else if (arg_index_type == PrimDataType::Int) {
     // If the given compile option doesn't specify the index type, and
@@ -366,6 +367,10 @@ void FusionExecutor::compileFusion(
     // it's safe to use 32-bit for the whole kernel, so unless it's
     // specified through CompileParams, we do not use 32-bit indexing.
     compile_params.index_type = arg_index_type;
+    NVF_ERROR(
+        !has_cp_async_bulk,
+        "Compilation with int64 is required based on input arguments, but ",
+        "int32 is required because of TMA operations.");
   } else if (has_cp_async_bulk) {
     // TMA operations require 32-bit indexing.
     compile_params.index_type = PrimDataType::Int32;

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -332,6 +332,16 @@ void FusionExecutor::compileFusion(
     fusion->printMath();
   }
 
+  has_cp_async_bulk_ = std::any_of(fusion->exprs().begin(),
+	                               fusion->exprs().end(),
+	                               [](Expr* e) {
+	                                 return ir_utils::isCpAsyncBulk(e);
+	                               });
+  // Disable magic zero if there are any TMA operations in Fusion
+  if (has_cp_async_bulk_) {
+    compile_params.enable_magic_zero = false;
+  }
+
   // Set the index type of compile params if not already set. If set,
   // make sure the compile param type is valid with the given kernel
   // arguments.
@@ -343,6 +353,9 @@ void FusionExecutor::compileFusion(
         !(compile_params.index_type.value() == PrimDataType::Int32 &&
           arg_index_type == PrimDataType::Int),
         "Compilation with int32 is requested but int64 is required for the arguments");
+    NVF_ERROR(!has_cp_async_bulk_ || (compile_params.index_type.value() == PrimDataType::Int32),
+        "Compilation with int64 is requested but int32 is required because of TMA operations");
+
   } else if (arg_index_type == PrimDataType::Int) {
     // If the given compile option doesn't specify the index type, and
     // the arguments require 64-bit indexing, we need to use 64-bit
@@ -350,6 +363,9 @@ void FusionExecutor::compileFusion(
     // it's safe to use 32-bit for the whole kernel, so unless it's
     // specified through CompileParams, we do not use 32-bit indexing.
     compile_params.index_type = arg_index_type;
+  } else if (has_cp_async_bulk_) {
+    // TMA operations require 32-bit indexing.
+    compile_params.index_type = PrimDataType::Int32;
   }
 
   c10::DeviceGuard dg(options_.device);

--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -332,11 +332,10 @@ void FusionExecutor::compileFusion(
     fusion->printMath();
   }
 
-  has_cp_async_bulk_ = std::any_of(fusion->exprs().begin(),
-	                               fusion->exprs().end(),
-	                               [](Expr* e) {
-	                                 return ir_utils::isCpAsyncBulk(e);
-	                               });
+  has_cp_async_bulk_ =
+      std::any_of(fusion->exprs().begin(), fusion->exprs().end(), [](Expr* e) {
+        return ir_utils::isCpAsyncBulk(e);
+      });
   // Disable magic zero if there are any TMA operations in Fusion
   if (has_cp_async_bulk_) {
     compile_params.enable_magic_zero = false;
@@ -353,7 +352,9 @@ void FusionExecutor::compileFusion(
         !(compile_params.index_type.value() == PrimDataType::Int32 &&
           arg_index_type == PrimDataType::Int),
         "Compilation with int32 is requested but int64 is required for the arguments");
-    NVF_ERROR(!has_cp_async_bulk_ || (compile_params.index_type.value() == PrimDataType::Int32),
+    NVF_ERROR(
+        !has_cp_async_bulk_ ||
+            (compile_params.index_type.value() == PrimDataType::Int32),
         "Compilation with int64 is requested but int32 is required because of TMA operations");
 
   } else if (arg_index_type == PrimDataType::Int) {

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -558,10 +558,6 @@ class FusionExecutor : public NonCopyable {
  private:
   CompileOptions options_;
 
-  //! Force index_type to int and disable magic zero if we detect that the
-  //! kernel contains any TMA memory operations.
-  bool has_cp_async_bulk_ = false;
-
   //! Absolute limit of all available shared mem space from cudaDeviceProp
   int64_t device_smem_limit_ = 0;
 

--- a/csrc/executor.h
+++ b/csrc/executor.h
@@ -558,6 +558,10 @@ class FusionExecutor : public NonCopyable {
  private:
   CompileOptions options_;
 
+  //! Force index_type to int and disable magic zero if we detect that the
+  //! kernel contains any TMA memory operations.
+  bool has_cp_async_bulk_ = false;
+
   //! Absolute limit of all available shared mem space from cudaDeviceProp
   int64_t device_smem_limit_ = 0;
 

--- a/tests/python/test_schedule_ops.py
+++ b/tests/python/test_schedule_ops.py
@@ -10,7 +10,13 @@ import torch
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_ROCM, TestCase
 from torch.testing._internal.jit_utils import RUN_CUDA
 
-from nvfuser import FusionDefinition, DataType, ParallelType, MemoryType, LoadStoreOpType
+from nvfuser import (
+    FusionDefinition,
+    DataType,
+    ParallelType,
+    MemoryType,
+    LoadStoreOpType,
+)
 
 RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
 
@@ -20,6 +26,7 @@ def is_pre_volta():
         return False
     prop = torch.cuda.get_device_properties(torch.cuda.current_device())
     return prop.major < 7
+
 
 def is_pre_hopper():
     if not RUN_NVFUSER:
@@ -776,9 +783,7 @@ class TestScheduleOps(TestCase):
                 fd.sched.transform_like(reference_tv, all_tvs_except_tma)
 
                 # rfactor reduction tensors
-                reduction_tvs = list(
-                    filter(fd.sched.is_reduction, fd.sched.tensors())
-                )
+                reduction_tvs = list(filter(fd.sched.is_reduction, fd.sched.tensors()))
                 rfactor_tvs = [
                     fd.sched.rfactor(tv, dims=[-3, -2, -1]) for tv in reduction_tvs
                 ]
@@ -817,6 +822,7 @@ class TestScheduleOps(TestCase):
         var, mean = torch.var_mean(inputs[0], dim=-1, correction=0, keepdim=True)
         eager_out = (inputs[0] - mean) / torch.sqrt(var + 1e-6)
         self.assertTrue(torch.allclose(eager_out, nvf_out[0], atol=1e-1))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tests/python/test_schedule_ops.py
+++ b/tests/python/test_schedule_ops.py
@@ -10,7 +10,7 @@ import torch
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_ROCM, TestCase
 from torch.testing._internal.jit_utils import RUN_CUDA
 
-from nvfuser import FusionDefinition, DataType, ParallelType, MemoryType
+from nvfuser import FusionDefinition, DataType, ParallelType, MemoryType, LoadStoreOpType
 
 RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
 
@@ -20,6 +20,12 @@ def is_pre_volta():
         return False
     prop = torch.cuda.get_device_properties(torch.cuda.current_device())
     return prop.major < 7
+
+def is_pre_hopper():
+    if not RUN_NVFUSER:
+        return False
+    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return prop.major < 9
 
 
 @unittest.skipIf(not RUN_NVFUSER, "requires CUDA")
@@ -623,14 +629,16 @@ class TestScheduleOps(TestCase):
                 self.norm_const = fd.define_scalar(tensor_size, dtype=DataType.Int)
 
                 self.sum0 = fd.ops.sum(self.t0, dims=[-1])
-                # NOTE Manually broadcast because fusion definition cannot access hidden reduction tensor view.
+                # NOTE Manually broadcast because fusion definition cannot
+                # access hidden reduction tensor view.
                 self.bcast_sum0 = fd.ops.broadcast(self.sum0, [False, True])
                 self.mean = fd.ops.div(self.bcast_sum0, self.norm_const)
 
                 self.diff = fd.ops.sub(self.t0, self.mean)
                 self.diff_sq = fd.ops.mul(self.diff, self.diff)
                 self.sum1 = fd.ops.sum(self.diff_sq, dims=[-1])
-                # NOTE Manually broadcast because fusion definition cannot access hidden reduction tensor view.
+                # NOTE Manually broadcast because fusion definition cannot
+                # access hidden reduction tensor view.
                 self.bcast_sum1 = fd.ops.broadcast(self.sum1, [False, True])
                 self.var = fd.ops.div(self.bcast_sum1, self.norm_const)
 
@@ -680,6 +688,135 @@ class TestScheduleOps(TestCase):
         eager_out = (inputs[0] - mean) / torch.sqrt(var + 1e-6)
         self.assertEqual(eager_out, nvf_out[0])
 
+    def test_var_mean_tma_user_schedule(self):
+        """
+        Implement a simple normalization kernel using TMA ops with a user defined schedule
+        """
+        tensor_size = 4096
+        use_tma_ops = not is_pre_hopper()
+        inputs = [
+            torch.randn(tensor_size, tensor_size, dtype=torch.bfloat16, device="cuda")
+        ]
+
+        class VarMean(FusionDefinition):
+            def definition(self):
+                self.t0 = fd.from_pytorch(inputs[0])
+                self.s0 = fd.define_scalar(1e-6, dtype=DataType.Double)
+                self.norm_const = fd.define_scalar(tensor_size, dtype=DataType.Int)
+
+                self.mean_cast = fd.ops.cast(self.t0, dtype=DataType.Float)
+                self.sum0 = fd.ops.sum(self.mean_cast, dims=[-1])
+                # NOTE Manually broadcast because fusion definition cannot
+                # access hidden reduction tensor view.
+                self.bcast_sum0 = fd.ops.broadcast(self.sum0, [False, True])
+                self.mean = fd.ops.div(self.bcast_sum0, self.norm_const)
+
+                self.var_cast = fd.ops.cast(self.t0, dtype=DataType.Float)
+                self.diff = fd.ops.sub(self.var_cast, self.mean)
+                self.diff_sq = fd.ops.mul(self.diff, self.diff)
+                self.sum1 = fd.ops.sum(self.diff_sq, dims=[-1])
+                # NOTE Manually broadcast because fusion definition cannot
+                # access hidden reduction tensor view.
+                self.bcast_sum1 = fd.ops.broadcast(self.sum1, [False, True])
+                self.var = fd.ops.div(self.bcast_sum1, self.norm_const)
+
+                self.t0_cast = fd.ops.cast(self.t0, dtype=DataType.Float)
+                self.t0_diff = fd.ops.sub(self.t0_cast, self.mean)
+                self.var_eps = fd.ops.sqrt(fd.ops.add(self.var, self.s0))
+                self.t0_norm = fd.ops.div(self.t0_diff, self.var_eps)
+
+                self.t0_norm_cast = fd.ops.cast(self.t0_norm, dtype=DataType.BFloat16)
+                self.add_output(self.t0_norm_cast)
+
+            def schedule(self):
+                smem_cache_op = (
+                    LoadStoreOpType.tma if use_tma_ops else LoadStoreOpType.set
+                )
+                t0_smem = fd.sched.cache_after(self.t0, smem_cache_op)
+                fd.sched.set_memory_type(t0_smem, MemoryType.shared)
+                tma_tvs = [t0_smem]
+
+                t0_lmem = fd.sched.cache_after(t0_smem)
+                cache_before_t0_norm = fd.sched.cache_before(self.t0_norm_cast)
+
+                def _is_not_tma_tensor(a):
+                    return a not in tma_tvs
+
+                all_tvs_except_tma = list(
+                    filter(_is_not_tma_tensor, fd.sched.tensors())
+                )
+
+                tma_width = 256
+                vectorize = 8
+                elem_per_compute_thread = tensor_size // tma_width // vectorize
+
+                # Define TMA Box
+                fd.sched.split(t0_smem, dim=-1, factor=tma_width)
+
+                reference_tv = self.t0_norm_cast
+
+                # Schedule Reference
+                # root domain: [I1, I2]
+                # split: [I1, I2/V, V]
+                fd.sched.split(reference_tv, dim=-1, factor=vectorize)
+                # NOTE use outer-split to have constant register allocation
+                # split: [I1, EPCT, I2/V/EPCT (block_x), V]
+                fd.sched.split(
+                    reference_tv,
+                    dim=-2,
+                    factor=elem_per_compute_thread,
+                    inner_split=False,
+                )
+                # split: [I1, EPCT, I2/V/EPCT (block_x), U, V]
+                fd.sched.split(reference_tv, dim=-2, factor=1)
+                # split: [I1, I2/V/EPCT (block_x), EPCT, U, V]
+                fd.sched.reorder(reference_tv, {-4: -3, -3: -4})
+
+                # Transform all tensors
+                fd.sched.transform_like(reference_tv, all_tvs_except_tma)
+
+                # rfactor reduction tensors
+                reduction_tvs = list(
+                    filter(fd.sched.is_reduction, fd.sched.tensors())
+                )
+                rfactor_tvs = [
+                    fd.sched.rfactor(tv, dims=[-3, -2, -1]) for tv in reduction_tvs
+                ]
+
+                # Apply general parallelization
+                fd.sched.parallelize(reference_tv, axis := 0, ParallelType.grid_x)
+                fd.sched.parallelize(reference_tv, axis := 1, ParallelType.block_x)
+                fd.sched.parallelize(reference_tv, axis := -2, ParallelType.unroll)
+                fd.sched.parallelize_like(reference_tv)
+
+                # vectorize store output
+                fd.sched.parallelize(
+                    self.t0_norm_cast, axis := -1, ParallelType.vectorize
+                )
+
+                # tma load input
+                if use_tma_ops:
+                    fd.sched.parallelize(t0_smem, axis := -1, ParallelType.tma)
+
+                # computeAt
+                fd.sched.inline_at(
+                    reference_tv,
+                    pos=-1,
+                    best_effort=True,
+                    selected_tensors=all_tvs_except_tma,
+                )
+                fd.sched.inline_at(
+                    t0_lmem,
+                    pos=-1,
+                    best_effort=True,
+                    selected_tensors=[t0_smem],
+                )
+
+        fd = VarMean()
+        nvf_out = fd.execute(inputs)
+        var, mean = torch.var_mean(inputs[0], dim=-1, correction=0, keepdim=True)
+        eager_out = (inputs[0] - mean) / torch.sqrt(var + 1e-6)
+        self.assertTrue(torch.allclose(eager_out, nvf_out[0], atol=1e-1))
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
When using TMA operations, we must use 32-bit indexing and disable magic zero support. Currently, we manually pass the correct `CompileParams` to `FusionExecutor::compileFusion`. This PR automatically updates the `CompileParams` if TMA operations are detected during compilation. It also includes a basic normalization kernel using TMA operations in the python frontend.