### PR TITLE
add scheduler_tools::scheduleLoopDomainsBy

### DIFF
--- a/csrc/id_model/#id_model.cpp#
+++ b/csrc/id_model/#id_model.cpp#
@@ -1,0 +1,1196 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <id_model/id_model.h>
+#include <id_model/loop_promotion.h>
+#include <id_model/to_string.h>
+#include <id_model/transform_replay.h>
+#include <id_model/utils.h>
+#include <id_model/validation_utils.h>
+
+#include <device_lower/analysis/trivial_broadcast.h>
+#include <device_lower/lower2device.h>
+#include <device_lower/utils.h>
+#include <disjoint_set.h>
+#include <ir/utils.h>
+#include <iter_visitor.h>
+#include <logical_domain_map.h>
+#include <transform_iter.h>
+#include <val_graph_visitor.h>
+
+#include <memory>
+#include <tuple>
+#include <utility>
+
+namespace nvfuser {
+
+namespace {
+
+// Map through loop swizzles, as input/output IterDomains are exact, only the
+// order they're traversed differs.
+void mapThroughLoopSwizzles(ValGraph& graph) {
+  std::vector<Swizzle2D*> all_swizzles;
+
+  for (const auto& expr_set :
+       std::as_const(graph).disjointExprSets().disjointSets()) {
+    auto swizzles_in_expr_set = ir_utils::filterByType<Swizzle2D>(
+        expr_set->vector().begin(), expr_set->vector().end());
+    all_swizzles.insert(
+        all_swizzles.end(),
+        swizzles_in_expr_set.begin(),
+        swizzles_in_expr_set.end());
+  }
+
+  for (auto swizzle : all_swizzles) {
+    if (swizzle->swizzleMode() == SwizzleMode::Loop) {
+      graph.mapVals(swizzle->inX(), swizzle->outX());
+      graph.mapVals(swizzle->inY(), swizzle->outY());
+    }
+  }
+}
+
+} // namespace
+
+void IdModel::assertNoSelfMapping() {
+  const ValGraph& exact_graph = idGraph(IdMappingMode::EXACT);
+  for (TensorView* tv : tvs_) {
+    std::optional<SelfMapping> self_mapping = hasSelfMapping(tv, exact_graph);
+    NVF_CHECK(
+        !self_mapping.has_value(),
+        "Unsupported domain mapping detected in ",
+        tv,
+        ". ",
+        self_mapping->where,
+        " domains, ",
+        self_mapping->id1,
+        " and ",
+        self_mapping->id2,
+        ", are mapped with each other.");
+  }
+}
+
+IdModel::IdModel(
+    const std::vector<Expr*>& exprs,
+    const std::vector<TensorView*>& additional_tvs,
+    bool build_graphs,
+    bool allow_self_mapping,
+    LoopPromotionMapBuilderCallback* loop_promotion_map_builder_callback)
+    : allow_self_mapping_(allow_self_mapping),
+      loop_promotion_map_builder_callback_(
+          loop_promotion_map_builder_callback) {
+  std::copy_if(
+      exprs.begin(),
+      exprs.end(),
+      std::back_inserter(tv_exprs_),
+      [](Expr* expr) {
+        NVF_ERROR(expr != nullptr);
+        return ir_utils::isTvOp(expr);
+      });
+
+  auto all_tvs = ir_utils::allTvsOfExprs(tv_exprs_);
+  all_tvs.pushBack(additional_tvs.begin(), additional_tvs.end());
+
+  tvs_ = all_tvs.vector();
+
+  NVF_ERROR(!tvs_.empty(), "No tensor to build IdModel for");
+
+  fusion_ = tvs_.front()->fusion();
+
+  // Add uses and definitions to all iter domains.
+  buildIterDomainDefinitionsAndUses();
+
+  if (build_graphs) {
+    buildAllGraphs();
+  }
+}
+
+IdModel::IdModel(
+    Fusion* fusion,
+    bool build_graphs,
+    bool allow_self_mapping,
+    bool validate,
+    LoopPromotionMapBuilderCallback* loop_promotion_map_builder_callback)
+    : fusion_(fusion),
+      allow_self_mapping_(allow_self_mapping),
+      validate_(validate),
+      loop_promotion_map_builder_callback_(
+          loop_promotion_map_builder_callback) {
+  auto all_exprs = fusion->exprs();
+  std::copy_if(
+      all_exprs.begin(),
+      all_exprs.end(),
+      std::back_inserter(tv_exprs_),
+      [](Expr* expr) {
+        NVF_ERROR(expr != nullptr);
+        return ir_utils::isTvOp(expr);
+      });
+
+  auto all_tvs = ir_utils::allTvsOfExprs(tv_exprs_);
+
+  {
+    auto inp_tvs = ir_utils::filterByType<TensorView>(fusion->inputs());
+    all_tvs.pushBack(inp_tvs.begin(), inp_tvs.end());
+  }
+  {
+    auto out_tvs = ir_utils::filterByType<TensorView>(fusion->outputs());
+    all_tvs.pushBack(out_tvs.begin(), out_tvs.end());
+  }
+
+  tvs_ = all_tvs.vector();
+
+  // Add uses and definitions to all iter domains.
+  buildIterDomainDefinitionsAndUses();
+
+  if (build_graphs) {
+    buildAllGraphs();
+  }
+}
+
+const ValGraph& IdModel::idGraph(IdMappingMode mode) const {
+  auto graph_it = id_graphs_.find(mode);
+  NVF_ERROR(
+      graph_it != id_graphs_.end(),
+      "Failed to find an IdGraph with the ",
+      mode,
+      " mode");
+  return graph_it->second;
+}
+
+ValGraph& IdModel::idGraph(IdMappingMode mode) {
+  auto graph_it = id_graphs_.find(mode);
+  NVF_ERROR(
+      graph_it != id_graphs_.end(),
+      "Failed to find an IdGraph with the ",
+      mode,
+      " mode");
+  return graph_it->second;
+}
+
+void IdModel::buildIterDomainDefinitionsAndUses() {
+  for (const auto tv : tvs_) {
+    std::vector<IterDomain*> all_ids = tv->domain()->allIDs();
+
+    // Check if this domain is a consumer of a view-like operation
+    const bool view_like_domain = tv->domain()->hasViewLikeRFactor();
+
+    for (auto id : all_ids) {
+      // Check if this id is a view like rfactor id
+      if (view_like_domain && id->isRFactorProduct()) {
+        // If the tensor domain is a view like domain, and the iteration
+        // domain is marked as an rfactor product and is in the rfactor
+        // domain, it's a view like rfactor iteration domain
+        const auto& logical_domain = tv->domain()->logical();
+        if (std::find(logical_domain.begin(), logical_domain.end(), id) !=
+            logical_domain.end()) {
+          view_rfactor_ids_.emplace(id);
+        }
+      }
+
+      if (id_definitions_.find(id) == id_definitions_.end()) {
+        id_definitions_.emplace(id, VectorOfUniqueEntries<Expr*>{});
+      }
+
+      if (id_uses_.find(id) == id_uses_.end()) {
+        id_uses_.emplace(id, VectorOfUniqueEntries<Expr*>{});
+      }
+
+      Expr* def = id->definition();
+
+      if (def == nullptr) {
+        continue;
+      }
+#if 0
+      // If any of the inputs is not included in the all ID set, do
+      // not include the definition in the model. Note that it is
+      // possible that some are included but not all since a single ID
+      // may be used by multiple exprs.
+      if (std::any_of(
+              def->inputs().begin(), def->inputs().end(), [&](Val* inp) {
+                return std::find(
+                           all_ids.begin(),
+                           all_ids.end(),
+                           inp->as<IterDomain>()) == all_ids.end();
+              })) {
+        continue;
+      }
+
+      id_definitions_[id].pushBack(def);
+
+      auto inp_ids = ir_utils::filterByType<IterDomain>(def->inputs());
+      for (auto inp_id : inp_ids) {
+        id_uses_[inp_id].pushBack(def);
+      }
+    }
+  }
+}
+
+std::string IdModel::toString() const {
+  std::stringstream ss;
+  ss << "IterDomainGraphs { \n";
+  // Only print initialized graphs
+  for (auto mode : kIdMappingModes) {
+    auto graph_it = id_graphs_.find(mode);
+    if (graph_it == id_graphs_.end()) {
+      continue;
+    }
+
+    // graph may be empty, but then just print it as an empty graph,
+    // which might be useful for debugging
+    ss << "  IdGraph " << mode << "{ \n";
+    ss << "  Disjoint Ids:\n"
+       << idGroupsString(idGraph(mode), 2)
+       << "\n  Disjoint Expression groups:\n"
+       << exprGroupsString(idGraph(mode), 2) << std::endl;
+    ss << "   } IdGraph\n" << std::endl;
+  }
+  ss << " } IterDomainGraphs\n" << std::endl;
+  return ss.str();
+}
+
+ValGraph IdModel::initializeIdGraph(bool propagate_through_exprs) const {
+  ValGraph id_graph(propagate_through_exprs);
+
+  // To deterministically initialize the graph, the order of adding
+  // domains must be deterministic. Here, we sort all IDs by their
+  // names.
+
+  std::vector<IterDomain*> all_ids;
+  all_ids.reserve(id_definitions_.size());
+  for (const auto& [id, defs] : id_definitions_) {
+    all_ids.push_back(id);
+  }
+
+  std::sort(
+      all_ids.begin(), all_ids.end(), [](IterDomain* id1, IterDomain* id2) {
+        return id1->name() < id2->name();
+      });
+
+  for (auto id : all_ids) {
+    auto uses_it = id_uses_.find(id);
+    NVF_ERROR(
+        uses_it != id_uses_.end(),
+        "Failed to initialize id: ",
+        id->toString(),
+        " as it's missing a definition entry.");
+    id_graph.initializeVal(id, id_definitions_.at(id), uses_it->second);
+  }
+
+  return id_graph;
+}
+
+ValGraph& IdModel::buildExactGraph() {
+  // Initialize the maps with all the IterDomains used in the provded
+  // expressions.
+  NVF_ERROR(
+      id_graphs_.emplace(IdMappingMode::EXACT, initializeIdGraph()).second);
+
+  auto& graph = idGraph(IdMappingMode::EXACT);
+
+  for (auto expr : tv_exprs_) {
+    TensorView* c_tv = ir_utils::getTvOutput(expr);
+
+    auto all_tv_outputs = ir_utils::filterByType<TensorView>(expr->outputs());
+
+    // Map siblings, as all other tv output domains must match the first tv
+    // outputs domain.
+    std::deque<TensorView*> other_tv_outputs(
+        all_tv_outputs.begin(), all_tv_outputs.end());
+    other_tv_outputs.pop_front();
+
+    // Map producer-consumer relationships based on the root domain map
+    auto tv_inputs = ir_utils::filterByType<TensorView>(expr->inputs());
+    for (auto p_tv : tv_inputs) {
+      // For exact mapings do not map any broadcast dimensions to
+      // non-broadcast dimensions. Prevent any broadcasted axes being mapped
+      // to non-broadcasted axes.
+      auto exact_c2p_logical_map = PairwiseLogicalDomainMap(p_tv, c_tv)
+                                       .mapBroadcast(false)
+                                       .mapConsumerToProducer();
+
+      for (auto c_id :
+           getSortedKeys(exact_c2p_logical_map, Statement::lessThan)) {
+        auto p_id = exact_c2p_logical_map.at(c_id);
+        graph.mapVals(c_id, p_id);
+      }
+    }
+
+    if (ir_utils::hasUniformSiblings(expr)) {
+      for (auto other_tv_output : other_tv_outputs) {
+        NVF_ERROR(
+            other_tv_output->getMaybeRootDomain().size() ==
+                c_tv->getMaybeRootDomain().size(),
+            "Multiple outputs with mismatched TV domains is not supported.");
+
+        for (auto domain_i : c10::irange(c_tv->getMaybeRootDomain().size())) {
+          auto c_id = c_tv->getMaybeRootDomain()[domain_i];
+          auto o_id = other_tv_output->getMaybeRootDomain()[domain_i];
+          graph.mapVals(o_id, c_id);
+        }
+      }
+    } else {
+      for (auto p_tv : tv_inputs) {
+        for (auto c_tv : other_tv_outputs) {
+          auto exact_c2p_root_map = PairwiseLogicalDomainMap(p_tv, c_tv)
+                                        .mapBroadcast(false)
+                                        .mapConsumerToProducer();
+
+          for (auto c_id :
+               getSortedKeys(exact_c2p_root_map, Statement::lessThan)) {
+            auto p_id = exact_c2p_root_map.at(c_id);
+            graph.mapVals(c_id, p_id);
+          }
+        }
+      }
+    }
+
+    // TODO: Revisit if we really should map domains in the exact map
+    mapThroughLoopSwizzles(graph);
+  }
+
+  // Map additional exact mappings if registered. Only map those that
+  // appear in this IdModel and when they are the same (per sameAs).
+  if (!tv_exprs_.empty()) {
+    Fusion* fusion = tv_exprs_.front()->fusion();
+    if (fusion->hasRegisteredExactMappings()) {
+      DisjointSets<IterDomain*> additional_mappings =
+          fusion->registeredExactMappings();
+      for (const auto& disjoint_set : additional_mappings.disjointSets()) {
+        IterDomain* registerd_id = nullptr;
+        for (auto id : *disjoint_set) {
+          if (!graph.hasGroup(id)) {
+            continue;
+          }
+
+          if (registerd_id == nullptr) {
+            registerd_id = id;
+          } else {
+            graph.mapVals(registerd_id, id);
+          }
+        }
+      }
+    }
+  }
+
+  graph.validateConsistency();
+
+  return graph;
+}
+
+namespace {
+
+// Checks if the expression is a trivial operation where an input is simply an
+// output of the transformation. Returns the mapped iter domains if found.
+std::vector<std::vector<Val*>> getTriviallyMappedIds(Expr* expr) {
+  std::vector<std::vector<Val*>> mapped_ids;
+  if (auto merge = dynamic_cast<Merge*>(expr)) {
+    // Size-one domains should be broadcast, so just checking
+    // isBroadcast should be sufficient, but just in case if there's
+    // any missing conversion to broadcast
+    if (merge->inner()->isBroadcast() || merge->inner()->extent()->isOneInt()) {
+      mapped_ids.push_back({merge->outer(), merge->out()});
+    }
+    if (merge->outer()->isBroadcast() || merge->outer()->extent()->isOneInt()) {
+      mapped_ids.push_back({merge->inner(), merge->out()});
+    }
+  } else if (auto split = dynamic_cast<Split*>(expr)) {
+    if (split->factor()->isOneInt()) {
+      if (split->innerSplit()) {
+        mapped_ids.push_back({split->in(), split->outer()});
+      } else {
+        mapped_ids.push_back({split->in(), split->inner()});
+      }
+    } else {
+      // Rare, but don't want to deal with zero-dim IDs
+      if (!split->in()->extent()->isZeroInt()) {
+        // Even when the factor is not known to be 1, as long as the
+        // input and output have the same extent, they should be
+        // mapped. This happens, for example, split 32 by 32 -> 1, 32.
+        if (split->outer()->extent()->sameAs(split->in()->extent())) {
+          // In and outer have the same extent. They must be non-one and
+          // the inner must be one, or they must be one.
+          NVF_ERROR(
+              split->inner()->extent()->isOneInt() ||
+                  split->outer()->extent()->isOneInt(),
+              "Unexpected split: ",
+              split->toString());
+          mapped_ids.push_back({split->in(), split->outer()});
+        }
+        if (split->inner()->extent()->sameAs(split->in()->extent())) {
+          NVF_ERROR(
+              split->inner()->extent()->isOneInt() ||
+                  split->outer()->extent()->isOneInt(),
+              "Unexpected split: ",
+              split->toString());
+          mapped_ids.push_back({split->in(), split->inner()});
+        }
+      }
+    }
+  } else if (auto swizzle = dynamic_cast<Swizzle2D*>(expr)) {
+    if (swizzle->swizzleType() == Swizzle2DType::NoSwizzle ||
+        swizzle->swizzleMode() == SwizzleMode::NoSwizzle) {
+      mapped_ids.push_back({swizzle->inX(), swizzle->outX()});
+      mapped_ids.push_back({swizzle->inY(), swizzle->outY()});
+    }
+  }
+  return mapped_ids;
+}
+
+} // namespace
+
+ValGraph& IdModel::buildAlmostExactGraph() {
+  // Make sure the exact graph is already built
+  maybeBuildGraph(IdMappingMode::EXACT);
+
+  // Build almost exact map by forwarding through broadcast axes
+  NVF_ERROR(
+      id_graphs_
+          .emplace(IdMappingMode::ALMOSTEXACT, idGraph(IdMappingMode::EXACT))
+          .second);
+
+  auto& almost_exact_graph = idGraph(IdMappingMode::ALMOSTEXACT);
+
+  // Maps iter domain pairs returned by calling that return mappings from
+  // isTrivialExpr on every expression in the graph.
+
+  // Don't traverse the graph and at the same time add more mappings
+  // as the traversal would be invalidated
+  std::vector<std::pair<Val*, Val*>> ids_to_map;
+
+  for (const auto& expr_group :
+       almost_exact_graph.disjointExprSets().disjointSets()) {
+    for (auto expr : *expr_group) {
+      // If not trivial continue
+      auto mapped_ids = getTriviallyMappedIds(expr);
+      if (mapped_ids.empty()) {
+        continue;
+      }
+
+      // Map through trivial expressions
+      for (auto mapped_id_group : mapped_ids) {
+        for (auto id : mapped_id_group) {
+          // almost_exact_graph.mapVals(mapped_id_group.front(), id);
+          ids_to_map.emplace_back(mapped_id_group.front(), id);
+        }
+      }
+    }
+  }
+
+  for (const auto& [id1, id2] : ids_to_map) {
+    almost_exact_graph.mapVals(id1, id2);
+  }
+
+  almost_exact_graph.validateConsistency();
+
+  return almost_exact_graph;
+}
+
+ValGraph& IdModel::buildBroadcastGraph() {
+  // Make sure the exact graph is already built
+  maybeBuildGraph(IdMappingMode::EXACT);
+
+  // Use the exact graph as the starting map rather than the
+  // almost-exact graph. Almost exact is useful for index hoisting but
+  // not necessary otherwise
+  NVF_ERROR(
+      id_graphs_
+          .emplace(IdMappingMode::BROADCAST, idGraph(IdMappingMode::EXACT))
+          .second);
+
+  auto& graph = idGraph(IdMappingMode::BROADCAST);
+
+  for (auto expr : tv_exprs_) {
+    for (TensorView* c_tv :
+         ir_utils::filterByType<TensorView>(expr->outputs())) {
+      auto tv_inputs = ir_utils::filterByType<TensorView>(expr->inputs());
+
+      for (auto p_tv : tv_inputs) {
+        auto permissive_c2p_logical_map =
+            PairwiseLogicalDomainMap(p_tv, c_tv).mapBroadcast(true);
+
+        for (auto entry : permissive_c2p_logical_map.mapConsumerToProducer()) {
+          graph.mapVals(entry.first, entry.second);
+        }
+      }
+
+      // If all outputs are uniformly mapped, only the first consumer
+      // needs to be examined
+      if (ir_utils::hasUniformSiblings(expr)) {
+        break;
+      }
+    }
+  }
+
+  graph.validateConsistency();
+
+  return graph;
+}
+
+ValGraph& IdModel::buildPermissiveGraph() {
+  maybeBuildGraph(IdMappingMode::BROADCAST);
+
+  NVF_ERROR(
+      id_graphs_
+          .emplace(IdMappingMode::PERMISSIVE, idGraph(IdMappingMode::BROADCAST))
+          .second);
+
+  auto& graph = idGraph(IdMappingMode::PERMISSIVE);
+
+  for (auto expr : tv_exprs_) {
+    for (TensorView* c_tv :
+         ir_utils::filterByType<TensorView>(expr->outputs())) {
+      auto tv_inputs = ir_utils::filterByType<TensorView>(expr->inputs());
+
+      // If the loop domain is not generated from the logial domain
+      // with not extra IDs, broadcast forwarding is not
+      // supported. As such, permissive mappings are not generated.
+      if (!ir_utils::isLoopDomainFullyDerivedFromLogicalDomain(c_tv)) {
+        continue;
+      }
+
+      for (auto p_tv : tv_inputs) {
+        if (!ir_utils::isLoopDomainFullyDerivedFromLogicalDomain(p_tv)) {
+          continue;
+        }
+        ForwardingInfo permissive_forwarding(p_tv, c_tv);
+        for (auto entry : permissive_forwarding.producer_forwarding_map) {
+          graph.mapVals(entry.first, entry.second);
+        }
+
+        if (permissive_graph_map_compliment_ids_) {
+          for (const auto& entry :
+               permissive_forwarding.producer_compliment_map) {
+            for (auto entry_2 : entry.second) {
+              graph.mapVals(entry.first, entry_2);
+            }
+          }
+        }
+
+        for (auto entry : permissive_forwarding.consumer_forwarding_map) {
+          graph.mapVals(entry.first, entry.second);
+        }
+
+        if (permissive_graph_map_compliment_ids_) {
+          for (const auto& entry :
+               permissive_forwarding.consumer_compliment_map) {
+            for (auto entry_2 : entry.second) {
+              graph.mapVals(entry.first, entry_2);
+            }
+          }
+        }
+      }
+      // If all outputs are uniformly mapped, only the first consumer
+      // needs to be examined
+      if (ir_utils::hasUniformSiblings(expr)) {
+        break;
+      }
+    }
+  }
+
+  graph.validateConsistency();
+
+  return graph;
+}
+
+namespace {
+
+// Returns the root producer iteration domains that are resolved by provided
+// consumer
+std::vector<std::pair<IterDomain*, IterDomain*>> resolvedRootBroadcasts(
+    TensorView* producer,
+    TensorView* consumer) {
+  auto p2c_map = PairwiseLogicalDomainMap(producer, consumer)
+                     .mapBroadcast(true)
+                     .mapProducerToConsumer();
+
+  std::vector<std::pair<IterDomain*, IterDomain*>> resolved_bcast_domains;
+  for (const auto& [p_id, c_id] : p2c_map) {
+    // Look for a broadcast producer and non-broadcast consumer
+
+    // Ignore non-broadcast producer and broadcast consumer dims
+    if (!p_id->isBroadcast() || c_id->isBroadcast()) {
+      continue;
+    }
+
+    if (c_id->isReduction()) {
+      // This should only happen with expanded broadcast
+      // domains. Otherwise, squeeze should be used
+      NVF_ERROR(
+          p_id->hasExpandedExtent(), "Unexpected domain: ", c_id->toString());
+      continue;
+    }
+
+    resolved_bcast_domains.emplace_back(p_id, c_id);
+  }
+  return resolved_bcast_domains;
+}
+
+} // namespace
+
+// Grab inlining relationships
+StatefulInliningInfo buildStatefulInliningInfo(
+    const std::vector<Expr*>& exprs,
+    const ValGraph& permissive_graph) {
+  StatefulInliningInfo info;
+  for (auto expr : exprs) {
+    for (auto producer_tv :
+         ir_utils::filterByType<TensorView>(expr->inputs())) {
+      const auto& producer_logical = producer_tv->getLogicalDomain();
+      const auto& producer_domain = producer_tv->domain()->loop();
+
+      // Grab all iteration domains in producer that its compute at iter domains
+      // depend on.
+      VectorOfUniqueEntries<IterDomain*> all_producer_ca_deps;
+
+      // Broadcast forwarding is not applied when the loop domain is
+      // not fully derived from the logical domain. In that case, the
+      // loop promotion analysis effectively does nothing, however, we
+      // still need to make loop groups, for which ordered_p_ca_ids as
+      // well as p2c_ca_permissive_maps are required. Since no
+      // promotion analysis is done, only loop IDs need to be
+      // considered.
+
+      if (ir_utils::isLoopDomainFullyDerivedFromLogicalDomain(producer_tv)) {
+        auto ca_dep_vals = DependencyCheck::getAllValsBetween(
+            {producer_logical.begin(), producer_logical.end()},
+            {producer_domain.begin(),
+             producer_domain.begin() + producer_tv->getComputeAtPosition()});
+        auto ca_deps_filter = ir_utils::filterByType<IterDomain>(ca_dep_vals);
+        all_producer_ca_deps = VectorOfUniqueEntries<IterDomain*>(
+            ca_deps_filter.begin(), ca_deps_filter.end());
+      } else {
+        all_producer_ca_deps = VectorOfUniqueEntries<IterDomain*>(
+            producer_tv->getLoopDomain().begin(),
+            producer_tv->getLoopDomain().begin() +
+                producer_tv->getComputeAtPosition());
+      }
+
+      info.ordered_p_ca_ids.pushBack(all_producer_ca_deps);
+
+      // Gather info on and producer-consumer
+      // mappings of CA domains and broadcast resolution
+      for (auto consumer_tv :
+           ir_utils::filterByType<TensorView>(expr->outputs())) {
+        auto all_producer_ids = producer_tv->domain()->allIDs();
+        auto all_consumer_ids = consumer_tv->domain()->allIDs();
+
+        auto p2c_permissive_map = permissive_graph.buildMapBetween(
+            all_producer_ids, all_consumer_ids);
+
+        for (const auto& [p_id, c_ids] : p2c_permissive_map) {
+          if (!c_ids.empty() &&
+              all_producer_ca_deps.has(p_id->as<IterDomain>())) {
+            info.p2c_ca_permissive_maps[p_id->as<IterDomain>()].pushBack(c_ids);
+          }
+        }
+
+        const std::vector<std::pair<IterDomain*, IterDomain*>>
+            resolved_bcast_domains =
+                resolvedRootBroadcasts(producer_tv, consumer_tv);
+
+        for (const auto& [p_root_id, c_root_id] : resolved_bcast_domains) {
+          info.p2c_root_broadcast_resolution_map[p_root_id].pushBack(c_root_id);
+        }
+      }
+    }
+
+    if (ir_utils::hasUniformSiblings(expr)) {
+      auto consumer_tvs = ir_utils::filterByType<TensorView>(expr->outputs());
+      if (consumer_tvs.size() > 1) {
+        auto all_consumer_ids = consumer_tvs.vector().at(0)->domain()->allIDs();
+        info.ordered_sibling_ids.pushBack(
+            {all_consumer_ids.begin(), all_consumer_ids.end()});
+        for (const auto i : c10::irange(1, consumer_tvs.size())) {
+          auto consumer_tv_i = consumer_tvs.vector().at(i);
+          auto all_consumer_i_ids = consumer_tv_i->domain()->allIDs();
+
+          auto sibling_map = permissive_graph.buildMapBetween(
+              all_consumer_ids, all_consumer_i_ids);
+
+          for (const auto& [c_id_1, c_ids] : sibling_map) {
+            // Note that c_ids can have multiple domains as this graph
+            // is a Permissive graph and there may be broadcast merged
+            // domains
+            info.sibling_maps[c_id_1->as<IterDomain>()].pushBack(c_ids);
+          }
+        }
+      }
+    }
+  }
+  return info;
+}
+
+void IdModel::initializeLoopGraph(const StatefulInliningInfo& info) {
+  // In the case of the Loop graph, we do not propagate mappings but
+  // explicitly set which domains to map based on the permissive graph
+  // and the CA positions.
+  NVF_ERROR(
+      id_graphs_.emplace(IdMappingMode::LOOP, initializeIdGraph(false)).second);
+
+  // Make sure this is called in a deterministic order. Build all inlined
+  // relationships in loop graph.
+  for (IterDomain* p_id : info.ordered_p_ca_ids) {
+    auto entry_it = info.p2c_ca_permissive_maps.find(p_id);
+    if (entry_it != info.p2c_ca_permissive_maps.end()) {
+      const VectorOfUniqueEntries<Val*>& c_ids = entry_it->second;
+      for (Val* c_id : c_ids) {
+        idGraph(IdMappingMode::LOOP).mapVals(p_id, c_id);
+      }
+    }
+  }
+
+  // Similarly maps all sibling domains
+  for (IterDomain* id : info.ordered_sibling_ids) {
+    auto entry_it = info.sibling_maps.find(id);
+    if (entry_it != info.sibling_maps.end()) {
+      const VectorOfUniqueEntries<Val*>& sibling_ids = entry_it->second;
+      for (Val* sibling_id : sibling_ids) {
+        idGraph(IdMappingMode::LOOP).mapVals(id, sibling_id);
+      }
+    }
+  }
+}
+
+ValGraph& IdModel::buildLoopGraph() {
+  // Make sure the depedent graphs are already built
+  maybeBuildGraph(IdMappingMode::EXACT);
+  maybeBuildGraph(IdMappingMode::PERMISSIVE);
+
+  const StatefulInliningInfo inlining_info =
+      buildStatefulInliningInfo(tv_exprs_, idGraph(IdMappingMode::PERMISSIVE));
+
+  initializeLoopGraph(inlining_info);
+
+  validateLoopGraphHasNoSelfMappedLeafDomains();
+
+  loop_promotion_map_ = LoopPromotionMapBuilder::get(
+      *this, inlining_info, loop_promotion_map_builder_callback_);
+
+  // New domains are added. Make sure there's still no self mapping in
+  // the loop domains
+  validateLoopGraphHasNoSelfMappedLeafDomains();
+
+  idGraph(IdMappingMode::LOOP).validateConsistency();
+
+  return idGraph(IdMappingMode::LOOP);
+}
+
+void IdModel::buildAllGraphs() {
+  if (tvs_.empty()) {
+    return;
+  }
+
+  std::unique_ptr<IdModelValidator> validator;
+
+  Fusion* fusion = tvs_.front()->fusion();
+
+  // A ComputeAtMap will be built inside the constructor of
+  // IdModelValidator, which may fail for some fusions that are not
+  // supported currently (but work with IdModel). Make sure the
+  // validator is only created when it is indeed requested
+  if (validate_) {
+    validator = std::make_unique<IdModelValidator>(fusion, allow_self_mapping_);
+  }
+
+  FusionGuard fg(fusion);
+
+  buildExactGraph();
+  if (validate_) {
+    validator->checkExactGraphEquivalence(idGraph(IdMappingMode::EXACT));
+  }
+
+  // Make sure there's no self mapping in the Exact graph as that
+  // would invalidate lowering assumptions.
+  if (!allow_self_mapping_) {
+    assertNoSelfMapping();
+  }
+
+  buildAlmostExactGraph();
+  // Skip validating the almost exact graph as the IdModel graph also
+  // maps non-size-one broadcast domains
+
+  buildPermissiveGraph();
+  // Validation is not implemented when compliment mapping is enabled
+  if (!permissive_graph_map_compliment_ids_ && validate_) {
+    validator->checkPermissiveGraphEquivalence(
+        idGraph(IdMappingMode::PERMISSIVE));
+  }
+
+  buildLoopGraph();
+}
+
+void IdModel::buildGraph(IdMappingMode mode) {
+  switch (mode) {
+    case IdMappingMode::EXACT:
+      buildExactGraph();
+      break;
+    case IdMappingMode::ALMOSTEXACT:
+      buildAlmostExactGraph();
+      break;
+    case IdMappingMode::BROADCAST:
+      buildBroadcastGraph();
+      break;
+    case IdMappingMode::PERMISSIVE:
+      buildPermissiveGraph();
+      break;
+    case IdMappingMode::LOOP:
+      buildLoopGraph();
+      break;
+    default:
+      NVF_THROW("Unsupported mode: ", mode);
+  }
+}
+
+void IdModel::maybeBuildGraph(IdMappingMode mode) {
+  if (id_graphs_.find(mode) != id_graphs_.end()) {
+    return;
+  } else {
+    buildGraph(mode);
+  }
+}
+
+ValGraph IdModel::buildIntersection(
+    const ValGraph& graph0,
+    const ValGraph& graph1,
+    bool propagate_exprs) const {
+  ValGraph intersection = initializeIdGraph(propagate_exprs);
+  for (const ValGroup& group0 : graph0.disjointValSets().disjointSets()) {
+    auto set_size = group0->size();
+    for (auto id0_i : c10::irange(set_size)) {
+      Val* id0 = group0->vector()[id0_i];
+      for (auto id1_i = id0_i; id1_i < set_size; id1_i++) {
+        Val* id1 = group0->vector()[id1_i];
+        // id0 and id1 map in group0. If they also map in the group1,
+        // add the mapping to the intersection.
+        if (graph1.disjointValSets().strictAreMapped(id0, id1)) {
+          intersection.mapVals(id0, id1);
+        }
+      }
+    }
+  }
+  return intersection;
+}
+
+// Replay Expr but with the inputs provided.
+Expr* IdModel::addReplayAs(std::vector<IterDomain*> new_inputs, Expr* expr) {
+  // Figure out which graphs are already initialized to make sure we add the new
+  // expression to them.
+  std::vector<IdMappingMode> initialized_modes;
+  for (auto mode : kIdMappingModes) {
+    auto graph_it = id_graphs_.find(mode);
+    if (graph_it == id_graphs_.end()) {
+      continue;
+    }
+
+    auto& graph = graph_it->second;
+    if (graph.disjointValSets().disjointSetMap().empty()) {
+      continue;
+    }
+
+    initialized_modes.push_back(mode);
+  }
+
+  // Replace the provided inputs with IterType::Iteration domains as
+  // reduction domains cannot be merged with non-reduction domains.
+  if (std::any_of(
+          new_inputs.begin(),
+          new_inputs.end(),
+          [](IterDomain* id) { return id->isReduction(); }) &&
+      std::any_of(new_inputs.begin(), new_inputs.end(), [](IterDomain* id) {
+        return !id->isReduction();
+      })) {
+    // Inputs have mismatched type, replace new_inputs
+    auto tmp_inputs = new_inputs;
+    for (const auto i : c10::irange(new_inputs.size())) {
+      new_inputs.at(i) = IterDomainBuilder(tmp_inputs.at(i))
+                             .iter_type(IterType::Iteration)
+                             .build();
+      id_definitions_[new_inputs.at(i)];
+      id_uses_[new_inputs.at(i)];
+      for (auto mode : initialized_modes) {
+        idGraph(mode).initializeVal(
+            new_inputs.at(i), idGraph(mode).toGroup(tmp_inputs.at(i)));
+      }
+    }
+  }
+
+  const std::vector<IterDomain*> orig_input_ids =
+      ir_utils::filterByType<IterDomain>(expr->inputs()).vector();
+
+  // Sanity check of the original inputs
+  {
+    NVF_ERROR(
+        new_inputs.size() == orig_input_ids.size(),
+        "Invalid number of inputs: ",
+        new_inputs.size(),
+        " does not match number of iter domain inputs for ",
+        expr->toString());
+
+    for (auto mode : initialized_modes) {
+      for (auto inp : orig_input_ids) {
+        NVF_ERROR(
+            idGraph(mode).hasGroup(inp),
+            "All inputs for replay need to be initialized in all graphs, ",
+            inp->toString(),
+            " was not found in mode: ",
+            mode);
+      }
+    }
+  }
+
+  // Create the new expression with provided inputs
+  auto replay = ReplayTransform::replayAs(new_inputs, expr);
+  NVF_ERROR(replay != nullptr, "no replay found");
+
+  for (auto out_id : ir_utils::filterByType<IterDomain>(replay->outputs())) {
+    id_definitions_[out_id].pushBack(replay);
+    // out_id is a new IterDomain with no use expr yet. Initialize its
+    // use mapping with an empty set
+    NVF_ERROR(id_uses_.emplace(out_id, VectorOfUniqueEntries<Expr*>{}).second);
+  }
+
+  // Add the expression to the uses of the inputs
+  for (auto inp_id : ir_utils::filterByType<IterDomain>(replay->inputs())) {
+    // inp_id should not be a new domain, so just make sure it has a
+    // def mapping.
+    NVF_ERROR(id_definitions_.find(inp_id) != id_definitions_.end());
+    id_uses_[inp_id].pushBack(replay);
+  }
+
+  // Initialize output iter domains in the graphs
+  for (auto mode : initialized_modes) {
+    auto& graph = idGraph(mode);
+
+    // Initialize output ids in map. The replay expr will be
+    // registered as a definition by registerExpr
+    for (auto out_id : ir_utils::filterByType<IterDomain>(replay->outputs())) {
+      graph.initializeVal(out_id, {}, {});
+    }
+
+    graph.registerExpr(replay);
+
+    // Propagate through all the uses of the iter domain groups of the inputs
+    // with the new expression.
+    // Gather all use expressions from inputs
+    VectorOfUniqueEntries<Expr*> representative_uses;
+    for (IterDomain* inp : new_inputs) {
+      for (const ExprGroup& use_group : graph.getUses(graph.toGroup(inp))) {
+        NVF_ERROR(!use_group->empty());
+        representative_uses.pushBack(use_group->front());
+      }
+    }
+
+    for (auto rep_use : representative_uses) {
+      graph.maybeMapThroughExprs(rep_use, replay, true);
+    }
+  }
+
+  return replay;
+}
+
+void IdModel::validateLoopGraphHasNoSelfMappedLeafDomains() const {
+  for (auto tv : tvs_) {
+    auto self_mappped_loop_pair =
+        detectSelfMapping(tv->domain()->loop(), idGraph(IdMappingMode::LOOP));
+    NVF_ERROR(
+        !self_mappped_loop_pair.has_value(),
+        "Detected loop domains are mapped in the loop graph. Tensor: ",
+        tv->toString(),
+        ". Mapped loop domains: ",
+        self_mappped_loop_pair->first->toString(),
+        " and ",
+        self_mappped_loop_pair->second->toString());
+  }
+}
+
+std::unordered_map<ValGroup, IterDomain*> updateValGroupIdMap(
+    const std::unordered_map<ValGroup, IterDomain*>& stale_map,
+    ValGraph& new_graph) {
+  std::unordered_map<ValGroup, IterDomain*> new_map;
+
+  for (const auto& [stale_group, mapped_id] : stale_map) {
+    const ValGroups& new_groups = new_graph.toGroups(*stale_group);
+    NVF_ERROR(
+        new_groups.size() == 1,
+        "\nUpdate map assumes that new graph is equivalent to old graph plus extra mappings.\n",
+        "i.e. all mappings in new_graph should exist in the graph stale_map was produced on.\n",
+        "old:",
+        nvfuser::toString(stale_group),
+        "new: ",
+        nvfuser::toString(new_groups));
+    NVF_ERROR(
+        new_map.emplace(new_groups.front(), mapped_id).second,
+        "Expected only a single mapping but multiple entries detected for ",
+        nvfuser::toString(new_groups.front()));
+  }
+  return new_map;
+}
+
+// Mostly just copied from ComputeAtMap::validateAndPropagatePType
+void IdModel::validateAndPropagatePType() {
+  for (const ValGroup& loop_group :
+       idGraph(IdMappingMode::LOOP).disjointValSets().disjointSets()) {
+    ParallelType common_ptype = ParallelType::Serial;
+    for (Val* id : *loop_group) {
+      auto id_ptype = id->as<IterDomain>()->getParallelType();
+      NVF_ERROR(
+          id_ptype == common_ptype || id_ptype == ParallelType::Serial ||
+              common_ptype == ParallelType::Serial,
+          "Issue validating parallel type disjoint ptype is, ",
+          common_ptype,
+          " but found in the set the id: ",
+          id->toString());
+      common_ptype =
+          common_ptype == ParallelType::Serial ? id_ptype : common_ptype;
+    }
+
+    for (auto id : *loop_group) {
+      // Due to the broadcast forwarding, not all IDs in a loop group
+      // are indeed loop domains. For example, an ID may be used in a
+      // merge whose output is also in this loop group.
+      bool not_a_loop_domain = false;
+      for (auto expr : id->uses()) {
+        if (auto merge = dynamic_cast<Merge*>(expr);
+            merge != nullptr && loop_group->has(merge->out())) {
+          not_a_loop_domain = true;
+          break;
+        }
+        // This is another case of input-output mappings
+        if (auto swizzle2d = dynamic_cast<Swizzle2D*>(expr);
+            swizzle2d != nullptr &&
+            swizzle2d->swizzleMode() == SwizzleMode::Loop) {
+          not_a_loop_domain = true;
+          break;
+        }
+      }
+      if (not_a_loop_domain) {
+        continue;
+      }
+      id->as<IterDomain>()->parallelize(common_ptype);
+    }
+  }
+}
+
+void IdModel::allocateLoopIndexVariables() {
+  FusionGuard fg(fusion_);
+
+  NVF_ERROR(GpuLower::hasCurrent());
+
+  NVF_ERROR(
+      hasIdGraph(IdMappingMode::LOOP),
+      "getLoopIndexVariable requires Loop graph");
+
+  // Follow the same logic as ComputeAtMap::allocateIndexVariables
+  for (const ValGroup& loop_group :
+       idGraph(IdMappingMode::LOOP).disjointValSets().disjointSets()) {
+    auto loop_promotion_map_it = loop_promotion_map_.find(loop_group);
+
+    // Not all loop groups actually correspond to a for-loop. Ideally,
+    // non for-loop loop groups should be removed. Such loop groups do
+    // not need indices and don't have loop promotion.
+    if (loop_promotion_map_it == loop_promotion_map_.end()) {
+      continue;
+    }
+
+    ParallelType ptype = getParallelType(loop_group);
+
+    Val* loop_index = nullptr;
+
+    // TODO: Cleanup needed. ir_utils::isMemoryPartitionedAcross
+    // should be used, but that means we would need to consider
+    // multiple outputs with different memory types, though it
+    // should be uncommon in practice.
+    if (shouldUseZeroIndex(loop_group, *this) ||
+        isParallelTypeDeviceDim(ptype)) {
+      loop_index = fusion_->zeroVal();
+    } else if (isParallelTypeThread(ptype)) {
+      loop_index = NamedScalar::getParallelIndex(ptype);
+    }
+
+    if (loop_index != nullptr) {
+      loop_index_variable_map_[loop_group] = loop_index;
+      continue;
+    }
+
+    if (GpuLower::current()->circularBufferInfo().isCircularBufferedIterDomain(
+            loop_group->front()->as<IterDomain>())) {
+      // Allocate index variable for each stage of the circular buffered loop.
+      circular_buffered_loop_index_variable_map_[loop_group] =
+          std::make_unique<CircularBufferIndices>(CircularBufferIndices(
+              {{CircularBufferLoopStage::Prolog,
+                IrBuilder::create<Val>(DataType::Index)},
+               {CircularBufferLoopStage::Main,
+                IrBuilder::create<Val>(DataType::Index)},
+               {CircularBufferLoopStage::Epilog,
+                IrBuilder::create<Val>(DataType::Index)}}));
+      continue;
+    }
+
+    // If enabled, allocate own indices. Otherwise, use the one
+    // generated for ComputeAtMap for compatibility with the legacy
+    // indexing
+    if (GpuLower::current()->idModelOptions().loop()) {
+      loop_index = IrBuilder::create<Val>(DataType::Index);
+    } else {
+      const auto& ca_map = GpuLower::current()->caMap();
+      for (const auto& id :
+           ir_utils::filterByType<IterDomain>(loop_group->vector())) {
+        if (!ca_map->getIdSets(IdMappingMode::LOOP).mappingExists(id)) {
+          continue;
+        }
+        loop_index = ca_map->getIndexVariable(id);
+        break;
+      }
+      NVF_ERROR(
+          loop_index != nullptr,
+          "No existing index found for ",
+          nvfuser::toString(loop_group));
+    }
+
+    NVF_ERROR(loop_index != nullptr);
+    loop_index_variable_map_[loop_group] = loop_index;
+  }
+
+  return;
+}
+
+Val* IdModel::getLoopIndexVariable(
+    const ValGroup& loop_group,
+    CircularBufferLoopStage circular_buffer_loop_stage) const {
+  NVF_ERROR(
+      !loop_index_variable_map_.empty(),
+      "Loop index variables not generated. IdModel::allocateIndexVariables may have not been callled.");
+
+  // Check if this loop was modified by circular buffer pass.
+  bool is_circular_buffer_iterdomain =
+      GpuLower::current()->circularBufferInfo().isCircularBufferedIterDomain(
+          loop_group->front()->as<IterDomain>());
+
+  if (is_circular_buffer_iterdomain) {
+    // Use dedicated circular buffer index variable if the loop is circular
+    // buffer loop
+    if (circular_buffer_loop_stage == CircularBufferLoopStage::NotApplicable) {
+      // The circular buffered loop stages are created after the loop nest
+      //  lowering phase so this function will be querried before the double
+      //  buffer pass. At that point, no forloop has any circular buffer
+      //  stage defined, and we just default to using the main stage index.
+      circular_buffer_loop_stage = CircularBufferLoopStage::Main;
+    }
+    return circular_buffered_loop_index_variable_map_.at(loop_group)
+        ->at(circular_buffer_loop_stage);
+  } else {
+    return loop_index_variable_map_.at(loop_group);
+  }
+}
+
+Val* IdModel::getLoopIndexVariable(
+    IterDomain* id,
+    CircularBufferLoopStage circular_buffer_loop_stage) const {
+  const auto& loop_group = idGraph(IdMappingMode::LOOP).toGroup(id);
+  return getLoopIndexVariable(loop_group, circular_buffer_loop_stage);
+}
+
+} // namespace nvfuser

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -204,6 +204,20 @@ void IdModel::buildIterDomainDefinitionsAndUses() {
         continue;
       }
 
+      // If any of the inputs is not included in the all ID set, do
+      // not include the definition in the model. Note that it is
+      // possible that some are included but not all since a single ID
+      // may be used by multiple exprs.
+      if (std::any_of(
+              def->inputs().begin(), def->inputs().end(), [&](Val* inp) {
+                return std::find(
+                           all_ids.begin(),
+                           all_ids.end(),
+                           inp->as<IterDomain>()) == all_ids.end();
+              })) {
+        continue;
+      }
+
       id_definitions_[id].pushBack(def);
 
       auto inp_ids = ir_utils::filterByType<IterDomain>(def->inputs());

--- a/csrc/scheduler/tools/loop_domain_scheduler.cpp
+++ b/csrc/scheduler/tools/loop_domain_scheduler.cpp
@@ -396,8 +396,6 @@ void scheduleLoopDomainsBy(
   const ValGroups output_groups = exact_graph.toGroups(transform->outputs());
 
   for (auto tv : tvs) {
-    const ValGroups loop_groups = exact_graph.toGroups(tv->getLoopDomain());
-
     // Check if either the inputs or the outputs are mapped with the
     // loop domain.
 

--- a/csrc/scheduler/tools/loop_domain_scheduler.h
+++ b/csrc/scheduler/tools/loop_domain_scheduler.h
@@ -25,13 +25,36 @@ void scheduleLoopDomainsLike(
     const std::vector<IterDomain*>& ref_loop_dom);
 
 // Replay a transform expr on the loop domain of each of the given
-// tensors. If the input of the transform matches with the loop
+// tensors. If the input of the transform is exact mapped with the loop
 // domain, the transform is replayed as a forward op. If the output
-// matches with the loop domain, it's replayed as a backward
+// is exact mapped with the loop domain, it's replayed as a backward
 // op. The loop domain of each tensor is updated with the replayed
 // transform expr. If it's replayed as a forward op, the outputs
 // replace the inputs in the loop domain. If it's replayed as a
-// backward op, the inputs replace the outputs in the loop domain.
+// backward op, the inputs replace the outputs in the loop domain. The
+// new IDs are inserted at the outermost position of the input IDs.
+//
+// For example, suppose a fusion has:
+//
+// t0 = makeSymbolicTensor(1);
+// t1 = sin(t0);
+// t2 = t1[1:]); // slice
+//
+// In this case, t2 has a resize op with a left expansion factor of
+// -1. This function can be used to propagate this resize onto t1 as
+// follows:
+//
+// scheduleLoopDomainsBy({t1}, t2->axis(0)->definition());
+//
+// Then the t1 domain should look like:
+//
+// Logical: i0
+//  resize i0 by {-1, 0} -> i1
+// Loop: i1
+//
+// Now that the loop domain of t1 and t2 are exact mapped, it's also
+// possible to inline t1 into the innermost position of t2. See
+// LoopDomainSchedulingTest.ScheduleLoopDomainsBy1 for more examples.
 void scheduleLoopDomainsBy(
     const std::vector<TensorView*>& tvs,
     Expr* transform);

--- a/csrc/scheduler/tools/loop_domain_scheduler.h
+++ b/csrc/scheduler/tools/loop_domain_scheduler.h
@@ -11,6 +11,7 @@
 
 namespace nvfuser {
 
+class Expr;
 class TensorView;
 class IterDomain;
 
@@ -22,6 +23,18 @@ namespace scheduler_tools {
 void scheduleLoopDomainsLike(
     const std::vector<TensorView*>& tvs,
     const std::vector<IterDomain*>& ref_loop_dom);
+
+// Replay a transform expr on the loop domain of each of the given
+// tensors. If the input of the transform matches with the loop
+// domain, the transform is replayed as a forward op. If the output
+// matches with the loop domain, it's replayed as a backward
+// op. The loop domain of each tensor is updated with the replayed
+// transform expr. If it's replayed as a forward op, the outputs
+// replace the inputs in the loop domain. If it's replayed as a
+// backward op, the inputs replace the outputs in the loop domain.
+void scheduleLoopDomainsBy(
+    const std::vector<TensorView*>& tvs,
+    Expr* transform);
 
 } // namespace scheduler_tools
 } // namespace nvfuser

--- a/tests/cpp/test_loop_domain_scheduling.cpp
+++ b/tests/cpp/test_loop_domain_scheduling.cpp
@@ -317,4 +317,67 @@ TEST_F(LoopDomainSchedulingTest, ManyReshape) {
   }
 }
 
+// Testing scheduleLoopDomainsBy with a trivial fusion
+TEST_F(LoopDomainSchedulingTest, ScheduleLoopDomainsBy) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape({100});
+
+  // concrete shapes to avoid dynamic Fusion
+  auto tv0 = makeConcreteTensor(shape);
+  fusion.addInput(tv0);
+
+  auto tv1 = unaryOp(UnaryOpType::Sin, tv0);
+  auto tv2 = unaryOp(UnaryOpType::Cos, tv1);
+  auto tv3 =
+      slice(tv2, {{IrBuilder::create<Val>(1L), IrBuilder::create<Val>(99)}});
+  auto tv4 = unaryOp(UnaryOpType::Exp, tv3);
+
+  fusion.addOutput(tv4);
+
+  auto resize = tv3->getLogicalDomain().at(0)->definition()->as<Resize>();
+
+  scheduler_tools::scheduleLoopDomainsBy({tv1, tv2, tv4}, resize);
+
+  // tv1 and tv2 should have the same loop domain as tv3's loop domain
+  IdModel id_model(&fusion, /*build_graphs=*/false);
+  const auto& exact_graph = id_model.buildExactGraph();
+  EXPECT_EQ(
+      exact_graph.toGroups(tv1->getLoopDomain()),
+      exact_graph.toGroups(tv3->getLoopDomain()));
+  EXPECT_EQ(
+      exact_graph.toGroups(tv2->getLoopDomain()),
+      exact_graph.toGroups(tv3->getLoopDomain()));
+  // In the case of tv4, its logical ID is mapped with the resize
+  // output ID, so the resize op is replayed such that the logical ID
+  // is produced by the resize op. The loop domain is then set to the
+  // input ID of the resize op, so the tv4 loop domain should be equal
+  // to the root domain of tv3.
+  auto tv4_resize =
+      dynamic_cast<Resize*>(tv4->getLogicalDomain().at(0)->definition());
+  EXPECT_NE(tv4_resize, nullptr);
+  EXPECT_EQ(
+      exact_graph.toGroups(tv4->getLoopDomain()),
+      exact_graph.toGroups(tv3->getRootDomain()));
+
+  // Reset the loop domains
+  tv1->setLoopDomain(tv1->getLogicalDomain());
+  tv2->setLoopDomain(tv2->getLogicalDomain());
+  tv4->setLoopDomain(tv4->getLogicalDomain());
+
+  // This time, apply some scheduling to tv1 and tv2 before using
+  // scheduleLoopDomainsBy. The resize op should not be replayed as
+  // their loop domains no longer match with any of the resize input
+  // or output IDs.
+  tv1->split(0, 4);
+  auto tv1_loop_domain = tv1->getLoopDomain();
+  tv2->split(0, 2);
+  auto tv2_loop_domain = tv2->getLoopDomain();
+  scheduler_tools::scheduleLoopDomainsBy({tv1, tv2}, resize);
+
+  EXPECT_EQ(tv1->getLoopDomain(), tv1_loop_domain);
+  EXPECT_EQ(tv2->getLoopDomain(), tv2_loop_domain);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Extracted from #3425 

A simple scheduling utility that replays a single transform expr on the loop domain of a given tensor. It is conceptually similar to the existing transform propagator, but this interface can also replay a transform expr not just as a forward expr but also as a backward expr. 

The existing `scheduler_tools::scheduleLoopDomainsLike` can also be used to propagate loop domains across tensors, but I encountered with a couple of issues due to the resize mapping [issue](#3455). This `scheduleLoopDomainsBy` gives more explicit control to set loop domains with resize ops.