### PR TITLE
Fix type consistency in st matrix testing

### DIFF
--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -196,17 +196,17 @@ inline bool isHopper(MmaMacro macro) {
 }
 
 //! Get the m size from macro type
-inline int getM(MmaMacro macro) {
+inline int64_t getM(MmaMacro macro) {
   return MmaMacroEncode(macro).m;
 }
 
 //! Get the n size from macro type
-inline int getN(MmaMacro macro) {
+inline int64_t getN(MmaMacro macro) {
   return MmaMacroEncode(macro).n;
 }
 
 //! Get the k size from macro type
-inline int getK(MmaMacro macro) {
+inline int64_t getK(MmaMacro macro) {
   return MmaMacroEncode(macro).k;
 }
 

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -3769,8 +3769,8 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
     tv3c->setAllocationDomain(s.as<IterDomain*>(), true);
 
     // We'll use stmatrix.x4 to store from reg to shared memory
-    fusion.manage("st_matrix_m_tile", 16);
-    fusion.manage("st_matrix_n_tile", 16);
+    fusion.manage("st_matrix_m_tile", (int64_t)16);
+    fusion.manage("st_matrix_n_tile", (int64_t)16);
     fusion.manage("st_matrix_m", getM(macro));
     fusion.manage("st_matrix_n", getN(macro));
 

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -2831,8 +2831,8 @@ TEST_P(StMatrixTest, Regular) {
   auto tile_sizes = std::get<1>(GetParam());
   auto sizeM = getM(macro);
   auto sizeN = getN(macro);
-  auto tile_m = tile_sizes.at(0);
-  auto tile_n = tile_sizes.at(1);
+  int64_t tile_m = tile_sizes.at(0);
+  int64_t tile_n = tile_sizes.at(1);
 
   if (sizeM % tile_m || sizeN % tile_n) {
     GTEST_SKIP() << "Fractional tiling is not supported/tested";
@@ -2902,8 +2902,8 @@ INSTANTIATE_TEST_SUITE_P(
         kAllHopperMacros,
         testing::Values(
             // tile_m, tile_n
-            std::vector<int64_t>{16, 8},
-            std::vector<int64_t>{16, 16})),
+            std::vector<int>{16, 8},
+            std::vector<int>{16, 16})),
     testNameStMatrixTest);
 
 TEST_P(LdMatrixTest, Transpose) {

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -2902,8 +2902,8 @@ INSTANTIATE_TEST_SUITE_P(
         kAllHopperMacros,
         testing::Values(
             // tile_m, tile_n
-            std::vector<int>{16, 8},
-            std::vector<int>{16, 16})),
+            std::vector<int64_t>{16, 8},
+            std::vector<int64_t>{16, 16})),
     testNameStMatrixTest);
 
 TEST_P(LdMatrixTest, Transpose) {


### PR DESCRIPTION
This was causing errors in one of my development branches. We need to be consistent with types that we manage with fusion when storing and getting.