### PR TITLE
Host irs/add collective wait

### DIFF
--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -140,7 +140,8 @@ class Val;
 #define DISPATCH_FOR_ALL_HIR_EXPRS(f) \
   f(HostUnit);                        \
   f(PostOnStream);                    \
-  f(SetCurrentStream);
+  f(SetCurrentStream);                \
+  f(Wait);
 
 // Forward declarations for all Val and Expr types
 

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -129,17 +129,23 @@ void HostIrExecutor::handle(Communication* communication) {
     output_tensor = val_to_IValue_.at(output_val).toTensor();
   }
 
-  c10d::Backend* backend =
-      communicator_->getBackendForTeam(communication->team(), std::nullopt);
-  c10::intrusive_ptr<c10d::Work> work = postSingleCommunication(
+  c10d::Backend* backend = communicator_->getBackendForTeam(communication->team(), std::nullopt);
+  works_[communication] = postSingleCommunication(
       communication,
       communicator_->deviceId(),
       backend,
       input_tensor,
       output_tensor);
+}
+
+void HostIrExecutor::handle(Wait* wait) {
+  Communication* communication = wait->communication();
+  NVF_ERROR(works_.find(communication) != works_.end(), "no wait req");
+  auto& work = works_.at(communication);
   if (work != nullptr) {
     work->wait();
   }
+  works_.erase(communication);
 }
 
 } // namespace hir

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -129,7 +129,8 @@ void HostIrExecutor::handle(Communication* communication) {
     output_tensor = val_to_IValue_.at(output_val).toTensor();
   }
 
-  c10d::Backend* backend = communicator_->getBackendForTeam(communication->team(), std::nullopt);
+  c10d::Backend* backend =
+      communicator_->getBackendForTeam(communication->team(), std::nullopt);
   works_[communication] = postSingleCommunication(
       communication,
       communicator_->deviceId(),

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -60,6 +60,7 @@ class HostIrExecutor final : public OptInDispatch {
   void handle(SetCurrentStream* set_current_stream) override;
   void handle(PostOnStream* post_ir) override;
   void handle(Communication* communication) override;
+  void handle(Wait* wait) override;
 
   std::unique_ptr<HostIrContainer> container_;
   Communicator* communicator_;
@@ -70,6 +71,7 @@ class HostIrExecutor final : public OptInDispatch {
   std::unordered_map<HostUnit*, FusionExecutor> fe_;
   std::unordered_map<HostUnit*, FusionExecutorCache> fec_;
   std::unordered_map<Stream*, c10::cuda::CUDAStream> streams_;
+  std::unordered_map<Communication*, c10::intrusive_ptr<c10d::Work>> works_;
 };
 
 } // namespace hir

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -152,9 +152,7 @@ bool SetCurrentStream::sameAs(const Statement* other) const {
   return false;
 }
 
-
-Wait::Wait(IrBuilderPasskey passkey,
-      Communication* communication)
+Wait::Wait(IrBuilderPasskey passkey, Communication* communication)
     : Expr(passkey, {}, {}, {communication}) {
   NVF_ERROR(
       passkey.ir_container_->isA<hir::HostIrContainer>(), // NOLINT

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -152,6 +152,37 @@ bool SetCurrentStream::sameAs(const Statement* other) const {
   return false;
 }
 
+
+Wait::Wait(IrBuilderPasskey passkey,
+      Communication* communication)
+    : Expr(passkey, {}, {}, {communication}) {
+  NVF_ERROR(
+      passkey.ir_container_->isA<hir::HostIrContainer>(), // NOLINT
+      this,
+      "must be registered in a HostIrContainer");
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(Wait)
+
+std::string Wait::toString(int indent_size) const {
+  int indent_increment = 2;
+  std::stringstream ss;
+  indent(ss, indent_size) << "Wait the communication :{" << std::endl;
+  ss << communication()->toString(indent_size + indent_increment) << std::endl;
+  indent(ss, indent_size) << "}";
+  return ss.str();
+}
+
+// TODO: implement better ?
+std::string Wait::toInlineString(int indent_size) const {
+  return toString(indent_size);
+}
+
+// TODO: implement
+bool Wait::sameAs(const Statement* other) const {
+  return false;
+}
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -157,12 +157,10 @@ class SetCurrentStream : public Expr {
   }
 };
 
-
 class Wait : public Expr {
  public:
   using Expr::Expr;
-  Wait(IrBuilderPasskey passkey,
-      Communication* communication);
+  Wait(IrBuilderPasskey passkey, Communication* communication);
 
   Wait(const Wait& other) = delete;
   Wait& operator=(const Wait& other) = delete;

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -157,6 +157,33 @@ class SetCurrentStream : public Expr {
   }
 };
 
+
+class Wait : public Expr {
+ public:
+  using Expr::Expr;
+  Wait(IrBuilderPasskey passkey,
+      Communication* communication);
+
+  Wait(const Wait& other) = delete;
+  Wait& operator=(const Wait& other) = delete;
+  Wait(Wait&& other) = delete;
+  Wait& operator=(Wait&& other) = delete;
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+  const char* getOpString() const override {
+    return "hir::Wait";
+  }
+
+  bool sameAs(const Statement* other) const override;
+
+  Communication* communication() const {
+    return attributes_.at(0)->as<Communication>();
+  }
+};
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -131,7 +131,7 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
        {communication->outputs().back(), output}});
 
   // validate the obtained results
-  GTEST_EXPECT_TRUE(torch::allclose(ref_output, outputs.back()));
+  EXPECT_TRUE(torch::allclose(ref_output, outputs.back()));
 }
 
 TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
@@ -232,7 +232,7 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
        {communication->outputs().back(), output}});
 
   // validate the obtained results
-  GTEST_EXPECT_TRUE(torch::allclose(ref_output, outputs.back()));
+  EXPECT_TRUE(torch::allclose(ref_output, outputs.back()));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -101,10 +101,12 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
       -1,
       communication_input,
       communication_output);
+  auto wait = IrBuilder::createInContainer<Wait>(hic.get(), communication);
 
   // [Step 6)] Define the Host program
   hic->pushBackTopLevelExprs(post_compute);
   hic->pushBackTopLevelExprs(communication);
+  hic->pushBackTopLevelExprs(wait);
 
   // [Step 7)] Define the Host program's global I/O
   hic->addInput(post_compute->inputs().back());

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -134,6 +134,109 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
   GTEST_EXPECT_TRUE(torch::allclose(ref_output, outputs.back()));
 }
 
+TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
+  auto [use_fusion_executor_cache, with_sharding_annotations] = GetParam();
+
+  const int64_t communicator_size = communicator->size();
+  std::vector<int64_t> unsharded_input_sizes = {communicator_size, 8, 32};
+  std::vector<int64_t> sharded_input_sizes = unsharded_input_sizes;
+  sharded_input_sizes[0] = 1;
+
+  // [Step 1] Define the Fusion we want to execute
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0_fusion = makeConcreteTensor(
+      with_sharding_annotations ? unsharded_input_sizes : sharded_input_sizes);
+  auto tv1_fusion = add(tv0_fusion, tv0_fusion);
+  fusion->addInput(tv0_fusion);
+  fusion->addOutput(tv1_fusion);
+
+  DeviceMesh mesh = DeviceMesh::createForNumDevices(communicator_size);
+  if (with_sharding_annotations) {
+    for (auto tv : {tv0_fusion, tv1_fusion}) {
+      tv->setDeviceMesh(mesh);
+      tv->axis(0)->parallelize(ParallelType::DIDx);
+    }
+  }
+
+  // [Step 2)] Instantiate an HostIrContainer
+  auto hic = std::make_unique<HostIrContainer>();
+  FusionGuard::setCurFusion(hic.get());
+
+  // [Step 3a)] Create a HostUnit Ir holding the fusions
+  auto hu = IrBuilder::create<HostUnit>(
+      static_cast<IrContainer*>(hic.get()), std::move(fusion));
+
+  // [Step 4)] Create TensorViews at the Host level
+  IrCloner ir_cloner(hic.get());
+  auto tv0 = ir_cloner.clone(
+      hu->fusion_to_execute()->inputs().at(0)->as<TensorView>());
+  auto tv1 = ir_cloner.clone(
+      hu->fusion_to_execute()->outputs().at(0)->as<TensorView>());
+  auto tv2 = makeConcreteTensor(unsharded_input_sizes);
+  tv2->setDeviceMesh(mesh);
+
+  // [Step 5)a.] Create PostOnStream Irs representing executing the Fusion
+  std::vector<Val*> compute_inputs = {tv0};
+  std::vector<Val*> compute_outputs = {tv1};
+  auto post_compute = IrBuilder::create<PostOnStream>(
+      static_cast<IrContainer*>(hic.get()),
+      hu,
+      compute_inputs,
+      compute_outputs);
+  // [Step 5)b.] Create Communication Ir representing executing the Fusion
+  TensorView* communication_inputs = tv1->as<TensorView>();
+  TensorView* communication_outputs = tv2->as<TensorView>();
+  CommParams comm_params{
+      .type = CommunicationType::Allgather,
+      .root = 0,
+      .mesh = mesh,
+      .team = mesh.vector()};
+  auto communication = IrBuilder::create<Communication>(
+      static_cast<IrContainer*>(hic.get()),
+      comm_params,
+      communication_inputs,
+      communication_outputs);
+  auto wait = IrBuilder::create<Wait>(static_cast<IrContainer*>(hic.get()), communication);
+
+  // [Step 6)] Define the Host program
+  hic->pushBackTopLevelExprs(post_compute);
+  hic->pushBackTopLevelExprs(communication);
+  hic->pushBackTopLevelExprs(post_compute);
+  hic->pushBackTopLevelExprs(wait);
+  hic->pushBackTopLevelExprs(post_compute);
+
+  // [Step 7)] Define the Host program's global I/O
+  hic->addInput(post_compute->inputs().back());
+  hic->addOutput(communication->outputs().back());
+
+  hic->print(debug());
+
+  // [Step 8)] Execute the Host program
+  HostIrExecutorParams params;
+  params.use_fusion_executor_cache = use_fusion_executor_cache;
+  if (with_sharding_annotations && use_fusion_executor_cache) {
+    // sharding + autoscheduler is not supported at this point
+    params.skip_auto_scheduling = true;
+  }
+  HostIrExecutor hie(std::move(hic), communicator, params);
+
+  auto options = at::TensorOptions().device(communicator->device());
+  at::Tensor unsharded_input = at::randn(unsharded_input_sizes, options);
+  c10::IValue input = unsharded_input.slice(
+      0, communicator->deviceId(), communicator->deviceId() + 1);
+  at::Tensor output = at::empty(unsharded_input_sizes, options);
+  auto ref_output = unsharded_input * 2;
+
+  auto outputs = hie.runWithInput(
+      {{post_compute->inputs().back(), input},
+       {communication->outputs().back(), output}});
+
+  // validate the obtained results
+  GTEST_EXPECT_TRUE(torch::allclose(ref_output, outputs.back()));
+}
+
 INSTANTIATE_TEST_SUITE_P(
     Manual,
     MultiDeviceHostIrTest,

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -165,8 +165,8 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   FusionGuard::setCurFusion(hic.get());
 
   // [Step 3a)] Create a HostUnit Ir holding the fusions
-  auto hu = IrBuilder::create<HostUnit>(
-      static_cast<IrContainer*>(hic.get()), std::move(fusion));
+  auto hu = IrBuilder::createInContainer<HostUnit>(
+    hic.get(), std::move(fusion));
 
   // [Step 4)] Create TensorViews at the Host level
   IrCloner ir_cloner(hic.get());
@@ -180,28 +180,31 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   // [Step 5)a.] Create PostOnStream Irs representing executing the Fusion
   std::vector<Val*> compute_inputs = {tv0};
   std::vector<Val*> compute_outputs = {tv1};
-  auto post_compute = IrBuilder::create<PostOnStream>(
-      static_cast<IrContainer*>(hic.get()),
+  auto post_compute = IrBuilder::createInContainer<PostOnStream>(
+      hic.get(),
       hu,
       compute_inputs,
       compute_outputs);
   // [Step 5)b.] Create Communication Ir representing executing the Fusion
-  TensorView* communication_inputs = tv1->as<TensorView>();
-  TensorView* communication_outputs = tv2->as<TensorView>();
-  CommParams comm_params{
-      .type = CommunicationType::Allgather,
-      .root = 0,
-      .mesh = mesh,
-      .team = mesh.vector()};
-  auto communication = IrBuilder::create<Communication>(
-      static_cast<IrContainer*>(hic.get()),
-      comm_params,
-      communication_inputs,
-      communication_outputs);
-  auto wait = IrBuilder::create<Wait>(
-      static_cast<IrContainer*>(hic.get()), communication);
+  TensorView* communication_input = tv1->as<TensorView>();
+  TensorView* communication_output = tv2->as<TensorView>();
+  auto communication = IrBuilder::createInContainer<Communication>(
+      hic.get(),
+      CommunicationType::Allgather,
+      mesh,
+      mesh.vector(),
+      -1,
+      RedOpType::UNUSED,
+      -1,
+      communication_input,
+      communication_output);
+  auto wait = IrBuilder::createInContainer<Wait>(
+      hic.get(), communication);
 
   // [Step 6)] Define the Host program
+  hic->pushBackTopLevelExprs(post_compute);
+  hic->pushBackTopLevelExprs(communication);
+  hic->pushBackTopLevelExprs(wait);
   hic->pushBackTopLevelExprs(post_compute);
   hic->pushBackTopLevelExprs(communication);
   hic->pushBackTopLevelExprs(post_compute);

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -198,7 +198,8 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
       comm_params,
       communication_inputs,
       communication_outputs);
-  auto wait = IrBuilder::create<Wait>(static_cast<IrContainer*>(hic.get()), communication);
+  auto wait = IrBuilder::create<Wait>(
+      static_cast<IrContainer*>(hic.get()), communication);
 
   // [Step 6)] Define the Host program
   hic->pushBackTopLevelExprs(post_compute);

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -211,8 +211,6 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   hic->addInput(post_compute->inputs().back());
   hic->addOutput(communication->outputs().back());
 
-  hic->print(debug());
-
   // [Step 8)] Execute the Host program
   HostIrExecutorParams params;
   params.use_fusion_executor_cache = use_fusion_executor_cache;

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -165,8 +165,8 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   FusionGuard::setCurFusion(hic.get());
 
   // [Step 3a)] Create a HostUnit Ir holding the fusions
-  auto hu = IrBuilder::createInContainer<HostUnit>(
-    hic.get(), std::move(fusion));
+  auto hu =
+      IrBuilder::createInContainer<HostUnit>(hic.get(), std::move(fusion));
 
   // [Step 4)] Create TensorViews at the Host level
   IrCloner ir_cloner(hic.get());
@@ -181,10 +181,7 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   std::vector<Val*> compute_inputs = {tv0};
   std::vector<Val*> compute_outputs = {tv1};
   auto post_compute = IrBuilder::createInContainer<PostOnStream>(
-      hic.get(),
-      hu,
-      compute_inputs,
-      compute_outputs);
+      hic.get(), hu, compute_inputs, compute_outputs);
   // [Step 5)b.] Create Communication Ir representing executing the Fusion
   TensorView* communication_input = tv1->as<TensorView>();
   TensorView* communication_output = tv2->as<TensorView>();
@@ -198,8 +195,7 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
       -1,
       communication_input,
       communication_output);
-  auto wait = IrBuilder::createInContainer<Wait>(
-      hic.get(), communication);
+  auto wait = IrBuilder::createInContainer<Wait>(hic.get(), communication);
 
   // [Step 6)] Define the Host program
   hic->pushBackTopLevelExprs(post_compute);


### PR DESCRIPTION
Pick up from #2338 which introduced [a bug](https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/jobs/97151941#L925) and has been reverted in #2399

We apply the same patch here, plus [an additional commit](https://github.com/NVIDIA/Fuser/commit/d292a5fe9f7d86860aa4f4e9e479dd809a115843) that fixes the bug. The fix is to add a "wait" primitive after the collective is posted in the test `MultiDeviceHostIrTest.SingleFusionSingleComm`.