### PR TITLE
Host IRs: stream Synchronize

### DIFF
--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -142,7 +142,8 @@ class Val;
   f(HostUnit);                        \
   f(PostOnStream);                    \
   f(SetCurrentStream);                \
-  f(Wait);
+  f(Wait);                            \
+  f(Synchronize);
 
 // Forward declarations for all Val and Expr types
 

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -77,8 +77,7 @@ std::vector<at::Tensor> HostIrExecutor::runWithInput(
   return getKnownTensorOrUndefined(container_->outputs(), expr_evaluator_);
 }
 
-void HostIrExecutor::handle(SetCurrentStream* set_current_stream) {
-  Stream* stream = set_current_stream->stream();
+c10::cuda::CUDAStream HostIrExecutor::getCUDAStream(Stream* stream) {
   StreamKey stream_key = stream;
   // if stream points to an index, it represents the dynamic value of that index
   if (Val* index = stream->index(); index != nullptr) {
@@ -95,7 +94,15 @@ void HostIrExecutor::handle(SetCurrentStream* set_current_stream) {
          c10::cuda::getStreamFromPool(
              /*isHighPriority=*/false, static_cast<c10::DeviceIndex>(i))});
   }
-  setCurrentCUDAStream(streams_.at(stream_key));
+  return streams_.at(stream_key);
+}
+
+void HostIrExecutor::handle(SetCurrentStream* set_current_stream) {
+  setCurrentCUDAStream(getCUDAStream(set_current_stream->stream()));
+}
+
+void HostIrExecutor::handle(Synchronize* synchronize) {
+  getCUDAStream(synchronize->stream()).synchronize();
 }
 
 void HostIrExecutor::handle(PostOnStream* post_ir) {

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -75,6 +75,7 @@ class HostIrExecutor final : public OptInDispatch {
  private:
   using OptInDispatch::handle;
   void handle(SetCurrentStream* set_current_stream) override;
+  void handle(Synchronize* synchronize) override;
   void handle(PostOnStream* post_ir) override;
   void handle(Communication* communication) override;
   void handle(Wait* wait) override;
@@ -82,6 +83,8 @@ class HostIrExecutor final : public OptInDispatch {
   void handle(SliceOp* slice_op) override;
   void handle(MatmulOp* matmul_op) override;
   void handle(SelectOp* select_op) override;
+
+  c10::cuda::CUDAStream getCUDAStream(Stream* stream);
 
   std::unique_ptr<HostIrContainer> container_;
   Communicator* communicator_;
@@ -93,7 +96,7 @@ class HostIrExecutor final : public OptInDispatch {
   std::unordered_map<HostUnit*, FusionExecutorCache> fec_;
   using StreamKey = std::variant<int64_t, Stream*>;
   std::unordered_map<StreamKey, c10::cuda::CUDAStream> streams_;
-  std::unordered_map<Communication*, c10::intrusive_ptr<c10d::Work>> works_;
+  std::unordered_map<Expr*, c10::intrusive_ptr<c10d::Work>> works_;
 };
 
 } // namespace hir

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -21,7 +21,7 @@ namespace hir {
 
 HostUnit::HostUnit(IrBuilderPasskey passkey, std::unique_ptr<Fusion> fusion)
     : Expr(passkey), fusion_(std::make_unique<Fusion>(*fusion)) {
-  NVF_ERROR(passkey.ir_container_->isA<hir::HostIrContainer>()); // NOLINT
+  NVF_ERROR(passkey.ir_container_->isA<HostIrContainer>()); // NOLINT
 }
 
 HostUnit::HostUnit(const HostUnit* src, IrCloner* ir_cloner)
@@ -66,7 +66,7 @@ PostOnStream::PostOnStream(
     std::vector<Val*> outputs)
     : Expr(passkey, std::move(inputs), std::move(outputs), {host_op}) {
   NVF_ERROR(
-      passkey.ir_container_->isA<hir::HostIrContainer>(), // NOLINT
+      passkey.ir_container_->isA<HostIrContainer>(), // NOLINT
       this,
       "must be registered in a HostIrContainer");
   NVF_ERROR(
@@ -152,7 +152,7 @@ bool Stream::sameAs(const Statement* other) const {
 
 SetCurrentStream::SetCurrentStream(IrBuilderPasskey passkey, Stream* stream)
     : Expr(passkey, {stream}, {}, {stream}) {
-  NVF_ERROR(passkey.ir_container_->isA<hir::HostIrContainer>()); // NOLINT
+  NVF_ERROR(passkey.ir_container_->isA<HostIrContainer>()); // NOLINT
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(SetCurrentStream)
@@ -177,7 +177,7 @@ bool SetCurrentStream::sameAs(const Statement* other) const {
 Wait::Wait(IrBuilderPasskey passkey, Communication* communication)
     : Expr(passkey, {}, {}, {communication}) {
   NVF_ERROR(
-      passkey.ir_container_->isA<hir::HostIrContainer>(), // NOLINT
+      passkey.ir_container_->isA<HostIrContainer>(), // NOLINT
       this,
       "must be registered in a HostIrContainer");
 }
@@ -198,6 +198,31 @@ std::string Wait::toInlineString(int indent_size) const {
 
 // TODO: implement
 bool Wait::sameAs(const Statement* other) const {
+  return false;
+}
+
+Synchronize::Synchronize(IrBuilderPasskey passkey, Stream* stream)
+    : Expr(passkey, {}, {}, {stream}) {
+  NVF_ERROR(
+      passkey.ir_container_->isA<HostIrContainer>(), // NOLINT
+      this,
+      "must be registered in a HostIrContainer");
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(Synchronize)
+
+std::string Synchronize::toString(int indent_size) const {
+  std::stringstream ss;
+  indent(ss, indent_size) << "Synchronize " << stream() << std::endl;
+  return ss.str();
+}
+
+std::string Synchronize::toInlineString(int indent_size) const {
+  NVF_CHECK(false, "Cannot be printed inline");
+}
+
+// TODO: implement
+bool Synchronize::sameAs(const Statement* other) const {
   return false;
 }
 

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -203,8 +203,9 @@ bool Wait::sameAs(const Statement* other) const {
 
 Synchronize::Synchronize(IrBuilderPasskey passkey, Stream* stream)
     : Expr(passkey, {}, {}, {stream}) {
+  NVF_ERROR(passkey.ir_container_ != nullptr);
   NVF_ERROR(
-      passkey.ir_container_->isA<HostIrContainer>(), // NOLINT
+      passkey.ir_container_->isA<HostIrContainer>(),
       this,
       "must be registered in a HostIrContainer");
 }

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -186,6 +186,31 @@ class Wait : public Expr {
   }
 };
 
+class Synchronize : public Expr {
+ public:
+  using Expr::Expr;
+  Synchronize(IrBuilderPasskey passkey, Stream* stream);
+
+  Synchronize(const Synchronize& other) = delete;
+  Synchronize& operator=(const Synchronize& other) = delete;
+  Synchronize(Synchronize&& other) = delete;
+  Synchronize& operator=(Synchronize&& other) = delete;
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+  const char* getOpString() const override {
+    return "hir::Synchronize";
+  }
+
+  bool sameAs(const Statement* other) const override;
+
+  Stream* stream() const {
+    return attributes_.at(0)->as<Stream>();
+  }
+};
+
 } // namespace hir
 
 } // namespace nvfuser


### PR DESCRIPTION
# What

- adds a Host IR representing a call to `c10::cuda::CUDAStream::synchronize()`, used to synchronise the current stream with another stream.

- adds a stream synchronization that was missing in RS+GEMM host IR implementation

# Why

- required in #3060
