### PR TITLE
Cleanup reject messages for reduction and normalization schedulers

### DIFF
--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -1136,10 +1136,10 @@ bool checkReductionPattern(
               rtvs[it - 1], rtvs[it], root_map)) {
         scheduler_debug_utils::canScheduleRejectReason(
             schedule_heuristic,
-            "Unmapped reduction ",
-            rtvs[it - 1],
+            "Un-mapped multi-reduction: ",
+            rtvs[it - 1]->toString(),
             " and ",
-            rtvs[it]);
+            rtvs[it]->toString());
         return false;
       }
     }
@@ -1237,7 +1237,7 @@ bool compileTimeCheck(Fusion* fusion, ScheduleHeuristic schedule_heuristic) {
       if (reduction_root_size(red) != axis_count) {
         scheduler_debug_utils::canScheduleRejectReason(
             schedule_heuristic,
-            "inconsistent reduction root size: ",
+            "Inconsistent reduction root size: ",
             red->toString(),
             ", expected: ",
             axis_count);

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -954,9 +954,9 @@ bool ReductionScheduler::canScheduleCompileTime(Fusion* fusion) {
         if (reduction_root_size(red) != axis_count) {
           scheduler_debug_utils::canScheduleRejectReason(
               heuristicType(),
-              "Inconsistent reduction axes ",
-              red,
-              "is not ",
+              "Inconsistent reduction root size: ",
+              red->toString(),
+              ", expected: ",
               axis_count);
           return false;
         }
@@ -976,7 +976,7 @@ bool ReductionScheduler::canScheduleCompileTime(Fusion* fusion) {
             heuristicType(),
             "Un-mapped multi-reduction: ",
             reduction_tvs[it - 1]->toString(),
-            " ",
+            " and ",
             reduction_tvs[it]->toString());
         return false;
       }


### PR DESCRIPTION
This PR makes the reject messages for reduction and normalization schedulers consistent.