### PR TITLE
Support predicate indexing for unswitch/unroll/vectorize

### DIFF
--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -238,59 +238,6 @@ IndexingParameters getNonGlobalInitialIndexParameters(
   return index_parameters;
 }
 
-// Return true if it is sufficient to predicate the end of the loop
-// iteration. An aligned vectorized loop is one example where it is
-// guaranteed to be valid by the validation checks. More generally,
-// the divisible split set is used to find such loops. The divisible
-// split set contains splits used in view transformations as well as
-// those whose output domains are vectorized. View transformations
-// guarantee that any split involved is divisible, whereas
-// vectorization only guarantees that the overall root extent is
-// divisible by the split factor. Thus, if a loop IterDomain is
-// an output of a split included in the divisible view splits, we can
-// just predicate the end of the loop iteration. If a loop IterDomain
-// is an output of a divisible split due to vectorization, it is only
-// valid when the loop IterDomain is mapped with the vectorized inner
-// output IterDomain. If it is mapped with an outer IterDomain, since
-// the split input IterDomain may be an output IterDomain of a
-// non-divisible split, we still need to predicate each loop iteration
-// value.
-bool predicateAtEnd(ForLoop* loop) {
-  auto loop_id = loop->iter_domain();
-  auto split = dynamic_cast<Split*>(loop_id->definition());
-  if (split == nullptr) {
-    return false;
-  }
-
-  bool is_divisible = GpuLower::current()->divisibleSplitSet().count(split) > 0;
-
-  if (!is_divisible) {
-    return false;
-  }
-
-  // Find the other output of the split
-  auto other_out_id =
-      split->inner() == loop_id ? split->outer() : split->inner();
-
-  // If the other output is mapped with a vectorized IterDomain,
-  // this IterDomain needs to be predicated at each iteration point.
-  const auto& other_id_exact_set = GpuLower::current()
-                                       ->caMap()
-                                       ->getIdSets(IdMappingMode::EXACT)
-                                       .getDisjointSetOf(other_out_id);
-
-  if (std::any_of(
-          other_id_exact_set.begin(), other_id_exact_set.end(), [](auto id) {
-            return id->getParallelType() == ParallelType::Vectorize;
-          })) {
-    return false;
-  }
-
-  // Now it is either loop_id is mapped with a vectorized IterDomain
-  // or it's an output of view transformations.
-  return true;
-}
-
 // Check if this loop is actually unswitched, meaning an initial index
 // of the maximum value from a non-size-one range is used.
 bool trackUnswitchedDomain(ForLoop* loop) {
@@ -379,8 +326,8 @@ IndexingParameters getPredicateInitialIndexParameters(
       within_unswitch = loop == unswitch_or_vec_loop;
     }
 
-    bool predicate_at_end =
-        within_unswitch || loop == unswitch_or_vec_loop || predicateAtEnd(loop);
+    bool predicate_at_end = within_unswitch || loop == unswitch_or_vec_loop ||
+        lower_utils::predicateAtEnd(loop);
 
     if (predicate_at_end) {
       // Rely on the reference to check broadcasting. The for loop could be

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -942,23 +942,6 @@ bool isReductionInitExpr(const Expr* expr) {
   return true;
 }
 
-// Return true if it is sufficient to predicate the end of the loop
-// iteration. An aligned vectorized loop is one example where it is
-// guaranteed to be valid by the validation checks. More generally,
-// the divisible split set is used to find such loops. The divisible
-// split set contains splits used in view transformations as well as
-// those whose output domains are vectorized. View transformations
-// guarantee that any split involved is divisible, whereas
-// vectorization only guarantees that the overall root extent is
-// divisible by the split factor. Thus, if a loop IterDomain is
-// an output of a split included in the divisible view splits, we can
-// just predicate the end of the loop iteration. If a loop IterDomain
-// is an output of a divisible split due to vectorization, it is only
-// valid when the loop IterDomain is mapped with the vectorized inner
-// output IterDomain. If it is mapped with an outer IterDomain, since
-// the split input IterDomain may be an output IterDomain of a
-// non-divisible split, we still need to predicate each loop iteration
-// value.
 bool predicateAtEnd(ForLoop* loop) {
   auto loop_id = loop->iter_domain();
   auto split = dynamic_cast<Split*>(loop_id->definition());

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -942,6 +942,59 @@ bool isReductionInitExpr(const Expr* expr) {
   return true;
 }
 
+// Return true if it is sufficient to predicate the end of the loop
+// iteration. An aligned vectorized loop is one example where it is
+// guaranteed to be valid by the validation checks. More generally,
+// the divisible split set is used to find such loops. The divisible
+// split set contains splits used in view transformations as well as
+// those whose output domains are vectorized. View transformations
+// guarantee that any split involved is divisible, whereas
+// vectorization only guarantees that the overall root extent is
+// divisible by the split factor. Thus, if a loop IterDomain is
+// an output of a split included in the divisible view splits, we can
+// just predicate the end of the loop iteration. If a loop IterDomain
+// is an output of a divisible split due to vectorization, it is only
+// valid when the loop IterDomain is mapped with the vectorized inner
+// output IterDomain. If it is mapped with an outer IterDomain, since
+// the split input IterDomain may be an output IterDomain of a
+// non-divisible split, we still need to predicate each loop iteration
+// value.
+bool predicateAtEnd(ForLoop* loop) {
+  auto loop_id = loop->iter_domain();
+  auto split = dynamic_cast<Split*>(loop_id->definition());
+  if (split == nullptr) {
+    return false;
+  }
+
+  bool is_divisible = GpuLower::current()->divisibleSplitSet().count(split) > 0;
+
+  if (!is_divisible) {
+    return false;
+  }
+
+  // Find the other output of the split
+  auto other_out_id =
+      split->inner() == loop_id ? split->outer() : split->inner();
+
+  // If the other output is mapped with a vectorized IterDomain,
+  // this IterDomain needs to be predicated at each iteration point.
+  const auto& other_id_exact_set = GpuLower::current()
+                                       ->caMap()
+                                       ->getIdSets(IdMappingMode::EXACT)
+                                       .getDisjointSetOf(other_out_id);
+
+  if (std::any_of(
+          other_id_exact_set.begin(), other_id_exact_set.end(), [](auto id) {
+            return id->getParallelType() == ParallelType::Vectorize;
+          })) {
+    return false;
+  }
+
+  // Now it is either loop_id is mapped with a vectorized IterDomain
+  // or it's an output of view transformations.
+  return true;
+}
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -326,6 +326,25 @@ std::array<UnitDim, 2> getMmaLayout(const MmaOp* expr);
 // buffer.
 bool isReductionInitExpr(const Expr* expr);
 
+// Return true if it is sufficient to predicate the end of the loop
+// iteration. An aligned vectorized loop is one example where it is
+// guaranteed to be valid by the validation checks. More generally,
+// the divisible split set is used to find such loops. The divisible
+// split set contains splits used in view transformations as well as
+// those whose output domains are vectorized. View transformations
+// guarantee that any split involved is divisible, whereas
+// vectorization only guarantees that the overall root extent is
+// divisible by the split factor. Thus, if a loop IterDomain is
+// an output of a split included in the divisible view splits, we can
+// just predicate the end of the loop iteration. If a loop IterDomain
+// is an output of a divisible split due to vectorization, it is only
+// valid when the loop IterDomain is mapped with the vectorized inner
+// output IterDomain. If it is mapped with an outer IterDomain, since
+// the split input IterDomain may be an output IterDomain of a
+// non-divisible split, we still need to predicate each loop iteration
+// value.
+bool predicateAtEnd(ForLoop* loop);
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -1007,10 +1007,11 @@ void TensorIndexer::setupAllocationDomains(const std::vector<Expr*>& exprs) {
   alloc_info_ = std::move(alloc_setup.tv_alloc_info_map);
 }
 
-std::vector<PredicateInfo> TensorIndexer::getInlinePredicates(
+std::vector<PredicateInfo> TensorIndexer::getPredicates(
     TensorView* tv,
     const Expr* expr,
-    const std::vector<ForLoop*>& for_loops) const {
+    const std::vector<ForLoop*>& for_loops,
+    ForLoop* unswitched_loop) const {
   const auto& zero_val = tv->fusion()->zeroVal();
 
   const std::vector<IterDomain*>& predicate_domains =
@@ -1020,6 +1021,26 @@ std::vector<PredicateInfo> TensorIndexer::getInlinePredicates(
       expr, traversalGraph().toGroups(predicate_domains), for_loops);
 
   const auto& index_map = index_info.index_map;
+
+  const std::unordered_map<Val*, Val*> replacement_map_start =
+      getPredicateIndexReplacementMap(
+          tv,
+          for_loops,
+          index_map,
+          traversalGraph(),
+          id_model_,
+          /*is_start_predicate=*/true,
+          /*unswitched_loop=*/unswitched_loop);
+
+  const std::unordered_map<Val*, Val*> replacement_map_stop =
+      getPredicateIndexReplacementMap(
+          tv,
+          for_loops,
+          index_map,
+          traversalGraph(),
+          id_model_,
+          /*is_start_predicate=*/false,
+          /*unswitched_loop=*/unswitched_loop);
 
   std::vector<PredicateInfo> info_vec;
   info_vec.reserve(predicate_domains.size());
@@ -1033,11 +1054,14 @@ std::vector<PredicateInfo> TensorIndexer::getInlinePredicates(
         predicate_domain->toString());
 
     Val* idx = idx_it->second;
+    Val* start_idx =
+        ir_utils::replaceValRecursively(idx, replacement_map_start);
+    Val* stop_idx = ir_utils::replaceValRecursively(idx, replacement_map_stop);
 
     // Generate predicates as follows:
     //
-    // (idx + start_offset) >= 0 &&
-    // (idx + stop_offset) < extent.
+    // (start_idx + start_offset) >= 0 &&
+    // (stop_idx + stop_offset) < extent.
 
     PredicateInfo info;
     // For now, just set zero for both start and stop offsets by
@@ -1047,10 +1071,10 @@ std::vector<PredicateInfo> TensorIndexer::getInlinePredicates(
     info.stop_offset_ = tv->fusion()->zeroVal();
 
     info.start_predicate_ = SimplifyingIrBuilder::geExpr(
-        SimplifyingIrBuilder::addExpr(idx, info.start_offset_), zero_val);
+        SimplifyingIrBuilder::addExpr(start_idx, info.start_offset_), zero_val);
 
     info.stop_predicate_ = SimplifyingIrBuilder::ltExpr(
-        SimplifyingIrBuilder::addExpr(idx, info.stop_offset_),
+        SimplifyingIrBuilder::addExpr(stop_idx, info.stop_offset_),
         predicate_domain->extent());
 
     info.predicated_domains_ = {predicate_domain};

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -88,10 +88,16 @@ class TensorIndexer {
   // expr as a consumer. Each predicate corresponds to a domain of the
   // tensor, which is by default one of the logical domains but can be
   // an intermediate domain with contiguous indexing.
-  std::vector<PredicateInfo> getInlinePredicates(
+  //
+  // An optional ForLoop parameter specifies a loop that is either
+  // unswitched/unrolled or vectorized, both of which are handled by
+  // UnswitchPredicate. For normal inline predicates, the parameter
+  // should be nullptr.
+  std::vector<PredicateInfo> getPredicates(
       TensorView* tv,
       const Expr* expr,
-      const std::vector<ForLoop*>& for_loops) const;
+      const std::vector<ForLoop*>& for_loops,
+      ForLoop* unswitched_loop = nullptr) const;
 
  private:
   // Build a map of loop groups to their index Vals. See the comment

--- a/csrc/id_model/predicate_indexing.cpp
+++ b/csrc/id_model/predicate_indexing.cpp
@@ -71,7 +71,7 @@ std::unordered_map<Val*, Val*> getPredicateIndexReplacementMap(
   // - predicateAtEnd returns true
   // - Within an unswitch/unroll loop
   //
-  // Use N-1 instead of i but not when it's thread paralellized so
+  // Use N-1 instead of i but not when it's thread parallelized so
   // that each thread or block can take different paths. This may not
   // be optimal for TID, though, as it might result in thread
   // divergence.

--- a/csrc/id_model/predicate_indexing.cpp
+++ b/csrc/id_model/predicate_indexing.cpp
@@ -53,4 +53,104 @@ std::vector<IterDomain*> getPredicateDomains(
   return predicate_domains;
 }
 
+std::unordered_map<Val*, Val*> getPredicateIndexReplacementMap(
+    TensorView* tv,
+    const std::vector<ForLoop*>& for_loops,
+    const std::unordered_map<ValGroup, Val*>& index_map,
+    const ValGraph& traversal_graph,
+    const IdModel& id_model,
+    bool is_start_predicate,
+    ForLoop* unswitched_loop) {
+  std::unordered_map<Val*, Val*> replacement_map;
+
+  // For an iter domain of index i, it is valid to use N-1 instead of
+  // i, where N is the extent of the iter domain if either of the
+  // following conditions is satisfied:
+  //
+  // - Vectorized
+  // - predicateAtEnd returns true
+  // - Within an unswitch/unroll loop
+  //
+  // Use N-1 instead of i but not when it's thread paralellized so
+  // that each thread or block can take different paths. This may not
+  // be optimal for TID, though, as it might result in thread
+  // divergence.
+  //
+  // Also in the case of vectorization, instead of N-1, it's also
+  // valid to use 0 since the splits involved to create the iter
+  // domain are all guaranteed to be divisible.
+  auto predicate_at_end =
+      [&](ForLoop* fl, IterDomain* loop_id, bool within_unswitch) -> Val* {
+    // Don't replace thread indices even when unswitched
+    if (!fl->iter_domain()->isThread() &&
+        (fl->iter_domain()->getParallelType() == ParallelType::Vectorize ||
+         within_unswitch || lower_utils::predicateAtEnd(fl))) {
+      return is_start_predicate
+          ? fl->fusion()->zeroVal()
+          : SimplifyingIrBuilder::subExpr(
+                fl->simplifiedStop(), fl->fusion()->oneVal());
+    } else {
+      return nullptr;
+    }
+  };
+
+  // Inspect the for-loops from outer to inner and keep track of
+  // unswitching since it affects all inner loops
+  bool within_unswitch = false;
+  for (const auto fl : for_loops) {
+    auto parallel_type = fl->iter_domain()->getParallelType();
+
+    // Note that unswitched_loop may be a vectorized loop
+    if (fl == unswitched_loop && parallel_type != ParallelType::Vectorize) {
+      within_unswitch = true;
+    }
+
+    auto loop_id =
+        indexing_utils::getLoopPromotion(fl->iter_domain(), id_model);
+
+    NVF_ERROR(
+        !loop_id->maybePartial(),
+        "Partial loop not supported: ",
+        fl->toString());
+
+    auto loop_index_it = index_map.find(traversal_graph.toGroup(loop_id));
+
+    if (loop_index_it == index_map.end()) {
+      // The index map is built from the tensor loop domains. There
+      // can be for-loops that are not part of this tensor, e.g, a
+      // tensor inlined into a higher dimensional tensor.
+      continue;
+    }
+
+    Val* loop_index = loop_index_it->second;
+
+    // If it's already const scalar, no replacment should be necessary
+    if (loop_index->isConst()) {
+      continue;
+    }
+
+    Val* replacement = loop_index;
+
+    // Trivial loop. Note that not all trivial loops should just use
+    // the start index for predication. For example, a vectorized loop
+    // is trivial, but its predicate should use `vec_factor - 1` as
+    // its index. This is taken care after this.
+    if (fl->isTrivial()) {
+      replacement = fl->start();
+    }
+
+    if (auto idx = predicate_at_end(fl, loop_id, within_unswitch)) {
+      replacement = idx;
+    }
+
+    if (replacement != loop_index) {
+      auto inserted = replacement_map.emplace(loop_index, replacement).second;
+      NVF_ERROR(
+          inserted, "Duplicate replacement attempted: ", loop_id->toString());
+    }
+  }
+
+  return replacement_map;
+}
+
 } // namespace nvfuser

--- a/csrc/id_model/predicate_indexing.h
+++ b/csrc/id_model/predicate_indexing.h
@@ -19,4 +19,19 @@ std::vector<IterDomain*> getPredicateDomains(
     TensorView* consumer_tv,
     const Expr* expr);
 
+// Get a replace map for predicate indexing of a given tensor appearing
+// in a given loop-nest.
+//
+// The unswitched_loop parameter is an optional ForLoop that is used
+// when this predicate is for an unswitched, unrolled or vectorized
+// loop.
+std::unordered_map<Val*, Val*> getPredicateIndexReplacementMap(
+    TensorView* tv,
+    const std::vector<ForLoop*>& for_loops,
+    const std::unordered_map<ValGroup, Val*>& index_map,
+    const ValGraph& traversal_graph,
+    const IdModel& id_model,
+    bool is_start_predicate,
+    ForLoop* unswitched_loop = nullptr);
+
 } // namespace nvfuser


### PR DESCRIPTION
Adding support of generating predicates for unswitch/unroll and vectorize.

These predicates are generated by `UnswitchPredicate`. Unswitch and unroll are effectively the same for predication. Vectorize is also mostly the same with only one difference, which is that the predicate of the vectorized loop itself is altered.

For example, if a tensor has `[I0, I1, I2]` and `I1` is unswitched, the code structure would look like:

```
for i0 in I0:
  if idx(i0, I1 - 1, I2 - 1) < N:
    for i1 in I1:
       for i2 in I2:
           do_something
       end-for
     end-for
  else
    for i1 in I1:
       for i2 in I2:
           if idx(i0, i1, i2) < N:
              do_something
           end-if
       end-for
     end-for
  end-if
end-for
```

Here, `idx` is a function to produce the linearized index using the loop indices, and `N` is the extent of the domain. Notice that both `I1` and `I2` loops are predicated with their maximum index values.
 
If `I1` is vectorized:

```
for i0 in I0:
  for i2 in I2:
    if idx(i0, I1 - 1, i2) < N:
      do_something
    end-if
   end-for
end-for
```

I tried to reproduce the same predicates as much as possible with the current lowering. For example, while working on this, I realized it should be also fine to use `0` instead of `I - 1` for vectorized domains since splits involved in vectorized domains are guaranteed to be divisible. For example, this should be equivalent to the above example:

```
for i0 in I0:
  for i2 in I2:
    if idx(i0, 0, i2) < N:
      do_something
    end-if
   end-for
end-for
```

Using zero would probably make the expression simplifier work more effectively, so that's probably a better option for performance. I'll look into it as a separate PR (#2628).