### PR TITLE
Compare cparams in MatmulParams::sameAs

### DIFF
--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -22,7 +22,7 @@ namespace nvfuser {
 class MatmulParams : public HeuristicParams {
  public:
   MatmulParams()
-      : HeuristicParams(SchedulerType::Matmul), supported_vec_size(){};
+      : HeuristicParams(SchedulerType::Matmul), supported_vec_size() {};
   //! A list of possible strategies used to define along which axis
   //!  parallelization will be done.
   enum class TileRasterizationOrder { RowMajor = 0, ColumnMajor = 1 };

--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -238,7 +238,8 @@ class MatmulParams : public HeuristicParams {
       return false;
     }
 
-    return other->mma_macro == mma_macro &&
+    return other->cparams == cparams &&
+        other->mma_macro == mma_macro &&
         other->async_gmem_load_operands == async_gmem_load_operands &&
         other->rotate_ldmatrix_out_of_main_loop ==
         rotate_ldmatrix_out_of_main_loop &&

--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -22,7 +22,7 @@ namespace nvfuser {
 class MatmulParams : public HeuristicParams {
  public:
   MatmulParams()
-      : HeuristicParams(SchedulerType::Matmul), supported_vec_size() {};
+      : HeuristicParams(SchedulerType::Matmul), supported_vec_size(){};
   //! A list of possible strategies used to define along which axis
   //!  parallelization will be done.
   enum class TileRasterizationOrder { RowMajor = 0, ColumnMajor = 1 };
@@ -238,8 +238,7 @@ class MatmulParams : public HeuristicParams {
       return false;
     }
 
-    return other->cparams == cparams &&
-        other->mma_macro == mma_macro &&
+    return other->cparams == cparams && other->mma_macro == mma_macro &&
         other->async_gmem_load_operands == async_gmem_load_operands &&
         other->rotate_ldmatrix_out_of_main_loop ==
         rotate_ldmatrix_out_of_main_loop &&


### PR DESCRIPTION
A change of index_type caused the IMA encountered in #3157. This happened because an earlier fusion was compiled with the same matmul params but Int32 index type, then it was re-used when Int was needed, causing wraparound and an illegal index.

Fixes #3157