### PR TITLE
Propagating slice/pad/cat to inputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/scheduler/tools/inlining.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/tools/loop_domain_scheduler.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/tools/maxinfo_propagator.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/tools/resize_utils.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/transpose.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/utils.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/vectorize_helper.cpp

--- a/csrc/scheduler/tools/loop_domain_scheduler.cpp
+++ b/csrc/scheduler/tools/loop_domain_scheduler.cpp
@@ -381,6 +381,10 @@ void scheduleLoopDomainsLike(
   LoopDomainScheduler scheduler(ref_loop_dom);
 
   for (auto tv : tvs) {
+    // Loop domain of fusion inputs should have no meaning
+    if (tv->isFusionInput()) {
+      continue;
+    }
     scheduler.schedule(tv);
   }
 }

--- a/csrc/scheduler/tools/resize_utils.cpp
+++ b/csrc/scheduler/tools/resize_utils.cpp
@@ -1,0 +1,60 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <id_model/id_model.h>
+#include <ir/cloner.h>
+#include <ir/utils.h>
+#include <iter_visitor.h>
+#include <logical_domain_map.h>
+#include <scheduler/tools/loop_domain_scheduler.h>
+#include <scheduler/tools/resize_utils.h>
+#include <val_graph_visitor.h>
+
+namespace nvfuser {
+namespace scheduler_tools {
+
+void propagateResizeToInputs(Expr* resize_tensor_op) {
+  DebugStreamGuard dsg(std::cerr);
+
+  NVF_ERROR(
+      resize_tensor_op->isA<SliceOp>() || resize_tensor_op->isA<PadOp>(),
+      "Unexpected resize tensor op: ",
+      resize_tensor_op->toString());
+
+  Fusion* fusion = resize_tensor_op->fusion();
+
+  auto producer_tv = resize_tensor_op->input(0)->as<TensorView>();
+  auto consumer_tv = resize_tensor_op->output(0)->as<TensorView>();
+
+  auto all_dep_vals = DependencyCheck::getAllValsBetween(
+      {fusion->inputs().begin(), fusion->inputs().end()}, {producer_tv});
+
+  std::vector<TensorView*> tvs_to_schedule;
+  tvs_to_schedule.reserve(all_dep_vals.size());
+  for (auto val : all_dep_vals) {
+    if (val->isA<TensorView>() && !val->isFusionInput()) {
+      tvs_to_schedule.push_back(val->as<TensorView>());
+    }
+  }
+
+  scheduler_tools::scheduleLoopDomainsLike(
+      tvs_to_schedule, producer_tv->getLoopDomain());
+
+  for (const auto i : c10::irange(consumer_tv->getLogicalDomain().size())) {
+    auto out_logical_id = consumer_tv->getLogicalDomain().at(i);
+    auto resize = dynamic_cast<Resize*>(out_logical_id->definition());
+    if (resize == nullptr) {
+      continue;
+    }
+
+    scheduler_tools::scheduleLoopDomainsBy(tvs_to_schedule, resize);
+  }
+}
+
+} // namespace scheduler_tools
+} // namespace nvfuser

--- a/csrc/scheduler/tools/resize_utils.cpp
+++ b/csrc/scheduler/tools/resize_utils.cpp
@@ -19,8 +19,6 @@ namespace nvfuser {
 namespace scheduler_tools {
 
 void propagateResizeToInputs(Expr* resize_tensor_op) {
-  DebugStreamGuard dsg(std::cerr);
-
   NVF_ERROR(
       resize_tensor_op->isA<SliceOp>() || resize_tensor_op->isA<PadOp>(),
       "Unexpected resize tensor op: ",

--- a/csrc/scheduler/tools/resize_utils.h
+++ b/csrc/scheduler/tools/resize_utils.h
@@ -13,8 +13,8 @@ class Expr;
 
 namespace scheduler_tools {
 
-// For a given resize-based op such as slice and pad, make the loop
-// domain of each depedent producer tensor exact-mapped by propagating
+// For a given resize-based tensor op such as SliceOp and PadOp, make the loop
+// domain of each dependent producer tensor exact-mapped by propagating
 // the iter-domain ops of the output tensor of the given op. Note that
 // fusion inputs are skipped as their loop domains don't matter.
 void propagateResizeToInputs(Expr* resize_op);

--- a/csrc/scheduler/tools/resize_utils.h
+++ b/csrc/scheduler/tools/resize_utils.h
@@ -1,0 +1,19 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+namespace nvfuser {
+
+class Expr;
+
+namespace scheduler_tools {
+
+void propagateResizeToInputs(Expr* resize_op);
+
+} // namespace scheduler_tools
+} // namespace nvfuser

--- a/csrc/scheduler/tools/resize_utils.h
+++ b/csrc/scheduler/tools/resize_utils.h
@@ -13,6 +13,10 @@ class Expr;
 
 namespace scheduler_tools {
 
+// For a given resize-based op such as slice and pad, make the loop
+// domain of each depedent producer tensor exact-mapped by propagating
+// the iter-domain ops of the output tensor of the given op. Note that
+// fusion inputs are skipped as their loop domains don't matter.
 void propagateResizeToInputs(Expr* resize_op);
 
 } // namespace scheduler_tools

--- a/tests/cpp/test_loop_domain_scheduling.cpp
+++ b/tests/cpp/test_loop_domain_scheduling.cpp
@@ -284,7 +284,12 @@ TEST_F(LoopDomainSchedulingTest, ManyReshape) {
     // The new loop domain of each tensor should be exactly mapped
     // with the reference loop domain
     for (const auto tv : fusion_copy.allTvs()) {
-      EXPECT_EQ(tv->getLoopDomain().size(), ref_loop.size());
+      // scheduleLoopDomainsLike skips fusion inputs
+      if (tv->isFusionInput()) {
+        continue;
+      }
+      EXPECT_EQ(tv->getLoopDomain().size(), ref_loop.size())
+          << "Invalid rank of loop domain: " << tv->toString();
       for (const auto i : c10::irange(ref_loop.size())) {
         EXPECT_TRUE(exact_graph.disjointValSets().strictAreMapped(
             tv->getLoopDomain().at(i), ref_loop.at(i)))

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -4150,7 +4150,7 @@ TEST_F(ResizeTest, PropagateSliceToInputs) {
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
 
-// Propagating slice to inputs with rehsape before slice
+// Propagating slice to inputs with reshape before slice
 TEST_F(ResizeTest, PropagateSliceToInputsWithReshape1) {
   Fusion fusion;
   FusionGuard fg(&fusion);
@@ -4222,7 +4222,7 @@ TEST_F(ResizeTest, PropagateSliceToInputsWithReshape1) {
   testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
 
-// Propagating slice to inputs with rehsape after slice
+// Propagating slice to inputs with reshape after slice
 TEST_F(ResizeTest, PropagateSliceToInputsWithReshape2) {
   Fusion fusion;
   FusionGuard fg(&fusion);

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -18,10 +18,42 @@
 #include <runtime/fusion_executor_cache.h>
 #include <scheduler/tools/inlining.h>
 #include <scheduler/tools/loop_domain_scheduler.h>
+#include <scheduler/tools/resize_utils.h>
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
 
+#include <fstream>
+
 namespace nvfuser {
+
+namespace {
+
+void checkLoopDomainEquivalence(
+    TensorView* ref_tv,
+    std::vector<TensorView*> tvs_to_check = {}) {
+  Fusion* fusion = ref_tv->fusion();
+
+  IdModel id_model(fusion, /*build_graphs=*/false);
+  const auto& graph = id_model.buildExactGraph();
+
+  const auto ref_loop_groups = graph.toGroups(ref_tv->getLoopDomain());
+
+  if (tvs_to_check.empty()) {
+    tvs_to_check = fusion->allTvs();
+  }
+
+  for (auto tv : tvs_to_check) {
+    // Don't care inputs
+    if (tv->isFusionInput() || tv == ref_tv) {
+      continue;
+    }
+
+    EXPECT_EQ(graph.toGroups(tv->getLoopDomain()), ref_loop_groups)
+        << "Mismatched loop domain: " << tv->toString();
+  }
+}
+
+} // namespace
 
 using ResizeTest = NVFuserFixtureParamTest<bool>;
 
@@ -4049,6 +4081,436 @@ TEST_F(ResizeTest, SliceSliceConcatConcat) {
       0);
 
   NVF_CHECK(ref.equal(cg_outputs[0]));
+}
+
+// Consumer-based scheduling of slice
+TEST_F(ResizeTest, PropagateSliceToInputs) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape({-1, 100});
+
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
+  auto tv0 = makeConcreteTensor(shape);
+  fusion.addInput(tv0);
+
+  auto tv1 = set(tv0);
+
+  auto tv2 = slice(
+      tv1,
+      {{fusion.zeroVal(), tv1->getLogicalDomain().at(0)->extent()},
+       {IrBuilder::create<Val>(1L), IrBuilder::create<Val>(99)}});
+
+  auto tv3 = set(tv2);
+
+  fusion.addOutput(tv3);
+
+  scheduler_tools::propagateResizeToInputs(tv2->definition());
+
+  auto ref_tv = tv3;
+
+  // Fusion should have a uniform loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  // Schedule the reference
+  ref_tv->flatten();
+  // For TIDx
+  ref_tv->split(0, 128);
+  // For BIDx
+  ref_tv->split(0, 4);
+
+  scheduler_tools::scheduleLoopDomainsLike(
+      fusion.allTvs(), ref_tv->getLoopDomain());
+
+  // Fusion should still have a uniform loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  inlineMost();
+
+  // All tensors, except for fusion inputs, should be fully inlined
+  for (auto tv : fusion.allTvs()) {
+    if (tv->isFusionInput()) {
+      continue;
+    }
+    EXPECT_EQ(tv->getComputeAtPosition(), tv->nDims());
+  }
+
+  ref_tv->axis(-1)->parallelize(ParallelType::TIDx);
+  ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({16, 100}, options);
+  std::vector<c10::IValue> inputs({t0});
+
+  KernelExecutor ke;
+  ke.compile(&fusion, inputs);
+  auto outputs = ke.run(inputs);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+}
+
+// Propagating slice to inputs with rehsape before slice
+TEST_F(ResizeTest, PropagateSliceToInputsWithReshape1) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape({16, 100});
+
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
+  auto tv0 = makeConcreteTensor(shape);
+  fusion.addInput(tv0);
+
+  auto tv1 = set(tv0);
+
+  auto tv2 = reshape(tv1, shape, {16, 5, 20});
+
+  auto tv3 = slice(
+      tv2,
+      {{fusion.zeroVal(), tv2->getLogicalDomain().at(0)->extent()},
+       {fusion.zeroVal(), tv2->getLogicalDomain().at(1)->extent()},
+       {IrBuilder::create<Val>(1L), IrBuilder::create<Val>(10)}});
+
+  auto tv4 = set(tv3);
+
+  fusion.addOutput(tv4);
+
+  scheduler_tools::propagateResizeToInputs(tv3->definition());
+
+  auto ref_tv = tv4;
+
+  // Fusion should have a uniform loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  fusion.print();
+
+  // Schedule the reference
+  ref_tv->flatten();
+  // For TIDx
+  ref_tv->split(0, 128);
+  // For BIDx
+  ref_tv->split(0, 4);
+
+  scheduler_tools::scheduleLoopDomainsLike(
+      fusion.allTvs(), ref_tv->getLoopDomain());
+
+  // Fusion should still have a uniform loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  inlineMost();
+
+  // All tensors, except for fusion inputs, should be fully inlined
+  for (auto tv : fusion.allTvs()) {
+    if (tv->isFusionInput()) {
+      continue;
+    }
+    EXPECT_EQ(tv->getComputeAtPosition(), tv->nDims());
+  }
+
+  ref_tv->axis(-1)->parallelize(ParallelType::TIDx);
+  ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn(shape, options);
+  std::vector<c10::IValue> inputs({t0});
+
+  KernelExecutor ke;
+  ke.compile(&fusion, inputs);
+  auto outputs = ke.run(inputs);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+}
+
+// Propagating slice to inputs with rehsape after slice
+TEST_F(ResizeTest, PropagateSliceToInputsWithReshape2) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape({16, 100});
+
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
+  auto tv0 = makeConcreteTensor(shape);
+  fusion.addInput(tv0);
+
+  auto tv1 = set(tv0);
+
+  auto tv2 = slice(
+      tv1,
+      {{fusion.zeroVal(), tv1->getLogicalDomain().at(0)->extent()},
+       {IrBuilder::create<Val>(1L), IrBuilder::create<Val>(50)}});
+
+  auto tv3 = reshape(tv2, {shape[0], 49}, {shape[0] * 49});
+
+  auto tv4 = set(tv3);
+
+  fusion.addOutput(tv4);
+
+  scheduler_tools::propagateResizeToInputs(tv2->definition());
+
+  auto ref_tv = tv4;
+
+  // Schedule the reference
+  ref_tv->flatten();
+  // For TIDx
+  ref_tv->split(0, 128);
+  // For BIDx
+  ref_tv->split(0, 4);
+
+  scheduler_tools::scheduleLoopDomainsLike(
+      fusion.allTvs(), ref_tv->getLoopDomain());
+
+  // Fusion should have a uniform loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  inlineMost();
+
+  // All tensors, except for fusion inputs, should be fully inlined
+  for (auto tv : fusion.allTvs()) {
+    if (tv->isFusionInput()) {
+      continue;
+    }
+    EXPECT_EQ(tv->getComputeAtPosition(), tv->nDims());
+  }
+
+  ref_tv->axis(-1)->parallelize(ParallelType::TIDx);
+  ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn(shape, options);
+  std::vector<c10::IValue> inputs({t0});
+
+  KernelExecutor ke;
+  ke.compile(&fusion, inputs);
+  auto outputs = ke.run(inputs);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+}
+
+TEST_F(ResizeTest, PropagateMultipleSlicesToInputs) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape({-1, 100});
+
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
+  auto tv0 = makeConcreteTensor(shape);
+  fusion.addInput(tv0);
+
+  auto tv1 = set(tv0);
+
+  auto tv2 = slice(
+      tv1,
+      {{fusion.zeroVal(), tv1->getLogicalDomain().at(0)->extent()},
+       {IrBuilder::create<Val>(1L), tv1->getLogicalDomain().at(1)->extent()}});
+
+  auto tv3 = slice(
+      tv2,
+      {{fusion.zeroVal(), tv2->getLogicalDomain().at(0)->extent()},
+       {IrBuilder::create<Val>(1L), tv2->getLogicalDomain().at(1)->extent()}});
+
+  auto tv4 = set(tv3);
+
+  fusion.addOutput(tv4);
+
+  // Propagate the first slice to tv1
+  scheduler_tools::propagateResizeToInputs(tv2->definition());
+
+  // Propagate the second slice to tv1 and tv2
+  scheduler_tools::propagateResizeToInputs(tv3->definition());
+
+  // Each of tv1 and tv2 has two resize ops.
+  for (auto tv : {tv1, tv2}) {
+    auto resize1 = dynamic_cast<Resize*>(tv->axis(-1)->definition());
+    EXPECT_NE(resize1, nullptr);
+    auto resize2 = dynamic_cast<Resize*>(resize1->in()->definition());
+    EXPECT_NE(resize2, nullptr) << tv->toString();
+  }
+
+  auto ref_tv = tv4;
+
+  // Fusion should have a uniform loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  fusion.print();
+
+  // Schedule the reference
+  ref_tv->flatten();
+  // For TIDx
+  ref_tv->split(0, 128);
+  // For BIDx
+  ref_tv->split(0, 4);
+
+  scheduler_tools::scheduleLoopDomainsLike(
+      fusion.allTvs(), ref_tv->getLoopDomain());
+
+  // Fusion should still have a uniform loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  inlineMost();
+
+  // All tensors, except for fusion inputs, should be fully inlined
+  for (auto tv : fusion.allTvs()) {
+    if (tv->isFusionInput()) {
+      continue;
+    }
+    EXPECT_EQ(tv->getComputeAtPosition(), tv->nDims());
+  }
+
+  ref_tv->axis(-1)->parallelize(ParallelType::TIDx);
+  ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({16, 100}, options);
+  std::vector<c10::IValue> inputs({t0});
+
+  KernelExecutor ke;
+  ke.compile(&fusion, inputs);
+  auto outputs = ke.run(inputs);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+}
+
+// Consumer-based scheduling of pad
+TEST_F(ResizeTest, PropagatePadToInputs) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape({-1, 100});
+
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
+  auto tv0 = makeConcreteTensor(shape);
+  fusion.addInput(tv0);
+
+  auto tv1 = set(tv0);
+
+  auto tv2 = pad(tv1, {fusion.oneVal(), IrBuilder::create<Val>(2L)});
+
+  auto tv3 = set(tv2);
+
+  fusion.addOutput(tv3);
+
+  scheduler_tools::propagateResizeToInputs(tv2->definition());
+
+  auto ref_tv = tv3;
+
+  // Fusion should have a uniform loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  // Schedule the reference
+  ref_tv->flatten();
+  // For TIDx
+  ref_tv->split(0, 128);
+  // For BIDx
+  ref_tv->split(0, 4);
+
+  scheduler_tools::scheduleLoopDomainsLike(
+      fusion.allTvs(), ref_tv->getLoopDomain());
+
+  // Fusion should still have a uniform loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  inlineMost();
+
+  // All tensors, except for fusion inputs, should be fully inlined
+  for (auto tv : fusion.allTvs()) {
+    if (tv->isFusionInput()) {
+      continue;
+    }
+    EXPECT_EQ(tv->getComputeAtPosition(), tv->nDims());
+  }
+
+  ref_tv->axis(-1)->parallelize(ParallelType::TIDx);
+  ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({16, 100}, options);
+  std::vector<c10::IValue> inputs({t0});
+
+  KernelExecutor ke;
+  ke.compile(&fusion, inputs);
+  auto outputs = ke.run(inputs);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+}
+
+// Consumer-based scheduling of cat
+TEST_F(ResizeTest, PropagateCatToInputs) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape({-1, 100});
+
+  EnableOptionsGuard enable_options_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
+  auto tv0 = makeConcreteTensor(shape);
+  fusion.addInput(tv0);
+  auto tv1 = makeConcreteTensor(shape);
+  fusion.addInput(tv1);
+
+  auto tv2 = set(tv0);
+  auto tv3 = set(tv1);
+
+  auto tv4 = cat({tv2, tv3}, -1);
+
+  auto tv5 = set(tv4);
+
+  fusion.addOutput(tv5);
+
+  // Propagate the pad op of each cat input
+  for (auto cat_inp :
+       ir_utils::filterByType<TensorView>(tv4->definition()->inputs())) {
+    auto pad_op = dynamic_cast<PadOp*>(cat_inp->definition());
+    ASSERT_NE(pad_op, nullptr);
+    scheduler_tools::propagateResizeToInputs(pad_op);
+    auto pad_inp = pad_op->input(0)->as<TensorView>();
+    checkLoopDomainEquivalence(cat_inp, {pad_inp});
+  }
+
+  auto ref_tv = tv4;
+
+  // At this point, all tensors should have the same loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  // Schedule the reference
+  ref_tv->flatten();
+  // For TIDx
+  ref_tv->split(0, 128);
+  // For BIDx
+  ref_tv->split(0, 4);
+
+  scheduler_tools::scheduleLoopDomainsLike(
+      fusion.allTvs(), ref_tv->getLoopDomain());
+
+  // Fusion should still have a uniform loop domain
+  checkLoopDomainEquivalence(ref_tv);
+
+  inlineMost();
+
+  // All tensors, except for fusion inputs, should be fully inlined
+  for (auto tv : fusion.allTvs()) {
+    if (tv->isFusionInput()) {
+      continue;
+    }
+    EXPECT_EQ(tv->getComputeAtPosition(), tv->nDims());
+  }
+
+  ref_tv->axis(-1)->parallelize(ParallelType::TIDx);
+  ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({16, 100}, options);
+  auto t1 = at::randn({16, 100}, options);
+  std::vector<c10::IValue> inputs({t0, t1});
+
+  KernelExecutor ke;
+  ke.compile(&fusion, inputs);
+  auto outputs = ke.run(inputs);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
 }
 
 // manual scheduling that should have vectorized load on padded inputs.


### PR DESCRIPTION
Added a scheduler util function schedule a fusion with resize-based ops such as slice, pad and concat. This propagates resize ops to producers so that all tensors have the exact-mapped loop domains. 

Part of #3425. Extracted so that it can be individually tested.

(There's a follow-up PR: #3555)