### PR TITLE
fix reduction python benchmark

### DIFF
--- a/benchmarks/python/test_reduction.py
+++ b/benchmarks/python/test_reduction.py
@@ -68,7 +68,7 @@ def test_reduction_baseline_benchmark(
 ):
     clear_cuda_cache()
 
-    input = torch.randn(*size, degvice="cuda", dtype=dtype)
+    input = torch.randn(size, device="cuda", dtype=dtype)
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,


### PR DESCRIPTION
I think this explains why we didn't see any baseline results of reduction benchmarks from the weely runs