### PR TITLE
Fix torch allocator clearing cache on every benchmark

### DIFF
--- a/nvfuser/pytorch_utils.py
+++ b/nvfuser/pytorch_utils.py
@@ -173,9 +173,6 @@ def clear_cuda_cache() -> None:
     """
     Utility function to clear CUDA cache before running a test.
     """
-    if (
-        torch.cuda.memory_allocated()
-        or torch.cuda.memory_reserved() > 0.8 * DEVICE_PROPERTIES["gpu_gmem_bytes"]
-    ):
+    if torch.cuda.memory_reserved() > 0.8 * DEVICE_PROPERTIES["gpu_gmem_bytes"]:
         gc.collect()
         torch.cuda.empty_cache()


### PR DESCRIPTION
This speeds up running the benchmarks by quite a bit since malloc is so slow.