### PR TITLE
Don't use `fence.proxy.async`

### DIFF
--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -211,19 +211,6 @@ class LowerToInlinePtx : public kir::ExprMutator {
             std::vector<Val*>{},
             std::vector<Val*>{},
             kir::Asm::Options{/*volatile=*/true}));
-    // TODO: is this fence.proxy.async necessary? The above links say we need
-    // it, but seems that CUTLASS is not using it? Wouldn't wgmma.fence itself
-    // make sure registers are available to the async proxy? And would
-    // __syncthreads() make sure smem is available to the async proxy?
-    // Reference:
-    // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-membar-fence
-    registerInsertBefore(
-        mma,
-        IrBuilder::create<kir::Asm>(
-            "fence.proxy.async",
-            std::vector<Val*>{},
-            std::vector<Val*>{},
-            kir::Asm::Options{/*volatile=*/true}));
 
     // Do MMA
     std::stringstream inst_ss;


### PR DESCRIPTION
According to: https://docs.nvidia.com/cuda/parallel-thread-execution/#async-proxy, mbarrier wait already guaranteed correct ordering, so this sync is not needed:

> The completion of a `cp{.reduce}.async.bulk` operation is followed by an implicit generic-async proxy fence. So the result of the asynchronous operation is made visible to the generic proxy as soon as its completion is observed. Async-group OR mbarrier-based completion mechanism must be used to wait for the completion of the `cp{.reduce}.async.bulk` instructions.