### PR TITLE
Allocation domain inference patch mma like op

### DIFF
--- a/csrc/preseg_passes/allocation_order_inference.cpp
+++ b/csrc/preseg_passes/allocation_order_inference.cpp
@@ -300,7 +300,15 @@ void AllocationDomainPass::runPass(Fusion* fusion) {
   std::vector<TensorView*> srcs(input_tvs.begin(), input_tvs.end());
   // mark output TensorViews as propagation destinations
   auto output_tvs = ir_utils::filterByType<TensorView>(fusion->outputs());
-  std::vector<TensorView*> dsts(output_tvs.begin(), output_tvs.end());
+  std::vector<TensorView*> dsts();
+  dsts.reserve(output_tvs.size());
+  for (TensorView* output : output_tvs) {
+    if (output->isDefinitionType<LinearOp>() || output->isDefinitionType<MatmulOp>() ||
+    output->isDefinitionType<MmaOp>()) {
+      continue;
+    }
+    dsts.push_back(output);
+  }
   // propagate allocation domain from sources to destinations
   inferenceAllocationOrder(fusion, srcs, dsts);
 }

--- a/csrc/preseg_passes/allocation_order_inference.cpp
+++ b/csrc/preseg_passes/allocation_order_inference.cpp
@@ -307,7 +307,7 @@ void AllocationDomainPass::runPass(Fusion* fusion) {
   // rather than a semantic requirement coming from computation definition.
   // Scheduler/segmenter would be able to coordinate and discard optimization
   // hint, but they should respect semantic requirement.
-  // see issue: https://github.com/NVIDIA/Fuser/pull/2426
+  // see issue: https://github.com/NVIDIA/Fuser/pull/2425
   for (TensorView* output : output_tvs) {
     if (output->isDefinitionType<LinearOp>() ||
         output->isDefinitionType<MatmulOp>() ||

--- a/csrc/preseg_passes/allocation_order_inference.cpp
+++ b/csrc/preseg_passes/allocation_order_inference.cpp
@@ -303,8 +303,9 @@ void AllocationDomainPass::runPass(Fusion* fusion) {
   std::vector<TensorView*> dsts();
   dsts.reserve(output_tvs.size());
   for (TensorView* output : output_tvs) {
-    if (output->isDefinitionType<LinearOp>() || output->isDefinitionType<MatmulOp>() ||
-    output->isDefinitionType<MmaOp>()) {
+    if (output->isDefinitionType<LinearOp>() ||
+        output->isDefinitionType<MatmulOp>() ||
+        output->isDefinitionType<MmaOp>()) {
       continue;
     }
     dsts.push_back(output);

--- a/csrc/preseg_passes/allocation_order_inference.cpp
+++ b/csrc/preseg_passes/allocation_order_inference.cpp
@@ -300,7 +300,7 @@ void AllocationDomainPass::runPass(Fusion* fusion) {
   std::vector<TensorView*> srcs(input_tvs.begin(), input_tvs.end());
   // mark output TensorViews as propagation destinations
   auto output_tvs = ir_utils::filterByType<TensorView>(fusion->outputs());
-  std::vector<TensorView*> dsts();
+  std::vector<TensorView*> dsts;
   dsts.reserve(output_tvs.size());
   for (TensorView* output : output_tvs) {
     if (output->isDefinitionType<LinearOp>() ||

--- a/csrc/preseg_passes/allocation_order_inference.cpp
+++ b/csrc/preseg_passes/allocation_order_inference.cpp
@@ -302,6 +302,12 @@ void AllocationDomainPass::runPass(Fusion* fusion) {
   auto output_tvs = ir_utils::filterByType<TensorView>(fusion->outputs());
   std::vector<TensorView*> dsts;
   dsts.reserve(output_tvs.size());
+  // TODO: instead of exclusion to propagation, this pass should mark it clear
+  // that the propagated allocation order is strictly an optimization hint,
+  // rather than a semantic requirement coming from computation definition.
+  // Scheduler/segmenter would be able to coordinate and discard optimization
+  // hint, but they should respect semantic requirement.
+  // see issue: https://github.com/NVIDIA/Fuser/pull/2426
   for (TensorView* output : output_tvs) {
     if (output->isDefinitionType<LinearOp>() ||
         output->isDefinitionType<MatmulOp>() ||

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -4230,7 +4230,7 @@ class TestNvFuserFrontend(TestCase):
             fd.add_output(T4)
 
         with FusionDefinition() as fd:
-                fusion_fn(fd)
+            fusion_func(fd)
 
         inputs = [
             torch.randn((8, 4), dtype=torch.float32, device='cuda:0'),

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -4234,7 +4234,7 @@ class TestNvFuserFrontend(TestCase):
 
         inputs = [
             torch.randn((8, 4), dtype=torch.float32, device='cuda:0'),
-            torch.randn((6, 2, 8,), dtype=torch.float32, device='cuda:0')
+            torch.randn((6, 2, 4,), dtype=torch.float32, device='cuda:0')
         ]
 
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -4221,8 +4221,20 @@ class TestNvFuserFrontend(TestCase):
 
     def test_matmul_issue_2354(self):
         def fusion_func(fd: FusionDefinition):
-            T0 = fd.define_tensor(shape=[-1, -1], contiguity=[True, True], dtype=DataType.Float, is_cpu=False, stride_order=[1, 0])
-            T1 = fd.define_tensor(shape=[-1, -1, -1], contiguity=[True, True, True], dtype=DataType.Float, is_cpu=False, stride_order=[2, 1, 0])
+            T0 = fd.define_tensor(
+                shape=[-1, -1],
+                contiguity=[True, True],
+                dtype=DataType.Float,
+                is_cpu=False,
+                stride_order=[1, 0],
+            )
+            T1 = fd.define_tensor(
+                shape=[-1, -1, -1],
+                contiguity=[True, True, True],
+                dtype=DataType.Float,
+                is_cpu=False,
+                stride_order=[2, 1, 0],
+            )
             T2 = fd.ops.linear(T1, T0)
             S3 = fd.define_scalar(1.41421, dtype=DataType.Double)
             T4 = fd.ops.mul(T2, S3)
@@ -4233,8 +4245,16 @@ class TestNvFuserFrontend(TestCase):
             fusion_func(fd)
 
         inputs = [
-            torch.randn((8, 4), dtype=torch.float32, device='cuda:0'),
-            torch.randn((6, 2, 4,), dtype=torch.float32, device='cuda:0')
+            torch.randn((8, 4), dtype=torch.float32, device="cuda:0"),
+            torch.randn(
+                (
+                    6,
+                    2,
+                    4,
+                ),
+                dtype=torch.float32,
+                device="cuda:0",
+            ),
         ]
 
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -4220,6 +4220,19 @@ class TestNvFuserFrontend(TestCase):
                 ), f"At least three entries match in {output}"
 
     def test_matmul_issue_2354(self):
+        inputs = [
+            torch.randn((8, 4), dtype=torch.float32, device="cuda:0"),
+            torch.randn(
+                (
+                    6,
+                    2,
+                    4,
+                ),
+                dtype=torch.float32,
+                device="cuda:0",
+            ),
+        ]
+
         def fusion_func(fd: FusionDefinition):
             T0 = fd.define_tensor(
                 shape=[-1, -1],
@@ -4240,22 +4253,6 @@ class TestNvFuserFrontend(TestCase):
             T4 = fd.ops.mul(T2, S3)
             fd.add_output(T2)
             fd.add_output(T4)
-
-        with FusionDefinition() as fd:
-            fusion_func(fd)
-
-        inputs = [
-            torch.randn((8, 4), dtype=torch.float32, device="cuda:0"),
-            torch.randn(
-                (
-                    6,
-                    2,
-                    4,
-                ),
-                dtype=torch.float32,
-                device="cuda:0",
-            ),
-        ]
 
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
 

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -4220,7 +4220,7 @@ class TestNvFuserFrontend(TestCase):
                 ), f"At least three entries match in {output}"
 
     def test_matmul_issue_2354(self):
-        def fusion_fn(fd: FusionDefinition):
+        def fusion_func(fd: FusionDefinition):
             T0 = fd.define_tensor(shape=[-1, -1], contiguity=[True, True], dtype=DataType.Float, is_cpu=False, stride_order=[1, 0])
             T1 = fd.define_tensor(shape=[-1, -1, -1], contiguity=[True, True, True], dtype=DataType.Float, is_cpu=False, stride_order=[2, 1, 0])
             T2 = fd.ops.linear(T1, T0)


### PR DESCRIPTION
Fixes #2354 

Disables allocation order inference propagation for matmul/mma/linear.