### PR TITLE
Clear `profiler` object to avoid `FunctionEvent` accumulation

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -220,6 +220,9 @@ class NVFBenchmark:
             prof_averages = self.prof.key_averages()
             elapsed_cuda_time = self._get_kernel_time(prof_averages)
             self._increment_global_time(elapsed_cuda_time)
+            # Clear the internal profiler object to avoid accumulating function events and then restart the profiler
+            # See PR: https://github.com/pytorch/pytorch/pull/125510
+            self.prof.profiler = None
             self.prof.start()
         except AssertionError:
             self.prof.start()


### PR DESCRIPTION
PR: https://github.com/pytorch/pytorch/pull/125510 updates `torch.profiler` to increment to the Events list for a profiler instance instead of resetting the list to start afresh after `prof.stop`. This leads to the time measurements being accumulated which caused the benchmarking numbers to drop in the last week. Thanks to @xwang233 for identifying this.

Example for the difference in functionality:

```
prof.start()
target_fn()
prof.stop()

# CUDA time = 2ms

prof.start()
target_fn()
prof.stop()

# CUDA time = 4ms (Previous version: 2ms)
```
