### PR TITLE
Run with and without half-precision matmul reduction in benchmark

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -127,11 +127,11 @@ class NVFBenchmark:
         Returns:
             self.current_time: Global monotonic clock variable
         """
-        try:
-            self.prof.stop()
-        except AssertionError:
+        if self.prof.profiler is None:
             self.prof.start()
             return self.current_time
+
+        self.prof.stop()
 
         prof_averages = self.prof.key_averages()
         elapsed_cuda_time = self._get_kernel_time(prof_averages)
@@ -161,7 +161,7 @@ class NVFBenchmark:
             time_value: Elapsed CUDA time in seconds.
         """
         elapsed_cuda_time = 0
-        has_cuda_event = False
+        self.has_cuda_event = False
         for event in prof_averages:
             if event.device_type != DeviceType.CUDA:
                 continue
@@ -172,7 +172,6 @@ class NVFBenchmark:
                 if hasattr(event, "self_device_time_total")
                 else event.self_cuda_time_total
             )
-        assert has_cuda_event, "No CUDA events found"
         return elapsed_cuda_time / 1e6
 
     def _increment_global_time(self, elapsed_time: float) -> None:
@@ -223,14 +222,15 @@ class NVFBenchmark:
                     iobytes += out.element_size() * out.numel()
 
         self.benchmark.extra_info["IOBytes"] = iobytes
-        bandwidth_bps = (
-            iobytes * self.benchmark.stats["rounds"]
-        ) / self.benchmark.stats["total"]
-        self.benchmark.extra_info["Bandwidth (Bps)"] = bandwidth_bps
-        self.benchmark.extra_info["Bandwidth (GBps)"] = bandwidth_bps / 1e9
-        self.benchmark.extra_info["% Peak Bandwidth (SOL)"] = (
-            100 * (bandwidth_bps / 1e9) / PEAK_BANDWIDTH_GBPS
-        )
+        if self.has_cuda_event:
+            bandwidth_bps = (
+                iobytes * self.benchmark.stats["rounds"]
+            ) / self.benchmark.stats["total"]
+            self.benchmark.extra_info["Bandwidth (Bps)"] = bandwidth_bps
+            self.benchmark.extra_info["Bandwidth (GBps)"] = bandwidth_bps / 1e9
+            self.benchmark.extra_info["% Peak Bandwidth (SOL)"] = (
+                100 * (bandwidth_bps / 1e9) / PEAK_BANDWIDTH_GBPS
+            )
 
 
 def run_benchmark(

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -127,11 +127,11 @@ class NVFBenchmark:
         Returns:
             self.current_time: Global monotonic clock variable
         """
-        if self.prof.profiler is None:
+        try:
+            self.prof.stop()
+        except AssertionError:
             self.prof.start()
             return self.current_time
-
-        self.prof.stop()
 
         prof_averages = self.prof.key_averages()
         elapsed_cuda_time = self._get_kernel_time(prof_averages)
@@ -161,7 +161,7 @@ class NVFBenchmark:
             time_value: Elapsed CUDA time in seconds.
         """
         elapsed_cuda_time = 0
-        self.has_cuda_event = False
+        has_cuda_event = False
         for event in prof_averages:
             if event.device_type != DeviceType.CUDA:
                 continue
@@ -172,6 +172,7 @@ class NVFBenchmark:
                 if hasattr(event, "self_device_time_total")
                 else event.self_cuda_time_total
             )
+        assert has_cuda_event, "No CUDA events found"
         return elapsed_cuda_time / 1e6
 
     def _increment_global_time(self, elapsed_time: float) -> None:
@@ -222,15 +223,14 @@ class NVFBenchmark:
                     iobytes += out.element_size() * out.numel()
 
         self.benchmark.extra_info["IOBytes"] = iobytes
-        if self.has_cuda_event:
-            bandwidth_bps = (
-                iobytes * self.benchmark.stats["rounds"]
-            ) / self.benchmark.stats["total"]
-            self.benchmark.extra_info["Bandwidth (Bps)"] = bandwidth_bps
-            self.benchmark.extra_info["Bandwidth (GBps)"] = bandwidth_bps / 1e9
-            self.benchmark.extra_info["% Peak Bandwidth (SOL)"] = (
-                100 * (bandwidth_bps / 1e9) / PEAK_BANDWIDTH_GBPS
-            )
+        bandwidth_bps = (
+            iobytes * self.benchmark.stats["rounds"]
+        ) / self.benchmark.stats["total"]
+        self.benchmark.extra_info["Bandwidth (Bps)"] = bandwidth_bps
+        self.benchmark.extra_info["Bandwidth (GBps)"] = bandwidth_bps / 1e9
+        self.benchmark.extra_info["% Peak Bandwidth (SOL)"] = (
+            100 * (bandwidth_bps / 1e9) / PEAK_BANDWIDTH_GBPS
+        )
 
 
 def run_benchmark(

--- a/benchmarks/python/test_matmul.py
+++ b/benchmarks/python/test_matmul.py
@@ -25,11 +25,11 @@ def load_matmul_problems():
         return list((int(m), int(n), int(k), layout) for m, n, k, layout in reader)
 
 
+@pytest.mark.parametrize("half_reduction", [False, True], ids=["fullred", "halfred"])
 @pytest.mark.parametrize("eager", [False, True], ids=["nvfuser", "eager"])
-@pytest.mark.parametrize("half_reduction", [False, True])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
 @pytest.mark.parametrize(
-    "config", load_matmul_problems(), ids=lambda val: "_".join(str(v) for v in val)
+    "config", load_matmul_problems(), ids=lambda val: "-".join(str(v) for v in val)
 )
 def test_matmul_nvf_benchmark(
     benchmark,

--- a/benchmarks/python/test_matmul.py
+++ b/benchmarks/python/test_matmul.py
@@ -40,6 +40,11 @@ def test_matmul_nvf_benchmark(
 
     clear_cuda_cache()
 
+    # disable half-precision split-K reduction in cuBLAS since we do not
+    # support this in nvFuser
+    torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+    torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+
     try:
         a = torch.randn(m, k, device="cuda", dtype=dtype)
         b = torch.randn(k, n, device="cuda", dtype=dtype)

--- a/benchmarks/python/test_matmul.py
+++ b/benchmarks/python/test_matmul.py
@@ -57,12 +57,11 @@ def test_matmul_baseline_benchmark(
             b = b.as_strided(size=[k, n], stride=[1, k])
 
         # NOTE: we never need to validate eager, as it is our baseline
-        if not disable_benchmarking:
-            run_benchmark(
-                benchmark,
-                lambda ab: torch.matmul(*ab),
-                [a, b],
-            )
+        run_benchmark(
+            benchmark,
+            lambda ab: torch.matmul(*ab),
+            [a, b],
+        )
 
     except torch.OutOfMemoryError:
         pytest.skip("Test failed due to OutOfMemoryError")


### PR DESCRIPTION
This changes the python matmul benchmark to run four times as many tests:
- We parametrize by reduction in float or in fp16/bf16, which is enabled by default in PyTorch.
- We parametrize by `eager`. If this is true we directly compute `torch.matmul` without involving nvFuser. Otherwise we use nvFuser. This lets us compute baselines in the same run as we compute the nvFuser result instead of needing to re-run the benchmark with different environment variables as we previously had to.

nvFuser does not support split-K in reduced precision (see #1719), so we skip these cases for now.