### PR TITLE
Host IRs: add `SelectOp`

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -267,6 +267,10 @@ void HostIrExecutor::handle(MatmulOp* matmul_op) {
   return handleWithExpressionEvaluator(matmul_op, expr_evaluator_);
 }
 
+void HostIrExecutor::handle(SelectOp* select_op) {
+  return handleWithExpressionEvaluator(select_op, expr_evaluator_);
+}
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -77,6 +77,7 @@ class HostIrExecutor final : public OptInDispatch {
   void handle(ForLoop* for_loop) override;
   void handle(SliceOp* slice_op) override;
   void handle(MatmulOp* matmul_op) override;
+  void handle(SelectOp* select_op) override;
 
   std::unique_ptr<HostIrContainer> container_;
   Communicator* communicator_;


### PR DESCRIPTION
# What 

Add `SelectOp` to `HostIrExecutor`

# Why

Will be used in reduce-scatter overlap technic #2584, to simplify and potentially improve perfs, cf [item 3 here](https://github.com/NVIDIA/Fuser/pull/2584#issuecomment-2238833771) 

# How

handle `SelectOp` through `ExpressionEvaluator`