### PR TITLE
Add ReductionParams to python frontend

### DIFF
--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -686,6 +686,48 @@ void defineHeuristicParamBindings(py::module& nvfuser) {
       .PARAM(PointwiseParams, unroll_factor_outer)
       .PARAM(PointwiseParams, lparams);
 
+  // Reduction scheduler parameters
+  INITHEURISTICPARAMS(ReductionParams)
+      .PARAM(ReductionParams, fastest_dim)
+      .PARAM(ReductionParams, persistent_kernel)
+      .PARAM(ReductionParams, project_persistent_buffers)
+      .PARAM(ReductionParams, schedule_3D)
+      .PARAM(ReductionParams, flip_grid)
+      .PARAM(ReductionParams, cross_block_inner_reduction)
+      .PARAM(ReductionParams, cross_grid_inner_reduction)
+      .PARAM(ReductionParams, unroll_factor_inner_reduction)
+      .PARAM(ReductionParams, unroll_factor_top_of_vectorization)
+      .PARAM(ReductionParams, vectorize_inner_reduction)
+      .PARAM(ReductionParams, split_grid_dim_inner_reduction)
+      .PARAM(ReductionParams, pad_inner_reduction_to_warp)
+      .PARAM(ReductionParams, batches_per_block_inner_reduction)
+      .PARAM(ReductionParams, block_dim_inner_reduction)
+      .PARAM(ReductionParams, grid_dim_inner_reduction)
+      .PARAM(ReductionParams, multiple_reds_per_blk)
+      .PARAM(ReductionParams, unroll_factor_iter_dom)
+      .PARAM(ReductionParams, vectorize_iter_dom)
+      .PARAM(ReductionParams, split_grid_dim_iter_dom_inner)
+      .PARAM(ReductionParams, split_grid_dim_iter_dom_outer)
+      .PARAM(ReductionParams, block_dim_iter_dom)
+      .PARAM(ReductionParams, grid_dim_iter_dom)
+      .PARAM(ReductionParams, cross_block_outer_reduction)
+      .PARAM(ReductionParams, cross_grid_outer_reduction)
+      .PARAM(ReductionParams, batches_per_block_outer_reduction)
+      .PARAM(ReductionParams, unroll_factor_outer_reduction)
+      .PARAM(ReductionParams, block_dim_outer_reduction)
+      .PARAM(ReductionParams, grid_dim_outer_reduction)
+      .PARAM(ReductionParams, compute_persistent_buffer_with_first_consumer)
+      .PARAM(ReductionParams, static_bdimx)
+      .PARAM(ReductionParams, static_bdimy)
+      .PARAM(ReductionParams, combined_inner_outer)
+      .PARAM(ReductionParams, tidx_for_outer_reduction)
+      .PARAM(ReductionParams, pad_outer_reduction_to_warp)
+      .PARAM(ReductionParams, combined_split_grid_inner_dim)
+      .PARAM(ReductionParams, vectorization_factor_outer)
+      .PARAM(ReductionParams, vectorization_factor_tmp_gmem_write)
+      .PARAM(ReductionParams, block_dim_inner_reduction_extra)
+      .PARAM(ReductionParams, lparams);
+
   // Matmul scheduler parameters
   INITHEURISTICPARAMS(MatmulParams)
       .PARAM(MatmulParams, tile_sizes)
@@ -3934,6 +3976,18 @@ void initNvFuserPythonBindings(PyObject* module) {
         HeuristicParams* parameters =
             sched->computeHeuristics(SchedulerType::PointWise);
         return *parameters->as<PointwiseParams>();
+      },
+      py::return_value_policy::reference);
+  nvf_sched.def(
+      "compute_reduction_heuristics",
+      [](FusionDefinition::SchedOperators& self) -> ReductionParams& {
+        NVF_CHECK(
+            self.validUse(),
+            "Attempting to use a SchedOperators Op prior to definition!");
+        UserSchedule* sched = self.fusion_definition->userSchedule();
+        HeuristicParams* parameters =
+            sched->computeHeuristics(SchedulerType::Reduction);
+        return *parameters->as<ReductionParams>();
       },
       py::return_value_policy::reference);
   nvf_sched.def(


### PR DESCRIPTION
This PR add support for `ReductionParams` to the python frontend. All parameters are exposed except `std::vector<TensorView*> smem_persistent_buffers` and `CompileParams`.