### PR TITLE
Check for presence of ExprEval-only nodes early in canSchedule to avoid segmentation errors.

### DIFF
--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -456,7 +456,6 @@ bool hasAnyReductionOps(Fusion* fusion) {
   return hasOpsOfType<ReductionOp, GroupedReductionOp, WelfordOp>(fusion);
 }
 
-
 namespace {
 
 class ValReplacementMutator : private OptOutMutator {

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -456,9 +456,6 @@ bool hasAnyReductionOps(Fusion* fusion) {
   return hasOpsOfType<ReductionOp, GroupedReductionOp, WelfordOp>(fusion);
 }
 
-bool hasAnyMatmulOps(Fusion* fusion) {
-  return hasOpsOfType<LinearOp, MmaOp, MatmulOp, SdpaFwdOp>(fusion);
-}
 
 namespace {
 

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -632,9 +632,6 @@ std::vector<Expr*> getAllTypesOfReductionOps(Fusion* fusion);
 //! Returns true if fusion has any reduction ops.
 bool hasAnyReductionOps(Fusion* fusion);
 
-//! Returns true if fusion has any matmul ops.
-bool hasAnyMatmulOps(Fusion* fusion);
-
 int64_t getVectorizeSize(const TensorView* tv);
 
 // Returns the permutation from `in` to `out`, i.e., `out[i]==in[perm[i]]`. If

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -50,12 +50,6 @@ bool NoOpScheduler::canScheduleCompileTime(Fusion* fusion) {
     return true;
   }
 
-  if (ir_utils::hasAnyMatmulOps(fusion)) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        heuristicType(), "matmul ops are not supported");
-    return false;
-  }
-
   // Check there're no non-trivial reduction ops.
   for (auto reduction : ir_utils::getAllTypesOfReductionOps(fusion)) {
     for (auto output :

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -1100,13 +1100,6 @@ bool checkOpsAndInputs(Fusion* fusion, ScheduleHeuristic schedule_heuristic) {
     return false;
   }
 
-  // Fusions handled by persistent schedulers cannot have matmul ops.
-  if (ir_utils::hasAnyMatmulOps(fusion)) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        schedule_heuristic, "no support for matmul ops.");
-    return false;
-  }
-
   if (registry_utils::hasNonUniqueBcast(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
         schedule_heuristic,

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -47,13 +47,6 @@ bool PointWiseScheduler::canScheduleCompileTime(Fusion* fusion) {
     return false;
   }
 
-  // Fusions handled by pointwise scheduler cannot have matmul ops.
-  if (ir_utils::hasAnyMatmulOps(fusion)) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        heuristicType(), "no support for matmul ops.");
-    return false;
-  }
-
   if (!ir_utils::getViewOps(fusion).empty()) {
     ComputeAtMap ca_map(fusion);
     if (registry_utils::requiresForwardViewReplay(fusion, ca_map)) {

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -884,13 +884,6 @@ bool ReductionScheduler::canScheduleCompileTime(Fusion* fusion) {
     return false;
   }
 
-  // Fusions handled by reduction scheduler cannot have matmul ops.
-  if (ir_utils::hasAnyMatmulOps(fusion)) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        heuristicType(), "no support for matmul ops.");
-    return false;
-  }
-
   auto reduction_tvs = scheduler_utils::getReductionTvs(fusion);
 
   if (reduction_tvs.empty()) {

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -170,7 +170,20 @@ bool checkCanSchedule(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     HeuristicSummary* data_cache = nullptr) {
+
+  // ExprEval scheduler only requires `canScheduleCompileTime` check and should not use this fn.
+  // The following checks build the computeAt map that do not work with SDPAOp.
+  NVF_ERROR(SchedulerType::heuristicType() != ScheduleHeuristic::ExprEval);
+  
   FusionGuard fg(fusion);
+
+  // Fusions with `MatmulOp/LinearOp/SdpaOp` are only accepted in `ExprEval` scheduler, all other schedulers should reject them.
+  if (ir_utils::hasAnyMatmulOps(fusion)) {
+    scheduler_debug_utils::canScheduleRejectReason(
+        SchedulerType::heuristicType(), "Matmul ops are not supported");
+    return false;
+  }
+
   // If a data cache is given, the compile time part doesn't need to be checked,
   // since for all current use cases
   //  it has to pass all the compile time checks to create a data cache for this

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -177,20 +177,20 @@ bool checkCanSchedule(
 
   FusionGuard fg(fusion);
 
-  // Fusions with `MatmulOp/LinearOp/SdpaOp` are only accepted in `ExprEval`
+  // Fusions with `SdpaFwdOp` are only accepted in `ExprEval`
   // scheduler, all other schedulers should reject them.
-  if (ir_utils::hasOpsOfType<MatmulOp, LinearOp, SdpaFwdOp>(fusion)) {
+  if (ir_utils::hasOpsOfType<SdpaFwdOp>(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
         SchedulerType::heuristicType(),
-        "ExprEval-only nodes (MatmulOp/LinearOp/SdpaOps) are not supported.");
+        "SdpaOps are not supported.");
     return false;
   }
 
-  // Fusions with `MmaOp` are only accepted by Matmul scheduler.
+  // Fusions with `MatmulOp, LinearOp, MmaOp` can only be accepted by Matmul scheduler.
   if (SchedulerType::heuristicType() != ScheduleHeuristic::Matmul &&
-      ir_utils::hasOpsOfType<MmaOp>(fusion)) {
+      ir_utils::hasOpsOfType<MatmulOp, LinearOp, MmaOp>(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        SchedulerType::heuristicType(), "MmaOp is not supported.");
+        SchedulerType::heuristicType(), "Matmul ops are not supported.");
     return false;
   }
 

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -181,12 +181,12 @@ bool checkCanSchedule(
   // scheduler, all other schedulers should reject them.
   if (ir_utils::hasOpsOfType<SdpaFwdOp>(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
-        SchedulerType::heuristicType(),
-        "SdpaOps are not supported.");
+        SchedulerType::heuristicType(), "SdpaOps are not supported.");
     return false;
   }
 
-  // Fusions with `MatmulOp, LinearOp, MmaOp` can only be accepted by Matmul scheduler.
+  // Fusions with `MatmulOp, LinearOp, MmaOp` can only be accepted by Matmul
+  // scheduler.
   if (SchedulerType::heuristicType() != ScheduleHeuristic::Matmul &&
       ir_utils::hasOpsOfType<MatmulOp, LinearOp, MmaOp>(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(

--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -34,13 +34,6 @@ bool TransposeScheduler::canScheduleCompileTime(Fusion* fusion) {
     return false;
   }
 
-  // Fusions handled by transpose scheduler cannot have matmul ops.
-  if (ir_utils::hasAnyMatmulOps(fusion)) {
-    scheduler_debug_utils::canScheduleRejectReason(
-        heuristicType(), "no support for matmul ops.");
-    return false;
-  }
-
   for (auto select : ir_utils::getOpsOfType<SelectOp>(fusion)) {
     auto inner = TensorDomain::noReductions(
         select->input(0)->as<TensorView>()->getMaybeAllocationDomain());

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -523,7 +523,7 @@ TEST_F(SDPATest, AttnProgram) {
       /*scale=*/nullptr);
   TensorView* tvsdpa = segment_set(tvattn.output);
 
-  TensorView* tvout = add(tvsdpa, tvsdpa);    
+  TensorView* tvout = add(tvsdpa, tvsdpa);
   fusion->addOutput(tvout);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
@@ -533,7 +533,7 @@ TEST_F(SDPATest, AttnProgram) {
 
   double scale = 1.0 / std::sqrt(e);
   auto aten_outputs = at::_scaled_dot_product_flash_attention(
-      q+q,
+      q + q,
       k,
       v,
       /*dropout_p=*/0.0,

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -496,6 +496,8 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
       __FILE__);
 }
 
+// Test SDPA is segmented correctly. See issue #2517:
+// https://github.com/NVIDIA/Fuser/issues/2517
 TEST_F(SDPATest, AttnProgram) {
   NVFUSER_TEST_CUDA_ARCH_GUARD(8, 0);
   auto fusion = std::make_unique<Fusion>();


### PR DESCRIPTION
Resolves #2517.
`SdpaFwdOp` is not compatiable with computeAt map since the outputs of the op do not all have the same root domain.
For larger fusions containing `SdpaFwdOp`, `checkCanSchedule` runs into error due to this.
