### PR TITLE
Clear fusion cache to fix OOM

### DIFF
--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -159,6 +159,7 @@ void FusionDefinition::finalizeSchedule(
   }
 
   FusionGuard::setCurFusion(prev_fusion_);
+  user_sched_->runtime_info.reset();
   prev_fusion_ = nullptr;
   user_sched_ = nullptr;
 }

--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -190,9 +190,10 @@ def definition_op_in_schedule_error_test_fn(opinfo: OpInfo, sample: SampleInput)
 # TODO Maybe only test a single dtype
 @create_op_test(tuple(op for op in opinfos if op.sample_input_generator is not None))
 def test_definition_op_in_schedule_error(op: OpInfo, dtype: torch.dtype):
-    FusionCache.reset()
-    clear_cuda_cache()
     for sample in op.sample_input_generator(op, dtype):
+        # clear cache for each sample
+        FusionCache.reset()
+        clear_cuda_cache()
         with pytest.raises(
             RuntimeError, match=r"Attempting to add to a completed definition"
         ):

--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -15,7 +15,7 @@ from pytest_opinfos import opinfos
 from pytest_utils import ArgumentType, is_tensor, requiresJAX
 from typing import Callable
 
-from nvfuser import FusionDefinition
+from nvfuser import FusionCache, FusionDefinition
 
 
 def is_pre_volta():
@@ -190,6 +190,7 @@ def definition_op_in_schedule_error_test_fn(opinfo: OpInfo, sample: SampleInput)
 # TODO Maybe only test a single dtype
 @create_op_test(tuple(op for op in opinfos if op.sample_input_generator is not None))
 def test_definition_op_in_schedule_error(op: OpInfo, dtype: torch.dtype):
+    FusionCache.reset()
     clear_cuda_cache()
     for sample in op.sample_input_generator(op, dtype):
         with pytest.raises(


### PR DESCRIPTION
Fix #2617

`SchedulerRuntimeInfo` is created in `setupSchedule`. Normally, `finalizeSchedule` is called after scheduling, which destroys `runtime_info`.  When there is an exception, the program exits. During testing, we don't exit the program after an exception, so we accumulate `UserSchedule` objects. The fix is to clear the `FusionCache` after each test to destroy those objects.