### PR TITLE
Use SimplyfingIrBuilder for circular buffering

### DIFF
--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -97,7 +97,7 @@ class CircularBufferLoopCloner : public kir::IrVisitor {
       }
       case CircularBufferLoopStage::Main: {
         if (requireEpilogue(circular_buffer_load_exprs_)) {
-          stop = IrBuilder::subExpr(
+          stop = SimplifyingIrBuilder::subExpr(
               circular_buffer_loop_->stop(),
               SimplifyingIrBuilder::create<Val>(
                   prefetch_distance, DataType::Index));
@@ -106,7 +106,7 @@ class CircularBufferLoopCloner : public kir::IrVisitor {
       }
       case CircularBufferLoopStage::Epilog: {
         NVF_ERROR(requireEpilogue(circular_buffer_load_exprs_));
-        start = IrBuilder::subExpr(
+        start = SimplifyingIrBuilder::subExpr(
             circular_buffer_loop_->stop(),
             SimplifyingIrBuilder::create<Val>(
                 prefetch_distance, DataType::Index));
@@ -424,7 +424,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
     int64_t stage_depth =
         GpuLower::current()->circularBufferInfo().getStageDepthFor(
             circular_buffer_loop_->iter_domain());
-    Val* result = IrBuilder::modExpr(
+    Val* result = SimplifyingIrBuilder::modExpr(
         cloned_top_level_loop_->indexOrStartIfTrivial(),
         IrBuilder::create<Val>(stage_depth, PrimDataType::Index));
     return GpuLower::current()->commonScalarMap().hoistScalar(
@@ -441,8 +441,8 @@ class CloneTmaCircularBufferLoopAndInsertSync
         GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
             circular_buffer_loop_->iter_domain());
 
-    auto current_load_stage = IrBuilder::modExpr(
-        IrBuilder::addExpr(
+    auto current_load_stage = SimplifyingIrBuilder::modExpr(
+        SimplifyingIrBuilder::addExpr(
             cloned_top_level_loop_->indexOrStartIfTrivial(),
             IrBuilder::create<Val>(prefetch_distance, PrimDataType::Index)),
         IrBuilder::create<Val>(stage_depth, PrimDataType::Index));

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4881,6 +4881,13 @@ bool ForLoop::isTrivial() const {
     return true;
   }
 
+  if (start()->isConstScalar() && simplifiedStop()->isConstScalar() &&
+      start()->evaluate().as<int64_t>() + 1 ==
+          simplifiedStop()->evaluate().as<int64_t>() &&
+      step()->isOneInt()) {
+    return true;
+  }
+
   return false;
 }
 

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -2151,6 +2151,11 @@ TEST_F(IndexingTest, DoubleBuffering6) {
         return nullptr;
       }
 
+      // This loop is double buffered. Since the loop originally has
+      // just a trip count of 2, the double-buffered main loop has a
+      // trip count of 1. Thus, this loop is always trivial
+      loop_indices.at(1) = tv->fusion()->zeroVal();
+
       switch (tv->name()) {
         case 1: {
           if (!as_consumer) {


### PR DESCRIPTION
Noticed some easy simplification while working on #3309. Not necessary for correctness and the actual perf would probably have no effect ,if any, thanks to expr simplification and index hoisting, but examining generated code could be easier when simplification is possible.