### PR TITLE
Allow linear to take a >2D weight and a >1D bias.

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4326,14 +4326,40 @@ std::string LinearOp::toInlineString(int indent_size) const {
 std::vector<PolymorphicValue> LinearOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
-  const auto a = inputs.at(0).as<at::Tensor>();
-  const auto b = inputs.at(1).as<at::Tensor>();
+  const auto in = inputs.at(0).as<at::Tensor>();
+  auto weight = inputs.at(1).as<at::Tensor>();
 
+  auto squeeze_device_dims = [](at::Tensor& t,
+                                int64_t num_device_dims) -> void {
+    // Record the initial shape for the error message.
+    std::vector<int64_t> shape = t.sizes().vec();
+    for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
+      NVF_CHECK(
+          t.size(0) == 1,
+          "When the weight is >2D, expect its preceding dimensions and "
+          "the bias's preceding dimensions to "
+          "be DID-parallel and therefore size-1: ",
+          shape);
+      t = t.squeeze(0);
+    }
+  };
+
+  auto num_device_dims = weight.dim() - 2;
+  squeeze_device_dims(weight, num_device_dims);
+
+  at::Tensor out;
   if (has_bias()) {
-    const auto bias = inputs.at(2).as<at::Tensor>();
-    return {at::linear(a, b, bias)};
+    auto bias = inputs.at(2).as<at::Tensor>();
+    squeeze_device_dims(bias, num_device_dims);
+    out = at::linear(in, weight, bias);
+  } else {
+    out = at::linear(in, weight);
   }
-  return {at::linear(a, b)};
+
+  for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
+    out = out.unsqueeze(0);
+  }
+  return {out};
 }
 
 SdpaFwdOp::SdpaFwdOp(

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4344,6 +4344,8 @@ std::vector<PolymorphicValue> LinearOp::evaluate(
     }
   };
 
+  // The squeezes and unsqueezes are currently required to support a sharded
+  // linear layer. Remove them after #2563.
   auto num_device_dims = weight.dim() - 2;
   squeeze_device_dims(weight, num_device_dims);
 

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -133,7 +133,7 @@ TensorView* linear(TensorView* input, TensorView* weight, TensorView* bias) {
 
   if (bias != nullptr) {
     NVF_CHECK(
-        TensorDomain::noReductions(bias->getLogicalDomain()).size() >= 1,
+        !TensorDomain::noReductions(bias->getLogicalDomain()).empty(),
         "Input bias must be at least 1D. The last dimension represents out "
         "features. The extra, preceding dimensions are expected to be "
         "parallelized on DIDs during scheduling: ",

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -232,44 +232,75 @@ std::vector<IterDomain*> mapLinearOpIterDomains(
     size_t out_size,
     bool k_bcast) {
   std::vector<IterDomain*> mapping(out_size, nullptr);
-  auto inp_size = input_domain.size();
 
   NVF_ERROR(
       input_position == 0 || input_position == 1 || input_position == 2,
       "Input position must be 0, 1, or 2. Found ",
       input_position);
 
-  auto red_dims = k_bcast ? 0 : 1;
-
-  // Input A: {*, M, K}
-  // Input B: {*, N, K} / {K}
-  // Bias: {N} / {}
-
-  // Map K if K is not bcast
-  if (input_position != 2 && !k_bcast) {
-    mapping[out_size - 1] = input_domain.back();
-  }
-
+  // Input: {*_i, K}
+  // Weight: {*_wb, N, K}
+  // Bias: {*_wb, N}
+  // Output: {*_wb, *_i, N, (rK)}. rK exists iff K is not a broadcast.
   switch (input_position) {
     case 0: {
-      // Linear output is same as input for inp_size - 1 dimensions.
-      // K is already mapped above if not broadcast.
-      for (auto inx : c10::irange(inp_size - 1)) {
-        mapping[inx] = input_domain[inx];
+      // Fill `mapping` from the back.
+      // Map K if K is not a broadcast.
+      auto in_index = input_domain.rbegin();
+      auto out_index = static_cast<int64_t>(out_size) - 1;
+      if (!k_bcast) {
+        mapping[out_index] = *in_index;
+        in_index++;
+        out_index--;
+      } else {
+        in_index++;
+      }
+
+      // Skip N.
+      out_index--;
+
+      // Map the rest, i.e., *_i.
+      while (in_index != input_domain.rend()) {
+        mapping[out_index] = *in_index;
+        in_index++;
+        out_index--;
       }
       break;
     }
     case 1: {
-      // Map N / out_features if present
-      if (inp_size > 1) {
-        mapping[out_size - 1 - red_dims] = input_domain.front();
+      auto in_r_index = static_cast<int64_t>(input_domain.size()) - 1;
+      // Map K if K is not broadcast.
+      auto out_index = static_cast<int64_t>(out_size) - 1;
+      if (!k_bcast) {
+        mapping[out_index] = input_domain[in_r_index];
+        in_r_index--;
+        out_index--;
+      } else {
+        in_r_index--;
+      }
+      // Fill `N`
+      mapping[out_index] = input_domain[in_r_index];
+
+      // Fill *_wb from the front.
+      out_index = 0;
+      for (auto in_index : c10::irange(in_r_index)) {
+        mapping[out_index] = input_domain[in_index];
+        out_index++;
       }
       break;
     }
     case 2: {
-      if (inp_size > 0) {
-        // Bias is 1D tensor of shape {out_features}
-        mapping[out_size - 1 - red_dims] = input_domain.front();
+      auto out_index = static_cast<int64_t>(out_size) - 1;
+      // If K is not a broadcast, skip K.
+      if (!k_bcast) {
+        out_index--;
+      }
+      // Fill `N`
+      mapping[out_index] = input_domain.back();
+
+      // Fill *_wb from the front.
+      for (auto index : c10::irange(input_domain.size() - 1)) {
+        mapping[index] = input_domain[index];
       }
       break;
     }

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -113,8 +113,8 @@ void checkLinearOpIdMapping(
   vg.validateConsistency();
 
   // input: [* , in_features]
-  // weight: [out_features, in_features] / [out_features]
-  // bias (optional): [out_features]/[]
+  // weight: [out_features, in_features]
+  // bias (optional): [out_features]
   // output = [*, (out_features), rK]
 
   bool k_bcast = input->axis(-1)->isBroadcast();
@@ -341,7 +341,7 @@ INSTANTIATE_TEST_SUITE_P(
             Sizes({b, m, k}),
             Sizes({1, k}),
             Sizes({b, 1, k})),
-        testing::Values(Sizes({k}), Sizes({n, k}), Sizes({1, k})),
+        testing::Values(Sizes({n, k}), Sizes({1, k})),
         testing::Values(std::nullopt)));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -355,7 +355,7 @@ INSTANTIATE_TEST_SUITE_P(
             Sizes({1, k}),
             Sizes({b, 1, k})),
         testing::Values(Sizes({n, k})),
-        testing::Values(Sizes({}), Sizes({n}))));
+        testing::Values(Sizes({n}))));
 
 INSTANTIATE_TEST_SUITE_P(
     LinearReductionAxisIsOne,
@@ -368,6 +368,6 @@ INSTANTIATE_TEST_SUITE_P(
             Sizes({1, 1}),
             Sizes({b, 1, 1})),
         testing::Values(Sizes({n, 1})),
-        testing::Values(Sizes({}), Sizes({n}))));
+        testing::Values(Sizes({n}))));
 
 } // namespace nvfuser

--- a/tests/cpp/test_translate_mma.cpp
+++ b/tests/cpp/test_translate_mma.cpp
@@ -590,9 +590,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(2l, 2l, -1l, false, false, true),
         std::make_tuple(2l, 2l, -1l, false, true, true),
         std::make_tuple(1l, 2l, -1l, false, false, true),
-        std::make_tuple(2l, 1l, -1l, false, false, true),
         std::make_tuple(2l, 2l, 1l, false, false, true),
-        std::make_tuple(1l, 1l, -1l, false, false, true),
         std::make_tuple(3l, 2l, 1l, false, false, true),
         std::make_tuple(4l, 2l, 1l, false, false, true),
 
@@ -603,15 +601,11 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(2l, 2l, -1l, true, true, true),
         // We don't fuse 1D inputs
         std::make_tuple(1l, 2l, -1l, true, false, true),
-        std::make_tuple(2l, 1l, -1l, true, false, true),
-        // Check that zero-dim output fusion is not claimed by NoOp scheduler
-        std::make_tuple(1l, 1l, -1l, true, false, true),
         // Batch dims in input
         // mixed length inputs via broadcasted batch dims
         std::make_tuple(3l, 2l, -1l, true, false, false),
         std::make_tuple(4l, 2l, -1l, true, false, false),
         // Bias cases
-        std::make_tuple(2l, 2l, 0l, true, false, false),
         std::make_tuple(2l, 2l, 1l, true, false, false),
         std::make_tuple(3l, 2l, 1l, true, false, false),
         std::make_tuple(4l, 2l, 1l, true, false, false)),

--- a/tests/python/opinfo_input_generators.py
+++ b/tests/python/opinfo_input_generators.py
@@ -1523,13 +1523,13 @@ def linear_input_generator(
 
     # Cases without bias
     shapes_input = ((K), (M, K), (B, M, K), (B, 1, M, K))
-    shapes_weight = ((K), (N, K), (1, K))
+    shapes_weight = ((N, K), (1, K))
     for shape_input, shape_weight in itertools.product(shapes_input, shapes_weight):
         yield SampleInput(make_arg(shape_input), make_arg(shape_weight))
 
     # Cases with bias
     shape_weight = (N, K)
-    shapes_bias = ((), (N,))
+    shapes_bias = ((N,),)
     for shape_input, shape_bias in itertools.product(shapes_input, shapes_bias):
         yield SampleInput(
             make_arg(shape_input), make_arg(shape_weight), make_arg(shape_bias)

--- a/tests/python/opinfo_input_generators.py
+++ b/tests/python/opinfo_input_generators.py
@@ -1547,19 +1547,13 @@ def linear_error_generator(
     N = 256
     K = 32
 
-    bias_with_1dweight = (
-        ((M, K), (K), (N)),
-        RuntimeError,
-        "Expected B to be a 2D matrix if bias is given, got 1D.",
-    )
-
     mismatched_bias_extent = (
         ((M, K), (1, K), (N)),
         RuntimeError,
         f"The expanded size of the tensor (1) must match the existing size ({N}) at non-singleton dimension 1.  Target sizes: [{M}, 1].  Tensor sizes: [{N}]",
     )
 
-    error_cases = [bias_with_1dweight, mismatched_bias_extent]
+    error_cases = [mismatched_bias_extent]
 
     for input_shapes, ex_type, ex_str in error_cases:
         shape_input, shape_weight, shape_bias = input_shapes

--- a/tests/python/test_matmul.py
+++ b/tests/python/test_matmul.py
@@ -141,7 +141,7 @@ class TestMatmul(NVFuserTest):
             fd.add_output(T2)
             fd.add_output(T4)
 
-        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
+        self.exec_nvfuser(fusion_func, inputs)
 
     # Tests broadcast reduction axis in matmul: Issue #2532.
     def test_repro_issue2532(self):
@@ -174,7 +174,7 @@ class TestMatmul(NVFuserTest):
                 (1025, 1, 1024), (1024, 1024, 1)
             ),
         ]
-        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
+        self.exec_nvfuser(fusion_func, inputs)
 
     def test_linear_slice(self):
         def fusion_func(fd: FusionDefinition) -> None:

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -58,3 +58,48 @@ def test_pointwise(mpi_test):
     fn = Model()
     outputs = fn.execute([sharded_input])
     torch.testing.assert_close(outputs[0], unsharded_input.relu() * 2)
+
+
+@pytest.mark.mpi
+def test_linear(mpi_test):
+    class Model(FusionDefinition):
+        def __init__(self, num_devices, batch, sequence, hidden):
+            super().__init__()
+            self._num_devices = num_devices
+            self._batch = batch
+            self._sequence = sequence
+            self._hidden = hidden
+
+        def definition(self):
+            d, b, s, h = self._num_devices, self._batch, self._sequence, self._hidden
+            self.inp = self.define_tensor([b, s, h])
+            self.weight = self.define_tensor([d, h, h])
+            self.bias = self.define_tensor([d, h])
+            out = self.ops.linear(self.inp, self.weight, self.bias)
+            self.add_output(out)
+
+        def multidevice_schedule(self):
+            mesh = self.sched._create_device_mesh(range(self._num_devices))
+            for t in [self.inp, self.weight, self.bias]:
+                self.sched._set_device_mesh(t, mesh)
+            for t in [self.weight, self.bias]:
+                self.sched.parallelize(t, 0, nvfuser.ParallelType.mesh_x)
+
+    d = mpi_test.size
+    rank = mpi_test.rank
+
+    torch.cuda.set_device(mpi_test.local_rank)
+
+    b, s, h = 2, 1024, 768
+    torch.manual_seed(0)
+    inp_tensor = torch.randn(b, s, h, device="cuda")
+    unsharded_weight_tensor = torch.randn(d * h, h, device="cuda")
+    weight_tensor = unsharded_weight_tensor.view([d, h, h])[rank : rank + 1]
+    unsharded_bias_tensor = torch.randn(d * h, device="cuda")
+    bias_tensor = unsharded_bias_tensor.view([d, h])[rank : rank + 1]
+
+    fn = Model(d, b, s, h)
+    out_tensors = fn.execute([inp_tensor, weight_tensor, bias_tensor])
+
+    unsharded_out_tensor = torch.linear(inp_tensor, unsharded_weight_tensor, unsharded_bias_tensor)
+    torch.testing.assert_close(out_tensors[0], unsharded_out_tensor[..., rank * h: (rank + 1) * h])

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -105,7 +105,10 @@ def test_linear(mpi_test):
     unsharded_out_tensor = torch.nn.functional.linear(
         inp_tensor, unsharded_weight_tensor, unsharded_bias_tensor
     )
-    sharded_out_tensor = unsharded_out_tensor.view([b, s, d, h]).permute(2, 0, 1, 3)[
+    expected_out_tensor = unsharded_out_tensor.view([b, s, d, h]).permute(2, 0, 1, 3)[
         rank : rank + 1
     ]
-    torch.testing.assert_close(out_tensors[0], sharded_out_tensor)
+    # rtol is the same as the default for fp32. atol is slightly increased.
+    torch.testing.assert_close(
+        out_tensors[0], expected_out_tensor, rtol=1.3e-6, atol=1e-4
+    )


### PR DESCRIPTION
As long as the extra dimensions are DID-parallel.

This allows a distributed transformer layer to use linear (instead of matmul+add) for speed and will simplify the pending #3045. 

To avoid ambiguity, this PR also removes the support for 1D weight and 0D bias; otherwise, it's unclear whether a 2D weight is one device dimension plus a non-device or two non-devices. This support can be added back by changing the thunder-to-nvFuser bridge to convert a 1D/0D linear to unsqueeze followed by a 2D/1D linear followed by a squeeze. 