### PR TITLE
Inspect all IDs instead of just loop in ParallelDimensionMap

### DIFF
--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -41,7 +41,7 @@ void ParallelDimensionMap::build(Fusion* fusion) {
   VectorOfUniqueEntries<PAndID> all_concrete_ids;
   auto all_vals = fusion->usedMathVals();
   for (auto tv : ir_utils::filterByType<TensorView>(all_vals)) {
-    for (auto id : tv->getLoopDomain()) {
+    for (auto id : tv->domain()->allIDs()) {
       auto ptype = id->getParallelType();
       if (!isParallelTypeThread(ptype)) {
         continue;

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -9008,7 +9008,7 @@ TEST_F(NVFuserTest, ParallelDimensionsInAllocation) {
   fusion.addOutput(tv2);
 
   IterDomain* merged_id = IterDomain::merge(tv1->axis(0), tv1->axis(1));
-  tv1->setAllocationDomain({merged_id}, {true});
+  tv1->setAllocationDomain({merged_id}, true);
   merged_id->parallelize(ParallelType::TIDx);
 
   GpuLower gpulw(&fusion);


### PR DESCRIPTION
This is important for Hopper MMA (see #3278) in which we only parallelize TIDx on the allocation domain of the MmaOp output. Currently this leads to us generating a usable kernel but we are not able to launch it properly because we can't infer the x dimension of the block size. This PR fixes that by replacing `tv->getLoopDomain()` with `tv->domain()->allIDs()` which will inspect the root, logical, loop, allocation domains and even intermediate IterDomains to try and find parallelized dimensions.