### PR TITLE
Fix the legacy loop indexing traversal

### DIFF
--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -1382,6 +1382,8 @@ IterDomain* getLogicalIDToTraverse(
     return nullptr;
   }
 
+  IterDomain* fallback_candidate = nullptr;
+
   for (auto logical_id : logical_ids) {
     auto def = logical_id->definition();
     if (def == nullptr) {
@@ -1398,6 +1400,22 @@ IterDomain* getLogicalIDToTraverse(
             })) {
       return logical_id;
     }
+
+    if (std::any_of(
+            logical_id_inputs.begin(),
+            logical_id_inputs.end(),
+            [&](IterDomain* logical_id_input) {
+              return isPermissivelyMappedWithAny(
+                  logical_id_input, consumer_all_ids);
+            })) {
+      if (fallback_candidate == nullptr) {
+        fallback_candidate = logical_id;
+      }
+    }
+  }
+
+  if (fallback_candidate != nullptr) {
+    return fallback_candidate;
   }
 
   // No mapped ID found, which means the consumer is a post-view

--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -1372,6 +1372,10 @@ std::unordered_set<IterDomain*> buildLoopIndexingPreferredPath(
 // multiple such IDs exist, select one whose input IDs are mapped with
 // the consumer IDs. This is to ensure the path from the loop
 // IterDomains to the root matches with the consumer tensor.
+// Additionally, when none of the candidate iter domain has all of its
+// inputs mapped with the consumer tensor, prefer one that has at
+// least one mapped. This matters when the consumer tensor only has
+// one of the merge inputs, for example.
 IterDomain* getLogicalIDToTraverse(
     IterDomain* id,
     const std::vector<Val*>& consumer_all_ids) {
@@ -1382,6 +1386,7 @@ IterDomain* getLogicalIDToTraverse(
     return nullptr;
   }
 
+  // Keep track of an iter domain that has at least one input mapped.
   IterDomain* fallback_candidate = nullptr;
 
   for (auto logical_id : logical_ids) {


### PR DESCRIPTION
This is a temporary WAR for #3374. It's temporary since the repro has no problem with the IdModel-based indexer. This is for unblocking @IvanYashchuk until we can make the new indexer enabled by default.

The root cause of the issue is when we attempt to find a correct indexing path from the loop domain to the allocation domain of the indexed tensor, the algorithm fails to find a path visiting a backward merge when the indexed tensor has only one of the inputs. That happens when the tensor is broadcast and gets inlined with broadcast forwarding. In the current code, in that case, it just picks the first traversal option, which I think happens to be working fine, but that's not necessarily the right chose, particularly because we are looking at all candidate next traversal targets that are permissively mapped.

The WAR is simply picking a candidate as long as it has at least one mapped ID. I think this would be good enough as a temporary WAR.

Fixes #3374 