### PR TITLE
add pointwise benchmark

### DIFF
--- a/benchmarks/python/test_simple_pointwise.py
+++ b/benchmarks/python/test_simple_pointwise.py
@@ -9,34 +9,29 @@ import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
 
-def reduction_fusion(
+def simple_pointwise_fusion(
     fd: FusionDefinition,
     dtype: DataType,
-    reduction_axis: int,
 ) -> None:
     T0 = fd.define_tensor(
         shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
     )
     if dtype in PROMOTE_DTYPES:
         T0 = fd.ops.cast(T0, dtype=DataType.Float)
-    T2 = fd.ops.sum(T0, dims=[reduction_axis], keepdim=False)
+    T2 = fd.ops.mul(T0, T0)
     if dtype in PROMOTE_DTYPES:
         T2 = fd.ops.cast(T2, dtype=dtype)
     fd.add_output(T2)
 
-
-def reduction_fwd_fn(inputs: list):  # in_tensor, reduction_axis
-    return torch.sum(inputs[0], dim=inputs[1])
-
+def simple_pointwise_fwd_fn(inputs: list):  # in_tensor
+    return torch.mul(inputs[0], inputs[0])
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-@pytest.mark.parametrize("reduction_axis", [0, 1])
-def test_reduction_nvf_benchmark(
+def test_simple_pointwise_nvf_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    reduction_axis: int,
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
@@ -45,10 +40,10 @@ def test_reduction_nvf_benchmark(
     inputs = [torch.randn(*size, device="cuda", dtype=dtype)]
 
     with FusionDefinition() as fd:
-        reduction_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), reduction_axis)
+        simple_pointwise_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
 
     if not disable_validation:
-        eager_output = torch.sum(inputs[0].to(torch.double), dim=reduction_axis)
+        eager_output = torch.mul(inputs[0].to(torch.double), inputs[0].to(torch.double))
         fd.validate(inputs, [eager_output.to(dtype)])
 
     if not disable_benchmarking:
@@ -58,12 +53,10 @@ def test_reduction_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-@pytest.mark.parametrize("reduction_axis", [0, 1])
-def test_reduction_baseline_benchmark(
+def test_simple_pointwise_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    reduction_axis: int,
     compile: bool,
 ):
     clear_cuda_cache()
@@ -72,6 +65,6 @@ def test_reduction_baseline_benchmark(
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,
-        torch.compile(reduction_fwd_fn) if compile else reduction_fwd_fn,
-        [input, reduction_axis],
+        torch.compile(simple_pointwise_fwd_fn) if compile else simple_pointwise_fwd_fn,
+        [input],
     )

--- a/benchmarks/python/test_simple_pointwise.py
+++ b/benchmarks/python/test_simple_pointwise.py
@@ -23,8 +23,10 @@ def simple_pointwise_fusion(
         T2 = fd.ops.cast(T2, dtype=dtype)
     fd.add_output(T2)
 
+
 def simple_pointwise_fwd_fn(inputs: list):  # in_tensor
     return torch.mul(inputs[0], inputs[0])
+
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)

--- a/benchmarks/python/test_simple_pointwise.py
+++ b/benchmarks/python/test_simple_pointwise.py
@@ -9,7 +9,7 @@ import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
 
-def simple_pointwise_fusion(
+def pointwise_mul_fusion(
     fd: FusionDefinition,
     dtype: DataType,
 ) -> None:


### PR DESCRIPTION
**What is in this PR?**
add a simple pointwise benchmark
```
def simple_pointwise_fwd_fn(inputs: list):  # in_tensor
    return torch.mul(inputs[0], inputs[0])
```
**Why need to add this?**
(1) serve as a basline to check the best bandwidth we can expect for a specific problem size
(2) check whether the device is healthy.

**Current performance:** see [link](https://docs.google.com/document/d/1FtIU_s-iw_Q9C7psdJn5FMp9ApKdzqdkJe4p6R9TQkU/edit?usp=sharing).