### PR TITLE
Loop promotion fix for loop groups with view rf domains

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -391,7 +391,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (isOptionEnabled(EnableOption::IdModel)) {
+  if (true || isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_);
   }
 

--- a/csrc/id_model/loop_promotion.cpp
+++ b/csrc/id_model/loop_promotion.cpp
@@ -585,14 +585,6 @@ std::unordered_map<ValGroup, ValGroups> computeCoveredGroups(
       covered_ids[id_group] = {id_group};
     }
 
-    // Initialize rfactor groups
-    if (std::any_of(id_group->begin(), id_group->end(), [&](Val* id) {
-          return view_rfactor_ids.find(id->as<IterDomain>()) !=
-              view_rfactor_ids.end();
-        })) {
-      covered_ids[id_group] = {id_group};
-    }
-
     // Initialize broadcast groups to empty since broadcast domains
     // don't matter for indexing
     if (std::any_of(id_group->begin(), id_group->end(), [&](Val* id) {
@@ -668,9 +660,11 @@ IterDomain* LoopPromotionMapBuilder::findPromotionOfLoopGroup(
   // Grab all the (potentially promoted) terminal iter domains in this group.
   // Save the exact group and the iter domain in this vector.
   std::vector<std::pair<ValGroup, IterDomain*>> exact_promoted_terminal_ids;
-  for (auto loop_id : *loop_group) {
+  for (Val* loop_group_val : *loop_group) {
+    auto loop_id = loop_group_val->as<IterDomain>();
+
     // If not a terminal id in the group skip
-    if (!terminal_loop_ids.has(loop_id->as<IterDomain>())) {
+    if (!terminal_loop_ids.has(loop_id)) {
       continue;
     }
 
@@ -680,6 +674,16 @@ IterDomain* LoopPromotionMapBuilder::findPromotionOfLoopGroup(
     // so the new domains can be simply ignored.
     if (!iel_graph.hasGroup(loop_id)) {
       continue;
+    }
+
+    // If this domain is a view rfactor domain and a terminal domain,
+    // it is guaranteed to represent this loop group because all the
+    // domains merged into this loop_id must be non-broadcast
+    // domains. A concrete example can be found in test
+    // LoopPromotionWithRfactorDomains1.
+    if (id_model_.viewRfactorIds().find(loop_id) !=
+        id_model_.viewRfactorIds().end()) {
+      return loop_id;
     }
 
     const ValGroup& iel_group = iel_graph.toGroup(loop_id);

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -17,10 +17,13 @@
 #include <id_model/id_model.h>
 #include <id_model/loop_promotion.h>
 #include <id_model/to_string.h>
+#include <ir/graphviz.h>
 #include <inlining.h>
 #include <ops/all_ops.h>
 #include <transform_iter.h>
 #include <val_graph_visitor.h>
+
+#include <fstream>
 
 namespace nvfuser {
 
@@ -2378,4 +2381,99 @@ TEST_F(IdModelTest, LoopGraphWithSibling) {
     }
   }
 }
+
+// Repro of issue #2296
+TEST_F(IdModelTest, LoopPromotionWithRfactorDomains1) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeConcreteTensor({5});
+  fusion.addInput(tv0);
+  auto tv1 = makeConcreteTensor({5, 2});
+  fusion.addInput(tv1);
+
+  auto tv2 = set(tv0);
+  auto tv3 = broadcast(tv2, {false, true});
+  auto tv4 = add(tv3, tv1);
+  auto tv5 = reshape(tv4, {5, 2}, {10});
+  fusion.addOutput(tv5);
+
+  tv4->merge(0);
+  tv3->merge(0);
+
+  inlineMost();
+
+  IdModel id_model(&fusion);
+
+  const auto& loop_graph = id_model.idGraph(IdMappingMode::LOOP);
+  const auto& loop_group = loop_graph.toGroup(tv5->axis(0));
+
+  // All of the inlined tensors (i.e., all tensors except for the
+  // inputs) should be grouped together.
+  for (auto tv : ir_utils::allTvs(&fusion)) {
+    if (tv->isFusionInput()) {
+      continue;
+    }
+    for (auto id : ir_utils::allIDsOf(tv)) {
+      ASSERT_TRUE(loop_group->has(id))
+          << "Expected to be included. ID: " << id->toString()
+          << ". Loop group: " << nvfuser::toString(loop_group);
+    }
+  }
+
+  const auto& loop_promotion_map = id_model.loopPromotionMap();
+  auto promotion = loop_promotion_map.at(loop_group);
+  ASSERT_EQ(promotion, tv5->axis(0)) << "Invalid promotion";
+}
+
+// Another repro of issue #2296
+TEST_F(IdModelTest, LoopPromotionWithRfactorDomains2) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeConcreteTensor({5});
+  fusion.addInput(tv0);
+  auto tv1 = makeConcreteTensor({5, 2});
+  fusion.addInput(tv1);
+  auto tv2 = makeConcreteTensor({10, 3});
+  fusion.addInput(tv2);
+
+  auto tv3 = set(tv0);
+  auto tv4 = broadcast(tv3, {false, true});
+  auto tv5 = add(tv4, tv1);
+  auto tv6 = reshape(tv5, {5, 2}, {10});
+  auto tv7 = broadcast(tv6, {false, true});
+  auto tv8 = add(tv7, tv2);
+  fusion.addOutput(tv8);
+
+  tv4->merge(0);
+  tv5->merge(0);
+  tv8->merge(0);
+  tv7->merge(0);
+
+  inlineMost();
+
+  IdModel id_model(&fusion);
+
+  const auto& loop_graph = id_model.idGraph(IdMappingMode::LOOP);
+  const auto& loop_group = loop_graph.toGroup(tv8->axis(0));
+
+  // All of the inlined tensors (i.e., all tensors except for the
+  // inputs) should be grouped together.
+  for (auto tv : ir_utils::allTvs(&fusion)) {
+    if (tv->isFusionInput()) {
+      continue;
+    }
+    for (auto id : ir_utils::allIDsOf(tv)) {
+      ASSERT_TRUE(loop_group->has(id))
+          << "Expected to be included. ID: " << id->toString()
+          << ". Loop group: " << nvfuser::toString(loop_group);
+    }
+  }
+
+  const auto& loop_promotion_map = id_model.loopPromotionMap();
+  auto promotion = loop_promotion_map.at(loop_group);
+  ASSERT_EQ(promotion, tv8->axis(0)) << "Invalid promotion";
+}
+
 } // namespace nvfuser

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -17,8 +17,8 @@
 #include <id_model/id_model.h>
 #include <id_model/loop_promotion.h>
 #include <id_model/to_string.h>
-#include <ir/graphviz.h>
 #include <inlining.h>
+#include <ir/graphviz.h>
 #include <ops/all_ops.h>
 #include <transform_iter.h>
 #include <val_graph_visitor.h>


### PR DESCRIPTION
Fixes #2296 

In addition to stopping at view rfactor domains as mentioned in the issue page, I also put in a quick shortcut for the case where a view rfactor domain is a terminal domain. In that case, it's guaranteed that the domain is the right promotion domain. This is a shortcut and not strictly necessary for the correctness of the analysis, but I think it's simple enough to have as a quick optimization.