### PR TITLE
Multidevice Executor add accessor to fusion executor caches

### DIFF
--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -284,7 +284,7 @@ std::vector<FusionExecutorCache*> MultiDeviceExecutor::
       "MultideviceExecutor must be configured to use FusionExecutorCache");
   std::vector<FusionExecutorCache*> fecs;
   for (SegmentedGroup* group : workspace_.group_run_order) {
-    if (!is_resharding_.at(group)) {
+    if (fec_.count(group) > 0) {
       fecs.push_back(&(fec_.at(group)));
     }
   }

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -110,6 +110,12 @@ class MultiDeviceExecutor {
   //! Print to default debugging output stream
   std::ostream& print();
 
+  // Returns a vector of Fusion executor caches that corresponds to
+  // each compute segment in runtime order.This is only valid if the executor
+  // was configured to use FusionExecutorCache. i.e.
+  // params.use_fusion_executor_cache = true
+  std::vector<FusionExecutorCache*> getFusionExecutorCaches();
+
  private:
   // execute locally a SegmentedGroup that does not involve inter-device
   // communication. Launch Params are used only if
@@ -129,7 +135,7 @@ class MultiDeviceExecutor {
   // 2) a Fusion comprised of one Expr, representing inter-device communication
   std::unique_ptr<SegmentedFusion> staged_fusion_;
   // Stores the order in which the pipeline's stage should be executed
-  RuntimeWorkSpace workspace;
+  RuntimeWorkSpace workspace_;
   // Cache Fusions, FusionExecutors, and Communications
   std::unordered_map<SegmentedGroup*, FusionExecutor> fe_;
   std::unordered_map<SegmentedGroup*, FusionExecutorCache> fec_;

--- a/tests/cpp/test_multidevice_matmul.cpp
+++ b/tests/cpp/test_multidevice_matmul.cpp
@@ -122,6 +122,9 @@ TEST_F(DistributedMatmulTest, LayoutTN_NoComms) {
       {expected_output},
       __LINE__,
       __FILE__);
+
+  std::vector<FusionExecutorCache*> fecs = runtime.getFusionExecutorCaches();
+  EXPECT_EQ(fecs.size(), 1);
 }
 
 TEST_F(DistributedMatmulTest, LayoutTN_Allgather) {
@@ -177,6 +180,9 @@ TEST_F(DistributedMatmulTest, LayoutTN_Allgather) {
       {expected_output},
       __LINE__,
       __FILE__);
+
+  std::vector<FusionExecutorCache*> fecs = runtime.getFusionExecutorCaches();
+  EXPECT_EQ(fecs.size(), 1);
 }
 
 TEST_F(DistributedMatmulTest, LayoutNT_AllReduce) {
@@ -228,6 +234,9 @@ TEST_F(DistributedMatmulTest, LayoutNT_AllReduce) {
 
   testValidate(
       runtime.completeFusion(), outputs, inputs, {out}, __LINE__, __FILE__);
+
+  std::vector<FusionExecutorCache*> fecs = runtime.getFusionExecutorCaches();
+  EXPECT_EQ(fecs.size(), 1);
 }
 
 TEST_F(DistributedMatmulTest, LayoutNT_ReduceScatter) {
@@ -292,5 +301,8 @@ TEST_F(DistributedMatmulTest, LayoutNT_ReduceScatter) {
       {expected_output},
       __LINE__,
       __FILE__);
+
+  std::vector<FusionExecutorCache*> fecs = runtime.getFusionExecutorCaches();
+  EXPECT_EQ(fecs.size(), 1);
 }
 } // namespace nvfuser


### PR DESCRIPTION
Add `MultiDeviceExecutor::getFusionExecutorCaches` which returns a vector of pointers to the multidevice executor's fusion executor caches.

Note, Also renames the field `workspace` to `workspace_` to match naming conventions. 

cc @Priya2698 for https://github.com/NVIDIA/Fuser/pull/2386 