### PR TITLE
Create TmaCircularBufferInfo to consolidate data fields.

### DIFF
--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -182,6 +182,10 @@ class GpuLower : public NonCopyable {
     return circular_buffer_info_;
   }
 
+  TmaCircularBufferInfo& tmaCircularBufferInfo() {
+    return tma_circular_buffer_info_;
+  }
+
   CommonScalarMap& commonScalarMap() {
     return common_scalar_map_;
   }
@@ -228,32 +232,6 @@ class GpuLower : public NonCopyable {
 
   const std::unordered_map<const Expr*, TensorView*>& ldstMBarrierMap() const {
     return ldst_mbarrier_map_;
-  }
-
-  std::unordered_map<const Expr*, TensorView*>& ldstMBarrierTokenMap() {
-    return ldst_mbarrier_token_map_;
-  }
-
-  const std::unordered_map<const Expr*, TensorView*>& ldstMBarrierTokenMap()
-      const {
-    return ldst_mbarrier_token_map_;
-  }
-
-  std::unordered_set<const Expr*>& mBarrierTokenSmemAllocSet() {
-    return mbarrier_token_smem_alloc_set_;
-  }
-
-  const std::unordered_set<const Expr*>& mBarrierTokenSmemAllocSet() const {
-    return mbarrier_token_smem_alloc_set_;
-  }
-
-  std::unordered_map<const Expr*, kir::TensorIndex*>& ldstMBarrierIndexMap() {
-    return ldst_mbarrier_index_map_;
-  }
-
-  const std::unordered_map<const Expr*, kir::TensorIndex*>&
-  ldstMBarrierIndexMap() const {
-    return ldst_mbarrier_index_map_;
   }
 
   bool isNvFuserZeroEnabled() {
@@ -360,6 +338,7 @@ class GpuLower : public NonCopyable {
   ParallelDimensionMap parallel_dimension_map_;
   NonDivisibleSplitInfo non_divisible_split_info_;
   CircularBufferInfo circular_buffer_info_;
+  TmaCircularBufferInfo tma_circular_buffer_info_;
   CommonScalarMap common_scalar_map_;
   FusedReductionInfo fused_reduction_info_;
   std::shared_ptr<const SyncMap> sync_map_;
@@ -388,19 +367,6 @@ class GpuLower : public NonCopyable {
   //! "extent mod split_factor == 0" and an error message for divisibility check
   //! for vectorization.
   std::vector<std::pair<const Val*, std::string>> validations_;
-
-  // Keep track of placeholders for tokens returned by arrive/expected tx
-  // mbarrier operations for each load/store operation that requires such
-  // synchronization
-  std::unordered_map<const Expr*, TensorView*> ldst_mbarrier_token_map_;
-
-  // Collection of kir::Allocate for smem buffers used for mbarrier and token
-  // objects from cpAsyncBulk synchronization
-  std::unordered_set<const Expr*> mbarrier_token_smem_alloc_set_;
-
-  // Keep track what mbarrier object is used in load/store operation that
-  // requires such synchronization, required by indexing pass
-  std::unordered_map<const Expr*, kir::TensorIndex*> ldst_mbarrier_index_map_;
 
   Fusion* fusion_ = nullptr;
 

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -890,9 +890,13 @@ class AllocationInfoMap : private kir::IrVisitor {
 
       // Register start of lifetime for a mbarrier token returned by
       // MBarrierArriveExpectTx and MBarrierArrive.
-      if (GpuLower::current()->ldstMBarrierTokenMap().count(expr) > 0) {
+      if (GpuLower::current()
+              ->tmaCircularBufferInfo()
+              .ldst_mbarrier_token_map.count(expr) > 0) {
         mark_liveness(
-            GpuLower::current()->ldstMBarrierTokenMap()[expr],
+            GpuLower::current()
+                ->tmaCircularBufferInfo()
+                .ldst_mbarrier_token_map[expr],
             /*is_write=*/true);
       }
     } else if (auto inval = dynamic_cast<kir::MBarrierInvalidate*>(expr)) {
@@ -900,9 +904,13 @@ class AllocationInfoMap : private kir::IrVisitor {
 
       // Register end of lifetime for a mbarrier token returned by
       // returned by MBarrierArriveExpectTx and MBarrierArrive
-      if (GpuLower::current()->ldstMBarrierTokenMap().count(expr) > 0) {
+      if (GpuLower::current()
+              ->tmaCircularBufferInfo()
+              .ldst_mbarrier_token_map.count(expr) > 0) {
         mark_liveness(
-            GpuLower::current()->ldstMBarrierTokenMap()[expr],
+            GpuLower::current()
+                ->tmaCircularBufferInfo()
+                .ldst_mbarrier_token_map[expr],
             /*is_write=*/false);
       }
     }

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -542,18 +542,25 @@ class AllocationInserter : public kir::ExprMutator {
 
         // Map LoadStoreOp expression to ir nodes created in this pass
         GpuLower::current()->ldstMBarrierMap()[expr] = mbarrier;
-        GpuLower::current()->ldstMBarrierTokenMap()[expr] = mbarrier_tokens;
+        GpuLower::current()
+            ->tmaCircularBufferInfo()
+            .ldst_mbarrier_token_map[expr] = mbarrier_tokens;
         // Register tokens placeholder for MBarrierInit and MBarrierInvalidate,
         //  needed to manage life time of smem buffor in alias memory
-        GpuLower::current()->ldstMBarrierTokenMap()[mbarrier_init] =
-            mbarrier_tokens;
-        GpuLower::current()->ldstMBarrierTokenMap()[mbarrier_inval] =
-            mbarrier_tokens;
+        GpuLower::current()
+            ->tmaCircularBufferInfo()
+            .ldst_mbarrier_token_map[mbarrier_init] = mbarrier_tokens;
+        GpuLower::current()
+            ->tmaCircularBufferInfo()
+            .ldst_mbarrier_token_map[mbarrier_inval] = mbarrier_tokens;
         // Keep track of kir::Allocate for mBarrier and token objects,
         //  to simplify circular buffering pass logic
-        GpuLower::current()->mBarrierTokenSmemAllocSet().insert(mbarrier_alloc);
-        GpuLower::current()->mBarrierTokenSmemAllocSet().insert(
-            mbarrier_tokens_alloc);
+        GpuLower::current()
+            ->tmaCircularBufferInfo()
+            .mbarrier_token_smem_alloc_set.insert(mbarrier_alloc);
+        GpuLower::current()
+            ->tmaCircularBufferInfo()
+            .mbarrier_token_smem_alloc_set.insert(mbarrier_tokens_alloc);
       } else {
         // create and allocate a memory barrier
         TensorView* mbarrier = TensorViewBuilder()

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -553,6 +553,14 @@ class AllocationInserter : public kir::ExprMutator {
         GpuLower::current()
             ->tmaCircularBufferInfo()
             .ldst_mbarrier_token_map[mbarrier_inval] = mbarrier_tokens;
+        // Associate each cpAsyncBulk load expression with its corresponding
+        // MBarrierInit and MBarrierInvalidate
+        GpuLower::current()
+            ->tmaCircularBufferInfo()
+            .ldst_mbarrier_init_map[expr] = mbarrier_init;
+        GpuLower::current()
+            ->tmaCircularBufferInfo()
+            .ldst_mbarrier_inval_map[expr] = mbarrier_inval;
         // Keep track of kir::Allocate for mBarrier and token objects,
         //  to simplify circular buffering pass logic
         GpuLower::current()

--- a/csrc/device_lower/pass/circular_buffer.h
+++ b/csrc/device_lower/pass/circular_buffer.h
@@ -165,6 +165,21 @@
 
 namespace nvfuser {
 
+struct TmaCircularBufferInfo {
+  // Keep track of placeholders for tokens returned by arrive/expected tx
+  //   // mbarrier operations for each load/store operation that requires such
+  //     // synchronization
+  std::unordered_map<const Expr*, TensorView*> ldst_mbarrier_token_map;
+
+  // Collection of kir::Allocate for smem buffers used for mbarrier and token
+  // objects from cpAsyncBulk synchronization
+  std::unordered_set<const Expr*> mbarrier_token_smem_alloc_set;
+
+  // Keep track what mbarrier object is used in load/store operation that
+  // requires such synchronization, required by indexing pass
+  std::unordered_map<const Expr*, kir::TensorIndex*> ldst_mbarrier_index_map;
+};
+
 class CircularBufferPass {
  public:
   //! Apply circular buffering transformations

--- a/csrc/device_lower/pass/circular_buffer.h
+++ b/csrc/device_lower/pass/circular_buffer.h
@@ -166,18 +166,24 @@
 namespace nvfuser {
 
 struct TmaCircularBufferInfo {
-  // Keep track of placeholders for tokens returned by arrive/expected tx
-  //   // mbarrier operations for each load/store operation that requires such
-  //     // synchronization
+  // Track of mbarrier tokens returned by arrive and arriveExpectTx
+  // mbarrier operations for each load operation
   std::unordered_map<const Expr*, TensorView*> ldst_mbarrier_token_map;
 
-  // Collection of kir::Allocate for smem buffers used for mbarrier and token
-  // objects from cpAsyncBulk synchronization
+  // Collection of kir::Allocate for shared memory buffers used for mbarrier
+  // and token objects from cpAsyncBulk synchronization
   std::unordered_set<const Expr*> mbarrier_token_smem_alloc_set;
 
-  // Keep track what mbarrier object is used in load/store operation that
-  // requires such synchronization, required by indexing pass
+  // Track mbarrier used for cpAsyncBulk load operation. Required by indexing
+  // pass.
   std::unordered_map<const Expr*, kir::TensorIndex*> ldst_mbarrier_index_map;
+
+  // Track mbarrier init expression used for cpAsyncBulk load operation.
+  std::unordered_map<const Expr*, kir::MBarrierInit*> ldst_mbarrier_init_map;
+
+  // Track mbarrier invalidate expression used for cpAsyncBulk load operation.
+  std::unordered_map<const Expr*, kir::MBarrierInvalidate*>
+      ldst_mbarrier_inval_map;
 };
 
 class CircularBufferPass {

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1481,11 +1481,14 @@ void IndexLowering::handleCpAsyncBulkLoad(const LoadStoreOp* ldst) {
   // mbarrier_wait are added by the circular buffer pass. Otherwise, those
   // nodes are added here.
   bool is_circular_buffered =
-      (GpuLower::current()->ldstMBarrierIndexMap().count(ldst) != 0);
+      (GpuLower::current()
+           ->tmaCircularBufferInfo()
+           .ldst_mbarrier_index_map.count(ldst) != 0);
 
   if (is_circular_buffered) {
     kir::TensorIndex* mbarrier =
-        GpuLower::current()->ldstMBarrierIndexMap().at(ldst);
+        GpuLower::current()->tmaCircularBufferInfo().ldst_mbarrier_index_map.at(
+            ldst);
     Val* mbarrier_index = lower_utils::u32IndexScalarSmemTv(mbarrier);
 
     // gmem indexing and expect_bytes for mbarrier
@@ -1501,7 +1504,9 @@ void IndexLowering::handleCpAsyncBulkLoad(const LoadStoreOp* ldst) {
     pushBack(new_ldst);
 
     // register new LoadStoreOp with mbarrier
-    GpuLower::current()->ldstMBarrierIndexMap()[new_ldst] = mbarrier;
+    GpuLower::current()
+        ->tmaCircularBufferInfo()
+        .ldst_mbarrier_index_map[new_ldst] = mbarrier;
 
     GpuLower::current()->propagateExprInfo(ldst, back());
   } else {


### PR DESCRIPTION
This PR creates `TmaCircularBufferInfo` struct to consolidate data fields for TMA circular buffering.

Moved these fields to `TmaCircularBufferInfo` struct
* ldstMBarrierTokenMap
* mBarrierTokenSmemAllocSet
* ldstMBarrierIndexMap

Created new fields to track mbarrier init and invalidate expressions created for `cpAsyncBulk` in the allocation pass.
* ldst_mbarrier_init_map
* ldst_mbarrier_inval_map

In the circular buffering pass, we create new `MBarrierInit` and `MBarrierInvalidate` to handle the mbarrier create for each circular buffer stage.