### PR TITLE
validateContiguity prints better error message.

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2922,7 +2922,11 @@ void validateContiguity(
     NVF_CHECK(
         expect_null != contiguity.at(i).has_value(),
         "The contiguity of a broadcast/reduction dimension must be None. "
-        "The contiguity of a non-broadcast/reduction dimension must be true/false");
+        "The contiguity of a non-broadcast/reduction dimension must be true/false. alloation_domain=[",
+        toDelimitedString(allocation_domain),
+        "], contiguity=[",
+        toDelimitedString(contiguity),
+        "]");
   }
 }
 


### PR DESCRIPTION
For example,
```
The contiguity of a broadcast/reduction dimension must be None. The contiguity of a non-broadcast/reduction dimension must be true/false. alloation_domain=[bS33{1}, bS35{1 ex 96}, bS34{1}, iS36{2048}, iS37{128}], contiguity=[n, n, t, t, t]
```