### PR TITLE
Promote hoisting of vectorize predicates

### DIFF
--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -383,8 +383,14 @@ IndexingParameters getPredicateInitialIndexParameters(
       } else {
         // Similar to the above, loop_id()->extent() is
         // used here instead of loop->stop(). See the above comment.
-        loop_to_ind_map[loop] = SimplifyingIrBuilder::subExpr(
-            loop_id->extent(), GpuLower::current()->kernel()->oneVal());
+        if (unswitch_pred) {
+          loop_to_ind_map[loop] = SimplifyingIrBuilder::subExpr(
+              loop_id->extent(), GpuLower::current()->kernel()->oneVal());
+        } else {
+          // For vectorize, zero should be fine as well and that would
+          // promote better index hoisting
+          loop_to_ind_map[loop] = GpuLower::current()->kernel()->zeroVal();
+        }
       }
 
       // When predicating a loop at the maximum end, predicate

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -5031,15 +5031,6 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
         auto cond_inputs = InputsOf::output(cond);
         auto index_it =
             std::find(cond_inputs.begin(), cond_inputs.end(), loop_index);
-        auto vec_factor_it =
-            std::find_if(cond_inputs.begin(), cond_inputs.end(), [](Val* inp) {
-              auto int_val = inp->value();
-              return int_val.hasValue() &&
-                  (int_val.as<int64_t>() == vec_factor - 1 ||
-                   int_val.as<int64_t>() == -(vec_factor - 1));
-            });
-        // If vectorized, the predicate should use (vec_factor - 1) or
-        // -(vec_factor - 1) rather than the loop index.
         if (vectorized_) {
           NVF_CHECK(
               index_it == cond_inputs.end(),
@@ -5047,23 +5038,11 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
               loop_index->toInlineString(),
               " in ",
               cond->toInlineString());
-          NVF_CHECK(
-              vec_factor_it != cond_inputs.end(),
-              "Expected to have ",
-              vec_factor - 1,
-              " in ",
-              cond->toInlineString());
         } else {
           NVF_CHECK(
               index_it != cond_inputs.end(),
               "Expected to have ",
               loop_index->toInlineString(),
-              " in ",
-              cond->toInlineString());
-          NVF_CHECK(
-              vec_factor_it == cond_inputs.end(),
-              "Not expected to have ",
-              vec_factor - 1,
               " in ",
               cond->toInlineString());
         }


### PR DESCRIPTION
Currently, we generate predicates for vectorization as:

```
// 4-way vectorization
if (idx(i + 3) < N) {
  local_tensor[0] = loadGlobalToLocal(gmem_tensor[idx(i)]);
}
```

where `idx(x)` returns an index of the tensor with the vectorized loop index as `x`. The predicate is to make sure that the access of the 4-way vectorized load is within the extent. 

This should be equivalent to:

```
// 4-way vectorization
if (idx(i) < N) {
  local_tensor[0] = loadGlobalToLocal(gmem_tensor[idx(i)]);
}
```

Notice the predicate is the same as the index for the load access. I belive that these two patterns should be equivalent since we assert that the vectorized domain is divisible by the vectorization factor.

The latter pattern is likely to promote more effective hoisting as the indices of the predicate and the tensor access are the same. Also, I think we can simplify the predicate logic for vectorization.

I tested the change with all the C++ tests and the python benchmarks using compute-sanitizer on H100. No invalid memory access happened, although sanitizer may not be perfect and also some of the matmul tests couldn't run due to out-of-memory errors (likely because sanitizer needs more memory).

Anyone has any concern?
