### PR TITLE
Host irs/overlap: add `number_of_streams` and `number_of_iterations`

### DIFF
--- a/tests/cpp/test_multidevice_overlap.cpp
+++ b/tests/cpp/test_multidevice_overlap.cpp
@@ -211,10 +211,13 @@ class OverlapTest : public MultiDeviceTest {
 // clang-format on
 TEST_F(OverlapTest, ReduceScatterBasedPipeliningATenImplementation) {
   std::vector<c10::cuda::CUDAStream> streams;
-  std::generate_n(std::back_inserter(streams), params.number_of_streams, [my_device_index=my_device_index_]() {
-    return c10::cuda::getStreamFromPool(
-        /*isHighPriority=*/false, my_device_index);
-  });
+  std::generate_n(
+      std::back_inserter(streams),
+      params.number_of_streams,
+      [my_device_index = my_device_index_]() {
+        return c10::cuda::getStreamFromPool(
+            /*isHighPriority=*/false, my_device_index);
+      });
 
   for ([[maybe_unused]] const auto& _ :
        c10::irange(params.number_of_iterations)) {

--- a/tests/cpp/test_multidevice_overlap.cpp
+++ b/tests/cpp/test_multidevice_overlap.cpp
@@ -211,9 +211,9 @@ class OverlapTest : public MultiDeviceTest {
 // clang-format on
 TEST_F(OverlapTest, ReduceScatterBasedPipeliningATenImplementation) {
   std::vector<c10::cuda::CUDAStream> streams;
-  std::generate_n(std::back_inserter(streams), params.number_of_streams, [=]() {
+  std::generate_n(std::back_inserter(streams), params.number_of_streams, [my_device_index=my_device_index_]() {
     return c10::cuda::getStreamFromPool(
-        /*isHighPriority=*/false, my_device_index_);
+        /*isHighPriority=*/false, my_device_index);
   });
 
   for ([[maybe_unused]] const auto& _ :

--- a/tests/cpp/test_multidevice_overlap.cpp
+++ b/tests/cpp/test_multidevice_overlap.cpp
@@ -104,6 +104,9 @@ class OverlapTest : public MultiDeviceTest {
     auto cpu_options = at::TensorOptions().dtype(at::kFloat);
     at::TensorOptions gpu_options = cpu_options.device(communicator_->device());
 
+    // Unsharded tensors are large and only used for validating data corectness.
+    // Therefore, to improve GPU memory footprint, we allocate those tensors on
+    // the CPU
     ta_unsharded_ = at::empty(ta_unsharded_sizes, cpu_options);
     tb_unsharded_ = at::empty(tb_unsharded_sizes, cpu_options);
     ta_ = at::empty(ta_sizes, gpu_options);


### PR DESCRIPTION
# What

This patch adds features and improve several aspects the reduce-scatter-based pipelining overlap experiments. We patch both the ATen and the host IR implementation.

### adds a parameter`number_of_streams`: 
For each slice of the tensor, we change the stream in a round-robin fashion. Before this patch, we used as many streams as there were slices (aka `params.S`, the extent of the outermost dimension). We observe in #2673 (see in particular [this message](https://github.com/NVIDIA/Fuser/issues/2673#issuecomment-2260235042)) that we want to:
   - have at least one warm-up iteration
   - keep the number of streams relatively low:
       - `at::matmul_out` (and, in general, pytorch allocator cache) allocates buffers per stream.
       - We only need a couple of streams to achieve overlap. I think using two or three streams should be sufficient (**TODO**: check what is done in Megatron)

Doing so, **we eliminate the undesired `cudaMalloc`** described [here](https://github.com/NVIDIA/Fuser/pull/2584#issuecomment-2238833771) **and achieve overlap between comms and compute**. See screenshots below.

### adds a parameter `number_of_iterations`
For repeating the whole process of instantiating the inputs with new random values and posting the compute/comms. We validate data corectness only on the last iteration. The goal is to have one or more warmup iterations before analyzing the profile and perf.

### Improve memory footprint:
- `tc_locally_reduced_` outermost axis is chosen to be smaller than the number of streams
- unsharded tensors `ta_unsharded_`, `tb_unsharded_` are large tensors only used for validation, so we allocate them on the CPU memory.

# TODO 
- use several PG for comms/comms overlap.
- Run at bigger scale, on H100
- Lookup what params are used in TE


# Profile analysis

### Settings:
8*A100 40g, luna node

Params:
- `M=N=K=2^10`

Other parameters as in the file.
- `S=8`
- `number_of_streams=3`
- `number_of_iterations=4`

## ATen implementation
`OverlapTest.ReduceScatterBasedPipeliningATenImplementation`

In this first zoomed-out screenshot, we can see four "large blocks" separated by the green `cudaStreamSynchronize`, corresponding to the parameter`number_of_iteration=4`. We observe that the first `ncclDevKernel_ReduceScatter` is longer than the other -- probably due to a reallocation of the input at each iteration (which we tried to avoid though...).
![Screenshot 2024-08-02 at 13 22 52](https://github.com/user-attachments/assets/cdb8f965-5832-4d6a-9e54-f8b5abb60657)


In the second screenshot, we zoom inside one iteration. We highlight the `Kernel2`(`cutlass::Kernel2<cutlass_80_tensorop_s1688gemm_64x64_16x6_nn_align4>`) which corresponds to the `matmul_out` operation. The three first matmul are executed before and during the first reduce_scatter, corresponding to the parameter `number_of_streams=3`.
![Screenshot 2024-08-02 at 13 25 20](https://github.com/user-attachments/assets/be7d608a-c40a-429a-a6d8-edf71da3ebb1)

If we zoom further on the right part, we clearly see that over is achieved between comms and compute.
![Screenshot 2024-08-02 at 13 27 18](https://github.com/user-attachments/assets/8cb9e97b-2152-4bd8-98f3-587e0b04a316)

## Host IR implementation

The same behavior is observed in the Host IR implementation `OverlapTest.ReduceScatterBasedPipeliningHostIrImplementation`:

![Screenshot 2024-08-02 at 13 28 16](https://github.com/user-attachments/assets/efe3fa6f-dcdf-4175-94c8-5f1eb0594c7e)



