### PR TITLE
[Host IRs] fix trailing new line when printing

### DIFF
--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -102,13 +102,12 @@ std::string PostOnStream::toString(int indent_size) const {
   std::for_each(outputs().begin(), outputs().end(), [&ss](auto output) {
     ss << output->toString(0) << ", ";
   });
-  ss << "})";
+  ss << "})" << std::endl;
   return ss.str();
 }
 
-// TODO: implement better ?
 std::string PostOnStream::toInlineString(int indent_size) const {
-  return toString(indent_size);
+  NVF_CHECK(false, "Can not be printed inline");
 }
 
 // TODO: implement
@@ -160,13 +159,13 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(SetCurrentStream)
 
 std::string SetCurrentStream::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << "SetCurrentStream to " << stream()->toString();
+  indent(ss, indent_size) << "SetCurrentStream to " << stream()->toString() << std::endl;
   return ss.str();
 }
 
 // TODO: implement better ?
 std::string SetCurrentStream::toInlineString(int indent_size) const {
-  return toString(indent_size);
+    NVF_CHECK(false, "Cannot be printed inline");
 }
 
 // TODO: implement
@@ -186,14 +185,13 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(Wait)
 
 std::string Wait::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << "Wait Communication " << communication()->name()
-                          << "\n";
+  indent(ss, indent_size) << "Wait Communication " << communication()->name() << std::endl;
   return ss.str();
 }
 
 // TODO: implement better ?
 std::string Wait::toInlineString(int indent_size) const {
-  return toString(indent_size);
+  NVF_CHECK(false, "Cannot be printed inline");
 }
 
 // TODO: implement

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -159,13 +159,14 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(SetCurrentStream)
 
 std::string SetCurrentStream::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << "SetCurrentStream to " << stream()->toString() << std::endl;
+  indent(ss, indent_size) << "SetCurrentStream to " << stream()->toString()
+                          << std::endl;
   return ss.str();
 }
 
 // TODO: implement better ?
 std::string SetCurrentStream::toInlineString(int indent_size) const {
-    NVF_CHECK(false, "Cannot be printed inline");
+  NVF_CHECK(false, "Cannot be printed inline");
 }
 
 // TODO: implement
@@ -185,7 +186,8 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(Wait)
 
 std::string Wait::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << "Wait Communication " << communication()->name() << std::endl;
+  indent(ss, indent_size) << "Wait Communication " << communication()->name()
+                          << std::endl;
   return ss.str();
 }
 

--- a/csrc/ir/iostream.cpp
+++ b/csrc/ir/iostream.cpp
@@ -103,7 +103,7 @@ void IrPrinter::handle(const hir::HostIrContainer* host_ir_container) {
   // host_ir_container body
   indent_size_++;
   for (auto expr : host_ir_container->topLevelExprs()) {
-    os() << expr->toString(indent_size_) << std::endl;
+    os() << expr->toString(indent_size_);
   }
   indent_size_--;
   for (auto* host_unit : ir_utils::filterByType<hir::HostUnit>(


### PR DESCRIPTION
Continuation of https://github.com/NVIDIA/Fuser/pull/2720 to improve printing host IRs and make it more consistent with other parts of nvFuser

- `Expr::toString` should always contain a trailing new line
-  Hence `IrPrinter::handle(const hir::HostIrContainer*)` do not need to add a new line when printing top-level expressions
- `Expr::toInlineString` throw an error, as is commonly done in Fuser in general, e.g., https://github.com/NVIDIA/Fuser/blob/694a156aa4225b957d3d2045f12d10d5d29f5a80/csrc/ir/nodes.cpp#L68