### PR TITLE
`HostIrExecutor`: Concretize fusions before calling `FusionExecutor`

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -89,9 +89,8 @@ void HostIrExecutor::handle(PostOnStream* post_ir) {
     }
     outputs = fec_.at(hu).runFusionWithInputs(input_IValues);
   } else {
-    auto [it, has_emplaced] = fe_.try_emplace(hu);
-    auto& fe = it->second;
-    if (has_emplaced) {
+    FusionExecutor& fe = fe_[hu];
+    if (!fe.isCompiled()) {
       Fusion* fusion = hu->fusion_to_execute();
       DynamicTransform::concretizeFusion(fusion, input_IValues);
       fe.compileFusion(fusion, input_IValues);

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 
+#include <dynamic_transform.h>
 #include <host_ir/executor.h>
 #include <ir/utils.h>
 
@@ -91,7 +92,9 @@ void HostIrExecutor::handle(PostOnStream* post_ir) {
     auto [it, has_emplaced] = fe_.try_emplace(hu);
     auto& fe = it->second;
     if (has_emplaced) {
-      fe.compileFusion(hu->fusion_to_execute(), input_IValues);
+      Fusion* fusion = hu->fusion_to_execute();
+      DynamicTransform::concretizeFusion(fusion, input_IValues);
+      fe.compileFusion(fusion, input_IValues);
     }
     outputs = fe.runFusion(input_IValues);
     if (!params_.cache_fusion_executor) {

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -443,10 +443,6 @@ TEST_P(HostIrTest, ForLoops) {
 
   HostIrExecutorParams params;
   auto [use_fusion_executor_cache] = GetParam();
-  if (!use_fusion_executor_cache) {
-    GTEST_SKIP()
-        << "not supported for now because of concretization issue, getting the error: dynamic_tvs.empty() INTERNAL ASSERT FAILED at /opt/pytorch/Fuser/csrc/device_lower/validation.cpp:187, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues. Tensor with dynamic transform must be concretized before lowering: T1_l[ ?S2{( ( ( -( fmax(0, ( where(( i7 < 0 ), ( i7 + 10 ), i7) )) ) ) + 10 ) + ( ( fmax(( fmax(0, ( where(( i7 < 0 ), ( i7 + 10 ), i7) )) ), ( fmin(10, ( where(( ( i7 + 1 ) < 0 ), ( ( i7 + 1 ) + 10 ), ( i7 + 1 )) )) )) ) - 10 ) )}rf ], T3_g[ ?S4{( ( ( -( fmax(0, ( where(( i7 < 0 ), ( i7 + 10 ), i7) )) ) ) + 10 ) + ( ( fmax(( fmax(0, ( where(( i7 < 0 ), ( i7 + 10 ), i7) )) ), ( fmin(10, ( where(( ( i7 + 1 ) < 0 ), ( ( i7 + 1 ) + 10 ), ( i7 + 1 )) )) )) ) - 10 ) )} ]";
-  }
   params.use_fusion_executor_cache = use_fusion_executor_cache;
   HostIrExecutor hie(std::move(hic), /*communicator=*/nullptr, params);
 


### PR DESCRIPTION
# What
With this patch, we concretize the fusion inside `HostIrExecutor` before calling `FusionExecutor`.

Solves https://github.com/NVIDIA/Fuser/issues/2462

We also re-enable a test that was previously failing.

# Why 

This has been lacking for a long time and this was preventing us to support some scenarios with dynamic shapes. We always made sure to never trigger those scenario, but with this patch we don't have this restriction anymore.

# How

thanks @jacobhinkle for the recent patch https://github.com/NVIDIA/Fuser/pull/2465

We do not care to add the same patch to `MultiDeviceExecutor` because kernel execution will be removed there in favor of `HostIrExecutor` with https://github.com/NVIDIA/Fuser/pull/2457