### PR TITLE
Use a consistent loop graph while building loop promotion mappings

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -390,7 +390,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (isOptionEnabled(EnableOption::IdModel)) {
+  if (true || isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_);
   }
 


### PR DESCRIPTION
Currently when building the loop promotion mappings, we just use the latest loop graph (i.e., `idGraph(IdMappingMode::LOOP)`. However, since that graph is incrementally updated while building the promotion mappings, and each of the steps build a map based on the Loop graph at that point, using those maps in subsequent steps may not work as intended. I found in some cases the final mappings were inconsistent when testing the IdModel-based indexing. This PR fixes the usage of the underlying Loop graph when building the promotion mappings. I didn't add any particular unit test since I thought this change just makes sense.