### PR TITLE
Skip p2p test if communicator size is 1

### DIFF
--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -250,6 +250,10 @@ TEST_F(P2PCommHostIrTest, RingPairwiseExchange) {
   const int64_t recv_peer =
       (communicator_size + my_device_index - 1) % communicator_size;
 
+  if (communicator_size < 2) {
+    GTEST_SKIP() << "needs at least two ranks";
+  }
+
   auto hic = std::make_unique<HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
 


### PR DESCRIPTION
Skip a test that requires at least two ranks.

Fixes a CI issue https://github.com/NVIDIA/Fuser/pull/2970#issuecomment-2393893166