### PR TITLE
Ensure expression simplification is enabled in proveLinearAndGetStride

### DIFF
--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -1907,6 +1907,11 @@ Val* proveLinearAndGetStride(
     const ValGroup& linear_g,
     const ValGroups& domain) {
   FusionGuard fg(linear_g->front()->fusion());
+  // This function uses simplifyExpr extensively. If we have disable expression
+  // simplification in order to help inspect generated kernels then we will get
+  // incorrect results here. Instead, we ensure it is enabled using this guard.
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().unset(DisableOption::ExprSimplify);
   if (simplifyExpr(extent(linear_g))->isOne()) {
     // If the extent of the linear group is 1, we always consider it as linear,
     // regardless of its relationship with domain. For this case, we use stride


### PR DESCRIPTION
When debugging the matmul scheduler, I noticed that we hit an error when generating Hopper MMA when we use `NVFUSER_DISABLE=expr_simplify`. This PR makes that possible again. Note that the option is disabled only within `proveLinearAndGetStride` so it has no direct effect on index expressions, which is what we want to look at when using that option.