### PR TITLE
Extend stmatrix to support 16x8 and 16x16 matrices in addition to 8x8.

### DIFF
--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1589,7 +1589,7 @@ std::pair<Val*, Val*> hardCodedIndexGenerationForStMatrix(
       IrBuilder::create<Val>(0, DataType::Index),
       as_type);
 
-  Val* out_index;
+  Val* out_index = nullptr;
   // This will hanlde 8x8 and 16x8.
   if (output_n_extent == 8) {
     // T_shared[toSmem(T_shared) + 16 * tidx.x]

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1568,6 +1568,74 @@ static inline DataType getMmaOutType(TensorView* mma_out) {
   return ArrayType{std::make_shared<DataType>(DataType::Float), (size_t)size};
 }
 
+namespace {
+std::pair<Val*, Val*> hardCodedIndexGenerationForStMatrix(
+    const LoadStoreOp* ldst,
+    const int64_t output_m_extent,
+    const int64_t output_n_extent) {
+  NVF_ERROR(
+      (output_m_extent == 8 && output_n_extent == 8) ||
+          (output_m_extent == 16 && output_n_extent == 8) ||
+          (output_m_extent == 16 && output_n_extent == 16),
+      "size not currently supported for stmatrix");
+
+  auto num_regs = (output_m_extent) / 8 * (output_n_extent) / 8;
+  auto as_type = ArrayType{
+      std::make_shared<DataType>(DataType::UInt32),
+      static_cast<size_t>(num_regs)};
+
+  Val* in = IrBuilder::create<kir::TensorIndex>(
+      dynamic_cast<TensorView*>(ldst->in()),
+      IrBuilder::create<Val>(0, DataType::Index),
+      as_type);
+
+  Val* out_index;
+  // This will hanlde 8x8 and 16x8.
+  if (output_n_extent == 8) {
+    // T_shared[toSmem(T_shared) + 16 * tidx.x]
+    out_index = IrBuilder::addExpr(
+        IrBuilder::baseAddressExpr(dynamic_cast<TensorView*>(ldst->out())),
+        IrBuilder::mulExpr(
+            IrBuilder::create<Val>(16, DataType::Index),
+            IrBuilder::create<NamedScalar>("threadIdx.x", DataType::Index)));
+  } else if (output_n_extent == 16) {
+    // This will hanlde 16x16
+    // T_shared[toSmem(T_shared) + 256 * (tidx.x / 16) +  32 * (tidx.x%8)  +
+    // ((tidx.x/8)%2) * 16]
+
+    // 256 * (tidx.x / 16)
+    auto expr0 = IrBuilder::mulExpr(
+        IrBuilder::create<Val>(256, DataType::Index),
+        IrBuilder::divExpr(
+            IrBuilder::create<NamedScalar>("threadIdx.x", DataType::Index),
+            IrBuilder::create<Val>(16, DataType::Index)));
+    // 32 * (tidx.x%8)
+    auto expr1 = IrBuilder::mulExpr(
+        IrBuilder::modExpr(
+            IrBuilder::create<NamedScalar>("threadIdx.x", DataType::Index),
+            IrBuilder::create<Val>(8, DataType::Index)),
+        IrBuilder::create<Val>(32, DataType::Index));
+
+    // ((tidx.x/8)%2) * 16]
+    auto expr2 = IrBuilder::mulExpr(
+        IrBuilder::modExpr(
+            IrBuilder::divExpr(
+                IrBuilder::create<NamedScalar>("threadIdx.x", DataType::Index),
+                IrBuilder::create<Val>(8, DataType::Index)),
+            IrBuilder::create<Val>(2, DataType::Index)),
+        IrBuilder::create<Val>(16, DataType::Index));
+
+    out_index = IrBuilder::addExpr(
+        IrBuilder::baseAddressExpr(dynamic_cast<TensorView*>(ldst->out())),
+        IrBuilder::addExpr(expr0, IrBuilder::addExpr(expr1, expr2)));
+  }
+  Val* out = IrBuilder::create<kir::TensorIndex>(
+      dynamic_cast<TensorView*>(ldst->out()), out_index);
+
+  return {in, out};
+}
+} // namespace
+
 void IndexLowering::handle(const LoadStoreOp* ldst) {
   Val* in = nullptr;
   Val* out = nullptr;
@@ -1587,32 +1655,33 @@ void IndexLowering::handle(const LoadStoreOp* ldst) {
           (size_t)ir_utils::getVectorizeSize(ldst->out()->as<TensorView>()) /
               2};
     } else if (ir_utils::isStMatrixOp(ldst)) {
-      as_type = ArrayType{
-          std::make_shared<DataType>(DataType::UInt32),
-          1 /*hard coded for 8*8 store*/};
+      NVF_ERROR(
+          ldst->out()->as<TensorView>()->getLogicalDomain().size() == 2,
+          "We only support 2D inputs stmatrix");
+
+      auto output_m_extent = ldst->out()
+                                 ->as<TensorView>()
+                                 ->getLogicalDomain()[0]
+                                 ->extent()
+                                 ->evaluate()
+                                 .as<int64_t>();
+      auto output_n_extent = ldst->out()
+                                 ->as<TensorView>()
+                                 ->getLogicalDomain()[1]
+                                 ->extent()
+                                 ->evaluate()
+                                 .as<int64_t>();
+
+      auto [in_idx, out_idx] = hardCodedIndexGenerationForStMatrix(
+          ldst, output_m_extent, output_n_extent);
+      in = in_idx;
+      out = out_idx;
     } else if (ldst->out()->definition()->isA<MmaOp>()) {
       // For MMA accumulator initialization
       as_type = getMmaOutType(ldst->out()->as<TensorView>());
     }
 
-    if (ir_utils::isStMatrixOp(ldst)) {
-      // Currently we create hard coded indexing for stmatrix which works on 8x8
-      // matrices. T_local[0]
-      in = IrBuilder::create<kir::TensorIndex>(
-          dynamic_cast<TensorView*>(ldst->in()),
-          IrBuilder::create<Val>(0, DataType::Index),
-          as_type);
-
-      // T_shared[toSmem(T_shared) + 16 * tidx.x]
-      auto out_index = IrBuilder::addExpr(
-          IrBuilder::baseAddressExpr(dynamic_cast<TensorView*>(ldst->out())),
-          IrBuilder::mulExpr(
-              IrBuilder::create<Val>(16, DataType::Index),
-              IrBuilder::create<NamedScalar>("threadIdx.x", DataType::Index)));
-
-      out = IrBuilder::create<kir::TensorIndex>(
-          dynamic_cast<TensorView*>(ldst->out()), out_index);
-    } else {
+    if (!ir_utils::isStMatrixOp(ldst)) {
       in = lowerSrcIndex(
           ldst->in(),
           ldst->out(),

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -1629,9 +1629,7 @@ TEST_F(TMARuntimeInvalidTest, SizeOfTransfer) {
       &fusion, cg_outputs, {t0, items_of_16_bytes}, {t0}, __LINE__, __FILE__);
 
   EXPECT_THAT(
-      [&]() {
-        fe.runFusion({t0, items_of_16_bytes / 2});
-      },
+      [&]() { fe.runFusion({t0, items_of_16_bytes / 2}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "The expected bytes must be a multiple of 16 bytes, but ")));
 }
@@ -2520,7 +2518,7 @@ TEST_P(StMatrixTest, Regular) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto operand = MmaOperand::B;
+  auto operand = MmaOperand::A;
   auto sizes = GetParam();
   int sizeM = sizes.at(0);
   int sizeN = sizes.at(1);
@@ -2542,11 +2540,11 @@ TEST_P(StMatrixTest, Regular) {
 
   tv2->applyMmaSwizzle(operand);
   tv2->setAllocationDomain(tv2->getLoopDomain(), true);
-  // Get 32 threads out to parallelize over.
-  tv2->merge(0);
-  tv2->axis(0)->parallelize(ParallelType::TIDx);
+  // // Get 32 threads out to parallelize over.
+  tv2->merge(1);
+  tv2->axis(1)->parallelize(ParallelType::TIDx);
 
-  // We do not really schedule tv3 as yet, this is just for parllel code gen.
+  // We do not really schedule tv3 as yet, this is just for parllel codegen.
   tv3->merge(0);
   tv3->split(0, 32);
   tv3->axis(1)->parallelize(ParallelType::TIDx);

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -1629,7 +1629,9 @@ TEST_F(TMARuntimeInvalidTest, SizeOfTransfer) {
       &fusion, cg_outputs, {t0, items_of_16_bytes}, {t0}, __LINE__, __FILE__);
 
   EXPECT_THAT(
-      [&]() { fe.runFusion({t0, items_of_16_bytes / 2}); },
+      [&]() {
+        fe.runFusion({t0, items_of_16_bytes / 2});
+      },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "The expected bytes must be a multiple of 16 bytes, but ")));
 }
@@ -2504,7 +2506,7 @@ TEST_P(LdMatrixTest, Regular) {
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
-class StMatrixTest : public NVFuserTest {
+class StMatrixTest : public NVFuserFixtureParamTest<std::vector<int>> {
  protected:
   void SetUp() override {
     if (cudaArchGuardShouldSkip(9, 0)) {
@@ -2514,14 +2516,14 @@ class StMatrixTest : public NVFuserTest {
   }
 };
 
-TEST_F(StMatrixTest, Regular) {
+TEST_P(StMatrixTest, Regular) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
   auto operand = MmaOperand::B;
-
-  int sizeM = 8;
-  int sizeN = 8;
+  auto sizes = GetParam();
+  int sizeM = sizes.at(0);
+  int sizeN = sizes.at(1);
 
   auto tv0 = makeContigConcreteTensor({sizeM, sizeN}, DataType::Half);
   fusion.addInput(tv0);
@@ -2540,7 +2542,14 @@ TEST_F(StMatrixTest, Regular) {
 
   tv2->applyMmaSwizzle(operand);
   tv2->setAllocationDomain(tv2->getLoopDomain(), true);
-  // We do not schedule tv3 as yet.
+  // Get 32 threads out to parallelize over.
+  tv2->merge(0);
+  tv2->axis(0)->parallelize(ParallelType::TIDx);
+
+  // We do not really schedule tv3 as yet, this is just for parllel code gen.
+  tv3->merge(0);
+  tv3->split(0, 32);
+  tv3->axis(1)->parallelize(ParallelType::TIDx);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   auto t0 = at::randn({sizeM, sizeN}, options);
@@ -2551,6 +2560,15 @@ TEST_F(StMatrixTest, Regular) {
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    StMatrixTest,
+    testing::Values(
+        // M, N
+        std::vector<int>{8, 8},
+        std::vector<int>{16, 8},
+        std::vector<int>{16, 16}));
 
 TEST_P(LdMatrixTest, Transpose) {
   Fusion fusion;


### PR DESCRIPTION
Extend the hard coded index generation to support 16x8 and 16x16.
Extend the unit tests for the same.
Correct an error in the existing unit test for stmatrix (for 8x8)