### PR TITLE
Host IRs: Fix for-loop test

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -194,8 +194,8 @@ void allConsumerValsOfHelper(
   if (visisted_vals.find(val) != visisted_vals.end()) {
     return;
   }
+  visisted_vals.insert(val);
   for (Val* consumer : ir_utils::consumerValsOf(val)) {
-    visisted_vals.insert(consumer);
     allConsumerValsOfHelper(consumer, visisted_vals);
   }
 }


### PR DESCRIPTION
# What
Fixes CI after merging #2584.
- [1st commit:](https://github.com/NVIDIA/Fuser/pull/2665/commits/60dc02ae15b4ceaa4f28079af9de057b25804292) This PR fixes the tests `HostIrTest.ForLoops/*` which were broken by merging #2584.
- [2nd commit:](https://github.com/NVIDIA/Fuser/pull/2665/commits/2e89f7b2b229732b6868cf3cac107a99951c80b8)This PR also fixes the test `OverlapTest.ReduceScatterBasedPipeliningHostIrImplementation`, where a typo was introduced in the implementation of `allConsumerValsOf` in [a commit right before](https://github.com/NVIDIA/Fuser/pull/2584/commits/c87084f4593d4a4ef1c946600d297d8342389007) merging #2584.

# How
The test case `HostIrTest.ForLoops/*` features an accumulation buffer. Reusing a buffer for accumulation should always be marked through I/O aliasing. Instead, we were emulating the aliasing by using the same `TensorView*` for `PostOnStream`'s I/O, i.e., for the fusion's I/O.

Since #2584 introduced the invalidation of for-loop's index's consumers, it would invalidate the aforementioned `TensorView*`, which also plays the role of the fusion's input: executing the fusion thus became impossible because it was missing concrete input.

With this patch, we don't use the same`TensorView*` to represent the fusion's input and output. Instead, we explicitly write the aliasing inside the Fusion, as it always should be. This is enough to fix the test.

cc @wujingyue: this is an exact illustration of the discussion we had [here](https://github.com/NVIDIA/Fuser/pull/2584#discussion_r1682268410), and a demonstration that our design supports reusing buffers through aliasing.