### PR TITLE
Allow both load and compute to be pipelined for circular buffering

### DIFF
--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -204,21 +204,21 @@ void CircularBufferInfo::setStageDepthAndPrefetchDistance(
     int64_t prefetch_distance) {
   auto concrete_loop_id = lower_utils::getConcreteLoopID(id);
 
-  auto maybe_exisiting_depth_it =
+  auto maybe_existing_depth_it =
       circular_buffer_options_.find(concrete_loop_id);
-  if (maybe_exisiting_depth_it == circular_buffer_options_.end()) {
+  if (maybe_existing_depth_it == circular_buffer_options_.end()) {
     circular_buffer_options_[concrete_loop_id].stage = stage_depth;
     circular_buffer_options_[concrete_loop_id].prefetch = prefetch_distance;
   } else {
     NVF_ERROR(
-        stage_depth == maybe_exisiting_depth_it->second.stage &&
-            prefetch_distance == maybe_exisiting_depth_it->second.prefetch,
+        stage_depth == maybe_existing_depth_it->second.stage &&
+            prefetch_distance == maybe_existing_depth_it->second.prefetch,
         "Unsupported multiple depth/prefetch pipelining, was set to (",
-        maybe_exisiting_depth_it->second.stage,
+        maybe_existing_depth_it->second.stage,
         ",",
-        maybe_exisiting_depth_it->second.prefetch,
+        maybe_existing_depth_it->second.prefetch,
         ") by ",
-        maybe_exisiting_depth_it->first->toString(),
+        maybe_existing_depth_it->first->toString(),
         " and then set to (",
         stage_depth,
         ",",

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -194,25 +194,36 @@ void CircularBufferInfo::setCircularBufferAxis(
     IterDomain* axis) {
   getTvInfo(tv).circular_buffer_axis = axis;
   // Set and validate the new stage depth.
-  setStageDepth(axis, tv->circularBufferDepth());
+  setStageDepthAndPrefetchDistance(
+      axis, tv->circularBufferDepth(), tv->circularBufferPrefetchDistance());
 }
 
-void CircularBufferInfo::setStageDepth(IterDomain* id, int64_t stage_depth) {
+void CircularBufferInfo::setStageDepthAndPrefetchDistance(
+    IterDomain* id,
+    int64_t stage_depth,
+    int64_t prefetch_distance) {
   auto concrete_loop_id = lower_utils::getConcreteLoopID(id);
 
-  auto maybe_exisiting_depth_it = stage_depth_.find(concrete_loop_id);
-  if (maybe_exisiting_depth_it == stage_depth_.end()) {
-    stage_depth_[concrete_loop_id] = stage_depth;
+  auto maybe_exisiting_depth_it =
+      circular_buffer_options_.find(concrete_loop_id);
+  if (maybe_exisiting_depth_it == circular_buffer_options_.end()) {
+    circular_buffer_options_[concrete_loop_id].stage = stage_depth;
+    circular_buffer_options_[concrete_loop_id].prefetch = prefetch_distance;
   } else {
     NVF_ERROR(
-        stage_depth == maybe_exisiting_depth_it->second,
-        "Unsupported multiple depth pipelining, was set to ",
-        maybe_exisiting_depth_it->second,
-        " by ",
+        stage_depth == maybe_exisiting_depth_it->second.stage &&
+            prefetch_distance == maybe_exisiting_depth_it->second.prefetch,
+        "Unsupported multiple depth/prefetch pipelining, was set to (",
+        maybe_exisiting_depth_it->second.stage,
+        ",",
+        maybe_exisiting_depth_it->second.prefetch,
+        ") by ",
         maybe_exisiting_depth_it->first->toString(),
-        " and then set to ",
+        " and then set to (",
         stage_depth,
-        " by ",
+        ",",
+        prefetch_distance,
+        ") by ",
         concrete_loop_id->toString());
   }
 }
@@ -230,11 +241,26 @@ int64_t CircularBufferInfo::getStageDepthFor(
     IterDomain* circular_buffer_axis) const {
   auto concrete_id = lower_utils::getConcreteLoopID(circular_buffer_axis);
 
-  auto maybe_depth_it = stage_depth_.find(concrete_id);
+  auto maybe_depth_it = circular_buffer_options_.find(concrete_id);
 
-  NVF_ERROR(maybe_depth_it != stage_depth_.end(), "Stage depth not found");
+  NVF_ERROR(
+      maybe_depth_it != circular_buffer_options_.end(),
+      "Stage depth not found");
 
-  return maybe_depth_it->second;
+  return maybe_depth_it->second.stage;
+}
+
+int64_t CircularBufferInfo::getPrefetchDistanceFor(
+    IterDomain* circular_buffer_axis) const {
+  auto concrete_id = lower_utils::getConcreteLoopID(circular_buffer_axis);
+
+  auto maybe_depth_it = circular_buffer_options_.find(concrete_id);
+
+  NVF_ERROR(
+      maybe_depth_it != circular_buffer_options_.end(),
+      "Prefetch distance not found");
+
+  return maybe_depth_it->second.prefetch;
 }
 
 ForLoop* CircularBufferInfo::getCircularBufferLoop(

--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -60,22 +60,26 @@ class CircularBufferInfo {
   //!  as a circular buffer loop.
   bool isCircularBufferedIterDomain(IterDomain* id);
 
-  //! Get the number of circular buffer stages for the given axis.
-  //! The number of stages will be 2 in the case of double buffer loop.
+  //! Get the number of circular buffer stages and the prefetch distance for the
+  //! given axis. The number of stages will be 2 in the case of double buffer
+  //! loop.
   int64_t getStageDepthFor(IterDomain* circular_buffered_id) const;
+  int64_t getPrefetchDistanceFor(IterDomain* circular_buffered_id) const;
 
  private:
   const TvInfo& getTvInfo(const TensorView* tv) const;
 
   TvInfo& getTvInfo(const TensorView* tv);
 
-  //! Set the number of circular buffer stages for the given
-  //! circular_buffered_id.
-  //!  Current code generation only supports one stage depth per loop disjoint
-  //!  set,
-  //! so this function will throw an error if trying to set different stage
-  //! numbers to iterdomains that are loop mapped.
-  void setStageDepth(IterDomain* circular_buffered_id, int64_t stage_depth);
+  //! Set the number of circular buffer stages and the prefetch distance for the
+  //! given circular_buffered_id. Current code generation only supports one
+  //! stage depth and prefetch distance per loop disjoint set, so this function
+  //! will throw an error if trying to set different stage numbers to
+  //! iterdomains that are loop mapped.
+  void setStageDepthAndPrefetchDistance(
+      IterDomain* circular_buffered_id,
+      int64_t stage_depth,
+      int64_t prefetch_distance);
 
  private:
   //! Keeps track of information for lowering circular buffered tensors
@@ -85,11 +89,12 @@ class CircularBufferInfo {
   //!  iterdomains.
   std::unordered_set<const IterDomain*> concrete_circular_buffered_loop_id_;
 
-  //! Keeps track of circular buffer loop stage depth.
+  //! Keeps track of circular buffer loop stage depth and prefetch distance.
   //! Currently for each disjoint set of loop mapped iterdomains,
-  //! Only one stage depth is supported, so that the loops can indeed
-  //! shared with the same prolog extent and main loop offset.
-  std::unordered_map<IterDomain*, int64_t> stage_depth_;
+  //! Only one stage depth and prefetch distance is supported, so that the loops
+  //! can indeed shared with the same prolog extent and main loop offset.
+  std::unordered_map<IterDomain*, CircularBufferOptions>
+      circular_buffer_options_;
 };
 
 } // namespace nvfuser

--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -149,14 +149,14 @@ IndexingParameters getLinearIndexParameters(
             GpuLower::current()->caMap()->getConcreteMappedID(
                 loop_id, IdMappingMode::EXACT);
 
-        auto stage_depth =
-            (int64_t)GpuLower::current()->circularBufferInfo().getStageDepthFor(
+        auto prefetch_distance =
+            GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
                 loop->iter_domain());
         index_parameters.initial_concrete_id_index[concrete_loop_id] =
             SimplifyingIrBuilder::addExpr(
                 index_parameters.initial_concrete_id_index[concrete_loop_id],
                 SimplifyingIrBuilder::create<Val>(
-                    stage_depth - 1L, DataType::Index));
+                    prefetch_distance, DataType::Index));
       }
     }
   }
@@ -416,9 +416,10 @@ IndexingParameters getPredicateInitialIndexParameters(
       // be true that that index has been modified to support
       // unswitch. In that case, it is not necessary to move ahead the
       // index for circular buffering.
-      auto stage_depth =
-          (int64_t)GpuLower::current()->circularBufferInfo().getStageDepthFor(
-              db_loop->iter_domain());
+      auto prefetch_distance =
+          (int64_t)GpuLower::current()
+              ->circularBufferInfo()
+              .getPrefetchDistanceFor(db_loop->iter_domain());
       bool is_same =
           (rotated_loops.count(db_loop)
                ? cur_index->sameAs(SimplifyingIrBuilder::addExpr(
@@ -428,7 +429,7 @@ IndexingParameters getPredicateInitialIndexParameters(
         loop_to_ind_map[db_loop] = SimplifyingIrBuilder::addExpr(
             cur_index,
             SimplifyingIrBuilder::create<Val>(
-                stage_depth - 1L, DataType::Index));
+                prefetch_distance, DataType::Index));
       }
     }
   }

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -668,7 +668,8 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         // here, except for the initial load part, which is taken care
         // separately by CircularBufferInserter.
         if (tv->getMemoryType() == MemoryType::Shared &&
-            !tv->isCircularBuffered()) {
+            (!tv->isCircularBuffered() ||
+             tv->circularBufferPrefetchDistance() == 0)) {
           smem[tv] = expr;
 
           // only keep track of async writes in smem_async

--- a/csrc/id_model/circular_buffer_indexing.cpp
+++ b/csrc/id_model/circular_buffer_indexing.cpp
@@ -80,9 +80,9 @@ Val* getLoopIndexOffsetForProducerOfCircularBuffer(
     return nullptr;
   }
 
-  auto stage_depth = (int64_t)info.getStageDepthFor(for_loop->iter_domain());
+  auto prefetch_distance = info.getPrefetchDistanceFor(for_loop->iter_domain());
 
-  return IrBuilder::create<Val>(stage_depth - 1L, DataType::Index);
+  return IrBuilder::create<Val>(prefetch_distance, DataType::Index);
 }
 
 Val* getOffsetForCircularBufferTensor(
@@ -115,6 +115,9 @@ Val* getOffsetForCircularBufferTensor(
   const auto stage_depth =
       (int64_t)gpu_lower->circularBufferInfo().getStageDepthFor(
           circular_buffer_loop->iter_domain());
+  const auto prefetch_distance =
+      gpu_lower->circularBufferInfo().getPrefetchDistanceFor(
+          circular_buffer_loop->iter_domain());
 
   // If this appears as a consumer, it should be either prologue or
   // main. If it's producer, it should be main or epilogue
@@ -135,7 +138,7 @@ Val* getOffsetForCircularBufferTensor(
   if (as_consumer && is_main) {
     offset = SimplifyingIrBuilder::addExpr(
         offset,
-        SimplifyingIrBuilder::create<Val>(stage_depth - 1, DataType::Index));
+        SimplifyingIrBuilder::create<Val>(prefetch_distance, DataType::Index));
   }
 
   // Add "offset % num_stages", except when it's in prologue

--- a/csrc/id_model/predicate_indexing.cpp
+++ b/csrc/id_model/predicate_indexing.cpp
@@ -248,12 +248,13 @@ std::unordered_map<Val*, Val*> getPredicateIndexReplacementMap(
     if (fl->circularBufferLoopStage() == CircularBufferLoopStage::Prolog) {
       return nullptr;
     } else {
-      auto stage_depth =
-          (int64_t)GpuLower::current()->circularBufferInfo().getStageDepthFor(
+      auto prefetch_distance =
+          GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
               fl->iter_domain());
       return SimplifyingIrBuilder::addExpr(
           original_index,
-          SimplifyingIrBuilder::create<Val>(stage_depth - 1L, DataType::Index));
+          SimplifyingIrBuilder::create<Val>(
+              prefetch_distance, DataType::Index));
     }
   };
 

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1167,9 +1167,6 @@ indexMapFromTV(
     }
 
     if (loop == circular_buffer_loop) {
-      const int64_t stage_depth =
-          GpuLower::current()->circularBufferInfo().getStageDepthFor(
-              loop->iter_domain());
       const int64_t prefetch_distance =
           GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
               loop->iter_domain());

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1170,9 +1170,13 @@ indexMapFromTV(
       const int64_t stage_depth =
           GpuLower::current()->circularBufferInfo().getStageDepthFor(
               loop->iter_domain());
+      const int64_t prefetch_distance =
+          GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
+              loop->iter_domain());
       idx = SimplifyingIrBuilder::addExpr(
           idx,
-          SimplifyingIrBuilder::create<Val>(stage_depth - 1L, DataType::Index));
+          SimplifyingIrBuilder::create<Val>(
+              prefetch_distance, DataType::Index));
     }
 
     loop_to_ind_map[loop] = idx;
@@ -2031,6 +2035,9 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
         consumer_tv, loops);
     int64_t stage_depth = gpu_lower->circularBufferInfo().getStageDepthFor(
         db_loop->iter_domain());
+    int64_t prefetch_distance =
+        gpu_lower->circularBufferInfo().getPrefetchDistanceFor(
+            db_loop->iter_domain());
     bool is_circular_buffer_loop = stage_depth > 2;
     bool is_prolog =
         db_loop->circularBufferLoopStage() == CircularBufferLoopStage::Prolog;
@@ -2061,7 +2068,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
             SimplifyingIrBuilder::addExpr(
                 loop_index,
                 SimplifyingIrBuilder::create<Val>(
-                    stage_depth - 1, DataType::Index)),
+                    prefetch_distance, DataType::Index)),
             SimplifyingIrBuilder::create<Val>(stage_depth, DataType::Index));
       }
 

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -499,8 +499,9 @@ class NVF_API TensorView : public Val {
 
   void setMemoryType(MemoryType mt);
 
-  // Apply circular buffering transformation
-  void circularBuffer(int64_t number_of_stages, int64_t prefetch_distance=-1);
+  // Apply circular buffering transformation. Negative prefetch_distance
+  // means "all but", for example, -1 means number_of_stages - 1.
+  void circularBuffer(int64_t number_of_stages, int64_t prefetch_distance = -1);
 
   // Returns true if this tensor is circular buffered.
   bool isCircularBuffered() const {

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -112,8 +112,7 @@ TensorView::TensorView(const TensorView* src, IrCloner* ir_cloner)
       compute_at_pos_(src->compute_at_pos_),
       max_producer_pos_(src->max_producer_pos_),
       memory_type_(src->memory_type_),
-      is_circular_buffered_(src->is_circular_buffered_),
-      circular_buffer_stage_(src->circular_buffer_stage_),
+      circular_buffer_options_(src->circular_buffer_options_),
       cpu_scalar_(src->cpu_scalar_),
       has_swizzle_op_(src->has_swizzle_op_),
       compute_with_consumers_(ir_cloner->clone(src->compute_with_consumers_)),
@@ -1318,14 +1317,22 @@ void TensorView::clearReductionIterDomains() {
   }
 }
 
-void TensorView::circularBuffer(int64_t number_of_stages) {
+void TensorView::circularBuffer(
+    int64_t number_of_stages,
+    int64_t prefetch_distance) {
   // Early correctness checking. May miss eventual errors as the
   // checks depend on memory types and parallelization, which may not
   // be finalized until lowering.
-  NVF_ERROR(number_of_stages > 1, "Unsupported stage number");
+  NVF_CHECK(number_of_stages > 1, "Unsupported stage number");
+  if (prefetch_distance < 0) {
+    prefetch_distance += number_of_stages;
+  }
+  NVF_CHECK(
+      prefetch_distance >= 0 && prefetch_distance < number_of_stages,
+      "Invalid prefetch distance");
   validateCircularBufferedTensor(this);
-  is_circular_buffered_ = true;
-  circular_buffer_stage_ = number_of_stages;
+  circular_buffer_options_.stage = number_of_stages;
+  circular_buffer_options_.prefetch = prefetch_distance;
 }
 
 bool TensorView::isEmptyTensor() const {

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -815,8 +815,8 @@ auto StagesAndPrefetches() {
 }
 
 std::string nonTMAName(const testing::TestParamInfo<StageAndPrefetch>& info) {
-  return "stage_" + std::to_string(info.param.first) +
-      "_prefetch_" + std::to_string(info.param.second);
+  return "stage_" + std::to_string(info.param.first) + "_prefetch_" +
+      std::to_string(info.param.second);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1775,10 +1775,10 @@ auto tmaCircularBufferingParams() {
 
 std::string tmaName(
     const testing::TestParamInfo<TmaCircularBufferingParams>& info) {
-  return "stage_" + std::to_string(std::get<0>(info.param)) +
-      "_prefetch_" + std::to_string(std::get<1>(info.param)) +
-      "_M_" + std::to_string(std::get<2>(info.param)) +
-      "_N_" + std::to_string(std::get<3>(info.param));
+  return "stage_" + std::to_string(std::get<0>(info.param)) + "_prefetch_" +
+      std::to_string(std::get<1>(info.param)) + "_M_" +
+      std::to_string(std::get<2>(info.param)) + "_N_" +
+      std::to_string(std::get<3>(info.param));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -15,12 +15,16 @@
 
 namespace nvfuser {
 
-class CircularBufferingTest : public NVFuserFixtureParamTest<int> {
+using StageAndPrefetch = std::pair<int64_t, int64_t>;
+
+class CircularBufferingTest : public NVFuserFixtureParamTest<StageAndPrefetch> {
  protected:
   int64_t number_of_stages = 1;
+  int64_t prefetch_distance = 1;
 
   void SetUp() override {
-    number_of_stages = GetParam();
+    number_of_stages = std::get<0>(GetParam());
+    prefetch_distance = std::get<1>(GetParam());
     NVFuserTest::SetUp();
   }
 };
@@ -55,7 +59,7 @@ TEST_P(CircularBufferingTest, SingleDim1) {
   tv3->axis(-1)->parallelize(ParallelType::TIDx);
   scheduler_utils::parallelizeAllLike(tv3);
 
-  tv1->circularBuffer(number_of_stages);
+  tv1->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({1000}, options);
@@ -103,7 +107,7 @@ TEST_P(CircularBufferingTest, SingleDim2) {
   tv3->axis(-1)->parallelize(ParallelType::TIDx);
   scheduler_utils::parallelizeAllLike(tv3);
 
-  tv1->circularBuffer(number_of_stages);
+  tv1->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({1000}, options);
@@ -150,12 +154,12 @@ TEST_P(CircularBufferingTest, SingleDim3) {
   // tv2 is invalid to circular-buffer as its producer, tv1, is
   // computed inside the circular-buffering loop.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(tv2->circularBuffer(number_of_stages));
+  ASSERT_ANY_THROW(tv2->circularBuffer(number_of_stages, prefetch_distance));
 
   // Moving tv2 inner makes tv1 large enough to circular-buffer tv2
   tv2->computeAt(tv3, 2);
 
-  tv2->circularBuffer(number_of_stages);
+  tv2->circularBuffer(number_of_stages, prefetch_distance);
 
   tv3->axis(-1)->parallelize(ParallelType::TIDx);
   scheduler_utils::parallelizeAllLike(tv3);
@@ -210,7 +214,7 @@ TEST_P(CircularBufferingTest, SingleDimUnswitch1) {
   tv3->axis(1)->parallelize(ParallelType::Unswitch);
   scheduler_utils::parallelizeAllLike(tv3);
 
-  tv2->circularBuffer(number_of_stages);
+  tv2->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({1000}, options);
@@ -262,7 +266,7 @@ TEST_P(CircularBufferingTest, SingleDimUnswitch2) {
   tv2->axis(1)->parallelize(ParallelType::Unswitch);
   scheduler_utils::parallelizeAllLike(tv2);
 
-  tv1->circularBuffer(number_of_stages);
+  tv1->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({1000}, options);
@@ -316,7 +320,7 @@ TEST_P(CircularBufferingTest, SingleDimUnroll) {
   tv3->axis(2)->parallelize(ParallelType::Unroll);
   tv3->axis(4)->parallelize(ParallelType::TIDx);
 
-  tv2->circularBuffer(number_of_stages);
+  tv2->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({199}, options);
@@ -363,7 +367,7 @@ TEST_P(CircularBufferingTest, SingleDimVectorize) {
 
   tv1->axis(-1)->parallelize(ParallelType::Vectorize);
 
-  tv1->circularBuffer(number_of_stages);
+  tv1->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({200}, options);
@@ -413,8 +417,8 @@ TEST_P(CircularBufferingTest, MultipleTensors) {
   tv4->axis(-1)->parallelize(ParallelType::TIDx);
   scheduler_utils::parallelizeAllLike(tv4);
 
-  tv2->circularBuffer(number_of_stages);
-  tv3->circularBuffer(number_of_stages);
+  tv2->circularBuffer(number_of_stages, prefetch_distance);
+  tv3->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({500}, options);
@@ -465,8 +469,8 @@ TEST_P(CircularBufferingTest, NestedTensors) {
   out->axis(-1)->parallelize(ParallelType::TIDx);
   scheduler_utils::parallelizeAllLike(out);
 
-  tv2->circularBuffer(number_of_stages);
-  tv3->circularBuffer(number_of_stages);
+  tv2->circularBuffer(number_of_stages, prefetch_distance);
+  tv3->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({1001}, options);
@@ -550,11 +554,11 @@ TEST_P(CircularBufferingTest, SmemBlockGemmCache) {
 
   scheduler_utils::parallelizeAllLike(tv5);
 
-  tv0_cache_local->circularBuffer(number_of_stages);
-  tv1_cache_local->circularBuffer(number_of_stages);
+  tv0_cache_local->circularBuffer(number_of_stages, prefetch_distance);
+  tv1_cache_local->circularBuffer(number_of_stages, prefetch_distance);
 
-  tv0_cache_smem->circularBuffer(number_of_stages);
-  tv1_cache_smem->circularBuffer(number_of_stages);
+  tv0_cache_smem->circularBuffer(number_of_stages, prefetch_distance);
+  tv1_cache_smem->circularBuffer(number_of_stages, prefetch_distance);
 
   constexpr int M = 154, K = 45, N = 1524;
 
@@ -614,7 +618,7 @@ TEST_P(CircularBufferingTest, Vector) {
   tv1cr->computeAt(tv2c, 2);
 
   tv1cw->setMemoryType(MemoryType::Shared);
-  tv1cr->circularBuffer(number_of_stages);
+  tv1cr->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
@@ -668,7 +672,7 @@ TEST_P(CircularBufferingTest, CpAsync1) {
   tv2->axis(-1)->parallelize(ParallelType::TIDx);
 
   // circular buffer the shared mem tensor.
-  tv0_shared->circularBuffer(number_of_stages);
+  tv0_shared->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({m, n}, options);
@@ -721,7 +725,7 @@ TEST_P(CircularBufferingTest, CpAsync2) {
   tv2->axis(-2)->parallelize(ParallelType::TIDx);
 
   // circular buffer the shared mem tensor.
-  tv0_shared->circularBuffer(number_of_stages);
+  tv0_shared->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({m, n}, options);
@@ -775,7 +779,7 @@ TEST_P(CircularBufferingTest, NoSync) {
   tv2->axis(-2)->parallelize(ParallelType::TIDx);
 
   // circular buffer the shared mem tensor.
-  tv0_shared->circularBuffer(number_of_stages);
+  tv0_shared->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({m, n}, options);
@@ -800,24 +804,43 @@ TEST_P(CircularBufferingTest, NoSync) {
 }
 
 // Test circular buffer from 2 to 10 stages
+auto StagesAndPrefetches() {
+  std::vector<StageAndPrefetch> values;
+  for (int64_t i : c10::irange(2, 10)) {
+    for (int64_t j : c10::irange(i)) {
+      values.emplace_back(i, j);
+    }
+  }
+  return testing::ValuesIn(values);
+}
+
+std::string nonTMAName(const testing::TestParamInfo<StageAndPrefetch>& info) {
+  return "stage_" + std::to_string(info.param.first) +
+      "_prefetch_" + std::to_string(info.param.second);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     NonTma,
     CircularBufferingTest,
-    ::testing::Range(2, 10));
+    StagesAndPrefetches(),
+    nonTMAName);
 
-using TmaCircularBufferingParams = std::tuple<int, int, int>;
+using TmaCircularBufferingParams =
+    std::tuple<int64_t, int64_t, int64_t, int64_t>;
 
 class TmaCircularBufferingTest
     : public NVFuserFixtureParamTest<TmaCircularBufferingParams> {
  protected:
   int64_t number_of_stages = 1;
+  int64_t prefetch_distance = 1;
   int64_t tensor_outer_dim = 1;
   int64_t tensor_inner_dim = 1;
 
   void SetUp() override {
     number_of_stages = std::get<0>(GetParam());
-    tensor_outer_dim = std::get<1>(GetParam());
-    tensor_inner_dim = std::get<2>(GetParam());
+    prefetch_distance = std::get<1>(GetParam());
+    tensor_outer_dim = std::get<2>(GetParam());
+    tensor_inner_dim = std::get<3>(GetParam());
 
     // NOTE: Multiple of 16 required for inner dimension
     NVF_ERROR(tensor_inner_dim % 16 == 0);
@@ -988,7 +1011,7 @@ TEST_P(TmaCircularBufferingTest, SingleDim) {
   tv1->axis(-1)->parallelize(ParallelType::TIDx);
 
   // Circular Buffer with TMA loads
-  tv2->circularBuffer(number_of_stages);
+  tv2->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({tensor_inner_dim}, options);
@@ -1041,7 +1064,7 @@ TEST_P(TmaCircularBufferingTest, SingleDimUnroll) {
 
   // Circular Buffer with TMA loads
   tv2->axis(-1)->parallelize(ParallelType::Bulk);
-  tv2->circularBuffer(number_of_stages);
+  tv2->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({tensor_inner_dim}, options);
@@ -1101,7 +1124,7 @@ TEST_P(TmaCircularBufferingTest, SingleDimUnswitch) {
 
   // Circular Buffer with TMA loads
   tv2->axis(-1)->parallelize(ParallelType::Bulk);
-  tv2->circularBuffer(number_of_stages);
+  tv2->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({tensor_inner_dim}, options);
@@ -1171,7 +1194,7 @@ TEST_P(TmaCircularBufferingTest, MultiDim) {
   tv2->axis(0)->parallelize(ParallelType::BIDx);
   tv2->axis(-1)->parallelize(ParallelType::Bulk);
   tv2->axis(-2)->parallelize(ParallelType::Bulk);
-  tv2->circularBuffer(number_of_stages);
+  tv2->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::ones({tensor_outer_dim, tensor_inner_dim}, options);
@@ -1223,11 +1246,11 @@ TEST_P(TmaCircularBufferingTest, Pointwise) {
   // Circular Buffer with TMA loads
   tv3->axis(0)->parallelize(ParallelType::BIDx);
   tv3->axis(2)->parallelize(ParallelType::Bulk);
-  tv3->circularBuffer(number_of_stages);
+  tv3->circularBuffer(number_of_stages, prefetch_distance);
 
   // Circular Buffer with set operation
   tv4->axis(0)->parallelize(ParallelType::BIDx);
-  tv4->circularBuffer(number_of_stages);
+  tv4->circularBuffer(number_of_stages, prefetch_distance);
 
   // Split reference to parallelize TMA tile
   reference->split(-1, 32);
@@ -1288,13 +1311,13 @@ TEST_P(TmaCircularBufferingTest, PointwiseCpAsync) {
   // Circular Buffer with TMA loads
   tv3->axis(0)->parallelize(ParallelType::BIDx);
   tv3->axis(2)->parallelize(ParallelType::Bulk);
-  tv3->circularBuffer(number_of_stages);
+  tv3->circularBuffer(number_of_stages, prefetch_distance);
 
   // Circular Buffer with set operation
   tv4->axis(0)->parallelize(ParallelType::BIDx);
   // TODO Disable circular buffering for CpAsync
   // Circular buffering handles cpAsync sync logic separate from cloner logic.
-  // tv4->circularBuffer(number_of_stages);
+  // tv4->circularBuffer(number_of_stages, prefetch_distance);
 
   // Split reference to parallelize TMA tile
   reference->split(-1, 32);
@@ -1358,7 +1381,7 @@ TEST_P(TmaCircularBufferingTest, Reduction) {
   // Circular Buffer with TMA loads
   tv2->axis(0)->parallelize(ParallelType::BIDx);
   tv2->axis(-1)->parallelize(ParallelType::Bulk);
-  tv2->circularBuffer(number_of_stages);
+  tv2->circularBuffer(number_of_stages, prefetch_distance);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({tensor_outer_dim, tensor_inner_dim}, options);
@@ -1482,7 +1505,7 @@ TEST_P(TmaCircularBufferingTest, Persistent) {
   // Apply circular buffer after computeAt
   x_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
   if (examples_per_cta > 1) {
-    x_cache_smem->circularBuffer(number_of_stages);
+    x_cache_smem->circularBuffer(number_of_stages, prefetch_distance);
   }
 
   auto options = at::TensorOptions().dtype(dtype).device(at::kCUDA, 0);
@@ -1598,11 +1621,11 @@ TEST_P(TmaCircularBufferingTest, Matmul) {
   inlineMost();
 
   // Apply circular buffering after setting computeAt position
-  tv0_cache_local->circularBuffer(number_of_stages);
-  tv1_cache_local->circularBuffer(number_of_stages);
+  tv0_cache_local->circularBuffer(number_of_stages, prefetch_distance);
+  tv1_cache_local->circularBuffer(number_of_stages, prefetch_distance);
 
-  tv0_cache_smem->circularBuffer(number_of_stages);
-  tv1_cache_smem->circularBuffer(number_of_stages);
+  tv0_cache_smem->circularBuffer(number_of_stages, prefetch_distance);
+  tv1_cache_smem->circularBuffer(number_of_stages, prefetch_distance);
 
   constexpr int64_t K = 1024;
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -1713,11 +1736,11 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   inlineMost();
 
   // Apply circular buffering after setting computeAt position
-  tv0_cache_local->circularBuffer(number_of_stages);
-  tv1_cache_local->circularBuffer(number_of_stages);
+  tv0_cache_local->circularBuffer(number_of_stages, prefetch_distance);
+  tv1_cache_local->circularBuffer(number_of_stages, prefetch_distance);
 
-  tv0_cache_smem->circularBuffer(number_of_stages);
-  tv1_cache_smem->circularBuffer(number_of_stages);
+  tv0_cache_smem->circularBuffer(number_of_stages, prefetch_distance);
+  tv1_cache_smem->circularBuffer(number_of_stages, prefetch_distance);
 
   constexpr int64_t K = 1024;
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -1736,12 +1759,32 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
 }
 
 // Test circular buffer from 2 to 5 stages
+auto tmaCircularBufferingParams() {
+  std::vector<TmaCircularBufferingParams> values;
+  for (int64_t i : c10::irange(2, 5)) {
+    for (int64_t j : c10::irange(i)) {
+      for (int64_t m : {128, 500, 1024}) {
+        for (int64_t n : {128, 1024}) {
+          values.emplace_back(i, j, m, n);
+        }
+      }
+    }
+  }
+  return testing::ValuesIn(values);
+}
+
+std::string tmaName(
+    const testing::TestParamInfo<TmaCircularBufferingParams>& info) {
+  return "stage_" + std::to_string(std::get<0>(info.param)) +
+      "_prefetch_" + std::to_string(std::get<1>(info.param)) +
+      "_M_" + std::to_string(std::get<2>(info.param)) +
+      "_N_" + std::to_string(std::get<3>(info.param));
+}
+
 INSTANTIATE_TEST_SUITE_P(
     Hopper,
     TmaCircularBufferingTest,
-    testing::Combine(
-        ::testing::Range(2, 5),
-        testing::Values(128, 500, 1024),
-        testing::Values(128, 1024)));
+    tmaCircularBufferingParams(),
+    tmaName);
 
 } // namespace nvfuser

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -807,7 +807,7 @@ TEST_P(CircularBufferingTest, NoSync) {
 auto StagesAndPrefetches() {
   std::vector<StageAndPrefetch> values;
   for (int64_t i : c10::irange(2, 10)) {
-    for (int64_t j : c10::irange(i)) {
+    for (int64_t j : c10::irange(-i, i)) {
       values.emplace_back(i, j);
     }
   }
@@ -815,8 +815,15 @@ auto StagesAndPrefetches() {
 }
 
 std::string nonTMAName(const testing::TestParamInfo<StageAndPrefetch>& info) {
+  auto prefetch_distance = std::get<1>(info.param);
+  std::string prefetch_distance_str;
+  if (prefetch_distance < 0) {
+    prefetch_distance_str = "neg" + std::to_string(-prefetch_distance);
+  } else {
+    prefetch_distance_str = std::to_string(prefetch_distance);
+  }
   return "stage_" + std::to_string(info.param.first) + "_prefetch_" +
-      std::to_string(info.param.second);
+      prefetch_distance_str;
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1762,7 +1769,7 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
 auto tmaCircularBufferingParams() {
   std::vector<TmaCircularBufferingParams> values;
   for (int64_t i : c10::irange(2, 5)) {
-    for (int64_t j : c10::irange(i)) {
+    for (int64_t j : c10::irange(-i, i)) {
       for (int64_t m : {128, 500, 1024}) {
         for (int64_t n : {128, 1024}) {
           values.emplace_back(i, j, m, n);
@@ -1775,10 +1782,16 @@ auto tmaCircularBufferingParams() {
 
 std::string tmaName(
     const testing::TestParamInfo<TmaCircularBufferingParams>& info) {
+  auto prefetch_distance = std::get<1>(info.param);
+  std::string prefetch_distance_str;
+  if (prefetch_distance < 0) {
+    prefetch_distance_str = "neg" + std::to_string(-prefetch_distance);
+  } else {
+    prefetch_distance_str = std::to_string(prefetch_distance);
+  }
   return "stage_" + std::to_string(std::get<0>(info.param)) + "_prefetch_" +
-      std::to_string(std::get<1>(info.param)) + "_M_" +
-      std::to_string(std::get<2>(info.param)) + "_N_" +
-      std::to_string(std::get<3>(info.param));
+      prefetch_distance_str + "_M_" + std::to_string(std::get<2>(info.param)) +
+      "_N_" + std::to_string(std::get<3>(info.param));
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Today, a circular-buffered Hopper MMA kernel looks like below (assuming 4 stages):

```python
# prologue
for i in range(3):
    load to A_buffer[i];
    load to B_buffer[i];
# main loop
for i in range(N):
    load to A_buffer[(i + 3) % 4];
    load to B_buffer[(i + 3) % 4];
    wait for A_buffer[i % 4] and B_buffer[i % 4] to be ready;
    mma(A_buffer[i % 4], B_buffer[i % 4]);
    wait for mma to complete
# epilogue
for i in range(N-3, N):
    wait for A_buffer[i % 4] and B_buffer[i % 4] to be ready;
    mma(A_buffer[i % 4], B_buffer[i % 4]);
    wait for mma to complete
```

Note that the `wait for mma to complete` in the main loop is mandatory, because at the next iteration, TMA will write to the operands of the mma operation in the current iteration, and the wait in the end of the current iteration is to avoid WAR hazard. Due to this wait, we are actually using mma as a synchronous op because we sync immediately after the mma instruction being fired. Not taking advantage of the async nature of mma means that it could be hard to make the TensorCore full.

This PR adds an additional parameter `prefetch` to have better control of our circular buffering behavior. Currently, we always allocate `stage * tile_size` buffer size, and prefetch `stage - 1` tiles in the prologue. With this PR, we still allocate `stage * tile_size` buffer size, but we will prefetch `prefetch` tiles in the prologue. `prefetch` can range from `0` to `stage - 1`. If `prefetch == 0`, this means we do not prefetch at all. `prefetch == stage - 1` would reproduce the current behavior, therefore is the default value. For the case where `prefetch < stage - 1`, the operand of the MMA in each iteration will not be overwritten by the next iteration, therefore no WAR hazard, and we can defer the wait of mma a few iterations away, allowing MMA to be pipelined.

I would consider `prefetch` as a slide bar between `0` and `stage - 1`, adjusting the partition of the entire `stage * tile_size` into "buffers to remove WAR hazard" and "buffers to remove RAW hazard". Sliding to the left most means "the entire buffer is used for removing WAR", and sliding to the right most means "the entire buffer is used for removing RAW". During schedule, we should adjust this slide bar to achieve the best performance.

I haven't looked deep into the impact on Hopper matmul perf. Just did a quick experiment, and I was able to push our perf to 58% of cuBLAS. Please note that this PR alone will not benefit Hopper matmul perf, because we always generate `wgmma.wait_group 0` (which means to wait untill 0 pending mma ops). A followup-PR will update this value according to `prefetch` and `stage`.