### PR TITLE
Add MatmulParams::CircularBufferOptions::smem_circular_buffer_prefetch_gap

### DIFF
--- a/csrc/scheduler/ampere_multi_matmul.cpp
+++ b/csrc/scheduler/ampere_multi_matmul.cpp
@@ -1302,11 +1302,13 @@ void AmpereMultipleMatmulScheduler::setUpCircularBuffering() {
 
     for (TensorView* acw_smem : acw_smems_) {
       acw_smem->circularBuffer(
-          params_->circular_buffer_options.smem_circular_buffer_stage);
+          params_->circular_buffer_options.smem_circular_buffer_stage,
+          params_->circular_buffer_options.smem_circular_buffer_prefetch);
     }
     for (TensorView* bcw_smem : bcw_smems_) {
       bcw_smem->circularBuffer(
-          params_->circular_buffer_options.smem_circular_buffer_stage);
+          params_->circular_buffer_options.smem_circular_buffer_stage,
+          params_->circular_buffer_options.smem_circular_buffer_prefetch);
     }
   }
 

--- a/csrc/scheduler/ampere_multi_matmul.cpp
+++ b/csrc/scheduler/ampere_multi_matmul.cpp
@@ -1303,12 +1303,16 @@ void AmpereMultipleMatmulScheduler::setUpCircularBuffering() {
     for (TensorView* acw_smem : acw_smems_) {
       acw_smem->circularBuffer(
           params_->circular_buffer_options.smem_circular_buffer_stage,
-          params_->circular_buffer_options.smem_circular_buffer_prefetch);
+          params_->circular_buffer_options.smem_circular_buffer_stage -
+              params_->circular_buffer_options
+                  .smem_circular_buffer_prefetch_gap);
     }
     for (TensorView* bcw_smem : bcw_smems_) {
       bcw_smem->circularBuffer(
           params_->circular_buffer_options.smem_circular_buffer_stage,
-          params_->circular_buffer_options.smem_circular_buffer_prefetch);
+          params_->circular_buffer_options.smem_circular_buffer_stage -
+              params_->circular_buffer_options
+                  .smem_circular_buffer_prefetch_gap);
     }
   }
 

--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -1204,6 +1204,16 @@ void HopperMultipleMatmulScheduler::setUpCircularBuffering() {
           params_->async_gmem_load_operands,
           "Circular buffer only supports async load");
     }
+    NVF_CHECK(
+        params_->circular_buffer_options.smem_circular_buffer_prefetch_gap >
+                0 &&
+            params_->circular_buffer_options
+                    .smem_circular_buffer_prefetch_gap <=
+                params_->circular_buffer_options.smem_circular_buffer_stage,
+        "smem_circular_buffer_prefetch_gap is ",
+        params_->circular_buffer_options.smem_circular_buffer_prefetch_gap,
+        " but is expected to be positive and not greater than number of stages: ",
+        params_->circular_buffer_options.smem_circular_buffer_stage);
 
     for (TensorView* acw_smem : acw_smems_) {
       acw_smem->circularBuffer(

--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -1209,13 +1209,13 @@ void HopperMultipleMatmulScheduler::setUpCircularBuffering() {
       acw_smem->circularBuffer(
           params_->circular_buffer_options.smem_circular_buffer_stage,
           /*prefetch_distance=*/
-          params_->circular_buffer_options.smem_circular_buffer_stage - 1);
+          params_->circular_buffer_options.smem_circular_buffer_prefetch);
     }
     for (TensorView* bcw_smem : bcw_smems_) {
       bcw_smem->circularBuffer(
           params_->circular_buffer_options.smem_circular_buffer_stage,
           /*prefetch_distance=*/
-          params_->circular_buffer_options.smem_circular_buffer_stage - 1);
+          params_->circular_buffer_options.smem_circular_buffer_prefetch);
     }
   }
 

--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -1209,13 +1209,17 @@ void HopperMultipleMatmulScheduler::setUpCircularBuffering() {
       acw_smem->circularBuffer(
           params_->circular_buffer_options.smem_circular_buffer_stage,
           /*prefetch_distance=*/
-          params_->circular_buffer_options.smem_circular_buffer_prefetch);
+          params_->circular_buffer_options.smem_circular_buffer_stage -
+              params_->circular_buffer_options
+                  .smem_circular_buffer_prefetch_gap);
     }
     for (TensorView* bcw_smem : bcw_smems_) {
       bcw_smem->circularBuffer(
           params_->circular_buffer_options.smem_circular_buffer_stage,
           /*prefetch_distance=*/
-          params_->circular_buffer_options.smem_circular_buffer_prefetch);
+          params_->circular_buffer_options.smem_circular_buffer_stage -
+              params_->circular_buffer_options
+                  .smem_circular_buffer_prefetch_gap);
     }
   }
 

--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -41,13 +41,18 @@ class MatmulParams : public HeuristicParams {
     // greater than one. Otherwise it is ignored.
     int smem_circular_buffer_stage = 2;
 
-    int smem_circular_buffer_prefetch = 1;
+    // The circular buffering prefetch distance will be set to
+    //   smem_circular_buffer_stage - smem_circular_buffer_prefetch_gap
+    // This value must be positive since the prefetch distance must be strictly
+    // less than the number of stages.
+    int smem_circular_buffer_prefetch_gap = 1;
 
     bool operator==(const CircularBufferOptions& other) const {
       return other.circular_buffer_smem_write == circular_buffer_smem_write &&
           other.circular_buffer_smem_read == circular_buffer_smem_read &&
           other.smem_circular_buffer_stage == smem_circular_buffer_stage &&
-          other.smem_circular_buffer_prefetch == smem_circular_buffer_prefetch;
+          other.smem_circular_buffer_prefetch_gap ==
+          smem_circular_buffer_prefetch_gap;
     }
 
     std::string toString() const {
@@ -59,14 +64,14 @@ class MatmulParams : public HeuristicParams {
          << (circular_buffer_smem_read ? "true" : "false") << "\n"
          << "  smem_circular_buffer_stage: " << smem_circular_buffer_stage
          << "\n"
-         << "  smem_circular_buffer_prefetch: "
-         << smem_circular_buffer_prefetch;
+         << "  smem_circular_buffer_prefetch_gap: "
+         << smem_circular_buffer_prefetch_gap;
       return ss.str();
     }
 
     size_t hash() const {
       return std::hash<size_t>{}(
-                 (static_cast<size_t>(smem_circular_buffer_prefetch) << 3) |
+                 (static_cast<size_t>(smem_circular_buffer_prefetch_gap) << 3) |
                  (static_cast<size_t>(smem_circular_buffer_stage) << 2) |
                  (static_cast<size_t>(circular_buffer_smem_write)) << 1) |
           (static_cast<size_t>(circular_buffer_smem_read));

--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -41,10 +41,13 @@ class MatmulParams : public HeuristicParams {
     // greater than one. Otherwise it is ignored.
     int smem_circular_buffer_stage = 2;
 
+    int smem_circular_buffer_prefetch = 1;
+
     bool operator==(const CircularBufferOptions& other) const {
       return other.circular_buffer_smem_write == circular_buffer_smem_write &&
           other.circular_buffer_smem_read == circular_buffer_smem_read &&
-          other.smem_circular_buffer_stage == smem_circular_buffer_stage;
+          other.smem_circular_buffer_stage == smem_circular_buffer_stage &&
+          other.smem_circular_buffer_prefetch == smem_circular_buffer_prefetch;
     }
 
     std::string toString() const {
@@ -54,12 +57,16 @@ class MatmulParams : public HeuristicParams {
          << (circular_buffer_smem_write ? "true" : "false") << "\n"
          << "  circular_buffer_smem_read: "
          << (circular_buffer_smem_read ? "true" : "false") << "\n"
-         << "  smem_circular_buffer_stage: " << smem_circular_buffer_stage;
+         << "  smem_circular_buffer_stage: " << smem_circular_buffer_stage
+         << "\n"
+         << "  smem_circular_buffer_prefetch: "
+         << smem_circular_buffer_prefetch;
       return ss.str();
     }
 
     size_t hash() const {
       return std::hash<size_t>{}(
+                 (static_cast<size_t>(smem_circular_buffer_prefetch) << 3) |
                  (static_cast<size_t>(smem_circular_buffer_stage) << 2) |
                  (static_cast<size_t>(circular_buffer_smem_write)) << 1) |
           (static_cast<size_t>(circular_buffer_smem_read));

--- a/csrc/scheduler/matmul_heuristic_plugin.cpp
+++ b/csrc/scheduler/matmul_heuristic_plugin.cpp
@@ -135,6 +135,8 @@ void copyParamsToConfig(KernelConfig* config, const MatmulParams* mparams) {
   };
   config->load_stages =
       mparams->circular_buffer_options.smem_circular_buffer_stage;
+  config->prefetch_distance =
+      mparams->circular_buffer_options.smem_circular_buffer_prefetch;
   config->async_gmem_load_operands = mparams->async_gmem_load_operands;
   setConfigTile(config->cta_tile, mparams->tile_sizes.cta_tile);
   setConfigTile(config->warp_tile, mparams->tile_sizes.warp_tile);
@@ -163,6 +165,8 @@ void copyConfigToParams(MatmulParams* mparams, const KernelConfig* config) {
   setGemmTile(mparams->tile_sizes.warp_tile, config->warp_tile);
   mparams->circular_buffer_options.smem_circular_buffer_stage =
       config->load_stages;
+  mparams->circular_buffer_options.smem_circular_buffer_prefetch =
+      config->prefetch_distance;
   mparams->async_gmem_load_operands = config->async_gmem_load_operands;
   // Update mma macro if necessary to match provided instruction tile
   MmaMacroEncode menc(mparams->mma_macro); // this will record the family

--- a/csrc/scheduler/matmul_heuristic_plugin.cpp
+++ b/csrc/scheduler/matmul_heuristic_plugin.cpp
@@ -135,8 +135,8 @@ void copyParamsToConfig(KernelConfig* config, const MatmulParams* mparams) {
   };
   config->load_stages =
       mparams->circular_buffer_options.smem_circular_buffer_stage;
-  config->prefetch_distance =
-      mparams->circular_buffer_options.smem_circular_buffer_prefetch;
+  config->prefetch_gap =
+      mparams->circular_buffer_options.smem_circular_buffer_prefetch_gap;
   config->async_gmem_load_operands = mparams->async_gmem_load_operands;
   setConfigTile(config->cta_tile, mparams->tile_sizes.cta_tile);
   setConfigTile(config->warp_tile, mparams->tile_sizes.warp_tile);
@@ -165,8 +165,8 @@ void copyConfigToParams(MatmulParams* mparams, const KernelConfig* config) {
   setGemmTile(mparams->tile_sizes.warp_tile, config->warp_tile);
   mparams->circular_buffer_options.smem_circular_buffer_stage =
       config->load_stages;
-  mparams->circular_buffer_options.smem_circular_buffer_prefetch =
-      config->prefetch_distance;
+  mparams->circular_buffer_options.smem_circular_buffer_prefetch_gap =
+      config->prefetch_gap;
   mparams->async_gmem_load_operands = config->async_gmem_load_operands;
   // Update mma macro if necessary to match provided instruction tile
   MmaMacroEncode menc(mparams->mma_macro); // this will record the family

--- a/csrc/scheduler/matmul_heuristic_plugin_api.h
+++ b/csrc/scheduler/matmul_heuristic_plugin_api.h
@@ -74,7 +74,9 @@ struct KernelConfig {
   Tile instruction_tile = {16, 16, 16};
   uint16_t splitk_factor = 1;
   uint8_t load_stages = 2;
-  uint8_t prefetch_distance = 1;
+  // The circular buffering prefetch distance will be set to
+  //   load_stages - prefetch_gap
+  uint8_t prefetch_gap = 1;
   uint8_t grid_swizzle_factor = 0;
   uint8_t cta_order = 0;
   bool circular_buffer_smem_read = true;

--- a/csrc/scheduler/matmul_heuristic_plugin_api.h
+++ b/csrc/scheduler/matmul_heuristic_plugin_api.h
@@ -74,6 +74,7 @@ struct KernelConfig {
   Tile instruction_tile = {16, 16, 16};
   uint16_t splitk_factor = 1;
   uint8_t load_stages = 2;
+  uint8_t prefetch_distance = 1;
   uint8_t grid_swizzle_factor = 0;
   uint8_t cta_order = 0;
   bool circular_buffer_smem_read = true;

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -91,9 +91,6 @@ void limitCircularBufferingSmemOperands(
 
   mparams->circular_buffer_options.circular_buffer_smem_write = (stages != 1);
   mparams->circular_buffer_options.smem_circular_buffer_stage = (int)stages;
-  mparams->circular_buffer_options.smem_circular_buffer_prefetch = std::min(
-      mparams->circular_buffer_options.smem_circular_buffer_prefetch,
-      (int)stages - 1);
 }
 
 //! A wrapper for core heuristics initialization.
@@ -159,8 +156,6 @@ inline bool initCoreHeuristics(
       mparams->circular_buffer_options.circular_buffer_smem_write = true;
       mparams->circular_buffer_options.circular_buffer_smem_read = true;
       mparams->circular_buffer_options.smem_circular_buffer_stage = stages;
-      mparams->circular_buffer_options.smem_circular_buffer_prefetch =
-          stages - 1;
     }
   }
 
@@ -186,9 +181,6 @@ inline bool initCoreHeuristics(
     // most.
     mparams->circular_buffer_options.smem_circular_buffer_stage = std::min(
         2, mparams->circular_buffer_options.smem_circular_buffer_stage);
-    mparams->circular_buffer_options.smem_circular_buffer_prefetch = std::min(
-        mparams->circular_buffer_options.smem_circular_buffer_prefetch,
-        mparams->circular_buffer_options.smem_circular_buffer_stage - 1);
   }
   return true;
 }

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -91,6 +91,9 @@ void limitCircularBufferingSmemOperands(
 
   mparams->circular_buffer_options.circular_buffer_smem_write = (stages != 1);
   mparams->circular_buffer_options.smem_circular_buffer_stage = (int)stages;
+  mparams->circular_buffer_options.smem_circular_buffer_prefetch = std::min(
+      mparams->circular_buffer_options.smem_circular_buffer_prefetch,
+      (int)stages - 1);
 }
 
 //! A wrapper for core heuristics initialization.
@@ -156,6 +159,8 @@ inline bool initCoreHeuristics(
       mparams->circular_buffer_options.circular_buffer_smem_write = true;
       mparams->circular_buffer_options.circular_buffer_smem_read = true;
       mparams->circular_buffer_options.smem_circular_buffer_stage = stages;
+      mparams->circular_buffer_options.smem_circular_buffer_prefetch =
+          stages - 1;
     }
   }
 
@@ -181,6 +186,9 @@ inline bool initCoreHeuristics(
     // most.
     mparams->circular_buffer_options.smem_circular_buffer_stage = std::min(
         2, mparams->circular_buffer_options.smem_circular_buffer_stage);
+    mparams->circular_buffer_options.smem_circular_buffer_prefetch = std::min(
+        mparams->circular_buffer_options.smem_circular_buffer_prefetch,
+        mparams->circular_buffer_options.smem_circular_buffer_stage - 1);
   }
   return true;
 }

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3197,7 +3197,6 @@ class HopperMatmulSchedulerTest
     mparams.circular_buffer_options.circular_buffer_smem_write = true;
     mparams.circular_buffer_options.circular_buffer_smem_read = true;
     mparams.circular_buffer_options.smem_circular_buffer_stage = 4;
-    mparams.circular_buffer_options.smem_circular_buffer_prefetch = 3;
   }
 
   void TearDown() {

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3197,9 +3197,7 @@ class HopperMatmulSchedulerTest
     mparams.circular_buffer_options.circular_buffer_smem_write = true;
     mparams.circular_buffer_options.circular_buffer_smem_read = true;
     mparams.circular_buffer_options.smem_circular_buffer_stage = 4;
-
-    // TODO Create prefetch parameter
-    // mparams.circular_buffer_options.smem_circular_buffer_prefetch = 3;
+    mparams.circular_buffer_options.smem_circular_buffer_prefetch = 3;
   }
 
   void TearDown() {


### PR DESCRIPTION
Previously we had hardcoded to use `smem_circular_buffer_stage - 1` but this gives us more flexibility in our heuristic. We will use `smem_circular_buffer_stage - smem_circular_buffer_prefetch_gap` as the prefetch distance. Parametrizing this way lets us modify the number of stages without needing to adjust the prefetch gap each time, since it will most commonly just be 1.