### PR TITLE
Adding unit tests to check TMA loads for input B

### DIFF
--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -619,7 +619,7 @@ void checkDimSize(
   }
 }
 
-static void setWarpMapped(TensorView* tv, int64_t number_of_dims) {
+void setWarpMapped(TensorView* tv, int64_t number_of_dims) {
   for (int64_t id : c10::irange(number_of_dims)) {
     tv->axis(-id - 1)->toMmaSwizzled();
   }

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -401,6 +401,9 @@ std::vector<ValGroup> canonicalDimOrdering(
     const mma_utils::DimRolesMap& dim_roles,
     const ValGraph& permissive_graph);
 
+//! Set the number_of_dims IDs from the end to swizzled.
+void setWarpMapped(TensorView* tv, int64_t number_of_dims);
+
 } // namespace mma_utils
 
 } // namespace nvfuser

--- a/tests/cpp/test_mma.cpp
+++ b/tests/cpp/test_mma.cpp
@@ -441,6 +441,254 @@ TEST_P(HopperRS, SingleTile) {
   EXPECT_TRUE(at::allclose(cg_outputs[0], tref, 1e-5, 1e-5));
 }
 
+void scheduleTMALoadWhereOuterDimIsSplit(
+    TensorView* tv,
+    MmaInputSmemSwizzle swizzle,
+    DataType dtype) {
+  // We move the broadcast dim to be the left most.
+  moveInnerBroadcastLeft(tv);
+
+  if (swizzle == MmaInputSmemSwizzle::None) {
+    // For no-swizzle case, the entire tile are divided into 8x8 core matrices,
+    // and each core matrix resides in a contiguous 8*8*2 bytes region in shared
+    // memory. [K, M]
+    tv->split(-2, 8);
+    tv->split(-1, 8);
+    // [Ko, K8, Mo, M8]
+    tv->reorder({{-2, -3}});
+    // [Ko, Mo, K8, M8]
+    return;
+  }
+
+  // {B, K, N}
+  // {B, KO, 8, N}
+  //  We use 8 because it's 128 / getBytesFromSwizzle(swizzle)  *
+  //  getBytesFromSwizzle(swizzle) / 16
+  tv->split(-2, 8);
+
+  // {B, KO, KI(8), NO(2), NI(16)}
+  tv->split(-1, getBytesFromSwizzle(swizzle) / dataTypeSize(dtype));
+
+  // {B, NO, KO, KI(8), NI(16) }
+  tv->reorder({{2, 3}, {3, 2}});
+
+  // {B, NO, KO, KIO(2), KII(4),  NI(16) }
+  tv->split(-2, (128 / (getBytesFromSwizzle(swizzle))));
+
+  // {B, NO, KO, KIO(2), KII(4),  NIO(2), NII(8) }
+  tv->split(-1, (core_matrix_width_bytes / dataTypeSize(dtype)));
+
+  tv->swizzle(SwizzleType::XOR, -4, -2);
+}
+
+TEST_P(HopperRS, SingleTileWithTMALoad) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto shapes = matmulAtInputShape3DHopperRS(
+      getM(macro), getN(macro), getK(macro), layout);
+
+  auto tv0 = makeContigConcreteTensor(shapes.first, dtype);
+  auto tv1 = makeContigConcreteTensor(shapes.second, dtype);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  // Just doing a gmem->register copy
+  tv0 = set(tv0);
+  // Just doing a gmem->smem copy
+  tv1 = set(tv1);
+  tv1->setMemoryType(MemoryType::Shared);
+  tv1->definition()->as<LoadStoreOp>()->setOpType(
+      LoadStoreOpType::CpAsyncBulkTensorTile);
+
+  auto tv2 = fusedMultiplySum(tv0, tv1, {layout == MmaLayout::TT ? 1 : 2});
+
+  fusion.addOutput(tv2);
+
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
+  NVF_CHECK(
+      1 == mma_ops.size(),
+      "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
+      mma_ops.size());
+  mma_ops.front()->setMacro(macro);
+
+  auto tv2c = tv2->cacheBefore();
+
+  moveInnerBroadcastLeft(tv0);
+  tv0->applyMmaSwizzle(MmaOperand::A);
+
+  tv0->merge(1);
+  tv0->merge(1);
+  tv0->axis(1)->parallelize(ParallelType::TIDx);
+
+  scheduleTMALoadWhereOuterDimIsSplit(tv1, swizzle_b, dtype);
+  tv1->setAllocationDomain(tv1->getLoopDomain(), true);
+
+  int skip = 0;
+  int count = 3;
+  for (auto id : tv1->getLoopDomain()) {
+    if (skip < count) {
+      skip++;
+      continue;
+    }
+    id->parallelize(ParallelType::Bulk);
+  }
+
+  // This is stop the validation from complaining
+  // about IDs not being swizzled.
+  mma_utils::setWarpMapped(tv1, tv1->getLoopDomain().size());
+
+  if (layout == MmaLayout::TT) {
+    // [M, K, N] -> [M, N, K]
+    tv2c->reorder({{-1, -2}});
+  }
+
+  tv2c->applyMmaSwizzle(MmaOperand::Accumulator);
+  tv2->applyMmaSwizzle(MmaOperand::Accumulator);
+
+  auto inputs = matmulAtInput3DHopperRS(
+      getM(macro), getN(macro), getK(macro), layout, data_type_to_aten(dtype));
+
+  FusionExecutor fe;
+  fe.compileFusion(
+      &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
+
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.squeeze().to(at::kFloat),
+      inputs.second.squeeze().to(at::kFloat),
+      layout);
+  EXPECT_TRUE(at::allclose(cg_outputs[0], tref, 1e-5, 1e-5));
+}
+
+void scheduleTMALoadOuterDimNotSplit(
+    TensorView* tv,
+    MmaInputSmemSwizzle swizzle,
+    DataType dtype) {
+  // We move the broadcast dim to be the left most.
+  moveInnerBroadcastLeft(tv);
+
+  if (swizzle == MmaInputSmemSwizzle::None) {
+    // For no-swizzle case, the entire tile are divided into 8x8 core matrices,
+    // and each core matrix resides in a contiguous 8*8*2 bytes region in shared
+    // memory. [K, M]
+    tv->split(-2, 8);
+    tv->split(-1, 8);
+    // [Ko, K8, Mo, M8]
+    tv->reorder({{-2, -3}});
+    // [Ko, Mo, K8, M8]
+    return;
+  }
+
+  // {B, N, K}
+  // {B, NO, N_dim, K}
+  tv->split(-2, tv->axis(-2)->extent());
+
+  // {B, NO, N_dim, KO, KI (32/64/128)}
+  tv->split(-1, getBytesFromSwizzle(swizzle) / dataTypeSize(dtype));
+
+  // {B, NO, KO, N_dim, KI }
+  tv->reorder({{2, 3}, {3, 2}});
+
+  // {B, NO, KO, N_dim_O, N_128/(32, 64, 128),  KI}
+  tv->split(-2, (128 / (getBytesFromSwizzle(swizzle))));
+
+  // {B, NO, KO, N_dim_O, N_128/(32, 64, 128),  KIO, KII}
+  tv->split(-1, (core_matrix_width_bytes / dataTypeSize(dtype)));
+
+  // split N_dim_O by N/16 N =swizzle size (32/64/128)
+  // {B, NO, KO, N_dim_O/(swizzle_size/16), N_128/(32, 64, 128),  KIO, KII}
+  tv->split(-4, (getBytesFromSwizzle(swizzle) / 16));
+
+  tv->swizzle(SwizzleType::XOR, -4, -2);
+}
+
+TEST_P(HopperRS, SingleTileWithTMALoadOuterDimNotSplit) {
+  if (layout == MmaLayout::TT) {
+    GTEST_SKIP() << "Skipping test as we only handle TN layout in this test";
+  }
+
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto shapes = matmulAtInputShape3DHopperRS(
+      getM(macro), getN(macro), getK(macro), layout);
+
+  auto tv0 = makeContigConcreteTensor(shapes.first, dtype);
+  auto tv1 = makeContigConcreteTensor(shapes.second, dtype);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  // Just doing a gmem->register copy
+  tv0 = set(tv0);
+  // Just doing a gmem->smem copy
+  tv1 = set(tv1);
+  tv1->setMemoryType(MemoryType::Shared);
+  tv1->definition()->as<LoadStoreOp>()->setOpType(
+      LoadStoreOpType::CpAsyncBulkTensorTile);
+
+  auto tv2 = fusedMultiplySum(tv0, tv1, {layout == MmaLayout::TT ? 1 : 2});
+
+  fusion.addOutput(tv2);
+
+  auto mma_ops = ir_utils::getOpsOfType<MmaOp>(&fusion);
+  NVF_CHECK(
+      1 == mma_ops.size(),
+      "Invalid number of MmaOp instances in fusion definition, expected 1, got ",
+      mma_ops.size());
+  mma_ops.front()->setMacro(macro);
+
+  auto tv2c = tv2->cacheBefore();
+
+  moveInnerBroadcastLeft(tv0);
+  tv0->applyMmaSwizzle(MmaOperand::A);
+
+  tv0->merge(1);
+  tv0->merge(1);
+  tv0->axis(1)->parallelize(ParallelType::TIDx);
+
+  // In this case we don't split the outer dimension, thus having
+  // fewer TMA loads.
+  scheduleTMALoadWhereOuterDimIsSplit(tv1, swizzle_b, dtype);
+  tv1->setAllocationDomain(tv1->getLoopDomain(), true);
+
+  int skip = 0;
+  int count = 3;
+  for (auto id : tv1->getLoopDomain()) {
+    if (skip < count) {
+      skip++;
+      continue;
+    }
+    id->parallelize(ParallelType::Bulk);
+  }
+
+  // This is stop the validation from complaining
+  // about IDs not being swizzled.
+  mma_utils::setWarpMapped(tv1, tv1->getLoopDomain().size());
+
+  if (layout == MmaLayout::TT) {
+    // [M, K, N] -> [M, N, K]
+    tv2c->reorder({{-1, -2}});
+  }
+
+  tv2c->applyMmaSwizzle(MmaOperand::Accumulator);
+  tv2->applyMmaSwizzle(MmaOperand::Accumulator);
+
+  auto inputs = matmulAtInput3DHopperRS(
+      getM(macro), getN(macro), getK(macro), layout, data_type_to_aten(dtype));
+
+  FusionExecutor fe;
+  fe.compileFusion(
+      &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
+
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.squeeze().to(at::kFloat),
+      inputs.second.squeeze().to(at::kFloat),
+      layout);
+  EXPECT_TRUE(at::allclose(cg_outputs[0], tref, 1e-5, 1e-5));
+}
+
 std::string testNameHopperRS(
     const testing::TestParamInfo<HopperMmaRSTestParams>& info) {
   std::ostringstream os;


### PR DESCRIPTION
In the new unit test added we load the input B tensor to shared memory using TMA. These tests are for a single tile, where M=64, N=8 ... 256 and K=16. So for the TN layout B: {N, K} TT: {K, N}.  In the following figure we show how we tile the tensor to 4 loads. 

![image](https://github.com/NVIDIA/Fuser/assets/10635897/e1c1bb7e-6644-40a6-bed7-0b5d659920bb)

The figure below shows the scheduling for the above tiling. This schedule/tiling works for all inputs sizes (and TT and TN)

![image](https://github.com/NVIDIA/Fuser/assets/10635897/38e4583e-48d7-4056-83f3-fa0b6318f13a)

In addition to the above tiling/shedules, we could have scheduled the same shape above to reduce the number of TMA loads to 2 from 4. It's illustrated in the figure below. Please note that it correctly works for cases where we don't need to split the inner dimension. As future work we can try and make it work for all cases.

![image](https://github.com/NVIDIA/Fuser/assets/10635897/738a9aa4-7324-48d0-b2b2-659b1e7a3b63)

The schedule for the above tiling scheme is show below. This is illustrated in the test `SingleTileWithTMALoadOuterDimNotSplit`
![image](https://github.com/NVIDIA/Fuser/assets/10635897/c2f777e5-75f2-4402-a495-45f88c5f409b)

