### PR TITLE
Adding ExpandOp in alias analysis

### DIFF
--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -37,6 +37,7 @@ class AliasFinder : public OptOutConstDispatch {
   void handle(const SliceOp*) override;
   void handle(const BroadcastOp*) override;
   void handle(const SqueezeOp*) override;
+  void handle(const ExpandOp*) override;
 
  private:
   // A helper function used to compute the perferred output layout. It computes
@@ -362,6 +363,23 @@ void AliasFinder::handle(const SqueezeOp* squeeze) {
     return;
   }
   auto* out = squeeze->out()->as<TensorView>();
+
+  // Preserve the allocation order of existing dimensions.
+  std::optional<Layout> out_layout =
+      mapInLayoutToOutRoot(analysis_.preferredLayout(in), in, out);
+  if (!out_layout.has_value()) {
+    return;
+  }
+
+  analysis_.add(out, in, std::move(*out_layout));
+}
+
+void AliasFinder::handle(const ExpandOp* expand) {
+  TensorView* in = dynamic_cast<TensorView*>(expand->in());
+  if (in == nullptr) {
+    return;
+  }
+  auto* out = expand->out()->as<TensorView>();
 
   // Preserve the allocation order of existing dimensions.
   std::optional<Layout> out_layout =

--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -375,7 +375,7 @@ void AliasFinder::handle(const SqueezeOp* squeeze) {
 }
 
 void AliasFinder::handle(const ExpandOp* expand) {
-  TensorView* in = dynamic_cast<TensorView*>(expand->in());
+  auto* in = dynamic_cast<TensorView*>(expand->in());
   if (in == nullptr) {
     return;
   }

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -279,7 +279,7 @@ TEST_F(AliasAnalysisTest, BroadcastExpandDimensions) {
   fusion.addOutput(expanded_tv);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(expanded_tv), nullptr);
+  EXPECT_EQ(alias_analysis.getNearestAliasedIo(expanded_tv), in);
 }
 
 using AliasTest = NVFuserTest;

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -264,6 +264,24 @@ TEST_F(AliasAnalysisTest, MergeSlicedDimensions) {
   EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), nullptr);
 }
 
+TEST_F(AliasAnalysisTest, BroadcastExpandDimensions) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* in = makeContigConcreteTensor({2, 3});
+  fusion.addInput(in);
+  TensorView* broadcast_tv = broadcast(in, {false, true, false});
+  TensorView* expanded_tv = expand(
+      tv2,
+      {broadcast_tv->axis(0)->extent(),
+       IrBuilder::create<Val>(4),
+       broadcast_tv->axis(2)->extent()});
+  fusion.addOutput(expanded_tv);
+
+  AliasAnalysisResult alias_analysis = findAliases(&fusion);
+  EXPECT_EQ(alias_analysis.getNearestAliasedIo(expanded_tv), nullptr);
+}
+
 using AliasTest = NVFuserTest;
 
 TEST_F(AliasTest, View) {
@@ -926,6 +944,28 @@ TEST_F(AliasTest, Broadcast) {
   TensorView* out = broadcast(in, {false, true, false});
   fusion->addInput(in);
   fusion->addOutput(out);
+
+  FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor = at::randn({2, 3}).cuda();
+  at::Tensor out_tensor = fec.runFusionWithInputs({in_tensor})[0];
+  testValidate(fec.fusion(), {out_tensor}, {in_tensor}, __LINE__, __FILE__);
+
+  EXPECT_EQ(out_tensor.data_ptr(), in_tensor.data_ptr());
+}
+
+TEST_F(AliasTest, Expand) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* in = makeContigConcreteTensor({-1, -1});
+  fusion.addInput(in);
+  TensorView* broadcast_tv = broadcast(in, {false, true, false});
+  TensorView* expanded_tv = expand(
+      tv2,
+      {broadcast_tv->axis(0)->extent(),
+       IrBuilder::create<Val>(4),
+       broadcast_tv->axis(2)->extent()});
+  fusion.addOutput(expanded_tv);
 
   FusionExecutorCache fec(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -272,7 +272,7 @@ TEST_F(AliasAnalysisTest, BroadcastExpandDimensions) {
   fusion.addInput(in);
   TensorView* broadcast_tv = broadcast(in, {false, true, false});
   TensorView* expanded_tv = expand(
-      tv2,
+      broadcast_tv,
       {broadcast_tv->axis(0)->extent(),
        IrBuilder::create<Val>(4),
        broadcast_tv->axis(2)->extent()});
@@ -954,18 +954,18 @@ TEST_F(AliasTest, Broadcast) {
 }
 
 TEST_F(AliasTest, Expand) {
-  Fusion fusion;
-  FusionGuard fg(&fusion);
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
 
   TensorView* in = makeContigConcreteTensor({-1, -1});
-  fusion.addInput(in);
+  fusion->addInput(in);
   TensorView* broadcast_tv = broadcast(in, {false, true, false});
   TensorView* expanded_tv = expand(
-      tv2,
+      broadcast_tv,
       {broadcast_tv->axis(0)->extent(),
        IrBuilder::create<Val>(4),
        broadcast_tv->axis(2)->extent()});
-  fusion.addOutput(expanded_tv);
+  fusion->addOutput(expanded_tv);
 
   FusionExecutorCache fec(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();


### PR DESCRIPTION
Adding entry for `ExpandOp` in alias analysis to allow no-op for `broadcast + expand` pattern.