### PR TITLE
Scheduling tool: representativeId(const ValGroup&)

### DIFF
--- a/csrc/id_model/schedule.cpp
+++ b/csrc/id_model/schedule.cpp
@@ -26,24 +26,16 @@ IterDomain* representativeId(const ValGroup& vg) {
     }
   };
 
-  auto preferNewExtent = [&rep](IterDomain* new_id) {
-    if (rep->hasExpandedExtent() && !new_id->hasExpandedExtent()) {
-      // Prefer non-expanded dimensions
-      return true;
-    }
-    // Prefer constant extent IDs to symbolic
-    return !rep->getMaybeExpandedExtent()->isConstInt() &&
-        new_id->getMaybeExpandedExtent()->isConstInt();
-  };
-
   for (Val* v : *vg) {
     if (auto id = dynamic_cast<IterDomain*>(v); id &&
         (rep == nullptr || preferNewIterType(id) ||
-         (id->getIterType() == rep->getIterType() && preferNewExtent(id)))) {
+         (id->getIterType() == rep->getIterType() &&
+          id->name() < rep->name()))) {
       rep = id;
       continue;
     }
   }
+
   NVF_ERROR(rep != nullptr);
   return rep;
 }

--- a/csrc/id_model/schedule.cpp
+++ b/csrc/id_model/schedule.cpp
@@ -10,10 +10,48 @@
 
 namespace nvfuser {
 
+IterDomain* representativeId(const ValGroup& vg) {
+  IterDomain* rep = nullptr;
+
+  auto preferNewIterType = [&rep](IterDomain* new_id) {
+    if (rep->isReduction()) {
+      return new_id->isBroadcast() || new_id->isIteration();
+    } else if (rep->isBroadcast()) {
+      return new_id->isIteration();
+    } else if (rep->isIteration()) {
+      return false;
+    } else {
+      // Prefer anything else to a non-iter, non-bcast, non-reduction ID
+      return true;
+    }
+  };
+
+  auto preferNewExtent = [&rep](IterDomain* new_id) {
+    if (rep->hasExpandedExtent() && !new_id->hasExpandedExtent()) {
+      // Prefer non-expanded dimensions
+      return true;
+    }
+    // Prefer constant extent IDs to symbolic
+    return !rep->getMaybeExpandedExtent()->isConstInt() &&
+        new_id->getMaybeExpandedExtent()->isConstInt();
+  };
+
+  for (Val* v : *vg) {
+    if (auto id = dynamic_cast<IterDomain*>(v); id &&
+        (rep == nullptr || preferNewIterType(id) ||
+         (id->getIterType() == rep->getIterType() && preferNewExtent(id)))) {
+      rep = id;
+      continue;
+    }
+  }
+  NVF_ERROR(rep != nullptr);
+  return rep;
+}
+
 ValGroup merge(ValGraph* graph, const ValGroup& g0, const ValGroup& g1) {
   NVF_ERROR(!g0->empty() && !g1->empty(), "ValGroup can not be empty");
-  auto g0_id = g0->front()->as<IterDomain>();
-  auto g1_id = g1->front()->as<IterDomain>();
+  auto g0_id = representativeId(g0);
+  auto g1_id = representativeId(g1);
   NVF_ERROR(
       graph->hasGroup(g0_id) && graph->toGroup(g0_id) == g0,
       "Invalid g0 given: g0 is not in the given ValGraph");
@@ -51,7 +89,7 @@ std::pair<ValGroup, ValGroup> split(
     Val* factor,
     bool inner_split) {
   NVF_ERROR(!g->empty(), "ValGroup can not be empty");
-  auto g_id = g->front()->as<IterDomain>();
+  auto g_id = representativeId(g);
   NVF_ERROR(
       graph->hasGroup(g_id) && graph->toGroup(g_id) == g,
       "Invalid g given: g is not in the given ValGraph");
@@ -98,8 +136,8 @@ std::pair<ValGroup, ValGroup> swizzle(
     const ValGroup& g0,
     const ValGroup& g1) {
   NVF_ERROR(!g0->empty() && !g1->empty(), "ValGroup can not be empty");
-  auto g0_id = g0->front()->as<IterDomain>();
-  auto g1_id = g1->front()->as<IterDomain>();
+  auto g0_id = representativeId(g0);
+  auto g1_id = representativeId(g1);
   NVF_ERROR(
       graph->hasGroup(g0_id) && graph->toGroup(g0_id) == g0,
       "Invalid g0 given: g0 is not in the given ValGraph");

--- a/csrc/id_model/schedule.h
+++ b/csrc/id_model/schedule.h
@@ -16,8 +16,6 @@ namespace nvfuser {
 //   1. Iteration domains
 //   2. Broadcast domains
 //   3. Reduction domains
-// Among IterDomains with the same IterType, we prefer IterDomains with a
-// constant unexpanded extent to others.
 IterDomain* representativeId(const ValGroup& vg);
 
 // Given a ValGraph and two ValGroups g0 and g1 in this graph, if there is

--- a/csrc/id_model/schedule.h
+++ b/csrc/id_model/schedule.h
@@ -11,6 +11,15 @@
 
 namespace nvfuser {
 
+// Choose an IterDomain from the ValGroup that is amenable to transforms.
+// Specifically we prefer, in descending order:
+//   1. Iteration domains
+//   2. Broadcast domains
+//   3. Reduction domains
+// Among IterDomains with the same IterType, we prefer IterDomains with a
+// constant unexpanded extent to others.
+IterDomain* representativeId(const ValGroup& vg);
+
 // Given a ValGraph and two ValGroups g0 and g1 in this graph, if there is
 // already a merge of g0 with g1 in graph, return the output ValGroup of that
 // merge. Otherwise create an new ValGroup that is a merge of g0 and g1 in

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -16,6 +16,7 @@
 #include <fusion.h>
 #include <id_model/id_model.h>
 #include <id_model/loop_promotion.h>
+#include <id_model/schedule.h>
 #include <id_model/to_string.h>
 #include <inlining.h>
 #include <ir/graphviz.h>
@@ -2612,6 +2613,35 @@ TEST_F(IdModelTest, ParallelTypePropagation) {
       << "Parallel type propagation failed";
   EXPECT_EQ(tv1->axis(1)->getParallelType(), tv2->axis(1)->getParallelType())
       << "Parallel type propagation failed";
+}
+
+TEST_F(IdModelTest, RepresentativeId) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeConcreteTensor({-1, 1});
+  auto tv1 = makeConcreteTensor({-1, -1});
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  auto tv2 = add(tv0, tv1);
+  auto tv3 = sum(tv2, {0, 1});
+  fusion.addOutput(tv3);
+
+  IdModel id_model(&fusion);
+  const ValGraph& graph = id_model.idGraph(IdMappingMode::PERMISSIVE);
+
+  // In the permissive map we will have a group with Iteration and Reduction,
+  // and another with Iteration, Broadcast, and Reduction
+  EXPECT_EQ(graph.disjointValSets().size(), 2);
+
+  for (IterDomain* id : {tv0->axis(0), tv0->axis(1)}) {
+    ASSERT_TRUE(graph.hasGroup(id));
+    IterDomain* rep = representativeId(graph.toGroup(id));
+    ASSERT_TRUE(rep != nullptr);
+    EXPECT_FALSE(rep->isBroadcast());
+    EXPECT_FALSE(rep->isReduction());
+  }
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
This introduces a tool to get a representative IterDomain for a ValGroup. A ValGroup might have IterDomains with different IterTypes. For example, the Exact graph maps Iteration domains with Reduction domains, and the permissive graph maps Broadcast domains with Iteration when the broadcasts are concretized.

The purpose of `representativeId` is to find an `IterDomain` that is most useful for scheduling. In particular, it is an ID that is easiest to merge with other IDs. Since we restrict merging Reduction domains with non-Reduction domains, we give the lowest priority to Reduction domains in the ValGroup; we only return a Reduction domain if there is no other choice. Other than that, we prefer Iteration to Broadcast, we prefer unexpanded Broadcasts to expanded ones, and we prefer IDs with constant extents to those with symbolic extents.