### PR TITLE
clear memory in pytest

### DIFF
--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -7,6 +7,7 @@ import torch
 import pytest
 import numpy as np
 
+from benchmarks.python.core import clear_cuda_cache
 from pytest_fusion_definitions import default_fd_fn, parse_inputs_fusion_definition
 from pytest_framework import create_op_test
 from pytest_core import ReferenceType, OpInfo, SampleInput
@@ -155,6 +156,7 @@ def correctness_test_fn(
 
 @create_op_test(tuple(op for op in opinfos if op.sample_input_generator is not None))
 def test_correctness(op: OpInfo, dtype: torch.dtype):
+    clear_cuda_cache()
     for sample in op.sample_input_generator(op, dtype):
         result = correctness_test_fn(op.reference_type, op, sample)
         if result is not None:
@@ -188,6 +190,7 @@ def definition_op_in_schedule_error_test_fn(opinfo: OpInfo, sample: SampleInput)
 # TODO Maybe only test a single dtype
 @create_op_test(tuple(op for op in opinfos if op.sample_input_generator is not None))
 def test_definition_op_in_schedule_error(op: OpInfo, dtype: torch.dtype):
+    clear_cuda_cache()
     for sample in op.sample_input_generator(op, dtype):
         with pytest.raises(
             RuntimeError, match=r"Attempting to add to a completed definition"
@@ -221,6 +224,7 @@ def _regex_escape_parenthesis(a: str) -> str:
 
 @create_op_test(tuple(op for op in opinfos if op.error_input_generator is not None))
 def test_errors(op: OpInfo, dtype: torch.dtype):
+    clear_cuda_cache()
     for sample, exception_type, exception_regex in op.error_input_generator(op, dtype):
         with pytest.raises(
             exception_type, match=_regex_escape_parenthesis(exception_regex)


### PR DESCRIPTION
CI at at [link](https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/jobs/101537058/raw) detected many failed cases due to out of memory.
For example:
```
00:17:01 FAILED tests/python/pytest_ops.py::test_definition_op_in_schedule_error_sub_complex128 - torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 32.00 MiB. GPU 0 has a total capacity of 39.39 GiB of which 11.94 MiB is free. Process 4101543 has 39.37 GiB memory in use. Of the allocated memory 9.27 GiB is allocated by PyTorch, and 8.61 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
00:17:01 FAILED tests/python/pytest_ops.py::test_definition_op_in_schedule_error_sub_complex64 - torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 20.00 MiB. GPU 0 has a total capacity of 39.39 GiB of which 11.94 MiB is free. Process 4101543 has 39.37 GiB memory in use. Of the allocated memory 9.27 GiB is allocated by PyTorch, and 8.60 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
00:17:01 FAILED tests/python/pytest_ops.py::test_definition_op_in_schedule_error_matmul_bfloat16 - torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.00 MiB. GPU 0 has a total capacity of 39.39 GiB of which 1.94 MiB is free. Process 4101543 has 39.38 GiB memory in use. Of the allocated memory 9.28 GiB is allocated by PyTorch, and 543.50 KiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
00:17:01 FAILED tests/python/pytest_ops.py::test_definition_op_in_schedule_error_matmul_float16 - torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.00 MiB. GPU 0 has a total capacity of 39.39 GiB of which 1.94 MiB is free. Process 4101543 has 39.38 GiB memory in use. Of the allocated memory 9.28 GiB is allocated by PyTorch, and 527.00 KiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
00:17:01 FAILED tests/python/pytest_ops.py::test_definition_op_in_schedule_error_linear_bfloat16 - torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 20.00 MiB. GPU 0 has a total capacity of 39.39 GiB of which 1.94 MiB is free. Process 4101543 has 39.38 GiB memory in use. Of the allocated memory 9.28 GiB is allocated by PyTorch, and 396.00 KiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
00:17:01 FAILED tests/python/pytest_ops.py::test_definition_op_in_schedule_error_linear_float16 - torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 20.00 MiB. GPU 0 has a total capacity of 39.39 GiB of which 1.94 MiB is free. Process 4101543 has 39.38 GiB memory in use. Of the allocated memory 9.28 GiB is allocated by PyTorch, and 264.50 KiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
00:17:01 ============ 27 failed, 841 passed, 4 warnings in 570.34s (0:09:30) ============
```

This PR added `clear_cuda_cache()` to each test in `tests/python/pytest_ops.py`

