### PR TITLE
Short-circut magic zero pass completely when not needed

### DIFF
--- a/csrc/device_lower/pass/magic_zero.cpp
+++ b/csrc/device_lower/pass/magic_zero.cpp
@@ -125,6 +125,10 @@ void protectNonPredicateIndexWithMagicZero(
     const std::vector<ForLoop*>& loops,
     const std::vector<IterDomain*>& loop_domains,
     std::unordered_map<IterDomain*, Val*>& concrete_loop_idx_map) {
+  if (!GpuLower::current()->isNvFuserZeroEnabled()) {
+    return;
+  }
+
   // Find magic zero insertion point
   IterDomain* magic_zero_loop = nullptr;
 
@@ -182,6 +186,12 @@ IndexMagicZeroInfo protectPredicateIndexWithMagicZero(
     Val* index,
     const IndexFromIdGraph& id_graph,
     const std::vector<ForLoop*>& loops) {
+  if (!GpuLower::current()->isNvFuserZeroEnabled()) {
+    IndexMagicZeroInfo not_proteced;
+    not_proteced.index = index;
+    return not_proteced;
+  }
+
   // Gather the loop indices
   std::unordered_set<Val*> loop_indices;
   for (auto loop_id : id_graph.resolved_loop_domains) {


### PR DESCRIPTION
I encountered an indexing error in `protectPredicateIndexWithMagicZero` in one of my matmul unit tests. Matmul doesn't use magic zero, so just completely short-circuit it when not needed.