### PR TITLE
Host IRs: support `SliceOp`

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -217,7 +217,8 @@ void handleWithExpressionEvaluator(
         "must be precomputed before being retrieved");
   }
   for (auto output : expr->outputs()) {
-    expr_evaluator.bind(output, expr_evaluator.evaluate(output), true);
+    expr_evaluator.bind(
+        output, expr_evaluator.evaluate(output), /*evaluate_validate=*/true);
   }
 }
 

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -202,6 +202,11 @@ void HostIrExecutor::handle(ForLoop* for_loop) {
   }
 }
 
+void HostIrExecutor::handle(SliceOp* slice_op) {
+  Val* output = slice_op->out();
+  expr_evaluator_.bind(output, expr_evaluator_.evaluate(output), true);
+}
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -207,10 +207,16 @@ void HostIrExecutor::handle(SliceOp* slice_op) {
 }
 
 void HostIrExecutor::handleWithExpressionEvaluator(Expr* expr) {
-  for (auto input: ir_utils::filterByType<TensorView>(expr->inputs())) {
-    NVF_ERROR(expr_evaluator_.isKnown(input), "input ", input->toString(), " of the expression ", expr->toString(), "must be precomputed before being retrieved");
+  for (auto input : ir_utils::filterByType<TensorView>(expr->inputs())) {
+    NVF_ERROR(
+        expr_evaluator_.isKnown(input),
+        "input ",
+        input->toString(),
+        " of the expression ",
+        expr->toString(),
+        "must be precomputed before being retrieved");
   }
-  for (auto output: expr->outputs()) {
+  for (auto output : expr->outputs()) {
     expr_evaluator_.bind(output, expr_evaluator_.evaluate(output), true);
   }
 }

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -203,8 +203,16 @@ void HostIrExecutor::handle(ForLoop* for_loop) {
 }
 
 void HostIrExecutor::handle(SliceOp* slice_op) {
-  Val* output = slice_op->out();
-  expr_evaluator_.bind(output, expr_evaluator_.evaluate(output), true);
+  return handleWithExpressionEvaluator(slice_op);
+}
+
+void HostIrExecutor::handleWithExpressionEvaluator(Expr* expr) {
+  for (auto input: ir_utils::filterByType<TensorView>(expr->inputs())) {
+    NVF_ERROR(expr_evaluator_.isKnown(input), "input ", input->toString(), " of the expression ", expr->toString(), "must be precomputed before being retrieved");
+  }
+  for (auto output: expr->outputs()) {
+    expr_evaluator_.bind(output, expr_evaluator_.evaluate(output), true);
+  }
 }
 
 } // namespace hir

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -77,8 +77,6 @@ class HostIrExecutor final : public OptInDispatch {
   void handle(ForLoop* for_loop) override;
   void handle(SliceOp* slice_op) override;
 
-  void handleWithExpressionEvaluator(Expr* expr);
-
   std::unique_ptr<HostIrContainer> container_;
   Communicator* communicator_;
   HostIrExecutorParams params_;

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -77,6 +77,8 @@ class HostIrExecutor final : public OptInDispatch {
   void handle(ForLoop* for_loop) override;
   void handle(SliceOp* slice_op) override;
 
+  void handleWithExpressionEvaluator(Expr* expr);
+
   std::unique_ptr<HostIrContainer> container_;
   Communicator* communicator_;
   HostIrExecutorParams params_;

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -75,6 +75,7 @@ class HostIrExecutor final : public OptInDispatch {
   void handle(Communication* communication) override;
   void handle(Wait* wait) override;
   void handle(ForLoop* for_loop) override;
+  void handle(SliceOp* slice_op) override;
 
   std::unique_ptr<HostIrContainer> container_;
   Communicator* communicator_;

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -686,10 +686,11 @@ TEST_P(SliceHostIrTest, SlicingTensor) {
       input_aten.dim(), at::indexing::Slice());
   ranges_aten.at(axis) = at::indexing::Slice(start, stop, step);
   auto ref_output = input_aten.index(ranges_aten);
-
-  EXPECT_TRUE(ref_output.equal(output))
-      << "input=" << input << "\nobtained output=" << output
-      << "\nexpected output=" << ref_output;
+  if (put_slice_op_in_top_level_expr) {
+    EXPECT_TRUE(ref_output.equal(output));
+  } else {
+    EXPECT_EQ(output.numel(), 0);
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
# What

add support for `SliceOp` in `HostIrExecutor`.

~~Stacked on top of #2533~~

# Why

Used in reduce-scatter overlap technic 
https://github.com/NVIDIA/Fuser/blob/bad998ae277ffc2f43fdc28dca07d01d737a1623/tests/cpp/test_multidevice_overlap.cpp#L129

# How 

We rely on `ExpressionEvaluator::evaluate` to execute the slice operation on the at::Tensor.

The `SliceOp` needs to be explicitly added to `HostIrExecutor::top_level_exprs_`, as illustrated in the provided unit test.