### PR TITLE
Temporarily disable the overlap test.

### DIFF
--- a/tests/cpp/test_multidevice_overlap.cpp
+++ b/tests/cpp/test_multidevice_overlap.cpp
@@ -194,7 +194,7 @@ class OverlapTest : public MultiDeviceTest {
 //      the second is scattered. This is why we choose the layouts to be
 //      [S, sharded_axis, M, ...]
 // clang-format on
-TEST_F(OverlapTest, SimpleComputeComm) {
+TEST_F(OverlapTest, DISABLED_SimpleComputeComm) {
   std::vector<c10::cuda::CUDAStream> streams;
   for (auto j : c10::irange(params.S)) {
     // define the sliced tensors


### PR DESCRIPTION
It fails in CI
(https://github.com/NVIDIA/Fuser/actions/runs/9721491546/job/26834237293) for unrelated PRs and I am able to reliably reproduce this locally on A100x2.

cc @samnordmann 