### PR TITLE
Cleanup `swizzleSharedMemory`

### DIFF
--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -1007,7 +1007,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
     // domain are mapped in the loop graph of IdModel due to the mapping of
     // compliment IDs. We should remove forwarding completely, and remove this
     // workaround.
-    mma_result->split(-2, 2);
+    mma_result->split(-2, 1);
     mma_result->merge(-3);
   }
 


### PR DESCRIPTION
Smem epilogue tensor is now using TensorIndexer and new swizzle, so there is no need to schedule an "empty" swizzle just to make IDs match. The problem of self mapping still exist, but it can be easily workaround by a much simpler transformation.