### PR TITLE
Fix warning during compile with gcc

### DIFF
--- a/csrc/preseg_passes/translate_repeat_to_expand.cpp
+++ b/csrc/preseg_passes/translate_repeat_to_expand.cpp
@@ -160,7 +160,7 @@ class RepeatToExpandTranslator {
           std::find(inp_domain.begin(), inp_domain.end(), info.repeated_id));
       bcast_flags.at(repeated_id_offset) = true;
       auto broadcast_tv = broadcast(info.input_tv, bcast_flags);
-      NVF_ERROR(broadcast_tv->nDims() == inp_domain.size() + 1);
+      NVF_ERROR((size_t)broadcast_tv->nDims() == inp_domain.size() + 1);
 
       // Step 2
       std::vector<Val*> expanded_sizes(


### PR DESCRIPTION
This just silences a warning I am seeing using gcc.
```
[109/335] Building CXX object CMakeFiles/codegen_internal.dir/csrc/preseg_passes/translate_repeat_to_expand.cpp.o
In file included from /opt/pytorch/nvfuser/csrc/preseg_passes/translate_repeat_to_expand.h:10,
                 from /opt/pytorch/nvfuser/csrc/preseg_passes/translate_repeat_to_expand.cpp:8:
/opt/pytorch/nvfuser/csrc/preseg_passes/translate_repeat_to_expand.cpp: In member function ‘void nvfuser::preseg_passes::{anonymous}::RepeatToExpandTranslator::translate()’:
/opt/pytorch/nvfuser/csrc/preseg_passes/translate_repeat_to_expand.cpp:163:39: warning: comparison of integer expressions of different signedness: ‘int64_t’ {aka ‘long int’} and ‘std::vector<nvfuser::IterDomain*>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  163 |       NVF_ERROR(broadcast_tv->nDims() == inp_domain.size() + 1);
      |                 ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
```