### PR TITLE
Fix scheduleLoopDomainsLike when the update-only mode is used

### DIFF
--- a/csrc/scheduler/tools/loop_domain_scheduler.cpp
+++ b/csrc/scheduler/tools/loop_domain_scheduler.cpp
@@ -238,8 +238,9 @@ void LoopDomainScheduler::schedule(TensorView* tv) const {
   }
 
   const auto path_from_ref = getReplayPath(tv);
-  const ExprGroups all_existing_expr_groups =
-      graph().toGroups(tv->domain()->allExprs());
+  const ExprGroups all_existing_expr_groups = update_loop_domain_only_
+      ? ExprGroups{}
+      : graph().toGroups(tv->domain()->allExprs());
 
   // Replay the path on the target tensor
   for (const auto& [expr_g, dir] : path_from_ref) {


### PR DESCRIPTION
Just fixing a simple bug that I didn't consider before. In `scheduleLoopDomainsLike`, when updating the existing loop domain, obviously it should not reuse the existing ID exprs.