### PR TITLE
change FusionReshapeReductionShmoo from test_f to test_p

### DIFF
--- a/tests/cpp/test_gpu_view.cpp
+++ b/tests/cpp/test_gpu_view.cpp
@@ -370,8 +370,7 @@ std::vector<reshape_example> reshape_after_reduce_examples = {
     {{1, 7844, 1, 7}, {1, 1961, 4}}};
 
 // Parameterized test for reshape before reduction
-class ReshapeBeforeReduction : public NVFuserFixtureParamTest<reshape_example> {
-};
+using ReshapeBeforeReduction =  NVFuserFixtureParamTest<reshape_example>;
 TEST_P(ReshapeBeforeReduction, FusionReshapeBeforeReduction) {
   auto e = GetParam();
   maybeClearAllocator(); // Shmoo tests can occupy a lot of memory
@@ -384,8 +383,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(all_reshape_examples));
 
 // Parameterized test for reshape after reduction
-class ReshapeAfterReduction : public NVFuserFixtureParamTest<reshape_example> {
-};
+using ReshapeAfterReduction =  NVFuserFixtureParamTest<reshape_example>;
 TEST_P(ReshapeAfterReduction, FusionReshapeAfterReduction) {
   auto e = GetParam();
   maybeClearAllocator(); // Shmoo tests can occupy a lot of memory

--- a/tests/cpp/test_gpu_view.cpp
+++ b/tests/cpp/test_gpu_view.cpp
@@ -369,8 +369,8 @@ std::vector<reshape_example> reshape_after_reduce_examples = {
     {{1, 27454, 1, 2}, {1, 3922, 1, 7}},
     {{1, 7844, 1, 7}, {1, 1961, 4}}};
 
-// Parameterized test for reshape before reduction
-using ReshapeBeforeReduction =  NVFuserFixtureParamTest<reshape_example>;
+namespace {
+using ReshapeBeforeReduction = NVFuserFixtureParamTest<reshape_example>;
 TEST_P(ReshapeBeforeReduction, FusionReshapeBeforeReduction) {
   auto e = GetParam();
   maybeClearAllocator(); // Shmoo tests can occupy a lot of memory
@@ -381,9 +381,10 @@ INSTANTIATE_TEST_SUITE_P(
     ,
     ReshapeBeforeReduction,
     ::testing::ValuesIn(all_reshape_examples));
+} // namespace
 
-// Parameterized test for reshape after reduction
-using ReshapeAfterReduction =  NVFuserFixtureParamTest<reshape_example>;
+namespace {
+using ReshapeAfterReduction = NVFuserFixtureParamTest<reshape_example>;
 TEST_P(ReshapeAfterReduction, FusionReshapeAfterReduction) {
   auto e = GetParam();
   maybeClearAllocator(); // Shmoo tests can occupy a lot of memory
@@ -394,6 +395,7 @@ INSTANTIATE_TEST_SUITE_P(
     ,
     ReshapeAfterReduction,
     ::testing::ValuesIn(reshape_after_reduce_examples));
+} // namespace
 
 void persistentViewAddFusion(
     std::vector<int64_t>& input_shape,

--- a/tests/cpp/test_gpu_view.cpp
+++ b/tests/cpp/test_gpu_view.cpp
@@ -375,7 +375,7 @@ TEST_P(ReshapeBeforeReduction, FusionReshapeBeforeReduction) {
   const auto& [input_shape, output_shape] = GetParam();
   maybeClearAllocator(); // Shmoo tests can occupy a lot of memory
   reductionViewAddFusion(
-      e.first, e.second, true /* reshape_before_reduction */);
+      e.first, e.second, /*reshape_before_reduction=*/true);
 }
 INSTANTIATE_TEST_SUITE_P(
     ,

--- a/tests/cpp/test_gpu_view.cpp
+++ b/tests/cpp/test_gpu_view.cpp
@@ -372,7 +372,7 @@ std::vector<reshape_example> reshape_after_reduce_examples = {
 namespace {
 using ReshapeBeforeReduction = NVFuserFixtureParamTest<reshape_example>;
 TEST_P(ReshapeBeforeReduction, FusionReshapeBeforeReduction) {
-  auto e = GetParam();
+  const auto& [input_shape, output_shape] = GetParam();
   maybeClearAllocator(); // Shmoo tests can occupy a lot of memory
   reductionViewAddFusion(
       e.first, e.second, true /* reshape_before_reduction */);


### PR DESCRIPTION
Issue: #2463 
This is the 1st PR to change shmoo tests from test_f to test_p
namespace is used to avoid potentail name conflicts e.g. when have multiple suites using same named para structures and functions to generate paras.
