### PR TITLE
Remove extra prof.start

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -152,7 +152,6 @@ class NVFBenchmark:
         # Clear the internal profiler object to avoid accumulating function events and then restart the profiler
         # See PR: https://github.com/pytorch/pytorch/pull/125510
         self.prof.profiler = None
-        self.prof.start()
 
         return self.current_time
 


### PR DESCRIPTION
This extra `prof.start()` should not be present, since we are toggling the profiler in the try-except block at the start. This line restarts the profile after the first round finishes, and then the profiler tries to extract CUDA events at the beginning of the next round, when the target function has not run yet. Since, we clear L2 cache between rounds, we do not always see an error, and alternate rounds get correctly timed.

I think it is remnant from https://github.com/NVIDIA/Fuser/commit/9fc7bb39a6adaf78c49bedb469f4e410cd31d49a around the same time when we first saw this error in the CI.

Thanks to @jacobhinkle for the following deterministic repro which currently fails on main:
`pytest "benchmarks/python/test_matmul.py::test_matmul_baseline_benchmark[60456-8968-387936-TT-fp16-executor='eager'-fullred]" -vs --benchmark-eager`
This is resolved now.