### PR TITLE
Use standard {uniform,normal} if params are 0, 1

### DIFF
--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -190,16 +190,7 @@ namespace {
 bool valEqualsInt(Val* val, int64_t i) {
   ExpressionEvaluator ee;
   PolymorphicValue pv = ee.evaluate(val);
-  if (!pv.hasValue()) {
-    return false;
-  }
-  if (pv.is<int64_t>()) {
-    return pv.as<int64_t>() == i;
-  }
-  if (pv.is<double>()) {
-    return pv.as<double>() == (double)i;
-  }
-  return false;
+  return pv.hasValue() && (pv == i).as<bool>();
 }
 
 } // namespace

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -190,7 +190,10 @@ namespace {
 bool valEqualsInt(Val* val, int64_t i) {
   ExpressionEvaluator ee;
   PolymorphicValue pv = ee.evaluate(val);
-  return pv.hasValue() && (pv == i).as<bool>();
+  if (!pv.hasValue()) {
+    return false;
+  }
+  return pv == i;
 }
 
 } // namespace

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -182,6 +182,28 @@ TensorView* rand(
 }
 
 // TENSOR FACTORIES
+
+namespace {
+
+//! Check that val is an int or float scalar equal to the given integer (after
+//! possible promotion)
+bool valEqualsInt(Val* val, int64_t i) {
+  ExpressionEvaluator ee;
+  PolymorphicValue pv = ee.evaluate(val);
+  if (!pv.hasValue()) {
+    return false;
+  }
+  if (pv.is<int64_t>()) {
+    return pv.as<int64_t>() == i;
+  }
+  if (pv.is<double>()) {
+    return pv.as<double>() == (double)i;
+  }
+  return false;
+}
+
+} // namespace
+
 TensorView* uniform(
     const std::vector<Val*>& shape,
     Val* low,
@@ -191,13 +213,24 @@ TensorView* uniform(
     Val* philox_offset,
     bool maybe_symbolic) {
   TensorView* out = factoryOutput(shape, dtype, maybe_symbolic);
-  IrBuilder::create<RNGOp>(
-      RNGOpType::UniformRange,
-      out,
-      dtype,
-      std::vector<Val*>{low, high},
-      philox_seed,
-      philox_offset);
+  if (valEqualsInt(low, 0l) && valEqualsInt(high, 1l)) {
+    // Avoid unnecessary shifting and scaling
+    IrBuilder::create<RNGOp>(
+        RNGOpType::Uniform,
+        out,
+        dtype,
+        std::vector<Val*>{},
+        philox_seed,
+        philox_offset);
+  } else {
+    IrBuilder::create<RNGOp>(
+        RNGOpType::UniformRange,
+        out,
+        dtype,
+        std::vector<Val*>{low, high},
+        philox_seed,
+        philox_offset);
+  }
   return out;
 }
 
@@ -210,13 +243,24 @@ TensorView* normal(
     Val* philox_offset,
     bool maybe_symbolic) {
   TensorView* out = factoryOutput(shape, dtype, maybe_symbolic);
-  IrBuilder::create<RNGOp>(
-      RNGOpType::NormalGeneral,
-      out,
-      dtype,
-      std::vector<Val*>{mean, std},
-      philox_seed,
-      philox_offset);
+  if (valEqualsInt(mean, 0l) && valEqualsInt(std, 1l)) {
+    // Avoid unnecessary shifting and scaling
+    IrBuilder::create<RNGOp>(
+        RNGOpType::NormalStandard,
+        out,
+        dtype,
+        std::vector<Val*>{},
+        philox_seed,
+        philox_offset);
+  } else {
+    IrBuilder::create<RNGOp>(
+        RNGOpType::NormalGeneral,
+        out,
+        dtype,
+        std::vector<Val*>{mean, std},
+        philox_seed,
+        philox_offset);
+  }
   return out;
 }
 


### PR DESCRIPTION
This just opportunistically uses our unscaled runtime functions instead of the parametrized ones whenever we detect that the input parameters are constant 0 and 1.

I thought nvcc would remove an identity transformation like `(x * 1 + 0)` automatically but the PTX diff shows 8 removed add(0) instructions in `tests/python/test_python_frontend.py::TestNvFuserFrontend::test_nanogpt_mha_dpa`. This is also reflected in the SASS (for sm80).