### PR TITLE
Add an example to demonstrate schedule mismatching reshape

### DIFF
--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -170,9 +170,6 @@ ValGraph& IdModel::idGraph(IdMappingMode mode) {
 
 void IdModel::buildIterDomainDefinitionsAndUses() {
   for (const auto tv : tvs_) {
-    VectorOfUniqueEntries<IterDomain*> root_domain_ids{
-        tv->getMaybeRootDomain().begin(), tv->getMaybeRootDomain().end()};
-
     std::vector<IterDomain*> all_ids = tv->domain()->allIDs();
 
     // Check if this domain is a consumer of a view-like operation
@@ -201,7 +198,7 @@ void IdModel::buildIterDomainDefinitionsAndUses() {
 
       Expr* def = id->definition();
 
-      if (def == nullptr || root_domain_ids.has(id)) {
+      if (def == nullptr) {
         continue;
       }
 


### PR DESCRIPTION
Now, domains are no longer required to have a nice linear transformation from root domain to loop domain. We can take advantage of that and schedule reshape.