### PR TITLE
Benchmark backprop of a te.TransformerLayer.

### DIFF
--- a/tests/python/multidevice.py
+++ b/tests/python/multidevice.py
@@ -10,19 +10,17 @@ from mpi4py import MPI
 
 class MultideviceTest:
     def __init__(self):
-        comm = MPI.COMM_WORLD
-        self._size = comm.size
-        self._rank = comm.rank
+        self._comm = MPI.COMM_WORLD
         self._local_size = int(os.environ["OMPI_COMM_WORLD_LOCAL_SIZE"])
         self._local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
 
     @property
     def size(self):
-        return self._size
+        return self._comm.size
 
     @property
     def rank(self):
-        return self._rank
+        return self._comm.rank
 
     @property
     def local_size(self):
@@ -32,7 +30,12 @@ class MultideviceTest:
     def local_rank(self):
         return self._local_rank
 
+    def barrier(self):
+        self._comm.barrier()
+
 
 @pytest.fixture
 def multidevice_test():
-    return MultideviceTest()
+    fixture = MultideviceTest()
+    yield fixture
+    fixture.barrier()

--- a/tests/python/multidevice.py
+++ b/tests/python/multidevice.py
@@ -10,17 +10,17 @@ from mpi4py import MPI
 
 class MultideviceTest:
     def __init__(self):
-        self._comm = MPI.COMM_WORLD
+        self._communicator = MPI.COMM_WORLD
         self._local_size = int(os.environ["OMPI_COMM_WORLD_LOCAL_SIZE"])
         self._local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
 
     @property
     def size(self):
-        return self._comm.size
+        return self._communicator.size
 
     @property
     def rank(self):
-        return self._comm.rank
+        return self._communicator.rank
 
     @property
     def local_size(self):
@@ -31,11 +31,12 @@ class MultideviceTest:
         return self._local_rank
 
     def barrier(self):
-        self._comm.barrier()
+        self._communicator.barrier()
 
 
 @pytest.fixture
 def multidevice_test():
     fixture = MultideviceTest()
     yield fixture
+    # Sync all ranks after each test for isolation.
     fixture.barrier()

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -22,7 +22,11 @@ class ComputeType(Enum):
 
 
 @pytest.mark.mpi
-@pytest.mark.parametrize("compute_type", [ComputeType.FORWARD, ComputeType.BACKWARD])
+@pytest.mark.parametrize(
+    "compute_type",
+    [ComputeType.FORWARD, ComputeType.BACKWARD],
+    ids=["forward", "backward"],
+)
 def test_transformer_layer(multidevice_test, benchmark, compute_type):
     # Hyperparameters for GPT-3
     hidden_size = 12288

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -6,6 +6,7 @@ import os
 import pytest
 import torch
 import torch.distributed as dist
+from enum import auto, Enum
 
 import transformer_engine.pytorch as te
 
@@ -15,8 +16,14 @@ import multidevice
 multidevice_test = multidevice.multidevice_test
 
 
+class ComputeType(Enum):
+    FORWARD = auto()
+    BACKWARD = auto()
+
+
 @pytest.mark.mpi
-def test_transformer_layer(multidevice_test):
+@pytest.mark.parametrize("compute_type", [ComputeType.FORWARD, ComputeType.BACKWARD])
+def test_transformer_layer(multidevice_test, benchmark, compute_type):
     # Hyperparameters for GPT-3
     hidden_size = 12288
     num_heads = 96
@@ -51,7 +58,32 @@ def test_transformer_layer(multidevice_test):
     x = torch.randn(
         batch_size, sequence_length, hidden_size, dtype=dtype, device="cuda"
     )
-    y = transformer_layer(x)
-    assert y.size() == torch.Size([batch_size, sequence_length, hidden_size])
+
+    match compute_type:
+        case ComputeType.FORWARD:
+
+            def benchmark_fn():
+                return transformer_layer(x)
+
+            y = benchmark(benchmark_fn)
+            assert y.size() == torch.Size([batch_size, sequence_length, hidden_size])
+        case ComputeType.BACKWARD:
+            # Due to
+            # https://github.com/Lightning-AI/lightning-thunder/issues/701, a
+            # limitation in TransformerEngine, we can't repeatedly call
+            # torch.autograd.backward to benchmark just backprop. As a
+            # workaround, the code below runs forward before each backprop but
+            # only measure the backprop time.
+            def setup_fn():
+                y = transformer_layer(x)
+                dy = torch.rand_like(y)
+                return (y, dy), {}
+
+            def benchmark_fn(y, dy):
+                torch.autograd.backward(y, dy)
+
+            benchmark.pedantic(
+                benchmark_fn, setup=setup_fn, warmup_rounds=2, iterations=1, rounds=5
+            )
 
     dist.destroy_process_group()

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -41,7 +41,9 @@ def test_transformer_layer(multidevice_test, benchmark, compute_type):
 
     torch.cuda.set_device(rank)
     os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = "29500"
+    # nvFuser's Communicator singleton is hardcoded to use port 29500. Use a
+    # different port here to avoid conflict.
+    os.environ["MASTER_PORT"] = "29400"
     dist.init_process_group(
         backend="nccl",
         init_method="env://",


### PR DESCRIPTION
```
$ mpirun -np 1 pytest tests/python/test_transformer_engine.py --only-mpi

------------------------------------------------------------------------------------------------- benchmark: 2 tests ------------------------------------------------------------------------------------------------
Name (time in us)                           Min                   Max                  Mean              StdDev                Median                 IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_transformer_layer[forward]        952.7383 (1.0)      1,200.1079 (1.0)      1,016.5755 (1.0)      103.4595 (1.0)        976.7041 (1.0)       79.6057 (1.0)           1;1  983.6948 (1.0)           5           1
test_transformer_layer[backward]     1,070.4808 (1.12)     1,347.0454 (1.12)     1,188.3112 (1.17)     136.6049 (1.32)     1,125.9178 (1.15)     257.2080 (3.23)          1;0  841.5304 (0.86)          5           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```