### PR TITLE
Modifying option for nvrtc

### DIFF
--- a/csrc/fusion_executor/executor.cpp
+++ b/csrc/fusion_executor/executor.cpp
@@ -179,16 +179,16 @@ std::string FusionExecutor::getStructuredCode(
             << code << "\n======================================\n\n";
   }
   if (isDebugDumpEnabled(DebugDumpOption::CudaToFile) ||
-      isDebugDumpEnabled(DebugDumpOption::DebugInfo)) {
+      isOptionEnabled(EnableOption::KernelLineInfo))
     std::stringstream file_name;
-    file_name << "__tmp_kernel_" << kernel_id_ << ".cu";
-    debug() << "PRINTING: " << file_name.str() << std::endl;
-    std::ofstream out(file_name.str());
-    out << code << std::endl;
-    out.close();
-  }
+  file_name << "__tmp_kernel_" << kernel_id_ << ".cu";
+  debug() << "PRINTING: " << file_name.str() << std::endl;
+  std::ofstream out(file_name.str());
+  out << code << std::endl;
+  out.close();
+}
 
-  return code;
+return code;
 }
 
 std::string FusionExecutor::getStructuredCode() const {

--- a/csrc/fusion_executor/executor.cpp
+++ b/csrc/fusion_executor/executor.cpp
@@ -179,16 +179,16 @@ std::string FusionExecutor::getStructuredCode(
             << code << "\n======================================\n\n";
   }
   if (isDebugDumpEnabled(DebugDumpOption::CudaToFile) ||
-      isOptionEnabled(EnableOption::KernelLineInfo))
+      isOptionEnabled(EnableOption::KernelLineInfo)) {
     std::stringstream file_name;
-  file_name << "__tmp_kernel_" << kernel_id_ << ".cu";
-  debug() << "PRINTING: " << file_name.str() << std::endl;
-  std::ofstream out(file_name.str());
-  out << code << std::endl;
-  out.close();
-}
+    file_name << "__tmp_kernel_" << kernel_id_ << ".cu";
+    debug() << "PRINTING: " << file_name.str() << std::endl;
+    std::ofstream out(file_name.str());
+    out << code << std::endl;
+    out.close();
+  }
 
-return code;
+  return code;
 }
 
 std::string FusionExecutor::getStructuredCode() const {

--- a/csrc/fusion_executor/executor.cpp
+++ b/csrc/fusion_executor/executor.cpp
@@ -178,8 +178,7 @@ std::string FusionExecutor::getStructuredCode(
             << " =======\n\n"
             << code << "\n======================================\n\n";
   }
-  if (isDebugDumpEnabled(DebugDumpOption::CudaToFile) ||
-      isOptionEnabled(EnableOption::KernelLineInfo)) {
+  if (isDebugDumpEnabled(DebugDumpOption::CudaToFile)) {
     std::stringstream file_name;
     file_name << "__tmp_kernel_" << kernel_id_ << ".cu";
     debug() << "PRINTING: " << file_name.str() << std::endl;

--- a/csrc/fusion_executor/executor_utils.cpp
+++ b/csrc/fusion_executor/executor_utils.cpp
@@ -978,6 +978,9 @@ void fillCompileOptions(
     const CompileParams& compile_params,
     std::optional<int64_t> opt_block_size) {
   nvrtc_compile_driver.setOption("--std=c++17");
+  if (isOptionEnabled(EnableOption::JitDebug)) {
+    nvrtc_compile_driver.setOption("-G");
+  }
 
   // Suppress warnings for functions that are defined but unused, since we have
   // many unused functions in the preamble.

--- a/csrc/fusion_executor/executor_utils.cpp
+++ b/csrc/fusion_executor/executor_utils.cpp
@@ -978,7 +978,7 @@ void fillCompileOptions(
     const CompileParams& compile_params,
     std::optional<int64_t> opt_block_size) {
   nvrtc_compile_driver.setOption("--std=c++17");
-  if (isOptionEnabled(EnableOption::JitDebug)) {
+  if (isOptionEnabled(EnableOption::KernelDebug)) {
     nvrtc_compile_driver.setOption("-G");
   }
 
@@ -1011,7 +1011,7 @@ void fillCompileOptions(
   }
 
   // Add line info to generated kernels
-  if (isDebugDumpEnabled(DebugDumpOption::DebugInfo)) {
+  if (isOptionEnabled(EnableOption::KernelLineInfo)) {
     nvrtc_compile_driver.setOption("-lineinfo");
   }
 

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -162,6 +162,7 @@ std::unordered_map<EnableOption, std::vector<std::string>> Options<
       {"static_fusion_count", EnableOption::StaticFusionCount},
       {"warn_register_spill", EnableOption::WarnRegisterSpill},
       {"io_to_lower_precision", EnableOption::IoToLowerPrecision},
+      {"jit_debug", EnableOption::JitDebug},
   };
 
   return parseEnvOptions("ENABLE", available_options);

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -106,7 +106,6 @@ std::unordered_map<DebugDumpOption, std::vector<std::string>> Options<
       {"cuda_full", DebugDumpOption::CudaFull},
       {"cuda_kernel", DebugDumpOption::CudaKernel},
       {"cuda_to_file", DebugDumpOption::CudaToFile},
-      {"debug_info", DebugDumpOption::DebugInfo},
       {"draw_segmented_fusion", DebugDumpOption::FusionSegmentsDrawing},
       {"expr_simplify", DebugDumpOption::ExprSimplification},
       {"expr_sort", DebugDumpOption::ExprSort},
@@ -162,7 +161,8 @@ std::unordered_map<EnableOption, std::vector<std::string>> Options<
       {"static_fusion_count", EnableOption::StaticFusionCount},
       {"warn_register_spill", EnableOption::WarnRegisterSpill},
       {"io_to_lower_precision", EnableOption::IoToLowerPrecision},
-      {"jit_debug", EnableOption::JitDebug},
+      {"kernel_debug", EnableOption::KernelDebug},
+      {"kernel_lineinfo", EnableOption::KernelLineInfo},
   };
 
   return parseEnvOptions("ENABLE", available_options);

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -47,8 +47,6 @@ enum class DebugDumpOption {
   CudaKernel, //!< Dump the generated CUDA C++ kernel code
   CudaFull, //!< Dump the complete CUDA C++ code
   CudaToFile, //!< Dump CUDA Strings to File
-  DebugInfo, //!< Embed line info and debug info to compiled kernel, and dump
-             //!< the full CUDA C++ code
   LaunchParam, //!< Dump the Launch parameters of kernel
   FusionSegments, //!< Dump Segmented Fusion Graph
   FusionSegmenterLog, //!< Dump Detailed Segmenter Logging
@@ -102,7 +100,9 @@ enum class EnableOption {
   WarnRegisterSpill, //! Enable warnings of register spill
   IoToLowerPrecision, //! Enable castInputOutputToLowerPrecision. #1889 explains
                       //! why we disabled it by default.
-  JitDebug, //! Enable debug mode in nvrtc
+  KernelDebug, //! Enable debug mode in nvrtc
+  KernelLineInfo, //! Embed line info to compiled kernel, and dump the full CUDA
+                  //! C++ code
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -102,6 +102,7 @@ enum class EnableOption {
   WarnRegisterSpill, //! Enable warnings of register spill
   IoToLowerPrecision, //! Enable castInputOutputToLowerPrecision. #1889 explains
                       //! why we disabled it by default.
+  JitDebug, //! Enable debug mode in nvrtc
   EndOfOption //! Placeholder for counting the number of elements
 };
 


### PR DESCRIPTION
Adding `NVFUSER_ENABLE=kernel_debug` to enable debug option `-G` in nvrtc;
Moving `DebugDumpOption::DebugInfo` to `EnableOption::KernelLineInfo`.