### PR TITLE
Add NVFUSER_DUMP=python_definition_segments

### DIFF
--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -135,6 +135,7 @@ std::unordered_map<DebugDumpOption, std::vector<std::string>> Options<
       {"ptx", DebugDumpOption::Ptx},
       {"ptxas_verbose", DebugDumpOption::PrintPtxasLog},
       {"python_definition", DebugDumpOption::PythonDefinition},
+      {"python_definition_segments", DebugDumpOption::PythonDefinitionSegments},
       {"python_frontend_debug", DebugDumpOption::PythonFrontendDebug},
       {"sass", DebugDumpOption::Sass},
       {"segmented_fusion", DebugDumpOption::FusionSegments},

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -64,6 +64,7 @@ enum class DebugDumpOption {
                     //! associated with what's running
   PreSegmenterLogging,
   PythonDefinition, //! Python Frontend Fusion Definition.
+  PythonDefinitionSegments, //! Python Frontend Fusion Definition of segments.
   PythonFrontendDebug, //! Python Frontend debug information.
   TransformPropagator, //! When running TransformPropagator, print propagation
                        //! path and replay result

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -13,6 +13,8 @@
 #include <instrumentation.h>
 #include <ir/base_nodes.h>
 #include <preseg_passes/pre_segmenter.h>
+#include <python_frontend/fusion_definition.h>
+#include <python_frontend/translation.h>
 #include <runtime/executor.h>
 #include <runtime/fusion_cache_utils.h>
 #include <scheduler/heuristic.h>
@@ -297,6 +299,14 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
   std::mutex thread_pool_error_message_mutex;
   for (int64_t run_order_id = 0; run_order_id < num_groups; ++run_order_id) {
     auto group_to_run = runtime_workspace_.group_run_order.at(run_order_id);
+
+    if (isDebugDumpEnabled(DebugDumpOption::PythonDefinitionSegments)) {
+      debug() << "Python definition for segmented group "
+              << group_to_run->groupId() << ":" << std::endl;
+      python_frontend::FusionDefinition fd(/*id=*/std::nullopt);
+      python_frontend::translate(group_to_run->getFusion(), &fd);
+      fd.print(debug());
+    }
 
     // TODO: index mode should be updated per segmented kernel
     // Prepare input vector


### PR DESCRIPTION
This adds a new debug dump option that simply prints out all of the segmented fusion segments as python FusionDefinitions at compile time. This is useful for debugging non-segmentation related errors whose repros contain many segments. To do so, when you notice a compile error the printout will tell you which segmented group it was found in. Then run your code again with `NVFUSER_DUMP=python_definition_segments` which will print a definition function for each segmented group using the C++ to python translation that was recently added. This lets you create a more targeted repro by copying that smaller definition into the repro printed in the error message then updating the inputs so that it executes.