### PR TITLE
Fix the computation of slice's output TV. 

### DIFF
--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -773,12 +773,13 @@ TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges) {
 
   bool needs_real_slicing = false;
   for (const auto idx : c10::irange(ndims)) {
-    auto inp_root_id = inp_dom[idx];
-    auto range = normalize_slice_range(ranges.at(idx), inp_root_id->extent());
+    IterDomain* inp_root_id = inp_dom[idx];
+    Val* inp_root_size = inp_root_id->getMaybeExpandedExtent();
+    Slice range = normalize_slice_range(ranges.at(idx), inp_root_size);
     normalized_ranges.at(idx) = range;
     IterDomain* out_root_id = nullptr;
     IterDomain* out_rf_id = nullptr;
-    if (range.start->isZeroInt() && range.stop->sameAs(inp_root_id->extent()) &&
+    if (range.start->isZeroInt() && range.stop->sameAs(inp_root_size) &&
         range.step->isOneInt()) {
       // This dim doesn't need slicing
       out_root_id = inp_root_id->cloneWithoutRFactor();
@@ -790,8 +791,7 @@ TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges) {
       out_rf_id = IterDomain::resize(
           out_root_id,
           SimplifyingIrBuilder::negExpr(range.start),
-          SimplifyingIrBuilder::subExpr(
-              range.stop, inp_root_id->getMaybeExpandedExtent()),
+          SimplifyingIrBuilder::subExpr(range.stop, inp_root_size),
           true);
       needs_real_slicing = true;
     }

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -790,7 +790,8 @@ TensorView* slice(TensorView* inp, const std::vector<Slice>& ranges) {
       out_rf_id = IterDomain::resize(
           out_root_id,
           SimplifyingIrBuilder::negExpr(range.start),
-          SimplifyingIrBuilder::subExpr(range.stop, inp_root_id->extent()),
+          SimplifyingIrBuilder::subExpr(
+              range.stop, inp_root_id->getMaybeExpandedExtent()),
           true);
       needs_real_slicing = true;
     }

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -1395,28 +1395,4 @@ TEST_F(AliasTest, SegmentMetaOps) {
   }
 }
 
-TEST_F(AliasTest, Issue2552) {
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-
-  TensorView* x = makeContigConcreteTensor({1, 3});
-  TensorView* y = makeContigConcreteTensor({1, 3});
-  fusion->addInput(x);
-  fusion->addInput(y);
-  x = expand(x, {IrBuilder::create<Val>(2), x->axis(1)->extent()});
-  x = slice(x, /*starts=*/{0, 0}, /*stops=*/{1, 3});
-  fusion->addOutput(x);
-  TensorView* z = add(x, y);
-  fusion->addOutput(z);
-
-  FusionExecutorCache fec(std::move(fusion));
-  auto options = at::dtype(at::kFloat).device(at::kCUDA);
-  at::Tensor x_tensor = at::randn({1, 3}, options);
-  at::Tensor y_tensor = at::randn({1, 3}, options);
-  std::vector<at::Tensor> out_tensors =
-      fec.runFusionWithInputs({x_tensor, y_tensor});
-  testValidate(
-      fec.fusion(), out_tensors, {x_tensor, y_tensor}, __LINE__, __FILE__);
-}
-
 } // namespace nvfuser

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -2220,7 +2220,9 @@ TEST_F(ResizeTest, FusionSqueezeSymbolic) {
   NVF_CHECK(ref0.equal(cg_outputs[0]));
 
   EXPECT_THAT(
-      [&]() { fec.runFusionWithInputs({t0, 10}); },
+      [&]() {
+        fec.runFusionWithInputs({t0, 10});
+      },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "must concretize to IterType::Broadcast but found")));
 }


### PR DESCRIPTION
Fixes #2552. 

CI: https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/pipelines/16451691