### PR TITLE
fix build error

### DIFF
--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -2482,7 +2482,7 @@ TEST_F(PredicateIndexingTest, ReductionRfactor) {
     Val* getPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
 
-      bool is_init = tv->nDims() > for_loops_.size();
+      bool is_init = tv->nDims() > (int64_t)for_loops_.size();
 
       switch (tv->name()) {
         case 1: {


### PR DESCRIPTION
Fixes a build error seen in CI runs:

```
/opt/pytorch/nvfuser/tests/cpp/test_indexing.cpp:2485:34: error: comparison of integer expressions of different signedness: ‘int64_t’ {aka ‘long int’} and ‘std::vector<nvfuser::ForLoop*>::size_type’ {aka ‘long unsigned int’} [-Werror=sign-compare]
#12 123.3  2485 |       bool is_init = tv->nDims() > for_loops_.size();
#12 123.3       |                      ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
#12 123.3 cc1plus: all warnings being treated as errors
```