### PR TITLE
Update `HopperMatmulTest.HSH_NT_128BSwizzle`

### DIFF
--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -3613,6 +3613,10 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
   constexpr auto swizzle = MmaInputSmemSwizzle::B128;
   const auto dtype = DataType::Half;
 
+  constexpr int64_t stages = 4;
+  const int64_t cta_m = 1 * getM(macro);
+  const int64_t cta_n = 1 * getN(macro);
+
   auto tv0 = makeContigConcreteTensor({-1, -1, 1}, dtype);
   auto tv1 = makeContigConcreteTensor({-1, 1, -1}, dtype);
   fusion.addInput(tv0);
@@ -3651,8 +3655,8 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
   // register [M, N, rK] -cast-> register [M, N] -set-> gmem [M, N]
 
   // Create tiles
-  tv2->split(-3, getM(macro));
-  tv2->split(-2, getN(macro));
+  tv2->split(-3, cta_m);
+  tv2->split(-2, cta_n);
   tv2->split(-1, getK(macro));
   // [Mo, Mi, No, Ni, Ko, Ki] -> [Mo, No, Ko, Mi, Ni, Ki]
   tv2->reorder({{-5, -3}, {-3, -2}});
@@ -3669,6 +3673,23 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
   // [..., Mi, Ni, Ki] -> [..., Mi, Ki, Ni]
   tv1c->reorder({{-1, -2}});
   tv1c->applyMmaSwizzleForTMALoad(swizzle);
+
+  {
+    tv2->split(-3, getM(macro));
+    tv2->split(-2, getN(macro));
+    // [Mo, No, Ko, Mio, Mii, Nio, Nii, Ki]
+    // -> [Mo, No, Ko, Mio, Nio, Mii, Nii, Ki]
+    tv2->reorder({{-4, -3}});
+    tv2->merge(-5);
+    tv2->axis(-4)->parallelize(ParallelType::TIDy);
+    scheduler_utils::BoundedDirectionalTransformPropagator::forward(
+        tv2,
+        -1,
+        {tv3},
+        scheduler_utils::BoundedDirectionalTransformPropagator::Options()
+            .propagateParallelType()
+            .propagateToBoundary());
+  }
 
   {
     auto s = mma_utils::MmaSwizzler::scheduleMmaOutputAllocation(
@@ -3688,8 +3709,8 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
 
   inlineMost();
 
-  tv0c->circularBuffer(/*number_of_stages=*/4);
-  tv1c->circularBuffer(/*number_of_stages=*/4);
+  tv0c->circularBuffer(stages);
+  tv1c->circularBuffer(stages);
 
   auto inputs =
       matmulAtInput3DHopperSS(M, N, K, layout, data_type_to_aten(dtype));


### PR DESCRIPTION
Previously, this test was assuming that, each CTA only has a single tile of MMA. This PR removes this assumption so that it is more convenient to try different things.