### PR TITLE
Deduplicate tensor_sizes and shape.

### DIFF
--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1738,17 +1738,6 @@ TensorView* expand_as(TensorView* inp, TensorView* other) {
   return out_tensor;
 }
 
-std::vector<Val*> tensor_sizes(TensorView* inp) {
-  auto iter_domains = TensorDomain::noReductions(inp->getLogicalDomain());
-  std::vector<Val*> sizes(iter_domains.size(), nullptr);
-
-  for (auto idx : c10::irange(iter_domains.size())) {
-    sizes[idx] = iter_domains[idx]->getMaybeExpandedExtent();
-  }
-
-  return sizes;
-}
-
 std::vector<Val*> shape(TensorView* inp) {
   auto iter_domains = TensorDomain::noReductions(inp->getLogicalDomain());
   std::vector<Val*> shape;

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -429,10 +429,6 @@ NVF_API TensorView* expand(
 // non broadcasted iter domain, inp will be expanded to other's size.
 NVF_API TensorView* expand_as(TensorView* inp, TensorView* other);
 
-// This is a function used to give the symbolic sizes of a tensor for use
-// with functions like broadcast_in_size that take in a vector of sizes
-// to use to expand an input tensor
-NVF_API std::vector<Val*> tensor_sizes(TensorView* inp);
 // This is a function used to give the symbolic shape of a tensor for use
 // with functions like broadcast_in_dim that take a shape vector
 // to use to expand an input tensor

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #pragma once
+
 #include <c10/util/complex.h>
 #include <debug.h>
 #include <exceptions.h>
@@ -2377,7 +2378,7 @@ struct TensorSizesRecord : RecordFunctor {
 
   void operator()(FusionState& fd) final {
     auto arg = fd.getFusionState(args_.at(0).index)->as<TensorView>();
-    auto sizes = tensor_sizes(arg);
+    auto sizes = shape(arg);
     for (const auto idx : c10::irange(sizes.size())) {
       fd.setFusionState(outputs_.at(idx).index, sizes[idx]);
     }

--- a/tests/cpp/test_dynamic_transform.cpp
+++ b/tests/cpp/test_dynamic_transform.cpp
@@ -1090,7 +1090,7 @@ TEST_F(NVFuserTest, DynamicTransformIssue418_CUDA) {
   auto s0 = IrBuilder::create<Val>(DataType::Int);
   fusion->addInput(s0);
 
-  auto sh = tensor_sizes(tv0);
+  auto sh = shape(tv0);
   auto tv1 = reshape(tv0, {sh[0], div(sh[1], s0), s0, sh[2], sh[3]});
   // Reducing along axis 2 in tv1 is equivalent to a partial reduction across
   // axis 1 of tv0.


### PR DESCRIPTION
They have the same implementation -- not sure why they have co-existed. I prefer `shape` because it's shorter. To reduce blast radius, I only removed `tensor_sizes` from the C++ APIs. The python API, `fd.ops.tensor_sizes`, remains the same. 