### PR TITLE
Skip broadcast when computing TMA's expect bytes in circular buffering pass

### DIFF
--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -155,7 +155,7 @@ class CircularBufferLoopCloner : public kir::IrVisitor {
   }
 
   void handle(kir::IfThenElse* ite) final {
-    NVF_THROW("No IfThenElse should exist yet");
+    NVF_THROW("No IfThenElse should exist yet:\n", ite->toString());
   }
 
   void dispatch(Expr* expr) override {
@@ -706,12 +706,11 @@ class CloneTmaCircularBufferLoopAndInsertSync
     // product of all coordinate TMA iterDomains to the right of the circular
     // buffer axis.
     const std::vector<IterDomain*>& loop_domain = consumer_tv->getLoopDomain();
-    const IdModel& id_model = GpuLower::current()->idModel();
     for (size_t idx = consumer_tv->getComputeAtPosition();
          idx < loop_domain.size();
          ++idx) {
-      IterDomain* id = getLoopPromotion(loop_domain.at(idx), id_model);
-      if (!isParallelTypeThread(id->getParallelType()) &&
+      IterDomain* id = loop_domain.at(idx);
+      if (!id->isBroadcast() && !isParallelTypeThread(id->getParallelType()) &&
           id->getParallelType() != ParallelType::Bulk) {
         expected_bytes =
             SimplifyingIrBuilder::mulExpr(expected_bytes, id->extent());

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -155,6 +155,7 @@ class CircularBufferLoopCloner : public kir::IrVisitor {
   }
 
   void handle(kir::IfThenElse* ite) final {
+    return;
     NVF_THROW("No IfThenElse should exist yet:\n", ite->toString());
   }
 

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -155,7 +155,6 @@ class CircularBufferLoopCloner : public kir::IrVisitor {
   }
 
   void handle(kir::IfThenElse* ite) final {
-    return;
     NVF_THROW("No IfThenElse should exist yet:\n", ite->toString());
   }
 

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -316,6 +316,8 @@ const char* predicate_type2string(PredicateType t) {
       return "ReductionWrite";
     case PredicateType::LoopRotation:
       return "LoopRotation";
+    case PredicateType::ElectSync:
+      return "ElectSync";
     default:
       NVF_THROW("No string found for predicate type.");
   }

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1716,8 +1716,8 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   tv0_cache_local->circularBuffer(number_of_stages);
   tv1_cache_local->circularBuffer(number_of_stages);
 
-  // tv0_cache_smem->circularBuffer(number_of_stages);
-  // tv1_cache_smem->circularBuffer(number_of_stages);
+  tv0_cache_smem->circularBuffer(number_of_stages);
+  tv1_cache_smem->circularBuffer(number_of_stages);
 
   constexpr int64_t K = 1024;
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1621,6 +1621,120 @@ TEST_P(TmaCircularBufferingTest, Matmul) {
       fusion.get(), cg_outputs, {t0, t1}, {aten_output}, __LINE__, __FILE__);
 }
 
+TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
+  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  // Algorithm
+  TensorView* tv0 = makeContigConcreteTensor({-1, -1, 1}); // (M, K, B)
+  TensorView* tv1 = makeContigConcreteTensor({1, -1, -1}); // (B, K, N)
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+
+  TensorView* tv2 = mul(tv0, tv1); // M, K, N
+  TensorView* tv3 = sum(tv2, {1}); // M, R, N
+  fusion->addOutput(tv3);
+
+  // CpAsyncBulk Store
+  TensorView* tv4 = tv3->cacheBefore(LoadStoreOpType::CpAsyncBulkTensorTile);
+  tv4->setMemoryType(MemoryType::Shared);
+
+  // For register circular buffering
+  TensorView* tv0_cache_local = tv0->cacheAfter();
+  TensorView* tv1_cache_local = tv1->cacheAfter();
+
+  // For shared memory circular buffering
+  TensorView* tv0_cache_smem =
+      tv0->cacheAfter(LoadStoreOpType::CpAsyncBulkTensorTile);
+  TensorView* tv1_cache_smem =
+      tv1->cacheAfter(LoadStoreOpType::CpAsyncBulkTensorTile);
+  tv0_cache_smem->setMemoryType(MemoryType::Shared);
+  tv1_cache_smem->setMemoryType(MemoryType::Shared);
+
+  constexpr int64_t BSX = 64;
+  constexpr int64_t TSX = 32;
+
+  // Step 0: [M, K, N]
+  // Step 1: [M, K, N/BSX, BSX]
+  tv4->split(-1, BSX);
+
+  // Step 2: [M, K, N/BSX, BSX/TSX, TSX]
+  tv4->split(-1, TSX);
+
+  // Step 3: [M, K/BSX, BSX, N/BSX, BSX/TSX, TSX]
+  tv4->split(1, BSX);
+
+  // Step 4: [M/BSX, BSX, K/BSX, BSX, N/BSX, BSX/TSX, TSX]
+  tv4->split(0, BSX);
+
+  // Step 5:[M/BSX, BSX/TSX, TSX, K/BSX, BSX, N/BSX, BSX/TSX, TSX]
+  tv4->split(1, TSX);
+
+  // Step 6: [M/BSX, N/BSX, K/BSX, BSX/TSX, BSX/TSX, TSX, TSX, BSX]
+  tv4->reorder(
+      {{4, 7}, {7, 6}, {6, 5}, {2, 4}, {1, 3}, {3, 2}, {5, 1}, {0, 0}});
+
+  // Step 7a: [M/BSX, N/BSX, K/BSX, BSX/TSX, BSX/TSX, TSX, TSX, BSX (reduce)]
+  // Step 7b: [M/BSX, N/BSX, K/BSX (reduce), BSX/TSX, BSX/TSX, TSX, TSX]
+  TensorView* tv4_rf = tv4->rFactor({-1});
+
+  TransformPropagatorWithCheck propagator(tv4_rf);
+  MaxLogicalDomainInfoSpanningTree(tv4_rf).traverse(&propagator);
+
+  // Parallelize
+  tv3->axis(0)->parallelize(ParallelType::BIDx);
+  tv3->axis(1)->parallelize(ParallelType::BIDy);
+  tv3->axis(-3)->parallelize(ParallelType::TIDy);
+  tv3->axis(-1)->parallelize(ParallelType::TIDx);
+
+  scheduler_utils::parallelizeAllLike(tv3);
+
+  // (BSX/TSX * TSX * BSX) = 1024 floats = 4096 bytes * (number of buffers)
+  // Apply circular buffering to smem and local cache tensors
+  tv0_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
+  tv0_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
+  tv0_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
+
+  tv1_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
+  tv1_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
+  tv1_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
+
+  // Apply ParallelType::Bulk to global output tensor.
+  tv3->axis(-4)->parallelize(ParallelType::Bulk);
+  tv3->axis(-3)->parallelize(ParallelType::Bulk);
+  tv3->axis(-2)->parallelize(ParallelType::Bulk);
+  tv3->axis(-1)->parallelize(ParallelType::Bulk);
+
+  // IterDomain: [M/BSX, N/BSX, K/BSX, BSX/TSX, BSX/TSX, TSX, TSX, BSX]
+  // Parallelization: BDX, BDY, K/BSX ||, BSX/TSX, BSX/TSX, TDY, TSX, TDX]
+  // 4 non-parallelized for-loops
+  inlineMost();
+
+  // Apply circular buffering after setting computeAt position
+  tv0_cache_local->circularBuffer(number_of_stages);
+  tv1_cache_local->circularBuffer(number_of_stages);
+
+  tv0_cache_smem->circularBuffer(number_of_stages);
+  tv1_cache_smem->circularBuffer(number_of_stages);
+
+  constexpr int64_t K = 1024;
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({tensor_outer_dim, K, 1}, options);
+  at::Tensor t1 = at::randn({1, K, tensor_inner_dim}, options);
+  at::Tensor aten_output = (t0 * t1).sum(/*dim=*/1);
+
+  FusionExecutor fe;
+  fe.compileFusion(fusion.get(), {t0, t1});
+
+  std::vector<at::Tensor> cg_outputs = fe.runFusion({t0, t1});
+  compare<float>(
+      tensor_outer_dim, tensor_inner_dim, cg_outputs.front(), aten_output);
+  testValidate(
+      fusion.get(), cg_outputs, {t0, t1}, {aten_output}, __LINE__, __FILE__);
+}
+
 // Test circular buffer from 2 to 5 stages
 INSTANTIATE_TEST_SUITE_P(
     Hopper,

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1713,8 +1713,8 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   inlineMost();
 
   // Apply circular buffering after setting computeAt position
-  // tv0_cache_local->circularBuffer(number_of_stages);
-  // tv1_cache_local->circularBuffer(number_of_stages);
+  tv0_cache_local->circularBuffer(number_of_stages);
+  tv1_cache_local->circularBuffer(number_of_stages);
 
   // tv0_cache_smem->circularBuffer(number_of_stages);
   // tv1_cache_smem->circularBuffer(number_of_stages);

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1697,8 +1697,8 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   tv0_cache_smem->axis(-4)->parallelize(ParallelType::Bulk);
   tv0_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
 
-  tv1_cache_smem->axis(-5)->parallelize(ParallelType::Bulk);
-  tv1_cache_smem->axis(-4)->parallelize(ParallelType::Bulk);
+  tv1_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
+  tv1_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
   tv1_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
 
   // Apply ParallelType::Bulk to global output tensor.

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1713,11 +1713,11 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   inlineMost();
 
   // Apply circular buffering after setting computeAt position
-  tv0_cache_local->circularBuffer(number_of_stages);
-  tv1_cache_local->circularBuffer(number_of_stages);
+  // tv0_cache_local->circularBuffer(number_of_stages);
+  // tv1_cache_local->circularBuffer(number_of_stages);
 
-  tv0_cache_smem->circularBuffer(number_of_stages);
-  tv1_cache_smem->circularBuffer(number_of_stages);
+  // tv0_cache_smem->circularBuffer(number_of_stages);
+  // tv1_cache_smem->circularBuffer(number_of_stages);
 
   constexpr int64_t K = 1024;
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1693,12 +1693,12 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
 
   // (BSX/TSX * TSX * BSX) = 1024 floats = 4096 bytes * (number of buffers)
   // Apply circular buffering to smem and local cache tensors
-  tv0_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
-  tv0_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
+  tv0_cache_smem->axis(-5)->parallelize(ParallelType::Bulk);
+  tv0_cache_smem->axis(-4)->parallelize(ParallelType::Bulk);
   tv0_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
 
-  tv1_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
-  tv1_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
+  tv1_cache_smem->axis(-5)->parallelize(ParallelType::Bulk);
+  tv1_cache_smem->axis(-4)->parallelize(ParallelType::Bulk);
   tv1_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
 
   // Apply ParallelType::Bulk to global output tensor.


### PR DESCRIPTION
Looks like instead of using the promoted loop, we should just skip broadcast completely.