### PR TITLE
Host benchmarking for a fusion with multiple segments

### DIFF
--- a/benchmarks/python/test_many_segments_host.py
+++ b/benchmarks/python/test_many_segments_host.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+import pytest
+from nvfuser import FusionDefinition, DataType
+from .core import run_benchmark
+import torch
+
+
+def many_matmul_fusion(fd: FusionDefinition) -> None:
+    x = fd.define_tensor(
+        shape=[-1, -1], contiguity=[True, True], dtype=DataType.Float, is_cpu=False
+    )
+    y = fd.define_tensor(
+        shape=[-1, -1], contiguity=[True, True], dtype=DataType.Float, is_cpu=False
+    )
+    a = fd.ops.add(x, y)
+    for _ in range(5):
+        a_transpose = fd.ops.permute(a, [1, 0])
+        matmul_out = fd.ops.matmul(a_transpose, y)
+        add_out = fd.ops.add(a_transpose, y)
+        a = fd.ops.add(matmul_out, add_out)
+    fd.add_output(a)
+
+
+@pytest.mark.parametrize("host_bench_mode", ["compile", "steady", "dynamic"])
+def test_many_segment_benchmark(
+    benchmark,
+    host_bench_mode: str,
+    disable_validation: bool,
+    disable_benchmarking: bool,
+):
+    inputs = [torch.randn(16, 16, device="cuda", dtype=torch.float) for _ in range(2)]
+
+    # Generate multiple inputs to measure dynamic shape overhead.
+    if host_bench_mode == "dynamic":
+        input_sizes = [4, 8, 16, 32, 64, 128]
+        # Generate matrices of size x size dimensions
+        inputs = [
+            [
+                torch.randn(size, size, device="cuda", dtype=torch.float)
+                for _ in range(2)
+            ]
+            for size in input_sizes
+        ]
+
+    with FusionDefinition() as fd:
+        many_matmul_fusion(fd)
+
+    def validate(input):
+        x, y = input
+        eager_output = x + y
+        for _ in range(5):
+            eager_transpose = eager_output.t()
+            matmul_out = torch.matmul(eager_transpose, y)
+            add_out = eager_transpose + y
+            eager_output = matmul_out + add_out
+        fd.validate(input, [eager_output])
+
+    if not disable_validation:
+        if host_bench_mode == "dynamic":
+            # Run validate for all input sizes.
+            for input in inputs:
+                validate(input)
+        else:
+            validate(inputs)
+
+    if not disable_benchmarking:
+        run_benchmark(
+            benchmark,
+            None,
+            inputs,
+            device=f"host:{host_bench_mode}",
+            fusion_fn=many_matmul_fusion,
+        )


### PR DESCRIPTION
This benchmark uses matmul + pointwise op to create a fusion with 11 segments instead of using `segment_set` to force segmentation.


![Screenshot 2024-10-29 at 4 41 47 PM](https://github.com/user-attachments/assets/2e65f8b9-489b-431b-8694-ab265f90ce32)

For `host_benchmark_mode='compile'`, the profile is shown below. The `Finding valid segment solutions` pass takes 52 ms

![Screenshot 2024-10-29 at 4 41 26 PM](https://github.com/user-attachments/assets/60ee5d81-e289-4486-a6bf-b4ab9fdd6a37)

