### PR TITLE
Enable fp8 on sm89

### DIFF
--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -20,8 +20,8 @@ void MinimumDeviceVersion::dispatch(Val* val) {
   if (val->dtype() == DataType::Float8_e4m3fn ||
       val->dtype() == DataType::Float8_e5m2) {
     ensureVersion(
-        {9, 0},
-        "Fusion contains Float8_xxx values which was introduced in Hopper (9.0)");
+        {8, 9},
+        "Fusion contains Float8_xxx values which was introduced in Ada (8.9)");
   }
   IterVisitor::dispatch(val);
 }

--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <cuda.h>
+
 #include <device_lower/analysis/device_version.h>
 #include <device_lower/lower2device.h>
 #include <mma_type.h>
@@ -19,9 +21,22 @@ void MinimumDeviceVersion::dispatch(Val* val) {
   }
   if (val->dtype() == DataType::Float8_e4m3fn ||
       val->dtype() == DataType::Float8_e5m2) {
+// See release note
+// https://docs.nvidia.com/cuda/archive/12.1.0/parallel-thread-execution/index.html#ptx-isa-version-8-1
+#if (CUDA_VERSION >= 12010)
     ensureVersion(
         {8, 9},
         "Fusion contains Float8_xxx values which was introduced in Ada (8.9)");
+// See release note
+// https://docs.nvidia.com/cuda/archive/11.8.0/parallel-thread-execution/index.html#ptx-isa-version-7-8
+#elif (CUDA_VERSION >= 11080)
+    ensureVersion(
+        {8, 9},
+        "Fusion contains Float8_xxx values which was introduced in Hopper (9.0)");
+#else
+    NVF_ERROR(
+        "Fusion contains Float8_xxx values which was not supported in given CUDA version");
+#endif // (CUDA_VERSION >= 12010)
   }
   IterVisitor::dispatch(val);
 }

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -2711,12 +2711,17 @@ TEST_F(NVFuserTest, FusionFp8CastOps_CUDA) {
       std::vector<c10::IValue> inputs = {input1};
 
       KernelExecutor ke;
-
+#if (CUDA_VERSION >= 12010)
+      if (!deviceMajorMinorCheck(8, 9)) {
+#elif (CUDA_VERSION >= 11080)
       if (!deviceMajorMinorCheck(9)) {
+#else
+      if (true) {
+#endif
         ASSERT_THAT(
             [&]() { ke.compile(&fusion, inputs); },
             testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
-                "Reason: Fusion contains Float8_xxx values which was introduced in Hopper (9.0)")));
+                "Reason: Fusion contains Float8_xxx values")));
         GTEST_SKIP() << "skipping tests on pre-HOPPER GPUs";
       } else {
         ke.compile(&fusion, inputs);

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -2722,7 +2722,6 @@ TEST_F(NVFuserTest, FusionFp8CastOps_CUDA) {
             [&]() { ke.compile(&fusion, inputs); },
             testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
                 "Reason: Fusion contains Float8_xxx values")));
-        GTEST_SKIP() << "skipping tests on pre-HOPPER GPUs";
       } else {
         ke.compile(&fusion, inputs);
         auto outputs = ke.run(inputs);


### PR DESCRIPTION
fp8's supported has been lifted to sm89 since PTX ISA 8.1 and later per https://docs.nvidia.com/cuda/parallel-thread-execution/