### PR TITLE
Convert more NVF_ERROR(false, to use NVF_THROW

### DIFF
--- a/benchmarks/cpp/utils.cpp
+++ b/benchmarks/cpp/utils.cpp
@@ -124,8 +124,7 @@ std::string toString(const std::shared_ptr<HeuristicParams>& params) {
   if (tparams) {
     return toString(*tparams);
   }
-  NVF_ERROR(
-      false,
+  NVF_THROW(
       "Unknown heuristic parameter type. Did you just added a new heuristic parameter type but forget to update here?");
 }
 

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1974,8 +1974,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       }
       return;
     } else {
-      NVF_ERROR(
-          false, "Non-allreduce grouped grid welford is not yet supported");
+      NVF_THROW("Non-allreduce grouped grid welford is not yet supported");
     }
   }
 
@@ -2858,8 +2857,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const GroupedWelfordOp* grouped_wop) final {
-    NVF_ERROR(
-        false,
+    NVF_THROW(
         "Should not reach here as grouped welford is only enabled for grid welford,",
         " which is handled by its own handler");
   }

--- a/csrc/device_lower/analysis/fused_reduction.cpp
+++ b/csrc/device_lower/analysis/fused_reduction.cpp
@@ -161,8 +161,7 @@ class FusionInspector : private IterVisitor {
       } else if (preceding_expr->isA<WelfordOp>()) {
         fusion_list_.emplace_back(preceding_expr->as<WelfordOp>(), true);
       } else {
-        NVF_ERROR(
-            false, "Invalid preceding expr: ", preceding_expr->toString());
+        NVF_THROW("Invalid preceding expr: ", preceding_expr->toString());
       }
 
       fused_exprs_.insert(preceding_expr);

--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -988,8 +988,7 @@ bool PredicateElimination::setReductionInitValue(
   } else if (existing_val->sameAs(reduction_init)) {
     return true;
   } else {
-    NVF_ERROR(
-        false,
+    NVF_THROW(
         "Inconsistent setting of initialization value for t",
         tv->name(),
         ". Prev: ",

--- a/csrc/device_lower/analysis/sync_information.cpp
+++ b/csrc/device_lower/analysis/sync_information.cpp
@@ -780,8 +780,7 @@ SyncMap::SyncMap(Fusion* fusion) {
                 continue;
               }
               // Can this happen?
-              NVF_ERROR(
-                  false,
+              NVF_THROW(
                   "Unexpected case. Producer: ",
                   producer->toString(),
                   ", consumer: ",

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -483,8 +483,7 @@ class ScopeMap : private kir::IrVisitor {
   }
 
   void handle(kir::IfThenElse* ite) final {
-    NVF_ERROR(
-        false, "lower_alias_memory: no support for IfThenElse at this phase.");
+    NVF_THROW("lower_alias_memory: no support for IfThenElse at this phase.");
   }
 
   //! Factory function for internal loop information data
@@ -786,8 +785,7 @@ class AllocationInfoMap : private kir::IrVisitor {
   }
 
   void handle(kir::IfThenElse* ite) final {
-    NVF_ERROR(
-        false, "lower_alias_memory: no support for IfThenElse at this phase.");
+    NVF_THROW("lower_alias_memory: no support for IfThenElse at this phase.");
   }
 
   // Generate allocation info for allocation after some pre-filtering

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -599,8 +599,7 @@ class AllocationInserter : public kir::ExprMutator {
   }
 
   void handle(kir::IfThenElse*) final {
-    NVF_ERROR(
-        false,
+    NVF_THROW(
         "Pass does not support conditional statements, ",
         "this pass should be run before any conditionals are placed in code.");
   }

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1166,8 +1166,7 @@ void IndexLowering::handle(const GroupedWelfordOp* grouped_wop) {
     handleGroupedGridWelford(
         grouped_wop, indexed_outputs, indexed_inputs, grouped_wop->initVals());
   } else {
-    NVF_ERROR(
-        false,
+    NVF_THROW(
         "Only grid welford is supported. Validation should have caught non-grid welford grouping.");
   }
 }
@@ -1431,8 +1430,7 @@ void IndexLowering::handle(const kir::MBarrierInvalidate* minval) {
     smem_address_ptr = lower_utils::u32IndexScalarSmemTv(
         minval->mbarrier()->as<kir::TensorIndex>());
   } else {
-    NVF_ERROR(
-        false,
+    NVF_THROW(
         "Unexpected MBarrierInvalidate barrier value: ",
         minval->mbarrier()->toString());
   }

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -508,8 +508,7 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
   }
 
   void handle(kir::IfThenElse*) final {
-    NVF_ERROR(
-        false,
+    NVF_THROW(
         "Pass does not support conditional statements, ",
         "this pass should be run before any conditionals are placed in code.");
   }

--- a/csrc/dispatch.cpp
+++ b/csrc/dispatch.cpp
@@ -70,8 +70,7 @@ void Val::dispatch(T handler, Val* val) {
       ptr(handler)->handle(val);
       return;
   }
-  NVF_ERROR(
-      false,
+  NVF_THROW(
       "Unknown valtype in dispatch! val: ",
       val->toString(),
       " = ",
@@ -141,8 +140,7 @@ void Val::constDispatch(T handler, const Val* val) {
       ptr(handler)->handle(val);
       return;
   }
-  NVF_ERROR(
-      false,
+  NVF_THROW(
       "Unknown valtype in dispatch! val: ",
       val->toString(),
       " = ",
@@ -303,14 +301,10 @@ void OptOutConstDispatch::dispatch(const Val* v) {
 
 void OptInConstDispatch::unhandled(const Statement* stmt) {
   if (stmt->isExpr()) {
-    NVF_ERROR(
-        false,
-        "Handle not overriden for ",
-        stmt->as<Expr>()->getOpString(),
-        ".");
+    NVF_THROW(
+        "Handle not overriden for ", stmt->as<Expr>()->getOpString(), ".");
   } else if (stmt->isVal()) {
-    NVF_ERROR(
-        false, "Handle not overriden for ", stmt->getValType().value(), ".");
+    NVF_THROW("Handle not overriden for ", stmt->getValType().value(), ".");
   } else {
     NVF_THROW("Unrecognized statement type.");
   }
@@ -318,14 +312,10 @@ void OptInConstDispatch::unhandled(const Statement* stmt) {
 
 void OptInDispatch::unhandled(Statement* stmt) {
   if (stmt->isExpr()) {
-    NVF_ERROR(
-        false,
-        "Handle not overriden for ",
-        stmt->as<Expr>()->getOpString(),
-        ".");
+    NVF_THROW(
+        "Handle not overriden for ", stmt->as<Expr>()->getOpString(), ".");
   } else if (stmt->isVal()) {
-    NVF_ERROR(
-        false, "Handle not overriden for ", stmt->getValType().value(), ".");
+    NVF_THROW("Handle not overriden for ", stmt->getValType().value(), ".");
   } else {
     NVF_THROW("Unrecognized statement type.");
   }

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -565,8 +565,7 @@ void NaiveValueMachine::runUnaryOp(int index) {
       } else if (data_type_[index] == DataType::Bool) {
         dest = PolymorphicValue((bool)src);
       } else {
-        NVF_ERROR(
-            false, "dtype not supported in evaluator: ", data_type_[index]);
+        NVF_THROW("dtype not supported in evaluator: ", data_type_[index]);
       }
       break;
     case UnaryOpType::Abs:

--- a/csrc/fusion_executor/executor_kernel_arg.cpp
+++ b/csrc/fusion_executor/executor_kernel_arg.cpp
@@ -227,8 +227,7 @@ std::vector<std::byte> polymorphicValueToBytes(
       int32_t v32 = (int32_t)v;
       return std::vector<std::byte>((std::byte*)&v32, (std::byte*)&v32 + 4);
     } else {
-      NVF_ERROR(
-          false,
+      NVF_THROW(
           "Cannot convert int64_t to ",
           dtype,
           " type: only int32 and int64 are supported.");
@@ -265,8 +264,7 @@ std::vector<std::byte> polymorphicValueToBytes(
       return std::vector<std::byte>(
           (std::byte*)&v8, (std::byte*)&v8 + sizeof(at::Float8_e5m2));
     } else {
-      NVF_ERROR(
-          false,
+      NVF_THROW(
           "Cannot convert double to ",
           dtype,
           " type: only half, bfloat16, float and double are supported.");
@@ -282,8 +280,7 @@ std::vector<std::byte> polymorphicValueToBytes(
       return std::vector<std::byte>(
           (std::byte*)&v32, (std::byte*)&v32 + sizeof(std::complex<float>));
     } else {
-      NVF_ERROR(
-          false,
+      NVF_THROW(
           "Cannot convert complex double to ",
           dtype,
           " type: only complex float and complex double are supported.");
@@ -350,11 +347,8 @@ std::vector<std::byte> polymorphicValueToBytes(
     // FUSER_PERF_SCOPE("polymorphicValueToBytes(Opaque)");
     return argument.as<Opaque>().bytes();
   } else {
-    NVF_ERROR(
-        false,
-        "Cannot convert ",
-        argument.type().name(),
-        " to kernel argument data.");
+    NVF_THROW(
+        "Cannot convert ", argument.type().name(), " to kernel argument data.");
   }
 }
 

--- a/csrc/fusion_executor/executor_params.cpp
+++ b/csrc/fusion_executor/executor_params.cpp
@@ -69,10 +69,8 @@ void LaunchParams::bind(int64_t val, ParallelType p_type) {
       checkAndSet(val, gdimz_, "gridDim.z");
       break;
     default:
-      NVF_ERROR(
-          false,
-          "Tried to bind invalid parallel type in launch config: ",
-          p_type);
+      NVF_THROW(
+          "Tried to bind invalid parallel type in launch config: ", p_type);
   }
   assertValid();
 }
@@ -92,10 +90,8 @@ int64_t LaunchParams::getDim(ParallelType p_type) const {
     case ParallelType::BIDz:
       return gdimz();
     default:
-      NVF_ERROR(
-          false,
-          "Tried to get with invalid parallel type in launch config: ",
-          p_type);
+      NVF_THROW(
+          "Tried to get with invalid parallel type in launch config: ", p_type);
   }
 }
 
@@ -118,10 +114,8 @@ const int64_t& LaunchParams::getRawVal(ParallelType p_type) const {
     case ParallelType::BIDz:
       return gdimz_;
     default:
-      NVF_ERROR(
-          false,
-          "Tried to get with invalid parallel type in launch config: ",
-          p_type);
+      NVF_THROW(
+          "Tried to get with invalid parallel type in launch config: ", p_type);
   }
 }
 

--- a/csrc/fusion_executor/executor_utils.cpp
+++ b/csrc/fusion_executor/executor_utils.cpp
@@ -317,8 +317,7 @@ std::unique_ptr<caching::VectorizedTensorInfo> getVectorizedTensorValidationInfo
         vectorized_tensor_info_ptr->global_inp_misaligned_tv.insert(
             producer_tv);
       } else {
-        NVF_ERROR(
-            false,
+        NVF_THROW(
             "Unsupported memory configuration for misaligned vectorization.");
       }
     }
@@ -850,8 +849,7 @@ class NvrtcCompileDriver {
     if (result != NVRTC_SUCCESS) {
       // Print CUDA starting at first global function
       size_t kernel_start = src.find("__global__");
-      NVF_ERROR(
-          false,
+      NVF_THROW(
           "\n",
           src.substr(kernel_start),
           "\nCUDA NVRTC compile error: ",

--- a/csrc/id_model/circular_buffer_indexing.cpp
+++ b/csrc/id_model/circular_buffer_indexing.cpp
@@ -174,10 +174,8 @@ CircularBufferLoopStage getCircularBufferLoopStage(
     }
   }
 
-  NVF_ERROR(
-      false,
-      "Circular buffer loop not found for ",
-      circular_buffer_tv->toString());
+  NVF_THROW(
+      "Circular buffer loop not found for ", circular_buffer_tv->toString());
 }
 
 } // namespace nvfuser

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -741,8 +741,7 @@ ParallelType getParallelType(const ValGroup& loop_group) {
       common_pt = pt;
     } else {
       // Inconsistent parallelization
-      NVF_ERROR(
-          false,
+      NVF_THROW(
           "Inconsistent parallelization detected. ",
           "Known type: ",
           common_pt,

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -2174,8 +2174,7 @@ kir::TensorIndex* Index::getProducerIndex(
       } else if (items_per_thread == 4) {
         op = UnaryOpType::AdjustPartialLdMatrixAddrInTuring16;
       } else {
-        NVF_ERROR(
-            false,
+        NVF_THROW(
             "Unexpected output vectorizaiton for ldmatrix, expect 2, 4, or 8, get ",
             items_per_thread);
       }

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -60,16 +60,12 @@ bool Statement::lessThan(const Statement* stmt1, const Statement* stmt2) {
 }
 
 std::string Statement::toString(int indent_size) const {
-  NVF_ERROR(
-      false, "toString for IR node ", typeid(*this).name(), " is not defined");
+  NVF_THROW("toString for IR node ", typeid(*this).name(), " is not defined");
 }
 
 std::string Statement::toInlineString(int indent_size) const {
-  NVF_ERROR(
-      false,
-      "toInlineString for IR node ",
-      typeid(*this).name(),
-      " is not defined");
+  NVF_THROW(
+      "toInlineString for IR node ", typeid(*this).name(), " is not defined");
 }
 
 Fusion* Statement::fusion() const {
@@ -378,8 +374,7 @@ Expr* Expr::withWritePredicate(kir::Predicate* predicate) {
 std::vector<PolymorphicValue> Expr::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  NVF_ERROR(
-      false,
+  NVF_THROW(
       "`evaluate` method for expression ",
       getOpString(),
       " is not defined. ",

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -413,8 +413,7 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
       } else if (isComplexType(*out()->getDataType())) {
         return {PolymorphicValue((std::complex<double>)in)};
       } else {
-        NVF_ERROR(
-            false, "dtype not supported in evaluator: ", *out()->getDataType());
+        NVF_THROW("dtype not supported in evaluator: ", *out()->getDataType());
       }
     case UnaryOpType::Reciprocal:
       return {1.0 / in};
@@ -442,8 +441,7 @@ std::vector<PolymorphicValue> UnaryOp::evaluate(
       if (*out()->getDataType() == DataType::Float) {
         return {PolymorphicValue((double)*(float*)in)};
       } else {
-        NVF_ERROR(
-            false, "dtype not supported in evaluator: ", *out()->getDataType());
+        NVF_THROW("dtype not supported in evaluator: ", *out()->getDataType());
       }
       break;
     case UnaryOpType::Sigmoid:
@@ -1568,8 +1566,7 @@ int GroupedReductionOp::getExprIndexOfOutput(Val* output_val) const {
     return (int)std::distance(outputs().begin(), it);
   }
 
-  NVF_ERROR(
-      false, "Not an output, ", output_val->toString(), ", of ", toString());
+  NVF_THROW("Not an output, ", output_val->toString(), ", of ", toString());
 }
 
 std::vector<PolymorphicValue> GroupedReductionOp::evaluate(
@@ -1968,8 +1965,7 @@ int GroupedWelfordOp::getExprIndexOfOutput(Val* output_val) const {
     }
   }
 
-  NVF_ERROR(
-      false, "Not an output, ", output_val->toString(), ", of ", toString());
+  NVF_THROW("Not an output, ", output_val->toString(), ", of ", toString());
 }
 
 Val* GroupedWelfordOp::getInitValOfOutput(Val* output_val) const {

--- a/csrc/kernel_cache.cpp
+++ b/csrc/kernel_cache.cpp
@@ -340,8 +340,7 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
         } else if (input.isComplexDouble()) {
           encodeBuffer(input.toComplexDouble(), encoding_);
         } else {
-          NVF_ERROR(
-              false,
+          NVF_THROW(
               "Unhandled input type when creating input ID. Cannot record ",
               input);
         }

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -293,8 +293,7 @@ const char* getPTXConstraints(Val* value) {
         return "l";
       }
     default:
-      NVF_ERROR(
-          false, "Unsupported data type ", dt, " for inline PTX assembly.");
+      NVF_THROW("Unsupported data type ", dt, " for inline PTX assembly.");
   }
 }
 

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -914,8 +914,7 @@ std::unordered_map<IterDomain*, IterDomain*> ComputeAtLogicalDomainMap::map(
              removed_broadcast_domains_.end())) {
       continue;
     }
-    NVF_ERROR(
-        false,
+    NVF_THROW(
         "Mapping IterDomain ",
         from_id,
         " of ",

--- a/csrc/maxinfo_propagator.cpp
+++ b/csrc/maxinfo_propagator.cpp
@@ -152,8 +152,7 @@ void MaxInfoSpanningTree::traverse(Propagator* propagator) {
         propagator->propagateC2P(next_hop.from, next_hop.to);
         break;
       default:
-        NVF_ERROR(
-            false, "Unknown next hop type in MaxInfoSpanningTree::traverse.");
+        NVF_THROW("Unknown next hop type in MaxInfoSpanningTree::traverse.");
     }
   }
   propagator->tearDown();

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -51,8 +51,7 @@ bool isOutermostAllocatedId(TensorView* tv, IterDomain* id) {
       return false;
     }
   }
-  NVF_ERROR(
-      false, "Id", id->toString(), " is not in TensorView ", tv->toString());
+  NVF_THROW("Id", id->toString(), " is not in TensorView ", tv->toString());
   return false;
 }
 

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1436,8 +1436,7 @@ TensorView* reductionOp(
       } else if (reduction_op_type == BinaryOpType::Mul) {
         out = pow(out, factor);
       } else {
-        NVF_ERROR(
-            false,
+        NVF_THROW(
             "Add and Mul are the only non-trivial expand reductions allowed");
       }
     }

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -272,8 +272,7 @@ inline PolymorphicValue signbit(const PolymorphicValue& a) {
   if (a.is<at::Tensor>()) {
     return PolymorphicValue(a.as<at::Tensor>().signbit());
   }
-  NVF_ERROR(
-      false, "PolymorphicValue signbit not implemented for ", a.type().name());
+  NVF_THROW("PolymorphicValue signbit not implemented for ", a.type().name());
 }
 
 inline PolymorphicValue fmod(
@@ -310,8 +309,7 @@ inline PolymorphicValue fmod(
       return PolymorphicValue(a.as<at::Tensor>().fmod(b.as<at::Tensor>()));
     }
   }
-  NVF_ERROR(
-      false,
+  NVF_THROW(
       "PolymorphicValue fmod not implemented for ",
       a.type().name(),
       " , ",
@@ -367,16 +365,14 @@ inline PolymorphicValue abs(const PolymorphicValue& a) {
   if (a.is<at::Tensor>()) {
     return a.as<at::Tensor>().abs();
   }
-  NVF_ERROR(
-      false, "PolymorphicValue abs not implemented for ", a.type().name());
+  NVF_THROW("PolymorphicValue abs not implemented for ", a.type().name());
 }
 
 inline PolymorphicValue erf(const PolymorphicValue& a) {
   if (a.is<at::Tensor>()) {
     return PolymorphicValue(a.as<at::Tensor>().erf());
   }
-  NVF_ERROR(
-      false, "PolymorphicValue erf not implemented for ", a.type().name());
+  NVF_THROW("PolymorphicValue erf not implemented for ", a.type().name());
 }
 
 // Convert scalars, vector of scalars, vector of vector of scalars, etc., into
@@ -417,8 +413,7 @@ inline PolymorphicValue toTensor(
     }
     return PolymorphicValue(at::stack(tensors));
   }
-  NVF_ERROR(
-      false, "PolymorphicValue toTensor not implemented for ", x.type().name());
+  NVF_THROW("PolymorphicValue toTensor not implemented for ", x.type().name());
 }
 
 // Convert PolymorphicValue to c10::Scalar.

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1906,9 +1906,7 @@ struct ScalarRecord : RecordFunctor {
             "A ScalarRecord for Int inline definition not have a matching data type!");
         os << value_;
       } else {
-        NVF_ERROR(
-            false,
-            "A ScalarRecord with an unsupported inline definition type!");
+        NVF_THROW("A ScalarRecord with an unsupported inline definition type!");
       }
       // NOTE: close_function is not relevant for the inline definition as the
       // printing is specific to each operator and not partially done with the

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -1192,8 +1192,7 @@ void scheduleMatmul(Fusion* fusion, const MatmulParams& params) {
           ->parallelize(ParallelType::BIDx);
       break;
     default:
-      NVF_ERROR(
-          false, "Invalid TileRasterizationOrder passed to Matmul scheduler");
+      NVF_THROW("Invalid TileRasterizationOrder passed to Matmul scheduler");
   }
 
   // parallelize Mwo, Nwo by thread

--- a/csrc/scheduler/matmul_heuristic_plugin.cpp
+++ b/csrc/scheduler/matmul_heuristic_plugin.cpp
@@ -183,8 +183,7 @@ void copyConfigToParams(MatmulParams& params, const KernelConfig* config) {
       params.cta_order = MatmulParams::TileRasterizationOrder::ColumnMajor;
       break;
     default:
-      NVF_ERROR(
-          false,
+      NVF_THROW(
           "Unrecognized cta_order returned by plugin: ",
           config->cta_order,
           ". Expected 0 (row-major) or 1 (column-major)");

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1693,8 +1693,7 @@ MmaOp* MatmulPattern::translateToMmaOp() {
     fms = fusedMultiplySum(A, B, {-1});
     mma_op = fms->definition()->as<MmaOp>();
   } else {
-    NVF_ERROR(
-        false,
+    NVF_THROW(
         "Could not translate matmul pattern with output ",
         output->toString(),
         " to MmaOp");
@@ -1863,8 +1862,7 @@ DimRolesMap MatmulPattern::getDimRoles(IdModel& id_model) const {
     } else if (concrete_flags == 0b110) {
       dim_roles[g] = MatmulDimRole::N;
     } else {
-      NVF_ERROR(
-          false,
+      NVF_THROW(
           "IterDomain ValGroup should be present in at least two of A, B, output.",
           " present_flags: ",
           present_flags);

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -695,10 +695,8 @@ ScheduleHeuristic getPersistentHeuristicFor(ReductionType reduction_type) {
     case ReductionType::InnerOuter:
       return ScheduleHeuristic::InnerOuterPersistent;
     default:
-      NVF_ERROR(
-          false,
-          "Reduction type not supported! reduction_type: ",
-          reduction_type);
+      NVF_THROW(
+          "Reduction type not supported! reduction_type: ", reduction_type);
   }
 }
 

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2026,8 +2026,7 @@ DisjointSets<IterDomain*> disjointLogicalSets(Fusion* fusion) {
         auto resize = expr->as<Resize>();
         disjoint_logical_ids.mapEntries(resize->in(), resize->out());
       } else {
-        NVF_ERROR(
-            false, "Expression type: ", expr->toString(), " not supported.");
+        NVF_THROW("Expression type: ", expr->toString(), " not supported.");
       }
     }
   }
@@ -2472,8 +2471,7 @@ void promoteProducerMemoryTypes(
       } else if (isParallelTypeBlockDim(producer_non_ca_id_ptype)) {
         setPromotion(producer, MemoryType::Global);
       } else {
-        NVF_ERROR(
-            false, "Unexpected parallel type: ", producer_non_ca_id_ptype);
+        NVF_THROW("Unexpected parallel type: ", producer_non_ca_id_ptype);
       }
     }
   }

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -395,10 +395,8 @@ std::vector<IterDomain*> ContiguousInnerDimensionsMapper::projectId(
     } else {
       // TODO: I wonder if we should just remove all inputs instead of erroring.
       // Seems that would be safe.
-      NVF_ERROR(
-          false,
-          "ProjectDimensions does not support expr type: ",
-          expr->toString());
+      NVF_THROW(
+          "ProjectDimensions does not support expr type: ", expr->toString());
     } // switch on expr type
   } // For loop on the transform expressions
 
@@ -421,10 +419,8 @@ std::vector<IterDomain*> ContiguousInnerDimensionsMapper::projectId(
     } else {
       // TODO: I wonder if we should just remove all inputs instead of erroring.
       // Seems that would be safe.
-      NVF_ERROR(
-          false,
-          "ProjectDimensions does not support expr type: ",
-          expr->toString());
+      NVF_THROW(
+          "ProjectDimensions does not support expr type: ", expr->toString());
     } // switch on expr type
   } // For loop on the transform expressions
 

--- a/csrc/serde/polymorphic_value.cpp
+++ b/csrc/serde/polymorphic_value.cpp
@@ -62,8 +62,7 @@ nvfuser::PolymorphicValue deserializePolymorphicValue(const Scalar* c) {
           std::complex<double>(c->real_value(), c->imag_value()));
     }
     default:
-      NVF_ERROR(
-          false, "Unable to deserialize serde::Scalar as PolymorphicValue.");
+      NVF_THROW("Unable to deserialize serde::Scalar as PolymorphicValue.");
   }
 }
 

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -325,8 +325,7 @@ void ReplayTransformations::runReplay() {
     auto it_replayed = id_map_.find(out);
     if (it_replayed == id_map_.end()) {
       if (error_on_failure_) {
-        NVF_ERROR(
-            false,
+        NVF_THROW(
             "Transform traversal failed, could not find expected output.");
       }
       continue;

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -147,10 +147,8 @@ DataType getTypeFromComplexType(DataType dtype) {
     case DataType::ComplexDouble:
       return DataType::Double;
     default:
-      NVF_ERROR(
-          false,
-          "Only support ComplexFloat and ComplexDouble, current type:",
-          dtype);
+      NVF_THROW(
+          "Only support ComplexFloat and ComplexDouble, current type:", dtype);
   }
 }
 
@@ -1135,8 +1133,7 @@ at::ScalarType data_type_to_aten(const DataType& data_type) {
     case DataType::Int:
       return at::ScalarType::Long;
     case DataType::Index:
-      NVF_ERROR(
-          false,
+      NVF_THROW(
           "Index is determined at compile time,",
           " to convert from an aten type you need to have the compiled information. ",
           "This information is passed to GpuLower at compile time, and then copied to kerned.",

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -960,8 +960,7 @@ constexpr inline size_t primDataTypeSize(PrimDataType type) {
     case DataType::Float8_e5m2:
       return sizeof(at::Float8_e5m2);
     case DataType::Index:
-      NVF_ERROR(
-          false, "The actual type of Index is only known at compile time.");
+      NVF_THROW("The actual type of Index is only known at compile time.");
     case DataType::Int:
       return sizeof(int64_t);
     case DataType::Int32:

--- a/csrc/validator_utils.cpp
+++ b/csrc/validator_utils.cpp
@@ -147,8 +147,7 @@ std::pair<double, double> getTolerance(
     case DataType::Bool:
       return {0.0, 0.0};
     default:
-      NVF_ERROR(
-          false, "Do not have tolerance computation for type ", dtype, ".");
+      NVF_THROW("Do not have tolerance computation for type ", dtype, ".");
   }
 }
 

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -1950,8 +1950,7 @@ TEST_F(IndexingTest, DoubleBuffering1) {
                     mulExpr(loop_indices.at(1), tv->axis(2)->extent()),
                     loop_indices.at(2)));
           } else {
-            NVF_ERROR(
-                false,
+            NVF_THROW(
                 "Unexpected circular buffer stage: ",
                 circular_buffer_loop_stage_);
           }
@@ -2054,8 +2053,7 @@ TEST_F(IndexingTest, DoubleBuffering4) {
                       tv->axis(3)->extent()),
                   loop_indices.at(3));
             } else {
-              NVF_ERROR(
-                  false, "Unexpected stage: ", circular_buffer_loop_stage_);
+              NVF_THROW("Unexpected stage: ", circular_buffer_loop_stage_);
             }
           } else {
             return nullptr;
@@ -2071,8 +2069,7 @@ TEST_F(IndexingTest, DoubleBuffering4) {
               return modExpr(
                   addExpr(loop_indices.at(2), createInt(1)), createInt(2));
             } else {
-              NVF_ERROR(
-                  false, "Unexpected stage: ", circular_buffer_loop_stage_);
+              NVF_THROW("Unexpected stage: ", circular_buffer_loop_stage_);
             }
           } else {
             if (circular_buffer_loop_stage_ == CircularBufferLoopStage::Main) {
@@ -2083,8 +2080,7 @@ TEST_F(IndexingTest, DoubleBuffering4) {
               return modExpr(
                   subExpr(tv->axis(2)->extent(), createInt(1)), createInt(2));
             } else {
-              NVF_ERROR(
-                  false, "Unexpected stage: ", circular_buffer_loop_stage_);
+              NVF_THROW("Unexpected stage: ", circular_buffer_loop_stage_);
             }
           }
         }
@@ -2176,8 +2172,7 @@ TEST_F(IndexingTest, DoubleBuffering6) {
                       mulExpr(loop_indices.at(3), createInt(16))),
                   loop_indices.at(4));
             } else {
-              NVF_ERROR(
-                  false, "Unexpected stage: ", circular_buffer_loop_stage_);
+              NVF_THROW("Unexpected stage: ", circular_buffer_loop_stage_);
             }
           } else {
             return nullptr;
@@ -2205,8 +2200,7 @@ TEST_F(IndexingTest, DoubleBuffering6) {
                       tv->axis(2)->extent(), tv->axis(3)->extent()));
               return addExpr(base_offset, buffer_offset);
             } else {
-              NVF_ERROR(
-                  false, "Unexpected stage: ", circular_buffer_loop_stage_);
+              NVF_THROW("Unexpected stage: ", circular_buffer_loop_stage_);
             }
           } else {
             if (circular_buffer_loop_stage_ == CircularBufferLoopStage::Main) {
@@ -2232,8 +2226,7 @@ TEST_F(IndexingTest, DoubleBuffering6) {
                       tv->axis(2)->extent(), tv->axis(3)->extent()));
               return addExpr(base_offset, buffer_offset);
             } else {
-              NVF_ERROR(
-                  false, "Unexpected stage: ", circular_buffer_loop_stage_);
+              NVF_THROW("Unexpected stage: ", circular_buffer_loop_stage_);
             }
           }
         }
@@ -2321,8 +2314,7 @@ TEST_F(IndexingTest, CircularBuffering1) {
                     mulExpr(loop_indices.at(1), tv->axis(2)->extent()),
                     loop_indices.at(2)));
           } else {
-            NVF_ERROR(
-                false,
+            NVF_THROW(
                 "Unexpected circular buffer stage: ",
                 circular_buffer_loop_stage_);
           }
@@ -2448,8 +2440,7 @@ TEST_F(IndexingTest, CircularBuffering2) {
                       mulExpr(loop_indices.at(3), createInt(16))),
                   loop_indices.at(4));
             } else {
-              NVF_ERROR(
-                  false, "Unexpected stage: ", circular_buffer_loop_stage_);
+              NVF_THROW("Unexpected stage: ", circular_buffer_loop_stage_);
             }
           } else {
             return nullptr;
@@ -2480,8 +2471,7 @@ TEST_F(IndexingTest, CircularBuffering2) {
                       tv->axis(2)->extent(), tv->axis(3)->extent()));
               return addExpr(base_offset, buffer_offset);
             } else {
-              NVF_ERROR(
-                  false, "Unexpected stage: ", circular_buffer_loop_stage_);
+              NVF_THROW("Unexpected stage: ", circular_buffer_loop_stage_);
             }
           } else {
             if (circular_buffer_loop_stage_ == CircularBufferLoopStage::Main) {
@@ -2505,8 +2495,7 @@ TEST_F(IndexingTest, CircularBuffering2) {
                       tv->axis(2)->extent(), tv->axis(3)->extent()));
               return addExpr(base_offset, buffer_offset);
             } else {
-              NVF_ERROR(
-                  false, "Unexpected stage: ", circular_buffer_loop_stage_);
+              NVF_THROW("Unexpected stage: ", circular_buffer_loop_stage_);
             }
           }
         }


### PR DESCRIPTION
PR #2941 did a lot of conversions but only hit the cases where the arguments to `NVF_ERROR` were not wrapped to the next line. This PR picks up those line-wrapped cases.

For those interested, these were found using
```
rg --multiline 'NVF_ERROR\((\n|\s)*false' -l
```
and those files were edited in vim and processed using the vim command `:bufdo %s/NVF_ERROR(\_s*false,\_s*/NVF_THROW(/g`