### PR TITLE
Fix autotune_pointwise.py script

### DIFF
--- a/doc/dev/python_scheduling/autotune_pointwise.py
+++ b/doc/dev/python_scheduling/autotune_pointwise.py
@@ -89,7 +89,7 @@ def custom_pointwise_scheduler(fd, config):
         if config is not None:
             vectorization_factor, unroll_factor = config
             schedule_params.vectorization_factor = vectorization_factor
-            schedule_params.unroll_factor = unroll_factor
+            schedule_params.unroll_factor_inner = unroll_factor
 
         # Schedule fusion
         fd.sched.schedule()


### PR DESCRIPTION
Fix the `autotune_pointwise` script which was broken by https://github.com/NVIDIA/Fuser/pull/3275.
The earlier PR changed the pointwise setting from `unroll_factor` to `inner_unroll_factor`.