### PR TITLE
Add an experimental option to map cloned IterDomains in the Exact graph

### DIFF
--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -883,4 +883,29 @@ std::vector<TensorView*> Fusion::allTvs() {
   return std::vector<TensorView*>(*all_tvs_ptr_);
 }
 
+void Fusion::registerExactMapping(IterDomain* id0, IterDomain* id1) {
+  NVF_ERROR(
+      id0->sameAs(id1),
+      "Invalid domains to map: ",
+      id0->toString(),
+      ", ",
+      id1->toString());
+
+  if (!hasRegisteredExactMappings()) {
+    manage(exact_mappings_key, DisjointSets<IterDomain*>{});
+  }
+
+  auto& id_mappings = getManaged<DisjointSets<IterDomain*>>(exact_mappings_key);
+
+  id_mappings.mapEntries(id0, id1);
+}
+
+DisjointSets<IterDomain*> Fusion::registeredExactMappings() const {
+  if (!hasRegisteredExactMappings()) {
+    return {};
+  }
+
+  return getManaged<DisjointSets<IterDomain*>>(exact_mappings_key);
+}
+
 } // namespace nvfuser

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -419,6 +419,19 @@ class NVF_API Fusion : public IrContainer {
   //! making modifications to the fusion, it can easily cause a segfault.
   std::vector<TensorView*> allTvs();
 
+  //! Specify id0 and id1 are mapped in the Exact graph. This should
+  //! be used only when absolutely necessary.
+  //!
+  //! Currently, id0->sameAs(id1) needs to hold. It will be an error
+  //! otherwise.
+  void registerExactMapping(IterDomain* id0, IterDomain* id1);
+
+  bool hasRegisteredExactMappings() const {
+    return hasManaged(exact_mappings_key);
+  }
+
+  DisjointSets<IterDomain*> registeredExactMappings() const;
+
  protected:
   friend SegmentCandidateFinder;
   friend SegmentedFusion;
@@ -478,6 +491,8 @@ class NVF_API Fusion : public IrContainer {
   int64_t expected_dynamic_smem_bytes_ = -1LL;
 
   std::unique_ptr<std::vector<TensorView*>> all_tvs_ptr_ = nullptr;
+
+  inline static const std::string exact_mappings_key = "exact_mappings";
 };
 
 template <typename T>

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -298,7 +298,7 @@ ValGraph& IdModel::buildExactGraph() {
       for (auto c_id :
            getSortedKeys(exact_c2p_logical_map, Statement::lessThan)) {
         auto p_id = exact_c2p_logical_map.at(c_id);
-        idGraph(IdMappingMode::EXACT).mapVals(c_id, p_id);
+        graph.mapVals(c_id, p_id);
       }
     }
 
@@ -312,7 +312,7 @@ ValGraph& IdModel::buildExactGraph() {
         for (auto domain_i : c10::irange(c_tv->getMaybeRootDomain().size())) {
           auto c_id = c_tv->getMaybeRootDomain()[domain_i];
           auto o_id = other_tv_output->getMaybeRootDomain()[domain_i];
-          idGraph(IdMappingMode::EXACT).mapVals(o_id, c_id);
+          graph.mapVals(o_id, c_id);
         }
       }
     } else {
@@ -325,14 +325,14 @@ ValGraph& IdModel::buildExactGraph() {
           for (auto c_id :
                getSortedKeys(exact_c2p_root_map, Statement::lessThan)) {
             auto p_id = exact_c2p_root_map.at(c_id);
-            idGraph(IdMappingMode::EXACT).mapVals(c_id, p_id);
+            graph.mapVals(c_id, p_id);
           }
         }
       }
     }
 
     // TODO: Revisit if we really should map domains in the exact map
-    mapThroughLoopSwizzles(idGraph(IdMappingMode::EXACT));
+    mapThroughLoopSwizzles(graph);
   }
 
   // Map additional exact mappings if registered. Only map those that

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -343,15 +343,16 @@ ValGraph& IdModel::buildExactGraph() {
       DisjointSets<IterDomain*> additional_mappings =
           fusion->registeredExactMappings();
       for (const auto& disjoint_set : additional_mappings.disjointSets()) {
-        auto num_ids = disjoint_set->size();
-        for (const auto i : c10::irange(num_ids)) {
-          for (const auto j : c10::irange(i + 1, num_ids)) {
-            auto id_i = disjoint_set->at(i);
-            auto id_j = disjoint_set->at(j);
-            if (graph.hasGroup(id_i) && graph.hasGroup(id_j) &&
-                id_i->sameAs(id_j)) {
-              graph.mapVals(id_i, id_j);
-            }
+        IterDomain* registerd_id = nullptr;
+        for (auto id : *disjoint_set) {
+          if (!graph.hasGroup(id)) {
+            continue;
+          }
+
+          if (registerd_id == nullptr) {
+            registerd_id = id;
+          } else {
+            graph.mapVals(registerd_id, id);
           }
         }
       }

--- a/csrc/ir/cloner.h
+++ b/csrc/ir/cloner.h
@@ -7,6 +7,7 @@
 // clang-format on
 #pragma once
 
+#include <disjoint_set.h>
 #include <dispatch.h>
 #include <exceptions.h>
 #include <ir/builder.h>
@@ -91,6 +92,27 @@ class IrCloner {
       copy.emplace(clone(k), clone(v));
     }
     return copy;
+  }
+
+  template <typename T, typename Hash = std::hash<T>>
+  DisjointSets<T, Hash> clone(const DisjointSets<T, Hash>& disjoint_sets) {
+    DisjointSets<T, Hash> cloned_disjoint_sets;
+    for (const auto& original_set : disjoint_sets.disjointSets()) {
+      NVF_ERROR(!original_set->empty());
+      bool first = true;
+      for (const auto& val : *original_set) {
+        typename DisjointSets<T, Hash>::DisjointSet new_set;
+        if (first) {
+          auto it = cloned_disjoint_sets.initializeSet(val).first;
+          new_set = it->second;
+          first = false;
+        } else {
+          cloned_disjoint_sets.appendToSet(val, new_set);
+        }
+      }
+    }
+
+    return cloned_disjoint_sets;
   }
 
   IrContainer* container() const {

--- a/csrc/ir/cloner.h
+++ b/csrc/ir/cloner.h
@@ -102,12 +102,13 @@ class IrCloner {
       bool first = true;
       for (const auto& val : *original_set) {
         typename DisjointSets<T, Hash>::DisjointSet new_set;
+        auto clone_of_val = clone(val);
         if (first) {
-          auto it = cloned_disjoint_sets.initializeSet(val).first;
+          auto it = cloned_disjoint_sets.initializeSet(clone_of_val).first;
           new_set = it->second;
           first = false;
         } else {
-          cloned_disjoint_sets.appendToSet(val, new_set);
+          cloned_disjoint_sets.appendToSet(clone_of_val, new_set);
         }
       }
     }

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -111,7 +111,10 @@ class NVF_API IterDomain : public Val {
   //! Returns a new IterDomain matching properties of this
   //!
   //! This does NOT copy the is_rfactor_domain flag.
-  IterDomain* cloneWithoutRFactor() const;
+  //!
+  //! When map_with_original is true, the clone of the original is
+  //! mapped in the Exact graph.
+  IterDomain* cloneWithoutRFactor(bool map_with_original = false);
 
   //! Clone a vector domains
   static std::vector<IterDomain*> clone(

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2521,8 +2521,12 @@ std::string IterDomain::toInlineString(int indent_size) const {
 
 // Returns a new IterDomain matching properties of this except for
 // is_rfactor_domain_
-IterDomain* IterDomain::cloneWithoutRFactor() const {
+IterDomain* IterDomain::cloneWithoutRFactor(bool map_with_original) {
   auto cloned = IterDomainBuilder(this).resetRfactor().build();
+
+  if (map_with_original) {
+    fusion()->registerExactMapping(this, cloned);
+  }
 
   return cloned;
 }


### PR DESCRIPTION
The primary use case is when setting a loop domain of a tensor that would be involved in broadcast forwarding in the conventional inlining approach. For example, think of a fusion like below:

```
t0 = [i0]
t1 = [i0, i1]
t2 = broadcast(t0, {false, true}); // [i0, b2]
t3 = t1 + t2
```

To inline all tensors together, t0 and t2 would be inlined with broadcast forwarding.

Suppose a loop domain of t3 would be set for all tensors, t0, for example, would have a loop domain of: {t0->axis(0), clone of t3->axis(1)}. In this case, however, the clone is almost an exact copy of the t3 ID, there's no use or def to define its exact mapping with the original t3 ID. This is problematic when inlining t0 since the inlining rule would use the Exact (or Broadcast) graph to determine the validity of inlining, but for the cloned ID of t0, since there's no def or use, it would have no mapping with any of the other IDs, which means the inlining would fail.

The mapping option added in this PR workarounds the issue. While I am not completely confident about forcing certain ID mappings, I think it's a reasonable compromise between safety and flexibility. Besides, the mapping is currently only allowed if two IDs are the same per IterDomain::sameAs.