### PR TITLE
Linear with DID loop split

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4618,39 +4618,53 @@ std::vector<PolymorphicValue> LinearOp::evaluate(
     const std::vector<PolymorphicValue>& inputs) const {
   const auto in = inputs.at(0).as<at::Tensor>();
   auto weight = inputs.at(1).as<at::Tensor>();
+  debug() << inA()->as<TensorView>()->getLogicalDomain() << std::endl;
+  debug() << inA()->as<TensorView>()->getMaybeAllocationDomain() << std::endl;
+  debug() << inB()->as<TensorView>()->getLogicalDomain() << std::endl;
+  debug() << inB()->as<TensorView>()->getMaybeAllocationDomain() << std::endl;
+  if (has_bias()){
+      debug() << bias()->as<TensorView>()->getLogicalDomain() << std::endl;
+      debug() << bias()->as<TensorView>()->getMaybeAllocationDomain() << std::endl;
+  }
+  debug() << out()->as<TensorView>()->getLogicalDomain() << std::endl;
+  debug() << out()->as<TensorView>()->getMaybeAllocationDomain() << std::endl;
 
-  auto squeeze_device_dims = [](at::Tensor& t,
-                                int64_t num_device_dims) -> void {
-    // Record the initial shape for the error message.
-    std::vector<int64_t> shape = t.sizes().vec();
-    for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
-      NVF_CHECK(
-          t.size(0) == 1,
-          "When the weight is >2D, expect its preceding dimensions and "
-          "the bias's preceding dimensions to "
-          "be DID-parallel and therefore size-1: ",
-          shape);
-      t = t.squeeze(0);
-    }
-  };
+  debug() << "Input: " << in.sizes() << std::endl;
+  debug() << "Weight: " << weight.sizes() << std::endl;
+  debug() << "Bias: " << bias.sizes() << std::endl;
 
-  // The squeezes and unsqueezes are currently required to support a sharded
-  // linear layer. Remove them after #2563.
-  auto num_device_dims = weight.dim() - 2;
-  squeeze_device_dims(weight, num_device_dims);
+  // auto squeeze_device_dims = [](at::Tensor& t,
+  //                               int64_t num_device_dims) -> void {
+  //   // Record the initial shape for the error message.
+  //   std::vector<int64_t> shape = t.sizes().vec();
+  //   for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
+  //     NVF_CHECK(
+  //         t.size(0) == 1,
+  //         "When the weight is >2D, expect its preceding dimensions and "
+  //         "the bias's preceding dimensions to "
+  //         "be DID-parallel and therefore size-1: ",
+  //         shape);
+  //     t = t.squeeze(0);
+  //   }
+  // };
+
+  // // The squeezes and unsqueezes are currently required to support a sharded
+  // // linear layer. Remove them after #2563.
+  // auto num_device_dims = weight.dim() - 2;
+  // squeeze_device_dims(weight, num_device_dims);
 
   at::Tensor out;
   if (has_bias()) {
     auto bias = inputs.at(2).as<at::Tensor>();
-    squeeze_device_dims(bias, num_device_dims);
+    // squeeze_device_dims(bias, num_device_dims);
     out = at::linear(in, weight, bias);
   } else {
     out = at::linear(in, weight);
   }
-
-  for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
-    out = out.unsqueeze(0);
-  }
+  debug() << "Output: " << out.sizes() << std::endl;
+  // for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
+  //   out = out.unsqueeze(0);
+  // }
   return {out};
 }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4647,7 +4647,7 @@ std::vector<PolymorphicValue> LinearOp::evaluate(
   } else {
     out = at::linear(in, weight);
   }
-  
+
   for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
     out = out.unsqueeze(0);
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4618,40 +4618,26 @@ std::vector<PolymorphicValue> LinearOp::evaluate(
     const std::vector<PolymorphicValue>& inputs) const {
   const auto in = inputs.at(0).as<at::Tensor>();
   auto weight = inputs.at(1).as<at::Tensor>();
-  debug() << inA()->as<TensorView>()->getLogicalDomain() << std::endl;
-  debug() << inA()->as<TensorView>()->getMaybeAllocationDomain() << std::endl;
-  debug() << inB()->as<TensorView>()->getLogicalDomain() << std::endl;
-  debug() << inB()->as<TensorView>()->getMaybeAllocationDomain() << std::endl;
-  if (has_bias()){
-      debug() << bias()->as<TensorView>()->getLogicalDomain() << std::endl;
-      debug() << bias()->as<TensorView>()->getMaybeAllocationDomain() << std::endl;
-  }
-  debug() << out()->as<TensorView>()->getLogicalDomain() << std::endl;
-  debug() << out()->as<TensorView>()->getMaybeAllocationDomain() << std::endl;
 
-  debug() << "Input: " << in.sizes() << std::endl;
-  debug() << "Weight: " << weight.sizes() << std::endl;
-  debug() << "Bias: " << bias.sizes() << std::endl;
+  auto squeeze_device_dims = [](at::Tensor& t,
+                                int64_t num_device_dims) -> void {
+    // Record the initial shape for the error message.
+    std::vector<int64_t> shape = t.sizes().vec();
+    for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
+      NVF_CHECK(
+          t.size(0) == 1,
+          "When the weight is >2D, expect its preceding dimensions and "
+          "the bias's preceding dimensions to "
+          "be DID-parallel and therefore size-1: ",
+          shape);
+      t = t.squeeze(0);
+    }
+  };
 
-  // auto squeeze_device_dims = [](at::Tensor& t,
-  //                               int64_t num_device_dims) -> void {
-  //   // Record the initial shape for the error message.
-  //   std::vector<int64_t> shape = t.sizes().vec();
-  //   for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
-  //     NVF_CHECK(
-  //         t.size(0) == 1,
-  //         "When the weight is >2D, expect its preceding dimensions and "
-  //         "the bias's preceding dimensions to "
-  //         "be DID-parallel and therefore size-1: ",
-  //         shape);
-  //     t = t.squeeze(0);
-  //   }
-  // };
-
-  // // The squeezes and unsqueezes are currently required to support a sharded
-  // // linear layer. Remove them after #2563.
-  // auto num_device_dims = weight.dim() - 2;
-  // squeeze_device_dims(weight, num_device_dims);
+  // The squeezes and unsqueezes are currently required to support a sharded
+  // linear layer. Remove them after #2563.
+  auto num_device_dims = weight.dim() - 2;
+  squeeze_device_dims(weight, num_device_dims);
 
   at::Tensor out;
   if (has_bias()) {
@@ -4661,10 +4647,9 @@ std::vector<PolymorphicValue> LinearOp::evaluate(
   } else {
     out = at::linear(in, weight);
   }
-  debug() << "Output: " << out.sizes() << std::endl;
-  // for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
-  //   out = out.unsqueeze(0);
-  // }
+  for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
+    out = out.unsqueeze(0);
+  }
   return {out};
 }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4642,11 +4642,12 @@ std::vector<PolymorphicValue> LinearOp::evaluate(
   at::Tensor out;
   if (has_bias()) {
     auto bias = inputs.at(2).as<at::Tensor>();
-    // squeeze_device_dims(bias, num_device_dims);
+    squeeze_device_dims(bias, num_device_dims);
     out = at::linear(in, weight, bias);
   } else {
     out = at::linear(in, weight);
   }
+  
   for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
     out = out.unsqueeze(0);
   }

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -147,7 +147,6 @@ def test_linear_loop_split(multidevice_test):
 
     d = multidevice_test.size
     mesh = nvfuser.DeviceMesh(range(d))
-    rank = multidevice_test.rank
 
     torch.cuda.set_device(multidevice_test.local_rank)
 
@@ -168,7 +167,6 @@ def test_linear_loop_split(multidevice_test):
         inp_tensor.cpu(), unsharded_weight_tensor, unsharded_bias_tensor
     )
     expected_out_tensor = multidevice_test.shard_tensor(unsharded_out_tensor, -1, mesh)
-
     # rtol is the same as the default for fp32. atol is slightly increased.
     torch.testing.assert_close(
         out_tensors[0], expected_out_tensor, rtol=1.3e-6, atol=1e-3

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -124,8 +124,8 @@ def test_linear_loop_split(mpi_test):
         def definition(self):
             d, b, s, e = self._num_devices, self._batch, self._sequence, self._hidden
             self.inp = self.define_tensor([b, s, e])
-            self.weight = self.define_tensor([d * e, e], contiguity=[True, True])
-            self.bias = self.define_tensor([d * e], contiguity=[True])
+            self.weight = self.define_tensor([d * e, e], contiguity=True)
+            self.bias = self.define_tensor([d * e], contiguity=True)
             self.out = self.ops.linear(self.inp, self.weight, self.bias)
             self.add_output(self.out)
 

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -165,14 +165,13 @@ def test_linear_loop_split(multidevice_test):
 
     # [b, s, d*e]
     unsharded_out_tensor = torch.nn.functional.linear(
-        inp_tensor, unsharded_weight_tensor.cuda(), unsharded_bias_tensor.cuda()
+        inp_tensor.cpu(), unsharded_weight_tensor, unsharded_bias_tensor
     )
-    expected_out_tensor = unsharded_out_tensor.view([b, s, d, e]).permute(2, 0, 1, 3)[
-        rank : rank + 1
-    ]
+    expected_out_tensor = multidevice_test.shard_tensor(unsharded_out_tensor, -1, mesh)
+
     # rtol is the same as the default for fp32. atol is slightly increased.
     torch.testing.assert_close(
-        out_tensors[0], expected_out_tensor.squeeze(0), rtol=1.3e-6, atol=1e-3
+        out_tensors[0], expected_out_tensor, rtol=1.3e-6, atol=1e-3
     )
 
 

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -154,7 +154,9 @@ def test_linear_loop_split(multidevice_test):
     b, s, e = 2, 1024, 768
     inp_tensor = torch.randn(b, s, e, device="cuda")
     unsharded_weight_tensor = torch.randn(d * e, e)
-    sharded_weight_tensor = multidevice_test.shard_tensor(unsharded_weight_tensor, 0, mesh)
+    sharded_weight_tensor = multidevice_test.shard_tensor(
+        unsharded_weight_tensor, 0, mesh
+    )
     unsharded_bias_tensor = torch.randn(d * e)
     sharded_bias_tensor = multidevice_test.shard_tensor(unsharded_bias_tensor, 0, mesh)
 

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -124,8 +124,8 @@ def test_linear_loop_split(mpi_test):
         def definition(self):
             d, b, s, e = self._num_devices, self._batch, self._sequence, self._hidden
             self.inp = self.define_tensor([b, s, e])
-            self.weight = self.define_tensor([d * e, e], contiguity=True)
-            self.bias = self.define_tensor([d * e], contiguity=True)
+            self.weight = self.define_tensor([d * e, e])
+            self.bias = self.define_tensor([d * e])
             self.out = self.ops.linear(self.inp, self.weight, self.bias)
             self.add_output(self.out)
 
@@ -160,7 +160,6 @@ def test_linear_loop_split(mpi_test):
 
     fd = Model(d, b, s, e)
     out_tensors = fd.execute([inp_tensor, sharded_weight_tensor, sharded_bias_tensor])
-    print(f"Output tensor: {out_tensors[0].shape}")
 
     # [b, s, d*e]
     unsharded_out_tensor = torch.nn.functional.linear(

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -110,6 +110,66 @@ def test_linear(multidevice_test):
         out_tensors[0], expected_out_tensor, rtol=1.3e-6, atol=1e-3
     )
 
+@pytest.mark.mpi
+def test_linear_loop_split(mpi_test):
+    class Model(FusionDefinition):
+        def __init__(self, num_devices, batch, sequence, hidden):
+            super().__init__()
+            self._num_devices = num_devices
+            self._batch = batch
+            self._sequence = sequence
+            self._hidden = hidden
+        
+        def definition(self):
+            d, b, s, e = self._num_devices, self._batch, self._sequence, self._hidden
+            self.inp = self.define_tensor([b, s, e])
+            self.weight = self.define_tensor([d * e, e], contiguity=[True, True])
+            self.bias = self.define_tensor([d * e], contiguity=[True])
+            self.out = self.ops.linear(self.inp, self.weight, self.bias)
+            self.add_output(self.out)
+
+        def multidevice_schedule(self):
+            for t in [self.inp, self.weight, self.bias, self.out]: 
+                self.sched._set_device_mesh(t, mesh)
+
+            # Shard N for weight and bias
+            for t in [self.weight, self.bias]:
+              self.sched.split(t, 0, d, False)
+              self.sched.parallelize(t, 0, nvfuser.ParallelType.mesh_x)
+              self.sched.set_allocation_as_loop(t)
+
+            # Output of linear: {.., i{M}, i{N}, r{K}}
+            # Shard N -> axis(-2)
+            self.sched.split(self.out, -2, d, False)
+            self.sched.parallelize(self.out, -3, nvfuser.ParallelType.mesh_x)
+            self.sched.set_allocation_as_loop(self.out)
+    
+    d = mpi_test.size
+    mesh = nvfuser.DeviceMesh(range(d))
+    rank = mpi_test.rank
+
+    torch.cuda.set_device(mpi_test.local_rank)
+
+    b, s, e = 2, 1024, 768
+    inp_tensor = torch.randn(b, s, e, device="cuda")
+    unsharded_weight_tensor = torch.randn(d * e, e)
+    sharded_weight_tensor = mpi_test.shard_tensor(unsharded_weight_tensor, 0, mesh)
+    unsharded_bias_tensor = torch.randn(d * e)
+    sharded_bias_tensor = mpi_test.shard_tensor(unsharded_bias_tensor, 0, mesh)
+    
+    fd = Model(d, b, s, e)
+    out_tensors = fd.execute([inp_tensor, sharded_weight_tensor, sharded_bias_tensor])
+    print (f'Output tensor: {out_tensors[0].shape}')
+
+    # [b, s, d*e]
+    unsharded_out_tensor = torch.nn.functional.linear(inp_tensor, unsharded_weight_tensor.cuda(), unsharded_bias_tensor.cuda())
+    expected_out_tensor = unsharded_out_tensor.view([b, s, d, e]).permute(2, 0, 1, 3)[
+        rank : rank + 1
+    ]
+    # rtol is the same as the default for fp32. atol is slightly increased.
+    torch.testing.assert_close(
+        out_tensors[0], expected_out_tensor.squeeze(0), rtol=1.3e-6, atol=1e-3
+    )
 
 @pytest.mark.mpi
 def test_matmul_allreduce(multidevice_test):

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -132,7 +132,7 @@ def test_linear_loop_split(mpi_test):
             for t in [self.inp, self.weight, self.bias, self.out]: 
                 self.sched._set_device_mesh(t, mesh)
 
-            # Shard N for weight and bias
+            # Shard N for weight (N, K) and bias (N)
             for t in [self.weight, self.bias]:
               self.sched.split(t, 0, d, False)
               self.sched.parallelize(t, 0, nvfuser.ParallelType.mesh_x)
@@ -170,7 +170,7 @@ def test_linear_loop_split(mpi_test):
     torch.testing.assert_close(
         out_tensors[0], expected_out_tensor.squeeze(0), rtol=1.3e-6, atol=1e-3
     )
-
+    
 @pytest.mark.mpi
 def test_matmul_allreduce(multidevice_test):
     d, b, s, e = multidevice_test.size, 1, 4, 8

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -112,7 +112,7 @@ def test_linear(multidevice_test):
 
 
 @pytest.mark.mpi
-def test_linear_loop_split(mpi_test):
+def test_linear_loop_split(multidevice_test):
     class Model(FusionDefinition):
         def __init__(self, num_devices, batch, sequence, hidden):
             super().__init__()
@@ -145,18 +145,18 @@ def test_linear_loop_split(mpi_test):
             self.sched.parallelize(self.out, -3, nvfuser.ParallelType.mesh_x)
             self.sched.set_allocation_as_loop(self.out)
 
-    d = mpi_test.size
+    d = multidevice_test.size
     mesh = nvfuser.DeviceMesh(range(d))
-    rank = mpi_test.rank
+    rank = multidevice_test.rank
 
-    torch.cuda.set_device(mpi_test.local_rank)
+    torch.cuda.set_device(multidevice_test.local_rank)
 
     b, s, e = 2, 1024, 768
     inp_tensor = torch.randn(b, s, e, device="cuda")
     unsharded_weight_tensor = torch.randn(d * e, e)
-    sharded_weight_tensor = mpi_test.shard_tensor(unsharded_weight_tensor, 0, mesh)
+    sharded_weight_tensor = multidevice_test.shard_tensor(unsharded_weight_tensor, 0, mesh)
     unsharded_bias_tensor = torch.randn(d * e)
-    sharded_bias_tensor = mpi_test.shard_tensor(unsharded_bias_tensor, 0, mesh)
+    sharded_bias_tensor = multidevice_test.shard_tensor(unsharded_bias_tensor, 0, mesh)
 
     fd = Model(d, b, s, e)
     out_tensors = fd.execute([inp_tensor, sharded_weight_tensor, sharded_bias_tensor])


### PR DESCRIPTION
This PR adds a test case demonstrating DID loop split for linear.
The test does not require any changes to the `LinearOp::evaluate` method and works out of the box. DID split on logical domain continues to work for linear using the additional WARs present that squeeze/unsqueeze the DID dimension. Those WARs can be removed once we completely switch to representing device parallelism using allocation and loop domain.