### PR TITLE
Fix TensorDomain::allIDs when loop domain has extra IDs

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3630,11 +3630,18 @@ void TensorDomain::setAllocationDomain(
 }
 
 std::vector<IterDomain*> TensorDomain::allIDs() const {
+  // loop_domain_ must be the first domain since loop domains are
+  // allowed to have extra domains that may not exist in other
+  // domains and IRBFS::getExprsBetween is not symmetric with respect
+  // to its two domain parameters. For example, it can find all exprs
+  // from a loop domain to a logical domain but may miss from logical
+  // to loop. See NVFuserTest.AllIDsWithExtraLoopIDs for a concrete
+  // example.
   std::array<const std::vector<IterDomain*>*, 5> all_domains = {
+      &loop_domain_,
       &logical_domain_,
       &root_domain_,
       &allocation_domain_,
-      &loop_domain_,
       &additional_ids_};
   VectorOfUniqueEntries<IterDomain*> discovered_ids;
   for (auto domain : all_domains) {

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -6513,6 +6513,75 @@ TEST_F(NVFuserTest, CompareLogicalAndLoopDomains) {
           "Not all logical IDs are covered by loop domain")));
 }
 
+TEST_F(NVFuserTest, AllIDsWithExtraLoopIDs) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  // [i0, i1]
+  auto tv0 = makeSymbolicTensor(2);
+  fusion.addInput(tv0);
+  // [i0]
+  auto tv1 = makeSymbolicTensor(1);
+  fusion.addInput(tv1);
+
+  // [i0]
+  auto tv2 = set(tv1);
+  // [i0, b1]
+  auto tv3 = broadcast(tv2, {false, true});
+  // [i0, i1]
+  auto tv4 = add(tv0, tv3);
+  fusion.addOutput(tv4);
+
+  // Set the loop domain of tv2 the same as tv4. The new loop domain
+  // includes an ID that is not reachable from tv2 logical domain
+  auto tv2_inner_loop_domain =
+      tv4->getLoopDomain().at(1)->cloneWithoutRFactor();
+  tv2->setLoopDomain({tv2->getLogicalDomain().at(0), tv2_inner_loop_domain});
+
+  tv2->merge(0, 1);
+  auto tv2_merge_out = tv2->axis(0);
+  tv2->split(0, 32);
+
+  // tv2 logical: [i0]
+  //   merge(i0, i1) -> i0*i1
+  //   split(i0*i1, 32) -> i0*i1/32, 32
+  // tv2 loop: [i0*i1/32, 32]
+  //
+  // All IDs: [i0, i0*i1, i0*i1/32, 32]
+
+  // This ordering should return nothing as the logical domain does
+  // not have i1, thus the merge expr cannot be traversed.
+  EXPECT_TRUE(
+      IRBFS::getExprsBetween(
+          {tv2->getLogicalDomain().begin(), tv2->getLogicalDomain().end()},
+          {tv2->getLoopDomain().begin(), tv2->getLoopDomain().end()},
+          false)
+          .empty());
+
+  // This ordering should find two exprs (i.e., the merge and the split).
+  EXPECT_EQ(
+      IRBFS::getExprsBetween(
+          {tv2->getLoopDomain().begin(), tv2->getLoopDomain().end()},
+          {tv2->getLogicalDomain().begin(), tv2->getLogicalDomain().end()},
+          false)
+          .size(),
+      2);
+
+  std::unordered_set<IterDomain*> tv2_all_ids_ref;
+  tv2_all_ids_ref.insert(
+      tv2->getLogicalDomain().begin(), tv2->getLogicalDomain().end());
+  tv2_all_ids_ref.insert(tv2_inner_loop_domain);
+  tv2_all_ids_ref.insert(tv2_merge_out);
+  tv2_all_ids_ref.insert(
+      tv2->getLoopDomain().begin(), tv2->getLoopDomain().end());
+
+  auto tv2_all_ids = tv2->domain()->allIDs();
+  std::unordered_set<IterDomain*> tv2_all_id_set(
+      tv2_all_ids.begin(), tv2_all_ids.end());
+
+  EXPECT_EQ(tv2_all_id_set, tv2_all_ids_ref);
+}
+
 // Repro for issue #236 (https://github.com/NVIDIA/Fuser/issues/236)
 TEST_F(NVFuserTest, DoublePrecisionNorm_CUDA) {
   auto fusion = std::make_unique<Fusion>();


### PR DESCRIPTION
This is a follow-up to #2937, which allowed the loop domain of a tensor to have extra IDs (e.g., for inlining a 1D tensor to a 2D tensor).

When working on #2983, I realized `TensorDomain::allIDs` has a problem of finding all IDs with extra loop IDs. As mentioned in the added code comment, the issue is primarily because `IRBFS::getExprsBetween` is asymmetric with respect to its two domain parameters. See the added test for a simple concrete example.