### PR TITLE
Prefer simpler vals in replace sizes

### DIFF
--- a/csrc/device_lower/pass/replace_size.cpp
+++ b/csrc/device_lower/pass/replace_size.cpp
@@ -78,8 +78,10 @@ std::unordered_map<Val*, Val*> getSimplificationMap(Fusion* fusion) {
     // 1. Constant ints. These might be non-immediate constants
     // 2. Extents of input TVs.
     // 3. Extents of non-input TVs.
-    // Within these three classes, we find the IterDomain with the smallest
-    // name().
+    // Within these three classes, we find the IterDomain with the
+    // smallest name(). For case 3, we also prefer the IterDomain with
+    // the simplest extent, which has the smallest number of defining
+    // expessions.
     bool group_is_const = false;
     IterDomain* rep = nullptr;
     bool rep_is_input_id = false;
@@ -144,7 +146,6 @@ std::unordered_map<Val*, Val*> getSimplificationMap(Fusion* fusion) {
       }
     }
   }
-
   return simplification_map;
 }
 
@@ -153,10 +154,6 @@ std::unordered_map<Val*, Val*> getSimplificationMap(Fusion* fusion) {
 void replaceSymbolicSizes(Fusion* fusion) {
   FUSER_PERF_SCOPE("GpuLower::Lower::replaceSymbolicSizes");
   std::unordered_map<Val*, Val*> tensor_dim_map;
-
-  // std::cout << "replaceSymbolicSizes\n";
-  // fusion->print();
-  // std::cout << std::endl;
 
   // Grab inputs and outputs
   std::vector<TensorView*> inputs_and_outputs;

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1238,6 +1238,32 @@ bool isRecursivelyDefined(Val* val) {
   return false;
 }
 
+int64_t getOperationCount(Val* val) {
+  int64_t num_ops = 0;
+
+  // Start with the given val and recursively count the number of ops
+  // by traversing inputs
+  std::deque<Val*> vals;
+  vals.push_back(val);
+
+  while (!vals.empty()) {
+    auto v = vals.front();
+    vals.pop_front();
+
+    auto def = v->definition();
+    if (def == nullptr) {
+      continue;
+    }
+    ++num_ops;
+
+    for (auto inp : def->inputs()) {
+      vals.push_back(inp);
+    }
+  }
+
+  return num_ops;
+}
+
 } // namespace nvfuser::ir_utils
 
 namespace nvfuser::MmaOpUtils {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -733,4 +733,8 @@ bool isFunctional(const Val* v);
 // such as the Kernel IR
 bool isRecursivelyDefined(Val* val);
 
+// Return the number of operations that are used to define val. One
+// instance of Expr is counted as a single operation.
+int64_t getOperationCount(Val* val);
+
 } // namespace nvfuser::ir_utils

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -8929,7 +8929,7 @@ TEST_F(NVFuserTest, AvoidReplacingWithDependentVal) {
 }
 
 // Was also a repro of issue #3347
-TEST_F(NVFuserTest, PreferSimplerExtents) {
+TEST_F(NVFuserTest, ReplaceSymbolicSizesPreferSimplerExtents) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr;
   FusionGuard fg(fusion_ptr.get());
@@ -8967,7 +8967,8 @@ TEST_F(NVFuserTest, PreferSimplerExtents) {
   // All expr output tensors should use the same extent.
   auto ref_ext = fusion.outputs().at(0)->as<TensorView>()->axis(0)->extent();
 
-  // ref_ext should look like getMetaData(T1).logical_size[0] * getMetaData(T1).logical_size[1]
+  // ref_ext should look like getMetaData(T1).logical_size[0] *
+  // getMetaData(T1).logical_size[1]
   auto ext_def = dynamic_cast<BinaryOp*>(ref_ext->definition());
   ASSERT_NE(ext_def, nullptr);
   ASSERT_EQ(ext_def->getBinaryOpType(), BinaryOpType::Mul);


### PR DESCRIPTION
Noticed while working on #3309 that `i0` is replaced with `ceilDiv(i0, 1)`. While it isn't incorrect, it would make generated code look simpler if `ceilDiv(i0, 1)` is replaced with `i0`. 

This PR just changes representative iter domains used for replacing extents. In addition to the existing priority rules, the iter domain with the simplest extent is preferred as the representative ID of a given ID group. The simplicity of extents is just defined based on the number of expressions defining the extent val. So, for example, an iter domain with extent of `i0` should be used as the representative ID instead of iter domains with extent `ceilDiv(i0, 1)`.

There should be no logic change.