### PR TITLE
Fallback to stop in ForLoop::simplifiedStop

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4671,12 +4671,9 @@ Val* ForLoop::step() const {
 
 Val* ForLoop::simplifiedStop() const {
   if (simplified_stop_ == nullptr) {
-    if (stop()->isConstScalar()) {
-      simplified_stop_ = stop();
-    } else {
-      simplified_stop_ =
-          GpuLower::current()->commonScalarMap().hoistScalar(stop(), {});
-    }
+    simplified_stop_ = (stop()->isConstScalar())
+        ? stop()
+        : GpuLower::current()->commonScalarMap().hoistScalar(stop(), {});
   }
   return simplified_stop_;
 }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4671,9 +4671,9 @@ Val* ForLoop::step() const {
 
 Val* ForLoop::simplifiedStop() const {
   if (simplified_stop_ == nullptr) {
-    simplified_stop_ = (stop()->isConstScalar())
-        ? stop()
-        : GpuLower::current()->commonScalarMap().hoistScalar(stop(), {});
+    simplified_stop_ = GpuLower::hasCurrent()
+        ? GpuLower::current()->commonScalarMap().hoistScalar(stop(), {})
+        : stop();
   }
   return simplified_stop_;
 }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4719,11 +4719,6 @@ bool ForLoop::isTrivial() const {
     return true;
   }
 
-  // NOTE Remove by using expression simplifier to replace index with constant
-  if (circularBufferLoopStage() == CircularBufferLoopStage::Epilog) {
-    return false;
-  }
-
   // Another extent-1 loop: for (int i = N - 1; i < N; ++i) {
   if (start()->definition() != nullptr &&
       start()->definition()->isA<BinaryOp>() &&


### PR DESCRIPTION
Simple for-loops are used to initialize and invalidate mbarriers. The indexing pass is not used for these operations, so the `simplified_stop_` value is not initialized during lowering. This PR uses the original stop value if `simplified_stop_` is not initialized during lowering.

```cpp
  # mbarrier initialization
  if (hopper::elect_sync()) {
    #pragma unroll
    for(nvfuser_index_t i10 = 0; i10 < number_of_stages; ++i10) {
      mbarrier::init(toSmem((&T3[i10])), 1U);
    }
  }

  // remaining kernel

  // mbarrier invalidation
  if (hopper::elect_sync()) {
    #pragma unroll
    for(nvfuser_index_t i19 = 0; i19 < number_of_stages; ++i19) {
      mbarrier::inval(toSmem((&T3[i19])));
    }
  }
```