### PR TITLE
Use more detailed broadcast-squeeze analysis in preseg pass

### DIFF
--- a/csrc/preseg_passes/remove_bcast_squeeze.cpp
+++ b/csrc/preseg_passes/remove_bcast_squeeze.cpp
@@ -163,7 +163,7 @@ AxisOps composeOps(const AxisOps& prev, const AxisOps& next) {
     // to if it's not a broadcast. If it is a broadcast, then we'll unzip some
     // of these squeezes.
     while (next_pos < next.size() && next[next_pos] == AxisOp::BROADCAST) {
-      if (ops.back() == AxisOp::SQUEEZE) {
+      if (!ops.empty() && ops.back() == AxisOp::SQUEEZE) {
         ops.back() = AxisOp::PRESERVE;
       } else {
         ops.push_back(AxisOp::BROADCAST);

--- a/csrc/preseg_passes/remove_bcast_squeeze.cpp
+++ b/csrc/preseg_passes/remove_bcast_squeeze.cpp
@@ -205,10 +205,6 @@ TensorView* maybeDoReplacement(TensorView* orig) {
     return orig;
   }
 
-  std::cout << "Checking replaceable pair of exprs:" << std::endl;
-  std::cout << "  first=" << first->toString() << std::endl;
-  std::cout << "  second=" << second->toString() << std::endl;
-
   AxisOps first_ops = exprToAxisOps(first);
   AxisOps second_ops = exprToAxisOps(second);
   AxisOps simplified_ops = composeOps(first_ops, second_ops);

--- a/csrc/preseg_passes/remove_bcast_squeeze.cpp
+++ b/csrc/preseg_passes/remove_bcast_squeeze.cpp
@@ -168,11 +168,12 @@ std::vector<bool> nonPreservedDims(const AxisOps& ops) {
 //! descriptor of their composition
 AxisOps composeOps(const AxisOps& prev, const AxisOps& next) {
   size_t prev_pos = 0, next_pos = 0;
+  size_t prev_size = prev.size(), next_size = next.size();
   AxisOps ops;
   while (true) {
     // If there are previous squeezes, insert them since they don't affect next
     // position
-    while (prev_pos < prev.size() && prev[prev_pos] == AxisOp::SQUEEZE) {
+    while (prev_pos < prev_size && prev[prev_pos] == AxisOp::SQUEEZE) {
       ops.push_back(AxisOp::SQUEEZE);
       prev_pos++;
     }
@@ -180,7 +181,7 @@ AxisOps composeOps(const AxisOps& prev, const AxisOps& next) {
     // prev[prev_pos] now gives the provenance of the axis that next_pos points
     // to if it's not a broadcast. If it is a broadcast, then we'll unzip some
     // of these squeezes.
-    while (next_pos < next.size() && next[next_pos] == AxisOp::BROADCAST) {
+    while (next_pos < next_size && next[next_pos] == AxisOp::BROADCAST) {
       if (!ops.empty() && ops.back() == AxisOp::SQUEEZE) {
         // This is a "squeeze then broadcast" pattern
         ops.back() = AxisOp::PRESERVE;
@@ -190,9 +191,9 @@ AxisOps composeOps(const AxisOps& prev, const AxisOps& next) {
       next_pos++;
     }
 
-    if (prev_pos >= prev.size() || next_pos >= next.size()) {
+    if (prev_pos >= prev_size || next_pos >= next_size) {
       NVF_ERROR(
-          prev_pos >= prev.size() && next_pos >= next.size(),
+          prev_pos >= prev_size && next_pos >= next_size,
           "Failed to align some ops");
       break;
     }

--- a/csrc/preseg_passes/remove_bcast_squeeze.cpp
+++ b/csrc/preseg_passes/remove_bcast_squeeze.cpp
@@ -60,6 +60,20 @@ AxisOps squeezeToAxisOps(SqueezeOp* squeeze) {
   return ops;
 }
 
+bool hasCompatibleParallelization(TensorView* orig_tv, TensorView* new_tv) {
+  std::vector<IterDomain*> orig_domain =
+      TensorDomain::noReductions(orig_tv->getLoopDomain());
+  std::vector<IterDomain*> new_domain =
+      TensorDomain::noReductions(new_tv->getLoopDomain());
+  NVF_ERROR(orig_domain.size() == new_domain.size());
+  for (size_t i : c10::irange(orig_domain.size())) {
+    if (orig_domain[i]->getParallelType() != new_domain[i]->getParallelType()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 //! Checks whether this is a simple Set of a TensorView. If not, then this might
 //! represent a scalar set, or a segment_set.
 bool isSimpleTVSet(Expr* expr) {
@@ -67,10 +81,14 @@ bool isSimpleTVSet(Expr* expr) {
   if (ldst == nullptr) {
     return false;
   }
-  return ldst->opType() == LoadStoreOpType::Set &&
-      ldst->in()->isA<TensorView>()
+  auto in_tv = dynamic_cast<TensorView*>(ldst->in());
+  auto out_tv = dynamic_cast<TensorView*>(ldst->out());
+  return ldst->opType() == LoadStoreOpType::Set && in_tv != nullptr &&
+      out_tv != nullptr
       // The hasRoot() check is to prevent picking up Set.Permute ops here
-      && !ldst->out()->as<TensorView>()->hasRoot();
+      && !ldst->out()->as<TensorView>()->hasRoot()
+      // A set operation that changes parallelization is not considered trivial
+      && hasCompatibleParallelization(in_tv, out_tv);
 }
 
 //! This defines the types of operations that are eligible for simplification in
@@ -223,6 +241,13 @@ TensorView* maybeDoReplacement(TensorView* orig) {
       case AxisOp::PRESERVE:
         // This is equivalent to a set Op
         replacement = input_tv;
+        // Check that parallelization is consistent for replacement. We do not
+        // want to alter the parallelization of input_tv here; we only
+        // parallelize _new_ TVs. If the parallelization is inconsistent, we
+        // simply refuse to make the replacement.
+        if (!hasCompatibleParallelization(orig, replacement)) {
+          return orig;
+        }
         break;
       case AxisOp::SQUEEZE:
         replacement = squeeze(input_tv, nonPreservedDims(simplified_ops));

--- a/csrc/preseg_passes/remove_bcast_squeeze.cpp
+++ b/csrc/preseg_passes/remove_bcast_squeeze.cpp
@@ -14,6 +14,112 @@
 namespace nvfuser::preseg_passes {
 
 namespace {
+
+enum class AxisOp { PRESERVE, SQUEEZE, BROADCAST };
+
+//! This represents the combined state of a collection of broadcast and squeeze
+//! operations
+using AxisOps = std::vector<AxisOp>;
+
+//! Convert a broadcast Expr to an AxisOps descriptor
+AxisOps broadcastToOps(BroadcastOp* bcast) {
+  AxisOps ops;
+  const std::vector<bool>& flags = bcast->getBroadcastDimFlags();
+  ops.reserve(flags.size());
+  for (bool flag : flags) {
+    ops.push_back(flag ? AxisOp::BROADCAST : AxisOp::PRESERVE);
+  }
+  return ops;
+}
+
+//! Convert a squeeze Expr to an AxisOps descriptor
+AxisOps squeezeToOps(SqueezeOp* squeeze) {
+  AxisOps ops;
+  const std::vector<bool>& flags = squeeze->getSqueezeDimFlags();
+  ops.reserve(flags.size());
+  for (bool flag : flags) {
+    ops.push_back(flag ? AxisOp::SQUEEZE : AxisOp::PRESERVE);
+  }
+  return ops;
+}
+
+//! Return true if we are unable to simplify this combination to a single
+//! operation.
+bool isTrivial(const AxisOps& ops) {
+  bool has_broadcast = false, has_squeeze = false;
+  for (const AxisOp op : ops) {
+    switch (op) {
+      case AxisOp::PRESERVE:
+        break;
+      case AxisOp::SQUEEZE:
+        has_squeeze = true;
+        break;
+      case AxisOp::BROADCAST:
+        has_broadcast = true;
+        break;
+    }
+  }
+  return !has_broadcast || !has_squeeze;
+}
+
+//! Given a descriptors of two sequences of broadcast+squeeze ops, return a
+//! descriptor of their composition, with a applied before b
+AxisOps composeOps(const AxisOps& prev, const AxisOps& next) {
+  // Find dims present after prev (i.e. non-SQUEEZE dims)
+
+  // Add ops from next. Positions in next are relative to the present dims from
+  // prev.
+  //   If the next op is a SQUEEZE then
+  //      If there is an adjacent BROADCAST, remove it
+  //      Otherwise, insert the SQUEEZE
+  //   If the next op is a BROADCAST then
+  //      If there is an adjacent SQUEEZE, replace it with PRESERVE
+  //      Otherwise, insert the BROADCAST
+
+  size_t prev_pos = 0, next_pos = 0;
+  AxisOps out;
+  while (prev_pos < prev.size() || next_pos < next.size()) {
+    if (prev_pos < prev.size()) {
+      AxisOp prev_op = prev[prev_pos];
+      if (next_pos < next.size()) {
+        AxisOp next_op = next[next_pos];
+        switch (next_op) {
+          case AxisOp::PRESERVE:
+            out.push_back(prev_op);
+            prev_pos++;
+            next_pos++;
+            break;
+          case AxisOp::SQUEEZE:
+            switch (prev_op) {
+              case AxisOp::PRESERVE:
+                out.push_back(AxisOp::SQUEEZE);
+                prev_pos++;
+                next_pos++;
+                break;
+            }
+            out.push_back(prev_op);
+            prev_pos++;
+            next_pos++;
+            break;
+        }
+      } else {
+        NVF_ERROR(
+            prev_op == AxisOp::SQUEEZE,
+            "Found non-squeeze prev op but ran out of next ops");
+        prev_pos++;
+      }
+    } else {
+      AxisOp next_op = next[next_pos];
+      NVF_ERROR(
+          next_op == AxisOp::BROADCAST,
+          "Found non-broadcast next op but ran out of previous non-squeeze ops");
+      out.push_back(next_op);
+      next_pos++;
+    }
+  }
+  return out;
+}
+
 // Remove broadcast-squeeze and squeeze-broadcast patterns
 // TODO: still remove when have intermediate ops between broadcast and squeeze
 void removeBcastSqueeze(Fusion* fusion) {
@@ -42,10 +148,19 @@ void removeBcastSqueeze(Fusion* fusion) {
     // after : M = someOp(X)
     // conditions: (1) broadcast and squeeze have the same dim flags
     if (auto bcast = dynamic_cast<BroadcastOp*>(expr)) {
+      std::cout << "Found bcast " << bcast->toString() << "  "
+                << bcast->getBroadcastDimFlags() << std::endl;
       if (auto squeeze = dynamic_cast<SqueezeOp*>(bcast->in()->definition())) {
+        std::cout << "    Found squeeze " << squeeze->toString() << "  "
+                  << squeeze->getSqueezeDimFlags() << std::endl;
         if (bcast->getBroadcastDimFlags() == squeeze->getSqueezeDimFlags()) {
+          std::cout << "        REPLACING bcast out with squeeze in"
+                    << std::endl;
           ir_utils::replaceValInAllExprInputsAndFusionOutputs(
               bcast->out(), squeeze->in());
+        } else {
+          std::cout << "        NOT REPLACING bcast out with squeeze in"
+                    << std::endl;
         }
       }
     }


### PR DESCRIPTION
Our current broadcast+squeeze simplification pass (introduced in #2291) only does replacements if the broadcast flags exactly match the squeeze flags for neighboring `BroadcastOp` and `SqueezeOp` IR nodes. However, there are additional simplifications that can be made, and missing these can interfere with ID mapping leading to issues with inlining, for example: see comment here: https://github.com/NVIDIA/Fuser/issues/3027#issuecomment-2377501846.

This PR enables us to do simplifications where only some of the axes are bcast+squeezed. It also lets us remove intermediate `set` ops that could otherwise interfere with this analysis.

Fixes #3027

### Limitation with respect to expand

When we use `broadcast_in_dim` with new sizes other than 1, we insert two operations: a `BroadcastOp` and an `ExpandOp`. If we use that repeatedly we can have broadcast-expand-broadcast-expand patterns. We currently cannot collapse that into a single broadcast-expand, so if there were a squeeze preceding the first broadcast, we would not be able to simplify it:
```c++
fusion->addInput(tv0); // [ iS0{i0}  bS1{1} ]
auto tv1 = squeeze(tv0); // [ iS2{i0} ]
auto tv2 = broadcast(tv1, {true, false }); // [ bS3{1} iS4{i0} ]
auto tv3 = expand(tv2, {i1, i0}); // [ bS5{i1} iS6{i0} ]
auto tv4 = broadcast(tv3, {false, false, true}); // [ bS7{i1} iS8{i0} bS9{1} ]
auto tv5 = expand(tv4, {i1, i0, i2}); // [ bS10{i1} iS11{i0} bS12{i2} ]
```
Ideally we would be able to rearrange the expand-broadcast-expand pattern so that we could combine the two broadcasts, which would let us get rid of the squeeze. We can't currently do this because this pass still ignores expand, but it might be a useful optimization for a future PR.