### PR TITLE
Fix index replacement for circular buffering with trivial main loop.

### DIFF
--- a/csrc/id_model/circular_buffer_indexing.cpp
+++ b/csrc/id_model/circular_buffer_indexing.cpp
@@ -27,7 +27,9 @@ Val* getLoopIndexOfCircularBufferLoop(
   }
 
   if (fl->circularBufferLoopStage() != CircularBufferLoopStage::NotApplicable) {
-    return fl->indexOrStartIfTrivial();
+    // Always return index even if for-loop is trivial.
+    // Simplify index with substitution.
+    return fl->index();
   } else {
     return nullptr;
   }

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -1042,12 +1042,19 @@ std::unordered_map<Val*, Val*> TensorIndexer::getIndexReplacementMap(
         // If this for-loop is a circular buffer loop, the loop index
         // may need to have an additional offset
         if (!as_consumer) {
+          Val* base_index =
+              replacement_index != nullptr ? replacement_index : cur_index;
           if (auto circular_buffer_offset =
                   getLoopIndexOffsetForProducerOfCircularBuffer(
                       expr, for_loop, id_model_)) {
             replacement_index = SimplifyingIrBuilder::addExpr(
-                replacement_index != nullptr ? replacement_index : cur_index,
+                for_loop->isTrivial() ? for_loop->start() : base_index,
                 circular_buffer_offset);
+          } else if (
+              for_loop->circularBufferLoopStage() !=
+              CircularBufferLoopStage::NotApplicable) {
+            replacement_index =
+                for_loop->isTrivial() ? for_loop->start() : base_index;
           }
         }
       }

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -1151,10 +1151,12 @@ std::vector<PredicateInfo> TensorIndexer::getPredicates(
     info.loop_stage_ = loop_stage;
 
     info.start_predicate_ = SimplifyingIrBuilder::geExpr(
-        SimplifyingIrBuilder::addExpr(start_idx, info.start_offset_), zero_val);
+        SimplifyingIrBuilder::addExpr(simplifyExpr(start_idx), zero_val),
+        zero_val);
 
     info.stop_predicate_ = SimplifyingIrBuilder::ltExpr(
-        SimplifyingIrBuilder::addExpr(stop_idx, info.stop_offset_),
+        SimplifyingIrBuilder::addExpr(
+            simplifyExpr(stop_idx), info.stop_offset_),
         predicate_domain->extent());
 
     info.predicated_domains_ = {predicate_domain};

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -3343,15 +3343,18 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering1) {
       // where i2 is the circular buffer index. The index of iUS10 is
       // not included as its extent is 1.
 
-      // Start index: i0 * 4
-      Val* start_idx = mulExpr(loop_indices.at(0), createInt(4));
+      // NOTE: Expression Simplification is disabled in PredicateIndexValidator,
+      // so trivial addition appears in the expression.
+      // Start index: i0 * 4 + 0
+      Val* start_idx = IrBuilder::addExpr(
+          IrBuilder::mulExpr(loop_indices.at(0), createInt(4)), createInt(0));
 
       // Stop index: i0 * 4 + 4
       // Note that it isn't "i0 * 4 + 3" since i2 is circular buffered
       // and there's no epilog, so the main loop has a read of (i2 +
       // 1).
-      Val* stop_idx =
-          addExpr(mulExpr(loop_indices.at(0), createInt(4)), createInt(4));
+      Val* stop_idx = IrBuilder::addExpr(
+          IrBuilder::mulExpr(loop_indices.at(0), createInt(4)), createInt(4));
 
       return andExpr(
           geExpr(start_idx, zero),


### PR DESCRIPTION
## Problem ##
We encounter an indexing issue when the main loop is trivial with TMA circular buffering.

Fusion Details:
- Inner Reduction on 2D tensor
- Number of Stages: 4
- Tensor Size: (128, 128)

NOTE: This TMA load is for the last stage in the pipeline. The y-axis index is not shifted by `(num_stages - 1)`.
**Incorrect indexing:**
```cpp
  nvfuser_index_t i5;
  i5 = 4 * ((nvfuser_index_t)blockIdx.x);
  // tma load for last stage in main loop
  Hopper::cpAsyncBulkTensorTileG2S((Hopper::CpAsyncBulkTensorTileG2SIndex<2>{ 
                ptr4, (Array<nvfuser_index_t, 2, 1>{(256 * i17), i5}), toSmem((&T3[i19])) }), (i8 + (1024 * i17)));
```

**Correct indexing:**
```cpp
  nvfuser_index_t i5;
  i5 = 4 * ((nvfuser_index_t)blockIdx.x);
  nvfuser_index_t i8;
  i8 = 3 + i5;
  // tma load for last stage in main loop
  Hopper::cpAsyncBulkTensorTileG2S((Hopper::CpAsyncBulkTensorTileG2SIndex<2>{ 
                ptr4, (Array<nvfuser_index_t, 2, 1>{(256 * i18), i8}), toSmem((&T3[i20])) }), (i9 + (1024 * i18)));
```

## Explanation ##
Since main loop is trivial, `getLoopIndexOfCircularBufferLoop` returns the start value of for-loop.
In `IdGraphIndexCompute`, we apply `SimplifyingIrBuilder` that removes the trivial addition with zero start value.
The `getIndexReplacementMap` function adds an entry to replace the loop index with offset for circular buffer load.
However, we fail to replace the loop index while processing `ir_utils::replaceValRecursively` because the loop index does not exist. 

## Proposed Solution ##
1. Always return index of for-loop in `getLoopIndexOfCircularBufferLoop`. 
2. In getIndexReplacementMap, replace index with zero start-value. 
3. Apply `simplifyExpr` to remove trivial computation.

Essentially, the fix is avoid simplifying too early, so we can replace it with the correctly offset index.

## PR side-effect ## 
Expression simplification is disabled in `IndexValidator` and `PredicateIndexValidator`. 
Trivial computations appear in the reference `getLinearIndex` and `getInlinePredicate`.

## Cuda Kernel References ##
- Run `./build/nvfuser_tests --gtest_filter='*CircularBufferingTest*Reduction/12'` on `tma_circular_buffering` branch at 56f18831.
1. [fail_reduction_cb4_128_128.txt](https://github.com/user-attachments/files/16665425/fail_reduction_cb4_128_128.txt)
2.  [pass_reduction_cb4_128_128.txt](https://github.com/user-attachments/files/16665427/pass_reduction_cb4_128_128.txt)
