### PR TITLE
Update pairwise mapping for `SDPAFwdOp` outputs

### DIFF
--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -495,8 +495,11 @@ SdpfaFwdResult sdpfa_fwd(
   // Scalar tensors of int64_t dtype.
   TensorView* philox_seed = TensorViewBuilder().dtype(DataType::Int).build();
   TensorView* philox_offset = TensorViewBuilder().dtype(DataType::Int).build();
+
+  // Thunder metadata represents debug_attn_mask of type int64_t, although the debug_attn_mask is of query.dtype.
+  // Since we use return_debug_mask=false in the internal flash attention call, this is a scalar zero tensor.
   TensorView* debug_attn_mask =
-      TensorViewBuilder().dtype(DataType::Int).build();
+      TensorViewBuilder().dtype(query->dtype()).build();
 
   // Set default values for dropout_p (0.0), is_causal(false)
   if (dropout_p == nullptr) {

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -471,11 +471,12 @@ SdpfaFwdResult sdpfa_fwd(
 
   // Create a new Tensorview for cum_seq_q, cum_seq_k of shape (N + 1)
   auto newForCumulativeSeq = [&]() -> TensorView* {
-    IterDomain* batch_id = IterDomainBuilder(query_domain.front()).is_rfactor_domain(true).build();
+    IterDomain* batch_id = ops::newOutputIterDomain({query_domain.front(), key_domain.front(), value_domain.front()});
     IterDomain* resized_batch_id = IterDomain::resize(
         batch_id,
         IrBuilder::create<Val>(0, DataType::Index),
-        IrBuilder::create<Val>(1, DataType::Index));
+        IrBuilder::create<Val>(1, DataType::Index),
+        /*mark_as_rfactor=*/true);
 
     return IrBuilder::create<TensorView>(
       IrBuilder::create<TensorDomain>(

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -471,7 +471,8 @@ SdpfaFwdResult sdpfa_fwd(
 
   // Create a new Tensorview for cum_seq_q, cum_seq_k of shape (N + 1)
   auto newForCumulativeSeq = [&]() -> TensorView* {
-    IterDomain* batch_id = ops::newOutputIterDomain({query_domain.front(), key_domain.front(), value_domain.front()});
+    IterDomain* batch_id = ops::newOutputIterDomain(
+        {query_domain.front(), key_domain.front(), value_domain.front()});
     IterDomain* resized_batch_id = IterDomain::resize(
         batch_id,
         IrBuilder::create<Val>(0, DataType::Index),
@@ -479,12 +480,13 @@ SdpfaFwdResult sdpfa_fwd(
         /*mark_as_rfactor=*/true);
 
     return IrBuilder::create<TensorView>(
-      IrBuilder::create<TensorDomain>(
-          std::vector({batch_id}),
-          std::vector({resized_batch_id}),
-          std::vector({resized_batch_id}),
-          TensorDomain::getContiguityFilledWith(std::vector({resized_batch_id}), true)),
-      DataType::Int);
+        IrBuilder::create<TensorDomain>(
+            std::vector({batch_id}),
+            std::vector({resized_batch_id}),
+            std::vector({resized_batch_id}),
+            TensorDomain::getContiguityFilledWith(
+                std::vector({resized_batch_id}), true)),
+        DataType::Int);
   };
 
   TensorView* cum_seq_q = newForCumulativeSeq();
@@ -497,8 +499,9 @@ SdpfaFwdResult sdpfa_fwd(
   TensorView* philox_seed = TensorViewBuilder().dtype(DataType::Int).build();
   TensorView* philox_offset = TensorViewBuilder().dtype(DataType::Int).build();
 
-  // Thunder metadata represents debug_attn_mask of type int64_t, although the debug_attn_mask is of query.dtype.
-  // Since we use return_debug_mask=false in the internal flash attention call, this is a scalar zero tensor.
+  // Thunder metadata represents debug_attn_mask of type int64_t, although the
+  // debug_attn_mask is of query.dtype. Since we use return_debug_mask=false in
+  // the internal flash attention call, this is a scalar zero tensor.
   TensorView* debug_attn_mask =
       TensorViewBuilder().dtype(query->dtype()).build();
 


### PR DESCRIPTION
This PR:
- modifies the variables `cum_seq_q/k` to have root_domain as `{iN}` and logical domain as `{iN+1}`.
- updates the tests to validate all inputs from the forward pass. This excludes the scalar outputs `query_seq_len/key_seq_len` which will added in the follow-up PR.

