### PR TITLE
Communication class refactor

### DIFF
--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -154,28 +154,6 @@ Communication::Communication(
   addInput(in);
   addOutput(out);
   addDataAttribute(type);
-  addDataAttribute(DeviceMesh());
-  addDataAttribute(team);
-  addDataAttribute(root);
-  addDataAttribute(red_op);
-  addDataAttribute(scattered_axis);
-
-  validate();
-}
-
-Communication::Communication(
-    IrBuilderPasskey passkey,
-    CommunicationType type,
-    DeviceMesh mesh,
-    Team team,
-    DeviceIdxType root,
-    RedOpType red_op,
-    int64_t scattered_axis)
-    : Expr(passkey) {
-  NVF_ERROR(mesh.size() > 0, "The mesh size must be greater than 0.");
-
-  addDataAttribute(type);
-  addDataAttribute(mesh);
   addDataAttribute(team);
   addDataAttribute(root);
   addDataAttribute(red_op);

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -61,21 +61,6 @@ class Communication : public Expr {
       RedOpType red_op = RedOpType::UNUSED,
       int64_t scattered_axis = -1);
 
-  // Currently, it's only used by CommuniationTest for conciseness. In the
-  // future, it may be used to construct `Communication`s inside a
-  // `PostOnStream`, which if needed can take I/O TVs from the containing
-  // `PostOnStream`.
-  Communication(
-      IrBuilderPasskey passkey,
-      CommunicationType type,
-      DeviceMesh mesh,
-      Team team, // All devices involved in this communication. It must include
-                 // `root`. It can be a subset of `root`+`mesh` in case of 2D
-                 // sharding.
-      DeviceIdxType root = -1,
-      RedOpType red_op = RedOpType::UNUSED,
-      int64_t scattered_axis = -1);
-
   Communication(const Communication& other) = delete;
   Communication& operator=(const Communication& other) = delete;
   Communication(Communication&& other) = delete;
@@ -102,12 +87,11 @@ class Communication : public Expr {
   }
 
   const DeviceMesh& senderMesh() const {
-    return inputs().empty() ? attribute<DeviceMesh>(1) : in()->getDeviceMesh();
+    return in()->getDeviceMesh();
   }
 
   const DeviceMesh& receiverMesh() const {
-    return outputs().empty() ? attribute<DeviceMesh>(1)
-                             : out()->getDeviceMesh();
+    return out()->getDeviceMesh();
   }
 
   const Team& team() const {

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -95,19 +95,19 @@ class Communication : public Expr {
   }
 
   const Team& team() const {
-    return attribute<Team>(2);
+    return attribute<Team>(1);
   }
 
   DeviceIdxType root() const {
-    return attribute<DeviceIdxType>(3);
+    return attribute<DeviceIdxType>(2);
   }
 
   RedOpType reduceOp() const {
-    return attribute<RedOpType>(4);
+    return attribute<RedOpType>(3);
   }
 
   int64_t scatteredAxis() const {
-    return attribute<int64_t>(5);
+    return attribute<int64_t>(4);
   }
 
   // PyTorch's process group expects the root to be specified

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -86,14 +86,6 @@ class Communication : public Expr {
     return input(0)->as<TensorView>();
   }
 
-  const DeviceMesh& senderMesh() const {
-    return in()->getDeviceMesh();
-  }
-
-  const DeviceMesh& receiverMesh() const {
-    return out()->getDeviceMesh();
-  }
-
   const Team& team() const {
     return attribute<Team>(1);
   }

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1151,10 +1151,10 @@ NVFUSER_DEFINE_BINARY_COMPARE_OP(ne, NE)
 // REDUCTION OPERATIONS
 
 // TODO: How do we adjust this so we can reduce to a single scalar value?
-static TensorView* newForReduction(
+TensorView* newForReduction(
     TensorView* tv,
     const std::vector<unsigned int>& axes,
-    DataType data_type = DataType::Null) {
+    DataType data_type) {
   auto orig_domain = TensorDomain::noReductions(tv->getLogicalDomain());
   std::set<unsigned int> axes_set(axes.begin(), axes.end());
 

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -93,6 +93,13 @@ NVF_API TensorView* binaryOp(
     TensorView* v2,
     const TypePromotionConfig& config);
 
+// Return a new TensorView based on tv but with all reduction axes' IterDomain
+// as Reduction
+NVF_API TensorView* newForReduction(
+    TensorView* tv,
+    const std::vector<unsigned int>& axes,
+    DataType data_type = DataType::Null);
+
 // Perform a reduction operation on v1, initial value for reduction is init,
 // reduces across axes, and reduction operation defined by BinaryOp. Reduction
 // of size-1 dimension is automatically converted to squeeze.

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -93,8 +93,7 @@ NVF_API TensorView* binaryOp(
     TensorView* v2,
     const TypePromotionConfig& config);
 
-// Return a new TensorView based on tv but with all reduction axes' IterDomain
-// as Reduction
+// Return a new TensorView consistent with reducing `tv` on specified `axes`
 NVF_API TensorView* newForReduction(
     TensorView* tv,
     const std::vector<unsigned int>& axes,

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -72,7 +72,7 @@ TEST_P(CommunicationTest, Gather) {
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
   auto* out = ops::newValLike(in, in->dtype())->as<TensorView>();
-  auto communication = IrBuilder::create<Communication>(
+  auto* communication = IrBuilder::create<Communication>(
       CommunicationType::Gather, out, in, all_ranks_, kRoot);
 
   at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options);

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -223,9 +223,8 @@ TEST_P(CommunicationTest, SendRecv) {
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
   auto* out = ops::newValLike(in, in->dtype())->as<TensorView>();
-  
   auto communication = IrBuilder::create<Communication>(
-    CommunicationType::SendRecv, out, in, Team({sender, receiver}), sender);
+      CommunicationType::SendRecv, out, in, Team({sender, receiver}), sender);
 
   at::Tensor input_tensor;
   at::Tensor output_tensor;

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -223,8 +223,8 @@ TEST_P(CommunicationTest, SendRecv) {
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
   auto* out = ops::newValLike(in, in->dtype())->as<TensorView>();
+  
   auto communication = IrBuilder::create<Communication>(
-
     CommunicationType::SendRecv, out, in, Team({sender, receiver}), sender);
 
   at::Tensor input_tensor;

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -13,8 +13,8 @@
 #include <multidevice/communicator.h>
 #include <tests/cpp/multidevice.h>
 
-#include <ops/utils.h>
 #include <ops/arith.h>
+#include <ops/utils.h>
 
 #include <iostream>
 
@@ -360,8 +360,13 @@ TEST_P(CommunicationTest, ReduceScatter) {
   in->setDeviceMesh(full_mesh_);
   auto* out = sum(ops::newValLike(in, in->dtype())->as<TensorView>(), {0});
   auto communication = IrBuilder::create<Communication>(
-      CommunicationType::ReduceScatter, out, in, all_ranks_, /*root=*/ -1,
-      kReductionOp, /*scattered_axis=*/ 1);
+      CommunicationType::ReduceScatter,
+      out,
+      in,
+      all_ranks_,
+      /*root=*/ -1,
+      kReductionOp,
+      /*scattered_axis=*/ 1);
 
   const int num_devices = communicator_->size();
   const int device_id = communicator_->deviceId();

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -361,7 +361,7 @@ TEST_P(CommunicationTest, Allreduce) {
 TEST_P(CommunicationTest, ReduceScatter) {
   hir::HostIrContainer container;
   FusionGuard fg(&container);
-  auto* in = makeContigTensor(2);
+  auto* in = makeContigTensor(3);
   in->setDeviceMesh(full_mesh_);
   auto* out = newForReduction(in, {0});
   auto communication = IrBuilder::create<Communication>(

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -294,7 +294,7 @@ TEST_P(CommunicationTest, Reduce) {
   FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
-  auto* out = sum(ops::newValLike(in, in->dtype())->as<TensorView>(), {0});
+  auto* out = newForReduction(in, {0});
   auto communication = IrBuilder::create<Communication>(
       CommunicationType::Reduce, out, in, all_ranks_, kRoot, kReductionOp);
 
@@ -328,9 +328,14 @@ TEST_P(CommunicationTest, Allreduce) {
   FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
-  auto* out = sum(ops::newValLike(in, in->dtype())->as<TensorView>(), {0});
+  auto* out = newForReduction(in, {0});
   auto communication = IrBuilder::create<Communication>(
-      CommunicationType::Allreduce, out, in, all_ranks_, -1, kReductionOp);
+      CommunicationType::Allreduce,
+      out,
+      in,
+      all_ranks_,
+      /*root=*/-1,
+      kReductionOp);
 
   at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options);
   at::Tensor output_tensor = at::empty({kTensorSize}, tensor_options);
@@ -359,7 +364,7 @@ TEST_P(CommunicationTest, ReduceScatter) {
   FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
-  auto* out = sum(ops::newValLike(in, in->dtype())->as<TensorView>(), {0});
+  auto* out = newForReduction(in, {0});
   auto communication = IrBuilder::create<Communication>(
       CommunicationType::ReduceScatter,
       out,

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -224,6 +224,7 @@ TEST_P(CommunicationTest, SendRecv) {
   in->setDeviceMesh(full_mesh_);
   auto* out = ops::newValLike(in, in->dtype())->as<TensorView>();
   auto communication = IrBuilder::create<Communication>(
+
     CommunicationType::SendRecv, out, in, Team({sender, receiver}), sender);
 
   at::Tensor input_tensor;
@@ -364,9 +365,9 @@ TEST_P(CommunicationTest, ReduceScatter) {
       out,
       in,
       all_ranks_,
-      /*root=*/ -1,
+      /*root=*/-1,
       kReductionOp,
-      /*scattered_axis=*/ 1);
+      /*scattered_axis=*/1);
 
   const int num_devices = communicator_->size();
   const int device_id = communicator_->deviceId();

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -14,6 +14,7 @@
 #include <tests/cpp/multidevice.h>
 
 #include <ops/utils.h>
+#include <ops/arith.h>
 
 #include <iostream>
 
@@ -292,7 +293,7 @@ TEST_P(CommunicationTest, Reduce) {
   FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
-  auto* out = ops::newValLike(in, in->dtype())->as<TensorView>();
+  auto* out = sum(ops::newValLike(in, in->dtype())->as<TensorView>(), {0});
   auto communication = IrBuilder::create<Communication>(
       CommunicationType::Reduce, out, in, all_ranks_, kRoot, kReductionOp);
 
@@ -326,7 +327,7 @@ TEST_P(CommunicationTest, Allreduce) {
   FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
-  auto* out = ops::newValLike(in, in->dtype())->as<TensorView>();
+  auto* out = sum(ops::newValLike(in, in->dtype())->as<TensorView>(), {0});
   auto communication = IrBuilder::create<Communication>(
       CommunicationType::Allreduce, out, in, all_ranks_, -1, kReductionOp);
 
@@ -357,9 +358,9 @@ TEST_P(CommunicationTest, ReduceScatter) {
   FusionGuard fg(&container);
   auto* in = makeContigTensor(2);
   in->setDeviceMesh(full_mesh_);
-  auto* out = ops::newValLike(in, in->dtype())->as<TensorView>();
+  auto* out = sum(ops::newValLike(in, in->dtype())->as<TensorView>(), {0});
   auto communication = IrBuilder::create<Communication>(
-      CommunicationType::Allreduce, out, in, all_ranks_, /*root=*/ -1,
+      CommunicationType::ReduceScatter, out, in, all_ranks_, /*root=*/ -1,
       kReductionOp, /*scattered_axis=*/ 1);
 
   const int num_devices = communicator_->size();


### PR DESCRIPTION
This PR removes the second constructor from the Communication class that takes the device mesh. It also updates the CommunicationTest gtests to construct a communication with the other constructor.