### PR TITLE
Fix expected BAR instructions in AmpereModifiersSharedMemoryEpilogue

### DIFF
--- a/tests/cpp/test_matmul_sass.cpp
+++ b/tests/cpp/test_matmul_sass.cpp
@@ -372,9 +372,9 @@ TEST_F(MatmulSASSTest, AmpereModifiersSharedMemoryEpilogue) {
     bool found_LDGDEPBAR = false;
     bool found_DEPBAR = false; // kAllSupportedMmaLayout;
     int BAR_COUNT = 0;
-    // we have at least 6 shared memory barriers in the kernel if
-    // use_shared_epilogue. If promote_prologue_smem_reuse, then 8
-    const int EXPECTED_BAR_COUNT = promote_prologue_smem_reuse ? 8 : 6;
+    // we have at least 5 shared memory barriers in the kernel if
+    // use_shared_epilogue. If promote_prologue_smem_reuse, then 7
+    const int EXPECTED_BAR_COUNT = promote_prologue_smem_reuse ? 7 : 5;
     sass::Container sass;
     NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
         8,


### PR DESCRIPTION
In #3627 we reduced unrolling. This doesn't lead to a reduction in syncing, but it does reduce the number of sync instructions we see in the compiled SASS. That change broke a test which I'm updating in this PR.

Fixes #3661