### PR TITLE
Create TmaCircularBufferInfo class

### DIFF
--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -182,6 +182,10 @@ class GpuLower : public NonCopyable {
     return circular_buffer_info_;
   }
 
+  TmaCircularBufferInfo& tmaCircularBufferInfo() {
+    return tma_circular_buffer_info_;
+  }
+
   CommonScalarMap& commonScalarMap() {
     return common_scalar_map_;
   }
@@ -228,32 +232,6 @@ class GpuLower : public NonCopyable {
 
   const std::unordered_map<const Expr*, TensorView*>& ldstMBarrierMap() const {
     return ldst_mbarrier_map_;
-  }
-
-  std::unordered_map<const Expr*, TensorView*>& ldstMBarrierTokenMap() {
-    return ldst_mbarrier_token_map_;
-  }
-
-  const std::unordered_map<const Expr*, TensorView*>& ldstMBarrierTokenMap()
-      const {
-    return ldst_mbarrier_token_map_;
-  }
-
-  std::unordered_set<const Expr*>& mBarrierTokenSmemAllocSet() {
-    return mbarrier_token_smem_alloc_set_;
-  }
-
-  const std::unordered_set<const Expr*>& mBarrierTokenSmemAllocSet() const {
-    return mbarrier_token_smem_alloc_set_;
-  }
-
-  std::unordered_map<const Expr*, kir::TensorIndex*>& ldstMBarrierIndexMap() {
-    return ldst_mbarrier_index_map_;
-  }
-
-  const std::unordered_map<const Expr*, kir::TensorIndex*>&
-  ldstMBarrierIndexMap() const {
-    return ldst_mbarrier_index_map_;
   }
 
   bool isNvFuserZeroEnabled() {
@@ -360,6 +338,7 @@ class GpuLower : public NonCopyable {
   ParallelDimensionMap parallel_dimension_map_;
   NonDivisibleSplitInfo non_divisible_split_info_;
   CircularBufferInfo circular_buffer_info_;
+  TmaCircularBufferInfo tma_circular_buffer_info_;
   CommonScalarMap common_scalar_map_;
   FusedReductionInfo fused_reduction_info_;
   std::shared_ptr<const SyncMap> sync_map_;
@@ -388,19 +367,6 @@ class GpuLower : public NonCopyable {
   //! "extent mod split_factor == 0" and an error message for divisibility check
   //! for vectorization.
   std::vector<std::pair<const Val*, std::string>> validations_;
-
-  // Keep track of placeholders for tokens returned by arrive/expected tx
-  // mbarrier operations for each load/store operation that requires such
-  // synchronization
-  std::unordered_map<const Expr*, TensorView*> ldst_mbarrier_token_map_;
-
-  // Collection of kir::Allocate for smem buffers used for mbarrier and token
-  // objects from cpAsyncBulk synchronization
-  std::unordered_set<const Expr*> mbarrier_token_smem_alloc_set_;
-
-  // Keep track what mbarrier object is used in load/store operation that
-  // requires such synchronization, required by indexing pass
-  std::unordered_map<const Expr*, kir::TensorIndex*> ldst_mbarrier_index_map_;
 
   Fusion* fusion_ = nullptr;
 

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -897,13 +897,10 @@ class AllocationInfoMap : private kir::IrVisitor {
 
       // Register start of lifetime for a mbarrier token returned by
       // MBarrierArriveExpectTx and MBarrierArrive.
-      if (GpuLower::current()
-              ->tmaCircularBufferInfo()
-              .ldst_mbarrier_token_map.count(expr) > 0) {
+      if (GpuLower::current()->tmaCircularBufferInfo().existsMBarrierToken(
+              expr)) {
         mark_liveness(
-            GpuLower::current()
-                ->tmaCircularBufferInfo()
-                .ldst_mbarrier_token_map[expr],
+            GpuLower::current()->tmaCircularBufferInfo().getMBarrierToken(expr),
             /*is_write=*/true);
       }
     } else if (auto inval = dynamic_cast<kir::MBarrierInvalidate*>(expr)) {
@@ -914,13 +911,10 @@ class AllocationInfoMap : private kir::IrVisitor {
 
       // Register end of lifetime for a mbarrier token returned by
       // returned by MBarrierArriveExpectTx and MBarrierArrive
-      if (GpuLower::current()
-              ->tmaCircularBufferInfo()
-              .ldst_mbarrier_token_map.count(expr) > 0) {
+      if (GpuLower::current()->tmaCircularBufferInfo().existsMBarrierToken(
+              expr)) {
         mark_liveness(
-            GpuLower::current()
-                ->tmaCircularBufferInfo()
-                .ldst_mbarrier_token_map[expr],
+            GpuLower::current()->tmaCircularBufferInfo().getMBarrierToken(expr),
             /*is_write=*/false);
       }
     }

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -667,17 +667,16 @@ class AllocationInserter : public kir::ExprMutator {
 
         // Map LoadStoreOp expression to ir nodes created in this pass
         GpuLower::current()->ldstMBarrierMap()[expr] = mbarrier;
-        GpuLower::current()
-            ->tmaCircularBufferInfo()
-            .ldst_mbarrier_token_map[expr] = mbarrier_tokens;
-        // Register tokens placeholder for MBarrierInit and MBarrierInvalidate,
-        //  needed to manage life time of smem buffor in alias memory
-        GpuLower::current()
-            ->tmaCircularBufferInfo()
-            .ldst_mbarrier_token_map[mbarrier_init] = mbarrier_tokens;
-        GpuLower::current()
-            ->tmaCircularBufferInfo()
-            .ldst_mbarrier_token_map[mbarrier_inval] = mbarrier_tokens;
+
+        // Register tokens placeholder for cpAsyncBulk, MBarrierInit and
+        // MBarrierInvalidate. It is needed to manage lifetime of shared memory
+        // buffer in alias memory pass.
+        GpuLower::current()->tmaCircularBufferInfo().recordMBarrierToken(
+            expr, mbarrier_tokens);
+        GpuLower::current()->tmaCircularBufferInfo().recordMBarrierToken(
+            mbarrier_init, mbarrier_tokens);
+        GpuLower::current()->tmaCircularBufferInfo().recordMBarrierToken(
+            mbarrier_inval, mbarrier_tokens);
       } else {
         // create and allocate a memory barrier
         TensorView* mbarrier = TensorViewBuilder()

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -22,6 +22,109 @@ namespace nvfuser {
 
 namespace {
 
+// This function creates kir::Loop with range based on stage depth. It is
+// used for mbarrier initialization and invalidation.
+ForLoop* createStageDepthForLoop(ForLoop* circular_buffer_loop) {
+  int64_t stage_depth =
+      GpuLower::current()->circularBufferInfo().getStageDepthFor(
+          circular_buffer_loop->iter_domain());
+
+  Val* loop_start = IrBuilder::create<Val>(0L, PrimDataType::Index);
+  Val* loop_index = IrBuilder::create<Val>(PrimDataType::Index);
+  Val* loop_stop = IrBuilder::create<Val>(stage_depth, DataType::Index);
+  IterDomainBuilder loop_domain_builder(loop_start, loop_stop);
+
+  ForLoop* loop = IrBuilder::create<ForLoop>(
+      loop_domain_builder.build(),
+      loop_index,
+      loop_start,
+      loop_stop,
+      /*step=*/GpuLower::current()->kernel()->oneVal(),
+      /*vectorize=*/false,
+      /*vectorize_shift=*/nullptr,
+      /*unroll_required=*/false,
+      CircularBufferLoopStage::NotApplicable);
+
+  return loop;
+}
+
+// This helper function initializes mbarrier for all circular buffer stage.
+//
+// Expected result:
+// for (unsigned i = 0; i < stages; ++i) {
+//   if (warp_id == 0 && electSync()()) {
+//     mbarrier::init(...);
+//   }
+// }
+std::pair<ForLoop*, kir::MBarrierInit*> initializeMbarrier(
+    ForLoop* circular_buffer_loop,
+    LoadStoreOp* ldst,
+    TensorView* all_mbarriers) {
+  NVF_ERROR(circular_buffer_loop != nullptr);
+  NVF_ERROR(ir_utils::isCpAsyncBulk(ldst));
+  ForLoop* loop = createStageDepthForLoop(circular_buffer_loop);
+
+  // Get mbarrier for this circular buffer stage.
+  kir::TensorIndex* stage_mbarrier =
+      IrBuilder::create<kir::TensorIndex>(all_mbarriers, loop->index());
+
+  // Get all threads in CTA
+  Val* bdimx =
+      GpuLower::current()->parallelDimensionMap().get(ParallelType::TIDx);
+  Val* bdimy =
+      GpuLower::current()->parallelDimensionMap().get(ParallelType::TIDy);
+  Val* bdimz =
+      GpuLower::current()->parallelDimensionMap().get(ParallelType::TIDz);
+  Val* all_threads_in_cta = SimplifyingIrBuilder::mulExpr(
+      bdimx, SimplifyingIrBuilder::mulExpr(bdimy, bdimz));
+  all_threads_in_cta =
+      SimplifyingIrBuilder::maybeCastExpr(DataType::UInt32, all_threads_in_cta);
+
+  // Initialize mbarrier for each circular buffer stage. Use the thread
+  // count from the MBarrierInit created in the allocation pass. The wait
+  // condition for mbarrier is a all threads in CTA and the expected number
+  // of transaction bytes
+  kir::MBarrierInit* mbarrier_init =
+      IrBuilder::create<kir::MBarrierInit>(stage_mbarrier, all_threads_in_cta);
+
+  Expr* pred_mbarrier_init = mbarrier_init->withPredicate(
+      IrBuilder::create<kir::Predicate>(PredicateType::ElectSync));
+  loop->body().push_back(pred_mbarrier_init);
+  return {loop, pred_mbarrier_init->as<kir::MBarrierInit>()};
+}
+
+// This helper function invalidates mbarrier for all circular buffer stage after
+// TMA memory operations.
+//
+// Expected result:
+// for (unsigned i = 0; i < stages; ++i) {
+//   if (warp_id == 0 && electSync()()) {
+//     mbarrier::inval(...);
+//   }
+// }
+std::pair<ForLoop*, kir::MBarrierInvalidate*> invalidateMbarrier(
+    ForLoop* circular_buffer_loop,
+    LoadStoreOp* ldst,
+    TensorView* all_mbarriers) {
+  NVF_ERROR(circular_buffer_loop != nullptr);
+  NVF_ERROR(ir_utils::isCpAsyncBulk(ldst));
+  ForLoop* loop = createStageDepthForLoop(circular_buffer_loop);
+
+  // Get mbarrier for this circular buffer stage.
+  kir::TensorIndex* stage_mbarrier =
+      IrBuilder::create<kir::TensorIndex>(all_mbarriers, loop->index());
+
+  // Invalidate the mbarrier for each circular buffer stage.
+  kir::MBarrierInvalidate* mbarrier_inval =
+      IrBuilder::create<kir::MBarrierInvalidate>(stage_mbarrier);
+
+  Expr* pred_mbarrier_inval = mbarrier_inval->withPredicate(
+      IrBuilder::create<kir::Predicate>(PredicateType::ElectSync));
+
+  loop->body().push_back(pred_mbarrier_inval);
+  return {loop, pred_mbarrier_inval->as<kir::MBarrierInvalidate>()};
+}
+
 class AllocationInserter : public kir::ExprMutator {
  private:
   using kir::ExprMutator::handle;
@@ -483,18 +586,8 @@ class AllocationInserter : public kir::ExprMutator {
                 .build();
         mbarrier->setMemoryType(MemoryType::Shared);
 
-        // The wait condition for mbarrier is a single thread and the expected
-        // number of transaction bytes
-        kir::MBarrierInit* mbarrier_init = IrBuilder::create<kir::MBarrierInit>(
-            mbarrier, expr->container()->oneVal(DataType::UInt32));
-
         kir::Allocate* mbarrier_alloc =
             IrBuilder::create<kir::Allocate>(mbarrier, MemoryType::Shared);
-
-        Scope* expr_scope = scope_.empty() ? nullptr : scope_.back();
-
-        kir::MBarrierInvalidate* mbarrier_inval =
-            IrBuilder::create<kir::MBarrierInvalidate>(mbarrier);
 
         // For circular buffers we need to prepare a placeholder for the
         // tokens created by 'MBarrierArriveExpectTx' IR node. The tokens are
@@ -510,38 +603,81 @@ class AllocationInserter : public kir::ExprMutator {
         kir::Allocate* mbarrier_tokens_alloc = IrBuilder::create<kir::Allocate>(
             mbarrier_tokens, MemoryType::Shared);
 
+        NVF_ERROR(ir_utils::isCpAsyncBulkLoad(expr));
+        LoadStoreOp* ldst = expr->as<LoadStoreOp>();
+        TensorView* out_tv = ldst->out()->as<TensorView>();
+        ForLoop* circular_buffer_loop =
+            GpuLower::current()->circularBufferInfo().getCircularBufferLoop(
+                out_tv, for_loops_);
+
+        auto&& [pre_prologue_init, mbarrier_init] =
+            initializeMbarrier(circular_buffer_loop, ldst, mbarrier);
+
+        auto&& [post_epilogue_inval, mbarrier_inval] =
+            invalidateMbarrier(circular_buffer_loop, ldst, mbarrier);
+
+        // Block sync is necessary to finish mbarrier initialization.
+        kir::BlockSync* sync = IrBuilder::create<kir::BlockSync>(false);
+
         // Add tokens, mbarriers, init, and inval operations around tma
         // expression like this:
         //
-        // for (circular_buffer_loop) {
-        //   __shared__ tokens[num_stages];
-        //   __shared__ mbarrier[num_stages];
-        //   init(mbarrier);
-        //   cp.async.bulk(data, mbarrier);
-        //   inval(mbarrier);
+        // __shared__ tokens[num_stages];
+        // __shared__ mbarrier[num_stages];
+        // for (circular_buffer_stage) {
+        //   init(mbarrier[stage]);
         // }
+        // block_sync();
+        //
+        // for (circular_buffer_loop) {
+        //   cp.async.bulk(data, mbarrier);
+        // }
+        //
+        // for (circular_buffer_stage) {
+        //   inval(mbarrier[stage]);
+        // }
+        //
 
-        // NOTE: Block sync ir node is not added here. It will be added in the
-        // circular buffering pass
-        registerInsertBefore(expr, mbarrier_tokens_alloc, expr_scope);
-        registerInsertBefore(expr, mbarrier_alloc, expr_scope);
-        registerInsertBefore(expr, mbarrier_init, expr_scope);
-        registerInsertAfter(expr, mbarrier_inval, expr_scope);
+        // Find the scope containing the circular buffer for-loop. It is the
+        // scope one level higher than the circular buffer loop scope in scope_.
+        auto scope_iter = std::find(
+            scope_.begin(), scope_.end(), &circular_buffer_loop->body());
+        NVF_ERROR(scope_iter != scope_.end());
+        Scope* scope_containing_circular_buffer_loop =
+            (scope_iter == scope_.begin()) ? nullptr : *(scope_iter - 1);
+        registerInsertBefore(
+            circular_buffer_loop,
+            mbarrier_tokens_alloc,
+            scope_containing_circular_buffer_loop);
+        registerInsertBefore(
+            circular_buffer_loop,
+            mbarrier_alloc,
+            scope_containing_circular_buffer_loop);
+
+        registerInsertBefore(
+            circular_buffer_loop,
+            pre_prologue_init,
+            scope_containing_circular_buffer_loop);
+        registerInsertBefore(
+            circular_buffer_loop, sync, scope_containing_circular_buffer_loop);
+        registerInsertAfter(
+            circular_buffer_loop,
+            post_epilogue_inval,
+            scope_containing_circular_buffer_loop);
 
         // Map LoadStoreOp expression to ir nodes created in this pass
         GpuLower::current()->ldstMBarrierMap()[expr] = mbarrier;
-        GpuLower::current()->ldstMBarrierTokenMap()[expr] = mbarrier_tokens;
+        GpuLower::current()
+            ->tmaCircularBufferInfo()
+            .ldst_mbarrier_token_map[expr] = mbarrier_tokens;
         // Register tokens placeholder for MBarrierInit and MBarrierInvalidate,
         //  needed to manage life time of smem buffor in alias memory
-        GpuLower::current()->ldstMBarrierTokenMap()[mbarrier_init] =
-            mbarrier_tokens;
-        GpuLower::current()->ldstMBarrierTokenMap()[mbarrier_inval] =
-            mbarrier_tokens;
-        // Keep track of kir::Allocate for mBarrier and token objects,
-        //  to simplify circular buffering pass logic
-        GpuLower::current()->mBarrierTokenSmemAllocSet().insert(mbarrier_alloc);
-        GpuLower::current()->mBarrierTokenSmemAllocSet().insert(
-            mbarrier_tokens_alloc);
+        GpuLower::current()
+            ->tmaCircularBufferInfo()
+            .ldst_mbarrier_token_map[mbarrier_init] = mbarrier_tokens;
+        GpuLower::current()
+            ->tmaCircularBufferInfo()
+            .ldst_mbarrier_token_map[mbarrier_inval] = mbarrier_tokens;
       } else {
         // create and allocate a memory barrier
         TensorView* mbarrier = TensorViewBuilder()

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -570,6 +570,52 @@ class CircularBufferInserter : private kir::ExprMutator {
 
 } // namespace
 
+void TmaCircularBufferInfo::recordMBarrierToken(
+    const Expr* expr,
+    TensorView* mbarrier_tokens) {
+  NVF_ERROR(
+      ir_utils::isCpAsyncBulkLoad(expr) || expr->isA<kir::MBarrierInit>() ||
+      expr->isA<kir::MBarrierInvalidate>());
+  NVF_ERROR(ldst_mbarrier_token_map_.count(expr) == 0);
+  ldst_mbarrier_token_map_.emplace(expr, mbarrier_tokens);
+}
+
+bool TmaCircularBufferInfo::existsMBarrierToken(const Expr* expr) const {
+  return ldst_mbarrier_token_map_.count(expr) != 0;
+}
+
+TensorView* TmaCircularBufferInfo::getMBarrierToken(const Expr* expr) {
+  NVF_ERROR(
+      ir_utils::isCpAsyncBulkLoad(expr) || expr->isA<kir::MBarrierInit>() ||
+      expr->isA<kir::MBarrierInvalidate>());
+  // short-circuit: expr does not have mbarrier token.
+  if (ldst_mbarrier_token_map_.count(expr) == 0) {
+    return nullptr;
+  }
+  return ldst_mbarrier_token_map_.at(expr);
+}
+
+void TmaCircularBufferInfo::recordTensorIndex(
+    const Expr* expr,
+    kir::TensorIndex* index) {
+  NVF_ERROR(ir_utils::isCpAsyncBulkLoad(expr));
+  NVF_ERROR(ldst_mbarrier_index_map_.count(expr) == 0);
+  ldst_mbarrier_index_map_.emplace(expr, index);
+}
+
+bool TmaCircularBufferInfo::existsTensorIndex(const Expr* expr) const {
+  return ldst_mbarrier_index_map_.count(expr) != 0;
+}
+
+kir::TensorIndex* TmaCircularBufferInfo::getTensorIndex(const Expr* expr) {
+  NVF_ERROR(ir_utils::isCpAsyncBulkLoad(expr));
+  // short-circuit: expr does not have tensor index.
+  if (ldst_mbarrier_index_map_.count(expr) == 0) {
+    return nullptr;
+  }
+  return ldst_mbarrier_index_map_.at(expr);
+}
+
 std::vector<Expr*> CircularBufferPass::run(const std::vector<Expr*>& exprs) {
   InsertionInfo insertion_info = CircularBufferLoopNestInspector::run(exprs);
   return CircularBufferInserter::run(exprs, insertion_info);

--- a/csrc/device_lower/pass/circular_buffer.h
+++ b/csrc/device_lower/pass/circular_buffer.h
@@ -165,14 +165,35 @@
 
 namespace nvfuser {
 
-struct TmaCircularBufferInfo {
+class TmaCircularBufferInfo {
+ public:
+  // Map cpAsyncBulk, MBarrierInit, and MBarrierInvalidate to its mbarrier
+  // tokens
+  void recordMBarrierToken(const Expr* expr, TensorView* mbarrier_tokens);
+
+  // Check if expression has mbarrier tokens
+  bool existsMBarrierToken(const Expr* expr) const;
+
+  // Get mbarrier tokens for expression
+  TensorView* getMBarrierToken(const Expr* expr);
+
+  // Map cpAsyncBul to its tensor index
+  void recordTensorIndex(const Expr* expr, kir::TensorIndex* index);
+
+  // Check if tensor index exists for expression
+  bool existsTensorIndex(const Expr* expr) const;
+
+  // Get tensor index for expression
+  kir::TensorIndex* getTensorIndex(const Expr* expr);
+
+ private:
   // Track of mbarrier tokens returned by arrive and arriveExpectTx
   // mbarrier operations for each load operation
-  std::unordered_map<const Expr*, TensorView*> ldst_mbarrier_token_map;
+  std::unordered_map<const Expr*, TensorView*> ldst_mbarrier_token_map_;
 
   // Track mbarrier used for cpAsyncBulk load operation. Required by indexing
   // pass.
-  std::unordered_map<const Expr*, kir::TensorIndex*> ldst_mbarrier_index_map;
+  std::unordered_map<const Expr*, kir::TensorIndex*> ldst_mbarrier_index_map_;
 };
 
 class CircularBufferPass {

--- a/csrc/device_lower/pass/circular_buffer.h
+++ b/csrc/device_lower/pass/circular_buffer.h
@@ -165,6 +165,16 @@
 
 namespace nvfuser {
 
+struct TmaCircularBufferInfo {
+  // Track of mbarrier tokens returned by arrive and arriveExpectTx
+  // mbarrier operations for each load operation
+  std::unordered_map<const Expr*, TensorView*> ldst_mbarrier_token_map;
+
+  // Track mbarrier used for cpAsyncBulk load operation. Required by indexing
+  // pass.
+  std::unordered_map<const Expr*, kir::TensorIndex*> ldst_mbarrier_index_map;
+};
+
 class CircularBufferPass {
  public:
   //! Apply circular buffering transformations

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1470,14 +1470,11 @@ void IndexLowering::handleCpAsyncBulkLoad(const LoadStoreOp* ldst) {
   // mbarrier_wait are added by the circular buffer pass. Otherwise, those
   // nodes are added here.
   bool is_circular_buffered =
-      (GpuLower::current()
-           ->tmaCircularBufferInfo()
-           .ldst_mbarrier_index_map.count(ldst) != 0);
+      (GpuLower::current()->tmaCircularBufferInfo().existsTensorIndex(ldst));
 
   if (is_circular_buffered) {
     kir::TensorIndex* mbarrier =
-        GpuLower::current()->tmaCircularBufferInfo().ldst_mbarrier_index_map.at(
-            ldst);
+        GpuLower::current()->tmaCircularBufferInfo().getTensorIndex(ldst);
     Val* mbarrier_index = lower_utils::u32IndexScalarSmemTv(mbarrier);
 
     // gmem indexing and expect_bytes for mbarrier
@@ -1493,9 +1490,8 @@ void IndexLowering::handleCpAsyncBulkLoad(const LoadStoreOp* ldst) {
     pushBack(new_ldst);
 
     // register new LoadStoreOp with mbarrier
-    GpuLower::current()
-        ->tmaCircularBufferInfo()
-        .ldst_mbarrier_index_map[new_ldst] = mbarrier;
+    GpuLower::current()->tmaCircularBufferInfo().recordTensorIndex(
+        new_ldst, mbarrier);
 
     GpuLower::current()->propagateExprInfo(ldst, back());
   } else {

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1470,11 +1470,14 @@ void IndexLowering::handleCpAsyncBulkLoad(const LoadStoreOp* ldst) {
   // mbarrier_wait are added by the circular buffer pass. Otherwise, those
   // nodes are added here.
   bool is_circular_buffered =
-      (GpuLower::current()->ldstMBarrierIndexMap().count(ldst) != 0);
+      (GpuLower::current()
+           ->tmaCircularBufferInfo()
+           .ldst_mbarrier_index_map.count(ldst) != 0);
 
   if (is_circular_buffered) {
     kir::TensorIndex* mbarrier =
-        GpuLower::current()->ldstMBarrierIndexMap().at(ldst);
+        GpuLower::current()->tmaCircularBufferInfo().ldst_mbarrier_index_map.at(
+            ldst);
     Val* mbarrier_index = lower_utils::u32IndexScalarSmemTv(mbarrier);
 
     // gmem indexing and expect_bytes for mbarrier
@@ -1490,7 +1493,9 @@ void IndexLowering::handleCpAsyncBulkLoad(const LoadStoreOp* ldst) {
     pushBack(new_ldst);
 
     // register new LoadStoreOp with mbarrier
-    GpuLower::current()->ldstMBarrierIndexMap()[new_ldst] = mbarrier;
+    GpuLower::current()
+        ->tmaCircularBufferInfo()
+        .ldst_mbarrier_index_map[new_ldst] = mbarrier;
 
     GpuLower::current()->propagateExprInfo(ldst, back());
   } else {


### PR DESCRIPTION
This PR converts `TmaCircularBufferInfo` from a struct into a class.

It creates the following functions:

```cpp
  // Map cpAsyncBulk, MBarrierInit, and MBarrierInvalidate to its mbarrier tokens
  void recordMBarrierToken(const Expr* expr, TensorView* mbarrier_tokens);

  // Check if expression has mbarrier tokens
  bool existsMBarrierToken(const Expr* expr) const;

  // Get mbarrier tokens for expression
  TensorView* getMBarrierToken(const Expr* expr);

  // Map cpAsyncBul to its tensor index
  void recordTensorIndex(const Expr* expr, kir::TensorIndex* index);

  // Check if tensor index exists for expression
  bool existsTensorIndex(const Expr* expr) const;

  // Get tensor index for expression
  kir::TensorIndex* getTensorIndex(const Expr* expr);
```