### PR TITLE
Transformer benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,7 @@ if(BUILD_TEST)
   set(MULTIDEVICE_TEST_SRCS)
   list(APPEND MULTIDEVICE_TEST_SRCS
     ${NVFUSER_ROOT}/tests/cpp/multidevice.cpp
+    ${NVFUSER_ROOT}/tests/cpp/multidevice_transformer.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_overlap.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_communications.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_communicator.cpp
@@ -761,6 +762,46 @@ if(BUILD_NVFUSER_BENCHMARK)
       -Wall -Wno-unused-function
       -Werror -Wno-deprecated-copy
     )
+  endif()
+
+  # multidevice benchmarks
+  if (NVFUSER_DISTRIBUTED)
+    set(MULTIDEVICE_BENCHMARK_SRCS)
+    list(APPEND MULTIDEVICE_BENCHMARK_SRCS
+      ${NVFUSER_ROOT}/benchmarks/cpp/transformer.cpp
+      ${NVFUSER_ROOT}/tests/cpp/multidevice_transformer.cpp
+      ${NVFUSER_ROOT}/tests/cpp/utils.cpp
+    )
+
+    add_executable(nvfuser_multidevice_bench ${MULTIDEVICE_BENCHMARK_SRCS})
+    set_target_properties(nvfuser_multidevice_bench PROPERTIES
+      C_STANDARD ${NVFUSER_C_STANDARD}
+      CUDA_STANDARD ${NVFUSER_CUDA_STANDARD}
+      CXX_STANDARD ${NVFUSER_CPP_STANDARD}
+      CXX_STANDARD_REQUIRED ON
+      CXX_VISIBILITY_PRESET hidden
+      POSITION_INDEPENDENT_CODE Yes
+      VISIBILITY_INLINES_HIDDEN Yes
+    )
+
+    target_include_directories(nvfuser_multidevice_bench SYSTEM PRIVATE
+      ${CMAKE_SOURCE_DIR}/third_party/benchmark/include
+      ${CMAKE_SOURCE_DIR}/third_party/flatbuffers/include
+      ${CMAKE_SOURCE_DIR}/third_party/googletest/googletest/include
+    )
+    target_include_directories(nvfuser_multidevice_bench PUBLIC ${NVFUSER_ROOT})
+    target_link_libraries(nvfuser_multidevice_bench PRIVATE
+      benchmark::benchmark
+      codegen_internal
+    )
+    add_dependencies(nvfuser_multidevice_bench flatc build_flatbuffer_config)
+
+    if(NOT MSVC)
+    target_compile_options(nvfuser_bench PRIVATE
+      -Wall -Wno-unused-function
+      -Werror -Wno-deprecated-copy
+    )
+    endif()
   endif()
 endif()
 

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -1,0 +1,219 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <nvToolsExt.h>
+#include <cuda_profiler_api.h>
+
+#include <fusion.h>
+#include <ops/all_ops.h>
+#include <utils.h>
+#include <multidevice/utils.h>
+#include <benchmarks/cpp/utils.h>
+#include <tests/cpp/utils.h>
+#include <tests/cpp/multidevice.h>
+#include <tests/cpp/multidevice_transformer.h>
+
+using namespace nvfuser;
+
+constexpr int64_t B = 1, E = 12288, H = 96, S = 2048;
+constexpr double kParamScale = 0.02;
+constexpr int64_t warmup_itrs = 10, num_itrs = 10;
+
+at::Tensor shardTensor(
+    at::Tensor tensor,
+    int64_t axis,
+    const DeviceMesh& mesh,
+    Communicator* communicator_) {
+  const auto device_id = communicator_->deviceId();
+  auto i = mesh.idxOf(device_id);
+  auto extent = tensor.size(axis);
+  auto nslices = mesh.size();
+  NVF_CHECK(
+      extent % nslices == 0, "Sharded axis must be evenly divisble by mesh");
+  auto stride = extent / nslices;
+  i = (i < 0) ? 0 : i;
+  auto slice = tensor.slice(axis, i * stride, (i + 1) * stride).contiguous();
+  // Temporary until https://github.com/NVIDIA/Fuser/issues/2563. Adds DIDx
+  // axis in front representing the sharded extent of the tensor.
+  if (stride > 1) {
+    slice = slice.unsqueeze(0);
+  }
+  return slice;
+}
+
+void forward_transformer(Communicator* communicator_, bool profile) {
+  int64_t D = communicator_->size();
+  auto dtype = DataType::BFloat16;
+  at::ScalarType at_dtype = data_type_to_aten(dtype);
+  const auto mesh = DeviceMesh::createForNumDevices(D);
+  const auto options =
+      at::TensorOptions().dtype(at_dtype).device(communicator_->device());
+
+  auto x_ = at::randn({B * S, E}, options).to(at::kFloat);
+  auto ln0_w_ = at::randn(E, options).to(at::kFloat);
+  auto ln0_b_ = at::randn(E, options).to(at::kFloat);
+  auto mha_w0_ = at::randn({3 * E, E}, options) * kParamScale;
+  auto mha_b0_ = at::randn({3 * E}, options) * kParamScale;
+  auto mha_w1_ = at::randn({E, E}, options) * kParamScale;
+  auto mha_b1_ = at::randn({E}, options) * kParamScale;
+  auto ln1_w_ = at::randn(E, options).to(at::kFloat);
+  auto ln1_b_ = at::randn(E, options).to(at::kFloat);
+  auto mlp_w0_ = at::randn({4 * E, E}, options) * kParamScale;
+  auto mlp_b0_ = at::randn({4 * E}, options) * kParamScale;
+  auto mlp_w1_ = at::randn({E, 4 * E}, options) * kParamScale;
+  auto mlp_b1_ = at::randn({E}, options) * kParamScale;
+
+  std::vector<c10::IValue> inputs = {
+      x_,
+      ln0_w_,
+      ln0_b_,
+      shardTensor(mha_w0_.view({3, E, E}), 1, mesh, communicator_).view({1, 3 * E / D, E}),
+      shardTensor(mha_b0_.view({3, E}), 1, mesh, communicator_).view({1, 3 * E / D}),
+      shardTensor(mha_w1_, 1, mesh, communicator_),
+      mha_b1_,
+      ln1_w_,
+      ln1_b_,
+      shardTensor(mlp_w0_, 0, mesh, communicator_),
+      shardTensor(mlp_b0_, 0, mesh, communicator_),
+      shardTensor(mlp_w1_, 1, mesh, communicator_),
+      mlp_b1_};
+
+  DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
+  auto fec = model.forward(dtype);
+  cudaSetDevice(communicator_->deviceId());
+
+  auto start = std::chrono::high_resolution_clock::now();
+  for (auto i : c10::irange(num_itrs + warmup_itrs)) {
+    if (i == warmup_itrs) {
+      start = std::chrono::high_resolution_clock::now();
+      if (profile) {
+        cudaProfilerStart();
+      }
+    }
+    if (i >= warmup_itrs && profile) {
+      nvtxRangePush(("Iteration" + std::to_string(i)).c_str());
+    }
+    auto outputs = fec->runFusionWithInputs(inputs);
+    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize is not blocking until kernels are finished on all devices except 0
+    // TODO: are we not waiting until all kernels are appended to the stream?
+    std::cout << outputs[0][0][0] << std::endl; 
+
+    if (i > warmup_itrs && profile) {
+      nvtxRangePop();
+    }
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+
+  double foward_time = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() / (double) num_itrs / 1000.0;
+  std::cout << communicator_->deviceId() << ": Average forward time " << foward_time << "ms" << std::endl;
+}
+
+void backward_transformer(Communicator* communicator_, bool profile) {
+  auto dtype = DataType::BFloat16;
+  at::ScalarType at_dtype = data_type_to_aten(dtype);
+  int64_t D = communicator_->size();
+  const auto mesh = DeviceMesh::createForNumDevices(D);
+
+  const auto options =
+      at::TensorOptions().dtype(at_dtype).device(communicator_->device());
+  auto x_ = at::randn({B * S, E}, options).to(at::kFloat);
+  auto ln0_w_ = at::randn(E, options).to(at::kFloat);
+  auto ln0_b_ = at::randn(E, options).to(at::kFloat);
+  auto mha_w0_ = at::randn({3 * E, E}, options) * kParamScale;
+  auto mha_b0_ = at::randn({3 * E}, options) * kParamScale;
+  auto mha_w1_ = at::randn({E, E}, options) * kParamScale;
+  auto mha_b1_ = at::randn({E}, options) * kParamScale;
+  auto ln1_w_ = at::randn(E, options).to(at::kFloat);
+  auto ln1_b_ = at::randn(E, options).to(at::kFloat);
+  auto mlp_w0_ = at::randn({4 * E, E}, options) * kParamScale;
+  auto mlp_b0_ = at::randn({4 * E}, options) * kParamScale;
+  auto grad_ = at::randn({B * S, E}, options).to(at::kFloat) * kParamScale;
+  auto mlp_w1_ = at::randn({E, 4 * E}, options) * kParamScale;
+  auto mlp_b1_ = at::randn({E}, options) * kParamScale;
+
+  // Recomputed tensors
+  auto mlp_dropout_mask = at::rand({B * S, E}, options).lt(1.0 - 0.1);
+  auto mha_dropout_mask = at::rand({B * S, E}, options).lt(1.0 - 0.1);
+  auto sdpa_output = at::randn({B, H, S, E/H}, options);
+  auto sdpa_logsum_exp = at::randn({B, H, S}, options).to(at::kFloat);
+  auto sdpa_seed = at::scalar_tensor(1, at::kLong);
+  auto sdpa_offset = at::scalar_tensor(1, at::kLong);
+  auto ln0_mean = at::randn({B*S, 1}, options).to(at::kFloat);
+  auto ln0_rstd = at::randn({B*S, 1}, options).to(at::kFloat);
+  auto ln1_mean = at::randn({B*S, 1}, options).to(at::kFloat);
+  auto ln1_rstd = at::randn({B*S, 1}, options).to(at::kFloat);
+  auto mha_linear1 = at::rand({B*S, E}, options).to(at::kFloat);
+
+  std::vector<c10::IValue> inputs = {
+      x_,
+      grad_,
+      shardTensor(mha_w0_.view({3, E, E}), 1, mesh, communicator_).view({1, 3 * E / D, E}),
+      shardTensor(mha_b0_.view({3, E}), 1, mesh, communicator_).view({1, 3 * E / D}),
+      shardTensor(mha_w1_, 1, mesh, communicator_),
+      shardTensor(mlp_w0_, 0, mesh, communicator_),
+      shardTensor(mlp_b0_, 0, mesh, communicator_),
+      shardTensor(mlp_w1_, 1, mesh, communicator_),
+      mlp_b1_,
+      mlp_dropout_mask,
+      mha_dropout_mask,
+      shardTensor(sdpa_output, 1, mesh, communicator_),
+      shardTensor(sdpa_logsum_exp, 1, mesh, communicator_),
+      sdpa_seed,
+      sdpa_offset,
+      ln1_w_,
+      ln1_b_,
+      ln1_mean,
+      ln1_rstd,
+      ln0_w_,
+      ln0_b_,
+      ln0_mean,
+      ln0_rstd,
+      mha_linear1
+  };
+
+  DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
+  auto fec = model.backward(dtype);
+  std::vector<at::Tensor> outputs;
+
+  cudaSetDevice(communicator_->deviceId());
+  auto start = std::chrono::high_resolution_clock::now();
+  for (auto i : c10::irange(num_itrs + warmup_itrs)) {
+    if (i == warmup_itrs) {
+      start = std::chrono::high_resolution_clock::now();
+    }
+    if (i >= warmup_itrs && profile) {
+      nvtxRangePush(("Iteration" + std::to_string(i)).c_str());
+    }
+    outputs = fec->runFusionWithInputs(inputs);
+    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize is not blocking until kernels are finished on all devices except 0
+    // TODO: are we not waiting until all kernels are appended to the stream?
+    std::cout << outputs[0][0][0][0] << std::endl; 
+
+    if (i > warmup_itrs && profile) {
+      nvtxRangePop();
+    }
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  if (profile) {
+    cudaProfilerStop();
+  }
+
+  double backward_time = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() / (double) num_itrs / 1000.0;
+  std::cout << communicator_->deviceId() << ": Average backward time " << backward_time << "ms" << std::endl;
+
+}
+
+int main(int argc, char** argv) {
+  // using this is as a flag for when to profile
+  bool profile = argc > 1;
+  auto communicator_ = &Communicator::getInstance();
+  forward_transformer(communicator_, profile);
+  communicator_->barrier();
+  backward_transformer(communicator_, profile);
+}

--- a/tests/cpp/multidevice_transformer.cpp
+++ b/tests/cpp/multidevice_transformer.cpp
@@ -1,0 +1,616 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <vector>
+
+#include <fusion.h>
+#include <ops/all_ops.h>
+#include <tests/cpp/multidevice.h>
+#include <tests/cpp/multidevice_transformer.h>
+
+namespace nvfuser {
+namespace {
+// TODO: These linear_backwards helper functions can be merged once
+// we do not have logically split rfactor domain.
+struct LinearBackwardsResult {
+  TensorView* grad_x;
+  TensorView* grad_w;
+  TensorView* grad_b;
+};
+
+// x format: [i0, i1] dtype
+// weight format: [DID(D), i2/D, i1] dtype
+// grad format: [DID(D) i0, i2/D] float or dtype
+// outputs: grad_x [i0, i1] dtype
+// grad_w [DID i2/D, i1] dtype
+// grad_b [DID i2/2] float
+LinearBackwardsResult linear_backwards(
+    TensorView* x,
+    TensorView* w,
+    TensorView* grad) {
+  DataType dtype = w->dtype();
+  TensorView* grad_f = maybeCastOp(DataType::Float, grad);
+  TensorView* grad_q = maybeCastOp(dtype, grad);
+  TensorView* grad_x_partials = matmul(grad_q, w);
+  TensorView* grad_x = sum(grad_x_partials, {0}); // allreduce
+  TensorView* grad_q_t = transpose(grad_q, 1, 2);
+  TensorView* grad_w = matmul(grad_q_t, x);
+  TensorView* grad_b = sum(grad_f, {1});
+
+  return {grad_x, grad_w, grad_b};
+}
+
+// x format: [DID, i0, i1/D] dtype
+// weight format: [DID, i2, i1/D] dtype
+// grad format: [i0, i2] float
+// outputs: grad_x [DID i0, i1/D] dtype
+// grad_w [DID, i2,  i1/D] dtype
+// grad_b [i2] float
+LinearBackwardsResult sharded_linear_backwards(
+    TensorView* x,
+    TensorView* w,
+    TensorView* grad) {
+  DataType dtype = w->dtype();
+  TensorView* grad_q = castOp(dtype, grad);
+  TensorView* grad_x = matmul(grad_q, w);
+  TensorView* grad_t = transpose(grad_q, 0, 1);
+  TensorView* grad_w = matmul(grad_t, x);
+  TensorView* grad_b = sum(grad, {0});
+
+  return {grad_x, grad_w, grad_b};
+}
+
+// Forward layer_norm with cached mean_bcast and invstd tensors to avoid
+// recomputing Welford. For use in backwards pass.
+TensorView* layer_norm_with_cached_statistics(
+    TensorView* x,
+    TensorView* mean_bcast,
+    TensorView* invstd,
+    const std::vector<int64_t>& norm_shape,
+    TensorView* weight,
+    TensorView* bias) {
+  const int64_t kNumberOfDims =
+      (int64_t)TensorDomain::noReductions(x->getLogicalDomain()).size();
+  const int64_t kOuterNumDims = kNumberOfDims - norm_shape.size();
+  std::vector<bool> outer_broadcast_mask(kNumberOfDims, false);
+  for (const auto idx : c10::irange(kOuterNumDims)) {
+    outer_broadcast_mask[idx] = true;
+  }
+
+  auto x_sub_mean = sub(x, mean_bcast);
+  auto y = mul(x_sub_mean, invstd);
+
+  auto weight_bcast = broadcast(weight, outer_broadcast_mask);
+  y = mul(y, weight_bcast);
+  auto bias_bcast = broadcast(bias, outer_broadcast_mask);
+  return add(y, bias_bcast);
+}
+} // namespace
+
+std::vector<TensorView*> DistributedTransformer::mlp(
+    TensorView* x,
+    TensorView* w0,
+    TensorView* b0,
+    TensorView* w1,
+    TensorView* b1,
+    const DeviceMesh& mesh) {
+  const DataType dtype = w0->dtype();
+  // // Linear 0
+  TensorView* linear0 = linear(x, w0, b0);
+  // GeLU
+  TensorView* gelu = tanh_gelu(castOp(DataType::Float, linear0));
+  gelu = castOp(dtype, gelu);
+  // Linear 1
+  TensorView* local_matmul1 = matmul(gelu, transpose(w1, 1, 2));
+  TensorView* matmul1 = sum(local_matmul1, {0}); // Allreduce
+  TensorView* linear1 = add(matmul1, broadcast(b1, {true, false}));
+  // Dropout
+  Val* prob = IrBuilder::create<Val>(1.0 - kDropoutProb);
+  Val* scale = IrBuilder::create<Val>(1.0 / (1.0 - kDropoutProb));
+  auto dropout_result = dropout(linear1, prob, scale).output;
+
+  // Manual sharding annotations
+  for (auto tv : {x, b1, linear1, dropout_result}) {
+    tv->setDeviceMesh(mesh);
+  }
+  for (auto tv : {w0, b0, w1, linear0, gelu}) {
+    tv->setDeviceMesh(mesh);
+    tv->axis(0)->parallelize(ParallelType::DIDx);
+  }
+
+  return {linear0, gelu, linear1, dropout_result};
+}
+
+MHAQKVResult DistributedTransformer::mha_qkv(
+    TensorView* x,
+    TensorView* w0,
+    TensorView* b0,
+    const DeviceMesh& mesh) {
+  DataType dtype = w0->dtype();
+  const auto D = w0->axis(0)->extent()->value().as<int64_t>();
+  TensorView* linear0 = linear(x, w0, b0);
+  TensorView* linear0_float = castOp(DataType::Float, linear0);
+  // Forming the q,k,v vectors:
+  TensorView* qkv_cat =
+      reshape(linear0_float, {D, B * S, 3 * E / D}, {D, B, S, 3 * E / D});
+  std::vector<TensorView*> qkv = chunk(qkv_cat, 3, -1);
+  for (auto i : c10::irange(3)) {
+    qkv[i] = reshape(qkv[i], {D, B, S, E / D}, {D, B, S, H / D, E / H});
+    qkv[i] = transpose(qkv[i], 2, 3);
+    qkv[i] = castOp(dtype, qkv[i]);
+    // Explicitly shard q, k, and v before calling SDPA node
+    qkv[i]->setDeviceMesh(mesh);
+    qkv[i]->axis(0)->parallelize(ParallelType::DIDx);
+  }
+  return {linear0, qkv};
+}
+
+std::vector<TensorView*> DistributedTransformer::mha(
+    TensorView* x,
+    TensorView* w0,
+    TensorView* b0,
+    TensorView* w1,
+    TensorView* b1,
+    const DeviceMesh& mesh) {
+  const auto D = w0->axis(0)->extent()->value().as<int64_t>();
+  auto dtype = w0->dtype();
+  // Linear 0 + q, k, v vector formation
+  auto qkv_results = mha_qkv(x, w0, b0, mesh);
+  auto linear0 = qkv_results.linear0;
+  // SDPA
+  SdpfaFwdResult sdpa = sdpfa_fwd(
+      qkv_results.qkv[0],
+      qkv_results.qkv[1],
+      qkv_results.qkv[2],
+      IrBuilder::create<Val>(kSdpaProb),
+      IrBuilder::create<Val>(true),
+      IrBuilder::create<Val>(kSdpaScale));
+  TensorView* sdpa_output = sdpa.output;
+  // Linear 1
+  TensorView* sdpa_transpose = transpose(sdpa_output, 2, 3);
+  TensorView* sdpa_reshape =
+      reshape(sdpa_transpose, {D, B, S, H / D, E / H}, {D, B * S, E / D});
+  TensorView* local_matmul1 = matmul(sdpa_reshape, transpose(w1, 1, 2));
+  local_matmul1 = castOp(DataType::Float, local_matmul1);
+  TensorView* matmul1 = sum(local_matmul1, {0}); // allreduce
+  TensorView* linear1 = add(matmul1, broadcast(b1, {true, false}));
+  // Dropout
+  Val* prob = IrBuilder::create<Val>(1.0 - kDropoutProb);
+  Val* scale = IrBuilder::create<Val>(1.0 / (1.0 - kDropoutProb));
+  auto dropout_result = dropout(linear1, prob, scale).output;
+
+  for (auto tv : {x, b1, matmul1, linear1, dropout_result}) {
+    tv->setDeviceMesh(mesh);
+  }
+  for (auto tv : {w0, b0, w1, linear0, sdpa_output}) {
+    tv->setDeviceMesh(mesh);
+    tv->axis(0)->parallelize(ParallelType::DIDx);
+  }
+  return {linear0, sdpa_output, linear1, dropout_result};
+}
+
+std::vector<TensorView*> DistributedTransformer::mlp_backwards(
+    TensorView* grad,
+    TensorView* x,
+    TensorView* mask,
+    TensorView* w0,
+    TensorView* b0,
+    TensorView* w1,
+    const DeviceMesh& mesh,
+    TensorView* linear0,
+    TensorView* gelu) {
+  DataType dtype = w0->dtype();
+  if (linear0 == nullptr) {
+    linear0 = linear(x, w0, b0);
+  }
+  if (gelu == nullptr) {
+    gelu = castOp(dtype, tanh_gelu(castOp(DataType::Float, linear0)));
+  }
+
+  // Backwards pass
+  constexpr double kScale = 1.0 / (1.0 - kDropoutProb);
+  Val* dropout_scale = IrBuilder::create<Val>(kScale);
+  TensorView* dropout_grad = dropout_backward(grad, mask, dropout_scale);
+
+  auto linear1_grads = sharded_linear_backwards(gelu, w1, dropout_grad);
+
+  TensorView* matmul1_grad_x_ = castOp(DataType::Float, linear1_grads.grad_x);
+  TensorView* gelu_grad = tanh_gelu_backward(matmul1_grad_x_, linear0);
+
+  auto linear0_grads = linear_backwards(x, w0, gelu_grad);
+
+  // Manaul sharding annotations
+  for (auto tv :
+       {x,
+        grad,
+        mask,
+        dropout_grad,
+        linear1_grads.grad_b,
+        linear0_grads.grad_x}) {
+    tv->setDeviceMesh(mesh);
+  }
+
+  for (auto tv :
+       {w0,
+        b0,
+        w1,
+        linear1_grads.grad_x,
+        linear1_grads.grad_w,
+        gelu_grad,
+        linear0_grads.grad_w,
+        linear0_grads.grad_b}) {
+    tv->setDeviceMesh(mesh);
+    tv->axis(0)->parallelize(ParallelType::DIDx);
+  }
+
+  std::vector<TensorView*> outputs = {
+      dropout_grad,
+      linear1_grads.grad_w,
+      linear1_grads.grad_b,
+      gelu_grad,
+      linear0_grads.grad_w,
+      linear0_grads.grad_b,
+      linear0_grads.grad_x};
+  return outputs;
+}
+
+std::vector<TensorView*> DistributedTransformer::mha_backwards(
+    TensorView* x,
+    TensorView* w0,
+    TensorView* b0,
+    TensorView* w1,
+    TensorView* mask,
+    TensorView* sdpa_output,
+    TensorView* sdpa_log_sumexp,
+    TensorView* sdpa_seed,
+    TensorView* sdpa_offset,
+    TensorView* grad,
+    const std::vector<TensorView*>& qkv,
+    const DeviceMesh& mesh) {
+  DataType dtype = w0->dtype();
+  const auto D = w0->axis(0)->extent()->value().as<int64_t>();
+  // dropout backwards
+  constexpr double kScale = 1.0 / (1.0 - kDropoutProb);
+  auto dropout_scale = IrBuilder::create<Val>(kScale);
+  TensorView* dropout_grad = dropout_backward(grad, mask, dropout_scale);
+
+  // linear1 backwards
+  TensorView* sdpa_output_reshape =
+      transpose(sdpa_output, 2, 3);
+  sdpa_output_reshape =
+      reshape(sdpa_output_reshape, {D, B, S, H / D, E / H}, {D, B * S, E / D});
+  auto linear1_grads =
+      sharded_linear_backwards(sdpa_output_reshape, w1, dropout_grad);
+
+  // SDPA backwards
+  TensorView* linear1_x_grad =
+      reshape(linear1_grads.grad_x, {D, B * S, E / D}, {D, B, S, H / D, E / H});
+  linear1_x_grad = transpose(linear1_x_grad, 2, 3);
+  // Explicitly shard inputs before SDPA backward node
+  for (auto tv : {linear1_x_grad, sdpa_output, sdpa_log_sumexp}) {
+    tv->setDeviceMesh(mesh);
+    tv->axis(0)->parallelize(ParallelType::DIDx);
+  }
+  auto sdpa_grad = sdpfa_bwd(
+      linear1_x_grad,
+      qkv[0],
+      qkv[1],
+      qkv[2],
+      sdpa_output,
+      sdpa_log_sumexp,
+      /*dropout_p=*/IrBuilder::create<Val>(kSdpaProb),
+      /*is_causal=*/IrBuilder::create<Val>(true),
+      sdpa_seed,
+      sdpa_offset,
+      /*scale=*/IrBuilder::create<Val>(kSdpaScale));
+
+  TensorView* q_grad = transpose(sdpa_grad.grad_query, 2, 3);
+  q_grad = reshape(q_grad, {D, B, S, H / D, E / H}, {D, B * S, E / D});
+  TensorView* v_grad = transpose(sdpa_grad.grad_value, 2, 3);
+  v_grad = reshape(v_grad, {D, B, S, H / D, E / H}, {D, B * S, E / D});
+  TensorView* k_grad = transpose(sdpa_grad.grad_key, 2, 3);
+  k_grad = reshape(k_grad, {D, B, S, H / D, E / H}, {D, B * S, E / D});
+  TensorView* kqv_grad = cat({k_grad, q_grad, v_grad}, -1);
+  auto linear0_grads = linear_backwards(x, w0, kqv_grad);
+
+  for (auto tv :
+       {x,
+        mask,
+        grad,
+        dropout_grad,
+        linear1_grads.grad_b,
+        linear0_grads.grad_x}) {
+    tv->setDeviceMesh(mesh);
+  }
+  for (auto tv :
+       {w0,
+        b0,
+        w1,
+        sdpa_output,
+        linear1_grads.grad_x,
+        linear1_grads.grad_w,
+        linear0_grads.grad_w,
+        linear0_grads.grad_b,
+        sdpa_grad.grad_query,
+        sdpa_grad.grad_key,
+        sdpa_grad.grad_value}) {
+    tv->setDeviceMesh(mesh);
+    tv->axis(0)->parallelize(ParallelType::DIDx);
+  }
+  return {
+      dropout_grad,
+      linear1_grads.grad_w,
+      linear1_grads.grad_b,
+      sdpa_grad.grad_query,
+      sdpa_grad.grad_key,
+      sdpa_grad.grad_value,
+      linear0_grads.grad_w,
+      linear0_grads.grad_b,
+      linear0_grads.grad_x};
+}
+
+std::unique_ptr<FusionExecutorCache> DistributedTransformer::forward(
+    DataType dtype) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  const auto mesh = DeviceMesh::createForNumDevices(D);
+
+  TensorView* x = makeContigConcreteTensor({B * S, E}, DataType::Float);
+  TensorView* ln0_w = makeContigTensor(1);
+  TensorView* ln0_b = makeContigTensor(1);
+  TensorView* mha_w0 = makeContigConcreteTensor({D, 3 * E / D, E}, dtype);
+  TensorView* mha_b0 = makeContigConcreteTensor({D, 3 * E / D}, dtype);
+  TensorView* mha_w1 = makeContigConcreteTensor({D, E, E / D}, dtype);
+  TensorView* mha_b1 = makeContigConcreteTensor({E}, dtype);
+  TensorView* ln1_w = makeContigTensor(1);
+  TensorView* ln1_b = makeContigTensor(1);
+  TensorView* mlp_w0 = makeContigTensor(3, dtype);
+  TensorView* mlp_b0 = makeContigTensor(2, dtype);
+  TensorView* mlp_w1 = makeContigTensor(3, dtype);
+  TensorView* mlp_b1 = makeContigTensor(1, dtype);
+
+  fusion->addInput(x);
+  fusion->addInput(ln0_w);
+  fusion->addInput(ln0_b);
+  fusion->addInput(mha_w0);
+  fusion->addInput(mha_b0);
+  fusion->addInput(mha_w1);
+  fusion->addInput(mha_b1);
+  fusion->addInput(ln1_w);
+  fusion->addInput(ln1_b);
+  fusion->addInput(mlp_w0);
+  fusion->addInput(mlp_b0);
+  fusion->addInput(mlp_w1);
+  fusion->addInput(mlp_b1);
+
+  constexpr float kEps = 1e-5;
+  auto eps = IrBuilder::create<Val>(kEps);
+  std::vector<int64_t> norm_shape{E};
+
+  auto ln0 = layer_norm(x, norm_shape, ln0_w, ln0_b, eps);
+  auto mha_in = castOp(dtype, ln0.output);
+  auto mha_out = mha(mha_in, mha_w0, mha_b0, mha_w1, mha_b1, mesh)[3];
+  auto resid0 = add(x, mha_out);
+  auto ln1 = layer_norm(resid0, norm_shape, ln1_w, ln1_b, eps);
+  auto mlp_in = castOp(dtype, ln1.output);
+  auto mlp_out = mlp(mlp_in, mlp_w0, mlp_b0, mlp_w1, mlp_b1, mesh)[3];
+  auto resid1 = add(resid0, mlp_out);
+
+  fusion->addOutput(ln0.output);
+  fusion->addOutput(mha_out);
+  fusion->addOutput(ln1.output);
+  fusion->addOutput(mlp_out);
+  fusion->addOutput(resid1);
+
+  for (auto tv : {x, ln0.output, ln1.output, resid1}) {
+    tv->setDeviceMesh(mesh);
+  }
+
+  shardBetween({mha_in->definition()}, {mha_out->definition()}, mha_w0);
+  shardBetween({mlp_in->definition()}, {mlp_out->definition()}, mlp_w0);
+  shardBetween({x}, {mha_in}, x);
+
+  return std::make_unique<FusionExecutorCache>(std::move(fusion));
+}
+
+std::unique_ptr<FusionExecutorCache> DistributedTransformer::backward(
+    DataType dtype) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  const auto mesh = DeviceMesh::createForNumDevices(D);
+  std::vector<int64_t> norm_shape{E};
+
+  TensorView* x = makeContigConcreteTensor({B * S, E});
+  TensorView* grad = makeContigTensor(2);
+  TensorView* mha_w0 = makeContigConcreteTensor({D, 3 * E / D, E}, dtype);
+  TensorView* mha_b0 = makeContigConcreteTensor({D, 3 * E / D}, dtype);
+  TensorView* mha_w1 = makeContigConcreteTensor({D, E, E / D}, dtype);
+  TensorView* mlp_w0 = makeContigTensor(3, dtype);
+  TensorView* mlp_b0 = makeContigTensor(2, dtype);
+  TensorView* mlp_w1 = makeContigTensor(3, dtype);
+  TensorView* mlp_b1 = makeContigTensor(1, dtype);
+  TensorView* mha_mask = makeContigTensor(2, DataType::Bool);
+  TensorView* mlp_mask = makeContigTensor(2, DataType::Bool);
+  TensorView* mha_sdpa_out = makeConcreteTensor({D, B, H / D, S, E / H}, dtype);
+  TensorView* mha_sdpa_log_sumexp =
+      makeContigConcreteTensor({D, B, H / D, S}, DataType::Float);
+  TensorView* mha_sdpa_seed = makeSymbolicTensor({}, DataType::Int);
+  TensorView* mha_sdpa_offset = makeSymbolicTensor({}, DataType::Int);
+  TensorView* ln1_w = makeContigTensor(1);
+  TensorView* ln1_b = makeContigTensor(1);
+  TensorView* ln1_mean = makeConcreteTensor({B * S, 1});
+  TensorView* ln1_rstd = makeConcreteTensor({B * S, 1});
+  TensorView* ln0_w = makeContigTensor(1);
+  TensorView* ln0_b = makeContigTensor(1);
+  TensorView* ln0_mean = makeConcreteTensor({B * S, 1});
+  TensorView* ln0_rstd = makeConcreteTensor({B * S, 1});
+  TensorView* mha_linear1 = makeContigTensor(2);
+
+  fusion->addInput(x);
+  fusion->addInput(grad);
+  fusion->addInput(mha_w0);
+  fusion->addInput(mha_b0);
+  fusion->addInput(mha_w1);
+  fusion->addInput(mlp_w0);
+  fusion->addInput(mlp_b0);
+  fusion->addInput(mlp_w1);
+  fusion->addInput(mlp_b1);
+  fusion->addInput(mlp_mask);
+  fusion->addInput(mha_mask);
+  fusion->addInput(mha_sdpa_out);
+  fusion->addInput(mha_sdpa_log_sumexp);
+  fusion->addInput(mha_sdpa_seed);
+  fusion->addInput(mha_sdpa_offset);
+  fusion->addInput(ln1_w);
+  fusion->addInput(ln1_b);
+  fusion->addInput(ln1_mean);
+  fusion->addInput(ln1_rstd);
+  fusion->addInput(ln0_w);
+  fusion->addInput(ln0_b);
+  fusion->addInput(ln0_mean);
+  fusion->addInput(ln0_rstd);
+  fusion->addInput(mha_linear1);
+
+  // Recomputation: Recompute, mha linear0, qkv, mlp linear0, and mlp gelu.
+  // Partially recompute layer norms using cached statistics.
+  // Note: The thunder trace recompute mha linear1, but this would result in 3
+  // AllReduces in the backwards pass.
+  auto ln_0 = layer_norm_with_cached_statistics(
+      x, ln0_mean, ln0_rstd, norm_shape, ln0_w, ln0_b);
+  auto mha_in = castOp(dtype, ln_0);
+  auto qkv = mha_qkv(mha_in, mha_w0, mha_b0, mesh).qkv;
+
+  Val* dropout_scale = IrBuilder::create<Val>(1.0 / (1.0 - kDropoutProb));
+  // Use input mha_mask to implement dropout
+  auto mha_out = mul(mha_linear1, mha_mask);
+  mha_out = mul(mha_out, dropout_scale);
+  auto resid_0 = add(x, mha_out);
+  auto ln_1 = layer_norm_with_cached_statistics(
+      resid_0, ln1_mean, ln1_rstd, norm_shape, ln1_w, ln1_b);
+  auto mlp_in = castOp(dtype, ln_1);
+  // Note: We only use linear0 and gelu outputs from the mlp forward pass.
+  auto mlp_tvs = mlp(mlp_in, mlp_w0, mlp_b0, mlp_w1, mlp_b1, mesh);
+
+  // Backwards
+  auto mlp_grads = mlp_backwards(
+      grad,
+      mlp_in,
+      mlp_mask,
+      mlp_w0,
+      mlp_b0,
+      mlp_w1,
+      mesh,
+      mlp_tvs[0],
+      mlp_tvs[1]);
+  auto ln1_grads = layer_norm_backward(
+      castOp(DataType::Float, mlp_grads[6]),
+      resid_0,
+      norm_shape,
+      ln1_mean,
+      ln1_rstd,
+      ln1_w,
+      ln1_b,
+      {true, true, true});
+  auto resid1_grad = add(ln1_grads.grad_input, grad);
+  auto mha_grads = mha_backwards(
+      mha_in,
+      mha_w0,
+      mha_b0,
+      mha_w1,
+      mha_mask,
+      mha_sdpa_out,
+      mha_sdpa_log_sumexp,
+      mha_sdpa_seed,
+      mha_sdpa_offset,
+      resid1_grad,
+      qkv,
+      mesh);
+  auto ln0_grads = layer_norm_backward(
+      castOp(DataType::Float, mha_grads[8]),
+      x,
+      norm_shape,
+      ln0_mean,
+      ln0_rstd,
+      ln0_w,
+      ln0_b,
+      {true, true, true});
+  auto dx = add(ln0_grads.grad_input, resid1_grad);
+
+  fusion->addOutput(mlp_grads[1]); // mlp linear1 weight grad
+  fusion->addOutput(mlp_grads[2]); // mlp linear1 bias grad
+  fusion->addOutput(mlp_grads[4]); // mlp linear0 weight grad
+  fusion->addOutput(mlp_grads[5]); // mlp linear0 bias grad
+  fusion->addOutput(ln1_grads.grad_weight);
+  fusion->addOutput(ln1_grads.grad_bias);
+  fusion->addOutput(mha_grads[1]); // mha linear1 weight grad
+  fusion->addOutput(mha_grads[2]); // mha linear1 bias grad
+  fusion->addOutput(mha_grads[6]); // mha linear0 weight grad
+  fusion->addOutput(mha_grads[7]); // mha linear0 bias grad
+  fusion->addOutput(ln0_grads.grad_weight);
+  fusion->addOutput(ln0_grads.grad_bias);
+  fusion->addOutput(dx); // transformer grad input
+
+  // Sharding annotations for input and output TVs not sharded
+  // by mlp_backward, mha_backward, or mlp.
+  for (auto* tv :
+       {mha_linear1,
+        ln0_w,
+        ln0_b,
+        ln0_mean,
+        ln0_rstd,
+        ln1_w,
+        ln1_b,
+        ln1_mean,
+        ln1_rstd,
+        ln1_grads.grad_weight,
+        ln1_grads.grad_bias,
+        ln0_grads.grad_weight,
+        ln0_grads.grad_bias,
+        ln0_grads.grad_input}) {
+    tv->setDeviceMesh(mesh);
+  }
+  for (auto* tv : {mha_w0, mha_b0, mha_w1, mha_sdpa_out, mha_sdpa_log_sumexp}) {
+    tv->setDeviceMesh(mesh);
+    tv->axis(0)->parallelize(ParallelType::DIDx);
+  }
+
+  // Sharded inputs to outputs
+  shardBetween(
+      {mha_w0, mha_b0, mha_w1, mha_sdpa_out},
+      {mha_grads[1], mha_grads[6], mha_grads[7]},
+      mha_w0);
+  shardBetween(
+      {mlp_w0, mlp_w1, mlp_b0},
+      {mlp_grads[1], mlp_grads[4], mlp_grads[5]},
+      mlp_w0);
+
+  // Unsharded inputs to outputs
+  shardBetween(
+      {x,
+       grad,
+       mha_mask,
+       mlp_mask,
+       mha_linear1,
+       ln0_mean,
+       ln0_w,
+       ln0_b,
+       ln1_mean,
+       ln1_w,
+       ln1_b,
+       mlp_b1},
+      {mlp_grads[2],
+       ln1_grads.grad_weight,
+       ln1_grads.grad_bias,
+       mha_grads[2],
+       ln0_grads.grad_weight,
+       ln0_grads.grad_bias,
+       dx},
+      x);
+
+  return std::make_unique<FusionExecutorCache>(std::move(fusion));
+}
+} // namespace nvfuser

--- a/tests/cpp/multidevice_transformer.h
+++ b/tests/cpp/multidevice_transformer.h
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION &
+ * AFFILIATES. All rights reserved. SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <stdint.h>
+
+#include <runtime/fusion_executor_cache.h>
+
+namespace nvfuser {
+struct MHAQKVResult {
+  TensorView* linear0;
+  std::vector<TensorView*> qkv;
+};
+
+class DistributedTransformer {
+ public:
+  DistributedTransformer(
+      int64_t num_devices,
+      int64_t batch_size,
+      int64_t embedding_size,
+      int64_t number_heads,
+      int64_t sequence_length)
+      : D(num_devices),
+        B(batch_size),
+        E(embedding_size),
+        H(number_heads),
+        S(sequence_length) {}
+
+  std::unique_ptr<FusionExecutorCache> forward(DataType dtype);
+  std::unique_ptr<FusionExecutorCache> backward(DataType dtype);
+
+  std::vector<TensorView*> mlp(
+    TensorView* x,
+    TensorView* w0,
+    TensorView* b0,
+    TensorView* w1,
+    TensorView* b1,
+    const DeviceMesh& mesh);
+
+std::vector<TensorView*> mha(
+    TensorView* x,
+    TensorView* w0,
+    TensorView* b0,
+    TensorView* w1,
+    TensorView* b1,
+    const DeviceMesh& mesh);
+
+// Backwards MLP block. Recomputes linear0 and gelu
+// if either isn't provided as input.
+std::vector<TensorView*> mlp_backwards(
+    TensorView* grad,
+    TensorView* x,
+    TensorView* mask,
+    TensorView* w0,
+    TensorView* b0,
+    TensorView* w1,
+    const DeviceMesh& mesh,
+    TensorView* linear0 = nullptr,
+    TensorView* gelu = nullptr);
+
+std::vector<TensorView*> mha_backwards(
+    TensorView* x,
+    TensorView* w0,
+    TensorView* b0,
+    TensorView* w1,
+    TensorView* mask,
+    TensorView* sdpa_output,
+    TensorView* sdpa_log_sumexp,
+    TensorView* sdpa_seed,
+    TensorView* sdpa_offset,
+    TensorView* grad,
+    const std::vector<TensorView*>& qkv,
+    const DeviceMesh& mesh);
+
+MHAQKVResult mha_qkv(
+    TensorView* x,
+    TensorView* w0,
+    TensorView* b0,
+    const DeviceMesh& mesh);
+
+  int64_t D, B, E, H, S;
+  static constexpr double kDropoutProb = 0.1, kParamScale = 0.02, kSdpaProb = 0.0,
+                   kSdpaScale = 1e-3;
+
+};
+} // namespace nvfuser

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -52,11 +52,6 @@ void validate(
     const std::vector<at::Tensor>& expected_outputs,
     const std::vector<at::Tensor>& outputs,
     const std::vector<double>& atols) {
-  for (auto i : c10::irange(expected_outputs.size())) {
-    std::cout << i << " " << outputs[i].sizes() << " "
-              << expected_outputs[i].sizes() << std::endl;
-  }
-
   using testing::SizeIs;
   const auto num_outputs = outputs.size();
   ASSERT_THAT(expected_outputs, SizeIs(num_outputs));

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -13,20 +13,10 @@
 #include <fusion.h>
 #include <ops/all_ops.h>
 #include <tests/cpp/multidevice.h>
+#include <tests/cpp/multidevice_transformer.h>
 #include <tests/cpp/validator.h>
 
 namespace nvfuser {
-
-constexpr int64_t B = 2, E = 768, H = 16, S = 128;
-// Note parameters scaled by kParamScale following weight initialization
-// recommendations:
-// https://huggingface.co/docs/transformers/en/model_doc/gpt2#transformers.GPT2Config.initializer_range
-// Note: Sdpa probability is set to 0. Since the dropout mask is sharded it
-// throws off the seed offset between the sharded nvFuser program and the
-// unsharded reference.
-constexpr double kDropoutProb = 0.1, kParamScale = 0.02, kSdpaProb = 0.0,
-                 kSdpaScale = 1e-3;
-
 class DistributedTransformerTest
     : public MultiDeviceTest,
       public testing::WithParamInterface<DataType> {
@@ -40,177 +30,86 @@ class DistributedTransformerTest
     }
   }
 
-  const int64_t D; // number of devices
-};
-
-namespace {
-// testValidate doesn't work out of the box due to #2906, so I had to manually
-// specify the absolute tolerances. The atols passed in are tuned for bfloat,
-// the least precise dtype. They can probably be made stricter for other
-// dtypes.
-void validate(
-    const std::vector<at::Tensor>& expected_outputs,
-    const std::vector<at::Tensor>& outputs,
-    const std::vector<double>& atols) {
-  using testing::SizeIs;
-  const auto num_outputs = outputs.size();
-  ASSERT_THAT(expected_outputs, SizeIs(num_outputs));
-  ASSERT_THAT(atols, SizeIs(num_outputs));
-
-  for (const auto i : c10::irange(num_outputs)) {
-    // allclose can catch this as well. However, it would throw an exception,
-    // not showing which output was problematic.
-    ASSERT_EQ(outputs[i].dtype(), expected_outputs[i].dtype())
-        << "Output " << i << " has a mismatching data type.";
-
-    const double atol = atols[i];
-    // These default rtols are copied from
-    // https://github.com/pytorch/pytorch/blob/951c21d6790334d57862e94a3f582ac724147a53/torch/testing/_comparison.py#L65-L73.
-    double rtol;
-    switch (outputs[i].scalar_type()) {
-      case at::kBFloat16:
-        rtol = 1.6e-2;
-        break;
-      case at::kHalf:
-        rtol = 1e-3;
-        break;
-      case at::kFloat:
-        rtol = 1.3e-6;
-        break;
-      default:
-        rtol = 0.0;
-        break;
-    }
-
-    if (true) {
-      auto error =
-          (outputs[i].to(expected_outputs[i].dtype()) - expected_outputs[i])
-              .abs();
-      auto max_error = error.max().item().to<double>();
-      auto max_relative_error =
-          (max_error / expected_outputs[i].abs().max()).item();
-      auto error_count =
-          at::sum(error >= (atol + expected_outputs[i].abs() * rtol)).item();
-      std::cout << "output[" << i << "] max error: " << max_error << std::endl;
-      std::cout << "          max relative error: " << max_relative_error
-                << std::endl;
-      std::cout << "          failing elements: " << error_count << ", "
-                << error_count.to<float>() / at::numel(outputs[i]) * 100.0
-                << "\% of tensor" << std::endl;
-    }
-
-    auto generate_comparison_details = [](at::Tensor expected_out,
-                                          at::Tensor out,
-                                          double atol,
-                                          double rtol) -> std::string {
-      std::ostringstream oss;
-      auto error = (out - expected_out).abs();
-      auto max_relative_error =
-          (error.max() / expected_out.abs().max()).item().to<double>();
-      auto error_count =
-          at::sum(error >= atol + expected_out.abs() * rtol).item();
-      indent(oss, 1)
-          << "max absolute error under rtol: "
-          << (error - expected_out.abs() * rtol).max().item().to<double>()
-          << std::endl;
-      indent(oss, 1) << "max relative error: " << max_relative_error
-                     << std::endl;
-      indent(oss, 1) << "failing elements: " << error_count << ", "
-                     << error_count.to<float>() / at::numel(out) * 100.0
-                     << "\% of tensor";
-      return oss.str();
-    };
-
-    EXPECT_TRUE(outputs[i].allclose(expected_outputs[i], rtol, atol))
-        << "Output " << i << " mismatches with atol " << atol << ":"
-        << std::endl
-        << generate_comparison_details(
-               expected_outputs[i], outputs[i], atol, rtol);
+  std::vector<at::Tensor> reference_mlp(
+      at::Tensor x,
+      at::Tensor w0,
+      at::Tensor b0,
+      at::Tensor w1,
+      at::Tensor b1) {
+    auto at_dtype = w0.dtype();
+    auto linear0 = at::linear(x, w0, b0);
+    auto gelu = at::gelu(linear0.to(at::kFloat), "tanh").to(at_dtype);
+    auto linear1 = at::linear(gelu, w1, b1).to(at::kFloat);
+    auto [dropout, mask] = at::native_dropout(linear1, kDropoutProb, true);
+    return {linear0, gelu, linear1, dropout, mask};
   }
-}
 
-std::vector<at::Tensor> reference_mlp(
-    at::Tensor x,
-    at::Tensor w0,
-    at::Tensor b0,
-    at::Tensor w1,
-    at::Tensor b1) {
-  auto at_dtype = w0.dtype();
-  auto linear0 = at::linear(x, w0, b0);
-  auto gelu = at::gelu(linear0.to(at::kFloat), "tanh").to(at_dtype);
-  auto linear1 = at::linear(gelu, w1, b1).to(at::kFloat);
-  auto [dropout, mask] = at::native_dropout(linear1, kDropoutProb, true);
-  return {linear0, gelu, linear1, dropout, mask};
-}
-
-std::vector<at::Tensor> reference_mha(
-    at::Tensor x,
-    at::Tensor w0,
-    at::Tensor b0,
-    at::Tensor w1,
-    at::Tensor b1) {
-  auto linear0 = at::linear(x, w0, b0);
-  auto qkv = linear0.view({B, S, 3 * E}).split(E, 2);
-  for (auto i = 0; i < 3; i++) {
-    qkv[i] = qkv[i].reshape({B, S, H, E / H}).transpose(1, 2);
+  std::vector<at::Tensor> reference_mha(
+      at::Tensor x,
+      at::Tensor w0,
+      at::Tensor b0,
+      at::Tensor w1,
+      at::Tensor b1) {
+    auto linear0 = at::linear(x, w0, b0);
+    auto qkv = linear0.view({B, S, 3 * E}).split(E, 2);
+    for (auto i = 0; i < 3; i++) {
+      qkv[i] = qkv[i].reshape({B, S, H, E / H}).transpose(1, 2);
+    }
+    auto sdpa_out = at::_scaled_dot_product_flash_attention(
+        qkv[0], qkv[1], qkv[2], kSdpaProb, true, false, kSdpaScale);
+    auto sdpa = std::get<0>(sdpa_out);
+    // Reassemble heads (B, H, S, E/H) to (B, S, H, E/H) to (B, S, E)
+    auto y = sdpa.transpose(1, 2).reshape({B * S, E});
+    auto linear1 = at::linear(y, w1, b1).to(at::kFloat);
+    auto [dropout, mask] = at::native_dropout(linear1, kDropoutProb, true);
+    return {linear0, sdpa, linear1, dropout, mask};
   }
-  auto sdpa_out = at::_scaled_dot_product_flash_attention(
-      qkv[0], qkv[1], qkv[2], kSdpaProb, true, false, kSdpaScale);
-  auto sdpa = std::get<0>(sdpa_out);
-  // Reassemble heads (B, H, S, E/H) to (B, S, H, E/H) to (B, S, E)
-  auto y = sdpa.transpose(1, 2).reshape({B * S, E});
-  auto matmul1 = at::matmul(y, w1.transpose(0, 1));
-  auto linear1 = (matmul1 + b1).to(at::kFloat);
-  // auto linear1 = at::linear(y, w1, b1).to(at::kFloat);
-  auto [dropout, mask] = at::native_dropout(linear1, kDropoutProb, true);
-  return {linear0, sdpa, linear1, dropout, mask};
-}
 
-std::vector<at::Tensor> reference_mlp_backwards(
-    at::Tensor grad,
-    at::Tensor x,
-    at::Tensor mask,
-    at::Tensor w0,
-    at::Tensor b0,
-    at::Tensor w1) {
-  auto at_dtype = w0.dtype();
-  // recompute activations
-  auto linear0 = at::linear(x, w0, b0);
-  auto gelu = at::gelu(linear0.to(at::kFloat), "tanh");
+  std::vector<at::Tensor> reference_mlp_backwards(
+      at::Tensor grad,
+      at::Tensor x,
+      at::Tensor mask,
+      at::Tensor w0,
+      at::Tensor b0,
+      at::Tensor w1) {
+    auto at_dtype = w0.dtype();
+    // recompute activations
+    auto linear0 = at::linear(x, w0, b0);
+    auto gelu = at::gelu(linear0.to(at::kFloat), "tanh");
 
-  // backwards pass
-  auto dropout_grad =
-      at::native_dropout_backward(grad, mask, 1.0 / (1.0 - kDropoutProb));
-  auto dropout_grad_q = dropout_grad.to(at_dtype);
-  auto matmul1_grad = at::matmul(dropout_grad_q, w1);
-  auto matmul1_grad_w =
-      at::matmul(dropout_grad_q.transpose(0, 1), gelu.to(at_dtype));
-  auto matmul1_grad_b = at::sum(dropout_grad, {0});
-  auto gelu_grad =
-      at::gelu_backward(matmul1_grad.to(at::kFloat), linear0, "tanh");
-  auto gelu_grad_q = gelu_grad.to(at_dtype);
-  auto matmul0_grad_b = at::sum(gelu_grad, {0});
-  auto matmul0_grad = at::matmul(gelu_grad_q, w0);
-  auto matmul0_grad_w = at::matmul(gelu_grad_q.transpose(0, 1), x);
+    // backwards pass
+    auto dropout_grad =
+        at::native_dropout_backward(grad, mask, 1.0 / (1.0 - kDropoutProb));
+    auto dropout_grad_q = dropout_grad.to(at_dtype);
+    auto matmul1_grad = at::matmul(dropout_grad_q, w1);
+    auto matmul1_grad_w =
+        at::matmul(dropout_grad_q.transpose(0, 1), gelu.to(at_dtype));
+    auto matmul1_grad_b = at::sum(dropout_grad, {0});
+    auto gelu_grad =
+        at::gelu_backward(matmul1_grad.to(at::kFloat), linear0, "tanh");
+    auto gelu_grad_q = gelu_grad.to(at_dtype);
+    auto matmul0_grad_b = at::sum(gelu_grad, {0});
+    auto matmul0_grad = at::matmul(gelu_grad_q, w0);
+    auto matmul0_grad_w = at::matmul(gelu_grad_q.transpose(0, 1), x);
 
-  std::vector<at::Tensor> grads = {
-      dropout_grad,
-      matmul1_grad_w,
-      matmul1_grad_b,
-      gelu_grad,
-      matmul0_grad_w,
-      matmul0_grad_b,
-      matmul0_grad};
-  return grads;
-}
+    std::vector<at::Tensor> grads = {
+        dropout_grad,
+        matmul1_grad_w,
+        matmul1_grad_b,
+        gelu_grad,
+        matmul0_grad_w,
+        matmul0_grad_b,
+        matmul0_grad};
+    return grads;
+  }
 
-std::vector<at::Tensor> reference_mha_backwards(
-    at::Tensor y_grad,
-    at::Tensor x,
-    at::Tensor mask,
-    at::Tensor w0,
-    at::Tensor b0,
-    at::Tensor w1) {
+  std::vector<at::Tensor> reference_mha_backwards(
+      at::Tensor y_grad,
+      at::Tensor x,
+      at::Tensor mask,
+      at::Tensor w0,
+      at::Tensor b0,
+      at::Tensor w1) {
   auto at_dtype = w0.dtype();
   // recompute up to sdpa
   auto linear0 = at::linear(x, w0, b0).view({B, S, 3 * E});
@@ -292,354 +191,87 @@ std::vector<at::Tensor> reference_mha_backwards(
   return tensors;
 }
 
-std::vector<TensorView*> mlp(
-    TensorView* x,
-    TensorView* w0,
-    TensorView* b0,
-    TensorView* w1,
-    TensorView* b1,
-    const DeviceMesh& mesh) {
-  const DataType dtype = w0->dtype();
-  // // Linear 0
-  TensorView* linear0 = linear(x, w0, b0);
-  // GeLU
-  TensorView* gelu = tanh_gelu(castOp(DataType::Float, linear0));
-  gelu = castOp(dtype, gelu);
-  // Linear 1
-  TensorView* local_matmul1 = matmul(gelu, transpose(w1, 1, 2));
-  TensorView* matmul1 = sum(local_matmul1, {0}); // Allreduce
-  TensorView* linear1 = add(matmul1, broadcast(b1, {true, false}));
-  // Dropout
-  Val* prob = IrBuilder::create<Val>(1.0 - kDropoutProb);
-  Val* scale = IrBuilder::create<Val>(1.0 / (1.0 - kDropoutProb));
-  auto dropout_result = dropout(linear1, prob, scale).output;
-
-  // Manual sharding annotations
-  for (auto tv : {x, b1, linear1, dropout_result}) {
-    tv->setDeviceMesh(mesh);
-  }
-  for (auto tv : {w0, b0, w1, linear0, gelu}) {
-    tv->setDeviceMesh(mesh);
-    tv->axis(0)->parallelize(ParallelType::DIDx);
-  }
-
-  return {linear0, gelu, linear1, dropout_result};
-}
-
-struct MHAQKVResult {
-  TensorView* linear0;
-  std::vector<TensorView*> qkv;
+const int64_t D; // number of devices
+int64_t B = 2, E = 768, H = 16, S = 128;
+// Note parameters scaled by kParamScale following weight initialization
+// recommendations:
+// https://huggingface.co/docs/transformers/en/model_doc/gpt2#transformers.GPT2Config.initializer_range
+// Note: Sdpa probability is set to 0. Since the dropout mask is sharded it
+// throws off the seed offset between the sharded nvFuser program and the
+// unsharded reference.
+static constexpr double kDropoutProb = 0.1, kParamScale = 0.02, kSdpaProb = 0.0,
+                        kSdpaScale = 1e-3;
 };
 
-MHAQKVResult mha_qkv(
-    TensorView* x,
-    TensorView* w0,
-    TensorView* b0,
-    const DeviceMesh& mesh) {
-  DataType dtype = w0->dtype();
-  const auto D = w0->axis(0)->extent()->value().as<int64_t>();
-  TensorView* linear0 = linear(x, w0, b0);
-  TensorView* linear0_float = castOp(DataType::Float, linear0);
-  // TensorView* matmul0 = matmul(x, transpose(w0, 1, 2));
-  // TensorView* linear0 = add(matmul0, broadcast(b0, {false, true, false}));
-  // linear0 = castOp(dtype, linear0);
-  // Forming the q,k,v vectors:
-  TensorView* qkv_cat =
-      reshape(linear0_float, {D, B * S, 3 * E / D}, {D, B, S, 3 * E / D});
-  std::vector<TensorView*> qkv = chunk(qkv_cat, 3, -1);
-  for (auto i : c10::irange(3)) {
-    qkv[i] = reshape(qkv[i], {D, B, S, E / D}, {D, B, S, H / D, E / H});
-    qkv[i] = transpose(qkv[i], 2, 3);
-    qkv[i] = castOp(dtype, qkv[i]);
-    // Explicitly shard q, k, and v before calling SDPA node
-    qkv[i]->setDeviceMesh(mesh);
-    qkv[i]->axis(0)->parallelize(ParallelType::DIDx);
+namespace {
+// testValidate doesn't work out of the box due to #2906, so I had to manually
+// specify the absolute tolerances. The atols passed in are tuned for bfloat,
+// the least precise dtype. They can probably be made stricter for other
+// dtypes.
+void validate(
+    const std::vector<at::Tensor>& expected_outputs,
+    const std::vector<at::Tensor>& outputs,
+    const std::vector<double>& atols) {
+  using testing::SizeIs;
+  const auto num_outputs = outputs.size();
+  ASSERT_THAT(expected_outputs, SizeIs(num_outputs));
+  ASSERT_THAT(atols, SizeIs(num_outputs));
+
+  for (const auto i : c10::irange(num_outputs)) {
+    // allclose can catch this as well. However, it would throw an exception,
+    // not showing which output was problematic.
+    ASSERT_EQ(outputs[i].dtype(), expected_outputs[i].dtype())
+        << "Output " << i << " has a mismatching data type.";
+
+    const double atol = atols[i];
+    // These default rtols are copied from
+    // https://github.com/pytorch/pytorch/blob/951c21d6790334d57862e94a3f582ac724147a53/torch/testing/_comparison.py#L65-L73.
+    double rtol;
+    switch (outputs[i].scalar_type()) {
+      case at::kBFloat16:
+        rtol = 1.6e-2;
+        break;
+      case at::kHalf:
+        rtol = 1e-3;
+        break;
+      case at::kFloat:
+        rtol = 1.3e-6;
+        break;
+      default:
+        rtol = 0.0;
+        break;
+    }
+
+    auto generate_comparison_details = [](at::Tensor expected_out,
+                                          at::Tensor out,
+                                          double atol,
+                                          double rtol) -> std::string {
+      std::ostringstream oss;
+      auto error = (out - expected_out).abs();
+      auto max_relative_error =
+          (error.max() / expected_out.abs().max()).item().to<double>();
+      auto error_count =
+          at::sum(error >= atol + expected_out.abs() * rtol).item();
+      indent(oss, 1)
+          << "max absolute error under rtol: "
+          << (error - expected_out.abs() * rtol).max().item().to<double>()
+          << std::endl;
+      indent(oss, 1) << "max relative error: " << max_relative_error
+                     << std::endl;
+      indent(oss, 1) << "failing elements: " << error_count << ", "
+                     << error_count.to<float>() / at::numel(out) * 100.0
+                     << "\% of tensor";
+      return oss.str();
+    };
+
+    EXPECT_TRUE(outputs[i].allclose(expected_outputs[i], rtol, atol))
+        << "Output " << i << " mismatches with atol " << atol << ":"
+        << std::endl
+        << generate_comparison_details(
+               expected_outputs[i], outputs[i], atol, rtol);
   }
-  return {linear0, qkv};
 }
-
-std::vector<TensorView*> mha(
-    TensorView* x,
-    TensorView* w0,
-    TensorView* b0,
-    TensorView* w1,
-    TensorView* b1,
-    const DeviceMesh& mesh) {
-  const auto D = w0->axis(0)->extent()->value().as<int64_t>();
-  auto dtype = w0->dtype();
-  // Linear 0 + q, k, v vector formation
-  auto qkv_results = mha_qkv(x, w0, b0, mesh);
-  auto linear0 = qkv_results.linear0;
-  // SDPA
-  SdpfaFwdResult sdpa = sdpfa_fwd(
-      qkv_results.qkv[0],
-      qkv_results.qkv[1],
-      qkv_results.qkv[2],
-      IrBuilder::create<Val>(kSdpaProb),
-      IrBuilder::create<Val>(true),
-      IrBuilder::create<Val>(kSdpaScale));
-  TensorView* sdpa_output = sdpa.output;
-  // Linear 1
-  TensorView* sdpa_transpose = transpose(sdpa_output, 2, 3);
-  TensorView* sdpa_reshape =
-      reshape(sdpa_transpose, {D, B, S, H / D, E / H}, {D, B * S, E / D});
-  TensorView* local_matmul1 = matmul(sdpa_reshape, transpose(w1, 1, 2));
-  local_matmul1 = castOp(DataType::Float, local_matmul1);
-  TensorView* matmul1 = sum(local_matmul1, {0}); // allreduce
-  TensorView* linear1 = add(matmul1, broadcast(b1, {true, false}));
-  // Dropout
-  Val* prob = IrBuilder::create<Val>(1.0 - kDropoutProb);
-  Val* scale = IrBuilder::create<Val>(1.0 / (1.0 - kDropoutProb));
-  auto dropout_result = dropout(linear1, prob, scale).output;
-
-  for (auto tv : {x, b1, matmul1, linear1, dropout_result}) {
-    tv->setDeviceMesh(mesh);
-  }
-  for (auto tv : {w0, b0, w1, linear0, sdpa_output}) {
-    tv->setDeviceMesh(mesh);
-    tv->axis(0)->parallelize(ParallelType::DIDx);
-  }
-  return {linear0, sdpa_output, linear1, dropout_result};
-}
-
-// TODO: These linear_backwards helper functions can be merged once
-// we do not have logically split rfactor domain.
-struct LinearBackwardsResult {
-  TensorView* grad_x;
-  TensorView* grad_w;
-  TensorView* grad_b;
-};
-
-// x format: [i0, i1] dtype
-// weight format: [DID(D), i2/D, i1] dtype
-// grad format: [DID(D) i0, i2/D] float or dtype
-// outputs: grad_x [i0, i1] dtype
-// grad_w [DID i2/D, i1] dtype
-// grad_b [DID i2/2] float
-LinearBackwardsResult linear_backwards(
-    TensorView* x,
-    TensorView* w,
-    TensorView* grad) {
-  DataType dtype = w->dtype();
-  TensorView* grad_f = maybeCastOp(DataType::Float, grad);
-  TensorView* grad_q = maybeCastOp(dtype, grad);
-  TensorView* grad_x_partials = matmul(grad_q, w);
-  TensorView* grad_x = sum(grad_x_partials, {0}); // allreduce
-  TensorView* grad_q_t = transpose(grad_q, 1, 2);
-  TensorView* grad_w = matmul(grad_q_t, x);
-  TensorView* grad_b = sum(grad_f, {1});
-
-  return {grad_x, grad_w, grad_b};
-}
-
-// x format: [DID, i0, i1/D] dtype
-// weight format: [DID, i2, i1/D] dtype
-// grad format: [i0, i2] float
-// outputs: grad_x [DID i0, i1/D] dtype
-// grad_w [DID, i2,  i1/D] dtype
-// grad_b [i2] float
-LinearBackwardsResult sharded_linear_backwards(
-    TensorView* x,
-    TensorView* w,
-    TensorView* grad) {
-  DataType dtype = w->dtype();
-  TensorView* grad_q = castOp(dtype, grad);
-  TensorView* grad_x = matmul(grad_q, w);
-  TensorView* grad_t = transpose(grad_q, 0, 1);
-  TensorView* grad_w = matmul(grad_t, x);
-  TensorView* grad_b = sum(grad, {0});
-
-  return {grad_x, grad_w, grad_b};
-}
-
-// Forward layer_norm with cached mean_bcast and invstd tensors to avoid
-// recomputing Welford. For use in backwards pass.
-TensorView* layer_norm_with_cached_statistics(
-    TensorView* x,
-    TensorView* mean_bcast,
-    TensorView* invstd,
-    const std::vector<int64_t>& norm_shape,
-    TensorView* weight,
-    TensorView* bias) {
-  const int64_t kNumberOfDims =
-      (int64_t)TensorDomain::noReductions(x->getLogicalDomain()).size();
-  const int64_t kOuterNumDims = kNumberOfDims - norm_shape.size();
-  std::vector<bool> outer_broadcast_mask(kNumberOfDims, false);
-  for (const auto idx : c10::irange(kOuterNumDims)) {
-    outer_broadcast_mask[idx] = true;
-  }
-
-  auto x_sub_mean = sub(x, mean_bcast);
-  auto y = mul(x_sub_mean, invstd);
-
-  auto weight_bcast = broadcast(weight, outer_broadcast_mask);
-  y = mul(y, weight_bcast);
-  auto bias_bcast = broadcast(bias, outer_broadcast_mask);
-  return add(y, bias_bcast);
-}
-
-// Backwards MLP block. Recomputes linear0 and gelu
-// if either isn't provided as input.
-std::vector<TensorView*> mlp_backwards(
-    TensorView* grad,
-    TensorView* x,
-    TensorView* mask,
-    TensorView* w0,
-    TensorView* b0,
-    TensorView* w1,
-    const DeviceMesh& mesh,
-    TensorView* linear0 = nullptr,
-    TensorView* gelu = nullptr) {
-  DataType dtype = w0->dtype();
-  if (linear0 == nullptr) {
-    linear0 = linear(x, w0, b0);
-  }
-  if (gelu == nullptr) {
-    gelu = castOp(dtype, tanh_gelu(castOp(DataType::Float, linear0)));
-  }
-
-  // Backwards pass
-  constexpr double kScale = 1.0 / (1.0 - kDropoutProb);
-  Val* dropout_scale = IrBuilder::create<Val>(kScale);
-  TensorView* dropout_grad = dropout_backward(grad, mask, dropout_scale);
-
-  auto linear1_grads = sharded_linear_backwards(gelu, w1, dropout_grad);
-
-  TensorView* matmul1_grad_x_ = castOp(DataType::Float, linear1_grads.grad_x);
-  TensorView* gelu_grad = tanh_gelu_backward(matmul1_grad_x_, linear0);
-
-  auto linear0_grads = linear_backwards(x, w0, gelu_grad);
-
-  // Manaul sharding annotations
-  for (auto tv :
-       {x,
-        grad,
-        mask,
-        dropout_grad,
-        linear1_grads.grad_b,
-        linear0_grads.grad_x}) {
-    tv->setDeviceMesh(mesh);
-  }
-
-  for (auto tv :
-       {w0,
-        b0,
-        w1,
-        linear1_grads.grad_x,
-        linear1_grads.grad_w,
-        gelu_grad,
-        linear0_grads.grad_w,
-        linear0_grads.grad_b}) {
-    tv->setDeviceMesh(mesh);
-    tv->axis(0)->parallelize(ParallelType::DIDx);
-  }
-
-  std::vector<TensorView*> outputs = {
-      dropout_grad,
-      linear1_grads.grad_w,
-      linear1_grads.grad_b,
-      gelu_grad,
-      linear0_grads.grad_w,
-      linear0_grads.grad_b,
-      linear0_grads.grad_x};
-  return outputs;
-}
-
-std::vector<TensorView*> mha_backwards(
-    TensorView* x,
-    TensorView* w0,
-    TensorView* b0,
-    TensorView* w1,
-    TensorView* mask,
-    TensorView* sdpa_output,
-    TensorView* sdpa_log_sumexp,
-    TensorView* sdpa_seed,
-    TensorView* sdpa_offset,
-    TensorView* grad,
-    const std::vector<TensorView*>& qkv,
-    const DeviceMesh& mesh) {
-  DataType dtype = w0->dtype();
-  const auto D = w0->axis(0)->extent()->value().as<int64_t>();
-  // dropout backwards
-  constexpr double kScale = 1.0 / (1.0 - kDropoutProb);
-  auto dropout_scale = IrBuilder::create<Val>(kScale);
-  TensorView* dropout_grad = dropout_backward(grad, mask, dropout_scale);
-
-  // linear1 backwards
-  TensorView* sdpa_output_reshape =
-      transpose(sdpa_output, 2, 3); // D, B, S, H/D, E/H
-  sdpa_output_reshape =
-      reshape(sdpa_output_reshape, {D, B, S, H / D, E / H}, {D, B * S, E / D});
-  auto linear1_grads =
-      sharded_linear_backwards(sdpa_output_reshape, w1, dropout_grad);
-
-  // SDPA backwards
-  TensorView* linear1_x_grad =
-      reshape(linear1_grads.grad_x, {D, B * S, E / D}, {D, B, S, H / D, E / H});
-  linear1_x_grad = transpose(linear1_x_grad, 2, 3); // D, B, H/D, S, E/H
-  // Explicitly shard inputs before SDPA backward node
-  for (auto tv : {linear1_x_grad, sdpa_output, sdpa_log_sumexp}) {
-    tv->setDeviceMesh(mesh);
-    tv->axis(0)->parallelize(ParallelType::DIDx);
-  }
-  auto sdpa_grad = sdpfa_bwd(
-      linear1_x_grad,
-      qkv[0],
-      qkv[1],
-      qkv[2],
-      sdpa_output,
-      sdpa_log_sumexp,
-      /*dropout_p=*/IrBuilder::create<Val>(kSdpaProb),
-      /*is_causal=*/IrBuilder::create<Val>(true),
-      sdpa_seed,
-      sdpa_offset,
-      /*scale=*/IrBuilder::create<Val>(kSdpaScale));
-
-  TensorView* q_grad = transpose(sdpa_grad.grad_query, 2, 3);
-  q_grad = reshape(q_grad, {D, B, S, H / D, E / H}, {D, B * S, E / D});
-  TensorView* v_grad = transpose(sdpa_grad.grad_value, 2, 3);
-  v_grad = reshape(v_grad, {D, B, S, H / D, E / H}, {D, B * S, E / D});
-  TensorView* k_grad = transpose(sdpa_grad.grad_key, 2, 3);
-  k_grad = reshape(k_grad, {D, B, S, H / D, E / H}, {D, B * S, E / D});
-  TensorView* kqv_grad = cat({k_grad, q_grad, v_grad}, -1);
-  auto linear0_grads = linear_backwards(x, w0, kqv_grad);
-
-  for (auto tv :
-       {x,
-        mask,
-        grad,
-        dropout_grad,
-        linear1_grads.grad_b,
-        linear0_grads.grad_x}) {
-    tv->setDeviceMesh(mesh);
-  }
-  for (auto tv :
-       {w0,
-        b0,
-        w1,
-        sdpa_output,
-        linear1_grads.grad_x,
-        linear1_grads.grad_w,
-        linear0_grads.grad_w,
-        linear0_grads.grad_b,
-        sdpa_grad.grad_query,
-        sdpa_grad.grad_key,
-        sdpa_grad.grad_value}) {
-    tv->setDeviceMesh(mesh);
-    tv->axis(0)->parallelize(ParallelType::DIDx);
-  }
-  return {
-      dropout_grad,
-      linear1_grads.grad_w,
-      linear1_grads.grad_b,
-      sdpa_grad.grad_query,
-      sdpa_grad.grad_key,
-      sdpa_grad.grad_value,
-      linear0_grads.grad_w, // todo failing point tolerance wise
-      linear0_grads.grad_b,
-      linear0_grads.grad_x};
-}
-} // namespace
+} // namsespace
 
 TEST_P(DistributedTransformerTest, MLP_Layer) {
   if ((4 * E) % D != 0) {
@@ -664,7 +296,9 @@ TEST_P(DistributedTransformerTest, MLP_Layer) {
   fusion->addInput(tvw1);
   fusion->addInput(tvb1);
 
-  std::vector<TensorView*> tvsout = mlp(tvx, tvw0, tvb0, tvw1, tvb1, mesh);
+  DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
+  std::vector<TensorView*> tvsout =
+      model.mlp(tvx, tvw0, tvb0, tvw1, tvb1, mesh);
 
   for (auto* tv : tvsout) {
     fusion->addOutput(tv);
@@ -727,7 +361,8 @@ TEST_P(DistributedTransformerTest, MultiheadAttention) {
   fusion->addInput(tvw1);
   fusion->addInput(tvb1);
 
-  auto tv_outs = mha(tvx, tvw0, tvb0, tvw1, tvb1, mesh);
+  DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
+  auto tv_outs = model.mha(tvx, tvw0, tvb0, tvw1, tvb1, mesh);
 
   for (auto tv : tv_outs) {
     fusion->addOutput(tv);
@@ -790,8 +425,9 @@ TEST_P(DistributedTransformerTest, MLP_Backward) {
   fusion->addInput(b0);
   fusion->addInput(w1);
 
+  DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
   std::vector<TensorView*> tv_outs =
-      mlp_backwards(grad, x, mask, w0, b0, w1, mesh);
+      model.mlp_backwards(grad, x, mask, w0, b0, w1, mesh);
 
   for (TensorView* tv : tv_outs) {
     fusion->addOutput(tv);
@@ -872,8 +508,9 @@ TEST_P(DistributedTransformerTest, MHA_Backward) {
   fusion->addInput(tvsdpa_seed);
   fusion->addInput(tvsdpa_offset);
 
-  auto qkv = mha_qkv(tvx, tvw0, tvb0, mesh).qkv;
-  auto tvouts = mha_backwards(
+  DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
+  auto qkv = model.mha_qkv(tvx, tvw0, tvb0, mesh).qkv;
+  auto tvouts = model.mha_backwards(
       tvx,
       tvw0,
       tvb0,
@@ -949,67 +586,12 @@ TEST_P(DistributedTransformerTest, Forward) {
   }
   auto dtype = GetParam();
   at::ScalarType at_dtype = data_type_to_aten(dtype);
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-  const auto mesh = DeviceMesh::createForNumDevices(D);
-
-  TensorView* x = makeContigConcreteTensor({B * S, E}, DataType::Float);
-  TensorView* ln0_w = makeContigTensor(1);
-  TensorView* ln0_b = makeContigTensor(1);
-  TensorView* mha_w0 = makeContigConcreteTensor({D, 3 * E / D, E}, dtype);
-  TensorView* mha_b0 = makeContigConcreteTensor({D, 3 * E / D}, dtype);
-  TensorView* mha_w1 = makeContigConcreteTensor({D, E, E / D}, dtype);
-  TensorView* mha_b1 = makeContigConcreteTensor({E}, dtype);
-  TensorView* ln1_w = makeContigTensor(1);
-  TensorView* ln1_b = makeContigTensor(1);
-  TensorView* mlp_w0 = makeContigTensor(3, dtype);
-  TensorView* mlp_b0 = makeContigTensor(2, dtype);
-  TensorView* mlp_w1 = makeContigTensor(3, dtype);
-  TensorView* mlp_b1 = makeContigTensor(1, dtype);
-
-  fusion->addInput(x);
-  fusion->addInput(ln0_w);
-  fusion->addInput(ln0_b);
-  fusion->addInput(mha_w0);
-  fusion->addInput(mha_b0);
-  fusion->addInput(mha_w1);
-  fusion->addInput(mha_b1);
-  fusion->addInput(ln1_w);
-  fusion->addInput(ln1_b);
-  fusion->addInput(mlp_w0);
-  fusion->addInput(mlp_b0);
-  fusion->addInput(mlp_w1);
-  fusion->addInput(mlp_b1);
-
-  constexpr float kEps = 1e-5;
-  auto eps = IrBuilder::create<Val>(kEps);
-  std::vector<int64_t> norm_shape{E};
-
-  auto ln0 = layer_norm(x, norm_shape, ln0_w, ln0_b, eps);
-  auto mha_in = castOp(dtype, ln0.output);
-  auto mha_out = mha(mha_in, mha_w0, mha_b0, mha_w1, mha_b1, mesh)[3];
-  auto resid0 = add(x, mha_out);
-  auto ln1 = layer_norm(resid0, norm_shape, ln1_w, ln1_b, eps);
-  auto mlp_in = castOp(dtype, ln1.output);
-  auto mlp_out = mlp(mlp_in, mlp_w0, mlp_b0, mlp_w1, mlp_b1, mesh)[3];
-  auto resid1 = add(resid0, mlp_out);
-
-  fusion->addOutput(ln0.output);
-  fusion->addOutput(mha_out); // failing starting here
-  fusion->addOutput(ln1.output);
-  fusion->addOutput(mlp_out);
-  fusion->addOutput(resid1);
-
-  for (auto tv : {x, ln0.output, ln1.output, resid1}) {
-    tv->setDeviceMesh(mesh);
-  }
-
-  shardBetween({mha_in->definition()}, {mha_out->definition()}, mha_w0);
-  shardBetween({mlp_in->definition()}, {mlp_out->definition()}, mlp_w0);
-  shardBetween({x}, {mha_in}, x);
-
   const auto options =
       at::TensorOptions().dtype(at_dtype).device(communicator_->device());
+  constexpr float kEps = 1e-5;
+  std::vector<int64_t> norm_shape{E};
+  const auto mesh = DeviceMesh::createForNumDevices(D);
+
   auto x_ = at::randn({B * S, E}, options).to(at::kFloat);
   auto ln0_w_ = at::randn(E, options).to(at::kFloat);
   auto ln0_b_ = at::randn(E, options).to(at::kFloat);
@@ -1057,9 +639,10 @@ TEST_P(DistributedTransformerTest, Forward) {
   std::vector<at::Tensor> expected_outputs = {
       ln0_out_, mha_out_, ln1_out_, mlp_out_, at_out};
 
-  FusionExecutorCache fec(std::move(fusion));
+  DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
+  auto fec = model.forward(dtype);
   at::manual_seed(getATenRandomSeed());
-  auto outputs = fec.runFusionWithInputs(inputs);
+  auto outputs = fec->runFusionWithInputs(inputs);
   validate(expected_outputs, outputs, {1e-4, 0.02, 0.02, 0.04, 0.04});
 }
 
@@ -1070,199 +653,9 @@ TEST_P(DistributedTransformerTest, Backward) {
   }
   auto dtype = GetParam();
   at::ScalarType at_dtype = data_type_to_aten(dtype);
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
   const auto mesh = DeviceMesh::createForNumDevices(D);
   constexpr float kEps = 1e-5;
   std::vector<int64_t> norm_shape{E};
-
-  TensorView* x = makeContigConcreteTensor({B * S, E});
-  TensorView* grad = makeContigTensor(2);
-  TensorView* mha_w0 = makeContigConcreteTensor({D, 3 * E / D, E}, dtype);
-  TensorView* mha_b0 = makeContigConcreteTensor({D, 3 * E / D}, dtype);
-  TensorView* mha_w1 = makeContigConcreteTensor({D, E, E / D}, dtype);
-  TensorView* mlp_w0 = makeContigTensor(3, dtype);
-  TensorView* mlp_b0 = makeContigTensor(2, dtype);
-  TensorView* mlp_w1 = makeContigTensor(3, dtype);
-  TensorView* mlp_b1 = makeContigTensor(1, dtype);
-  TensorView* mha_mask = makeContigTensor(2, DataType::Bool);
-  TensorView* mlp_mask = makeContigTensor(2, DataType::Bool);
-  TensorView* mha_sdpa_out = makeConcreteTensor({D, B, H / D, S, E / H}, dtype);
-  TensorView* mha_sdpa_log_sumexp =
-      makeContigConcreteTensor({D, B, H / D, S}, DataType::Float);
-  TensorView* mha_sdpa_seed = makeSymbolicTensor({}, DataType::Int);
-  TensorView* mha_sdpa_offset = makeSymbolicTensor({}, DataType::Int);
-  TensorView* ln1_w = makeContigTensor(1);
-  TensorView* ln1_b = makeContigTensor(1);
-  TensorView* ln1_mean = makeConcreteTensor({B * S, 1});
-  TensorView* ln1_rstd = makeConcreteTensor({B * S, 1});
-  TensorView* ln0_w = makeContigTensor(1);
-  TensorView* ln0_b = makeContigTensor(1);
-  TensorView* ln0_mean = makeConcreteTensor({B * S, 1});
-  TensorView* ln0_rstd = makeConcreteTensor({B * S, 1});
-  TensorView* mha_linear1 = makeContigTensor(2);
-
-  fusion->addInput(x);
-  fusion->addInput(grad);
-  fusion->addInput(mha_w0);
-  fusion->addInput(mha_b0);
-  fusion->addInput(mha_w1);
-  fusion->addInput(mlp_w0);
-  fusion->addInput(mlp_b0);
-  fusion->addInput(mlp_w1);
-  fusion->addInput(mlp_b1);
-  fusion->addInput(mlp_mask);
-  fusion->addInput(mha_mask);
-  fusion->addInput(mha_sdpa_out);
-  fusion->addInput(mha_sdpa_log_sumexp);
-  fusion->addInput(mha_sdpa_seed);
-  fusion->addInput(mha_sdpa_offset);
-  fusion->addInput(ln1_w);
-  fusion->addInput(ln1_b);
-  fusion->addInput(ln1_mean);
-  fusion->addInput(ln1_rstd);
-  fusion->addInput(ln0_w);
-  fusion->addInput(ln0_b);
-  fusion->addInput(ln0_mean);
-  fusion->addInput(ln0_rstd);
-  fusion->addInput(mha_linear1);
-
-  // Recomputation: Recompute, mha linear0, qkv, mlp linear0, and mlp gelu.
-  // Partially recompute layer norms using cached statistics.
-  // Note: The thunder trace recompute mha linear1, but this would result in 3
-  // AllReduces in the backwards pass.
-  auto ln_0 = layer_norm_with_cached_statistics(
-      x, ln0_mean, ln0_rstd, norm_shape, ln0_w, ln0_b);
-  auto mha_in = castOp(dtype, ln_0);
-  auto qkv = mha_qkv(mha_in, mha_w0, mha_b0, mesh).qkv;
-
-  Val* dropout_scale = IrBuilder::create<Val>(1.0 / (1.0 - kDropoutProb));
-  // Use input mha_mask to implement dropout
-  auto mha_out = mul(mha_linear1, mha_mask);
-  mha_out = mul(mha_out, dropout_scale);
-  auto resid_0 = add(x, mha_out);
-  auto ln_1 = layer_norm_with_cached_statistics(
-      resid_0, ln1_mean, ln1_rstd, norm_shape, ln1_w, ln1_b);
-  auto mlp_in = castOp(dtype, ln_1);
-  // Note: We only use linear0 and gelu outputs from the mlp forward pass.
-  auto mlp_tvs = mlp(mlp_in, mlp_w0, mlp_b0, mlp_w1, mlp_b1, mesh);
-
-  // Backwards
-  auto mlp_grads = mlp_backwards(
-      grad,
-      mlp_in,
-      mlp_mask,
-      mlp_w0,
-      mlp_b0,
-      mlp_w1,
-      mesh,
-      mlp_tvs[0],
-      mlp_tvs[1]);
-  auto ln1_grads = layer_norm_backward(
-      castOp(DataType::Float, mlp_grads[6]),
-      resid_0,
-      norm_shape,
-      ln1_mean,
-      ln1_rstd,
-      ln1_w,
-      ln1_b,
-      {true, true, true});
-  auto resid1_grad = add(ln1_grads.grad_input, grad);
-  auto mha_grads = mha_backwards(
-      mha_in,
-      mha_w0,
-      mha_b0,
-      mha_w1,
-      mha_mask,
-      mha_sdpa_out,
-      mha_sdpa_log_sumexp,
-      mha_sdpa_seed,
-      mha_sdpa_offset,
-      resid1_grad,
-      qkv,
-      mesh);
-  auto ln0_grads = layer_norm_backward(
-      castOp(DataType::Float, mha_grads[8]),
-      x,
-      norm_shape,
-      ln0_mean,
-      ln0_rstd,
-      ln0_w,
-      ln0_b,
-      {true, true, true});
-  auto dx = add(ln0_grads.grad_input, resid1_grad);
-
-  fusion->addOutput(mlp_grads[1]); // mlp linear1 weight grad
-  fusion->addOutput(mlp_grads[2]); // mlp linear1 bias grad
-  fusion->addOutput(mlp_grads[4]); // mlp linear0 weight grad
-  fusion->addOutput(mlp_grads[5]); // mlp linear0 bias grad
-  fusion->addOutput(ln1_grads.grad_weight);
-  fusion->addOutput(ln1_grads.grad_bias);
-  fusion->addOutput(mha_grads[1]); // mha linear1 weight grad
-  fusion->addOutput(mha_grads[2]); // mha linear1 bias grad
-  fusion->addOutput(mha_grads[6]); // mha linear0 weight grad
-  fusion->addOutput(mha_grads[7]); // mha linear0 bias grad
-  fusion->addOutput(ln0_grads.grad_weight);
-  fusion->addOutput(ln0_grads.grad_bias);
-  fusion->addOutput(dx); // transformer grad input
-
-  // Sharding annotations for input and output TVs not sharded
-  // by mlp_backward, mha_backward, or mlp.
-  for (auto* tv :
-       {mha_linear1,
-        ln0_w,
-        ln0_b,
-        ln0_mean,
-        ln0_rstd,
-        ln1_w,
-        ln1_b,
-        ln1_mean,
-        ln1_rstd,
-        ln1_grads.grad_weight,
-        ln1_grads.grad_bias,
-        ln0_grads.grad_weight,
-        ln0_grads.grad_bias,
-        ln0_grads.grad_input}) {
-    tv->setDeviceMesh(mesh);
-  }
-  for (auto* tv : {mha_w0, mha_b0, mha_w1, mha_sdpa_out, mha_sdpa_log_sumexp}) {
-    tv->setDeviceMesh(mesh);
-    tv->axis(0)->parallelize(ParallelType::DIDx);
-  }
-
-  // Sharded inputs to outputs
-  shardBetween(
-      {mha_w0, mha_b0, mha_w1, mha_sdpa_out},
-      {mha_grads[1], mha_grads[6], mha_grads[7]},
-      mha_w0);
-  shardBetween(
-      {mlp_w0, mlp_w1, mlp_b0},
-      {mlp_grads[1], mlp_grads[4], mlp_grads[5]},
-      mlp_w0);
-
-  // Unsharded inputs to outputs
-  shardBetween(
-      {x,
-       grad,
-       mha_mask,
-       mlp_mask,
-       mha_linear1,
-       ln0_mean,
-       ln0_w,
-       ln0_b,
-       ln1_mean,
-       ln1_w,
-       ln1_b,
-       mlp_b1},
-      {mlp_grads[2],
-       ln1_grads.grad_weight,
-       ln1_grads.grad_bias,
-       mha_grads[2],
-       ln0_grads.grad_weight,
-       ln0_grads.grad_bias,
-       dx},
-      x);
-
   const auto options =
       at::TensorOptions().dtype(at_dtype).device(communicator_->device());
   auto x_ = at::randn({B * S, E}, options).to(at::kFloat);
@@ -1363,9 +756,10 @@ TEST_P(DistributedTransformerTest, Backward) {
       mha_out_[2].to(at::kFloat) // mha linear1
   };
 
-  FusionExecutorCache fec(std::move(fusion));
+  DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
+  auto fec = model.backward(dtype);
   at::manual_seed(getATenRandomSeed());
-  auto outputs = fec.runFusionWithInputs(inputs);
+  auto outputs = fec->runFusionWithInputs(inputs);
   validate(
       expected_outputs,
       outputs,

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -53,7 +53,8 @@ void validate(
     const std::vector<at::Tensor>& outputs,
     const std::vector<double>& atols) {
   for (auto i : c10::irange(expected_outputs.size())) {
-    std::cout << i << " " << outputs[i].sizes() << " " << expected_outputs[i].sizes() << std::endl;
+    std::cout << i << " " << outputs[i].sizes() << " "
+              << expected_outputs[i].sizes() << std::endl;
   }
 
   using testing::SizeIs;
@@ -84,6 +85,23 @@ void validate(
       default:
         rtol = 0.0;
         break;
+    }
+
+    if (true) {
+      auto error =
+          (outputs[i].to(expected_outputs[i].dtype()) - expected_outputs[i])
+              .abs();
+      auto max_error = error.max().item().to<double>();
+      auto max_relative_error =
+          (max_error / expected_outputs[i].abs().max()).item();
+      auto error_count =
+          at::sum(error >= (atol + expected_outputs[i].abs() * rtol)).item();
+      std::cout << "output[" << i << "] max error: " << max_error << std::endl;
+      std::cout << "          max relative error: " << max_relative_error
+                << std::endl;
+      std::cout << "          failing elements: " << error_count << ", "
+                << error_count.to<float>() / at::numel(outputs[i]) * 100.0
+                << "\% of tensor" << std::endl;
     }
 
     auto generate_comparison_details = [](at::Tensor expected_out,
@@ -124,7 +142,7 @@ std::vector<at::Tensor> reference_mlp(
     at::Tensor b1) {
   auto at_dtype = w0.dtype();
   auto linear0 = at::linear(x, w0, b0);
-  auto gelu = at::gelu(linear0, "tanh").to(at_dtype);
+  auto gelu = at::gelu(linear0.to(at::kFloat), "tanh").to(at_dtype);
   auto linear1 = at::linear(gelu, w1, b1).to(at::kFloat);
   auto [dropout, mask] = at::native_dropout(linear1, kDropoutProb, true);
   return {linear0, gelu, linear1, dropout, mask};
@@ -136,8 +154,8 @@ std::vector<at::Tensor> reference_mha(
     at::Tensor b0,
     at::Tensor w1,
     at::Tensor b1) {
-  auto linear0 = at::linear(x, w0, b0).view({B, S, 3 * E});
-  auto qkv = linear0.split(E, 2);
+  auto linear0 = at::linear(x, w0, b0);
+  auto qkv = linear0.view({B, S, 3 * E}).split(E, 2);
   for (auto i = 0; i < 3; i++) {
     qkv[i] = qkv[i].reshape({B, S, H, E / H}).transpose(1, 2);
   }
@@ -146,10 +164,10 @@ std::vector<at::Tensor> reference_mha(
   auto sdpa = std::get<0>(sdpa_out);
   // Reassemble heads (B, H, S, E/H) to (B, S, H, E/H) to (B, S, E)
   auto y = sdpa.transpose(1, 2).reshape({B * S, E});
-  auto linear1 = at::matmul(y, w1.transpose(0,1)).to(at::kFloat) + b1;
+  auto matmul1 = at::matmul(y, w1.transpose(0, 1));
+  auto linear1 = (matmul1 + b1).to(at::kFloat);
   // auto linear1 = at::linear(y, w1, b1).to(at::kFloat);
-  auto [dropout, mask] =
-      at::native_dropout(linear1, kDropoutProb, true);
+  auto [dropout, mask] = at::native_dropout(linear1, kDropoutProb, true);
   return {linear0, sdpa, linear1, dropout, mask};
 }
 
@@ -172,17 +190,13 @@ std::vector<at::Tensor> reference_mlp_backwards(
   auto matmul1_grad = at::matmul(dropout_grad_q, w1);
   auto matmul1_grad_w =
       at::matmul(dropout_grad_q.transpose(0, 1), gelu.to(at_dtype));
-  std::cout << "w1 " << w1.sizes() << " grad sizes " << matmul1_grad_w.sizes() << std::endl;
   auto matmul1_grad_b = at::sum(dropout_grad, {0});
   auto gelu_grad =
       at::gelu_backward(matmul1_grad.to(at::kFloat), linear0, "tanh");
   auto gelu_grad_q = gelu_grad.to(at_dtype);
   auto matmul0_grad_b = at::sum(gelu_grad, {0});
   auto matmul0_grad = at::matmul(gelu_grad_q, w0);
-  auto matmul0_grad_w =
-      at::matmul(gelu_grad_q.transpose(0, 1), x);
-    std::cout << "w10 " << w1.sizes() << " grad sizes " << matmul0_grad_w.sizes() << std::endl;
-
+  auto matmul0_grad_w = at::matmul(gelu_grad_q.transpose(0, 1), x);
 
   std::vector<at::Tensor> grads = {
       dropout_grad,
@@ -204,9 +218,7 @@ std::vector<at::Tensor> reference_mha_backwards(
     at::Tensor w1) {
   auto at_dtype = w0.dtype();
   // recompute up to sdpa
-  std::cout << "MHA x, w0 " << x.sizes() << " " << w0.sizes() << std::endl;
   auto linear0 = at::linear(x, w0, b0).view({B, S, 3 * E});
-  std::cout << "Out " << linear0.sizes() << std::endl;
   auto qkv = linear0.split(E, /*dim=*/-1);
   for (auto i = 0; i < 3; i++) {
     qkv[i] = qkv[i].reshape({B, S, H, E / H}).transpose(1, 2).to(at_dtype);
@@ -234,7 +246,6 @@ std::vector<at::Tensor> reference_mha_backwards(
   auto dropout_grad =
       at::native_dropout_backward(y_grad, mask, 1.0 / (1.0 - kDropoutProb));
   auto dropout_grad_q = dropout_grad.to(at_dtype);
-  std::cout << "Linear1xgrad " << dropout_grad_q.sizes() << " " << w1.sizes() << std::endl;
   auto linear1_x_grad = at::matmul(dropout_grad_q, w1);
   auto sdpa_output_reshape = sdpa_output.transpose(1, 2).view({B * S, E});
   auto linear1_w_grad =
@@ -264,7 +275,6 @@ std::vector<at::Tensor> reference_mha_backwards(
        v_grad.transpose(1, 2).view({B * S, E})},
       -1);
   auto linear0_b_grad = at::sum(qkv_grad.to(at::kFloat), {0});
-  std::cout << "Linear0xgrad " << qkv_grad.sizes() << " " << w0.sizes() << std::endl;
   auto linear0_x_grad = at::matmul(qkv_grad, w0);
   auto linear0_w_grad = at::matmul(qkv_grad.transpose(0, 1), x);
 
@@ -335,7 +345,7 @@ std::vector<TensorView*> mha_qkv(
   std::vector<TensorView*> qkv = chunk(qkv_cat, 3, -1);
   for (auto i : c10::irange(3)) {
     qkv[i] = reshape(qkv[i], {D, B, S, E / D}, {D, B, S, H / D, E / H});
-    qkv[i] = castOp(dtype, transpose(qkv[i], 2, 3));
+    qkv[i] = transpose(qkv[i], 2, 3);
     // Explicitly shard q, k, and v before calling SDPA node
     qkv[i]->setDeviceMesh(mesh);
     qkv[i]->axis(0)->parallelize(ParallelType::DIDx);
@@ -353,13 +363,18 @@ std::vector<TensorView*> mha(
   const auto D = w0->axis(0)->extent()->value().as<int64_t>();
   auto dtype = w0->dtype();
   TensorView* linear0 = linear(x, w0, b0);
+  TensorView* linear0_float = castOp(DataType::Float, linear0);
+  // TensorView* matmul0 = matmul(x, transpose(w0, 1, 2));
+  // TensorView* linear0 = add(matmul0, broadcast(b0, {false, true, false}));
+  // linear0 = castOp(dtype, linear0);
   // Forming the q,k,v vectors:
   TensorView* qkv_cat =
-      reshape(linear0, {D, B * S, 3 * E / D}, {D, B, S, 3 * E / D});
+      reshape(linear0_float, {D, B * S, 3 * E / D}, {D, B, S, 3 * E / D});
   std::vector<TensorView*> qkv = chunk(qkv_cat, 3, -1);
   for (auto i : c10::irange(3)) {
     qkv[i] = reshape(qkv[i], {D, B, S, E / D}, {D, B, S, H / D, E / H});
     qkv[i] = transpose(qkv[i], 2, 3);
+    qkv[i] = castOp(dtype, qkv[i]);
     // Explicitly shard q, k, and v before calling SDPA node
     qkv[i]->setDeviceMesh(mesh);
     qkv[i]->axis(0)->parallelize(ParallelType::DIDx);
@@ -378,6 +393,8 @@ std::vector<TensorView*> mha(
   TensorView* sdpa_reshape =
       reshape(sdpa_transpose, {D, B, S, H / D, E / H}, {D, B * S, E / D});
   TensorView* local_matmul1 = matmul(sdpa_reshape, transpose(w1, 1, 2));
+  std::cout << "Data type of matmul " << local_matmul1->toString() << std::endl;
+  local_matmul1 = castOp(DataType::Float, local_matmul1);
   TensorView* matmul1 = sum(local_matmul1, {0}); // allreduce
   TensorView* linear1 = add(matmul1, broadcast(b1, {true, false}));
   // Dropout
@@ -416,12 +433,10 @@ LinearBackwardsResult linear_backwards(
   DataType dtype = w->dtype();
   TensorView* grad_f = maybeCastOp(DataType::Float, grad);
   TensorView* grad_q = maybeCastOp(dtype, grad);
-  // TensorView* w_t = transpose(w, 1, 2);
   TensorView* grad_x_partials = matmul(grad_q, w);
   TensorView* grad_x = sum(grad_x_partials, {0}); // allreduce
   TensorView* grad_q_t = transpose(grad_q, 1, 2);
   TensorView* grad_w = matmul(grad_q_t, x);
-  // TensorView* grad_w = transpose(grad_w_t, 1, 2);
   TensorView* grad_b = sum(grad_f, {1});
 
   return {grad_x, grad_w, grad_b};
@@ -439,11 +454,9 @@ LinearBackwardsResult sharded_linear_backwards(
     TensorView* grad) {
   DataType dtype = w->dtype();
   TensorView* grad_q = castOp(dtype, grad);
-  // TensorView* w_t = transpose(w, 1, 2);
   TensorView* grad_x = matmul(grad_q, w);
   TensorView* grad_t = transpose(grad_q, 0, 1);
   TensorView* grad_w = matmul(grad_t, x);
-  // TensorView* grad_w = transpose(grad_w_t, 1, 2);
   TensorView* grad_b = sum(grad, {0});
 
   return {grad_x, grad_w, grad_b};
@@ -501,8 +514,6 @@ std::vector<TensorView*> mlp_backwards(
   TensorView* dropout_grad = dropout_backward(grad, mask, dropout_scale);
 
   auto linear1_grads = sharded_linear_backwards(gelu, w1, dropout_grad);
-  std::cout << "w1 " << w1->toString() << std::endl;
-  std::cout << "w1 grad " << linear1_grads.grad_w->toString() << std::endl;
 
   TensorView* matmul1_grad_x_ = castOp(DataType::Float, linear1_grads.grad_x);
   TensorView* gelu_grad = tanh_gelu_backward(matmul1_grad_x_, linear0);
@@ -634,7 +645,7 @@ std::vector<TensorView*> mha_backwards(
       sdpa_grad.grad_query,
       sdpa_grad.grad_key,
       sdpa_grad.grad_value,
-      linear0_grads.grad_w,
+      linear0_grads.grad_w, // todo failing point tolerance wise
       linear0_grads.grad_b,
       linear0_grads.grad_x};
 }
@@ -908,7 +919,6 @@ TEST_P(DistributedTransformerTest, MHA_Backward) {
 
   at::manual_seed(getATenRandomSeed());
   auto reference_outs = reference_mha_backwards(grad, x, mask, w0, b0, w1);
-  std::cout << "Reference done " << std::endl;
   std::vector<c10::IValue> inputs = {
       x,
       shardTensor(w0.view({3, E, E}), 1, mesh).view({1, 3 * E / D, E}),
@@ -920,8 +930,6 @@ TEST_P(DistributedTransformerTest, MHA_Backward) {
       shardTensor(reference_outs[1], 1, mesh), // sdpa.log_sumexp
       reference_outs[2],
       reference_outs[3]};
-  std::cout << "Done with inputs " << std::endl;
-  std::cout << "reference out 10 " << reference_outs[10].sizes() << " " << reference_outs[11].sizes() << std::endl;
   std::vector<at::Tensor> expected_outputs = {
       reference_outs[4], // dropout grad
       shardTensor(reference_outs[5], 1, mesh), // linear1 weight grad
@@ -934,7 +942,6 @@ TEST_P(DistributedTransformerTest, MHA_Backward) {
       shardTensor(reference_outs[11].view({3, E}), 1, mesh)
           .view({1, 3 * E / D}), // linear0 bias grad
       reference_outs[12]};
-  std::cout << "Done with outputs " << std::endl;
 
   FusionExecutorCache fec(std::move(fusion));
   at::manual_seed(getATenRandomSeed());
@@ -998,7 +1005,7 @@ TEST_P(DistributedTransformerTest, Forward) {
   auto resid1 = add(resid0, mlp_out);
 
   fusion->addOutput(ln0.output);
-  fusion->addOutput(mha_out);
+  fusion->addOutput(mha_out); // failing starting here
   fusion->addOutput(ln1.output);
   fusion->addOutput(mlp_out);
   fusion->addOutput(resid1);
@@ -1288,20 +1295,16 @@ TEST_P(DistributedTransformerTest, Backward) {
   auto [ln0_, ln0_mean_, ln0_rstd_] =
       at::native_layer_norm(x_, norm_shape, ln0_w_, ln0_b_, kEps);
   auto mha_in_ = ln0_.to(at_dtype);
-  std::cout << "1" << std::endl;
   auto mha_out_ = reference_mha(mha_in_, mha_w0_, mha_b0_, mha_w1_, mha_b1_);
-  std::cout << "2" << std::endl;
   auto resid0_ = mha_out_[3] + x_;
   auto [ln1_, ln1_mean_, ln1_rstd_] =
       at::native_layer_norm(resid0_, norm_shape, ln1_w_, ln1_b_, kEps);
   auto mlp_in_ = ln1_.to(at_dtype);
   auto mlp_out_ = reference_mlp(mlp_in_, mlp_w0_, mlp_b0_, mlp_w1_, mlp_b1_);
-  std::cout << "3" << std::endl;
 
   // Backwards pass
   auto mlp_grads_ = reference_mlp_backwards(
       grad_, mlp_in_, mlp_out_[4], mlp_w0_, mlp_b0_, mlp_w1_);
-  std::cout << "4" << std::endl;
   auto [ln1_x_grad_, ln1_w_grad_, ln1_b_grad_] = at::native_layer_norm_backward(
       mlp_grads_[6].to(at::kFloat),
       resid0_,
@@ -1312,7 +1315,6 @@ TEST_P(DistributedTransformerTest, Backward) {
       ln1_b_,
       {true, true, true});
   auto resid1_grad_ = ln1_x_grad_ + grad_;
-  std::cout << "5" << std::endl;
   auto mha_grads_ = reference_mha_backwards(
       resid1_grad_, mha_in_, mha_out_[4], mha_w0_, mha_b0_, mha_w1_);
   auto [ln0_x_grad_, ln0_w_grad_, ln0_b_grad_] = at::native_layer_norm_backward(
@@ -1324,9 +1326,7 @@ TEST_P(DistributedTransformerTest, Backward) {
       ln0_w_,
       ln0_b_,
       {true, true, true});
-  std::cout << "6" << std::endl;
   auto dx_ = ln0_x_grad_ + resid1_grad_;
-  std::cout << "done" << std::endl;
 
   auto expected_outputs = {
       shardTensor(mlp_grads_[1], 1, mesh), // mlp_linear1_weight_grad
@@ -1337,7 +1337,8 @@ TEST_P(DistributedTransformerTest, Backward) {
       ln1_b_grad_,
       shardTensor(mha_grads_[5], 1, mesh), // mha linear1 weight grad
       mha_grads_[6], // mha linear1 bias grad
-      shardTensor(mha_grads_[10].view({3, E, E}), 1, mesh)
+      shardTensor(
+          mha_grads_[10].view({3, E, E}), 1, mesh) // failing starting here
           .view({1, 3 * E / D, E}), // mha linear0 bias grad
       shardTensor(mha_grads_[11].view({3, E}), 1, mesh)
           .view({1, 3 * E / D}), // mha linear0 bias grad
@@ -1372,17 +1373,9 @@ TEST_P(DistributedTransformerTest, Backward) {
       mha_out_[2].to(at::kFloat) // mha linear1
   };
 
-  // FusionExecutorCache fec(std::move(fusion));
-  hir::HostIrExecutorParams executor_params_{
-      .use_fusion_executor_cache = true,
-      .skip_auto_scheduling = false,
-      .cache_fusion_executor = false};
-  MultiDeviceExecutor runtime(
-      std::move(fusion), *communicator_, executor_params_);
-
+  FusionExecutorCache fec(std::move(fusion));
   at::manual_seed(getATenRandomSeed());
-  auto outputs = runtime.runWithInput(inputs);
-  // auto outputs = fec.runFusionWithInputs(inputs);
+  auto outputs = fec.runFusionWithInputs(inputs);
   validate(
       expected_outputs,
       outputs,


### PR DESCRIPTION
(1) Moves C++ Transformer definition from `test_multidevice_transfromer.cpp` to `multidevice_transfromer.h/cpp`. So that we can call the same transformer definition in the tests for validation (with no SDPA dropout, smaller parameters) and in the benchmark (with GPT3 parameter sizes).