### PR TITLE
Segment out meta ops from a fusion. 

### DIFF
--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -320,7 +320,11 @@ void Fusion::replaceOutput(Val* output, Val* replacement) {
     }
     if (output->getValType().value() == ValType::TensorView) {
       output->setIsFusionOutput(false);
-      output->as<TensorView>()->setMemoryType(MemoryType::Local);
+      // If `output` is both an input and an output before the replacement,
+      // don't localize it.
+      if (!output->isFusionInput()) {
+        output->as<TensorView>()->setMemoryType(MemoryType::Local);
+      }
     }
     // Mark uses invalid so that they will be reset next time uses() is called
     invalidateTvUses();

--- a/csrc/transform_replay.h
+++ b/csrc/transform_replay.h
@@ -289,9 +289,8 @@ struct MostInlinedTransformPropagator
 
 // Replays an `Expr` with the new input, `new_in`. This function currently has
 // the following limitations:
-// 1. It doesn't set isRFactorProduct correctly (#1857).
-// 2. It requires `e` to be a unary op, and therefore takes a single new input.
-// 3. It requires `e` to be a TensorView op, which takes and produces only
+// 1. It requires `e` to be a unary op, and therefore takes a single new input.
+// 2. It requires `e` to be a TensorView op, which takes and produces only
 // TensorViews.
 Expr* replayExprWithNewInput(Expr* e, Val* new_in);
 

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -1372,8 +1372,8 @@ TEST_F(AliasTest, SegmentMetaOps) {
   std::vector<at::Tensor> out_tensors = fec.runFusionWithInputs({in_tensor});
   testValidate(fec.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
-  at::Tensor slice_out_tensor = out_tensors[0];
-  EXPECT_TRUE(slice_out_tensor.is_alias_of(in_tensor));
+  at::Tensor permute_out_tensor = out_tensors[0];
+  EXPECT_TRUE(permute_out_tensor.is_alias_of(in_tensor));
 
   FusionKernelRuntime* runtime = fec.getMostRecentKernelRuntime();
   // MarkAliasesPrepare adds a `segment_set` between `in` and `permute`, which

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -673,8 +673,9 @@ TEST_F(AliasTest, Issue1452) {
 
   // Large enough to trigger vectorization.
   TensorView* in = makeContigConcreteTensor({1024, 1024});
-  TensorView* set_out = set(in);
-  TensorView* add_out = add(in, fusion->oneVal());
+  TensorView* t = reshape(in, {1024, 1024}, {1024 * 1024});
+  TensorView* set_out = set(t);
+  TensorView* add_out = add(t, fusion->oneVal());
   fusion->addInput(in);
   fusion->addOutput(set_out);
   fusion->addOutput(add_out);

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -25,7 +25,9 @@
 
 namespace nvfuser::preseg_passes {
 
-TEST_F(NVFuserTest, FusionTestOptimizationPassFlag_CUDA) {
+using PresegTest = NVFuserTest;
+
+TEST_F(PresegTest, FusionTestOptimizationPassFlag) {
   class DerivedPass : public OptimizationPass<DerivedPass> {
     friend class OptimizationPass<DerivedPass>;
 
@@ -53,7 +55,7 @@ TEST_F(NVFuserTest, FusionTestOptimizationPassFlag_CUDA) {
           ::testing::HasSubstr("running DerivedPass")));
 }
 
-TEST_F(NVFuserTest, FusionCyclicGraph_CUDA) {
+TEST_F(PresegTest, FusionCyclicGraph) {
   {
     auto fusion = std::make_unique<Fusion>();
     FusionGuard fg(fusion.get());
@@ -145,7 +147,7 @@ TEST_F(NVFuserTest, FusionCyclicGraph_CUDA) {
 }
 
 // Test cast optimization
-TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
+TEST_F(PresegTest, FusionTestCastOptimization) {
   std::vector<int64_t> input_shape{3, 7, 8};
   auto options = at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0);
   at::Tensor at_x = at::randn(input_shape, options);
@@ -164,8 +166,7 @@ TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
     tv = castOp(DataType::Double, tv);
     // (input)double -> float -> half -> float -> double
     fusion->addOutput(tv);
-    preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(
-        fusion.get());
+    OptimizationPass<PreSegmenter>::runPass(fusion.get());
     // simplified as (input)double -> half -> double
     auto ref_tv = castOp(DataType::Half, tv0);
     ref_tv = castOp(DataType::Double, ref_tv);
@@ -185,8 +186,7 @@ TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
     tv = castOp(DataType::Half, tv);
     // (input)double -> float -> double -> half
     fusion->addOutput(tv);
-    preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(
-        fusion.get());
+    OptimizationPass<PreSegmenter>::runPass(fusion.get());
     // simplified as (input)double -> half
     auto ref_tv = castOp(DataType::Half, tv0);
     ASSERT_TRUE(ref_tv->sameAs(fusion->outputs()[0]));
@@ -207,8 +207,7 @@ TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
     tv = castOp(DataType::Half, tv);
     // (input)double -> float -> half -> float -> double -> half
     fusion->addOutput(tv);
-    preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(
-        fusion.get());
+    OptimizationPass<PreSegmenter>::runPass(fusion.get());
     // simplified as (input)double -> half
     auto ref_tv = castOp(DataType::Half, tv0);
     ASSERT_TRUE(ref_tv->sameAs(fusion->outputs()[0]));
@@ -226,8 +225,7 @@ TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
     tv = castOp(DataType::Float, tv);
     // (input)float -> double -> float
     fusion->addOutput(tv);
-    preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(
-        fusion.get());
+    OptimizationPass<PreSegmenter>::runPass(fusion.get());
     // TODO: should I have copied the tensor to avoid an aliased output?!
     // simplified as (input)
     ASSERT_TRUE(tv0->sameAs(fusion->outputs()[0]));
@@ -253,8 +251,7 @@ TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
     // (input)float -> double -> half -> float -> double -> float -> double ->
     // float -> double -> float
     fusion->addOutput(tv);
-    preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(
-        fusion.get());
+    OptimizationPass<PreSegmenter>::runPass(fusion.get());
     // simplified as (input)float -> half -> float
     auto ref_tv = castOp(DataType::Half, tv0);
     ref_tv = castOp(DataType::Float, ref_tv);
@@ -276,8 +273,7 @@ TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
     tv = castOp(DataType::Float, tv);
     // (input)float -> double -> half -> float -> bfloat16 -> float
     fusion->addOutput(tv);
-    preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(
-        fusion.get());
+    OptimizationPass<PreSegmenter>::runPass(fusion.get());
     // simplified as (input)float -> half -> bfloat16 -> float
     auto ref_tv = castOp(DataType::Half, tv0);
     ref_tv = castOp(DataType::BFloat16, ref_tv);
@@ -302,8 +298,7 @@ TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
     // (input)int32 -> double -> complex double -> int64 -> bfloat16 -> float ->
     // double
     fusion->addOutput(tv);
-    preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(
-        fusion.get());
+    OptimizationPass<PreSegmenter>::runPass(fusion.get());
     // simplified as (input)int32 -> bfloat16 -> double
     auto ref_tv = castOp(DataType::BFloat16, tv0);
     ref_tv = castOp(DataType::Double, ref_tv);
@@ -325,8 +320,7 @@ TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
     tv = castOp(DataType::Float, tv);
     // (input)float -> double(output0) -> half -> double -> float(output1)
     fusion->addOutput(tv);
-    preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(
-        fusion.get());
+    OptimizationPass<PreSegmenter>::runPass(fusion.get());
     // simplified as (input)float -> double(output0) -> half -> float(output1)
     auto ref_tv = castOp(DataType::Double, tv0);
     ASSERT_TRUE(ref_tv->sameAs(fusion->outputs()[0]));
@@ -348,8 +342,7 @@ TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
     tv = castOp(DataType::Half, tv);
     // (input)float -> half -> bfloat16 -> half
     fusion->addOutput(tv);
-    preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(
-        fusion.get());
+    OptimizationPass<PreSegmenter>::runPass(fusion.get());
     // simplified as (input)float -> half -> bfloat -> half
     auto ref_tv = castOp(DataType::Half, tv0);
     ref_tv = castOp(DataType::BFloat16, ref_tv);
@@ -359,7 +352,7 @@ TEST_F(NVFuserTest, FusionTestCastOptimization_CUDA) {
 }
 
 // Test that we remove empty output branch before segmentation
-TEST_F(NVFuserTest, FusionRemoveEmptyOutput_CUDA) {
+TEST_F(PresegTest, FusionRemoveEmptyOutput) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(fusion_ptr.get());
@@ -394,7 +387,7 @@ TEST_F(NVFuserTest, FusionRemoveEmptyOutput_CUDA) {
 }
 
 // Test that we replace empty reduction with full
-TEST_F(NVFuserTest, FusionRemoveEmptyReduction_CUDA) {
+TEST_F(PresegTest, FusionRemoveEmptyReduction) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(fusion_ptr.get());
@@ -426,7 +419,7 @@ TEST_F(NVFuserTest, FusionRemoveEmptyReduction_CUDA) {
 // In this test, a reduction over a non-empty axis occurs first, followed by a
 // reduction over the remaining empty axis. The output is actually not empty,
 // even though the first reduction results in an empty tensor.
-TEST_F(NVFuserTest, FusionRemoveEmptyReductionWithNonReduction_CUDA) {
+TEST_F(PresegTest, FusionRemoveEmptyReductionWithNonReduction) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(fusion_ptr.get());
@@ -457,7 +450,7 @@ TEST_F(NVFuserTest, FusionRemoveEmptyReductionWithNonReduction_CUDA) {
 }
 
 // Test that we replace empty Welford with full
-TEST_F(NVFuserTest, FusionRemoveEmptyWelford_CUDA) {
+TEST_F(PresegTest, FusionRemoveEmptyWelford) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(fusion_ptr.get());
@@ -503,7 +496,7 @@ TEST_F(NVFuserTest, FusionRemoveEmptyWelford_CUDA) {
 }
 
 // Test that we replace empty tensors in cat properly
-TEST_F(NVFuserTest, FusionRemoveEmptyCat_CUDA) {
+TEST_F(PresegTest, FusionRemoveEmptyCat) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(fusion_ptr.get());
@@ -549,7 +542,7 @@ TEST_F(NVFuserTest, FusionRemoveEmptyCat_CUDA) {
 }
 
 // Test that we replace empty tensors in pad properly
-TEST_F(NVFuserTest, FusionRemoveEmptyPad_CUDA) {
+TEST_F(PresegTest, FusionRemoveEmptyPad) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(fusion_ptr.get());
@@ -587,7 +580,7 @@ TEST_F(NVFuserTest, FusionRemoveEmptyPad_CUDA) {
 }
 
 // Test that we replace empty tensors in matmuls properly
-TEST_F(NVFuserTest, FusionRemoveEmptyMatmul_CUDA) {
+TEST_F(PresegTest, FusionRemoveEmptyMatmul) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(fusion_ptr.get());
@@ -629,6 +622,24 @@ TEST_F(NVFuserTest, FusionRemoveEmptyMatmul_CUDA) {
   auto outputs = runtime.runWithInputs(args);
 
   testValidate(preseg_fusion, outputs, aten_inputs, __LINE__, __FILE__);
+}
+
+TEST_F(PresegTest, ReplaceOutput) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* x = makeContigTensor(1);
+  fusion->addInput(x);
+  fusion->addOutput(x);
+
+  TensorView* y = add(x, x);
+  fusion->replaceOutput(x, y);
+
+  FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor = at::randn({10}, at::device(at::kCUDA));
+  at::Tensor out_tensor = fec.runFusionWithInputs({in_tensor})[0];
+
+  testValidate(fec.fusion(), {out_tensor}, {in_tensor}, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser::preseg_passes

--- a/tests/python/test_pointwise.py
+++ b/tests/python/test_pointwise.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 import pytest
 import torch
 from nvfuser import FusionDefinition, DataType

--- a/tests/python/test_pointwise.py
+++ b/tests/python/test_pointwise.py
@@ -1,0 +1,69 @@
+import pytest
+import torch
+from nvfuser import FusionDefinition, DataType
+
+
+def test_issue_2395():
+    def create_fusion(fd: FusionDefinition) -> None:
+        cond0 = fd.define_tensor(
+            shape=[-1, -1, -1],
+            contiguity=[True, True, None],
+            dtype=DataType.Bool,
+            is_cpu=False,
+            stride_order=[2, 1, 0],
+        )
+        values = fd.define_tensor(
+            shape=[-1, -1, -1],
+            contiguity=[True, True, True],
+            dtype=DataType.Float,
+            is_cpu=False,
+            stride_order=[2, 1, 0],
+        )
+        cond1 = fd.define_tensor(
+            shape=[-1, -1],
+            contiguity=[True, True],
+            dtype=DataType.Bool,
+            is_cpu=False,
+            stride_order=[1, 0],
+        )
+        cond1 = fd.ops.broadcast_in_dim(
+            cond1, shape=[16, 16, 32], broadcast_dims=[0, 1]
+        )
+        sliced = fd.ops.slice(
+            values,
+            start_indices=[0, 0, 16],
+            end_indices=[16, 16, 32],
+            strides=[1, 1, 1],
+        )
+        zero = fd.define_scalar(0.00000, dtype=DataType.Double)
+        masked = fd.ops.where(cond1, zero, values)
+        masked = fd.ops.where(cond0, zero, masked)
+        fd.add_output(sliced)
+        fd.add_output(masked)
+
+    with FusionDefinition() as fd:
+        create_fusion(fd)
+    ins = [
+        torch.randint(0, 2, (256,), dtype=torch.bool, device="cuda:0").as_strided(
+            (16, 16, 32), (16, 1, 0)
+        ),
+        torch.randn((8192,), dtype=torch.float32, device="cuda:0").as_strided(
+            (16, 16, 32), (512, 32, 1)
+        ),
+        torch.randint(0, 2, (256,), dtype=torch.bool, device="cuda:0").as_strided(
+            (16, 16), (16, 1)
+        ),
+    ]
+    outs = fd.execute(ins)
+
+    torch.testing.assert_close(outs[0], ins[1][:, :, 16:], rtol=0, atol=0)
+    torch.testing.assert_close(
+        outs[1],
+        torch.where(
+            torch.logical_or(ins[0] == 1, ins[2].unsqueeze(-1) == 1), 0, ins[1]
+        ),
+    )
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
We currently do that to some extent by adding `segment_set` before aliased outputs. This PR modifies and extends the logic for aliased inputs as well. 

Fixes #2395 