### PR TITLE
Rewrite TMA analysis

### DIFF
--- a/csrc/device_lower/analysis/tma.cpp
+++ b/csrc/device_lower/analysis/tma.cpp
@@ -285,10 +285,16 @@ class AnalyzeBoxingSplit : public Pass {
 };
 
 std::tuple<
-    std::unordered_set<ValGroup>,
-    std::unordered_set<ValGroup>,
-    std::list<TMADim>>
-run(std::list<std::pair<ExprGroup, Direction>>& exprs,
+    std::unordered_set<ValGroup>, // bulk groups, see the comment of
+                                  // InferBulkGroups for its definition
+    std::unordered_set<ValGroup>, // non-bulk groups, see the comment of
+                                  // InferNonBulkGroups for its definition
+    std::list<TMADim>> // inferred dimension information
+run(
+    // The whole path from consumer's loop domain to gmem tensor's allocation
+    // domain. Passed in as a non-const reference because passes will remove
+    // expressions from it when it has extracted information from them.
+    std::list<std::pair<ExprGroup, Direction>>& exprs,
     TensorView* consumer_tv) {
   ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
 

--- a/csrc/device_lower/analysis/tma.cpp
+++ b/csrc/device_lower/analysis/tma.cpp
@@ -17,6 +17,8 @@
 #include <unordered_map>
 #include <vector>
 
+// See doc/dev/tma.md for design
+
 namespace nvfuser {
 
 std::ostream& operator<<(std::ostream& os, const TMADim& d) {
@@ -48,33 +50,677 @@ int64_t getCpAsyncBulkTensorSwizzleSize(TensorView* smem_tv) {
   return 1;
 }
 
-// TODO: We should use utilities in val_graph_visitor.h so that we don't have
-// to manually filter out cyclic expr groups
-ExprGroups acyclicExprGroups(const ValGraph& id_graph, const ExprGroups& egs) {
-  ExprGroups result;
-  for (const auto& eg : egs) {
-    auto inputs = id_graph.inputGroups(eg);
-    auto outputs = id_graph.outputGroups(eg);
-    bool cyclic = false;
-    for (const auto& i : inputs) {
-      for (const auto& o : outputs) {
-        if (i == o) {
-          cyclic = true;
-          goto break_two_loops;
-        }
+// Infer roles (bulk, non-bulk, partitioned, box, tile, and stride) of ValGroups
+// by traversing along the traversal graph of the tensor indexer from the
+// consumer's loop domain to the gmem tensor's allocation domain. The end result
+// of the traversal are two sets of ValGroups: bulk and non-bulk, and a list of
+// TMADim objects describing the roles (partitioned, box, tile, and stride) of
+// ValGroups in a TMA dimension. Note that the returned list of TMADim objects
+// are not the final TMA dimensions, because: first, its order is not
+// determined; second, some dimensions may be collapsed according to the "define
+// box by compositing" mechanism; and third, implicit size-one box and implicit
+// whole box are not included.
+namespace infer_roles {
+// The traversal is done by a series of passes, each pass walks along the full
+// path of expressions from the consumer's loop domain to the gmem tensor's
+// allocation domain, but only looks for a specific pattern of ValGroups. Note
+// that different passes are designed in a way that each expression in the
+// traversal path is only useful for one pass. When one pass successfully
+// pattern match an expression and extracted its information, this expression
+// will become useless, therefore removed from the pending traversal path after
+// one pass consumes it.
+
+// Base class for all passes
+class Pass {
+ protected:
+  ValGroups from(const ExprGroup& expr, Direction direction) {
+    ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
+    return direction == Direction::Backward ? id_graph.outputGroups(expr)
+                                            : id_graph.inputGroups(expr);
+  }
+
+  ValGroups to(const ExprGroup& expr, Direction direction) {
+    ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
+    return direction == Direction::Backward ? id_graph.inputGroups(expr)
+                                            : id_graph.outputGroups(expr);
+  }
+
+  // Is this expr the pattern this pass is looking for?
+  virtual bool condition(ExprGroup expr, Direction direction) = 0;
+  // Extract information from the pattern
+  virtual void action(ExprGroup expr, Direction direction) = 0;
+
+ public:
+  // Traverse exprs. For each expr, loop for pattern as defined by condition.
+  // If condition is met, apply action and remove the expr from the list.
+  // Returns if any expr is removed.
+  bool run(std::list<std::pair<ExprGroup, Direction>>& exprs) {
+    bool changed = false;
+    for (auto it = exprs.begin(); it != exprs.end();) {
+      auto [expr, direction] = *it;
+      if (condition(expr, direction)) {
+        action(expr, direction);
+        it = exprs.erase(it);
+        changed = true;
+      } else {
+        it++;
       }
     }
-  break_two_loops:
-    if (!cyclic) {
-      result.pushBack(eg);
+    return changed;
+  }
+
+  virtual ~Pass() = default;
+};
+
+// A bulk group is a ValGroup that satisfies any of the following conditions:
+// - It contains an IterDomain in the loop domain of the consumer tensor that is
+//   parallelized with ParallelType::Bulk.
+// - On the path from the consumer tensor's loop group to the gmem tensor's
+//   allocation group, there is an expression that has all its from groups as
+//   bulk groups.
+// This pass assumes that bulk_groups is already initialized with the bulk
+// groups of the consumer tensor's loop domain.
+class InferBulkGroups : public Pass {
+  std::unordered_set<ValGroup>& bulk_groups_;
+
+  bool condition(ExprGroup expr, Direction direction) override {
+    auto from_ = from(expr, direction);
+    auto to_ = to(expr, direction);
+    return std::all_of(from_.begin(), from_.end(), [&](const ValGroup& g) {
+      return bulk_groups_.count(g) > 0;
+    });
+  }
+
+  void action(ExprGroup expr, Direction direction) override {
+    auto from_ = from(expr, direction);
+    auto to_ = to(expr, direction);
+    for (auto& g : to_) {
+      bulk_groups_.insert(std::move(g));
     }
+  }
+
+ public:
+  InferBulkGroups(std::unordered_set<ValGroup>& bulk_groups)
+      : bulk_groups_(bulk_groups) {}
+};
+
+// A non-bulk group is a ValGroup that satisfies any of the following
+// conditions:
+// - It contains an IterDomain in the loop domain of the consumer tensor that is
+//   NOT parallelized with ParallelType::Bulk.
+// - On the path from the consumer tensor's loop group to the gmem tensor's
+//   allocation group, there is an expression that has all its from groups as
+//   non-bulk groups.
+// This pass assumes that bulk_groups is already initialized with the non-bulk
+// groups of the consumer tensor's loop domain.
+class InferNonBulkGroups : public Pass {
+  std::unordered_set<ValGroup>& non_bulk_groups_;
+
+  bool condition(ExprGroup expr, Direction direction) override {
+    auto from_ = from(expr, direction);
+    auto to_ = to(expr, direction);
+    return std::all_of(from_.begin(), from_.end(), [&](const ValGroup& g) {
+      return non_bulk_groups_.count(g) > 0;
+    });
+  }
+
+  void action(ExprGroup expr, Direction direction) override {
+    auto from_ = from(expr, direction);
+    auto to_ = to(expr, direction);
+    for (auto& g : to_) {
+      non_bulk_groups_.insert(std::move(g));
+    }
+  }
+
+ public:
+  InferNonBulkGroups(std::unordered_set<ValGroup>& non_bulk_groups)
+      : non_bulk_groups_(non_bulk_groups) {}
+};
+
+// Note that not all groups are either bulk or non-bulk. Some groups are
+// neither. For example, if on the path from the consumer tensor's loop group to
+// the gmem tensor's allocation group, there is an expression that has two from
+// groups, one is bulk and the other is non-bulk, then the to group is neither
+// bulk nor non-bulk.
+
+// A striding split is a split or merge expression that splits a box group into
+// a tile group (outer) and a stride group (inner). Depending on the direction
+// of traversal, this expression can be either a split or merge. The stride
+// group must be a non-bulk group, and the tile group must be a bulk group. The
+// information extracted from a striding split is stored in inferred_dims_.
+class AnalyzeStridingSplit : public Pass {
+  const std::unordered_set<ValGroup>& bulk_groups_;
+  const std::unordered_set<ValGroup>& non_bulk_groups_;
+  std::list<TMADim>& inferred_dims_;
+
+  bool condition(ExprGroup expr, Direction direction) override {
+    if (!expr->front()->isOneOf<Split, Merge>()) {
+      return false;
+    }
+    auto from_ = from(expr, direction);
+    auto to_ = to(expr, direction);
+    return from_.size() == 2 && to_.size() == 1 &&
+        bulk_groups_.count(from_.at(0)) > 0 &&
+        non_bulk_groups_.count(from_.at(1)) > 0;
+  }
+
+  void action(ExprGroup expr, Direction direction) override {
+    auto from_ = from(expr, direction);
+    auto to_ = to(expr, direction);
+    inferred_dims_.emplace_back();
+    inferred_dims_.back().box = to_.at(0);
+    inferred_dims_.back().tile = from_.at(0);
+    inferred_dims_.back().stride = from_.at(1);
+    // The partitioned group may or may not be the same as the box group,
+    // depending on if there is a boxing split in the traversal path. Set
+    // partitioned group to the box group for now, and it may be updated by
+    // AnalyzeBoxingSplit later.
+    inferred_dims_.back().partitioned = to_.at(0);
+  }
+
+ public:
+  AnalyzeStridingSplit(
+      const std::unordered_set<ValGroup>& bulk_groups,
+      const std::unordered_set<ValGroup>& non_bulk_groups,
+      std::list<TMADim>& inferred_dims)
+      : bulk_groups_(bulk_groups),
+        non_bulk_groups_(non_bulk_groups),
+        inferred_dims_(inferred_dims) {}
+};
+
+// A boxing split is a split or merge expression that splits a partitioned group
+// into a coordinate group (outer) and a box group (inner). Depending on the
+// direction of traversal, this expression can be either a split or merge. The
+// coordinate group must be a non-bulk group and the box group must either be a
+// bulk group or a group that has been inferred as a box group by previous
+// passes.
+class AnalyzeBoxingSplit : public Pass {
+  const std::unordered_set<ValGroup>& bulk_groups_;
+  const std::unordered_set<ValGroup>& non_bulk_groups_;
+  std::list<TMADim>& inferred_dims_;
+
+  bool condition(ExprGroup expr, Direction direction) override {
+    auto from_ = from(expr, direction);
+    auto to_ = to(expr, direction);
+    return from_.size() == 2 && to_.size() == 1 &&
+        non_bulk_groups_.count(from_.at(0)) > 0 &&
+        (bulk_groups_.count(from_.at(1)) > 0 ||
+         std::any_of(
+             inferred_dims_.begin(),
+             inferred_dims_.end(),
+             [&](const TMADim& dim) { return dim.box == from_.at(1); }));
+  }
+
+  void action(ExprGroup expr, Direction direction) override {
+    auto from_ = from(expr, direction);
+    auto to_ = to(expr, direction);
+    auto dim_it = std::find_if(
+        inferred_dims_.begin(), inferred_dims_.end(), [&](const TMADim& dim) {
+          return dim.box == from_.at(1);
+        });
+    if (dim_it != inferred_dims_.end()) {
+      // If the box group has been inferred as a box group by previous passes,
+      // then there is no need to create a new entry in inferred_dims_. We just
+      // update the existing entry.
+      dim_it->partitioned = to_.at(0);
+    } else {
+      // There is no box group discovered by previous passes. This means that
+      // the box group is a bulk group. Create a new entry in inferred_dims_.
+      inferred_dims_.emplace_back();
+      inferred_dims_.back().partitioned = to_.at(0);
+      inferred_dims_.back().box = from_.at(1);
+      inferred_dims_.back().tile = from_.at(1);
+      inferred_dims_.back().stride = nullptr;
+    }
+  }
+
+ public:
+  AnalyzeBoxingSplit(
+      const std::unordered_set<ValGroup>& bulk_groups,
+      const std::unordered_set<ValGroup>& non_bulk_groups,
+      std::list<TMADim>& inferred_dims)
+      : bulk_groups_(bulk_groups),
+        non_bulk_groups_(non_bulk_groups),
+        inferred_dims_(inferred_dims) {}
+};
+
+std::tuple<
+    std::unordered_set<ValGroup>,
+    std::unordered_set<ValGroup>,
+    std::list<TMADim>>
+run(std::list<std::pair<ExprGroup, Direction>>& exprs,
+    TensorView* consumer_tv) {
+  ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
+
+  std::unordered_set<ValGroup> bulk_groups;
+  std::unordered_set<ValGroup> nonbulk_groups;
+  for (auto id : consumer_tv->getLoopDomain()) {
+    if (id->getParallelType() == ParallelType::Bulk) {
+      bulk_groups.insert(id_graph.toGroup(id));
+    } else {
+      nonbulk_groups.insert(id_graph.toGroup(id));
+    }
+  }
+
+  std::list<TMADim> inferred_dims;
+
+  InferBulkGroups bulk_pass(bulk_groups);
+  InferNonBulkGroups nonbulk_pass(nonbulk_groups);
+  AnalyzeStridingSplit striding_split_pass(
+      bulk_groups, nonbulk_groups, inferred_dims);
+  AnalyzeBoxingSplit boxing_split_pass(
+      bulk_groups, nonbulk_groups, inferred_dims);
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    changed = changed || bulk_pass.run(exprs);
+    changed = changed || nonbulk_pass.run(exprs);
+    changed = changed || striding_split_pass.run(exprs);
+    changed = changed || boxing_split_pass.run(exprs);
+  }
+  return {bulk_groups, nonbulk_groups, inferred_dims};
+}
+
+} // namespace infer_roles
+
+// View the allocation domain of the gmem tensor with given exprs, and compute
+// the contiguity and stride of each dimension in the view. Note that, usually,
+// the given exprs does not contain the full path from the consumer tensor's
+// loop domain to the gmem tensor's allocation domain, because many of the
+// expressions are removed by the infer_roles::run function before sending to
+// this function. Therefore, usually we are not viewing the gmem tensor's
+// allocation domain as the consumer tensor's loop domain, but as something in
+// the middle. We sometimes call this domain-in-the-middle the "raw TMA domain".
+namespace view_gmem_alloc_domain_with_exprs {
+
+// Get the allocation domain of the gmem tensor as ValGroups, and the contiguity
+// and stride of each dimension.
+std::list<std::tuple<ValGroup, /*contiguity*/ bool, /*stride*/ Val*>>
+getGmemAllocDomain(TensorView* gmem_tv) {
+  ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
+  std::list<std::tuple<ValGroup, /*contiguity*/ bool, /*stride*/ Val*>>
+      allocation_domain;
+  auto metadata = IrBuilder::metadataExpr(gmem_tv);
+  auto alloc_strides = IrBuilder::getAttrExpr(metadata, "alloc_stride");
+  auto gmem_alloc_dom =
+      TensorDomain::noReductions(gmem_tv->getMaybeAllocationDomain());
+  for (auto it = gmem_alloc_dom.begin(); it != gmem_alloc_dom.end(); it++) {
+    auto id = *it;
+    if (id->isBroadcast()) {
+      continue;
+    }
+    int64_t pos = std::distance(gmem_alloc_dom.begin(), it);
+    auto stride = IrBuilder::getItemExpr(alloc_strides, pos);
+    allocation_domain.emplace_back(
+        id_graph.toGroup(id), gmem_tv->getContiguity().at(pos).value(), stride);
+  }
+  return allocation_domain;
+}
+
+// Helper class that processes one expr in the traversal path
+class HandleExpr {
+  std::list<std::tuple<ValGroup, /*contiguity*/ bool, /*stride*/ Val*>>&
+      frontier_;
+
+  static auto from(ExprGroup expr, Direction direction) {
+    ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
+    return direction == Direction::Forward ? id_graph.outputGroups(expr)
+                                           : id_graph.inputGroups(expr);
+  }
+
+  static auto to(ExprGroup expr, Direction direction) {
+    ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
+    return direction == Direction::Forward ? id_graph.inputGroups(expr)
+                                           : id_graph.outputGroups(expr);
+  }
+
+  // Split one ValGroup in frontier_ into two ValGroups. Note that this is used
+  // to handle both Split and Merge, depending on the direction.
+  void handleOneToTwo(
+      std::vector<ValGroup> from,
+      std::vector<ValGroup> to,
+      ExprGroup expr) {
+    auto from_it =
+        std::find_if(frontier_.begin(), frontier_.end(), [from](auto tuple) {
+          return std::get<0>(tuple) == from[0];
+        });
+    NVF_ERROR(
+        from_it != frontier_.end(),
+        "The TMA domain must be equivalent to the allocation domain of the gmem tensor, but ",
+        from[0]->toString(),
+        " is not on the path.");
+    if (auto split = dynamic_cast<Split*>(expr->front())) {
+      // Only the forward of a split can be indivisible, otherwise, it is
+      // guaranteed to be divisible.
+      Val* is_divisible = SimplifyingIrBuilder::eqExpr(
+          SimplifyingIrBuilder::modExpr(
+              from[0]->front()->as<IterDomain>()->extent(), split->factor()),
+          split->fusion()->zeroVal());
+      GpuLower::current()->validate(
+          is_divisible,
+          "Invalid view in TMA: the extent of ",
+          from[0],
+          " must be divisible by ",
+          split->factor());
+    }
+    frontier_.insert(
+        from_it,
+        std::make_tuple(
+            to[0],
+            true,
+            SimplifyingIrBuilder::mulExpr(
+                std::get<2>(*from_it),
+                to[1]->front()->as<IterDomain>()->extent())));
+    std::get<0>(*from_it) = to[1];
+  }
+
+  // "Merge" two ValGroups in frontier_ into one ValGroup, and update the stride
+  // of the merged ValGroup. Note that this is used to handle both Split and
+  // Merge, depending on the direction.
+  void handleTwoToOne(std::vector<ValGroup> from, std::vector<ValGroup> to) {
+    auto outer = from[0];
+    auto outer_it =
+        std::find_if(frontier_.begin(), frontier_.end(), [outer](auto tuple) {
+          return std::get<0>(tuple) == outer;
+        });
+    NVF_ERROR(
+        outer_it != frontier_.end(),
+        "The TMA domain must be equivalent to the allocation domain of the gmem tensor, but ",
+        outer->toString(),
+        " is not on the path.");
+    auto inner = from[1];
+    auto inner_it = std::next(outer_it);
+    NVF_ERROR(
+        inner_it != frontier_.end(),
+        "The TMA domain must be equivalent to the allocation domain, but ",
+        inner->toString(),
+        " is not on the path.");
+    NVF_ERROR(
+        std::get<0>(*inner_it) == inner && std::get<1>(*outer_it),
+        "Can not merge discontiguous dimensions, but ",
+        outer->toString(),
+        " is merged with ",
+        inner->toString());
+    std::get<0>(*inner_it) = to[0];
+    frontier_.erase(outer_it);
+  }
+
+ public:
+  HandleExpr(
+      std::list<std::tuple<ValGroup, /*contiguity*/ bool, /*stride*/ Val*>>&
+          frontier)
+      : frontier_(frontier) {}
+
+  void handle(ExprGroup expr, Direction direction) {
+    NVF_ERROR(!expr->empty());
+    bool is_supported_expr = expr->front()->isOneOf<Split, Merge>();
+    NVF_ERROR(
+        is_supported_expr,
+        "TMA domain must be a view of the allocation domain of the gmem tensor, but ",
+        expr->toString(),
+        " is not a valid expression for view.");
+    auto from_ = from(expr, direction);
+    auto to_ = to(expr, direction);
+    if (from_.size() == 1) {
+      handleOneToTwo(from_, to_, expr);
+    } else {
+      handleTwoToOne(from_, to_);
+    }
+  }
+};
+
+std::list<std::tuple<ValGroup, /*contiguity*/ bool, /*stride*/ Val*>> run(
+    TensorView* gmem_tv,
+    std::list<std::pair<ExprGroup, Direction>>& exprs) {
+  // Initialize frontier as the allocation domain of gmem_tv
+  auto frontier = getGmemAllocDomain(gmem_tv);
+  // Propagate from the gmem allocation domain towards the consumer tensor's
+  // loop domain with the given exprs. Because the given exprs often do not
+  // contain the full path from the consumer tensor's loop domain to the gmem
+  // tensor's allocation domain, we will stop the propagation in the middle.
+  // This propagation must consume all expressions in the given list. If there
+  // is any unrecognized expression, this means there is an error in the
+  // schedule. The exprs are in the topology order from the consumer tensor's
+  // loop domain to the gmem tensor's allocation domain, so we need to use the
+  // reverse iterator to traverse.
+  HandleExpr handle_expr(frontier);
+  for (auto it = exprs.rbegin(); it != exprs.rend(); it++) {
+    auto [expr, direction] = *it;
+    handle_expr.handle(expr, direction);
+  }
+  return frontier;
+}
+
+} // namespace view_gmem_alloc_domain_with_exprs
+
+// Collapse the inferred raw TMA domain to get the final TMA domain according to
+// the "define box by compositing" mechanism.
+namespace collapse_tma_domain {
+
+// There can only be four types of ValGroups in the raw TMA domain:
+// -  P: partitioned ValGroup
+// -  C: coordinate ValGroup
+// - SB: strided box ValGroup
+// - CB: contiguous box ValGroup
+enum IDType { P, C, SB, CB };
+
+// Helper class for merging ValGroups and bookkeeping the information about
+// these groups
+class DomainMerger {
+  AbstractTensor domain_;
+  std::vector<std::pair<bool, Val*>> contiguity_and_stride_;
+  std::unordered_set<ValGroup>& bulk_groups_;
+  std::unordered_set<ValGroup>& nonbulk_groups_;
+  std::list<TMADim>& dim_info_;
+
+ public:
+  DomainMerger(
+      std::list<std::tuple<ValGroup, bool, Val*>> raw_tma_domain,
+      std::unordered_set<ValGroup>& bulk_groups,
+      std::unordered_set<ValGroup>& nonbulk_groups,
+      std::list<TMADim>& dim_info)
+      : bulk_groups_(bulk_groups),
+        nonbulk_groups_(nonbulk_groups),
+        dim_info_(dim_info) {
+    ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
+    domain_.domain.reserve(raw_tma_domain.size());
+    contiguity_and_stride_.reserve(raw_tma_domain.size());
+    for (auto& item : raw_tma_domain) {
+      domain_.domain.emplace_back(
+          ValGroupAndItsGraph{std::move(std::get<0>(item)), &id_graph});
+      contiguity_and_stride_.emplace_back(std::get<1>(item), std::get<2>(item));
+    }
+  }
+
+  bool contiguity(int64_t i) const {
+    return contiguity_and_stride_[i].first;
+  }
+
+  Val* stride(int64_t i) const {
+    return contiguity_and_stride_[i].second;
+  }
+
+  const ValGroup& operator[](int64_t i) const {
+    return domain_[i].as<ValGroupAndItsGraph>().group;
+  }
+
+  size_t size() const {
+    return domain_.size();
+  }
+
+  IDType type(int64_t i) const {
+    const auto& g = (*this)[i];
+    // Partitioned group must have already been inferred as a dimension in
+    // dim_info_, so we just try to find it. Note that dim.partitioned == g
+    // alone does not guarantee that g is a partitioned group, because it may
+    // also be a strided-box group.
+    if (std::any_of(dim_info_.begin(), dim_info_.end(), [&](const TMADim& dim) {
+          return dim.partitioned == g && dim.box != g;
+        })) {
+      return P;
+    }
+    auto dim_it = std::find_if(
+        dim_info_.begin(), dim_info_.end(), [&](const TMADim& dim) {
+          return dim.box == g;
+        });
+    // If there is an existing dimension info, use it.
+    if (dim_it != dim_info_.end()) {
+      if (dim_it->stride) {
+        NVF_ERROR(dim_it->tile != g);
+        return SB;
+      } else {
+        NVF_ERROR(dim_it->tile == g);
+        return CB;
+      }
+    }
+    // Otherwise, infer based on bulk_groups_ and nonbulk_groups_.
+    if (bulk_groups_.count(g) > 0) {
+      return CB;
+    }
+    NVF_ERROR(nonbulk_groups_.count(g) > 0);
+    return C;
+  }
+
+  void merge(int64_t i) {
+    auto type0 = type(i);
+    auto type1 = type(i + 1);
+    auto g0 = (*this)[i];
+    auto g1 = (*this)[i + 1];
+    domain_.merge(i);
+    contiguity_and_stride_.erase(contiguity_and_stride_.begin() + i);
+    const auto& g = (*this)[i];
+
+    // Update bulk_groups_ and nonbulk_groups_ by propagating through the merge.
+    if (bulk_groups_.count(g0) > 0 && bulk_groups_.count(g1) > 0) {
+      bulk_groups_.insert(g);
+    }
+    if (nonbulk_groups_.count(g0) > 0 && nonbulk_groups_.count(g1) > 0) {
+      nonbulk_groups_.insert(g);
+    }
+    // Set the dim_info_ for the merged group.
+    if (type0 == CB && type1 == CB) {
+      dim_info_.emplace_back();
+      dim_info_.back().partitioned = g;
+      dim_info_.back().box = g;
+      dim_info_.back().tile = g;
+      dim_info_.back().stride = nullptr;
+    } else if (type0 == C && (type1 == CB || type1 == SB)) {
+      dim_info_.emplace_back();
+      dim_info_.back().partitioned = g;
+      dim_info_.back().box = g1;
+      auto dim_it = std::find_if(
+          dim_info_.begin(), dim_info_.end(), [&](const TMADim& dim) {
+            return dim.partitioned == g1;
+          });
+      ValGroup tile, stride;
+      if (dim_it == dim_info_.end()) {
+        dim_info_.back().tile = g1;
+        dim_info_.back().stride = nullptr;
+      } else {
+        NVF_ERROR(dim_it->box == g1);
+        dim_info_.back().tile = dim_it->tile;
+        dim_info_.back().stride = dim_it->stride;
+      }
+    } else {
+      NVF_ERROR(type0 == C && type1 == C, "Invalid merge");
+      // Information about coordinate groups are not stored in dim_info_,
+      // nothing to do here.
+    }
+    // Remove the original dimensions from dim_info_.
+    auto it0 = std::find_if(
+        dim_info_.begin(), dim_info_.end(), [&](const TMADim& dim) {
+          return dim.partitioned == g0;
+        });
+    if (it0 != dim_info_.end()) {
+      dim_info_.erase(it0);
+    }
+    auto it1 = std::find_if(
+        dim_info_.begin(), dim_info_.end(), [&](const TMADim& dim) {
+          return dim.partitioned == g1;
+        });
+    if (it1 != dim_info_.end()) {
+      dim_info_.erase(it1);
+    }
+  }
+};
+
+// Do the collapse and returns the final TMA domnain. We first collapse
+// contiguous C groups to form larger C groups. and contiguous CB groups to form
+// larger CB groups. Then we collapse C group with its contiguous CB/SB groups
+// to form partitioned groups.
+std::vector<TMADim> run(
+    std::list<std::tuple<ValGroup, /*contiguity*/ bool, /*stride*/ Val*>>
+        raw_tma_domain,
+    std::unordered_set<ValGroup>& bulk_groups,
+    std::unordered_set<ValGroup>& nonbulk_groups,
+    std::list<TMADim>& dim_info,
+    int64_t item_size_bytes) {
+  DomainMerger tma_domain(
+      std::move(raw_tma_domain), bulk_groups, nonbulk_groups, dim_info);
+  // merge contiguous C groups and CB groups
+  for (int64_t i = 0; i < (int64_t)tma_domain.size() - 1; i++) {
+    if (!tma_domain.contiguity(i)) {
+      continue;
+    }
+    if ((tma_domain.type(i) == C && tma_domain.type(i + 1) == C) ||
+        (tma_domain.type(i) == CB && tma_domain.type(i + 1) == CB)) {
+      tma_domain.merge(i);
+      i--;
+    }
+  }
+  // merge contiguous C with SB/CB
+  for (int64_t i = 0; i < (int64_t)tma_domain.size() - 1; i++) {
+    if (!tma_domain.contiguity(i)) {
+      continue;
+    }
+    if (tma_domain.type(i) == C &&
+        (tma_domain.type(i + 1) == SB || tma_domain.type(i + 1) == CB)) {
+      tma_domain.merge(i);
+      i--;
+    }
+  }
+
+  // Compute the final TMA domain. As required by the hardware, tensors used by
+  // TMA must be in column major, so our final TMA domain is also from innermost
+  // to outermost.
+  std::vector<TMADim> result;
+  for (int64_t i = (int64_t)tma_domain.size() - 1; i >= 0; i--) {
+    const auto& g = tma_domain[i];
+    result.emplace_back();
+    auto dim_it =
+        std::find_if(dim_info.begin(), dim_info.end(), [&](const TMADim& dim) {
+          return dim.partitioned == g;
+        });
+    if (dim_it != dim_info.end()) {
+      // If there is already an entry in dim_info, just use it
+      result.back() = std::move(*dim_it);
+      dim_info.erase(dim_it);
+    } else {
+      // Otherwise, create a new entry
+      if (bulk_groups.count(g) > 0) {
+        // Implicit whole box dimension
+        result.back().partitioned = g;
+        result.back().box = g;
+        result.back().tile = g;
+        result.back().stride = nullptr;
+      } else {
+        // Implicit size-one box dimension
+        NVF_ERROR(nonbulk_groups.count(g) > 0, g->toString());
+        result.back().partitioned = g;
+        result.back().box = nullptr;
+        result.back().tile = nullptr;
+        result.back().stride = nullptr;
+      }
+    }
+    result.back().gmem_stride_bytes =
+        SimplifyingIrBuilder::mulExpr(tma_domain.stride(i), item_size_bytes);
   }
   return result;
 }
 
-// Analyze the schedule of the TMA expression, find the ValGroups for each role.
-// We first need to infer the TMA domain based on the schedule, which is done by
-// finding tile ValGroups first and analyze their definitions.
+} // namespace collapse_tma_domain
+
 TMAInfo getTMAInfo(LoadStoreOp* ldst) {
   TensorView* producer_tv = ldst->in()->as<TensorView>();
   TensorView* consumer_tv = ldst->out()->as<TensorView>();
@@ -90,399 +736,49 @@ TMAInfo getTMAInfo(LoadStoreOp* ldst) {
     gmem_tv = producer_tv;
   }
 
-  int64_t itemsize = dataTypeSize(gmem_tv->dtype());
+  std::list<std::pair<ExprGroup, Direction>> exprs = [&]() {
+    ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
+    auto exprs_vec = ValGraphBFS::getExprsBetween(
+        id_graph,
+        id_graph.toGroups(consumer_tv->getLoopDomain()),
+        id_graph.toGroups(gmem_tv->getMaybeAllocationDomain()));
+    return std::list(exprs_vec.begin(), exprs_vec.end());
+  }();
 
-  const TensorIndexer& indexer = GpuLower::current()->tensorIndexer();
-  ValGraph& id_graph = indexer.traversalGraph();
+  // Infer roles of ValGroups. In an expression is used to infer role, remove it
+  // from exprs.
+  auto [bulk_groups, nonbulk_groups, inferred_dims] =
+      infer_roles::run(exprs, consumer_tv);
 
-  auto gmem_alloc_dom = TensorDomain::noBroadcasts(
-      TensorDomain::noReductions(gmem_tv->getMaybeAllocationDomain()));
-  std::vector<ValGroup> gmem_alloc_groups_vec;
-  std::transform(
-      gmem_alloc_dom.begin(),
-      gmem_alloc_dom.end(),
-      std::back_inserter(gmem_alloc_groups_vec),
-      [&](IterDomain* id) { return id_graph.toGroup(id); });
-  ValGroups gmem_alloc_groups(gmem_alloc_groups_vec);
-  std::unordered_set<ValGroup> gmem_alloc_groups_set;
-  gmem_alloc_groups_set.reserve(gmem_alloc_dom.size());
-  std::transform(
-      gmem_alloc_dom.begin(),
-      gmem_alloc_dom.end(),
-      std::inserter(gmem_alloc_groups_set, gmem_alloc_groups_set.end()),
-      [&](IterDomain* id) { return id_graph.toGroup(id); });
+  // Treat the remaining expressions as view expressions to view the allocation
+  // domain of the gmem tensor as something in the middle between the consumer
+  // tensor's loop domain and the gmem tensor's allocation domain. The result is
+  // also called "raw TMA domain".
+  auto raw_tma_domain = view_gmem_alloc_domain_with_exprs::run(gmem_tv, exprs);
 
-  // Step 1: Get all bulk ValGroups and tile ValGroups.
-  // An ValGroup is considered "bulk" if it contains an IterDomain that has
-  // parallel type "Bulk" or all its children are considered "bulk". A "tile"
-  // ValGroup is a bulk ValGroup whose parents are not bulk.
-
-  // Get all bulk ValGroups
-  std::unordered_set<ValGroup> bulk_groups;
-  // Bulk ValGroup that we need to check its definition to see if it is a
-  // tile ValGroup.
-  std::deque<ValGroup> pending;
-  pending.push_back(nullptr); // use nullptr as a checkpoint
-  // Start from loop domain, where all the bulk IterDomains in the loop domain
-  // must be parallelized as ParallelType::Bulk.
-  for (auto id : consumer_tv->getLoopDomain()) {
-    if (id->getParallelType() == ParallelType::Bulk) {
-      auto g = id_graph.toGroup(id);
-      bulk_groups.insert(g);
-      pending.push_back(g);
-    }
-  }
-  // Use a BFS-like (not exactly BFS) algorithm to propagate back to get all
-  // bulk ValGroups
-  bool updated = true;
-  while (true) {
-    auto g = pending.front();
-    pending.pop_front();
-    if (g == nullptr) {
-      if (updated) {
-        // We discovered new bulk ValGroups in the last round, so we need to
-        // continue start a new round to see if we can discover more bulk
-        // ValGroups.
-        pending.push_back(nullptr);
-        updated = false;
-        continue;
-      } else {
-        // We have visited all ValGroups in pending for one round, but nothing
-        // has changed. This means that all ValGroups in pending are
-        // tile ValGroups, so we can no longer propagate further.
-        break;
-      }
-    }
-
-    auto defs = id_graph.getDefinitions(g);
-    NVF_ERROR(
-        gmem_alloc_groups_set.count(g) || !defs.empty(),
-        "Allocation domain of the gmem tensor is unreachable");
-    if (defs.empty() || gmem_alloc_groups_set.count(g)) {
-      pending.push_back(g);
-    } else {
-      for (const ExprGroup& def : defs) {
-        // We only continue propagating if we have not reached the allocation
-        // domain of the gmem tensor yet.
-        if (bulk_groups.count(id_graph.inputGroups(def)[0])) {
-          // already processed from another path
-          continue;
-        }
-        auto output_groups = id_graph.outputGroups(def);
-        bool should_propagate = std::all_of(
-            output_groups.begin(),
-            output_groups.end(),
-            [&](const ValGroup& out) { return bulk_groups.count(out) > 0; });
-
-        if (should_propagate) {
-          updated = true;
-          for (const auto& gg : id_graph.inputGroups(def)) {
-            if (bulk_groups.insert(gg).second) {
-              pending.push_back(gg);
-            }
-          }
-        } else {
-          // Not all outputs of def are bulk ValGroups, this could be because:
-          // 1. g is a tile ValGroup
-          // 2. g is not a tile ValGroup, we just haven't visited def's other
-          //    outputs yet.
-          pending.push_back(g);
-        }
-      }
-    }
-  }
-
-  // Get tile groups. Use VectorOfUniqueEntries instead of
-  // std::unordered_set to make the algorithm deterministic. However, the order
-  // here has no meaning, especially, is is not the order specifying which
-  // ValGroup is inner and which is outer. The actual order must be determined
-  // by propagating from the allocation domain of the gmem tensor.
-  VectorOfUniqueEntries<ValGroup> tile_groups;
-  for (const auto& g : pending) {
-    if (g == nullptr) {
-      continue;
-    }
-    tile_groups.pushBack(g);
-  }
-
-  // Step 2: Get the box, partitioned, and stride ValGroups from each tile
-  // ValGroup. Similarily, the order of the `tma_groups` has no meaning.
-  // So `tma_groups` contains the same set of ValGroups as the TMA domain, but
-  // can be in different order. We are using a std::vector<Val*> just to make
-  // the algorithm deterministic, not because we care about its order.
-
-  // tma_groups contains ValGroups known to be in the TMA domain. These
-  // ValGroups can be a box ValGroup or partitioned ValGroup. If a partitioned
-  // ValGroup is in tma_groups, this means that there is a box dimension defined
-  // by partitioning. If a box ValGroup is in tma_groups, this means that there
-  // is a box dimension defined by compositing.
-  std::vector<ValGroup> tma_groups;
-  std::unordered_map<ValGroup, ValGroup> tma_g_to_box_g;
-  std::unordered_map<ValGroup, std::pair<ValGroup, ValGroup>>
-      tma_g_to_tile_stride_g;
-  std::unordered_set<ValGroup> partitioned_groups;
-  for (const auto& tile_g : tile_groups) {
-    const auto& defs =
-        acyclicExprGroups(id_graph, id_graph.getDefinitions(tile_g));
-    NVF_ERROR(
-        defs.size() <= 1,
-        "Having multiple definitions of tile group is not supported");
-    ExprGroup striding_split = nullptr;
-    if (!defs.empty() && id_graph.outputGroups(defs.front())[0] == tile_g &&
-        defs.front()->front()->isA<Split>()) {
-      striding_split = defs.front();
-    }
-    ValGroup box_g =
-        (striding_split != nullptr ? id_graph.inputGroups(striding_split)[0]
-                                   : tile_g);
-    ValGroup stride_g =
-        (striding_split != nullptr ? id_graph.outputGroups(striding_split)[1]
-                                   : nullptr);
-    const ExprGroups& defs2 =
-        acyclicExprGroups(id_graph, id_graph.getDefinitions(box_g));
-    NVF_ERROR(
-        defs2.size() <= 1,
-        "Having multiple definitions of box group is not supported");
-    ExprGroup boxing_split = nullptr;
-    if (!defs2.empty() && defs2.front()->front()->isA<Split>()) {
-      boxing_split = defs2.front();
-    }
-    ValGroup partitioned_g =
-        (boxing_split != nullptr ? id_graph.inputGroups(boxing_split)[0]
-                                 : nullptr);
-    ValGroup tma_g = (partitioned_g != nullptr ? partitioned_g : box_g);
-
-    tma_groups.push_back(tma_g);
-    tma_g_to_box_g[tma_g] = box_g;
-    if (stride_g != nullptr) {
-      tma_g_to_tile_stride_g[tma_g] = {tile_g, stride_g};
-    }
-    if (partitioned_g != nullptr) {
-      partitioned_groups.insert(partitioned_g);
-    }
-  }
-
-  // Stpe 3: Propagate from the gmen tensor's allocation domain to the TMA
-  // domain, compute the order, contiguity, and stride of partitioned
-  // ValGroups. Note that this order is meaningful, and it is the order that
-  // defines which is inner and which is outer. The strides are also meaningful,
-  // and they are the `globalStrides` of the `cuTensorMapEncodeTiled`. After
-  // propagation, `frontier` will be the TMA domain
-
-  std::list<std::tuple<ValGroup, /*contiguity*/ bool, /*stride*/ Val*>>
-      frontier;
-  // Initialize frontier as the allocation domain
-  auto metadata = IrBuilder::metadataExpr(gmem_tv);
-  auto alloc_strides = IrBuilder::getAttrExpr(metadata, "alloc_stride");
-  // All allocation domains including broadcasts and reductions.
-  auto all_allocation_domains =
-      TensorDomain::noReductions(gmem_tv->getMaybeAllocationDomain());
-  for (auto id : gmem_alloc_dom) {
-    auto it = std::find(
-        all_allocation_domains.begin(), all_allocation_domains.end(), id);
-    NVF_ERROR(it != all_allocation_domains.end());
-    int64_t pos = it - all_allocation_domains.begin();
-    auto stride = IrBuilder::getItemExpr(alloc_strides, pos);
-    frontier.emplace_back(
-        id_graph.toGroup(id), gmem_tv->getContiguity().at(pos).value(), stride);
-  }
-  // Propagate forward from the gmem allocation domain to TMA ValGroups
-  for (auto [expr, direction] :
-       ValGraphBFS::getExprsBetween(id_graph, gmem_alloc_groups, tma_groups)) {
-    NVF_ERROR(!expr->empty());
-    NVF_ERROR(
-        direction == Direction::Forward,
-        "Backward propagation from allocation domain to TMA domain is not supported yet.");
-    if (expr->front()->isA<Split>()) {
-      Split* split = expr->front()->as<Split>();
-      auto in = id_graph.inputGroups(expr)[0];
-      auto in_it =
-          std::find_if(frontier.begin(), frontier.end(), [in](auto tuple) {
-            return std::get<0>(tuple) == in;
-          });
-      NVF_ERROR(
-          in_it != frontier.end(),
-          "The TMA domain must be equivalent to the allocation domain of the gmem tensor, but ",
-          in->toString(),
-          " is not on the path.");
-      Val* is_divisible = SimplifyingIrBuilder::eqExpr(
-          SimplifyingIrBuilder::modExpr(
-              in->front()->as<IterDomain>()->extent(), split->factor()),
-          gmem_tv->fusion()->zeroVal());
-      GpuLower::current()->validate(
-          is_divisible,
-          "Invalid view in TMA: the extent of ",
-          in,
-          " must be divisible by ",
-          split->factor());
-      frontier.insert(
-          in_it,
-          std::make_tuple(
-              id_graph.outputGroups(expr)[0],
-              true,
-              SimplifyingIrBuilder::mulExpr(
-                  std::get<2>(*in_it), split->factor())));
-      std::get<0>(*in_it) = id_graph.outputGroups(expr)[1];
-    } else if (expr->front()->isA<Merge>()) {
-      auto outer = id_graph.inputGroups(expr)[0];
-      auto outer_it =
-          std::find_if(frontier.begin(), frontier.end(), [outer](auto tuple) {
-            return std::get<0>(tuple) == outer;
-          });
-      NVF_ERROR(
-          outer_it != frontier.end(),
-          "The TMA domain must be equivalent to the allocation domain of the gmem tensor, but ",
-          outer->toString(),
-          " is not on the path.");
-      auto inner = id_graph.inputGroups(expr)[1];
-      auto inner_it = std::next(outer_it);
-      NVF_ERROR(
-          inner_it != frontier.end(),
-          "The TMA domain must be equivalent to the allocation domain, but ",
-          inner->toString(),
-          " is not on the path.");
-      NVF_ERROR(
-          std::get<0>(*inner_it) == inner && std::get<1>(*outer_it),
-          "Can not merge discontiguous dimensions, but ",
-          outer->toString(),
-          " is merged with ",
-          inner->toString());
-      std::get<0>(*inner_it) = id_graph.outputGroups(expr)[0];
-      frontier.erase(outer_it);
-    } else {
-      NVF_ERROR(
-          false,
-          "Unsupported expression between the allocation domain and TMA domain",
-          expr->toString());
-    }
-  }
-
-  // Frontier is now the TMA domain
   NVF_ERROR(
-      std::get<1>(frontier.back()),
+      std::get<1>(raw_tma_domain.back()),
       "The innermost dimension of the TMA domain must be contiguous");
+  auto inner_it = std::find_if(
+      inferred_dims.begin(), inferred_dims.end(), [&](const TMADim& dim) {
+        return dim.partitioned == std::get<0>(raw_tma_domain.back());
+      });
   NVF_ERROR(
-      tma_g_to_tile_stride_g.count(std::get<0>(frontier.back())) == 0,
+      inner_it == inferred_dims.end() || inner_it->stride == nullptr,
       "When interleave is CU_TENSOR_MAP_INTERLEAVE_NONE ",
       "(this is always the case for nvFuser now)",
       ", the first element of elementStrides must be one.");
 
-  // Validate that frontier is a superset of tma_groups, otherwise there is
-  // something wrong in the schedule.
-  {
-    std::unordered_set<ValGroup> seen;
-    std::unordered_set<ValGroup> pending_tma_groups(
-        tma_groups.begin(), tma_groups.end());
-    for (auto tuple : frontier) {
-      auto g = std::get<0>(tuple);
-      NVF_ERROR(
-          seen.insert(g).second,
-          "Mistake in schedule. Duplicate ValGroup found: ",
-          g->toString());
-      pending_tma_groups.erase(g);
-    }
-    NVF_ERROR(
-        pending_tma_groups.empty(),
-        "Can not infer TMA domain from the schedule. The ValGroup ",
-        ir_utils::toString(pending_tma_groups),
-        " are expected to be in the TMA domain.");
-  }
-
-  // Step 4: Handle "defining box by compositing"
-
-  // So far, we have infered the TMA domain. The size of TMA domain is not
-  // necessarily the dimensionality of TMA because we support defining box
-  // by compositing. We use AbstractTensor to further merge the TMA domain to
-  // the imagined TMA domain.
-  AbstractTensor tma_domain;
-  std::vector<bool> contiguity;
-  std::vector<Val*> global_strides;
-  tma_domain.domain.reserve(frontier.size());
-  global_strides.reserve(frontier.size());
-  contiguity.reserve(frontier.size());
-  for (auto& item : frontier) {
-    tma_domain.domain.emplace_back(
-        ValGroupAndItsGraph{std::move(std::get<0>(item)), &id_graph});
-    contiguity.push_back(std::get<1>(item));
-    global_strides.push_back(std::get<2>(item));
-  }
-  // There can only be four types of ValGroups in the TMA domain:
-  // -  P: partitioned ValGroup
-  // -  C: coordinate ValGroup
-  // - SB: strided box ValGroup
-  // - CB: contiguous box ValGroup
-  enum IDType { P, C, SB, CB };
-  auto gtype = [&](int64_t i) {
-    const auto& g = tma_domain[i].as<ValGroupAndItsGraph>().group;
-    return partitioned_groups.count(g)
-        ? P
-        : (!tma_g_to_box_g.count(g)
-               ? C
-               : (tma_g_to_tile_stride_g.count(g) ? SB : CB));
-  };
-  // merge contiguous C groups and CB groups
-  for (int64_t i = 0; i < (int64_t)tma_domain.size() - 1; i++) {
-    if (!contiguity[i]) {
-      continue;
-    }
-    bool is_c = (gtype(i) == C && gtype(i + 1) == C);
-    bool is_cb = (gtype(i) == CB && gtype(i + 1) == CB);
-    if (is_c || is_cb) {
-      tma_domain.merge(i);
-      contiguity.erase(contiguity.begin() + i);
-      global_strides.erase(global_strides.begin() + i);
-      if (is_cb) {
-        auto g = tma_domain[i].as<ValGroupAndItsGraph>().group;
-        tma_g_to_box_g.emplace(g, g);
-      }
-      i--;
-    }
-  }
-  // merge contiguous C with SB/CB
-  for (int64_t i = 0; i < (int64_t)tma_domain.size() - 1; i++) {
-    if (!contiguity[i]) {
-      continue;
-    }
-    bool this_is_c = (gtype(i) == C);
-    bool next_is_b = (gtype(i + 1) == SB || gtype(i + 1) == CB);
-    if (this_is_c && next_is_b) {
-      auto b = tma_domain[i + 1].as<ValGroupAndItsGraph>().group;
-      tma_domain.merge(i);
-      contiguity.erase(contiguity.begin() + i);
-      global_strides.erase(global_strides.begin() + i);
-      auto g = tma_domain[i].as<ValGroupAndItsGraph>().group;
-      tma_g_to_box_g.emplace(g, b);
-      if (auto it = tma_g_to_tile_stride_g.find(b);
-          it != tma_g_to_tile_stride_g.end()) {
-        tma_g_to_tile_stride_g.emplace(g, it->second);
-      }
-      i--;
-    }
-  }
-
-  // As required by the hardware, tensors used by TMA must be in column major
-  std::vector<TMADim> dims;
-  auto sit = global_strides.rbegin();
-  for (auto it = tma_domain.domain.rbegin(); it != tma_domain.domain.rend();
-       it++, sit++) {
-    auto g = it->as<ValGroupAndItsGraph>().group;
-    dims.emplace_back();
-    dims.back().partitioned = g;
-    if (auto it = tma_g_to_box_g.find(g); it != tma_g_to_box_g.end()) {
-      dims.back().box = it->second;
-    }
-    if (auto it = tma_g_to_tile_stride_g.find(g);
-        it != tma_g_to_tile_stride_g.end()) {
-      dims.back().tile = it->second.first;
-      dims.back().stride = it->second.second;
-    } else {
-      dims.back().tile = dims.back().box;
-    }
-    dims.back().gmem_stride_bytes =
-        SimplifyingIrBuilder::mulExpr(*sit, itemsize);
-  }
+  // Handle "defining box by compositing" by collapsing some dimensions in the
+  // raw TMA domain to get the final TMA domain.
+  auto final_tma_domain = collapse_tma_domain::run(
+      std::move(raw_tma_domain),
+      bulk_groups,
+      nonbulk_groups,
+      inferred_dims,
+      dataTypeSize(gmem_tv->dtype()));
   return TMAInfo(
-      std::move(dims),
+      std::move(final_tma_domain),
       getSwizzleFromBytes(
           getCpAsyncBulkTensorSwizzleSize(smem_tv) * core_matrix_width_bytes),
       gmem_tv);

--- a/csrc/device_lower/analysis/tma.h
+++ b/csrc/device_lower/analysis/tma.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <ostream>
 #include <unordered_map>
 #include <variant>
 #include <vector>

--- a/doc/dev/tma.md
+++ b/doc/dev/tma.md
@@ -151,7 +151,9 @@ Instead, the dimensionality of the imaginary TMA domain equals to the dimensiona
 Note that the number of IterDomains selected as box in a slice can be arbitrary.
 It can be as small as 0 IterDomains, or as large as the entire slice.
 When 0 IterDomains are selected as box, the box size is implicitly one.
+For this case, we call this box dimension "implicit size-one".
 When the entire slice is selected as box, the tensor only have one box on that dimension, and the size of the box equals the size of that dimension.
+For this case, we call this box dimension "implicit whole".
 
 ##### Define box by rotation
 


### PR DESCRIPTION
In the current main branch, the analysis in `csrc/device_lower/analysis/tma.cpp` mostly comes from copy-pasting the legacy indexing code of TMA with simple string replacement to fit for IdGraph. In this approach, although we are using IdGraph, I still don't consider it modern, because we are still assuming the traversal path to be like a TensorDomain (For example, traversal is only backward, no forward traversal is allowed, and each val group only have one definition).

This PR rewrites the TMA analysis to make it modern. This rewrite makes the analysis more extendable so that in the future I can easily add support for "define box by rotation". As a side effect of this rewrite, we now only requires a path from consumer's loop domain to gmem tv's allocation domain, and it does not matter if the traversal is forward or backward. This PR does not add any new unit tests, but in the next PR, I will add a few unit tests for testing backward+forward traversal. 

`tma.cpp` is almost completely rewritten, so I do not recommend looking at the diff. I suggest totally discard the original code and read the new code.

cc: @rdspring1 @protonu 