### PR TITLE
Host irs: support MatmulOp with pre-allocated outputs

### DIFF
--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -83,6 +83,7 @@ class HostIrExecutor final : public OptOutDispatch {
   void handle(ForLoop* for_loop) override;
   void handle(StartCoalescing* start_coalescing) override;
   void handle(EndCoalescing* end_coalescing) override;
+  void handle(MatmulOp* matmul) override;
   void unhandled(Statement* stmt) override;
 
   c10::cuda::CUDAStream getCUDAStream(Stream* stream);

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -790,6 +790,44 @@ TEST_F(MatmulHostIrTest, HostIr) {
   EXPECT_TRUE(ref_output.allclose(output));
 }
 
+TEST_F(MatmulHostIrTest, HostIrMatmulOut) {
+  constexpr int64_t H = 32;
+  constexpr int64_t M = 64;
+  constexpr int64_t K = 128;
+  constexpr int64_t N = 256;
+
+  auto hic = std::make_unique<HostIrContainer>();
+  FusionGuard fg(hic.get());
+
+  TensorView* a = makeContigTensor(3);
+  TensorView* b = makeContigTensor(3);
+  TensorView* c = makeContigTensor(3);
+  auto matmul = IrBuilder::create<MatmulOp>(c, a, b);
+
+  hic->addInput(a);
+  hic->addInput(b);
+  hic->addInput(c);
+  hic->addOutput(c);
+
+  hic->pushBackTopLevelExprs(matmul);
+
+  HostIrExecutor hie(std::move(hic));
+
+  auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
+  at::Tensor a_tensor = at::randn({H, M, K}, options);
+  at::Tensor b_tensor = at::randn({H, K, N}, options);
+  at::Tensor c_tensor = at::randn({H, M, N}, options);
+  std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
+      {a, a_tensor}, {b, b_tensor}, {c, c_tensor}};
+
+  hie.runWithInput(concrete_input_buffers);
+
+  // validate
+  auto ref_output = at::matmul(a_tensor, b_tensor);
+
+  EXPECT_TRUE(ref_output.allclose(c_tensor));
+}
+
 using SelectHostIrTestParams = bool;
 using SelectHostIrTest = NVFuserFixtureParamTest<SelectHostIrTestParams>;
 

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -802,7 +802,7 @@ TEST_F(MatmulHostIrTest, HostIrMatmulOut) {
   TensorView* a = makeContigTensor(3);
   TensorView* b = makeContigTensor(3);
   TensorView* c = makeContigTensor(3);
-  auto matmul = IrBuilder::create<MatmulOp>(c, a, b);
+  auto* matmul = IrBuilder::create<MatmulOp>(c, a, b);
 
   hic->addInput(a);
   hic->addInput(b);

--- a/tests/cpp/test_multidevice_overlap.cpp
+++ b/tests/cpp/test_multidevice_overlap.cpp
@@ -297,6 +297,8 @@ TEST_F(
   TensorView* tva = makeSymbolicTensor(ta_.dim());
   TensorView* tvb = makeSymbolicTensor(tb_.dim());
   TensorView* tvc = makeSymbolicTensor(tc_.dim());
+  TensorView* tvc_locally_reduced =
+      makeSymbolicTensor(tc_locally_reduced_.dim());
   hic->addInput(tva);
   hic->addInput(tvb);
   hic->addInput(tvc);
@@ -324,9 +326,8 @@ TEST_F(
   TensorView* tva_j = select(tva, 0, j);
   TensorView* tvc_j = select(tvc, 0, j);
   TensorView* tvc_locally_reduced_j =
-      matmul(tva_j, tvb); // ideally we should use the preallocated global
-                          // buffer tc_locally_reduced, but ExpressionEvaluator
-                          // do not support preallocated output buffer.
+      select(tvc_locally_reduced, 0, stream_index);
+  auto matmul = IrBuilder::create<MatmulOp>(tvc_locally_reduced_j, tva_j, tvb);
 
   // Setting the DeviceMesh of the communication's I/O is artificial but
   // required at this point
@@ -355,6 +356,7 @@ TEST_F(
       tva_j->definition(),
       tvc_j->definition(),
       tvc_locally_reduced_j->definition(),
+      matmul,
       communication,
       wait};
   for (Expr* expr : loop_body) {
@@ -396,7 +398,10 @@ TEST_F(
        c10::irange(params.number_of_iterations)) {
     initializeIO();
     std::unordered_map<Val*, c10::IValue> inputs = {
-        {tva, ta_}, {tvb, tb_}, {tvc, tc_}};
+        {tva, ta_},
+        {tvb, tb_},
+        {tvc, tc_},
+        {tvc_locally_reduced, tc_locally_reduced_}};
 
     hie.runWithInput(std::move(inputs));
   }

--- a/tests/cpp/test_multidevice_overlap.cpp
+++ b/tests/cpp/test_multidevice_overlap.cpp
@@ -327,7 +327,7 @@ TEST_F(
   TensorView* tvc_j = select(tvc, 0, j);
   TensorView* tvc_locally_reduced_j =
       select(tvc_locally_reduced, 0, stream_index);
-  auto matmul = IrBuilder::create<MatmulOp>(tvc_locally_reduced_j, tva_j, tvb);
+  auto* matmul = IrBuilder::create<MatmulOp>(tvc_locally_reduced_j, tva_j, tvb);
 
   // Setting the DeviceMesh of the communication's I/O is artificial but
   // required at this point


### PR DESCRIPTION
# What
support pre-allocated outputs for matmul

# Why
Prerequesite for https://github.com/NVIDIA/Fuser/pull/3181, where the matmul's output needs to be stored in a slice of a global buffer.

# How 
Use`at::matmul_out` if the output is already associated with a buffer.