### PR TITLE
Enable the Loop option of IdModle for resize

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -353,6 +353,7 @@ IdModelOptions getIdModelOptions(Fusion* fusion) {
       options.setConsumerIndex(true);
       options.setInlinePredicate(true);
       options.setUnswitchPredicate(true);
+      options.setLoop(true);
       continue;
     } else if (auto reshape = dynamic_cast<ViewOp*>(expr)) {
       // The legacy indexer has an issue when an expand broadcast is


### PR DESCRIPTION
Followup to #3567. I just found the Loop option is also necessary. With this option, the inlining analysis uses IdModel to understand if inlining is possible. The loop generation lowering pass also uses IdModel loop promotion to figure out which iter domains to use for each `ForLoop` node. The latter is not necessary for the resize scheduler at this moment, though.