### PR TITLE
Enable call/caller graphs in Doxygen

### DIFF
--- a/csrc/docs/fuser.doxygen
+++ b/csrc/docs/fuser.doxygen
@@ -31,7 +31,7 @@ DOXYFILE_ENCODING      = UTF-8
 # project for which the documentation is generated. This name is used in the
 # title of most generated pages and in a few other places.
 
-PROJECT_NAME           = "PyTorch JIT Fuser"
+PROJECT_NAME           = "nvFuser"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -453,7 +453,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,
@@ -2237,7 +2237,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: NO.
 
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of
@@ -2354,7 +2354,7 @@ INCLUDED_BY_GRAPH      = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALL_GRAPH             = NO
+CALL_GRAPH             = YES
 
 # If the CALLER_GRAPH tag is set to YES then doxygen will generate a caller
 # dependency graph for every global function or class method.
@@ -2366,7 +2366,7 @@ CALL_GRAPH             = NO
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALLER_GRAPH           = NO
+CALLER_GRAPH           = YES
 
 # If the GRAPHICAL_HIERARCHY tag is set to YES then doxygen will graphical
 # hierarchy of all classes instead of a textual one.
@@ -2409,7 +2409,7 @@ DOT_IMAGE_FORMAT       = png
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-INTERACTIVE_SVG        = NO
+INTERACTIVE_SVG        = YES
 
 # The DOT_PATH tag can be used to specify the path where the dot tool can be
 # found. If left blank, it is assumed the dot tool can be found in the path.


### PR DESCRIPTION
This changes our doxygen config to assume we have the `dot` executable in our `$PATH`. This enables a number of diagrams to be built by default by doxygen. This PR also enables some non-default graphs: the call graph which shows functions called by each function and the caller graph which shows all other functions that call the function at hand. If you make a change to a function and want to see the potential impact, it is useful to inspect the caller graph.

## Example: `nvfuser::isResharding` 

Call graph:
![image](https://github.com/user-attachments/assets/057d64a5-813a-43ba-ad23-756376158b09)

Caller graph:
![image](https://github.com/user-attachments/assets/b471c12d-47f8-4f7e-b96f-8d326856372d)
