### PR TITLE
Add expand operation to python frontend

### DIFF
--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -961,6 +961,61 @@ struct BroadcastOpRecord : RecordFunctor {
   std::vector<bool> is_broadcast_dim_;
 };
 
+//! Specialized Record Functor for the FusionState's expand op.
+struct ExpandOpRecord : RecordFunctor {
+  ExpandOpRecord(std::vector<State> _args, std::vector<State> _outputs)
+      : RecordFunctor(
+            std::move(_args),
+            std::move(_outputs),
+            "ops.expand",
+            serde::RecordType::ExpandOp) {
+    arg_names_[1] = "shape";
+  }
+  ~ExpandOpRecord() override = default;
+  RecordFunctor* clone() final {
+    return new ExpandOpRecord(*this);
+  }
+
+  //! Child specific hash function in lower 32 bits.
+  //! | 31 ---------------------------------------  0 |
+  //! | None                                          |
+  size_t hash() const final {
+    return RecordFunctor::hash();
+  }
+
+  bool operator==(const RecordFunctor& other) const final {
+    auto result = false;
+    if (dynamic_cast<const ExpandOpRecord*>(&other)) {
+      result = RecordFunctor::operator==(other);
+    }
+    return result;
+  }
+
+  void operator()(FusionState& fd) final {
+    auto arg = fd.getFusionState(args_.at(0).index)->template as<TensorView>();
+    const std::vector<Val*>& output_shape =
+        fd.getFusionStateVector(args_.at(1).index);
+
+    size_t arg_ndims = arg->domain()->noReductions().size();
+    NVF_CHECK(
+        output_shape.size() == arg_ndims,
+        "The new shape is expected to be equal to the input: ",
+        output_shape.size(),
+        " vs ",
+        arg_ndims);
+    auto expanded_output = expand(arg, output_shape);
+
+    fd.setFusionState(outputs_.at(0).index, expanded_output);
+  }
+
+  void print(std::ostream& os, bool close_function = true) const final {
+    RecordFunctor::print(os, false);
+    if (close_function) {
+      os << ")";
+    }
+  }
+};
+
 template <class OutType, class ArgType>
 struct CastOpRecord : RecordFunctor {
   CastOpRecord(

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -43,6 +43,7 @@ enum RecordType: int {
     CastVal,
     CatOp,
     End,
+    ExpandOp,
     FullOp,
     IotaOp,
     IndexSelectOp,

--- a/csrc/serde/fusion_record.cpp
+++ b/csrc/serde/fusion_record.cpp
@@ -381,6 +381,12 @@ void RecordFunctorFactory::registerAllParsers() {
   };
   registerParser(RecordType::BroadcastInDim, deserializeBroadcastInDimRecord);
 
+  auto deserializeExpandRecord = [](const RecordFunctor* buffer) {
+    return new python_frontend::ExpandOpRecord(
+        parseStateArgs(buffer->args()), parseStateArgs(buffer->outputs()));
+  };
+  registerParser(RecordType::ExpandOp, deserializeExpandRecord);
+
   auto deserializeCastTvRecord = [](const RecordFunctor* buffer) {
     std::function<TensorView*(nvfuser::DataType, TensorView*)> fusion_op =
         static_cast<TensorView* (*)(nvfuser::DataType, TensorView*)>(castOp);

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -203,6 +203,25 @@ class TestNvFuserFrontend(NVFuserTest):
         )
         self.assertEqual(eager_out, nvf_out[0])
 
+    def test_expand(self):
+        inputs = [
+            torch.randn(1, 1, 4, device="cuda"),
+            torch.randn(2, 3, 4, device="cuda"),
+        ]
+
+        def fusion_func(fd: FusionDefinition):
+            t0 = fd.from_pytorch(inputs[0])
+            t1 = fd.from_pytorch(inputs[1])
+
+            t0_b = fd.ops.expand(t0, inputs[1].size())
+            t2 = fd.ops.add(t0_b, t1)
+
+            fd.add_output(t2)
+
+        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
+        eager_out = inputs[0].expand(inputs[1].size()) + inputs[1]
+        self.assertEqual(eager_out, nvf_out[0])
+
     def test_broadcast_mixing(self):
         inputs = [
             torch.randn(3, 1, device="cuda"),


### PR DESCRIPTION
* Currently, the python frontend represents `broadcast_in_dims` as a `broadcast` and `expand` composite operation. 
* For cpp to python translation, when we encounter an `Expand` expression, we must create a `BroadcastInDimsOp`.
* This `BroadcastInDimsOp` creates a redundant `broadcast` because the original `broadcast` was handled separately from the `expand`. 
* By adding the `expand` operation to the python frontend, we can create a one-to-one mapping in the cpp to python translation.