### PR TITLE
Remove unused method DynamicTransformInitialInfo::operator==

### DIFF
--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -31,12 +31,6 @@ class DynamicTransformInitialInfoBuilder;
 //! sizes
 class DynamicTransformInitialInfo {
  public:
-  bool operator==(const DynamicTransformConcretizationInfo& other) const;
-
-  bool operator!=(const DynamicTransformConcretizationInfo& other) const {
-    return !(*this == other);
-  }
-
   Fusion* fusion() const {
     return fusion_;
   }


### PR DESCRIPTION
I just noticed a typo in this signature and decided to fix it, then realized it's probably unused so I figured I'd just remove it.