### PR TITLE
Cleanup of circular buffering pass: add `currentParity`

### DIFF
--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -423,6 +423,32 @@ class CloneTmaCircularBufferLoopAndInsertSync
         result, for_loop_stack_);
   }
 
+  // The mbarrier_parity for the current circular buffer stage is:
+  //   (loop_index / stage_depth) % 2
+  // We have an mbarrier for each circular buffer stage, so loop_index /
+  // stage_depth is loop_index_per_stage. The valid values of phaseParity
+  // operand are 0 and 1, so we take the modulo of loop_index_per_stage with a
+  // divisor of 2. See:
+  // https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-test-wait-mbarrier-try-wait
+  // for reference.
+  Val* currentParity() const {
+    int64_t stage_depth =
+        GpuLower::current()->circularBufferInfo().getStageDepthFor(
+            circular_buffer_loop_->iter_domain());
+
+    auto depth = IrBuilder::create<Val>(stage_depth, DataType::UInt32);
+    auto two = IrBuilder::create<Val>(2, DataType::UInt32);
+    Val* stage_parity = SimplifyingIrBuilder::modExpr(
+        SimplifyingIrBuilder::divExpr(
+            IrBuilder::maybeCastExpr(
+                DataType::UInt32,
+                cloned_top_level_loop_->indexOrStartIfTrivial()),
+            depth),
+        two);
+    return GpuLower::current()->commonScalarMap().hoistScalar(
+        stage_parity, for_loop_stack_);
+  }
+
   void processExpr(Expr* expr) final {
     TensorView* out_tv = ir_utils::getTvOutput(expr);
     bool is_circular_buffer_load_expr = std::any_of(
@@ -595,8 +621,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
     NVF_ERROR(
         mbarrier_wait_ == nullptr,
         "Expected mbarrier_wait to inactive for current TMA operation");
-    mbarrier_wait_ = createMbarrierWait(
-        ldst, cloned_top_level_loop_->indexOrStartIfTrivial());
+    mbarrier_wait_ = createMbarrierWait(ldst);
 
     // If last cloned scope is the cloned_top_level_loop body, then add
     // mbarrier::arriveExpectTx, new loadStoreOp, and mbarrier_wait
@@ -622,8 +647,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
     NVF_ERROR(
         mbarrier_wait_ == nullptr,
         "Expected mbarrier_wait to inactive for current TMA operation");
-    mbarrier_wait_ = createMbarrierWait(
-        ldst, cloned_top_level_loop_->indexOrStartIfTrivial());
+    mbarrier_wait_ = createMbarrierWait(ldst);
 
     // If last cloned scope is the cloned_top_level_loop body, then add
     // mbarrier_wait
@@ -742,39 +766,17 @@ class CloneTmaCircularBufferLoopAndInsertSync
 
   // This function creates kir::MBarrierWaitParity for given LoadStoreOp and
   // circular buffer stage.
-  kir::MBarrierWaitParity* createMbarrierWait(
-      LoadStoreOp* ldst,
-      Val* loop_index) {
+  kir::MBarrierWaitParity* createMbarrierWait(LoadStoreOp* ldst) {
     NVF_ERROR(ldst != nullptr);
-    NVF_ERROR(loop_index != nullptr);
-
-    int64_t stage_depth =
-        GpuLower::current()->circularBufferInfo().getStageDepthFor(
-            circular_buffer_loop_->iter_domain());
 
     // Get mbarrier for this circular buffer stage.
     TensorView* all_mbarriers = GpuLower::current()->ldstMBarrierMap().at(ldst);
     kir::TensorIndex* stage_mbarrier = IrBuilder::create<kir::TensorIndex>(
         all_mbarriers, currentComputeStage());
 
-    // The mbarrier_parity for this circular buffer stage is:
-    //   (loop_index / stage_depth) % 2
-    // We have an mbarrier for each circular buffer stage, so loop_index /
-    // stage_depth is loop_index_per_stage. The valid values of phaseParity
-    // operand are 0 and 1, so we take the modulo of loop_index_per_stage with a
-    // divisor of 2. See:
-    // https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-test-wait-mbarrier-try-wait
-    // for reference.
-    auto depth = IrBuilder::create<Val>(stage_depth, DataType::UInt32);
-    auto two = IrBuilder::create<Val>(2, DataType::UInt32);
-    Val* stage_parity = SimplifyingIrBuilder::modExpr(
-        SimplifyingIrBuilder::divExpr(
-            IrBuilder::maybeCastExpr(DataType::UInt32, loop_index), depth),
-        two);
-
     kir::MBarrierWaitParity* mbarrier_wait =
         IrBuilder::create<kir::MBarrierWaitParity>(
-            stage_mbarrier, stage_parity);
+            stage_mbarrier, currentParity());
     return mbarrier_wait;
   }
 


### PR DESCRIPTION
Similar to https://github.com/NVIDIA/Fuser/pull/3212