### PR TITLE
Fix incorrect DataType in allocGlobalBufferForGridComm

### DIFF
--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -503,7 +503,7 @@ Val* getGridSyncBufferSize(
     const std::vector<ForLoop*>& for_loops,
     bool is_persistent) {
   // See the comment above for getGridCommWorkBufferSize.
-  Val* buffer_size = GpuLower::current()->kernel()->oneVal(DataType::Index);
+  Val* buffer_size = GpuLower::current()->kernel()->oneVal();
   for (auto pt : kParallelTypeBIDs) {
     auto pt_dim = GpuLower::current()->parallelDimensionMap().get(pt);
     if (pt_dim == nullptr || pt_dim->isOneInt()) {

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -503,7 +503,7 @@ Val* getGridSyncBufferSize(
     const std::vector<ForLoop*>& for_loops,
     bool is_persistent) {
   // See the comment above for getGridCommWorkBufferSize.
-  Val* buffer_size = GpuLower::current()->kernel()->oneVal();
+  Val* buffer_size = GpuLower::current()->kernel()->oneVal(DataType::Index);
   for (auto pt : kParallelTypeBIDs) {
     auto pt_dim = GpuLower::current()->parallelDimensionMap().get(pt);
     if (pt_dim == nullptr || pt_dim->isOneInt()) {

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -695,7 +695,8 @@ kir::Allocate* allocGlobalBufferForGridComm(
     bool resets_to_zero) {
   const std::vector<IterDomain*> new_buffer_ids = {
       IrBuilder::create<IterDomain>(IterDomainBuilder(
-          GpuLower::current()->kernel()->zeroVal(), buffer_size))};
+          GpuLower::current()->kernel()->zeroVal(DataType::Index),
+          SimplifyingIrBuilder::maybeCastExpr(DataType::Index, buffer_size)))};
   const auto buffer_domain = IrBuilder::create<TensorDomain>(new_buffer_ids);
   const auto buffer_tv =
       IrBuilder::create<TensorView>(buffer_domain, dtype, MemoryType::Global);

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -695,7 +695,7 @@ kir::Allocate* allocGlobalBufferForGridComm(
     bool resets_to_zero) {
   const std::vector<IterDomain*> new_buffer_ids = {
       IrBuilder::create<IterDomain>(IterDomainBuilder(
-          GpuLower::current()->kernel()->zeroVal(DataType::Index),
+          GpuLower::current()->kernel()->zeroVal(),
           SimplifyingIrBuilder::maybeCastExpr(DataType::Index, buffer_size)))};
   const auto buffer_domain = IrBuilder::create<TensorDomain>(new_buffer_ids);
   const auto buffer_tv =

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -661,6 +661,14 @@ class DynamicTransformConcretizer : public OptOutMutator {
   //! check that the concretized value is a valid input to all of its uses.
   void registerConcretization(Val* old_val, Val* new_val) {
     checkConcretizedUses(old_val, new_val);
+    NVF_ERROR(
+        old_val->dtype() == new_val->dtype(),
+        "registerConcretization should not be used to change dtype of Val ",
+        old_val->toString(),
+        ". Old dtype: ",
+        old_val->dtype(),
+        ". New dtype: ",
+        new_val->dtype());
     registerMutation(old_val, new_val);
   }
 

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -14,6 +14,7 @@
 
 #include <ir/all_nodes.h>
 #include <ir/container.h>
+#include <type_promotion.h>
 
 #include <complex>
 #include <cstdint>
@@ -528,7 +529,10 @@ Val* SimplifyingIrBuilder::bitwiseAndExpr(Val* lhs, Val* rhs) {
   bool lhs_all_ones = false;
   if (lhs_scalar && lhs_scalar->isConst()) {
     if (rhs_scalar && rhs_scalar->isConst()) {
-      return IrBuilder::create<Val>(lhs_scalar->value() & rhs_scalar->value());
+      DataType out_dtype =
+          computeTypes(TypePromotion::default_op_config, {lhs, rhs});
+      return IrBuilder::create<Val>(
+          lhs_scalar->value() & rhs_scalar->value(), out_dtype);
     }
     lhs_zero = lhs_scalar->value().as<int64_t>() == 0;
     lhs_all_ones = lhs_scalar->value().as<int64_t>() == -1;
@@ -569,7 +573,10 @@ Val* SimplifyingIrBuilder::bitwiseOrExpr(Val* lhs, Val* rhs) {
   bool lhs_all_ones = false;
   if (lhs_scalar && lhs_scalar->isConst()) {
     if (rhs_scalar && rhs_scalar->isConst()) {
-      return IrBuilder::create<Val>(lhs_scalar->value() | rhs_scalar->value());
+      DataType out_dtype =
+          computeTypes(TypePromotion::default_op_config, {lhs, rhs});
+      return IrBuilder::create<Val>(
+          lhs_scalar->value() | rhs_scalar->value(), out_dtype);
     }
     lhs_zero = lhs_scalar->value().as<int64_t>() == 0;
     lhs_all_ones = lhs_scalar->value().as<int64_t>() == -1;
@@ -608,7 +615,9 @@ Val* minOrMaxExpr(
   } else if (lhs == nullptr || lhs->sameAs(rhs)) {
     return rhs;
   } else if (lhs->isConst() && rhs->isConst()) {
-    return IrBuilder::create<Val>(func(lhs->value(), rhs->value()));
+    DataType out_dtype =
+        computeTypes(TypePromotion::default_op_config, {lhs, rhs});
+    return IrBuilder::create<Val>(func(lhs->value(), rhs->value()), out_dtype);
   } else {
     return ir_builder_func(lhs, rhs);
   }

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -1840,7 +1840,9 @@ TEST_F(NVFuserTest, FusionSimpleCpAsync_CUDA) {
   // requires ampere+ GPU
   if (!deviceMajorMinorCheck(8)) {
     ASSERT_THAT(
-        [&]() { fe.compileFusion(&fusion, {t0, t1}); },
+        [&]() {
+          fe.compileFusion(&fusion, {t0, t1});
+        },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
@@ -8350,6 +8352,42 @@ TEST_F(NVFuserTest, ReplayRFactorMergeBcast) {
     testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
   }
 }
+
+// This tests that we don't hit errors when we have multiple grid reductions
+// scheduled with different static-sized extents mapped to the same parallel
+// dimension.
+// See https://github.com/NVIDIA/Fuser/issues/2634
+TEST_F(NVFuserTest, MultipleDifferentSizeGridReduction) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeContigConcreteTensor({128});
+  TensorView* tv1 = makeContigConcreteTensor({192});
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+  TensorView* tv2 = max(tv0, {0});
+  TensorView* tv3 = sum(tv1, {0});
+  TensorView* tv4 = add(tv2, tv3);
+
+  fusion.addOutput(tv4);
+
+  tv1->axis(0)->parallelize(ParallelType::BIDx);
+  tv2->axis(0)->parallelize(ParallelType::BIDx);
+
+  inlineMost();
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  const at::Tensor t0 = at::randn({128}, options);
+  const at::Tensor t1 = at::randn({192}, options);
+  const std::vector<c10::IValue> inputs = {t0, t1};
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion, inputs);
+  auto cg_outputs = fe.runFusion(inputs);
+
+  testValidate(&fusion, cg_outputs, inputs, __LINE__, __FILE__);
+}
+
 // Test file size should be up to 10K LoC. Create a new file for more tests.
 
 } // namespace nvfuser

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -1840,7 +1840,7 @@ TEST_F(NVFuserTest, FusionSimpleCpAsync_CUDA) {
   // requires ampere+ GPU
   if (!deviceMajorMinorCheck(8)) {
     ASSERT_THAT(
-        [&]() {fe.compileFusion(&fusion, {t0, t1});},
+        [&]() { fe.compileFusion(&fusion, {t0, t1}); },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -1840,9 +1840,7 @@ TEST_F(NVFuserTest, FusionSimpleCpAsync_CUDA) {
   // requires ampere+ GPU
   if (!deviceMajorMinorCheck(8)) {
     ASSERT_THAT(
-        [&]() {
-          fe.compileFusion(&fusion, {t0, t1});
-        },
+        [&]() {fe.compileFusion(&fusion, {t0, t1});},
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -1758,7 +1758,9 @@ TEST_F(IndexingTest, ResizePath) {
           return addExpr(
               mulExpr(
                   loop_indices.at(0), tv->getLogicalDomain().at(1)->extent()),
-              addExpr(loop_indices.at(1), IrBuilder::create<Val>(15)));
+              addExpr(
+                  loop_indices.at(1),
+                  IrBuilder::create<Val>(15, DataType::Index)));
         }
         default:
           return nullptr;


### PR DESCRIPTION
In #2634, an `IterDomain` is created during lowering (in `allocGlobalBufferForGridComm`) using an extent that is derived from parallel extents. In this case the computation is done with `Int` scalars, and the constructor of `IterDomain` asserts that the extent should be `Index` instead. This PR casts the stop value to `Index` if necessary before creating the `IterDomain` in `allocGlobalBufferForGridComm`.

The reason we have an `Int` parallel dimension is that we compute `SimplifyExpr::maxExpr` with two constant `IterDomain` extents each of which is `DataType::Index` and should return `DataType::Index`. However, it currently returns `Int`. This is similar to the problem encountered in #2646. This PR fixes this by computing the proper output type for `maxExpr`, `minExpr`, `bitwiseAndExpr`, and `bitwiseOrExpr`.

Fixes #2634