### PR TITLE
Allow domains to be decoupled: validateDomainEquivalence

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3037,10 +3037,10 @@ TensorDomain::TensorDomain(
                              : std::move(contiguity)) {
   validateContiguity(maybeAllocation(), contiguity_);
 
-  if (!logical_domain_.empty()) {
-    NVF_CHECK(!loop_domain_.empty(), "Root domain is not empty but loop is");
-    ir_utils::validateDomainEquivalence(logical_domain_, loop_domain_);
-  }
+  NVF_CHECK(
+      loop_domain_.empty() == logical_domain_.empty(),
+      "logical domain and loop domain can only be both empty or neither empty");
+  ir_utils::validateDomainEquivalence(logical_domain_, loop_domain_);
 
   // resetDomains initializes other member variables, required by clang-tidy
   resetDomains();
@@ -3061,13 +3061,12 @@ TensorDomain::TensorDomain(
                              : std::move(contiguity)) {
   validateContiguity(maybeAllocation(), contiguity_);
 
+  NVF_CHECK(
+      loop_domain_.empty() == logical_domain_.empty(),
+      "logical domain and loop domain can only be both empty or neither empty");
+  ir_utils::validateDomainEquivalence(logical_domain_, loop_domain_);
   if (!root_domain_.empty()) {
-    NVF_CHECK(!loop_domain_.empty(), "Root domain is not empty but loop is");
-    ir_utils::validateDomainEquivalence(root_domain_, loop_domain_);
-    if (!logical_domain_.empty()) {
-      ir_utils::validateDomainEquivalence(root_domain_, logical_domain_);
-      ir_utils::validateDomainEquivalence(logical_domain_, loop_domain_);
-    }
+    ir_utils::validateDomainEquivalence(logical_domain_, root_domain_);
   }
 
   // resetDomains initializes other member variables, required by clang-tidy
@@ -3091,17 +3090,15 @@ TensorDomain::TensorDomain(
                              : std::move(contiguity)) {
   validateContiguity(maybeAllocation(), contiguity_);
 
+  NVF_CHECK(
+      loop_domain_.empty() == logical_domain_.empty(),
+      "logical domain and loop domain can only be both empty or neither empty");
+  ir_utils::validateDomainEquivalence(logical_domain_, loop_domain_);
   if (!root_domain_.empty()) {
-    NVF_CHECK(!loop_domain_.empty(), "Root domain is not empty but loop is");
-    ir_utils::validateDomainEquivalence(root_domain_, loop_domain_);
-    if (!logical_domain_.empty()) {
-      ir_utils::validateDomainEquivalence(root_domain_, logical_domain_);
-      ir_utils::validateDomainEquivalence(logical_domain_, loop_domain_);
-    }
-    if (!allocation_domain_.empty()) {
-      ir_utils::validateDomainEquivalence(root_domain_, allocation_domain_);
-      ir_utils::validateDomainEquivalence(allocation_domain_, loop_domain_);
-    }
+    ir_utils::validateDomainEquivalence(logical_domain_, root_domain_);
+  }
+  if (!allocation_domain_.empty()) {
+    ir_utils::validateDomainEquivalence(logical_domain_, allocation_domain_);
   }
 
   // resetDomains initializes other member variables, required by clang-tidy

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -820,84 +820,36 @@ std::vector<TensorView*> getTVsWithDynamicTransform(Fusion* fusion) {
   return dynamic_tvs;
 }
 
-namespace {
+void validateDomainEquivalence(
+    const std::vector<IterDomain*>& dom0,
+    const std::vector<IterDomain*>& dom1) {
+  std::unordered_set<Val*> dom0_set(dom0.begin(), dom0.end());
+  std::unordered_set<Val*> dom1_set(dom1.begin(), dom1.end());
 
-class ValidateDomainEquivalence : private IterVisitor {
- public:
-  ValidateDomainEquivalence(
-      const std::vector<IterDomain*>& initial_domain,
-      const std::vector<IterDomain*>& derived_domain)
-      : initial_domain_({initial_domain.begin(), initial_domain.end()}),
-        derived_domain_({derived_domain.begin(), derived_domain.end()}),
-        frontier_({initial_domain.begin(), initial_domain.end()}) {
-    // empty domain are equivalent.
-    if (initial_domain.empty() && derived_domain.empty()) {
-      return;
-    }
-    NVF_ERROR(!initial_domain.empty());
-    NVF_ERROR(!derived_domain.empty());
-    // Make sure there's no duplicate in the parameter vectors
-    NVF_ERROR(
-        initial_domain.size() == initial_domain_.size(),
-        "Duplicated entry is detected in inial_domain: ",
-        toDelimitedString(initial_domain));
-    NVF_ERROR(
-        derived_domain.size() == derived_domain_.size(),
-        "Duplicated entry is detected in derived_domain: ",
-        toDelimitedString(derived_domain));
+  // empty domain are equivalent.
+  if (dom0.empty() && dom1.empty()) {
+    return;
+  }
+  NVF_ERROR(!dom0.empty());
+  NVF_ERROR(!dom1.empty());
+  // Make sure there's no duplicate in the parameter vectors
+  NVF_ERROR(
+      dom0.size() == dom0_set.size(),
+      "Duplicated entry is detected in dom0: ",
+      toDelimitedString(dom0));
+  NVF_ERROR(
+      dom1.size() == dom1_set.size(),
+      "Duplicated entry is detected in dom1: ",
+      toDelimitedString(dom1));
 
-    traverseBetween(
-        {initial_domain.begin(), initial_domain.end()},
-        {derived_domain.begin(), derived_domain.end()});
+  std::vector<Val*> dom0_val(dom0.begin(), dom0.end());
+  std::vector<Val*> dom1_val(dom1.begin(), dom1.end());
+  auto forward_exprs = StmtSort::getExprsBetween(dom0_val, dom1_val);
+  auto backward_exprs = StmtSort::getExprsBetween(dom1_val, dom0_val);
 
-    // At this point, the frontier set and the derived set should be
-    // equal, except when there's a symbolic ID in the derived set,
-    // where the traversal may be incomplete.
-    if (std::any_of(derived_domain.begin(), derived_domain.end(), [](auto id) {
-          return id->getIterType() == IterType::Symbolic;
-        })) {
-      // Make sure all non-symbolic IDs of the derived set are included
-      // in the frontier set
-      NVF_ERROR(
-          std::all_of(
-              derived_domain.begin(),
-              derived_domain.end(),
-              [&](auto id) {
-                return id->getIterType() == IterType::Symbolic ||
-                    frontier_.count(id);
-              }),
-          "Invalid derived domain. Initial domain: ",
-          toDelimitedString(initial_domain),
-          ". Derived domain: ",
-          toDelimitedString(derived_domain));
-      // Similarly, all frontier vals should be included in the
-      // derived set. It is also possible that an ID in the initial
-      // domain set still remains in the frontier set as there may be
-      // no expr connecting to the derived set, e.g., dynamic reshape
-      NVF_ERROR(
-          std::all_of(
-              frontier_.begin(),
-              frontier_.end(),
-              [&](Val* val) {
-                NVF_ERROR(val->isA<IterDomain>());
-                return derived_domain_.count(val->as<IterDomain>()) ||
-                    initial_domain_.count(val);
-              }),
-          "Invalid derived domain. Initial domain: ",
-          toDelimitedString(initial_domain),
-          ". Derived domain: ",
-          toDelimitedString(derived_domain));
-    } else {
-      NVF_ERROR(
-          derived_domain_ == frontier_,
-          "Invalid derived domain. Initial domain: ",
-          toDelimitedString(initial_domain),
-          ". Derived domain: ",
-          toDelimitedString(derived_domain));
-    }
-  };
+  std::unordered_set<Val*> frontier(dom0.begin(), dom0.end());
 
-  void dispatch(Expr* expr) override {
+  auto next = [&frontier](Expr* expr, bool forward) {
     NVF_ERROR(
         std::all_of(expr->inputs().begin(), expr->inputs().end(), [](Val* v) {
           return v->isA<IterDomain>();
@@ -906,45 +858,86 @@ class ValidateDomainEquivalence : private IterVisitor {
         std::all_of(expr->outputs().begin(), expr->outputs().end(), [](Val* v) {
           return v->isA<IterDomain>();
         }));
-    // If any of the inputs is included in derived_domain_, that means there's a
-    // dependency within derived_domain_ and the dependent domains
-    // redundantly cover the initial domain
-    NVF_ERROR(
-        std::none_of(
-            expr->inputs().begin(),
-            expr->inputs().end(),
-            [&](Val* input_val) {
-              return derived_domain_.find(input_val) != derived_domain_.end();
-            }),
-        "Invalid derived domain due to dependent expr: ",
-        expr->toString(),
-        ". Derived domain: ",
-        toDelimitedString(derived_domain_));
-    for (auto out : expr->outputs()) {
-      // Make sure the output is not yet visited
+    std::vector<Val*> from;
+    std::vector<Val*> to;
+    if (forward) {
+      from = expr->inputs();
+      to = expr->outputs();
+    } else {
+      from = expr->outputs();
+      to = expr->inputs();
+    }
+    for (auto id : to) {
       NVF_ERROR(
-          frontier_.insert(out).second,
+          frontier.insert(id).second,
           "Invalid derived domain due to dependent expr: ",
           expr->toString(),
           ". Output should just show up once: ",
-          out->toString());
+          id->toString());
     }
-    for (auto inp : expr->inputs()) {
+    for (auto id : from) {
       NVF_ERROR(
-          frontier_.erase(inp) == 1,
+          frontier.erase(id) == 1,
           "Invalid derived domain due to dependent expr: ",
           expr->toString(),
           ". Input not seen before: ",
-          inp->toString());
+          id->toString());
     }
+  };
+  for (Expr* expr : forward_exprs) {
+    next(expr, true);
+  }
+  for (auto it = backward_exprs.rbegin(); it != backward_exprs.rend(); it++) {
+    next(*it, false);
   }
 
- private:
-  const std::unordered_set<Val*> initial_domain_;
-  const std::unordered_set<Val*> derived_domain_;
-  //! Traversal frontier vals
-  std::unordered_set<Val*> frontier_;
-};
+  // At this point, the frontier set and dom1 should be equal, except when
+  // there's a symbolic ID in dom1, where the traversal may be incomplete.
+  if (std::any_of(dom1.begin(), dom1.end(), [](auto id) {
+        return id->getIterType() == IterType::Symbolic;
+      })) {
+    // Make sure all non-symbolic IDs of the dom1 set are included
+    // in the frontier set
+    NVF_ERROR(
+        std::all_of(
+            dom1.begin(),
+            dom1.end(),
+            [&](auto id) {
+              return id->getIterType() == IterType::Symbolic ||
+                  frontier.count(id);
+            }),
+        "dom0 and dom1 are not equal. dom0: ",
+        toDelimitedString(dom0),
+        ". dom1: ",
+        toDelimitedString(dom1));
+    // Similarly, all frontier vals should be included in the dom1 set. It is
+    // also possible that an ID in the dom0 set still remains in the frontier
+    // set as there may be no expr connecting to the derived set, e.g., dynamic
+    // reshape
+    NVF_ERROR(
+        std::all_of(
+            frontier.begin(),
+            frontier.end(),
+            [&](Val* val) {
+              NVF_ERROR(val->isA<IterDomain>());
+              return dom1_set.count(val->as<IterDomain>()) ||
+                  dom0_set.count(val);
+            }),
+        "dom0 and dom1 are not equal. dom0: ",
+        toDelimitedString(dom0),
+        ". dom1: ",
+        toDelimitedString(dom1));
+  } else {
+    NVF_ERROR(
+        dom1_set == frontier,
+        "dom0 and dom1 are not equal. dom0: ",
+        toDelimitedString(dom0),
+        ". dom1: ",
+        toDelimitedString(dom1));
+  }
+}
+
+namespace {
 
 std::vector<Statement*> next(Statement* stmt) {
   if (stmt->isVal()) {
@@ -962,12 +955,6 @@ std::vector<Statement*> next(Statement* stmt) {
 }
 
 } // namespace
-
-void validateDomainEquivalence(
-    const std::vector<IterDomain*>& initial_domain,
-    const std::vector<IterDomain*>& derived_domain) {
-  ValidateDomainEquivalence(initial_domain, derived_domain);
-}
 
 std::vector<Statement*> checkCycle(
     Fusion* fusion,

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -844,8 +844,8 @@ void validateDomainEquivalence(
 
   std::vector<Val*> dom0_val(dom0.begin(), dom0.end());
   std::vector<Val*> dom1_val(dom1.begin(), dom1.end());
-  auto forward_exprs = StmtSort::getExprsBetween(dom0_val, dom1_val);
-  auto backward_exprs = StmtSort::getExprsBetween(dom1_val, dom0_val);
+  auto forward_exprs = DependencyCheck::getAllExprsBetween(dom0_set, dom1_val);
+  auto backward_exprs = DependencyCheck::getAllExprsBetween(dom1_set, dom0_val);
 
   std::unordered_set<Val*> frontier(dom0.begin(), dom0.end());
 

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -515,14 +515,15 @@ std::vector<TensorView*> getTVsWithDynamicTransform(Fusion* fusion);
 //! [I6, I7, I2, I9]
 //!
 //! Please note that there are still limitations in validateDomainEquivalence
-//! that there are valid cases that will be rejected by this function. For example,
-//! if we have the following structure:
+//! that there are valid cases that will be rejected by this function. For
+//! example, if we have the following structure:
 //!    I0.........I0
 //!   /  \       /  \.
 //! I0/4  4    I0/5  5
 //! then [I0/4, 4] and [I0/5, 5] are equivalent, but validateDomainEquivalence
-//! will reject this case. This is because our IR visitor is only capable of traversing
-//! the IR in a single direction. We should lift this limitation in the future.
+//! will reject this case. This is because our IR visitor is only capable of
+//! traversing the IR in a single direction. We should lift this limitation in
+//! the future.
 NVF_API void validateDomainEquivalence(
     const std::vector<IterDomain*>& dom0,
     const std::vector<IterDomain*>& dom1);

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -493,23 +493,29 @@ bool hasResizedRfactor(const TensorView* tv);
 // Returns tvs that have symbolic axes
 std::vector<TensorView*> getTVsWithDynamicTransform(Fusion* fusion);
 
-//! Validate derived_domain completely covers initial_domain with no
-//! redundancy. Consider derived_domains as a different view of the
-//! same logical domain as initial_domain with affine
-//! transformations. This validation makes sure both sets
-//! of domains represent the same logical space.
+//! Validate dom0 and dom1 completely covers each other with no
+//! redundancy. When they are equivalent, we can consider them as a different
+//! view of the each other with affine transformations.
 //!
-//! It is intended to be used to validate rfactor and loop domains
-//! of a tensor root domain.
+//! For example, if we have
+//!  I0  I1  I2  I3
+//!   \  /    \  /
+//!    I4      I5
+//! then [I0, I1, I2, I3] is equivalent to [I4, I5], but [I1, I2, I3] is not
+//! equivalent to [I4, I5].
 //!
-//! For example, it's an error if a initial ID is split and
-//! only one of the outputs is included in the ids vector. It is
-//! also an error if both a producer and consumer ID are included in
-//! ids as they partially have the same dependency with the initial
-//! domain.
+//! Another example, if we have
+//!  I0  I1  I2  I3
+//!   \  /    \  /
+//!    I4      I5
+//!   /  \    /  \.
+//!  I6  I7  I8  I9
+//! Then [I0, I1, I8, I9] is equivalent to [I6, I7, I2, I3]. [I0, I1, I2, I3] is
+//! equivalent to [I6, I7, I8, I9]. But [I0, I1, I8, I3] is NOT equivalent to
+//! [I6, I7, I2, I9]
 NVF_API void validateDomainEquivalence(
-    const std::vector<IterDomain*>& initial_domain,
-    const std::vector<IterDomain*>& derived_domain);
+    const std::vector<IterDomain*>& dom0,
+    const std::vector<IterDomain*>& dom1);
 
 //! Check if all the inputs required to compute needed_val are known
 template <

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -513,6 +513,16 @@ std::vector<TensorView*> getTVsWithDynamicTransform(Fusion* fusion);
 //! Then [I0, I1, I8, I9] is equivalent to [I6, I7, I2, I3]. [I0, I1, I2, I3] is
 //! equivalent to [I6, I7, I8, I9]. But [I0, I1, I8, I3] is NOT equivalent to
 //! [I6, I7, I2, I9]
+//!
+//! Please note that there are still limitations in validateDomainEquivalence
+//! that there are valid cases that will be rejected by this function. For example,
+//! if we have the following structure:
+//!    I0.........I0
+//!   /  \       /  \.
+//! I0/4  4    I0/5  5
+//! then [I0/4, 4] and [I0/5, 5] are equivalent, but validateDomainEquivalence
+//! will reject this case. This is because our IR visitor is only capable of traversing
+//! the IR in a single direction. We should lift this limitation in the future.
 NVF_API void validateDomainEquivalence(
     const std::vector<IterDomain*>& dom0,
     const std::vector<IterDomain*>& dom1);

--- a/csrc/preseg_passes/exact_mapped_extent_substitution.cpp
+++ b/csrc/preseg_passes/exact_mapped_extent_substitution.cpp
@@ -19,8 +19,8 @@ namespace {
 // Skip domain whose extent is derived e.g. iS12{( i0 * i2 )}
 // e.g. in this set { iS11{( i0 * i2 )}rf; iS12{( i0 * i2 )}; iS14{i3} } from
 // NVFuserTest.SymbolicSqueeze, we can't substitute {i0 * i2} with {i3},
-// otherwise, ValidateDomainEquivalence fails. If we really want to substitute,
-// we may need to skip or modify ValidateDomainEquivalence.
+// otherwise, validateDomainEquivalence fails. If we really want to substitute,
+// we may need to skip or modify validateDomainEquivalence.
 inline bool isNonSubstitutableID(const IterDomain* id) {
   return (id->isBroadcast() && !id->hasExpandedExtent()) || id->definition() ||
       id->getMaybeExpandedExtent()->definition();

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -8242,13 +8242,13 @@ TEST_F(NVFuserTest, DecoupledDomains) {
 
   // XX shape structure:
   //
-  // domain 0: [I0, I1...    I4  I5} domain 1
+  // domain 0: [I0, I1...    I2  I3} domain 1
   //             \  /         \  /
   //            merge         merge
   //             /  \         /  \.
-  // domain 1: {I2  I3    ...I6, I7] domain 0
+  // domain 1: {I4  I5    ...I6, I7] domain 0
   // where domain 0 is [I0, I1, I6, I7], and
-  //       domain 1 is [I2, I3, I4, I5]
+  //       domain 1 is [I4, I5, I2, I3]
   auto create_xx_shape_structure = []() {
     auto s0 = IrBuilder::create<Val>(DataType::Index);
     auto s1 = IrBuilder::create<Val>(DataType::Index);

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -6572,7 +6572,7 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
             tv1->getLogicalDomain(), {tv1->axis(1), tv1->axis(2)});
       },
       testing::ThrowsMessage<nvfuser::nvfError>(
-          testing::HasSubstr("Invalid derived domain")));
+          testing::HasSubstr("dom0 and dom1 are not equal")));
 
   tv1->merge(0);
   // [I0/4*4, I1]
@@ -6598,7 +6598,7 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
             {tv1_intermediate_id, tv1->axis(0), tv1->axis(1), tv1->axis(2)});
       },
       testing::ThrowsMessage<nvfuser::nvfError>(
-          testing::HasSubstr("Invalid derived domain")));
+          testing::HasSubstr("dom0 and dom1 are not equal")));
 
   // Testing symbolic domains
   auto tv2 = reshape(
@@ -6630,7 +6630,7 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
             tv4->getLogicalDomain(), {tv4->axis(0), tv4->axis(1)});
       },
       testing::ThrowsMessage<nvfuser::nvfError>(
-          testing::HasSubstr("Invalid derived domain")));
+          testing::HasSubstr("dom0 and dom1 are not equal")));
 }
 
 // Repro for issue #236 (https://github.com/NVIDIA/Fuser/issues/236)

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -8266,22 +8266,24 @@ TEST_F(NVFuserTest, DecoupledDomains) {
     dom1.split(0, 256);
     return std::make_pair(dom0.as<IterDomain*>(), dom1.as<IterDomain*>());
   };
+  auto [logical_xx0, logical_xx1] = create_xx_shape_structure();
   auto [root_xx0, root_xx1] = create_xx_shape_structure();
   auto [alloc_xx0, alloc_xx1] = create_xx_shape_structure();
   auto [loop_xx0, loop_xx1] = create_xx_shape_structure();
 
-  auto concat = [](auto x, auto y, auto z) {
+  auto concat = [](auto x, auto y, auto z, auto q) {
     std::vector<IterDomain*> result;
-    result.reserve(x.size() + y.size() + z.size());
+    result.reserve(x.size() + y.size() + z.size() + q.size());
     result.insert(result.end(), x.begin(), x.end());
     result.insert(result.end(), y.begin(), y.end());
     result.insert(result.end(), z.begin(), z.end());
+    result.insert(result.end(), q.begin(), q.end());
     return result;
   };
-  auto logical_domain = concat(root_xx0, alloc_xx0, loop_xx0);
-  auto root_domain = concat(root_xx1, alloc_xx0, loop_xx0);
-  auto allocation_domain = concat(root_xx0, alloc_xx1, loop_xx0);
-  auto loop_domain = concat(root_xx0, alloc_xx0, loop_xx1);
+  auto logical_domain = concat(logical_xx1, root_xx0, alloc_xx0, loop_xx0);
+  auto root_domain = concat(logical_xx0, root_xx1, alloc_xx0, loop_xx0);
+  auto allocation_domain = concat(logical_xx0, root_xx0, alloc_xx1, loop_xx0);
+  auto loop_domain = concat(logical_xx0, root_xx0, alloc_xx0, loop_xx1);
   std::vector<std::optional<bool>> contiguity(allocation_domain.size(), true);
 
   TensorDomain* td = IrBuilder::create<TensorDomain>(

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -6562,8 +6562,8 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
   tv1->split(0, 4);
   // [I0/4, 4, I1]
 
-  // Initial domain: logical domain
-  // Derived domain: [4, I1]
+  // dom0: logical domain
+  // dom1: [4, I1]
   // Should fail as the derived domain only partially covers the
   // logical domain
   EXPECT_THAT(
@@ -6577,8 +6577,8 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
   tv1->merge(0);
   // [I0/4*4, I1]
 
-  // Initial domain: logical domain
-  // Derived domain: loop domain
+  // dom0: logical domain
+  // dom1: loop domain
   // Should succeed.
   ir_utils::validateDomainEquivalence(
       tv1->getLogicalDomain(), tv1->getLoopDomain());
@@ -6588,8 +6588,8 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
   tv1->split(0, 3);
   // [I0/4*4/3, 3, I1]
 
-  // Initial domain: logical domain
-  // Derived domain: loop + tv1_intermediate_id
+  // dom0: logical domain
+  // dom1: loop + tv1_intermediate_id
   // Should fail as the intermediate ID and the first two loop ids are redundant
   EXPECT_THAT(
       [&]() {
@@ -6620,10 +6620,9 @@ TEST_F(NVFuserTest, FusionDomainEquivalence_CUDA) {
   ir_utils::validateDomainEquivalence(
       tv4->getLogicalDomain(), tv4->getLoopDomain());
 
-  // Initial domain: root domain
-  // Derived domain: [S0, B0/4]
-  // Should fail as the derived domain only partially covers the
-  // root domain
+  // dom0: logical domain
+  // dom1: [S0, B0/4]
+  // Should fail as the dom1 only partially covers dom0
   EXPECT_THAT(
       [&]() {
         ir_utils::validateDomainEquivalence(

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -8246,7 +8246,9 @@ TEST_F(NVFuserTest, DecoupledDomains) {
   //             \  /         \  /
   //            merge         merge
   //             /  \         /  \.
-  // domain 1: {I2  I3    ...I6  I7] domain 0
+  // domain 1: {I2  I3    ...I6, I7] domain 0
+  // where domain 0 is [I0, I1, I6, I7], and
+  //       domain 1 is [I2, I3, I4, I5]
   auto create_xx_shape_structure = []() {
     auto s0 = IrBuilder::create<Val>(DataType::Index);
     auto s1 = IrBuilder::create<Val>(DataType::Index);


### PR DESCRIPTION
In the past, it was assumed that domains in a `TensorDomain` has linear structure `root -> logical -> allocation -> leaf`. I am removing this restriction. As the step 0 of the removal of this restriction, I am modifying the `validateDomainEquivalence`, which is called in the constructor of `TensorDomain`, to support arbitrary dependency order.