### PR TITLE
Validate allocation sizes and strides more widely.

### DIFF
--- a/benchmarks/cpp/lstm_cell.cpp
+++ b/benchmarks/cpp/lstm_cell.cpp
@@ -27,11 +27,11 @@ static void setupFusion(Fusion* fusion) {
 
   TensorView* tvs[16];
   for (size_t i = 0; i < 16; i++) {
-    tvs[i] = makeContigTensor(2, DataType::Float);
+    tvs[i] = makeSymbolicTensor(2, DataType::Float);
     fusion->addInput(tvs[i]);
   }
 
-  const auto cx = makeContigTensor(2, DataType::Float);
+  const auto cx = makeSymbolicTensor(2, DataType::Float);
   fusion->addInput(cx);
 
   const auto in_x = add(add(add(tvs[0], tvs[1]), tvs[2]), tvs[3]);

--- a/benchmarks/cpp/lstm_cell.cpp
+++ b/benchmarks/cpp/lstm_cell.cpp
@@ -28,10 +28,11 @@ static void setupFusion(Fusion* fusion) {
   TensorView* tvs[16];
   for (size_t i = 0; i < 16; i++) {
     tvs[i] = makeSymbolicTensor(2, DataType::Float);
+    tvs[i]->setContiguity({false, true});
     fusion->addInput(tvs[i]);
   }
 
-  const auto cx = makeSymbolicTensor(2, DataType::Float);
+  const auto cx = makeContigTensor(2, DataType::Float);
   fusion->addInput(cx);
 
   const auto in_x = add(add(add(tvs[0], tvs[1]), tvs[2]), tvs[3]);

--- a/csrc/ops/composite.cpp
+++ b/csrc/ops/composite.cpp
@@ -425,23 +425,6 @@ TensorView* matmul(TensorView* tv_a, TensorView* tv_b) {
   return out;
 }
 
-namespace {
-template <typename T>
-void checkAllEqual(std::initializer_list<T> elements) {
-  for (const auto& element : elements) {
-    NVF_CHECK(
-        element == *elements.begin(),
-        "Expected all elements to be equal, but found ",
-        element,
-        " and ",
-        *elements.begin(),
-        " in [",
-        toDelimitedString(elements),
-        "]");
-  }
-}
-} // namespace
-
 SdpfaFwdResult sdpfa_fwd(
     TensorView* query,
     TensorView* key,

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -598,4 +598,19 @@ template <typename T>
 using MaybeUniqueOwningPtr = dynamic_type::
     DynamicType<dynamic_type::NoContainers, T*, std::unique_ptr<T>>;
 
+template <typename T>
+void checkAllEqual(std::initializer_list<T> elements) {
+  for (const auto& element : elements) {
+    NVF_CHECK(
+        element == *elements.begin(),
+        "Expected all elements to be equal, but found ",
+        element,
+        " and ",
+        *elements.begin(),
+        " in [",
+        toDelimitedString(elements),
+        "]");
+  }
+}
+
 } // namespace nvfuser

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -6753,6 +6753,8 @@ TEST_F(NVFuserTest, FusionPersistentSoftmaxLocalShared_CUDA) {
 
   TensorView* sx_softmax = div(sx_exp, bcast_sum); // (M, N)
   TensorView* dx_softmax = div(dx_exp, bcast_sum); // (M, N)
+  sx_softmax->setContiguity(false);
+  dx_softmax->setContiguity(false);
   fusion.addOutput(sx_softmax);
   fusion.addOutput(dx_softmax);
 

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -1758,7 +1758,8 @@ TEST_F(TMARuntimeInvalidTest, MisalignedGlobalStride) {
   const DataType dtype = DataType::Float;
   const int64_t items_of_16_bytes = 16 / dataTypeSize(dtype);
 
-  auto tv0 = makeContigTensor(2, dtype);
+  auto tv0 = makeSymbolicTensor(2, dtype);
+  tv0->setContiguity({false, true});
   fusion.addInput(tv0);
   auto tv1 = set(tv0);
   auto tv2 = set(tv1);

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -147,7 +147,8 @@ TEST_P(ShardingTest, ComputeIndex) {
   c->setDeviceMesh(mesh);
   d->setDeviceMesh(mesh);
   a->axis(2)->parallelize(ParallelType::DIDx);
-  b->axis(2)->parallelize(ParallelType::DIDx);
+  TensorDomain::noReductions(b->getLoopDomain())[1]->parallelize(
+      ParallelType::DIDx);
   c->axis(2)->parallelize(ParallelType::DIDx);
   d->axis(0)->parallelize(ParallelType::DIDx);
 


### PR DESCRIPTION
Currently, GetMetaData::evaluate validates allocation sizes and strides
only when the TV has allocation that's different from logical. With this
PR, it will validate allocation even when it's the same as logical.

This extra validation captured many bugs including #3386 and #3194.
These bugs are either fixed in this PR or in follow-ups.

Prepares for #3282 