### PR TITLE
Host irs: use `Communicator` directly instead of wrapped inside `PostOnStream`

### DIFF
--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -56,8 +56,8 @@ class HostIrExecutor final : public OptInDispatch {
  private:
   using OptInDispatch::handle;
   void handle(PostOnStream* post_ir) override;
+  void handle(Communication* communication) override;
   void postCompute(PostOnStream* post_ir);
-  void postCommunication(PostOnStream* post_ir);
 
   std::unique_ptr<HostIrContainer> container_;
   Communicator* communicator_;

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -57,7 +57,7 @@ PostOnStream::PostOnStream(
       this,
       "must be registered in a HostIrContainer");
   NVF_ERROR(
-      (host_op->isOneOf<HostUnit, Communication>()), "wrong host op type");
+      (host_op->isA<HostUnit>()), "wrong host op type");
   if (host_op->isA<HostUnit>()) {
     NVF_ERROR(
         this->inputs().size() ==
@@ -72,13 +72,6 @@ PostOnStream::PostOnStream(
     // for (int i : c10::irange(outputs.size())) {
     //     NVF_ERROR(outputs.at(i)->sameAs(executable_fusion->outputs().at(i)));
     // }
-  } else if (host_op->isA<Communication>()) {
-    NVF_ERROR(
-        this->inputs().size() == 1,
-        "Communication must have exactly one input");
-    NVF_ERROR(
-        this->outputs().size() == 1,
-        "Communication must have exactly one output");
   }
 }
 

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -56,7 +56,8 @@ PostOnStream::PostOnStream(
       passkey.ir_container_->isA<hir::HostIrContainer>(), // NOLINT
       this,
       "must be registered in a HostIrContainer");
-  NVF_ERROR((host_op->isA<HostUnit>()), "wrong host op type: ", host_op->toString());
+  NVF_ERROR(
+      (host_op->isA<HostUnit>()), "wrong host op type: ", host_op->toString());
   if (host_op->isA<HostUnit>()) {
     NVF_ERROR(
         this->inputs().size() ==

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -56,8 +56,7 @@ PostOnStream::PostOnStream(
       passkey.ir_container_->isA<hir::HostIrContainer>(), // NOLINT
       this,
       "must be registered in a HostIrContainer");
-  NVF_ERROR(
-      (host_op->isA<HostUnit>()), "wrong host op type");
+  NVF_ERROR((host_op->isA<HostUnit>()), "wrong host op type");
   if (host_op->isA<HostUnit>()) {
     NVF_ERROR(
         this->inputs().size() ==

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -56,7 +56,7 @@ PostOnStream::PostOnStream(
       passkey.ir_container_->isA<hir::HostIrContainer>(), // NOLINT
       this,
       "must be registered in a HostIrContainer");
-  NVF_ERROR((host_op->isA<HostUnit>()), "wrong host op type");
+  NVF_ERROR((host_op->isA<HostUnit>()), "wrong host op type: ", host_op->toString());
   if (host_op->isA<HostUnit>()) {
     NVF_ERROR(
         this->inputs().size() ==

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -127,7 +127,11 @@ int64_t getRootRelativeIndex(const CommParams& params) {
 
 } // namespace
 
-Communication::Communication(IrBuilderPasskey passkey, CommParams params, TensorView* input_tv, TensorView* output_tv)
+Communication::Communication(
+    IrBuilderPasskey passkey,
+    CommParams params,
+    TensorView* input_tv,
+    TensorView* output_tv)
     : Expr(passkey, {input_tv}, {output_tv}, {}), params_(std::move(params)) {
   NVF_ERROR(params_.mesh.size() > 0, "The mesh size must be greater than 0.");
 }

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -127,8 +127,8 @@ int64_t getRootRelativeIndex(const CommParams& params) {
 
 } // namespace
 
-Communication::Communication(IrBuilderPasskey passkey, CommParams params)
-    : Expr(passkey), params_(std::move(params)) {
+Communication::Communication(IrBuilderPasskey passkey, CommParams params, TensorView* input_tv, TensorView* output_tv)
+    : Expr(passkey, {input_tv}, {output_tv}, {}), params_(std::move(params)) {
   NVF_ERROR(params_.mesh.size() > 0, "The mesh size must be greater than 0.");
 }
 

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -121,7 +121,7 @@ Communication::Communication(
     int64_t scattered_axis,
     TensorView* input_tv,
     TensorView* output_tv)
-    : Expr(passkey, {input_tv}, {output_tv}, {}) {
+    : Expr(passkey) {
   NVF_ERROR(mesh.size() > 0, "The mesh size must be greater than 0.");
   NVF_ERROR(
       hasRoot(type) == (root >= 0),
@@ -133,6 +133,12 @@ Communication::Communication(
   NVF_ERROR(
       (type == CommunicationType::ReduceScatter) == (scattered_axis >= 0));
 
+  if (input_tv != nullptr) {
+    addInput(input_tv);
+  }
+  if (output_tv != nullptr) {
+    addOutput(output_tv);
+  }
   addDataAttribute(type);
   addDataAttribute(mesh);
   addDataAttribute(team);

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -124,7 +124,7 @@ struct CommParams {
 class Communication : public Expr {
  public:
   using Expr::Expr;
-  Communication(IrBuilderPasskey passkey, CommParams params);
+  Communication(IrBuilderPasskey passkey, CommParams params, TensorView* input_tv = nullptr, TensorView* output_tv = nullptr);
   Communication(const Communication* src, IrCloner* ir_cloner);
 
   Communication(const Communication& other) = delete;

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -124,7 +124,11 @@ struct CommParams {
 class Communication : public Expr {
  public:
   using Expr::Expr;
-  Communication(IrBuilderPasskey passkey, CommParams params, TensorView* input_tv = nullptr, TensorView* output_tv = nullptr);
+  Communication(
+      IrBuilderPasskey passkey,
+      CommParams params,
+      TensorView* input_tv = nullptr,
+      TensorView* output_tv = nullptr);
   Communication(const Communication* src, IrCloner* ir_cloner);
 
   Communication(const Communication& other) = delete;

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -99,7 +99,10 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
       .mesh = mesh,
       .team = mesh.vector()};
   auto communication = IrBuilder::create<Communication>(
-      static_cast<IrContainer*>(hic.get()), comm_params, communication_inputs, communication_outputs);
+      static_cast<IrContainer*>(hic.get()),
+      comm_params,
+      communication_inputs,
+      communication_outputs);
 
   // [Step 6)] Define the Host program
   hic->pushBackTopLevelExprs(post_compute);


### PR DESCRIPTION
Bootstrapping for simplifying the design. With this patch, the `Communication` class is used to post a collective, without the need of wrapping it inside a `PostOnStream` Ir.

There is no functional change, this is only a minor cleanup I would like to upstream before introducing the "collective wait" IR.

To achieve this, we need to add I/O TVs to the `Communication`'s constructor, and use those I/O directly. This patch aligns with the discussion from https://github.com/NVIDIA/Fuser/pull/2250 and should lead to further simplification in `MultiDeviceExecutor`, that I would like to leave to another PR for avoiding conflicts.

Note that the `Communication` class is used in two places: Host IRs and `MultiDeviceExecutor`. Since the former case should replace the latter eventually, we maintain for now these two usages. In `MultiDeviceExecutor`, we don't set a `Communication`'s I/O, that's why those arguments are made optional in the constructor
