### PR TITLE
Fix launch configuration error with ScatterGatherTest.TorchGatherAllRankAllSelectedDim

### DIFF
--- a/tests/cpp/test_scatter_gather.cpp
+++ b/tests/cpp/test_scatter_gather.cpp
@@ -132,7 +132,7 @@ TEST_F(ScatterGatherTest, TorchGatherAllRankAllSelectedDim) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   for (const auto is_take_along : {false, true}) {
-    for (int rank = 1; rank <= 5; ++rank) {
+    for (int rank = 1; rank <= 3; ++rank) {
       for (int dim = 0; dim < rank; ++dim) {
         // this test uses a random input shape, clear the allocator to avoid
         // OOM.


### PR DESCRIPTION
This test uses pseudo random numbers to generate index tensors, which can result in requiring too large grid dimensions. For instance, there was this error reported today:

```
C++ exception with description " INTERNAL ASSERT FAILED at "/opt/pytorch/nvfuser/csrc/runtime/executor_params.cpp":41, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues. Invalid number of blocks in y direction: 69923
Exception raised from assertValid at /opt/pytorch/nvfuser/csrc/runtime/executor_params.cpp:41 (most recent call first):
```

The true fix would be making sure the scheduler to use a proper launch configurations, but these index operations are only there as experimental ops, I think this fix should be good enough for now.

