### PR TITLE
move more buffers to smem

### DIFF
--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -415,11 +415,12 @@ std::pair<int64_t, int64_t> getBufferBatchSizeAndThreadsPerBlock(
       threads_per_block *= 2;
       inner_batch = ceilDiv(after_vectorization, threads_per_block);
     }
-  }else{
+  } else {
     while (inner_batch > batch_max &&
-          threads_per_block + warp_size <= threads_per_block_max &&
-          ceilDiv(after_vectorization, threads_per_block  + warp_size) >= batch_min) {
-      threads_per_block  += warp_size;
+           threads_per_block + warp_size <= threads_per_block_max &&
+           ceilDiv(after_vectorization, threads_per_block + warp_size) >=
+               batch_min) {
+      threads_per_block += warp_size;
       inner_batch = ceilDiv(after_vectorization, threads_per_block);
     }
   }

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -1220,15 +1220,26 @@ void movePersistentBufferToSmem(
     // isSharedMemoryPersistent() twice, one for the buffer iteself and the
     // other for the buffer's input tensor if the buffer is a cached input
     // and it is not in [smem_persistent_buffers].
+    bool is_cached_input = false;
     bool use_smem = isSharedMemoryPersistent(tv);
     if (!use_smem &&
         std::find(cached_inputs.begin(), cached_inputs.end(), tv) !=
             cached_inputs.end()) {
       auto input_tv = ir_utils::producerTvsOf(tv).at(0);
       use_smem = isSharedMemoryPersistent(input_tv);
+      is_cached_input = true;
     }
     if (use_smem) {
       tv->setMemoryType(MemoryType::Shared);
+      // When loading from global memory (gmem), use CpAsync with a short data
+      // path of gmem -> smem to reduce temporary register usage. Otherwise, the
+      // data path from gmem to shared memory (smem) follows this sequence: gmem
+      // -> L1 cache -> register -> smem.
+      if (is_cached_input) {
+        tv->definition()->as<LoadStoreOp>()->setOpType(
+            LoadStoreOpType::CpAsync);
+        tv->definition()->as<LoadStoreOp>()->setCacheOp(CacheOp::Unspecified);
+      }
     }
   }
 }

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -1235,7 +1235,8 @@ void movePersistentBufferToSmem(
       // path of gmem -> smem to reduce temporary register usage. Otherwise, the
       // data path from gmem to shared memory (smem) follows this sequence: gmem
       // -> L1 cache -> register -> smem.
-      if (is_cached_input) {
+      int hw_major = at::cuda::getCurrentDeviceProperties()->major;
+      if (is_cached_input && hw_major >= 8) {
         tv->definition()->as<LoadStoreOp>()->setOpType(
             LoadStoreOpType::CpAsync);
         tv->definition()->as<LoadStoreOp>()->setCacheOp(CacheOp::Unspecified);


### PR DESCRIPTION
**In this PR**
(1) Move more buffer from registers to shared memory until their sizes are similar (For RMS norm, it has 6 bytes of cached input buffer and 8 bytes internal outer reduction buffer,equivalent to move all cached input buffers. For RMS norm, it has 6 bytes of cached input buffer and 4 bytes internal outer reduction buffer, only 4 bytes of cached input buffer is moved to shared memory)
(2) revise heuristics to set threads per block to pow2, e.g. 128 and 256. 
**Performance**
(1) Layer Norm Backward
![image](https://github.com/user-attachments/assets/ae68e86c-3f11-4bc4-b743-196f535f2724)
(2) RMS Norm Backward (batch size = 8K, for 16K hidden size is limited to about 36K where 3 smem buffer is not triggered yet)
In the first section, only 2 tvs are moved to smem, if moving all 3 tvs to smem the smem buffer size is larger than register buffer size and causes regression, e.g. perf reduced from 80% SOL to 50% SOL at hidden size 25600.
![image](https://github.com/user-attachments/assets/8290585d-7dc4-4b0c-b1cc-3d818830506b)

**Why**
(1) Async copy to smem is more efficient than regular copy, https://github.com/NVIDIA/Fuser/pull/3132 shows perf improvment when moving 3 buffers to register but not much change when only moves 1 or 2 buffers.
(2) After step-(1), layer norm backward has regression from 16K to 19K, see blue squares in the perf figure.
For case at 18K, achieved 70% SOL with 192 threads, the parallelizaiton is:
```
inner reduction inner dim: 18432 = 8(vect) x 48 (bdimx) x 4 (bdimy) x 12 (persistent)
inner reduction outer dim: 16384 = 132 (gdimy) x serial
outer reduction inner dim: 18432 = 4(vect) x 48 (bdimx) x 96 (gdimy)
outer reduciton outer dim: 132 = 4 (bdimy) x 33 (serial)
```
after revision, achieved 78% SOL with 256 threads, the parallelizaiton is:
```
inner reduction inner dim: 18432 = 8(vect) x 64 (bdimx) x 4 (bdimy) x 9 (persistent)
inner reduction outer dim: 16384 = 132 (gdimy) x serial
outer reduction inner dim: 18432 = 4(vect) x 64 (bdimx) x 72 (gdimy)
outer reduciton outer dim: 132 = 4 (bdimy) x 33 (serial)
```
The increased perf comes from higher occupancy (6 warps --> 8 warps) and lower workload per thread (12 batches --> 9 batches).