### PR TITLE
HostIrContainer: add default stream

### DIFF
--- a/csrc/host_ir/container.cpp
+++ b/csrc/host_ir/container.cpp
@@ -19,6 +19,13 @@ namespace nvfuser {
 
 namespace hir {
 
+Stream* HostIrContainer::getDefaultStream() {
+  if (!default_stream_) {
+    default_stream_ = IrBuilder::createInContainer<Stream>(this);
+  }
+  return default_stream_;
+}
+
 std::ostream& HostIrContainer::print(std::ostream& os) const {
   os << "\n%HostIrContainer {\n";
   IrMathPrinter op_exprs(os);

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -8,12 +8,11 @@
 #pragma once
 
 #include <fusion.h>
+#include <host_ir/host_ir.h>
 
 namespace nvfuser {
 
 namespace hir {
-
-class Stream;
 
 /*
 HostIrContainer is used to represent a host program.

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -46,7 +46,7 @@ class HostIrContainer final : public Fusion {
 
  private:
   std::vector<Expr*> top_level_exprs_;
-  Stream* default_stream_;
+  Stream* default_stream_ = nullptr;
 };
 
 } // namespace hir

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -13,6 +13,8 @@ namespace nvfuser {
 
 namespace hir {
 
+class Stream;
+
 /*
 HostIrContainer is used to represent a host program.
 1) It inherits from Fusion, so that (Host) IRs can be resgistered to it.
@@ -40,8 +42,11 @@ class HostIrContainer final : public Fusion {
     return top_level_exprs_.push_back(expr);
   }
 
+  Stream* getDefaultStream();
+
  private:
   std::vector<Expr*> top_level_exprs_;
+  Stream* default_stream_;
 };
 
 } // namespace hir

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -27,7 +27,8 @@ HostIrExecutor::HostIrExecutor(
       : 0;
   streams_.insert(
       {container_->getDefaultStream(),
-       c10::cuda::getDefaultCUDAStream(device_index)});
+       c10::cuda::getDefaultCUDAStream(
+           static_cast<c10::DeviceIndex>(device_index))});
 }
 
 std::vector<at::Tensor> HostIrExecutor::runWithInput(

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -20,7 +20,7 @@ HostIrExecutor::HostIrExecutor(
     HostIrExecutorParams params)
     : container_(std::move(container)),
       communicator_(communicator),
-      params_(std::move(params)) {
+      params_(params) {
   auto device_index =
       (communicator_ != nullptr && communicator_->is_available())
       ? communicator_->deviceId()

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -20,7 +20,15 @@ HostIrExecutor::HostIrExecutor(
     HostIrExecutorParams params)
     : container_(std::move(container)),
       communicator_(communicator),
-      params_(params) {}
+      params_(params) {
+  auto device_index =
+      (communicator_ != nullptr && communicator_->is_available())
+      ? communicator_->deviceId()
+      : 0;
+  streams_.insert(
+      {container_->getDefaultStream(),
+       c10::cuda::getDefaultCUDAStream(device_index)});
+}
 
 std::vector<at::Tensor> HostIrExecutor::runWithInput(
     std::unordered_map<Val*, c10::IValue> val_to_IValue) {

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -20,7 +20,7 @@ HostIrExecutor::HostIrExecutor(
     HostIrExecutorParams params)
     : container_(std::move(container)),
       communicator_(communicator),
-      params_(params) {
+      params_(std::move(params)) {
   auto device_index =
       (communicator_ != nullptr && communicator_->is_available())
       ? communicator_->deviceId()

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -471,9 +471,11 @@ INSTANTIATE_TEST_SUITE_P(
                                      : "useFusionExecutor";
     });
 
+using StreamTest = NVFuserTest;
+
 // The following test simply demonstrate how to change current CUDA stream in
 // the host program
-TEST_F(NVFuserTest, HostIrSetStream) {
+TEST_F(StreamTest, HostIrSetStream) {
   auto hic = std::make_unique<HostIrContainer>();
   auto stream = IrBuilder::createInContainer<Stream>(hic.get());
   auto set_stream =
@@ -489,7 +491,7 @@ TEST_F(NVFuserTest, HostIrSetStream) {
 
 // The following test simply demonstrate how to change current CUDA stream in
 // the host program
-TEST_F(NVFuserTest, HostIrDefaultStream) {
+TEST_F(StreamTest, HostIrDefaultStream) {
   auto change_stream = [](bool use_default_stream) {
     auto hic = std::make_unique<HostIrContainer>();
     Stream* stream;
@@ -506,10 +508,10 @@ TEST_F(NVFuserTest, HostIrDefaultStream) {
   };
 
   setCurrentCUDAStream(c10::cuda::getDefaultCUDAStream(0));
-  change_stream(false);
+  change_stream(/*use_default_stream=*/false);
   EXPECT_NE(
       c10::cuda::getDefaultCUDAStream(0), c10::cuda::getCurrentCUDAStream(0));
-  change_stream(true);
+  change_stream(/*use_default_stream=*/true);
   EXPECT_EQ(
       c10::cuda::getDefaultCUDAStream(0), c10::cuda::getCurrentCUDAStream(0));
 }


### PR DESCRIPTION
# What
add in `HostIrContainer` an IR representation of the "default stream" as defined by torch

# Why

used in the overlap implementation
https://github.com/NVIDIA/Fuser/blob/3258fa5d3bf9e89c600c1615f6dbc24b00b8dcce/tests/cpp/test_multidevice_overlap.cpp#L220

# How

`IrContainer::oneVal()` is a similar concept as what we try to achieve here. But the implementation there has some complexity
https://github.com/NVIDIA/Fuser/blob/3258fa5d3bf9e89c600c1615f6dbc24b00b8dcce/csrc/ir/container.cpp#L266
in particular, `oneVal` is not built with `IrBuilder::create` as one would expect, though I am not sure to understand the benefit.

Here, I didn't care to reproduce the implementation of `oneVal`, I propose something simpler relying on `IrBuilder::create`. Let me know if you prefer something in the same vein as the implementation of `oneVal`.