### PR TITLE
Minor cleanup of HeuristicDataCache

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -4409,8 +4409,7 @@ std::unique_ptr<HeuristicParams> SegmentedFusion::makeInitialHeuristicParams(
     SchedulerRuntimeInfo& runtime_info) {
   // This will be the first time each group is scheduled. So we'd want to
   //  construct the cache data here.
-  auto heuristic_data_cache_ptr = std::make_unique<HeuristicDataCache>(
-      runtime_info.fusion(), sg->schedulerType(), runtime_info);
+  auto heuristic_data_cache_ptr = std::make_unique<HeuristicDataCache>();
   auto heuristic_data_cache = heuristic_data_cache_ptr.get();
   setCachedHeuristicDataFor(sg, std::move(heuristic_data_cache_ptr));
   return SchedulerEntry::makeSchedulerInstance(sg->schedulerType())

--- a/csrc/scheduler/compile_time_info.h
+++ b/csrc/scheduler/compile_time_info.h
@@ -232,11 +232,6 @@ class HeuristicDataCache {
   using EntryType = HeuristicCompileTime::CompileTimeEntryType;
 
  public:
-  HeuristicDataCache(
-      Fusion* fusion,
-      SchedulerType scheduler_type,
-      SchedulerRuntimeInfo& runtime_info);
-
   bool hasEntry(EntryType entry_type) {
     return entry_type_map_.find(entry_type) != entry_type_map_.end();
   }
@@ -250,7 +245,6 @@ class HeuristicDataCache {
  private:
   std::vector<EntryOwningPtr> entries_;
   std::unordered_map<EntryType, EntryPtr> entry_type_map_;
-  SchedulerType scheduler_type_;
 };
 
 //! A utility class to facilitate accessing HeuristicDataCache.

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -297,12 +297,6 @@ class CompileTimeInfo : public HeuristicCompileTime::CompileTimeInfoBase {
 
 } // namespace
 
-HeuristicDataCache::HeuristicDataCache(
-    Fusion* fusion,
-    SchedulerType scheduler_type,
-    SchedulerRuntimeInfo& runtime_info)
-    : scheduler_type_(scheduler_type) {}
-
 void HeuristicDataCache::insert(HeuristicDataCache::EntryOwningPtr new_entry) {
   // Just override when insertion duplicates, equality not checked.
   entry_type_map_[new_entry->type()] = new_entry.get();


### PR DESCRIPTION
Remove HeuristicDataCache::scheduler_type_ since it is unused.

Remove the constructor of HeuristicDataCache as it does nothing.