### PR TITLE
Run `preseg` before `schedule`.

### DIFF
--- a/benchmarks/cpp/matmul.cpp
+++ b/benchmarks/cpp/matmul.cpp
@@ -61,6 +61,8 @@ void setupMatmul(Fusion* fusion, MmaLayout layout, MatmulParams params) {
 
   fusion->addOutput(d);
 
+  preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(fusion);
+
   scheduleMatmul(fusion, params);
 }
 
@@ -160,8 +162,6 @@ static void SingleMatmulBase(
 
   // Define fusion graph
   setupMatmul(fusion, layout, params);
-
-  preseg_passes::OptimizationPass<preseg_passes::PreSegmenter>::runPass(fusion);
 
   KernelArgumentHolder args = KernelArgumentHolder::createKernelArgumentHolder(
       {inputs.first, inputs.second});


### PR DESCRIPTION
This fixes a potential problem that's exposed by #2639, and is AFAIK the right order of actions. We almost never run preseg passes after scheduling, except for multi-GPU.

I could combine this #2639 so the fix is shipped with a regression test. However, the fix seems to be straightforward enough to stand alone, making #2639 a bit smaller. I don't have a strong opinion -- let me know if you prefer the other way. 