### PR TITLE
Profile configurations for pointwise scheduler in python frontend

### DIFF
--- a/csrc/python_frontend/fusion_cache.h
+++ b/csrc/python_frontend/fusion_cache.h
@@ -61,8 +61,17 @@ struct UserSchedule {
   std::tuple<bool, std::string> canScheduleDebug(
       const SchedulerType& scheduler_type);
 
+  //! Get heuristic parameters for fusion
+  std::unique_ptr<HeuristicParams> computeHeuristics(
+      SchedulerType scheduler_type);
+
   //! Schedule fusion with heuristic
   void scheduleWithType(SchedulerType scheduler_type);
+
+  //! Schedule fusion with heuristic and parameters
+  void scheduleWithType(
+      SchedulerType scheduler_type,
+      HeuristicParams* heuristic_params);
 };
 
 //! \struct FusionSchedules
@@ -224,7 +233,8 @@ class FusionCache {
   UserSchedule* createUserSchedule(
       FusionSchedules* scheds,
       const at::ArrayRef<c10::IValue>& inputs,
-      int device);
+      int device,
+      bool overwrite_existing_schedule = false);
   //! Get the root Trie ptr
   NVF_API TrieNode* rootTriePtr();
 

--- a/csrc/python_frontend/fusion_cache.h
+++ b/csrc/python_frontend/fusion_cache.h
@@ -26,14 +26,22 @@ struct UserSchedule {
 
   //! Runtime information for schedulers
   std::unique_ptr<SchedulerRuntimeInfo> runtime_info;
+
   //! The scheduler heuristic for this UserSchedule
+  std::unique_ptr<SchedulerEntry> scheduler;
+
+  //! The parameters for scheduler heuristic.
   std::unique_ptr<HeuristicParams> heuristic_params;
+
   //! Concretized, Scheduled Fusion IR
   std::unique_ptr<Fusion> scheduled_fusion;
+
   //! Generated kernel container
   std::unique_ptr<FusionExecutor> executor;
+
   //! ID of fusion in python frontend fusion cache
   int64_t fusion_id_ = -1;
+
   //! device ID for this user schedule
   int64_t device_id_ = -1;
 
@@ -61,17 +69,14 @@ struct UserSchedule {
   std::tuple<bool, std::string> canScheduleDebug(
       const SchedulerType& scheduler_type);
 
-  //! Get heuristic parameters for fusion
-  std::unique_ptr<HeuristicParams> computeHeuristics(
-      SchedulerType scheduler_type);
+  //! Create scheduler and get heuristic parameters for fusion.
+  HeuristicParams* computeHeuristics(SchedulerType scheduler_type);
 
-  //! Schedule fusion with heuristic
+  //! Schedule fusion with selected heuristics and scheduler.
+  void schedule();
+
+  //! Schedule fusion with heuristic.
   void scheduleWithType(SchedulerType scheduler_type);
-
-  //! Schedule fusion with heuristic and parameters
-  void scheduleWithType(
-      SchedulerType scheduler_type,
-      HeuristicParams* heuristic_params);
 };
 
 //! \struct FusionSchedules

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -199,7 +199,9 @@ bool FusionDefinition::existSchedule(const at::ArrayRef<c10::IValue>& inputs) {
   return fusionCache()->existUserSchedule(scheds, inputs, device);
 }
 
-void FusionDefinition::setupSchedule(const at::ArrayRef<c10::IValue>& inputs) {
+void FusionDefinition::setupSchedule(
+    const at::ArrayRef<c10::IValue>& inputs,
+    bool overwrite_existing_schedule) {
   FUSER_PERF_SCOPE("FusionDefinition::setupSchedule");
   NVF_CHECK(id().has_value(), "FusionDefinition definition does not exist!");
   FusionSchedules* scheds = fusionCache()->queryFusionSchedules(id().value());
@@ -216,7 +218,8 @@ void FusionDefinition::setupSchedule(const at::ArrayRef<c10::IValue>& inputs) {
     recording_state_.pop_back();
   }
 
-  user_sched_ = fusionCache()->createUserSchedule(scheds, inputs, device);
+  user_sched_ = fusionCache()->createUserSchedule(
+      scheds, inputs, device, overwrite_existing_schedule);
 
   // Building a new Fusion container for scheduling with definition such that
   // the definition's tensor data members refer to the corresponding IR objects

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -175,7 +175,9 @@ class NVF_API FusionDefinition : public FusionState {
   NVF_API bool existSchedule(const at::ArrayRef<c10::IValue>& inputs);
   //! Setup user scheduling of a fusion
   //! Copies fusion object and sets up FusionGuard
-  NVF_API void setupSchedule(const at::ArrayRef<c10::IValue>& inputs);
+  NVF_API void setupSchedule(
+      const at::ArrayRef<c10::IValue>& inputs,
+      bool overwrite_existing_schedule = false);
   //! Finalized use scheduling of a fusion
   //! resets FusionGuard, lowers IR to a kernel, compiles kernel
   NVF_API void finalizeSchedule(const at::ArrayRef<c10::IValue>& inputs);

--- a/doc/dev/python_scheduling/autotune_pointwise.py
+++ b/doc/dev/python_scheduling/autotune_pointwise.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# Owner(s): ["module: nvfuser"]
+
+import torch
+import itertools
+import random
+from nvfuser import FusionDefinition, SchedulerType
+
+# ============================ Description ============================
+
+# 1. Define a nvfuser fusion and its pytorch eager mode reference.
+#
+# 2. Profile the CUDA kernel performance by iterating over a set of input
+# arguments and scheduler configurations.
+#
+# 3. Train a regression model to predict the desired performance metric given
+# some input arguments and a scheduler configuration.
+#
+# 4. Measure the performance of the regression model.
+#  - Calculate RMSE of predicted and actual performance on test set.
+#  - Find the configuration with the best performance using regression model.
+#    Then, compare against the heuristic configuration selected by nvfuser.
+#  - For a specific batch size, gather performance across a range of hidden
+#    sizes. Calculate performance for best predicted and nvfuser
+#    configurations. Plot a chart comparing performance using matplotlib.
+
+# The selected performance metric is effective_bandwidth_gbs. The empirical
+# scheduler selects the configuration that has the highest predicted
+# effective_bandwidth_gbs.
+
+# ============================ Configurations ============================
+
+# Settings for input tensor generation
+num_dimensions = 2
+shapes = [2**i for i in range(5, 10)]
+
+# For pointwise scheduler, we test the cartesian product of vectorization and
+# unroll factors.
+parameter_configurations = [
+    vectorize_range := [1, 2, 4],
+    unroll_range := list(range(1, 10)),
+]
+
+# We profile a range of input shapes with various configurations.
+# This argument determines how much of the profiled data to keep as a test set.
+test_data_percentage = 0.1
+
+# The selected batch size for empirical and nvfuser comparison.
+empirical_batch_size = 512
+
+# The range of hidden sizes for empirical and nvfuser comparision.
+empirical_hidden_sizes = list(range(256, 28672, 256))
+
+
+# A decorator to create a pointwise fusion given some input arguments.
+def create_fusion_func(inputs):
+    def fusion_func(fd: FusionDefinition):
+        t0 = fd.from_pytorch(inputs[0])
+        t1 = fd.from_pytorch(inputs[1])
+        c0 = fd.define_scalar(3.0)
+        t2 = fd.ops.add(t0, t1)
+        t3 = fd.ops.mul(t2, c0)
+        fd.add_output(t3)
+
+    return fusion_func
+
+
+# The pytorch eager mode reference used to validating nvfuser kernel.
+def eager_reference(inputs):
+    return (inputs[0] + inputs[1]) * 3
+
+
+# ============================ Function Definitions ============================
+
+
+# Apply scheduler with custom parameters using decorator
+def custom_pointwise_scheduler(fd, config):
+    def inner_fn():
+        # Check if compatible with pointwise scheduler
+        status, _ = fd.sched.can_schedule(SchedulerType.pointwise)
+        assert status
+
+        schedule_params = fd.sched.compute_pointwise_heuristics()
+
+        # Modify original parameters
+        if config is not None:
+            vectorization_factor, unroll_factor = config
+            schedule_params.vectorization_factor = vectorization_factor
+            schedule_params.unroll_factor = unroll_factor
+
+        # Schedule fusion
+        fd.sched.schedule(SchedulerType.pointwise, schedule_params)
+
+    fd.schedule = inner_fn
+    return fd
+
+
+# Apply schedule decorator, run fusion, and profile performance
+def run_profile(presched_fd, inputs, config=None):
+    scheduled_fd = custom_pointwise_scheduler(presched_fd, config)
+    nvf_outputs = scheduled_fd.execute(inputs, profile=True)
+
+    # validate correctness
+    assert torch.allclose(nvf_outputs[0], eager_reference(inputs))
+
+    prof = scheduled_fd.profile()
+    bandwidth = prof.kernel_profiles[0].effective_bandwidth_gbs
+    time = prof.kernel_profiles[0].time_ms
+    return bandwidth, time
+
+
+def argmax(map_config_to_perf):
+    best_perf = -1
+    best_config = None
+    for config, perf in map_config_to_perf.items():
+        if perf > best_perf:
+            best_perf = perf
+            best_config = config
+    return best_config
+
+
+# Given a prediction model, input_shape, and set of parameter configurations,
+# find the best parameters
+def find_best_parameters(predictor, input_shape, parameter_configurations):
+    map_config_to_performance = {
+        config: predictor.predict([[*input_shape, *config]])
+        for config in itertools.product(*parameter_configurations)
+    }
+    return argmax(map_config_to_performance)
+
+
+# ============================ Run Experiments  ================================
+
+# Collect data for decision tree
+parameters = []
+performance = []
+
+per_dim_shapes = [shapes] * num_dimensions
+for shape in itertools.product(*per_dim_shapes):
+    print(shape)
+    inputs = [
+        torch.randn(*shape, device="cuda"),
+        torch.randn(*shape, device="cuda"),
+    ]
+
+    with FusionDefinition() as presched_fd:
+        create_fusion_func(inputs)(presched_fd)
+
+    # unroll and vectorization configurations
+    for config in itertools.product(vectorize_range, unroll_range):
+        perf_metric, _ = run_profile(presched_fd, inputs, config)
+        parameters.append((*shape, *config))
+        performance.append(perf_metric)
+
+# ============================ Separate Data  ==================================
+
+# Separate collected data into training and test sets
+train_data = []
+test_data = []
+train_perf = []
+test_perf = []
+test_shapes = set()
+all_test_config = {}  # key: input_shape, value: (config, perf)
+
+for data, perf in zip(parameters, performance):
+    shape = data[:num_dimensions]
+    config = data[num_dimensions:]
+
+    if shape in all_test_config:
+        all_test_config[shape][config] = perf
+    else:
+        all_test_config[shape] = {config: perf}
+
+    if random.random() < test_data_percentage:
+        test_data.append(data)
+        test_perf.append(perf)
+    else:
+        test_shapes.add(shape)
+        train_data.append(data)
+        train_perf.append(perf)
+
+# key: input_shape, value: best_config
+best_test_config = {shape: argmax(all_test_config[shape]) for shape in test_shapes}
+
+# ========================= Train Regression Models  ===========================
+
+# Apply decision tree regressor
+# Given input shapes and scheduler parameters, predict performance metric.
+from sklearn import tree
+
+clf = tree.DecisionTreeRegressor()
+clf = clf.fit(train_data, train_perf)
+test_pred = clf.predict(test_data)
+
+print("===================== measure performance rmse ========================")
+
+# Estimate prediction error with RMSE
+import numpy as np
+
+test_perf = np.array(test_perf)
+print(
+    "Test prediction error (RMSE)",
+    np.sqrt(np.mean(np.power(test_perf - test_pred, 2))),
+)
+print("Test performance", test_perf)
+print("Test prediction", test_pred)
+
+print("======================= compare configurations  =======================")
+# Find best configuration for test_shapes
+print(
+    "input shape, estimate_config:(vectorization, unroll), actual_config:(vectorization, unroll), correct"
+)
+correctness_count = 0
+mismatch_configs = []
+for shape in test_shapes:
+    estimate_config = find_best_parameters(clf, shape, parameter_configurations)
+
+    match_config = estimate_config == best_test_config[shape]
+    if not match_config:
+        mismatch_configs.append((shape, estimate_config))
+
+    correctness_count += int(match_config)
+    print(f"{shape}, {estimate_config}, {best_test_config[shape]}, {match_config}")
+print("% of predictions match nvfuser parameters", correctness_count / len(test_shapes))
+print(correctness_count, "out of", len(test_shapes))
+
+print("======================= compare performance =========================")
+
+for shape, estimate_config in mismatch_configs:
+    inputs = [
+        torch.randn(*shape, device="cuda"),
+        torch.randn(*shape, device="cuda"),
+    ]
+
+    with FusionDefinition() as presched_fd:
+        create_fusion_func(inputs)(presched_fd)
+
+    _, est_perf = run_profile(presched_fd, inputs, estimate_config)
+    _, nvf_perf = run_profile(presched_fd, inputs)
+    est_perf_faster = est_perf < nvf_perf
+    print(
+        f"{shape} \t estimate_perf:{est_perf:.5f} \t nvfuser_perf:{nvf_perf:.5f} \t is_estimated_config_faster:\t{est_perf_faster}"
+    )
+
+print("=====================================================================")
+
+#  For a specific batch size, gather performance across a range of hidden sizes.
+#  Calculate performance for best predicted and nvfuser configurations. Plot a
+#  chart comparing performance using matplotlib.
+
+# NOTE: The matplotlib experiment plots the kernel runtime, which could be
+# different than the selected performance metric. Currently, the performance
+# metric is effective_bandwidth_gbs.
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+est_perfs = []
+nvf_perfs = []
+
+for hidden_shape in empirical_hidden_sizes:
+    inputs = [
+        torch.randn(empirical_batch_size, hidden_shape, device="cuda"),
+        torch.randn(empirical_batch_size, hidden_shape, device="cuda"),
+    ]
+    estimate_config = find_best_parameters(
+        clf, (empirical_batch_size, hidden_shape), parameter_configurations
+    )
+
+    with FusionDefinition() as presched_fd:
+        create_fusion_func(inputs)(presched_fd)
+
+    _, est_time_ms = run_profile(presched_fd, inputs, estimate_config)
+    _, nvf_time_ms = run_profile(presched_fd, inputs)
+    est_perfs.append(est_time_ms)
+    nvf_perfs.append(nvf_time_ms)
+    print(
+        f"{empirical_batch_size}, {hidden_shape}, {est_time_ms:.3f}, {nvf_time_ms:.3f}"
+    )
+
+# Get mean speed-up from nvfuser to empirical configurations across all input shapes.
+# Negative value mean empirical configurations are slower than nvfuser.
+print("Mean speed-up", np.mean(np.array(nvf_perfs) - np.array(est_perfs)))
+
+np_hidden_size = np.array(empirical_hidden_sizes)
+plt.plot(np_hidden_size, np.array(est_perfs))
+plt.plot(np_hidden_size, np.array(nvf_perfs))
+
+plt.xlabel("Hidden Size")
+plt.ylabel("Time(ms)")
+plt.title(
+    f"Batch Size = {empirical_batch_size}, Compare Decision Tree Heuristic vs NvFuser"
+)
+plt.legend(["decision_tree", "nvfuser"], loc="lower right")
+plt.savefig(f"pointwise_empirical_batchsize{empirical_batch_size}.png")
+
+# =============================================================================

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 import sys
-from typing import Optional, Union, List  # noqa: F401
+from typing import Callable, Optional, Union, List  # noqa: F401
 
 import torch
 
@@ -133,20 +133,6 @@ class FusionDefinition(_C._FusionDefinition):
     def definition(self):
         raise NotImplementedError("definition() should be implemented by child class!")
 
-    # Unlike `schedule`, `multidevice_schedule` is designed for inter-device
-    # scheduling, The scheduling is done before concretization and therefore
-    # before pre-segmentation. `schedule` however assumes the FusionDefinition
-    # has been concretized and pre-segmented, and therefore requires
-    # `_setup_schedule` and `_finalize_schedule` to be called before and after.
-    #
-    # Note: there's a plan to embed multidevice schedules into FusionDefinition
-    # as annotating nodes. This may eventually replace `multidevice_schedule`.
-    def multidevice_schedule(self):
-        pass
-
-    def schedule(self):
-        raise NotImplementedError("schedule() should be implemented by child class!")
-
     def execute(
         self,
         inputs,
@@ -213,23 +199,35 @@ class FusionDefinition(_C._FusionDefinition):
             self.definition()
             self._finalize_definition()
 
-        defined_multidevice_schedule = (
-            type(self).multidevice_schedule != FusionDefinition.multidevice_schedule
+        defined_multidevice_schedule = hasattr(
+            self, "multidevice_schedule"
+        ) and isinstance(self.multidevice_schedule, Callable)
+        defined_schedule = hasattr(self, "schedule") and isinstance(
+            self.schedule, Callable
         )
-        defined_schedule = type(self).schedule != FusionDefinition.schedule
         assert not (
             defined_multidevice_schedule and defined_schedule
         ), "I haven't tested what if both are defined. We don't plan to support this use case although it may just work."
 
         if defined_multidevice_schedule:
+            # Unlike `schedule`, `multidevice_schedule` is designed for inter-device
+            # scheduling, The scheduling is done before concretization and therefore
+            # before pre-segmentation. `schedule` however assumes the FusionDefinition
+            # has been concretized and pre-segmented, and therefore requires
+            # `_setup_schedule` and `_finalize_schedule` to be called before and after.
+            #
+            # Note: there's a plan to embed multidevice schedules into FusionDefinition
+            # as annotating nodes. This may eventually replace `multidevice_schedule`.
             self.multidevice_schedule()
 
         # If schedule is defined by child class and schedule is not defined for
         # inputs, make a schedule.
-        if defined_schedule and not self._exist_schedule(inputs):
-            self._setup_schedule(inputs)
-            self.schedule()
-            self._finalize_schedule(inputs)
+        if defined_schedule:
+            # Schedule fusion if it does not exist yet or profiling fusion
+            if profile or not self._exist_schedule(inputs):
+                self._setup_schedule(inputs, overwrite_existing_schedule=profile)
+                self.schedule()
+                self._finalize_schedule(inputs)
 
         try:
             return self._execute(


### PR DESCRIPTION
# Summary
This PR explores auto-tuning a Pointwise fusion in the python-frontend.

# Details
- Exposes `PointwiseParams` in python frontend.
- Enables scheduling a fusion with the `Pointwise` scheduler and specific parameter configuration.
- Create `autotune_pointwise.py` to test several parameter configurations then apply `DecisionTreeRegressor`
- Using trained `DecisionTreeRegressor`, iterate over parameter configurations for given input arguments and predict the performance metric. The configuration with the best predicted performance is used to schedule a fusion.

# Orthogonal Changes
- Removes child class requirement for defining `schedule` function in `FusionDefinition`
- Recompiles user schedule if `profile == True` in `FusionDefinition.execute`

# API
1. schedule(SchedulerType) -> schedule fusion with specified heuristic. It creates `HeuristicParams` and `SchedulerEntry`
2. `compute_pointwise_heuristics()` -> It creates `HeuristicParams` and `SchedulerEntry`. A `PointwiseParams` reference is returned so any modifications in python will update the reference.
3. `schedule()` - It schedules the fusion given the `SchedulerEntry` and modified `HeuristicParams`.

# Overview of `autotune_pointwise.py`
1. Define a nvfuser fusion and its pytorch eager mode reference.
4. Profile the CUDA kernel performance by iterating over a set of input arguments and scheduler configurations.
5. Train a regression model to predict the desired performance metric given some input arguments and a scheduler configuration.
6. Measure the performance of the regression model.
- Calculate RMSE of predicted and actual performance on test set.
- Find the configuration with the best performance using regression model.    Then, compare against the heuristic configuration selected by nvfuser.
-  For a specific batch size, gather performance across a range of hidden sizes. Calculate performance for best predicted and nvfuser configurations. Plot a chart comparing performance using `matplotlib`.

The selected performance metric is `effective_bandwidth_gbs`. The empirical scheduler selects the configuration that has the highest predicted `effective_bandwidth_gbs`.

# Machine Learning Decisions
### Why Decision Tree?
1. Decision trees work well with discrete parameters like tensor input shape, vectorization factor, and unroll factor.
2. Decision tress are human-understandable because it is a series of if-then-else statements.
3. Relatively fast - quadradic time `O(num_samples * feature_size)` construction and linear time `O(feature_size)` inference

### Random forest algorithm option
- For better predictive performance, we can easily switch to [RandomForestEnsemble](https://scikit-learn.org/1.5/modules/generated/sklearn.ensemble.RandomForestRegressor.html). It is a series of decision trees, where the algorithm picks the best decision from all the trees.

#### How to create graphic of decision tree?
```python
from sklearn import tree
clf = tree.DecisionTreeRegressor()
clf = clf.fit(inputs, outputs)
tree.plot_tree(clf)
```

### Why performance metric is `effective_bandwidth_gbs`?
- Gpu bandwidth is between 0 and 3350 GB/s on H100, so it is a constrained integer metric.

### Why plot metric is `kernel_runtime_ms`?
- The plot looks less noisy because the y-axis scale is constrained between (0, 2.5) ms. Minor perturbations in running-time is smoothed away.