### PR TITLE
Replace `allgather` by `_allgather_base`

### DIFF
--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -253,6 +253,11 @@ c10::intrusive_ptr<c10d::Work> postAllgather(
   assertBufferCount(splits, communication->team().size());
   assertBuffersHaveSameSize({input_tensor}, splits);
 
+  // allgather primitive in c10d induces extra buffering time to copy out the
+  // received tensors into user buffer. It is therefore always preferable to use
+  // _allgather_base, which does not perform any extra copy at the cost of
+  // assuming that the receive buffers are placed contiguously. See #2384 for an
+  // illustration.
   return backend->_allgather_base(output_tensor, input_tensor, {});
 }
 

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -249,7 +249,6 @@ c10::intrusive_ptr<c10d::Work> postAllgather(
     c10d::Backend* backend,
     at::Tensor input_tensor,
     at::Tensor output_tensor) {
-
   auto splits = at::split(output_tensor, /*split_size=*/1, /*dim=*/0);
   assertBufferCount(splits, communication->team().size());
   assertBuffersHaveSameSize({input_tensor}, splits);

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -249,13 +249,12 @@ c10::intrusive_ptr<c10d::Work> postAllgather(
     c10d::Backend* backend,
     at::Tensor input_tensor,
     at::Tensor output_tensor) {
-  std::vector<at::Tensor> input_tensors({input_tensor});
-  std::vector<std::vector<at::Tensor>> output_tensors(1);
-  output_tensors[0] = at::split(output_tensor, /*split_size=*/1, /*dim=*/0);
 
-  assertBufferCount(output_tensors[0], communication->team().size());
-  assertBuffersHaveSameSize(input_tensors, output_tensors[0]);
-  return backend->allgather(output_tensors, input_tensors, {});
+  auto splits = at::split(output_tensor, /*split_size=*/1, /*dim=*/0);
+  assertBufferCount(splits, communication->team().size());
+  assertBuffersHaveSameSize({input_tensor}, splits);
+
+  return backend->_allgather_base(output_tensor, input_tensor, {});
 }
 
 c10::intrusive_ptr<c10d::Work> postScatter(


### PR DESCRIPTION
`allgather` primitive in c10d induces extra buffering time to copy out the received tensors into user buffer. It is therefore always preferable to use `_allgather_base`, which does not perform any extra copy at the cost of assuming that the receive buffers are placed contiguously.

Illustration, with `allgather`, you can see the red segment indicating `cudaMemcpyAsync`:
![Screenshot 2024-06-11 at 19 10 18](https://github.com/NVIDIA/Fuser/assets/17732757/d60d2970-9a9a-4df7-8962-50b71440112e)

With `_allgather_base`, the `cudaMemcpyAsync` disappear
![Screenshot 2024-06-11 at 19 11 21](https://github.com/NVIDIA/Fuser/assets/17732757/6d2dbffa-138c-40d1-aeaa-8e9705f2fe33)

