### PR TITLE
Some minor cleanup of header include and declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/fusion_executor/executor_kernel_arg.cpp
   ${NVFUSER_SRCS_DIR}/fusion_executor/executor_params.cpp
   ${NVFUSER_SRCS_DIR}/fusion_executor/executor_utils.cpp
+  ${NVFUSER_SRCS_DIR}/fusion_guard.cpp
   ${NVFUSER_SRCS_DIR}/fusion_segmenter.cpp
   ${NVFUSER_SRCS_DIR}/global_allocator.cpp
   ${NVFUSER_SRCS_DIR}/grouped_reduction.cpp

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -28,25 +28,6 @@
 
 namespace nvfuser {
 
-/*static*/ thread_local Fusion* FusionGuard::active_fusion_ = nullptr;
-
-FusionGuard::FusionGuard(Fusion* fusion) : prev_fusion_(active_fusion_) {
-  active_fusion_ = fusion;
-}
-
-FusionGuard::~FusionGuard() {
-  active_fusion_ = prev_fusion_;
-}
-
-// Cast to non-cast because many users need it.
-/*static*/ Fusion* FusionGuard::getCurFusion() {
-  return active_fusion_;
-}
-
-/*static*/ void FusionGuard::setCurFusion(Fusion* fusion) {
-  active_fusion_ = fusion;
-}
-
 void swap(Fusion& a, Fusion& b) noexcept {
   FUSER_PERF_SCOPE("Fusion swap");
 

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -12,7 +12,9 @@
 
 #include <debug.h>
 #include <fusion_executor/executor_params.h>
+#include <fusion_guard.h>
 #include <ir/base_nodes.h>
+#include <ir/cloner.h>
 #include <ir/container.h>
 #include <iter_visitor.h>
 #include <visibility.h>
@@ -25,11 +27,11 @@
 
 namespace nvfuser {
 
-//! Usage: FusionGuard and Fusion are required user interfaces for any operation
-//! underlying the code generator. In order to create values, expressions, and
-//! generate code a Fusion instance must be active. It is the responsibility of
-//! the user to create a Fusion instance and register it with the fusion guard.
-//! The simplest example of this is:
+//! Usage: FusionGuard (defined in fusion_guard.h) and Fusion are required user
+//! interfaces for any operation underlying the code generator. In order to
+//! create values, expressions, and generate code a Fusion instance must be
+//! active. It is the responsibility of the user to create a Fusion instance and
+//! register it with the fusion guard. The simplest example of this is:
 //!
 //!     Fusion fusion;
 //!     FusionGuard fg(&fusion);
@@ -64,24 +66,6 @@ class SegmentedFusion;
 class KernelArgumentHolder;
 
 class DynamicTransformConcretizationInfo;
-
-//! Fusion Guard is our "context manager". It holds the active fusion and
-//! allows it to be accessed anywhere through FusionGuard::getCurFusion()
-class FusionGuard {
- public:
-  //! Set the active fusion so it can be manipulated.
-  NVF_API explicit FusionGuard(Fusion* fusion);
-
-  NVF_API ~FusionGuard();
-
-  NVF_API static Fusion* getCurFusion();
-  static void setCurFusion(Fusion* fusion);
-
- private:
-  Fusion* prev_fusion_;
-
-  static thread_local Fusion* active_fusion_;
-};
 
 // Set the enum base to `int` so it can be safely serialized as a part of
 // serde::InputOutputAlias.
@@ -495,6 +479,22 @@ class NVF_API Fusion : public IrContainer {
 
   std::unique_ptr<std::vector<TensorView*>> all_tvs_ptr_ = nullptr;
 };
+
+template <typename T>
+size_t Fusion::manage(T data) {
+  std::any a = data;
+  return manage(a, [](IrCloner& cloner, std::any data) {
+    return std::any(cloner.clone(std::any_cast<T>(data)));
+  });
+}
+
+template <typename T>
+void Fusion::manage(std::string key, T data) {
+  std::any a = data;
+  manage(key, a, [](IrCloner& cloner, std::any data) {
+    return std::any(cloner.clone(std::any_cast<T>(data)));
+  });
+}
 
 // Returns true if all fusion outputs are expression evaluated.
 bool isExpressionEvaluated(Fusion* fusion);

--- a/csrc/fusion_guard.cpp
+++ b/csrc/fusion_guard.cpp
@@ -1,0 +1,31 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <fusion_guard.h>
+
+namespace nvfuser {
+
+/*static*/ thread_local Fusion* FusionGuard::active_fusion_ = nullptr;
+
+FusionGuard::FusionGuard(Fusion* fusion) : prev_fusion_(active_fusion_) {
+  active_fusion_ = fusion;
+}
+
+FusionGuard::~FusionGuard() {
+  active_fusion_ = prev_fusion_;
+}
+
+// Cast to non-cast because many users need it.
+/*static*/ Fusion* FusionGuard::getCurFusion() {
+  return active_fusion_;
+}
+
+/*static*/ void FusionGuard::setCurFusion(Fusion* fusion) {
+  active_fusion_ = fusion;
+}
+
+} // namespace nvfuser

--- a/csrc/fusion_guard.h
+++ b/csrc/fusion_guard.h
@@ -11,40 +11,13 @@
 
 namespace nvfuser {
 
-//! Usage: FusionGuard and Fusion are required user interfaces for any operation
-//! underlying the code generator. In order to create values, expressions, and
-//! generate code a Fusion instance must be active. It is the responsibility of
-//! the user to create a Fusion instance and register it with the fusion guard.
-//! The simplest example of this is:
-//!
-//!     Fusion fusion;
-//!     FusionGuard fg(&fusion);
-//!
-//! Once a fusion is active all values and operations will be registered with
-//! it.
-//!
-//! FusionGuard and Fusion are critical to the lifetime model of the IR system.
-//! FusionGuard is a convenient way to set what base container instance holds
-//! the defined IR. Statements that are defined are registered through the
-//! FusionGuard with a particular Fusion. FusionGuard provides convenient
-//! methods to access the active fusion so it doesn't need to be passed around
-//! constantly. Any IR node derived classes from Statement must register with
-//! Fusion to avoid memory leaks.
-//!
-//! Fusion is generally thought of as a translated fusion group from the JIT. It
-//! is likely a single kernel, although, we don't have to stick to this in the
-//! future and could in theory generate multiple kernels with an executor to run
-//! them.
-//!
-//! Fusion also allows users to set input/output values that will allow us to
-//! figure out how to hook up runtime data to and from the JIT as well as
-//! provide us mechanisms for dependency analysis and DCE including safety
-//! checks.
-
 class Fusion;
 
 //! Fusion Guard is our "context manager". It holds the active fusion and
-//! allows it to be accessed anywhere through FusionGuard::getCurFusion()
+//! allows it to be accessed anywhere through
+//! FusionGuard::getCurFusion().
+//!
+//! See also the comments in fusion.h
 class FusionGuard {
  public:
   //! Set the active fusion so it can be manipulated.

--- a/csrc/fusion_guard.h
+++ b/csrc/fusion_guard.h
@@ -1,0 +1,64 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <visibility.h>
+
+namespace nvfuser {
+
+//! Usage: FusionGuard and Fusion are required user interfaces for any operation
+//! underlying the code generator. In order to create values, expressions, and
+//! generate code a Fusion instance must be active. It is the responsibility of
+//! the user to create a Fusion instance and register it with the fusion guard.
+//! The simplest example of this is:
+//!
+//!     Fusion fusion;
+//!     FusionGuard fg(&fusion);
+//!
+//! Once a fusion is active all values and operations will be registered with
+//! it.
+//!
+//! FusionGuard and Fusion are critical to the lifetime model of the IR system.
+//! FusionGuard is a convenient way to set what base container instance holds
+//! the defined IR. Statements that are defined are registered through the
+//! FusionGuard with a particular Fusion. FusionGuard provides convenient
+//! methods to access the active fusion so it doesn't need to be passed around
+//! constantly. Any IR node derived classes from Statement must register with
+//! Fusion to avoid memory leaks.
+//!
+//! Fusion is generally thought of as a translated fusion group from the JIT. It
+//! is likely a single kernel, although, we don't have to stick to this in the
+//! future and could in theory generate multiple kernels with an executor to run
+//! them.
+//!
+//! Fusion also allows users to set input/output values that will allow us to
+//! figure out how to hook up runtime data to and from the JIT as well as
+//! provide us mechanisms for dependency analysis and DCE including safety
+//! checks.
+
+class Fusion;
+
+//! Fusion Guard is our "context manager". It holds the active fusion and
+//! allows it to be accessed anywhere through FusionGuard::getCurFusion()
+class FusionGuard {
+ public:
+  //! Set the active fusion so it can be manipulated.
+  NVF_API explicit FusionGuard(Fusion* fusion);
+
+  NVF_API ~FusionGuard();
+
+  NVF_API static Fusion* getCurFusion();
+  static void setCurFusion(Fusion* fusion);
+
+ private:
+  Fusion* prev_fusion_;
+
+  static thread_local Fusion* active_fusion_;
+};
+
+} // namespace nvfuser

--- a/csrc/ir/builder.h
+++ b/csrc/ir/builder.h
@@ -8,8 +8,9 @@
 #pragma once
 
 #include <exceptions.h>
-#include <ir/all_nodes.h>
+#include <fusion_guard.h>
 #include <ir/builder_passkey.h>
+#include <ir/container.h>
 #include <utils.h>
 #include <visibility.h>
 
@@ -19,7 +20,12 @@ namespace kir {
 class Kernel;
 }
 
+class ArrayConstruct;
 class IrCloner;
+class NamedScalar;
+class StructConstruct;
+class TensorView;
+class Val;
 
 //! IR builder interface
 class IrBuilder {

--- a/csrc/ir/cloner.h
+++ b/csrc/ir/cloner.h
@@ -159,20 +159,4 @@ T* IrBuilder::clone(const T* src, IrCloner* ir_cloner) {
   return dest;
 }
 
-template <typename T>
-size_t Fusion::manage(T data) {
-  std::any a = data;
-  return manage(a, [](IrCloner& cloner, std::any data) {
-    return std::any(cloner.clone(std::any_cast<T>(data)));
-  });
-}
-
-template <typename T>
-void Fusion::manage(std::string key, T data) {
-  std::any a = data;
-  manage(key, a, [](IrCloner& cloner, std::any data) {
-    return std::any(cloner.clone(std::any_cast<T>(data)));
-  });
-}
-
 } // namespace nvfuser

--- a/csrc/ir/container.cpp
+++ b/csrc/ir/container.cpp
@@ -6,9 +6,11 @@
  */
 // clang-format on
 #include <instrumentation.h>
+#include <ir/base_nodes.h>
 #include <ir/builder.h>
 #include <ir/cloner.h>
 #include <ir/container.h>
+#include <ir/internal_nodes.h>
 
 namespace nvfuser {
 


### PR DESCRIPTION
- Moved Fusion::manage from cloner.h to fusion.h
- Moved FusionGuard to its own file to allow only include FusionGuard without defining Fusion
- Removed include of all_nodes.h from builder.h