### PR TITLE
Enable IdModel-based predication for new producer-based scheduling tests

### DIFF
--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -424,8 +424,9 @@ Val* PredicateCompute::getInlinePredicate(
   }
 
   std::vector<PredicateInfo> pred_info_vec;
-  if (isIdModelOptionEnabled(IdModelEnableOption::InlinePredicate) &&
-      GpuLower::current()->isTensorIndexerEnabled()) {
+  if (!lower_utils::hasRootToLoopLinearTransformations(out_tv) ||
+      (isIdModelOptionEnabled(IdModelEnableOption::InlinePredicate) &&
+       GpuLower::current()->isTensorIndexerEnabled())) {
     pred_info_vec =
         gpu_lower->tensorIndexer().getPredicates(out_tv, expr, loops);
   } else {
@@ -524,8 +525,9 @@ void UnswitchPredicate::predicateOn(Expr* tv_expr) {
 
   std::vector<PredicateInfo> ref_pred_info;
 
-  if (isIdModelOptionEnabled(IdModelEnableOption::UnswitchPredicate) &&
-      GpuLower::current()->isTensorIndexerEnabled()) {
+  if (!lower_utils::hasRootToLoopLinearTransformations(out_tv) ||
+      (isIdModelOptionEnabled(IdModelEnableOption::UnswitchPredicate) &&
+       GpuLower::current()->isTensorIndexerEnabled())) {
     ref_pred_info = gpu_lower->tensorIndexer().getPredicates(
         out_tv, tv_expr, for_loops_, unrolled_loop_);
   } else {

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -3721,6 +3721,9 @@ TEST_F(ResizeTest, SliceScheduledLikeProducer) {
   auto t0 = at::randn(shape, options);
   std::vector<c10::IValue> aten_inputs({t0});
 
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
@@ -3818,6 +3821,9 @@ TEST_F(ResizeTest, SliceThenPadLeftHalf) {
   auto t0 = at::randn(shape, options);
   std::vector<c10::IValue> aten_inputs({t0});
 
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);
   auto cg_outputs = fe.runFusion(aten_inputs);
@@ -3873,6 +3879,9 @@ TEST_F(ResizeTest, SliceThenPadRightHalf) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   std::vector<c10::IValue> aten_inputs({t0});
+
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);
@@ -3968,6 +3977,9 @@ TEST_F(ResizeTest, SliceThenConcat) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   std::vector<c10::IValue> aten_inputs({t0});
+
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);
@@ -4234,6 +4246,9 @@ TEST_F(ResizeTest, SliceSliceConcatConcat) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({i0}, options);
   std::vector<c10::IValue> aten_inputs({t0});
+
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   FusionExecutor fe;
   fe.compileFusion(&fusion, aten_inputs);


### PR DESCRIPTION
Fixes #2924 

Tensor indexing automatically uses the new indexer, but that wasn't the case for predicate indexing, and because of that no proper predicate was generated and resulted in the sanitizer errors.

Explicitly opted in using the new indexer in those tests. Also, make it more automatic whenever non-convention scheduling is used.

