### PR TITLE
Explicitly specify the device ID to ProcessGroup::barrier. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,6 +602,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/tests/cpp/multidevice.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_overlap.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_communications.cpp
+    ${NVFUSER_ROOT}/tests/cpp/test_multidevice_communicator.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_host_ir.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_matmul.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_pipeline.cpp

--- a/csrc/multidevice/c10d_mock.h
+++ b/csrc/multidevice/c10d_mock.h
@@ -66,9 +66,14 @@ struct ReduceOptions {
   int64_t rootRank = 0;
 };
 
+struct BarrierOptions {
+  std::vector<int64_t> device_ids;
+};
+
 class Backend : public torch::CustomClassHolder {
  public:
-  c10::intrusive_ptr<Work> barrier() {
+  c10::intrusive_ptr<Work> barrier(
+      const BarrierOptions& opts = BarrierOptions()) {
     return c10::make_intrusive<Work>();
   }
 

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -268,11 +268,11 @@ c10d::Backend* Communicator::getWorld(
 }
 
 void Communicator::barrier(std::optional<CommunicatorBackend> backend) {
-  // Explicitly specify the device ID to avoid a warning. Without this,
+  // Explicitly specify the (local) device ID to avoid a warning. Without this,
   // ProcessGroupNCCL::barrier may guess the wrong mapping and failed to block
   // CPU properly:
   // https://github.com/pytorch/pytorch/blob/7e4329c258306cc14303895e5f1e6036b009e74f/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L3905-L3912.
-  c10d::BarrierOptions options{.device_ids = {deviceId()}};
+  c10d::BarrierOptions options{.device_ids = {local_rank()}};
   getWorld(backend)->barrier(options)->wait();
 }
 

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -267,4 +267,13 @@ c10d::Backend* Communicator::getWorld(
   return getBackendForTeam(all_ranks, backend);
 }
 
+void Communicator::barrier(std::optional<CommunicatorBackend> backend) {
+  // Explicitly specify the device ID to avoid a warning. Without this,
+  // ProcessGroupNCCL::barrier may guess the wrong mapping and failed to block
+  // CPU properly:
+  // https://github.com/pytorch/pytorch/blob/7e4329c258306cc14303895e5f1e6036b009e74f/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L3905-L3912.
+  c10d::BarrierOptions options{.device_ids = {deviceId()}};
+  getWorld(backend)->barrier(options)->wait();
+}
+
 } // namespace nvfuser

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -82,9 +82,7 @@ class Communicator {
   }
 
   // performs a blocking barrier in the communicator
-  void barrier(std::optional<CommunicatorBackend> backend = std::nullopt) {
-    getWorld(backend)->barrier()->wait();
-  }
+  void barrier(std::optional<CommunicatorBackend> backend = std::nullopt);
 
   // returns the backend associated with a team
   // the argument "prefix" is prepended to the key used to retrieve preexisting

--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -34,7 +34,7 @@ void MultiDeviceTestEnvironment::TearDown() {
   delete communicator_;
 }
 
-/*static=*/Communicator* MultiDeviceTestEnvironment::communicator_ = nullptr;
+/*static*/ Communicator* MultiDeviceTestEnvironment::communicator_ = nullptr;
 
 MultiDeviceTest::MultiDeviceTest() {
   // Enable logging in c10d so debug messages can be printed out via

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -19,7 +19,7 @@ namespace nvfuser {
 
 class CommunicationTest
     : public MultiDeviceTest,
-      public ::testing::WithParamInterface<CommunicatorBackend> {
+      public testing::WithParamInterface<CommunicatorBackend> {
  protected:
   CommunicationTest();
   void SetUp() override;

--- a/tests/cpp/test_multidevice_communicator.cpp
+++ b/tests/cpp/test_multidevice_communicator.cpp
@@ -14,10 +14,12 @@
 
 namespace nvfuser {
 
-using CommunicatorTest = MultiDeviceTest;
+class CommunicatorTest
+    : public MultiDeviceTest,
+      public testing::WithParamInterface<CommunicatorBackend> {};
 
 // A regression test for #2499.
-TEST_F(CommunicatorTest, Barrier) {
+TEST_P(CommunicatorTest, Barrier) {
   using clock = std::chrono::high_resolution_clock;
 
   const auto rank = communicator_->deviceId();
@@ -42,5 +44,11 @@ TEST_F(CommunicatorTest, Barrier) {
     EXPECT_GE(duration, expected_duration - kUnitDuration / 2);
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    CommunicatorTest,
+    testing::Values(CommunicatorBackend::nccl, CommunicatorBackend::ucc),
+    testing::PrintToStringParamName());
 
 } // namespace nvfuser

--- a/tests/cpp/test_multidevice_communicator.cpp
+++ b/tests/cpp/test_multidevice_communicator.cpp
@@ -1,0 +1,46 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <chrono>
+
+#include <gtest/gtest.h>
+
+#include <multidevice/communicator.h>
+#include <tests/cpp/multidevice.h>
+
+namespace nvfuser {
+
+using CommunicatorTest = MultiDeviceTest;
+
+// A regression test for #2499.
+TEST_F(CommunicatorTest, Barrier) {
+  using clock = std::chrono::high_resolution_clock;
+
+  const auto rank = communicator_->deviceId();
+  constexpr int kNumIterations = 4;
+  constexpr auto kUnitDuration = std::chrono::milliseconds(500);
+
+  std::vector<std::chrono::time_point<clock>> end_times;
+  end_times.reserve(kNumIterations);
+  for ([[maybe_unused]] auto _ : c10::irange(kNumIterations)) {
+    // The last rank enters the barrier the last. Therefore, the duration per
+    // iteration is expected to be `kUnitDuration*(num_devices - 1)`.
+    std::this_thread::sleep_for(kUnitDuration * rank);
+    communicator_->barrier();
+    end_times.push_back(clock::now());
+  }
+
+  const auto expected_duration = kUnitDuration * (communicator_->size() - 1);
+  for (int i = 1; i < kNumIterations; i++) {
+    const auto duration = end_times[i] - end_times[i - 1];
+    // Expects `duration` to be close enoguh to `expected_duration`.
+    EXPECT_LE(duration, expected_duration + kUnitDuration / 2);
+    EXPECT_GE(duration, expected_duration - kUnitDuration / 2);
+  }
+}
+
+} // namespace nvfuser


### PR DESCRIPTION
See code comments. This PR avoids a warning in PyTorch and makes the code safer. It also checks in a test to verify #2499 is fixed. 

cc @eqy