### PR TITLE
Move `clear_cuda_cache` to `nvfuser` module

### DIFF
--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -2,7 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from .core import DEVICE_PROPERTIES, BENCHMARK_CONFIG
+from .core import BENCHMARK_CONFIG
+from nvfuser.pytorch_utils import DEVICE_PROPERTIES
 
 
 def pytest_addoption(parser):

--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -2,8 +2,7 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from .core import BENCHMARK_CONFIG
-from nvfuser.pytorch_utils import DEVICE_PROPERTIES
+from .core import DEVICE_PROPERTIES, BENCHMARK_CONFIG
 
 
 def pytest_addoption(parser):

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -37,6 +37,7 @@ def clear_dynamo_cache() -> None:
     """
     torch._dynamo.reset()
 
+
 # Backward function for torch baseline benchmarks.
 def unary_bwd_torch(inputs: List):  # [output, grad_out]
     inputs[0].backward(inputs[1], retain_graph=True)

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -8,13 +8,14 @@ from torch.profiler import profile, ProfilerActivity
 from typing import List, Callable, Union
 import numpy as np
 from nvfuser import FusionDefinition, FusionCache
-from nvfuser.pytorch_utils import DEVICE_PROPERTIES
+from nvfuser.pytorch_utils import get_device_properties
 
 # These variables can be overwritten through CLI commands
 # --benchmark-rounds=rounds --benchmark-warmup-rounds=warmup_rounds
 # --benchmark-num-inputs=num_inputs
 BENCHMARK_CONFIG = {"rounds": 10, "warmup_rounds": 1, "num_inputs": None}
 
+DEVICE_PROPERTIES = get_device_properties()
 L2_CACHE_SIZE = DEVICE_PROPERTIES["gpu_l2_bytes"]
 PEAK_BANDWIDTH_GBPS = DEVICE_PROPERTIES["gpu_peak_bandwidth_gbps"]
 

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -8,14 +8,13 @@ from torch.profiler import profile, ProfilerActivity
 from typing import List, Callable, Union
 import numpy as np
 from nvfuser import FusionDefinition, FusionCache
-from nvfuser.pytorch_utils import get_device_properties
+from nvfuser.pytorch_utils import DEVICE_PROPERTIES
 
 # These variables can be overwritten through CLI commands
 # --benchmark-rounds=rounds --benchmark-warmup-rounds=warmup_rounds
 # --benchmark-num-inputs=num_inputs
 BENCHMARK_CONFIG = {"rounds": 10, "warmup_rounds": 1, "num_inputs": None}
 
-DEVICE_PROPERTIES = get_device_properties()
 L2_CACHE_SIZE = DEVICE_PROPERTIES["gpu_l2_bytes"]
 PEAK_BANDWIDTH_GBPS = DEVICE_PROPERTIES["gpu_peak_bandwidth_gbps"]
 

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -1,128 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
-import ctypes
-import gc
 import pytest_benchmark
 import torch
 from torch.autograd import DeviceType
 from torch.profiler import profile, ProfilerActivity
-from typing import List, Callable, Union, Tuple
+from typing import List, Callable, Union
 import numpy as np
 from nvfuser import FusionDefinition, FusionCache
-
-
-def get_device_properties() -> Tuple[int, float]:
-    """
-    Computes device properties using ctypes and cuda.
-    Note: Consider using CUDA-Python when CUDA support >= 12.0.
-    """
-    libnames = ("libcuda.so", "libcuda.dylib", "nvcuda.dll", "cuda.dll")
-    for libname in libnames:
-        try:
-            cuda = ctypes.CDLL(libname)
-        except OSError:
-            continue
-        else:
-            break
-    else:
-        raise OSError("could not load any of: " + " ".join(libnames))
-
-    # Device attribute enums (taken from cuda.h)
-    # https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1ge12b8a782bebe21b1ac0091bf9f4e2a3
-
-    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1
-    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8
-    CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK = 12
-    CU_DEVICE_ATTRIBUTE_CLOCK_RATE = 13
-    CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE = 36
-    CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH = 37
-    CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE = 38
-    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR = 39
-
-    device_properties = {}
-    device = torch.cuda.current_device()
-    cuda_properties = torch.cuda.get_device_properties(device)
-
-    device_properties["gpu_name"] = cuda_properties.name
-    device_properties["gpu_compute_capability_major"] = cuda_properties.major
-    device_properties["gpu_compute_capability_minor"] = cuda_properties.minor
-    device_properties["gpu_gmem_bytes"] = cuda_properties.total_memory
-    device_properties["gpu_sm_count"] = cuda_properties.multi_processor_count
-
-    max_threads_per_block = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(max_threads_per_block),
-        CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
-        device,
-    )
-    device_properties["gpu_max_threads_per_block"] = max_threads_per_block.value
-
-    smem_per_block = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(smem_per_block),
-        CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
-        device,
-    )
-    device_properties["gpu_smem_bytes_per_block"] = smem_per_block.value
-
-    max_reg_per_block = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(max_reg_per_block),
-        CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
-        device,
-    )
-    device_properties["gpu_regs_per_block"] = max_reg_per_block.value
-
-    max_clock_khz = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(max_clock_khz),
-        CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
-        device,
-    )
-    device_properties["gpu_clock_rate_khz"] = max_clock_khz.value
-
-    l2_cache_size = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(l2_cache_size), CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, device
-    )
-    device_properties["gpu_l2_bytes"] = l2_cache_size.value
-
-    memory_clock_rate = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(memory_clock_rate), CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, device
-    )
-    device_properties["gpu_mem_clock_khz"] = memory_clock_rate.value
-
-    memory_bus_width = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(memory_bus_width),
-        CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH,
-        device,
-    )
-    device_properties["gpu_mem_bus_width"] = memory_bus_width.value
-
-    max_threads_per_sm = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(max_threads_per_sm),
-        CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,
-        device,
-    )
-    device_properties["gpu_max_threads_per_sm"] = max_threads_per_sm.value
-
-    # Compute peak bandwidth in GBps
-    peak_bandwidth = (2 * memory_bus_width.value * memory_clock_rate.value) / (1e6 * 8)
-    device_properties["gpu_peak_bandwidth_gbps"] = peak_bandwidth
-
-    return device_properties
-
+from nvfuser.pytorch_utils import DEVICE_PROPERTIES
 
 # These variables can be overwritten through CLI commands
 # --benchmark-rounds=rounds --benchmark-warmup-rounds=warmup_rounds
 # --benchmark-num-inputs=num_inputs
 BENCHMARK_CONFIG = {"rounds": 10, "warmup_rounds": 1, "num_inputs": None}
 
-DEVICE_PROPERTIES = get_device_properties()
 L2_CACHE_SIZE = DEVICE_PROPERTIES["gpu_l2_bytes"]
 PEAK_BANDWIDTH_GBPS = DEVICE_PROPERTIES["gpu_peak_bandwidth_gbps"]
 
@@ -144,19 +36,6 @@ def clear_dynamo_cache() -> None:
     Ref: https://github.com/pytorch/pytorch/issues/107444
     """
     torch._dynamo.reset()
-
-
-def clear_cuda_cache() -> None:
-    """
-    Utility function to clear CUDA cache before running a test.
-    """
-    if (
-        torch.cuda.memory_allocated()
-        or torch.cuda.memory_reserved() > 0.8 * DEVICE_PROPERTIES["gpu_gmem_bytes"]
-    ):
-        gc.collect()
-        torch.cuda.empty_cache()
-
 
 # Backward function for torch baseline benchmarks.
 def unary_bwd_torch(inputs: List):  # [output, grad_out]

--- a/benchmarks/python/global_params.py
+++ b/benchmarks/python/global_params.py
@@ -4,7 +4,8 @@
 import torch
 from typing import Union, List, Tuple
 from nvfuser import DataType
-from .core import DEVICE_PROPERTIES, BENCHMARK_CONFIG
+from .core import BENCHMARK_CONFIG
+from nvfuser.pytorch_utils import DEVICE_PROPERTIES
 import itertools
 import os
 from random import sample

--- a/benchmarks/python/normalization.py
+++ b/benchmarks/python/normalization.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from nvfuser import FusionDefinition, DataType
 from .global_params import PROMOTE_DTYPES
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
 import torch
-from .core import run_benchmark, clear_cuda_cache, unary_bwd_torch, clear_dynamo_cache
+from .core import run_benchmark, unary_bwd_torch, clear_dynamo_cache
 import numpy as np
 
 

--- a/benchmarks/python/test_dropout_layernorm_bwd.py
+++ b/benchmarks/python/test_dropout_layernorm_bwd.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
 from .core import (
     run_benchmark,
-    clear_cuda_cache,
     clear_dynamo_cache,
     unary_bwd_torch,
     compute_total_iobytes,

--- a/benchmarks/python/test_dropout_layernorm_fwd.py
+++ b/benchmarks/python/test_dropout_layernorm_fwd.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
 from .core import (
     run_benchmark,
-    clear_cuda_cache,
     clear_dynamo_cache,
     compute_total_iobytes,
 )

--- a/benchmarks/python/test_dropout_rmsnorm_bwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_bwd.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
 from .core import (
     run_benchmark,
-    clear_cuda_cache,
     clear_dynamo_cache,
     unary_bwd_torch,
     compute_total_iobytes,

--- a/benchmarks/python/test_dropout_rmsnorm_fwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_fwd.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
 from .core import (
     run_benchmark,
-    clear_cuda_cache,
     clear_dynamo_cache,
     compute_total_iobytes,
 )

--- a/benchmarks/python/test_gelu_bwd.py
+++ b/benchmarks/python/test_gelu_bwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache, unary_bwd_torch
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_gelu_bwd_reduction.py
+++ b/benchmarks/python/test_gelu_bwd_reduction.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_gelu_fwd.py
+++ b/benchmarks/python/test_gelu_fwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/benchmarks/python/test_groupnorm_fwd.py
+++ b/benchmarks/python/test_groupnorm_fwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 import thunder
 from thunder.executors.nvfuserex import nvfuserex

--- a/benchmarks/python/test_huggingface_attn_bwd.py
+++ b/benchmarks/python/test_huggingface_attn_bwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache, unary_bwd_torch
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/benchmarks/python/test_huggingface_attn_fwd.py
+++ b/benchmarks/python/test_huggingface_attn_fwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache, unary_bwd_torch
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_many_pointwise_ops.py
+++ b/benchmarks/python/test_many_pointwise_ops.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark
 import torch
 from .global_params import PROMOTE_DTYPES
 from functools import partial

--- a/benchmarks/python/test_matmul.py
+++ b/benchmarks/python/test_matmul.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition
-from .core import run_benchmark, clear_cuda_cache
+from nvfuser.pytorch_utils import clear_cuda_cache
+from .core import run_benchmark
 import torch
 
 import csv

--- a/benchmarks/python/test_nanogpt_attn_bwd.py
+++ b/benchmarks/python/test_nanogpt_attn_bwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache, unary_bwd_torch
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/benchmarks/python/test_nanogpt_attn_fwd.py
+++ b/benchmarks/python/test_nanogpt_attn_fwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/benchmarks/python/test_pointwise_mul.py
+++ b/benchmarks/python/test_pointwise_mul.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/benchmarks/python/test_reduction.py
+++ b/benchmarks/python/test_reduction.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/benchmarks/python/test_reduction_epilogue.py
+++ b/benchmarks/python/test_reduction_epilogue.py
@@ -4,8 +4,8 @@
 
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/benchmarks/python/test_rmsnorm_bwd.py
+++ b/benchmarks/python/test_rmsnorm_bwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache, unary_bwd_torch
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_rmsnorm_fwd.py
+++ b/benchmarks/python/test_rmsnorm_fwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_rope.py
+++ b/benchmarks/python/test_rope.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from .core import run_benchmark, clear_cuda_cache
+from nvfuser.pytorch_utils import clear_cuda_cache
+from .core import run_benchmark
 import torch
 
 

--- a/benchmarks/python/test_scale_bias_relu_bwd.py
+++ b/benchmarks/python/test_scale_bias_relu_bwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache, unary_bwd_torch
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_scale_bias_relu_fwd.py
+++ b/benchmarks/python/test_scale_bias_relu_fwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_silu_mul_bwd.py
+++ b/benchmarks/python/test_silu_mul_bwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache, unary_bwd_torch
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_silu_mul_fwd.py
+++ b/benchmarks/python/test_silu_mul_fwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/benchmarks/python/test_softmax_bwd.py
+++ b/benchmarks/python/test_softmax_bwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES
 import numpy as np

--- a/benchmarks/python/test_softmax_fwd.py
+++ b/benchmarks/python/test_softmax_fwd.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_transformer.py
+++ b/benchmarks/python/test_transformer.py
@@ -39,7 +39,8 @@ backward nvFusion executed many times.
 """
 
 from nvfuser import FusionDefinition, DataType
-from .core import run_benchmark, clear_cuda_cache
+from .core import run_benchmark
+from nvfuser.pytorch_utils import clear_cuda_cache
 import torch
 
 

--- a/benchmarks/python/test_transpose.py
+++ b/benchmarks/python/test_transpose.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_cuda_cache, clear_dynamo_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/nvfuser/pytorch_utils.py
+++ b/nvfuser/pytorch_utils.py
@@ -62,6 +62,9 @@ def get_device_properties() -> Tuple[int, float]:
     """
     Computes device properties using ctypes and cuda.
     Note: Consider using CUDA-Python when CUDA support >= 12.0.
+    Loading libraries will raise errors on non-CUDA machines, so this
+    function should be called within other functions where this info is needed
+    instead of having a global variable.
     """
     libnames = ("libcuda.so", "libcuda.dylib", "nvcuda.dll", "cuda.dll")
     for libname in libnames:
@@ -163,16 +166,14 @@ def get_device_properties() -> Tuple[int, float]:
     return device_properties
 
 
-DEVICE_PROPERTIES = get_device_properties()
-
-
 def clear_cuda_cache() -> None:
     """
     Utility function to clear CUDA cache before running a test.
     """
+    device_properties = get_device_properties()
     if (
         torch.cuda.memory_allocated()
-        or torch.cuda.memory_reserved() > 0.8 * DEVICE_PROPERTIES["gpu_gmem_bytes"]
+        or torch.cuda.memory_reserved() > 0.8 * device_properties["gpu_gmem_bytes"]
     ):
         gc.collect()
         torch.cuda.empty_cache()

--- a/nvfuser/pytorch_utils.py
+++ b/nvfuser/pytorch_utils.py
@@ -162,7 +162,9 @@ def get_device_properties() -> Tuple[int, float]:
 
     return device_properties
 
+
 DEVICE_PROPERTIES = get_device_properties()
+
 
 def clear_cuda_cache() -> None:
     """

--- a/nvfuser/pytorch_utils.py
+++ b/nvfuser/pytorch_utils.py
@@ -2,7 +2,9 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import torch
-from typing import Type, Union
+from typing import Type, Union, Tuple
+import ctypes
+import gc
 
 from ._C import DataType
 
@@ -54,3 +56,121 @@ def patch_codegen_so():
         os.path.join(src_dir, "libnvfuser_codegen.so"),
         os.path.join(dst_dir, "libnvfuser_codegen.so"),
     )
+
+
+def get_device_properties() -> Tuple[int, float]:
+    """
+    Computes device properties using ctypes and cuda.
+    Note: Consider using CUDA-Python when CUDA support >= 12.0.
+    """
+    libnames = ("libcuda.so", "libcuda.dylib", "nvcuda.dll", "cuda.dll")
+    for libname in libnames:
+        try:
+            cuda = ctypes.CDLL(libname)
+        except OSError:
+            continue
+        else:
+            break
+    else:
+        raise OSError("could not load any of: " + " ".join(libnames))
+
+    # Device attribute enums (taken from cuda.h)
+    # https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1ge12b8a782bebe21b1ac0091bf9f4e2a3
+
+    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1
+    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8
+    CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK = 12
+    CU_DEVICE_ATTRIBUTE_CLOCK_RATE = 13
+    CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE = 36
+    CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH = 37
+    CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE = 38
+    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR = 39
+
+    device_properties = {}
+    device = torch.cuda.current_device()
+    cuda_properties = torch.cuda.get_device_properties(device)
+
+    device_properties["gpu_name"] = cuda_properties.name
+    device_properties["gpu_compute_capability_major"] = cuda_properties.major
+    device_properties["gpu_compute_capability_minor"] = cuda_properties.minor
+    device_properties["gpu_gmem_bytes"] = cuda_properties.total_memory
+    device_properties["gpu_sm_count"] = cuda_properties.multi_processor_count
+
+    max_threads_per_block = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_threads_per_block),
+        CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+        device,
+    )
+    device_properties["gpu_max_threads_per_block"] = max_threads_per_block.value
+
+    smem_per_block = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(smem_per_block),
+        CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
+        device,
+    )
+    device_properties["gpu_smem_bytes_per_block"] = smem_per_block.value
+
+    max_reg_per_block = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_reg_per_block),
+        CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
+        device,
+    )
+    device_properties["gpu_regs_per_block"] = max_reg_per_block.value
+
+    max_clock_khz = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_clock_khz),
+        CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
+        device,
+    )
+    device_properties["gpu_clock_rate_khz"] = max_clock_khz.value
+
+    l2_cache_size = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(l2_cache_size), CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, device
+    )
+    device_properties["gpu_l2_bytes"] = l2_cache_size.value
+
+    memory_clock_rate = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(memory_clock_rate), CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, device
+    )
+    device_properties["gpu_mem_clock_khz"] = memory_clock_rate.value
+
+    memory_bus_width = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(memory_bus_width),
+        CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH,
+        device,
+    )
+    device_properties["gpu_mem_bus_width"] = memory_bus_width.value
+
+    max_threads_per_sm = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_threads_per_sm),
+        CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,
+        device,
+    )
+    device_properties["gpu_max_threads_per_sm"] = max_threads_per_sm.value
+
+    # Compute peak bandwidth in GBps
+    peak_bandwidth = (2 * memory_bus_width.value * memory_clock_rate.value) / (1e6 * 8)
+    device_properties["gpu_peak_bandwidth_gbps"] = peak_bandwidth
+
+    return device_properties
+
+DEVICE_PROPERTIES = get_device_properties()
+
+def clear_cuda_cache() -> None:
+    """
+    Utility function to clear CUDA cache before running a test.
+    """
+    if (
+        torch.cuda.memory_allocated()
+        or torch.cuda.memory_reserved() > 0.8 * DEVICE_PROPERTIES["gpu_gmem_bytes"]
+    ):
+        gc.collect()
+        torch.cuda.empty_cache()

--- a/tests/python/test_ops.py
+++ b/tests/python/test_ops.py
@@ -8,7 +8,6 @@ import pytest
 import numpy as np
 from copy import deepcopy
 
-from benchmarks.python.core import clear_cuda_cache
 from opinfo_fusion_definitions import default_fd_fn, parse_inputs_fusion_definition
 from opinfo_framework import create_op_test, atexit_serde_create_op_test
 from opinfo_core import ReferenceType, OpInfo, SampleInput
@@ -17,6 +16,7 @@ from utils import ArgumentType, is_tensor, requiresJAX
 from typing import Callable
 
 from nvfuser import FusionCache, FusionDefinition
+from nvfuser.pytorch_utils import clear_cuda_cache
 
 from utils import check_captured_python_definition, debug_serde, basic_serde_check
 


### PR DESCRIPTION
This PR moves the utility function `clear_cuda_cache` from `benchmarks` to `nvfuser` module. This function is now also used in the `tests` module which causes some import discrepancies. nvFuser wheel does not bundle `benchmarks` module, and hence, cannot run `test_ops.py` directly there (CC: @xwang233).