### PR TITLE
Remove `query/key_seq_len, debug_attn_mask` in `SdpaFwdOp`

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2237,11 +2237,8 @@ class SdpaFwdOp : public Expr {
       IrBuilderPasskey,
       TensorView* output,
       TensorView* log_sumexp,
-      TensorView* query_seq_len,
-      TensorView* key_seq_len,
       TensorView* philox_seed,
       TensorView* philox_offset,
-      TensorView* debug_attn_mask,
       Val* query,
       Val* key,
       Val* value,
@@ -2517,8 +2514,6 @@ key = [N, H, S, E]
 value = [N, H, S, Ev]
 output = [N, H, L, Ev]
 logsumexp = [N, H, L]
-query_seq_len = scalar(int)
-key_seq_len = scalar(int)
 dropout_p = scalar(double)
 is_causal = scalar(bool)
 philox_seed = scalar CPU tensor
@@ -2550,8 +2545,6 @@ class SdpaBwdOp : public Expr {
       TensorView* value,
       TensorView* output,
       TensorView* log_sumexp,
-      TensorView* query_seq_len,
-      TensorView* key_seq_len,
       Val* dropout_p,
       Val* is_causal,
       TensorView* philox_seed,
@@ -2603,33 +2596,25 @@ class SdpaBwdOp : public Expr {
     return input(5);
   }
 
-  Val* max_q() const {
+  Val* dropout_p() const {
     return input(6);
   }
 
-  Val* max_k() const {
+  Val* is_causal() const {
     return input(7);
   }
 
-  Val* dropout_p() const {
+  Val* philox_seed() const {
     return input(8);
   }
 
-  Val* is_causal() const {
+  Val* philox_offset() const {
     return input(9);
   }
 
-  Val* philox_seed() const {
-    return input(10);
-  }
-
-  Val* philox_offset() const {
-    return input(11);
-  }
-
   Val* scale() const {
-    if (inputs().size() > 12) {
-      return input(12);
+    if (inputs().size() > 10) {
+      return input(10);
     }
     return nullptr;
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4299,11 +4299,8 @@ SdpaFwdOp::SdpaFwdOp(
     IrBuilderPasskey passkey,
     TensorView* output,
     TensorView* log_sumexp,
-    TensorView* query_seq_len,
-    TensorView* key_seq_len,
     TensorView* philox_seed,
     TensorView* philox_offset,
-    TensorView* debug_attn_mask,
     Val* query,
     Val* key,
     Val* value,
@@ -4313,11 +4310,8 @@ SdpaFwdOp::SdpaFwdOp(
     : Expr(passkey) {
   addOutput(output);
   addOutput(log_sumexp);
-  addOutput(query_seq_len);
-  addOutput(key_seq_len);
   addOutput(philox_seed);
   addOutput(philox_offset);
-  addOutput(debug_attn_mask);
 
   addInput(query);
   addInput(key);
@@ -4376,7 +4370,7 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
 
   // Flash attention requires the last dimension to be padded to 8.
   // https://github.com/pytorch/pytorch/blob/c27882ffa8c1c7e4cf8ebc6c2f879e5b6c8814ad/aten/src/ATen/native/transformers/attention.cpp#L675-L677
-  const auto last_dim_size = query.sizes()[3];
+  const auto last_dim_size = query.size(-1);
   auto pad_last_dim = [last_dim_size](
                           at::Tensor inp, int alignment_size) -> at::Tensor {
     if (last_dim_size % alignment_size == 0) {
@@ -4417,29 +4411,24 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
               scale);
 
   // If the inputs were padded, slice the output to restore the original size
-  if (output.sizes()[3] != last_dim_size) {
+  if (output.size(-1) != last_dim_size) {
     output = output.slice(-1, 0, last_dim_size);
   }
 
   // Add back the device dim axis for output.
   if (handle_device_dim) {
     output = output.unsqueeze(0);
+    log_sumexp = log_sumexp.unsqueeze(0);
   }
 
-  // Query and key seq len are of type c10::SymInt -> convert them to CPU scalar
-  // tensors to support adding them as fusion outputs.
   // We ignore cum_seq_q/k outputs since they are undefined tensors for
-  // non-nested tensors.
+  // non-nested tensors. We do not store query/key_seq_len since they can be computed in non-nested tensor directly.
+  // debug_attn_mask is ignored since `return_debug_mask=false`.
   return {
       output,
       log_sumexp,
-      at::scalar_tensor(
-          *query_seq_len.maybe_as_int(), at::device(at::kCPU).dtype(at::kLong)),
-      at::scalar_tensor(
-          *key_seq_len.maybe_as_int(), at::device(at::kCPU).dtype(at::kLong)),
       philox_seed,
-      philox_offset,
-      debug_attn_mask};
+      philox_offset};
 }
 
 std::string Scope::toString(int indent_size) const {
@@ -4807,8 +4796,6 @@ SdpaBwdOp::SdpaBwdOp(
     TensorView* value,
     TensorView* output,
     TensorView* log_sumexp,
-    TensorView* max_q,
-    TensorView* max_k,
     Val* dropout_p,
     Val* is_causal,
     TensorView* philox_seed,
@@ -4824,8 +4811,6 @@ SdpaBwdOp::SdpaBwdOp(
   addInput(value);
   addInput(output);
   addInput(log_sumexp);
-  addInput(max_q);
-  addInput(max_k);
   addInput(dropout_p);
   addInput(is_causal);
   addInput(philox_seed);
@@ -4852,10 +4837,6 @@ std::string SdpaBwdOp::toString(int indent_size) const {
   indent(ss, indent_size + 1)
       << "          logsum_exp = " << logsumexp()->toString() << ",\n";
   indent(ss, indent_size + 1)
-      << "          max_q = " << max_q()->toString() << ",\n";
-  indent(ss, indent_size + 1)
-      << "          max_k = " << max_k()->toString() << ",\n";
-  indent(ss, indent_size + 1)
       << "          dropout_p = " << dropout_p()->toInlineString() << ",\n";
   indent(ss, indent_size + 1)
       << "          is_causal = " << is_causal()->toInlineString() << ",\n";
@@ -4881,17 +4862,17 @@ std::vector<PolymorphicValue> SdpaBwdOp::evaluate(
   // Backward tensor inputs: grad_input, query, key, value, output, logsumexp,
   // max_q/k
   std::vector<at::Tensor> bwd_inputs;
-  for (auto idx : c10::irange(8)) {
+  for (auto idx : c10::irange(6)) {
     bwd_inputs.emplace_back(inputs.at(idx).as<at::Tensor>());
   }
-  const auto dropout_p = inputs.at(8).as<double>();
-  const auto is_causal = inputs.at(9).as<bool>();
-  const auto philox_seed = inputs.at(10).as<at::Tensor>();
-  const auto philox_offset = inputs.at(11).as<at::Tensor>();
+  const auto dropout_p = inputs.at(6).as<double>();
+  const auto is_causal = inputs.at(7).as<bool>();
+  const auto philox_seed = inputs.at(8).as<at::Tensor>();
+  const auto philox_offset = inputs.at(9).as<at::Tensor>();
 
   // Flash attention requires the last dimension to be padded to 8.
   // https://github.com/pytorch/pytorch/blob/c27882ffa8c1c7e4cf8ebc6c2f879e5b6c8814ad/aten/src/ATen/native/transformers/attention.cpp#L675-L677
-  const auto last_dim_size = bwd_inputs[0].sizes()[3];
+  const auto last_dim_size = bwd_inputs[0].size(-1);
   auto pad_last_dim = [last_dim_size](
                           at::Tensor inp, int alignment_size) -> at::Tensor {
     if (last_dim_size % alignment_size == 0) {
@@ -4903,7 +4884,7 @@ std::vector<PolymorphicValue> SdpaBwdOp::evaluate(
   };
 
   // Conmpute scale using original size of last dimension
-  double scale = inputs.size() > 12 ? inputs.back().as<double>()
+  double scale = inputs.size() > 10 ? inputs.back().as<double>()
                                     : 1.0 / std::sqrt(last_dim_size);
 
   // ATen reference:
@@ -4920,8 +4901,8 @@ std::vector<PolymorphicValue> SdpaBwdOp::evaluate(
           /*cum_seq_q=*/at::Tensor(),
           /*cum_seq_k=*/at::Tensor(),
           // Note: ATen implementation expects max_q/max_k as scalars.
-          /*max_q=*/bwd_inputs[6].item<int64_t>(),
-          /*max_k=*/bwd_inputs[7].item<int64_t>(),
+          /*max_q=*/bwd_inputs[1].size(2),
+          /*max_k=*/bwd_inputs[2].size(2),
           /*dropout_p=*/dropout_p,
           /*is_causal=*/is_causal,
           /*philox_seed=*/philox_seed,
@@ -4930,7 +4911,7 @@ std::vector<PolymorphicValue> SdpaBwdOp::evaluate(
 
   // If the inputs were padded, slice the gradsto restore the original size
   auto slice_last_dim = [last_dim_size](at::Tensor output) -> at::Tensor {
-    if (output.sizes()[3] != last_dim_size) {
+    if (output.size(-1) != last_dim_size) {
       return output;
     }
     return output.slice(-1, 0, last_dim_size);

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4422,13 +4422,10 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
   }
 
   // We ignore cum_seq_q/k outputs since they are undefined tensors for
-  // non-nested tensors. We do not store query/key_seq_len since they can be computed in non-nested tensor directly.
-  // debug_attn_mask is ignored since `return_debug_mask=false`.
-  return {
-      output,
-      log_sumexp,
-      philox_seed,
-      philox_offset};
+  // non-nested tensors. We do not store query/key_seq_len since they can be
+  // computed in non-nested tensor directly. debug_attn_mask is ignored since
+  // `return_debug_mask=false`.
+  return {output, log_sumexp, philox_seed, philox_offset};
 }
 
 std::string Scope::toString(int indent_size) const {

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -234,14 +234,14 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     //   value = [DIDx(D)?, N, H, S, Ev]
     // Consumers:
     //   output = [DIDx(D)?, N, H, L, Ev]
-    //   logsumexp = [N, H, L]
+    //   logsumexp = [DIDx(D)?, N, H, L]
     // Note: S, E are not mapped together in the producers and do not have any
     // mapping to the consumer.
 
     size_t num_device_dim = producer_logical.at(0)->isDeviceDim() ? 1 : 0;
     // Map N, H from any input (query/key/value)
     for (auto idx : c10::irange(consumer_root.size())) {
-      if (idx >= num_device_dim && idx < (2 + num_device_dim)) {
+      if (idx < (2 + num_device_dim)) {
         updatePairwiseLogicalDomainMap(
             producer_logical.at(idx), consumer_root.at(idx));
       }
@@ -255,11 +255,6 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
         updatePairwiseLogicalDomainMap(
             producer_logical.at(idx), consumer_root.at(idx));
       }
-    }
-    // Map D from any input (query/key/value) to output only.
-    if (num_device_dim == 1 && consumer_root.size() > 3) {
-      updatePairwiseLogicalDomainMap(
-          producer_logical.at(0), consumer_root.at(0));
     }
     return dom_map;
   }

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -452,7 +452,7 @@ SdpfaFwdResult sdpfa_fwd(
   NVF_CHECK(
       !scale || scale->isScalar(), "Expected scale to be a scalar double.");
 
-  // Query: [N,H,L,E], Key: [N,H,S,E], Value: [N,H,S,Ev] Output: [N,H,L,Ev]
+  // Query: [DIDx(D)?,N,H,L,E], Key: [DIDx(D)?,N,H,S,E], Value: [DIDx(D)?,N,H,S,Ev] Output: [DIDx(D)?,N,H,L,Ev]
   // N, H are mapped for all inputs to outputs. L is mapped from query to
   // output. Ev is mapped from value to output. Note: There is no mapping for S,
   // E. This may change in the future if we add additional reduction ids to the
@@ -474,7 +474,7 @@ SdpfaFwdResult sdpfa_fwd(
       out_domain, TensorDomain::getContiguityFilledWith(out_domain, true));
   TensorView* output = IrBuilder::create<TensorView>(attn_td, query->dtype());
 
-  // TensorView for log_sumexp [N, H, L]
+  // TensorView for log_sumexp [DIDx(D)?,N, H, L]
   std::vector<IterDomain*> log_sumexp_dom(ndims_out - 1, nullptr);
   for (auto idx : c10::irange(ndims_out - 2)) {
     log_sumexp_dom[idx] = ops::newOutputIterDomain(
@@ -488,22 +488,11 @@ SdpfaFwdResult sdpfa_fwd(
   TensorView* log_sumexp =
       IrBuilder::create<TensorView>(log_sumexp_td, DataType::Float);
 
-  TensorView* query_seq_len = TensorViewBuilder().dtype(DataType::Int).build();
-  TensorView* key_seq_len = TensorViewBuilder().dtype(DataType::Int).build();
-  query_seq_len->setCpuScalar(true);
-  key_seq_len->setCpuScalar(true);
-
   // Scalar tensors of int64_t dtype.
   TensorView* philox_seed = TensorViewBuilder().dtype(DataType::Int).build();
   TensorView* philox_offset = TensorViewBuilder().dtype(DataType::Int).build();
   philox_seed->setCpuScalar(true);
   philox_offset->setCpuScalar(true);
-
-  // Thunder metadata represents debug_attn_mask of type int64_t, although the
-  // debug_attn_mask is of query.dtype. Since we use return_debug_mask=false in
-  // the internal flash attention call, this is a scalar zero tensor.
-  TensorView* debug_attn_mask =
-      TensorViewBuilder().dtype(query->dtype()).build();
 
   // Set default values for dropout_p (0.0), is_causal(false)
   if (dropout_p == nullptr) {
@@ -517,11 +506,8 @@ SdpfaFwdResult sdpfa_fwd(
   IrBuilder::create<SdpaFwdOp>(
       output,
       log_sumexp,
-      query_seq_len,
-      key_seq_len,
       philox_seed,
       philox_offset,
-      debug_attn_mask,
       query,
       key,
       value,
@@ -531,11 +517,8 @@ SdpfaFwdResult sdpfa_fwd(
   return {
       output,
       log_sumexp,
-      query_seq_len,
-      key_seq_len,
       philox_seed,
-      philox_offset,
-      debug_attn_mask};
+      philox_offset};
 }
 
 SdpfaBwdResult sdpfa_bwd(
@@ -545,8 +528,6 @@ SdpfaBwdResult sdpfa_bwd(
     TensorView* value,
     TensorView* output,
     TensorView* log_sumexp,
-    TensorView* query_seq_len,
-    TensorView* key_seq_len,
     Val* dropout_p,
     Val* is_causal,
     TensorView* philox_seed,
@@ -585,8 +566,6 @@ SdpfaBwdResult sdpfa_bwd(
       !scale || scale->isScalar(), "Expected scale to be a scalar double.");
 
   // Mark CPU scalar tensors.
-  query_seq_len->setCpuScalar(true);
-  key_seq_len->setCpuScalar(true);
   philox_seed->setCpuScalar(true);
   philox_offset->setCpuScalar(true);
 
@@ -605,8 +584,6 @@ SdpfaBwdResult sdpfa_bwd(
       value,
       output,
       log_sumexp,
-      query_seq_len,
-      key_seq_len,
       dropout_p,
       is_causal,
       philox_seed,

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -452,11 +452,11 @@ SdpfaFwdResult sdpfa_fwd(
   NVF_CHECK(
       !scale || scale->isScalar(), "Expected scale to be a scalar double.");
 
-  // Query: [DIDx(D)?,N,H,L,E], Key: [DIDx(D)?,N,H,S,E], Value: [DIDx(D)?,N,H,S,Ev] Output: [DIDx(D)?,N,H,L,Ev]
-  // N, H are mapped for all inputs to outputs. L is mapped from query to
-  // output. Ev is mapped from value to output. Note: There is no mapping for S,
-  // E. This may change in the future if we add additional reduction ids to the
-  // output.
+  // Query: [DIDx(D)?,N,H,L,E], Key: [DIDx(D)?,N,H,S,E], Value:
+  // [DIDx(D)?,N,H,S,Ev] Output: [DIDx(D)?,N,H,L,Ev] N, H are mapped for all
+  // inputs to outputs. L is mapped from query to output. Ev is mapped from
+  // value to output. Note: There is no mapping for S, E. This may change in the
+  // future if we add additional reduction ids to the output.
   auto ndims_out = query_domain.size();
 
   // TensorView for attention output
@@ -514,11 +514,7 @@ SdpfaFwdResult sdpfa_fwd(
       dropout_p,
       is_causal,
       scale);
-  return {
-      output,
-      log_sumexp,
-      philox_seed,
-      philox_offset};
+  return {output, log_sumexp, philox_seed, philox_offset};
 }
 
 SdpfaBwdResult sdpfa_bwd(

--- a/csrc/ops/composite.h
+++ b/csrc/ops/composite.h
@@ -80,11 +80,8 @@ TensorView* matmul(TensorView* tv_a, TensorView* tv_b);
 struct SdpfaFwdResult {
   TensorView* output = nullptr;
   TensorView* log_sumexp = nullptr;
-  TensorView* query_seq_len = nullptr;
-  TensorView* key_seq_len = nullptr;
   TensorView* philox_seed = nullptr;
   TensorView* philox_offset = nullptr;
-  TensorView* debug_attn_mask = nullptr;
 };
 
 // Scaled Dot Product Flash Attention Forward API.
@@ -113,8 +110,6 @@ SdpfaBwdResult sdpfa_bwd(
     TensorView* value,
     TensorView* output,
     TensorView* log_sumexp,
-    TensorView* query_seq_len,
-    TensorView* key_seq_len,
     Val* dropout_p,
     Val* is_causal,
     TensorView* philox_seed,

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -55,8 +55,8 @@ auto validateSdpaFwdOutputs = [](std::vector<at::Tensor> nvf_out,
        philox_seed,
        philox_offset,
        debug_attn_mask] = aten_out;
-  // nvf_out = {attn, log_sumexp, philox_seed, philox_offset}. 
-  // Since, dropout_p = 0.0 to validate outputs, 
+  // nvf_out = {attn, log_sumexp, philox_seed, philox_offset}.
+  // Since, dropout_p = 0.0 to validate outputs,
   // philox_seed and philox_offset are uninitialized empty tensors with
   // garbage values for this case, so we skip validating those values.
   EXPECT_TRUE(at::allclose(nvf_out[0], attn));
@@ -459,14 +459,7 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
   at::Tensor grad_out = at::randn(attn_shape, options);
 
   std::vector<c10::IValue> sdpa_bwd_inputs = {
-      grad_out,
-      q,
-      k,
-      v,
-      output,
-      log_sumexp,
-      philox_seed,
-      philox_offset};
+      grad_out, q, k, v, output, log_sumexp, philox_seed, philox_offset};
 
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs(sdpa_bwd_inputs);
@@ -575,14 +568,7 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
   at::Tensor grad_out = at::randn(attn_shape, options);
 
   std::vector<c10::IValue> sdpa_bwd_inputs = {
-      grad_out,
-      q,
-      k,
-      v,
-      output,
-      log_sumexp,
-      philox_seed,
-      philox_offset};
+      grad_out, q, k, v, output, log_sumexp, philox_seed, philox_offset};
 
   FusionExecutorCache fec(std::move(fusion));
   auto out = fec.runFusionWithInputs(sdpa_bwd_inputs);

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -29,11 +29,8 @@ constexpr int64_t n = 16, h = 32, l = 64, s = 128, e = 64;
 auto addSdpaFwdOutputs = [](Fusion* fusion, SdpfaFwdResult output) {
   fusion->addOutput(output.output);
   fusion->addOutput(output.log_sumexp);
-  fusion->addOutput(output.query_seq_len);
-  fusion->addOutput(output.key_seq_len);
   fusion->addOutput(output.philox_seed);
   fusion->addOutput(output.philox_offset);
-  fusion->addOutput(output.debug_attn_mask);
 };
 
 using AtenSdpaOut = std::tuple<
@@ -58,15 +55,12 @@ auto validateSdpaFwdOutputs = [](std::vector<at::Tensor> nvf_out,
        philox_seed,
        philox_offset,
        debug_attn_mask] = aten_out;
-  // nvf_out = {attn, log_sumexp, query_seq_len, key_seq_len, philox_seed,
-  // philox_offset, debug_attn_mask}. Since, dropout_p = 0.0 to validate
-  // outputs, philox_seed and philox_offset are uninitialized empty tensors with
+  // nvf_out = {attn, log_sumexp, philox_seed, philox_offset}. 
+  // Since, dropout_p = 0.0 to validate outputs, 
+  // philox_seed and philox_offset are uninitialized empty tensors with
   // garbage values for this case, so we skip validating those values.
   EXPECT_TRUE(at::allclose(nvf_out[0], attn));
   EXPECT_TRUE(at::allclose(nvf_out[1], log_sumexp));
-  EXPECT_EQ(nvf_out[2].item<int64_t>(), query_seq_len);
-  EXPECT_EQ(nvf_out[3].item<int64_t>(), key_seq_len);
-  EXPECT_TRUE(at::equal(nvf_out[6], debug_attn_mask));
 };
 
 void checkSdpaFwdMapping(Fusion* fusion, Expr* op) {
@@ -431,8 +425,6 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
   auto tvv = makeConcreteTensor(kv_shape, DataType::Half);
   auto tv_output = makeConcreteTensor(attn_shape, DataType::Half);
   auto tv_logsumexp = makeConcreteTensor({n, h, l}, DataType::Float);
-  auto tv_maxq = makeConcreteTensor({}, DataType::Int);
-  auto tv_maxk = makeConcreteTensor({}, DataType::Int);
   auto tv_seed = makeConcreteTensor({}, DataType::Int);
   auto tv_offset = makeConcreteTensor({}, DataType::Int);
 
@@ -442,8 +434,6 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
   fusion->addInput(tvv);
   fusion->addInput(tv_output);
   fusion->addInput(tv_logsumexp);
-  fusion->addInput(tv_maxq);
-  fusion->addInput(tv_maxk);
   fusion->addInput(tv_seed);
   fusion->addInput(tv_offset);
 
@@ -454,8 +444,6 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
       tvv,
       tv_output,
       tv_logsumexp,
-      tv_maxq,
-      tv_maxk,
       /*dropout_p=*/IrBuilder::create<Val>(dropout_p),
       /*is_causal=*/IrBuilder::create<Val>(is_causal),
       tv_seed,
@@ -477,10 +465,6 @@ TEST_F(SDPATest, NonCausalAttnConcreteBwd) {
       v,
       output,
       log_sumexp,
-      // max_q/k are represented as CPU scalar tensors in nvFuser and integers
-      // in ATen.
-      at::scalar_tensor(*query_seq_len.maybe_as_int(), at::dtype(at::kLong)),
-      at::scalar_tensor(*key_seq_len.maybe_as_int(), at::dtype(at::kLong)),
       philox_seed,
       philox_offset};
 
@@ -557,8 +541,6 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
   auto tvv = makeSymbolicTensor(kv_shape, DataType::Half);
   auto tv_output = makeSymbolicTensor(attn_shape, DataType::Half);
   auto tv_logsumexp = makeSymbolicTensor({n, h, l}, DataType::Float);
-  auto tv_maxq = makeSymbolicTensor({}, DataType::Int);
-  auto tv_maxk = makeSymbolicTensor({}, DataType::Int);
   auto tv_seed = makeSymbolicTensor({}, DataType::Int);
   auto tv_offset = makeSymbolicTensor({}, DataType::Int);
 
@@ -568,8 +550,6 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
   fusion->addInput(tvv);
   fusion->addInput(tv_output);
   fusion->addInput(tv_logsumexp);
-  fusion->addInput(tv_maxq);
-  fusion->addInput(tv_maxk);
   fusion->addInput(tv_seed);
   fusion->addInput(tv_offset);
 
@@ -580,8 +560,6 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
       tvv,
       tv_output,
       tv_logsumexp,
-      tv_maxq,
-      tv_maxk,
       /*dropout_p=*/IrBuilder::create<Val>(dropout_p),
       /*is_causal=*/IrBuilder::create<Val>(is_causal),
       tv_seed,
@@ -603,10 +581,6 @@ TEST_F(SDPATest, NonCausalAttnSymbolicBwd) {
       v,
       output,
       log_sumexp,
-      // max_q/k are represented as CPU scalar tensors in nvFuser and integers
-      // in ATen.
-      at::scalar_tensor(*query_seq_len.maybe_as_int(), at::dtype(at::kLong)),
-      at::scalar_tensor(*key_seq_len.maybe_as_int(), at::dtype(at::kLong)),
       philox_seed,
       philox_offset};
 
@@ -729,8 +703,6 @@ TEST_F(SDPATest, AttnFwdBwd) {
       tvv,
       sdpa_fwd_out.output,
       sdpa_fwd_out.log_sumexp,
-      sdpa_fwd_out.query_seq_len,
-      sdpa_fwd_out.key_seq_len,
       /*dropout_p=*/IrBuilder::create<Val>(0.0),
       /*is_causal=*/IrBuilder::create<Val>(false),
       sdpa_fwd_out.philox_seed,


### PR DESCRIPTION
1. Since, we have deviated from torch API, making the following changes to have a leaner API:

-   Removes `debug_attn_mask` which is a 1D zero-tensor since `return_debug_mask=false` in `SdpaFwdOp`.
-   Removes `query_seq_len, key_seq_len`: These variables can be computed in the backward pass for non-nested tensors.

2. Adds `DIDx` axis to `log_sumexp` in `SdpaFwdOp::evaluate` and `logical_domain_mapping`. The `DIDx` axis is assumed when the tensorview is created but was not added everywhere. This removes discrepancy in different parts of the code. This will be revisited after work on sharded `SdpaBwdOp`. The `DIDx` can be removed from `log_sumexp` if not required.
  
