### PR TITLE
Print the dtype of a TensorView.

### DIFF
--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -521,12 +521,12 @@ void Fusion::printMath(bool from_outputs_only) {
   auto exprs_for_print = exprs();
   debug() << "Inputs:" << std::endl;
   for (auto inp : inputs()) {
-    debug() << "  " << inp << ", " << inp->getDataType().value() << std::endl;
+    debug() << "  " << inp << std::endl;
   }
 
   debug() << "Outputs:" << std::endl;
   for (auto out : outputs()) {
-    debug() << "  " << out << ", " << out->getDataType().value() << std::endl;
+    debug() << "  " << out << std::endl;
   }
 
   // If we want everything in the fusion, grab all values without uses to

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -63,7 +63,7 @@ std::string TensorView::toString(int indent_size) const {
     default:
       NVF_ERROR(false, "Unknown tensor memory type.");
   }
-  ss << domain()->toString(indent_size) << " of " << dtype();
+  ss << "_" << dtype() << domain()->toString(indent_size);
 
   if (getComputeAtPosition() > 0) {
     ss << " ca_pos( ";

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -63,7 +63,7 @@ std::string TensorView::toString(int indent_size) const {
     default:
       NVF_ERROR(false, "Unknown tensor memory type.");
   }
-  ss << domain()->toString(indent_size);
+  ss << domain()->toString(indent_size) << " of " << dtype();
 
   if (getComputeAtPosition() > 0) {
     ss << " ca_pos( ";

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -4249,9 +4249,7 @@ class TestNvFuserFrontend(NVFuserTest):
 
         with pytest.raises(
             Exception,
-            match=re.escape(
-                "Expected input 0, T0_g[ iS0{i0} ], to be an at::Tensor but got scalar 2"
-            ),
+            match="Expected input 0, .*, to be an at::Tensor but got scalar 2",
         ):
             nvf_out = fd.execute([scalar_inp, scalar_inp])
 
@@ -4265,10 +4263,7 @@ class TestNvFuserFrontend(NVFuserTest):
 
         with pytest.raises(
             Exception,
-            match=re.escape(
-                "Expected input 0, T0_g[ iS0{i0} ], to be bound to a tensor of dtype float,"
-                " but got a tensor of dtype __half"
-            ),
+            match="Expected input 0, .*, to be bound to a tensor of dtype float, but got a tensor of dtype __half",
         ):
             wrong_tensor_inp = torch.rand((15,), dtype=torch.float16, device="cuda:0")
             nvf_out = fd.execute([wrong_tensor_inp, 2.0])


### PR DESCRIPTION
This helps me to debug some numerical problems because nvFuser has a non-obvious dtype promotion rule. However, it has a large blast radius so I'd love to hear your opinions. 

Example:
```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from AliasTest
[ RUN      ] AliasTest.QKVSplitBackprop
Fusion IR after pre-segmenter optimization passes:
Inputs:
  T0_g_float[ iS0{16}, iS1{128}, iS2{768} ]
  T1_g_float[ iS3{16}, iS4{128}, iS5{768} ]
  T2_g_float[ iS6{16}, iS7{128}, iS8{768} ]
Outputs:
  T7_g_float[ rS24{16}, rS25{128}, iS26{2304} ]
  T8_g_float[ iS32{( 16 * 128 )}rf, iS29{2304} ]
  T9_g_float[ iS34{2304}, iS33{( 16 * 128 )} ]

%kernel_math {
T3_l_float[ iS9{16}, iS10{128}, iS12{2304}rf ]
   = pad( T0_g_float[ iS0{16}, iS1{128}, iS2{768} ], {0, 0, 0, 0, 0, 1536} )
i23 = 0 + 768;
T4_l_float[ iS13{16}, iS14{128}, iS16{( ( ( 0 + 768 ) + 768 ) + 768 )}rf ]
   = pad( T1_g_float[ iS3{16}, iS4{128}, iS5{768} ], {0, 0, 0, 0, i23, 768} )
i36 = i23 + 768;
T5_l_float[ iS17{16}, iS18{128}, iS20{( ( ( 0 + 768 ) + 768 ) + 768 )}rf ]
   = pad( T2_g_float[ iS6{16}, iS7{128}, iS8{768} ], {0, 0, 0, 0, i36, 0} )
T6_l_float[ iS21{16}, iS22{128}, iS23{2304} ]
   = cat( T3_l_float[ iS9{16}, iS10{128}, iS12{2304}rf ], T4_l_float[ iS13{16}, iS14{128}, iS16{( ( ( 0 + 768 ) + 768 ) + 768 )}rf ], T5_l_float[ iS17{16}, iS18{128}, iS20{( ( ( 0 + 768 ) + 768 ) + 768 )}rf ], 2 )
T7_g_float[ rS24{16}, rS25{128}, iS26{2304} ]
   = reduction( T6_l_float[ iS21{16}, iS22{128}, iS23{2304} ], op = add, initial value = float(0), allreduce = false )
T10_l_float[ iS35{16}, iS36{128}, iS37{2304} ]
   = SegmenterSet( T6_l_float[ iS21{16}, iS22{128}, iS23{2304} ] )
T8_g_float[ iS32{( 16 * 128 )}rf, iS29{2304} ] = view( T10_l_float[ iS35{16}, iS36{128}, iS37{2304} ] )
T9_g_float[ iS34{2304}, iS33{( 16 * 128 )} ]
   = Set.Permute( T8_g_float[ iS32{( 16 * 128 )}rf, iS29{2304} ], cache_op=Streaming )
} // %kernel_math

[       OK ] AliasTest.QKVSplitBackprop (501 ms)
[----------] 1 test from AliasTest (501 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (501 ms total)
[  PASSED  ] 1 test.
```