### PR TITLE
Don't generate unnecessary loops for `mbarrier::wait`

### DIFF
--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -642,7 +642,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
         createMbarrierWait(ldst, epilogue_compute_stage);
 
     // If last cloned scope is the cloned_top_level_loop body, then add
-    // mbarrier::arriveExpectTx, new loadStoreOp, and mbarrier_wait
+    // mbarrier_wait
     int64_t active_for_loops = std::count_if(
         for_loop_stack_.begin(), for_loop_stack_.end(), [](ForLoop* fl) {
           return fl->iter_domain()->getParallelType() == ParallelType::Serial;

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -638,8 +638,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
     NVF_ERROR(
         mbarrier_wait_ == nullptr,
         "Expected mbarrier_wait to inactive for current TMA operation");
-    mbarrier_wait_ =
-        createMbarrierWait(ldst, epilogue_compute_stage);
+    mbarrier_wait_ = createMbarrierWait(ldst, epilogue_compute_stage);
 
     // If last cloned scope is the cloned_top_level_loop body, then add
     // mbarrier_wait

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -638,9 +638,21 @@ class CloneTmaCircularBufferLoopAndInsertSync
     NVF_ERROR(
         mbarrier_wait_ == nullptr,
         "Expected mbarrier_wait to inactive for current TMA operation");
-    kir::MBarrierWait* mbarrier_wait =
+    mbarrier_wait_ =
         createMbarrierWait(ldst, epilogue_compute_stage);
-    for_loop_stack_.back()->body().push_back(mbarrier_wait);
+
+    // If last cloned scope is the cloned_top_level_loop body, then add
+    // mbarrier::arriveExpectTx, new loadStoreOp, and mbarrier_wait
+    int64_t active_for_loops = std::count_if(
+        for_loop_stack_.begin(), for_loop_stack_.end(), [](ForLoop* fl) {
+          return fl->iter_domain()->getParallelType() == ParallelType::Serial;
+        });
+    if (active_for_loops == 1) {
+      NVF_ERROR(mbarrier_wait_ != nullptr);
+      for_loop_stack_.back()->body().push_back(mbarrier_wait_);
+      mbarrier_wait_ = nullptr;
+      return;
+    }
   }
 
   // This function selects a single thread to launch tma load and mbarrier


### PR DESCRIPTION
See diff in generated kernel: https://www.diffchecker.com/uFzYklHb/

There is a tiny perf improvement:
```C++
 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name

 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     23.0          1664884          1  1664884.0  1664884.0   1664884   1664884          0.0  <unnamed>::nvfuser_none_f0_c0_r0_g0(<unnamed>::Tensor<<unnamed>::__half, (int)3, (int)3>, <unnamed>…
     10.8           782010          1   782010.0   782010.0    782010    782010          0.0  nvjet_hsh_192x192_64x3_2x1_v_bz_coopB_NTN
```
(benchmarked with https://github.com/NVIDIA/Fuser/pull/3139 and https://github.com/NVIDIA/Fuser/pull/3136)

Perf nvFuser/cuBLAS: `47%`, previously (https://github.com/NVIDIA/Fuser/issues/3137#issuecomment-2400955663) `46.6%`.