### PR TITLE
Update input sizes for `test_many_segment_benchmark` to ensure kernel reuse

### DIFF
--- a/benchmarks/python/test_many_segments_host.py
+++ b/benchmarks/python/test_many_segments_host.py
@@ -30,11 +30,13 @@ def test_many_segment_benchmark(
     disable_validation: bool,
     disable_benchmarking: bool,
 ):
-    inputs = [torch.randn(16, 16, device="cuda", dtype=torch.float) for _ in range(2)]
+    inputs = [torch.randn(5, 5, device="cuda", dtype=torch.float) for _ in range(2)]
 
     # Generate multiple inputs to measure dynamic shape overhead.
     if host_bench_mode == "dynamic":
-        input_sizes = [4, 8, 16, 32, 64, 128]
+        # Note: Using these sizes to allow kernel reuse in dynamic.
+        # Using sizes = [4, 8, 16, 32, 64, 128] led to heuristic mismatch and kernel recompilation.
+        input_sizes = [5, 7, 9, 11]
         # Generate matrices of size x size dimensions
         inputs = [
             [


### PR DESCRIPTION
Updating the sizes for this benchmark since we use different heuristics leading to kernel recompilation on A100 and H100.

Before: `sizes = [4, 8, 16, 32, 64, 128`
<img width="1512" alt="Screenshot 2024-11-08 at 2 39 35 PM" src="https://github.com/user-attachments/assets/1c197bf8-2122-4eed-8fb7-88560efb84ee">


Current: `sizes = [5, 7, 9, 11]`
<img width="1512" alt="Screenshot 2024-11-08 at 2 39 11 PM" src="https://github.com/user-attachments/assets/45a2f136-e3b6-4dca-b2a9-a12451aac88d">

The `dynamic` measurement has lower standard deviation since we reuse kernels for all cases, and the average measurement is ~1.8ms as opposed to ~80ms with the earlier input sizes, with the maximum measurement of ~400ms