### PR TITLE
Use a single elect sync ite for all trasactions

### DIFF
--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -534,10 +534,6 @@ class CloneTmaCircularBufferLoopAndInsertSync
           return out_tv == circular_buffer_tv;
         });
 
-    if (!is_circular_buffer_load_expr) {
-      elect_sync_if_then_else_ = nullptr;
-    }
-
     insertMBarrierWaitBeforeFirstRead(expr);
 
     // Handle Short-Circuit conditions

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -707,9 +707,9 @@ class CloneTmaCircularBufferLoopAndInsertSync
   // If there is already an if-then-else with electSync() predicate, use it.
   // Otherwise, create a new one.
   kir::IfThenElse* getElectSyncIfThenElse() {
-    if (loop_containing_elec_sync_ != for_loop_stack_.back()) {
-      elect_sync_if_then_else_ = nullptr;
-    }
+    // if (loop_containing_elec_sync_ != for_loop_stack_.back()) {
+    //   elect_sync_if_then_else_ = nullptr;
+    // }
     if (elect_sync_if_then_else_ == nullptr) {
       elect_sync_if_then_else_ = IrBuilder::create<kir::IfThenElse>(
           IrBuilder::create<kir::Predicate>(PredicateType::ElectSync));

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -534,6 +534,10 @@ class CloneTmaCircularBufferLoopAndInsertSync
           return out_tv == circular_buffer_tv;
         });
 
+    if (!is_circular_buffer_load_expr) {
+      elect_sync_if_then_else_ = nullptr;
+    }
+
     insertMBarrierWaitBeforeFirstRead(expr);
 
     // Handle Short-Circuit conditions

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -707,14 +707,10 @@ class CloneTmaCircularBufferLoopAndInsertSync
   // If there is already an if-then-else with electSync() predicate, use it.
   // Otherwise, create a new one.
   kir::IfThenElse* getElectSyncIfThenElse() {
-    // if (loop_containing_elec_sync_ != for_loop_stack_.back()) {
-    //   elect_sync_if_then_else_ = nullptr;
-    // }
     if (elect_sync_if_then_else_ == nullptr) {
       elect_sync_if_then_else_ = IrBuilder::create<kir::IfThenElse>(
           IrBuilder::create<kir::Predicate>(PredicateType::ElectSync));
-      loop_containing_elec_sync_ = for_loop_stack_.back();
-      loop_containing_elec_sync_->body().push_back(elect_sync_if_then_else_);
+      for_loop_stack_.back()->body().push_back(elect_sync_if_then_else_);
     }
     return elect_sync_if_then_else_;
   }
@@ -861,7 +857,6 @@ class CloneTmaCircularBufferLoopAndInsertSync
   // ElectSync if-then-else for the cloned loop. We put all the circular buffer
   // load TMA operations under this if-then-else.
   kir::IfThenElse* elect_sync_if_then_else_ = nullptr;
-  ForLoop* loop_containing_elec_sync_ = nullptr;
 
   // The circular buffered TVs for the loop being cloned
   std::unordered_set<const TensorView*> circular_buffer_load_tvs_;

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -707,10 +707,14 @@ class CloneTmaCircularBufferLoopAndInsertSync
   // If there is already an if-then-else with electSync() predicate, use it.
   // Otherwise, create a new one.
   kir::IfThenElse* getElectSyncIfThenElse() {
-    if (true || elect_sync_if_then_else_ == nullptr) {
+    if (loop_containing_elec_sync_ != for_loop_stack_.back()) {
+      elect_sync_if_then_else_ = nullptr;
+    }
+    if (elect_sync_if_then_else_ == nullptr) {
       elect_sync_if_then_else_ = IrBuilder::create<kir::IfThenElse>(
           IrBuilder::create<kir::Predicate>(PredicateType::ElectSync));
-      for_loop_stack_.back()->body().push_back(elect_sync_if_then_else_);
+      loop_containing_elec_sync_ = for_loop_stack_.back();
+      loop_containing_elec_sync_->body().push_back(elect_sync_if_then_else_);
     }
     return elect_sync_if_then_else_;
   }
@@ -857,6 +861,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
   // ElectSync if-then-else for the cloned loop. We put all the circular buffer
   // load TMA operations under this if-then-else.
   kir::IfThenElse* elect_sync_if_then_else_ = nullptr;
+  ForLoop* loop_containing_elec_sync_ = nullptr;
 
   // The circular buffered TVs for the loop being cloned
   std::unordered_set<const TensorView*> circular_buffer_load_tvs_;

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -707,7 +707,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
   // If there is already an if-then-else with electSync() predicate, use it.
   // Otherwise, create a new one.
   kir::IfThenElse* getElectSyncIfThenElse() {
-    if (elect_sync_if_then_else_ == nullptr) {
+    if (true || elect_sync_if_then_else_ == nullptr) {
       elect_sync_if_then_else_ = IrBuilder::create<kir::IfThenElse>(
           IrBuilder::create<kir::Predicate>(PredicateType::ElectSync));
       for_loop_stack_.back()->body().push_back(elect_sync_if_then_else_);

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -2238,6 +2238,7 @@ kir::TensorIndex* Index::getConsumerIndex(
     DataType as_type) {
   Val* index = nullptr;
   if (!ir_utils::hasRootToLoopLinearTransformations(consumer) ||
+      ir_utils::isCpAsyncBulkLoad(consumer->definition()) ||
       (isIdModelOptionEnabled(IdModelEnableOption::ConsumerIndex) &&
        GpuLower::current()->isTensorIndexerEnabled())) {
     index = GpuLower::current()->tensorIndexer().getLinearIndex(


### PR DESCRIPTION
Before:

```C++
if (elect-sync) {
  arrive-expect-tx1;
  tma1;
}
if (elect-sync) {
  arrive-expect-tx2;
  tma2;
}
```
After:
```
if (elect-sync) {
  arrive-expect-tx1;
  tma1;
  arrive-expect-tx2;
  tma2;
}
```

Perf:
```markdown
 Time (%)  Total Time (ns)  Instances  Avg (ns)  Med (ns)  Min (ns)  Max (ns)  StdDev (ns)                                                  Name

 --------  ---------------  ---------  --------  --------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
     36.0           151775          1  151775.0  151775.0    151775    151775          0.0  <unnamed>::nvfuser_none_f0_c0_r0_g0(<unnamed>::Tensor<<unnamed>::__half, (int)3, (int)3>, <unnamed>…
     20.7            87135          1   87135.0   87135.0     87135     87135          0.0  nvjet_hsh_256x128_64x4_1x2_h_bz_coopA_NTT
```
nvFuser/cuBLAS = `57.4%`.