### PR TITLE
fix padded bdimx to use warp reduction in inner reduction scheduler

### DIFF
--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -388,9 +388,6 @@ std::unique_ptr<ReductionParams> innerReductionHeuristic(
   bool pad_bdimx = bdimx > 16 &&
       bdimx * bdimy <
           (int64_t)at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
-  // If barely just covering reduction dim, don't pad to the next warp
-  pad_bdimx = pad_bdimx &&
-      bdimx * inner_reduction_unroll_factor != inner_most_dimension_numel;
   rparams->pad_inner_reduction_to_warp = pad_bdimx;
 
   if (rparams->pad_inner_reduction_to_warp) {


### PR DESCRIPTION
Simple fix to padded bdimx in inner reduction scheduler.
**Performance changes:**
**(1) H100**
5 lines corresponds to batch size of 16, 512, 2048, 8192, 16384
![image](https://github.com/user-attachments/assets/225e2ed1-0c99-402d-acce-894f728e083b)
**(2) A100**
![image](https://github.com/user-attachments/assets/0658a933-dc5e-4cf3-af48-4b95289b0977)