### PR TITLE
Test error fix

### DIFF
--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -42,7 +42,7 @@ TEST_F(IdModelTest, DetectSelfMapping) {
   EXPECT_THAT(
       [&]() { IdModel id_model(&fusion, /*build_graphs=*/true); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
-          ::testing::HasSubstr("!hasSelfMapping")));
+          ::testing::HasSubstr("are mapped with each other")));
 }
 
 TEST_F(IdModelTest, PerTensorSelfMapping) {


### PR DESCRIPTION
Previously an exception was thrown by ComputeAtMap when the validation of IdModel was done. Now that the validation is disabled by default, the error message changed.