### PR TITLE
Don't invalidate existing ValGroup when not necessary

### DIFF
--- a/csrc/id_model/schedule.cpp
+++ b/csrc/id_model/schedule.cpp
@@ -38,8 +38,8 @@ ValGroup merge(ValGraph* graph, const ValGroup& g0, const ValGroup& g1) {
   g0_id = g0_id->cloneWithoutRFactor();
   g1_id = g1_id->cloneWithoutRFactor();
   auto output_id = IterDomain::merge(g0_id, g1_id);
-  graph->appendToGroup(g0_id, g0);
-  graph->appendToGroup(g1_id, g1);
+  graph->initializeVal(g0_id, g0);
+  graph->initializeVal(g1_id, g1);
   graph->initializeVal(output_id, {}, {});
   graph->registerExpr(output_id->definition());
   return graph->toGroup(output_id);
@@ -85,7 +85,7 @@ std::pair<ValGroup, ValGroup> split(
   // There is no such split, then create one
   g_id = g_id->cloneWithoutRFactor();
   auto [outer_id, inner_id] = IterDomain::split(g_id, factor, inner_split);
-  graph->appendToGroup(g_id, g);
+  graph->initializeVal(g_id, g);
   graph->initializeVal(outer_id, {}, {});
   graph->initializeVal(inner_id, {}, {});
   graph->registerExpr(inner_id->definition());

--- a/csrc/id_model/schedule.cpp
+++ b/csrc/id_model/schedule.cpp
@@ -38,10 +38,8 @@ ValGroup merge(ValGraph* graph, const ValGroup& g0, const ValGroup& g1) {
   g0_id = g0_id->cloneWithoutRFactor();
   g1_id = g1_id->cloneWithoutRFactor();
   auto output_id = IterDomain::merge(g0_id, g1_id);
-  graph->initializeVal(g0_id, {}, {});
-  graph->initializeVal(g1_id, {}, {});
-  graph->mapVals(g0->front(), g0_id);
-  graph->mapVals(g1->front(), g1_id);
+  graph->appendToGroup(g0_id, g0);
+  graph->appendToGroup(g1_id, g1);
   graph->initializeVal(output_id, {}, {});
   graph->registerExpr(output_id->definition());
   return graph->toGroup(output_id);
@@ -87,8 +85,7 @@ std::pair<ValGroup, ValGroup> split(
   // There is no such split, then create one
   g_id = g_id->cloneWithoutRFactor();
   auto [outer_id, inner_id] = IterDomain::split(g_id, factor, inner_split);
-  graph->initializeVal(g_id, {}, {});
-  graph->mapVals(g->front(), g_id);
+  graph->appendToGroup(g_id, g);
   graph->initializeVal(outer_id, {}, {});
   graph->initializeVal(inner_id, {}, {});
   graph->registerExpr(inner_id->definition());

--- a/csrc/id_model/schedule.h
+++ b/csrc/id_model/schedule.h
@@ -15,12 +15,14 @@ namespace nvfuser {
 // already a merge of g0 with g1 in graph, return the output ValGroup of that
 // merge. Otherwise create an new ValGroup that is a merge of g0 and g1 in
 // graph, and a new ExprGroup that is the definition of the new ValGroup.
+// After the merge, g0 and g1 will remain valid pointers.
 ValGroup merge(ValGraph* graph, const ValGroup& g0, const ValGroup& g1);
 
 // Given a ValGraph and a ValGroup g in this graph, if there is already a split
 // of g in graph with the same factor, then return the output ValGroups of that
 // split. Otherwise create two new ValGroups that is a split of g in
 // graph, and a new ExprGroup that is the definition of the new ValGroups.
+// After the merge, g will remain valid pointers.
 std::pair<ValGroup, ValGroup> split(
     ValGraph* graph,
     const ValGroup& g,

--- a/csrc/id_model/schedule.h
+++ b/csrc/id_model/schedule.h
@@ -22,7 +22,7 @@ ValGroup merge(ValGraph* graph, const ValGroup& g0, const ValGroup& g1);
 // of g in graph with the same factor, then return the output ValGroups of that
 // split. Otherwise create two new ValGroups that is a split of g in
 // graph, and a new ExprGroup that is the definition of the new ValGroups.
-// After the merge, g will remain valid pointers.
+// After the split, g will remain valid pointers.
 std::pair<ValGroup, ValGroup> split(
     ValGraph* graph,
     const ValGroup& g,

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -201,6 +201,11 @@ class ValGraph {
   // already registered.
   void registerExpr(Expr* expr);
 
+  // Append a Val into a ValGroup, and add mapping for this Val
+  void appendToGroup(Val* v, ValGroup vg) {
+    disjoint_vals_.appendToSet(v, vg);
+  }
+
   // Returns true if first and second are expressions through which
   // this ValGraph has matching inputs (if forward), or outputs (if not
   // forward). Returning true means the expressions are "the same", in terms

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -186,7 +186,9 @@ class ValGraph {
   std::string toString() const;
 
   // Initializes entries for the provided Val with its definitions and
-  // uses.
+  // uses. The provided Val will have its own new ValGroup, each item in the
+  // definitions and uses will become a new ExprGroup, and these new ExprGroups
+  // will be the definitions and uses of the new ValGroup.
   void initializeVal(
       Val* val,
       const VectorOfUniqueEntries<Expr*>& definitions,
@@ -196,15 +198,17 @@ class ValGraph {
   // used
   void initializeVal(Val* val);
 
+  // Initializes entries for the provided Val. The provided Val will be added to
+  // the provided existing ValGroup. There will be no changes on the definitions
+  // and uses of the provided ValGroup.
+  void initializeVal(Val* v, ValGroup vg) {
+    disjoint_vals_.appendToSet(v, vg);
+  }
+
   // Add expr to the disjoint sets as a sole group. Used for
   // registering replayed domains and exprs. Error if the expr is
   // already registered.
   void registerExpr(Expr* expr);
-
-  // Append a Val into a ValGroup, and add mapping for this Val
-  void appendToGroup(Val* v, ValGroup vg) {
-    disjoint_vals_.appendToSet(v, vg);
-  }
 
   // Returns true if first and second are expressions through which
   // this ValGraph has matching inputs (if forward), or outputs (if not


### PR DESCRIPTION
Currently, functions in `id_model/schedule.{h,cpp}` will invalidate the input `ValGroup` because it will create a new `ValGroup` with a new ID and map that new group with the input group. This is annoying and unnecessarily expensive. This PR changes the behavior by just appending the new ID into the existing `ValGroup`.