### PR TITLE
MarkAliasesPrepare applies bookend from inputs as well as outputs. 

### DIFF
--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -174,53 +174,61 @@ void ExpressionEvaluator::bind_(
         t.dim());
     for (auto i : c10::irange(t.dim())) {
       auto id = logical_domain[i];
-      if (id->hasExpandedExtent()) {
-        // Verify that t is also expanded
-        NVF_ERROR(
-            t.size(i) == 1 || t.stride(i) == 0,
-            "IterDomain ",
-            id->toString(),
-            " in ",
-            getInputPosString(tv),
-            "TensorView ",
-            tv->toString(),
-            " has expanded extent but input tensor has size ",
-            t.size(i),
-            " and stride ",
-            t.stride(i),
-            " in dimension ",
-            i);
-        bind_(
-            logical_domain[i]->expandedExtent(), t.size(i), evaluate_validate);
-      } else if (logical_domain[i]->isDeviceDim()) {
-        // Currently we have the restrictions:
-        // (1) Devices parallelized axis extent == DeviceMesh's extent
-        // (2) Device parallelized axis cannot be split or merged
-        // Therefore, the device parallelized extents will always be allocated
-        // with size 1, but the symbolic axis extent is binded with the extent
-        // of the DeviceMesh
-        NVF_CHECK(
-            1 == t.size(i),
-            "TensorView ",
-            tv->toString(),
-            getInputPosString(tv),
-            " IterDomain ",
-            id->toString(),
-            "is sharded and must have size 1, but input tensor has size ",
-            t.size(i));
-        NVF_CHECK(
-            tv->hasDeviceMesh(),
-            "TV ",
-            tv->toString(),
-            getInputPosString(tv),
-            " has an empty DeviceMesh with DID parallelization")
-        bind_(
-            logical_domain[i]->extent(),
-            static_cast<int>(
-                tv->getDeviceMesh().size(logical_domain[i]->getParallelType())),
-            evaluate_validate);
+      if (id->isBroadcast()) {
+        // DIDs are ignored.
+        bind_(logical_domain[i]->extent(), 1, evaluate_validate);
+        if (id->hasExpandedExtent()) {
+          // Verify that t is also expanded
+          NVF_ERROR(
+              t.size(i) == 1 || t.stride(i) == 0,
+              "IterDomain ",
+              id->toString(),
+              " in ",
+              getInputPosString(tv),
+              "TensorView ",
+              tv->toString(),
+              " has expanded extent but input tensor has size ",
+              t.size(i),
+              " and stride ",
+              t.stride(i),
+              " in dimension ",
+              i);
+          bind_(
+              logical_domain[i]->expandedExtent(),
+              t.size(i),
+              evaluate_validate);
+        }
       } else {
-        bind_(logical_domain[i]->extent(), t.size(i), evaluate_validate);
+        if (logical_domain[i]->isDeviceDim()) {
+          // Currently we have the restrictions:
+          // (1) Devices parallelized axis extent == DeviceMesh's extent
+          // (2) Device parallelized axis cannot be split or merged
+          // Therefore, the device parallelized extents will always be allocated
+          // with size 1, but the symbolic axis extent is binded with the extent
+          // of the DeviceMesh
+          NVF_CHECK(
+              1 == t.size(i),
+              "TensorView ",
+              tv->toString(),
+              getInputPosString(tv),
+              " IterDomain ",
+              id->toString(),
+              "is sharded and must have size 1, but input tensor has size ",
+              t.size(i));
+          NVF_CHECK(
+              tv->hasDeviceMesh(),
+              "TV ",
+              tv->toString(),
+              getInputPosString(tv),
+              " has an empty DeviceMesh with DID parallelization")
+          bind_(
+              logical_domain[i]->extent(),
+              static_cast<int64_t>(tv->getDeviceMesh().size(
+                  logical_domain[i]->getParallelType())),
+              evaluate_validate);
+        } else {
+          bind_(logical_domain[i]->extent(), t.size(i), evaluate_validate);
+        }
       }
     }
   }

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -323,6 +323,13 @@ IterDomain* newOutputIterDomain(
       continue;
     }
 
+    NVF_ERROR(
+        id->getParallelType() == ParallelType::Serial ||
+            isParallelTypeDeviceDim(id->getParallelType()),
+        id->getParallelType(),
+        " is not expected when building ops.");
+    parallel_type = promoteParallelType(parallel_type, id->getParallelType());
+
     if (id->isBroadcast()) {
       if (id->hasExpandedExtent()) {
         expanded_extent_val =
@@ -330,13 +337,6 @@ IterDomain* newOutputIterDomain(
       }
       continue;
     }
-
-    NVF_ERROR(
-        id->getParallelType() == ParallelType::Serial ||
-            isParallelTypeDeviceDim(id->getParallelType()),
-        id->getParallelType(),
-        " is not expected when building ops.");
-    parallel_type = promoteParallelType(parallel_type, id->getParallelType());
 
     if (extent_is_from_symbolic && !id->isSymbolic()) {
       // We prefer to use extents from non-Symbolic inputs if there are any

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -503,11 +503,12 @@ TEST_F(AliasTest, AliasOutputBeforeNonAliasOutput) {
   at::Tensor slice_out_tensor = out_tensors[0];
   EXPECT_TRUE(slice_out_tensor.is_alias_of(in_tensor));
 
-  const FusionExecutor& fe = onlyExecutorInMostRecentRuntime(fec);
-  EXPECT_FALSE(storesToOutput(fe, /*out_index=*/0))
-      << "The generated CUDA kernel shouldn't store data to output 0:"
-      << std::endl
-      << fe.kernelString();
+  FusionKernelRuntime* runtime = fec.getMostRecentKernelRuntime();
+  EXPECT_THAT(
+      runtime->fusionSegments()->groups(),
+      UnorderedElementsAre(
+          HeuristicIs(ScheduleHeuristic::NoOp),
+          HeuristicIs(ScheduleHeuristic::PointWise)));
 }
 
 TEST_F(AliasTest, Set_NoAliasForIncompatibleLayout) {

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -35,6 +35,8 @@
 #include <kernel_ir_dispatch.h>
 #include <logical_domain_map.h>
 #include <ops/all_ops.h>
+#include <preseg_passes/mark_aliases_prepare.h>
+#include <preseg_passes/optimization_pass.h>
 #include <scheduler/all_schedulers.h>
 #include <scheduler/reduction_utils.h>
 #include <scheduler/utils.h>
@@ -7821,6 +7823,12 @@ TEST_F(NVFuserTest, Reduction3DConstantIterationDomain) {
 TEST_F(NVFuserTest, AvoidCachingSliceInput) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
+
+  // Avoid `slice`s from being bookended. This test is to exercise kernel
+  // caching when a `SliceOp` is applied on a segment input. Bookending
+  // `slice`s would defeat that purpose.
+  preseg_passes::OptimizationPassGuard<preseg_passes::MarkAliasesPreparePass>
+      optimization_guard(false);
 
   // values to trigger the original bug.
   const int64_t eight = 8;

--- a/tests/cpp/test_no_op.cpp
+++ b/tests/cpp/test_no_op.cpp
@@ -20,6 +20,7 @@ namespace nvfuser {
 
 using NoOpTest = NVFuserTest;
 
+using testing::Each;
 using testing::IsEmpty;
 using testing::UnorderedElementsAre;
 
@@ -228,9 +229,12 @@ TEST_F(NoOpTest, ExpandedReduction) {
   FusionKernelRuntime* runtime = fec.getMostRecentKernelRuntime();
   EXPECT_THAT(
       runtime->fusionSegments()->groups(),
-      UnorderedElementsAre(HeuristicIs(ScheduleHeuristic::NoOp)));
-  const auto& executor = runtime->executors().front();
-  EXPECT_THAT(executor.kernel()->summary().global_allocations, IsEmpty());
+      Each(HeuristicIs(ScheduleHeuristic::NoOp)));
+  for (const auto& fe : runtime->executors()) {
+    if (fe.hasCompiledKernel()) {
+      EXPECT_THAT(fe.kernel()->summary().global_allocations, IsEmpty());
+    }
+  }
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_predicate_elimination.cpp
+++ b/tests/cpp/test_predicate_elimination.cpp
@@ -8,12 +8,13 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
-#include <tests/cpp/utils.h>
-#include <tests/cpp/validator.h>
-
 #include <fusion.h>
 #include <ir/all_nodes.h>
 #include <ops/all_ops.h>
+#include <preseg_passes/mark_aliases_prepare.h>
+#include <preseg_passes/optimization_pass.h>
+#include <tests/cpp/utils.h>
+#include <tests/cpp/validator.h>
 
 namespace nvfuser {
 
@@ -326,6 +327,10 @@ TEST_F(PredicateEliminationTest, 8) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
+  // Disable bookending to avoid segmentation. Validation code below assumes
+  // one segment.
+  preseg_passes::OptimizationPassGuard<preseg_passes::MarkAliasesPreparePass>
+      optimization_guard(false);
 
   const int64_t channel_size = 16;
   const int64_t batch_size = 8;


### PR DESCRIPTION
As a follow-up to #2639. #2639 bookends from the outputs, and this PR bookends from the inputs. 

Fixes #2599. 
Fixes #2577. 

Benchmark results are mostly neutral. `test_nanogpt_layer_norm` got slower because of the added host latency. This is expected because, compared with #2639, latency of ops bookended from the inputs is more likely to appear on the critical path. See benchmark details below. 

```
$ nvidia-smi -L
GPU 0: NVIDIA A100 80GB PCIe (UUID: GPU-d9e8abeb-4f1a-5cd0-f825-a45f7ea57875)
$ python tools/benchmark_thunder.py --storage ~/workspace --sync main:main main:wjy/bookend
$ pytest-benchmark --storage ~/workspace compare 0027 0028 --group-by name
```

https://gist.github.com/wujingyue/fc11f9725bc510827d9c53061ca05898

0027 -- without the PR
0028 -- with the PR

Below are the nvprof traces of `test_nanogpt_layer_norm[inference-thunder]` without and with this PR. 

Without the PR: 

![without-2815](https://github.com/user-attachments/assets/d761ae7d-315d-43d0-9909-9328b55de5b9)

With the PR:

![with-2815](https://github.com/user-attachments/assets/f4d7f972-0dd3-4f37-a885-9a81a3ec57ad)
