### PR TITLE
Host IR: make stream synchronization non blocking

### DIFF
--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -138,6 +138,8 @@ class HostIrEvaluator final : public OptOutDispatch {
   using StreamKey = std::variant<int64_t, Stream*>;
   std::unordered_map<StreamKey, c10::cuda::CUDAStream> streams_;
   std::unordered_map<Expr*, c10::intrusive_ptr<c10d::Work>> works_;
+  const int64_t my_device_index_;
+  std::vector<cudaEvent_t> events_;
 };
 
 } // namespace hir

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <cuda_utils.h>
 #include <multidevice/communicator.h>
 #include <options.h>
 
@@ -195,6 +196,8 @@ Communicator::Communicator(
   if (!is_available_) {
     return;
   }
+
+  NVFUSER_CUDA_RT_SAFE_CALL(cudaSetDevice(local_rank_));
 
 #ifdef NVFUSER_DISTRIBUTED
   c10d::TCPStoreOptions store_opts;


### PR DESCRIPTION
# What

Make stream synchronization non-blocking from the CPU point of view

# Why

Needed for achieving overlap in 
- https://github.com/NVIDIA/Fuser/pull/3606

before this patch:
![Screenshot 2024-12-18 at 12 08 25](https://github.com/user-attachments/assets/f5c84282-ea85-4cb8-8a60-538cd91cfa1c)
after this patch
![Screenshot 2024-12-18 at 12 08 05](https://github.com/user-attachments/assets/25537a5d-3e33-4ff8-baf4-4f013c1ed230)


# How 

- Before this patch, the host IR `Synchronize` would call `c10::synchronize()` on the cuda stream, which makes the CPU blocks until stream completion. With this patch, we synchronize the current stream with a given stream through a `cudaEvent` and the API `cudaStreamWaitEvent`.
- We store the created cuda events in the HostIrExecutor
- We block the CPU on the user's stream completion at the end of `HostIrEvaluator::runWithInput`. This is necessary to free the created Events. I don't know how to do otherwise but I am open to suggestions. Today, there isn't a clear contract on whether nvFuser is non-blocking.