### PR TITLE
Fix a compiler warning.

### DIFF
--- a/csrc/disjoint_set.h
+++ b/csrc/disjoint_set.h
@@ -487,7 +487,7 @@ class DisjointSets {
     return ss.str();
   }
 
-  auto size() const {
+  int64_t size() const {
     return disjoint_sets_.size();
   }
 


### PR DESCRIPTION
```
[257/438] Building CXX object CMakeFiles/codegen_internal.dir/csrc/val_graph_visitor.cpp.o
/opt/pytorch/nvfuser/csrc/val_graph_visitor.cpp: In member function ‘bool nvfuser::ValGraphVisitor::traverse()’:
/opt/pytorch/nvfuser/csrc/val_graph_visitor.cpp:179:28: warning: comparison of integer expressions of different signedness: ‘int64_t’ {aka ‘long int’} and ‘long unsigned int’ [-Wsign-compare]
  179 |   if (visited_exprs.size() != graph().disjointExprSets().size()) {
      |       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```