### PR TITLE
Pick the most parallelized input as the reference.

### DIFF
--- a/tests/cpp/test_multidevice_matmul.cpp
+++ b/tests/cpp/test_multidevice_matmul.cpp
@@ -349,9 +349,8 @@ TEST_F(DistributedMatmulTest, PresegPreservesSharding) {
     tv->axis(0)->parallelize(ParallelType::DIDx);
   }
 
-  const auto options = at::TensorOptions().device(communicator_->device());
-  auto x_tensor = at::randn({12, 48}, options);
-  auto w_tensor = at::randn({mesh.size(), 36, 48}, options);
+  auto x_tensor = at::randn({12, 48}, tensor_options);
+  auto w_tensor = at::randn({mesh.size(), 36, 48}, tensor_options);
   auto sharded_w_tensor = shardTensor(w_tensor, w);
 
   FusionExecutorCache fec(std::move(fusion));
@@ -367,6 +366,44 @@ TEST_F(DistributedMatmulTest, PresegPreservesSharding) {
       outputs,
       inputs,
       {shardTensor(expected_mm_t_tensor, mm_t)},
+      __LINE__,
+      __FILE__);
+}
+
+TEST_F(DistributedMatmulTest, AnnotateWeightOnly) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* x = makeContigTensor(2);
+  TensorView* w = makeContigTensor(3);
+  TensorView* y = matmul(x, w);
+  fusion->addInput(x);
+  fusion->addInput(w);
+  fusion->addOutput(y);
+
+  auto mesh = DeviceMesh::createForNumDevices(communicator_->size());
+  x->setDeviceMesh(mesh);
+  w->setDeviceMesh(mesh);
+  w->axis(0)->parallelize(ParallelType::DIDx);
+
+  // x is of shape [2, 3] and replicated.
+  // w is of shape [3, D*5] and column-wise sharded.
+  // y is expected to have shape [2, D*5] and to be also column-wise sharded.
+  auto x_tensor = at::randn({2, 3}, tensor_options);
+  auto w_tensor = at::randn({mesh.size(), 3, 5}, tensor_options);
+  auto sharded_w_tensor = shardTensor(w_tensor, w);
+
+  FusionExecutorCache fec(std::move(fusion));
+  std::vector<c10::IValue> inputs({x_tensor, sharded_w_tensor});
+  std::vector<at::Tensor> outputs = fec.runFusionWithInputs(inputs);
+
+  at::Tensor expected_y_tensor =
+      at::bmm(x_tensor.unsqueeze(0).expand({mesh.size(), -1, -1}), w_tensor);
+  testValidate(
+      fec.fusion(),
+      outputs,
+      inputs,
+      {shardTensor(expected_y_tensor, 0, mesh)},
       __LINE__,
       __FILE__);
 }

--- a/tests/cpp/test_multidevice_matmul.cpp
+++ b/tests/cpp/test_multidevice_matmul.cpp
@@ -397,8 +397,7 @@ TEST_F(DistributedMatmulTest, AnnotateWeightOnly) {
   std::vector<c10::IValue> inputs({x_tensor, sharded_w_tensor});
   std::vector<at::Tensor> outputs = fec.runFusionWithInputs(inputs);
 
-  at::Tensor expected_y_tensor =
-      at::bmm(x_tensor.unsqueeze(0).expand({mesh.size(), -1, -1}), w_tensor);
+  at::Tensor expected_y_tensor = at::matmul(x_tensor, w_tensor);
   testValidate(
       fec.fusion(),
       outputs,


### PR DESCRIPTION
See code comments for details. 

This is required to land #3045. 