### PR TITLE
Introduce @retry_on_oom_or_skip_test

### DIFF
--- a/benchmarks/python/normalization.py
+++ b/benchmarks/python/normalization.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from nvfuser import FusionDefinition, DataType
 from .global_params import PROMOTE_DTYPES
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 import torch
 from .core import run_benchmark, unary_bwd_torch, clear_dynamo_cache
 import numpy as np
@@ -205,9 +205,6 @@ def norm_fwd_nvf_benchmark(
     """
     Common benchmark setup for batchnorm/instance forward call in training mode.
     """
-
-    clear_cuda_cache()
-
     assert norm in ["batch_norm", "instance_norm"], NotImplementedError
 
     # Size is assumed to be in the order N, C, ...
@@ -292,8 +289,6 @@ def norm_bwd_nvf_benchmark(
     """
     Common benchmark setup for batchnorm/instance forward call in training mode.
     """
-
-    clear_cuda_cache()
 
     assert norm in ["batch_norm", "instance_norm"], NotImplementedError
 
@@ -440,7 +435,6 @@ def norm_fwd_baseline_benchmark(
     compile: bool,
     norm: str,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
 
@@ -475,7 +469,6 @@ def norm_bwd_baseline_benchmark(
     compile: bool,
     norm: str,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
 

--- a/benchmarks/python/test_batchnorm_bwd.py
+++ b/benchmarks/python/test_batchnorm_bwd.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 import torch
+from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 from .global_params import generate_input_sizes, FLOAT_DTYPES
 from .normalization import norm_bwd_nvf_benchmark, norm_bwd_baseline_benchmark
 
@@ -10,6 +11,7 @@ from .normalization import norm_bwd_nvf_benchmark, norm_bwd_baseline_benchmark
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
+@retry_on_oom_or_skip_test
 def test_batchnorm_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -35,6 +37,7 @@ def test_batchnorm_bwd_nvf_benchmark(
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
+@retry_on_oom_or_skip_test
 def test_batchnorm_bwd_baseline_benchmark(
     benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, compile: bool
 ):

--- a/benchmarks/python/test_batchnorm_fwd.py
+++ b/benchmarks/python/test_batchnorm_fwd.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 import torch
+from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 from .global_params import generate_input_sizes, FLOAT_DTYPES
 from .normalization import norm_fwd_nvf_benchmark, norm_fwd_baseline_benchmark
 
@@ -10,6 +11,7 @@ from .normalization import norm_fwd_nvf_benchmark, norm_fwd_baseline_benchmark
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
+@retry_on_oom_or_skip_test
 def test_batchnorm_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -35,6 +37,7 @@ def test_batchnorm_fwd_nvf_benchmark(
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
+@retry_on_oom_or_skip_test
 def test_batchnorm_fwd_baseline_benchmark(
     benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, compile: bool
 ):

--- a/benchmarks/python/test_dropout_layernorm_fwd.py
+++ b/benchmarks/python/test_dropout_layernorm_fwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import (
     run_benchmark,
     clear_dynamo_cache,
@@ -103,6 +106,7 @@ def dropout_layernorm_fwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_dropout_layernorm_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -111,7 +115,6 @@ def test_dropout_layernorm_fwd_nvf_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
-    clear_cuda_cache()
     inputs = [
         torch.randn(size, device="cuda", dtype=dtype),
         torch.randn(size, device="cuda", dtype=dtype),
@@ -164,13 +167,13 @@ def test_dropout_layernorm_fwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_dropout_layernorm_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
 

--- a/benchmarks/python/test_dropout_rmsnorm_bwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_bwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import (
     run_benchmark,
     clear_dynamo_cache,
@@ -127,6 +130,7 @@ def dropout_rmsnorm_bwd_iobytes(size, dtype):
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.inner_outer_persistent
+@retry_on_oom_or_skip_test
 def test_dropout_rmsnorm_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -135,8 +139,6 @@ def test_dropout_rmsnorm_bwd_nvf_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
-    clear_cuda_cache()
-
     input1 = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     input2 = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(size, device="cuda", dtype=dtype)
@@ -174,13 +176,13 @@ def test_dropout_rmsnorm_bwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_dropout_rmsnorm_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     dropout_p = 0.2

--- a/benchmarks/python/test_dropout_rmsnorm_fwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_fwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import (
     run_benchmark,
     clear_dynamo_cache,
@@ -103,6 +106,7 @@ def dropout_rmsnorm_fwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_dropout_rmsnorm_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -111,8 +115,6 @@ def test_dropout_rmsnorm_fwd_nvf_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
-    clear_cuda_cache()
-
     input1 = torch.randn(size, device="cuda", dtype=dtype)
     input2 = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype)
@@ -150,13 +152,13 @@ def test_dropout_rmsnorm_fwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_dropout_rmsnorm_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     dropout_p = 0.2

--- a/benchmarks/python/test_gelu_bwd.py
+++ b/benchmarks/python/test_gelu_bwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -64,6 +67,7 @@ def gelu_bwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_gelu_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -71,8 +75,6 @@ def test_gelu_bwd_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
-
     inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(size, device="cuda", dtype=dtype)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
@@ -93,13 +95,13 @@ def test_gelu_bwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_gelu_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)

--- a/benchmarks/python/test_gelu_fwd.py
+++ b/benchmarks/python/test_gelu_fwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -47,6 +50,7 @@ def gelu_fwd_fn(inputs: list):  # [in_tensor, bias]
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_gelu_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -54,8 +58,6 @@ def test_gelu_fwd_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
-
     inputs = [
         torch.randn(size, device="cuda", dtype=dtype, requires_grad=True),  # in_tensor
         torch.ones(size[-1], device="cuda", dtype=dtype),  # bias
@@ -72,13 +74,13 @@ def test_gelu_fwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_gelu_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     inputs = [

--- a/benchmarks/python/test_groupnorm_fwd.py
+++ b/benchmarks/python/test_groupnorm_fwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 import thunder
@@ -103,6 +106,7 @@ def groupnorm_fwd(inputs: list):  # [in_tensor, weights, bias, n_groups]
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.inner_persistent
+@retry_on_oom_or_skip_test
 def test_groupnorm_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -111,8 +115,6 @@ def test_groupnorm_fwd_nvf_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
-    clear_cuda_cache()
-
     N, C, H, W = size
     x = torch.randn(size, device="cuda", dtype=dtype)
     weight = torch.randn(C, device="cuda", dtype=dtype)
@@ -132,12 +134,12 @@ def test_groupnorm_fwd_nvf_benchmark(
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_groupnorm_fwd_thunder_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
 ):
-    clear_cuda_cache()
     N, C, H, W = size
     x = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     weight = torch.randn(C, device="cuda", dtype=dtype, requires_grad=True)
@@ -153,13 +155,13 @@ def test_groupnorm_fwd_thunder_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_groupnorm_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     N, C, H, W = size

--- a/benchmarks/python/test_huggingface_attn_fwd.py
+++ b/benchmarks/python/test_huggingface_attn_fwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -97,6 +100,7 @@ def huggingface_attn_fwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_huggingface_attn_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -104,8 +108,6 @@ def test_huggingface_attn_fwd_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
-
     batch_size, seq_len, nh, n_embd = size
     dropout_p = 0.2
     inputs = torch.randn(batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype)
@@ -140,13 +142,13 @@ def test_huggingface_attn_fwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_huggingface_attn_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     batch_size, seq_len, nh, n_embd = size

--- a/benchmarks/python/test_instancenorm_bwd.py
+++ b/benchmarks/python/test_instancenorm_bwd.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 import torch
+from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 from .global_params import generate_input_sizes, FLOAT_DTYPES
 from .normalization import norm_bwd_nvf_benchmark, norm_bwd_baseline_benchmark
 
@@ -10,6 +11,7 @@ from .normalization import norm_bwd_nvf_benchmark, norm_bwd_baseline_benchmark
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
+@retry_on_oom_or_skip_test
 def test_instancenorm_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -34,6 +36,7 @@ def test_instancenorm_bwd_nvf_benchmark(
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
+@retry_on_oom_or_skip_test
 def test_instancenorm_bwd_baseline_benchmark(
     benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, compile: bool
 ):

--- a/benchmarks/python/test_instancenorm_fwd.py
+++ b/benchmarks/python/test_instancenorm_fwd.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 import torch
+from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 from .global_params import generate_input_sizes, FLOAT_DTYPES
 from .normalization import norm_fwd_nvf_benchmark, norm_fwd_baseline_benchmark
 
@@ -10,6 +11,7 @@ from .normalization import norm_fwd_nvf_benchmark, norm_fwd_baseline_benchmark
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
+@retry_on_oom_or_skip_test
 def test_instancenorm_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -33,6 +35,7 @@ def test_instancenorm_fwd_nvf_benchmark(
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
+@retry_on_oom_or_skip_test
 def test_instancenorm_fwd_baseline_benchmark(
     benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, compile: bool
 ):

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -76,6 +79,7 @@ def layernorm_fwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_layernorm_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -84,8 +88,6 @@ def test_layernorm_fwd_nvf_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
-    clear_cuda_cache()
-
     batch_size, hidden_size = size
     inputs = [
         torch.randn(size, device="cuda", dtype=dtype),
@@ -111,13 +113,13 @@ def test_layernorm_fwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_layernorm_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     batch_size, hidden_size = size

--- a/benchmarks/python/test_many_pointwise_ops.py
+++ b/benchmarks/python/test_many_pointwise_ops.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark
 import torch
 from .global_params import PROMOTE_DTYPES
@@ -32,6 +35,7 @@ def pointwise_ops_fusion(fd: FusionDefinition, dtype: DataType, num_iters: int):
 # NOTE: num_iters restricted due to issue #1234.
 @pytest.mark.parametrize("num_iters", [2, 4, 8, 16])
 @pytest.mark.parametrize("host_bench_mode", ["compile", "steady", "dynamic"])
+@retry_on_oom_or_skip_test
 def test_pointwise_ops_benchmark(
     benchmark,
     num_iters: int,
@@ -39,8 +43,6 @@ def test_pointwise_ops_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
-
     inputs = [torch.randn(13, device="cuda", dtype=torch.float16) for _ in range(2)]
 
     # Generate multiple inputs to measure dynamic shape overhead.

--- a/benchmarks/python/test_matmul.py
+++ b/benchmarks/python/test_matmul.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition
-from nvfuser.pytorch_utils import clear_cuda_cache
+from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 from .core import run_benchmark
 import torch
 
@@ -29,6 +29,7 @@ def load_matmul_problems():
     "config", load_matmul_problems(), ids=lambda val: "_".join(str(v) for v in val)
 )
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@retry_on_oom_or_skip_test
 def test_matmul_nvf_benchmark(
     benchmark,
     config: tuple,
@@ -37,8 +38,6 @@ def test_matmul_nvf_benchmark(
     disable_benchmarking: bool,
 ):
     m, n, k, layout = config
-
-    clear_cuda_cache()
 
     try:
         a = torch.randn(m, k, device="cuda", dtype=dtype)

--- a/benchmarks/python/test_nanogpt_attn_bwd.py
+++ b/benchmarks/python/test_nanogpt_attn_bwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -84,6 +87,7 @@ def nanogpt_attn_bwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_nanogpt_attn_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -91,7 +95,6 @@ def test_nanogpt_attn_bwd_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
     batch_size, seq_len, nh, n_embd = size
     hs = n_embd // nh
     dropout_p = 0.2
@@ -128,13 +131,13 @@ def test_nanogpt_attn_bwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_nanogpt_attn_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     batch_size, seq_len, nh, n_embd = size

--- a/benchmarks/python/test_nanogpt_attn_fwd.py
+++ b/benchmarks/python/test_nanogpt_attn_fwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -95,6 +98,7 @@ def nanogpt_attn_fwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_nanogpt_attn_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -102,7 +106,6 @@ def test_nanogpt_attn_fwd_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
     batch_size, seq_len, nh, n_embd = size
     hs = n_embd // nh
     dropout_p = 0.2
@@ -141,13 +144,13 @@ def test_nanogpt_attn_fwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_nanogpt_attn_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     batch_size, seq_len, nh, n_embd = size

--- a/benchmarks/python/test_pointwise_mul.py
+++ b/benchmarks/python/test_pointwise_mul.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -30,6 +33,7 @@ def pointwise_mul_fwd_fn(inputs: list):  # in_tensor
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_pointwise_mul_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -37,8 +41,6 @@ def test_pointwise_mul_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
-
     inputs = [torch.randn(size, device="cuda", dtype=dtype)]
 
     with FusionDefinition() as fd:
@@ -55,13 +57,13 @@ def test_pointwise_mul_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_pointwise_mul_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype)

--- a/benchmarks/python/test_reduction_epilogue.py
+++ b/benchmarks/python/test_reduction_epilogue.py
@@ -4,7 +4,10 @@
 
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -42,6 +45,7 @@ def reduction_epilogue_fwd_fn(
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0])
+@retry_on_oom_or_skip_test
 def test_reduction_epilogue_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -50,7 +54,6 @@ def test_reduction_epilogue_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
     x = torch.randn(size, device="cuda", dtype=dtype)
     epilogue = torch.randn(size[reduction_axis - 1], device="cuda", dtype=dtype)
     with FusionDefinition() as fd:
@@ -72,6 +75,7 @@ def test_reduction_epilogue_nvf_benchmark(
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0])
+@retry_on_oom_or_skip_test
 def test_reduction_epilogue_baseline_benchmark(
     benchmark,
     size: tuple,
@@ -79,7 +83,6 @@ def test_reduction_epilogue_baseline_benchmark(
     reduction_axis: int,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     x = torch.randn(size, device="cuda", dtype=dtype)

--- a/benchmarks/python/test_rmsnorm_bwd.py
+++ b/benchmarks/python/test_rmsnorm_bwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -83,6 +86,7 @@ def rmsnorm_bwd_iobytes(size: tuple, dtype: torch.dtype):
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.inner_outer_persistent
+@retry_on_oom_or_skip_test
 def test_rmsnorm_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -91,7 +95,6 @@ def test_rmsnorm_bwd_nvf_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
-    clear_cuda_cache()
     inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
@@ -116,13 +119,13 @@ def test_rmsnorm_bwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_rmsnorm_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)

--- a/benchmarks/python/test_rmsnorm_fwd.py
+++ b/benchmarks/python/test_rmsnorm_fwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -62,6 +65,7 @@ def rmsnorm_fwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_rmsnorm_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -70,8 +74,6 @@ def test_rmsnorm_fwd_nvf_benchmark(
     disable_benchmarking: bool,
     eps: float = 1e-5,
 ):
-    clear_cuda_cache()
-
     inputs = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype)
 
@@ -91,13 +93,13 @@ def test_rmsnorm_fwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_rmsnorm_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     inputs = torch.randn(size, device="cuda", dtype=dtype)

--- a/benchmarks/python/test_rope.py
+++ b/benchmarks/python/test_rope.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import clear_cuda_cache
+from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 from .core import run_benchmark
 import torch
 
@@ -125,11 +125,10 @@ def rope_without_cat_fusion(
 
 
 @pytest.mark.parametrize("use_cat", [True, False], ids=["with_cat", "without_cat"])
+@retry_on_oom_or_skip_test
 def test_rope_benchmark(
     benchmark, use_cat: bool, disable_validation: bool, disable_benchmarking: bool
 ):
-    clear_cuda_cache()
-
     batch_size = 32
     seq_len = 4096
     num_heads = 32

--- a/benchmarks/python/test_scale_bias_relu_bwd.py
+++ b/benchmarks/python/test_scale_bias_relu_bwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -54,6 +57,7 @@ def sbr_bwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_sbr_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -61,8 +65,6 @@ def test_sbr_bwd_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
-
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
     scale = torch.ones(size[-1], device="cuda", dtype=dtype)
@@ -84,13 +86,13 @@ def test_sbr_bwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_sbr_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)

--- a/benchmarks/python/test_silu_mul_bwd.py
+++ b/benchmarks/python/test_silu_mul_bwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -58,6 +61,7 @@ def silu_mul_bwd_iobytes(size: tuple, dtype: torch.dtype):
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_silu_mul_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -65,7 +69,6 @@ def test_silu_mul_bwd_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
     x = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     y = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
@@ -83,13 +86,13 @@ def test_silu_mul_bwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_silu_mul_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     x = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)

--- a/benchmarks/python/test_silu_mul_fwd.py
+++ b/benchmarks/python/test_silu_mul_fwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -37,6 +40,7 @@ def silu_mul_fwd_fn(inputs: list):  # [in_tensor1, in_tensor_2]
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_silu_mul_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -44,7 +48,6 @@ def test_silu_mul_fwd_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
     inputs = [torch.randn(*size, device="cuda", dtype=dtype) for _ in range(2)]
 
     with FusionDefinition() as fd:
@@ -60,13 +63,13 @@ def test_silu_mul_fwd_nvf_benchmark(
 @pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@retry_on_oom_or_skip_test
 def test_silu_mul_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     inputs = [torch.randn(*size, device="cuda", dtype=dtype) for _ in range(2)]

--- a/benchmarks/python/test_softmax_bwd.py
+++ b/benchmarks/python/test_softmax_bwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES
@@ -71,6 +74,7 @@ def softmax_bwd_iobytes(size: tuple, dtype: torch.dtype):
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0, 1])
+@retry_on_oom_or_skip_test
 def test_softmax_bwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -79,8 +83,6 @@ def test_softmax_bwd_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
-
     inputs = [
         torch.randn(size, device="cuda", dtype=dtype, requires_grad=True),
         torch.randn(size, device="cuda", dtype=dtype),
@@ -102,6 +104,7 @@ def test_softmax_bwd_nvf_benchmark(
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0, 1])
+@retry_on_oom_or_skip_test
 def test_softmax_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
@@ -109,7 +112,6 @@ def test_softmax_bwd_baseline_benchmark(
     reduction_axis: int,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)

--- a/benchmarks/python/test_softmax_fwd.py
+++ b/benchmarks/python/test_softmax_fwd.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -60,6 +63,7 @@ def softmax_fwd_iobytes(size: tuple, dtype: torch.dtype):
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0, 1])
+@retry_on_oom_or_skip_test
 def test_softmax_fwd_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -68,8 +72,6 @@ def test_softmax_fwd_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
-
     inputs = [torch.randn(size, device="cuda", dtype=dtype)]
 
     with FusionDefinition() as fd:
@@ -87,6 +89,7 @@ def test_softmax_fwd_nvf_benchmark(
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0, 1])
+@retry_on_oom_or_skip_test
 def test_softmax_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
@@ -94,7 +97,6 @@ def test_softmax_fwd_baseline_benchmark(
     reduction_axis: int,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype)

--- a/benchmarks/python/test_transformer.py
+++ b/benchmarks/python/test_transformer.py
@@ -40,7 +40,7 @@ backward nvFusion executed many times.
 
 from nvfuser import FusionDefinition, DataType
 from .core import run_benchmark
-from nvfuser.pytorch_utils import clear_cuda_cache
+from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 import torch
 
 
@@ -303,11 +303,10 @@ def transformer_forward_fusion(fd: FusionDefinition) -> None:
     fd.add_output(T224)
 
 
+@retry_on_oom_or_skip_test
 def test_transformer_forward(
     benchmark, disable_validation: bool, disable_benchmarking: bool
 ):
-    clear_cuda_cache()
-
     with FusionDefinition() as fd:
         transformer_forward_fusion(fd)
 
@@ -990,11 +989,10 @@ def transformer_backward_fusion(fd: FusionDefinition) -> None:
     fd.add_output(T456)  # dx output grad
 
 
+@retry_on_oom_or_skip_test
 def test_transformer_backward(
     benchmark, disable_validation: bool, disable_benchmarking: bool
 ):
-    clear_cuda_cache()
-
     with FusionDefinition() as fd:
         transformer_backward_fusion(fd)
 

--- a/benchmarks/python/test_transpose.py
+++ b/benchmarks/python/test_transpose.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, clear_cuda_cache
+from nvfuser.pytorch_utils import (
+    torch_dtype_to_nvfuser_dtype,
+    retry_on_oom_or_skip_test,
+)
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -47,6 +50,7 @@ def transpose_fwd_fn(inputs: list):  # [input1, input2, dim0, dim1]
 @pytest.mark.parametrize("size", generate_input_sizes(dims=3))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("axes", [(0, 1), (0, 2), (1, 2)])
+@retry_on_oom_or_skip_test
 def test_transpose_nvf_benchmark(
     benchmark,
     size: tuple,
@@ -55,8 +59,6 @@ def test_transpose_nvf_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
-
     input1 = torch.randn(size, device="cuda", dtype=dtype)
     input2 = torch.randn(size, device="cuda", dtype=dtype)
     permute_axes = list(range(len(size)))
@@ -80,6 +82,7 @@ def test_transpose_nvf_benchmark(
 @pytest.mark.parametrize("size", generate_input_sizes(dims=3))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("axes", [(0, 1), (0, 2), (1, 2)])
+@retry_on_oom_or_skip_test
 def test_transpose_baseline_benchmark(
     benchmark,
     size: tuple,
@@ -87,7 +90,6 @@ def test_transpose_baseline_benchmark(
     axes: list,
     compile: bool,
 ):
-    clear_cuda_cache()
     if compile:
         clear_dynamo_cache()
     input1 = torch.randn(size, device="cuda", dtype=dtype)

--- a/nvfuser/pytorch_utils.py
+++ b/nvfuser/pytorch_utils.py
@@ -189,9 +189,11 @@ def retry_on_oom_or_skip_test(func):
 
         try:
             output = func(*args, **kwargs)
-        except torch.OutOfMemoryError:
+        except torch.OutOfMemoryError as e:
             # If we hit an OOM this time, then skip the test
-            pytest.skip("Test failed due to OutOfMemoryError")
+            import pytest
+
+            pytest.skip(f"Test failed due to OutOfMemoryError: {e}")
             return
 
         return output

--- a/tests/python/test_ops.py
+++ b/tests/python/test_ops.py
@@ -16,7 +16,7 @@ from utils import ArgumentType, is_tensor, requiresJAX
 from typing import Callable
 
 from nvfuser import FusionCache, FusionDefinition
-from nvfuser.pytorch_utils import clear_cuda_cache
+from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 
 from utils import (
     check_captured_python_definition,
@@ -200,8 +200,8 @@ def correctness_test_fn(
 
 # Run serde check for each operation and dtype but not for each sample input.
 # NOTE: Disabled serde_check_ops decorator to avoid CI timeout.
+@retry_on_oom_or_skip_test
 def serde_test_fn(op: OpInfo, dtype: torch.dtype):
-    clear_cuda_cache()
     for sample in op.sample_input_generator(op, dtype):
         result = correctness_test_fn(op.reference_type, op, sample)
         if result is not None:
@@ -241,11 +241,11 @@ def definition_op_in_schedule_error_test_fn(opinfo: OpInfo, sample: SampleInput)
 
 # TODO Maybe only test a single dtype
 @create_op_test(tuple(op for op in opinfos if op.sample_input_generator is not None))
+@retry_on_oom_or_skip_test
 def test_definition_op_in_schedule_error(op: OpInfo, dtype: torch.dtype):
     for sample in op.sample_input_generator(op, dtype):
         # clear cache for each sample
         FusionCache.reset()
-        clear_cuda_cache()
         with pytest.raises(
             RuntimeError, match=r"Attempting to add to a completed definition"
         ):
@@ -277,8 +277,8 @@ def _regex_escape_parenthesis(a: str) -> str:
 
 
 @create_op_test(tuple(op for op in opinfos if op.error_input_generator is not None))
+@retry_on_oom_or_skip_test
 def test_errors(op: OpInfo, dtype: torch.dtype):
-    clear_cuda_cache()
     for sample, exception_type, exception_regex in op.error_input_generator(op, dtype):
         with pytest.raises(
             exception_type, match=_regex_escape_parenthesis(exception_regex)


### PR DESCRIPTION
Inspired by https://github.com/NVIDIA/Fuser/pull/3174

This is an alternative to #3238.

Previously we were manually resetting the cuda cache whenever the usage was above 80%. This is not ideal since we could have 79% usage and a test that requires 25% and that would fail. We also might clear the cache unnecessarily sometimes: e.g. we are using 81% but only need a few percent for the remainder of tests.

This PR cleans this up by introducing a new test decorator `@retry_on_oom_or_skip_test`. This decorator must be placed innermost, underneath the other decorators. It will execute the test inside a try block. If the test fails due to `torch.OutOfMemoryError`, we clear the cuda cache and retry the test. If it fails again due to `torch.OutOfMemoryError`, then we skip the test.
