### PR TITLE
The no-op scheduler clears memory space.

### DIFF
--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -118,6 +118,11 @@ void NoOpScheduler::schedule(Fusion* fusion) {
     return;
   }
 
+  // Make sure we don't have global memory set on intermediate tensors from
+  // fusion segmentation. Otherwise, the generated kernel may unnecessarily
+  // access intermediate buffers. See NoOpTest.ExpandedReduction.
+  scheduler_utils::clearMemorySpace(fusion);
+
   markAliases(fusion);
 }
 


### PR DESCRIPTION
I hit a serde error when I was working on #2639. This PR fixes that error. 

As a known limitation of serde, https://github.com/NVIDIA/Fuser/blob/446e24737cae95154aca5126a038a30b636ad512/csrc/kernel_cache.cpp#L1053-L1080 runs different code paths for default compilation and for deserialization. This usually leads to the same segmented fusion, but the added test case triggers an actual difference if without this PR. The default compilation path calls `findSegments`, which sets global memory type for attempted segment boundaries (via addInput/addOutput and removeInput/removeOutput). The deserialization path however doesn't call `findSegments`, so attempted segment boundaries remain local. As a result, `kernel->summary().global_allocations` is non-empty for default compilation and empty for deserialization. 

This PR resets memory space of intermediate tensors to local, and therefore makes the segmented fusion between the two paths the same. 