### PR TITLE
clear_dynamo_cache in rms norm bwd baseline

### DIFF
--- a/benchmarks/python/test_rmsnorm_bwd.py
+++ b/benchmarks/python/test_rmsnorm_bwd.py
@@ -92,8 +92,6 @@ def test_rmsnorm_bwd_nvf_benchmark(
     eps: float = 1e-5,
 ):
     clear_cuda_cache()
-    if compile:
-        clear_dynamo_cache()
     inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
@@ -125,7 +123,8 @@ def test_rmsnorm_bwd_baseline_benchmark(
     compile: bool,
 ):
     clear_cuda_cache()
-
+    if compile:
+        clear_dynamo_cache()
     inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)


### PR DESCRIPTION
Should apply `clear_dynamo_cache()` in baseline benchmark.