### PR TITLE
use bdimy = 1 to WAR smem race

### DIFF
--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -186,6 +186,7 @@ PersistentBufferStorageParams getPersistentBufferStorageParams(
     SchedulerRuntimeInfo& runtime_info,
     HeuristicDataCache* data_cache,
     const std::vector<TensorView*>& reduction_tvs,
+    const int64_t total_reduction_numel,
     const int64_t vectorize_factor,
     const int64_t threads_per_block_min,
     const int64_t threads_per_block_max) {
@@ -262,9 +263,11 @@ PersistentBufferStorageParams getPersistentBufferStorageParams(
   std::unordered_map<TensorView*, std::pair<int64_t, int64_t>>
       required_size_regs_smem_map;
   int64_t total_smem_buffer_size = 0;
+  int64_t total_regs_buffer_size = 0;
   for (auto buffer : buffers) {
     int64_t buffer_size_regs = scheduler_utils::getPersistentBufferSizeOfTensor(
         buffer, runtime_info, persistent_buffer_info);
+    total_regs_buffer_size += buffer_size_regs;
     int64_t buffer_size_smem = roundUpSharedMemory(
         buffer_size_regs,
         dataTypeSize(buffer->getDataType().value()),
@@ -279,6 +282,19 @@ PersistentBufferStorageParams getPersistentBufferStorageParams(
   buffer_params.smem_buffer_size = total_smem_buffer_size;
   buffer_params.regs_buffer_size =
       partialOuterReductionBufferSize(reduction_tvs, runtime_info);
+
+  // when total_reduction_numel <= 1024, scheduler may use multiple reductions
+  // per block with bdimy > 1, this leads to race condition in shared memory
+  // when using async copy. Adding `cp.async.wait_all`after the 1st async copy
+  // can avoid the race, but needs to figure out the root cause before we can
+  // safely use it. So, here we put all buffers in registers.
+  if (total_reduction_numel <= 1024L) {
+    buffer_params.regs_buffer_size += total_regs_buffer_size;
+    buffer_params.smem_buffer_size = 0;
+    buffer_params.has_enough_regs_and_smem = true;
+    return buffer_params;
+  }
+
   if (buffer_params.regs_buffer_size <= available_regs &&
       buffer_params.smem_buffer_size <= available_smem) {
     buffer_params.smem_persistent_buffers = buffers;
@@ -842,6 +858,7 @@ std::unique_ptr<ReductionParams> getInnerOuterPersistentHeuristics(
       runtime_info,
       data_cache,
       reduction_tvs,
+      properties.total_reduction_numel,
       hp.vectorize_factor,
       hp.threads_per_block_min,
       hp.threads_per_block_max);
@@ -1371,6 +1388,7 @@ bool InnerOuterPersistentKernelScheduler::canScheduleRunTime(
       runtime_info,
       data_cache,
       reduction_tvs,
+      properties.total_reduction_numel,
       hp.vectorize_factor,
       hp.threads_per_block_min,
       hp.threads_per_block_max);

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -657,7 +657,6 @@ std::unique_ptr<ReductionParams> innerOuterPersistentHeuristic(
   if (inner_dim_numel <= 1024) {
     rparams->multiple_reds_per_blk = true;
     rparams->tidx_for_outer_reduction = true;
-    constexpr int64_t threads_per_block_mrpb = 512;
 
     // Step-1, InnerParams, Reduction dim: inner_vect(reuse),
     // inner_batch(reuse), bdimx


### PR DESCRIPTION
  when total_reduction_numel <= 1024, scheduler may use multiple reductions per block with bdimy > 1, this leads to race condition in shared memory when using async copy. Adding `cp.async.wait_all`after the 1st async copy can avoid the race, but needs to figure out the root cause before we can safely use it. So, here we put all buffers in registers.

race detected with:
```
NVFUSER_DUMP=scheduler_params,cuda_to_file NVFUSER_ENABLE=kernel_debug PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool racecheck --racecheck-detect-level info  ./nvfuser_tests --gtest_filter='CombinedSchedulerTest.LayerNormBackward/dtype_double_batch_216_hidden_96'
```