### PR TITLE
Print iteration number

### DIFF
--- a/tests/cpp/test_multidevice_communicator.cpp
+++ b/tests/cpp/test_multidevice_communicator.cpp
@@ -76,7 +76,9 @@ TEST_P(CommunicatorTest, Barrier) {
         toSeconds(expected_duration + kUnitDuration / 2);
     const auto expected_lower =
         toSeconds(expected_duration - kUnitDuration / 2);
-    EXPECT_THAT(duration, IsBetween(expected_lower, expected_upper));
+    EXPECT_THAT(duration, IsBetween(expected_lower, expected_upper))
+        << "Duration of iteration " << i
+        << " is outside the range of expectation.";
   }
 }
 


### PR DESCRIPTION
to get a better idea when the mismatch happened.