### PR TITLE
Enable matmul operands with non-trivial alloc domains

### DIFF
--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -339,6 +339,15 @@ std::string isMatmulFusionDefinitionSupported(
       }
     }
   }
+
+  // TODO: Lift this requirement once we properly handle output allocation
+  // domain
+  for (Val* outp : fusion->outputs()) {
+    if (auto tv = dynamic_cast<TensorView*>(outp);
+        tv && !ir_utils::hasTrivialAllocationDomain(tv)) {
+      return "detected output TV with non-trivial allocation domain";
+    }
+  }
   return "";
 }
 

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -339,23 +339,6 @@ std::string isMatmulFusionDefinitionSupported(
       }
     }
   }
-
-  // Check that no non-trivial allocation domains are set on inputs or
-  // outputs.
-  // TODO: Lift this requirement once we have proper allocation domain support
-  for (Val* inp : fusion->inputs()) {
-    if (auto tv = dynamic_cast<TensorView*>(inp);
-        tv && !ir_utils::hasTrivialAllocationDomain(tv)) {
-      return "detected input TV with non-trivial allocation domain";
-    }
-  }
-  for (Val* outp : fusion->outputs()) {
-    if (auto tv = dynamic_cast<TensorView*>(outp);
-        tv && !ir_utils::hasTrivialAllocationDomain(tv)) {
-      return "detected output TV with non-trivial allocation domain";
-    }
-  }
-
   return "";
 }
 

--- a/csrc/scheduler/runtime_info.cpp
+++ b/csrc/scheduler/runtime_info.cpp
@@ -62,18 +62,10 @@ SchedulerRuntimeInfo::SchedulerRuntimeInfo(
       if (alloc_perm_opt.has_value()) {
         // Save the strides in order of allocation domain in case the
         // allocation domain is a permutation of RFactor domain
-        std::vector<int64_t> orig_sizes = alloc_sizes.vec();
-        std::vector<int64_t> orig_strides = alloc_strides.vec();
-        std::vector<int64_t> ordered_sizes, ordered_strides;
-        ordered_sizes.reserve(orig_sizes.size());
-        ordered_strides.reserve(orig_strides.size());
-        NVF_ERROR(orig_strides.size() == alloc_perm_opt->size());
-        for (int64_t i : alloc_perm_opt.value()) {
-          ordered_sizes.push_back(orig_sizes[i]);
-          ordered_strides.push_back(orig_strides[i]);
-        }
-        input_sizes_[fusion_inp] = std::move(ordered_sizes);
-        input_strides_elements_[fusion_inp] = std::move(ordered_strides);
+        // NOTE: alloc_sizes and alloc_strides are already in order of
+        // allocation domain
+        input_sizes_.emplace(fusion_inp, alloc_sizes.vec());
+        input_strides_elements_.emplace(fusion_inp, alloc_strides.vec());
       }
 
       // find and push discontiguous stride

--- a/tests/cpp/test_translate_mma.cpp
+++ b/tests/cpp/test_translate_mma.cpp
@@ -412,8 +412,7 @@ INSTANTIATE_TEST_SUITE_P(
         // Tests with fusion enabled
 
         std::make_tuple(2l, 2l, true, false, false, SchedulerType::Matmul),
-        // We cannot yet handle allocation domain in matmul scheduler
-        std::make_tuple(2l, 2l, true, true, true, SchedulerType::ExprEval),
+        std::make_tuple(2l, 2l, true, true, false, SchedulerType::Matmul),
         // Size-1 input combinations
         std::make_tuple(1l, 2l, true, false, true, SchedulerType::ExprEval),
         std::make_tuple(2l, 1l, true, false, true, SchedulerType::ExprEval),
@@ -597,8 +596,7 @@ INSTANTIATE_TEST_SUITE_P(
         // Enable fusion
 
         std::make_tuple(2l, 2l, -1l, true, false, false),
-        // We cannot yet handle allocation domain in matmul scheduler
-        std::make_tuple(2l, 2l, -1l, true, true, true),
+        std::make_tuple(2l, 2l, -1l, true, true, false),
         // We don't fuse 1D inputs
         std::make_tuple(1l, 2l, -1l, true, false, true),
         // Batch dims in input


### PR DESCRIPTION
Previously we rejected matmul segments with non-trivial allocation domains. However, I believe we properly handle allocation domain now with the latest changes to the matmul scheduler. I am enabling this now so that we can run all the python benchmarks.

Note that we still reject fusions with non-trivial output allocation domains. That support is likely also working but requires more testing before we enable it I believe.