### PR TITLE
patch isZero/isOne

### DIFF
--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -218,7 +218,7 @@ PolymorphicValue Val::evaluate() {
 }
 
 bool Val::isZero() const {
-  return value().hasValue() && (bool)(value() == 0);
+  return value().hasValue() && (bool)(value() == 0.0);
 }
 
 bool Val::isZeroInt() const {
@@ -227,7 +227,8 @@ bool Val::isZeroInt() const {
 }
 
 bool Val::isOne() const {
-  return value().hasValue() && (bool)(value() == 1);
+  // NOTE: does this work for complex?!
+  return value().hasValue() && (bool)(value() == 1.0);
 }
 
 bool Val::isOneInt() const {

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -227,7 +227,6 @@ bool Val::isZeroInt() const {
 }
 
 bool Val::isOne() const {
-  // NOTE: does this work for complex?!
   return value().hasValue() && (bool)(value() == 1.0);
 }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3972,7 +3972,8 @@ std::vector<PolymorphicValue> PadOp::evaluate(
   }
 
   if (isComplexType(*out()->getDataType())) {
-    std::complex<double> value = static_cast<std::complex<double>>(inputs.at(1));
+    std::complex<double> value =
+        static_cast<std::complex<double>>(inputs.at(1));
     auto real = at::real(in);
     auto imag = at::imag(in);
     auto padded_real = at::pad(real, pad_widths, "constant", value.real());

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3959,7 +3959,6 @@ std::vector<PolymorphicValue> PadOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   const auto& in = inputs.at(0).as<at::Tensor>();
-  double value = (double)inputs.at(1);
 
   std::vector<int64_t> pad_widths;
   auto pad_width_offset = getPadWidthInputOffset();
@@ -3972,7 +3971,17 @@ std::vector<PolymorphicValue> PadOp::evaluate(
     pad_widths.push_back(right_pad);
   }
 
-  return {at::pad(in, pad_widths, "constant", value)};
+  if (isComplexType(*out()->getDataType())) {
+    std::complex<double> value = static_cast<std::complex<double>>(inputs.at(1));
+    auto real = at::real(in);
+    auto imag = at::imag(in);
+    auto padded_real = at::pad(real, pad_widths, "constant", value.real());
+    auto padded_imag = at::pad(imag, pad_widths, "constant", value.imag());
+    return {at::complex(padded_real, padded_imag)};
+  } else {
+    double value = static_cast<double>(inputs.at(1));
+    return {at::pad(in, pad_widths, "constant", value)};
+  }
 }
 
 SliceOp::SliceOp(

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -3471,9 +3471,6 @@ TEST_F(ResizeTest, PadDtypes) {
     fusion->addOutput(out_tv);
 
     auto* pad_value = out_tv->definition()->as<PadOp>()->value();
-    std::cout << "dtype: " << pad_value->getDataType().value() << std::endl;
-    std::cout << "iszeor: " << pad_value->isZero() << std::endl;
-
     EXPECT_TRUE(pad_value->isZero());
     EXPECT_FALSE(pad_value->isOne());
   }

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -3467,7 +3467,8 @@ TEST_F(ResizeTest, PadDtypes) {
       continue;
     }
     auto full_tv = full({size}, fill_val, aten_to_data_type(dtype));
-    auto out_tv = pad(full_tv, {IrBuilder::create<Val>(1L), IrBuilder::create<Val>(1L)});
+    auto out_tv =
+        pad(full_tv, {IrBuilder::create<Val>(1L), IrBuilder::create<Val>(1L)});
     fusion->addOutput(out_tv);
 
     auto* pad_value = out_tv->definition()->as<PadOp>()->value();
@@ -3481,11 +3482,7 @@ TEST_F(ResizeTest, PadDtypes) {
     auto cg_outputs = executor_cache.runFusionWithInputs({size, 8});
 
     testValidate(
-        executor_cache.fusion(),
-        cg_outputs,
-        {size, 8},
-        __LINE__,
-        __FILE__);
+        executor_cache.fusion(), cg_outputs, {size, 8}, __LINE__, __FILE__);
   }
 }
 

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -3474,7 +3474,8 @@ TEST_F(TensorFactoryTest, FullPad) {
     std::cout << "dtype: " << pad_value->getDataType().value() << std::endl;
     std::cout << "iszeor: " << pad_value->isZero() << std::endl;
 
-    NVF_ERROR(pad_value->isZero(), "default pad value should be zero");
+    EXPECT_TRUE(pad_value->isZero());
+    EXPECT_FALSE(pad_value->isOne());
   }
 
   FusionExecutorCache executor_cache(std::move(fusion));

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -3442,7 +3442,7 @@ TEST_F(ResizeTest, CatMemoryPromotionReducedFloating) {
   }
 }
 
-TEST_F(TensorFactoryTest, FullPad) {
+TEST_F(ResizeTest, PadDtypes) {
   auto sizes = {0, 10};
   auto dtypes = {
       at::kBool,

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -3442,4 +3442,53 @@ TEST_F(ResizeTest, CatMemoryPromotionReducedFloating) {
   }
 }
 
+TEST_F(TensorFactoryTest, FullPad) {
+  auto sizes = {0, 10};
+  auto dtypes = {
+      at::kBool,
+      at::kFloat,
+      at::kLong,
+      at::kDouble,
+      at::kHalf,
+      at::kBFloat16,
+      at::kInt,
+      at::kComplexFloat,
+      at::kComplexDouble};
+
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  Val* size = IrBuilder::create<Val>(DataType::Int);
+  Val* fill_val = IrBuilder::create<Val>(DataType::Int);
+  fusion->addInput(size);
+  fusion->addInput(fill_val);
+  for (auto dtype : dtypes) {
+    if (!isSupportedTypeByDevice(aten_to_data_type(dtype))) {
+      continue;
+    }
+    auto full_tv = full({size}, fill_val, aten_to_data_type(dtype));
+    auto out_tv = pad(full_tv, {IrBuilder::create<Val>(1L), IrBuilder::create<Val>(1L)});
+    fusion->addOutput(out_tv);
+
+    auto* pad_value = out_tv->definition()->as<PadOp>()->value();
+    std::cout << "dtype: " << pad_value->getDataType().value() << std::endl;
+    std::cout << "iszeor: " << pad_value->isZero() << std::endl;
+
+    NVF_ERROR(pad_value->isZero(), "default pad value should be zero");
+  }
+
+  FusionExecutorCache executor_cache(std::move(fusion));
+
+  for (auto size : sizes) {
+    auto cg_outputs = executor_cache.runFusionWithInputs({size, 8});
+
+    testValidate(
+        executor_cache.fusion(),
+        cg_outputs,
+        {size, 8},
+        __LINE__,
+        __FILE__);
+  }
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
1. There's no overload across equal operator for `std::complex<T>, T`
```
auto x = std::complex<float>(0.0, 0.0);
x == 0; // This one triggers an error.
```

So we hit this with our dynamic type thing in `Val::isZero()`. But it magically worked if I change it from an integer to a float. I have no idea why. cc'ing @zasdfgbnm 

2. `at::pad` does not support complex dtype. But nvfuser API does. Added a chain of operation to support it.