### PR TITLE
Add option to configure the install directory in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@
 #   --build-dir=<ABSOLUTE PATH>
 #     Specify in which directory to build nvfuser. If not specified, the default build directory is "./build".
 #
+#   --install-dir=<ABSOLUTE PATH>
+#     Specify in which directory to install nvfuser. If not specified, the default install directory is "./nvfuser".
+#
 #   -version-tag=TAG
 #     Specify the tag for build nvfuser version, this is used for pip wheel
 #     package nightly where we might want to add a date tag
@@ -80,6 +83,7 @@ VERSION_TAG = None
 BUILD_TYPE = "Release"
 WHEEL_NAME = "nvfuser"
 BUILD_DIR = ""
+INSTALL_DIR = ""
 INSTALL_REQUIRES = []
 EXTRAS_REQUIRE = {}
 CPP_STANDARD = 17
@@ -117,6 +121,9 @@ for i, arg in enumerate(sys.argv):
         continue
     if arg.startswith("--build-dir"):
         BUILD_DIR = arg.split("=")[1]
+        continue
+    if arg.startswith("--install-dir"):
+        INSTALL_DIR = arg.split("=")[1]
         continue
     if arg.startswith("-install_requires="):
         INSTALL_REQUIRES = arg.split("=")[1].split(",")
@@ -282,12 +289,14 @@ def version_tag():
 from tools.memory import get_available_memory_gb
 
 
-def cmake(install_prefix: str = "./nvfuser"):
+def cmake():
     # make build directories
     cwd = os.path.dirname(os.path.abspath(__file__))
     cmake_build_dir = os.path.join(cwd, "build") if not BUILD_DIR else BUILD_DIR
     if not os.path.exists(cmake_build_dir):
         os.makedirs(cmake_build_dir)
+
+    install_prefix = os.path.join(cwd, "nvfuser") if not INSTALL_DIR else INSTALL_DIR
 
     from tools.gen_nvfuser_version import (
         get_pytorch_cmake_prefix,


### PR DESCRIPTION
# What

Add in `setup.py` an option `install-dir=<absolute path>` to specify the install directory. If not provided, the install dir defaults to `./nvfuser`, thus the current default behavior remains unchanged.

# Why

- Useful option in itself
- My use case: I develop by  mounting the source repo inside a docker. Since NFS is very slow, I want to restrict the write/read to the mounted repo to the bare minimum, i.e., reading the source files. I am therefore already building fuser on a local mount, using the option `--build-dir`. But I found out that changing also the install dir speeds up further the installation
- I hope this could help reduce the NFS usage, as [was requested](https://nvidia.slack.com/archives/C8JCM3DPY/p1727281989644789?thread_ts=1727238691.063249&cid=C8JCM3DPY) to @cowanmeg and myself 