### PR TITLE
Initialize size_ and local_size_ to 1.

### DIFF
--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -171,9 +171,9 @@ Communicator::Communicator(
     : is_available_(false),
       default_backend_(backend),
       rank_(0),
-      size_(0),
+      size_(1),
       local_rank_(0),
-      local_size_(0),
+      local_size_(1),
       master_port_(c10d::TCPStoreOptions::kDefaultPort),
       ucc_available_(false),
       nccl_available_(false) {

--- a/tests/cpp/test_multidevice_matmul.cpp
+++ b/tests/cpp/test_multidevice_matmul.cpp
@@ -32,7 +32,7 @@ class DistributedMatmulTest : public MultiDeviceTest {
  protected:
   DistributedMatmulTest() : num_devices_(communicator_->size()) {}
 
-  void SetUp() {
+  void SetUp() override {
     MultiDeviceTest::SetUp();
     if (!deviceMajorMinorCheck(8)) {
       GTEST_SKIP() << "Distributed matmul tests require Ampere or newer";

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -41,7 +41,7 @@ class DistributedTransformerTest
  protected:
   DistributedTransformerTest() : D(communicator_->size()) {}
 
-  void SetUp() {
+  void SetUp() override {
     MultiDeviceTest::SetUp();
     if (H % D != 0) {
       GTEST_SKIP()


### PR DESCRIPTION
This partially fixes the bug that Sam found in
https://github.com/NVIDIA/Fuser/pull/2804/files#r1761633706. One is also a more logical initial value when the communicator is unavailable -- the test is being run on single node and single GPU.