### PR TITLE
Rename addSetsForCacheReads to cacheOperandsToRegisters

### DIFF
--- a/csrc/scheduler/ampere_multi_matmul.cpp
+++ b/csrc/scheduler/ampere_multi_matmul.cpp
@@ -498,10 +498,10 @@ void AmpereMultipleMatmulScheduler::cacheInputsAndOutputs() {
 
 void AmpereMultipleMatmulScheduler::defineOperandCaches() {
   cacheOperandsToSmem(as_, acw_smems_, params_->supported_vec_size.a);
-  addSetsForCacheReads(acw_smems_, acrs_);
+  cacheOperandsToRegisters(acw_smems_, acrs_);
 
   cacheOperandsToSmem(bs_, bcw_smems_, params_->supported_vec_size.b);
-  addSetsForCacheReads(bcw_smems_, bcrs_);
+  cacheOperandsToRegisters(bcw_smems_, bcrs_);
 
   // Now that we are finished possibly redefining the inputs to the MmaOps,
   // we can set the macro for those ops
@@ -551,7 +551,7 @@ void AmpereMultipleMatmulScheduler::cacheOperandsToSmem(
   }
 }
 
-void AmpereMultipleMatmulScheduler::addSetsForCacheReads(
+void AmpereMultipleMatmulScheduler::cacheOperandsToRegisters(
     const std::vector<TensorView*>& tv_smems,
     std::vector<TensorView*>& tv_rs) {
   tv_rs.resize(tv_smems.size(), nullptr);

--- a/csrc/scheduler/ampere_multi_matmul.h
+++ b/csrc/scheduler/ampere_multi_matmul.h
@@ -128,7 +128,7 @@ class AmpereMultipleMatmulScheduler : public MultipleMatmulScheduler {
   // existing LoadStoreOp present. Please note that for the second LoadStore
   // we don't propagate the allocation domain, since the scheduler sets the
   // allocation domain in the registers.
-  void addSetsForCacheReads(
+  void cacheOperandsToRegisters(
       const std::vector<TensorView*>& tv_smems,
       std::vector<TensorView*>& tv_rs);
 


### PR DESCRIPTION
As suggested by @zasdfgbnm in https://github.com/NVIDIA/Fuser/pull/3278/files#r1833466428, this just renames one method in the Ampere matmul scheduler for clarity. No functional change is expected.