### PR TITLE
Add `TensorIndexer::computeIndex(valgroups)`

### DIFF
--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -513,11 +513,10 @@ std::vector<IterDomain*> TensorIndexer::getLoopDomains(const Expr* expr) const {
 
 IndexingInfo TensorIndexer::computeIndex(
     const Expr* expr,
-    const std::vector<IterDomain*>& index_domains) const {
+    const std::vector<ValGroup>& index_groups) const {
   const auto loop_domains = getLoopDomains(expr);
 
   const ValGroups loop_groups = traversalGraph().toGroups(loop_domains);
-  const ValGroups index_groups = traversalGraph().toGroups(index_domains);
   const ExprPath traversal_path =
       ValGraphBFS::getExprsBetween(traversalGraph(), loop_groups, index_groups);
 
@@ -532,6 +531,12 @@ IndexingInfo TensorIndexer::computeIndex(
 
   IndexingInfo info{loop_domains, traversal_path, index_compute.indexMap()};
   return info;
+}
+
+IndexingInfo TensorIndexer::computeIndex(
+    const Expr* expr,
+    const std::vector<IterDomain*>& index_domains) const {
+  return computeIndex(expr, traversalGraph().toGroups(index_domains));
 }
 
 std::unordered_map<Val*, Val*> TensorIndexer::getIndexReplacementMap(

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -513,7 +513,7 @@ std::vector<IterDomain*> TensorIndexer::getLoopDomains(const Expr* expr) const {
 
 IndexingInfo TensorIndexer::computeIndex(
     const Expr* expr,
-    const std::vector<ValGroup>& index_groups) const {
+    const ValGroups& index_groups) const {
   const auto loop_domains = getLoopDomains(expr);
 
   const ValGroups loop_groups = traversalGraph().toGroups(loop_domains);

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -53,6 +53,15 @@ class TensorIndexer {
   // Get the index of a loop domain. Intended to be used only for testing.
   Val* getLoopIndex(IterDomain* loop_id) const;
 
+  // Returns the index map as well as its traversal path of given
+  // index domains appearing in a given expr. Used by
+  // getLinearIndex.
+  IndexingInfo computeIndex(const Expr* expr, const ValGroups& index_groups)
+      const;
+  IndexingInfo computeIndex(
+      const Expr* expr,
+      const std::vector<IterDomain*>& index_domains) const;
+
  private:
   // The AlmostExact graph is used since size-1 splits and merges
   // should not affect actual index exprs.
@@ -75,15 +84,6 @@ class TensorIndexer {
   // function may return the loop domains of a producer for
   // producer-based indexing.
   std::vector<IterDomain*> getLoopDomains(const Expr* expr) const;
-
-  // Returns the index map as well as its traversal path of given
-  // index domains appearing in a given expr. Used by
-  // getLinearIndex.
-  IndexingInfo computeIndex(const Expr* expr, const ValGroups& index_groups)
-      const;
-  IndexingInfo computeIndex(
-      const Expr* expr,
-      const std::vector<IterDomain*>& index_domains) const;
 
   // Check if the loop index of a loop group should be always
   // just zero. For example, a loop group with an extent of one, i.e.,

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -79,9 +79,8 @@ class TensorIndexer {
   // Returns the index map as well as its traversal path of given
   // index domains appearing in a given expr. Used by
   // getLinearIndex.
-  IndexingInfo computeIndex(
-      const Expr* expr,
-      const ValGroups& index_groups) const;
+  IndexingInfo computeIndex(const Expr* expr, const ValGroups& index_groups)
+      const;
   IndexingInfo computeIndex(
       const Expr* expr,
       const std::vector<IterDomain*>& index_domains) const;

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -81,7 +81,7 @@ class TensorIndexer {
   // getLinearIndex.
   IndexingInfo computeIndex(
       const Expr* expr,
-      const std::vector<ValGroup>& index_groups) const;
+      const ValGroups& index_groups) const;
   IndexingInfo computeIndex(
       const Expr* expr,
       const std::vector<IterDomain*>& index_domains) const;

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -81,6 +81,9 @@ class TensorIndexer {
   // getLinearIndex.
   IndexingInfo computeIndex(
       const Expr* expr,
+      const std::vector<ValGroup>& index_groups) const;
+  IndexingInfo computeIndex(
+      const Expr* expr,
       const std::vector<IterDomain*>& index_domains) const;
 
   // Check if the loop index of a loop group should be always


### PR DESCRIPTION
Will be used for indexing TMA, so make them public