### PR TITLE
Remove bit_cast to convert MmaMacroEncode to uint64_t

### DIFF
--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -16,9 +16,6 @@
 #include <cstring>
 #include <ostream>
 
-#if IS_CPP20
-#include <bit>
-#endif
 #include <cstdint>
 
 namespace nvfuser {

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -98,12 +98,18 @@ struct MmaMacroEncode {
         (uint64_t)k;
   }
 
-  constexpr operator MmaMacro();
+  constexpr operator MmaMacro() {
+    return static_cast<MmaMacro>(static_cast<uint64_t>(*this));
+  }
 
-  constexpr MmaMacroEncode(MmaMacro macro);
+  constexpr MmaMacroEncode(MmaMacro macro)
+      : arch(Arch(toUnderlying(macro) >> 48)),
+        m((toUnderlying(macro) >> 32) & 0xFFFF),
+        n((toUnderlying(macro) >> 16) & 0xFFFF),
+        k(toUnderlying(macro) & 0xFFFF) {}
 
-  constexpr MmaMacroEncode(Arch arch, unsigned m, unsigned n, unsigned k)
-      : arch(arch), m(m), n(n), k(k) {}
+  constexpr MmaMacroEncode(Arch arch_, uint16_t m_, uint16_t n_, uint16_t k_)
+      : arch(arch_), m(m_), n(n_), k(k_) {}
 };
 
 static_assert(sizeof(MmaMacroEncode) == sizeof(uint64_t));
@@ -167,29 +173,6 @@ enum class MmaMacro : uint64_t {
 };
 
 #undef MACRO
-
-constexpr MmaMacroEncode::operator MmaMacro() {
-#if IS_CPP20 && !defined(__clang__)
-  // std::bit_cast for bit field is not supported by clang yet
-  return std::bit_cast<MmaMacro>(*this);
-#else
-  return static_cast<MmaMacro>(static_cast<uint64_t>(*this));
-#endif
-}
-
-constexpr MmaMacroEncode::MmaMacroEncode(MmaMacro macro)
-#if IS_CPP20 && !defined(__clang__)
-{
-  // std::bit_cast for bit field is not supported by clang yet
-  *this = std::bit_cast<MmaMacroEncode>(macro);
-}
-#else
-    : arch((Arch)(toUnderlying(macro) >> 48)),
-      m((toUnderlying(macro) >> 32) & 0xFFFF),
-      n((toUnderlying(macro) >> 16) & 0xFFFF),
-      k(toUnderlying(macro) & 0xFFFF) {
-}
-#endif
 
 //! [Operand Layout Convention]
 //! Operand layout, T=transposed/row_major, N=normal/col_major

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -88,19 +88,14 @@ struct MatMulTileOptions {
 enum class MmaMacro : uint64_t;
 
 struct MmaMacroEncode {
-  enum class Arch { NoMma, Volta, Turing, Ampere, Hopper } arch : 16;
-  unsigned m : 16;
-  unsigned n : 16;
-  unsigned k : 16;
+  enum class Arch : uint16_t { NoMma, Volta, Turing, Ampere, Hopper } arch;
+  uint16_t m;
+  uint16_t n;
+  uint16_t k;
 
   constexpr operator uint64_t() {
-#if IS_CPP20 && !defined(__clang__)
-    // std::bit_cast for bit field is not supported by clang yet
-    return std::bit_cast<uint64_t>(*this);
-#else
     return (uint64_t)arch << 48 | (uint64_t)m << 32 | (uint64_t)n << 16 |
         (uint64_t)k;
-#endif
   }
 
   constexpr operator MmaMacro();


### PR DESCRIPTION
This standardizes how we convert `MmaMacroEncode` to `uint64_t`. Doing this with a bitcast actually gives us UB because we are not guaranteed to have the given order for struct fields defined as bitfields. I first noticed this was happening when using a `libnvfuser.so` compiled as C++20 with another project linking against that was compiled using C++17. In that case, the compilation and linking worked properly, but we wound up with garbage for the `MmaMacro`. I think this PR will address this kind of issue.