### PR TITLE
Turn stream priority to low

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -51,7 +51,7 @@ void HostIrExecutor::handle(SetCurrentStream* set_current_stream) {
     streams_.insert(
         {stream,
          c10::cuda::getStreamFromPool(
-             /*isHighPriority=*/true, static_cast<c10::DeviceIndex>(i))});
+             /*isHighPriority=*/false, static_cast<c10::DeviceIndex>(i))});
   }
   setCurrentCUDAStream(streams_.at(stream));
 }

--- a/tests/cpp/test_multidevice_overlap.cpp
+++ b/tests/cpp/test_multidevice_overlap.cpp
@@ -204,7 +204,7 @@ TEST_F(OverlapTest, SimpleComputeComm) {
 
     if (params.use_different_streams) {
       auto new_stream = c10::cuda::getStreamFromPool(
-          /*isHighPriority=*/true, my_device_index_);
+          /*isHighPriority=*/false, my_device_index_);
       streams.push_back(new_stream);
       setCurrentCUDAStream(new_stream);
     }


### PR DESCRIPTION
We set the priority of Streams to "low" to match [torch's default API](https://github.com/pytorch/pytorch/blob/82c8fc3a2b500cded29b4bd6836b22f88e4d7047/c10/cuda/CUDAStream.h#L213), as request by @wujingyue [in this comment](https://github.com/NVIDIA/Fuser/pull/2401#discussion_r1653115772)