### PR TITLE
Multi-matmul scheduler: Skip device dims when counting local batch dims

### DIFF
--- a/csrc/scheduler/multi_matmul.cpp
+++ b/csrc/scheduler/multi_matmul.cpp
@@ -590,7 +590,11 @@ class MultipleMatmulScheduler {
     TensorView* mma_result = patterns_.front().output;
     num_device_dims_ = numDeviceDims(mma_result);
     for (const auto& it : id_roles_) {
-      if (it.second == MatmulDimRole::Batch) {
+      if (it.second == MatmulDimRole::Batch &&
+          // Skip device dims
+          !std::any_of(it.first->begin(), it.first->end(), [](Val* v) {
+            return v->as<IterDomain>()->isDeviceDim();
+          })) {
         // All batch dims will be merged into one, if any exist
         num_local_batch_dims_ = 1;
       }

--- a/tests/cpp/test_multi_matmul_scheduler.cpp
+++ b/tests/cpp/test_multi_matmul_scheduler.cpp
@@ -563,6 +563,40 @@ TEST_P(MultiMatmulSchedulerMatchTest, BatchMatmul) {
   fusion->addOutput(tv2);
 }
 
+// Copied from DistributedMatmulTest.MulSum_LayoutTN_NoComms
+TEST_P(MultiMatmulSchedulerMatchTest, MultiDeviceMulSum) {
+  int num_devices = 1;
+  auto mesh = DeviceMesh::createForNumDevices(num_devices);
+  int M = 256, N = 64, K = 64;
+  int Mo = num_devices;
+  int Mi = M / Mo;
+  std::vector<int> a_shape = {Mo, Mi, K};
+  std::vector<int> b_shape = {N, K};
+
+  TensorView* a = makeContigTensor(3, DataType::Half); // (Mo,Mi,K)
+  TensorView* b = makeContigTensor(2, DataType::Half); // (N,K)
+  TensorView* a_b = broadcast(a, {false, false, true, false}); // (Mo,Mi,b,K)
+  TensorView* b_b = broadcast(b, {true, true, false, false}); // (b,b,N,K)
+  TensorView* ab = mul(a_b, b_b); // (Mo,Mi,N,K)
+  TensorView* c = sum(ab, {-1}); // (Mo,Mi,N,r)
+
+  fusion->addInput(a);
+  fusion->addInput(b);
+  fusion->addOutput(c);
+
+  // Sharding M dimension
+  auto all_sharded_tvs = {a, a_b, b_b, ab, c};
+  for (auto tv : all_sharded_tvs) {
+    tv->axis(0)->parallelize(ParallelType::DIDx);
+    tv->setDeviceMesh(mesh);
+  }
+  b->setDeviceMesh(mesh);
+  // TODO: If c's allocation domain isn't set, it will fail validation at
+  // csrc/device_lower/validation.cpp:419, Vectorized dim for consumer has to be
+  // from a contiguous inner most position.
+  c->setAllocationDomain(c->getLoopDomain(), true);
+}
+
 std::string printMatchTestParams(
     const testing::TestParamInfo<MultiMatmulSchedulerMatchTestParams>& info) {
   std::ostringstream os;


### PR DESCRIPTION
This patches a small bug that incorrectly counted dimensions. We use a different system (`MatmulDimRolesMap`) to detect device and batch dimensions now, and it was identifying some device dims as batch dimensions. Although these dimensions _are_ batch dimensions in the batch matmul sense, they are not _local_ batch dimensions, i.e. they are not realized on each rank, so we skip them when computing `num_local_batch_dims_`. By contrast, in the existing scheduler we simply look for a device dim then subtract that plus 3 from `mma_result->nDims()`, which is not as flexible for future supported use cases with multiple M, N, or K dimensions.

This is necessary to get #3043 working.