### PR TITLE
newValLike tries to propagate sharding. 

### DIFF
--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -48,6 +48,10 @@ class DeviceMesh final {
     return static_cast<int64_t>(vector_.size());
   }
 
+  bool empty() const {
+    return vector_.empty();
+  }
+
   // Returns a vector containing the device indices of the mesh
   const std::vector<DeviceIdxType>& vector() const {
     return vector_;

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -48,10 +48,6 @@ class DeviceMesh final {
     return static_cast<int64_t>(vector_.size());
   }
 
-  bool empty() const {
-    return vector_.empty();
-  }
-
   // Returns a vector containing the device indices of the mesh
   const std::vector<DeviceIdxType>& vector() const {
     return vector_;

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -415,20 +415,13 @@ TensorView* newOutputTV(const std::vector<Val*>& vals, DataType dtype) {
       dtype);
 
   DeviceMesh new_mesh;
+  // Find the first input that has a mesh. This seems arbitrary, but is at this
+  // moment safest because it's consistent with PropagateShardingsPass.
   for (auto* tv : ir_utils::filterByType<TensorView>(vals)) {
     const DeviceMesh& mesh = tv->getDeviceMesh();
-    if (mesh.empty()) {
-      continue;
-    }
-    if (new_mesh.empty()) {
+    if (!mesh.empty()) {
       new_mesh = mesh;
-    } else {
-      NVF_ERROR(
-          new_mesh == mesh,
-          "Inconsistent device mesh among inputs: ",
-          new_mesh,
-          " vs ",
-          mesh);
+      break;
     }
   }
   new_out->setDeviceMesh(new_mesh);

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -418,9 +418,8 @@ TensorView* newOutputTV(const std::vector<Val*>& vals, DataType dtype) {
   // Find the first input that has a mesh. This seems arbitrary, but is at this
   // moment safest because it's consistent with PropagateShardingsPass.
   for (auto* tv : ir_utils::filterByType<TensorView>(vals)) {
-    const DeviceMesh& mesh = tv->getDeviceMesh();
-    if (!mesh.empty()) {
-      new_mesh = mesh;
+    if (tv->hasDeviceMesh()) {
+      new_mesh = tv->getDeviceMesh();
       break;
     }
   }

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -316,6 +316,11 @@ IterDomain* newOutputIterDomain(
       continue;
     }
 
+    NVF_ERROR(
+        id->getParallelType() == ParallelType::Serial ||
+            isParallelTypeDeviceDim(id->getParallelType()),
+        id->getParallelType(),
+        " is not expected when building ops.");
     parallel_type = promoteParallelType(parallel_type, id->getParallelType());
 
     if (extent_is_from_symbolic && !id->isSymbolic()) {

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -5,12 +5,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <ir/builder.h>
-#include <ops/arith.h>
-#include <ops/utils.h>
-
 #include <algorithm>
 #include <limits>
+
+#include <ir/builder.h>
+#include <ir/utils.h>
+#include <ops/arith.h>
+#include <ops/utils.h>
 
 namespace nvfuser {
 namespace ops {
@@ -263,6 +264,22 @@ std::vector<IterDomain*> mapLinearOpIterDomains(
   return mapping;
 }
 
+namespace {
+ParallelType promoteParallelType(ParallelType a, ParallelType b) {
+  if (a == b) {
+    return a;
+  }
+  NVF_ERROR(
+      a == ParallelType::Serial || b == ParallelType::Serial,
+      "Doesn't know how to resolve ",
+      a,
+      " and ",
+      b,
+      " at this moment.");
+  return a == ParallelType::Serial ? b : a;
+}
+} // namespace
+
 // Adding these pragmas since gcc-12.2.1
 // incorrectly reports a warning with the use of evaluate
 #if defined(__GNUC__) && !defined(__clang__)
@@ -282,19 +299,15 @@ IterDomain* newOutputIterDomain(
   Val* extent_val = nullptr;
   bool extent_is_from_symbolic = true;
   Val* expanded_extent_val = nullptr;
+  auto parallel_type = ParallelType::Serial;
   std::optional<IterType> iter_type = std::nullopt;
 
-  std::vector<IterDomain*> ids;
-  ids.reserve(input_ids.size());
+  for (auto id : input_ids) {
+    // Filter out any nullptrs
+    if (id == nullptr) {
+      continue;
+    }
 
-  // Filter out any nullptrs
-  std::copy_if(
-      input_ids.begin(),
-      input_ids.end(),
-      std::back_inserter(ids),
-      [](IterDomain* id) { return id != nullptr; });
-
-  for (auto id : ids) {
     if (id->isBroadcast()) {
       if (id->hasExpandedExtent()) {
         expanded_extent_val =
@@ -302,6 +315,9 @@ IterDomain* newOutputIterDomain(
       }
       continue;
     }
+
+    parallel_type = promoteParallelType(parallel_type, id->getParallelType());
+
     if (extent_is_from_symbolic && !id->isSymbolic()) {
       // We prefer to use extents from non-Symbolic inputs if there are any
       // because they might indicate a broadcast axis that is resolved in this
@@ -347,6 +363,7 @@ IterDomain* newOutputIterDomain(
         IterDomainBuilder(
             IrBuilder::create<Val>(start_offset, DataType::Index), extent_val)
             .stop_offset(IrBuilder::create<Val>(stop_offset, DataType::Index))
+            .parallel_type(parallel_type)
             .iter_type(iter_type.value())
             .build();
   } else {
@@ -354,6 +371,7 @@ IterDomain* newOutputIterDomain(
                      FusionGuard::getCurFusion()->zeroVal(),
                      FusionGuard::getCurFusion()->oneVal())
                      .expanded_extent(expanded_extent_val)
+                     .parallel_type(parallel_type)
                      .iter_type(IterType::Broadcast)
                      .build();
   }
@@ -366,8 +384,8 @@ IterDomain* newOutputIterDomain(
 std::vector<IterDomain*> newOutputDomain(const std::vector<Val*>& vals) {
   std::vector<TensorView*> tvs;
   for (auto val : vals) {
-    if (val->getValType() == ValType::TensorView) {
-      tvs.push_back(val->as<TensorView>());
+    if (auto* tv = dynamic_cast<TensorView*>(val)) {
+      tvs.push_back(tv);
     }
   }
   NVF_CHECK(
@@ -380,7 +398,7 @@ std::vector<IterDomain*> newOutputDomain(const std::vector<Val*>& vals) {
   for (const auto dim_i : c10::irange(out_domain.size())) {
     std::vector<IterDomain*> input_ids;
     input_ids.reserve(tvs.size());
-    for (auto tv : tvs) {
+    for (auto* tv : tvs) {
       auto dom = TensorDomain::noReductions(tv->getLogicalDomain());
       input_ids.emplace_back(dom[dim_i]);
     }
@@ -391,10 +409,31 @@ std::vector<IterDomain*> newOutputDomain(const std::vector<Val*>& vals) {
 
 TensorView* newOutputTV(const std::vector<Val*>& vals, DataType dtype) {
   auto out_domain = newOutputDomain(vals);
-  return IrBuilder::create<TensorView>(
+  auto* new_out = IrBuilder::create<TensorView>(
       IrBuilder::create<TensorDomain>(
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       dtype);
+
+  DeviceMesh new_mesh;
+  for (auto* tv : ir_utils::filterByType<TensorView>(vals)) {
+    const DeviceMesh& mesh = tv->getDeviceMesh();
+    if (mesh.empty()) {
+      continue;
+    }
+    if (new_mesh.empty()) {
+      new_mesh = mesh;
+    } else {
+      NVF_ERROR(
+          new_mesh == mesh,
+          "Inconsistent device mesh among inputs: ",
+          new_mesh,
+          " vs ",
+          mesh);
+    }
+  }
+  new_out->setDeviceMesh(new_mesh);
+
+  return new_out;
 }
 
 std::vector<Val*> maybeBroadcast(const std::vector<Val*>& vals) {
@@ -424,9 +463,7 @@ Val* newValLike(Val* val, DataType dtype) {
   NVF_CHECK(
       dtype != DataType::Null, "Invalid datatype provided for new value.");
 
-  const ValType vtype = val->getValType().value();
-
-  if (vtype == ValType::TensorView) {
+  if (val->isA<TensorView>()) {
     return newOutputTV({val}, dtype);
   }
 

--- a/csrc/ops/utils.h
+++ b/csrc/ops/utils.h
@@ -84,8 +84,10 @@ IterDomain* newOutputIterDomain(
     const std::vector<IterDomain*>& ids,
     const std::optional<IterType> force_iter_type = std::nullopt);
 
-// Takes a vector of tensorviews and assumes they are all aligned to create the
-// output tensorview. For eg: BinaryOp.
+// Takes a vector of `Val*`s and assumes they are all aligned to create the
+// output tensorview, e.g., for BinaryOp. `vals` can contain scalars, e.g, when
+// creating the output TensorView for `tv0+scalar`. This is for convenience and
+// scalars will be ignored.
 std::vector<IterDomain*> newOutputDomain(const std::vector<Val*>& vals);
 
 TensorView* newOutputTV(const std::vector<Val*>& vals, DataType dtype);

--- a/tests/cpp/test_multidevice_matmul.cpp
+++ b/tests/cpp/test_multidevice_matmul.cpp
@@ -419,12 +419,8 @@ TEST_F(DistributedMatmulTest, PresegPreservesSharding) {
   auto w_tensor = at::randn({mesh.size(), 36, 48}, options);
   auto sharded_w_tensor = shardTensor(w_tensor, w);
 
-  hir::HostIrExecutorParams executor_params{
-      .use_fusion_executor_cache = true,
-      .skip_auto_scheduling = false,
-      .cache_fusion_executor = false};
   MultiDeviceExecutor runtime(
-      std::move(fusion), *communicator_, executor_params);
+      std::move(fusion), *communicator_, executor_params_);
   std::vector<c10::IValue> inputs({x_tensor, sharded_w_tensor});
   std::vector<at::Tensor> outputs = runtime.runWithInput(inputs);
 

--- a/tests/cpp/test_resharding.cpp
+++ b/tests/cpp/test_resharding.cpp
@@ -82,97 +82,98 @@ TEST_F(ReshardingTest, Detection) {
 
   TensorView* tv0 = makeContigTensor(3);
   fusion->addInput(tv0);
+  TensorView* tv1 = set(tv0);
+  TensorView* tv2 = set(tv1); // resharding
+  TensorView* tv3 = set(tv2);
+  TensorView* tv4 = set(tv3); // resharding
+  TensorView* tv5 = set(tv4); // resharding
+  TensorView* tv6 = set(tv5);
+  TensorView* tv7 = set(tv6); // resharding
+  TensorView* tv8 = sum(tv0, {0});
+  TensorView* tv9 = sum(tv0, {0}); // resharding, but seems invalid
+  TensorView* tv10 = sum(tv0, {0}); // resharding,
+  TensorView* tv11 = sum(tv0, {0}); // resharding,
+  TensorView* tv12 = sum(tv5, {0}); // not resharding
+  TensorView* tv13 = sum(tv5, {0}); // resharding
+  TensorView* tv14 = sum(tv5, {0}); // resharding
+  TensorView* tv15 = add(tv0, tv1);
+  TensorView* tv16 = add(tv0, tv1); // resharding
+  TensorView* tv17 = add(tv0, tv1); // resharding
+  TensorView* tv18 = add(tv5, tv6);
+  TensorView* tv19 = add(tv5, tv7); // resharding
+  TensorView* tv20 = add(tv5, tv7); // resharding
+  TensorView* tv21 = add(tv0, tv7); // resharding
+  TensorView* tv22 = sum(tv5, {1});
+  TensorView* tv23 = sum(tv5, {1}); // resharding
+  TensorView* tv24 = sum(tv7, {0});
+  TensorView* tv25 = sum(tv7, {0}); // not resharding but invalid
+  TensorView* tv26 = add(tv5, tv6); // resharding
+
   tv0->setDeviceMesh(mesh0);
 
-  TensorView* tv1 = set(tv0);
   tv1->setDeviceMesh(mesh0);
 
-  TensorView* tv2 = set(tv1); // resharding
   tv2->setDeviceMesh(mesh1);
 
-  TensorView* tv3 = set(tv2);
   tv3->setDeviceMesh(mesh1);
 
-  TensorView* tv4 = set(tv3); // resharding
   tv4->setDeviceMesh(mesh2);
 
-  TensorView* tv5 = set(tv4); // resharding
   tv5->setDeviceMesh(mesh2);
   tv5->axis(0)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv6 = set(tv5);
   tv6->setDeviceMesh(mesh2);
   tv6->axis(0)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv7 = set(tv6); // resharding
   tv7->setDeviceMesh(mesh2);
 
-  TensorView* tv8 = sum(tv0, {0});
   tv8->setDeviceMesh(mesh0);
 
-  TensorView* tv9 = sum(tv0, {0}); // resharding, but seems invalid
   tv9->setDeviceMesh(mesh0);
   tv9->axis(0)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv10 = sum(tv0, {0}); // resharding,
   tv10->setDeviceMesh(mesh0);
   tv10->axis(1)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv11 = sum(tv0, {0}); // resharding,
   tv11->setDeviceMesh(mesh1);
 
-  TensorView* tv12 = sum(tv5, {0}); // not resharding
   tv12->setDeviceMesh(mesh2);
   tv12->axis(0)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv13 = sum(tv5, {0}); // resharding
   tv13->setDeviceMesh(mesh2);
   tv13->axis(1)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv14 = sum(tv5, {0}); // resharding
   tv14->setDeviceMesh(mesh2);
   tv14->axis(0)->parallelize(ParallelType::DIDx);
   tv14->axis(1)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv15 = add(tv0, tv1);
   tv15->setDeviceMesh(mesh0);
 
-  TensorView* tv16 = add(tv0, tv1); // resharding
   tv16->setDeviceMesh(mesh1);
 
-  TensorView* tv17 = add(tv0, tv1); // resharding
   tv17->setDeviceMesh(mesh0);
   tv17->axis(0)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv18 = add(tv5, tv6);
   tv18->setDeviceMesh(mesh2);
   tv18->axis(0)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv19 = add(tv5, tv7); // resharding
   tv19->setDeviceMesh(mesh2);
   tv19->axis(0)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv20 = add(tv5, tv7); // resharding
   tv20->setDeviceMesh(mesh2);
 
-  TensorView* tv21 = add(tv0, tv7); // resharding
   tv21->setDeviceMesh(mesh2);
 
-  TensorView* tv22 = sum(tv5, {1});
   tv22->setDeviceMesh(mesh2);
   tv22->axis(0)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv23 = sum(tv5, {1}); // resharding
   tv23->setDeviceMesh(mesh2);
 
-  TensorView* tv24 = sum(tv7, {0});
   tv24->setDeviceMesh(mesh2);
 
-  TensorView* tv25 = sum(tv7, {0}); // not resharding but invalid
   tv25->setDeviceMesh(mesh2);
   tv22->axis(0)->parallelize(ParallelType::DIDx);
 
-  TensorView* tv26 = add(tv5, tv6); // resharding
   tv26->setDeviceMesh(mesh2);
 
   fusion->addOutput(tv1);


### PR DESCRIPTION
Fixes #2721. 

#2721 uncovers a deeper problem: the existing preseg passes are not aware of shardings, and therefore generate TensorViews that have no meshes or have wrong DIDs, breaking communication lowering. 

The current flow is:
1. The user annotates meshes and DIDs to some TensorViews. 
2. MultiDeviceExecutor runs PropagateShardingsPass to ensure all TensorViews have a mesh and propagate DIDs to more tensors than annotated. 
3. FusionExecutorCache runs the preseg passes. MarkAliasesPrepare is the one in question, but the problem can happen to any preseg pass. 

This PR implements one solution, although I'm all ears for alternatives. It extends `newValLike` so most `csrc/ops` APIs will attempt to propagate shardings from inputs to outputs. This minimizes the changes to the passes. However, the order of creating ops and setting meshes/paralleltypes will affect the semantics. For example, in
```cpp
TensorView* in = ...;
in->setDeviceMesh(...);
in->axis(...)->parallelize(DID);
TensorView* out = set(in);
``` 
`in` and `out` will have the same sharding. 

However, in
```cpp
TensorView* in = ...;
TensorView* out = set(in);
in->setDeviceMesh(...);
in->axis(...)->parallelize(DID);
```
`out` won't be sharded at all. 

The latter pattern is expected to be used in the Thunder integration -- build the ops before annotate shardings. The former pattern is expected to be used in internal transformation passes who intend to propagate the input sharding to the newly added op. 