### PR TITLE
Make nvfuser.__version__ less unknown when "git" cannot find the commit id 

### DIFF
--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -11,6 +11,7 @@ nvfuser_root = Path(__file__).parent.parent
 
 # note that this root currently is still part of pytorch.
 def get_sha() -> str:
+    import os
     # assume the $NVFUSER_VERSION is in sha form
     nvfuser_version = os.environ.get('NVFUSER_VERSION')
     try:

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -11,10 +11,6 @@ nvfuser_root = Path(__file__).parent.parent
 
 # note that this root currently is still part of pytorch.
 def get_sha() -> str:
-    import os
-
-    # assume the $NVFUSER_VERSION is in sha form
-    nvfuser_version = os.environ.get("NVFUSER_VERSION")
     try:
         return (
             subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=nvfuser_root)
@@ -22,7 +18,11 @@ def get_sha() -> str:
             .strip()
         )
     except Exception:
-        return nvfuser_version if nvfuser_version is not None else UNKNOWN
+        import os
+        # assume the $NVFUSER_VERSION is in sha form
+        if nvfuser_version := os.environ.get("NVFUSER_VERSION"):
+            return nvfuser_version
+        return UNKNOWN
 
 
 def get_version() -> str:

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -12,8 +12,9 @@ nvfuser_root = Path(__file__).parent.parent
 # note that this root currently is still part of pytorch.
 def get_sha() -> str:
     import os
+
     # assume the $NVFUSER_VERSION is in sha form
-    nvfuser_version = os.environ.get('NVFUSER_VERSION')
+    nvfuser_version = os.environ.get("NVFUSER_VERSION")
     try:
         return (
             subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=nvfuser_root)

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -24,7 +24,7 @@ def get_sha() -> str:
         if nvfuser_version := os.environ.get("NVFUSER_VERSION"):
             assert (
                 len(nvfuser_version) < 11
-            ), f"The NVFUSER_VERSION should be in sha form"
+            ), "The NVFUSER_VERSION should be in sha form"
             return nvfuser_version
         return UNKNOWN
 

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -19,6 +19,7 @@ def get_sha() -> str:
         )
     except Exception:
         import os
+
         # assume the $NVFUSER_VERSION is in sha form
         if nvfuser_version := os.environ.get("NVFUSER_VERSION"):
             return nvfuser_version

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -22,6 +22,7 @@ def get_sha() -> str:
 
         # assume the $NVFUSER_VERSION is in sha form
         if nvfuser_version := os.environ.get("NVFUSER_VERSION"):
+            assert len(nvfuser_version) < 11, f"The NVFUSER_VERSION should be in sha form"
             return nvfuser_version
         return UNKNOWN
 

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -23,7 +23,7 @@ def get_sha() -> str:
         # assume the $NVFUSER_VERSION is in sha form
         if nvfuser_version := os.environ.get("NVFUSER_VERSION"):
             assert (
-len(nvfuser_version) < 11
+                len(nvfuser_version) < 11
             ), f"The NVFUSER_VERSION should be in sha form"
             return nvfuser_version
         return UNKNOWN

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -22,7 +22,9 @@ def get_sha() -> str:
 
         # assume the $NVFUSER_VERSION is in sha form
         if nvfuser_version := os.environ.get("NVFUSER_VERSION"):
-            assert len(nvfuser_version) < 11, f"The NVFUSER_VERSION should be in sha form"
+            assert (
+len(nvfuser_version) < 11
+            ), f"The NVFUSER_VERSION should be in sha form"
             return nvfuser_version
         return UNKNOWN
 

--- a/tools/gen_nvfuser_version.py
+++ b/tools/gen_nvfuser_version.py
@@ -11,6 +11,8 @@ nvfuser_root = Path(__file__).parent.parent
 
 # note that this root currently is still part of pytorch.
 def get_sha() -> str:
+    # assume the $NVFUSER_VERSION is in sha form
+    nvfuser_version = os.environ.get('NVFUSER_VERSION')
     try:
         return (
             subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=nvfuser_root)
@@ -18,7 +20,7 @@ def get_sha() -> str:
             .strip()
         )
     except Exception:
-        return UNKNOWN
+        return nvfuser_version if nvfuser_version is not None else UNKNOWN
 
 
 def get_version() -> str:


### PR DESCRIPTION
Rely on the NVFUSER_VERSION environment variable to set the gitSHA, when "git" command fails to find the commit sha, e.g. in an environment where "git" is not found.