### PR TITLE
Implement basic split-k gemm for hopper matmul scheduler

### DIFF
--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -921,7 +921,7 @@ std::array<UnitDim, 2> getMmaLayout(const MmaOp* expr) {
 
   auto out_tv = ir_utils::getTv(expr->out());
   IterDomain* reduction_id = nullptr;
-  for (auto id : out_tv->getLogicalDomain()) {
+  for (auto id : out_tv->getMaybeRootDomain()) {
     if (id->isReduction()) {
       reduction_id = id;
       break;

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -921,6 +921,10 @@ std::array<UnitDim, 2> getMmaLayout(const MmaOp* expr) {
 
   auto out_tv = ir_utils::getTv(expr->out());
   IterDomain* reduction_id = nullptr;
+  // For hopper matmuls, the mma_result logical domain is reordered as [M, N, K]
+  // using commitLeafToLogical. In the split-k case, use the root domain for the
+  // mma layout because the k dimension is divided into two iterDomains in the
+  // logical domain.
   for (auto id : out_tv->getMaybeRootDomain()) {
     if (id->isReduction()) {
       reduction_id = id;

--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -34,7 +34,7 @@ void HopperMultipleMatmulScheduler::transformLikeMmaOutput(
     bool is_mma_result) {
   // TODO Add constraints
 
-  auto apply_k_dim_offset = [is_mma_result](int64_t idx) {
+  auto apply_k_dim_offset = [is_mma_result](int64_t idx) constexpr {
     return (is_mma_result) ? idx - 1 : idx;
   };
 

--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -409,9 +409,7 @@ void HopperMultipleMatmulScheduler::scheduleMmaResults() {
     // -> [Mo, No, Ko, Mio, Nio, Mii, Nii, Ki]
     mma_result->reorder({{-4, -3}});
     mma_result->merge(-5);
-    // if (params_->splitk_factor == 1) {
     mma_result->axis(-4)->parallelize(ParallelType::TIDy);
-    //}
 
     auto s = mma_utils::MmaSwizzler::scheduleMmaOutputAllocation(
         mma_result->getLoopDomain());

--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -410,7 +410,9 @@ void HopperMultipleMatmulScheduler::scheduleMmaResults() {
     // -> [Mo, No, Ko, Mio, Nio, Mii, Nii, Ki]
     mma_result->reorder({{-4, -3}});
     mma_result->merge(-5);
-    mma_result->axis(-4)->parallelize(ParallelType::TIDy);
+    if (params_->splitk_factor == 1) {
+      mma_result->axis(-4)->parallelize(ParallelType::TIDy);
+    }
 
     auto s = mma_utils::MmaSwizzler::scheduleMmaOutputAllocation(
         mma_result->getLoopDomain());

--- a/csrc/scheduler/hopper_multi_matmul.h
+++ b/csrc/scheduler/hopper_multi_matmul.h
@@ -191,6 +191,11 @@ class HopperMultipleMatmulScheduler : public MultipleMatmulScheduler {
   // Return MatmulDimRole for IterDomain
   MatmulDimRole findMatmulDimRole(IterDomain* id);
 
+  // Schedule a block-tiled TensorView like mma output.
+  // Why? WGMMA has a unique output format. TensorViews after the mma-result in
+  // registers must respect this format for correctness.
+  void transformLikeMmaOutput(TensorView* tv);
+
  private:
   std::vector<ValGroup> canonical_dim_ordering_;
 

--- a/csrc/scheduler/hopper_multi_matmul.h
+++ b/csrc/scheduler/hopper_multi_matmul.h
@@ -194,7 +194,7 @@ class HopperMultipleMatmulScheduler : public MultipleMatmulScheduler {
   // Schedule a block-tiled TensorView like mma output.
   // Why? WGMMA has a unique output format. TensorViews after the mma-result in
   // registers must respect this format for correctness.
-  void transformLikeMmaOutput(TensorView* tv);
+  void transformLikeMmaOutput(TensorView* tv, bool is_mma_result);
 
  private:
   std::vector<ValGroup> canonical_dim_ordering_;

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -804,7 +804,12 @@ TensorView* TensorView::rFactor(const std::vector<int64_t>& axes) {
       "Error rfactoring ",
       this,
       " its definition is either a nullptr or not a reduction.");
-
+  // For hopper matmuls, the mma_result logical domain is reordered as [M, N, K]
+  // using commitLeafToLogical. Thus, the original logical domain is moved to
+  // the root domain.
+  NVF_CHECK(
+      definition()->isA<MmaOp>() || !domain()->hasRoot(),
+      "Cannot call rfactor on the same view twice.");
   NVF_CHECK(
       !definition()->isA<GroupedReductionOp>(),
       "For GroupedReductionOp, use TensorView::rFactor(const std::vector<int64_t>& axes, const std::vector<TensorView*>& tvs)");
@@ -932,6 +937,13 @@ std::vector<TensorView*> TensorView::rFactor(
       "Error rfactoring multi-output reduction op ",
       this,
       " its definition is either a nullptr or not a GroupedReductionOp or a multi-output reduction op.");
+
+  // For hopper matmuls, the mma_result logical domain is reordered as [M, N, K]
+  // using commitLeafToLogical. Thus, the original logical domain is moved to
+  // the root domain.
+  NVF_CHECK(
+      definition()->isA<MmaOp>() || !domain()->hasRoot(),
+      "Cannot call rfactor on the same view twice.");
 
   NVF_CHECK(
       definition()->outputs().size() == tvs.size(),

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -804,8 +804,6 @@ TensorView* TensorView::rFactor(const std::vector<int64_t>& axes) {
       "Error rfactoring ",
       this,
       " its definition is either a nullptr or not a reduction.");
-  // NVF_CHECK(
-  //! domain()->hasRoot(), "Cannot call rfactor on the same view twice.");
 
   NVF_CHECK(
       !definition()->isA<GroupedReductionOp>(),
@@ -934,9 +932,6 @@ std::vector<TensorView*> TensorView::rFactor(
       "Error rfactoring multi-output reduction op ",
       this,
       " its definition is either a nullptr or not a GroupedReductionOp or a multi-output reduction op.");
-
-  NVF_CHECK(
-      !domain()->hasRoot(), "Cannot call rfactor on the same view twice.");
 
   NVF_CHECK(
       definition()->outputs().size() == tvs.size(),

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -804,8 +804,8 @@ TensorView* TensorView::rFactor(const std::vector<int64_t>& axes) {
       "Error rfactoring ",
       this,
       " its definition is either a nullptr or not a reduction.");
-  NVF_CHECK(
-      !domain()->hasRoot(), "Cannot call rfactor on the same view twice.");
+  // NVF_CHECK(
+  //! domain()->hasRoot(), "Cannot call rfactor on the same view twice.");
 
   NVF_CHECK(
       !definition()->isA<GroupedReductionOp>(),

--- a/csrc/transform_rfactor.cpp
+++ b/csrc/transform_rfactor.cpp
@@ -340,7 +340,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
           [](IterDomain* id) { return id->maybePartial(); }),
       "rFactor of partial domains not allowed, but at least one found.");
 
-  auto original_td_root = original_td->logical();
+  auto original_td_root = original_td->maybeRoot();
 
   // Generate a new TensorDomain and set up map from one root to this one.
   std::vector<IterDomain*> new_producer_root(original_td_root.size(), nullptr);

--- a/csrc/transform_rfactor.cpp
+++ b/csrc/transform_rfactor.cpp
@@ -340,6 +340,9 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
           [](IterDomain* id) { return id->maybePartial(); }),
       "rFactor of partial domains not allowed, but at least one found.");
 
+  // For hopper matmuls, the mma_result logical domain is reordered as [M, N, K]
+  // using commitLeafToLogical. Thus, the original logical domain is moved to
+  // the root domain. In this case, map from producer to consumer's root domain.
   auto original_td_root = original_td->maybeRoot();
 
   // Generate a new TensorDomain and set up map from one root to this one.

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3236,7 +3236,8 @@ class HopperMatmulSchedulerTest
     KernelExecutor ke;
     ke.compile(fusion, inputs, LaunchParams(), matmul_cparams);
     auto nvf_out = ke.run(inputs);
-    EXPECT_TRUE(at::allclose(nvf_out.at(0), tref, 1e-5, 1e-5));
+    // NOTE Relax tolerances for split-k case
+    EXPECT_TRUE(at::allclose(nvf_out.at(0), tref, 1e-3, 1e-3));
   }
 
  protected:

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3217,7 +3217,7 @@ class HopperMatmulSchedulerTest
     mparams.async_gmem_load_operands = true;
     mparams.circular_buffer_options.circular_buffer_smem_write = true;
     mparams.circular_buffer_options.circular_buffer_smem_read = true;
-    mparams.circular_buffer_options.smem_circular_buffer_stage = 4;
+    mparams.circular_buffer_options.smem_circular_buffer_stage = 2;
   }
 
   void TearDown() {

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3120,7 +3120,9 @@ using HopperMatmulSchedulerTestParams = std::tuple<
     int64_t, // M
     int64_t, // N
     int64_t, // K
-    MmaMacro>;
+    MmaMacro,
+    int64_t // SplitK Factor
+    >;
 
 std::string hopperTestName(
     const testing::TestParamInfo<HopperMatmulSchedulerTestParams>& info) {
@@ -3129,14 +3131,25 @@ std::string hopperTestName(
   bool a_k_inner, b_k_inner;
   int64_t M, N, K;
   MmaMacro mma_macro;
-  std::tie(use_smem_epilogue, a_k_inner, b_k_inner, M, N, K, mma_macro) =
-      info.param;
+  int64_t splitk_factor;
+  std::tie(
+      use_smem_epilogue,
+      a_k_inner,
+      b_k_inner,
+      M,
+      N,
+      K,
+      mma_macro,
+      splitk_factor) = info.param;
   os << (a_k_inner ? "K" : "M");
   os << (b_k_inner ? "K" : "N");
   os << "_" << M << "_" << N << "_" << K;
   os << "_MmaMacro_" << macroToString(mma_macro);
   if (use_smem_epilogue) {
     os << "_tma_store";
+  }
+  if (splitk_factor > 1) {
+    os << "_splitk_" << splitk_factor;
   }
   return os.str();
 }
@@ -3162,8 +3175,15 @@ class HopperMatmulSchedulerTest
   void SetUp() {
     NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(9, 0, 10, 0);
 
-    std::tie(use_smem_epilogue, a_k_inner, b_k_inner, M, N, K, mma_macro) =
-        GetParam();
+    std::tie(
+        use_smem_epilogue,
+        a_k_inner,
+        b_k_inner,
+        M,
+        N,
+        K,
+        mma_macro,
+        splitk_factor) = GetParam();
 
     if (a_k_inner) {
       layout = b_k_inner ? MmaLayout::TN : MmaLayout::TT;
@@ -3192,6 +3212,7 @@ class HopperMatmulSchedulerTest
 
     mparams.use_smem_epilogue = use_smem_epilogue;
 
+    mparams.splitk_factor = splitk_factor;
     mparams.tile_sizes = gemm_tile;
     mparams.async_gmem_load_operands = true;
     mparams.circular_buffer_options.circular_buffer_smem_write = true;
@@ -3223,6 +3244,7 @@ class HopperMatmulSchedulerTest
   bool a_k_inner, b_k_inner;
   int64_t M, N, K;
   MmaMacro mma_macro;
+  int64_t splitk_factor;
   std::unique_ptr<Fusion> fusion_up;
   Fusion* fusion;
   std::unique_ptr<FusionGuard> fusion_guard;
@@ -3304,7 +3326,8 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(512), // M
         testing::Values(256), // N
         testing::Values(64), // K
-        testing::Values(MmaMacro::Hopper_64_128_16) // mma_macros
+        testing::Values(MmaMacro::Hopper_64_128_16), // mma_macros
+        testing::Values(1, 2) // SplitK Factor
         ),
     hopperTestName);
 
@@ -3323,7 +3346,8 @@ INSTANTIATE_TEST_SUITE_P(
             MmaMacro::Hopper_64_128_16,
             MmaMacro::Hopper_64_64_16,
             MmaMacro::Hopper_64_32_16,
-            MmaMacro::Hopper_64_16_16) // mma_macros
+            MmaMacro::Hopper_64_16_16), // mma_macros
+        testing::Values(1) // SplitK Factor
         ),
     hopperTestNameSwizzle);
 


### PR DESCRIPTION
This PR implements `scheduleSplitKSum` function to support split-k gemm with the hopper matmul schedule.

- It support all operand formats such as TT, NT, TN, NN.