### PR TITLE
Avoid canScheduleCompileTime for dynamic shape check

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -2633,7 +2633,9 @@ void deDuplicateScalarExprs(std::vector<Expr*>& exprs) {
 } // namespace
 
 std::optional<std::unique_ptr<HeuristicParams>> SegmentedGroup::
-    getMaybeHeuristicParams(SchedulerRuntimeInfo& runtime_info) {
+    getMaybeHeuristicParams(
+        SchedulerRuntimeInfo& runtime_info,
+        bool skip_compile_time_checks) {
   FUSER_PERF_SCOPE("SegmentedFusion::getMaybeHeuristicParams");
   auto heuristic_data_cache =
       segmented_fusion_->getCachedHeuristicDataFor(this);
@@ -2641,7 +2643,8 @@ std::optional<std::unique_ptr<HeuristicParams>> SegmentedGroup::
           schedulerType(),
           runtime_info.fusion(),
           runtime_info,
-          heuristic_data_cache)) {
+          heuristic_data_cache,
+          skip_compile_time_checks)) {
     return std::nullopt;
   }
   return SchedulerEntry::makeSchedulerInstance(schedulerType())

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -154,7 +154,8 @@ class SegmentedGroup {
   //! Returns a nullopt if this group cannot be scheduled
   //!  with the same heuristics.
   std::optional<std::unique_ptr<HeuristicParams>> getMaybeHeuristicParams(
-      SchedulerRuntimeInfo& runtime_info);
+      SchedulerRuntimeInfo& runtime_info,
+      bool skip_compile_time_checks = false);
 
   //! Query if this is a group for a fusion input
   bool isFusionInputGroup() const;

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -517,8 +517,8 @@ std::optional<std::unique_ptr<HeuristicParamsList>> FusionKernelRuntime::
               group_to_run, fusion_to_run_info);
     } else {
       // Try to get scheduler entry
-      auto maybe_heuristic_params =
-          group_to_run->getMaybeHeuristicParams(fusion_to_run_info);
+      auto maybe_heuristic_params = group_to_run->getMaybeHeuristicParams(
+          fusion_to_run_info, /*skip_compile_time_checks=*/true);
       // If unavailable, then return std::nullopt
       if (!maybe_heuristic_params.has_value()) {
         return std::nullopt;

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -120,7 +120,8 @@ bool canSchedule(
     SchedulerType scheduler_type,
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
-    HeuristicDataCache* data_cache) {
+    HeuristicDataCache* data_cache,
+    bool skip_compile_time_checks) {
   // If a data cache is given, the compile time part doesn't need to be checked,
   // since during segmentation the segmenter will call
   // SchedulerEntry::proposeHeuristics which doesn't pass a data_cache.
@@ -130,8 +131,12 @@ bool canSchedule(
 
   std::unique_ptr<SchedulerEntry> scheduler =
       SchedulerEntry::makeSchedulerInstance(scheduler_type);
-  return scheduler->canScheduleCompileTime(fusion) &&
-      scheduler->canScheduleRunTime(fusion, runtime_info, data_cache);
+
+  if (!skip_compile_time_checks && !scheduler->canScheduleCompileTime(fusion)) {
+    return false;
+  }
+
+  return scheduler->canScheduleRunTime(fusion, runtime_info, data_cache);
 }
 
 // Simply loop through the list as baseline strategy

--- a/csrc/scheduler/registry.h
+++ b/csrc/scheduler/registry.h
@@ -83,7 +83,8 @@ bool canSchedule(
     SchedulerType sh,
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
-    HeuristicDataCache* data_cache = nullptr);
+    HeuristicDataCache* data_cache = nullptr,
+    bool skip_compile_time_checks = false);
 
 //! Fusion segmenter facing API,
 //!   returns a schedule that applies in the given fusion, returns


### PR DESCRIPTION
This PR plumbs through an option to skip the call to `canScheduleCompileTime` in `Schedule::canSchedule`, allowing us to avoid this check when getting heuristics for new dynamic shapes. As mentioned in https://github.com/NVIDIA/Fuser/issues/3419#issuecomment-2479956772 this gives us a sizeable speedup in most cases.

Before this PR:
![image](https://github.com/user-attachments/assets/3d09d193-9e30-47d6-98b9-94bb9f90453b)

After this PR:
![image](https://github.com/user-attachments/assets/acbb485a-87a1-4e6c-89ca-18b91c312b3c)

This is related to #3419, but until we address the many-segments latency I will refrain from closing that issue.