### PR TITLE
Cast tensors to fp64 for torch.allclose

### DIFF
--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -48,9 +48,14 @@ def check_captured_python_definition(reference_outputs, fd, inputs, device=None)
         torch.manual_seed(0)
         captured_outputs = fd_cap.execute(inputs, device=device)
         # Make sure the original and captured definitions match
+        # torch.allclose does not work with fp8 datatype, so cast to fp64.
         return all(
             [
-                torch.allclose(ref_out, captured_outputs[idx], equal_nan=True)
+                torch.allclose(
+                    ref_out.to(torch.float64),
+                    captured_outputs[idx].to(torch.float64),
+                    equal_nan=True,
+                )
                 for idx, ref_out in enumerate(reference_outputs)
             ]
         )


### PR DESCRIPTION
`torch.allclose` does not support fp8 datatypes. The fix is to cast nvfuser result and torch reference to fp64.

Failing Test:
```
# Failed tests (if any)
### [jit_python_tests_17_H100] TestNvFuserFrontend.test_cast_fp8

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/torch/testing/_internal/common_utils.py", line 2918, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/nvfuser/tests/python/test_python_frontend.py", line 216, in test_cast_fp8
    fn(type0, type1)
  File "/opt/pytorch/nvfuser/tests/python/test_python_frontend.py", line 210, in fn
    nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
  File "/opt/pytorch/nvfuser/tests/python/test_python_frontend.py", line 80, in inner_fn
    test_fn(self, fusion_func, inputs_copy, **kwargs)
  File "/opt/pytorch/nvfuser/tests/python/test_python_frontend.py", line 114, in exec_nvfuser
    self.assertTrue(check_captured_python_definition(out, fd, inputs_cap, device))
  File "/opt/pytorch/nvfuser/tests/python/utils.py", line 63, in check_captured_python_definition
    raise err
  File "/opt/pytorch/nvfuser/tests/python/utils.py", line 52, in check_captured_python_definition
    [
  File "/opt/pytorch/nvfuser/tests/python/utils.py", line 53, in <listcomp>
    torch.allclose(ref_out, captured_outputs[idx], equal_nan=True)
RuntimeError: "mul_cuda" not implemented for 'Float8_e4m3fn'

To execute this test, run the following from the base repo dir:
    python test_python_frontend.py -k TestNvFuserFrontend.test_cast_fp8
```