### PR TITLE
Fill contiguity according to stride_order. 

### DIFF
--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -1120,6 +1120,11 @@ void initNvFuserPythonBindings(PyObject* module) {
 
             const auto rank = static_cast<int64_t>(shape.size());
             std::vector<std::optional<bool>> contiguity_vec(rank);
+            // This duplicates some code around
+            // https://github.com/NVIDIA/Fuser/blob/b60f2341bbe2ec276b1fe60f4f25a4a5b093faa9/csrc/python_frontend/fusion_record.h#L1370.
+            // Alternatively, I can extend TensorRecord to allow contiguity as
+            // a boolean. If you think it's worth doing, I'm happy to pursue it
+            // in a separate PR.
             for (const auto index : c10::irange(rank)) {
               const auto contig_index =
                   stride_order.empty() ? index : rank - 1 - stride_order[index];

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -1118,13 +1118,15 @@ void initNvFuserPythonBindings(PyObject* module) {
 
             verifyShape(shape);
 
-            std::vector<std::optional<bool>> contiguity_vec;
-            contiguity_vec.reserve(shape.size());
-            for (const auto dim_size : shape) {
-              if (dim_size == 1) {
-                contiguity_vec.emplace_back(std::nullopt);
+            const auto rank = static_cast<int64_t>(shape.size());
+            std::vector<std::optional<bool>> contiguity_vec(rank);
+            for (const auto index : c10::irange(rank)) {
+              const auto contig_index =
+                  stride_order.empty() ? index : rank - 1 - stride_order[index];
+              if (shape[index] == 1) {
+                contiguity_vec[contig_index] = std::nullopt;
               } else {
-                contiguity_vec.emplace_back(contiguity);
+                contiguity_vec[contig_index] = contiguity;
               }
             }
 

--- a/tests/python/test_define.py
+++ b/tests/python/test_define.py
@@ -38,3 +38,13 @@ def test_define_tensor_broadcast():
     inp_tensor = torch.randn(1, 2, 1, device="cuda").as_strided([1, 2, 1], [0, 1, 0])
     out_tensor = fd.execute([inp_tensor])[0]
     torch.testing.assert_close(out_tensor, inp_tensor * 2)
+
+def test_define_tensor_stride_order():
+    with FusionDefinition() as fd:
+        inp = fd.define_tensor([1, 2], contiguity=True, stride_order=[0, 1])
+        out = fd.ops.add(inp, inp)
+        fd.add_output(out)
+
+    inp_tensor = torch.randn(1, 2, device="cuda")
+    out_tensor = fd.execute([inp_tensor])[0]
+    torch.testing.assert_close(out_tensor, inp_tensor * 2)

--- a/tests/python/test_define.py
+++ b/tests/python/test_define.py
@@ -8,6 +8,10 @@ from nvfuser import FusionDefinition
 from utils import NVFuserTest
 
 
+# I tried to merge the tests to opinfo and
+# [failed](https://github.com/NVIDIA/Fuser/commit/b0ccb481a7d60f944abf4b6b164f625fec31d147).
+# There seems to be a bug in opinfo causing the generated test to pass fewer
+# arguments than parameters.
 class TestDefine(NVFuserTest):
     def test_contiguous(self):
         def fusion_func(fd: FusionDefinition):

--- a/tests/python/test_define.py
+++ b/tests/python/test_define.py
@@ -8,10 +8,7 @@ from nvfuser import FusionDefinition
 from utils import NVFuserTest
 
 
-# I tried to merge the tests to opinfo and
-# [failed](https://github.com/NVIDIA/Fuser/commit/b0ccb481a7d60f944abf4b6b164f625fec31d147).
-# There seems to be a bug in opinfo causing the generated test to pass fewer
-# arguments than parameters.
+# I tried to merge the tests to opinfo and [failed](https://github.com/NVIDIA/Fuser/issues/3225).
 class TestDefine(NVFuserTest):
     def test_contiguous(self):
         def fusion_func(fd: FusionDefinition):

--- a/tests/python/test_define.py
+++ b/tests/python/test_define.py
@@ -19,7 +19,6 @@ class TestDefine(NVFuserTest):
         out_tensors, _ = self.exec_nvfuser(fusion_func, [in_tensor])
         torch.testing.assert_close(out_tensors[0], in_tensor * 2)
 
-
     def test_noncontiguous(self):
         def fusion_func(fd: FusionDefinition):
             inp = fd.define_tensor([2, 3])
@@ -29,7 +28,6 @@ class TestDefine(NVFuserTest):
         in_tensor = torch.randn(8, device="cuda").as_strided([2, 3], [4, 1])
         out_tensors, _ = self.exec_nvfuser(fusion_func, [in_tensor])
         torch.testing.assert_close(out_tensors[0], in_tensor * 2)
-
 
     def test_broadcast(self):
         def fusion_func(fd: FusionDefinition):


### PR DESCRIPTION
This will fix a bug introduced by my https://github.com/NVIDIA/Fuser/pull/3145. 