### PR TITLE
Fix for when allocation domains are promoted to reduction domains

### DIFF
--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -43,7 +43,7 @@ IterDomain* getLoopPromotion(IterDomain* loop_id, const IdModel& id_model) {
   return loop_promotion_map_it->second;
 }
 
-// True if a given domain is a loop doamin of a given tensor and its
+// True if a given domain is a loop domain of a given tensor and its
 // loop is partitioned with respect to the memory type of the tensor
 bool isPartitionedLoop(TensorView* tv, IterDomain* id) {
   // False if id is not a loop ID
@@ -59,12 +59,23 @@ bool isPartitionedLoop(TensorView* tv, IterDomain* id) {
 }
 
 bool isSizeOneDomain(IterDomain* id) {
-  return id->isBroadcast() || id->isReduction() || id->extent()->isOneInt();
+  return id->isBroadcast() || id->extent()->isOneInt();
 }
 
-// True if a given domain of a tensor *may* require allocation
-bool mayRequireAllocation(TensorView* tv, IterDomain* id) {
-  return !isPartitionedLoop(tv, id) && !isSizeOneDomain(id);
+// True if a given domain of a tensor *may* require allocation. The
+// optional promotion domain is also considered if given.
+bool mayRequireAllocation(
+    TensorView* tv,
+    IterDomain* id,
+    IterDomain* promotion_id = nullptr) {
+  // Conditions to consider:
+  // - Fully partitioned: Check the original ID, not the promotion ID
+  // - Size one: Check the promotion ID if given, the original ID otherwise.
+  // - Reduction: Check the original ID, not the promotion, which may
+  //   be a reduction ID even though the original ID is not a reduction
+  return !isPartitionedLoop(tv, id) &&
+      !isSizeOneDomain(promotion_id != nullptr ? promotion_id : id) &&
+      !id->isReduction();
 }
 
 // Get the allocation stride of a given allocation domain
@@ -139,6 +150,9 @@ std::tuple<std::vector<IterDomain*>, std::vector<Val*>> getAllocationDomains(
     }
   }
 
+  std::vector<IterDomain*> promoted_allocation_domains;
+  promoted_allocation_domains.reserve(allocation_domains.size());
+
   // Loop promotion may affect allocations. Promotions of intermediate
   // domains may not be defined correctly. Only consider loop domains
   // for now.
@@ -147,10 +161,13 @@ std::tuple<std::vector<IterDomain*>, std::vector<Val*>> getAllocationDomains(
                        tv->getLoopDomain().begin(),
                        tv->getLoopDomain().end(),
                        allocation_domain) != tv->getLoopDomain().end();
-    if (!is_loop) {
-      continue;
+    IterDomain* promotion_domain = nullptr;
+    if (is_loop) {
+      promotion_domain = getLoopPromotion(allocation_domain, id_model);
+    } else {
+      promotion_domain = allocation_domain;
     }
-    allocation_domain = getLoopPromotion(allocation_domain, id_model);
+    promoted_allocation_domains.push_back(promotion_domain);
   }
 
   // Compute the strides from innermost to outermost domains
@@ -159,8 +176,9 @@ std::tuple<std::vector<IterDomain*>, std::vector<Val*>> getAllocationDomains(
   for (const auto i : c10::irange(allocation_domains.size())) {
     auto dim = allocation_domains.size() - i - 1;
     auto allocation_domain = allocation_domains.at(dim);
+    auto promotion_domain = promoted_allocation_domains.at(dim);
 
-    if (!mayRequireAllocation(tv, allocation_domain)) {
+    if (!mayRequireAllocation(tv, allocation_domain, promotion_domain)) {
       continue;
     }
 
@@ -172,13 +190,14 @@ std::tuple<std::vector<IterDomain*>, std::vector<Val*>> getAllocationDomains(
     if (contig_flag.value()) {
       strides[dim] = cur_contig_stride;
       cur_contig_stride = SimplifyingIrBuilder::mulExpr(
-          allocation_domains.at(dim)->extent(), cur_contig_stride);
+          promotion_domain->extent(), cur_contig_stride);
     } else {
       // Assume that the tensor should always be a Global memory
       // tensor if it has non-contig allocation domains
       NVF_ERROR(tv->getMemoryType() == MemoryType::Global);
       strides[dim] = getStrideOfGlobalMemoryTensor(tv, (int64_t)dim);
-      cur_contig_stride = strides[dim];
+      cur_contig_stride = SimplifyingIrBuilder::mulExpr(
+          strides[dim], promotion_domain->extent());
     }
   }
 
@@ -191,12 +210,13 @@ std::tuple<std::vector<IterDomain*>, std::vector<Val*>> getAllocationDomains(
   std::vector<Val*> actual_strides;
   for (const auto i : c10::irange(allocation_domains.size())) {
     auto allocation_domain = allocation_domains.at(i);
-    if (!mayRequireAllocation(tv, allocation_domain)) {
+    auto promotion_domain = promoted_allocation_domains.at(i);
+    if (!mayRequireAllocation(tv, allocation_domain, promotion_domain)) {
       continue;
     }
     auto stride = strides.at(i);
     NVF_ERROR(stride != nullptr);
-    actual_allocation_domains.push_back(allocation_domain);
+    actual_allocation_domains.push_back(promotion_domain);
     actual_strides.push_back(stride);
   }
 

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -423,6 +423,54 @@ TEST_F(IndexingTest, SimpleReduction) {
   IndexValidator<GetReference>::validate(&fusion);
 }
 
+// Reduction with inlining. Loop promotion picks a reduction domain,
+// which indexing should not ignore.
+TEST_F(IndexingTest, PromotionToReductionDomain) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeContigTensor(2);
+  fusion.addInput(tv0);
+
+  auto tv1 = add(tv0, IrBuilder::create<Val>(1.0));
+  auto tv2 = sum(tv1, {1});
+  fusion.addOutput(tv2);
+
+  tv1->setMemoryType(MemoryType::Shared);
+
+  inlineMost();
+
+  tv1->axis(1)->parallelize(ParallelType::TIDx);
+  tv2->axis(1)->parallelize(ParallelType::TIDx);
+
+  // tv1's index should be "threadIdx.x". However, since its
+  // allocation domain, tv1->axis(1), is promoted to tv2->axis(1),
+  // which is a reduction domain, the initial version of indexing
+  // mistakenly excluded the domain from indexing.
+
+  struct GetReference : AbstractGetReference {
+    GetReference(const TensorIndexer& indexer)
+        : AbstractGetReference(indexer) {}
+
+    Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
+        const override {
+      bool as_consumer = maybe_consumer == nullptr;
+      auto consumer_tv = as_consumer ? tv : maybe_consumer;
+      std::vector<Val*> loop_indices = getLoopIndices(consumer_tv, indexer_);
+
+      switch (tv->name()) {
+        case 1: {
+          return loop_indices.at(1);
+        }
+        default:
+          return nullptr;
+      }
+    }
+  };
+
+  IndexValidator<GetReference>::validate(&fusion);
+}
+
 // Fusion copied from AllocationDomainTest.TransposedIntermediate
 TEST_F(IndexingTest, AllocationDomain) {
   Fusion fusion;


### PR DESCRIPTION
For non-global tensors, unless explicitly set, allocation domains are promotion domains of loop domains. Promotion can be a reduction domain even for non-reduction domains as there's no special handling for reduction domains. This can result in incorrect indexing with the current code. Specifically, we skip reduction domains from allocation, however, since we look at promotion domains, they may be reduction domains even though original loop domains are not. This can result in incorrectly skipping indexing. See the added unit test for a concrete example.

The fix in this PR is to use both the original loop domain and its promotion domain when determining the allocation domain of a given tensor to index.