### PR TITLE
Fix the setting of `gdimx` in 2d and 3d inner reduction heuristics

### DIFF
--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -372,9 +372,9 @@ std::unique_ptr<ReductionParams> inner2dReductionHeuristic(
 
   } else {
     rparams->grid_dim_iter_dom = ParallelType::BIDx;
-    if (gdimx > scheduler_utils::x_grid_limit) {
+    gdimx = std::min(godim, scheduler_utils::x_grid_limit);
+    if (godim > scheduler_utils::x_grid_limit) {
       rparams->split_grid_dim_iter_dom_outer = true;
-      gdimx = godim;
     }
   }
 
@@ -751,9 +751,9 @@ std::unique_ptr<ReductionParams> inner3dReductionHeuristic(
 
   } else {
     rparams->grid_dim_iter_dom = ParallelType::BIDx;
-    if (gdimx > scheduler_utils::x_grid_limit) {
+    gdimx = std::min(godim, scheduler_utils::x_grid_limit);
+    if (godim > scheduler_utils::x_grid_limit) {
       rparams->split_grid_dim_iter_dom_outer = true;
-      gdimx = godim;
     }
   }
 

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -367,14 +367,14 @@ std::unique_ptr<ReductionParams> inner2dReductionHeuristic(
     rparams->grid_dim_iter_dom = ParallelType::BIDy;
     if (godim > scheduler_utils::y_grid_limit) {
       rparams->split_grid_dim_iter_dom_outer = true;
-      gdimy = std::min(godim, scheduler_utils::y_grid_limit);
+      gdimy = scheduler_utils::y_grid_limit;
     }
 
   } else {
     rparams->grid_dim_iter_dom = ParallelType::BIDx;
-    gdimx = std::min(godim, scheduler_utils::x_grid_limit);
     if (godim > scheduler_utils::x_grid_limit) {
       rparams->split_grid_dim_iter_dom_outer = true;
+      gdimx = scheduler_utils::x_grid_limit;
     }
   }
 
@@ -746,14 +746,14 @@ std::unique_ptr<ReductionParams> inner3dReductionHeuristic(
     rparams->grid_dim_iter_dom = ParallelType::BIDy;
     if (godim > scheduler_utils::y_grid_limit) {
       rparams->split_grid_dim_iter_dom_outer = true;
-      gdimy = std::min(godim, scheduler_utils::y_grid_limit);
+      gdimy = scheduler_utils::y_grid_limit;
     }
 
   } else {
     rparams->grid_dim_iter_dom = ParallelType::BIDx;
-    gdimx = std::min(godim, scheduler_utils::x_grid_limit);
     if (godim > scheduler_utils::x_grid_limit) {
       rparams->split_grid_dim_iter_dom_outer = true;
+      gdimx = scheduler_utils::x_grid_limit;
     }
   }
 


### PR DESCRIPTION
This PR fixes the setting of `gdimx` in 2d and 3d inner reduction heuristics. 

Previously, `gdimx == LaunchParams::UNINITIALIZED_VAL` in the else block, so the `gdimx > scheduler_utils::x_grid_limit` if statement was always false and `gdimx` was not set.