### PR TITLE
Combine MatmulRole::INPUT_{A,B} into MatmulRole::OPERAND

### DIFF
--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -29,16 +29,13 @@ constexpr std::string_view MATMUL_LOG_PREFIX = "[MATMUL DEBUG] ";
 enum class MatmulDomain { M = 0, N, K, Batch };
 
 //! Named descriptors of TensorView roles in fusion
-//!  INPUT_A - a producer of MMA input A
-//!  INPUT_B - a producer of MMA input B
-//!  INPUT_C - a producer of a tensor used in fusion epilogue,
-//!            for example tensor used in beta scaling fusion
-//!  OUTPUT_D - fusion outputs that have the matmul as a dependency
+//!  OPERAND - an input to the fusion that is a producer of a matmul input
+//!  OUTPUT - fusion outputs that have the matmul as a dependency
+//!  EPILOGUE_INPUT - an input to the fusion that is a producer of an
+//!    OUTPUT, but not of an MMA input
 //!
-//! Naming convention is based on the following formula:
-//!    D = alpha * A x B + beta * C
-//!  Note: bias vector tensors will be assigned to INPUT_C role.
-enum class MatmulRole { INPUT_A = 0, INPUT_B, INPUT_C, OUTPUT_D };
+//!  Note: bias vector tensors will be assigned to the EPILOGUE_INPUT role.
+enum class MatmulRole { OPERAND = 0, OUTPUT, EPILOGUE_INPUT };
 
 //! The expected number of occurances of core TensorView roles in fusion
 static constexpr size_t MATMUL_CORE_ROLES_EXPECTED_COUNT = 1;

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -71,14 +71,13 @@ static TensorView* newForLinear(
   auto ndims_out = input_domain.size() + weight_domain.size() - 1;
 
   const std::vector<IterDomain*>& mapping_a =
-      ops::mapLinearOpIterDomains(input_domain, MatmulRole::INPUT_A, ndims_out);
-  const std::vector<IterDomain*>& mapping_b = ops::mapLinearOpIterDomains(
-      weight_domain, MatmulRole::INPUT_B, ndims_out);
+      ops::mapLinearOpIterDomains(input_domain, 0, ndims_out);
+  const std::vector<IterDomain*>& mapping_b =
+      ops::mapLinearOpIterDomains(weight_domain, 1, ndims_out);
   std::vector<IterDomain*> mapping_bias(ndims_out, nullptr);
   if (bias != nullptr) {
     auto bias_domain = TensorDomain::noReductions(bias->getLogicalDomain());
-    mapping_bias = ops::mapLinearOpIterDomains(
-        bias_domain, MatmulRole::INPUT_C, ndims_out);
+    mapping_bias = ops::mapLinearOpIterDomains(bias_domain, 2, ndims_out);
   }
 
   std::vector<IterDomain*> out_domain(ndims_out, nullptr);
@@ -348,10 +347,10 @@ static TensorView* newForMatmul(TensorView* tv_a, TensorView* tv_b) {
 
   std::vector<IterDomain*> out_domain(ndims_out, nullptr);
 
-  const std::vector<IterDomain*>& mapping_a = ops::mapMatmulOpIterDomains(
-      orig_domain_a, MatmulRole::INPUT_A, ndims_out);
-  const std::vector<IterDomain*>& mapping_b = ops::mapMatmulOpIterDomains(
-      orig_domain_b, MatmulRole::INPUT_B, ndims_out);
+  const std::vector<IterDomain*>& mapping_a =
+      ops::mapMatmulOpIterDomains(orig_domain_a, 0, ndims_out);
+  const std::vector<IterDomain*>& mapping_b =
+      ops::mapMatmulOpIterDomains(orig_domain_b, 1, ndims_out);
 
   for (auto idx : c10::irange(ndims_out - 1)) {
     out_domain[idx] =

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -181,17 +181,18 @@ IterType promoteIterType(IterType type1, IterType type2) {
 //! index.
 std::vector<IterDomain*> mapMatmulOpIterDomains(
     const std::vector<IterDomain*>& input_domain,
-    MatmulRole input_role,
+    int64_t input_position,
     size_t out_size) {
   NVF_ERROR(
-      input_role == MatmulRole::INPUT_A || input_role == MatmulRole::INPUT_B,
-      "Unexpected input type.");
+      input_position == 0 || input_position == 1,
+      "Input position must be 0 or 1. Found ",
+      input_position);
   std::vector<IterDomain*> mapping(out_size, nullptr);
   auto inp_size = (int64_t)input_domain.size();
 
   // Input A to matmul: {*, M, K}
   // Input B to matmul: {*, K, N}
-  auto kpos = input_role == MatmulRole::INPUT_A ? inp_size - 1 : inp_size - 2;
+  auto kpos = input_position == 0 ? inp_size - 1 : inp_size - 2;
 
   if (inp_size == 1) {
     // Only reduction axis {K}
@@ -222,16 +223,21 @@ std::vector<IterDomain*> mapMatmulOpIterDomains(
 
 std::vector<IterDomain*> mapLinearOpIterDomains(
     const std::vector<IterDomain*>& input_domain,
-    MatmulRole input_role,
+    int64_t input_position,
     size_t out_size) {
   std::vector<IterDomain*> mapping(out_size, nullptr);
   auto inp_size = input_domain.size();
 
+  NVF_ERROR(
+      input_position == 0 || input_position == 1 || input_position == 2,
+      "Input position must be 0, 1, or 2. Found ",
+      input_position);
+
   // Input A: {*, M, K}
   // Input B: {*, N, K} / {K}
   // Bias: {N} / {}
-  switch (input_role) {
-    case MatmulRole::INPUT_A: {
+  switch (input_position) {
+    case 0: {
       // Linear output is same as input for all but the last dimension
       for (auto inx : c10::irange(inp_size - 1)) {
         mapping[inx] = input_domain[inx];
@@ -239,14 +245,14 @@ std::vector<IterDomain*> mapLinearOpIterDomains(
       mapping[out_size - 1] = input_domain.back();
       break;
     }
-    case MatmulRole::INPUT_B: {
+    case 1: {
       for (auto inx : c10::irange(inp_size)) {
         // Map N, K to the last two positions of the output.
         mapping[out_size - 1 - inx] = input_domain[inp_size - 1 - inx];
       }
       break;
     }
-    case MatmulRole::INPUT_C: {
+    case 2: {
       if (inp_size > 0) {
         // Bias is 1D tensor of shape {out_features}
         mapping[out_size - 2] = input_domain[0];

--- a/csrc/ops/utils.h
+++ b/csrc/ops/utils.h
@@ -52,12 +52,12 @@ IterType promoteIterType(IterType type1, IterType type2);
 // Args:
 // 1. input_domain: root/logical domain without reductions for any input to
 // MatmulOp
-// 2. input_role: Specifies if the input is A / B (MatmulRole::Input_A/Input_B)
+// 2. input_position: Specifies if the input is A / B (0 or 1)
 // 3: out_size: MatmulOp output dimension (input and output may not be the same
 // size).
 std::vector<IterDomain*> mapMatmulOpIterDomains(
     const std::vector<IterDomain*>& input_domain,
-    MatmulRole input_role,
+    int64_t input_position,
     size_t out_size);
 
 // For LinearOp, the output is the same as the first input (A[*,
@@ -67,12 +67,12 @@ std::vector<IterDomain*> mapMatmulOpIterDomains(
 // output. Args:
 // 1. input_domain: root/logical domain without reductions for any input to
 // LinearOp
-// 2. input_role: Specifies if the input is A / B / Bias
+// 2. input_position: Specifies if the input is A / B / Bias (0, 1, or 2)
 // (MatmulRole::Input_A/Input_B/Input_C) 3: out_size: LinearOp output dimension
 // (input and output may not be the same size).
 std::vector<IterDomain*> mapLinearOpIterDomains(
     const std::vector<IterDomain*>& input_domain,
-    MatmulRole input_role,
+    int64_t input_position,
     size_t out_size);
 
 // Takes a vector of aligned input iterdomains to create the output iterdomain.

--- a/csrc/root_domain_map.cpp
+++ b/csrc/root_domain_map.cpp
@@ -182,9 +182,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseRootDomainMap::map(
   // For MatmulOp, use the corresponding mapped input iterdomains.
   if (MatmulOp* op = dynamic_cast<MatmulOp*>(consumer_tv_->definition())) {
     // Check if the producer is lhs/rhs input
-    MatmulRole input_role = producer_tv_->sameAs(op->inA())
-        ? MatmulRole::INPUT_A
-        : MatmulRole::INPUT_B;
+    int64_t input_position = producer_tv_->sameAs(op->inA()) ? 0 : 1;
     auto out_size = consumer_root.size();
 
     // For MatmulOp, the input iterdomains at a given index do not necessarily
@@ -196,7 +194,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseRootDomainMap::map(
     // 2. `B, M, K] x [K, N] -> [B, M, N]`: For  input B, the second iterdomain
     // maps to the third output iterdomain.
     const std::vector<IterDomain*>& aligned_producer_ids =
-        ops::mapMatmulOpIterDomains(producer_logical, input_role, out_size);
+        ops::mapMatmulOpIterDomains(producer_logical, input_position, out_size);
     pairwiseMapAllIds(aligned_producer_ids, consumer_root);
     return dom_map;
   }
@@ -205,26 +203,25 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseRootDomainMap::map(
     auto out_size = consumer_root.size();
 
     // Check if the producer is A, B or bias.
-    std::optional<MatmulRole> input_role = std::nullopt;
+    int64_t input_position = -1;
     if (producer->sameAs(op->inA()->as<TensorView>()->domain())) {
-      input_role = MatmulRole::INPUT_A;
+      input_position = 0;
     } else if (producer->sameAs(op->inB()->as<TensorView>()->domain())) {
-      input_role = MatmulRole::INPUT_B;
+      input_position = 1;
     } else if (producer->sameAs(op->bias()->as<TensorView>()->domain())) {
-      input_role = MatmulRole::INPUT_C;
+      input_position = 2;
     } else {
       NVF_ERROR(false, "Producer did not match any LinearOp input.")
     }
 
     // LinearOp:
-    // inputs (INPUT_A) = {*, in_features}
-    // weight (INPUT_B) = {out_features, in_features} / {in_features}
-    // bias (INPUT_C) = {out_features} / {}
+    // inputs (0) = {*, in_features}
+    // weight (1) = {out_features, in_features} / {in_features}
+    // bias (2) = {out_features} / {}
     // output = {*, out_features} / {*}
 
     const std::vector<IterDomain*>& aligned_producer_ids =
-        ops::mapLinearOpIterDomains(
-            producer_logical, input_role.value(), out_size);
+        ops::mapLinearOpIterDomains(producer_logical, input_position, out_size);
     pairwiseMapAllIds(aligned_producer_ids, consumer_root);
     return dom_map;
   }

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -653,17 +653,17 @@ void scheduleFusionInputsForEpilogue(
     bool with_smem_epilogue) {
   std::vector<TensorView*> cached_tvs;
 
-  // Handling transformations in fusion input tvs with assigned INPUT_C role by
-  //  propagating fusion output transformations through cached views of INPUT_C
-  //  fusion input tvs and by setting vectorization of the inner most iterdomain
-  //  of these cached views
-  if (tensor_roles.count(MatmulRole::INPUT_C)) {
-    auto& c_tvs = tensor_roles.at(MatmulRole::INPUT_C);
+  // Handling transformations in fusion input tvs with assigned EPILOGUE_INPUT
+  //  role by propagating fusion output transformations through cached views of
+  //  EPILOGUE_INPUT fusion input tvs and by setting vectorization of the inner
+  //  most iterdomain of these cached views
+  if (tensor_roles.count(MatmulRole::EPILOGUE_INPUT)) {
+    auto& c_tvs = tensor_roles.at(MatmulRole::EPILOGUE_INPUT);
 
     // The system supports only scenario where there is only one fusion output
-    //  with assigned OUTPUT_D role, this condition is already verified so there
+    //  with assigned OUTPUT role, this condition is already verified so there
     //  is no need for an additional checks here
-    auto output_d = tensor_roles.at(MatmulRole::OUTPUT_D).front();
+    auto output_d = tensor_roles.at(MatmulRole::OUTPUT).front();
     for (auto* c : c_tvs) {
       cached_tvs.push_back(c->cacheAfter());
     }
@@ -684,7 +684,7 @@ void scheduleFusionInputsForEpilogue(
     scheduler_utils::parallelizeAllLike(
         output_d, -1, cached_tvs, parallel_types);
 
-    // The cached INPUT_C tvs are not needed anymore
+    // The cached EPILOGUE_INPUT tvs are not needed anymore
     cached_tvs.clear();
   }
 }
@@ -776,8 +776,11 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   NVF_ERROR(fusion_layout.isValid(), fusion_layout.getErrorMsg());
 
   // Core roles: there can be only one... TV with assigned core role
-  TensorView* a = tensor_roles.at(MatmulRole::INPUT_A).front();
-  TensorView* b = tensor_roles.at(MatmulRole::INPUT_B).front();
+  const std::vector<TensorView*>& operands =
+      tensor_roles.at(MatmulRole::OPERAND);
+  NVF_ERROR(operands.size() == 2, "We currently require exactly two operands");
+  TensorView* a = operands.front();
+  TensorView* b = operands.back();
 
   const auto& gemm_tile = params.tile_sizes;
 
@@ -786,7 +789,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   const bool has_epilogue = !mma->out()->isFusionOutput();
 
   const bool has_fusion_c_roles =
-      (0 != tensor_roles.count(MatmulRole::INPUT_C));
+      (0 != tensor_roles.count(MatmulRole::EPILOGUE_INPUT));
   const bool has_non_mma_input_tvs = has_epilogue && has_fusion_c_roles;
 
   // Including current tensor naming convention for reference,

--- a/csrc/scheduler/matmul_heuristic_plugin.cpp
+++ b/csrc/scheduler/matmul_heuristic_plugin.cpp
@@ -85,11 +85,14 @@ uint8_t layoutToByte(MmaLayout layout) {
 std::string rolesToPrecisionString(
     const mma_utils::TensorRolesMap& tensor_roles) {
   std::string precision = "   ";
-  TensorView* a = tensor_roles.at(MatmulRole::INPUT_A).front();
-  TensorView* b = tensor_roles.at(MatmulRole::INPUT_B).front();
+  const std::vector<TensorView*>& operands =
+      tensor_roles.at(MatmulRole::OPERAND);
+  NVF_ERROR(operands.size() == 2, "We currently require exactly two operands");
+  TensorView* a = operands.front();
+  TensorView* b = operands.back();
   NVF_CHECK(
       a->dtype() == b->dtype(), "Differing A and B dtypes not yet supported");
-  TensorView* d = tensor_roles.at(MatmulRole::OUTPUT_D).front();
+  TensorView* d = tensor_roles.at(MatmulRole::OUTPUT).front();
   precision[0] = mma_utils::dtypeToChar(a->dtype());
   // NOTE: this assumes compute type is Float
   precision[1] = 'S';

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -134,7 +134,7 @@ inline bool initCoreHeuristics(
     }
   }
 
-  const auto& roleMinDtypeSize = [&tensor_roles](MatmulRole role) -> int64_t {
+  const auto roleMinDtypeSize = [&tensor_roles](MatmulRole role) -> int64_t {
     const auto op_it = tensor_roles.find(role);
     NVF_ERROR(op_it != tensor_roles.end());
     int64_t min_size_bytes = 128LL;
@@ -144,9 +144,7 @@ inline bool initCoreHeuristics(
     return min_size_bytes;
   };
   params->async_gmem_load_operands = isCpAsyncOperandLoadSupported(
-      params.get(),
-      roleMinDtypeSize(MatmulRole::INPUT_A),
-      roleMinDtypeSize(MatmulRole::INPUT_B));
+      params.get(), roleMinDtypeSize(MatmulRole::OPERAND));
 
   if (!params->async_gmem_load_operands) {
     // Circular buffering requires async load. If we cannot use async load due
@@ -243,10 +241,10 @@ std::string isMatmulFusionDefinitionSupported(
     // outputs have recognized roles
     std::set<TensorView*> tvs_with_roles;
 
-    for (MatmulRole role : {MatmulRole::INPUT_A, MatmulRole::INPUT_B}) {
-      auto entry = tensor_roles.find(role);
+    {
+      auto entry = tensor_roles.find(MatmulRole::OPERAND);
       if (entry != tensor_roles.end()) {
-        if (MATMUL_CORE_ROLES_EXPECTED_COUNT == entry->second.size()) {
+        if (2 == entry->second.size()) {
           tvs_with_roles.insert(entry->second.begin(), entry->second.end());
           for (TensorView* tv : entry->second) {
             const std::vector<IterDomain*>& logical = tv->getLogicalDomain();
@@ -269,14 +267,14 @@ std::string isMatmulFusionDefinitionSupported(
             }
           }
         } else {
-          return "There is more than a single fusion input that can be MMA operand ";
+          return "There is other than two fusion inputs that can be MMA operands";
         }
       } else {
         return "No candidate in fusion inputs for MMA operand";
       }
     }
 
-    auto entry = tensor_roles.find(MatmulRole::OUTPUT_D);
+    auto entry = tensor_roles.find(MatmulRole::OUTPUT);
     if (entry != tensor_roles.end()) {
       tvs_with_roles.insert(entry->second.begin(), entry->second.end());
     } else {
@@ -284,7 +282,7 @@ std::string isMatmulFusionDefinitionSupported(
     }
 
     // Non-core input roles are optional, no requirements for definitions
-    entry = tensor_roles.find(MatmulRole::INPUT_C);
+    entry = tensor_roles.find(MatmulRole::EPILOGUE_INPUT);
     if (entry != tensor_roles.end()) {
       tvs_with_roles.insert(entry->second.begin(), entry->second.end());
     }
@@ -339,11 +337,8 @@ class VectorizationCalculator {
  private:
   std::vector<int64_t> operandVectorizations() {
     std::vector<int64_t> vec_sizes;
-    for (MatmulRole role : {MatmulRole::INPUT_A, MatmulRole::INPUT_B}) {
-      const auto op_it = tensor_roles_.find(role);
-      if (op_it == tensor_roles_.end()) {
-        continue;
-      }
+    const auto op_it = tensor_roles_.find(MatmulRole::OPERAND);
+    if (op_it != tensor_roles_.end()) {
       for (TensorView* tv : op_it->second) {
         vec_sizes.push_back(operandVectorization(tv));
       }
@@ -604,7 +599,7 @@ class VectorizationCalculator {
           ptrAndDTypeVec(tv), innerDimsVectorization(tv, inner_nonk_dims));
     };
 
-    const auto d_it = tensor_roles_.find(MatmulRole::OUTPUT_D);
+    const auto d_it = tensor_roles_.find(MatmulRole::OUTPUT);
     NVF_ERROR(
         d_it != tensor_roles_.end(), "Could not find any output D tensors");
     int64_t vec_size = 16l;
@@ -615,7 +610,7 @@ class VectorizationCalculator {
       }
       vec_size = std::min(vec_size, v);
     }
-    if (const auto c_it = tensor_roles_.find(MatmulRole::INPUT_C);
+    if (const auto c_it = tensor_roles_.find(MatmulRole::EPILOGUE_INPUT);
         c_it != tensor_roles_.end()) {
       for (TensorView* tv : c_it->second) {
         int64_t v = innerMostVec(tv);
@@ -755,8 +750,7 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
 
 bool isCpAsyncOperandLoadSupported(
     const MatmulParams* params,
-    int64_t dtype_size_a,
-    int64_t dtype_size_b) {
+    int64_t min_dtype_size) {
   if (!isAmpere(params->mma_macro)) {
     return false;
   }
@@ -766,9 +760,13 @@ bool isCpAsyncOperandLoadSupported(
     int64_t cp_bytes = dtype_size * vec_size;
     return cp_bytes == 16 || cp_bytes == 8 || cp_bytes == 4;
   };
+  // TODO: We should compute validCpAsyncVecSize for all the operand
+  // dtype/vec_size pairs and AND them together
   return params->double_buffer_options.smem_double_buffer_stage > 1 &&
-      validCpAsyncVecSize(dtype_size_a, params->supported_vec_size.a) &&
-      validCpAsyncVecSize(dtype_size_b, params->supported_vec_size.b);
+      validCpAsyncVecSize(
+             min_dtype_size,
+             std::min(
+                 params->supported_vec_size.a, params->supported_vec_size.b));
 }
 
 std::shared_ptr<MatmulParams> getMatmulHeuristics(

--- a/csrc/scheduler/matmul_utils.h
+++ b/csrc/scheduler/matmul_utils.h
@@ -40,7 +40,6 @@ std::string getMatmulRunTimeRejectReason(
 //! async_gmem_load_operands.
 bool NVF_API isCpAsyncOperandLoadSupported(
     const MatmulParams* params,
-    int64_t dtype_size_a,
-    int64_t dtype_size_b);
+    int64_t min_dtype_size);
 
 } // namespace nvfuser

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -24,7 +24,7 @@ namespace nvfuser {
 namespace mma_utils {
 
 //! A wrapper to get MMA Tensor data types
-//!   The order of returned types: INPUT_A, INPUT_B, OUTPUT_D
+//!   The order of returned types: A, B, OUTPUT
 inline mma_utils::MmaDataTypes getMmaDataTypes(
     const TensorRolesMap& tensor_roles) {
   auto getMMADataType = [&](MatmulRole role) {
@@ -34,9 +34,14 @@ inline mma_utils::MmaDataTypes getMmaDataTypes(
     }
     NVF_ERROR(false, "Get MMA Tensor data type failed!");
   };
-  const auto a_type = getMMADataType(MatmulRole::INPUT_A);
-  const auto b_type = getMMADataType(MatmulRole::INPUT_B);
-  const auto c_type = getMMADataType(MatmulRole::OUTPUT_D);
+  const auto it = tensor_roles.find(MatmulRole::OPERAND);
+  NVF_ERROR(
+      it != tensor_roles.end(), "Could not find any tensors with role OPERAND");
+  const std::vector<TensorView*>& operands = it->second;
+  NVF_ERROR(operands.size() == 2, "Exactly two operands are expected");
+  const auto a_type = operands.front()->dtype();
+  const auto b_type = operands.back()->dtype();
+  const auto c_type = getMMADataType(MatmulRole::OUTPUT);
   return mma_utils::MmaDataTypes{a_type, b_type, c_type};
 }
 
@@ -182,14 +187,13 @@ std::pair<bool, bool> generateSharedMemoryEpilogueHeuristics(
     const TensorRolesMap& tensor_roles,
     const bool ignore_occupancy_drop) {
   auto data_types = getMmaDataTypes(tensor_roles);
-  // getMmaDataTypes provides the dtypes of INPUT_A, INPUT_B, and OUTPUT_D.
+  // getMmaDataTypes provides the dtypes of A, B, and OUTPUT.
   // These are the problem types that indicate the gmem IO. We use smem to load
-  // INPUT_A and INPUT_B, but instead of OUTPUT_D which is the result of the
-  // epilogue, we store mma_result which is the _input_ to the epilogue. In
-  // cases where the epilogue contains a cast back down to reduced precision, we
-  // will still use Float for the epilogue smem. If we support Double or
-  // Complex in the future then we might need a better way to determine this
-  // data type.
+  // A and B, but instead of OUTPUT which is the result of the epilogue, we
+  // store mma_result which is the _input_ to the epilogue. In cases where the
+  // epilogue contains a cast back down to reduced precision, we will still use
+  // Float for the epilogue smem. If we support Double or Complex in the future
+  // then we might need a better way to determine this data type.
   data_types[2] = DataType::Float;
 
   // smem_a and smem_b are guaranteed to be re-used for smem_c as long as:
@@ -216,8 +220,13 @@ std::pair<bool, bool> generateSharedMemoryEpilogueHeuristics(
   // cases, we check that there is no re-use when there is more than one use of
   // either a or b. If there are multiple uses we might wind up re-using memory,
   // but in that case the calculation below will be overly conservative.
-  TensorView* a = tensor_roles.at(MatmulRole::INPUT_A).front();
-  TensorView* b = tensor_roles.at(MatmulRole::INPUT_B).front();
+  const auto it = tensor_roles.find(MatmulRole::OPERAND);
+  NVF_ERROR(
+      it != tensor_roles.end(), "Could not find any tensors with role OPERAND");
+  const std::vector<TensorView*>& operands = it->second;
+  NVF_ERROR(operands.size() == 2, "Exactly two operands are expected");
+  const TensorView* a = operands.front();
+  const TensorView* b = operands.back();
   bool smem_a_reuse_guaranteed = a->uses().size() == 1;
   bool smem_b_reuse_guaranteed = b->uses().size() == 1;
 
@@ -1146,40 +1155,31 @@ MatmulProblemLayoutOpt getProblemLayout(
   // this complication I'm using an unwrapped variant for the lambda's result
   // type.
   using UnitDimOpt = std::variant<std::string, UnitDim>;
-  const auto findUnitDim = [&tensor_roles, &dim_roles, &permissive_graph](
-                               MatmulRole role) -> UnitDimOpt {
-    const auto role_it = tensor_roles.find(role);
-    if (role_it == tensor_roles.end()) {
-      return "Could not find role in tensor_roles";
+  const auto findUnitDim = [&dim_roles,
+                            &permissive_graph](TensorView* tv) -> UnitDimOpt {
+    IterDomain* inner_id =
+        TensorDomain::noReductions(tv->getMaybeAllocationDomain()).back();
+    const ValGroup& g = permissive_graph.toGroup(inner_id);
+    auto g_it = dim_roles.find(g);
+    if (g_it == dim_roles.end()) {
+      return "Inner domain of tensor was not mapped to a MatmulDomain";
     }
-    std::optional<MatmulDomain> group_inner_dom = std::nullopt;
-    for (TensorView* tv : role_it->second) {
-      IterDomain* inner_id =
-          TensorDomain::noReductions(tv->getMaybeAllocationDomain()).back();
-      const ValGroup& g = permissive_graph.toGroup(inner_id);
-      auto g_it = dim_roles.find(g);
-      if (g_it == dim_roles.end()) {
-        return "Inner domain of tensor was not mapped to a MatmulDomain";
-      }
-      if (!group_inner_dom.has_value()) {
-        group_inner_dom = g_it->second;
-      } else if (group_inner_dom.value() != g_it->second) {
-        return "Group contains multiple inner dimension domains";
-      }
-    }
-    if (!group_inner_dom.has_value()) {
-      return "No tensor found in role";
-    }
-    return group_inner_dom.value() == MatmulDomain::K ? UnitDim::K
-                                                      : UnitDim::M_or_N;
+    return g_it->second == MatmulDomain::K ? UnitDim::K : UnitDim::M_or_N;
   };
+  const auto it = tensor_roles.find(MatmulRole::OPERAND);
+  NVF_ERROR(
+      it != tensor_roles.end(), "Could not find any tensors with role OPERAND");
+  const std::vector<TensorView*>& operands = it->second;
+  NVF_ERROR(operands.size() == 2, "Exactly two operands are expected");
+  TensorView* a = operands.front();
+  TensorView* b = operands.back();
 
-  const UnitDimOpt unitdim_a_opt = findUnitDim(MatmulRole::INPUT_A);
+  const UnitDimOpt unitdim_a_opt = findUnitDim(a);
   if (std::holds_alternative<std::string>(unitdim_a_opt)) {
     std::string err = std::get<std::string>(unitdim_a_opt);
     return err;
   }
-  const UnitDimOpt unitdim_b_opt = findUnitDim(MatmulRole::INPUT_B);
+  const UnitDimOpt unitdim_b_opt = findUnitDim(b);
   if (std::holds_alternative<std::string>(unitdim_b_opt)) {
     std::string err = std::get<std::string>(unitdim_b_opt);
     return err;
@@ -1254,17 +1254,10 @@ TensorRolesMapOpt getTensorRoles(
       // Don't map TVs to roles if they have unmapped dims
       continue;
     }
-    if (has.m && has.k && !has.n) {
-      tensor_roles[MatmulRole::INPUT_A].push_back(tv);
-      continue;
-    }
-    if (has.n && has.k && !has.m) {
-      tensor_roles[MatmulRole::INPUT_B].push_back(tv);
-      continue;
-    }
-    // Bias vectors are assigned to INPUT_C role
-    if (!has.k) {
-      tensor_roles[MatmulRole::INPUT_C].push_back(tv);
+    if (has.k) {
+      tensor_roles[MatmulRole::OPERAND].push_back(tv);
+    } else {
+      tensor_roles[MatmulRole::EPILOGUE_INPUT].push_back(tv);
       continue;
     }
   }
@@ -1290,7 +1283,7 @@ TensorRolesMapOpt getTensorRoles(
   }
 
   if (!storage.empty()) {
-    tensor_roles[MatmulRole::OUTPUT_D] = storage;
+    tensor_roles[MatmulRole::OUTPUT] = storage;
   }
 
   for (auto& [role, tvs] : tensor_roles) {
@@ -1727,9 +1720,9 @@ DimRolesMap MatmulPattern::getDimRoles(IdModel& id_model) const {
         permissive_graph,
         out_logical,
         ops::mapMatmulOpIterDomains(
-            A->getLogicalDomain(), MatmulRole::INPUT_A, out_logical.size()),
+            A->getLogicalDomain(), 0, out_logical.size()),
         ops::mapMatmulOpIterDomains(
-            B->getLogicalDomain(), MatmulRole::INPUT_B, out_logical.size()));
+            B->getLogicalDomain(), 1, out_logical.size()));
 
   } else if (output->definition()->isA<LinearOp>()) {
     const std::vector<IterDomain*>& out_logical = output->getLogicalDomain();
@@ -1737,9 +1730,9 @@ DimRolesMap MatmulPattern::getDimRoles(IdModel& id_model) const {
         permissive_graph,
         out_logical,
         ops::mapLinearOpIterDomains(
-            A->getLogicalDomain(), MatmulRole::INPUT_A, out_logical.size()),
+            A->getLogicalDomain(), 0, out_logical.size()),
         ops::mapLinearOpIterDomains(
-            B->getLogicalDomain(), MatmulRole::INPUT_B, out_logical.size()));
+            B->getLogicalDomain(), 1, out_logical.size()));
   }
 
   // The code below handles MmaOp or mul-sum patterns
@@ -1794,10 +1787,7 @@ std::vector<ValGroup> canonicalDimOrdering(
   // M/N ordering has been determined.
   int64_t n_inside_m = 0;
   for (MatmulRole tv_role :
-       {MatmulRole::OUTPUT_D,
-        MatmulRole::INPUT_A,
-        MatmulRole::INPUT_B,
-        MatmulRole::INPUT_C}) {
+       {MatmulRole::OUTPUT, MatmulRole::OPERAND, MatmulRole::EPILOGUE_INPUT}) {
     const auto it = tensor_roles.find(tv_role);
     if (it == tensor_roles.end()) {
       continue;
@@ -1837,8 +1827,7 @@ std::vector<ValGroup> canonicalDimOrdering(
               break;
             case MatmulDomain::K:
               // Order K dimensions like operands, and all others like outputs
-              if (tv_role == MatmulRole::INPUT_A ||
-                  tv_role == MatmulRole::INPUT_B) {
+              if (tv_role == MatmulRole::OPERAND) {
                 k_dims.pushBack(g);
               }
               break;

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -218,7 +218,7 @@ using DimRolesMap = std::unordered_map<ValGroup, MatmulDomain>;
 using TensorRolesMap = std::unordered_map<MatmulRole, std::vector<TensorView*>>;
 
 //! An alias for storing data types of the tensors in the mma op
-//!  the order is INPUT_A, INPUT_B, OUTPUT_D
+//!  the order is A, B, OUTPUT
 using MmaDataTypes = std::array<DataType, 3>;
 
 //! A wrapper for data containers with optional error message stored if


### PR DESCRIPTION
Also rename `MatmulRole::INPUT_C` to `MatmulRole::EPILOGUE_INPUT` and `MatmulRole::OUTPUT_D` to `MatmulRole::OUTPUT`. This is in preparation for generalizing our scheduler to handle any number of operands and `MatmulPattern`s.

Even when fusing a single `MatmulPattern` we might not have exactly one Fusion input for A or B. We could have zero if we use a factory method to create the operand, or we could have two if we do some pointwise operations in the prologue. I am trying to refactor our code to handle any of these cases gracefully.

Next steps in generalizing the matmul scheduler:

1. Change `MmaLayout` from an enum to a vector of inner allocation dimensions i.e. `std::vector<MatmulDomain>`. After that, the only reference to "A" and "B" will be the inputs to the actual MmaOp.
2. Modify `scheduleMatmul` to schedule all the tensors in `tensor_roles[MatmulRole::OPERAND]` in the same way. This means we will not have separate `acr` and `bcr` tensors, for example.
3. Modify `MatmulParams` and `matmul_heuristic_plugin::KernelConfig` to remove explicit mentions of A and B.
4. Relax assumptions that only two operands exist and remove canSchedule checks so that we accept a sample fusion that uses a factory method to create one or both operands.
5. Enable fusion of multiple MatmulPatterns like the llama2 FFN. By this point we should just need to modify the scheduler to be more careful during propagations, and modify some canSchedule checks.