### PR TITLE
Remove trim_out_of_bounds

### DIFF
--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -168,9 +168,7 @@ bool IterDomainGraph::exprsMap(
     auto first_split = first->as<Split>();
     auto second_split = second->as<Split>();
     if (!first_split->factor()->sameAs(second_split->factor()) ||
-        first_split->innerSplit() != second_split->innerSplit() ||
-        !first_split->startOffset()->sameAs(second_split->startOffset()) ||
-        !first_split->stopOffset()->sameAs(second_split->stopOffset())) {
+        first_split->innerSplit() != second_split->innerSplit()) {
       return false;
     }
   }
@@ -725,8 +723,7 @@ void IterDomainGraph::build(Fusion* fusion) {
         almost_exact_nodes_.mapEntries(merge->inner(), merge->out());
       }
     } else if (auto split = dynamic_cast<Split*>(def)) {
-      if (split->factor()->isOneInt() && split->startOffset()->isZeroInt() &&
-          split->stopOffset()->isZeroInt()) {
+      if (split->factor()->isOneInt()) {
         if (split->innerSplit()) {
           almost_exact_nodes_.mapEntries(split->in(), split->outer());
         } else {

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -334,8 +334,7 @@ std::vector<std::vector<Val*>> getTriviallyMappedIds(Expr* expr) {
       mapped_ids.push_back({merge->inner(), merge->out()});
     }
   } else if (auto split = dynamic_cast<Split*>(expr)) {
-    if (split->factor()->isOneInt() && split->startOffset()->isZeroInt() &&
-        split->stopOffset()->isZeroInt()) {
+    if (split->factor()->isOneInt()) {
       if (split->innerSplit()) {
         mapped_ids.push_back({split->in(), split->outer()});
       } else {

--- a/csrc/id_model/transform_replay.cpp
+++ b/csrc/id_model/transform_replay.cpp
@@ -34,9 +34,7 @@ void ReplayTransform::handle(const Split* split) {
   replayed_expr_ = IterDomain::split(
                        input_ids_[0],
                        split->factor(),
-                       split->innerSplit(),
-                       split->startOffset(),
-                       split->stopOffset())
+                       split->innerSplit())
                        .first->definition();
 }
 

--- a/csrc/id_model/transform_replay.cpp
+++ b/csrc/id_model/transform_replay.cpp
@@ -31,11 +31,9 @@ void ReplayTransform::handle(const Split* split) {
       input_ids_.size() == 1,
       "Expected one input to match split: ",
       split->toString());
-  replayed_expr_ = IterDomain::split(
-                       input_ids_[0],
-                       split->factor(),
-                       split->innerSplit())
-                       .first->definition();
+  replayed_expr_ =
+      IterDomain::split(input_ids_[0], split->factor(), split->innerSplit())
+          .first->definition();
 }
 
 // We're going to replay this merge operation on the corresponding IDs

--- a/csrc/id_model/validation_utils.cpp
+++ b/csrc/id_model/validation_utils.cpp
@@ -89,9 +89,7 @@ bool exprsMap(
     auto first_split = first->as<Split>();
     auto second_split = second->as<Split>();
     if (!first_split->factor()->sameAs(second_split->factor()) ||
-        first_split->innerSplit() != second_split->innerSplit() ||
-        !first_split->startOffset()->sameAs(second_split->startOffset()) ||
-        !first_split->stopOffset()->sameAs(second_split->stopOffset())) {
+        first_split->innerSplit() != second_split->innerSplit()) {
       return false;
     }
   }

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -286,19 +286,13 @@ class NVF_API TensorView : public Val {
   //! tv[id{extent}] -> tv[id{ceilDiv(extent, factor)}, id{factor}]
   //! e.g. split(0, 4, inner_split = false) will result in:
   //! tv[id{extent}] -> tv[id{factor}, id{ceilDiv(extent, factor)}]
-  TensorView* split(
-      int64_t axis,
-      int64_t factor,
-      bool inner_split = true);
+  TensorView* split(int64_t axis, int64_t factor, bool inner_split = true);
 
   // Split "axis" into 2 axes where the inner axes is size of "factor"
   // and outer axis is size axis.size() / factor. Factor can be a symbolic
   // value instead of constant. This requires setting the symbolic value as an
   // input, or using a parallel dim from NamedScalar::getParallelDim
-  TensorView* split(
-      int64_t axis,
-      Val* factor,
-      bool inner_split = true);
+  TensorView* split(int64_t axis, Val* factor, bool inner_split = true);
 
   // Merge axis_o and axis_i into 1 IterDomain
   TensorView* merge(int64_t axis_o, int64_t axis_i);

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -286,14 +286,10 @@ class NVF_API TensorView : public Val {
   //! tv[id{extent}] -> tv[id{ceilDiv(extent, factor)}, id{factor}]
   //! e.g. split(0, 4, inner_split = false) will result in:
   //! tv[id{extent}] -> tv[id{factor}, id{ceilDiv(extent, factor)}]
-  //!
-  //! When trim_out_of_bounds is true, only the inner domain defined by the
-  //! start and stop positions is split.
   TensorView* split(
       int64_t axis,
       int64_t factor,
-      bool inner_split = true,
-      bool trim_out_of_bounds = false);
+      bool inner_split = true);
 
   // Split "axis" into 2 axes where the inner axes is size of "factor"
   // and outer axis is size axis.size() / factor. Factor can be a symbolic
@@ -302,8 +298,7 @@ class NVF_API TensorView : public Val {
   TensorView* split(
       int64_t axis,
       Val* factor,
-      bool inner_split = true,
-      bool trim_out_of_bounds = false);
+      bool inner_split = true);
 
   // Merge axis_o and axis_i into 1 IterDomain
   TensorView* merge(int64_t axis_o, int64_t axis_i);

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -623,10 +623,7 @@ class TensorDomain : public Val {
   //! tv[id{extent}] -> tv[id{ceilDiv(extent, factor)}, id{factor}]
   //! e.g. split(0, 4, inner_split = false) will result in:
   //! tv[id{extent}] -> tv[id{factor}, id{ceilDiv(extent, factor)}]
-  void split(
-      int64_t axis_,
-      Val* factor,
-      bool inner_split);
+  void split(int64_t axis_, Val* factor, bool inner_split);
 
   // Merge axis_o and axis_i. axis_i is the fast changing dimension. Resulting
   // axis is by default placed at original position axis_o

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -127,29 +127,10 @@ class NVF_API IterDomain : public Val {
       IterDomain* inner,
       bool rfactor_domain = false);
 
-  //! start_offset and stop_offset defines partial split. Only root
-  //! domains are allowed to have non-zero start and stop offsets.
-  //! When `rfactor_domain` is true, also set the `is_rfactor_domain_` flag of
-  //! both result IterDomains.
   static std::pair<IterDomain*, IterDomain*> split(
       IterDomain* in,
       Val* factor,
       bool inner_split,
-      Val* start_offset = nullptr,
-      Val* stop_offset = nullptr,
-      bool rfactor_domain = false);
-
-  //! trim_out_of_bounds controls how the values outside start and stop
-  //! positions are treated. The option is only valid with root
-  //! domains as non-root domains do not have valid start and stop
-  //! positions.
-  //!
-  //! \param trim_out_of_bounds Trims [0, start_] and [-stop_offset_, extent_]
-  static std::pair<IterDomain*, IterDomain*> split(
-      IterDomain* in,
-      Val* factor,
-      bool inner_split,
-      bool trim_out_of_bounds,
       bool rfactor_domain = false);
 
   //! Resize an IterDomain by expanding both the left and right sides
@@ -645,8 +626,7 @@ class TensorDomain : public Val {
   void split(
       int64_t axis_,
       Val* factor,
-      bool inner_split,
-      bool trim_out_of_bounds = false);
+      bool inner_split);
 
   // Merge axis_o and axis_i. axis_i is the fast changing dimension. Resulting
   // axis is by default placed at original position axis_o

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1616,20 +1616,13 @@ class NVF_API Split : public Expr {
  public:
   using Expr::Expr;
 
-  // start_offset and stop_offset are used to express partial
-  // split. Only the partial domain from start_offset to stop_offset
-  // is split and the outer sub-regions are ignored. Note that both
-  // start_offset and stop_offset are distance from the left end and
-  // right ends, respectively.
   Split(
       IrBuilderPasskey,
       IterDomain* outer,
       IterDomain* inner,
       IterDomain* in,
       Val* factor,
-      bool inner_split = true,
-      Val* start_offset = nullptr,
-      Val* stop_offset = nullptr);
+      bool inner_split = true);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
@@ -1656,23 +1649,6 @@ class NVF_API Split : public Expr {
   bool innerSplit() const {
     return attribute<bool>(1);
   }
-
-  //! Start position of the input domain. Non-zero means partial
-  //! split. Elements until this offset are ignored.
-  Val* startOffset() const {
-    NVF_ERROR(attributeVal(2) != nullptr);
-    return attributeVal(2);
-  }
-
-  //! Offset from extent of the input domain. Non-zero means partial
-  //! split. Elements after this offset are ignored.
-  Val* stopOffset() const {
-    NVF_ERROR(attributeVal(3) != nullptr);
-    return attributeVal(3);
-  }
-
-  //! Utility function to compute the split extent.
-  static Val* extent(Val* in_extent, Val* start_offset, Val* stop_offset);
 };
 
 //! Merge the IterDomains outer and inner into one domain, outer and inner

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2631,8 +2631,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
       factor->isIntegralScalar(), "Cannot split by non-integer value ", factor);
 
   // outer loop size
-  Val* remainder =
-      ceilDiv(in->extent(), factor);
+  Val* remainder = ceilDiv(in->extent(), factor);
   Val* expanded_remainder = nullptr;
   if (in->hasExpandedExtent()) {
     expanded_remainder = ceilDiv(in->expandedExtent(), factor);
@@ -2662,13 +2661,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
           .is_rfactor_domain(rfactor_domain)
           .build();
 
-  IrBuilder::create<Split>(
-      in->container(),
-      ido,
-      idi,
-      in,
-      factor,
-      inner_split);
+  IrBuilder::create<Split>(in->container(), ido, idi, in, factor, inner_split);
   return {ido, idi};
 }
 
@@ -3373,10 +3366,7 @@ int64_t TensorDomain::rootPosOf(IterDomain* id) const {
   return std::distance(maybeRoot().begin(), it);
 }
 
-void TensorDomain::split(
-    int64_t axis,
-    Val* factor,
-    bool inner_split) {
+void TensorDomain::split(int64_t axis, Val* factor, bool inner_split) {
   NVF_ERROR(nDims() > 0, "Tried to do split on a 0-dim domain");
   axis = wrapDim(axis);
 
@@ -3386,8 +3376,7 @@ void TensorDomain::split(
       !id->isMmaSwizzled(),
       "Further transformation on warp mapped id's not allowed.");
 
-  auto split_ids =
-      IterDomain::split(id, factor, inner_split);
+  auto split_ids = IterDomain::split(id, factor, inner_split);
   leaf_domain_.erase(leaf_domain_.begin() + axis);
   leaf_domain_.insert(leaf_domain_.begin() + axis, split_ids.second);
   leaf_domain_.insert(leaf_domain_.begin() + axis, split_ids.first);

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -2927,8 +2927,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor arg,
          int64_t dim,
          int64_t factor,
-         bool inner_split,
-         bool trim_out_of_bounds) {
+         bool inner_split) {
         FUSER_PERF_SCOPE("SchedOperators.split");
         NVF_CHECK(
             self.validUse(),
@@ -2936,13 +2935,12 @@ void initNvFuserPythonBindings(PyObject* module) {
         FusionDefinition* fd = self.fusion_definition;
         auto input_tv =
             fd->getFusionState(arg.index)->template as<TensorView>();
-        input_tv->split(dim, factor, inner_split, trim_out_of_bounds);
+        input_tv->split(dim, factor, inner_split);
       },
       py::arg("arg"),
       py::arg("dim"),
       py::arg("factor"),
-      py::arg("inner_split") = true,
-      py::arg("trim_out_of_bounds") = false);
+      py::arg("inner_split") = true);
   nvf_sched.def(
       "cache_after",
       [](FusionDefinition::SchedOperators& self,

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -466,8 +466,7 @@ void TensorView::clearComputeWith() {
 TensorView* TensorView::split(
     int64_t axis,
     Val* factor,
-    bool inner_split,
-    bool trim_out_of_bounds) {
+    bool inner_split) {
   // Only check things associated with axis, factor will be validated in
   // IterDomain
   NVF_ERROR(
@@ -507,15 +506,14 @@ TensorView* TensorView::split(
     factor = castOp(DataType::Index, factor);
   }
 
-  domain()->split(axis, factor, inner_split, trim_out_of_bounds);
+  domain()->split(axis, factor, inner_split);
   return this;
 }
 
 TensorView* TensorView::split(
     int64_t axis,
     int64_t factor,
-    bool inner_split,
-    bool trim_out_of_bounds) {
+    bool inner_split) {
   // NOTE: safe cast to int64_t, factor (unsigned int) is within int64_t range
   NVF_CHECK(
       factor > 0,
@@ -524,8 +522,7 @@ TensorView* TensorView::split(
   split(
       axis,
       IrBuilder::create<Val>(factor, DataType::Index),
-      inner_split,
-      trim_out_of_bounds);
+      inner_split);
   return this;
 }
 

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -463,10 +463,7 @@ void TensorView::clearComputeWith() {
   NVF_ERROR(compute_with_consumers_.empty());
 }
 
-TensorView* TensorView::split(
-    int64_t axis,
-    Val* factor,
-    bool inner_split) {
+TensorView* TensorView::split(int64_t axis, Val* factor, bool inner_split) {
   // Only check things associated with axis, factor will be validated in
   // IterDomain
   NVF_ERROR(
@@ -510,19 +507,13 @@ TensorView* TensorView::split(
   return this;
 }
 
-TensorView* TensorView::split(
-    int64_t axis,
-    int64_t factor,
-    bool inner_split) {
+TensorView* TensorView::split(int64_t axis, int64_t factor, bool inner_split) {
   // NOTE: safe cast to int64_t, factor (unsigned int) is within int64_t range
   NVF_CHECK(
       factor > 0,
       "Invalid factor for split. Factor must be greater than 0. Factor = ",
       factor);
-  split(
-      axis,
-      IrBuilder::create<Val>(factor, DataType::Index),
-      inner_split);
+  split(axis, IrBuilder::create<Val>(factor, DataType::Index), inner_split);
   return this;
 }
 

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -55,8 +55,6 @@ void ReplayTransformations::handle(Split* s) {
       mapped,
       s->factor(),
       s->innerSplit(),
-      s->startOffset(),
-      s->stopOffset(),
       replay_rfactor_ && s->outer()->isRFactorProduct());
   // Remove mapped from the leaf IDs
   leaf_ids_.erase(mapped);

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -612,9 +612,7 @@ BestEffortReplay::BestEffortReplay(
       auto r_split = replay_expr->as<Split>();
       auto t_split = target_expr->as<Split>();
       if (!r_split->factor()->sameAs(t_split->factor()) ||
-          r_split->innerSplit() != t_split->innerSplit() ||
-          !r_split->startOffset()->sameAs(t_split->startOffset()) ||
-          !r_split->stopOffset()->sameAs(t_split->stopOffset())) {
+          r_split->innerSplit() != t_split->innerSplit()) {
         NVF_ERROR(!replay_has_rfactor_inp, err_str);
         continue;
       }

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -70,12 +70,7 @@ class ReplaySelf : public ReplayTransformations {
 
     // Generate the split node
     IrBuilder::create<Split>(
-        s->container(),
-        ido,
-        idi,
-        mapped,
-        s->factor(),
-        s->innerSplit());
+        s->container(), ido, idi, mapped, s->factor(), s->innerSplit());
 
     // Remove mapped id from leaf IDs
     leaf_ids_.erase(mapped);

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -53,9 +53,7 @@ class ReplaySelf : public ReplayTransformations {
         "Transform traversal failed, modified a node but it was not a leaf node.");
 
     // outer loop size
-    Val* remainder = ceilDiv(
-        Split::extent(mapped->extent(), s->startOffset(), s->stopOffset()),
-        s->factor());
+    Val* remainder = ceilDiv(mapped->extent(), s->factor());
 
     // Manually replay the split, following the output of the operations.
     // This is so rfactor ops are replayed correctly.
@@ -77,9 +75,7 @@ class ReplaySelf : public ReplayTransformations {
         idi,
         mapped,
         s->factor(),
-        s->innerSplit(),
-        s->startOffset(),
-        s->stopOffset());
+        s->innerSplit());
 
     // Remove mapped id from leaf IDs
     leaf_ids_.erase(mapped);

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -275,8 +275,6 @@ class SplitTransform final : public ViewTransform {
         id,
         factor,
         /*inner_split=*/false,
-        /*start_offset=*/nullptr,
-        /*stop_offset=*/nullptr,
         /*rfactor_domain=*/true);
 
     current_transformed_domain.erase(


### PR DESCRIPTION
Was only used with shift, which was removed in #2299.