### PR TITLE
Add interface to directly work with CircularBufferOptions

### DIFF
--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -66,10 +66,15 @@ class CircularBufferInfo {
   //!  as a circular buffer loop.
   bool isCircularBufferedIterDomain(IterDomain* id);
 
-  //! Get the number of circular buffer stages and the prefetch distance for the
-  //! given axis. The number of stages will be 2 in the case of double buffer
-  //! loop.
+  //! Get the circular buffer options for the given axis.
+  const CircularBufferOptions& getCircularBufferOptionsFor(
+      IterDomain* circular_buffered_id) const;
+
+  //! Get the stage depth for the given axis. The number of stages will be 2 in
+  //! the case of double buffer loop
   int64_t getStageDepthFor(IterDomain* circular_buffered_id) const;
+
+  //! Get the prefetch distance for the given axis.
   int64_t getPrefetchDistanceFor(IterDomain* circular_buffered_id) const;
 
   std::string toString() const;
@@ -79,15 +84,13 @@ class CircularBufferInfo {
 
   TvInfo& getTvInfo(const TensorView* tv);
 
-  //! Set the number of circular buffer stages and the prefetch distance for the
-  //! given circular_buffered_id. Current code generation only supports one
-  //! stage depth and prefetch distance per loop disjoint set, so this function
-  //! will throw an error if trying to set different stage numbers to
-  //! iterdomains that are loop mapped.
-  void setStageDepthAndPrefetchDistance(
+  //! Set the number of circular buffer options for the given
+  //! circular_buffered_id. Current code generation only supports one option per
+  //! loop disjoint set, so this function will throw an error if trying to set
+  //! different options to iterdomains that are loop mapped.
+  void setCircularBufferOptions(
       IterDomain* circular_buffered_id,
-      int64_t stage_depth,
-      int64_t prefetch_distance);
+      const CircularBufferOptions& opt);
 
  private:
   //! Keeps track of information for lowering circular buffered tensors

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -175,7 +175,18 @@ struct CircularBufferOptions {
   bool isEnable() const {
     return stage > 1;
   }
+
+  bool operator==(const CircularBufferOptions& other) const {
+    return stage == other.stage && prefetch == other.prefetch;
+  }
 };
+
+inline std::ostream& operator<<(
+    std::ostream& os,
+    const CircularBufferOptions& options) {
+  return os << "CircularBufferOptions{ stage=" << options.stage
+            << ", prefetch=" << options.prefetch << " }";
+}
 
 //! TensorView is our primitive Tensor Type used in code generation. It can be
 //! thought of as representing physical memory, however, its dimensionality is
@@ -512,6 +523,10 @@ class NVF_API TensorView : public Val {
   // Returns true if this tensor is circular buffered.
   bool isCircularBuffered() const {
     return circular_buffer_options_.isEnable();
+  }
+
+  const CircularBufferOptions& circularBufferOptions() const {
+    return circular_buffer_options_;
   }
 
   // Returns the depth of circular buffering if applicable.


### PR DESCRIPTION
Change `CircularBufferInfo::setStageDepthAndPrefetchDistance` to `CircularBufferInfo::setCircularBufferOptions` so that it will automatically work if in the future we add more fields to circular buffer options.