### PR TITLE
Update FunctionTrace{1,2} tests to reflect renamed file

### DIFF
--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -47,7 +47,7 @@ TEST_F(NVFuserTest, FunctionTrace1) {
   EXPECT_THAT(
       ss.str(),
       ::testing::HasSubstr("Leaving myFavoriteFunction returning 3 at "));
-  EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_gpu_utils.cpp:32"));
+  EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_utils.cpp:32"));
 #else
   GTEST_SKIP() << "Test only runs in debug mode";
 #endif
@@ -65,7 +65,7 @@ TEST_F(NVFuserTest, FunctionTrace2) {
   EXPECT_THAT(
       ss.str(),
       ::testing::HasSubstr("Leaving myFavoriteFunction returning -3 at "));
-  EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_gpu_utils.cpp:34"));
+  EXPECT_THAT(ss.str(), ::testing::HasSubstr("test_utils.cpp:34"));
 #else
   GTEST_SKIP() << "Test only runs in debug mode";
 #endif


### PR DESCRIPTION
This fixes a failure on TOT that has probably been present since #3126 was merged. This might not have been noticed previously since this test only runs in Debug mode.