### PR TITLE
Add `elect_sync` PTX instruction

### DIFF
--- a/runtime/memory.cu
+++ b/runtime/memory.cu
@@ -58,6 +58,32 @@ __device__ inline unsigned adjustPartialLdMatrixAddrInTuring(
 
 namespace Hopper {
 
+// Description: Elect a leader thread from a set of threads in a warp
+//
+// The common pattern is to select any thread from the first warp without
+// creating a serialized, peeling loop.
+//
+// Code example: threadIdx.x / 32 == 0 && ptx::elect_sync(~0)
+//
+// Compile Explorer Reference: https://ce.nvidia.com/z/d9x4q8
+//
+// Document Reference:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-elect-sync
+__device__ inline bool elect_sync(
+    const std::uint32_t& membermask) {
+  std::uint32_t is_elected;
+  asm volatile (
+    "{\n\t .reg .pred P_OUT; \n\t"
+    "elect.sync _|P_OUT, %1;\n\t"
+    "selp.b32 %0, 1, 0, P_OUT; \n"
+    "}"
+    : "=r"(is_elected)
+    : "r"(membermask)
+    :
+  );
+  return static_cast<bool>(is_elected);
+}
+
 // References:
 //
 // TMA:

--- a/runtime/memory.cu
+++ b/runtime/memory.cu
@@ -69,18 +69,16 @@ namespace Hopper {
 //
 // Document Reference:
 // https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-elect-sync
-__device__ inline bool elect_sync(
-    const std::uint32_t& membermask) {
+__device__ inline bool elect_sync(const std::uint32_t& membermask) {
   std::uint32_t is_elected;
-  asm volatile (
-    "{\n\t .reg .pred P_OUT; \n\t"
-    "elect.sync _|P_OUT, %1;\n\t"
-    "selp.b32 %0, 1, 0, P_OUT; \n"
-    "}"
-    : "=r"(is_elected)
-    : "r"(membermask)
-    :
-  );
+  asm volatile(
+      "{\n\t .reg .pred P_OUT; \n\t"
+      "elect.sync _|P_OUT, %1;\n\t"
+      "selp.b32 %0, 1, 0, P_OUT; \n"
+      "}"
+      : "=r"(is_elected)
+      : "r"(membermask)
+      :);
   return static_cast<bool>(is_elected);
 }
 


### PR DESCRIPTION
This PR adds the `elect_sync` ptx wrapper, which elects a leader thread from a set of threads in a warp.

It will be used to replace `threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0` predicate used in TMA circular buffering.

The common pattern is to select any thread from the first warp without creating a serialized, peeling loop.
Code example: 
```cpp
if (threadIdx.x / 32 == 0 && ptx::elect_sync(~0)) {
 // do_something
}
```

Document Reference:
https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-elect-sync