### PR TITLE
Handling allocation domain of the input TensorViews in the matmul scheduler 

### DIFF
--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -379,7 +379,8 @@ class NVF_API TensorView : public Val {
   //!   the the data tensor and the cache tensor
   TensorView* cacheAfter(
       LoadStoreOpType op_type = LoadStoreOpType::Set,
-      CacheOp cache_op = CacheOp::Unspecified);
+      CacheOp cache_op = CacheOp::Unspecified,
+      bool propagate_allocation_domain = true);
 
   // For a fusion output with other uses, we want to avoid writing to global
   // memory and then reading the output again. We write to global memory

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -734,19 +734,14 @@ void scheduleSplitKSum(
   splitk_sum->axis(-1)->parallelize(ParallelType::Vectorize);
 }
 
-// A LoadMatrixTranspose is needed is there's a rfactor which doesn't
-// match the alloc/root domain. If there's no rfactor, then we
-// need a transpose if the alloc domain and root don't match. When we say
-// match, we refer to the innermost iter domain.
-bool needsTranposedLoad(TensorView* out_tv) {
-  if (out_tv->hasRFactor()) {
-    auto use_root_or_alloc = out_tv->hasAllocation()
-        ? out_tv->getAllocationDomain()
-        : out_tv->getRootDomain();
-    return use_root_or_alloc.back() != out_tv->getRFactorDomain().back();
-  }
-  return out_tv->getRootDomain().back() !=
-      out_tv->getMaybeAllocationDomain().back();
+bool needsTranposedLoad(TensorView* producer, TensorView* consumer) {
+  const auto map =
+      PairwiseRootDomainMap(producer, consumer).mapProducerToConsumer();
+  auto maybeProducerAlloc = producer->getMaybeAllocationDomain();
+  auto maybeConsumerRFactor = consumer->getMaybeRFactorDomain();
+  auto prodToconsumerAllocDomInner =
+      map.find(maybeProducerAlloc.back())->second;
+  return maybeConsumerRFactor.back() != prodToconsumerAllocDomInner;
 }
 
 } // namespace
@@ -905,15 +900,18 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
 
   for (auto [tv_smem, tv_r] :
        {std::make_pair(acw_smem, &acr), std::make_pair(bcw_smem, &bcr)}) {
+    auto producer = tv_smem;
+    auto consumer = tv_smem->uses().at(0)->output(0)->as<TensorView>();
+    auto toTranspose = needsTranposedLoad(producer, consumer);
     if (auto ldst = dynamic_cast<LoadStoreOp*>(tv_smem->uses().at(0))) {
       *tv_r = ldst->out()->as<TensorView>();
       ldst->setOpType(
-          needsTranposedLoad(*tv_r) ? LoadStoreOpType::LdMatrixTranspose
-                                    : LoadStoreOpType::LdMatrix);
+          toTranspose ? LoadStoreOpType::LdMatrixTranspose
+                      : LoadStoreOpType::LdMatrix);
     } else {
       *tv_r = tv_smem->cacheAfter(
-          needsTranposedLoad(tv_smem) ? LoadStoreOpType::LdMatrixTranspose
-                                      : LoadStoreOpType::LdMatrix);
+          toTranspose ? LoadStoreOpType::LdMatrixTranspose
+                      : LoadStoreOpType::LdMatrix);
     }
   }
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -785,13 +785,6 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
 
   // Collect mma swizzle info
   auto mma = mma_ops.front();
-  const auto mma_layout_opt = mma->layout();
-  NVF_ERROR(
-      mma_layout_opt.has_value(), "fusion mma op has undefined input layout");
-  const auto fusion_layout = mma_utils::getMmaLayout(fusion);
-  NVF_ERROR(fusion_layout.isValid(), fusion_layout.getErrorMsg());
-
-  const auto& gemm_tile = params.tile_sizes;
   const bool has_epilogue = !mma->out()->isFusionOutput();
 
   const bool has_fusion_c_roles =

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -734,6 +734,10 @@ void scheduleSplitKSum(
   splitk_sum->axis(-1)->parallelize(ParallelType::Vectorize);
 }
 
+// A LoadMatrixTranspose is needed is there's a rfactor which doesn't
+// match the alloc/root domain. If there's no rfactor, then we
+// need a transpose if the alloc domain and root don't match. When we say
+// match, we refer to the innermost iter domain.
 bool needsTranposedLoad(TensorView* out_tv) {
   if (out_tv->hasRFactor()) {
     auto use_root_or_alloc = out_tv->hasAllocation()
@@ -798,7 +802,6 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   const auto mma_layout_opt = mma->layout();
   NVF_ERROR(
       mma_layout_opt.has_value(), "fusion mma op has undefined input layout");
-  // const auto mma_layout = mma_layout_opt.value();
   const auto fusion_layout = mma_utils::getMmaLayout(fusion);
   NVF_ERROR(fusion_layout.isValid(), fusion_layout.getErrorMsg());
 
@@ -906,7 +909,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
       *tv_r = ldst->out()->as<TensorView>();
       ldst->setOpType(
           needsTranposedLoad(*tv_r) ? LoadStoreOpType::LdMatrixTranspose
-                                   : LoadStoreOpType::LdMatrix);
+                                    : LoadStoreOpType::LdMatrix);
     } else {
       *tv_r = tv_smem->cacheAfter(
           needsTranposedLoad(tv_smem) ? LoadStoreOpType::LdMatrixTranspose

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <id_model/id_model.h>
 #include <inlining.h>
 #include <instrumentation.h>
 #include <multidevice/utils.h>
@@ -905,9 +906,6 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
     auto toTranspose = needsTranposedLoad(producer, consumer);
     if (auto ldst = dynamic_cast<LoadStoreOp*>(tv_smem->uses().at(0))) {
       *tv_r = ldst->out()->as<TensorView>();
-      if (*tv_r == bcr){
-        toTranspose = false;
-      } 
       ldst->setOpType(
           toTranspose ? LoadStoreOpType::LdMatrixTranspose
                       : LoadStoreOpType::LdMatrix);

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -884,7 +884,9 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   // We add two LoadStore operators to the inputs of our fusions. The first one
   // is for a read from global memory and the second one (below) is for
   // a cache read. As an optimizaton, we avoid adding an operator if there's an
-  // existing LoadStoreOp present.
+  // existing LoadStoreOp present. Please note that for the second LoadStore we
+  // don't propagte the allocation domain, since the scheduler sets the
+  // allocation domain in the registers.
   auto addSetForCacheRead = [](TensorView* tv_smem, TensorView** tv_r) {
     if (auto ldst = dynamic_cast<LoadStoreOp*>(tv_smem->uses().at(0))) {
       *tv_r = ldst->out()->as<TensorView>();

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <id_model/id_model.h>
 #include <inlining.h>
 #include <instrumentation.h>
 #include <multidevice/utils.h>

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -905,6 +905,9 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
     auto toTranspose = needsTranposedLoad(producer, consumer);
     if (auto ldst = dynamic_cast<LoadStoreOp*>(tv_smem->uses().at(0))) {
       *tv_r = ldst->out()->as<TensorView>();
+      if (*tv_r == bcr){
+        toTranspose = false;
+      } 
       ldst->setOpType(
           toTranspose ? LoadStoreOpType::LdMatrixTranspose
                       : LoadStoreOpType::LdMatrix);

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -901,18 +901,13 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
 
   for (auto [tv_smem, tv_r] :
        {std::make_pair(acw_smem, &acr), std::make_pair(bcw_smem, &bcr)}) {
-    auto producer = tv_smem;
-    auto consumer = tv_smem->uses().at(0)->output(0)->as<TensorView>();
-    auto toTranspose = needsTranposedLoad(producer, consumer);
     if (auto ldst = dynamic_cast<LoadStoreOp*>(tv_smem->uses().at(0))) {
       *tv_r = ldst->out()->as<TensorView>();
-      ldst->setOpType(
-          toTranspose ? LoadStoreOpType::LdMatrixTranspose
-                      : LoadStoreOpType::LdMatrix);
     } else {
       *tv_r = tv_smem->cacheAfter(
-          toTranspose ? LoadStoreOpType::LdMatrixTranspose
-                      : LoadStoreOpType::LdMatrix);
+          LoadStoreOpType::Set,
+          CacheOp::Unspecified,
+          false /* propagate allocation*/);
     }
   }
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -882,16 +882,17 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   NVF_ERROR(acw_smem->uses().size() == 1);
   NVF_ERROR(bcw_smem->uses().size() == 1);
 
-  // We add two set operators to the inputs of our fusions. The first set
-  // operator is for a read from global memory and the second one (below) is for
+  // We add two LoadStore operators to the inputs of our fusions. The first one
+  // is for a read from global memory and the second one (below) is for
   // a cache read. As an optimizaton, we avoid adding an operator if there's an
-  // existing LoadStoreOp present already.
+  // existing LoadStoreOp present.
   auto addSetForCacheRead = [](TensorView* tv_smem, TensorView** tv_r) {
     if (auto ldst = dynamic_cast<LoadStoreOp*>(tv_smem->uses().at(0))) {
       *tv_r = ldst->out()->as<TensorView>();
+      ldst->setOpType(LoadStoreOpType::LdMatrix);
     } else {
       *tv_r = tv_smem->cacheAfter(
-          LoadStoreOpType::Set,
+          LoadStoreOpType::LdMatrix,
           CacheOp::Unspecified,
           /*propagate_allocation_domain=*/false);
     }

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -735,16 +735,6 @@ void scheduleSplitKSum(
   splitk_sum->axis(-1)->parallelize(ParallelType::Vectorize);
 }
 
-bool needsTranposedLoad(TensorView* producer, TensorView* consumer) {
-  const auto map =
-      PairwiseRootDomainMap(producer, consumer).mapProducerToConsumer();
-  auto maybeProducerAlloc = producer->getMaybeAllocationDomain();
-  auto maybeConsumerRFactor = consumer->getMaybeRFactorDomain();
-  auto prodToconsumerAllocDomInner =
-      map.find(maybeProducerAlloc.back())->second;
-  return maybeConsumerRFactor.back() != prodToconsumerAllocDomInner;
-}
-
 } // namespace
 
 void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -406,11 +406,11 @@ void makeTile(TensorView* tv, std::vector<int64_t> tile_sizes) {
 
 namespace {
 
-std::optional<IterDomain*> getMaybeRootIfInnermostTiled(
+std::optional<IterDomain*> getMaybeAllocationIfInnermostTiled(
     IterDomain* id,
-    const std::unordered_set<IterDomain*>& maybe_rfactor_id_set) {
+    const std::unordered_set<IterDomain*>& maybe_allocation_id_set) {
   // Root id defaults to an "innermost id".
-  while (id->definition() && !maybe_rfactor_id_set.count(id)) {
+  while (id->definition() && !maybe_allocation_id_set.count(id)) {
     if (auto split = dynamic_cast<Split*>(id->definition())) {
       if (id == split->inner()) {
         id = split->in();
@@ -426,16 +426,17 @@ std::optional<IterDomain*> getMaybeRootIfInnermostTiled(
 
 } // namespace
 
-void orderTiledConcreteIdAsRoot(TensorView* tv) {
+void orderTiledConcreteIdAsMaybeAllocationDomain(TensorView* tv) {
   int64_t ndims = tv->nDims();
 
   // Keep track of the left most position where we will
   //  be reordering the axes.
   int64_t leftmost_pos = ndims;
 
-  // Pull the root id's of the given tv.
-  std::unordered_set<IterDomain*> maybe_rfactor_id_set{
-      tv->getRFactorDomain().begin(), tv->getRFactorDomain().end()};
+  // Pull the maybe allocation domain id's of the given tv.
+  std::unordered_set<IterDomain*> id_set{
+      tv->getMaybeAllocationDomain().begin(),
+      tv->getMaybeAllocationDomain().end()};
 
   // Keep track of leaf positions that is either a reduction
   //  or a broadcast.
@@ -444,9 +445,9 @@ void orderTiledConcreteIdAsRoot(TensorView* tv) {
   //  here for completeness.
   std::deque<int64_t> broadcast_or_reduction_pos;
 
-  // Map the root id's to their innermost concrete id's
+  // Map the id's to their innermost concrete id's
   //  on the leaf.
-  std::unordered_map<IterDomain*, int64_t> root_id_to_inner_leaf_pos;
+  std::unordered_map<IterDomain*, int64_t> id_to_inner_leaf_pos;
 
   // Try to re-order inner iterdomains from the innermost
   //  position backward. This utility only tries to re-order
@@ -470,18 +471,17 @@ void orderTiledConcreteIdAsRoot(TensorView* tv) {
       leftmost_pos = i;
       continue;
     }
-    auto maybe_root =
-        getMaybeRootIfInnermostTiled(leaf_id, maybe_rfactor_id_set);
+    auto maybe_alloc_domain =
+        getMaybeAllocationIfInnermostTiled(leaf_id, id_set);
 
-    if (maybe_root.has_value()) {
+    if (maybe_alloc_domain.has_value()) {
       // Found an innermost id, add them to the
       //  axes to reorder.
       NVF_ERROR(
-          root_id_to_inner_leaf_pos
-              .insert(std::make_pair(maybe_root.value(), i))
+          id_to_inner_leaf_pos.insert(std::make_pair(maybe_alloc_domain.value(), i))
               .second,
-          "Multiple \"innermost\" id seen for root id :",
-          maybe_root.value()->toString(),
+          "Multiple \"innermost\" id seen for id :",
+          maybe_alloc_domain.value()->toString(),
           " on ",
           tv->toString(),
           " very likely an invariant is broken.");
@@ -508,9 +508,9 @@ void orderTiledConcreteIdAsRoot(TensorView* tv) {
   //  domain ordering by iterating on the root domain and
   //  find their corresponding inner tile iterdomains from
   //  the populated root_id_to_inner_leaf_pos.
-  for (auto root_id : tv->getRFactorDomain()) {
-    auto leaf_id_pos_it = root_id_to_inner_leaf_pos.find(root_id);
-    if (leaf_id_pos_it != root_id_to_inner_leaf_pos.end()) {
+  for (auto id : tv->getMaybeAllocationDomain()) {
+    auto leaf_id_pos_it = id_to_inner_leaf_pos.find(id);
+    if (leaf_id_pos_it != id_to_inner_leaf_pos.end()) {
       reorder_map_old_to_new[leaf_id_pos_it->second] = current_pos++;
     }
   }

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -478,7 +478,8 @@ void orderTiledConcreteIdAsMaybeAllocationDomain(TensorView* tv) {
       // Found an innermost id, add them to the
       //  axes to reorder.
       NVF_ERROR(
-          id_to_inner_leaf_pos.insert(std::make_pair(maybe_alloc_domain.value(), i))
+          id_to_inner_leaf_pos
+              .insert(std::make_pair(maybe_alloc_domain.value(), i))
               .second,
           "Multiple \"innermost\" id seen for id :",
           maybe_alloc_domain.value()->toString(),

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -58,7 +58,7 @@ NVF_API void scheduleWarpTileWithNoReduction(
 void makeTile(TensorView* tv, std::vector<int64_t> tile_sizes);
 
 //! Order the inner tile dimensions as the original order in
-//!  root domain. Also putting broadcast domains on the left.
+//! (maybe allocation) domain. Also putting broadcast domains on the left.
 //! Eg. A[I0o,I1o,B2o,I0i,I1i,B2i] (maybe allocation domain: I1,B,I0)
 //! -> A[I0o, I1o, B2o, B2i, I1i, I0i]
 //! This is used to facilitate data layout swizzling and

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -59,11 +59,11 @@ void makeTile(TensorView* tv, std::vector<int64_t> tile_sizes);
 
 //! Order the inner tile dimensions as the original order in
 //!  root domain. Also putting broadcast domains on the left.
-//! Eg. A[I0o,I1o,B2o,I0i,I1i,B2i] (root domain: I1,B,I0)
+//! Eg. A[I0o,I1o,B2o,I0i,I1i,B2i] (maybe allocation domain: I1,B,I0)
 //! -> A[I0o, I1o, B2o, B2i, I1i, I0i]
 //! This is used to facilitate data layout swizzling and
 //!  defining vectorized loads.
-void orderTiledConcreteIdAsRoot(TensorView* tv);
+void orderTiledConcreteIdAsMaybeAllocationDomain(TensorView* tv);
 
 //! Orders the root id ordering of the given tv as
 //! [Device, Batch, Previous Reduction, M, N, K]

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1131,7 +1131,10 @@ TensorView* TensorView::cacheFork() {
   return new_output;
 }
 
-TensorView* TensorView::cacheAfter(LoadStoreOpType op_type, CacheOp cache_op) {
+TensorView* TensorView::cacheAfter(
+    LoadStoreOpType op_type,
+    CacheOp cache_op,
+    bool propagate_allocation_domain) {
   NVF_ERROR(
       !container()->isA<kir::Kernel>(),
       "Function invalid for kernel container.");
@@ -1207,10 +1210,12 @@ TensorView* TensorView::cacheAfter(LoadStoreOpType op_type, CacheOp cache_op) {
   IrBuilder::create<LoadStoreOp>(
       container(), op_type, consumer, producer, cache_op);
 
-  auto replayed_consumer_pair = TransformReplay::replayCasP(
-      consumer, producer, -1, TransformReplayOptions().replayAllocation());
+  if (propagate_allocation_domain) {
+    auto replayed_consumer_pair = TransformReplay::replayCasP(
+        consumer, producer, -1, TransformReplayOptions().replayAllocation());
 
-  consumer->setDomain(replayed_consumer_pair.first);
+    consumer->setDomain(replayed_consumer_pair.first);
+  }
 
   return consumer;
 }

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -117,6 +117,9 @@ class PolymorphicBase {
     auto downcast_ptr = static_cast<T*>(this);
 #else
     auto downcast_ptr = dynamic_cast<T*>(this);
+    if (downcast_ptr == nullptr) {
+      std::cout << "null";
+    }
     NVF_ERROR(downcast_ptr != nullptr);
 #endif
     return downcast_ptr;
@@ -128,6 +131,9 @@ class PolymorphicBase {
     auto downcast_ptr = static_cast<const T*>(this);
 #else
     auto downcast_ptr = dynamic_cast<const T*>(this);
+    if (downcast_ptr == nullptr) {
+      std::cout << "null";
+    }
     NVF_ERROR(downcast_ptr != nullptr);
 #endif
     return downcast_ptr;
@@ -215,8 +221,9 @@ std::vector<KeyType> getSortedKeys(
 
 // Based on https://stackoverflow.com/a/9154394
 template <typename T>
-static auto hasToStringHelper(int)
-    -> decltype(std::declval<typename std::remove_pointer<T>::type>().toString(), std::true_type{});
+static auto hasToStringHelper(int) -> decltype(
+    std::declval<typename std::remove_pointer<T>::type>().toString(),
+    std::true_type{});
 
 template <typename>
 static auto hasToStringHelper(long) -> std::false_type;

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -117,9 +117,6 @@ class PolymorphicBase {
     auto downcast_ptr = static_cast<T*>(this);
 #else
     auto downcast_ptr = dynamic_cast<T*>(this);
-    if (downcast_ptr == nullptr) {
-      std::cout << "null";
-    }
     NVF_ERROR(downcast_ptr != nullptr);
 #endif
     return downcast_ptr;
@@ -131,9 +128,6 @@ class PolymorphicBase {
     auto downcast_ptr = static_cast<const T*>(this);
 #else
     auto downcast_ptr = dynamic_cast<const T*>(this);
-    if (downcast_ptr == nullptr) {
-      std::cout << "null";
-    }
     NVF_ERROR(downcast_ptr != nullptr);
 #endif
     return downcast_ptr;
@@ -221,9 +215,8 @@ std::vector<KeyType> getSortedKeys(
 
 // Based on https://stackoverflow.com/a/9154394
 template <typename T>
-static auto hasToStringHelper(int) -> decltype(
-    std::declval<typename std::remove_pointer<T>::type>().toString(),
-    std::true_type{});
+static auto hasToStringHelper(int)
+    -> decltype(std::declval<typename std::remove_pointer<T>::type>().toString(), std::true_type{});
 
 template <typename>
 static auto hasToStringHelper(long) -> std::false_type;

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2812,224 +2812,102 @@ TEST_F(MatmulSchedulerTest, DISABLED_RequireExternalPlugin) {
   MatmulParams params;
 }
 
-TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTransposeAndAlloc) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
+class AllocationDomainTest
+    : public NVFuserFixtureParamTest<std::tuple<bool, bool>> {
+ protected:
+  // Allocation order set by the pass breaks matmul tests
+  // see issue https://github.com/NVIDIA/Fuser/issues/1810
+  AllocationDomainTest() : optimization_guard_(false) {
+    DisableOptionsGuard::getCurOptions().set(DisableOption::MatmulExprEval);
+  }
+
+ private:
+  preseg_passes::OptimizationPassGuard<preseg_passes::AllocationDomainPass>
+      optimization_guard_;
+
+  DisableOptionsGuard option_guard_;
+};
+
+// This tests fusions where inputs to a Matmul will have the root domains
+// [M, K] and [K, N], and all possible combinations of allocation domains.
+// Please note that inpout in B is transposed prior to creating a Mma op.
+TEST_P(AllocationDomainTest, BasicMatmul) {
+  bool a_has_allocation = std::get<0>(GetParam());
+  bool b_has_allocation = std::get<0>(GetParam());
+
+  auto setupFusion = [](Fusion* fusion, TensorView* tv0, TensorView* tv1) {
+    fusion->addInput(tv0);
+    fusion->addInput(tv1);
+
+    // This has rfactor: {N, K}
+    auto tv1t = transpose(tv1);
+
+    // Propagate the allocation domain of B accross the transpose.
+    if (tv1->hasAllocation()) {
+      tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
+    }
+
+    // [M, N, K]
+    auto tv0b = broadcast(tv0, {false, true, false});
+    auto tv1b = broadcast(tv1t, {true, false, false});
+
+    auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+    fusion->addOutput(tv2);
+  };
+
+  auto schedule = [](Fusion* fusion) {
+    MatMulTileOptions gemm_tile;
+    gemm_tile.cta_tile = GemmTile(128, 128, 32);
+    gemm_tile.warp_tile = GemmTile(64, 64, 32);
+    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+    MatmulParams params;
+    params.mma_macro = MmaMacro::Ampere_16_8_16;
+    params.tile_sizes = gemm_tile;
+    params.async_gmem_load_operands = true;
+    params.double_buffer_options.double_buffer_smem_write = true;
+    params.double_buffer_options.double_buffer_smem_read = true;
+    params.double_buffer_options.smem_double_buffer_stage = 4;
+    scheduleMatmul(fusion, params);
+  };
+
   const int M = 128, N = 256, K = 512;
-  // const auto layout = MmaLayout::TT;
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
   auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
   auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
-  // Input -B.
-  tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
+  if (a_has_allocation) {
+    tv0->setAllocationDomain({tv0->axis(1), tv0->axis(0)}, true);
+  }
 
-  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
-  tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
-  // [M, N, K]
-  auto tv0b = broadcast(tv0, {false, true, false});
-  auto tv1b = broadcast(tv1t, {true, false, false});
-  // Propagate the allocation domain post-broadcast.
-  // Don't set it in the test, but make this part of the scheduler.
-  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
+  if (b_has_allocation) {
+    tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
+  }
 
-  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
-
-  fusion->addOutput(tv2);
+  setupFusion(fusion.get(), tv0, tv1);
+  schedule(fusion.get());
 
   const auto options =
       at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
-  auto t0 = at::randn({M, K}, options);
-  auto t1 = at::randn({K, N}, options);
-  t1 = t1.as_strided(t1.sizes(), {1, K});
-
-  MatMulTileOptions gemm_tile;
-  gemm_tile.cta_tile = GemmTile(128, 128, 32);
-  gemm_tile.warp_tile = GemmTile(64, 64, 32);
-  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
-
-  MatmulParams params;
-  params.mma_macro = MmaMacro::Ampere_16_8_16;
-  params.tile_sizes = gemm_tile;
-  params.async_gmem_load_operands = true;
-  params.double_buffer_options.double_buffer_smem_write = true;
-  params.double_buffer_options.double_buffer_smem_read = true;
-  params.double_buffer_options.smem_double_buffer_stage = 4;
-  scheduleMatmul(fusion.get(), params);
+  auto t0 = a_has_allocation
+      ? at::randn({M, K}, options).as_strided({M, K}, {1, M})
+      : at::randn({M, K}, options);
+  auto t1 = b_has_allocation
+      ? at::randn({K, N}, options).as_strided({K, N}, {1, K})
+      : at::randn({K, N}, options);
 
   FusionExecutor fe;
   fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
-
   auto cg_outputs = fe.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
-TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTranspose) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
-  const int M = 128, N = 256, K = 512;
-  // const auto layout = MmaLayout::TT;
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-
-  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
-  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
-  // Input -B. No transpose in this case.
-  // tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-
-  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
-  // tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
-  // [M, N, K]
-  auto tv0b = broadcast(tv0, {false, true, false});
-  auto tv1b = broadcast(tv1t, {true, false, false});
-  // Propagate the allocation domain post-broadcast.
-  // Don't set it in the test, but make this part of the scheduler.
-  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
-
-  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
-
-  fusion->addOutput(tv2);
-
-  const auto options =
-      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
-  auto t0 = at::randn({M, K}, options);
-  auto t1 = at::randn({K, N}, options);
-
-  MatMulTileOptions gemm_tile;
-  gemm_tile.cta_tile = GemmTile(128, 128, 32);
-  gemm_tile.warp_tile = GemmTile(64, 64, 32);
-  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
-
-  MatmulParams params;
-  params.mma_macro = MmaMacro::Ampere_16_8_16;
-  params.tile_sizes = gemm_tile;
-  params.async_gmem_load_operands = true;
-  params.double_buffer_options.double_buffer_smem_write = true;
-  params.double_buffer_options.double_buffer_smem_read = true;
-  params.double_buffer_options.smem_double_buffer_stage = 4;
-  scheduleMatmul(fusion.get(), params);
-
-  FusionExecutor fe;
-  fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
-
-  auto cg_outputs = fe.runFusion({t0, t1});
-  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
-  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-}
-
-TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTransposeWithAllocDomainForA) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
-  const int M = 128, N = 256, K = 512;
-  // const auto layout = MmaLayout::TT;
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-
-  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
-  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
-  tv0->setAllocationDomain({tv0->axis(1), tv0->axis(0)}, true);
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-
-  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
-  
-  // tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
-  // [M, N, K]
-  auto tv0b = broadcast(tv0, {false, true, false});
-  auto tv1b = broadcast(tv1t, {true, false, false});
-  // Propagate the allocation domain post-broadcast.
-  // Don't set it in the test, but make this part of the scheduler.
-  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
-
-  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
-
-  fusion->addOutput(tv2);
-
-  const auto options =
-      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
-  auto t0 = at::randn({M, K}, options).as_strided({M, K}, {1, M});
-  auto t1 = at::randn({K, N}, options);
-
-  MatMulTileOptions gemm_tile;
-  gemm_tile.cta_tile = GemmTile(128, 128, 32);
-  gemm_tile.warp_tile = GemmTile(64, 64, 32);
-  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
-
-  MatmulParams params;
-  params.mma_macro = MmaMacro::Ampere_16_8_16;
-  params.tile_sizes = gemm_tile;
-  params.async_gmem_load_operands = true;
-  params.double_buffer_options.double_buffer_smem_write = true;
-  params.double_buffer_options.double_buffer_smem_read = true;
-  params.double_buffer_options.smem_double_buffer_stage = 4;
-  scheduleMatmul(fusion.get(), params);
-
-  FusionExecutor fe;
-  fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
-
-  auto cg_outputs = fe.runFusion({t0, t1});
-  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
-  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-}
-
-TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTransposeWithAllocDomainForAandB) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
-  const int M = 128, N = 256, K = 512;
-  // const auto layout = MmaLayout::TT;
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-
-  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
-  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
-  tv0->setAllocationDomain({tv0->axis(1), tv0->axis(0)}, true);
-  tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-
-  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
-  tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
-  
-  // tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
-  // [M, N, K]
-  auto tv0b = broadcast(tv0, {false, true, false});
-  auto tv1b = broadcast(tv1t, {true, false, false});
-  // Propagate the allocation domain post-broadcast.
-  // Don't set it in the test, but make this part of the scheduler.
-  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
-
-  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
-
-  fusion->addOutput(tv2);
-
-  const auto options =
-      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
-  auto t0 = at::randn({M, K}, options).as_strided({M, K}, {1, M});
-  auto t1 = at::randn({K, N}, options).as_strided({K, N}, {1, K});
-
-  MatMulTileOptions gemm_tile;
-  gemm_tile.cta_tile = GemmTile(128, 128, 32);
-  gemm_tile.warp_tile = GemmTile(64, 64, 32);
-  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
-
-  MatmulParams params;
-  params.mma_macro = MmaMacro::Ampere_16_8_16;
-  params.tile_sizes = gemm_tile;
-  params.async_gmem_load_operands = true;
-  params.double_buffer_options.double_buffer_smem_write = true;
-  params.double_buffer_options.double_buffer_smem_read = true;
-  params.double_buffer_options.smem_double_buffer_stage = 4;
-  scheduleMatmul(fusion.get(), params);
-
-  FusionExecutor fe;
-  fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
-
-  auto cg_outputs = fe.runFusion({t0, t1});
-  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
-  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-}
+INSTANTIATE_TEST_SUITE_P(
+    MatmulSchedulerTest,
+    AllocationDomainTest,
+    testing::Combine(testing::Bool(), testing::Bool()));
 
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD
 

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2833,8 +2833,8 @@ class AllocationDomainTest
 // Please note that inpout in B is transposed prior to creating a Mma op.
 TEST_P(AllocationDomainTest, BasicMatmul) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
-  bool a_has_allocation = std::get<0>(GetParam());
-  bool b_has_allocation = std::get<0>(GetParam());
+  bool a_m_inner = std::get<0>(GetParam());
+  bool b_k_inner = std::get<0>(GetParam());
 
   auto setupFusion = [](Fusion* fusion, TensorView* tv0, TensorView* tv1) {
     fusion->addInput(tv0);
@@ -2842,11 +2842,6 @@ TEST_P(AllocationDomainTest, BasicMatmul) {
 
     // This has rfactor: {N, K}
     auto tv1t = transpose(tv1);
-
-    // Propagate the allocation domain of B accross the transpose.
-    if (tv1->hasAllocation()) {
-      tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
-    }
 
     // [M, N, K]
     auto tv0b = broadcast(tv0, {false, true, false});
@@ -2879,11 +2874,11 @@ TEST_P(AllocationDomainTest, BasicMatmul) {
 
   auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
   auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
-  if (a_has_allocation) {
+  if (a_m_inner) {
     tv0->setAllocationDomain({tv0->axis(1), tv0->axis(0)}, true);
   }
 
-  if (b_has_allocation) {
+  if (b_k_inner) {
     tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
   }
 
@@ -2892,12 +2887,10 @@ TEST_P(AllocationDomainTest, BasicMatmul) {
 
   const auto options =
       at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
-  auto t0 = a_has_allocation
-      ? at::randn({M, K}, options).as_strided({M, K}, {1, M})
-      : at::randn({M, K}, options);
-  auto t1 = b_has_allocation
-      ? at::randn({K, N}, options).as_strided({K, N}, {1, K})
-      : at::randn({K, N}, options);
+  auto t0 = a_m_inner ? at::randn({M, K}, options).as_strided({M, K}, {1, M})
+                      : at::randn({M, K}, options);
+  auto t1 = b_k_inner ? at::randn({K, N}, options).as_strided({K, N}, {1, K})
+                      : at::randn({K, N}, options);
 
   FusionExecutor fe;
   fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2866,7 +2866,7 @@ class AllocationDomainTest
     return {t0, t1};
   }
 
-  MatmulParams params;
+  static MatmulParams params;
 
  private:
   preseg_passes::OptimizationPassGuard<preseg_passes::AllocationDomainPass>
@@ -2899,7 +2899,7 @@ TEST_P(AllocationDomainTest, BasicMatmul) {
   auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
   fusion->addOutput(tv2);
 
-  scheduleMatmul(fusion.get(), params);
+  scheduleMatmul(fusion.get(), AllocationDomainTest::params);
 
   auto [t0, t1] = getInputTensors(M, N, K, a_m_inner, b_k_inner);
   FusionExecutor fe;

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2921,6 +2921,116 @@ TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTranspose) {
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
+TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTransposeWithAllocDomainForA) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
+  const int M = 128, N = 256, K = 512;
+  // const auto layout = MmaLayout::TT;
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
+  tv0->setAllocationDomain({tv0->axis(1), tv0->axis(0)}, true);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+
+  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
+  
+  // tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
+  // [M, N, K]
+  auto tv0b = broadcast(tv0, {false, true, false});
+  auto tv1b = broadcast(tv1t, {true, false, false});
+  // Propagate the allocation domain post-broadcast.
+  // Don't set it in the test, but make this part of the scheduler.
+  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
+
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+
+  fusion->addOutput(tv2);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
+  auto t0 = at::randn({M, K}, options).as_strided({M, K}, {1, M});
+  auto t1 = at::randn({K, N}, options);
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.double_buffer_options.double_buffer_smem_write = true;
+  params.double_buffer_options.double_buffer_smem_read = true;
+  params.double_buffer_options.smem_double_buffer_stage = 4;
+  scheduleMatmul(fusion.get(), params);
+
+  FusionExecutor fe;
+  fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
+TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTransposeWithAllocDomainForAandB) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
+  const int M = 128, N = 256, K = 512;
+  // const auto layout = MmaLayout::TT;
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
+  tv0->setAllocationDomain({tv0->axis(1), tv0->axis(0)}, true);
+  tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+
+  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
+  tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
+  
+  // tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
+  // [M, N, K]
+  auto tv0b = broadcast(tv0, {false, true, false});
+  auto tv1b = broadcast(tv1t, {true, false, false});
+  // Propagate the allocation domain post-broadcast.
+  // Don't set it in the test, but make this part of the scheduler.
+  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
+
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+
+  fusion->addOutput(tv2);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
+  auto t0 = at::randn({M, K}, options).as_strided({M, K}, {1, M});
+  auto t1 = at::randn({K, N}, options).as_strided({K, N}, {1, K});
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.double_buffer_options.double_buffer_smem_write = true;
+  params.double_buffer_options.double_buffer_smem_read = true;
+  params.double_buffer_options.smem_double_buffer_stage = 4;
+  scheduleMatmul(fusion.get(), params);
+
+  FusionExecutor fe;
+  fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD
 
 } // namespace nvfuser

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2906,4 +2906,60 @@ INSTANTIATE_TEST_SUITE_P(
 
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD
 
+// Matmul test for Ampere MMA: across supported layouts
+TEST_F(MatmulSchedulerTest, FusionAmpereMatmul_CUDA) {
+  // Keep multiples of 8 to keep vectorizable.
+  int M = 512, N = 128, K = 256;
+
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
+  tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
+
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  auto tvSet = set(tv1);
+  // K, N -> N, K
+  auto tv1t = transpose(tvSet);
+
+  // M, N, K
+  auto tv0b = broadcast(tv0, {false, true, false});
+  auto tv1b = broadcast(tv1t, {true, false, false});
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+
+  fusion.addOutput(tv2);
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.double_buffer_options.double_buffer_smem_write = false;
+  params.double_buffer_options.double_buffer_smem_read = false;
+  params.double_buffer_options.smem_double_buffer_stage = 1;
+  scheduleMatmul(&fusion, params);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
+  auto t0 = at::randn({M, K}, options);
+  auto t1 = at::randn({K, N}, options).as_strided({K, N}, {1, K});
+
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
 } // namespace nvfuser

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2832,6 +2832,7 @@ class AllocationDomainTest
 // [M, K] and [K, N], and all possible combinations of allocation domains.
 // Please note that inpout in B is transposed prior to creating a Mma op.
 TEST_P(AllocationDomainTest, BasicMatmul) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   bool a_has_allocation = std::get<0>(GetParam());
   bool b_has_allocation = std::get<0>(GetParam());
 

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2916,7 +2916,7 @@ TEST_F(MatmulSchedulerTest, FusionAmpereMatmul_CUDA) {
 
   auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
   auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
-  // tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
+  tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
 
   fusion.addInput(tv0);
   fusion.addInput(tv1);
@@ -2950,8 +2950,7 @@ TEST_F(MatmulSchedulerTest, FusionAmpereMatmul_CUDA) {
   const auto options =
       at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
   auto t0 = at::randn({M, K}, options);
-  // auto t1 = at::randn({K, N}, options).as_strided({K, N}, {1, K});
-  auto t1 = at::randn({K, N}, options);
+  auto t1 = at::randn({K, N}, options).as_strided({K, N}, {1, K});
 
   FusionExecutor fe;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
@@ -3016,8 +3015,6 @@ TEST_F(MatmulSchedulerTest, FusionAmpereMatmulWithPrologue) {
       fe.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
   auto cg_outputs = fe.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.sin().to(at::kFloat));
-  std::cout << tref << std::endl;
-  std::cout << cg_outputs[0] << std::endl;
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.1, 0.1));
 }
 

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3037,6 +3037,139 @@ TEST_P(AllocationDomainTest, FusionAmpereMatmulWithPrologue) {
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.1, 0.1));
 }
 
+// Matmul test for Ampere MMA: across supported layouts
+TEST_P(AllocationDomainTest, FusionAmpereMatmulNoTranspose) {
+  // Keep multiples of 8 to keep vectorizable.
+  int M = 512, N = 128, K = 256;
+
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
+  bool a_m_inner = std::get<0>(GetParam());
+  bool b_k_inner = std::get<0>(GetParam());
+
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
+
+  if (a_m_inner) {
+    tv0->setAllocationDomain({tv0->axis(1), tv0->axis(0)}, true);
+  }
+
+  if (b_k_inner) {
+    tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
+  }
+
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  // M, K, N
+  auto tv0b = broadcast(tv0, {false, false, true});
+  auto tv1b = broadcast(tv1, {true, false, false});
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+
+  fusion.addOutput(tv2);
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.double_buffer_options.double_buffer_smem_write = false;
+  params.double_buffer_options.double_buffer_smem_read = false;
+  params.double_buffer_options.smem_double_buffer_stage = 1;
+  scheduleMatmul(&fusion, params);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
+  auto t0 = a_m_inner ? at::randn({M, K}, options).as_strided({M, K}, {1, M})
+                      : at::randn({M, K}, options);
+  auto t1 = b_k_inner ? at::randn({K, N}, options).as_strided({K, N}, {1, K})
+                      : at::randn({K, N}, options);
+
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
+// Matmul test for Ampere MMA: across supported layouts
+TEST_P(AllocationDomainTest, FusionAmpereMatmulPrologueNoTranspose) {
+  // Keep multiples of 8 to keep vectorizable.
+  int M = 512, N = 128, K = 256;
+
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
+  bool a_m_inner = std::get<0>(GetParam());
+  bool b_k_inner = std::get<0>(GetParam());
+
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
+
+  if (a_m_inner) {
+    tv0->setAllocationDomain({tv0->axis(1), tv0->axis(0)}, true);
+  }
+
+  if (b_k_inner) {
+    tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
+  }
+
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  auto tv1set = set(tv1);
+  auto tv1c = castOp(DataType::Half, sin(tv1set));
+
+  // M, K, N
+  auto tv0b = broadcast(tv0, {false, false, true});
+  auto tv1b = broadcast(tv1c, {true, false, false});
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {1});
+
+  fusion.addOutput(tv2);
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.double_buffer_options.double_buffer_smem_write = false;
+  params.double_buffer_options.double_buffer_smem_read = false;
+  params.double_buffer_options.smem_double_buffer_stage = 1;
+  scheduleMatmul(&fusion, params);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
+  auto t0 = a_m_inner ? at::randn({M, K}, options).as_strided({M, K}, {1, M})
+                      : at::randn({M, K}, options);
+  auto t1 = b_k_inner ? at::randn({K, N}, options).as_strided({K, N}, {1, K})
+                      : at::randn({K, N}, options);
+
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = t0.to(at::kFloat).matmul(t1.sin().to(at::kFloat));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
 INSTANTIATE_TEST_SUITE_P(
     MatmulSchedulerTest,
     AllocationDomainTest,

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2864,6 +2864,7 @@ TEST_P(AllocationDomainTest, BasicMatmul) {
 
     MatmulParams params;
     params.mma_macro = MmaMacro::Ampere_16_8_16;
+    params.supported_vec_size = {8, 8, 4};
     params.tile_sizes = gemm_tile;
     params.async_gmem_load_operands = true;
     params.double_buffer_options.double_buffer_smem_write = true;

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2812,6 +2812,61 @@ TEST_F(MatmulSchedulerTest, DISABLED_RequireExternalPlugin) {
   MatmulParams params;
 }
 
+TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTransposeAndAlloc) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
+  const int M = 128, N = 256, K = 512;
+  // const auto layout = MmaLayout::TT;
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
+  // Input -B.
+  tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+
+  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
+  tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
+  // [M, N, K]
+  auto tv0b = broadcast(tv0, {false, true, false});
+  auto tv1b = broadcast(tv1t, {true, false, false});
+  // Propagate the allocation domain post-broadcast.
+  // Don't set it in the test, but make this part of the scheduler.
+  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
+
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+
+  fusion->addOutput(tv2);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
+  auto t0 = at::randn({M, K}, options);
+  auto t1 = at::randn({K, N}, options);
+  t1 = t1.as_strided(t1.sizes(), {1, K});
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.double_buffer_options.double_buffer_smem_write = true;
+  params.double_buffer_options.double_buffer_smem_read = true;
+  params.double_buffer_options.smem_double_buffer_stage = 4;
+  scheduleMatmul(fusion.get(), params);
+
+  FusionExecutor fe;
+  fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD
 
 } // namespace nvfuser

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2867,6 +2867,60 @@ TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTransposeAndAlloc) {
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
+TEST_F(MatmulSchedulerPluginTest, SimpleMatmulWithTranspose) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 8, 9);
+  const int M = 128, N = 256, K = 512;
+  // const auto layout = MmaLayout::TT;
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeContigConcreteTensor({M, K}, DataType::Half);
+  auto tv1 = makeContigConcreteTensor({K, N}, DataType::Half);
+  // Input -B. No transpose in this case.
+  // tv1->setAllocationDomain({tv1->axis(1), tv1->axis(0)}, true);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+
+  auto tv1t = transpose(tv1); // This has rfactor: {N, K}
+  // tv1t->setAllocationDomain({tv1t->axis(0), tv1t->axis(1)}, true);
+  // [M, N, K]
+  auto tv0b = broadcast(tv0, {false, true, false});
+  auto tv1b = broadcast(tv1t, {true, false, false});
+  // Propagate the allocation domain post-broadcast.
+  // Don't set it in the test, but make this part of the scheduler.
+  // tv1->setAllocationDomain({tv1->axis(0), tv1->axis(2), tv1->axis(1)}, true);
+
+  auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
+
+  fusion->addOutput(tv2);
+
+  const auto options =
+      at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0 /*device*/);
+  auto t0 = at::randn({M, K}, options);
+  auto t1 = at::randn({K, N}, options);
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.double_buffer_options.double_buffer_smem_write = true;
+  params.double_buffer_options.double_buffer_smem_read = true;
+  params.double_buffer_options.smem_double_buffer_stage = 4;
+  scheduleMatmul(fusion.get(), params);
+
+  FusionExecutor fe;
+  fe.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD
 
 } // namespace nvfuser

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2866,7 +2866,7 @@ class AllocationDomainTest
     return {t0, t1};
   }
 
-  static MatmulParams params;
+  MatmulParams params;
 
  private:
   preseg_passes::OptimizationPassGuard<preseg_passes::AllocationDomainPass>
@@ -2899,7 +2899,7 @@ TEST_P(AllocationDomainTest, BasicMatmul) {
   auto tv2 = fusedMultiplySum(tv0b, tv1b, {2});
   fusion->addOutput(tv2);
 
-  scheduleMatmul(fusion.get(), AllocationDomainTest::params);
+  scheduleMatmul(fusion.get(), params);
 
   auto [t0, t1] = getInputTensors(M, N, K, a_m_inner, b_k_inner);
   FusionExecutor fe;


### PR DESCRIPTION
In this PR we extend the matmul scheduler to support inputs with allocation domains.


To the fusion (with inputs tv_a and tv_b), we add two LoadStoreOps to both inputs.
The first Op corresponds to a load to shared memory, where we propagate the allocation domain. The second op corresponds to reading to registers, where we don't propagate the allocation domain since the scheduler takes charge of setting the allocation domain in the registers. Based on the difference in the (maybe)allocation domain of the producer and consumer of the second LoadStoreOp, we may do transposed load when reading to registers.

![image](https://github.com/NVIDIA/Fuser/assets/10635897/89395990-9b85-4ce1-8e7d-006e43a86b85)


See also https://github.com/NVIDIA/Fuser/pull/2315.