### PR TITLE
Host irs: add support for `MatmulOp`

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -228,6 +228,10 @@ void HostIrExecutor::handle(SliceOp* slice_op) {
   return handleWithExpressionEvaluator(slice_op, expr_evaluator_);
 }
 
+void HostIrExecutor::handle(MatmulOp* matmul_op) {
+  return handleWithExpressionEvaluator(matmul_op, expr_evaluator_);
+}
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -76,6 +76,7 @@ class HostIrExecutor final : public OptInDispatch {
   void handle(Wait* wait) override;
   void handle(ForLoop* for_loop) override;
   void handle(SliceOp* slice_op) override;
+  void handle(MatmulOp* matmul_op) override;
 
   std::unique_ptr<HostIrContainer> container_;
   Communicator* communicator_;

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -732,15 +732,15 @@ TEST_F(MatmulHostIrTest, HostIr) {
   HostIrExecutor hie(std::move(hic));
 
   auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
-  c10::IValue A_ivalue = at::randn({H, M, K}, options);
-  c10::IValue B_ivalue = at::randn({H, K, N}, options);
+  at::Tensor a_tensor = at::randn({H, M, K}, options);
+  at::Tensor b_tensor = at::randn({H, K, N}, options);
   std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
-      {hie.inputs().at(0), A_ivalue}, {hie.inputs().at(1), B_ivalue}};
+      {hie.inputs().at(0), a_tensor}, {hie.inputs().at(1), b_tensor}};
 
   auto output = hie.runWithInput(concrete_input_buffers).at(0);
 
   // validate
-  auto ref_output = at::matmul(A_ivalue.toTensor(), B_ivalue.toTensor());
+  auto ref_output = at::matmul(a_tensor, b_tensor);
 
   EXPECT_TRUE(ref_output.allclose(output));
 }

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -719,15 +719,15 @@ TEST_F(MatmulHostIrTest, HostIr) {
   auto hic = std::make_unique<HostIrContainer>();
   FusionGuard fg(hic.get());
 
-  TensorView* A = makeContigTensor(3);
-  TensorView* B = makeContigTensor(3);
-  TensorView* C = matmul(A, B);
+  TensorView* a = makeContigTensor(3);
+  TensorView* b = makeContigTensor(3);
+  TensorView* c = matmul(a, b);
 
-  hic->addInput(A);
-  hic->addInput(B);
-  hic->addOutput(C);
+  hic->addInput(a);
+  hic->addInput(b);
+  hic->addOutput(c);
 
-  hic->pushBackTopLevelExprs(C->definition());
+  hic->pushBackTopLevelExprs(c->definition());
 
   HostIrExecutor hie(std::move(hic));
 


### PR DESCRIPTION
Adds support for `MatmulOp` in `HostIrExecutor`

The implementation makes it very easy to support new ops that `ExpressionEvaluator` can handle.


Stacked on top of 
- #2533
- #2535