### PR TITLE
Sharded pointwise scheduler

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -544,4 +544,27 @@ int64_t getShardedAxis(TensorView* tv) {
   return -1;
 }
 
+void reorderDIDToFront(TensorView* tv) {
+  // new position to old position
+  std::unordered_map<int64_t, int64_t> order_map;
+  int64_t current_pos = 0;
+
+  for (auto pos : c10::irange(tv->nDims())) {
+    if (tv->axis(pos)->isDeviceDim()) {
+      order_map[current_pos] = pos;
+      current_pos++;
+    }
+  }
+
+
+  for (auto pos : c10::irange(tv->nDims())) {
+    if (!tv->axis(pos)->isDeviceDim()) {
+      order_map[current_pos] = pos;
+      current_pos++;
+    }
+  }
+
+  tv->reorder(order_map);
+}
+
 } // namespace nvfuser

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -556,7 +556,6 @@ void reorderDIDToFront(TensorView* tv) {
     }
   }
 
-
   for (auto pos : c10::irange(tv->nDims())) {
     if (!tv->axis(pos)->isDeviceDim()) {
       order_map[current_pos] = pos;

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -116,4 +116,6 @@ void setShardedAllocationDomain(Fusion* fusion);
 // TODO: Assumes no merges/splits on sharded axis.
 int64_t getShardedAxis(TensorView*);
 
+// Reorders a TensorView so that the DID parallelized axis are in front.
+void reorderDIDToFront(TensorView*);
 } // namespace nvfuser

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -10,6 +10,7 @@
 #include <debug.h>
 #include <inlining.h>
 #include <instrumentation.h>
+#include <multidevice/utils.h>
 #include <scheduler/cache_policy_refiner.h>
 #include <scheduler/debug_utils.h>
 #include <scheduler/mark_aliases.h>
@@ -223,7 +224,7 @@ std::shared_ptr<PointwiseParams> getPointwiseHeuristics(
   }
   // We always cacheBefore output at the beginning of the scheduling. And after
   // cacheBefore, the reference tensor will have all reduction IDs removed.
-  ref_root = TensorDomain::noReductions(ref_root);
+  ref_root = TensorDomain::noDevices(TensorDomain::noReductions(ref_root));
 
   std::vector<int64_t> elem_counts(ref_root.size(), 1);
   int64_t n_elems = 1;
@@ -239,8 +240,9 @@ std::shared_ptr<PointwiseParams> getPointwiseHeuristics(
   }
 
   // If zero dimensional or zero size, return default parameters
-  if (TensorDomain::noReductions(
-          TensorDomain::noBroadcasts(largest_out->getLeafDomain()))
+  if (TensorDomain::noDevices(
+          TensorDomain::noReductions(
+              TensorDomain::noBroadcasts(largest_out->getLeafDomain())))
           .empty() ||
       n_elems == 0) {
     auto vectorizable_inputs_outputs_entry = HeuristicSummaryEntry<
@@ -333,7 +335,6 @@ std::shared_ptr<PointwiseParams> getPointwiseHeuristics(
 
   auto& view_disjoint_sets = broadcast_info.get().view_disjoint_set_ids;
   auto& broadcast_byte_multiples = broadcast_info.get().broadcast_multiples;
-
   NVF_ERROR(broadcast_byte_multiples.size() == ref_root.size());
 
   int64_t dtype_sum = 0;
@@ -582,6 +583,9 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
       reference_tv != nullptr,
       "Could not find a fully broadcasted output to reference schedule on.");
 
+  int64_t num_device_dims = numDeviceDims(reference_tv);
+  int64_t device_aware_break_point = params.break_point + num_device_dims;
+
   // Positions of rhs and lhs after merging all dimensions.
   int64_t rhs_i = -1;
   int64_t lhs_i = -1;
@@ -602,17 +606,17 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
     // values too.
     auto lhs_all_vals = DependencyCheck::getAllValsBetween(
         {reference_tv->getLogicalDomain().begin(),
-         reference_tv->getLogicalDomain().begin() + params.break_point},
-        {reference_tv->getLeafDomain().begin(),
+         reference_tv->getLogicalDomain().begin() + device_aware_break_point},
+        {reference_tv->getLeafDomain().begin() + num_device_dims,
          reference_tv->getLeafDomain().end()});
 
     std::unordered_set<Val*> lhs_all_vals_set(
         lhs_all_vals.begin(), lhs_all_vals.end());
 
     auto rhs_all_vals = DependencyCheck::getAllValsBetween(
-        {reference_tv->getLogicalDomain().begin() + params.break_point,
+        {reference_tv->getLogicalDomain().begin() + device_aware_break_point,
          reference_tv->getLogicalDomain().end()},
-        {reference_tv->getLeafDomain().begin(),
+        {reference_tv->getLeafDomain().begin() + num_device_dims,
          reference_tv->getLeafDomain().end()});
 
     std::unordered_set<Val*> rhs_all_vals_set(
@@ -672,7 +676,7 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
     }
 
     // Merge right side of break point
-    for (int64_t i = reference_tv->nDims(); i > params.break_point; i--) {
+    for (int64_t i = reference_tv->nDims(); i > device_aware_break_point; i--) {
       auto axis_i = i - 1;
       if (rhs_i == -1) {
         rhs_i = axis_i;
@@ -687,7 +691,7 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
     }
 
     // Merge left side of break point
-    for (int64_t i = params.break_point; i > 0; i--) {
+    for (int64_t i = device_aware_break_point; i > num_device_dims; i--) {
       auto axis_i = i - 1;
       if (lhs_i == -1) {
         lhs_i = axis_i;

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -599,6 +599,8 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
     // reorder for better merging.
     reference_tv->reorder(
         scheduler_utils::domainReorderAsLogicalMap(reference_tv));
+    // Reorder so that DeviceDims are in front
+    reorderDIDToFront(reference_tv);
 
     // Break point is relative to logical domain, find the leaf domain ID's in
     // the left/right side, we really need the values in domain, but easiest way
@@ -674,6 +676,7 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams& params) {
     if (!logical_reorder_map.empty()) {
       reference_tv->reorder(logical_reorder_map);
     }
+    reorderDIDToFront(reference_tv);
 
     // Merge right side of break point
     for (int64_t i = reference_tv->nDims(); i > device_aware_break_point; i--) {

--- a/csrc/scheduler/pointwise.h
+++ b/csrc/scheduler/pointwise.h
@@ -149,6 +149,10 @@ namespace nvfuser {
  * considered together, since it's hard to account for partial dimensions that
  * are being broadcasted. So for view it's primarily an all or nothing situation
  * when it comes to the 2D pointwise scheduler.
+ *
+ * DID axes, which are not allocated, are ignored in the analysis.
+ * Specifically, two fusions that only differ by DID axes result in
+ * the same scheduling decisions.
  */
 
 class SchedulerRuntimeInfo;

--- a/csrc/scheduler/pointwise_utils.h
+++ b/csrc/scheduler/pointwise_utils.h
@@ -64,9 +64,9 @@ class DomainMap {
 // Returns number of non-reduction/non-broadcas/non-device dims in logical
 // domain
 inline int64_t nRootDims(const TensorView* tv) {
-  auto root_dom = tv->getLogicalDomain();
+  auto logical_dom = tv->getLogicalDomain();
   int64_t tv_n_dims = 0;
-  for (auto dim : root_dom) {
+  for (auto dim : logical_dom) {
     if (!dim->isReduction() && !dim->isBroadcast() && !dim->isDeviceDim()) {
       tv_n_dims++;
     }

--- a/csrc/scheduler/pointwise_utils.h
+++ b/csrc/scheduler/pointwise_utils.h
@@ -61,12 +61,13 @@ class DomainMap {
   std::vector<TensorView*> tvs_with_rfactor_;
 };
 
-// Returns number of non-reduction/non-broadcast dims in logical domain
+// Returns number of non-reduction/non-broadcas/non-device dims in logical
+// domain
 inline int64_t nRootDims(const TensorView* tv) {
   auto root_dom = tv->getLogicalDomain();
   int64_t tv_n_dims = 0;
   for (auto dim : root_dom) {
-    if (!dim->isReduction() && !dim->isBroadcast()) {
+    if (!dim->isReduction() && !dim->isBroadcast() && !dim->isDeviceDim()) {
       tv_n_dims++;
     }
   }

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1664,7 +1664,8 @@ BroadcastMultipleInformation getBroadcastMultiples(
   for (auto in_out_tv : in_out_tvs) {
     std::vector<bool> mapped_axes(ref_root_domain.size(), false);
 
-    auto in_out_tv_domain = in_out_tv->getMaybeRootDomain();
+    auto in_out_tv_domain =
+        TensorDomain::noDevices(in_out_tv->getMaybeRootDomain());
     auto in_out_tv_domain_list = std::list<IterDomain*>(
         in_out_tv_domain.begin(), in_out_tv_domain.end());
 

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1630,8 +1630,8 @@ BroadcastMultipleInformation getBroadcastMultiples(
 
   // We always cacheBefore output at the beginning of the scheduling. And after
   // cacheBefore, the reference tensor will have all reduction IDs removed.
-  auto ref_root_domain =
-      TensorDomain::noReductions(reference_tv->getLogicalDomain());
+  auto ref_root_domain = TensorDomain::noDevices(
+      TensorDomain::noReductions(reference_tv->getLogicalDomain()));
 
   if (!logical_reorder_map.empty()) {
     ref_root_domain =

--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -544,9 +544,9 @@ TEST_F(PointwiseTest, ShardedPointwise) {
     auto params = getPointwiseHeuristics(&sharded_fusion, sharded_inputs);
     auto unsharded_params = getPointwiseHeuristics(&unsharded_fusion, {t0, t1});
     // Note: occasionally one of the compile parameter index types is int64_t
-    // instead of int64 which causes `PointwiseParams::sameAs` to return false,
+    // instead of int which causes PointwiseParams::sameAs to return false,
     // despite the pointwise specific parameters being identical, so we just
-    // check these.
+    // explicitly check pointwise schedule params.
     EXPECT_EQ(params->vectorize, unsharded_params->vectorize);
     EXPECT_EQ(params->break_point, unsharded_params->break_point);
     EXPECT_EQ(params->split_block, unsharded_params->split_block);

--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -490,7 +490,7 @@ TEST_F(PointwiseTest, VIssue1567ectorizationFactorAnalysisCase3) {
 class ShardedPointwiseTest
     : public NVFuserTest,
       public testing::WithParamInterface<std::tuple<bool, int>> {};
-   
+
 TEST_P(ShardedPointwiseTest, DID_Compatible) {
   auto [use_1D_scheduler, sharded_dim] = GetParam();
   auto fusion_ptr = std::make_unique<Fusion>();
@@ -526,8 +526,7 @@ TEST_P(ShardedPointwiseTest, DID_Compatible) {
   }
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor t0 =
-      at::randn(input_size, options).unsqueeze(sharded_dim);
+  at::Tensor t0 = at::randn(input_size, options).unsqueeze(sharded_dim);
   at::Tensor t1 = at::randn({input_size[1], input_size[2]}, options);
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
@@ -537,11 +536,11 @@ TEST_P(ShardedPointwiseTest, DID_Compatible) {
   fe.compileFusion(fusion, aten_inputs, lparams);
   auto cg_outputs = fe.runFusion(aten_inputs, lparams);
 
-  EXPECT_EQ(use_1D_scheduler, params->break_point==0);
+  EXPECT_EQ(use_1D_scheduler, params->break_point == 0);
   testValidate(fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 
-  // Create a single device fusion and verify the same scheduling parameters are used for
-  // given the same single device fusion. 
+  // Create a single device fusion and verify the same scheduling parameters are
+  // used for given the same single device fusion.
   auto unsharded_fusion_ptr = std::make_unique<Fusion>();
   auto unsharded_fusion = unsharded_fusion_ptr.get();
   FusionGuard unsharded_fg(unsharded_fusion);
@@ -559,8 +558,10 @@ TEST_P(ShardedPointwiseTest, DID_Compatible) {
   FusionExecutorCache fec2(std::move(unsharded_fusion_ptr));
   fec2.profile(true);
 
-  std::vector<c10::IValue> unsharded_aten_inputs = {t0.squeeze(sharded_dim), t1};
-  auto unsharded_params = getPointwiseHeuristics(unsharded_fusion, unsharded_aten_inputs);
+  std::vector<c10::IValue> unsharded_aten_inputs = {
+      t0.squeeze(sharded_dim), t1};
+  auto unsharded_params =
+      getPointwiseHeuristics(unsharded_fusion, unsharded_aten_inputs);
   EXPECT_TRUE(params->sameAs(unsharded_params));
 }
 


### PR DESCRIPTION
Makes the pointwise scheduler DID compatible by ignorning DID axes from analysis and scheduling operations. It will schedule the compute of sharded pointwise fusion identically to its equivalent single device fusion.

Modifications:
- Remove DID extents from `getPointwiseHeuristics` so that any size based calculations (e.g. break point) only analyze allocated sizes.
- Inside `schedulePointwise`, DID axes are reordered to the front of the leaf domain. In the 2D scheduler merged axis are adjusted to ignore DID axes.