### PR TITLE
Add option to disable multidevice at runtime

### DIFF
--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <multidevice/communicator.h>
+#include <options.h>
 
 #include <netdb.h>
 #include <map>
@@ -183,6 +184,10 @@ Communicator::Communicator(
           c10d::TCPStoreOptions::kDefaultPort + 42), // to avoid collision
       ucc_available_(false),
       nccl_available_(false) {
+  if (isOptionDisabled(DisableOption::Multidevice)) {
+    return;
+  }
+
   // retrieves rank and communicator size
   is_available_ = parseEnv(
       rank_, size_, local_rank_, local_size_, master_addr_, master_port_);

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -191,7 +191,8 @@ std::unordered_map<DisableOption, std::vector<std::string>> Options<
       {"var_name_remapping", DisableOption::VarNameRemapping},
       {"welford_vectorization", DisableOption::WelfordVectorization},
       {"reuse_mismatched_type_registers",
-       DisableOption::ReuseMismatchedTypeRegisters}};
+       DisableOption::ReuseMismatchedTypeRegisters},
+      {"multidevice", DisableOption::Multidevice}};
 
   auto options = parseEnvOptions("DISABLE", available_options);
 

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -134,6 +134,7 @@ enum class DisableOption {
   WelfordVectorization, //! Disable vectorizaton of Welford ops
   ReuseMismatchedTypeRegisters, //! Disable explicitly re-using registers unless
                                 //! types match
+  Multidevice, //! Disable creation of multidevice communicator
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -134,7 +134,12 @@ enum class DisableOption {
   WelfordVectorization, //! Disable vectorizaton of Welford ops
   ReuseMismatchedTypeRegisters, //! Disable explicitly re-using registers unless
                                 //! types match
-  Multidevice, //! Disable creation of multidevice communicator
+  Multidevice, //! Disable creation of multidevice communicator. Mainly for
+               //! debugging. This option quickly disables the multidevice
+               //! module even when Fuser is built with multidevice support. We
+               //! need this in particular to investigate possible conflicts
+               //! between nvFuser communicator and the framework also setting
+               //! up `c10d::ProcessGroup`
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/tests/cpp/test_multidevice_overlap.cpp
+++ b/tests/cpp/test_multidevice_overlap.cpp
@@ -171,6 +171,9 @@ class OverlapTest : public MultiDeviceTest {
   }
 
   void TearDown() override {
+    if (!communicator_->is_available()) {
+      return;
+    }
     validate();
     MultiDeviceTest::TearDown();
   }
@@ -181,6 +184,9 @@ class CollectiveBasedOverlapTest : public OverlapTest {
   at::Tensor tc_locally_reduced_;
   void SetUp() override {
     OverlapTest::SetUp();
+    if (!communicator_->is_available()) {
+      return;
+    }
 
     std::vector<int64_t> tc_locally_reduced_sizes = {
         std::min(params.S, params.number_of_streams),
@@ -410,6 +416,9 @@ class RingBasedOverlapTest : public OverlapTest {
 
   void SetUp() override {
     OverlapTest::SetUp();
+    if (!communicator_->is_available()) {
+      return;
+    }
 
     ASSERT_EQ(params.S % num_devices_, 0);
     number_of_steps_per_ring_ = num_devices_;


### PR DESCRIPTION
# What
- Add an option to disable setting up multidevice communicator at runtime through parsing the env `NVFUSER_DISABLE` with the new option `multidevice`.

- Add missing checks to gracefully skip some recently added tests when the communicator is unavailable.

# Why

Mainly for debugging. This option quickly disables the multidevice module even when Fuser is built with multidevice support. We need this in particular to investigate possible conflicts between nvFuser communicator and the framework also setting up `c10d::ProcessGroup`