### PR TITLE
Allocate index for all circular buffer stages

### DIFF
--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -865,8 +865,8 @@ void ComputeAtMap::allocateIndexVariables() {
       // Allocate index variable for each stage of the circular buffered loop.
       circular_buffered_loop_index_variable_map_[loop_disjoint_set.get()] =
           std::make_unique<CircularBufferIndices>();
-      for (auto i :
-           c10::irange(static_cast<int>(CircularBufferLoopStage::NumStages))) {
+      for (auto i : c10::irange(
+               static_cast<int>(CircularBufferLoopStage::EndOfStages))) {
         auto stage = static_cast<CircularBufferLoopStage>(i);
         circular_buffered_loop_index_variable_map_[loop_disjoint_set.get()]
             ->emplace(stage, IrBuilder::create<Val>(DataType::Index));

--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -864,13 +864,13 @@ void ComputeAtMap::allocateIndexVariables() {
             concrete_loop_id)) {
       // Allocate index variable for each stage of the circular buffered loop.
       circular_buffered_loop_index_variable_map_[loop_disjoint_set.get()] =
-          std::make_unique<CircularBufferIndices>(CircularBufferIndices(
-              {{CircularBufferLoopStage::Prolog,
-                IrBuilder::create<Val>(DataType::Index)},
-               {CircularBufferLoopStage::Main,
-                IrBuilder::create<Val>(DataType::Index)},
-               {CircularBufferLoopStage::Epilog,
-                IrBuilder::create<Val>(DataType::Index)}}));
+          std::make_unique<CircularBufferIndices>();
+      for (auto i :
+           c10::irange(static_cast<int>(CircularBufferLoopStage::NumStages))) {
+        auto stage = static_cast<CircularBufferLoopStage>(i);
+        circular_buffered_loop_index_variable_map_[loop_disjoint_set.get()]
+            ->emplace_back(stage, IrBuilder::create<Val>(DataType::Index));
+      }
     } else {
       // Everything now should be serial concrete loops,
       //   we just allocate a loop index integer for each set of loops.

--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -869,7 +869,7 @@ void ComputeAtMap::allocateIndexVariables() {
            c10::irange(static_cast<int>(CircularBufferLoopStage::NumStages))) {
         auto stage = static_cast<CircularBufferLoopStage>(i);
         circular_buffered_loop_index_variable_map_[loop_disjoint_set.get()]
-            ->emplace_back(stage, IrBuilder::create<Val>(DataType::Index));
+            ->emplace(stage, IrBuilder::create<Val>(DataType::Index));
       }
     } else {
       // Everything now should be serial concrete loops,

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -112,7 +112,7 @@ class CircularBufferLoopCloner : public kir::IrVisitor {
                 prefetch_distance, DataType::Index));
         break;
       }
-      case CircularBufferLoopStage::NotApplicable: {
+      default: {
         NVF_THROW("Unsupported loop mode, got: ", loop_type_);
       }
     }
@@ -204,7 +204,7 @@ class CircularBufferLoopCloner : public kir::IrVisitor {
         }
         break;
       }
-      case CircularBufferLoopStage::NotApplicable: {
+      default: {
         NVF_THROW("Unsupported loop mode, got: ", loop_type_);
       }
     }
@@ -563,7 +563,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
         }
         break;
       }
-      case CircularBufferLoopStage::NotApplicable: {
+      default: {
         NVF_ERROR(false, "Unsupported loop mode, got: ", loop_type_);
       }
     }
@@ -579,7 +579,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
       case CircularBufferLoopStage::Epilog: {
         return;
       }
-      case CircularBufferLoopStage::NotApplicable: {
+      default: {
         NVF_ERROR(false, "Unsupported loop mode, got: ", loop_type_);
       }
     }

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -766,7 +766,13 @@ enum class LoadStoreOpType {
 
 // Used to label what part of the circular buffered iterdomain
 //  a for loop is materializing.
-enum class CircularBufferLoopStage { NotApplicable, Prolog, Main, Epilog };
+enum class CircularBufferLoopStage {
+  Prolog,
+  Main,
+  Epilog,
+  NumStages,
+  NotApplicable
+};
 
 //! Supported swizzle types,
 //!  corresponds to swizzles functions on the runtime cuda

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -767,10 +767,10 @@ enum class LoadStoreOpType {
 // Used to label what part of the circular buffered iterdomain
 //  a for loop is materializing.
 enum class CircularBufferLoopStage {
-  Prolog,
+  Prolog = 0,
   Main,
   Epilog,
-  NumStages,
+  EndOfStages, // A special placeholder used to iterate over all stages
   NotApplicable
 };
 


### PR DESCRIPTION
Don't hard code the list of all stages. Instead, get them. This will make it easier to add new stages in the future.