### PR TITLE
Call init/destroy_process_group once. 

### DIFF
--- a/tests/python/mpi_fixtures.py
+++ b/tests/python/mpi_fixtures.py
@@ -34,7 +34,7 @@ class MpiTest:
         self._communicator.barrier()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def mpi_test():
     fixture = MpiTest()
     yield fixture

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -2,7 +2,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import os
 import pytest
 import torch
 import torch.distributed as dist

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -50,7 +50,7 @@ def setup_process_group(mpi_test) -> None:
     [ComputeType.FORWARD, ComputeType.BACKWARD],
     ids=["forward", "backward"],
 )
-def test_transformer_layer(mpi_test, setup_process_group, benchmark, compute_type):
+def test_transformer_layer(setup_process_group, benchmark, compute_type):
     # Hyperparameters for GPT-3
     hidden_size = 12288
     num_heads = 96
@@ -59,8 +59,8 @@ def test_transformer_layer(mpi_test, setup_process_group, benchmark, compute_typ
     sequence_length = 2048
     dtype = torch.bfloat16
 
-    size = mpi_test.size
-    rank = mpi_test.rank
+    size = dist.get_world_size()
+    rank = dist.get_rank()
 
     torch.cuda.set_device(rank)
 

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -25,12 +25,10 @@ class ComputeType(Enum):
 
 @pytest.fixture(scope="module")
 def setup_process_group(mpi_test) -> None:
-    os.environ["MASTER_ADDR"] = "localhost"
     # The default port as used by https://github.com/pytorch/pytorch/blob/45a8b5682eb69d865cbf68c7f2f689b56b4efd53/torch/csrc/distributed/c10d/TCPStore.hpp#L51.
-    os.environ["MASTER_PORT"] = "29500"
     dist.init_process_group(
         backend="nccl",
-        init_method="env://",
+        init_method="tcp://localhost:29500",
         world_size=mpi_test.size,
         rank=mpi_test.rank,
     )

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -63,14 +63,13 @@ def test_transformer_layer(mpi_test, setup_process_group, benchmark, compute_typ
     rank = mpi_test.rank
 
     torch.cuda.set_device(rank)
-    tp_group = dist.new_group()
 
     transformer_layer = te.TransformerLayer(
         hidden_size,
         ffn_hidden_size,
         num_heads,
         set_parallel_mode=True,
-        tp_group=tp_group,
+        tp_group=dist.group.WORLD,
     )
     transformer_layer.to(dtype).to("cuda")
 
@@ -134,5 +133,3 @@ def test_transformer_layer(mpi_test, setup_process_group, benchmark, compute_typ
                 setup=partial(setup_fn, True),
                 rounds=5,
             )
-
-    dist.destroy_process_group(group=tp_group)

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -32,11 +32,8 @@ class ComputeType(Enum):
 @pytest.mark.mpi
 @pytest.mark.parametrize(
     "compute_type",
-    # TODO(#3119): add the backward test back.
-    # [ComputeType.FORWARD, ComputeType.BACKWARD],
-    # ids=["forward", "backward"],
-    [ComputeType.FORWARD],
-    ids=["forward"],
+    [ComputeType.FORWARD, ComputeType.BACKWARD],
+    ids=["forward", "backward"],
 )
 def test_transformer_layer(mpi_test, benchmark, compute_type):
     # Hyperparameters for GPT-3

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -24,7 +24,7 @@ class ComputeType(Enum):
 
 
 @pytest.fixture(scope="module")
-def process_group(mpi_test) -> None:
+def setup_process_group(mpi_test) -> None:
     os.environ["MASTER_ADDR"] = "localhost"
     # The default port as used by https://github.com/pytorch/pytorch/blob/45a8b5682eb69d865cbf68c7f2f689b56b4efd53/torch/csrc/distributed/c10d/TCPStore.hpp#L51.
     os.environ["MASTER_PORT"] = "29500"
@@ -50,7 +50,7 @@ def process_group(mpi_test) -> None:
     [ComputeType.FORWARD, ComputeType.BACKWARD],
     ids=["forward", "backward"],
 )
-def test_transformer_layer(mpi_test, process_group, benchmark, compute_type):
+def test_transformer_layer(mpi_test, setup_process_group, benchmark, compute_type):
     # Hyperparameters for GPT-3
     hidden_size = 12288
     num_heads = 96


### PR DESCRIPTION
Fixes #3129. 

This is done by using fixtures. 

It's unclear why this avoids #3129. However, this appears to be the best practice according to https://pytorch.org/docs/stable/distributed.html#shutdown, and is more efficient. 