### PR TITLE
Skip C++ matmul benchmarks on Hopper

### DIFF
--- a/benchmarks/cpp/matmul.cpp
+++ b/benchmarks/cpp/matmul.cpp
@@ -405,6 +405,12 @@ static void NvFuserScheduler_Matmul(
   NVFUSER_BENCHMARK_ARCH_SMEM_GUARD(
       8, 0, getSmemSize(cta_tile, number_of_stage), benchmark_state);
 
+  if (cudaArchGuardShouldSkip(8, 0, 9, 0)) {
+    benchmark_state.SkipWithError(
+        "This Fusion includes broadcasts on the operands, which is not supported on Hopper+");
+    return;
+  }
+
   // Run benchmark:
   if (partitionedk) {
     SingleMatmulPartitionedK(benchmark_state, layout, &mparams, splitk_factor);


### PR DESCRIPTION
Currently the C++ matmul benchmarks are defined with broadcasts and we do not strip them in the Hopper automatic scheduler. Instead we assert that there are no extraneous ops in the prologue like `BroadcastOp`, which causes the benchmark to fail. This PR simply skips these tests on Hopper.