### PR TITLE
Handle placeholders in AbstractTensor

### DIFF
--- a/csrc/abstract_tensor.cpp
+++ b/csrc/abstract_tensor.cpp
@@ -22,7 +22,9 @@ struct DispatchSplit {
       Val* factor,
       bool inner_split) const {
     using IN = std::decay_t<INPUT>;
-    if constexpr (std::is_same_v<IN, IterDomain*>) {
+    if constexpr (std::is_same_v<IN, std::monostate>) {
+      return {std::monostate{}, std::monostate{}};
+    } else if constexpr (std::is_same_v<IN, IterDomain*>) {
       return IterDomain::split(std::forward<INPUT>(in), factor, inner_split);
     } else if constexpr (std::is_same_v<IN, ValGroupAndItsGraph>) {
       auto graph = in.graph;
@@ -71,6 +73,10 @@ struct DispatchMerge {
     using L = std::decay_t<LHS>;
     using R = std::decay_t<RHS>;
     if constexpr (
+        std::is_same_v<L, std::monostate> &&
+        std::is_same_v<R, std::monostate>) {
+      return std::monostate{};
+    } else if constexpr (
         std::is_same_v<L, IterDomain*> && std::is_same_v<R, IterDomain*>) {
       return IterDomain::merge(std::forward<LHS>(lhs), std::forward<RHS>(rhs));
     } else if constexpr (
@@ -197,6 +203,10 @@ struct DispatchSwizzle {
     using L = std::decay_t<LHS>;
     using R = std::decay_t<RHS>;
     if constexpr (
+        std::is_same_v<L, std::monostate> &&
+        std::is_same_v<R, std::monostate>) {
+      return {std::monostate{}, std::monostate{}};
+    } else if constexpr (
         std::is_same_v<L, IterDomain*> && std::is_same_v<R, IterDomain*>) {
       auto [out_x, out_y] = IterDomain::swizzle(
           swizzle_type, std::forward<LHS>(lhs), std::forward<RHS>(rhs));
@@ -284,6 +294,10 @@ struct DispatchLegacySwizzle {
     using L = std::decay_t<LHS>;
     using R = std::decay_t<RHS>;
     if constexpr (
+        std::is_same_v<L, std::monostate> &&
+        std::is_same_v<R, std::monostate>) {
+      return {std::monostate{}, std::monostate{}};
+    } else if constexpr (
         std::is_same_v<L, IterDomain*> && std::is_same_v<R, IterDomain*>) {
       auto [out_x, out_y] = IterDomain::swizzle(
           swizzle_type, std::forward<LHS>(lhs), std::forward<RHS>(rhs));

--- a/csrc/abstract_tensor.h
+++ b/csrc/abstract_tensor.h
@@ -228,8 +228,8 @@ struct AbstractTensor {
     domain.push_back(std::move(id));
     return *this;
   }
-  
-  template<typename... Args>
+
+  template <typename... Args>
   AbstractTensor& emplaceBack(Args&&... args) {
     domain.emplace_back(std::forward<Args>(args)...);
     return *this;

--- a/csrc/abstract_tensor.h
+++ b/csrc/abstract_tensor.h
@@ -119,14 +119,23 @@ using AbstractId = dynamic_type::DynamicType<
 // Example 8:
 //   IterDomain *id0, *id1, *id2, *id3;
 //   AbstractTensor v({{id0, id1}, {id2, id3}});
-//   auto ub = v.unzip();
-// Then ub will be {AbstractTensor{id0, id2}, AbstractTensor{id1, id3}}
+//   auto uz = v.unzip();
+// Then uz will be {AbstractTensor{id0, id2}, AbstractTensor{id1, id3}}
 //
 // Example 9:
 //   IterDomain *id0, *id1, *id2;
 //   AbstractTensor v({{id0, id1}, id2});
-//   auto ub = v.unzip();
-// Then ub will be {AbstractTensor{id0, id2}, AbstractTensor{id1, id2}}
+//   auto uz = v.unzip();
+// Then uz will be {AbstractTensor{id0, id2}, AbstractTensor{id1, id2}}
+//
+// AbstractId in AbstractTensor can be place holders std::monostate{}. For
+// example:
+//
+// Example 10:
+//   AbstractTensor v({{}, {}}); // [null, null]
+//   v.split(0, 2); // [null, null, null]
+//   v.merge(0); // [null, null]
+//   v.swizzle(SwizzleType::XOR, 0, 1); // [null, null]
 
 struct AbstractTensor {
   std::vector<AbstractId> domain;
@@ -159,6 +168,54 @@ struct AbstractTensor {
 
   decltype(auto) size() const {
     return domain.size();
+  }
+
+  decltype(auto) begin() {
+    return domain.begin();
+  }
+
+  decltype(auto) begin() const {
+    return domain.begin();
+  }
+
+  decltype(auto) end() {
+    return domain.end();
+  }
+
+  decltype(auto) end() const {
+    return domain.end();
+  }
+
+  decltype(auto) rbegin() {
+    return domain.rbegin();
+  }
+
+  decltype(auto) rbegin() const {
+    return domain.rbegin();
+  }
+
+  decltype(auto) rend() {
+    return domain.rend();
+  }
+
+  decltype(auto) rend() const {
+    return domain.rend();
+  }
+
+  decltype(auto) cbegin() const {
+    return domain.cbegin();
+  }
+
+  decltype(auto) cend() const {
+    return domain.cend();
+  }
+
+  decltype(auto) crbegin() const {
+    return domain.crbegin();
+  }
+
+  decltype(auto) crend() const {
+    return domain.crend();
   }
 
   template <typename T>

--- a/csrc/abstract_tensor.h
+++ b/csrc/abstract_tensor.h
@@ -132,10 +132,12 @@ using AbstractId = dynamic_type::DynamicType<
 // example:
 //
 // Example 10:
-//   AbstractTensor v({{}, {}}); // [null, null]
-//   v.split(0, 2); // [null, null, null]
-//   v.merge(0); // [null, null]
-//   v.swizzle(SwizzleType::XOR, 0, 1); // [null, null]
+//   IterDomain *id0;
+//   AbstractTensor v({{}, {}, id0}); // [null, null, id0]
+//   v.split(0, 2); // [null, null, null, id0]
+//   v.merge(0); // [null, null, id0]
+//   v.swizzle(SwizzleType::XOR, 0, 1); // [null, null, id0]
+//   auto vv = v.strip(); // [id0]
 
 struct AbstractTensor {
   std::vector<AbstractId> domain;
@@ -168,6 +170,10 @@ struct AbstractTensor {
 
   decltype(auto) size() const {
     return domain.size();
+  }
+
+  decltype(auto) empty() const {
+    return domain.empty();
   }
 
   decltype(auto) begin() {
@@ -218,6 +224,17 @@ struct AbstractTensor {
     return domain.crend();
   }
 
+  AbstractTensor& pushBack(AbstractId id) {
+    domain.push_back(std::move(id));
+    return *this;
+  }
+  
+  template<typename... Args>
+  AbstractTensor& emplaceBack(Args&&... args) {
+    domain.emplace_back(std::forward<Args>(args)...);
+    return *this;
+  }
+
   template <typename T>
   bool operator==(T&& t) const {
     if constexpr (std::is_same_v<AbstractTensor, std::decay_t<T>>) {
@@ -232,38 +249,41 @@ struct AbstractTensor {
     return !operator==(std::forward<T>(t));
   }
 
-  void split(int64_t axis, Val* factor, bool inner_split = true);
-  void split(int64_t axis, int64_t factor, bool inner_split = true);
+  AbstractTensor& split(int64_t axis, Val* factor, bool inner_split = true);
+  AbstractTensor& split(int64_t axis, int64_t factor, bool inner_split = true);
 
-  void merge(int64_t axis_o, int64_t axis_i);
-  void merge(int64_t axis) {
-    merge(axis, axis + 1);
+  AbstractTensor& merge(int64_t axis_o, int64_t axis_i);
+  AbstractTensor& merge(int64_t axis) {
+    return merge(axis, axis + 1);
   }
 
-  void reorder(const std::unordered_map<int64_t, int64_t>& old2new);
-  void reorder(
+  AbstractTensor& reorder(const std::unordered_map<int64_t, int64_t>& old2new);
+  AbstractTensor& reorder(
       const std::initializer_list<std::pair<const int64_t, int64_t>>& old2new) {
     return reorder(std::unordered_map<int64_t, int64_t>(old2new));
   }
   // old2new[index] = permutation[index]
-  void reorder(const std::vector<int64_t>& permutation);
-  void reorder(const std::initializer_list<int64_t>& permutation) {
-    reorder(std::vector<int64_t>(permutation));
+  AbstractTensor& reorder(const std::vector<int64_t>& permutation);
+  AbstractTensor& reorder(const std::initializer_list<int64_t>& permutation) {
+    return reorder(std::vector<int64_t>(permutation));
   }
 
   // Both `from` and `to` are inclusive.
-  void flatten(int64_t from = 0, int64_t to = -1);
+  AbstractTensor& flatten(int64_t from = 0, int64_t to = -1);
 
-  void swizzle(SwizzleType swizzle_type, int64_t x, int64_t y);
+  AbstractTensor& swizzle(SwizzleType swizzle_type, int64_t x, int64_t y);
 
   // Temporary helper for legacy swizzle, should be removed eventually.
   // This is a copy-paste of AbstractTensor::swizzle(SwizzleType
-  void swizzle(Swizzle2DType swizzle_type, int64_t x, int64_t y);
+  AbstractTensor& swizzle(Swizzle2DType swizzle_type, int64_t x, int64_t y);
 
   // Unzip the AbstractTensor to separate tensors. For example, if this
   // AbstractTensor is [dim0={id0, id1}, dim1={id2, id3}], then the return value
   // will be {AbstractTensor{id0, id2}, AbstractTensor{id1, id3}}.
   std::vector<AbstractTensor> unzip() const;
+
+  // Remove all the null elements.
+  AbstractTensor& strip();
 };
 
 } // namespace nvfuser

--- a/tests/cpp/test_abstract_tensor.cpp
+++ b/tests/cpp/test_abstract_tensor.cpp
@@ -736,6 +736,9 @@ TEST_F(AbstractTensorTest, PlaceHolder) {
   for (auto i : v) {
     EXPECT_FALSE(i.hasValue());
   }
+
+  v.strip();
+  EXPECT_TRUE(v.empty());
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_abstract_tensor.cpp
+++ b/tests/cpp/test_abstract_tensor.cpp
@@ -691,12 +691,12 @@ TEST_F(AbstractTensorTest, Unzip) {
   auto id2 = newID();
   auto id3 = newID();
   const AbstractTensor v({{id0, id1}, {id2, id3}});
-  auto ub = v.unzip();
-  ASSERT_EQ(ub.size(), 2);
+  auto uz = v.unzip();
+  ASSERT_EQ(uz.size(), 2);
   AbstractTensor expect0{id0, id2};
   AbstractTensor expect1{id1, id3};
-  EXPECT_EQ(ub[0], expect0);
-  EXPECT_EQ(ub[1], expect1);
+  EXPECT_EQ(uz[0], expect0);
+  EXPECT_EQ(uz[1], expect1);
 }
 
 TEST_F(AbstractTensorTest, UnzipBroadcasting) {
@@ -704,12 +704,38 @@ TEST_F(AbstractTensorTest, UnzipBroadcasting) {
   auto id1 = newID();
   auto id2 = newID();
   const AbstractTensor v({id0, {id1, id2}});
-  auto ub = v.unzip();
-  ASSERT_EQ(ub.size(), 2);
+  auto uz = v.unzip();
+  ASSERT_EQ(uz.size(), 2);
   AbstractTensor expect0{id0, id1};
   AbstractTensor expect1{id0, id2};
-  EXPECT_EQ(ub[0], expect0);
-  EXPECT_EQ(ub[1], expect1);
+  EXPECT_EQ(uz[0], expect0);
+  EXPECT_EQ(uz[1], expect1);
+}
+
+TEST_F(AbstractTensorTest, PlaceHolder) {
+  AbstractTensor v({{}, {}});
+  EXPECT_EQ(v.size(), 2);
+  for (auto i : v) {
+    EXPECT_FALSE(i.hasValue());
+  }
+
+  v.split(0, 2);
+  EXPECT_EQ(v.size(), 3);
+  for (auto i : v) {
+    EXPECT_FALSE(i.hasValue());
+  }
+
+  v.merge(0);
+  EXPECT_EQ(v.size(), 2);
+  for (auto i : v) {
+    EXPECT_FALSE(i.hasValue());
+  }
+
+  v.swizzle(SwizzleType::XOR, 0, 1);
+  EXPECT_EQ(v.size(), 2);
+  for (auto i : v) {
+    EXPECT_FALSE(i.hasValue());
+  }
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_swizzle.cpp
+++ b/tests/cpp/test_swizzle.cpp
@@ -731,9 +731,9 @@ TEST_F(SwizzleTest, Transpose1) {
   }
   // BIDx, 4, TIDx
 
-  auto ub = loop.unzip();
-  tv1->setLoopDomain(ub[0].as<IterDomain*>());
-  tv2->setLoopDomain(ub[1].as<IterDomain*>());
+  auto uz = loop.unzip();
+  tv1->setLoopDomain(uz[0].as<IterDomain*>());
+  tv2->setLoopDomain(uz[1].as<IterDomain*>());
 
   inlineMost();
 


### PR DESCRIPTION
```C++
// AbstractId in AbstractTensor can be place holders std::monostate{}. For
// example:
//
// Example 10:
//   AbstractTensor v({{}, {}}); // [null, null]
//   v.split(0, 2); // [null, null, null]
//   v.merge(0); // [null, null]
//   v.swizzle(SwizzleType::XOR, 0, 1); // [null, null]
```