### PR TITLE
Check captured python definition in pytest framework.

### DIFF
--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -17,8 +17,6 @@ from typing import Callable
 
 from nvfuser import FusionCache, FusionDefinition
 
-from utils import is_pre_volta
-
 
 def parse_args_fusion_execution(opinfo: OpInfo, *args):
     if len(args) == 0:

--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -17,10 +17,7 @@ from typing import Callable
 
 from nvfuser import FusionCache, FusionDefinition
 
-
-def is_pre_volta():
-    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return prop.major < 7
+from utils import is_pre_volta
 
 
 def parse_args_fusion_execution(opinfo: OpInfo, *args):

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -138,6 +138,8 @@ class TestNvFuserFrontend(TestCase):
     ):
         fc = FusionCache.get()
         before_fusions = fc.num_fusions()
+        # Copy inputs because aliased outputs can modify inputs when running
+        # FusionDefinition
         inputs_cap = deepcopy(inputs)
 
         # Execute a fusion function and capture the string python definition

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -31,8 +31,12 @@ from nvfuser import (
 )
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 
-from utils import check_captured_python_definition
-
+from utils import (
+    is_pre_volta,
+    is_pre_ampere,
+    is_pre_hopper,
+    check_captured_python_definition,
+)
 
 RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
 
@@ -49,27 +53,6 @@ RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
 # Normally, these files are deleted after each test.
 env_var_debug_serde = os.getenv("DEBUG_SERDE")
 debug_serde: bool = env_var_debug_serde in ("true", "1")
-
-
-def is_pre_volta():
-    if not RUN_NVFUSER:
-        return False
-    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return prop.major < 7
-
-
-def is_pre_ampere():
-    if not RUN_NVFUSER:
-        return False
-    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return prop.major < 8
-
-
-def is_pre_hopper():
-    if not RUN_NVFUSER:
-        return False
-    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return prop.major < 9
 
 
 def setUpModule():

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -145,11 +145,9 @@ class TestNvFuserFrontend(TestCase):
             fusion_func(fd)
         torch.manual_seed(0)
         out = fd.execute(inputs, device=device)
-        out_cap = check_captured_python_definition(fd, inputs_cap, device)
 
-        # Make sure the original and captured definitions match
-        for idx in range(len(out)):
-            self.assertEqual(out[idx], out_cap[idx])
+        self.assertTrue(check_captured_python_definition(out, fd, inputs_cap, device))
+
         self.assertEqual(fc.num_fusions() - before_fusions, int(new_fusion_expected))
         return out, fd
 

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -6,7 +6,9 @@
 import torch
 from torch.testing._internal.common_utils import TEST_WITH_ROCM
 from torch.testing._internal.jit_utils import RUN_CUDA
-from nvfuser import FusionDefinition
+
+# flake8: noqa
+from nvfuser import FusionDefinition, DataType
 
 RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
 

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -4,7 +4,29 @@
 # Owner(s): ["module: nvfuser"]
 
 import torch
-from nvfuser import (FusionDefinition, DataType)
+from nvfuser import FusionDefinition, DataType
+
+
+def is_pre_volta():
+    if not RUN_NVFUSER:
+        return False
+    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return prop.major < 7
+
+
+def is_pre_ampere():
+    if not RUN_NVFUSER:
+        return False
+    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return prop.major < 8
+
+
+def is_pre_hopper():
+    if not RUN_NVFUSER:
+        return False
+    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return prop.major < 9
+
 
 def check_captured_python_definition(fd, inputs, device):
     import re

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# Owner(s): ["module: nvfuser"]
+
+import torch
+from nvfuser import (FusionDefinition, DataType)
+
+def check_captured_python_definition(fd, inputs, device):
+    import re
+
+    # Execute the python definition that was captured
+    try:
+        fd_str = fd.__repr__()
+        func_name = re.findall("(nvfuser_fusion_id\\d+)", fd_str.split("\n")[1])[0]
+        exec(fd_str)
+        with FusionDefinition() as fd_cap:
+            eval(func_name)(fd_cap)
+        torch.manual_seed(0)
+        return fd_cap.execute(inputs, device=device)
+    except Exception as err:
+        print("\nException For Printed FusionDefinition:")
+        print(
+            "(A failure here suggests a mismatch in functionality between the original definition and the printed definition.)"
+        )
+        print(fd_str)
+        raise err


### PR DESCRIPTION
The string representation of a `FusionDefinition` is an executable function. Previously, this feature was only checked in `test_python_frontend.py`. This PR adds that check to the pytest framework.

Details:
- Created `utils.py` to hold helper functions
- Create `check_captured_python_definition` test helper function to enforce that the string representation runs the same as the original `FusionDefinition`
- Move cuda device checks to `utils.py`