### PR TITLE
Restructure baseline benchmarks

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -10,6 +10,9 @@ import numpy as np
 from nvfuser import FusionDefinition, FusionCache
 from nvfuser.pytorch_utils import DEVICE_PROPERTIES
 import warnings
+import thunder
+from thunder.executors.nvfuserex import nvfuserex
+
 
 # These variables can be overwritten through CLI commands
 # --benchmark-rounds=rounds --benchmark-warmup-rounds=warmup_rounds
@@ -43,6 +46,16 @@ def clear_dynamo_cache() -> None:
 def unary_bwd_torch(inputs: List):  # [output, grad_out]
     inputs[0].backward(inputs[1], retain_graph=True)
 
+def with_executor(executor: str, fwd_fn: Callable) -> Callable:
+    assert executor in ["eager", "torchcompile", "thunder"]
+    if executor == 'eager':
+        return fwd_fn
+    if executor == 'torchcompile':
+        return torch.compile(fwd_fn)
+    if executor == 'thunder':
+        return thunder.jit(
+            fwd_dn, nv_enable_bookend=False, executors=[nvfuserex]
+        )            
 
 def compute_total_iobytes(
     tensor_props: dict[str, tuple[int | tuple[int, ...], torch.dtype]]

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -46,16 +46,16 @@ def clear_dynamo_cache() -> None:
 def unary_bwd_torch(inputs: List):  # [output, grad_out]
     inputs[0].backward(inputs[1], retain_graph=True)
 
+
 def with_executor(executor: str, fwd_fn: Callable) -> Callable:
     assert executor in ["eager", "torchcompile", "thunder"]
-    if executor == 'eager':
+    if executor == "eager":
         return fwd_fn
-    if executor == 'torchcompile':
+    if executor == "torchcompile":
         return torch.compile(fwd_fn)
-    if executor == 'thunder':
-        return thunder.jit(
-            fwd_fn, nv_enable_bookend=False, executors=[nvfuserex]
-        )            
+    if executor == "thunder":
+        return thunder.jit(fwd_fn, nv_enable_bookend=False, executors=[nvfuserex])
+
 
 def compute_total_iobytes(
     tensor_props: dict[str, tuple[int | tuple[int, ...], torch.dtype]]

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -54,7 +54,7 @@ def with_executor(executor: str, fwd_fn: Callable) -> Callable:
         return torch.compile(fwd_fn)
     if executor == 'thunder':
         return thunder.jit(
-            fwd_dn, nv_enable_bookend=False, executors=[nvfuserex]
+            fwd_fn, nv_enable_bookend=False, executors=[nvfuserex]
         )            
 
 def compute_total_iobytes(

--- a/benchmarks/python/test_dropout_layernorm_bwd.py
+++ b/benchmarks/python/test_dropout_layernorm_bwd.py
@@ -9,11 +9,12 @@ from .core import (
     clear_dynamo_cache,
     unary_bwd_torch,
     compute_total_iobytes,
-    with_executor
+    with_executor,
 )
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 from .torch_ops import dropout_layernorm
+
 
 def dropout_layernorm_bwd_fusion(
     fd: FusionDefinition, dtype: DataType, dropout_p: float

--- a/benchmarks/python/test_dropout_layernorm_bwd.py
+++ b/benchmarks/python/test_dropout_layernorm_bwd.py
@@ -13,7 +13,7 @@ from .core import (
 )
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import dropout_layernorm
+from .torch_ops import dropout_layernorm
 
 def dropout_layernorm_bwd_fusion(
     fd: FusionDefinition, dtype: DataType, dropout_p: float

--- a/benchmarks/python/test_dropout_layernorm_fwd.py
+++ b/benchmarks/python/test_dropout_layernorm_fwd.py
@@ -8,11 +8,12 @@ from .core import (
     run_benchmark,
     clear_dynamo_cache,
     compute_total_iobytes,
-    with_executor
+    with_executor,
 )
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 from .torch_ops import dropout_layernorm
+
 
 def dropout_layernorm_fwd_fusion(
     fd: FusionDefinition, dtype: DataType, dropout_p: float, eps: float = 1e-5

--- a/benchmarks/python/test_dropout_layernorm_fwd.py
+++ b/benchmarks/python/test_dropout_layernorm_fwd.py
@@ -12,7 +12,7 @@ from .core import (
 )
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import dropout_layernorm
+from .torch_ops import dropout_layernorm
 
 def dropout_layernorm_fwd_fusion(
     fd: FusionDefinition, dtype: DataType, dropout_p: float, eps: float = 1e-5

--- a/benchmarks/python/test_dropout_rmsnorm_bwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_bwd.py
@@ -9,11 +9,12 @@ from .core import (
     clear_dynamo_cache,
     unary_bwd_torch,
     compute_total_iobytes,
-    with_executor
+    with_executor,
 )
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 from .torch_ops import dropout_rmsnorm
+
 
 def dropout_rmsnorm_bwd_fusion(
     fd: FusionDefinition,

--- a/benchmarks/python/test_dropout_rmsnorm_bwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_bwd.py
@@ -13,7 +13,7 @@ from .core import (
 )
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import dropout_rmsnorm
+from .torch_ops import dropout_rmsnorm
 
 def dropout_rmsnorm_bwd_fusion(
     fd: FusionDefinition,

--- a/benchmarks/python/test_dropout_rmsnorm_bwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_bwd.py
@@ -9,10 +9,11 @@ from .core import (
     clear_dynamo_cache,
     unary_bwd_torch,
     compute_total_iobytes,
+    with_executor
 )
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
-
+from torch_ops import dropout_rmsnorm
 
 def dropout_rmsnorm_bwd_fusion(
     fd: FusionDefinition,
@@ -186,16 +187,9 @@ def test_dropout_rmsnorm_bwd_baseline_benchmark(
     grads = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype)
 
-    def dropout_rmsnorm_fwd():
-        x = input2 + torch.nn.functional.dropout(input1, p=dropout_p)
-        output = weights * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-5)
-        return output
-
-    fwd_fn = {
-        "eager": dropout_rmsnorm_fwd,
-        "torchcompile": torch.compile(dropout_rmsnorm_fwd),
-    }
-    outputs = fwd_fn[executor]()
+    fwd_fn = with_executor(executor, dropout_rmsnorm)
+    fwd_inputs = [input1, input2, weights, dropout_p]
+    outputs = fwd_fn(fwd_inputs)
 
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_dropout_rmsnorm_fwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_fwd.py
@@ -12,7 +12,7 @@ from .core import (
 )
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import dropout_rmsnorm
+from .torch_ops import dropout_rmsnorm
 
 def dropout_rmsnorm_fwd_fusion(
     fd: FusionDefinition,

--- a/benchmarks/python/test_dropout_rmsnorm_fwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_fwd.py
@@ -8,11 +8,12 @@ from .core import (
     run_benchmark,
     clear_dynamo_cache,
     compute_total_iobytes,
-    with_executor
+    with_executor,
 )
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 from .torch_ops import dropout_rmsnorm
+
 
 def dropout_rmsnorm_fwd_fusion(
     fd: FusionDefinition,
@@ -161,7 +162,7 @@ def test_dropout_rmsnorm_fwd_baseline_benchmark(
     ]
 
     benchmark_fn = with_executor(executor, dropout_rmsnorm)
-    
+
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_gelu_bwd.py
+++ b/benchmarks/python/test_gelu_bwd.py
@@ -8,7 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_execu
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-from torch_ops import gelu
+from .torch_ops import gelu
 
 def gelu_bwd_fusion(
     fd: FusionDefinition,

--- a/benchmarks/python/test_gelu_bwd.py
+++ b/benchmarks/python/test_gelu_bwd.py
@@ -10,6 +10,7 @@ from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
 from .torch_ops import gelu
 
+
 def gelu_bwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,

--- a/benchmarks/python/test_gelu_bwd.py
+++ b/benchmarks/python/test_gelu_bwd.py
@@ -4,11 +4,11 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-
+from torch_ops import gelu
 
 def gelu_bwd_fusion(
     fd: FusionDefinition,
@@ -103,14 +103,9 @@ def test_gelu_bwd_baseline_benchmark(
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     grads = torch.randn(size, device="cuda", dtype=dtype)
 
-    def gelu_fwd():
-        return torch.nn.functional.gelu(inputs + bias, approximate="tanh")
-
-    fwd_fn = {
-        "eager": gelu_fwd,
-        "torchcompile": torch.compile(gelu_fwd),
-    }
-    outputs = fwd_fn[executor]()
+    fwd_fn = with_executor(executor, gelu)
+    fwd_inputs = [inputs, bias]
+    outputs = fwd_fn(fwd_inputs)
 
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_gelu_fwd.py
+++ b/benchmarks/python/test_gelu_fwd.py
@@ -9,6 +9,7 @@ import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 from .torch_ops import gelu
 
+
 def gelu_fwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,

--- a/benchmarks/python/test_gelu_fwd.py
+++ b/benchmarks/python/test_gelu_fwd.py
@@ -57,7 +57,7 @@ def test_gelu_fwd_nvf_benchmark(
     with FusionDefinition() as fd:
         gelu_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
     if not disable_validation:
-        eager_output = gelu_fwd_fn(inputs)
+        eager_output = gelu(inputs)
         fd.validate(inputs, [eager_output])
     if not disable_benchmarking:
         run_benchmark(benchmark, fd.execute, inputs)

--- a/benchmarks/python/test_gelu_fwd.py
+++ b/benchmarks/python/test_gelu_fwd.py
@@ -7,7 +7,7 @@ from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import gelu
+from .torch_ops import gelu
 
 def gelu_fwd_fusion(
     fd: FusionDefinition,

--- a/benchmarks/python/test_groupnorm_fwd.py
+++ b/benchmarks/python/test_groupnorm_fwd.py
@@ -6,8 +6,6 @@ from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
-import thunder
-from thunder.executors.nvfuserex import nvfuserex
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
 

--- a/benchmarks/python/test_groupnorm_fwd.py
+++ b/benchmarks/python/test_groupnorm_fwd.py
@@ -4,7 +4,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache
+from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 import thunder
 from thunder.executors.nvfuserex import nvfuserex
@@ -145,15 +145,10 @@ def test_groupnorm_fwd_baseline_benchmark(
     bias = torch.randn(C, device="cuda", dtype=dtype)
     num_groups = get_n_groups(C)
 
-    benchmark_fn = {
-        "eager": groupnorm_fwd,
-        "torchcompile": torch.compile(groupnorm_fwd),
-        "thunder": thunder.jit(
-            groupnorm_fwd, nv_enable_bookend=False, executors=[nvfuserex]
-        ),
-    }
+    benchmark_fn = with_executor(executor, groupnorm_fwd)
+
     run_benchmark(
         benchmark,
-        benchmark_fn[executor],
+        benchmark_fn,
         [x, weight, bias, num_groups],
     )

--- a/benchmarks/python/test_huggingface_attn_bwd.py
+++ b/benchmarks/python/test_huggingface_attn_bwd.py
@@ -9,6 +9,7 @@ import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
 from .torch_ops import huggingface_attn
 
+
 # Fusion from huggingface attention implementation
 # The nvFuser defintion only includes the non-matmul computation (add + reshape + softmax + dropout)
 def huggingface_attn_bwd_fusion(
@@ -128,7 +129,7 @@ def test_huggingface_attn_bwd_baseline_benchmark(
     )
 
     # Compile the fwd fn for torchcompile
-    fwd_fn =with_executor(executor, huggingface_attn)
+    fwd_fn = with_executor(executor, huggingface_attn)
     fwd_inputs = [inputs, attention_mask, size, dropout_p]
     outputs = fwd_fn(fwd_inputs)
     grads = torch.randn(batch_size * nh, seq_len, seq_len, device="cuda", dtype=dtype)

--- a/benchmarks/python/test_huggingface_attn_bwd.py
+++ b/benchmarks/python/test_huggingface_attn_bwd.py
@@ -7,7 +7,7 @@ from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_executor
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import huggingface_attn
+from .torch_ops import huggingface_attn
 
 # Fusion from huggingface attention implementation
 # The nvFuser defintion only includes the non-matmul computation (add + reshape + softmax + dropout)

--- a/benchmarks/python/test_huggingface_attn_bwd.py
+++ b/benchmarks/python/test_huggingface_attn_bwd.py
@@ -4,10 +4,10 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_executor
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
-
+from torch_ops import huggingface_attn
 
 # Fusion from huggingface attention implementation
 # The nvFuser defintion only includes the non-matmul computation (add + reshape + softmax + dropout)
@@ -127,18 +127,10 @@ def test_huggingface_attn_bwd_baseline_benchmark(
         batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype
     )
 
-    def huggingface_attn_fwd():
-        attn = (inputs + attention_mask).view(batch_size * nh, seq_len, seq_len)
-        attn = torch.nn.functional.softmax(attn, dim=-1)
-        output = torch.nn.functional.dropout(attn, p=dropout_p)
-        return output
-
     # Compile the fwd fn for torchcompile
-    fwd_fn = {
-        "eager": huggingface_attn_fwd,
-        "torchcompile": torch.compile(huggingface_attn_fwd),
-    }
-    outputs = fwd_fn[executor]()
+    fwd_fn =with_executor(executor, huggingface_attn)
+    fwd_inputs = [inputs, attention_mask, size, dropout_p]
+    outputs = fwd_fn(fwd_inputs)
     grads = torch.randn(batch_size * nh, seq_len, seq_len, device="cuda", dtype=dtype)
 
     # Manually compute IOBytes: See PR #1725

--- a/benchmarks/python/test_huggingface_attn_fwd.py
+++ b/benchmarks/python/test_huggingface_attn_fwd.py
@@ -7,7 +7,7 @@ from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import huggingface_attn
+from .torch_ops import huggingface_attn
 
 # Fusion from huggingface attention implementation.
 # The nvFuser defintion only includes the non-matmul computation (add + reshape + softmax + dropout)

--- a/benchmarks/python/test_huggingface_attn_fwd.py
+++ b/benchmarks/python/test_huggingface_attn_fwd.py
@@ -4,10 +4,10 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache
+from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import huggingface_attn_fwd
+from torch_ops import huggingface_attn
 
 # Fusion from huggingface attention implementation.
 # The nvFuser defintion only includes the non-matmul computation (add + reshape + softmax + dropout)

--- a/benchmarks/python/test_huggingface_attn_fwd.py
+++ b/benchmarks/python/test_huggingface_attn_fwd.py
@@ -9,6 +9,7 @@ import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
 from .torch_ops import huggingface_attn
 
+
 # Fusion from huggingface attention implementation.
 # The nvFuser defintion only includes the non-matmul computation (add + reshape + softmax + dropout)
 def huggingface_attn_fwd_fusion(

--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -8,6 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
+from torch_ops import layernorm
 
 
 def layernorm_bwd_fusion(
@@ -163,19 +164,9 @@ def test_layernorm_bwd_baseline_benchmark(
     weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
     bias = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=True)
 
-    def layernorm_fwd():
-        return torch.nn.functional.layer_norm(
-            inputs,
-            inputs.shape[1:],
-            weight=weights,
-            bias=bias,
-        )
-
-    fwd_fn = {
-        "eager": layernorm_fwd,
-        "torchcompile": torch.compile(layernorm_fwd),
-    }
-    outputs = fwd_fn[executor]()
+    fwd_fn = with_executor(executor, layernorm)
+    fwd_inputs = [inputs, weights, bias]
+    outputs = fwd_fn(fwd_inputs)
 
     # Manually compute IOBytes: See PR #1725
     run_benchmark(

--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -4,7 +4,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np

--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -8,7 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_execu
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-from torch_ops import layernorm
+from .torch_ops import layernorm
 
 
 def layernorm_bwd_fusion(

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -8,7 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-from torch_ops import layernorm
+from .torch_ops import layernorm
 
 def layernorm_fwd_fusion(
     fd: FusionDefinition,

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -86,7 +86,7 @@ def test_layernorm_fwd_nvf_benchmark(
         layernorm_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
 
     if not disable_validation:
-        eager_output = layernorm_fwd(inputs)
+        eager_output = layernorm(inputs)
         mean = inputs[0].to(torch.float).mean(dim=-1)
         variance = inputs[0].to(torch.float).var(dim=-1, unbiased=False)
         invstd = (1.0 / torch.sqrt(variance + eps)).unsqueeze(1)

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -10,6 +10,7 @@ from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
 from .torch_ops import layernorm
 
+
 def layernorm_fwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,

--- a/benchmarks/python/test_nanogpt_attn_bwd.py
+++ b/benchmarks/python/test_nanogpt_attn_bwd.py
@@ -4,10 +4,10 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_executor
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
-
+from torch_ops import nanogpt_attn
 
 # Fusion from nanogpt attention module
 # The nvFuser defintion only includes the non-matmul computation (masked_fill + softmax + dropout)
@@ -144,21 +144,10 @@ def test_nanogpt_attn_bwd_baseline_benchmark(
         1, 1, seq_len, seq_len
     )
 
-    def nanogpt_attn_fwd():
-        # Compute output
-        hs = n_embd // nh
-        attn = inputs / (hs**0.5)
-        attn = attn.masked_fill(bias[:, :, :seq_len, :seq_len] == 0, float("-inf"))
-        attn = torch.nn.functional.softmax(attn, dim=-1)
-        output = torch.nn.functional.dropout(attn, p=dropout_p)
-        return output
-
     # Compile the fwd fn for torchcompile
-    fwd_fn = {
-        "eager": nanogpt_attn_fwd,
-        "torchcompile": torch.compile(nanogpt_attn_fwd),
-    }
-    outputs = fwd_fn[executor]()
+    fwd_fn = with_executor(executor, nanogpt_attn)
+    fwd_inputs = [inputs, bias, size, dropout_p]
+    outputs = fwd_fn(fwd_inputs)
 
     grads = torch.randn(batch_size, nh, seq_len, seq_len, device="cuda", dtype=dtype)
 

--- a/benchmarks/python/test_nanogpt_attn_bwd.py
+++ b/benchmarks/python/test_nanogpt_attn_bwd.py
@@ -9,6 +9,7 @@ import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
 from .torch_ops import nanogpt_attn
 
+
 # Fusion from nanogpt attention module
 # The nvFuser defintion only includes the non-matmul computation (masked_fill + softmax + dropout)
 def nanogpt_attn_bwd_fusion(

--- a/benchmarks/python/test_nanogpt_attn_bwd.py
+++ b/benchmarks/python/test_nanogpt_attn_bwd.py
@@ -7,7 +7,7 @@ from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_executor
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import nanogpt_attn
+from .torch_ops import nanogpt_attn
 
 # Fusion from nanogpt attention module
 # The nvFuser defintion only includes the non-matmul computation (masked_fill + softmax + dropout)

--- a/benchmarks/python/test_nanogpt_attn_fwd.py
+++ b/benchmarks/python/test_nanogpt_attn_fwd.py
@@ -7,7 +7,7 @@ from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import nanogpt_attn
+from .torch_ops import nanogpt_attn
 
 # Fusion from nanogpt attention module
 # The nvFuser defintion only includes the non-matmul computation (masked_fill + softmax + dropout)

--- a/benchmarks/python/test_nanogpt_attn_fwd.py
+++ b/benchmarks/python/test_nanogpt_attn_fwd.py
@@ -9,6 +9,7 @@ import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES
 from .torch_ops import nanogpt_attn
 
+
 # Fusion from nanogpt attention module
 # The nvFuser defintion only includes the non-matmul computation (masked_fill + softmax + dropout)
 def nanogpt_attn_fwd_fusion(

--- a/benchmarks/python/test_pointwise_mul.py
+++ b/benchmarks/python/test_pointwise_mul.py
@@ -4,7 +4,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache
+from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -63,13 +63,11 @@ def test_pointwise_mul_baseline_benchmark(
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype)
 
-    benchmark_fn = {
-        "eager": pointwise_mul_fwd_fn,
-        "torchcompile": torch.compile(pointwise_mul_fwd_fn),
-    }
+    benchmark_fn = with_executor(executor, pointwise_mul_fwd_fn)
+    
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,
-        benchmark_fn[executor],
+        benchmark_fn,
         [input],
     )

--- a/benchmarks/python/test_pointwise_mul.py
+++ b/benchmarks/python/test_pointwise_mul.py
@@ -64,7 +64,7 @@ def test_pointwise_mul_baseline_benchmark(
     input = torch.randn(size, device="cuda", dtype=dtype)
 
     benchmark_fn = with_executor(executor, pointwise_mul_fwd_fn)
-    
+
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_reduction.py
+++ b/benchmarks/python/test_reduction.py
@@ -4,7 +4,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache
+from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 

--- a/benchmarks/python/test_reduction.py
+++ b/benchmarks/python/test_reduction.py
@@ -69,7 +69,7 @@ def test_reduction_baseline_benchmark(
     input = torch.randn(size, device="cuda", dtype=dtype)
 
     benchmark_fn = with_executor(executor, reduction_fwd_fn)
-    
+
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_reduction.py
+++ b/benchmarks/python/test_reduction.py
@@ -68,13 +68,11 @@ def test_reduction_baseline_benchmark(
         clear_dynamo_cache()
     input = torch.randn(size, device="cuda", dtype=dtype)
 
-    benchmark_fn = {
-        "eager": reduction_fwd_fn,
-        "torchcompile": torch.compile(reduction_fwd_fn),
-    }
+    benchmark_fn = with_executor(executor, reduction_fwd_fn)
+    
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,
-        benchmark_fn[executor],
+        benchmark_fn,
         [input, reduction_axis],
     )

--- a/benchmarks/python/test_reduction_epilogue.py
+++ b/benchmarks/python/test_reduction_epilogue.py
@@ -5,7 +5,7 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache
+from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 
@@ -84,13 +84,10 @@ def test_reduction_epilogue_baseline_benchmark(
     epilogue = torch.randn(size[reduction_axis - 1], device="cuda", dtype=dtype)
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
 
-    benchmark_fn = {
-        "eager": reduction_epilogue_fwd_fn,
-        "torchcompile": torch.compile(reduction_epilogue_fwd_fn),
-    }
+    benchmark_fn = with_executor(executor, reduction_epilogue_fwd_fn)
 
     run_benchmark(
         benchmark,
-        benchmark_fn[executor],
+        benchmark_fn,
         [x, epilogue, reduction_axis],
     )

--- a/benchmarks/python/test_rmsnorm_bwd.py
+++ b/benchmarks/python/test_rmsnorm_bwd.py
@@ -10,6 +10,7 @@ from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
 from .torch_ops import rmsnorm
 
+
 def rmsnorm_bwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,

--- a/benchmarks/python/test_rmsnorm_bwd.py
+++ b/benchmarks/python/test_rmsnorm_bwd.py
@@ -8,7 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_execu
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-from torch_ops import rmsnorm
+from .torch_ops import rmsnorm
 
 def rmsnorm_bwd_fusion(
     fd: FusionDefinition,

--- a/benchmarks/python/test_rmsnorm_fwd.py
+++ b/benchmarks/python/test_rmsnorm_fwd.py
@@ -10,6 +10,7 @@ from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
 from .torch_ops import rmsnorm
 
+
 def rmsnorm_fwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,

--- a/benchmarks/python/test_rmsnorm_fwd.py
+++ b/benchmarks/python/test_rmsnorm_fwd.py
@@ -4,11 +4,11 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache
+from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-
+from torch_ops import rmsnorm
 
 def rmsnorm_fwd_fusion(
     fd: FusionDefinition,
@@ -43,12 +43,6 @@ def rmsnorm_fwd_fusion(
 
     fd.add_output(T29)
     fd.add_output(T15)
-
-
-def rmsnorm_fwd_fn(inputs: list):  # [inputs, weights]
-    squared_mean = (inputs[0] ** 2).mean(1, keepdim=True)
-    rms_eps = torch.sqrt(squared_mean + 1e-5)
-    return inputs[1] * (inputs[0] / rms_eps)
 
 
 def rmsnorm_fwd_iobytes(size: tuple, dtype: torch.dtype):
@@ -100,14 +94,11 @@ def test_rmsnorm_fwd_baseline_benchmark(
     inputs = torch.randn(size, device="cuda", dtype=dtype)
     weights = torch.randn(size[1], device="cuda", dtype=dtype)
 
-    benchmark_fn = {
-        "eager": rmsnorm_fwd_fn,
-        "torchcompile": torch.compile(rmsnorm_fwd_fn),
-    }
+    benchmark_fn = with_executor(executor, rmsnorm)
     # Manually compute IOBytes: See PR #1725
     run_benchmark(
         benchmark,
-        benchmark_fn[executor],
+        benchmark_fn,
         [inputs, weights],
         iobytes=rmsnorm_fwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_rmsnorm_fwd.py
+++ b/benchmarks/python/test_rmsnorm_fwd.py
@@ -8,7 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-from torch_ops import rmsnorm
+from .torch_ops import rmsnorm
 
 def rmsnorm_fwd_fusion(
     fd: FusionDefinition,

--- a/benchmarks/python/test_scale_bias_relu_bwd.py
+++ b/benchmarks/python/test_scale_bias_relu_bwd.py
@@ -10,6 +10,7 @@ from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
 from .torch_ops import scale_bias_relu
 
+
 def sbr_bwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,

--- a/benchmarks/python/test_scale_bias_relu_bwd.py
+++ b/benchmarks/python/test_scale_bias_relu_bwd.py
@@ -4,11 +4,11 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-
+from torch_ops import scale_bias_relu
 
 def sbr_bwd_fusion(
     fd: FusionDefinition,
@@ -95,12 +95,10 @@ def test_sbr_bwd_baseline_benchmark(
     scale = torch.ones(size[-1], device="cuda", dtype=dtype)
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
 
-    def sbr_fwd():
-        return torch.nn.functional.relu(inputs * scale + bias)
-
     # Compile the fwd fn for torchcompile
-    fwd_fn = {"eager": sbr_fwd, "torchcompile": torch.compile(sbr_fwd)}
-    outputs = fwd_fn[executor]()
+    fwd_fn = with_executor(executor, scale_bias_relu)
+    fwd_inputs = [inputs, scale, bias]
+    outputs = fwd_fn(fwd_inputs)
 
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_scale_bias_relu_bwd.py
+++ b/benchmarks/python/test_scale_bias_relu_bwd.py
@@ -8,7 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_execu
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-from torch_ops import scale_bias_relu
+from .torch_ops import scale_bias_relu
 
 def sbr_bwd_fusion(
     fd: FusionDefinition,

--- a/benchmarks/python/test_scale_bias_relu_fwd.py
+++ b/benchmarks/python/test_scale_bias_relu_fwd.py
@@ -10,6 +10,7 @@ from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
 from .torch_ops import scale_bias_relu
 
+
 def sbr_fwd_fusion(
     fd: FusionDefinition,
     dtype: DataType,

--- a/benchmarks/python/test_scale_bias_relu_fwd.py
+++ b/benchmarks/python/test_scale_bias_relu_fwd.py
@@ -8,7 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-from torch_ops import scale_bias_relu
+from .torch_ops import scale_bias_relu
 
 def sbr_fwd_fusion(
     fd: FusionDefinition,
@@ -97,7 +97,7 @@ def test_sbr_fwd_baseline_benchmark(
 
     run_benchmark(
         benchmark,
-        benchmark_fn[executor],
+        benchmark_fn,
         [inputs, scale, bias],
         iobytes=sbr_fwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_scale_bias_relu_fwd.py
+++ b/benchmarks/python/test_scale_bias_relu_fwd.py
@@ -4,11 +4,11 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache
+from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-
+from torch_ops import scale_bias_relu
 
 def sbr_fwd_fusion(
     fd: FusionDefinition,
@@ -44,10 +44,6 @@ def sbr_fwd_fusion(
 
     fd.add_output(T23)
     fd.add_output(T25)
-
-
-def sbr_fwd_fn(inputs: list):  # [bias, scale, in_tensor]
-    return torch.nn.functional.relu(inputs[1] * inputs[2] + inputs[0])
 
 
 def sbr_fwd_iobytes(size: tuple, dtype: torch.dtype):
@@ -97,11 +93,11 @@ def test_sbr_fwd_baseline_benchmark(
     bias = torch.ones(size[-1], device="cuda", dtype=dtype)
     scale = torch.ones(size[-1], device="cuda", dtype=dtype)
 
-    benchmark_fn = {"eager": sbr_fwd_fn, "torchcompile": torch.compile(sbr_fwd_fn)}
+    benchmark_fn = with_executor(executor, scale_bias_relu)
 
     run_benchmark(
         benchmark,
         benchmark_fn[executor],
-        [bias, scale, inputs],
+        [inputs, scale, bias],
         iobytes=sbr_fwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_silu_mul_bwd.py
+++ b/benchmarks/python/test_silu_mul_bwd.py
@@ -4,11 +4,11 @@
 import pytest
 from nvfuser import FusionDefinition, DataType
 from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
-from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch
+from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-
+from torch_ops import silu_mul
 
 def silu_mul_bwd_fusion(fd: FusionDefinition, dtype: DataType):
     T0 = fd.define_tensor(
@@ -94,12 +94,11 @@ def test_silu_mul_bwd_baseline_benchmark(
     y = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
 
-    def silu_mul_fwd():
-        return torch.nn.functional.silu(x) * y
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = {"eager": silu_mul_fwd, "torchcompile": torch.compile(silu_mul_fwd)}
-    outputs = fwd_fn[executor]()
+    fwd_fn = with_executor(executor, scale_bias_relu)
+    fwd_inputs = [inputs, scale, bias]
+    outputs = fwd_fn(fwd_inputs)
 
     run_benchmark(
         benchmark,

--- a/benchmarks/python/test_silu_mul_bwd.py
+++ b/benchmarks/python/test_silu_mul_bwd.py
@@ -8,7 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_execu
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-from torch_ops import silu_mul
+from .torch_ops import silu_mul
 
 def silu_mul_bwd_fusion(fd: FusionDefinition, dtype: DataType):
     T0 = fd.define_tensor(
@@ -96,8 +96,8 @@ def test_silu_mul_bwd_baseline_benchmark(
 
 
     # Compile the fwd fn for torchcompile
-    fwd_fn = with_executor(executor, scale_bias_relu)
-    fwd_inputs = [inputs, scale, bias]
+    fwd_fn = with_executor(executor, silu_mul)
+    fwd_inputs = [x, y]
     outputs = fwd_fn(fwd_inputs)
 
     run_benchmark(

--- a/benchmarks/python/test_silu_mul_bwd.py
+++ b/benchmarks/python/test_silu_mul_bwd.py
@@ -10,6 +10,7 @@ from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
 from .torch_ops import silu_mul
 
+
 def silu_mul_bwd_fusion(fd: FusionDefinition, dtype: DataType):
     T0 = fd.define_tensor(
         shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False
@@ -93,7 +94,6 @@ def test_silu_mul_bwd_baseline_benchmark(
     x = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     y = torch.randn(*size, device="cuda", dtype=dtype, requires_grad=True)
     grads = torch.randn(*size, device="cuda", dtype=dtype)
-
 
     # Compile the fwd fn for torchcompile
     fwd_fn = with_executor(executor, silu_mul)

--- a/benchmarks/python/test_silu_mul_fwd.py
+++ b/benchmarks/python/test_silu_mul_fwd.py
@@ -31,10 +31,6 @@ def silu_mul_fwd_fusion(fd: FusionDefinition, dtype: DataType):
     fd.add_output(T8)
 
 
-def silu_mul_fwd_fn(inputs: list):  # [in_tensor1, in_tensor_2]
-    return torch.nn.functional.silu(inputs[0]) * inputs[1]
-
-
 @pytest.mark.parametrize("size", generate_input_sizes(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_silu_mul_fwd_nvf_benchmark(
@@ -49,7 +45,7 @@ def test_silu_mul_fwd_nvf_benchmark(
     with FusionDefinition() as fd:
         silu_mul_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype))
     if not disable_validation:
-        eager_output = silu_mul_fwd_fn(inputs)
+        eager_output = silu_mul(inputs)
         fd.validate(inputs, [eager_output])
 
     if not disable_benchmarking:

--- a/benchmarks/python/test_silu_mul_fwd.py
+++ b/benchmarks/python/test_silu_mul_fwd.py
@@ -7,7 +7,7 @@ from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
-from torch_ops import silu_mul
+from .torch_ops import silu_mul
 
 def silu_mul_fwd_fusion(fd: FusionDefinition, dtype: DataType):
     T0 = fd.define_tensor(

--- a/benchmarks/python/test_silu_mul_fwd.py
+++ b/benchmarks/python/test_silu_mul_fwd.py
@@ -9,6 +9,7 @@ import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 from .torch_ops import silu_mul
 
+
 def silu_mul_fwd_fusion(fd: FusionDefinition, dtype: DataType):
     T0 = fd.define_tensor(
         shape=[-1, -1], contiguity=[True, True], dtype=dtype, is_cpu=False

--- a/benchmarks/python/test_softmax_bwd.py
+++ b/benchmarks/python/test_softmax_bwd.py
@@ -8,7 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, unary_bwd_torch, with_execu
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES
 import numpy as np
-from torch_ops import softmax
+from .torch_ops import softmax
 
 def softmax_bwd_fusion(
     fd: FusionDefinition, dtype: DataType, reduction_axis: int

--- a/benchmarks/python/test_softmax_bwd.py
+++ b/benchmarks/python/test_softmax_bwd.py
@@ -10,6 +10,7 @@ from .global_params import generate_input_sizes, FLOAT_DTYPES
 import numpy as np
 from .torch_ops import softmax
 
+
 def softmax_bwd_fusion(
     fd: FusionDefinition, dtype: DataType, reduction_axis: int
 ) -> None:

--- a/benchmarks/python/test_softmax_fwd.py
+++ b/benchmarks/python/test_softmax_fwd.py
@@ -10,6 +10,7 @@ from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
 from .torch_ops import softmax
 
+
 def softmax_fwd_fusion(
     fd: FusionDefinition, dtype: DataType, reduction_axis: int
 ) -> None:

--- a/benchmarks/python/test_softmax_fwd.py
+++ b/benchmarks/python/test_softmax_fwd.py
@@ -8,7 +8,7 @@ from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
 import numpy as np
-from torch_ops import softmax
+from .torch_ops import softmax
 
 def softmax_fwd_fusion(
     fd: FusionDefinition, dtype: DataType, reduction_axis: int
@@ -95,7 +95,7 @@ def test_softmax_fwd_baseline_benchmark(
     benchmark_fn = with_executor(executor, softmax)
     run_benchmark(
         benchmark,
-        benchmark_fn[executor],
+        benchmark_fn,
         [inputs, reduction_axis],
         iobytes=softmax_fwd_iobytes(size, dtype),
     )

--- a/benchmarks/python/test_softmax_fwd.py
+++ b/benchmarks/python/test_softmax_fwd.py
@@ -70,7 +70,7 @@ def test_softmax_fwd_nvf_benchmark(
         softmax_fwd_fusion(fd, torch_dtype_to_nvfuser_dtype(dtype), reduction_axis)
 
     if not disable_validation:
-        eager_output = softmax_fwd_fn([inputs[0], reduction_axis])
+        eager_output = softmax([inputs[0], reduction_axis])
         fd.validate(inputs, [eager_output])
 
     if not disable_benchmarking:

--- a/benchmarks/python/test_transpose.py
+++ b/benchmarks/python/test_transpose.py
@@ -3,10 +3,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, with_executor
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache
 import torch
-from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
+from .global_params import (
+    generate_input_sizes,
+    FLOAT_DTYPES,
+    PROMOTE_DTYPES,
+    with_executor,
+)
 
 
 def transpose_fusion(

--- a/benchmarks/python/test_transpose.py
+++ b/benchmarks/python/test_transpose.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype, with_executor
 from .core import run_benchmark, clear_dynamo_cache
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES
@@ -90,14 +90,11 @@ def test_transpose_baseline_benchmark(
     input1 = torch.randn(size, device="cuda", dtype=dtype)
     input2 = torch.randn(size, device="cuda", dtype=dtype)
 
-    benchmark_fn = {
-        "eager": transpose_fwd_fn,
-        "torchcompile": torch.compile(transpose_fwd_fn),
-    }
+    benchmark_fn = with_executor(executor, transpose_fwd_fn)
 
     # Inputs and outputs are same as nvFuser, no need for manual IOByte computation
     run_benchmark(
         benchmark,
-        benchmark_fn[executor],
+        benchmark_fn,
         [input1, input2, axes[0], axes[1]],
     )

--- a/benchmarks/python/torch_ops.py
+++ b/benchmarks/python/torch_ops.py
@@ -5,6 +5,7 @@
 import torch
 import torch.nn.functional as F
 
+
 def dropout_layernorm(inputs: list):
     inp1, inp2, weights, bias, dropout_p = inputs
     return F.layer_norm(
@@ -14,15 +15,18 @@ def dropout_layernorm(inputs: list):
         bias=bias,
     )
 
+
 def dropout_rmsnorm(inputs: list):
     inp1, inp2, weights, dropout_p = inputs
     x = inp2 + F.dropout(inp1, p=dropout_p)
     output = weights * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-5)
     return output
 
+
 def gelu(inputs: list):
     inp, bias = inputs
     return F.gelu(inp + bias, approximate="tanh")
+
 
 def huggingface_attn(inputs: list):
     # Reference implementation in Thunder: https://github.com/Lightning-AI/lightning-thunder/blob/888b46324462fba70f93d5017bc0d99025f05091/thunder/tests/hf_bart_self_attn.py#L73-L83
@@ -33,6 +37,7 @@ def huggingface_attn(inputs: list):
     output = F.dropout(attn, p=dropout_p)
     return output
 
+
 def layernorm(inputs: list):
     inp, weights, bias = inputs
     return F.layer_norm(
@@ -41,7 +46,8 @@ def layernorm(inputs: list):
         weight=weights,
         bias=bias,
     )
-    
+
+
 def nanogpt_attn(inputs: list):
     # Reference implementation from Thunder: https://github.com/Lightning-AI/lightning-thunder/blob/d3da8517bff02a913fd149b4d6559f6b5a4c6c7f/thunder/tests/nanogpt_model.py#L102-L106
     inp, bias, size, dropout_p = inputs
@@ -53,6 +59,7 @@ def nanogpt_attn(inputs: list):
     output = F.dropout(attn, p=dropout_p)
     return output
 
+
 def rmsnorm(inputs: list):
     inp, weights = inputs
     squared_mean = (inp**2).mean(1, keepdim=True)
@@ -60,13 +67,16 @@ def rmsnorm(inputs: list):
     output = weights * (inp / rms_eps)
     return output
 
+
 def scale_bias_relu(inputs: list):
     inp, scale, bias = inputs
     return F.relu(inp * scale + bias)
 
+
 def silu_mul(inputs: list):
     x, y = inputs
     return F.silu(x) * y
+
 
 def softmax(inputs: list):
     inp, reduction_axis = inputs

--- a/benchmarks/python/torch_ops.py
+++ b/benchmarks/python/torch_ops.py
@@ -1,0 +1,69 @@
+import torch
+import torch.nn.functional as F
+
+def dropout_layernorm(inputs: list):
+    inp1, inp2, weights, bias, dropout_p = inputs
+    return F.layer_norm(
+        inp2 + torch.nn.functional.dropout(inp1, p=dropout_p),
+        normalized_shape=inp1.shape[1:],
+        weight=weights,
+        bias=bias,
+    )
+
+def dropout_rmsnorm(inputs: list):
+    inp1, inp2, weights, dropout_p = inputs
+    x = in2 + F.dropout(inp1, p=dropout_p)
+    output = weights * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-5)
+    return output
+
+def gelu(inputs: list):
+    inp, bias = inputs
+    return F.gelu(inp + bias, approximate="tanh")
+
+def huggingface_attn(inputs: list):
+    # Reference implementation in Thunder: https://github.com/Lightning-AI/lightning-thunder/blob/888b46324462fba70f93d5017bc0d99025f05091/thunder/tests/hf_bart_self_attn.py#L73-L83
+    inp, attention_mask, size, dropout_p = inputs
+    batch_size, seq_len, nh, n_embd = size
+    attn = (inp + attention_mask).view(batch_size * nh, seq_len, seq_len)
+    attn = F.softmax(attn, dim=-1)
+    output = F.dropout(attn, p=dropout_p)
+    return output
+
+def layernorm(inputs: list):
+    inp, weight, bias = inputs
+    return F.layer_norm(
+        inp,
+        inp.shape[1:],
+        weight=weights,
+        bias=bias,
+    )
+    
+def nanogpt_attn(inputs: list):
+    # Reference implementation from Thunder: https://github.com/Lightning-AI/lightning-thunder/blob/d3da8517bff02a913fd149b4d6559f6b5a4c6c7f/thunder/tests/nanogpt_model.py#L102-L106
+    inp, bias, size, dropout_p = inputs
+    batch_size, seq_len, nh, n_embd = size
+    hs = n_embd // nh
+    attn = inp / (hs**0.5)
+    attn = attn.masked_fill(bias[:, :, :seq_len, :seq_len] == 0, float("-inf"))
+    attn = F.softmax(attn, dim=-1)
+    output = F.dropout(attn, p=dropout_p)
+    return output
+
+def rmsnorm(inputs: list):
+    inp, weights = inputs
+    squared_mean = (inp**2).mean(1, keepdim=True)
+    rms_eps = torch.sqrt(squared_mean + eps)
+    output = weights * (inp / rms_eps)
+    return output
+
+def scale_bias_relu(inputs: list):
+    inp, scale, bias = inputs
+    return F.relu(inp * scale + bias)
+
+def silu_mul(inputs: list):
+    x, y = inputs
+    return F.silu(x) * y
+
+def softmax(inputs: list):
+    inp, reduction_axis = inputs
+    return F.softmax(inp, dim=reduction_axis)

--- a/benchmarks/python/torch_ops.py
+++ b/benchmarks/python/torch_ops.py
@@ -12,7 +12,7 @@ def dropout_layernorm(inputs: list):
 
 def dropout_rmsnorm(inputs: list):
     inp1, inp2, weights, dropout_p = inputs
-    x = in2 + F.dropout(inp1, p=dropout_p)
+    x = inp2 + F.dropout(inp1, p=dropout_p)
     output = weights * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-5)
     return output
 
@@ -30,7 +30,7 @@ def huggingface_attn(inputs: list):
     return output
 
 def layernorm(inputs: list):
-    inp, weight, bias = inputs
+    inp, weights, bias = inputs
     return F.layer_norm(
         inp,
         inp.shape[1:],
@@ -52,7 +52,7 @@ def nanogpt_attn(inputs: list):
 def rmsnorm(inputs: list):
     inp, weights = inputs
     squared_mean = (inp**2).mean(1, keepdim=True)
-    rms_eps = torch.sqrt(squared_mean + eps)
+    rms_eps = torch.sqrt(squared_mean + 1e-5)
     output = weights * (inp / rms_eps)
     return output
 

--- a/benchmarks/python/torch_ops.py
+++ b/benchmarks/python/torch_ops.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import torch
 import torch.nn.functional as F
 

--- a/benchmarks/python/torch_ops.py
+++ b/benchmarks/python/torch_ops.py
@@ -19,7 +19,7 @@ def dropout_layernorm(inputs: list):
 def dropout_rmsnorm(inputs: list):
     inp1, inp2, weights, dropout_p = inputs
     x = inp2 + F.dropout(inp1, p=dropout_p)
-    output = weights * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-5)
+    output = weights * x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-5)
     return output
 
 


### PR DESCRIPTION
This PR restructures the baseline benchmarks:
1. use `with_executor` to centralize executor definitions. Thanks to @jacobhinkle for this suggestion.
2. Move torch definitions to a separate file for reuse between forward and backward benchmark files.