### PR TITLE
Clean double buffering references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_allocation_order_inference.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_ca_root_domain_map.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_combined_inner_outer_reduction.cpp
-  ${NVFUSER_ROOT}/tests/cpp/test_double_buffering.cpp
+  ${NVFUSER_ROOT}/tests/cpp/test_circular_buffering.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_abstract_tensor.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_dynamic_transform.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_evaluator.cpp

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -705,8 +705,7 @@ void CircularBufferInfo::setCircularBufferAxis(
   if (tv->isCircularBuffered()) {
     stage_depth = tv->circularBufferDepth();
   } else {
-    // Double buffer is essentially
-    //  circular buffer with depth 2.
+    // Double buffer is a circular buffer with depth 2.
     stage_depth = 2;
   }
 

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2492,7 +2492,7 @@ class ForLoop final : public Expr {
   //! True if loop is grouped reduction/welford
   bool isGroup() const;
 
-  //! Returns the stage of a double buffered iterdomain
+  //! Returns the stage of a circular buffered iterdomain
   //!  that this for loop materializes.
   auto circularBufferLoopStage() const {
     return attribute<CircularBufferLoopStage>(6);

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -152,7 +152,7 @@ inline bool initCoreHeuristics(
 
   if (!params->async_gmem_load_operands) {
     // Circular buffering requires async load. If we cannot use async load due
-    // to unsupported vectorization width, then we can only double buffer at
+    // to unsupported vectorization width, then we can only circular buffer at
     // most.
     params->circular_buffer_options.smem_circular_buffer_stage =
         std::min(2, params->circular_buffer_options.smem_circular_buffer_stage);

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -13,10 +13,10 @@
 namespace nvfuser {
 
 namespace {
-class DoubleBufferingTest : public NVFuserTest {};
+class CircularBufferingTest : public NVFuserTest {};
 } // anonymous namespace
 
-TEST_F(DoubleBufferingTest, DoubleBuffering1) {
+TEST_F(CircularBufferingTest, CircularBuffering1) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -55,7 +55,7 @@ TEST_F(DoubleBufferingTest, DoubleBuffering1) {
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
-TEST_F(DoubleBufferingTest, DoubleBuffering2) {
+TEST_F(CircularBufferingTest, CircularBuffering2) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -92,7 +92,7 @@ TEST_F(DoubleBufferingTest, DoubleBuffering2) {
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
-TEST_F(DoubleBufferingTest, DoubleBuffering3) {
+TEST_F(CircularBufferingTest, CircularBuffering3) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -113,12 +113,12 @@ TEST_F(DoubleBufferingTest, DoubleBuffering3) {
 
   tv0->computeAt(tv3, 1);
 
-  // tv2 is invalid to double-buffer as its producer, tv1, is
-  // computed inside the double-buffering loop.
+  // tv2 is invalid to circular-buffer as its producer, tv1, is
+  // computed inside the circular-buffering loop.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   ASSERT_ANY_THROW(tv2->circularBuffer(/*number_of_stages=*/2));
 
-  // Moving tv2 inner makes tv1 large enough to double-buffer tv2
+  // Moving tv2 inner makes tv1 large enough to circular-buffer tv2
   tv2->computeAt(tv3, 2);
 
   tv2->circularBuffer(/*number_of_stages=*/2);
@@ -138,8 +138,8 @@ TEST_F(DoubleBufferingTest, DoubleBuffering3) {
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
-// Double buffering smem to local and unswitch
-TEST_F(DoubleBufferingTest, DoubleBuffering4) {
+// circular buffering smem to local and unswitch
+TEST_F(CircularBufferingTest, CircularBuffering4) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -180,8 +180,8 @@ TEST_F(DoubleBufferingTest, DoubleBuffering4) {
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
-// Double buffering gmem to shared and unswitch
-TEST_F(DoubleBufferingTest, DoubleBuffering5) {
+// circular buffering gmem to shared and unswitch
+TEST_F(CircularBufferingTest, CircularBuffering5) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -221,8 +221,8 @@ TEST_F(DoubleBufferingTest, DoubleBuffering5) {
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
-// Double buffering smem to local and unroll
-TEST_F(DoubleBufferingTest, DoubleBuffering6) {
+// circular buffering smem to local and unroll
+TEST_F(CircularBufferingTest, CircularBuffering6) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -263,8 +263,8 @@ TEST_F(DoubleBufferingTest, DoubleBuffering6) {
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
-// Double buffering and vectorize
-TEST_F(DoubleBufferingTest, DoubleBuffering7) {
+// circular buffering and vectorize
+TEST_F(CircularBufferingTest, CircularBuffering7) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -300,8 +300,8 @@ TEST_F(DoubleBufferingTest, DoubleBuffering7) {
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
-// Multiple tensors to double-buffer
-TEST_F(DoubleBufferingTest, DoubleBuffering8) {
+// Multiple tensors to circular-buffer
+TEST_F(CircularBufferingTest, CircularBuffering8) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -342,8 +342,8 @@ TEST_F(DoubleBufferingTest, DoubleBuffering8) {
   testValidate(&fusion, cg_outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
 
-// Nested double buffering from gmem to smem and smem to register
-TEST_F(DoubleBufferingTest, DoubleBuffering9) {
+// Nested circular buffering from gmem to smem and smem to register
+TEST_F(CircularBufferingTest, CircularBuffering9) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -384,8 +384,8 @@ TEST_F(DoubleBufferingTest, DoubleBuffering9) {
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
-// FusionSmemBlockGemmCache + double buffering at both smem and local
-TEST_F(DoubleBufferingTest, SmemBlockGemmCacheDoubleBuffer) {
+// FusionSmemBlockGemmCache + circular buffering at both smem and local
+TEST_F(CircularBufferingTest, SmemBlockGemmCacheCircularBuffer) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -402,11 +402,11 @@ TEST_F(DoubleBufferingTest, SmemBlockGemmCacheDoubleBuffer) {
 
   TensorView* tv6 = tv5->cacheBefore();
 
-  // For smem double buffering
+  // For smem circular buffering
   auto tv0_cache_local = tv0->cacheAfter();
   auto tv1_cache_local = tv1->cacheAfter();
 
-  // For register double buffering
+  // For register circular buffering
   auto tv0_cache_smem = tv0->cacheAfter();
   auto tv1_cache_smem = tv1->cacheAfter();
 
@@ -468,15 +468,15 @@ TEST_F(DoubleBufferingTest, SmemBlockGemmCacheDoubleBuffer) {
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
   // The smem cache write in this test case is redundant predicated,
-  //   and also double buffered. Currently we are relying on WAR sync
-  //   insertion to ensure ordering of double buffered tensor access.
+  //   and also circular buffered. Currently we are relying on WAR sync
+  //   insertion to ensure ordering of circular buffered tensor access.
   // The check below makes sure that the sync is inserted so that the
   //   test isn't running on a race condition.
   NVF_CHECK(fe.kernel()->summary().war_hazard_syncs_count > 0);
 }
 
-// Vectorized reset test for double buffered registers
-TEST_F(DoubleBufferingTest, DoubleBufferVector) {
+// Vectorized reset test for circular buffered registers
+TEST_F(CircularBufferingTest, CircularBufferVector) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -517,10 +517,10 @@ TEST_F(DoubleBufferingTest, DoubleBufferVector) {
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
-// Simple test of async copy primitive: double buffered
-//   Double buffer case 1, both block sync and async wait
+// Simple test of async copy primitive: circular buffered
+//   circular buffer case 1, both block sync and async wait
 //  are needed.
-TEST_F(DoubleBufferingTest, DoubleBufferCpAsync1) {
+TEST_F(CircularBufferingTest, CircularBufferCpAsync1) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -551,7 +551,7 @@ TEST_F(DoubleBufferingTest, DoubleBufferCpAsync1) {
   tv2->split(1, 12);
   tv2->axis(-1)->parallelize(ParallelType::TIDx);
 
-  // Double buffer the shared mem tensor.
+  // circular buffer the shared mem tensor.
   tv0_shared->circularBuffer(/*number_of_stages=*/2);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -572,9 +572,9 @@ TEST_F(DoubleBufferingTest, DoubleBufferCpAsync1) {
   testValidate(&fusion, cg_outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
 
-// Simple test of async copy primitive: double buffered
-//   Double buffer case 2, only async wait is needed
-TEST_F(DoubleBufferingTest, DoubleBufferCpAsync2) {
+// Simple test of async copy primitive: circular buffered
+//   circular buffer case 2, only async wait is needed
+TEST_F(CircularBufferingTest, CircularBufferCpAsync2) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -604,7 +604,7 @@ TEST_F(DoubleBufferingTest, DoubleBufferCpAsync2) {
   tv2->split(1, 4);
   tv2->axis(-2)->parallelize(ParallelType::TIDx);
 
-  // Double buffer the shared mem tensor.
+  // circular buffer the shared mem tensor.
   tv0_shared->circularBuffer(/*number_of_stages=*/2);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -625,10 +625,10 @@ TEST_F(DoubleBufferingTest, DoubleBufferCpAsync2) {
   testValidate(&fusion, cg_outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
 
-// Simple test for double buffer in shared mem,
+// Simple test for circular buffer in shared mem,
 //  where we should not insert redundant syncs when
 //  they are not needed.
-TEST_F(DoubleBufferingTest, DoubleBufferNoSync) {
+TEST_F(CircularBufferingTest, CircularBufferNoSync) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -658,7 +658,7 @@ TEST_F(DoubleBufferingTest, DoubleBufferNoSync) {
   tv2->split(1, 4);
   tv2->axis(-2)->parallelize(ParallelType::TIDx);
 
-  // Double buffer the shared mem tensor.
+  // circular buffer the shared mem tensor.
   tv0_shared->circularBuffer(/*number_of_stages=*/2);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);

--- a/tests/cpp/test_gpu_fused_reduction.cpp
+++ b/tests/cpp/test_gpu_fused_reduction.cpp
@@ -174,7 +174,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce2_CUDA) {
 }
 
 // Grid reduction with serial non-reduction axis. The global work
-// buffer is double buffered.
+// buffer is circular buffered.
 TEST_F(NVFuserTest, FusionGridAllreduce3_CUDA) {
   const int nx = 100;
   const int ny = 5000;
@@ -428,7 +428,7 @@ TEST_F(NVFuserTest, FusionGridAllreduceWelford1_CUDA) {
 }
 
 // Grid welford reduction with serial non-reduction axis. The global
-// work buffer is double buffered.
+// work buffer is circular buffered.
 TEST_F(NVFuserTest, FusionGridAllreduceWelford2_CUDA) {
   const int nx = 100;
   const int ny = 5000;

--- a/tests/cpp/test_gpu_tensorcore.cpp
+++ b/tests/cpp/test_gpu_tensorcore.cpp
@@ -489,7 +489,7 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereSwizzle_CUDA) {
   }
 }
 
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulRegDoubleBuffer_CUDA) {
+TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulRegCircularBuffer_CUDA) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
   REQUIRE_DEVICE_SMEM_SIZE(70 << 10, 0);

--- a/tests/cpp/test_loop_rotation.cpp
+++ b/tests/cpp/test_loop_rotation.cpp
@@ -285,7 +285,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   }
 }
 
-TEST_F(LoopRotationTest, DoubleBuffered) {
+TEST_F(LoopRotationTest, CircularBuffered) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -396,7 +396,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   }
 }
 
-TEST_F(LoopRotationTest, SelectDoubleBufferLoad) {
+TEST_F(LoopRotationTest, SelectCircularBufferLoad) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -536,8 +536,8 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
 // This is a case similar to matmul, where we have
 // tv4 = set(tv0) // cp.async for matmul
 // tv1 = set(tv4) // ld.matrix for matmul
-// and both are double buffered
-TEST_F(LoopRotationTest, MultipleDoubleBuffer) {
+// and both are circular buffered
+TEST_F(LoopRotationTest, MultipleCircularBuffer) {
   if (!deviceMajorMinorCheck(8)) {
     GTEST_SKIP() << "skipping tests on pre-Ampere GPUs";
     return;


### PR DESCRIPTION
This PR renames the tests in `tests/cpp/test_double_buffering.cpp` to circular buffering. It also cleans other references to double-buffering.