### PR TITLE
MarkAliasesPrepare attempts to put segment_set after intermediate tensors.

### DIFF
--- a/benchmarks/cpp/timm.cpp
+++ b/benchmarks/cpp/timm.cpp
@@ -46,13 +46,11 @@ static void setup_vit_base_patch16_224_bcast7(Fusion* fusion, void* null) {
   auto t11 = mul(t10, t4);
   auto t25 = mul(t9, t11);
   auto t26 = sum(t25, {0, 1});
-  auto t36 = set(t26);
   auto t27 = sum(t9, {0, 1});
-  auto t37 = set(t27);
   auto t39 = castOp(DataType::Half, t11);
 
-  fusion->addOutput(t36);
-  fusion->addOutput(t37);
+  fusion->addOutput(t26);
+  fusion->addOutput(t27);
   fusion->addOutput(t39);
 }
 

--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <alias_analysis.h>
-#include <compute_at_map.h>
 #include <dispatch.h>
 #include <fusion.h>
 #include <ir/interface_nodes.h>
@@ -18,8 +17,6 @@
 #include <ir/utils.h>
 #include <linked_hash_map.h>
 #include <logical_domain_map.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/registry_utils.h>
 
 namespace nvfuser {
 
@@ -428,69 +425,18 @@ bool okToRelayout(
                                             : tv->getMaybeAllocationDomain());
   return new_layout.isCompliantWith({allocation, tv->getContiguity()});
 }
-
-// Returns true if the output tv's definition op may cause segmentation.
-// Only considered view op interfering with reduction.
-// TODO: other ops?
-bool outputInterferingReduction(Fusion* fusion) {
-  // output must be defined as view op
-  const auto& output_tvs =
-      ir_utils::filterByType<TensorView>(fusion->outputs());
-  if (std::none_of(
-          output_tvs.begin(), output_tvs.end(), [](TensorView* out_tv) {
-            return out_tv->definition()->isA<ViewOp>();
-          })) {
-    return false;
-  }
-
-  // fusion must have reduction tvs
-  const auto& reduction_tvs = scheduler_utils::getReductionTvs(fusion);
-  if (reduction_tvs.empty()) {
-    return false;
-  }
-
-  ComputeAtMap ca_map(fusion);
-  if (registry_utils::requiresForwardViewReplay(fusion, ca_map)) {
-    return true;
-  }
-
-  // check if view op interferes with reduction
-  auto ref_redu_tv =
-      reduction_scheduler_utils::getRepresentativeReductionTv(reduction_tvs);
-  if (registry_utils::reductionInterferingView(fusion, ca_map, ref_redu_tv)) {
-    return true;
-  }
-
-  return false;
-}
-
-// Stop at view op
-// TODO: other ops?
-bool isOpsToStop(const Expr* expr, bool stop_at_view) {
-  return stop_at_view && expr->isA<ViewOp>();
-}
-
 } // namespace
 
 void AliasAnalysisResult::finalize(
-    Fusion* fusion,
-    const bool can_override_empty_allocation_domain,
-    const bool may_alias_intermediate) {
-  // If allow output to alias intermediate, then we don't need to walk up
-  // the chain to find an input or output root. It changes the last reshape
-  // in group norm to a no-op.
-  bool stop_at_view =
-      may_alias_intermediate && outputInterferingReduction(fusion);
+    const bool can_override_empty_allocation_domain) {
   for (auto [alias, source_and_layout] : alias_to_source_) {
     auto [root, preferred_layout] = source_and_layout;
-    if (!isOpsToStop(alias->definition(), stop_at_view)) {
-      while (root != nullptr && !root->isFusionInput() &&
-             !root->isFusionOutput()) {
-        const auto i = alias_to_source_.find(root);
-        root = (i == alias_to_source_.end() ? nullptr : i->second.first);
-      }
+    // Walks up the `alias_to_source_` chain.
+    while (root != nullptr && !root->isFusionInput() &&
+           !root->isFusionOutput()) {
+      const auto i = alias_to_source_.find(root);
+      root = (i == alias_to_source_.end() ? nullptr : i->second.first);
     }
-
     if (root == nullptr) {
       continue;
     }
@@ -541,8 +487,7 @@ std::string AliasAnalysisResult::toString(const int indent_size) const {
 
 AliasAnalysisResult findAliases(
     Fusion* fusion,
-    const bool can_override_empty_allocation_domain,
-    const bool may_alias_intermediate) {
+    const bool can_override_empty_allocation_domain) {
   AliasAnalysisResult analysis;
   AliasFinder finder(analysis);
   // Fusion::exprs() computes and returns topological order.
@@ -554,9 +499,7 @@ AliasAnalysisResult findAliases(
     // results).
     finder.dispatch(expr);
   }
-
-  analysis.finalize(
-      fusion, can_override_empty_allocation_domain, may_alias_intermediate);
+  analysis.finalize(can_override_empty_allocation_domain);
   return analysis;
 }
 

--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -415,14 +415,6 @@ TensorView* AliasAnalysisResult::getNearestAliasedIo(
   return getOrDefault(alias_to_root_, alias);
 }
 
-TensorView* AliasAnalysisResult::source(const TensorView* alias) const {
-  if (const auto i = alias_to_source_.find(alias);
-      i != alias_to_source_.end()) {
-    return i->second.first;
-  }
-  return nullptr;
-}
-
 namespace {
 bool okToRelayout(
     const TensorView* tv,

--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -410,8 +410,7 @@ void AliasAnalysisResult::add(
       i->second.first);
 }
 
-TensorView* AliasAnalysisResult::getNearestAliasedIo(
-    const TensorView* alias) const {
+TensorView* AliasAnalysisResult::getRoot(const TensorView* alias) const {
   return getOrDefault(alias_to_root_, alias);
 }
 

--- a/csrc/alias_analysis.h
+++ b/csrc/alias_analysis.h
@@ -70,6 +70,8 @@ class AliasAnalysisResult {
   // Returns the mapped value in `alias_to_root_` or null.
   TensorView* getNearestAliasedIo(const TensorView* alias) const;
 
+  TensorView* source(const TensorView* alias) const;
+
  private:
   // Maps an alias (e.g. the output of a `ViewOp`) to its direct source (e.g.
   // the input of the same `ViewOp`). Also stores the preferred output layout

--- a/csrc/alias_analysis.h
+++ b/csrc/alias_analysis.h
@@ -59,10 +59,7 @@ class AliasAnalysisResult {
   // Computes transitive aliases and caches them in `alias_to_root_`.
   // See `findAliases` for the meaning of
   // `can_override_empty_allocation_domain`.
-  void finalize(
-      Fusion* fusion,
-      bool can_override_empty_allocation_domain,
-      bool can_alias_intermediate);
+  void finalize(bool can_override_empty_allocation_domain);
 
   // Returns the preferred layout. If `alias` is not in `alias_to_source_`,
   // returns the `TensorView`'s initial layout.
@@ -116,7 +113,6 @@ class AliasAnalysisResult {
 // Fusion::aliasOutputToInput to mark aliases.
 AliasAnalysisResult findAliases(
     Fusion* fusion,
-    bool can_override_empty_allocation_domain = true,
-    bool may_alias_intermediate = false);
+    bool can_override_empty_allocation_domain = true);
 
 } // namespace nvfuser

--- a/csrc/alias_analysis.h
+++ b/csrc/alias_analysis.h
@@ -70,8 +70,6 @@ class AliasAnalysisResult {
   // Returns the mapped value in `alias_to_root_` or null.
   TensorView* getNearestAliasedIo(const TensorView* alias) const;
 
-  TensorView* source(const TensorView* alias) const;
-
  private:
   // Maps an alias (e.g. the output of a `ViewOp`) to its direct source (e.g.
   // the input of the same `ViewOp`). Also stores the preferred output layout

--- a/csrc/alias_analysis.h
+++ b/csrc/alias_analysis.h
@@ -68,7 +68,7 @@ class AliasAnalysisResult {
   std::string toString(int indent_size) const;
 
   // Returns the mapped value in `alias_to_root_` or null.
-  TensorView* getNearestAliasedIo(const TensorView* alias) const;
+  TensorView* getRoot(const TensorView* alias) const;
 
  private:
   // Maps an alias (e.g. the output of a `ViewOp`) to its direct source (e.g.

--- a/csrc/alias_analysis.h
+++ b/csrc/alias_analysis.h
@@ -79,10 +79,8 @@ class AliasAnalysisResult {
   std::unordered_map<const TensorView*, std::pair<TensorView*, Layout>>
       alias_to_source_;
 
-  // Maps an alias to its nearest, transitively aliased fusion input/output, if
-  // its preferred layout is compliant with its actual layout.
-  //
-  // TODO(wujingyue): consider to merge `alias_to_source_` and `alias_to_root_`.
+  // Maps an alias to its "highest ancestor" according to `alias_to_source_`,
+  // if its preferred layout is compliant with its actual layout.
   std::unordered_map<const TensorView*, TensorView*> alias_to_root_;
 };
 

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -593,6 +593,15 @@ bool isPointwiseTvOp(const Expr* expr) {
        (expr->isA<LoadStoreOp>() && !ir_utils::getTvOutput(expr)->hasRoot()));
 }
 
+bool isSegmentSet(const Expr* e) {
+  if (const auto* ldst = dynamic_cast<const LoadStoreOp*>(e)) {
+    if (ldst->opType() == LoadStoreOpType::SegmenterSet) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::vector<ViewOp*> getViewOps(Fusion* fusion) {
   auto all_exprs = fusion->exprs();
 

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -408,6 +408,8 @@ NVF_API bool isReductionTvOp(const Expr*);
 // Returns if Expr is a pointwise op op with TensorView or TensorIndex
 bool isPointwiseTvOp(const Expr* expr);
 
+bool isSegmentSet(const Expr* e);
+
 // Returns all non-trivial view operations. We shouldn't have trivial view
 // operations but this function is to simply make sure if we ever do we don't
 // pull them in.

--- a/csrc/preseg_passes/mark_aliases_prepare.cpp
+++ b/csrc/preseg_passes/mark_aliases_prepare.cpp
@@ -15,10 +15,8 @@
 namespace nvfuser::preseg_passes {
 
 void MarkAliasesPreparePass::runPass(Fusion* fusion) {
-  const AliasAnalysisResult analysis = findAliases(
-      fusion,
-      /*can_override_empty_allocation_domain=*/true,
-      /*may_alias_intermediate=*/true);
+  const AliasAnalysisResult analysis =
+      findAliases(fusion, /*can_override_empty_allocation_domain=*/true);
   if (isDebugDumpEnabled(DebugDumpOption::PreSegmenterLogging)) {
     debug() << "Alias analysis result:" << std::endl;
     debug() << analysis.toString(/*indent_size=*/1) << std::endl;

--- a/csrc/preseg_passes/mark_aliases_prepare.cpp
+++ b/csrc/preseg_passes/mark_aliases_prepare.cpp
@@ -48,15 +48,6 @@ Use findUseToSegment(
   }
 }
 
-bool isSegmentSet(Expr* e) {
-  if (LoadStoreOp* ldst = dynamic_cast<LoadStoreOp*>(e)) {
-    if (ldst->opType() == LoadStoreOpType::SegmenterSet) {
-      return true;
-    }
-  }
-  return false;
-}
-
 // Collects all expressions that are (transitively) used by non-alias
 // TensorViews.
 std::unordered_set<Expr*> exprsUsedByNonAliases(
@@ -175,15 +166,16 @@ void MarkAliasesPreparePass::runPass(Fusion* fusion) {
 
         // Rarely, if `use_of` is already defined by `segment_set`, don't
         // create another `segment_set`.
-        if (isSegmentSet(use_of->definition())) {
+        if (ir_utils::isSegmentSet(use_of->definition())) {
           return;
         }
       }
 
       // If all aliasing users are `segment_set`, don't create another
       // `segment_set`.
-      if (std::all_of(
-              i, j, [](const Use& use) { return isSegmentSet(use.user); })) {
+      if (std::all_of(i, j, [](const Use& use) {
+            return ir_utils::isSegmentSet(use.user);
+          })) {
         return;
       }
 

--- a/csrc/preseg_passes/mark_aliases_prepare.cpp
+++ b/csrc/preseg_passes/mark_aliases_prepare.cpp
@@ -24,8 +24,7 @@ std::pair<TensorView*, Expr*> findUseToSegment(
   Expr* user = nullptr;
   while (true) {
     Expr* def = out->definition();
-    if (analysis.getNearestAliasedIo(out) == nullptr ||
-        used_by_non_aliases.count(def)) {
+    if (analysis.getRoot(out) == nullptr || used_by_non_aliases.count(def)) {
       return {out, user};
     }
     out = def->input(0)->as<TensorView>();
@@ -54,7 +53,7 @@ void MarkAliasesPreparePass::runPass(Fusion* fusion) {
 
   // Materialize the alias-enabling allocation domain.
   for (TensorView* tv : ir_utils::allTvs(fusion)) {
-    if (analysis.getNearestAliasedIo(tv) == nullptr) {
+    if (analysis.getRoot(tv) == nullptr) {
       continue;
     }
 
@@ -83,7 +82,7 @@ void MarkAliasesPreparePass::runPass(Fusion* fusion) {
   auto used_by_non_aliases = [&]() -> std::unordered_set<Expr*> {
     std::vector<Val*> non_aliases;
     for (TensorView* tv : ir_utils::allTvs(fusion)) {
-      if (analysis.getNearestAliasedIo(tv) == nullptr) {
+      if (analysis.getRoot(tv) == nullptr) {
         non_aliases.push_back(tv);
       }
     }

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -25,10 +25,8 @@ void markAliases(Fusion* fusion) {
     fusion->printMath();
   }
 
-  const AliasAnalysisResult analysis = findAliases(
-      fusion,
-      /*can_override_empty_allocation_domain=*/false,
-      /*may_alias_intermediate=*/false);
+  const AliasAnalysisResult analysis =
+      findAliases(fusion, /*can_override_empty_allocation_domain=*/false);
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerVerbose)) {
     vlog("Alias analysis result:\n", analysis.toString(/*indent_size=*/1));
   }

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -31,8 +31,7 @@ void markAliases(Fusion* fusion) {
     vlog("Alias analysis result:\n", analysis.toString(/*indent_size=*/1));
   }
 
-  for (TensorView* out :
-       ir_utils::filterByType<TensorView>(fusion->outputs())) {
+  for (auto* out : ir_utils::filterByType<TensorView>(fusion->outputs())) {
     // AllocationType::ReuseBuffer requires the output to be updated in place
     // so it can't be computed as an alias.
     if (fusion->getOutputAlias(out).type == AllocationType::ReuseBuffer) {

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -39,7 +39,7 @@ void markAliases(Fusion* fusion) {
       continue;
     }
 
-    if (TensorView* aliased_io = analysis.getNearestAliasedIo(out)) {
+    if (TensorView* aliased_io = analysis.getRoot(out)) {
       if (aliased_io->isFusionInput() || aliased_io->isFusionOutput()) {
         fusion->aliasOutputToInput(out, aliased_io, AllocationType::Evaluate);
         vlog(

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -32,10 +32,8 @@ NoOpScheduler::NoOpScheduler(
 
 namespace {
 bool allOutputsArePointerArithmetics(Fusion* fusion) {
-  const AliasAnalysisResult analysis = findAliases(
-      fusion,
-      /*can_override_empty_allocation_domain=*/false,
-      /*may_alias_intermediate=*/false);
+  const AliasAnalysisResult analysis =
+      findAliases(fusion, /*can_override_empty_allocation_domain=*/false);
   auto out_tvs = ir_utils::filterByType<TensorView>(fusion->outputs());
   return std::all_of(
       out_tvs.begin(), out_tvs.end(), [&analysis, fusion](TensorView* out) {

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -41,7 +41,7 @@ bool allOutputsArePointerArithmetics(Fusion* fusion) {
       return false;
     }
 
-    TensorView* root = analysis.getNearestAliasedIo(out);
+    TensorView* root = analysis.getRoot(out);
     return root != nullptr && root->isFusionInput();
   });
 }

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -35,12 +35,15 @@ bool allOutputsArePointerArithmetics(Fusion* fusion) {
   const AliasAnalysisResult analysis =
       findAliases(fusion, /*can_override_empty_allocation_domain=*/false);
   auto out_tvs = ir_utils::filterByType<TensorView>(fusion->outputs());
-  return std::all_of(
-      out_tvs.begin(), out_tvs.end(), [&analysis, fusion](TensorView* out) {
-        // Check out has an alias and out is not an inplace update target.
-        return analysis.getNearestAliasedIo(out) != nullptr &&
-            fusion->getOutputAlias(out).type != AllocationType::ReuseBuffer;
-      });
+  return std::all_of(out_tvs.begin(), out_tvs.end(), [&](TensorView* out) {
+    // Check out has an alias and out is not an inplace update target.
+    if (fusion->getOutputAlias(out).type == AllocationType::ReuseBuffer) {
+      return false;
+    }
+
+    TensorView* root = analysis.getNearestAliasedIo(out);
+    return root != nullptr && root->isFusionInput();
+  });
 }
 } // namespace
 
@@ -131,4 +134,5 @@ void NoOpScheduler::computeHeuristics(
   // Heuristics is no-op.
   return;
 }
+
 } // namespace nvfuser

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -937,20 +937,5 @@ std::ostream& operator<<(std::ostream& os, ReductionType reduction_type) {
   return os;
 }
 
-TensorView* getRepresentativeReductionTv(
-    const std::vector<TensorView*>& reduction_tvs) {
-  TensorView* inner_ref = nullptr;
-  TensorView* outer_ref = nullptr;
-  for (auto tv : reduction_tvs) {
-    if (scheduler_utils::isFastestDimReduction(tv)) {
-      inner_ref = inner_ref == nullptr ? tv : inner_ref;
-    } else {
-      outer_ref = outer_ref == nullptr ? tv : outer_ref;
-    }
-  }
-  // use inner_ref for inner reduction and innerOuter reduction
-  // use outer_ref for outer reduction
-  return inner_ref != nullptr ? inner_ref : outer_ref;
-}
 } // namespace reduction_scheduler_utils
 } // namespace nvfuser

--- a/csrc/scheduler/reduction_utils.h
+++ b/csrc/scheduler/reduction_utils.h
@@ -105,13 +105,5 @@ std::string toString(ReductionType reduction_type);
 ReductionType getReductionType(Fusion* fusion);
 ReductionType getReductionType(const std::vector<TensorView*>& reduction_tvs);
 
-//! Get the representative reduction tv from the given reduction tvs.
-//! If there are no reduction tvs, return nullptr.
-//! If there are only inner reduction tvs, return the first inner reduction tv.
-//! If there are only outer reduction tvs, return the first outer reduction tv.
-//! If there are both inner and outer reduction tvs, return the first inner
-//! reduction tv.
-TensorView* getRepresentativeReductionTv(
-    const std::vector<TensorView*>& reduction_tvs);
 } // namespace reduction_scheduler_utils
 } // namespace nvfuser

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -285,12 +285,6 @@ TEST_F(AliasAnalysisTest, BroadcastExpandDimensions) {
 
 using AliasTest = NVFuserTest;
 
-namespace {
-MATCHER_P(HeuristicIs, heuristic, "") {
-  return arg->heuristic() == heuristic;
-}
-} // namespace
-
 TEST_F(AliasTest, View) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -1555,6 +1555,7 @@ TEST_F(AliasTest, Bookend_ReuseSegmentSet) {
 
   TensorView* in = makeContigConcreteTensor({2, 3, 5});
   TensorView* t = add(in, in);
+  // Expect the three reshapes to be placed in the same no-op segment.
   t = reshape(t, {2, 3, 5}, {30});
   TensorView* out0 = reshape(t, {30}, {6, 5});
   TensorView* out1 = reshape(t, {30}, {2, 15});

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -51,7 +51,7 @@ TEST_F(AliasAnalysisTest, View_SymbolicTensor) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), in);
+  EXPECT_EQ(alias_analysis.getRoot(out), in);
 }
 
 TEST_F(AliasAnalysisTest, ChainOfViews) {
@@ -69,7 +69,7 @@ TEST_F(AliasAnalysisTest, ChainOfViews) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), in);
+  EXPECT_EQ(alias_analysis.getRoot(out), in);
 }
 
 TEST_F(AliasAnalysisTest, View_Contiguous) {
@@ -85,7 +85,7 @@ TEST_F(AliasAnalysisTest, View_Contiguous) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), in);
+  EXPECT_EQ(alias_analysis.getRoot(out), in);
   Layout preferred_layout = alias_analysis.preferredLayout(out);
   EXPECT_THAT(
       preferred_layout.allocation_domain,
@@ -110,7 +110,7 @@ TEST_F(AliasAnalysisTest, View_MergeNonContiguous) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), nullptr);
+  EXPECT_EQ(alias_analysis.getRoot(out), nullptr);
 }
 
 TEST_F(AliasAnalysisTest, Set) {
@@ -125,7 +125,7 @@ TEST_F(AliasAnalysisTest, Set) {
   in->setAllocationDomain({in->axis(1), in->axis(2), in->axis(0)}, true);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), in);
+  EXPECT_EQ(alias_analysis.getRoot(out), in);
 
   const std::vector<IterDomain*>& out_logical = out->getLogicalDomain();
   EXPECT_THAT(
@@ -145,7 +145,7 @@ TEST_F(AliasAnalysisTest, Permute) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), in);
+  EXPECT_EQ(alias_analysis.getRoot(out), in);
 
   const std::vector<IterDomain*>& out_logical = out->getLogicalDomain();
   EXPECT_THAT(
@@ -173,7 +173,7 @@ TEST_F(AliasAnalysisTest, View_SplitExpandedBroadcast) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), nullptr);
+  EXPECT_EQ(alias_analysis.getRoot(out), nullptr);
 }
 
 TEST_F(AliasAnalysisTest, View_ForwardExpandedBroadcast) {
@@ -192,7 +192,7 @@ TEST_F(AliasAnalysisTest, View_ForwardExpandedBroadcast) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), in);
+  EXPECT_EQ(alias_analysis.getRoot(out), in);
 
   // Verify the last dimension isn't expanded physically.
   FusionExecutor fe;
@@ -220,7 +220,7 @@ TEST_F(AliasAnalysisTest, View_MergeExpandedBroadcast) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), nullptr);
+  EXPECT_EQ(alias_analysis.getRoot(out), nullptr);
 }
 
 TEST_F(AliasAnalysisTest, TrivialSlice) {
@@ -234,7 +234,7 @@ TEST_F(AliasAnalysisTest, TrivialSlice) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), in);
+  EXPECT_EQ(alias_analysis.getRoot(out), in);
 }
 
 TEST_F(AliasAnalysisTest, MergeTriviallySlicedDimensions) {
@@ -248,7 +248,7 @@ TEST_F(AliasAnalysisTest, MergeTriviallySlicedDimensions) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), in);
+  EXPECT_EQ(alias_analysis.getRoot(out), in);
 }
 
 TEST_F(AliasAnalysisTest, MergeSlicedDimensions) {
@@ -262,7 +262,7 @@ TEST_F(AliasAnalysisTest, MergeSlicedDimensions) {
   fusion.addOutput(out);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), nullptr);
+  EXPECT_EQ(alias_analysis.getRoot(out), nullptr);
 }
 
 TEST_F(AliasAnalysisTest, BroadcastExpandDimensions) {
@@ -280,7 +280,7 @@ TEST_F(AliasAnalysisTest, BroadcastExpandDimensions) {
   fusion.addOutput(expanded_tv);
 
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(expanded_tv), in);
+  EXPECT_EQ(alias_analysis.getRoot(expanded_tv), in);
 }
 
 using AliasTest = NVFuserTest;
@@ -1408,7 +1408,7 @@ TEST_F(AliasTest, FusionExecutor) {
 
   // Sanity-check that `out` is a valid alias of `in`.
   AliasAnalysisResult alias_analysis = findAliases(&fusion);
-  EXPECT_EQ(alias_analysis.getNearestAliasedIo(out), in);
+  EXPECT_EQ(alias_analysis.getRoot(out), in);
 
   // Mark them alias so FusionExecutor::runFusion expression-evaluates the
   // output on the host instead of launching a CUDA kernel.

--- a/tests/cpp/test_gpu_view.cpp
+++ b/tests/cpp/test_gpu_view.cpp
@@ -48,10 +48,9 @@
 #include <iostream>
 
 namespace nvfuser {
-using testing::Contains;
-using testing::UnorderedElementsAre;
 
 using namespace at::indexing;
+
 using GpuViewTest = NVFuserTest;
 
 TEST_F(GpuViewTest, FusionViewDtypeSameSizeOutput) {
@@ -2379,102 +2378,6 @@ TEST_F(GpuViewTest, SplitMergePointwiseSplitMerge) {
   auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   testValidate(executor_cache.fusion(), {cg_outputs}, {t0}, __LINE__, __FILE__);
-}
-
-// segmented into 2 kernels: pointwise and reduction
-TEST_F(GpuViewTest, GroupNormOriginal) {
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-  const int64_t N = 2, C = 128, H = 16, W = 16, G = 32;
-  const std::vector<int64_t> input_shape = {N, C, H, W};
-  const std::vector<int64_t> group_shape = {N, G, C / G, H, W};
-  const std::vector<int64_t> input_shape_wb = {C};
-  const std::vector<int64_t> group_shape_wb = {G, C / G};
-  DataType dtype = DataType::Half;
-  auto tv0 = makeContigTensor(input_shape.size(), dtype);
-  auto tv1 = makeContigTensor(input_shape_wb.size(), DataType::Float);
-  auto tv2 = makeContigTensor(input_shape_wb.size(), DataType::Float);
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  fusion->addInput(tv2);
-  // pointwise ops, e.g. cast
-  auto tv3 = castOp(DataType::Float, tv0);
-  // reshape from {N, C, H, W} to {N, G, C / G, H, W}
-  auto tv4 = reshape(tv3, input_shape, group_shape);
-  // normalization
-  auto tv5 = sum(tv4, {-1, -2, -3});
-  auto tv6 = broadcast(tv5, {false, false, true, true, true});
-  auto tv7 = div(tv4, tv6);
-  // reshape back to {N, C, H, W}
-  auto tv8 = reshape(tv7, group_shape, input_shape);
-  // pointwise ops, e.g. scale, bias, cast
-  auto tv9 = broadcast(tv1, {true, false, true, true});
-  auto tv10 = broadcast(tv2, {true, false, true, true});
-  auto tv11 = mul(tv8, tv9);
-  auto tv12 = add(tv11, tv10);
-  auto tv13 = castOp(dtype, tv12);
-  fusion->addOutput(tv13);
-
-  auto options =
-      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
-  auto options_wb = at::TensorOptions()
-                        .dtype(data_type_to_aten(DataType::Float))
-                        .device(at::kCUDA, 0);
-  auto t0 = at::randn(input_shape, options);
-  auto tw = at::randn(input_shape_wb, options_wb);
-  auto tb = at::randn(input_shape_wb, options_wb);
-
-  FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs({t0, tw, tb});
-  // should expect 1 after adding a pre-segment pass to move reshape to input
-  // and output.
-  EXPECT_THAT(
-      executor_cache.getMostRecentKernelRuntime()->fusionSegments()->groups(),
-      UnorderedElementsAre(
-          HeuristicIs(ScheduleHeuristic::PointWise),
-          HeuristicIs(ScheduleHeuristic::Reduction)));
-
-  testValidate(
-      executor_cache.fusion(), cg_outputs, {t0, tw, tb}, __LINE__, __FILE__);
-}
-
-TEST_F(GpuViewTest, OutputAliasIntermediate) {
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-  const int64_t N = 2, C = 128, H = 16, W = 16, G = 32;
-  const std::vector<int64_t> input_shape = {N, G, C / G, H, W};
-  const std::vector<int64_t> output_shape = {N, C, H, W};
-  DataType dtype = DataType::Half;
-  auto tv0 = makeContigTensor(input_shape.size(), dtype);
-  fusion->addInput(tv0);
-  auto tv1 = castOp(DataType::Float, tv0);
-  auto tv2 = set(tv1);
-  auto tv3 = sum(tv2, {-1, -2, -3});
-  auto tv4 = broadcast(tv3, {false, false, true, true, true});
-  auto tv5 = div(tv2, tv4);
-  auto tv6 = castOp(dtype, tv5);
-  auto tv7 = reshape(tv6, input_shape, output_shape);
-  fusion->addOutput(tv7);
-
-  auto options =
-      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
-  auto t0 = at::randn(input_shape, options);
-  auto t1 = t0.to(at::kFloat);
-  auto t2 = t1.sum({-1, -2, -3}).unsqueeze(-1).unsqueeze(-1).unsqueeze(-1);
-  auto t3 = t1 / t2;
-  auto t4 = t3.reshape(output_shape);
-
-  FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
-  const std::vector<SegmentedGroup*>& seg_groups =
-      executor_cache.getMostRecentKernelRuntime()->fusionSegments()->groups();
-  EXPECT_THAT(
-      seg_groups, Contains(HeuristicIs(ScheduleHeuristic::NoOp)).Times(1));
-  EXPECT_THAT(
-      seg_groups,
-      Contains(HeuristicIs(ScheduleHeuristic::InnerPersistent)).Times(1));
-  testValidate(
-      executor_cache.fusion(), cg_outputs, {t0}, {t4}, __LINE__, __FILE__);
 }
 
 using ReductionAxes = std::vector<int64_t>;

--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -12,6 +12,8 @@
 #include <ir/interface_nodes.h>
 #include <kernel_cache.h>
 #include <ops/all_ops.h>
+#include <preseg_passes/mark_aliases_prepare.h>
+#include <preseg_passes/optimization_pass.h>
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
 
@@ -563,6 +565,8 @@ TEST_F(PointwiseTest, ShardedPointwise) {
 
 // Repro of issue #657
 TEST_F(PointwiseTest, VectorizeWithBroadcastAndReshape1) {
+  preseg_passes::OptimizationPassGuard<preseg_passes::MarkAliasesPreparePass>
+      optimization_guard(false);
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -608,6 +612,8 @@ TEST_F(PointwiseTest, VectorizeWithBroadcastAndReshape1) {
 
 // Repro of issue #657
 TEST_F(PointwiseTest, VectorizeWithBroadcastAndReshape2) {
+  preseg_passes::OptimizationPassGuard<preseg_passes::MarkAliasesPreparePass>
+      optimization_guard(false);
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 

--- a/tests/cpp/test_remove_bcast_squeeze.cpp
+++ b/tests/cpp/test_remove_bcast_squeeze.cpp
@@ -78,7 +78,7 @@ TEST_F(RemoveBcastSqueezeTest, BcastSqueezeMultipleUses) {
   auto tv1 = set(tv0);
   auto tv2 = broadcast(tv1, is_broadcast_dim);
   auto tv3 = squeeze(tv2, is_broadcast_dim);
-  auto tv4 = set(tv3);
+  auto tv4 = add(tv3, tv3);
   auto tv5 = add(tv2, tvb);
   fusion->addOutput(tv4);
   fusion->addOutput(tv5);
@@ -97,14 +97,7 @@ TEST_F(RemoveBcastSqueezeTest, BcastSqueezeMultipleUses) {
   FusionExecutorCache executor_cache(std::move(fusion));
   std::vector<at::Tensor> outputs =
       executor_cache.runFusionWithInputs({t0, t1});
-  auto ref = t0.unsqueeze(-1) + t1;
-  testValidate(
-      executor_cache.fusion(),
-      outputs,
-      {t0, t1},
-      {t0, ref},
-      __LINE__,
-      __FILE__);
+  testValidate(executor_cache.fusion(), outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(RemoveBcastSqueezeTest, BcastSqueezeUnmatchedDim) {

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -2001,6 +2001,8 @@ TEST_F(ResizeTest, ResizeReshapeAndSlice) {
       tv1,
       {{IrBuilder::create<Val>(0L), IrBuilder::create<Val>(2L)},
        {IrBuilder::create<Val>(0L), IrBuilder::create<Val>(2L)}});
+  // Without the `add`, the fusion will be accepted by NoOp, defeating the
+  // purpose of testing PointWise.
   auto tv3 = add(tv2, tv2);
   fusion->addOutput(tv3);
 

--- a/tests/cpp/test_scatter_gather.cpp
+++ b/tests/cpp/test_scatter_gather.cpp
@@ -5,22 +5,23 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <csrc/exceptions.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include <torch/torch.h>
+
+#include <exceptions.h>
 #include <executor.h>
 #include <inlining.h>
 #include <ir/all_nodes.h>
 #include <ir/builder.h>
 #include <kernel_cache.h>
 #include <ops/all_ops.h>
+#include <preseg_passes/mark_aliases_prepare.h>
+#include <preseg_passes/optimization_pass.h>
 #include <scheduler/all_schedulers.h>
-
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
-
-#include <torch/torch.h>
 
 namespace nvfuser {
 
@@ -1101,6 +1102,9 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose2) {
 // transpose the dimension produced by take_along_axis. Currently not
 // supported by the transpose scheduler
 TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose3) {
+  preseg_passes::OptimizationPassGuard<preseg_passes::MarkAliasesPreparePass>
+      optimization_guard(false);
+
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);


### PR DESCRIPTION
# Summary

This PR improves segmentation around meta ops for #2599. It mimics Thunder's bookend optimization, although only the output end is implemented at this moment. Although the implementation isn't complete, I believe it's an improvement overall. It segments out meta ops more aggressively than before, making non-meta ops easier to schedule. 

# Potential problems

1. `segment_set` enforces the segmenter to give up scheduling the complete fusion and instead trying to merge from singletons. In theory, merging should be able to reach a "local maxima". But in practice it's not always as powerful as expected, e.g., https://github.com/NVIDIA/Fuser/pull/2639/files#diff-cf6d314e82c49485e9039e700a04a678904e5c669abcd1610ade897ca8f57c78R1472. 
2. MarkAliasesPreparePass may set an suboptimal layout, because it runs before `AllocationDomainPass` and reasons about only meta ops. For example, 
   ```
   // `in` has a column-major input matrix. 
   x = PointwiseUnary(in);
   out = Transpose(x);
   ```
   MarkAliasesPreparePass will make `x` row-major, the default layout, and `out` column-major. Although `Transpose` is made no-op, `PointwiseUnary` becomes a pointwise kernel with transposition rather than a streamline pointwise kernel. I think this can be fixed by combining the allocation-domain part of MarkAliasesPreparePass into AllocationDomainPass and of course running AllocationDomainPass before. 

# Performance comparison with TOT

https://gist.github.com/wujingyue/afdc3e89e693ff6bbc18271c96409b94 is the performance comparison before the PR and after. This is collected by running the following commands. 

```
$ python tools/benchmark_thunder.py --storage ~/workspace --filter='test_litgpt_qkv_split_rope[phi-2-backward-bs1-thunder] or test_litgpt_gelu[phi-2-backward-bs1-thunder] or test_batch_norm[backward-thunder]' main:main main:bug2599
$ pytest-benchmark --storage=$HOME/workspace compare 0011 0012 --group-by=name
```

Most benchmarks are neutral, which is as expected because bookend is still on. Several benchmarks (namely, `test_litgpt_qkv_split_rope[phi-2-backward-bs1-thunder]`, `test_litgpt_gelu[phi-2-backward-bs1-thunder]` and `test_batch_norm[backward-thunder]`) showed some regression. However, the regression disappeared the second time I ran the benchmarks, so it's likely a noise. 