### PR TITLE
Allow creating CPU scalar tensors using `fd.from_pytorch`

### DIFF
--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -264,14 +264,12 @@ class FusionDefinition(_C._FusionDefinition):
         except ImportError:
             raise ImportError("Unable to import pytorch_utils!")
 
-        if not tensor.is_cuda:
-            raise ValueError("Tensor should be on a cuda device!")
-
         return self.define_tensor(
             sizes=tensor.size(),
             strides=tensor.stride(),
             dtype=torch_dtype_to_nvfuser_dtype(tensor.dtype),
             static_sizes=static_sizes,
+            is_cpu=tensor.is_cpu,
         )
 
     def fusion_ir(self):

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -264,6 +264,9 @@ class FusionDefinition(_C._FusionDefinition):
         except ImportError:
             raise ImportError("Unable to import pytorch_utils!")
 
+        if not tensor.is_cuda and len(tensor.size()) != 0:
+            raise ValueError("CPU non-scalar tensor is not supported!")
+
         return self.define_tensor(
             sizes=tensor.size(),
             strides=tensor.stride(),

--- a/tests/python/test_pointwise.py
+++ b/tests/python/test_pointwise.py
@@ -69,8 +69,10 @@ def test_issue_2395():
 
 # Tests that CPU scalar tensor can be instantiated using fd.from_pytorch
 def test_cpu_add():
-    inputs = [torch.tensor(2.0, device="cpu", dtype=torch.float),
-              torch.randn(3, device="cuda", dtype=torch.float)]
+    inputs = [
+        torch.tensor(2.0, device="cpu", dtype=torch.float),
+        torch.randn(3, device="cuda", dtype=torch.float),
+    ]
 
     def fusion_func(fd: FusionDefinition):
         t0 = fd.from_pytorch(inputs[0])

--- a/tests/python/test_pointwise.py
+++ b/tests/python/test_pointwise.py
@@ -69,15 +69,16 @@ def test_issue_2395():
 
 # Tests that CPU scalar tensor can be instantiated using fd.from_pytorch
 def test_cpu_add():
-    inputs = [torch.tensor(2.0, device="cpu", dtype=torch.float)]
+    inputs = [torch.tensor(2.0, device="cpu", dtype=torch.float),
+              torch.randn(3, device="cuda", dtype=torch.float)]
 
     def fusion_func(fd: FusionDefinition):
         t0 = fd.from_pytorch(inputs[0])
-        s0 = fd.define_scalar(3.0)
+        s0 = fd.from_pytorch(inputs[1])
         t1 = fd.ops.add(t0, s0)
         fd.add_output(t1)
 
     with FusionDefinition() as fd:
         fusion_func(fd)
     nvf_out = fd.execute(inputs)
-    torch.testing.assert_close(nvf_out[0].cpu(), inputs[0] + 3.0)
+    torch.testing.assert_close(nvf_out[0], inputs[0] + inputs[1])

--- a/tests/python/test_pointwise.py
+++ b/tests/python/test_pointwise.py
@@ -65,3 +65,19 @@ def test_issue_2395():
             torch.logical_or(ins[0] == 1, ins[2].unsqueeze(-1) == 1), 0, ins[1]
         ),
     )
+
+
+# Tests that CPU scalar tensor can be instantiated using fd.from_pytorch
+def test_cpu_add():
+    inputs = [torch.tensor(2.0, device="cpu", dtype=torch.float)]
+
+    def fusion_func(fd: FusionDefinition):
+        t0 = fd.from_pytorch(inputs[0])
+        s0 = fd.define_scalar(3.0)
+        t1 = fd.ops.add(t0, s0)
+        fd.add_output(t1)
+
+    with FusionDefinition() as fd:
+        fusion_func(fd)
+    nvf_out = fd.execute(inputs)
+    torch.testing.assert_close(nvf_out[0].cpu(), inputs[0] + 3.0)


### PR DESCRIPTION
This PR sets the `is_cpu` flag in `define_tensor` instead of raising an error when `fd.from_pytorch` is called for CPU scalar tensors.