### PR TITLE
Add serialization check to the pytest framework.

### DIFF
--- a/tests/python/pytest_framework.py
+++ b/tests/python/pytest_framework.py
@@ -61,8 +61,13 @@ class create_op_test:
 
 
 # This pseudo-decorator enables automatic serialization upon program exit and
-# tests deserializing the default workspace upon creating the tests. Do not
-# apply to the error testing functions that can corrupt the FusionCache.
+# tests deserializing the default workspace upon creating the tests.
+#
+# Serializing error test cases corrupts the serialized binary. We call
+# FusionCache.reset() to clear the cache after running an error test in
+# `test_python_frontend.py'. In the pytest framework, the error tests are
+# separate from the correctness tests. Only apply this decorator to the
+# correctness tests to avoid calling FusionCache.reset().
 class atexit_serde_create_op_test(create_op_test):
     def __init__(self, opinfos, *, scope=None):
         from utils import debug_serde

--- a/tests/python/pytest_framework.py
+++ b/tests/python/pytest_framework.py
@@ -70,18 +70,8 @@ class create_op_test:
 # correctness tests to avoid calling FusionCache.reset().
 class atexit_serde_create_op_test(create_op_test):
     def __init__(self, opinfos, *, scope=None):
-        from utils import debug_serde
-        from nvfuser import FusionCache
+        from utils import atexit_serde_check
 
-        if not debug_serde:
-            from nvfuser import enable_automatic_serialization
-
-            # Turn on default serialization upon program exit
-            enable_automatic_serialization()
-
-        # Automatically load common workplace
-        fc = FusionCache.get()
-        # Clear FusionCache because the tests expect a new fusion to be generated.
-        FusionCache.reset()
+        atexit_serde_check()
 
         create_op_test.__init__(self, opinfos, scope=scope)

--- a/tests/python/pytest_framework.py
+++ b/tests/python/pytest_framework.py
@@ -58,3 +58,25 @@ class create_op_test:
                 )
                 # Adds the instantiated test to the requested scope
                 self.scope[test.__name__] = test
+
+
+# This pseudo-decorator enables automatic serialization upon program exit and
+# tests deserializing the default workspace upon creating the tests. Do not
+# apply to the error testing functions that can corrupt the FusionCache.
+class atexit_serde_create_op_test(create_op_test):
+    def __init__(self, opinfos, *, scope=None):
+        from utils import debug_serde
+        from nvfuser import FusionCache
+
+        if not debug_serde:
+            from nvfuser import enable_automatic_serialization
+
+            # Turn on default serialization upon program exit
+            enable_automatic_serialization()
+
+        # Automatically load common workplace
+        fc = FusionCache.get()
+        # Clear FusionCache because the tests expect a new fusion to be generated.
+        FusionCache.reset()
+
+        create_op_test.__init__(self, opinfos, scope=scope)

--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 
 from benchmarks.python.core import clear_cuda_cache
 from pytest_fusion_definitions import default_fd_fn, parse_inputs_fusion_definition
-from pytest_framework import create_op_test
+from pytest_framework import create_op_test, atexit_serde_create_op_test
 from pytest_core import ReferenceType, OpInfo, SampleInput
 from pytest_opinfos import opinfos
 from pytest_utils import ArgumentType, is_tensor, requiresJAX
@@ -199,7 +199,9 @@ def serde_test_fn(op: OpInfo, dtype: torch.dtype):
             return result
 
 
-@create_op_test(tuple(op for op in opinfos if op.sample_input_generator is not None))
+@atexit_serde_create_op_test(
+    tuple(op for op in opinfos if op.sample_input_generator is not None)
+)
 def test_correctness(op: OpInfo, dtype: torch.dtype):
     return serde_test_fn(op, dtype)
 

--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -23,9 +23,10 @@ from utils import check_captured_python_definition, debug_serde, basic_serde_che
 
 def serde_check(test_fn: Callable):
     """
-    A decorator to verify that serialization works with the given exec_nvfuser
-    function. Currently, it uses serialization to rebuild the FusionCache
-    structure.
+    The pytest framework decorator only checks per-operator and per-dtype.
+    It doesn't check every single sample input. We check more input variations
+    in the pytest benchmarks than test_python_frontend.py. This is a timesaving
+    measure.
     """
 
     def inner_fn(*args, **kwargs):

--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -18,10 +18,10 @@ from typing import Callable
 
 from nvfuser import FusionCache, FusionDefinition
 
-from utils import check_captured_python_definition, debug_serde, basic_serde_check
+from utils import check_captured_python_definition, debug_serde, basic_serde_check_ops
 
 
-def serde_check(test_fn: Callable):
+def serde_check_ops(test_fn: Callable):
     """
     The pytest framework decorator only checks per-operator and per-dtype.
     It doesn't check every single sample input. We check more input variations
@@ -191,7 +191,7 @@ def correctness_test_fn(
 
 
 # Run serde check for each operation and dtype but not for each sample input.
-@serde_check
+@serde_check_ops
 def serde_test_fn(op: OpInfo, dtype: torch.dtype):
     clear_cuda_cache()
     for sample in op.sample_input_generator(op, dtype):

--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -17,8 +17,6 @@ from typing import Callable
 
 from nvfuser import FusionCache, FusionDefinition
 
-from utils import is_pre_volta
-
 
 def parse_args_fusion_execution(opinfo: OpInfo, *args):
     if len(args) == 0:

--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -17,10 +17,7 @@ from typing import Callable
 
 from nvfuser import FusionCache, FusionDefinition
 
-
-def is_pre_volta():
-    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return prop.major < 7
+from utils import is_pre_volta
 
 
 def parse_args_fusion_execution(opinfo: OpInfo, *args):

--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -18,7 +18,7 @@ from typing import Callable
 
 from nvfuser import FusionCache, FusionDefinition
 
-from utils import check_captured_python_definition, debug_serde, basic_serde_check_ops
+from utils import check_captured_python_definition, debug_serde, basic_serde_check
 
 
 def serde_check_ops(test_fn: Callable):

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -138,6 +138,8 @@ class TestNvFuserFrontend(TestCase):
     ):
         fc = FusionCache.get()
         before_fusions = fc.num_fusions()
+        # Copy inputs because aliased outputs can modify inputs when running
+        # FusionDefinition
         inputs_cap = deepcopy(inputs)
 
         # Execute a fusion function and capture the string python definition

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -31,8 +31,12 @@ from nvfuser import (
 )
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 
-from utils import check_captured_python_definition
-
+from utils import (
+    is_pre_volta,
+    is_pre_ampere,
+    is_pre_hopper,
+    check_captured_python_definition,
+)
 
 RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
 
@@ -49,27 +53,6 @@ RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
 # Normally, these files are deleted after each test.
 env_var_debug_serde = os.getenv("DEBUG_SERDE")
 debug_serde: bool = env_var_debug_serde in ("true", "1")
-
-
-def is_pre_volta():
-    if not RUN_NVFUSER:
-        return False
-    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return prop.major < 7
-
-
-def is_pre_ampere():
-    if not RUN_NVFUSER:
-        return False
-    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return prop.major < 8
-
-
-def is_pre_hopper():
-    if not RUN_NVFUSER:
-        return False
-    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return prop.major < 9
 
 
 def setUpModule():

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -145,11 +145,9 @@ class TestNvFuserFrontend(TestCase):
             fusion_func(fd)
         torch.manual_seed(0)
         out = fd.execute(inputs, device=device)
-        out_cap = check_captured_python_definition(fd, inputs_cap, device)
 
-        # Make sure the original and captured definitions match
-        for idx in range(len(out)):
-            self.assertEqual(out[idx], out_cap[idx])
+        self.assertTrue(check_captured_python_definition(out, fd, inputs_cap, device))
+
         self.assertEqual(fc.num_fusions() - before_fusions, int(new_fusion_expected))
         return out, fd
 

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -8,10 +8,8 @@ from functools import partial
 import itertools
 import math
 import random
-from typing import List, Callable
-import tempfile
+from typing import List
 import unittest
-import os
 
 import torch
 import torch.nn.functional as F
@@ -36,23 +34,11 @@ from utils import (
     is_pre_ampere,
     is_pre_hopper,
     check_captured_python_definition,
+    serde_check,
+    debug_serde,
 )
 
 RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
-
-# This DEBUG_SERDE environment flag is used to debug serialization failures.
-#
-# 1) It disables automatically saving FusionCache upon program exit. Therefore,
-# it has to be a global flag not per-test.
-#
-# 2) It resets the FusionCache after each test, which is useful for isolating
-# failures. Note, some failures only occur when running multiple tests
-# together and accumulating fusions in the cache.
-#
-# 3) It keeps the temporary files that are created during serde_check.
-# Normally, these files are deleted after each test.
-env_var_debug_serde = os.getenv("DEBUG_SERDE")
-debug_serde: bool = env_var_debug_serde in ("true", "1")
 
 
 def setUpModule():
@@ -66,64 +52,6 @@ def setUpModule():
     fc = FusionCache.get()
     # Clear FusionCache because the tests expect a new fusion to be generated.
     FusionCache.reset()
-
-
-def serde_check(test_fn: Callable):
-    """
-    A decorator to verify that serialization works with the given exec_nvfuser function.
-    Currently, it uses serialization to rebuild the FusionCache structure.
-    """
-
-    def inner_fn(*args, **kwargs):
-        self, fusion_func, inputs = args
-
-        # NOTE: For debug purposes, clear FusionCache before running first test
-        # so the behavior is more deterministic (PR #1848).
-        is_new_fusion_expected = kwargs.get("new_fusion_expected", True)
-        if debug_serde and is_new_fusion_expected:
-            FusionCache.reset()
-            assert FusionCache.get().num_fusions() == 0
-
-        # skip_serde_check is only used by the decorator so remove it before running test_fn
-        skip_serde_check = kwargs.pop("skip_serde_check", False)
-        if skip_serde_check:
-            return test_fn(self, fusion_func, inputs, **kwargs)
-
-        # Run test to populate FusionCache. Deep copy inputs for this run but
-        # not the final run. When a fusion output aliases an input, it will
-        # change the input value for subsequent function calls. Therefore, only
-        # the final run should take the original tensors and potentially update
-        # their values.
-        inputs_copy = deepcopy(inputs)
-        test_fn(self, fusion_func, inputs_copy, **kwargs)
-
-        # If DEBUG_SERDE is enabled, the temporary file is not deleted automatically
-        with tempfile.NamedTemporaryFile(delete=(not debug_serde)) as tmp:
-            try:
-                # Serialize FusionCache
-                fc = FusionCache.get()
-                fc.serialize(tmp.name)
-
-                FusionCache.reset()
-
-                # Get new FusionCache because the previous one was destroyed by the reset call.
-                fc = FusionCache.get()
-                fc.deserialize(tmp.name)
-            except Exception as e:
-                if debug_serde:
-                    raise RuntimeError(
-                        f"***** {tmp.name} contains the serialized binary for this failure."
-                    )
-                else:
-                    raise RuntimeError(
-                        "***** Use DEBUG_SERDE=true to debug serialization failure."
-                    )
-
-        # Run test with repopulated FusionCache
-        kwargs["new_fusion_expected"] = False
-        return test_fn(self, fusion_func, inputs, **kwargs)
-
-    return inner_fn
 
 
 @unittest.skipIf(not RUN_NVFUSER, "requires CUDA")

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -8,7 +8,7 @@ from functools import partial
 import itertools
 import math
 import random
-from typing import List
+from typing import List, Callable
 import unittest
 
 import torch
@@ -34,11 +34,52 @@ from utils import (
     is_pre_ampere,
     is_pre_hopper,
     check_captured_python_definition,
-    serde_check,
+    basic_serde_check,
     debug_serde,
 )
 
 RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
+
+
+def serde_check(test_fn: Callable):
+    """
+    A decorator to verify that serialization works with the given exec_nvfuser
+    function. Currently, it uses serialization to rebuild the FusionCache
+    structure.
+    """
+
+    def inner_fn(*args, **kwargs):
+        self, fusion_func, inputs = args
+
+        # NOTE: For debug purposes, clear FusionCache before running first test
+        # so the behavior is more deterministic (PR #1848).
+        is_new_fusion_expected = kwargs.get("new_fusion_expected", True)
+        if debug_serde and is_new_fusion_expected:
+            FusionCache.reset()
+            assert FusionCache.get().num_fusions() == 0
+
+        # skip_serde_check is only used by the decorator so remove it before
+        # running test_fn
+        skip_serde_check = kwargs.pop("skip_serde_check", False)
+        if skip_serde_check:
+            return test_fn(self, fusion_func, inputs, **kwargs)
+
+        # Run test to populate FusionCache. Deep copy inputs for this run but
+        # not the final run. When a fusion output aliases an input, it will
+        # change the input value for subsequent function calls. Therefore, only
+        # the final run should take the original tensors and potentially update
+        # their values.
+        inputs_copy = deepcopy(inputs)
+        test_fn(self, fusion_func, inputs_copy, **kwargs)
+
+        # Serialize and Deserialize FusionCache
+        basic_serde_check()
+
+        # Run test with repopulated FusionCache
+        kwargs["new_fusion_expected"] = False
+        return test_fn(self, fusion_func, inputs, **kwargs)
+
+    return inner_fn
 
 
 def setUpModule():

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -83,16 +83,9 @@ def serde_check(test_fn: Callable):
 
 
 def setUpModule():
-    if not debug_serde:
-        from nvfuser import enable_automatic_serialization
+    from utils import atexit_serde_check
 
-        # Turn on default serialization upon program exit
-        enable_automatic_serialization()
-
-    # Automatically load common workplace
-    fc = FusionCache.get()
-    # Clear FusionCache because the tests expect a new fusion to be generated.
-    FusionCache.reset()
+    atexit_serde_check()
 
 
 @unittest.skipIf(not RUN_NVFUSER, "requires CUDA")

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -6,7 +6,9 @@
 import torch
 from torch.testing._internal.common_utils import TEST_WITH_ROCM
 from torch.testing._internal.jit_utils import RUN_CUDA
-from nvfuser import FusionDefinition
+
+# flake8: noqa
+from nvfuser import FusionDefinition, DataType
 
 RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
 

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -4,7 +4,29 @@
 # Owner(s): ["module: nvfuser"]
 
 import torch
-from nvfuser import (FusionDefinition, DataType)
+from nvfuser import FusionDefinition, DataType
+
+
+def is_pre_volta():
+    if not RUN_NVFUSER:
+        return False
+    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return prop.major < 7
+
+
+def is_pre_ampere():
+    if not RUN_NVFUSER:
+        return False
+    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return prop.major < 8
+
+
+def is_pre_hopper():
+    if not RUN_NVFUSER:
+        return False
+    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return prop.major < 9
+
 
 def check_captured_python_definition(fd, inputs, device):
     import re

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# Owner(s): ["module: nvfuser"]
+
+import torch
+from nvfuser import (FusionDefinition, DataType)
+
+def check_captured_python_definition(fd, inputs, device):
+    import re
+
+    # Execute the python definition that was captured
+    try:
+        fd_str = fd.__repr__()
+        func_name = re.findall("(nvfuser_fusion_id\\d+)", fd_str.split("\n")[1])[0]
+        exec(fd_str)
+        with FusionDefinition() as fd_cap:
+            eval(func_name)(fd_cap)
+        torch.manual_seed(0)
+        return fd_cap.execute(inputs, device=device)
+    except Exception as err:
+        print("\nException For Printed FusionDefinition:")
+        print(
+            "(A failure here suggests a mismatch in functionality between the original definition and the printed definition.)"
+        )
+        print(fd_str)
+        raise err

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -116,3 +116,23 @@ def basic_serde_check():
                 raise RuntimeError(
                     "***** Use DEBUG_SERDE=true to debug serialization failure."
                 )
+
+
+# Enable automatic serialization upon program exit and test deserializing the
+# default workspace. NOTE: Serializing error test cases corrupts the serialized
+# binary. Call FusionCache.reset() to clear the cache after running an error
+# test in `test_python_frontend.py'.
+def atexit_serde_check():
+    from utils import debug_serde
+    from nvfuser import FusionCache
+
+    if not debug_serde:
+        from nvfuser import enable_automatic_serialization
+
+        # Turn on default serialization upon program exit
+        enable_automatic_serialization()
+
+    # Automatically load common workplace
+    fc = FusionCache.get()
+    # Clear FusionCache because the tests expect a new fusion to be generated.
+    FusionCache.reset()

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -87,6 +87,10 @@ env_var_debug_serde = os.getenv("DEBUG_SERDE")
 debug_serde: bool = env_var_debug_serde in ("true", "1")
 
 
+# The pytest framework and test_python_frontend.py use different arguments for
+# testing, so we need specific `serde_check` decorators for both frameworks.
+# basic_serde_check is the common part between them. It serializes the cache,
+# deletes it, and then deserialized to recreate the cache.
 def basic_serde_check():
     # If DEBUG_SERDE is enabled, the temporary file is not deleted
     # automatically

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -3,12 +3,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Owner(s): ["module: nvfuser"]
 
+import os
+from copy import deepcopy
+from typing import Callable
+import tempfile
+
 import torch
 from torch.testing._internal.common_utils import TEST_WITH_ROCM
 from torch.testing._internal.jit_utils import RUN_CUDA
 
 # flake8: noqa
-from nvfuser import FusionDefinition, DataType
+from nvfuser import FusionCache, FusionDefinition, DataType
 
 RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
 
@@ -65,3 +70,76 @@ def check_captured_python_definition(reference_outputs, fd, inputs, device=None)
         )
         print(fd_str)
         raise err
+
+
+# This DEBUG_SERDE environment flag is used to debug serialization failures.
+#
+# 1) It disables automatically saving FusionCache upon program exit. Therefore,
+# it has to be a global flag not per-test.
+#
+# 2) It resets the FusionCache after each test, which is useful for isolating
+# failures. Note, some failures only occur when running multiple tests
+# together and accumulating fusions in the cache.
+#
+# 3) It keeps the temporary files that are created during serde_check.
+# Normally, these files are deleted after each test.
+env_var_debug_serde = os.getenv("DEBUG_SERDE")
+debug_serde: bool = env_var_debug_serde in ("true", "1")
+
+
+def serde_check(test_fn: Callable):
+    """
+    A decorator to verify that serialization works with the given exec_nvfuser function.
+    Currently, it uses serialization to rebuild the FusionCache structure.
+    """
+
+    def inner_fn(*args, **kwargs):
+        self, fusion_func, inputs = args
+
+        # NOTE: For debug purposes, clear FusionCache before running first test
+        # so the behavior is more deterministic (PR #1848).
+        is_new_fusion_expected = kwargs.get("new_fusion_expected", True)
+        if debug_serde and is_new_fusion_expected:
+            FusionCache.reset()
+            assert FusionCache.get().num_fusions() == 0
+
+        # skip_serde_check is only used by the decorator so remove it before running test_fn
+        skip_serde_check = kwargs.pop("skip_serde_check", False)
+        if skip_serde_check:
+            return test_fn(self, fusion_func, inputs, **kwargs)
+
+        # Run test to populate FusionCache. Deep copy inputs for this run but
+        # not the final run. When a fusion output aliases an input, it will
+        # change the input value for subsequent function calls. Therefore, only
+        # the final run should take the original tensors and potentially update
+        # their values.
+        inputs_copy = deepcopy(inputs)
+        test_fn(self, fusion_func, inputs_copy, **kwargs)
+
+        # If DEBUG_SERDE is enabled, the temporary file is not deleted automatically
+        with tempfile.NamedTemporaryFile(delete=(not debug_serde)) as tmp:
+            try:
+                # Serialize FusionCache
+                fc = FusionCache.get()
+                fc.serialize(tmp.name)
+
+                FusionCache.reset()
+
+                # Get new FusionCache because the previous one was destroyed by the reset call.
+                fc = FusionCache.get()
+                fc.deserialize(tmp.name)
+            except Exception as e:
+                if debug_serde:
+                    raise RuntimeError(
+                        f"***** {tmp.name} contains the serialized binary for this failure."
+                    )
+                else:
+                    raise RuntimeError(
+                        "***** Use DEBUG_SERDE=true to debug serialization failure."
+                    )
+
+        # Run test with repopulated FusionCache
+        kwargs["new_fusion_expected"] = False
+        return test_fn(self, fusion_func, inputs, **kwargs)
+
+    return inner_fn

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -87,59 +87,28 @@ env_var_debug_serde = os.getenv("DEBUG_SERDE")
 debug_serde: bool = env_var_debug_serde in ("true", "1")
 
 
-def serde_check(test_fn: Callable):
-    """
-    A decorator to verify that serialization works with the given exec_nvfuser function.
-    Currently, it uses serialization to rebuild the FusionCache structure.
-    """
+def basic_serde_check():
+    # If DEBUG_SERDE is enabled, the temporary file is not deleted
+    # automatically
+    with tempfile.NamedTemporaryFile(delete=(not debug_serde)) as tmp:
+        try:
+            # Serialize FusionCache
+            fc = FusionCache.get()
+            fc.serialize(tmp.name)
 
-    def inner_fn(*args, **kwargs):
-        self, fusion_func, inputs = args
-
-        # NOTE: For debug purposes, clear FusionCache before running first test
-        # so the behavior is more deterministic (PR #1848).
-        is_new_fusion_expected = kwargs.get("new_fusion_expected", True)
-        if debug_serde and is_new_fusion_expected:
             FusionCache.reset()
-            assert FusionCache.get().num_fusions() == 0
 
-        # skip_serde_check is only used by the decorator so remove it before running test_fn
-        skip_serde_check = kwargs.pop("skip_serde_check", False)
-        if skip_serde_check:
-            return test_fn(self, fusion_func, inputs, **kwargs)
-
-        # Run test to populate FusionCache. Deep copy inputs for this run but
-        # not the final run. When a fusion output aliases an input, it will
-        # change the input value for subsequent function calls. Therefore, only
-        # the final run should take the original tensors and potentially update
-        # their values.
-        inputs_copy = deepcopy(inputs)
-        test_fn(self, fusion_func, inputs_copy, **kwargs)
-
-        # If DEBUG_SERDE is enabled, the temporary file is not deleted automatically
-        with tempfile.NamedTemporaryFile(delete=(not debug_serde)) as tmp:
-            try:
-                # Serialize FusionCache
-                fc = FusionCache.get()
-                fc.serialize(tmp.name)
-
-                FusionCache.reset()
-
-                # Get new FusionCache because the previous one was destroyed by the reset call.
-                fc = FusionCache.get()
-                fc.deserialize(tmp.name)
-            except Exception as e:
-                if debug_serde:
-                    raise RuntimeError(
-                        f"***** {tmp.name} contains the serialized binary for this failure."
-                    )
-                else:
-                    raise RuntimeError(
-                        "***** Use DEBUG_SERDE=true to debug serialization failure."
-                    )
-
-        # Run test with repopulated FusionCache
-        kwargs["new_fusion_expected"] = False
-        return test_fn(self, fusion_func, inputs, **kwargs)
-
-    return inner_fn
+            # Get new FusionCache because the previous one was destroyed by
+            # the reset call.
+            fc = FusionCache.get()
+            assert fc.num_fusions() == 0
+            fc.deserialize(tmp.name)
+        except Exception as e:
+            if debug_serde:
+                raise RuntimeError(
+                    f"***** {tmp.name} contains the serialized binary for this failure."
+                )
+            else:
+                raise RuntimeError(
+                    "***** Use DEBUG_SERDE=true to debug serialization failure."
+                )


### PR DESCRIPTION
This PR adds a serialization check to the pytest opinfo framework.

Details:
- The pytest framework `serde_check` only checks per-operator and per-dtype. It doesn't check every single sample input. We check more input variations in the pytest benchmarks than `test_python_frontend.py`. This is a timesaving measure.
- Creates `atexit_serde_create_op_test` pseudo decorator to test automatic serialization. Serializing error test cases embeds errors in the serialized binary. Normally, we call `FusionCache.reset()` to clear the cache after running an error test. In the pytest framework, the error tests are separate from the correctness tests. We use this decorator to apply this to the correctness tests.
- The pytest framework and `test_python_frontend.py` use different arguments. `basic_serde_check` is the common part between them. It serializes the cache, deletes it, and then deserialized to recreate the cache. 
