### PR TITLE
[codediff] Handle timestamps in pytest verbose mode

### DIFF
--- a/tools/codediff/run_command.sh
+++ b/tools/codediff/run_command.sh
@@ -124,6 +124,9 @@ removecudafiles() {
 date > "$testdir/date"
 stdoutfile="$testdir/incomplete-stdout"
 stderrfile="$testdir/incomplete-stderr"
+fusioncachedir=/tmp/nvfuser_kernel_db
+fusioncachedirbackup=${fusioncachedir}-backup
+mv "$fusioncachedir" "$fusioncachedirbackup"
 cleanup() {
     numcu=$(find . -maxdepth 1 -name '__tmp_kernel*.cu' | wc -l)
     numptx=$(find . -maxdepth 1 -name '__tmp_kernel*.ptx' | wc -l)
@@ -141,6 +144,9 @@ cleanup() {
     then
         mv "$stderrfile" "$testdir/stderr" 2> /dev/null
     fi
+    # remove the serialized fusion cache and reinstate the original one
+    rm -rf "$fusioncachedir"
+    mv "$fusioncachedirbackup" "$fusioncachedir"
 }
 trap "cleanup" EXIT
 


### PR DESCRIPTION
Our improper handling of pytest log output led to failures in codediff CI jobs in the past day or so. I removed the splitting-based parser code and improved the regex approach. I tested with the artifact from a recent failing job and it worked.

This also fixes a tricky bug where we were observing different numbers of kernels in tests that did not have any code changes that would cause such behavior. The problem was that the FusionCache was serialized to `/tmp/nvfuser_kernel_db` on the first run of the script then it was deserialized on the next run. This means the second run would show fewer new kernels being compiled since there would be some cache hits. Now I make sure to clear `/tmp/nvfuser_kernel_db` inside `run_command.sh` and reinstate it after.