### PR TITLE
Enable sequence parallelism in test_transformer_engine.py. 

### DIFF
--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -65,6 +65,9 @@ def test_transformer_layer(setup_process_group, benchmark, compute_type):
         hidden_size,
         ffn_hidden_size,
         num_heads,
+        # https://github.com/NVIDIA/TransformerEngine/issues/1350: the
+        # benchmark fails to execute on H100 with the default format (SBHD).
+        attn_input_format="bshd",
         set_parallel_mode=True,
         tp_group=dist.group.WORLD,
     )

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -69,6 +69,7 @@ def test_transformer_layer(setup_process_group, benchmark, compute_type):
         # benchmark fails to execute on H100 with the default format (SBHD).
         attn_input_format="bshd",
         set_parallel_mode=True,
+        sequence_parallel=True,
         tp_group=dist.group.WORLD,
     )
     transformer_layer.to(dtype).to("cuda")


### PR DESCRIPTION
```bash
_bn && mpirun -np 2 pytest tests/python/test_transformer_engine.py -k forward --only-mpi
```

Before: 

```
---------------------------------------------------- benchmark: 1 tests ----------------------------------------------------
Name (time in ms)                      Min      Max     Mean   StdDev  Median     IQR  Outliers      OPS  Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------
test_transformer_layer[forward]     6.3392  43.4468  13.8773  16.5315  6.3657  9.6836       1;1  72.0604       5           1
----------------------------------------------------------------------------------------------------------------------------
```

After

```
----------------------------------------------------- benchmark: 1 tests ----------------------------------------------------
Name (time in ms)                       Min      Max     Mean  StdDev   Median     IQR  Outliers      OPS  Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------
test_transformer_layer[forward]     11.9229  12.3986  12.1244  0.1996  12.1512  0.3255       2;0  82.4784       5           1
-----------------------------------------------------------------------------------------------------------------------------
```