### PR TITLE
Print StructHandle in toString(PolymorphicValue) [second attempt]

### DIFF
--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -222,8 +222,8 @@ void PrecomputedValues::print() const {
   debug() << "Precomputed Values:\n";
   for (auto i : c10::irange(symbols_.size())) {
     if (defined_[i]) {
-      debug() << symbols_[i]->toInlineString() << " = " << values_[i]
-              << std::endl;
+      debug() << symbols_[i]->toInlineString() << " = "
+              << PolymorphicValue_functions::toString(values_[i]) << std::endl;
     }
   }
 }

--- a/csrc/polymorphic_value.cpp
+++ b/csrc/polymorphic_value.cpp
@@ -5,9 +5,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-
 #include <polymorphic_value.h>
 #include <type.h>
+
+#include <string>
 
 namespace nvfuser {
 
@@ -37,5 +38,40 @@ bool StructHandle::operator==(const StructHandle& other) const {
   }
   return true;
 }
+
+namespace PolymorphicValue_functions {
+
+std::string toString(const PolymorphicValue& v) {
+  std::stringstream ss;
+  if (v.is<at::Tensor>()) {
+    const auto& t = v.as<at::Tensor>();
+    ss << "Tensor(sizes=" << t.sizes() << ", "
+       << "stride=" << t.strides() << ", dtype=" << t.dtype()
+       << ", device=" << t.device() << ", data_ptr=" << t.data_ptr() << ")";
+  } else if (v.is<std::monostate>()) {
+    ss << "std::monostate";
+  } else if (v.is<StructHandle>()) {
+    const StructHandle& hdl = v.as<StructHandle>();
+    StructType type = (v->*&StructHandle::type)();
+    ss << "StructHandle<" << type.name << ">{";
+    bool first = true;
+    for (size_t i : c10::irange(type.fields.size())) {
+      if (first) {
+        first = false;
+      } else {
+        ss << ", ";
+      }
+      const std::string& fieldname = type.fields.at(i).name;
+      ss << fieldname << "=";
+      ss << toString(hdl->*(fieldname));
+    }
+    ss << "}";
+  } else {
+    ss << v;
+  }
+  return ss.str();
+}
+
+} // namespace PolymorphicValue_functions
 
 } // namespace nvfuser

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -221,20 +221,7 @@ using PolymorphicValue = dynamic_type::DynamicType<
 
 namespace PolymorphicValue_functions {
 
-inline std::string toString(const PolymorphicValue& v) {
-  std::stringstream ss;
-  if (v.is<at::Tensor>()) {
-    const auto& t = v.as<at::Tensor>();
-    ss << "Tensor(sizes=" << t.sizes() << ", "
-       << "stride=" << t.strides() << ", dtype=" << t.dtype()
-       << ", device=" << t.device() << ", data_ptr=" << t.data_ptr() << ")";
-  } else if (v.is<std::monostate>()) {
-    ss << "std::monostate";
-  } else {
-    ss << v;
-  }
-  return ss.str();
-}
+std::string toString(const PolymorphicValue& v);
 
 template <typename T>
 inline bool isNan(const T& a) {

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -221,7 +221,7 @@ using PolymorphicValue = dynamic_type::DynamicType<
 
 namespace PolymorphicValue_functions {
 
-std::string toString(const PolymorphicValue& v);
+NVF_API std::string toString(const PolymorphicValue& v);
 
 template <typename T>
 inline bool isNan(const T& a) {

--- a/tests/cpp/test_evaluator.cpp
+++ b/tests/cpp/test_evaluator.cpp
@@ -453,7 +453,6 @@ TEST_F(ExprEvalTest, TensorMetaData) {
   FusionGuard fg(&fusion);
 
   TensorView* tv = makeSymbolicTensor(2);
-  fusion.addInput(tv);
   auto metadata = IrBuilder::metadataExpr(tv);
   auto data = IrBuilder::getAttrExpr(metadata, "data");
   auto sizes = IrBuilder::getAttrExpr(metadata, "logical_size");
@@ -479,19 +478,6 @@ TEST_F(ExprEvalTest, TensorMetaData) {
   checkIntValue(evaluator, size1, 128L);
   checkIntValue(evaluator, stride0, 128L);
   checkIntValue(evaluator, stride1, 1L);
-
-  {
-    // Now bind a PrecomputedValues and print
-    PrecomputedValues pv(&fusion);
-    evaluator.bindPrecomputedValues(&pv);
-    pv.bindInputs(KernelArgumentHolder::createKernelArgumentHolder({a}));
-
-    // Test that printing works and shows that we have bound something to T0
-    std::ostringstream ss;
-    DebugStreamGuard dsg(ss);
-    evaluator.print();
-    EXPECT_THAT(ss.str(), testing::HasSubstr("( getMetaData(T0) )"));
-  }
 }
 
 TEST_F(ExprEvalTest, Validation) {

--- a/tests/cpp/test_polymorphic_value.cpp
+++ b/tests/cpp/test_polymorphic_value.cpp
@@ -43,6 +43,19 @@ TEST_F(PolymorphicValueTest, OpaqueEquality) {
   EXPECT_NE(c, a2);
 }
 
+TEST_F(PolymorphicValueTest, OpaquePrint) {
+  Opaque a{DataType::Int};
+  struct A {
+    int64_t x;
+    double y;
+  };
+  Opaque a1(A{1, 2.0});
+  EXPECT_THAT(
+      PolymorphicValue_functions::toString(a), testing::StartsWith("Opaque<"));
+  EXPECT_THAT(
+      PolymorphicValue_functions::toString(a1), testing::StartsWith("Opaque<"));
+}
+
 TEST_F(PolymorphicValueTest, Struct) {
   struct A : public Struct {
     int64_t x;
@@ -107,6 +120,10 @@ TEST_F(PolymorphicValueTest, Struct) {
   EXPECT_EQ(*type.fields.at(1).type, DataType::Double);
   EXPECT_FALSE(type.fields.at(1).used_in_kernel);
 
+  EXPECT_EQ(
+      PolymorphicValue_functions::toString(a),
+      "StructHandle<A>{x=2788, y=2.71828}");
+
   {
     // intentionally create a new scope and define another struct with the same
     // name to make sure the previous struct is not accessible
@@ -138,6 +155,9 @@ TEST_F(PolymorphicValueTest, Struct) {
     EXPECT_EQ(b->*"y", PolymorphicValue(3.1415926));
 
     EXPECT_EQ(type, (b->*&StructHandle::type)());
+    EXPECT_EQ(
+        PolymorphicValue_functions::toString(b),
+        "StructHandle<A>{x=299792458, y=3.14159}");
   }
 }
 


### PR DESCRIPTION
I merged #2810 too hastily and wound up breaking CI. This was reverted in #2829. This PR is a second attempt to fix printing of `StructHandle`.