### PR TITLE
Add option to benchmark a subset of inputs

### DIFF
--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -44,6 +44,13 @@ def pytest_addoption(parser):
         help="Number of warmup rounds for each benchmark.",
     )
 
+    parser.addoption(
+        "--benchmark-num-inputs",
+        action="store",
+        default=None,
+        help="Number of inputs to randomly sample for each benchmark.",
+    )
+
 
 @pytest.fixture
 def disable_validation(request):
@@ -70,6 +77,8 @@ def pytest_configure(config):
     BENCHMARK_CONFIG["warmup_rounds"] = int(
         config.getoption("--benchmark-warmup-rounds")
     )
+    if config.getoption("--benchmark-num-inputs"):
+        BENCHMARK_CONFIG["num_inputs"] = int(config.getoption("--benchmark-num-inputs"))
     config.addinivalue_line(
         "markers",
         "inner_outer_persistent: mark tests using inner_outer_persistent scheduler if not being segmented.",

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -116,6 +116,11 @@ def get_device_properties() -> Tuple[int, float]:
     return device_properties
 
 
+# These variables can be overwritten through CLI commands
+# --benchmark-rounds=rounds --benchmark-warmup-rounds=warmup_rounds
+# --benchmark-num-inputs=num_inputs
+BENCHMARK_CONFIG = {"rounds": 10, "warmup_rounds": 1, "num_inputs": None}
+
 DEVICE_PROPERTIES = get_device_properties()
 L2_CACHE_SIZE = DEVICE_PROPERTIES["gpu_l2_bytes"]
 PEAK_BANDWIDTH_GBPS = DEVICE_PROPERTIES["gpu_peak_bandwidth_gbps"]
@@ -310,11 +315,6 @@ class NVFBenchmark:
         self.benchmark.extra_info["% Peak Bandwidth (SOL)"] = (
             100 * (bandwidth_bps / 1024**3) / PEAK_BANDWIDTH_GBPS
         )
-
-
-# These variables can be overwritten through CLI commands
-# --benchmark-rounds=rounds --benchmark-warmup-rounds=warmup_rounds
-BENCHMARK_CONFIG = {"rounds": 10, "warmup_rounds": 1}
 
 
 def run_benchmark(

--- a/benchmarks/python/global_params.py
+++ b/benchmarks/python/global_params.py
@@ -4,9 +4,10 @@
 import torch
 from typing import Union, List, Tuple
 from nvfuser import DataType
-from .core import DEVICE_PROPERTIES
+from .core import DEVICE_PROPERTIES, BENCHMARK_CONFIG
 import itertools
 import os
+from random import sample
 
 # BENCHMARK_MODE = weekly/nightly.
 BENCHMARK_MODE = os.getenv("BENCHMARK_MODE")
@@ -149,6 +150,9 @@ def generate_input_sizes(dims: Union[int, List] = 2) -> List[Tuple]:
             raise NotImplementedError(
                 f"Generating input sizes of dimension {dim} is not implemented"
             )
+    if BENCHMARK_CONFIG["num_inputs"] is not None:
+        inputs = sample(inputs, BENCHMARK_CONFIG["num_inputs"])
+
     return inputs
 
 
@@ -162,4 +166,8 @@ def generate_attn_inputs():
             batch_range, seq_lengths, LLM_CONFIGS
         )
     ]
+
+    if BENCHMARK_CONFIG["num_inputs"] is not None:
+        inputs = sample(inputs, BENCHMARK_CONFIG["num_inputs"])
+
     return inputs


### PR DESCRIPTION
A subset of inputs can be run for each benchmark using `--benchmark-num-inputs=num_inputs`.
Allows for quick functionality test. By default, the entire suite will be run.

Closes Issue #2348.