### PR TITLE
Sharding Detection with multiple IO

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -48,11 +48,12 @@ std::unordered_set<IterDomain*> getShardedIterDomains(TensorView* tv) {
 // actual allocation, but this will have to change in the future.
 int64_t allocationIndex(TensorView* tv, IterDomain* id) {
   int64_t index = 0;
-  for (auto i : tv->getLoopDomain()) {
-    if (i == id) {
+  for (auto* loop_id : tv->getLoopDomain()) {
+    if (loop_id == id) {
       return index;
     }
-    if (!i->isDeviceDim() && !i->isReduction() && !i->isBroadcast()) {
+    if (!loop_id->isDeviceDim() && !loop_id->isReduction() &&
+        !loop_id->isBroadcast()) {
       index++;
     }
   }

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -42,7 +42,7 @@ std::unordered_set<IterDomain*> getShardedIterDomains(TensorView* tv) {
   return sharded_ids;
 }
 
-// Returns the position where an axis is allocated in a tv. Returns -1 if id is
+// Returns the position where an axis is allocated in a tv, skipping trivial dimensions (i.e. DID, reduction and broadcast). Returns -1 if id is
 // not in tv's loop domain WAR: today we assume that the loop domain match with
 // the actual allocation, but this will have to change in the future.
 int64_t allocationIndex(TensorView* tv, IterDomain* id) {

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -42,9 +42,10 @@ std::unordered_set<IterDomain*> getShardedIterDomains(TensorView* tv) {
   return sharded_ids;
 }
 
-// Returns the position where an axis is allocated in a tv, skipping trivial dimensions (i.e. DID, reduction and broadcast). Returns -1 if id is
-// not in tv's loop domain WAR: today we assume that the loop domain match with
-// the actual allocation, but this will have to change in the future.
+// Returns the position where an axis is allocated in a tv, skipping trivial
+// dimensions (i.e. DID, reduction and broadcast). Returns -1 if id is not in
+// tv's loop domain WAR: today we assume that the loop domain match with the
+// actual allocation, but this will have to change in the future.
 int64_t allocationIndex(TensorView* tv, IterDomain* id) {
   int64_t index = 0;
   for (auto i : tv->getLoopDomain()) {

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -30,7 +30,8 @@ NVF_API bool distributedEnabled();
 // TODO: Analyze loop domain for unsharded/sharded IDs and return their
 // parent root IDs.
 std::pair<std::vector<IterDomain*>, std::vector<IterDomain*>> getShardingChanges(
-    Expr* expr);
+    TensorView* producer,
+    TensorView* consumer);
 
 // Returns whether a TensorView has a non-reduction axis parallelized Didx
 // Checks that the other non-reduction axis are not parallelized on Didx

--- a/csrc/preseg_passes/reorder_sharded_axis.cpp
+++ b/csrc/preseg_passes/reorder_sharded_axis.cpp
@@ -40,7 +40,7 @@ void ReorderShardedAxisPass::runPass(Fusion* fusion) {
         expr->toString());
     auto* output = expr->outputs().at(0)->as<TensorView>();
     auto* input = expr->inputs().at(0)->as<TensorView>();
-    auto [shard_additions, shard_deletions] = getShardingChanges(expr);
+    auto [shard_additions, shard_deletions] = getShardingChanges(input, output);
     NVF_ERROR(
         shard_additions.size() + shard_deletions.size() <= 1,
         "Resharding expr can only support one axis: ",


### PR DESCRIPTION
# What

Patch resharding detection routines in `multidevice/utils` to handle expressions with multiple I/O

# Why

As a step toward https://jirasw.nvidia.com/browse/NVFUSER-106, the motivation for this patch is to be able to keep the MatmulOp (and potentially other ops in the future) as a resharding OP, which will undergo a special HostIr lowering (bypassing `ReorderShardedAxisPass`)