### PR TITLE
Do not assume mul-sum pattern inputs are TensorView

### DIFF
--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1420,8 +1420,14 @@ class MatmulPatternMatcher : IterVisitor {
       // the Fusion was segmented and casts to half precision were inserted at
       // the segmentation edge (see castInputOutputToLowerPrecision in
       // fusion_segmenter.cpp).
-      TensorView* ltv = getTensorviewPriorToCast(bop->lhs()->as<TensorView>());
-      TensorView* rtv = getTensorviewPriorToCast(bop->rhs()->as<TensorView>());
+      TensorView* ltv = dynamic_cast<TensorView*>(bop->lhs());
+      TensorView* rtv = dynamic_cast<TensorView*>(bop->rhs());
+      if (ltv == nullptr || rtv == nullptr) {
+        // Found a scalar input
+        return;
+      }
+      ltv = getTensorviewPriorToCast(ltv);
+      rtv = getTensorviewPriorToCast(rtv);
 
       std::vector<IterDomain*> lrf =
           TensorDomain::noReductions(ltv->getMaybeRFactorDomain());


### PR DESCRIPTION
This was a change I made to handle casts that wound up breaking some tests and benchmarks in #2272, leading to dynamic cast errors or segfaults. The solution is to test the type of the left and right hand sides before processing the pattern matching.