### PR TITLE
Minor cleanup in `CloneTmaCircularBufferLoopAndInsertSync`

### DIFF
--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -366,8 +366,7 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
     // that the `cloned_loop` is the loop containing the first read of a
     // circular buffered TensorView. We need to insert that wait expression
     // before `cloned_loop`.
-    if (for_loop_stack_.size() == 1) {
-      NVF_ERROR(for_loop_stack_.front() == cloned_top_level_loop_);
+    if (onlyOneSerialForLoopOnStack()) {
       for (auto it = mbarriers_to_wait_.begin();
            it != mbarriers_to_wait_.end();) {
         auto wait = it->second;
@@ -409,6 +408,15 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
         addTmaLoadBlock(cloned_loop);
       }
     }
+  }
+
+  // Check if there is only one serial for-loop in the stack
+  bool onlyOneSerialForLoopOnStack() const {
+    return std::count_if(
+               for_loop_stack_.begin(), for_loop_stack_.end(), [](ForLoop* fl) {
+                 return fl->iter_domain()->getParallelType() ==
+                     ParallelType::Serial;
+               }) == 1;
   }
 
   // Current compute stage: loop_index % stages
@@ -508,8 +516,7 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
       if (wait == nullptr) {
         wait = createMbarrierWait(ldst);
       }
-      if (for_loop_stack_.size() == 1) {
-        NVF_ERROR(for_loop_stack_.front() == cloned_top_level_loop_);
+      if (onlyOneSerialForLoopOnStack()) {
         for_loop_stack_.back()->body().push_back(wait_it->second);
         mbarriers_to_wait_.erase(wait_it);
       }
@@ -616,8 +623,7 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
 
     // If last cloned scope is the cloned_top_level_loop body, then add
     // mbarrier::arriveExpectTx and new loadStoreOp.
-    if (for_loop_stack_.size() == 1) {
-      NVF_ERROR(for_loop_stack_.front() == cloned_top_level_loop_);
+    if (onlyOneSerialForLoopOnStack()) {
       return addTmaLoadBlock(new_ldst);
     }
 
@@ -661,8 +667,7 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
 
     // If last cloned scope is the cloned_top_level_loop body, then add
     // mbarrier::arriveExpectTx and new loadStoreOp
-    if (for_loop_stack_.size() == 1) {
-      NVF_ERROR(for_loop_stack_.front() == cloned_top_level_loop_);
+    if (onlyOneSerialForLoopOnStack()) {
       return addTmaLoadBlock(ldst);
     }
 


### PR DESCRIPTION
- Rename it to `ClonePipelinedTmaCircularBufferLoopAndInsertSync`.
- Use `circular_buffer_load_tvs_` instead of getting the data again.
- Fix an error in comment.