### PR TITLE
Revert "only set maxrregcount when want to use less than 255 registers"

### DIFF
--- a/csrc/fusion_executor/executor_utils.cpp
+++ b/csrc/fusion_executor/executor_utils.cpp
@@ -811,10 +811,8 @@ std::optional<int64_t> getMaxRegCount(
     max_register = env_max_reg_count;
   }
 
-  // only need to set this option when we want to limit the register usage,
-  // otherwise compiler with cuda-12.7 may use more registers than needed,
-  // which may cause lower occupancy and performance regression.
-  if (max_register < max_register_limit) {
+  // At this point, max_register should be <= max_register_limit if set
+  if (max_register <= max_register_limit) {
     return max_register;
   } else {
     return std::optional<int64_t>();


### PR DESCRIPTION
Reverts NVIDIA/Fuser#2968 to check register usage changes.
Not intend to do the actual revert, just use this PR to  check register usage changes