### PR TITLE
Change getProblemLayout to getOperandInnerDims

### DIFF
--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -771,9 +771,9 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   NVF_ERROR(tensor_roles_opt.isValid(), tensor_roles_opt.getErrorMsg());
   const auto tensor_roles = tensor_roles_opt.getData();
 
-  const mma_utils::MatmulProblemLayoutOpt fusion_layout =
-      mma_utils::getProblemLayout(id_model, id_roles, tensor_roles);
-  NVF_ERROR(fusion_layout.isValid(), fusion_layout.getErrorMsg());
+  const mma_utils::MatmulOperandInnerDimsOpt inner_dims =
+      mma_utils::getOperandInnerDims(id_model, id_roles, tensor_roles);
+  NVF_ERROR(inner_dims.isValid(), inner_dims.getErrorMsg());
 
   // Core roles: there can be only one... TV with assigned core role
   TensorView* a = tensor_roles.at(MatmulRole::INPUT_A).front();

--- a/csrc/scheduler/matmul_heuristic_plugin.cpp
+++ b/csrc/scheduler/matmul_heuristic_plugin.cpp
@@ -66,20 +66,25 @@ thread_local KernelConfigFactory config_factory = defaultConfigFactory;
 // overridden.
 thread_local bool config_factory_modified = false;
 
-//! Utility to standardize conversion of MmaLayout to uint8_t
-uint8_t layoutToByte(MmaLayout layout) {
-  switch (layout) {
-    case MmaLayout::NN:
-      return 0;
-    case MmaLayout::NT:
-      return 1;
-    case MmaLayout::TN:
-      return 2;
-    case MmaLayout::TT:
-      return 3;
-    default:
-      return 255;
+//! Utility to standardize conversion of inner dimensions to uint8_t
+//! This uses the 2-operand layout format:
+//!   NN: 0
+//!   NT: 1
+//!   TN: 2
+//!   TT: 3
+uint8_t innerDimsToByte(const mma_utils::MatmulOperandInnerDims& inner_dims) {
+  bool A_K_inner = inner_dims.empty() || inner_dims.front() == MatmulDomain::K;
+  bool B_K_inner = inner_dims.empty() || inner_dims.back() == MatmulDomain::K;
+  if (A_K_inner && B_K_inner) {
+    return 0;
+  } else if (A_K_inner && !B_K_inner) {
+    return 1;
+  } else if (!A_K_inner && B_K_inner) {
+    return 2;
+  } else if (!A_K_inner && !B_K_inner) {
+    return 3;
   }
+  return 255; // This should be unreachable
 }
 
 std::string rolesToPrecisionString(
@@ -103,14 +108,14 @@ void fillProblemDescription(
     int64_t n,
     int64_t k,
     int64_t batch_size,
-    MmaLayout layout,
+    const mma_utils::MatmulOperandInnerDims& inner_dims,
     const char* precision) {
   problem.m = (uint32_t)m;
   problem.n = (uint32_t)n;
   problem.k = (uint32_t)k;
   problem.batch_size = (uint32_t)batch_size;
   problem.layout =
-      KernelConfig::ProblemDescription::Layout(layoutToByte(layout));
+      KernelConfig::ProblemDescription::Layout(innerDimsToByte(inner_dims));
   problem.precision = precision;
 }
 
@@ -193,7 +198,7 @@ bool updateMatmulParams(
     int64_t n,
     int64_t k,
     int64_t batch_size,
-    MmaLayout layout,
+    const mma_utils::MatmulOperandInnerDims& inner_dims,
     const mma_utils::TensorRolesMap& tensor_roles) {
   if (!hasPlugin()) {
     return false;
@@ -208,7 +213,7 @@ bool updateMatmulParams(
   // The heuristic must know the input shapes, precision, and layout.
   std::string precision = rolesToPrecisionString(tensor_roles);
   fillProblemDescription(
-      config->problem, m, n, k, batch_size, layout, precision.c_str());
+      config->problem, m, n, k, batch_size, inner_dims, precision.c_str());
 
   // Execute the user-provided heuristic
   config->configure();

--- a/csrc/scheduler/matmul_heuristic_plugin.cpp
+++ b/csrc/scheduler/matmul_heuristic_plugin.cpp
@@ -81,10 +81,9 @@ uint8_t innerDimsToByte(const mma_utils::MatmulOperandInnerDims& inner_dims) {
     return 1;
   } else if (!A_K_inner && B_K_inner) {
     return 2;
-  } else if (!A_K_inner && !B_K_inner) {
+  } else {
     return 3;
   }
-  return 255; // This should be unreachable
 }
 
 std::string rolesToPrecisionString(

--- a/csrc/scheduler/matmul_heuristic_plugin.h
+++ b/csrc/scheduler/matmul_heuristic_plugin.h
@@ -26,15 +26,16 @@ bool hasPlugin();
 
 //! If there is no user-defined plugin (see hasPlugin()) we return false.
 //! Otherwise, we use the plugin to modify the heuristic parameters in place. M,
-//! N, K, layout, and precision must be provided. For convenience, we use
-//! `roles_map` to build the precision string.
+//! N, K, layout (inner allocated dimension roles of each operand), and
+//! precision must be provided. For convenience, we use `roles_map` to build the
+//! precision string.
 bool updateMatmulParams(
     MatmulParams& params,
     int64_t M,
     int64_t N,
     int64_t K,
     int64_t batch_size,
-    MmaLayout layout,
+    const mma_utils::MatmulOperandInnerDims& inner_dims,
     const mma_utils::TensorRolesMap& tensor_roles);
 
 //! Defines the type of the "makeConfig" symbol

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -745,7 +745,7 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
 
   // #5
   const auto input_layout_opt =
-      mma_utils::getProblemLayout(id_model, id_roles, tensor_roles);
+      mma_utils::getOperandInnerDims(id_model, id_roles, tensor_roles);
   if (!input_layout_opt.isValid()) {
     return input_layout_opt.getErrorMsg();
   }
@@ -819,10 +819,11 @@ std::shared_ptr<MatmulParams> getMatmulHeuristics(
       runtime_info);
 
   if (matmul_heuristic_plugin::hasPlugin()) {
-    const mma_utils::MatmulProblemLayoutOpt layout_opt =
-        mma_utils::getProblemLayout(id_model, id_roles, tensor_roles);
-    NVF_ERROR(layout_opt.isValid(), layout_opt.getErrorMsg());
-    const MmaLayout layout = layout_opt.getData();
+    const mma_utils::MatmulOperandInnerDimsOpt inner_dims_opt =
+        mma_utils::getOperandInnerDims(id_model, id_roles, tensor_roles);
+    NVF_ERROR(inner_dims_opt.isValid(), inner_dims_opt.getErrorMsg());
+    const mma_utils::MatmulOperandInnerDims inner_dims =
+        inner_dims_opt.getData();
 
     // Fill in proper values using plugin
     matmul_heuristic_plugin::updateMatmulParams(
@@ -831,7 +832,7 @@ std::shared_ptr<MatmulParams> getMatmulHeuristics(
         problem_shape[(size_t)MatmulDomain::N],
         problem_shape[(size_t)MatmulDomain::K],
         problem_shape[(size_t)MatmulDomain::Batch],
-        layout,
+        inner_dims,
         tensor_roles);
   } else {
     TORCH_WARN_ONCE(

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -282,7 +282,10 @@ struct MatmulPattern {
 //! Traverse the fusion to find supported matmul patterns
 std::vector<MatmulPattern> findMatmulPatterns(Fusion* fusion);
 
-using MatmulProblemLayoutOpt = DataWrapperOpt<MmaLayout>;
+//! This is a vector of roles describing the inner dimension of each operand
+using MatmulOperandInnerDims = std::vector<MatmulDomain>;
+
+using MatmulOperandInnerDimsOpt = DataWrapperOpt<MatmulOperandInnerDims>;
 using ProblemIterDomainsOpt = DataWrapperOpt<ProblemIterDomains>;
 using DimRolesMapOpt = DataWrapperOpt<DimRolesMap>;
 using TensorRolesMapOpt = DataWrapperOpt<TensorRolesMap>;
@@ -290,8 +293,8 @@ using TensorRolesMapOpt = DataWrapperOpt<TensorRolesMap>;
 using DomainsDesc = std::vector<MatmulDomain>;
 using DependenciesMap = std::map<TensorView*, DomainsDesc>;
 
-//! Returns wrapped matmul input layout data, if supported, otherwise returned
-//!  object contains a message with failure root cause.
+//! Returns wrapped matmul input memory layout data, if supported, otherwise
+//! returned object contains a message with failure root cause.
 //!
 //! Matmul layout depends only on fusion definition while mma layout relies on
 //!  HW implementation to handle input layout from fusion definition. Detailed
@@ -303,14 +306,14 @@ using DependenciesMap = std::map<TensorView*, DomainsDesc>;
 //!  transposition of inputs in mma instructions, while other (e.g. Turing,
 //!  Ampere) the only supported transposition is TN which means that mma
 //!  instruction first input is transposed, the second input is non-transposed.
-NVF_API MatmulProblemLayoutOpt getProblemLayout(
+NVF_API MatmulOperandInnerDimsOpt getOperandInnerDims(
     const IdModel& id_model,
     const DimRolesMap& dim_roles,
     const TensorRolesMap& tensor_roles);
 
 //! This version assumes the Fusion contains a single MatmulPattern, then builds
 //! an IdModel and infers dim roles then calls the above function.
-NVF_API MatmulProblemLayoutOpt getProblemLayout(Fusion* fusion);
+NVF_API MatmulOperandInnerDimsOpt getOperandInnerDims(Fusion* fusion);
 
 //! Returns wrapped collection of TensorView roles in fusion.
 //!  An error message is stored in retruned object if valid data cannot

--- a/tests/cpp/test_gpu_tensorcore.cpp
+++ b/tests/cpp/test_gpu_tensorcore.cpp
@@ -3149,16 +3149,13 @@ TEST_F(GPUTTensorCoreTest, MisalignedVectorization) {
 
           fusion->addOutput(tv2);
 
-          const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+          const MmaLayout fusion_layout = getMatmulProblemLayout(fusion.get());
           NVF_CHECK(
-              fusion_layout.isValid(),
-              "failed to get decide matmul layout through fusion definition");
-          NVF_CHECK(
-              fusion_layout.getData() == layout,
+              fusion_layout == layout,
               "mismatch between test layout (",
               toString(layout),
               ") and layout inferred from fusion definition (",
-              toString(fusion_layout.getData()),
+              toString(fusion_layout),
               ")");
 
           // determine supported vectorization of an ATen tensor that will be

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -172,16 +172,13 @@ TEST_P(PrecisionParametrizedTest, EpilogueBias) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -266,16 +263,13 @@ TEST_P(PrecisionParametrizedTest, EpilogueRelu) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -366,16 +360,13 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasRelu) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -462,16 +453,13 @@ TEST_P(PrecisionParametrizedTest, EpilogueReluAux) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -570,16 +558,13 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasReluAux) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -666,16 +651,13 @@ TEST_P(PrecisionParametrizedTest, EpilogueGelu) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -755,16 +737,13 @@ TEST_P(PrecisionParametrizedTest, EpilogueGeluAux) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -857,16 +836,13 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasGelu) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -967,16 +943,13 @@ TEST_P(PrecisionParametrizedTest, EpilogueBiasGeluAux) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -1084,16 +1057,13 @@ TEST_F(MatmulSchedulerTest, BasicMatmulStrictCheckTT) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K);
@@ -1134,16 +1104,13 @@ TEST_F(MatmulSchedulerTest, BasicMatmulRelaxedCheck) {
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
     NVF_CHECK(
-        fusion_layout.isValid(),
-        "failed to get decide matmul layout through fusion definition");
-    NVF_CHECK(
-        fusion_layout.getData() == layout,
+        fusion_layout == layout,
         "mismatch between test layout (",
         toString(layout),
         ") and layout inferred from fusion definition (",
-        toString(fusion_layout.getData()),
+        toString(fusion_layout),
         ")");
 
     auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K);
@@ -1186,16 +1153,13 @@ TEST_F(MatmulSchedulerTest, BasicMatmulInputShuffledTT) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K);
@@ -1236,16 +1200,13 @@ TEST_F(MatmulSchedulerTest, EpilogueOutputCast) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -1292,16 +1253,13 @@ TEST_F(MatmulSchedulerTest, EpilogueAlpha) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -1350,16 +1308,13 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaOutputCast) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -1417,16 +1372,13 @@ TEST_F(MatmulSchedulerTest, EpilogueBeta) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -1492,16 +1444,13 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBeta) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -1573,16 +1522,13 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaGeluOutputCast) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -1658,16 +1604,13 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias) {
       1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
       "matmul fusion must have at least one MmaOp");
 
-  const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
   NVF_CHECK(
-      fusion_layout.isValid(),
-      "failed to get decide matmul layout through fusion definition");
-  NVF_CHECK(
-      fusion_layout.getData() == layout,
+      fusion_layout == layout,
       "mismatch between test layout (",
       toString(layout),
       ") and layout inferred from fusion definition (",
-      toString(fusion_layout.getData()),
+      toString(fusion_layout),
       ")");
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -1728,16 +1671,13 @@ TEST_F(MatmulSchedulerTest, StridedBatch) {
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
     NVF_CHECK(
-        fusion_layout.isValid(),
-        "failed to get decide matmul layout through fusion definition");
-    NVF_CHECK(
-        fusion_layout.getData() == layout,
+        fusion_layout == layout,
         "mismatch between test layout (",
         toString(layout),
         ") and layout inferred from fusion definition (",
-        toString(fusion_layout.getData()),
+        toString(fusion_layout),
         ")");
 
     FusionExecutorCache executor_cache(std::move(fusion));
@@ -1801,16 +1741,13 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta) {
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
     NVF_CHECK(
-        fusion_layout.isValid(),
-        "failed to get decide matmul layout through fusion definition");
-    NVF_CHECK(
-        fusion_layout.getData() == layout,
+        fusion_layout == layout,
         "mismatch between test layout (",
         toString(layout),
         ") and layout inferred from fusion definition (",
-        toString(fusion_layout.getData()),
+        toString(fusion_layout),
         ")");
 
     FusionExecutorCache executor_cache(std::move(fusion));
@@ -1887,16 +1824,13 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta) {
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
     NVF_CHECK(
-        fusion_layout.isValid(),
-        "failed to get decide matmul layout through fusion definition");
-    NVF_CHECK(
-        fusion_layout.getData() == layout,
+        fusion_layout == layout,
         "mismatch between test layout (",
         toString(layout),
         ") and layout inferred from fusion definition (",
-        toString(fusion_layout.getData()),
+        toString(fusion_layout),
         ")");
 
     FusionExecutorCache executor_cache(std::move(fusion));
@@ -1961,16 +1895,13 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueBias) {
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
     NVF_CHECK(
-        fusion_layout.isValid(),
-        "failed to get decide matmul layout through fusion definition");
-    NVF_CHECK(
-        fusion_layout.getData() == layout,
+        fusion_layout == layout,
         "mismatch between test layout (",
         toString(layout),
         ") and layout inferred from fusion definition (",
-        toString(fusion_layout.getData()),
+        toString(fusion_layout),
         ")");
 
     FusionExecutorCache executor_cache(std::move(fusion));
@@ -2028,16 +1959,13 @@ TEST_F(MatmulSchedulerTest, StridedBatchEpilogueSingleBias) {
         1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
         "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
     NVF_CHECK(
-        fusion_layout.isValid(),
-        "failed to get decide matmul layout through fusion definition");
-    NVF_CHECK(
-        fusion_layout.getData() == layout,
+        fusion_layout == layout,
         "mismatch between test layout (",
         toString(layout),
         ") and layout inferred from fusion definition (",
-        toString(fusion_layout.getData()),
+        toString(fusion_layout),
         ")");
 
     FusionExecutorCache executor_cache(std::move(fusion));
@@ -2097,17 +2025,13 @@ TEST_F(MatmulSchedulerTest, MisalignedVectorization) {
 
         fusion->addOutput(tv2);
 
-        const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+        const auto fusion_layout = getMatmulProblemLayout(fusion.get());
         NVF_CHECK(
-            fusion_layout.isValid(),
-            "failed to get decide matmul layout through fusion definition. Error: ",
-            fusion_layout.getErrorMsg());
-        NVF_CHECK(
-            fusion_layout.getData() == layout,
+            fusion_layout == layout,
             "mismatch between test layout (",
             toString(layout),
             ") and layout inferred from fusion definition (",
-            toString(fusion_layout.getData()),
+            toString(fusion_layout),
             ")");
 
         FusionExecutorCache executor_cache(std::move(fusion));
@@ -2287,16 +2211,13 @@ TEST_F(MatmulSchedulerTest, StridedInputs) {
 
           fusion->addOutput(tv2);
 
-          const auto fusion_layout = mma_utils::getProblemLayout(fusion.get());
+          const auto fusion_layout = getMatmulProblemLayout(fusion.get());
           NVF_CHECK(
-              fusion_layout.isValid(),
-              "failed to get decide matmul layout through fusion definition");
-          NVF_CHECK(
-              fusion_layout.getData() == layout,
+              fusion_layout == layout,
               "mismatch between test layout (",
               toString(layout),
               ") and layout inferred from fusion definition (",
-              toString(fusion_layout.getData()),
+              toString(fusion_layout),
               ")");
 
           FusionExecutorCache executor_cache(std::move(fusion));

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -8,6 +8,7 @@
 #include <tests/cpp/utils.h>
 
 #include <ops/all_ops.h>
+#include <scheduler/mma_utils.h>
 
 #include <regex>
 #include <sstream>
@@ -758,5 +759,32 @@ bool checkMapped(const ValGraph& vg, IterDomain* x, IterDomain* y) {
   const ValGroup& gy = vg.toGroup(y);
   return gx.get() == gy.get();
 };
+
+MmaLayout getMatmulProblemLayout(Fusion* fusion) {
+  const mma_utils::MatmulOperandInnerDimsOpt inner_dims_opt =
+      mma_utils::getOperandInnerDims(fusion);
+
+  NVF_ERROR(
+      inner_dims_opt.isValid(),
+      "Could not get operand inner dims: ",
+      inner_dims_opt.getErrorMsg());
+
+  const mma_utils::MatmulOperandInnerDims inner_dims = inner_dims_opt.getData();
+
+  NVF_ERROR(inner_dims.size() == 2, "Found other than two operands");
+
+  const bool A_K_inner = inner_dims.front() == MatmulDomain::K;
+  const bool B_K_inner = inner_dims.back() == MatmulDomain::K;
+
+  if (A_K_inner && B_K_inner) {
+    return MmaLayout::TN;
+  } else if (A_K_inner && !B_K_inner) {
+    return MmaLayout::TT;
+  } else if (!A_K_inner && B_K_inner) {
+    return MmaLayout::NT;
+  } else {
+    return MmaLayout::NN;
+  }
+}
 
 } // namespace nvfuser

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -781,9 +781,9 @@ MmaLayout getMatmulProblemLayout(Fusion* fusion) {
   } else if (A_K_inner && !B_K_inner) {
     return MmaLayout::TT;
   } else if (!A_K_inner && B_K_inner) {
-    return MmaLayout::NT;
-  } else {
     return MmaLayout::NN;
+  } else {
+    return MmaLayout::NT;
   }
 }
 

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -686,4 +686,9 @@ int64_t getNumSMs();
 
 bool checkMapped(const ValGraph& vg, IterDomain* x, IterDomain* y);
 
+// This uses mma_utils::getOperandInnerDims(fusion) to get the inner allocation
+// dimensions of fusion operands and translate that into one of the MmaOp
+// layouts TT, TN, NT, or NN.
+MmaLayout getMatmulProblemLayout(Fusion* fusion);
+
 } // namespace nvfuser


### PR DESCRIPTION
This is related to #2419 which is working toward generalizing our scheduler to handle any number of operands instead of exactly 2.

In order to keep the change small, I introduced a `MmaLayout getMatmulProblemLayout(Fusion*)` utility in `tests/cpp/utils.cpp`. This should give the same result that `mma_utils::getProblemLayout(fusion)` used to give, but asserting instead of wrapping in a `DataWrapperOpt`, so we don't need to change our supported layouts much. For new code, we could change to support vectors of inner dimension roles instead.

After this PR, `MmaLayout` should only be used in these places
- In `MmaOpUtils::getInputLayout` which finds the layout of the actual inputs to the `MmaOp` (not the Fusion inputs). This is the correct location to use `MmaLayout` since `MmaOp` supports a single A operand and a single B operand.
- In C++ matmul tests, which still use `MmaLayout` to describe the problem layout.
- In C++ matmul benchmarks, which similarly use `MmaLayout`.