### PR TITLE
Create CPP Fusion to Python FusionDefinition framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,8 @@ if(BUILD_PYTHON)
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_cache.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_definition.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_state.cpp
+    ${NVFUSER_SRCS_DIR}/python_frontend/translation.cpp
+    ${NVFUSER_SRCS_DIR}/python_frontend/translation_utils.cpp
     ${NVFUSER_SRCS_DIR}/serde/fusion_record.cpp
   )
 endif()

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -475,6 +475,10 @@ class TensorDomain : public Val {
     return contiguity_;
   }
 
+  const std::vector<int64_t>& strideOrder() const {
+    return stride_order_;
+  }
+
   NVF_API void setContiguity(const std::vector<std::optional<bool>>& contig);
 
   std::string getContiguityString() const {
@@ -672,6 +676,7 @@ class TensorDomain : public Val {
   std::vector<IterDomain*> no_bcast_domain_;
   std::vector<IterDomain*> no_reduction_domain_;
   std::vector<std::optional<bool>> contiguity_;
+  std::vector<int64_t> stride_order_;
   bool has_reduction_ = false;
 };
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2954,7 +2954,8 @@ TensorDomain::TensorDomain(
       loop_domain_(logical_domain_),
       contiguity_(
           contiguity.empty() ? getContiguityFilledWith(maybeAllocation(), false)
-                             : std::move(contiguity)) {
+                             : std::move(contiguity)),
+      stride_order_(stride_order) {
   // setting the proper allocation domain
   if (!stride_order.empty()) {
     auto rank = logical_domain_.size();

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -891,7 +891,7 @@ TensorView* binaryOp(
         BinaryOpType::op_type, v1, v2, TypePromotion::float_op_config); \
   }
 
-NVFUSER_DEFINE_BINARY_FLOAT_OP(truediv, Div)
+NVFUSER_DEFINE_BINARY_FLOAT_OP(truediv, Truediv)
 NVFUSER_DEFINE_BINARY_FLOAT_OP(atan2, Atan2)
 #undef NVFUSER_DEFINE_BINARY_FLOAT_OP
 

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -165,6 +165,12 @@ class NVF_API FusionDefinition : public FusionState {
   FusionDefinition(FusionDefinition&& fd) = delete;
   FusionDefinition& operator=(const FusionDefinition& fd) = delete;
   FusionDefinition& operator=(FusionDefinition&& fd) = delete;
+  ~FusionDefinition() override = default;
+
+  //! Copy definition from other FusionDefintion's presched CPP fusion.
+  //! Primarily for testing purposes to check that the translation from CPP
+  //! fusion is correct.
+  void clone(FusionDefinition& other);
 
   //! Enter Python Context Manager -- Reset trie for new cache lookup
   NVF_API FusionDefinition* setupDefinition();

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -704,6 +704,11 @@ void initNvFuserPythonBindings(PyObject* module) {
             return ss.str();
           })
       .def(
+          "_clone",
+          [](FusionDefinition& self, FusionDefinition& other) {
+            self.clone(other);
+          })
+      .def(
           "_execute",
           [](FusionDefinition& self,
              const py::iterable& iter,

--- a/csrc/python_frontend/translation.cpp
+++ b/csrc/python_frontend/translation.cpp
@@ -1,0 +1,252 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+//
+#include <dispatch.h>
+#include <python_frontend/translation.h>
+#include <python_frontend/translation_utils.h>
+
+#include <vector>
+
+namespace nvfuser::python_frontend {
+namespace {
+class FusionTranslator : public OptInConstDispatch {
+ public:
+  static void translate(Fusion* fusion, FusionDefinition* fd) {
+    FusionTranslator translator(fusion, fd);
+    translator.translate();
+  }
+
+ private:
+  FusionTranslator(Fusion* fusion, FusionDefinition* fd)
+      : fusion_(fusion), fd_(fd) {}
+
+  bool checkExpressionDependencies(Expr* e) {
+    return std::all_of(
+        e->inputs().begin(), e->inputs().end(), [&](const Val* v) {
+          return map_val_to_fd_index_.count(v) > 0;
+        });
+  }
+
+  void translate() {
+    fd_->setupDefinition();
+
+    std::deque<nvfuser::Expr*> to_visit;
+
+    // Add Fusion inputs to FusionDefinition
+    for (nvfuser::Val* v : fusion_->inputs()) {
+      OptOutConstDispatch::dispatch(v);
+
+      // Add uses for input value to to_visit
+      for (Expr* e : v->uses()) {
+        to_visit.push_back(e);
+      }
+    }
+
+    // Topological search of Fusion expressions
+    std::unordered_set<nvfuser::Expr*> visited;
+    while (!to_visit.empty()) {
+      Expr* e = to_visit.front();
+      to_visit.pop_front();
+
+      // short-circuit: skip if already visited
+      if (visited.count(e) > 0) {
+        continue;
+      }
+
+      // short-circuit: add to back of stack if not all of the expression's
+      // inputs are available.
+      if (!checkExpressionDependencies(e)) {
+        to_visit.push_back(e);
+        continue;
+      }
+
+      visited.insert(e);
+
+      // Create RecordFunctor given inputs, outputs, and attributes.
+      OptOutConstDispatch::dispatch(e);
+
+      // Add output uses to to_visit
+      for (Val* v : e->outputs()) {
+        for (Expr* e : v->uses()) {
+          to_visit.push_back(e);
+        }
+      }
+    }
+
+    // Outputs and Aliasing
+    for (nvfuser::Val* v : fusion_->outputs()) {
+      // Handle only TensorViews
+      NVF_ERROR(v->isA<TensorView>());
+      handleOutput(v->as<TensorView>());
+    }
+
+    fd_->finalizeDefinition();
+  }
+
+  void handle(const Val* v) final {
+    Scalar output = fd_->defineScalar();
+    fd_->defineRecord(new ScalarRecord(
+        {fd_->recordingState(output())},
+        v->value(),
+        std::get<PrimDataType>(v->dtype().type)));
+    map_val_to_fd_index_.emplace(v, output());
+  }
+
+  void handle(const TensorView* tv) final {
+    Tensor output = fd_->defineTensor(tv->nDims());
+
+    std::vector<int64_t> shape;
+    std::transform(
+        tv->domain()->logical().begin(),
+        tv->domain()->logical().end(),
+        std::back_inserter(shape),
+        [](IterDomain* id) {
+          return (id->extent()->isConstScalar())
+              ? id->extent()->evaluate().as<int64_t>()
+              : -1;
+        });
+
+    fd_->defineRecord(new TensorRecord(
+        {fd_->recordingState(output())},
+        shape,
+        tv->domain()->contiguity(),
+        std::get<PrimDataType>(tv->dtype().type),
+        tv->isCpuScalar(),
+        tv->domain()->strideOrder()));
+
+    map_val_to_fd_index_.emplace(tv, output());
+  }
+
+  void handleOutput(const TensorView* tv) {
+    // Add fusion outputs to FusionDefinition
+    size_t output_index = map_val_to_fd_index_.at(tv);
+    fd_->defineRecord(new OutputRecord<TensorView>(
+        {fd_->recordingState(output_index)}, serde::RecordType::OutputTv));
+  }
+
+  void handle(const BroadcastOp* bcast_op) final {
+    Tensor output =
+        fd_->defineTensor(bcast_op->out()->as<TensorView>()->nDims());
+    fd_->defineRecord(new BroadcastOpRecord(
+        {fd_->recordingState(map_val_to_fd_index_.at(bcast_op->in()))},
+        {fd_->recordingState(output())},
+        "ops.broadcast",
+        bcast_op->getBroadcastDimFlags()));
+    map_val_to_fd_index_.emplace(bcast_op->out(), output());
+  }
+
+  template <typename ExprType, typename ResultType, typename... ArgTypes>
+  void handleOpRecord(
+      const Expr* e,
+      serde::RecordType record_type,
+      ResultType result,
+      ArgTypes... args) {
+    NVF_ERROR(e->isA<ExprType>());
+    std::vector<State> argument_states;
+    std::transform(
+        e->inputs().begin(),
+        e->inputs().end(),
+        std::back_inserter(argument_states),
+        [&](auto arg) {
+          return fd_->recordingState(map_val_to_fd_index_.at(arg));
+        });
+
+    fd_->defineRecord(new OpRecord<ResultType, ArgTypes...>(
+        argument_states,
+        {fd_->recordingState(map_val_to_fd_index_.at(result))},
+        "ops." + getString(e->as<ExprType>()),
+        record_type,
+        getFunction<ResultType, ArgTypes...>(e->as<ExprType>())));
+  }
+
+  void handle(const UnaryOp* uop) final {
+    NVF_ERROR(uop->getUnaryOpType() == UnaryOpType::Cast);
+    handleCastOp(uop);
+  }
+
+  void handleCastOp(const UnaryOp* uop) {
+    NVF_ERROR(uop->getUnaryOpType() == UnaryOpType::Cast);
+    size_t input_fd_index = map_val_to_fd_index_.at(uop->in());
+    if (uop->in()->isA<TensorView>()) {
+      Tensor output = fd_->defineTensor(uop->out()->as<TensorView>()->nDims());
+      map_val_to_fd_index_.emplace(uop->out(), output());
+      fd_->defineRecord(new CastOpRecord<TensorView*, TensorView*>(
+          {fd_->recordingState(input_fd_index)},
+          {fd_->recordingState(output())},
+          "ops.cast",
+          serde::RecordType::CastTv,
+          static_cast<TensorView* (*)(DataType, TensorView*)>(castOp),
+          std::get<PrimDataType>(uop->in()->dtype().type)));
+    } else {
+      Scalar output = fd_->defineScalar();
+      map_val_to_fd_index_.emplace(uop->out(), output());
+      fd_->defineRecord(new CastOpRecord<Val*, Val*>(
+          {fd_->recordingState(input_fd_index)},
+          {fd_->recordingState(output())},
+          "ops.cast",
+          serde::RecordType::CastVal,
+          static_cast<Val* (*)(DataType, Val*)>(castOp),
+          std::get<PrimDataType>(uop->in()->dtype().type)));
+    }
+  }
+
+  void handle(const BinaryOp* bop) final {
+    bool is_lhs_tv = bop->lhs()->isA<TensorView>();
+    bool is_rhs_tv = bop->rhs()->isA<TensorView>();
+
+    if (is_lhs_tv || is_rhs_tv) {
+      Tensor output = fd_->defineTensor(bop->out()->as<TensorView>()->nDims());
+      map_val_to_fd_index_.emplace(bop->out(), output());
+
+      if (is_lhs_tv && is_rhs_tv) {
+        handleOpRecord<nvfuser::BinaryOp>(
+            bop,
+            serde::RecordType::Binary_TV,
+            bop->out()->as<TensorView>(),
+            bop->lhs()->as<TensorView>(),
+            bop->rhs()->as<TensorView>());
+      } else if (is_lhs_tv && !is_rhs_tv) {
+        handleOpRecord<nvfuser::BinaryOp>(
+            bop,
+            serde::RecordType::Binary_TV_VAL,
+            bop->out()->as<TensorView>(),
+            bop->lhs()->as<TensorView>(),
+            bop->rhs());
+      } else {
+        handleOpRecord<nvfuser::BinaryOp>(
+            bop,
+            serde::RecordType::Binary_VAL_TV,
+            bop->out()->as<TensorView>(),
+            bop->lhs(),
+            bop->rhs()->as<TensorView>());
+      }
+    } else {
+      Scalar output = fd_->defineScalar();
+      map_val_to_fd_index_.emplace(bop->out(), output());
+      handleOpRecord<nvfuser::BinaryOp>(
+          bop,
+          serde::RecordType::Binary_VAL,
+          bop->out(),
+          bop->lhs(),
+          bop->rhs());
+    }
+  }
+
+ private:
+  const Fusion* fusion_ = nullptr;
+  FusionDefinition* fd_ = nullptr;
+  std::unordered_map<const nvfuser::Val*, size_t> map_val_to_fd_index_;
+};
+
+} // namespace
+
+void translate(Fusion* fusion, FusionDefinition* fd) {
+  FusionTranslator::translate(fusion, fd);
+}
+
+} // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/translation.h
+++ b/csrc/python_frontend/translation.h
@@ -1,0 +1,18 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+#include <fusion.h>
+#include <python_frontend/fusion_definition.h>
+#include <python_frontend/fusion_record.h>
+
+namespace nvfuser::python_frontend {
+
+// Translate a CPP Fusion into a Python FusionDefinition.
+void translate(Fusion* fusion, FusionDefinition* fd);
+
+} // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/translation_utils.cpp
+++ b/csrc/python_frontend/translation_utils.cpp
@@ -1,0 +1,102 @@
+
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+//
+#include <ops/all_ops.h>
+#include <python_frontend/translation_utils.h>
+
+namespace nvfuser::python_frontend {
+
+std::string getString(const BinaryOp* bop) {
+  switch (bop->getBinaryOpType()) {
+    case BinaryOpType::Add:
+      return "add";
+      break;
+    case BinaryOpType::Atan2:
+      return "atan2";
+      break;
+    case BinaryOpType::Div:
+      return "div";
+      break;
+    case BinaryOpType::Truediv:
+      return "truediv";
+      break;
+    case BinaryOpType::Fmod:
+      return "fmod";
+      break;
+    case BinaryOpType::Mul:
+      return "mul";
+      break;
+    case BinaryOpType::Nextafter:
+      return "nextafter";
+      break;
+    case BinaryOpType::Pow:
+      return "pow";
+      break;
+    case BinaryOpType::Remainder:
+      return "remainder";
+      break;
+    case BinaryOpType::Sub:
+      return "sub";
+      break;
+    case BinaryOpType::Mod:
+      return "mod";
+      break;
+    case BinaryOpType::Eq:
+      return "eq";
+      break;
+    case BinaryOpType::NE:
+      return "ne";
+      break;
+    case BinaryOpType::GT:
+      return "gt";
+      break;
+    case BinaryOpType::GE:
+      return "ge";
+      break;
+    case BinaryOpType::LT:
+      return "lt";
+      break;
+    case BinaryOpType::LE:
+      return "le";
+      break;
+    case BinaryOpType::BitwiseAnd:
+      return "bitwise_and";
+      break;
+    case BinaryOpType::BitwiseOr:
+      return "bitwise_or";
+      break;
+    case BinaryOpType::BitwiseXor:
+      return "bitwise_xor";
+      break;
+    case BinaryOpType::LogicalAnd:
+      return "logical_and";
+      break;
+    case BinaryOpType::LogicalOr:
+      return "logical_or";
+      break;
+    case BinaryOpType::Lshift:
+      return "bitwise_left_shift";
+      break;
+    case BinaryOpType::Rshift:
+      return "bitwise_right_shift";
+      break;
+    case BinaryOpType::Gcd:
+      return "gcd";
+      break;
+    default:
+      NVF_CHECK(
+          false,
+          "Unexpected operator type: ",
+          bop->getBinaryOpType(),
+          " in ",
+          bop->toString());
+  }
+}
+
+} // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/translation_utils.h
+++ b/csrc/python_frontend/translation_utils.h
@@ -1,0 +1,109 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+#include <ir/all_nodes.h>
+
+namespace nvfuser::python_frontend {
+
+// Get std::function for BinaryOp
+template <typename ResultType, typename... ArgTypes>
+std::function<ResultType(ArgTypes...)> getFunction(const BinaryOp* bop) {
+  auto get_std_function = [](ResultType (*fn)(ArgTypes...)) {
+    return static_cast<ResultType (*)(ArgTypes...)>(fn);
+  };
+
+  switch (bop->getBinaryOpType()) {
+    case BinaryOpType::Add:
+      return get_std_function(add);
+      break;
+    case BinaryOpType::Atan2:
+      return get_std_function(atan2);
+      break;
+    case BinaryOpType::Div:
+      return get_std_function(div);
+      break;
+    case BinaryOpType::Truediv:
+      return get_std_function(truediv);
+      break;
+    case BinaryOpType::Fmod:
+      return get_std_function(fmod);
+      break;
+    case BinaryOpType::Mul:
+      return get_std_function(mul);
+      break;
+    case BinaryOpType::Nextafter:
+      return get_std_function(nextafter);
+      break;
+    case BinaryOpType::Pow:
+      return get_std_function(pow);
+      break;
+    case BinaryOpType::Remainder:
+      return get_std_function(remainder);
+      break;
+    case BinaryOpType::Sub:
+      return get_std_function(sub);
+      break;
+    case BinaryOpType::Mod:
+      return get_std_function(mod);
+      break;
+    case BinaryOpType::Eq:
+      return get_std_function(eq);
+      break;
+    case BinaryOpType::NE:
+      return get_std_function(ne);
+      break;
+    case BinaryOpType::GT:
+      return get_std_function(gt);
+      break;
+    case BinaryOpType::GE:
+      return get_std_function(ge);
+      break;
+    case BinaryOpType::LT:
+      return get_std_function(lt);
+      break;
+    case BinaryOpType::LE:
+      return get_std_function(le);
+      break;
+    case BinaryOpType::BitwiseAnd:
+      return get_std_function(bitwise_and);
+      break;
+    case BinaryOpType::BitwiseOr:
+      return get_std_function(bitwise_or);
+      break;
+    case BinaryOpType::BitwiseXor:
+      return get_std_function(bitwise_xor);
+      break;
+    case BinaryOpType::LogicalAnd:
+      return get_std_function(logical_and);
+      break;
+    case BinaryOpType::LogicalOr:
+      return get_std_function(logical_or);
+      break;
+    case BinaryOpType::Lshift:
+      return get_std_function(bitwise_left_shift);
+      break;
+    case BinaryOpType::Rshift:
+      return get_std_function(bitwise_right_shift);
+      break;
+    case BinaryOpType::Gcd:
+      return get_std_function(gcd);
+      break;
+    default:
+      NVF_CHECK(
+          false,
+          "Unexpected operator type: ",
+          bop->getBinaryOpType(),
+          " in ",
+          bop->toString());
+  }
+}
+
+// Get string name for BinaryOp
+std::string getString(const BinaryOp* bop);
+
+} // namespace nvfuser::python_frontend

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -500,6 +500,7 @@ bool needFloatSuffix(BinaryOpType t) {
     case BinaryOpType::Atan2:
     case BinaryOpType::Div:
     case BinaryOpType::Fmod:
+    case BinaryOpType::Truediv:
       return true;
     default:
       return false;
@@ -513,6 +514,7 @@ static const char* binary_op_type2string(BinaryOpType t) {
     case BinaryOpType::Atan2:
       return "atan2";
     case BinaryOpType::Div:
+    case BinaryOpType::Truediv:
       return "div";
     case BinaryOpType::Fmod:
       return "fmod";
@@ -606,6 +608,7 @@ static const char* binary_op_type_inline_op2string(BinaryOpType t) {
     case BinaryOpType::Add:
       return "+";
     case BinaryOpType::Div:
+    case BinaryOpType::Truediv:
       return "/";
     case BinaryOpType::Mul:
       return "*";

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -609,6 +609,7 @@ enum class BinaryOpType {
   Pow,
   Remainder,
   Sub,
+  Truediv,
   // TypeAs,
 
   // Integer output ops.

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -54,6 +54,11 @@ class FusionDefinition(_C._FusionDefinition):
         super(FusionDefinition, self).__init__(id, max_length)
         self.profiled = False
 
+    def clone(self):
+        new_fd = FusionDefinition()
+        new_fd._clone(self)
+        return new_fd
+
     def __enter__(self):
         return self._setup_definition()
 

--- a/tests/cpp/python_frontend/test_nvfuser_fusion_definition.cpp
+++ b/tests/cpp/python_frontend/test_nvfuser_fusion_definition.cpp
@@ -12,6 +12,7 @@
 
 #include <python_frontend/fusion_definition.h>
 #include <python_frontend/fusion_record.h>
+#include <python_frontend/translation.h>
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
 
@@ -171,6 +172,24 @@ TEST_F(NVFuserTest, FusionDefinition_CUDA) {
              << e.what();
     }
   }
+}
+
+TEST_F(NVFuserTest, CreateFusionDefinition) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* tv0 = makeContigConcreteTensor({128});
+  TensorView* tv1 = makeContigConcreteTensor({128});
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+  TensorView* tv2 = add(tv0, tv1);
+  fusion.addOutput(tv2);
+
+  auto fd = std::make_unique<FusionDefinition>(/*id=*/std::nullopt);
+  python_frontend::translate(&fusion, fd.get());
+  std::stringstream ss;
+  fd->print(ss);
+  std::cout << ss.str() << std::endl;
 }
 
 } // namespace nvfuser

--- a/tests/python/pytest_core.py
+++ b/tests/python/pytest_core.py
@@ -121,3 +121,7 @@ class OpInfo:
     # All keyword arguments are considered constant.
     # If symbolic_parameter_list is None, then we assume all parameters to be symbolic.
     symbolic_parameter_list: Optional[list[ArgumentType]] = None
+
+    # Enable check_cpp_translation test
+    # Tests that translation from CPP Fusion back to Python FusionDefinition is correct.
+    is_clonable: bool = False

--- a/tests/python/pytest_framework.py
+++ b/tests/python/pytest_framework.py
@@ -74,4 +74,14 @@ class atexit_serde_create_op_test(create_op_test):
 
         atexit_serde_check()
 
-        create_op_test.__init__(self, opinfos, scope=scope)
+        # Replicate create_op_test.__init__ to have correct scope
+        self.opinfos = opinfos
+
+        # Acquires the caller's global scope
+        if scope is None:
+            previous_frame = inspect.currentframe().f_back
+            scope = previous_frame.f_globals
+        self.scope = scope
+
+    def __call__(self, test_template):
+        return create_op_test.__call__(self, test_template)

--- a/tests/python/pytest_opinfos.py
+++ b/tests/python/pytest_opinfos.py
@@ -523,6 +523,7 @@ add_opinfo = OpInfo(
         elementwise_binary_generator, enable_extremal_value_testing=False
     ),
     reference=_elementwise_binary_torch(torch.add),
+    is_clonable=True,
 )
 binary_ops.append(add_opinfo)
 
@@ -533,6 +534,7 @@ atan2_opinfo = OpInfo(
     dtypes=int_float_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.atan2),
+    is_clonable=True,
 )
 binary_ops.append(atan2_opinfo)
 
@@ -542,6 +544,7 @@ bitwise_and_opinfo = OpInfo(
     dtypes=bool_int_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.bitwise_and),
+    is_clonable=True,
 )
 binary_ops.append(bitwise_and_opinfo)
 
@@ -551,6 +554,7 @@ bitwise_left_shift_opinfo = OpInfo(
     dtypes=int_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.bitwise_left_shift),
+    is_clonable=True,
 )
 binary_ops.append(bitwise_left_shift_opinfo)
 
@@ -560,6 +564,7 @@ bitwise_or_opinfo = OpInfo(
     dtypes=bool_int_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.bitwise_or),
+    is_clonable=True,
 )
 binary_ops.append(bitwise_or_opinfo)
 
@@ -569,6 +574,7 @@ bitwise_right_shift_opinfo = OpInfo(
     dtypes=int_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.bitwise_right_shift),
+    is_clonable=True,
 )
 binary_ops.append(bitwise_right_shift_opinfo)
 
@@ -578,6 +584,7 @@ bitwise_xor_opinfo = OpInfo(
     dtypes=bool_int_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.bitwise_xor),
+    is_clonable=True,
 )
 binary_ops.append(bitwise_xor_opinfo)
 
@@ -587,6 +594,7 @@ div_opinfo = OpInfo(
     dtypes=float_complex_dtypes,
     sample_input_generator=div_input_generator,
     reference=_elementwise_binary_torch(torch.div),
+    is_clonable=True,
 )
 binary_ops.append(div_opinfo)
 
@@ -595,6 +603,7 @@ eq_opinfo = OpInfo(
     "eq",
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.eq),
+    is_clonable=True,
 )
 binary_ops.append(eq_opinfo)
 
@@ -604,6 +613,7 @@ fmod_opinfo = OpInfo(
     dtypes=int_float_dtypes,
     sample_input_generator=partial(elementwise_binary_generator, exclude_zero=True),
     reference=_elementwise_binary_torch(torch.fmod),
+    is_clonable=True,
 )
 binary_ops.append(fmod_opinfo)
 
@@ -613,6 +623,7 @@ ge_opinfo = OpInfo(
     dtypes=int_float_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.ge),
+    is_clonable=True,
 )
 binary_ops.append(ge_opinfo)
 
@@ -622,6 +633,7 @@ gt_opinfo = OpInfo(
     dtypes=int_float_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.gt),
+    is_clonable=True,
 )
 binary_ops.append(gt_opinfo)
 
@@ -631,6 +643,7 @@ le_opinfo = OpInfo(
     dtypes=int_float_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.le),
+    is_clonable=True,
 )
 binary_ops.append(le_opinfo)
 
@@ -649,6 +662,7 @@ logical_right_shift_opinfo = OpInfo(
     ),
     reference=jax.lax.shift_right_logical if JAX_AVAILABLE else None,
     reference_type=ReferenceType.Jax,
+    is_clonable=True,
 )
 binary_ops.append(logical_right_shift_opinfo)
 
@@ -658,6 +672,7 @@ lt_opinfo = OpInfo(
     dtypes=int_float_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.lt),
+    is_clonable=True,
 )
 binary_ops.append(lt_opinfo)
 
@@ -672,6 +687,7 @@ mod_opinfo = OpInfo(
     # Matlab rem (Remainder after Division) function
     # For more details, see https://www.mathworks.com/help/matlab/ref/rem.html
     reference=lambda a, b: a - b * torch.trunc(a / b).to(a.dtype),
+    is_clonable=True,
 )
 binary_ops.append(mod_opinfo)
 
@@ -682,6 +698,7 @@ mul_opinfo = OpInfo(
         elementwise_binary_generator, enable_extremal_value_testing=False
     ),
     reference=_elementwise_binary_torch(torch.mul),
+    is_clonable=True,
 )
 binary_ops.append(mul_opinfo)
 
@@ -690,6 +707,7 @@ ne_opinfo = OpInfo(
     "ne",
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.ne),
+    is_clonable=True,
 )
 binary_ops.append(ne_opinfo)
 
@@ -699,6 +717,7 @@ nextafter_opinfo = OpInfo(
     dtypes=full_precision_float_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.nextafter),
+    is_clonable=True,
 )
 binary_ops.append(nextafter_opinfo)
 
@@ -709,6 +728,7 @@ pow_opinfo = OpInfo(
     dtypes=int_float_dtypes,
     sample_input_generator=elementwise_binary_generator,
     reference=_elementwise_binary_torch(torch.pow),
+    is_clonable=True,
 )
 binary_ops.append(pow_opinfo)
 
@@ -722,6 +742,7 @@ remainder_opinfo = OpInfo(
         enable_extremal_value_testing=False,
     ),
     reference=_elementwise_binary_torch(torch.remainder),
+    is_clonable=True,
 )
 binary_ops.append(remainder_opinfo)
 
@@ -732,6 +753,7 @@ sub_opinfo = OpInfo(
         elementwise_binary_generator, enable_extremal_value_testing=False
     ),
     reference=_elementwise_binary_torch(torch.sub),
+    is_clonable=True,
 )
 binary_ops.append(sub_opinfo)
 
@@ -740,6 +762,7 @@ truediv_opinfo = OpInfo(
     "truediv",
     sample_input_generator=div_input_generator,
     reference=_elementwise_binary_torch(torch.true_divide),
+    is_clonable=True,
 )
 binary_ops.append(truediv_opinfo)
 
@@ -755,6 +778,7 @@ trunc_div_opinfo = OpInfo(
         exclude_zero=True,
     ),
     reference=_elementwise_binary_torch(partial(torch.div, rounding_mode="trunc")),
+    is_clonable=True,
 )
 binary_ops.append(trunc_div_opinfo)
 

--- a/tests/python/pytest_ops.py
+++ b/tests/python/pytest_ops.py
@@ -18,7 +18,12 @@ from typing import Callable
 
 from nvfuser import FusionCache, FusionDefinition
 
-from utils import check_captured_python_definition, debug_serde, basic_serde_check
+from utils import (
+    check_captured_python_definition,
+    check_cpp_translation,
+    debug_serde,
+    basic_serde_check,
+)
 
 
 def serde_check_ops(test_fn: Callable):
@@ -80,6 +85,9 @@ def torch_correctness_test_fn(fd_fn: Callable, nvf_op: OpInfo, sample: SampleInp
     inputs_cap = deepcopy(inputs)
     nvfuser_result = fd.execute(inputs)
     assert check_captured_python_definition(nvfuser_result, fd, inputs_cap)
+
+    if nvf_op.is_clonable:
+        assert check_cpp_translation(nvfuser_result, fd, inputs_cap)
 
     torch_result = nvf_op.reference(*sample.args, **sample.kwargs)
 


### PR DESCRIPTION
## Goal ##
Translate from CPP `Fusion` to Python `FusionDefinition`

## Why ##
- Access fusions in python frontend after running `Presegmentation` and `Segmentation` passes.  

## Overview ##

- This PR creates `void translate(Fusion* fusion, FusionDefinition* fd)`, which translates the CPP fusion's expressions and values into corresponding `RecordFunctors` for `FusionDefinition`.
- `FusionDefinition::clone(FusionDefinition& other)` acts like a copy constructor. It translates the prescheduled fusion from `other` to the blank `FusionDefinition`. Only used for testing purposes.
- It adds `check_cpp_translation` check to python testing, which checks that the translated CPP fusion is functionally equivalent to original `FusionDefinition`.
- Currently, only the binary operations are supported with `FusionTranslation`. The remaining operations will be added in future PRs.