### PR TITLE
Disable UCC for some tests.

### DIFF
--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -266,7 +266,7 @@ INSTANTIATE_TEST_SUITE_P(
     Bcast_sharded,
     PipelineTestTwoStages,
     testing::Combine(
-        testing::Values(CommunicatorBackend::nccl, CommunicatorBackend::ucc),
+        testing::Values(CommunicatorBackend::nccl),
         testing::Values(mesh3, mesh4),
         testing::Values(mesh3, mesh4),
         testing::Values(true),

--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -266,6 +266,7 @@ INSTANTIATE_TEST_SUITE_P(
     Bcast_sharded,
     PipelineTestTwoStages,
     testing::Combine(
+        // TODO(#2794): add back CommunicatorBackend::ucc
         testing::Values(CommunicatorBackend::nccl),
         testing::Values(mesh3, mesh4),
         testing::Values(mesh3, mesh4),


### PR DESCRIPTION
Works around an "undefined symbol" error in https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/jobs/106423695. 

```
00:04:58 [1,2]<stdout>:[ RUN      ] Bcast_sharded/PipelineTestTwoStages.Communication/20
00:04:58 [1,2]<stderr>:bin/test_multidevice: symbol lookup error: /usr/local/ucx/lib/ucx/libuct_cuda_gdrcopy.so.0: undefined symbol: gdr_get_info_v2
```

To reproduce this error: 

```
mpirun --get-stack-traces --tag-output --report-state-on-timeout --allow-run-as-root -np 4 bin/test_multidevice | ts -s
```

According to @xwang233, `pjnl-20240813` works and `pjnl-20240814` fails. 08/13 has HPCX_VERSION 2.19 and 08/14 has HPCX_VERSION 2.20, so that might be the cause.

Tested: https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/pipelines/17572797