### PR TITLE
[Host Irs] minor fix in printing

### DIFF
--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -170,7 +170,8 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(Wait)
 
 std::string Wait::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << "Wait Communication " << communication()->name();
+  indent(ss, indent_size) << "Wait Communication " << communication()->name()
+                          << "\n";
   return ss.str();
 }
 

--- a/csrc/ir/iostream.cpp
+++ b/csrc/ir/iostream.cpp
@@ -111,7 +111,7 @@ void IrPrinter::handle(const hir::HostIrContainer* host_ir_container) {
     os() << std::endl;
     os() << host_unit->toString(indent_size_);
   }
-  os() << "\n} // %HostIrContainer\n\n";
+  os() << "} // %HostIrContainer\n\n";
 }
 
 void IrPrinter::handle(hir::HostIrContainer& host_ir_container) {

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -219,7 +219,7 @@ std::string Communication::toString(const int indent_size) const {
     ss << "root=" << root() << ", ";
   }
   ss << (inputs().empty() ? "" : "Input=" + in()->toString()) << ", "
-     << (outputs().empty() ? "" : "Output=" + out()->toString()) << ")";
+     << (outputs().empty() ? "" : "Output=" + out()->toString()) << ")\n";
   return ss.str();
 }
 


### PR DESCRIPTION
This PR does some minor changes in how we print the host IRs, by removing or adding a couple of trailing new line.

This PR makes two changes:
- add a trailing new line for `Wait::toString` and `Communication::toString`
- remove a trailing new line in `IrPrinter::handle(const hir::HostIrContainer*)` which is simply unnecessary and adds an undesired extra blank line in the prints.

This fixes some printing. For example, before this patch, running `OverlapTest.ReduceScatterBasedPipeliningHostIrImplementation` with `NVFUSER_DUMP=host_ir` would give

```
%HostIrContainer { (T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ], T1_g[ iS3{i4}, iS4{i5} ], T2_g[ iS5{i6}, iS6{i7}, iS7{i8} ]) -> (T5_g[ iS12{i2}, iS13{i5}, rS14{i3} ] (DeviceMesh{0 1 2 3 4 5 6 7})) :
  FOR i9 in iS0{i0}:
    T3_l[ iS8{i2}, iS9{i3} ]
       = select( T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ], axis = iS0{i0}, index = i9 )
    T4_l[ iS10{i7}, iS11{i8} ] (DeviceMesh{0 1 2 3 4 5 6 7})
       = select( T2_g[ iS5{i6}, iS6{i7}, iS7{i8} ], axis = iS5{i6}, index = i9 )
    T5_g[ iS12{i2}, iS13{i5}, rS14{i3} ] (DeviceMesh{0 1 2 3 4 5 6 7})
       = matmul(T3_l[ iS8{i2}, iS9{i3} ],
                T1_g[ iS3{i4}, iS4{i5} ])
    Communication 4 (type=ReduceScatter, team=(0 1 2 3 4 5 6 7), Input=T5_g[ iS12{i2}, iS13{i5}, rS14{i3} ] (DeviceMesh{0 1 2 3 4 5 6 7}), Output=T4_l[ iS10{i7}, iS11{i8} ] (DeviceMesh{0 1 2 3 4 5 6 7}))    Wait Communication 4

} // %HostIrContainer
```
, after this patch, we get
```
%HostIrContainer { (T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ], T1_g[ iS3{i4}, iS4{i5} ], T2_g[ iS5{i6}, iS6{i7}, iS7{i8} ]) -> (T5_g[ iS12{i2}, iS13{i5}, rS14{i3} ] (DeviceMesh{0 1 2 3 4 5 6 7})) :
  FOR i9 in iS0{i0}:
    T3_l[ iS8{i2}, iS9{i3} ]
       = select( T0_g[ iS0{i0}, iS1{i2}, iS2{i3} ], axis = iS0{i0}, index = i9 )
    T4_l[ iS10{i7}, iS11{i8} ] (DeviceMesh{0 1 2 3 4 5 6 7})
       = select( T2_g[ iS5{i6}, iS6{i7}, iS7{i8} ], axis = iS5{i6}, index = i9 )
    T5_g[ iS12{i2}, iS13{i5}, rS14{i3} ] (DeviceMesh{0 1 2 3 4 5 6 7})
       = matmul(T3_l[ iS8{i2}, iS9{i3} ],
                T1_g[ iS3{i4}, iS4{i5} ])
    Communication 4 (type=ReduceScatter, team=(0 1 2 3 4 5 6 7), Input=T5_g[ iS12{i2}, iS13{i5}, rS14{i3} ] (DeviceMesh{0 1 2 3 4 5 6 7}), Output=T4_l[ iS10{i7}, iS11{i8} ] (DeviceMesh{0 1 2 3 4 5 6 7}))
    Wait Communication 4

} // %HostIrContainer
```

Also, it seems that this patch matches with a common pattern I saw in the codebase:
- `Val::toString` don't have a trailing new line
- `Expr::toString` have a trailing new line