### PR TITLE
Compile forward function in baseline backward benchmarks

### DIFF
--- a/benchmarks/python/normalization.py
+++ b/benchmarks/python/normalization.py
@@ -489,12 +489,15 @@ def norm_bwd_baseline_benchmark(
         grads = grads.to(memory_format=torch.channels_last)
 
     norm_fwd_fn = batchnorm_fwd_fn if norm == "batch_norm" else instancenorm_fwd_fn
+    
+    # Compile the fwd fn for torchcompile
+    norm_fwd_fn = torch.compile(norm_fwd_fn) if compile else norm_fwd_fn
     output = norm_fwd_fn([inputs, weight, bias, running_mean, running_var])
 
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
-        torch.compile(unary_bwd_torch) if compile else unary_bwd_torch,
+        unary_bwd_torch,
         [output, grads],
         iobytes=norm_bwd_iobytes(size, dtype, norm),
     )

--- a/benchmarks/python/normalization.py
+++ b/benchmarks/python/normalization.py
@@ -489,7 +489,7 @@ def norm_bwd_baseline_benchmark(
         grads = grads.to(memory_format=torch.channels_last)
 
     norm_fwd_fn = batchnorm_fwd_fn if norm == "batch_norm" else instancenorm_fwd_fn
-    
+
     # Compile the fwd fn for torchcompile
     norm_fwd_fn = torch.compile(norm_fwd_fn) if compile else norm_fwd_fn
     output = norm_fwd_fn([inputs, weight, bias, running_mean, running_var])

--- a/benchmarks/python/test_dropout_layernorm_bwd.py
+++ b/benchmarks/python/test_dropout_layernorm_bwd.py
@@ -207,7 +207,7 @@ def test_dropout_layernorm_bwd_baseline_benchmark(
     grads = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
     bias = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
-    
+
     def dropout_layernorm_fwd():
         return torch.nn.functional.layer_norm(
             input2 + torch.nn.functional.dropout(input1, p=dropout_p),
@@ -215,11 +215,11 @@ def test_dropout_layernorm_bwd_baseline_benchmark(
             weight=weights,
             bias=bias,
         )
-    
+
     # Compile the fwd fn for torchcompile
     fwd_fn = torch.compile(dropout_layernorm_fwd) if compile else dropout_layernorm_fwd
     output = fwd_fn()
-    
+
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_dropout_layernorm_bwd.py
+++ b/benchmarks/python/test_dropout_layernorm_bwd.py
@@ -207,17 +207,23 @@ def test_dropout_layernorm_bwd_baseline_benchmark(
     grads = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
     bias = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
-
-    output = torch.nn.functional.layer_norm(
-        input2 + torch.nn.functional.dropout(input1, p=dropout_p),
-        normalized_shape=input1.shape[1:],
-        weight=weights,
-        bias=bias,
-    )
+    
+    def dropout_layernorm_fwd():
+        return torch.nn.functional.layer_norm(
+            input2 + torch.nn.functional.dropout(input1, p=dropout_p),
+            normalized_shape=input1.shape[1:],
+            weight=weights,
+            bias=bias,
+        )
+    
+    # Compile the fwd fn for torchcompile
+    fwd_fn = torch.compile(dropout_layernorm_fwd) if compile else dropout_layernorm_fwd
+    output = fwd_fn()
+    
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
-        torch.compile(unary_bwd_torch) if compile else unary_bwd_torch,
+        unary_bwd_torch,
         [output, grads],
         iobytes=dropout_layernorm_bwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_dropout_rmsnorm_bwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_bwd.py
@@ -190,8 +190,8 @@ def test_dropout_rmsnorm_bwd_baseline_benchmark(
         x = input2 + torch.nn.functional.dropout(input1, p=dropout_p)
         output = weights * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-5)
         return output
-    
-    fwd_fn = torch.compile(dropout_rmsnorm_fwd) else dropout_rmsnorm_fwd
+
+    fwd_fn = torch.compile(dropout_rmsnorm_fwd) if compile else dropout_rmsnorm_fwd
     output = fwd_fn()
 
     run_benchmark(

--- a/benchmarks/python/test_dropout_rmsnorm_bwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_bwd.py
@@ -186,12 +186,17 @@ def test_dropout_rmsnorm_bwd_baseline_benchmark(
     grads = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype)
 
-    x = input2 + torch.nn.functional.dropout(input1, p=dropout_p)
-    output = weights * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-5)
+    def dropout_rmsnorm_fwd():
+        x = input2 + torch.nn.functional.dropout(input1, p=dropout_p)
+        output = weights * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-5)
+        return output
+    
+    fwd_fn = torch.compile(dropout_rmsnorm_fwd) else dropout_rmsnorm_fwd
+    output = fwd_fn()
 
     run_benchmark(
         benchmark,
-        torch.compile(unary_bwd_torch) if compile else unary_bwd_torch,
+        unary_bwd_torch,
         [output, grads],
         iobytes=dropout_rmsnorm_bwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_gelu_bwd.py
+++ b/benchmarks/python/test_gelu_bwd.py
@@ -102,12 +102,13 @@ def test_gelu_bwd_baseline_benchmark(
     inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     grads = torch.randn(size, device="cuda", dtype=dtype)
-    
+
     def gelu_fwd():
         return torch.nn.functional.gelu(inputs + bias, approximate="tanh")
+
     fwd_fn = torch.compile(gelu_fwd) if compile else gelu_fwd
     eager_output = fwd_fn()
-    
+
     run_benchmark(
         benchmark,
         unary_bwd_torch,

--- a/benchmarks/python/test_huggingface_attn_bwd.py
+++ b/benchmarks/python/test_huggingface_attn_bwd.py
@@ -126,7 +126,7 @@ def test_huggingface_attn_bwd_baseline_benchmark(
     attention_mask = torch.zeros(
         batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype
     )
-    
+
     def huggingface_attn_fwd():
         attn = (inputs + attention_mask).view(batch_size * nh, seq_len, seq_len)
         attn = torch.nn.functional.softmax(attn, dim=-1)

--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -163,17 +163,20 @@ def test_layernorm_bwd_baseline_benchmark(
     weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
     bias = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
 
-    output = torch.nn.functional.layer_norm(
-        inputs,
-        inputs.shape[1:],
-        weight=weights,
-        bias=bias,
-    )
-
+    def layernorm_fwd():
+        return torch.nn.functional.layer_norm(
+            inputs,
+            inputs.shape[1:],
+            weight=weights,
+            bias=bias,
+        )
+    fwd_fn = torch.compile(layernorm_fwd) if compile else layernorm_fwd
+    output = fwd_fn()
+    
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
-        torch.compile(unary_bwd_torch) if compile else unary_bwd_torch,
+        unary_bwd_torch,
         [output, grads],
         iobytes=layernorm_bwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -170,9 +170,10 @@ def test_layernorm_bwd_baseline_benchmark(
             weight=weights,
             bias=bias,
         )
+
     fwd_fn = torch.compile(layernorm_fwd) if compile else layernorm_fwd
     output = fwd_fn()
-    
+
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_rmsnorm_bwd.py
+++ b/benchmarks/python/test_rmsnorm_bwd.py
@@ -132,7 +132,7 @@ def test_rmsnorm_bwd_baseline_benchmark(
         rms_eps = torch.sqrt(squared_mean + 1e-5)
         output = weights * (inputs / rms_eps)
         return output
-    
+
     # Compile the fwd fn for torchcompile
     fwd_fn = torch.compile(rmsnorm_fwd) if compile else rmsnorm_fwd
     output = fwd_fn()

--- a/benchmarks/python/test_scale_bias_relu_bwd.py
+++ b/benchmarks/python/test_scale_bias_relu_bwd.py
@@ -94,13 +94,14 @@ def test_sbr_bwd_baseline_benchmark(
     grads = torch.randn(*size, device="cuda", dtype=dtype)
     scale = torch.ones(size[-1], device="cuda", dtype=dtype)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
-    
+
     def sbr_fwd():
         return torch.nn.functional.relu(inputs * scale + bias)
+
     # Compile the fwd fn for torchcompile
     fwd_fn = torch.compile(sbr_fwd) if compile else sbr_fwd
     eager_output = sbr_fwd()
-    
+
     run_benchmark(
         benchmark,
         unary_bwd_torch,

--- a/benchmarks/python/test_silu_mul_bwd.py
+++ b/benchmarks/python/test_silu_mul_bwd.py
@@ -93,13 +93,14 @@ def test_silu_mul_bwd_baseline_benchmark(
     x = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     y = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
-    
+
     def silu_mul_fwd():
         return torch.nn.functional.silu(x) * y
+
     # Compile the fwd fn for torchcompile
     fwd_fn = torch.compile(silu_mul_fwd) if compile else silu_mul_fwd
     eager_output = fwd_fn()
-    
+
     run_benchmark(
         benchmark,
         unary_bwd_torch,

--- a/benchmarks/python/test_silu_mul_bwd.py
+++ b/benchmarks/python/test_silu_mul_bwd.py
@@ -93,11 +93,16 @@ def test_silu_mul_bwd_baseline_benchmark(
     x = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     y = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
-    eager_output = torch.nn.functional.silu(x) * y
-
+    
+    def silu_mul_fwd():
+        return torch.nn.functional.silu(x) * y
+    # Compile the fwd fn for torchcompile
+    fwd_fn = torch.compile(silu_mul_fwd) if compile else silu_mul_fwd
+    eager_output = fwd_fn()
+    
     run_benchmark(
         benchmark,
-        torch.compile(unary_bwd_torch) if compile else unary_bwd_torch,
+        unary_bwd_torch,
         [eager_output, grads],
         iobytes=silu_mul_bwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_softmax_bwd.py
+++ b/benchmarks/python/test_softmax_bwd.py
@@ -4,7 +4,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES
 import numpy as np
@@ -58,11 +58,6 @@ def softmax_bwd_fusion(
     fd.add_output(T19)
 
 
-def unary_bwd_torch(inputs: list):  # [in_tensor, output, grads]
-    inputs[1].backward(inputs[2], retain_graph=True)
-    return inputs[0].grad
-
-
 def softmax_bwd_iobytes(size: tuple, dtype: torch.dtype):
     # Total IO bytes = output + grad_out + grad_input
     return int(np.prod(size) * dtype.itemsize * 3)
@@ -111,10 +106,15 @@ def test_softmax_bwd_baseline_benchmark(
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(size, device="cuda", dtype=dtype)
-    output = torch.nn.functional.softmax(input, dim=reduction_axis)
+    
+    def softmax_fwd():
+        return torch.nn.functional.softmax(input, dim=reduction_axis)
+    fwd_fn = torch.compile(softmax_fwd) if compile else softmax_fwd
+    output = fwd_fn()
+    
     run_benchmark(
         benchmark,
-        torch.compile(unary_bwd_torch) if compile else unary_bwd_torch,
-        [input, output, grads],
+        unary_bwd_torch,
+        [output, grads],
         iobytes=softmax_bwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_softmax_bwd.py
+++ b/benchmarks/python/test_softmax_bwd.py
@@ -106,12 +106,13 @@ def test_softmax_bwd_baseline_benchmark(
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(size, device="cuda", dtype=dtype)
-    
+
     def softmax_fwd():
         return torch.nn.functional.softmax(input, dim=reduction_axis)
+
     fwd_fn = torch.compile(softmax_fwd) if compile else softmax_fwd
     output = fwd_fn()
-    
+
     run_benchmark(
         benchmark,
         unary_bwd_torch,


### PR DESCRIPTION
Currently, the backward benchmark for `torch.compile` are compiling the `output.backward(grads)` function.
This PR changes the benchmarks to compile the corresponding forward function. 

The benchmarking results are at: http://nv/emR
Earlier, I was observing similar performance for eager and torchcompile for these backward benchmarks.
The files `*_bwd.py` are changed in this PR. We observe improved performance with torchcompile as compared to eager now. Note, that, the results from weekly will have more data points than the CI pipeline.

**Question**: `test_gelu_bwd_reduction.py` reduces the gradient of the input. I am not sure what would be the right function to compile here :/

Thanks to @xwang233 for help with running the CI pipeline!