### PR TITLE
More refactor on `CloneTmaCircularBufferLoopAndInsertSync`

### DIFF
--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -703,155 +703,72 @@ class CloneTmaCircularBufferLoopAndInsertSync
           NVF_ERROR(circular_buffer_tv != nullptr);
           return out_tv == circular_buffer_tv;
         });
+    bool is_cp_async_bulk_expr = ir_utils::isCpAsyncBulk(expr);
 
     updateRawMbarrierToWaitMap(expr);
     updateWarMbarrierToWaitMap(expr);
     insertMBarrierWaitBeforeFirstRead();
 
-    // Handle Short-Circuit conditions
-    switch (loop_type_) {
-      case CircularBufferLoopStage::Prolog: {
-        // Short-circuit: skip expression if it is not circular buffer load
-        // expression.
-        if (!is_circular_buffer_load_expr) {
-          goto handle_war;
-        }
+    // If expr is a TMA circular buffer load, then special handling it.
+    // Otherwise just add it to the cloned loop body if needed.
+    if (hasCircularBufferLoad() && is_circular_buffer_load_expr &&
+        is_cp_async_bulk_expr) {
+      // TMA circular buffer load expression
+      auto ldst = dynamic_cast<LoadStoreOp*>(expr);
+      NVF_ERROR(ldst != nullptr);
 
-        // Short-circuit: There can be circular buffered loads without
-        // cpAsyncBulk load expressions.
-        if (!ir_utils::isCpAsyncBulkLoad(expr)) {
-          for_loop_stack_.back()->body().push_back(expr);
-          goto handle_war;
-        }
-        break;
+      // We always clone expr. The reason for cloning is because, one loop
+      // before this pass will be cloned as multiple loops in this pass. Cloning
+      // makes sure that different loop stage has different LoadStoreOp* for
+      // the same operation, so that they can be handled differently in the
+      // later passes. Depending on the setup of circular buffer options, and
+      // the current loop stage, cloning may or may not be strictly necessary,
+      // but it is not harmful to just clone it.
+      Expr* new_ldst =
+          IrBuilder::create<LoadStoreOp>(
+              ldst->opType(), ldst->out(), ldst->in(), ldst->cacheOp())
+              ->withPredicate(ldst->predicate());
+
+      // Create mbarrier_arrive_tx_. Note that mbarrier_arrive_tx_ is created
+      // here when we are processing a cpAsyncBulk load expression, but added to
+      // the cloned loop body by addTmaLoadBlock either here or later when we
+      // are exiting the last cloned scope containing the cpAsyncBulk load
+      // expression.
+      NVF_ERROR(
+          mbarrier_arrive_tx_ == nullptr,
+          "There is a single mbarrier_arrive_tx_ for each cpAsyncBulk load expression. ",
+          "A mbarrier_arrive_tx_ for another cpAsyncBulk load expression should not be active.");
+      mbarrier_arrive_tx_ = createRawMbarrierArriveExpectTx(ldst);
+      // Register mbarrier object to be used with the cloned LoadStoreOp
+      NVF_ERROR(mbarrier_arrive_tx_->mbarrier()->isA<kir::TensorIndex>());
+      GpuLower::current()->tmaCircularBufferInfo().recordTensorIndex(
+          new_ldst, mbarrier_arrive_tx_->mbarrier()->as<kir::TensorIndex>());
+
+      // If last cloned scope is the cloned_top_level_loop body, this means that
+      // we only have a single TMA instruction in the top level loop for each
+      // iteration, then add mbarrier::arriveExpectTx and new loadStoreOp.
+      if (for_loop_stack_.size() == 1) {
+        NVF_ERROR(for_loop_stack_.front() == cloned_top_level_loop_);
+        addTmaLoadBlock(new_ldst);
+      } else {
+        // Otherwise, in the top-level loop, there is a nested for-loop that
+        // issues multiple TMA instructions, and right now, we are in that
+        // nested for-loop and handling the cpAsyncBulk in it. In such case, we
+        // should wait until we return to top-level for loop and add the
+        // mbarrier::arriveExpectTx and new loadStoreOp there.
+        for_loop_stack_.back()->body().push_back(new_ldst);
       }
-      case CircularBufferLoopStage::Main:
-      case CircularBufferLoopStage::Epilog: {
-        // Short-circuit: Add expression if not circular-buffered load store
-        // operation.
-        if (!is_circular_buffer_load_expr || !ir_utils::isCpAsyncBulk(expr)) {
-          for_loop_stack_.back()->body().push_back(expr);
-          goto handle_war;
-        }
-        break;
-      }
-      default: {
-        NVF_ERROR(false, "Unsupported loop mode, got: ", loop_type_);
-      }
+    } else if (
+        (is_circular_buffer_load_expr && hasCircularBufferLoad() &&
+         !is_cp_async_bulk_expr) ||
+        (!is_circular_buffer_load_expr && hasCircularBufferConsume())) {
+      // For non-TMA circular buffer loads, and for computes, we just add it to
+      // the cloned loop body.
+      for_loop_stack_.back()->body().push_back(expr);
     }
 
-    // Handle cpAsyncBulk expression with circular buffered TensorView output.
-    switch (loop_type_) {
-      case CircularBufferLoopStage::Prolog: {
-        handlePrologueLoop(expr);
-        break;
-      }
-      case CircularBufferLoopStage::Main: {
-        handleMainLoop(expr);
-        break;
-      }
-      case CircularBufferLoopStage::Epilog: {
-        break;
-      }
-      default: {
-        NVF_ERROR(false, "Unsupported loop mode, got: ", loop_type_);
-      }
-    }
-
-  handle_war:
     updateWarMbarrierUseMap(expr);
     insertWarMBarrierArriveAfterLastRead();
-  }
-
-  // Replace cpAsyncBulk type LoadStoreOp with:
-  //   if (warp_id == 0 && electSync()()) {
-  //     mbarrier::arriveExpectTx(mbarrier[loop_index], expected_bytes);
-  //     for (...) {
-  //       cpAsyncBulk(mbarriers[loop_index], ...);
-  //     }
-  //   }
-  // }
-  void handlePrologueLoop(Expr* expr) {
-    NVF_ERROR(expr != nullptr);
-
-    // Skip if not LoadStoreOp expression
-    if (!expr->isA<LoadStoreOp>()) {
-      return;
-    }
-
-    LoadStoreOp* ldst = expr->as<LoadStoreOp>();
-
-    // There should be a single mbarrier_arrive_tx_ for all ldst in current
-    // stage.
-    NVF_ERROR(mbarrier_arrive_tx_ == nullptr);
-    mbarrier_arrive_tx_ = createRawMbarrierArriveExpectTx(ldst);
-
-    // Clone LoadStoreOp and map it to mbarrier alloc
-    Expr* new_ldst =
-        IrBuilder::create<LoadStoreOp>(
-            ldst->opType(), ldst->out(), ldst->in(), ldst->cacheOp())
-            ->withPredicate(ldst->predicate());
-
-    // Register mbarrier object to be used with new LoadStoreOp
-    // from prolog loop
-    NVF_ERROR(mbarrier_arrive_tx_->mbarrier()->isA<kir::TensorIndex>());
-    GpuLower::current()->tmaCircularBufferInfo().recordTensorIndex(
-        new_ldst, mbarrier_arrive_tx_->mbarrier()->as<kir::TensorIndex>());
-
-    // If last cloned scope is the cloned_top_level_loop body, then add
-    // mbarrier::arriveExpectTx and new loadStoreOp.
-    if (for_loop_stack_.size() == 1) {
-      NVF_ERROR(for_loop_stack_.front() == cloned_top_level_loop_);
-      return addTmaLoadBlock(new_ldst);
-    }
-
-    // Otherwise, we are in a nested for-loop and should wait until we
-    // return to top-level for loop.
-    for_loop_stack_.back()->body().push_back(new_ldst);
-  }
-
-  // Handle cpAsyncBulk type LoadStoreOp that is a circular buffer load
-  //
-  // compute_stage = loop_index % stage_depth
-  // load_stage = (loop_index + prefetch_distance) % stage_depth)
-  //
-  // Replace LoadStoreOp with:
-  //   if (warp_id == 0 && electSync()()) {
-  //     mbarrier::arriveExpectTx(mbarrier[load_stage], expected_bytes);
-  //     for (...) {
-  //       cpAsyncBulk(mbarrier[load_stage], ...);
-  //     }
-  //   }
-  //   mbarrier::wait((loop_index / stage_depth) % 2);
-  //
-  // Where mbarrier are shared memory arrays bound to the LoadStoreOp
-  void handleMainLoop(Expr* expr) {
-    NVF_ERROR(expr != nullptr && expr->isA<LoadStoreOp>());
-
-    LoadStoreOp* ldst = expr->as<LoadStoreOp>();
-
-    // There is a single mbarrier_arrive_tx_ for each cpAsyncBulk load
-    // expression. A mbarrier_arrive_tx_ for another cpAsyncBulk load expression
-    // should not be active.
-    NVF_ERROR(mbarrier_arrive_tx_ == nullptr);
-    mbarrier_arrive_tx_ = createRawMbarrierArriveExpectTx(ldst);
-
-    // Register mbarrier object to be used with LoadStoreOp
-    //  from main loop
-    NVF_ERROR(mbarrier_arrive_tx_->mbarrier()->isA<kir::TensorIndex>());
-    GpuLower::current()->tmaCircularBufferInfo().recordTensorIndex(
-        ldst, mbarrier_arrive_tx_->mbarrier()->as<kir::TensorIndex>());
-
-    // If last cloned scope is the cloned_top_level_loop body, then add
-    // mbarrier::arriveExpectTx and new loadStoreOp
-    if (for_loop_stack_.size() == 1) {
-      NVF_ERROR(for_loop_stack_.front() == cloned_top_level_loop_);
-      return addTmaLoadBlock(ldst);
-    }
-
-    // Otherwise, we are in a nested for-loop and should wait until we
-    // return to top-level for loop.
-    for_loop_stack_.back()->body().push_back(ldst);
   }
 
   // For each mbarrier that is used to wait for the loading of circular buffers


### PR DESCRIPTION
Another refactor that makes no behavioral change, but makes it naturally generalizes to warp specialization.

Removes `handlePrologueLoop` and `handleMainLoop`, move its logic into `processExpr`. This way, `processExpr` is not directly referring to any loop stage, but doing things like "if this loop stage has circular buffer load, then do this".