### PR TITLE
use cpAsync in shared memory persistent kernels

### DIFF
--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -1220,15 +1220,26 @@ void movePersistentBufferToSmem(
     // isSharedMemoryPersistent() twice, one for the buffer iteself and the
     // other for the buffer's input tensor if the buffer is a cached input
     // and it is not in [smem_persistent_buffers].
+    bool is_cached_input = false;
     bool use_smem = isSharedMemoryPersistent(tv);
     if (!use_smem &&
         std::find(cached_inputs.begin(), cached_inputs.end(), tv) !=
             cached_inputs.end()) {
       auto input_tv = ir_utils::producerTvsOf(tv).at(0);
       use_smem = isSharedMemoryPersistent(input_tv);
+      is_cached_input = true;
     }
     if (use_smem) {
       tv->setMemoryType(MemoryType::Shared);
+      // When loading from global memory (gmem), use CpAsync with a short data
+      // path of gmem -> smem to reduce temporary register usage. Otherwise, the
+      // data path from gmem to shared memory (smem) follows this sequence: gmem
+      // -> L1 cache -> register -> smem.
+      if (is_cached_input) {
+        tv->definition()->as<LoadStoreOp>()->setOpType(
+            LoadStoreOpType::CpAsync);
+        tv->definition()->as<LoadStoreOp>()->setCacheOp(CacheOp::Unspecified);
+      }
     }
   }
 }

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -1235,7 +1235,8 @@ void movePersistentBufferToSmem(
       // path of gmem -> smem to reduce temporary register usage. Otherwise, the
       // data path from gmem to shared memory (smem) follows this sequence: gmem
       // -> L1 cache -> register -> smem.
-      if (is_cached_input) {
+      int hw_major = at::cuda::getCurrentDeviceProperties()->major;
+      if (is_cached_input && hw_major >= 8) {
         tv->definition()->as<LoadStoreOp>()->setOpType(
             LoadStoreOpType::CpAsync);
         tv->definition()->as<LoadStoreOp>()->setCacheOp(CacheOp::Unspecified);


### PR DESCRIPTION
**In this PR:**
When loading from global memory (gmem), use `CpAsync` with a short data path of `gmem -> smem` to reduce temporary register usage. Otherwise, the data path from gmem to shared memory (smem) follows this sequence: `gmem -> L1 cache -> register -> smem`.

1. Only enabled when device major version > 8 
2. Enabled for shared memory persistent kernels.

**Performance:**
(1) Large speeup happens when 3 buffers are using shared memory.
![image](https://github.com/user-attachments/assets/3fa8d03e-f1f7-4aca-b5ec-b4bf9726681c)

(2) Has a regression at 18688, register spills slightly increased.
Without CpAsync
```
ptxas info    : 3 bytes gmem
ptxas info    : Compiling entry function '_ZN90_GLOBAL__N__00000000_50___tmp_kernel_inner_outer_persistent_f0_c1_r0_g0_cu_a2ef60c3_11326442nvfuser_inner_outer_persistent_f0_c1_r0_g0ENS_6TensorINS_8__bfloatELi2ELi2EEES2_NS0_IfLi1ELi1EEENS0_IfLi2ELi2EEENS0_IS1_Li1ELi1EEES2_S5_S5_S4_S4_NS0_IxLi1ELi1EEE' for 'sm_90a'
ptxas info    : Function properties for _ZN90_GLOBAL__N__00000000_50___tmp_kernel_inner_outer_persistent_f0_c1_r0_g0_cu_a2ef60c3_11326442nvfuser_inner_outer_persistent_f0_c1_r0_g0ENS_6TensorINS_8__bfloatELi2ELi2EEES2_NS0_IfLi1ELi1EEENS0_IfLi2ELi2EEENS0_IS1_Li1ELi1EEES2_S5_S5_S4_S4_NS0_IxLi1ELi1EEE
ptxas         .     72 bytes stack frame, 72 bytes spill stores, 128 bytes spill loads
ptxas info    : Used 255 registers, used 1 barriers, 72 bytes cumulative stack size, 16 bytes smem

```
With CpAsync
```
ptxas info    : 3 bytes gmem
ptxas info    : Compiling entry function '_ZN90_GLOBAL__N__00000000_50___tmp_kernel_inner_outer_persistent_f0_c1_r0_g0_cu_a18cc6a9_11693442nvfuser_inner_outer_persistent_f0_c1_r0_g0ENS_6TensorINS_8__bfloatELi2ELi2EEES2_NS0_IfLi1ELi1EEENS0_IfLi2ELi2EEENS0_IS1_Li1ELi1EEES2_S5_S5_S4_S4_NS0_IxLi1ELi1EEE' for 'sm_90a'
ptxas info    : Function properties for _ZN90_GLOBAL__N__00000000_50___tmp_kernel_inner_outer_persistent_f0_c1_r0_g0_cu_a18cc6a9_11693442nvfuser_inner_outer_persistent_f0_c1_r0_g0ENS_6TensorINS_8__bfloatELi2ELi2EEES2_NS0_IfLi1ELi1EEENS0_IfLi2ELi2EEENS0_IS1_Li1ELi1EEES2_S5_S5_S4_S4_NS0_IxLi1ELi1EEE
ptxas         .     80 bytes stack frame, 76 bytes spill stores, 132 bytes spill loads
ptxas info    : Used 255 registers, used 1 barriers, 80 bytes cumulative stack size, 16 bytes smem

```

**Following works:**
Revise when should move tensors to shared memory.
