### PR TITLE
Export DEBUG_SERDE=true in compare_codegen.sh

### DIFF
--- a/tools/codediff/compare_codegen.sh
+++ b/tools/codediff/compare_codegen.sh
@@ -189,6 +189,7 @@ collect_kernels() {
     # Make tests reproducible
     export NVFUSER_TEST_RANDOM_SEED=0
     export NVFUSER_DISABLE=parallel_compile
+    export DEBUG_SERDE=true
     # run tests and benchmarks with cuda_to_file and dump output to files
 
     mkdir -p "$outdir/$commit"


### PR DESCRIPTION
I am trying to fix some false positives in the codediff script