### PR TITLE
Fix compile error in multi-matmul scheduler

### DIFF
--- a/tests/cpp/test_multi_matmul_scheduler.cpp
+++ b/tests/cpp/test_multi_matmul_scheduler.cpp
@@ -358,10 +358,10 @@ class MultiMatmulSchedulerMatchTest
     cloner_ = std::make_unique<IrCloner>(Fusion::copy(fusion, &new_fusion));
 
     // Schedule fusion with original matmul scheduler
-    scheduleMatmul(fusion, params);
+    scheduleMatmul(fusion, &params);
 
     // Schedule cloned fusion with new scheduler
-    scheduleMultipleMatmuls(&new_fusion, params);
+    scheduleMultipleMatmuls(&new_fusion, &params);
 
     // Find tensors to compare. Note that these, and all producer tensors will
     // be checked.


### PR DESCRIPTION
`main` is currently not compiling due to the changes introduced in #2913. There was a change on main that I didn't see between when CI passed and when I merged. This PR fixes that.