### PR TITLE
Remove an unnecessary filter

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -106,7 +106,7 @@ std::pair<std::vector<IterDomain*>, std::vector<IterDomain*>> getShardingChanges
 
 bool isSharded(const TensorView* tv) {
   bool is_sharded = false;
-  for (IterDomain* id : TensorDomain::noReductions(tv->getLoopDomain())) {
+  for (IterDomain* id : tv->getLoopDomain()) {
     if (!id->isDeviceDim()) {
       continue;
     }

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -45,6 +45,22 @@ TEST_F(ShardingTest, IsSharded) {
   EXPECT_ANY_THROW(isSharded(c)) << "Multiple DIDx";
 }
 
+TEST_F(ShardingTest, ReductionShouldNotBeSharded) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  TensorView* x = makeSymbolicTensor(2);
+  TensorView* y = sum(x, {0});
+
+  x->axis(0)->parallelize(ParallelType::DIDx);
+  // y->axis(0) is a reduction dimension and shouldn't be sharded. Doing so
+  // leads to a multi-DIDx exception.
+  y->axis(0)->parallelize(ParallelType::DIDx);
+  y->axis(1)->parallelize(ParallelType::DIDx);
+
+  EXPECT_ANY_THROW(isSharded(y)) << "Multiple DIDx";
+}
+
 TEST_F(ShardingTest, PropagateSharding) {
   Fusion fusion;
   FusionGuard fg(&fusion);


### PR DESCRIPTION
We used to put DID on reduction IterDomains and therefore needed noReductions. 