### PR TITLE
Extend the host latency benchmarking for additional cases.

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -267,6 +267,11 @@ def run_benchmark(
     ], f'Unsupported device type: {device.split(":")[0]}. Use one of cuda/host.'
 
     host_bench_mode = None
+
+    # Store warmup rounds locally to modify for host:steady/dynamic cases.
+    global warmup_rounds
+    warmup_rounds = BENCHMARK_CONFIG["warmup_rounds"]
+
     if device.split(":")[0] == "host":
         # Host benchmarking expects a fusion function to generate fusion definitions everytime FusionCache is reset.
         assert fusion_fn is not None and benchmark_fn is None
@@ -286,9 +291,9 @@ def run_benchmark(
         ):
             # By default, warmup_rounds=1. If BENCHMARK_CONFIG['warmup_rounds'] == 0 through --benchmark-warmup-rounds, raise a warning that it was ignored.
             warnings.warn(
-                "--benchmark-warmup-rounds=0 was ignored for host benchmarking. Setting warmup_rounds=1."
+                "--benchmark-warmup-rounds=0 is ignored for host:steady/dynamic benchmarking. Setting warmup_rounds=1."
             )
-            BENCHMARK_CONFIG["warmup_rounds"] = 1
+            warmup_rounds = 1
 
     """
     Setup function: This is called before each benchmarking round. This function is used to:
@@ -355,7 +360,7 @@ def run_benchmark(
         benchmark_fn,
         setup=setup,
         rounds=BENCHMARK_CONFIG["rounds"],
-        warmup_rounds=BENCHMARK_CONFIG["warmup_rounds"],
+        warmup_rounds=warmup_rounds,
     )
 
     if device == "cuda":

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -269,7 +269,6 @@ def run_benchmark(
     host_bench_mode = None
 
     # Store warmup rounds locally to modify for host:steady/dynamic cases.
-    global warmup_rounds
     warmup_rounds = BENCHMARK_CONFIG["warmup_rounds"]
 
     if device.split(":")[0] == "host":

--- a/benchmarks/python/test_many_pointwise_ops.py
+++ b/benchmarks/python/test_many_pointwise_ops.py
@@ -30,7 +30,7 @@ def pointwise_ops_fusion(fd: FusionDefinition, dtype: DataType, num_iters: int):
 
 
 # NOTE: num_iters restricted due to issue #1234.
-@pytest.mark.parametrize("num_iters", [16])
+@pytest.mark.parametrize("num_iters", [2, 4, 8, 16])
 @pytest.mark.parametrize("host_bench_mode", ["compile", "steady", "dynamic"])
 def test_pointwise_ops_benchmark(
     benchmark,

--- a/benchmarks/python/test_many_pointwise_ops.py
+++ b/benchmarks/python/test_many_pointwise_ops.py
@@ -30,43 +30,8 @@ def pointwise_ops_fusion(fd: FusionDefinition, dtype: DataType, num_iters: int):
 
 
 # NOTE: num_iters restricted due to issue #1234.
-# @pytest.mark.parametrize("num_iters", [2, 4, 8, 16])
-# @pytest.mark.parametrize("host_bench_mode", ["compile", "steady"])
-# def test_pointwise_ops_benchmark(
-#     benchmark,
-#     num_iters: int,
-#     host_bench_mode: str,
-#     disable_validation: bool,
-#     disable_benchmarking: bool,
-# ):
-#     clear_cuda_cache()
-#     inputs = [torch.randn(13, device="cuda", dtype=torch.float16) for _ in range(2)]
-#     with FusionDefinition() as fd:
-#         pointwise_ops_fusion(fd, torch_dtype_to_nvfuser_dtype(torch.float16), num_iters)
-
-#     if not disable_validation:
-#         eager_output = inputs[0] + inputs[1]
-#         for _ in range(num_iters):
-#             x = torch.cos(eager_output)
-#             y = torch.sin(eager_output)
-#             eager_output = x + y
-#         fd.validate(inputs, [eager_output])
-
-#     if not disable_benchmarking:
-#         run_benchmark(
-#             benchmark,
-#             None,
-#             inputs,
-#             device=f"host:{host_bench_mode}",
-#             fusion_fn=partial(
-#                 pointwise_ops_fusion,
-#                 dtype=torch_dtype_to_nvfuser_dtype(torch.float16),
-#                 num_iters=num_iters,
-#             ),
-#         )
-
 @pytest.mark.parametrize("num_iters", [16])
-@pytest.mark.parametrize("host_bench_mode", ["dynamic"])
+@pytest.mark.parametrize("host_bench_mode", ["compile", "steady", "dynamic"])
 def test_pointwise_ops_benchmark(
     benchmark,
     num_iters: int,
@@ -75,20 +40,35 @@ def test_pointwise_ops_benchmark(
     disable_benchmarking: bool,
 ):
     clear_cuda_cache()
-    input_sizes = [5, 10, 13, 15, 17, 20]
+
+    inputs = [torch.randn(13, device="cuda", dtype=torch.float16) for _ in range(2)]
+
+    # Generate multiple inputs to measure dynamic shape overhead.
+    if host_bench_mode == "dynamic":
+        input_sizes = [5, 10, 13, 15, 17, 20]
+        inputs = [
+            [torch.randn(size, device="cuda", dtype=torch.float16) for _ in range(2)]
+            for size in input_sizes
+        ]
+
     with FusionDefinition() as fd:
         pointwise_ops_fusion(fd, torch_dtype_to_nvfuser_dtype(torch.float16), num_iters)
-    inputs = []
-    for size in input_sizes:
-        inputs.append([torch.randn(size, device="cuda", dtype=torch.float16) for _ in range(2)])
 
-    # if not disable_validation:
-    #     eager_output = inputs[0] + inputs[1]
-    #     for _ in range(num_iters):
-    #         x = torch.cos(eager_output)
-    #         y = torch.sin(eager_output)
-    #         eager_output = x + y
-    #     fd.validate(inputs, [eager_output])
+    def validate(input):
+        eager_output = input[0] + input[1]
+        for _ in range(num_iters):
+            x = torch.cos(eager_output)
+            y = torch.sin(eager_output)
+            eager_output = x + y
+        fd.validate(input, [eager_output])
+
+    if not disable_validation:
+        if host_bench_mode == "dynamic":
+            # Run validate for all input sizes.
+            for input in inputs:
+                validate(input)
+        else:
+            validate(inputs)
 
     if not disable_benchmarking:
         run_benchmark(


### PR DESCRIPTION
We currently measure the first time overhead of a fusion execution. The FusionCache is reset at the start of every benchmarking round to measure this overhead correctly. This work aims at extending the current setup for measuring host latencies in the python benchmarks to cover the following cases:

- Case 1: Compilation through NVRTC (Host time – first time overhead): This measures the first time overhead when executing a fusion definition (current setup)
- Case 2: Cache Hit overhead: This ignores the first time overhead, and measures the host latency when executing the same input multiple times.
- Case 3: Dynamic Shape overhead (not counting first time overhead): This ignores the first time overhead, and measures the host latency when executing different inputs shapes for the same fusion definition.


<img width="1409" alt="Screenshot 2024-09-23 at 2 31 37 PM" src="https://github.com/user-attachments/assets/33669bb6-bc55-441f-ae41-969db736b8a0">
