### PR TITLE
Schedule epilogue (for Hopper Matmul) by propagation backward from output - smem epilogue not supported.

### DIFF
--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -436,7 +436,6 @@ void HopperMultipleMatmulScheduler::scheduleMmaResults() {
 
 void HopperMultipleMatmulScheduler::scheduleEpilogue() {
   std::vector<TensorView*> cached_tvs;
-  std::vector<TensorView*> c_tvs;
 
   // Propagate to (not including) the splitk output if there is a splitk
   // else this is just mma_results_
@@ -478,7 +477,9 @@ void HopperMultipleMatmulScheduler::scheduleEpilogue() {
       // inner-dim with extent 2.
       // TODO: support vectorization_factor.
       d->axis(-1)->parallelize(ParallelType::Vectorize);
-      scheduler_utils::parallelizeAllLike(d, -1, cached_tvs);
+      if (!cached_tvs.empty()) {
+        scheduler_utils::parallelizeAllLike(d, -1, cached_tvs);
+      }
     }
   } else {
     constexpr int64_t stmatrix_tile_m = 16;

--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -9,7 +9,6 @@
 #include <disjoint_set.h>
 #include <id_model/schedule.h>
 #include <instrumentation.h>
-#include <ir/graphviz.h>
 #include <ir/utils.h>
 #include <scheduler/debug_utils.h>
 #include <scheduler/hopper_multi_matmul.h>

--- a/csrc/scheduler/hopper_multi_matmul.h
+++ b/csrc/scheduler/hopper_multi_matmul.h
@@ -171,14 +171,7 @@ class HopperMultipleMatmulScheduler : public MultipleMatmulScheduler {
 
   void scheduleMmaResults();
 
-  void scheduleOutputTensor(TensorView* c);
-
   void scheduleEpilogue();
-
-  //! Propagates transformations from fusion output to fusion tv inputs that are
-  //!  producers in the epilogue. Transformations' propagation aims at input tvs
-  //!  which are not assigned to core roles, that is, are not MMA inputs.
-  void scheduleFusionInputsForEpilogue();
 
   void scheduleSplitKSum();
 

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3376,6 +3376,8 @@ TEST_P(HopperMatmulSchedulerTest, FusedMultiplySum) {
   tref = atMatmul(A.squeeze(), B.squeeze(), layout);
 }
 
+// TODO: Remove this test once the architecture agnostic can be
+// run on hopper.
 TEST_P(HopperMatmulSchedulerTest, FusedMultiplySumBiasNeg) {
   if (use_smem_epilogue) {
     GTEST_SKIP()


### PR DESCRIPTION
This adds support for scheduling epilogue for the hopper matmul scheduler.
We don't support smem epilogue as yet.

We also don't honor the vectorization_factor as yet for the store to output. That'll be covered in a separate PR.