### PR TITLE
Skip SetUp when the communicator isn't available.

### DIFF
--- a/tests/cpp/test_multidevice_overlap.cpp
+++ b/tests/cpp/test_multidevice_overlap.cpp
@@ -688,6 +688,9 @@ class AllgatherOverlapTest : public MultiDeviceTest {
 
   void SetUp() {
     MultiDeviceTest::SetUp();
+    if (!communicator_->is_available()) {
+      return;
+    }
 
     num_devices_ = communicator_->size();
     my_device_index_ = communicator_->deviceId();


### PR DESCRIPTION
Although `MultiDeviceTest::SetUp` early returns when the communicator isn't available, it doesn't automagically make the *caller* exit early.