### PR TITLE
Remove reduction axis when `K=1`

### DIFF
--- a/csrc/executor.cpp
+++ b/csrc/executor.cpp
@@ -1861,6 +1861,7 @@ std::vector<at::Tensor> FusionExecutor::evaluateFusionOutputs(
     for (const auto& out_val : fusion()->outputs()) {
       auto out_tensor =
           expr_eval.evaluate(out_val->as<TensorView>()).as<at::Tensor>();
+      expr_eval.bind(out_val, out_tensor);
       outputs.emplace_back(out_tensor);
     }
   }

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -213,7 +213,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     } else {
       NVF_ERROR(false, "Producer did not match any LinearOp input.")
     }
-    
+
     bool k_bcast = op->inA()->as<TensorView>()->axis(-1)->isBroadcast();
     // LinearOp:
     // inputs (0) = {*, in_features}
@@ -222,7 +222,8 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     // output = {*, out_features} / {*}
 
     const std::vector<IterDomain*>& aligned_producer_ids =
-        ops::mapLinearOpIterDomains(producer_logical, input_position, out_size, k_bcast);
+        ops::mapLinearOpIterDomains(
+            producer_logical, input_position, out_size, k_bcast);
     pairwiseMapAllIds(aligned_producer_ids, consumer_root);
     return dom_map;
   }

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -213,7 +213,8 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     } else {
       NVF_ERROR(false, "Producer did not match any LinearOp input.")
     }
-
+    
+    bool k_bcast = op->inA()->as<TensorView>()->axis(-1)->isBroadcast();
     // LinearOp:
     // inputs (0) = {*, in_features}
     // weight (1) = {out_features, in_features} / {in_features}
@@ -221,7 +222,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     // output = {*, out_features} / {*}
 
     const std::vector<IterDomain*>& aligned_producer_ids =
-        ops::mapLinearOpIterDomains(producer_logical, input_position, out_size);
+        ops::mapLinearOpIterDomains(producer_logical, input_position, out_size, k_bcast);
     pairwiseMapAllIds(aligned_producer_ids, consumer_root);
     return dom_map;
   }

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -65,6 +65,7 @@ static TensorView* newForLinear(
   auto weight_domain = TensorDomain::noReductions(weight->getLogicalDomain());
 
   // Output has a reduction axis rK if K is not bcast
+  NVF_CHECK(input_domain.back()->isBroadcast() == weight_domain.back()->isBroadcast(), "K should be broadcast in both inputs and weights, or neither.");
   bool k_bcast = input_domain.back()->isBroadcast();
   size_t red_dims = k_bcast ? 0 : 1;
 
@@ -339,9 +340,12 @@ namespace {
 static TensorView* newForMatmul(TensorView* tv_a, TensorView* tv_b) {
   auto orig_domain_a = TensorDomain::noReductions(tv_a->getLogicalDomain());
   auto orig_domain_b = TensorDomain::noReductions(tv_b->getLogicalDomain());
-
+  
   auto ndims_a = orig_domain_a.size();
   auto ndims_b = orig_domain_b.size();
+
+  auto b_kpos = orig_domain_b.size() > 1 ? ndims_b - 2 : ndims_b - 1;
+  NVF_CHECK(orig_domain_a.back()->isBroadcast() == orig_domain_b.at(b_kpos)->isBroadcast(), "K should be broadcast in both A and B, or neither.");
 
   // Output has a reduction axis rK if K is not bcast
   bool k_bcast = orig_domain_a.back()->isBroadcast();

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -71,7 +71,8 @@ static TensorView* newForLinear(
   // Linear: a = {*, in_features}, b = {out_features, in_features} /
   // {in_features}.The linear output is {*, (out_features), rK?}.
   // Reduction K is present only when K is not bcast.
-  auto ndims_out = (input_domain.size() - 1) + (weight_domain.size() - 1) + red_dims;
+  auto ndims_out =
+      (input_domain.size() - 1) + (weight_domain.size() - 1) + red_dims;
 
   const std::vector<IterDomain*>& mapping_a =
       ops::mapLinearOpIterDomains(input_domain, 0, ndims_out, k_bcast);
@@ -80,7 +81,8 @@ static TensorView* newForLinear(
   std::vector<IterDomain*> mapping_bias(ndims_out, nullptr);
   if (bias != nullptr) {
     auto bias_domain = TensorDomain::noReductions(bias->getLogicalDomain());
-    mapping_bias = ops::mapLinearOpIterDomains(bias_domain, 2, ndims_out, k_bcast);
+    mapping_bias =
+        ops::mapLinearOpIterDomains(bias_domain, 2, ndims_out, k_bcast);
   }
 
   std::vector<IterDomain*> out_domain(ndims_out, nullptr);
@@ -90,11 +92,11 @@ static TensorView* newForLinear(
         {mapping_a.at(idx), mapping_b.at(idx), mapping_bias.at(idx)});
   }
 
-  if (!k_bcast){
+  if (!k_bcast) {
     // Specify the iterdomain for K as reduction
     out_domain[ndims_out - 1] = ops::newOutputIterDomain(
         {mapping_a.back(), mapping_b.back()},
-        /*force_iter_type=*/IterType::Reduction);    
+        /*force_iter_type=*/IterType::Reduction);
   }
 
   TensorDomain* td = IrBuilder::create<TensorDomain>(
@@ -340,13 +342,14 @@ static TensorView* newForMatmul(TensorView* tv_a, TensorView* tv_b) {
 
   auto ndims_a = orig_domain_a.size();
   auto ndims_b = orig_domain_b.size();
-  
+
   // Output has a reduction axis rK if K is not bcast
   bool k_bcast = orig_domain_a.back()->isBroadcast();
   size_t red_dims = k_bcast ? 0 : 1;
 
   // Matmul output size is same as the higher dimensional input size if both A/B
-  // > 1D, but with 1 additional IterType::Reduction axis rK if K is not broadcast.
+  // > 1D, but with 1 additional IterType::Reduction axis rK if K is not
+  // broadcast.
   auto ndims_out = std::max(ndims_a, ndims_b) + red_dims;
   if (std::min(ndims_a, ndims_b) == 1) {
     // If one of the inputs is 1D, the output size is the same as the higher
@@ -366,7 +369,7 @@ static TensorView* newForMatmul(TensorView* tv_a, TensorView* tv_b) {
     out_domain[idx] =
         ops::newOutputIterDomain({mapping_a.at(idx), mapping_b.at(idx)});
   }
-  if (!k_bcast){
+  if (!k_bcast) {
     out_domain[ndims_out - 1] = ops::newOutputIterDomain(
         {mapping_a.back(), mapping_b.back()},
         /*force_iter_type=*/IterType::Reduction);

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -336,16 +336,17 @@ static TensorView* newForMatmul(TensorView* tv_a, TensorView* tv_b) {
   auto ndims_b = orig_domain_b.size();
   
   // Output has a reduction axis rK if K is not bcast
-  bool k_non_bcast = !tv_a->axis(-1)->isBroadcast();
+  bool k_bcast = tv_a->axis(-1)->isBroadcast();
+  size_t red_dims = k_bcast ? 0 : 1;
 
   // Matmul output size is same as the higher dimensional input size if both A/B
   // > 1D, but with 1 additional IterType::Reduction axis rK if K is not broadcast.
-  auto ndims_out = std::max(ndims_a, ndims_b) + (size_t)k_non_bcast;
+  auto ndims_out = std::max(ndims_a, ndims_b) + red_dims;
   if (std::min(ndims_a, ndims_b) == 1) {
     // If one of the inputs is 1D, the output size is the same as the higher
     // dimensional input size, since we will include a Reduction axis for K in
     // the output. For example: [iM, iK] x [iK] -> [iM, rK]
-    ndims_out = std::max(ndims_a, ndims_b) - 1 + + (size_t)k_non_bcast;
+    ndims_out = std::max(ndims_a, ndims_b) - 1 + red_dims;
   }
 
   std::vector<IterDomain*> out_domain(ndims_out, nullptr);
@@ -355,11 +356,11 @@ static TensorView* newForMatmul(TensorView* tv_a, TensorView* tv_b) {
   const std::vector<IterDomain*>& mapping_b =
       ops::mapMatmulOpIterDomains(orig_domain_b, 1, ndims_out);
 
-  for (auto idx : c10::irange(ndims_out - k_non_bcast)) {
+  for (auto idx : c10::irange(ndims_out - red_dims)) {
     out_domain[idx] =
         ops::newOutputIterDomain({mapping_a.at(idx), mapping_b.at(idx)});
   }
-  if (k_non_bcast){
+  if (!k_bcast){
     out_domain[ndims_out - 1] = ops::newOutputIterDomain(
         {mapping_a.back(), mapping_b.back()},
         /*force_iter_type=*/IterType::Reduction);

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -65,7 +65,9 @@ static TensorView* newForLinear(
   auto weight_domain = TensorDomain::noReductions(weight->getLogicalDomain());
 
   // Output has a reduction axis rK if K is not bcast
-  NVF_CHECK(input_domain.back()->isBroadcast() == weight_domain.back()->isBroadcast(), "K should be broadcast in both inputs and weights, or neither.");
+  NVF_CHECK(
+      input_domain.back()->isBroadcast() == weight_domain.back()->isBroadcast(),
+      "K should be broadcast in both inputs and weights, or neither.");
   bool k_bcast = input_domain.back()->isBroadcast();
   size_t red_dims = k_bcast ? 0 : 1;
 
@@ -340,12 +342,15 @@ namespace {
 static TensorView* newForMatmul(TensorView* tv_a, TensorView* tv_b) {
   auto orig_domain_a = TensorDomain::noReductions(tv_a->getLogicalDomain());
   auto orig_domain_b = TensorDomain::noReductions(tv_b->getLogicalDomain());
-  
+
   auto ndims_a = orig_domain_a.size();
   auto ndims_b = orig_domain_b.size();
 
   auto b_kpos = orig_domain_b.size() > 1 ? ndims_b - 2 : ndims_b - 1;
-  NVF_CHECK(orig_domain_a.back()->isBroadcast() == orig_domain_b.at(b_kpos)->isBroadcast(), "K should be broadcast in both A and B, or neither.");
+  NVF_CHECK(
+      orig_domain_a.back()->isBroadcast() ==
+          orig_domain_b.at(b_kpos)->isBroadcast(),
+      "K should be broadcast in both A and B, or neither.");
 
   // Output has a reduction axis rK if K is not bcast
   bool k_bcast = orig_domain_a.back()->isBroadcast();

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -190,7 +190,10 @@ std::vector<IterDomain*> mapMatmulOpIterDomains(
 
   // Input A to matmul: {*, M, K}
   // Input B to matmul: {*, K, N}
-  auto kpos = input_position == 0 ? inp_size - 1 : inp_size - 2;
+  auto kpos = inp_size - 1;
+  if (input_position == 1 && inp_size > 1){
+    kpos = inp_size - 2;
+  }
   bool k_bcast = input_domain.at(kpos)->isBroadcast();
   int64_t red_dims = k_bcast ? 0 : 1;
 

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -191,7 +191,7 @@ std::vector<IterDomain*> mapMatmulOpIterDomains(
   // Input A to matmul: {*, M, K}
   // Input B to matmul: {*, K, N}
   auto kpos = inp_size - 1;
-  if (input_position == 1 && inp_size > 1){
+  if (input_position == 1 && inp_size > 1) {
     kpos = inp_size - 2;
   }
   bool k_bcast = input_domain.at(kpos)->isBroadcast();
@@ -199,13 +199,14 @@ std::vector<IterDomain*> mapMatmulOpIterDomains(
 
   // Last position is a reduction dimension mapping to K if K is not broadcast.
   if (!k_bcast) {
-    mapping[out_size - 1] = input_domain.at(kpos);;
+    mapping[out_size - 1] = input_domain.at(kpos);
+    ;
   }
 
-  if (inp_size == 1){
+  if (inp_size == 1) {
     return mapping;
   }
-  
+
   for (auto out_idx = (int64_t)out_size - 1 - red_dims, inp_idx = inp_size - 1;
        inp_idx >= 0;
        inp_idx--) {
@@ -244,9 +245,9 @@ std::vector<IterDomain*> mapLinearOpIterDomains(
   // Bias: {N} / {}
 
   // Map K if K is not bcast
-  if (input_position != 2 && !k_bcast){
+  if (input_position != 2 && !k_bcast) {
     mapping[out_size - 1] = input_domain.back();
-  }  
+  }
 
   switch (input_position) {
     case 0: {
@@ -259,7 +260,7 @@ std::vector<IterDomain*> mapLinearOpIterDomains(
     }
     case 1: {
       // Map N / out_features if present
-      if (inp_size > 1){
+      if (inp_size > 1) {
         mapping[out_size - 1 - red_dims] = input_domain.front();
       }
       break;

--- a/csrc/ops/utils.h
+++ b/csrc/ops/utils.h
@@ -73,7 +73,8 @@ std::vector<IterDomain*> mapMatmulOpIterDomains(
 std::vector<IterDomain*> mapLinearOpIterDomains(
     const std::vector<IterDomain*>& input_domain,
     int64_t input_position,
-    size_t out_size);
+    size_t out_size,
+    bool k_bcast);
 
 // Takes a vector of aligned input iterdomains to create the output iterdomain.
 // This is used if the input iterdomains are not trivially mapped to the output

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1809,13 +1809,14 @@ DimRolesMap MatmulPattern::getDimRoles(IdModel& id_model) const {
 
   } else if (output->definition()->isA<LinearOp>()) {
     const std::vector<IterDomain*>& out_logical = output->getLogicalDomain();
+    bool k_bcast = A->getLogicalDomain().back()->isBroadcast();
     return matmulOrLinearOpDimRoles(
         permissive_graph,
         out_logical,
         ops::mapLinearOpIterDomains(
-            A->getLogicalDomain(), 0, out_logical.size()),
+            A->getLogicalDomain(), 0, out_logical.size(), k_bcast),
         ops::mapLinearOpIterDomains(
-            B->getLogicalDomain(), 1, out_logical.size()));
+            B->getLogicalDomain(), 1, out_logical.size(), k_bcast));
   }
 
   // The code below handles MmaOp or mul-sum patterns

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -66,7 +66,7 @@ void checkMatmulOpIdMapping(
     out_ndims = std::max(A->nDims(), B->nDims()) - 1 + red_dims;
   }
   ASSERT_EQ(output->nDims(), out_ndims);
-  
+
   if (A->nDims() > 1) {
     int out_mpos = B->nDims() > 1 ? -2 - red_dims : -1 - red_dims;
     EXPECT_TRUE(checkMapped(vg, A->axis(-2), output->axis(out_mpos))); // M
@@ -86,7 +86,8 @@ void checkMatmulOpIdMapping(
   // Note that A and B can have different dimensions, so here we count
   // backwards from the innermost batch dimension. Then we check that the axis
   // exists (is not negative) and is not Broadcast before checking mapping.
-  int batch_ndims = output->nDims() - (B->nDims() > 1) - (A->nDims() > 1) - red_dims;
+  int batch_ndims =
+      output->nDims() - (B->nDims() > 1) - (A->nDims() > 1) - red_dims;
   for (int64_t i : c10::irange(batch_ndims)) {
     int64_t i_a = A->nDims() - 3 - i;
     int64_t i_b = B->nDims() - 3 - i;
@@ -129,7 +130,8 @@ void checkLinearOpIdMapping(
   // Check out_features dim is mapped in weight & bias if present.
   if (weight->nDims() > 1) {
     if (!weight->axis(0)->isBroadcast()) {
-      EXPECT_TRUE(checkMapped(vg, weight->axis(0), output->axis(-1 - red_dims)));
+      EXPECT_TRUE(
+          checkMapped(vg, weight->axis(0), output->axis(-1 - red_dims)));
     }
     if (bias != nullptr && bias->nDims() > 0 && !bias->axis(0)->isBroadcast()) {
       EXPECT_TRUE(checkMapped(vg, bias->axis(0), output->axis(-1 - red_dims)));


### PR DESCRIPTION
When K=1, we will be mapping a reduction axis to broadcast axis in `LinearOp/MatmulOp`. This is not allowed in nvFuser. This was first noticed in Issue #2532 but exists generally.

PR #2534 is included in this PR for checking `LinearOp`.