### PR TITLE
Host IR Test Cleanup

### DIFF
--- a/tests/cpp/test_gpu_fused_reduction.cpp
+++ b/tests/cpp/test_gpu_fused_reduction.cpp
@@ -1339,8 +1339,7 @@ TEST_F(NVFuserTest, FusionPersistentBNBackwardAllreduce_CUDA) {
 
   if (weight == nullptr) {
     grad_scale =
-        mul(broadcast(invstd, broadcast_mask),
-            IrBuilder::createInContainer<Val>(input->container(), 1.0));
+        mul(broadcast(invstd, broadcast_mask), IrBuilder::create<Val>(1.0));
   } else {
     grad_scale = mul(
         broadcast(invstd, broadcast_mask), broadcast(weight, broadcast_mask));

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -102,8 +102,7 @@ TEST_P(HostIrTest, SingleFusion) {
   auto hic = std::make_unique<HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
   // [Step 3)] Create a HostUnit Ir holding the created fusion
-  auto host_unit =
-      IrBuilder::createInContainer<HostUnit>(hic.get(), std::move(fusion));
+  auto host_unit = IrBuilder::create<HostUnit>(std::move(fusion));
 
   // [Step 4)] Create TensorViews representing the Fusion's I/O at the Host
   // level
@@ -115,8 +114,8 @@ TEST_P(HostIrTest, SingleFusion) {
 
   // [Step 5)] Create a PostOnStream Ir representing executing the Fusion with
   // given I/O
-  auto post_on_stream = IrBuilder::createInContainer<PostOnStream>(
-      hic.get(), host_unit, post_on_stream_inputs, post_on_stream_outputs);
+  auto post_on_stream = IrBuilder::create<PostOnStream>(
+      host_unit, post_on_stream_inputs, post_on_stream_outputs);
 
   // [Step 6)] Define the Host program by adding PostOnStream to the container's
   // top level expression
@@ -183,10 +182,10 @@ TEST_P(HostIrTest, TwoFusions) {
   FusionGuard::setCurFusion(hic.get());
 
   // [Step 3)] Create two HostUnit Irs holding the fusions
-  auto host_unit_0 = IrBuilder::createInContainer<HostUnit>(
-      hic.get(), std::make_unique<Fusion>(fusion_0));
-  auto host_unit_1 = IrBuilder::createInContainer<HostUnit>(
-      hic.get(), std::make_unique<Fusion>(fusion_1));
+  auto host_unit_0 =
+      IrBuilder::create<HostUnit>(std::make_unique<Fusion>(fusion_0));
+  auto host_unit_1 =
+      IrBuilder::create<HostUnit>(std::make_unique<Fusion>(fusion_1));
 
   // [Step 4)a.] Create TensorViews representing the first Fusions I/O at the
   // Host level
@@ -197,8 +196,7 @@ TEST_P(HostIrTest, TwoFusions) {
       ir_cloner.clone(host_unit_0->fusion_to_execute()->outputs().at(0))};
   // [Step 5)a.] Create a PostOnStream Ir representing executing the first
   // Fusion with given I/O
-  auto post_on_stream_0 = IrBuilder::createInContainer<PostOnStream>(
-      hic.get(),
+  auto post_on_stream_0 = IrBuilder::create<PostOnStream>(
       host_unit_0,
       std::move(post_on_stream_inputs_0),
       post_on_stream_outputs_0);
@@ -210,8 +208,7 @@ TEST_P(HostIrTest, TwoFusions) {
       ir_cloner.clone(host_unit_1->fusion_to_execute()->outputs().at(0))};
   // [Step 5)b.] Create a PostOnStream Ir representing executing the second
   // Fusion with given I/O
-  auto post_on_stream_1 = IrBuilder::createInContainer<PostOnStream>(
-      hic.get(),
+  auto post_on_stream_1 = IrBuilder::create<PostOnStream>(
       host_unit_1,
       std::move(post_on_stream_inputs_1),
       post_on_stream_outputs_1);
@@ -288,12 +285,12 @@ TEST_P(HostIrTest, ThreeFusions) {
   auto hic = std::make_unique<HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
   // [Step 3)] Create HostUnit Irs holding the fusions
-  auto host_unit_0 = IrBuilder::createInContainer<HostUnit>(
-      hic.get(), std::make_unique<Fusion>(fusion_0));
-  auto host_unit_1 = IrBuilder::createInContainer<HostUnit>(
-      hic.get(), std::make_unique<Fusion>(fusion_1));
-  auto host_unit_2 = IrBuilder::createInContainer<HostUnit>(
-      hic.get(), std::make_unique<Fusion>(fusion_2));
+  auto host_unit_0 =
+      IrBuilder::create<HostUnit>(std::make_unique<Fusion>(fusion_0));
+  auto host_unit_1 =
+      IrBuilder::create<HostUnit>(std::make_unique<Fusion>(fusion_1));
+  auto host_unit_2 =
+      IrBuilder::create<HostUnit>(std::make_unique<Fusion>(fusion_2));
 
   // [Step 4)a.] Create TensorViews representing the first Fusions I/O at the
   // Host level
@@ -309,8 +306,7 @@ TEST_P(HostIrTest, ThreeFusions) {
   std::vector<Val*> post_on_stream_outputs_0 = clone({tv1_0, tv2_0});
   // [Step 5)a.] Create a PostOnStream Ir representing executing the first
   // Fusion with given I/O
-  auto post_on_stream_0 = IrBuilder::createInContainer<PostOnStream>(
-      hic.get(),
+  auto post_on_stream_0 = IrBuilder::create<PostOnStream>(
       host_unit_0,
       std::move(post_on_stream_inputs_0),
       post_on_stream_outputs_0);
@@ -321,8 +317,7 @@ TEST_P(HostIrTest, ThreeFusions) {
   std::vector<Val*> post_on_stream_outputs_1 = clone({tv2_1});
   // [Step 5)b.] Create a PostOnStream Ir representing executing the first
   // Fusion with given I/O
-  auto post_on_stream_1 = IrBuilder::createInContainer<PostOnStream>(
-      hic.get(),
+  auto post_on_stream_1 = IrBuilder::create<PostOnStream>(
       host_unit_1,
       std::move(post_on_stream_inputs_1),
       post_on_stream_outputs_1);
@@ -334,8 +329,7 @@ TEST_P(HostIrTest, ThreeFusions) {
   std::vector<Val*> post_on_stream_outputs_2 = clone({tv2_2});
   // [Step 5)c.] Create a PostOnStream Ir representing executing the first
   // Fusion with given I/O
-  auto post_on_stream_2 = IrBuilder::createInContainer<PostOnStream>(
-      hic.get(),
+  auto post_on_stream_2 = IrBuilder::create<PostOnStream>(
       host_unit_2,
       std::move(post_on_stream_inputs_2),
       post_on_stream_outputs_2);
@@ -479,9 +473,9 @@ using StreamTest = NVFuserTest;
 // the host program
 TEST_F(StreamTest, HostIrSetStream) {
   auto hic = std::make_unique<HostIrContainer>();
-  auto stream = IrBuilder::createInContainer<Stream>(hic.get());
-  auto set_stream =
-      IrBuilder::createInContainer<SetCurrentStream>(hic.get(), stream);
+  FusionGuard fg(hic.get());
+  auto stream = IrBuilder::create<Stream>();
+  auto set_stream = IrBuilder::create<SetCurrentStream>(stream);
   hic->pushBackTopLevelExprs(set_stream);
 
   HostIrExecutor hie(std::move(hic));
@@ -496,14 +490,14 @@ TEST_F(StreamTest, HostIrSetStream) {
 TEST_F(StreamTest, HostIrDefaultStream) {
   auto change_stream = [](bool use_default_stream) {
     auto hic = std::make_unique<HostIrContainer>();
+    FusionGuard fg(hic.get());
     Stream* stream;
     if (use_default_stream) {
       stream = hic->getDefaultStream();
     } else {
-      stream = IrBuilder::createInContainer<Stream>(hic.get());
+      stream = IrBuilder::create<Stream>();
     }
-    auto set_stream =
-        IrBuilder::createInContainer<SetCurrentStream>(hic.get(), stream);
+    auto set_stream = IrBuilder::create<SetCurrentStream>(stream);
     hic->pushBackTopLevelExprs(set_stream);
     HostIrExecutor hie(std::move(hic));
     hie.runWithInput({});
@@ -547,12 +541,11 @@ TEST_P(StreamHostIrTest, SingleFusionMultipleStreams) {
   // Create N different Streams
   std::vector<Stream*> streams;
   for (int i = 0; i < n_streams; i++) {
-    streams.push_back(IrBuilder::createInContainer<Stream>(hic.get()));
+    streams.push_back(IrBuilder::create<Stream>());
   }
 
   // [Step 3)] Create a HostUnit Ir holding the created fusion
-  auto host_unit =
-      IrBuilder::createInContainer<HostUnit>(hic.get(), std::move(fusion));
+  auto host_unit = IrBuilder::create<HostUnit>(std::move(fusion));
 
   // [Step 4)] Create TensorViews representing the Fusion's inputs at the Host
   // level
@@ -570,12 +563,12 @@ TEST_P(StreamHostIrTest, SingleFusionMultipleStreams) {
 
     // [Step 5)] Create a PostOnStream Ir representing executing the Fusion with
     // given I/O
-    auto post_on_stream = IrBuilder::createInContainer<PostOnStream>(
-        hic.get(), host_unit, post_on_stream_inputs, post_on_stream_outputs);
+    auto post_on_stream = IrBuilder::create<PostOnStream>(
+        host_unit, post_on_stream_inputs, post_on_stream_outputs);
 
     // Set the Stream
-    auto set_stream = IrBuilder::createInContainer<SetCurrentStream>(
-        hic.get(), streams[i % streams.size()]);
+    auto set_stream =
+        IrBuilder::create<SetCurrentStream>(streams[i % streams.size()]);
 
     // [Step 6)] Define the Host program by adding PostOnStream to the
     // container's top level expression

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -70,8 +70,7 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
   FusionGuard::setCurFusion(hic.get());
 
   // [Step 3a)] Create a HostUnit Ir holding the fusions
-  auto hu =
-      IrBuilder::createInContainer<HostUnit>(hic.get(), std::move(fusion));
+  auto hu = IrBuilder::create<HostUnit>(std::move(fusion));
 
   // [Step 4)] Create TensorViews at the Host level
   IrCloner ir_cloner(hic.get());
@@ -85,19 +84,18 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
   // [Step 5)a.] Create PostOnStream Irs representing executing the Fusion
   std::vector<Val*> compute_inputs = {tv0};
   std::vector<Val*> compute_outputs = {tv1};
-  auto post_compute = IrBuilder::createInContainer<PostOnStream>(
-      hic.get(), hu, compute_inputs, compute_outputs);
+  auto post_compute =
+      IrBuilder::create<PostOnStream>(hu, compute_inputs, compute_outputs);
   // [Step 5)b.] Create Communication Ir representing executing the Fusion
   auto communication_input = tv1->as<TensorView>();
   auto communication_output = tv2->as<TensorView>();
 
-  auto communication = IrBuilder::createInContainer<Communication>(
-      hic.get(),
+  auto communication = IrBuilder::create<Communication>(
       CommunicationType::Allgather,
       communication_output,
       communication_input,
       mesh.vector());
-  auto wait = IrBuilder::createInContainer<Wait>(hic.get(), communication);
+  auto wait = IrBuilder::create<Wait>(communication);
 
   // [Step 6)] Define the Host program
   hic->pushBackTopLevelExprs(post_compute);
@@ -163,8 +161,7 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   FusionGuard::setCurFusion(hic.get());
 
   // [Step 3a)] Create a HostUnit Ir holding the fusions
-  auto hu =
-      IrBuilder::createInContainer<HostUnit>(hic.get(), std::move(fusion));
+  auto hu = IrBuilder::create<HostUnit>(std::move(fusion));
 
   // [Step 4)] Create TensorViews at the Host level
   IrCloner ir_cloner(hic.get());
@@ -178,18 +175,17 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   // [Step 5)a.] Create PostOnStream Irs representing executing the Fusion
   std::vector<Val*> compute_inputs = {tv0};
   std::vector<Val*> compute_outputs = {tv1};
-  auto post_compute = IrBuilder::createInContainer<PostOnStream>(
-      hic.get(), hu, compute_inputs, compute_outputs);
+  auto post_compute =
+      IrBuilder::create<PostOnStream>(hu, compute_inputs, compute_outputs);
   // [Step 5)b.] Create Communication Ir representing executing the Fusion
   TensorView* communication_input = tv1->as<TensorView>();
   TensorView* communication_output = tv2->as<TensorView>();
-  auto communication = IrBuilder::createInContainer<Communication>(
-      hic.get(),
+  auto communication = IrBuilder::create<Communication>(
       CommunicationType::Allgather,
       communication_output,
       communication_input,
       mesh.vector());
-  auto wait = IrBuilder::createInContainer<Wait>(hic.get(), communication);
+  auto wait = IrBuilder::create<Wait>(communication);
 
   // [Step 6)] Define the Host program
   hic->pushBackTopLevelExprs(post_compute);

--- a/tests/cpp/test_predicate_elimination.cpp
+++ b/tests/cpp/test_predicate_elimination.cpp
@@ -347,7 +347,7 @@ TEST_F(PredicateEliminationTest, 8) {
 
   std::vector<int64_t> reduction_axes = {0, 2, 3};
 
-  Val* num_features = IrBuilder::createInContainer<Val>(tv1->container(), 1.0);
+  Val* num_features = IrBuilder::create<Val>(1.0);
   for (const auto dim : reduction_axes) {
     num_features = mul(num_features, tv1->getLoopDomain()[dim]->extent());
   }


### PR DESCRIPTION
 Cleanup uses of IrBuilder::createInContainer when IrBuilder::create is sufficient.