### PR TITLE
Remove `getStageDepthFor`, `getPrefetchDistanceFor`, `circularBufferDepth`, `circularBufferPrefetchDistance`

### DIFF
--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -243,11 +243,6 @@ const CircularBufferOptions& CircularBufferInfo::getCircularBufferOptionsFor(
   return maybe_depth_it->second;
 }
 
-int64_t CircularBufferInfo::getStageDepthFor(
-    IterDomain* circular_buffer_axis) const {
-  return getCircularBufferOptionsFor(circular_buffer_axis).stage;
-}
-
 int64_t CircularBufferInfo::getPrefetchDistanceFor(
     IterDomain* circular_buffer_axis) const {
   return getCircularBufferOptionsFor(circular_buffer_axis).prefetch;

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -243,11 +243,6 @@ const CircularBufferOptions& CircularBufferInfo::getCircularBufferOptionsFor(
   return maybe_depth_it->second;
 }
 
-int64_t CircularBufferInfo::getPrefetchDistanceFor(
-    IterDomain* circular_buffer_axis) const {
-  return getCircularBufferOptionsFor(circular_buffer_axis).prefetch;
-}
-
 ForLoop* CircularBufferInfo::getCircularBufferLoop(
     IterDomain* axis,
     const std::vector<ForLoop*>& loops,

--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -70,13 +70,6 @@ class CircularBufferInfo {
   const CircularBufferOptions& getCircularBufferOptionsFor(
       IterDomain* circular_buffered_id) const;
 
-  //! Get the stage depth for the given axis. The number of stages will be 2 in
-  //! the case of double buffer loop
-  int64_t getStageDepthFor(IterDomain* circular_buffered_id) const;
-
-  //! Get the prefetch distance for the given axis.
-  int64_t getPrefetchDistanceFor(IterDomain* circular_buffered_id) const;
-
   std::string toString() const;
 
  private:

--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -150,8 +150,10 @@ IndexingParameters getLinearIndexParameters(
                 loop_id, IdMappingMode::EXACT);
 
         auto prefetch_distance =
-            GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
-                loop->iter_domain());
+            GpuLower::current()
+                ->circularBufferInfo()
+                .getCircularBufferOptionsFor(loop->iter_domain())
+                .prefetch;
         index_parameters.initial_concrete_id_index[concrete_loop_id] =
             SimplifyingIrBuilder::addExpr(
                 index_parameters.initial_concrete_id_index[concrete_loop_id],
@@ -419,7 +421,8 @@ IndexingParameters getPredicateInitialIndexParameters(
       auto prefetch_distance =
           (int64_t)GpuLower::current()
               ->circularBufferInfo()
-              .getPrefetchDistanceFor(db_loop->iter_domain());
+              .getCircularBufferOptionsFor(db_loop->iter_domain())
+              .prefetch;
       bool is_same =
           (rotated_loops.count(db_loop)
                ? cur_index->sameAs(SimplifyingIrBuilder::addExpr(

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -422,7 +422,8 @@ class AllocationInserter : public kir::ExprMutator {
       }
       GpuLower::current()->circularBufferInfo().setOriginalAllocSize(
           info.buffer, original_alloc_size);
-      int64_t circular_buffer_stage = info.buffer->circularBufferDepth();
+      int64_t circular_buffer_stage =
+          info.buffer->circularBufferOptions().stage;
       alloc_dims.push_back(
           IrBuilder::create<Val>(circular_buffer_stage, DataType::Index));
     }
@@ -514,11 +515,11 @@ class AllocationInserter : public kir::ExprMutator {
 
       // Check that all circular buffer depth match
       if (out_tv->isCircularBuffered() && circular_buffer_depth == 1) {
-        circular_buffer_depth = out_tv->circularBufferDepth();
+        circular_buffer_depth = out_tv->circularBufferOptions().stage;
       }
       NVF_ERROR(
           circular_buffer_depth == 1 ||
-              circular_buffer_depth == out_tv->circularBufferDepth(),
+              circular_buffer_depth == out_tv->circularBufferOptions().stage,
           "Expected all output TensorViews for the same expression ",
           "to have the same circular_buffer_depth");
 

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -26,8 +26,10 @@ namespace {
 // used for mbarrier initialization and invalidation.
 ForLoop* createStageDepthForLoop(ForLoop* circular_buffer_loop) {
   int64_t stage_depth =
-      GpuLower::current()->circularBufferInfo().getStageDepthFor(
-          circular_buffer_loop->iter_domain());
+      GpuLower::current()
+          ->circularBufferInfo()
+          .getCircularBufferOptionsFor(circular_buffer_loop->iter_domain())
+          .stage;
   return ir_utils::createRangeLoop(stage_depth);
 }
 
@@ -638,8 +640,10 @@ class AllocationInserter : public kir::ExprMutator {
       // mbarrier::inval will be updated in circular buffering pass, but we
       // add them here to handle shared memory correctly in alias memory pass.
       int64_t circular_buffer_depth =
-          GpuLower::current()->circularBufferInfo().getStageDepthFor(
-              fl->iter_domain());
+          GpuLower::current()
+              ->circularBufferInfo()
+              .getCircularBufferOptionsFor(fl->iter_domain())
+              .stage;
 
       TensorView* mbarrier =
           TensorViewBuilder()

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -1037,8 +1037,10 @@ class CircularBufferInserter : private kir::ExprMutator {
 
   bool hasPrefetch(ForLoop* circular_buffer_loop) {
     int64_t prefetch_distance =
-        GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
-            circular_buffer_loop->iter_domain());
+        GpuLower::current()
+            ->circularBufferInfo()
+            .getCircularBufferOptionsFor(circular_buffer_loop->iter_domain())
+            .prefetch;
     return prefetch_distance > 0;
   }
 
@@ -1115,9 +1117,11 @@ class CircularBufferInserter : private kir::ExprMutator {
       has_cpasync =
           std::any_of(loads.begin(), loads.end(), ir_utils::isCpAsyncOp);
       if (prologue_loop != nullptr && has_cpasync) {
-        int64_t prefetch_distance =
-            GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
-                circular_buffer_loop->iter_domain());
+        int64_t prefetch_distance = GpuLower::current()
+                                        ->circularBufferInfo()
+                                        .getCircularBufferOptionsFor(
+                                            circular_buffer_loop->iter_domain())
+                                        .prefetch;
         kir::AsyncWait* cp_async_wait = IrBuilder::create<kir::AsyncWait>(
             AsyncOpType::CpAsync, prefetch_distance - 1);
         prologue_loop->body().push_back(
@@ -1232,8 +1236,10 @@ class CircularBufferInserter : private kir::ExprMutator {
     //  passes. Cleanups suggested in [Circular Buffer Sync]
     //  would resolve this dependency on pass ordering.
     int64_t prefetch_distance =
-        GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
-            main_loop->iter_domain());
+        GpuLower::current()
+            ->circularBufferInfo()
+            .getCircularBufferOptionsFor(main_loop->iter_domain())
+            .prefetch;
     kir::AsyncCommit* cp_async_commit =
         IrBuilder::create<kir::AsyncCommit>(AsyncOpType::CpAsync);
     kir::AsyncWait* cp_async_wait = IrBuilder::create<kir::AsyncWait>(

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -81,26 +81,21 @@ class CircularBufferLoopCloner : public kir::IrVisitor {
         circular_buffer_loop_->iter_domain(), loop_type_);
     Val* start = circular_buffer_loop_->start();
     Val* stop = circular_buffer_loop_->stop();
-    int64_t stage_depth =
-        GpuLower::current()->circularBufferInfo().getStageDepthFor(
-            circular_buffer_loop_->iter_domain());
-    int64_t prefetch_distance =
-        GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
+    const auto& opt =
+        GpuLower::current()->circularBufferInfo().getCircularBufferOptionsFor(
             circular_buffer_loop_->iter_domain());
 
     switch (loop_type_) {
       case CircularBufferLoopStage::Prolog: {
         NVF_ERROR(start->isZeroInt());
-        stop = SimplifyingIrBuilder::create<Val>(
-            prefetch_distance, DataType::Index);
+        stop = SimplifyingIrBuilder::create<Val>(opt.prefetch, DataType::Index);
         break;
       }
       case CircularBufferLoopStage::Main: {
         if (requireEpilogue(circular_buffer_load_exprs_)) {
           stop = SimplifyingIrBuilder::subExpr(
               circular_buffer_loop_->stop(),
-              SimplifyingIrBuilder::create<Val>(
-                  prefetch_distance, DataType::Index));
+              SimplifyingIrBuilder::create<Val>(opt.prefetch, DataType::Index));
         }
         break;
       }
@@ -108,8 +103,7 @@ class CircularBufferLoopCloner : public kir::IrVisitor {
         NVF_ERROR(requireEpilogue(circular_buffer_load_exprs_));
         start = SimplifyingIrBuilder::subExpr(
             circular_buffer_loop_->stop(),
-            SimplifyingIrBuilder::create<Val>(
-                prefetch_distance, DataType::Index));
+            SimplifyingIrBuilder::create<Val>(opt.prefetch, DataType::Index));
         break;
       }
       default: {
@@ -127,7 +121,7 @@ class CircularBufferLoopCloner : public kir::IrVisitor {
         /*vectorize_shift=*/nullptr,
         circular_buffer_loop_->isUnrollRequired(),
         loop_type_,
-        /*circular_buffer_loop_stage_depth=*/stage_depth);
+        /*circular_buffer_loop_stage_depth=*/opt.stage);
 
     handle(circular_buffer_loop_);
   }
@@ -422,8 +416,10 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
   // Current compute stage: loop_index % stages
   Val* currentComputeStage() const {
     int64_t stage_depth =
-        GpuLower::current()->circularBufferInfo().getStageDepthFor(
-            circular_buffer_loop_->iter_domain());
+        GpuLower::current()
+            ->circularBufferInfo()
+            .getCircularBufferOptionsFor(circular_buffer_loop_->iter_domain())
+            .stage;
     Val* result = SimplifyingIrBuilder::modExpr(
         cloned_top_level_loop_->indexOrStartIfTrivial(),
         IrBuilder::create<Val>(stage_depth, PrimDataType::Index));
@@ -434,18 +430,16 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
   // Current load stage (for main loop): (loop_index + prefetch) % stages
   Val* currentLoadStage() const {
     NVF_ERROR(loop_type_ == CircularBufferLoopStage::Main);
-    int64_t stage_depth =
-        GpuLower::current()->circularBufferInfo().getStageDepthFor(
-            circular_buffer_loop_->iter_domain());
-    int64_t prefetch_distance =
-        GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
+
+    const auto& opt =
+        GpuLower::current()->circularBufferInfo().getCircularBufferOptionsFor(
             circular_buffer_loop_->iter_domain());
 
     auto current_load_stage = SimplifyingIrBuilder::modExpr(
         SimplifyingIrBuilder::addExpr(
             cloned_top_level_loop_->indexOrStartIfTrivial(),
-            IrBuilder::create<Val>(prefetch_distance, PrimDataType::Index)),
-        IrBuilder::create<Val>(stage_depth, PrimDataType::Index));
+            IrBuilder::create<Val>(opt.prefetch, PrimDataType::Index)),
+        IrBuilder::create<Val>(opt.stage, PrimDataType::Index));
     return GpuLower::current()->commonScalarMap().hoistScalar(
         current_load_stage, for_loop_stack_);
   }
@@ -460,8 +454,10 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
   // for reference.
   Val* currentParity() const {
     int64_t stage_depth =
-        GpuLower::current()->circularBufferInfo().getStageDepthFor(
-            circular_buffer_loop_->iter_domain());
+        GpuLower::current()
+            ->circularBufferInfo()
+            .getCircularBufferOptionsFor(circular_buffer_loop_->iter_domain())
+            .stage;
 
     auto depth = IrBuilder::create<Val>(stage_depth, DataType::UInt32);
     auto two = IrBuilder::create<Val>(2, DataType::UInt32);

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -700,7 +700,7 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         // separately by CircularBufferInserter.
         if (tv->getMemoryType() == MemoryType::Shared &&
             (!tv->isCircularBuffered() ||
-             tv->circularBufferPrefetchDistance() == 0)) {
+             tv->circularBufferOptions().prefetch == 0)) {
           smem[tv] = expr;
 
           // only keep track of async writes in smem_async

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -971,12 +971,11 @@ class WarAsyncWaitInserter : private kir::ExprMutator {
           "Only main circular buffer loop needs WAR async wait, ",
           "so the code should not reach here. Stage:",
           stage);
-      const auto stage_depth = gpu_lower->circularBufferInfo().getStageDepthFor(
-          circular_buffer_loop->iter_domain());
-      const auto prefetch_distance =
-          gpu_lower->circularBufferInfo().getPrefetchDistanceFor(
-              circular_buffer_loop->iter_domain());
-      pending_ops = std::min(pending_ops, stage_depth - prefetch_distance - 1);
+
+      const auto& opt =
+          GpuLower::current()->circularBufferInfo().getCircularBufferOptionsFor(
+              circular_buffer_loop_->iter_domain());
+      pending_ops = std::min(pending_ops, opt.stage - opt.prefetch - 1);
     }
     return pending_ops;
   }

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -974,7 +974,7 @@ class WarAsyncWaitInserter : private kir::ExprMutator {
 
       const auto& opt =
           GpuLower::current()->circularBufferInfo().getCircularBufferOptionsFor(
-              circular_buffer_loop_->iter_domain());
+              circular_buffer_loop->iter_domain());
       pending_ops = std::min(pending_ops, opt.stage - opt.prefetch - 1);
     }
     return pending_ops;

--- a/csrc/id_model/circular_buffer_indexing.cpp
+++ b/csrc/id_model/circular_buffer_indexing.cpp
@@ -80,7 +80,8 @@ Val* getLoopIndexOffsetForProducerOfCircularBuffer(
     return nullptr;
   }
 
-  auto prefetch_distance = info.getPrefetchDistanceFor(for_loop->iter_domain());
+  auto prefetch_distance =
+      info.getCircularBufferOptionsFor(for_loop->iter_domain()).prefetch;
 
   return IrBuilder::create<Val>(prefetch_distance, DataType::Index);
 }
@@ -114,7 +115,7 @@ Val* getOffsetForCircularBufferTensor(
 
   const auto& opt =
       GpuLower::current()->circularBufferInfo().getCircularBufferOptionsFor(
-          circular_buffer_loop_->iter_domain());
+          circular_buffer_loop->iter_domain());
 
   // If this appears as a consumer, it should be either prologue or
   // main. If it's producer, it should be main or epilogue

--- a/csrc/id_model/predicate_indexing.cpp
+++ b/csrc/id_model/predicate_indexing.cpp
@@ -249,8 +249,10 @@ std::unordered_map<Val*, Val*> getPredicateIndexReplacementMap(
       return nullptr;
     } else {
       auto prefetch_distance =
-          GpuLower::current()->circularBufferInfo().getPrefetchDistanceFor(
-              fl->iter_domain());
+          GpuLower::current()
+              ->circularBufferInfo()
+              .getCircularBufferOptionsFor(fl->iter_domain())
+              .prefetch;
       return SimplifyingIrBuilder::addExpr(
           original_index,
           SimplifyingIrBuilder::create<Val>(

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -2029,7 +2029,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
     const auto& opt =
         gpu_lower->circularBufferInfo().getCircularBufferOptionsFor(
             db_loop->iter_domain());
-    bool is_circular_buffer_loop = stage_depth > 2;
+    bool is_circular_buffer_loop = opt.stage > 2;
     bool is_prolog =
         db_loop->circularBufferLoopStage() == CircularBufferLoopStage::Prolog;
 

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1580,8 +1580,9 @@ std::vector<Val*> Index::getNonGlobalProducerStridedIndices(
         producer_tv, loops, true);
     if (db_loop != nullptr) {
       const int64_t stage_depth =
-          gpu_lower->circularBufferInfo().getStageDepthFor(
-              db_loop->iter_domain());
+          gpu_lower->circularBufferInfo()
+              .getCircularBufferOptionsFor(db_loop->iter_domain())
+              .stage;
       auto loop_index = db_loop->indexOrStartIfTrivial();
       if (rotated_loops.count(db_loop) > 0) {
         loop_index = SimplifyingIrBuilder::addExpr(loop_index, db_loop->step());
@@ -2023,8 +2024,10 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
   if (consumer_tv->isCircularBuffered()) {
     auto db_loop = gpu_lower->circularBufferInfo().getCircularBufferLoop(
         consumer_tv, loops);
-    int64_t stage_depth = gpu_lower->circularBufferInfo().getStageDepthFor(
-        db_loop->iter_domain());
+    int64_t stage_depth =
+        gpu_lower->circularBufferInfo()
+            .getCircularBufferOptionsFor(db_loop->iter_domain())
+            .stage;
     int64_t prefetch_distance =
         gpu_lower->circularBufferInfo().getPrefetchDistanceFor(
             db_loop->iter_domain());

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -529,16 +529,6 @@ class NVF_API TensorView : public Val {
     return circular_buffer_options_;
   }
 
-  // Returns the depth of circular buffering if applicable.
-  int64_t circularBufferDepth() const {
-    return circular_buffer_options_.stage;
-  }
-
-  // Returns the prefetch of circular buffering if applicable.
-  int64_t circularBufferPrefetchDistance() const {
-    return circular_buffer_options_.prefetch;
-  }
-
   //! Transforms the innermost iterdomains according to the given mma swizzle,
   //!  this should be used on the tvs that are either inputs/outputs of an
   //!  MmaOp, or any tv's that are involved in prolog/epilog fusions and need to

--- a/csrc/runtime/executor_utils.cpp
+++ b/csrc/runtime/executor_utils.cpp
@@ -673,12 +673,12 @@ void validateCircularBuffering(
     NVF_ERROR(axis != nullptr);
     PolymorphicValue runtime_axis_size = expr_eval.evaluate(axis->extent());
     NVF_ERROR(
-        runtime_axis_size >= cb_tv->circularBufferDepth(),
+        runtime_axis_size >= cb_tv->circularBufferOptions().stage,
         "This kernel fails to fill the circular buffer pipeline at runtime. ",
         "The extent of the circular buffer axis is ",
         runtime_axis_size,
         " while ",
-        cb_tv->circularBufferDepth(),
+        cb_tv->circularBufferOptions().stage,
         " is the number of stages in the circular buffer.");
   }
 }


### PR DESCRIPTION
Remove `CircularBufferInfo::getStageDepthFor`, `CircularBufferInfo::getPrefetchDistanceFor`, `TensorView::circularBufferDepth`, and `TensorView::circularBufferPrefetchDistance`.

It is trivial enough to get the these fields from options, so they do not deserve a separate function.