### PR TITLE
Fix finding right non-divisible splits to predicate

### DIFF
--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -1168,7 +1168,7 @@ std::vector<PredicateInfo> TensorIndexer::getPredicates(
   if (!lower_utils::isReductionInitExpr(expr)) {
     for (const auto& [eg, direction] : index_info.traversal_path) {
       // NOTE: Fundamentally, the problem of non divisiblity should be
-      // checked while traversing the indexng path. Currently, it uses
+      // checked while traversing the indexing path. Currently, it uses
       // the information gathered in a tensor-by-tensor basis. This
       // should be fine currently, but may not work if, e.g., the
       // indexing path involved both backward and forward traversals.

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -976,9 +976,9 @@ IndexingInfo TensorIndexer::computeIndex(
 
   // Initialize the loop dependency mappings
   for (const auto& loop_domain : loop_domains) {
-    const auto& traversal_graph_group =
-        traversalGraph().toGroup(loop_domain);
-    const auto& loop_graph_group = id_model_.idGraph(IdMappingMode::LOOP).toGroup(loop_domain);
+    const auto& traversal_graph_group = traversalGraph().toGroup(loop_domain);
+    const auto& loop_graph_group =
+        id_model_.idGraph(IdMappingMode::LOOP).toGroup(loop_domain);
     loop_group_dependencies[traversal_graph_group].pushBack(loop_graph_group);
   }
 

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -968,7 +968,7 @@ IndexingInfo TensorIndexer::computeIndex(
 
   IdGraphIndexCompute index_compute(traversalGraph(), initial_index_map);
 
-  // In addition to indeices themselves, keep track of the
+  // In addition to indices themselves, keep track of the
   // dependency from each domain to loop domains. This dependency is
   // represented as a map from ValGroup of the traversal graph to
   // ValGroup of the LOOP graph.

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -28,6 +28,8 @@ struct IndexingInfo {
   ExprPath<ExprGroup> traversal_path;
   // Index mappings of ID groups along the traversal path
   std::unordered_map<ValGroup, Val*> index_map;
+  // Mappings from ID groups to dependent loop groups
+  std::unordered_map<ValGroup, ValGroups> loop_group_dependencies;
 };
 
 struct IndexingAllocationInfo {

--- a/csrc/id_model/predicate_indexing.h
+++ b/csrc/id_model/predicate_indexing.h
@@ -53,7 +53,7 @@ inline bool isNonDivisibleSplit(const ExprGroup& expr_group) {
   // may result in duplicate predicates, which should be removed by
   // the expression simplifier.
   //
-  // For example, suppose tv0 as a 1D tensor of size 16:
+  // For example, suppose tv0 is a 1D tensor of size 16:
   //
   // auto tv1 = reshape(tv0, {16}, {2, 8});
   // tv1->split(1, 3);

--- a/csrc/id_model/predicate_indexing.h
+++ b/csrc/id_model/predicate_indexing.h
@@ -35,4 +35,70 @@ std::unordered_map<Val*, Val*> getPredicateIndexReplacementMap(
     bool is_start_predicate,
     ForLoop* unswitched_loop = nullptr);
 
+// Check if a given ExprGroup is a split that needs an additional
+// predicate due to its non-divisibility.
+inline bool isNonDivisibleSplit(const ExprGroup& expr_group) {
+  if (!expr_group->front()->isA<Split>()) {
+    return false;
+  }
+
+  const auto& non_divisible_split_info =
+      GpuLower::current()->nonDivisibleSplitInfo();
+
+  std::vector<PredicateDomainInfo> pred_info_vec;
+
+  // The splitsToPredicate map is for each tensor. Here, it's assumed
+  // that if any tensor has a non-divisible split that's mapped with
+  // expr_group, it should be considered a non-divisible split. This
+  // may result in duplicate predicates, which should be removed by
+  // the expression simplifier.
+  //
+  // For example, suppose tv0 as a 1D tensor of size 16:
+  //
+  // auto tv1 = reshape(tv0, {16}, {2, 8});
+  // tv1->split(1, 3);
+  //
+  // propagate_transformation(to: tv0, from: tv1)
+  //
+  // Here, the split by 3 of tv1 is not included in its non-divisible
+  // split list even though it is indeed non-divisible. The reason is
+  // that the input to the non-divisible split, the inner logical
+  // domain of extent 8, is predicated anyway since it's a logical
+  // domain. Specifically, its predicate should consist of:
+  //
+  // - Predicate for the outer logical domain
+  // - Predicate for the inner logical domain
+  //
+  // However, for tv0, it is indeed included in the non-divisible
+  // split list since the domain of extent 8 is not part
+  // of its logical domain.
+  //
+  // - Predicate for the sole logical domain
+  // - Predicate for the non-divisible split
+  //
+  // This would mean that when generating a predicate for tv1, since
+  // the below check would find a mapping with the non-divisible split
+  // for tv0, the tv1 predicate would be:
+  //
+  // - Predicate for the outer logical domain
+  // - Predicate for the inner logical domain
+  // - Predicate for the non-divisible split
+  //
+  // Here, the last two predicates are redundant since both of them
+  // guard the index with respect to the domain of extent 8, which is
+  // redundant. This is a bit annonying but should have no actual
+  // impact as the redundancy should be removed by the expression
+  // simplifier.
+  for (const auto& [tv, splits] :
+       non_divisible_split_info.splitsToPredicate()) {
+    if (std::find_if(splits.begin(), splits.end(), [&](Split* split) {
+          return expr_group->has(split);
+        }) != splits.end()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 } // namespace nvfuser

--- a/csrc/index_compute.h
+++ b/csrc/index_compute.h
@@ -390,6 +390,10 @@ class PredicateInfo {
     return predicated_domains_;
   }
 
+  const auto& loopDomains() const {
+    return loop_domains_;
+  }
+
   CircularBufferLoopStage loopStage() const {
     return loop_stage_;
   }
@@ -409,6 +413,8 @@ class PredicateInfo {
   Val* stop_offset_ = nullptr;
   // Track which domains are covered by the generated predicates
   std::unordered_set<IterDomain*> predicated_domains_;
+  // Loops domains used for the predicate domains
+  std::unordered_set<IterDomain*> loop_domains_;
   // Circular buffer loop stage if applicable
   CircularBufferLoopStage loop_stage_ = CircularBufferLoopStage::NotApplicable;
 };

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -278,6 +278,11 @@ UnswitchPredicateKey::UnswitchPredicateKey(
   //
   // TODO: Clean up once the migration to the new indexer is
   // completed.
+  //
+  // When loop_ids_ is not empty, the correct loop domains are already
+  // given to this class. That's the case when using the new
+  // indexer. When given, use them to figure out which parallel type
+  // is used for which loop domain.
   if (!loop_ids_.empty()) {
     for (auto loop_id : loop_ids_) {
       auto pt = loop_id->getParallelType();
@@ -287,21 +292,22 @@ UnswitchPredicateKey::UnswitchPredicateKey(
         // This map is supposed to contain CA conrete IDs but as long
         // as they are uniquely mapped to some representative domains,
         // it should work.
-        parallel_concrete_ids_.at(pt) =
-            GpuLower::current()->tensorIndexer().traversalGraph().toGroup(
-                loop_id)->front()->as<IterDomain>();
+        parallel_concrete_ids_.at(pt) = GpuLower::current()
+                                            ->tensorIndexer()
+                                            .traversalGraph()
+                                            .toGroup(loop_id)
+                                            ->front()
+                                            ->as<IterDomain>();
       }
     }
     return;
-  } else {
-    std::copy_if(
-        consumer_tv->getLoopDomain().begin(),
-        consumer_tv->getLoopDomain().end(),
-        std::back_inserter(all_parallelized_consumer_loop_ids),
-        [](IterDomain* x) {
-          return isParallelTypeThread(x->getParallelType());
-        });
   }
+
+  std::copy_if(
+      consumer_tv->getLoopDomain().begin(),
+      consumer_tv->getLoopDomain().end(),
+      std::back_inserter(all_parallelized_consumer_loop_ids),
+      [](IterDomain* x) { return isParallelTypeThread(x->getParallelType()); });
 
   // If the consumer domais are not parallelized at all, no need to
   // differentiate keys based on how the predicated id is parallelized

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -255,19 +255,51 @@ UnswitchPredicateKey::UnswitchPredicateKey()
 UnswitchPredicateKey::UnswitchPredicateKey(
     IterDomain* predicated_consumer_id,
     TensorView* consumer_tv,
-    IterDomain* predicated_concrete_id)
-    : predicated_concrete_id_(predicated_concrete_id) {
+    IterDomain* predicated_concrete_id,
+    std::unordered_set<IterDomain*> loop_ids)
+    : predicated_concrete_id_(predicated_concrete_id),
+      loop_ids_(std::move(loop_ids)) {
   // Initialize the parallelized domain map
+  // TODO: Add DID
   for (auto pt : kParallelTypeThreads) {
     parallel_concrete_ids_.insert({pt, nullptr});
   }
 
   std::vector<Val*> all_parallelized_consumer_loop_ids;
-  std::copy_if(
-      consumer_tv->getLoopDomain().begin(),
-      consumer_tv->getLoopDomain().end(),
-      std::back_inserter(all_parallelized_consumer_loop_ids),
-      [](IterDomain* x) { return isParallelTypeThread(x->getParallelType()); });
+
+  // Identify which parallel type is used for which loop domain for
+  // this index. This information is obtained here for the legacy method by
+  // looking at the dependency between the predicated domain and the
+  // loop domains of the tensor. However, in the case of the new
+  // indexer, that information is not readily available since the
+  // indexing graph needs to be traversed. Instead, the loop
+  // dependency information is given to this constructor in the case
+  // of the new indexer.
+  //
+  // TODO: Clean up once the migration to the new indexer is
+  // completed.
+  if (!loop_ids_.empty()) {
+    for (auto loop_id : loop_ids_) {
+      auto pt = loop_id->getParallelType();
+      // DID is ignored.
+      // TODO: support DID
+      if (isParallelTypeThread(pt)) {
+        // This map is supposed to contain CA conrete IDs but as long
+        // as they are uniquely mapped to some representative domains,
+        // it should work.
+        parallel_concrete_ids_.at(pt) = loop_id;
+      }
+    }
+    return;
+  } else {
+    std::copy_if(
+        consumer_tv->getLoopDomain().begin(),
+        consumer_tv->getLoopDomain().end(),
+        std::back_inserter(all_parallelized_consumer_loop_ids),
+        [](IterDomain* x) {
+          return isParallelTypeThread(x->getParallelType());
+        });
+  }
 
   // If the consumer domais are not parallelized at all, no need to
   // differentiate keys based on how the predicated id is parallelized
@@ -521,7 +553,8 @@ void UnswitchPredicate::predicateOn(Expr* tv_expr) {
         continue;
       }
 
-      UnswitchPredicateKey key(root_id, out_tv, concrete_root_id);
+      UnswitchPredicateKey key(
+          root_id, out_tv, concrete_root_id, pred_info.loopDomains());
       auto inserted = predicated_keys_.insert(key).second;
       add_pred = add_pred || inserted;
 
@@ -556,6 +589,11 @@ void UnswitchPredicate::predicateOn(Expr* tv_expr) {
 
       // To look up this MergedPredicates for other predicates
       // generated for the same predicate key
+      // TODO: This seems to assume the merge logic is only necessary
+      // for shift predicates. Now that it's removed, it should be
+      // possible to clean this up.
+      // TODO: This doesn't seem to work if circular buffer predicates
+      // are involved with contig indexing.
       if (root_ids.size() == 1) {
         merged_pred.predicate_key = first_key;
       }

--- a/csrc/predicate_compute.h
+++ b/csrc/predicate_compute.h
@@ -84,10 +84,13 @@ class UnswitchPredicateKey {
  public:
   UnswitchPredicateKey();
 
+  // Parameter loop_ids represents the loop domains used for the
+  // predicated domain
   UnswitchPredicateKey(
       IterDomain* predicated_consumer_id,
       TensorView* consumer_tv,
-      IterDomain* predicated_concrete_id);
+      IterDomain* predicated_concrete_id,
+      std::unordered_set<IterDomain*> loop_ids);
 
   bool operator==(const UnswitchPredicateKey& other) const {
     return predicated_concrete_id_ == other.predicated_concrete_id_ &&
@@ -116,6 +119,8 @@ class UnswitchPredicateKey {
  private:
   //! Predicated concrete domain
   IterDomain* predicated_concrete_id_ = nullptr;
+  //! Dependent loop domains
+  std::unordered_set<IterDomain*> loop_ids_;
   //! Store parallelized concrete domains
   std::unordered_map<ParallelType, IterDomain*> parallel_concrete_ids_;
 };

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -4332,8 +4332,8 @@ TEST_F(PredicateIndexingTest, UnswitchConsolidationDifferentThreading) {
   // patterns: one with TIDy and TIDx and another with TIDx and
   // TIDy. Specifically, the unswitch predicate should consist of:
   //
-  // (bidx * 8 + tidy) * 16 + tidx
-  // (bidx * 8 + tidx) * 16 + tidy
+  // (bidx * 8 + tidy) * 16 + tidx < i0
+  // (bidx * 8 + tidx) * 16 + tidy < i0
   //
   // Additionally, since tidx and tidy are both used for different
   // extents, there should be parallel domain predicates as well. The

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -16,6 +16,7 @@
 #include <fusion.h>
 #include <id_model/id_model.h>
 #include <id_model/indexing.h>
+#include <id_model/indexing_utils.h>
 #include <id_model/to_string.h>
 #include <inlining.h>
 #include <ir/builder.h>
@@ -39,6 +40,17 @@ std::vector<Val*> getLoopIndices(TensorView* tv, const TensorIndexer& indexer) {
     loop_indices.push_back(indexer.getLoopIndex(loop_id));
   }
   return loop_indices;
+}
+
+std::vector<IterDomain*> getLoopDomains(
+    TensorView* tv,
+    const IdModel& id_model) {
+  std::vector<IterDomain*> loop_domains;
+  for (auto loop_id : tv->getLoopDomain()) {
+    loop_domains.push_back(indexing_utils::getLoopPromotion(loop_id, id_model));
+  }
+
+  return loop_domains;
 }
 
 template <typename... Args>
@@ -95,6 +107,33 @@ Val* createInt(int64_t i) {
   return IrBuilder::create<Val>(i, DataType::Index);
 }
 
+// Predicates should be a composite val that should look like (((x &&
+// y) && z). To make it easier to read error messages, decompose the
+// composite predicate to each component and print each in a separate
+// line.
+std::string prettyPrintPredicate(Val* pred) {
+  std::deque<Val*> pred_list;
+
+  while (true) {
+    NVF_ERROR(pred != nullptr);
+    if (auto bop = dynamic_cast<BinaryOp*>(pred->definition());
+        bop != nullptr && bop->getBinaryOpType() == BinaryOpType::LogicalAnd) {
+      pred_list.push_front(bop->input(1));
+      pred = bop->input(0);
+    } else {
+      pred_list.push_front(pred);
+      break;
+    }
+  }
+
+  std::stringstream ss;
+  for (auto each_pred : pred_list) {
+    ss << each_pred->toInlineString() << "\n";
+  }
+
+  return ss.str();
+}
+
 // AbstractGetReference and IndexValidator are used to validate
 // lowered index vals. Each test subclasses either or both of
 // getLinearIndex and getLinearIndexString of
@@ -102,7 +141,8 @@ Val* createInt(int64_t i) {
 // validate each tensor indices.
 class AbstractGetReference {
  public:
-  AbstractGetReference(const TensorIndexer& indexer) : indexer_(indexer) {}
+  AbstractGetReference(const TensorIndexer& indexer, const IdModel& id_model)
+      : indexer_(indexer), id_model_(id_model) {}
   virtual ~AbstractGetReference() = default;
 
   // Returns the index of a given tensor. If maybe_consumer is not
@@ -149,6 +189,7 @@ class AbstractGetReference {
 
  protected:
   const TensorIndexer& indexer_;
+  const IdModel& id_model_;
   // These could be getLinearIndex parameters, but it's just easier to
   // add them here since the function signature doesn't need to change.
   std::vector<ForLoop*> for_loops_;
@@ -250,7 +291,7 @@ class IndexValidator : public kir::IrVisitor {
     testing::internal::GetCapturedStderr();
 
     IndexValidator<GetReference> validator(
-        lower, GetReference(lower.tensorIndexer(), args...));
+        lower, GetReference(lower.tensorIndexer(), lower.idModel(), args...));
 
     FusionGuard fg(kernel);
     validator.handle(kernel->topLevelExprs());
@@ -348,11 +389,12 @@ class PredicateIndexValidator : public kir::IrVisitor {
       if (loop_stage != CircularBufferLoopStage::NotApplicable) {
         loop_stage_msg << " in " << loop_stage;
       }
+      std::stringstream actual_str;
       EXPECT_TRUE(actual->sameAs(ref))
           << "Validation failure of outer predicate for "
-          << ti->view()->toString() << loop_stage_msg.str()
-          << "\nRef: " << ref->toInlineString()
-          << "\nActual: " << actual->toInlineString();
+          << ti->view()->toString() << loop_stage_msg.str() << "\nRef:\n"
+          << prettyPrintPredicate(ref) << "Actual:\n"
+          << prettyPrintPredicate(actual);
       return;
     }
 
@@ -383,7 +425,7 @@ class PredicateIndexValidator : public kir::IrVisitor {
     testing::internal::GetCapturedStderr();
 
     PredicateIndexValidator<GetReference> validator(
-        lower, GetReference(lower.tensorIndexer(), args...));
+        lower, GetReference(lower.tensorIndexer(), lower.idModel(), args...));
 
     FusionGuard fg(kernel);
     validator.handle(kernel->topLevelExprs());
@@ -416,8 +458,8 @@ TEST_F(IndexingTest, SimplePointwise1) {
   tv1->inlineAt(1);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -523,8 +565,8 @@ TEST_F(IndexingTest, SimplePointwise2) {
   // contribute to the index
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -583,8 +625,8 @@ TEST_F(IndexingTest, SimpleReduction) {
   fusion.addOutput(tv2);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -644,8 +686,8 @@ TEST_F(IndexingTest, PromotionToReductionDomain) {
   // mistakenly excluded the domain from indexing.
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -685,8 +727,8 @@ TEST_F(IndexingTest, AllocationDomain) {
   tv1->setAllocationDomain(tv1_transposed, true);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -745,8 +787,8 @@ TEST_F(IndexingTest, Reshape) {
   inlineMost();
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -816,8 +858,8 @@ TEST_F(IndexingTest, SimpleBroadcast1) {
   fusion.addOutput(tv2);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -864,8 +906,8 @@ TEST_F(IndexingTest, SimpleBroadcast2) {
   // indices, respecitvely.
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     // tv0 is a global memory tensor, so the indexing is done with its
     // allocation domain, which is mapped with the merge of the two
@@ -922,8 +964,8 @@ TEST_F(IndexingTest, SimpleBroadcast3) {
   inlineMost();
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1001,8 +1043,8 @@ TEST_F(IndexingTest, SimpleBroadcast4) {
   // is also just the inner loop index of the loop domains of tv4.
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1038,8 +1080,8 @@ TEST_F(IndexingTest, MultiDevice1DNoSplitMerge) {
   tv1->axis(0)->parallelize(ParallelType::DIDx);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1070,8 +1112,8 @@ TEST_F(IndexingTest, MultiDevice1DSplit) {
   tv1->axis(0)->parallelize(ParallelType::DIDx);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1107,8 +1149,8 @@ TEST_F(IndexingTest, MultiDevice2D) {
   tv1->axis(0)->parallelize(ParallelType::DIDx);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1153,8 +1195,8 @@ TEST_F(IndexingTest, MultiDevice2DLeafAllocation) {
   tv1->setAllocationDomain(tv1->getLoopDomain(), true);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1189,8 +1231,8 @@ TEST_F(IndexingTest, MultiDevice2DTranspose) {
   tv1->axis(0)->parallelize(ParallelType::DIDx);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1245,8 +1287,8 @@ TEST_F(IndexingTest, PromotedBroadcast) {
   // inlined, the resulting index of tv2 should just be zero.
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1292,8 +1334,8 @@ TEST_F(IndexingTest, SimpleVectorize) {
   scheduler_utils::parallelizeAllLike(tv2, ir_utils::allTvs(&fusion));
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1364,8 +1406,8 @@ TEST_F(IndexingTest, NonInnermostVectorize) {
   tv3->axis(2)->parallelize(ParallelType::Vectorize);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1426,8 +1468,8 @@ TEST_F(IndexingTest, AlmostExactTraversalWithNonOneBroadcast) {
   inlineAllAt(tv3, 1, true);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1480,8 +1522,8 @@ TEST_F(IndexingTest, Swizzle) {
   tv1->setAllocationDomain(alloc.as<IterDomain*>(), true);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1546,8 +1588,8 @@ TEST_F(IndexingTest, SimpleUnroll) {
   // isn't a scalar but has the unroll domain. Make sure the domain is
   // indeed indexed.
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1609,8 +1651,8 @@ TEST_F(IndexingTest, InlinedUnroll) {
 
   // Make sure tv2 is indexed with the innermost loop domain
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1671,8 +1713,11 @@ TEST_F(IndexingTest, SmemAllocationDomainForTranspose) {
   // Validate the smem tensor index. Its allocation domain should be
   // [32, 32], where each "32" comes from I1 and I0, respectively.
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer, StmtNameType smem_tv_name)
-        : AbstractGetReference(indexer), smem_tv_name(smem_tv_name) {}
+    GetReference(
+        const TensorIndexer& indexer,
+        const IdModel& id_model,
+        StmtNameType smem_tv_name)
+        : AbstractGetReference(indexer, id_model), smem_tv_name(smem_tv_name) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1778,8 +1823,8 @@ TEST_F(IndexingTest, ResizePath) {
   // [32, 32], where each "32" comes from I1 and I0, respectively.
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1850,8 +1895,8 @@ TEST_F(IndexingTest, DoubleBuffering1) {
   tv1->circularBuffer(/*number_of_stages=*/2);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -1960,8 +2005,8 @@ TEST_F(IndexingTest, DoubleBuffering4) {
   // - Producer of the producer of the circular buffered tensor
   // - Circular buffered tensor itself
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -2074,8 +2119,8 @@ TEST_F(IndexingTest, DoubleBuffering6) {
   // - Producer of the producer of the circular buffered tensor
   // - Circular buffered tensor itself
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -2211,8 +2256,8 @@ TEST_F(IndexingTest, CircularBuffering1) {
   tv1->circularBuffer(/*number_of_stages=*/4);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -2341,8 +2386,8 @@ TEST_F(IndexingTest, CircularBuffering2) {
   // - Producer of the producer of the circular buffered tensor
   // - Circular buffered tensor itself
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getLinearIndex(TensorView* tv, TensorView* maybe_consumer)
         const override {
@@ -2475,8 +2520,8 @@ TEST_F(PredicateIndexingTest, SimplePointwise1) {
   tv1->inlineAt(1);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getInlinePredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -2527,8 +2572,8 @@ TEST_F(PredicateIndexingTest, ReductionRfactor) {
   inlineMost();
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getInlinePredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -2622,8 +2667,8 @@ TEST_F(PredicateIndexingTest, SimpleUnroll) {
   tv2->axis(2)->parallelize(ParallelType::TIDx);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     // T2 should look like:
     //
@@ -2704,8 +2749,8 @@ TEST_F(PredicateIndexingTest, SimpleUnswitch) {
   // iUS10{4}, iS8{8}, ithreadIdx.x6{128} ] ca_pos( 4 ) produce_pos( 4 )
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     // The unswitch predicate should look like:
     //
@@ -2780,8 +2825,8 @@ TEST_F(PredicateIndexingTest, SimpleVectorize) {
   // Both tv1 and tv2 are vectorized. Their predicates are the same as
   // this is a simple memcpy.
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getInlinePredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -2855,8 +2900,8 @@ TEST_F(PredicateIndexingTest, NonInnermostVectorize) {
   // not innermost. Make sure only the vectorized domain is predicated with
   // (extent - 1).
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getInlinePredicate(TensorView* tv) const override {
       if (tv->name() != 1 && tv->name() != 3) {
@@ -2920,8 +2965,8 @@ TEST_F(PredicateIndexingTest, DoubleBuffering1) {
   // ithreadIdx.x15{32} ] ca_pos( 2 )
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getInlinePredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -3019,8 +3064,8 @@ TEST_F(PredicateIndexingTest, CircularBuffering1) {
   // ithreadIdx.x15{32} ] ca_pos( 2 )
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getInlinePredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -3132,8 +3177,8 @@ TEST_F(PredicateIndexingTest, UnrolledCircularBuffering) {
   //    +-- BIDx
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getOuterPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -3283,8 +3328,8 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering1) {
   // )
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getOuterPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -3366,8 +3411,8 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering2) {
   tv1->axis(0)->parallelize(ParallelType::BIDx);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getOuterPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -3471,8 +3516,8 @@ TEST_P(PredicateIndexingTest, UnswitchedCircularBuffering3) {
   }
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getOuterPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -3562,8 +3607,8 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering4) {
   //   +-- unswitch
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getOuterPredicate(TensorView* tv) const override {
       auto one = tv->fusion()->oneVal();
@@ -3632,8 +3677,8 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplit1) {
   tv2->split(1, 2);
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getInlinePredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -3734,8 +3779,8 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithUnswitch) {
   // predicate should only have one.
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getOuterPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -3820,8 +3865,8 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithCircularBuffering) {
   // predicate should use the incremented index for the axis.
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getInlinePredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -3933,8 +3978,8 @@ TEST_F(
   // ((ceilDiv(10, 3) - 1) + 2) * 3 + threadIdx.x < 10
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getOuterPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -4022,8 +4067,8 @@ TEST_P(PredicateIndexingTest, UnswitchPredicateIssueRepro681) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   struct GetReference : AbstractGetReference {
-    GetReference(const TensorIndexer& indexer)
-        : AbstractGetReference(indexer) {}
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
 
     Val* getOuterPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
@@ -4079,6 +4124,180 @@ TEST_P(PredicateIndexingTest, UnswitchPredicateIssueRepro681) {
   auto ref = t0.to(at::kDouble).sum();
 
   testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+}
+
+// Testing unswitched non-divisible predicates. For a given tensor,
+// its required unswitch predicates should be generated from its
+// indexing path, not its logical to loop dependencies. In this test,
+// the tv2 transformation has an non-divisible split that needs to be
+// predicated, but since it's inline into tv3, the acual non-divisible
+// split should be based on tv3.
+TEST_F(PredicateIndexingTest, NonDivisibleSplitWithUnswitchAndBroadcast) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(1);
+  fusion.addInput(tv0);
+  auto tv1 = makeSymbolicTensor(2);
+  fusion.addInput(tv1);
+
+  auto tv2 = broadcast(tv0, {false, true});
+  auto tv3 = add(tv2, tv1);
+  fusion.addOutput(tv3);
+
+  // [i0, i1]
+  tv3->merge(0);
+  // [i0*i1]
+
+  tv3->split(0, 100);
+  // [i0*i1/100, 100]
+
+  // This split needs to predicated as a non-divisible split
+  tv3->split(1, 16);
+  // [i0*i1/100, 100/16, 16]
+
+  tv3->split(0, 1);
+  // [i0*i1/100/1, 1, 100/16, 16]
+
+  TransformPropagatorWithCheck propagator(tv3);
+  MaxLogicalDomainInfoSpanningTree(tv3).traverse(&propagator);
+
+  inlineMost();
+
+  tv3->axis(1)->parallelize(ParallelType::Unswitch);
+  tv3->axis(-2)->parallelize(ParallelType::TIDy);
+  tv3->axis(-1)->parallelize(ParallelType::TIDx);
+
+  // The reference is tv3. tv2 lacks the inner concrete domain. Since
+  // tv2 is fully inlined, the effective loop domains should be the
+  // same for both tensors.
+  //
+  // The unswitch predicates should be:
+  //
+  // i0_idx >= 0
+  // i0_idx < i0
+  // i1_idx >= 0
+  // i1_idx < i1
+  //
+  // Additionally, since the split by 16 is non-divisible, it should
+  // also have:
+  //
+  // threadIdx.y * 16 + threadIdx.x < 100
+
+  struct GetReference : AbstractGetReference {
+    GetReference(const TensorIndexer& indexer, const IdModel& id_model)
+        : AbstractGetReference(indexer, id_model) {}
+
+    Val* getOuterPredicate(TensorView* tv) const override {
+      std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_);
+      std::vector<IterDomain*> loop_domains = getLoopDomains(tv, id_model_);
+      auto zero = tv->fusion()->zeroVal();
+      // auto one = tv->fusion()->oneVal();
+
+      auto non_divisible_split_to_predicate =
+          dynamic_cast<Split*>(loop_domains.at(2)->definition());
+      NVF_ERROR(non_divisible_split_to_predicate != nullptr);
+
+      auto first_merge_out_id = loop_domains.at(0)
+                                    ->definition()
+                                    ->input(0)
+                                    ->definition()
+                                    ->input(0)
+                                    ->as<IterDomain>();
+      auto ref_logical_id0 =
+          first_merge_out_id->definition()->input(0)->as<IterDomain>();
+      auto ref_logical_id1 =
+          first_merge_out_id->definition()->input(1)->as<IterDomain>();
+
+      auto non_divisible_domain_start_idx = addExpr(
+          mulExpr(loop_indices.at(2), createInt(16)), loop_indices.at(3));
+      auto non_divisible_domain_stop_idx = addExpr(
+          mulExpr(loop_indices.at(2), createInt(16)), loop_indices.at(3));
+
+      auto merge_out_start_idx = addExpr(
+          mulExpr(loop_indices.at(0), createInt(100)),
+          non_divisible_domain_start_idx);
+
+      auto merge_out_stop_idx = addExpr(
+          mulExpr(loop_indices.at(0), createInt(100)),
+          non_divisible_domain_stop_idx);
+
+      auto logical_id0_start_idx =
+          divExpr(merge_out_start_idx, ref_logical_id1->extent());
+      auto logical_id0_stop_idx =
+          divExpr(merge_out_stop_idx, ref_logical_id1->extent());
+
+      auto logical_id1_start_idx =
+          modExpr(merge_out_start_idx, ref_logical_id1->extent());
+      auto logical_id1_stop_idx =
+          modExpr(merge_out_stop_idx, ref_logical_id1->extent());
+
+      // Since tv2 is first visited, the unswitch predicate should
+      // look like:
+      //
+      // i0_idx >= 0 // generated for tv2
+      // i0_idx < i0 // generated for tv2
+      // threadIdx.y * 16 + threadIdx.x < 100 // generated for tv2
+      // i1_idx >= 0 // generated for tv3
+      // i1_idx < i1 // generated for tv3
+      //
+      // Note that the unswitch predicate comes before the predicates
+      // for i1.
+
+      // i0_idx >= 0
+      Val* pred = geExpr(logical_id0_start_idx, zero);
+
+      // i0_idx < i0
+      pred = andExpr(
+          pred, ltExpr(logical_id0_stop_idx, ref_logical_id0->extent()));
+
+      // threadIdx.y * 16 + threadIdx.x < 100
+      pred = andExpr(
+          pred,
+          ltExpr(
+              non_divisible_domain_stop_idx,
+              non_divisible_split_to_predicate->in()->extent()));
+
+      // TODO: Consolidating unswitch predicates isn't
+      // working. Currently duplicate predicates are generated.
+      // i0_idx >= 0
+      pred = andExpr(pred, geExpr(logical_id0_start_idx, zero));
+      // i0_idx < i0
+      pred = andExpr(
+          pred, ltExpr(logical_id0_stop_idx, ref_logical_id0->extent()));
+
+      // i1_idx >= 0
+      pred = andExpr(pred, geExpr(logical_id1_start_idx, zero));
+      // i1_idx < i1
+      pred = andExpr(
+          pred, ltExpr(logical_id1_stop_idx, ref_logical_id1->extent()));
+
+      // TODO: Another duplication
+      pred = andExpr(
+          pred,
+          ltExpr(
+              non_divisible_domain_stop_idx,
+              non_divisible_split_to_predicate->in()->extent()));
+
+      return pred;
+    }
+  };
+
+  PredicateIndexValidator<GetReference>::validate(&fusion);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({5}, options);
+  at::Tensor t1 = at::randn({5, 100}, options);
+  std::vector<c10::IValue> aten_inputs = {t0, t1};
+
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
+  FusionExecutor fe;
+  fe.compileFusion(&fusion, aten_inputs);
+  auto outputs = fe.runFusion(aten_inputs);
+
+  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
This is a bug fix for #2691, which isn't sufficient when broadcast tensors are involved.