### PR TITLE
Convert from dynamic type to static type early

### DIFF
--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -153,11 +153,13 @@ bool IterDomainGraph::exprsMap(
 
     auto extent_0_match = extent_0o->sameAs(extent_1o) ||
         (extent_0o->isConstInt() && extent_1o->isConstInt() &&
-         extent_0o->evaluate() == extent_1o->evaluate());
+         extent_0o->evaluate().as<int64_t>() ==
+             extent_1o->evaluate().as<int64_t>());
 
     auto extent_1_match = extent_0i->sameAs(extent_1i) ||
         (extent_0i->isConstInt() && extent_1i->isConstInt() &&
-         extent_0i->evaluate() == extent_1i->evaluate());
+         extent_0i->evaluate().as<int64_t>() ==
+             extent_1i->evaluate().as<int64_t>());
 
     if (!(extent_0_match || extent_1_match)) {
       return false;

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -172,7 +172,8 @@ class ProducerConsumerPairAnalyzer : public OptOutDispatch {
 
     auto in_extent = split->in()->extent();
 
-    if (!in_extent->isConstInt() || ((in_extent->evaluate() % factor) != 0)) {
+    if (!in_extent->isConstInt() ||
+        ((in_extent->evaluate().as<int64_t>() % factor.as<int64_t>()) != 0)) {
       needs_predicate_ = true;
       return;
     }

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -179,7 +179,8 @@ void GpuLower::collectPaddedParallelDims() {
             size_after_padding.value() == warp_size;
 
         if (id->extent()->isConstInt() &&
-            id->extent()->evaluate() > warp_size && !padding_to_single_warp) {
+            id->extent()->evaluate().as<int64_t>() > warp_size &&
+            !padding_to_single_warp) {
           // If we see any other TIDx binding that's larger than
           //  a warp or unknown, we shouldn't lower warp reduce
           //  to a single warp type.
@@ -188,7 +189,7 @@ void GpuLower::collectPaddedParallelDims() {
         } else if (can_be_single_warp) {
           if (padding_to_single_warp ||
               (id->extent()->isConstInt() &&
-               id->extent()->evaluate() == warp_size)) {
+               id->extent()->evaluate().as<int64_t>() == warp_size)) {
             warp_pad_info_.is_tidx_single_warp = true;
           }
         }

--- a/csrc/device_lower/pass/unroll.cpp
+++ b/csrc/device_lower/pass/unroll.cpp
@@ -304,7 +304,8 @@ bool UnrollPass::canOmitElseClause(kir::ForLoop* fl) {
       visit_once = true;
     }
     if (!visit_once) {
-      if (loop->stop()->isConstInt() && loop->stop()->evaluate() == 1) {
+      if (loop->stop()->isConstInt() &&
+          loop->stop()->evaluate().as<int64_t>() == 1) {
         visit_once = true;
       }
     }

--- a/csrc/device_lower/pass/warp_reduce.cpp
+++ b/csrc/device_lower/pass/warp_reduce.cpp
@@ -364,13 +364,14 @@ class FuseBroadcastWithWarpReduce : private kir::IrVisitor {
       // not have
       //  a size of 1, since it would have required re-indexing.
       if (!reduction_allocate_it->second->size()->isConstInt() ||
-          reduction_allocate_it->second->size()->evaluate() != 1) {
+          reduction_allocate_it->second->size()->evaluate().as<int64_t>() !=
+              1) {
         return;
       }
 
       auto broadcast_allocate = getActiveAllocateFor(out_tv);
       if (!broadcast_allocate->size()->isConstInt() ||
-          broadcast_allocate->size()->evaluate() != 1) {
+          broadcast_allocate->size()->evaluate().as<int64_t>() != 1) {
         return;
       }
 

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -194,7 +194,7 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
     ExpressionEvaluator ee;
     for (auto id : rfd) {
       if (!id->getMaybeExpandedExtent()->isConstScalar() ||
-          id->getMaybeExpandedExtent()->evaluate() == 0) {
+          id->getMaybeExpandedExtent()->evaluate().as<int64_t>() == 0) {
         info_.maybe_zero_extents_set_.insert(id->getMaybeExpandedExtent());
         leaf_dynamic_vals_.push_back(id->getMaybeExpandedExtent());
       }

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -1513,7 +1513,7 @@ bool isPositiveHelper(Val* value, const Context& context) {
 
 bool isNonZero(Val* value, const Context& context) {
   value = foldConstants(value);
-  if (value->value().hasValue() && (value->value() != 0).as<bool>()) {
+  if (value->value().hasValue() && (bool)(value->value() != 0)) {
     return true;
   }
   if (isPositive(value, context)) {

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -1513,7 +1513,7 @@ bool isPositiveHelper(Val* value, const Context& context) {
 
 bool isNonZero(Val* value, const Context& context) {
   value = foldConstants(value);
-  if (value->value().hasValue() && value->value() != 0) {
+  if (value->value().hasValue() && (value->value() != 0).as<bool>()) {
     return true;
   }
   if (isPositive(value, context)) {
@@ -1977,7 +1977,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       // 0 / a -> 0
       if (rhs->isOne() ||
           (isValidDenominator(rhs, context) && lhs->value().hasValue() &&
-           lhs->value().is<int64_t>() && lhs->value() == 0)) {
+           lhs->value().is<int64_t>() && lhs->value().as<int64_t>() == 0)) {
         return lhs;
       }
     } else if (bop->getBinaryOpType() == BinaryOpType::CeilDiv) {
@@ -1985,7 +1985,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       // 0 / a -> 0
       if (rhs->isOne() ||
           (isValidDenominator(rhs, context) && lhs->value().hasValue() &&
-           lhs->value().is<int64_t>() && lhs->value() == 0)) {
+           lhs->value().is<int64_t>() && lhs->value().as<int64_t>() == 0)) {
         return lhs;
       }
     }

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -348,7 +348,8 @@ bool Fusion::isNoOp() {
         TensorDomain::noReductions(out_tv->getRFactorDomain());
     const bool size_zero =
         std::any_of(root_dom.begin(), root_dom.end(), [](IterDomain* id) {
-          return id->extent()->isConstScalar() && id->extent()->evaluate() == 0;
+          return id->extent()->isConstScalar() &&
+              id->extent()->evaluate().as<int64_t>() == 0;
         });
     if (!size_zero) {
       return false;

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -218,7 +218,7 @@ PolymorphicValue Val::evaluate() {
 }
 
 bool Val::isZero() const {
-  return value().hasValue() && (value() == 0).as<bool>();
+  return value().hasValue() && (bool)(value() == 0);
 }
 
 bool Val::isZeroInt() const {
@@ -227,7 +227,7 @@ bool Val::isZeroInt() const {
 }
 
 bool Val::isOne() const {
-  return value().hasValue() && (value() == 1).as<bool>();
+  return value().hasValue() && (bool)(value() == 1);
 }
 
 bool Val::isOneInt() const {

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -218,19 +218,21 @@ PolymorphicValue Val::evaluate() {
 }
 
 bool Val::isZero() const {
-  return value().hasValue() && value() == 0;
+  return value().hasValue() && (value() == 0).as<bool>();
 }
 
 bool Val::isZeroInt() const {
-  return value().hasValue() && value().is<int64_t>() && value() == 0;
+  return value().hasValue() && value().is<int64_t>() &&
+      value().as<int64_t>() == 0;
 }
 
 bool Val::isOne() const {
-  return value().hasValue() && value() == 1;
+  return value().hasValue() && (value() == 1).as<bool>();
 }
 
 bool Val::isOneInt() const {
-  return value().hasValue() && value().is<int64_t>() && value() == 1;
+  return value().hasValue() && value().is<int64_t>() &&
+      value().as<int64_t>() == 1;
 }
 
 bool Val::isTrue() const {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -1317,7 +1317,8 @@ SqueezeOp::SqueezeOp(
         // Check concrete broadcast extent here. For Symbolic inputs, this check
         // will be deferred to concretization. See dynamic_transform.cpp
         NVF_ERROR(
-            id->extent()->isConstScalar() && id->extent()->evaluate() == 1,
+            id->extent()->isConstScalar() &&
+                id->extent()->evaluate().as<int64_t>() == 1,
             "Can not squeeze dimension(s) with size != 1.");
       }
     } else {

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -125,7 +125,7 @@ TensorView* reshape(TensorView* inp_tv, const std::vector<Val*>& new_sizes) {
   bool found_neg_one = false;
   for (const auto i : c10::irange(new_sizes.size())) {
     auto new_size = new_sizes.at(i);
-    if (new_size->isConstScalar() && new_size->evaluate() == -1) {
+    if (new_size->isConstScalar() && new_size->evaluate().as<int64_t>() == -1) {
       // It is usually safe to use the provided scalars as the output shapes.
       // However, if -1 is provided for some position, it will not correspond to
       // the actual extent in that position.
@@ -264,7 +264,8 @@ TensorView* squeeze(
             id->toString(),
             ". To force removal of this axis, use squeeze_expanded=true.");
         NVF_CHECK(
-            id->extent()->isConstScalar() && id->extent()->evaluate() == 1,
+            id->extent()->isConstScalar() &&
+                id->extent()->evaluate().as<int64_t>() == 1,
             "Can not squeeze dimension(s) with size != 1.");
       }
     } else {

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1543,7 +1543,7 @@ TensorView* expand(TensorView* inp, const std::vector<Val*>& expanded_sizes) {
 
     // If the expanded size is -1, let the input extent be propagated
     // as is
-    if (expanded_size_int.hasValue() && expanded_size_int == -1) {
+    if (expanded_size_int.hasValue() && expanded_size_int.as<int64_t>() == -1) {
       // This is just done for clarity. It isn't necessary as it's
       // already done when constructing out_id_builder.
       out_id_builder.extent(inp_id->extent());
@@ -1551,8 +1551,10 @@ TensorView* expand(TensorView* inp, const std::vector<Val*>& expanded_sizes) {
         // special patch for Symbolic IterDomain with a static size-1 extent
         // since we know it will become broadcast at concretization
         // See Issue: https://github.com/NVIDIA/Fuser/pull/1393
-        (inp_id->extent()->isConstInt() && inp_id->extent()->evaluate() == 1) &&
-        (!expanded_size_int.hasValue() || expanded_size_int != 1)) {
+        (inp_id->extent()->isConstInt() &&
+         inp_id->extent()->evaluate().as<int64_t>() == 1) &&
+        (!expanded_size_int.hasValue() ||
+         expanded_size_int.as<int64_t>() != 1)) {
       // When input id is a broadcast, expand the extent to the given
       // size, which can be concrete or symbolic.
       expanded = true;

--- a/csrc/preseg_passes/remove_empty.cpp
+++ b/csrc/preseg_passes/remove_empty.cpp
@@ -29,7 +29,7 @@ std::vector<int64_t> emptyAxes(const std::vector<IterDomain*>& domain) {
   for (auto ax : c10::irange(domain.size())) {
     auto id = domain.at(ax);
     if (id->getMaybeExpandedExtent()->isConst() &&
-        id->getMaybeExpandedExtent()->evaluate() == 0) {
+        id->getMaybeExpandedExtent()->evaluate().as<int64_t>() == 0) {
       empty_axes.push_back((int64_t)ax);
     }
   }
@@ -258,7 +258,7 @@ class EmptyTensorRemover : public DeadCodeRemover {
       auto tv = inp->definition()->as<PadOp>()->in()->as<TensorView>();
       auto cat_id = TensorDomain::noReductions(tv->getRFactorDomain()).at(dim);
       if (cat_id->getMaybeExpandedExtent()->isConst() &&
-          cat_id->getMaybeExpandedExtent()->evaluate() == 0) {
+          cat_id->getMaybeExpandedExtent()->evaluate().as<int64_t>() == 0) {
         continue;
       }
       non_empty_inputs.push_back(tv);

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -897,15 +897,11 @@ int64_t getVectorizationFactorTransposeGroup(
           .getTvToContigMergeOfInnerSizeMap();
   for (auto tv : vec_tv) {
     auto inner_size_it = contig_inner_map.find(tv);
-    auto tv_vectorize_factor_opt = inner_size_it == contig_inner_map.end()
+    int64_t tv_vectorize_factor = inner_size_it == contig_inner_map.end()
         ? 1
-        : runtime_info.expressionEvaluator().evaluate(inner_size_it->second);
-    // TODO: Do not assert here. we can just reduce vectorization size to 1 if
-    // we can't infer an inner size.
-    NVF_ERROR(
-        tv_vectorize_factor_opt.hasValue(),
-        "Vectorization heuristic could not evaluate inner most size.");
-    int64_t tv_vectorize_factor = tv_vectorize_factor_opt.as<int64_t>();
+        : runtime_info.expressionEvaluator()
+              .evaluate(inner_size_it->second)
+              .as<int64_t>();
     max_vectorization = std::min(
         max_vectorization,
         scheduler_utils::maxVectorizationWidth(tv_vectorize_factor));

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1481,7 +1481,7 @@ TensorView* TensorViewBuilder::build() const {
           SimplifyingIrBuilder::maybeCastExpr(DataType::Index, shape_.at(i));
     }
     IterDomainBuilder builder(FusionGuard::getCurFusion()->zeroVal(), extent);
-    if (extent->isConstScalar() && extent->evaluate() == 1) {
+    if (extent->isConstScalar() && extent->evaluate().as<int64_t>() == 1) {
       builder.iter_type(IterType::Broadcast);
     }
     if (expanded_extent != nullptr) {

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -242,7 +242,8 @@ class ValGraph {
     auto extent_match = [](IterDomain* id0, IterDomain* id1) -> bool {
       return id0->extent()->sameAs(id1->extent()) ||
           (id0->extent()->isConstInt() && id1->extent()->isConstInt() &&
-           id0->extent()->evaluate() == id1->extent()->evaluate());
+           id0->extent()->evaluate().as<int64_t>() ==
+               id1->extent()->evaluate().as<int64_t>());
     };
 
     // If one pair of the domains are mapped in the given graph, the

--- a/tests/cpp/test_expr_simplifier.cpp
+++ b/tests/cpp/test_expr_simplifier.cpp
@@ -880,9 +880,11 @@ TEST_F(ExprSimplifierTest, Compare) {
   EXPECT_TRUE(simplify("i1 >= i3"_, "i1 >= i2 && i2 > i3"_).as<bool>());
   EXPECT_TRUE(simplify("i1 >= i3"_, "i1 >= i2 && i2 >= i3"_).as<bool>());
 
-  EXPECT_TRUE(simplify(
-      "i1 < 3"_,
-      "i1 < i2 && i2 <= i3 && i3 < i4 && i4 <= i5 && i5 <= i6 && i6 < i7 && i7 <= i8 && i8 <= 2"_).as<bool>());
+  EXPECT_TRUE(
+      simplify(
+          "i1 < 3"_,
+          "i1 < i2 && i2 <= i3 && i3 < i4 && i4 <= i5 && i5 <= i6 && i6 < i7 && i7 <= i8 && i8 <= 2"_)
+          .as<bool>());
 
   EXPECT_TRUE(simplify("i1 <= i1 * i2"_, "i1 >= 0 && i2 > 0"_).as<bool>());
   EXPECT_TRUE(simplify("i1 >= i1 * i2"_, "i1 <= 0 && i2 > 0"_).as<bool>());
@@ -891,23 +893,29 @@ TEST_F(ExprSimplifierTest, Compare) {
   EXPECT_TRUE(
       simplifyExpr(
           "ceilDiv( T0.logical_size[0] , 128 ) * 4 >= ceilDiv( T0.logical_size[0] , 128 )"_)
-          ->value().as<bool>());
+          ->value()
+          .as<bool>());
 
-  EXPECT_TRUE(simplify("ceilDiv( i1 , i2 ) > 0"_, "i1 > 0 && i2 > 0"_).as<bool>());
-  EXPECT_TRUE(simplify("ceilDiv( i1 , i2 ) >= 1"_, "i1 > 0 && i2 > 0"_).as<bool>());
+  EXPECT_TRUE(
+      simplify("ceilDiv( i1 , i2 ) > 0"_, "i1 > 0 && i2 > 0"_).as<bool>());
+  EXPECT_TRUE(
+      simplify("ceilDiv( i1 , i2 ) >= 1"_, "i1 > 0 && i2 > 0"_).as<bool>());
 
   EXPECT_TRUE(simplify(
-      "blockIdx.x < ceilDiv( T0.logical_size[0] , 128 ) * 4"_,
-      "blockIdx.x < ceilDiv( T0.logical_size[0] , 128 ) * 4"_).as<bool>());
+                  "blockIdx.x < ceilDiv( T0.logical_size[0] , 128 ) * 4"_,
+                  "blockIdx.x < ceilDiv( T0.logical_size[0] , 128 ) * 4"_)
+                  .as<bool>());
 
   EXPECT_TRUE(simplify("i1 % i2 < i2"_, "i2 >= 0"_).as<bool>());
 
-  EXPECT_TRUE(
-      simplifyExpr("T0.logical_size[0] - 1 < T0.logical_size[0]"_)->value().as<bool>());
+  EXPECT_TRUE(simplifyExpr("T0.logical_size[0] - 1 < T0.logical_size[0]"_)
+                  ->value()
+                  .as<bool>());
   EXPECT_TRUE(
       simplifyExpr(
           "T0.logical_size[0] + 1 + 2 + 3 < T0.logical_size[0] + 1 + 2 + 3 + 4"_)
-          ->value().as<bool>());
+          ->value()
+          .as<bool>());
   // Two terms of the LHS are both the same as the single RHS term,
   // but the removal should be done only for one of them. If doubly
   // removed, the predicate would be false
@@ -1163,10 +1171,10 @@ TEST_F(ExprSimplifierTest, DivModLessThan) {
 // See https://github.com/NVIDIA/Fuser/pull/1827
 TEST_F(ExprSimplifierTest, OrderTransitivity) {
   // Macro is just for nicer error printing
-#define EXPECT_VALUE_TRUE(val)          \
-  EXPECT_TRUE(val->value().hasValue()); \
-  if (val->value().hasValue()) {        \
-    EXPECT_TRUE(val->value().as<bool>());          \
+#define EXPECT_VALUE_TRUE(val)            \
+  EXPECT_TRUE(val->value().hasValue());   \
+  if (val->value().hasValue()) {          \
+    EXPECT_TRUE(val->value().as<bool>()); \
   }
   EXPECT_VALUE_TRUE(simplifyExpr("neg( 8 ) < 0"_, {}, {}));
 

--- a/tests/cpp/test_expr_simplifier.cpp
+++ b/tests/cpp/test_expr_simplifier.cpp
@@ -858,62 +858,62 @@ TEST_F(ExprSimplifierTest, Compare) {
     return simplifyExpr(x, {}, {assumption})->value();
   };
 
-  EXPECT_TRUE(simplify("i1 <= i1"_, "i1 < i2"_));
+  EXPECT_TRUE(simplify("i1 <= i1"_, "i1 < i2"_).as<bool>());
 
-  EXPECT_TRUE(simplify("i1 < i3"_, "i1 < i2 && i2 < i3"_));
-  EXPECT_TRUE(simplify("i1 < i3"_, "i1 < i2 && i2 <= i3"_));
-  EXPECT_TRUE(simplify("i1 < i3"_, "i1 <= i2 && i2 < i3"_));
+  EXPECT_TRUE(simplify("i1 < i3"_, "i1 < i2 && i2 < i3"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 < i3"_, "i1 < i2 && i2 <= i3"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 < i3"_, "i1 <= i2 && i2 < i3"_).as<bool>());
   EXPECT_FALSE(simplify("i1 < i3"_, "i1 <= i2 && i2 <= i3"_).hasValue());
 
-  EXPECT_TRUE(simplify("i1 > i3"_, "i1 > i2 && i2 > i3"_));
-  EXPECT_TRUE(simplify("i1 > i3"_, "i1 > i2 && i2 >= i3"_));
-  EXPECT_TRUE(simplify("i1 > i3"_, "i1 >= i2 && i2 > i3"_));
+  EXPECT_TRUE(simplify("i1 > i3"_, "i1 > i2 && i2 > i3"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 > i3"_, "i1 > i2 && i2 >= i3"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 > i3"_, "i1 >= i2 && i2 > i3"_).as<bool>());
   EXPECT_FALSE(simplify("i1 > i3"_, "i1 >= i2 && i2 >= i3"_).hasValue());
 
-  EXPECT_TRUE(simplify("i1 <= i3"_, "i1 < i2 && i2 < i3"_));
-  EXPECT_TRUE(simplify("i1 <= i3"_, "i1 < i2 && i2 <= i3"_));
-  EXPECT_TRUE(simplify("i1 <= i3"_, "i1 <= i2 && i2 < i3"_));
-  EXPECT_TRUE(simplify("i1 <= i3"_, "i1 <= i2 && i2 <= i3"_));
+  EXPECT_TRUE(simplify("i1 <= i3"_, "i1 < i2 && i2 < i3"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 <= i3"_, "i1 < i2 && i2 <= i3"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 <= i3"_, "i1 <= i2 && i2 < i3"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 <= i3"_, "i1 <= i2 && i2 <= i3"_).as<bool>());
 
-  EXPECT_TRUE(simplify("i1 >= i3"_, "i1 > i2 && i2 > i3"_));
-  EXPECT_TRUE(simplify("i1 >= i3"_, "i1 > i2 && i2 >= i3"_));
-  EXPECT_TRUE(simplify("i1 >= i3"_, "i1 >= i2 && i2 > i3"_));
-  EXPECT_TRUE(simplify("i1 >= i3"_, "i1 >= i2 && i2 >= i3"_));
+  EXPECT_TRUE(simplify("i1 >= i3"_, "i1 > i2 && i2 > i3"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 >= i3"_, "i1 > i2 && i2 >= i3"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 >= i3"_, "i1 >= i2 && i2 > i3"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 >= i3"_, "i1 >= i2 && i2 >= i3"_).as<bool>());
 
   EXPECT_TRUE(simplify(
       "i1 < 3"_,
-      "i1 < i2 && i2 <= i3 && i3 < i4 && i4 <= i5 && i5 <= i6 && i6 < i7 && i7 <= i8 && i8 <= 2"_));
+      "i1 < i2 && i2 <= i3 && i3 < i4 && i4 <= i5 && i5 <= i6 && i6 < i7 && i7 <= i8 && i8 <= 2"_).as<bool>());
 
-  EXPECT_TRUE(simplify("i1 <= i1 * i2"_, "i1 >= 0 && i2 > 0"_));
-  EXPECT_TRUE(simplify("i1 >= i1 * i2"_, "i1 <= 0 && i2 > 0"_));
-  EXPECT_TRUE(simplify("d1 <= d1 * d2"_, "d1 >= 0.0 && d2 >= 1.0"_));
-  EXPECT_TRUE(simplify("d1 >= d1 * d2"_, "d1 <= 0.0 && d2 >= 1.0"_));
+  EXPECT_TRUE(simplify("i1 <= i1 * i2"_, "i1 >= 0 && i2 > 0"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 >= i1 * i2"_, "i1 <= 0 && i2 > 0"_).as<bool>());
+  EXPECT_TRUE(simplify("d1 <= d1 * d2"_, "d1 >= 0.0 && d2 >= 1.0"_).as<bool>());
+  EXPECT_TRUE(simplify("d1 >= d1 * d2"_, "d1 <= 0.0 && d2 >= 1.0"_).as<bool>());
   EXPECT_TRUE(
       simplifyExpr(
           "ceilDiv( T0.logical_size[0] , 128 ) * 4 >= ceilDiv( T0.logical_size[0] , 128 )"_)
-          ->value());
+          ->value().as<bool>());
 
-  EXPECT_TRUE(simplify("ceilDiv( i1 , i2 ) > 0"_, "i1 > 0 && i2 > 0"_));
-  EXPECT_TRUE(simplify("ceilDiv( i1 , i2 ) >= 1"_, "i1 > 0 && i2 > 0"_));
+  EXPECT_TRUE(simplify("ceilDiv( i1 , i2 ) > 0"_, "i1 > 0 && i2 > 0"_).as<bool>());
+  EXPECT_TRUE(simplify("ceilDiv( i1 , i2 ) >= 1"_, "i1 > 0 && i2 > 0"_).as<bool>());
 
   EXPECT_TRUE(simplify(
       "blockIdx.x < ceilDiv( T0.logical_size[0] , 128 ) * 4"_,
-      "blockIdx.x < ceilDiv( T0.logical_size[0] , 128 ) * 4"_));
+      "blockIdx.x < ceilDiv( T0.logical_size[0] , 128 ) * 4"_).as<bool>());
 
-  EXPECT_TRUE(simplify("i1 % i2 < i2"_, "i2 >= 0"_));
+  EXPECT_TRUE(simplify("i1 % i2 < i2"_, "i2 >= 0"_).as<bool>());
 
   EXPECT_TRUE(
-      simplifyExpr("T0.logical_size[0] - 1 < T0.logical_size[0]"_)->value());
+      simplifyExpr("T0.logical_size[0] - 1 < T0.logical_size[0]"_)->value().as<bool>());
   EXPECT_TRUE(
       simplifyExpr(
           "T0.logical_size[0] + 1 + 2 + 3 < T0.logical_size[0] + 1 + 2 + 3 + 4"_)
-          ->value());
+          ->value().as<bool>());
   // Two terms of the LHS are both the same as the single RHS term,
   // but the removal should be done only for one of them. If doubly
   // removed, the predicate would be false
-  EXPECT_TRUE(simplify("i1 + i1 > i1"_, "i1 > 0"_));
-  EXPECT_TRUE(simplify("i1 < i1 + i1"_, "i1 > 0"_));
-  EXPECT_TRUE(simplify("i1 + i1 < i1 + i1 + i1"_, "i1 > 0"_));
+  EXPECT_TRUE(simplify("i1 + i1 > i1"_, "i1 > 0"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 < i1 + i1"_, "i1 > 0"_).as<bool>());
+  EXPECT_TRUE(simplify("i1 + i1 < i1 + i1 + i1"_, "i1 > 0"_).as<bool>());
 }
 
 TEST_F(ExprSimplifierTest, FundamentalDivisionWithRemainderProperty) {
@@ -1166,7 +1166,7 @@ TEST_F(ExprSimplifierTest, OrderTransitivity) {
 #define EXPECT_VALUE_TRUE(val)          \
   EXPECT_TRUE(val->value().hasValue()); \
   if (val->value().hasValue()) {        \
-    EXPECT_TRUE(val->value());          \
+    EXPECT_TRUE(val->value().as<bool>());          \
   }
   EXPECT_VALUE_TRUE(simplifyExpr("neg( 8 ) < 0"_, {}, {}));
 

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -5036,7 +5036,7 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
             std::find_if(cond_inputs.begin(), cond_inputs.end(), [](Val* inp) {
               auto int_val = inp->value();
               return int_val.hasValue() &&
-                  (int_val == vec_factor - 1 || int_val == -(vec_factor - 1));
+                  (int_val.as<int64_t>() == vec_factor - 1 || int_val.as<int64_t>() == -(vec_factor - 1));
             });
         // If vectorized, the predicate should use (vec_factor - 1) or
         // -(vec_factor - 1) rather than the loop index.

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -5036,7 +5036,8 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
             std::find_if(cond_inputs.begin(), cond_inputs.end(), [](Val* inp) {
               auto int_val = inp->value();
               return int_val.hasValue() &&
-                  (int_val.as<int64_t>() == vec_factor - 1 || int_val.as<int64_t>() == -(vec_factor - 1));
+                  (int_val.as<int64_t>() == vec_factor - 1 ||
+                   int_val.as<int64_t>() == -(vec_factor - 1));
             });
         // If vectorized, the predicate should use (vec_factor - 1) or
         // -(vec_factor - 1) rather than the loop index.


### PR DESCRIPTION
When talking about design decisions in `DynamicType`, there are some subtle details that is hard to tell which is the best decision. For example, `at::Tensor == at::Tensor` returns an `at::Tensor`, but some C++ code assumes `operator==` always returns `bool`. For this case, should we make `PolymorphicValue == PolymorphicValue` always return `bool` and disable `at::Tensor == at::Tensor`, or make it return `PolymorphicValue` which is a superset of `bool` and can be casted to `bool`? There is no clear answer to this question. None is perfect, it's just a matter of choosing which bad you want to take. So far, I believe the decision is based on whatever the behavior is that makes `DynamicType` codebase simple.

Recently, I added `DynamicType::dispatch`, which is primarily for supporting https://github.com/NVIDIA/Fuser/pull/2321, but I also noticed that this is a powerful tool that can be used to cleanup implementations of `DynamicType`'s operators.
To be able to more thoroughly cleaning things up, some decisions like above could change. Again, I believe this change is neither an improvement nor a regression on the behavior. It is just a different behavior.

One pitfall for using `PolymorphicValue` is, its `operator&&` and `operator||` are no longer short-circuiting. This is a fundamental limitation of C++ operator overloading, and to the best of my knowledge, there is no workaround for it. This means, if you write code like below:
```C++
pv.hasValue() && f(pv)
```
what you are thinking is likely
```C++
if (pv.hasValue()) {
  return (bool)f(pv);
} else {
  return false;
}
```
but what you get will be
```C++
PolymorphicValue cond1 = pv.hasValue();
PolymorphicValue cond2 = f(pv);
return (bool)(cond1 && cond2);
```
That is, `f(pv)` is always evaluated and likely this evaluation will leads to errors. To get the correct behavior, you will have to use
```C++
pv.hasValue() && (bool)(f(pv))
```
so that the `operator&&` is the `operator&&` of `bool`, not of `PolymorphicValue`.

In the past, I changed a batch of patterns like this during the enablement of `PolymorphicValue`, but there are still patterns like above remain unchanged because it was saved by the fact that the comparison operator of `PolymorphicValue` returning `bool`. If I changed the comparison operators to return `PolymorphicValue`, these uses will break too.

This PR further changes codes like above, so that we always use `operator&&` of bool regardless of the return type of the comparison operators.