### PR TITLE
iter grouped multiple reductions

### DIFF
--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -556,7 +556,8 @@ void propagateParallelization(
         std::back_inserter(allreduce_tvs),
         [&](auto tv) {
           return reduction_tv != tv &&
-              reduction_scheduler_utils::isGridAllreduce(tv);
+              (reduction_scheduler_utils::isGridAllreduce(tv) ||
+               use_grouped_reduction);
         });
     if (!allreduce_tvs.empty()) {
       scheduler_utils::parallelizeAllLike(

--- a/tests/cpp/test_gpu_outer_reduction.cpp
+++ b/tests/cpp/test_gpu_outer_reduction.cpp
@@ -2458,4 +2458,105 @@ TEST_F(OuterReductionTest, OuterReductionMagicScheduler) {
   }
 }
 
+TEST_F(OuterReductionTest, IterGroupedMultipleReductions) {
+  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeContigTensor(2);
+  auto tv1 = makeContigTensor(2);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+  auto tv2 = sum(tv0, {0});
+  auto tv3 = add(tv0, tv1);
+  auto tv4 = sum(tv3, {0});
+  fusion.addOutput(tv2);
+  fusion.addOutput(tv4);
+
+  int vect = 4, unroll = 2;
+  int bdimx = 32, bdimy = 16;
+  int gdimx = 8, gdimy = 8;
+  int serial = 2;
+  int iter_dim = vect * bdimx * gdimx;
+  int redu_dim = unroll * bdimy * gdimy * serial;
+
+  // manually set how to schedule the fusion
+  auto rparams = std::make_shared<ReductionParams>();
+  // vectorize
+  rparams->vectorize_iter_dom = true;
+  rparams->unroll_factor_iter_dom = vect;
+  // use bdimx
+  rparams->multiple_reds_per_blk = true;
+  rparams->block_dim_iter_dom = ParallelType::TIDx;
+  // use gdimx
+  rparams->grid_dim_iter_dom = ParallelType::BIDx;
+  // use unroll
+  rparams->unroll_factor_inner_reduction = unroll;
+  // use bdimy
+  rparams->cross_block_inner_reduction = true;
+  rparams->block_dim_inner_reduction = ParallelType::TIDy;
+  // use gdimy
+  rparams->cross_grid_inner_reduction = true;
+  rparams->split_grid_dim_inner_reduction = true;
+  rparams->grid_dim_inner_reduction = ParallelType::BIDy;
+  // set launch para
+  auto lparams = LaunchParams(
+      gdimx,
+      gdimy,
+      LaunchParams::UNINITIALIZED_VAL,
+      bdimx,
+      bdimy,
+      LaunchParams::UNINITIALIZED_VAL);
+  rparams->lparams = lparams;
+  scheduleReduction(&fusion, *rparams);
+
+  // Ensure we have two iteration grouped reductions
+  int num_iter_grouped_reductions = 0;
+  const auto& reduction_tvs =
+      scheduler_utils::getReductionTvs(fusion_ptr.get());
+  for (auto tv : reduction_tvs) {
+    bool has_grid_reduction = false;
+    bool has_grouped_domain = false;
+    for (auto id : tv->getLeafDomain()) {
+      if (id->isReduction() && id->getParallelType() == ParallelType::BIDy) {
+        has_grid_reduction = true;
+      }
+      if (id->getParallelType() == ParallelType::Group) {
+        has_grouped_domain = true;
+      }
+    }
+    if (has_grid_reduction) {
+      EXPECT_TRUE(has_grouped_domain)
+          << "Expect Iteration domain grouped grid reduction, tv: "
+          << tv->toString();
+    }
+    if (has_grid_reduction && has_grouped_domain) {
+      num_iter_grouped_reductions++;
+    }
+  }
+  EXPECT_TRUE(num_iter_grouped_reductions == 2)
+      << "Expect 2 Iteration domain grouped grid reductions, got: "
+      << num_iter_grouped_reductions;
+
+  FusionExecutor fe;
+  std::vector<int64_t> shape({redu_dim, iter_dim});
+  auto options = at::TensorOptions().device(at::kCUDA, 0);
+  auto t0 = at::randn(shape, options);
+  auto t1 = at::randn(shape, options);
+  std::vector<c10::IValue> aten_inputs({t0, t1});
+
+  fe.compileFusion(&fusion, aten_inputs, lparams);
+  auto cg_outputs = fe.runFusion(aten_inputs, lparams);
+
+  testValidate(
+      &fusion,
+      cg_outputs,
+      aten_inputs,
+      {t0.sum(0), (t0 + t1).sum(0)},
+      __LINE__,
+      __FILE__,
+      "",
+      lparams);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
**Issue:** when have multiple outer reductions in a fusion, if vectorized, only the first reduction tv is grouped.
**Fix:** ensure all reductions are grouped
**Influence:** about 1.1x speedup for case `NvFuserScheduler_BiasDropoutAddLayernormBwd1_tf32/1024/128/864/manual_time`, the name is confusing, it is just a simple fusion with 2 reductions. Before this PR, the first reduction is using iterGroupedGridReduction while the 2nd reduction uses regular grid reduction. After this PR, both reductions use iterGroupedGridReduction.
```
Inputs:
  T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ], float
  T1_g[ iS27{i0}, iS28{i2}, iS29{i3} ], float
  T2_g[ iS30{i0}, iS31{i2}, bS8{1} ], float
  T3_g[ iS35{i0}, iS36{i2}, bS11{1} ], float
Outputs:
  T6_g[ rS18{i0}, rS19{i2}, iS20{i3} ], float
  T8_g[ rS24{i0}, rS25{i2}, iS26{i3} ], float
  T5_g[ iS37{i0}, iS38{i2}, iS39{i3} ], float

%kernel_math {
T6_g[ rS18{i0}, rS19{i2}, iS20{i3} ]
   = reduction( T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ], op = add, initial value = float(0), allreduce = false )
T4_l[ iS32{i0}, iS33{i2}, iS34{i3} ]
   = T1_g[ iS27{i0}, iS28{i2}, iS29{i3} ]
   - T2_g[ iS30{i0}, iS31{i2}, bS8{1} ];
T5_g[ iS37{i0}, iS38{i2}, iS39{i3} ]
   = T4_l[ iS32{i0}, iS33{i2}, iS34{i3} ]
   * T3_g[ iS35{i0}, iS36{i2}, bS11{1} ];
T7_l[ iS21{i0}, iS22{i2}, iS23{i3} ]
   = T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ]
   * T5_g[ iS37{i0}, iS38{i2}, iS39{i3} ];
T8_g[ rS24{i0}, rS25{i2}, iS26{i3} ]
   = reduction( T7_l[ iS21{i0}, iS22{i2}, iS23{i3} ], op = add, initial value = float(0), allreduce = false )
}
```