### PR TITLE
Split getReproErrorString in two

### DIFF
--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -64,14 +64,10 @@ class FusionDefinition(_C._FusionDefinition):
             logger.exception(self.getReproErrorString("defining"))
             raise
 
-    def getReproErrorString(self, section: str, inputs: list | None = None):
+    def getReproString(self, inputs: list | None = None) -> str:
         msg = (
-            f"An error occurred while {section} nvFuser FusionDefinition {self.id()}.\n"
-            "If you believe this is a bug or need assistance, please file an issue at "
-            "https://github.com/NVIDIA/Fuser/issues/new\n"
-            f"Here's a script to reproduce the error:\n"
-            "```python\n"
-            "# CUDA devices:\n"
+        "```python\n"
+        "# CUDA devices:\n"
         )
         for i in range(torch.cuda.device_count()):
             msg += f"#  {0}: {torch.cuda.get_device_name(i)}\n"
@@ -123,6 +119,16 @@ class FusionDefinition(_C._FusionDefinition):
             msg += "]"
             msg += "\nfd.execute(inputs)\n"
         msg += "```\n"
+        return msg
+    
+    def getReproErrorString(self, section: str, inputs: list | None = None):
+        msg = (
+            f"An error occurred while {section} nvFuser FusionDefinition {self.id()}.\n"
+            "If you believe this is a bug or need assistance, please file an issue at "
+            "https://github.com/NVIDIA/Fuser/issues/new\n"
+            f"Here's a script to reproduce the error:\n"
+            )
+        msg += self.getReproString(inputs)
         return msg
 
     def definition(self):

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -65,10 +65,7 @@ class FusionDefinition(_C._FusionDefinition):
             raise
 
     def getReproString(self, inputs: list | None = None) -> str:
-        msg = (
-        "```python\n"
-        "# CUDA devices:\n"
-        )
+        msg = "# CUDA devices:\n"
         for i in range(torch.cuda.device_count()):
             msg += f"#  {0}: {torch.cuda.get_device_name(i)}\n"
         msg += (
@@ -120,7 +117,7 @@ class FusionDefinition(_C._FusionDefinition):
             msg += "\nfd.execute(inputs)\n"
 
         return msg
-    
+
     def getReproErrorString(self, section: str, inputs: list | None = None):
         msg = (
             f"An error occurred while {section} nvFuser FusionDefinition {self.id()}.\n"
@@ -128,7 +125,7 @@ class FusionDefinition(_C._FusionDefinition):
             "https://github.com/NVIDIA/Fuser/issues/new\n"
             f"Here's a script to reproduce the error:\n"
             "```python\n"
-            )
+        )
         msg += self.getReproString(inputs)
         msg += "```\n"
         return msg

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -118,7 +118,7 @@ class FusionDefinition(_C._FusionDefinition):
                     msg += f"    {input_as_string},\n"
             msg += "]"
             msg += "\nfd.execute(inputs)\n"
-        msg += "```\n"
+
         return msg
     
     def getReproErrorString(self, section: str, inputs: list | None = None):
@@ -127,8 +127,10 @@ class FusionDefinition(_C._FusionDefinition):
             "If you believe this is a bug or need assistance, please file an issue at "
             "https://github.com/NVIDIA/Fuser/issues/new\n"
             f"Here's a script to reproduce the error:\n"
+            "```python\n"
             )
         msg += self.getReproString(inputs)
+        msg += "```\n"
         return msg
 
     def definition(self):


### PR DESCRIPTION
By splitting this helper function devs can get the repro by using `getReproString`.  