### PR TITLE
Sharded SDPAFwdOp

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4351,10 +4351,11 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
     return padded_inp;
   };
 
-  // Temporary hack to handle sharding the head dimension
-  // on the logical domain.
+  // Temporary handling of DID parallelization see
+  // https://github.com/NVIDIA/Fuser/issues/2563
   bool handle_device_dim = false;
   if (query.dim() == 5) {
+    NVF_CHECK(key.dim() == 5 && value.dim() == 5);
     handle_device_dim = true;
     query = query.squeeze(0);
     key = key.squeeze(0);

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4391,15 +4391,14 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
               /*return_debug_mask=*/false,
               scale);
 
-  // Add back the device dim axis for outputs with a head dimension.
-  if (handle_device_dim) {
-    output = output.unsqueeze(0);
-    log_sumexp = log_sumexp.unsqueeze(0);
-  }
-
   // If the inputs were padded, slice the output to restore the original size
   if (output.sizes()[3] != last_dim_size) {
     output = output.slice(-1, 0, last_dim_size);
+  }
+
+  // Add back the device dim axis for output.
+  if (handle_device_dim) {
+    output = output.unsqueeze(0);
   }
 
   // Query and key seq len are of type c10::SymInt -> convert them to CPU scalar

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4338,6 +4338,17 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
   const auto dropout_p = inputs.at(3).as<double>();
   const auto is_causal = inputs.at(4).as<bool>();
 
+  // Temporary handling of DID parallelization see
+  // https://github.com/NVIDIA/Fuser/issues/2563
+  bool handle_device_dim = false;
+  if (query.dim() == 5) {
+    NVF_CHECK(key.dim() == 5 && value.dim() == 5);
+    handle_device_dim = true;
+    query = query.squeeze(0);
+    key = key.squeeze(0);
+    value = value.squeeze(0);
+  }
+
   // Flash attention requires the last dimension to be padded to 8.
   // https://github.com/pytorch/pytorch/blob/c27882ffa8c1c7e4cf8ebc6c2f879e5b6c8814ad/aten/src/ATen/native/transformers/attention.cpp#L675-L677
   const auto last_dim_size = query.sizes()[3];
@@ -4350,17 +4361,6 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
     auto padded_inp = at::pad(inp, {0, pad_count});
     return padded_inp;
   };
-
-  // Temporary handling of DID parallelization see
-  // https://github.com/NVIDIA/Fuser/issues/2563
-  bool handle_device_dim = false;
-  if (query.dim() == 5) {
-    NVF_CHECK(key.dim() == 5 && value.dim() == 5);
-    handle_device_dim = true;
-    query = query.squeeze(0);
-    key = key.squeeze(0);
-    value = value.squeeze(0);
-  }
 
   query = pad_last_dim(query, 8);
   key = pad_last_dim(key, 8);

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -414,15 +414,20 @@ SdpfaFwdResult sdpfa_fwd(
   auto key_domain = TensorDomain::noReductions(key->getLogicalDomain());
   auto value_domain = TensorDomain::noReductions(value->getLogicalDomain());
 
+  // TODO: This is temporary until device dims are allowed on the loop domain.
+  auto concrete_query_size = TensorDomain::noDevices(query_domain).size();
+  auto concrete_key_size = TensorDomain::noDevices(key_domain).size();
+  auto concrete_value_size = TensorDomain::noDevices(value_domain).size();
+
   NVF_CHECK(
-      query_domain.size() == 4 && key_domain.size() == 4 &&
-          value_domain.size() == 4,
+      concrete_query_size == 4 && concrete_key_size == 4 &&
+          concrete_value_size == 4,
       "Expected query, key, and value to be 4D but got: ",
-      query_domain.size(),
+      concrete_query_size ,
       " ",
-      key_domain.size(),
+      concrete_key_size,
       " ,and ",
-      value_domain.size());
+      concrete_value_size);
 
   NVF_CHECK(
       !dropout_p || dropout_p->isScalar(),

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -414,7 +414,21 @@ SdpfaFwdResult sdpfa_fwd(
   auto key_domain = TensorDomain::noReductions(key->getLogicalDomain());
   auto value_domain = TensorDomain::noReductions(value->getLogicalDomain());
 
-  // TODO: This is temporary until device dims are allowed on the loop domain.
+  // Temporary handling of DID parallelization see
+  // https://github.com/NVIDIA/Fuser/issues/2563
+  bool has_device_dim = (query_domain.size() == 5);
+  if (has_device_dim) {
+    NVF_CHECK(
+        query_domain[0]->isDeviceDim(),
+        "Only suport DID parallelization on outermost axis");
+    NVF_CHECK(
+        key_domain[0]->isDeviceDim(),
+        "Only suport DID parallelization on outermost axis");
+    NVF_CHECK(
+        value_domain[0]->isDeviceDim(),
+        "Only suport DID parallelization on outermost axis");
+  }
+
   auto concrete_query_size = TensorDomain::noDevices(query_domain).size();
   auto concrete_key_size = TensorDomain::noDevices(key_domain).size();
   auto concrete_value_size = TensorDomain::noDevices(value_domain).size();
@@ -423,7 +437,7 @@ SdpfaFwdResult sdpfa_fwd(
       concrete_query_size == 4 && concrete_key_size == 4 &&
           concrete_value_size == 4,
       "Expected query, key, and value to be 4D but got: ",
-      concrete_query_size ,
+      concrete_query_size,
       " ",
       concrete_key_size,
       " ,and ",
@@ -475,9 +489,12 @@ SdpfaFwdResult sdpfa_fwd(
       IrBuilder::create<TensorView>(log_sumexp_td, DataType::Float);
 
   // Create a new Tensorview for cum_seq_q, cum_seq_k of shape (N + 1)
+  auto batch_idx = has_device_dim ? 1 : 0;
   auto newForCumulativeSeq = [&]() -> TensorView* {
     IterDomain* batch_id = ops::newOutputIterDomain(
-        {query_domain.front(), key_domain.front(), value_domain.front()});
+        {query_domain.at(batch_idx),
+         key_domain.at(batch_idx),
+         value_domain.at(batch_idx)});
     IterDomain* resized_batch_id = IterDomain::resize(
         batch_id,
         IrBuilder::create<Val>(0, DataType::Index),

--- a/csrc/preseg_passes/exact_mapped_extent_substitution.cpp
+++ b/csrc/preseg_passes/exact_mapped_extent_substitution.cpp
@@ -44,6 +44,10 @@ void exactMappedExtentSubstitution(Fusion* fusion) {
       // find the const extent, if already seen, check if they are the same
       if (id->getMaybeExpandedExtent()->isConstScalar()) {
         if (const_extent) {
+          if (!const_extent->sameAs(id->getMaybeExpandedExtent())) {
+            std::cout << id->toString() << std::endl;
+            std::cout << const_extent->toString() << " " << id->getMaybeExpandedExtent()->toString() << std::endl;
+          }
           NVF_CHECK(
               const_extent->sameAs(id->getMaybeExpandedExtent()),
               "Found two different const extents in the same set: ",

--- a/csrc/preseg_passes/exact_mapped_extent_substitution.cpp
+++ b/csrc/preseg_passes/exact_mapped_extent_substitution.cpp
@@ -44,10 +44,6 @@ void exactMappedExtentSubstitution(Fusion* fusion) {
       // find the const extent, if already seen, check if they are the same
       if (id->getMaybeExpandedExtent()->isConstScalar()) {
         if (const_extent) {
-          if (!const_extent->sameAs(id->getMaybeExpandedExtent())) {
-            std::cout << id->toString() << std::endl;
-            std::cout << const_extent->toString() << " " << id->getMaybeExpandedExtent()->toString() << std::endl;
-          }
           NVF_CHECK(
               const_extent->sameAs(id->getMaybeExpandedExtent()),
               "Found two different const extents in the same set: ",

--- a/csrc/root_domain_map.cpp
+++ b/csrc/root_domain_map.cpp
@@ -228,17 +228,16 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseRootDomainMap::map(
 
   if (SdpaFwdOp* op = dynamic_cast<SdpaFwdOp*>(consumer_tv_->definition())) {
     // Note: Explicit handling of DIDx(D) until
-    // https://github.com/NVIDIA/Fuser/issues/2563 is resolved. 
-    // Producers:
+    // https://github.com/NVIDIA/Fuser/issues/2563 is resolved. Producers:
     //   query = [DIDx(D)?, N, H, L, E]
     //   key = [DIDx(D)?, N, H, S, E]
     //   value = [DIDx(D)?, N, H, S, Ev]
     // Consumers:
     //   output = [DIDx(D)?, N, H, L, Ev]
-    //   logsumexp = [DIDx(D)?, N, H, L]
+    //   logsumexp = [N, H, L]
     //   cum_seq_q/k = [N + 1]
 
-    unsigned int num_device_dim = producer_logical.at(0)->isDeviceDim() ? 1 : 0;
+    size_t num_device_dim = producer_logical.at(0)->isDeviceDim() ? 1 : 0;
     // Map N, H from any input (query/key/value)
     for (auto idx : c10::irange(consumer_root.size())) {
       if (idx >= num_device_dim && idx < (2 + num_device_dim)) {
@@ -248,16 +247,16 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseRootDomainMap::map(
       // Map L, E from query and value respectively
       if (idx == (2 + num_device_dim) && producer_tv_->sameAs(op->query())) {
         updatePairwiseRootDomainMap(
-            producer_logical.at(3), consumer_root.at(3));
+            producer_logical.at(idx), consumer_root.at(idx));
       }
       // Map Ev from value to output
       if (idx == (3 + num_device_dim) && producer_tv_->sameAs(op->value())) {
         updatePairwiseRootDomainMap(
-            producer_logical.at(4), consumer_root.at(4));
+            producer_logical.at(idx), consumer_root.at(idx));
       }
     }
-    // Map D from any input (query/key/value) to output, logsumexp only.
-    if (num_device_dim == 1 && consumer_root.size() > 1) {
+    // Map D from any input (query/key/value) to output only.
+    if (num_device_dim == 1 && consumer_root.size() > 3) {
       updatePairwiseRootDomainMap(producer_logical.at(0), consumer_root.at(0));
     }
     return dom_map;

--- a/csrc/root_domain_map.cpp
+++ b/csrc/root_domain_map.cpp
@@ -228,7 +228,8 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseRootDomainMap::map(
 
   if (SdpaFwdOp* op = dynamic_cast<SdpaFwdOp*>(consumer_tv_->definition())) {
     // Note: Explicit handling of DIDx(D) until
-    // https://github.com/NVIDIA/Fuser/issues/2563 is resolved. Producers:
+    // https://github.com/NVIDIA/Fuser/issues/2563 is resolved. 
+    // Producers:
     //   query = [DIDx(D)?, N, H, L, E]
     //   key = [DIDx(D)?, N, H, S, E]
     //   value = [DIDx(D)?, N, H, S, Ev]

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -713,16 +713,16 @@ TEST_F(SDPATest, AttnFwdBwd) {
       __FILE__);
 }
 
-// TODO: Update/remove test when DID parallelization
-// allowed on loop domain.
+// TODO: Remove/update when https://github.com/NVIDIA/Fuser/issues/2563 is
+// resolved.
 TEST_F(SDPATest, Sharded_SdpaFwd) {
   NVFUSER_TEST_CUDA_ARCH_GUARD(8, 0);
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
   constexpr int64_t d = 4;
   auto mesh = DeviceMesh::createForNumDevices(d);
-  std::vector<int64_t> q_shape({d, n, h/d, l, e});
-  std::vector<int64_t> kv_shape({d, n, h/d, s, e});
+  std::vector<int64_t> q_shape({d, n, h / d, l, e});
+  std::vector<int64_t> kv_shape({d, n, h / d, s, e});
 
   auto tvq = makeConcreteTensor(q_shape, DataType::Half);
   auto tvk = makeConcreteTensor(kv_shape, DataType::Half);
@@ -744,7 +744,7 @@ TEST_F(SDPATest, Sharded_SdpaFwd) {
       /*dropout_p=*/IrBuilder::create<Val>(0.0),
       /*is_causal=*/IrBuilder::create<Val>(false),
       /*scale=*/nullptr);
-  
+
   addSdpaFwdOutputs(fusion.get(), output);
   for (TensorView* tv : {output.output, output.log_sumexp}) {
     tv->setDeviceMesh(mesh);
@@ -752,9 +752,9 @@ TEST_F(SDPATest, Sharded_SdpaFwd) {
   }
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-  at::Tensor q = at::randn({n, h/d, l, e}, options);
-  at::Tensor k = at::randn({n, h/d, s, e}, options);
-  at::Tensor v = at::randn({n, h/d, s, e}, options);
+  at::Tensor q = at::randn({n, h / d, l, e}, options);
+  at::Tensor k = at::randn({n, h / d, s, e}, options);
+  at::Tensor v = at::randn({n, h / d, s, e}, options);
 
   double scale = 1.0 / std::sqrt(e);
   auto aten_out = at::_scaled_dot_product_flash_attention(
@@ -765,18 +765,10 @@ TEST_F(SDPATest, Sharded_SdpaFwd) {
       /*is_causal=*/false,
       /*return_debug_mask=*/false,
       scale);
-  std::cout << "aten" << std::endl;
-  std::cout << std::get<0>(aten_out).sizes() << std::endl;
-  std::cout << std::get<1>(aten_out).sizes() << std::endl;
 
-  std::cout << "nvfuser" << std::endl;
-  
   FusionExecutorCache fec(std::move(fusion));
-  auto nvf_out = fec.runFusionWithInputs({q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0)});
-  std::cout << "nvfuser size " << nvf_out[8].sizes() << std::endl;
-  nvf_out[0].squeeze(0); // attn
-  nvf_out[1].squeeze(1); // log_sumexp
+  auto nvf_out =
+      fec.runFusionWithInputs({q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0)});
   validateSdpaFwdOutputs(nvf_out, aten_out);
 }
-
 } // namespace nvfuser


### PR DESCRIPTION
Temporarily add support for a sharded forward scaled dot product attention.
Currently, we only support DID parallelization on the logical domain which requires us to split and parallelize an axis at the logical level see https://github.com/NVIDIA/Fuser/issues/2563. This is a hack until we support DID parallelization on the loop domain after which this PR can be reverted.

Restrictions:
1. q,k,v inputs are manually sharded _before_ the SDPAFwdOp is created. We cannot rely on sharding propagation or sharding after the Fusion is created, because the dimension checks are called when the op is created. 
2. Only the head dimension is sharded and all inputs and outputs have either a sharded head dimension or unshaded. 
3. DID axis is the outermost axis. This is because during evaluation if we see 5 dimensions, it is assumed the first is the DID axis and is appropriately squeezed from the inputs and unsqueezed onto the outputs. 