### PR TITLE
Rename take_along_axis and torch_gather to camelCase

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -3604,7 +3604,7 @@ class PreferredMergeCandidatePicker {
   }
 
   //! Prefer merging groups with select-like exprs with producer
-  //! groups, including index_select, torch_gather and take_along_axis
+  //! groups, including indexSelect, torchGather and takeAlongAxis
   //! where only one element is selected/gathered/taken, producing a
   //! broadcast domain. Fusing these exprs with producers is
   //! straightforward, but may not be always possible with consumers as
@@ -3614,11 +3614,11 @@ class PreferredMergeCandidatePicker {
   //! these exprs as the segment output tensors would become smaller.
   //!
   //! A motivating example is cross-entropy loss, where softmax is
-  //! followed by take_along_axis, and then is followed by a
+  //! followed by takeAlongAxis, and then is followed by a
   //! reduction. Currently, it's not possible to fuse the softmax and
   //! the reduction, so it must be segmented to two groups, and we
-  //! want to segment the fusion between the take_along_axis and the
-  //! reduction, not between the softmax and take_along_axis.
+  //! want to segment the fusion between the takeAlongAxis and the
+  //! reduction, not between the softmax and takeAlongAxis.
   std::optional<SegmentedGroup::NeighborGroup> mergeSelectLikeOpsWithProducers(
       SegmentedGroup* group) const;
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -196,7 +196,7 @@ std::string TorchGatherOp::toString(int indent_size) const {
   indent(ss, indent_size) << output(0)->toString() << "\n";
   indent_size++;
   indent(ss, indent_size) << " = "
-                          << (exactSizes() ? "take_along_axis" : "torch_gather")
+                          << (exactSizes() ? "takeAlongAxis" : "torchGather")
                           << "( " << input(0)->toString();
   if (exactSizes()) {
     ss << ", " << input(1)->toString() << ", dim = " << dim() << " )\n";

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -443,11 +443,11 @@ bool isSqueezeInput(const TensorView* tv);
 bool isSqueezedID(const TensorView* tv, const IterDomain* id);
 
 // Test if the given ID in the given tensor is indirectly accessed by,
-// e.g., index_select, torch_gather and scatter
+// e.g., indexSelect, torchGather and scatter
 bool isIndexedID(const TensorView* tv, const IterDomain* id);
 
 // Test if the given ID in the given tensor is indirectly read by,
-// e.g., index_select and torch_gather
+// e.g., indexSelect and torchGather
 bool isIndexedProducerID(const TensorView* tv, const IterDomain* id);
 
 // Test if the given ID in the given tensor is indirectly written to by,
@@ -455,7 +455,7 @@ bool isIndexedProducerID(const TensorView* tv, const IterDomain* id);
 bool isIndexedConsumerID(const TensorView* tv, const IterDomain* id);
 
 // Return a producer ID, if any, that is indirectly accessed by, e.g.,
-// index_select and torch_gather.
+// indexSelect and torchGather.
 IterDomain* getIndexedProducerID(const Expr* expr);
 
 // Return the corresponding consumer if of a producer ID that is

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -315,7 +315,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     // Conditions to check:
     // 1. Indirectly accessed IDs (e.g., select)
     // 2. IDs that may have different extents (e.g., non indexed
-    //  domains of torch_gather)
+    //  domains of torchGather)
     // 3. Squeeze and unsqueeze
 
     // Condition 1: when the producer ID is the dim of a select-like op

--- a/csrc/logical_domain_map.h
+++ b/csrc/logical_domain_map.h
@@ -156,9 +156,9 @@ class PairwiseLogicalDomainMap : public LogicalDomainMap {
   //! match. Note that this is off by default, in which case they are mapped
   //! only if their extents match.
   bool map_symbolic_ = false;
-  //! Map domains that may have different extents, e.g., torch_gather
+  //! Map domains that may have different extents, e.g., torchGather
   bool map_different_extents_ = false;
-  //! Map domains that are indirectly accessed, e.g., index_select
+  //! Map domains that are indirectly accessed, e.g., indexSelect
   bool map_indexed_domains_ = false;
 };
 

--- a/csrc/ops/indexing.cpp
+++ b/csrc/ops/indexing.cpp
@@ -101,7 +101,7 @@ TensorView* indexSelect(
 }
 
 // torch.gather
-TensorView* torch_gather(TensorView* inp, int64_t dim, TensorView* index) {
+TensorView* torchGather(TensorView* inp, int64_t dim, TensorView* index) {
   auto inp_domain = TensorDomain::noReductions(inp->getLogicalDomain());
   auto idx_domain = TensorDomain::noReductions(index->getLogicalDomain());
   NVF_CHECK(
@@ -178,7 +178,7 @@ TensorView* scatter(
   return scatterOp(ScatterOpType::Set, self, dim, index, src);
 }
 
-TensorView* take_along_axis(TensorView* inp, TensorView* index, int64_t dim) {
+TensorView* takeAlongAxis(TensorView* inp, TensorView* index, int64_t dim) {
   const auto inp_domain = TensorDomain::noReductions(inp->getLogicalDomain());
   const auto idx_domain = TensorDomain::noReductions(index->getLogicalDomain());
 

--- a/csrc/ops/indexing.h
+++ b/csrc/ops/indexing.h
@@ -24,7 +24,7 @@ NVF_API TensorView* indexSelect(
     TensorView* index);
 
 // torch.gather
-NVF_API TensorView* torch_gather(
+NVF_API TensorView* torchGather(
     TensorView* input,
     int64_t dim,
     TensorView* index);
@@ -46,8 +46,8 @@ NVF_API TensorView* scatter(
 //! numpy.take_along_axis
 //! (https://numpy.org/doc/stable/reference/generated/numpy.take_along_axis.html)
 //! Note the order of the parameters follows the numpy order, which is
-//! different from torch_gather.
-NVF_API TensorView* take_along_axis(
+//! different from torchGather.
+NVF_API TensorView* takeAlongAxis(
     TensorView* input,
     TensorView* index,
     int64_t dim);

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1840,7 +1840,7 @@ struct TorchGatherOpRecord : RecordFunctor {
     auto arg1 = fd.getFusionState(args_.at(0).index)->template as<TensorView>();
     auto arg3 = fd.getFusionState(args_.at(1).index)->template as<TensorView>();
 
-    Val* output = torch_gather(arg1, dim_, arg3);
+    Val* output = torchGather(arg1, dim_, arg3);
     fd.setFusionState(outputs_.at(0).index, output);
   }
 
@@ -1894,7 +1894,7 @@ struct TakeAlongAxisOpRecord : RecordFunctor {
     auto arg1 = fd.getFusionState(args_.at(0).index)->template as<TensorView>();
     auto arg3 = fd.getFusionState(args_.at(1).index)->template as<TensorView>();
 
-    Val* output = take_along_axis(arg1, arg3, dim_);
+    Val* output = takeAlongAxis(arg1, arg3, dim_);
     fd.setFusionState(outputs_.at(0).index, output);
   }
 

--- a/csrc/scheduler/pointwise_utils.cpp
+++ b/csrc/scheduler/pointwise_utils.cpp
@@ -54,11 +54,11 @@ getIndexedConsumerToProducerMap(Fusion* fusion, const ComputeAtMap& ca_map) {
 }
 
 // Check if a root ID of a fusion input tensor that is indirectly
-// accessed by ops such as torch_gather needs to be mapped with
+// accessed by ops such as torchGather needs to be mapped with
 // a reference tensor. Select has a similar effect as squeeze as the
 // indexed domain is removed, so the domain does not need to be mapped
 // as long as the tensor is a fusion input. Similarly, in index_select
-// and torch_gather, if the output domain is a broadcast, it does not
+// and torchGather, if the output domain is a broadcast, it does not
 // need to be mapped if not resolved.
 bool canIgnoreIndexedInputDomainID(
     TensorView* input_tv,
@@ -83,9 +83,9 @@ bool canIgnoreIndexedInputDomainID(
         return false;
       }
     } else if (auto gather = dynamic_cast<TorchGatherOp*>(use)) {
-      // TODO: Remove this. Once slice is used for torch_gather, this
+      // TODO: Remove this. Once slice is used for torchGather, this
       // should not be necessary. For now, it is necessary to not
-      // break the existing torch_gather tests
+      // break the existing torchGather tests
       if (!gather->exactSizes()) {
         continue;
       }

--- a/csrc/scheduler/pointwise_utils.h
+++ b/csrc/scheduler/pointwise_utils.h
@@ -46,7 +46,7 @@ class DomainMap {
       IterDomain* out_id) const;
 
   // Check if in_ids are mapped to ids through any root domain as
-  // well as indirectly accessed domains with ops like torch_gather
+  // well as indirectly accessed domains with ops like torchGather
   void eraseifInputMappedThroughRootDomainAndIndexing(
       std::unordered_set<IterDomain*>& in_ids,
       const std::vector<IterDomain*>& ids) const;

--- a/csrc/scheduler/registry_utils.cpp
+++ b/csrc/scheduler/registry_utils.cpp
@@ -170,7 +170,7 @@ bool rejectScheduleForMemoryPromotion(
   for (auto expr : fusion->exprs()) {
     if (expr->isOneOf<SelectOp, IndexSelectOp, TorchGatherOp>()) {
       // For now, only relax the input requirement when it's
-      // take_along_axis. Also since this would require memory
+      // takeAlongAxis. Also since this would require memory
       // promotion, i.e., persistent global sync in the case of
       // block-parallel ops, it needs to be explictly enabled.
       if (expr->isA<TorchGatherOp>() &&

--- a/tests/cpp/test_gpu_fused_reduction.cpp
+++ b/tests/cpp/test_gpu_fused_reduction.cpp
@@ -2519,7 +2519,7 @@ TEST_F(NVFuserTest, FusionCrossEntropyGatherPattern_CUDA) {
   fusion.addInput(labels);
 
   auto tv2 = broadcast(labels, {false, true});
-  auto tv3 = torch_gather(log_probs, 1, tv2);
+  auto tv3 = torchGather(log_probs, 1, tv2);
   auto tv4 = squeeze(tv3, std::vector<bool>({false, true}));
 
   fusion.addOutput(tv4);

--- a/tests/cpp/test_scatter_gather.cpp
+++ b/tests/cpp/test_scatter_gather.cpp
@@ -34,7 +34,7 @@ auto randomVector(int64_t low, int64_t high, int rank) {
   return out;
 }
 
-// When take_along_axis is true, the extents of non-indexed dimensions
+// When takeAlongAxis is true, the extents of non-indexed dimensions
 // are set to be the same as those of the input dimensions
 auto randomIndexVector(
     const std::vector<int64_t>& input_dims,
@@ -145,8 +145,8 @@ TEST_F(ScatterGatherTest, TorchGatherAllRankAllSelectedDim) {
         TensorView* tv_idx = makeContigTensor(rank, DataType::Int);
         fusion.addInput(tv1);
         fusion.addInput(tv_idx);
-        TensorView* tv_out = is_take_along ? take_along_axis(tv1, tv_idx, dim)
-                                           : torch_gather(tv1, dim, tv_idx);
+        TensorView* tv_out = is_take_along ? takeAlongAxis(tv1, tv_idx, dim)
+                                           : torchGather(tv1, dim, tv_idx);
         fusion.addOutput(tv_out);
 
         auto input_dims = randomVector(2, max_dim_size, rank);
@@ -182,8 +182,8 @@ TEST_F(ScatterGatherTest, TorchGatherAddMul) {
         TensorView* tv_idx = makeContigTensor(rank, DataType::Int);
         fusion.addInput(tv1);
         fusion.addInput(tv_idx);
-        auto tv_gather = is_take_along ? take_along_axis(tv1, tv_idx, dim)
-                                       : torch_gather(tv1, dim, tv_idx);
+        auto tv_gather = is_take_along ? takeAlongAxis(tv1, tv_idx, dim)
+                                       : torchGather(tv1, dim, tv_idx);
         auto tv_add = add(tv_gather, tv_gather);
         auto tv_out = mul(tv_gather, tv_add);
         fusion.addOutput(tv_out);
@@ -226,8 +226,8 @@ TEST_F(ScatterGatherTest, AddGatherSumAdd) {
         fusion.addInput(tv_idx_2);
 
         auto tv_index = add(tv_idx_1, tv_idx_2);
-        auto tv_out = is_take_along ? take_along_axis(tv_lookup, tv_index, dim)
-                                    : torch_gather(tv_lookup, dim, tv_index);
+        auto tv_out = is_take_along ? takeAlongAxis(tv_lookup, tv_index, dim)
+                                    : torchGather(tv_lookup, dim, tv_index);
 
         fusion.addOutput(tv_out);
 
@@ -269,8 +269,8 @@ TEST_F(ScatterGatherTest, TorchGatherSumAdd) {
         fusion.addInput(tv_idx);
         fusion.addInput(tv2);
 
-        auto tv_gather = is_take_along ? take_along_axis(tv1, tv_idx, dim)
-                                       : torch_gather(tv1, dim, tv_idx);
+        auto tv_gather = is_take_along ? takeAlongAxis(tv1, tv_idx, dim)
+                                       : torchGather(tv1, dim, tv_idx);
         auto tv_sum = sum(tv_gather, {0}, true);
         auto tv_out = add(tv_sum, tv2);
 
@@ -315,8 +315,8 @@ TEST_F(ScatterGatherTest, TorchGatherAddMulHugeSize) {
 
         fusion.addInput(tv1);
         fusion.addInput(tv_idx);
-        auto tv_gather = is_take_along ? take_along_axis(tv1, tv_idx, dim)
-                                       : torch_gather(tv1, dim, tv_idx);
+        auto tv_gather = is_take_along ? takeAlongAxis(tv1, tv_idx, dim)
+                                       : torchGather(tv1, dim, tv_idx);
         auto tv_add = add(tv_gather, tv_gather);
         auto tv_out = mul(tv_gather, tv_add);
         fusion.addOutput(tv_out);
@@ -352,7 +352,7 @@ TEST_F(ScatterGatherTest, TorchGatherInput) {
   fusion.addInput(tv_idx);
 
   auto tv_inp = add(tv1, tv1);
-  auto tv_gather = torch_gather(tv_inp, 0, tv_idx);
+  auto tv_gather = torchGather(tv_inp, 0, tv_idx);
   fusion.addOutput(tv_gather);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -385,7 +385,7 @@ TEST_F(ScatterGatherTest, TorchGatherIndexTvExtentIsOne) {
   fusion.addInput(tv_idx);
   fusion.addInput(tv_in2);
 
-  auto tv_gather = torch_gather(tv_in1, 1, tv_idx);
+  auto tv_gather = torchGather(tv_in1, 1, tv_idx);
   auto tv_add =
       clamp(tv_gather, IrBuilder::create<Val>(-1L), IrBuilder::create<Val>(1L));
   auto tv_out = mul(tv_add, tv_in2);
@@ -409,7 +409,7 @@ TEST_F(ScatterGatherTest, TorchGatherIndexTvExtentIsOne) {
       &fusion, cg_outputs, aten_inputs, {tv_out_ref}, __LINE__, __FILE__);
 }
 
-// Test take_along_axis with a broadcast index tensor
+// Test takeAlongAxis with a broadcast index tensor
 TEST_F(ScatterGatherTest, TakeAlongBroadcastIndex) {
   for (const auto index_dim : {1, 3}) {
     auto fusion_ptr = std::make_unique<Fusion>();
@@ -425,7 +425,7 @@ TEST_F(ScatterGatherTest, TakeAlongBroadcastIndex) {
     fusion.addInput(tv2);
 
     auto tv3 = broadcast(tv1, {true, false, true});
-    auto tv4 = take_along_axis(tv0, tv3, 1);
+    auto tv4 = takeAlongAxis(tv0, tv3, 1);
     auto tv5 = add(tv4, tv2);
     fusion.addOutput(tv5);
 
@@ -450,11 +450,11 @@ TEST_F(ScatterGatherTest, TakeAlongBroadcastIndex) {
 
 TEST_F(ScatterGatherTest, GatherBroadcastInput) {
   for (const auto is_take_along : {false, true}) {
-    // torch_gather not supported yet. The issue is one of the index
+    // torchGather not supported yet. The issue is one of the index
     // tensor has a broadcast domain, but its corresponding input
     // domain is a normal domain. The output domain is also a
-    // broadcast in torch_gather, whereas it's a normal domain in
-    // take_along_axis. In the case of torch_gather, indexing the
+    // broadcast in torchGather, whereas it's a normal domain in
+    // takeAlongAxis. In the case of torchGather, indexing the
     // input domain needs to be able to index the normal producer
     // domain with a broadcast reference domain. getProduerIndex needs
     // some fix.
@@ -466,11 +466,11 @@ TEST_F(ScatterGatherTest, GatherBroadcastInput) {
         // [B, B, I] when inp_indexed_dim == 1, otherwise [B, I, I]
         std::vector<int64_t> input_dims{1, inp_indexed_dim, 12};
         // [I, B] when idx_index_dim == 1, otherwise [I, I]
-        // In torch_gather, an index dimension must be smaller or
+        // In torchGather, an index dimension must be smaller or
         // equal to the corresponding input dimension
         std::vector<int64_t> index_dims{
             is_take_along ? 5 : input_dims.at(0), idx_index_dim};
-        // This needs to match with the take_along_axis output
+        // This needs to match with the takeAlongAxis output
         std::vector<int64_t> out_dims{
             index_dims.at(0), index_dims.at(1), input_dims.at(2)};
 
@@ -486,7 +486,7 @@ TEST_F(ScatterGatherTest, GatherBroadcastInput) {
         fusion.addInput(tv2);
 
         auto tv3 = broadcast(tv1, {false, false, true});
-        auto tv4 = take_along_axis(tv0, tv3, 1);
+        auto tv4 = takeAlongAxis(tv0, tv3, 1);
         auto tv5 = add(tv4, tv2);
         fusion.addOutput(tv5);
 
@@ -508,7 +508,7 @@ TEST_F(ScatterGatherTest, GatherBroadcastInput) {
   }
 }
 
-// Test take_along_axis with non fusion inputs
+// Test takeAlongAxis with non fusion inputs
 TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorPointwise1) {
   Fusion fusion;
   FusionGuard fg(&fusion);
@@ -522,7 +522,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorPointwise1) {
 
   auto tv2 = add(tv0, IrBuilder::create<Val>(1.0));
   auto tv3 = broadcast(tv1, {false, true});
-  auto tv4 = take_along_axis(tv2, tv3, 1);
+  auto tv4 = takeAlongAxis(tv2, tv3, 1);
   fusion.addOutput(tv4);
 
   scheduler_utils::prepareForMemoryTypePromotion(&fusion);
@@ -546,7 +546,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorPointwise1) {
   }
 
   // This should not inline the indexed producer domain. Note that the
-  // producer tensor of the take_along_axis expr is not tv2 as a copy
+  // producer tensor of the takeAlongAxis expr is not tv2 as a copy
   // is inserted
   inlineMost();
   auto take_along_axis_input =
@@ -612,7 +612,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorPointwise2) {
 
   auto tv2 = add(tv0, IrBuilder::create<Val>(1.0));
   auto tv3 = broadcast(tv1, {false, true});
-  auto tv4 = take_along_axis(tv2, tv3, 1);
+  auto tv4 = takeAlongAxis(tv2, tv3, 1);
   fusion.addOutput(tv4);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -630,7 +630,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorPointwise2) {
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
-// Reduction then take_along_axis. This is currently segmented due to
+// Reduction then takeAlongAxis. This is currently segmented due to
 // the post-reduction rule as documented in
 // https://github.com/NVIDIA/Fuser/issues/260
 TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction1) {
@@ -646,7 +646,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction1) {
   fusion.addInput(tv1);
 
   auto tv2 = sum(tv0, {1});
-  auto tv4 = take_along_axis(tv2, tv1, 0);
+  auto tv4 = takeAlongAxis(tv2, tv1, 0);
   fusion.addOutput(tv4);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -665,7 +665,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction1) {
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
-// take_along_axis to broadcast, squeeze, then reduction. Segmented
+// takeAlongAxis to broadcast, squeeze, then reduction. Segmented
 // before the reduction
 TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction2) {
   auto fusion_ptr = std::make_unique<Fusion>();
@@ -684,7 +684,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction2) {
 
   auto tv2 = add(tv0, IrBuilder::create<Val>(1.0));
   auto tv3 = broadcast(tv1, {false, true});
-  auto tv4 = take_along_axis(tv2, tv3, 1);
+  auto tv4 = takeAlongAxis(tv2, tv3, 1);
   auto tv5 = squeeze(tv4, std::vector<bool>{false, true});
   auto tv6 = sum(tv5, {0});
   fusion.addOutput(tv6);
@@ -705,7 +705,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction2) {
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
-// take_along_axis then reduction. Should not be segmented.
+// takeAlongAxis then reduction. Should not be segmented.
 TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction3) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
@@ -723,7 +723,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction3) {
   fusion.addInput(tv1);
 
   auto tv2 = add(tv0, IrBuilder::create<Val>(1.0));
-  auto tv3 = take_along_axis(tv2, tv1, 1);
+  auto tv3 = takeAlongAxis(tv2, tv1, 1);
   auto tv4 = sum(tv3, {1});
   fusion.addOutput(tv4);
 
@@ -762,7 +762,7 @@ TEST_F(ScatterGatherTest, DISABLED_TakeAlongAxisIntermediateTensorReduction4) {
 
   auto tv2 = add(tv0, IrBuilder::create<Val>(1.0));
   auto tv3 = broadcast(tv1, {false, true});
-  auto tv4 = take_along_axis(tv2, tv3, 1);
+  auto tv4 = takeAlongAxis(tv2, tv3, 1);
   auto tv5 = sum(tv4, {0});
   // TODO: remove this. Currently, validation fails without this
   // likely because of a predication bug
@@ -785,7 +785,7 @@ TEST_F(ScatterGatherTest, DISABLED_TakeAlongAxisIntermediateTensorReduction4) {
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
-// Normalization then take_along_axis
+// Normalization then takeAlongAxis
 TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization1) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
@@ -805,7 +805,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization1) {
   auto tv3 = broadcast(tv2, {false, true});
   auto tv4 = div(tv0, tv3);
   auto tv5 = broadcast(tv1, {false, true});
-  auto tv6 = take_along_axis(tv4, tv5, 1);
+  auto tv6 = takeAlongAxis(tv4, tv5, 1);
   fusion.addOutput(tv6);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -844,7 +844,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization2) {
 
   auto tv2 = add(tv0, IrBuilder::create<Val>(1.0));
   auto tv3 = broadcast(tv1, {false, true});
-  auto tv4 = take_along_axis(tv2, tv3, 1);
+  auto tv4 = takeAlongAxis(tv2, tv3, 1);
   auto tv5 = squeeze(tv4, std::vector<bool>{false, true});
   auto tv6 = sum(tv5, {0});
   auto tv7 = broadcast(tv6, {true});
@@ -871,7 +871,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization2) {
   testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
 }
 
-// take_along_axis then normalization. Should not be segmented.
+// takeAlongAxis then normalization. Should not be segmented.
 TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization3) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
@@ -889,7 +889,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization3) {
   fusion.addInput(tv1);
 
   auto tv2 = add(tv0, IrBuilder::create<Val>(1.0));
-  auto tv3 = take_along_axis(tv2, tv1, 1);
+  auto tv3 = takeAlongAxis(tv2, tv1, 1);
   auto tv4 = sum(tv3, {1});
   auto tv5 = broadcast(tv4, {false, true});
   auto tv6 = div(tv3, tv5);
@@ -914,7 +914,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization3) {
   testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
 }
 
-// Normalization, then take_along_axis, then reduction. Similar
+// Normalization, then takeAlongAxis, then reduction. Similar
 // pattern as cross entropy.
 TEST_F(
     ScatterGatherTest,
@@ -933,7 +933,7 @@ TEST_F(
   auto tv2 = sum(tv0, {1});
   auto tv3 = broadcast(tv2, {false, true});
   auto tv4 = div(tv0, tv3);
-  auto tv5 = take_along_axis(tv4, tv1, 1);
+  auto tv5 = takeAlongAxis(tv4, tv1, 1);
   auto tv6 = sum(tv5, {0, 1});
   fusion.addOutput(tv6);
 
@@ -984,7 +984,7 @@ TEST_F(
   auto tv3 = broadcast(tv2, {false, true});
   auto tv4 = div(tv0, tv3);
   auto tv5 = broadcast(tv1, {false, true});
-  auto tv6 = take_along_axis(tv4, tv5, 1);
+  auto tv6 = takeAlongAxis(tv4, tv5, 1);
   auto tv7 = add(tv0, tv6);
   auto tv8 = sum(tv7, {1});
   fusion.addOutput(tv8);
@@ -1009,7 +1009,7 @@ TEST_F(
   testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
 }
 
-// take_along_axis then transpose
+// takeAlongAxis then transpose
 TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose1) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
@@ -1032,7 +1032,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose1) {
 
   auto tv2 = add(tv0, IrBuilder::create<Val>(1.0));
   auto tv3 = broadcast(tv1, {true, false, false});
-  auto tv4 = take_along_axis(tv2, tv3, 0);
+  auto tv4 = takeAlongAxis(tv2, tv3, 0);
   auto tv5 = transpose(tv4, 1, 2);
   fusion.addOutput(tv5);
   // specify output allocation domain to avoid allocation order pass changing
@@ -1054,7 +1054,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose1) {
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
-// transpose then take_along_axis. Currently failed to pick the
+// transpose then takeAlongAxis. Currently failed to pick the
 // Transpose scheduler due to a limitation of the analysis for the
 // scheduler. See DomainMap::findReferenceFor in transpose.cpp for
 // more details.
@@ -1079,7 +1079,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose2) {
   fusion.addInput(tv1);
 
   auto tv2 = transpose(tv0, 1, 2);
-  auto tv4 = take_along_axis(tv2, tv1, 0);
+  auto tv4 = takeAlongAxis(tv2, tv1, 0);
   fusion.addOutput(tv4);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
@@ -1097,7 +1097,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose2) {
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
-// transpose the dimension produced by take_along_axis. Currently not
+// transpose the dimension produced by takeAlongAxis. Currently not
 // supported by the transpose scheduler
 TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose3) {
   auto fusion_ptr = std::make_unique<Fusion>();
@@ -1120,7 +1120,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose3) {
 
   auto tv2 = add(tv0, IrBuilder::create<Val>(1.0));
   auto tv3 = broadcast(tv1, {true, false, false});
-  auto tv4 = take_along_axis(tv2, tv3, 2);
+  auto tv4 = takeAlongAxis(tv2, tv3, 2);
   auto tv5 = transpose(tv4, 1, 2);
   // Without the `add`, the transpose will be taken by NoOp, defeating the
   // purpose of testing PointWise.
@@ -1170,7 +1170,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisCrossEntropyLoss) {
   auto tv11 = log(tv10);
   auto tv12 = neg(tv11);
   auto tv13 = reshape(tv1, {128}, {128, 1});
-  auto tv14 = take_along_axis(tv12, tv13, 1);
+  auto tv14 = takeAlongAxis(tv12, tv13, 1);
   auto s15 = IrBuilder::create<Val>(5L);
   auto tv16 = eq(tv13, s15);
   auto s17 = IrBuilder::create<Val>(0.0);
@@ -1198,7 +1198,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisCrossEntropyLoss) {
       kernel_runtime,
       {SchedulerType::InnerPersistent, SchedulerType::Reduction});
 
-  // Make sure take_along_axis is in the persistent group
+  // Make sure takeAlongAxis is in the persistent group
   for (const auto group : kernel_runtime->fusionSegments()->groups()) {
     if (group->schedulerType() == SchedulerType::InnerPersistent) {
       NVF_CHECK(std::any_of(
@@ -1238,7 +1238,7 @@ TEST_F(ScatterGatherTest, GatherIterGoupedReduction) {
   TensorView* tv_idx = makeContigTensor(rank, DataType::Int);
   fusion.addInput(tv1);
   fusion.addInput(tv_idx);
-  auto tv_gather = torch_gather(tv1, dim, tv_idx);
+  auto tv_gather = torchGather(tv1, dim, tv_idx);
   auto tv_sum = sum(tv_gather, {0}, false);
   fusion.addOutput(tv_sum);
 

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -249,6 +249,8 @@ def check_cpp_translation(reference_outputs, fd, inputs, device=None):
         torch.manual_seed(0)
         cloned_fd = FusionDefinition()
         clone(fd, cloned_fd)
+        print(fd)
+        print(cloned_fd)
         cloned_outputs = cloned_fd.execute(inputs, device=device)
 
         # Make sure the results of original and cloned definitions match.


### PR DESCRIPTION
This PR renames some index operations from `snake_case` to `camelCase` for consistency.

* from `take_along_axis` to `takeAlongAxis`
* from `torch_gather` to `torchGather`