### PR TITLE
set maxrregcount in outer reduction heuristic

### DIFF
--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -924,7 +924,8 @@ std::unique_ptr<ReductionParams> heuristicParaToSchedulerPara(
       2;
   int64_t threads_per_block = params.bdimx * params.bdimy;
   int64_t threads_per_sm =
-      target_threads_per_sm / threads_per_block * threads_per_block;
+      scheduler_utils::safeDiv(target_threads_per_sm, threads_per_block) *
+      threads_per_block;
   int64_t reg_per_thread = getRegPerThreadGivenThreadsPerSM(threads_per_sm);
   rparams->cparams.maxrregcount = reg_per_thread;
 

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -912,6 +912,22 @@ std::unique_ptr<ReductionParams> heuristicParaToSchedulerPara(
   // bool flip_grid = gidim > 1 && gidim < 8;
   const bool flip_grid = false;
   auto rparams = std::make_unique<ReductionParams>();
+
+  // Configure register count to achieve 50% occupancy with 1024 threads per SM.
+  // Typical thread configurations are 512 or 1024 threads per block, both
+  // evenly divisible. This setup ensures each thread is limited to 64
+  // registers, preventing compilers from allocating more registers per thread,
+  // which could reduce occupancy and degrade performance.
+  int64_t target_threads_per_sm =
+      (int64_t)at::cuda::getCurrentDeviceProperties()
+          ->maxThreadsPerMultiProcessor /
+      2;
+  int64_t threads_per_block = params.bdimx * params.bdimy;
+  int64_t threads_per_sm =
+      target_threads_per_sm / threads_per_block * threads_per_block;
+  int64_t reg_per_thread = getRegPerThreadGivenThreadsPerSM(threads_per_sm);
+  rparams->cparams.maxrregcount = reg_per_thread;
+
   // cross grid implies cross block
   rparams->cross_block_inner_reduction = params.bdimy > 1 || params.grdim > 1;
   rparams->cross_grid_inner_reduction = params.grdim > 1;


### PR DESCRIPTION
**Code Changes**
In outer reduction heuristic, set register count to achieve 50% occupancy with 1024 threads per SM. 

**Why**
nvFuser calculates register count based on one block per sm in `getMaxRegCount`, if compiler follows this register count, we may lose the opportunity to get 2 or more blocks per sm.

Another approach is to use `__launch_bounds__(max threads per block)` but that requires modify `__launch_bounds__` if launch para is changed, which doesn't seem as convenient as directly setting maxrregcount. Tried in [PR-3413](https://github.com/NVIDIA/Fuser/pull/3413), then closed.

**Performance changes:**
see [doc](https://docs.google.com/presentation/d/199smuyiLyWFdilOgAPYF7v9nmzIiFGmrm1K2lSXtWSs/edit?usp=sharing).