### PR TITLE
Add support for 32B and 64B swizzles to hopper matmul scheduler

### DIFF
--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1842,7 +1842,7 @@ Val* hardCodedIndexGenerationForStMatrix(
 // To account for the threadIdx.y, we have to add it to the offset:
 //   offset_from_tdy = threadIdx.y * tma_m * tma_n * 2 (half)
 //
-// Now, lets apply stmatrix tile (16, 16) to the TMA Box (NO(2), M(64), NI(64].
+// Now, lets apply stmatrix tile (16, 16) to the TMA Box [NO(2), M(64), NI(64)].
 //   [NO(2), MO(4), MI(16), NIO(4), NII(16)].
 //
 // A warp group of 128 threads contains four warps. StMatrix is a warp-level
@@ -1929,10 +1929,10 @@ Val* hardCodedIndexGenerationForStMatrix(
 // with the 8 rows of the matrix to avoid bank conflicts. This swizzle pattern
 // is repeated along the rows of the TMA box.
 //
-// The number of distinct rows is number of bytes for swizzle divided by size of
-// megabank (16B). The number of times a swizzle pattern is repeated to fill
-// (8, 8) matrix is number of swizzle rows (8) divided by number of distinct
-// rows.
+// The number of distinct swizzle rows is number of bytes for swizzle divided by
+// size of megabank (16B). The number of times a swizzle pattern is repeated to
+// fill core (8, 8) matrix is number of swizzle rows (8) divided by number of
+// distinct rows.
 //
 // Swizzle column
 //   row_in_swizzle_pattern = (row % swizzle_row_size(8)) / swizzle_repetitions

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1958,8 +1958,10 @@ Val* hardCodedIndexGenerationForStMatrix128BSwizzle(
 
   NVF_ERROR(ldst->out()->isA<TensorView>());
   TensorView* out_tv = ldst->out()->as<TensorView>();
+  std::cout << out_tv->toString() << std::endl;
   MmaInputSmemSwizzle swizzle = getSwizzle(out_tv);
   int64_t swizzle_bytes = getBytesFromSwizzle(swizzle);
+  std::cout << "swizzle stmatrix\t" << swizzle_bytes << std::endl;
 
   // Constants
   constexpr int64_t dtype_size = 2;

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1559,15 +1559,15 @@ void IndexLowering::handleCpAsyncBulkStore(const LoadStoreOp* ldst) {
 }
 
 static DataType getMmaInputAType(MmaMacro macro) {
-  int warp_group_size = isHopper(macro) ? 128 : 32;
-  int size = getM(macro) * getK(macro) / warp_group_size /
-      2 /* halves per 32bit register */;
+  int64_t warp_group_size = isHopper(macro) ? 128L : 32L;
+  int64_t size = getM(macro) * getK(macro) / warp_group_size /
+      2L /* halves per 32bit register */;
   return ArrayType{std::make_shared<DataType>(DataType::UInt32), (size_t)size};
 }
 
 static DataType getMmaInputBType(MmaMacro macro) {
-  int size = getN(macro) * getK(macro) / 32 /* threads per warp */ /
-      2 /* halves per 32bit register */;
+  int64_t size = getN(macro) * getK(macro) / 32L /* threads per warp */ /
+      2L /* halves per 32bit register */;
   return ArrayType{std::make_shared<DataType>(DataType::UInt32), (size_t)size};
 }
 

--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -1027,13 +1027,6 @@ void HopperMultipleMatmulScheduler::scheduleEpilogue() {
     const int64_t tma_m = getM(params_->mma_macro);
     const int64_t tma_n = getN(params_->mma_macro);
 
-    NVF_ERROR(
-        tma_n >= 64,
-        "Scheduler only supports 128B swizzle that requires N dimension of MMA ",
-        "macro to be >= 64, but received ",
-        tma_n,
-        ".");
-
     fusion_->manage("st_matrix_m_tile", stmatrix_tile_m);
     fusion_->manage("st_matrix_n_tile", stmatrix_tile_n);
     fusion_->manage("st_matrix_m", tma_m);
@@ -1084,12 +1077,14 @@ void HopperMultipleMatmulScheduler::scheduleEpilogue() {
         dc->setAllocationDomain(s.as<IterDomain*>(), true);
       }
 
+      MmaInputSmemSwizzle swizzle = tmaSwizzleSharedMemory(d_smem);
+
       // Schedule shared memory cache; Output from StMatrix
       scheduleStMatrixForMmaOutput(
-          d_smem, stmatrix_tile_m, stmatrix_tile_n, tma_m, tma_n);
+          d_smem, swizzle, stmatrix_tile_m, stmatrix_tile_n, tma_m, tma_n);
 
       // Schedule global memory output; Output from TMA Store
-      scheduleTMAStoreForMmaOutput(d, tma_m, tma_n);
+      scheduleTMAStoreForMmaOutput(d, swizzle, tma_m, tma_n);
     }
   }
 }
@@ -1247,6 +1242,7 @@ void HopperMultipleMatmulScheduler::setUpCircularBuffering() {
 
 void HopperMultipleMatmulScheduler::scheduleStMatrixForMmaOutput(
     TensorView* tv,
+    MmaInputSmemSwizzle swizzle,
     int64_t tile_m,
     int64_t tile_n,
     int64_t tma_m,
@@ -1263,7 +1259,7 @@ void HopperMultipleMatmulScheduler::scheduleStMatrixForMmaOutput(
       mma_utils::MmaSwizzler::scheduleMmaOutputAllocation(tv->getLoopDomain());
 
   // Create tma store allocation domain with swizzle
-  scheduleTMAStoreForMmaOutput(tv, tma_m, tma_n);
+  scheduleTMAStoreForMmaOutput(tv, swizzle, tma_m, tma_n);
 
   tv->setLoopDomain(s.as<IterDomain*>());
 
@@ -1290,6 +1286,7 @@ void HopperMultipleMatmulScheduler::scheduleStMatrixForMmaOutput(
 
 void HopperMultipleMatmulScheduler::scheduleTMAStoreForMmaOutput(
     TensorView* tv,
+    MmaInputSmemSwizzle swizzle,
     int64_t m,
     int64_t n) {
   // [M(m), N(n)] -> [MO(1), MI(m), NO(1), NI(n)]
@@ -1301,7 +1298,6 @@ void HopperMultipleMatmulScheduler::scheduleTMAStoreForMmaOutput(
   // [BDX, BDY, TDY, MO(1), NO(1), MI, NI]
   // skip the first 5 iterDomains
   int64_t num_ids_to_skip = 5;
-  MmaInputSmemSwizzle swizzle = MmaInputSmemSwizzle::B128;
 
   NVF_ERROR(num_ids_to_skip >= 0);
   if (swizzle == MmaInputSmemSwizzle::None) {

--- a/csrc/scheduler/hopper_multi_matmul.h
+++ b/csrc/scheduler/hopper_multi_matmul.h
@@ -190,7 +190,11 @@ class HopperMultipleMatmulScheduler : public MultipleMatmulScheduler {
 
   //! Schedules the copy operation of output of a Mma op which resided in the
   //! shared memory to global memory.
-  void scheduleTMAStoreForMmaOutput(TensorView* tv, MmaInputSmemSwizzle swizzle, int64_t m, int64_t n);
+  void scheduleTMAStoreForMmaOutput(
+      TensorView* tv,
+      MmaInputSmemSwizzle swizzle,
+      int64_t m,
+      int64_t n);
 
   // Map TensorView's iterDomain to its ValGroup.
   // Then, find the MatmulDimRole for the ValGroup.

--- a/csrc/scheduler/hopper_multi_matmul.h
+++ b/csrc/scheduler/hopper_multi_matmul.h
@@ -182,6 +182,7 @@ class HopperMultipleMatmulScheduler : public MultipleMatmulScheduler {
   //! registers to shared memory.
   void scheduleStMatrixForMmaOutput(
       TensorView* tv,
+      MmaInputSmemSwizzle swizzle,
       int64_t tile_m,
       int64_t tile_n,
       int64_t tma_m,
@@ -189,7 +190,7 @@ class HopperMultipleMatmulScheduler : public MultipleMatmulScheduler {
 
   //! Schedules the copy operation of output of a Mma op which resided in the
   //! shared memory to global memory.
-  void scheduleTMAStoreForMmaOutput(TensorView* tv, int64_t m, int64_t n);
+  void scheduleTMAStoreForMmaOutput(TensorView* tv, MmaInputSmemSwizzle swizzle, int64_t m, int64_t n);
 
   // Map TensorView's iterDomain to its ValGroup.
   // Then, find the MatmulDimRole for the ValGroup.

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3159,14 +3159,14 @@ class HopperMatmulSchedulerTest
     // Create custom Matmul Params
     MatMulTileOptions gemm_tile;
     // TODO cta tile is a multiple of mma macro for hopper.
-    gemm_tile.cta_tile = GemmTile(128, 256, 16);
+    gemm_tile.cta_tile = GemmTile(128, 32, 16);
 
     // TODO warp tile is (macroM, macroN, macroK) for hopper.
-    gemm_tile.warp_tile = GemmTile(64, 128, 16);
+    gemm_tile.warp_tile = GemmTile(64, 32, 16);
 
     mparams.supported_vec_size = {8, 8, 4};
 
-    mparams.mma_macro = MmaMacro::Hopper_64_128_16;
+    mparams.mma_macro = MmaMacro::Hopper_64_32_16;
 
     mparams.use_smem_epilogue = use_smem_epilogue;
 
@@ -3282,7 +3282,7 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Bool(), // a_k_inner
         testing::Bool(), // b_k_inner
         testing::Values(512), // M
-        testing::Values(256), // N
+        testing::Values(32), // N
         testing::Values(64) // K
         ),
     hopperTestName);

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -703,6 +703,40 @@ static auto kAllHopperMacros = testing::Values(
     MmaMacro::Hopper_64_248_16,
     MmaMacro::Hopper_64_256_16);
 
+static std::unordered_map<MmaMacro, std::string> mma_macro_to_str_map = {
+    {MmaMacro::Hopper_64_8_16, "m64_n8_k16"},
+    {MmaMacro::Hopper_64_16_16, "m64_n16_k16"},
+    {MmaMacro::Hopper_64_24_16, "m64_n24_k16"},
+    {MmaMacro::Hopper_64_32_16, "m64_n32_k16"},
+    {MmaMacro::Hopper_64_40_16, "m64_n40_k16"},
+    {MmaMacro::Hopper_64_48_16, "m64_n48_k16"},
+    {MmaMacro::Hopper_64_56_16, "m64_n56_k16"},
+    {MmaMacro::Hopper_64_64_16, "m64_n64_k16"},
+    {MmaMacro::Hopper_64_72_16, "m64_n72_k16"},
+    {MmaMacro::Hopper_64_80_16, "m64_n80_k16"},
+    {MmaMacro::Hopper_64_88_16, "m64_n88_k16"},
+    {MmaMacro::Hopper_64_96_16, "m64_n96_k16"},
+    {MmaMacro::Hopper_64_104_16, "m64_n104_k16"},
+    {MmaMacro::Hopper_64_112_16, "m64_n112_k16"},
+    {MmaMacro::Hopper_64_120_16, "m64_n120_k16"},
+    {MmaMacro::Hopper_64_128_16, "m64_n128_k16"},
+    {MmaMacro::Hopper_64_136_16, "m64_n136_k16"},
+    {MmaMacro::Hopper_64_144_16, "m64_n144_k16"},
+    {MmaMacro::Hopper_64_152_16, "m64_n152_k16"},
+    {MmaMacro::Hopper_64_160_16, "m64_n160_k16"},
+    {MmaMacro::Hopper_64_168_16, "m64_n168_k16"},
+    {MmaMacro::Hopper_64_176_16, "m64_n176_k16"},
+    {MmaMacro::Hopper_64_184_16, "m64_n184_k16"},
+    {MmaMacro::Hopper_64_192_16, "m64_n192_k16"},
+    {MmaMacro::Hopper_64_200_16, "m64_n200_k16"},
+    {MmaMacro::Hopper_64_208_16, "m64_n208_k16"},
+    {MmaMacro::Hopper_64_216_16, "m64_n216_k16"},
+    {MmaMacro::Hopper_64_224_16, "m64_n224_k16"},
+    {MmaMacro::Hopper_64_232_16, "m64_n232_k16"},
+    {MmaMacro::Hopper_64_240_16, "m64_n240_k16"},
+    {MmaMacro::Hopper_64_248_16, "m64_n248_k16"},
+    {MmaMacro::Hopper_64_256_16, "m64_n256_k16"}};
+
 // Utility to generate matmul input tensors based on given layout
 at::Tensor atMatmul(at::Tensor a, at::Tensor b, MmaLayout layout);
 


### PR DESCRIPTION
This PR adds support for 32B and 64B swizzles to StMatrix indexing and to the hopper matmul scheduler.

### Key Index Change
The number of distinct swizzle rows is number of bytes for swizzle divided by size of megabank (16B). The number of times a swizzle pattern is repeated to fill core (8, 8) matrix is number of swizzle rows (8) divided by number of distinct
rows.

```cpp
MmaInputSmemSwizzle swizzle = getSwizzle(out_tv);
int64_t swizzle_bytes = getBytesFromSwizzle(swizzle);
constexpr int64_t megabank_size_bytes = 16;
const int64_t distinct_swizzle_row_size = swizzle_bytes / megabank_size_bytes;

int row = ...;
int col = ...;
constexpr int64_t swizzle_row_size = 8;
const int64_t swizzle_row_repetitions = swizzle_row_size / distinct_swizzle_row_size;
int64_t  row_in_swizzle_pattern = (row % swizzle_row_size) / swizzle_row_repetitions;
int64_t swizzle_col = col ^ row_in_swizzle_pattern;
```

### Testing Changes
* Added `mma_macro` as testing value.
* Created separate test suite called `Swizzle/HopperMatmulSchedulerTest` to test `32B`, `64B`, `128B` swizzles.
