### PR TITLE
remove iter gather

### DIFF
--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -188,10 +188,6 @@ class NVF_API IterDomain : public Val {
     return getIterType() == IterType::GatherScatter;
   }
 
-  bool isGather() const {
-    return getIterType() == IterType::Gather;
-  }
-
   bool isStride() const {
     return getIterType() == IterType::Stride;
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2561,10 +2561,6 @@ IterDomain* IterDomain::merge(
       outer->toString(),
       ", Inner: ",
       inner->toString());
-  NVF_CHECK(
-      (outer->isGather() && inner->isGather()) ||
-          (!outer->isGather() && !inner->isGather()),
-      "Merging gather and non-gather domains is not supported.");
 
   NVF_CHECK(
       !outer->isStride() && !inner->isStride(),
@@ -2700,11 +2696,6 @@ std::pair<IterDomain*, IterDomain*> IterDomain::swizzle(
         "swizzling broadcast axes not yet supported");
   }
 
-  // TODO: gather and shift check on swizzle
-  NVF_ERROR(
-      !in_x->isGather() && !in_y->isGather(),
-      "Swizzled gather not yet supported");
-
   IterDomain* out_x = IterDomainBuilder(in_x).build();
 
   IterDomain* out_y = IterDomainBuilder(in_y).build();
@@ -2734,11 +2725,6 @@ std::pair<IterDomain*, IterDomain*> IterDomain::swizzle(
         !input->as<IterDomain>()->isBroadcast(),
         "swizzling broadcast axes not yet supported");
   }
-
-  // TODO: gather and shift check on swizzle
-  NVF_ERROR(
-      !in_x->isGather() && !in_y->isGather(),
-      "Swizzled gather not yet supported");
 
   IterDomain* out_x = IterDomainBuilder(in_x).build();
 

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -125,7 +125,7 @@ IterType promoteIterType(IterType type1, IterType type2) {
   // Iteration: Default
   // Reduction: Should not appear here
   // Broadcast: Propagated only if type1 and type2 are Broadcast
-  // Gather: Converted to Iteration
+  // GatherScatter: Converted to Iteration
   // Stride: Shold not appear here
   // VectorComponent: Converted to Iteration
 
@@ -138,13 +138,11 @@ IterType promoteIterType(IterType type1, IterType type2) {
       "Invalid IterType: ",
       type2);
 
-  // Do not propagate Gather and VectorComponent
-  if (type1 == IterType::Gather || type1 == IterType::VectorComponent ||
-      type1 == IterType::GatherScatter) {
+  // Do not propagate GatherScatter and VectorComponent
+  if (type1 == IterType::VectorComponent || type1 == IterType::GatherScatter) {
     type1 = IterType::Iteration;
   }
-  if (type2 == IterType::Gather || type2 == IterType::VectorComponent ||
-      type2 == IterType::GatherScatter) {
+  if (type2 == IterType::VectorComponent || type2 == IterType::GatherScatter) {
     type2 = IterType::Iteration;
   }
 

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -795,8 +795,6 @@ static const char* iter_type2string(IterType t) {
       return "r";
     case IterType::Broadcast:
       return "b";
-    case IterType::Gather:
-      return "g";
     case IterType::Stride:
       return "s";
     case IterType::GatherScatter:

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -707,7 +707,6 @@ enum class IterType {
   Iteration,
   Reduction,
   Broadcast,
-  Gather,
   Stride,
   GatherScatter,
   VectorComponent,


### PR DESCRIPTION
`IterType::Gather` is no longer used after #2299 , so maybe we should also remove releated code about `IterType::Gather` or is there some special reason to keep it?