### PR TITLE
Fixing `DomainMap::areAllTargetIdsCoveredBy` to handle broadcast to non-root IDs 

### DIFF
--- a/csrc/scheduler/tools/domain_map.cpp
+++ b/csrc/scheduler/tools/domain_map.cpp
@@ -259,140 +259,140 @@ bool DomainMap::areAllTargetIdsCoveredBy(
     auto concrete_id_out =
         ca_map_.getConcreteMappedID(source_id_out, IdMappingMode::PERMISSIVE);
 
-    for (IterDomain* concrete_source_id_out : get_source_iter_domains({concrete_id_out)) {
-        // if we find any source_id_out that's not contained, it's possible our
-        // propagation would fail since transformation involving this iter
-        // domain can't be resolved.
-        if (!getMappedInputConcreteID(
-                covered_source_ids, concrete_source_id_out)) {
-          return false;
-        }
+    for (IterDomain* concrete_source_id_out :
+         get_source_iter_domains({concrete_id_out})) {
+      // if we find any source_id_out that's not contained, it's possible our
+      // propagation would fail since transformation involving this iter
+      // domain can't be resolved.
+      if (!getMappedInputConcreteID(
+              covered_source_ids, concrete_source_id_out)) {
+        return false;
       }
+    }
   }
   return true;
-  }
+}
 
-  // Reference domains must exactly match with the input domains. See
-  // also PR #661
-  IterDomain* DomainMap::getMappedInputConcreteID(
-      const std::unordered_set<IterDomain*>& in_concrete_ids,
-      IterDomain* out_id) const {
-    auto in_concrete_id_iter = std::find_if(
-        in_concrete_ids.begin(),
-        in_concrete_ids.end(),
-        [&](IterDomain* in_concrete_id) {
-          return ca_map_.areMapped(
-              in_concrete_id, out_id, IdMappingMode::EXACT);
-        });
-    if (in_concrete_id_iter != in_concrete_ids.end()) {
-      return *in_concrete_id_iter;
-    } else {
-      return nullptr;
+// Reference domains must exactly match with the input domains. See
+// also PR #661
+IterDomain* DomainMap::getMappedInputConcreteID(
+    const std::unordered_set<IterDomain*>& in_concrete_ids,
+    IterDomain* out_id) const {
+  auto in_concrete_id_iter = std::find_if(
+      in_concrete_ids.begin(),
+      in_concrete_ids.end(),
+      [&](IterDomain* in_concrete_id) {
+        return ca_map_.areMapped(in_concrete_id, out_id, IdMappingMode::EXACT);
+      });
+  if (in_concrete_id_iter != in_concrete_ids.end()) {
+    return *in_concrete_id_iter;
+  } else {
+    return nullptr;
+  }
+}
+
+// Erase input concrete ID if it is mapped to output ID
+bool DomainMap::eraseIfMapped(
+    std::unordered_set<IterDomain*>& in_concrete_ids,
+    IterDomain* out_id) const {
+  auto mapped_input_conrete_id =
+      getMappedInputConcreteID(in_concrete_ids, out_id);
+  if (mapped_input_conrete_id != nullptr) {
+    in_concrete_ids.erase(mapped_input_conrete_id);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void DomainMap::eraseifInputMappedThroughRootDomainAndIndexing(
+    std::unordered_set<IterDomain*>& in_ids,
+    const std::vector<IterDomain*>& ids) const {
+  // Use ComputeAtMap::getAllDisjointSetProducers to grab all producer
+  // IDs through rfactor exprs
+  VectorOfUniqueEntries<std::shared_ptr<VectorOfUniqueEntries<IterDomain*>>>
+      exact_sets;
+  std::for_each(ids.begin(), ids.end(), [&](IterDomain* id) {
+    exact_sets.pushBack(ca_map_.disjointSetOf(id, IdMappingMode::EXACT));
+  });
+
+  // Traverse through indexed domains.
+  const auto indexed_id_multimap =
+      getIndexedConsumerToProducerMap(fusion_, ca_map_);
+
+  VectorOfUniqueEntries<std::shared_ptr<VectorOfUniqueEntries<IterDomain*>>>
+      all_exact_sets_covered;
+
+  // Back traverses through the exact map and indexed
+  // producer-consumer pairs
+  for (auto current_sets = exact_sets; !current_sets.empty();) {
+    auto producer_sets = ca_map_.getAllDisjointSetProducers(current_sets);
+    all_exact_sets_covered.pushBack(producer_sets);
+
+    current_sets.clear();
+
+    // Further traversal if any of the new producer sets is a producer
+    // of indexed domains
+    for (const auto& producer_set : producer_sets) {
+      auto indexed_id_multimap_range =
+          indexed_id_multimap.equal_range(producer_set);
+      for (auto producer_of_producer_it = indexed_id_multimap_range.first;
+           producer_of_producer_it != indexed_id_multimap_range.second;
+           ++producer_of_producer_it) {
+        current_sets.pushBack(producer_of_producer_it->second);
+      }
     }
   }
 
-  // Erase input concrete ID if it is mapped to output ID
-  bool DomainMap::eraseIfMapped(
-      std::unordered_set<IterDomain*> & in_concrete_ids, IterDomain * out_id)
-      const {
-    auto mapped_input_conrete_id =
-        getMappedInputConcreteID(in_concrete_ids, out_id);
-    if (mapped_input_conrete_id != nullptr) {
-      in_concrete_ids.erase(mapped_input_conrete_id);
-      return true;
-    } else {
+  for (const auto& exact_set_ptr : all_exact_sets_covered) {
+    auto exact_concrete_id = ca_map_.getConcreteMappedID(
+        exact_set_ptr->front(), IdMappingMode::EXACT);
+    eraseIfMapped(in_ids, exact_concrete_id);
+  }
+}
+
+// Find any id in domain that maps with target id
+IterDomain* DomainMap::anyMapped(
+    const std::vector<IterDomain*>& domain,
+    IterDomain* target) const {
+  for (auto id : domain) {
+    if (ca_map_.areMapped(id, target, IdMappingMode::EXACT)) {
+      return id;
+    }
+  }
+  return nullptr;
+}
+
+// Determine if output TensorView is a valid reference tensor for this fusion.
+// The reference tensor must map to all the iterDomains in each input and
+// output
+bool DomainMap::isValidReference(TensorView* tv) const {
+  for (auto input_tv : ir_utils::filterByType<TensorView>(fusion_->inputs())) {
+    if (input_tv->uses().empty()) {
+      continue;
+    }
+    // TODO: Same backward traversal from tv is done for all input
+    // tvs. Consider doing the analysis one for all inputs
+    if (!areAllInputIdsMappedTo(input_tv, tv)) {
       return false;
     }
   }
-
-  void DomainMap::eraseifInputMappedThroughRootDomainAndIndexing(
-      std::unordered_set<IterDomain*> & in_ids,
-      const std::vector<IterDomain*>& ids) const {
-    // Use ComputeAtMap::getAllDisjointSetProducers to grab all producer
-    // IDs through rfactor exprs
-    VectorOfUniqueEntries<std::shared_ptr<VectorOfUniqueEntries<IterDomain*>>>
-        exact_sets;
-    std::for_each(ids.begin(), ids.end(), [&](IterDomain* id) {
-      exact_sets.pushBack(ca_map_.disjointSetOf(id, IdMappingMode::EXACT));
-    });
-
-    // Traverse through indexed domains.
-    const auto indexed_id_multimap =
-        getIndexedConsumerToProducerMap(fusion_, ca_map_);
-
-    VectorOfUniqueEntries<std::shared_ptr<VectorOfUniqueEntries<IterDomain*>>>
-        all_exact_sets_covered;
-
-    // Back traverses through the exact map and indexed
-    // producer-consumer pairs
-    for (auto current_sets = exact_sets; !current_sets.empty();) {
-      auto producer_sets = ca_map_.getAllDisjointSetProducers(current_sets);
-      all_exact_sets_covered.pushBack(producer_sets);
-
-      current_sets.clear();
-
-      // Further traversal if any of the new producer sets is a producer
-      // of indexed domains
-      for (const auto& producer_set : producer_sets) {
-        auto indexed_id_multimap_range =
-            indexed_id_multimap.equal_range(producer_set);
-        for (auto producer_of_producer_it = indexed_id_multimap_range.first;
-             producer_of_producer_it != indexed_id_multimap_range.second;
-             ++producer_of_producer_it) {
-          current_sets.pushBack(producer_of_producer_it->second);
-        }
-      }
+  // The check on outputs are optional, transpose scheduler might propose a
+  // secondary reference that only applies to a subset of IO tensors. Ideally
+  // we should have a more robust check and consider the IO groups instead of
+  // blindly skip outputs.
+  for (auto output_tv :
+       ir_utils::filterByType<TensorView>(fusion_->outputs())) {
+    // no need to check for self.
+    if (output_tv == tv) {
+      continue;
     }
-
-    for (const auto& exact_set_ptr : all_exact_sets_covered) {
-      auto exact_concrete_id = ca_map_.getConcreteMappedID(
-          exact_set_ptr->front(), IdMappingMode::EXACT);
-      eraseIfMapped(in_ids, exact_concrete_id);
+    if (!areAllTargetIdsCoveredBy(output_tv, tv)) {
+      return false;
     }
   }
-
-  // Find any id in domain that maps with target id
-  IterDomain* DomainMap::anyMapped(
-      const std::vector<IterDomain*>& domain, IterDomain* target) const {
-    for (auto id : domain) {
-      if (ca_map_.areMapped(id, target, IdMappingMode::EXACT)) {
-        return id;
-      }
-    }
-    return nullptr;
-  }
-
-  // Determine if output TensorView is a valid reference tensor for this fusion.
-  // The reference tensor must map to all the iterDomains in each input and
-  // output
-  bool DomainMap::isValidReference(TensorView * tv) const {
-    for (auto input_tv :
-         ir_utils::filterByType<TensorView>(fusion_->inputs())) {
-      if (input_tv->uses().empty()) {
-        continue;
-      }
-      // TODO: Same backward traversal from tv is done for all input
-      // tvs. Consider doing the analysis one for all inputs
-      if (!areAllInputIdsMappedTo(input_tv, tv)) {
-        return false;
-      }
-    }
-    // The check on outputs are optional, transpose scheduler might propose a
-    // secondary reference that only applies to a subset of IO tensors. Ideally
-    // we should have a more robust check and consider the IO groups instead of
-    // blindly skip outputs.
-    for (auto output_tv :
-         ir_utils::filterByType<TensorView>(fusion_->outputs())) {
-      // no need to check for self.
-      if (output_tv == tv) {
-        continue;
-      }
-      if (!areAllTargetIdsCoveredBy(output_tv, tv)) {
-        return false;
-      }
-    }
-    return true;
-  }
+  return true;
+}
 
 } // namespace scheduler_tools
 } // namespace nvfuser

--- a/csrc/scheduler/tools/domain_map.cpp
+++ b/csrc/scheduler/tools/domain_map.cpp
@@ -259,6 +259,9 @@ bool DomainMap::areAllTargetIdsCoveredBy(
     auto concrete_id_out =
         ca_map_.getConcreteMappedID(source_id_out, IdMappingMode::PERMISSIVE);
 
+    // After mapping with PERMISSIVE map, `concrete_id_out` might no longer be a
+    // source ID. We project to source ID again from concrete_id_out. See test
+    // DomainMapBroadcastIssue3653
     for (IterDomain* concrete_source_id_out :
          get_source_iter_domains({concrete_id_out})) {
       // if we find any source_id_out that's not contained, it's possible our

--- a/csrc/scheduler/tools/domain_map.cpp
+++ b/csrc/scheduler/tools/domain_map.cpp
@@ -250,11 +250,15 @@ bool DomainMap::areAllTargetIdsCoveredBy(
   for (IterDomain* source_id_out :
        get_source_iter_domains(target_tv->getLogicalDomain())) {
     // NOTE: we use concrete id instead. This allows us to link indirect
-    // broadcast. So in the example below: T2[i0, i1] = T0[i0, b0] + T1[i0, i1]
-    // T3[i0, i9] = pad(T0[i0, b0])
+    // broadcast. So in the example below:
+    //   input T0[
+    //   T2[i0, i2*i3] = T0[i0, i2, i3]
+    //   T3[i0, i2*i3] = T1[i0, b0] + T2[i0, i2*i3]
+    //   T4[i0, i9] = pad(T1[i0, b0])
     // We have i9 in T3
     //     -> source ID b0
-    //     -> concrete map to i1
+    //     -> concrete map to i2*i3
+    //     -> source ID from i2*i3 to [i2, i3]
     // So T3 is contained by T2. See test `PointwiseTest.DomainMapPad1`
     auto concrete_id_out =
         ca_map_.getConcreteMappedID(source_id_out, IdMappingMode::PERMISSIVE);
@@ -262,6 +266,9 @@ bool DomainMap::areAllTargetIdsCoveredBy(
     // After mapping with PERMISSIVE map, `concrete_id_out` might no longer be a
     // source ID. We project to source ID again from concrete_id_out. See test
     // DomainMapBroadcastIssue3653
+    // In the example above. `i2*i3` is not a source ID. Hence we needed to go
+    // through another projection to source IDs in order to map it to
+    // covered_source_ids.
     for (IterDomain* concrete_source_id_out :
          get_source_iter_domains({concrete_id_out})) {
       // if we find any source_id_out that's not contained, it's possible our

--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -1242,4 +1242,40 @@ TEST_F(PointwiseTest, DomainMapSlice1) {
   testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
 }
 
+TEST_F(NVFuserTest, DomainMapBroadcastIssue3653) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  FusionGuard fg(fusion_ptr.get());
+  Fusion& fusion = *fusion_ptr;
+
+  auto tv0 = makeConcreteTensor({2, 4, 8});
+  fusion.addInput(tv0);
+  auto tv1 = makeConcreteTensor({2});
+  fusion.addInput(tv1);
+
+  auto tv2 = reshape(tv0, {2, 4, 8}, {2, 32});
+  auto tv3 = broadcast(tv1, {false, true});
+  auto tv4 = add(tv2, tv3);
+
+  fusion.addOutput(tv4);
+  fusion.addOutput(tv3);
+
+  DomainMapUnitTest domain_map(fusion);
+  EXPECT_TRUE(domain_map.isValidReference(tv4));
+
+  auto options =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({2, 4, 8}, options);
+  auto t1 = at::randn({2}, options);
+  std::vector<c10::IValue> inputs({t0, t1});
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+
+  FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
+  NVF_CHECK(!runtime->isSegmented());
+
+  testValidate(
+      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+}
+
 } // namespace nvfuser

--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -1259,7 +1259,7 @@ TEST_F(NVFuserTest, DomainMapBroadcastIssue3653) {
   fusion.addOutput(tv4);
   fusion.addOutput(tv3);
 
-  DomainMapUnitTest domain_map(fusion);
+  DomainMapUnitTest domain_map(fusion_ptr.get());
   EXPECT_TRUE(domain_map.isValidReference(tv4));
 
   auto options =


### PR DESCRIPTION
Fixes #3653

This PR adds another projection to source ID after permissive mapping. This allows us to correctly identify coverage when the broadcast IDs are not source ID directly.