### PR TITLE
Fix typo in NoOpHeuristic::sameAs

### DIFF
--- a/csrc/scheduler/no_op.h
+++ b/csrc/scheduler/no_op.h
@@ -64,7 +64,7 @@ class NoOpHeuristic : public HeuristicParams {
     return std::make_shared<NoOpHeuristic>();
   }
   bool sameAs(const std::shared_ptr<HeuristicParams>& other) const override {
-    auto other_casted = std::dynamic_pointer_cast<ReductionParams>(other);
+    auto other_casted = std::dynamic_pointer_cast<NoOpHeuristic>(other);
     return other_casted != nullptr && other_casted->cparams == cparams;
   };
 };


### PR DESCRIPTION
This was probably a cut/paste error. The result though is that comparing two `NoOpHeuristic`s will currently always return false, which leads to a recompile of the entire segmented fusion if it contains a single NoOp segment.