### PR TITLE
Allow multiple outputs with different root domains for SDPAOp in IDModel

### DIFF
--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -319,7 +319,7 @@ void IdModel::buildExactGraph() {
     } else {
       for (auto p_tv : tv_inputs) {
         for (auto c_tv : other_tv_outputs) {
-          auto exact_c2p_root_map = PairwiseRootDomainMap(p_tv, c_tv)
+          auto exact_c2p_root_map = PairwiseLogicalDomainMap(p_tv, c_tv)
                                         .mapBroadcast(false)
                                         .mapConsumerToProducer();
 
@@ -940,7 +940,7 @@ void IdModel::validateAndPropagatePType() {
 class SdpaFwdOp;
 
 bool hasUniformSiblings(Expr* expr) {
-  return !expr->isOneOf<SdpaFwdOp>();
+  return !expr->isOneOf<SdpaFwdOp, SdpaBwdOp>();
 }
 
 } // namespace nvfuser

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -937,8 +937,6 @@ void IdModel::validateAndPropagatePType() {
   }
 }
 
-class SdpaFwdOp;
-
 bool hasUniformSiblings(Expr* expr) {
   return !expr->isOneOf<SdpaFwdOp, SdpaBwdOp>();
 }

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -286,22 +286,6 @@ void IdModel::buildExactGraph() {
         all_tv_outputs.begin(), all_tv_outputs.end());
     other_tv_outputs.pop_front();
 
-    for (auto other_tv_output : other_tv_outputs) {
-      // Sibling tv's must be exactly mapped with eachother so simply zip
-      // their loop iter domains.
-
-      NVF_ERROR(
-          other_tv_output->getMaybeRootDomain().size() ==
-              c_tv->getMaybeRootDomain().size(),
-          "Multiple outputs with mismatched TV domains is not supported.");
-
-      for (auto domain_i : c10::irange(c_tv->getMaybeRootDomain().size())) {
-        auto c_id = c_tv->getMaybeRootDomain()[domain_i];
-        auto o_id = other_tv_output->getMaybeRootDomain()[domain_i];
-        idGraph(IdMappingMode::EXACT).mapVals(o_id, c_id);
-      }
-    }
-
     // Map producer-consumer relationships based on the root domain map
     auto tv_inputs = ir_utils::filterByType<TensorView>(expr->inputs());
     for (auto p_tv : tv_inputs) {
@@ -316,6 +300,35 @@ void IdModel::buildExactGraph() {
            getSortedKeys(exact_c2p_logical_map, Statement::lessThan)) {
         auto p_id = exact_c2p_logical_map.at(c_id);
         idGraph(IdMappingMode::EXACT).mapVals(c_id, p_id);
+      }
+    }
+
+    if (hasUniformSiblings(expr)) {
+      for (auto other_tv_output : other_tv_outputs) {
+        NVF_ERROR(
+            other_tv_output->getMaybeRootDomain().size() ==
+                c_tv->getMaybeRootDomain().size(),
+            "Multiple outputs with mismatched TV domains is not supported.");
+
+        for (auto domain_i : c10::irange(c_tv->getMaybeRootDomain().size())) {
+          auto c_id = c_tv->getMaybeRootDomain()[domain_i];
+          auto o_id = other_tv_output->getMaybeRootDomain()[domain_i];
+          idGraph(IdMappingMode::EXACT).mapVals(o_id, c_id);
+        }
+      }
+    } else {
+      for (auto p_tv : tv_inputs) {
+        for (auto c_tv : other_tv_outputs) {
+          auto exact_c2p_root_map = PairwiseRootDomainMap(p_tv, c_tv)
+                                        .mapBroadcast(false)
+                                        .mapConsumerToProducer();
+
+          for (auto c_id :
+               getSortedKeys(exact_c2p_root_map, Statement::lessThan)) {
+            auto p_id = exact_c2p_root_map.at(c_id);
+            idGraph(IdMappingMode::EXACT).mapVals(c_id, p_id);
+          }
+        }
       }
     }
 
@@ -551,24 +564,26 @@ StatefulInliningInfo buildStatefulInliningInfo(
       }
     }
 
-    // Siblings should always be mapped
-    auto consumer_tvs = ir_utils::filterByType<TensorView>(expr->outputs());
-    if (consumer_tvs.size() > 1) {
-      auto all_consumer_ids = consumer_tvs.vector().at(0)->domain()->allIDs();
-      info.ordered_sibling_ids.pushBack(
-          {all_consumer_ids.begin(), all_consumer_ids.end()});
-      for (const auto i : c10::irange(1, consumer_tvs.size())) {
-        auto consumer_tv_i = consumer_tvs.vector().at(i);
-        auto all_consumer_i_ids = consumer_tv_i->domain()->allIDs();
+    if (hasUniformSiblings(expr)) {
+      // Siblings should always be mapped
+      auto consumer_tvs = ir_utils::filterByType<TensorView>(expr->outputs());
+      if (consumer_tvs.size() > 1) {
+        auto all_consumer_ids = consumer_tvs.vector().at(0)->domain()->allIDs();
+        info.ordered_sibling_ids.pushBack(
+            {all_consumer_ids.begin(), all_consumer_ids.end()});
+        for (const auto i : c10::irange(1, consumer_tvs.size())) {
+          auto consumer_tv_i = consumer_tvs.vector().at(i);
+          auto all_consumer_i_ids = consumer_tv_i->domain()->allIDs();
 
-        auto sibling_map = permissive_graph.buildMapBetween(
-            all_consumer_ids, all_consumer_i_ids);
+          auto sibling_map = permissive_graph.buildMapBetween(
+              all_consumer_ids, all_consumer_i_ids);
 
-        for (const auto& [c_id_1, c_ids] : sibling_map) {
-          // Note that c_ids can have multiple domains as this graph
-          // is a Permissive graph and there may be broadcast merged
-          // domains
-          info.sibling_maps[c_id_1->as<IterDomain>()].pushBack(c_ids);
+          for (const auto& [c_id_1, c_ids] : sibling_map) {
+            // Note that c_ids can have multiple domains as this graph
+            // is a Permissive graph and there may be broadcast merged
+            // domains
+            info.sibling_maps[c_id_1->as<IterDomain>()].pushBack(c_ids);
+          }
         }
       }
     }
@@ -920,6 +935,12 @@ void IdModel::validateAndPropagatePType() {
       id->as<IterDomain>()->parallelize(common_ptype);
     }
   }
+}
+
+class SdpaFwdOp;
+
+bool hasUniformSiblings(Expr* expr) {
+  return !expr->isOneOf<SdpaFwdOp>();
 }
 
 } // namespace nvfuser

--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -295,4 +295,7 @@ std::unordered_map<ValGroup, IterDomain*> updateValGroupIdMap(
     const std::unordered_map<ValGroup, IterDomain*>& stale_map,
     ValGraph& new_graph);
 
+// Returns true if all expr outputs should be mapped unconditionally
+bool hasUniformSiblings(Expr* expr);
+
 } // namespace nvfuser

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -300,7 +300,7 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
   encodeBuffer(device, encoding_);
   for (const auto i : c10::irange(inputs.size())) {
     auto input = inputs[i];
-    if (input.isTensor()) {
+    if (input.isTensor() && input.toTensor().defined()) {
       auto& input_tensor = input.toTensor();
 
       for (auto size : input_tensor.sizes()) {

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -300,7 +300,7 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
   encodeBuffer(device, encoding_);
   for (const auto i : c10::irange(inputs.size())) {
     auto input = inputs[i];
-    if (input.isTensor() && input.toTensor().defined()) {
+    if (input.isTensor()) {
       auto& input_tensor = input.toTensor();
 
       for (auto size : input_tensor.sizes()) {

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -235,6 +235,8 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     // Consumers:
     //   output = [DIDx(D)?, N, H, L, Ev]
     //   logsumexp = [N, H, L]
+    // Note: S, E are not mapped together in the producers and do not have any
+    // mapping to the consumer.
 
     size_t num_device_dim = producer_logical.at(0)->isDeviceDim() ? 1 : 0;
     // Map N, H from any input (query/key/value)

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -20,20 +20,7 @@
 
 namespace nvfuser {
 
-class SDPATest : public NVFuserTest {
- protected:
-  SDPATest() : optimization_guard_(false), allocation_order_guard_(false) {}
-
- private:
-  // Note: `MoveSplitCat` and `AllocationDomain` preseg passes use ID model.
-  // `SdpaFwdOp` currently does not work with ID model since it requires all
-  // sibling outputs to have the same root domain.
-  //  This will be modified in a future PR.
-  preseg_passes::OptimizationPassGuard<preseg_passes::MoveSplitCatPass>
-      optimization_guard_;
-  preseg_passes::OptimizationPassGuard<preseg_passes::AllocationDomainPass>
-      allocation_order_guard_;
-};
+using SDPATest = NVFuserTest;
 
 constexpr int64_t n = 16, h = 32, l = 64, s = 128, e = 64;
 

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -85,6 +85,8 @@ void checkSdpaFwdMapping(Fusion* fusion, Expr* op) {
   query = [N, H, L, E]
   key = [N, H, S, E]
   value = [N, H, S, Ev]
+  Note: S, E are not mapped together in the producers and do not have any
+  mapping to the consumer.
   */
 
   for (auto producer : sdpa_op->inputs()) {

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -644,6 +644,7 @@ TEST_F(SDPATest, AttnFwdBwd) {
   fusion->addOutput(sdpa_grad.grad_query);
   fusion->addOutput(sdpa_grad.grad_key);
   fusion->addOutput(sdpa_grad.grad_value);
+  fusion->addOutput(sdpa_fwd_out.query_seq_len);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor q = at::randn(q_shape, options).set_requires_grad(true);

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -644,7 +644,6 @@ TEST_F(SDPATest, AttnFwdBwd) {
   fusion->addOutput(sdpa_grad.grad_query);
   fusion->addOutput(sdpa_grad.grad_key);
   fusion->addOutput(sdpa_grad.grad_value);
-  fusion->addOutput(sdpa_fwd_out.query_seq_len);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor q = at::randn(q_shape, options).set_requires_grad(true);


### PR DESCRIPTION
CC: @naoyam 

This PR allows outputs of the SDPA ops to have different root domains.