### PR TITLE
Remove deprecated `clear_cuda_cache`

### DIFF
--- a/benchmarks/python/test_adaptive_layernorm_host.py
+++ b/benchmarks/python/test_adaptive_layernorm_host.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import clear_cuda_cache
 from .core import run_benchmark
 import torch
 
@@ -73,8 +72,6 @@ def test_adaptive_layernorm_fwd_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    clear_cuda_cache()
-
     B = 1
     T = 30 * 1024
     D = 1024


### PR DESCRIPTION
This benchmark was added recently and did not have the changes added by PR #3252.
The benchmark will fail on the CI due to missing import function