### PR TITLE
cache query patch

### DIFF
--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -658,7 +658,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             for (py::handle obj : iter) {
               inputs.push_back(torch::jit::toIValue(obj, c10::AnyType::get()));
             }
-            self.existSchedule(inputs);
+            return self.existSchedule(inputs);
           })
       .def(
           "_setup_schedule",

--- a/tests/python/test_schedule_ops.py
+++ b/tests/python/test_schedule_ops.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.jit_utils import RUN_CUDA
 
 from nvfuser import (
+    FusionCache,
     FusionDefinition,
     DataType,
     ParallelType,
@@ -82,6 +83,9 @@ class TestScheduleOps(TestCase):
             fd = DefError()
             _ = fd.execute(inputs)
 
+        # reset cache to avoid follow up test picking up the manual user schedule
+        FusionCache.get().reset()
+
     def check_input_error(
         self, sched_fn: Callable, error_msg: str, error_type=RuntimeError
     ):
@@ -107,6 +111,9 @@ class TestScheduleOps(TestCase):
         with self.assertRaisesRegex(error_type, error_msg):
             fd = InputError()
             _ = fd.execute(inputs)
+
+        # reset cache to avoid follow up test picking up the manual user schedule
+        FusionCache.get().reset()
 
     def valid_use(self, sched_op_fn: Callable):
         """

--- a/tests/python/test_schedule_ops.py
+++ b/tests/python/test_schedule_ops.py
@@ -135,6 +135,7 @@ class TestScheduleOps(TestCase):
         nvf_user_out = fd.execute(inputs)
         nvf_out = fd.execute(inputs, override_user_schedule=True)
         self.assertEqual(nvf_user_out, nvf_out)
+        self.assertTrue(fd._exist_schedule(inputs))
 
     def test_print(self):
         """


### PR DESCRIPTION
`_exist_schedule` forgot to return the value, ended up with each execution iteration re-schedule the same fusion.

existing python tests needs to clear cache. Since we use input look up for cache key, which doesn't distinguish scalar value changes.