### PR TITLE
Only do `wgmma.fence.sync.aligned` once

### DIFF
--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -571,9 +571,7 @@ class AllocationInserter : public kir::ExprMutator {
         // Needs to do a wgmma.fence.sync.aligned so that the initial values of
         // the accumulator are visible to TensorCore.
         if (auto mma = dynamic_cast<MmaOp*>(expr)) {
-          std::cout << "mma->macro(): " << std::endl;
           if (isHopper(mma->macro())) {
-            std::cout << "isHopper(mma->macro()): " << std::endl;
             auto wgmma_fence = IrBuilder::create<kir::Asm>(
                 "wgmma.fence.sync.aligned",
                 std::vector<Val*>{},

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -571,6 +571,7 @@ class AllocationInserter : public kir::ExprMutator {
         // Needs to do a wgmma.fence.sync.aligned so that the initial values of
         // the accumulator are visible to TensorCore.
         if (auto mma = dynamic_cast<MmaOp*>(expr)) {
+          std::cout << "mma->macro(): " << mma->macro() << std::endl;
           if (isHopper(mma->macro())) {
             auto wgmma_fence = IrBuilder::create<kir::Asm>(
                 "wgmma.fence.sync.aligned",

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -571,8 +571,9 @@ class AllocationInserter : public kir::ExprMutator {
         // Needs to do a wgmma.fence.sync.aligned so that the initial values of
         // the accumulator are visible to TensorCore.
         if (auto mma = dynamic_cast<MmaOp*>(expr)) {
-          std::cout << "mma->macro(): " << mma->macro() << std::endl;
+          std::cout << "mma->macro(): " << std::endl;
           if (isHopper(mma->macro())) {
+            std::cout << "isHopper(mma->macro()): " << std::endl;
             auto wgmma_fence = IrBuilder::create<kir::Asm>(
                 "wgmma.fence.sync.aligned",
                 std::vector<Val*>{},

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2100,7 +2100,7 @@ void IndexLowering::handle(const BroadcastOp* bop) {
 
 void IndexLowering::handle(const kir::Asm* asm_) {
   // TODO(kir): remove the need for const_cast
-  pushBack(const_cast<kir::Allocate*>(asm_)); // NOLINT
+  pushBack(const_cast<kir::Asm*>(asm_)); // NOLINT
 }
 
 void IndexLowering::handle(const kir::Allocate* allocate) {

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -160,8 +160,8 @@ void IndexLowering::handle(const ForLoop* for_loop) {
   active_scope_ = prev_scope;
 }
 
-void IndexLowering::handle(const kir::Asm* asm) {
-  pushBack(asm);
+void IndexLowering::handle(const kir::Asm* asm_) {
+  pushBack(asm_);
 }
 
 void IndexLowering::handle(const RNGOp* rop) {

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -160,6 +160,10 @@ void IndexLowering::handle(const ForLoop* for_loop) {
   active_scope_ = prev_scope;
 }
 
+void IndexLowering::handle(const kir::Asm* asm) {
+  pushBack(asm);
+}
+
 void IndexLowering::handle(const RNGOp* rop) {
   // Write random tensor indices into the consumer
   //  tensor index if the output is a tensor.

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -160,10 +160,6 @@ void IndexLowering::handle(const ForLoop* for_loop) {
   active_scope_ = prev_scope;
 }
 
-void IndexLowering::handle(const kir::Asm* asm_) {
-  pushBack(asm_);
-}
-
 void IndexLowering::handle(const RNGOp* rop) {
   // Write random tensor indices into the consumer
   //  tensor index if the output is a tensor.
@@ -2100,6 +2096,11 @@ void IndexLowering::handle(const BroadcastOp* bop) {
 
   pushBack(grid_broadcast);
   GpuLower::current()->propagateExprInfo(bop, back());
+}
+
+void IndexLowering::handle(const kir::Asm* asm_) {
+  // TODO(kir): remove the need for const_cast
+  pushBack(const_cast<kir::Allocate*>(asm_)); // NOLINT
 }
 
 void IndexLowering::handle(const kir::Allocate* allocate) {

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -38,6 +38,7 @@ class IndexLowering : private OptOutConstDispatch {
   // Insert an expression before the current top-level expression.
   void insertAtTopLevel(Expr* expr);
 
+  void handle(const kir::Asm*) final;
   void handle(const FullOp*) final;
   void handle(const IotaOp*) final;
   void handle(const EyeOp*) final;

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -38,7 +38,6 @@ class IndexLowering : private OptOutConstDispatch {
   // Insert an expression before the current top-level expression.
   void insertAtTopLevel(Expr* expr);
 
-  void handle(const kir::Asm*) final;
   void handle(const FullOp*) final;
   void handle(const IotaOp*) final;
   void handle(const EyeOp*) final;
@@ -68,6 +67,7 @@ class IndexLowering : private OptOutConstDispatch {
   void handle(const SliceOp*) final;
   void handle(const CatOp*) final;
 
+  void handle(const kir::Asm*) final;
   void handle(const ForLoop*) final;
   void handle(const kir::IfThenElse*) final;
   void handle(const kir::Allocate*) final;

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -201,16 +201,6 @@ class LowerToInlinePtx : public kir::ExprMutator {
     // Reference:
     // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#asynchronous-warpgroup-level-matrix-async-proxy
 
-    // TODO: we should not insert sync here. We should keep the lowerToInlinePtx
-    // pass only do simple translations, instead of inserting syncs. This will
-    // be fixed in a future PR.
-    registerInsertBefore(
-        mma,
-        IrBuilder::create<kir::Asm>(
-            "wgmma.fence.sync.aligned",
-            std::vector<Val*>{},
-            std::vector<Val*>{},
-            kir::Asm::Options{/*volatile=*/true}));
     // TODO: is this fence.proxy.async necessary? The above links say we need
     // it, but seems that CUTLASS is not using it? Wouldn't wgmma.fence itself
     // make sure registers are available to the async proxy? And would


### PR DESCRIPTION
Currently, the code for Hopper matmul kernel looks like below
```C++
accumulator = 0
for (prologue) {
  TMA load A;
  TMA load B;
}
for (main) {
  TMA load A;
  TMA load B;
  mbarrier wait;
  wgmma.fence;
  wgmma;
}
for (epilogue) {
  mbarrier wait;
  wgmma.fence;
  wgmma;
}
```
where we do the fencing at  every iteration. This is not optimal because, according to https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#asynchronous-warpgroup-level-matrix-instructions-wgmma-fence:

> The wgmma.fence instruction must be issued by all warps of the warpgroup at the following locations:
> 
> - Before the first `wgmma.mma_async` operation in a warpgroup.
>
> - Between a register access by a thread in the warpgroup and any `wgmma.mma_async` instruction that accesses the same registers, either as accumulator or input register containing fragments of matrix A, except when these are accumulator register accesses across multiple `wgmma.mma_async` instructions of the same shape. In the latter case, an ordering guarantee is provided by default.

Because the order of `wgmma.mma_async` instructions of the same shape is automatically guaranteed, there is no need to do a fence at every iteration.

This PR changes the generated code into:
```C++
accumulator = 0
wgmma.fence;
for (prologue) {
  TMA load A;
  TMA load B;
}
for (main) {
  TMA load A;
  TMA load B;
  mbarrier wait;
  wgmma;
}
for (epilogue) {
  mbarrier wait;
  wgmma;
}
```
which in theory should be better.

There is no visible perf change for this PR.