### PR TITLE
Avoid replacing a Val with a dependent Val

### DIFF
--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1204,6 +1204,40 @@ bool isFunctional(const Val* v) {
   return std::all_of(def->inputs().begin(), def->inputs().end(), isFunctional);
 }
 
+bool isRecursivelyDefined(Val* val) {
+  NVF_ERROR(val != nullptr);
+
+  std::deque<Val*> vals_to_visit;
+  vals_to_visit.push_back(val);
+
+  std::unordered_set<Val*> visited_vals;
+
+  while (!vals_to_visit.empty()) {
+    auto v = vals_to_visit.front();
+    vals_to_visit.pop_front();
+
+    visited_vals.insert(v);
+
+    auto v_def = v->definition();
+    if (v_def == nullptr) {
+      continue;
+    }
+
+    for (const auto inp : v_def->inputs()) {
+      if (inp == val) {
+        // Recursive dependency detected
+        return true;
+      }
+      // Don't visit the same multiple times
+      if (!visited_vals.count(inp)) {
+        vals_to_visit.push_back(inp);
+      }
+    }
+  }
+
+  return false;
+}
+
 } // namespace nvfuser::ir_utils
 
 namespace nvfuser::MmaOpUtils {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -728,4 +728,9 @@ std::string nullOrToInlineString(const Statement* stmt);
 //! always returns the same result when called with the same inputs.
 bool isFunctional(const Val* v);
 
+// Check if the given val is recursively defined, which is invalid in
+// the Fusion IR but may not be necessarily the case in other IRs
+// such as the Kernel IR
+bool isRecursivelyDefined(Val* val);
+
 } // namespace nvfuser::ir_utils

--- a/csrc/mutator.cpp
+++ b/csrc/mutator.cpp
@@ -77,6 +77,18 @@ void OptOutMutator::registerMutation(Val* val, Val* mutation) {
       ", ",
       mutation->dtype(),
       ")");
+
+  NVF_ERROR(
+      !DependencyCheck::isDependencyOf(val, mutation),
+      "Attempted to replace a val, ",
+      val->toString(),
+      ", with a dependent val, ",
+      mutation->toString(),
+      " (",
+      mutation->toInlineString(),
+      "), which is not allowed as it would result in a recursive definition of ",
+      mutation->toString());
+
   mutations_[val] = mutation;
 }
 


### PR DESCRIPTION
It would result in a recursive definition.