### PR TITLE
Fix epilogue loop generation

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -2895,20 +2895,9 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       indent() << "#pragma unroll 1\n";
     }
 
-    indent() << "for(nvfuser_index_t " << gen_index;
-    if (loop->iter_domain()->isParallelized()) {
-      code_ << " = " << gen_start << "; ";
-    } else {
-      // Do not start at  the start of the ID when not parallelized. Instead,
-      // start at 0. Predicates will protect buffers between 0 and ID->start(),
-      // however if we started at ID->start and extent == ID->start, we could
-      // have a "degenerate" loop (loop with no iterations). It may not be an
-      // issue to have a 0-sized loop, but all potential consequences haven't
-      // been covered. One example is WAR analysis which could incorrectly think
-      // a barrier inside a 0-sized loop actually provides protection.
-      code_ << " = 0; ";
-    }
-    code_ << gen_index << " < " << gen_stop << "; " << step_code.str() << ") ";
+    indent() << "for(nvfuser_index_t " << gen_index << " = " << gen_start
+             << "; " << gen_index << " < " << gen_stop << "; "
+             << step_code.str() << ") ";
     startBlock(true);
     kir::ConstIrVisitor::handle(loop);
     endBlock();

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -703,7 +703,7 @@ void CircularBufferInfo::setCircularBufferAxis(
   getTvInfo(tv).circular_buffer_axis = axis;
 
   // Also validate the stage consistency with CA map.
-  unsigned int stage_depth = 0;
+  int64_t stage_depth = 0;
   if (tv->isCircularBuffered()) {
     stage_depth = tv->circularBufferDepth();
   } else {
@@ -715,9 +715,7 @@ void CircularBufferInfo::setCircularBufferAxis(
   setStageDepth(axis, stage_depth);
 }
 
-void CircularBufferInfo::setStageDepth(
-    IterDomain* id,
-    unsigned int stage_depth) {
+void CircularBufferInfo::setStageDepth(IterDomain* id, int64_t stage_depth) {
   auto concrete_loop_id = GpuLower::current()->caMap()->getConcreteMappedID(
       id, IdMappingMode::LOOP);
 
@@ -746,7 +744,7 @@ IterDomain* CircularBufferInfo::getCircularBufferAxis(const TensorView* tv) {
   return getTvInfo(tv).circular_buffer_axis;
 }
 
-unsigned int CircularBufferInfo::getStageDepthFor(
+int64_t CircularBufferInfo::getStageDepthFor(
     IterDomain* circular_buffer_axis) const {
   auto concrete_id = GpuLower::current()->caMap()->getConcreteMappedID(
       circular_buffer_axis, IdMappingMode::LOOP);

--- a/csrc/device_lower/pass/circular_buffer.h
+++ b/csrc/device_lower/pass/circular_buffer.h
@@ -217,7 +217,7 @@ class CircularBufferInfo {
 
   //! Get the number of circular buffer stages for the given axis,
   //!  the number of stages will be 2 in the case of circular buffer loop.
-  unsigned int getStageDepthFor(IterDomain* circular_buffered_id) const;
+  int64_t getStageDepthFor(IterDomain* circular_buffered_id) const;
 
  private:
   TvInfo& getTvInfo(const TensorView* tv);
@@ -228,9 +228,7 @@ class CircularBufferInfo {
   //!  set,
   //! so this function will throw an error if trying to set different stage
   //! numbers to iterdomains that are loop mapped.
-  void setStageDepth(
-      IterDomain* circular_buffered_id,
-      unsigned int stage_depth);
+  void setStageDepth(IterDomain* circular_buffered_id, int64_t stage_depth);
 
  private:
   //! Keeps track of information for lowering circular buffered tensors
@@ -244,7 +242,7 @@ class CircularBufferInfo {
   //!  Currently for each disjoint set of loop mapped iterdomains,
   //! Only one stage depth is supported, so that the loops can indeed
   //! shared with the same prolog extent and main loop offset.
-  std::unordered_map<IterDomain*, unsigned int> stage_depth_;
+  std::unordered_map<IterDomain*, int64_t> stage_depth_;
 };
 
 } // namespace nvfuser

--- a/csrc/device_lower/pass/circular_buffer.h
+++ b/csrc/device_lower/pass/circular_buffer.h
@@ -217,7 +217,7 @@ class CircularBufferInfo {
 
   //! Get the number of circular buffer stages for the given axis,
   //!  the number of stages will be 2 in the case of circular buffer loop.
-  unsigned int getStageDepthFor(IterDomain* circular_buffered_id);
+  unsigned int getStageDepthFor(IterDomain* circular_buffered_id) const;
 
  private:
   TvInfo& getTvInfo(const TensorView* tv);

--- a/tests/cpp/test_loop_rotation.cpp
+++ b/tests/cpp/test_loop_rotation.cpp
@@ -36,7 +36,7 @@ TEST_F(LoopRotationTest, RotateInner) {
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i0 = 0; i0 < T0.logical_size[0LL]; ++i0) {
+  for(nvfuser_index_t i0 = 0LL; i0 < T0.logical_size[0LL]; ++i0) {
     nvfuser_index_t i1;
     i1 = T0.alloc_stride[0LL] * i0;
     nvfuser_index_t i2;
@@ -50,7 +50,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
        = T1[0LL];
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+    for(nvfuser_index_t i3 = 0LL; i3 < 3LL; ++i3) {
       nvfuser_index_t i4;
       i4 = (1LL + i3) + nvfuser_zero;
       float T3[1LL];
@@ -104,24 +104,24 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   float T1[3LL];
   float T2[3LL];
   #pragma unroll
-  for(nvfuser_index_t i0 = 0; i0 < 3LL; ++i0) {
+  for(nvfuser_index_t i0 = 0LL; i0 < 3LL; ++i0) {
     T1[i0] = 0LL;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i0 = 0; i0 < 3LL; ++i0) {
+  for(nvfuser_index_t i0 = 0LL; i0 < 3LL; ++i0) {
     T1[i0]
        = T0[(T0.alloc_stride[1LL] * (i0 + nvfuser_zero))];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i1 = 0; i1 < 3LL; ++i1) {
+  for(nvfuser_index_t i1 = 0LL; i1 < 3LL; ++i1) {
     T2[i1]
        = T1[i1];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i2 = 0; i2 < T0.logical_size[0LL]; ++i2) {
+  for(nvfuser_index_t i2 = 0LL; i2 < T0.logical_size[0LL]; ++i2) {
     nvfuser_index_t i3;
     i3 = 3LL * i2;
     nvfuser_index_t i4;
@@ -131,24 +131,24 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     // Alias Allocation - register
     auto& T3 = T1;
     #pragma unroll
-    for(nvfuser_index_t i6 = 0; i6 < 3LL; ++i6) {
+    for(nvfuser_index_t i6 = 0LL; i6 < 3LL; ++i6) {
       T3[i6]
          = T2[i6];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i7 = 0; i7 < 3LL; ++i7) {
+    for(nvfuser_index_t i7 = 0LL; i7 < 3LL; ++i7) {
       T4[(i3 + (i7 + nvfuser_zero))]
          = T3[i7];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i0 = 0; i0 < 3LL; ++i0) {
+    for(nvfuser_index_t i0 = 0LL; i0 < 3LL; ++i0) {
       T1[i0] = 0LL;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i0 = 0; i0 < 3LL; ++i0) {
+    for(nvfuser_index_t i0 = 0LL; i0 < 3LL; ++i0) {
       if (b5) {
         T1[i0]
            = T0[(i4 + (T0.alloc_stride[1LL] * (i0 + nvfuser_zero)))];
@@ -156,7 +156,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i1 = 0; i1 < 3LL; ++i1) {
+    for(nvfuser_index_t i1 = 0LL; i1 < 3LL; ++i1) {
       T2[i1]
          = T1[i1];
     }
@@ -205,12 +205,12 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   float T1[5LL];
   float T2[5LL];
   #pragma unroll
-  for(nvfuser_index_t i2 = 0; i2 < 5LL; ++i2) {
+  for(nvfuser_index_t i2 = 0LL; i2 < 5LL; ++i2) {
     T1[i2] = 0LL;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i2 = 0; i2 < 5LL; ++i2) {
+  for(nvfuser_index_t i2 = 0LL; i2 < 5LL; ++i2) {
     nvfuser_index_t i3;
     i3 = i2 + nvfuser_zero;
     if ((i3 < i0)) {
@@ -220,13 +220,13 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i4 = 0; i4 < 5LL; ++i4) {
+  for(nvfuser_index_t i4 = 0LL; i4 < 5LL; ++i4) {
     T2[i4]
        = T1[i4];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i5 = 0; i5 < i1; ++i5) {
+  for(nvfuser_index_t i5 = 0LL; i5 < i1; ++i5) {
     nvfuser_index_t i6;
     i6 = 5LL * i5;
     nvfuser_index_t i7;
@@ -234,13 +234,13 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     // Alias Allocation - register
     auto& T3 = T1;
     #pragma unroll
-    for(nvfuser_index_t i8 = 0; i8 < 5LL; ++i8) {
+    for(nvfuser_index_t i8 = 0LL; i8 < 5LL; ++i8) {
       T3[i8]
          = T2[i8];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i9 = 0; i9 < 5LL; ++i9) {
+    for(nvfuser_index_t i9 = 0LL; i9 < 5LL; ++i9) {
       nvfuser_index_t i10;
       i10 = i6 + (i9 + nvfuser_zero);
       if ((i10 < i0)) {
@@ -250,12 +250,12 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i2 = 0; i2 < 5LL; ++i2) {
+    for(nvfuser_index_t i2 = 0LL; i2 < 5LL; ++i2) {
       T1[i2] = 0LL;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i2 = 0; i2 < 5LL; ++i2) {
+    for(nvfuser_index_t i2 = 0LL; i2 < 5LL; ++i2) {
       nvfuser_index_t i11;
       i11 = i7 + (i2 + nvfuser_zero);
       if ((i11 < i0)) {
@@ -265,7 +265,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i4 = 0; i4 < 5LL; ++i4) {
+    for(nvfuser_index_t i4 = 0LL; i4 < 5LL; ++i4) {
       T2[i4]
          = T1[i4];
     }
@@ -308,7 +308,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   i0 = 4LL * T0.alloc_stride[0LL];
   float T1[15LL];
   #pragma unroll
-  for(nvfuser_index_t i1 = 0; i1 < 4LL; ++i1) {
+  for(nvfuser_index_t i1 = 0LL; i1 < 4LL; ++i1) {
     nvfuser_index_t i2;
     i2 = 3LL * i1;
     nvfuser_index_t i3;
@@ -316,11 +316,11 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     bool b4;
     b4 = (i1 + nvfuser_zero) < T0.logical_size[0LL];
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
+    for(nvfuser_index_t i5 = 0LL; i5 < 3LL; ++i5) {
       T1[(i2 + i5)] = 0LL;
     }
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
+    for(nvfuser_index_t i5 = 0LL; i5 < 3LL; ++i5) {
       if (b4) {
         T1[(i2 + i5)]
            = T0[(i3 + (T0.alloc_stride[1LL] * (i5 + nvfuser_zero)))];
@@ -330,13 +330,13 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   NVFUSER_UPDATE_MAGIC_ZERO;
   float T2[3LL];
   #pragma unroll
-  for(nvfuser_index_t i6 = 0; i6 < 3LL; ++i6) {
+  for(nvfuser_index_t i6 = 0LL; i6 < 3LL; ++i6) {
     T2[i6]
        = T1[i6];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i7 = 0; i7 < T0.logical_size[0LL]; ++i7) {
+  for(nvfuser_index_t i7 = 0LL; i7 < T0.logical_size[0LL]; ++i7) {
     nvfuser_index_t i8;
     i8 = 4LL + i7;
     nvfuser_index_t i9;
@@ -350,12 +350,12 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     bool b13;
     b13 = i8 < T0.logical_size[0LL];
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
+    for(nvfuser_index_t i5 = 0LL; i5 < 3LL; ++i5) {
       T1[(i9 + i5)] = 0LL;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i5 = 0; i5 < 3LL; ++i5) {
+    for(nvfuser_index_t i5 = 0LL; i5 < 3LL; ++i5) {
       if (b13) {
         T1[(i9 + i5)]
            = T0[(i10 + (T0.alloc_stride[1LL] * (i5 + nvfuser_zero)))];
@@ -364,19 +364,19 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     NVFUSER_UPDATE_MAGIC_ZERO;
     float T3[3LL];
     #pragma unroll
-    for(nvfuser_index_t i14 = 0; i14 < 3LL; ++i14) {
+    for(nvfuser_index_t i14 = 0LL; i14 < 3LL; ++i14) {
       T3[i14]
          = T2[i14];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i15 = 0; i15 < 3LL; ++i15) {
+    for(nvfuser_index_t i15 = 0LL; i15 < 3LL; ++i15) {
       T4[(i11 + (i15 + nvfuser_zero))]
          = T3[i15];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i6 = 0; i6 < 3LL; ++i6) {
+    for(nvfuser_index_t i6 = 0LL; i6 < 3LL; ++i6) {
       T2[i6]
          = T1[(i12 + i6)];
     }
@@ -423,18 +423,18 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   b2 = 4LL < T0.logical_size[0LL];
   float T1[15LL];
   #pragma unroll
-  for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+  for(nvfuser_index_t i3 = 0LL; i3 < 3LL; ++i3) {
     T1[i3] = 0LL;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+  for(nvfuser_index_t i3 = 0LL; i3 < 3LL; ++i3) {
     T1[i3]
        = T0[(T0.alloc_stride[1LL] * (i3 + nvfuser_zero))];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i4 = 0; i4 < 4LL; ++i4) {
+  for(nvfuser_index_t i4 = 0LL; i4 < 4LL; ++i4) {
     nvfuser_index_t i5;
     i5 = 3LL + (3LL * i4);
     nvfuser_index_t i6;
@@ -442,11 +442,11 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     bool b7;
     b7 = ((1LL + i4) + nvfuser_zero) < T0.logical_size[0LL];
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+    for(nvfuser_index_t i3 = 0LL; i3 < 3LL; ++i3) {
       T1[(i5 + i3)] = 0LL;
     }
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+    for(nvfuser_index_t i3 = 0LL; i3 < 3LL; ++i3) {
       if (b7) {
         T1[(i5 + i3)]
            = T0[(i6 + (T0.alloc_stride[1LL] * (i3 + nvfuser_zero)))];
@@ -456,12 +456,12 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   NVFUSER_UPDATE_MAGIC_ZERO;
   float T2[3LL];
   #pragma unroll
-  for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+  for(nvfuser_index_t i3 = 0LL; i3 < 3LL; ++i3) {
     T1[(12LL + i3)] = 0LL;
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+  for(nvfuser_index_t i3 = 0LL; i3 < 3LL; ++i3) {
     if (b2) {
       T1[(12LL + i3)]
          = T0[(i0 + (T0.alloc_stride[1LL] * (i3 + nvfuser_zero)))];
@@ -469,13 +469,13 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll
-  for(nvfuser_index_t i8 = 0; i8 < 3LL; ++i8) {
+  for(nvfuser_index_t i8 = 0LL; i8 < 3LL; ++i8) {
     T2[i8]
        = T1[i8];
   }
   NVFUSER_UPDATE_MAGIC_ZERO;
   #pragma unroll 1
-  for(nvfuser_index_t i9 = 0; i9 < T0.logical_size[0LL]; ++i9) {
+  for(nvfuser_index_t i9 = 0LL; i9 < T0.logical_size[0LL]; ++i9) {
     nvfuser_index_t i10;
     i10 = 3LL * i9;
     nvfuser_index_t i11;
@@ -488,24 +488,24 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     b14 = (5LL + i9) < T0.logical_size[0LL];
     float T3[3LL];
     #pragma unroll
-    for(nvfuser_index_t i15 = 0; i15 < 3LL; ++i15) {
+    for(nvfuser_index_t i15 = 0LL; i15 < 3LL; ++i15) {
       T3[i15]
          = T2[i15];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i16 = 0; i16 < 3LL; ++i16) {
+    for(nvfuser_index_t i16 = 0LL; i16 < 3LL; ++i16) {
       T4[(i10 + (i16 + nvfuser_zero))]
          = T3[i16];
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+    for(nvfuser_index_t i3 = 0LL; i3 < 3LL; ++i3) {
       T1[(i11 + i3)] = 0LL;
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i3 = 0; i3 < 3LL; ++i3) {
+    for(nvfuser_index_t i3 = 0LL; i3 < 3LL; ++i3) {
       if (b14) {
         T1[(i11 + i3)]
            = T0[(i12 + (T0.alloc_stride[1LL] * (i3 + nvfuser_zero)))];
@@ -513,7 +513,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     }
     NVFUSER_UPDATE_MAGIC_ZERO;
     #pragma unroll
-    for(nvfuser_index_t i8 = 0; i8 < 3LL; ++i8) {
+    for(nvfuser_index_t i8 = 0LL; i8 < 3LL; ++i8) {
       T2[i8]
          = T1[(i13 + i8)];
     }
@@ -573,7 +573,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   float* ptr1;
   ptr1 = T0.data + (4LL * T0.alloc_stride[0LL]);
   #pragma unroll
-  for(nvfuser_index_t i2 = 0; i2 < 4LL; ++i2) {
+  for(nvfuser_index_t i2 = 0LL; i2 < 4LL; ++i2) {
     float* ptr3;
     ptr3 = T0.data + (T0.alloc_stride[0LL] * i2);
     unsigned i4;
@@ -583,7 +583,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     bool b6;
     b6 = !b5;
     #pragma unroll
-    for(nvfuser_index_t i7 = 0; i7 < 3LL; ++i7) {
+    for(nvfuser_index_t i7 = 0LL; i7 < 3LL; ++i7) {
       asm volatile(
         "{\n"
         "  .reg .pred p0; \n"
@@ -605,7 +605,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
   T1[0LL]
      = T4[0LL];
   #pragma unroll 1
-  for(nvfuser_index_t i8 = 0; i8 < T0.logical_size[0LL]; ++i8) {
+  for(nvfuser_index_t i8 = 0LL; i8 < T0.logical_size[0LL]; ++i8) {
     float* ptr9;
     ptr9 = ptr1 + (T0.alloc_stride[0LL] * i8);
     nvfuser_index_t i10;
@@ -621,7 +621,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     bool b15;
     b15 = !b14;
     #pragma unroll
-    for(nvfuser_index_t i7 = 0; i7 < 3LL; ++i7) {
+    for(nvfuser_index_t i7 = 0LL; i7 < 3LL; ++i7) {
       asm volatile(
         "{\n"
         "  .reg .pred p0; \n"
@@ -638,7 +638,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     NVFUSER_UPDATE_MAGIC_ZERO;
     asm volatile("cp.async.commit_group;\n");
     #pragma unroll
-    for(nvfuser_index_t i16 = 0; i16 < 2LL; ++i16) {
+    for(nvfuser_index_t i16 = 0LL; i16 < 2LL; ++i16) {
       T1[((1LL + i16) % 2LL)]
          = T4[(i12 + i16)];
       float T2[1LL];

--- a/tests/cpp/test_scalar_hoisting.cpp
+++ b/tests/cpp/test_scalar_hoisting.cpp
@@ -388,11 +388,11 @@ __global__ void CUDAGeneratedKernel(int64_t i0, int64_t i1, int64_t i2, Tensor<i
   int64_t i8;
   i8 = (int64_t)(i7);
   #pragma unroll 1
-  for(nvfuser_index_t i9 = 0; i9 < i7; ++i9) {
+  for(nvfuser_index_t i9 = 0LL; i9 < i7; ++i9) {
     T0[i9] = (i0 + (i2 * i9));
   }
   #pragma unroll 1
-  for(nvfuser_index_t i10 = 0; i10 < i7; ++i10) {
+  for(nvfuser_index_t i10 = 0LL; i10 < i7; ++i10) {
     T1[i10] = i8;
   }
 }


### PR DESCRIPTION
Note that CudaCodeGenerator currently always starts a loop with 0 even if ForLoop::start_ is non-zero. I think this change is safe since only use case of non-zero start should be the epilogue loop of circular buffering. The concern of degenerate loop should not be applicable.