### PR TITLE
Limit use of the indexing war for resize

### DIFF
--- a/csrc/id_model/indexing_traversal.cpp
+++ b/csrc/id_model/indexing_traversal.cpp
@@ -83,6 +83,14 @@ std::optional<IndexingTraversal::ExprPath> IndexingTraversal::
   // domain is resized multiple times. In other words, there must be
   // at least two connected resize exprs. If not, this WAR is not
   // necessary.
+  //
+  // Note that the actual indexing is done from the loop IDs, which
+  // might be promoted to IDs outside of this particular expr. Thus,
+  // to get the true indexing path, the global IdModel may need to be
+  // used rather than the local model. Here, since we just need to
+  // know if there are multiple dependent resize exprs, and loop
+  // promotion should not further add resize exprs, it is sufficient
+  // to analyze only the IDs of this expr only.
 
   // Shortcut for a common case to avoid building the graph below
   if (resize_exprs.size() < 2) {

--- a/csrc/id_model/indexing_traversal.cpp
+++ b/csrc/id_model/indexing_traversal.cpp
@@ -90,7 +90,7 @@ std::optional<IndexingTraversal::ExprPath> IndexingTraversal::
   // used rather than the local model. Here, since we just need to
   // know if there are multiple dependent resize exprs, and loop
   // promotion should not further add resize exprs, it is sufficient
-  // to analyze only the IDs of this expr only.
+  // to analyze only the IDs of this expr.
 
   // Shortcut for a common case to avoid building the graph below
   if (resize_exprs.size() < 2) {
@@ -99,7 +99,15 @@ std::optional<IndexingTraversal::ExprPath> IndexingTraversal::
 
   const auto& local_graph = local_model.buildAlmostExactGraph();
 
-  // See if these resize expr groups are connected
+  // See if these resize expr groups are connected. Note that in the
+  // current default scheduling method, any tensor ops using resize
+  // should only show up with a fusion input as its input, so there
+  // must be no chained resize ops. The default scheduling, this
+  // function should not move beyond this point. In the case of the
+  // new resize scheduler that is currently under development will
+  // have multiple chained resize ops, but the scheduler should
+  // explicitly set the loop domain such that no promotion would
+  // happen, thus avoiding hitting the assertion down below.
   ExprGroups resize_groups = local_graph.toGroups(resize_exprs);
   bool single_id_resized_multiple_times = false;
   for (const auto i : c10::irange(resize_groups.size() - 1)) {


### PR DESCRIPTION
Fixes this error of #3505 

```
Error from segmentation group 9:  INTERNAL ASSERT FAILED at "/Fuser/csrc/id_model/indexing_traversal.cpp":102, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues. Indexing path for resize not found: iblockIdx.y376{( ceilDiv(1280, blockDim.x) )}
```

The error happens when trying to use the indexing WAR for resize that was recently added (#3454). The war itself is limited, in particular it does not work with promoted loop IDs. The limitation should be fine for the RoPE scheduling I've been working on, but it's a real issue in general.

This PR avoids the issue by limiting the use of the WAR. Currently, the WAR is used whenever there's at least a single resize expr in a single math expr. That is actually overly pessimistic since the indexing issue only happens when there's multiple resize exprs that result in a cycle in the exact graph. For example, if there's only one resize, there must be no cycle, thus the indexing WAR is not necessary.

This PR attempts to limit the use of the WAR by doing a little deeper analysis. The added check should entirely disable the WAR for the current default scheduling, where resize is only allowed with fusion inputs, which means there can be no multiple dependent resize exprs in a single fusion. 

The limitation of the WAR remains, but it does not matter for RoPE, and with this PR it should also not matter for general cases.

