### PR TITLE
Allow to print null.

### DIFF
--- a/csrc/ir/iostream.cpp
+++ b/csrc/ir/iostream.cpp
@@ -166,7 +166,11 @@ void IrTransformPrinter::printTransforms(const TensorView* tv) {
 }
 
 std::ostream& operator<<(std::ostream& os, const Statement* stmt) {
-  return os << stmt->toString();
+  if (stmt == nullptr) {
+    return os << "<null>";
+  } else {
+    return os << stmt->toString();
+  }
 }
 
 std::ostream& operator<<(std::ostream& os, Fusion* f) {


### PR DESCRIPTION
This is useful when printing a vector of `Statement*` where some elements are null. For example,
https://github.com/NVIDIA/Fuser/blob/1aa6ed072d890d75b9f2114a2c00f918d4ab75b4/csrc/ops/composite.cpp#L80-L81.