### PR TITLE
`TmaCircularBufferingTest.Matmul` change

### DIFF
--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1623,6 +1623,8 @@ TEST_P(TmaCircularBufferingTest, Matmul) {
   tv0_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
   tv0_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
 
+  // (BSX/TSY * TSY * BSX) = 1024 floats = 4096 bytes * (number of buffers)
+  // Apply circular buffering to smem and local cache tensors
   tv1_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
   tv1_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
   tv1_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1741,7 +1741,7 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   tv0_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
 
   // (BSX/TSY * TSY * BSX) = 1024 floats = 4096 bytes * (number of buffers)
-  tv1_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
+  tv1_cache_smem->axis(-4)->parallelize(ParallelType::Bulk);
   tv1_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
   tv1_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
 

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1618,13 +1618,11 @@ TEST_P(TmaCircularBufferingTest, Matmul) {
   scheduler_utils::parallelizeAllLike(tv5);
 
   // (BSX/TSX * TSX * BSX) = 1024 floats = 4096 bytes * (number of buffers)
-  // Apply circular buffering to smem and local cache tensors
   tv0_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
   tv0_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
   tv0_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
 
   // (BSX/TSY * TSY * BSX) = 1024 floats = 4096 bytes * (number of buffers)
-  // Apply circular buffering to smem and local cache tensors
   tv1_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
   tv1_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
   tv1_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
@@ -1738,11 +1736,11 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   scheduler_utils::parallelizeAllLike(tv3);
 
   // (BSX/TSX * TSX * BSX) = 1024 floats = 4096 bytes * (number of buffers)
-  // Apply circular buffering to smem and local cache tensors
   tv0_cache_smem->axis(-5)->parallelize(ParallelType::Bulk);
   tv0_cache_smem->axis(-4)->parallelize(ParallelType::Bulk);
   tv0_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
 
+  // (BSX/TSY * TSY * BSX) = 1024 floats = 4096 bytes * (number of buffers)
   tv1_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
   tv1_cache_smem->axis(-2)->parallelize(ParallelType::Bulk);
   tv1_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1732,7 +1732,7 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   // Parallelize
   tv3->axis(0)->parallelize(ParallelType::BIDx);
   tv3->axis(1)->parallelize(ParallelType::BIDy);
-  tv3->axis(-3)->parallelize(ParallelType::TIDy);
+  tv3->axis(-2)->parallelize(ParallelType::TIDy);
   tv3->axis(-1)->parallelize(ParallelType::TIDx);
 
   scheduler_utils::parallelizeAllLike(tv3);

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1737,7 +1737,7 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
 
   // (BSX/TSX * TSX * BSX) = 1024 floats = 4096 bytes * (number of buffers)
   tv0_cache_smem->axis(-5)->parallelize(ParallelType::Bulk);
-  tv0_cache_smem->axis(-4)->parallelize(ParallelType::Bulk);
+  tv0_cache_smem->axis(-3)->parallelize(ParallelType::Bulk);
   tv0_cache_smem->axis(-1)->parallelize(ParallelType::Bulk);
 
   // (BSX/TSY * TSY * BSX) = 1024 floats = 4096 bytes * (number of buffers)

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -1635,8 +1635,8 @@ TEST_P(TmaCircularBufferingTest, Matmul) {
   tv5->axis(-2)->parallelize(ParallelType::Bulk);
   tv5->axis(-1)->parallelize(ParallelType::Bulk);
 
-  // IterDomain: [M/BSX, N/BSX, K/BSX, BSX/TSX, BSX/TSX, TSX, TSX, BSX]
-  // Parallelization: BDX, BDY, K/BSX ||, BSX/TSX, BSX/TSX, TDY, TSX, TDX]
+  // IterDomain: [M/BSX, N/BSX, K/BSX, BSX/TSY, BSX/TSX, TSY, TSX, BSX]
+  // Parallelization: BDX, BDY, K/BSX ||, BSX/TSY, BSX/TSX, TSY, TSX, TDX]
   // 4 non-parallelized for-loops
   inlineMost();
 
@@ -1700,6 +1700,7 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
 
   constexpr int64_t BSX = 64;
   constexpr int64_t TSX = 32;
+  constexpr int64_t TSY = 16;
 
   // Step 0: [M, K, N]
   // Step 1: [M, K, N/BSX, BSX]
@@ -1714,15 +1715,15 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   // Step 4: [M/BSX, BSX, K/BSX, BSX, N/BSX, BSX/TSX, TSX]
   tv4->split(0, BSX);
 
-  // Step 5:[M/BSX, BSX/TSX, TSX, K/BSX, BSX, N/BSX, BSX/TSX, TSX]
-  tv4->split(1, TSX);
+  // Step 5:[M/BSX, BSX/TSY, TSY, K/BSX, BSX, N/BSX, BSX/TSX, TSX]
+  tv4->split(1, TSY);
 
-  // Step 6: [M/BSX, N/BSX, K/BSX, BSX/TSX, BSX/TSX, TSX, TSX, BSX]
+  // Step 6: [M/BSX, N/BSX, K/BSX, BSX/TSY, BSX/TSX, TSY, TSX, BSX]
   tv4->reorder(
-      {{4, 7}, {7, 6}, {6, 5}, {2, 4}, {1, 3}, {3, 2}, {5, 1}, {0, 0}});
+      {{4, 7}, {7, 6}, {6, 4}, {2, 5}, {1, 3}, {3, 2}, {5, 1}, {0, 0}});
 
-  // Step 7a: [M/BSX, N/BSX, K/BSX, BSX/TSX, BSX/TSX, TSX, TSX, BSX (reduce)]
-  // Step 7b: [M/BSX, N/BSX, K/BSX (reduce), BSX/TSX, BSX/TSX, TSX, TSX]
+  // Step 7a: [M/BSX, N/BSX, K/BSX, BSX/TSY, BSX/TSX, TSY, TSX, BSX (reduce)]
+  // Step 7b: [M/BSX, N/BSX, K/BSX (reduce), BSX/TSY, BSX/TSX, TSY, TSX]
   TensorView* tv4_rf = tv4->rFactor({-1});
 
   TransformPropagatorWithCheck propagator(tv4_rf);
@@ -1752,8 +1753,8 @@ TEST_P(TmaCircularBufferingTest, MatmulWithBroadcastedInput) {
   tv3->axis(-2)->parallelize(ParallelType::Bulk);
   tv3->axis(-1)->parallelize(ParallelType::Bulk);
 
-  // IterDomain: [M/BSX, N/BSX, K/BSX, BSX/TSX, BSX/TSX, TSX, TSX, BSX]
-  // Parallelization: BDX, BDY, K/BSX ||, BSX/TSX, BSX/TSX, TDY, TSX, TDX]
+  // IterDomain: [M/BSX, N/BSX, K/BSX, BSX/TSY, BSX/TSX, TSY, TSX, BSX]
+  // Parallelization: BDX, BDY, K/BSX ||, BSX/TSY, BSX/TSX, TSY, TSX, TDX]
   // 4 non-parallelized for-loops
   inlineMost();
 


### PR DESCRIPTION
- Fixes a minor bug where the code and comment does not match
- Reduces the tile size on Y from 32 to 16 (because 32 means 1024 threads/CTA, already the max and no extra space for warp specialization)