### PR TITLE
Use a single mbarrier to guard all TMA loads for circular buffering

### DIFF
--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -97,8 +97,6 @@ Expr* initializeMbarrier(
       });
   Val* n = IrBuilder::create<Val>(num_of_tvs_loaded_by_tma, DataType::UInt32);
   Val* num_of_arrives = SimplifyingIrBuilder::mulExpr(n, all_threads_in_cta);
-  num_of_arrives =
-      SimplifyingIrBuilder::maybeCastExpr(DataType::UInt32, num_of_arrives);
 
   // Initialize mbarrier for each circular buffer stage. Use the thread
   // count from the MBarrierInit created in the allocation pass. The wait

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -658,59 +658,59 @@ class AllocationInserter : public kir::ExprMutator {
         });
 
     if (circular_buffer_load_is_tma) {
+      // Create and allocate a memory barrier. If this is a circular buffer,
+      // then allocate an array of mbarier objects. mbarrier::init and
+      // mbarrier::inval will be updated in circular buffering pass, but we
+      // add them here to handle shared memory correctly in alias memory pass.
+      int64_t circular_buffer_depth =
+          GpuLower::current()->circularBufferInfo().getStageDepthFor(
+              fl->iter_domain());
+
+      TensorView* mbarrier =
+          TensorViewBuilder()
+              .shape(std::vector<int64_t>{circular_buffer_depth})
+              .dtype(DataType::UInt)
+              .contiguity(true)
+              .build();
+      mbarrier->setMemoryType(MemoryType::Shared);
+
+      kir::Allocate* mbarrier_alloc =
+          IrBuilder::create<kir::Allocate>(mbarrier, MemoryType::Shared);
+
+      auto mbarrier_init = initializeMbarrier(fl, mbarrier);
+      auto mbarrier_inval = invalidateMbarrier(fl, mbarrier);
+
+      // Block sync is necessary to finish mbarrier initialization.
+      kir::BlockSync* sync = IrBuilder::create<kir::BlockSync>(false);
+
+      // Add mbarriers, init, and inval operations around tma expression like
+      // this:
+      //
+      // __shared__ mbarrier[num_stages];
+      // for (circular_buffer_stage) {
+      //   init(mbarrier[stage]);
+      // }
+      // block_sync();
+      //
+      // for (circular_buffer_loop) {
+      //   cp.async.bulk(data, mbarrier);
+      // }
+      //
+      // for (circular_buffer_stage) {
+      //   inval(mbarrier[stage]);
+      // }
+      //
+      Scope* current_scope = scope_.empty() ? nullptr : scope_.back();
+      registerInsertBefore(fl, mbarrier_alloc, current_scope);
+      registerInsertBefore(fl, mbarrier_init, current_scope);
+      registerInsertBefore(fl, sync, current_scope);
+      registerInsertAfter(fl, mbarrier_inval, current_scope);
+
       for (auto tv : circular_buffer_tvs) {
         // short-circuit: circular buffered tv is not defined with TMA load.
         if (!ir_utils::isCpAsyncBulkLoad(tv->definition())) {
           continue;
         }
-        // Create and allocate a memory barrier. If this is a circular buffer,
-        // then allocate an array of mbarier objects. mbarrier::init and
-        // mbarrier::inval will be updated in circular buffering pass, but we
-        // add them here to handle shared memory correctly in alias memory pass.
-        int64_t circular_buffer_depth =
-            GpuLower::current()->circularBufferInfo().getStageDepthFor(
-                fl->iter_domain());
-
-        TensorView* mbarrier =
-            TensorViewBuilder()
-                .shape(std::vector<int64_t>{circular_buffer_depth})
-                .dtype(DataType::UInt)
-                .contiguity(true)
-                .build();
-        mbarrier->setMemoryType(MemoryType::Shared);
-
-        kir::Allocate* mbarrier_alloc =
-            IrBuilder::create<kir::Allocate>(mbarrier, MemoryType::Shared);
-
-        auto mbarrier_init = initializeMbarrier(fl, mbarrier);
-        auto mbarrier_inval = invalidateMbarrier(fl, mbarrier);
-
-        // Block sync is necessary to finish mbarrier initialization.
-        kir::BlockSync* sync = IrBuilder::create<kir::BlockSync>(false);
-
-        // Add mbarriers, init, and inval operations around tma expression like
-        // this:
-        //
-        // __shared__ mbarrier[num_stages];
-        // for (circular_buffer_stage) {
-        //   init(mbarrier[stage]);
-        // }
-        // block_sync();
-        //
-        // for (circular_buffer_loop) {
-        //   cp.async.bulk(data, mbarrier);
-        // }
-        //
-        // for (circular_buffer_stage) {
-        //   inval(mbarrier[stage]);
-        // }
-        //
-        Scope* current_scope = scope_.empty() ? nullptr : scope_.back();
-        registerInsertBefore(fl, mbarrier_alloc, current_scope);
-        registerInsertBefore(fl, mbarrier_init, current_scope);
-        registerInsertBefore(fl, sync, current_scope);
-        registerInsertAfter(fl, mbarrier_inval, current_scope);
-
         // Map LoadStoreOp expression to ir nodes created in this pass
         GpuLower::current()->ldstMBarrierMap()[tv->definition()] = mbarrier;
       }


### PR DESCRIPTION
We need to wait for all of them anyway, so why not just use a single mbarrier?

I suggest reviewing this PR hiding whitespaces, the diff ignoring spaces are very small:
![image](https://github.com/NVIDIA/Fuser/assets/1032377/892cfeff-f080-49a0-9846-319632538339)

Perf:

```C++
 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name

 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     19.1          1309169          1  1309169.0  1309169.0   1309169   1309169          0.0  <unnamed>::nvfuser_none_f0_c0_r0_g0(<unnamed>::Tensor<<unnamed>::__half, (int)3, (int)3>, <unnamed>…
     11.3           776119          1   776119.0   776119.0    776119    776119          0.0  nvjet_hsh_192x192_64x3_2x1_v_bz_coopB_NTN
```

Perf nvFuser/cuBLAS: `59.28%`.