### PR TITLE
support inplace update with FusionInput as source

### DIFF
--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -818,6 +818,11 @@ void Fusion::aliasOutputToInput(
     output = castOp(input->getDataType().value(), output);
   }
 
+  if (output->isFusionInput()) {
+    // ensure that codegen produce a write operation on the buffer.
+    output = set(output);
+  }
+
   NVF_ERROR(
       isAliasCompatible(input, output),
       "The input and output values are not alias-compatible.");

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -21,6 +21,7 @@
 #include <ir/utils.h>
 #include <iter_visitor.h>
 #include <kernel.h>
+#include <ops/alias.h>
 #include <ops/arith.h>
 
 #include <iterator>

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -33,6 +33,10 @@ void markAliases(Fusion* fusion) {
 
   for (TensorView* out :
        ir_utils::filterByType<TensorView>(fusion->outputs())) {
+    if (fusion->getOutputAlias(out).type != AllocationType::New) {
+      continue;
+    }
+
     TensorView* aliased_io = analysis.getNearestAliasedIo(out);
     if (aliased_io == nullptr) {
       continue;

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -36,8 +36,10 @@ bool allOutputsArePointerArithmetics(Fusion* fusion) {
       findAliases(fusion, /*can_override_empty_allocation_domain=*/false);
   auto out_tvs = ir_utils::filterByType<TensorView>(fusion->outputs());
   return std::all_of(
-      out_tvs.begin(), out_tvs.end(), [&analysis](TensorView* out) {
-        return analysis.getNearestAliasedIo(out) != nullptr;
+      out_tvs.begin(), out_tvs.end(), [&analysis, &fusion](TensorView* out) {
+        // Check out has an alias and out is not an inplace update target.
+        return analysis.getNearestAliasedIo(out) != nullptr &&
+            fusion->getOutputAlias(out).type != AllocationType::ReuseBuffer;
       });
 }
 } // namespace

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -36,7 +36,7 @@ bool allOutputsArePointerArithmetics(Fusion* fusion) {
       findAliases(fusion, /*can_override_empty_allocation_domain=*/false);
   auto out_tvs = ir_utils::filterByType<TensorView>(fusion->outputs());
   return std::all_of(
-      out_tvs.begin(), out_tvs.end(), [&analysis, &fusion](TensorView* out) {
+      out_tvs.begin(), out_tvs.end(), [&analysis, fusion](TensorView* out) {
         // Check out has an alias and out is not an inplace update target.
         return analysis.getNearestAliasedIo(out) != nullptr &&
             fusion->getOutputAlias(out).type != AllocationType::ReuseBuffer;

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -1407,9 +1407,9 @@ TEST_F(AliasTest, InplaceUpdate) {
 
   FusionExecutorCache fec(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  at::Tensor out_tensor = at::randn({2, 3}).cuda();
+  at::Tensor out_tensor = in_tensor + 1;
   fec.runFusionWithInputs({in_tensor, out_tensor});
-  EXPECT_TRUE(out_tensor.allclose(in_tensor));
+  EXPECT_TRUE(out_tensor.equal(in_tensor));
 
   FusionKernelRuntime* runtime = fec.getMostRecentKernelRuntime();
   EXPECT_THAT(

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -1395,4 +1395,26 @@ TEST_F(AliasTest, SegmentMetaOps) {
   }
 }
 
+TEST_F(AliasTest, InplaceUpdate) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({2, 3});
+  TensorView* out = makeContigConcreteTensor({2, 3});
+  fusion->addInput(in);
+  fusion->addInput(out);
+  fusion->aliasOutputToInput(out, in, AllocationType::ReuseBuffer);
+
+  FusionExecutorCache fec(std::move(fusion));
+  at::Tensor in_tensor = at::randn({2, 3}).cuda();
+  at::Tensor out_tensor = at::randn({2, 3}).cuda();
+  fec.runFusionWithInputs({in_tensor, out_tensor});
+  EXPECT_TRUE(out_tensor.allclose(in_tensor));
+
+  FusionKernelRuntime* runtime = fec.getMostRecentKernelRuntime();
+  EXPECT_THAT(
+      runtime->fusionSegments()->groups(),
+      UnorderedElementsAre(HeuristicIs(ScheduleHeuristic::PointWise)));
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Previously when we have

```
  TensorView* in = makeContigConcreteTensor({2, 3});
  TensorView* out = makeContigConcreteTensor({2, 3});
  fusion->addInput(in);
  fusion->addInput(out);
  fusion->aliasOutputToInput(out, in, AllocationType::ReuseBuffer);
```

The inplace update instruction `fusion->aliasOutputToInput(out, in, AllocationType::ReuseBuffer);` would mistakenly be put into a no-op kernel (or mistakenly ignored by pointwise).

We need to generate a real kernel to perform the inplace update. This PR fixes that, as well as creating a cpp test to validate the behavior.