### PR TITLE
dynamo reset

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -136,6 +136,16 @@ def clear_l2_cache() -> None:
     y = torch.clone(x)
 
 
+def clear_dynamo_cache() -> None:
+    """
+    Utility function to enforce re-compilation to avoid different results between
+    running a serials of tests and a standalone test due to kernel re-use.
+    It slows down the test but ensures the correctness of the benchmark results.
+    Ref: https://github.com/pytorch/pytorch/issues/107444
+    """
+    torch._dynamo.reset()
+
+
 def clear_cuda_cache() -> None:
     """
     Utility function to clear CUDA cache before running a test.

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -119,7 +119,7 @@ def test_layernorm_fwd_baseline_benchmark(
 ):
     clear_cuda_cache()
     if compile:
-      clear_dynamo_cache()
+        clear_dynamo_cache()
     batch_size, hidden_size = size
     inputs = [
         torch.randn(size, device="cuda", dtype=dtype),

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -4,7 +4,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache
+from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
@@ -118,6 +118,8 @@ def test_layernorm_fwd_baseline_benchmark(
     compile: bool,
 ):
     clear_cuda_cache()
+    if compile:
+      clear_dynamo_cache()
     batch_size, hidden_size = size
     inputs = [
         torch.randn(size, device="cuda", dtype=dtype),


### PR DESCRIPTION
Add
```
def clear_dynamo_cache() -> None:
    """
    Utility function to enforce re-compilation to avoid different results between
    running a serials of tests and a standalone test due to kernel re-use.
    It slows down the test but ensures the correctness of the benchmark results.
    Ref: https://github.com/pytorch/pytorch/issues/107444
    """
    torch._dynamo.reset()
```
Performance data of torch.compile looks more reasonable, the max speedup of nvFuser to torch.compile is 2.0x instead of 25.0x
see  [dashboard](http://nv/egW)

TODO:
(1) add to other tests
(2) check weekly CI time change