### PR TITLE
Ignore reduction axes in inputs for bcast+squeeze analysis

### DIFF
--- a/csrc/preseg_passes/remove_bcast_squeeze.cpp
+++ b/csrc/preseg_passes/remove_bcast_squeeze.cpp
@@ -93,7 +93,9 @@ bool isReplaceableExpr(Expr* expr) {
 AxisOps setToAxisOps(LoadStoreOp* ldst) {
   NVF_ERROR(isSimpleTVSet(ldst));
   return AxisOps(
-      ldst->in()->as<TensorView>()->getLogicalDomain().size(),
+      TensorDomain::noReductions(
+          ldst->in()->as<TensorView>()->getLogicalDomain())
+          .size(),
       AxisOp::PRESERVE);
 }
 


### PR DESCRIPTION
This fixes an error seen in `mpirun -np 6 test_multidevice --gtest_filter=PipelineTest.Pipeline` which requires a six-GPU system.