### PR TITLE
Remove unnecessary calls to `.ndims`.

### DIFF
--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -838,7 +838,6 @@ TEST_F(AliasTest, MergeTwoExpandedBroadcasts) {
   FusionGuard fg(fusion.get());
 
   TensorView* in = TensorViewBuilder()
-                       .ndims(3)
                        .dtype(DataType::Float)
                        .contiguity({std::nullopt, std::nullopt, std::nullopt})
                        .shape({4, 5, 6})
@@ -862,7 +861,6 @@ TEST_F(AliasTest, MergeBroadcastsBetweenConcretes) {
   FusionGuard fg(fusion.get());
 
   TensorView* in = TensorViewBuilder()
-                       .ndims(4)
                        .dtype(DataType::Float)
                        .contiguity({true, std::nullopt, std::nullopt, true})
                        .shape({2, 3, 5, 7})


### PR DESCRIPTION
They can be inferred from `.shape`s.