### PR TITLE
Refactor of the circular buffering analysis and allocation pass

### DIFF
--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -29,7 +29,7 @@ class CircularBufferInfo {
  public:
   void build(Fusion* fusion);
 
-  void setCircularBufferAxis(const TensorView* tv, IterDomain* id);
+  void setCircularBufferTv(const TensorView* tv);
 
   IterDomain* getCircularBufferAxis(const TensorView* tv) const;
 
@@ -52,6 +52,12 @@ class CircularBufferInfo {
       const std::vector<ForLoop*>& loops,
       bool ignore_prologue = false);
 
+  //! Get the circular-buffered tensors for the given loop/axis.
+  std::unordered_set<const TensorView*> getCircularBufferTvs(
+      ForLoop* axis) const;
+  std::unordered_set<const TensorView*> getCircularBufferTvs(
+      IterDomain* axis) const;
+
   void setOriginalAllocSize(const TensorView* tv, Val* size);
 
   Val* getOriginalAllocSize(const TensorView* tv);
@@ -65,6 +71,8 @@ class CircularBufferInfo {
   //! loop.
   int64_t getStageDepthFor(IterDomain* circular_buffered_id) const;
   int64_t getPrefetchDistanceFor(IterDomain* circular_buffered_id) const;
+
+  std::string toString() const;
 
  private:
   const TvInfo& getTvInfo(const TensorView* tv) const;
@@ -95,6 +103,11 @@ class CircularBufferInfo {
   //! can indeed shared with the same prolog extent and main loop offset.
   std::unordered_map<IterDomain*, CircularBufferOptions>
       circular_buffer_options_;
+
+  //! Keeps track of circular buffer tvs for each disjoint set of loop mapped
+  //! iterdomains.
+  std::unordered_map<IterDomain*, std::unordered_set<const TensorView*>>
+      circular_buffer_tvs_;
 };
 
 } // namespace nvfuser

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -57,12 +57,10 @@ ForLoop* createStageDepthForLoop(ForLoop* circular_buffer_loop) {
 //     mbarrier::init(...);
 //   }
 // }
-std::pair<ForLoop*, kir::MBarrierInit*> initializeMbarrier(
+Expr* initializeMbarrier(
     ForLoop* circular_buffer_loop,
-    LoadStoreOp* ldst,
     TensorView* all_mbarriers) {
   NVF_ERROR(circular_buffer_loop != nullptr);
-  NVF_ERROR(ir_utils::isCpAsyncBulk(ldst));
   ForLoop* loop = createStageDepthForLoop(circular_buffer_loop);
 
   // Get mbarrier for this circular buffer stage.
@@ -91,7 +89,7 @@ std::pair<ForLoop*, kir::MBarrierInit*> initializeMbarrier(
   Expr* pred_mbarrier_init = mbarrier_init->withPredicate(
       IrBuilder::create<kir::Predicate>(PredicateType::ElectSync));
   loop->body().push_back(pred_mbarrier_init);
-  return {loop, pred_mbarrier_init->as<kir::MBarrierInit>()};
+  return loop;
 }
 
 // This helper function invalidates mbarrier for all circular buffer stage after
@@ -103,12 +101,10 @@ std::pair<ForLoop*, kir::MBarrierInit*> initializeMbarrier(
 //     mbarrier::inval(...);
 //   }
 // }
-std::pair<ForLoop*, kir::MBarrierInvalidate*> invalidateMbarrier(
+Expr* invalidateMbarrier(
     ForLoop* circular_buffer_loop,
-    LoadStoreOp* ldst,
     TensorView* all_mbarriers) {
   NVF_ERROR(circular_buffer_loop != nullptr);
-  NVF_ERROR(ir_utils::isCpAsyncBulk(ldst));
   ForLoop* loop = createStageDepthForLoop(circular_buffer_loop);
 
   // Get mbarrier for this circular buffer stage.
@@ -123,7 +119,7 @@ std::pair<ForLoop*, kir::MBarrierInvalidate*> invalidateMbarrier(
       IrBuilder::create<kir::Predicate>(PredicateType::ElectSync));
 
   loop->body().push_back(pred_mbarrier_inval);
-  return {loop, pred_mbarrier_inval->as<kir::MBarrierInvalidate>()};
+  return loop;
 }
 
 class AllocationInserter : public kir::ExprMutator {
@@ -592,15 +588,80 @@ class AllocationInserter : public kir::ExprMutator {
       }
     }
 
-    // Allocate mbarrier for cp.async.bulk, note that this is only a temporary
-    // solution, we should remove this after we have a better way to handle
-    // synchronizations for cp.async.bulk.
-    if (ir_utils::isCpAsyncBulkLoad(expr)) {
-      if (circular_buffer_depth > 1) {
+    // Allocate mbarrier for cp.async.bulk, for non-circular buffered cases by
+    // lowering a single cp.async.bulk as:
+    //    alloc mbarrier
+    //    init mbarrier
+    //    block_sync
+    //    cp.async.bulk
+    //    inval mbarrier
+    //    block_sync
+    // Note that this is only a temporary solution, we should remove this after
+    // we have a better way to handle synchronizations for cp.async.bulk.
+    //
+    // The circular buffer case is handled in handle(ForLoop* fl) and the
+    // circular buffering pass.
+    if (ir_utils::isCpAsyncBulkLoad(expr) && circular_buffer_depth == 1) {
+      // create and allocate a memory barrier
+      TensorView* mbarrier = TensorViewBuilder()
+                                 .shape(std::vector<int64_t>{})
+                                 .dtype(DataType::UInt)
+                                 .contiguity(true)
+                                 .build();
+      mbarrier->setMemoryType(MemoryType::Shared);
+      auto mbarrier_init = IrBuilder::create<kir::MBarrierInit>(
+          mbarrier,
+          simplifyExpr(SimplifyingIrBuilder::maybeCastExpr(
+              DataType::UInt32,
+              lower_utils::getNumThreadsInTensorView(
+                  expr->output(0)->as<TensorView>()))));
+      auto sync_init = IrBuilder::create<kir::BlockSync>();
+      auto mbarrier_inval =
+          IrBuilder::create<kir::MBarrierInvalidate>(mbarrier);
+      auto sync_inval = IrBuilder::create<kir::BlockSync>();
+
+      kir::Allocate* mbarrier_alloc =
+          IrBuilder::create<kir::Allocate>(mbarrier, MemoryType::Shared);
+      Scope* expr_scope = scope_.empty() ? nullptr : scope_.back();
+      registerInsertBefore(expr, mbarrier_alloc, expr_scope);
+      registerInsertBefore(expr, mbarrier_init, expr_scope);
+      registerInsertBefore(expr, sync_init, expr_scope);
+      registerInsertAfter(expr, mbarrier_inval, expr_scope);
+      registerInsertAfter(expr, sync_inval, expr_scope);
+      GpuLower::current()->ldstMBarrierMap()[expr] = mbarrier;
+    }
+  }
+
+  void handle(ForLoop* fl) final {
+    ExprMutator::handle(fl);
+
+    // If fl is a circular buffered loop, the we should lowering the loop as:
+    //    alloc mbarrier
+    //    init mbarrier
+    //    block_sync
+    //    fl
+    //    inval mbarrier
+
+    auto circular_buffer_tvs =
+        GpuLower::current()->circularBufferInfo().getCircularBufferTvs(fl);
+
+    bool circular_buffer_load_is_tma = std::any_of(
+        circular_buffer_tvs.begin(),
+        circular_buffer_tvs.end(),
+        [](TensorView* tv) {
+          return ir_utils::isCpAsyncBulkLoad(tv->definition());
+        });
+
+    if (circular_buffer_load_is_tma) {
+      for (auto tv : circular_buffer_tvs) {
         // Create and allocate a memory barrier. If this is a circular buffer,
         // then allocate an array of mbarier objects. mbarrier::init and
         // mbarrier::inval will be updated in circular buffering pass, but we
         // add them here to handle shared memory correctly in alias memory pass.
+        int64_t circular_buffer_depth =
+            GpuLower::current()->circularBufferInfo().getStageDepthFor(
+                fl->iter_domain());
+
         TensorView* mbarrier =
             TensorViewBuilder()
                 .shape(std::vector<int64_t>{circular_buffer_depth})
@@ -612,18 +673,8 @@ class AllocationInserter : public kir::ExprMutator {
         kir::Allocate* mbarrier_alloc =
             IrBuilder::create<kir::Allocate>(mbarrier, MemoryType::Shared);
 
-        NVF_ERROR(ir_utils::isCpAsyncBulkLoad(expr));
-        LoadStoreOp* ldst = expr->as<LoadStoreOp>();
-        TensorView* out_tv = ldst->out()->as<TensorView>();
-        ForLoop* circular_buffer_loop =
-            GpuLower::current()->circularBufferInfo().getCircularBufferLoop(
-                out_tv, for_loops_);
-
-        auto&& [pre_prologue_init, mbarrier_init] =
-            initializeMbarrier(circular_buffer_loop, ldst, mbarrier);
-
-        auto&& [post_epilogue_inval, mbarrier_inval] =
-            invalidateMbarrier(circular_buffer_loop, ldst, mbarrier);
+        auto mbarrier_init = initializeMbarrier(fl, mbarrier);
+        auto mbarrier_inval = invalidateMbarrier(fl, mbarrier);
 
         // Block sync is necessary to finish mbarrier initialization.
         kir::BlockSync* sync = IrBuilder::create<kir::BlockSync>(false);
@@ -645,60 +696,14 @@ class AllocationInserter : public kir::ExprMutator {
         //   inval(mbarrier[stage]);
         // }
         //
-
-        // Find the scope containing the circular buffer for-loop. It is the
-        // scope one level higher than the circular buffer loop scope in scope_.
-        auto scope_iter = std::find(
-            scope_.begin(), scope_.end(), &circular_buffer_loop->body());
-        NVF_ERROR(scope_iter != scope_.end());
-        Scope* scope_containing_circular_buffer_loop =
-            (scope_iter == scope_.begin()) ? nullptr : *(scope_iter - 1);
-        registerInsertBefore(
-            circular_buffer_loop,
-            mbarrier_alloc,
-            scope_containing_circular_buffer_loop);
-
-        registerInsertBefore(
-            circular_buffer_loop,
-            pre_prologue_init,
-            scope_containing_circular_buffer_loop);
-        registerInsertBefore(
-            circular_buffer_loop, sync, scope_containing_circular_buffer_loop);
-        registerInsertAfter(
-            circular_buffer_loop,
-            post_epilogue_inval,
-            scope_containing_circular_buffer_loop);
+        Scope* current_scope = scope_.empty() ? nullptr : scope_.back();
+        registerInsertBefore(fl, mbarrier_alloc, current_scope);
+        registerInsertBefore(fl, mbarrier_init, current_scope);
+        registerInsertBefore(fl, sync, current_scope);
+        registerInsertAfter(fl, mbarrier_inval, current_scope);
 
         // Map LoadStoreOp expression to ir nodes created in this pass
-        GpuLower::current()->ldstMBarrierMap()[expr] = mbarrier;
-      } else {
-        // create and allocate a memory barrier
-        TensorView* mbarrier = TensorViewBuilder()
-                                   .shape(std::vector<int64_t>{})
-                                   .dtype(DataType::UInt)
-                                   .contiguity(true)
-                                   .build();
-        mbarrier->setMemoryType(MemoryType::Shared);
-        auto mbarrier_init = IrBuilder::create<kir::MBarrierInit>(
-            mbarrier,
-            simplifyExpr(SimplifyingIrBuilder::maybeCastExpr(
-                DataType::UInt32,
-                lower_utils::getNumThreadsInTensorView(
-                    expr->output(0)->as<TensorView>()))));
-        auto sync_init = IrBuilder::create<kir::BlockSync>();
-        auto mbarrier_inval =
-            IrBuilder::create<kir::MBarrierInvalidate>(mbarrier);
-        auto sync_inval = IrBuilder::create<kir::BlockSync>();
-
-        kir::Allocate* mbarrier_alloc =
-            IrBuilder::create<kir::Allocate>(mbarrier, MemoryType::Shared);
-        Scope* expr_scope = scope_.empty() ? nullptr : scope_.back();
-        registerInsertBefore(expr, mbarrier_alloc, expr_scope);
-        registerInsertBefore(expr, mbarrier_init, expr_scope);
-        registerInsertBefore(expr, sync_init, expr_scope);
-        registerInsertAfter(expr, mbarrier_inval, expr_scope);
-        registerInsertAfter(expr, sync_inval, expr_scope);
-        GpuLower::current()->ldstMBarrierMap()[expr] = mbarrier;
+        GpuLower::current()->ldstMBarrierMap()[tv->definition()] = mbarrier;
       }
     }
   }

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -648,7 +648,7 @@ class AllocationInserter : public kir::ExprMutator {
     bool circular_buffer_load_is_tma = std::any_of(
         circular_buffer_tvs.begin(),
         circular_buffer_tvs.end(),
-        [](TensorView* tv) {
+        [](const TensorView* tv) {
           return ir_utils::isCpAsyncBulkLoad(tv->definition());
         });
 

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1161,6 +1161,14 @@ bool isLoopDomainFullyDerivedFromLogicalDomain(TensorView* tv) {
            .dom0_has_unreachable_ids;
 }
 
+std::string nullOrToString(const Statement* val) {
+  return val ? val->toString() : "nullptr";
+}
+
+std::string nullOrToInlineString(const Statement* id) {
+  return id ? id->toInlineString() : "nullptr";
+}
+
 } // namespace nvfuser::ir_utils
 
 namespace nvfuser::MmaOpUtils {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -462,10 +462,10 @@ IterDomain* getIndexedProducerID(const Expr* expr);
 // indirectly accessed.
 IterDomain* getConsumerOfIndexedProducerID(const Expr* expr);
 
-// Check if the given tv is first argment of index_select(lookup, dim, indices)
+// Check if the given tv is first argment of indexSelect(lookup, dim, indices)
 bool isIndexSelectLookupTv(const TensorView* tv);
 
-// Check if the given tv is third argment of index_select(lookup, dim, indices)
+// Check if the given tv is third argment of indexSelect(lookup, dim, indices)
 bool isIndexSelectIndicesTv(const TensorView* tv);
 
 bool isTorchGatherLookupTv(const Val* tv);

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -462,10 +462,10 @@ IterDomain* getIndexedProducerID(const Expr* expr);
 // indirectly accessed.
 IterDomain* getConsumerOfIndexedProducerID(const Expr* expr);
 
-// Check if the given tv is first argment of indexSelect(lookup, dim, indices)
+// Check if the given tv is first argment of index_select(lookup, dim, indices)
 bool isIndexSelectLookupTv(const TensorView* tv);
 
-// Check if the given tv is third argment of indexSelect(lookup, dim, indices)
+// Check if the given tv is third argment of index_select(lookup, dim, indices)
 bool isIndexSelectIndicesTv(const TensorView* tv);
 
 bool isTorchGatherLookupTv(const Val* tv);
@@ -714,5 +714,13 @@ bool hasRootToLoopLinearTransformations(const TensorView* tv);
 //! In addition to the above hasRootToLoopLinearTransformations, it
 //! also checks the loop domain has any extra domain
 bool isLoopDomainFullyDerivedFromLogicalDomain(TensorView* tv);
+
+//! If the given statement is nullptr, return "nullptr", otherwise return its
+//! toString()
+std::string nullOrToString(const Statement* stmt);
+
+//! If the given statement is nullptr, return "nullptr", otherwise return its
+//! toInlineString()
+std::string nullOrToInlineString(const Statement* stmt);
 
 } // namespace nvfuser::ir_utils


### PR DESCRIPTION
A refactor of the circular buffering analysis and allocation pass pulled out from https://github.com/NVIDIA/Fuser/pull/3202. There should be no behavioral change, just code movement to make it easier to implement https://github.com/NVIDIA/Fuser/pull/3202.

Changes:
- Let `CircularBufferInfo` track the concrete loop id -> circular buffered tv mapping. To conveniently do that, `setCircularBufferAxis` is renamed as `setCircularBufferTv` which not only does the things of the original `setCircularBufferAxis` but also updates `circular_buffer_tvs_`, the container used to track the new mapping.
- Move the insertion of the mbarrier allocation, initialization, and invalidation to `handle(ForLoop* fl)` in the allocation pass.