### PR TITLE
Matmul with DID loop split

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4543,8 +4543,6 @@ std::vector<PolymorphicValue> MatmulOp::evaluate(
   if (meta_out.is_contiguous()) {
     return {matmul_out};
   }
-  // auto matmul_sizes = matmul_out.sizes();
-  // auto strides = computeStrides(out(), matmul_sizes);
   auto strided_matmul_out = at::empty_strided(sizes, strides, a.options());
   strided_matmul_out = strided_matmul_out.copy_(matmul_out);
   return {strided_matmul_out};

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4537,9 +4537,7 @@ std::vector<PolymorphicValue> MatmulOp::evaluate(
 
   auto matmul_out = at::matmul(a, b);
   const auto& [sizes, strides] = inferShapeOfOutput(out(), ee);
-  auto options =
-      c10::TensorOptions().device(c10::Device(c10::DeviceType::Meta));
-  auto meta_out = at::empty_strided(sizes, strides, options);
+  auto meta_out = at::detail::empty_strided_meta(sizes, strides, a.dtype());
   if (meta_out.is_contiguous()) {
     return {matmul_out};
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4519,7 +4519,7 @@ std::vector<int64_t> computeStrides(
 
   std::optional<std::vector<int64_t>> out_order = ir_utils::computePermutation(
       TensorDomain::noReductions(logical_domain),
-      TensorDomain::noReductions(allocation_domain));
+      TensorDomain::noDevices(TensorDomain::noReductions(allocation_domain)));
   NVF_CHECK(
       out_order.has_value(),
       "Valid permute from logical to allocation domain was not found.");

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -18,6 +18,7 @@
 #include <kernel_ir.h>
 #include <logical_domain_map.h>
 #include <ops/arith.h>
+#include <runtime/allocations.h>
 #include <transform_iter.h>
 #include <transform_rfactor.h>
 #include <transform_view.h>
@@ -4507,39 +4508,6 @@ std::vector<PolymorphicValue> CatOp::evaluate(
   return {at::cat(unpadded_inputs, concat_dim)};
 }
 
-namespace {
-
-// Given a tensorview, compute the strides according to the allocation domain
-// for re-striding the corresponding ATen tensor.
-std::vector<int64_t> computeStrides(
-    TensorView* tv,
-    const c10::IntArrayRef sizes) {
-  const auto& logical_domain = tv->getLogicalDomain();
-  const auto& allocation_domain = tv->getMaybeAllocationDomain();
-
-  std::optional<std::vector<int64_t>> out_order = ir_utils::computePermutation(
-      TensorDomain::noReductions(logical_domain),
-      TensorDomain::noReductions(allocation_domain));
-  NVF_CHECK(
-      out_order.has_value(),
-      "Valid permute from logical to allocation domain was not found.");
-
-  auto rank = sizes.size();
-  std::vector<int64_t> sorted_strides(rank);
-  auto permuted_sizes = ir_utils::applyPermutation(sizes.vec(), *out_order);
-  sorted_strides[rank - 1] = 1;
-  for (int64_t idx = (int64_t)rank - 2; idx >= 0; idx--) {
-    sorted_strides[idx] = permuted_sizes[idx + 1] * sorted_strides[idx + 1];
-  }
-  // Rearrange the strides in correct order of allocation
-  std::vector<int64_t> strides(rank);
-  for (auto idx : c10::irange(rank)) {
-    strides[out_order.value()[idx]] = sorted_strides[idx];
-  }
-  return strides;
-}
-} // namespace
-
 MatmulOp::MatmulOp(IrBuilderPasskey passkey, Val* out, Val* in_a, Val* in_b)
     : Expr(passkey) {
   addOutput(out);
@@ -4568,13 +4536,16 @@ std::vector<PolymorphicValue> MatmulOp::evaluate(
   const auto b = inputs.at(1).as<at::Tensor>();
 
   auto matmul_out = at::matmul(a, b);
-  if (ir_utils::hasTrivialAllocationDomain(out())) {
+  const auto& [sizes, strides] = inferShapeOfOutput(out(), ee);
+  auto options =
+      c10::TensorOptions().device(c10::Device(c10::DeviceType::Meta));
+  auto meta_out = at::empty_strided(sizes, strides, options);
+  if (meta_out.is_contiguous()) {
     return {matmul_out};
   }
-  auto matmul_sizes = matmul_out.sizes();
-  auto strides = computeStrides(out(), matmul_sizes);
-  auto strided_matmul_out =
-      at::empty_strided(matmul_sizes, strides, a.options());
+  // auto matmul_sizes = matmul_out.sizes();
+  // auto strides = computeStrides(out(), matmul_sizes);
+  auto strided_matmul_out = at::empty_strided(sizes, strides, a.options());
   strided_matmul_out = strided_matmul_out.copy_(matmul_out);
   return {strided_matmul_out};
 }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4519,7 +4519,7 @@ std::vector<int64_t> computeStrides(
 
   std::optional<std::vector<int64_t>> out_order = ir_utils::computePermutation(
       TensorDomain::noReductions(logical_domain),
-      TensorDomain::noDevices(TensorDomain::noReductions(allocation_domain)));
+      TensorDomain::noReductions(allocation_domain));
   NVF_CHECK(
       out_order.has_value(),
       "Valid permute from logical to allocation domain was not found.");

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -12,7 +12,6 @@
 #include <ir/iostream.h>
 #include <ir/utils.h>
 #include <iter_visitor.h>
-#include <multidevice/utils.h>
 #include <ops/arith.h>
 #include <scheduler/mma_utils.h>
 

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -12,6 +12,7 @@
 #include <ir/iostream.h>
 #include <ir/utils.h>
 #include <iter_visitor.h>
+#include <multidevice/utils.h>
 #include <ops/arith.h>
 #include <scheduler/mma_utils.h>
 
@@ -1312,9 +1313,37 @@ bool hasTrivialAllocationDomain(const TensorView* tv) {
   }
   const std::vector<IterDomain*>& alloc = tv->getMaybeAllocationDomain();
   const std::vector<IterDomain*>& logical = tv->getLogicalDomain();
-  return TensorDomain::noBroadcasts(TensorDomain::noReductions(logical)) ==
+  const auto alloc_no_red_bcast =
       TensorDomain::noBroadcasts(TensorDomain::noReductions(alloc));
+  const auto logical_no_red_bcast =
+      TensorDomain::noBroadcasts(TensorDomain::noReductions(logical));
+
+  if (!isSharded(tv)) {
+    return alloc_no_red_bcast == logical_no_red_bcast;
+  }
+
+  // This handles the case where DID parallelization is applied on
+  // allocation/logical dimensions.
+  const auto alloc_no_red_bcast_device =
+      TensorDomain::noDevices(alloc_no_red_bcast);
+  if (alloc_no_red_bcast_device.size() != logical_no_red_bcast.size()) {
+    return false;
+  }
+
+  int64_t sharded_logical_idx = getShardedLogicalAxis(tv, ParallelType::DIDx);
+  for (auto idx : c10::irange((int64_t)logical_no_red_bcast.size())) {
+    // Compare all but the sharded axis since the logical and alloc ID will have
+    // different extents.
+    if (idx == sharded_logical_idx) {
+      continue;
+    }
+    if (alloc_no_red_bcast_device.at(idx) != logical_no_red_bcast.at(idx)) {
+      return false;
+    }
+  }
+  return true;
 }
+
 bool hasUniformSiblings(Expr* expr) {
   return !expr->isOneOf<SdpaFwdOp, SdpaBwdOp>();
 }

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -144,7 +144,7 @@ std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShape(
     const TensorView* tv,
     std::vector<Val*> symbolic_sizes,
     std::vector<bool> expand_flags,
-    ExpressionEvaluator& expr_eval) {
+    const ExpressionEvaluator& expr_eval) {
   FUSER_PERF_SCOPE("fusion_executor::allocations::inferShape");
 
   // Allocate should be provided for intermediates. We just need to
@@ -401,7 +401,7 @@ namespace {
 
 class ForwardTraverseFromAllocToLogical {
   at::Tensor tensor_;
-  ExpressionEvaluator& ee_;
+  const ExpressionEvaluator& ee_;
   std::list<IterDomain*>& frontier_;
 
   // Forward traverse split from allocation to logical. Needs to, for example,
@@ -518,7 +518,7 @@ class ForwardTraverseFromAllocToLogical {
  public:
   ForwardTraverseFromAllocToLogical(
       at::Tensor tensor,
-      ExpressionEvaluator& ee,
+      const ExpressionEvaluator& ee,
       std::list<IterDomain*>& frontier)
       : tensor_(std::move(tensor)), ee_(ee), frontier_(frontier) {}
 
@@ -538,7 +538,7 @@ class ForwardTraverseFromAllocToLogical {
 // transformations.
 class BackwardTraverseFromAllocToLogical {
   at::Tensor tensor_;
-  ExpressionEvaluator& ee_;
+  const ExpressionEvaluator& ee_;
   std::list<IterDomain*>& frontier_;
 
   // Backward traverse split from allocation to logical. Needs to, for example,
@@ -642,7 +642,7 @@ class BackwardTraverseFromAllocToLogical {
  public:
   BackwardTraverseFromAllocToLogical(
       at::Tensor tensor,
-      ExpressionEvaluator& ee,
+      const ExpressionEvaluator& ee,
       std::list<IterDomain*>& frontier)
       : tensor_(std::move(tensor)), ee_(ee), frontier_(frontier) {}
 
@@ -671,7 +671,7 @@ class BackwardTraverseFromAllocToLogical {
 at::Tensor transformFromAllocationToLogical(
     at::Tensor tensor,
     TensorView* tv,
-    ExpressionEvaluator& ee) {
+    const ExpressionEvaluator& ee) {
   FUSER_PERF_SCOPE("allocations::transformFromAllocationToLogical");
   // Ignore reductions because reductions does not exist in tensor's definition
   auto logical = TensorDomain::noReductions(tv->getLogicalDomain());
@@ -706,7 +706,7 @@ at::Tensor transformFromAllocationToLogical(
 
 std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShapeOfOutput(
     TensorView* tv,
-    ExpressionEvaluator& expr_eval) {
+    const ExpressionEvaluator& expr_eval) {
   FUSER_PERF_SCOPE("fusion_executor::allocations::inferShapeOfOutput");
   // Fusion outputs do not come with Allocate and
   // need to be allocated while taking expanded broadcasts into

--- a/csrc/runtime/allocations.h
+++ b/csrc/runtime/allocations.h
@@ -59,7 +59,7 @@ void fillTensorWithNan(at::Tensor& t);
 // Infer the sizes and strides of an output tensor
 std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShapeOfOutput(
     TensorView* tv,
-    ExpressionEvaluator& expr_eval);
+    const ExpressionEvaluator& expr_eval);
 
 // Allocate an `at::Tensor` for `out_info` or compute it as an alias.
 at::Tensor allocateTensor(

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -202,7 +202,9 @@ def test_matmul_loop_split(multidevice_test):
     b, s, e = 2, 1024, 768
     inp_tensor = torch.randn(b, s, e, device="cuda")
     unsharded_weight_tensor = torch.randn(e, d * e)
-    sharded_weight_tensor = multidevice_test.shard_tensor(unsharded_weight_tensor, -1, mesh)
+    sharded_weight_tensor = multidevice_test.shard_tensor(
+        unsharded_weight_tensor, -1, mesh
+    )
 
     fd = Model(d, b, s, e)
     out_tensors = fd.execute([inp_tensor, sharded_weight_tensor])

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -161,6 +161,64 @@ def test_matmul_allreduce(multidevice_test):
     torch.testing.assert_close(in_grad.cpu(), expected_in_grad, rtol=1e-3, atol=1e-2)
 
 
+@pytest.mark.mpi
+def test_matmul_loop_split(mpi_test):
+    class Model(FusionDefinition):
+        def __init__(self, num_devices, batch, sequence, hidden):
+            super().__init__()
+            self._num_devices = num_devices
+            self._batch = batch
+            self._sequence = sequence
+            self._hidden = hidden
+
+        def definition(self):
+            d, b, s, e = self._num_devices, self._batch, self._sequence, self._hidden
+            self.inp = self.define_tensor([b, s, e])
+            self.weight = self.define_tensor([e, d * e], contiguity=[True, True])
+            self.out = self.ops.matmul(self.inp, self.weight)
+            self.add_output(self.out)
+
+        def multidevice_schedule(self):
+            for t in [self.inp, self.weight, self.out]:
+                self.sched._set_device_mesh(t, mesh)
+
+            # Shard N for weight (K, N)
+            self.sched.split(self.weight, -1, d, False)
+            self.sched.parallelize(self.weight, -2, nvfuser.ParallelType.mesh_x)
+            self.sched.set_allocation_as_loop(self.weight)
+
+            # Output of linear: {.., i{M}, i{N}, r{K}}
+            # Shard N -> axis(-2)
+            self.sched.split(self.out, -2, d, False)
+            self.sched.parallelize(self.out, -3, nvfuser.ParallelType.mesh_x)
+            self.sched.set_allocation_as_loop(self.out)
+
+    d = mpi_test.size
+    mesh = nvfuser.DeviceMesh(range(d))
+    rank = mpi_test.rank
+
+    torch.cuda.set_device(mpi_test.local_rank)
+
+    b, s, e = 2, 1024, 768
+    inp_tensor = torch.randn(b, s, e, device="cuda")
+    unsharded_weight_tensor = torch.randn(e, d * e)
+    sharded_weight_tensor = mpi_test.shard_tensor(unsharded_weight_tensor, -1, mesh)
+
+    fd = Model(d, b, s, e)
+    out_tensors = fd.execute([inp_tensor, sharded_weight_tensor])
+    print(f"Output tensor: {out_tensors[0].shape}")
+
+    # [b, s, d*e]
+    unsharded_out_tensor = torch.matmul(inp_tensor, unsharded_weight_tensor.cuda())
+    expected_out_tensor = unsharded_out_tensor.view([b, s, d, e]).permute(2, 0, 1, 3)[
+        rank : rank + 1
+    ]
+    # rtol is the same as the default for fp32. atol is slightly increased.
+    torch.testing.assert_close(
+        out_tensors[0], expected_out_tensor.squeeze(0), rtol=1.3e-6, atol=1e-3
+    )
+
+
 class QkvFormat(Enum):
     BHSE = auto()
     BSHE = auto()


### PR DESCRIPTION
This PR modifies the `hasTrivialAllocationDomain` to consider if the tensorview has a DID loop split. In this case, we compare the corresponding iterdomains for logical and allocation domain across all but the sharded logical axis.

Note: This does not guarantee that `MatmulOp` with non-trivial stride order will work for DID loop split. I suspect it will require some additional changes to the `MatmulOp::evaluate` method.