### PR TITLE
s/gmock_main/gmock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,7 +571,7 @@ function(add_test TEST_NAME TEST_SRC ADDITIONAL_LINK)
     codegen_internal
     ${ADDITIONAL_LINK}
     dynamic_type
-    GTest::gtest_main GTest::gmock_main
+    GTest::gtest_main GTest::gmock
     flatbuffers
     ${TORCH_LIBRARIES}
   )


### PR DESCRIPTION
I'm surprised that gmock_main even worked. The `main` definition in gmock_main and gtest_main can conflict.