### PR TITLE
Use parallel dimension map for reduction buffers in codegen

### DIFF
--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -182,15 +182,20 @@ bool ParallelDimensionMap::isExact(ParallelType pt) const {
   return exact_types_.find(pt) != exact_types_.end();
 }
 
+Val* ParallelDimensionMap::getRawCompute(ParallelType pt) const {
+  Val* raw = getRaw(pt);
+  if (warp_specialized_types_.count(pt)) {
+    return SimplifyingIrBuilder::addExpr(raw, -1);
+  }
+  return raw;
+}
+
 Val* ParallelDimensionMap::getNumComputeThreadsEachBlock() const {
   Val* num_threads = FusionGuard::getCurFusion()->oneVal();
   for (auto pt : kParallelTypeTIDs) {
-    auto dim = getRaw(pt);
+    auto dim = getRawCompute(pt);
     if (dim == nullptr) {
       continue;
-    }
-    if (warp_specialized_types_.find(pt) != warp_specialized_types_.end()) {
-      dim = SimplifyingIrBuilder::addExpr(dim, -1);
     }
     num_threads = SimplifyingIrBuilder::mulExpr(num_threads, dim);
   }

--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -163,7 +163,8 @@ void ParallelDimensionMap::setWarpSpecializeOn(ParallelType pt) {
     // nodes like addExpr(x, 1), and SimplifyingIrBuilder::addExpr in
     // getRawCompute will be able to simplify find the x when we do
     // addExpr(addExpr(x, 1) - 1).
-    dim_map_[pt] = IrBuilder::addExpr(dim_it->second, 1);
+    dim_map_[pt] =
+        IrBuilder::addExpr(dim_it->second, dim_it->second->fusion()->oneVal());
   }
   exact_types_.erase(pt);
   warp_specialized_types_.insert(pt);

--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -160,8 +160,9 @@ void ParallelDimensionMap::setWarpSpecializeOn(ParallelType pt) {
     // to be callable in an environment without FusionGuard, that is, when the
     // IR container is read-only. In such an environment, we can't create new IR
     // nodes for (x - 1). By using IrBuilder::addExpr, we can always create IR
-    // nodes like addExpr(x, 1), and SimplifyingIrBuilder::addExpr in getRawCompute
-    // will be able to simplify find the x when we do addExpr(addExpr(x, 1) - 1).
+    // nodes like addExpr(x, 1), and SimplifyingIrBuilder::addExpr in
+    // getRawCompute will be able to simplify find the x when we do
+    // addExpr(addExpr(x, 1) - 1).
     dim_map_[pt] = IrBuilder::addExpr(dim_it->second, 1);
   }
   exact_types_.erase(pt);

--- a/csrc/parallel_dimension_map.h
+++ b/csrc/parallel_dimension_map.h
@@ -41,6 +41,12 @@ class ParallelDimensionMap {
     return dim_map_;
   }
 
+  //! Get the "compute" parallel dimension on the given ParallelType. In case
+  //! of no warp specialization, this is the same as getRaw(pt). If we are doing
+  //! warp specialization on pt, the result is getRaw(pt) - 1, because the last
+  //! of pt is used for loading circular buffer tensors.
+  Val* getRawCompute(ParallelType pt) const;
+
   //! Get the number of threads per each CTA used for computation. When there is
   //! no warp specialization, the result is trivial: it is just the product of
   //! parallel dimensions of TIDx, TIDy and TIDz. If we do have warp


### PR DESCRIPTION
In codegen, don't generate hard-coded `blockDim.x * blockDim.y * blockDim.z` for reduction buffer size. Instead, generate the size according to the parallel dimension map and subtract the extra warp due to warp specialization.