### PR TITLE
[WIP] Accept multi-matmul fusions for automatic scheduling

### DIFF
--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -262,11 +262,7 @@ std::string isMatmulFusionDefinitionSupported(
            {MatmulTensorRole::OPERAND_A, MatmulTensorRole::OPERAND_B}) {
         auto entry = tensor_roles.find(role);
         if (entry != tensor_roles.end()) {
-          if (1 == entry->second.size()) {
-            tvs_with_roles.insert(entry->second.begin(), entry->second.end());
-          } else {
-            return "There is other than one fusion input that can be MMA operand";
-          }
+          tvs_with_roles.insert(entry->second.begin(), entry->second.end());
         } else {
           return "No candidate in fusion inputs for MMA operand";
         }
@@ -376,10 +372,14 @@ class VectorizationCalculator {
   MatmulParams::SupportedVectorization compute() {
     const std::vector<int64_t> a_vecs =
         operandVectorizations(MatmulTensorRole::OPERAND_A);
-    NVF_ERROR(a_vecs.size() == 1, "Expected exactly one A operand");
+    // TODO: handle multiple operands using MatmulFusionTopology object
+    // To do this, we'll likely need to change the structure of MatmulParams to
+    // include a vectorization factor for each operand in each main loop.
+    //
+    // NVF_ERROR(a_vecs.size() == 1, "Expected exactly one A operand");
     const std::vector<int64_t> b_vecs =
         operandVectorizations(MatmulTensorRole::OPERAND_B);
-    NVF_ERROR(b_vecs.size() == 1, "Expected exactly one B operand");
+    // NVF_ERROR(b_vecs.size() == 1, "Expected exactly one B operand");
     return {a_vecs[0], b_vecs[0], epilogueVectorization()};
   }
 
@@ -851,9 +851,6 @@ std::unique_ptr<MatmulParams> getMatmulHeuristics(
   std::vector<mma_utils::MatmulPattern> patterns =
       mma_utils::findMatmulPatterns(fusion);
   NVF_ERROR(!patterns.empty(), "No matmul patterns were found");
-  NVF_ERROR(
-      patterns.size() == 1,
-      "Only a single matmul pattern can currently be fused");
   mma_utils::MatmulPattern& pattern = patterns.front();
 
   // IdModel is used to analyze problem shape & layout

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -187,9 +187,6 @@ TensorView* getOperandTv(
   const auto it = tensor_roles.find(role);
   NVF_ERROR(it != tensor_roles.end(), "Could not find any tensors with role");
   const std::vector<TensorView*>& operands = it->second;
-  NVF_ERROR(
-      operands.size() == 1,
-      "Exactly one operand is expected in each A and B role");
   return operands.front();
 }
 


### PR DESCRIPTION
Stacked on #2458

This updates the Matmul scheduler to accept fusions that have multiple matmul patterns if they pass a topology check. These conditions are checked:
- No matmul pattern can depend on the output of another matmul pattern
- Dimension roles must be compatible among all matmul patterns. That means a dimension must not appear as an M dimension in one pattern and an N dimension in another pattern, for example.
- The above condition implies that tensor roles are also compatible: an A operand in one pattern cannot appear as a B operand in another pattern for example.

Each `mma_utils::MatmulPattern` is mapped to its global memory operand inputs and patterns that share at least one of these operands are collected together. These collections will be computed together in a "main loop"; these are described by `mma_utils::MainLoopDescriptor` which holds the number of A  and B operands as well as the number of matmul patterns computed in that loop i.e. the number of register result buffers needed. The fusion topology is then described by a `mma_utils::MatmulFusionTopology` struct which just holds a vector of main loop descriptors.

This PR introduces those types along with `mma_utils::computeMatmulFusionTopology()`, and runs that in `getMatmulCompileTimeRejectReason`. Additionally, it updates `getMatmulHeuristics` to accomodate the multiple matmul case such that we do not run out of smem or register space.

### TODO
- Finish updating the matmul heuristics
- Update `mma_utils::generateSharedMemoryEpilogueHeuristics` to account for topology
- Update `MatmulParams` to accomodate different vectorization sizes for each operand in each main loop
- Plumb changes to `MatmulParams` to heuristic plugin so that we can make adjustments in the heuristic plugin instead of the post hoc approach here.
- Add more tests. Currently I'm just looking at the Llama2FFN test.