### PR TITLE
Strip reduction axes in segmentation edges

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1914,15 +1914,17 @@ void eraseInputDistinctRootDomains(Fusion* fusion) {
     }
     if (has_reduction) {
       if (new_td->hasAllocation()) {
+        const std::vector<IterDomain*> new_logical =
+            TensorDomain::noReductions(new_td->logical());
         new_td = IrBuilder::create<TensorDomain>(
-            std::vector<IterDomain*>{},
-            TensorDomain::noReductions(new_td->logical()),
-            no_red_alloc,
-            std::vector<IterDomain*>{},
-            no_red_contiguity);
+            /*root_domain=*/std::vector<IterDomain*>{},
+            /*logical_domain=*/new_logical,
+            /*allocation=*/no_red_alloc,
+            /*loop_domain=*/new_logical,
+            /*contiguity=*/no_red_contiguity);
       } else {
-        new_td =
-            IrBuilder::create<TensorDomain>(no_red_alloc, no_red_contiguity);
+        new_td = IrBuilder::create<TensorDomain>(
+            /*logical_domain=*/no_red_alloc, /*contiguity=*/no_red_contiguity);
       }
     }
 

--- a/tests/cpp/test_segmentation.cpp
+++ b/tests/cpp/test_segmentation.cpp
@@ -629,7 +629,6 @@ TEST_F(SegmentationTest, EraseReductionsInSegmentationEdges) {
   const FusionKernelRuntime* runtime = fec.getMostRecentKernelRuntime();
   ASSERT_TRUE(runtime != nullptr);
 
-
   SegmentedFusion* segmented_fusion = runtime->fusionSegments();
 
   EXPECT_EQ(segmented_fusion->groups().size(), 3);

--- a/tests/cpp/test_segmentation.cpp
+++ b/tests/cpp/test_segmentation.cpp
@@ -627,9 +627,8 @@ TEST_F(SegmentationTest, EraseReductionsInSegmentationEdges) {
   testValidate(fec.fusion(), outputs, {in0}, __LINE__, __FILE__);
 
   const FusionKernelRuntime* runtime = fec.getMostRecentKernelRuntime();
-  ASSERT_NE(runtime, nullptr);
+  ASSERT_TRUE(runtime != nullptr);
 
-  EXPECT_TRUE(runtime->isSegmented());
 
   SegmentedFusion* segmented_fusion = runtime->fusionSegments();
 


### PR DESCRIPTION
Currently, when we segment at the output of a reduction, the consumer segment will have an input tensor that has a `Reduction` axis in it. This can be problematic; see #2481 and #2317. This PR strips reduction axes from the root and allocation domain in these cases.