### PR TITLE
Fix fd.ops.linear to compute the right output rank.

### DIFF
--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -72,8 +72,10 @@ TensorView* newForLinear(
   bool k_bcast = input_domain.back()->isBroadcast();
   size_t red_dims = k_bcast ? 0 : 1;
 
-  // Linear: a = {*, in_features}, b = {out_features, in_features} /
-  // {in_features}.The linear output is {*, (out_features), rK?}.
+  // input: {*_i, in_features},
+  // weight: {*_wb, out_features, in_features}
+  // output: {*_wb, *_i, out_features, rK?}.
+  //
   // Reduction K is present only when K is not bcast.
   auto ndims_out =
       (input_domain.size() - 1) + (weight_domain.size() - 1) + red_dims;
@@ -449,13 +451,13 @@ SdpfaFwdResult sdpfa_fwd(
   if (has_device_dim) {
     NVF_CHECK(
         query_domain[0]->isDeviceDim(),
-        "Only suport DID parallelization on outermost axis");
+        "Only support DID parallelization on outermost axis");
     NVF_CHECK(
         key_domain[0]->isDeviceDim(),
-        "Only suport DID parallelization on outermost axis");
+        "Only support DID parallelization on outermost axis");
     NVF_CHECK(
         value_domain[0]->isDeviceDim(),
-        "Only suport DID parallelization on outermost axis");
+        "Only support DID parallelization on outermost axis");
   }
 
   auto concrete_query_size = TensorDomain::noDevices(query_domain).size();

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -1425,7 +1425,8 @@ void initNvFuserPythonBindings(PyObject* module) {
         NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
-        Tensor output = fd->defineTensor(arg1.dims);
+        // See newForLinear for how the output rank is computed.
+        Tensor output = fd->defineTensor(arg1.dims + arg2.dims - 2);
 
         if (bias.has_value()) {
           fd->defineRecord(


### PR DESCRIPTION
This PR fixes a bug introduced in #3073. This bug causes `nvFuser.Tensor` to have a different rank than the corresponding `TensorView`. This didn't trigger any test failure until I wrote a more complicated test that `slice`s the output of a linear. 

Question for @rdspring1 and/or @kevinstephano: shouldn't this bug be caught earlier? I guess when the Python frontend finalizes the definition it should have checked the output `nvFuser.Tensor`s are consistent with the output `TensorView`s. Wdyt? 