### PR TITLE
Destruct the singleton Communicator via testing::Environment. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,7 +607,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_pipeline.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_sharding.cpp
   )
-  add_test(test_multidevice "${MULTIDEVICE_TEST_SRCS}" "")
+  add_test_without_main(test_multidevice "${MULTIDEVICE_TEST_SRCS}" "")
   list(APPEND TEST_BINARIES test_multidevice)
 
   add_test(test_view "${NVFUSER_ROOT}/tests/cpp/test_gpu_view.cpp" "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,7 +555,7 @@ if(BUILD_TEST)
   target_include_directories(${RNG_TEST_KERNELS} PRIVATE "${NVFUSER_ROOT}")
 endif()
 
-function(add_test TEST_NAME TEST_SRC ADDITIONAL_LINK)
+function(add_test_without_main TEST_NAME TEST_SRC ADDITIONAL_LINK)
   list(APPEND TEST_SRC ${NVFUSER_ROOT}/tests/cpp/utils.cpp)
   add_executable(${TEST_NAME} ${TEST_SRC})
   set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD ${NVFUSER_CPP_STANDARD})
@@ -572,7 +572,7 @@ function(add_test TEST_NAME TEST_SRC ADDITIONAL_LINK)
     codegen_internal
     ${ADDITIONAL_LINK}
     dynamic_type
-    GTest::gtest_main GTest::gmock
+    GTest::gtest GTest::gmock
     flatbuffers
     ${TORCH_LIBRARIES}
   )
@@ -582,6 +582,11 @@ function(add_test TEST_NAME TEST_SRC ADDITIONAL_LINK)
       -Wall -Wno-unused-function -Werror
     )
   endif()
+endfunction()
+
+function(add_test TEST_NAME TEST_SRC ADDITIONAL_LINK)
+  list(APPEND ADDITIONAL_LINK "GTest::gtest_main")
+  add_test_without_main("${TEST_NAME}" "${TEST_SRC}" "${ADDITIONAL_LINK}")
 endfunction()
 
 if(BUILD_TEST)

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -215,7 +215,7 @@ Communicator::Communicator(
 }
 
 Communicator::~Communicator() {
-#ifdef NVFUSER_DISTRIBUTED
+#if defined(NVFUSER_DISTRIBUTED) && defined(USE_C10D_NCCL)
   for (auto& [key, backend] : backends_) {
     // Call shutdown before destructing a ProcessGroupNCCL as instructed by
     // https://github.com/pytorch/pytorch/blob/e62073d7997c9e63896cb5289ffd0874a8cc1838/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1164-L1170.

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -56,6 +56,7 @@ class Communicator {
   Communicator(
       CommunicatorBackend backend = comm_backend_default,
       RankType server_local_rank = comm_server_local_rank_default);
+  ~Communicator();
 
   Communicator(const Communicator&) = delete;
   Communicator& operator=(const Communicator&) = delete;

--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -232,3 +232,8 @@ PipelineTest::PipelineTest() {
 }
 
 } // namespace nvfuser
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -15,6 +15,20 @@
 
 namespace nvfuser {
 
+class MultiDeviceTestEnvironment : public testing::Environment {
+ public:
+  ~MultiDeviceTestEnvironment() override {}
+  void SetUp() override;
+  void TearDown() override;
+
+  static Communicator* getCommunicator() {
+    return communicator_;
+  }
+
+ private:
+  static Communicator* communicator_;
+};
+
 class MultiDeviceTest : public NVFuserTest {
  protected:
   MultiDeviceTest();
@@ -30,8 +44,6 @@ class MultiDeviceTest : public NVFuserTest {
       at::Tensor tensor,
       TensorView* tv,
       DeviceIdxType deviceId);
-
-  static Communicator* getOrCreateCommunicator();
 
   Communicator* communicator_;
   c10::TensorOptions tensor_options;


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/Fuser/issues/2497.

My other attempt (#2503) failed. There were errors that seem to be related to repeated create/delete the singleton Communicator, which I don't understand. This PR tries to create/delete the Communicator just once, keeping the behavior as close as before. 