### PR TITLE
Add `unsafeBind` to `LaunchParams` to allow modification.

### DIFF
--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -562,6 +562,46 @@ void verifyShape(const std::vector<int64_t>& shape) {
 }
 
 void defineHeuristicParamBindings(py::module& nvfuser) {
+  py::class_<LaunchParams> launch_parameters(nvfuser, "LaunchParams");
+  launch_parameters.def(
+      py::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>());
+  launch_parameters.def_property(
+      "bdimx",
+      [](LaunchParams& self) { return self.bdimx(); },
+      [](LaunchParams& self, int64_t val) {
+        self.bindUnsafe(val, ParallelType::TIDx);
+      });
+  launch_parameters.def_property(
+      "bdimy",
+      [](LaunchParams& self) { return self.bdimy(); },
+      [](LaunchParams& self, int64_t val) {
+        self.bindUnsafe(val, ParallelType::TIDy);
+      });
+  launch_parameters.def_property(
+      "bdimz",
+      [](LaunchParams& self) { return self.bdimz(); },
+      [](LaunchParams& self, int64_t val) {
+        self.bindUnsafe(val, ParallelType::TIDz);
+      });
+  launch_parameters.def_property(
+      "gdimx",
+      [](LaunchParams& self) { return self.gdimx(); },
+      [](LaunchParams& self, int64_t val) {
+        self.bindUnsafe(val, ParallelType::BIDx);
+      });
+  launch_parameters.def_property(
+      "gdimy",
+      [](LaunchParams& self) { return self.gdimy(); },
+      [](LaunchParams& self, int64_t val) {
+        self.bindUnsafe(val, ParallelType::BIDy);
+      });
+  launch_parameters.def_property(
+      "gdimy",
+      [](LaunchParams& self) { return self.gdimz(); },
+      [](LaunchParams& self, int64_t val) {
+        self.bindUnsafe(val, ParallelType::BIDz);
+      });
+
 #define DEFINECLASS(type) py::class_<type>(nvfuser, #type)
 
 #define TOSTRINGTOPLEVEL(type) \
@@ -643,7 +683,8 @@ void defineHeuristicParamBindings(py::module& nvfuser) {
       .PARAM(PointwiseParams, flip_grid_binding)
       .PARAM(PointwiseParams, vectorization_factor)
       .PARAM(PointwiseParams, unroll_factor_inner)
-      .PARAM(PointwiseParams, unroll_factor_outer);
+      .PARAM(PointwiseParams, unroll_factor_outer)
+      .PARAM(PointwiseParams, lparams);
 
   // Matmul scheduler parameters
   INITHEURISTICPARAMS(MatmulParams)

--- a/csrc/runtime/executor_params.cpp
+++ b/csrc/runtime/executor_params.cpp
@@ -75,6 +75,33 @@ void LaunchParams::bind(int64_t val, ParallelType p_type) {
   assertValid();
 }
 
+void LaunchParams::bindUnsafe(int64_t val, ParallelType p_type) {
+  switch (p_type) {
+    case ParallelType::TIDx:
+      bdimx_ = val;
+      break;
+    case ParallelType::BIDx:
+      gdimx_ = val;
+      break;
+    case ParallelType::TIDy:
+      bdimy_ = val;
+      break;
+    case ParallelType::BIDy:
+      gdimy_ = val;
+      break;
+    case ParallelType::TIDz:
+      bdimz_ = val;
+      break;
+    case ParallelType::BIDz:
+      gdimz_ = val;
+      break;
+    default:
+      NVF_THROW(
+          "Tried to bind invalid parallel type in launch config: ", p_type);
+  }
+  assertValid();
+}
+
 int64_t LaunchParams::getDim(ParallelType p_type) const {
   switch (p_type) {
     case ParallelType::TIDx:

--- a/csrc/runtime/executor_params.h
+++ b/csrc/runtime/executor_params.h
@@ -131,8 +131,16 @@ class LaunchParams {
     assertValid();
   }
 
-  // Binds dim assocaited with p_type to val
+  // Binds dim associated with p_type to val.
+  // Checks if ParallelType already has been assigned a value.
   void bind(int64_t val, ParallelType p_type);
+
+  // The LaunchParams class can act as a scheduler parameter or an executor
+  // constraint. The bind function uses checkAndSet to enforce that the value
+  // for a ParallelType cannot be set multiple times. bindUnsafe allows setting
+  // value of ParallelType multiple times. It is used for when LaunchParams is
+  // a configuration parameter.
+  void bindUnsafe(int64_t val, ParallelType p_type);
 
   // Adjusted value based on get functions above for each value
   NVF_API int64_t getDim(ParallelType p_type) const;


### PR DESCRIPTION
The `LaunchParams` class can act as a scheduler parameter or an executor constraint. The `bind` function uses `checkAndSet` to enforce that the value for a `ParallelType` cannot be set multiple times. The only way to modify a `LaunchParams` is construct a copy and replace the desired value.

This PR adds `bindUnsafe` to `LaunchParams` that allows setting value of `ParallelType` multiple times. It is only for use when `LaunchParams` is a configuration parameter.

* The `LaunchParams` class is exposed in the python frontend via `PointwiseParams` class.
