### PR TITLE
Mark SDPA variables as cpu scalars within API

### DIFF
--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -490,10 +490,14 @@ SdpfaFwdResult sdpfa_fwd(
 
   TensorView* query_seq_len = TensorViewBuilder().dtype(DataType::Int).build();
   TensorView* key_seq_len = TensorViewBuilder().dtype(DataType::Int).build();
+  query_seq_len->setCpuScalar(true);
+  key_seq_len->setCpuScalar(true);
 
   // Scalar tensors of int64_t dtype.
   TensorView* philox_seed = TensorViewBuilder().dtype(DataType::Int).build();
   TensorView* philox_offset = TensorViewBuilder().dtype(DataType::Int).build();
+  philox_seed->setCpuScalar(true);
+  philox_offset->setCpuScalar(true);
 
   // Thunder metadata represents debug_attn_mask of type int64_t, although the
   // debug_attn_mask is of query.dtype. Since we use return_debug_mask=false in
@@ -579,6 +583,12 @@ SdpfaBwdResult sdpfa_bwd(
       "Expected is_causal to be a scalar boolean.");
   NVF_CHECK(
       !scale || scale->isScalar(), "Expected scale to be a scalar double.");
+
+  // Mark CPU scalar tensors.
+  query_seq_len->setCpuScalar(true);
+  key_seq_len->setCpuScalar(true);
+  philox_seed->setCpuScalar(true);
+  philox_offset->setCpuScalar(true);
 
   // Query: [N,H,L,E], Key: [N,H,S,E], Value: [N,H,S,Ev] Output: [N,H,L,Ev]
   TensorView* grad_query = ops::newOutputTV({query}, query->dtype());

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -432,13 +432,9 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
   auto tv_output = makeConcreteTensor(attn_shape, DataType::Half);
   auto tv_logsumexp = makeConcreteTensor({n, h, l}, DataType::Float);
   auto tv_maxq = makeConcreteTensor({}, DataType::Int);
-  tv_maxq->setCpuScalar(true);
   auto tv_maxk = makeConcreteTensor({}, DataType::Int);
-  tv_maxk->setCpuScalar(true);
   auto tv_seed = makeConcreteTensor({}, DataType::Int);
-  tv_seed->setCpuScalar(true);
   auto tv_offset = makeConcreteTensor({}, DataType::Int);
-  tv_offset->setCpuScalar(true);
 
   fusion->addInput(tv_grad_output);
   fusion->addInput(tvq);
@@ -562,13 +558,9 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
   auto tv_output = makeSymbolicTensor(attn_shape, DataType::Half);
   auto tv_logsumexp = makeSymbolicTensor({n, h, l}, DataType::Float);
   auto tv_maxq = makeSymbolicTensor({}, DataType::Int);
-  tv_maxq->setCpuScalar(true);
   auto tv_maxk = makeSymbolicTensor({}, DataType::Int);
-  tv_maxk->setCpuScalar(true);
   auto tv_seed = makeSymbolicTensor({}, DataType::Int);
-  tv_seed->setCpuScalar(true);
   auto tv_offset = makeSymbolicTensor({}, DataType::Int);
-  tv_offset->setCpuScalar(true);
 
   fusion->addInput(tv_grad_output);
   fusion->addInput(tvq);
@@ -726,12 +718,6 @@ TEST_F(SDPATest, AttnFwdBwd) {
       /*dropout_p=*/IrBuilder::create<Val>(0.0),
       /*is_causal=*/IrBuilder::create<Val>(false),
       /*scale=*/nullptr);
-
-  // Set query_seq_len, key_seq_len as CPU scalars
-  sdpa_fwd_out.query_seq_len->setCpuScalar(true);
-  sdpa_fwd_out.key_seq_len->setCpuScalar(true);
-  sdpa_fwd_out.philox_seed->setCpuScalar(true);
-  sdpa_fwd_out.philox_offset->setCpuScalar(true);
 
   auto tv_grad_output = makeConcreteTensor(attn_shape, DataType::Half);
   fusion->addInput(tv_grad_output);


### PR DESCRIPTION
This PR marks the outputs as CPU scalars within the API so it doesn't need to be done in tests and avoids any errors stemming from tensorviews not setting this attribute.

