### PR TITLE
Modify `matmul` API to always create `MatmulOp`

### DIFF
--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -388,38 +388,7 @@ TensorView* matmul(TensorView* tv_a, TensorView* tv_b) {
       " and ",
       tv_b->dtype());
 
-  // Check for K=1 i.e. reduction of broadcast. In these cases we don't need a
-  // matmul so we translate it to a multiplication+cast
-  auto b_k_axis = tv_b->nDims() == 1 ? -1 : -2;
-  NVF_CHECK(
-      tv_a->axis(-1)->isBroadcast() == tv_b->axis(b_k_axis)->isBroadcast(),
-      "K dimension must be broadcast in both operands or none");
-  if (tv_a->axis(-1)->isBroadcast()) {
-    TensorView* float_result = nullptr;
-    if (tv_a->nDims() == 1 && tv_b->nDims() == 1) {
-      // [1] @ [1] = []
-      float_result =
-          mul(squeeze(tv_a, std::vector<int64_t>{0}),
-              squeeze(tv_b, std::vector<int64_t>{0}));
-    } else if (tv_a->nDims() == 1) {
-      // [1] @ [..., 1, N] = [..., N]
-      float_result = mul(tv_a, squeeze(tv_b, std::vector<int64_t>{-2}));
-    } else if (tv_b->nDims() == 1) {
-      // [..., M, 1] @ [1] = [..., M]
-      float_result = mul(squeeze(tv_a, std::vector<int64_t>{-1}), tv_b);
-    } else {
-      float_result = mul(tv_a, tv_b);
-    }
-    return maybeCastOp(tv_a->dtype(), float_result);
-  }
-
-  if (tv_a->nDims() == 1 && tv_b->nDims() == 1) {
-    // Return the dot product instead of creating the MatmulOp.
-    // Cast back the output if needed since torch.matmul maintains input dtype.
-    return maybeCastOp(tv_a->dtype(), sum(mul(tv_a, tv_b), {0}));
-  }
-
-  // For all other cases, create a new MatmulOp
+  // Create a new MatmulOp
   TensorView* out = newForMatmul(tv_a, tv_b);
   IrBuilder::create<MatmulOp>(out, tv_a, tv_b);
   return out;

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -198,7 +198,7 @@ std::vector<IterDomain*> mapMatmulOpIterDomains(
 
   // Input A to matmul: {*, M, K}
   // Input B to matmul: {*, K, N} 
-  auto kpos = input_role == MatmulRole::INPUT_A ? inp_size - 1 : inp_size - 2;
+  auto kpos = input_position == 0 ? inp_size - 1 : inp_size - 2;
 
   // Last position is a reduction dimension mapping to K
   mapping[out_size - 1] = input_domain.at(kpos);

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -190,15 +190,15 @@ std::vector<IterDomain*> mapMatmulOpIterDomains(
   std::vector<IterDomain*> mapping(out_size, nullptr);
   auto inp_size = (int64_t)input_domain.size();
 
-  // Input A to matmul: {*, M, K}
-  // Input B to matmul: {*, K, N}
-  auto kpos = input_position == 0 ? inp_size - 1 : inp_size - 2;
-
   if (inp_size == 1) {
     // Only reduction axis {K}
     mapping[out_size - 1] = input_domain[0];
     return mapping;
   }
+
+  // Input A to matmul: {*, M, K}
+  // Input B to matmul: {*, K, N} 
+  auto kpos = input_role == MatmulRole::INPUT_A ? inp_size - 1 : inp_size - 2;
 
   // Last position is a reduction dimension mapping to K
   mapping[out_size - 1] = input_domain.at(kpos);

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -197,7 +197,7 @@ std::vector<IterDomain*> mapMatmulOpIterDomains(
   }
 
   // Input A to matmul: {*, M, K}
-  // Input B to matmul: {*, K, N} 
+  // Input B to matmul: {*, K, N}
   auto kpos = input_position == 0 ? inp_size - 1 : inp_size - 2;
 
   // Last position is a reduction dimension mapping to K

--- a/tests/cpp/test_combine_mul_sum.cpp
+++ b/tests/cpp/test_combine_mul_sum.cpp
@@ -271,7 +271,8 @@ TEST_F(CombineMulSumAsMmaTest, UseMatmulScheduler) {
   }
 }
 
-// Parameters: [A_dim, B_dim, enable_fusion, transpose_a_alloc, expect_segmented, SchedulerHeuristic]
+// Parameters: [A_dim, B_dim, enable_fusion, transpose_a_alloc,
+// expect_segmented, SchedulerHeuristic]
 using MatmulNodeTranslationTestParams =
     std::tuple<int64_t, int64_t, bool, bool, bool, ScheduleHeuristic>;
 using MatmulNodeTranslationTest =
@@ -396,13 +397,7 @@ INSTANTIATE_TEST_SUITE_P(
         // Size-1 input combinations
         std::make_tuple(1l, 2l, true, false, true, ScheduleHeuristic::ExprEval),
         std::make_tuple(2l, 1l, true, false, true, ScheduleHeuristic::ExprEval),
-        std::make_tuple(
-            1l,
-            1l,
-            true,
-            false,
-            true,
-            ScheduleHeuristic::ExprEval),
+        std::make_tuple(1l, 1l, true, false, true, ScheduleHeuristic::ExprEval),
         // Batch dims
         std::make_tuple(3l, 1l, true, false, true, ScheduleHeuristic::ExprEval),
         std::make_tuple(3l, 3l, true, false, false, ScheduleHeuristic::Matmul),

--- a/tests/cpp/test_combine_mul_sum.cpp
+++ b/tests/cpp/test_combine_mul_sum.cpp
@@ -271,6 +271,7 @@ TEST_F(CombineMulSumAsMmaTest, UseMatmulScheduler) {
   }
 }
 
+// Parameters: [A_dim, B_dim, enable_fusion, transpose_a_alloc, expect_segmented, SchedulerHeuristic]
 using MatmulNodeTranslationTestParams =
     std::tuple<int64_t, int64_t, bool, bool, bool, ScheduleHeuristic>;
 using MatmulNodeTranslationTest =
@@ -402,7 +403,7 @@ INSTANTIATE_TEST_SUITE_P(
             true,
             false,
             false,
-            ScheduleHeuristic::Reduction),
+            ScheduleHeuristic::ExprEval),
         // Batch dims
         std::make_tuple(3l, 1l, true, false, true, ScheduleHeuristic::ExprEval),
         std::make_tuple(3l, 3l, true, false, false, ScheduleHeuristic::Matmul),

--- a/tests/cpp/test_combine_mul_sum.cpp
+++ b/tests/cpp/test_combine_mul_sum.cpp
@@ -396,13 +396,12 @@ INSTANTIATE_TEST_SUITE_P(
         // Size-1 input combinations
         std::make_tuple(1l, 2l, true, false, true, ScheduleHeuristic::ExprEval),
         std::make_tuple(2l, 1l, true, false, true, ScheduleHeuristic::ExprEval),
-        // We fuse this case using the Reduction scheduler
         std::make_tuple(
             1l,
             1l,
             true,
             false,
-            false,
+            true,
             ScheduleHeuristic::ExprEval),
         // Batch dims
         std::make_tuple(3l, 1l, true, false, true, ScheduleHeuristic::ExprEval),

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -61,20 +61,20 @@ void checkMatmulOpIdMapping(
   // If K is Broadcast then we will not have a reduction dim
   bool k_bcast = A->axis(-1)->isBroadcast();
   auto out_ndims = std::max(A->nDims(), B->nDims()) + 1;
-  if (std::min(A->nDims(), B->nDims()) == 1){
+  if (std::min(A->nDims(), B->nDims()) == 1) {
     out_ndims = std::max(A->nDims(), B->nDims());
   }
   ASSERT_EQ(output->nDims(), out_ndims);
-  
-  if (A->nDims() > 1){
+
+  if (A->nDims() > 1) {
     int out_mpos = B->nDims() > 1 ? -3 : -2;
     EXPECT_TRUE(checkMapped(vg, A->axis(-2), output->axis(out_mpos))); // M
   }
 
-  if (B->nDims() > 1){
-    EXPECT_TRUE(checkMapped(vg, B->axis(-1), output->axis(-2))); // N  
+  if (B->nDims() > 1) {
+    EXPECT_TRUE(checkMapped(vg, B->axis(-1), output->axis(-2))); // N
   }
-  
+
   if (!k_bcast) {
     int b_kpos = B->nDims() > 1 ? -2 : -1; // {..iK, iN} or {iK}
     EXPECT_TRUE(checkMapped(vg, A->axis(-1), B->axis(b_kpos))); // K
@@ -84,12 +84,12 @@ void checkMatmulOpIdMapping(
   // Check that batch dims are mapped
   // Note that A and B can have different dimensions, so here we count
   // backwards from the innermost batch dimension. Then we check that the axis
-  // exists (is not negative) and is not Broadcast before checking mapping. 
-  int batch_ndims = output->nDims() - (B->nDims() > 1) - (A->nDims() > 1) - 1; 
+  // exists (is not negative) and is not Broadcast before checking mapping.
+  int batch_ndims = output->nDims() - (B->nDims() > 1) - (A->nDims() > 1) - 1;
   for (int64_t i : c10::irange(batch_ndims)) {
     int64_t i_a = A->nDims() - 3 - i;
     int64_t i_b = B->nDims() - 3 - i;
-    int64_t i_out = batch_ndims -1 - i;
+    int64_t i_out = batch_ndims - 1 - i;
     if (i_a >= 0 && !A->axis(i_a)->isBroadcast()) {
       EXPECT_TRUE(checkMapped(vg, A->axis(i_a), output->axis(i_out)));
     }

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -60,72 +60,42 @@ void checkMatmulOpIdMapping(
 
   // If K is Broadcast then we will not have a reduction dim
   bool k_bcast = A->axis(-1)->isBroadcast();
-  int64_t red_dims = k_bcast ? 0 : 1;
+  auto out_ndims = std::max(A->nDims(), B->nDims()) + 1;
+  if (std::min(A->nDims(), B->nDims()) == 1){
+    out_ndims = std::max(A->nDims(), B->nDims());
+  }
+  ASSERT_EQ(output->nDims(), out_ndims);
+  
+  if (A->nDims() > 1){
+    int out_mpos = B->nDims() > 1 ? -3 : -2;
+    EXPECT_TRUE(checkMapped(vg, A->axis(-2), output->axis(out_mpos))); // M
+  }
 
-  if (A->nDims() == 1 && B->nDims() == 1) {
-    // [K] @ [K] = []
-    // Note there is no IterType::Reduction dim ever in this case because we
-    // translate to a mul+sum+cast
-    EXPECT_EQ(output->nDims(), 0);
-    // When K is Broadcast, we squeeze then multiply then cast instead
-    if (!k_bcast) {
-      EXPECT_TRUE(checkMapped(vg, A->axis(0), B->axis(0))); // K
+  if (B->nDims() > 1){
+    EXPECT_TRUE(checkMapped(vg, B->axis(-1), output->axis(-2))); // N  
+  }
+  
+  if (!k_bcast) {
+    int b_kpos = B->nDims() > 1 ? -2 : -1; // {..iK, iN} or {iK}
+    EXPECT_TRUE(checkMapped(vg, A->axis(-1), B->axis(b_kpos))); // K
+    EXPECT_TRUE(checkMapped(vg, A->axis(-1), output->axis(-1))); // K
+  }
+
+  // Check that batch dims are mapped
+  // Note that A and B can have different dimensions, so here we count
+  // backwards from the innermost batch dimension. Then we check that the axis
+  // exists (is not negative) and is not Broadcast before checking mapping. 
+  int batch_ndims = output->nDims() - (B->nDims() > 1) - (A->nDims() > 1) - 1; 
+  for (int64_t i : c10::irange(batch_ndims)) {
+    int64_t i_a = A->nDims() - 3 - i;
+    int64_t i_b = B->nDims() - 3 - i;
+    int64_t i_out = batch_ndims -1 - i;
+    if (i_a >= 0 && !A->axis(i_a)->isBroadcast()) {
+      EXPECT_TRUE(checkMapped(vg, A->axis(i_a), output->axis(i_out)));
     }
-  } else if (A->nDims() > 1 && B->nDims() == 1) {
-    // [..., iM, iK] @ [iK] = [..., iM, rK]
-    ASSERT_EQ(output->nDims(), A->nDims() + red_dims - 1);
-    EXPECT_TRUE(checkMapped(vg, A->axis(-2), output->axis(-1 - red_dims))); // M
-    if (!k_bcast) {
-      EXPECT_TRUE(checkMapped(vg, A->axis(-1), B->axis(0))); // K
-      EXPECT_TRUE(checkMapped(vg, A->axis(-1), output->axis(-1))); // K
+    if (i_b >= 0 && !B->axis(i_b)->isBroadcast()) {
+      EXPECT_TRUE(checkMapped(vg, B->axis(i_b), output->axis(i_out)));
     }
-    // Check that batch dims are mapped
-    for (int64_t i : c10::irange(output->nDims() - red_dims - 1)) {
-      if (!A->axis(i)->isBroadcast()) {
-        EXPECT_TRUE(checkMapped(vg, A->axis(i), output->axis(i)));
-      }
-    }
-  } else if (A->nDims() == 1 && B->nDims() > 1) {
-    // [iK] @ [..., iK, iN] = [..., iN, rK]
-    ASSERT_EQ(output->nDims(), B->nDims() + red_dims - 1);
-    EXPECT_TRUE(checkMapped(vg, B->axis(-1), output->axis(-1 - red_dims))); // N
-    if (!k_bcast) {
-      EXPECT_TRUE(checkMapped(vg, A->axis(0), B->axis(-2))); // K
-      EXPECT_TRUE(checkMapped(vg, A->axis(0), output->axis(-1))); // K
-    }
-    // Check that batch dims are mapped
-    for (int64_t i : c10::irange(output->nDims() - red_dims - 1)) {
-      if (!B->axis(i)->isBroadcast()) {
-        EXPECT_TRUE(checkMapped(vg, B->axis(i), output->axis(i)));
-      }
-    }
-  } else if (A->nDims() > 1 && B->nDims() > 1) {
-    // [..., iM, iK] @ [..., iK, iN] = [..., iM, iN, rK]
-    ASSERT_EQ(output->nDims(), std::max(A->nDims(), B->nDims()) + red_dims);
-    EXPECT_TRUE(checkMapped(vg, A->axis(-2), output->axis(-2 - red_dims))); // M
-    EXPECT_TRUE(checkMapped(vg, B->axis(-1), output->axis(-1 - red_dims))); // N
-    if (!k_bcast) {
-      EXPECT_TRUE(checkMapped(vg, A->axis(-1), B->axis(-2))); // K
-      EXPECT_TRUE(checkMapped(vg, A->axis(-1), output->axis(-1))); // K
-    }
-    // Check that batch dims are mapped
-    // Note that A and B can have different dimensions, so here we count
-    // backwards from the innermost batch dimension. Then we check that the axis
-    // exists (is not negative) and is not Broadcast before checking mapping.
-    for (int64_t i : c10::irange(output->nDims() - red_dims - 2)) {
-      int64_t i_a = A->nDims() - 3 - i;
-      int64_t i_b = B->nDims() - 3 - i;
-      int64_t i_out = output->nDims() - red_dims - 3 - i;
-      if (i_a >= 0 && !A->axis(i_a)->isBroadcast()) {
-        EXPECT_TRUE(checkMapped(vg, A->axis(i_a), output->axis(i_out)));
-      }
-      if (i_b >= 0 && !B->axis(i_b)->isBroadcast()) {
-        EXPECT_TRUE(checkMapped(vg, B->axis(i_b), output->axis(i_out)));
-      }
-    }
-  } else {
-    std::cerr << "Unhandled set of input dimensions" << std::endl;
-    EXPECT_TRUE(false);
   }
 }
 


### PR DESCRIPTION
Removing special handling for some cases in `MatmulOp` to avoid any performance regressions as compared to ATen, particularly for gemmv cases.