### PR TITLE
Don't `-Werror` for now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,7 @@ add_library(codegen_internal OBJECT ${NVFUSER_SRCS})
 if(NOT MSVC)
   target_compile_options(codegen_internal PRIVATE
     -Wall -Wno-unused-function
-    -Werror
+    # -Werror
   )
 endif()
 


### PR DESCRIPTION
Looks like `-Werror` triggers some compiler bug in gcc-12: https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/jobs/102347991

```
#19 104.6 [183/310] Building CXX object CMakeFiles/codegen_internal.dir/csrc/ir/utils.cpp.o
#19 104.6 FAILED: CMakeFiles/codegen_internal.dir/csrc/ir/utils.cpp.o 
#19 104.6 /opt/rh/gcc-toolset-12/root/usr/bin/c++ -DNVFUSER_DISTRIBUTED -DTORCH_CUDA_BUILD_MAIN_LIB -DUSE_C10D_GLOO -DUSE_C10D_NCCL -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -I/workspace/Fuser/csrc -I/workspace/Fuser/build/include -I/workspace/Fuser/lib/dynamic_type/src -isystem /workspace/Fuser/third_party/gloo -isystem /workspace/Fuser/third_party/flatbuffers/include -isystem /usr/local/cuda/extras/CUPTI/include -isystem /usr/local/cuda/include -isystem /opt/python/cp310-cp310/lib/python3.10/site-packages/torch/include -isystem /opt/python/cp310-cp310/lib/python3.10/site-packages/torch/include/torch/csrc/api/include -Wno-psabi -D_GLIBCXX_USE_CXX11_ABI=0 -O3 -DNDEBUG -std=gnu++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wno-unused-function -Werror -D_GLIBCXX_USE_CXX11_ABI=0 -MD -MT CMakeFiles/codegen_internal.dir/csrc/ir/utils.cpp.o -MF CMakeFiles/codegen_internal.dir/csrc/ir/utils.cpp.o.d -o CMakeFiles/codegen_internal.dir/csrc/ir/utils.cpp.o -c /workspace/Fuser/csrc/ir/utils.cpp
#19 104.6 In file included from /opt/rh/gcc-toolset-12/root/usr/include/c++/12/array:43,
#19 104.6                  from /workspace/Fuser/csrc/exceptions.h:13,
#19 104.6                  from /workspace/Fuser/csrc/device_lower/utils.h:11,
#19 104.6                  from /workspace/Fuser/csrc/ir/utils.cpp:8:
#19 104.6 In static member function ‘static _Tp* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(const _Tp*, const _Tp*, _Tp*) [with _Tp = nvfuser::Val*; bool _IsMove = false]’,
#19 104.6     inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = nvfuser::Val* const*; _OI = nvfuser::Val**]’ at /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/stl_algobase.h:495:30,
#19 104.6     inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = nvfuser::Val* const*; _OI = nvfuser::Val**]’ at /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/stl_algobase.h:522:42,
#19 104.6     inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<nvfuser::Val* const*, vector<nvfuser::Val*> >; _OI = __gnu_cxx::__normal_iterator<nvfuser::Val**, vector<nvfuser::Val*> >]’ at /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/stl_algobase.h:529:31,
#19 104.6     inlined from ‘_OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<nvfuser::Val* const*, vector<nvfuser::Val*> >; _OI = __gnu_cxx::__normal_iterator<nvfuser::Val**, vector<nvfuser::Val*> >]’ at /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/stl_algobase.h:620:7,
#19 104.6     inlined from ‘std::vector<_Tp, _Alloc>& std::vector<_Tp, _Alloc>::operator=(const std::vector<_Tp, _Alloc>&) [with _Tp = nvfuser::Val*; _Alloc = std::allocator<nvfuser::Val*>]’ at /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/vector.tcc:244:21:
#19 104.6 /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/stl_algobase.h:431:30: error: argument 1 null where non-null expected [-Werror=nonnull]
#19 104.6   431 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
#19 104.6       |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#19 104.6 /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/stl_algobase.h:431:30: note: in a call to built-in function ‘void* __builtin_memmove(void*, const void*, long unsigned int)’
#19 104.6 cc1plus: all warnings being treated as errors
```
this error is triggered from my PR https://github.com/NVIDIA/Fuser/pull/2618

Please note that the wheel container is using an unsupported compiler (gcc 12.2). We only support compilers officially supported by upstream, according to https://gcc.gnu.org/, today, it is gcc 12.4.