### PR TITLE
Add another constructor of `Communication` that takes I/O TensorViews instead of the mesh. 

### DIFF
--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -150,23 +150,50 @@ Communication::Communication(
   NVF_ERROR(
       out->getDeviceMesh().size() > 0,
       "The output mesh size must be greater than 0.");
-  NVF_ERROR(
-      hasRoot(type) == (root >= 0),
-      "Root ",
-      root,
-      " is not expected by CommunicationType ",
-      type);
-  NVF_ERROR(isReduction(type) == (red_op != RedOpType::UNUSED))
-  NVF_ERROR(
-      (type == CommunicationType::ReduceScatter) == (scattered_axis >= 0));
 
   addInput(in);
   addOutput(out);
   addDataAttribute(type);
+  addDataAttribute(DeviceMesh());
   addDataAttribute(team);
   addDataAttribute(root);
   addDataAttribute(red_op);
   addDataAttribute(scattered_axis);
+
+  validate();
+}
+
+Communication::Communication(
+    IrBuilderPasskey passkey,
+    CommunicationType type,
+    DeviceMesh mesh,
+    Team team,
+    DeviceIdxType root,
+    RedOpType red_op,
+    int64_t scattered_axis)
+    : Expr(passkey) {
+  NVF_ERROR(mesh.size() > 0, "The mesh size must be greater than 0.");
+
+  addDataAttribute(type);
+  addDataAttribute(mesh);
+  addDataAttribute(team);
+  addDataAttribute(root);
+  addDataAttribute(red_op);
+  addDataAttribute(scattered_axis);
+
+  validate();
+}
+
+void Communication::validate() {
+  NVF_ERROR(
+      hasRoot(type()) == (root() >= 0),
+      "Root ",
+      root(),
+      " is not expected by CommunicationType ",
+      type());
+  NVF_ERROR(isReduction(type()) == (reduceOp() != RedOpType::UNUSED))
+  NVF_ERROR(
+      (type() == CommunicationType::ReduceScatter) == (scatteredAxis() >= 0));
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(Communication)

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -61,7 +61,10 @@ class Communication : public Expr {
       RedOpType red_op = RedOpType::UNUSED,
       int64_t scattered_axis = -1);
 
-  // Currently, only used for MultiDeviceExecutor.
+  // Currently, it's only used by CommuniationTest for conciseness. In the
+  // future, it may be used to construct `Communication`s inside a
+  // `PostOnStream`, which if needed can take I/O TVs from the containing
+  // `PostOnStream`.
   Communication(
       IrBuilderPasskey passkey,
       CommunicationType type,

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -169,7 +169,7 @@ void MultiDeviceExecutor::postCommunication(SegmentedGroup* group) {
       communication_containers_[group];
   if (container == nullptr) {
     container = std::make_unique<hir::HostIrContainer>();
-    IrCloner cloner = Fusion::copy(group->getFusion(), container.get());
+    IrCloner cloner(container.get());
     std::vector<Communication*> communications =
         lowerCommunication(comm_.deviceId(), cloner.clone(expr));
     for (auto* communication : communications) {

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -168,7 +168,7 @@ void MultiDeviceExecutor::postCommunication(SegmentedGroup* group) {
   std::unique_ptr<hir::HostIrContainer>& container =
       communication_containers_[group];
   if (container == nullptr) {
-    container.reset(new hir::HostIrContainer());
+    container = std::make_unique<hir::HostIrContainer>();
     IrCloner cloner = Fusion::copy(group->getFusion(), container.get());
     std::vector<Communication*> communications =
         lowerCommunication(comm_.deviceId(), cloner.clone(expr));

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -178,8 +178,8 @@ void MultiDeviceExecutor::postCommunication(SegmentedGroup* group) {
   }
 
   // Compute input_tensor and output_tensor.
-  auto input_val = expr->input(0);
-  auto output_val = expr->output(0);
+  Val* input_val = expr->input(0);
+  Val* output_val = expr->output(0);
   at::Tensor input_tensor;
   if (val_to_IValue_.find(input_val) != val_to_IValue_.end()) {
     input_tensor = val_to_IValue_.at(input_val).toTensor();

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -8,6 +8,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <device_lower/utils.h>
 #include <fusion_segmenter.h>
+#include <host_ir/container.h>
 #include <ir/utils.h>
 #include <multidevice/device_mesh.h>
 #include <multidevice/executor.h>
@@ -164,11 +165,19 @@ void MultiDeviceExecutor::postCommunication(SegmentedGroup* group) {
       expr->outputs().size() == 1,
       "Communication must have exactly one output");
 
-  auto communications = lowerCommunication(comm_.deviceId(), expr);
+  hir::HostIrContainer& container = communication_containers_[group];
+  if (container.topLevelExprs().empty()) {
+    IrCloner cloner = Fusion::copy(group->getFusion(), &container);
+    std::vector<Communication*> communications =
+        lowerCommunication(comm_.deviceId(), cloner.clone(expr));
+    for (auto* communication : communications) {
+      container.pushBackTopLevelExprs(communication);
+    }
+  }
 
   // Compute input_tensor and output_tensor.
-  auto input_val = expr->inputs().at(0);
-  auto output_val = expr->outputs().at(0);
+  auto input_val = expr->input(0);
+  auto output_val = expr->output(0);
   at::Tensor input_tensor;
   if (val_to_IValue_.find(input_val) != val_to_IValue_.end()) {
     input_tensor = val_to_IValue_.at(input_val).toTensor();
@@ -179,7 +188,8 @@ void MultiDeviceExecutor::postCommunication(SegmentedGroup* group) {
   }
 
   // post and wait communications
-  for (Communication* communication : communications) {
+  for (Expr* lowered : container.topLevelExprs()) {
+    auto* communication = lowered->as<Communication>();
     c10d::Backend* backend =
         comm_.getBackendForTeam(communication->team(), std::nullopt);
     c10::intrusive_ptr<c10d::Work> work = postSingleCommunication(

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -140,7 +140,7 @@ class MultiDeviceExecutor {
   // Cache Fusions, FusionExecutors, and Communications
   std::unordered_map<SegmentedGroup*, FusionExecutor> fe_;
   std::unordered_map<SegmentedGroup*, FusionExecutorCache> fec_;
-  std::unordered_map<SegmentedGroup*, hir::HostIrContainer>
+  std::unordered_map<SegmentedGroup*, std::unique_ptr<hir::HostIrContainer>>
       communication_containers_;
   // Cache whether a SegmentedGroup should be run by the current device
   std::unordered_map<SegmentedGroup*, bool> should_run_;

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -11,6 +11,7 @@
 #include <exceptions.h>
 #include <fusion.h>
 #include <fusion_segmenter.h>
+#include <host_ir/container.h>
 #include <multidevice/communication.h>
 #include <multidevice/communicator.h>
 #include <multidevice/multidevice.h>
@@ -139,6 +140,8 @@ class MultiDeviceExecutor {
   // Cache Fusions, FusionExecutors, and Communications
   std::unordered_map<SegmentedGroup*, FusionExecutor> fe_;
   std::unordered_map<SegmentedGroup*, FusionExecutorCache> fec_;
+  std::unordered_map<SegmentedGroup*, hir::HostIrContainer>
+      communication_containers_;
   // Cache whether a SegmentedGroup should be run by the current device
   std::unordered_map<SegmentedGroup*, bool> should_run_;
   // Cache whether a SegmentedGroup requires inter-device communication

--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -73,7 +73,7 @@ void lowerToScatter(
     team.push_back(root);
   }
   comms.push_back(IrBuilder::create<Communication>(
-      CommunicationType::Scatter, receiver_mesh, team, root));
+      CommunicationType::Scatter, output_tv, input_tv, team, root));
 }
 
 /*
@@ -98,7 +98,7 @@ void lowerToGather(
       team.push_back(root);
     }
     comms.push_back(IrBuilder::create<Communication>(
-        CommunicationType::Gather, sender_mesh, team, root));
+        CommunicationType::Gather, output_tv, input_tv, team, root));
   }
 }
 
@@ -114,15 +114,17 @@ void lowerToAllgather(
   }
 
   comms.push_back(IrBuilder::create<Communication>(
-      CommunicationType::Allgather, mesh, mesh.vector()));
+      CommunicationType::Allgather, output_tv, input_tv, mesh.vector()));
 }
 
 // Adds one or zero Broadcast communication to the vector 'comms'
 void lowerToBroadcast(
     DeviceIdxType my_device_index,
+    TensorView* input_tv,
+    TensorView* output_tv,
     DeviceIdxType root,
-    const DeviceMesh& mesh, // receiver devices
     std::vector<Communication*>& comms) {
+  const DeviceMesh& mesh = output_tv->getDeviceMesh();
   if (!isDeviceInvolved(my_device_index, root, mesh)) {
     return;
   }
@@ -131,14 +133,14 @@ void lowerToBroadcast(
     team.push_back(root);
   }
   comms.push_back(IrBuilder::create<Communication>(
-      CommunicationType::Broadcast, mesh, team, root));
+      CommunicationType::Broadcast, output_tv, input_tv, team, root));
 }
 
-// Adds several Broadcast communications to the vector 'comms'
+// Adds several Broadcast or SendRecv communications to the vector 'comms'
 // For now, we assume that this function is called only if
 // the input and output have the same sharding. Later we could support more
 // general cases.
-void lowerToBroadcast(
+void lowerToBroadcastOrSendRecv(
     DeviceIdxType my_device_index,
     TensorView* input_tv,
     TensorView* output_tv,
@@ -155,11 +157,16 @@ void lowerToBroadcast(
         " vs ",
         receiver_mesh.size());
     for (auto i : c10::irange(sender_mesh.size())) {
-      lowerToBroadcast(
-          my_device_index,
-          sender_mesh.at(i),
-          DeviceMesh({receiver_mesh.at(i)}),
-          comms);
+      const DeviceIdxType sender = sender_mesh.at(i);
+      const DeviceIdxType receiver = receiver_mesh.at(i);
+      if (my_device_index == sender || my_device_index == receiver) {
+        comms.push_back(IrBuilder::create<Communication>(
+            CommunicationType::SendRecv,
+            output_tv,
+            input_tv,
+            Team({sender, receiver}),
+            /*root=*/sender));
+      }
     }
   } else {
     // Either of the following two cases is happening.
@@ -168,7 +175,12 @@ void lowerToBroadcast(
     // 2. `sender_mesh` contains multiple devices but the input is not sharded.
     // In this case, we arbitrarily choose the first device of the sender mesh
     // to be the root.
-    lowerToBroadcast(my_device_index, sender_mesh.at(0), receiver_mesh, comms);
+    lowerToBroadcast(
+        my_device_index,
+        input_tv,
+        output_tv,
+        /*root=*/sender_mesh.at(0),
+        comms);
   }
 }
 
@@ -191,7 +203,12 @@ void lowerToReduce(
       team.push_back(root);
     }
     comms.push_back(IrBuilder::create<Communication>(
-        CommunicationType::Reduce, sender_mesh, team, root, reduce_op_type));
+        CommunicationType::Reduce,
+        output_tv,
+        input_tv,
+        team,
+        root,
+        reduce_op_type));
   }
 }
 
@@ -208,7 +225,8 @@ void lowerToAllreduce(
 
   comms.push_back(IrBuilder::create<Communication>(
       CommunicationType::Allreduce,
-      mesh,
+      output_tv,
+      input_tv,
       mesh.vector(),
       /*root=*/-1,
       getC10dReduceOpType(op_type)));
@@ -237,8 +255,9 @@ void lowerToReduceScatter(
 
   comms.push_back(IrBuilder::create<Communication>(
       CommunicationType::ReduceScatter,
-      mesh,
-      mesh.vector(),
+      output_tv,
+      input_tv,
+      /*team=*/mesh.vector(),
       /*root=*/-1,
       getC10dReduceOpType(op_type),
       scattered_axis));
@@ -256,12 +275,13 @@ TODO:
 *) Leverage the topology to ensure that the senders and recerivers are close
 */
 std::vector<Communication*> lowerCommunication(
-    DeviceIdxType my_device_index,
+    DeviceIdxType my_device_index, // TODO: my_device_index shouldn't be used at
+                                   // compile time.
     Expr* c) {
   std::vector<Communication*> comms;
   NVF_ERROR(
-      c->inputs().size() == 1 && c->inputs().at(0)->isA<TensorView>() &&
-          c->outputs().size() == 1 && c->outputs().at(0)->isA<TensorView>(),
+      c->inputs().size() == 1 && c->input(0)->isA<TensorView>() &&
+          c->outputs().size() == 1 && c->output(0)->isA<TensorView>(),
       "I/O must be TensorViews");
   TensorView* input_tv = c->input(0)->as<TensorView>();
   TensorView* output_tv = c->output(0)->as<TensorView>();
@@ -317,7 +337,7 @@ std::vector<Communication*> lowerCommunication(
         lowerToGather(my_device_index, input_tv, output_tv, comms);
       }
     } else {
-      lowerToBroadcast(my_device_index, input_tv, output_tv, comms);
+      lowerToBroadcastOrSendRecv(my_device_index, input_tv, output_tv, comms);
     }
   }
   return comms;

--- a/csrc/multidevice/lower_communication.cpp
+++ b/csrc/multidevice/lower_communication.cpp
@@ -278,6 +278,8 @@ std::vector<Communication*> lowerCommunication(
     DeviceIdxType my_device_index, // TODO: my_device_index shouldn't be used at
                                    // compile time.
     Expr* c) {
+  FusionGuard fg(c->fusion());
+
   std::vector<Communication*> comms;
   NVF_ERROR(
       c->inputs().size() == 1 && c->input(0)->isA<TensorView>() &&

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <fusion.h>
+#include <host_ir/container.h>
 #include <ir/builder.h>
 #include <multidevice/communication.h>
 #include <multidevice/communicator.h>
@@ -61,8 +62,8 @@ void CommunicationTest::validate(at::Tensor obtained, at::Tensor expected) {
 }
 
 TEST_P(CommunicationTest, Gather) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  hir::HostIrContainer container;
+  FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
   auto* out = makeContigTensor(2);
@@ -95,13 +96,13 @@ TEST_P(CommunicationTest, Gather) {
 }
 
 TEST_P(CommunicationTest, Allgather) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  hir::HostIrContainer container;
+  FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
   auto* out = makeContigTensor(2);
   out->setDeviceMesh(full_mesh_);
-  auto communication = IrBuilder::create<Communication>(
+  auto* communication = IrBuilder::create<Communication>(
       CommunicationType::Allgather, out, in, all_ranks_);
 
   at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options);
@@ -128,13 +129,13 @@ TEST_P(CommunicationTest, Allgather) {
 }
 
 TEST_P(CommunicationTest, Scatter) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  hir::HostIrContainer container;
+  FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
   auto* out = makeContigTensor(2);
   out->setDeviceMesh(full_mesh_);
-  auto communication = IrBuilder::create<Communication>(
+  auto* communication = IrBuilder::create<Communication>(
       CommunicationType::Scatter, out, in, all_ranks_, kRoot);
 
   at::Tensor input_tensor;
@@ -167,13 +168,13 @@ TEST_P(CommunicationTest, Scatter) {
 }
 
 TEST_P(CommunicationTest, Broadcast) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  hir::HostIrContainer container;
+  FusionGuard fg(&container);
   auto* in = makeContigTensor(1);
   in->setDeviceMesh(full_mesh_);
   auto* out = makeContigTensor(1);
   out->setDeviceMesh(full_mesh_);
-  auto communication = IrBuilder::create<Communication>(
+  auto* communication = IrBuilder::create<Communication>(
       CommunicationType::Broadcast, out, in, all_ranks_, kRoot);
 
   at::Tensor input_tensor;
@@ -217,8 +218,8 @@ TEST_P(CommunicationTest, SendRecv) {
     return;
   }
 
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  hir::HostIrContainer container;
+  FusionGuard fg(&container);
   auto* in = makeContigTensor(1);
   in->setDeviceMesh({sender});
   auto* out = makeContigTensor(1);
@@ -264,8 +265,8 @@ TEST_P(CommunicationTest, SendRecvToSelf) {
     return;
   }
 
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  hir::HostIrContainer container;
+  FusionGuard fg(&container);
   auto* in = makeContigTensor(1);
   in->setDeviceMesh({sender});
   auto* out = makeContigTensor(1);
@@ -298,8 +299,8 @@ TEST_P(CommunicationTest, SendRecvToSelf) {
 }
 
 TEST_P(CommunicationTest, Reduce) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  hir::HostIrContainer container;
+  FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
   auto* out = makeContigTensor(1);
@@ -333,8 +334,8 @@ TEST_P(CommunicationTest, Reduce) {
 }
 
 TEST_P(CommunicationTest, Allreduce) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  hir::HostIrContainer container;
+  FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
   auto* out = makeContigTensor(1);
@@ -370,8 +371,8 @@ TEST_P(CommunicationTest, Allreduce) {
 }
 
 TEST_P(CommunicationTest, ReduceScatter) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  hir::HostIrContainer container;
+  FusionGuard fg(&container);
   auto* in = makeContigTensor(3);
   in->setDeviceMesh(full_mesh_);
   auto* out = makeContigTensor(2);

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -220,14 +220,14 @@ TEST_P(CommunicationTest, SendRecv) {
   Fusion fusion;
   FusionGuard fg(&fusion);
   auto* in = makeContigTensor(1);
-  in->setDeviceMesh(full_mesh_);
+  in->setDeviceMesh({sender});
   auto* out = makeContigTensor(1);
-  out->setDeviceMesh(full_mesh_);
+  out->setDeviceMesh({receiver});
   auto* communication = IrBuilder::create<Communication>(
       CommunicationType::SendRecv,
       out,
       in,
-      /*team=*/Team({sender, receiver}),
+      Team({sender, receiver}),
       /*root=*/sender);
 
   at::Tensor input_tensor;

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -94,13 +94,9 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
   auto communication = IrBuilder::createInContainer<Communication>(
       hic.get(),
       CommunicationType::Allgather,
-      mesh,
-      mesh.vector(),
-      -1,
-      RedOpType::UNUSED,
-      -1,
+      communication_output,
       communication_input,
-      communication_output);
+      mesh.vector());
   auto wait = IrBuilder::createInContainer<Wait>(hic.get(), communication);
 
   // [Step 6)] Define the Host program
@@ -190,13 +186,9 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   auto communication = IrBuilder::createInContainer<Communication>(
       hic.get(),
       CommunicationType::Allgather,
-      mesh,
-      mesh.vector(),
-      -1,
-      RedOpType::UNUSED,
-      -1,
+      communication_output,
       communication_input,
-      communication_output);
+      mesh.vector());
   auto wait = IrBuilder::createInContainer<Wait>(hic.get(), communication);
 
   // [Step 6)] Define the Host program

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -58,9 +58,9 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
   fusion->addOutput(tv1_fusion);
 
   DeviceMesh mesh = DeviceMesh::createForNumDevices(communicator_size);
-  if (with_sharding_annotations) {
-    for (auto tv : {tv0_fusion, tv1_fusion}) {
-      tv->setDeviceMesh(mesh);
+  for (auto tv : {tv0_fusion, tv1_fusion}) {
+    tv->setDeviceMesh(mesh);
+    if (with_sharding_annotations) {
       tv->axis(0)->parallelize(ParallelType::DIDx);
     }
   }
@@ -151,9 +151,9 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   fusion->addOutput(tv1_fusion);
 
   DeviceMesh mesh = DeviceMesh::createForNumDevices(communicator_size);
-  if (with_sharding_annotations) {
-    for (auto tv : {tv0_fusion, tv1_fusion}) {
-      tv->setDeviceMesh(mesh);
+  for (auto tv : {tv0_fusion, tv1_fusion}) {
+    tv->setDeviceMesh(mesh);
+    if (with_sharding_annotations) {
       tv->axis(0)->parallelize(ParallelType::DIDx);
     }
   }

--- a/tests/cpp/test_multidevice_matmul.cpp
+++ b/tests/cpp/test_multidevice_matmul.cpp
@@ -274,7 +274,7 @@ TEST_F(DistributedMatmulTest, Matmul_LayoutNT_AllReduce) {
   // MmaLayout::NT matmul A(N), B(T), C(T)
   // Sharding: A, B are sharded along K. C is replicated.
   // Tests local matmul + allreduce
-  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
   auto mesh = DeviceMesh::createForNumDevices(communicator->size());
 
@@ -335,7 +335,7 @@ TEST_F(DistributedMatmulTest, Matmul_LayoutNT_ReduceScatter) {
   // MmaLayout::NT matmul A(N), B(T), C(T)
   // A, B are sharded on K. C is sharded on M
   // Tests local matmul + reduce scatter
-  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
   auto mesh = DeviceMesh::createForNumDevices(communicator->size());
 


### PR DESCRIPTION
The other constructor is still used in some tests. 

Communications created by the new constructor must be put in a non-SSA IrContainer. This is because multiple Communications can have the same input and output TensorViews, e.g., Gather with a receiver mesh of size 2. 