### PR TITLE
Host benchmarking 

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -357,7 +357,7 @@ def run_benchmark(
         benchmark_fn: Target function
         inputs: Inputs to the target function
         iobytes (Optional): When given, IO bytes computation is skipped
-                and this is used to compute the metrics.
+                and this is used to compute SOL and bandwidth.
         device (Optional): Default: CUDA, Possible values: ["cuda", "host"].
             Using device="host" is only allowed with nvFuser FusionDefinition.
         fusion_fn (Optional): Must be provided if device = "host".

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -338,7 +338,7 @@ class NVFBenchmark:
 
 # These variables can be overwritten through CLI commands
 # --benchmark-rounds=rounds --benchmark-warmup-rounds=warmup_rounds
-BENCHMARK_CONFIG = {"rounds": 1, "warmup_rounds": 0}
+BENCHMARK_CONFIG = {"rounds": 10, "warmup_rounds": 1}
 
 
 def run_benchmark(

--- a/benchmarks/python/test_many_pointwise_ops.py
+++ b/benchmarks/python/test_many_pointwise_ops.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype

--- a/benchmarks/python/test_many_pointwise_ops.py
+++ b/benchmarks/python/test_many_pointwise_ops.py
@@ -1,0 +1,54 @@
+import pytest
+from nvfuser import FusionDefinition, DataType
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from .core import run_benchmark, clear_cuda_cache
+import torch
+from .global_params import PROMOTE_DTYPES
+from functools import partial
+
+def pointwise_ops_fusion(
+    fd: FusionDefinition,
+    dtype: DataType,
+    num_iters: int
+):
+    x = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
+    y = fd.define_tensor(shape=[-1], contiguity=[True], dtype=dtype, is_cpu=False)
+
+    if dtype in PROMOTE_DTYPES:
+        x = fd.ops.cast(x, dtype=DataType.Float)
+        y = fd.ops.cast(y, dtype=DataType.Float)
+
+    a = fd.ops.add(x, y)
+    for _ in range(num_iters):
+        x = fd.ops.cos(a)
+        y = fd.ops.sin(a)
+        a = fd.ops.add(x, y)
+
+    if dtype in PROMOTE_DTYPES:
+        a = fd.ops.cast(a, dtype=dtype)
+    fd.add_output(a)
+
+#NOTE: num_iters restricted due to issue #1234.
+@pytest.mark.parametrize("num_iters", [16])
+def test_pointwise_ops_benchmark(
+    benchmark,
+    num_iters: int,
+    disable_validation: bool,
+    disable_benchmarking: bool,
+):  
+    clear_cuda_cache()
+    inputs = [torch.randn(13, device="cuda", dtype=torch.float16) for _ in range(2)]
+    with FusionDefinition() as fd:
+        pointwise_ops_fusion(fd, torch_dtype_to_nvfuser_dtype(torch.float16), num_iters)
+
+    # if not disable_validation:
+    #     eager_output = inputs[0] + inputs[1]
+    #     for _ in range(num_iters):
+    #         x = torch.cos(eager_output)
+    #         y = torch.sin(eager_output)
+    #         eager_output = x + y
+
+    #     fd.validate(inputs, [eager_output])
+
+    if not disable_benchmarking:
+        run_benchmark(benchmark, partial(fd.execute, profile=True), inputs, device="host", fd=fd)

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -4073,10 +4073,7 @@ class TestNvFuserFrontend(TestCase):
 
         # Testing that the profile returns 2 segments
         try:
-            fn = partial(fd.execute, profile=True)
-            breakpoint()
-            fn(inputs)
-            # fd.execute(inputs, profile=True)
+            fd.execute(inputs, profile=True)
             prof = fd.profile()
             self.assertEqual(prof.segments, 2)
             self.assertEqual(len(prof.kernel_profiles), 2)

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -4073,7 +4073,10 @@ class TestNvFuserFrontend(TestCase):
 
         # Testing that the profile returns 2 segments
         try:
-            fd.execute(inputs, profile=True)
+            fn = partial(fd.execute, profile=True)
+            breakpoint()
+            fn(inputs)
+            # fd.execute(inputs, profile=True)
             prof = fd.profile()
             self.assertEqual(prof.segments, 2)
             self.assertEqual(len(prof.kernel_profiles), 2)


### PR DESCRIPTION
1. Adds a fusion profiler based timer to measure the host timings for nvFuser.
2. To measure for uncached host overhead, the `setup` function resets `FusionCache` and initializes a new FusionDefinition