### PR TITLE
save cuda file when kernel line info is enabled

### DIFF
--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -379,7 +379,7 @@ void FusionExecutor::compileFusion(
     file_name << "__tmp_kernel_" << kernel_id_ << ".cu";
     debug() << "PRINTING: " << file_name.str() << std::endl;
     std::ofstream out(file_name.str());
-    out << code << std::endl;
+    out << structured_code << std::endl;
     out.close();
   }
 

--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -169,14 +169,6 @@ std::string FusionExecutor::getStructuredCode(
             << " =======\n\n"
             << code << "\n======================================\n\n";
   }
-  if (isDebugDumpEnabled(DebugDumpOption::CudaToFile)) {
-    std::stringstream file_name;
-    file_name << "__tmp_kernel_" << kernel_id_ << ".cu";
-    debug() << "PRINTING: " << file_name.str() << std::endl;
-    std::ofstream out(file_name.str());
-    out << code << std::endl;
-    out.close();
-  }
 
   return code;
 }
@@ -376,6 +368,19 @@ void FusionExecutor::compileFusion(
       getStructuredCodeFromExternalFiles(getGlobalFusionCount());
   if (structured_code.empty()) {
     structured_code = getStructuredCode();
+  }
+
+  // always dump the generated code to a file if kernel line info is enabled.
+  // It ensures the correct source code is loaded when profile with [ncu
+  // --import-source yes]
+  if (isDebugDumpEnabled(DebugDumpOption::CudaToFile) ||
+      isOptionEnabled(EnableOption::KernelLineInfo)) {
+    std::stringstream file_name;
+    file_name << "__tmp_kernel_" << kernel_id_ << ".cu";
+    debug() << "PRINTING: " << file_name.str() << std::endl;
+    std::ofstream out(file_name.str());
+    out << code << std::endl;
+    out.close();
   }
 
   const kir::KernelSummary& kernel_summary = kernel->summary();


### PR DESCRIPTION
1. When profiling with `ncu --import-source yes`, it's necessary to enable `NVFUSER_DUMP=cuda_to_file` to ensure the correct source code is loaded into the profile results.
2. This PR automatically dumps the CUDA code to a file when `NVFUSER_ENABLE=kernel_lineinfo` is enabled, as this option is commonly used in debugging or profiling scenarios.
3. Additionally, the code responsible for dumping the CUDA source has been moved outside of getStructuredCode(), ensuring that the correct file name is saved when the kernel is executed with `NVFUSER_EXTERNAL_SRC`.
4. These changes are for convenience purpose.