### PR TITLE
Remove executor_utils::CudaKernelTimer 

### DIFF
--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -1367,8 +1367,6 @@ std::vector<at::Tensor> KernelExecutor::run(
     debug() << "Index type: " << kernel()->indexType() << std::endl;
   }
 
-  executor_utils::CudaKernelTimer timer(stream);
-
   if (execute_kernel_ && !kernel()->topLevelExprs().empty()) {
     FUSER_PERF_SCOPE("KernelExecutor::runFusion::execute_kernel");
     ensureAvailableDynamicSmemSize(executor_entry->launch_params.smem());

--- a/csrc/runtime/executor_utils.h
+++ b/csrc/runtime/executor_utils.h
@@ -253,53 +253,6 @@ void validateCircularBuffering(
     kir::Kernel* kernel,
     ExpressionEvaluator& expr_eval);
 
-//! Kernel timing utility
-//!
-//! Usage example:
-//!
-//!   CudaKernelTimer timer(stream);
-//!   timer.init();
-//!   kernel<<<..., stream>>>(...);
-//!   auto elapsed_ms = timer.elapsed();
-//!
-class CudaKernelTimer {
- public:
-  CudaKernelTimer(cudaStream_t s) : stream_(s) {}
-
-  ~CudaKernelTimer() {
-    if (initialized_) {
-      NVFUSER_CUDA_RT_SAFE_CALL(cudaEventDestroy(start_event));
-      NVFUSER_CUDA_RT_SAFE_CALL(cudaEventDestroy(finish_event));
-    }
-  }
-
-  void init() {
-    NVFUSER_CUDA_RT_SAFE_CALL(cudaEventCreate(&start_event));
-    NVFUSER_CUDA_RT_SAFE_CALL(cudaEventCreate(&finish_event));
-    initialized_ = true;
-  }
-
-  void start() {
-    NVFUSER_CUDA_RT_SAFE_CALL(cudaEventRecord(start_event, stream_));
-  }
-
-  float elapsed() {
-    NVFUSER_CUDA_RT_SAFE_CALL(cudaEventRecord(finish_event, stream_));
-    NVFUSER_CUDA_RT_SAFE_CALL(cudaEventSynchronize(start_event));
-    NVFUSER_CUDA_RT_SAFE_CALL(cudaEventSynchronize(finish_event));
-    NVFUSER_CUDA_RT_SAFE_CALL(
-        cudaEventElapsedTime(&kernel_time_ms_, start_event, finish_event));
-    return kernel_time_ms_;
-  }
-
- private:
-  cudaStream_t stream_;
-  cudaEvent_t start_event = {};
-  cudaEvent_t finish_event = {};
-  bool initialized_ = false;
-  float kernel_time_ms_ = 0;
-};
-
 //! Query the target GPU version number NVRTC compiles CUDA kernels for
 void queryTargetGPUVersion(
     const cudaDeviceProp* const prop,


### PR DESCRIPTION
executor_utils::CudaKernelTimer is no longer used, likely due to the switch to FusionProfiler.