### PR TITLE
Move validateSegmentatation from tests/cpp/utils.h to tests/cpp/validator.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/utils.cpp
   ${NVFUSER_SRCS_DIR}/val_graph.cpp
   ${NVFUSER_SRCS_DIR}/val_graph_visitor.cpp
+  ${NVFUSER_SRCS_DIR}/validator_utils.cpp
 )
 
 # We don't link CUPTI for MSVC
@@ -563,7 +564,10 @@ if(BUILD_TEST)
 endif()
 
 function(add_test_without_main TEST_NAME TEST_SRC ADDITIONAL_LINK)
-  list(APPEND TEST_SRC ${NVFUSER_ROOT}/tests/cpp/utils.cpp)
+  list(APPEND TEST_SRC
+    ${NVFUSER_ROOT}/tests/cpp/utils.cpp
+    ${NVFUSER_ROOT}/tests/cpp/validator.cpp
+  )
   add_executable(${TEST_NAME} ${TEST_SRC})
   set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD ${NVFUSER_CPP_STANDARD})
   target_compile_definitions(${TEST_NAME} PRIVATE USE_GTEST)

--- a/csrc/validator_utils.cpp
+++ b/csrc/validator_utils.cpp
@@ -1,0 +1,307 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <validator_utils.h>
+
+#include <unordered_map>
+
+#include <ATen/cuda/CUDAContext.h>
+
+#include <device_lower/utils.h>
+#include <exceptions.h>
+#include <executor_utils.h>
+#include <expr_evaluator.h>
+#include <fusion.h>
+#include <ir/iostream.h>
+
+namespace nvfuser {
+
+std::pair<double, double> getTolerance(
+    DataType dtype,
+    int64_t reduction_size,
+    const ValidationConstants& tolerances) {
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+  switch (std::get<PrimDataType>(dtype.type)) {
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    case DataType::ComplexFloat:
+    case DataType::ComplexDouble:
+    case DataType::Float:
+    // TODO: Pull new tolerances for Double, for now we will just use float
+    // tolerances as it should be no worse.
+    case DataType::Double: {
+      const auto& sum_tolerance_entry = tolerances.sum_tolerances_float;
+      const auto& base_abs = tolerances.base_float_abs_tol;
+      const auto& base_rel = tolerances.base_float_rel_tol;
+
+      if (reduction_size <= 1) {
+        // No reduction case
+        if (base_abs == -1 || base_rel == -1) {
+          return {sum_tolerance_entry[0][1], sum_tolerance_entry[1][1]};
+        } else {
+          return {base_abs, base_rel};
+        }
+      } else {
+        // Reduction case
+        size_t entry = 0;
+        while (entry < sum_tolerance_entry.size() &&
+               (int64_t)sum_tolerance_entry[entry][0] < reduction_size) {
+          entry++;
+        }
+        double abs_tol = 0.0;
+        if (entry + 1 < sum_tolerance_entry.size()) {
+          // Grab the next entry up so we have some margin
+          abs_tol = sum_tolerance_entry[entry + 1][1];
+        } else {
+          // If we hit the end of the list, return twice the max error we
+          // measured
+          abs_tol = sum_tolerance_entry[sum_tolerance_entry.size() - 1][1] * 2.;
+        }
+        // Relative tol we're going to set to 1% of abs tol just for
+        // a small margin of rel error.
+        return {abs_tol, abs_tol * 0.01};
+      }
+    }
+    case DataType::Half: {
+      // Copied from float case
+      const auto& sum_tolerance_entry = tolerances.sum_tolerances_half;
+      const auto& base_abs = tolerances.base_half_abs_tol;
+      const auto& base_rel = tolerances.base_half_rel_tol;
+
+      if (reduction_size <= 1) {
+        // No reduction case
+        if (base_abs == -1 || base_rel == -1) {
+          return {sum_tolerance_entry[0][1], sum_tolerance_entry[1][1]};
+        } else {
+          return {base_abs, base_rel};
+        }
+      } else {
+        // Reduction case
+        size_t entry = 0;
+        while ((int64_t)sum_tolerance_entry[entry][0] < reduction_size &&
+               entry < sum_tolerance_entry.size()) {
+          entry++;
+        }
+        double abs_tol = 0.0;
+        if (entry + 1 < sum_tolerance_entry.size()) {
+          // Grab the next entry up so we have some margin
+          abs_tol = sum_tolerance_entry[entry + 1][1];
+        } else {
+          // If we hit the end of the list, return twice the max error we
+          // measured
+          abs_tol = sum_tolerance_entry[sum_tolerance_entry.size() - 1][1] * 2.;
+        }
+        // Relative tol we're going to set to 1% of abs tol just for
+        // a small margin of rel error.
+        return {abs_tol, abs_tol * 0.01};
+      }
+    }
+    // TODO: fp8 likely will need higher tolerance.
+    case DataType::Float8_e4m3fn:
+    case DataType::Float8_e5m2:
+    case DataType::BFloat16: {
+      // Copied from float case
+      const auto& sum_tolerance_entry = tolerances.sum_tolerances_half;
+      const auto& base_abs = tolerances.base_half_abs_tol;
+      const auto& base_rel = tolerances.base_half_rel_tol;
+
+      if (reduction_size <= 1) {
+        // No reduction case
+        if (base_abs == -1 || base_rel == -1) {
+          return {sum_tolerance_entry[0][1], sum_tolerance_entry[1][1]};
+        } else {
+          return {base_abs * 10.0, base_rel * 10.0};
+        }
+      } else {
+        // Reduction case
+        size_t entry = 0;
+        while ((int64_t)sum_tolerance_entry[entry][0] < reduction_size &&
+               entry < sum_tolerance_entry.size()) {
+          entry++;
+        }
+        double abs_tol = 0.0;
+        if (entry + 1 < sum_tolerance_entry.size()) {
+          // Grab the next entry up so we have some margin
+          abs_tol = sum_tolerance_entry[entry + 1][1];
+        } else {
+          // If we hit the end of the list, return twice the max error we
+          // measured
+          abs_tol = sum_tolerance_entry[sum_tolerance_entry.size() - 1][1] * 2.;
+        }
+        // Relative tol we're going to set to 1% of abs tol just for
+        // a small margin of rel error.
+        return {abs_tol * 10.0, abs_tol * 0.01 * 10.0};
+      }
+    }
+    case DataType::Int:
+    case DataType::Int32:
+    case DataType::Index:
+    case DataType::Bool:
+      return {0.0, 0.0};
+    default:
+      NVF_ERROR(
+          false, "Do not have tolerance computation for type ", dtype, ".");
+  }
+}
+
+/*static*/ std::unordered_map<TensorView*, int64_t> ReductionSizeMapper::
+    computeReductionSizes(Fusion* fusion, ExpressionEvaluator& expr_eval) {
+  ReductionSizeMapper mapper(fusion, expr_eval);
+  return mapper.reduction_map;
+}
+
+ReductionSizeMapper::ReductionSizeMapper(
+    Fusion* fusion,
+    ExpressionEvaluator& expr_eval)
+    : expr_eval_(expr_eval) {
+  // Initialize input values
+  for (auto inp : fusion->inputs()) {
+    if (inp->isA<TensorView>()) {
+      auto tv = inp->as<TensorView>();
+      // Shouldn't have any reductions, but run it through analysis anyways.
+      reduction_map[tv] = getReductionSize(tv);
+    }
+  }
+
+  IterVisitor::traverse(fusion);
+
+  // catch up with dangling outputs;
+  for (auto out : fusion->outputs()) {
+    if (out->isA<TensorView>()) {
+      auto tv = out->as<TensorView>();
+      // possible that we have a dangling output that's not generated by any
+      // expression. e.g. 0 workspace or null tensor
+      if (reduction_map.count(tv) == 0) {
+        // Shouldn't have any reductions, but run it through analysis anyways.
+        reduction_map[tv] = getReductionSize(tv);
+      }
+    }
+  }
+}
+
+int64_t ReductionSizeMapper::getReductionSize(const TensorView* tv) {
+  int64_t reduction_elements = 1;
+  for (auto id : tv->getLogicalDomain()) {
+    if (id->isReduction()) {
+      auto inferred_extent = expr_eval_.evaluate(id->extent());
+      NVF_ERROR(
+          inferred_extent.hasValue(),
+          "Couldn't figure out what the dimensions of a tensorview is in evaluation for validation. ",
+          id,
+          " in ",
+          tv);
+      reduction_elements = reduction_elements * inferred_extent.as<int64_t>();
+    }
+  }
+  return reduction_elements;
+}
+
+void ReductionSizeMapper::dispatch(Expr* expr) {
+  if (!ir_utils::isTvOp(expr)) {
+    return;
+  }
+
+  int64_t inp_reduction_elements = 1;
+  for (auto inp : expr->inputs()) {
+    if (inp->isA<TensorView>()) {
+      if (auto tv = inp->as<TensorView>()) {
+        inp_reduction_elements =
+            std::max(inp_reduction_elements, reduction_map.at(tv));
+      }
+    }
+  }
+
+  for (auto out : expr->outputs()) {
+    if (out->isA<TensorView>()) {
+      auto tv = out->as<TensorView>();
+      reduction_map[tv] = getReductionSize(tv) * inp_reduction_elements;
+    }
+  }
+}
+
+ExpressionEvaluator bindInputsAndLaunchParams(
+    Fusion* fusion,
+    const at::ArrayRef<c10::IValue>& aten_inputs,
+    const LaunchParams& launch_constraints) {
+  KernelArgumentHolder argument_holder;
+  argument_holder.push(aten_inputs);
+
+  auto expr_eval = executor_utils::bindInputs(argument_holder, fusion);
+  for (auto val : fusion->vals()) {
+    if (!val->isA<TensorView>()) {
+      continue;
+    }
+
+    // Roughly taken from executor.cpp/computeLaunchParams
+    auto tv = val->as<TensorView>();
+    for (auto id : tv->getLoopDomain()) {
+      if (!(id->isThread() && id->extent()->definition() == nullptr)) {
+        continue;
+      }
+
+      if (id->isBroadcast()) {
+        continue;
+      }
+
+      auto extent = id->extent();
+      auto inferred_extent = expr_eval.evaluate(extent);
+      auto p_type = id->getParallelType();
+
+      if (inferred_extent.hasValue()) {
+        // This value could have been inferred, make sure it was set right.
+        NVF_CHECK(
+            inferred_extent == launch_constraints.getDim(p_type) ||
+                launch_constraints.getRawVal(p_type) == -1,
+            "inferred that ",
+            p_type,
+            " should be set to ",
+            inferred_extent,
+            " but launch constraints specified ",
+            launch_constraints.getRawVal(p_type));
+      } else {
+        // Bind the launch constraint into our evaluation context
+        if (launch_constraints.hasDim(id->getParallelType())) {
+          expr_eval.bind(extent, launch_constraints.getDim(p_type));
+        }
+      }
+    }
+  }
+  return expr_eval;
+}
+
+std::vector<std::pair<double, double>> get_val_constants(
+    Fusion* fusion,
+    const at::ArrayRef<c10::IValue>& aten_inputs,
+    const LaunchParams& lparams,
+    const ValidationConstants& tolerances) {
+  FusionGuard fg(fusion);
+  auto expr_eval = bindInputsAndLaunchParams(fusion, aten_inputs, lparams);
+  auto reduction_sizes =
+      ReductionSizeMapper::computeReductionSizes(fusion, expr_eval);
+
+  std::vector<std::pair<double, double>> tolerance_values;
+  for (size_t i = 0; i < fusion->outputs().size(); i++) {
+    auto fusion_output_tv = fusion->outputs()[i]->as<TensorView>();
+    NVF_ERROR(
+        reduction_sizes.count(fusion_output_tv),
+        "Missed reduction size count on fusion output at index: ",
+        i);
+
+    int64_t reduction_size = reduction_sizes.at(fusion_output_tv);
+
+    auto tolerance_value = getTolerance(
+        fusion_output_tv->getDataType().value(), reduction_size, tolerances);
+    tolerance_values.push_back(tolerance_value);
+  }
+  return tolerance_values;
+}
+
+} // namespace nvfuser

--- a/csrc/validator_utils.h
+++ b/csrc/validator_utils.h
@@ -7,20 +7,20 @@
 // clang-format on
 #pragma once
 
-#include <device_lower/utils.h>
-#include <exceptions.h>
-#include <executor_utils.h>
+#include <array>
+#include <unordered_map>
+#include <utility>
+
+#include <ATen/ArrayRef.h>
+
+#include <executor_params.h>
 #include <expr_evaluator.h>
 #include <fusion.h>
-#include <ir/iostream.h>
-
-#include <ATen/cuda/CUDAContext.h>
-
-#include <unordered_map>
+#include <ir/interface_nodes.h>
+#include <iter_visitor.h>
+#include <type.h>
 
 namespace nvfuser {
-
-namespace {
 
 struct ValidationConstants {
   // Tolerances generated from randn + add + sum fusion
@@ -51,138 +51,11 @@ struct ValidationConstants {
   double base_float_rel_tol = -1;
 };
 
-// Returns abs and relative values to use for validation
+// Returns abs and relative values to use for validation.
 std::pair<double, double> getTolerance(
     DataType dtype,
     int64_t reduction_size,
-    const ValidationConstants& tolerances) {
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-  switch (std::get<PrimDataType>(dtype.type)) {
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-    case DataType::ComplexFloat:
-    case DataType::ComplexDouble:
-    case DataType::Float:
-    // TODO: Pull new tolerances for Double, for now we will just use float
-    // tolerances as it should be no worse.
-    case DataType::Double: {
-      const auto& sum_tolerance_entry = tolerances.sum_tolerances_float;
-      const auto& base_abs = tolerances.base_float_abs_tol;
-      const auto& base_rel = tolerances.base_float_rel_tol;
-
-      if (reduction_size <= 1) {
-        // No reduction case
-        if (base_abs == -1 || base_rel == -1) {
-          return {sum_tolerance_entry[0][1], sum_tolerance_entry[1][1]};
-        } else {
-          return {base_abs, base_rel};
-        }
-      } else {
-        // Reduction case
-        size_t entry = 0;
-        while (entry < sum_tolerance_entry.size() &&
-               (int64_t)sum_tolerance_entry[entry][0] < reduction_size) {
-          entry++;
-        }
-        double abs_tol = 0.0;
-        if (entry + 1 < sum_tolerance_entry.size()) {
-          // Grab the next entry up so we have some margin
-          abs_tol = sum_tolerance_entry[entry + 1][1];
-        } else {
-          // If we hit the end of the list, return twice the max error we
-          // measured
-          abs_tol = sum_tolerance_entry[sum_tolerance_entry.size() - 1][1] * 2.;
-        }
-        // Relative tol we're going to set to 1% of abs tol just for
-        // a small margin of rel error.
-        return {abs_tol, abs_tol * 0.01};
-      }
-    }
-    case DataType::Half: {
-      // Copied from float case
-      const auto& sum_tolerance_entry = tolerances.sum_tolerances_half;
-      const auto& base_abs = tolerances.base_half_abs_tol;
-      const auto& base_rel = tolerances.base_half_rel_tol;
-
-      if (reduction_size <= 1) {
-        // No reduction case
-        if (base_abs == -1 || base_rel == -1) {
-          return {sum_tolerance_entry[0][1], sum_tolerance_entry[1][1]};
-        } else {
-          return {base_abs, base_rel};
-        }
-      } else {
-        // Reduction case
-        size_t entry = 0;
-        while ((int64_t)sum_tolerance_entry[entry][0] < reduction_size &&
-               entry < sum_tolerance_entry.size()) {
-          entry++;
-        }
-        double abs_tol = 0.0;
-        if (entry + 1 < sum_tolerance_entry.size()) {
-          // Grab the next entry up so we have some margin
-          abs_tol = sum_tolerance_entry[entry + 1][1];
-        } else {
-          // If we hit the end of the list, return twice the max error we
-          // measured
-          abs_tol = sum_tolerance_entry[sum_tolerance_entry.size() - 1][1] * 2.;
-        }
-        // Relative tol we're going to set to 1% of abs tol just for
-        // a small margin of rel error.
-        return {abs_tol, abs_tol * 0.01};
-      }
-    }
-    // TODO: fp8 likely will need higher tolerance.
-    case DataType::Float8_e4m3fn:
-    case DataType::Float8_e5m2:
-    case DataType::BFloat16: {
-      // Copied from float case
-      const auto& sum_tolerance_entry = tolerances.sum_tolerances_half;
-      const auto& base_abs = tolerances.base_half_abs_tol;
-      const auto& base_rel = tolerances.base_half_rel_tol;
-
-      if (reduction_size <= 1) {
-        // No reduction case
-        if (base_abs == -1 || base_rel == -1) {
-          return {sum_tolerance_entry[0][1], sum_tolerance_entry[1][1]};
-        } else {
-          return {base_abs * 10.0, base_rel * 10.0};
-        }
-      } else {
-        // Reduction case
-        size_t entry = 0;
-        while ((int64_t)sum_tolerance_entry[entry][0] < reduction_size &&
-               entry < sum_tolerance_entry.size()) {
-          entry++;
-        }
-        double abs_tol = 0.0;
-        if (entry + 1 < sum_tolerance_entry.size()) {
-          // Grab the next entry up so we have some margin
-          abs_tol = sum_tolerance_entry[entry + 1][1];
-        } else {
-          // If we hit the end of the list, return twice the max error we
-          // measured
-          abs_tol = sum_tolerance_entry[sum_tolerance_entry.size() - 1][1] * 2.;
-        }
-        // Relative tol we're going to set to 1% of abs tol just for
-        // a small margin of rel error.
-        return {abs_tol * 10.0, abs_tol * 0.01 * 10.0};
-      }
-    }
-    case DataType::Int:
-    case DataType::Int32:
-    case DataType::Index:
-    case DataType::Bool:
-      return {0.0, 0.0};
-    default:
-      NVF_ERROR(
-          false, "Do not have tolerance computation for type ", dtype, ".");
-  }
-}
+    const ValidationConstants& tolerances);
 
 class ReductionSizeMapper : private IterVisitor {
  public:
@@ -190,80 +63,15 @@ class ReductionSizeMapper : private IterVisitor {
   //! to compute each tensorview.
   static std::unordered_map<TensorView*, int64_t> computeReductionSizes(
       Fusion* fusion,
-      ExpressionEvaluator& expr_eval) {
-    ReductionSizeMapper mapper(fusion, expr_eval);
-    return mapper.reduction_map;
-  }
+      ExpressionEvaluator& expr_eval);
 
  private:
-  ReductionSizeMapper(Fusion* fusion, ExpressionEvaluator& expr_eval)
-      : expr_eval_(expr_eval) {
-    // Initialize input values
-    for (auto inp : fusion->inputs()) {
-      if (inp->isA<TensorView>()) {
-        auto tv = inp->as<TensorView>();
-        // Shouldn't have any reductions, but run it through analysis anyways.
-        reduction_map[tv] = getReductionSize(tv);
-      }
-    }
+  ReductionSizeMapper(Fusion* fusion, ExpressionEvaluator& expr_eval);
 
-    IterVisitor::traverse(fusion);
+  int64_t getReductionSize(const TensorView* tv);
 
-    // catch up with dangling outputs;
-    for (auto out : fusion->outputs()) {
-      if (out->isA<TensorView>()) {
-        auto tv = out->as<TensorView>();
-        // possible that we have a dangling output that's not generated by any
-        // expression. e.g. 0 workspace or null tensor
-        if (reduction_map.count(tv) == 0) {
-          // Shouldn't have any reductions, but run it through analysis anyways.
-          reduction_map[tv] = getReductionSize(tv);
-        }
-      }
-    }
-  }
+  void dispatch(Expr* expr) override;
 
-  int64_t getReductionSize(const TensorView* tv) {
-    int64_t reduction_elements = 1;
-    for (auto id : tv->getLogicalDomain()) {
-      if (id->isReduction()) {
-        auto inferred_extent = expr_eval_.evaluate(id->extent());
-        NVF_ERROR(
-            inferred_extent.hasValue(),
-            "Couldn't figure out what the dimensions of a tensorview is in evaluation for validation. ",
-            id,
-            " in ",
-            tv);
-        reduction_elements = reduction_elements * inferred_extent.as<int64_t>();
-      }
-    }
-    return reduction_elements;
-  }
-
-  void dispatch(Expr* expr) override {
-    if (!ir_utils::isTvOp(expr)) {
-      return;
-    }
-
-    int64_t inp_reduction_elements = 1;
-    for (auto inp : expr->inputs()) {
-      if (inp->isA<TensorView>()) {
-        if (auto tv = inp->as<TensorView>()) {
-          inp_reduction_elements =
-              std::max(inp_reduction_elements, reduction_map.at(tv));
-        }
-      }
-    }
-
-    for (auto out : expr->outputs()) {
-      if (out->isA<TensorView>()) {
-        auto tv = out->as<TensorView>();
-        reduction_map[tv] = getReductionSize(tv) * inp_reduction_elements;
-      }
-    }
-  }
-
- private:
   using IterVisitor::handle;
 
   std::unordered_map<TensorView*, int64_t> reduction_map;
@@ -273,79 +81,12 @@ class ReductionSizeMapper : private IterVisitor {
 ExpressionEvaluator bindInputsAndLaunchParams(
     Fusion* fusion,
     const at::ArrayRef<c10::IValue>& aten_inputs,
-    const LaunchParams& launch_constraints) {
-  KernelArgumentHolder argument_holder;
-  argument_holder.push(aten_inputs);
-
-  auto expr_eval = executor_utils::bindInputs(argument_holder, fusion);
-  for (auto val : fusion->vals()) {
-    if (!val->isA<TensorView>()) {
-      continue;
-    }
-
-    // Roughly taken from executor.cpp/computeLaunchParams
-    auto tv = val->as<TensorView>();
-    for (auto id : tv->getLoopDomain()) {
-      if (!(id->isThread() && id->extent()->definition() == nullptr)) {
-        continue;
-      }
-
-      if (id->isBroadcast()) {
-        continue;
-      }
-
-      auto extent = id->extent();
-      auto inferred_extent = expr_eval.evaluate(extent);
-      auto p_type = id->getParallelType();
-
-      if (inferred_extent.hasValue()) {
-        // This value could have been inferred, make sure it was set right.
-        NVF_CHECK(
-            inferred_extent == launch_constraints.getDim(p_type) ||
-                launch_constraints.getRawVal(p_type) == -1,
-            "inferred that ",
-            p_type,
-            " should be set to ",
-            inferred_extent,
-            " but launch constraints specified ",
-            launch_constraints.getRawVal(p_type));
-      } else {
-        // Bind the launch constraint into our evaluation context
-        if (launch_constraints.hasDim(id->getParallelType())) {
-          expr_eval.bind(extent, launch_constraints.getDim(p_type));
-        }
-      }
-    }
-  }
-  return expr_eval;
-}
+    const LaunchParams& launch_constraints);
 
 std::vector<std::pair<double, double>> get_val_constants(
     Fusion* fusion,
     const at::ArrayRef<c10::IValue>& aten_inputs,
     const LaunchParams& lparams = LaunchParams(),
-    const ValidationConstants& tolerances = ValidationConstants()) {
-  FusionGuard fg(fusion);
-  auto expr_eval = bindInputsAndLaunchParams(fusion, aten_inputs, lparams);
-  auto reduction_sizes =
-      ReductionSizeMapper::computeReductionSizes(fusion, expr_eval);
+    const ValidationConstants& tolerances = ValidationConstants());
 
-  std::vector<std::pair<double, double>> tolerance_values;
-  for (size_t i = 0; i < fusion->outputs().size(); i++) {
-    auto fusion_output_tv = fusion->outputs()[i]->as<TensorView>();
-    NVF_ERROR(
-        reduction_sizes.count(fusion_output_tv),
-        "Missed reduction size count on fusion output at index: ",
-        i);
-
-    int64_t reduction_size = reduction_sizes.at(fusion_output_tv);
-
-    auto tolerance_value = getTolerance(
-        fusion_output_tv->getDataType().value(), reduction_size, tolerances);
-    tolerance_values.push_back(tolerance_value);
-  }
-  return tolerance_values;
-}
-
-} // namespace
 } // namespace nvfuser

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -548,34 +548,6 @@ bool isSchedulerInUse(
   return false;
 }
 
-void validateSegmentation(
-    FusionKernelRuntime* runtime,
-    const std::vector<ScheduleHeuristic>& expected_heuristics) {
-  const auto& segment_groups = runtime->fusionSegments()->groups();
-
-  NVF_CHECK(
-      segment_groups.size() == expected_heuristics.size(),
-      "Unexpected segments. Expected: ",
-      expected_heuristics.size(),
-      ". Actual: ",
-      segment_groups.size());
-
-  // Assumes up to two segments exist for simplicity
-  NVF_ERROR(
-      segment_groups.size() <= 2, "True segment order analysis is required");
-
-  for (auto& group : segment_groups) {
-    int64_t segment_order = group->producer_edges.empty() ? 0 : 1;
-    NVF_CHECK(
-        group->heuristic() == expected_heuristics.at(segment_order),
-        "Expected to use the ",
-        expected_heuristics.at(segment_order),
-        " scheduler but ",
-        group->heuristic(),
-        " was used");
-  }
-}
-
 TensorView* biasEpilogue(TensorView* tensor, TensorView* bias) {
   NVF_CHECK(
       tensor->dtype() == bias->dtype(),

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -722,12 +722,6 @@ bool isSchedulerInUse(
 // Disable magic zero
 constexpr CompileParams matmul_cparams{DataType::Int32, 255, false};
 
-// Validate that the fusion is segmented with desired scheduler, currently only
-// supporting two segments
-void validateSegmentation(
-    FusionKernelRuntime* runtime,
-    const std::vector<ScheduleHeuristic>& expected_heuristics);
-
 // Utility to generate tensor with bias applied on the input tensor
 TensorView* biasEpilogue(TensorView* tensor, TensorView* bias);
 

--- a/tests/cpp/validator.cpp
+++ b/tests/cpp/validator.cpp
@@ -1,0 +1,197 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <tests/cpp/validator.h>
+
+#include <validator_utils.h>
+
+namespace nvfuser {
+
+void testValidate(
+    Fusion* fusion,
+    const std::vector<at::Tensor>& fusion_outputs,
+    const at::ArrayRef<c10::IValue>& aten_inputs,
+    std::vector<at::Tensor> aten_outputs,
+    int line_number,
+    const char* file_name,
+    std::string err_msg,
+    const LaunchParams& lparams,
+    const ValidationConstants& tolerances) {
+  FusionGuard fg(fusion);
+
+  std::vector<Val*> non_hidden_outputs;
+  std::copy_if(
+      fusion->outputs().begin(),
+      fusion->outputs().end(),
+      std::back_inserter(non_hidden_outputs),
+      [fusion](Val* out) {
+        // Returns true when `out` is **not** an aliased output that's hidden
+        // from integration. Hidden outputs won't show up in `fusion_outputs`
+        // for us to compare, so we skip them.
+        return !fusion->getOutputAlias(out).hide_output;
+      });
+
+  auto expr_eval = bindInputsAndLaunchParams(fusion, aten_inputs, lparams);
+
+  auto reduction_sizes =
+      ReductionSizeMapper::computeReductionSizes(fusion, expr_eval);
+
+  if (aten_outputs.empty()) {
+    for (Val* out : non_hidden_outputs) {
+      aten_outputs.emplace_back(expr_eval.evaluate(out).as<at::Tensor>());
+    }
+  }
+
+  NVF_ERROR(
+      fusion_outputs.size() == aten_outputs.size(),
+      "Number of outputs don't match: ",
+      fusion_outputs.size(),
+      " vs ",
+      aten_outputs.size());
+
+  NVF_ERROR(
+      fusion->inputs().size() == aten_inputs.size(),
+      "Number of inputs don't match: ",
+      fusion->inputs().size(),
+      " vs ",
+      aten_inputs.size());
+
+  for (auto i : c10::irange(fusion->inputs().size())) {
+    if (fusion->inputs()[i]->isA<TensorView>()) {
+      NVF_ERROR(aten_inputs[i].isTensor(), "Mismatch of tensor inputs.");
+
+      auto fusion_input_tv = fusion->inputs()[i]->as<TensorView>();
+      auto at_tensor = aten_inputs[i].toTensor();
+
+      NVF_ERROR(
+          at_tensor.dim() ==
+              static_cast<int64_t>(TensorDomain::noReductions(
+                                       fusion_input_tv->getLogicalDomain())
+                                       .size()),
+          "Dimensionality mismatch in inputs.");
+    }
+  }
+
+  for (auto i : c10::irange(non_hidden_outputs.size())) {
+    Val* out = non_hidden_outputs[i];
+    NVF_ERROR(out->isA<TensorView>());
+    TensorView* out_tv = out->as<TensorView>();
+
+    const at::Tensor& fusion_output_tensor = fusion_outputs[i];
+    const at::Tensor& aten_output_tensor = aten_outputs[i];
+
+    NVF_ERROR(
+        reduction_sizes.count(out_tv),
+        "Missed reduction size count on fusion output: ",
+        out_tv->toString());
+
+    int64_t reduction_size = reduction_sizes.at(out_tv);
+
+    NVF_ERROR(
+        aten_output_tensor.dim() == fusion_output_tensor.dim() &&
+            fusion_outputs[i].dim() ==
+                static_cast<int64_t>(
+                    TensorDomain::noReductions(out_tv->getLogicalDomain())
+                        .size()),
+        "Dimensionality mismatch in outputs.");
+
+    auto tolerance_values =
+        getTolerance(out_tv->getDataType().value(), reduction_size, tolerances);
+
+    if (aten_output_tensor.is_floating_point() ||
+        aten_output_tensor.is_complex()) {
+      NVF_ERROR(
+          aten_output_tensor.allclose(
+              fusion_output_tensor.to(aten_output_tensor.dtype()),
+              tolerance_values.second,
+              tolerance_values.first,
+              /*equal_nan=*/true),
+          "\n",
+          err_msg,
+          "\nValidation error in output ",
+          i,
+          " on line ",
+          line_number,
+          " in file ",
+          file_name,
+          ".\n  Detected abs error of: ",
+          aten_output_tensor.sub(fusion_output_tensor)
+              .abs()
+              .max()
+              .item()
+              .to<double>(),
+          "\n    absolute tolerance was set to ",
+          tolerance_values.first,
+          "\n    and relative tolerance set to ",
+          tolerance_values.second);
+    } else {
+      NVF_ERROR(
+          aten_output_tensor.equal(
+              fusion_output_tensor.to(aten_output_tensor.dtype())),
+          "\n",
+          err_msg,
+          ".\n  Validation error in output ",
+          i,
+          " on line ",
+          line_number,
+          " in file ",
+          file_name,
+          ".\n Values are not equal and are not a floating type.");
+    }
+  }
+}
+
+void testValidate(
+    Fusion* fusion,
+    const std::vector<at::Tensor>& fusion_outputs,
+    const at::ArrayRef<c10::IValue>& aten_inputs,
+    int line_number,
+    const char* file_name,
+    std::string err_msg,
+    const LaunchParams& lparams,
+    const ValidationConstants& tolerances) {
+  testValidate(
+      fusion,
+      fusion_outputs,
+      aten_inputs,
+      /*aten_outputs=*/{},
+      line_number,
+      file_name,
+      err_msg,
+      lparams,
+      tolerances);
+}
+
+void validateSegmentation(
+    FusionKernelRuntime* runtime,
+    const std::vector<ScheduleHeuristic>& expected_heuristics) {
+  const auto& segment_groups = runtime->fusionSegments()->groups();
+
+  NVF_CHECK(
+      segment_groups.size() == expected_heuristics.size(),
+      "Unexpected segments. Expected: ",
+      expected_heuristics.size(),
+      ". Actual: ",
+      segment_groups.size());
+
+  // Assumes up to two segments exist for simplicity
+  NVF_ERROR(
+      segment_groups.size() <= 2, "True segment order analysis is required");
+
+  for (auto& group : segment_groups) {
+    int64_t segment_order = group->producer_edges.empty() ? 0 : 1;
+    NVF_CHECK(
+        group->heuristic() == expected_heuristics.at(segment_order),
+        "Expected to use the ",
+        expected_heuristics.at(segment_order),
+        " scheduler but ",
+        group->heuristic(),
+        " was used");
+  }
+}
+
+} // namespace nvfuser

--- a/tests/cpp/validator.h
+++ b/tests/cpp/validator.h
@@ -5,9 +5,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#pragma once
 
 #include <gmock/gmock-matchers.h>
 
+#include <string>
+#include <vector>
+
+#include <fusion.h>
+#include <kernel_cache.h>
+#include <scheduler/heuristic_types.h>
 #include <validator_utils.h>
 
 namespace nvfuser {
@@ -34,130 +41,7 @@ void testValidate(
     const char* file_name,
     std::string err_msg = "",
     const LaunchParams& lparams = LaunchParams(),
-    const ValidationConstants& tolerances = ValidationConstants()) {
-  FusionGuard fg(fusion);
-
-  std::vector<Val*> non_hidden_outputs;
-  std::copy_if(
-      fusion->outputs().begin(),
-      fusion->outputs().end(),
-      std::back_inserter(non_hidden_outputs),
-      [fusion](Val* out) {
-        // Returns true when `out` is **not** an aliased output that's hidden
-        // from integration. Hidden outputs won't show up in `fusion_outputs`
-        // for us to compare, so we skip them.
-        return !fusion->getOutputAlias(out).hide_output;
-      });
-
-  auto expr_eval = bindInputsAndLaunchParams(fusion, aten_inputs, lparams);
-
-  auto reduction_sizes =
-      ReductionSizeMapper::computeReductionSizes(fusion, expr_eval);
-
-  if (aten_outputs.empty()) {
-    for (Val* out : non_hidden_outputs) {
-      aten_outputs.emplace_back(expr_eval.evaluate(out).as<at::Tensor>());
-    }
-  }
-
-  NVF_ERROR(
-      fusion_outputs.size() == aten_outputs.size(),
-      "Number of outputs don't match: ",
-      fusion_outputs.size(),
-      " vs ",
-      aten_outputs.size());
-
-  NVF_ERROR(
-      fusion->inputs().size() == aten_inputs.size(),
-      "Number of inputs don't match: ",
-      fusion->inputs().size(),
-      " vs ",
-      aten_inputs.size());
-
-  for (auto i : c10::irange(fusion->inputs().size())) {
-    if (fusion->inputs()[i]->isA<TensorView>()) {
-      NVF_ERROR(aten_inputs[i].isTensor(), "Mismatch of tensor inputs.");
-
-      auto fusion_input_tv = fusion->inputs()[i]->as<TensorView>();
-      auto at_tensor = aten_inputs[i].toTensor();
-
-      NVF_ERROR(
-          at_tensor.dim() ==
-              static_cast<int64_t>(TensorDomain::noReductions(
-                                       fusion_input_tv->getLogicalDomain())
-                                       .size()),
-          "Dimensionality mismatch in inputs.");
-    }
-  }
-
-  for (auto i : c10::irange(non_hidden_outputs.size())) {
-    Val* out = non_hidden_outputs[i];
-    NVF_ERROR(out->isA<TensorView>());
-    TensorView* out_tv = out->as<TensorView>();
-
-    const at::Tensor& fusion_output_tensor = fusion_outputs[i];
-    const at::Tensor& aten_output_tensor = aten_outputs[i];
-
-    NVF_ERROR(
-        reduction_sizes.count(out_tv),
-        "Missed reduction size count on fusion output: ",
-        out_tv->toString());
-
-    int64_t reduction_size = reduction_sizes.at(out_tv);
-
-    NVF_ERROR(
-        aten_output_tensor.dim() == fusion_output_tensor.dim() &&
-            fusion_outputs[i].dim() ==
-                static_cast<int64_t>(
-                    TensorDomain::noReductions(out_tv->getLogicalDomain())
-                        .size()),
-        "Dimensionality mismatch in outputs.");
-
-    auto tolerance_values =
-        getTolerance(out_tv->getDataType().value(), reduction_size, tolerances);
-
-    if (aten_output_tensor.is_floating_point() ||
-        aten_output_tensor.is_complex()) {
-      NVF_ERROR(
-          aten_output_tensor.allclose(
-              fusion_output_tensor.to(aten_output_tensor.dtype()),
-              tolerance_values.second,
-              tolerance_values.first,
-              /*equal_nan=*/true),
-          "\n",
-          err_msg,
-          "\nValidation error in output ",
-          i,
-          " on line ",
-          line_number,
-          " in file ",
-          file_name,
-          ".\n  Detected abs error of: ",
-          aten_output_tensor.sub(fusion_output_tensor)
-              .abs()
-              .max()
-              .item()
-              .to<double>(),
-          "\n    absolute tolerance was set to ",
-          tolerance_values.first,
-          "\n    and relative tolerance set to ",
-          tolerance_values.second);
-    } else {
-      NVF_ERROR(
-          aten_output_tensor.equal(
-              fusion_output_tensor.to(aten_output_tensor.dtype())),
-          "\n",
-          err_msg,
-          ".\n  Validation error in output ",
-          i,
-          " on line ",
-          line_number,
-          " in file ",
-          file_name,
-          ".\n Values are not equal and are not a floating type.");
-    }
-  }
-}
+    const ValidationConstants& tolerances = ValidationConstants());
 
 // The variant with automatically inferred aten outputs. The `evaluate` method
 // of the exprs in the fusion must be overriden to handle at::Tensor.
@@ -169,22 +53,17 @@ void testValidate(
     const char* file_name,
     std::string err_msg = "",
     const LaunchParams& lparams = LaunchParams(),
-    const ValidationConstants& tolerances = ValidationConstants()) {
-  testValidate(
-      fusion,
-      fusion_outputs,
-      aten_inputs,
-      {},
-      line_number,
-      file_name,
-      err_msg,
-      lparams,
-      tolerances);
-}
+    const ValidationConstants& tolerances = ValidationConstants());
 
 // A gmock matcher for matching heuristics.
 MATCHER_P(HeuristicIs, heuristic, "") {
   return arg->heuristic() == heuristic;
 }
+
+// Validate that the fusion is segmented with desired scheduler, currently only
+// supporting two segments
+void validateSegmentation(
+    FusionKernelRuntime* runtime,
+    const std::vector<ScheduleHeuristic>& expected_heuristics);
 
 } // namespace nvfuser


### PR DESCRIPTION
I'm unsure about the difference between tests/cpp/utils.h and tests/cpp/validator.h. AFAICS, tests/cpp/validator.h is only used by tests not benchmarks, so it seems to be the right home for validateSegmentation. 

This PR comes with some other fixes I had to make along the way: 
1. Move non-trivial implementation to cpp files: https://google.github.io/styleguide/cppguide.html#Inline_Functions. 
2. Add missing `#pragma once`s. 
3. Move definitions of external methods in validation_utils.h out of anonymous namespaces. 