### PR TITLE
Add function `lastKernelTime()` to `FusionProfiler` for FusionExecutor timing

### DIFF
--- a/csrc/fusion_profiler.cpp
+++ b/csrc/fusion_profiler.cpp
@@ -843,6 +843,13 @@ const FusionProfile& FusionProfiler::profile() {
   return get()->profile_;
 }
 
+double FusionProfiler::lastKernelTime() {
+  const auto& fprof = profile();
+  NVF_CHECK(
+      !fprof.kernel_profiles.empty(), "There are no kernel profiles to query!");
+  return fprof.kernel_profiles.back().time_ms;
+}
+
 void FusionProfiler::recordAsyncCorrIdActivity(
     uint32_t seg_id,
     uint32_t corr_id) {

--- a/csrc/fusion_profiler.h
+++ b/csrc/fusion_profiler.h
@@ -251,6 +251,11 @@ class FusionProfiler {
   static void inputBytesAccessed(int64_t bytes);
   static void outputBytesAccessed(int64_t bytes);
   NVF_API static const FusionProfile& profile();
+  // An API to query the last kernel time measured that is convenient
+  // for profile a single kernel from the Fusion Executor.  Note, there
+  // may be other kernels profiles as a code generated kernel requires
+  // allocated outputs.
+  NVF_API static double lastKernelTime();
   static SegmentProfiler& segment(size_t idx);
 
   //! Methods to capture Asynchronous CUPTI activity that get called from


### PR DESCRIPTION
This is a simple addition to the `FusionProfiler` API.

In our C++ tests, developers like to schedule a Fusion independent of our cache hierarchy that includes segmentation.  `FusionProfiler` is designed to work with the cache hierarchy to profile all the segments of a fusion.  In the simple C++ tests, developers only use the `FusionExecutor` that executes a single kernel, therefore, is convenient to allow the user to measure the time of a single kernel.  In some instance, nvFuser allocates outputs and the `FusionProfiler` picks up those allocations as kernels from CUPTI and aggregates them as part of `FusionProfile.kernel_time_ms`.  Often, the user just wants to know the kernel time of the kernel they scheduled.  The following API `FusionProfiiler::lastKernelTime()` enables the user to get that specific time, as a convenience, instead of having to use an uglier query like: `FusionProfiler::profile().kernel_profiles.back().time_ms`.

Example:

```c++
      if (!getenv("NO_FUSION_PROFILER")) {
        FusionProfiler::stop();
        // auto t = FusionProfiler::profile().kernel_time_ms;
        // auto t = FusionProfiler::profile().kernel_profiles.back().time_ms;
        auto t = FusionProfiler::lastKernelTime();
        std::cout << "Elapsed time (us): " << (t * 1000) << "\n";
        std::cout << "Bandwidth (GB/s): "
                  << ((float)mem_size * 0.001 * 0.001 * 0.001 / (t * 0.001))
                  << "\n";
      }
```