### PR TITLE
Move and cleanup sharded mlp test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,6 +608,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_matmul.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_pipeline.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_sharding.cpp
+    ${NVFUSER_ROOT}/tests/cpp/test_multidevice_transformer.cpp
   )
   add_test_without_main(test_multidevice "${MULTIDEVICE_TEST_SRCS}" "")
   list(APPEND TEST_BINARIES test_multidevice)

--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -159,6 +159,13 @@ void MultiDeviceTest::SetUp() {
   return slice;
 }
 
+at::Tensor MultiDeviceTest::shardTensor(
+    at::Tensor tensor,
+    int64_t axis,
+    const DeviceMesh& mesh) {
+  return shardTensor(tensor, axis, mesh, communicator_->deviceId());
+}
+
 void PipelineTest::validate(bool validate_with_prescribed_values) {
   if (!validate_with_prescribed_values) {
     // execute the fusion on one device without pipeline scheduling

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -35,20 +35,12 @@ class MultiDeviceTest : public NVFuserTest {
   ~MultiDeviceTest();
   void SetUp() override;
 
-  // Given an aten tensor, TensorView the tensor is bound to, and deviceId
-  // returns a shard of the tensor according the sharding annotation in tv
+  // Returns a shard of the tensor according to the sharding annotation in tv
   // for the deviceId. If tensor is not sharded returns the original tensor.
   // TODO: If deviceId is not part of the mesh this should return an empty
   // tensor. Currently, we don't support this, so for now it returns a slice.
-  static at::Tensor shardTensor(
-      at::Tensor tensor,
-      TensorView* tv,
-      DeviceIdxType deviceId);
-  static at::Tensor shardTensor(
-      at::Tensor tensor,
-      int64_t axis,
-      const DeviceMesh& mesh,
-      DeviceIdxType deviceId);
+  at::Tensor shardTensor(at::Tensor tensor, TensorView* tv);
+
   at::Tensor shardTensor(
       at::Tensor tensor,
       int64_t axis,

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -44,12 +44,15 @@ class MultiDeviceTest : public NVFuserTest {
       at::Tensor tensor,
       TensorView* tv,
       DeviceIdxType deviceId);
-
   static at::Tensor shardTensor(
       at::Tensor tensor,
       int64_t axis,
       const DeviceMesh& mesh,
       DeviceIdxType deviceId);
+  at::Tensor shardTensor(
+      at::Tensor tensor,
+      int64_t axis,
+      const DeviceMesh& mesh);
 
   Communicator* communicator_;
   c10::TensorOptions tensor_options;

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -45,6 +45,12 @@ class MultiDeviceTest : public NVFuserTest {
       TensorView* tv,
       DeviceIdxType deviceId);
 
+  static at::Tensor shardTensor(
+      at::Tensor tensor,
+      int64_t axis,
+      const DeviceMesh& mesh,
+      DeviceIdxType deviceId);
+
   Communicator* communicator_;
   c10::TensorOptions tensor_options;
   bool debug_print;

--- a/tests/cpp/test_multidevice_lower_communication.cpp
+++ b/tests/cpp/test_multidevice_lower_communication.cpp
@@ -62,7 +62,7 @@ TEST_P(LowerGatherTest, ) {
   const auto device_id = communicator_->deviceId();
   at::Tensor unsharded_tensor =
       at::randn({in_mesh.size(), kTensorSize}, tensor_options);
-  at::Tensor in_tensor = shardTensor(unsharded_tensor, in, device_id);
+  at::Tensor in_tensor = shardTensor(unsharded_tensor, in);
 
   FusionExecutor fe(communicator_);
   fe.compileFusion(&fusion, {in_tensor});
@@ -112,8 +112,7 @@ TEST_P(LowerScatterTest, ) {
   at::Tensor out_tensor = fe.runFusion({unsharded_tensor})[0];
 
   if (out_mesh.has(device_id)) {
-    EXPECT_TRUE(
-        at::equal(out_tensor, shardTensor(unsharded_tensor, out, device_id)));
+    EXPECT_TRUE(at::equal(out_tensor, shardTensor(unsharded_tensor, out)));
   }
 }
 
@@ -149,7 +148,7 @@ TEST_P(LowerSendRecvTest, ) {
   const auto device_id = communicator_->deviceId();
   at::Tensor unsharded_tensor =
       at::randn({in_mesh.size(), kTensorSize}, tensor_options);
-  at::Tensor in_tensor = shardTensor(unsharded_tensor, in, device_id);
+  at::Tensor in_tensor = shardTensor(unsharded_tensor, in);
 
   FusionExecutor fe(communicator_);
   fe.compileFusion(&fusion, {in_tensor});
@@ -157,8 +156,7 @@ TEST_P(LowerSendRecvTest, ) {
   at::Tensor out_tensor = fe.runFusion({in_tensor})[0];
 
   if (out_mesh.has(device_id)) {
-    EXPECT_TRUE(
-        at::equal(out_tensor, shardTensor(unsharded_tensor, out, device_id)));
+    EXPECT_TRUE(at::equal(out_tensor, shardTensor(unsharded_tensor, out)));
   }
 }
 
@@ -190,8 +188,7 @@ TEST_F(LowerCollectiveTest, Allgather) {
 
   at::Tensor unsharded_tensor =
       at::randn({num_devices, kTensorSize}, tensor_options);
-  at::Tensor in_tensor =
-      shardTensor(unsharded_tensor, in, communicator_->deviceId());
+  at::Tensor in_tensor = shardTensor(unsharded_tensor, in);
 
   FusionExecutor fe(communicator_);
   fe.compileFusion(&fusion, {in_tensor});
@@ -249,7 +246,7 @@ TEST_F(LowerCollectiveTest, Reduce) {
   at::Tensor unsharded_in_tensor =
       at::randn({num_devices, kTensorSize}, tensor_options);
   const auto device_id = communicator_->deviceId();
-  at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in, device_id);
+  at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in);
 
   FusionExecutor fe(communicator_);
   fe.compileFusion(&fusion, {in_tensor});
@@ -279,8 +276,7 @@ TEST_F(LowerCollectiveTest, Allreduce) {
 
   at::Tensor unsharded_in_tensor =
       at::randn({num_devices, kTensorSize}, tensor_options);
-  const auto device_id = communicator_->deviceId();
-  at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in, device_id);
+  at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in);
 
   FusionExecutor fe(communicator_);
   fe.compileFusion(&fusion, {in_tensor});
@@ -308,8 +304,7 @@ TEST_F(LowerCollectiveTest, ReduceScatter) {
 
   at::Tensor unsharded_in_tensor =
       at::randn({num_devices, num_devices, kTensorSize}, tensor_options);
-  const auto device_id = communicator_->deviceId();
-  at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in, device_id);
+  at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in);
 
   FusionExecutor fe(communicator_);
   fe.compileFusion(&fusion, {in_tensor});
@@ -317,8 +312,7 @@ TEST_F(LowerCollectiveTest, ReduceScatter) {
   at::Tensor out_tensor = fe.runFusion({in_tensor})[0];
 
   at::Tensor unsharded_out_tensor = unsharded_in_tensor.sum(0);
-  EXPECT_TRUE(at::allclose(
-      out_tensor, shardTensor(unsharded_out_tensor, out, device_id)));
+  EXPECT_TRUE(at::allclose(out_tensor, shardTensor(unsharded_out_tensor, out)));
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_multidevice_matmul.cpp
+++ b/tests/cpp/test_multidevice_matmul.cpp
@@ -98,9 +98,8 @@ TEST_F(DistributedMatmulTest, MulSum_LayoutTN_NoComms) {
       MmaLayout::TN, M, N, K, /*dtype=*/at::kFloat);
   in0 = in0.view({Mo, Mi, K});
   out = out.view({Mo, Mi, N});
-  std::vector<c10::IValue> inputs = {
-      shardTensor(in0, a, communicator_->deviceId()), in1};
-  auto expected_output = shardTensor(out, c, communicator_->deviceId());
+  std::vector<c10::IValue> inputs = {shardTensor(in0, a), in1};
+  auto expected_output = shardTensor(out, c);
   MultiDeviceExecutor runtime(
       std::move(fusion), *communicator_, executor_params_);
   auto outputs = runtime.runWithInput(inputs);
@@ -166,9 +165,8 @@ TEST_F(DistributedMatmulTest, Matmul_LayoutTN_NoComms) {
       getInputsAndReferenceOutputs(MmaLayout::TN, M, N, K, /*dtype=*/at::kHalf);
   in0 = in0.view({Mo, Mi, K});
   out = out.view({Mo, Mi, N});
-  std::vector<c10::IValue> inputs = {
-      shardTensor(in0, a, communicator_->deviceId()), in1};
-  auto expected_output = shardTensor(out, c, communicator_->deviceId());
+  std::vector<c10::IValue> inputs = {shardTensor(in0, a), in1};
+  auto expected_output = shardTensor(out, c);
 
   MultiDeviceExecutor runtime(
       std::move(fusion), *communicator_, executor_params_);
@@ -234,9 +232,8 @@ TEST_F(DistributedMatmulTest, Matmul_LayoutTN_Allgather) {
   in0 = in0.view({Mo, Mi, K});
   out = out.view({Mo, Mi, N});
 
-  std::vector<c10::IValue> inputs = {
-      shardTensor(in0, a, communicator_->deviceId()), in1};
-  auto expected_output = shardTensor(out, c, communicator_->deviceId());
+  std::vector<c10::IValue> inputs = {shardTensor(in0, a), in1};
+  auto expected_output = shardTensor(out, c);
   MultiDeviceExecutor runtime(
       std::move(fusion), *communicator_, executor_params_);
   auto outputs = runtime.runWithInput(inputs);
@@ -299,9 +296,7 @@ TEST_F(DistributedMatmulTest, Matmul_LayoutNT_AllReduce) {
       getInputsAndReferenceOutputs(MmaLayout::NT, M, N, K, /*dtype=*/at::kHalf);
   in0 = in0.view({Ko, Ki, M});
   in1 = in1.view({Ko, Ki, N});
-  std::vector<c10::IValue> inputs = {
-      shardTensor(in0, a, communicator_->deviceId()),
-      shardTensor(in1, b, communicator_->deviceId())};
+  std::vector<c10::IValue> inputs = {shardTensor(in0, a), shardTensor(in1, b)};
 
   MultiDeviceExecutor runtime(
       std::move(fusion), *communicator_, executor_params_);
@@ -367,11 +362,8 @@ TEST_F(DistributedMatmulTest, Matmul_LayoutNT_ReduceScatter) {
   in0 = in0.view({Ko, Ki, M});
   in1 = in1.view({Ko, Ki, N});
   out = out.view({Mo, Mi, N});
-  std::vector<c10::IValue> inputs = {
-      shardTensor(in0, a, communicator_->deviceId()),
-      shardTensor(in1, b, communicator_->deviceId())};
-  auto expected_output =
-      shardTensor(out, c, communicator_->deviceId()).view({1, Mi, N});
+  std::vector<c10::IValue> inputs = {shardTensor(in0, a), shardTensor(in1, b)};
+  auto expected_output = shardTensor(out, c).view({1, Mi, N});
 
   MultiDeviceExecutor runtime(
       std::move(fusion), *communicator_, executor_params_);

--- a/tests/cpp/test_multidevice_matmul.cpp
+++ b/tests/cpp/test_multidevice_matmul.cpp
@@ -7,8 +7,6 @@
 // clang-format on
 #include <gtest/gtest.h>
 
-#include <codegen.h>
-#include <device_lower/lower2device.h>
 #include <executor.h>
 #include <expr_evaluator.h>
 #include <fusion.h>
@@ -18,22 +16,16 @@
 #include <ir/iostream.h>
 #include <ir/printer.h>
 #include <ir/utils.h>
-#include <iter_visitor.h>
-#include <kernel_cache.h>
-#include <kernel_ir.h>
 #include <mma_type.h>
 #include <ops/all_ops.h>
 #include <scheduler/mma_utils.h>
 #include <scheduler/utils.h>
 #include <tests/cpp/multidevice.h>
 #include <tests/cpp/validator.h>
-#include <transform_replay.h>
-#include <transform_rfactor.h>
 
 namespace nvfuser {
 
-class DistributedMatmulTest : public MultiDeviceTest,
-                              public testing::WithParamInterface<bool> {
+class DistributedMatmulTest : public MultiDeviceTest {
  protected:
   DistributedMatmulTest() : num_devices_(communicator_->size()) {}
 
@@ -405,184 +397,4 @@ TEST_F(DistributedMatmulTest, Matmul_LayoutNT_ReduceScatter) {
                                     ->heuristic();
   EXPECT_EQ(heuristic, ScheduleHeuristic::ExprEval);
 }
-
-TEST_P(DistributedMatmulTest, MLP_Layer) {
-  bool use_aten_matmul = GetParam();
-  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-  auto mesh = DeviceMesh::createForNumDevices(communicator_->size());
-
-  int64_t sb = 64; // sequence * batch
-  int64_t h = 128;
-  int64_t h4 = 4 * h;
-
-  TensorView* x = makeContigTensor(2, DataType::BFloat16);
-  TensorView* w0 = makeContigTensor(3, DataType::BFloat16);
-  TensorView* b0 = makeContigTensor(2, DataType::BFloat16);
-  TensorView* w1 = makeContigTensor(3, DataType::BFloat16);
-  TensorView* b1 = makeContigTensor(1, DataType::BFloat16);
-
-  fusion->addInput(x);
-  fusion->addInput(w0);
-  fusion->addInput(b0);
-  fusion->addInput(w1);
-  fusion->addInput(b1);
-
-  // Linear #1
-  TensorView* matmul1;
-  if (use_aten_matmul) {
-    // TODO: use linear op instead
-    TensorView* w0_t = transpose(w0, 2, 1);
-    matmul1 = matmul(x, w0_t);
-  } else {
-    TensorView* linear_int0 = broadcast(x, {true, false, true, false});
-    TensorView* linear_int1 = broadcast(w0, {false, true, false, false});
-    TensorView* linear_int2 = mul(linear_int0, linear_int1);
-    matmul1 = sum(linear_int2, {-1});
-    // TODO: linear_int0 has a bcast device axis that the sharding propagation
-    // pass misses.
-    linear_int0->setDeviceMesh(mesh);
-    linear_int0->axis(0)->parallelize(ParallelType::DIDx);
-  }
-  TensorView* b0_bcast = broadcast(b0, {false, true, false});
-  TensorView* linear1 = add(matmul1, b0_bcast);
-
-  TensorView* linear1_ = castOp(DataType::Float, linear1);
-  TensorView* gelu = tanh_gelu(linear1_);
-  TensorView* gelu_ = castOp(DataType::BFloat16, gelu);
-
-  // Linear #2
-  TensorView* local_matmul2;
-  if (use_aten_matmul) {
-    TensorView* w1_t = transpose(w1, 1, 2);
-    local_matmul2 = matmul(gelu_, w1_t);
-  } else {
-    // segment_set required to ensure the matmul scheduler is called
-    gelu_ = segment_set(gelu_);
-    TensorView* linear2_int0 = broadcast(gelu_, {false, false, true, false});
-    TensorView* linear2_int1 = broadcast(w1, {false, true, false, false});
-    TensorView* linear2_int2 = mul(linear2_int0, linear2_int1);
-    local_matmul2 = sum(linear2_int2, {-1});
-  }
-
-  TensorView* matmul2 = sum(local_matmul2, {0}); // Allreduce
-  TensorView* bcast_bias = broadcast(b1, {true, false});
-  TensorView* linear2 = add(matmul2, bcast_bias);
-
-  // Dropout
-  // Note: Propagation breaks at rand_like because it creates a fresh TV.
-  // Temporarily this prevents us from using dropout composite node.
-  TensorView* linear2_ = castOp(DataType::Float, linear2);
-  constexpr double kProb = 0.1;
-  constexpr double kScale = 1.0 / (1.0 - kProb);
-  Val* philox_seed = fusion->zeroVal();
-  Val* philox_offset = fusion->zeroVal();
-  TensorView* rand_vals = rand_like(linear2_, philox_seed, philox_offset);
-  TensorView* mask = lt(rand_vals, IrBuilder::create<Val>(1.0 - kProb));
-  TensorView* apply_mask = mul(linear2_, mask);
-  TensorView* dropout = mul(apply_mask, IrBuilder::create<Val>(kScale));
-
-  fusion->addOutput(linear1);
-  fusion->addOutput(gelu);
-  fusion->addOutput(linear2);
-  fusion->addOutput(dropout);
-
-  // Manually shard inputs: x, w0, b0, w1, b1
-  // outputs: linear1, gelu, linear2, dropout
-  // TVs where sharding changes: matmul2
-  // (TODO) TVs where sharding propagation breaks down:
-  // linear_int0 = broadcasts where a device dim axis is broadcasted.
-  // rand_vals => rand_like creates a fresh new TV.
-
-  // TVs replicated on each device.
-  auto tv_inputs = {x, b1, matmul2, linear2, rand_vals, dropout};
-  for (auto tv : tv_inputs) {
-    tv->setDeviceMesh(mesh);
-  }
-
-  // TVs sharded on the outermost dimension.
-  auto tvs = {w0, b0, w1, linear1, gelu, gelu_};
-  for (auto tv : tvs) {
-    tv->setDeviceMesh(mesh);
-    tv->axis(0)->parallelize(ParallelType::DIDx);
-  }
-
-  const auto options = at::TensorOptions()
-                           .dtype(c10::ScalarType::BFloat16)
-                           .device(at::kCUDA, communicator_->local_rank());
-  auto x_ = at::randn({sb, h}, options);
-  auto w0_ = at::randn({h4, h}, options);
-  auto b0_ = at::randn({h4}, options);
-  auto w1_ = at::randn({h, h4}, options);
-  auto b1_ = at::randn({h}, options);
-
-  std::vector<c10::IValue> inputs = {
-      x_,
-      shardTensor(
-          w0_.view({num_devices_, h4 / num_devices_, h}),
-          w0,
-          communicator_->deviceId()),
-      shardTensor(
-          b0_.view({num_devices_, h4 / num_devices_}),
-          b0,
-          communicator_->deviceId()),
-      shardTensor(
-          w1_.view({h, num_devices_, h4 / num_devices_}).transpose(1, 0),
-          w1,
-          communicator_->deviceId()),
-      b1_};
-  at::manual_seed(0);
-  auto linear1_aten =
-      at::linear(x_.to(at::kDouble), w0_.to(at::kDouble), b0_.to(at::kDouble));
-  auto gelu_aten = at::gelu(linear1_aten.to(at::kFloat), "tanh");
-  auto linear2_aten = at::linear(
-      gelu_aten.to(at::kBFloat16).to(at::kDouble),
-      w1_.to(at::kDouble),
-      b1_.to(at::kDouble));
-  auto dropout_aten = at::dropout(linear2_aten.to(at::kFloat), kProb, true);
-  std::vector<at::Tensor> expected_outputs = {
-      shardTensor(
-          at::transpose(
-              linear1_aten.view({sb, num_devices_, h4 / num_devices_}), 1, 0),
-          linear1,
-          communicator_->deviceId()),
-      shardTensor(
-          at::transpose(
-              gelu_aten.view({sb, num_devices_, h4 / num_devices_}), 1, 0),
-          gelu,
-          communicator_->deviceId()),
-      linear2_aten,
-      dropout_aten};
-
-  at::manual_seed(0);
-  MultiDeviceExecutor runtime(
-      std::move(fusion), *communicator_, executor_params_);
-  auto outputs = runtime.runWithInput(inputs);
-
-  // Bump up the tolerance - the second matmul carries
-  // the numerical error from the prior matmul
-  auto tolerance_overwrite = ValidationConstants();
-  std::array<std::array<double, 2>, 20> relaxed_sum_tol;
-  for (auto& arr : relaxed_sum_tol) {
-    arr = {128, 3.0};
-  }
-  tolerance_overwrite.sum_tolerances_float = relaxed_sum_tol;
-
-  testValidate(
-      runtime.completeFusion(),
-      outputs,
-      inputs,
-      expected_outputs,
-      __LINE__,
-      __FILE__,
-      "",
-      LaunchParams(),
-      tolerance_overwrite);
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    ,
-    DistributedMatmulTest,
-    testing::Bool(),
-    testing::PrintToStringParamName());
 } // namespace nvfuser

--- a/tests/cpp/test_multidevice_sharding.cpp
+++ b/tests/cpp/test_multidevice_sharding.cpp
@@ -56,10 +56,9 @@ TEST_P(MultideviceShardingTest, UnshardedGlobalInput) {
 
   auto x0 = at::randn(input_size, tensor_options);
   std::vector<c10::IValue> inputs = {x0};
-  auto x1 = shardTensor(x0, tv1, communicator_->deviceId());
+  auto x1 = shardTensor(x0, tv1);
   auto x2 = x1 + x1;
-  auto x3 = shardTensor(
-      at::sum(x0 + x0, {sharded_dim}), tv3, communicator_->deviceId());
+  auto x3 = shardTensor(at::sum(x0 + x0, {sharded_dim}), tv3);
   MultiDeviceExecutor runtime(std::move(fusion), *communicator_);
   auto outputs = runtime.runWithInput(inputs);
   testValidate(
@@ -99,8 +98,7 @@ TEST_P(MultideviceShardingTest, ShardGlobalInput) {
   }
 
   auto x1 = at::randn(unsharded_input_size, tensor_options);
-  std::vector<c10::IValue> inputs = {
-      shardTensor(x1, tv0, communicator_->deviceId())};
+  std::vector<c10::IValue> inputs = {shardTensor(x1, tv0)};
   auto x2 = x1 * 2;
   MultiDeviceExecutor runtime(std::move(fusion), *communicator_);
   auto outputs = runtime.runWithInput(inputs);

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -225,9 +225,9 @@ TEST_P(DistributedTransformerTest, MLP_Layer) {
 
   std::vector<c10::IValue> inputs = {
       x_,
-      shardTensor(w0_, 0, mesh, communicator_->deviceId()),
-      shardTensor(b0_, 0, mesh, communicator_->deviceId()),
-      shardTensor(w1_, 1, mesh, communicator_->deviceId()),
+      shardTensor(w0_, 0, mesh),
+      shardTensor(b0_, 0, mesh),
+      shardTensor(w1_, 1, mesh),
       b1_};
   at::manual_seed(0);
   auto linear1_aten =
@@ -238,8 +238,8 @@ TEST_P(DistributedTransformerTest, MLP_Layer) {
                           .to(at::kFloat);
   auto dropout_aten = at::dropout(linear2_aten, kProb, true);
   std::vector<at::Tensor> expected_outputs = {
-      shardTensor(linear1_aten, 1, mesh, communicator_->deviceId()),
-      shardTensor(gelu_aten, 1, mesh, communicator_->deviceId()),
+      shardTensor(linear1_aten, 1, mesh),
+      shardTensor(gelu_aten, 1, mesh),
       linear2_aten,
       dropout_aten};
 

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -1,0 +1,266 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <gtest/gtest.h>
+
+#include <executor.h>
+#include <expr_evaluator.h>
+#include <fusion.h>
+#include <fusion_segmenter.h>
+#include <ir/all_nodes.h>
+#include <ir/interface_nodes.h>
+#include <ir/utils.h>
+#include <mma_type.h>
+#include <ops/all_ops.h>
+#include <preseg_passes/allocation_order_inference.h>
+#include <preseg_passes/move_split_cat.h>
+#include <preseg_passes/optimization_pass.h>
+#include <scheduler/mma_utils.h>
+#include <scheduler/utils.h>
+#include <tests/cpp/multidevice.h>
+#include <tests/cpp/validator.h>
+
+namespace nvfuser {
+
+class DistributedTransformerTest
+    : public MultiDeviceTest,
+      public testing::WithParamInterface<std::tuple<bool, DataType>> {
+ protected:
+  DistributedTransformerTest()
+      : D(communicator_->size()),
+        optimization_guard_(false),
+        allocation_order_guard_(false) {
+    NVF_CHECK(E % H == 0);
+    NVF_CHECK(H % D == 0);
+    NVF_CHECK(E % D == 0);
+  }
+
+  void SetUp() {
+    MultiDeviceTest::SetUp();
+    if (!deviceMajorMinorCheck(8)) {
+      GTEST_SKIP() << "Distributed transformer tests require Ampere or newer";
+    }
+  }
+
+  hir::HostIrExecutorParams executor_params_{
+      .use_fusion_executor_cache = true,
+      .skip_auto_scheduling = false,
+      .cache_fusion_executor = false};
+  const int D;
+  const int B = 4;
+  const int E = 128;
+  const int H = 4;
+  const int S = 32;
+
+  // Temporary until https://github.com/NVIDIA/Fuser/issues/2563
+  at::Tensor shardTensor(at::Tensor tensor, int64_t axis, DeviceMesh& mesh) {
+    auto i = mesh.idxOf(communicator_->deviceId());
+    auto extent = tensor.size(axis);
+    auto nslices = mesh.size();
+    NVF_CHECK(
+        extent % nslices == 0,
+        "Sharded axis must be evenly divisble by mesh");
+    auto stride = extent / nslices;
+    // TODO: returning slice 0 temporarily when device is not in the mesh.
+    i = (i < 0) ? 0 : i;
+    return tensor.slice(axis, i * stride, (i + 1) * stride)
+                 .contiguous()
+                 .unsqueeze(0);
+  }
+
+ private:
+  // Note: `MoveSplitCat` and `AllocationDomain` preseg passes use ID model.
+  // `SdpaFwdOp` currently does not work with ID model since it requires all
+  // sibling outputs to have the same root domain.
+  //  This will be modified in a future PR.
+  preseg_passes::OptimizationPassGuard<preseg_passes::MoveSplitCatPass>
+      optimization_guard_;
+  preseg_passes::OptimizationPassGuard<preseg_passes::AllocationDomainPass>
+      allocation_order_guard_;
+};
+
+namespace {
+TensorView* replicated_dropout(
+    TensorView* x,
+    const double kProb,
+    Fusion* fusion,
+    DeviceMesh mesh) {
+  // Need to modify two things before we can use the existing dropout function
+  // in composite.cpp (1) Sharding propagation breaks at rand_like because it
+  // creates a fresh TV. (2) The philox seed and offset must be set to ensure
+  // the masks are identical across processes.
+  TensorView* x_float = castOp(DataType::Float, x);
+  const double kScale = 1.0 / (1.0 - kProb);
+  Val* philox_seed = fusion->zeroVal();
+  Val* philox_offset = fusion->zeroVal();
+  TensorView* rand_vals = rand_like(x_float, philox_seed, philox_offset);
+  TensorView* mask = lt(rand_vals, IrBuilder::create<Val>(1.0 - kProb));
+  TensorView* apply_mask = mul(x_float, mask);
+  TensorView* dropout = mul(apply_mask, IrBuilder::create<Val>(kScale));
+  rand_vals->setDeviceMesh(mesh);
+  return dropout;
+}
+
+void validate(
+    std::vector<at::Tensor> expected_out,
+    std::vector<at::Tensor> out) {
+  EXPECT_EQ(expected_out.size(), out.size());
+  for (auto i : c10::irange(out.size())) {
+    // Note: Scale the tolerance up since the error accumulates across ops
+    double tolerance = 0.5 * (i + 1);
+    auto all_close = expected_out[i].allclose(
+        out[i].to(expected_out[i].dtype()),
+        tolerance,
+        tolerance,
+        /*equal_nan=*/true);
+
+    if (!all_close) {
+      auto max_error =
+          (expected_out[i].sub(out[i])).abs().max().item().to<double>();
+      auto max_relative_error = (max_error / expected_out[i].abs().max()).item();
+      auto error_count =
+          at::sum((expected_out[i].sub(out[i])).abs() > tolerance).item();
+      std::cout << "output[" << i << "] max error: " << max_error << std::endl;
+      std::cout << "          max relative error: " << max_relative_error
+                << std::endl;
+       std::cout << error_count << " elements failing "
+                << error_count.to<float>() / at::numel(out[i]) * 100.0 << "\% of tensor" << std::endl;
+    }
+    EXPECT_TRUE(all_close);
+  }
+}
+} // namespace
+
+TEST_P(DistributedTransformerTest, MLP_Layer) {
+  auto [use_aten_matmul, dtype] = GetParam();
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  auto mesh = DeviceMesh::createForNumDevices(communicator_->size());
+  at::ScalarType at_dtype = data_type_to_aten(dtype);
+
+  TensorView* x = makeContigTensor(2, dtype);
+  TensorView* w0 = makeContigTensor(3, dtype);
+  TensorView* b0 = makeContigTensor(2, dtype);
+  TensorView* w1 = makeContigTensor(3, dtype);
+  TensorView* b1 = makeContigTensor(1, dtype);
+
+  fusion->addInput(x);
+  fusion->addInput(w0);
+  fusion->addInput(b0);
+  fusion->addInput(w1);
+  fusion->addInput(b1);
+
+  // Linear #1
+  TensorView* matmul1;
+  if (use_aten_matmul) {
+    // TODO: use linear op instead
+    TensorView* w0_t = transpose(w0, 2, 1);
+    matmul1 = matmul(x, w0_t);
+  } else {
+    TensorView* linear_int0 = broadcast(x, {true, false, true, false});
+    TensorView* linear_int1 = broadcast(w0, {false, true, false, false});
+    TensorView* linear_int2 = mul(linear_int0, linear_int1);
+    matmul1 = sum(linear_int2, {-1});
+    // TODO: linear_int0 has a bcast device axis that the sharding propagation
+    // pass misses.
+    linear_int0->setDeviceMesh(mesh);
+    linear_int0->axis(0)->parallelize(ParallelType::DIDx);
+  }
+  TensorView* b0_bcast = broadcast(b0, {false, true, false});
+  TensorView* linear1 = add(matmul1, b0_bcast);
+
+  TensorView* linear1_ = castOp(DataType::Float, linear1);
+  TensorView* gelu = tanh_gelu(linear1_);
+  TensorView* gelu_ = castOp(dtype, gelu);
+
+  // Linear #2
+  TensorView* local_matmul2;
+  if (use_aten_matmul) {
+    TensorView* w1_t = transpose(w1, 1, 2);
+    local_matmul2 = matmul(gelu_, w1_t);
+  } else {
+    // segment_set required to ensure the matmul scheduler is called
+    gelu_ = segment_set(gelu_);
+    TensorView* linear2_int0 = broadcast(gelu_, {false, false, true, false});
+    TensorView* linear2_int1 = broadcast(w1, {false, true, false, false});
+    TensorView* linear2_int2 = mul(linear2_int0, linear2_int1);
+    local_matmul2 = sum(linear2_int2, {-1});
+  }
+
+  TensorView* matmul2 = sum(local_matmul2, {0}); // Allreduce
+  TensorView* bcast_bias = broadcast(b1, {true, false});
+  TensorView* linear2 = add(matmul2, bcast_bias);
+
+  // Dropout
+  const double kProb = 0.1;
+  TensorView* dropout = replicated_dropout(linear2, kProb, fusion.get(), mesh);
+
+  fusion->addOutput(linear1);
+  fusion->addOutput(gelu);
+  fusion->addOutput(linear2);
+  fusion->addOutput(dropout);
+
+  // Manually shard inputs: x, w0, b0, w1, b1
+  // outputs: linear1, gelu, linear2, dropout
+  // TVs where sharding changes: matmul2
+  // (TODO) TVs where sharding propagation breaks down:
+  // linear_int0: broadcasts where a device dim axis is broadcasted.
+  // rand_vals: rand_like creates a fresh new TV.
+
+  // TVs replicated on each device.
+  auto tv_inputs = {x, b1, matmul2, linear2, dropout};
+  for (auto tv : tv_inputs) {
+    tv->setDeviceMesh(mesh);
+  }
+
+  // TVs sharded on the outermost dimension.
+  auto tvs = {w0, b0, w1, linear1, gelu, gelu_};
+  for (auto tv : tvs) {
+    tv->setDeviceMesh(mesh);
+    tv->axis(0)->parallelize(ParallelType::DIDx);
+  }
+
+  const auto options = at::TensorOptions().dtype(at_dtype).device(
+      at::kCUDA, communicator_->local_rank());
+  auto x_ = at::randn({B * S, E}, options) / 10.0;
+  auto w0_ = at::randn({4 * E, E}, options);
+  auto b0_ = at::randn({4 * E}, options);
+  auto w1_ = at::randn({E, 4 * E}, options);
+  auto b1_ = at::randn({E}, options);
+
+  std::vector<c10::IValue> inputs = {
+      x_,
+      shardTensor(w0_, 0, mesh),
+      shardTensor(b0_, 0, mesh),
+      shardTensor(w1_, 1, mesh),
+      b1_};
+  at::manual_seed(0);
+  auto linear1_aten = at::matmul(x_, w0_.transpose(1, 0)).add(b0_).to(at::kFloat);
+  auto gelu_aten = at::gelu(linear1_aten, "tanh");
+  auto linear2_aten =
+      at::matmul(gelu_aten.to(at_dtype), w1_.transpose(1, 0)).add(b1_).to(at::kFloat);
+  auto dropout_aten = at::dropout(linear2_aten, kProb, true);
+  std::vector<at::Tensor> expected_outputs = {
+      shardTensor(linear1_aten, 1, mesh),
+      shardTensor(gelu_aten, 1, mesh),
+      linear2_aten,
+      dropout_aten};
+
+  at::manual_seed(0);
+  MultiDeviceExecutor runtime(
+      std::move(fusion), *communicator_, executor_params_);
+  auto outputs = runtime.runWithInput(inputs);
+  validate(expected_outputs, outputs);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    DistributedTransformerTest,
+    testing::Combine(
+        testing::Bool(),
+        testing::Values(DataType::Half, DataType::BFloat16)));
+} // namespace nvfuser


### PR DESCRIPTION
Moves sharded mlp test from test_multidevice_matmul to test_multidevice_transformer. 
Add helper functions for replicated dropout, sharding tensors, and validation. Changes that are more than copy paste are highlighted. 