### PR TITLE
Split MatmulRole::OPERAND into OPERAND_{A,B}

### DIFF
--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -29,13 +29,14 @@ constexpr std::string_view MATMUL_LOG_PREFIX = "[MATMUL DEBUG] ";
 enum class MatmulDomain { M = 0, N, K, Batch };
 
 //! Named descriptors of TensorView roles in fusion
-//!  OPERAND - an input to the fusion that is a producer of a matmul input
+//!  OPERAND_A - an input to the fusion that is a producer of a matmul "A" input
+//!  OPERAND_B - an input to the fusion that is a producer of a matmul "B" input
 //!  OUTPUT - fusion outputs that have the matmul as a dependency
 //!  EPILOGUE_INPUT - an input to the fusion that is a producer of an
 //!    OUTPUT, but not of an MMA input
 //!
 //!  Note: bias vector tensors will be assigned to the EPILOGUE_INPUT role.
-enum class MatmulRole { OPERAND = 0, OUTPUT, EPILOGUE_INPUT };
+enum class MatmulRole { OPERAND_A = 0, OPERAND_B, OUTPUT, EPILOGUE_INPUT };
 
 //! The expected number of occurances of core TensorView roles in fusion
 static constexpr size_t MATMUL_CORE_ROLES_EXPECTED_COUNT = 1;

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -776,11 +776,16 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   NVF_ERROR(inner_dims.isValid(), inner_dims.getErrorMsg());
 
   // Core roles: there can be only one... TV with assigned core role
-  const std::vector<TensorView*>& operands =
-      tensor_roles.at(MatmulRole::OPERAND);
-  NVF_ERROR(operands.size() == 2, "We currently require exactly two operands");
-  TensorView* a = operands.front();
-  TensorView* b = operands.back();
+  const std::vector<TensorView*>& a_operands =
+      tensor_roles.at(MatmulRole::OPERAND_A);
+  NVF_ERROR(
+      a_operands.size() == 1, "We currently require exactly one A operand");
+  TensorView* a = a_operands.front();
+  const std::vector<TensorView*>& b_operands =
+      tensor_roles.at(MatmulRole::OPERAND_B);
+  NVF_ERROR(
+      b_operands.size() == 1, "We currently require exactly one B operand");
+  TensorView* b = b_operands.back();
 
   const auto& gemm_tile = params.tile_sizes;
 

--- a/csrc/scheduler/matmul_heuristic_plugin.cpp
+++ b/csrc/scheduler/matmul_heuristic_plugin.cpp
@@ -89,11 +89,16 @@ uint8_t innerDimsToByte(const mma_utils::MatmulOperandInnerDims& inner_dims) {
 std::string rolesToPrecisionString(
     const mma_utils::TensorRolesMap& tensor_roles) {
   std::string precision = "   ";
-  const std::vector<TensorView*>& operands =
-      tensor_roles.at(MatmulRole::OPERAND);
-  NVF_ERROR(operands.size() == 2, "We currently require exactly two operands");
-  TensorView* a = operands.front();
-  TensorView* b = operands.back();
+  const std::vector<TensorView*>& a_operands =
+      tensor_roles.at(MatmulRole::OPERAND_A);
+  NVF_ERROR(
+      a_operands.size() == 1, "We currently require exactly one A operand");
+  const std::vector<TensorView*>& b_operands =
+      tensor_roles.at(MatmulRole::OPERAND_B);
+  NVF_ERROR(
+      b_operands.size() == 1, "We currently require exactly one B operand");
+  TensorView* a = a_operands.front();
+  TensorView* b = b_operands.front();
   NVF_CHECK(
       a->dtype() == b->dtype(), "Differing A and B dtypes not yet supported");
   TensorView* d = tensor_roles.at(MatmulRole::OUTPUT).front();

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -144,7 +144,10 @@ inline bool initCoreHeuristics(
     return min_size_bytes;
   };
   params->async_gmem_load_operands = isCpAsyncOperandLoadSupported(
-      params.get(), roleMinDtypeSize(MatmulRole::OPERAND));
+      params.get(),
+      std::min(
+          roleMinDtypeSize(MatmulRole::OPERAND_A),
+          roleMinDtypeSize(MatmulRole::OPERAND_B)));
 
   if (!params->async_gmem_load_operands) {
     // Circular buffering requires async load. If we cannot use async load due
@@ -242,35 +245,37 @@ std::string isMatmulFusionDefinitionSupported(
     std::set<TensorView*> tvs_with_roles;
 
     {
-      auto entry = tensor_roles.find(MatmulRole::OPERAND);
-      if (entry != tensor_roles.end()) {
-        if (2 == entry->second.size()) {
-          tvs_with_roles.insert(entry->second.begin(), entry->second.end());
-          for (TensorView* tv : entry->second) {
-            const std::vector<IterDomain*>& logical = tv->getLogicalDomain();
-            int64_t ndims = (int64_t)std::count_if(
-                logical.begin(), logical.end(), [](IterDomain* id) {
-                  return !id->isReduction() && !id->isDeviceDim();
-                });
-            if (operand_dim == -1) {
-              operand_dim = ndims;
-            } else if (ndims != operand_dim) {
-              // We cannot always handle differently sized inputs, such as those
-              // we encounter when translating MatmulOp and LinearOp. This is
-              // because in those cases one of the operands will have new
-              // Broadcast dimensions where the other operand has Iteration
-              // batch dimensions, meaning these new dims are actually M or N
-              // dimensions. Multiple M and N dimension support is planned but
-              // for now we must reject these patterns before attempting to
-              // translate them.
-              return "All operands must have the same no-devices dimension.";
+      for (MatmulRole role : {MatmulRole::OPERAND_A, MatmulRole::OPERAND_B}) {
+        auto entry = tensor_roles.find(role);
+        if (entry != tensor_roles.end()) {
+          if (1 == entry->second.size()) {
+            tvs_with_roles.insert(entry->second.begin(), entry->second.end());
+            for (TensorView* tv : entry->second) {
+              const std::vector<IterDomain*>& logical = tv->getLogicalDomain();
+              int64_t ndims = (int64_t)std::count_if(
+                  logical.begin(), logical.end(), [](IterDomain* id) {
+                    return !id->isReduction() && !id->isDeviceDim();
+                  });
+              if (operand_dim == -1) {
+                operand_dim = ndims;
+              } else if (ndims != operand_dim) {
+                // We cannot always handle differently sized inputs, such as
+                // those we encounter when translating MatmulOp and LinearOp.
+                // This is because in those cases one of the operands will have
+                // new Broadcast dimensions where the other operand has
+                // Iteration batch dimensions, meaning these new dims are
+                // actually M or N dimensions. Multiple M and N dimension
+                // support is planned but for now we must reject these patterns
+                // before attempting to translate them.
+                return "All operands must have the same no-devices dimension.";
+              }
             }
+          } else {
+            return "There is other than one fusion input that can be MMA operand";
           }
         } else {
-          return "There is other than two fusion inputs that can be MMA operands";
+          return "No candidate in fusion inputs for MMA operand";
         }
-      } else {
-        return "No candidate in fusion inputs for MMA operand";
       }
     }
 
@@ -294,7 +299,8 @@ std::string isMatmulFusionDefinitionSupported(
     }
   }
 
-  // Check that no non-trivial allocation domains are set on inputs or outputs.
+  // Check that no non-trivial allocation domains are set on inputs or
+  // outputs.
   // TODO: Lift this requirement once we have proper allocation domain support
   for (Val* inp : fusion->inputs()) {
     if (auto tv = dynamic_cast<TensorView*>(inp);
@@ -329,15 +335,19 @@ class VectorizationCalculator {
             permissive_graph_)) {}
 
   MatmulParams::SupportedVectorization compute() {
-    const std::vector<int64_t> op_vecs = operandVectorizations();
-    NVF_ERROR(op_vecs.size() == 2, "Expected exactly two operands");
-    return {op_vecs[0], op_vecs[1], epilogueVectorization()};
+    const std::vector<int64_t> a_vecs =
+        operandVectorizations(MatmulRole::OPERAND_A);
+    NVF_ERROR(a_vecs.size() == 1, "Expected exactly one A operand");
+    const std::vector<int64_t> b_vecs =
+        operandVectorizations(MatmulRole::OPERAND_B);
+    NVF_ERROR(b_vecs.size() == 1, "Expected exactly one B operand");
+    return {a_vecs[0], b_vecs[0], epilogueVectorization()};
   }
 
  private:
-  std::vector<int64_t> operandVectorizations() {
+  std::vector<int64_t> operandVectorizations(MatmulRole role) {
     std::vector<int64_t> vec_sizes;
-    const auto op_it = tensor_roles_.find(MatmulRole::OPERAND);
+    const auto op_it = tensor_roles_.find(role);
     if (op_it != tensor_roles_.end()) {
       for (TensorView* tv : op_it->second) {
         vec_sizes.push_back(operandVectorization(tv));
@@ -354,10 +364,10 @@ class VectorizationCalculator {
   }
 
   int64_t ptrAndDTypeVec(TensorView* tv) const {
-    // TODO: ptrOf returns a fully aligned value of 16 for non-inputs. However,
-    // we might be provided an output tensor. We should verify once preallocated
-    // outputs are fully plumbed in that misaligned pointers are respected in
-    // this calculation.
+    // TODO: ptrOf returns a fully aligned value of 16 for non-inputs.
+    // However, we might be provided an output tensor. We should verify once
+    // preallocated outputs are fully plumbed in that misaligned pointers are
+    // respected in this calculation.
     const int64_t data_ptr_int = (int64_t)runtime_info_.ptrOf(tv);
     int64_t vec_size = scheduler_utils::maxVectorizationWidth(data_ptr_int);
     vec_size = std::min(vec_size, 16l);
@@ -367,15 +377,15 @@ class VectorizationCalculator {
   }
 
   //! To analyze vectorization, we need to know pointer alignment, sizes, and
-  //! strides. SchedulerRuntimeInfo contains all this info about fusion inputs,
-  //! but fusion outputs are allocated by FusionExecutor so they are absent from
-  //! SchedulerRuntimeInfo.
+  //! strides. SchedulerRuntimeInfo contains all this info about fusion
+  //! inputs, but fusion outputs are allocated by FusionExecutor so they are
+  //! absent from SchedulerRuntimeInfo.
   //!
-  //! This function just extracts sizes and strides from runtime_info_ when the
-  //! argument is a fusion input. When the input is a fusion output, we respect
-  //! the contiguity marked in the allocation domain. For discontiguous
-  //! dimensions, we return a stride that has been padded to an odd value, which
-  //! is the worst case scenario for vectorization.
+  //! This function just extracts sizes and strides from runtime_info_ when
+  //! the argument is a fusion input. When the input is a fusion output, we
+  //! respect the contiguity marked in the allocation domain. For
+  //! discontiguous dimensions, we return a stride that has been padded to an
+  //! odd value, which is the worst case scenario for vectorization.
   //!
   //! Note that this function is non-const because we use
   //! runtime_info_.expressionEvaluator() which caches intermediate values
@@ -391,9 +401,9 @@ class VectorizationCalculator {
         "getSizesAndStrides should only be called with fusion inputs or outputs. Found ",
         tv->toString());
     // For outputs, compute sizes using ExpressionEvaluator, then compute
-    // strides based on allocation domain, assuming contiguity as marked in the
-    // TensorView. For discontiguous dimensions, we compute a stride that is
-    // least favorable to vectorization, by padding to an odd value.
+    // strides based on allocation domain, assuming contiguity as marked in
+    // the TensorView. For discontiguous dimensions, we compute a stride that
+    // is least favorable to vectorization, by padding to an odd value.
     std::vector<int64_t> sizes, strides;
     std::vector<bool> concrete_contig;
     for (size_t i : c10::irange(tv->getMaybeAllocationDomain().size())) {
@@ -429,13 +439,13 @@ class VectorizationCalculator {
     return {sizes, strides};
   }
 
-  // Given a TensorView and a vector of dimension ValGroups find vectorization.
-  // The vector of dimensions indicates how the tensor will be scheduled;
-  // dimensions in tv will be reordered if needed then the vector of dimensions
-  // will be merged. We check the allocation domain of tv to tell how the
-  // resulting merged TV can be vectorized. If the tensor does not have any
-  // inner_dims, then it cannot be vectorized. In that case we return 0 so that
-  // this tensor can be ignored in later computation.
+  // Given a TensorView and a vector of dimension ValGroups find
+  // vectorization. The vector of dimensions indicates how the tensor will be
+  // scheduled; dimensions in tv will be reordered if needed then the vector
+  // of dimensions will be merged. We check the allocation domain of tv to
+  // tell how the resulting merged TV can be vectorized. If the tensor does
+  // not have any inner_dims, then it cannot be vectorized. In that case we
+  // return 0 so that this tensor can be ignored in later computation.
   int64_t innerDimsVectorization(
       TensorView* tv,
       const std::vector<ValGroup>& inner_dims) {
@@ -444,8 +454,8 @@ class VectorizationCalculator {
 
     // Position of the outermost vectorizable dimension, in allocation domain
     size_t inner_dim_pos = tv->getMaybeAllocationDomain().size();
-    // Product of sizes of all vectorizable dims; i.e. the number of elements in
-    // the merged vectorized dimension.
+    // Product of sizes of all vectorizable dims; i.e. the number of elements
+    // in the merged vectorized dimension.
     int64_t inner_dims_numel = 1;
     std::vector<ValGroup> remaining_inner_dims(inner_dims);
     for (int64_t i = (int64_t)tv->getMaybeAllocationDomain().size() - 1; i >= 0;
@@ -512,10 +522,10 @@ class VectorizationCalculator {
   // vectorization width.
   //
   // We canonicalize dimensions by reordering them with the given ordering
-  // before merging all dimensions that have the same role. For a given operand,
-  // this might mean that the inner-most dimension gets reordered to be outer,
-  // even if it has the same role as the innermost dimension in the canonical
-  // ordering.
+  // before merging all dimensions that have the same role. For a given
+  // operand, this might mean that the inner-most dimension gets reordered to
+  // be outer, even if it has the same role as the innermost dimension in the
+  // canonical ordering.
   int64_t operandVectorization(TensorView* tv) {
     // Check data pointer alignment
     int64_t vec_size = ptrAndDTypeVec(tv);
@@ -586,8 +596,8 @@ class VectorizationCalculator {
     if (!inner_nonk_role.has_value() ||
         inner_nonk_role.value() == MatmulDomain::Batch) {
       // If the innermost non-K dimension is a batch dimension, then we cannot
-      // vectorize the outputs since we parallelize batch dimensions across the
-      // grid.
+      // vectorize the outputs since we parallelize batch dimensions across
+      // the grid.
       return 1l;
     }
 

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -34,13 +34,8 @@ inline mma_utils::MmaDataTypes getMmaDataTypes(
     }
     NVF_ERROR(false, "Get MMA Tensor data type failed!");
   };
-  const auto it = tensor_roles.find(MatmulRole::OPERAND);
-  NVF_ERROR(
-      it != tensor_roles.end(), "Could not find any tensors with role OPERAND");
-  const std::vector<TensorView*>& operands = it->second;
-  NVF_ERROR(operands.size() == 2, "Exactly two operands are expected");
-  const auto a_type = operands.front()->dtype();
-  const auto b_type = operands.back()->dtype();
+  const auto a_type = getMMADataType(MatmulRole::OPERAND_A);
+  const auto b_type = getMMADataType(MatmulRole::OPERAND_B);
   const auto c_type = getMMADataType(MatmulRole::OUTPUT);
   return mma_utils::MmaDataTypes{a_type, b_type, c_type};
 }
@@ -181,6 +176,16 @@ std::pair<bool, bool> generateSharedMemoryEpilogueHeuristics(
       promote_prologue_smem_reuse};
 }
 
+TensorView* getOperandTv(const TensorRolesMap& tensor_roles, MatmulRole role) {
+  const auto it = tensor_roles.find(role);
+  NVF_ERROR(it != tensor_roles.end(), "Could not find any tensors with role");
+  const std::vector<TensorView*>& operands = it->second;
+  NVF_ERROR(
+      operands.size() == 1,
+      "Exactly one operand is expected in each A and B role");
+  return operands.front();
+}
+
 std::pair<bool, bool> generateSharedMemoryEpilogueHeuristics(
     const MatMulTileOptions& gemm_tile,
     const int smem_double_buffer_stage,
@@ -220,13 +225,8 @@ std::pair<bool, bool> generateSharedMemoryEpilogueHeuristics(
   // cases, we check that there is no re-use when there is more than one use of
   // either a or b. If there are multiple uses we might wind up re-using memory,
   // but in that case the calculation below will be overly conservative.
-  const auto it = tensor_roles.find(MatmulRole::OPERAND);
-  NVF_ERROR(
-      it != tensor_roles.end(), "Could not find any tensors with role OPERAND");
-  const std::vector<TensorView*>& operands = it->second;
-  NVF_ERROR(operands.size() == 2, "Exactly two operands are expected");
-  const TensorView* a = operands.front();
-  const TensorView* b = operands.back();
+  const TensorView* a = getOperandTv(tensor_roles, MatmulRole::OPERAND_A);
+  const TensorView* b = getOperandTv(tensor_roles, MatmulRole::OPERAND_B);
   bool smem_a_reuse_guaranteed = a->uses().size() == 1;
   bool smem_b_reuse_guaranteed = b->uses().size() == 1;
 
@@ -1166,13 +1166,8 @@ MatmulOperandInnerDimsOpt getOperandInnerDims(
     }
     return g_it->second;
   };
-  const auto it = tensor_roles.find(MatmulRole::OPERAND);
-  NVF_ERROR(
-      it != tensor_roles.end(), "Could not find any tensors with role OPERAND");
-  const std::vector<TensorView*>& operands = it->second;
-  NVF_ERROR(operands.size() == 2, "Exactly two operands are expected");
-  TensorView* a = operands.front();
-  TensorView* b = operands.back();
+  TensorView* a = getOperandTv(tensor_roles, MatmulRole::OPERAND_A);
+  TensorView* b = getOperandTv(tensor_roles, MatmulRole::OPERAND_B);
 
   const MatmulDomainOpt innerdim_a_opt = findInnerDim(a);
   if (std::holds_alternative<std::string>(innerdim_a_opt)) {
@@ -1246,7 +1241,8 @@ TensorRolesMapOpt getTensorRoles(
       continue;
     }
     if (has.k) {
-      tensor_roles[MatmulRole::OPERAND].push_back(tv);
+      tensor_roles[has.m ? MatmulRole::OPERAND_A : MatmulRole::OPERAND_B]
+          .push_back(tv);
     } else {
       tensor_roles[MatmulRole::EPILOGUE_INPUT].push_back(tv);
       continue;
@@ -1778,7 +1774,10 @@ std::vector<ValGroup> canonicalDimOrdering(
   // M/N ordering has been determined.
   int64_t n_inside_m = 0;
   for (MatmulRole tv_role :
-       {MatmulRole::OUTPUT, MatmulRole::OPERAND, MatmulRole::EPILOGUE_INPUT}) {
+       {MatmulRole::OUTPUT,
+        MatmulRole::OPERAND_A,
+        MatmulRole::OPERAND_B,
+        MatmulRole::EPILOGUE_INPUT}) {
     const auto it = tensor_roles.find(tv_role);
     if (it == tensor_roles.end()) {
       continue;
@@ -1818,7 +1817,8 @@ std::vector<ValGroup> canonicalDimOrdering(
               break;
             case MatmulDomain::K:
               // Order K dimensions like operands, and all others like outputs
-              if (tv_role == MatmulRole::OPERAND) {
+              if (tv_role == MatmulRole::OPERAND_A ||
+                  tv_role == MatmulRole::OPERAND_B) {
                 k_dims.pushBack(g);
               }
               break;


### PR DESCRIPTION
This is not a full reversion of #2419, which also renamed `INPUT_C` and `OUTPUT_D`, and made some modifications to
`map{Linear,Matmul}OpIterDomains`. This preserves those changes but allows us to keep distinguishing A and B operands.

Fixes #2434