### PR TITLE
A few cleanups

### DIFF
--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -572,11 +572,7 @@ class AllocationInserter : public kir::ExprMutator {
         // the accumulator are visible to TensorCore.
         if (auto mma = dynamic_cast<MmaOp*>(expr)) {
           if (isHopper(mma->macro())) {
-            auto wgmma_fence = IrBuilder::create<kir::Asm>(
-                "wgmma.fence.sync.aligned",
-                std::vector<Val*>{},
-                std::vector<Val*>{},
-                kir::Asm::Options{/*volatile=*/true});
+            auto wgmma_fence = IrBuilder::create<kir::WgMmaFence>();
             registerInsertBefore(
                 allocation.init_place_before, wgmma_fence, scope);
             auto fence_async = IrBuilder::create<kir::FenceAsyncProxy>();

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -579,11 +579,7 @@ class AllocationInserter : public kir::ExprMutator {
                 kir::Asm::Options{/*volatile=*/true});
             registerInsertBefore(
                 allocation.init_place_before, wgmma_fence, scope);
-            auto fence_async = IrBuilder::create<kir::Asm>(
-                "fence.proxy.async",
-                std::vector<Val*>{},
-                std::vector<Val*>{},
-                kir::Asm::Options{/*volatile=*/true});
+            auto fence_async = IrBuilder::create<kir::FenceAsyncProxy>();
             registerInsertBefore(
                 allocation.init_place_before, fence_async, scope);
           }

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -576,6 +576,9 @@ class AllocationInserter : public kir::ExprMutator {
               // instruction. For this case, we need to insert these fences
               // after the initialization of the accumulator, so that the
               // inilization is visible to the async proxy.
+              // When all inputs are guarded by mbarrier, we will insert these
+              // fences before each mma instruction, so there is no need to
+              // insert them after the initialization of the accumulator here.
               auto wgmma_fence = IrBuilder::create<kir::WgMmaFence>();
               registerInsertBefore(
                   allocation.init_place_before, wgmma_fence, scope);

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2106,6 +2106,11 @@ void IndexLowering::handle(const kir::AsyncWait* wait) {
   pushBack(const_cast<kir::AsyncWait*>(wait)); // NOLINT
 }
 
+void IndexLowering::handle(const kir::FenceAsyncProxy* fence) {
+  // TODO(kir): remove the need for const_cast
+  pushBack(const_cast<kir::FenceAsyncProxy*>(fence)); // NOLINT
+}
+
 void IndexLowering::handle(const kir::AsyncCommit* commit) {
   // TODO(kir): remove the need for const_cast
   pushBack(const_cast<kir::AsyncCommit*>(commit)); // NOLINT

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2111,6 +2111,11 @@ void IndexLowering::handle(const kir::FenceAsyncProxy* fence) {
   pushBack(const_cast<kir::FenceAsyncProxy*>(fence)); // NOLINT
 }
 
+void IndexLowering::handle(const kir::WgMmaFence* fence) {
+  // TODO(kir): remove the need for const_cast
+  pushBack(const_cast<kir::WgMmaFence*>(fence)); // NOLINT
+}
+
 void IndexLowering::handle(const kir::AsyncCommit* commit) {
   // TODO(kir): remove the need for const_cast
   pushBack(const_cast<kir::AsyncCommit*>(commit)); // NOLINT

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1537,11 +1537,6 @@ void IndexLowering::handleCpAsyncBulkLoad(const LoadStoreOp* ldst) {
 }
 
 void IndexLowering::handleCpAsyncBulkStore(const LoadStoreOp* ldst) {
-  pushBack(IrBuilder::create<kir::Asm>(
-      "fence.proxy.async",
-      std::vector<Val*>{},
-      std::vector<Val*>{},
-      kir::Asm::Options{/*volatile=*/true}));
   auto in = lowerSrcIndex(ldst->in(), ldst->out(), {}, true);
   auto [out, _] =
       Index::getCpAsyncBulkGmemIndex(ldst, nullptr, for_loops_, rotated_loop_);
@@ -1550,11 +1545,6 @@ void IndexLowering::handleCpAsyncBulkStore(const LoadStoreOp* ldst) {
           ->withPredicate(ldst->predicate());
   pushBack(new_ldst);
   GpuLower::current()->propagateExprInfo(ldst, back());
-  // Waits on all the prior bulk async-groups to complete.
-  // TODO: we should not insert sync here. We should move this to
-  // insertRawThreadSynchronization or insertWarThreadSynchronization.
-  pushBack(IrBuilder::create<kir::AsyncCommit>(AsyncOpType::CpAsyncBulk));
-  pushBack(IrBuilder::create<kir::AsyncWait>(AsyncOpType::CpAsyncBulk, 0));
 }
 
 static DataType getMmaInputAType(MmaMacro macro) {
@@ -2035,13 +2025,6 @@ void IndexLowering::handle(const MmaOp* mma) {
       IrBuilder::create<MmaOp>(out, a, b, mma->init(), mma->macro());
   pushBack(mma_indexed);
   GpuLower::current()->propagateExprInfo(mma, back());
-  if (mma->isHopper()) {
-    // Waits on all the prior bulk async-groups to complete.
-    // TODO: we should not insert sync here. We should move this to
-    // insertRawThreadSynchronization or insertWarThreadSynchronization.
-    pushBack(IrBuilder::create<kir::AsyncCommit>(AsyncOpType::WgMma));
-    pushBack(IrBuilder::create<kir::AsyncWait>(AsyncOpType::WgMma, 0));
-  }
 }
 
 void IndexLowering::handle(const BroadcastOp* bop) {

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -73,6 +73,7 @@ class IndexLowering : private OptOutConstDispatch {
   void handle(const kir::Allocate*) final;
   void handle(const kir::BlockSync*) final;
   void handle(const kir::GridSync*) final;
+  void handle(const kir::FenceAsyncProxy*) final;
   void handle(const kir::MBarrierInit*) final;
   void handle(const kir::MBarrierInvalidate*) final;
   void handle(const kir::MBarrierArrive*) final;

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -74,6 +74,7 @@ class IndexLowering : private OptOutConstDispatch {
   void handle(const kir::BlockSync*) final;
   void handle(const kir::GridSync*) final;
   void handle(const kir::FenceAsyncProxy*) final;
+  void handle(const kir::WgMmaFence*) final;
   void handle(const kir::MBarrierInit*) final;
   void handle(const kir::MBarrierInvalidate*) final;
   void handle(const kir::MBarrierArrive*) final;

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -267,10 +267,10 @@ class LowerToInlinePtx : public kir::ExprMutator {
     registerReplace(
         fence,
         IrBuilder::create<kir::Asm>(
-              "wgmma.fence.sync.aligned",
-              std::vector<Val*>{},
-              std::vector<Val*>{},
-              kir::Asm::Options{/*volatile=*/true}));
+            "wgmma.fence.sync.aligned",
+            std::vector<Val*>{},
+            std::vector<Val*>{},
+            kir::Asm::Options{/*volatile=*/true}));
   }
 };
 

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -262,6 +262,16 @@ class LowerToInlinePtx : public kir::ExprMutator {
             std::vector<Val*>{},
             kir::Asm::Options{/*volatile=*/true}));
   }
+
+  void handle(kir::WgMmaFence* fence) final {
+    registerReplace(
+        fence,
+        IrBuilder::create<kir::Asm>(
+              "wgmma.fence.sync.aligned",
+              std::vector<Val*>{},
+              std::vector<Val*>{},
+              kir::Asm::Options{/*volatile=*/true}));
+  }
 };
 
 std::vector<Expr*> lowerToInlinePtx(const std::vector<Expr*>& exprs) {

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -384,9 +384,12 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         auto wait = IrBuilder::create<kir::AsyncWait>(AsyncOpType::WgMma, 0);
         registerInsertAfter(expr, commit, scope);
         registerInsertAfter(expr, wait, scope);
-        auto a = ir_utils::getTv(mma->inA());
-        bool guarded_by_mbarrier = ir_utils::isCpAsyncBulkLoad(a->definition());
-        if (!guarded_by_mbarrier) {
+        bool inputs_guarded_by_mbarrier =
+            ir_utils::isCpAsyncBulkLoad(
+                ir_utils::getTv(mma->inA())->definition()) &&
+            ir_utils::isCpAsyncBulkLoad(
+                ir_utils::getTv(mma->inB())->definition());
+        if (!inputs_guarded_by_mbarrier) {
           // Makes sure that writes to register operand A in the general proxy
           // are visible to the async proxy
           auto wgmma_fence = IrBuilder::create<kir::WgMmaFence>();

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -384,12 +384,7 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         auto wait = IrBuilder::create<kir::AsyncWait>(AsyncOpType::WgMma, 0);
         registerInsertAfter(expr, commit, scope);
         registerInsertAfter(expr, wait, scope);
-        bool inputs_guarded_by_mbarrier =
-            ir_utils::isCpAsyncBulkLoad(
-                ir_utils::getTv(mma->inA())->definition()) &&
-            ir_utils::isCpAsyncBulkLoad(
-                ir_utils::getTv(mma->inB())->definition());
-        if (!inputs_guarded_by_mbarrier) {
+        if (!lower_utils::allMmaInputsGuardedByMBarrier(mma)) {
           // Makes sure that writes to register operand A in the general proxy
           // are visible to the async proxy
           auto wgmma_fence = IrBuilder::create<kir::WgMmaFence>();

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -394,11 +394,7 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
               std::vector<Val*>{},
               kir::Asm::Options{/*volatile=*/true});
           registerInsertBefore(expr, wgmma_fence, scope);
-          auto fence_async = IrBuilder::create<kir::Asm>(
-              "fence.proxy.async",
-              std::vector<Val*>{},
-              std::vector<Val*>{},
-              kir::Asm::Options{/*volatile=*/true});
+          auto fence_async = IrBuilder::create<kir::FenceAsyncProxy>();
           registerInsertBefore(expr, fence_async, scope);
         }
       }
@@ -406,11 +402,7 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
 
     if (ir_utils::isCpAsyncBulkStore(expr)) {
       auto scope = scope_.empty() ? nullptr : scope_.back();
-      auto fence_proxy = IrBuilder::create<kir::Asm>(
-          "fence.proxy.async",
-          std::vector<Val*>{},
-          std::vector<Val*>{},
-          kir::Asm::Options{/*volatile=*/true});
+      auto fence_proxy = IrBuilder::create<kir::FenceAsyncProxy>();
       auto commit =
           IrBuilder::create<kir::AsyncCommit>(AsyncOpType::CpAsyncBulk);
       auto wait =

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -388,11 +388,7 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
             MemoryType::Register) {
           // Makes sure that writes to register operand A in the general proxy
           // are visible to the async proxy
-          auto wgmma_fence = IrBuilder::create<kir::Asm>(
-              "wgmma.fence.sync.aligned",
-              std::vector<Val*>{},
-              std::vector<Val*>{},
-              kir::Asm::Options{/*volatile=*/true});
+          auto wgmma_fence = IrBuilder::create<kir::WgMmaFence>();
           registerInsertBefore(expr, wgmma_fence, scope);
           auto fence_async = IrBuilder::create<kir::FenceAsyncProxy>();
           registerInsertBefore(expr, fence_async, scope);

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -384,8 +384,7 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         auto wait = IrBuilder::create<kir::AsyncWait>(AsyncOpType::WgMma, 0);
         registerInsertAfter(expr, commit, scope);
         registerInsertAfter(expr, wait, scope);
-        if (ir_utils::getTv(mma->inA())->getMemoryType() ==
-            MemoryType::Register) {
+        if (ir_utils::getTv(mma->inA())->getMemoryType() == MemoryType::Local) {
           // Makes sure that writes to register operand A in the general proxy
           // are visible to the async proxy
           auto wgmma_fence = IrBuilder::create<kir::WgMmaFence>();

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -384,7 +384,9 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         auto wait = IrBuilder::create<kir::AsyncWait>(AsyncOpType::WgMma, 0);
         registerInsertAfter(expr, commit, scope);
         registerInsertAfter(expr, wait, scope);
-        if (ir_utils::getTv(mma->inA())->getMemoryType() == MemoryType::Local) {
+        auto a = ir_utils::getTv(mma->inA());
+        bool guarded_by_mbarrier = ir_utils::isCpAsyncBulkLoad(a->definition());
+        if (!guarded_by_mbarrier) {
           // Makes sure that writes to register operand A in the general proxy
           // are visible to the async proxy
           auto wgmma_fence = IrBuilder::create<kir::WgMmaFence>();

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -382,8 +382,8 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         auto scope = scope_.empty() ? nullptr : scope_.back();
         auto commit = IrBuilder::create<kir::AsyncCommit>(AsyncOpType::WgMma);
         auto wait = IrBuilder::create<kir::AsyncWait>(AsyncOpType::WgMma, 0);
-        registerInsertAfter(expr, commit, scope);
         registerInsertAfter(expr, wait, scope);
+        registerInsertAfter(expr, commit, scope);
         if (!lower_utils::allMmaInputsGuardedByMBarrier(mma)) {
           // Makes sure that writes to operands in the generic proxy are visible
           // to the async proxy
@@ -403,8 +403,8 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
       auto wait =
           IrBuilder::create<kir::AsyncWait>(AsyncOpType::CpAsyncBulk, 0);
       registerInsertBefore(expr, fence_proxy, scope);
-      registerInsertAfter(expr, commit, scope);
       registerInsertAfter(expr, wait, scope);
+      registerInsertAfter(expr, commit, scope);
     }
 
     // An identical but separate flow of timing for cpasync_wait.

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -377,7 +377,7 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
       return;
     }
 
-    if (auto mma = dynamic_cast<kir::MmaOp*>(expr)) {
+    if (auto mma = dynamic_cast<MmaOp*>(expr)) {
       if (mma->isHopper()) {
         auto scope = scope_.empty() ? nullptr : scope_.back();
         auto commit = IrBuilder::create<kir::AsyncCommit>(AsyncOpType::WgMma);

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -385,8 +385,8 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         registerInsertAfter(expr, commit, scope);
         registerInsertAfter(expr, wait, scope);
         if (!lower_utils::allMmaInputsGuardedByMBarrier(mma)) {
-          // Makes sure that writes to register operand A in the general proxy
-          // are visible to the async proxy
+          // Makes sure that writes to operands in the generic proxy are visible
+          // to the async proxy
           auto wgmma_fence = IrBuilder::create<kir::WgMmaFence>();
           registerInsertBefore(expr, wgmma_fence, scope);
           auto fence_async = IrBuilder::create<kir::FenceAsyncProxy>();

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -1982,6 +1982,12 @@ IterDomain* getConcreteLoopID(IterDomain* id) {
   }
 }
 
+bool allMmaInputsGuardedByMBarrier(const MmaOp* mma) {
+  return ir_utils::isCpAsyncBulkLoad(
+             ir_utils::getTv(mma->inA())->definition()) &&
+      ir_utils::isCpAsyncBulkLoad(ir_utils::getTv(mma->inB())->definition());
+}
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -367,6 +367,9 @@ struct IterDomainDependencySorter {
   const IterDomain* kernel_scope_domain_ = nullptr;
 };
 
+// Check if all the inputs of the given MmaOp is guarded by mbarrier
+bool allMmaInputsGuardedByMBarrier(const MmaOp* mma);
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -118,6 +118,7 @@ class Val;
   f(Asm);                             \
   f(BlockSync);                       \
   f(GridSync);                        \
+  f(FenceAsyncProxy);                 \
   f(MBarrierInit);                    \
   f(MBarrierInvalidate);              \
   f(MBarrierArrive);                  \

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -119,6 +119,7 @@ class Val;
   f(BlockSync);                       \
   f(GridSync);                        \
   f(FenceAsyncProxy);                 \
+  f(WgMmaFence);                      \
   f(MBarrierInit);                    \
   f(MBarrierInvalidate);              \
   f(MBarrierArrive);                  \

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -465,7 +465,7 @@ std::string FenceAsyncProxy::toInlineString(int indent_size) const {
   NVF_CHECK(false, "FenceAsyncProxy can not be printed inline");
 }
 
-NVFUSER_DEFINE_CLONE_AND_CREATE(AsyncWait)
+NVFUSER_DEFINE_CLONE_AND_CREATE(FenceAsyncProxy)
 
 MBarrierInit::MBarrierInit(
     IrBuilderPasskey passkey,

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -450,6 +450,23 @@ std::string GridSync::toInlineString(int indent_size) const {
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(GridSync)
 
+FenceAsyncProxy::FenceAsyncProxy(IrBuilderPasskey passkey) : Expr(passkey) {
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
+      passkey.ir_container_->isA<kir::Kernel>(),
+      "IR type only valid for Kernel container.");
+}
+
+std::string FenceAsyncProxy::toString(int indent_size) const {
+  return "fence.proxy.async\n";
+}
+
+std::string FenceAsyncProxy::toInlineString(int indent_size) const {
+  NVF_CHECK(false, "FenceAsyncProxy can not be printed inline");
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(AsyncWait)
+
 MBarrierInit::MBarrierInit(
     IrBuilderPasskey passkey,
     Val* mbarrier,

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -467,6 +467,23 @@ std::string FenceAsyncProxy::toInlineString(int indent_size) const {
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(FenceAsyncProxy)
 
+WgMmaFence::WgMmaFence(IrBuilderPasskey passkey) : Expr(passkey) {
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
+      passkey.ir_container_->isA<kir::Kernel>(),
+      "IR type only valid for Kernel container.");
+}
+
+std::string WgMmaFence::toString(int indent_size) const {
+  return "fence.proxy.async\n";
+}
+
+std::string WgMmaFence::toInlineString(int indent_size) const {
+  NVF_CHECK(false, "WgMmaFence can not be printed inline");
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(WgMmaFence)
+
 MBarrierInit::MBarrierInit(
     IrBuilderPasskey passkey,
     Val* mbarrier,

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -40,6 +40,7 @@ class Asm;
 class BlockSync;
 class GridSync;
 class FenceAsyncProxy;
+class WgMmaFence;
 class MBarrierInit;
 class MBarrierInvalidate;
 class MBarrierArrive;
@@ -444,6 +445,23 @@ class NVF_API FenceAsyncProxy final : public Expr {
 
   const char* getOpString() const override {
     return "FenceAsyncProxy";
+  }
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+};
+
+// PTX: wgmma.fence.sync.aligned
+class NVF_API WgMmaFence final : public Expr {
+ public:
+  using Expr::Expr;
+
+  explicit WgMmaFence(IrBuilderPasskey passkey);
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  const char* getOpString() const override {
+    return "WgMmaFence";
   }
 
   std::string toString(int indent_size = 0) const override;

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -39,6 +39,7 @@ class Allocate;
 class Asm;
 class BlockSync;
 class GridSync;
+class FenceAsyncProxy;
 class MBarrierInit;
 class MBarrierInvalidate;
 class MBarrierArrive;
@@ -430,6 +431,23 @@ class NVF_API GridSync final : public Expr {
   Val* syncBuffer() const {
     return attributeVal(1);
   }
+};
+
+// PTX: fence.proxy.async
+class NVF_API FenceAsyncProxy final : public Expr {
+ public:
+  using Expr::Expr;
+
+  explicit FenceAsyncProxy();
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  const char* getOpString() const override {
+    return "FenceAsyncProxy";
+  }
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
 };
 
 class NVF_API MBarrierInit final : public Expr {

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -438,7 +438,7 @@ class NVF_API FenceAsyncProxy final : public Expr {
  public:
   using Expr::Expr;
 
-  explicit FenceAsyncProxy();
+  explicit FenceAsyncProxy(IrBuilderPasskey passkey);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 


### PR DESCRIPTION
- add new IR node `kir::FenceAsyncProxy` and `kir::WgMmaFence`, which will be lowered as `fence.proxy.async` and `wgmma.fence.sync.aligned` in `inline_ptx.cpp`. While it is possible to just create the `kir::Asm` nodes in the passes, I believe it's better to have a separate IR node so that other passes will not need to worry about details of the PTX instruction.
- In the past, syncs for TMA store and MMA are inserted in `index.cpp` and `inline_ptx.cpp`, which is not optimal. I moved the insertion code to `insert_syncs.cpp`.
- For Hopper MMA whose inputs are not guarded by mbarrier, insert fences before each mma instruction. These fences were removed in https://github.com/NVIDIA/Fuser/pull/3139 and https://github.com/NVIDIA/Fuser/pull/3136, but I believe we should add them back for this edge case, because there was no mbarrier guaranteeing the ordering. This is just an edge case, for real kernel, we will only use the SS variant and operands will always be guarded by mbarrier.

This is just a cleanup, there is no change in the perf of https://github.com/NVIDIA/Fuser/issues/3137