### PR TITLE
Add some death tests to make sure we don't fail silently

### DIFF
--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -81,17 +81,14 @@ class ForwardTraverseFromLogicalToAlloc {
     auto [outer_size, outer_stride] = outer_it->second;
     NVF_ERROR(
         inner_stride * inner_size == outer_stride,
-        "The logical domain and allocation domain of fusion input/output ",
-        "tensors must be a one-to-one map, therefore, ",
-        "merging of discontiguous dimensions is not allowed in allocation domain");
+        "Merging of discontiguous dimensions is not allowed in allocation "
+        "domain. An allocation IterDomain can't have two different strides.");
     NVF_ERROR(active_ids_.erase(inner) == 1);
     NVF_ERROR(active_ids_.erase(outer) == 1);
-    NVF_ERROR(active_ids_
-                  .emplace(
-                      out,
-                      std::pair<int64_t, int64_t>{
-                          inner_size * outer_size, inner_stride})
-                  .second);
+    NVF_ERROR(
+        active_ids_
+            .emplace(out, std::make_pair(inner_size * outer_size, inner_stride))
+            .second);
   }
 
   void handle(Expr* expr) {

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -1441,6 +1441,53 @@ TEST_F(AllocationDomainTest, InputAllocationIsSplit_Concrete) {
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 }
 
+TEST_F(AllocationDomainTest, InputAllocationIsSplitReorderContiguous) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({6});
+  TensorView* out = set(in);
+  fusion->addInput(in);
+  fusion->addOutput(out);
+
+  in->split(0, 2);
+  in->reorder({{1, 0}});
+  // new_contiguity=True is the problem here. After reordering, the two
+  // IterDomains are no longer contiguous.
+  in->setAllocationDomain(in->getLoopDomain(), true);
+
+  FusionExecutorCache executor_cache(std::move(fusion));
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA);
+  at::Tensor in_tensor = at::randn({6}, options);
+  EXPECT_THAT(
+      [&]() { executor_cache.runFusionWithInputs({in_tensor}); },
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
+          ::testing::HasSubstr("Stride mismatch with contiguity info")));
+}
+
+TEST_F(AllocationDomainTest, InputAllocationIsSplitReorderMerge) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({6});
+  TensorView* out = set(in);
+  fusion->addInput(in);
+  fusion->addOutput(out);
+
+  in->split(0, 2);
+  in->reorder({{1, 0}});
+  in->merge(0);
+  in->setAllocationDomain(in->getLoopDomain(), false);
+
+  FusionExecutorCache executor_cache(std::move(fusion));
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA);
+  at::Tensor in_tensor = at::randn({6}, options);
+  EXPECT_THAT(
+      [&]() { executor_cache.runFusionWithInputs({in_tensor}); },
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
+          ::testing::HasSubstr("Merging of discontiguous dimensions")));
+}
+
 // TODO(#3480): the test fails as is. The symbolic IterDomains in
 // loop/allocation are not concretized. I tried to change
 // DynamicTransformConcretizer::mutate to grab all expressions between root and

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -1475,8 +1475,7 @@ TEST_F(AllocationDomainTest, InputAllocationIsSplitReorderMerge) {
   fusion->addOutput(out);
 
   in->split(0, 2);
-  in->reorder({{1, 0}});
-  in->merge(0);
+  in->merge(1, 0);
   in->setAllocationDomain(in->getLoopDomain(), false);
 
   FusionExecutorCache executor_cache(std::move(fusion));

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -850,8 +850,8 @@ TEST_F(AllocationDomainTest, NHWC2d_To_NHWC2d_cacheAfter) {
 
   EXPECT_THAT(
       [&]() { ke.run({t0_wrong_format}); },
-      ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
-          "merging of discontiguous dimensions is not allowed in allocation domain")));
+      ::testing::ThrowsMessage<nvfuser::nvfError>(
+          ::testing::HasSubstr("Merging of discontiguous dimensions")));
 
   auto cg_outputs = ke.run({t0});
 


### PR DESCRIPTION
with unsupported logical-to-allocation transforms.

https://github.com/google/googletest/blob/main/docs/advanced.md#death-tests