### PR TITLE
When computing isResharding, ignore parallel types for broadcasts. 

### DIFF
--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -71,7 +71,10 @@ void assertBuffersHaveSameSize(
     for (const auto& buf : bufs) {
       NVF_ERROR(
           buf.numel() == numel,
-          "all buffers must have the same number of elements");
+          "all buffers must have the same number of elements: ",
+          buf.numel(),
+          " vs ",
+          numel);
     }
   }
 }

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -164,8 +164,15 @@ bool haveDifferentShardings(
       // trigger resharding.
       continue;
     }
-
     auto c_id = i->second;
+
+    // `b(DID{i0})` and `b(i0)` bear the same semantics, so don't treat it as
+    // resharding. The former is used more often due to how parallelizeAllLike
+    // is implemented.
+    if (p_id->isBroadcast() && c_id->isBroadcast()) {
+      continue;
+    }
+
     if (p_id->getParallelType() != c_id->getParallelType() &&
         (p_id->isDeviceDim() || c_id->isDeviceDim())) {
       // Mismatch found

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -166,10 +166,9 @@ bool haveDifferentShardings(
     }
     auto c_id = i->second;
 
-    // `b(DID{i0})` and `b(i0)` bear the same semantics, so don't treat it as
-    // resharding. The former is used more often due to how parallelizeAllLike
-    // is implemented.
-    if (p_id->isBroadcast() && c_id->isBroadcast()) {
+    // `b(DID{i0})` and `b(i0)` bear the same semantics, so don't treat a
+    // mapping from/to a broadcast dimension as resharding.
+    if (p_id->isBroadcast() || c_id->isBroadcast()) {
       continue;
     }
 

--- a/csrc/preseg_passes/propagate_shardings.cpp
+++ b/csrc/preseg_passes/propagate_shardings.cpp
@@ -98,6 +98,14 @@ void PropagateShardingsPass::runPass(Fusion* fusion) {
     shardAllLike(ref_input, outputs_without_mesh);
   }
 
+  for (TensorView* tv : fusion->allTvs()) {
+    for (IterDomain* id : tv->getLoopDomain()) {
+      if (id->isBroadcast() && id->isDeviceDim()) {
+        id->parallelize(ParallelType::Serial);
+      }
+    }
+  }
+
   // Back-propagate device meshes. This makes sure all TensorViews have a mesh
   // if any of them has one. This is needed in addition to the forward
   // propagation for ops that don't take any TensorView operands, e.g.,

--- a/tests/cpp/test_multidevice_sharding.cpp
+++ b/tests/cpp/test_multidevice_sharding.cpp
@@ -305,18 +305,41 @@ TEST_F(MultiDeviceTest, Transpose) {
       UnorderedElementsAre(HeuristicIs(SchedulerType::Transpose)));
 }
 
-class MultiDeviceBroadcastTest : public MultiDeviceTest,
-                                 public testing::WithParamInterface<bool> {};
-
-// This test and the following `ExpandedBroadcast` test verify the expression
+// TEST_F(MultiDeviceTest, Broadcast) {
+//   auto fusion = std::make_unique<Fusion>();
+//   FusionGuard fg(fusion.get());
+//
+//   const auto num_devices = communicator_->size();
+//   auto mesh = DeviceMesh::createForNumDevices(num_devices);
+//
+//   TensorView* in = makeContigConcreteTensor({1, -1});
+//   in->setDeviceMesh(mesh);
+//   TensorView* out = set(in);
+//   fusion->addInput(in);
+//   fusion->addOutput(out);
+//   in->axis(0)->parallelize(ParallelType::DIDx);
+//
+//   FusionExecutorCache fec(std::move(fusion));
+//   at::Tensor in_tensor = at::randn({1, 8}, tensor_options);
+//   at::Tensor out_tensor = fec.runFusionWithInputs({in_tensor})[0];
+//   testValidate(fec.fusion(), {out_tensor}, {in_tensor}, __LINE__, __FILE__);
+// }
+//
+// `MutliDeviceBroadcastTest`s verify the expression
 // evaluator correctly binds the extent of a broadcast dimension to 1 and the
 // expanded extent to the tensor size. There used to be a bug where it
 // incorrectly binds the extent(s) to the mesh size.
 //
 // `b(DID{i0})` and `b(i0)` bear the same semantics. The former is used more
 // often due to how parallelizeAllLike is implemented.
-TEST_P(MultiDeviceBroadcastTest, NotExpanded) {
-  const bool parallelizes_broadcast = GetParam();
+class MultiDeviceBroadcastTest
+    : public MultiDeviceTest,
+      public testing::WithParamInterface<std::tuple<bool, bool, bool>> {};
+
+TEST_P(MultiDeviceBroadcastTest, DeviceParallel) {
+  // Whether to DID-parallelize the broadcast dimension in the input and in the
+  // output.
+  auto [expanded, parallelizes_in, parallelizes_out] = GetParam();
 
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
@@ -324,56 +347,35 @@ TEST_P(MultiDeviceBroadcastTest, NotExpanded) {
   const auto num_devices = communicator_->size();
   auto mesh = DeviceMesh::createForNumDevices(num_devices);
 
+  const int64_t broadcast_dim_extent = (expanded ? 3 : 1);
   TensorView* in = TensorViewBuilder()
                        .dtype(DataType::Float)
                        .contiguity({std::nullopt, true})
-                       .shape({1, -1})
+                       .shape({broadcast_dim_extent, -1})
+                       .expanded({expanded, false})
                        .build();
   in->setDeviceMesh(mesh);
-  if (parallelizes_broadcast) {
-    in->axis(0)->parallelize(ParallelType::DIDx);
-  }
   TensorView* out = set(in);
   fusion->addInput(in);
   fusion->addOutput(out);
 
-  FusionExecutorCache fec(std::move(fusion));
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor in_tensor = at::randn({1, 8}, options);
-  at::Tensor out_tensor = fec.runFusionWithInputs({in_tensor})[0];
-  testValidate(fec.fusion(), {out_tensor}, {in_tensor}, __LINE__, __FILE__);
-}
-
-TEST_P(MultiDeviceBroadcastTest, Expanded) {
-  const bool parallelizes_broadcast = GetParam();
-
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-
-  const auto num_devices = communicator_->size();
-  auto mesh = DeviceMesh::createForNumDevices(num_devices);
-
-  TensorView* in = TensorViewBuilder()
-                       .dtype(DataType::Float)
-                       .contiguity({std::nullopt, true})
-                       .shape({3, -1})
-                       .expanded({true, false})
-                       .build();
-  in->setDeviceMesh(mesh);
-  if (parallelizes_broadcast) {
+  if (parallelizes_in) {
     in->axis(0)->parallelize(ParallelType::DIDx);
   }
-  TensorView* out = set(in);
-  fusion->addInput(in);
-  fusion->addOutput(out);
+  if (parallelizes_out) {
+    out->axis(0)->parallelize(ParallelType::DIDx);
+  }
 
   FusionExecutorCache fec(std::move(fusion));
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor in_tensor = at::randn({8}, options).as_strided({3, 8}, {0, 1});
+  at::Tensor in_tensor = at::randn({8}, tensor_options)
+                             .as_strided({broadcast_dim_extent, 8}, {0, 1});
   at::Tensor out_tensor = fec.runFusionWithInputs({in_tensor})[0];
   testValidate(fec.fusion(), {out_tensor}, {in_tensor}, __LINE__, __FILE__);
 }
 
-INSTANTIATE_TEST_SUITE_P(, MultiDeviceBroadcastTest, testing::Bool());
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    MultiDeviceBroadcastTest,
+    testing::Combine(testing::Bool(), testing::Bool(), testing::Bool()));
 
 } // namespace nvfuser

--- a/tests/cpp/test_multidevice_sharding.cpp
+++ b/tests/cpp/test_multidevice_sharding.cpp
@@ -305,26 +305,6 @@ TEST_F(MultiDeviceTest, Transpose) {
       UnorderedElementsAre(HeuristicIs(SchedulerType::Transpose)));
 }
 
-// TEST_F(MultiDeviceTest, Broadcast) {
-//   auto fusion = std::make_unique<Fusion>();
-//   FusionGuard fg(fusion.get());
-//
-//   const auto num_devices = communicator_->size();
-//   auto mesh = DeviceMesh::createForNumDevices(num_devices);
-//
-//   TensorView* in = makeContigConcreteTensor({1, -1});
-//   in->setDeviceMesh(mesh);
-//   TensorView* out = set(in);
-//   fusion->addInput(in);
-//   fusion->addOutput(out);
-//   in->axis(0)->parallelize(ParallelType::DIDx);
-//
-//   FusionExecutorCache fec(std::move(fusion));
-//   at::Tensor in_tensor = at::randn({1, 8}, tensor_options);
-//   at::Tensor out_tensor = fec.runFusionWithInputs({in_tensor})[0];
-//   testValidate(fec.fusion(), {out_tensor}, {in_tensor}, __LINE__, __FILE__);
-// }
-//
 // `MutliDeviceBroadcastTest`s verify the expression
 // evaluator correctly binds the extent of a broadcast dimension to 1 and the
 // expanded extent to the tensor size. There used to be a bug where it


### PR DESCRIPTION
This is a follow-up to #2877. The fix wasn't complete, causing some intra-device set to be mistaken as a communication. 

This is required to land #3045. 