### PR TITLE
Add `DynamicType::dispatch` as a general mechanism for dispatching function calls

### DIFF
--- a/lib/dynamic_type/CMakeLists.txt
+++ b/lib/dynamic_type/CMakeLists.txt
@@ -13,6 +13,7 @@ if(BUILD_TEST)
             test/assignment.cpp
             test/binary_ops.cpp
             test/container.cpp
+            test/dispatch.cpp
             test/examples.cpp
             test/hash.cpp
             test/member.cpp

--- a/lib/dynamic_type/README.md
+++ b/lib/dynamic_type/README.md
@@ -272,6 +272,29 @@ for (T : {int, double, std::monostate, std::vector<IntDoubleVec>}) {
 }
 ```
 
+The function being dispatched can have multiple arguments, each argument can be either a `DynamicType` or a regular type.
+For each `DynamicType` argument, `dispatch` will do a loop on all types to find the actual type and call the function with that type.
+For example:
+
+```C++
+auto get_total_size = [](auto x, size_t num_x, auto y, size_t num_y) {
+  return sizeof(x) * num_x + sizeof(y) * num_y;
+};
+IntDoubleVec::dispatch(get_total_size, mydata1, 3, mydata2, 5); // returns 44
+```
+
+where the above dispatch is equivalent to the following pseudocode:
+
+```C++
+for (T1 : {int, double, std::monostate, std::vector<IntDoubleVec>}) {
+  for (T2 : {int, double, std::monostate, std::vector<IntDoubleVec>}) {
+    if (mydata1.is<T1>() && mydata2.is<T2>()) {
+      return get_total_size(mydata1.as<T1>(), 3, mydata2.as<T2>(), 5);
+    }
+  }
+}
+```
+
 # Benchmarks
 
 The benchmark `benchmark/sort.cpp` for running a simple `std::sort` on a vector of `int64_t`

--- a/lib/dynamic_type/README.md
+++ b/lib/dynamic_type/README.md
@@ -295,6 +295,34 @@ for (T1 : {int, double, std::monostate, std::vector<IntDoubleVec>}) {
 }
 ```
 
+If the output type of the callback function is different for different input types,
+then we promote the output type to `DynamicType`. For example:
+
+```C++
+auto my_pow = [](auto x, auto exp) {
+  if constexpr (
+      std::is_arithmetic_v<decltype(x)> &&
+      std::is_arithmetic_v<decltype(exp)>) {
+    if constexpr (std::is_integral_v<decltype(exp)>) {
+      decltype(x) result = 1;
+      while (exp-- > 0) {
+        result *= x;
+      }
+      return result;
+    } else {
+      return std::pow(x, exp);
+    }
+  } else {
+    throw std::runtime_error("Unsupported type");
+    return;
+  }
+};
+IntDoubleVec::dispatch(my_pow, mydata1, mydata1); //IntDoubleVec(double, 27.0)
+IntDoubleVec::dispatch(my_pow, mydata1, mydata2); //IntDoubleVec(double, 9.0)
+IntDoubleVec::dispatch(my_pow, mydata2, mydata1); //IntDoubleVec(double, 8.0)
+IntDoubleVec::dispatch(my_pow, mydata2, mydata2); //IntDoubleVec(int, 4)
+```
+
 # Benchmarks
 
 The benchmark `benchmark/sort.cpp` for running a simple `std::sort` on a vector of `int64_t`

--- a/lib/dynamic_type/README.md
+++ b/lib/dynamic_type/README.md
@@ -323,6 +323,24 @@ IntDoubleVec::dispatch(my_pow, mydata2, mydata1); //IntDoubleVec(double, 8.0)
 IntDoubleVec::dispatch(my_pow, mydata2, mydata2); //IntDoubleVec(int, 4)
 ```
 
+The arguments and return types of the callback function are perfectly forwarded.
+So we can use references as arguments or return values, and it will be correctly handled.
+For example:
+
+```C++
+std::vector<float> vec = {0.0, 1.0, 2.0, 3.0};
+auto get_item = [](auto& v, auto index) -> decltype(auto) {
+  if constexpr (std::is_integral_v<decltype(index)>) {
+    return v[index];
+  } else {
+    throw std::runtime_error("Illegal index type");
+    return;
+  }
+};
+IntDoubleVec::dispatch(get_item, vec, mydata2) = 100.0;
+// vec is now {0.0, 1.0, 100.0, 3.0}
+```
+
 # Benchmarks
 
 The benchmark `benchmark/sort.cpp` for running a simple `std::sort` on a vector of `int64_t`

--- a/lib/dynamic_type/README.md
+++ b/lib/dynamic_type/README.md
@@ -262,10 +262,9 @@ IntDoubleVec mydata2 = 123;
 IntDoubleVec::dispatch(get_size, mydata2); // returns 4
 ```
 
-The above code is equivalent to the following pseudocode:
+The above dispatch is equivalent to the following pseudocode:
 
 ```C++
-auto get_size = [](auto x) { return sizeof(x); };
 for (T : {int, double, std::monostate, std::vector<IntDoubleVec>}) {
   if (mydata.is<T>()) {
     return get_size(mydata.as<T>());

--- a/lib/dynamic_type/README.md
+++ b/lib/dynamic_type/README.md
@@ -251,7 +251,27 @@ Operations on `DynamicType` are as `constexpr` as possible. So most tests in
 ## Dispatching
 
 `DynamicType` has a static member function `dispatch`, which is a general tool to dispatch on function calls.
-For example, if you have the following function:
+For example, if you want to know the size of the actual data held in a `DynamicType`, you can do the following:
+
+```C++
+using IntDoubleVec = DynamicType<Containers<std::vector>, int, double>;
+auto get_size = [](auto x) { return sizeof(x); };
+IntDoubleVec mydata1 = 3.0;
+IntDoubleVec::dispatch(get_size, mydata1); // returns 8
+IntDoubleVec mydata2 = 123;
+IntDoubleVec::dispatch(get_size, mydata2); // returns 4
+```
+
+The above code is equivalent to the following pseudocode:
+
+```C++
+auto get_size = [](auto x) { return sizeof(x); };
+for (T : {int, double, std::monostate, std::vector<IntDoubleVec>}) {
+  if (mydata.is<T>()) {
+    return get_size(mydata.as<T>());
+  }
+}
+```
 
 # Benchmarks
 

--- a/lib/dynamic_type/README.md
+++ b/lib/dynamic_type/README.md
@@ -130,13 +130,15 @@ extra work. All the behaviors mentioned in this note are tested in
 `test/examples.cpp`, so if you want to change anything in this doc, please make
 sure to update the test as well.
 
+## Containers
+
 `DynamicType` also supports recursive types, that is, the type list can
 contain `DynamicType`. For example, something like:
 
 ```C++
 // Warning: this code does not compile!
 using IntFloatVecList = DynamicType<
-    NoContainers,
+    ??,
     int,
     float,
     std::vector<IntFloatVecList>,
@@ -204,6 +206,8 @@ x[0] // gets IntFloatVec(1)
 x[1] // gets IntFloatVec(2.3f)
 ```
 
+## Class member access
+
 If one of the candidate type of `DynamicType` is a struct or class, then we can use
 operator `->*&` to access their members. For example:
 
@@ -243,6 +247,11 @@ get different hash, which does not make sense.
 
 Operations on `DynamicType` are as `constexpr` as possible. So most tests in
 `DynamicTypeTest` are `static_assert` tests.
+
+## Dispatching
+
+`DynamicType` has a static member function `dispatch`, which is a general tool to dispatch on function calls.
+For example, if you have the following function:
 
 # Benchmarks
 

--- a/lib/dynamic_type/meson.build
+++ b/lib/dynamic_type/meson.build
@@ -19,6 +19,7 @@ foreach standard : ['17', '20', '23']
             'test/assignment.cpp',
             'test/binary_ops.cpp',
             'test/container.cpp',
+            'test/dispatch.cpp',
             'test/examples.cpp',
             'test/hash.cpp',
             'test/member.cpp',

--- a/lib/dynamic_type/src/dynamic_type/dynamic_type.h
+++ b/lib/dynamic_type/src/dynamic_type/dynamic_type.h
@@ -168,9 +168,6 @@ struct DynamicType {
                 std::reference_wrapper<std::remove_reference_t<result_type>>>,
             result_type>;
         ret_storage_t ret;
-        // if constexpr (!std::is_same_v<ret_storage_t, float>) {
-        //   std::tuple<ret_storage_t> a = std::nullopt;
-        // }
         DynamicType::for_all_types([&](auto t) -> decltype(auto) {
           using T = typename decltype(t)::type;
           if (arg0.template is<T>()) {

--- a/lib/dynamic_type/src/dynamic_type/dynamic_type.h
+++ b/lib/dynamic_type/src/dynamic_type/dynamic_type.h
@@ -171,6 +171,8 @@ struct DynamicType {
             has_single_return_type,
             typename std::tuple_element_t<0, result_types>::type,
             DynamicType>;
+        // Needs to wrap reference as optional<reference_wrapper<T>> because
+        // C++ does not allow rebinding a reference.
         constexpr bool is_reference = std::is_reference_v<result_type>;
         using ret_storage_t = std::conditional_t<
             is_reference,

--- a/lib/dynamic_type/src/dynamic_type/type_traits.h
+++ b/lib/dynamic_type/src/dynamic_type/type_traits.h
@@ -7,11 +7,13 @@
 // clang-format on
 #pragma once
 
+#include <cstddef>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 
 #include "C++20/type_traits"
+#include "error.h"
 
 // Note on the coding style of this file:
 // - I use `namespace dynamic_type` and `} // namespace dynamic_type` a lot to

--- a/lib/dynamic_type/src/dynamic_type/type_traits.h
+++ b/lib/dynamic_type/src/dynamic_type/type_traits.h
@@ -7,7 +7,6 @@
 // clang-format on
 #pragma once
 
-#include <cstddef>
 #include <tuple>
 #include <type_traits>
 #include <utility>

--- a/lib/dynamic_type/src/dynamic_type/type_traits.h
+++ b/lib/dynamic_type/src/dynamic_type/type_traits.h
@@ -12,7 +12,6 @@
 #include <utility>
 
 #include "C++20/type_traits"
-#include "error.h"
 
 // Note on the coding style of this file:
 // - I use `namespace dynamic_type` and `} // namespace dynamic_type` a lot to

--- a/lib/dynamic_type/test/dispatch.cpp
+++ b/lib/dynamic_type/test/dispatch.cpp
@@ -1,0 +1,180 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include "dynamic_type/dynamic_type.h"
+
+#include <string>
+
+using namespace dynamic_type;
+
+class DynamicTypeTest : public ::testing::Test {};
+
+TEST_F(DynamicTypeTest, DispatchBasic) {
+  using IntOrStr = DynamicType<NoContainers, int64_t, std::string>;
+  auto concat = [](std::string a, auto x, auto y, std::string b) {
+    std::string result = a;
+    if constexpr (std::is_same_v<decltype(x), int64_t>) {
+      result += std::to_string(x);
+    } else if constexpr (std::is_same_v<decltype(x), std::string>) {
+      result += x;
+    }
+    if constexpr (std::is_same_v<decltype(y), int64_t>) {
+      result += std::to_string(y);
+    } else if constexpr (std::is_same_v<decltype(y), std::string>) {
+      result += y;
+    }
+    return result + b;
+  };
+
+  IntOrStr one(std::string("1"));
+  IntOrStr two(2);
+  EXPECT_TRUE(one.is<std::string>());
+  EXPECT_TRUE(two.is<int64_t>());
+
+  auto concated_result11 = IntOrStr::dispatch(concat, "0", one, one, "3");
+  static_assert(std::is_same_v<decltype(concated_result11), std::string>);
+  EXPECT_EQ(concated_result11, "0113");
+
+  auto concated_result12 = IntOrStr::dispatch(concat, "0", one, two, "3");
+  static_assert(std::is_same_v<decltype(concated_result12), std::string>);
+  EXPECT_EQ(concated_result12, "0123");
+
+  auto concated_result21 = IntOrStr::dispatch(concat, "0", two, one, "3");
+  static_assert(std::is_same_v<decltype(concated_result21), std::string>);
+  EXPECT_EQ(concated_result21, "0213");
+
+  auto concated_result22 = IntOrStr::dispatch(concat, "0", two, two, "3");
+  static_assert(std::is_same_v<decltype(concated_result22), std::string>);
+  EXPECT_EQ(concated_result22, "0223");
+}
+
+TEST_F(DynamicTypeTest, DispatchArgumentPerfectForwarding) {
+  using IntOrStr = DynamicType<NoContainers, int64_t, std::string>;
+  struct NonCopyable {
+    NonCopyable() = default;
+    NonCopyable(const NonCopyable&) = delete;
+  };
+  auto concat =
+      [](std::string& result, NonCopyable&& nc, auto x, auto y, std::string b) {
+        if constexpr (std::is_same_v<decltype(x), int64_t>) {
+          result += std::to_string(x);
+        } else if constexpr (std::is_same_v<decltype(x), std::string>) {
+          result += x;
+        }
+        if constexpr (std::is_same_v<decltype(y), int64_t>) {
+          result += std::to_string(y);
+        } else if constexpr (std::is_same_v<decltype(y), std::string>) {
+          result += y;
+        }
+        result += b;
+      };
+
+  IntOrStr one(std::string("1"));
+  IntOrStr two(2);
+  EXPECT_TRUE(one.is<std::string>());
+  EXPECT_TRUE(two.is<int64_t>());
+
+  std::string concated_result11;
+  IntOrStr::dispatch(concat, concated_result11, NonCopyable{}, one, one, "3");
+  static_assert(std::is_same_v<decltype(concated_result11), std::string>);
+  EXPECT_EQ(concated_result11, "113");
+
+  std::string concated_result12;
+  IntOrStr::dispatch(concat, concated_result12, NonCopyable{}, one, two, "3");
+  static_assert(std::is_same_v<decltype(concated_result12), std::string>);
+  EXPECT_EQ(concated_result12, "123");
+
+  std::string concated_result21;
+  IntOrStr::dispatch(concat, concated_result21, NonCopyable{}, two, one, "3");
+  static_assert(std::is_same_v<decltype(concated_result21), std::string>);
+  EXPECT_EQ(concated_result21, "213");
+
+  std::string concated_result22;
+  IntOrStr::dispatch(concat, concated_result22, NonCopyable{}, two, two, "3");
+  static_assert(std::is_same_v<decltype(concated_result22), std::string>);
+  EXPECT_EQ(concated_result22, "223");
+}
+
+TEST_F(DynamicTypeTest, DispatchReturnsDynamicType) {
+  using IntOrFloat = DynamicType<NoContainers, int64_t, float>;
+  auto add = [](auto x, auto y) {
+    if constexpr (opcheck<decltype(x)> + opcheck<decltype(y)>) {
+      return x + y;
+    } else {
+      return;
+    }
+  };
+  constexpr IntOrFloat one(1);
+  constexpr IntOrFloat two(2.0f);
+  static_assert(one.is<int64_t>());
+  static_assert(two.is<float>());
+
+  auto r11 = IntOrFloat::dispatch(add, one, one);
+  static_assert(std::is_same_v<decltype(r11), IntOrFloat>);
+  EXPECT_TRUE(r11.is<int64_t>());
+  EXPECT_EQ(r11, 2);
+
+  constexpr auto ce_r11 = IntOrFloat::dispatch(add, one, one);
+  static_assert(std::is_same_v<decltype(ce_r11), const IntOrFloat>);
+  static_assert(ce_r11.is<int64_t>());
+  static_assert(ce_r11 == 2);
+
+  auto r12 = IntOrFloat::dispatch(add, one, two);
+  static_assert(std::is_same_v<decltype(r12), IntOrFloat>);
+  EXPECT_TRUE(r12.is<float>());
+  EXPECT_EQ(r12, 3.0f);
+
+  constexpr auto ce_r12 = IntOrFloat::dispatch(add, one, two);
+  static_assert(std::is_same_v<decltype(ce_r12), const IntOrFloat>);
+  static_assert(ce_r12.is<float>());
+  static_assert(ce_r12 == 3.0f);
+
+  auto r21 = IntOrFloat::dispatch(add, two, one);
+  static_assert(std::is_same_v<decltype(r21), IntOrFloat>);
+  EXPECT_TRUE(r21.is<float>());
+  EXPECT_EQ(r21, 3.0f);
+
+  constexpr auto ce_r21 = IntOrFloat::dispatch(add, two, one);
+  static_assert(std::is_same_v<decltype(ce_r21), const IntOrFloat>);
+  static_assert(ce_r21.is<float>());
+  static_assert(ce_r21 == 3.0f);
+
+  auto r22 = IntOrFloat::dispatch(add, two, two);
+  static_assert(std::is_same_v<decltype(r22), IntOrFloat>);
+  EXPECT_TRUE(r22.is<float>());
+  EXPECT_EQ(r22, 4.0f);
+
+  constexpr auto ce_r22 = IntOrFloat::dispatch(add, two, two);
+  static_assert(std::is_same_v<decltype(ce_r22), const IntOrFloat>);
+  static_assert(ce_r22.is<float>());
+  static_assert(ce_r22 == 4.0f);
+}
+
+TEST_F(DynamicTypeTest, DispatchReturnsReference) {
+  using IntOrFloat = DynamicType<NoContainers, int64_t, float>;
+  auto add = [](std::vector<int> &x, auto y) -> int& {
+    if constexpr (std::is_integral_v<decltype(y)>) {
+      return x[y];
+    }
+    throw std::runtime_error("Bad type");
+  };
+  constexpr IntOrFloat one(1);
+  constexpr IntOrFloat two(2.0f);
+  static_assert(one.is<int64_t>());
+  static_assert(two.is<float>());
+
+  std::vector<int> x = {0, 1, 2, 3};
+
+  auto& r1 = IntOrFloat::dispatch(add, x, one);
+  static_assert(std::is_same_v<decltype(r1), int&>);
+  EXPECT_EQ(r1, 1);
+  EXPECT_EQ(&r1, &x[1]);
+}

--- a/lib/dynamic_type/test/dispatch.cpp
+++ b/lib/dynamic_type/test/dispatch.cpp
@@ -162,5 +162,5 @@ TEST_F(DynamicTypeTest, DispatchReturnsReference) {
   EXPECT_THAT(
       [&]() { IntOrFloat::dispatch(add, a, two, 1); },
       ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
-          "Result is dynamic but not convertible to DynamicType")));
+          "Result is dynamic but not convertible to result type")));
 }

--- a/lib/dynamic_type/test/dispatch.cpp
+++ b/lib/dynamic_type/test/dispatch.cpp
@@ -160,9 +160,9 @@ TEST_F(DynamicTypeTest, DispatchReturnsDynamicType) {
 
 TEST_F(DynamicTypeTest, DispatchReturnsReference) {
   using IntOrFloat = DynamicType<NoContainers, int64_t, float>;
-  auto add = [](std::vector<int> &x, auto y) -> int& {
-    if constexpr (std::is_integral_v<decltype(y)>) {
-      return x[y];
+  auto add = [](std::vector<int>& a, auto x, int64_t y) -> int& {
+    if constexpr (std::is_integral_v<decltype(x)>) {
+      return a[x + y];
     }
     throw std::runtime_error("Bad type");
   };
@@ -171,10 +171,10 @@ TEST_F(DynamicTypeTest, DispatchReturnsReference) {
   static_assert(one.is<int64_t>());
   static_assert(two.is<float>());
 
-  std::vector<int> x = {0, 1, 2, 3};
+  std::vector<int> a = {0, 1, 2, 3};
 
-  auto& r1 = IntOrFloat::dispatch(add, x, one);
+  auto& r1 = IntOrFloat::dispatch(add, a, one, 1);
   static_assert(std::is_same_v<decltype(r1), int&>);
-  EXPECT_EQ(r1, 1);
-  EXPECT_EQ(&r1, &x[1]);
+  EXPECT_EQ(r1, 2);
+  EXPECT_EQ(&r1, &a[2]);
 }

--- a/lib/dynamic_type/test/examples.cpp
+++ b/lib/dynamic_type/test/examples.cpp
@@ -187,3 +187,12 @@ TEST_F(Examples, Example10) {
   EXPECT_EQ(b->*&B::y, 2.5);
   EXPECT_EQ((b->*&B::name)(), "B");
 }
+
+TEST_F(Examples, Example11) {
+  using IntDoubleVec = DynamicType<Containers<std::vector>, int, double>;
+  auto get_size = [](auto x) { return sizeof(x); };
+  IntDoubleVec mydata1 = 3.0;
+  EXPECT_EQ(IntDoubleVec::dispatch(get_size, mydata1), 8);
+  IntDoubleVec mydata2 = 123;
+  EXPECT_EQ(IntDoubleVec::dispatch(get_size, mydata2), 4);
+}

--- a/lib/dynamic_type/test/examples.cpp
+++ b/lib/dynamic_type/test/examples.cpp
@@ -193,11 +193,46 @@ TEST_F(Examples, Example11) {
   auto get_size = [](auto x) { return sizeof(x); };
   IntDoubleVec mydata1 = 3.0;
   EXPECT_EQ(IntDoubleVec::dispatch(get_size, mydata1), 8);
-  IntDoubleVec mydata2 = 123;
+  IntDoubleVec mydata2 = 2;
   EXPECT_EQ(IntDoubleVec::dispatch(get_size, mydata2), 4);
 
   auto get_total_size = [](auto x, size_t num_x, auto y, size_t num_y) {
     return sizeof(x) * num_x + sizeof(y) * num_y;
   };
   EXPECT_EQ(IntDoubleVec::dispatch(get_total_size, mydata1, 3, mydata2, 5), 44);
+
+  auto my_pow = [](auto x, auto exp) {
+    if constexpr (
+        std::is_arithmetic_v<decltype(x)> &&
+        std::is_arithmetic_v<decltype(exp)>) {
+      if constexpr (std::is_integral_v<decltype(exp)>) {
+        decltype(x) result = 1;
+        while (exp-- > 0) {
+          result *= x;
+        }
+        return result;
+      } else {
+        return std::pow(x, exp);
+      }
+    } else {
+      throw std::runtime_error("Unsupported type");
+      return;
+    }
+  };
+  auto r11 = IntDoubleVec::dispatch(my_pow, mydata1, mydata1);
+  static_assert(std::is_same_v<decltype(r11), IntDoubleVec>);
+  EXPECT_TRUE(r11.is<double>());
+  EXPECT_EQ(r11, 27.0);
+  auto r12 = IntDoubleVec::dispatch(my_pow, mydata1, mydata2);
+  static_assert(std::is_same_v<decltype(r12), IntDoubleVec>);
+  EXPECT_TRUE(r12.is<double>());
+  EXPECT_EQ(r12, 9.0);
+  auto r21 = IntDoubleVec::dispatch(my_pow, mydata2, mydata1);
+  static_assert(std::is_same_v<decltype(r21), IntDoubleVec>);
+  EXPECT_TRUE(r21.is<double>());
+  EXPECT_EQ(r21, 8.0);
+  auto r22 = IntDoubleVec::dispatch(my_pow, mydata2, mydata2);
+  static_assert(std::is_same_v<decltype(r22), IntDoubleVec>);
+  EXPECT_TRUE(r22.is<int>());
+  EXPECT_EQ(r22, 4);
 }

--- a/lib/dynamic_type/test/examples.cpp
+++ b/lib/dynamic_type/test/examples.cpp
@@ -235,4 +235,17 @@ TEST_F(Examples, Example11) {
   static_assert(std::is_same_v<decltype(r22), IntDoubleVec>);
   EXPECT_TRUE(r22.is<int>());
   EXPECT_EQ(r22, 4);
+
+  std::vector<float> vec = {0.0, 1.0, 2.0, 3.0};
+  auto get_item = [](auto& v, auto index) -> decltype(auto) {
+    if constexpr (std::is_integral_v<decltype(index)>) {
+      return v[index];
+    } else {
+      throw std::runtime_error("Illegal index type");
+      return;
+    }
+  };
+  IntDoubleVec::dispatch(get_item, vec, mydata2) = 100.0;
+  std::vector<float> expect{0.0, 1.0, 100.0, 3.0};
+  EXPECT_EQ(vec, expect);
 }

--- a/lib/dynamic_type/test/examples.cpp
+++ b/lib/dynamic_type/test/examples.cpp
@@ -195,4 +195,9 @@ TEST_F(Examples, Example11) {
   EXPECT_EQ(IntDoubleVec::dispatch(get_size, mydata1), 8);
   IntDoubleVec mydata2 = 123;
   EXPECT_EQ(IntDoubleVec::dispatch(get_size, mydata2), 4);
+
+  auto get_total_size = [](auto x, size_t num_x, auto y, size_t num_y) {
+    return sizeof(x) * num_x + sizeof(y) * num_y;
+  };
+  EXPECT_EQ(IntDoubleVec::dispatch(get_total_size, mydata1, 3, mydata2, 5), 44);
 }

--- a/lib/dynamic_type/test/typing.cpp
+++ b/lib/dynamic_type/test/typing.cpp
@@ -76,8 +76,8 @@ TEST_F(DynamicTypeTest, Typing) {
   EXPECT_THAT(
       // suppress unused value warning
       []() { (void)(SomeType)IntSomeType(1); },
-      ::testing::ThrowsMessage<std::runtime_error>(
-          ::testing::HasSubstr("Cannot cast from ")));
+      ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+          "Result is dynamic but not convertible to result type")));
 }
 
 TEST_F(DynamicTypeTest, CastToDynamicType) {


### PR DESCRIPTION
Please see the update in the `README.md` for description. 

This PR also updates `DynamicType`'s conversion operator to use this mechanism for testing purposes. In a followup PR, more operators will be changed to use this mechanism.