### PR TITLE
More pattern matching in  `SimplifyingIrBuilder::addExpr`

### DIFF
--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -254,7 +254,8 @@ class IndexValidator : public kir::IrVisitor {
     Val* actual = ti->index();
     Val* ref = get_ref_.getLinearIndex(tv, maybe_consumer);
     if (ref != nullptr) {
-      EXPECT_TRUE(actual->sameAs(ref))
+      Val* is_equal = IrBuilder::eqExpr(actual, ref);
+      EXPECT_TRUE(simplifyExpr(is_equal)->isTrue())
           << "Validation failure of " << ti->view()->toString() << " as "
           << (out_ti != nullptr ? "producer" : "consumer")
           << "\nRef: " << ref->toInlineString()
@@ -380,7 +381,8 @@ class PredicateIndexValidator : public kir::IrVisitor {
     TensorView* tv = ti->view();
     Val* ref = get_ref_.getInlinePredicate(tv);
     if (ref != nullptr) {
-      EXPECT_TRUE(actual->sameAs(ref))
+      Val* is_equal = IrBuilder::eqExpr(actual, ref);
+      EXPECT_TRUE(simplifyExpr(is_equal)->isTrue())
           << "Validation failure of inline predicate for "
           << ti->view()->toString() << "\nRef: " << ref->toInlineString()
           << "\nActual: " << actual->toInlineString();
@@ -402,7 +404,8 @@ class PredicateIndexValidator : public kir::IrVisitor {
         loop_stage_msg << " in " << loop_stage;
       }
       std::stringstream actual_str;
-      EXPECT_TRUE(actual->sameAs(ref))
+      Val* is_equal = IrBuilder::eqExpr(actual, ref);
+      EXPECT_TRUE(simplifyExpr(is_equal)->isTrue())
           << "Validation failure of outer predicate for "
           << ti->view()->toString() << loop_stage_msg.str() << "\nRef:\n"
           << prettyPrintPredicate(ref) << "Actual:\n"

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -254,8 +254,7 @@ class IndexValidator : public kir::IrVisitor {
     Val* actual = ti->index();
     Val* ref = get_ref_.getLinearIndex(tv, maybe_consumer);
     if (ref != nullptr) {
-      Val* is_equal = IrBuilder::eqExpr(actual, ref);
-      EXPECT_TRUE(simplifyExpr(is_equal)->isTrue())
+      EXPECT_TRUE(actual->sameAs(ref))
           << "Validation failure of " << ti->view()->toString() << " as "
           << (out_ti != nullptr ? "producer" : "consumer")
           << "\nRef: " << ref->toInlineString()
@@ -381,8 +380,7 @@ class PredicateIndexValidator : public kir::IrVisitor {
     TensorView* tv = ti->view();
     Val* ref = get_ref_.getInlinePredicate(tv);
     if (ref != nullptr) {
-      Val* is_equal = IrBuilder::eqExpr(actual, ref);
-      EXPECT_TRUE(simplifyExpr(is_equal)->isTrue())
+      EXPECT_TRUE(actual->sameAs(ref))
           << "Validation failure of inline predicate for "
           << ti->view()->toString() << "\nRef: " << ref->toInlineString()
           << "\nActual: " << actual->toInlineString();
@@ -404,8 +402,7 @@ class PredicateIndexValidator : public kir::IrVisitor {
         loop_stage_msg << " in " << loop_stage;
       }
       std::stringstream actual_str;
-      Val* is_equal = IrBuilder::eqExpr(actual, ref);
-      EXPECT_TRUE(simplifyExpr(is_equal)->isTrue())
+      EXPECT_TRUE(actual->sameAs(ref))
           << "Validation failure of outer predicate for "
           << ti->view()->toString() << loop_stage_msg.str() << "\nRef:\n"
           << prettyPrintPredicate(ref) << "Actual:\n"

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -285,9 +285,9 @@ class IndexValidator : public kir::IrVisitor {
     EnableOptionsGuard::getCurOptions().set(
         EnableOption::IdModel, {"consumer_index", "producer_index"});
 
-    // Disable simplifications to make the pattern matching of sameAs work
+    // Disable index hoisting to make the pattern matching of
+    // simplifyExpr(actual, ref)->isTrue() work
     DisableOptionsGuard disable_options_guard;
-    DisableOptionsGuard::getCurOptions().set(DisableOption::ExprSimplify);
     DisableOptionsGuard::getCurOptions().set(DisableOption::IndexHoist);
     // Magic zero is not yet supported
     DisableOptionsGuard::getCurOptions().set(DisableOption::MagicZero);
@@ -425,9 +425,9 @@ class PredicateIndexValidator : public kir::IrVisitor {
     EnableOptionsGuard::getCurOptions().set(
         EnableOption::IdModel, {"predicate"});
 
-    // Disable simplifications to make the pattern matching of sameAs work
+    // Disable index hoisting to make the pattern matching of
+    // simplifyExpr(actual, ref)->isTrue() work
     DisableOptionsGuard disable_options_guard;
-    DisableOptionsGuard::getCurOptions().set(DisableOption::ExprSimplify);
     DisableOptionsGuard::getCurOptions().set(DisableOption::IndexHoist);
     // Magic zero is not yet supported
     DisableOptionsGuard::getCurOptions().set(DisableOption::MagicZero);

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -5201,7 +5201,6 @@ TEST_F(IndexingTest, PerDimLogicalIndices) {
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
   DisableOptionsGuard disable_options_guard;
-  DisableOptionsGuard::getCurOptions().set(DisableOption::ExprSimplify);
   DisableOptionsGuard::getCurOptions().set(DisableOption::IndexHoist);
 
   GpuLower lower(&fusion);

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -3493,9 +3493,8 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering2) {
       // uses 0 for start and (vec_factor - 1) for stop
 
       // Start index: (i0 * 128) * 4
-      Val* start_idx = mulExpr(
-          IrBuilder::addExpr(mulExpr(loop_indices.at(0), createInt(128)), zero),
-          createInt(4));
+      Val* start_idx =
+          mulExpr(mulExpr(loop_indices.at(0), createInt(128)), createInt(4));
       // Stop index: (i0 * 128 + 129) * 4 + 3
       Val* stop_idx = addExpr(
           mulExpr(

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -3492,13 +3492,10 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering2) {
       // to the vectorization. Since it's vectorized, the predicate
       // uses 0 for start and (vec_factor - 1) for stop
 
-      // Start index: (i0 * 128 + 0) * 4 + 0
-      Val* start_idx = IrBuilder::addExpr(
-          mulExpr(
-              IrBuilder::addExpr(
-                  mulExpr(loop_indices.at(0), createInt(128)), zero),
-              createInt(4)),
-          zero);
+      // Start index: (i0 * 128 + 0) * 4
+      Val* start_idx = mulExpr(
+          IrBuilder::addExpr(mulExpr(loop_indices.at(0), createInt(128)), zero),
+          createInt(4));
       // Stop index: (i0 * 128 + 129) * 4 + 3
       Val* stop_idx = addExpr(
           mulExpr(
@@ -3597,13 +3594,10 @@ TEST_P(PredicateIndexingTest, UnswitchedCircularBuffering3) {
       // to the vectorization. Since it's vectorized, the predicate
       // uses 0 for start and (vec_factor - 1) for stop
 
-      // Start index: (i0 * 128 + 0) * 4 + 0
-      Val* start_idx = IrBuilder::addExpr(
-          mulExpr(
-              IrBuilder::addExpr(
-                  mulExpr(loop_indices.at(0), createInt(128)), zero),
-              createInt(4)),
-          zero);
+      // Start index: (i0 * 128 + 0) * 4
+      Val* start_idx = mulExpr(
+          IrBuilder::addExpr(mulExpr(loop_indices.at(0), createInt(128)), zero),
+          createInt(4));
       // Stop index: (i0 * 128 + 129) * 4 + 3
       Val* stop_idx = addExpr(
           mulExpr(

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -3413,11 +3413,8 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering1) {
       // where i2 is the circular buffer index. The index of iUS10 is
       // not included as its extent is 1.
 
-      // NOTE: Expression Simplification is disabled in PredicateIndexValidator,
-      // so trivial addition appears in the expression.
-      // Start index: i0 * 4 + 0
-      Val* start_idx = IrBuilder::addExpr(
-          IrBuilder::mulExpr(loop_indices.at(0), createInt(4)), createInt(0));
+      // Start index: i0 * 4
+      Val* start_idx = IrBuilder::mulExpr(loop_indices.at(0), createInt(4));
 
       // Stop index: i0 * 4 + 4
       // Note that it isn't "i0 * 4 + 3" since i2 is circular buffered
@@ -3490,8 +3487,6 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering2) {
     Val* getOuterPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_, for_loops_);
 
-      auto zero = tv->fusion()->zeroVal();
-
       // The base index is:
       //
       // (i0 * 128 + i2) * 4 + i3
@@ -3500,13 +3495,10 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering2) {
       // to the vectorization. Since it's vectorized, the predicate
       // uses 0 for start and (vec_factor - 1) for stop
 
-      // Start index: (i0 * 128 + 0) * 4 + 0
-      Val* start_idx = IrBuilder::addExpr(
-          mulExpr(
-              IrBuilder::addExpr(
-                  mulExpr(loop_indices.at(0), createInt(128)), zero),
-              createInt(4)),
-          zero);
+      // Start index: (i0 * 128) * 4
+      Val* start_idx = mulExpr(
+          IrBuilder::addExpr(mulExpr(loop_indices.at(0), createInt(128)), zero),
+          createInt(4));
       // Stop index: (i0 * 128 + 129) * 4 + 3
       Val* stop_idx = addExpr(
           mulExpr(
@@ -3595,8 +3587,6 @@ TEST_P(PredicateIndexingTest, UnswitchedCircularBuffering3) {
     Val* getOuterPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_, for_loops_);
 
-      auto zero = tv->fusion()->zeroVal();
-
       // The base index is:
       //
       // (i0 * 128 + i2) * 4 + i3
@@ -3605,13 +3595,9 @@ TEST_P(PredicateIndexingTest, UnswitchedCircularBuffering3) {
       // to the vectorization. Since it's vectorized, the predicate
       // uses 0 for start and (vec_factor - 1) for stop
 
-      // Start index: (i0 * 128 + 0) * 4 + 0
-      Val* start_idx = IrBuilder::addExpr(
-          mulExpr(
-              IrBuilder::addExpr(
-                  mulExpr(loop_indices.at(0), createInt(128)), zero),
-              createInt(4)),
-          zero);
+      // Start index: (i0 * 128) * 4
+      Val* start_idx =
+          mulExpr(mulExpr(loop_indices.at(0), createInt(128)), createInt(4));
       // Stop index: (i0 * 128 + 129) * 4 + 3
       Val* stop_idx = addExpr(
           mulExpr(

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -3401,8 +3401,6 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering1) {
     Val* getOuterPredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_, for_loops_);
 
-      auto zero = tv->fusion()->zeroVal();
-
       // The base index is:
       //
       // i0 * 4 + i2
@@ -3421,7 +3419,7 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering1) {
           IrBuilder::mulExpr(loop_indices.at(0), createInt(4)), createInt(4));
 
       return andExpr(
-          geExpr(start_idx, zero),
+          geExpr(start_idx, tv->fusion()->zeroVal()),
           ltExpr(stop_idx, tv->getLogicalDomain().at(0)->extent()));
     }
   };
@@ -3504,7 +3502,7 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering2) {
           createInt(3));
 
       return andExpr(
-          geExpr(start_idx, zero),
+          geExpr(start_idx, tv->fusion()->zeroVal()),
           ltExpr(stop_idx, tv->getLogicalDomain().at(0)->extent()));
     }
   };

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -2978,8 +2978,7 @@ TEST_F(PredicateIndexingTest, NonInnermostVectorize) {
                   loop_indices.at(1)),
               tv->axis(3)->extent()),
           loop_indices.at(3));
-      auto start_idx = IrBuilder::addExpr(
-          mulExpr(common_idx, tv->axis(2)->extent()), tv->fusion()->zeroVal());
+      auto start_idx = mulExpr(common_idx, tv->axis(2)->extent());
       auto stop_idx = addExpr(
           mulExpr(common_idx, tv->axis(2)->extent()),
           subExpr(tv->axis(2)->extent(), createInt(1)));

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -3601,7 +3601,7 @@ TEST_P(PredicateIndexingTest, UnswitchedCircularBuffering3) {
           createInt(3));
 
       return andExpr(
-          geExpr(start_idx, zero),
+          geExpr(start_idx, tv->fusion()->zeroVal()),
           ltExpr(stop_idx, tv->getLogicalDomain().at(0)->extent()));
     }
   };

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -1382,13 +1382,11 @@ TEST_F(IndexingTest, SimpleVectorize) {
           // vectorized domain with zero, which doesn't go through the
           // simplification of SimplifyingIrBuilder. We could use simplifyExpr,
           // but for the sake of testing, just use IrBuilder::addExpr.
-          return IrBuilder::addExpr(
-              mulExpr(
-                  addExpr(
-                      mulExpr(loop_indices.at(0), tv->axis(1)->extent()),
-                      loop_indices.at(1)),
-                  tv->axis(2)->extent()),
-              tv->fusion()->zeroVal());
+          return mulExpr(
+              addExpr(
+                  mulExpr(loop_indices.at(0), tv->axis(1)->extent()),
+                  loop_indices.at(1)),
+              tv->axis(2)->extent());
         case 1:
           return tv->fusion()->zeroVal();
         default:
@@ -2896,13 +2894,11 @@ TEST_F(PredicateIndexingTest, SimpleVectorize) {
     Val* getInlinePredicate(TensorView* tv) const override {
       std::vector<Val*> loop_indices = getLoopIndices(tv, indexer_, for_loops_);
 
-      auto start_idx = IrBuilder::addExpr(
-          mulExpr(
-              addExpr(
-                  mulExpr(loop_indices.at(0), tv->axis(1)->extent()),
-                  loop_indices.at(1)),
-              tv->axis(2)->extent()),
-          tv->fusion()->zeroVal());
+      auto start_idx = mulExpr(
+          addExpr(
+              mulExpr(loop_indices.at(0), tv->axis(1)->extent()),
+              loop_indices.at(1)),
+          tv->axis(2)->extent());
       auto stop_idx = addExpr(
           mulExpr(
               addExpr(
@@ -2911,7 +2907,7 @@ TEST_F(PredicateIndexingTest, SimpleVectorize) {
               tv->axis(2)->extent()),
           subExpr(tv->axis(2)->extent(), createInt(1)));
 
-      // ( ( ( ( ( blockIdx.x * 128 ) + threadIdx.x ) * 4 ) + 0 )>= 0 ) &&
+      // ( ( ( ( blockIdx.x * 128 ) + threadIdx.x ) * 4 ) >= 0 ) &&
       // ( ( ( ( ( blockIdx.x * 128 ) + threadIdx.x ) * 4 ) + 3 ) < ( (( ((
       // getMetaData(T0) )).logical_size ))[0] ) ) )
       return andExpr(


### PR DESCRIPTION
- If the simplification result is 1 or 0, use the cached IR node from fusion.
- Simplify `x + y - y` into `x`