### PR TITLE
install nlohmann-json3-dev to patch build failures related to pytorch distributed changes

### DIFF
--- a/tools/apt-install-things.sh
+++ b/tools/apt-install-things.sh
@@ -4,4 +4,4 @@
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
 sudo dpkg -i cuda-keyring_1.0-1_all.deb
 sudo apt-get update
-sudo apt-get -y install ninja-build cuda-compiler-12-1 cuda-command-line-tools-12-1 cuda-libraries-dev-12-1 libnccl-dev clang-14
+sudo apt-get -y install ninja-build cuda-compiler-12-1 cuda-command-line-tools-12-1 cuda-libraries-dev-12-1 libnccl-dev clang-14 nlohmann-json3-dev


### PR DESCRIPTION
hacking headers to workaround https://github.com/pytorch/pytorch/issues/130678