### PR TITLE
[Tutotial]: Host IRs

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -224,12 +224,9 @@ std::unordered_set<Val*> allConsumerValsOf(Val* val) {
 } // namespace
 
 void HostIrExecutor::handle(ForLoop* for_loop) {
-  NVF_ERROR(for_loop->start()->isConstInt());
-  NVF_ERROR(for_loop->step()->isConstInt());
-  NVF_ERROR(for_loop->stop()->isConstInt());
-  auto start = for_loop->start()->value().as<int64_t>();
-  auto step = for_loop->step()->value().as<int64_t>();
-  auto stop = for_loop->stop()->value().as<int64_t>();
+  auto start = expr_evaluator_.evaluate(for_loop->start()).as<int64_t>();
+  auto step = expr_evaluator_.evaluate(for_loop->step()).as<int64_t>();
+  auto stop = expr_evaluator_.evaluate(for_loop->stop()).as<int64_t>();
 
   for (auto i = start; i < stop; i += step) {
     // invalidate i and its consumers before binding

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -102,13 +102,12 @@ std::string PostOnStream::toString(int indent_size) const {
   std::for_each(outputs().begin(), outputs().end(), [&ss](auto output) {
     ss << output->toString(0) << ", ";
   });
-  ss << "})";
+  ss << "})" << std::endl;
   return ss.str();
 }
 
-// TODO: implement better ?
 std::string PostOnStream::toInlineString(int indent_size) const {
-  return toString(indent_size);
+  NVF_CHECK(false, "Can not be printed inline");
 }
 
 // TODO: implement
@@ -160,13 +159,14 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(SetCurrentStream)
 
 std::string SetCurrentStream::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << "SetCurrentStream to " << stream()->toString();
+  indent(ss, indent_size) << "SetCurrentStream to " << stream()->toString()
+                          << std::endl;
   return ss.str();
 }
 
 // TODO: implement better ?
 std::string SetCurrentStream::toInlineString(int indent_size) const {
-  return toString(indent_size);
+  NVF_CHECK(false, "Cannot be printed inline");
 }
 
 // TODO: implement
@@ -187,13 +187,13 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(Wait)
 std::string Wait::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "Wait Communication " << communication()->name()
-                          << "\n";
+                          << std::endl;
   return ss.str();
 }
 
 // TODO: implement better ?
 std::string Wait::toInlineString(int indent_size) const {
-  return toString(indent_size);
+  NVF_CHECK(false, "Cannot be printed inline");
 }
 
 // TODO: implement

--- a/csrc/ir/iostream.cpp
+++ b/csrc/ir/iostream.cpp
@@ -103,7 +103,7 @@ void IrPrinter::handle(const hir::HostIrContainer* host_ir_container) {
   // host_ir_container body
   indent_size_++;
   for (auto expr : host_ir_container->topLevelExprs()) {
-    os() << expr->toString(indent_size_) << std::endl;
+    os() << expr->toString(indent_size_);
   }
   indent_size_--;
   for (auto* host_unit : ir_utils::filterByType<hir::HostUnit>(

--- a/tests/cpp/test_multidevice_tutorial.cpp
+++ b/tests/cpp/test_multidevice_tutorial.cpp
@@ -188,13 +188,9 @@ TEST_F(MultiDeviceTutorial, DeviceMeshesNoResharding) {
   DeviceMesh mesh_one({1});
   // We can also consider the mesh of device indices "0" "2"
   DeviceMesh mesh_zero_and_two({0, 2});
-  // Or the mesh containing all available devices in the world communicator_
-  std::vector<int64_t> all_devices(communicator_->size());
-  std::iota(
-      all_devices.begin(),
-      all_devices.end(),
-      0); // all_devices = [0,1,..., communicator_->size()-1]
-  DeviceMesh mesh_full(all_devices);
+  // Or the mesh containing all available devices in the world communicator_,
+  // i.e.,[0,1,..., communicator_->size()-1]
+  auto mesh_full = DeviceMesh::createForNumDevices(communicator_->size());
   // However, it is forbidden to define a mesh with duplicates indices:
   EXPECT_ANY_THROW(DeviceMesh mesh_with_duplicates({1, 1}));
 
@@ -415,7 +411,7 @@ TEST_F(MultiDeviceTutorial, TensorShardingAndResharding) {
   // Let us define, as in previous tests, a 1D Device Mesh comprised of all
   // available device IDs, i.e., [0,1,..., communicator_->size()-1]
   auto mesh_full = DeviceMesh::createForNumDevices(communicator_->size());
-  ;
+
   // Let us set tv0 and tv1's mesh:
   tv0->setDeviceMesh(mesh_full);
   tv1->setDeviceMesh(mesh_full);

--- a/tests/cpp/test_multidevice_tutorial.cpp
+++ b/tests/cpp/test_multidevice_tutorial.cpp
@@ -6,6 +6,9 @@
  */
 // clang-format on
 
+#include <host_ir/container.h>
+#include <host_ir/executor.h>
+#include <host_ir/host_ir.h>
 #include <ir/iostream.h>
 #include <multidevice/communicator.h>
 #include <ops/all_ops.h>
@@ -614,5 +617,94 @@ TEST_F(MultiDeviceTutorial, TensorShardingAndResharding) {
     }
   }
 }
+
+// We have seen how to multidevice-schedule a Fusion by setting tensors' sharding, i.e., setting device mesh and setting axis parallel type to DIDx.
+
+// At the time where this comment is written, we only support 1D tensor sharding, i.e., we have not introduced yet multidimensional meshes and other parallel types such as DIDy and DIDz. This will be done in the future. Let us poit out by the way that 1D multidevice parallelism already covers interesting real-world scenarios, such as Transformer with Tensor Parallel, see `tests/cpp/test_multidevice_transformer.cpp`.
+
+// Let us now explore lower than the mere multidevice scheduling API and introduce the host IR. In classical single-device nvFuser, the "host program" could be summarized as launching one or a couple of CUDA Kernels. When dealing with multiple devices, the host plays a more proeminent role because it needs to orchestrate and synchronize compute Kernels and Communications (which are necessarily CPU-initiated when using NCCL or UCC). Other examples, not necessarily tied to multidevice setting, rely on complex host orchestration, such as multi streaming, kernel pipelining, overlap technics, using CUDA Graphs, etc.
+
+// These examples suggest that Fuser should be able to reason about the interplay between host and device execution. This motivates the introduction of "host IRs" to represent the host program, in an abstract/symbolic way, allowing us reason about the host program, apply optimizations passes, and possibly compile it (in the future).
+
+// The host program is typically generated automatically during lowering. This is what is done at the instantiation of MultiDeviceExecutor, and what gets printed by `MultiDeviceExecutor::print()`. However, the Host Ir API has been designed to allow a fully manual host programmation. This is what we are going to introduce in the following tests.
+
+// The HostIr component is comprised of three parts:
+// - Host IRs: each IR represents an elementary host operation
+// - HostIrContainer: represents the host program
+// - HostIrExecutor: executes a HostIrContainer
+// In the first test, we will show how to express through host IRs a simple host program consisting of simply launching a fusion.
+namespace {
+
+// Let us consider an arbitrary fusion. We assume for simplicity (but without loss of generality) that the fusion has one input and one output which are both a 2D tensor.
+
+constexpr int64_t nDims = 2;
+
+std::unique_ptr<Fusion> CreateArbitraryFusion () {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  auto tv0 = makeSymbolicTensor(nDims);
+  fusion->addInput(tv0);
+  auto tv1 = mul(tv0, IrBuilder::create<Val>(2.));
+  tv1->setMemoryType(MemoryType::Global); // to avoid an error of the type "Allocations must be based on constant integers for local memory"
+  auto tv2 = add(tv1, IrBuilder::create<Val>(1.));
+  fusion->addOutput(tv2);
+  return fusion;
+}
+
+} // namespace
+
+namespace hir { // HostIr has its own namespace "hir"
+
+//  Let us start with the simplest non-trivial host program possible: compiling and running a single Fusion. It is a good starting point to understand the Host Ir semantics. The host program could be illustrated as follows:
+/*
+  | tv0: input
+  | tv1 = Fusion0 (tv0)
+  | tv1: output
+*/
+TEST_F(MultiDeviceTutorial, HostIrLaunchingFusion) {
+  // Instantiate an HostIrContainer. This container is used to 1) register the Host IRs, and 2) represent the Host program through its `std::vector<Expr*> top_level_exprs_`.
+  auto hic = std::make_unique<HostIrContainer>();
+  FusionGuard fg(hic.get());
+
+  // The first Host IR we introduce is called `HostUnit`. It is used to represent a fusion definition at the host IR level.
+  auto host_unit = IrBuilder::create<HostUnit>(CreateArbitraryFusion());
+
+  // We then create an IR `PostOnStream` which represents compiling+executing the fusion with some I/O.
+  auto input = makeSymbolicTensor(nDims);
+  auto output = makeSymbolicTensor(nDims);
+  auto post_fusion = IrBuilder::create<PostOnStream>(host_unit, std::vector<Val*>({input}), std::vector<Val*>({output}));
+
+  // Let us add "post_fusion" to the host program
+  hic->pushBackTopLevelExprs(post_fusion);
+
+  // Define the Host program's global I/O. (This step could potentially be automated in the future, at least partially)
+  hic->addInput(input);
+  hic->addOutput(output);
+
+  if (verbose_ && communicator_->deviceId() == 0) {
+    hic->print(debug());
+    // We reproduce, for convenience, what gets printed:
+    /*
+    %HostIrContainer { (T0_g[ iS0{i0}, iS1{i2} ]) -> (T1_g[ iS2{i3}, iS3{i4} ]) :
+      PostOnStream (HostUnit0, Inputs:{T0_g[ iS0{i0}, iS1{i2} ], }, Outputs:{T1_g[ iS2{i3}, iS3{i4} ], })
+
+    HostUnit0: [...]
+    } // %HostIrContainer
+    */
+  //  the "[...]" contains the result of Fusion::printMath(), which we omit here.
+  }
+
+  // define concrete inputs
+  at::Tensor aten_input = at::randn({16,32}, at::TensorOptions().device(communicator_->device()));
+
+  // Let us now execute the Host program.
+  HostIrExecutor hie(std::move(hic));
+  auto outputs = hie.runWithInput({{input, aten_input}});
+
+  // validate the result
+  GTEST_EXPECT_TRUE(torch::allclose(2*aten_input + 1, outputs.at(0)));
+}
+
+} // namespace hir
 
 } // namespace nvfuser

--- a/tests/cpp/test_multidevice_tutorial.cpp
+++ b/tests/cpp/test_multidevice_tutorial.cpp
@@ -716,7 +716,7 @@ TEST_F(MultiDeviceTutorial, HostIrLaunchingFusion) {
     HostUnit0: [...]
     } // %HostIrContainer
     */
-    //  clang-format on
+    // clang-format on
     //  the "[...]" contains the result of Fusion::printMath(), which we omit
     //  here.
   }
@@ -733,8 +733,9 @@ TEST_F(MultiDeviceTutorial, HostIrLaunchingFusion) {
   GTEST_EXPECT_TRUE(torch::allclose(2 * aten_input + 1, outputs.at(0)));
 }
 
-
-// Let us now present a case where the host program consists of launching three fusions, with a non-linear dependency between the respective I/O. The host program could be illustrated as follows:
+// Let us now present a case where the host program consists of launching three
+// fusions, with a non-linear dependency between the respective I/O. The host
+// program could be illustrated as follows:
 /*
   | tv0: input
   | (tv1, tv2) = Fusion0 (tv0)
@@ -749,7 +750,7 @@ TEST_F(MultiDeviceTutorial, HostIrLaunchingThreeFusions) {
   // loss of generality) that the fusion has one input and one output which are
   // both a 2D tensor.
   constexpr int64_t nDims = 2;
-  auto CreateFusion0 = [nDims] () -> std::unique_ptr<Fusion> {
+  auto CreateFusion0 = [nDims]() -> std::unique_ptr<Fusion> {
     auto fusion = std::make_unique<Fusion>();
     FusionGuard fg(fusion.get());
     TensorView* tv0 = makeSymbolicTensor(nDims);
@@ -760,7 +761,7 @@ TEST_F(MultiDeviceTutorial, HostIrLaunchingThreeFusions) {
     fusion->addOutput(tv2);
     return fusion;
   };
-  auto CreateFusion1 = [nDims] () -> std::unique_ptr<Fusion> {
+  auto CreateFusion1 = [nDims]() -> std::unique_ptr<Fusion> {
     auto fusion = std::make_unique<Fusion>();
     FusionGuard fg(fusion.get());
     TensorView* tv1 = makeSymbolicTensor(nDims);
@@ -769,7 +770,7 @@ TEST_F(MultiDeviceTutorial, HostIrLaunchingThreeFusions) {
     fusion->addOutput(tv3);
     return fusion;
   };
-  auto CreateFusion2 = [nDims] () -> std::unique_ptr<Fusion> {
+  auto CreateFusion2 = [nDims]() -> std::unique_ptr<Fusion> {
     auto fusion = std::make_unique<Fusion>();
     FusionGuard fg(fusion.get());
     TensorView* tv2 = makeSymbolicTensor(nDims);
@@ -802,14 +803,14 @@ TEST_F(MultiDeviceTutorial, HostIrLaunchingThreeFusions) {
   auto post_fusion0 = IrBuilder::create<PostOnStream>(
       fusion0,
       /*inputs=*/std::vector<Val*>({tv0}),
-      /*outputs=*/std::vector<Val*>({tv1,tv2}));
+      /*outputs=*/std::vector<Val*>({tv1, tv2}));
   auto post_fusion1 = IrBuilder::create<PostOnStream>(
       fusion1,
       /*inputs=*/std::vector<Val*>({tv1}),
       /*outputs=*/std::vector<Val*>({tv3}));
   auto post_fusion2 = IrBuilder::create<PostOnStream>(
       fusion2,
-      /*inputs=*/std::vector<Val*>({tv2,tv3}),
+      /*inputs=*/std::vector<Val*>({tv2, tv3}),
       /*outputs=*/std::vector<Val*>({tv4}));
   // Note that the same host unit can be reused multiple times
   auto post_fusion1_bis = IrBuilder::create<PostOnStream>(
@@ -842,7 +843,7 @@ TEST_F(MultiDeviceTutorial, HostIrLaunchingThreeFusions) {
     HostUnit0: [...]
     } // %HostIrContainer
     */
-    //  clang-format on
+    // clang-format on
     //  the "[...]" contains the result of Fusion::printMath(), which we omit
     //  here.
   }
@@ -859,8 +860,10 @@ TEST_F(MultiDeviceTutorial, HostIrLaunchingThreeFusions) {
   GTEST_EXPECT_TRUE(torch::allclose(4 * aten_tv0 + 5, outputs.at(0)));
 }
 
-
-// Let us now present a real world scenario, used in transformer, where we need to execute a matmul followed by a Reduce-Scatter MPI collective. This is the first example we provide where host IRs are used in a multidevice setting. The host program can be summarized as follows:
+// Let us now present a real world scenario, used in transformer, where we need
+// to execute a matmul followed by a Reduce-Scatter MPI collective. This is the
+// first example we provide where host IRs are used in a multidevice setting.
+// The host program can be summarized as follows:
 /*
   | tva, tvb: inputs
   | tvc = Matmul(tva, tvb)
@@ -869,8 +872,8 @@ TEST_F(MultiDeviceTutorial, HostIrLaunchingThreeFusions) {
   | tvd: output
 */
 // here, all the tensors are implicitely sharded tensors accross devices.
-// `Matmul` and MPI-collectives are Host IRs that can be used directly in the host program.
-
+// `Matmul` and MPI-collectives are Host IRs that can be used directly in the
+// host program.
 TEST_F(MultiDeviceTutorial, HostIrGemmReduceScatter) {
   // Instantiate an HostIrContainer
   auto hic = std::make_unique<HostIrContainer>();
@@ -879,12 +882,15 @@ TEST_F(MultiDeviceTutorial, HostIrGemmReduceScatter) {
   constexpr int64_t nDims = 2;
   TensorView* tva = makeSymbolicTensor(nDims);
   TensorView* tvb = makeSymbolicTensor(nDims);
-  // some ops, like MatMulOp are natively supported as HostIrs, and do not need to be implemented as a Fusion
+  // some ops, like MatMulOp are natively supported as HostIrs, and do not need
+  // to be implemented as a Fusion
   TensorView* tvc = matmul(tva, tvb);
   Expr* matmul_op = tvc->definition();
 
   TensorView* tvd = makeSymbolicTensor(nDims);
-  // Before defining the communication (reduce-scatter) that produces tvd from tvc, it is required to set tvd and tvc device mesh (this might be removed in the future)
+  // Before defining the communication (reduce-scatter) that produces tvd from
+  // tvc, it is required to set tvd and tvc device mesh (this might be removed
+  // in the future)
   std::vector<int64_t> all_devices(communicator_->size());
   std::iota(
       all_devices.begin(),
@@ -895,15 +901,17 @@ TEST_F(MultiDeviceTutorial, HostIrGemmReduceScatter) {
   tvd->setDeviceMesh(mesh_full);
 
   auto* reduce_scatter = IrBuilder::create<Communication>(
-    CommunicationType::ReduceScatter,
-    /*out=*/tvd,
-    /*in=*/tvc,
-    /*team=*/all_devices,
-    /*(unused)root=*/-1,
-    RedOpType::SUM,
-    /*scattered_axis=*/0);
+      CommunicationType::ReduceScatter,
+      /*out=*/tvd,
+      /*in=*/tvc,
+      /*team=*/all_devices,
+      /*(unused)root=*/-1,
+      RedOpType::SUM,
+      /*scattered_axis=*/0);
 
-  // Since communications are non-blocking, it is always required to wait for a posted communication. Node that "wait" blocks the stream but not the CPU (except for barrier)
+  // Since communications are non-blocking, it is always required to wait for a
+  // posted communication. Node that "wait" blocks the stream but not the CPU
+  // (except for barrier)
   auto* wait = IrBuilder::create<hir::Wait>(reduce_scatter);
 
   // Let us create the host program and the I/O
@@ -913,7 +921,8 @@ TEST_F(MultiDeviceTutorial, HostIrGemmReduceScatter) {
 
   hic->addInput(tva);
   hic->addInput(tvb);
-  hic->addInput(tvd); // a buffer must be provided for tvd, this is why it is tagged as an input
+  hic->addInput(tvd); // a buffer must be provided for tvd, this is why it is
+                      // tagged as an input
   hic->addOutput(tvd);
 
   if (verbose_ && communicator_->deviceId() == 0) {
@@ -929,26 +938,27 @@ TEST_F(MultiDeviceTutorial, HostIrGemmReduceScatter) {
       Wait Communication 1
     } // %HostIrContainer
     */
-    //  clang-format on
+    // clang-format on
   }
 
   // define a concrete input
   constexpr int64_t M = 1680;
   constexpr int64_t K = 16;
   constexpr int64_t N = 64;
-  ASSERT_EQ(M % communicator_->size(), 0) << "the test must be launched with a number of devices n that divides M=" << M << ", but we have n=" << communicator_->size();
+  ASSERT_EQ(M % communicator_->size(), 0)
+      << "the test must be launched with a number of devices n that divides M="
+      << M << ", but we have n=" << communicator_->size();
 
   auto options = at::TensorOptions().device(communicator_->device());
-  at::Tensor aten_tva =
-      at::randn({M, K}, options);
-  at::Tensor aten_tvb =
-      at::randn({K, N}, options);
-  at::Tensor aten_tvd =
-      at::empty({M / communicator_->size(), N}, options);
+  at::Tensor aten_tva = at::randn({M, K}, options);
+  at::Tensor aten_tvb = at::randn({K, N}, options);
+  at::Tensor aten_tvd = at::empty({M / communicator_->size(), N}, options);
 
-  // Let us now execute the Host program. When multidevice are requested, we need to pass a pointer to a Communicator
+  // Let us now execute the Host program. When multidevice is requested, we
+  // need to pass a pointer to a Communicator
   HostIrExecutor hie(std::move(hic), communicator_);
-  auto outputs = hie.runWithInput({{tva, aten_tva}, {tvb, aten_tvb}, {tvd, aten_tvd}});
+  auto outputs =
+      hie.runWithInput({{tva, aten_tva}, {tvb, aten_tvb}, {tvd, aten_tvd}});
 
   // "validate" the result
   EXPECT_EQ(outputs.at(0).numel(), (M * N) / communicator_->size());

--- a/tests/cpp/test_tutorial.cpp
+++ b/tests/cpp/test_tutorial.cpp
@@ -176,10 +176,12 @@ TEST_F(Tutorial, Reduction) {
   FusionGuard fg(&fusion);
 
   // Create a 2D tensor
+  // tv0 [i1, i2]
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
   // Reduce the second dimension
+  // tv1 [i1, r2]
   auto tv1 = sum(tv0, {1});
   fusion.addOutput(tv1);
 

--- a/tests/cpp/test_tutorial.cpp
+++ b/tests/cpp/test_tutorial.cpp
@@ -176,12 +176,10 @@ TEST_F(Tutorial, Reduction) {
   FusionGuard fg(&fusion);
 
   // Create a 2D tensor
-  // tv0 [i1, i2]
   TensorView* tv0 = makeSymbolicTensor(2);
   fusion.addInput(tv0);
 
   // Reduce the second dimension
-  // tv1 [i1, r2]
   auto tv1 = sum(tv0, {1});
   fusion.addOutput(tv1);
 


### PR DESCRIPTION
This tutorial introduces Host IRs and how to manually write host programs. The tutorial is composed of four examples:
- Vanilla host program, launching one fusion
- Launching three fusions, with a non-linear dependency between the respective I/O
- Compute+Comms with the example of Matmul+Reduce-Scatter as done in Transformer
- Kernel Pipelining, with a Host for-loop and multistreaming