### PR TITLE
Run user-scheduled fusions with input arguments on different devices.

### DIFF
--- a/csrc/python_frontend/fusion_cache.cpp
+++ b/csrc/python_frontend/fusion_cache.cpp
@@ -471,7 +471,7 @@ const UserSchedule& FusionCache::queryUserSchedule(
   return user_sched->second.at(device);
 }
 
-bool FusionCache::existsUserSchedule(
+bool FusionCache::existUserSchedule(
     const FusionSchedules* scheds,
     const at::ArrayRef<c10::IValue>& inputs,
     int device) {

--- a/csrc/python_frontend/fusion_cache.h
+++ b/csrc/python_frontend/fusion_cache.h
@@ -190,7 +190,7 @@ class FusionCache {
   //! Query a Fusion's Schedules based on fusion id or cache id
   FusionSchedules* queryFusionSchedules(size_t fusion_id) const;
   //! Determine if a user schedule exists for given inputs.
-  bool existsUserSchedule(
+  bool existUserSchedule(
       const FusionSchedules* scheds,
       const at::ArrayRef<c10::IValue>& inputs,
       int device);

--- a/csrc/python_frontend/fusion_cache.h
+++ b/csrc/python_frontend/fusion_cache.h
@@ -189,6 +189,11 @@ class FusionCache {
       RecordFunctor* rec) const;
   //! Query a Fusion's Schedules based on fusion id or cache id
   FusionSchedules* queryFusionSchedules(size_t fusion_id) const;
+  //! Determine if a user schedule exists for given inputs.
+  bool existsUserSchedule(
+      const FusionSchedules* scheds,
+      const at::ArrayRef<c10::IValue>& inputs,
+      int device);
   //! Lookup the User Schedule Id and return null if one does not exist.
   //! NOTE: this method cannot be const because the InputsIdLookup can
   //! cause a modification to that data member for cache eviction.

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -105,6 +105,9 @@ void FusionDefinition::finalizeDefinition() {
     trie_node_ = child_node.value();
     fusion_id_ = std::optional<size_t>(trie_node_->fusion_id);
   }
+
+  NVF_ERROR(num_recording_states_presched_ == 0);
+  num_recording_states_presched_ = recording_state_.size();
 }
 
 void FusionDefinition::findHiddenTensorViews(Fusion* fusion) {
@@ -194,8 +197,6 @@ void FusionDefinition::setupSchedule(const at::ArrayRef<c10::IValue>& inputs) {
   // members that represent tensors would refer to the IR objects in the
   // original and not the copy needed for scheduling.
   buildFusionIr(user_sched_->schedule.get());
-  NVF_ERROR(num_recording_states_presched_ == 0);
-  num_recording_states_presched_ = recording_state_.size();
 
   // Add TensorViews created by composite operations to Python FusionDefinition.
   findHiddenTensorViews(user_sched_->schedule.get());
@@ -250,7 +251,6 @@ void FusionDefinition::finalizeSchedule(
   for (size_t rnd = 0; rnd < num_states_to_remove; ++rnd) {
     recording_state_.pop_back();
   }
-  num_recording_states_presched_ = 0;
 }
 
 void FusionDefinition::print(std::ostream& os) const {

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -107,7 +107,7 @@ void FusionDefinition::finalizeDefinition() {
   }
 
   NVF_ERROR(num_recording_states_presched_ == 0);
-  num_recording_states_presched_ = recording_state_.size();
+  num_recording_states_presched_ = (int64_t)recording_state_.size();
 }
 
 void FusionDefinition::findHiddenTensorViews(Fusion* fusion) {

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -192,6 +192,7 @@ void FusionDefinition::setupSchedule(const at::ArrayRef<c10::IValue>& inputs) {
   NVF_CHECK(
       inputs.empty() || device > -1, "Inputs are not all on the same device!");
 
+  // NOTE: Clear user schedule state in setupSchedule.
   // Scheduling the fusion can add states to recording_state.
   // Remove any schedule-only states before applying new schedule.
   size_t num_states_to_remove =
@@ -253,6 +254,9 @@ void FusionDefinition::finalizeSchedule(
   FusionGuard::setCurFusion(prev_fusion_);
   user_sched_->runtime_info.reset();
   prev_fusion_ = nullptr;
+
+  // NOTE: Clear user schedule state in setupSchedule.
+  // Users can access schedule objects after scheduling the fusion.
 }
 
 void FusionDefinition::print(std::ostream& os) const {

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -247,7 +247,7 @@ void FusionDefinition::finalizeSchedule(
   // Remove the schedule-only states.
   size_t num_states_to_remove =
       recording_state_.size() - num_recording_states_presched_;
-  for (size_t _ : c10::irange(num_states_to_remove)) {
+  for (size_t rnd = 0; rnd < num_states_to_remove; ++rnd) {
     recording_state_.pop_back();
   }
   num_recording_states_presched_ = 0;

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -253,7 +253,6 @@ void FusionDefinition::finalizeSchedule(
   FusionGuard::setCurFusion(prev_fusion_);
   user_sched_->runtime_info.reset();
   prev_fusion_ = nullptr;
-  user_sched_ = nullptr;
 }
 
 void FusionDefinition::print(std::ostream& os) const {

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -171,6 +171,9 @@ class NVF_API FusionDefinition : public FusionState {
   //! Exit Python Context Manager -- Triggers Fusion IR build if it is not
   //! cached
   NVF_API void finalizeDefinition();
+  //! Check that a user schedule exists for FusionDefinition and input
+  //! arguments on device.
+  NVF_API bool existsSchedule(const at::ArrayRef<c10::IValue>& inputs);
   //! Setup user scheduling of a fusion
   //! Copies fusion object and sets up FusionGuard
   NVF_API void setupSchedule(const at::ArrayRef<c10::IValue>& inputs);

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -173,7 +173,7 @@ class NVF_API FusionDefinition : public FusionState {
   NVF_API void finalizeDefinition();
   //! Check that a user schedule exists for FusionDefinition and input
   //! arguments on device.
-  NVF_API bool existsSchedule(const at::ArrayRef<c10::IValue>& inputs);
+  NVF_API bool existSchedule(const at::ArrayRef<c10::IValue>& inputs);
   //! Setup user scheduling of a fusion
   //! Copies fusion object and sets up FusionGuard
   NVF_API void setupSchedule(const at::ArrayRef<c10::IValue>& inputs);

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -281,6 +281,8 @@ class NVF_API FusionDefinition : public FusionState {
   Fusion* prev_fusion_;
   //! Data member for holding the current user schedule object
   UserSchedule* user_sched_;
+  //! Number of recording_states_ before applying user schedule
+  int64_t num_recording_states_presched_ = 0;
 
  public:
   //! The Operators are not directly defined in this header.  They are defined

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -652,13 +652,13 @@ void initNvFuserPythonBindings(PyObject* module) {
             inst::Trace::instance()->endEvent(nullptr);
           })
       .def(
-          "_exists_schedule",
+          "_exist_schedule",
           [](FusionDefinition& self, const py::iterable& iter) {
             std::vector<c10::IValue> inputs;
             for (py::handle obj : iter) {
               inputs.push_back(torch::jit::toIValue(obj, c10::AnyType::get()));
             }
-            self.existsSchedule(inputs);
+            self.existSchedule(inputs);
           })
       .def(
           "_setup_schedule",

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -652,6 +652,15 @@ void initNvFuserPythonBindings(PyObject* module) {
             inst::Trace::instance()->endEvent(nullptr);
           })
       .def(
+          "_exists_schedule",
+          [](FusionDefinition& self, const py::iterable& iter) {
+            std::vector<c10::IValue> inputs;
+            for (py::handle obj : iter) {
+              inputs.push_back(torch::jit::toIValue(obj, c10::AnyType::get()));
+            }
+            self.existsSchedule(inputs);
+          })
+      .def(
           "_setup_schedule",
           [](FusionDefinition& self, const py::iterable& iter) {
             // Instrumentation to mark the beginning of a schedule

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -202,10 +202,16 @@ class FusionDefinition(_C._FusionDefinition):
             self.definition()
             self._finalize_definition()
 
-        # If schedule is defined by child class, make a schedule for inputs
-        if not self._exists_schedule(inputs) and (
-            super(type(self), self).schedule != self.schedule
-        ):
+        # If schedule is defined by child class and schedule is not defined for
+        # inputs, make a schedule.
+        is_fusion_definition_child_class = (
+            type(self) != FusionDefinition
+        ) and issubclass(type(self), FusionDefinition)
+        defined_schedule = (
+            is_fusion_definition_child_class
+            and super(type(self), self).schedule != self.schedule
+        )
+        if defined_schedule and not self._exists_schedule(inputs):
             self._setup_schedule(inputs)
             self.schedule()
             self._finalize_schedule(inputs)

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -211,7 +211,7 @@ class FusionDefinition(_C._FusionDefinition):
             is_fusion_definition_child_class
             and super(type(self), self).schedule != self.schedule
         )
-        if defined_schedule and not self._exists_schedule(inputs):
+        if defined_schedule and not self._exist_schedule(inputs):
             self._setup_schedule(inputs)
             self.schedule()
             self._finalize_schedule(inputs)

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -186,7 +186,6 @@ class FusionDefinition(_C._FusionDefinition):
         Returns:
             List[Tensor]
         """
-        func_based_def = False
         self.profiled = profile
 
         if device is not None:
@@ -202,10 +201,12 @@ class FusionDefinition(_C._FusionDefinition):
             self._setup_definition()
             self.definition()
             self._finalize_definition()
-            func_based_def = True
 
         # If schedule is defined by child class, make a schedule for inputs
-        if func_based_def and (super(type(self), self).schedule != self.schedule):
+        if self._exists_schedule(inputs) and (
+            super(type(self), self).schedule != self.schedule
+        ):
+            print("here")
             self._setup_schedule(inputs)
             self.schedule()
             self._finalize_schedule(inputs)

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -203,10 +203,9 @@ class FusionDefinition(_C._FusionDefinition):
             self._finalize_definition()
 
         # If schedule is defined by child class, make a schedule for inputs
-        if self._exists_schedule(inputs) and (
+        if not self._exists_schedule(inputs) and (
             super(type(self), self).schedule != self.schedule
         ):
-            print("here")
             self._setup_schedule(inputs)
             self.schedule()
             self._finalize_schedule(inputs)

--- a/tests/python/test_schedule_ops.py
+++ b/tests/python/test_schedule_ops.py
@@ -7,7 +7,8 @@ from typing import Callable
 import unittest
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_ROCM, TestCase
+from utils import is_pre_volta, is_pre_hopper
+from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.jit_utils import RUN_CUDA
 
 from nvfuser import (
@@ -25,22 +26,6 @@ all_scheduler_heuristics = [
     for heuristic, _ in SchedulerHeuristic.__entries.values()
     if not SchedulerHeuristic.none
 ]
-
-RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM
-
-
-def is_pre_volta():
-    if not RUN_NVFUSER:
-        return False
-    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return prop.major < 7
-
-
-def is_pre_hopper():
-    if not RUN_NVFUSER:
-        return False
-    prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return prop.major < 9
 
 
 # A helper function to test heuristic schedulers with user schedules
@@ -70,7 +55,7 @@ def _apply_scheduler_helper(schedule, selected_heuristic):
     schedule.schedule(selected_heuristic)
 
 
-@unittest.skipIf(not RUN_NVFUSER, "requires CUDA")
+@unittest.skipIf(not RUN_CUDA, "requires CUDA")
 @unittest.skipIf(is_pre_volta(), "Only supported on Volta and newer devices.")
 class TestScheduleOps(TestCase):
     def sched_op_in_definition_error(self, sched_op_fn: Callable):

--- a/tests/python/test_schedule_ops.py
+++ b/tests/python/test_schedule_ops.py
@@ -1102,6 +1102,7 @@ class TestScheduleOps(TestCase):
         torch_ref = torch.abs(inputs[0]).reshape(inputs[1].shape) + inputs[1]
         self.assertEqual(nvf_out[0], torch_ref)
 
+    @unittest.skipIf(torch.cuda.device_count() < 2, "More than 1 GPU required")
     def test_inputs_with_different_devices(self):
         """
         Test case for issue 2056. Run the same fusion definition with inputs on

--- a/tests/python/test_schedule_ops.py
+++ b/tests/python/test_schedule_ops.py
@@ -1125,13 +1125,17 @@ class TestScheduleOps(TestCase):
         inputs = [
             torch.randn(8, 8, 8, dtype=torch.float32, device="cuda:0"),
         ]
-        fd.execute(inputs)
+        torch_ref = inputs[0].sum(-1)
+        nvf_out = fd.execute(inputs)
+        self.assertEqual(nvf_out[0], torch_ref)
 
         # execute with device 1
         inputs = [
             torch.randn(8, 8, 8, dtype=torch.float32, device="cuda:1"),
         ]
+        torch_ref = inputs[0].sum(-1)
         fd.execute(inputs)
+        self.assertEqual(nvf_out[0], torch_ref)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes issue #2056.

In the python frontend, user scheduled fusions are cached based on their input arguments and cuda device. Currently, we cannot run a user-scheduled fusion with inputs on a multiple device.

Proposed fix:
1. Check if a user-schedule fusion exists for given input arguments and device. The associated functions are `FusionCache::existsUserSchedule` and `FusionDefinition::existsSchedule`.
2. If not, create a new user schedule.

Secondary Issues:
- We are now calling `setupSchedule` and `finalizeSchedule` for each new `UserSchedule`. During scheduling, new tensors are created and added to the `FusionDefinition`. These schedule-only tensors must be removed in `setupSchedule` prior to scheduling the fusion.
- To address this, we track the number of recording states in prescheduled fusion. Then, pop the schedule-only states in `setupSchedule`.