### PR TITLE
Modify the `compile` parameter in baseline benchmarks to `executor`

### DIFF
--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -96,45 +96,36 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(session, config, items):
     """
-    The baseline benchmarks use `compile` parameter:
-        compile = false: Eager mode benchmark
-        compile = true: torch.compile benchmark
+    The baseline benchmarks use `executor` parameter with 
+    values ["eager", "torchcompile", "thunder"] that are optionally
+    run using `--benchmark-{executor}` flag. They are skipped by 
+    default.
     """
-    run_eager = config.getoption("--benchmark-eager")
-    run_thunder = config.getoption("--benchmark-thunder")
-    run_torchcompile = config.getoption("--benchmark-torchcompile")
 
     from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 
+    def get_test_executor(item) -> str | None:
+        if (
+            hasattr(item, "callspec")
+            and "executor" in item.callspec.params
+        ):
+            return item.callspec.params["executor"]
+        return None
+    
+    executors_to_skip = []
+
+    for executor in ["eager", "torchcompile", "thunder"]:
+        if not config.getoption(f"--benchmark-{executor}"):
+            executors_to_skip.append(executor)
+    
     for item in items:
         item.obj = retry_on_oom_or_skip_test(item.obj)
+        
+        test_executor = get_test_executor(item)
+        
+        if test_executor is not None and test_executor in executors_to_skip:
+            item.add_marker(
+                pytest.mark.skip(reason=f"need --benchmark-{test_executor} option to run.")
+            )
+                
 
-    if not run_eager:
-        skip_eager = pytest.mark.skip(reason="need --benchmark-eager option to run")
-        for item in items:
-            # If the benchmark has compile=False parameter (eager mode), skip it.
-            if (
-                hasattr(item, "callspec")
-                and "compile" in item.callspec.params
-                and not item.callspec.params["compile"]
-            ):
-                item.add_marker(skip_eager)
-
-    if not run_torchcompile:
-        skip_torchcompile = pytest.mark.skip(
-            reason="need --benchmark-torchcompile option to run"
-        )
-        for item in items:
-            # If the benchmark has compile=True parameter (torch.compile mode), skip it.
-            if (
-                hasattr(item, "callspec")
-                and "compile" in item.callspec.params
-                and item.callspec.params["compile"]
-            ):
-                item.add_marker(skip_torchcompile)
-
-    if not run_thunder:
-        skip_thunder = pytest.mark.skip(reason="need --benchmark-thunder option to run")
-        for item in items:
-            if "thunder" in item.nodeid:
-                item.add_marker(skip_thunder)

--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -104,14 +104,20 @@ def pytest_collection_modifyitems(session, config, items):
 
     from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 
+    executors = ["eager", "torchcompile", "thunder"]
+
     def get_test_executor(item) -> str | None:
         if hasattr(item, "callspec") and "executor" in item.callspec.params:
-            return item.callspec.params["executor"]
+            test_executor = item.callspec.params["executor"]
+            assert (
+                test_executor in executors
+            ), f"Expected executor to be one of 'eager', 'torchcompile', 'thunder', found {test_executor}."
+            return test_executor
         return None
 
     executors_to_skip = []
 
-    for executor in ["eager", "torchcompile", "thunder"]:
+    for executor in executors:
         if not config.getoption(f"--benchmark-{executor}"):
             executors_to_skip.append(executor)
 

--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -96,36 +96,33 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(session, config, items):
     """
-    The baseline benchmarks use `executor` parameter with 
+    The baseline benchmarks use `executor` parameter with
     values ["eager", "torchcompile", "thunder"] that are optionally
-    run using `--benchmark-{executor}` flag. They are skipped by 
+    run using `--benchmark-{executor}` flag. They are skipped by
     default.
     """
 
     from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 
     def get_test_executor(item) -> str | None:
-        if (
-            hasattr(item, "callspec")
-            and "executor" in item.callspec.params
-        ):
+        if hasattr(item, "callspec") and "executor" in item.callspec.params:
             return item.callspec.params["executor"]
         return None
-    
+
     executors_to_skip = []
 
     for executor in ["eager", "torchcompile", "thunder"]:
         if not config.getoption(f"--benchmark-{executor}"):
             executors_to_skip.append(executor)
-    
+
     for item in items:
         item.obj = retry_on_oom_or_skip_test(item.obj)
-        
+
         test_executor = get_test_executor(item)
-        
+
         if test_executor is not None and test_executor in executors_to_skip:
             item.add_marker(
-                pytest.mark.skip(reason=f"need --benchmark-{test_executor} option to run.")
+                pytest.mark.skip(
+                    reason=f"need --benchmark-{test_executor} option to run."
+                )
             )
-                
-

--- a/benchmarks/python/normalization.py
+++ b/benchmarks/python/normalization.py
@@ -452,11 +452,8 @@ def norm_fwd_baseline_benchmark(
         inputs = inputs.to(memory_format=torch.channels_last)
 
     norm_fwd_fn = batchnorm_fwd_fn if norm == "batch_norm" else instancenorm_fwd_fn
-    
-    benchmark_fn = {
-        "eager": norm_fwd_fn,
-        "torchcompile": torch.compile(norm_fwd_fn)
-    }
+
+    benchmark_fn = {"eager": norm_fwd_fn, "torchcompile": torch.compile(norm_fwd_fn)}
 
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
@@ -496,10 +493,7 @@ def norm_bwd_baseline_benchmark(
     norm_fwd_fn = batchnorm_fwd_fn if norm == "batch_norm" else instancenorm_fwd_fn
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = {
-        "eager": norm_fwd_fn,
-        "torchcompile": torch.compile(norm_fwd_fn)
-    }
+    fwd_fn = {"eager": norm_fwd_fn, "torchcompile": torch.compile(norm_fwd_fn)}
     outputs = fwd_fn[executor]([inputs, weight, bias, running_mean, running_var])
 
     # Manually compute IOBytes: See PR #1725

--- a/benchmarks/python/test_batchnorm_bwd.py
+++ b/benchmarks/python/test_batchnorm_bwd.py
@@ -31,13 +31,13 @@ def test_batchnorm_bwd_nvf_benchmark(
     )
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
 def test_batchnorm_bwd_baseline_benchmark(
-    benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, compile: bool
+    benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, executor: str
 ):
     norm_bwd_baseline_benchmark(
-        benchmark, size, dtype, channels_last, compile, "batch_norm"
+        benchmark, size, dtype, channels_last, executor, "batch_norm"
     )

--- a/benchmarks/python/test_batchnorm_fwd.py
+++ b/benchmarks/python/test_batchnorm_fwd.py
@@ -31,13 +31,13 @@ def test_batchnorm_fwd_nvf_benchmark(
     )
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
 def test_batchnorm_fwd_baseline_benchmark(
-    benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, compile: bool
+    benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, executor: str
 ):
     norm_fwd_baseline_benchmark(
-        benchmark, size, dtype, channels_last, compile, "batch_norm"
+        benchmark, size, dtype, channels_last, executor, "batch_norm"
     )

--- a/benchmarks/python/test_broadcast_add_fwd.py
+++ b/benchmarks/python/test_broadcast_add_fwd.py
@@ -111,10 +111,10 @@ def test_bcast_add_baseline_benchmark(
     if not contiguous:
         x = x.t()
     assert x.is_contiguous() == contiguous
-    
+
     benchmark_fn = {
         "eager": bcast_add_fwd_fn,
-        "torchcompile": torch.compile(bcast_add_fwd_fn)
+        "torchcompile": torch.compile(bcast_add_fwd_fn),
     }
 
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation

--- a/benchmarks/python/test_broadcast_add_fwd.py
+++ b/benchmarks/python/test_broadcast_add_fwd.py
@@ -88,7 +88,7 @@ def test_bcast_add_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [bias, x])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("bcast_axis", [0, 1], ids=["outer", "inner"])
@@ -101,9 +101,9 @@ def test_bcast_add_baseline_benchmark(
     dtype: torch.dtype,
     bcast_axis: int,
     contiguous: bool,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     bias = torch.randn(size[1 - bcast_axis], dtype=dtype, device="cuda")
     input_shape = size if contiguous else (size[1], size[0])
@@ -111,10 +111,15 @@ def test_bcast_add_baseline_benchmark(
     if not contiguous:
         x = x.t()
     assert x.is_contiguous() == contiguous
+    
+    benchmark_fn = {
+        "eager": bcast_add_fwd_fn,
+        "torchcompile": torch.compile(bcast_add_fwd_fn)
+    }
 
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,
-        torch.compile(bcast_add_fwd_fn) if compile else bcast_add_fwd_fn,
+        benchmark_fn[executor],
         [bias, x, bcast_axis],
     )

--- a/benchmarks/python/test_dropout_layernorm_bwd.py
+++ b/benchmarks/python/test_dropout_layernorm_bwd.py
@@ -220,7 +220,7 @@ def test_dropout_layernorm_bwd_baseline_benchmark(
     fwd_fn = {
         "eager": dropout_layernorm_fwd,
         "torchcompile": torch.compile(dropout_layernorm_fwd),
-    } 
+    }
     outputs = fwd_fn[executor]()
 
     # Manually compute IOBytes: See PR #1725

--- a/benchmarks/python/test_dropout_layernorm_fwd.py
+++ b/benchmarks/python/test_dropout_layernorm_fwd.py
@@ -160,16 +160,16 @@ def test_dropout_layernorm_fwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, inputs)
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_dropout_layernorm_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
 
     dropout_p = 0.2
@@ -180,11 +180,16 @@ def test_dropout_layernorm_fwd_baseline_benchmark(
         torch.zeros(size[1], device="cuda", dtype=dtype),
         dropout_p,
     ]
+    
+    benchmark_fn = {
+        "eager": dropout_layernorm_fwd,
+        "torchcompile": torch.compile(dropout_layernorm_fwd),
+    } 
 
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
-        torch.compile(dropout_layernorm_fwd) if compile else dropout_layernorm_fwd,
+        benchmark_fn[executor],
         inputs,
         iobytes=dropout_layernorm_fwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_dropout_layernorm_fwd.py
+++ b/benchmarks/python/test_dropout_layernorm_fwd.py
@@ -180,11 +180,11 @@ def test_dropout_layernorm_fwd_baseline_benchmark(
         torch.zeros(size[1], device="cuda", dtype=dtype),
         dropout_p,
     ]
-    
+
     benchmark_fn = {
         "eager": dropout_layernorm_fwd,
         "torchcompile": torch.compile(dropout_layernorm_fwd),
-    } 
+    }
 
     # Manually compute IOBytes: See PR #1725
     run_benchmark(

--- a/benchmarks/python/test_dropout_rmsnorm_fwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_fwd.py
@@ -169,7 +169,7 @@ def test_dropout_rmsnorm_fwd_baseline_benchmark(
         "eager": dropout_rmsnorm_fwd,
         "torchcompile": torch.compile(dropout_rmsnorm_fwd),
     }
-    
+
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_gelu_bwd_reduction.py
+++ b/benchmarks/python/test_gelu_bwd_reduction.py
@@ -120,12 +120,12 @@ def test_gelu_bwd_reduction_baseline_benchmark(
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     grads = torch.randn(size, device="cuda", dtype=dtype)
     eager_output = torch.nn.functional.gelu(inputs + bias, approximate="tanh")
-    
+
     benchmark_fn = {
         "eager": gelu_bwd_reduction_torch,
         "torchcompile": torch.compile(gelu_bwd_reduction_torch),
     }
-    
+
     run_benchmark(
         benchmark,
         benchmark_fn[executor],

--- a/benchmarks/python/test_gelu_fwd.py
+++ b/benchmarks/python/test_gelu_fwd.py
@@ -82,13 +82,11 @@ def test_gelu_fwd_baseline_benchmark(
         torch.randn(size, device="cuda", dtype=dtype, requires_grad=True),  # in_tensor
         torch.ones(size[-1], device="cuda", dtype=dtype),  # bias
     ]
-    
+
     benchmark_fn = {
         "eager": gelu_fwd_fn,
         "torchcompile": torch.compile(gelu_fwd_fn),
     }
-    
+
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
-    run_benchmark(
-        benchmark, benchmark_fn[executor], inputs
-    )
+    run_benchmark(benchmark, benchmark_fn[executor], inputs)

--- a/benchmarks/python/test_gelu_fwd.py
+++ b/benchmarks/python/test_gelu_fwd.py
@@ -67,22 +67,28 @@ def test_gelu_fwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, inputs)
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_gelu_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     inputs = [
         torch.randn(size, device="cuda", dtype=dtype, requires_grad=True),  # in_tensor
         torch.ones(size[-1], device="cuda", dtype=dtype),  # bias
     ]
+    
+    benchmark_fn = {
+        "eager": gelu_fwd_fn,
+        "torchcompile": torch.compile(gelu_fwd_fn),
+    }
+    
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
-        benchmark, torch.compile(gelu_fwd_fn) if compile else gelu_fwd_fn, inputs
+        benchmark, benchmark_fn[executor], inputs
     )

--- a/benchmarks/python/test_groupnorm_fwd.py
+++ b/benchmarks/python/test_groupnorm_fwd.py
@@ -148,7 +148,7 @@ def test_groupnorm_fwd_baseline_benchmark(
     benchmark_fn = {
         "eager": groupnorm_fwd,
         "torchcompile": torch.compile(groupnorm_fwd),
-        "thunder": thunder.jit(groupnorm_fwd, , nv_enable_bookend=False, executors=[nvfuserex])
+        "thunder": thunder.jit(groupnorm_fwd, nv_enable_bookend=False, executors=[nvfuserex])
     }
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_groupnorm_fwd.py
+++ b/benchmarks/python/test_groupnorm_fwd.py
@@ -148,7 +148,9 @@ def test_groupnorm_fwd_baseline_benchmark(
     benchmark_fn = {
         "eager": groupnorm_fwd,
         "torchcompile": torch.compile(groupnorm_fwd),
-        "thunder": thunder.jit(groupnorm_fwd, nv_enable_bookend=False, executors=[nvfuserex])
+        "thunder": thunder.jit(
+            groupnorm_fwd, nv_enable_bookend=False, executors=[nvfuserex]
+        ),
     }
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_groupnorm_fwd.py
+++ b/benchmarks/python/test_groupnorm_fwd.py
@@ -128,35 +128,16 @@ def test_groupnorm_fwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [x, weight, bias])
 
 
-@pytest.mark.parametrize("size", generate_input_sizes(dims=4))
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_groupnorm_fwd_thunder_benchmark(
-    benchmark,
-    size: tuple,
-    dtype: torch.dtype,
-):
-    N, C, H, W = size
-    x = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
-    weight = torch.randn(C, device="cuda", dtype=dtype, requires_grad=True)
-    bias = torch.randn(C, device="cuda", dtype=dtype, requires_grad=True)
-    num_groups = get_n_groups(C)
-    # thunder compiled model
-    groupnorm_fwd_jit = thunder.jit(
-        groupnorm_fwd, nv_enable_bookend=False, executors=[nvfuserex]
-    )
-    run_benchmark(benchmark, groupnorm_fwd_jit, [x, weight, bias, num_groups])
-
-
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile", "thunder"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_groupnorm_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     N, C, H, W = size
     x = torch.randn(size, device="cuda", dtype=dtype)
@@ -164,8 +145,13 @@ def test_groupnorm_fwd_baseline_benchmark(
     bias = torch.randn(C, device="cuda", dtype=dtype)
     num_groups = get_n_groups(C)
 
+    benchmark_fn = {
+        "eager": groupnorm_fwd,
+        "torchcompile": torch.compile(groupnorm_fwd),
+        "thunder": thunder.jit(groupnorm_fwd, , nv_enable_bookend=False, executors=[nvfuserex])
+    }
     run_benchmark(
         benchmark,
-        torch.compile(groupnorm_fwd) if compile else groupnorm_fwd,
+        benchmark_fn[executor],
         [x, weight, bias, num_groups],
     )

--- a/benchmarks/python/test_huggingface_attn_bwd.py
+++ b/benchmarks/python/test_huggingface_attn_bwd.py
@@ -107,16 +107,16 @@ def test_huggingface_attn_bwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [grads, attn, dropout_mask])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_huggingface_attn_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     batch_size, seq_len, nh, n_embd = size
     dropout_p = 0.2
@@ -134,14 +134,17 @@ def test_huggingface_attn_bwd_baseline_benchmark(
         return output
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = torch.compile(huggingface_attn_fwd) if compile else huggingface_attn_fwd
-    output = fwd_fn()
+    fwd_fn = {
+        "eager": huggingface_attn_fwd,
+        "torchcompile": torch.compile(huggingface_attn_fwd)
+    }
+    outputs = fwd_fn[executor]()
     grads = torch.randn(batch_size * nh, seq_len, seq_len, device="cuda", dtype=dtype)
 
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
         unary_bwd_torch,
-        [output, grads],
+        [outputs, grads],
         iobytes=huggingface_attn_bwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_huggingface_attn_bwd.py
+++ b/benchmarks/python/test_huggingface_attn_bwd.py
@@ -136,7 +136,7 @@ def test_huggingface_attn_bwd_baseline_benchmark(
     # Compile the fwd fn for torchcompile
     fwd_fn = {
         "eager": huggingface_attn_fwd,
-        "torchcompile": torch.compile(huggingface_attn_fwd)
+        "torchcompile": torch.compile(huggingface_attn_fwd),
     }
     outputs = fwd_fn[executor]()
     grads = torch.randn(batch_size * nh, seq_len, seq_len, device="cuda", dtype=dtype)

--- a/benchmarks/python/test_huggingface_attn_fwd.py
+++ b/benchmarks/python/test_huggingface_attn_fwd.py
@@ -157,7 +157,7 @@ def test_huggingface_attn_fwd_baseline_benchmark(
         "eager": huggingface_attn_fwd,
         "torchcompile": torch.compile(huggingface_attn_fwd),
     }
-    
+
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_huggingface_attn_fwd.py
+++ b/benchmarks/python/test_huggingface_attn_fwd.py
@@ -135,16 +135,16 @@ def test_huggingface_attn_fwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [attention_mask, inputs])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_huggingface_attn_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     batch_size, seq_len, nh, n_embd = size
     dropout_p = 0.2
@@ -153,10 +153,15 @@ def test_huggingface_attn_fwd_baseline_benchmark(
         batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype
     )
 
+    benchmark_fn = {
+        "eager": huggingface_attn_fwd,
+        "torchcompile": torch.compile(huggingface_attn_fwd),
+    }
+    
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
-        torch.compile(huggingface_attn_fwd) if compile else huggingface_attn_fwd,
+        benchmark_fn[executor],
         [attention_mask, inputs, size, dropout_p],
         iobytes=huggingface_attn_fwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_instancenorm_bwd.py
+++ b/benchmarks/python/test_instancenorm_bwd.py
@@ -30,13 +30,13 @@ def test_instancenorm_bwd_nvf_benchmark(
     )
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
 def test_instancenorm_bwd_baseline_benchmark(
-    benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, compile: bool
+    benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, executor: str
 ):
     norm_bwd_baseline_benchmark(
-        benchmark, size, dtype, channels_last, compile, "instance_norm"
+        benchmark, size, dtype, channels_last, executor, "instance_norm"
     )

--- a/benchmarks/python/test_instancenorm_fwd.py
+++ b/benchmarks/python/test_instancenorm_fwd.py
@@ -29,13 +29,13 @@ def test_instancenorm_fwd_nvf_benchmark(
     )
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("channels_last", [True, False])
 def test_instancenorm_fwd_baseline_benchmark(
-    benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, compile: bool
+    benchmark, size: tuple, dtype: torch.dtype, channels_last: bool, executor: str
 ):
     norm_fwd_baseline_benchmark(
-        benchmark, size, dtype, channels_last, compile, "instance_norm"
+        benchmark, size, dtype, channels_last, executor, "instance_norm"
     )

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -128,7 +128,7 @@ def test_layernorm_fwd_baseline_benchmark(
         "eager": layernorm_fwd,
         "torchcompile": torch.compile(layernorm_fwd),
     }
-    
+
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -106,16 +106,16 @@ def test_layernorm_fwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, inputs)
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_layernorm_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     batch_size, hidden_size = size
     inputs = [
@@ -124,10 +124,15 @@ def test_layernorm_fwd_baseline_benchmark(
         torch.randn(hidden_size, device="cuda", dtype=dtype),
     ]
 
+    benchmark_fn = {
+        "eager": layernorm_fwd,
+        "torchcompile": torch.compile(layernorm_fwd),
+    }
+    
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
-        torch.compile(layernorm_fwd) if compile else layernorm_fwd,
+        benchmark_fn[executor],
         inputs,
         iobytes=layernorm_fwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_matmul.py
+++ b/benchmarks/python/test_matmul.py
@@ -25,14 +25,14 @@ def load_matmul_problems():
 
 
 @pytest.mark.parametrize("half_reduction", [False, True], ids=["fullred", "halfred"])
-@pytest.mark.parametrize("compile", [False], ids=["eager"])
+@pytest.mark.parametrize("executor", ["eager"])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
 @pytest.mark.parametrize(
     "config", load_matmul_problems(), ids=lambda val: "-".join(str(v) for v in val)
 )
 def test_matmul_baseline_benchmark(
     benchmark,
-    compile: bool,
+    executor: str,
     config: tuple,
     dtype: torch.dtype,
     half_reduction: bool,

--- a/benchmarks/python/test_nanogpt_attn_bwd.py
+++ b/benchmarks/python/test_nanogpt_attn_bwd.py
@@ -124,16 +124,16 @@ def test_nanogpt_attn_bwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [grads, attn, dropout_mask, bias_mask])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_nanogpt_attn_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     batch_size, seq_len, nh, n_embd = size
     dropout_p = 0.2
@@ -154,14 +154,18 @@ def test_nanogpt_attn_bwd_baseline_benchmark(
         return output
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = torch.compile(nanogpt_attn_fwd) if compile else nanogpt_attn_fwd
-    output = fwd_fn()
+    fwd_fn = {
+        "eager": nanogpt_attn_fwd,
+        "torchcompile": torch.compile(nanogpt_attn_fwd),
+    }
+    outputs = fwd_fn[executor]()
+    
     grads = torch.randn(batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype)
 
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
         unary_bwd_torch,
-        [output, grads],
+        [outputs, grads],
         iobytes=nanogpt_attn_bwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_nanogpt_attn_bwd.py
+++ b/benchmarks/python/test_nanogpt_attn_bwd.py
@@ -159,7 +159,7 @@ def test_nanogpt_attn_bwd_baseline_benchmark(
         "torchcompile": torch.compile(nanogpt_attn_fwd),
     }
     outputs = fwd_fn[executor]()
-    
+
     grads = torch.randn(batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype)
 
     # Manually compute IOBytes: See PR #1725

--- a/benchmarks/python/test_nanogpt_attn_fwd.py
+++ b/benchmarks/python/test_nanogpt_attn_fwd.py
@@ -137,16 +137,16 @@ def test_nanogpt_attn_fwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [inputs, bias])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_attn_inputs())
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_nanogpt_attn_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     batch_size, seq_len, nh, n_embd = size
     dropout_p = 0.2
@@ -154,10 +154,16 @@ def test_nanogpt_attn_fwd_baseline_benchmark(
     bias = torch.tril(torch.ones(seq_len, seq_len, device="cuda")).view(
         1, 1, seq_len, seq_len
     )
+    
+    benchmark_fn = {
+        "eager": nanogpt_attn_fwd,
+        "torchcompile": torch.compile(nanogpt_attn_fwd)
+    }
+    
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
-        torch.compile(nanogpt_attn_fwd) if compile else nanogpt_attn_fwd,
+        benchmark_fn[executor],
         [inputs, bias, size, dropout_p],
         iobytes=nanogpt_attn_fwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_nanogpt_attn_fwd.py
+++ b/benchmarks/python/test_nanogpt_attn_fwd.py
@@ -154,12 +154,12 @@ def test_nanogpt_attn_fwd_baseline_benchmark(
     bias = torch.tril(torch.ones(seq_len, seq_len, device="cuda")).view(
         1, 1, seq_len, seq_len
     )
-    
+
     benchmark_fn = {
         "eager": nanogpt_attn_fwd,
-        "torchcompile": torch.compile(nanogpt_attn_fwd)
+        "torchcompile": torch.compile(nanogpt_attn_fwd),
     }
-    
+
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_pointwise_mul.py
+++ b/benchmarks/python/test_pointwise_mul.py
@@ -50,21 +50,26 @@ def test_pointwise_mul_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, inputs)
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_pointwise_mul_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype)
+    
+    benchmark_fn = {
+        "eager": pointwise_mul_fwd_fn,
+        "torchcompile": torch.compile(pointwise_mul_fwd_fn)
+    }
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,
-        torch.compile(pointwise_mul_fwd_fn) if compile else pointwise_mul_fwd_fn,
+        benchmark_fn[executor],
         [input],
     )

--- a/benchmarks/python/test_pointwise_mul.py
+++ b/benchmarks/python/test_pointwise_mul.py
@@ -62,10 +62,10 @@ def test_pointwise_mul_baseline_benchmark(
     if executor == "torchcompile":
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype)
-    
+
     benchmark_fn = {
         "eager": pointwise_mul_fwd_fn,
-        "torchcompile": torch.compile(pointwise_mul_fwd_fn)
+        "torchcompile": torch.compile(pointwise_mul_fwd_fn),
     }
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(

--- a/benchmarks/python/test_reduction.py
+++ b/benchmarks/python/test_reduction.py
@@ -67,10 +67,10 @@ def test_reduction_baseline_benchmark(
     if executor == "torchcompile":
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype)
-    
+
     benchmark_fn = {
         "eager": reduction_fwd_fn,
-        "torchcompile": torch.compile(reduction_fwd_fn)
+        "torchcompile": torch.compile(reduction_fwd_fn),
     }
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(

--- a/benchmarks/python/test_reduction.py
+++ b/benchmarks/python/test_reduction.py
@@ -53,7 +53,7 @@ def test_reduction_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, inputs)
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0, 1])
@@ -62,14 +62,19 @@ def test_reduction_baseline_benchmark(
     size: tuple,
     dtype: torch.dtype,
     reduction_axis: int,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype)
+    
+    benchmark_fn = {
+        "eager": reduction_fwd_fn,
+        "torchcompile": torch.compile(reduction_fwd_fn)
+    }
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,
-        torch.compile(reduction_fwd_fn) if compile else reduction_fwd_fn,
+        benchmark_fn[executor],
         [input, reduction_axis],
     )

--- a/benchmarks/python/test_reduction_epilogue.py
+++ b/benchmarks/python/test_reduction_epilogue.py
@@ -67,7 +67,7 @@ def test_reduction_epilogue_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [x, epilogue])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("reduction_axis", [0])
@@ -76,17 +76,21 @@ def test_reduction_epilogue_baseline_benchmark(
     size: tuple,
     dtype: torch.dtype,
     reduction_axis: int,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     x = torch.randn(size, device="cuda", dtype=dtype)
     epilogue = torch.randn(size[reduction_axis - 1], device="cuda", dtype=dtype)
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
+    
+    benchmark_fn = {
+        "eager": reduction_epilogue_fwd_fn,
+        "torchcompile": torch.compile(reduction_epilogue_fwd_fn)
+    }
+    
     run_benchmark(
         benchmark,
-        torch.compile(reduction_epilogue_fwd_fn)
-        if compile
-        else reduction_epilogue_fwd_fn,
+        benchmark_fn[executor],
         [x, epilogue, reduction_axis],
     )

--- a/benchmarks/python/test_reduction_epilogue.py
+++ b/benchmarks/python/test_reduction_epilogue.py
@@ -83,12 +83,12 @@ def test_reduction_epilogue_baseline_benchmark(
     x = torch.randn(size, device="cuda", dtype=dtype)
     epilogue = torch.randn(size[reduction_axis - 1], device="cuda", dtype=dtype)
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
-    
+
     benchmark_fn = {
         "eager": reduction_epilogue_fwd_fn,
-        "torchcompile": torch.compile(reduction_epilogue_fwd_fn)
+        "torchcompile": torch.compile(reduction_epilogue_fwd_fn),
     }
-    
+
     run_benchmark(
         benchmark,
         benchmark_fn[executor],

--- a/benchmarks/python/test_rmsnorm_bwd.py
+++ b/benchmarks/python/test_rmsnorm_bwd.py
@@ -134,10 +134,7 @@ def test_rmsnorm_bwd_baseline_benchmark(
         return output
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = {
-        "eager": rmsnorm_fwd,
-        "torchcompile": torch.compile(rmsnorm_fwd)
-    }
+    fwd_fn = {"eager": rmsnorm_fwd, "torchcompile": torch.compile(rmsnorm_fwd)}
     outputs = fwd_fn[executor]()
 
     # Manually compute IOBytes: See PR #1725

--- a/benchmarks/python/test_rmsnorm_bwd.py
+++ b/benchmarks/python/test_rmsnorm_bwd.py
@@ -112,16 +112,16 @@ def test_rmsnorm_bwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [inputs, rms_eps, grads, weights])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_rmsnorm_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(size, device="cuda", dtype=dtype)
@@ -134,13 +134,16 @@ def test_rmsnorm_bwd_baseline_benchmark(
         return output
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = torch.compile(rmsnorm_fwd) if compile else rmsnorm_fwd
-    output = fwd_fn()
+    fwd_fn = {
+        "eager": rmsnorm_fwd,
+        "torchcompile": torch.compile(rmsnorm_fwd)
+    }
+    outputs = fwd_fn[executor]()
 
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
         unary_bwd_torch,
-        [output, grads],
+        [outputs, grads],
         iobytes=rmsnorm_bwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_rmsnorm_fwd.py
+++ b/benchmarks/python/test_rmsnorm_fwd.py
@@ -86,24 +86,28 @@ def test_rmsnorm_fwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [inputs, weights])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_rmsnorm_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     inputs = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype)
 
+    benchmark_fn = {
+        "eager": rmsnorm_fwd_fn,
+        "torchcompile": torch.compile(rmsnorm_fwd_fn)
+    }
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
-        torch.compile(rmsnorm_fwd_fn) if compile else rmsnorm_fwd_fn,
+        benchmark_fn[executor],
         [inputs, weights],
         iobytes=rmsnorm_fwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_rmsnorm_fwd.py
+++ b/benchmarks/python/test_rmsnorm_fwd.py
@@ -102,7 +102,7 @@ def test_rmsnorm_fwd_baseline_benchmark(
 
     benchmark_fn = {
         "eager": rmsnorm_fwd_fn,
-        "torchcompile": torch.compile(rmsnorm_fwd_fn)
+        "torchcompile": torch.compile(rmsnorm_fwd_fn),
     }
     # Manually compute IOBytes: See PR #1725
     run_benchmark(

--- a/benchmarks/python/test_scale_bias_relu_bwd.py
+++ b/benchmarks/python/test_scale_bias_relu_bwd.py
@@ -99,10 +99,7 @@ def test_sbr_bwd_baseline_benchmark(
         return torch.nn.functional.relu(inputs * scale + bias)
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = {
-        "eager": sbr_fwd,
-        "torchcompile": torch.compile(sbr_fwd)
-    }
+    fwd_fn = {"eager": sbr_fwd, "torchcompile": torch.compile(sbr_fwd)}
     outputs = fwd_fn[executor]()
 
     run_benchmark(

--- a/benchmarks/python/test_scale_bias_relu_bwd.py
+++ b/benchmarks/python/test_scale_bias_relu_bwd.py
@@ -79,16 +79,16 @@ def test_sbr_bwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [scale, bool_mask, grads])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_sbr_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
@@ -99,12 +99,15 @@ def test_sbr_bwd_baseline_benchmark(
         return torch.nn.functional.relu(inputs * scale + bias)
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = torch.compile(sbr_fwd) if compile else sbr_fwd
-    eager_output = sbr_fwd()
+    fwd_fn = {
+        "eager": sbr_fwd,
+        "torchcompile": torch.compile(sbr_fwd)
+    }
+    outputs = fwd_fn[executor]()
 
     run_benchmark(
         benchmark,
         unary_bwd_torch,
-        [eager_output, grads],
+        [outputs, grads],
         iobytes=sbr_bwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_scale_bias_relu_fwd.py
+++ b/benchmarks/python/test_scale_bias_relu_fwd.py
@@ -97,11 +97,8 @@ def test_sbr_fwd_baseline_benchmark(
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     scale = torch.ones(size[-1], device="cuda", dtype=dtype)
 
-    benchmark_fn = {
-        "eager": sbr_fwd_fn,
-        "torchcompile": torch.compile(sbr_fwd_fn)
-    }
-    
+    benchmark_fn = {"eager": sbr_fwd_fn, "torchcompile": torch.compile(sbr_fwd_fn)}
+
     run_benchmark(
         benchmark,
         benchmark_fn[executor],

--- a/benchmarks/python/test_scale_bias_relu_fwd.py
+++ b/benchmarks/python/test_scale_bias_relu_fwd.py
@@ -82,24 +82,29 @@ def test_sbr_fwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [bias, scale, inputs])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_sbr_fwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     inputs = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     scale = torch.ones(size[-1], device="cuda", dtype=dtype)
 
+    benchmark_fn = {
+        "eager": sbr_fwd_fn,
+        "torchcompile": torch.compile(sbr_fwd_fn)
+    }
+    
     run_benchmark(
         benchmark,
-        torch.compile(sbr_fwd_fn) if compile else sbr_fwd_fn,
+        benchmark_fn[executor],
         [bias, scale, inputs],
         iobytes=sbr_fwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_silu_mul_bwd.py
+++ b/benchmarks/python/test_silu_mul_bwd.py
@@ -98,10 +98,7 @@ def test_silu_mul_bwd_baseline_benchmark(
         return torch.nn.functional.silu(x) * y
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = {
-        "eager": silu_mul_fwd,
-        "torchcompile": torch.compile(silu_mul_fwd)
-    }
+    fwd_fn = {"eager": silu_mul_fwd, "torchcompile": torch.compile(silu_mul_fwd)}
     outputs = fwd_fn[executor]()
 
     run_benchmark(

--- a/benchmarks/python/test_silu_mul_bwd.py
+++ b/benchmarks/python/test_silu_mul_bwd.py
@@ -79,16 +79,16 @@ def test_silu_mul_bwd_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [grads, x, y])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_silu_mul_bwd_baseline_benchmark(
     benchmark,
     size: tuple,
     dtype: torch.dtype,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     x = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     y = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
@@ -98,12 +98,15 @@ def test_silu_mul_bwd_baseline_benchmark(
         return torch.nn.functional.silu(x) * y
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = torch.compile(silu_mul_fwd) if compile else silu_mul_fwd
-    eager_output = fwd_fn()
+    fwd_fn = {
+        "eager": silu_mul_fwd,
+        "torchcompile": torch.compile(silu_mul_fwd)
+    }
+    outputs = fwd_fn[executor]()
 
     run_benchmark(
         benchmark,
         unary_bwd_torch,
-        [eager_output, grads],
+        [outputs, grads],
         iobytes=silu_mul_bwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_silu_mul_fwd.py
+++ b/benchmarks/python/test_silu_mul_fwd.py
@@ -71,9 +71,9 @@ def test_silu_mul_fwd_baseline_benchmark(
 
     benchmark_fn = {
         "eager": silu_mul_fwd_fn,
-        "torchcompile": torch.compile(silu_mul_fwd_fn)
+        "torchcompile": torch.compile(silu_mul_fwd_fn),
     }
-    
+
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_softmax_bwd.py
+++ b/benchmarks/python/test_softmax_bwd.py
@@ -110,10 +110,7 @@ def test_softmax_bwd_baseline_benchmark(
     def softmax_fwd():
         return torch.nn.functional.softmax(input, dim=reduction_axis)
 
-    fwd_fn = {
-        "eager": softmax_fwd,
-        "torchcompile": torch.compile(softmax_fwd)
-    }
+    fwd_fn = {"eager": softmax_fwd, "torchcompile": torch.compile(softmax_fwd)}
     outputs = fwd_fn[executor]()
 
     run_benchmark(

--- a/benchmarks/python/test_softmax_fwd.py
+++ b/benchmarks/python/test_softmax_fwd.py
@@ -98,7 +98,7 @@ def test_softmax_fwd_baseline_benchmark(
 
     benchmark_fn = {
         "eager": softmax_fwd_fn,
-        "torchcompile": torch.compile(softmax_fwd_fn)
+        "torchcompile": torch.compile(softmax_fwd_fn),
     }
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_transpose.py
+++ b/benchmarks/python/test_transpose.py
@@ -89,12 +89,12 @@ def test_transpose_baseline_benchmark(
         clear_dynamo_cache()
     input1 = torch.randn(size, device="cuda", dtype=dtype)
     input2 = torch.randn(size, device="cuda", dtype=dtype)
-    
+
     benchmark_fn = {
         "eager": transpose_fwd_fn,
-        "torchcompile": torch.compile(transpose_fwd_fn)
+        "torchcompile": torch.compile(transpose_fwd_fn),
     }
-    
+
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_transpose.py
+++ b/benchmarks/python/test_transpose.py
@@ -74,7 +74,7 @@ def test_transpose_nvf_benchmark(
         run_benchmark(benchmark, fd.execute, [input1, input2])
 
 
-@pytest.mark.parametrize("compile", [False, True], ids=["eager", "compile"])
+@pytest.mark.parametrize("executor", ["eager", "torchcompile"])
 @pytest.mark.parametrize("size", generate_input_sizes(dims=3))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("axes", [(0, 1), (0, 2), (1, 2)])
@@ -83,15 +83,21 @@ def test_transpose_baseline_benchmark(
     size: tuple,
     dtype: torch.dtype,
     axes: list,
-    compile: bool,
+    executor: str,
 ):
-    if compile:
+    if executor == "torchcompile":
         clear_dynamo_cache()
     input1 = torch.randn(size, device="cuda", dtype=dtype)
     input2 = torch.randn(size, device="cuda", dtype=dtype)
+    
+    benchmark_fn = {
+        "eager": transpose_fwd_fn,
+        "torchcompile": torch.compile(transpose_fwd_fn)
+    }
+    
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,
-        torch.compile(transpose_fwd_fn) if compile else transpose_fwd_fn,
+        benchmark_fn[executor],
         [input1, input2, axes[0], axes[1]],
     )


### PR DESCRIPTION
This PR is the first step in adding `thunder.jit` benchmarks.
The major change is modifying the `compile` parameter to `executor` with values `eager`, `torchcompile`, `thunder`. This PR does not introduce any new thunder benchmarks (to be done in next PR).

CC: @xwang233 for dashboard changes.

Issue: #2718 