### PR TITLE
Grab all IDs and exprs with StmtSort::getAllStmts (and fix replaceSymbolicSizes)

### DIFF
--- a/csrc/device_lower/pass/expr_sort.cpp
+++ b/csrc/device_lower/pass/expr_sort.cpp
@@ -1088,7 +1088,7 @@ bool ExprSegmentationSorter::interIterUpdate() {
     NVF_ERROR(
         !fallback_mode_enabled_,
         "Couldn't succcessfully sort out the fusion expressions. ",
-        "There are remaining connections of the heirarchical segmentation which should have been ",
+        "There are remaining connections of the hierarchical segmentation which should have been ",
         "flattened to a single ordered group, or disjoint ordered groups.\n",
         toString());
     // We didn't finish, but we haven't tried the fallback, try again with that.

--- a/csrc/device_lower/pass/replace_size.cpp
+++ b/csrc/device_lower/pass/replace_size.cpp
@@ -137,6 +137,75 @@ std::unordered_map<Val*, Val*> getSimplificationMap(Fusion* fusion) {
   return simplification_map;
 }
 
+class IterDomainReplacementMutator : private OptOutMutator {
+ public:
+  IterDomainReplacementMutator(
+      Fusion* fusion,
+      const std::unordered_map<Val*, Val*>& replacement_map)
+      : replacement_map_(replacement_map) {
+    FusionGuard fg(fusion);
+
+    std::unordered_map<TensorView*, std::vector<Statement*>> tv_stmts;
+    for (auto tv : fusion->allTvs()) {
+      auto all_stmts = tv->domain()->allStatements();
+
+      std::vector<Statement*> stmts_to_visit;
+      for (auto stmt : all_stmts) {
+        if (auto id = dynamic_cast<IterDomain*>(stmt)) {
+          auto id_members = MemberStatements::get(id);
+          for (auto id_member : id_members) {
+            for (auto stmt_dep :
+                 StmtSort::getStmtsTo({id_member->as<Val>()}, true, true)) {
+              stmts_to_visit.push_back(stmt_dep);
+            }
+          }
+          stmts_to_visit.push_back(id);
+        } else {
+          auto expr = dynamic_cast<Expr*>(stmt);
+          NVF_ERROR(expr != nullptr);
+          for (auto attr : expr->attributes()) {
+            for (auto stmt_dep :
+                 StmtSort::getStmtsTo({attr->as<Val>()}, true, true)) {
+              stmts_to_visit.push_back(stmt_dep);
+            }
+          }
+          stmts_to_visit.push_back(expr);
+        }
+      }
+
+      tv_stmts.emplace(tv, stmts_to_visit);
+    }
+
+    std::unordered_set<Statement*> visited;
+    for (auto tv : fusion->allTvs()) {
+      const auto& stmts_to_visit = tv_stmts.at(tv);
+      for (auto stmt : stmts_to_visit) {
+        if (visited.count(stmt)) {
+          continue;
+        }
+        dispatchMutate(stmt);
+        visited.insert(stmt);
+      }
+
+      dispatchMutate(tv->domain());
+      dispatchMutate(tv);
+    }
+  }
+
+ private:
+  using OptOutMutator::dispatchMutate;
+
+  void dispatchMutate(Val* val) final {
+    if (replacement_map_.find(val) == replacement_map_.end()) {
+      return OptOutMutator::dispatchMutate(val);
+    }
+    auto replaced_val = replacement_map_.at(val);
+    registerMutation(val, replaced_val);
+  }
+
+  const std::unordered_map<Val*, Val*>& replacement_map_;
+};
+
 } // namespace
 
 void replaceSymbolicSizes(Fusion* fusion) {
@@ -266,8 +335,8 @@ void replaceSymbolicSizes(Fusion* fusion) {
     }
   }
 
-  // Run mutation on the fusion with the tensor_dim_map
-  ir_utils::replaceValue(fusion, extent_simplification_map);
+  // NOLINTNEXTLINE(bugprone-unused-raii)
+  IterDomainReplacementMutator(fusion, extent_simplification_map);
 }
 
 } // namespace nvfuser

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -610,6 +610,9 @@ class TensorDomain : public Val {
   // Similar to allIDs but returns all ID expressions.
   std::vector<Expr*> allExprs() const;
 
+  // Combine allIDs and allExprs
+  std::vector<Statement*> allStatements() const;
+
   const std::vector<IterDomain*>& maybeAllocation() const {
     return hasAllocation() ? allocation_domain_ : logical();
   };

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3763,8 +3763,10 @@ std::vector<IterDomain*> TensorDomain::allIDs() const {
   while (!ids_to_be_sorted.empty()) {
     auto it = ids_to_be_sorted.begin();
     while (it != ids_to_be_sorted.end()) {
-      auto in_it = out2in.find(*it);
-      if (in_it == out2in.end() || sorted_ids.has(in_it->second)) {
+      auto range = out2in.equal_range(*it);
+      if (std::all_of(range.first, range.second, [&](const auto& kv) {
+            return sorted_ids.has(kv.second);
+          })) {
         sorted_ids.pushBack(*it);
         it = ids_to_be_sorted.erase(it);
       } else {

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -451,7 +451,9 @@ class ValReplacementMutator : private OptOutMutator {
     // typically not used by anything else. If we don't grab that count, then it
     // would be a tensorview that doesn't get updated extents. Therefore, first
     // grab all leaves towards outputs and grab stmts from there.
-    auto stmts = StmtSort::getStmtsTo(allLeafOuts(fusion), true, true);
+    // auto stmts = StmtSort::getStmtsTo(allLeafOuts(fusion), true,
+    // true);
+    auto stmts = StmtSort::getAllStmtsTo(allLeafOuts(fusion), true, true);
 
     // Some fusions, such as standalone rand_like, can have disconnected DAG, so
     // we need some mechanism to make sure our replacement set is as complete as
@@ -501,6 +503,21 @@ class ValReplacementMutator : private OptOutMutator {
     std::unordered_set<Val*> outputs;
     std::vector<Val*> ordered_outputs;
     for (auto expr : exprs) {
+      if (std::any_of(
+              expr->outputs().begin(), expr->outputs().end(), [](Val* output) {
+                return output->isA<IterDomain>();
+              })) {
+        NVF_ERROR(std::all_of(
+            expr->outputs().begin(), expr->outputs().end(), [](Val* output) {
+              return output->isA<IterDomain>();
+            }));
+        NVF_ERROR(std::all_of(
+            expr->inputs().begin(), expr->inputs().end(), [](Val* input) {
+              return input->isA<IterDomain>();
+            }));
+        continue;
+      }
+
       inputs.insert(expr->inputs().begin(), expr->inputs().end());
       outputs.insert(expr->outputs().begin(), expr->outputs().end());
       ordered_outputs.insert(

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -451,8 +451,6 @@ class ValReplacementMutator : private OptOutMutator {
     // typically not used by anything else. If we don't grab that count, then it
     // would be a tensorview that doesn't get updated extents. Therefore, first
     // grab all leaves towards outputs and grab stmts from there.
-    // auto stmts = StmtSort::getStmtsTo(allLeafOuts(fusion), true,
-    // true);
     auto stmts = StmtSort::getAllStmtsTo(allLeafOuts(fusion), true, true);
 
     // Some fusions, such as standalone rand_like, can have disconnected DAG, so
@@ -503,6 +501,9 @@ class ValReplacementMutator : private OptOutMutator {
     std::unordered_set<Val*> outputs;
     std::vector<Val*> ordered_outputs;
     for (auto expr : exprs) {
+      // Iter domains and their exprs are taken care by traversing
+      // from TensorDomain with TensorDomain::allStatements, so they
+      // don't need to be included here
       if (std::any_of(
               expr->outputs().begin(), expr->outputs().end(), [](Val* output) {
                 return output->isA<IterDomain>();

--- a/csrc/iter_visitor.cpp
+++ b/csrc/iter_visitor.cpp
@@ -925,6 +925,87 @@ std::vector<Statement*> StmtSort::getStmtsTo(
   return es.stmts;
 }
 
+std::vector<Statement*> StmtSort::getAllStmts(
+    Fusion* fusion,
+    bool traverse_members,
+    bool traverse_attributes,
+    bool traverse_siblings) {
+  return getAllStmtsTo(
+      fusion->getTerminatingOutputs(),
+      traverse_members,
+      traverse_attributes,
+      traverse_siblings);
+}
+
+std::vector<Statement*> StmtSort::getAllStmtsTo(
+    const std::vector<Val*>& to,
+    bool traverse_members,
+    bool traverse_attributes,
+    bool traverse_siblings) {
+  // If members are not traversed, this can just be handled by getStmts
+  if (!traverse_members) {
+    return getStmtsTo(
+        to, traverse_members, traverse_attributes, traverse_siblings);
+  }
+
+  // to is assumed to include only scalar or TensorView
+  NVF_ERROR(std::all_of(to.begin(), to.end(), [](Val* to_val) {
+    return to_val->vtype() == ValType::TensorView ||
+        to_val->vtype() == ValType::Others;
+  }));
+
+  // First, grab all statements without traversing tensor members
+  auto stmts = getStmtsTo(to, false, traverse_attributes, traverse_siblings);
+
+  VectorOfUniqueEntries<Statement*> all_stmts;
+
+  for (auto stmt : stmts) {
+    auto tv = dynamic_cast<TensorView*>(stmt);
+    if (tv == nullptr) {
+      all_stmts.pushBack(stmt);
+      continue;
+    }
+
+    auto all_id_stmts = tv->domain()->allStatements();
+    for (auto id_stmt : all_id_stmts) {
+      if (auto id = dynamic_cast<IterDomain*>(id_stmt)) {
+        auto id_members = MemberStatements::get(id);
+        // Note that traverse_members is always true at this point
+        for (auto id_member : id_members) {
+          for (auto stmt_dep : StmtSort::getStmtsTo(
+                   {id_member->as<Val>()},
+                   /*traverse_members=*/true,
+                   traverse_attributes,
+                   traverse_siblings)) {
+            all_stmts.pushBack(stmt_dep);
+          }
+        }
+        all_stmts.pushBack(id);
+      } else {
+        auto expr = dynamic_cast<Expr*>(id_stmt);
+        NVF_ERROR(expr != nullptr);
+        if (traverse_attributes) {
+          for (auto attr : expr->attributes()) {
+            for (auto stmt_dep : StmtSort::getStmtsTo(
+                     {attr->as<Val>()},
+                     /*traverse_members=*/true,
+                     traverse_attributes,
+                     traverse_siblings)) {
+              all_stmts.pushBack(stmt_dep);
+            }
+          }
+        }
+        all_stmts.pushBack(expr);
+      }
+    }
+
+    all_stmts.pushBack(tv->domain());
+    all_stmts.pushBack(tv);
+  }
+
+  return all_stmts.vector();
+}
+
 std::vector<Statement*> StmtSort::getStmtsBetween(
     const std::vector<Val*>& from,
     const std::vector<Val*>& to,

--- a/csrc/iter_visitor.cpp
+++ b/csrc/iter_visitor.cpp
@@ -36,51 +36,38 @@ void remove_visited(
   }
 }
 
-class MemberStatements : public OptOutDispatch {
- public:
-  // Return all members of the stmt if it's a Val. For expressions it returns
-  // nothing.
-  static std::vector<Statement*> next(Statement* stmt) {
-    MemberStatements find_next(stmt);
-    return find_next.next_stmts_;
-  }
-
- private:
-  MemberStatements() = default;
-
-  MemberStatements(Statement* stmt) {
-    dispatch(stmt);
-  }
-
-  using OptOutDispatch::dispatch;
-  using OptOutDispatch::handle;
-
-  void dispatch(Val* val) final {
-    FusionGuard::getCurFusion()->assertInContainer(
-        val,
-        "IterVisitor.cpp::MemberStatements::dispatch(Val*) Cannot traverse val, ");
-    OptOutDispatch::dispatch(val);
-  }
-
-  void handle(IterDomain* stmt) final {
-    next_stmts_.push_back(stmt->start());
-    next_stmts_.push_back(stmt->extent());
-    next_stmts_.push_back(stmt->stopOffset());
-  }
-
-  void handle(TensorDomain* stmt) final {
-    next_stmts_.insert(
-        next_stmts_.end(), stmt->loop().begin(), stmt->loop().end());
-  }
-
-  void handle(TensorView* tv) final {
-    next_stmts_.push_back(tv->domain());
-  }
-
-  std::vector<Statement*> next_stmts_;
-};
-
 } // namespace
+
+std::vector<Statement*> MemberStatements::get(Statement* stmt) {
+  MemberStatements find_next(stmt);
+  return find_next.next_stmts_;
+}
+
+MemberStatements::MemberStatements(Statement* stmt) {
+  dispatch(stmt);
+}
+
+void MemberStatements::dispatch(Val* val) {
+  FusionGuard::getCurFusion()->assertInContainer(
+      val,
+      "IterVisitor.cpp::MemberStatements::dispatch(Val*) Cannot traverse val, ");
+  OptOutDispatch::dispatch(val);
+}
+
+void MemberStatements::handle(IterDomain* stmt) {
+  next_stmts_.push_back(stmt->start());
+  next_stmts_.push_back(stmt->extent());
+  next_stmts_.push_back(stmt->stopOffset());
+}
+
+void MemberStatements::handle(TensorDomain* stmt) {
+  next_stmts_.insert(
+      next_stmts_.end(), stmt->loop().begin(), stmt->loop().end());
+}
+
+void MemberStatements::handle(TensorView* tv) {
+  next_stmts_.push_back(tv->domain());
+}
 
 std::vector<Statement*> IterVisitor::next(Statement* stmt) {
   if (stmt->isVal()) {
@@ -229,7 +216,7 @@ void IterVisitor::traverseBetween(
       }
 
       if (traverse_into_members) {
-        auto members = MemberStatements::next(stmt);
+        auto members = MemberStatements::get(stmt);
         next_stmts.insert(next_stmts.end(), members.begin(), members.end());
       }
 

--- a/csrc/iter_visitor.h
+++ b/csrc/iter_visitor.h
@@ -341,6 +341,18 @@ class StmtSort : public IterVisitor {
       bool traverse_attributes = false,
       bool traverse_siblings = false);
 
+  NVF_API static std::vector<Statement*> getAllStmts(
+      Fusion* fusion,
+      bool traverse_members = false,
+      bool traverse_attributes = false,
+      bool traverse_siblings = false);
+
+  NVF_API static std::vector<Statement*> getAllStmtsTo(
+      const std::vector<Val*>& to,
+      bool traverse_members = false,
+      bool traverse_attributes = false,
+      bool traverse_siblings = false);
+
   // Returns ordered Statements required to produce from, including from.
   // Stops traversal once hiting any Statements in to. Includes Statements in
   // to.

--- a/csrc/iter_visitor.h
+++ b/csrc/iter_visitor.h
@@ -242,6 +242,31 @@ class BackwardVisitor : public OptOutDispatch {
   bool must_cover_all_expr_outputs_ = true;
 };
 
+class MemberStatements : public OptOutDispatch {
+ public:
+  // Return all members of the stmt if it's a Val. For expressions it returns
+  // nothing.
+  static std::vector<Statement*> get(Statement* stmt);
+
+ private:
+  MemberStatements() = default;
+
+  MemberStatements(Statement* stmt);
+
+  using OptOutDispatch::dispatch;
+  using OptOutDispatch::handle;
+
+  void dispatch(Val* val) final;
+
+  void handle(IterDomain* stmt) final;
+
+  void handle(TensorDomain* stmt) final;
+
+  void handle(TensorView* tv) final;
+
+  std::vector<Statement*> next_stmts_;
+};
+
 class DependencyCheck {
  public:
   // Returns if "dependency" is a dependency of "of".

--- a/csrc/iter_visitor.h
+++ b/csrc/iter_visitor.h
@@ -316,12 +316,21 @@ class StmtSort : public IterVisitor {
       bool traverse_attributes = false,
       bool traverse_siblings = false);
 
+  // Returns all ordered Statements of a given fusion. Unlike
+  // getStmts, for TensorDomain, all of its iter domains and exprs are
+  // grabbed and returned in a topological order.
   NVF_API static std::vector<Statement*> getAllStmts(
       Fusion* fusion,
       bool traverse_members = false,
       bool traverse_attributes = false,
       bool traverse_siblings = false);
 
+  // Returns ordered Statements required to produce 'to', including
+  // 'to'. Unlike getStmtsTo, for TensorDomain, all of its iter domains and
+  // exprs are grabbed and returned in a topological order.
+  //
+  // The to vals are assumed to be either TensorView or scalar
+  // Val. This assumption could be removed if desired.
   NVF_API static std::vector<Statement*> getAllStmtsTo(
       const std::vector<Val*>& to,
       bool traverse_members = false,

--- a/csrc/iter_visitor.h
+++ b/csrc/iter_visitor.h
@@ -242,31 +242,6 @@ class BackwardVisitor : public OptOutDispatch {
   bool must_cover_all_expr_outputs_ = true;
 };
 
-class MemberStatements : public OptOutDispatch {
- public:
-  // Return all members of the stmt if it's a Val. For expressions it returns
-  // nothing.
-  static std::vector<Statement*> get(Statement* stmt);
-
- private:
-  MemberStatements() = default;
-
-  MemberStatements(Statement* stmt);
-
-  using OptOutDispatch::dispatch;
-  using OptOutDispatch::handle;
-
-  void dispatch(Val* val) final;
-
-  void handle(IterDomain* stmt) final;
-
-  void handle(TensorDomain* stmt) final;
-
-  void handle(TensorView* tv) final;
-
-  std::vector<Statement*> next_stmts_;
-};
-
 class DependencyCheck {
  public:
   // Returns if "dependency" is a dependency of "of".

--- a/csrc/iter_visitor.h
+++ b/csrc/iter_visitor.h
@@ -327,7 +327,8 @@ class StmtSort : public IterVisitor {
 
   // Returns ordered Statements required to produce 'to', including
   // 'to'. Unlike getStmtsTo, for TensorDomain, all of its iter domains and
-  // exprs are grabbed and returned in a topological order.
+  // exprs are grabbed and returned in a topological order, regardless of
+  // `traverse_members`.
   //
   // The to vals are assumed to be either TensorView or scalar
   // Val. This assumption could be removed if desired.

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -9225,6 +9225,51 @@ TEST_F(NVFuserTest, ParallelDimensionsInAllocation) {
   ASSERT_TRUE(tidx_dim != nullptr);
 }
 
+// Check the topological ordering of TensorDomain::allIDs(). Repro of
+// issue #3583
+TEST_F(NVFuserTest, AllIdsMultipleDependencies) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeConcreteTensor({10, 20});
+  fusion.addInput(tv0);
+
+  auto tv1 = slice(
+      tv0,
+      {{fusion.zeroVal(), IrBuilder::create<Val>(2)},
+       {fusion.zeroVal(), tv0->getLogicalDomain().at(1)->extent()}});
+
+  fusion.addOutput(tv1);
+
+  tv1->merge(0);
+  tv1->split(0, 4);
+  tv1->split(0, 8);
+
+  fusion.print();
+
+  auto all_ids = tv1->domain()->allIDs();
+
+  auto split2 = tv1->axis(0)->definition()->as<Split>();
+  auto split1 = split2->input(0)->definition()->as<Split>();
+  auto merge = split1->input(0)->definition()->as<Merge>();
+  auto resize = merge->input(0)->definition()->as<Resize>();
+
+  std::vector<Expr*> exprs{resize, merge, split1, split2};
+
+  for (auto expr : exprs) {
+    for (auto inp : ir_utils::filterByType<IterDomain>(expr->inputs())) {
+      auto inp_it = std::find(all_ids.begin(), all_ids.end(), inp);
+      for (auto out : ir_utils::filterByType<IterDomain>(expr->outputs())) {
+        auto out_it = std::find(all_ids.begin(), all_ids.end(), out);
+        EXPECT_LT(inp_it, out_it)
+            << "Invalid ordering: " << out->toString() << " detected before "
+            << inp->toString() << ". All IDs: " << toDelimitedString(all_ids)
+            << "\n";
+      }
+    }
+  }
+}
+
 // Test file size should be up to 10K LoC. Create a new file for more tests.
 
 } // namespace nvfuser

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -4090,8 +4090,6 @@ TEST_F(ResizeTest, PropagateSliceToInputsWithReshape1) {
   // Fusion should have a uniform loop domain
   checkLoopDomainEquivalence(ref_tv);
 
-  fusion.print();
-
   // Schedule the reference
   ref_tv->flatten();
   // For TIDx
@@ -4240,8 +4238,6 @@ TEST_F(ResizeTest, PropagateMultipleSlicesToInputs) {
 
   // Fusion should have a uniform loop domain
   checkLoopDomainEquivalence(ref_tv);
-
-  fusion.print();
 
   // Schedule the reference
   ref_tv->flatten();


### PR DESCRIPTION
Stacked on #3585 

`StmtSort::getStmtsTo` may not grab all active iter domains if IDs are connected in an unconventional way. For example, we can set the loop domain of a tensor as a producer of its logical domain, but due to the nature of `IterVisitor`, such ID dependency patterns are not supported, meaning `StmtSort::getStmtsTo` would fail to grab all valid IDs and their exprs.

I just recently noticed this issue while working on #3556, specifically the issue got exposed as an inconsistent replacement of extent vals. I've been experimenting such patterns of domains, but I hadn't seen this before, likely because I was using just static shape tensors for convenience.

To fix the issue, I added a variation of `StmtSort::getStmtsTo`, which traverses a fusion as usual but stops at TensorView. For each TensorView, instead of using `IterVisitor`, it uses `TensorDomain::getAllStatements()`, which combines both `TensorDomain::allIDs()` and `TensorDomain::allExprs()`, and traverse the IDs and exprs in the returned order.

It's a bit naive implementation, but I think this is good enough for now and also I don't have any other immediate idea to try.

I changed `ValReplacementMutator` to use the new interface. That's the only use for now.
