### PR TITLE
Add prefix option to the communicator's backend cache

### DIFF
--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -216,9 +216,10 @@ Communicator::Communicator(
 
 c10d::Backend* Communicator::getBackendForTeam(
     const Team& team,
-    std::optional<CommunicatorBackend> backend) {
+    std::optional<CommunicatorBackend> backend,
+    std::string prefix) {
   CommunicatorBackend b = getBackend(backend);
-  std::string team_key = getTeamKey(team, b);
+  std::string team_key = prefix + getTeamKey(team, b);
   // check if backend associated with the team is present in the cache
   if (backends_.find(team_key) ==
       backends_.end()) { // create the backend and cache it

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -217,7 +217,7 @@ Communicator::Communicator(
 c10d::Backend* Communicator::getBackendForTeam(
     const Team& team,
     std::optional<CommunicatorBackend> backend,
-    std::string prefix) {
+    const std::string& prefix) {
   CommunicatorBackend b = getBackend(backend);
   std::string team_key = prefix + getTeamKey(team, b);
   // check if backend associated with the team is present in the cache

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -87,8 +87,8 @@ class Communicator {
 
   // returns the backend associated with a team
   // the argument "prefix" is prepended to the key used to retrieve preexisting
-  // backends. This allow us to have a fine-grained control on how the backends
-  // are cached.
+  // backends. Prefix is used to distinguish between different backends with the
+  // same team
   c10d::Backend* getBackendForTeam(
       const Team& team,
       std::optional<CommunicatorBackend> backend,

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -92,7 +92,7 @@ class Communicator {
   c10d::Backend* getBackendForTeam(
       const Team& team,
       std::optional<CommunicatorBackend> backend,
-      std::string prefix = "");
+      const std::string& prefix = "");
 
   // returns the device associated with the current process
   auto device() const {

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -86,9 +86,13 @@ class Communicator {
   }
 
   // returns the backend associated with a team
+  // the argument "prefix" is prepended to the key used to retrieve preexisting
+  // backends. This allow us to have a fine-grained control on how the backends
+  // are cached.
   c10d::Backend* getBackendForTeam(
       const Team& team,
-      std::optional<CommunicatorBackend> backend);
+      std::optional<CommunicatorBackend> backend,
+      std::string prefix = "");
 
   // returns the device associated with the current process
   auto device() const {


### PR DESCRIPTION
# What
Adds a fine grain control of the Communicator's backend cache

# Why
The `Communicator` is used as a singleton instance managing the different backends for communication. It internally holds a cache of the previously created backend to avoid the costly initial overhead of ProcessGroup creation.

One the one hand, it is important that this caching occurs at the Communicator's level and not at the caller site, because the communicator exists globally accross test instances.

On the other hand, in order to achieve communication/communication overlap, one must use multiple backends because each backend has one and only one internal stream on which it posts kernels.

# How
We add an optional `std::string prefix=""` argument to the function `Communicator:: getBackendForTeam` that is prepended to the key used to retrieve a backend from the cache. This allows arbitrary control of the cache from the caller.