### PR TITLE
Add a test for SDPA's logsumexp output

### DIFF
--- a/tests/python/test_sdpa.py
+++ b/tests/python/test_sdpa.py
@@ -53,7 +53,9 @@ class TestSdpa(NVFuserTest):
                 fusion_func,
                 inputs,
             )
-        torch.testing.assert_close(nvf_out[0].cpu(), torch.full((n, h, l), math.log(s) + 1))
+        torch.testing.assert_close(
+            nvf_out[0].cpu(), torch.full((n, h, l), math.log(s) + 1)
+        )
 
     def test_sdpa_fwd(self):
         def fusion_func(

--- a/tests/python/test_sdpa.py
+++ b/tests/python/test_sdpa.py
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Owner(s): ["module: nvfuser"]
 
+import itertools
 import math
+import pytest
 import torch
 import torch.nn.functional as F
-import pytest
-import itertools
-from utils import NVFuserTest, is_pre_ampere
-from nvfuser import FusionDefinition, DataType, FusionCache
 from functools import partial
+from nvfuser import FusionDefinition, DataType, FusionCache
+from utils import NVFuserTest, is_pre_ampere
 
 
 @pytest.mark.skipif(

--- a/tests/python/test_sdpa.py
+++ b/tests/python/test_sdpa.py
@@ -57,7 +57,7 @@ class TestSdpa(NVFuserTest):
         # matrix full of `sqrt(e)`s.  Therefore, the logsumexp of each row is
         # expected to be log(exp(sqrt(e)) * s) = log(s) + sqrt(e).
         torch.testing.assert_close(
-            nvf_out[0].cpu(), torch.full((n, h, l), math.log(s) + e ** 0.5)
+            nvf_out[0].cpu(), torch.full((n, h, l), math.log(s) + e**0.5)
         )
 
     def test_sdpa_fwd(self):

--- a/tests/python/test_sdpa.py
+++ b/tests/python/test_sdpa.py
@@ -53,6 +53,9 @@ class TestSdpa(NVFuserTest):
                 fusion_func,
                 inputs,
             )
+        # Ignoring size-1 dimensions, Q @ K^T generates a SxS matrix full of 1s.
+        # Therefore, the logsumexp of each row is expected to be log(e^1 * s) =
+        # log(s) + 1.
         torch.testing.assert_close(
             nvf_out[0].cpu(), torch.full((n, h, l), math.log(s) + 1)
         )


### PR DESCRIPTION
When investigating context parallelism, I got conflicting signals about the meaning of the logsumexp output. For example, https://github.com/NVIDIA/TransformerEngine/blob/838345eba4fdd2a169dd9e087d39c30a360e684a/transformer_engine/pytorch/cpp_extensions/fused_attn.py#L1028 seems to suggest its `log(sum(e^(x-max)))` instead of `log(sum(e^x))`. This test verifies that we are returning the latter. 