### PR TITLE
Skip loop promotion analysis a little more aggressively

### DIFF
--- a/csrc/id_model/loop_promotion.cpp
+++ b/csrc/id_model/loop_promotion.cpp
@@ -102,7 +102,6 @@ namespace {
 // loop groups of the loop domains need to be checked as loop
 // promotion does not matter for the other domains.
 bool isLoopGraphUniform(const IdModel& id_model) {
-  const auto& loop_graph = id_model.idGraph(IdMappingMode::LOOP);
   for (const auto tv : id_model.tvs()) {
     if (tv->isFusionInput()) {
       continue;


### PR DESCRIPTION
Currently we check all loop groups, no matter if they correspond to loop IDs. For loop promotion, we only need to consider loop domains when checking if the full loop promotion analysis can be skipped. This refinement was necessary when playing with scheduling approaches for resize, although it is not currently necessary in #3425. I think this is generally better than the current method.