### PR TITLE
Make `TensorIndexer::traversalGraph` public

### DIFF
--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -53,13 +53,13 @@ class TensorIndexer {
   // Get the index of a loop domain. Intended to be used only for testing.
   Val* getLoopIndex(IterDomain* loop_id) const;
 
- private:
   // The AlmostExact graph is used since size-1 splits and merges
   // should not affect actual index exprs.
   const ValGraph& traversalGraph() const {
     return id_model_.idGraph(IdMappingMode::ALMOSTEXACT);
   }
 
+ private:
   // Build a map of loop groups to their index Vals. See the comment
   // on loop_index_map_.
   void buildLoopIndexMap();


### PR DESCRIPTION
When writing analysis, we might store `ValGroup`s instead of `IterDomain`s as the result of the analysis, for the convenience of usage. It could be important to use the `ValGroup`s belonging to the same IdGraph as the indexer. So I make this public so analysis writer could access and write their analysis based on this graph.