### PR TITLE
Cache exact map to speed up ExpressionEvaluator ctor

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -13,6 +13,7 @@
 #include <fusion.h>
 #include <ir/cloner.h>
 #include <ir/utils.h>
+#include <logical_domain_map.h>
 #include <ops/alias.h>
 #include <ops/arith.h>
 #include <ops/utils.h>
@@ -252,7 +253,8 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
 
 DynamicTransformConcretizationInfo::DynamicTransformConcretizationInfo(
     const DynamicTransformInitialInfo* initial_info,
-    ExpressionEvaluator* expr_eval)
+    ExpressionEvaluator* expr_eval,
+    ExactLogicalDomainMap* exact_map)
     : initial_info_(initial_info) {
   NVF_ERROR(
       !fusion()->isA<kir::Kernel>(),
@@ -260,7 +262,8 @@ DynamicTransformConcretizationInfo::DynamicTransformConcretizationInfo(
 
   // Make sure all exactly mapped IDs have the same value in the
   // evaluator when any one of the IDs has a known value
-  expr_eval->propagateBoundValuesThroughExactMaps(initial_info_->fusion());
+  expr_eval->propagateBoundValuesThroughExactMaps(
+      initial_info_->fusion(), exact_map);
 
   analyzeReshapes(expr_eval);
 

--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -15,6 +15,7 @@
 #include <ir/cloner.h>
 #include <ir/iostream.h>
 #include <iter_visitor.h>
+#include <logical_domain_map.h>
 #include <transform_view.h>
 #include <utils.h>
 
@@ -141,7 +142,8 @@ class DynamicTransformConcretizationInfo {
  public:
   NVF_API DynamicTransformConcretizationInfo(
       const DynamicTransformInitialInfo* initial_info,
-      ExpressionEvaluator* expr_eval);
+      ExpressionEvaluator* expr_eval,
+      ExactLogicalDomainMap* exact_map = nullptr);
 
   //! Return a vector of integers each corresponding to the position in
   //! initialInfo()->getMaybeZeroExtents() of an extent Val which is guaranteed

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -344,11 +344,18 @@ void ExpressionEvaluator::print() const {
   debug() << "--------------------\n\n";
 }
 
-void ExpressionEvaluator::propagateBoundValuesThroughExactMaps(Fusion* fusion) {
+void ExpressionEvaluator::propagateBoundValuesThroughExactMaps(
+    Fusion* fusion,
+    ExactLogicalDomainMap* exact_map) {
   // We map Symbolic IterDomains here only if their extents match. This avoids
   // mapping between symbolic domains that might concretize to an (Iteration,
   // Broadcast) pair from a resolved broadcast.
-  const auto mapped_sets = ExactLogicalDomainMap(fusion).getMappedSets();
+  std::unique_ptr<ExactLogicalDomainMap> exact_map_ptr;
+  if (exact_map == nullptr) {
+    exact_map_ptr = std::make_unique<ExactLogicalDomainMap>(fusion);
+    exact_map = exact_map_ptr.get();
+  }
+  const auto mapped_sets = exact_map->getMappedSets();
 
   for (const auto& set : mapped_sets.disjointSets()) {
     int64_t known_size = -1;

--- a/csrc/expr_evaluator.h
+++ b/csrc/expr_evaluator.h
@@ -12,6 +12,7 @@
 #include <ir/cloner.h>
 #include <ir/interface_nodes.h>
 #include <iter_visitor.h>
+#include <logical_domain_map.h>
 #include <polymorphic_value.h>
 #include <visibility.h>
 
@@ -90,7 +91,9 @@ class ExpressionEvaluator {
   //! root IDs that are exactly mapped also get bound to the same
   //! value. This is currently just done with ExactLogicalDomainMap, but
   //! can be similarly done with the Exact CA map as well.
-  void propagateBoundValuesThroughExactMaps(Fusion* fusion);
+  void propagateBoundValuesThroughExactMaps(
+      Fusion* fusion,
+      ExactLogicalDomainMap* exact_map = nullptr);
 
   ExpressionEvaluator clone(IrCloner& ir_cloner) const;
 

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -15,6 +15,7 @@
 #include <fusion_profiler.h>
 #include <instrumentation.h>
 #include <ir/utils.h>
+#include <logical_domain_map.h>
 #include <options.h>
 #include <preseg_passes/pre_segmenter.h>
 #include <scheduler/debug_utils.h>
@@ -440,6 +441,7 @@ FusionExecutorCache::FusionExecutorCache(
     int64_t fusion_id,
     bool auto_schedule)
     : fusion_(std::move(fusion)),
+      exact_map_(std::make_unique<ExactLogicalDomainMap>(fusion_.get())),
       fusion_id_{fusion_id},
       auto_schedule_(auto_schedule) {}
 
@@ -689,7 +691,7 @@ FusionKernelRuntime* FusionExecutorCache::getKernelRuntimeFor(
     auto expr_eval = executor_utils::bindInputs(args, fusion_.get());
     cached_conc_info_.emplace_back(
         std::make_unique<DynamicTransformConcretizationInfo>(
-            &initial_info, &expr_eval));
+            &initial_info, &expr_eval, exact_map_.get()));
     conc_info = cached_conc_info_.back().get();
   }
 
@@ -886,7 +888,7 @@ void FusionExecutorCache::deserialize(
       auto expr_eval = executor_utils::bindInputs(args, fusion_.get());
       cached_conc_info_.emplace_back(
           std::make_unique<DynamicTransformConcretizationInfo>(
-              &initial_info, &expr_eval));
+              &initial_info, &expr_eval, exact_map_.get()));
       conc_info = cached_conc_info_.back().get();
     }
 

--- a/csrc/kernel_cache.h
+++ b/csrc/kernel_cache.h
@@ -13,6 +13,7 @@
 #include <executor.h>
 #include <fusion.h>
 #include <fusion_segmenter.h>
+#include <logical_domain_map.h>
 #include <scheduler/all_schedulers.h>
 #include <scheduler/registry.h>
 #include <serde/fusion_cache_generated.h>
@@ -731,6 +732,9 @@ class FusionExecutorCache {
   //! For serialization, track a deterministic order for (device_id and
   //! concretization info) pair
   std::vector<ConcreteInfo> deterministic_conc_info_;
+
+  //! This is cached to speed up finding concretization info
+  std::unique_ptr<ExactLogicalDomainMap> exact_map_;
 
   //! Logging state for most recent compilation
   bool profiling_ = false;


### PR DESCRIPTION
This just precomputes an ExactLogicalDomainMap for the dynamic fusion in FusionExecutorCache, so that we don't need to re-build that map every time we call `propagateBoundValuesThroughExactMaps`. This speeds up the dynamic shape overhead due to building
`DynamicTransformConcretizationInfo` considerably.