### PR TITLE
NVFUSER_DUMP=fusion_ir_preseg prints out transforms.

### DIFF
--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -85,7 +85,7 @@ FusionKernelRuntime::FusionKernelRuntime(
     if (!communicator.is_available() || communicator.local_rank() == 0) {
       debug() << "Fusion IR after pre-segmenter optimization passes:"
               << std::endl;
-      fusion->printMath();
+      fusion->print();
     }
   }
 


### PR DESCRIPTION
Preseg passes (i.e. MarkAliasesPrepare and AllocationDomainInference) take care of allocation domain propagation. I found it more useful to print out the transforms as well as the math.