### PR TITLE
Avoid warnings on gcc in multi_matmul.cpp

### DIFF
--- a/csrc/scheduler/multi_matmul.cpp
+++ b/csrc/scheduler/multi_matmul.cpp
@@ -42,7 +42,7 @@ namespace {
 // Putting this all together we have the following order for a simple matmul
 //
 //   a -> acw_smem -> acr -> ... -> ab
-//                                    \
+//                                    \                                      .
 //                                      mma_result ->  ... -> dc -> d
 //                                    /
 //   b -> bcw_smem -> bcr -> ... -> bb
@@ -53,9 +53,9 @@ namespace {
 // In this example there are two matmuls both using the same "a" operand:
 //
 //   b1 -> bcw_smem1 -> bcr1 -> ... -> bb1
-//                                        \
+//                                        \                                  .
 //                                          mma_result1
-//                                        /             \
+//                                        /             \                    .
 //       a -> acw_smem -> acr -> ... -> ab                ... -> dc -> d
 //                                        \             /
 //                                          mma_result2


### PR DESCRIPTION
Previously, this would give the following warning:
```
[1/17] Building CXX object CMakeFiles/codegen_internal.dir/csrc/scheduler/multi_matmul.cpp.o
/opt/pytorch/nvfuser/csrc/scheduler/multi_matmul.cpp:49:1: warning: multi-line comment [-Wcomment]
   49 | //                                    \
      | ^
/opt/pytorch/nvfuser/csrc/scheduler/multi_matmul.cpp:60:1: warning: multi-line comment [-Wcomment]
   60 | //                                        \
      | ^
/opt/pytorch/nvfuser/csrc/scheduler/multi_matmul.cpp:62:1: warning: multi-line comment [-Wcomment]
   62 | //                                        /             \
      | ^
```
Unfortunately, this cannot be ignored using `#pragma GCC diagnostic ignored "-Wcomment"`, so I added a . at the end of each line that ended in a backslash. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61638