### PR TITLE
Set `fusion_id` and `device_id` of `KernelExecutor` in constructor for user scheduling.

### DIFF
--- a/csrc/python_frontend/fusion_cache.cpp
+++ b/csrc/python_frontend/fusion_cache.cpp
@@ -597,11 +597,6 @@ UserSchedule* FusionCache::createUserSchedule(
   auto& user_scheds = scheds->user_def_schedules;
   auto input_id = user_def_input_encodings_.lookupId(inputs);
 
-  // Create device to UserSchedule map for input arguments id
-  if (user_scheds.count(input_id.id) == 0) {
-    user_scheds[input_id.id] = std::unordered_map<int, UserSchedule>();
-  }
-
   // Create UserSchedule for device
   if (user_scheds[input_id.id].count(device) == 0) {
     user_scheds[input_id.id].emplace(

--- a/csrc/python_frontend/fusion_cache.cpp
+++ b/csrc/python_frontend/fusion_cache.cpp
@@ -186,7 +186,11 @@ void serialize() {
 std::mutex FusionCache::singleton_lock_;
 FusionCache* FusionCache::singleton_ = nullptr;
 
-UserSchedule::UserSchedule() : scheduled_fusion(nullptr), executor(nullptr) {
+UserSchedule::UserSchedule(int64_t fusion_id, int64_t device_id)
+    : scheduled_fusion(nullptr),
+      executor(nullptr),
+      fusion_id_(fusion_id),
+      device_id_(device_id) {
   scheduled_fusion = std::make_unique<Fusion>();
   executor = std::make_unique<KernelExecutor>();
 }
@@ -591,22 +595,25 @@ UserSchedule* FusionCache::createUserSchedule(
   std::lock_guard<std::mutex> guard(scheds->scheds_lock);
   auto& user_scheds = scheds->user_def_schedules;
   auto input_id = user_def_input_encodings_.lookupId(inputs);
-  auto user_sched = user_scheds.find(input_id.id);
-  if (user_sched == user_scheds.end()) {
-    user_scheds[input_id.id] = std::vector<UserSchedule>(device + 1);
-  } else {
-    if (static_cast<size_t>(device) >= user_scheds[input_id.id].size()) {
-      user_scheds[input_id.id].resize(device + 1);
-    } else {
-      if (!overwrite_existing_schedule) {
-        TORCH_WARN(
-            "You are overwriting the current user schedule for a definition!");
-      }
-      user_scheds[input_id.id].at(device) = UserSchedule();
-    }
+
+  // Create device to UserSchedule map for input arguments id
+  if (user_scheds.count(input_id.id) == 0) {
+    user_scheds[input_id.id] = std::unordered_map<int, UserSchedule>();
   }
-  user_scheds[input_id.id].at(device).fusion_id_ = scheds->fusion_id_;
-  user_scheds[input_id.id].at(device).device_id_ = device;
+
+  // Create UserSchedule for device
+  if (user_scheds[input_id.id].count(device) == 0) {
+    user_scheds[input_id.id].emplace(
+        device, UserSchedule(scheds->fusion_id_, device));
+  } else {
+    if (!overwrite_existing_schedule) {
+      TORCH_WARN(
+          "You are overwriting the current user schedule for a definition!");
+    }
+    user_scheds[input_id.id].at(device) =
+        UserSchedule(scheds->fusion_id_, device);
+  }
+
   return &user_scheds[input_id.id].at(device);
 }
 

--- a/csrc/python_frontend/fusion_cache.cpp
+++ b/csrc/python_frontend/fusion_cache.cpp
@@ -192,7 +192,8 @@ UserSchedule::UserSchedule(int64_t fusion_id, int64_t device_id)
       fusion_id_(fusion_id),
       device_id_(device_id) {
   scheduled_fusion = std::make_unique<Fusion>();
-  executor = std::make_unique<KernelExecutor>();
+  executor =
+      std::make_unique<KernelExecutor>(fusion_id, /*concrete_id=*/device_id);
 }
 
 bool UserSchedule::canSchedule(const SchedulerType& scheduler_type) {

--- a/csrc/python_frontend/fusion_cache.h
+++ b/csrc/python_frontend/fusion_cache.h
@@ -23,7 +23,7 @@ namespace nvfuser::python_frontend {
 //! \brief A container to hold a scheduled Fusion IR as well as an executor
 //! to contain the corresponding generated kernel.
 struct UserSchedule {
-  UserSchedule();
+  UserSchedule(int64_t fusion_id, int64_t device_id);
 
   //! Runtime information for schedulers
   std::unique_ptr<SchedulerRuntimeInfo> runtime_info;
@@ -98,7 +98,8 @@ struct FusionSchedules {
   //! Key:   Input Encoding hash of Fusion inputs as is created by the
   //!        InputsIdLookup struct found inside of the FusionCache.
   //! Value: A vector based on device_id of User Defined Fusion Schedules.
-  std::unordered_map<size_t, std::vector<UserSchedule>> user_def_schedules;
+  std::unordered_map<size_t, std::unordered_map<int, UserSchedule>>
+      user_def_schedules;
   //! Keeps a pointer to the last scheduled Fusion IR for printing
   Fusion* last_user_def_scheduled_ir;
   //! Keeps a pointer to the last executed executor for printing its cuda kernel

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -371,12 +371,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
         // Manual schedule
         if (!user_sched.executor->isCompiled()) {
           user_sched.executor->compile(
-              user_sched.scheduled_fusion.get(), inputs
-              // TODO: Fix, this is difficult because this function is const and
-              // ids should be passed as constructor of the executor
-              // ,user_sched.fusion_id_,
-              // user_sched.device_id_
-          );
+              user_sched.scheduled_fusion.get(), inputs);
         }
         outputs = user_sched.executor->run(inputs);
       } else {
@@ -389,12 +384,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
                   inputs, getCommonDeviceCUDA(inputs)),
               user_sched.heuristic_params->lparams,
               user_sched.heuristic_params->cparams,
-              user_sched.heuristic_params->scheduler_type
-              // TODO: Fix, this is difficult because this function is const and
-              // ids should be passed as constructor of the executor
-              // ,user_sched.fusion_id_,
-              // user_sched.device_id_
-          );
+              user_sched.heuristic_params->scheduler_type);
         }
         outputs = user_sched.executor->run(
             inputs,

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -163,14 +163,9 @@ flatbuffers::Offset<serde::FusionKernelRuntime> FusionKernelRuntime::serialize(
     flatbuffers::FlatBufferBuilder& builder) const {
   // See table definition for FusionKernelRuntime in serde/fusion_cache.fbs
 
-  // This check needs to be disabled though it seems strange to me that we
-  // would/could/should serialize KRTs that aren't compiled. For now the pytorch
-  // tests require it.
-  //
-  // NVF_CHECK(
-  //     isCompiled(),
-  //     "Tried to serialize entries of executors before they were
-  //     initialized.");
+  NVF_CHECK(
+      isCompiled(),
+      "Tried to serialize entries of executors before they were initialized.");
 
   // 1. Serialize KernelExecutor objects
   std::vector<flatbuffers::Offset<serde::KernelExecutor>> executors_fb;


### PR DESCRIPTION
The goal is to set `fusion_id` and `device_id` when creating `KernelExecutor` for `UserSchedule. Previously, it was set during `FusionExecutor::compileFusion`. This PR is stacked on `executor_dispatch`

**Changes to `UserSchedule` cache system:**
**Current:** The map key is the integer value of input arguments. The vector is of size `device id`.
`std::unordered_map<size_t, std::vector<UserSchedule>> user_def_schedules;`

**New:** The key to first map is the integer value of input arguments. The key to second map is of `device`.

**Why?** We can set the the `fusion_id` and `device_id` in the constructor of `UserSchedule` and `KernelExecutor`.