### PR TITLE
Update batch size for nightly/weekly runs

### DIFF
--- a/benchmarks/python/global_params.py
+++ b/benchmarks/python/global_params.py
@@ -55,12 +55,8 @@ def generate_input_sizes(dims: Union[int, List] = 2) -> List[Tuple]:
     """
     The weekly vs nightly input ranges only differ for 2D inputs currently.
     Nightly input range:
-        Batch size: [16->16384] Hidden size: [768, 4*18432] (step size = 256)
+        Batch size: [16, 512, 2048, 8192, 16384] Hidden size: [768, 4*18432] (step size = 256)
     Weekly input range:
-        Batch size:
-            [16]: Latency bound state
-            [512, 1024]: Just filled the machine
-            [16384]: Steady state (full machine)
         Hidden size: Additonally benchmark hidden sizes at
             [step_size + 2, step_size + 4, step_size + 8, step_size + 16] to check vectorization.
     Note: The hidden size is restricted to 2 * 18432 for the batch size 16384 to avoid OOM.
@@ -74,11 +70,7 @@ def generate_input_sizes(dims: Union[int, List] = 2) -> List[Tuple]:
             input_ranges = []
 
             step_size = 256
-            # max_batch_range: set according to max size that fits in GPU memory
-            batch_range = [2**i for i in range(4, 14)]  # {16, 8192}
-
-            if BENCHMARK_MODE == "weekly":
-                batch_range = [16, 512, 1024]
+            batch_range = [16, 512, 2048, 8192]
 
             # max_hidden_size = 4 * d_model_max (max hidden size in feedforward layers)
             # NOTE: (This is not applicable to the updated implementation but leaving it here for future updates).


### PR DESCRIPTION
This PR updates the batch size to be the same for nightly/weekly runs.
This will allow us to plot S-curves for the nightly results using the torch baselines from the previous weekly run.
We use `batch size = [16, 512, 2048, 8192, 16384]`