### PR TITLE
Add a util function to get a concrete loop ID

### DIFF
--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <device_lower/lower2device.h>
+#include <device_lower/utils.h>
 #include <ir/utils.h>
 #include <kernel_ir.h>
 
@@ -161,14 +162,12 @@ void CircularBufferInfo::build(Fusion* fusion) {
     //  variable would need to be allocated in each
     //  circular buffer stage.
     concrete_circular_buffered_loop_id_.insert(
-        GpuLower::current()->caMap()->getConcreteMappedID(
-            circular_buffer_axis, IdMappingMode::LOOP));
+        lower_utils::getConcreteLoopID(circular_buffer_axis));
   }
 }
 
 bool CircularBufferInfo::isCircularBufferedIterDomain(IterDomain* id) {
-  auto concrete_loop_id = GpuLower::current()->caMap()->getConcreteMappedID(
-      id, IdMappingMode::LOOP);
+  auto concrete_loop_id = lower_utils::getConcreteLoopID(id);
   return concrete_circular_buffered_loop_id_.count(concrete_loop_id);
 }
 
@@ -209,8 +208,7 @@ void CircularBufferInfo::setCircularBufferAxis(
 }
 
 void CircularBufferInfo::setStageDepth(IterDomain* id, int64_t stage_depth) {
-  auto concrete_loop_id = GpuLower::current()->caMap()->getConcreteMappedID(
-      id, IdMappingMode::LOOP);
+  auto concrete_loop_id = lower_utils::getConcreteLoopID(id);
 
   auto maybe_exisiting_depth_it = stage_depth_.find(concrete_loop_id);
   if (maybe_exisiting_depth_it == stage_depth_.end()) {
@@ -240,8 +238,7 @@ IterDomain* CircularBufferInfo::getCircularBufferAxis(
 
 int64_t CircularBufferInfo::getStageDepthFor(
     IterDomain* circular_buffer_axis) const {
-  auto concrete_id = GpuLower::current()->caMap()->getConcreteMappedID(
-      circular_buffer_axis, IdMappingMode::LOOP);
+  auto concrete_id = lower_utils::getConcreteLoopID(circular_buffer_axis);
 
   auto maybe_depth_it = stage_depth_.find(concrete_id);
 

--- a/csrc/device_lower/analysis/thread_predicate.cpp
+++ b/csrc/device_lower/analysis/thread_predicate.cpp
@@ -587,8 +587,7 @@ class ConcretizedBroadcastRedundantWriteRemover {
   void setConcretizedBroadcastLogicalDomain() {
     std::shared_ptr<const ComputeAtMap> caMap = GpuLower::current()->caMap();
     for (auto loop_id : candidate_loop_domains_) {
-      auto loop_concrete_id =
-          caMap->getConcreteMappedID(loop_id, IdMappingMode::LOOP);
+      auto loop_concrete_id = lower_utils::getConcreteLoopID(loop_id);
       auto concrete_logical_vals = IterVisitor::getInputsTo({loop_concrete_id});
       auto concrete_logical_ids =
           ir_utils::filterByType<IterDomain>(concrete_logical_vals);

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -102,8 +102,8 @@ bool isSerialBroadcastResolution(
   for (auto for_loop : for_loops) {
     // ForLoop::iter_domain() should be the concrete domain, but just
     // in case.
-    auto concrete_loop_id = GpuLower::current()->caMap()->getConcreteMappedID(
-        for_loop->iter_domain(), IdMappingMode::LOOP);
+    auto concrete_loop_id =
+        lower_utils::getConcreteLoopID(for_loop->iter_domain());
 
     // Check for any serial loop id with non-trivial extent. If the
     // concrete ID is a broadcast, it shouldn't materialize an actual

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -124,8 +124,8 @@ class AllocationInserter : public kir::ExprMutator {
           info.buffer->axis(axis_i)->isBroadcast()) {
         continue;
       }
-      auto concrete_id = gpu_lower->caMap()->getConcreteMappedID(
-          info.buffer->axis(axis_i), IdMappingMode::LOOP);
+      auto concrete_id =
+          lower_utils::getConcreteLoopID(info.buffer->axis(axis_i));
       init_dims.push_back(concrete_id);
     }
     Expr* init_expr = IrBuilder::create<LoadStoreOp>(
@@ -264,8 +264,8 @@ class AllocationInserter : public kir::ExprMutator {
         continue;
       }
 
-      auto concrete_id = gpu_lower->caMap()->getConcreteMappedID(
-          info.buffer->axis(axis_i), IdMappingMode::LOOP);
+      auto concrete_id =
+          lower_utils::getConcreteLoopID(info.buffer->axis(axis_i));
       const bool is_block_dim =
           isParallelTypeBlockDim(concrete_id->getParallelType());
       const bool is_thread_dim =
@@ -365,7 +365,8 @@ class AllocationInserter : public kir::ExprMutator {
       }
 
       auto out_tv = out->as<TensorView>();
-      auto default_val = gpu_lower->predicateElimination().getInitValue(out_tv);
+      auto default_val =
+          gpu_lower_->predicateElimination().getInitValue(out_tv);
 
       Val* init = nullptr;
       if (expr->isA<ReductionOp>() && out_tv->hasReduction()) {
@@ -605,12 +606,12 @@ class AllocationInserter : public kir::ExprMutator {
   }
 
   AllocationInserter(const std::vector<Expr*>& exprs)
-      : gpu_lower(GpuLower::current()) {
+      : gpu_lower_(GpuLower::current()) {
     kir::ExprMutator::traverseAndInsert(exprs);
   }
 
  private:
-  GpuLower* gpu_lower;
+  GpuLower* gpu_lower_ = nullptr;
 
  public:
   static std::vector<Expr*> insert(const std::vector<Expr*>& exprs) {

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -335,8 +335,7 @@ class ExprSegmentationSorter {
     if (id == kernelScopeDomain()) {
       return id;
     } else {
-      return GpuLower::current()->caMap()->getConcreteMappedID(
-          id, IdMappingMode::LOOP);
+      return lower_utils::getConcreteLoopID(id);
     }
   }
 
@@ -798,8 +797,6 @@ std::vector<IterDomain*> getLocalDomainOrdering(
     return std::vector<IterDomain*>();
   }
 
-  const auto& ca_map = GpuLower::current()->caMap();
-
   std::unordered_set<IterDomain*> domains;
 
   for (auto expr : exprs) {
@@ -820,17 +817,15 @@ std::vector<IterDomain*> getLocalDomainOrdering(
                   tv_input->getComputePosition(tv_output),
                   tv_input->getMaxProducerPosition()),
           std::back_inserter(domain),
-          [&ca_map](IterDomain* id) {
-            return ca_map->getConcreteMappedID(id, IdMappingMode::LOOP);
-          });
+          lower_utils::getConcreteLoopID);
 
       domain.erase(
           std::remove_if(
               domain.begin(),
               domain.end(),
-              [&filter, &ca_map](IterDomain* id) {
-                return filter.find(ca_map->getConcreteMappedID(
-                           id, IdMappingMode::LOOP)) == filter.end();
+              [&filter](IterDomain* id) {
+                return filter.find(lower_utils::getConcreteLoopID(id)) ==
+                    filter.end();
               }),
           domain.end());
 

--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -837,8 +837,7 @@ std::vector<IterDomain*> getLocalDomainOrdering(
   std::sort(
       merged_domain.begin(),
       merged_domain.end(),
-      ir_utils::IterDomainDependencySorter(
-          concrete_id_dependencies, GpuLower::current()->caMap()));
+      lower_utils::IterDomainDependencySorter(concrete_id_dependencies));
   return merged_domain;
 }
 
@@ -1327,10 +1326,8 @@ bool ExprSegmentationSorter::supportedMerge(ExprGroup* sg1, ExprGroup* sg2) {
   // For the consumer, if there's a dependency from PA to CA, definitely
   // not possible to merge
   if (!consumer_pa_domain.empty() && !consumer_ca_domain.empty() &&
-      ir_utils::IterDomainDependencySorter(
-          concrete_id_dependencies_,
-          GpuLower::current()->caMap(),
-          kernelScopeDomain())(
+      lower_utils::IterDomainDependencySorter(
+          concrete_id_dependencies_, kernelScopeDomain())(
           consumer_pa_domain.back(), consumer_ca_domain.back())) {
     if (isDebugDumpEnabled(DebugDumpOption::ExprSortVerbose)) {
       debug() << "Not supported as the consumer has a dependency from PA to CA"
@@ -1344,10 +1341,8 @@ bool ExprSegmentationSorter::supportedMerge(ExprGroup* sg1, ExprGroup* sg2) {
   // dependency from CA to PA
   if (consumer_pa_domain.size() < consumer_ca_domain.size() &&
       !(!consumer_pa_domain.empty() && !consumer_ca_domain.empty() &&
-        ir_utils::IterDomainDependencySorter(
-            concrete_id_dependencies_,
-            GpuLower::current()->caMap(),
-            kernelScopeDomain())(
+        lower_utils::IterDomainDependencySorter(
+            concrete_id_dependencies_, kernelScopeDomain())(
             consumer_ca_domain.back(), consumer_pa_domain.back()))) {
     if (isDebugDumpEnabled(DebugDumpOption::ExprSortVerbose)) {
       debug() << "Not supported as the consumer has more PA domains than CA"

--- a/csrc/device_lower/pass/loop_rotation.cpp
+++ b/csrc/device_lower/pass/loop_rotation.cpp
@@ -119,9 +119,7 @@ class RotateLoop : kir::ExprMutator {
   std::unordered_set<Statement*> selection_;
 
   RotateLoop(IterDomain* loop_id, std::unordered_set<Statement*> selection)
-      : loop_concrete_id_(GpuLower::current()->caMap()->getConcreteMappedID(
-            loop_id,
-            IdMappingMode::LOOP)),
+      : loop_concrete_id_(lower_utils::getConcreteLoopID(loop_id)),
         selection_(std::move(selection)) {}
 
   // We use the following strategy on expr selection:

--- a/csrc/device_lower/pass/loops.cpp
+++ b/csrc/device_lower/pass/loops.cpp
@@ -141,16 +141,13 @@ void LoopNestGenerator::generate(const std::vector<Expr*>& exprs) {
   // lower_expr_sort, EXCEPT dependencies are in opposite order,
   // inner loops are dependant on outer loops.
 
-  const auto& ca_map = GpuLower::current()->caMap();
-
   std::unordered_map<IterDomain*, std::unordered_set<IterDomain*>>
       concrete_id_dependencies;
   for (auto tv : FusionGuard::getCurFusion()->allTvs()) {
     std::unordered_set<IterDomain*> dependencies;
 
     for (auto tv_id : tv->getLoopDomain()) {
-      auto concrete_id =
-          ca_map->getConcreteMappedID(tv_id, IdMappingMode::LOOP);
+      auto concrete_id = lower_utils::getConcreteLoopID(tv_id);
 
       if (concrete_id_dependencies.find(concrete_id) ==
           concrete_id_dependencies.end()) {
@@ -219,8 +216,8 @@ void LoopNestGenerator::generate(const std::vector<Expr*>& exprs) {
       continue;
     }
 
-    auto last_id_concrete = ca_map->getConcreteMappedID(
-        tv->axis(tv->nDims() - 1), IdMappingMode::LOOP);
+    auto last_id_concrete =
+        lower_utils::getConcreteLoopID(tv->axis(tv->nDims() - 1));
     auto all_loops_it = concrete_id_dependencies.find(last_id_concrete);
     NVF_ERROR(
         all_loops_it != concrete_id_dependencies.end(),

--- a/csrc/device_lower/pass/loops.cpp
+++ b/csrc/device_lower/pass/loops.cpp
@@ -232,8 +232,7 @@ void LoopNestGenerator::generate(const std::vector<Expr*>& exprs) {
     std::sort(
         loop_structure.rbegin(),
         loop_structure.rend(),
-        ir_utils::IterDomainDependencySorter(
-            concrete_id_dependencies, GpuLower::current()->caMap()));
+        lower_utils::IterDomainDependencySorter(concrete_id_dependencies));
     loop_structures_[tv] = loop_structure;
   }
 

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -1933,6 +1933,15 @@ Val* proveLinearAndGetStride(
   return proveLinearAndGetStrideAfterPropagation(frontier, domain);
 }
 
+IterDomain* getConcreteLoopID(IterDomain* loop_id) {
+  NVF_ERROR(
+      GpuLower::hasCurrent(),
+      "GpuLower is required for getting a concrete loop domain");
+
+  return GpuLower::current()->caMap()->getConcreteMappedID(
+      loop_id, IdMappingMode::LOOP);
+}
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -375,6 +375,9 @@ Val* proveLinearAndGetStride(
     const ValGroup& linear_g,
     const ValGroups& domain);
 
+// Get the concrete loop domain of a given loop ID
+IterDomain* getConcreteLoopID(IterDomain* loop_id);
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -185,71 +185,6 @@ std::vector<Expr*> replaceInputsInExpr(
     const std::vector<Expr*>& exprs,
     const std::unordered_map<Val*, Val*>& replacement_map);
 
-// Go through all expressions and compute a local ordering of loops. operator<
-// is implemented based on the concrete_id_dependencies analysis done. If
-// there's no dependency between two IDs then order doesn't mater, otherwise we
-// can tell which is inner most by checking if there's any dependency
-// relationships.
-//
-// Dependency relationships in concrete_id_dependencies has a "global" view in
-// the fusion, so it can resolve ordering by only looking at id's and the
-// dependency map.
-//
-// For example two expressions may have domains: [I0], [I1] Yet we
-// won't know the ordering unless we see a domain with: [I0, I1]. This happened
-// in Indexing9 (also see Indexing17) test when merging T5 with
-// the group containing T10 (cache of T5, which is post broadcasted output) and
-// T6(pre broadcasted output).
-// T5 had the domain [0, 1, 2, 3, 4] produce at 3
-// T6 had the domain [0, 3, 4] compute at 3
-// Merging [0, 1, 2] and [0, 3, 4] resulted in the domain [0, 3, 4, 1, 2]
-//
-// If ID's are not in filter, we don't care about their ordering and ignore
-// them. This is because we're only focused on loops we will have to merge
-// across groups. If the domain is not in a produce at position in the producer
-// edges, or a compute at position in the consumer edges, the expressions we
-// look at may not have a unique ordering.
-//
-// The optional kernel_scope_domain parameter is only used in
-// expression sorting. It isn't in the CA map, but since we only have
-// a single unique IterDomain, the conrete ID is just itself.
-struct IterDomainDependencySorter {
-  IterDomainDependencySorter(
-      const std::unordered_map<IterDomain*, std::unordered_set<IterDomain*>>&
-          concrete_id_dependencies,
-      std::shared_ptr<const ComputeAtMap> compute_at_map,
-      IterDomain* kernel_scope_domain = nullptr)
-      : concrete_id_dependencies_(concrete_id_dependencies),
-        compute_at_map_(std::move(compute_at_map)),
-        kernel_scope_domain_(kernel_scope_domain) {}
-
-  // Return true if id0 should be before id1
-  // Orders such that if x maps to {y}, x comes before y in final ordering.
-  inline bool operator()(IterDomain* id0, IterDomain* id1) {
-    auto concrete_id_0 = id0 != kernel_scope_domain_
-        ? compute_at_map_->getConcreteMappedID(id0, IdMappingMode::LOOP)
-        : id0;
-    auto concrete_id_1 = id1 != kernel_scope_domain_
-        ? compute_at_map_->getConcreteMappedID(id1, IdMappingMode::LOOP)
-        : id1;
-    if (concrete_id_dependencies_.find(concrete_id_0) !=
-        concrete_id_dependencies_.end()) {
-      const auto& dependencies_0 = concrete_id_dependencies_.at(concrete_id_0);
-      // if id0 depends on id1 it means id1 is inside id0, so id0 < id1
-      if (dependencies_0.count(concrete_id_1)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  const std::unordered_map<IterDomain*, std::unordered_set<IterDomain*>>&
-      concrete_id_dependencies_;
-  const std::shared_ptr<const ComputeAtMap> compute_at_map_;
-  const IterDomain* kernel_scope_domain_ = nullptr;
-};
-
 } // namespace ir_utils
 
 namespace lower_utils {
@@ -377,6 +312,66 @@ Val* proveLinearAndGetStride(
 
 // Get the concrete loop domain of a given loop ID
 IterDomain* getConcreteLoopID(IterDomain* loop_id);
+
+// Go through all expressions and compute a local ordering of loops. operator<
+// is implemented based on the concrete_id_dependencies analysis done. If
+// there's no dependency between two IDs then order doesn't mater, otherwise we
+// can tell which is inner most by checking if there's any dependency
+// relationships.
+//
+// Dependency relationships in concrete_id_dependencies has a "global" view in
+// the fusion, so it can resolve ordering by only looking at id's and the
+// dependency map.
+//
+// For example two expressions may have domains: [I0], [I1] Yet we
+// won't know the ordering unless we see a domain with: [I0, I1]. This happened
+// in Indexing9 (also see Indexing17) test when merging T5 with
+// the group containing T10 (cache of T5, which is post broadcasted output) and
+// T6(pre broadcasted output).
+// T5 had the domain [0, 1, 2, 3, 4] produce at 3
+// T6 had the domain [0, 3, 4] compute at 3
+// Merging [0, 1, 2] and [0, 3, 4] resulted in the domain [0, 3, 4, 1, 2]
+//
+// If ID's are not in filter, we don't care about their ordering and ignore
+// them. This is because we're only focused on loops we will have to merge
+// across groups. If the domain is not in a produce at position in the producer
+// edges, or a compute at position in the consumer edges, the expressions we
+// look at may not have a unique ordering.
+//
+// The optional kernel_scope_domain parameter is only used in
+// expression sorting. It isn't in the CA map, but since we only have
+// a single unique IterDomain, the conrete ID is just itself.
+struct IterDomainDependencySorter {
+  IterDomainDependencySorter(
+      const std::unordered_map<IterDomain*, std::unordered_set<IterDomain*>>&
+          concrete_id_dependencies,
+      IterDomain* kernel_scope_domain = nullptr)
+      : concrete_id_dependencies_(concrete_id_dependencies),
+        kernel_scope_domain_(kernel_scope_domain) {}
+
+  // Return true if id0 should be before id1
+  // Orders such that if x maps to {y}, x comes before y in final ordering.
+  inline bool operator()(IterDomain* id0, IterDomain* id1) {
+    auto concrete_id_0 =
+        id0 != kernel_scope_domain_ ? getConcreteLoopID(id0) : id0;
+    auto concrete_id_1 =
+        id1 != kernel_scope_domain_ ? getConcreteLoopID(id1) : id1;
+    if (concrete_id_dependencies_.find(concrete_id_0) !=
+        concrete_id_dependencies_.end()) {
+      const auto& dependencies_0 = concrete_id_dependencies_.at(concrete_id_0);
+      // if id0 depends on id1 it means id1 is inside id0, so id0 < id1
+      if (dependencies_0.count(concrete_id_1)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  const std::unordered_map<IterDomain*, std::unordered_set<IterDomain*>>&
+      concrete_id_dependencies_;
+  const IterDomain* kernel_scope_domain_ = nullptr;
+};
 
 } // namespace lower_utils
 

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -568,9 +568,7 @@ void validateAndCollectVectorizeInfo(Fusion* fusion) {
 
     for (const auto i : c10::irange(tv->nDims())) {
       IterDomain* id = tv->axis(i);
-      IterDomain* concrete_id =
-          GpuLower::current()->caMap()->getConcreteMappedID(
-              id, IdMappingMode::LOOP);
+      IterDomain* concrete_id = lower_utils::getConcreteLoopID(id);
 
       auto ptype = concrete_id->getParallelType();
 
@@ -853,8 +851,7 @@ void validateLoopSwizzle(
     NVF_ERROR(
         loop_domains.count(out_id),
         "Loop swizzle can only be direct producer of loop domains.");
-    if (GpuLower::current()->caMap()->getConcreteMappedID(
-            out_id, IdMappingMode::LOOP) != out_id) {
+    if (lower_utils::getConcreteLoopID(out_id) != out_id) {
       TORCH_WARN_ONCE("Ignored loop swizzle :", swizzle_expr->toString());
     }
   }
@@ -916,10 +913,7 @@ void validateAndConvertIterDomainGrouping(Fusion* fusion) {
     bool is_grouped = false;
     for (const auto id_idx : c10::irange(tv->nDims())) {
       const auto id = tv->axis(id_idx);
-      auto ptype = GpuLower::current()
-                       ->caMap()
-                       ->getConcreteMappedID(id, IdMappingMode::LOOP)
-                       ->getParallelType();
+      auto ptype = lower_utils::getConcreteLoopID(id)->getParallelType();
       if (ptype != ParallelType::Group) {
         // Not a grouped ID
         continue;


### PR DESCRIPTION
Nothing should change with this PR.  Currently, it is just a thin wrapper of `ComputeAtMap::getConcreteMappedID` with `IdMappingMode::LOOP`. Will be extended to support IdModel in an upcoming PR.

Not all use case of `getConcreteMappedID` with the LOOP map are replaced. Those that should only be used with `ComputeAtMap` are left unchanged. Also, the fusion executor also uses `ComputeAtMap`, which I believe should be refactored, so I didn't change at this moment.

Remaining uses:

```
grep -r -A 2 getConcreteMappedID csrc | grep  IdMappingMode::LOOP                           
csrc/fusion_executor/executor_utils.cpp:          if (lower->caMap()->getConcreteMappedID(id, IdMappingMode::LOOP) ==
csrc/device_lower/utils.cpp-      loop_id, IdMappingMode::LOOP);
csrc/device_lower/analysis/sync_information.cpp-                consumer_loop_id, IdMappingMode::LOOP);
csrc/device_lower/analysis/sync_information.cpp:            ca_map->getConcreteMappedID(producer_axis, IdMappingMode::LOOP)
csrc/device_lower/analysis/sync_information.cpp:              ca_map->getConcreteMappedID(consumer_axis, IdMappingMode::LOOP)
csrc/device_lower/analysis/sync_information.cpp:              ca_map->getConcreteMappedID(p_id, IdMappingMode::LOOP)
csrc/device_lower/analysis/sync_information.cpp:              : ca_map->getConcreteMappedID(c_id, IdMappingMode::LOOP)
csrc/device_lower/analysis/index_compute.cpp-            consumer_loop_id, IdMappingMode::LOOP);
```
