### PR TITLE
Use indent utility in dynamic_transform/id_model toString functions

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -61,30 +61,29 @@ DynamicTransformInitialInfo DynamicTransformInitialInfo::clone(
 std::string DynamicTransformInitialInfo::toString() const {
   std::stringstream ss;
   ss << "DynamicTransformInitialInfo\n";
-  std::string indent = "  ";
-  ss << indent << "Dynamic reshaped TensorViews:\n";
+  indent(ss, 1) << "Dynamic reshaped TensorViews:\n";
   for (const auto& tv : dynamic_reshaped_tvs_) {
-    ss << indent << indent << tv->toString() << "\n";
+    indent(ss, 2) << tv->toString() << "\n";
   }
-  ss << indent << "Dynamic resized IterDomains:\n";
+  indent(ss, 1) << "Dynamic resized IterDomains:\n";
   for (const auto& id : dynamic_resized_ids_) {
-    ss << indent << indent << id->toString() << "\n";
+    indent(ss, 2) << id->toString() << "\n";
   }
-  ss << indent << "Dynamic expanded TensorViews:\n";
+  indent(ss, 1) << "Dynamic expanded TensorViews:\n";
   for (const auto& tv : dynamic_expanded_tvs_) {
-    ss << indent << indent << tv->toString() << "\n";
+    indent(ss, 2) << tv->toString() << "\n";
   }
-  ss << indent << "Dynamic factory-function output TensorViews:\n";
+  indent(ss, 1) << "Dynamic factory-function output TensorViews:\n";
   for (const auto& tv : dynamic_factory_tvs_) {
-    ss << indent << indent << tv->toString() << "\n";
+    indent(ss, 2) << tv->toString() << "\n";
   }
-  ss << indent << "Dynamic extent Vals:\n";
+  indent(ss, 1) << "Dynamic extent Vals:\n";
   for (const auto& v : maybe_zero_extents_) {
-    ss << indent << indent << v->toInlineString() << "\n";
+    indent(ss, 2) << v->toInlineString() << "\n";
   }
-  ss << indent << "Root dynamic Vals:\n";
+  indent(ss, 1) << "Root dynamic Vals:\n";
   for (const auto& v : root_dynamic_vals_) {
-    ss << indent << indent << v->toInlineString() << "\n";
+    indent(ss, 2) << v->toInlineString() << "\n";
   }
   return ss.str();
 }
@@ -554,44 +553,43 @@ bool DynamicTransformConcretizationInfo::operator==(
 std::string DynamicTransformConcretizationInfo::toString() const {
   std::stringstream ss;
   ss << "DynamicTransformConcretizationInfo\n";
-  std::string indent = "  ";
-  ss << indent << "Empty tensor extents:\n";
+  indent(ss, 1) << "Empty tensor extents:\n";
   for (const auto& i : empty_extents_) {
     auto ext = initial_info_->getMaybeZeroExtents().at(i);
-    ss << indent << indent << ext->toString() << " is zero\n";
+    indent(ss, 2) << ext->toString() << " is zero\n";
   }
-  ss << indent << "Reshape:\n";
+  indent(ss, 1) << "Reshape:\n";
   NVF_ERROR(
       reshape_transforms_.size() ==
       initial_info_->getDynamicReshapedTensorViews().size());
   for (const auto& [tv_index, view_info] : reshape_transforms_) {
     auto tv = initial_info_->getDynamicReshapedTensorViews().at(tv_index);
     if (std::holds_alternative<AnalyzeViewResult>(view_info)) {
-      ss << indent << indent << tv->toString() << " (index=" << tv_index
-         << "), " << std::get<AnalyzeViewResult>(view_info).toString() << "\n";
+      indent(ss, 2) << tv->toString() << " (index=" << tv_index << "), "
+                    << std::get<AnalyzeViewResult>(view_info).toString()
+                    << "\n";
     } else {
-      ss << indent << indent << tv->toString() << " (index=" << tv_index
-         << "), is empty. Symbolic reshape sizes: "
-         << std::get<std::vector<int64_t>>(view_info) << "\n";
+      indent(ss, 2) << tv->toString() << " (index=" << tv_index
+                    << "), is empty. Symbolic reshape sizes: "
+                    << std::get<std::vector<int64_t>>(view_info) << "\n";
     }
   }
-  ss << indent << "Resize:\n";
+  indent(ss, 1) << "Resize:\n";
   NVF_ERROR(
       resize_itertypes_.size() ==
       initial_info_->getDynamicResizedIterDomains().size());
   for (const auto& [id_index, iter_type] : resize_itertypes_) {
     auto id = initial_info_->getDynamicResizedIterDomains().at(id_index);
-    ss << indent << indent << id->toString() << " (index=" << id_index << "), "
-       << iter_type << "\n";
+    indent(ss, 2) << id->toString() << " (index=" << id_index << "), "
+                  << iter_type << "\n";
   }
-  ss << indent << "Expand:\n";
+  indent(ss, 1) << "Expand:\n";
   NVF_ERROR(
       expand_axes_.size() ==
       initial_info_->getDynamicExpandedTensorViews().size());
   for (const auto& [tv_index, expand_axes] : expand_axes_) {
     auto tv = initial_info_->getDynamicExpandedTensorViews().at(tv_index);
-    ss << indent << indent << tv->toString() << " (index=" << tv_index
-       << "), {";
+    indent(ss, 2) << tv->toString() << " (index=" << tv_index << "), {";
     bool first = true;
     for (bool e : expand_axes) {
       if (!first) {
@@ -602,17 +600,16 @@ std::string DynamicTransformConcretizationInfo::toString() const {
     }
     ss << "}\n";
   }
-  ss << indent << "Factory Output IterTypes:\n";
+  indent(ss, 1) << "Factory Output IterTypes:\n";
   NVF_ERROR(
       factory_output_itertypes_.size() ==
       initial_info_->getDynamicFactoryOutputs().size());
   for (int64_t i : c10::irange((int64_t)factory_output_itertypes_.size())) {
     TensorView* tv = initial_info_->getDynamicFactoryOutputs().at(i);
-    ss << indent << indent << tv->toString() << std::endl;
+    indent(ss, 2) << tv->toString() << std::endl;
     for (const auto& [pos, iter_type] : factory_output_itertypes_.at(i)) {
-      ss << indent << indent << indent
-         << tv->getLogicalDomain().at(pos)->toString() << " => " << iter_type
-         << std::endl;
+      indent(ss, 3) << tv->getLogicalDomain().at(pos)->toString() << " => "
+                    << iter_type << std::endl;
     }
   }
   return ss.str();

--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -13,6 +13,7 @@
 #include <expr_evaluator.h>
 #include <ir/all_nodes.h>
 #include <ir/cloner.h>
+#include <ir/iostream.h>
 #include <iter_visitor.h>
 #include <transform_view.h>
 #include <utils.h>

--- a/csrc/id_model/to_string.cpp
+++ b/csrc/id_model/to_string.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <id_model/to_string.h>
+#include <ir/iostream.h>
 
 namespace nvfuser {
 
@@ -24,17 +25,6 @@ std::string toString(const T* ptr, bool enable) {
   ss << ptr;
   return "[0x." + ss.str().substr(9) + "]";
 }
-
-std::string indent(int size = 0) {
-  std::stringstream ss;
-  for (auto i : c10::irange(size)) {
-    // Unused variable error
-    if (i >= 0) {
-      ss << "  ";
-    }
-  }
-  return ss.str();
-}
 } // namespace
 
 std::string toString(const std::vector<Val*>& id_group, int indent_size) {
@@ -46,7 +36,7 @@ std::string toString(const std::vector<Val*>& id_group, int indent_size) {
   std::sort(names.begin(), names.end());
 
   std::stringstream ss;
-  ss << indent(indent_size) << "{" << names << "}";
+  indent(ss, indent_size) << "{" << names << "}";
   return ss.str();
 }
 
@@ -60,9 +50,10 @@ std::string toString(
 
 std::string toString(const ValGroup& id_group, int indent_size, bool with_ptr) {
   std::stringstream ss;
-  ss << indent(indent_size) << "idg" << (with_ptr ? "(" : "")
-     << toString(id_group.get(), with_ptr) << (with_ptr ? ")" : "")
-     << toString(id_group->vector());
+  indent(ss, indent_size) << "idg" << (with_ptr ? "(" : "")
+                          << toString(id_group.get(), with_ptr)
+                          << (with_ptr ? ")" : "")
+                          << toString(id_group->vector());
   return ss.str();
 }
 
@@ -87,7 +78,7 @@ std::string toString(
     group_name_info.emplace_back(min_id_name, pos++);
   }
 
-  ss << indent(indent_size) << "(idgs){\n";
+  indent(ss, indent_size) << "(idgs){\n";
 
   // Sort based on minimum id in the group
   std::sort(group_name_info.begin(), group_name_info.end());
@@ -122,7 +113,7 @@ std::string toString(
     group_name_info.emplace_back(min_id_name, pos++);
   }
 
-  ss << indent(indent_size) << "(idgs){\n";
+  indent(ss, indent_size) << "(idgs){\n";
 
   // Sort based on minimum id in the group
   std::sort(group_name_info.begin(), group_name_info.end());
@@ -182,7 +173,7 @@ std::string toString(const std::vector<Expr*>& expr_group, int indent_size) {
   std::sort(names.begin(), names.end());
 
   std::stringstream ss;
-  ss << indent(indent_size) << "{" << names << "}";
+  indent(ss, indent_size) << "{" << names << "}";
   return ss.str();
 }
 
@@ -191,9 +182,10 @@ std::string toString(
     int indent_size,
     bool with_ptr) {
   std::stringstream ss;
-  ss << indent(indent_size) << "exprg" << (with_ptr ? "(" : "")
-     << toString(expr_group.get(), with_ptr) << (with_ptr ? ")" : "")
-     << toString(expr_group->vector());
+  indent(ss, indent_size) << "exprg" << (with_ptr ? "(" : "")
+                          << toString(expr_group.get(), with_ptr)
+                          << (with_ptr ? ")" : "")
+                          << toString(expr_group->vector());
   return ss.str();
 }
 
@@ -219,7 +211,7 @@ std::string toString(
     group_name_info.emplace_back(min_expr_name, pos++);
   }
 
-  ss << indent(indent_size) << "(exprgs){\n";
+  indent(ss, indent_size) << "(exprgs){\n";
 
   // Sort based on minimum id in the group
   std::sort(group_name_info.begin(), group_name_info.end());
@@ -231,12 +223,12 @@ std::string toString(
     auto inputs = ValGroups(id_graph.inputGroups(expr_group));
     auto outputs = ValGroups(id_graph.outputGroups(expr_group));
 
-    ss << indent(indent_size + 1) << toInlineString(inputs.vector()) << " --"
-       << toString(expr_group, 0, with_ptr) << "--> "
-       << toInlineString(outputs.vector()) << "\n";
+    indent(ss, indent_size + 1) << toInlineString(inputs.vector()) << " --"
+                                << toString(expr_group, 0, with_ptr) << "--> "
+                                << toInlineString(outputs.vector()) << "\n";
   }
 
-  ss << indent(indent_size) << "}";
+  indent(ss, indent_size) << "}";
   return ss.str();
 }
 
@@ -262,7 +254,7 @@ std::string toString(
     group_name_info.emplace_back(min_id_name, pos++);
   }
 
-  ss << indent(indent_size) << "(exprgs){\n";
+  indent(ss, indent_size) << "(exprgs){\n";
 
   // Sort based on minimum id in the group
   std::sort(group_name_info.begin(), group_name_info.end());
@@ -274,12 +266,12 @@ std::string toString(
     auto inputs = ValGroups(id_graph.inputGroups(expr_group));
     auto outputs = ValGroups(id_graph.outputGroups(expr_group));
 
-    ss << indent(indent_size + 1) << toInlineString(inputs.vector()) << " --"
-       << toString(expr_group, 0, with_ptr) << "--> "
-       << toInlineString(outputs.vector()) << "\n";
+    indent(ss, indent_size + 1) << toInlineString(inputs.vector()) << " --"
+                                << toString(expr_group, 0, with_ptr) << "--> "
+                                << toInlineString(outputs.vector()) << "\n";
   }
 
-  ss << indent(indent_size) << "}";
+  indent(ss, indent_size) << "}";
   return ss.str();
 }
 


### PR DESCRIPTION
This just uses the pre-existing utility in `ir/iostream.h` instead of `ss << indent` style indenting.