### PR TITLE
Make Communicator a singleton. 

### DIFF
--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -179,6 +179,7 @@ Communicator::Communicator(
       master_port_(0),
       ucc_available_(false),
       nccl_available_(false) {
+  std::cerr << "Communicator constructed" << std::endl;
   // retrieves rank and communicator size
   is_available_ = parseEnv(
       rank_, size_, local_rank_, local_size_, master_addr_, master_port_);
@@ -215,6 +216,7 @@ Communicator::Communicator(
 }
 
 Communicator::~Communicator() {
+  std::cerr << "Communicator destroyed" << std::endl;
 #if defined(NVFUSER_DISTRIBUTED) && defined(USE_C10D_NCCL)
   for (auto& [key, backend] : backends_) {
     // Call shutdown before destructing a ProcessGroupNCCL as instructed by

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -179,7 +179,6 @@ Communicator::Communicator(
       master_port_(0),
       ucc_available_(false),
       nccl_available_(false) {
-  std::cerr << "Communicator::Communicator" << std::endl;
   // retrieves rank and communicator size
   is_available_ = parseEnv(
       rank_, size_, local_rank_, local_size_, master_addr_, master_port_);
@@ -216,8 +215,6 @@ Communicator::Communicator(
 }
 
 void Communicator::cleanup() {
-  std::cerr << "Communicator::cleanup" << std::endl;
-
   store_ = nullptr;
 
 #if defined(NVFUSER_DISTRIBUTED) && defined(USE_C10D_NCCL)

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -217,7 +217,7 @@ Communicator::Communicator(
 void Communicator::cleanup() {
   if (!is_available_) {
     TORCH_WARN(
-        "The singleton Communicator wasn't available before the cleanup. "
+        "The singleton Communicator isn't available. "
         "This is likely because Communicator::cleanup was called more than "
         "once or the instance wasn't successfully initialized.");
     return;
@@ -243,6 +243,12 @@ c10d::Backend* Communicator::getBackendForTeam(
     const Team& team,
     std::optional<CommunicatorBackend> backend,
     const std::string& prefix) {
+  NVF_ERROR(
+      is_available(),
+      "The singleton Communicator isn't available. "
+      "This is likely because Communicator::cleanup has been called "
+      "or the instance wasn't successfully initialized.");
+
   CommunicatorBackend b = getBackend(backend);
   // generate a string key which is unique to the team
   // create the team and cache it

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -215,6 +215,14 @@ Communicator::Communicator(
 }
 
 void Communicator::cleanup() {
+  if (!is_available_) {
+    TORCH_WARN(
+        "The singleton Communicator wasn't available before the cleanup. "
+        "This is likely because Communicator::cleanup was called more than "
+        "once or the instance wasn't successfully initialized.");
+    return;
+  }
+
   store_ = nullptr;
 
 #if defined(NVFUSER_DISTRIBUTED) && defined(USE_C10D_NCCL)
@@ -227,6 +235,8 @@ void Communicator::cleanup() {
   }
 #endif
   backends_.clear();
+
+  is_available_ = false;
 }
 
 c10d::Backend* Communicator::getBackendForTeam(

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -179,7 +179,7 @@ Communicator::Communicator(
       master_port_(0),
       ucc_available_(false),
       nccl_available_(false) {
-  std::cerr << "Communicator constructed" << std::endl;
+  std::cerr << "Communicator::Communicator" << std::endl;
   // retrieves rank and communicator size
   is_available_ = parseEnv(
       rank_, size_, local_rank_, local_size_, master_addr_, master_port_);
@@ -215,8 +215,11 @@ Communicator::Communicator(
 #endif
 }
 
-Communicator::~Communicator() {
-  std::cerr << "Communicator destroyed" << std::endl;
+void Communicator::cleanup() {
+  std::cerr << "Communicator::cleanup" << std::endl;
+
+  store_ = nullptr;
+
 #if defined(NVFUSER_DISTRIBUTED) && defined(USE_C10D_NCCL)
   for (auto& [key, backend] : backends_) {
     // Call shutdown before destructing a ProcessGroupNCCL as instructed by
@@ -226,6 +229,7 @@ Communicator::~Communicator() {
     }
   }
 #endif
+  backends_.clear();
 }
 
 c10d::Backend* Communicator::getBackendForTeam(

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -51,6 +51,21 @@ constexpr int comm_server_local_rank_default = 0;
 class Communicator {
  public:
   static Communicator& getInstance() {
+    // This isn't the best practice to use singleton. Ideally, we'd like to
+    // ```
+    // static Communicator communicator;
+    // ```
+    // and let the destructor clean it up at program exit after `main` returns.
+    // This however would cause a "driver shutting down" error, likely because
+    // another static variable destructor shuts down the CUDA driver before
+    // ~Communicator. Note that the order of static variable destruction
+    // across translation units is undefined.
+    //
+    // Therefore, we `new Communicator()` as a raw pointer and let the user
+    // call Communicator::getInstance().cleanup() to clean up the Communicator
+    // explicitly before the end of `main`. For example, the cleanup method is
+    // called via MultiDeviceTestEnvironment::TearDown in C++ unit tests and
+    // nvfuser._cleanup() in Python.
     static auto* communicator = new Communicator();
     return *communicator;
   }

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -51,12 +51,13 @@ constexpr int comm_server_local_rank_default = 0;
 class Communicator {
  public:
   static Communicator& getInstance() {
-    static Communicator communicator;
-    return communicator;
+    static auto* communicator = new Communicator();
+    return *communicator;
   }
 
   Communicator(const Communicator&) = delete;
   Communicator& operator=(const Communicator&) = delete;
+  void cleanup();
 
   // returns if distributed config is available
   auto is_available() const {
@@ -126,7 +127,6 @@ class Communicator {
   Communicator(
       CommunicatorBackend backend = comm_backend_default,
       RankType server_local_rank = comm_server_local_rank_default);
-  ~Communicator();
 
   // returns the rank corresponding to a device index
   RankType dIdToRank(DeviceIdxType d_id) const {

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -72,6 +72,9 @@ class Communicator {
 
   Communicator(const Communicator&) = delete;
   Communicator& operator=(const Communicator&) = delete;
+  ~Communicator() = delete;
+  // As said in `getInstance`, the user of this class is supposed to call this
+  // method to clean up the singleton. This obviously can only be called once.
   void cleanup();
 
   // returns if distributed config is available

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -24,18 +24,15 @@
 
 namespace nvfuser {
 
-/*
-   This file implements the class Communicator which sets up the inter-process
-   Backend. This class contains inter-process information, such as the rank, the
-   world size, as well as the Process Group that can be called to perform
-   inter-process communications.
-
-   Each process is associated with a unique deviceId and device. The actual MPI
-   rank remains private to the class and should not be used by the user. The
-   communicator class holds privately the mappings ranks <-> device IDs <->
-   device.
-
-*/
+// This file implements the class Communicator which sets up the inter-process
+// Backend. This class contains inter-process information, such as the rank, the
+// world size, as well as the Process Group that can be called to perform
+// inter-process communications.
+//
+// Each process is associated with a unique deviceId and device. The actual MPI
+// rank remains private to the class and should not be used by the user. The
+// communicator class holds privately the mappings ranks <-> device IDs <->
+// device.
 
 using RankType = DeviceIdxType;
 
@@ -53,10 +50,10 @@ constexpr int comm_server_local_rank_default = 0;
 
 class Communicator {
  public:
-  Communicator(
-      CommunicatorBackend backend = comm_backend_default,
-      RankType server_local_rank = comm_server_local_rank_default);
-  ~Communicator();
+  static Communicator& getInstance() {
+    static Communicator communicator;
+    return communicator;
+  }
 
   Communicator(const Communicator&) = delete;
   Communicator& operator=(const Communicator&) = delete;
@@ -126,6 +123,11 @@ class Communicator {
   }
 
  private:
+  Communicator(
+      CommunicatorBackend backend = comm_backend_default,
+      RankType server_local_rank = comm_server_local_rank_default);
+  ~Communicator();
+
   // returns the rank corresponding to a device index
   RankType dIdToRank(DeviceIdxType d_id) const {
     return static_cast<RankType>(d_id);

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -135,12 +135,11 @@ void FusionDefinition::finalizeSchedule(
   // TODO: remove when multidevice executor integration is done natively
   Fusion* fusion = user_sched_->schedule.get();
   std::vector<TensorView*> tvs = ir_utils::allTvs(fusion);
-  static Communicator* comm = new Communicator();
   if (std::any_of(tvs.begin(), tvs.end(), [](Val* v) {
         return v->isA<TensorView>() && v->as<TensorView>()->hasDeviceMesh();
       })) {
     multidevice_executor_ = std::make_unique<MultiDeviceExecutor>(
-        std::make_unique<Fusion>(*fusion), *comm);
+        std::make_unique<Fusion>(*fusion), Communicator::getInstance());
   }
 
   FusionGuard::setCurFusion(prev_fusion_);

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -3267,4 +3267,9 @@ void initNvFuserPythonBindings(PyObject* module) {
       },
       py::arg("tensor"));
 }
+
+void cleanup() {
+  Communicator::getInstance().cleanup();
+}
+
 } // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/python_bindings.h
+++ b/csrc/python_frontend/python_bindings.h
@@ -7,10 +7,13 @@
 // clang-format on
 #pragma once
 
-#include <exceptions.h>
 #include <torch/csrc/jit/python/pybind.h>
 #include <torch/csrc/utils/pybind.h>
 
+#include <visibility.h>
+
 namespace nvfuser::python_frontend {
 NVF_API void initNvFuserPythonBindings(PyObject* module);
-}
+
+NVF_API void cleanup();
+} // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/python_bindings_extension.cpp
+++ b/csrc/python_frontend/python_bindings_extension.cpp
@@ -10,5 +10,9 @@
 
 PYBIND11_MODULE(EXTENSION_NAME, m) {
   m.doc() = "nvfuser C API python binding"; // optional module docstring
+
   nvfuser::python_frontend::initNvFuserPythonBindings(m.ptr());
+
+  auto cleanup = []() {};
+  m.add_object("_cleanup", py::capsule(cleanup));
 }

--- a/csrc/python_frontend/python_bindings_extension.cpp
+++ b/csrc/python_frontend/python_bindings_extension.cpp
@@ -13,6 +13,6 @@ PYBIND11_MODULE(EXTENSION_NAME, m) {
 
   nvfuser::python_frontend::initNvFuserPythonBindings(m.ptr());
 
-  auto cleanup = []() {};
+  auto cleanup = []() -> void { nvfuser::python_frontend::cleanup(); };
   m.add_object("_cleanup", py::capsule(cleanup));
 }

--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -27,12 +27,10 @@
 namespace nvfuser {
 
 void MultiDeviceTestEnvironment::SetUp() {
-  communicator_ = new Communicator();
+  communicator_ = &Communicator::getInstance();
 }
 
-void MultiDeviceTestEnvironment::TearDown() {
-  delete communicator_;
-}
+void MultiDeviceTestEnvironment::TearDown() {}
 
 /*static*/ Communicator* MultiDeviceTestEnvironment::communicator_ = nullptr;
 

--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -35,7 +35,7 @@ MultiDeviceTest::MultiDeviceTest() {
   // `TORCH_DISTRIBUTED_DEBUG`.
   c10d::setDebugLevelFromEnvironment();
 
-  communicator_ = MultiDeviceTestEnvironment::getCommunicator();
+  communicator_ = &Communicator::getInstance();
   tensor_options =
       at::TensorOptions().dtype(at::kFloat).device(communicator_->device());
   debug_print = getNvFuserEnv("MULTIDEVICE_DEBUG_PRINT") != nullptr;

--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -26,13 +26,9 @@
 
 namespace nvfuser {
 
-void MultiDeviceTestEnvironment::SetUp() {
-  communicator_ = &Communicator::getInstance();
+void MultiDeviceTestEnvironment::TearDown() {
+  Communicator::getInstance().cleanup();
 }
-
-void MultiDeviceTestEnvironment::TearDown() {}
-
-/*static*/ Communicator* MultiDeviceTestEnvironment::communicator_ = nullptr;
 
 MultiDeviceTest::MultiDeviceTest() {
   // Enable logging in c10d so debug messages can be printed out via

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -17,16 +17,11 @@ namespace nvfuser {
 
 class MultiDeviceTestEnvironment : public testing::Environment {
  public:
-  ~MultiDeviceTestEnvironment() override {}
-  void SetUp() override;
   void TearDown() override;
 
   static Communicator* getCommunicator() {
-    return communicator_;
+    return &Communicator::getInstance();
   }
-
- private:
-  static Communicator* communicator_;
 };
 
 class MultiDeviceTest : public NVFuserTest {

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -15,13 +15,10 @@
 
 namespace nvfuser {
 
+// Used to clean up the Communicator singleton.
 class MultiDeviceTestEnvironment : public testing::Environment {
  public:
   void TearDown() override;
-
-  static Communicator* getCommunicator() {
-    return &Communicator::getInstance();
-  }
 };
 
 class MultiDeviceTest : public NVFuserTest {

--- a/tests/python/mpi_test.py
+++ b/tests/python/mpi_test.py
@@ -34,7 +34,7 @@ class MultiDeviceModel(FusionDefinition):
         self.sched._set_device_mesh(self.t0, mesh)
         self.sched._set_device_mesh(self.t1, mesh)
         self.sched._set_device_mesh(self.t2, mesh)
-        self.sched._parallelize(self.t0, 0, nvfuser.ParallelType.mesh_x)
+        self.sched.parallelize(self.t0, 0, nvfuser.ParallelType.mesh_x)
 
 
 fn = MultiDeviceModel()


### PR DESCRIPTION
As a follow-up to https://github.com/NVIDIA/Fuser/pull/2575#discussion_r1676563522. 

As the comment says, it's not the best practice but acceptable -- the lifetime concern is localized to the cleanup method, which can be educated. 