### PR TITLE
Refactor matmul tests

### DIFF
--- a/tests/cpp/test_gpu_tensorcore.cpp
+++ b/tests/cpp/test_gpu_tensorcore.cpp
@@ -55,7 +55,17 @@
 
 namespace nvfuser {
 
-using GPUTTensorCoreTest = NVFuserTest;
+using MatmulTest = NVFuserTest;
+
+class MatmulTestWithLayout : public NVFuserTest,
+                             public ::testing::WithParamInterface<MmaLayout> {
+ protected:
+  MmaLayout layout;
+  void SetUp() override {
+    layout = GetParam();
+    NVFuserTest::SetUp();
+  }
+};
 
 using namespace at::indexing;
 
@@ -71,294 +81,284 @@ using namespace at::indexing;
   }
 
 // Matmul test for Ampere MMA: across supported layouts
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmul_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmul) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
-    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+  auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+  auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+  auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-    fusion.addOutput(tv2);
+  fusion.addOutput(tv2);
 
-    MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 32);
-    gemm_tile.warp_tile = GemmTile(64, 64, 32);
-    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-    MatmulParams params;
-    params.supported_vec_size = {8, 8, 4};
-    params.mma_macro = MmaMacro::Ampere_16_8_16;
-    params.tile_sizes = gemm_tile;
-    params.async_gmem_load_operands = true;
-    params.circular_buffer_options.circular_buffer_smem_write = true;
-    params.circular_buffer_options.circular_buffer_smem_read = true;
-    params.circular_buffer_options.smem_circular_buffer_stage = 4;
-    scheduleMatmul(&fusion, params);
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.circular_buffer_options.circular_buffer_smem_write = true;
+  params.circular_buffer_options.circular_buffer_smem_read = true;
+  params.circular_buffer_options.smem_circular_buffer_stage = 4;
+  scheduleMatmul(&fusion, params);
 
-    auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+  auto inputs = matmulAtInput3DTuring(M, N, K, layout);
 
-    FusionExecutor fe;
-    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-        8,
-        0,
-        fe.compileFusion(
-            &fusion,
-            {inputs.first, inputs.second},
-            LaunchParams(),
-            matmul_cparams));
-    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-    auto tref = atMatmul(
-        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-  }
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(
+          &fusion,
+          {inputs.first, inputs.second},
+          LaunchParams(),
+          matmul_cparams));
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
-TEST_F(GPUTTensorCoreTest, FusionAmperePrologueFusionBroadcast_CUDA) {
+TEST_P(MatmulTestWithLayout, AmperePrologueFusionBroadcast) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
-    auto tv0 = makeContigTensor(2, DataType::Half);
-    auto tv1 = makeContigTensor(2, DataType::Half);
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  auto tv0 = makeContigTensor(2, DataType::Half);
+  auto tv1 = makeContigTensor(2, DataType::Half);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-    fusion.addOutput(tv2);
+  fusion.addOutput(tv2);
 
-    MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 32);
-    gemm_tile.warp_tile = GemmTile(64, 64, 32);
-    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-    MatmulParams params;
-    params.supported_vec_size = {8, 8, 4};
-    params.mma_macro = MmaMacro::Ampere_16_8_16;
-    params.tile_sizes = gemm_tile;
-    params.async_gmem_load_operands = true;
-    params.circular_buffer_options.circular_buffer_smem_write = true;
-    params.circular_buffer_options.circular_buffer_smem_read = true;
-    params.circular_buffer_options.smem_circular_buffer_stage = 4;
-    scheduleMatmul(&fusion, params);
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.circular_buffer_options.circular_buffer_smem_write = true;
+  params.circular_buffer_options.circular_buffer_smem_read = true;
+  params.circular_buffer_options.smem_circular_buffer_stage = 4;
+  scheduleMatmul(&fusion, params);
 
-    auto inputs = matmulAtInput2D(M, N, K, layout);
+  auto inputs = matmulAtInput2D(M, N, K, layout);
 
-    FusionExecutor fe;
-    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-        8,
-        0,
-        fe.compileFusion(
-            &fusion,
-            {inputs.first, inputs.second},
-            LaunchParams(),
-            matmul_cparams));
-    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-    auto tref = atMatmul(
-        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-  }
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(
+          &fusion,
+          {inputs.first, inputs.second},
+          LaunchParams(),
+          matmul_cparams));
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
-TEST_F(GPUTTensorCoreTest, FusionAmpereProloguePointwise_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereProloguePointwise) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
-    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+  auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+  auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+  auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv0 = castOp(DataType::Half, sin(tv0));
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    tv1 = castOp(DataType::Half, sin(tv1));
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv0 = castOp(DataType::Half, sin(tv0));
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  tv1 = castOp(DataType::Half, sin(tv1));
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-    fusion.addOutput(tv2);
+  fusion.addOutput(tv2);
 
-    MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 32);
-    gemm_tile.warp_tile = GemmTile(64, 64, 32);
-    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-    MatmulParams params;
-    params.supported_vec_size = {8, 8, 4};
-    params.mma_macro = MmaMacro::Ampere_16_8_16;
-    params.tile_sizes = gemm_tile;
-    params.async_gmem_load_operands = true;
-    params.circular_buffer_options.circular_buffer_smem_write = true;
-    params.circular_buffer_options.circular_buffer_smem_read = true;
-    params.circular_buffer_options.smem_circular_buffer_stage = 4;
-    scheduleMatmul(&fusion, params);
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.circular_buffer_options.circular_buffer_smem_write = true;
+  params.circular_buffer_options.circular_buffer_smem_read = true;
+  params.circular_buffer_options.smem_circular_buffer_stage = 4;
+  scheduleMatmul(&fusion, params);
 
-    auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+  auto inputs = matmulAtInput3DTuring(M, N, K, layout);
 
-    FusionExecutor fe;
-    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-        8,
-        0,
-        fe.compileFusion(
-            &fusion,
-            {inputs.first, inputs.second},
-            LaunchParams(),
-            matmul_cparams));
-    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-    auto tref = atMatmul(
-        inputs.first.sin().to(at::kFloat),
-        inputs.second.sin().to(at::kFloat),
-        layout);
-    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-  }
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(
+          &fusion,
+          {inputs.first, inputs.second},
+          LaunchParams(),
+          matmul_cparams));
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.sin().to(at::kFloat),
+      inputs.second.sin().to(at::kFloat),
+      layout);
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulBFloat16_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmulBFloat16) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
-    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+  auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::BFloat16);
-    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::BFloat16);
+  auto tv0 = makeContigConcreteTensor(shapes.first, DataType::BFloat16);
+  auto tv1 = makeContigConcreteTensor(shapes.second, DataType::BFloat16);
 
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-    fusion.addOutput(tv2);
+  fusion.addOutput(tv2);
 
-    MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 32);
-    gemm_tile.warp_tile = GemmTile(64, 64, 32);
-    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-    MatmulParams params;
-    params.supported_vec_size = {8, 8, 4};
-    params.mma_macro = MmaMacro::Ampere_16_8_16;
-    params.tile_sizes = gemm_tile;
-    params.async_gmem_load_operands = true;
-    params.circular_buffer_options.circular_buffer_smem_write = true;
-    params.circular_buffer_options.circular_buffer_smem_read = true;
-    params.circular_buffer_options.smem_circular_buffer_stage = 4;
-    scheduleMatmul(&fusion, params);
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.circular_buffer_options.circular_buffer_smem_write = true;
+  params.circular_buffer_options.circular_buffer_smem_read = true;
+  params.circular_buffer_options.smem_circular_buffer_stage = 4;
+  scheduleMatmul(&fusion, params);
 
-    auto inputs = matmulAtInput3DTuring(M, N, K, layout, at::kBFloat16);
+  auto inputs = matmulAtInput3DTuring(M, N, K, layout, at::kBFloat16);
 
-    FusionExecutor fe;
-    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-        8,
-        0,
-        fe.compileFusion(
-            &fusion,
-            {inputs.first, inputs.second},
-            LaunchParams(),
-            matmul_cparams));
-    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-    auto tref = atMatmul(
-        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-  }
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(
+          &fusion,
+          {inputs.first, inputs.second},
+          LaunchParams(),
+          matmul_cparams));
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 // Matmul test for Ampere MMA: with pipelined gmem load
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulPipelineGmem_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmulPipelineGmem) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
   REQUIRE_DEVICE_SMEM_SIZE(70 << 10, 0);
 
   // Gmem pipeline stage
   for (auto stage : {3, 4}) {
-    for (auto layout : kAllSupportedMmaLayout) {
-      Fusion fusion;
-      FusionGuard fg(&fusion);
+    Fusion fusion;
+    FusionGuard fg(&fusion);
 
-      auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-      auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-      auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
-      fusion.addInput(tv0);
-      fusion.addInput(tv1);
+    fusion.addInput(tv0);
+    fusion.addInput(tv1);
 
-      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-      auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-      fusion.addOutput(tv2);
+    fusion.addOutput(tv2);
 
-      MatMulTileOptions gemm_tile;
-      gemm_tile.cta_tile = GemmTile(128, 128, 32);
-      gemm_tile.warp_tile = GemmTile(64, 64, 32);
-      gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+    MatMulTileOptions gemm_tile;
+    gemm_tile.cta_tile = GemmTile(128, 128, 32);
+    gemm_tile.warp_tile = GemmTile(64, 64, 32);
+    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-      MatmulParams params;
-      params.supported_vec_size = {8, 8, 4};
-      params.mma_macro = MmaMacro::Ampere_16_8_16;
-      params.tile_sizes = gemm_tile;
-      params.tile_sizes = gemm_tile;
-      params.async_gmem_load_operands = true;
-      params.circular_buffer_options.circular_buffer_smem_write = true;
-      params.circular_buffer_options.smem_circular_buffer_stage = stage;
-      scheduleMatmul(&fusion, params);
+    MatmulParams params;
+    params.supported_vec_size = {8, 8, 4};
+    params.mma_macro = MmaMacro::Ampere_16_8_16;
+    params.tile_sizes = gemm_tile;
+    params.tile_sizes = gemm_tile;
+    params.async_gmem_load_operands = true;
+    params.circular_buffer_options.circular_buffer_smem_write = true;
+    params.circular_buffer_options.smem_circular_buffer_stage = stage;
+    scheduleMatmul(&fusion, params);
 
-      auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+    auto inputs = matmulAtInput3DTuring(M, N, K, layout);
 
-      FusionExecutor fe;
-      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-          8,
-          0,
-          fe.compileFusion(
-              &fusion,
-              {inputs.first, inputs.second},
-              LaunchParams(),
-              matmul_cparams));
-      ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-      auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-      auto tref = atMatmul(
-          inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-      NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-    }
+    FusionExecutor fe;
+    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+        8,
+        0,
+        fe.compileFusion(
+            &fusion,
+            {inputs.first, inputs.second},
+            LaunchParams(),
+            matmul_cparams));
+    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+    auto tref = atMatmul(
+        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
 // Matmul test for Ampere MMA: checking CTA Swizzles
-TEST_F(GPUTTensorCoreTest, FusionAmpereSwizzle_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereSwizzle) {
   // Keep multiples of 8 to keep vectorizable.
   int dim = 8192;
   int M = dim, N = dim, K = dim;
@@ -480,83 +480,79 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereSwizzle_CUDA) {
   };
 
   // Checking only a single layout to keep runtime short (compilation overhead)
-  for (auto layout : {MmaLayout::TT}) {
-    for (auto order : all_orders) {
-      float runtime1 = 0;
-      test(layout, order, 1, runtime1);
+  for (auto order : all_orders) {
+    float runtime1 = 0;
+    test(layout, order, 1, runtime1);
 
-      float runtime4 = 0;
-      test(layout, order, 4, runtime4);
+    float runtime4 = 0;
+    test(layout, order, 4, runtime4);
 
-      // GRID Swizzle requires further changes to work in main. So for now we
-      // don't assert the perf benefit here.
-      // NVF_CHECK(runtime4 < runtime1);
-    }
+    // GRID Swizzle requires further changes to work in main. So for now we
+    // don't assert the perf benefit here.
+    // NVF_CHECK(runtime4 < runtime1);
   }
 }
 
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulRegCircularBuffer_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmulRegCircularBuffer) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
   REQUIRE_DEVICE_SMEM_SIZE(70 << 10, 0);
 
   // Gmem pipeline stage
   for (auto stage : {3, 4}) {
-    for (auto layout : kAllSupportedMmaLayout) {
-      Fusion fusion;
-      FusionGuard fg(&fusion);
+    Fusion fusion;
+    FusionGuard fg(&fusion);
 
-      auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-      auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-      auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
-      fusion.addInput(tv0);
-      fusion.addInput(tv1);
+    fusion.addInput(tv0);
+    fusion.addInput(tv1);
 
-      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-      auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-      fusion.addOutput(tv2);
+    fusion.addOutput(tv2);
 
-      MatMulTileOptions gemm_tile;
-      gemm_tile.cta_tile = GemmTile(128, 128, 32);
-      gemm_tile.warp_tile = GemmTile(64, 64, 32);
-      gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+    MatMulTileOptions gemm_tile;
+    gemm_tile.cta_tile = GemmTile(128, 128, 32);
+    gemm_tile.warp_tile = GemmTile(64, 64, 32);
+    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-      MatmulParams params;
-      params.supported_vec_size = {8, 8, 4};
-      params.mma_macro = MmaMacro::Ampere_16_8_16;
-      params.tile_sizes = gemm_tile;
-      params.async_gmem_load_operands = true;
-      params.circular_buffer_options.circular_buffer_smem_write = true;
-      params.circular_buffer_options.smem_circular_buffer_stage = stage;
-      params.circular_buffer_options.circular_buffer_smem_read = true;
-      scheduleMatmul(&fusion, params);
+    MatmulParams params;
+    params.supported_vec_size = {8, 8, 4};
+    params.mma_macro = MmaMacro::Ampere_16_8_16;
+    params.tile_sizes = gemm_tile;
+    params.async_gmem_load_operands = true;
+    params.circular_buffer_options.circular_buffer_smem_write = true;
+    params.circular_buffer_options.smem_circular_buffer_stage = stage;
+    params.circular_buffer_options.circular_buffer_smem_read = true;
+    scheduleMatmul(&fusion, params);
 
-      auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+    auto inputs = matmulAtInput3DTuring(M, N, K, layout);
 
-      FusionExecutor fe;
-      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-          8,
-          0,
-          fe.compileFusion(
-              &fusion,
-              {inputs.first, inputs.second},
-              LaunchParams(),
-              matmul_cparams));
-      ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-      auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-      auto tref = atMatmul(
-          inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-      NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-    }
+    FusionExecutor fe;
+    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+        8,
+        0,
+        fe.compileFusion(
+            &fusion,
+            {inputs.first, inputs.second},
+            LaunchParams(),
+            matmul_cparams));
+    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+    auto tref = atMatmul(
+        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
 // Matmul-Matmul fusion test on Ampere
-TEST_F(GPUTTensorCoreTest, FusionMatmulMatmulAmpere_CUDA) {
+TEST_F(MatmulTest, MatmulMatmulAmpere) {
   NVFUSER_TEST_CUDA_ARCH_GUARD(8, 0);
 
   Fusion fusion;
@@ -817,7 +813,7 @@ TEST_F(GPUTTensorCoreTest, FusionMatmulMatmulAmpere_CUDA) {
 
 // Simplified Matmul-Softmax-Matmul test on Ampere
 //   (To be extended in follow ups)
-TEST_F(GPUTTensorCoreTest, FusionMatmulSoftmaxMatmulAmpere_CUDA) {
+TEST_F(MatmulTest, MatmulSoftmaxMatmulAmpere) {
   NVFUSER_TEST_CUDA_ARCH_GUARD(8, 0);
 
   Fusion fusion;
@@ -1180,54 +1176,52 @@ TEST_F(GPUTTensorCoreTest, FusionMatmulSoftmaxMatmulAmpere_CUDA) {
 }
 
 // Matmul test for Turing MMA: across supported layouts
-TEST_F(GPUTTensorCoreTest, FusionTuringMatmul_CUDA) {
+TEST_P(MatmulTestWithLayout, TuringMatmul) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
-    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+  auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+  auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+  auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-    fusion.addOutput(tv2);
+  fusion.addOutput(tv2);
 
-    MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 32);
-    gemm_tile.warp_tile = GemmTile(64, 64, 32);
-    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-    MatmulParams params;
-    params.supported_vec_size = {8, 8, 4};
-    params.mma_macro = MmaMacro::Turing_16_8_16;
-    params.tile_sizes = gemm_tile;
-    scheduleMatmul(&fusion, params);
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Turing_16_8_16;
+  params.tile_sizes = gemm_tile;
+  scheduleMatmul(&fusion, params);
 
-    auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+  auto inputs = matmulAtInput3DTuring(M, N, K, layout);
 
-    FusionExecutor fe;
-    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-        7, 5, fe.compileFusion(&fusion, {inputs.first, inputs.second}));
-    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-    auto tref = atMatmul(
-        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-  }
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      7, 5, fe.compileFusion(&fusion, {inputs.first, inputs.second}));
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 // Matmul test on ampere, using ampere memory ops
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTNcpAsync_CUDA) {
+TEST_F(MatmulTest, AmpereMatmulTNCpAsync) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -1362,7 +1356,7 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTNcpAsync_CUDA) {
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
-TEST_F(GPUTTensorCoreTest, FusionAmpereStridedBatchedMatmulTN_CUDA) {
+TEST_F(MatmulTest, AmpereStridedBatchedMatmulTN) {
   NVFUSER_TEST_CUDA_ARCH_GUARD(8, 0);
 
   Fusion fusion;
@@ -1532,7 +1526,7 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereStridedBatchedMatmulTN_CUDA) {
 }
 
 // Matmul test on Ampere with a reshape on prolog
-TEST_F(GPUTTensorCoreTest, FusionAmpereViewMatmulTN_CUDA) {
+TEST_F(MatmulTest, AmpereViewMatmulTN) {
   NVFUSER_TEST_CUDA_ARCH_GUARD(8, 0);
 
   Fusion fusion;
@@ -1687,7 +1681,7 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereViewMatmulTN_CUDA) {
 
 // Test an end-to-end matmul case with swizzled smem
 // data layout.
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTNSwizzled_CUDA) {
+TEST_F(MatmulTest, AmpereMatmulTNSwizzled) {
   NVFUSER_TEST_CUDA_ARCH_GUARD(8, 0);
 
   Fusion fusion;
@@ -1858,271 +1852,119 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTNSwizzled_CUDA) {
 }
 
 // Matmul test on Ampere using ldmatrix.x4 to load operands
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulLargeLoad_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmulLargeLoad) {
   REQUIRE_DEVICE_SMEM_SIZE(98384, 0);
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
-    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+  auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+  auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+  auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-    fusion.addOutput(tv2);
+  fusion.addOutput(tv2);
 
-    MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 64);
-    gemm_tile.warp_tile = GemmTile(64, 64, 64);
-    gemm_tile.instruction_tile = GemmTile(16, 16, 16);
-    MatmulParams params;
-    params.supported_vec_size = {8, 8, 4};
-    params.mma_macro = MmaMacro::Ampere_16_16_16;
-    params.tile_sizes = gemm_tile;
-    params.async_gmem_load_operands = true;
-    params.circular_buffer_options.circular_buffer_smem_write = true;
-    params.circular_buffer_options.circular_buffer_smem_read = true;
-    params.circular_buffer_options.smem_circular_buffer_stage = 3;
-    scheduleMatmul(&fusion, params);
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 64);
+  gemm_tile.warp_tile = GemmTile(64, 64, 64);
+  gemm_tile.instruction_tile = GemmTile(16, 16, 16);
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_16_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.circular_buffer_options.circular_buffer_smem_write = true;
+  params.circular_buffer_options.circular_buffer_smem_read = true;
+  params.circular_buffer_options.smem_circular_buffer_stage = 3;
+  scheduleMatmul(&fusion, params);
 
-    auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+  auto inputs = matmulAtInput3DTuring(M, N, K, layout);
 
-    FusionExecutor fe;
-    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-        8,
-        0,
-        fe.compileFusion(
-            &fusion,
-            {inputs.first, inputs.second},
-            LaunchParams(),
-            matmul_cparams));
-    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-    auto tref = atMatmul(
-        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-  }
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(
+          &fusion,
+          {inputs.first, inputs.second},
+          LaunchParams(),
+          matmul_cparams));
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 // Matmul test for Turing MMA: across supported layouts
-TEST_F(GPUTTensorCoreTest, FusionTuringMatmulLargeLoad_CUDA) {
+TEST_P(MatmulTestWithLayout, TuringMatmulLargeLoad) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
-    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+  auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+  auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+  auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-    fusion.addOutput(tv2);
+  fusion.addOutput(tv2);
 
-    MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 32);
-    gemm_tile.warp_tile = GemmTile(64, 64, 32);
-    gemm_tile.instruction_tile = GemmTile(16, 16, 16);
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 16, 16);
 
-    MatmulParams params;
-    params.supported_vec_size = {8, 8, 4};
-    params.mma_macro = MmaMacro::Turing_16_16_16;
-    params.tile_sizes = gemm_tile;
-    scheduleMatmul(&fusion, params);
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Turing_16_16_16;
+  params.tile_sizes = gemm_tile;
+  scheduleMatmul(&fusion, params);
 
-    auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+  auto inputs = matmulAtInput3DTuring(M, N, K, layout);
 
-    FusionExecutor fe;
-    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-        7,
-        5,
-        fe.compileFusion(
-            &fusion,
-            {inputs.first, inputs.second},
-            LaunchParams(),
-            matmul_cparams));
-    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-    auto tref = atMatmul(
-        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-  }
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      7,
+      5,
+      fe.compileFusion(
+          &fusion,
+          {inputs.first, inputs.second},
+          LaunchParams(),
+          matmul_cparams));
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
 // Tile layout check for symmetric 4-warp recipes
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTileCheck4warp_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmulTileCheck4warp) {
   REQUIRE_DEVICE_SMEM_SIZE(98384, 0);
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
-  for (auto layout : kAllSupportedMmaLayout) {
-    // Symmetric tile with 16x16x16 macro,
-    //  supports mn_size of multiple of 32,
-    //  and k size multiple of 16.
-    for (int mn_size : {32, 64, 96, 128, 160, 192}) {
-      for (int k_size : {32, 48, 64}) {
-        Fusion fusion;
-        FusionGuard fg(&fusion);
-
-        auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
-
-        auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-        auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
-
-        fusion.addInput(tv0);
-        fusion.addInput(tv1);
-
-        tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-        tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-        auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
-
-        fusion.addOutput(tv2);
-
-        MatMulTileOptions gemm_tile;
-        gemm_tile.cta_tile = GemmTile(mn_size, mn_size, k_size);
-        gemm_tile.warp_tile = GemmTile(mn_size / 2, mn_size / 2, k_size);
-        gemm_tile.instruction_tile = GemmTile(16, 16, 16);
-
-        MatmulParams params;
-        params.supported_vec_size = {8, 8, 4};
-        params.mma_macro = MmaMacro::Ampere_16_16_16;
-        params.tile_sizes = gemm_tile;
-        params.async_gmem_load_operands = true;
-        params.circular_buffer_options.circular_buffer_smem_write = true;
-        mma_utils::MmaDataTypes data_types = {
-            DataType::Half, DataType::Half, DataType::Float};
-        std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
-            mma_utils::generateSharedMemoryEpilogueHeuristics(
-                gemm_tile,
-                params.circular_buffer_options.smem_circular_buffer_stage,
-                data_types,
-                true,
-                true);
-        scheduleMatmul(&fusion, params);
-
-        auto inputs = matmulAtInput3DTuring(M, N, K, layout);
-
-        FusionExecutor fe;
-        NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-            8,
-            0,
-            fe.compileFusion(
-                &fusion,
-                {inputs.first, inputs.second},
-                LaunchParams(),
-                matmul_cparams));
-        EXPECT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-        auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-        auto tref = atMatmul(
-            inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-        NVF_CHECK(
-            cg_outputs[0].allclose(tref, 0.0001, 0.0001),
-            "error :",
-            (cg_outputs[0] - tref).abs().max(),
-            "tile dim:",
-            mn_size,
-            " ",
-            k_size);
-      }
-    }
-  }
-}
-
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTileCheck8warp_CUDA) {
-  REQUIRE_DEVICE_SMEM_SIZE(98384, 0);
-  // Keep multiples of 8 to keep vectorizable.
-  int M = 504, N = 136, K = 248;
-  for (auto layout : kAllSupportedMmaLayout) {
-    // ASymmetric tile with 16x16x16 macro,
-    for (int m_size : {256}) {
-      for (int n_size : {32, 64, 96, 128}) {
-        for (int k_size : {32, 48, 64}) {
-          Fusion fusion;
-          FusionGuard fg(&fusion);
-
-          auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
-
-          auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-          auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
-
-          fusion.addInput(tv0);
-          fusion.addInput(tv1);
-
-          tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-          tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-          auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
-
-          fusion.addOutput(tv2);
-
-          MatMulTileOptions gemm_tile;
-          gemm_tile.cta_tile = GemmTile(m_size, n_size, k_size);
-          gemm_tile.warp_tile = GemmTile(m_size / 4, n_size / 2, k_size);
-          gemm_tile.instruction_tile = GemmTile(16, 16, 16);
-
-          MatmulParams params;
-          params.supported_vec_size = {8, 8, 4};
-          params.mma_macro = MmaMacro::Ampere_16_16_16;
-          params.tile_sizes = gemm_tile;
-          params.async_gmem_load_operands = true;
-          params.circular_buffer_options.circular_buffer_smem_write = true;
-          params.circular_buffer_options.circular_buffer_smem_read = true;
-          params.circular_buffer_options.smem_circular_buffer_stage = 2;
-          mma_utils::MmaDataTypes data_types = {
-              DataType::Half, DataType::Half, DataType::Float};
-          std::tie(
-              params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
-              mma_utils::generateSharedMemoryEpilogueHeuristics(
-                  gemm_tile,
-                  params.circular_buffer_options.smem_circular_buffer_stage,
-                  data_types);
-
-          scheduleMatmul(&fusion, params);
-
-          auto inputs = matmulAtInput3DTuring(M, N, K, layout);
-
-          FusionExecutor fe;
-          NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-              8,
-              0,
-              fe.compileFusion(
-                  &fusion,
-                  {inputs.first, inputs.second},
-                  LaunchParams(),
-                  matmul_cparams));
-          ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-          auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-          auto tref = atMatmul(
-              inputs.first.to(at::kFloat),
-              inputs.second.to(at::kFloat),
-              layout);
-          NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-        }
-      }
-    }
-  }
-}
-
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTileCheck6warp_CUDA) {
-  REQUIRE_DEVICE_SMEM_SIZE(98384, 0);
-  // Keep multiples of 8 to keep vectorizable.
-  int M = 504, N = 136, K = 248;
-  for (auto layout : kAllSupportedMmaLayout) {
+  // Symmetric tile with 16x16x16 macro,
+  //  supports mn_size of multiple of 32,
+  //  and k size multiple of 16.
+  for (int mn_size : {32, 64, 96, 128, 160, 192}) {
     for (int k_size : {32, 48, 64}) {
       Fusion fusion;
       FusionGuard fg(&fusion);
@@ -2142,9 +1984,8 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTileCheck6warp_CUDA) {
       fusion.addOutput(tv2);
 
       MatMulTileOptions gemm_tile;
-      // 2 warp by 3 warp
-      gemm_tile.cta_tile = GemmTile(192, 128, k_size);
-      gemm_tile.warp_tile = GemmTile(64, 64, k_size);
+      gemm_tile.cta_tile = GemmTile(mn_size, mn_size, k_size);
+      gemm_tile.warp_tile = GemmTile(mn_size / 2, mn_size / 2, k_size);
       gemm_tile.instruction_tile = GemmTile(16, 16, 16);
 
       MatmulParams params;
@@ -2153,15 +1994,15 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTileCheck6warp_CUDA) {
       params.tile_sizes = gemm_tile;
       params.async_gmem_load_operands = true;
       params.circular_buffer_options.circular_buffer_smem_write = true;
-      params.circular_buffer_options.circular_buffer_smem_read = true;
-      params.circular_buffer_options.smem_circular_buffer_stage = 2;
       mma_utils::MmaDataTypes data_types = {
           DataType::Half, DataType::Half, DataType::Float};
       std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
           mma_utils::generateSharedMemoryEpilogueHeuristics(
               gemm_tile,
               params.circular_buffer_options.smem_circular_buffer_stage,
-              data_types);
+              data_types,
+              true,
+              true);
       scheduleMatmul(&fusion, params);
 
       auto inputs = matmulAtInput3DTuring(M, N, K, layout);
@@ -2175,20 +2016,96 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulTileCheck6warp_CUDA) {
               {inputs.first, inputs.second},
               LaunchParams(),
               matmul_cparams));
-      ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+      EXPECT_TRUE(getBankConflictInfo(fe.kernel()).empty());
       auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
       auto tref = atMatmul(
           inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-      NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+      NVF_CHECK(
+          cg_outputs[0].allclose(tref, 0.0001, 0.0001),
+          "error :",
+          (cg_outputs[0] - tref).abs().max(),
+          "tile dim:",
+          mn_size,
+          " ",
+          k_size);
     }
   }
 }
 
-// Matmul test on Ampere using ldmatrix.x4 to load operands
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulLargeLoadLargeK_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmulTileCheck8warp) {
+  REQUIRE_DEVICE_SMEM_SIZE(98384, 0);
   // Keep multiples of 8 to keep vectorizable.
-  int M = 504, N = 136, K = 2048;
-  for (auto layout : kAllSupportedMmaLayout) {
+  int M = 504, N = 136, K = 248;
+  // ASymmetric tile with 16x16x16 macro,
+  for (int m_size : {256}) {
+    for (int n_size : {32, 64, 96, 128}) {
+      for (int k_size : {32, 48, 64}) {
+        Fusion fusion;
+        FusionGuard fg(&fusion);
+
+        auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+
+        auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+        auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+
+        fusion.addInput(tv0);
+        fusion.addInput(tv1);
+
+        tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+        tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+        auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+
+        fusion.addOutput(tv2);
+
+        MatMulTileOptions gemm_tile;
+        gemm_tile.cta_tile = GemmTile(m_size, n_size, k_size);
+        gemm_tile.warp_tile = GemmTile(m_size / 4, n_size / 2, k_size);
+        gemm_tile.instruction_tile = GemmTile(16, 16, 16);
+
+        MatmulParams params;
+        params.supported_vec_size = {8, 8, 4};
+        params.mma_macro = MmaMacro::Ampere_16_16_16;
+        params.tile_sizes = gemm_tile;
+        params.async_gmem_load_operands = true;
+        params.circular_buffer_options.circular_buffer_smem_write = true;
+        params.circular_buffer_options.circular_buffer_smem_read = true;
+        params.circular_buffer_options.smem_circular_buffer_stage = 2;
+        mma_utils::MmaDataTypes data_types = {
+            DataType::Half, DataType::Half, DataType::Float};
+        std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
+            mma_utils::generateSharedMemoryEpilogueHeuristics(
+                gemm_tile,
+                params.circular_buffer_options.smem_circular_buffer_stage,
+                data_types);
+
+        scheduleMatmul(&fusion, params);
+
+        auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+
+        FusionExecutor fe;
+        NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+            8,
+            0,
+            fe.compileFusion(
+                &fusion,
+                {inputs.first, inputs.second},
+                LaunchParams(),
+                matmul_cparams));
+        ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+        auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+        auto tref = atMatmul(
+            inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+        NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+      }
+    }
+  }
+}
+
+TEST_P(MatmulTestWithLayout, AmpereMatmulTileCheck6warp) {
+  REQUIRE_DEVICE_SMEM_SIZE(98384, 0);
+  // Keep multiples of 8 to keep vectorizable.
+  int M = 504, N = 136, K = 248;
+  for (int k_size : {32, 48, 64}) {
     Fusion fusion;
     FusionGuard fg(&fusion);
 
@@ -2207,8 +2124,9 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulLargeLoadLargeK_CUDA) {
     fusion.addOutput(tv2);
 
     MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 64);
-    gemm_tile.warp_tile = GemmTile(64, 64, 64);
+    // 2 warp by 3 warp
+    gemm_tile.cta_tile = GemmTile(192, 128, k_size);
+    gemm_tile.warp_tile = GemmTile(64, 64, k_size);
     gemm_tile.instruction_tile = GemmTile(16, 16, 16);
 
     MatmulParams params;
@@ -2218,7 +2136,14 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulLargeLoadLargeK_CUDA) {
     params.async_gmem_load_operands = true;
     params.circular_buffer_options.circular_buffer_smem_write = true;
     params.circular_buffer_options.circular_buffer_smem_read = true;
-    params.circular_buffer_options.smem_circular_buffer_stage = 3;
+    params.circular_buffer_options.smem_circular_buffer_stage = 2;
+    mma_utils::MmaDataTypes data_types = {
+        DataType::Half, DataType::Half, DataType::Float};
+    std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
+        mma_utils::generateSharedMemoryEpilogueHeuristics(
+            gemm_tile,
+            params.circular_buffer_options.smem_circular_buffer_stage,
+            data_types);
     scheduleMatmul(&fusion, params);
 
     auto inputs = matmulAtInput3DTuring(M, N, K, layout);
@@ -2236,20 +2161,129 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulLargeLoadLargeK_CUDA) {
     auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    NVF_CHECK(cg_outputs[0].allclose(tref, 0.001, 0.001));
+    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
   }
 }
 
+// Matmul test on Ampere using ldmatrix.x4 to load operands
+TEST_P(MatmulTestWithLayout, AmpereMatmulLargeLoadLargeK) {
+  // Keep multiples of 8 to keep vectorizable.
+  int M = 504, N = 136, K = 2048;
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+
+  auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+  auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+
+  fusion.addOutput(tv2);
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 64);
+  gemm_tile.warp_tile = GemmTile(64, 64, 64);
+  gemm_tile.instruction_tile = GemmTile(16, 16, 16);
+
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_16_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.circular_buffer_options.circular_buffer_smem_write = true;
+  params.circular_buffer_options.circular_buffer_smem_read = true;
+  params.circular_buffer_options.smem_circular_buffer_stage = 3;
+  scheduleMatmul(&fusion, params);
+
+  auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(
+          &fusion,
+          {inputs.first, inputs.second},
+          LaunchParams(),
+          matmul_cparams));
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.001, 0.001));
+}
+
 // Matmul test for Ampere MMA: across supported layouts
-TEST_F(GPUTTensorCoreTest, FusionAmpereSplitKLikeStridedBatchedMatmul_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereSplitKLikeStridedBatchedMatmul) {
   // Keep multiples of 8 to keep vectorizable.
   int B = 2, M = 504, N = 136, K = 248;
 
-  for (auto layout : kAllSupportedMmaLayout) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  auto tv0 = makeContigTensor(3, DataType::Half);
+  auto tv1 = makeContigTensor(3, DataType::Half);
+
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+
+  fusion.addOutput(tv2);
+
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.circular_buffer_options.circular_buffer_smem_write = true;
+  params.circular_buffer_options.circular_buffer_smem_read = true;
+  params.circular_buffer_options.smem_circular_buffer_stage = 4;
+  scheduleMatmul(&fusion, params);
+
+  auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
+  auto t1 = matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
+
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  auto cg_outputs = fe.runFusion({t0, t1});
+  auto tref = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
+}
+
+TEST_P(MatmulTestWithLayout, AmpereMatmulSmemEpilogue) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
+  constexpr bool ignore_occupancy_drop = true;
+  // Keep multiples of 8 to keep vectorizable.
+  int M = 4096, N = 4096, K = 4096;
+  // This tests num_stages=0, which should be treated identically to
+  // num_stages=1. It is put here to exercise this path to ensure we don't
+  // crash in generateSharedMemoryEpilogueHeuristics.
+  // See https://github.com/NVIDIA/Fuser/pull/1917 for more info
+  for (int num_stages : {0, 2}) {
     Fusion fusion;
     FusionGuard fg(&fusion);
-    auto tv0 = makeContigTensor(3, DataType::Half);
-    auto tv1 = makeContigTensor(3, DataType::Half);
+
+    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+
+    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
     fusion.addInput(tv0);
     fusion.addInput(tv1);
@@ -2260,9 +2294,14 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereSplitKLikeStridedBatchedMatmul_CUDA) {
 
     fusion.addOutput(tv2);
 
+    // The settings of cta_tile, warp_tile, and smem_circular_buffer_stage
+    // have been purposefully selected to produce a constant occupancy of 25%.
+    // This allows us to effectively evaluate the influence of the
+    // use_smem_epilogue parameter on performance, since changing its value to
+    // either true or false will not affect the occupancy rate.
     MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 32);
-    gemm_tile.warp_tile = GemmTile(64, 64, 32);
+    gemm_tile.cta_tile = GemmTile(64, 128, 32);
+    gemm_tile.warp_tile = GemmTile(32, 32, 32);
     gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
     MatmulParams params;
@@ -2270,172 +2309,104 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereSplitKLikeStridedBatchedMatmul_CUDA) {
     params.mma_macro = MmaMacro::Ampere_16_8_16;
     params.tile_sizes = gemm_tile;
     params.async_gmem_load_operands = true;
-    params.circular_buffer_options.circular_buffer_smem_write = true;
-    params.circular_buffer_options.circular_buffer_smem_read = true;
-    params.circular_buffer_options.smem_circular_buffer_stage = 4;
+    params.circular_buffer_options.circular_buffer_smem_write = num_stages > 1;
+    params.circular_buffer_options.circular_buffer_smem_read = num_stages > 1;
+    params.circular_buffer_options.smem_circular_buffer_stage = num_stages;
+    mma_utils::MmaDataTypes data_types = {
+        DataType::Half, DataType::Half, DataType::Float};
+    std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
+        mma_utils::generateSharedMemoryEpilogueHeuristics(
+            gemm_tile,
+            params.circular_buffer_options.smem_circular_buffer_stage,
+            data_types,
+            ignore_occupancy_drop);
     scheduleMatmul(&fusion, params);
 
-    auto t0 =
-        matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
-    auto t1 =
-        matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
+    // If use_smem_epilogue is true, there should be 3 shared memory tensors 2
+    // for prologue and 1 for epilogue.
+    int num_shared_mem_tensors = 0;
+    int expected_num_shared_mem_tensors = params.use_smem_epilogue ? 3 : 2;
+    for (const auto& tv : ir_utils::allTvs(&fusion)) {
+      if (tv->getMemoryType() == MemoryType::Shared) {
+        num_shared_mem_tensors++;
+      }
+    }
+    NVF_CHECK(
+        num_shared_mem_tensors == expected_num_shared_mem_tensors,
+        "Number of shared memory tensors doesn't match!",
+        "Expected: ",
+        expected_num_shared_mem_tensors,
+        ", Got: ",
+        num_shared_mem_tensors);
+
+    at::manual_seed(0);
+    auto inputs = matmulAtInput3DTuring(M, N, K, layout);
 
     FusionExecutor fe;
     NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
         8,
         0,
-        fe.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
+        fe.compileFusion(
+            &fusion,
+            {inputs.first, inputs.second},
+            LaunchParams(),
+            matmul_cparams));
+    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+    auto tref = atMatmul(
+        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+
+    // check bank conflicts
     ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    auto cg_outputs = fe.runFusion({t0, t1});
-    auto tref =
-        splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
-    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-  }
-}
+    // (0.001, 0.001) passed on local A100 but failed on CI A100
+    NVF_CHECK(
+        cg_outputs[0].allclose(tref, 0.01, 0.01),
+        "Result validation failed. Max diff: ",
+        (cg_outputs[0] - tref).abs().max());
 
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSmemEpilogue_CUDA) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
-  constexpr bool ignore_occupancy_drop = true;
-  // Keep multiples of 8 to keep vectorizable.
-  int M = 4096, N = 4096, K = 4096;
-  // This tests num_stages=0, which should be treated identically to
-  // num_stages=1. It is put here to exercise this path to ensure we don't
-  // crash in generateSharedMemoryEpilogueHeuristics.
-  // See https://github.com/NVIDIA/Fuser/pull/1917 for more info
-  for (int num_stages : {0, 2}) {
-    for (auto layout : kAllSupportedMmaLayout) {
-      Fusion fusion;
-      FusionGuard fg(&fusion);
+    if (!params.use_smem_epilogue) {
+      GTEST_SKIP()
+          << "Test conducted without utilizing shared memory epilogue due to the device's constrained shared memory capacity.";
+    }
 
-      auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
-
-      auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-      auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
-
-      fusion.addInput(tv0);
-      fusion.addInput(tv1);
-
-      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-      auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
-
-      fusion.addOutput(tv2);
-
-      // The settings of cta_tile, warp_tile, and smem_circular_buffer_stage
-      // have been purposefully selected to produce a constant occupancy of 25%.
-      // This allows us to effectively evaluate the influence of the
-      // use_smem_epilogue parameter on performance, since changing its value to
-      // either true or false will not affect the occupancy rate.
-      MatMulTileOptions gemm_tile;
-      gemm_tile.cta_tile = GemmTile(64, 128, 32);
-      gemm_tile.warp_tile = GemmTile(32, 32, 32);
-      gemm_tile.instruction_tile = GemmTile(16, 8, 16);
-
-      MatmulParams params;
-      params.supported_vec_size = {8, 8, 4};
-      params.mma_macro = MmaMacro::Ampere_16_8_16;
-      params.tile_sizes = gemm_tile;
-      params.async_gmem_load_operands = true;
-      params.circular_buffer_options.circular_buffer_smem_write =
-          num_stages > 1;
-      params.circular_buffer_options.circular_buffer_smem_read = num_stages > 1;
-      params.circular_buffer_options.smem_circular_buffer_stage = num_stages;
-      mma_utils::MmaDataTypes data_types = {
-          DataType::Half, DataType::Half, DataType::Float};
-      std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
-          mma_utils::generateSharedMemoryEpilogueHeuristics(
-              gemm_tile,
-              params.circular_buffer_options.smem_circular_buffer_stage,
-              data_types,
-              ignore_occupancy_drop);
-      scheduleMatmul(&fusion, params);
-
-      // If use_smem_epilogue is true, there should be 3 shared memory tensors 2
-      // for prologue and 1 for epilogue.
-      int num_shared_mem_tensors = 0;
-      int expected_num_shared_mem_tensors = params.use_smem_epilogue ? 3 : 2;
-      for (const auto& tv : ir_utils::allTvs(&fusion)) {
-        if (tv->getMemoryType() == MemoryType::Shared) {
-          num_shared_mem_tensors++;
-        }
-      }
-      NVF_CHECK(
-          num_shared_mem_tensors == expected_num_shared_mem_tensors,
-          "Number of shared memory tensors doesn't match!",
-          "Expected: ",
-          expected_num_shared_mem_tensors,
-          ", Got: ",
-          num_shared_mem_tensors);
-
-      at::manual_seed(0);
-      auto inputs = matmulAtInput3DTuring(M, N, K, layout);
-
-      FusionExecutor fe;
-      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-          8,
-          0,
-          fe.compileFusion(
-              &fusion,
-              {inputs.first, inputs.second},
-              LaunchParams(),
-              matmul_cparams));
-      auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-      auto tref = atMatmul(
-          inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-
-      // check bank conflicts
-      ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-      // (0.001, 0.001) passed on local A100 but failed on CI A100
-      NVF_CHECK(
-          cg_outputs[0].allclose(tref, 0.01, 0.01),
-          "Result validation failed. Max diff: ",
-          (cg_outputs[0] - tref).abs().max());
-
-      if (!params.use_smem_epilogue) {
-        GTEST_SKIP()
-            << "Test conducted without utilizing shared memory epilogue due to the device's constrained shared memory capacity.";
-      }
-
-      // Check that smem is allocated as expected.
-      // There are three cases that are determined by the current device in
-      // mma_utils::generateSharedMemoryEpilogueHeuristics:
-      //   - !use_smem_epilogue : A + B (this test is skipped in this case)
-      //   - use_smem_epilogue && !promote_prologue_smem_reuse : A + B + C
-      //   - use_smem_epilogue && promote_prologue_smem_reuse : max(A + B, C)
-      auto smem_allocs = fe.kernel()->summary().dynamic_smem_allocations;
-      NVF_CHECK(smem_allocs.size() == 3);
-      if (params.promote_prologue_smem_reuse) {
-        // Check prologue shared memory re-use
-        // smem_allocs = {A, B, C} where C is the epilogue buffer
-        // since A and B have no further uses, we should be able to reuse both
-        // of them, implying that the address of C is zero. In this case, B will
-        // also be allocated at address 0 with A stacked above it at position
-        // 8192.
-        EXPECT_EQ(
-            smem_allocs.at(0)->address()->evaluate(),
-            // Assuming B numel times size(dtype) is a multiple of 16 so that
-            // this address is aligned
-            smem_allocs.at(1)->size()->evaluate() *
-                dataTypeSize(smem_allocs.at(1)->buffer()->dtype()));
-        EXPECT_EQ(smem_allocs.at(1)->address()->evaluate(), 0L);
-        EXPECT_EQ(smem_allocs.at(2)->address()->evaluate(), 0L);
-      } else {
-        // Prologue shared memory is not re-used. In this case, memory should
-        // stack in C, B, A order.
-        EXPECT_EQ(
-            smem_allocs.at(0)->address()->evaluate(),
-            // Assuming for B and C that numel times size(dtype) is a multiple
-            // of 16 so that this address is aligned
-            smem_allocs.at(1)->size()->evaluate() *
-                    dataTypeSize(smem_allocs.at(1)->buffer()->dtype()) +
-                smem_allocs.at(2)->size()->evaluate() *
-                    dataTypeSize(smem_allocs.at(2)->buffer()->dtype()));
-        EXPECT_EQ(
-            smem_allocs.at(1)->address()->evaluate(),
-            smem_allocs.at(2)->size()->evaluate() *
-                dataTypeSize(smem_allocs.at(2)->buffer()->dtype()));
-        EXPECT_EQ(smem_allocs.at(2)->address()->evaluate(), 0L);
-      }
+    // Check that smem is allocated as expected.
+    // There are three cases that are determined by the current device in
+    // mma_utils::generateSharedMemoryEpilogueHeuristics:
+    //   - !use_smem_epilogue : A + B (this test is skipped in this case)
+    //   - use_smem_epilogue && !promote_prologue_smem_reuse : A + B + C
+    //   - use_smem_epilogue && promote_prologue_smem_reuse : max(A + B, C)
+    auto smem_allocs = fe.kernel()->summary().dynamic_smem_allocations;
+    NVF_CHECK(smem_allocs.size() == 3);
+    if (params.promote_prologue_smem_reuse) {
+      // Check prologue shared memory re-use
+      // smem_allocs = {A, B, C} where C is the epilogue buffer
+      // since A and B have no further uses, we should be able to reuse both
+      // of them, implying that the address of C is zero. In this case, B will
+      // also be allocated at address 0 with A stacked above it at position
+      // 8192.
+      EXPECT_EQ(
+          smem_allocs.at(0)->address()->evaluate(),
+          // Assuming B numel times size(dtype) is a multiple of 16 so that
+          // this address is aligned
+          smem_allocs.at(1)->size()->evaluate() *
+              dataTypeSize(smem_allocs.at(1)->buffer()->dtype()));
+      EXPECT_EQ(smem_allocs.at(1)->address()->evaluate(), 0L);
+      EXPECT_EQ(smem_allocs.at(2)->address()->evaluate(), 0L);
+    } else {
+      // Prologue shared memory is not re-used. In this case, memory should
+      // stack in C, B, A order.
+      EXPECT_EQ(
+          smem_allocs.at(0)->address()->evaluate(),
+          // Assuming for B and C that numel times size(dtype) is a multiple
+          // of 16 so that this address is aligned
+          smem_allocs.at(1)->size()->evaluate() *
+                  dataTypeSize(smem_allocs.at(1)->buffer()->dtype()) +
+              smem_allocs.at(2)->size()->evaluate() *
+                  dataTypeSize(smem_allocs.at(2)->buffer()->dtype()));
+      EXPECT_EQ(
+          smem_allocs.at(1)->address()->evaluate(),
+          smem_allocs.at(2)->size()->evaluate() *
+              dataTypeSize(smem_allocs.at(2)->buffer()->dtype()));
+      EXPECT_EQ(smem_allocs.at(2)->address()->evaluate(), 0L);
     }
   }
 }
@@ -2443,9 +2414,7 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSmemEpilogue_CUDA) {
 // On A100, this problem is able to make use of smem epilogue but only if we
 // promote use.
 // See https://github.com/NVIDIA/Fuser/pull/1834
-TEST_F(
-    GPUTTensorCoreTest,
-    FusionAmpereMatmulSmemEpiloguePromotionRequiredA100_CUDA) {
+TEST_F(MatmulTest, AmpereMatmulSmemEpiloguePromotionRequiredA100) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   // Keep multiples of 8 to keep vectorizable.
   int M = 4096, N = 4096, K = 4096;
@@ -2541,199 +2510,195 @@ TEST_F(
   }
 }
 
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSmemEpilogueCast_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmulSmemEpilogueCast) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   constexpr bool ignore_occupancy_drop = true;
   // Keep multiples of 8 to keep vectorizable.
   int M = 4096, N = 4096, K = 4096;
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
-    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+  auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+  auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+  auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
-    auto tv3 = castOp(DataType::Half, tv2);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  auto tv3 = castOp(DataType::Half, tv2);
 
-    fusion.addOutput(tv3);
+  fusion.addOutput(tv3);
 
-    MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 32);
-    gemm_tile.warp_tile = GemmTile(64, 64, 32);
-    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-    MatmulParams params;
-    params.supported_vec_size = {8, 8, 8};
-    params.mma_macro = MmaMacro::Ampere_16_8_16;
-    params.tile_sizes = gemm_tile;
-    params.async_gmem_load_operands = true;
-    params.circular_buffer_options.circular_buffer_smem_write = true;
-    params.circular_buffer_options.circular_buffer_smem_read = true;
-    params.circular_buffer_options.smem_circular_buffer_stage = 4;
-    mma_utils::MmaDataTypes data_types = {
-        DataType::Half, DataType::Half, DataType::Float};
-    std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
-        mma_utils::generateSharedMemoryEpilogueHeuristics(
-            gemm_tile,
-            params.circular_buffer_options.smem_circular_buffer_stage,
-            data_types,
-            ignore_occupancy_drop);
-    scheduleMatmul(&fusion, params);
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 8};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.circular_buffer_options.circular_buffer_smem_write = true;
+  params.circular_buffer_options.circular_buffer_smem_read = true;
+  params.circular_buffer_options.smem_circular_buffer_stage = 4;
+  mma_utils::MmaDataTypes data_types = {
+      DataType::Half, DataType::Half, DataType::Float};
+  std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
+      mma_utils::generateSharedMemoryEpilogueHeuristics(
+          gemm_tile,
+          params.circular_buffer_options.smem_circular_buffer_stage,
+          data_types,
+          ignore_occupancy_drop);
+  scheduleMatmul(&fusion, params);
 
-    // If use_smem_epilogue is true, there should be 3 shared memory tensors 2
-    // for prologue and 1 for epilogue.
-    int num_shared_mem_tensors = 0;
-    int expected_num_shared_mem_tensors = params.use_smem_epilogue ? 3 : 2;
-    for (const auto& tv : ir_utils::allTvs(&fusion)) {
-      if (tv->getMemoryType() == MemoryType::Shared) {
-        num_shared_mem_tensors++;
-      }
+  // If use_smem_epilogue is true, there should be 3 shared memory tensors 2
+  // for prologue and 1 for epilogue.
+  int num_shared_mem_tensors = 0;
+  int expected_num_shared_mem_tensors = params.use_smem_epilogue ? 3 : 2;
+  for (const auto& tv : ir_utils::allTvs(&fusion)) {
+    if (tv->getMemoryType() == MemoryType::Shared) {
+      num_shared_mem_tensors++;
     }
-    NVF_CHECK(
-        num_shared_mem_tensors == expected_num_shared_mem_tensors,
-        "Number of shared memory tensors doesn't match!",
-        "Expected: ",
-        expected_num_shared_mem_tensors,
-        ", Got: ",
-        num_shared_mem_tensors);
+  }
+  NVF_CHECK(
+      num_shared_mem_tensors == expected_num_shared_mem_tensors,
+      "Number of shared memory tensors doesn't match!",
+      "Expected: ",
+      expected_num_shared_mem_tensors,
+      ", Got: ",
+      num_shared_mem_tensors);
 
-    at::manual_seed(0);
-    auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+  at::manual_seed(0);
+  auto inputs = matmulAtInput3DTuring(M, N, K, layout);
 
-    FusionExecutor fe;
-    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-        8,
-        0,
-        fe.compileFusion(
-            &fusion,
-            {inputs.first, inputs.second},
-            LaunchParams(),
-            matmul_cparams));
-    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-    auto tref = atMatmul(
-        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    tref = tref.to(at::kHalf);
-    // check bank conflicts
-    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    // (0.001, 0.001) passed on local A100 but failed on CI A100
-    NVF_CHECK(
-        cg_outputs[0].allclose(tref, 0.01, 0.01),
-        "Result validation failed. Max diff: ",
-        (cg_outputs[0] - tref).abs().max());
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(
+          &fusion,
+          {inputs.first, inputs.second},
+          LaunchParams(),
+          matmul_cparams));
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+  tref = tref.to(at::kHalf);
+  // check bank conflicts
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  // (0.001, 0.001) passed on local A100 but failed on CI A100
+  NVF_CHECK(
+      cg_outputs[0].allclose(tref, 0.01, 0.01),
+      "Result validation failed. Max diff: ",
+      (cg_outputs[0] - tref).abs().max());
 
-    if (!params.use_smem_epilogue) {
-      GTEST_SKIP()
-          << "Test conducted without utilizing shared memory epilogue due to the device's constrained shared memory capacity.";
-    }
+  if (!params.use_smem_epilogue) {
+    GTEST_SKIP()
+        << "Test conducted without utilizing shared memory epilogue due to the device's constrained shared memory capacity.";
   }
 }
 
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSmemEpilogueRelu_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmulSmemEpilogueRelu) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   constexpr bool ignore_occupancy_drop = true;
   // Keep multiples of 8 to keep vectorizable.
   int M = 4096, N = 4096, K = 4096;
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
+  Fusion fusion;
+  FusionGuard fg(&fusion);
 
-    auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+  auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-    auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-    auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+  auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+  auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
-    auto tv3 = relu(tv2);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  auto tv3 = relu(tv2);
 
-    fusion.addOutput(tv3);
+  fusion.addOutput(tv3);
 
-    MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 32);
-    gemm_tile.warp_tile = GemmTile(64, 64, 32);
-    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-    MatmulParams params;
-    params.supported_vec_size = {8, 8, 4};
-    params.mma_macro = MmaMacro::Ampere_16_8_16;
-    params.tile_sizes = gemm_tile;
-    params.async_gmem_load_operands = true;
-    params.circular_buffer_options.circular_buffer_smem_write = true;
-    params.circular_buffer_options.circular_buffer_smem_read = true;
-    params.circular_buffer_options.smem_circular_buffer_stage = 4;
-    mma_utils::MmaDataTypes data_types = {
-        DataType::Half, DataType::Half, DataType::Float};
-    std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
-        mma_utils::generateSharedMemoryEpilogueHeuristics(
-            gemm_tile,
-            params.circular_buffer_options.smem_circular_buffer_stage,
-            data_types,
-            ignore_occupancy_drop);
-    scheduleMatmul(&fusion, params);
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.circular_buffer_options.circular_buffer_smem_write = true;
+  params.circular_buffer_options.circular_buffer_smem_read = true;
+  params.circular_buffer_options.smem_circular_buffer_stage = 4;
+  mma_utils::MmaDataTypes data_types = {
+      DataType::Half, DataType::Half, DataType::Float};
+  std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
+      mma_utils::generateSharedMemoryEpilogueHeuristics(
+          gemm_tile,
+          params.circular_buffer_options.smem_circular_buffer_stage,
+          data_types,
+          ignore_occupancy_drop);
+  scheduleMatmul(&fusion, params);
 
-    // If use_smem_epilogue is true, there should be 3 shared memory tensors 2
-    // for prologue and 1 for epilogue.
-    int num_shared_mem_tensors = 0;
-    int expected_num_shared_mem_tensors = params.use_smem_epilogue ? 3 : 2;
-    for (const auto& tv : ir_utils::allTvs(&fusion)) {
-      if (tv->getMemoryType() == MemoryType::Shared) {
-        num_shared_mem_tensors++;
-      }
+  // If use_smem_epilogue is true, there should be 3 shared memory tensors 2
+  // for prologue and 1 for epilogue.
+  int num_shared_mem_tensors = 0;
+  int expected_num_shared_mem_tensors = params.use_smem_epilogue ? 3 : 2;
+  for (const auto& tv : ir_utils::allTvs(&fusion)) {
+    if (tv->getMemoryType() == MemoryType::Shared) {
+      num_shared_mem_tensors++;
     }
-    NVF_CHECK(
-        num_shared_mem_tensors == expected_num_shared_mem_tensors,
-        "Number of shared memory tensors doesn't match!",
-        "Expected: ",
-        expected_num_shared_mem_tensors,
-        ", Got: ",
-        num_shared_mem_tensors);
+  }
+  NVF_CHECK(
+      num_shared_mem_tensors == expected_num_shared_mem_tensors,
+      "Number of shared memory tensors doesn't match!",
+      "Expected: ",
+      expected_num_shared_mem_tensors,
+      ", Got: ",
+      num_shared_mem_tensors);
 
-    at::manual_seed(0);
-    auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+  at::manual_seed(0);
+  auto inputs = matmulAtInput3DTuring(M, N, K, layout);
 
-    FusionExecutor fe;
-    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-        8,
-        0,
-        fe.compileFusion(
-            &fusion,
-            {inputs.first, inputs.second},
-            LaunchParams(),
-            matmul_cparams));
-    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-    auto t2 = atMatmul(
-        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    auto tref = at::relu(t2).to(at::kFloat);
+  FusionExecutor fe;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      fe.compileFusion(
+          &fusion,
+          {inputs.first, inputs.second},
+          LaunchParams(),
+          matmul_cparams));
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto t2 = atMatmul(
+      inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+  auto tref = at::relu(t2).to(at::kFloat);
 
-    // check bank conflicts
-    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    // (0.001, 0.001) passed on local A100 but failed on CI A100
-    NVF_CHECK(
-        cg_outputs[0].allclose(tref, 0.01, 0.01),
-        "Result validation failed. Max diff: ",
-        (cg_outputs[0] - tref).abs().max());
+  // check bank conflicts
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  // (0.001, 0.001) passed on local A100 but failed on CI A100
+  NVF_CHECK(
+      cg_outputs[0].allclose(tref, 0.01, 0.01),
+      "Result validation failed. Max diff: ",
+      (cg_outputs[0] - tref).abs().max());
 
-    if (!params.use_smem_epilogue) {
-      GTEST_SKIP()
-          << "Test conducted without utilizing shared memory epilogue due to the device's constrained shared memory capacity.";
-    }
+  if (!params.use_smem_epilogue) {
+    GTEST_SKIP()
+        << "Test conducted without utilizing shared memory epilogue due to the device's constrained shared memory capacity.";
   }
 }
 
 // Test the matmul scheduler's single-kernel split-K support
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSplitK_CUDA) {
+TEST_P(MatmulTestWithLayout, FusionAmpereMatmulSplitK_CUDA) {
   // requires Ampere or higher GPU
   if (!deviceMajorMinorCheck(8)) {
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
@@ -2742,75 +2707,72 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSplitK_CUDA) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 8096;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    for (int splitk_factor : {2}) {
-      for (int use_smem_epilogue : {false, true}) {
-        Fusion fusion;
-        FusionGuard fg(&fusion);
-        auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+  for (int splitk_factor : {2}) {
+    for (int use_smem_epilogue : {false, true}) {
+      Fusion fusion;
+      FusionGuard fg(&fusion);
+      auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-        auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-        auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+      auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+      auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
 
-        fusion.addInput(tv0);
-        fusion.addInput(tv1);
+      fusion.addInput(tv0);
+      fusion.addInput(tv1);
 
-        tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-        tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-        auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+      auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-        fusion.addOutput(tv2);
+      fusion.addOutput(tv2);
 
-        MatMulTileOptions gemm_tile;
-        gemm_tile.cta_tile = GemmTile(128, 128, 32);
-        gemm_tile.warp_tile = GemmTile(64, 64, 32);
-        gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+      MatMulTileOptions gemm_tile;
+      gemm_tile.cta_tile = GemmTile(128, 128, 32);
+      gemm_tile.warp_tile = GemmTile(64, 64, 32);
+      gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-        MatmulParams params;
-        params.supported_vec_size = {8, 8, 4};
-        params.mma_macro = MmaMacro::Ampere_16_8_16;
-        params.tile_sizes = gemm_tile;
-        params.splitk_factor = splitk_factor;
-        if (use_smem_epilogue) {
-          std::tie(
-              params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
-              mma_utils::generateSharedMemoryEpilogueHeuristics(
-                  gemm_tile,
-                  1,
-                  {DataType::Half, DataType::Half, DataType::Float},
-                  true,
-                  true,
-                  true);
-          if (!params.use_smem_epilogue) {
-            std::cout
-                << "Skipping smem epilogue due to shared memory constraints on this device"
-                << std::endl;
-            continue;
-          }
-          params.promote_prologue_smem_reuse = true;
+      MatmulParams params;
+      params.supported_vec_size = {8, 8, 4};
+      params.mma_macro = MmaMacro::Ampere_16_8_16;
+      params.tile_sizes = gemm_tile;
+      params.splitk_factor = splitk_factor;
+      if (use_smem_epilogue) {
+        std::tie(params.use_smem_epilogue, params.promote_prologue_smem_reuse) =
+            mma_utils::generateSharedMemoryEpilogueHeuristics(
+                gemm_tile,
+                1,
+                {DataType::Half, DataType::Half, DataType::Float},
+                true,
+                true,
+                true);
+        if (!params.use_smem_epilogue) {
+          std::cout
+              << "Skipping smem epilogue due to shared memory constraints on this device"
+              << std::endl;
+          continue;
         }
-
-        scheduleMatmul(&fusion, params);
-
-        auto inputs = matmulAtInput3DTuring(M, N, K, layout);
-
-        FusionExecutor fe;
-        NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-            7, 5, fe.compileFusion(&fusion, {inputs.first, inputs.second}));
-        EXPECT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-        auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-        auto tref = atMatmul(
-            inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-
-        // Relax tolerance for larger sum due to large K
-        NVF_CHECK(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
+        params.promote_prologue_smem_reuse = true;
       }
+
+      scheduleMatmul(&fusion, params);
+
+      auto inputs = matmulAtInput3DTuring(M, N, K, layout);
+
+      FusionExecutor fe;
+      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+          7, 5, fe.compileFusion(&fusion, {inputs.first, inputs.second}));
+      EXPECT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+      auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+      auto tref = atMatmul(
+          inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+
+      // Relax tolerance for larger sum due to large K
+      NVF_CHECK(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
     }
   }
 }
 
 // Test splitk with bias epilogue
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSplitKBias_CUDA) {
+TEST_P(MatmulTestWithLayout, FusionAmpereMatmulSplitKBias_CUDA) {
   // requires Ampere or higher GPU
   if (!deviceMajorMinorCheck(8)) {
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
@@ -2819,66 +2781,64 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulSplitKBias_CUDA) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 8096;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    for (int splitk_factor : {2}) {
-      for (int use_smem_epilogue : {false, true}) {
-        Fusion fusion;
-        FusionGuard fg(&fusion);
-        auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
+  for (int splitk_factor : {2}) {
+    for (int use_smem_epilogue : {false, true}) {
+      Fusion fusion;
+      FusionGuard fg(&fusion);
+      auto shapes = matmulAtInputShape3DTuring(-1, -1, -1, layout);
 
-        auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
-        auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
-        auto tv2 = makeContigTensor(1, DataType::Half);
+      auto tv0 = makeContigConcreteTensor(shapes.first, DataType::Half);
+      auto tv1 = makeContigConcreteTensor(shapes.second, DataType::Half);
+      auto tv2 = makeContigTensor(1, DataType::Half);
 
-        fusion.addInput(tv0);
-        fusion.addInput(tv1);
-        fusion.addInput(tv2);
+      fusion.addInput(tv0);
+      fusion.addInput(tv1);
+      fusion.addInput(tv2);
 
-        tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-        tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-        auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
-        auto tv4 = broadcast(tv2, {false, true});
-        auto tv5 = add(tv3, tv4); // bias
+      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+      auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
+      auto tv4 = broadcast(tv2, {false, true});
+      auto tv5 = add(tv3, tv4); // bias
 
-        fusion.addOutput(tv5);
+      fusion.addOutput(tv5);
 
-        MatMulTileOptions gemm_tile;
-        gemm_tile.cta_tile = GemmTile(128, 128, 32);
-        gemm_tile.warp_tile = GemmTile(64, 64, 32);
-        gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+      MatMulTileOptions gemm_tile;
+      gemm_tile.cta_tile = GemmTile(128, 128, 32);
+      gemm_tile.warp_tile = GemmTile(64, 64, 32);
+      gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-        MatmulParams params;
-        params.supported_vec_size = {8, 8, 4};
-        params.mma_macro = MmaMacro::Ampere_16_8_16;
-        params.tile_sizes = gemm_tile;
-        params.splitk_factor = splitk_factor;
-        params.use_smem_epilogue = use_smem_epilogue;
-        params.promote_prologue_smem_reuse = true;
+      MatmulParams params;
+      params.supported_vec_size = {8, 8, 4};
+      params.mma_macro = MmaMacro::Ampere_16_8_16;
+      params.tile_sizes = gemm_tile;
+      params.splitk_factor = splitk_factor;
+      params.use_smem_epilogue = use_smem_epilogue;
+      params.promote_prologue_smem_reuse = true;
 
-        scheduleMatmul(&fusion, params);
+      scheduleMatmul(&fusion, params);
 
-        auto [aten_a, aten_b] = matmulAtInput3DTuring(M, N, K, layout);
-        at::Tensor aten_bias = at::randn({M}, aten_a.options());
-        std::vector<c10::IValue> inputs = {aten_a, aten_b, aten_bias};
+      auto [aten_a, aten_b] = matmulAtInput3DTuring(M, N, K, layout);
+      at::Tensor aten_bias = at::randn({M}, aten_a.options());
+      std::vector<c10::IValue> inputs = {aten_a, aten_b, aten_bias};
 
-        FusionExecutor fe;
-        NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-            7, 5, fe.compileFusion(&fusion, inputs));
-        ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-        auto cg_outputs = fe.runFusion(inputs);
-        auto tref = atBiasEpilogue(
-            atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout),
-            aten_bias);
+      FusionExecutor fe;
+      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+          7, 5, fe.compileFusion(&fusion, inputs));
+      ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+      auto cg_outputs = fe.runFusion(inputs);
+      auto tref = atBiasEpilogue(
+          atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout),
+          aten_bias);
 
-        // Relax tolerance for larger sum due to large K
-        NVF_CHECK(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
-      }
+      // Relax tolerance for larger sum due to large K
+      NVF_CHECK(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
     }
   }
 }
 
 // Same as above but has a batch dimension and splitk
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulBatchSplitK_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmulBatchSplitK) {
   // requires Ampere or higher GPU
   if (!deviceMajorMinorCheck(8)) {
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
@@ -2887,62 +2847,60 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulBatchSplitK_CUDA) {
   // Keep multiples of 8 to keep vectorizable.
   int B = 2, M = 504, N = 136, K = 2048;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    for (int splitk_factor : {2}) {
-      for (int use_smem_epilogue : {false, true}) {
-        Fusion fusion;
-        FusionGuard fg(&fusion);
-        auto tv0 = makeContigTensor(3, DataType::Half);
-        auto tv1 = makeContigTensor(3, DataType::Half);
+  for (int splitk_factor : {2}) {
+    for (int use_smem_epilogue : {false, true}) {
+      Fusion fusion;
+      FusionGuard fg(&fusion);
+      auto tv0 = makeContigTensor(3, DataType::Half);
+      auto tv1 = makeContigTensor(3, DataType::Half);
 
-        fusion.addInput(tv0);
-        fusion.addInput(tv1);
+      fusion.addInput(tv0);
+      fusion.addInput(tv1);
 
-        tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-        tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-        auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+      auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-        fusion.addOutput(tv2);
+      fusion.addOutput(tv2);
 
-        MatMulTileOptions gemm_tile;
-        gemm_tile.cta_tile = GemmTile(128, 128, 32);
-        gemm_tile.warp_tile = GemmTile(64, 64, 32);
-        gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+      MatMulTileOptions gemm_tile;
+      gemm_tile.cta_tile = GemmTile(128, 128, 32);
+      gemm_tile.warp_tile = GemmTile(64, 64, 32);
+      gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-        MatmulParams params;
-        params.supported_vec_size = {8, 8, 4};
-        params.mma_macro = MmaMacro::Ampere_16_8_16;
-        params.tile_sizes = gemm_tile;
-        params.splitk_factor = splitk_factor;
-        params.use_smem_epilogue = use_smem_epilogue;
-        params.promote_prologue_smem_reuse = true;
+      MatmulParams params;
+      params.supported_vec_size = {8, 8, 4};
+      params.mma_macro = MmaMacro::Ampere_16_8_16;
+      params.tile_sizes = gemm_tile;
+      params.splitk_factor = splitk_factor;
+      params.use_smem_epilogue = use_smem_epilogue;
+      params.promote_prologue_smem_reuse = true;
 
-        scheduleMatmul(&fusion, params);
+      scheduleMatmul(&fusion, params);
 
-        at::Tensor aten_a =
-            matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
-        at::Tensor aten_b =
-            matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
+      at::Tensor aten_a =
+          matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
+      at::Tensor aten_b =
+          matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
 
-        std::vector<c10::IValue> inputs = {aten_a, aten_b};
+      std::vector<c10::IValue> inputs = {aten_a, aten_b};
 
-        FusionExecutor fe;
-        NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-            7, 5, fe.compileFusion(&fusion, inputs));
-        ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-        auto cg_outputs = fe.runFusion(inputs);
-        auto tref =
-            atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout);
+      FusionExecutor fe;
+      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+          7, 5, fe.compileFusion(&fusion, inputs));
+      ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+      auto cg_outputs = fe.runFusion(inputs);
+      auto tref =
+          atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout);
 
-        // Relax tolerance for larger sum due to large K
-        EXPECT_TRUE(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
-      }
+      // Relax tolerance for larger sum due to large K
+      EXPECT_TRUE(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
     }
   }
 }
 
 // Test batch splitk with bias epilogue
-TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulBatchSplitKBias_CUDA) {
+TEST_P(MatmulTestWithLayout, AmpereMatmulBatchSplitKBias) {
   // requires Ampere or higher GPU
   if (!deviceMajorMinorCheck(8)) {
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
@@ -2951,68 +2909,66 @@ TEST_F(GPUTTensorCoreTest, FusionAmpereMatmulBatchSplitKBias_CUDA) {
   // Keep multiples of 8 to keep vectorizable.
   int B = 2, M = 504, N = 136, K = 2048;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    for (int splitk_factor : {2}) {
-      for (int use_smem_epilogue : {false, true}) {
-        Fusion fusion;
-        FusionGuard fg(&fusion);
-        auto tv0 = makeContigTensor(3, DataType::Half);
-        auto tv1 = makeContigTensor(3, DataType::Half);
-        auto tv2 = makeContigTensor(1, DataType::Half);
+  for (int splitk_factor : {2}) {
+    for (int use_smem_epilogue : {false, true}) {
+      Fusion fusion;
+      FusionGuard fg(&fusion);
+      auto tv0 = makeContigTensor(3, DataType::Half);
+      auto tv1 = makeContigTensor(3, DataType::Half);
+      auto tv2 = makeContigTensor(1, DataType::Half);
 
-        fusion.addInput(tv0);
-        fusion.addInput(tv1);
-        fusion.addInput(tv2);
+      fusion.addInput(tv0);
+      fusion.addInput(tv1);
+      fusion.addInput(tv2);
 
-        tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-        tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-        auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
-        auto tv4 = broadcast(tv2, {true, false, true});
-        auto tv5 = add(tv3, tv4);
+      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+      auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
+      auto tv4 = broadcast(tv2, {true, false, true});
+      auto tv5 = add(tv3, tv4);
 
-        fusion.addOutput(tv5);
+      fusion.addOutput(tv5);
 
-        MatMulTileOptions gemm_tile;
-        gemm_tile.cta_tile = GemmTile(128, 128, 32);
-        gemm_tile.warp_tile = GemmTile(64, 64, 32);
-        gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+      MatMulTileOptions gemm_tile;
+      gemm_tile.cta_tile = GemmTile(128, 128, 32);
+      gemm_tile.warp_tile = GemmTile(64, 64, 32);
+      gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-        MatmulParams params;
-        params.supported_vec_size = {8, 8, 4};
-        params.mma_macro = MmaMacro::Ampere_16_8_16;
-        params.tile_sizes = gemm_tile;
-        params.splitk_factor = splitk_factor;
-        params.use_smem_epilogue = use_smem_epilogue;
-        params.promote_prologue_smem_reuse = true;
+      MatmulParams params;
+      params.supported_vec_size = {8, 8, 4};
+      params.mma_macro = MmaMacro::Ampere_16_8_16;
+      params.tile_sizes = gemm_tile;
+      params.splitk_factor = splitk_factor;
+      params.use_smem_epilogue = use_smem_epilogue;
+      params.promote_prologue_smem_reuse = true;
 
-        scheduleMatmul(&fusion, params);
+      scheduleMatmul(&fusion, params);
 
-        at::Tensor aten_a =
-            matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
-        at::Tensor aten_b =
-            matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
-        at::Tensor aten_bias = at::randn({M}, aten_a.options());
+      at::Tensor aten_a =
+          matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
+      at::Tensor aten_b =
+          matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
+      at::Tensor aten_bias = at::randn({M}, aten_a.options());
 
-        std::vector<c10::IValue> inputs = {aten_a, aten_b, aten_bias};
+      std::vector<c10::IValue> inputs = {aten_a, aten_b, aten_bias};
 
-        FusionExecutor fe;
-        NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-            7, 5, fe.compileFusion(&fusion, inputs));
-        ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-        auto cg_outputs = fe.runFusion(inputs);
-        auto tref = atBiasEpilogue(
-            atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout),
-            aten_bias);
+      FusionExecutor fe;
+      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+          7, 5, fe.compileFusion(&fusion, inputs));
+      ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+      auto cg_outputs = fe.runFusion(inputs);
+      auto tref = atBiasEpilogue(
+          atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout),
+          aten_bias);
 
-        // Relax tolerance for larger sum due to large K
-        EXPECT_TRUE(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
-      }
+      // Relax tolerance for larger sum due to large K
+      EXPECT_TRUE(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
     }
   }
 }
 
 // Avoid lowering error https://github.com/NVIDIA/Fuser/issues/1808
-TEST_F(GPUTTensorCoreTest, ReproIssue1808) {
+TEST_F(MatmulTest, ReproIssue1808) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 
@@ -3069,165 +3025,158 @@ TEST_F(GPUTTensorCoreTest, ReproIssue1808) {
 }
 
 // Test matmul with sizes that are not divisible by 8 and with misaligned inputs
-TEST_F(GPUTTensorCoreTest, MisalignedVectorization) {
-  for (auto layout : kAllSupportedMmaLayout) {
-    for (bool add_2d_bias : {false, true}) {
-      for (bool downcast_output : {false, true}) {
-        for (const auto& [M, N, K, alignA, alignB, alignBias] :
-             std::vector<std::tuple<
-                 int64_t,
-                 int64_t,
-                 int64_t,
-                 int64_t,
-                 int64_t,
-                 int64_t>>{
-                 {504, 136, 248, 8, 8, 8}, // all fully vectorizable in all
-                                           // layouts
-                 {504, 136, 249, 8, 8, 8}, // odd K, operands not vectorizable
-                                           // in TN. output fully vectorizable
-                 {504, 137, 248, 8, 8, 8}, // A fully vectorizable, B fully
-                                           // vectorizable unless transposed,
-                                           // output not vectorizable
-                 {505, 136, 248, 8, 8, 8}, // B fully vectorizable, A
-                                           // vectorizable unless transposed,
-                                           // output fully vectorizable
-                 {505, 137, 248, 8, 8, 8}, // none vectorizable
+TEST_P(MatmulTestWithLayout, MisalignedVectorization) {
+  for (bool add_2d_bias : {false, true}) {
+    for (bool downcast_output : {false, true}) {
+      for (const auto& [M, N, K, alignA, alignB, alignBias] : std::vector<
+               std::
+                   tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>>{
+               {504, 136, 248, 8, 8, 8}, // all fully vectorizable in all
+                                         // layouts
+               {504, 136, 249, 8, 8, 8}, // odd K, operands not vectorizable
+                                         // in TN. output fully vectorizable
+               {504, 137, 248, 8, 8, 8}, // A fully vectorizable, B fully
+                                         // vectorizable unless transposed,
+                                         // output not vectorizable
+               {505, 136, 248, 8, 8, 8}, // B fully vectorizable, A
+                                         // vectorizable unless transposed,
+                                         // output fully vectorizable
+               {505, 137, 248, 8, 8, 8}, // none vectorizable
 
-                 // Cases with vectorizable strides but misaligned base pointers
-                 {504, 136, 248, 2, 8, 8}, // A not vectorizable due to offset
-                 {504, 136, 248, 8, 2, 8}, // B not vectorizable due to offset
-                 {504, 136, 248, 8, 8, 2}, // epilogue not vectorizable due to
-                 // offset
-             }) {
-          const auto maybeUnalign = [](const at::Tensor& t, int64_t offset) {
-            if (offset == 16 / t.element_size()) {
-              // Already fully aligned
-              return t;
-            }
-            return at::pad(t.ravel(), {{0, offset}})
-                .index({at::indexing::Slice(offset, t.numel() + offset, 1)})
-                .view({t.size(0), t.size(1)});
-          };
-
-          auto t0 = maybeUnalign(
-              matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K),
-              alignA);
-          auto t1 = maybeUnalign(
-              matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K),
-              alignB);
-
-          auto tref = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
-
-          std::vector<c10::IValue> inputs = {t0, t1};
-
-          if (add_2d_bias) {
-            const auto options =
-                at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-            auto bias = maybeUnalign(at::randn({M, N}, options), alignBias);
-            tref = tref + bias;
-            inputs.push_back(bias);
+               // Cases with vectorizable strides but misaligned base pointers
+               {504, 136, 248, 2, 8, 8}, // A not vectorizable due to offset
+               {504, 136, 248, 8, 2, 8}, // B not vectorizable due to offset
+               {504, 136, 248, 8, 8, 2}, // epilogue not vectorizable due to
+               // offset
+           }) {
+        const auto maybeUnalign = [](const at::Tensor& t, int64_t offset) {
+          if (offset == 16 / t.element_size()) {
+            // Already fully aligned
+            return t;
           }
+          return at::pad(t.ravel(), {{0, offset}})
+              .index({at::indexing::Slice(offset, t.numel() + offset, 1)})
+              .view({t.size(0), t.size(1)});
+        };
 
-          if (downcast_output) {
-            tref = tref.to(at::kHalf);
-          }
+        auto t0 = maybeUnalign(
+            matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K),
+            alignA);
+        auto t1 = maybeUnalign(
+            matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K),
+            alignB);
 
-          auto fusion = std::make_unique<Fusion>();
-          FusionGuard fg(fusion.get());
+        auto tref = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
 
-          auto tv0 = makeContigTensor(2, DataType::Half);
-          auto tv1 = makeContigTensor(2, DataType::Half);
-          fusion->addInput(tv0);
-          fusion->addInput(tv1);
+        std::vector<c10::IValue> inputs = {t0, t1};
 
-          tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-          tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-          auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
-
-          if (add_2d_bias) {
-            auto bias = makeContigTensor(2, DataType::Half);
-            fusion->addInput(bias);
-            tv2 = add(tv2, bias);
-          }
-
-          if (downcast_output) {
-            tv2 = castOp(DataType::Half, tv2);
-          }
-
-          fusion->addOutput(tv2);
-
-          const MmaLayout fusion_layout = getMatmulProblemLayout(fusion.get());
-          NVF_CHECK(
-              fusion_layout == layout,
-              "mismatch between test layout (",
-              toString(layout),
-              ") and layout inferred from fusion definition (",
-              toString(fusion_layout),
-              ")");
-
-          // determine supported vectorization of an ATen tensor that will be
-          // loaded along its innermost dimension
-          const auto atenSupportedVectorization =
-              [](const at::Tensor& tens) -> int64_t {
-            auto data_ptr_int = static_cast<int64_t>(
-                reinterpret_cast<std::uintptr_t>(tens.data_ptr()));
-            int64_t vec_size =
-                scheduler_utils::maxVectorizationWidth(data_ptr_int) /
-                tens.element_size();
-            std::vector<int64_t> strides = tens.strides().vec();
-            std::sort(strides.begin(), strides.end());
-            if (strides.front() > 1) {
-              // Discontiguous input
-              return 1;
-            }
-            strides.erase(strides.begin());
-            NVF_ERROR(!strides.empty());
-            // Next smallest stride determines supported vectorization
-            vec_size = std::min(
-                vec_size,
-                scheduler_utils::maxVectorizationWidth(strides.front()));
-            return std::min(vec_size, (int64_t)(16 / tens.element_size()));
-          };
-
-          MatmulParams params;
-          params.mma_macro = MmaMacro::Ampere_16_8_16;
-          params.supported_vec_size = {
-              .a = atenSupportedVectorization(t0),
-              .b = atenSupportedVectorization(t1),
-              .epilogue = std::min(
-                  alignBias,
-                  std::min(
-                      scheduler_utils::maxVectorizationWidth(N),
-                      (int64_t)(16 / (downcast_output ? 2 : 4))))};
-          // Supported vectorization determines whether we are able to do async
-          // gmem->smem loads.
-          params.async_gmem_load_operands = params.supported_vec_size.a >= 4 &&
-              params.supported_vec_size.b >= 4;
-          params.circular_buffer_options.circular_buffer_smem_write = true;
-          // If we cannot use cp.async, it means we cannot do circular buffering
-          params.circular_buffer_options.smem_circular_buffer_stage =
-              params.async_gmem_load_operands ? 4 : 2;
-
-          scheduleMatmul(fusion.get(), params);
-
-          FusionExecutor fe;
-          NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-              8,
-              0,
-              fe.compileFusion(
-                  fusion.get(), inputs, LaunchParams(), matmul_cparams));
-          ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-          auto outputs = fe.runFusion(inputs);
-
-          EXPECT_TRUE(outputs[0].allclose(tref, 0.001, 0.001));
+        if (add_2d_bias) {
+          const auto options =
+              at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
+          auto bias = maybeUnalign(at::randn({M, N}, options), alignBias);
+          tref = tref + bias;
+          inputs.push_back(bias);
         }
+
+        if (downcast_output) {
+          tref = tref.to(at::kHalf);
+        }
+
+        auto fusion = std::make_unique<Fusion>();
+        FusionGuard fg(fusion.get());
+
+        auto tv0 = makeContigTensor(2, DataType::Half);
+        auto tv1 = makeContigTensor(2, DataType::Half);
+        fusion->addInput(tv0);
+        fusion->addInput(tv1);
+
+        tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+        tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+        auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+
+        if (add_2d_bias) {
+          auto bias = makeContigTensor(2, DataType::Half);
+          fusion->addInput(bias);
+          tv2 = add(tv2, bias);
+        }
+
+        if (downcast_output) {
+          tv2 = castOp(DataType::Half, tv2);
+        }
+
+        fusion->addOutput(tv2);
+
+        const MmaLayout fusion_layout = getMatmulProblemLayout(fusion.get());
+        NVF_CHECK(
+            fusion_layout == layout,
+            "mismatch between test layout (",
+            toString(layout),
+            ") and layout inferred from fusion definition (",
+            toString(fusion_layout),
+            ")");
+
+        // determine supported vectorization of an ATen tensor that will be
+        // loaded along its innermost dimension
+        const auto atenSupportedVectorization =
+            [](const at::Tensor& tens) -> int64_t {
+          auto data_ptr_int = static_cast<int64_t>(
+              reinterpret_cast<std::uintptr_t>(tens.data_ptr()));
+          int64_t vec_size =
+              scheduler_utils::maxVectorizationWidth(data_ptr_int) /
+              tens.element_size();
+          std::vector<int64_t> strides = tens.strides().vec();
+          std::sort(strides.begin(), strides.end());
+          if (strides.front() > 1) {
+            // Discontiguous input
+            return 1;
+          }
+          strides.erase(strides.begin());
+          NVF_ERROR(!strides.empty());
+          // Next smallest stride determines supported vectorization
+          vec_size = std::min(
+              vec_size,
+              scheduler_utils::maxVectorizationWidth(strides.front()));
+          return std::min(vec_size, (int64_t)(16 / tens.element_size()));
+        };
+
+        MatmulParams params;
+        params.mma_macro = MmaMacro::Ampere_16_8_16;
+        params.supported_vec_size = {
+            .a = atenSupportedVectorization(t0),
+            .b = atenSupportedVectorization(t1),
+            .epilogue = std::min(
+                alignBias,
+                std::min(
+                    scheduler_utils::maxVectorizationWidth(N),
+                    (int64_t)(16 / (downcast_output ? 2 : 4))))};
+        // Supported vectorization determines whether we are able to do async
+        // gmem->smem loads.
+        params.async_gmem_load_operands = params.supported_vec_size.a >= 4 &&
+            params.supported_vec_size.b >= 4;
+        params.circular_buffer_options.circular_buffer_smem_write = true;
+        // If we cannot use cp.async, it means we cannot do circular buffering
+        params.circular_buffer_options.smem_circular_buffer_stage =
+            params.async_gmem_load_operands ? 4 : 2;
+
+        scheduleMatmul(fusion.get(), params);
+
+        FusionExecutor fe;
+        NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+            8,
+            0,
+            fe.compileFusion(
+                fusion.get(), inputs, LaunchParams(), matmul_cparams));
+        ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+        auto outputs = fe.runFusion(inputs);
+
+        EXPECT_TRUE(outputs[0].allclose(tref, 0.001, 0.001));
       }
     }
   }
 }
 
 // Matmul test with multiple M and N dimensions that are consecutive
-TEST_F(GPUTTensorCoreTest, MultipleConsecutiveDims) {
+TEST_F(MatmulTest, MultipleConsecutiveDims) {
   int M1 = 126, M2 = 4, N1 = 68, N2 = 2, K = 248;
 
   Fusion fusion;
@@ -3289,7 +3238,7 @@ TEST_F(GPUTTensorCoreTest, MultipleConsecutiveDims) {
 // [M1, K, M2], which is incompatible with ldMatrix. We need to gather the
 // allocation domains for the smem tensors by role instead, so that this
 // becomes [K, M1, M2].
-TEST_F(GPUTTensorCoreTest, DISABLED_MultipleNonConsecutiveMDims) {
+TEST_F(MatmulTest, DISABLED_MultipleNonConsecutiveMDims) {
   int M1 = 126, N = 136, M2 = 4, K = 248;
 
   Fusion fusion;
@@ -3351,7 +3300,7 @@ TEST_F(GPUTTensorCoreTest, DISABLED_MultipleNonConsecutiveMDims) {
 // [N1, K, N2], which is incompatible with ldMatrix. We need to gather the
 // allocation domains for the smem tensors by role instead, so that this
 // becomes [K, N1, N2].
-TEST_F(GPUTTensorCoreTest, DISABLED_MultipleNonConsecutiveNDims) {
+TEST_F(MatmulTest, DISABLED_MultipleNonConsecutiveNDims) {
   int M = 504, N1 = 68, N2 = 2, K = 248;
 
   Fusion fusion;
@@ -3408,7 +3357,7 @@ TEST_F(GPUTTensorCoreTest, DISABLED_MultipleNonConsecutiveNDims) {
 // This is a tougher test where we insert a batch dim between the M dims
 // The batch dim is parallelized, so M1 and M2 are consecutive in shared
 // memory.
-TEST_F(GPUTTensorCoreTest, MultipleMDimsBatch) {
+TEST_F(MatmulTest, MultipleMDimsBatch) {
   int Batch = 2, M1 = 126, N = 136, M2 = 4, K = 248;
 
   Fusion fusion;
@@ -3460,5 +3409,11 @@ TEST_F(GPUTTensorCoreTest, MultipleMDimsBatch) {
 }
 
 #undef NVFUSER_TEST_CUDA_ARCH_GUARD
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    MatmulTestWithLayout,
+    kAllSupportedMmaLayout,
+    mmaLayoutName);
 
 } // namespace nvfuser

--- a/tests/cpp/test_matmul_sass.cpp
+++ b/tests/cpp/test_matmul_sass.cpp
@@ -24,6 +24,17 @@ namespace nvfuser {
 
 using MatmulSASSTest = NVFuserTest;
 
+class MatmulSASSTestWithLayout
+    : public NVFuserTest,
+      public ::testing::WithParamInterface<MmaLayout> {
+ protected:
+  MmaLayout layout;
+  void SetUp() override {
+    layout = GetParam();
+    NVFuserTest::SetUp();
+  }
+};
+
 // For SASS instruction definitions, see:
 // https://docs.nvidia.com/cuda/cuda-binary-utilities/index.html#instruction-set-reference
 //
@@ -170,7 +181,7 @@ sass::Container getBinaryOpMulEpilogueSASSFor(
 
 } // namespace
 
-TEST_F(MatmulSASSTest, AmpereSanity_CUDA) {
+TEST_P(MatmulSASSTestWithLayout, AmpereSanity) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 
@@ -178,47 +189,51 @@ TEST_F(MatmulSASSTest, AmpereSanity_CUDA) {
   bool found_LDSM = false;
   bool found_HMMA = false;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    sass::Container sass;
-    NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-        8,
-        0,
-        sass = getSASSFor(
-            layout,
-            GemmTile(128, 128, 32),
-            GemmTile(64, 64, 32),
-            GemmTile(16, 8, 16),
-            MmaMacro::Ampere_16_8_16,
-            M,
-            N,
-            K));
-    for (const auto& inst : sass.code) {
-      std::visit(
-          [&](auto&& i) {
-            using T = std::decay_t<decltype(i)>;
-            if constexpr (std::is_same_v<sass::Instruction, T>) {
-              if (i.opCode() == "LDGSTS") {
-                found_LDGSTS = true;
-              } else if (i.opCode() == "LDSM") {
-                found_LDSM = true;
-              } else if (i.opCode() == "HMMA") {
-                found_HMMA = true;
-              }
+  sass::Container sass;
+  NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+      8,
+      0,
+      sass = getSASSFor(
+          layout,
+          GemmTile(128, 128, 32),
+          GemmTile(64, 64, 32),
+          GemmTile(16, 8, 16),
+          MmaMacro::Ampere_16_8_16,
+          M,
+          N,
+          K));
+  for (const auto& inst : sass.code) {
+    std::visit(
+        [&](auto&& i) {
+          using T = std::decay_t<decltype(i)>;
+          if constexpr (std::is_same_v<sass::Instruction, T>) {
+            if (i.opCode() == "LDGSTS") {
+              found_LDGSTS = true;
+            } else if (i.opCode() == "LDSM") {
+              found_LDSM = true;
+            } else if (i.opCode() == "HMMA") {
+              found_HMMA = true;
             }
-          },
-          inst);
-    }
-    NVF_CHECK(found_LDGSTS);
-    NVF_CHECK(found_LDSM);
-    NVF_CHECK(found_HMMA);
+          }
+        },
+        inst);
   }
+  NVF_CHECK(found_LDGSTS);
+  NVF_CHECK(found_LDSM);
+  NVF_CHECK(found_HMMA);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    MatmulSASSTestWithLayout,
+    kAllSupportedMmaLayout,
+    mmaLayoutName);
 
 // Check the modifiers of instructions. We are particularily interested in
 // load/store, mma, and sync instructions. Currently, the ground truth in this
 // test's asserts are based on experimental result of this test itself. In the
 // future, we should use cutlass's kernel as ground truth.
-TEST_F(MatmulSASSTest, AmpereModifiers_CUDA) {
+TEST_F(MatmulSASSTest, AmpereModifiers) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
@@ -333,7 +348,7 @@ TEST_F(MatmulSASSTest, AmpereModifiers_CUDA) {
 // load/store, mma, and sync instructions. Currently, the ground truth in this
 // test's asserts are based on experimental result of this test itself. In the
 // future, we should use cutlass's kernel as ground truth.
-TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue_CUDA) {
+TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   MatMulTileOptions gemm_tile;
   gemm_tile.cta_tile = GemmTile(128, 128, 32);
@@ -471,7 +486,7 @@ TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue_CUDA) {
   }
 }
 
-TEST_F(MatmulSASSTest, AmpereEpilogueBinaryOpMul_CUDA) {
+TEST_F(MatmulSASSTest, AmpereEpilogueBinaryOpMul) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(8, 0, 9, 0);
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
@@ -605,7 +620,7 @@ We need to reinvestigate the test below to determine whether to change it or del
 //   LDSM.16.M88.2 R144, [R213+0xa00] ;
 //   LDSM.16.M88.2 R146, [R213+0xc00] ;
 //   LDSM.16.M88.2 R148, [R213+0xe00] ;
-TEST_F(MatmulSASSTest, AmpereRegisterUsageLDSM_CUDA) {
+TEST_F(MatmulSASSTest, AmpereRegisterUsageLDSM) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -36,6 +36,17 @@ class MatmulSchedulerTest : public NVFuserTest {
       optimization_guard_;
 };
 
+class MatmulSchedulerTestWithLayout
+    : public MatmulSchedulerTest,
+      public ::testing::WithParamInterface<MmaLayout> {
+ protected:
+  MmaLayout layout;
+  void SetUp() override {
+    layout = GetParam();
+    MatmulSchedulerTest::SetUp();
+  }
+};
+
 using PrecisionsDesc = std::tuple<PrimDataType, PrimDataType, PrimDataType>;
 
 using AbsoluteError = double;
@@ -1081,50 +1092,48 @@ TEST_F(MatmulSchedulerTest, BasicMatmulStrictCheckTT) {
 }
 
 // Matmul test that reslies on segmenter for 'C = A x B' fusion, for Ampere
-TEST_F(MatmulSchedulerTest, BasicMatmulRelaxedCheck) {
+TEST_P(MatmulSchedulerTestWithLayout, BasicMatmulRelaxedCheck) {
   // skip until we have Hopper support
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 2048;
-  for (auto layout : kAllSupportedMmaLayout) {
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
 
-    auto tv0 = makeContigTensor(2, DataType::Half);
-    auto tv1 = makeContigTensor(2, DataType::Half);
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
+  auto tv0 = makeContigTensor(2, DataType::Half);
+  auto tv1 = makeContigTensor(2, DataType::Half);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-    fusion->addOutput(tv2);
+  fusion->addOutput(tv2);
 
-    NVF_CHECK(
-        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
-        "matmul fusion must have at least one MmaOp");
+  NVF_CHECK(
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
+      "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
-    NVF_CHECK(
-        fusion_layout == layout,
-        "mismatch between test layout (",
-        toString(layout),
-        ") and layout inferred from fusion definition (",
-        toString(fusion_layout),
-        ")");
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
+  NVF_CHECK(
+      fusion_layout == layout,
+      "mismatch between test layout (",
+      toString(layout),
+      ") and layout inferred from fusion definition (",
+      toString(fusion_layout),
+      ")");
 
-    auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K);
-    auto t1 = matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K);
-    auto tref = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
+  auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K);
+  auto t1 = matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K);
+  auto tref = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
 
-    FusionExecutorCache executor_cache(std::move(fusion));
+  FusionExecutorCache executor_cache(std::move(fusion));
 
-    auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
-    checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
+  checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
 
-    NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
-  }
+  NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
 }
 
 // Matmul test that reslies on segmenter for 'C = A x B' fusion, for Ampere
@@ -1647,365 +1656,521 @@ TEST_F(MatmulSchedulerTest, EpilogueAlphaBetaBias) {
 
 // Strided batch gemm test taht uses matmul scheduler, for Ampere:
 //   D = (A x B)
-TEST_F(MatmulSchedulerTest, StridedBatch) {
+TEST_P(MatmulSchedulerTestWithLayout, StridedBatch) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 248, B = 2;
-  for (auto layout : kAllSupportedMmaLayout) {
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
 
-    // A - tv0, B - tv1
-    auto tv0 = makeContigTensor(3, DataType::Half);
-    auto tv1 = makeContigTensor(3, DataType::Half);
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
+  // A - tv0, B - tv1
+  auto tv0 = makeContigTensor(3, DataType::Half);
+  auto tv1 = makeContigTensor(3, DataType::Half);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
 
-    // tv2 := A x B
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+  // tv2 := A x B
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
-    fusion->addOutput(tv2);
+  fusion->addOutput(tv2);
 
-    NVF_CHECK(
-        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
-        "matmul fusion must have at least one MmaOp");
+  NVF_CHECK(
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
+      "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
-    NVF_CHECK(
-        fusion_layout == layout,
-        "mismatch between test layout (",
-        toString(layout),
-        ") and layout inferred from fusion definition (",
-        toString(fusion_layout),
-        ")");
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
+  NVF_CHECK(
+      fusion_layout == layout,
+      "mismatch between test layout (",
+      toString(layout),
+      ") and layout inferred from fusion definition (",
+      toString(fusion_layout),
+      ")");
 
-    FusionExecutorCache executor_cache(std::move(fusion));
+  FusionExecutorCache executor_cache(std::move(fusion));
 
-    at::manual_seed(0);
-    auto t0 =
-        matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
-    auto t1 =
-        matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
-    auto t2 = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
+  at::manual_seed(0);
+  auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
+  auto t1 = matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
+  auto t2 = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
 
-    auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
-    checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
+  checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
 
-    // NOTE: increasted absolute tolerance to silence false negative
-    // verification
-    //       caused by different way of calculating reference
-    NVF_CHECK(outputs[0].allclose(t2, 0.0001, 0.0001));
-  }
+  // NOTE: increasted absolute tolerance to silence false negative
+  // verification
+  //       caused by different way of calculating reference
+  NVF_CHECK(outputs[0].allclose(t2, 0.0001, 0.0001));
 }
 
 // Strided batch gemm test with alpha and beta that uses matmul scheduler,
 //  for Ampere architecture:
 //   D = alpha * (A x B) + beta * C
-TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaBeta) {
+TEST_P(MatmulSchedulerTestWithLayout, StridedBatchEpilogueAlphaBeta) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 248, B = 2;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
 
-    // A - tv0, B - tv1, C - tv2
-    // alpha - s0, beta - s1
-    auto s0 = IrBuilder::create<Val>(DataType::Double);
-    auto s1 = IrBuilder::create<Val>(DataType::Double);
-    auto tv0 = makeContigTensor(3, DataType::Half);
-    auto tv1 = makeContigTensor(3, DataType::Half);
-    auto tv2 = makeContigTensor(3, DataType::Float);
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addInput(tv2);
-    fusion->addInput(s0);
-    fusion->addInput(s1);
+  // A - tv0, B - tv1, C - tv2
+  // alpha - s0, beta - s1
+  auto s0 = IrBuilder::create<Val>(DataType::Double);
+  auto s1 = IrBuilder::create<Val>(DataType::Double);
+  auto tv0 = makeContigTensor(3, DataType::Half);
+  auto tv1 = makeContigTensor(3, DataType::Half);
+  auto tv2 = makeContigTensor(3, DataType::Float);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
+  fusion->addInput(s0);
+  fusion->addInput(s1);
 
-    // tv3 := A x B
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
-    // tv4 := alpha * (A x B)
-    auto tv4 = mul(s0, tv3);
-    // tv5 := beta * C
-    auto tv5 = mul(s1, tv2);
-    // tv6 := alpha * (A x B) + beta * C
-    auto tv6 = add(tv4, tv5);
+  // tv3 := A x B
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
+  // tv4 := alpha * (A x B)
+  auto tv4 = mul(s0, tv3);
+  // tv5 := beta * C
+  auto tv5 = mul(s1, tv2);
+  // tv6 := alpha * (A x B) + beta * C
+  auto tv6 = add(tv4, tv5);
 
-    fusion->addOutput(tv6);
+  fusion->addOutput(tv6);
 
-    NVF_CHECK(
-        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
-        "matmul fusion must have at least one MmaOp");
+  NVF_CHECK(
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
+      "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
-    NVF_CHECK(
-        fusion_layout == layout,
-        "mismatch between test layout (",
-        toString(layout),
-        ") and layout inferred from fusion definition (",
-        toString(fusion_layout),
-        ")");
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
+  NVF_CHECK(
+      fusion_layout == layout,
+      "mismatch between test layout (",
+      toString(layout),
+      ") and layout inferred from fusion definition (",
+      toString(fusion_layout),
+      ")");
 
-    FusionExecutorCache executor_cache(std::move(fusion));
+  FusionExecutorCache executor_cache(std::move(fusion));
 
-    at::manual_seed(0);
-    const double alpha = 2.5;
-    const double beta = 1.5;
+  at::manual_seed(0);
+  const double alpha = 2.5;
+  const double beta = 1.5;
 
-    auto t0 =
-        matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
-    auto t1 =
-        matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
-    auto t2 =
-        matmulAtInput2D(layout, TensorMatmulPos::C, at::kFloat, M, N, K, B);
+  auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
+  auto t1 = matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
+  auto t2 = matmulAtInput2D(layout, TensorMatmulPos::C, at::kFloat, M, N, K, B);
 
-    auto t3 = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
-    auto t4 = at::mul(t3, alpha).to(at::kFloat);
-    auto t5 = at::mul(t2, beta).to(at::kFloat);
-    auto t6 = at::add(t4, t5);
+  auto t3 = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
+  auto t4 = at::mul(t3, alpha).to(at::kFloat);
+  auto t5 = at::mul(t2, beta).to(at::kFloat);
+  auto t6 = at::add(t4, t5);
 
-    auto outputs =
-        executor_cache.runFusionWithInputs({t0, t1, t2, alpha, beta});
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2, alpha, beta});
 
-    checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
+  checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
 
-    // NOTE: increasted absolute tolerance to silence false negative
-    //  verification caused by different way of calculating reference
-    NVF_CHECK(outputs[0].allclose(t6, 0.0001, 0.0001));
-  }
+  // NOTE: increasted absolute tolerance to silence false negative
+  //  verification caused by different way of calculating reference
+  NVF_CHECK(outputs[0].allclose(t6, 0.0001, 0.0001));
 }
 
 // Strided batch gemm test with alpha and beta scaling that uses matmul
 // scheduler,
 //  there is only single C tensor for whole batch; test for Ampere architecture:
 //   D = alpha * (A x B) + beta * C
-TEST_F(MatmulSchedulerTest, StridedBatchEpilogueAlphaSingleBeta) {
+TEST_P(MatmulSchedulerTestWithLayout, StridedBatchEpilogueAlphaSingleBeta) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 248, B = 2;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
 
-    // A - tv0, B - tv1, C - tv2
-    // alpha - s0, beta - s1
-    auto s0 = IrBuilder::create<Val>(DataType::Double);
-    auto s1 = IrBuilder::create<Val>(DataType::Double);
-    auto tv0 = makeContigTensor(3, DataType::Half);
-    auto tv1 = makeContigTensor(3, DataType::Half);
-    auto tv2 = makeContigTensor(2, DataType::Float);
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addInput(tv2);
-    fusion->addInput(s0);
-    fusion->addInput(s1);
+  // A - tv0, B - tv1, C - tv2
+  // alpha - s0, beta - s1
+  auto s0 = IrBuilder::create<Val>(DataType::Double);
+  auto s1 = IrBuilder::create<Val>(DataType::Double);
+  auto tv0 = makeContigTensor(3, DataType::Half);
+  auto tv1 = makeContigTensor(3, DataType::Half);
+  auto tv2 = makeContigTensor(2, DataType::Float);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
+  fusion->addInput(s0);
+  fusion->addInput(s1);
 
-    // tv3 := A x B
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
-    // tv4 := alpha * (A x B)
-    auto tv4 = mul(s0, tv3);
-    // tv5 := beta * C
-    auto tv5 = mul(s1, tv2);
-    // tv6 := bcast(beta * C)
-    // [M, N] -> [B, M, N], with B as bcast
-    auto tv6 = broadcast(tv5, {true, false, false});
-    // tv7 := alpha * (A x B) + beta * C
-    auto tv7 = add(tv4, tv6);
+  // tv3 := A x B
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
+  // tv4 := alpha * (A x B)
+  auto tv4 = mul(s0, tv3);
+  // tv5 := beta * C
+  auto tv5 = mul(s1, tv2);
+  // tv6 := bcast(beta * C)
+  // [M, N] -> [B, M, N], with B as bcast
+  auto tv6 = broadcast(tv5, {true, false, false});
+  // tv7 := alpha * (A x B) + beta * C
+  auto tv7 = add(tv4, tv6);
 
-    fusion->addOutput(tv7);
+  fusion->addOutput(tv7);
 
-    NVF_CHECK(
-        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
-        "matmul fusion must have at least one MmaOp");
+  NVF_CHECK(
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
+      "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
-    NVF_CHECK(
-        fusion_layout == layout,
-        "mismatch between test layout (",
-        toString(layout),
-        ") and layout inferred from fusion definition (",
-        toString(fusion_layout),
-        ")");
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
+  NVF_CHECK(
+      fusion_layout == layout,
+      "mismatch between test layout (",
+      toString(layout),
+      ") and layout inferred from fusion definition (",
+      toString(fusion_layout),
+      ")");
 
-    FusionExecutorCache executor_cache(std::move(fusion));
+  FusionExecutorCache executor_cache(std::move(fusion));
 
-    at::manual_seed(0);
-    const double alpha = 1.5;
-    const double beta = 2.5;
+  at::manual_seed(0);
+  const double alpha = 1.5;
+  const double beta = 2.5;
 
-    auto t0 =
-        matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
-    auto t1 =
-        matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
-    auto t2 = matmulAtInput2D(layout, TensorMatmulPos::C, at::kFloat, M, N, K);
+  auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
+  auto t1 = matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
+  auto t2 = matmulAtInput2D(layout, TensorMatmulPos::C, at::kFloat, M, N, K);
 
-    auto t3 = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
-    auto t4 = at::mul(t3, alpha).to(at::kFloat);
-    auto t5 = at::mul(t2, beta).to(at::kFloat);
-    // NOTE: t6, a result of adding an outer-most broadcast dimension to
-    //  the result of scaling C with beta
-    auto t6 = at::unsqueeze(t5, 0);
-    auto t7 = at::add(t4, t5);
+  auto t3 = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
+  auto t4 = at::mul(t3, alpha).to(at::kFloat);
+  auto t5 = at::mul(t2, beta).to(at::kFloat);
+  // NOTE: t6, a result of adding an outer-most broadcast dimension to
+  //  the result of scaling C with beta
+  auto t6 = at::unsqueeze(t5, 0);
+  auto t7 = at::add(t4, t5);
 
-    auto outputs =
-        executor_cache.runFusionWithInputs({t0, t1, t2, alpha, beta});
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2, alpha, beta});
 
-    checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
+  checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
 
-    // NOTE: increasted absolute tolerance to silence false negative
-    //  verification caused by different way of calculating reference
-    NVF_CHECK(outputs[0].allclose(t7, 0.0001, 0.0001));
-  }
+  // NOTE: increasted absolute tolerance to silence false negative
+  //  verification caused by different way of calculating reference
+  NVF_CHECK(outputs[0].allclose(t7, 0.0001, 0.0001));
 }
 
 // Strided batch gemm test with bias that uses matmul scheduler, for Ampere:
 //   D = (A x B) + bias
-TEST_F(MatmulSchedulerTest, StridedBatchEpilogueBias) {
+TEST_P(MatmulSchedulerTestWithLayout, StridedBatchEpilogueBias) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 248, B = 2;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
 
-    // A - tv0, B - tv1, bias - tv2
-    auto tv0 = makeContigTensor(3, DataType::Half);
-    auto tv1 = makeContigTensor(3, DataType::Half);
-    auto tv2 = makeContigTensor(2, DataType::Float);
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addInput(tv2);
+  // A - tv0, B - tv1, bias - tv2
+  auto tv0 = makeContigTensor(3, DataType::Half);
+  auto tv1 = makeContigTensor(3, DataType::Half);
+  auto tv2 = makeContigTensor(2, DataType::Float);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
 
-    // tv3 := A x B
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
-    // tv4 := (A x B) + bias
-    auto tv4 = biasEpilogue(tv3, tv2);
+  // tv3 := A x B
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
+  // tv4 := (A x B) + bias
+  auto tv4 = biasEpilogue(tv3, tv2);
 
-    fusion->addOutput(tv4);
+  fusion->addOutput(tv4);
 
-    NVF_CHECK(
-        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
-        "matmul fusion must have at least one MmaOp");
+  NVF_CHECK(
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
+      "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
-    NVF_CHECK(
-        fusion_layout == layout,
-        "mismatch between test layout (",
-        toString(layout),
-        ") and layout inferred from fusion definition (",
-        toString(fusion_layout),
-        ")");
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
+  NVF_CHECK(
+      fusion_layout == layout,
+      "mismatch between test layout (",
+      toString(layout),
+      ") and layout inferred from fusion definition (",
+      toString(fusion_layout),
+      ")");
 
-    FusionExecutorCache executor_cache(std::move(fusion));
+  FusionExecutorCache executor_cache(std::move(fusion));
 
-    at::manual_seed(0);
-    auto t0 =
-        matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
-    auto t1 =
-        matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
-    auto t2 =
-        matmulAtInput2D(layout, TensorMatmulPos::Bias, at::kFloat, M, N, K, B);
+  at::manual_seed(0);
+  auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
+  auto t1 = matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
+  auto t2 =
+      matmulAtInput2D(layout, TensorMatmulPos::Bias, at::kFloat, M, N, K, B);
 
-    auto t3 = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
-    auto t4 = atBiasEpilogue(t3, t2).to(at::kFloat);
+  auto t3 = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
+  auto t4 = atBiasEpilogue(t3, t2).to(at::kFloat);
 
-    auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
-    checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
+  checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
 
-    // NOTE: increasted absolute tolerance to silence false negative
-    //  verification caused by different way of calculating reference
-    NVF_CHECK(outputs[0].allclose(t4, 0.0001, 0.0001));
-  }
+  // NOTE: increasted absolute tolerance to silence false negative
+  //  verification caused by different way of calculating reference
+  NVF_CHECK(outputs[0].allclose(t4, 0.0001, 0.0001));
 }
 
 // Strided batch gemm test with single bias vector that uses matmul
 // scheduler, for Ampere:
 //   D = (A x B) + bias
-TEST_F(MatmulSchedulerTest, StridedBatchEpilogueSingleBias) {
+TEST_P(MatmulSchedulerTestWithLayout, StridedBatchEpilogueSingleBias) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   const int M = 504, N = 136, K = 248, B = 2;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
 
-    // A - tv0, B - tv1, bias - tv2
-    auto tv0 = makeContigTensor(3, DataType::Half);
-    auto tv1 = makeContigTensor(3, DataType::Half);
-    auto tv2 = makeContigTensor(1, DataType::Float);
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    fusion->addInput(tv2);
+  // A - tv0, B - tv1, bias - tv2
+  auto tv0 = makeContigTensor(3, DataType::Half);
+  auto tv1 = makeContigTensor(3, DataType::Half);
+  auto tv2 = makeContigTensor(1, DataType::Float);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addInput(tv2);
 
-    // tv3 := A x B
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
-    // tv4 := (A x B) + bias
-    auto tv4 = biasEpilogue(tv3, tv2);
+  // tv3 := A x B
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv3 = fusedMultiplySum(tv0, tv1, {-1});
+  // tv4 := (A x B) + bias
+  auto tv4 = biasEpilogue(tv3, tv2);
 
-    fusion->addOutput(tv4);
+  fusion->addOutput(tv4);
 
-    NVF_CHECK(
-        1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
-        "matmul fusion must have at least one MmaOp");
+  NVF_CHECK(
+      1 == ir_utils::getOpsOfType<MmaOp>(fusion.get()).size(),
+      "matmul fusion must have at least one MmaOp");
 
-    const auto fusion_layout = getMatmulProblemLayout(fusion.get());
-    NVF_CHECK(
-        fusion_layout == layout,
-        "mismatch between test layout (",
-        toString(layout),
-        ") and layout inferred from fusion definition (",
-        toString(fusion_layout),
-        ")");
+  const auto fusion_layout = getMatmulProblemLayout(fusion.get());
+  NVF_CHECK(
+      fusion_layout == layout,
+      "mismatch between test layout (",
+      toString(layout),
+      ") and layout inferred from fusion definition (",
+      toString(fusion_layout),
+      ")");
 
-    FusionExecutorCache executor_cache(std::move(fusion));
+  FusionExecutorCache executor_cache(std::move(fusion));
 
-    at::manual_seed(0);
-    auto t0 =
-        matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
-    auto t1 =
-        matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
-    // Explicitly make bias tensor a single dim by passing 0 for batch
-    auto t2 =
-        matmulAtInput2D(layout, TensorMatmulPos::Bias, at::kFloat, M, N, K, 0);
+  at::manual_seed(0);
+  auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
+  auto t1 = matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
+  // Explicitly make bias tensor a single dim by passing 0 for batch
+  auto t2 =
+      matmulAtInput2D(layout, TensorMatmulPos::Bias, at::kFloat, M, N, K, 0);
 
-    auto t3 = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
-    auto t4 = atBiasEpilogue(t3, t2).to(at::kFloat);
+  auto t3 = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
+  auto t4 = atBiasEpilogue(t3, t2).to(at::kFloat);
 
-    auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
-    checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
+  checkUnsegmentedVectorization(executor_cache, 8, 8, 4);
 
-    // NOTE: increasted absolute tolerance to silence false negative
-    //  verification caused by different way of calculating reference
-    NVF_CHECK(outputs[0].allclose(t4, 0.0001, 0.0001));
-  }
+  // NOTE: increasted absolute tolerance to silence false negative
+  //  verification caused by different way of calculating reference
+  NVF_CHECK(outputs[0].allclose(t4, 0.0001, 0.0001));
 }
 
 // Test matmul with contiguous inputs but sizes that are not divisible by 8 and
 // with misaligned input pointers
-TEST_F(MatmulSchedulerTest, MisalignedVectorization) {
+TEST_P(MatmulSchedulerTestWithLayout, MisalignedVectorization) {
   NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
   // TODO: parametrized test instead of nested loops (still use a loop over
   // sizes and re-use FusionExecutorCache)
-  for (auto layout : kAllSupportedMmaLayout) {
-    for (bool add_2d_bias : {false, true}) {
-      for (bool downcast_output : {false, true}) {
+  for (bool add_2d_bias : {false, true}) {
+    for (bool downcast_output : {false, true}) {
+      auto fusion = std::make_unique<Fusion>();
+      FusionGuard fg(fusion.get());
+
+      auto tv0 = makeContigTensor(2, DataType::Half);
+      auto tv1 = makeContigTensor(2, DataType::Half);
+      fusion->addInput(tv0);
+      fusion->addInput(tv1);
+
+      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+      auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
+
+      if (add_2d_bias) {
+        auto bias = makeContigTensor(2, DataType::Half);
+        fusion->addInput(bias);
+        tv2 = add(tv2, bias);
+      }
+
+      if (downcast_output) {
+        tv2 = castOp(DataType::Half, tv2);
+      }
+
+      fusion->addOutput(tv2);
+
+      const auto fusion_layout = getMatmulProblemLayout(fusion.get());
+      NVF_CHECK(
+          fusion_layout == layout,
+          "mismatch between test layout (",
+          toString(layout),
+          ") and layout inferred from fusion definition (",
+          toString(fusion_layout),
+          ")");
+
+      FusionExecutorCache executor_cache(std::move(fusion));
+
+      auto run = [&](int M,
+                     int N,
+                     int K,
+                     // Pointer alignment
+                     int align_A,
+                     int align_B,
+                     int align_bias,
+                     int expected_vec_A,
+                     int expected_vec_B,
+                     int expected_vec_epilogue) {
+        const auto maybeUnalign = [](const at::Tensor& t, int offset) {
+          if (offset == 16 / t.element_size()) {
+            // Already fully aligned
+            return t;
+          }
+          return at::pad(t.ravel(), {{0, offset}})
+              .index({at::indexing::Slice(offset, t.numel() + offset, 1)})
+              .view({t.size(0), t.size(1)});
+        };
+
+        auto t0 = maybeUnalign(
+            matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K),
+            align_A);
+        auto t1 = maybeUnalign(
+            matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K),
+            align_B);
+
+        auto tref = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
+
+        std::vector<c10::IValue> inputs = {t0, t1};
+
+        if (add_2d_bias) {
+          const auto options =
+              at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
+          auto bias = maybeUnalign(at::randn({M, N}, options), align_bias);
+          tref = tref + bias;
+          inputs.emplace_back(bias);
+        }
+
+        if (downcast_output) {
+          tref = tref.to(at::kHalf);
+        }
+
+        auto outputs = executor_cache.runFusionWithInputs(inputs);
+
+        FusionKernelRuntime* runtime =
+            executor_cache.getMostRecentKernelRuntime();
+
+        ASSERT_NE(runtime, nullptr);
+
+        // expected to match whole fusion with single segment
+        EXPECT_FALSE(runtime->isSegmented());
+
+        ASSERT_TRUE(isSchedulerInUse(runtime, ScheduleHeuristic::Matmul));
+
+        // Check that supported_vec_size matches expected.
+        const MatmulParams& params = runtime->schedulerHeuristics()
+                                         ->heuristicsList()
+                                         .front()
+                                         ->matmulParams();
+
+        EXPECT_EQ(params.supported_vec_size.a, expected_vec_A);
+        EXPECT_EQ(params.supported_vec_size.b, expected_vec_B);
+        EXPECT_EQ(params.supported_vec_size.epilogue, expected_vec_epilogue);
+
+        EXPECT_TRUE(outputs[0].allclose(tref, 0.001, 0.001));
+      };
+
+      [[maybe_unused]] bool contig_K_A =
+          layout == MmaLayout::TT || layout == MmaLayout::TN;
+      [[maybe_unused]] bool contig_K_B =
+          layout == MmaLayout::TN || layout == MmaLayout::NN;
+
+      // When not downcasting, outputs are Float
+      [[maybe_unused]] int max_vec_epi = downcast_output ? 8 : 4;
+
+      // all fully vectorizable in all layouts
+      run(504, 136, 248, 8, 8, 8, 8, 8, max_vec_epi);
+      // odd K. Operands vectorizable when K is not the contiguous axis.
+      // Output always fully vectorizable
+      run(504,
+          136,
+          249,
+          8,
+          8,
+          8,
+          contig_K_A ? 1 : 8,
+          contig_K_B ? 1 : 8,
+          max_vec_epi);
+      // Odd N. Output not vectorizable. A fully vectorizable. B fully
+      // vectorizable unless N is the contiguous dim.
+      run(504, 137, 248, 8, 8, 8, 8, contig_K_B ? 8 : 1, 1);
+      // Odd M. Output fully vectorizable. B fully vectorizable. A fully
+      // vectorizable unless M is the contiguous dim.
+      run(505, 136, 248, 8, 8, 8, contig_K_A ? 8 : 1, 8, max_vec_epi);
+      // Odd M and N. Output not vectorizable. A and B fully vectorizable
+      // unless K is not the contiguous dim.
+      run(505, 137, 248, 8, 8, 8, contig_K_A ? 8 : 1, contig_K_B ? 8 : 1, 1);
+      // Odd M, N, K. None vectorizable.
+      run(505, 137, 249, 8, 8, 8, 1, 1, 1);
+      // Cases with vectorizable strides but misaligned base pointers
+      // A not vectorizable due to pointer offset
+      run(504, 136, 248, 2, 8, 8, 2, 8, max_vec_epi);
+      // B not vectorizable due to pointer offset
+      run(504, 136, 248, 8, 2, 8, 8, 2, max_vec_epi);
+      run(504, 136, 248, 8, 8, 2, 8, 8, add_2d_bias ? 2 : max_vec_epi);
+    }
+  }
+}
+
+// Test matmul with strided inputs. This tests that vectorization is properly
+// computed.
+TEST_P(MatmulSchedulerTestWithLayout, StridedInputs) {
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
+  for (bool add_2d_bias : {false, true}) {
+    for (bool downcast_output : {false, true}) {
+      auto run = [&](int M,
+                     int N,
+                     int K,
+                     // Pointer alignment
+                     int align_A,
+                     int align_B,
+                     int align_bias,
+                     // Whether to mark the TensorViews as contiguous
+                     bool contiguous_inner_dim_A,
+                     bool contiguous_inner_dim_B,
+                     bool contiguous_inner_dim_bias,
+                     // Padding
+                     int pad_A,
+                     int pad_B,
+                     int pad_bias,
+                     int expected_vec_A,
+                     int expected_vec_B,
+                     int expected_vec_epilogue) {
         auto fusion = std::make_unique<Fusion>();
         FusionGuard fg(fusion.get());
 
-        auto tv0 = makeContigTensor(2, DataType::Half);
-        auto tv1 = makeContigTensor(2, DataType::Half);
+        // Inputs are contiguous in their inner dimension but discontiguous
+        // in the outer dim.
+        auto tv0 = TensorViewBuilder()
+                       .ndims(2)
+                       .contiguity({false, contiguous_inner_dim_A})
+                       .dtype(DataType::Half)
+                       .build();
+        auto tv1 = TensorViewBuilder()
+                       .ndims(2)
+                       .contiguity({false, contiguous_inner_dim_B})
+                       .dtype(DataType::Half)
+                       .build();
+
         fusion->addInput(tv0);
         fusion->addInput(tv1);
 
@@ -2014,7 +2179,11 @@ TEST_F(MatmulSchedulerTest, MisalignedVectorization) {
         auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
 
         if (add_2d_bias) {
-          auto bias = makeContigTensor(2, DataType::Half);
+          auto bias = TensorViewBuilder()
+                          .ndims(2)
+                          .contiguity({false, contiguous_inner_dim_bias})
+                          .dtype(DataType::Half)
+                          .build();
           fusion->addInput(bias);
           tv2 = add(tv2, bias);
         }
@@ -2036,416 +2205,207 @@ TEST_F(MatmulSchedulerTest, MisalignedVectorization) {
 
         FusionExecutorCache executor_cache(std::move(fusion));
 
-        auto run = [&](int M,
-                       int N,
-                       int K,
-                       // Pointer alignment
-                       int align_A,
-                       int align_B,
-                       int align_bias,
-                       int expected_vec_A,
-                       int expected_vec_B,
-                       int expected_vec_epilogue) {
-          const auto maybeUnalign = [](const at::Tensor& t, int offset) {
-            if (offset == 16 / t.element_size()) {
-              // Already fully aligned
-              return t;
-            }
-            return at::pad(t.ravel(), {{0, offset}})
-                .index({at::indexing::Slice(offset, t.numel() + offset, 1)})
-                .view({t.size(0), t.size(1)});
-          };
-
-          auto t0 = maybeUnalign(
-              matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K),
-              align_A);
-          auto t1 = maybeUnalign(
-              matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K),
-              align_B);
-
-          auto tref = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
-
-          std::vector<c10::IValue> inputs = {t0, t1};
-
-          if (add_2d_bias) {
-            const auto options =
-                at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-            auto bias = maybeUnalign(at::randn({M, N}, options), align_bias);
-            tref = tref + bias;
-            inputs.emplace_back(bias);
-          }
-
-          if (downcast_output) {
-            tref = tref.to(at::kHalf);
-          }
-
-          auto outputs = executor_cache.runFusionWithInputs(inputs);
-
-          FusionKernelRuntime* runtime =
-              executor_cache.getMostRecentKernelRuntime();
-
-          ASSERT_NE(runtime, nullptr);
-
-          // expected to match whole fusion with single segment
-          EXPECT_FALSE(runtime->isSegmented());
-
-          ASSERT_TRUE(isSchedulerInUse(runtime, ScheduleHeuristic::Matmul));
-
-          // Check that supported_vec_size matches expected.
-          const MatmulParams& params = runtime->schedulerHeuristics()
-                                           ->heuristicsList()
-                                           .front()
-                                           ->matmulParams();
-
-          EXPECT_EQ(params.supported_vec_size.a, expected_vec_A);
-          EXPECT_EQ(params.supported_vec_size.b, expected_vec_B);
-          EXPECT_EQ(params.supported_vec_size.epilogue, expected_vec_epilogue);
-
-          EXPECT_TRUE(outputs[0].allclose(tref, 0.001, 0.001));
-        };
-
-        [[maybe_unused]] bool contig_K_A =
-            layout == MmaLayout::TT || layout == MmaLayout::TN;
-        [[maybe_unused]] bool contig_K_B =
-            layout == MmaLayout::TN || layout == MmaLayout::NN;
-
-        // When not downcasting, outputs are Float
-        [[maybe_unused]] int max_vec_epi = downcast_output ? 8 : 4;
-
-        // all fully vectorizable in all layouts
-        run(504, 136, 248, 8, 8, 8, 8, 8, max_vec_epi);
-        // odd K. Operands vectorizable when K is not the contiguous axis.
-        // Output always fully vectorizable
-        run(504,
-            136,
-            249,
-            8,
-            8,
-            8,
-            contig_K_A ? 1 : 8,
-            contig_K_B ? 1 : 8,
-            max_vec_epi);
-        // Odd N. Output not vectorizable. A fully vectorizable. B fully
-        // vectorizable unless N is the contiguous dim.
-        run(504, 137, 248, 8, 8, 8, 8, contig_K_B ? 8 : 1, 1);
-        // Odd M. Output fully vectorizable. B fully vectorizable. A fully
-        // vectorizable unless M is the contiguous dim.
-        run(505, 136, 248, 8, 8, 8, contig_K_A ? 8 : 1, 8, max_vec_epi);
-        // Odd M and N. Output not vectorizable. A and B fully vectorizable
-        // unless K is not the contiguous dim.
-        run(505, 137, 248, 8, 8, 8, contig_K_A ? 8 : 1, contig_K_B ? 8 : 1, 1);
-        // Odd M, N, K. None vectorizable.
-        run(505, 137, 249, 8, 8, 8, 1, 1, 1);
-        // Cases with vectorizable strides but misaligned base pointers
-        // A not vectorizable due to pointer offset
-        run(504, 136, 248, 2, 8, 8, 2, 8, max_vec_epi);
-        // B not vectorizable due to pointer offset
-        run(504, 136, 248, 8, 2, 8, 8, 2, max_vec_epi);
-        run(504, 136, 248, 8, 8, 2, 8, 8, add_2d_bias ? 2 : max_vec_epi);
-      }
-    }
-  }
-}
-
-// Test matmul with strided inputs. This tests that vectorization is properly
-// computed.
-TEST_F(MatmulSchedulerTest, StridedInputs) {
-  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(7, 5, 9, 0);
-  for (auto layout : kAllSupportedMmaLayout) {
-    for (bool add_2d_bias : {false, true}) {
-      for (bool downcast_output : {false, true}) {
-        auto run = [&](int M,
-                       int N,
-                       int K,
-                       // Pointer alignment
-                       int align_A,
-                       int align_B,
-                       int align_bias,
-                       // Whether to mark the TensorViews as contiguous
-                       bool contiguous_inner_dim_A,
-                       bool contiguous_inner_dim_B,
-                       bool contiguous_inner_dim_bias,
-                       // Padding
-                       int pad_A,
-                       int pad_B,
-                       int pad_bias,
-                       int expected_vec_A,
-                       int expected_vec_B,
-                       int expected_vec_epilogue) {
-          auto fusion = std::make_unique<Fusion>();
-          FusionGuard fg(fusion.get());
-
-          // Inputs are contiguous in their inner dimension but discontiguous
-          // in the outer dim.
-          auto tv0 = TensorViewBuilder()
-                         .ndims(2)
-                         .contiguity({false, contiguous_inner_dim_A})
-                         .dtype(DataType::Half)
-                         .build();
-          auto tv1 = TensorViewBuilder()
-                         .ndims(2)
-                         .contiguity({false, contiguous_inner_dim_B})
-                         .dtype(DataType::Half)
-                         .build();
-
-          fusion->addInput(tv0);
-          fusion->addInput(tv1);
-
-          tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-          tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-          auto tv2 = fusedMultiplySum(tv0, tv1, {-1});
-
-          if (add_2d_bias) {
-            auto bias = TensorViewBuilder()
-                            .ndims(2)
-                            .contiguity({false, contiguous_inner_dim_bias})
-                            .dtype(DataType::Half)
-                            .build();
-            fusion->addInput(bias);
-            tv2 = add(tv2, bias);
-          }
-
-          if (downcast_output) {
-            tv2 = castOp(DataType::Half, tv2);
-          }
-
-          fusion->addOutput(tv2);
-
-          const auto fusion_layout = getMatmulProblemLayout(fusion.get());
-          NVF_CHECK(
-              fusion_layout == layout,
-              "mismatch between test layout (",
-              toString(layout),
-              ") and layout inferred from fusion definition (",
-              toString(fusion_layout),
-              ")");
-
-          FusionExecutorCache executor_cache(std::move(fusion));
-
-          // stride to introduce pad in the inner-most dimension, and shift
-          // data pointer by offset
-          const auto padAndUnalign2D =
-              [](const at::Tensor& t, int pad_to, int offset) {
-                // Determine new strides. We pad the contiguous axis by
-                // increasing the other stride to the next highest multiple of 8
-                std::vector<int64_t> new_strides(t.ndimension(), 0);
-                int64_t linear_size = 1;
-                for (size_t i : c10::irange(t.ndimension())) {
-                  new_strides[i] = t.stride((int64_t)i);
-                  if (new_strides[i] != 1) {
-                    // Pad contiguous dimension by modifying other stride. This
-                    // only works for 2D tensors.
-                    new_strides[i] += pad_to;
-                  }
-                  // Use strides to determine space needed for padded tensor
-                  linear_size += t.size((int64_t)i) * new_strides[i];
+        // stride to introduce pad in the inner-most dimension, and shift
+        // data pointer by offset
+        const auto padAndUnalign2D =
+            [](const at::Tensor& t, int pad_to, int offset) {
+              // Determine new strides. We pad the contiguous axis by
+              // increasing the other stride to the next highest multiple of 8
+              std::vector<int64_t> new_strides(t.ndimension(), 0);
+              int64_t linear_size = 1;
+              for (size_t i : c10::irange(t.ndimension())) {
+                new_strides[i] = t.stride((int64_t)i);
+                if (new_strides[i] != 1) {
+                  // Pad contiguous dimension by modifying other stride. This
+                  // only works for 2D tensors.
+                  new_strides[i] += pad_to;
                 }
+                // Use strides to determine space needed for padded tensor
+                linear_size += t.size((int64_t)i) * new_strides[i];
+              }
 
-                at::Tensor out = at::as_strided(
-                    at::empty({linear_size}, t.options())
-                        .index({at::indexing::Slice(
-                            offset, linear_size + offset, 1)}),
-                    t.sizes(),
-                    new_strides);
-                out.copy_(t);
-                return out;
-              };
+              at::Tensor out = at::as_strided(
+                  at::empty({linear_size}, t.options())
+                      .index({at::indexing::Slice(
+                          offset, linear_size + offset, 1)}),
+                  t.sizes(),
+                  new_strides);
+              out.copy_(t);
+              return out;
+            };
 
-          auto t0 = padAndUnalign2D(
-              matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K),
-              pad_A,
-              align_A);
-          auto t1 = padAndUnalign2D(
-              matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K),
-              pad_B,
-              align_B);
+        auto t0 = padAndUnalign2D(
+            matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K),
+            pad_A,
+            align_A);
+        auto t1 = padAndUnalign2D(
+            matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K),
+            pad_B,
+            align_B);
 
-          auto tref = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
+        auto tref = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
 
-          std::vector<c10::IValue> inputs = {t0, t1};
+        std::vector<c10::IValue> inputs = {t0, t1};
 
-          if (add_2d_bias) {
-            const auto options =
-                at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-            auto bias = padAndUnalign2D(
-                at::randn({M, N}, options), pad_bias, align_bias);
-            tref = tref + bias;
-            inputs.emplace_back(bias);
-          }
+        if (add_2d_bias) {
+          const auto options =
+              at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
+          auto bias =
+              padAndUnalign2D(at::randn({M, N}, options), pad_bias, align_bias);
+          tref = tref + bias;
+          inputs.emplace_back(bias);
+        }
 
-          if (downcast_output) {
-            tref = tref.to(at::kHalf);
-          }
+        if (downcast_output) {
+          tref = tref.to(at::kHalf);
+        }
 
-          auto outputs = executor_cache.runFusionWithInputs(inputs);
+        auto outputs = executor_cache.runFusionWithInputs(inputs);
 
-          FusionKernelRuntime* runtime =
-              executor_cache.getMostRecentKernelRuntime();
+        FusionKernelRuntime* runtime =
+            executor_cache.getMostRecentKernelRuntime();
 
-          ASSERT_NE(runtime, nullptr);
+        ASSERT_NE(runtime, nullptr);
 
-          // expected to match whole fusion with single segment
-          EXPECT_FALSE(runtime->isSegmented());
+        // expected to match whole fusion with single segment
+        EXPECT_FALSE(runtime->isSegmented());
 
-          ASSERT_TRUE(isSchedulerInUse(runtime, ScheduleHeuristic::Matmul));
+        ASSERT_TRUE(isSchedulerInUse(runtime, ScheduleHeuristic::Matmul));
 
-          // Check that supported_vec_size matches expected.
-          const MatmulParams& params = runtime->schedulerHeuristics()
-                                           ->heuristicsList()
-                                           .front()
-                                           ->matmulParams();
+        // Check that supported_vec_size matches expected.
+        const MatmulParams& params = runtime->schedulerHeuristics()
+                                         ->heuristicsList()
+                                         .front()
+                                         ->matmulParams();
 
-          EXPECT_EQ(params.supported_vec_size.a, expected_vec_A);
-          EXPECT_EQ(params.supported_vec_size.b, expected_vec_B);
-          EXPECT_EQ(params.supported_vec_size.epilogue, expected_vec_epilogue);
+        EXPECT_EQ(params.supported_vec_size.a, expected_vec_A);
+        EXPECT_EQ(params.supported_vec_size.b, expected_vec_B);
+        EXPECT_EQ(params.supported_vec_size.epilogue, expected_vec_epilogue);
 
-          EXPECT_TRUE(outputs[0].allclose(tref, 0.001, 0.001));
-        };
+        EXPECT_TRUE(outputs[0].allclose(tref, 0.001, 0.001));
+      };
 
-        [[maybe_unused]] bool contig_K_A =
-            layout == MmaLayout::TT || layout == MmaLayout::TN;
-        [[maybe_unused]] bool contig_K_B =
-            layout == MmaLayout::TN || layout == MmaLayout::NN;
+      [[maybe_unused]] bool contig_K_A =
+          layout == MmaLayout::TT || layout == MmaLayout::TN;
+      [[maybe_unused]] bool contig_K_B =
+          layout == MmaLayout::TN || layout == MmaLayout::NN;
 
-        // When not downcasting, outputs are Float
-        [[maybe_unused]] int max_vec_epi = downcast_output ? 8 : 4;
+      // When not downcasting, outputs are Float
+      [[maybe_unused]] int max_vec_epi = downcast_output ? 8 : 4;
 
-        // Pad outer stride of A by 1. M and K are even, so no vectorization of
-        // A is possible despite compatible sizes.
-        run(504,
-            136,
-            248,
-            8,
-            8,
-            8,
-            true,
-            true,
-            true,
-            1,
-            0,
-            0,
-            1,
-            8,
-            max_vec_epi);
-        // Pad outer stride of B by 1. N and K are even, so no vectorization of
-        // B is possible despite compatible sizes.
-        run(504,
-            136,
-            248,
-            8,
-            8,
-            8,
-            true,
-            true,
-            true,
-            0,
-            1,
-            0,
-            8,
-            1,
-            max_vec_epi);
-        // Padding by 2 from a multiple of 8 means we can only vectorize at
-        // width 2
-        run(504,
-            136,
-            248,
-            8,
-            8,
-            8,
-            true,
-            true,
-            true,
-            2,
-            2,
-            2,
-            2,
-            2,
-            add_2d_bias ? 2 : max_vec_epi);
-        // Incompatible sizes are not vectorized despite padding to compatible
-        // strides
-        run(505,
-            136,
-            249,
-            8,
-            8,
-            8,
-            true,
-            true,
-            true,
-            1,
-            0,
-            0,
-            1,
-            contig_K_B ? 1 : 8,
-            max_vec_epi);
-        run(504,
-            137,
-            249,
-            8,
-            8,
-            8,
-            true,
-            true,
-            true,
-            0,
-            1,
-            0,
-            contig_K_A ? 1 : 8,
-            1,
-            1);
+      // Pad outer stride of A by 1. M and K are even, so no vectorization of
+      // A is possible despite compatible sizes.
+      run(504, 136, 248, 8, 8, 8, true, true, true, 1, 0, 0, 1, 8, max_vec_epi);
+      // Pad outer stride of B by 1. N and K are even, so no vectorization of
+      // B is possible despite compatible sizes.
+      run(504, 136, 248, 8, 8, 8, true, true, true, 0, 1, 0, 8, 1, max_vec_epi);
+      // Padding by 2 from a multiple of 8 means we can only vectorize at
+      // width 2
+      run(504,
+          136,
+          248,
+          8,
+          8,
+          8,
+          true,
+          true,
+          true,
+          2,
+          2,
+          2,
+          2,
+          2,
+          add_2d_bias ? 2 : max_vec_epi);
+      // Incompatible sizes are not vectorized despite padding to compatible
+      // strides
+      run(505,
+          136,
+          249,
+          8,
+          8,
+          8,
+          true,
+          true,
+          true,
+          1,
+          0,
+          0,
+          1,
+          contig_K_B ? 1 : 8,
+          max_vec_epi);
+      run(504,
+          137,
+          249,
+          8,
+          8,
+          8,
+          true,
+          true,
+          true,
+          0,
+          1,
+          0,
+          contig_K_A ? 1 : 8,
+          1,
+          1);
 
-        // Test that declaring a tensor's inner dimension discontiguous in the
-        // Fusion means we don't hit an error even if the inputs would support
-        // vectorization.
-        run(504,
-            136,
-            248,
-            8,
-            8,
-            8,
-            false,
-            true,
-            true,
-            0,
-            0,
-            0,
-            1,
-            8,
-            max_vec_epi);
-        run(504,
-            136,
-            248,
-            8,
-            8,
-            8,
-            true,
-            false,
-            true,
-            0,
-            0,
-            0,
-            8,
-            1,
-            max_vec_epi);
-        run(504,
-            136,
-            248,
-            8,
-            8,
-            8,
-            true,
-            true,
-            false,
-            0,
-            0,
-            0,
-            8,
-            8,
-            add_2d_bias ? 1 : max_vec_epi);
-      }
+      // Test that declaring a tensor's inner dimension discontiguous in the
+      // Fusion means we don't hit an error even if the inputs would support
+      // vectorization.
+      run(504,
+          136,
+          248,
+          8,
+          8,
+          8,
+          false,
+          true,
+          true,
+          0,
+          0,
+          0,
+          1,
+          8,
+          max_vec_epi);
+      run(504,
+          136,
+          248,
+          8,
+          8,
+          8,
+          true,
+          false,
+          true,
+          0,
+          0,
+          0,
+          8,
+          1,
+          max_vec_epi);
+      run(504,
+          136,
+          248,
+          8,
+          8,
+          8,
+          true,
+          true,
+          false,
+          0,
+          0,
+          0,
+          8,
+          8,
+          add_2d_bias ? 1 : max_vec_epi);
     }
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    MatmulSchedulerTestWithLayout,
+    kAllSupportedMmaLayout,
+    mmaLayoutName);
 
 class TestKernelConfig : public matmul_heuristic_plugin::KernelConfig {
   void configure() override {

--- a/tests/cpp/test_mma.cpp
+++ b/tests/cpp/test_mma.cpp
@@ -274,16 +274,6 @@ INSTANTIATE_TEST_SUITE_P(
         all_dtypes),
     testName);
 
-class HopperBase : public NVFuserTest {
- protected:
-  void SetUp() override {
-    if (cudaArchGuardShouldSkip(9, 0)) {
-      GTEST_SKIP() << "skipping tests on pre-Hopper GPUs";
-    }
-    NVFuserTest::SetUp();
-  }
-};
-
 // For smem mma input tensors, the schedule does not matter, we just naively
 // parallelize it so the test runs faster.
 void naivelyParallelize(TensorView* tv) {
@@ -293,43 +283,6 @@ void naivelyParallelize(TensorView* tv) {
   tv->split(0, 128);
   tv->axis(1)->parallelize(ParallelType::TIDx);
 }
-
-auto all_mma_layouts =
-    testing::Values(MmaLayout::TT, MmaLayout::TN, MmaLayout::NT, MmaLayout::NN);
-
-auto all_hopper_macros = testing::Values(
-    MmaMacro::Hopper_64_8_16,
-    MmaMacro::Hopper_64_16_16,
-    MmaMacro::Hopper_64_24_16,
-    MmaMacro::Hopper_64_32_16,
-    MmaMacro::Hopper_64_40_16,
-    MmaMacro::Hopper_64_48_16,
-    MmaMacro::Hopper_64_56_16,
-    MmaMacro::Hopper_64_64_16,
-    MmaMacro::Hopper_64_72_16,
-    MmaMacro::Hopper_64_80_16,
-    MmaMacro::Hopper_64_88_16,
-    MmaMacro::Hopper_64_96_16,
-    MmaMacro::Hopper_64_104_16,
-    MmaMacro::Hopper_64_112_16,
-    MmaMacro::Hopper_64_120_16,
-    MmaMacro::Hopper_64_128_16,
-    MmaMacro::Hopper_64_136_16,
-    MmaMacro::Hopper_64_144_16,
-    MmaMacro::Hopper_64_152_16,
-    MmaMacro::Hopper_64_160_16,
-    MmaMacro::Hopper_64_168_16,
-    MmaMacro::Hopper_64_176_16,
-    MmaMacro::Hopper_64_184_16,
-    MmaMacro::Hopper_64_192_16,
-    MmaMacro::Hopper_64_200_16,
-    MmaMacro::Hopper_64_208_16,
-    MmaMacro::Hopper_64_216_16,
-    MmaMacro::Hopper_64_224_16,
-    MmaMacro::Hopper_64_232_16,
-    MmaMacro::Hopper_64_240_16,
-    MmaMacro::Hopper_64_248_16,
-    MmaMacro::Hopper_64_256_16);
 
 using HopperMmaRSTestParams =
     std::tuple<MmaMacro, PrimDataType, MmaLayout, MmaInputSmemSwizzle>;
@@ -666,7 +619,7 @@ INSTANTIATE_TEST_SUITE_P(
     MmaTest,
     HopperRS,
     testing::Combine(
-        all_hopper_macros,
+        kAllHopperMacros,
         all_dtypes,
         testing::Values(MmaLayout::TT, MmaLayout::TN),
         kAllSmemSwizzleModes),
@@ -942,9 +895,9 @@ INSTANTIATE_TEST_SUITE_P(
     MmaTest,
     HopperSS,
     testing::Combine(
-        all_hopper_macros,
+        kAllHopperMacros,
         all_dtypes,
-        all_mma_layouts,
+        kAllSupportedMmaLayout,
         kAllSmemSwizzleModes,
         kAllSmemSwizzleModes),
     testNameHopperSS);

--- a/tests/cpp/test_translate_mma.cpp
+++ b/tests/cpp/test_translate_mma.cpp
@@ -59,6 +59,17 @@ class CombineMulSumAsMmaTest : public NVFuserTest {
   }
 };
 
+class CombineMulSumAsMmaTestWithLayout
+    : public NVFuserTest,
+      public ::testing::WithParamInterface<MmaLayout> {
+ protected:
+  MmaLayout layout;
+  void SetUp() override {
+    layout = GetParam();
+    NVFuserTest::SetUp();
+  }
+};
+
 void performSubstitution(Fusion* fusion, bool should_not_find = false) {
   EXPECT_TRUE(ir_utils::getOpsOfType<MmaOp>(fusion).empty());
 
@@ -79,25 +90,23 @@ void performSubstitution(Fusion* fusion, bool should_not_find = false) {
 
 // Test checks to see that the combiner can correctly replace
 // the mul-sum pair with a mma op.
-TEST_F(CombineMulSumAsMmaTest, AmpereMulSumToMatmul_Pass) {
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
-    auto tv0 = makeContigTensor(2, DataType::Half);
-    auto tv1 = makeContigTensor(2, DataType::Half);
+TEST_P(CombineMulSumAsMmaTestWithLayout, AmpereMulSumToMatmul_Pass) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  auto tv0 = makeContigTensor(2, DataType::Half);
+  auto tv1 = makeContigTensor(2, DataType::Half);
 
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = mul(tv0, tv1);
-    auto tv3 = sum(tv2, {-1});
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = mul(tv0, tv1);
+  auto tv3 = sum(tv2, {-1});
 
-    fusion.addOutput(tv3);
+  fusion.addOutput(tv3);
 
-    performSubstitution(&fusion);
-  }
+  performSubstitution(&fusion);
 }
 
 // This test checks that the pattern matcher does not incorrectly identify
@@ -169,106 +178,102 @@ TEST_F(CombineMulSumAsMmaTest, AmpereMulSumToMatmul_MultipleBroadcasts) {
 // As a sanity check we test that after replacing a mul-sum
 // pair with a mma op, we are able to schedule it as we did with
 // a fusion that had a mma op to begin with.
-TEST_F(CombineMulSumAsMmaTest, AmpereMulSumToMatmul_Schedule) {
+TEST_P(CombineMulSumAsMmaTestWithLayout, AmpereMulSumToMatmul_Schedule) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 
-  for (auto layout : kAllSupportedMmaLayout) {
-    Fusion fusion;
-    FusionGuard fg(&fusion);
-    auto tv0 = makeContigTensor(2, DataType::Half);
-    auto tv1 = makeContigTensor(2, DataType::Half);
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  auto tv0 = makeContigTensor(2, DataType::Half);
+  auto tv1 = makeContigTensor(2, DataType::Half);
 
-    fusion.addInput(tv0);
-    fusion.addInput(tv1);
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
 
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = sum(mul(tv0, tv1), {-1});
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = sum(mul(tv0, tv1), {-1});
 
-    fusion.addOutput(tv2);
+  fusion.addOutput(tv2);
 
-    performSubstitution(&fusion);
+  performSubstitution(&fusion);
 
-    MatMulTileOptions gemm_tile;
-    gemm_tile.cta_tile = GemmTile(128, 128, 32);
-    gemm_tile.warp_tile = GemmTile(64, 64, 32);
-    gemm_tile.instruction_tile = GemmTile(16, 8, 16);
+  MatMulTileOptions gemm_tile;
+  gemm_tile.cta_tile = GemmTile(128, 128, 32);
+  gemm_tile.warp_tile = GemmTile(64, 64, 32);
+  gemm_tile.instruction_tile = GemmTile(16, 8, 16);
 
-    MatmulParams params;
-    params.supported_vec_size = {8, 8, 4};
-    params.mma_macro = MmaMacro::Ampere_16_8_16;
-    params.tile_sizes = gemm_tile;
-    params.async_gmem_load_operands = true;
-    params.circular_buffer_options.circular_buffer_smem_write = true;
-    params.circular_buffer_options.circular_buffer_smem_read = true;
-    params.circular_buffer_options.smem_circular_buffer_stage = 4;
-    scheduleMatmul(&fusion, params);
+  MatmulParams params;
+  params.supported_vec_size = {8, 8, 4};
+  params.mma_macro = MmaMacro::Ampere_16_8_16;
+  params.tile_sizes = gemm_tile;
+  params.async_gmem_load_operands = true;
+  params.circular_buffer_options.circular_buffer_smem_write = true;
+  params.circular_buffer_options.circular_buffer_smem_read = true;
+  params.circular_buffer_options.smem_circular_buffer_stage = 4;
+  scheduleMatmul(&fusion, params);
 
-    auto inputs = matmulAtInput2D(M, N, K, layout);
+  auto inputs = matmulAtInput2D(M, N, K, layout);
 
-    FusionExecutor fe;
-    fe.compileFusion(
-        &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
-    ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
-    auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
-    auto tref = atMatmul(
-        inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
-    NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
-  }
+  FusionExecutor fe;
+  fe.compileFusion(
+      &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
+  ASSERT_TRUE(getBankConflictInfo(fe.kernel()).empty());
+  auto cg_outputs = fe.runFusion({inputs.first, inputs.second});
+  auto tref = atMatmul(
+      inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
+  NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
-TEST_F(CombineMulSumAsMmaTest, UseMatmulScheduler) {
+TEST_P(CombineMulSumAsMmaTestWithLayout, UseMatmulScheduler) {
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
-  for (auto layout : kAllSupportedMmaLayout) {
-    auto fusion = std::make_unique<Fusion>();
-    FusionGuard fg(fusion.get());
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
 
-    auto tv0 = makeContigTensor(2, DataType::Half);
-    auto tv1 = makeContigTensor(2, DataType::Half);
+  auto tv0 = makeContigTensor(2, DataType::Half);
+  auto tv1 = makeContigTensor(2, DataType::Half);
 
-    fusion->addInput(tv0);
-    fusion->addInput(tv1);
-    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-    auto tv2 = sum(mul(tv0, tv1), {-1});
-    // setting output alloc_domain to avoid allocation order propagation, which
-    // breaks the assumption of matmul scheduler. see issue:
-    // https://github.com/NVIDIA/Fuser/issues/2014
-    tv2->setAllocationDomain(tv2->getLogicalDomain(), true);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+  tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+  auto tv2 = sum(mul(tv0, tv1), {-1});
+  // setting output alloc_domain to avoid allocation order propagation, which
+  // breaks the assumption of matmul scheduler. see issue:
+  // https://github.com/NVIDIA/Fuser/issues/2014
+  tv2->setAllocationDomain(tv2->getLogicalDomain(), true);
 
-    fusion->addOutput(tv2);
-    ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(fusion.get()).empty());
+  fusion->addOutput(tv2);
+  ASSERT_TRUE(ir_utils::getOpsOfType<MmaOp>(fusion.get()).empty());
 
-    auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K);
-    auto t1 = matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K);
-    auto tref = atMatmul(t0, t1, layout);
+  auto t0 = matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K);
+  auto t1 = matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K);
+  auto tref = atMatmul(t0, t1, layout);
 
-    FusionExecutorCache executor_cache(std::move(fusion));
-    auto outputs = executor_cache.runFusionWithInputs({t0, t1});
-    // Ensure there's a mma op.
-    // If there's no mma op present, then stop the test.
-    ASSERT_FALSE(ir_utils::getOpsOfType<MmaOp>(
-                     executor_cache.getMostRecentKernelRuntime()
-                         ->executors()
-                         .at(0)
-                         .kernel())
-                     .empty());
-    // Ensure that the matmul scheduler ran.
-    EXPECT_TRUE(
-        dynamic_cast<MatmulScheduler*>(
-            executor_cache.getMostRecentKernelRuntime()
-                ->schedulerHeuristics()
-                ->heuristicsList()
-                .at(0)
-                .get()) != nullptr);
+  FusionExecutorCache executor_cache(std::move(fusion));
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  // Ensure there's a mma op.
+  // If there's no mma op present, then stop the test.
+  ASSERT_FALSE(
+      ir_utils::getOpsOfType<MmaOp>(executor_cache.getMostRecentKernelRuntime()
+                                        ->executors()
+                                        .at(0)
+                                        .kernel())
+          .empty());
+  // Ensure that the matmul scheduler ran.
+  EXPECT_TRUE(
+      dynamic_cast<MatmulScheduler*>(
+          executor_cache.getMostRecentKernelRuntime()
+              ->schedulerHeuristics()
+              ->heuristicsList()
+              .at(0)
+              .get()) != nullptr);
 
-    EXPECT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented());
+  EXPECT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented());
 
-    testValidate(
-        executor_cache.fusion(), outputs, {t0, t1}, {tref}, __LINE__, __FILE__);
-  }
+  testValidate(
+      executor_cache.fusion(), outputs, {t0, t1}, {tref}, __LINE__, __FILE__);
 }
 
 // Parameters: [A_dim, B_dim, enable_fusion, transpose_a_alloc,
@@ -617,60 +622,58 @@ INSTANTIATE_TEST_SUITE_P(
 
 // Check that we determine A and B properly when they are swapped as inputs to
 // mul
-TEST_F(CombineMulSumAsMmaTest, SwapAandB) {
-  for (auto layout : kAllSupportedMmaLayout) {
-    for (bool swap : {false, true}) {
-      Fusion fusion;
-      FusionGuard fg(&fusion);
-      auto tv0 = makeContigTensor(2, DataType::Half);
-      auto tv1 = makeContigTensor(2, DataType::Half);
+TEST_P(CombineMulSumAsMmaTestWithLayout, SwapAandB) {
+  for (bool swap : {false, true}) {
+    Fusion fusion;
+    FusionGuard fg(&fusion);
+    auto tv0 = makeContigTensor(2, DataType::Half);
+    auto tv1 = makeContigTensor(2, DataType::Half);
 
-      fusion.addInput(tv0);
-      fusion.addInput(tv1);
+    fusion.addInput(tv0);
+    fusion.addInput(tv1);
 
-      tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
-      tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
-      // We should identify tv0 as A and tv1 as B regardless of the order here
-      auto tv2 = swap ? mul(tv1, tv0) : mul(tv0, tv1);
-      auto tv3 = sum(tv2, {-1});
+    tv0 = canonicalizeInputToBMNK(tv0, layout, MmaOperand::A);
+    tv1 = canonicalizeInputToBMNK(tv1, layout, MmaOperand::B);
+    // We should identify tv0 as A and tv1 as B regardless of the order here
+    auto tv2 = swap ? mul(tv1, tv0) : mul(tv0, tv1);
+    auto tv3 = sum(tv2, {-1});
 
-      fusion.addOutput(tv3);
+    fusion.addOutput(tv3);
 
-      std::vector<mma_utils::MatmulPattern> patterns =
-          mma_utils::findMatmulPatterns(&fusion);
+    std::vector<mma_utils::MatmulPattern> patterns =
+        mma_utils::findMatmulPatterns(&fusion);
 
-      ASSERT_FALSE(patterns.empty());
-      EXPECT_EQ(patterns.size(), 1);
+    ASSERT_FALSE(patterns.empty());
+    EXPECT_EQ(patterns.size(), 1);
 
-      mma_utils::MatmulPattern& pattern = patterns.front();
+    mma_utils::MatmulPattern& pattern = patterns.front();
 
-      EXPECT_EQ(pattern.A, tv0);
-      EXPECT_EQ(pattern.B, tv1);
-      EXPECT_EQ(pattern.output, tv3);
+    EXPECT_EQ(pattern.A, tv0);
+    EXPECT_EQ(pattern.B, tv1);
+    EXPECT_EQ(pattern.output, tv3);
 
-      pattern.translateToMmaOp();
+    pattern.translateToMmaOp();
 
-      // Check that we didn't modify the pattern roles
-      EXPECT_EQ(pattern.A, tv0);
-      EXPECT_EQ(pattern.B, tv1);
-      EXPECT_EQ(pattern.output, tv3);
+    // Check that we didn't modify the pattern roles
+    EXPECT_EQ(pattern.A, tv0);
+    EXPECT_EQ(pattern.B, tv1);
+    EXPECT_EQ(pattern.output, tv3);
 
-      // Check that we properly map M and N to their roles even with swap
-      IdModel id_model(&fusion);
-      mma_utils::DimRolesMap dim_roles = pattern.getDimRoles(id_model);
-      ValGraph& permissive_graph = id_model.idGraph(IdMappingMode::PERMISSIVE);
-      const ValGroup& m_gp = permissive_graph.toGroup(tv0->axis(-3));
-      auto m_it = dim_roles.find(m_gp);
-      ASSERT_NE(m_it, dim_roles.end());
-      EXPECT_EQ(m_it->second, MatmulDimRole::M);
+    // Check that we properly map M and N to their roles even with swap
+    IdModel id_model(&fusion);
+    mma_utils::DimRolesMap dim_roles = pattern.getDimRoles(id_model);
+    ValGraph& permissive_graph = id_model.idGraph(IdMappingMode::PERMISSIVE);
+    const ValGroup& m_gp = permissive_graph.toGroup(tv0->axis(-3));
+    auto m_it = dim_roles.find(m_gp);
+    ASSERT_NE(m_it, dim_roles.end());
+    EXPECT_EQ(m_it->second, MatmulDimRole::M);
 
-      const ValGroup& n_gp = permissive_graph.toGroup(tv1->axis(-2));
-      auto n_it = dim_roles.find(n_gp);
-      ASSERT_NE(n_it, dim_roles.end());
-      EXPECT_EQ(n_it->second, MatmulDimRole::N);
+    const ValGroup& n_gp = permissive_graph.toGroup(tv1->axis(-2));
+    auto n_it = dim_roles.find(n_gp);
+    ASSERT_NE(n_it, dim_roles.end());
+    EXPECT_EQ(n_it->second, MatmulDimRole::N);
 
-      ASSERT_FALSE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
-    }
+    ASSERT_FALSE(ir_utils::getOpsOfType<MmaOp>(&fusion).empty());
   }
 }
 
@@ -750,5 +753,11 @@ INSTANTIATE_TEST_SUITE_P(
       os << (std::get<2>(info.param) ? "_twooutputs" : "");
       return os.str();
     });
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    CombineMulSumAsMmaTestWithLayout,
+    kAllSupportedMmaLayout,
+    mmaLayoutName);
 
 } // namespace nvfuser

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -606,7 +606,8 @@ Container parse(const std::string& nvdisasm_output);
 static auto kAllSupportedMmaLayout =
     testing::Values(MmaLayout::TT, MmaLayout::TN, MmaLayout::NT, MmaLayout::NN);
 
-inline std::string mmaLayoutName(const testing::TestParamInfo<MmaLayout>& info) {
+inline std::string mmaLayoutName(
+    const testing::TestParamInfo<MmaLayout>& info) {
   return toString(info.param);
 }
 

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -421,6 +421,63 @@ size_t getCRandomSeed();
 //! Returns the seed for ATen functions like at::randn() used for every test.
 size_t getATenRandomSeed();
 
+inline bool cudaArchGuardShouldSkip(int required_major, int required_minor) {
+  int capability_major = at::cuda::getCurrentDeviceProperties()->major;
+  int capability_minor = at::cuda::getCurrentDeviceProperties()->minor;
+
+  if (capability_major < required_major ||
+      (capability_major == required_major &&
+       capability_minor < required_minor)) {
+    return true;
+  }
+  return false;
+}
+
+inline bool cudaArchGuardShouldSkip(
+    int lower_major, // inclusive
+    int lower_minor, // inclusive
+    int upper_major, // exclusive
+    int upper_minor // exclusive
+) {
+  int capability_major = at::cuda::getCurrentDeviceProperties()->major;
+  int capability_minor = at::cuda::getCurrentDeviceProperties()->minor;
+
+  if (capability_major < lower_major ||
+      (capability_major == lower_major && capability_minor < lower_minor)) {
+    return true;
+  }
+  if (capability_major > upper_major ||
+      (capability_major == upper_major && capability_minor >= upper_minor)) {
+    return true;
+  }
+  return false;
+}
+
+#define NVFUSER_TEST_CUDA_ARCH_GUARD(REQUIRED_MAJOR, REQUIRED_MINOR)          \
+  if (cudaArchGuardShouldSkip(REQUIRED_MAJOR, REQUIRED_MINOR)) {              \
+    GTEST_SKIP() << "Requires GPU capability above " << REQUIRED_MAJOR << "." \
+                 << REQUIRED_MINOR << " to run.\n";                           \
+  }
+
+#define NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(                             \
+    LOWER_MAJOR, LOWER_MINOR, UPPER_MAJOR, UPPER_MINOR)                 \
+  if (cudaArchGuardShouldSkip(                                          \
+          LOWER_MAJOR, LOWER_MINOR, UPPER_MAJOR, UPPER_MINOR)) {        \
+    GTEST_SKIP() << "Requires GPU capability >= " << LOWER_MAJOR << "." \
+                 << LOWER_MINOR << " and < " << UPPER_MAJOR << "."      \
+                 << UPPER_MINOR << " to run.\n";                        \
+  }
+
+#define NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(                                \
+    REQUIRED_MAJOR, REQUIRED_MINOR, COMPILE_FUSION)                          \
+  if (cudaArchGuardShouldSkip(REQUIRED_MAJOR, REQUIRED_MINOR)) {             \
+    ASSERT_ANY_THROW(COMPILE_FUSION);                                        \
+    GTEST_SKIP() << "(Lowered Only) Requires GPU capability above "          \
+                 << REQUIRED_MAJOR << "." << REQUIRED_MINOR << " to run.\n"; \
+  } else {                                                                   \
+    COMPILE_FUSION;                                                          \
+  }
+
 // Fixture class must be uniquely identified, i.e., can't be in an
 // anonymous namespace
 class NVFuserTest : public ::testing::Test {
@@ -494,6 +551,16 @@ class NVFuserTest : public ::testing::Test {
   bool capturing_ = false;
 };
 
+class HopperBase : public NVFuserTest {
+ protected:
+  void SetUp() override {
+    if (cudaArchGuardShouldSkip(9, 0)) {
+      GTEST_SKIP() << "skipping tests on pre-Hopper GPUs";
+    }
+    NVFuserTest::SetUp();
+  }
+};
+
 // Fixture with param class must be uniquely identified, i.e., can't be in an
 // anonymous namespace
 template <typename tParam>
@@ -536,74 +603,52 @@ Container parse(const std::string& nvdisasm_output);
 
 } // namespace sass
 
-inline bool cudaArchGuardShouldSkip(int required_major, int required_minor) {
-  int capability_major = at::cuda::getCurrentDeviceProperties()->major;
-  int capability_minor = at::cuda::getCurrentDeviceProperties()->minor;
+static auto kAllSupportedMmaLayout =
+    testing::Values(MmaLayout::TT, MmaLayout::TN, MmaLayout::NT, MmaLayout::NN);
 
-  if (capability_major < required_major ||
-      (capability_major == required_major &&
-       capability_minor < required_minor)) {
-    return true;
-  }
-  return false;
+inline std::string mmaLayoutName(const testing::TestParamInfo<MmaLayout>& info) {
+  return toString(info.param);
 }
-
-inline bool cudaArchGuardShouldSkip(
-    int lower_major, // inclusive
-    int lower_minor, // inclusive
-    int upper_major, // exclusive
-    int upper_minor // exclusive
-) {
-  int capability_major = at::cuda::getCurrentDeviceProperties()->major;
-  int capability_minor = at::cuda::getCurrentDeviceProperties()->minor;
-
-  if (capability_major < lower_major ||
-      (capability_major == lower_major && capability_minor < lower_minor)) {
-    return true;
-  }
-  if (capability_major > upper_major ||
-      (capability_major == upper_major && capability_minor >= upper_minor)) {
-    return true;
-  }
-  return false;
-}
-
-#define NVFUSER_TEST_CUDA_ARCH_GUARD(REQUIRED_MAJOR, REQUIRED_MINOR)          \
-  if (cudaArchGuardShouldSkip(REQUIRED_MAJOR, REQUIRED_MINOR)) {              \
-    GTEST_SKIP() << "Requires GPU capability above " << REQUIRED_MAJOR << "." \
-                 << REQUIRED_MINOR << " to run.\n";                           \
-  }
-
-#define NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(                             \
-    LOWER_MAJOR, LOWER_MINOR, UPPER_MAJOR, UPPER_MINOR)                 \
-  if (cudaArchGuardShouldSkip(                                          \
-          LOWER_MAJOR, LOWER_MINOR, UPPER_MAJOR, UPPER_MINOR)) {        \
-    GTEST_SKIP() << "Requires GPU capability >= " << LOWER_MAJOR << "." \
-                 << LOWER_MINOR << " and < " << UPPER_MAJOR << "."      \
-                 << UPPER_MINOR << " to run.\n";                        \
-  }
-
-#define NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(                                \
-    REQUIRED_MAJOR, REQUIRED_MINOR, COMPILE_FUSION)                          \
-  if (cudaArchGuardShouldSkip(REQUIRED_MAJOR, REQUIRED_MINOR)) {             \
-    ASSERT_ANY_THROW(COMPILE_FUSION);                                        \
-    GTEST_SKIP() << "(Lowered Only) Requires GPU capability above "          \
-                 << REQUIRED_MAJOR << "." << REQUIRED_MINOR << " to run.\n"; \
-  } else {                                                                   \
-    COMPILE_FUSION;                                                          \
-  }
-
-static constexpr std::array<MmaLayout, 4> kAllSupportedMmaLayout = {
-    MmaLayout::TT,
-    MmaLayout::NT,
-    MmaLayout::TN,
-    MmaLayout::NN};
 
 static auto kAllSmemSwizzleModes = testing::Values(
     MmaInputSmemSwizzle::None,
     MmaInputSmemSwizzle::B128,
     MmaInputSmemSwizzle::B64,
     MmaInputSmemSwizzle::B32);
+
+static auto kAllHopperMacros = testing::Values(
+    MmaMacro::Hopper_64_8_16,
+    MmaMacro::Hopper_64_16_16,
+    MmaMacro::Hopper_64_24_16,
+    MmaMacro::Hopper_64_32_16,
+    MmaMacro::Hopper_64_40_16,
+    MmaMacro::Hopper_64_48_16,
+    MmaMacro::Hopper_64_56_16,
+    MmaMacro::Hopper_64_64_16,
+    MmaMacro::Hopper_64_72_16,
+    MmaMacro::Hopper_64_80_16,
+    MmaMacro::Hopper_64_88_16,
+    MmaMacro::Hopper_64_96_16,
+    MmaMacro::Hopper_64_104_16,
+    MmaMacro::Hopper_64_112_16,
+    MmaMacro::Hopper_64_120_16,
+    MmaMacro::Hopper_64_128_16,
+    MmaMacro::Hopper_64_136_16,
+    MmaMacro::Hopper_64_144_16,
+    MmaMacro::Hopper_64_152_16,
+    MmaMacro::Hopper_64_160_16,
+    MmaMacro::Hopper_64_168_16,
+    MmaMacro::Hopper_64_176_16,
+    MmaMacro::Hopper_64_184_16,
+    MmaMacro::Hopper_64_192_16,
+    MmaMacro::Hopper_64_200_16,
+    MmaMacro::Hopper_64_208_16,
+    MmaMacro::Hopper_64_216_16,
+    MmaMacro::Hopper_64_224_16,
+    MmaMacro::Hopper_64_232_16,
+    MmaMacro::Hopper_64_240_16,
+    MmaMacro::Hopper_64_248_16,
+    MmaMacro::Hopper_64_256_16);
 
 // Utility to generate matmul input tensors based on given layout
 at::Tensor atMatmul(at::Tensor a, at::Tensor b, MmaLayout layout);


### PR DESCRIPTION
I suggest reviewing this PR hiding whitespaces:
![image](https://github.com/NVIDIA/Fuser/assets/1032377/892cfeff-f080-49a0-9846-319632538339)

This PR moves some common things into headers, and make many tests as parameterize tests with layout as parameter. Mostly code movement, no logical change.