### PR TITLE
Update print message for cycle detection.

### DIFF
--- a/csrc/iter_visitor.cpp
+++ b/csrc/iter_visitor.cpp
@@ -264,8 +264,9 @@ void IterVisitor::traverseBetween(
                 })) {
           std::unordered_set<Statement*> from_stmt(from.begin(), from.end());
           auto cycle = ir_utils::checkCycle(fusion, from_stmt, to);
+          TORCH_WARN("A cycle is detected in the fusion.");
           std::stringstream ss;
-          ss << "cycle detected in fusion: " << std::endl;
+          ss << "Statements found in the cycle: " << std::endl;
           for (auto expr :
                ir_utils::filterByType<Expr>(cycle.begin(), cycle.end())) {
             ss << expr << std::endl;


### PR DESCRIPTION
When a cycle occurs in the fusion, a segmentation fault can occur when printing the statements in the cycle. In this case, the developer doesn't get any information and must use `gdb` to diagnose the segmentation fault. This PR adds a warning message to print that a cycle is detected before printing the cycle's statements. 

