### PR TITLE
Change test_transformer_engine.py uses pytest.mark.mpi.

### DIFF
--- a/tests/python/multidevice.py
+++ b/tests/python/multidevice.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 import pytest
 

--- a/tests/python/multidevice.py
+++ b/tests/python/multidevice.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+import pytest
 
 from mpi4py import MPI
 
@@ -30,3 +31,8 @@ class MultideviceTest:
     @property
     def local_rank(self):
         return self._local_rank
+
+
+@pytest.fixture
+def multidevice_test():
+    return MultideviceTest()

--- a/tests/python/multidevice.py
+++ b/tests/python/multidevice.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
-import pytest
 
 from mpi4py import MPI
+
 
 class MultideviceTest:
     def __init__(self):
@@ -30,8 +30,3 @@ class MultideviceTest:
     @property
     def local_rank(self):
         return self._local_rank
-
-
-@pytest.fixture
-def multidevice_test():
-    return MultideviceTest()

--- a/tests/python/multidevice.py
+++ b/tests/python/multidevice.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+
+from mpi4py import MPI
+
+class MultideviceTest:
+    def __init__(self):
+        comm = MPI.COMM_WORLD
+        self._size = comm.size
+        self._rank = comm.rank
+        self._local_size = int(os.environ["OMPI_COMM_WORLD_LOCAL_SIZE"])
+        self._local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def rank(self):
+        return self._rank
+
+    @property
+    def local_size(self):
+        return self._local_size
+
+    @property
+    def local_rank(self):
+        return self._local_rank
+
+
+@pytest.fixture
+def multidevice_test():
+    return MultideviceTest()

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -10,9 +10,7 @@ import nvfuser
 from nvfuser import DataType, FusionDefinition
 
 
-@pytest.fixture
-def multidevice_test():
-    return multidevice.MultideviceTest()
+multidevice_test = multidevice.multidevice_test
 
 
 @pytest.mark.mpi

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -2,44 +2,12 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import os
 import pytest
 import torch
 
-from mpi4py import MPI
-
 import nvfuser
+from multidevice import multidevice_test
 from nvfuser import DataType, FusionDefinition
-
-
-class MultideviceTest:
-    def __init__(self):
-        comm = MPI.COMM_WORLD
-        self._size = comm.size
-        self._rank = comm.rank
-        self._local_size = int(os.environ["OMPI_COMM_WORLD_LOCAL_SIZE"])
-        self._local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
-
-    @property
-    def size(self):
-        return self._size
-
-    @property
-    def rank(self):
-        return self._rank
-
-    @property
-    def local_size(self):
-        return self._local_size
-
-    @property
-    def local_rank(self):
-        return self._local_rank
-
-
-@pytest.fixture
-def multidevice_test():
-    return MultideviceTest()
 
 
 @pytest.mark.mpi

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -5,9 +5,14 @@
 import pytest
 import torch
 
+import multidevice
 import nvfuser
-from multidevice import multidevice_test
 from nvfuser import DataType, FusionDefinition
+
+
+@pytest.fixture
+def multidevice_test():
+    return multidevice.MultideviceTest()
 
 
 @pytest.mark.mpi

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -12,9 +12,7 @@ import transformer_engine.pytorch as te
 import multidevice
 
 
-@pytest.fixture
-def multidevice_test():
-    return multidevice.MultideviceTest()
+multidevice_test = multidevice.multidevice_test
 
 
 @pytest.mark.mpi

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -2,9 +2,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-# This test is yet to be added to CI. For now, run it manually with `mpirun -n
-# 2 pytest transformer_engine_test.py`.
-
 import os
 import pytest
 import torch

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -9,7 +9,12 @@ import torch.distributed as dist
 
 import transformer_engine.pytorch as te
 
-from multidevice import multidevice_test
+import multidevice
+
+
+@pytest.fixture
+def multidevice_test():
+    return multidevice.MultideviceTest()
 
 
 @pytest.mark.mpi

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -6,12 +6,17 @@
 # 2 pytest transformer_engine_test.py`.
 
 import os
+import pytest
 import torch
 import torch.distributed as dist
+
 import transformer_engine.pytorch as te
 
+from multidevice import multidevice_test
 
-def test_transformer_layer():
+
+@pytest.mark.mpi
+def test_transformer_layer(multidevice_test):
     # Hyperparameters for GPT-3
     hidden_size = 12288
     num_heads = 96
@@ -20,15 +25,16 @@ def test_transformer_layer():
     sequence_length = 2048
     dtype = torch.bfloat16
 
-    os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = "29500"
-    world_size = int(os.environ["OMPI_COMM_WORLD_SIZE"])
-    rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
+    size = multidevice_test.size
+    rank = multidevice_test.rank
 
     torch.cuda.set_device(rank)
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = "29500"
     dist.init_process_group(
-        "nccl",
-        world_size=world_size,
+        backend="nccl",
+        init_method="env://",
+        world_size=size,
         rank=rank,
     )
     tp_group = dist.new_group()


### PR DESCRIPTION
So it can be picked up by CI, similar to test_multidevice.py.