### PR TITLE
Fix IterDomain::merge with expanded inner input

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2593,7 +2593,7 @@ IterDomain* IterDomain::merge(
       } else {
         expanded_extent = mul(outer->expandedExtent(), inner->extent());
       }
-    } else if (outer->hasExpandedExtent() && inner->hasExpandedExtent()) {
+    } else if (!outer->hasExpandedExtent() && inner->hasExpandedExtent()) {
       if (outer->isBroadcast()) {
         expanded_extent = inner->expandedExtent();
       } else {


### PR DESCRIPTION
I believe this is just a trivial bug, and, luckily, I don't think it would actually affect anything. This could matter if an expanded iter domain got merged with a non-broadcast iter domain as part of a reshape op, but reshape converts expanded iter domains to non-broadcast iter domains, so this bug won't matter.

In the case of normal scheduling, whether the output of a merge with an expanded broadcast is still a broadcast or not shouldn't matter, I believe.