### PR TITLE
TORCH_WARN => LOG(INFO)

### DIFF
--- a/csrc/multidevice/c10d_mock.h
+++ b/csrc/multidevice/c10d_mock.h
@@ -152,6 +152,10 @@ class Backend : public torch::CustomClassHolder {
   }
 };
 
+struct TCPStoreOptions {
+  static constexpr uint16_t kDefaultPort = 0;
+};
+
 class TCPStore : public torch::CustomClassHolder {};
 
 } // namespace c10d

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -108,13 +108,11 @@ bool parseEnv(
   }
 
   // retrieves master port
-  env = std::getenv("MASTER_PORT");
-  if (env) {
+  if ((env = std::getenv("MASTER_PORT")) != nullptr) {
     master_port = std::atoi(env);
   } else {
-    TORCH_WARN(
-        "the environment variable MASTER_PORT "
-        "has not been specified. Set to default");
+    LOG(INFO) << "The environment variable MASTER_PORT has not been specified. "
+              << "Set the master port to default: " << master_port;
   }
 
   return true;
@@ -176,7 +174,7 @@ Communicator::Communicator(
       size_(0),
       local_rank_(0),
       local_size_(0),
-      master_port_(0),
+      master_port_(c10d::TCPStoreOptions::kDefaultPort),
       ucc_available_(false),
       nccl_available_(false) {
   // retrieves rank and communicator size
@@ -199,9 +197,7 @@ Communicator::Communicator(
                            master_addr_ == gethostbyname(hostname)->h_name) &&
         local_rank_ == server_local_rank;
   }
-  constexpr int comm_master_port_default =
-      c10d::TCPStoreOptions::kDefaultPort; // 29500
-  store_opts.port = master_port_ ? master_port_ : comm_master_port_default;
+  store_opts.port = master_port_;
   store_ = c10::make_intrusive<c10d::TCPStore>(master_addr_, store_opts);
 #endif
 


### PR DESCRIPTION
(Small annoyances; happy to drop)

It's suboptimal to see a warning printed out every time people run the unit tests. LOG(INFO) seems more appropriate or we should make sure MASTER_PORT is set.