### PR TITLE
expose and test getPersistentBufferStorageParams

### DIFF
--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -18,7 +18,8 @@
 #include <ATen/cuda/CUDAContext.h>
 
 namespace nvfuser {
-namespace {
+
+namespace inner_outer_scheduler_utils {
 
 // The roundup is due to the fact that the shared memory buffer is allocated
 // as: ceilDiv(dim_size / vectorize_factor, threads_per_block).
@@ -46,6 +47,68 @@ int64_t roundUpSharedMemory(
         n_batch * vectorize_factor * threads_per_block * data_type_size);
   }
   return max_smem;
+}
+
+// Size of buffers storing intermediate outer reduction results
+// TODO: check if we can directly start with [buffer_size = 1]
+int64_t partialOuterReductionBufferSize(
+    const std::vector<TensorView*>& reduction_tvs,
+    SchedulerRuntimeInfo& runtime_info) {
+  int64_t partial_reduction_buffer_size = 0;
+  for (auto buffer : reduction_tvs) {
+    if (scheduler_utils::isFastestDimReduction(buffer)) {
+      continue;
+    }
+    int64_t buffer_size = -1;
+    for (auto id : buffer->getLogicalDomain()) {
+      if (id->isReduction() || id->isBroadcast()) {
+        continue;
+      }
+      auto id_size = runtime_info.expressionEvaluator().evaluate(id->extent());
+      NVF_ERROR(id_size.hasValue(), "Could not infer persistent buffer size.");
+      if (buffer_size == -1) {
+        buffer_size = id_size.as<int64_t>();
+      } else {
+        buffer_size *= id_size.as<int64_t>();
+      }
+    }
+    buffer_size = (buffer_size == -1) ? 0
+                                      : buffer_size *
+            (int64_t)dataTypeSize(buffer->getDataType().value(),
+                                  runtime_info.getIndexType());
+    partial_reduction_buffer_size += buffer_size;
+  }
+  return partial_reduction_buffer_size;
+}
+
+// Prioritize keeping buffers used by outer broadcast tensors to shared memory
+// because:
+// (1) They are reused in every iteration of the outer loop, has lower IO.
+// (2) Load occurs before the outer loop. Temporary register usage won't
+//     increase register pressure since the loop is the high-pressure region.
+std::vector<TensorView*> sortProjectableBufferInputs(
+    const std::vector<TensorView*>& projectable_buffer_inputs,
+    const std::vector<TensorView*>& outer_broadcast_tvs) {
+  // mark whether the buffer is used by outer broadcast tensors
+  std::unordered_map<TensorView*, bool> is_used_by_outer_bcast;
+  for (auto buffer : projectable_buffer_inputs) {
+    is_used_by_outer_bcast[buffer] = std::any_of(
+        outer_broadcast_tvs.begin(),
+        outer_broadcast_tvs.end(),
+        [&buffer](TensorView* tv) {
+          return DependencyCheck::isDependencyOf(buffer, tv);
+        });
+  }
+
+  // sort based on [is_used_by_outer_bcast]
+  std::vector<TensorView*> sorted_buffer = projectable_buffer_inputs;
+  std::sort(
+      sorted_buffer.begin(),
+      sorted_buffer.end(),
+      [&](TensorView* a, TensorView* b) {
+        return !is_used_by_outer_bcast[a] && is_used_by_outer_bcast[b];
+      });
+  return sorted_buffer;
 }
 
 // Return the broadcast tvs that are broadcast to the iteration dimensions of
@@ -85,100 +148,6 @@ std::vector<TensorView*> getOuterBroadcastTvs(
     }
   }
   return outer_broadcast_tvs;
-}
-
-// Size of buffers storing intermediate outer reduction results
-// TODO: check if we can directly start with [buffer_size = 1]
-int64_t partialOuterReductionBufferSize(
-    const std::vector<TensorView*>& reduction_tvs,
-    SchedulerRuntimeInfo& runtime_info) {
-  int64_t partial_reduction_buffer_size = 0;
-  for (auto buffer : reduction_tvs) {
-    if (scheduler_utils::isFastestDimReduction(buffer)) {
-      continue;
-    }
-    int64_t buffer_size = -1;
-    for (auto id : buffer->getLogicalDomain()) {
-      if (id->isReduction() || id->isBroadcast()) {
-        continue;
-      }
-      auto id_size = runtime_info.expressionEvaluator().evaluate(id->extent());
-      NVF_ERROR(id_size.hasValue(), "Could not infer persistent buffer size.");
-      if (buffer_size == -1) {
-        buffer_size = id_size.as<int64_t>();
-      } else {
-        buffer_size *= id_size.as<int64_t>();
-      }
-    }
-    buffer_size = (buffer_size == -1) ? 0
-                                      : buffer_size *
-            (int64_t)dataTypeSize(buffer->getDataType().value(),
-                                  runtime_info.getIndexType());
-    partial_reduction_buffer_size += buffer_size;
-  }
-  return partial_reduction_buffer_size;
-}
-
-// Decide where to store persistent buffers.
-// By default, they reside in registers.
-// If register space runs low but there's ample shared memory,
-// move one or more buffers to shared memory until the register space is
-// sufficient.
-struct PersistentBufferStorageParams {
-  // representing buffers that are stored in shared memory, other buffers are
-  // stored in registers.
-  std::vector<TensorView*> smem_persistent_buffers;
-
-  // Total number of bytes occupied by all persistent buffers stored in shared
-  // memory.
-  int64_t smem_buffer_size = -1;
-
-  // Total number of bytes occupied by all persistent buffers stored in
-  // registers.
-  int64_t regs_buffer_size = -1;
-
-  // Additional shared memory usage per block that is not associated with
-  // persistent buffers. This includes memory for driver overhead and workspace
-  // for reductions.
-  int64_t smem_overhead = -1;
-
-  // Flag indicating whether there are sufficient registers and shared memory
-  // available to accommodate all persistent buffers as required for efficient
-  // execution.
-  bool has_enough_regs_and_smem = false;
-
-  // Flag indicating whether the persistent buffers are recomputed using inputs.
-  bool project_to_input = false;
-};
-
-// Prioritize keeping buffers used by outer broadcast tensors to shared memory
-// because:
-// (1) They are reused in every iteration of the outer loop, has lower IO.
-// (2) Load occurs before the outer loop. Temporary register usage won't
-//     increase register pressure since the loop is the high-pressure region.
-std::vector<TensorView*> sortProjectableBufferInputs(
-    const std::vector<TensorView*>& projectable_buffer_inputs,
-    const std::vector<TensorView*>& outer_broadcast_tvs) {
-  // mark whether the buffer is used by outer broadcast tensors
-  std::unordered_map<TensorView*, bool> is_used_by_outer_bcast;
-  for (auto buffer : projectable_buffer_inputs) {
-    is_used_by_outer_bcast[buffer] = std::any_of(
-        outer_broadcast_tvs.begin(),
-        outer_broadcast_tvs.end(),
-        [&buffer](TensorView* tv) {
-          return DependencyCheck::isDependencyOf(buffer, tv);
-        });
-  }
-
-  // sort based on [is_used_by_outer_bcast]
-  std::vector<TensorView*> sorted_buffer = projectable_buffer_inputs;
-  std::sort(
-      sorted_buffer.begin(),
-      sorted_buffer.end(),
-      [&](TensorView* a, TensorView* b) {
-        return !is_used_by_outer_bcast[a] && is_used_by_outer_bcast[b];
-      });
-  return sorted_buffer;
 }
 
 PersistentBufferStorageParams getPersistentBufferStorageParams(
@@ -332,15 +301,20 @@ PersistentBufferStorageParams getPersistentBufferStorageParams(
     buffer_params.has_enough_regs_and_smem = true;
     auto n_smem_buffer = n_buffers - n_regs_buffer;
     buffer_params.smem_persistent_buffers.reserve(n_smem_buffer);
-    for (int i = 0; i < n_smem_buffer; i++) {
-      buffer_params.smem_persistent_buffers.emplace_back(
-          buffers[n_buffers - 1 - i]);
+    // copy buffers in range [n_regs_buffer, n_buffers) to shared memory, keep
+    // the original order to avoid confusions in unit test.
+    for (int i = n_regs_buffer; i < n_buffers; i++) {
+      buffer_params.smem_persistent_buffers.emplace_back(buffers[i]);
     }
   } else {
     buffer_params.has_enough_regs_and_smem = false;
   }
   return buffer_params;
 }
+
+} // namespace inner_outer_scheduler_utils
+
+namespace {
 
 // Calculate the persistent buffer batches and threads per block.
 // Start from a large value of inner_dim_numel / (inner_vect * warpSize/4),
@@ -770,8 +744,9 @@ std::unique_ptr<ReductionParams> getInnerOuterPersistentHeuristics(
   NVF_ERROR(
       !persistent_buffer_info.persistent_buffers.empty(),
       "Persistent scheduler requires persistent buffers.");
-  auto buffer_params = getPersistentBufferStorageParams(
-      fusion, runtime_info, data_cache, reduction_tvs, vectorize_factor);
+  auto buffer_params =
+      inner_outer_scheduler_utils::getPersistentBufferStorageParams(
+          fusion, runtime_info, data_cache, reduction_tvs, vectorize_factor);
 
   std::unique_ptr<ReductionParams> rparams = innerOuterPersistentHeuristic(
       properties.total_iteration_numel,
@@ -1266,8 +1241,9 @@ bool InnerOuterPersistentKernelScheduler::canScheduleRunTime(
       (int)(reduced_tv->nDims() - properties.inner_most_dimension_ndims));
 
   // check if there is enough register and shared memory for persistence
-  const auto buffer_params = getPersistentBufferStorageParams(
-      fusion, runtime_info, data_cache, reduction_tvs, vectorize_factor);
+  const auto buffer_params =
+      inner_outer_scheduler_utils::getPersistentBufferStorageParams(
+          fusion, runtime_info, data_cache, reduction_tvs, vectorize_factor);
 
   const int64_t device_multiprocessor_count =
       (int64_t)at::cuda::getCurrentDeviceProperties()->multiProcessorCount;

--- a/tests/cpp/test_combined_inner_outer_reduction.cpp
+++ b/tests/cpp/test_combined_inner_outer_reduction.cpp
@@ -926,4 +926,55 @@ TEST_F(CombinedSchedulerTest, InnerOuterNoOuterBroadcastTv) {
       "",
       persistent_params->lparams);
 }
+
+TEST_F(CombinedSchedulerTest, InnerOuterSharedMemoryRegisterPersistent) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  const auto dev_prop = at::cuda::getCurrentDeviceProperties();
+  int64_t available_smem = (int64_t)dev_prop->sharedMemPerMultiprocessor;
+  // set to 1/3 of the available shared memory, so smem can't store all of
+  // the 3 buffers after considering the overhead.
+  // tv0 is a outer bcast tv, it stays in shared memory, so tv1 will be moved
+  // to register. tv2 and tv0 stays in shared memory.
+  int64_t dim1 = ceilDiv(available_smem / sizeof(float), 3);
+  int64_t dim0 = 1024;
+  auto tv0 = makeContigTensor(1);
+  auto tv1 = makeContigTensor(2);
+  auto tv2 = makeContigTensor(2);
+  // These 3 inputs are persistent buffers
+  // Shared memory can't store all of them, so tv0 is moved to registers
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+  fusion.addInput(tv2);
+  auto tv3 = broadcast(tv0, {true, false});
+  auto tv4 = add(tv1, tv2);
+  auto tv5 = add(tv3, tv4);
+  // Here tv5 is a inner normalization buffer but projected back to inputs
+  auto tv6 = sum(tv5, {1});
+  auto tv7 = broadcast(tv6, {false, true});
+  auto tv8 = add(tv7, tv5);
+  // Needs a outer reduction buffer in register
+  auto tv9 = sum(tv0, {0});
+  fusion.addOutput(tv8);
+  fusion.addOutput(tv9);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({dim1}, options);
+  at::Tensor t1 = at::randn({dim0, dim1}, options);
+  at::Tensor t2 = at::randn({dim0, dim1}, options);
+  std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
+  SchedulerRuntimeInfo runtime_info(&fusion, aten_inputs);
+
+  const int64_t vectorize_factor = 4;
+  HeuristicDataCache* data_cache = nullptr;
+  const auto& reduction_tvs = scheduler_utils::getReductionTvs(&fusion);
+  auto buffer_params =
+      inner_outer_scheduler_utils::getPersistentBufferStorageParams(
+          &fusion, runtime_info, data_cache, reduction_tvs, vectorize_factor);
+  EXPECT_TRUE(buffer_params.project_to_input);
+  EXPECT_TRUE(buffer_params.has_enough_regs_and_smem);
+  // order matters, tv0 should be the last one since it is an outer bcast tv
+  EXPECT_THAT(
+      buffer_params.smem_persistent_buffers, testing::ElementsAre(tv2, tv0));
+}
 } // namespace nvfuser


### PR DESCRIPTION
**Purpose:** test getPersistentBufferStorageParams
**Code chanage:**
(1) Add namespace `inner_outer_scheduler_utils` and move `getPersistentBufferStorageParams` to it.
(2) Add test which has 3 input buffers and shared memory can only store 2 of them.

**Special:**
This PR is merged to head of https://github.com/NVIDIA/Fuser/pull/3217