### PR TITLE
Remove HopperMultipleMatmulScheduler::cached_outputs_

### DIFF
--- a/csrc/scheduler/hopper_multi_matmul.h
+++ b/csrc/scheduler/hopper_multi_matmul.h
@@ -184,8 +184,6 @@ class HopperMultipleMatmulScheduler : public MultipleMatmulScheduler {
   MatmulDimRole findMatmulDimRole(IterDomain* id);
 
  private:
-  std::vector<std::pair<TensorView*, TensorView*>> cached_outputs_;
-
   std::vector<ValGroup> canonical_dim_ordering_;
 
   std::vector<TensorView*> acw_smems_, bcw_smems_, acrs_, bcrs_, abs_, bbs_,


### PR DESCRIPTION
Instead of tracking these pairs of cache tensors and outputs, this PR just uses `fusion_->outputs()`. This change is a response to a tricky issue I found when translating matmul patterns whose output is a `dc` tensor. In such case if the translation replaces the output tensor, it will modify `cached_outputs_` leading to confusion. I'm removing this attribute to avoid this situation and because it doesn't offer us much convenience anyway.