### PR TITLE
Remove MatmulRole::OUTPUT_AUX

### DIFF
--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -33,14 +33,13 @@ enum class MatmulDomain { M = 0, N, K };
 //!  INPUT_B - a producer of MMA input B
 //!  INPUT_C - a producer of a tensor used in fusion epilogue,
 //!            for example tensor used in beta scaling fusion
-//!  OUTPUT_D - the main consumer of MMA op results
-//!  OUTPUT_AUX - fusion outputs that are consumers of OUTPUT_D
+//!  OUTPUT_D - fusion outputs that have the matmul as a dependency
 //!
 //! Naming convention is based on the following formula:
 //!    D = alpha * A x B + beta * C
 //!    AUX = relu(D)
 //!  Note: bias vector tensors will be assigned to INPUT_C role.
-enum class MatmulRole { INPUT_A = 0, INPUT_B, OUTPUT_D, INPUT_C, OUTPUT_AUX };
+enum class MatmulRole { INPUT_A = 0, INPUT_B, INPUT_C, OUTPUT_D };
 
 //! The expected number of occurances of core TensorView roles in fusion
 static constexpr size_t MATMUL_CORE_ROLES_EXPECTED_COUNT = 1;

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -37,7 +37,6 @@ enum class MatmulDomain { M = 0, N, K };
 //!
 //! Naming convention is based on the following formula:
 //!    D = alpha * A x B + beta * C
-//!    AUX = relu(D)
 //!  Note: bias vector tensors will be assigned to INPUT_C role.
 enum class MatmulRole { INPUT_A = 0, INPUT_B, INPUT_C, OUTPUT_D };
 

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -275,12 +275,6 @@ std::string isMatmulFusionDefinitionSupported(
       tvs_with_roles.insert(entry->second.begin(), entry->second.end());
     }
 
-    // Non-core output roles are optional, no requirements for definitions
-    entry = roles_map.find(MatmulRole::OUTPUT_AUX);
-    if (entry != roles_map.end()) {
-      tvs_with_roles.insert(entry->second.begin(), entry->second.end());
-    }
-
     const auto in_out_tvs_count =
         fusion_inputs_tvs.size() + fusion_outputs_tvs.size();
     if (in_out_tvs_count != tvs_with_roles.size()) {

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1288,13 +1288,7 @@ RolesMapOpt getTensorsRoles(
     });
 
     if (!storage.empty()) {
-      // NOTE: currently, we pick as a reference tensor one with `m` and `n`
-      //       IterDomains and the most uses
-      auto pos = storage.begin();
-      roles_map[MatmulRole::OUTPUT_D].push_back(*pos);
-      for (++pos; pos != storage.end(); ++pos) {
-        roles_map[MatmulRole::OUTPUT_AUX].push_back(*pos);
-      }
+      roles_map[MatmulRole::OUTPUT_D] = storage;
     }
   };
 


### PR DESCRIPTION
We already have `MatmulRole::OUTPUT_D`. We populate both of these by reverse sorting all outputs that are downstream of the `MmaOp` first by number of uses then by `name()`. The first in that reverse sorted list is `OUTPUT_D` and all others are `OUTPUT_AUX`. After this PR, there is only the `OUTPUT_D` list but it might have more than one element: namely the former `OUTPUT_AUX` tensors are now appended in the same order to the `OUTPUT_D` list in the roles map.

I believe the main reason to reverse sort by uses is to find a reference tensor for reverse propagating transforms to epilogue inputs here: https://github.com/NVIDIA/Fuser/blob/0892405e5396820ffc4a300cba916cd6cb65e6be/csrc/scheduler/matmul.cpp#L660-L672
There should be no change to this section since we have not changed the first element of the `OUTPUT_D` vector.