### PR TITLE
Generalize IRBFSWithPermissiveDependence to BFSWithPermissiveDependence

### DIFF
--- a/csrc/bfs.h
+++ b/csrc/bfs.h
@@ -549,6 +549,77 @@ class BFS {
   Direction allowed_direction_ = Direction::Undefined;
 };
 
+// Unlike the default BFS behavior, Expr is considered ready to
+// visit as long as one of the inputs or outputs has its dependency met
+template <
+    typename ExprT,
+    typename ValT,
+    typename DefinitionT,
+    typename UsesT,
+    typename InputsT,
+    typename OutputsT>
+class BFSWithPermissiveDependence
+    : public BFS<ExprT, ValT, DefinitionT, UsesT, InputsT, OutputsT> {
+ public:
+  using NodeType =
+      typename BFS<ExprT, ValT, DefinitionT, UsesT, InputsT, OutputsT>::
+          NodeType;
+
+  BFSWithPermissiveDependence(
+      DefinitionT definition,
+      UsesT uses,
+      InputsT inputs,
+      OutputsT outputs,
+      std::vector<NodeType> from,
+      std::vector<NodeType> to,
+      bool require_all_to_visited = true,
+      Direction allowed_direction = Direction::Undefined)
+      : BFS<ExprT, ValT, DefinitionT, UsesT, InputsT, OutputsT>(
+            definition,
+            uses,
+            inputs,
+            outputs,
+            std::move(from),
+            std::move(to),
+            require_all_to_visited,
+            allowed_direction) {}
+
+  std::optional<std::pair<Direction, std::vector<NodeType>>> isReady(
+      const ExprT& expr) const override {
+    // Either any inputs or any outputs must have been visited
+    decltype(auto) inputs = this->inputs_(expr);
+    if (!inputs.empty() && this->allowed_direction_ != Direction::Backward &&
+        std::any_of(
+            inputs.begin(), inputs.end(), [&](const ValT& input) -> bool {
+              return this->isDependencySatisfied(input);
+            })) {
+      std::vector<NodeType> prev_nodes;
+      std::copy_if(
+          inputs.begin(),
+          inputs.end(),
+          std::back_inserter(prev_nodes),
+          [&](const ValT& input) -> bool { return this->isVisited(input); });
+      return std::make_pair(Direction::Forward, prev_nodes);
+    }
+
+    decltype(auto) outputs = this->outputs_(expr);
+    if (!outputs.empty() && this->allowed_direction_ != Direction::Forward &&
+        std::any_of(
+            outputs.begin(), outputs.end(), [&](const ValT& output) -> bool {
+              return this->isDependencySatisfied(output);
+            })) {
+      std::vector<NodeType> prev_nodes;
+      std::copy_if(
+          outputs.begin(),
+          outputs.end(),
+          std::back_inserter(prev_nodes),
+          [&](const ValT& output) -> bool { return this->isVisited(output); });
+      return std::make_pair(Direction::Backward, prev_nodes);
+    }
+    return std::nullopt;
+  }
+};
+
 // Find the shortest path from the from vals to the to
 // vals. Dependency between vals and exprs must be satisfied.
 // It is an error if no valid path is found unless

--- a/csrc/bfs.h
+++ b/csrc/bfs.h
@@ -550,7 +550,7 @@ class BFS {
 };
 
 // Unlike the default BFS behavior, Expr is considered ready to
-// visit as long as one of the inputs or outputs has its dependency met
+// visit as long as one of the inputs or outputs has any of its dependencies met
 template <
     typename ExprT,
     typename ValT,

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -938,14 +938,13 @@ CompareDomainWithReferenceResult compareDomainWithReference(
     //  the reference domain. If it's connected even with missing
     //  dependencies, it should be considered redundant. For this
     //  reason, a variant of IRBFS with a relaxed dependency condition
-    //  is used. IRBFSWithPermissiveDependence can traverse as long as one of
+    //  is used. IRPermissiveBFS can traverse as long as one of
     //  the inputs or outputs is visited.
-    const auto from_remaining_ids =
-        getExprsBetween<IRBFSWithPermissiveDependence>(
-            {unused_ids.begin(), unused_ids.end()},
-            {reference.begin(), reference.end()},
-            /*require_all_to_visited=*/false)
-            .first;
+    const auto from_remaining_ids = getExprsBetween<IRPermissiveBFS>(
+                                        {unused_ids.begin(), unused_ids.end()},
+                                        {reference.begin(), reference.end()},
+                                        /*require_all_to_visited=*/false)
+                                        .first;
     // Nothing is reachable, which means all of the unused IDs are not redundant
     if (from_remaining_ids.empty()) {
       additional_ids = unused_ids;

--- a/csrc/iter_visitor.h
+++ b/csrc/iter_visitor.h
@@ -634,55 +634,28 @@ inline std::vector<Val*> getOutputsOfExpr(Expr* expr, Direction dir) {
   return getOutputsOfExpr<Expr*>(expr, dir, IRInputs(), IROutputs());
 }
 
-// Unlike the default IRBFS behavior, Expr is considered ready to
-// visit as long as one of the inputs or outputs has its dependency met
-class IRBFSWithPermissiveDependence : public IRBFS {
+class IRPermissiveBFS : public BFSWithPermissiveDependence<
+                            Expr*,
+                            Val*,
+                            IRDefinitions,
+                            IRUses,
+                            IRInputs,
+                            IROutputs> {
  public:
-  IRBFSWithPermissiveDependence(
-      const std::vector<Val*>& from_ids,
-      const std::vector<Val*>& to_ids,
-      bool require_all_to_visited = true,
+  IRPermissiveBFS(
+      std::vector<NodeType> from_groups,
+      std::vector<NodeType> to_groups,
+      bool require_all_to_visited,
       Direction allowed_direction = Direction::Undefined)
-      : IRBFS(
-            {from_ids.begin(), from_ids.end()},
-            {to_ids.begin(), to_ids.end()},
+      : BFSWithPermissiveDependence(
+            IRDefinitions{},
+            IRUses{},
+            IRInputs{},
+            IROutputs{},
+            std::move(from_groups),
+            std::move(to_groups),
             require_all_to_visited,
             allowed_direction) {}
-
-  std::optional<std::pair<Direction, std::vector<NodeType>>> isReady(
-      const ExprType& expr) const override {
-    // Either any inputs or any outputs must have been visited
-    decltype(auto) inputs = inputs_(expr);
-    if (!inputs.empty() && allowed_direction_ != Direction::Backward &&
-        std::any_of(
-            inputs.begin(), inputs.end(), [&](const ValType& input) -> bool {
-              return isDependencySatisfied(input);
-            })) {
-      std::vector<NodeType> prev_nodes;
-      std::copy_if(
-          inputs.begin(),
-          inputs.end(),
-          std::back_inserter(prev_nodes),
-          [&](const ValType& input) -> bool { return isVisited(input); });
-      return std::make_pair(Direction::Forward, prev_nodes);
-    }
-
-    decltype(auto) outputs = outputs_(expr);
-    if (!outputs.empty() && allowed_direction_ != Direction::Forward &&
-        std::any_of(
-            outputs.begin(), outputs.end(), [&](const ValType& output) -> bool {
-              return isDependencySatisfied(output);
-            })) {
-      std::vector<NodeType> prev_nodes;
-      std::copy_if(
-          outputs.begin(),
-          outputs.end(),
-          std::back_inserter(prev_nodes),
-          [&](const ValType& output) -> bool { return isVisited(output); });
-      return std::make_pair(Direction::Backward, prev_nodes);
-    }
-    return std::nullopt;
-  }
 };
 
 } // namespace nvfuser

--- a/csrc/val_graph_visitor.h
+++ b/csrc/val_graph_visitor.h
@@ -216,4 +216,44 @@ class ValGraphBFS : public BFS<
   }
 };
 
+class ValGraphPermissiveBFS : public BFSWithPermissiveDependence<
+                                  ExprGroup,
+                                  ValGroup,
+                                  ValGraphDefinitions,
+                                  ValGraphUses,
+                                  ValGraphInputs,
+                                  ValGraphOutputs> {
+ public:
+  ValGraphPermissiveBFS(
+      const ValGraph& graph,
+      std::vector<NodeType> from_groups,
+      std::vector<NodeType> to_groups,
+      bool require_all_to_visited = true,
+      Direction allowed_direction = Direction::Undefined)
+      : BFSWithPermissiveDependence(
+            ValGraphDefinitions(graph),
+            ValGraphUses(graph),
+            ValGraphInputs(graph),
+            ValGraphOutputs(graph),
+            std::move(from_groups),
+            std::move(to_groups),
+            require_all_to_visited,
+            allowed_direction) {}
+
+  // Just a shortcut to the generic getExprsBetween
+  static std::pair<ValGraphPermissiveBFS::ExprPath, bool> getExprGroupsBetween(
+      const ValGraph& graph,
+      const ValGroups& from,
+      const ValGroups& to,
+      bool require_all_to_visited = true,
+      Direction allowed_direction = Direction::Undefined) {
+    return getExprsBetween<ValGraphPermissiveBFS>(
+        from.vector(),
+        to.vector(),
+        require_all_to_visited,
+        allowed_direction,
+        graph);
+  }
+};
+
 } // namespace nvfuser

--- a/tests/cpp/test_bfs.cpp
+++ b/tests/cpp/test_bfs.cpp
@@ -474,7 +474,7 @@ TEST_F(BFSTest, TraversalDirection) {
   EXPECT_TRUE(backward_path.empty()) << "Actual: " << backward_path;
 }
 
-// A simple test for IRBFSWithPermissiveDependence
+// A simple test for BFSWithPermissiveDependence
 TEST_F(BFSTest, IRBFSPermissiveTraversal) {
   Fusion fusion;
   FusionGuard fg(&fusion);
@@ -508,7 +508,7 @@ TEST_F(BFSTest, IRBFSPermissiveTraversal) {
   // to: [i4]
   // -> forward merge, forward split
   {
-    auto path = getExprsBetween<IRBFSWithPermissiveDependence>(
+    auto path = getExprsBetween<IRPermissiveBFS>(
                     {i0, i2}, {i4}, /*require_all_to_visited=*/false)
                     .first;
     EXPECT_EQ(path.size(), 2);
@@ -524,7 +524,7 @@ TEST_F(BFSTest, IRBFSPermissiveTraversal) {
   // to: [i1]
   // -> bwd split, bwd merge
   {
-    auto path = getExprsBetween<IRBFSWithPermissiveDependence>(
+    auto path = getExprsBetween<IRPermissiveBFS>(
                     {i4, i5}, {i1}, /*require_all_to_visited=*/false)
                     .first;
     EXPECT_EQ(path.size(), 2);


### PR DESCRIPTION
Currently, the permissive BFS is only implemented for IRBFS. This change introduces the same traversal for ValGraphBFS, which is used in #3657. There should be no change for anything existing. There's a simple test for IRBFS (`BFSTest.IRBFSPermissiveTraversal`), which I still think should be enough.