### PR TITLE
Make SchedulerEntry symbols visible

### DIFF
--- a/csrc/scheduler/registry.h
+++ b/csrc/scheduler/registry.h
@@ -24,12 +24,12 @@ class SchedulerRuntimeInfo;
 //!   and a bool canSchedule(Fusion*) interface
 class SchedulerEntry {
  public:
-  virtual ~SchedulerEntry() = default;
+  NVF_API virtual ~SchedulerEntry() = default;
 
   //! Fusion runtime facing API,
   //!   schedule the given fusion with heuristics owned
   //!   by this entry, for actual heuristics to override
-  virtual void schedule(Fusion* fusion, const HeuristicParams* params) = 0;
+  NVF_API virtual void schedule(Fusion* fusion, const HeuristicParams* params) = 0;
 
   virtual std::unique_ptr<HeuristicParams> computeHeuristics(
       Fusion* fusion,
@@ -49,7 +49,7 @@ class SchedulerEntry {
   // Dispatch heuristic type to the right derived class of scheduler entry.
   // Scheduler entries are stateless so it's a lightweight class to dispatch to
   // the virtual functions in this abstract class.
-  static std::unique_ptr<SchedulerEntry> makeSchedulerInstance(
+  NVF_API static std::unique_ptr<SchedulerEntry> makeSchedulerInstance(
       SchedulerType scheduler_type);
 
   // Checks the provided scheduler type can schedule the fusion with the
@@ -64,9 +64,9 @@ class SchedulerEntry {
       bool validate_scheduler = true);
 
   //! Heuristic comparison
-  bool sameAs(const SchedulerEntry* other);
+  NVF_API bool sameAs(const SchedulerEntry* other);
 
-  const HeuristicParams* params() const {
+  NVF_API const HeuristicParams* params() const {
     return params_.get();
   }
 

--- a/csrc/scheduler/registry.h
+++ b/csrc/scheduler/registry.h
@@ -29,7 +29,9 @@ class SchedulerEntry {
   //! Fusion runtime facing API,
   //!   schedule the given fusion with heuristics owned
   //!   by this entry, for actual heuristics to override
-  NVF_API virtual void schedule(Fusion* fusion, const HeuristicParams* params) = 0;
+  NVF_API virtual void schedule(
+      Fusion* fusion,
+      const HeuristicParams* params) = 0;
 
   virtual std::unique_ptr<HeuristicParams> computeHeuristics(
       Fusion* fusion,


### PR DESCRIPTION
This PR makes all methods in SchedulerEntry visible. This is helpful for third-party libraries such as our internal matmul heuristic plugin. Prior to this we will get a linker error when trying to instantiate a `SchedulerEntry` and call `schedule`.