### PR TITLE
Renaming from #3263 part2

### DIFF
--- a/benchmarks/cpp/gelu_backward.cpp
+++ b/benchmarks/cpp/gelu_backward.cpp
@@ -193,8 +193,8 @@ static void NvFuserScheduler_GeluBackward_RunFusion(
   C10_CUDA_CHECK(cudaDeviceSynchronize());
 
   for (auto _ : benchmark_state) {
-    outputs = ke.runFusion(
-        c10::ArrayRef<c10::IValue>(inputs), heuristic_params->lparams);
+    outputs =
+        ke.run(c10::ArrayRef<c10::IValue>(inputs), heuristic_params->lparams);
     C10_CUDA_CHECK(cudaDeviceSynchronize());
     clearL2Cache();
   }
@@ -252,8 +252,8 @@ static void NvFuserScheduler_GeluBackward_RunFusion_CpuOnly(
   ke.compile(&fusion, inputs, heuristic_params->lparams);
 
   for (auto _ : benchmark_state) {
-    outputs = ke.runFusion(
-        c10::ArrayRef<c10::IValue>(inputs), heuristic_params->lparams);
+    outputs =
+        ke.run(c10::ArrayRef<c10::IValue>(inputs), heuristic_params->lparams);
   }
 }
 

--- a/benchmarks/cpp/gelu_backward.cpp
+++ b/benchmarks/cpp/gelu_backward.cpp
@@ -163,7 +163,7 @@ static void NvFuserScheduler_GeluBackward_Compile(
 
   for (auto _ : benchmark_state) {
     KernelExecutor ke;
-    ke.compileFusion(&fusion, inputs, heuristic_params->lparams);
+    ke.compile(&fusion, inputs, heuristic_params->lparams);
   }
 }
 
@@ -188,7 +188,7 @@ static void NvFuserScheduler_GeluBackward_RunFusion(
       &fusion, SchedulerType::PointWise, c10::ArrayRef<c10::IValue>(inputs));
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs, heuristic_params->lparams);
+  ke.compile(&fusion, inputs, heuristic_params->lparams);
 
   C10_CUDA_CHECK(cudaDeviceSynchronize());
 
@@ -219,7 +219,7 @@ static void NvFuserScheduler_GeluBackward_RunFusion_GpuOnly(
       &fusion, SchedulerType::PointWise, c10::ArrayRef<c10::IValue>(inputs));
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs, heuristic_params->lparams);
+  ke.compile(&fusion, inputs, heuristic_params->lparams);
 
   runBenchmarkIterations(
       benchmark_state, &ke, inputs, heuristic_params->lparams);
@@ -249,7 +249,7 @@ static void NvFuserScheduler_GeluBackward_RunFusion_CpuOnly(
 
   KernelExecutor ke;
   ke.setExecuteKernelFlag(false);
-  ke.compileFusion(&fusion, inputs, heuristic_params->lparams);
+  ke.compile(&fusion, inputs, heuristic_params->lparams);
 
   for (auto _ : benchmark_state) {
     outputs = ke.runFusion(

--- a/benchmarks/cpp/indexselect.cpp
+++ b/benchmarks/cpp/indexselect.cpp
@@ -164,7 +164,7 @@ static void NvFuserScheduler_IndexSelect_RunFusion(
   at::Tensor output = at::empty_like(inputs[0].toTensor());
 
   for (auto _ : benchmark_state) {
-    ke.runFusion(
+    ke.run(
         c10::ArrayRef<c10::IValue>(inputs),
         {output},
         heuristic_params->lparams);

--- a/benchmarks/cpp/indexselect.cpp
+++ b/benchmarks/cpp/indexselect.cpp
@@ -133,7 +133,7 @@ static void NvFuserScheduler_IndexSelect_Compile(
 
   for (auto _ : benchmark_state) {
     KernelExecutor ke;
-    ke.compileFusion(
+    ke.compile(
         &fusion, c10::ArrayRef<c10::IValue>(inputs), heuristic_params->lparams);
   }
 }
@@ -156,7 +156,7 @@ static void NvFuserScheduler_IndexSelect_RunFusion(
       &fusion, SchedulerType::PointWise, c10::ArrayRef<c10::IValue>(inputs));
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion, c10::ArrayRef<c10::IValue>(inputs), heuristic_params->lparams);
 
   C10_CUDA_CHECK(cudaDeviceSynchronize());

--- a/benchmarks/cpp/lstm_cell.cpp
+++ b/benchmarks/cpp/lstm_cell.cpp
@@ -188,8 +188,8 @@ static void NvFuserScheduler_LstmCell_RunFusion(
   C10_CUDA_CHECK(cudaDeviceSynchronize());
 
   for (auto _ : benchmark_state) {
-    outputs = ke.runFusion(
-        c10::ArrayRef<c10::IValue>(inputs), heuristic_params->lparams);
+    outputs =
+        ke.run(c10::ArrayRef<c10::IValue>(inputs), heuristic_params->lparams);
     C10_CUDA_CHECK(cudaDeviceSynchronize());
   }
 }
@@ -264,8 +264,8 @@ static void NvFuserScheduler_LstmCell_RunFusion_CpuOnly(
   ke.compile(&fusion, inputs);
 
   for (auto _ : benchmark_state) {
-    outputs = ke.runFusion(
-        c10::ArrayRef<c10::IValue>(inputs), heuristic_params->lparams);
+    outputs =
+        ke.run(c10::ArrayRef<c10::IValue>(inputs), heuristic_params->lparams);
   }
 }
 

--- a/benchmarks/cpp/lstm_cell.cpp
+++ b/benchmarks/cpp/lstm_cell.cpp
@@ -156,7 +156,7 @@ static void NvFuserScheduler_LstmCell_Compile(
 
   for (auto _ : benchmark_state) {
     KernelExecutor ke;
-    ke.compileFusion(&fusion, inputs);
+    ke.compile(&fusion, inputs);
   }
 }
 
@@ -183,7 +183,7 @@ static void NvFuserScheduler_LstmCell_RunFusion(
       &fusion, SchedulerType::PointWise, c10::ArrayRef<c10::IValue>(inputs));
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
 
   C10_CUDA_CHECK(cudaDeviceSynchronize());
 
@@ -221,7 +221,7 @@ static void NvFuserScheduler_LstmCell_RunFusion_GpuOnly(
       &fusion, SchedulerType::PointWise, c10::ArrayRef<c10::IValue>(inputs));
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
 
   runBenchmarkIterations(
       benchmark_state, &ke, inputs, heuristic_params->lparams);
@@ -261,7 +261,7 @@ static void NvFuserScheduler_LstmCell_RunFusion_CpuOnly(
 
   KernelExecutor ke;
   ke.setExecuteKernelFlag(false);
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
 
   for (auto _ : benchmark_state) {
     outputs = ke.runFusion(

--- a/benchmarks/cpp/matmul.cpp
+++ b/benchmarks/cpp/matmul.cpp
@@ -176,7 +176,7 @@ static void SingleMatmulBase(
   // Compile kernel
   auto launch_constraints = LaunchParams();
   KernelExecutor ke;
-  ke.compileFusion(fusion, args, launch_constraints, cparams);
+  ke.compile(fusion, args, launch_constraints, cparams);
   NVF_CHECK(
       getBankConflictInfo(ke.kernel(), launch_constraints).empty(),
       "Shared memory bank conflict not removed.");
@@ -357,7 +357,7 @@ static void SingleMatmulPartitionedK(
   // Compile kernel
   KernelExecutor ke;
   auto lparams = LaunchParams();
-  ke.compileFusion(fusion, args, lparams, cparams);
+  ke.compile(fusion, args, lparams, cparams);
   NVF_CHECK(
       getBankConflictInfo(ke.kernel(), lparams).empty(),
       "Shared memory bank conflict not removed.");
@@ -462,7 +462,7 @@ static void NvFuserScheduler_MatmulSplitKReduction(
 
   // Compile kernel
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       fusion, args, heuristic_params->lparams, heuristic_params->cparams);
 
   NVF_CHECK(

--- a/benchmarks/cpp/matmul.cpp
+++ b/benchmarks/cpp/matmul.cpp
@@ -184,7 +184,7 @@ static void SingleMatmulBase(
   std::vector<c10::IValue> aten_inputs({inputs.first, inputs.second});
 
   // Warm up run
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
   checkMatch(expected_output, outputs.at(0).to(at::kDouble), k);
 
   runBenchmarkIterations(benchmark_state, &ke, aten_inputs);
@@ -363,7 +363,7 @@ static void SingleMatmulPartitionedK(
       "Shared memory bank conflict not removed.");
 
   // Warm up run
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   checkMatch(expected_output, outputs.at(0).to(at::kDouble), Ki);
 
@@ -470,7 +470,7 @@ static void NvFuserScheduler_MatmulSplitKReduction(
       "Shared memory bank conflict not removed.");
 
   // Warm up run
-  auto outputs = ke.runFusion(aten_inputs, heuristic_params->lparams);
+  auto outputs = ke.run(aten_inputs, heuristic_params->lparams);
 
   checkMatch(expected_output, outputs.at(0).to(at::kDouble), splitk_factor);
 

--- a/benchmarks/cpp/softmax.cpp
+++ b/benchmarks/cpp/softmax.cpp
@@ -106,7 +106,7 @@ static void NvFuserScheduler_Softmax_WarpReduceReference(
   scheduler->schedule(fusion, heuristic_params.get());
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, aten_inputs);
+  ke.compile(fusion, aten_inputs);
 
   runBenchmarkIterations(benchmark_state, &ke, aten_inputs);
 
@@ -153,7 +153,7 @@ static void NvFuserScheduler_Softmax_WarpReduce(
   }
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, aten_inputs);
+  ke.compile(fusion, aten_inputs);
 
   runBenchmarkIterations(benchmark_state, &ke, aten_inputs);
 

--- a/benchmarks/cpp/utils.cpp
+++ b/benchmarks/cpp/utils.cpp
@@ -230,8 +230,8 @@ int64_t runBenchmarkIterations(
   int64_t io_bytes = getSizeOfInputs(aten_inputs);
   {
     // Warm-up run
-    auto cg_outputs = fusion_executor->runFusion(
-        aten_inputs, launch_constraints, compile_params);
+    auto cg_outputs =
+        fusion_executor->run(aten_inputs, launch_constraints, compile_params);
     io_bytes += getSizeOfOutputs(cg_outputs);
   }
 
@@ -246,8 +246,8 @@ int64_t runBenchmarkIterations(
     clearL2Cache();
     FusionProfiler::start();
     FusionProfiler::createSegments(1);
-    auto cg_outputs = fusion_executor->runFusion(
-        aten_inputs, launch_constraints, compile_params);
+    auto cg_outputs =
+        fusion_executor->run(aten_inputs, launch_constraints, compile_params);
     FusionProfiler::stop();
     benchmark_state.SetIterationTime(
         FusionProfiler::profile().kernel_time_ms / 1000.0);

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -159,7 +159,7 @@ void HostIrExecutor::handle(PostOnStream* post_ir) {
       DynamicTransform::concretizeFusion(fusion, input_IValues);
       ke.compile(fusion, input_IValues);
     }
-    outputs = ke.runFusion(input_IValues);
+    outputs = ke.run(input_IValues);
     if (!params_.cache_fusion_executor) {
       fe_.erase(hu);
     }

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -157,7 +157,7 @@ void HostIrExecutor::handle(PostOnStream* post_ir) {
     if (!ke.isCompiled()) {
       Fusion* fusion = hu->fusion_to_execute();
       DynamicTransform::concretizeFusion(fusion, input_IValues);
-      ke.compileFusion(fusion, input_IValues);
+      ke.compile(fusion, input_IValues);
     }
     outputs = ke.runFusion(input_IValues);
     if (!params_.cache_fusion_executor) {

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -370,7 +370,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
       if (user_sched.heuristic_params == nullptr) {
         // Manual schedule
         if (!user_sched.executor->isCompiled()) {
-          user_sched.executor->compileFusion(
+          user_sched.executor->compile(
               user_sched.scheduled_fusion.get(),
               inputs,
               user_sched.fusion_id_,
@@ -381,7 +381,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
         // Automatic scheduler was used for UserSchedule.
         // Pass launch and compile params to compileFusion and runFusion.
         if (!user_sched.executor->isCompiled()) {
-          user_sched.executor->compileFusion(
+          user_sched.executor->compile(
               user_sched.scheduled_fusion.get(),
               KernelArgumentHolder::createKernelArgumentHolder(
                   inputs, getCommonDeviceCUDA(inputs)),

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -376,7 +376,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
               user_sched.fusion_id_,
               user_sched.device_id_);
         }
-        outputs = user_sched.executor->runFusion(inputs);
+        outputs = user_sched.executor->run(inputs);
       } else {
         // Automatic scheduler was used for UserSchedule.
         // Pass launch and compile params to compileFusion and runFusion.
@@ -391,7 +391,7 @@ std::vector<at::Tensor> FusionDefinition::execute(
               user_sched.fusion_id_,
               user_sched.device_id_);
         }
-        outputs = user_sched.executor->runFusion(
+        outputs = user_sched.executor->run(
             inputs,
             user_sched.heuristic_params->lparams,
             user_sched.heuristic_params->cparams);

--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -185,7 +185,7 @@ std::string KernelExecutor::getStructuredCode() const {
   return getStructuredCode(kernelString(), kernel()->indexType());
 }
 
-void KernelExecutor::compileFusion(
+void KernelExecutor::compile(
     Fusion* fusion,
     const KernelArgumentHolder& args,
     const LaunchParams& launch_constraints,

--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -1137,7 +1137,7 @@ at::Tensor findBufferForFusionOutput(
 }
 } // namespace
 
-std::vector<at::Tensor> KernelExecutor::runFusion(
+std::vector<at::Tensor> KernelExecutor::run(
     KernelArgumentHolder& args,
     const LaunchParams& launch_constraints,
     CompileParams compile_params,

--- a/csrc/runtime/executor.h
+++ b/csrc/runtime/executor.h
@@ -92,15 +92,15 @@ class KernelExecutor : public NonCopyable {
   // TODO: args shouldn't come in a reference here because we will append the
   // outputs to be able to send it to the kernel. For now none of the users are
   // reconsuming the args, so it is okay. It isn't done now because changing it
-  // from a reference makes a call as runFusion({}) ambiguous, and that is used
+  // from a reference makes a call as run({}) ambiguous, and that is used
   // in some places in the codebase.
-  NVF_API std::vector<at::Tensor> runFusion(
+  NVF_API std::vector<at::Tensor> run(
       KernelArgumentHolder& args,
       const LaunchParams& launch_constraints = LaunchParams(),
       CompileParams compile_params = CompileParams(),
       std::vector<at::Tensor> outputs = {});
 
-  std::vector<at::Tensor> runFusion(
+  std::vector<at::Tensor> run(
       const at::ArrayRef<c10::IValue>& inputs,
       const std::vector<at::Tensor>& outputs,
       const LaunchParams& launch_constraints = LaunchParams(),
@@ -111,15 +111,15 @@ class KernelExecutor : public NonCopyable {
     if (opt_code.has_value()) {
       args.setCacheId(*opt_code);
     }
-    return runFusion(args, launch_constraints, compile_params, outputs);
+    return run(args, launch_constraints, compile_params, outputs);
   }
 
-  std::vector<at::Tensor> runFusion(
+  std::vector<at::Tensor> run(
       const at::ArrayRef<c10::IValue>& inputs,
       const LaunchParams& launch_constraints = LaunchParams(),
       CompileParams compile_params = CompileParams(),
       const std::optional<size_t>& opt_code = std::nullopt) {
-    return runFusion(inputs, {}, launch_constraints, compile_params, opt_code);
+    return run(inputs, {}, launch_constraints, compile_params, opt_code);
   }
 
   // Register a lowering hooks that are called to modify the GpuLower object

--- a/csrc/runtime/executor.h
+++ b/csrc/runtime/executor.h
@@ -42,7 +42,7 @@ class KernelExecutor : public NonCopyable {
   //! To compile a fusion with the 32-bit index type, CompileParams
   //! must be passed in. There used to be an index type associated
   //! with KernelArgumentHolder, but it is no longer the case.
-  NVF_API void compileFusion(
+  NVF_API void compile(
       Fusion* fusion,
       const KernelArgumentHolder& args,
       const LaunchParams& launch_constraints,
@@ -56,25 +56,25 @@ class KernelExecutor : public NonCopyable {
   // TODO: merge it with the overload above.
   //! This API is merely here so we don't have to go back and update all cpp
   //! tests.
-  void compileFusion(
+  void compile(
       Fusion* fusion,
       const at::ArrayRef<c10::IValue>& inputs = {},
       const LaunchParams& launch_constraints = LaunchParams(),
       CompileParams compile_params = CompileParams()) {
     KernelArgumentHolder args =
         KernelArgumentHolder::createKernelArgumentHolder(inputs);
-    compileFusion(fusion, args, launch_constraints, compile_params);
+    compile(fusion, args, launch_constraints, compile_params);
   }
 
   //! Used by user defined schedules in python frontend
-  void compileFusion(
+  void compile(
       Fusion* fusion,
       const at::ArrayRef<c10::IValue>& inputs,
       int64_t fusion_id,
       int64_t concrete_id) {
     KernelArgumentHolder args =
         KernelArgumentHolder::createKernelArgumentHolder(inputs);
-    compileFusion(
+    compile(
         fusion,
         args,
         LaunchParams(),

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -595,7 +595,7 @@ std::vector<at::Tensor> FusionKernelRuntime::runKernelWithInput(
   if (executor.groupId() < 0) {
     executor.setGroupId(group_id);
   }
-  auto outputs = executor.runFusion(args, launch_params, compile_params);
+  auto outputs = executor.run(args, launch_params, compile_params);
 
   return outputs;
 }

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -625,7 +625,7 @@ void FusionKernelRuntime::compileKernel(
   NVF_ERROR(
       heuristic_params->cparams.index_type.has_value(),
       "Kernel index type is not defined.");
-  executors_.at(group_id).compileFusion(
+  executors_.at(group_id).compile(
       fusion_to_run.get(),
       args,
       heuristic_params->lparams,

--- a/examples/sinh_extension/main.cpp
+++ b/examples/sinh_extension/main.cpp
@@ -35,8 +35,8 @@ at::Tensor sinh_nvfuser(const at::Tensor& input) {
       SchedulerEntry::scheduleWith(&fusion, SchedulerType::PointWise, {input});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input}, heuristic_params->lparams);
-  auto outputs = ke.runFusion({input}, heuristic_params->lparams);
+  ke.compile(&fusion, {input}, heuristic_params->lparams);
+  auto outputs = ke.run({input}, heuristic_params->lparams);
 
   return outputs[0];
 }

--- a/examples/sinh_libtorch/main.cpp
+++ b/examples/sinh_libtorch/main.cpp
@@ -32,8 +32,8 @@ at::Tensor sinh_nvfuser(const at::Tensor& input) {
       &fusion, SchedulerType::PointWise, {input});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input}, heuristic_params->lparams);
-  auto outputs = ke.runFusion({input}, heuristic_params->lparams);
+  ke.compile(&fusion, {input}, heuristic_params->lparams);
+  auto outputs = ke.run({input}, heuristic_params->lparams);
 
   return outputs[0];
 }

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -1026,7 +1026,7 @@ TEST_F(AliasTest, ReuseBuffer_KernelExecutor) {
   auto expected_tensor = tensor + 1.0;
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {tensor});
+  ke.compile(&fusion, {tensor});
   ke.runFusion({tensor}, {tensor});
   EXPECT_TRUE(tensor.allclose(expected_tensor));
 }
@@ -1231,7 +1231,7 @@ TEST_F(AliasTest, KernelExecutor) {
   KernelExecutor ke;
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor in_tensor = at::randn({10, 10}, options);
-  ke.compileFusion(&fusion, {in_tensor});
+  ke.compile(&fusion, {in_tensor});
   at::Tensor out_tensor = ke.runFusion({in_tensor})[0];
   EXPECT_EQ(out_tensor.data_ptr(), in_tensor.data_ptr());
 }

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -1027,7 +1027,7 @@ TEST_F(AliasTest, ReuseBuffer_KernelExecutor) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {tensor});
-  ke.runFusion({tensor}, {tensor});
+  ke.run({tensor}, {tensor});
   EXPECT_TRUE(tensor.allclose(expected_tensor));
 }
 
@@ -1232,7 +1232,7 @@ TEST_F(AliasTest, KernelExecutor) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor in_tensor = at::randn({10, 10}, options);
   ke.compile(&fusion, {in_tensor});
-  at::Tensor out_tensor = ke.runFusion({in_tensor})[0];
+  at::Tensor out_tensor = ke.run({in_tensor})[0];
   EXPECT_EQ(out_tensor.data_ptr(), in_tensor.data_ptr());
 }
 

--- a/tests/cpp/test_alias_analysis.cpp
+++ b/tests/cpp/test_alias_analysis.cpp
@@ -186,7 +186,7 @@ TEST_F(AliasAnalysisTest, View_ForwardExpandedBroadcast) {
   at::Tensor in_tensor =
       at::randn({4, 5}).cuda().as_strided({4, 5, 6}, {5, 1, 0});
   ke.compile(&fusion, {in_tensor});
-  at::Tensor out_tensor = ke.runFusion({in_tensor})[0];
+  at::Tensor out_tensor = ke.run({in_tensor})[0];
 
   EXPECT_THAT(out_tensor.strides(), ElementsAre(1, 0));
 }

--- a/tests/cpp/test_alias_analysis.cpp
+++ b/tests/cpp/test_alias_analysis.cpp
@@ -185,7 +185,7 @@ TEST_F(AliasAnalysisTest, View_ForwardExpandedBroadcast) {
   KernelExecutor ke;
   at::Tensor in_tensor =
       at::randn({4, 5}).cuda().as_strided({4, 5, 6}, {5, 1, 0});
-  ke.compileFusion(&fusion, {in_tensor});
+  ke.compile(&fusion, {in_tensor});
   at::Tensor out_tensor = ke.runFusion({in_tensor})[0];
 
   EXPECT_THAT(out_tensor.strides(), ElementsAre(1, 0));

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -60,7 +60,7 @@ TEST_F(AllocationDomainTest, TransposedIntermediate) {
 
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
@@ -99,7 +99,7 @@ TEST_F(AllocationDomainTest, NCHW4d_To_NHWC4d) {
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), {t0});
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -138,7 +138,7 @@ TEST_F(AllocationDomainTest, NCHW4d_To_NHWC1d) {
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), {t0});
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -178,7 +178,7 @@ TEST_F(AllocationDomainTest, NCHW4d_To_NHWC2d) {
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), {t0});
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -225,7 +225,7 @@ TEST_F(AllocationDomainTest, Tensor3d_To_NHWC3d) {
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), {t0});
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -285,7 +285,7 @@ TEST_F(AllocationDomainTest, Tensor3d_To_NHWC4d_FwdBwd) {
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), {t0});
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -342,11 +342,11 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Stride mismatch with contiguity info")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -401,11 +401,11 @@ TEST_F(AllocationDomainTest, NHWC1d_To_NHWC4d) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "splitting one dimension into discontiguous dimensions is not allowed in allocation domain")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -457,11 +457,11 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC1d) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Stride mismatch with contiguity info")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -518,11 +518,11 @@ TEST_F(AllocationDomainTest, NHWC1d_To_NHWC1d) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "splitting one dimension into discontiguous dimensions is not")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -586,11 +586,11 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "splitting one dimension into discontiguous dimensions is not allowed in allocation domain")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -651,11 +651,11 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d_cacheBefore) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Stride mismatch with contiguity info")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -728,11 +728,11 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_cacheBefore) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "splitting one dimension into discontiguous dimensions is not allowed in allocation domain")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -793,11 +793,11 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d_cacheAfter) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Stride mismatch with contiguity info")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -864,11 +864,11 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_cacheAfter) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "merging of discontiguous dimensions is not allowed in allocation domain")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -936,11 +936,11 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d_cacheFork) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Stride mismatch with contiguity info")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -1026,11 +1026,11 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_cacheFork) {
   ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0_wrong_format}); },
+      [&]() { ke.run({t0_wrong_format}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "splitting one dimension into discontiguous dimensions is not allowed in allocation domain")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
 
@@ -1227,7 +1227,7 @@ TEST_F(AllocationDomainTest, VectorizeOverlappingTensor) {
 
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -1277,7 +1277,7 @@ TEST_F(AllocationDomainTest, Issue1290_ReplayCasPFailedDueToDifferentRanks) {
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
   KernelExecutor ke;
   ke.compile(&fusion, {in_tensor});
-  at::Tensor out_tensor = ke.runFusion({in_tensor})[0];
+  at::Tensor out_tensor = ke.run({in_tensor})[0];
   EXPECT_THAT(out_tensor.sizes(), ElementsAre(2));
 }
 

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -59,7 +59,7 @@ TEST_F(AllocationDomainTest, TransposedIntermediate) {
   at::Tensor t0 = at::randn({32, 32}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
   auto cg_outputs = ke.runFusion({t0});
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -97,7 +97,7 @@ TEST_F(AllocationDomainTest, NCHW4d_To_NHWC4d) {
   at::Tensor t0 = at::randn({n, c, h, w}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   auto cg_outputs = ke.runFusion({t0});
 
@@ -136,7 +136,7 @@ TEST_F(AllocationDomainTest, NCHW4d_To_NHWC1d) {
   at::Tensor t0 = at::randn({n, c, h, w}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   auto cg_outputs = ke.runFusion({t0});
 
@@ -176,7 +176,7 @@ TEST_F(AllocationDomainTest, NCHW4d_To_NHWC2d) {
   at::Tensor t0 = at::randn({n, c, h, w}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   auto cg_outputs = ke.runFusion({t0});
 
@@ -223,7 +223,7 @@ TEST_F(AllocationDomainTest, Tensor3d_To_NHWC3d) {
   at::Tensor t0 = at::randn({n1, n2, h * w * c}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   auto cg_outputs = ke.runFusion({t0});
 
@@ -283,7 +283,7 @@ TEST_F(AllocationDomainTest, Tensor3d_To_NHWC4d_FwdBwd) {
   at::Tensor t0 = at::randn({n1, n2, c * h * w}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   auto cg_outputs = ke.runFusion({t0});
 
@@ -339,7 +339,7 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -398,7 +398,7 @@ TEST_F(AllocationDomainTest, NHWC1d_To_NHWC4d) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -454,7 +454,7 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC1d) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -515,7 +515,7 @@ TEST_F(AllocationDomainTest, NHWC1d_To_NHWC1d) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -583,7 +583,7 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -648,7 +648,7 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d_cacheBefore) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -725,7 +725,7 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_cacheBefore) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -790,7 +790,7 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d_cacheAfter) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -861,7 +861,7 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_cacheAfter) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -933,7 +933,7 @@ TEST_F(AllocationDomainTest, NHWC4d_To_NHWC4d_cacheFork) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -1023,7 +1023,7 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_cacheFork) {
       t0_wrong_format.as_strided({n, c, h, w}, {h * w * c, 1, w * c, c});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
 
   EXPECT_THAT(
       [&]() { ke.runFusion({t0_wrong_format}); },
@@ -1226,7 +1226,7 @@ TEST_F(AllocationDomainTest, VectorizeOverlappingTensor) {
       at::randn({4 * 5 * 7}).cuda().as_strided({4, 5, 7}, {7, 4, 1});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -1276,7 +1276,7 @@ TEST_F(AllocationDomainTest, Issue1290_ReplayCasPFailedDueToDifferentRanks) {
 
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {in_tensor});
+  ke.compile(&fusion, {in_tensor});
   at::Tensor out_tensor = ke.runFusion({in_tensor})[0];
   EXPECT_THAT(out_tensor.sizes(), ElementsAre(2));
 }

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -65,7 +65,7 @@ TEST_P(CircularBufferingTest, SingleDim1) {
   auto t0 = at::randn({1000}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   // Given computeAt axis 1, the axis_extent is I0/128.
   constexpr int64_t axis_extent = 8;
@@ -113,7 +113,7 @@ TEST_P(CircularBufferingTest, SingleDim2) {
   auto t0 = at::randn({1000}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   // Given computeAt axis 1, the axis_extent is I0/128.
   constexpr int64_t axis_extent = 8;
@@ -168,7 +168,7 @@ TEST_P(CircularBufferingTest, SingleDim3) {
   auto t0 = at::randn({1000}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   // Given computeAt axis 2, the axis_extent is 128/32.
   constexpr int64_t axis_extent = 4;
@@ -220,7 +220,7 @@ TEST_P(CircularBufferingTest, SingleDimUnswitch1) {
   auto t0 = at::randn({1000}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   // Given computeAt axis -1 and axis 3 is parallelized with TIDx, the axis
   // extent is 4.
@@ -272,7 +272,7 @@ TEST_P(CircularBufferingTest, SingleDimUnswitch2) {
   auto t0 = at::randn({1000}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   // Given computeAt axis -1 and axis 3 is parallelized with TIDx, the axis
   // extent is 4.
@@ -326,7 +326,7 @@ TEST_P(CircularBufferingTest, SingleDimUnroll) {
   auto t0 = at::randn({199}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   // Given computeAt axis -1 and axis 4 is parallelized with TIDx, the axis
   // extent is 2.
@@ -373,7 +373,7 @@ TEST_P(CircularBufferingTest, SingleDimVectorize) {
   auto t0 = at::randn({200}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   // Given computeAt axis 2 and axis 1 is parallelized with TIDx, the axis
   // extent is I0/128.
@@ -425,7 +425,7 @@ TEST_P(CircularBufferingTest, MultipleTensors) {
   auto t1 = at::randn({500}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
 
   // Given computeAt axis 1, the axis extent is I0/32/4.
   constexpr int64_t axis_extent = 1;
@@ -476,7 +476,7 @@ TEST_P(CircularBufferingTest, NestedTensors) {
   auto t0 = at::randn({1001}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   // Given computeAt axis 1 for tv2, the axis extent is I0/32/4 = 8.
   // Given computeAt axis 3 for tv3 and axis 3 is parallelized with TIDx,
@@ -570,7 +570,7 @@ TEST_P(CircularBufferingTest, SmemBlockGemmCache) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   constexpr int64_t axis_extent = 2;
   if (axis_extent < number_of_stages) {
@@ -624,7 +624,7 @@ TEST_P(CircularBufferingTest, Vector) {
 
   auto t0 = at::randn({200}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   constexpr int64_t axis_extent = 8;
   if (axis_extent < number_of_stages) {
@@ -681,10 +681,10 @@ TEST_P(CircularBufferingTest, CpAsync1) {
   KernelExecutor ke;
   // requires ampere+ GPU
   if (!deviceMajorMinorCheck(8)) {
-    ASSERT_ANY_THROW(ke.compileFusion(&fusion, {t0, t1}));
+    ASSERT_ANY_THROW(ke.compile(&fusion, {t0, t1}));
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
   }
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   auto ref = t0 + t1;
@@ -734,10 +734,10 @@ TEST_P(CircularBufferingTest, CpAsync2) {
   KernelExecutor ke;
   // requires ampere+ GPU
   if (!deviceMajorMinorCheck(8)) {
-    ASSERT_ANY_THROW(ke.compileFusion(&fusion, {t0, t1}));
+    ASSERT_ANY_THROW(ke.compile(&fusion, {t0, t1}));
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
   }
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   auto ref = t0 + t1;
@@ -795,7 +795,7 @@ TEST_P(CircularBufferingTest, NoSync) {
   NVF_ERROR(!sync_inserted, "Un-expected block sync inserted");
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   auto ref = t0 + t1;
@@ -973,7 +973,7 @@ TEST_F(NVFuserTest, ElectSyncCompatibility) {
   // a single thread.
   KernelExecutor ke;
   try {
-    ke.compileFusion(fusion.get(), {t0});
+    ke.compile(fusion.get(), {t0});
   } catch (const std::exception& e) {
     const char* reference =
         R"(This thread-parallelized TensorView T2_s_float[ iblockIdx.x15{( ceilDiv(( ceilDiv(( ceilDiv(( ( ( (( (( getMetaData(T0) )).logical_size ))[0] ) * ( (( (( getMetaData(T0) )).logical_size ))[1] ) ) * ( (( (( getMetaData(T0) )).logical_size ))[2] ) ), 256) ), 4) ), 2) )}, iS16{2}, ithreadIdx.x14{4}, iB12{256} ] ca_pos( 2 ) is incorrectly contained within a If-Then-Else with the ElectSync predicate.)";
@@ -1024,7 +1024,7 @@ TEST_P(TmaCircularBufferingTest, SingleDim) {
   at::Tensor t1 = at::exp(t0);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0});
+  ke.compile(fusion.get(), {t0});
 
   std::vector<at::Tensor> cg_outputs = ke.runFusion({t0});
   compare<float>(tensor_inner_dim, cg_outputs.front(), t1);
@@ -1077,7 +1077,7 @@ TEST_P(TmaCircularBufferingTest, SingleDimUnroll) {
   at::Tensor t1 = at::exp(t0);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0});
+  ke.compile(fusion.get(), {t0});
 
   int64_t axis_extent =
       ceilDiv(ceilDiv(tensor_inner_dim, bulk_inner_dim), unroll_dim);
@@ -1137,7 +1137,7 @@ TEST_P(TmaCircularBufferingTest, SingleDimUnswitch) {
   at::Tensor t1 = at::exp(t0);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0});
+  ke.compile(fusion.get(), {t0});
 
   int64_t axis_extent =
       ceilDiv(ceilDiv(tensor_inner_dim, bulk_inner_dim), unroll_dim);
@@ -1207,7 +1207,7 @@ TEST_P(TmaCircularBufferingTest, MultiDim) {
   at::Tensor t1 = at::exp(t0);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0});
+  ke.compile(fusion.get(), {t0});
 
   std::vector<at::Tensor> cg_outputs = ke.runFusion({t0});
   compare<float>(tensor_outer_dim, tensor_inner_dim, cg_outputs.front(), t1);
@@ -1269,7 +1269,7 @@ TEST_P(TmaCircularBufferingTest, Pointwise) {
   at::Tensor t2 = t0 + t1;
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1});
+  ke.compile(fusion.get(), {t0, t1});
 
   std::vector<at::Tensor> cg_outputs = ke.runFusion({t0, t1});
   compare<float>(tensor_outer_dim, tensor_inner_dim, cg_outputs.front(), t2);
@@ -1336,7 +1336,7 @@ TEST_P(TmaCircularBufferingTest, PointwiseCpAsync) {
   at::Tensor t2 = t0 + t1;
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1});
+  ke.compile(fusion.get(), {t0, t1});
 
   std::vector<at::Tensor> cg_outputs = ke.runFusion({t0, t1});
   compare<float>(tensor_outer_dim, tensor_inner_dim, cg_outputs.front(), t2);
@@ -1394,7 +1394,7 @@ TEST_P(TmaCircularBufferingTest, Reduction) {
   at::Tensor t1 = sum(t0, {-1});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0});
+  ke.compile(fusion.get(), {t0});
 
   std::vector<at::Tensor> cg_outputs = ke.runFusion({t0});
   compare<float>(tensor_outer_dim, cg_outputs.front(), t1);
@@ -1520,7 +1520,7 @@ TEST_P(TmaCircularBufferingTest, Persistent) {
 
   // Compile with KernelExecutor directly to avoid scheduling
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {at_tv0});
+  ke.compile(fusion.get(), {at_tv0});
   std::vector<at::Tensor> cg_outputs = ke.runFusion({at_tv0});
 
   std::tuple<at::Tensor, at::Tensor> at_var_mean =
@@ -1641,7 +1641,7 @@ TEST_P(TmaCircularBufferingTest, Matmul) {
       (t0.unsqueeze(/*dim=*/-1) * t1.unsqueeze(/*dim=*/0)).sum(/*dim=*/1);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1});
+  ke.compile(fusion.get(), {t0, t1});
 
   std::vector<at::Tensor> cg_outputs = ke.runFusion({t0, t1});
   compare<float>(
@@ -1755,7 +1755,7 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   at::Tensor aten_output = (t0 * t1).sum(/*dim=*/1);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1});
+  ke.compile(fusion.get(), {t0, t1});
 
   std::vector<at::Tensor> cg_outputs = ke.runFusion({t0, t1});
   compare<float>(

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -70,11 +70,11 @@ TEST_P(CircularBufferingTest, SingleDim1) {
   // Given computeAt axis 1, the axis_extent is I0/128.
   constexpr int64_t axis_extent = 8;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto ref = t0 + 1;
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
@@ -118,11 +118,11 @@ TEST_P(CircularBufferingTest, SingleDim2) {
   // Given computeAt axis 1, the axis_extent is I0/128.
   constexpr int64_t axis_extent = 8;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto ref = t0 + 1;
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
@@ -173,11 +173,11 @@ TEST_P(CircularBufferingTest, SingleDim3) {
   // Given computeAt axis 2, the axis_extent is 128/32.
   constexpr int64_t axis_extent = 4;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto ref = t0 + 2;
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
@@ -226,11 +226,11 @@ TEST_P(CircularBufferingTest, SingleDimUnswitch1) {
   // extent is 4.
   constexpr int64_t axis_extent = 4;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto ref = t0 + 2;
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
@@ -278,11 +278,11 @@ TEST_P(CircularBufferingTest, SingleDimUnswitch2) {
   // extent is 4.
   constexpr int64_t axis_extent = 4;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto ref = t0 + 1;
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
@@ -332,11 +332,11 @@ TEST_P(CircularBufferingTest, SingleDimUnroll) {
   // extent is 2.
   constexpr int64_t axis_extent = 2;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto ref = t0 + 2;
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
@@ -379,11 +379,11 @@ TEST_P(CircularBufferingTest, SingleDimVectorize) {
   // extent is I0/128.
   constexpr int64_t axis_extent = 2;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto ref = t0 + 1;
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
@@ -430,11 +430,11 @@ TEST_P(CircularBufferingTest, MultipleTensors) {
   // Given computeAt axis 1, the axis extent is I0/32/4.
   constexpr int64_t axis_extent = 1;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto ref = t0 + t1;
   testValidate(&fusion, cg_outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
@@ -483,11 +483,11 @@ TEST_P(CircularBufferingTest, NestedTensors) {
   // the axis extent is 4.
   constexpr int64_t axis_extent = 4;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto ref = t0 + 1;
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
@@ -574,11 +574,11 @@ TEST_P(CircularBufferingTest, SmemBlockGemmCache) {
 
   constexpr int64_t axis_extent = 2;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
   // The smem cache write in this test case is redundant predicated,
@@ -628,11 +628,11 @@ TEST_P(CircularBufferingTest, Vector) {
 
   constexpr int64_t axis_extent = 8;
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto ref = (t0 + 1).sum({0});
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
@@ -685,7 +685,7 @@ TEST_P(CircularBufferingTest, CpAsync1) {
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
   }
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref = t0 + t1;
 
@@ -738,7 +738,7 @@ TEST_P(CircularBufferingTest, CpAsync2) {
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
   }
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref = t0 + t1;
 
@@ -796,7 +796,7 @@ TEST_P(CircularBufferingTest, NoSync) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref = t0 + t1;
 
@@ -1026,7 +1026,7 @@ TEST_P(TmaCircularBufferingTest, SingleDim) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0});
 
-  std::vector<at::Tensor> cg_outputs = ke.runFusion({t0});
+  std::vector<at::Tensor> cg_outputs = ke.run({t0});
   compare<float>(tensor_inner_dim, cg_outputs.front(), t1);
   testValidate(fusion.get(), cg_outputs, {t0}, {t1}, __LINE__, __FILE__);
 }
@@ -1082,11 +1082,11 @@ TEST_P(TmaCircularBufferingTest, SingleDimUnroll) {
   int64_t axis_extent =
       ceilDiv(ceilDiv(tensor_inner_dim, bulk_inner_dim), unroll_dim);
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  std::vector<at::Tensor> cg_outputs = ke.runFusion({t0});
+  std::vector<at::Tensor> cg_outputs = ke.run({t0});
   compare<float>(tensor_inner_dim, cg_outputs.front(), t1);
   testValidate(fusion.get(), cg_outputs, {t0}, {t1}, __LINE__, __FILE__);
 }
@@ -1142,11 +1142,11 @@ TEST_P(TmaCircularBufferingTest, SingleDimUnswitch) {
   int64_t axis_extent =
       ceilDiv(ceilDiv(tensor_inner_dim, bulk_inner_dim), unroll_dim);
   if (axis_extent < number_of_stages) {
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
     return;
   }
 
-  std::vector<at::Tensor> cg_outputs = ke.runFusion({t0});
+  std::vector<at::Tensor> cg_outputs = ke.run({t0});
   compare<float>(tensor_inner_dim, cg_outputs.front(), t1);
   testValidate(fusion.get(), cg_outputs, {t0}, {t1}, __LINE__, __FILE__);
 }
@@ -1209,7 +1209,7 @@ TEST_P(TmaCircularBufferingTest, MultiDim) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0});
 
-  std::vector<at::Tensor> cg_outputs = ke.runFusion({t0});
+  std::vector<at::Tensor> cg_outputs = ke.run({t0});
   compare<float>(tensor_outer_dim, tensor_inner_dim, cg_outputs.front(), t1);
   testValidate(fusion.get(), cg_outputs, {t0}, {t1}, __LINE__, __FILE__);
 }
@@ -1271,7 +1271,7 @@ TEST_P(TmaCircularBufferingTest, Pointwise) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1});
 
-  std::vector<at::Tensor> cg_outputs = ke.runFusion({t0, t1});
+  std::vector<at::Tensor> cg_outputs = ke.run({t0, t1});
   compare<float>(tensor_outer_dim, tensor_inner_dim, cg_outputs.front(), t2);
   testValidate(fusion.get(), cg_outputs, {t0, t1}, {t2}, __LINE__, __FILE__);
 }
@@ -1338,7 +1338,7 @@ TEST_P(TmaCircularBufferingTest, PointwiseCpAsync) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1});
 
-  std::vector<at::Tensor> cg_outputs = ke.runFusion({t0, t1});
+  std::vector<at::Tensor> cg_outputs = ke.run({t0, t1});
   compare<float>(tensor_outer_dim, tensor_inner_dim, cg_outputs.front(), t2);
   testValidate(fusion.get(), cg_outputs, {t0, t1}, {t2}, __LINE__, __FILE__);
 }
@@ -1396,7 +1396,7 @@ TEST_P(TmaCircularBufferingTest, Reduction) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0});
 
-  std::vector<at::Tensor> cg_outputs = ke.runFusion({t0});
+  std::vector<at::Tensor> cg_outputs = ke.run({t0});
   compare<float>(tensor_outer_dim, cg_outputs.front(), t1);
   testValidate(fusion.get(), cg_outputs, {t0}, {t1}, __LINE__, __FILE__);
 }
@@ -1521,7 +1521,7 @@ TEST_P(TmaCircularBufferingTest, Persistent) {
   // Compile with KernelExecutor directly to avoid scheduling
   KernelExecutor ke;
   ke.compile(fusion.get(), {at_tv0});
-  std::vector<at::Tensor> cg_outputs = ke.runFusion({at_tv0});
+  std::vector<at::Tensor> cg_outputs = ke.run({at_tv0});
 
   std::tuple<at::Tensor, at::Tensor> at_var_mean =
       at::var_mean(at_tv0, {-1}, correction, keepdim);
@@ -1643,7 +1643,7 @@ TEST_P(TmaCircularBufferingTest, Matmul) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1});
 
-  std::vector<at::Tensor> cg_outputs = ke.runFusion({t0, t1});
+  std::vector<at::Tensor> cg_outputs = ke.run({t0, t1});
   compare<float>(
       tensor_outer_dim, tensor_inner_dim, cg_outputs.front(), aten_output);
   testValidate(
@@ -1757,7 +1757,7 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1});
 
-  std::vector<at::Tensor> cg_outputs = ke.runFusion({t0, t1});
+  std::vector<at::Tensor> cg_outputs = ke.run({t0, t1});
   compare<float>(
       tensor_outer_dim, tensor_inner_dim, cg_outputs.front(), aten_output);
   testValidate(

--- a/tests/cpp/test_combined_inner_outer_reduction.cpp
+++ b/tests/cpp/test_combined_inner_outer_reduction.cpp
@@ -637,7 +637,7 @@ TEST_F(CombinedSchedulerTest, CombinedReduction) {
   auto qv_aten_output = tv_input.to(at::kFloat).sum({0});
   KernelExecutor ke;
   ke.compile(&fusion, {tv_input}, launch_constraints, compile_params);
-  ke.runFusion(
+  ke.run(
       {tv_input},
       {tv_cg_output, qv_cg_output},
       launch_constraints,
@@ -814,7 +814,7 @@ TEST_F(CombinedSchedulerTest, CombinedReductionMultiPerBlock) {
   auto qv_aten_output = tv_input2.to(at::kFloat).sum({0});
   KernelExecutor ke;
   ke.compile(&fusion, {tv_input}, launch_constraints, compile_params);
-  ke.runFusion(
+  ke.run(
       {tv_input},
       {tv_cg_output, qv_cg_output},
       launch_constraints,
@@ -992,8 +992,8 @@ TEST_F(CombinedSchedulerTest, SharedMemoryPersistentVectFactor) {
       }
     }
   }
-  auto cg_outputs = ke.runFusion(
-      aten_inputs, heuristic_params->as<ReductionParams>()->lparams);
+  auto cg_outputs =
+      ke.run(aten_inputs, heuristic_params->as<ReductionParams>()->lparams);
   testValidate(&fusion_copy, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
 

--- a/tests/cpp/test_combined_inner_outer_reduction.cpp
+++ b/tests/cpp/test_combined_inner_outer_reduction.cpp
@@ -636,7 +636,7 @@ TEST_F(CombinedSchedulerTest, CombinedReduction) {
   at::Tensor qv_cg_output = at::empty({dim1}, options);
   auto qv_aten_output = tv_input.to(at::kFloat).sum({0});
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {tv_input}, launch_constraints, compile_params);
+  ke.compile(&fusion, {tv_input}, launch_constraints, compile_params);
   ke.runFusion(
       {tv_input},
       {tv_cg_output, qv_cg_output},
@@ -813,7 +813,7 @@ TEST_F(CombinedSchedulerTest, CombinedReductionMultiPerBlock) {
   at::Tensor tv_input2 = at::ones({dim0, dim1}, options);
   auto qv_aten_output = tv_input2.to(at::kFloat).sum({0});
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {tv_input}, launch_constraints, compile_params);
+  ke.compile(&fusion, {tv_input}, launch_constraints, compile_params);
   ke.runFusion(
       {tv_input},
       {tv_cg_output, qv_cg_output},
@@ -983,7 +983,7 @@ TEST_F(CombinedSchedulerTest, SharedMemoryPersistentVectFactor) {
       std::vector<TensorView*>{tv1};
   scheduler->schedule(&fusion, heuristic_params.get());
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   for (auto tv : fusion.allTvs()) {
     if (tv->getMemoryType() == MemoryType::Shared) {

--- a/tests/cpp/test_dynamic_transform.cpp
+++ b/tests/cpp/test_dynamic_transform.cpp
@@ -1212,7 +1212,7 @@ TEST_F(NVFuserTest, OptOutMutatorMutatedOutput) {
   KernelExecutor ke;
   ke.compile(fusion);
 
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   testValidate(fusion, outputs, {t0}, __LINE__, __FILE__);
 }
@@ -1249,7 +1249,7 @@ TEST_F(NVFuserTest, OptOutMutatorRedefinedConstant) {
   KernelExecutor ke;
   ke.compile(fusion);
 
-  auto outputs = ke.runFusion({3L});
+  auto outputs = ke.run({3L});
 
   testValidate(fusion, outputs, {3L}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_dynamic_transform.cpp
+++ b/tests/cpp/test_dynamic_transform.cpp
@@ -1210,7 +1210,7 @@ TEST_F(NVFuserTest, OptOutMutatorMutatedOutput) {
   inlineMost();
 
   KernelExecutor ke;
-  ke.compileFusion(fusion);
+  ke.compile(fusion);
 
   auto outputs = ke.runFusion({t0});
 
@@ -1247,7 +1247,7 @@ TEST_F(NVFuserTest, OptOutMutatorRedefinedConstant) {
   inlineMost();
 
   KernelExecutor ke;
-  ke.compileFusion(fusion);
+  ke.compile(fusion);
 
   auto outputs = ke.runFusion({3L});
 

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -208,7 +208,7 @@ TEST_F(NVFuserTest, FusionClear_CUDA) {
   at::Tensor input2 = at::randn_like(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input1, input2});
+  ke.compile(&fusion, {input1, input2});
   auto outputs = ke.runFusion({input1, input2});
 
   at::Tensor tv2_ref = input2 + 2.0;
@@ -814,7 +814,7 @@ TEST_F(NVFuserTest, FusionOuterSplit_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
   auto outputs = ke.runFusion({});
   const auto& output = outputs.at(0);
 
@@ -856,7 +856,7 @@ TEST_F(NVFuserTest, FusionCodeGen_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
   auto outputs = ke.runFusion({});
   const auto& output = outputs.at(0);
 
@@ -900,7 +900,7 @@ TEST_F(NVFuserTest, FusionCodeGen2_CUDA) {
   at::Tensor input2 = at::randn_like(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input1, input2});
+  ke.compile(&fusion, {input1, input2});
   auto outputs = ke.runFusion({input1, input2});
 
   at::Tensor tv2_ref = input2 + 2.0;
@@ -956,7 +956,7 @@ TEST_F(NVFuserTest, FusionSimplePWise_CUDA) {
   at::Tensor output = at::empty_like(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input1, input2});
+  ke.compile(&fusion, {input1, input2});
   ke.runFusion({input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + 2.0;
@@ -1014,7 +1014,7 @@ TEST_F(NVFuserTest, FusionSimplePWiseDtypeComplex_CUDA) {
   at::Tensor output = at::empty_like(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input1, input2});
+  ke.compile(&fusion, {input1, input2});
   ke.runFusion({input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + static_cast<c10::complex<double>>(scalar1);
@@ -1064,7 +1064,7 @@ TEST_F(NVFuserTest, FusionExecKernel_CUDA) {
   at::Tensor input2 = at::ones_like(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input1, input2});
+  ke.compile(&fusion, {input1, input2});
   auto outputs = ke.runFusion({input1, input2});
 
   at::Tensor check = at::full({1, 128}, 4, options);
@@ -1146,7 +1146,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt1_CUDA) {
       at::empty_like(aten_input, options), at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1200,7 +1200,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt2_CUDA) {
   at::Tensor input = at::randn({129, 127}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   testValidate(&fusion, cg_outputs, {input}, __LINE__, __FILE__);
@@ -1254,7 +1254,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt3_CUDA) {
   at::Tensor cg_output = at::empty_like(t0, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   ke.runFusion(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
@@ -1318,7 +1318,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt4_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1, t2, t3};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1354,7 +1354,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt5_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1389,7 +1389,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt6_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1450,7 +1450,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt7_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t2, t6};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1506,7 +1506,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt8_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t2, t6};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1575,7 +1575,7 @@ TEST_F(NVFuserTest, FusionComputeAtMultiConsumers_CUDA) {
       at::empty_like(aten_input, options), at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1645,7 +1645,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer1_CUDA) {
       at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1720,7 +1720,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer2_CUDA) {
   at::Tensor cg_output = at::empty_like(aten_input, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, {cg_output});
 
   testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
@@ -1801,7 +1801,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer3_CUDA) {
       at::empty_like(aten_input, options), at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1865,7 +1865,7 @@ TEST_F(NVFuserTest, FusionComputeAtNoCommonConsumer_CUDA) {
       at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1973,7 +1973,7 @@ TEST_F(NVFuserTest, FusionScalarInputs_CUDA) {
       at::Scalar(fl3)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   ke.runFusion(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
@@ -2025,7 +2025,7 @@ TEST_F(NVFuserTest, FusionLoopUnroll_CUDA) {
   at::Tensor input1 = at::randn({129, 13, 3}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input0, input1});
+  ke.compile(&fusion, {input0, input1});
   auto outputs = ke.runFusion({input0, input1});
 
   NVF_CHECK(outputs[0].equal(input0.add(input1.add(2.0))));
@@ -2174,7 +2174,7 @@ void test_op(
   cudaDeviceSynchronize();
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs_ivalues);
+  ke.compile(&fusion, aten_inputs_ivalues);
   ke.runFusion(aten_inputs_ivalues, output_vect);
   cudaDeviceSynchronize();
 
@@ -2714,12 +2714,12 @@ TEST_F(NVFuserTest, FusionFp8CastOps_CUDA) {
 
       if (!deviceMajorMinorCheck(9)) {
         ASSERT_THAT(
-            [&]() { ke.compileFusion(&fusion, inputs); },
+            [&]() { ke.compile(&fusion, inputs); },
             testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
                 "Reason: Fusion contains Float8_xxx values which was introduced in Hopper (9.0)")));
         GTEST_SKIP() << "skipping tests on pre-HOPPER GPUs";
       } else {
-        ke.compileFusion(&fusion, inputs);
+        ke.compile(&fusion, inputs);
         auto outputs = ke.runFusion(inputs);
 
         at::Tensor ref_output = input1.to(at_fp8_type).to(at_src_type);
@@ -2791,7 +2791,7 @@ TEST_F(NVFuserTest, FusionReduction1_CUDA) {
   at::Tensor cg_output = at::empty({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   ke.runFusion({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
@@ -2863,7 +2863,7 @@ TEST_F(NVFuserTest, FusionReduction2_CUDA) {
   at::Tensor input = at::randn({numel_x, numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   auto aten_output = input.to(at::kDouble).sum({1});
@@ -2914,7 +2914,7 @@ TEST_F(NVFuserTest, FusionReduction3_CUDA) {
   at::Tensor cg_output = at::empty({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, {cg_output});
 
   auto aten_output = aten_input.to(at::kDouble).sum({1});
@@ -2980,7 +2980,7 @@ TEST_F(NVFuserTest, FusionReduction4_CUDA) {
   at::Tensor t4 = at::randn({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1, t4});
+  ke.compile(&fusion, {t0, t1, t4});
   auto cg_outputs = ke.runFusion({t0, t1, t4});
 
   auto t2 = t0.add(t1);
@@ -3034,7 +3034,7 @@ TEST_F(NVFuserTest, FusionReduction5_CUDA) {
   at::Tensor cg_output = at::empty({bidy, tidx}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   ke.runFusion({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
@@ -3099,7 +3099,7 @@ TEST_F(NVFuserTest, FusionReduction6_CUDA) {
   at::Tensor input = at::randn({numel_x, numel_y, numel_z}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   auto aten_output = input.to(at::kDouble).sum({1, 2});
@@ -3131,7 +3131,7 @@ TEST_F(NVFuserTest, FusionMultiGridReduction_CUDA) {
   at::Tensor input = at::randn({numel_x, numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   testValidate(&fusion, cg_outputs, {input}, __LINE__, __FILE__);
@@ -3155,7 +3155,7 @@ TEST_F(NVFuserTest, FusionMultiGridReduction2_CUDA) {
   at::Tensor input = at::randn({4, 8}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_output = ke.runFusion({input});
   testValidate(&fusion, cg_output, {input}, __LINE__, __FILE__);
 }
@@ -3208,7 +3208,7 @@ TEST_F(NVFuserTest, FusionReductionTFT_CUDA) {
   at::Tensor cg_output = at::empty({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   ke.runFusion({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
@@ -3272,7 +3272,7 @@ TEST_F(NVFuserTest, FusionReductionOuterSplit_CUDA) {
   at::Tensor t4 = at::randn({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1, t4});
+  ke.compile(&fusion, {t0, t1, t4});
   auto cg_outputs = ke.runFusion({t0, t1, t4});
 
   auto t2 = t0.add(t1);
@@ -3331,7 +3331,7 @@ TEST_F(NVFuserTest, FusionBranches_CUDA) {
 
   std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -3378,7 +3378,7 @@ TEST_F(NVFuserTest, FusionSimpleBCast1_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t2, t3};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -3430,7 +3430,7 @@ TEST_F(NVFuserTest, FusionSimpleBCast2_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1, t4};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   ke.runFusion(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
@@ -3472,7 +3472,7 @@ TEST_F(NVFuserTest, FusionSimpleBCast3_CUDA) {
   at::Tensor cg_output = at::empty({x, y, z}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   ke.runFusion(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
@@ -3517,7 +3517,7 @@ TEST_F(NVFuserTest, FusionSimpleBCast4_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   ke.runFusion(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
@@ -3557,7 +3557,7 @@ TEST_F(NVFuserTest, FusionSimpleBCast5_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   ke.runFusion(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
@@ -3609,7 +3609,7 @@ TEST_F(NVFuserTest, FusionComplexBCast1_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t3, t6};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -3653,7 +3653,7 @@ TEST_F(NVFuserTest, FusionComplexBCast2_CUDA) {
   at::Tensor t4 = at::randn({x, y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t4});
+  ke.compile(&fusion, {t0, t4});
   auto cg_outputs = ke.runFusion({t0, t4});
 
   testValidate(&fusion, {cg_outputs}, {t0, t4}, __LINE__, __FILE__);
@@ -3727,7 +3727,7 @@ TEST_F(NVFuserTest, FusionSimpleGemm_CUDA) {
   at::Tensor t1 = at::randn({K, N}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1}, LaunchParams(1, -1, -1, 32, 4, 4));
+  ke.compile(&fusion, {t0, t1}, LaunchParams(1, -1, -1, 32, 4, 4));
   // Lets specify a few bounds in launch params to make sure it works
   ke.runFusion({t0, t1}, LaunchParams(1, -1, -1, 32, 4, 4));
 
@@ -3792,7 +3792,7 @@ TEST_F(NVFuserTest, FusionSoftmax1D_CUDA) {
   at::Tensor t3_output = at::empty_like(cg_output, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   ke.runFusion({t0}, {cg_output});
 
   auto aten_output = at::_softmax(t0.to(at::kDouble), -1, false);
@@ -3861,7 +3861,7 @@ TEST_F(NVFuserTest, FusionSoftmax1DNormalized_CUDA) {
   at::Tensor t3_output = at::empty({dimx}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   auto aten_output = at::_softmax(input.to(at::kDouble), -1, false);
@@ -3921,7 +3921,7 @@ TEST_F(NVFuserTest, FusionSoftmax3D_CUDA) {
   at::Tensor cg_output = at::empty({dimx, dimy, dimz}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   ke.runFusion({input}, {cg_output});
 
   auto aten_output = at::_softmax(input.to(at::kDouble), -1, false);
@@ -3996,7 +3996,7 @@ TEST_F(NVFuserTest, FusionSoftmax3DNormalized_CUDA) {
   at::Tensor t3_output = at::empty({dimx, dimy, dimz}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   auto aten_output = at::_softmax(input.to(at::kDouble), -1, false);
@@ -4082,7 +4082,7 @@ TEST_F(NVFuserTest, FusionGridReduction1_CUDA) {
   at::Tensor cg_output = at::empty({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   ke.runFusion({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
@@ -4142,7 +4142,7 @@ TEST_F(NVFuserTest, FusionGridReduction2_CUDA) {
   at::Tensor input = at::randn({numel_x, numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   auto aten_output = input.to(at::kDouble).sum({1});
@@ -4204,7 +4204,7 @@ TEST_F(NVFuserTest, FusionGridReduction3dim1_CUDA) {
   at::Tensor cg_output = at::empty({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   ke.runFusion({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
@@ -4263,7 +4263,7 @@ TEST_F(NVFuserTest, FusionGridReduction3dim0_CUDA) {
   at::Tensor input = at::randn({numel_x, numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   auto aten_output = input.to(at::kDouble).sum({0});
@@ -4329,7 +4329,7 @@ TEST_F(NVFuserTest, FusionGridReduction4_CUDA) {
   at::Tensor cg_output = at::empty({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   ke.runFusion({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
@@ -4386,7 +4386,7 @@ TEST_F(NVFuserTest, FusionGridReduction5_CUDA) {
   at::Tensor input = at::randn({numel_x, numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   auto aten_output = input.to(at::kDouble).sum({1});
@@ -4451,7 +4451,7 @@ TEST_F(NVFuserTest, FusionGridReduction6_CUDA) {
   at::Tensor cg_output = at::empty({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   ke.runFusion({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1, 2});
@@ -4483,7 +4483,7 @@ TEST_F(NVFuserTest, FusionGridReduction7_CUDA) {
   at::Tensor cg_output = at::empty({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto out = ke.runFusion({input});
 
   testValidate(&fusion, out, {input}, __LINE__, __FILE__);
@@ -4509,7 +4509,7 @@ TEST_F(NVFuserTest, FusionGridReduction8_CUDA) {
   at::Tensor input = at::randn({numel_x, numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto out = ke.runFusion({input});
 
   testValidate(&fusion, out, {input}, __LINE__, __FILE__);
@@ -4546,7 +4546,7 @@ TEST_F(NVFuserTest, FusionGridReduction9_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t2};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_output = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_output, {t0, t2}, __LINE__, __FILE__);
@@ -4587,7 +4587,7 @@ TEST_F(NVFuserTest, FusionGridReduction10_CUDA) {
   at::Tensor t0 = at::randn({numel_w, numel_x, numel_y, numel_z}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_output = ke.runFusion({t0});
 
   testValidate(&fusion, cg_output, {t0}, __LINE__, __FILE__);
@@ -4617,7 +4617,7 @@ TEST_F(NVFuserTest, FusionNonRedAxisBind_CUDA) {
   at::Tensor input = at::randn({16, bid_x * tid_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   testValidate(&fusion, cg_outputs, {input}, __LINE__, __FILE__);
@@ -4667,7 +4667,7 @@ TEST_F(NVFuserTest, FusionSplitBCast_CUDA) {
   at::Tensor cg_output = at::empty({32, 32, 128}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   ke.runFusion({t0, t1}, {cg_output});
 }
 
@@ -4748,7 +4748,7 @@ TEST_F(NVFuserTest, FusionComputeAtExprOrder1_CUDA) {
     at::Tensor aten_input = at::randn({100}, options);
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {aten_input});
+    ke.compile(&fusion, {aten_input});
     auto cg_outputs = ke.runFusion({aten_input});
 
     testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -4779,7 +4779,7 @@ TEST_F(NVFuserTest, FusionComputeAtExprOrder2_CUDA) {
   at::Tensor cg_output = at::empty_like(aten_input, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, {cg_output});
 
   testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
@@ -4809,7 +4809,7 @@ TEST_F(NVFuserTest, FusionComputeAtExprOrder3_CUDA) {
   at::Tensor aten_input = at::randn({dimx, dimy}, options);
 
   nvfuser::KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -4832,7 +4832,7 @@ TEST_F(NVFuserTest, FusionZeroDimComputeAt_CUDA) {
   at::Tensor aten_input = at::randn({100}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -4867,7 +4867,7 @@ TEST_F(NVFuserTest, FusionZeroDimBroadcast_CUDA) {
   at::Tensor cg_output = at::empty({}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   ke.runFusion(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
@@ -4902,7 +4902,7 @@ TEST_F(NVFuserTest, FusionZeroDimReduction_CUDA) {
   at::Tensor cg_output = at::empty({}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, {cg_output});
 
   testValidate(
@@ -4954,7 +4954,7 @@ TEST_F(NVFuserTest, FusionBCastAfterReduce_CUDA) {
 
   std::vector<c10::IValue> aten_inputs = {t0, t4};
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t4});
+  ke.compile(&fusion, {t0, t4});
   auto cg_outputs = ke.runFusion({t0, t4});
 
   testValidate(
@@ -4978,7 +4978,7 @@ TEST_F(NVFuserTest, FusionOutputBroadcast_CUDA) {
   at::Tensor aten_input = at::randn({2, 3}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -5001,7 +5001,7 @@ TEST_F(NVFuserTest, FusionReductionKeepDimBasic_CUDA) {
   at::Tensor aten_input = at::randn({2, 3, 4, 5, 6}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -5077,7 +5077,7 @@ TEST_F(NVFuserTest, FusionSumTo_CUDA) {
   at::Tensor aten_input = at::randn(tensor_shape_ref, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   NVF_CHECK(
@@ -5119,7 +5119,7 @@ TEST_F(NVFuserTest, FusionSumToNoop_CUDA) {
   at::Tensor aten_input = at::randn(tensor_shape_ref, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   NVF_CHECK(
@@ -5266,7 +5266,7 @@ TEST_F(NVFuserTest, FusionSymbolicReduction_CUDA) {
   LaunchParams lparams(-1, -1, -1, runtime_threadIdx_dim, -1, -1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input}, lparams);
+  ke.compile(&fusion, {aten_input}, lparams);
   auto cg_outputs = ke.runFusion({aten_input}, lparams);
 
   testValidate(
@@ -5308,7 +5308,7 @@ TEST_F(NVFuserTest, FusionReductionSchedulerMultiDimNonFastest_CUDA) {
   auto heuristic_params = SchedulerEntry::scheduleWith(
       &fusion, SchedulerType::Reduction, {aten_input});
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input}, heuristic_params->lparams);
+  ke.compile(&fusion, {aten_input}, heuristic_params->lparams);
   ke.runFusion({aten_input}, {cg_output}, heuristic_params->lparams);
 
   testValidate(
@@ -5537,7 +5537,7 @@ TEST_F(NVFuserTest, FusionCacheBefore_CUDA) {
   at::Tensor aten_input = at::randn({M, N}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -5573,7 +5573,7 @@ TEST_F(NVFuserTest, FusionCacheAfter_CUDA) {
   at::Tensor aten_input = at::randn({M, N}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -5615,7 +5615,7 @@ TEST_F(NVFuserTest, FusionCacheFork_CUDA) {
   at::Tensor aten_input = at::randn({M, N}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -5662,7 +5662,7 @@ TEST_F(NVFuserTest, FusionCacheIndirect_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1, t2, t3};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -5718,7 +5718,7 @@ TEST_F(NVFuserTest, FusionCacheBcast_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -5755,7 +5755,7 @@ TEST_F(NVFuserTest, FusionCacheMultiConsumer_CUDA) {
   at::Tensor aten_input = at::randn({N}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -5807,7 +5807,7 @@ TEST_F(NVFuserTest, FusionSmem_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -5855,7 +5855,7 @@ TEST_F(NVFuserTest, FusionSmemReduce_CUDA) {
   at::Tensor aten_output = sum(aten_input.to(at::kDouble), {1});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(
@@ -5925,7 +5925,7 @@ TEST_F(NVFuserTest, FusionSmemBlockGemm_CUDA) {
   at::Tensor aten_output = at::matmul(t0.to(at::kDouble), t1.to(at::kDouble));
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(
@@ -6014,7 +6014,7 @@ TEST_F(NVFuserTest, FusionSmemBlockGemmCache_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(
@@ -6086,7 +6086,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicPersistentSoftmax2D_CUDA) {
   auto aten_output = at::_softmax(aten_input.to(at::kDouble), -1, false);
 
   nvfuser::KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input, 128});
+  ke.compile(&fusion, {aten_input, 128});
   auto cg_outputs = ke.runFusion({aten_input, 128});
 
   testValidate(
@@ -6841,7 +6841,7 @@ TEST_F(NVFuserTest, FusionPersistentSoftmaxLocalShared_CUDA) {
       aten_output.narrow(1, static_size, dimy - static_size);
 
   nvfuser::KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_static_in, aten_dynamic_in});
+  ke.compile(&fusion, {aten_static_in, aten_dynamic_in});
   ke.runFusion(
       {aten_static_in, aten_dynamic_in}, {cg_static_out, cg_dynamic_out});
 
@@ -7030,7 +7030,7 @@ TEST_F(NVFuserTest, FusionPersistentNormLocalShared_CUDA) {
       aten_static_in, aten_dynamic_in, kGamma, kBeta, kEps, dimy};
 
   nvfuser::KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   ke.runFusion(aten_inputs, {cg_static_out, cg_dynamic_out});
 
@@ -7154,7 +7154,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicPersistentNorm_CUDA) {
       aten_input, kGamma, kBeta, kEps, dimy, TIDX};
 
   nvfuser::KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(
@@ -7200,7 +7200,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicReductionSymbolic_CUDA) {
   LaunchParams lparams(-1, -1, -1, runtime_threadIdx_dim, -1, -1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input}, lparams);
+  ke.compile(&fusion, {aten_input}, lparams);
   auto cg_outputs = ke.runFusion({aten_input}, lparams);
 
   testValidate(
@@ -7263,7 +7263,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicReductionSymbolicArg_CUDA) {
   auto lparams = LaunchParams(-1, -1, -1, runtime_threadIdx_dim, -1, -1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input, runtime_threadIdx_dim}, lparams);
+  ke.compile(&fusion, {aten_input, runtime_threadIdx_dim}, lparams);
   auto cg_outputs = ke.runFusion({aten_input, runtime_threadIdx_dim}, lparams);
 
   testValidate(
@@ -7327,7 +7327,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicPwiseMulSymbolicArgWAR_CUDA) {
   LaunchParams lparams(-1, -1, -1, BSX, -1, -1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs, lparams);
+  ke.compile(&fusion, aten_inputs, lparams);
   auto cg_outputs = ke.runFusion(aten_inputs, lparams);
 
   testValidate(
@@ -7453,7 +7453,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicTiledGemm_CUDA) {
 
   KernelExecutor ke;
   // Generate CUDA and compile with nvRTC
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -209,7 +209,7 @@ TEST_F(NVFuserTest, FusionClear_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input1, input2});
-  auto outputs = ke.runFusion({input1, input2});
+  auto outputs = ke.run({input1, input2});
 
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
@@ -815,7 +815,7 @@ TEST_F(NVFuserTest, FusionOuterSplit_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion);
-  auto outputs = ke.runFusion({});
+  auto outputs = ke.run({});
   const auto& output = outputs.at(0);
 
   at::Tensor output_ref = at::ones_like(output, options);
@@ -857,7 +857,7 @@ TEST_F(NVFuserTest, FusionCodeGen_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion);
-  auto outputs = ke.runFusion({});
+  auto outputs = ke.run({});
   const auto& output = outputs.at(0);
 
   at::Tensor output_ref = at::ones_like(output, options);
@@ -901,7 +901,7 @@ TEST_F(NVFuserTest, FusionCodeGen2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input1, input2});
-  auto outputs = ke.runFusion({input1, input2});
+  auto outputs = ke.run({input1, input2});
 
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
@@ -957,7 +957,7 @@ TEST_F(NVFuserTest, FusionSimplePWise_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input1, input2});
-  ke.runFusion({input1, input2}, {output});
+  ke.run({input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
@@ -1015,7 +1015,7 @@ TEST_F(NVFuserTest, FusionSimplePWiseDtypeComplex_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input1, input2});
-  ke.runFusion({input1, input2}, {output});
+  ke.run({input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + static_cast<c10::complex<double>>(scalar1);
   at::Tensor output_ref = input1 + tv2_ref;
@@ -1065,7 +1065,7 @@ TEST_F(NVFuserTest, FusionExecKernel_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input1, input2});
-  auto outputs = ke.runFusion({input1, input2});
+  auto outputs = ke.run({input1, input2});
 
   at::Tensor check = at::full({1, 128}, 4, options);
   ;
@@ -1147,7 +1147,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, cg_outputs);
+  ke.run({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1201,7 +1201,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   testValidate(&fusion, cg_outputs, {input}, __LINE__, __FILE__);
 }
@@ -1255,7 +1255,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  ke.runFusion(aten_inputs, {cg_output});
+  ke.run(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
 }
@@ -1319,7 +1319,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1355,7 +1355,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1390,7 +1390,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt6_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1451,7 +1451,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt7_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1507,7 +1507,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt8_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1576,7 +1576,7 @@ TEST_F(NVFuserTest, FusionComputeAtMultiConsumers_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, cg_outputs);
+  ke.run({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1646,7 +1646,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, cg_outputs);
+  ke.run({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1721,7 +1721,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, {cg_output});
+  ke.run({aten_input}, {cg_output});
 
   testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
@@ -1802,7 +1802,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, cg_outputs);
+  ke.run({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1866,7 +1866,7 @@ TEST_F(NVFuserTest, FusionComputeAtNoCommonConsumer_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, cg_outputs);
+  ke.run({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1974,7 +1974,7 @@ TEST_F(NVFuserTest, FusionScalarInputs_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  ke.runFusion(aten_inputs, {cg_output});
+  ke.run(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
 }
@@ -2026,7 +2026,7 @@ TEST_F(NVFuserTest, FusionLoopUnroll_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input0, input1});
-  auto outputs = ke.runFusion({input0, input1});
+  auto outputs = ke.run({input0, input1});
 
   NVF_CHECK(outputs[0].equal(input0.add(input1.add(2.0))));
 }
@@ -2175,7 +2175,7 @@ void test_op(
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs_ivalues);
-  ke.runFusion(aten_inputs_ivalues, output_vect);
+  ke.run(aten_inputs_ivalues, output_vect);
   cudaDeviceSynchronize();
 
   at::Tensor aten_output = af(aten_inputs);
@@ -2720,7 +2720,7 @@ TEST_F(NVFuserTest, FusionFp8CastOps_CUDA) {
         GTEST_SKIP() << "skipping tests on pre-HOPPER GPUs";
       } else {
         ke.compile(&fusion, inputs);
-        auto outputs = ke.runFusion(inputs);
+        auto outputs = ke.run(inputs);
 
         at::Tensor ref_output = input1.to(at_fp8_type).to(at_src_type);
 
@@ -2792,7 +2792,7 @@ TEST_F(NVFuserTest, FusionReduction1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  ke.runFusion({input}, {cg_output});
+  ke.run({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
 
@@ -2864,7 +2864,7 @@ TEST_F(NVFuserTest, FusionReduction2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   auto aten_output = input.to(at::kDouble).sum({1});
   testValidate(&fusion, cg_outputs, {input}, {aten_output}, __LINE__, __FILE__);
@@ -2915,7 +2915,7 @@ TEST_F(NVFuserTest, FusionReduction3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, {cg_output});
+  ke.run({aten_input}, {cg_output});
 
   auto aten_output = aten_input.to(at::kDouble).sum({1});
 
@@ -2981,7 +2981,7 @@ TEST_F(NVFuserTest, FusionReduction4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1, t4});
-  auto cg_outputs = ke.runFusion({t0, t1, t4});
+  auto cg_outputs = ke.run({t0, t1, t4});
 
   auto t2 = t0.add(t1);
   auto t3 = t2.to(at::kDouble).sum({1});
@@ -3035,7 +3035,7 @@ TEST_F(NVFuserTest, FusionReduction5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  ke.runFusion({input}, {cg_output});
+  ke.run({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
   testValidate(
@@ -3100,7 +3100,7 @@ TEST_F(NVFuserTest, FusionReduction6_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   auto aten_output = input.to(at::kDouble).sum({1, 2});
   testValidate(&fusion, cg_outputs, {input}, {aten_output}, __LINE__, __FILE__);
@@ -3132,7 +3132,7 @@ TEST_F(NVFuserTest, FusionMultiGridReduction_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   testValidate(&fusion, cg_outputs, {input}, __LINE__, __FILE__);
 }
@@ -3156,7 +3156,7 @@ TEST_F(NVFuserTest, FusionMultiGridReduction2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_output = ke.runFusion({input});
+  auto cg_output = ke.run({input});
   testValidate(&fusion, cg_output, {input}, __LINE__, __FILE__);
 }
 
@@ -3209,7 +3209,7 @@ TEST_F(NVFuserTest, FusionReductionTFT_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  ke.runFusion({input}, {cg_output});
+  ke.run({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
   testValidate(
@@ -3273,7 +3273,7 @@ TEST_F(NVFuserTest, FusionReductionOuterSplit_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1, t4});
-  auto cg_outputs = ke.runFusion({t0, t1, t4});
+  auto cg_outputs = ke.run({t0, t1, t4});
 
   auto t2 = t0.add(t1);
   auto t3 = t2.to(at::kDouble).sum({1});
@@ -3332,7 +3332,7 @@ TEST_F(NVFuserTest, FusionBranches_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3379,7 +3379,7 @@ TEST_F(NVFuserTest, FusionSimpleBCast1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3431,7 +3431,7 @@ TEST_F(NVFuserTest, FusionSimpleBCast2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  ke.runFusion(aten_inputs, {cg_output});
+  ke.run(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
 }
@@ -3473,7 +3473,7 @@ TEST_F(NVFuserTest, FusionSimpleBCast3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  ke.runFusion(aten_inputs, {cg_output});
+  ke.run(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
 }
@@ -3518,7 +3518,7 @@ TEST_F(NVFuserTest, FusionSimpleBCast4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  ke.runFusion(aten_inputs, {cg_output});
+  ke.run(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
 }
@@ -3558,7 +3558,7 @@ TEST_F(NVFuserTest, FusionSimpleBCast5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  ke.runFusion(aten_inputs, {cg_output});
+  ke.run(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
 }
@@ -3610,7 +3610,7 @@ TEST_F(NVFuserTest, FusionComplexBCast1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3654,7 +3654,7 @@ TEST_F(NVFuserTest, FusionComplexBCast2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t4});
-  auto cg_outputs = ke.runFusion({t0, t4});
+  auto cg_outputs = ke.run({t0, t4});
 
   testValidate(&fusion, {cg_outputs}, {t0, t4}, __LINE__, __FILE__);
 }
@@ -3729,7 +3729,7 @@ TEST_F(NVFuserTest, FusionSimpleGemm_CUDA) {
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1}, LaunchParams(1, -1, -1, 32, 4, 4));
   // Lets specify a few bounds in launch params to make sure it works
-  ke.runFusion({t0, t1}, LaunchParams(1, -1, -1, 32, 4, 4));
+  ke.run({t0, t1}, LaunchParams(1, -1, -1, 32, 4, 4));
 
   // Make sure bad launch params throws
   // TODO: Re-enable once we have parallelization validation in.
@@ -3737,7 +3737,7 @@ TEST_F(NVFuserTest, FusionSimpleGemm_CUDA) {
   // ASSERT_ANY_THROW(ke.runFusion({t0, t1}, LaunchParams(1, 2, 3, 4, 5, 6)));
 
   // Don't specify any launch params
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto aten_output = t0.to(at::kDouble).matmul(t1.to(at::kDouble));
 
@@ -3793,7 +3793,7 @@ TEST_F(NVFuserTest, FusionSoftmax1D_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  ke.runFusion({t0}, {cg_output});
+  ke.run({t0}, {cg_output});
 
   auto aten_output = at::_softmax(t0.to(at::kDouble), -1, false);
 
@@ -3862,7 +3862,7 @@ TEST_F(NVFuserTest, FusionSoftmax1DNormalized_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   auto aten_output = at::_softmax(input.to(at::kDouble), -1, false);
 
@@ -3922,7 +3922,7 @@ TEST_F(NVFuserTest, FusionSoftmax3D_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  ke.runFusion({input}, {cg_output});
+  ke.run({input}, {cg_output});
 
   auto aten_output = at::_softmax(input.to(at::kDouble), -1, false);
 
@@ -3997,7 +3997,7 @@ TEST_F(NVFuserTest, FusionSoftmax3DNormalized_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   auto aten_output = at::_softmax(input.to(at::kDouble), -1, false);
 
@@ -4083,7 +4083,7 @@ TEST_F(NVFuserTest, FusionGridReduction1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  ke.runFusion({input}, {cg_output});
+  ke.run({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
 
@@ -4143,7 +4143,7 @@ TEST_F(NVFuserTest, FusionGridReduction2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   auto aten_output = input.to(at::kDouble).sum({1});
 
@@ -4205,7 +4205,7 @@ TEST_F(NVFuserTest, FusionGridReduction3dim1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  ke.runFusion({input}, {cg_output});
+  ke.run({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
   testValidate(
@@ -4264,7 +4264,7 @@ TEST_F(NVFuserTest, FusionGridReduction3dim0_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   auto aten_output = input.to(at::kDouble).sum({0});
 
@@ -4330,7 +4330,7 @@ TEST_F(NVFuserTest, FusionGridReduction4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  ke.runFusion({input}, {cg_output});
+  ke.run({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1});
   testValidate(
@@ -4387,7 +4387,7 @@ TEST_F(NVFuserTest, FusionGridReduction5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   auto aten_output = input.to(at::kDouble).sum({1});
   testValidate(&fusion, cg_outputs, {input}, {aten_output}, __LINE__, __FILE__);
@@ -4452,7 +4452,7 @@ TEST_F(NVFuserTest, FusionGridReduction6_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  ke.runFusion({input}, {cg_output});
+  ke.run({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({1, 2});
 
@@ -4484,7 +4484,7 @@ TEST_F(NVFuserTest, FusionGridReduction7_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto out = ke.runFusion({input});
+  auto out = ke.run({input});
 
   testValidate(&fusion, out, {input}, __LINE__, __FILE__);
 }
@@ -4510,7 +4510,7 @@ TEST_F(NVFuserTest, FusionGridReduction8_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto out = ke.runFusion({input});
+  auto out = ke.run({input});
 
   testValidate(&fusion, out, {input}, __LINE__, __FILE__);
 }
@@ -4547,7 +4547,7 @@ TEST_F(NVFuserTest, FusionGridReduction9_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_output = ke.runFusion(aten_inputs);
+  auto cg_output = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_output, {t0, t2}, __LINE__, __FILE__);
 }
@@ -4588,7 +4588,7 @@ TEST_F(NVFuserTest, FusionGridReduction10_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_output = ke.runFusion({t0});
+  auto cg_output = ke.run({t0});
 
   testValidate(&fusion, cg_output, {t0}, __LINE__, __FILE__);
 }
@@ -4618,7 +4618,7 @@ TEST_F(NVFuserTest, FusionNonRedAxisBind_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   testValidate(&fusion, cg_outputs, {input}, __LINE__, __FILE__);
 }
@@ -4668,7 +4668,7 @@ TEST_F(NVFuserTest, FusionSplitBCast_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  ke.runFusion({t0, t1}, {cg_output});
+  ke.run({t0, t1}, {cg_output});
 }
 
 TEST_F(NVFuserTest, FusionBCastInnerDim_CUDA) {
@@ -4749,7 +4749,7 @@ TEST_F(NVFuserTest, FusionComputeAtExprOrder1_CUDA) {
 
     KernelExecutor ke;
     ke.compile(&fusion, {aten_input});
-    auto cg_outputs = ke.runFusion({aten_input});
+    auto cg_outputs = ke.run({aten_input});
 
     testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
   }
@@ -4780,7 +4780,7 @@ TEST_F(NVFuserTest, FusionComputeAtExprOrder2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, {cg_output});
+  ke.run({aten_input}, {cg_output});
 
   testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
@@ -4810,7 +4810,7 @@ TEST_F(NVFuserTest, FusionComputeAtExprOrder3_CUDA) {
 
   nvfuser::KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -4833,7 +4833,7 @@ TEST_F(NVFuserTest, FusionZeroDimComputeAt_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -4868,7 +4868,7 @@ TEST_F(NVFuserTest, FusionZeroDimBroadcast_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  ke.runFusion(aten_inputs, {cg_output});
+  ke.run(aten_inputs, {cg_output});
 
   testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
 }
@@ -4903,7 +4903,7 @@ TEST_F(NVFuserTest, FusionZeroDimReduction_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, {cg_output});
+  ke.run({aten_input}, {cg_output});
 
   testValidate(
       &fusion, {cg_output}, {aten_input}, {aten_output}, __LINE__, __FILE__);
@@ -4955,7 +4955,7 @@ TEST_F(NVFuserTest, FusionBCastAfterReduce_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t4};
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t4});
-  auto cg_outputs = ke.runFusion({t0, t4});
+  auto cg_outputs = ke.run({t0, t4});
 
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
@@ -4979,7 +4979,7 @@ TEST_F(NVFuserTest, FusionOutputBroadcast_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -5002,7 +5002,7 @@ TEST_F(NVFuserTest, FusionReductionKeepDimBasic_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -5078,7 +5078,7 @@ TEST_F(NVFuserTest, FusionSumTo_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   NVF_CHECK(
       cg_outputs[0].dim() == static_cast<int64_t>(sum_to_shape.size()),
@@ -5120,7 +5120,7 @@ TEST_F(NVFuserTest, FusionSumToNoop_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   NVF_CHECK(
       cg_outputs[0].dim() == static_cast<int64_t>(sum_to_shape.size()),
@@ -5267,7 +5267,7 @@ TEST_F(NVFuserTest, FusionSymbolicReduction_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input}, lparams);
-  auto cg_outputs = ke.runFusion({aten_input}, lparams);
+  auto cg_outputs = ke.run({aten_input}, lparams);
 
   testValidate(
       &fusion,
@@ -5309,7 +5309,7 @@ TEST_F(NVFuserTest, FusionReductionSchedulerMultiDimNonFastest_CUDA) {
       &fusion, SchedulerType::Reduction, {aten_input});
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input}, heuristic_params->lparams);
-  ke.runFusion({aten_input}, {cg_output}, heuristic_params->lparams);
+  ke.run({aten_input}, {cg_output}, heuristic_params->lparams);
 
   testValidate(
       &fusion,
@@ -5538,7 +5538,7 @@ TEST_F(NVFuserTest, FusionCacheBefore_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -5574,7 +5574,7 @@ TEST_F(NVFuserTest, FusionCacheAfter_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -5616,7 +5616,7 @@ TEST_F(NVFuserTest, FusionCacheFork_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -5663,7 +5663,7 @@ TEST_F(NVFuserTest, FusionCacheIndirect_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -5719,7 +5719,7 @@ TEST_F(NVFuserTest, FusionCacheBcast_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -5756,7 +5756,7 @@ TEST_F(NVFuserTest, FusionCacheMultiConsumer_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -5808,7 +5808,7 @@ TEST_F(NVFuserTest, FusionSmem_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 
@@ -5856,7 +5856,7 @@ TEST_F(NVFuserTest, FusionSmemReduce_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(
       &fusion, cg_outputs, {aten_input}, {aten_output}, __LINE__, __FILE__);
@@ -5926,7 +5926,7 @@ TEST_F(NVFuserTest, FusionSmemBlockGemm_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
@@ -6015,7 +6015,7 @@ TEST_F(NVFuserTest, FusionSmemBlockGemmCache_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
@@ -6087,7 +6087,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicPersistentSoftmax2D_CUDA) {
 
   nvfuser::KernelExecutor ke;
   ke.compile(&fusion, {aten_input, 128});
-  auto cg_outputs = ke.runFusion({aten_input, 128});
+  auto cg_outputs = ke.run({aten_input, 128});
 
   testValidate(
       &fusion,
@@ -6842,8 +6842,7 @@ TEST_F(NVFuserTest, FusionPersistentSoftmaxLocalShared_CUDA) {
 
   nvfuser::KernelExecutor ke;
   ke.compile(&fusion, {aten_static_in, aten_dynamic_in});
-  ke.runFusion(
-      {aten_static_in, aten_dynamic_in}, {cg_static_out, cg_dynamic_out});
+  ke.run({aten_static_in, aten_dynamic_in}, {cg_static_out, cg_dynamic_out});
 
   testValidate(
       &fusion,
@@ -7032,7 +7031,7 @@ TEST_F(NVFuserTest, FusionPersistentNormLocalShared_CUDA) {
   nvfuser::KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
 
-  ke.runFusion(aten_inputs, {cg_static_out, cg_dynamic_out});
+  ke.run(aten_inputs, {cg_static_out, cg_dynamic_out});
 
   auto at_mu = at::mean(aten_input.to(at::kDouble), -1).unsqueeze(1);
   auto at_var = at::var(aten_input.to(at::kDouble), -1, false).unsqueeze(1);
@@ -7155,7 +7154,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicPersistentNorm_CUDA) {
 
   nvfuser::KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
@@ -7201,7 +7200,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicReductionSymbolic_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input}, lparams);
-  auto cg_outputs = ke.runFusion({aten_input}, lparams);
+  auto cg_outputs = ke.run({aten_input}, lparams);
 
   testValidate(
       &fusion,
@@ -7264,7 +7263,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicReductionSymbolicArg_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input, runtime_threadIdx_dim}, lparams);
-  auto cg_outputs = ke.runFusion({aten_input, runtime_threadIdx_dim}, lparams);
+  auto cg_outputs = ke.run({aten_input, runtime_threadIdx_dim}, lparams);
 
   testValidate(
       &fusion,
@@ -7328,7 +7327,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicPwiseMulSymbolicArgWAR_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs, lparams);
-  auto cg_outputs = ke.runFusion(aten_inputs, lparams);
+  auto cg_outputs = ke.run(aten_inputs, lparams);
 
   testValidate(
       &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__, "", lparams);
@@ -7454,7 +7453,7 @@ TEST_F(NVFuserTest, FusionSmemDynamicTiledGemm_CUDA) {
   KernelExecutor ke;
   // Generate CUDA and compile with nvRTC
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);

--- a/tests/cpp/test_gpu2.cpp
+++ b/tests/cpp/test_gpu2.cpp
@@ -96,7 +96,7 @@ TEST_F(NVFuserTest, FusionGlobalIntermediate_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input}, lparams);
-  auto cg_outputs = ke.runFusion({input}, lparams);
+  auto cg_outputs = ke.run({input}, lparams);
 
   auto aten_output = input.to(at::kDouble).sum({1});
   testValidate(
@@ -143,7 +143,7 @@ TEST_F(NVFuserTest, FusionGlobalIntermediateDefaultSchedule_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1, t2, t3});
-  auto cg_outputs = ke.runFusion({t0, t1, t2, t3});
+  auto cg_outputs = ke.run({t0, t1, t2, t3});
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -201,7 +201,7 @@ TEST_F(NVFuserTest, FusionUnrollWithAlloc_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   auto aten_output = (input + 0).to(at::kDouble).sum(1);
 
@@ -278,7 +278,7 @@ TEST_F(NVFuserTest, FusionComputeAtNonterminatingOutput_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -312,7 +312,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, cg_outputs);
+  ke.run({aten_input}, cg_outputs);
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
 
@@ -349,7 +349,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, cg_outputs);
+  ke.run({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -401,7 +401,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder3_CUDA) {
 
     KernelExecutor ke;
     ke.compile(&fusion, {aten_input});
-    ke.runFusion({aten_input}, cg_outputs);
+    ke.run({aten_input}, cg_outputs);
 
     testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
   }
@@ -445,7 +445,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  ke.runFusion(aten_inputs, cg_outputs);
+  ke.run(aten_inputs, cg_outputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -478,7 +478,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, cg_outputs);
+  ke.run({aten_input}, cg_outputs);
 
   auto t1 = aten_input + 1;
   auto t2 = t1 + 2;
@@ -520,7 +520,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder6_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, {cg_output});
+  ke.run({aten_input}, {cg_output});
 
   testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
@@ -560,7 +560,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder7_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, {cg_output});
+  ke.run({aten_input}, {cg_output});
 
   testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
@@ -621,7 +621,7 @@ TEST_F(NVFuserTest, FusionThreadPredicate_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, cg_outputs);
+  ke.run({aten_input}, cg_outputs);
 
   testValidate(
       &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
@@ -742,7 +742,7 @@ TEST_F(NVFuserTest, FusionReduceSingle_CUDA) {
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
   // no broadcasting needed, omitting the last optional argument;
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -873,7 +873,7 @@ TEST_F(NVFuserTest, FusionTrivialReduction_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1283,7 +1283,7 @@ TEST_F(NVFuserTest, FusionIssue459_CUDA) {
 
   nvfuser::KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1313,7 +1313,7 @@ TEST_F(NVFuserTest, FusionSmemIndexingSimple_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1424,7 +1424,7 @@ TEST_F(NVFuserTest, FusionSmemIndexing_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
@@ -1459,7 +1459,7 @@ TEST_F(NVFuserTest, FusionCacheBeforeReduction_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  ke.runFusion({aten_input}, {cg_output});
+  ke.run({aten_input}, {cg_output});
 
   testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
 }
@@ -1496,7 +1496,7 @@ TEST_F(NVFuserTest, FusionCacheBeforeReduction2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1602,7 +1602,7 @@ TEST_F(NVFuserTest, FusionIssue367_CUDA) {
 
   nvfuser::KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
@@ -1628,7 +1628,7 @@ TEST_F(NVFuserTest, FusionIssue468_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1680,7 +1680,7 @@ TEST_F(NVFuserTest, FusionIssue363_CUDA) {
 
   nvfuser::KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1706,7 +1706,7 @@ TEST_F(NVFuserTest, FusionIssue484_CUDA) {
 
   nvfuser::KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1732,7 +1732,7 @@ TEST_F(NVFuserTest, FusionIssue329_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1773,7 +1773,7 @@ TEST_F(NVFuserTest, FusionIssue382_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1802,7 +1802,7 @@ TEST_F(NVFuserTest, FusionIssue507_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -1840,7 +1840,7 @@ TEST_F(NVFuserTest, FusionIssue532_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1869,7 +1869,7 @@ TEST_F(NVFuserTest, FusionLoopUnswitch_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1947,7 +1947,7 @@ TEST_F(NVFuserTest, FusionIssue549_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1}, lparams);
-  ke.runFusion({t0, t1}, lparams);
+  ke.run({t0, t1}, lparams);
 
   // Make sure bad launch params throws
   // TODO: Re-enable once we have parallelization validation in.
@@ -1955,7 +1955,7 @@ TEST_F(NVFuserTest, FusionIssue549_CUDA) {
   // ASSERT_ANY_THROW(ke.runFusion({t0, t1}, LaunchParams(1, 2, 3, 4, 5, 6)));
 
   // Don't specify any launch params
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto aten_output = (t0 + 1).to(at::kDouble).matmul(t1.to(at::kDouble));
 
@@ -2327,7 +2327,7 @@ TEST_F(NVFuserTest, FusionWelfordOp_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   // by default Welford outputs sum of square diff so need to divide to get var
   outputs[1] /= N;
@@ -2372,7 +2372,7 @@ TEST_F(NVFuserTest, FusionBlockWelfordOp_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   // by default Welford outputs sum of square diff so need to divide to get var
   outputs[1] /= N;
@@ -2417,7 +2417,7 @@ TEST_F(NVFuserTest, FusionGridWelfordOp_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   // by default Welford outputs sum of square diff so need to divide to get var
   outputs[1] /= N;
@@ -2461,7 +2461,7 @@ TEST_F(NVFuserTest, FusionRfactorWelfordOp_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   // by default Welford outputs sum of square diff so need to divide to get var
   outputs[1] /= N;
@@ -2593,12 +2593,12 @@ TEST_P(WelfordReduction, Test) {
   // lowering pass will use int64 as the index tpye, since this test saves
   // `tv_N` as index type, it may cause vectorization size validation error. For
   // example, the heuristics set index type to int32 and the max vectorization
-  // factor is 4, if compile para is not passed to compileFusion, the lowering
+  // factor is 4, if compile para is not passed to compile, the lowering
   // pass uses int64 as index type, so the max vectorization factor is 16 bytes
   // sizeof(int64) = 2, which is wrong since the actual index type is int32
   // and the max vectorization factor is 4.
   ke.compile(&fusion, {aten_input}, lparams, cparams);
-  auto outputs = ke.runFusion({aten_input}, lparams);
+  auto outputs = ke.run({aten_input}, lparams);
 
   // by default Welford outputs sum of square diff so need to divide to
   // get var
@@ -2757,10 +2757,10 @@ TEST_F(NVFuserTest, FusionSimpleGemmTransposed_CUDA) {
   LaunchParams lparams(1, -1, -1, 32, 4, 4);
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1}, lparams);
-  ke.runFusion({t0, t1}, lparams);
+  ke.run({t0, t1}, lparams);
 
   // Don't specify any launch params
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto aten_output = t0.t().to(at::kDouble).matmul(t1.t().to(at::kDouble));
 
@@ -2822,7 +2822,7 @@ TEST_F(NVFuserTest, FusionSoftmax3DTransposed_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  ke.runFusion({input}, {cg_output});
+  ke.run({input}, {cg_output});
 
   auto aten_input_t = at::transpose(input, 1, 2);
   auto aten_output = at::_softmax(aten_input_t.to(at::kDouble), -1, false);
@@ -2896,7 +2896,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   at::Tensor aten_input_t = aten_input.t();
 
@@ -2965,7 +2965,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  auto cg_outputs = ke.run({input});
 
   auto input_t = input.t();
   auto t1 = input_t.mul({-1.0});
@@ -3031,7 +3031,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto t0_t = t0.permute({3, 0, 1, 2});
   auto t1_t = t1.permute({3, 0, 1, 2});
@@ -3109,7 +3109,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto t0_t = t0.permute({3, 0, 1, 2});
   auto t1_t = t1.permute({3, 0, 1, 2});
@@ -3157,7 +3157,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto t2 = t0.t().add(2.0);
   auto aten_output = t1.t().mul(t2);
@@ -3199,7 +3199,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed6_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto t2 = t0.t().add(2.0);
   auto aten_output = t1.t().mul(t2);
@@ -3350,7 +3350,7 @@ TEST_F(NVFuserTest, FusionVectorizeSimple_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   at::Tensor aten_output = aten_input.sin();
 
@@ -3425,7 +3425,7 @@ TEST_F(NVFuserTest, FusionSimpleVectorizeUnroll_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input1, input2});
-  ke.runFusion({input1, input2}, {output});
+  ke.run({input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
@@ -3505,7 +3505,7 @@ TEST_F(NVFuserTest, FusionGridPersistence_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto out = ke.runFusion({input});
+  auto out = ke.run({input});
 
   testValidate(&fusion, out, {input}, __LINE__, __FILE__);
 }
@@ -3538,7 +3538,7 @@ TEST_F(NVFuserTest, FusionGridPersistence2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto out = ke.runFusion({input});
+  auto out = ke.run({input});
 
   testValidate(&fusion, out, {input}, __LINE__, __FILE__);
 }
@@ -3572,7 +3572,7 @@ TEST_F(NVFuserTest, FusionWelfordPersistence_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto out = ke.runFusion({input});
+  auto out = ke.run({input});
 
   auto aten_output = (input.mean({0}) + (input.var({0}, false) * numel_x))
                          .unsqueeze(-1)
@@ -3612,7 +3612,7 @@ TEST_F(NVFuserTest, FusionWelfordPersistence2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  auto out = ke.runFusion({input});
+  auto out = ke.run({input});
 
   auto aten_output = (input.mean({0}) + (input.var({0}, false) * numel_x))
                          .unsqueeze(0)
@@ -3650,7 +3650,7 @@ TEST_F(NVFuserTest, FusionIssue633_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3683,7 +3683,7 @@ TEST_F(NVFuserTest, FusionBroadcastAcrossComputeAt_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3732,7 +3732,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwise_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3788,7 +3788,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeContig_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3849,7 +3849,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicPass_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3966,7 +3966,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedRFactor_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto aten_output = t0.add(t1).sum(1);
   testValidate(
@@ -4058,7 +4058,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStride_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4115,7 +4115,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStrideFail_CUDA) {
 
   // Failure because the input + output tensors do not have the same stride
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.runFusion(aten_inputs));
+  ASSERT_ANY_THROW(ke.run(aten_inputs));
 }
 
 TEST_F(NVFuserTest, FusionVectorization1_CUDA) {
@@ -4159,7 +4159,7 @@ TEST_F(NVFuserTest, FusionVectorization1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4247,17 +4247,17 @@ TEST_F(NVFuserTest, FusionVectorization3_CUDA) {
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.runFusion(aten_inputs));
+  ASSERT_ANY_THROW(ke.run(aten_inputs));
 
   aten_inputs[0] = t0.index({"...", at::indexing::Slice(1)});
   aten_inputs[1] = t1.index({"...", at::indexing::Slice(1)});
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.runFusion(aten_inputs));
+  ASSERT_ANY_THROW(ke.run(aten_inputs));
 
   t0 = at::randn({bx, 2048}, options).index({"...", at::indexing::Slice(4)});
   t1 = at::randn({bx, 2048}, options).index({"...", at::indexing::Slice(4)});
   aten_inputs = {t0, t1};
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4311,7 +4311,7 @@ TEST_F(NVFuserTest, FusionVectorizationRFactor_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto aten_output = t0.add(t1).sum(1);
   testValidate(
@@ -4374,7 +4374,7 @@ TEST_F(NVFuserTest, FusionSizeOneLoop1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4408,7 +4408,7 @@ TEST_F(NVFuserTest, FusionSizeOneLoop2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4650,7 +4650,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize8_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input0, input1});
-  auto outputs = ke.runFusion({input0, input1});
+  auto outputs = ke.run({input0, input1});
 
   testValidate(&fusion, outputs, {input0, input1}, __LINE__, __FILE__);
 }
@@ -4739,7 +4739,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize10_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4785,7 +4785,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize11_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4899,7 +4899,7 @@ TEST_F(NVFuserTest, FusionBlockReduceInSerialLoop_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
@@ -4928,7 +4928,7 @@ TEST_F(NVFuserTest, FusionBlockWelfordInSerialLoop_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
   at::Tensor aten_avg = t0.mean({1, 2});
   at::Tensor aten_M2 = t0.var({1, 2}, false) * N * K;
   testValidate(
@@ -4967,7 +4967,7 @@ TEST_F(NVFuserTest, FusionReductionPredicate_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});
-  ke.runFusion({input}, {cg_output});
+  ke.run({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({0});
 
@@ -5064,7 +5064,7 @@ TEST_F(NVFuserTest, FusionIssue757_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -5102,7 +5102,7 @@ TEST_F(NVFuserTest, FusionPredicatedBlockBroadcast_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -6006,7 +6006,7 @@ TEST_F(NVFuserTest, FusionSimpleWarp_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
 
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
@@ -6055,7 +6055,7 @@ TEST_F(NVFuserTest, FusionSimpleWarpPad_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
 }
@@ -6100,7 +6100,7 @@ TEST_F(NVFuserTest, FusionWarpPadMergeSplit_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
 }
@@ -6142,7 +6142,7 @@ TEST_F(NVFuserTest, FusionSerialWarpReduction_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
 }
@@ -6187,7 +6187,7 @@ TEST_F(NVFuserTest, FusionTrivialWarpReduction_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
 }
@@ -6242,7 +6242,7 @@ TEST_F(NVFuserTest, FusionMultipleDimBinding_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1, input2});
-  auto outputs = ke.runFusion({input1, input2});
+  auto outputs = ke.run({input1, input2});
   testValidate(
       fusion.get(),
       outputs,
@@ -6280,7 +6280,7 @@ TEST_F(NVFuserTest, FusionPadNoWarpReduce_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
   testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
 }
 
@@ -6315,7 +6315,7 @@ TEST_F(NVFuserTest, FusionWarpMutipleThreadDim_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
 }
@@ -6366,7 +6366,7 @@ TEST_F(NVFuserTest, FusionWarpReduceUnrollOuterLoop_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
 }
@@ -6412,7 +6412,7 @@ TEST_F(NVFuserTest, FusionWarpReducePredication_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t2});
-  auto cg_outputs = ke.runFusion({t0, t2});
+  auto cg_outputs = ke.run({t0, t2});
 
   auto t1 = t0.sum({0});
   auto t4 = (t2 + 1).sum({0}) + 1;
@@ -6493,7 +6493,7 @@ TEST_F(NVFuserTest, FusionBufferReuseBroadCastMultiVisit_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion, {in0, in1});
-  auto outputs = ke.runFusion({in0, in1});
+  auto outputs = ke.run({in0, in1});
 
   testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
 }
@@ -6538,7 +6538,7 @@ TEST_F(NVFuserTest, FusionBufferReuseStressTest_CUDA) {
   KernelExecutor ke;
   ke.compile(fusion, {in0, in1});
 
-  auto outputs = ke.runFusion({in0, in1});
+  auto outputs = ke.run({in0, in1});
 
   testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
 }
@@ -6569,7 +6569,7 @@ TEST_F(NVFuserTest, FusionBufferReuseLargeBuffer_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion, {in0});
-  auto outputs = ke.runFusion({in0});
+  auto outputs = ke.run({in0});
 
   testValidate(fusion, outputs, {in0}, __LINE__, __FILE__);
 }
@@ -6601,7 +6601,7 @@ TEST_F(NVFuserTest, FusionBufferReuseNo2hop_CUDA) {
   auto in1 = at::randn({2, 2, 2}, options);
   KernelExecutor ke;
   ke.compile(fusion, {in0, in1});
-  auto outputs = ke.runFusion({in0, in1});
+  auto outputs = ke.run({in0, in1});
 
   testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
 }
@@ -6635,7 +6635,7 @@ TEST_F(NVFuserTest, FusionBufferReuseAllocationOrder_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion, {in0});
-  auto outputs = ke.runFusion({in0});
+  auto outputs = ke.run({in0});
 
   testValidate(fusion, outputs, {in0}, __LINE__, __FILE__);
 }
@@ -6664,7 +6664,7 @@ TEST_F(NVFuserTest, FusionBufferReuseLiveInterval_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion, {in0});
-  auto cg_outputs = ke.runFusion({in0});
+  auto cg_outputs = ke.run({in0});
 
   testValidate(fusion, cg_outputs, {in0}, __LINE__, __FILE__);
 }
@@ -6698,7 +6698,7 @@ TEST_F(NVFuserTest, FusionBufferReuseNoAcrossBroadcast_CUDA) {
   auto in1 = at::randn({2, 2, 2}, options);
   KernelExecutor ke;
   ke.compile(fusion, {in0, in1});
-  auto outputs = ke.runFusion({in0, in1});
+  auto outputs = ke.run({in0, in1});
 
   testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
 }
@@ -6724,7 +6724,7 @@ TEST_F(NVFuserTest, FusionIssue970_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
@@ -6755,7 +6755,7 @@ TEST_F(NVFuserTest, FusionIssue1016_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
@@ -6786,7 +6786,7 @@ TEST_F(NVFuserTest, FusionIssue1021_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -6821,7 +6821,7 @@ TEST_F(NVFuserTest, FusionNonUniqueThreadDim_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_tv1, at_tv2}, __LINE__, __FILE__);
 }
@@ -6858,7 +6858,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
 
   testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
 }
@@ -6895,7 +6895,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1, input2});
-  auto outputs = ke.runFusion({input1, input2});
+  auto outputs = ke.run({input1, input2});
 
   testValidate(fusion.get(), outputs, {input1, input2}, __LINE__, __FILE__);
 }
@@ -6943,7 +6943,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {input1});
-  auto outputs = ke.runFusion({input1});
+  auto outputs = ke.run({input1});
 
   testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
 }
@@ -6989,7 +6989,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input1, input2});
-  auto outputs = ke.runFusion({input1, input2});
+  auto outputs = ke.run({input1, input2});
 
   testValidate(&fusion, outputs, {input1, input2}, __LINE__, __FILE__);
 }
@@ -7033,7 +7033,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input1, input2});
-  auto outputs = ke.runFusion({input1, input2});
+  auto outputs = ke.run({input1, input2});
 
   testValidate(&fusion, outputs, {input1, input2}, __LINE__, __FILE__);
 }
@@ -7187,7 +7187,7 @@ TEST_F(NVFuserTest, FusionSerialAndParallelIndexing_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -7240,7 +7240,7 @@ TEST_F(NVFuserTest, FusionWARSyncAliasedSmem_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -7291,7 +7291,7 @@ TEST_F(NVFuserTest, FusionIssue1099_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -7333,7 +7333,7 @@ TEST_F(NVFuserTest, FusionUnswitchPredicate_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -7372,7 +7372,7 @@ TEST_F(NVFuserTest, FusionIssue1189_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto outputs = ke.runFusion({t0, t1});
+  auto outputs = ke.run({t0, t1});
 
   testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -7405,7 +7405,7 @@ TEST_F(NVFuserTest, FusionIssue1052_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -7511,7 +7511,7 @@ TEST_F(NVFuserTest, FusionSmemAliasSerial_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -7541,7 +7541,7 @@ TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -7571,7 +7571,7 @@ TEST_F(NVFuserTest, FusionGridWelfordWithNonExactParallelDimensions_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto ref1 = t0 + 1;
   auto ref2 = mean(t2, {0});
@@ -7618,7 +7618,7 @@ TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions2_CUDA) {
   at::Tensor t2 = at::randn({5, 6, 7}, options);
   at::Tensor t4 = at::randn({8, 9, 10}, options);
   std::vector<c10::IValue> aten_inputs = {t0, t2, t4};
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -7662,7 +7662,7 @@ TEST_F(NVFuserTest, FusionGridWelfordWithNonExactParallelDimensions2_CUDA) {
   at::Tensor t2 = at::randn({5, 6, 7}, options);
   at::Tensor t4 = at::randn({8, 9, 10}, options);
   std::vector<c10::IValue> aten_inputs = {t0, t2, t4};
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto ref1 = t0.mean(at::IntArrayRef{0, 1});
   auto ref2 = t2 + 1;
@@ -7725,7 +7725,7 @@ TEST_F(NVFuserTest, FusionPredicateParallelizedDomains_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto ref1 = t0 + 3;
   auto ref2 = sum(t4 + 4);
@@ -7787,7 +7787,7 @@ TEST_F(NVFuserTest, FusionSmemPredicateUnswitch_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -7836,7 +7836,7 @@ TEST_F(NVFuserTest, FusionFloatPow_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto p4 = at::pow(t0, 4);
   auto p2 = at::pow(t0, 2);
@@ -7905,7 +7905,7 @@ TEST_F(NVFuserTest, FusionThreadPredicateUnswitch_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -7928,7 +7928,7 @@ TEST_F(NVFuserTest, FusionNonContigOutputs_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {at_input});
-  auto returned_outputs = ke.runFusion({at_input}, {at_output});
+  auto returned_outputs = ke.run({at_input}, {at_output});
 
   // Returned outputs should only contain one tensor that is the same
   // as the output tensor given to runFusion
@@ -7976,7 +7976,7 @@ TEST_F(NVFuserTest, FusionTestWarpSoftMax_CUDA) {
   // Test result
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
   auto ref_output = at::_softmax(aten_input, 1, false);
   testValidate(&fusion, outputs, aten_inputs, {ref_output}, __LINE__, __FILE__);
 }
@@ -8050,7 +8050,7 @@ TEST_F(NVFuserTest, FusionIssue1133_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto ref = (t0 + 1).sum({1}) + 1;
 
@@ -8084,7 +8084,7 @@ TEST_F(NVFuserTest, FusionRfactorContigIDs_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto ref = t0.sum({1});
 
@@ -8139,7 +8139,7 @@ TEST_F(NVFuserTest, FusionIssue1223_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {at_t0});
-  auto cg_outputs = ke.runFusion({at_t0});
+  auto cg_outputs = ke.run({at_t0});
 
   auto at_t1 = (at_t0 + 1).sum();
 
@@ -8183,7 +8183,7 @@ TEST_F(NVFuserTest, FusionRfactorPredication1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {at_t0, at_t3});
-  auto cg_outputs = ke.runFusion({at_t0, at_t3});
+  auto cg_outputs = ke.run({at_t0, at_t3});
 
   auto at_t2 = (at_t0 + 1).min();
   auto at_t4 = at_t3 + 1;
@@ -8235,7 +8235,7 @@ TEST_F(NVFuserTest, FusionRfactorPredication2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {at_t0, at_t3});
-  auto cg_outputs = ke.runFusion({at_t0, at_t3});
+  auto cg_outputs = ke.run({at_t0, at_t3});
 
   auto at_t2 = std::get<0>(at_t0.min(0));
   auto at_t4 = at_t3 + 1;
@@ -8272,7 +8272,7 @@ TEST_F(NVFuserTest, FusionRfactorIndirectRoot_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {at_in});
-  auto cg_outputs = ke.runFusion({at_in});
+  auto cg_outputs = ke.run({at_in});
 
   testValidate(&fusion, cg_outputs, {at_in}, {at_out}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_gpu2.cpp
+++ b/tests/cpp/test_gpu2.cpp
@@ -95,7 +95,7 @@ TEST_F(NVFuserTest, FusionGlobalIntermediate_CUDA) {
   auto lparams = LaunchParams(-1, -1, -1, runtime_threadIdx_dim, -1, -1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input}, lparams);
+  ke.compile(&fusion, {input}, lparams);
   auto cg_outputs = ke.runFusion({input}, lparams);
 
   auto aten_output = input.to(at::kDouble).sum({1});
@@ -142,7 +142,7 @@ TEST_F(NVFuserTest, FusionGlobalIntermediateDefaultSchedule_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1, t2, t3};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1, t2, t3});
+  ke.compile(&fusion, {t0, t1, t2, t3});
   auto cg_outputs = ke.runFusion({t0, t1, t2, t3});
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -200,7 +200,7 @@ TEST_F(NVFuserTest, FusionUnrollWithAlloc_CUDA) {
   tv1->computeAt(tv2_rf, -1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   auto aten_output = (input + 0).to(at::kDouble).sum(1);
@@ -277,7 +277,7 @@ TEST_F(NVFuserTest, FusionComputeAtNonterminatingOutput_CUDA) {
   auto t4 = t3 + 4;
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -311,7 +311,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder1_CUDA) {
       at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, cg_outputs);
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
 }
@@ -348,7 +348,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder2_CUDA) {
       at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, cg_outputs);
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -400,7 +400,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder3_CUDA) {
         at::empty_like(aten_input, options)};
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {aten_input});
+    ke.compile(&fusion, {aten_input});
     ke.runFusion({aten_input}, cg_outputs);
 
     testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -444,7 +444,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder4_CUDA) {
       at::empty_like(t0, options)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   ke.runFusion(aten_inputs, cg_outputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -477,7 +477,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder5_CUDA) {
       at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, cg_outputs);
 
   auto t1 = aten_input + 1;
@@ -519,7 +519,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder6_CUDA) {
   at::Tensor cg_output = at::empty_like(aten_input, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, {cg_output});
 
   testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
@@ -559,7 +559,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder7_CUDA) {
   at::Tensor cg_output = at::empty_like(aten_input, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, {cg_output});
 
   testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
@@ -620,7 +620,7 @@ TEST_F(NVFuserTest, FusionThreadPredicate_CUDA) {
       at::empty_like(aten_input, options), at::empty({numel_x}, options)};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, cg_outputs);
 
   testValidate(
@@ -740,7 +740,7 @@ TEST_F(NVFuserTest, FusionReduceSingle_CUDA) {
 
   // Grab only tensor views, though there shouldn't be any other type
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   // no broadcasting needed, omitting the last optional argument;
   auto cg_outputs = ke.runFusion({aten_input});
 
@@ -872,7 +872,7 @@ TEST_F(NVFuserTest, FusionTrivialReduction_CUDA) {
   at::Tensor aten_input = at::randn({10, 20, 1}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1282,7 +1282,7 @@ TEST_F(NVFuserTest, FusionIssue459_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   nvfuser::KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1312,7 +1312,7 @@ TEST_F(NVFuserTest, FusionSmemIndexingSimple_CUDA) {
   auto aten_input = at::randn({12, 34}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1423,7 +1423,7 @@ TEST_F(NVFuserTest, FusionSmemIndexing_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1, 3, 4, 5};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(
@@ -1458,7 +1458,7 @@ TEST_F(NVFuserTest, FusionCacheBeforeReduction_CUDA) {
   at::Tensor cg_output = at::empty({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   ke.runFusion({aten_input}, {cg_output});
 
   testValidate(&fusion, {cg_output}, {aten_input}, __LINE__, __FILE__);
@@ -1495,7 +1495,7 @@ TEST_F(NVFuserTest, FusionCacheBeforeReduction2_CUDA) {
   at::Tensor aten_input = at::randn({numel_x, numel_y, numel_z}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1601,7 +1601,7 @@ TEST_F(NVFuserTest, FusionIssue367_CUDA) {
       mul(t0.unsqueeze(2), t1.unsqueeze(0)).to(at::kDouble).sum(1);
 
   nvfuser::KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(
@@ -1627,7 +1627,7 @@ TEST_F(NVFuserTest, FusionIssue468_CUDA) {
   at::Tensor aten_input = at::randn({10, 100}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1679,7 +1679,7 @@ TEST_F(NVFuserTest, FusionIssue363_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   nvfuser::KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1705,7 +1705,7 @@ TEST_F(NVFuserTest, FusionIssue484_CUDA) {
   at::Tensor aten_input = at::randn({M, M}, options);
 
   nvfuser::KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1731,7 +1731,7 @@ TEST_F(NVFuserTest, FusionIssue329_CUDA) {
   auto aten_input = at::randn(t0_shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1772,7 +1772,7 @@ TEST_F(NVFuserTest, FusionIssue382_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t3};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1801,7 +1801,7 @@ TEST_F(NVFuserTest, FusionIssue507_CUDA) {
   auto aten_input = at::randn(t0_shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(&fusion, cg_outputs, {aten_input}, __LINE__, __FILE__);
@@ -1839,7 +1839,7 @@ TEST_F(NVFuserTest, FusionIssue532_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -1868,7 +1868,7 @@ TEST_F(NVFuserTest, FusionLoopUnswitch_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -1946,7 +1946,7 @@ TEST_F(NVFuserTest, FusionIssue549_CUDA) {
   LaunchParams lparams(1, -1, -1, 32, 4, 4);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1}, lparams);
+  ke.compile(&fusion, {t0, t1}, lparams);
   ke.runFusion({t0, t1}, lparams);
 
   // Make sure bad launch params throws
@@ -2326,7 +2326,7 @@ TEST_F(NVFuserTest, FusionWelfordOp_CUDA) {
   at::Tensor t0 = at::randn({M, N}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   // by default Welford outputs sum of square diff so need to divide to get var
@@ -2371,7 +2371,7 @@ TEST_F(NVFuserTest, FusionBlockWelfordOp_CUDA) {
   at::Tensor t_N = at::empty({M}, options_int);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   // by default Welford outputs sum of square diff so need to divide to get var
@@ -2416,7 +2416,7 @@ TEST_F(NVFuserTest, FusionGridWelfordOp_CUDA) {
   at::Tensor t_N = at::empty({M}, options_int);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   // by default Welford outputs sum of square diff so need to divide to get var
@@ -2460,7 +2460,7 @@ TEST_F(NVFuserTest, FusionRfactorWelfordOp_CUDA) {
   at::Tensor t_N = at::empty({M}, options_int);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   // by default Welford outputs sum of square diff so need to divide to get var
@@ -2597,7 +2597,7 @@ TEST_P(WelfordReduction, Test) {
   // pass uses int64 as index type, so the max vectorization factor is 16 bytes
   // sizeof(int64) = 2, which is wrong since the actual index type is int32
   // and the max vectorization factor is 4.
-  ke.compileFusion(&fusion, {aten_input}, lparams, cparams);
+  ke.compile(&fusion, {aten_input}, lparams, cparams);
   auto outputs = ke.runFusion({aten_input}, lparams);
 
   // by default Welford outputs sum of square diff so need to divide to
@@ -2756,7 +2756,7 @@ TEST_F(NVFuserTest, FusionSimpleGemmTransposed_CUDA) {
   // Lets specify a few bounds in launch params to make sure it works
   LaunchParams lparams(1, -1, -1, 32, 4, 4);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1}, lparams);
+  ke.compile(&fusion, {t0, t1}, lparams);
   ke.runFusion({t0, t1}, lparams);
 
   // Don't specify any launch params
@@ -2821,7 +2821,7 @@ TEST_F(NVFuserTest, FusionSoftmax3DTransposed_CUDA) {
   at::Tensor cg_output = at::empty({dimx, dimy, dimz}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   ke.runFusion({input}, {cg_output});
 
   auto aten_input_t = at::transpose(input, 1, 2);
@@ -2895,7 +2895,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed1_CUDA) {
   at::Tensor aten_input = at::randn({129, 127}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   at::Tensor aten_input_t = aten_input.t();
@@ -2964,7 +2964,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed2_CUDA) {
   at::Tensor input = at::randn({129, 127}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto cg_outputs = ke.runFusion({input});
 
   auto input_t = input.t();
@@ -3030,7 +3030,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed3_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto t0_t = t0.permute({3, 0, 1, 2});
@@ -3108,7 +3108,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed4_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1, t2, t3};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto t0_t = t0.permute({3, 0, 1, 2});
@@ -3156,7 +3156,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed5_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto t2 = t0.t().add(2.0);
@@ -3198,7 +3198,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed6_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto t2 = t0.t().add(2.0);
@@ -3349,7 +3349,7 @@ TEST_F(NVFuserTest, FusionVectorizeSimple_CUDA) {
   at::Tensor aten_input = at::empty({2, 6, 32}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   at::Tensor aten_output = aten_input.sin();
@@ -3424,7 +3424,7 @@ TEST_F(NVFuserTest, FusionSimpleVectorizeUnroll_CUDA) {
   at::Tensor output = at::empty_like(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input1, input2});
+  ke.compile(&fusion, {input1, input2});
   ke.runFusion({input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + 2.0;
@@ -3504,7 +3504,7 @@ TEST_F(NVFuserTest, FusionGridPersistence_CUDA) {
   at::Tensor input = at::randn({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto out = ke.runFusion({input});
 
   testValidate(&fusion, out, {input}, __LINE__, __FILE__);
@@ -3537,7 +3537,7 @@ TEST_F(NVFuserTest, FusionGridPersistence2_CUDA) {
   at::Tensor input = at::randn({numel_x, numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto out = ke.runFusion({input});
 
   testValidate(&fusion, out, {input}, __LINE__, __FILE__);
@@ -3571,7 +3571,7 @@ TEST_F(NVFuserTest, FusionWelfordPersistence_CUDA) {
   at::Tensor input = at::randn({numel_x}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto out = ke.runFusion({input});
 
   auto aten_output = (input.mean({0}) + (input.var({0}, false) * numel_x))
@@ -3611,7 +3611,7 @@ TEST_F(NVFuserTest, FusionWelfordPersistence2_CUDA) {
   at::Tensor input = at::randn({numel_x, numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   auto out = ke.runFusion({input});
 
   auto aten_output = (input.mean({0}) + (input.var({0}, false) * numel_x))
@@ -3649,7 +3649,7 @@ TEST_F(NVFuserTest, FusionIssue633_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -3682,7 +3682,7 @@ TEST_F(NVFuserTest, FusionBroadcastAcrossComputeAt_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -3731,7 +3731,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwise_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -3787,7 +3787,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeContig_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -3848,7 +3848,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicPass_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -3912,7 +3912,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicFail_CUDA) {
   // TODO: throw assertion - cannot merge non-contiguous vectorization axes
   // Make sure compilation fails
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.compileFusion(&fusion));
+  ASSERT_ANY_THROW(ke.compile(&fusion));
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedRFactor_CUDA) {
@@ -3965,7 +3965,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedRFactor_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto aten_output = t0.add(t1).sum(1);
@@ -4009,7 +4009,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedWrongDimFail_CUDA) {
   KernelExecutor ke;
   // Make sure compilation fails
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.compileFusion(&fusion));
+  ASSERT_ANY_THROW(ke.compile(&fusion));
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedStride_CUDA) {
@@ -4057,7 +4057,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStride_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -4111,7 +4111,7 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStrideFail_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   // Failure because the input + output tensors do not have the same stride
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
@@ -4158,7 +4158,7 @@ TEST_F(NVFuserTest, FusionVectorization1_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -4200,7 +4200,7 @@ TEST_F(NVFuserTest, FusionVectorization2_CUDA) {
   KernelExecutor ke;
   // Make sure compilation fails
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.compileFusion(&fusion));
+  ASSERT_ANY_THROW(ke.compile(&fusion));
 }
 
 // TODO: Re-enable once vectorization validation is fixed
@@ -4245,7 +4245,7 @@ TEST_F(NVFuserTest, FusionVectorization3_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   ASSERT_ANY_THROW(ke.runFusion(aten_inputs));
 
@@ -4310,7 +4310,7 @@ TEST_F(NVFuserTest, FusionVectorizationRFactor_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto aten_output = t0.add(t1).sum(1);
@@ -4373,7 +4373,7 @@ TEST_F(NVFuserTest, FusionSizeOneLoop1_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -4407,7 +4407,7 @@ TEST_F(NVFuserTest, FusionSizeOneLoop2_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -4430,7 +4430,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize1_CUDA) {
   // Invalid as tv1 and tv2 do have the same ParallelType
   KernelExecutor ke;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.compileFusion(&fusion));
+  ASSERT_ANY_THROW(ke.compile(&fusion));
 }
 
 TEST_F(NVFuserTest, FusionValidateParallelize2_CUDA) {
@@ -4451,7 +4451,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize2_CUDA) {
   // tv1 and tv2 do have the same ParallelType, but tv1 is on shared
   // memory, so it is valid
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 }
 
 TEST_F(NVFuserTest, FusionValidateParallelize3_CUDA) {
@@ -4474,7 +4474,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize3_CUDA) {
 
   // tv1 and tv2 have the same shape and ParallelType
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 }
 
 TEST_F(NVFuserTest, FusionValidateParallelize4_CUDA) {
@@ -4497,7 +4497,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize4_CUDA) {
 
   // tv1 and tv2 do not have the same shape but global memory comm is supported.
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 }
 
 TEST_F(NVFuserTest, FusionValidateParallelize5_CUDA) {
@@ -4521,7 +4521,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize5_CUDA) {
   // tv1 and tv2 do not have the same shape, but tv1 is on shared
   // memory, so it is valid
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 }
 
 // See issue #995
@@ -4649,7 +4649,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize8_CUDA) {
   at::Tensor input1 = at::arange(32, options) * 0.01;
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input0, input1});
+  ke.compile(&fusion, {input0, input1});
   auto outputs = ke.runFusion({input0, input1});
 
   testValidate(&fusion, outputs, {input0, input1}, __LINE__, __FILE__);
@@ -4738,7 +4738,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize10_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -4784,7 +4784,7 @@ TEST_F(NVFuserTest, FusionValidateParallelize11_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -4898,7 +4898,7 @@ TEST_F(NVFuserTest, FusionBlockReduceInSerialLoop_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4927,7 +4927,7 @@ TEST_F(NVFuserTest, FusionBlockWelfordInSerialLoop_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
   at::Tensor aten_avg = t0.mean({1, 2});
   at::Tensor aten_M2 = t0.var({1, 2}, false) * N * K;
@@ -4966,7 +4966,7 @@ TEST_F(NVFuserTest, FusionReductionPredicate_CUDA) {
   at::Tensor cg_output = at::empty({numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
+  ke.compile(&fusion, {input});
   ke.runFusion({input}, {cg_output});
 
   auto aten_output = input.to(at::kDouble).sum({0});
@@ -5063,7 +5063,7 @@ TEST_F(NVFuserTest, FusionIssue757_CUDA) {
   std::vector<c10::IValue> inputs = {t0, t3};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -5101,7 +5101,7 @@ TEST_F(NVFuserTest, FusionPredicatedBlockBroadcast_CUDA) {
   std::vector<c10::IValue> inputs = {t0, t3};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -6005,7 +6005,7 @@ TEST_F(NVFuserTest, FusionSimpleWarp_CUDA) {
   auto at_output = input1.sum({1}, true).add(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
 
   testValidate(
@@ -6054,7 +6054,7 @@ TEST_F(NVFuserTest, FusionSimpleWarpPad_CUDA) {
   auto at_output = input1.sum({1}, true).add(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
@@ -6099,7 +6099,7 @@ TEST_F(NVFuserTest, FusionWarpPadMergeSplit_CUDA) {
   auto at_output = input1.sum({1, 2}, true).add(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
@@ -6141,7 +6141,7 @@ TEST_F(NVFuserTest, FusionSerialWarpReduction_CUDA) {
   auto at_output = input1.sum({1, 2}, true).add(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
@@ -6186,7 +6186,7 @@ TEST_F(NVFuserTest, FusionTrivialWarpReduction_CUDA) {
   auto at_output = input1.sum({1, 2, 3}, true).add(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
@@ -6241,7 +6241,7 @@ TEST_F(NVFuserTest, FusionMultipleDimBinding_CUDA) {
   auto at_output = input1.sum({1}, true).add(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1, input2});
+  ke.compile(fusion.get(), {input1, input2});
   auto outputs = ke.runFusion({input1, input2});
   testValidate(
       fusion.get(),
@@ -6279,7 +6279,7 @@ TEST_F(NVFuserTest, FusionPadNoWarpReduce_CUDA) {
   at::Tensor input1 = at::randn({16, 31}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
   testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
 }
@@ -6314,7 +6314,7 @@ TEST_F(NVFuserTest, FusionWarpMutipleThreadDim_CUDA) {
   auto at_output = (input1 + 1).sum({1});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
@@ -6365,7 +6365,7 @@ TEST_F(NVFuserTest, FusionWarpReduceUnrollOuterLoop_CUDA) {
   auto at_output = input1.sum({1}, true).add(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
@@ -6411,7 +6411,7 @@ TEST_F(NVFuserTest, FusionWarpReducePredication_CUDA) {
   auto t2 = at::randn(shape2, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t2});
+  ke.compile(&fusion, {t0, t2});
   auto cg_outputs = ke.runFusion({t0, t2});
 
   auto t1 = t0.sum({0});
@@ -6492,7 +6492,7 @@ TEST_F(NVFuserTest, FusionBufferReuseBroadCastMultiVisit_CUDA) {
   auto in1 = at::randn({2, 2, 2}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {in0, in1});
+  ke.compile(fusion, {in0, in1});
   auto outputs = ke.runFusion({in0, in1});
 
   testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
@@ -6536,7 +6536,7 @@ TEST_F(NVFuserTest, FusionBufferReuseStressTest_CUDA) {
   auto in1 = at::randn({2, 2, 2}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {in0, in1});
+  ke.compile(fusion, {in0, in1});
 
   auto outputs = ke.runFusion({in0, in1});
 
@@ -6568,7 +6568,7 @@ TEST_F(NVFuserTest, FusionBufferReuseLargeBuffer_CUDA) {
   auto in0 = at::randn({256, 512}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {in0});
+  ke.compile(fusion, {in0});
   auto outputs = ke.runFusion({in0});
 
   testValidate(fusion, outputs, {in0}, __LINE__, __FILE__);
@@ -6600,7 +6600,7 @@ TEST_F(NVFuserTest, FusionBufferReuseNo2hop_CUDA) {
   auto in0 = at::randn({2, 2}, options);
   auto in1 = at::randn({2, 2, 2}, options);
   KernelExecutor ke;
-  ke.compileFusion(fusion, {in0, in1});
+  ke.compile(fusion, {in0, in1});
   auto outputs = ke.runFusion({in0, in1});
 
   testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
@@ -6634,7 +6634,7 @@ TEST_F(NVFuserTest, FusionBufferReuseAllocationOrder_CUDA) {
   auto in0 = at::randn({3, 3, 3}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {in0});
+  ke.compile(fusion, {in0});
   auto outputs = ke.runFusion({in0});
 
   testValidate(fusion, outputs, {in0}, __LINE__, __FILE__);
@@ -6663,7 +6663,7 @@ TEST_F(NVFuserTest, FusionBufferReuseLiveInterval_CUDA) {
   auto in0 = at::randn({16, 16}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {in0});
+  ke.compile(fusion, {in0});
   auto cg_outputs = ke.runFusion({in0});
 
   testValidate(fusion, cg_outputs, {in0}, __LINE__, __FILE__);
@@ -6697,7 +6697,7 @@ TEST_F(NVFuserTest, FusionBufferReuseNoAcrossBroadcast_CUDA) {
   auto in0 = at::randn({2, 2}, options);
   auto in1 = at::randn({2, 2, 2}, options);
   KernelExecutor ke;
-  ke.compileFusion(fusion, {in0, in1});
+  ke.compile(fusion, {in0, in1});
   auto outputs = ke.runFusion({in0, in1});
 
   testValidate(fusion, outputs, {in0, in1}, __LINE__, __FILE__);
@@ -6723,7 +6723,7 @@ TEST_F(NVFuserTest, FusionIssue970_CUDA) {
   at::Tensor t0 = at::randn({nelm, nelm}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
@@ -6754,7 +6754,7 @@ TEST_F(NVFuserTest, FusionIssue1016_CUDA) {
   std::vector<c10::IValue> inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
@@ -6785,7 +6785,7 @@ TEST_F(NVFuserTest, FusionIssue1021_CUDA) {
   std::vector<c10::IValue> inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -6820,7 +6820,7 @@ TEST_F(NVFuserTest, FusionNonUniqueThreadDim_CUDA) {
   auto at_tv2 = input1 + 1;
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
   testValidate(
       fusion.get(), outputs, {input1}, {at_tv1, at_tv2}, __LINE__, __FILE__);
@@ -6857,7 +6857,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap1_CUDA) {
   at::Tensor input1 = at::randn({32}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
 
   testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
@@ -6894,7 +6894,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap2_CUDA) {
   at::Tensor input2 = at::randn({11, 13}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1, input2});
+  ke.compile(fusion.get(), {input1, input2});
   auto outputs = ke.runFusion({input1, input2});
 
   testValidate(fusion.get(), outputs, {input1, input2}, __LINE__, __FILE__);
@@ -6942,7 +6942,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap3_CUDA) {
   at::Tensor input1 = at::randn({13}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {input1});
+  ke.compile(fusion.get(), {input1});
   auto outputs = ke.runFusion({input1});
 
   testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
@@ -6988,7 +6988,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap4_CUDA) {
   at::Tensor input2 = at::randn({15, 13}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input1, input2});
+  ke.compile(&fusion, {input1, input2});
   auto outputs = ke.runFusion({input1, input2});
 
   testValidate(&fusion, outputs, {input1, input2}, __LINE__, __FILE__);
@@ -7032,7 +7032,7 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap5_CUDA) {
   at::Tensor input2 = at::randn({13, 15}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input1, input2});
+  ke.compile(&fusion, {input1, input2});
   auto outputs = ke.runFusion({input1, input2});
 
   testValidate(&fusion, outputs, {input1, input2}, __LINE__, __FILE__);
@@ -7186,7 +7186,7 @@ TEST_F(NVFuserTest, FusionSerialAndParallelIndexing_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -7239,7 +7239,7 @@ TEST_F(NVFuserTest, FusionWARSyncAliasedSmem_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -7290,7 +7290,7 @@ TEST_F(NVFuserTest, FusionIssue1099_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t3};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -7332,7 +7332,7 @@ TEST_F(NVFuserTest, FusionUnswitchPredicate_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -7371,7 +7371,7 @@ TEST_F(NVFuserTest, FusionIssue1189_CUDA) {
   at::Tensor t1 = at::randn({16, 16, 1}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
@@ -7404,7 +7404,7 @@ TEST_F(NVFuserTest, FusionIssue1052_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -7510,7 +7510,7 @@ TEST_F(NVFuserTest, FusionSmemAliasSerial_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t4};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -7540,7 +7540,7 @@ TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t2};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -7570,7 +7570,7 @@ TEST_F(NVFuserTest, FusionGridWelfordWithNonExactParallelDimensions_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t2};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   auto ref1 = t0 + 1;
@@ -7611,7 +7611,7 @@ TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions2_CUDA) {
   tv5->axis(2)->parallelize(ParallelType::BIDz);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({2, 3}, options);
@@ -7655,7 +7655,7 @@ TEST_F(NVFuserTest, FusionGridWelfordWithNonExactParallelDimensions2_CUDA) {
   tv5->axis(2)->parallelize(ParallelType::BIDz);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({2, 3}, options);
@@ -7724,7 +7724,7 @@ TEST_F(NVFuserTest, FusionPredicateParallelizedDomains_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t4};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   auto ref1 = t0 + 3;
@@ -7786,7 +7786,7 @@ TEST_F(NVFuserTest, FusionSmemPredicateUnswitch_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -7835,7 +7835,7 @@ TEST_F(NVFuserTest, FusionFloatPow_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   auto p4 = at::pow(t0, 4);
@@ -7904,7 +7904,7 @@ TEST_F(NVFuserTest, FusionThreadPredicateUnswitch_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -7927,7 +7927,7 @@ TEST_F(NVFuserTest, FusionNonContigOutputs_CUDA) {
   at::Tensor at_output = at::empty_strided({10}, {2}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {at_input});
+  ke.compile(&fusion, {at_input});
   auto returned_outputs = ke.runFusion({at_input}, {at_output});
 
   // Returned outputs should only contain one tensor that is the same
@@ -7975,7 +7975,7 @@ TEST_F(NVFuserTest, FusionTestWarpSoftMax_CUDA) {
 
   // Test result
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
   auto ref_output = at::_softmax(aten_input, 1, false);
   testValidate(&fusion, outputs, aten_inputs, {ref_output}, __LINE__, __FILE__);
@@ -8049,7 +8049,7 @@ TEST_F(NVFuserTest, FusionIssue1133_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   auto ref = (t0 + 1).sum({1}) + 1;
@@ -8083,7 +8083,7 @@ TEST_F(NVFuserTest, FusionRfactorContigIDs_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   auto ref = t0.sum({1});
@@ -8138,7 +8138,7 @@ TEST_F(NVFuserTest, FusionIssue1223_CUDA) {
   at::Tensor at_t0 = at::ones({11, 10}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {at_t0});
+  ke.compile(&fusion, {at_t0});
   auto cg_outputs = ke.runFusion({at_t0});
 
   auto at_t1 = (at_t0 + 1).sum();
@@ -8182,7 +8182,7 @@ TEST_F(NVFuserTest, FusionRfactorPredication1_CUDA) {
   at::Tensor at_t3 = at::randn({128}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {at_t0, at_t3});
+  ke.compile(&fusion, {at_t0, at_t3});
   auto cg_outputs = ke.runFusion({at_t0, at_t3});
 
   auto at_t2 = (at_t0 + 1).min();
@@ -8234,7 +8234,7 @@ TEST_F(NVFuserTest, FusionRfactorPredication2_CUDA) {
   at::Tensor at_t3 = at::randn({128}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {at_t0, at_t3});
+  ke.compile(&fusion, {at_t0, at_t3});
   auto cg_outputs = ke.runFusion({at_t0, at_t3});
 
   auto at_t2 = std::get<0>(at_t0.min(0));
@@ -8271,7 +8271,7 @@ TEST_F(NVFuserTest, FusionRfactorIndirectRoot_CUDA) {
   auto at_out = at_in.sum({1, 2});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {at_in});
+  ke.compile(&fusion, {at_in});
   auto cg_outputs = ke.runFusion({at_in});
 
   testValidate(&fusion, cg_outputs, {at_in}, {at_out}, __LINE__, __FILE__);

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -109,7 +109,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = t0.sum();
 
@@ -163,7 +163,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -212,7 +212,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = (t0 + 1).sum();
 
@@ -262,7 +262,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = (t0 + 1).sum();
 
@@ -316,7 +316,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = (t0 + 1).sum();
 
@@ -359,7 +359,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplitVectorize1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 
@@ -367,7 +367,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplitVectorize1_CUDA) {
   // Since ceilDiv(8, 8) is not divisible by 4, the vectorization is
   // illegal. The run-time validation of vectorization should throw an error.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.runFusion({t0_non_divisible}));
+  ASSERT_ANY_THROW(ke.run({t0_non_divisible}));
 }
 
 // If a split is validated at run time, it's not necessary to predicate.
@@ -414,7 +414,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplitVectorize2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = (t0 + 1).sum();
 
@@ -480,10 +480,10 @@ TEST_F(NVFuserTest, FusionIntermediateTensorVectorize_CUDA) {
     // This should throw an exception as the extent of t0 is not
     // divisible by the vector width
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-    ASSERT_ANY_THROW(ke.runFusion({t0}));
+    ASSERT_ANY_THROW(ke.run({t0}));
 
     auto t1 = at::randn({16}, options);
-    auto cg_outputs = ke.runFusion({t1});
+    auto cg_outputs = ke.run({t1});
 
     testValidate(&fusion, cg_outputs, {t1}, __LINE__, __FILE__);
   }
@@ -531,7 +531,7 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -574,7 +574,7 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto t3 = t0.sum().unsqueeze(-1).unsqueeze(-1);
 
@@ -619,7 +619,7 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -792,7 +792,7 @@ TEST_F(NVFuserTest, FusionIssue1430_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion);
-  auto cg_outputs = ke.runFusion({t0}, LaunchParams(X, V, -1, Y, -1, -1));
+  auto cg_outputs = ke.run({t0}, LaunchParams(X, V, -1, Y, -1, -1));
 
   auto t0_double = t0.to(at::kDouble);
 
@@ -946,7 +946,7 @@ TEST_F(NVFuserTest, FusionTestGridComm_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -990,7 +990,7 @@ TEST_F(NVFuserTest, FusionTestGridComm2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -1023,7 +1023,7 @@ TEST_F(NVFuserTest, FusionLargeSmem_CUDA) {
   auto t0 = at::randn({(int)(12288 * 4)}, options);
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto ref = t0 + 1 + 2;
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -1100,7 +1100,7 @@ TEST_F(NVFuserTest, FusionSmemAlignment_CUDA) {
   KernelExecutor ke;
 
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -1159,7 +1159,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndex_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   NVF_CHECK(t0.equal(cg_outputs[0]));
 }
@@ -1234,7 +1234,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndexFail2_CUDA) {
   // vector word size. The two domains are merged, but they are not
   // contiguous, so contig indexing is not involved in this case.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.runFusion({t0}));
+  ASSERT_ANY_THROW(ke.run({t0}));
 }
 
 TEST_F(NVFuserTest, FusionVectorizeInputToOutput_CUDA) {
@@ -1262,16 +1262,16 @@ TEST_F(NVFuserTest, FusionVectorizeInputToOutput_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   NVF_CHECK(t0.equal(cg_outputs[0]));
 
   // Pass misaligned input. This must fail.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.runFusion({t0_misaligned}));
+  ASSERT_ANY_THROW(ke.run({t0_misaligned}));
 
   // Pass misaligned output. This must fail too.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.runFusion({t0}, {t1_misaligned}));
+  ASSERT_ANY_THROW(ke.run({t0}, {t1_misaligned}));
 }
 
 // Repro of issue #1530
@@ -1304,7 +1304,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndexValidationFail_CUDA) {
   ke.compile(&fusion, {t0});
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.runFusion({t0}));
+  ASSERT_ANY_THROW(ke.run({t0}));
 }
 
 TEST_F(NVFuserTest, FusionContigIndexingWithBroadcast_CUDA) {
@@ -1333,7 +1333,7 @@ TEST_F(NVFuserTest, FusionContigIndexingWithBroadcast_CUDA) {
   {
     KernelExecutor ke;
     ke.compile(&fusion, {t0, t1});
-    auto cg_outputs = ke.runFusion({t0, t1});
+    auto cg_outputs = ke.run({t0, t1});
 
     testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
   }
@@ -1343,7 +1343,7 @@ TEST_F(NVFuserTest, FusionContigIndexingWithBroadcast_CUDA) {
   {
     KernelExecutor ke;
     ke.compile(&fusion, {t0, t1});
-    auto cg_outputs = ke.runFusion({t0, t1});
+    auto cg_outputs = ke.run({t0, t1});
 
     testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
   }
@@ -1389,7 +1389,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndexValidationFail2_CUDA) {
 
   // Vectorization of tv2 should be detected as invalid.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.runFusion({t0, t1}));
+  ASSERT_ANY_THROW(ke.run({t0, t1}));
 }
 
 TEST_F(NVFuserTest, FusionVectorizeContigIndexWithBroadcast_CUDA) {
@@ -1435,7 +1435,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndexWithBroadcast_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -1514,7 +1514,7 @@ TEST_F(NVFuserTest, FusionTrivialReductionForwarding4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto t2 = t0.unsqueeze(0);
   auto t3 = t1 + t2;
@@ -1565,7 +1565,7 @@ TEST_F(NVFuserTest, FusionRAWSyncInsertionPlace1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -1610,7 +1610,7 @@ TEST_F(NVFuserTest, FusionRAWSyncInsertionPlace2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -1653,7 +1653,7 @@ TEST_F(NVFuserTest, FusionRAWSyncInsertionPlace3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -1758,7 +1758,7 @@ TEST_F(NVFuserTest, FusionSerialSmemWriteParallelRead1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1, t2});
-  auto cg_outputs = ke.runFusion({t0, t1, t2});
+  auto cg_outputs = ke.run({t0, t1, t2});
 
   testValidate(&fusion, cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
@@ -1798,7 +1798,7 @@ TEST_F(NVFuserTest, FusionSerialSmemWriteParallelRead2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1, t2});
-  auto cg_outputs = ke.runFusion({t0, t1, t2});
+  auto cg_outputs = ke.run({t0, t1, t2});
 
   testValidate(&fusion, cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
@@ -1844,7 +1844,7 @@ TEST_F(NVFuserTest, FusionSimpleCpAsync_CUDA) {
     ke.compile(&fusion, {t0, t1});
   }
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -1889,7 +1889,7 @@ TEST_F(NVFuserTest, FusionCpAsyncPredicate_CUDA) {
   }
 
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = t0.sum({1});
 
@@ -2008,7 +2008,7 @@ TEST_F(NVFuserTest, FusionPropagateParallelTypesToSiblings_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   testValidate(ke.kernel(), outputs, {t0}, {t0.mean({0})}, __LINE__, __FILE__);
 }
@@ -2217,7 +2217,7 @@ TEST_F(NVFuserTest, FusionTestReEntrantGridWelford_CUDA) {
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({X, Y, Y, Z}, options);
 
-  auto cg_outputs = ke.runFusion({t0}, LaunchParams(-1, -1, -1, -1, -1, -1));
+  auto cg_outputs = ke.run({t0}, LaunchParams(-1, -1, -1, -1, -1, -1));
 
   // by default Welford outputs sum of square diff so need to divide to get var
   cg_outputs[1] = cg_outputs[1].div((float)(X * Y * Y));
@@ -2282,7 +2282,7 @@ TEST_F(NVFuserTest, FusionRedundantPredSync_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -2347,7 +2347,7 @@ TEST_F(NVFuserTest, FusionRedundantPredSync2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -2429,7 +2429,7 @@ TEST_F(NVFuserTest, FusionRedundantPredSync3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -2534,7 +2534,7 @@ TEST_F(NVFuserTest, FusionUnsqueeze1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -2569,7 +2569,7 @@ TEST_F(NVFuserTest, FusionSqueeze1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -2598,7 +2598,7 @@ TEST_F(NVFuserTest, FusionContigPredicate_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(ke.kernel(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -2622,7 +2622,7 @@ TEST_F(NVFuserTest, FusionDivScalarLhs_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, {aten_output}, __LINE__, __FILE__);
 }
@@ -3244,7 +3244,7 @@ TEST_F(NVFuserTest, FusionIssue1785Repro_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {in1, in2});
-  auto cg_outputs = ke.runFusion({in1, in2});
+  auto cg_outputs = ke.run({in1, in2});
 
   testValidate(&fusion, cg_outputs, {in1, in2}, __LINE__, __FILE__);
 }
@@ -3518,7 +3518,7 @@ TEST_F(NVFuserTest, FusionVectorComponentReduce_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__, "");
 }
@@ -3801,7 +3801,7 @@ TEST_F(NVFuserTest, FusionPredicateUnshare_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto out = cg_outputs[0];
 
   testValidate(fusion, {out}, {t0}, __LINE__, __FILE__);
@@ -3881,7 +3881,7 @@ TEST_F(NVFuserTest, FusionMergeBroadcastingTrivialReduction1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto out = cg_outputs[0];
 
   testValidate(
@@ -3925,7 +3925,7 @@ TEST_F(NVFuserTest, FusionMappingRelation_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto out = cg_outputs[0];
 
   testValidate(fusion, {out}, {t0, t1}, __LINE__, __FILE__);
@@ -3949,7 +3949,7 @@ TEST_F(NVFuserTest, FusionInlineAt_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto out = cg_outputs[0];
 
   testValidate(fusion, {out}, {t0}, __LINE__, __FILE__);
@@ -3983,7 +3983,7 @@ TEST_F(NVFuserTest, FusionReplayTrivialReductionAndBroadcast2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4055,7 +4055,7 @@ TEST_F(NVFuserTest, FusionSimpleAmperePipeline_CUDA) {
     ke.compile(&fusion, {input1});
   }
 
-  auto cg_outputs = ke.runFusion({input1});
+  auto cg_outputs = ke.run({input1});
 
   testValidate(&fusion, cg_outputs, {input1}, __LINE__, __FILE__);
 }
@@ -4430,7 +4430,7 @@ TEST_F(NVFuserTest, FusionSqueezeTransformPropagation_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -4484,7 +4484,7 @@ TEST_F(NVFuserTest, FusionSqueezeInlining_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -4887,7 +4887,7 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   NVF_CHECK(t0.equal(cg_outputs[0]));
 }
@@ -4994,7 +4994,7 @@ TEST_F(NVFuserTest, FusionIssue2163ReproInvalidAlias_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
   auto cg_output = cg_outputs.at(0);
 
   auto ref_x_sub_mean = at_input - at_input.sum({0}).unsqueeze(0);
@@ -5082,7 +5082,7 @@ TEST_F(NVFuserTest, FusionFloatingPointType_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
 
   testValidate(&fusion, cg_outputs, inputs, __LINE__, __FILE__);
 }
@@ -5148,7 +5148,7 @@ TEST_F(NVFuserTest, FusionIntegerType_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
 
   auto i2 = int64_val;
   auto i3 = int_val;
@@ -5211,7 +5211,7 @@ TEST_F(NVFuserTest, FusionVectorizeWelford1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref_avg = t0.mean({0});
   auto ref_var = t0.var({0}, false) * shape[0];
@@ -5284,7 +5284,7 @@ TEST_F(NVFuserTest, FusionVectorizeWelford2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref_avg = t0.to(at::kDouble).mean({0});
   auto ref_var = t0.to(at::kDouble).var({0}, false) * shape[0];
@@ -5386,7 +5386,7 @@ TEST_F(NVFuserTest, FusionExprSortMatmulLikeSchedule_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(ke.kernel(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -5455,7 +5455,7 @@ TEST_F(NVFuserTest, FusionCpAsyncCommitWait_CUDA) {
     ke.compile(&fusion, {t0});
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(ke.kernel(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
@@ -5521,7 +5521,7 @@ TEST_F(NVFuserTest, FusionClearThreadPredicateByRAWSync_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
 
   auto t3 = t0.sum({1}).sum({0});
   auto t6 = t0.sum({1});
@@ -5643,7 +5643,7 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitShared_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
 
   auto ref_t1 = t0.sum({0});
   auto ref_t4 = t1.exp();
@@ -5697,7 +5697,7 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitGlobal_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
 
   auto ref_t1 = t0.sum({0});
   auto ref_t3 = t1.exp();
@@ -5780,8 +5780,8 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
 
       // Since the index type is int64, both small and large inputs
       // should work fine
-      ke.runFusion(small_inputs);
-      ke.runFusion(large_inputs);
+      ke.run(small_inputs);
+      ke.run(large_inputs);
     }
 
     {
@@ -5797,8 +5797,8 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
 
       // Since the index type is int64, both small and large inputs
       // should work fine
-      ke.runFusion(small_inputs);
-      ke.runFusion(large_inputs);
+      ke.run(small_inputs);
+      ke.run(large_inputs);
     }
 
     {
@@ -5814,15 +5814,13 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
 
       // This should complete successfully as the arguments are small
       // enough to use the int32 index type
-      ke.runFusion(small_inputs);
+      ke.run(small_inputs);
 
       // This should fail as the Kernel is already compiled for Int32, but
       // the arguments are too large
       CompileParams compile_opts_large = {.index_type = PrimDataType::Int};
       EXPECT_THAT(
-          [&]() {
-            ke.runFusion(large_inputs, launch_params, compile_opts_large);
-          },
+          [&]() { ke.run(large_inputs, launch_params, compile_opts_large); },
           testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
               "Kernel index type and compilation index type don't match")));
     }
@@ -6249,7 +6247,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteNonOutput_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), inputs);
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
 
   // check thread_pred
   auto kernel = ke.kernel();
@@ -6313,7 +6311,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteNonNeighbor_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), inputs);
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
 
   // check thread_pred
   auto kernel = ke.kernel();
@@ -6769,7 +6767,7 @@ TEST_F(ExpandedBroadcastGlobalIntermediateTest, TheTest_CUDA) {
 
   KernelExecutor ke;
   ke.compile(fusion_ptr.get(), {t0});
-  auto cg_output = ke.runFusion({t0}).at(0);
+  auto cg_output = ke.run({t0}).at(0);
 
   ASSERT_EQ(cg_output.size(0), 2);
   ASSERT_EQ(cg_output.size(1), (1L << 60L));
@@ -6818,7 +6816,7 @@ TEST_F(NVFuserTest, FusionTestWarnRegisterSpill_CUDA) {
     compile_opts.enable_ptxas_verbose = true;
     KernelExecutor ke;
     ke.compile(&fusion, {aten_input}, heuristic_params->lparams, compile_opts);
-    auto cg_outputs = ke.runFusion({aten_input});
+    auto cg_outputs = ke.run({aten_input});
 
     // validate results
     testValidate(
@@ -6935,7 +6933,7 @@ TEST_F(NVFuserTest, IsFinite_CUDA) {
 
     KernelExecutor ke;
     ke.compile(fusion, {input});
-    const auto output = ke.runFusion({input});
+    const auto output = ke.run({input});
 
     testValidate(fusion, output, {input}, __LINE__, __FILE__);
   }
@@ -7410,7 +7408,7 @@ TEST_F(NVFuserTest, AllInputDtypes) {
 
     KernelExecutor ke;
     ke.compile(fusion.get(), args, LaunchParams{}, opt);
-    auto outputs = ke.runFusion(args, LaunchParams{}, opt);
+    auto outputs = ke.run(args, LaunchParams{}, opt);
 
     auto kernel_result = outputs.at(0).item<double>();
     auto expect = ee.evaluate(output).as<at::Tensor>().item<double>();
@@ -7530,7 +7528,7 @@ TEST_F(NVFuserTest, OpaqueTupleAsComplex) {
 
   KernelExecutor ke;
   ke.compile(&fusion);
-  auto outputs = ke.runFusion(args);
+  auto outputs = ke.run(args);
 
   EXPECT_EQ(
       outputs.at(0).item<c10::complex<float>>(), c10::complex<float>(1.2, 3.4));
@@ -7557,7 +7555,7 @@ TEST_F(NVFuserTest, StructConstruct) {
 
   KernelExecutor ke;
   ke.compile(&fusion);
-  auto outputs = ke.runFusion({1.2, 3.4});
+  auto outputs = ke.run({1.2, 3.4});
 
   EXPECT_EQ(
       outputs.at(0).item<c10::complex<float>>(), c10::complex<float>(1.2, 3.4));
@@ -7598,7 +7596,7 @@ TEST_F(NVFuserTest, VectorizationStrideValidation) {
 
   // This previously triggered a false positive error with the stride
   // validation
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   ASSERT_TRUE(cg_outputs[0].equal(t0));
 }
@@ -7625,7 +7623,7 @@ TEST_F(NVFuserTest, ConstLongExpressions) {
   KernelExecutor ke;
   ke.compile(fusion);
 
-  auto outputs = ke.runFusion({});
+  auto outputs = ke.run({});
 
   testValidate(fusion, outputs, {}, __LINE__, __FILE__);
 }
@@ -7697,7 +7695,7 @@ TEST_F(NVFuserTest, PredicateRNGOps) {
   KernelExecutor ke;
   ke.compile(fusion, {t0});
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 }
 
 TEST_F(NVFuserTest, LoweringHook) {
@@ -7952,7 +7950,7 @@ TEST_F(NVFuserTest, BlockReduction3D) {
 
     KernelExecutor ke;
     ke.compile(&fusion, {t0});
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
     auto ref = t0.sum(0).sum(-1);
     testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
   };
@@ -7995,7 +7993,7 @@ TEST_F(NVFuserTest, ReverseMerge) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   ASSERT_TRUE(t0.equal(cg_outputs.at(0)));
 }
 
@@ -8025,7 +8023,7 @@ TEST_F(NVFuserTest, FusionCpAsyncPredicateAvoidIllegalMemoryAccess) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   ASSERT_TRUE(t0.equal(cg_outputs.at(0)));
 }
 
@@ -8359,7 +8357,7 @@ TEST_F(NVFuserTest, BroadcastFromNowhereFusion) {
   at::Tensor t1 = at::randn({2, 4}, options);
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
@@ -8443,7 +8441,7 @@ TEST_F(NVFuserTest, MultipleDifferentSizeGridReduction) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
 
   testValidate(&fusion, cg_outputs, inputs, __LINE__, __FILE__);
 }
@@ -8878,7 +8876,7 @@ TEST_F(NVFuserTest, CpAsyncDataTypeBool) {
   // If not correctly lowered, would trigger error in compile
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -108,7 +108,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit1_CUDA) {
   at::Tensor t0 = at::randn({24}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = t0.sum();
@@ -162,7 +162,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit2_CUDA) {
   at::Tensor t0 = at::randn({13, 17}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -211,7 +211,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit3_CUDA) {
   at::Tensor t0 = at::randn({24}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = (t0 + 1).sum();
@@ -261,7 +261,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit4_CUDA) {
   at::Tensor t0 = at::randn({24, 2}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = (t0 + 1).sum();
@@ -315,7 +315,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplit5_CUDA) {
   at::Tensor t0 = at::randn({24}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = (t0 + 1).sum();
@@ -358,7 +358,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplitVectorize1_CUDA) {
   auto t0 = at::randn({32}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -413,7 +413,7 @@ TEST_F(NVFuserTest, FusionNonDivisibleSplitVectorize2_CUDA) {
   auto t0 = at::randn({1024}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = (t0 + 1).sum();
@@ -475,7 +475,7 @@ TEST_F(NVFuserTest, FusionIntermediateTensorVectorize_CUDA) {
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     auto t0 = at::randn({15}, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion);
+    ke.compile(&fusion);
 
     // This should throw an exception as the extent of t0 is not
     // divisible by the vector width
@@ -530,7 +530,7 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization1_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -573,7 +573,7 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization2_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   auto t3 = t0.sum().unsqueeze(-1).unsqueeze(-1);
@@ -618,7 +618,7 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization3_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -791,7 +791,7 @@ TEST_F(NVFuserTest, FusionIssue1430_CUDA) {
   at::Tensor t0 = at::randn({V, W, X, Y, Z}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
   auto cg_outputs = ke.runFusion({t0}, LaunchParams(X, V, -1, Y, -1, -1));
 
   auto t0_double = t0.to(at::kDouble);
@@ -945,7 +945,7 @@ TEST_F(NVFuserTest, FusionTestGridComm_CUDA) {
   auto t1 = at::randn({X, Y, Z}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -989,7 +989,7 @@ TEST_F(NVFuserTest, FusionTestGridComm2_CUDA) {
   auto t1 = at::randn({W, X}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -1022,7 +1022,7 @@ TEST_F(NVFuserTest, FusionLargeSmem_CUDA) {
 
   auto t0 = at::randn({(int)(12288 * 4)}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
   auto ref = t0 + 1 + 2;
 
@@ -1060,7 +1060,7 @@ TEST_F(NVFuserTest, FusionTooLargeSmem_CUDA) {
   KernelExecutor ke;
 
   //  NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.compileFusion(&fusion, {t0}));
+  ASSERT_ANY_THROW(ke.compile(&fusion, {t0}));
 }
 
 // Try to test alignment when multiple tensors are
@@ -1099,7 +1099,7 @@ TEST_F(NVFuserTest, FusionSmemAlignment_CUDA) {
   auto t0 = at::randn({3, 4, 7, 2, 5}, options);
   KernelExecutor ke;
 
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -1127,7 +1127,7 @@ TEST_F(NVFuserTest, FusionImmediateValueAsInput_CUDA) {
 
   // Make sure the kernel is compiled.
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 }
 
 // Repro of #1506
@@ -1158,7 +1158,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndex_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   NVF_CHECK(t0.equal(cg_outputs[0]));
@@ -1195,7 +1195,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndexFail_CUDA) {
   KernelExecutor ke;
   // This should fail at compile time as we're trying to merge in a
   // non-contiguous dimension, then split and vectorize it.
-  ASSERT_ANY_THROW(ke.compileFusion(&fusion, {t0}));
+  ASSERT_ANY_THROW(ke.compile(&fusion, {t0}));
 }
 
 // Make sure the same fusion as FusionVectorizeContigIndex fails if
@@ -1228,7 +1228,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndexFail2_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   // This should fail at the launch time as 14 is not divisible by the
   // vector word size. The two domains are merged, but they are not
@@ -1261,7 +1261,7 @@ TEST_F(NVFuserTest, FusionVectorizeInputToOutput_CUDA) {
       at::empty({n + 1}, options).index({at::indexing::Slice(1)});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
   NVF_CHECK(t0.equal(cg_outputs[0]));
 
@@ -1301,7 +1301,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndexValidationFail_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   ASSERT_ANY_THROW(ke.runFusion({t0}));
@@ -1332,7 +1332,7 @@ TEST_F(NVFuserTest, FusionContigIndexingWithBroadcast_CUDA) {
 
   {
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0, t1});
+    ke.compile(&fusion, {t0, t1});
     auto cg_outputs = ke.runFusion({t0, t1});
 
     testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -1342,7 +1342,7 @@ TEST_F(NVFuserTest, FusionContigIndexingWithBroadcast_CUDA) {
   tv2->setMemoryType(MemoryType::Global);
   {
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0, t1});
+    ke.compile(&fusion, {t0, t1});
     auto cg_outputs = ke.runFusion({t0, t1});
 
     testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -1385,7 +1385,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndexValidationFail2_CUDA) {
   auto t1 = at::randn(shape2, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
 
   // Vectorization of tv2 should be detected as invalid.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
@@ -1434,7 +1434,7 @@ TEST_F(NVFuserTest, FusionVectorizeContigIndexWithBroadcast_CUDA) {
   auto t1 = at::randn(shape2, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -1513,7 +1513,7 @@ TEST_F(NVFuserTest, FusionTrivialReductionForwarding4_CUDA) {
   auto t1 = at::randn({123, 111}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   auto t2 = t0.unsqueeze(0);
@@ -1564,7 +1564,7 @@ TEST_F(NVFuserTest, FusionRAWSyncInsertionPlace1_CUDA) {
   auto t1 = at::randn({10, 64}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -1609,7 +1609,7 @@ TEST_F(NVFuserTest, FusionRAWSyncInsertionPlace2_CUDA) {
   auto t1 = at::randn({10, 64}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -1652,7 +1652,7 @@ TEST_F(NVFuserTest, FusionRAWSyncInsertionPlace3_CUDA) {
   auto t1 = at::randn({50, 64}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -1757,7 +1757,7 @@ TEST_F(NVFuserTest, FusionSerialSmemWriteParallelRead1_CUDA) {
   at::Tensor t2 = at::randn({128, 6}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1, t2});
+  ke.compile(&fusion, {t0, t1, t2});
   auto cg_outputs = ke.runFusion({t0, t1, t2});
 
   testValidate(&fusion, cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
@@ -1797,7 +1797,7 @@ TEST_F(NVFuserTest, FusionSerialSmemWriteParallelRead2_CUDA) {
   at::Tensor t2 = at::randn({128, 6}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1, t2});
+  ke.compile(&fusion, {t0, t1, t2});
   auto cg_outputs = ke.runFusion({t0, t1, t2});
 
   testValidate(&fusion, cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
@@ -1836,14 +1836,14 @@ TEST_F(NVFuserTest, FusionSimpleCpAsync_CUDA) {
   // requires ampere+ GPU
   if (!deviceMajorMinorCheck(8)) {
     ASSERT_THAT(
-        [&]() { ke.compileFusion(&fusion, {t0, t1}); },
+        [&]() { ke.compile(&fusion, {t0, t1}); },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
   } else {
-    ke.compileFusion(&fusion, {t0, t1});
+    ke.compile(&fusion, {t0, t1});
   }
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -1880,15 +1880,15 @@ TEST_F(NVFuserTest, FusionCpAsyncPredicate_CUDA) {
   KernelExecutor ke;
   if (!deviceMajorMinorCheck(8)) {
     ASSERT_THAT(
-        [&]() { ke.compileFusion(&fusion, {t0}); },
+        [&]() { ke.compile(&fusion, {t0}); },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
   } else {
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
   }
 
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = t0.sum({1});
@@ -2007,7 +2007,7 @@ TEST_F(NVFuserTest, FusionPropagateParallelTypesToSiblings_CUDA) {
   at::Tensor t0 = at::randn({9999}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   testValidate(ke.kernel(), outputs, {t0}, {t0.mean({0})}, __LINE__, __FILE__);
@@ -2212,7 +2212,7 @@ TEST_F(NVFuserTest, FusionTestReEntrantGridWelford_CUDA) {
   checker.handle(gpulw.run()->topLevelExprs());
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {}, LaunchParams());
+  ke.compile(&fusion, {}, LaunchParams());
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({X, Y, Y, Z}, options);
@@ -2281,7 +2281,7 @@ TEST_F(NVFuserTest, FusionRedundantPredSync_CUDA) {
   at::Tensor t1 = at::randn({32, 32}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -2346,7 +2346,7 @@ TEST_F(NVFuserTest, FusionRedundantPredSync2_CUDA) {
   at::Tensor t1 = at::randn({32, 32}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -2428,7 +2428,7 @@ TEST_F(NVFuserTest, FusionRedundantPredSync3_CUDA) {
   at::Tensor t1 = at::randn({32, 32}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -2533,7 +2533,7 @@ TEST_F(NVFuserTest, FusionUnsqueeze1_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -2568,7 +2568,7 @@ TEST_F(NVFuserTest, FusionSqueeze1_CUDA) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -2597,7 +2597,7 @@ TEST_F(NVFuserTest, FusionContigPredicate_CUDA) {
   at::Tensor t0 = at::randn({3, 4}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(ke.kernel(), cg_outputs, {t0}, __LINE__, __FILE__);
@@ -2621,7 +2621,7 @@ TEST_F(NVFuserTest, FusionDivScalarLhs_CUDA) {
       at::native::wrapped_scalar_tensor(at::Scalar(2.0), options.device()), t0);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, {aten_output}, __LINE__, __FILE__);
@@ -3243,7 +3243,7 @@ TEST_F(NVFuserTest, FusionIssue1785Repro_CUDA) {
   at::Tensor in2 = at::randn({12, 16}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {in1, in2});
+  ke.compile(&fusion, {in1, in2});
   auto cg_outputs = ke.runFusion({in1, in2});
 
   testValidate(&fusion, cg_outputs, {in1, in2}, __LINE__, __FILE__);
@@ -3517,7 +3517,7 @@ TEST_F(NVFuserTest, FusionVectorComponentReduce_CUDA) {
   auto t0 = at::randn({1024}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0});
+  ke.compile(fusion.get(), {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__, "");
@@ -3800,7 +3800,7 @@ TEST_F(NVFuserTest, FusionPredicateUnshare_CUDA) {
   at::Tensor t0 = at::randn({5, 5}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {t0});
+  ke.compile(fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
   auto out = cg_outputs[0];
 
@@ -3880,7 +3880,7 @@ TEST_F(NVFuserTest, FusionMergeBroadcastingTrivialReduction1_CUDA) {
   at::Tensor t1 = at::randn({10}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {t0, t1});
+  ke.compile(fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
   auto out = cg_outputs[0];
 
@@ -3924,7 +3924,7 @@ TEST_F(NVFuserTest, FusionMappingRelation_CUDA) {
   at::Tensor t1 = at::randn({2, 1, 1}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {t0, t1});
+  ke.compile(fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
   auto out = cg_outputs[0];
 
@@ -3948,7 +3948,7 @@ TEST_F(NVFuserTest, FusionInlineAt_CUDA) {
   at::Tensor t0 = at::randn({100, 2}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {t0});
+  ke.compile(fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
   auto out = cg_outputs[0];
 
@@ -3982,7 +3982,7 @@ TEST_F(NVFuserTest, FusionReplayTrivialReductionAndBroadcast2_CUDA) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), aten_inputs);
+  ke.compile(fusion_ptr.get(), aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -4047,12 +4047,12 @@ TEST_F(NVFuserTest, FusionSimpleAmperePipeline_CUDA) {
   // requires ampere+ GPU
   if (!deviceMajorMinorCheck(8)) {
     ASSERT_THAT(
-        [&]() { ke.compileFusion(&fusion, {input1}); },
+        [&]() { ke.compile(&fusion, {input1}); },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
   } else {
-    ke.compileFusion(&fusion, {input1});
+    ke.compile(&fusion, {input1});
   }
 
   auto cg_outputs = ke.runFusion({input1});
@@ -4429,7 +4429,7 @@ TEST_F(NVFuserTest, FusionSqueezeTransformPropagation_CUDA) {
   at::Tensor t0 = at::randn({5, 1, 1, 1, 1}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -4483,7 +4483,7 @@ TEST_F(NVFuserTest, FusionSqueezeInlining_CUDA) {
   at::Tensor t0 = at::randn({1, 1024}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -4886,7 +4886,7 @@ TEST_F(NVFuserTest, FusionPropagateVectorizePredicate_CUDA) {
   at::Tensor t0 = at::randn({32}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   NVF_CHECK(t0.equal(cg_outputs[0]));
@@ -4993,7 +4993,7 @@ TEST_F(NVFuserTest, FusionIssue2163ReproInvalidAlias_CUDA) {
   std::vector<c10::IValue> aten_inputs({at_input, at_weight});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), aten_inputs);
+  ke.compile(fusion_ptr.get(), aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
   auto cg_output = cg_outputs.at(0);
 
@@ -5081,7 +5081,7 @@ TEST_F(NVFuserTest, FusionFloatingPointType_CUDA) {
   std::vector<c10::IValue> inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto cg_outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, cg_outputs, inputs, __LINE__, __FILE__);
@@ -5147,7 +5147,7 @@ TEST_F(NVFuserTest, FusionIntegerType_CUDA) {
   std::vector<c10::IValue> inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto cg_outputs = ke.runFusion(inputs);
 
   auto i2 = int64_val;
@@ -5210,7 +5210,7 @@ TEST_F(NVFuserTest, FusionVectorizeWelford1_CUDA) {
   at::Tensor t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref_avg = t0.mean({0});
@@ -5283,7 +5283,7 @@ TEST_F(NVFuserTest, FusionVectorizeWelford2_CUDA) {
   at::Tensor t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref_avg = t0.to(at::kDouble).mean({0});
@@ -5385,7 +5385,7 @@ TEST_F(NVFuserTest, FusionExprSortMatmulLikeSchedule_CUDA) {
   at::Tensor t1 = at::randn({N1, N2, K1, K2}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(ke.kernel(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -5447,12 +5447,12 @@ TEST_F(NVFuserTest, FusionCpAsyncCommitWait_CUDA) {
   KernelExecutor ke;
   if (!deviceMajorMinorCheck(8)) {
     ASSERT_THAT(
-        [&]() { ke.compileFusion(&fusion, {t0}); },
+        [&]() { ke.compile(&fusion, {t0}); },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
   } else {
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
   }
 
   auto cg_outputs = ke.runFusion({t0});
@@ -5520,7 +5520,7 @@ TEST_F(NVFuserTest, FusionClearThreadPredicateByRAWSync_CUDA) {
   std::vector<c10::IValue> inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto cg_outputs = ke.runFusion(inputs);
 
   auto t3 = t0.sum({1}).sum({0});
@@ -5642,7 +5642,7 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitShared_CUDA) {
   std::vector<c10::IValue> inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto cg_outputs = ke.runFusion(inputs);
 
   auto ref_t1 = t0.sum({0});
@@ -5696,7 +5696,7 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitGlobal_CUDA) {
   std::vector<c10::IValue> inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto cg_outputs = ke.runFusion(inputs);
 
   auto ref_t1 = t0.sum({0});
@@ -5771,7 +5771,7 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
       KernelExecutor ke;
       // Lower the kernel with large inputs and int64 index type.
       CompileParams compile_opts = {.index_type = PrimDataType::Int};
-      ke.compileFusion(&fusion, large_inputs, LaunchParams(), compile_opts);
+      ke.compile(&fusion, large_inputs, LaunchParams(), compile_opts);
 
       NVF_CHECK(
           ke.kernel()->indexType() == PrimDataType::Int,
@@ -5788,7 +5788,7 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
       KernelExecutor ke;
       // Lower the kernel with small inputs and int64 index type.
       CompileParams compile_opts = {.index_type = PrimDataType::Int};
-      ke.compileFusion(&fusion, small_inputs, LaunchParams(), compile_opts);
+      ke.compile(&fusion, small_inputs, LaunchParams(), compile_opts);
 
       NVF_CHECK(
           ke.kernel()->indexType() == PrimDataType::Int,
@@ -5805,7 +5805,7 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
       KernelExecutor ke;
       LaunchParams launch_params;
       CompileParams compile_opts = {.index_type = PrimDataType::Int32};
-      ke.compileFusion(&fusion, small_inputs, launch_params, compile_opts);
+      ke.compile(&fusion, small_inputs, launch_params, compile_opts);
 
       NVF_CHECK(
           ke.kernel()->indexType() == PrimDataType::Int32,
@@ -5834,8 +5834,7 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
       // This should fail due to the conflict
       EXPECT_THAT(
           [&]() {
-            ke.compileFusion(
-                &fusion, large_inputs, LaunchParams(), compile_opts);
+            ke.compile(&fusion, large_inputs, LaunchParams(), compile_opts);
           },
           testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
               "Compilation with int32 is requested but int64 is required for the arguments")));
@@ -6249,7 +6248,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteNonOutput_CUDA) {
   std::vector<c10::IValue> inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), inputs);
+  ke.compile(fusion_ptr.get(), inputs);
   auto cg_outputs = ke.runFusion(inputs);
 
   // check thread_pred
@@ -6313,7 +6312,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteNonNeighbor_CUDA) {
   std::vector<c10::IValue> inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), inputs);
+  ke.compile(fusion_ptr.get(), inputs);
   auto cg_outputs = ke.runFusion(inputs);
 
   // check thread_pred
@@ -6769,7 +6768,7 @@ TEST_F(ExpandedBroadcastGlobalIntermediateTest, TheTest_CUDA) {
   at::Tensor t0 = at::randn({2, 1, 2}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), {t0});
+  ke.compile(fusion_ptr.get(), {t0});
   auto cg_output = ke.runFusion({t0}).at(0);
 
   ASSERT_EQ(cg_output.size(0), 2);
@@ -6818,8 +6817,7 @@ TEST_F(NVFuserTest, FusionTestWarnRegisterSpill_CUDA) {
     compile_opts.maxrregcount = 32;
     compile_opts.enable_ptxas_verbose = true;
     KernelExecutor ke;
-    ke.compileFusion(
-        &fusion, {aten_input}, heuristic_params->lparams, compile_opts);
+    ke.compile(&fusion, {aten_input}, heuristic_params->lparams, compile_opts);
     auto cg_outputs = ke.runFusion({aten_input});
 
     // validate results
@@ -6936,7 +6934,7 @@ TEST_F(NVFuserTest, IsFinite_CUDA) {
     const auto input = at::from_blob(data.data(), {3}, {1}).to(options);
 
     KernelExecutor ke;
-    ke.compileFusion(fusion, {input});
+    ke.compile(fusion, {input});
     const auto output = ke.runFusion({input});
 
     testValidate(fusion, output, {input}, __LINE__, __FILE__);
@@ -7036,7 +7034,7 @@ TEST_F(NVFuserTest, FusionOptionsGuard_CUDA) {
   captureStdout();
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion,
       {aten_input},
       heuristic_params->lparams,
@@ -7411,7 +7409,7 @@ TEST_F(NVFuserTest, AllInputDtypes) {
     CompileParams opt{.index_type = index_type};
 
     KernelExecutor ke;
-    ke.compileFusion(fusion.get(), args, LaunchParams{}, opt);
+    ke.compile(fusion.get(), args, LaunchParams{}, opt);
     auto outputs = ke.runFusion(args, LaunchParams{}, opt);
 
     auto kernel_result = outputs.at(0).item<double>();
@@ -7531,7 +7529,7 @@ TEST_F(NVFuserTest, OpaqueTupleAsComplex) {
   args.push(Opaque(std::array<float, 2>{1.2, 3.4}));
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
   auto outputs = ke.runFusion(args);
 
   EXPECT_EQ(
@@ -7558,7 +7556,7 @@ TEST_F(NVFuserTest, StructConstruct) {
   fusion.addOutput(tv);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
   auto outputs = ke.runFusion({1.2, 3.4});
 
   EXPECT_EQ(
@@ -7596,7 +7594,7 @@ TEST_F(NVFuserTest, VectorizationStrideValidation) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   // This previously triggered a false positive error with the stride
   // validation
@@ -7625,7 +7623,7 @@ TEST_F(NVFuserTest, ConstLongExpressions) {
   fusion->addOutput(tv0);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion);
+  ke.compile(fusion);
 
   auto outputs = ke.runFusion({});
 
@@ -7697,7 +7695,7 @@ TEST_F(NVFuserTest, PredicateRNGOps) {
   at::Tensor t0 = at::zeros({2048, size}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {t0});
+  ke.compile(fusion, {t0});
 
   auto cg_outputs = ke.runFusion({t0});
 }
@@ -7888,7 +7886,7 @@ TEST_F(NVFuserTest, UnsupportedBFloat) {
 
   KernelExecutor ke;
   EXPECT_THAT(
-      [&]() { ke.compileFusion(&fusion); },
+      [&]() { ke.compile(&fusion); },
       testing::ThrowsMessage<nvfuser::nvfError>(
           testing::HasSubstr("Reason: Fusion contains BFloat16")));
 }
@@ -7953,7 +7951,7 @@ TEST_F(NVFuserTest, BlockReduction3D) {
     at::Tensor t0 = at::randn(shape, options);
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
     auto cg_outputs = ke.runFusion({t0});
     auto ref = t0.sum(0).sum(-1);
     testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
@@ -7996,7 +7994,7 @@ TEST_F(NVFuserTest, ReverseMerge) {
   at::Tensor t0 = at::randn({11, 12}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
   ASSERT_TRUE(t0.equal(cg_outputs.at(0)));
 }
@@ -8026,7 +8024,7 @@ TEST_F(NVFuserTest, FusionCpAsyncPredicateAvoidIllegalMemoryAccess) {
   at::Tensor t0 = at::randn({m, n}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
   ASSERT_TRUE(t0.equal(cg_outputs.at(0)));
 }
@@ -8360,7 +8358,7 @@ TEST_F(NVFuserTest, BroadcastFromNowhereFusion) {
   at::Tensor t0 = at::randn({4}, options);
   at::Tensor t1 = at::randn({2, 4}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -8444,7 +8442,7 @@ TEST_F(NVFuserTest, MultipleDifferentSizeGridReduction) {
   const std::vector<c10::IValue> inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto cg_outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, cg_outputs, inputs, __LINE__, __FILE__);
@@ -8879,7 +8877,7 @@ TEST_F(NVFuserTest, CpAsyncDataTypeBool) {
   // );
   // If not correctly lowered, would trigger error in compile
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_gpu_compute_with.cpp
+++ b/tests/cpp/test_gpu_compute_with.cpp
@@ -166,7 +166,7 @@ TEST_F(NVFuserTest, FusionComputeWith1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -221,7 +221,7 @@ TEST_F(NVFuserTest, FusionComputeWith2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto aten_output = at::_softmax(t0.to(at::kDouble), -1, false);
 
@@ -263,7 +263,7 @@ TEST_F(NVFuserTest, FusionComputeWith3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -309,7 +309,7 @@ TEST_F(NVFuserTest, FusionComputeWith4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -348,7 +348,7 @@ TEST_F(NVFuserTest, FusionComputeWith5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -451,7 +451,7 @@ TEST_F(NVFuserTest, FusionComputeWith6_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0}, LaunchParams());
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto t1 = t0.to(at::kFloat);
   auto t2 = t1.mean({0, 1, 2});

--- a/tests/cpp/test_gpu_compute_with.cpp
+++ b/tests/cpp/test_gpu_compute_with.cpp
@@ -165,7 +165,7 @@ TEST_F(NVFuserTest, FusionComputeWith1_CUDA) {
   at::Tensor t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -220,7 +220,7 @@ TEST_F(NVFuserTest, FusionComputeWith2_CUDA) {
   at::Tensor t0 = at::randn({dimx}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto aten_output = at::_softmax(t0.to(at::kDouble), -1, false);
@@ -262,7 +262,7 @@ TEST_F(NVFuserTest, FusionComputeWith3_CUDA) {
   at::Tensor t0 = at::randn({123}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -308,7 +308,7 @@ TEST_F(NVFuserTest, FusionComputeWith4_CUDA) {
   at::Tensor t0 = at::randn({345, 10}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -347,7 +347,7 @@ TEST_F(NVFuserTest, FusionComputeWith5_CUDA) {
   at::Tensor t0 = at::randn({345, 10}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -450,7 +450,7 @@ TEST_F(NVFuserTest, FusionComputeWith6_CUDA) {
   auto t0 = at::randn(input_shape, options_half);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, LaunchParams());
+  ke.compile(&fusion, {t0}, LaunchParams());
   auto cg_outputs = ke.runFusion({t0});
 
   auto t1 = t0.to(at::kFloat);

--- a/tests/cpp/test_gpu_fused_reduction.cpp
+++ b/tests/cpp/test_gpu_fused_reduction.cpp
@@ -117,7 +117,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = sum(t0).unsqueeze(0) + t0;
 
@@ -166,7 +166,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = sum(t0).unsqueeze(0) + t0;
 
@@ -214,7 +214,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = sum(t0, {1}).unsqueeze(-1) + t0;
 
@@ -259,7 +259,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = (sum(t0) + 1).unsqueeze(0) + t0;
 
@@ -321,7 +321,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t5});
-  auto cg_outputs = ke.runFusion({t0, t5});
+  auto cg_outputs = ke.run({t0, t5});
 
   auto ref = (sum(t0, {1}) + 1).unsqueeze(-1) + t0;
 
@@ -373,7 +373,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce6_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t0_double = t0.to(at::kDouble);
   auto ref = t0_double + t0_double.sum({0}).unsqueeze(0);
@@ -419,7 +419,7 @@ TEST_F(NVFuserTest, FusionGridAllreduceWelford1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref =
       (t0.mean({0}).unsqueeze(0) + t0) + t0.var({0}, false).unsqueeze(0) * nx;
@@ -469,7 +469,7 @@ TEST_F(NVFuserTest, FusionGridAllreduceWelford2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = (sum(t0, {1}) / ny).unsqueeze(-1) + t0;
 
@@ -589,7 +589,7 @@ TEST_F(NVFuserTest, FusionFusedReductionBatchnorm_CUDA) {
   KernelExecutor ke;
   LaunchParams launch_params(2, 2, -1, -1, -1, -1);
   ke.compile(&fusion, aten_inputs, launch_params);
-  auto cg_outputs = ke.runFusion(aten_inputs, launch_params);
+  auto cg_outputs = ke.run(aten_inputs, launch_params);
 
   auto t5 = t0.to(at::kFloat);
   auto t6 = t1.to(at::kFloat);
@@ -655,7 +655,7 @@ TEST_F(NVFuserTest, FusionGroupedReduction1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto ref = t0.sum({1}) * 2;
 
@@ -700,7 +700,7 @@ TEST_F(NVFuserTest, FusionGroupedReduction2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto ref = (t0 + 1).sum({1}) + std::get<0>((t0 + 2).max(1));
 
@@ -743,7 +743,7 @@ TEST_F(NVFuserTest, FusionGroupedReduction3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto ref = t0.sum({1}) + t0.to(c10::kDouble).sum({1}).to(c10::kFloat);
 
@@ -831,7 +831,7 @@ TEST_F(NVFuserTest, FusionGroupedReduction6_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   testValidate(ke.kernel(), outputs, {t0}, __LINE__, __FILE__);
 }
@@ -894,7 +894,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionRfactor1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto ref = t0.sum({0}) * 2;
 
@@ -939,7 +939,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionRfactor2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto ref = t0.sum({0}) * 2;
 
@@ -985,7 +985,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionAfterComputeAt_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto ref = (t0 + 1).sum({1}) * 2;
 
@@ -1025,7 +1025,7 @@ TEST_F(NVFuserTest, FusionGroupAllreduce1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t3 = t0.sum({0}).unsqueeze(-1);
   auto ref = t0 + t3 + t3;
@@ -1078,7 +1078,7 @@ TEST_F(NVFuserTest, FusionGroupAllreduce2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t2 = t0.sum({1}).unsqueeze(-1);
   auto t6 = t0.to(c10::kDouble).sum({1}).unsqueeze(-1).to(c10::kFloat);
@@ -1126,7 +1126,7 @@ TEST_F(NVFuserTest, FusionGroupAllreduce3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t3 = t0 / t0.sum({0}).unsqueeze(0);
   auto t6 = t0 / std::get<0>(t0.max(0)).unsqueeze(0);
@@ -1179,7 +1179,7 @@ TEST_F(NVFuserTest, FusionGroupAllreduce4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   at::Tensor ref = t0;
   for (int i = 0; i < num_reductions; ++i) {
@@ -1267,7 +1267,7 @@ TEST_F(NVFuserTest, FusionGroupAllreduce5_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto t3 = t0 / t0.sum({0}).unsqueeze(0).to(at::kComplexDouble);
   auto t7 = t4 / t4.sum({0}).unsqueeze(0).to(at::kComplexDouble);
@@ -1435,7 +1435,7 @@ TEST_F(NVFuserTest, FusionPersistentBNBackwardAllreduce_CUDA) {
     GTEST_SKIP() << "Not enough SMs to run this test";
   }
 
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   std::vector<int64_t> at_reduction_axes;
   std::copy(
@@ -1536,7 +1536,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionReEntrant1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t0_double = t0.to(at::kDouble);
   auto ref = (t0_double + 1).sum({0}) + (t0_double + 2).sum({0});
@@ -1651,7 +1651,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionChannelsLastBatchNormLike_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto t0_double = t0.to(at::kDouble);
   auto t1_double = t1.to(at::kDouble);
@@ -1782,7 +1782,7 @@ TEST_F(
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto t0_double = t0.to(at::kDouble);
   auto t1_double = t1.to(at::kDouble);
@@ -1870,7 +1870,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t0_double = t0.to(at::kDouble);
   auto ref = t0_double + t0_double.sum({0}).unsqueeze(0);
@@ -1948,7 +1948,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t0_double = t0.to(at::kDouble);
   auto ref = t0_double + t0_double.sum({0}).unsqueeze(0);
@@ -2032,7 +2032,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce3_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t0_double = t0.to(at::kDouble);
   auto t4 = t0_double + 1 + (t0_double + 1).sum({0}).unsqueeze(0);
@@ -2124,7 +2124,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce4_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t0_double = t0.to(at::kDouble);
   auto ref = t0_double + t0_double.sum({0}).unsqueeze(0);
@@ -2185,7 +2185,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduceWelford1_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t0_double = t0.to(at::kDouble);
   auto ref = t0_double + t0_double.mean({0}).unsqueeze(0);
@@ -2250,7 +2250,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduceWelford2_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto outputs = ke.runFusion({t0});
+  auto outputs = ke.run({t0});
 
   auto t0_double = t0.to(at::kDouble);
   auto ref = t0_double + t0_double.mean({0}).unsqueeze(0);
@@ -2397,7 +2397,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduceWelfordShmoo_CUDA) {
       return;
     }
 
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
 
     auto t1 = t0.to(at::kDouble);
     auto t2 = t1.mean({0, 1, 2}).unsqueeze(0).unsqueeze(0).unsqueeze(0);
@@ -2543,7 +2543,7 @@ TEST_F(NVFuserTest, FusionCrossEntropyGatherPattern_CUDA) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
 
   auto ref = at::gather(at_log_probs, 1, at_labels.unsqueeze(1)).squeeze();
 

--- a/tests/cpp/test_gpu_fused_reduction.cpp
+++ b/tests/cpp/test_gpu_fused_reduction.cpp
@@ -116,7 +116,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce1_CUDA) {
   auto t0 = at::randn({nx}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = sum(t0).unsqueeze(0) + t0;
@@ -165,7 +165,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce2_CUDA) {
   auto t0 = at::randn({nx}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = sum(t0).unsqueeze(0) + t0;
@@ -213,7 +213,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce3_CUDA) {
   auto t0 = at::randn({nx, ny}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = sum(t0, {1}).unsqueeze(-1) + t0;
@@ -258,7 +258,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce4_CUDA) {
   auto t0 = at::randn({nx}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = (sum(t0) + 1).unsqueeze(0) + t0;
@@ -320,7 +320,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce5_CUDA) {
   auto t5 = at::randn({bdimy, bdimx}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t5});
+  ke.compile(&fusion, {t0, t5});
   auto cg_outputs = ke.runFusion({t0, t5});
 
   auto ref = (sum(t0, {1}) + 1).unsqueeze(-1) + t0;
@@ -372,7 +372,7 @@ TEST_F(NVFuserTest, FusionGridAllreduce6_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t0_double = t0.to(at::kDouble);
@@ -418,7 +418,7 @@ TEST_F(NVFuserTest, FusionGridAllreduceWelford1_CUDA) {
   auto t0 = at::randn({nx}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref =
@@ -468,7 +468,7 @@ TEST_F(NVFuserTest, FusionGridAllreduceWelford2_CUDA) {
   auto t0 = at::randn({nx, ny}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = (sum(t0, {1}) / ny).unsqueeze(-1) + t0;
@@ -588,7 +588,7 @@ TEST_F(NVFuserTest, FusionFusedReductionBatchnorm_CUDA) {
 
   KernelExecutor ke;
   LaunchParams launch_params(2, 2, -1, -1, -1, -1);
-  ke.compileFusion(&fusion, aten_inputs, launch_params);
+  ke.compile(&fusion, aten_inputs, launch_params);
   auto cg_outputs = ke.runFusion(aten_inputs, launch_params);
 
   auto t5 = t0.to(at::kFloat);
@@ -654,7 +654,7 @@ TEST_F(NVFuserTest, FusionGroupedReduction1_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto ref = t0.sum({1}) * 2;
@@ -699,7 +699,7 @@ TEST_F(NVFuserTest, FusionGroupedReduction2_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto ref = (t0 + 1).sum({1}) + std::get<0>((t0 + 2).max(1));
@@ -742,7 +742,7 @@ TEST_F(NVFuserTest, FusionGroupedReduction3_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto ref = t0.sum({1}) + t0.to(c10::kDouble).sum({1}).to(c10::kFloat);
@@ -830,7 +830,7 @@ TEST_F(NVFuserTest, FusionGroupedReduction6_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   testValidate(ke.kernel(), outputs, {t0}, __LINE__, __FILE__);
@@ -893,7 +893,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionRfactor1_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto ref = t0.sum({0}) * 2;
@@ -938,7 +938,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionRfactor2_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto ref = t0.sum({0}) * 2;
@@ -984,7 +984,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionAfterComputeAt_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto ref = (t0 + 1).sum({1}) * 2;
@@ -1024,7 +1024,7 @@ TEST_F(NVFuserTest, FusionGroupAllreduce1_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t3 = t0.sum({0}).unsqueeze(-1);
@@ -1077,7 +1077,7 @@ TEST_F(NVFuserTest, FusionGroupAllreduce2_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t2 = t0.sum({1}).unsqueeze(-1);
@@ -1125,7 +1125,7 @@ TEST_F(NVFuserTest, FusionGroupAllreduce3_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t3 = t0 / t0.sum({0}).unsqueeze(0);
@@ -1178,7 +1178,7 @@ TEST_F(NVFuserTest, FusionGroupAllreduce4_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   at::Tensor ref = t0;
@@ -1266,7 +1266,7 @@ TEST_F(NVFuserTest, FusionGroupAllreduce5_CUDA) {
   std::vector<at::indexing::TensorIndex> indices({at::indexing::Slice(0, 10)});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   auto t3 = t0 / t0.sum({0}).unsqueeze(0).to(at::kComplexDouble);
@@ -1429,7 +1429,7 @@ TEST_F(NVFuserTest, FusionPersistentBNBackwardAllreduce_CUDA) {
   validateNoParallelBroadcastExist(gpulw.run());
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   if (bidx * bidy > deviceSMCount()) {
     GTEST_SKIP() << "Not enough SMs to run this test";
@@ -1535,7 +1535,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionReEntrant1_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t0_double = t0.to(at::kDouble);
@@ -1650,7 +1650,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionChannelsLastBatchNormLike_CUDA) {
   std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   auto t0_double = t0.to(at::kDouble);
@@ -1781,7 +1781,7 @@ TEST_F(
   std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   auto t0_double = t0.to(at::kDouble);
@@ -1869,7 +1869,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce1_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t0_double = t0.to(at::kDouble);
@@ -1947,7 +1947,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce2_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t0_double = t0.to(at::kDouble);
@@ -2031,7 +2031,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce3_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t0_double = t0.to(at::kDouble);
@@ -2123,7 +2123,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduce4_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t0_double = t0.to(at::kDouble);
@@ -2184,7 +2184,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduceWelford1_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t0_double = t0.to(at::kDouble);
@@ -2249,7 +2249,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduceWelford2_CUDA) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto outputs = ke.runFusion({t0});
 
   auto t0_double = t0.to(at::kDouble);
@@ -2386,7 +2386,7 @@ TEST_F(NVFuserTest, FusionCrossIterationGroupedGridAllreduceWelfordShmoo_CUDA) {
     auto t0 = at::randn(input_shape, options);
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
 
     // Skip the rest of this test size if the required number of SMs
     // exceeds the available SM count
@@ -2542,7 +2542,7 @@ TEST_F(NVFuserTest, FusionCrossEntropyGatherPattern_CUDA) {
   std::vector<c10::IValue> inputs = {at_log_probs, at_labels};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto cg_outputs = ke.runFusion(inputs);
 
   auto ref = at::gather(at_log_probs, 1, at_labels.unsqueeze(1)).squeeze();

--- a/tests/cpp/test_gpu_indexing_ops.cpp
+++ b/tests/cpp/test_gpu_indexing_ops.cpp
@@ -397,7 +397,7 @@ TEST_F(NVFuserTest, FusionIndexSelect_Sum_CUDA) {
   auto heuristic_params = SchedulerEntry::scheduleWith(
       &fusion, SchedulerType::Reduction, aten_inputs);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs, heuristic_params->lparams);
+  ke.compile(&fusion, aten_inputs, heuristic_params->lparams);
   ke.runFusion(aten_inputs, {cg_output}, heuristic_params->lparams);
 
   auto tv0_ref = at::index_select(input0, 0, input_idx);

--- a/tests/cpp/test_gpu_indexing_ops.cpp
+++ b/tests/cpp/test_gpu_indexing_ops.cpp
@@ -398,7 +398,7 @@ TEST_F(NVFuserTest, FusionIndexSelect_Sum_CUDA) {
       &fusion, SchedulerType::Reduction, aten_inputs);
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs, heuristic_params->lparams);
-  ke.runFusion(aten_inputs, {cg_output}, heuristic_params->lparams);
+  ke.run(aten_inputs, {cg_output}, heuristic_params->lparams);
 
   auto tv0_ref = at::index_select(input0, 0, input_idx);
   at::Tensor tv2_ref = tv0_ref * input1;

--- a/tests/cpp/test_gpu_outer_reduction.cpp
+++ b/tests/cpp/test_gpu_outer_reduction.cpp
@@ -132,7 +132,7 @@ TEST_F(OuterReductionTest, GroupedGridWelfordOuterOpt) {
         ", ",
         params.bidx);
 
-    auto cg_outputs = ke.runFusion(aten_inputs);
+    auto cg_outputs = ke.run(aten_inputs);
 
     auto t1 = t0;
     auto t2 = params.dtype == DataType::Half ? t1.to(at::kFloat) : t1;
@@ -648,12 +648,12 @@ void grid_persistent_reduction_outer_norm_like(
                  << params.bidx * bidy << ", available: " << deviceSMCount();
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   if (benchmark_mode) {
     for (int i = 0; i < 10; ++i) {
       clearL2Cache();
-      cg_outputs = ke.runFusion({t0});
+      cg_outputs = ke.run({t0});
     }
   }
 
@@ -747,12 +747,12 @@ void grid_persistent_welford_outer_norm_like(
                  << params.bidx * bidy << ", available: " << deviceSMCount();
   }
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   if (benchmark_mode) {
     for (int i = 0; i < 10; ++i) {
       clearL2Cache();
-      cg_outputs = ke.runFusion({t0});
+      cg_outputs = ke.run({t0});
     }
   }
 
@@ -908,7 +908,7 @@ void grid_persistent_batchnorm_manual(
                  << params.bidx * bidy << ", available: " << deviceSMCount();
   }
 
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
   cg_outputs.at(2) = cg_outputs.at(2).permute({0, 3, 1, 2});
 
   auto at_output = at::batch_norm(
@@ -934,7 +934,7 @@ void grid_persistent_batchnorm_manual(
   if (benchmark_mode) {
     for (int i = 0; i < 10; ++i) {
       clearL2Cache();
-      cg_outputs = ke.runFusion(aten_inputs);
+      cg_outputs = ke.run(aten_inputs);
     }
   }
 }
@@ -1047,12 +1047,12 @@ void grid_persistent_reduction_outer_norm_bwd_like(
                  << params.bidx * bidy << ", available: " << deviceSMCount();
   }
 
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   if (benchmark_mode) {
     for (int i = 0; i < 10; ++i) {
       clearL2Cache();
-      cg_outputs = ke.runFusion(aten_inputs);
+      cg_outputs = ke.run(aten_inputs);
     }
   }
 
@@ -1234,7 +1234,7 @@ void grid_persistent_batchnorm_bwd_manual(
                  << params.bidx * bidy << ", available: " << deviceSMCount();
   }
 
-  cg_outputs = ke.runFusion(aten_inputs);
+  cg_outputs = ke.run(aten_inputs);
   // Permute grad_input output
   cg_outputs.at(0) = cg_outputs.at(0).permute({0, 3, 1, 2});
 
@@ -1262,7 +1262,7 @@ void grid_persistent_batchnorm_bwd_manual(
   if (benchmark_mode) {
     for (int i = 0; i < 10; ++i) {
       clearL2Cache();
-      cg_outputs = ke.runFusion(aten_inputs);
+      cg_outputs = ke.run(aten_inputs);
     }
   }
 }
@@ -2183,7 +2183,7 @@ TEST_F(OuterReductionTest, IterGroupedBlockReduction) {
   scheduler->schedule(&fusion, rparams);
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs, heuristic_params->lparams);
-  auto cg_outputs = ke.runFusion(aten_inputs, heuristic_params->lparams);
+  auto cg_outputs = ke.run(aten_inputs, heuristic_params->lparams);
 
   // lowering & check iteration grouped reductions
   NVF_CHECK(
@@ -2292,7 +2292,7 @@ void shmooTestsOfIterGroupedBlockOrGridReduction(
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs, lparams);
-  auto cg_outputs = ke.runFusion(aten_inputs, lparams);
+  auto cg_outputs = ke.run(aten_inputs, lparams);
 
   testValidate(
       &fusion,
@@ -2549,7 +2549,7 @@ TEST_F(OuterReductionTest, IterGroupedMultipleReductions) {
   std::vector<c10::IValue> aten_inputs({t0, t1});
 
   ke.compile(&fusion, aten_inputs, lparams);
-  auto cg_outputs = ke.runFusion(aten_inputs, lparams);
+  auto cg_outputs = ke.run(aten_inputs, lparams);
 
   testValidate(
       &fusion,

--- a/tests/cpp/test_gpu_outer_reduction.cpp
+++ b/tests/cpp/test_gpu_outer_reduction.cpp
@@ -116,7 +116,7 @@ TEST_F(OuterReductionTest, GroupedGridWelfordOuterOpt) {
     std::vector<c10::IValue> aten_inputs = {t0};
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, aten_inputs);
+    ke.compile(&fusion, aten_inputs);
 
     NVF_CHECK(
         ke.kernel()->summary().has_outer_grouped_grid_welford ==
@@ -639,7 +639,7 @@ void grid_persistent_reduction_outer_norm_like(
   auto t0 = at::randn(input_shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   auto bidy = ceilDiv(ceilDiv(N * HW * HW, params.tidy), params.pb);
 
@@ -738,7 +738,7 @@ void grid_persistent_welford_outer_norm_like(
   auto t0 = at::randn(input_shape, options_half);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   auto bidy = ceilDiv(ceilDiv(N * HW * HW, params.tidy), params.pb);
 
@@ -899,7 +899,7 @@ void grid_persistent_batchnorm_manual(
       {at_input_nvfuser, at_weight, at_bias, at_running_mean, at_running_var});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), aten_inputs);
+  ke.compile(fusion_ptr.get(), aten_inputs);
 
   auto bidy = ceilDiv(ceilDiv(N * HW * HW, params.tidy), params.pb);
 
@@ -1038,7 +1038,7 @@ void grid_persistent_reduction_outer_norm_bwd_like(
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   auto bidy = ceilDiv(ceilDiv(N * HW * HW, params.tidy), params.pb);
 
@@ -1225,7 +1225,7 @@ void grid_persistent_batchnorm_bwd_manual(
   std::vector<at::Tensor> cg_outputs;
 
   KernelExecutor ke;
-  ke.compileFusion(fusion_ptr.get(), aten_inputs);
+  ke.compile(fusion_ptr.get(), aten_inputs);
 
   auto bidy = ceilDiv(ceilDiv(N * HW * HW, params.tidy), params.pb);
 
@@ -2182,7 +2182,7 @@ TEST_F(OuterReductionTest, IterGroupedBlockReduction) {
 
   scheduler->schedule(&fusion, rparams);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs, heuristic_params->lparams);
+  ke.compile(&fusion, aten_inputs, heuristic_params->lparams);
   auto cg_outputs = ke.runFusion(aten_inputs, heuristic_params->lparams);
 
   // lowering & check iteration grouped reductions
@@ -2291,7 +2291,7 @@ void shmooTestsOfIterGroupedBlockOrGridReduction(
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs, lparams);
+  ke.compile(&fusion, aten_inputs, lparams);
   auto cg_outputs = ke.runFusion(aten_inputs, lparams);
 
   testValidate(
@@ -2548,7 +2548,7 @@ TEST_F(OuterReductionTest, IterGroupedMultipleReductions) {
   auto t1 = at::randn(shape, options);
   std::vector<c10::IValue> aten_inputs({t0, t1});
 
-  ke.compileFusion(&fusion, aten_inputs, lparams);
+  ke.compile(&fusion, aten_inputs, lparams);
   auto cg_outputs = ke.runFusion(aten_inputs, lparams);
 
   testValidate(

--- a/tests/cpp/test_gpu_transpose.cpp
+++ b/tests/cpp/test_gpu_transpose.cpp
@@ -548,7 +548,7 @@ TEST_F(TransposeTest, FusionManualScheduleTransposeComplexDAG1) {
   at::Tensor input2 = at::randn({512, 256, 1024}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input0, input1, input2});
+  ke.compile(&fusion, {input0, input1, input2});
   auto outputs = ke.runFusion({input0, input1, input2});
 
   testValidate(&fusion, outputs, {input0, input1, input2}, __LINE__, __FILE__);
@@ -988,7 +988,7 @@ TEST_F(TransposeTest, FusionTransposeBankConflict9) {
   at::Tensor input = at::randn({32, 32, 2}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
   auto outputs = ke.runFusion({input});
 
   testValidate(&fusion, outputs, {input}, __LINE__, __FILE__);

--- a/tests/cpp/test_gpu_transpose.cpp
+++ b/tests/cpp/test_gpu_transpose.cpp
@@ -549,7 +549,7 @@ TEST_F(TransposeTest, FusionManualScheduleTransposeComplexDAG1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input0, input1, input2});
-  auto outputs = ke.runFusion({input0, input1, input2});
+  auto outputs = ke.run({input0, input1, input2});
 
   testValidate(&fusion, outputs, {input0, input1, input2}, __LINE__, __FILE__);
 }
@@ -989,7 +989,7 @@ TEST_F(TransposeTest, FusionTransposeBankConflict9) {
 
   KernelExecutor ke;
   ke.compile(&fusion);
-  auto outputs = ke.runFusion({input});
+  auto outputs = ke.run({input});
 
   testValidate(&fusion, outputs, {input}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_gpu_view.cpp
+++ b/tests/cpp/test_gpu_view.cpp
@@ -135,7 +135,7 @@ TEST_F(GpuViewTest, FusionViewAsRealOutput) {
   std::vector<c10::IValue> aten_inputs = {at_x, at_bias, at_y};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -638,7 +638,7 @@ TEST_F(GpuViewTest, FusionReshapeConcreteDomain) {
   auto t1 = at::randn({1, 6}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -851,7 +851,7 @@ TEST_F(GpuViewTest, FusionFlattenAfterUnsqueezeOutput) {
   x_reshape->axis(0)->parallelize(ParallelType::TIDx);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -915,7 +915,7 @@ TEST_F(GpuViewTest, FusionExpandRepro) {
   std::vector<c10::IValue> aten_inputs = {at_x, at_y};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
   LaunchParams l_params;
   auto outputs = ke.runFusion(aten_inputs, {}, l_params, {});
 
@@ -1350,7 +1350,7 @@ TEST_F(GpuViewTest, FusionPwiseViewSchedule) {
   at::Tensor t3 = at::randn({x, y, z}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t3});
+  ke.compile(&fusion, {t0, t3});
   auto cg_outputs = ke.runFusion({t0, t3});
 
   testValidate(&fusion, cg_outputs, {t0, t3}, __LINE__, __FILE__);
@@ -1416,7 +1416,7 @@ TEST_F(GpuViewTest, FusionSumViewSchedule) {
   auto t6 = t0 + t3;
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t3});
+  ke.compile(&fusion, {t0, t3});
   auto cg_outputs = ke.runFusion({t0, t3});
 
   testValidate(&fusion, cg_outputs, {t0, t3}, {t2, t5, t6}, __LINE__, __FILE__);
@@ -1945,7 +1945,7 @@ TEST_F(GpuViewTest, FusionReshapeMapping) {
   at::Tensor t3 = at::randn({w, x * y, z}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t3});
+  ke.compile(&fusion, {t0, t3});
   auto cg_outputs = ke.runFusion({t0, t3});
 
   testValidate(&fusion, cg_outputs, {t0, t3}, __LINE__, __FILE__);
@@ -2319,7 +2319,7 @@ TEST_F(GpuViewTest, ExpandedBroadcast) {
       at::randn({4, 5}, at::dtype(at::kFloat).device(at::kCUDA, 0));
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {in_tensor});
+  ke.compile(&fusion, {in_tensor});
   at::Tensor actual_out_tensor = ke.runFusion({in_tensor})[0];
 
   testValidate(&fusion, {actual_out_tensor}, {in_tensor}, __LINE__, __FILE__);
@@ -2698,7 +2698,7 @@ TEST_F(GpuViewTest, FusionMismatchingReshape) {
   // this fusion.
   at::Tensor t0 = at::randn({2, 3, 5}).to(options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);

--- a/tests/cpp/test_gpu_view.cpp
+++ b/tests/cpp/test_gpu_view.cpp
@@ -136,7 +136,7 @@ TEST_F(GpuViewTest, FusionViewAsRealOutput) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -639,7 +639,7 @@ TEST_F(GpuViewTest, FusionReshapeConcreteDomain) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -852,7 +852,7 @@ TEST_F(GpuViewTest, FusionFlattenAfterUnsqueezeOutput) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -917,12 +917,12 @@ TEST_F(GpuViewTest, FusionExpandRepro) {
   KernelExecutor ke;
   ke.compile(&fusion);
   LaunchParams l_params;
-  auto outputs = ke.runFusion(aten_inputs, {}, l_params, {});
+  auto outputs = ke.run(aten_inputs, {}, l_params, {});
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 
   // second run to verify cached output allocation
-  outputs = ke.runFusion(aten_inputs, {}, l_params, {});
+  outputs = ke.run(aten_inputs, {}, l_params, {});
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
 
@@ -1351,7 +1351,7 @@ TEST_F(GpuViewTest, FusionPwiseViewSchedule) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t3});
-  auto cg_outputs = ke.runFusion({t0, t3});
+  auto cg_outputs = ke.run({t0, t3});
 
   testValidate(&fusion, cg_outputs, {t0, t3}, __LINE__, __FILE__);
 }
@@ -1417,7 +1417,7 @@ TEST_F(GpuViewTest, FusionSumViewSchedule) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t3});
-  auto cg_outputs = ke.runFusion({t0, t3});
+  auto cg_outputs = ke.run({t0, t3});
 
   testValidate(&fusion, cg_outputs, {t0, t3}, {t2, t5, t6}, __LINE__, __FILE__);
 }
@@ -1946,7 +1946,7 @@ TEST_F(GpuViewTest, FusionReshapeMapping) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t3});
-  auto cg_outputs = ke.runFusion({t0, t3});
+  auto cg_outputs = ke.run({t0, t3});
 
   testValidate(&fusion, cg_outputs, {t0, t3}, __LINE__, __FILE__);
 }
@@ -2320,7 +2320,7 @@ TEST_F(GpuViewTest, ExpandedBroadcast) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {in_tensor});
-  at::Tensor actual_out_tensor = ke.runFusion({in_tensor})[0];
+  at::Tensor actual_out_tensor = ke.run({in_tensor})[0];
 
   testValidate(&fusion, {actual_out_tensor}, {in_tensor}, __LINE__, __FILE__);
 }
@@ -2699,7 +2699,7 @@ TEST_F(GpuViewTest, FusionMismatchingReshape) {
   at::Tensor t0 = at::randn({2, 3, 5}).to(options);
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -1774,7 +1774,7 @@ TEST_F(IndexingTest, SmemAllocationDomainForTranspose) {
   at::Tensor input0 = at::randn({256, 256}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input0});
+  ke.compile(&fusion, {input0});
   auto outputs = ke.runFusion({input0});
 
   testValidate(&fusion, outputs, {input0}, __LINE__, __FILE__);
@@ -3041,7 +3041,7 @@ TEST_F(PredicateIndexingTest, DoubleBuffering1) {
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -3140,7 +3140,7 @@ TEST_F(PredicateIndexingTest, CircularBuffering1) {
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -3307,7 +3307,7 @@ TEST_F(PredicateIndexingTest, UnrolledCircularBuffering) {
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -3388,7 +3388,7 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering1) {
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -3477,7 +3477,7 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering2) {
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -3583,7 +3583,7 @@ TEST_P(PredicateIndexingTest, UnswitchedCircularBuffering3) {
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -3662,7 +3662,7 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering4) {
   auto t0 = at::randn({16}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -3755,7 +3755,7 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplit1) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -3846,7 +3846,7 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithUnswitch) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -3941,7 +3941,7 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithCircularBuffering) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -4052,7 +4052,7 @@ TEST_F(
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -4137,7 +4137,7 @@ TEST_P(PredicateIndexingTest, UnswitchPredicateIssueRepro681) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   auto ref = t0.to(at::kDouble).sum();
@@ -4297,7 +4297,7 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithUnswitchAndBroadcast) {
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -4420,7 +4420,7 @@ TEST_F(PredicateIndexingTest, UnswitchConsolidationDifferentThreading) {
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
@@ -4835,7 +4835,7 @@ TEST_F(ContigIndexingTest, ConcretizedBroadcastMerge) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -5064,7 +5064,7 @@ TEST_F(ContigPredicateIndexingTest, NonDivisibleSplit1) {
   std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -1775,7 +1775,7 @@ TEST_F(IndexingTest, SmemAllocationDomainForTranspose) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input0});
-  auto outputs = ke.runFusion({input0});
+  auto outputs = ke.run({input0});
 
   testValidate(&fusion, outputs, {input0}, __LINE__, __FILE__);
 }
@@ -3042,7 +3042,7 @@ TEST_F(PredicateIndexingTest, DoubleBuffering1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -3141,7 +3141,7 @@ TEST_F(PredicateIndexingTest, CircularBuffering1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -3308,7 +3308,7 @@ TEST_F(PredicateIndexingTest, UnrolledCircularBuffering) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -3389,7 +3389,7 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -3478,7 +3478,7 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering2) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -3584,7 +3584,7 @@ TEST_P(PredicateIndexingTest, UnswitchedCircularBuffering3) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -3663,7 +3663,7 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering4) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -3756,7 +3756,7 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplit1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3847,7 +3847,7 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithUnswitch) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3942,7 +3942,7 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithCircularBuffering) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4053,7 +4053,7 @@ TEST_F(
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4138,7 +4138,7 @@ TEST_P(PredicateIndexingTest, UnswitchPredicateIssueRepro681) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   auto ref = t0.to(at::kDouble).sum();
 
@@ -4298,7 +4298,7 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithUnswitchAndBroadcast) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4421,7 +4421,7 @@ TEST_F(PredicateIndexingTest, UnswitchConsolidationDifferentThreading) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -4836,7 +4836,7 @@ TEST_F(ContigIndexingTest, ConcretizedBroadcastMerge) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -5065,7 +5065,7 @@ TEST_F(ContigPredicateIndexingTest, NonDivisibleSplit1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_indexing_advanced.cpp
+++ b/tests/cpp/test_indexing_advanced.cpp
@@ -73,7 +73,7 @@ TEST_P(AdvancedIndexingTest, InlineBroadcast) {
   at::Tensor t1 = at::randn({3, 123}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
 
   auto outputs = ke.runFusion({t0, t1});
 
@@ -124,7 +124,7 @@ TEST_P(AdvancedIndexingTest, 1) {
 
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -175,7 +175,7 @@ TEST_P(AdvancedIndexingTest, 2) {
 
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -230,7 +230,7 @@ TEST_P(AdvancedIndexingTest, 4) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -264,7 +264,7 @@ TEST_P(AdvancedIndexingTest, 5) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -346,7 +346,7 @@ TEST_P(AdvancedIndexingTest, 7) {
   auto at_t1 = at::randn({numel_x, numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {at_t0, at_t1});
+  ke.compile(&fusion, {at_t0, at_t1});
   auto cg_outputs = ke.runFusion({at_t0, at_t1});
 
   auto aten_output = (at_t0.unsqueeze(-1).expand({numel_x, numel_y}) + at_t1)
@@ -392,7 +392,7 @@ TEST_P(AdvancedIndexingTest, 8) {
   auto at_t1 = at::randn({numel_x, numel_y}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {at_t0, at_t1});
+  ke.compile(&fusion, {at_t0, at_t1});
   auto cg_outputs = ke.runFusion({at_t0, at_t1});
 
   auto aten_output = (at_t0.unsqueeze(-1).expand({numel_x, numel_y}) + at_t1)
@@ -485,7 +485,7 @@ TEST_P(AdvancedIndexingTest, 10) {
   at::Tensor output = at::empty_like(input1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input1, input2});
+  ke.compile(&fusion, {input1, input2});
   ke.runFusion({input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + 2.0;
@@ -538,7 +538,7 @@ TEST_P(AdvancedIndexingTest, 11) {
 
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -575,7 +575,7 @@ TEST_P(AdvancedIndexingTest, 12) {
   std::vector<at::Tensor> aten_outputs = {t2, t4};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {aten_input});
+  ke.compile(&fusion, {aten_input});
   auto cg_outputs = ke.runFusion({aten_input});
 
   testValidate(
@@ -624,7 +624,7 @@ TEST_P(AdvancedIndexingTest, 13) {
   std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -666,7 +666,7 @@ TEST_P(AdvancedIndexingTest, 14) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -701,7 +701,7 @@ TEST_P(AdvancedIndexingTest, 15) {
   std::vector<c10::IValue> aten_inputs = {t0, t3};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -733,7 +733,7 @@ TEST_P(AdvancedIndexingTest, 16) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -768,7 +768,7 @@ TEST_P(AdvancedIndexingTest, 17) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -805,7 +805,7 @@ TEST_P(AdvancedIndexingTest, 18) {
   std::vector<c10::IValue> inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto cg_outputs = ke.runFusion(inputs);
 
   auto ref = (t0.unsqueeze(-1) + t1).sum();
@@ -849,7 +849,7 @@ TEST_P(AdvancedIndexingTest, 19) {
   std::vector<c10::IValue> inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -1023,7 +1023,7 @@ TEST_F(AdvancedIndexingIdModelTest, MultiPromotion1) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1120,7 +1120,7 @@ TEST_F(AdvancedIndexingIdModelTest, IndexSplitMerge) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(

--- a/tests/cpp/test_indexing_advanced.cpp
+++ b/tests/cpp/test_indexing_advanced.cpp
@@ -75,7 +75,7 @@ TEST_P(AdvancedIndexingTest, InlineBroadcast) {
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
 
-  auto outputs = ke.runFusion({t0, t1});
+  auto outputs = ke.run({t0, t1});
 
   testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -125,7 +125,7 @@ TEST_P(AdvancedIndexingTest, 1) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -176,7 +176,7 @@ TEST_P(AdvancedIndexingTest, 2) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -231,7 +231,7 @@ TEST_P(AdvancedIndexingTest, 4) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -265,7 +265,7 @@ TEST_P(AdvancedIndexingTest, 5) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -347,7 +347,7 @@ TEST_P(AdvancedIndexingTest, 7) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {at_t0, at_t1});
-  auto cg_outputs = ke.runFusion({at_t0, at_t1});
+  auto cg_outputs = ke.run({at_t0, at_t1});
 
   auto aten_output = (at_t0.unsqueeze(-1).expand({numel_x, numel_y}) + at_t1)
                          .to(at::kDouble)
@@ -393,7 +393,7 @@ TEST_P(AdvancedIndexingTest, 8) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {at_t0, at_t1});
-  auto cg_outputs = ke.runFusion({at_t0, at_t1});
+  auto cg_outputs = ke.run({at_t0, at_t1});
 
   auto aten_output = (at_t0.unsqueeze(-1).expand({numel_x, numel_y}) + at_t1)
                          .to(at::kDouble)
@@ -486,7 +486,7 @@ TEST_P(AdvancedIndexingTest, 10) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {input1, input2});
-  ke.runFusion({input1, input2}, {output});
+  ke.run({input1, input2}, {output});
 
   at::Tensor tv2_ref = input2 + 2.0;
   at::Tensor output_ref = input1 + tv2_ref;
@@ -539,7 +539,7 @@ TEST_P(AdvancedIndexingTest, 11) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -576,7 +576,7 @@ TEST_P(AdvancedIndexingTest, 12) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {aten_input});
-  auto cg_outputs = ke.runFusion({aten_input});
+  auto cg_outputs = ke.run({aten_input});
 
   testValidate(
       &fusion, cg_outputs, {aten_input}, aten_outputs, __LINE__, __FILE__);
@@ -625,7 +625,7 @@ TEST_P(AdvancedIndexingTest, 13) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -667,7 +667,7 @@ TEST_P(AdvancedIndexingTest, 14) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -702,7 +702,7 @@ TEST_P(AdvancedIndexingTest, 15) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -734,7 +734,7 @@ TEST_P(AdvancedIndexingTest, 16) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -769,7 +769,7 @@ TEST_P(AdvancedIndexingTest, 17) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -806,7 +806,7 @@ TEST_P(AdvancedIndexingTest, 18) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
 
   auto ref = (t0.unsqueeze(-1) + t1).sum();
 
@@ -850,7 +850,7 @@ TEST_P(AdvancedIndexingTest, 19) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -914,8 +914,8 @@ TEST_F(AdvancedIndexingIdModelTest, 20) {
   std::vector<c10::IValue> inputs = {t0, t1, t2};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  ke.compile(&fusion, inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 #endif
@@ -979,8 +979,8 @@ TEST_F(AdvancedIndexingIdModelTest, 21) {
   std::vector<c10::IValue> inputs = {t0, t3, t6};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  ke.compile(&fusion, inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 #endif
@@ -1024,7 +1024,7 @@ TEST_F(AdvancedIndexingIdModelTest, MultiPromotion1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1121,7 +1121,7 @@ TEST_F(AdvancedIndexingIdModelTest, IndexSplitMerge) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(
       &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);

--- a/tests/cpp/test_inlining.cpp
+++ b/tests/cpp/test_inlining.cpp
@@ -49,8 +49,8 @@ TEST_F(InliningTest, InliningMismatchedDims1) {
   at::Tensor input = at::randn({2, 3, 4}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  ke.compile(&fusion, {input});
+  auto cg_outputs = ke.run({input});
 
   testValidate(&fusion, cg_outputs, {input}, __LINE__, __FILE__);
 }
@@ -81,8 +81,8 @@ TEST_F(InliningTest, InliningMismatchedDims2) {
   at::Tensor input = at::randn({2, 3, 4}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  ke.compile(&fusion, {input});
+  auto cg_outputs = ke.run({input});
 
   testValidate(&fusion, cg_outputs, {input}, __LINE__, __FILE__);
 }
@@ -114,8 +114,8 @@ TEST_F(InliningTest, InliningMismatchedDims4) {
   at::Tensor input = at::randn({2, 3, 4}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  ke.compile(&fusion, {input});
+  auto cg_outputs = ke.run({input});
 
   testValidate(&fusion, cg_outputs, {input}, __LINE__, __FILE__);
 }
@@ -151,8 +151,8 @@ TEST_F(InliningTest, InliningBroadcast) {
   at::Tensor input = at::randn({2, 3, 4}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {input});
-  auto cg_outputs = ke.runFusion({input});
+  ke.compile(&fusion, {input});
+  auto cg_outputs = ke.run({input});
 
   testValidate(&fusion, cg_outputs, {input}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_loop_domain_scheduling.cpp
+++ b/tests/cpp/test_loop_domain_scheduling.cpp
@@ -87,7 +87,7 @@ TEST_F(LoopDomainSchedulingTest, ReshapeSplitThenMerge) {
   std::vector<c10::IValue> inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, inputs);
+  ke.compile(&fusion, inputs);
   auto outputs = ke.runFusion(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
@@ -148,7 +148,7 @@ TEST_F(LoopDomainSchedulingTest, Slice) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
@@ -307,7 +307,7 @@ TEST_F(LoopDomainSchedulingTest, ManyReshape) {
     std::vector<c10::IValue> aten_inputs({t0});
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, aten_inputs);
+    ke.compile(&fusion, aten_inputs);
     auto cg_outputs = ke.runFusion(aten_inputs);
 
     auto ref = t0 * 2;

--- a/tests/cpp/test_loop_domain_scheduling.cpp
+++ b/tests/cpp/test_loop_domain_scheduling.cpp
@@ -88,7 +88,7 @@ TEST_F(LoopDomainSchedulingTest, ReshapeSplitThenMerge) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  auto outputs = ke.runFusion(inputs);
+  auto outputs = ke.run(inputs);
 
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
@@ -149,7 +149,7 @@ TEST_F(LoopDomainSchedulingTest, Slice) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
 
@@ -308,7 +308,7 @@ TEST_F(LoopDomainSchedulingTest, ManyReshape) {
 
     KernelExecutor ke;
     ke.compile(&fusion, aten_inputs);
-    auto cg_outputs = ke.runFusion(aten_inputs);
+    auto cg_outputs = ke.run(aten_inputs);
 
     auto ref = t0 * 2;
     EXPECT_TRUE(ref.equal(cg_outputs[0]));

--- a/tests/cpp/test_loop_rotation.cpp
+++ b/tests/cpp/test_loop_rotation.cpp
@@ -78,7 +78,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t0});
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
@@ -171,7 +171,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t0});
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
@@ -280,7 +280,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t0});
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
@@ -391,7 +391,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t0});
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
@@ -528,7 +528,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t0});
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
@@ -664,7 +664,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t0});
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }

--- a/tests/cpp/test_loop_rotation.cpp
+++ b/tests/cpp/test_loop_rotation.cpp
@@ -77,7 +77,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
     auto cg_outputs = ke.runFusion({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
@@ -170,7 +170,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
     auto cg_outputs = ke.runFusion({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
@@ -279,7 +279,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
     auto cg_outputs = ke.runFusion({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
@@ -390,7 +390,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
     auto cg_outputs = ke.runFusion({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
@@ -527,7 +527,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
     auto cg_outputs = ke.runFusion({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
@@ -663,7 +663,7 @@ __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     auto t0 = at::randn({n, 3}, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
     auto cg_outputs = ke.runFusion({t0});
     testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -136,7 +136,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmul) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -197,7 +197,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulBroadcastBatch) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref =
       atMatmul(
           inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout)
@@ -255,7 +255,7 @@ TEST_P(MatmulTestWithLayout, AmperePrologueFusionBroadcast) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -316,7 +316,7 @@ TEST_P(MatmulTestWithLayout, AmpereProloguePointwise) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.sin().to(at::kFloat),
       inputs.second.sin().to(at::kFloat),
@@ -377,7 +377,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulBFloat16) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -440,7 +440,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulPipelineGmem) {
     ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
     ASSERT_FALSE(
         PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-    auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+    auto cg_outputs = ke.run({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -524,7 +524,7 @@ TEST_P(MatmulTestWithLayout, AmpereSwizzle) {
     ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
     ASSERT_FALSE(
         PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-    auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+    auto cg_outputs = ke.run({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.01, 0.01));
@@ -652,7 +652,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulRegCircularBuffer) {
     ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
     ASSERT_FALSE(
         PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-    auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+    auto cg_outputs = ke.run({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -937,7 +937,7 @@ TEST_F(MatmulTest, MatmulMatmulAmpere) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8, 0, ke.compile(&fusion, {t0, t1, t2}, LaunchParams(), matmul_cparams));
 
-  auto cg_outputs = ke.runFusion({t0, t1, t2});
+  auto cg_outputs = ke.run({t0, t1, t2});
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
   // relaxed check for now, err accumulation is significant.
@@ -1315,7 +1315,7 @@ TEST_F(MatmulTest, MatmulSoftmaxMatmulAmpere) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8, 0, ke.compile(&fusion, {t0, t1, t2}, LaunchParams(), matmul_cparams));
 
-  auto cg_outputs = ke.runFusion({t0, t1, t2});
+  auto cg_outputs = ke.run({t0, t1, t2});
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
   auto g1 = t0.to(at::kFloat).matmul(t1.t().to(at::kFloat));
@@ -1369,7 +1369,7 @@ TEST_P(MatmulTestWithLayout, TuringMatmul) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -1511,7 +1511,7 @@ TEST_F(MatmulTest, AmpereMatmulTNCpAsync) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
   auto tref = t0.to(at::kFloat).matmul(t1.t().to(at::kFloat));
@@ -1678,7 +1678,7 @@ TEST_F(MatmulTest, AmpereStridedBatchedMatmulTN) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
   // ref implementation:
@@ -1849,7 +1849,7 @@ TEST_F(MatmulTest, AmpereViewMatmulTN) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
   auto tref =
@@ -2032,7 +2032,7 @@ TEST_F(MatmulTest, AmpereMatmulTNSwizzled) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
   auto tref = t0.to(at::kFloat).matmul(t1.t().to(at::kFloat));
@@ -2093,7 +2093,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulLargeLoad) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -2149,7 +2149,7 @@ TEST_P(MatmulTestWithLayout, TuringMatmulLargeLoad) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -2219,7 +2219,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulTileCheck4warp) {
               LaunchParams(),
               matmul_cparams));
       EXPECT_TRUE(getBankConflictInfo(ke.kernel()).empty());
-      auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+      auto cg_outputs = ke.run({inputs.first, inputs.second});
       ASSERT_FALSE(
           PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
       auto tref = atMatmul(
@@ -2302,7 +2302,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulTileCheck8warp) {
         ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
         ASSERT_FALSE(
             PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-        auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+        auto cg_outputs = ke.run({inputs.first, inputs.second});
         auto tref = atMatmul(
             inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
         NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -2373,7 +2373,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulTileCheck6warp) {
     ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
     ASSERT_FALSE(
         PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-    auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+    auto cg_outputs = ke.run({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
     NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -2433,7 +2433,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulLargeLoadLargeK) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.001, 0.001));
@@ -2485,7 +2485,7 @@ TEST_P(MatmulTestWithLayout, AmpereSplitKLikeStridedBatchedMatmul) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto tref = splitkLikeAtMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
@@ -2575,7 +2575,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulSmemEpilogue) {
             {inputs.first, inputs.second},
             LaunchParams(),
             matmul_cparams));
-    auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+    auto cg_outputs = ke.run({inputs.first, inputs.second});
     auto tref = atMatmul(
         inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
 
@@ -2700,7 +2700,7 @@ TEST_F(MatmulTest, AmpereMatmulSmemEpiloguePromotionRequiredA100) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
-  // KernelExecutor::compileFusion would fail otherwise.
+  // KernelExecutor::compile would fail otherwise.
   SKIP_IF_INSUFFICIENT_SMEM(&mparams, data_types);
 
   at::manual_seed(0);
@@ -2715,7 +2715,7 @@ TEST_F(MatmulTest, AmpereMatmulSmemEpiloguePromotionRequiredA100) {
           {inputs.first, inputs.second},
           LaunchParams(),
           matmul_cparams));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
 
@@ -2815,7 +2815,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulSmemEpilogueCast) {
           {inputs.first, inputs.second},
           LaunchParams(),
           matmul_cparams));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   tref = tref.to(at::kHalf);
@@ -2911,7 +2911,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulSmemEpilogueRelu) {
           {inputs.first, inputs.second},
           LaunchParams(),
           matmul_cparams));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto t2 = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   auto tref = at::relu(t2).to(at::kFloat);
@@ -2995,7 +2995,7 @@ TEST_P(MatmulTestWithLayout, FusionAmpereMatmulSplitK_CUDA) {
       NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
           7, 5, ke.compile(&fusion, {inputs.first, inputs.second}));
       EXPECT_TRUE(getBankConflictInfo(ke.kernel()).empty());
-      auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+      auto cg_outputs = ke.run({inputs.first, inputs.second});
       ASSERT_FALSE(
           PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
       auto tref = atMatmul(
@@ -3059,7 +3059,7 @@ TEST_P(MatmulTestWithLayout, FusionAmpereMatmulSplitKBias_CUDA) {
       KernelExecutor ke;
       NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(7, 5, ke.compile(&fusion, inputs));
       EXPECT_TRUE(getBankConflictInfo(ke.kernel()).empty());
-      auto cg_outputs = ke.runFusion(inputs);
+      auto cg_outputs = ke.run(inputs);
       ASSERT_FALSE(
           PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
       auto tref = atBiasEpilogue(
@@ -3123,7 +3123,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulBatchSplitK) {
       ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
       ASSERT_FALSE(
           PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-      auto cg_outputs = ke.runFusion(inputs);
+      auto cg_outputs = ke.run(inputs);
       auto tref =
           atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout);
 
@@ -3189,7 +3189,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulBatchSplitKBias) {
       ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
       ASSERT_FALSE(
           PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-      auto cg_outputs = ke.runFusion(inputs);
+      auto cg_outputs = ke.run(inputs);
       auto tref = atBiasEpilogue(
           atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout),
           aten_bias);
@@ -3254,7 +3254,7 @@ TEST_F(MatmulTest, ReproIssue1808) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -3406,7 +3406,7 @@ TEST_P(MatmulTestWithLayout, MisalignedVectorization) {
         ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
         ASSERT_FALSE(
             PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-        auto outputs = ke.runFusion(inputs);
+        auto outputs = ke.run(inputs);
 
         EXPECT_TRUE(outputs[0].allclose(tref, 0.001, 0.001));
       }
@@ -3463,7 +3463,7 @@ TEST_F(MatmulTest, MultipleConsecutiveDims) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
   auto tref = at::reshape(
       at::linear(
           at::reshape(A.to(at::kFloat), {M1 * M2, K}),
@@ -3529,7 +3529,7 @@ TEST_F(MatmulTest, DISABLED_MultipleNonConsecutiveMDims) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
   auto Apermuted = A.permute({{1, 2}}).reshape({M1 * M2, K});
   auto tref = at::linear(Apermuted.to(at::kFloat), B.to(at::kFloat))
                   .reshape({M1, M2, N})
@@ -3595,7 +3595,7 @@ TEST_F(MatmulTest, DISABLED_MultipleNonConsecutiveNDims) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
   auto Bpermuted = B.permute({{1, 2}}).reshape({N1 * N2, K});
   auto tref = at::linear(A.to(at::kFloat), Bpermuted.to(at::kFloat))
                   .reshape({M, N1, N2});
@@ -3653,7 +3653,7 @@ TEST_F(MatmulTest, MultipleMDimsBatch) {
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
-  auto cg_outputs = ke.runFusion(inputs);
+  auto cg_outputs = ke.run(inputs);
   auto tref =
       at::matmul(A.to(at::kFloat), at::permute(B.to(at::kFloat), {0, 2, 1}));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -3785,7 +3785,7 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
   KernelExecutor ke;
   ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(inputs.first.squeeze(), inputs.second.squeeze(), layout);
   EXPECT_TRUE(at::allclose(cg_outputs[0], tref, 1e-5, 1e-5));
 }

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -128,7 +128,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmul) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -189,7 +189,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulBroadcastBatch) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -247,7 +247,7 @@ TEST_P(MatmulTestWithLayout, AmperePrologueFusionBroadcast) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -308,7 +308,7 @@ TEST_P(MatmulTestWithLayout, AmpereProloguePointwise) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -369,7 +369,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulBFloat16) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -432,7 +432,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulPipelineGmem) {
     NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
         8,
         0,
-        ke.compileFusion(
+        ke.compile(
             &fusion,
             {inputs.first, inputs.second},
             LaunchParams(),
@@ -516,7 +516,7 @@ TEST_P(MatmulTestWithLayout, AmpereSwizzle) {
     NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
         8,
         0,
-        ke.compileFusion(
+        ke.compile(
             &fusion,
             {inputs.first, inputs.second},
             LaunchParams(),
@@ -644,7 +644,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulRegCircularBuffer) {
     NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
         8,
         0,
-        ke.compileFusion(
+        ke.compile(
             &fusion,
             {inputs.first, inputs.second},
             LaunchParams(),
@@ -935,9 +935,7 @@ TEST_F(MatmulTest, MatmulMatmulAmpere) {
   KernelExecutor ke;
 
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8,
-      0,
-      ke.compileFusion(&fusion, {t0, t1, t2}, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, {t0, t1, t2}, LaunchParams(), matmul_cparams));
 
   auto cg_outputs = ke.runFusion({t0, t1, t2});
   ASSERT_FALSE(
@@ -1315,9 +1313,7 @@ TEST_F(MatmulTest, MatmulSoftmaxMatmulAmpere) {
   KernelExecutor ke;
 
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8,
-      0,
-      ke.compileFusion(&fusion, {t0, t1, t2}, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, {t0, t1, t2}, LaunchParams(), matmul_cparams));
 
   auto cg_outputs = ke.runFusion({t0, t1, t2});
   ASSERT_FALSE(
@@ -1369,7 +1365,7 @@ TEST_P(MatmulTestWithLayout, TuringMatmul) {
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      7, 5, ke.compileFusion(&fusion, {inputs.first, inputs.second}));
+      7, 5, ke.compile(&fusion, {inputs.first, inputs.second}));
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
@@ -1513,9 +1509,7 @@ TEST_F(MatmulTest, AmpereMatmulTNCpAsync) {
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8,
-      0,
-      ke.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
 
   auto cg_outputs = ke.runFusion({t0, t1});
   ASSERT_FALSE(
@@ -1682,9 +1676,7 @@ TEST_F(MatmulTest, AmpereStridedBatchedMatmulTN) {
   KernelExecutor ke;
 
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8,
-      0,
-      ke.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
 
   auto cg_outputs = ke.runFusion({t0, t1});
   ASSERT_FALSE(
@@ -1855,9 +1847,7 @@ TEST_F(MatmulTest, AmpereViewMatmulTN) {
   KernelExecutor ke;
 
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8,
-      0,
-      ke.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
 
   auto cg_outputs = ke.runFusion({t0, t1});
   ASSERT_FALSE(
@@ -2041,7 +2031,7 @@ TEST_F(MatmulTest, AmpereMatmulTNSwizzled) {
   auto t1 = at::randn({N, K}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams);
+  ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams);
   auto cg_outputs = ke.runFusion({t0, t1});
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
@@ -2095,7 +2085,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulLargeLoad) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -2151,7 +2141,7 @@ TEST_P(MatmulTestWithLayout, TuringMatmulLargeLoad) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       7,
       5,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -2223,7 +2213,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulTileCheck4warp) {
       NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
           8,
           0,
-          ke.compileFusion(
+          ke.compile(
               &fusion,
               {inputs.first, inputs.second},
               LaunchParams(),
@@ -2304,7 +2294,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulTileCheck8warp) {
         NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
             8,
             0,
-            ke.compileFusion(
+            ke.compile(
                 &fusion,
                 {inputs.first, inputs.second},
                 LaunchParams(),
@@ -2375,7 +2365,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulTileCheck6warp) {
     NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
         8,
         0,
-        ke.compileFusion(
+        ke.compile(
             &fusion,
             {inputs.first, inputs.second},
             LaunchParams(),
@@ -2435,7 +2425,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulLargeLoadLargeK) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -2491,9 +2481,7 @@ TEST_P(MatmulTestWithLayout, AmpereSplitKLikeStridedBatchedMatmul) {
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8,
-      0,
-      ke.compileFusion(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
@@ -2582,7 +2570,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulSmemEpilogue) {
     NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
         8,
         0,
-        ke.compileFusion(
+        ke.compile(
             &fusion,
             {inputs.first, inputs.second},
             LaunchParams(),
@@ -2722,7 +2710,7 @@ TEST_F(MatmulTest, AmpereMatmulSmemEpiloguePromotionRequiredA100) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -2822,7 +2810,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulSmemEpilogueCast) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -2918,7 +2906,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulSmemEpilogueRelu) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -3005,7 +2993,7 @@ TEST_P(MatmulTestWithLayout, FusionAmpereMatmulSplitK_CUDA) {
 
       KernelExecutor ke;
       NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-          7, 5, ke.compileFusion(&fusion, {inputs.first, inputs.second}));
+          7, 5, ke.compile(&fusion, {inputs.first, inputs.second}));
       EXPECT_TRUE(getBankConflictInfo(ke.kernel()).empty());
       auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
       ASSERT_FALSE(
@@ -3069,8 +3057,7 @@ TEST_P(MatmulTestWithLayout, FusionAmpereMatmulSplitKBias_CUDA) {
       std::vector<c10::IValue> inputs = {aten_a, aten_b, aten_bias};
 
       KernelExecutor ke;
-      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-          7, 5, ke.compileFusion(&fusion, inputs));
+      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(7, 5, ke.compile(&fusion, inputs));
       EXPECT_TRUE(getBankConflictInfo(ke.kernel()).empty());
       auto cg_outputs = ke.runFusion(inputs);
       ASSERT_FALSE(
@@ -3132,8 +3119,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulBatchSplitK) {
       std::vector<c10::IValue> inputs = {aten_a, aten_b};
 
       KernelExecutor ke;
-      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-          7, 5, ke.compileFusion(&fusion, inputs));
+      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(7, 5, ke.compile(&fusion, inputs));
       ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
       ASSERT_FALSE(
           PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
@@ -3199,8 +3185,7 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulBatchSplitKBias) {
       std::vector<c10::IValue> inputs = {aten_a, aten_b, aten_bias};
 
       KernelExecutor ke;
-      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-          7, 5, ke.compileFusion(&fusion, inputs));
+      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(7, 5, ke.compile(&fusion, inputs));
       ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
       ASSERT_FALSE(
           PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
@@ -3261,7 +3246,7 @@ TEST_F(MatmulTest, ReproIssue1808) {
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
       8,
       0,
-      ke.compileFusion(
+      ke.compile(
           &fusion,
           {inputs.first, inputs.second},
           LaunchParams(),
@@ -3417,8 +3402,7 @@ TEST_P(MatmulTestWithLayout, MisalignedVectorization) {
         NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
             8,
             0,
-            ke.compileFusion(
-                fusion.get(), inputs, LaunchParams(), matmul_cparams));
+            ke.compile(fusion.get(), inputs, LaunchParams(), matmul_cparams));
         ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
         ASSERT_FALSE(
             PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
@@ -3475,7 +3459,7 @@ TEST_F(MatmulTest, MultipleConsecutiveDims) {
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8, 0, ke.compileFusion(&fusion, inputs, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, inputs, LaunchParams(), matmul_cparams));
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
@@ -3541,7 +3525,7 @@ TEST_F(MatmulTest, DISABLED_MultipleNonConsecutiveMDims) {
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8, 0, ke.compileFusion(&fusion, inputs, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, inputs, LaunchParams(), matmul_cparams));
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
@@ -3607,7 +3591,7 @@ TEST_F(MatmulTest, DISABLED_MultipleNonConsecutiveNDims) {
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8, 0, ke.compileFusion(&fusion, inputs, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, inputs, LaunchParams(), matmul_cparams));
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
@@ -3665,7 +3649,7 @@ TEST_F(MatmulTest, MultipleMDimsBatch) {
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8, 0, ke.compileFusion(&fusion, inputs, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, inputs, LaunchParams(), matmul_cparams));
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   ASSERT_FALSE(
       PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(ke.kernel()));
@@ -3799,7 +3783,7 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
       matmulAtInput3DHopperSS(M, N, K, layout, data_type_to_aten(dtype));
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
   auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
   auto tref = atMatmul(inputs.first.squeeze(), inputs.second.squeeze(), layout);

--- a/tests/cpp/test_matmul_sass.cpp
+++ b/tests/cpp/test_matmul_sass.cpp
@@ -99,7 +99,7 @@ sass::Container getSASSFor(
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
   auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
   auto tref = atMatmul(
@@ -162,7 +162,7 @@ sass::Container getBinaryOpMulEpilogueSASSFor(
   const double alpha = 2.5;
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion,
       {inputs.first, inputs.second, alpha},
       LaunchParams(),

--- a/tests/cpp/test_matmul_sass.cpp
+++ b/tests/cpp/test_matmul_sass.cpp
@@ -101,7 +101,7 @@ sass::Container getSASSFor(
   KernelExecutor ke;
   ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
 
@@ -167,7 +167,7 @@ sass::Container getBinaryOpMulEpilogueSASSFor(
       {inputs.first, inputs.second, alpha},
       LaunchParams(),
       matmul_cparams);
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second, alpha});
+  auto cg_outputs = ke.run({inputs.first, inputs.second, alpha});
   auto tref = at::mul(
                   atMatmul(
                       inputs.first.to(at::kFloat),

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2814,7 +2814,7 @@ TEST_P(AllocationDomainTest, BasicMatmul) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
@@ -2847,7 +2847,7 @@ TEST_P(AllocationDomainTest, BasicMatmulNoTranspose) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
@@ -2883,7 +2883,7 @@ TEST_P(AllocationDomainTest, BasicMatmulWithPrologueSet) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
@@ -2921,7 +2921,7 @@ TEST_P(AllocationDomainTest, BasicMatmulWithPrologueSetCastSin) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.sin().to(at::kFloat));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
@@ -2958,7 +2958,7 @@ TEST_P(AllocationDomainTest, BasicMatmulWithPrologueSetCastSinNoTranspose) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.sin().to(at::kFloat));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
@@ -2995,7 +2995,7 @@ TEST_P(AllocationDomainTest, BasicMatmulWithPrologueSetCastSinSetNoTranspose) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.sin().to(at::kFloat));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
@@ -3032,7 +3032,7 @@ TEST_P(AllocationDomainTest, MatmulWithPrologueSetCastSinTranspose) {
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.sin().to(at::kFloat));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
@@ -3141,12 +3141,12 @@ TEST_F(MatmulSchedulerTest, HSH_TT) {
   //! of ampere scheduler.
   /*
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       fusion.get(),
       {inputs.first, inputs.second},
       LaunchParams(),
       matmul_cparams);
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(inputs.first.squeeze(), inputs.second.squeeze(), layout);
   EXPECT_TRUE(at::allclose(cg_outputs[0], tref, 1e-5, 1e-5));
   */
@@ -3218,7 +3218,7 @@ TEST_F(MatmulSchedulerTest, HSH_TN) {
       LaunchParams(),
       matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(inputs.first.squeeze(), inputs.second.squeeze(), layout);
   EXPECT_TRUE(at::allclose(cg_outputs[0], tref, 1e-5, 1e-5));
 }
@@ -3293,7 +3293,7 @@ TEST_F(MatmulSchedulerTest, HSH_NT) {
       LaunchParams(),
       matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(inputs.first.squeeze(), inputs.second.squeeze(), layout);
   EXPECT_TRUE(at::allclose(cg_outputs[0], tref, 1e-5, 1e-5));
 }
@@ -3364,12 +3364,12 @@ TEST_F(MatmulSchedulerTest, HSH_NN) {
   // of ampere scheduler.
   /*
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       fusion.get(),
       {inputs.first, inputs.second},
       LaunchParams(),
       matmul_cparams);
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(inputs.first.squeeze(), inputs.second.squeeze(), layout);
   EXPECT_TRUE(at::allclose(cg_outputs[0], tref, 1e-5, 1e-5));
   */

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2812,7 +2812,7 @@ TEST_P(AllocationDomainTest, BasicMatmul) {
 
   auto [t0, t1] = getInputTensors(M, N, K, a_m_inner, b_k_inner);
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+  ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
   auto cg_outputs = ke.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
@@ -2845,7 +2845,7 @@ TEST_P(AllocationDomainTest, BasicMatmulNoTranspose) {
 
   auto [t0, t1] = getInputTensors(M, N, K, a_m_inner, b_k_inner);
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+  ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
   auto cg_outputs = ke.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
@@ -2881,7 +2881,7 @@ TEST_P(AllocationDomainTest, BasicMatmulWithPrologueSet) {
 
   auto [t0, t1] = getInputTensors(M, N, K, a_m_inner, b_k_inner);
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+  ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
   auto cg_outputs = ke.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.to(at::kFloat));
@@ -2919,7 +2919,7 @@ TEST_P(AllocationDomainTest, BasicMatmulWithPrologueSetCastSin) {
 
   auto [t0, t1] = getInputTensors(M, N, K, a_m_inner, b_k_inner);
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+  ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
   auto cg_outputs = ke.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.sin().to(at::kFloat));
@@ -2956,7 +2956,7 @@ TEST_P(AllocationDomainTest, BasicMatmulWithPrologueSetCastSinNoTranspose) {
 
   auto [t0, t1] = getInputTensors(M, N, K, a_m_inner, b_k_inner);
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+  ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
   auto cg_outputs = ke.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.sin().to(at::kFloat));
@@ -2993,7 +2993,7 @@ TEST_P(AllocationDomainTest, BasicMatmulWithPrologueSetCastSinSetNoTranspose) {
 
   auto [t0, t1] = getInputTensors(M, N, K, a_m_inner, b_k_inner);
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+  ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
   auto cg_outputs = ke.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.sin().to(at::kFloat));
@@ -3030,7 +3030,7 @@ TEST_P(AllocationDomainTest, MatmulWithPrologueSetCastSinTranspose) {
 
   auto [t0, t1] = getInputTensors(M, N, K, a_m_inner, b_k_inner);
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+  ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
 
   auto cg_outputs = ke.runFusion({t0, t1});
   auto tref = t0.to(at::kFloat).matmul(t1.sin().to(at::kFloat));
@@ -3212,7 +3212,7 @@ TEST_F(MatmulSchedulerTest, HSH_TN) {
       matmulAtInput3DHopperSS(M, N, K, layout, data_type_to_aten(dtype));
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       fusion.get(),
       {inputs.first, inputs.second},
       LaunchParams(),
@@ -3287,7 +3287,7 @@ TEST_F(MatmulSchedulerTest, HSH_NT) {
       matmulAtInput3DHopperSS(M, N, K, layout, data_type_to_aten(dtype));
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       fusion.get(),
       {inputs.first, inputs.second},
       LaunchParams(),

--- a/tests/cpp/test_mbarrier.cpp
+++ b/tests/cpp/test_mbarrier.cpp
@@ -122,7 +122,7 @@ TEST_F(MBarrierTest, Simple) {
     top_level_exprs.push_back(invalidate);
   });
 
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 
   // Make sure that the post-lowering hook successfully inserted all mbarrier
   // operations

--- a/tests/cpp/test_mbarrier.cpp
+++ b/tests/cpp/test_mbarrier.cpp
@@ -138,7 +138,7 @@ TEST_F(MBarrierTest, Simple) {
 
   auto input = at::randn(
       {32, 32}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
-  auto outputs = ke.runFusion({input});
+  auto outputs = ke.run({input});
 
   testValidate(&fusion, outputs, {input}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -82,7 +82,7 @@ TEST_P(MemoryTest, LoadCache) {
   {
     DebugDumpOptionsGuard debug_dump_options_guard;
     DebugDumpOptionsGuard::getCurOptions().set(DebugDumpOption::Ptx);
-    ke.compileFusion(&fusion, {input});
+    ke.compile(&fusion, {input});
   }
 
   // Verify PTX.
@@ -157,7 +157,7 @@ TEST_F(MemoryTest, RefineCachePolicy) {
   {
     DebugDumpOptionsGuard debug_dump_options_guard;
     DebugDumpOptionsGuard::getCurOptions().set(DebugDumpOption::Ptx);
-    ke.compileFusion(&fusion, {a, b});
+    ke.compile(&fusion, {a, b});
   }
 
   // Verify PTX.
@@ -458,7 +458,7 @@ TEST_P(TMASimpleLdstTest, Load) {
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), dim);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -534,7 +534,7 @@ TEST_P(TMALoadTestWithABroadcastDim, LoadWithBroadcast) {
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   auto cg_outputs = ke.runFusion({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
@@ -578,7 +578,7 @@ TEST_P(TMASimpleLdstTest, Store) {
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), dim);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -640,7 +640,7 @@ TEST_F(TMAIndexingTest, Load2DTensorWith1DTMA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({1024, 1024}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -677,7 +677,7 @@ TEST_F(TMAIndexingTest, Load1DTensorWith2DTMA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({1024 * 1024}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -714,7 +714,7 @@ TEST_F(TMAIndexingTest, NonOneElementStride) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({1024, 1024}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
@@ -785,7 +785,7 @@ TEST_F(TMAIndexingTest, Advanced) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({4, 32, 2, 8, 8, 8, 32, 8}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 4);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -834,7 +834,7 @@ TEST_F(TMAIndexingTest, DefineBoxByCompositing1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({4, 32, 2, 8, 8, 8, 32, 8}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 4);
   EXPECT_FALSE(PredicatedChecker::isPredicated(tv1, ke.kernel()));
@@ -887,7 +887,7 @@ TEST_F(TMAIndexingTest, DefineBoxByCompositing2) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({32, 4, 2, 8, 8, 8, 2, 8, 4}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 5);
   EXPECT_FALSE(PredicatedChecker::isPredicated(tv1, ke.kernel()));
@@ -948,7 +948,7 @@ TEST_F(TMAIndexingTest, DefineBoxByRotation1) {
   auto t0 = at::randn(
       {prime_number, prime_number, multiple_of_16B_but_not_more}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 3);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -995,7 +995,7 @@ TEST_F(TMAIndexingTest, DefineBoxByRotation2) {
   int64_t multiple_of_8_but_not_more = 8 * 997;
   auto t0 = at::randn({multiple_of_8_but_not_more}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   // We will be using 2D TMA instead of 1D, because strided box can not be
   // merged with other bulk axes by rotation. So, this schedule will be
@@ -1057,7 +1057,7 @@ TEST_F(TMAIndexingTest, DefineBoxByRotation3) {
   int64_t multiple_of_23 = 23 * 997;
   auto t0 = at::randn({multiple_of_23, 8}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   // We will be using 3D TMA instead of 2D, because split(23, 8) is indivisible,
   // we can not consider this schedule as a 2D TMA whose first dimension has box
@@ -1119,7 +1119,7 @@ TEST_F(TMAIndexingTest, NonTrivialGmemAllocationDomain1) {
                 .transpose(0, 1)
                 .view({128, 1024, 128});
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -1174,7 +1174,7 @@ TEST_F(TMAIndexingTest, NonTrivialGmemAllocationDomain2) {
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 3, 5, 7, 11, 32}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 3);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -1222,7 +1222,7 @@ TEST_F(TMAMiscTest, AdvancedThreadParallelizationLoad) {
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   auto t0 = at::randn({100000}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 4);
@@ -1265,7 +1265,7 @@ TEST_F(TMAMiscTest, AdvancedThreadParallelizationStore) {
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   auto t0 = at::randn({100000}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 4);
@@ -1301,7 +1301,7 @@ TEST_F(TMAMiscTest, DisableIndexHoisting) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({32}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
@@ -1333,7 +1333,7 @@ TEST_F(TMAMiscTest, Repro1977) {
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   auto t0 = at::randn({1024}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
@@ -1424,7 +1424,7 @@ TEST_F(TMAMiscTest, StoreSyncInsertion) {
         1);
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {input}, {}, matmul_cparams);
+    ke.compile(&fusion, {input}, {}, matmul_cparams);
     auto cg_outputs = ke.runFusion({input});
     testValidate(&fusion, cg_outputs, {input}, {input}, __LINE__, __FILE__);
   }
@@ -1476,7 +1476,7 @@ TEST_F(TMAMiscTest, StoreSyncInsertion) {
     // remove the RAW sync by adding a cleanup pass.
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {input}, {}, matmul_cparams);
+    ke.compile(&fusion, {input}, {}, matmul_cparams);
     auto cg_outputs = ke.runFusion({input});
     testValidate(&fusion, cg_outputs, {input}, {input}, __LINE__, __FILE__);
   }
@@ -1543,7 +1543,7 @@ TEST_F(TMAMiscTest, StoreSyncInsertion) {
         2);
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {input}, {}, matmul_cparams);
+    ke.compile(&fusion, {input}, {}, matmul_cparams);
     auto cg_outputs = ke.runFusion({input});
     testValidate(&fusion, cg_outputs, {input}, {input}, __LINE__, __FILE__);
   }
@@ -1633,7 +1633,7 @@ TEST_F(TMACompileTimeInvalidTest, BulkNotInTMA) {
             at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
         auto t0 = at::randn({32}, options);
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "ParallelType::Bulk is only supported for cp.async.bulk.")));
@@ -1662,7 +1662,7 @@ TEST_F(TMACompileTimeInvalidTest, BulkBroadcast) {
             at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
         auto t0 = at::randn({32}, options);
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "ParallelType::Bulk is only supported for IterType::Iteration.")));
@@ -1690,7 +1690,7 @@ TEST_F(TMACompileTimeInvalidTest, InvalidParallelType) {
             at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
         auto t0 = at::randn({32}, options);
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Invalid parallel type for cp.async.bulk: V")));
@@ -1728,7 +1728,7 @@ TEST_F(TMARuntimeInvalidTest, MisalignedGlobalAddress) {
   auto t0_aligned = at::randn({128 + items_of_16_bytes}, options)
                         .narrow(0, items_of_16_bytes, 128);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0_aligned}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0_aligned}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -1783,7 +1783,7 @@ TEST_F(TMARuntimeInvalidTest, MisalignedGlobalStride) {
   auto t0_aligned =
       at::randn({128, 128 + items_of_16_bytes}, options).narrow(1, 0, 128);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0_aligned}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0_aligned}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -1837,7 +1837,7 @@ TEST_F(TMACompileTimeInvalidTest, SizeOfTransfer) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "The expected bytes must be a multiple of 16 bytes, but 8 is not.")));
@@ -1877,7 +1877,7 @@ TEST_F(TMARuntimeInvalidTest, SizeOfTransfer) {
   auto t0 = at::randn({128}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, items_of_16_bytes}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0, items_of_16_bytes}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -1930,7 +1930,7 @@ TEST_F(TMARuntimeInvalidTest, InvalidView) {
   // (10240,) can be viewed as (10, 1024)
   auto t0_valid = at::randn({10240}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0_valid}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0_valid}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
 
@@ -1976,7 +1976,7 @@ TEST_F(TMACompileTimeInvalidTest, InnermostDiscontiguous) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "The innermost dimension of the TMA domain must be contiguous")));
@@ -2017,7 +2017,7 @@ TEST_F(TMACompileTimeInvalidTest, MergeDiscontiguous) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Can not merge discontiguous dimensions, but")));
@@ -2053,7 +2053,7 @@ TEST_F(TMACompileTimeInvalidTest, InnermostElementStrideNotOne) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "When interleave is CU_TENSOR_MAP_INTERLEAVE_NONE "
@@ -2092,7 +2092,7 @@ TEST_F(TMACompileTimeInvalidTest, SwizzleBulkWithNonBulk) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "TMA domain must be a view of the allocation domain of the gmem tensor")));
@@ -2136,7 +2136,7 @@ TEST_F(TMADocTest, Figure13a) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Some error message")));
@@ -2174,7 +2174,7 @@ TEST_F(TMADocTest, Figure14a) {
   auto t0 = at::randn({16, 200}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
@@ -2215,7 +2215,7 @@ TEST_F(TMADocTest, Figure13b) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Some error message")));
@@ -2250,7 +2250,7 @@ TEST_F(TMADocTest, Figure14b) {
   auto t0 = at::randn({16, 10}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
@@ -2292,7 +2292,7 @@ TEST_F(TMADocTest, Figure13c) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Some error message")));
@@ -2328,7 +2328,7 @@ TEST_F(TMADocTest, Figure14c) {
   auto t0 = at::randn({16, 200}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
@@ -2367,7 +2367,7 @@ TEST_F(TMADocTest, Figure13d) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Some error message")));
@@ -2399,7 +2399,7 @@ TEST_F(TMADocTest, Figure14d) {
   auto t0 = at::randn({16, 12}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -2442,7 +2442,7 @@ TEST_F(TMADocTest, Figure13e) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Some error message")));
@@ -2479,7 +2479,7 @@ TEST_F(TMADocTest, Figure14e) {
   auto t0 = at::randn({16, 10}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
@@ -2524,7 +2524,7 @@ TEST_F(TMADocTest, Figure15a) {
   auto t0 = at::randn({16, 10}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
@@ -2566,7 +2566,7 @@ TEST_F(TMADocTest, Figure15b) {
   auto t0 = at::randn({16, 12}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 4);
@@ -2614,7 +2614,7 @@ TEST_F(TMADocTest, Figure15c) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Some error message")));
@@ -2661,7 +2661,7 @@ TEST_F(TMADocTest, Figure15d) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Some error message")));
@@ -2702,7 +2702,7 @@ TEST_F(TMADocTest, Figure15e) {
   EXPECT_THAT(
       [&]() {
         KernelExecutor ke;
-        ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+        ke.compile(&fusion, {t0}, {}, matmul_cparams);
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Some error message")));
@@ -2756,7 +2756,7 @@ TEST_P(LdMatrixTest, Regular) {
   auto t0 = at::randn({size1, getK(macro)}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, LaunchParams(), matmul_cparams);
+  ke.compile(&fusion, {t0}, LaunchParams(), matmul_cparams);
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -2882,7 +2882,7 @@ TEST_P(StMatrixSingleTileTest, Regular) {
   auto t0 = at::randn({sizeM, sizeN}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, LaunchParams(), matmul_cparams);
+  ke.compile(&fusion, {t0}, LaunchParams(), matmul_cparams);
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -2943,7 +2943,7 @@ TEST_P(StMatrixTest, Regular) {
   auto t0 = at::randn({sizeM, sizeN}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, LaunchParams(), matmul_cparams);
+  ke.compile(&fusion, {t0}, LaunchParams(), matmul_cparams);
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -3018,7 +3018,7 @@ TEST_P(LdMatrixTest, Transpose) {
   auto t0 = at::randn({getK(macro), size2}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, LaunchParams(), matmul_cparams);
+  ke.compile(&fusion, {t0}, LaunchParams(), matmul_cparams);
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -98,7 +98,7 @@ TEST_P(MemoryTest, LoadCache) {
   std::filesystem::remove(compiled_kernel.ptx_filename);
 
   // Verify output tensors.
-  std::vector<at::Tensor> actual_ts = ke.runFusion({input});
+  std::vector<at::Tensor> actual_ts = ke.run({input});
   testValidate(
       &fusion, actual_ts, {input}, {expected_output}, __LINE__, __FILE__);
 }
@@ -170,7 +170,7 @@ TEST_F(MemoryTest, RefineCachePolicy) {
   debug() << "Removing " << compiled_kernel.ptx_filename << std::endl;
   std::filesystem::remove(compiled_kernel.ptx_filename);
 
-  std::vector<at::Tensor> actual_outputs = ke.runFusion({a, b});
+  std::vector<at::Tensor> actual_outputs = ke.run({a, b});
   testValidate(&fusion, actual_outputs, {a, b}, {c}, __LINE__, __FILE__);
 }
 
@@ -466,7 +466,7 @@ TEST_P(TMASimpleLdstTest, Load) {
       XorFinder::findXor(ke.kernel()), (swizzle != MmaInputSmemSwizzle::None));
   TMADimChecker::getDim(ke.kernel());
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -536,7 +536,7 @@ TEST_P(TMALoadTestWithABroadcastDim, LoadWithBroadcast) {
   KernelExecutor ke;
   ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -585,7 +585,7 @@ TEST_P(TMASimpleLdstTest, Store) {
   ASSERT_EQ(
       XorFinder::findXor(ke.kernel()), (swizzle != MmaInputSmemSwizzle::None));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -645,7 +645,7 @@ TEST_F(TMAIndexingTest, Load2DTensorWith1DTMA) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -682,7 +682,7 @@ TEST_F(TMAIndexingTest, Load1DTensorWith2DTMA) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -719,7 +719,7 @@ TEST_F(TMAIndexingTest, NonOneElementStride) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -790,7 +790,7 @@ TEST_F(TMAIndexingTest, Advanced) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 4);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -839,7 +839,7 @@ TEST_F(TMAIndexingTest, DefineBoxByCompositing1) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 4);
   EXPECT_FALSE(PredicatedChecker::isPredicated(tv1, ke.kernel()));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -892,7 +892,7 @@ TEST_F(TMAIndexingTest, DefineBoxByCompositing2) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 5);
   EXPECT_FALSE(PredicatedChecker::isPredicated(tv1, ke.kernel()));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -953,7 +953,7 @@ TEST_F(TMAIndexingTest, DefineBoxByRotation1) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 3);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -1005,7 +1005,7 @@ TEST_F(TMAIndexingTest, DefineBoxByRotation2) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 
   // The tensor shape is not a multiple of 8, so the view should fail.
@@ -1016,7 +1016,7 @@ TEST_F(TMAIndexingTest, DefineBoxByRotation2) {
                            .device(at::kCUDA, 0);
         int64_t prime_number = 997;
         auto t0 = at::randn({prime_number}, options);
-        auto cg_outputs = ke.runFusion({t0});
+        auto cg_outputs = ke.run({t0});
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("must be divisible by 8")));
@@ -1068,7 +1068,7 @@ TEST_F(TMAIndexingTest, DefineBoxByRotation3) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 3);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 
   // The tensor shape is not a multiple of 23, so the view should fail.
@@ -1079,7 +1079,7 @@ TEST_F(TMAIndexingTest, DefineBoxByRotation3) {
                            .device(at::kCUDA, 0);
         int64_t prime_number = 997;
         auto t0 = at::randn({prime_number, 8}, options);
-        auto cg_outputs = ke.runFusion({t0});
+        auto cg_outputs = ke.run({t0});
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("must be divisible by 23")));
@@ -1125,7 +1125,7 @@ TEST_F(TMAIndexingTest, NonTrivialGmemAllocationDomain1) {
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
   ASSERT_TRUE(XorFinder::findXor(ke.kernel()));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -1179,7 +1179,7 @@ TEST_F(TMAIndexingTest, NonTrivialGmemAllocationDomain2) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 3);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -1227,7 +1227,7 @@ TEST_F(TMAMiscTest, AdvancedThreadParallelizationLoad) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 4);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -1270,7 +1270,7 @@ TEST_F(TMAMiscTest, AdvancedThreadParallelizationStore) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 4);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -1306,7 +1306,7 @@ TEST_F(TMAMiscTest, DisableIndexHoisting) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -1338,7 +1338,7 @@ TEST_F(TMAMiscTest, Repro1977) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -1425,7 +1425,7 @@ TEST_F(TMAMiscTest, StoreSyncInsertion) {
 
     KernelExecutor ke;
     ke.compile(&fusion, {input}, {}, matmul_cparams);
-    auto cg_outputs = ke.runFusion({input});
+    auto cg_outputs = ke.run({input});
     testValidate(&fusion, cg_outputs, {input}, {input}, __LINE__, __FILE__);
   }
 
@@ -1477,7 +1477,7 @@ TEST_F(TMAMiscTest, StoreSyncInsertion) {
 
     KernelExecutor ke;
     ke.compile(&fusion, {input}, {}, matmul_cparams);
-    auto cg_outputs = ke.runFusion({input});
+    auto cg_outputs = ke.run({input});
     testValidate(&fusion, cg_outputs, {input}, {input}, __LINE__, __FILE__);
   }
 
@@ -1544,7 +1544,7 @@ TEST_F(TMAMiscTest, StoreSyncInsertion) {
 
     KernelExecutor ke;
     ke.compile(&fusion, {input}, {}, matmul_cparams);
-    auto cg_outputs = ke.runFusion({input});
+    auto cg_outputs = ke.run({input});
     testValidate(&fusion, cg_outputs, {input}, {input}, __LINE__, __FILE__);
   }
 }
@@ -1587,11 +1587,11 @@ TEST_F(TMAMiscTest, LoadStrongCorrectness) {
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   auto t0 = at::arange(1, 33, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto expect = at::zeros({2, 1, 2, 16}, options);
   expect.flatten(0, 2).select(0, 0) = at::arange(1, 17, options);
@@ -1733,7 +1733,7 @@ TEST_F(TMARuntimeInvalidTest, MisalignedGlobalAddress) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0_aligned});
+  auto cg_outputs = ke.run({t0_aligned});
   testValidate(
       &fusion, cg_outputs, {t0_aligned}, {t0_aligned}, __LINE__, __FILE__);
 
@@ -1741,7 +1741,7 @@ TEST_F(TMARuntimeInvalidTest, MisalignedGlobalAddress) {
       [&]() {
         auto t0_misaligned = at::randn({128 + items_of_16_bytes / 2}, options)
                                  .narrow(0, items_of_16_bytes / 2, 128);
-        ke.runFusion({t0_misaligned});
+        ke.run({t0_misaligned});
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "globalAddress, which specifies the starting address of the memory region described, "
@@ -1788,7 +1788,7 @@ TEST_F(TMARuntimeInvalidTest, MisalignedGlobalStride) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0_aligned});
+  auto cg_outputs = ke.run({t0_aligned});
   testValidate(
       &fusion, cg_outputs, {t0_aligned}, {t0_aligned}, __LINE__, __FILE__);
 
@@ -1797,7 +1797,7 @@ TEST_F(TMARuntimeInvalidTest, MisalignedGlobalStride) {
         auto t0_misaligned =
             at::randn({128, 128 + items_of_16_bytes / 2}, options)
                 .narrow(1, 0, 128);
-        ke.runFusion({t0_misaligned});
+        ke.run({t0_misaligned});
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "globalStrides array, which specifies tensor stride of each of the lower tensorRank - 1 dimensions in bytes, "
@@ -1882,12 +1882,12 @@ TEST_F(TMARuntimeInvalidTest, SizeOfTransfer) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 1);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0, items_of_16_bytes});
+  auto cg_outputs = ke.run({t0, items_of_16_bytes});
   testValidate(
       &fusion, cg_outputs, {t0, items_of_16_bytes}, {t0}, __LINE__, __FILE__);
 
   EXPECT_THAT(
-      [&]() { ke.runFusion({t0, items_of_16_bytes / 2}); },
+      [&]() { ke.run({t0, items_of_16_bytes / 2}); },
       ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
           "The expected bytes must be a multiple of 16 bytes, but ")));
 }
@@ -1934,14 +1934,14 @@ TEST_F(TMARuntimeInvalidTest, InvalidView) {
 
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
 
-  auto cg_outputs = ke.runFusion({t0_valid});
+  auto cg_outputs = ke.run({t0_valid});
   testValidate(&fusion, cg_outputs, {t0_valid}, {t0_valid}, __LINE__, __FILE__);
 
   EXPECT_THAT(
       [&]() {
         // it is impossible to view (10249,) as (?, 1024)
         auto t0_inval = at::randn({10249}, options);
-        ke.runFusion({t0_inval});
+        ke.run({t0_inval});
       },
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("Invalid view in TMA: the extent of")));
@@ -2179,7 +2179,7 @@ TEST_F(TMADocTest, Figure14a) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -2255,7 +2255,7 @@ TEST_F(TMADocTest, Figure14b) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -2333,7 +2333,7 @@ TEST_F(TMADocTest, Figure14c) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -2404,7 +2404,7 @@ TEST_F(TMADocTest, Figure14d) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -2484,7 +2484,7 @@ TEST_F(TMADocTest, Figure14e) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 1);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -2529,7 +2529,7 @@ TEST_F(TMADocTest, Figure15a) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 0);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -2571,7 +2571,7 @@ TEST_F(TMADocTest, Figure15b) {
   EXPECT_EQ(TMADimChecker::getDim(ke.kernel()), 2);
   TMAPredicateChecker::checkPredicate(ke.kernel(), 4);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
@@ -2757,7 +2757,7 @@ TEST_P(LdMatrixTest, Regular) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0}, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -2883,7 +2883,7 @@ TEST_P(StMatrixSingleTileTest, Regular) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0}, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -2944,7 +2944,7 @@ TEST_P(StMatrixTest, Regular) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0}, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -3019,7 +3019,7 @@ TEST_P(LdMatrixTest, Transpose) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0}, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_mma.cpp
+++ b/tests/cpp/test_mma.cpp
@@ -175,7 +175,7 @@ std::vector<at::Tensor> scheduleCompileAndRun(
   KernelExecutor ke;
   ke.compile(
       fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
-  return ke.runFusion({inputs.first, inputs.second});
+  return ke.run({inputs.first, inputs.second});
 }
 
 TEST_P(MmaTest, SingleTile) {
@@ -392,7 +392,7 @@ TEST_P(HopperRS, SingleTile) {
   ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.squeeze().to(at::kFloat),
       inputs.second.squeeze().to(at::kFloat),
@@ -488,7 +488,7 @@ TEST_P(HopperRS, SingleTileWithTMALoadStore) {
   ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.squeeze().to(at::kFloat),
       inputs.second.squeeze().to(at::kFloat),
@@ -653,7 +653,7 @@ TEST_P(HopperSS, SingleTile) {
   KernelExecutor ke;
   ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.squeeze().to(at::kFloat),
       inputs.second.squeeze().to(at::kFloat),
@@ -782,7 +782,7 @@ TEST_P(HopperSS, SingleTileTransposed) {
   KernelExecutor ke;
   ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.squeeze().to(at::kFloat),
       inputs.second.squeeze().to(at::kFloat),
@@ -961,7 +961,7 @@ TEST_P(HopperSS, MultipleTile) {
   KernelExecutor ke;
   ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.squeeze().to(at::kFloat),
       inputs.second.squeeze().to(at::kFloat),

--- a/tests/cpp/test_mma.cpp
+++ b/tests/cpp/test_mma.cpp
@@ -173,7 +173,7 @@ std::vector<at::Tensor> scheduleCompileAndRun(
   }
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
   return ke.runFusion({inputs.first, inputs.second});
 }
@@ -389,7 +389,7 @@ TEST_P(HopperRS, SingleTile) {
       getM(macro), getN(macro), getK(macro), layout, data_type_to_aten(dtype));
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
 
   auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
@@ -485,7 +485,7 @@ TEST_P(HopperRS, SingleTileWithTMALoadStore) {
       getM(macro), getN(macro), getK(macro), layout, data_type_to_aten(dtype));
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
 
   auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
@@ -651,7 +651,7 @@ TEST_P(HopperSS, SingleTile) {
       getM(macro), getN(macro), getK(macro), layout, data_type_to_aten(dtype));
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
   auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
   auto tref = atMatmul(
@@ -780,7 +780,7 @@ TEST_P(HopperSS, SingleTileTransposed) {
       getM(macro), getN(macro), getK(macro), layout, data_type_to_aten(dtype));
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
   auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
   auto tref = atMatmul(
@@ -959,7 +959,7 @@ TEST_P(HopperSS, MultipleTile) {
       data_type_to_aten(dtype));
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
   auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
   auto tref = atMatmul(

--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -1299,7 +1299,7 @@ TEST_F(PersistentBufferTest, SmemPersistent2DReduction) {
 
   // Run the fusion and validate the results
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), aten_inputs);
+  ke.compile(fusion.get(), aten_inputs);
   // Shared memory access should be vectorized.
   // getBankConflictInfo(ke.kernel()) triggers error "std::get: wrong index for
   // variant" when trying to evaluate index with:

--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -1314,8 +1314,8 @@ TEST_F(PersistentBufferTest, SmemPersistent2DReduction) {
       }
     }
   }
-  auto cg_outputs = ke.runFusion(
-      aten_inputs, heuristic_params->as<ReductionParams>()->lparams);
+  auto cg_outputs =
+      ke.run(aten_inputs, heuristic_params->as<ReductionParams>()->lparams);
   auto t1 = t0 / t0.sum({1, 2, 3}, true);
   testValidate(fusion.get(), cg_outputs, aten_inputs, {t1}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -550,7 +550,7 @@ TEST_F(PointwiseTest, ShardedPointwise) {
 
     pwise_scheduler->schedule(&sharded_fusion, sharded_params.get());
     KernelExecutor ke;
-    ke.compileFusion(&sharded_fusion, sharded_inputs, sharded_params->lparams);
+    ke.compile(&sharded_fusion, sharded_inputs, sharded_params->lparams);
     auto cg_outputs = ke.runFusion(sharded_inputs, sharded_params->lparams);
     testValidate(
         &sharded_fusion, cg_outputs, sharded_inputs, __LINE__, __FILE__);
@@ -707,7 +707,7 @@ TEST_P(PointwiseParamsTest, UnrollOnTopOfVectorize) {
   // Schedule, compile, run, validate
   scheduler_instance->schedule(fusion.get(), pparams);
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), runtime_inputs, pparams->lparams);
+  ke.compile(fusion.get(), runtime_inputs, pparams->lparams);
   auto cg_outputs = ke.runFusion(runtime_inputs, pparams->lparams);
   const auto& lparams = ke.lastLaunchParams();
   ASSERT_EQ(lparams.gdimy(), dim0 / unroll_outer);

--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -551,7 +551,7 @@ TEST_F(PointwiseTest, ShardedPointwise) {
     pwise_scheduler->schedule(&sharded_fusion, sharded_params.get());
     KernelExecutor ke;
     ke.compile(&sharded_fusion, sharded_inputs, sharded_params->lparams);
-    auto cg_outputs = ke.runFusion(sharded_inputs, sharded_params->lparams);
+    auto cg_outputs = ke.run(sharded_inputs, sharded_params->lparams);
     testValidate(
         &sharded_fusion, cg_outputs, sharded_inputs, __LINE__, __FILE__);
   }
@@ -708,7 +708,7 @@ TEST_P(PointwiseParamsTest, UnrollOnTopOfVectorize) {
   scheduler_instance->schedule(fusion.get(), pparams);
   KernelExecutor ke;
   ke.compile(fusion.get(), runtime_inputs, pparams->lparams);
-  auto cg_outputs = ke.runFusion(runtime_inputs, pparams->lparams);
+  auto cg_outputs = ke.run(runtime_inputs, pparams->lparams);
   const auto& lparams = ke.lastLaunchParams();
   ASSERT_EQ(lparams.gdimy(), dim0 / unroll_outer);
   ASSERT_EQ(

--- a/tests/cpp/test_predicate_elimination.cpp
+++ b/tests/cpp/test_predicate_elimination.cpp
@@ -79,7 +79,7 @@ TEST_F(PredicateEliminationTest, 2) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = (t0 + 1).sum({1}) + 1;
 
@@ -129,7 +129,7 @@ TEST_F(PredicateEliminationTest, 3) {
 
     KernelExecutor ke;
     ke.compile(&fusion, {t0});
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
 
     auto ref = sum(t0) + 1;
     testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
@@ -182,7 +182,7 @@ TEST_F(PredicateEliminationTest, 4) {
 
       KernelExecutor ke;
       ke.compile(&fusion, {t0});
-      auto cg_outputs = ke.runFusion({t0});
+      auto cg_outputs = ke.run({t0});
 
       auto t1 = t0.sum({1});
       auto t3 = t1.sum({0}) + 1;
@@ -230,7 +230,7 @@ TEST_F(PredicateEliminationTest, 5) {
 
     KernelExecutor ke;
     ke.compile(&fusion, {t0});
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
 
     auto ref = t0.mean({0});
 
@@ -279,7 +279,7 @@ TEST_F(PredicateEliminationTest, 6) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -315,7 +315,7 @@ TEST_F(PredicateEliminationTest, 7) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -433,7 +433,7 @@ TEST_F(PredicateEliminationTest, 9) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
@@ -479,7 +479,7 @@ TEST_F(PredicateEliminationTest, ExtentEqualToMaxParallelTypeExtent) {
   });
   ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 

--- a/tests/cpp/test_predicate_elimination.cpp
+++ b/tests/cpp/test_predicate_elimination.cpp
@@ -78,7 +78,7 @@ TEST_F(PredicateEliminationTest, 2) {
   auto t0 = at::randn(shape, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   auto ref = (t0 + 1).sum({1}) + 1;
@@ -128,7 +128,7 @@ TEST_F(PredicateEliminationTest, 3) {
     auto t0 = at::randn({size}, options);
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
     auto cg_outputs = ke.runFusion({t0});
 
     auto ref = sum(t0) + 1;
@@ -181,7 +181,7 @@ TEST_F(PredicateEliminationTest, 4) {
       auto t0 = at::randn({s0, s1}, options);
 
       KernelExecutor ke;
-      ke.compileFusion(&fusion, {t0});
+      ke.compile(&fusion, {t0});
       auto cg_outputs = ke.runFusion({t0});
 
       auto t1 = t0.sum({1});
@@ -229,7 +229,7 @@ TEST_F(PredicateEliminationTest, 5) {
     auto t0 = at::randn({s0}, options);
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t0});
+    ke.compile(&fusion, {t0});
     auto cg_outputs = ke.runFusion({t0});
 
     auto ref = t0.mean({0});
@@ -278,7 +278,7 @@ TEST_F(PredicateEliminationTest, 6) {
   auto t0 = at::randn({2, 3}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -314,7 +314,7 @@ TEST_F(PredicateEliminationTest, 7) {
   auto t0 = at::randn({123}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -432,7 +432,7 @@ TEST_F(PredicateEliminationTest, 9) {
   EXPECT_TRUE(PredicatedChecker::isPredicated(tv1, gpulw));
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0});
+  ke.compile(fusion.get(), {t0});
   auto cg_outputs = ke.runFusion({t0});
   testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -477,7 +477,7 @@ TEST_F(PredicateEliminationTest, ExtentEqualToMaxParallelTypeExtent) {
         {"validate_smem_predicate_elimination",
          validate_smem_predicate_elimination});
   });
-  ke.compileFusion(&fusion, {t0}, {}, matmul_cparams);
+  ke.compile(&fusion, {t0}, {}, matmul_cparams);
 
   auto cg_outputs = ke.runFusion({t0});
   testValidate(&fusion, cg_outputs, {t0}, {t0}, __LINE__, __FILE__);

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -65,7 +65,7 @@ TEST_P(ResizeTest, Pad1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1});
 
@@ -101,7 +101,7 @@ TEST_P(ResizeTest, Pad2) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1});
 
@@ -154,7 +154,7 @@ TEST_P(ResizeTest, Pad3) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -188,7 +188,7 @@ TEST_P(ResizeTest, Pad4) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1});
 
@@ -243,7 +243,7 @@ TEST_P(ResizeTest, Pad5) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1});
 
@@ -294,7 +294,7 @@ TEST_P(ResizeTest, Pad6) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -345,7 +345,7 @@ TEST_P(ResizeTest, Pad7) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -389,8 +389,8 @@ TEST_F(ResizeTest, Pad8) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  ke.compile(&fusion, aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(t0, {0, 1}) + at::pad(t0, {1, 0});
 
@@ -615,7 +615,7 @@ TEST_F(ResizeTest, Cat1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::cat({t0, t1}, 0);
 
@@ -647,7 +647,7 @@ TEST_F(ResizeTest, Cat2) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::cat({t0, t1}, 0);
 
@@ -688,7 +688,7 @@ TEST_F(ResizeTest, Cat3) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::cat({t0, t1}, 1);
 
@@ -732,7 +732,7 @@ TEST_F(ResizeTest, Cat4) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::cat({t0, t1}, 1);
 
@@ -781,7 +781,7 @@ TEST_F(ResizeTest, Cat5) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -825,7 +825,7 @@ TEST_F(ResizeTest, Cat6) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::cat({t0, t1, t2}, 0);
 
@@ -881,7 +881,7 @@ TEST_F(ResizeTest, Cat7) {
 
     KernelExecutor ke;
     ke.compile(&fusion, aten_inputs_ivalue);
-    auto cg_outputs = ke.runFusion(aten_inputs_ivalue);
+    auto cg_outputs = ke.run(aten_inputs_ivalue);
 
     auto ref = at::cat(aten_inputs, concat_dim);
 
@@ -1015,7 +1015,7 @@ TEST_F(ResizeTest, Slice1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
 
@@ -1046,7 +1046,7 @@ TEST_F(ResizeTest, Slice2) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1144,7 +1144,7 @@ TEST_F(ResizeTest, Slice4) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = (t0 + 1).to(at::kDouble).sum({1});
 
@@ -1199,7 +1199,7 @@ TEST_F(ResizeTest, Slice5) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto t1 = t0.index(
       {at::indexing::Slice(0, at::indexing::None),
@@ -1251,7 +1251,7 @@ TEST_F(ResizeTest, SliceConstantShmoo) {
 
     KernelExecutor ke;
     ke.compile(&fusion, aten_inputs);
-    auto cg_outputs = ke.runFusion(aten_inputs);
+    auto cg_outputs = ke.run(aten_inputs);
 
     testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
   }
@@ -1300,7 +1300,7 @@ TEST_F(ResizeTest, SliceInputShmoo) {
   auto t0 = at::randn(shape, options);
   for (auto [start, stop] : slice_cases) {
     std::vector<c10::IValue> aten_inputs({t0, start, stop});
-    auto cg_outputs = ke.runFusion(aten_inputs);
+    auto cg_outputs = ke.run(aten_inputs);
 
     testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
   }
@@ -1758,7 +1758,7 @@ TEST_P(ResizeTest, PadWithValue) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1}, "constant", 2);
 
@@ -1833,7 +1833,7 @@ TEST_P(ResizeTest, PadHalfWithDoubleValue) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1}, "constant", 2.5);
 
@@ -2237,7 +2237,7 @@ TEST_F(ResizeTest, FusionSizeZeroSliceSplit) {
   auto t0 = at::randn(shape, options);
   std::vector<c10::IValue> aten_inputs({t0});
 
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref0 = t0.index({at::indexing::Slice(2, 2), at::indexing::Slice(0, 5)});
 
@@ -2683,7 +2683,7 @@ TEST_F(ResizeTest, Slice1DVectorizeManual1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref =
       t0.index({at::indexing::Slice(slice_offset, shape[0] - slice_offset)});
@@ -2736,7 +2736,7 @@ TEST_F(ResizeTest, Slice1DVectorizeManual2) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref_t1 =
       t0.index({at::indexing::Slice(slice_offset, shape[0] - slice_offset)});
@@ -2787,7 +2787,7 @@ TEST_F(ResizeTest, Slice1DVectorizeManual3) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref =
       t0.index({at::indexing::Slice(slice_offset, shape[0] - slice_offset)});
@@ -2826,7 +2826,7 @@ TEST_F(ResizeTest, Slice1DVectorizeManual4) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0_aligned});
-  auto cg_outputs = ke.runFusion({t0_aligned});
+  auto cg_outputs = ke.run({t0_aligned});
 
   auto ref_aligned = t0_aligned.index({at::indexing::Slice(1, -3)});
 
@@ -2870,7 +2870,7 @@ TEST_F(ResizeTest, Slice2DVectorizeManual1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = t0.index(
       {at::indexing::Slice(slice_offset, shape[0] - slice_offset),
@@ -2922,7 +2922,7 @@ TEST_F(ResizeTest, Slice3DVectorizeManual1) {
   ke.compile(&fusion, aten_inputs);
 
   EXPECT_THAT(
-      [&]() { ke.runFusion(aten_inputs); },
+      [&]() { ke.run(aten_inputs); },
       ThrowsMessage<nvfError>(
           HasSubstr("with word size 2 not possible due to invalid stride")));
 }
@@ -2965,7 +2965,7 @@ TEST_F(ResizeTest, Slice3DVectorizeManual2) {
   ke.compile(&fusion, aten_inputs);
 
   EXPECT_THAT(
-      [&]() { ke.runFusion(aten_inputs); },
+      [&]() { ke.run(aten_inputs); },
       ThrowsMessage<nvfError>(
           HasSubstr("with word size 4 not possible due to invalid stride")));
 }
@@ -3044,7 +3044,7 @@ TEST_F(ResizeTest, SliceAndReshapeRepro540Manual) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   for (const auto i : c10::irange(3)) {
     auto slice_out_ref = t0.index(
@@ -3182,7 +3182,7 @@ TEST_F(ResizeTest, CatOfBroadcast) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::cat({t0, t1}, 0);
 
@@ -3219,7 +3219,7 @@ TEST_F(ResizeTest, CatOfExpandedBroadcast) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::cat({at::expand_copy(t0, shape0e), t1}, 0);
 
@@ -3305,7 +3305,7 @@ TEST_P(ResizeTest, PadOfBroadcast) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3341,7 +3341,7 @@ TEST_P(ResizeTest, PadOfExpandedBroadcast) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -3729,7 +3729,7 @@ TEST_F(ResizeTest, SliceScheduledLikeProducer) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
 
@@ -3777,7 +3777,7 @@ TEST_F(ResizeTest, PadScheduledLikeConsumer) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(t0 + 1, {1, 1}) + 1;
 
@@ -3829,7 +3829,7 @@ TEST_F(ResizeTest, SliceThenPadLeftHalf) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(
       t0.index({at::indexing::Slice(0, shape[0] / 2)}), {0, shape[0] / 2});
@@ -3884,7 +3884,7 @@ TEST_F(ResizeTest, SliceThenPadRightHalf) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(
       t0.index({at::indexing::Slice(shape[0] / 2, shape[0])}),
@@ -3948,7 +3948,7 @@ TEST_F(ResizeTest, SliceThenConcat) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   EXPECT_TRUE(t0.equal(cg_outputs[0]));
 }
@@ -4042,7 +4042,7 @@ TEST_F(ResizeTest, SliceSliceConcatConcat) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::concat(
       {at::slice(t0, 0, 0, rope_size / 2) + 1,
@@ -4080,7 +4080,7 @@ TEST_F(ResizeTest, VectorizePadLowering) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   auto ref = at::pad(t0, {4, 4});
   ASSERT_TRUE(ref.equal(cg_outputs[0]));
@@ -4116,7 +4116,7 @@ TEST_F(ResizeTest, VectorizeWhereLowering) {
 
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.runFusion(aten_inputs);
+  auto cg_outputs = ke.run(aten_inputs);
 
   // Note: we cannot use at::where, because aten only support tensor as
   // predicate.

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -64,7 +64,7 @@ TEST_P(ResizeTest, Pad1) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1});
@@ -100,7 +100,7 @@ TEST_P(ResizeTest, Pad2) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1});
@@ -153,7 +153,7 @@ TEST_P(ResizeTest, Pad3) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -187,7 +187,7 @@ TEST_P(ResizeTest, Pad4) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1});
@@ -242,7 +242,7 @@ TEST_P(ResizeTest, Pad5) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1});
@@ -293,7 +293,7 @@ TEST_P(ResizeTest, Pad6) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -344,7 +344,7 @@ TEST_P(ResizeTest, Pad7) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -614,7 +614,7 @@ TEST_F(ResizeTest, Cat1) {
   std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::cat({t0, t1}, 0);
@@ -646,7 +646,7 @@ TEST_F(ResizeTest, Cat2) {
   std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::cat({t0, t1}, 0);
@@ -687,7 +687,7 @@ TEST_F(ResizeTest, Cat3) {
   std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::cat({t0, t1}, 1);
@@ -731,7 +731,7 @@ TEST_F(ResizeTest, Cat4) {
   std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::cat({t0, t1}, 1);
@@ -780,7 +780,7 @@ TEST_F(ResizeTest, Cat5) {
   std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -824,7 +824,7 @@ TEST_F(ResizeTest, Cat6) {
   std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::cat({t0, t1, t2}, 0);
@@ -880,7 +880,7 @@ TEST_F(ResizeTest, Cat7) {
         {aten_inputs.begin(), aten_inputs.end()});
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, aten_inputs_ivalue);
+    ke.compile(&fusion, aten_inputs_ivalue);
     auto cg_outputs = ke.runFusion(aten_inputs_ivalue);
 
     auto ref = at::cat(aten_inputs, concat_dim);
@@ -1014,7 +1014,7 @@ TEST_F(ResizeTest, Slice1) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
@@ -1045,7 +1045,7 @@ TEST_F(ResizeTest, Slice2) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1143,7 +1143,7 @@ TEST_F(ResizeTest, Slice4) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = (t0 + 1).to(at::kDouble).sum({1});
@@ -1198,7 +1198,7 @@ TEST_F(ResizeTest, Slice5) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto t1 = t0.index(
@@ -1250,7 +1250,7 @@ TEST_F(ResizeTest, SliceConstantShmoo) {
     std::vector<c10::IValue> aten_inputs({t0});
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion, aten_inputs);
+    ke.compile(&fusion, aten_inputs);
     auto cg_outputs = ke.runFusion(aten_inputs);
 
     testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -1295,7 +1295,7 @@ TEST_F(ResizeTest, SliceInputShmoo) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 
   auto t0 = at::randn(shape, options);
   for (auto [start, stop] : slice_cases) {
@@ -1757,7 +1757,7 @@ TEST_P(ResizeTest, PadWithValue) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1}, "constant", 2);
@@ -1832,7 +1832,7 @@ TEST_P(ResizeTest, PadHalfWithDoubleValue) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::pad(t0, {1, 1}, "constant", 2.5);
@@ -2230,7 +2230,7 @@ TEST_F(ResizeTest, FusionSizeZeroSliceSplit) {
   tv1->split(0, 4); // sizes (0, 4)
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get());
+  ke.compile(fusion.get());
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
@@ -2682,7 +2682,7 @@ TEST_F(ResizeTest, Slice1DVectorizeManual1) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref =
@@ -2735,7 +2735,7 @@ TEST_F(ResizeTest, Slice1DVectorizeManual2) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref_t1 =
@@ -2786,7 +2786,7 @@ TEST_F(ResizeTest, Slice1DVectorizeManual3) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref =
@@ -2825,7 +2825,7 @@ TEST_F(ResizeTest, Slice1DVectorizeManual4) {
   auto t0_aligned = t0_unaligned.index({at::indexing::Slice(3, -1)});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0_aligned});
+  ke.compile(&fusion, {t0_aligned});
   auto cg_outputs = ke.runFusion({t0_aligned});
 
   auto ref_aligned = t0_aligned.index({at::indexing::Slice(1, -3)});
@@ -2869,7 +2869,7 @@ TEST_F(ResizeTest, Slice2DVectorizeManual1) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = t0.index(
@@ -2919,7 +2919,7 @@ TEST_F(ResizeTest, Slice3DVectorizeManual1) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   EXPECT_THAT(
       [&]() { ke.runFusion(aten_inputs); },
@@ -2962,7 +2962,7 @@ TEST_F(ResizeTest, Slice3DVectorizeManual2) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   EXPECT_THAT(
       [&]() { ke.runFusion(aten_inputs); },
@@ -3043,7 +3043,7 @@ TEST_F(ResizeTest, SliceAndReshapeRepro540Manual) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   for (const auto i : c10::irange(3)) {
@@ -3181,7 +3181,7 @@ TEST_F(ResizeTest, CatOfBroadcast) {
   std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::cat({t0, t1}, 0);
@@ -3218,7 +3218,7 @@ TEST_F(ResizeTest, CatOfExpandedBroadcast) {
   std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::cat({at::expand_copy(t0, shape0e), t1}, 0);
@@ -3304,7 +3304,7 @@ TEST_P(ResizeTest, PadOfBroadcast) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -3340,7 +3340,7 @@ TEST_P(ResizeTest, PadOfExpandedBroadcast) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
@@ -3728,7 +3728,7 @@ TEST_F(ResizeTest, SliceScheduledLikeProducer) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
@@ -3776,7 +3776,7 @@ TEST_F(ResizeTest, PadScheduledLikeConsumer) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::pad(t0 + 1, {1, 1}) + 1;
@@ -3828,7 +3828,7 @@ TEST_F(ResizeTest, SliceThenPadLeftHalf) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::pad(
@@ -3883,7 +3883,7 @@ TEST_F(ResizeTest, SliceThenPadRightHalf) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::pad(
@@ -3947,7 +3947,7 @@ TEST_F(ResizeTest, SliceThenConcat) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   EXPECT_TRUE(t0.equal(cg_outputs[0]));
@@ -4041,7 +4041,7 @@ TEST_F(ResizeTest, SliceSliceConcatConcat) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::concat(
@@ -4079,7 +4079,7 @@ TEST_F(ResizeTest, VectorizePadLowering) {
   std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   auto ref = at::pad(t0, {4, 4});
@@ -4115,7 +4115,7 @@ TEST_F(ResizeTest, VectorizeWhereLowering) {
   std::vector<c10::IValue> aten_inputs({at::Scalar(false), t0});
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
   auto cg_outputs = ke.runFusion(aten_inputs);
 
   // Note: we cannot use at::where, because aten only support tensor as

--- a/tests/cpp/test_rng.cpp
+++ b/tests/cpp/test_rng.cpp
@@ -122,7 +122,7 @@ TEST_F(RNGTest, ManualScheduleValidateWithCURand) {
   at::Tensor t0 = at::zeros({size}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {t0});
+  ke.compile(fusion, {t0});
 
   at::manual_seed(0);
   auto cg_outputs = ke.runFusion({t0});
@@ -160,7 +160,7 @@ TEST_F(RNGTest, ManualScheduleValidateWithCURand2) {
   fusion->addOutput(tv0);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {10, 10, 10, 10});
+  ke.compile(fusion, {10, 10, 10, 10});
 
   at::manual_seed(0);
   auto cg_outputs = ke.runFusion({10, 10, 10, 10});
@@ -294,7 +294,7 @@ TEST_F(RNGTest, BroadcastingRNGSmemNonSquareTile) {
       ->schedule(fusion, &tparams);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion, {t0, t1});
+  ke.compile(fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
   auto out = cg_outputs[0];
 

--- a/tests/cpp/test_rng.cpp
+++ b/tests/cpp/test_rng.cpp
@@ -125,7 +125,7 @@ TEST_F(RNGTest, ManualScheduleValidateWithCURand) {
   ke.compile(fusion, {t0});
 
   at::manual_seed(0);
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   auto out = cg_outputs[0];
 
   at::manual_seed(0);
@@ -163,7 +163,7 @@ TEST_F(RNGTest, ManualScheduleValidateWithCURand2) {
   ke.compile(fusion, {10, 10, 10, 10});
 
   at::manual_seed(0);
-  auto cg_outputs = ke.runFusion({10, 10, 10, 10});
+  auto cg_outputs = ke.run({10, 10, 10, 10});
   auto out = cg_outputs[0];
 
   at::manual_seed(0);
@@ -295,7 +295,7 @@ TEST_F(RNGTest, BroadcastingRNGSmemNonSquareTile) {
 
   KernelExecutor ke;
   ke.compile(fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
   auto out = cg_outputs[0];
 
   NVF_CHECK((out.select(1, 0) == out.select(1, 1)).all().item<bool>());

--- a/tests/cpp/test_scalar_hoisting.cpp
+++ b/tests/cpp/test_scalar_hoisting.cpp
@@ -215,7 +215,7 @@ TEST_F(ScalarHoistTest, IndexHoist1) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -259,7 +259,7 @@ TEST_F(ScalarHoistTest, IndexHoist2) {
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
-  auto cg_outputs = ke.runFusion({t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
@@ -292,7 +292,7 @@ TEST_F(ScalarHoistTest, IndexHoist3) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0});
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T2) {
@@ -371,7 +371,7 @@ TEST_F(ScalarHoistTest, ARange) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {start, end, step});
-  auto cg_outputs = ke.runFusion({start, end, step});
+  auto cg_outputs = ke.run({start, end, step});
 
   const std::string expected_kernel = R"(
 __global__ void CUDAGeneratedKernel(int64_t i0, int64_t i1, int64_t i2, Tensor<int64_t, 1, 1> T0, Tensor<int64_t, 1, 1> T1) {

--- a/tests/cpp/test_scalar_hoisting.cpp
+++ b/tests/cpp/test_scalar_hoisting.cpp
@@ -214,7 +214,7 @@ TEST_F(ScalarHoistTest, IndexHoist1) {
   auto t0 = at::randn({15, 17}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
@@ -258,7 +258,7 @@ TEST_F(ScalarHoistTest, IndexHoist2) {
   auto t1 = at::randn({16}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0, t1});
+  ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.runFusion({t0, t1});
 
   testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -291,7 +291,7 @@ TEST_F(ScalarHoistTest, IndexHoist3) {
   at::Tensor t0 = at::arange(10000, options).view({100, 100});
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {t0});
+  ke.compile(fusion.get(), {t0});
   auto cg_outputs = ke.runFusion({t0});
 
   const std::string expected_kernel = R"(
@@ -370,7 +370,7 @@ TEST_F(ScalarHoistTest, ARange) {
   int64_t start = 0, end = 100, step = 1;
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {start, end, step});
+  ke.compile(fusion.get(), {start, end, step});
   auto cg_outputs = ke.runFusion({start, end, step});
 
   const std::string expected_kernel = R"(

--- a/tests/cpp/test_scatter_gather.cpp
+++ b/tests/cpp/test_scatter_gather.cpp
@@ -587,7 +587,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorPointwise1) {
   std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   auto outputs = ke.runFusion(aten_inputs);
 
@@ -1295,7 +1295,7 @@ TEST_F(ScatterGatherTest, GatherIterGoupedReduction) {
 
   KernelExecutor ke;
   auto lparams = rparams->lparams;
-  ke.compileFusion(&fusion, aten_inputs, lparams);
+  ke.compile(&fusion, aten_inputs, lparams);
   auto cg_outputs = ke.runFusion(aten_inputs, lparams);
 
   auto t_gather = at::gather(input, dim, input_idx);

--- a/tests/cpp/test_scatter_gather.cpp
+++ b/tests/cpp/test_scatter_gather.cpp
@@ -589,7 +589,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorPointwise1) {
   KernelExecutor ke;
   ke.compile(&fusion, aten_inputs);
 
-  auto outputs = ke.runFusion(aten_inputs);
+  auto outputs = ke.run(aten_inputs);
 
   testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
 }
@@ -1296,7 +1296,7 @@ TEST_F(ScatterGatherTest, GatherIterGoupedReduction) {
   KernelExecutor ke;
   auto lparams = rparams->lparams;
   ke.compile(&fusion, aten_inputs, lparams);
-  auto cg_outputs = ke.runFusion(aten_inputs, lparams);
+  auto cg_outputs = ke.run(aten_inputs, lparams);
 
   auto t_gather = at::gather(input, dim, input_idx);
   testValidate(

--- a/tests/cpp/test_serial_gridreduce.cpp
+++ b/tests/cpp/test_serial_gridreduce.cpp
@@ -124,7 +124,7 @@ TEST_F(SerialGridReductionTest, Scheduling) {
 
         auto input = at::randn(
             {H, W}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
-        auto outputs = ke.runFusion({input});
+        auto outputs = ke.run({input});
 
         if (serial) {
           // Verify that zeroed semaphore memory was reused instead of

--- a/tests/cpp/test_serial_gridreduce.cpp
+++ b/tests/cpp/test_serial_gridreduce.cpp
@@ -120,7 +120,7 @@ TEST_F(SerialGridReductionTest, Scheduling) {
         if (serial) {
           tv3->definition()->as<ReductionOp>()->requestSerialGridReduction();
         }
-        ke.compileFusion(fusion);
+        ke.compile(fusion);
 
         auto input = at::randn(
             {H, W}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -156,7 +156,7 @@ TEST_P(ShardingTest, ComputeIndex) {
   auto a_tensor = at::randn({4, 2, 1, 5}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {a_tensor});
+  ke.compile(fusion.get(), {a_tensor});
   auto outputs = ke.runFusion({a_tensor});
   testValidate(fusion.get(), outputs, {a_tensor}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -157,7 +157,7 @@ TEST_P(ShardingTest, ComputeIndex) {
 
   KernelExecutor ke;
   ke.compile(fusion.get(), {a_tensor});
-  auto outputs = ke.runFusion({a_tensor});
+  auto outputs = ke.run({a_tensor});
   testValidate(fusion.get(), outputs, {a_tensor}, __LINE__, __FILE__);
 }
 

--- a/tests/cpp/test_smem_reuse.cpp
+++ b/tests/cpp/test_smem_reuse.cpp
@@ -558,7 +558,7 @@ TEST_F(SmemReuseTest, SmemReuseWithDifferentVectorizationFactor) {
   auto t0 = at::randn({n_element}, options);
   KernelExecutor ke;
   ke.compile(fusion.get());
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
@@ -618,7 +618,7 @@ TEST_F(SmemReuseTest, RegisterReuseWithDifferentVectorizationFactor) {
     auto t0 = at::randn({n_element}, options);
     KernelExecutor ke;
     ke.compile(fusion.get());
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
     testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__);
   };
 
@@ -679,7 +679,7 @@ TEST_F(SmemReuseTest, ExpandInterferes) {
     at::Tensor t0 = at::randn({y}, options);
     KernelExecutor ke;
     ke.compile(fusion.get());
-    auto cg_outputs = ke.runFusion({t0});
+    auto cg_outputs = ke.run({t0});
     testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__);
   };
 

--- a/tests/cpp/test_smem_reuse.cpp
+++ b/tests/cpp/test_smem_reuse.cpp
@@ -557,7 +557,7 @@ TEST_F(SmemReuseTest, SmemReuseWithDifferentVectorizationFactor) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({n_element}, options);
   KernelExecutor ke;
-  ke.compileFusion(fusion.get());
+  ke.compile(fusion.get());
   auto cg_outputs = ke.runFusion({t0});
   testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -617,7 +617,7 @@ TEST_F(SmemReuseTest, RegisterReuseWithDifferentVectorizationFactor) {
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     auto t0 = at::randn({n_element}, options);
     KernelExecutor ke;
-    ke.compileFusion(fusion.get());
+    ke.compile(fusion.get());
     auto cg_outputs = ke.runFusion({t0});
     testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__);
   };
@@ -678,7 +678,7 @@ TEST_F(SmemReuseTest, ExpandInterferes) {
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     at::Tensor t0 = at::randn({y}, options);
     KernelExecutor ke;
-    ke.compileFusion(fusion.get());
+    ke.compile(fusion.get());
     auto cg_outputs = ke.runFusion({t0});
     testValidate(fusion.get(), cg_outputs, {t0}, __LINE__, __FILE__);
   };

--- a/tests/cpp/test_swizzle.cpp
+++ b/tests/cpp/test_swizzle.cpp
@@ -59,7 +59,7 @@ TEST_F(LegacySwizzleTest, SimpleSwizzle0) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 32}, options);
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -98,7 +98,7 @@ TEST_F(LegacySwizzleTest, SimpleSwizzle1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 32}, options);
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -155,7 +155,7 @@ TEST_F(LegacySwizzleTest, SimpleSwizzle2) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({32, 32}, options);
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -284,7 +284,7 @@ TEST_F(LegacySwizzleTest, LoopSwizzle0) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 32}, options);
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -319,7 +319,7 @@ TEST_F(LegacySwizzleTest, LoopSwizzle1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({45, 77}, options);
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
 
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -617,7 +617,7 @@ TEST_F(LegacySwizzleTest, SwizzleIndexing170) {
 
   KernelExecutor ke;
   ke.compile(&fusion);
-  auto outputs = ke.runFusion({t});
+  auto outputs = ke.run({t});
 
   testValidate(&fusion, outputs, {t}, __LINE__, __FILE__);
 }
@@ -680,7 +680,7 @@ TEST_F(LegacySwizzleTest, SwizzleInProducerProjection) {
 
   KernelExecutor ke;
   ke.compile(fusion.get());
-  auto outputs = ke.runFusion({t});
+  auto outputs = ke.run({t});
 
   auto expect = at::empty_like(t);
   for (auto i : c10::irange(t.size(0) / 8)) {
@@ -738,7 +738,7 @@ TEST_F(SwizzleTest, Transpose1) {
   KernelExecutor ke;
   ke.compile(&fusion, {t});
   EXPECT_TRUE(getBankConflictInfo(ke.kernel()).empty());
-  std::vector<at::Tensor> outputs = ke.runFusion({t});
+  std::vector<at::Tensor> outputs = ke.run({t});
   EXPECT_TRUE(at::equal(t.t(), outputs[0]));
 }
 

--- a/tests/cpp/test_swizzle.cpp
+++ b/tests/cpp/test_swizzle.cpp
@@ -55,7 +55,7 @@ TEST_F(LegacySwizzleTest, SimpleSwizzle0) {
   NVF_CHECK(str.find("where") != std::string::npos);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 32}, options);
@@ -94,7 +94,7 @@ TEST_F(LegacySwizzleTest, SimpleSwizzle1) {
   tv1->computeAt(tv2, -1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 32}, options);
@@ -151,7 +151,7 @@ TEST_F(LegacySwizzleTest, SimpleSwizzle2) {
   }
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({32, 32}, options);
@@ -280,7 +280,7 @@ TEST_F(LegacySwizzleTest, LoopSwizzle0) {
   tv0->computeAt(tv2, -1);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 32}, options);
@@ -315,7 +315,7 @@ TEST_F(LegacySwizzleTest, LoopSwizzle1) {
   tv2->axis(1)->parallelize(ParallelType::BIDy);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({45, 77}, options);
@@ -350,7 +350,7 @@ TEST_F(LegacySwizzleTest, LoopSwizzleCheck0) {
   tv0->computeAt(tv2, -1);
 
   KernelExecutor ke;
-  ASSERT_ANY_THROW(ke.compileFusion(&fusion));
+  ASSERT_ANY_THROW(ke.compile(&fusion));
 }
 
 // Test assertion in unsupported pattern: half-inlined loop swizzle.
@@ -382,7 +382,7 @@ TEST_F(LegacySwizzleTest, LoopSwizzleCheck1) {
   tv0->computeAt(tv3, -2);
 
   KernelExecutor ke;
-  ASSERT_ANY_THROW(ke.compileFusion(&fusion));
+  ASSERT_ANY_THROW(ke.compile(&fusion));
 }
 
 TEST_F(LegacySwizzleTest, SwizzleVectorize) {
@@ -616,7 +616,7 @@ TEST_F(LegacySwizzleTest, SwizzleIndexing170) {
   at::Tensor t = at::randn({64, 64}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion);
+  ke.compile(&fusion);
   auto outputs = ke.runFusion({t});
 
   testValidate(&fusion, outputs, {t}, __LINE__, __FILE__);
@@ -679,7 +679,7 @@ TEST_F(LegacySwizzleTest, SwizzleInProducerProjection) {
   auto t = at::randn({32, 64}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get());
+  ke.compile(fusion.get());
   auto outputs = ke.runFusion({t});
 
   auto expect = at::empty_like(t);
@@ -736,7 +736,7 @@ TEST_F(SwizzleTest, Transpose1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t = at::randn({10240, 10240}, options);
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t});
+  ke.compile(&fusion, {t});
   EXPECT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   std::vector<at::Tensor> outputs = ke.runFusion({t});
   EXPECT_TRUE(at::equal(t.t(), outputs[0]));

--- a/tests/cpp/test_tensor_factories.cpp
+++ b/tests/cpp/test_tensor_factories.cpp
@@ -353,7 +353,7 @@ TEST_F(TensorFactoryTest, TensorConstruct) {
   fusion->addOutput(output);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get());
+  ke.compile(fusion.get());
   auto cg_outputs = ke.runFusion({00, 01, 10, 11});
 
   testValidate(fusion.get(), cg_outputs, {00, 01, 10, 11}, __LINE__, __FILE__);
@@ -404,7 +404,7 @@ TEST_F(TensorFactoryTest, MetadataAsTensor) {
   auto input1 = at::randn({6, 7, 8, 9}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(fusion.get());
+  ke.compile(fusion.get());
   auto cg_outputs = ke.runFusion({input0, input1});
 
   testValidate(fusion.get(), cg_outputs, {input0, input1}, __LINE__, __FILE__);

--- a/tests/cpp/test_tensor_factories.cpp
+++ b/tests/cpp/test_tensor_factories.cpp
@@ -354,7 +354,7 @@ TEST_F(TensorFactoryTest, TensorConstruct) {
 
   KernelExecutor ke;
   ke.compile(fusion.get());
-  auto cg_outputs = ke.runFusion({00, 01, 10, 11});
+  auto cg_outputs = ke.run({00, 01, 10, 11});
 
   testValidate(fusion.get(), cg_outputs, {00, 01, 10, 11}, __LINE__, __FILE__);
 }
@@ -405,7 +405,7 @@ TEST_F(TensorFactoryTest, MetadataAsTensor) {
 
   KernelExecutor ke;
   ke.compile(fusion.get());
-  auto cg_outputs = ke.runFusion({input0, input1});
+  auto cg_outputs = ke.run({input0, input1});
 
   testValidate(fusion.get(), cg_outputs, {input0, input1}, __LINE__, __FILE__);
 }

--- a/tests/cpp/test_translate_mma.cpp
+++ b/tests/cpp/test_translate_mma.cpp
@@ -233,7 +233,7 @@ TEST_P(CombineMulSumAsMmaTestWithLayout, AmpereMulSumToMatmul_Schedule) {
   ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
-  auto cg_outputs = ke.runFusion({inputs.first, inputs.second});
+  auto cg_outputs = ke.run({inputs.first, inputs.second});
   auto tref = atMatmul(
       inputs.first.to(at::kFloat), inputs.second.to(at::kFloat), layout);
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));

--- a/tests/cpp/test_translate_mma.cpp
+++ b/tests/cpp/test_translate_mma.cpp
@@ -230,7 +230,7 @@ TEST_P(CombineMulSumAsMmaTestWithLayout, AmpereMulSumToMatmul_Schedule) {
   auto inputs = matmulAtInput2D(M, N, K, layout);
 
   KernelExecutor ke;
-  ke.compileFusion(
+  ke.compile(
       &fusion, {inputs.first, inputs.second}, LaunchParams(), matmul_cparams);
   ASSERT_TRUE(getBankConflictInfo(ke.kernel()).empty());
   auto cg_outputs = ke.runFusion({inputs.first, inputs.second});

--- a/tests/cpp/test_tutorial.cpp
+++ b/tests/cpp/test_tutorial.cpp
@@ -87,7 +87,7 @@ TEST_F(Tutorial, Memcpy) {
   ke.compile(&fusion, aten_inputs);
 
   // KernelExecutor now has a compiled kernel, which can be executed as:
-  std::vector<at::Tensor> outputs = ke.runFusion(aten_inputs);
+  std::vector<at::Tensor> outputs = ke.run(aten_inputs);
   // Note that this run is done using just one thread, which will be
   // corrected below.
 
@@ -166,7 +166,7 @@ TEST_F(Tutorial, Memcpy) {
   // thread block and grid shapes, are autoatically inferred from the
   // given inputs. To see how many threads are used, run this test
   // with NVFUSER_DUMP=launch_param
-  outputs = ke2.runFusion(aten_inputs);
+  outputs = ke2.run(aten_inputs);
 
   ASSERT_TRUE(outputs[0].equal(t0));
 }
@@ -207,7 +207,7 @@ TEST_F(Tutorial, Reduction) {
   {
     KernelExecutor ke;
     ke.compile(&fusion);
-    std::vector<at::Tensor> outputs = ke.runFusion(aten_inputs);
+    std::vector<at::Tensor> outputs = ke.run(aten_inputs);
     testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
   }
 
@@ -223,7 +223,7 @@ TEST_F(Tutorial, Reduction) {
   {
     KernelExecutor ke;
     ke.compile(&fusion);
-    std::vector<at::Tensor> outputs = ke.runFusion(aten_inputs);
+    std::vector<at::Tensor> outputs = ke.run(aten_inputs);
     testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
   }
 
@@ -246,12 +246,12 @@ TEST_F(Tutorial, Reduction) {
     // input tensor, which is too large in CUDA.
     //
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-    ASSERT_ANY_THROW(ke.runFusion(aten_inputs));
+    ASSERT_ANY_THROW(ke.run(aten_inputs));
 
     // Try again with a smaller input. This should launch a kernel
     // with thread blocks of shape 32x10
     at::Tensor t1 = at::randn({10, 32}, options);
-    std::vector<at::Tensor> outputs = ke.runFusion({t1});
+    std::vector<at::Tensor> outputs = ke.run({t1});
     testValidate(
         &fusion, outputs, aten_inputs, {t1.sum({1})}, __LINE__, __FILE__);
   }
@@ -272,7 +272,7 @@ TEST_F(Tutorial, Reduction) {
     // will be launched with 10 thread blocks, each of which has 1024
     // threads. Try running this test with NVFUSER_DUMP=launch_param
     // to see the launch configuration of each kernel lauch
-    std::vector<at::Tensor> outputs = ke.runFusion(aten_inputs);
+    std::vector<at::Tensor> outputs = ke.run(aten_inputs);
     testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
   }
 }
@@ -386,7 +386,7 @@ TEST_F(Tutorial, ReductionRFactor) {
     // Since the size of the input is 10000, which is split by a
     // factor of 1024, the first per-thread reduction is done for
     // ceilDiv(10000, 1024) = 10 elements.
-    std::vector<at::Tensor> outputs = ke.runFusion(aten_inputs);
+    std::vector<at::Tensor> outputs = ke.run(aten_inputs);
     testValidate(&fusion_copy, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
   }
 
@@ -442,7 +442,7 @@ TEST_F(Tutorial, ReductionRFactor) {
     KernelExecutor ke;
     ke.compile(&fusion_copy);
 
-    std::vector<at::Tensor> outputs = ke.runFusion(aten_inputs);
+    std::vector<at::Tensor> outputs = ke.run(aten_inputs);
     testValidate(&fusion_copy, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
   }
 }
@@ -788,7 +788,7 @@ TEST_F(Tutorial, BasicTMA) {
     auto t = at::randn(shape, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t}, {}, index32bit);
-    std::vector<at::Tensor> outputs = ke.runFusion({t});
+    std::vector<at::Tensor> outputs = ke.run({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
 
@@ -872,7 +872,7 @@ TEST_F(Tutorial, BasicTMA) {
     auto t = at::randn(shape, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t}, {}, index32bit);
-    std::vector<at::Tensor> outputs = ke.runFusion({t});
+    std::vector<at::Tensor> outputs = ke.run({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
 
@@ -955,7 +955,7 @@ TEST_F(Tutorial, BasicTMA) {
     auto t = at::randn(shape, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t}, {}, index32bit);
-    std::vector<at::Tensor> outputs = ke.runFusion({t});
+    std::vector<at::Tensor> outputs = ke.run({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
 
@@ -1035,7 +1035,7 @@ TEST_F(Tutorial, BasicTMA) {
     auto t = at::randn(shape, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t}, {}, index32bit);
-    std::vector<at::Tensor> outputs = ke.runFusion({t});
+    std::vector<at::Tensor> outputs = ke.run({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
 
@@ -1140,7 +1140,7 @@ TEST_F(Tutorial, BasicTMA) {
     auto t = at::randn(shape, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t}, {}, index32bit);
-    std::vector<at::Tensor> outputs = ke.runFusion({t});
+    std::vector<at::Tensor> outputs = ke.run({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
 
@@ -1246,7 +1246,7 @@ TEST_F(Tutorial, BasicTMA) {
     auto t = at::randn(shape, options);
     KernelExecutor ke;
     ke.compile(&fusion, {t}, {}, index32bit);
-    std::vector<at::Tensor> outputs = ke.runFusion({t});
+    std::vector<at::Tensor> outputs = ke.run({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
 }
@@ -1346,7 +1346,7 @@ TEST_F(Tutorial, VectorizeStorePointwiseTMA) {
   // Compile with KernelExecutor directly to avoid scheduling
   KernelExecutor ke;
   ke.compile(fusion.get(), {at_tv0, at_tv1}, {}, index32bit);
-  auto outputs = ke.runFusion({at_tv0, at_tv1});
+  auto outputs = ke.run({at_tv0, at_tv1});
 
   auto at_output = at_tv0 + at_tv1;
   testValidate(
@@ -1450,7 +1450,7 @@ TEST_F(Tutorial, PointwiseBroadcastTMA) {
   // Compile with KernelExecutor directly to avoid scheduling
   KernelExecutor ke;
   ke.compile(fusion.get(), {at_tv0, at_tv1}, {}, index32bit);
-  auto outputs = ke.runFusion({at_tv0, at_tv1});
+  auto outputs = ke.run({at_tv0, at_tv1});
 
   auto at_output = at_tv0 + at_tv1;
   testValidate(
@@ -1554,7 +1554,7 @@ TEST_F(Tutorial, TMABankConflictFreeTranspose) {
   KernelExecutor ke;
   CompileParams index32bit{DataType::Int32, 255, false};
   ke.compile(&fusion, {t}, {}, index32bit);
-  std::vector<at::Tensor> outputs = ke.runFusion({t});
+  std::vector<at::Tensor> outputs = ke.run({t});
   ASSERT_TRUE(at::equal(t.t(), outputs[0]));
 }
 

--- a/tests/cpp/test_tutorial.cpp
+++ b/tests/cpp/test_tutorial.cpp
@@ -84,7 +84,7 @@ TEST_F(Tutorial, Memcpy) {
   // Next, lower the fusion to Kernel, generate CUDA kernel source and then
   // compile it with nvrtc. All of them are done by KernelExecutor
   KernelExecutor ke;
-  ke.compileFusion(&fusion, aten_inputs);
+  ke.compile(&fusion, aten_inputs);
 
   // KernelExecutor now has a compiled kernel, which can be executed as:
   std::vector<at::Tensor> outputs = ke.runFusion(aten_inputs);
@@ -159,7 +159,7 @@ TEST_F(Tutorial, Memcpy) {
 
   // Since the fusion is modified, we need to recompile it.
   KernelExecutor ke2;
-  ke2.compileFusion(&fusion, aten_inputs);
+  ke2.compile(&fusion, aten_inputs);
 
   // This time, the kernel is launched with multiple threads and
   // thread blocks. Note that the launch configurations, i.e., the
@@ -206,7 +206,7 @@ TEST_F(Tutorial, Reduction) {
 
   {
     KernelExecutor ke;
-    ke.compileFusion(&fusion);
+    ke.compile(&fusion);
     std::vector<at::Tensor> outputs = ke.runFusion(aten_inputs);
     testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
   }
@@ -222,7 +222,7 @@ TEST_F(Tutorial, Reduction) {
 
   {
     KernelExecutor ke;
-    ke.compileFusion(&fusion);
+    ke.compile(&fusion);
     std::vector<at::Tensor> outputs = ke.runFusion(aten_inputs);
     testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
   }
@@ -240,7 +240,7 @@ TEST_F(Tutorial, Reduction) {
 
   {
     KernelExecutor ke;
-    ke.compileFusion(&fusion);
+    ke.compile(&fusion);
     // Running this fusion, however, should fail as it would require
     // thread blocks of shape 1024x10, i.e., the same shape as the
     // input tensor, which is too large in CUDA.
@@ -267,7 +267,7 @@ TEST_F(Tutorial, Reduction) {
 
   {
     KernelExecutor ke;
-    ke.compileFusion(&fusion);
+    ke.compile(&fusion);
     // The original input should not fail in this case. The kernel
     // will be launched with 10 thread blocks, each of which has 1024
     // threads. Try running this test with NVFUSER_DUMP=launch_param
@@ -381,7 +381,7 @@ TEST_F(Tutorial, ReductionRFactor) {
     at::Tensor ref = t0.sum({0});
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion_copy);
+    ke.compile(&fusion_copy);
 
     // Since the size of the input is 10000, which is split by a
     // factor of 1024, the first per-thread reduction is done for
@@ -440,7 +440,7 @@ TEST_F(Tutorial, ReductionRFactor) {
     at::Tensor ref = t0.sum({0});
 
     KernelExecutor ke;
-    ke.compileFusion(&fusion_copy);
+    ke.compile(&fusion_copy);
 
     std::vector<at::Tensor> outputs = ke.runFusion(aten_inputs);
     testValidate(&fusion_copy, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
@@ -787,7 +787,7 @@ TEST_F(Tutorial, BasicTMA) {
     std::vector<int64_t> shape(3, 300);
     auto t = at::randn(shape, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t}, {}, index32bit);
+    ke.compile(&fusion, {t}, {}, index32bit);
     std::vector<at::Tensor> outputs = ke.runFusion({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
@@ -871,7 +871,7 @@ TEST_F(Tutorial, BasicTMA) {
     std::vector<int64_t> shape(3, 300);
     auto t = at::randn(shape, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t}, {}, index32bit);
+    ke.compile(&fusion, {t}, {}, index32bit);
     std::vector<at::Tensor> outputs = ke.runFusion({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
@@ -954,7 +954,7 @@ TEST_F(Tutorial, BasicTMA) {
     std::vector<int64_t> shape(3, 300);
     auto t = at::randn(shape, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t}, {}, index32bit);
+    ke.compile(&fusion, {t}, {}, index32bit);
     std::vector<at::Tensor> outputs = ke.runFusion({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
@@ -1034,7 +1034,7 @@ TEST_F(Tutorial, BasicTMA) {
     std::vector<int64_t> shape(3, 300);
     auto t = at::randn(shape, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t}, {}, index32bit);
+    ke.compile(&fusion, {t}, {}, index32bit);
     std::vector<at::Tensor> outputs = ke.runFusion({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
@@ -1139,7 +1139,7 @@ TEST_F(Tutorial, BasicTMA) {
     std::vector<int64_t> shape(3, 300);
     auto t = at::randn(shape, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t}, {}, index32bit);
+    ke.compile(&fusion, {t}, {}, index32bit);
     std::vector<at::Tensor> outputs = ke.runFusion({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
@@ -1245,7 +1245,7 @@ TEST_F(Tutorial, BasicTMA) {
     std::vector<int64_t> shape(3, 300);
     auto t = at::randn(shape, options);
     KernelExecutor ke;
-    ke.compileFusion(&fusion, {t}, {}, index32bit);
+    ke.compile(&fusion, {t}, {}, index32bit);
     std::vector<at::Tensor> outputs = ke.runFusion({t});
     ASSERT_TRUE(at::equal(t, outputs[0]));
   }
@@ -1345,7 +1345,7 @@ TEST_F(Tutorial, VectorizeStorePointwiseTMA) {
 
   // Compile with KernelExecutor directly to avoid scheduling
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {at_tv0, at_tv1}, {}, index32bit);
+  ke.compile(fusion.get(), {at_tv0, at_tv1}, {}, index32bit);
   auto outputs = ke.runFusion({at_tv0, at_tv1});
 
   auto at_output = at_tv0 + at_tv1;
@@ -1449,7 +1449,7 @@ TEST_F(Tutorial, PointwiseBroadcastTMA) {
 
   // Compile with KernelExecutor directly to avoid scheduling
   KernelExecutor ke;
-  ke.compileFusion(fusion.get(), {at_tv0, at_tv1}, {}, index32bit);
+  ke.compile(fusion.get(), {at_tv0, at_tv1}, {}, index32bit);
   auto outputs = ke.runFusion({at_tv0, at_tv1});
 
   auto at_output = at_tv0 + at_tv1;
@@ -1553,7 +1553,7 @@ TEST_F(Tutorial, TMABankConflictFreeTranspose) {
   auto t = at::randn({10000, 10000}, options);
   KernelExecutor ke;
   CompileParams index32bit{DataType::Int32, 255, false};
-  ke.compileFusion(&fusion, {t}, {}, index32bit);
+  ke.compile(&fusion, {t}, {}, index32bit);
   std::vector<at::Tensor> outputs = ke.runFusion({t});
   ASSERT_TRUE(at::equal(t.t(), outputs[0]));
 }

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -1116,7 +1116,7 @@ TEST_F(NVFuserTest, FusionSASSDumpError) {
   at::Tensor t0 = at::randn({8}, options);
 
   KernelExecutor ke;
-  ke.compileFusion(&fusion, {t0});
+  ke.compile(&fusion, {t0});
 
   EXPECT_THAT(
       [&]() { ke.disassembledKernelSASS(); },

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -1123,7 +1123,7 @@ TEST_F(NVFuserTest, FusionSASSDumpError) {
       ::testing::ThrowsMessage<nvfuser::nvfError>(
           ::testing::HasSubstr("I am fake")));
 
-  auto cg_outputs = ke.runFusion({t0});
+  auto cg_outputs = ke.run({t0});
   testValidate(ke.kernel(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -26,7 +26,7 @@ CGResultsPackage scheduleAndRun(
       fusion, scheduler_type, runtime_inputs, validate_scheduler);
   auto ke = std::make_unique<KernelExecutor>();
   ke->compile(fusion, runtime_inputs, heuristic_params->lparams);
-  auto cg_outputs = ke->runFusion(runtime_inputs, heuristic_params->lparams);
+  auto cg_outputs = ke->run(runtime_inputs, heuristic_params->lparams);
   CGResultsPackage results = {
       .outputs = cg_outputs,
       .heuristic_params = std::move(heuristic_params),

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -25,7 +25,7 @@ CGResultsPackage scheduleAndRun(
   auto heuristic_params = SchedulerEntry::scheduleWith(
       fusion, scheduler_type, runtime_inputs, validate_scheduler);
   auto ke = std::make_unique<KernelExecutor>();
-  ke->compileFusion(fusion, runtime_inputs, heuristic_params->lparams);
+  ke->compile(fusion, runtime_inputs, heuristic_params->lparams);
   auto cg_outputs = ke->runFusion(runtime_inputs, heuristic_params->lparams);
   CGResultsPackage results = {
       .outputs = cg_outputs,


### PR DESCRIPTION
Follow-up to #3349 

`KernelExecutor::compileFusion` -> `KernelExecutor::compile`
`KernelExecutor::runFusion` -> `KernelExecutor::run`