### PR TITLE
Change shape of `HSH_NT_128BSwizzle`

### DIFF
--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -3607,7 +3607,7 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  constexpr int64_t M = 1024 * 16, N = 1024 * 16, K = 1024;
+  constexpr int64_t M = 2048, N = 2048, K = 8192;
   constexpr auto macro = MmaMacro::Hopper_64_256_16;
   constexpr auto layout = MmaLayout::NT; // [K, M] x [K, N] -> [M, N]
   constexpr auto swizzle = MmaInputSmemSwizzle::B128;
@@ -3615,7 +3615,7 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
 
   constexpr int64_t stages = 4;
   constexpr int64_t prefetch = 3;
-  const int64_t cta_m = 1 * getM(macro);
+  const int64_t cta_m = 2 * getM(macro);
   const int64_t cta_n = 1 * getN(macro);
 
   auto tv0 = makeContigConcreteTensor({-1, -1, 1}, dtype);


### PR DESCRIPTION
This shape makes more sense: https://github.com/NVIDIA/Fuser/issues/3137#issuecomment-2438559998, https://github.com/NVIDIA/Fuser/issues/3279

Perf:
```
 Time (%)  Total Time (ns)  Instances  Avg (ns)  Med (ns)  Min (ns)  Max (ns)  StdDev (ns)                                                  Name

 --------  ---------------  ---------  --------  --------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     43.2           205150          1  205150.0  205150.0    205150    205150          0.0  <unnamed>::nvfuser_none_f0_c0_r0_g0(<unnamed>::Tensor<<unnamed>::__half, (int)3, (int)3>, <unnamed>…
     18.5            87550          1   87550.0   87550.0     87550     87550          0.0  nvjet_hsh_256x128_64x4_1x2_h_bz_coopA_NTT
```

nvFuser/cuBLAS = `42.7%`