### PR TITLE
Fix detection of root domains

### DIFF
--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -539,6 +539,10 @@ class TensorDomain : public Val {
         std::find(root().begin(), root().end(), id) != root().end();
   }
 
+  bool isMaybeRoot(const IterDomain* id) const {
+    return (hasRoot() && isRoot(id)) || (!hasRoot() && isLogical(id));
+  }
+
   // The output logical domain.
   const std::vector<IterDomain*>& logical() const {
     return logical_domain_;

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -802,8 +802,10 @@ std::unordered_set<IterDomain*> getMmaDomainSet(
 // from K, but while going back up the DAG we end up with a non-K ID. Eg: (K, M)
 // -> Merge -> () -> Split -> (K, M) -> Reorder -> (M , K) -> Split -> M, K_o,
 // K_in. If we start with K_in we can end up with M.
-IterDomain* getIDinConsumerRoot(IterDomain* id) {
-  while (Expr* expr = id->definition()) {
+IterDomain* getIDinConsumerRoot(IterDomain* id, TensorView* tv) {
+  while (!tv->domain()->isMaybeRoot(id)) {
+    Expr* expr = id->definition();
+    NVF_ERROR(expr != nullptr);
     NVF_CHECK(expr->isA<Merge>() || expr->isA<Split>());
     if (expr->isA<Split>()) {
       NVF_CHECK(
@@ -837,8 +839,8 @@ bool isLdMatrixTranspose(const LoadStoreOp* ldst) {
   const auto producer = ir_utils::getTvInput(ldst);
 
   // Get the innermost ID and go back up the DAG to the root domain.
-  auto corresponding_id_in_consumer_root =
-      getIDinConsumerRoot(consumer->getMaybeAllocationDomain().back());
+  auto corresponding_id_in_consumer_root = getIDinConsumerRoot(
+      consumer->getMaybeAllocationDomain().back(), consumer);
 
   // This gives us the ID in the consumer root domain.
   // We'll later map this ID to one in the producer.


### PR DESCRIPTION
`Expr::definition() == nullptr` is no longer a valid check to detect root domains.