### PR TITLE
Fix memory access error

### DIFF
--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -443,6 +443,7 @@ class VectorizationCalculator {
       IterDomain* id = tv->getMaybeAllocationDomain().at(i);
       if (id->isBroadcast()) {
         sizes.push_back(1);
+        concrete_contig.push_back(false);
         continue;
       }
       if (id->isReduction()) {
@@ -464,7 +465,7 @@ class VectorizationCalculator {
     for (int64_t i = (int64_t)(sizes.size()) - 1l; i >= 0; --i) {
       strides[(size_t)i] = sizes[(size_t)i] == 1 ? 0 : stride;
       stride *= sizes[(size_t)i];
-      if (!concrete_contig[(size_t)i]) {
+      if (!concrete_contig.at((size_t)i)) {
         // pad non-concrete dims to next odd value
         stride |= 1l;
       }


### PR DESCRIPTION
In the current main, `concrete_contig[(size_t)i]` can be a out-of-bound access. Changed it to `.at`, the following test results in an error as shown below:

```
./bin/test_matmul --gtest_filter='*CombineMulSumAsMmaTest.AmpereMulSumToMatmul_MultipleBroadcasts'
C++ exception with description "vector<bool>::_M_range_check: __n (which is 2) >= this->size() (which is 2)" thrown in the test body.
```

I suspect it's missing `push_back(false)` when the ID is broadcast, but not entirely sure.