### PR TITLE
Adding alignment check to handle stride check for resize-introduced non-contiguous access

### DIFF
--- a/csrc/scheduler/compile_time_info.h
+++ b/csrc/scheduler/compile_time_info.h
@@ -38,6 +38,7 @@ enum class CompileTimeEntryType {
   VECTORIZABLE_INPUTS_AND_OUTPUTS,
   INPUTS_AND_OUTPUTS_INNER_DIM_GROUPS,
   TV_TO_CONTIG_INNER_SIZE_MAPS,
+  TV_TO_RESIZE_ALIGNMENT_INFO_MAPS,
   UNROLLABLE_INPUTS_AND_OUTPUTS,
   REDUCTION_TVS,
   PERSISTENT_BUFFER_INFO,
@@ -98,12 +99,20 @@ class VectorizableInputsAndOutputs {
 };
 
 //! Entry type definition class for `TV_TO_CONTIG_INNER_SIZE_MAPS`,
-//!  stores the vectorizable TensorViews on a fusion's inputs and outputs.
 class TvToContigInnerSizeMaps {
  public:
   using DataType = std::vector<std::unordered_map<TensorView*, Val*>>;
   static const CompileTimeEntryType EntryType =
       CompileTimeEntryType::TV_TO_CONTIG_INNER_SIZE_MAPS;
+};
+
+//! Entry type definition class for `TV_TO_RESIZE_ALIGNMENT_INFO_MAPS`,
+class TvToResizeAlignmentInfoMaps {
+ public:
+  using DataType = std::
+      unordered_map<TensorView*, vectorize_helper::TensorResizeAlignmentInfo>;
+  static const CompileTimeEntryType EntryType =
+      CompileTimeEntryType::TV_TO_RESIZE_ALIGNMENT_INFO_MAPS;
 };
 
 //! Entry type definition class for `INPUTS_AND_OUTPUTS_INNER_DIM_GROUPS`,

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -216,6 +216,8 @@ template class HeuristicDataCacheEntry<
 template class HeuristicDataCacheEntry<
     HeuristicCompileTime::TvToContigInnerSizeMaps>;
 template class HeuristicDataCacheEntry<
+    HeuristicCompileTime::TvToResizeAlignmentInfoMaps>;
+template class HeuristicDataCacheEntry<
     HeuristicCompileTime::InputsOutputsInnerDimGroups>;
 template class HeuristicDataCacheEntry<
     HeuristicCompileTime::UnrollableInputsAndOutputs>;

--- a/csrc/scheduler/runtime_info.h
+++ b/csrc/scheduler/runtime_info.h
@@ -12,6 +12,7 @@
 #include <expr_evaluator.h>
 #include <fusion.h>
 #include <runtime/executor_kernel_arg.h>
+#include <scheduler/vectorize_helper.h>
 #include <utils.h>
 #include <visibility.h>
 
@@ -57,10 +58,16 @@ class SchedulerRuntimeInfo : public NonCopyable {
       const at::ArrayRef<c10::IValue>& aten_inputs);
 
   //! Lookup for the alignment sizes of the given tv. Currently only returns
-  //!  actual alignment info for input tensors to the complete fusion,
-  //!  and for other intermediate/fuser-allocated tensors will
-  //!  return max_alignment_size_in_byte.
-  size_t getAlignmentSize(TensorView* tv);
+  //! actual alignment info for input tensors to the complete fusion,
+  //! and for other intermediate/fuser-allocated tensors will
+  //! return max_alignment_size_in_byte. datatype_size needs to be passed here
+  //! because index dtype could be undefined during compile time.
+  size_t getAlignmentSize(
+      TensorView* tv,
+      int64_t datatype_size,
+      const std::unordered_map<
+          TensorView*,
+          vectorize_helper::TensorResizeAlignmentInfo>& resize_alignment_map);
 
   //! Returns sizes of tensor dimensions in same order as allocation domain,
   //! ignoring any IterType::Reduction domains in the allocation domain. This

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -842,7 +842,7 @@ std::vector<std::unordered_map<TensorView*, Val*>> getTvToContigInnerSizeMapsOf(
   return mappers;
 }
 
-// The returns a map of input to their resize alignment info. This function
+// Returns a map of input to their resize alignment info. This function
 // currently checks the alignment requirement on contiguous iterdomain in
 // allocation domain that *could be* broken by resize. This function returns a
 // map for TensorView, containing the index in their allocation domain whose
@@ -871,6 +871,8 @@ mapResizeAlignmentToInputs(TensorView* ref) {
   for (auto inp : in_tvs) {
     auto inp_alloc_dom = inp->getMaybeAllocationDomain();
 
+    // We check each non-broadcast ID against its non-broadcast inner ID. For a
+    // size-1 allocation domain, there's nothing to check.
     if (inp_alloc_dom.size() <= 1) {
       continue;
     }
@@ -882,6 +884,9 @@ mapResizeAlignmentToInputs(TensorView* ref) {
         continue;
       }
 
+      // inner_i is the index of the dimension in allocation domain, that
+      // current dimension's contiguity collapsed to if applicable. We need to
+      // seach across to skip broadcast dimensions.
       int64_t inner_i = i + 1;
       while (inner_i < (int64_t)contiguity.size() &&
              !contiguity[inner_i].has_value()) {

--- a/csrc/scheduler/vectorize_helper.h
+++ b/csrc/scheduler/vectorize_helper.h
@@ -310,6 +310,16 @@ class NVF_API ContiguousInnerDimensionsMapper
   std::unordered_map<IterDomain*, Val*> projected_extent_;
 };
 
+// Holding information needed for vectorization factor check specific for resize
+// operation. Currently we only checks strides for alignment. The offset changed
+// by resize is enforced through the propagation.
+struct TensorResizeAlignmentInfo {
+  // SchedulerRuntimeInfo::getInputAllocationSizes use this to check alignment
+  // of strides on dimensions that becomes non-contiguous after resize
+  // operations.
+  std::vector<int64_t> non_contig_idx_alloc;
+};
+
 // logical_reorder_map is provided to assume reference_tv will be reordered per
 // the map, hence changing the order of IterDomain in the reference
 int64_t getVectorizationFactor(


### PR DESCRIPTION
Previously, vectorization analysis can only support resize in `PadOp` with positive extents: 1. General resize operation or negative extent would exclude the resized iter domain to participate in vectorized data movement; 2. Sliced inputs wouldn't have vectorized load.

This is a series of stacked PRs to adds support in vectorization analysis for general resize and it allows vectorized load on sliced inputs as well.

Order of PRs:

1. Adding general support for `resize` op in `propagateResize` during projection; Adding support for negative resize extent in propagation. #3457

[with updated more restrictive analysis on 1, the second PR is only optional at this point.]
**2. Adding alignment check on stride for resize-introduced non-contiguity, where a contiguous dimension becomes non-contiguous due to resize on its immediate inner dimension.**

3. Enable vectorized load on slice, refactoring slice vectorize manual test to use automatic scheduler instead. #3529