### PR TITLE
Loop graph: Remove an assertion that no longer holds

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -390,7 +390,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (true || isOptionEnabled(EnableOption::IdModel)) {
+  if (isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_);
   }
 

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -390,7 +390,7 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (isOptionEnabled(EnableOption::IdModel)) {
+  if (true || isOptionEnabled(EnableOption::IdModel)) {
     IdModel id_model(fusion_);
   }
 

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -557,7 +557,9 @@ StatefulInliningInfo buildStatefulInliningInfo(
             all_consumer_ids, all_consumer_i_ids);
 
         for (const auto& [c_id_1, c_ids] : sibling_map) {
-          NVF_ERROR(c_ids.size() == 1);
+          // Note that c_ids can have multiple domains as this graph
+          // is a Permissive graph and there may be broadcast merged
+          // domains
           info.sibling_maps[c_id_1->as<IterDomain>()].pushBack(c_ids);
         }
       }


### PR DESCRIPTION
Currently, there's an assertion failure with `InstanceNorm3d_channels_last_fp32/1/32/128`:

```
 what():  c_ids.size() == 1 INTERNAL ASSERT FAILED at "csrc/id_model/id_model.cpp":571, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues. multiple sibling mapping: iS505{( (( (( getMetaData(T1) )).logical_size ))[0] )} mapped to  iS510{( (( (( getMetaData(T1) )).logical_size ))[0] )} iS511{( (( (( getMetaData(T1) )).logical_size ))[4] )} iS431{( ( (( (( getMetaData(T1) )).logical_size ))[0] ) * ( (( (( getMetaData(T1) )).logical_size ))[4] ) )}
```

This happens when building sibling mappings. Originally it was using the exact graph to find mappings between siblings, but it was recently changed to use the permissive graph (#2290), so mappings are not guaranteed to be just 1 to 1. I think it's just safe to remove the assertion.