### PR TITLE
Append to AbstractTensor's info whenever we append to domain

### DIFF
--- a/csrc/abstract_tensor.h
+++ b/csrc/abstract_tensor.h
@@ -634,6 +634,8 @@ struct AbstractTensorWithInfo {
       int64_t axis,
       Val* factor,
       bool inner_split = true) {
+    NVF_ERROR(domain.size() == info.size());
+
     axis = wrapDim(axis, (int64_t)domain.size());
     auto [outer, inner] = AbstractId::dispatch(
         DispatchSplit{}, domain[axis], factor, inner_split);
@@ -656,6 +658,8 @@ struct AbstractTensorWithInfo {
   }
 
   AbstractTensorWithInfo& merge(int64_t axis_o, int64_t axis_i) {
+    NVF_ERROR(domain.size() == info.size());
+
     axis_o = wrapDim(axis_o, (int64_t)domain.size());
     axis_i = wrapDim(axis_i, (int64_t)domain.size());
 
@@ -682,6 +686,8 @@ struct AbstractTensorWithInfo {
 
   AbstractTensorWithInfo& reorder(
       const std::unordered_map<int64_t, int64_t>& old2new) {
+    NVF_ERROR(domain.size() == info.size());
+
     NVF_ERROR(
         !domain.empty() || old2new.empty(), "Tried to reorder a 0-dim domain");
 
@@ -744,6 +750,8 @@ struct AbstractTensorWithInfo {
       SwizzleType swizzle_type,
       int64_t x,
       int64_t y) {
+    NVF_ERROR(domain.size() == info.size());
+
     x = wrapDim(x, (int64_t)domain.size());
     y = wrapDim(y, (int64_t)domain.size());
 
@@ -767,6 +775,8 @@ struct AbstractTensorWithInfo {
       Swizzle2DType swizzle_type,
       int64_t x,
       int64_t y) {
+    NVF_ERROR(domain.size() == info.size());
+
     x = wrapDim(x, (int64_t)domain.size());
     y = wrapDim(y, (int64_t)domain.size());
 

--- a/csrc/device_lower/analysis/tma.cpp
+++ b/csrc/device_lower/analysis/tma.cpp
@@ -816,6 +816,7 @@ class DomainMerger {
     for (auto& item : raw_tma_domain) {
       domain_.domain.emplace_back(
           ValGroupAndItsGraph{std::move(std::get<0>(item)), &id_graph});
+      domain_.info.emplace_back();
       contiguity_and_stride_.emplace_back(std::get<1>(item), std::get<2>(item));
     }
   }


### PR DESCRIPTION
This fixes failures in `TMAIndexingTest` tests on Hopper that result in a segfault due to unchecked accesses that result when `domain` has entries but `info` is empty in `AbstractTensorWithInfo`. Note that another approach would be to switch to a class instead of a struct and add accessors that guarantee we maintain the same length for each of these vectors.

This change also adds more assertions in scheduling methods of AbstractTensorWithInfo to check that the `domain` and `info` attributes maintain the same size.