### PR TITLE
Change where we print python repros to allow us to print repros prior to segfaults

### DIFF
--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -178,6 +178,8 @@ class FusionDefinition(_C._FusionDefinition):
 
         results = None
         try:
+            if print_repro:
+                print(self.repro_script_for(inputs))
             results = self._execute(
                 inputs,
                 device=device,
@@ -185,8 +187,6 @@ class FusionDefinition(_C._FusionDefinition):
                 capture_debug_output=capture_debug_output,
                 profile=profile,
             )
-            if print_repro:
-                print(self.repro_script_for(inputs))
             return results
         except Exception as err:
             logger.exception(self._repro_error_str("executing", inputs))


### PR DESCRIPTION
This is just a simple code reordering to put the point at which I print a repro from `fd.execute()` after the pybind function `_execute()` to before the function to allow us to print repros prior to segfaults.