### PR TITLE
Replacing one flavor of `IrBuilder::create` to `createInContainer`.

### DIFF
--- a/csrc/device_lower/pass/fusion_simplifier.cpp
+++ b/csrc/device_lower/pass/fusion_simplifier.cpp
@@ -42,7 +42,7 @@ class LoadStoreOpInserter : private kir::ExprMutator {
     auto container = out->container();
     registerReplaceAndPropagate(
         sop,
-        IrBuilder::create<LoadStoreOp>(
+        IrBuilder::createInContainer<LoadStoreOp>(
             container, LoadStoreOpType::Set, out, in));
   }
 
@@ -52,7 +52,7 @@ class LoadStoreOpInserter : private kir::ExprMutator {
     auto container = out->container();
     registerReplaceAndPropagate(
         eop,
-        IrBuilder::create<LoadStoreOp>(
+        IrBuilder::createInContainer<LoadStoreOp>(
             container, LoadStoreOpType::Set, out, in));
   }
 
@@ -62,7 +62,7 @@ class LoadStoreOpInserter : private kir::ExprMutator {
     auto container = out->container();
     registerReplaceAndPropagate(
         vop,
-        IrBuilder::create<LoadStoreOp>(
+        IrBuilder::createInContainer<LoadStoreOp>(
             container, LoadStoreOpType::Set, out, in));
   }
 };

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -1008,13 +1008,8 @@ void validateAndConvertIterDomainGrouping(Fusion* fusion) {
       std::vector<Val*> inputs({rop->in()});
 
       fusion->removeExpr(rop);
-      IrBuilder::create<GroupedReductionOp>(
-          static_cast<IrContainer*>(fusion),
-          op_types,
-          init_vals,
-          outputs,
-          inputs,
-          is_allreduce);
+      IrBuilder::createInContainer<GroupedReductionOp>(
+          fusion, op_types, init_vals, outputs, inputs, is_allreduce);
     } else if (tv->definition()->isA<WelfordOp>()) {
       // Convert WelfordOp to GroupedWelfordOp
       auto wop = def->as<WelfordOp>();
@@ -1039,12 +1034,8 @@ void validateAndConvertIterDomainGrouping(Fusion* fusion) {
       std::vector<WelfordTriplet> init_vals(
           {{wop->initAvg(), wop->initVar(), wop->initN()}});
       fusion->removeExpr(wop);
-      IrBuilder::create<GroupedWelfordOp>(
-          static_cast<IrContainer*>(fusion),
-          output_vals,
-          input_vals,
-          init_vals,
-          is_allreduce);
+      IrBuilder::createInContainer<GroupedWelfordOp>(
+          fusion, output_vals, input_vals, init_vals, is_allreduce);
     }
   }
 }

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -1092,7 +1092,7 @@ void DynamicTransformConcretizer::mutate(TensorDomain* td) {
     }
   }
 
-  Val* mutated_val = IrBuilder::create<TensorDomain>(
+  Val* mutated_val = IrBuilder::createInContainer<TensorDomain>(
       td->container(), root_dom, rfactor_dom, alloc_dom, leaf_domain, contig);
   registerConcretization(td, mutated_val);
 }

--- a/csrc/grouped_reduction.cpp
+++ b/csrc/grouped_reduction.cpp
@@ -245,7 +245,7 @@ bool groupReductions(
     return false;
   }
 
-  IrBuilder::create<GroupedReductionOp>(
+  IrBuilder::createInContainer<GroupedReductionOp>(
       container, op_types, init_vals, outputs, inputs);
 
   for (auto output : ir_utils::filterByType<TensorView>(outputs)) {

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -417,7 +417,7 @@ std::vector<PolymorphicValue> Expr::evaluate(
 }
 
 void Expr::addDataAttribute(PolymorphicValue attr) {
-  addAttribute(IrBuilder::create<Val>(container(), std::move(attr)));
+  addAttribute(IrBuilder::createInContainer<Val>(container(), std::move(attr)));
 }
 
 } // namespace nvfuser

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -260,7 +260,7 @@ class NVF_API Val : public Statement {
       : Statement(src, ir_cloner),
         vtype_(src->vtype_),
         dtype_(src->dtype_),
-        value_(src->value_){};
+        value_(src->value_) {};
 
   std::string toString(int indent_size = 0) const override;
 
@@ -682,7 +682,7 @@ bool Val::isDefinitionType() const {
       std::vector<Val*> inputs,                            \
       std::vector<Val*> outputs,                           \
       std::vector<Statement*> attributes) {                \
-    return IrBuilder::create<ClassName>(                   \
+    return IrBuilder::createInContainer<ClassName>(        \
         container, inputs, outputs, attributes);           \
   }
 

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -260,7 +260,7 @@ class NVF_API Val : public Statement {
       : Statement(src, ir_cloner),
         vtype_(src->vtype_),
         dtype_(src->dtype_),
-        value_(src->value_) {};
+        value_(src->value_) {}
 
   std::string toString(int indent_size = 0) const override;
 

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -243,14 +243,14 @@ Val* IrBuilder::gcdExpr(Val* lhs, Val* rhs) {
 Val* IrBuilder::getItemExpr(Val* array, Val* index) {
   auto item_dtype = std::get<ArrayType>(array->dtype().type).type;
   auto out = create<Val>(*item_dtype);
-  create<GetItem>(array->container(), out, array, index);
+  createInContainer<GetItem>(array->container(), out, array, index);
   return out;
 }
 
 Val* IrBuilder::getItemExpr(Val* array, PolymorphicValue index) {
   auto item_dtype = std::get<ArrayType>(array->dtype().type).type;
   auto out = create<Val>(*item_dtype);
-  create<GetItem>(
+  createInContainer<GetItem>(
       array->container(), out, array, create<Val>(index, DataType::Int));
   return out;
 }
@@ -259,7 +259,8 @@ Val* IrBuilder::getAttrExpr(Val* struct_, std::string attr) {
   auto struct_type = std::get<StructType>(struct_->dtype().type);
   const auto& item_type = struct_type.fieldDataType(attr);
   auto out = create<Val>(item_type);
-  create<GetAttr>(struct_->container(), out, struct_, std::move(attr));
+  createInContainer<GetAttr>(
+      struct_->container(), out, struct_, std::move(attr));
   return out;
 }
 

--- a/csrc/ir/builder.h
+++ b/csrc/ir/builder.h
@@ -41,7 +41,7 @@ class IrBuilder {
   //! Allocate a new IR node, forwarding the arguments to the appropriate
   //! constructor and registering with the container
   template <class T, class... Args>
-  static T* create(IrContainer* container, Args&&... args) {
+  static T* createInContainer(IrContainer* container, Args&&... args) {
     NVF_ERROR(container != nullptr, "Need an active container to build IR.");
     T* node = new T(IrBuilderPasskey(container), std::forward<Args>(args)...);
 

--- a/csrc/ir/builder.h
+++ b/csrc/ir/builder.h
@@ -29,13 +29,7 @@ class IrBuilder {
   template <class T, class... Args>
   static T* create(Args&&... args) {
     Fusion* fusion = FusionGuard::getCurFusion();
-    // return create<T>(fusion, std::forward<Args>(args)...);
-    NVF_ERROR(fusion != nullptr, "Need an active container to build IR.");
-    T* node = new T(IrBuilderPasskey(fusion), std::forward<Args>(args)...);
-
-    fusion->registerStmt(IrBuilderPasskey(fusion), node);
-
-    return node;
+    return createInContainer<T>(fusion, std::forward<Args>(args)...);
   }
 
   //! Allocate a new IR node, forwarding the arguments to the appropriate

--- a/csrc/ir/container.cpp
+++ b/csrc/ir/container.cpp
@@ -243,7 +243,8 @@ bool IrContainer::inContainer(const Statement* stmt) const {
 // Shortcuts for frequently used vals
 Val* IrContainer::zeroVal() {
   if (!zero_val_) {
-    auto zero_val = IrBuilder::create<Val>(this, 0L, DataType::Index);
+    auto zero_val =
+        IrBuilder::createInContainer<Val>(this, 0L, DataType::Index);
     NVF_ERROR(vals_up_.back().get() == zero_val);
     zero_val_ = std::unique_ptr<Val>(vals_up_.back().release());
     vals_up_.pop_back();
@@ -258,13 +259,13 @@ Val* IrContainer::zeroVal(DataType dtype) {
     return falseVal();
   } else {
     // NOTE: this does not cache values
-    return IrBuilder::create<Val>(this, 0L, dtype);
+    return IrBuilder::createInContainer<Val>(this, 0L, dtype);
   }
 }
 
 Val* IrContainer::oneVal() {
   if (!one_val_) {
-    auto one_val = IrBuilder::create<Val>(this, 1L, DataType::Index);
+    auto one_val = IrBuilder::createInContainer<Val>(this, 1L, DataType::Index);
     NVF_ERROR(vals_up_.back().get() == one_val);
     one_val_ = std::unique_ptr<Val>(vals_up_.back().release());
     vals_up_.pop_back();
@@ -279,13 +280,14 @@ Val* IrContainer::oneVal(DataType dtype) {
     return trueVal();
   } else {
     // NOTE: this does not cache values
-    return IrBuilder::create<Val>(this, 1L, dtype);
+    return IrBuilder::createInContainer<Val>(this, 1L, dtype);
   }
 }
 
 Val* IrContainer::falseVal() {
   if (!false_val_) {
-    auto false_val = IrBuilder::create<Val>(this, false, DataType::Bool);
+    auto false_val =
+        IrBuilder::createInContainer<Val>(this, false, DataType::Bool);
     NVF_ERROR(vals_up_.back().get() == false_val);
     false_val_ = std::unique_ptr<Val>(vals_up_.back().release());
     vals_up_.pop_back();
@@ -295,7 +297,8 @@ Val* IrContainer::falseVal() {
 
 Val* IrContainer::trueVal() {
   if (!true_val_) {
-    auto true_val = IrBuilder::create<Val>(this, true, DataType::Bool);
+    auto true_val =
+        IrBuilder::createInContainer<Val>(this, true, DataType::Bool);
     NVF_ERROR(vals_up_.back().get() == true_val);
     true_val_ = std::unique_ptr<Val>(vals_up_.back().release());
     vals_up_.pop_back();
@@ -317,8 +320,10 @@ NamedScalar* IrContainer::magicZeroVal() {
 
 Val* IrContainer::metadataOf(Val* v) {
   if (metadata_.count(v) == 0) {
-    auto metadata_val = IrBuilder::create<Val>(this, metaDataTypeOf(v));
-    auto metadata_expr = IrBuilder::create<GetMetaData>(this, metadata_val, v);
+    auto metadata_val =
+        IrBuilder::createInContainer<Val>(this, metaDataTypeOf(v));
+    auto metadata_expr =
+        IrBuilder::createInContainer<GetMetaData>(this, metadata_val, v);
     metadata_[v] = std::make_pair(metadata_val, metadata_expr);
   }
   return metadata_.at(v).first;

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2662,7 +2662,8 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
           .is_rfactor_domain(rfactor_domain)
           .build();
 
-  IrBuilder::createInContainer<Split>(in->container(), ido, idi, in, factor, inner_split);
+  IrBuilder::createInContainer<Split>(
+      in->container(), ido, idi, in, factor, inner_split);
   return {ido, idi};
 }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2363,7 +2363,7 @@ IterDomain* IterDomainBuilder::build() const {
   NVF_ERROR(
       start_ != nullptr && extent_ != nullptr,
       "Start and extent are required to build an iter domain.");
-  return IrBuilder::create<IterDomain>(start_->container(), *this);
+  return IrBuilder::createInContainer<IterDomain>(start_->container(), *this);
 }
 
 IterDomain::IterDomain(
@@ -2617,7 +2617,8 @@ IterDomain* IterDomain::merge(
           .is_rfactor_domain(rfactor_domain)
           .build();
 
-  IrBuilder::create<Merge>(outer->container(), merged_id, outer, inner);
+  IrBuilder::createInContainer<Merge>(
+      outer->container(), merged_id, outer, inner);
 
   return merged_id;
 }
@@ -2661,7 +2662,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
           .is_rfactor_domain(rfactor_domain)
           .build();
 
-  IrBuilder::create<Split>(in->container(), ido, idi, in, factor, inner_split);
+  IrBuilder::createInContainer<Split>(in->container(), ido, idi, in, factor, inner_split);
   return {ido, idi};
 }
 
@@ -2669,7 +2670,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::stridedSplit(int64_t factor) {
   // Use partial split so that only valid values are retained
   auto split_out = IterDomain::split(
       this,
-      IrBuilder::create<Val>(container(), factor, DataType::Index),
+      IrBuilder::createInContainer<Val>(container(), factor, DataType::Index),
       true,
       true);
 
@@ -2707,7 +2708,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::swizzle(
 
   IterDomain* out_y = IterDomainBuilder(in_y).build();
 
-  IrBuilder::create<Swizzle>(
+  IrBuilder::createInContainer<Swizzle>(
       in_x->container(), out_x, out_y, in_x, in_y, swizzle_type);
 
   return std::make_pair(out_x, out_y);
@@ -2742,7 +2743,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::swizzle(
 
   IterDomain* out_y = IterDomainBuilder(in_y).build();
 
-  IrBuilder::create<Swizzle2D>(
+  IrBuilder::createInContainer<Swizzle2D>(
       in_x->container(), out_x, out_y, in_x, in_y, swizzle_type, swizzle_mode);
 
   return std::make_pair(out_x, out_y);
@@ -2864,7 +2865,7 @@ IterDomain* IterDomain::resize(
           .iter_type(iter_type)
           .build();
 
-  IrBuilder::create<Resize>(
+  IrBuilder::createInContainer<Resize>(
       in->container(), resized_id, in, left_expansion, right_expansion);
 
   return resized_id;

--- a/csrc/mutator.cpp
+++ b/csrc/mutator.cpp
@@ -135,7 +135,7 @@ void OptOutMutator::mutate(TensorDomain* td) {
     return;
   }
 
-  Val* mutated_val = IrBuilder::create<TensorDomain>(
+  Val* mutated_val = IrBuilder::createInContainer<TensorDomain>(
       td->container(),
       root_dom,
       rfactor_dom,

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -167,7 +167,7 @@ TensorView* reshape(TensorView* inp_tv, const std::vector<Val*>& new_sizes) {
           TensorDomain::getContiguityFilledWith(rfactor_domain, true)),
       inp_tv->dtype());
 
-  IrBuilder::create<ViewOp>(inp_tv->container(), out_tv, inp_tv);
+  IrBuilder::createInContainer<ViewOp>(inp_tv->container(), out_tv, inp_tv);
 
   return out_tv;
 }
@@ -195,7 +195,7 @@ TensorView* flatten(TensorView* x, int64_t start_dim, int64_t end_dim) {
     return x;
   }
 
-  auto out = IrBuilder::create<TensorView>(
+  auto out = IrBuilder::createInContainer<TensorView>(
       x->container(),
       x->domain()->flatten(start_dim, end_dim),
       x->getDataType().value());
@@ -282,7 +282,7 @@ TensorView* squeeze(
     // If we did not squeeze any axes, this is just set()
     IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, x);
   } else {
-    IrBuilder::create<SqueezeOp>(x->container(), out, x, to_squeeze);
+    IrBuilder::createInContainer<SqueezeOp>(x->container(), out, x, to_squeeze);
   }
 
   return out;

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1038,11 +1038,11 @@ typename std::conditional<
 logical_right_shift_helper(LHS x, RHS shift) {
   auto sizeof_int_dtype = (x->dtype() == PrimDataType::Int) ? 64L : 32L;
 
-  auto neg_one = IrBuilder::create<Val>(x->container(), -1L);
-  auto one = IrBuilder::create<Val>(x->container(), 1L);
-  auto two = IrBuilder::create<Val>(x->container(), 2L);
+  auto neg_one = IrBuilder::createInContainer<Val>(x->container(), -1L);
+  auto one = IrBuilder::createInContainer<Val>(x->container(), 1L);
+  auto two = IrBuilder::createInContainer<Val>(x->container(), 2L);
   auto num_bits_scalar =
-      IrBuilder::create<Val>(x->container(), sizeof_int_dtype);
+      IrBuilder::createInContainer<Val>(x->container(), sizeof_int_dtype);
 
   auto mask =
       where(ge(shift, num_bits_scalar), neg_one, sub(pow(two, shift), one));
@@ -2232,13 +2232,13 @@ TensorView* viewAsScalar(TensorView* inp) {
           .build();
   out_domain.push_back(id);
 
-  auto out = IrBuilder::create<TensorView>(
+  auto out = IrBuilder::createInContainer<TensorView>(
       inp->container(),
       IrBuilder::create<TensorDomain>(
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       out_type);
 
-  IrBuilder::create<ViewAsScalar>(inp->container(), out, inp, id);
+  IrBuilder::createInContainer<ViewAsScalar>(inp->container(), out, inp, id);
 
   return out;
 }
@@ -2383,13 +2383,13 @@ TensorView* tensor(Val* val) {
     out_domain.push_back(id);
   }
 
-  auto out = IrBuilder::create<TensorView>(
+  auto out = IrBuilder::createInContainer<TensorView>(
       val->container(),
       IrBuilder::create<TensorDomain>(
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       dtype);
 
-  IrBuilder::create<TensorConstruct>(val->container(), out, val);
+  IrBuilder::createInContainer<TensorConstruct>(val->container(), out, val);
   return out;
 }
 

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -14,10 +14,11 @@
 namespace nvfuser {
 
 ForwardDropoutResult dropout(TensorView* x, Val* prob) {
-  auto p1m = sub(IrBuilder::create<Val>(x->container(), 1.), prob);
+  auto p1m = sub(IrBuilder::createInContainer<Val>(x->container(), 1.), prob);
   auto zero_check =
-      add(eq(p1m, IrBuilder::create<Val>(x->container(), 0.)), p1m);
-  auto scale = div(IrBuilder::create<Val>(x->container(), 1.), zero_check);
+      add(eq(p1m, IrBuilder::createInContainer<Val>(x->container(), 0.)), p1m);
+  auto scale =
+      div(IrBuilder::createInContainer<Val>(x->container(), 1.), zero_check);
   return dropout(x, p1m, scale);
 }
 
@@ -166,9 +167,9 @@ namespace {
 template <typename T>
 T* sign(T* x) {
   NVF_ERROR(x != nullptr, "Input is invalid.");
-  auto zero = IrBuilder::create<Val>(x->container(), 0.);
-  auto one = IrBuilder::create<Val>(x->container(), 1.);
-  auto minus_one = IrBuilder::create<Val>(x->container(), -1.);
+  auto zero = IrBuilder::createInContainer<Val>(x->container(), 0.);
+  auto one = IrBuilder::createInContainer<Val>(x->container(), 1.);
+  auto minus_one = IrBuilder::createInContainer<Val>(x->container(), -1.);
   auto sign = where(gt(x, zero), one, where(lt(x, zero), minus_one, zero));
   return castOp(x->getDataType().value(), sign);
 }
@@ -196,9 +197,9 @@ TensorView* softplus(TensorView* x, Val* beta, Val* threshold) {
 TensorView* gelu(TensorView* x) {
   NVF_ERROR(x != nullptr, "Input is invalid");
 
-  auto kappa = IrBuilder::create<Val>(x->container(), M_SQRT1_2);
-  auto half = IrBuilder::create<Val>(x->container(), 0.5);
-  auto one = IrBuilder::create<Val>(x->container(), 1.);
+  auto kappa = IrBuilder::createInContainer<Val>(x->container(), M_SQRT1_2);
+  auto half = IrBuilder::createInContainer<Val>(x->container(), 0.5);
+  auto one = IrBuilder::createInContainer<Val>(x->container(), 1.);
 
   auto cdf = mul(half, add(one, erf(mul(x, kappa))));
   auto y = mul(x, cdf);
@@ -212,17 +213,24 @@ TensorView* gelu_backward(TensorView* dy, TensorView* x) {
   constexpr double kAlpha = M_2_SQRTPI * M_SQRT1_2 * 0.5;
   const double kHalf = 0.5;
 
-  auto cdf_1 = mul(x, IrBuilder::create<Val>(x->container(), M_SQRT1_2));
+  auto cdf_1 =
+      mul(x, IrBuilder::createInContainer<Val>(x->container(), M_SQRT1_2));
   auto cdf_2 = erf(cdf_1);
-  auto cdf_3 = add(cdf_2, IrBuilder::create<Val>(x->container(), 1.));
-  auto cdf_4 = mul(cdf_3, IrBuilder::create<Val>(x->container(), kHalf));
+  auto cdf_3 =
+      add(cdf_2, IrBuilder::createInContainer<Val>(x->container(), 1.));
+  auto cdf_4 =
+      mul(cdf_3, IrBuilder::createInContainer<Val>(x->container(), kHalf));
 
   auto pdf_1 = mul(x, x);
-  auto pdf_2 = mul(pdf_1, IrBuilder::create<Val>(x->container(), -kHalf));
+  auto pdf_2 =
+      mul(pdf_1, IrBuilder::createInContainer<Val>(x->container(), -kHalf));
   auto pdf_3 = exp(pdf_2);
 
-  auto out =
-      addcmul(cdf_4, x, pdf_3, IrBuilder::create<Val>(x->container(), kAlpha));
+  auto out = addcmul(
+      cdf_4,
+      x,
+      pdf_3,
+      IrBuilder::createInContainer<Val>(x->container(), kAlpha));
   auto dx = mul(out, dy);
   return dx;
 }
@@ -235,14 +243,17 @@ TensorView* tanh_gelu(TensorView* x) {
 
   auto x_cube = mul(x, mul(x, x));
 
-  auto inner_1 = mul(IrBuilder::create<Val>(x->container(), kKappa), x_cube);
+  auto inner_1 =
+      mul(IrBuilder::createInContainer<Val>(x->container(), kKappa), x_cube);
   auto inner_2 = add(x, inner_1);
-  auto inner_3 = mul(IrBuilder::create<Val>(x->container(), kBeta), inner_2);
+  auto inner_3 =
+      mul(IrBuilder::createInContainer<Val>(x->container(), kBeta), inner_2);
   auto tanh_inner = tanh(inner_3);
 
-  auto out =
-      mul(x, add(IrBuilder::create<Val>(x->container(), 1.), tanh_inner));
-  auto y = mul(IrBuilder::create<Val>(x->container(), 0.5), out);
+  auto out = mul(
+      x,
+      add(IrBuilder::createInContainer<Val>(x->container(), 1.), tanh_inner));
+  auto y = mul(IrBuilder::createInContainer<Val>(x->container(), 0.5), out);
   return y;
 }
 
@@ -256,25 +267,30 @@ TensorView* tanh_gelu_backward(TensorView* dy, TensorView* x) {
   auto x_sq = mul(x, x);
   auto x_cube = mul(x, x_sq);
 
-  auto inner_1 = mul(IrBuilder::create<Val>(x->container(), kKappa), x_cube);
+  auto inner_1 =
+      mul(IrBuilder::createInContainer<Val>(x->container(), kKappa), x_cube);
   auto inner_2 = add(x, inner_1);
-  auto inner_3 = mul(IrBuilder::create<Val>(x->container(), kBeta), inner_2);
+  auto inner_3 =
+      mul(IrBuilder::createInContainer<Val>(x->container(), kBeta), inner_2);
   auto tanh_inner = tanh(inner_3);
 
-  auto left = mul(IrBuilder::create<Val>(x->container(), 0.5), x);
-  auto right = add(IrBuilder::create<Val>(x->container(), 1.), tanh_inner);
+  auto left = mul(IrBuilder::createInContainer<Val>(x->container(), 0.5), x);
+  auto right =
+      add(IrBuilder::createInContainer<Val>(x->container(), 1.), tanh_inner);
 
   auto left_derivative =
-      mul(IrBuilder::create<Val>(x->container(), 0.5), right);
+      mul(IrBuilder::createInContainer<Val>(x->container(), 0.5), right);
 
   auto tanh_inner_sq = mul(tanh_inner, tanh_inner);
-  auto tanh_derivative =
-      sub(IrBuilder::create<Val>(x->container(), 1.0), tanh_inner_sq);
+  auto tanh_derivative = sub(
+      IrBuilder::createInContainer<Val>(x->container(), 1.0), tanh_inner_sq);
 
   auto constant_mul_x_sq =
-      mul(IrBuilder::create<Val>(x->container(), kBeta * 3 * kKappa), x_sq);
+      mul(IrBuilder::createInContainer<Val>(x->container(), kBeta * 3 * kKappa),
+          x_sq);
   auto inner_derivative =
-      add(IrBuilder::create<Val>(x->container(), kBeta), constant_mul_x_sq);
+      add(IrBuilder::createInContainer<Val>(x->container(), kBeta),
+          constant_mul_x_sq);
   auto right_derivative = mul(left, mul(tanh_derivative, inner_derivative));
 
   auto dx = mul(dy, add(left_derivative, right_derivative));
@@ -285,7 +301,7 @@ TensorView* tanh_backward(TensorView* dy, TensorView* tanh_x) {
   NVF_ERROR(dy != nullptr, "Grad Output is invalid.");
   NVF_ERROR(tanh_x != nullptr, "Input is invalid");
 
-  auto one = IrBuilder::create<Val>(tanh_x->container(), 1.);
+  auto one = IrBuilder::createInContainer<Val>(tanh_x->container(), 1.);
   auto tanh_sq = mul(tanh_x, tanh_x);
   auto sub_tanh_sq = sub(one, tanh_sq);
   auto dx = mul(dy, sub_tanh_sq);
@@ -295,7 +311,7 @@ TensorView* tanh_backward(TensorView* dy, TensorView* tanh_x) {
 TensorView* leaky_relu(TensorView* x, Val* negative_slope) {
   NVF_ERROR(x != nullptr, "input is invalid.");
   NVF_ERROR(negative_slope != nullptr, "negative_slope is invalid");
-  auto zero = IrBuilder::create<Val>(x->container(), 0.);
+  auto zero = IrBuilder::createInContainer<Val>(x->container(), 0.);
   return where(ge(x, zero), x, mul(negative_slope, x));
 }
 

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1016,9 +1016,9 @@ TensorView* TensorView::cacheBefore(LoadStoreOpType op_type) {
   // This domain will be the consumer which needs a new domain, so replace the
   // producers domain with this domain.
 
-  TensorView* producer = IrBuilder::create<TensorView>(
+  TensorView* producer = IrBuilder::createInContainer<TensorView>(
       container(),
-      IrBuilder::create<TensorDomain>(
+      IrBuilder::createInContainer<TensorDomain>(
           container(),
           getRootDomain(),
           getRFactorDomain(),
@@ -1040,7 +1040,7 @@ TensorView* TensorView::cacheBefore(LoadStoreOpType op_type) {
 
   // Warning: allocation domain is temporarily discarded. It will be recovered
   // later.
-  consumer->setDomain(IrBuilder::create<TensorDomain>(
+  consumer->setDomain(IrBuilder::createInContainer<TensorDomain>(
       container(),
       new_root_domain,
       TensorDomain::getContiguityFilledWith(new_root_domain, true)));
@@ -1056,7 +1056,8 @@ TensorView* TensorView::cacheBefore(LoadStoreOpType op_type) {
   }
   ir_utils::transferDefinitionToNewOutputs(definition(), replaced_siblings);
 
-  IrBuilder::create<LoadStoreOp>(container(), op_type, consumer, producer);
+  IrBuilder::createInContainer<LoadStoreOp>(
+      container(), op_type, consumer, producer);
 
   // definition_ is no longer valid
   // setDefinition(nullptr);
@@ -1094,16 +1095,16 @@ TensorView* TensorView::cacheFork() {
   // This domain will be the producer, so create the consumer
   auto root_domain = TensorDomain::noReductions(getRFactorDomain());
 
-  TensorView* new_output = IrBuilder::create<TensorView>(
+  TensorView* new_output = IrBuilder::createInContainer<TensorView>(
       container(),
-      IrBuilder::create<TensorDomain>(
+      IrBuilder::createInContainer<TensorDomain>(
           container(),
           IterDomain::clone(root_domain),
           TensorDomain::getContiguityFilledWith(root_domain, true)),
       getDataType().value());
 
   // Create write operation from this TV to new output
-  IrBuilder::create<LoadStoreOp>(
+  IrBuilder::createInContainer<LoadStoreOp>(
       container(), LoadStoreOpType::Set, new_output, this);
 
   // The new TV becomes an output.
@@ -1174,9 +1175,9 @@ TensorView* TensorView::cacheAfter(
   }
 
   // This domain will be the producer, so create the consumer
-  TensorView* consumer = IrBuilder::create<TensorView>(
+  TensorView* consumer = IrBuilder::createInContainer<TensorView>(
       container(),
-      IrBuilder::create<TensorDomain>(
+      IrBuilder::createInContainer<TensorDomain>(
           container(),
           new_root_domain,
           TensorDomain::getContiguityFilledWith(new_root_domain, true)),
@@ -1195,7 +1196,7 @@ TensorView* TensorView::cacheAfter(
   }
 
   // Expr* consumer_definition =
-  IrBuilder::create<LoadStoreOp>(
+  IrBuilder::createInContainer<LoadStoreOp>(
       container(), op_type, consumer, producer, cache_op);
 
   if (propagate_allocation_domain) {
@@ -1252,10 +1253,10 @@ void TensorView::clearReductionIterDomains() {
   if (new_alloc == new_root) {
     // if new allocation domain is identical to new root domain, we don't need
     // to specify allocation domain
-    setDomain(
-        IrBuilder::create<TensorDomain>(container(), new_root, new_contig));
+    setDomain(IrBuilder::createInContainer<TensorDomain>(
+        container(), new_root, new_contig));
   } else {
-    setDomain(IrBuilder::create<TensorDomain>(
+    setDomain(IrBuilder::createInContainer<TensorDomain>(
         container(),
         std::vector<IterDomain*>(),
         new_root,
@@ -1329,7 +1330,7 @@ void TensorView::commitLeafToRFactor() {
   NVF_CHECK(
       ir_utils::consumerTvsOf(this).empty(),
       "Changing the rFactor domain of an intermediate tensor is not supported yet");
-  setDomain(IrBuilder::create<TensorDomain>(
+  setDomain(IrBuilder::createInContainer<TensorDomain>(
       container(),
       domain_->maybeRoot(),
       domain_->leaf(),

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -69,7 +69,7 @@ class ReplaySelf : public ReplayTransformations {
                           .build();
 
     // Generate the split node
-    IrBuilder::create<Split>(
+    IrBuilder::createInContainer<Split>(
         s->container(), ido, idi, mapped, s->factor(), s->innerSplit());
 
     // Remove mapped id from leaf IDs
@@ -115,7 +115,7 @@ class ReplaySelf : public ReplayTransformations {
                                 .extent(merged_id_size)
                                 .build();
 
-    IrBuilder::create<Merge>(
+    IrBuilder::createInContainer<Merge>(
         m->container(), merged_id, id_outer_mapped, id_inner_mapped);
 
     // Remove inputs from the leaf IDs
@@ -231,7 +231,7 @@ TensorDomain* TransformReplay::fullSelfReplay(
             "Error during replay, didn't replay an axis.");
         new_rfactor_domain[i++] = it->second;
       }
-      return IrBuilder::create<TensorDomain>(
+      return IrBuilder::createInContainer<TensorDomain>(
           self->container(),
           new_self_root->root(),
           new_rfactor_domain,
@@ -240,7 +240,7 @@ TensorDomain* TransformReplay::fullSelfReplay(
     }
   }
 
-  return IrBuilder::create<TensorDomain>(
+  return IrBuilder::createInContainer<TensorDomain>(
       self->container(),
       new_self_root->rfactor(),
       new_domain,
@@ -510,7 +510,7 @@ std::pair<TensorDomain*, int64_t> TransformReplay::replayPasC(
       !opt.replay_allocation,
       "replayAllocation is not implemented yet for TransformReplay::replayPasC");
 
-  TensorDomain* replayed = IrBuilder::create<TensorDomain>(
+  TensorDomain* replayed = IrBuilder::createInContainer<TensorDomain>(
       producer->container(),
       producer->getRootDomain(),
       producer->getRFactorDomain(),
@@ -739,7 +739,7 @@ std::pair<TensorDomain*, int64_t> TransformReplay::replayCasP(
   }
 
   if (!opt.replay_allocation) {
-    TensorDomain* replayed = IrBuilder::create<TensorDomain>(
+    TensorDomain* replayed = IrBuilder::createInContainer<TensorDomain>(
         consumer->container(),
         consumer->getRootDomain(),
         consumer->getRFactorDomain(),
@@ -756,7 +756,7 @@ std::pair<TensorDomain*, int64_t> TransformReplay::replayCasP(
       "Other ops (e.g. `consumer = broadcast(producer)`) can break. "
       "See https://github.com/NVIDIA/Fuser/pull/1291#discussion_r1391999007 for details.");
 
-  TensorDomain* replayed = IrBuilder::create<TensorDomain>(
+  TensorDomain* replayed = IrBuilder::createInContainer<TensorDomain>(
       consumer->container(),
       consumer->getRootDomain(),
       consumer->getRFactorDomain(),
@@ -1256,7 +1256,7 @@ TensorDomain* fullReplay(
       });
 
   if (!old_domain->hasRoot()) {
-    return IrBuilder::create<TensorDomain>(
+    return IrBuilder::createInContainer<TensorDomain>(
         old_domain->container(), new_root, new_leaf, old_domain->contiguity());
   }
 
@@ -1270,7 +1270,7 @@ TensorDomain* fullReplay(
         return replay.getReplay().at(old_rfactor_id);
       });
 
-  return IrBuilder::create<TensorDomain>(
+  return IrBuilder::createInContainer<TensorDomain>(
       old_domain->container(),
       new_root,
       new_rfactor,

--- a/csrc/transform_rfactor.cpp
+++ b/csrc/transform_rfactor.cpp
@@ -143,7 +143,7 @@ class ReplayRFactor : public ReplayTransformations {
             .build();
 
     // Generate the split node
-    IrBuilder::create<Split>(
+    IrBuilder::createInContainer<Split>(
         s->container(), ido, idi, mapped, s->factor(), s->innerSplit());
 
     // Remove mapped id from leaf IDs
@@ -193,7 +193,7 @@ class ReplayRFactor : public ReplayTransformations {
             .is_rfactor_domain(static_rfactor_ids_.count(m->out()))
             .build();
 
-    IrBuilder::create<Merge>(
+    IrBuilder::createInContainer<Merge>(
         m->container(), merged_id, id_outer_mapped, id_inner_mapped);
 
     // Remove inputs from the leaf IDs
@@ -421,7 +421,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
         return replayed_id_it->second;
       });
 
-  TensorDomain* producer_domain = IrBuilder::create<TensorDomain>(
+  TensorDomain* producer_domain = IrBuilder::createInContainer<TensorDomain>(
       original_td->container(),
       new_producer_root,
       new_producer_rfactor_domain,
@@ -481,7 +481,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
     }
   }
 
-  auto consumer_domain = IrBuilder::create<TensorDomain>(
+  auto consumer_domain = IrBuilder::createInContainer<TensorDomain>(
       original_td->container(),
       new_consumer_root_domain,
       new_consumer_domain,

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -936,12 +936,13 @@ TensorView* applyViewTransforms(
 
   NVF_ERROR(!view_analysis.transforms.empty());
 
-  TensorView* consumer = IrBuilder::create<TensorView>(
+  TensorView* consumer = IrBuilder::createInContainer<TensorView>(
       orig_tv->container(),
       orig_tv->domain()->view(view_analysis),
       orig_tv->getDataType().value());
 
-  IrBuilder::create<ViewOp>(orig_tv->container(), consumer, post_reduce_tv);
+  IrBuilder::createInContainer<ViewOp>(
+      orig_tv->container(), consumer, post_reduce_tv);
 
   return consumer;
 }

--- a/tests/cpp/test_gpu_fused_reduction.cpp
+++ b/tests/cpp/test_gpu_fused_reduction.cpp
@@ -1340,7 +1340,7 @@ TEST_F(NVFuserTest, FusionPersistentBNBackwardAllreduce_CUDA) {
   if (weight == nullptr) {
     grad_scale =
         mul(broadcast(invstd, broadcast_mask),
-            IrBuilder::create<Val>(input->container(), 1.0));
+            IrBuilder::createInContainer<Val>(input->container(), 1.0));
   } else {
     grad_scale = mul(
         broadcast(invstd, broadcast_mask), broadcast(weight, broadcast_mask));

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -100,8 +100,8 @@ TEST_P(HostIrTest, SingleFusion) {
   auto hic = std::make_unique<HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
   // [Step 3)] Create a HostUnit Ir holding the created fusion
-  auto host_unit = IrBuilder::create<HostUnit>(
-      static_cast<IrContainer*>(hic.get()), std::move(fusion));
+  auto host_unit =
+      IrBuilder::createInContainer<HostUnit>(hic.get(), std::move(fusion));
 
   // [Step 4)] Create TensorViews representing the Fusion's I/O at the Host
   // level
@@ -113,11 +113,8 @@ TEST_P(HostIrTest, SingleFusion) {
 
   // [Step 5)] Create a PostOnStream Ir representing executing the Fusion with
   // given I/O
-  auto post_on_stream = IrBuilder::create<PostOnStream>(
-      static_cast<IrContainer*>(hic.get()),
-      host_unit,
-      post_on_stream_inputs,
-      post_on_stream_outputs);
+  auto post_on_stream = IrBuilder::createInContainer<PostOnStream>(
+      hic.get(), host_unit, post_on_stream_inputs, post_on_stream_outputs);
 
   // [Step 6)] Define the Host program by adding PostOnStream to the container's
   // top level expression
@@ -184,10 +181,10 @@ TEST_P(HostIrTest, TwoFusions) {
   FusionGuard::setCurFusion(hic.get());
 
   // [Step 3)] Create two HostUnit Irs holding the fusions
-  auto host_unit_0 = IrBuilder::create<HostUnit>(
-      static_cast<IrContainer*>(hic.get()), std::make_unique<Fusion>(fusion_0));
-  auto host_unit_1 = IrBuilder::create<HostUnit>(
-      static_cast<IrContainer*>(hic.get()), std::make_unique<Fusion>(fusion_1));
+  auto host_unit_0 = IrBuilder::createInContainer<HostUnit>(
+      hic.get(), std::make_unique<Fusion>(fusion_0));
+  auto host_unit_1 = IrBuilder::createInContainer<HostUnit>(
+      hic.get(), std::make_unique<Fusion>(fusion_1));
 
   // [Step 4)a.] Create TensorViews representing the first Fusions I/O at the
   // Host level
@@ -198,8 +195,8 @@ TEST_P(HostIrTest, TwoFusions) {
       ir_cloner.clone(host_unit_0->fusion_to_execute()->outputs().at(0))};
   // [Step 5)a.] Create a PostOnStream Ir representing executing the first
   // Fusion with given I/O
-  auto post_on_stream_0 = IrBuilder::create<PostOnStream>(
-      static_cast<IrContainer*>(hic.get()),
+  auto post_on_stream_0 = IrBuilder::createInContainer<PostOnStream>(
+      hic.get(),
       host_unit_0,
       std::move(post_on_stream_inputs_0),
       post_on_stream_outputs_0);
@@ -211,8 +208,8 @@ TEST_P(HostIrTest, TwoFusions) {
       ir_cloner.clone(host_unit_1->fusion_to_execute()->outputs().at(0))};
   // [Step 5)b.] Create a PostOnStream Ir representing executing the second
   // Fusion with given I/O
-  auto post_on_stream_1 = IrBuilder::create<PostOnStream>(
-      static_cast<IrContainer*>(hic.get()),
+  auto post_on_stream_1 = IrBuilder::createInContainer<PostOnStream>(
+      hic.get(),
       host_unit_1,
       std::move(post_on_stream_inputs_1),
       post_on_stream_outputs_1);
@@ -289,12 +286,12 @@ TEST_P(HostIrTest, ThreeFusions) {
   auto hic = std::make_unique<HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
   // [Step 3)] Create HostUnit Irs holding the fusions
-  auto host_unit_0 = IrBuilder::create<HostUnit>(
-      static_cast<IrContainer*>(hic.get()), std::make_unique<Fusion>(fusion_0));
-  auto host_unit_1 = IrBuilder::create<HostUnit>(
-      static_cast<IrContainer*>(hic.get()), std::make_unique<Fusion>(fusion_1));
-  auto host_unit_2 = IrBuilder::create<HostUnit>(
-      static_cast<IrContainer*>(hic.get()), std::make_unique<Fusion>(fusion_2));
+  auto host_unit_0 = IrBuilder::createInContainer<HostUnit>(
+      hic.get(), std::make_unique<Fusion>(fusion_0));
+  auto host_unit_1 = IrBuilder::createInContainer<HostUnit>(
+      hic.get(), std::make_unique<Fusion>(fusion_1));
+  auto host_unit_2 = IrBuilder::createInContainer<HostUnit>(
+      hic.get(), std::make_unique<Fusion>(fusion_2));
 
   // [Step 4)a.] Create TensorViews representing the first Fusions I/O at the
   // Host level
@@ -310,8 +307,8 @@ TEST_P(HostIrTest, ThreeFusions) {
   std::vector<Val*> post_on_stream_outputs_0 = clone({tv1_0, tv2_0});
   // [Step 5)a.] Create a PostOnStream Ir representing executing the first
   // Fusion with given I/O
-  auto post_on_stream_0 = IrBuilder::create<PostOnStream>(
-      static_cast<IrContainer*>(hic.get()),
+  auto post_on_stream_0 = IrBuilder::createInContainer<PostOnStream>(
+      hic.get(),
       host_unit_0,
       std::move(post_on_stream_inputs_0),
       post_on_stream_outputs_0);
@@ -322,8 +319,8 @@ TEST_P(HostIrTest, ThreeFusions) {
   std::vector<Val*> post_on_stream_outputs_1 = clone({tv2_1});
   // [Step 5)b.] Create a PostOnStream Ir representing executing the first
   // Fusion with given I/O
-  auto post_on_stream_1 = IrBuilder::create<PostOnStream>(
-      static_cast<IrContainer*>(hic.get()),
+  auto post_on_stream_1 = IrBuilder::createInContainer<PostOnStream>(
+      hic.get(),
       host_unit_1,
       std::move(post_on_stream_inputs_1),
       post_on_stream_outputs_1);
@@ -335,8 +332,8 @@ TEST_P(HostIrTest, ThreeFusions) {
   std::vector<Val*> post_on_stream_outputs_2 = clone({tv2_2});
   // [Step 5)c.] Create a PostOnStream Ir representing executing the first
   // Fusion with given I/O
-  auto post_on_stream_2 = IrBuilder::create<PostOnStream>(
-      static_cast<IrContainer*>(hic.get()),
+  auto post_on_stream_2 = IrBuilder::createInContainer<PostOnStream>(
+      hic.get(),
       host_unit_2,
       std::move(post_on_stream_inputs_2),
       post_on_stream_outputs_2);

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -62,7 +62,7 @@ void CommunicationTest::validate(at::Tensor obtained, at::Tensor expected) {
 }
 
 TEST_P(CommunicationTest, Gather) {
-  auto communication = IrBuilder::create<Communication>(
+  auto communication = IrBuilder::createInContainer<Communication>(
       &container, CommunicationType::Gather, full_mesh_, all_ranks_, kRoot);
 
   at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options);
@@ -90,7 +90,7 @@ TEST_P(CommunicationTest, Gather) {
 }
 
 TEST_P(CommunicationTest, Allgather) {
-  auto communication = IrBuilder::create<Communication>(
+  auto communication = IrBuilder::createInContainer<Communication>(
       &container, CommunicationType::Allgather, full_mesh_, all_ranks_);
 
   at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options);
@@ -117,7 +117,7 @@ TEST_P(CommunicationTest, Allgather) {
 }
 
 TEST_P(CommunicationTest, Scatter) {
-  auto communication = IrBuilder::create<Communication>(
+  auto communication = IrBuilder::createInContainer<Communication>(
       &container, CommunicationType::Scatter, full_mesh_, all_ranks_, kRoot);
 
   at::Tensor input_tensor;
@@ -150,7 +150,7 @@ TEST_P(CommunicationTest, Scatter) {
 }
 
 TEST_P(CommunicationTest, Broadcast) {
-  auto communication = IrBuilder::create<Communication>(
+  auto communication = IrBuilder::createInContainer<Communication>(
       &container, CommunicationType::Broadcast, full_mesh_, all_ranks_, kRoot);
 
   at::Tensor input_tensor;
@@ -193,7 +193,7 @@ TEST_P(CommunicationTest, SendRecv) {
     return;
   }
 
-  auto communication = IrBuilder::create<Communication>(
+  auto* communication = IrBuilder::createInContainer<Communication>(
       &container,
       CommunicationType::SendRecv,
       DeviceMesh({receiver}),
@@ -236,7 +236,7 @@ TEST_P(CommunicationTest, SendRecvToSelf) {
     return;
   }
 
-  auto communication = IrBuilder::create<Communication>(
+  auto* communication = IrBuilder::createInContainer<Communication>(
       &container,
       CommunicationType::SendRecv,
       DeviceMesh({sender}),
@@ -262,7 +262,7 @@ TEST_P(CommunicationTest, SendRecvToSelf) {
 }
 
 TEST_P(CommunicationTest, Reduce) {
-  auto communication = IrBuilder::create<Communication>(
+  auto* communication = IrBuilder::createInContainer<Communication>(
       &container,
       CommunicationType::Reduce,
       full_mesh_,
@@ -296,7 +296,7 @@ TEST_P(CommunicationTest, Reduce) {
 }
 
 TEST_P(CommunicationTest, Allreduce) {
-  auto communication = IrBuilder::create<Communication>(
+  auto* communication = IrBuilder::createInContainer<Communication>(
       &container,
       CommunicationType::Allreduce,
       full_mesh_,
@@ -327,7 +327,7 @@ TEST_P(CommunicationTest, Allreduce) {
 }
 
 TEST_P(CommunicationTest, ReduceScatter) {
-  auto communication = IrBuilder::create<Communication>(
+  auto* communication = IrBuilder::createInContainer<Communication>(
       &container,
       CommunicationType::ReduceScatter,
       full_mesh_,

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -70,11 +70,11 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
   FusionGuard::setCurFusion(hic.get());
 
   // [Step 3a)] Create a HostUnit Ir holding the fusions
-  auto hu = IrBuilder::create<HostUnit>(
-      static_cast<IrContainer*>(hic.get()), std::move(fusion));
+  auto hu =
+      IrBuilder::createInContainer<HostUnit>(hic.get(), std::move(fusion));
 
   // [Step 3b)] Create a Communication Ir
-  auto communication = IrBuilder::create<Communication>(
+  auto communication = IrBuilder::createInContainer<Communication>(
       static_cast<IrContainer*>(hic.get()),
       CommunicationType::Allgather,
       mesh,
@@ -93,18 +93,12 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
   // the Communication
   std::vector<Val*> compute_inputs = {tv0};
   std::vector<Val*> compute_outputs = {tv1};
-  auto post_compute = IrBuilder::create<PostOnStream>(
-      static_cast<IrContainer*>(hic.get()),
-      hu,
-      compute_inputs,
-      compute_outputs);
+  auto post_compute = IrBuilder::createInContainer<PostOnStream>(
+      hic.get(), hu, compute_inputs, compute_outputs);
   std::vector<Val*> communication_inputs = {tv1};
   std::vector<Val*> communication_outputs = {tv2};
-  auto post_communication = IrBuilder::create<PostOnStream>(
-      static_cast<IrContainer*>(hic.get()),
-      communication,
-      communication_inputs,
-      communication_outputs);
+  auto post_communication = IrBuilder::createInContainer<PostOnStream>(
+      hic.get(), communication, communication_inputs, communication_outputs);
 
   // [Step 6)] Define the Host program
   hic->pushBackTopLevelExprs(post_compute);

--- a/tests/cpp/test_predicate_elimination.cpp
+++ b/tests/cpp/test_predicate_elimination.cpp
@@ -347,7 +347,7 @@ TEST_F(PredicateEliminationTest, 8) {
 
   std::vector<int64_t> reduction_axes = {0, 2, 3};
 
-  Val* num_features = IrBuilder::create<Val>(tv1->container(), 1.0);
+  Val* num_features = IrBuilder::createInContainer<Val>(tv1->container(), 1.0);
   for (const auto dim : reduction_axes) {
     num_features = mul(num_features, tv1->getLeafDomain()[dim]->extent());
   }


### PR DESCRIPTION
As a follow-up to https://github.com/NVIDIA/Fuser/pull/2312#discussion_r1625015218.

Currently, the two flavors of `IrBuilder::create` both accept variadic template arguments and therefore require the caller to type perfectly. 