### PR TITLE
Split `insertMBarrierWaitBeforeFirstRead`

### DIFF
--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -835,7 +835,8 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
   // of ldst -> wait or tv -> wait, because multiple buffers and TMA load
   // operations can share the same mbarrier. In this case, we only want to
   // create a single wait expression to wait for all of them.
-  std::unordered_map<TensorView*, kir::MBarrierWaitParity*> mbarriers_to_wait_;
+  std::unordered_map<TensorView*, kir::MBarrierWaitParity*>
+      raw_mbarriers_to_wait_;
 
   // Mbarrier_ArriveExpectTx to add to cloned_top_level_loop
   kir::MBarrierArriveExpectTx* mbarrier_arrive_tx_ = nullptr;

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -344,8 +344,8 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
            it != raw_mbarriers_to_wait_.end();) {
         auto wait = it->second;
         // short-circuit: wait expression does not exist yet for mbarrier.
-        // This means: the mbarrier is used by the circular buffer loop for
-        // waiting for its loads, but we have not encountered the first read of
+        // This means: the mbarrier is used by the circular buffer for loop
+        // to wait for its loads. However, we have not encountered the first read of
         // the circular buffer yet, so no need to wait right now.
         if (wait == nullptr) {
           ++it;

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -345,8 +345,8 @@ class ClonePipelinedTmaCircularBufferLoopAndInsertSync
         auto wait = it->second;
         // short-circuit: wait expression does not exist yet for mbarrier.
         // This means: the mbarrier is used by the circular buffer for loop
-        // to wait for its loads. However, we have not encountered the first read of
-        // the circular buffer yet, so no need to wait right now.
+        // to wait for its loads. However, we have not encountered the first
+        // read of the circular buffer yet, so no need to wait right now.
         if (wait == nullptr) {
           ++it;
           continue;


### PR DESCRIPTION
This PR is just a refactor with no behavioral change. Things changed:
- Rename `mbarriers_to_wait_` -> `raw_mbarriers_to_wait_`
- Rename `getAllMbarriersToWaitFor` -> `getAllMbarriersToWait`
- Split `insertMBarrierWaitBeforeFirstRead` into two functions: `insertMBarrierWaitBeforeFirstRead` (same name), and `updateRawMbarrierToWaitMap`, where `insertMBarrierWaitBeforeFirstRead` checks if there are wait ready to be inserted, and insert these waits, and `updateRawMbarrierToWaitMap` updates `raw_mbarriers_to_wait_`.