### PR TITLE
Fix Issue 3117

### DIFF
--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -194,10 +194,10 @@ void FusionDefinition::verifyTensorDimensions() {
   NVF_CHECK(id().has_value(), "Invalid fusion id!");
 
   std::vector<Tensor> all_tensors = tensors();
-  for (Tensor& t : all_tensors) {
+  for (const Tensor& t : all_tensors) {
     Val* v = getFusionState(t.index);
-    NVF_ERROR(v->isA<TensorView>());
-    int64_t tv_ndims = v->as<TensorView>()->nDims();
+    NVF_ERROR(v->isA<TensorView>(), v->toString());
+    const int64_t tv_ndims = v->as<TensorView>()->nDims();
     NVF_ERROR(
         tv_ndims == (int64_t)t.dims,
         "Expected TensorView to have same number of dimensions as Tensor but got: ",

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -197,11 +197,11 @@ void FusionDefinition::verifyTensorDimensions() {
   for (Tensor& t : all_tensors) {
     Val* v = getFusionState(t.index);
     NVF_ERROR(v->isA<TensorView>());
-    TensorView* tv = v->as<TensorView>();
+    int64_t tv_ndims = v->as<TensorView>()->nDims();
     NVF_ERROR(
-        tv->nDims() == (int64_t)t.dims,
+        tv_ndims == (int64_t)t.dims,
         "Expected TensorView to have same number of dimensions as Tensor but got: ",
-        tv->nDims(),
+        tv_ndims,
         " and ",
         t.dims);
   }

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -264,6 +264,9 @@ class NVF_API FusionDefinition : public FusionState {
   //! Update Symbolic FusionStates after DynamicTransform pass
   void updateSymbolicStates(
       const std::unordered_map<Val*, Val*>& symbolic_to_concretized_map);
+  // Check that the NvFuser TensorView and the Python Tensor dimensions match.
+  // Apply after buildFusionIr
+  void verifyTensorDimensions();
 
   //! Holds the defined maximum length of a FusionDefinition in order to
   //! prevent a run away error. The user should feel free to increase this

--- a/tests/python/test_alias.py
+++ b/tests/python/test_alias.py
@@ -9,7 +9,7 @@ from utils import NVFuserTest
 
 
 class TestAlias(NVFuserTest):
-    def test_squeeze(self):
+    def test_squeeze_issue_3192(self):
         def fusion_func(fd: FusionDefinition):
             inp = fd.define_tensor([1, 1, 2], contiguity=True)
             out = fd.ops.squeeze(inp, [0, 1])


### PR DESCRIPTION
Fixes #3117 

This PR creates `verifyTensorDimensions` to check that `Tensor.dims` equals the rank of the corresponding `TensorView`. It is called in `FusionDefinition::finalizeDefinition` after `buildFusionIr`.
