### PR TITLE
Unit test for a TMA load of a TV with a dimension that is broadcast

### DIFF
--- a/csrc/device_lower/analysis/tma.cpp
+++ b/csrc/device_lower/analysis/tma.cpp
@@ -261,14 +261,17 @@ TMAInfo getTMAInfo(LoadStoreOp* ldst) {
   // Initialize frontier as the allocation domain
   auto metadata = IrBuilder::metadataExpr(gmem_tv);
   auto alloc_strides = IrBuilder::getAttrExpr(metadata, "alloc_stride");
-  for (auto i : c10::irange((int64_t)gmem_alloc_dom.size())) {
-    auto id = gmem_alloc_dom.at(i);
-    // TODO: should I use i below, or should I instead use the position of id in
-    // the allocation domain with broadcast? I don't remember the detail, but
-    // I will just use i for now and leave the support for broadcast for future.
-    auto stride = IrBuilder::getItemExpr(alloc_strides, i);
+  // All allocation domains including broadcasts and reductions.
+  auto all_allocation_domains =
+      TensorDomain::noReductions(gmem_tv->getMaybeAllocationDomain());
+  for (auto id : gmem_alloc_dom) {
+    auto it = std::find(
+        all_allocation_domains.begin(), all_allocation_domains.end(), id);
+    NVF_ERROR(it != all_allocation_domains.end());
+    int64_t pos = it - all_allocation_domains.begin();
+    auto stride = IrBuilder::getItemExpr(alloc_strides, pos);
     frontier.emplace_back(
-        id_graph.toGroup(id), gmem_tv->getContiguity().at(i).value(), stride);
+        id_graph.toGroup(id), gmem_tv->getContiguity().at(pos).value(), stride);
   }
   // Propagate forward from the gmem allocation domain to TMA ValGroups
   for (auto [expr, direction] :

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -504,6 +504,13 @@ class TMALoadTestWithABroadcastDim
   MmaInputSmemSwizzle swizzle;
   DataType dtype;
 
+  void SetUp() override {
+    if (cudaArchGuardShouldSkip(9, 0)) {
+      GTEST_SKIP() << "skipping tests on pre-Hopper GPUs";
+    }
+    NVFuserTest::SetUp();
+  }
+
   void schedule(TensorView* tv) {
     // We move the broadcast dim to be the left most.
     moveInnerBroadcastLeft(tv);

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -497,6 +497,112 @@ TEST_P(TMASimpleLdstTest, Load) {
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
+class TMALoadTestWithABroadcastDim
+    : public NVFuserFixtureParamTest<
+          std::tuple<std::vector<int64_t>, DataType, MmaInputSmemSwizzle>> {
+ protected:
+  MmaInputSmemSwizzle swizzle;
+  DataType dtype;
+
+  void schedule(TensorView* tv) {
+    // We move the broadcast dim to be the left most.
+    moveInnerBroadcastLeft(tv);
+
+    // {B, N, K}
+    // {B, NO, N_dim, K}
+    tv->split(-2, tv->axis(-2)->extent());
+
+    if (swizzle == MmaInputSmemSwizzle::None) {
+      return;
+    }
+    // {B, NO, N_dim, KO, KI (32/64/128)}
+    tv->split(-1, getBytesFromSwizzle(swizzle) / dataTypeSize(dtype));
+
+    // {B, NO, KO, N_dim, KI }
+    tv->reorder({{2, 3}, {3, 2}});
+
+    // {B, NO * KO, N_dim, KI}
+    tv->merge(1);
+
+    // {B, NO * KO, N_dim_O, N_128/(32, 64, 128),  KI}
+    tv->split(-2, (128 / (getBytesFromSwizzle(swizzle))));
+
+    // {B, NO * KO, N_dim_O, N_128/(32, 64, 128),  KIO, KII}
+    tv->split(-1, (core_matrix_width_bytes / dataTypeSize(dtype)));
+
+    // split N_dim_O by N/16 N =swizzle size (32/64/128)
+    // {B, NO * KO, N_dim_O/(swizzle_size/16), N_128/(32, 64, 128),  KIO, KII}
+    tv->split(-4, (getBytesFromSwizzle(swizzle) / 16));
+
+    tv->swizzle(SwizzleType::XOR, -4, -2);
+  }
+
+  void markAllDimsExceptFirstTwoAsBulk(const TensorView* tv) {
+    int skip = 0;
+    for (auto id : tv->getLoopDomain()) {
+      if (skip < 2) {
+        skip++;
+        continue;
+      }
+      id->parallelize(ParallelType::Bulk);
+    }
+  }
+
+  TMALoadTestWithABroadcastDim() {
+    dtype = std::get<1>(GetParam());
+    swizzle = std::get<2>(GetParam());
+  }
+};
+
+TEST_P(TMALoadTestWithABroadcastDim, LoadWithBroadcast) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  auto shape = std::get<0>(GetParam());
+
+  auto tv0 = makeContigConcreteTensor(shape, dtype);
+  fusion.addInput(tv0);
+  auto tv1 = set(tv0);
+  auto tv2 = set(tv1);
+  fusion.addOutput(tv2);
+
+  tv1->setMemoryType(MemoryType::Shared);
+  tv1->definition()->as<LoadStoreOp>()->setOpType(
+      LoadStoreOpType::CpAsyncBulkTensorTile);
+
+  schedule(tv1);
+  tv1->setAllocationDomain(tv1->getLoopDomain(), true);
+  markAllDimsExceptFirstTwoAsBulk(tv1);
+
+  schedule(tv2);
+  // Naively parallelize an outer dim of tv2.
+  // We use a single CTA. Inputs are small enough not to error out.
+  tv2->axis(2)->parallelize(ParallelType::TIDx);
+
+  auto options =
+      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+  auto t0 = at::randn(shape, options);
+  FusionExecutor fe;
+  fe.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+
+  auto cg_outputs = fe.runFusion({t0});
+  testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
+}
+
+std::vector<std::vector<int64_t>> shapes_to_load =
+    {{1, 64, 16}, {1, 16, 64}, {1, 128, 64}, {1, 128, 128}, {64, 1, 16}};
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    TMALoadTestWithABroadcastDim,
+    testing::Combine(
+        testing::ValuesIn(shapes_to_load),
+        testing::Values(DataType::Half, DataType::Float, DataType::Double),
+        testing::Values(
+            MmaInputSmemSwizzle::None,
+            MmaInputSmemSwizzle::B128,
+            MmaInputSmemSwizzle::B64,
+            MmaInputSmemSwizzle::B32)));
+
 TEST_P(TMASimpleLdstTest, Store) {
   Fusion fusion;
   FusionGuard fg(&fusion);


### PR DESCRIPTION
Adding a test which mimics the way we'll be loading inputs for a matmul (which will one dimension being a broadcast dimension).  The figure below illustrates the scheduling strategy I use.  The broadcast dim is first pulled out, and then we schedule to achieve the layout explained here (https://github.com/NVIDIA/Fuser/blob/main/doc/dev/tma/swizzle.svg)

![image](https://github.com/NVIDIA/Fuser/assets/10635897/fb64167a-8425-409f-bb26-20e040ff1ca7)
