### PR TITLE
Avoid Reduction/Broadcast domains in ValGraph scheduling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,6 +546,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_swizzle.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_tensor_factories.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_unary.cpp
+  ${NVFUSER_ROOT}/tests/cpp/test_valgraph_scheduling.cpp
 )
 
 if(BUILD_TEST)

--- a/csrc/id_model/schedule.cpp
+++ b/csrc/id_model/schedule.cpp
@@ -10,10 +10,48 @@
 
 namespace nvfuser {
 
+IterDomain* representativeId(const ValGroup& vg) {
+  IterDomain* rep = nullptr;
+
+  auto preferNewIterType = [&rep](IterDomain* new_id) {
+    if (rep->isReduction()) {
+      return new_id->isBroadcast() || new_id->isIteration();
+    } else if (rep->isBroadcast()) {
+      return new_id->isIteration();
+    } else if (rep->isIteration()) {
+      return false;
+    } else {
+      // Prefer anything else to a non-iter, non-bcast, non-reduction ID
+      return true;
+    }
+  };
+
+  auto preferNewExtent = [&rep](IterDomain* new_id) {
+    if (rep->hasExpandedExtent() && !new_id->hasExpandedExtent()) {
+      // Prefer non-expanded dimensions
+      return true;
+    }
+    // Prefer constant extent IDs to symbolic
+    return !rep->getMaybeExpandedExtent()->isConstInt() &&
+        new_id->getMaybeExpandedExtent()->isConstInt();
+  };
+
+  for (Val* v : *vg) {
+    if (auto id = dynamic_cast<IterDomain*>(v); id &&
+        (rep == nullptr || preferNewIterType(id) ||
+         (id->getIterType() == rep->getIterType() && preferNewExtent(id)))) {
+      rep = id;
+      continue;
+    }
+  }
+  NVF_ERROR(rep != nullptr);
+  return rep;
+}
+
 ValGroup merge(ValGraph* graph, const ValGroup& g0, const ValGroup& g1) {
   NVF_ERROR(!g0->empty() && !g1->empty(), "ValGroup can not be empty");
-  auto g0_id = g0->front()->as<IterDomain>();
-  auto g1_id = g1->front()->as<IterDomain>();
+  auto g0_id = representativeId(g0);
+  auto g1_id = representativeId(g1);
   NVF_ERROR(
       graph->hasGroup(g0_id) && graph->toGroup(g0_id) == g0,
       "Invalid g0 given: g0 is not in the given ValGraph");
@@ -51,7 +89,7 @@ std::pair<ValGroup, ValGroup> split(
     Val* factor,
     bool inner_split) {
   NVF_ERROR(!g->empty(), "ValGroup can not be empty");
-  auto g_id = g->front()->as<IterDomain>();
+  auto g_id = representativeId(g);
   NVF_ERROR(
       graph->hasGroup(g_id) && graph->toGroup(g_id) == g,
       "Invalid g given: g is not in the given ValGraph");
@@ -98,8 +136,8 @@ std::pair<ValGroup, ValGroup> swizzle(
     const ValGroup& g0,
     const ValGroup& g1) {
   NVF_ERROR(!g0->empty() && !g1->empty(), "ValGroup can not be empty");
-  auto g0_id = g0->front()->as<IterDomain>();
-  auto g1_id = g1->front()->as<IterDomain>();
+  auto g0_id = representativeId(g0);
+  auto g1_id = representativeId(g1);
   NVF_ERROR(
       graph->hasGroup(g0_id) && graph->toGroup(g0_id) == g0,
       "Invalid g0 given: g0 is not in the given ValGraph");

--- a/csrc/id_model/schedule.h
+++ b/csrc/id_model/schedule.h
@@ -11,6 +11,15 @@
 
 namespace nvfuser {
 
+// Choose an IterDomain from the ValGroup that is amenable to transforms.
+// Specifically we prefer, in descending order:
+//   1. Iteration domains
+//   2. Broadcast domains
+//   3. Reduction domains
+// Among IterDomains with the same IterType, we prefer IterDomains with a
+// constant unexpanded extent to others.
+IterDomain* representativeId(const ValGroup& vg);
+
 // Given a ValGraph and two ValGroups g0 and g1 in this graph, if there is
 // already a merge of g0 with g1 in graph, return the output ValGroup of that
 // merge. Otherwise create an new ValGroup that is a merge of g0 and g1 in

--- a/tests/cpp/test_valgraph_scheduling.cpp
+++ b/tests/cpp/test_valgraph_scheduling.cpp
@@ -1,0 +1,68 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <tests/cpp/utils.h>
+
+#include <id_model/schedule.h>
+#include <ir/internal_base_nodes.h>
+
+namespace nvfuser {
+
+using ValGraphSchedulingTest = NVFuserTest;
+
+// Create a ValGroup with both Reduction and Iteration domains. Test that the
+// Reduction IterDomains are not used as representatives when merging.
+TEST_F(ValGraphSchedulingTest, MergeIterationWithReduction) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion* fusion = fusion_ptr.get();
+  FusionGuard guard(fusion);
+
+  auto id0 = IterDomainBuilder(
+                 fusion->zeroVal(), IrBuilder::create<Val>(DataType::Index))
+                 .iter_type(IterType::Reduction)
+                 .build();
+  auto id1 = IterDomainBuilder(
+                 fusion->zeroVal(), IrBuilder::create<Val>(DataType::Index))
+                 .iter_type(IterType::Iteration)
+                 .build();
+  auto id2 = IterDomainBuilder(
+                 fusion->zeroVal(), IrBuilder::create<Val>(DataType::Index))
+                 .iter_type(IterType::Broadcast)
+                 .build();
+  auto id3 = IterDomainBuilder(
+                 fusion->zeroVal(), IrBuilder::create<Val>(DataType::Index))
+                 .iter_type(IterType::Iteration)
+                 .build();
+
+  ValGraph graph;
+  graph.initializeVal(id0);
+  ValGroup g0 = graph.toGroup(id0);
+  graph.initializeVal(id1, g0);
+
+  graph.initializeVal(id2);
+  ValGroup g1 = graph.toGroup(id2);
+  graph.initializeVal(id3, g1);
+
+  EXPECT_TRUE(g0->front()->as<IterDomain>()->isReduction());
+  EXPECT_TRUE(g1->front()->as<IterDomain>()->isBroadcast());
+
+  // merge {id0, id1} with {id2}
+  // If this is done by cloning the first Val in each group then applying
+  // IterDomain::merge, an error will be encountered due to the IterTypes being
+  // incompatible. Each group contains a well-behaved IterType::Iteration ID
+  // that should be used instead.
+  ValGroup gmerge = merge(&graph, g0, g1);
+
+  ASSERT_FALSE(gmerge->empty());
+  ASSERT_TRUE(gmerge->front()->isA<IterDomain>());
+  EXPECT_FALSE(gmerge->front()->as<IterDomain>()->isReduction());
+}
+
+} // namespace nvfuser


### PR DESCRIPTION
Currently, in `id_model/schedule.cpp` if a requested `ExprGroup` doesn't already exist we select the first element in each producer `ValGroup`, clone it without rfactor, then apply IterDomain methods `split`, `merge`, or `swizzle`, and map the result as a new consumer `ValGroup`. See #2321.

Selecting the first element of the `ValGroup` is problematic though since it might mean we try to merge an `IterType::Reduction` domain with an `IterType::Iteration` domain. Instead, this PR introduces a utility `IterDomain* representativeId(const ValGroup& vg)` which picks the "best-behaved" `IterDomain` from the group. It errors if there are no `IterDomain`s in the `ValGroup`.

I created the utility to avoid the Iteration/Reduction merge problem, but it is useful in other contexts also such as trying to extract a constant extent from a `ValGroup` where there might be some mapped symbolic extents, etc.