### PR TITLE
Refactor `swizzleSharedMemory` to return an `AbstractTensor`

### DIFF
--- a/csrc/abstract_tensor.cpp
+++ b/csrc/abstract_tensor.cpp
@@ -22,10 +22,7 @@ struct DispatchSplit {
       Val* factor,
       bool inner_split) const {
     using IN = std::decay_t<INPUT>;
-    if constexpr (std::is_same_v<IN, std::monostate>) {
-      NVF_CHECK(false, "Unsupported type in AbstractTensor::split");
-      return {};
-    } else if constexpr (std::is_same_v<IN, IterDomain*>) {
+    if constexpr (std::is_same_v<IN, IterDomain*>) {
       return IterDomain::split(std::forward<INPUT>(in), factor, inner_split);
     } else if constexpr (std::is_same_v<IN, ValGroupAndItsGraph>) {
       auto graph = in.graph;
@@ -74,11 +71,6 @@ struct DispatchMerge {
     using L = std::decay_t<LHS>;
     using R = std::decay_t<RHS>;
     if constexpr (
-        std::is_same_v<L, std::monostate> ||
-        std::is_same_v<R, std::monostate>) {
-      NVF_CHECK(false, "Unsupported type in AbstractTensor::merge");
-      return {};
-    } else if constexpr (
         std::is_same_v<L, IterDomain*> && std::is_same_v<R, IterDomain*>) {
       return IterDomain::merge(std::forward<LHS>(lhs), std::forward<RHS>(rhs));
     } else if constexpr (
@@ -205,11 +197,6 @@ struct DispatchSwizzle {
     using L = std::decay_t<LHS>;
     using R = std::decay_t<RHS>;
     if constexpr (
-        std::is_same_v<L, std::monostate> ||
-        std::is_same_v<R, std::monostate>) {
-      NVF_CHECK(false, "Unsupported type in AbstractTensor::merge");
-      return {};
-    } else if constexpr (
         std::is_same_v<L, IterDomain*> && std::is_same_v<R, IterDomain*>) {
       auto [out_x, out_y] = IterDomain::swizzle(
           swizzle_type, std::forward<LHS>(lhs), std::forward<RHS>(rhs));
@@ -297,11 +284,6 @@ struct DispatchLegacySwizzle {
     using L = std::decay_t<LHS>;
     using R = std::decay_t<RHS>;
     if constexpr (
-        std::is_same_v<L, std::monostate> ||
-        std::is_same_v<R, std::monostate>) {
-      NVF_CHECK(false, "Unsupported type in AbstractTensor::merge");
-      return {};
-    } else if constexpr (
         std::is_same_v<L, IterDomain*> && std::is_same_v<R, IterDomain*>) {
       auto [out_x, out_y] = IterDomain::swizzle(
           swizzle_type, std::forward<LHS>(lhs), std::forward<RHS>(rhs));

--- a/csrc/abstract_tensor.cpp
+++ b/csrc/abstract_tensor.cpp
@@ -286,6 +286,92 @@ struct DispatchSwizzle {
   }
 };
 
+// Copy-paste of DispatchSwizzle with s/SwizzleType/Swizzle2DType/g
+// This is a temporary helper and should be removed eventually.
+struct DispatchLegacySwizzle {
+  template <typename LHS, typename RHS>
+  std::pair<AbstractId, AbstractId> operator()(
+      Swizzle2DType swizzle_type,
+      LHS&& lhs,
+      RHS&& rhs) const {
+    using L = std::decay_t<LHS>;
+    using R = std::decay_t<RHS>;
+    if constexpr (
+        std::is_same_v<L, std::monostate> ||
+        std::is_same_v<R, std::monostate>) {
+      NVF_CHECK(false, "Unsupported type in AbstractTensor::merge");
+      return {};
+    } else if constexpr (
+        std::is_same_v<L, IterDomain*> && std::is_same_v<R, IterDomain*>) {
+      auto [out_x, out_y] = IterDomain::swizzle(
+          swizzle_type, std::forward<LHS>(lhs), std::forward<RHS>(rhs));
+      return {out_x, out_y};
+    } else if constexpr (
+        std::is_same_v<L, ValGroupAndItsGraph> &&
+        std::is_same_v<R, ValGroupAndItsGraph>) {
+      NVF_ERROR(false, "not supported");
+    } else if constexpr (
+        std::is_same_v<L, IterDomain*> &&
+        std::is_same_v<R, ValGroupAndItsGraph>) {
+      return (*this)(
+          swizzle_type,
+          ValGroupAndItsGraph{rhs.graph->toGroup(lhs), rhs.graph},
+          std::forward<RHS>(rhs));
+    } else if constexpr (
+        std::is_same_v<L, ValGroupAndItsGraph> &&
+        std::is_same_v<R, IterDomain*>) {
+      return (*this)(
+          swizzle_type,
+          std::forward<LHS>(lhs),
+          ValGroupAndItsGraph{lhs.graph->toGroup(rhs), lhs.graph});
+    } else if constexpr (
+        std::is_same_v<L, std::vector<AbstractId>> &&
+        std::is_same_v<R, std::vector<AbstractId>>) {
+      NVF_CHECK(
+          lhs.size() == rhs.size(),
+          "Can not merge vectors of AbstractId of different size.");
+      std::vector<AbstractId> result_x;
+      std::vector<AbstractId> result_y;
+      result_x.reserve(lhs.size());
+      result_y.reserve(lhs.size());
+      for (auto i : c10::irange(lhs.size())) {
+        auto [out_x, out_y] =
+            AbstractId::dispatch((*this), swizzle_type, lhs[i], rhs[i]);
+        result_x.emplace_back(out_x);
+        result_y.emplace_back(out_y);
+      }
+      return {result_x, result_y};
+    } else if constexpr (std::is_same_v<L, std::vector<AbstractId>>) {
+      std::vector<AbstractId> result_x;
+      std::vector<AbstractId> result_y;
+      result_x.reserve(lhs.size());
+      result_y.reserve(lhs.size());
+      for (auto i : c10::irange(lhs.size())) {
+        auto [out_x, out_y] = AbstractId::dispatch(
+            (*this), swizzle_type, lhs[i], std::forward<RHS>(rhs));
+        result_x.emplace_back(out_x);
+        result_y.emplace_back(out_y);
+      }
+      return {result_x, result_y};
+    } else if constexpr (std::is_same_v<R, std::vector<AbstractId>>) {
+      std::vector<AbstractId> result_x;
+      std::vector<AbstractId> result_y;
+      result_x.reserve(rhs.size());
+      result_y.reserve(rhs.size());
+      for (auto i : c10::irange(rhs.size())) {
+        auto [out_x, out_y] = AbstractId::dispatch(
+            (*this), swizzle_type, std::forward<LHS>(lhs), rhs[i]);
+        result_x.emplace_back(out_x);
+        result_y.emplace_back(out_y);
+      }
+      return {result_x, result_y};
+    } else {
+      NVF_CHECK(false, "Unsupported type in AbstractTensor::merge");
+      return {};
+    }
+  }
+};
+
 } // namespace
 
 void AbstractTensor::swizzle(SwizzleType swizzle_type, int64_t x, int64_t y) {
@@ -294,6 +380,19 @@ void AbstractTensor::swizzle(SwizzleType swizzle_type, int64_t x, int64_t y) {
 
   auto [out_x, out_y] = AbstractId::dispatch(
       DispatchSwizzle{}, swizzle_type, domain[x], domain[y]);
+
+  std::swap(domain[x], out_x);
+  std::swap(domain[y], out_y);
+}
+
+// Temporary helper for legacy swizzle, should be removed eventually.
+// This is a copy-paste of AbstractTensor::swizzle(SwizzleType
+void AbstractTensor::swizzle(Swizzle2DType swizzle_type, int64_t x, int64_t y) {
+  x = wrapDim(x, (int64_t)domain.size());
+  y = wrapDim(y, (int64_t)domain.size());
+
+  auto [out_x, out_y] = AbstractId::dispatch(
+      DispatchLegacySwizzle{}, swizzle_type, domain[x], domain[y]);
 
   std::swap(domain[x], out_x);
   std::swap(domain[y], out_y);

--- a/csrc/abstract_tensor.h
+++ b/csrc/abstract_tensor.h
@@ -133,10 +133,12 @@ struct AbstractTensor {
   }
 
   decltype(auto) operator[](int64_t i) {
+    i = wrapDim(i, (int64_t)domain.size());
     return domain[i];
   }
 
   decltype(auto) operator[](int64_t i) const {
+    i = wrapDim(i, (int64_t)domain.size());
     return domain[i];
   }
 
@@ -177,6 +179,10 @@ struct AbstractTensor {
   void flatten(int64_t from = 0, int64_t to = -1);
 
   void swizzle(SwizzleType swizzle_type, int64_t x, int64_t y);
+
+  // Temporary helper for legacy swizzle, should be removed eventually.
+  // This is a copy-paste of AbstractTensor::swizzle(SwizzleType
+  void swizzle(Swizzle2DType swizzle_type, int64_t x, int64_t y);
 };
 
 } // namespace nvfuser

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -196,6 +196,10 @@ class NVF_API TensorView : public Val {
     return domain()->maybeAllocation();
   };
 
+  void setLoopDomain(std::vector<IterDomain*> new_loop_domain) {
+    domain()->setLoopDomain(std::move(new_loop_domain));
+  }
+
   void setAllocationDomain(
       std::vector<IterDomain*> new_allocation_domain,
       std::vector<std::optional<bool>> new_contiguity) {
@@ -418,6 +422,11 @@ class NVF_API TensorView : public Val {
   //!  implementation is used and will be removed in follow ups.
   bool hasSwizzleOp() const {
     return has_swizzle_op_;
+  }
+
+  //! A temporary helper function for the transition from Swizzle2D to Swizzle
+  void setHasSwizzleOp() {
+    has_swizzle_op_ = true;
   }
 
   friend TransformPropagator;

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -584,7 +584,9 @@ class TensorDomain : public Val {
   // Set the loop domain of this TensorDomain.
   NVF_API void setLoopDomain(std::vector<IterDomain*> new_loop_domain);
 
-  // Set the allocation domain of this TensorDomain.
+  // Set the allocation domain of this TensorDomain. Because contiguity is
+  // always defined w.r.t. the allocation domain, the contiguity must be updated
+  // accordingly.
   NVF_API void setAllocationDomain(
       std::vector<IterDomain*> new_allocation_domain,
       std::vector<std::optional<bool>> new_contiguity);

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -581,10 +581,10 @@ class TensorDomain : public Val {
     return hasAllocation() ? allocation_domain_ : logical();
   };
 
-  // Set the allocation domain of this TensorDomain. The new allocation domain
-  // must satisfy root <= allocation <= loop, that is, it must be within the
-  // history between root and loop domain. Because contiguity is always defined
-  // w.r.t. the allocation domain, the contiguity must be updated accordingly.
+  // Set the loop domain of this TensorDomain.
+  NVF_API void setLoopDomain(std::vector<IterDomain*> new_loop_domain);
+
+  // Set the allocation domain of this TensorDomain.
   NVF_API void setAllocationDomain(
       std::vector<IterDomain*> new_allocation_domain,
       std::vector<std::optional<bool>> new_contiguity);

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3639,13 +3639,18 @@ std::pair<TensorDomain*, TensorDomain*> TensorDomain::rFactor(
   return TransformRFactor::runReplay(this, axes_);
 }
 
+void TensorDomain::setLoopDomain(std::vector<IterDomain*> new_loop_domain) {
+  ir_utils::validateDomainEquivalence(logical_domain_, new_loop_domain);
+  loop_domain_ = std::move(new_loop_domain);
+  resetDomains();
+}
+
 void TensorDomain::setAllocationDomain(
     std::vector<IterDomain*> new_allocation_domain,
     std::vector<std::optional<bool>> new_contiguity) {
   validateContiguity(new_allocation_domain, new_contiguity);
 
-  ir_utils::validateDomainEquivalence(maybeRoot(), new_allocation_domain);
-  ir_utils::validateDomainEquivalence(new_allocation_domain, loop_domain_);
+  ir_utils::validateDomainEquivalence(logical_domain_, new_allocation_domain);
 
   allocation_domain_ = std::move(new_allocation_domain);
   contiguity_ = std::move(new_contiguity);

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <abstract_tensor.h>
 #include <inlining.h>
 #include <instrumentation.h>
 #include <multidevice/utils.h>
@@ -122,12 +123,17 @@ inline void checkConcreteStaticDim(IterDomain* id) {
 //! If the input tensorview is not stored in shared memory, the function will
 //! skip the actual swizzle. This is used to help the domain mapping between
 //! mma_result and the epilogue tensor.
-void swizzleSharedMemory(TensorView* shared_mem_tv) {
+//! Returns the domain with swizzle. For the case of legacy swizzle, this
+//! domain must be set as loop domain. For the case of new swizzle, this domain
+//! must be set as allocation domain.
+template <bool legacy = true>
+AbstractTensor swizzleSharedMemory(TensorView* shared_mem_tv) {
   // Set skip to skip all consecutive reduction domains starting from the
   //  innermost dimension.
+  AbstractTensor swizzle_domain(shared_mem_tv->getLoopDomain());
   int64_t skip = 0;
-  for (int64_t i = shared_mem_tv->nDims() - 1; i >= 0; --i) {
-    if (shared_mem_tv->axis(i)->isReduction()) {
+  for (int64_t i = (int64_t)swizzle_domain.size() - 1; i >= 0; --i) {
+    if (swizzle_domain[i]->isReduction()) {
       skip++;
     } else {
       break;
@@ -137,17 +143,17 @@ void swizzleSharedMemory(TensorView* shared_mem_tv) {
   // Check that the innermost 2 dimensions are concrete and static
   //  sized so that the swizzle function can be defined.
   NVF_ERROR(
-      shared_mem_tv->nDims() >= 2 + skip,
+      (int64_t)swizzle_domain.size() >= 2 + skip,
       "At least 2D input (excluding consecutive reduction domains starting from the innermost dim) needed for swizzling, but get ",
       shared_mem_tv->toString());
-  checkConcreteStaticDim(shared_mem_tv->axis(-2 - skip));
-  checkConcreteStaticDim(shared_mem_tv->axis(-1 - skip));
+  checkConcreteStaticDim(swizzle_domain[-2 - skip].as<IterDomain*>());
+  checkConcreteStaticDim(swizzle_domain[-1 - skip].as<IterDomain*>());
 
   // Extract the constant sizes of the swizzled tile
   const int64_t tile_size_x =
-      shared_mem_tv->axis(-2 - skip)->extent()->evaluate().as<int64_t>();
+      swizzle_domain[-2 - skip]->extent()->evaluate().as<int64_t>();
   const int64_t tile_size_y =
-      shared_mem_tv->axis(-1 - skip)->extent()->evaluate().as<int64_t>();
+      swizzle_domain[-1 - skip]->extent()->evaluate().as<int64_t>();
 
   // Only tested for (1) ldmatrix access with sizeof(T) == 16bit (i.e.
   // half/bfloat16) and (2) epilogue general access with sizeof(T) == 32bit
@@ -322,7 +328,7 @@ void swizzleSharedMemory(TensorView* shared_mem_tv) {
 
   int64_t g = std::gcd(num_megabanks, row_stride_znz);
   if (g == 1) {
-    return; // No need to swizzle in this case.
+    return swizzle_domain; // No need to swizzle in this case.
   }
 
   /* For the case where stride does not coprime with n, we note that
@@ -357,7 +363,7 @@ void swizzleSharedMemory(TensorView* shared_mem_tv) {
   int64_t repeated_pattern_size = num_megabanks / g;
 
   if (repeated_pattern_size >= n_rows) {
-    return; // No need to swizzle in this case.
+    return swizzle_domain; // No need to swizzle in this case.
   }
 
   /* Now we know that we have a g-way bank conflict. How do we remove this
@@ -431,12 +437,12 @@ void swizzleSharedMemory(TensorView* shared_mem_tv) {
   //   -2   -1
   // [row, col]
   if (repeated_pattern_size > 1) {
-    shared_mem_tv->split(-2 - skip, repeated_pattern_size);
+    swizzle_domain.split(-2 - skip, repeated_pattern_size);
   }
-  shared_mem_tv->split(-1 - skip, n_cols);
+  swizzle_domain.split(-1 - skip, n_cols);
   //      -4         -3       -2        -1
   // [gigarow id, gigarow, matrix id, matrix]
-  shared_mem_tv->split(-2 - skip, num_gigabanks);
+  swizzle_domain.split(-2 - skip, num_gigabanks);
   //      -5        -4        -3        -2         -1
   // [gigarow id, gigarow, y outer, gigabank id, matrix]
   // Note that megabanks inside a gigabank are not contiguous, so the gigabank
@@ -487,7 +493,7 @@ void swizzleSharedMemory(TensorView* shared_mem_tv) {
   //      -5        -4        -3        -2         -1
   // [gigarow id, gigarow, y outer, gigabank id, matrix]
   int axis_of_gigarow_id = repeated_pattern_size > 1 ? -5 : -4;
-  shared_mem_tv->split(axis_of_gigarow_id - skip, num_gigabanks);
+  swizzle_domain.split(axis_of_gigarow_id - skip, num_gigabanks);
   //     -6     -5     -4       -3        -2         -1
   // [wave id, wave, gigarow, y outer, gigabank id, matrix]
 
@@ -511,23 +517,29 @@ void swizzleSharedMemory(TensorView* shared_mem_tv) {
   // mapping.
   if (shared_mem_tv->getMemoryType() == MemoryType::Shared) {
     int axis_of_gigarow_id = repeated_pattern_size > 1 ? -5 : -4;
+    using SwizzleTypeMaybeLegacy =
+        std::conditional_t<legacy, Swizzle2DType, SwizzleType>;
     if (isPowOf2(num_gigabanks)) {
-      shared_mem_tv->swizzle(
-          Swizzle2DType::XOR, axis_of_gigarow_id - skip, -2 - skip);
+      swizzle_domain.swizzle(
+          SwizzleTypeMaybeLegacy::XOR, axis_of_gigarow_id - skip, -2 - skip);
     } else {
-      shared_mem_tv->swizzle(
-          Swizzle2DType::CyclicShift, axis_of_gigarow_id - skip, -2 - skip);
+      swizzle_domain.swizzle(
+          SwizzleTypeMaybeLegacy::CyclicShift,
+          axis_of_gigarow_id - skip,
+          -2 - skip);
     }
   }
 
   if (repeated_pattern_size > 1) {
-    shared_mem_tv->merge(-6 - skip);
+    swizzle_domain.merge(-6 - skip);
   }
-  shared_mem_tv->merge(-5 - skip);
+  swizzle_domain.merge(-5 - skip);
 
   // merge back tile_size_y
-  shared_mem_tv->merge(-3 - skip);
-  shared_mem_tv->merge(-2 - skip);
+  swizzle_domain.merge(-3 - skip);
+  swizzle_domain.merge(-2 - skip);
+
+  return swizzle_domain;
 }
 
 //! Generates the prolog schedule on the shared memory buffer
@@ -553,7 +565,9 @@ void scheduleProlog(
   mma_utils::orderTiledConcreteIdAsMaybeAllocationDomain(shared_mem_tv);
 
   // Swizzle the shared memory data layout
-  swizzleSharedMemory(shared_mem_tv);
+  auto swizzled_dom = swizzleSharedMemory(shared_mem_tv);
+  shared_mem_tv->setLoopDomain(swizzled_dom.as<IterDomain*>());
+  shared_mem_tv->setHasSwizzleOp();
   // Assuming we are always vectorizing smem write by 128b at the moment:
   //   TODO: would need a data-type and alignment dependent interface
   //    to support non-vectorizable shapes.
@@ -1009,7 +1023,8 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
     // Transform mma_result through the epilogue swizzle without actually
     // swizzling the axes. This is done to enable the domains
     // are mapped between mma_result and smem_epilogue.
-    swizzleSharedMemory(mma_result);
+    auto swizzled_dom = swizzleSharedMemory(mma_result);
+    mma_result->setLoopDomain(swizzled_dom.as<IterDomain*>());
   }
 
   // Schedule warp tile
@@ -1200,7 +1215,9 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
   // handle epilogue and always vectorize Ki
   if (params.use_smem_epilogue) {
     smem_epilogue->setMemoryType(MemoryType::Shared);
-    swizzleSharedMemory(smem_epilogue);
+    auto swizzled_dom = swizzleSharedMemory(smem_epilogue);
+    smem_epilogue->setLoopDomain(swizzled_dom.as<IterDomain*>());
+    smem_epilogue->setHasSwizzleOp();
     scheduler_utils::BoundedDirectionalTransformPropagator::forward(
         mma_result,
         -1,

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -767,7 +767,7 @@ enum class DoubleBufferLoopStage { NotApplicable, Prolog, Main, Epilog };
 //!
 //!  TODO: unify with existing swizzle logic, currently
 //!    doesn't have the same type.
-enum class SwizzleType { NoSwizzle = 0, XOR };
+enum class SwizzleType { NoSwizzle = 0, XOR, CyclicShift };
 enum class Swizzle2DType { NoSwizzle = 0, ZShape, XOR, CyclicShift };
 
 //! Modes of swizzle, see [Note on swizzle mode].


### PR DESCRIPTION
After this PR, `swizzleSharedMemory` will no longer modify the tensor that should be swizzled. Instead, it returns an `AbstractTensor` that contains the swizzled domain. For now, this domain must be set as the loop domain of the swizzled tensor.

In the future, I will modify `swizzleSharedMemory` to use the new `Swizzle` instead of the deprecated `Swizzle2D`. The returned domain of `swizzleSharedMemory` will be the allocation domain instead of the loop domain of the swizzled tensor.
When everything is done, `Swizzle2D` will be removed.