### PR TITLE
Simplify cat implementation

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -3365,41 +3365,6 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     indent() << "NVFUSER_UPDATE_MAGIC_ZERO;\n";
   }
 
-  void handle(const CatOp* cat) final {
-    auto out = gen(cat->output(0));
-
-    // Generate code like:
-    // if (consumer_idx < producer_0_extent) {
-    //   consumer[consumer_idx] = produce_0[producer_idx0];
-    // } else if (consumer_idx < producer_1_extent) {
-    //   consumer[consumer_idx] = produce_1[producer_idx1];
-    // } else if (consumer_idx < producer_2_extent) {
-    //   consumer[consumer_idx] = produce_2[producer_idx2];
-    // } else {
-    //   consumer[consumer_idx] = produce_3[producer_idx3];
-    // }
-
-    for (const auto i : c10::irange(cat->inputs().size())) {
-      auto inp = cat->input(i)->as<kir::TensorIndex>();
-      auto inp_str = gen(inp);
-      if (i < cat->inputs().size() - 1) {
-        if (i == 0) {
-          indent() << "if (";
-        } else {
-          indent() << "} else if (";
-        }
-        code_ << gen(cat->getPred((int)i)) << ") {\n";
-      } else {
-        // last case doesn't need to be predicated
-        indent() << "} else {\n";
-      }
-
-      indent() << kTab << out << " = " << gen(inp) << ";\n";
-    }
-
-    indent() << "}\n";
-  }
-
  private:
   std::stringstream code_;
   const kir::Kernel* kernel_;

--- a/runtime/bf16_support.cu
+++ b/runtime/bf16_support.cu
@@ -302,3 +302,11 @@ __device__ __inline__ bool __heq(const __bfloat a, const __bfloat b) {
 #endif
   return (val != 0U) ? true : false;
 }
+
+__device__ __inline__ __bfloat operator|(const __bfloat x, const __bfloat y) {
+  __bfloat val;
+  asm("{  or.b16 %0, %1, %2;}\n"
+      : "=h"(__NVFUSER_BFLOAT_TO_US(val))
+      : "h"(__NVFUSER_BFLOAT_TO_CUS(x)), "h"(__NVFUSER_BFLOAT_TO_CUS(y)));
+  return val;
+}

--- a/runtime/fp16_support.cu
+++ b/runtime/fp16_support.cu
@@ -220,3 +220,11 @@ __device__ __inline__ bool __heq(const __half a, const __half b) {
       : "h"(__NVFUSER_HALF_TO_CUS(a)), "h"(__NVFUSER_HALF_TO_CUS(b)));
   return (val != 0U) ? true : false;
 }
+
+__device__ __inline__ __half operator|(const __half x, const __half y) {
+  __half val;
+  asm("{  or.b16 %0, %1, %2;}\n"
+      : "=h"(__NVFUSER_HALF_TO_US(val))
+      : "h"(__NVFUSER_HALF_TO_CUS(x)), "h"(__NVFUSER_HALF_TO_CUS(y)));
+  return val;
+}

--- a/runtime/fp8_support.cu
+++ b/runtime/fp8_support.cu
@@ -73,12 +73,11 @@ struct __align__(1) __e4m3 {
     __x = __double2e4m3(f).__x;
   }
 
-  __device__ __e4m3(const int x): __x(x) {}
+  __device__ __e4m3(const int x) : __x(x) {}
 
-  __device__ __e4m3(const uint8_t x): __x(x) {}
+  __device__ __e4m3(const uint8_t x) : __x(x) {}
 
-  __device__ __e4m3(const uint16_t x): __x(x) {}
-
+  __device__ __e4m3(const uint16_t x) : __x(x) {}
 
   __device__ uint8_t raw() const {
     return __x;
@@ -211,9 +210,7 @@ __device__ __inline__ __e4m3 operator|(const __e4m3 x, const __e4m3 y) {
   unsigned short val;
   unsigned short x_val = x.raw();
   unsigned short y_val = y.raw();
-  asm("{  or.b16 %0, %1, %2;}\n"
-      : "=h"(val)
-      : "h"(x_val), "h"(y_val));
+  asm("{  or.b16 %0, %1, %2;}\n" : "=h"(val) : "h"(x_val), "h"(y_val));
   return __e4m3(val);
 }
 
@@ -284,11 +281,11 @@ struct __align__(1) __e5m2 {
     __x = __double2e5m2(f).__x;
   }
 
-  __device__ __e5m2(const int x): __x(x) {}
+  __device__ __e5m2(const int x) : __x(x) {}
 
-  __device__ __e5m2(const uint8_t x): __x(x) {}
+  __device__ __e5m2(const uint8_t x) : __x(x) {}
 
-  __device__ __e5m2(const uint16_t x): __x(x) {}
+  __device__ __e5m2(const uint16_t x) : __x(x) {}
 
   __device__ uint8_t raw() const {
     return __x;
@@ -421,8 +418,6 @@ __device__ __inline__ __e5m2 operator|(const __e5m2 x, const __e5m2 y) {
   unsigned short val;
   unsigned short x_val = x.raw();
   unsigned short y_val = y.raw();
-  asm("{  or.b16 %0, %1, %2;}\n"
-      : "=h"(val)
-      : "h"(x_val), "h"(y_val));
+  asm("{  or.b16 %0, %1, %2;}\n" : "=h"(val) : "h"(x_val), "h"(y_val));
   return __e5m2(val);
 }

--- a/runtime/fp8_support.cu
+++ b/runtime/fp8_support.cu
@@ -195,6 +195,10 @@ __device__ __inline__ __bfloat __e4m32bfloat(const __e4m3 h) {
   return val;
 }
 
+__device__ __inline__ __e4m3 operator|(const __e4m3 x, const __e4m3 y) {
+  return x.raw() | y.raw();
+}
+
 struct __e5m2;
 __device__ __inline__ __e5m2 __float2e5m2(const float);
 
@@ -382,4 +386,8 @@ __device__ __inline__ __bfloat __e5m22bfloat(const __e5m2 h) {
       : "h"(_tmp_buffer));
 
   return val;
+}
+
+__device__ __inline__ __e5m2 operator|(const __e5m2 x, const __e5m2 y) {
+  return x.raw() | y.raw();
 }

--- a/runtime/fp8_support.cu
+++ b/runtime/fp8_support.cu
@@ -8,6 +8,7 @@
 
 struct __e4m3;
 __device__ __inline__ __e4m3 __float2e4m3(const float);
+__device__ __inline__ __e4m3 __double2e4m3(const double);
 
 struct __align__(1) __e4m3 {
   __e4m3() = default;
@@ -67,6 +68,17 @@ struct __align__(1) __e4m3 {
   __device__ __e4m3(const float f) {
     __x = __float2e4m3(f).__x;
   }
+
+  __device__ __e4m3(const double f) {
+    __x = __double2e4m3(f).__x;
+  }
+
+  __device__ __e4m3(const int x): __x(x) {}
+
+  __device__ __e4m3(const uint8_t x): __x(x) {}
+
+  __device__ __e4m3(const uint16_t x): __x(x) {}
+
 
   __device__ uint8_t raw() const {
     return __x;
@@ -196,11 +208,18 @@ __device__ __inline__ __bfloat __e4m32bfloat(const __e4m3 h) {
 }
 
 __device__ __inline__ __e4m3 operator|(const __e4m3 x, const __e4m3 y) {
-  return x.raw() | y.raw();
+  unsigned short val;
+  unsigned short x_val = x.raw();
+  unsigned short y_val = y.raw();
+  asm("{  or.b16 %0, %1, %2;}\n"
+      : "=h"(val)
+      : "h"(x_val), "h"(y_val));
+  return __e4m3(val);
 }
 
 struct __e5m2;
 __device__ __inline__ __e5m2 __float2e5m2(const float);
+__device__ __inline__ __e5m2 __double2e5m2(const double);
 
 struct __align__(1) __e5m2 {
   __e5m2() = default;
@@ -260,6 +279,16 @@ struct __align__(1) __e5m2 {
   __device__ __e5m2(const float f) {
     __x = __float2e5m2(f).__x;
   }
+
+  __device__ __e5m2(const double f) {
+    __x = __double2e5m2(f).__x;
+  }
+
+  __device__ __e5m2(const int x): __x(x) {}
+
+  __device__ __e5m2(const uint8_t x): __x(x) {}
+
+  __device__ __e5m2(const uint16_t x): __x(x) {}
 
   __device__ uint8_t raw() const {
     return __x;
@@ -389,5 +418,11 @@ __device__ __inline__ __bfloat __e5m22bfloat(const __e5m2 h) {
 }
 
 __device__ __inline__ __e5m2 operator|(const __e5m2 x, const __e5m2 y) {
-  return x.raw() | y.raw();
+  unsigned short val;
+  unsigned short x_val = x.raw();
+  unsigned short y_val = y.raw();
+  asm("{  or.b16 %0, %1, %2;}\n"
+      : "=h"(val)
+      : "h"(x_val), "h"(y_val));
+  return __e5m2(val);
 }


### PR DESCRIPTION
`cat` is translated to CUDA code with a if-then-else block:

```
if (i < input0_ext) {
  out[idx] = input0[idx];
} else if (i < input0_ext + input1_ext) {
  out[idx] = input1[idx];
} else if ...
```

This is correct, but I believe this can be simplified to just `out[idx] = input0[idx] + input1[idx] + ...` since all of the inputs are padded by zero, so this result should be equivalent.

Since `+` is not defined for some low precision types, bitwise-or is instead used when addition is not available.

On A100, this simplification yielded about 5% perf improvement of a RoPE module.

I didn't add any specific test since I don't know if any new test would be beneficial. Half, bfloat16 and fp8 types are tested by `ResizeTest.CatMemoryPromotionReducedFloating`.