### PR TITLE
Add coalescing in c10d_mock.h

### DIFF
--- a/csrc/multidevice/c10d_mock.h
+++ b/csrc/multidevice/c10d_mock.h
@@ -72,6 +72,12 @@ struct BarrierOptions {
 
 class Backend : public torch::CustomClassHolder {
  public:
+  void startCoalescing() {}
+
+  c10::intrusive_ptr<Work> endCoalescing() {
+    return c10::make_intrusive<Work>();
+  }
+
   c10::intrusive_ptr<Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) {
     return c10::make_intrusive<Work>();


### PR DESCRIPTION
Fix the [build issue](https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/jobs/113280838) when building on ARM with `NVFUSER_DISTRIBUTED` disabled. PR #2950 introduced that bug.