### PR TITLE
More AlmostExact mappings

### DIFF
--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -383,12 +383,11 @@ std::vector<std::vector<Val*>> getTriviallyMappedIds(Expr* expr) {
       mapped_ids.push_back({merge->inner(), merge->out()});
     }
   } else if (auto split = dynamic_cast<Split*>(expr)) {
-    if (split->factor()->isOneInt()) {
-      if (split->innerSplit()) {
-        mapped_ids.push_back({split->in(), split->outer()});
-      } else {
-        mapped_ids.push_back({split->in(), split->inner()});
-      }
+    if (split->inner()->extent()->isOneInt()) {
+      mapped_ids.push_back({split->in(), split->outer()});
+    }
+    if (split->outer()->extent()->isOneInt()) {
+      mapped_ids.push_back({split->in(), split->inner()});
     }
   } else if (auto swizzle = dynamic_cast<Swizzle2D*>(expr)) {
     if (swizzle->swizzleType() == Swizzle2DType::NoSwizzle ||

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -390,26 +390,29 @@ std::vector<std::vector<Val*>> getTriviallyMappedIds(Expr* expr) {
         mapped_ids.push_back({split->in(), split->inner()});
       }
     } else {
-      // Even when the factor is not known to be 1, as long as the
-      // input and output have the same extent, they should be
-      // mapped. This happens, for example, split 32 by 32 -> 1, 32.
-      if (split->outer()->extent()->sameAs(split->in()->extent())) {
-        // In and outer have the same extent. They must be non-one and
-        // the inner must be one, or they must be one.
-        NVF_ERROR(
-            split->inner()->extent()->isOneInt() ||
-                split->outer()->extent()->isOneInt(),
-            "Unexpected split: ",
-            split->toString());
-        mapped_ids.push_back({split->in(), split->outer()});
-      }
-      if (split->inner()->extent()->sameAs(split->in()->extent())) {
-        NVF_ERROR(
-            split->inner()->extent()->isOneInt() ||
-                split->outer()->extent()->isOneInt(),
-            "Unexpected split: ",
-            split->toString());
-        mapped_ids.push_back({split->in(), split->inner()});
+      // Rare, but don't want to deal with zero-dim IDs
+      if (!split->in()->extent()->isZeroInt()) {
+        // Even when the factor is not known to be 1, as long as the
+        // input and output have the same extent, they should be
+        // mapped. This happens, for example, split 32 by 32 -> 1, 32.
+        if (split->outer()->extent()->sameAs(split->in()->extent())) {
+          // In and outer have the same extent. They must be non-one and
+          // the inner must be one, or they must be one.
+          NVF_ERROR(
+              split->inner()->extent()->isOneInt() ||
+                  split->outer()->extent()->isOneInt(),
+              "Unexpected split: ",
+              split->toString());
+          mapped_ids.push_back({split->in(), split->outer()});
+        }
+        if (split->inner()->extent()->sameAs(split->in()->extent())) {
+          NVF_ERROR(
+              split->inner()->extent()->isOneInt() ||
+                  split->outer()->extent()->isOneInt(),
+              "Unexpected split: ",
+              split->toString());
+          mapped_ids.push_back({split->in(), split->inner()});
+        }
       }
     }
   } else if (auto swizzle = dynamic_cast<Swizzle2D*>(expr)) {

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -394,11 +394,21 @@ std::vector<std::vector<Val*>> getTriviallyMappedIds(Expr* expr) {
       // input and output have the same extent, they should be
       // mapped. This happens, for example, split 32 by 32 -> 1, 32.
       if (split->outer()->extent()->sameAs(split->in()->extent())) {
-        NVF_ERROR(split->inner()->extent()->isOneInt());
+        // In and outer have the same extent. They must be non-one and
+        // the inner must be one, or they must be one.
+        NVF_ERROR(
+            split->inner()->extent()->isOneInt() ||
+                split->outer()->extent()->isOneInt(),
+            "Unexpected split: ",
+            split->toString());
         mapped_ids.push_back({split->in(), split->outer()});
       }
       if (split->inner()->extent()->sameAs(split->in()->extent())) {
-        NVF_ERROR(split->outer()->extent()->isOneInt())
+        NVF_ERROR(
+            split->inner()->extent()->isOneInt() ||
+                split->outer()->extent()->isOneInt(),
+            "Unexpected split: ",
+            split->toString());
         mapped_ids.push_back({split->in(), split->inner()});
       }
     }

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -1518,8 +1518,10 @@ TEST_F(IndexingTest, AlmostExactTraversalWithNonOneBroadcast) {
 
       // iS20 is the only ID to index.
       // T3's iS8 is mapped with id15. The AlmostExact graph maps iS15
-      // with iS18 and iS20.
+      // with iS18 but not iS20 since the extent of iS18 is different
+      // from that of iS20.
       std::vector<Val*> loop_indices = getLoopIndices(consumer_tv, indexer_);
+      TensorView* tv2 = tv;
       TensorView* tv3 = consumer_tv;
       IterDomain* id11 = tv3->axis(1)->definition()->input(0)->as<IterDomain>();
       IterDomain* id9 = id11->definition()->input(1)->as<IterDomain>();
@@ -1527,7 +1529,9 @@ TEST_F(IndexingTest, AlmostExactTraversalWithNonOneBroadcast) {
           mulExpr(loop_indices.at(1), tv3->axis(2)->extent()),
           loop_indices.at(2));
       Val* id8_idx = divExpr(id11_idx, id9->extent());
-      return id8_idx;
+      IterDomain* id20 = tv2->axis(2);
+      Val* id20_idx = modExpr(id8_idx, id20->extent());
+      return id20_idx;
     }
   };
 

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -1495,8 +1495,31 @@ TEST_F(IndexingTest, AlmostExactTraversalWithNonOneBroadcast) {
       if (tv->name() != 2 || as_consumer) {
         return nullptr;
       }
+
+      // T2_l_float[ iS14{( ceilDiv(i0, 3) )}, iS19{1}, iS20{5}, bS17{4} ]
+      // ca_pos( 1 ) logical domain : (iS3{i0}, bS4{1}) contiguity: t n
+      //  Split: iS3{i0} by factor 3 -> iS14{( ceilDiv(i0, 3) )}, iS15{3}
+      //  Split: bS4{1} by factor 4 -> bS16{1}, bS17{4}
+      //  Merge: iS15{3} and bS16{1} -> iS18{3}
+      //  Split: iS18{3} by factor 5 -> iS19{1}, iS20{5}
+      // loop domain : (iS14{( ceilDiv(i0, 3) )}, iS19{1}, iS20{5}, bS17{4})
+
+      // T3_g_float[ iS7{( ceilDiv(i2, 3) )}, iS12{( ceilDiv(( ( ceilDiv(i3, 4)
+      // ) * 3 ), 5) )}, iS13{5}, iS10{4} ] ca_pos( 1 ) produce_pos( 1 )
+      //  logical domain : (iS5{i2}, iS6{i3})
+      //  contiguity: t t
+      //   Split: iS5{i2} by factor 3 -> iS7{( ceilDiv(i2, 3) )}, iS8{3}
+      //   Split: iS6{i3} by factor 4 -> iS9{( ceilDiv(i3, 4) )}, iS10{4}
+      //   Merge: iS8{3} and iS9{( ceilDiv(i3, 4) )} -> iS11{( ( ceilDiv(i3, 4)
+      //   ) * 3 )} Split: iS11{( ( ceilDiv(i3, 4) ) * 3 )} by factor 5 ->
+      //   iS12{( ceilDiv(( ( ceilDiv(i3, 4) ) * 3 ), 5) )}, iS13{5}
+      //  loop domain : (iS7{( ceilDiv(i2, 3) )}, iS12{( ceilDiv(( ( ceilDiv(i3,
+      //  4) ) * 3 ), 5) )}, iS13{5}, iS10{4})
+
+      // iS20 is the only ID to index.
+      // T3's iS8 is mapped with id15. The AlmostExact graph maps iS15
+      // with iS18 and iS20.
       std::vector<Val*> loop_indices = getLoopIndices(consumer_tv, indexer_);
-      TensorView* tv2 = tv;
       TensorView* tv3 = consumer_tv;
       IterDomain* id11 = tv3->axis(1)->definition()->input(0)->as<IterDomain>();
       IterDomain* id9 = id11->definition()->input(1)->as<IterDomain>();
@@ -1504,11 +1527,7 @@ TEST_F(IndexingTest, AlmostExactTraversalWithNonOneBroadcast) {
           mulExpr(loop_indices.at(1), tv3->axis(2)->extent()),
           loop_indices.at(2));
       Val* id8_idx = divExpr(id11_idx, id9->extent());
-      // id8 is mapped with id15, which should also be mapped with
-      // id18
-      IterDomain* id20 = tv2->axis(2);
-      Val* id20_idx = modExpr(id8_idx, id20->extent());
-      return id20_idx;
+      return id8_idx;
     }
   };
 


### PR DESCRIPTION
Just found that we can extend the AlmostExact graph by considering not just the factor of a split but its output extents. For example, splitting of an iter domain of extent 2 by a factor of 2 results in generating iter domains of extents 1 and 2, respectively. Previously, this didn't trigger any mapping, but it should be valid to consider the input ID and the inner ID mapped in the AlmostExact graph.

Codediff check shows a bunch of differences with matmul tests. As far as I see, they are just negligible changes like:

```
1: MatmulTest.AmpereMatmulSmemEpiloguePromotionRequiredA100
  Kernel 1 CUDA PTX    ceed503d Diff c5a95cab -5 +5index type: int registers: 116 gmem: 3 static smem: 0 stack frame: 0 spill stores: 0 spill loads: 0 cmem[0]: 440 cmem[1]: 0 cmem[2]: 0 cmem[3]: 0 cmem[4]: 24
--- ceed503d

+++ c5a95cab

@@ -92,21 +92,21 @@

   unsigned i43;
   i43 = (i34 + i35) + i36;
   nvfuser_index_t i44;
   i44 = (2 + i31) + i32;
   nvfuser_index_t i45;
-  i45 = ((nvfuser_index_t)threadIdx.x) / 4;
+  i45 = ((nvfuser_index_t)threadIdx.x) % 4;
   nvfuser_index_t i46;
-  i46 = ((nvfuser_index_t)threadIdx.x) % 4;
+  i46 = ((nvfuser_index_t)threadIdx.x) / 4;
   nvfuser_index_t i47;
   i47 = 32 * ((nvfuser_index_t)threadIdx.y);
   nvfuser_index_t i48;
-  i48 = ((((1536 * (i45 / 8)) + (96 * i45)) + (2 * (i46 % 4))) + i47) + i13;
+  i48 = (((96 * i46) + (2 * (i45 % 4))) + i47) + i13;
   nvfuser_index_t i49;
-  i49 = i46 / 4;
+  i49 = i45 / 4;
   nvfuser_index_t i50;
-  i50 = i45 % 4;
+  i50 = i46 % 4;
   nvfuser_index_t i51;
   i51 = ((nvfuser_index_t)threadIdx.x) + i47;
   nvfuser_index_t i52;
   i52 = i51 / 24;
   nvfuser_index_t i53;
```
