### PR TITLE
Print all outputs in `SdpaFwdOp`

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2261,6 +2261,18 @@ class SdpaFwdOp : public Expr {
     return output(0)->as<TensorView>();
   }
 
+  TensorView* logsumexp() const {
+    return output(1)->as<TensorView>();
+  }
+
+  TensorView* philox_seed() const {
+    return output(2)->as<TensorView>();
+  }
+
+  TensorView* philox_offset() const {
+    return output(3)->as<TensorView>();
+  }
+
   TensorView* query() const {
     return input(0)->as<TensorView>();
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4426,7 +4426,10 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(SdpaFwdOp)
 
 std::string SdpaFwdOp::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << attn_out()->toString() << "\n";
+  indent(ss, indent_size) << attn_out()->toString() << ",\n";
+  indent(ss, indent_size) << logsumexp()->toString() << ",\n";
+  indent(ss, indent_size) << philox_seed()->toString() << ",\n";
+  indent(ss, indent_size) << philox_offset()->toString() << "\n";
   indent(ss, indent_size + 1) << " = sdpa(" << query()->toString() << ",\n";
   indent(ss, indent_size + 1) << "          " << key()->toString() << ",\n";
   indent(ss, indent_size + 1) << "          " << value()->toString() << ",\n";


### PR DESCRIPTION
Closes Issue #3037.

For the test: https://github.com/NVIDIA/Fuser/blob/f08bd5182df894019cfd07f04f7b2125750af713/tests/cpp/test_sdpa_node.cpp#L691


**`SdpaFwdOp::toString()`**
```
T3_l___half[ iS12{16}, iS13{32}, iS14{64}, iS15{64} ],
T4_l_float[ iS16{16}, iS17{32}, iS18{64} ],
T5_l_int64_t[ ],
T6_l_int64_t[ ]
   = sdpa(T0_g___half[ iS0{16}, iS1{32}, iS2{64}, iS3{64} ],
            T1_g___half[ iS4{16}, iS5{32}, iS6{128}, iS7{64} ],
            T2_g___half[ iS8{16}, iS9{32}, iS10{128}, iS11{64} ],
            dropout_p = double(0),
            is_causal = false  )
```
**`SdpaBwdOp::toString()`**
```
T8_g___half[ iS23{16}, iS24{32}, iS25{64}, iS26{64} ],
T9_g___half[ iS27{16}, iS28{32}, iS29{128}, iS30{64} ],
T10_g___half[ iS31{16}, iS32{32}, iS33{128}, iS34{64} ]
   = sdpa_bwd(T7_g___half[ iS19{16}, iS20{32}, iS21{64}, iS22{64} ],
            T0_g___half[ iS0{16}, iS1{32}, iS2{64}, iS3{64} ],
            T1_g___half[ iS4{16}, iS5{32}, iS6{128}, iS7{64} ],
            T2_g___half[ iS8{16}, iS9{32}, iS10{128}, iS11{64} ],
            T3_g___half[ iS12{16}, iS13{32}, iS14{64}, iS15{64} ],
            logsum_exp = T4_l_float[ iS16{16}, iS17{32}, iS18{64} ],
            dropout_p = double(0),
            is_causal = false,
            philox_seed = T5_l_int64_t[ ],
            philox_offset = T6_l_int64_t[ ],
  )
```
