### PR TITLE
Fix compile error in test_indexing

### DIFF
--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -125,7 +125,7 @@ class AbstractGetReference {
   // add them here since the function signature doesn't need to change.
   std::vector<ForLoop*> for_loops_;
   CircularBufferLoopStage circular_buffer_loop_stage_ =
-      CircularBufferLoopStage::Main;
+      CircularBufferLoopStage::NotApplicable;
 };
 
 template <typename GetReference>

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -124,7 +124,8 @@ class AbstractGetReference {
   // These could be getLinearIndex parameters, but it's just easier to
   // add them here since the function signature doesn't need to change.
   std::vector<ForLoop*> for_loops_;
-  CircularBufferLoopStage circular_buffer_loop_stage_;
+  CircularBufferLoopStage circular_buffer_loop_stage_ =
+      CircularBufferLoopStage::Main;
 };
 
 template <typename GetReference>


### PR DESCRIPTION
This PR fixes this compile error in `tests/cpp/test_indexing.cpp`.

```
/opt/pytorch/nvfuser/tests/cpp/test_indexing.cpp:87:7: error: ‘<unnamed>.GetReference::<unnamed>.nvfuser::{anonymous}::AbstractGetReference::circular_buffer_loop_stage_’ may be used uninitialized [-Werror=maybe-uninitialized]
```