### PR TITLE
Fix reference implementations and improve validation. 

### DIFF
--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -276,24 +276,23 @@ TensorView* tanh_gelu_backward(TensorView* dy, TensorView* x) {
 
   auto x_sq = mul(x, x);
   auto x_cube = mul(x, x_sq);
+  auto beta = IrBuilder::create<Val>(kBeta);
+  auto kappa = IrBuilder::create<Val>(kKappa);
+  auto one = IrBuilder::create<Val>(1.0);
+  auto half = IrBuilder::create<Val>(0.5);
 
-  auto inner_1 = mul(IrBuilder::create<Val>(kKappa), x_cube);
-  auto inner_2 = add(x, inner_1);
-  auto inner_3 = mul(IrBuilder::create<Val>(kBeta), inner_2);
-  auto tanh_inner = tanh(inner_3);
+  auto inner = mul(beta, add(x, mul(kappa, x_cube)));
+  auto tanh_inner = tanh(inner);
 
-  auto left = mul(IrBuilder::create<Val>(0.5), x);
-  auto right = add(IrBuilder::create<Val>(1.0), tanh_inner);
+  auto left = mul(half, x);
+  auto right = add(one, tanh_inner);
 
-  auto left_derivative = mul(IrBuilder::create<Val>(0.5), right);
+  auto left_derivative = mul(half, right);
 
-  auto tanh_inner_sq = mul(tanh_inner, tanh_inner);
-  auto tanh_derivative = sub(IrBuilder::create<Val>(1.0), tanh_inner_sq);
-
-  auto constant_mul_x_sq =
-      mul(IrBuilder::create<Val>(kBeta * 3 * kKappa), x_sq);
-  auto inner_derivative = add(IrBuilder::create<Val>(kBeta), constant_mul_x_sq);
-  auto right_derivative = mul(left, mul(tanh_derivative, inner_derivative));
+  auto tanh_derivative = sub(one, mul(tanh_inner, tanh_inner));
+  auto inner_derivative =
+      mul(beta, add(one, mul(mul(IrBuilder::create<Val>(3.0), kappa), x_sq)));
+  auto right_derivative = mul(mul(left, tanh_derivative), inner_derivative);
 
   auto dx = mul(dy, add(left_derivative, right_derivative));
   return dx;

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -103,7 +103,8 @@ void validate(
     };
 
     EXPECT_TRUE(outputs[i].allclose(expected_outputs[i], rtol, atol))
-        << "Output " << i << " mismatches:" << std::endl
+        << "Output " << i << " mismatches with rtol " << rtol << " and atol "
+        << atol << ":" << std::endl
         << generate_comparison_details(
                expected_outputs[i], outputs[i], rtol, atol);
   }

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -800,7 +800,7 @@ TEST_P(DistributedTransformerTest, MLP_Backward) {
       expected_outputs,
       outputs,
       {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      {1e-5, 0.2, 1e-5, 0.01, 0.2, 0.01, 0.01});
+      {1e-5, 0.2, 1e-5, 0.01, 0.2, 0.01, 0.02});
 }
 
 TEST_P(DistributedTransformerTest, MHA_Backward) {

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -430,8 +430,7 @@ std::vector<TensorView*> mlp_backwards(
   // Activation recomputation
   TensorView* matmul0 = matmul(x, w0);
   TensorView* b0_bcast = broadcast(b0, {false, true, false});
-  TensorView* linear0 = add(matmul0, b0_bcast);
-  linear0 = castOp(DataType::Float, linear0);
+  TensorView* linear0 = add(matmul0, b0_bcast); // add generates float.
   TensorView* gelu = tanh_gelu(linear0);
   gelu = castOp(dtype, gelu);
 

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -800,7 +800,7 @@ TEST_P(DistributedTransformerTest, MLP_Backward) {
       expected_outputs,
       outputs,
       {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      {1e-5, 1e-5, 1e-5, 1e-5, 0.05, 1e-5, 0.01});
+      {1e-5, 0.2, 1e-5, 0.01, 0.2, 0.01, 0.01});
 }
 
 TEST_P(DistributedTransformerTest, MHA_Backward) {
@@ -900,7 +900,7 @@ TEST_P(DistributedTransformerTest, MHA_Backward) {
       expected_outputs,
       out,
       {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      {1e-5, 1e-5, 1e-5, 1e-4, 1e-4, 0.1, 0.1, 0.1, 0.01});
+      {1e-5, 0.02, 1e-5, 1e-5, 1e-5, 0.1, 0.1, 0.02, 0.01});
 }
 
 TEST_P(DistributedTransformerTest, Forward) {
@@ -1013,7 +1013,7 @@ TEST_P(DistributedTransformerTest, Forward) {
       expected_outputs,
       outputs,
       {0.0, 0.0, 0.0, 0.0, 0.0},
-      {1e-5, 0.01, 0.01, 0.01, 0.02});
+      {1e-5, 0.01, 0.01, 0.02, 0.02});
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpp/validator.cpp
+++ b/tests/cpp/validator.cpp
@@ -121,7 +121,7 @@ void testValidate(
           line_number,
           " in file ",
           file_name,
-          ".\n  Detected abs error of: ",
+          ".\n  Detected max abs error of: ",
           aten_output_tensor.sub(fusion_output_tensor)
               .abs()
               .max()


### PR DESCRIPTION
1. Fix some reference implementations to cast in the same way as nvFuser. 
2. Allow `validate` to take tolerances. 
3. Refine the tolerances so the tests pass up to 6 GPUs. 