### PR TITLE
SDPA Bwd Mapping

### DIFF
--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -153,6 +153,7 @@ bool isTvOp(const Expr* expr) {
           MmaOp,
           LinearOp,
           SdpaFwdOp,
+          SdpaBwdOp,
           BroadcastOp,
           SqueezeOp,
           ExpandOp,

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -54,7 +54,9 @@ void validateValWithConcreteValue(
         ", but got a tensor of dtype ",
         actual_dtype);
     // Intermediate tensorviews marked as CPU scalars will be created as meta
-    // tensors during compilation.
+    // tensors during compilation. For example, for fusions containing SDPA fwd
+    // and bwd, some outputs of the fwd op (philox seed, philox offset) are CPU
+    // scalars.
     if (tv->isCpuScalar()) {
       NVF_CHECK(
           is_cpu_scalar(t) || is_meta_scalar(t),

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -55,10 +55,10 @@ void validateValWithConcreteValue(
         actual_dtype);
     if (tv->isCpuScalar()) {
       NVF_CHECK(
-          t.is_meta() || is_cpu_scalar(t),
+          is_cpu_scalar(t) || is_meta_scalar(t),
           "Expected ",
           tv->toString(),
-          " to be bound to a CPU scalar tensor "
+          " to be bound to a CPU or meta scalar tensor "
           ", but got a tensor on device ",
           t.device(),
           " with ",

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -55,7 +55,7 @@ void validateValWithConcreteValue(
         actual_dtype);
     if (tv->isCpuScalar()) {
       NVF_CHECK(
-          is_cpu_scalar(t),
+          t.is_meta() || is_cpu_scalar(t),
           "Expected ",
           tv->toString(),
           " to be bound to a CPU scalar tensor "

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -53,6 +53,8 @@ void validateValWithConcreteValue(
         value->dtype(),
         ", but got a tensor of dtype ",
         actual_dtype);
+    // Intermediate tensorviews marked as CPU scalars will be created as meta
+    // tensors during compilation.
     if (tv->isCpuScalar()) {
       NVF_CHECK(
           is_cpu_scalar(t) || is_meta_scalar(t),

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2205,8 +2205,6 @@ class LinearOp : public Expr {
 SDPA node with same functionality at::_scaled_dot_product_flash_attention
 output = [N, H, L, Ev]
 logsumexp = [N, H, L]
-cum_seq_q = [N + 1,]
-cum_seq_k = [N + 1,]
 query_seq_len = scalar(int)
 key_seq_len = scalar(int)
 philox_seed = scalar tensor
@@ -2239,8 +2237,6 @@ class SdpaFwdOp : public Expr {
       IrBuilderPasskey,
       TensorView* output,
       TensorView* log_sumexp,
-      TensorView* cum_seq_q,
-      TensorView* cum_seq_k,
       TensorView* query_seq_len,
       TensorView* key_seq_len,
       TensorView* philox_seed,
@@ -2521,8 +2517,6 @@ key = [N, H, S, E]
 value = [N, H, S, Ev]
 output = [N, H, L, Ev]
 logsumexp = [N, H, L]
-cum_seq_q = [N + 1,] (undefined tensor for non-nested tensor)
-cum_seq_k = [N + 1,] (undefined tensor for non-nested tensor)
 query_seq_len = scalar(int)
 key_seq_len = scalar(int)
 dropout_p = scalar(double)
@@ -2556,8 +2550,6 @@ class SdpaBwdOp : public Expr {
       TensorView* value,
       TensorView* output,
       TensorView* log_sumexp,
-      TensorView* cum_seq_q,
-      TensorView* cum_seq_k,
       TensorView* query_seq_len,
       TensorView* key_seq_len,
       Val* dropout_p,
@@ -2611,41 +2603,33 @@ class SdpaBwdOp : public Expr {
     return input(5);
   }
 
-  Val* cum_seq_q() const {
+  Val* max_q() const {
     return input(6);
   }
 
-  Val* cum_seq_k() const {
+  Val* max_k() const {
     return input(7);
   }
 
-  Val* max_q() const {
+  Val* dropout_p() const {
     return input(8);
   }
 
-  Val* max_k() const {
+  Val* is_causal() const {
     return input(9);
   }
 
-  Val* dropout_p() const {
+  Val* philox_seed() const {
     return input(10);
   }
 
-  Val* is_causal() const {
+  Val* philox_offset() const {
     return input(11);
   }
 
-  Val* philox_seed() const {
-    return input(12);
-  }
-
-  Val* philox_offset() const {
-    return input(13);
-  }
-
   Val* scale() const {
-    if (inputs().size() > 14) {
-      return input(14);
+    if (inputs().size() > 12) {
+      return input(12);
     }
     return nullptr;
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4399,12 +4399,15 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
 
   // Query and key seq len are of type c10::SymInt -> convert them to CPU scalar
   // tensors to support adding them as fusion outputs.
-  // We ignore cum_seq_q/k outputs since they are undefined tensors for non-nested tensors.
+  // We ignore cum_seq_q/k outputs since they are undefined tensors for
+  // non-nested tensors.
   return {
       output,
       log_sumexp,
-      at::scalar_tensor(*query_seq_len.maybe_as_int(), at::device(at::kCPU).dtype(at::kLong)),
-      at::scalar_tensor(*key_seq_len.maybe_as_int(), at::device(at::kCPU).dtype(at::kLong)),
+      at::scalar_tensor(
+          *query_seq_len.maybe_as_int(), at::device(at::kCPU).dtype(at::kLong)),
+      at::scalar_tensor(
+          *key_seq_len.maybe_as_int(), at::device(at::kCPU).dtype(at::kLong)),
       philox_seed,
       philox_offset,
       debug_attn_mask};

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4270,8 +4270,6 @@ SdpaFwdOp::SdpaFwdOp(
     IrBuilderPasskey passkey,
     TensorView* output,
     TensorView* log_sumexp,
-    TensorView* cum_seq_q,
-    TensorView* cum_seq_k,
     TensorView* query_seq_len,
     TensorView* key_seq_len,
     TensorView* philox_seed,
@@ -4286,8 +4284,6 @@ SdpaFwdOp::SdpaFwdOp(
     : Expr(passkey) {
   addOutput(output);
   addOutput(log_sumexp);
-  addOutput(cum_seq_q);
-  addOutput(cum_seq_k);
   addOutput(query_seq_len);
   addOutput(key_seq_len);
   addOutput(philox_seed);
@@ -4403,13 +4399,12 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
 
   // Query and key seq len are of type c10::SymInt -> convert them to CPU scalar
   // tensors to support adding them as fusion outputs.
+  // We ignore cum_seq_q/k outputs since they are undefined tensors for non-nested tensors.
   return {
       output,
       log_sumexp,
-      cum_seq_q,
-      cum_seq_k,
-      at::scalar_tensor(*query_seq_len.maybe_as_int(), at::dtype(at::kLong)),
-      at::scalar_tensor(*key_seq_len.maybe_as_int(), at::dtype(at::kLong)),
+      at::scalar_tensor(*query_seq_len.maybe_as_int(), at::device(at::kCPU).dtype(at::kLong)),
+      at::scalar_tensor(*key_seq_len.maybe_as_int(), at::device(at::kCPU).dtype(at::kLong)),
       philox_seed,
       philox_offset,
       debug_attn_mask};
@@ -4780,8 +4775,6 @@ SdpaBwdOp::SdpaBwdOp(
     TensorView* value,
     TensorView* output,
     TensorView* log_sumexp,
-    TensorView* cum_seq_q,
-    TensorView* cum_seq_k,
     TensorView* max_q,
     TensorView* max_k,
     Val* dropout_p,
@@ -4799,8 +4792,6 @@ SdpaBwdOp::SdpaBwdOp(
   addInput(value);
   addInput(output);
   addInput(log_sumexp);
-  addInput(cum_seq_q);
-  addInput(cum_seq_k);
   addInput(max_q);
   addInput(max_k);
   addInput(dropout_p);
@@ -4829,10 +4820,6 @@ std::string SdpaBwdOp::toString(int indent_size) const {
   indent(ss, indent_size + 1)
       << "          logsum_exp = " << logsumexp()->toString() << ",\n";
   indent(ss, indent_size + 1)
-      << "          cum_seq_q = " << cum_seq_q()->toString() << ",\n";
-  indent(ss, indent_size + 1)
-      << "          cum_seq_k = " << cum_seq_k()->toString() << ",\n";
-  indent(ss, indent_size + 1)
       << "          max_q = " << max_q()->toString() << ",\n";
   indent(ss, indent_size + 1)
       << "          max_k = " << max_k()->toString() << ",\n";
@@ -4860,15 +4847,15 @@ std::vector<PolymorphicValue> SdpaBwdOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   // Backward tensor inputs: grad_input, query, key, value, output, logsumexp,
-  // cum_seq_q/k, max_q/k
+  // max_q/k
   std::vector<at::Tensor> bwd_inputs;
-  for (auto idx : c10::irange(10)) {
+  for (auto idx : c10::irange(8)) {
     bwd_inputs.emplace_back(inputs.at(idx).as<at::Tensor>());
   }
-  const auto dropout_p = inputs.at(10).as<double>();
-  const auto is_causal = inputs.at(11).as<bool>();
-  const auto philox_seed = inputs.at(12).as<at::Tensor>();
-  const auto philox_offset = inputs.at(13).as<at::Tensor>();
+  const auto dropout_p = inputs.at(8).as<double>();
+  const auto is_causal = inputs.at(9).as<bool>();
+  const auto philox_seed = inputs.at(10).as<at::Tensor>();
+  const auto philox_offset = inputs.at(11).as<at::Tensor>();
 
   // Flash attention requires the last dimension to be padded to 8.
   // https://github.com/pytorch/pytorch/blob/c27882ffa8c1c7e4cf8ebc6c2f879e5b6c8814ad/aten/src/ATen/native/transformers/attention.cpp#L675-L677
@@ -4884,11 +4871,12 @@ std::vector<PolymorphicValue> SdpaBwdOp::evaluate(
   };
 
   // Conmpute scale using original size of last dimension
-  double scale = inputs.size() > 14 ? inputs.back().as<double>()
+  double scale = inputs.size() > 12 ? inputs.back().as<double>()
                                     : 1.0 / std::sqrt(last_dim_size);
 
   // ATen reference:
   // https://github.com/pytorch/pytorch/blob/c27882ffa8c1c7e4cf8ebc6c2f879e5b6c8814ad/aten/src/ATen/native/transformers/attention.cpp#L680-L681
+  // cum_seq_q/k are undefined tensors for non-nested input tensors.
   auto [grad_query, grad_key, grad_value] =
       at::_scaled_dot_product_flash_attention_backward(
           /*grad_output=*/pad_last_dim(bwd_inputs[0], 8),
@@ -4897,11 +4885,11 @@ std::vector<PolymorphicValue> SdpaBwdOp::evaluate(
           /*value=*/pad_last_dim(bwd_inputs[3], 8),
           /*output=*/pad_last_dim(bwd_inputs[4], 8),
           /*logsumexp=*/bwd_inputs[5],
-          /*cum_seq_q=*/bwd_inputs[6],
-          /*cum_seq_k=*/bwd_inputs[7],
+          /*cum_seq_q=*/at::Tensor(),
+          /*cum_seq_k=*/at::Tensor(),
           // Note: ATen implementation expects max_q/max_k as scalars.
-          /*max_q=*/bwd_inputs[8].item<int64_t>(),
-          /*max_k=*/bwd_inputs[9].item<int64_t>(),
+          /*max_q=*/bwd_inputs[6].item<int64_t>(),
+          /*max_k=*/bwd_inputs[7].item<int64_t>(),
           /*dropout_p=*/dropout_p,
           /*is_causal=*/is_causal,
           /*philox_seed=*/philox_seed,

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -300,7 +300,7 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
   encodeBuffer(device, encoding_);
   for (const auto i : c10::irange(inputs.size())) {
     auto input = inputs[i];
-    if (input.isTensor()) {
+    if (input.isTensor() && input.toTensor().defined()) {
       auto& input_tensor = input.toTensor();
 
       for (auto size : input_tensor.sizes()) {

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -300,7 +300,7 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
   encodeBuffer(device, encoding_);
   for (const auto i : c10::irange(inputs.size())) {
     auto input = inputs[i];
-    if (input.isTensor() && input.toTensor().defined()) {
+    if (input.isTensor()) {
       auto& input_tensor = input.toTensor();
 
       for (auto size : input_tensor.sizes()) {

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -275,11 +275,15 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     //   grad_key = [N, H, S, E]
     //   grad_value = [N, H, S, Ev]
 
-    bool producer_has_s = producer_tv_->sameAs(op->key()) || producer_tv_->sameAs(op->value());
-    bool consumer_has_s = consumer_tv_->sameAs(op->grad_key()) || consumer_tv_->sameAs(op->grad_value());
+    bool producer_has_s =
+        producer_tv_->sameAs(op->key()) || producer_tv_->sameAs(op->value());
+    bool consumer_has_s = consumer_tv_->sameAs(op->grad_key()) ||
+        consumer_tv_->sameAs(op->grad_value());
 
-    bool producer_has_e = producer_tv_->sameAs(op->query()) || producer_tv_->sameAs(op->key());
-    bool consumer_has_e = consumer_tv_->sameAs(op->grad_query()) || consumer_tv_->sameAs(op->grad_key());
+    bool producer_has_e =
+        producer_tv_->sameAs(op->query()) || producer_tv_->sameAs(op->key());
+    bool consumer_has_e = consumer_tv_->sameAs(op->grad_query()) ||
+        consumer_tv_->sameAs(op->grad_key());
 
     for (auto idx : c10::irange(producer_logical.size())) {
       if (idx < 2) {
@@ -288,12 +292,12 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
             producer_logical.at(idx), consumer_root.at(idx));
       } else if (idx == 2 && (producer_has_s == consumer_has_s)) {
         // producer/consumer[2] = L/S
-          updatePairwiseLogicalDomainMap(
-          producer_logical.at(2), consumer_root.at(2));
+        updatePairwiseLogicalDomainMap(
+            producer_logical.at(2), consumer_root.at(2));
       } else if (idx == 3 && (producer_has_e == consumer_has_e)) {
         // producer/consumer[3] = E/Ev
-          updatePairwiseLogicalDomainMap(
-          producer_logical.at(3), consumer_root.at(3));
+        updatePairwiseLogicalDomainMap(
+            producer_logical.at(3), consumer_root.at(3));
       }
     }
     return dom_map;

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -284,15 +284,15 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     for (auto idx : c10::irange(producer_logical.size())) {
       if (idx < 2) {
         // Map N, H from all producers to consumers
-        updatePairwiseRootDomainMap(
+        updatePairwiseLogicalDomainMap(
             producer_logical.at(idx), consumer_root.at(idx));
       } else if (idx == 2 && (producer_has_s == consumer_has_s)) {
         // producer/consumer[2] = L/S
-          updatePairwiseRootDomainMap(
+          updatePairwiseLogicalDomainMap(
           producer_logical.at(2), consumer_root.at(2));
       } else if (idx == 3 && (producer_has_e == consumer_has_e)) {
         // producer/consumer[3] = E/Ev
-          updatePairwiseRootDomainMap(
+          updatePairwiseLogicalDomainMap(
           producer_logical.at(3), consumer_root.at(3));
       }
     }

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -235,7 +235,6 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     // Consumers:
     //   output = [DIDx(D)?, N, H, L, Ev]
     //   logsumexp = [N, H, L]
-    //   cum_seq_q/k = [N + 1]
 
     size_t num_device_dim = producer_logical.at(0)->isDeviceDim() ? 1 : 0;
     // Map N, H from any input (query/key/value)
@@ -271,7 +270,6 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     //   value = [N, H, S, Ev]
     //   attn_out = [N, H, L, Ev]
     //   logsumexp = [N, H, L]
-    //   cum_seq_q/k = [N + 1]
     // Consumers:
     //   grad_query = [N, H, L, E]
     //   grad_key = [N, H, S, E]

--- a/csrc/ops/composite.h
+++ b/csrc/ops/composite.h
@@ -80,8 +80,6 @@ TensorView* matmul(TensorView* tv_a, TensorView* tv_b);
 struct SdpfaFwdResult {
   TensorView* output = nullptr;
   TensorView* log_sumexp = nullptr;
-  TensorView* cum_seq_q = nullptr;
-  TensorView* cum_seq_k = nullptr;
   TensorView* query_seq_len = nullptr;
   TensorView* key_seq_len = nullptr;
   TensorView* philox_seed = nullptr;
@@ -115,8 +113,6 @@ SdpfaBwdResult sdpfa_bwd(
     TensorView* value,
     TensorView* output,
     TensorView* log_sumexp,
-    TensorView* cum_seq_q,
-    TensorView* cum_seq_k,
     TensorView* query_seq_len,
     TensorView* key_seq_len,
     Val* dropout_p,

--- a/csrc/scheduler/expr_eval_sched.cpp
+++ b/csrc/scheduler/expr_eval_sched.cpp
@@ -18,18 +18,16 @@ bool ExprEvalScheduler::canScheduleCompileTime(Fusion* fusion) {
   auto exprs = fusion->exprs();
   if (exprs.size() > 1) {
     scheduler_debug_utils::canScheduleRejectReason(
-        heuristicType(),
-        "Fusion must contain only a single expression.");
-  }
-  else if (exprs.front()->isOneOf<SdpaFwdOp, SdpaBwdOp>()){
+        heuristicType(), "Fusion must contain only a single expression.");
+  } else if (exprs.front()->isOneOf<SdpaFwdOp, SdpaBwdOp>()) {
     return true;
-  } else if (exprs.front()->isOneOf<LinearOp, MatmulOp>()){
-    if (!isOptionDisabled(DisableOption::MatmulExprEval)){
+  } else if (exprs.front()->isOneOf<LinearOp, MatmulOp>()) {
+    if (!isOptionDisabled(DisableOption::MatmulExprEval)) {
       return true;
     } else {
-    scheduler_debug_utils::canScheduleRejectReason(
-        heuristicType(),
-        "Matmul ATen evaluation was disabled by NVFUSER_DISABLE=matmul_expr_eval");
+      scheduler_debug_utils::canScheduleRejectReason(
+          heuristicType(),
+          "Matmul ATen evaluation was disabled by NVFUSER_DISABLE=matmul_expr_eval");
     }
   } else {
     scheduler_debug_utils::canScheduleRejectReason(

--- a/csrc/scheduler/expr_eval_sched.cpp
+++ b/csrc/scheduler/expr_eval_sched.cpp
@@ -16,7 +16,7 @@ namespace nvfuser {
 // Check if the fusion has a single MatmulOp/LinearOp node
 bool ExprEvalScheduler::canScheduleCompileTime(Fusion* fusion) {
   auto exprs = fusion->exprs();
-  if (exprs.size() > 1) {
+  if (exprs.size() != 1) {
     scheduler_debug_utils::canScheduleRejectReason(
         heuristicType(), "Fusion must contain only a single expression.");
   } else if (exprs.front()->isOneOf<SdpaFwdOp, SdpaBwdOp>()) {

--- a/csrc/scheduler/expr_eval_sched.cpp
+++ b/csrc/scheduler/expr_eval_sched.cpp
@@ -16,18 +16,25 @@ namespace nvfuser {
 // Check if the fusion has a single MatmulOp/LinearOp node
 bool ExprEvalScheduler::canScheduleCompileTime(Fusion* fusion) {
   auto exprs = fusion->exprs();
-  if (!isOptionDisabled(DisableOption::MatmulExprEval)) {
-    if (exprs.size() == 1 &&
-        (exprs.front()->isOneOf<LinearOp, MatmulOp, SdpaFwdOp>())) {
-      return true;
-    }
+  if (exprs.size() > 1) {
     scheduler_debug_utils::canScheduleRejectReason(
         heuristicType(),
-        "Fusion must contain a single expression of type MatmulOp or LinearOp");
-  } else {
+        "Fusion must contain only a single expression.");
+  }
+  else if (exprs.front()->isOneOf<SdpaFwdOp, SdpaBwdOp>()){
+    return true;
+  } else if (exprs.front()->isOneOf<LinearOp, MatmulOp>()){
+    if (!isOptionDisabled(DisableOption::MatmulExprEval)){
+      return true;
+    } else {
     scheduler_debug_utils::canScheduleRejectReason(
         heuristicType(),
         "Matmul ATen evaluation was disabled by NVFUSER_DISABLE=matmul_expr_eval");
+    }
+  } else {
+    scheduler_debug_utils::canScheduleRejectReason(
+        heuristicType(),
+        "Fusion must contain only a single expression of type MatmulOp/LinearOp/SdpaFwdOp/SdpaBwdOp");
   }
   return false;
 }

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -177,9 +177,9 @@ bool checkCanSchedule(
 
   FusionGuard fg(fusion);
 
-  // Fusions with `SdpaFwdOp` are only accepted in `ExprEval`
+  // Fusions with `SdpaFwdOp/SdpaBwdOp` are only accepted in `ExprEval`
   // scheduler, all other schedulers should reject them.
-  if (ir_utils::hasOpsOfType<SdpaFwdOp>(fusion)) {
+  if (ir_utils::hasOpsOfType<SdpaFwdOp, SdpaBwdOp>(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
         SchedulerType::heuristicType(), "SdpaOps are not supported.");
     return false;

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -117,7 +117,7 @@ bool is_cpu_scalar(const c10::TensorType& tensor_type) {
       opt_numel.value() == 1;
 }
 
-bool is_meta_scalar(const at::Tensor& tensor){
+bool is_meta_scalar(const at::Tensor& tensor) {
   return tensor.device().is_meta() && tensor.numel() == 1 && tensor.dim() == 0;
 }
 

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -117,6 +117,10 @@ bool is_cpu_scalar(const c10::TensorType& tensor_type) {
       opt_numel.value() == 1;
 }
 
+bool is_meta_scalar(const at::Tensor& tensor){
+  return tensor.device().is_meta() && tensor.numel() == 1 && tensor.dim() == 0;
+}
+
 int8_t getCommonDeviceCUDA(
     const at::ArrayRef<c10::IValue>& inputs,
     std::optional<int8_t> selected_device) {

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -60,6 +60,8 @@ bool is_zero_sized_tensor(const std::shared_ptr<c10::TensorType>& tensor_type);
 bool is_cpu_scalar(const at::Tensor& tensor);
 bool is_cpu_scalar(const c10::TensorType& tensor_type);
 
+bool is_meta_scalar(const at::Tensor& tensor);
+
 //! Find common device among tensor inputs. If no tensor inputs are found and
 //! the selected_device argument is omitted, a default value of 0 is returned.
 //! If no tensor inputs are found and selected_device is provided,

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -619,6 +619,8 @@ TEST_F(SDPATest, AttnFwdBwd) {
   // Set query_seq_len, key_seq_len as CPU scalars
   sdpa_fwd_out.query_seq_len->setCpuScalar(true);
   sdpa_fwd_out.key_seq_len->setCpuScalar(true);
+  sdpa_fwd_out.philox_seed->setCpuScalar(true);
+  sdpa_fwd_out.philox_offset->setCpuScalar(true);
 
   auto tv_grad_output = makeConcreteTensor(attn_shape, DataType::Half);
   fusion->addInput(tv_grad_output);

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -42,8 +42,6 @@ constexpr int64_t n = 16, h = 32, l = 64, s = 128, e = 64;
 auto addSdpaFwdOutputs = [](Fusion* fusion, SdpfaFwdResult output) {
   fusion->addOutput(output.output);
   fusion->addOutput(output.log_sumexp);
-  fusion->addOutput(output.cum_seq_q);
-  fusion->addOutput(output.cum_seq_k);
   fusion->addOutput(output.query_seq_len);
   fusion->addOutput(output.key_seq_len);
   fusion->addOutput(output.philox_seed);
@@ -73,17 +71,15 @@ auto validateSdpaFwdOutputs = [](std::vector<at::Tensor> nvf_out,
        philox_seed,
        philox_offset,
        debug_attn_mask] = aten_out;
-  // nvf_out = {attn, log_sumexp, cum_seq_q, cum_seq_k, philox_seed,
-  // philox_offset, debug_attn_mask} Since, dropout_p = 0.0 to validate outputs,
+  // nvf_out = {attn, log_sumexp, philox_seed, philox_offset, debug_attn_mask} 
+  // Since, dropout_p = 0.0 to validate outputs,
   // philox_seed and philox_offset are uninitialized empty tensors with garbage
   // values for this case, so we skip validating those values.
   EXPECT_TRUE(at::allclose(nvf_out[0], attn));
   EXPECT_TRUE(at::allclose(nvf_out[1], log_sumexp));
-  EXPECT_FALSE(nvf_out[2].defined());
-  EXPECT_FALSE(nvf_out[3].defined());
-  EXPECT_EQ(nvf_out[4].item<int64_t>(), query_seq_len);
-  EXPECT_EQ(nvf_out[5].item<int64_t>(), key_seq_len);
-  EXPECT_TRUE(at::equal(nvf_out[8], debug_attn_mask));
+  EXPECT_EQ(nvf_out[2].item<int64_t>(), query_seq_len);
+  EXPECT_EQ(nvf_out[3].item<int64_t>(), key_seq_len);
+  EXPECT_TRUE(at::equal(nvf_out[6], debug_attn_mask));
 };
 
 TEST_F(SDPATest, NonCausalAttnConcrete) {
@@ -253,7 +249,6 @@ TEST_F(SDPATest, PairwiseLogicalDomainMap) {
   // Consumers:
   //   output = [N, H, L, Ev]
   //   logsumexp = [N, H, L]
-  //   cum_seq_q/k = [N + 1]
   std::vector<TensorView*> producer_tvs{tvq, tvk, tvv};
   for (auto role : {AttnRole::Q, AttnRole::K, AttnRole::V}) {
     auto producer_tv = producer_tvs[(int)role];
@@ -268,8 +263,6 @@ TEST_F(SDPATest, PairwiseLogicalDomainMap) {
             pairwise_map[p_id] == c_id;
       };
 
-      // For cum_seq_q/k, root_domain = {iN}, logical_domain = {i(N+1)}
-      // Mapping exists from root domain to producer.
       auto consumer_root = consumer_tv->getMaybeRootDomain();
       for (auto idx : c10::irange(consumer_tv->nDims())) {
         // Mapping for N, H exists from Q/K/V to any output.
@@ -333,8 +326,6 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
   auto tvv = makeConcreteTensor(kv_shape, DataType::Half);
   auto tv_output = makeConcreteTensor(attn_shape, DataType::Half);
   auto tv_logsumexp = makeConcreteTensor({n, h, l}, DataType::Float);
-  auto tv_cumq = makeConcreteTensor({0}, DataType::Null);
-  auto tv_cumk = makeConcreteTensor({0}, DataType::Null);
   auto tv_maxq = makeConcreteTensor({}, DataType::Int);
   tv_maxq->setCpuScalar(true);
   auto tv_maxk = makeConcreteTensor({}, DataType::Int);
@@ -350,8 +341,6 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
   fusion->addInput(tvv);
   fusion->addInput(tv_output);
   fusion->addInput(tv_logsumexp);
-  fusion->addInput(tv_cumq);
-  fusion->addInput(tv_cumk);
   fusion->addInput(tv_maxq);
   fusion->addInput(tv_maxk);
   fusion->addInput(tv_seed);
@@ -364,8 +353,6 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
       tvv,
       tv_output,
       tv_logsumexp,
-      tv_cumq,
-      tv_cumk,
       tv_maxq,
       tv_maxk,
       /*dropout_p=*/IrBuilder::create<Val>(dropout_p),
@@ -387,8 +374,6 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
       v,
       output,
       log_sumexp,
-      cum_seq_q,
-      cum_seq_k,
       // max_q/k are represented as CPU scalar tensors in nvFuser and integers
       // in ATen.
       at::scalar_tensor(*query_seq_len.maybe_as_int(), at::dtype(at::kLong)),
@@ -418,7 +403,7 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
           /*scale=*/scale);
 
   testValidate(
-      fusion.get(),
+      fec.fusion(),
       out,
       sdpa_bwd_inputs,
       {ref_grad_query, ref_grad_key, ref_grad_value},
@@ -469,8 +454,6 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
   auto tvv = makeSymbolicTensor(kv_shape, DataType::Half);
   auto tv_output = makeSymbolicTensor(attn_shape, DataType::Half);
   auto tv_logsumexp = makeSymbolicTensor({n, h, l}, DataType::Float);
-  auto tv_cumq = makeSymbolicTensor(1, DataType::Null);
-  auto tv_cumk = makeSymbolicTensor(1, DataType::Null);
   auto tv_maxq = makeSymbolicTensor({}, DataType::Int);
   tv_maxq->setCpuScalar(true);
   auto tv_maxk = makeSymbolicTensor({}, DataType::Int);
@@ -486,8 +469,6 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
   fusion->addInput(tvv);
   fusion->addInput(tv_output);
   fusion->addInput(tv_logsumexp);
-  fusion->addInput(tv_cumq);
-  fusion->addInput(tv_cumk);
   fusion->addInput(tv_maxq);
   fusion->addInput(tv_maxk);
   fusion->addInput(tv_seed);
@@ -500,8 +481,6 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
       tvv,
       tv_output,
       tv_logsumexp,
-      tv_cumq,
-      tv_cumk,
       tv_maxq,
       tv_maxk,
       /*dropout_p=*/IrBuilder::create<Val>(dropout_p),
@@ -523,8 +502,6 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
       v,
       output,
       log_sumexp,
-      cum_seq_q,
-      cum_seq_k,
       // max_q/k are represented as CPU scalar tensors in nvFuser and integers
       // in ATen.
       at::scalar_tensor(*query_seq_len.maybe_as_int(), at::dtype(at::kLong)),
@@ -554,7 +531,7 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
           /*scale=*/scale);
 
   testValidate(
-      fusion.get(),
+      fec.fusion(),
       out,
       sdpa_bwd_inputs,
       {ref_grad_query, ref_grad_key, ref_grad_value},
@@ -639,6 +616,10 @@ TEST_F(SDPATest, AttnFwdBwd) {
       /*is_causal=*/IrBuilder::create<Val>(false),
       /*scale=*/nullptr);
 
+  // Set query_seq_len, key_seq_len as CPU scalars
+  sdpa_fwd_out.query_seq_len->setCpuScalar(true);
+  sdpa_fwd_out.key_seq_len->setCpuScalar(true);
+
   auto tv_grad_output = makeConcreteTensor(attn_shape, DataType::Half);
   fusion->addInput(tv_grad_output);
 
@@ -649,8 +630,6 @@ TEST_F(SDPATest, AttnFwdBwd) {
       tvv,
       sdpa_fwd_out.output,
       sdpa_fwd_out.log_sumexp,
-      sdpa_fwd_out.cum_seq_q,
-      sdpa_fwd_out.cum_seq_k,
       sdpa_fwd_out.query_seq_len,
       sdpa_fwd_out.key_seq_len,
       /*dropout_p=*/IrBuilder::create<Val>(0.0),
@@ -663,6 +642,7 @@ TEST_F(SDPATest, AttnFwdBwd) {
   fusion->addOutput(sdpa_grad.grad_query);
   fusion->addOutput(sdpa_grad.grad_key);
   fusion->addOutput(sdpa_grad.grad_value);
+  fusion->addOutput(sdpa_fwd_out.query_seq_len);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor q = at::randn(q_shape, options).set_requires_grad(true);
@@ -686,13 +666,13 @@ TEST_F(SDPATest, AttnFwdBwd) {
   v.retain_grad();
   attn.backward(grad_out);
 
-  testValidate(
-      fusion.get(),
-      nvf_out,
-      {q, k, v, grad_out},
-      {attn, q.grad(), k.grad(), v.grad()},
-      __LINE__,
-      __FILE__);
+  // testValidate(
+  //     fusion.get(),
+  //     nvf_out,
+  //     {q, k, v, grad_out},
+  //     {attn, q.grad(), k.grad(), v.grad()},
+  //     __LINE__,
+  //     __FILE__);
 }
 
 // TODO: Remove/update when https://github.com/NVIDIA/Fuser/issues/2563 is

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -644,7 +644,6 @@ TEST_F(SDPATest, AttnFwdBwd) {
   fusion->addOutput(sdpa_grad.grad_query);
   fusion->addOutput(sdpa_grad.grad_key);
   fusion->addOutput(sdpa_grad.grad_value);
-  fusion->addOutput(sdpa_fwd_out.query_seq_len);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor q = at::randn(q_shape, options).set_requires_grad(true);
@@ -669,7 +668,7 @@ TEST_F(SDPATest, AttnFwdBwd) {
   attn.backward(grad_out);
 
   testValidate(
-      fusion.get(),
+      fec.fusion(),
       nvf_out,
       {q, k, v, grad_out},
       {attn, q.grad(), k.grad(), v.grad()},

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -71,10 +71,10 @@ auto validateSdpaFwdOutputs = [](std::vector<at::Tensor> nvf_out,
        philox_seed,
        philox_offset,
        debug_attn_mask] = aten_out;
-  // nvf_out = {attn, log_sumexp, philox_seed, philox_offset, debug_attn_mask} 
-  // Since, dropout_p = 0.0 to validate outputs,
-  // philox_seed and philox_offset are uninitialized empty tensors with garbage
-  // values for this case, so we skip validating those values.
+  // nvf_out = {attn, log_sumexp, query_seq_len, key_seq_len, philox_seed,
+  // philox_offset, debug_attn_mask}. Since, dropout_p = 0.0 to validate
+  // outputs, philox_seed and philox_offset are uninitialized empty tensors with
+  // garbage values for this case, so we skip validating those values.
   EXPECT_TRUE(at::allclose(nvf_out[0], attn));
   EXPECT_TRUE(at::allclose(nvf_out[1], log_sumexp));
   EXPECT_EQ(nvf_out[2].item<int64_t>(), query_seq_len);

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -668,13 +668,13 @@ TEST_F(SDPATest, AttnFwdBwd) {
   v.retain_grad();
   attn.backward(grad_out);
 
-  // testValidate(
-  //     fusion.get(),
-  //     nvf_out,
-  //     {q, k, v, grad_out},
-  //     {attn, q.grad(), k.grad(), v.grad()},
-  //     __LINE__,
-  //     __FILE__);
+  testValidate(
+      fusion.get(),
+      nvf_out,
+      {q, k, v, grad_out},
+      {attn, q.grad(), k.grad(), v.grad()},
+      __LINE__,
+      __FILE__);
 }
 
 // TODO: Remove/update when https://github.com/NVIDIA/Fuser/issues/2563 is


### PR DESCRIPTION
This PR:

1. Removes `cum_seq_q/k` from `SdpaFwdOp` outputs and `SdpaBwdOp` inputs. These are undefined tensors for non-nested inputs which are not supported as fusion inputs. The nvFuser API now differs from torch/Thunder.
2. Adds pairwise domain mapping and scheduling support for `SdpaBwdOp`.
3. Allows tensor views marked as CPU scalars to be meta tensors. Detailed reasoning in code comments.