### PR TITLE
Remove debug prints

### DIFF
--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -2595,12 +2595,6 @@ TEST_F(IdModelTest, LoopPromotionWithCyclicGraph) {
     IdModel id_model(&fusion, /*build_graphs=*/false);
     id_model.buildExactGraph();
 
-    std::ofstream ofs("exact_graph.dot", std::ofstream::trunc);
-    auto dot_string =
-        id_model.idGraph(IdMappingMode::EXACT).toGraphvizDotGraph();
-    ofs << dot_string;
-    ofs.close();
-
     // The exact graph is cyclic
     EXPECT_TRUE(isCyclic(id_model.idGraph(IdMappingMode::EXACT)));
 


### PR DESCRIPTION
Unit tests are supposed to clean themselves. If the purpose is to test toGraphvizDotGraph, I'd keep just that statement without storing the result to a file, the content of which isn't validated anyway.