### PR TITLE
Re-enable -Werror, with exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,12 +297,13 @@ endif()
 add_library(codegen_internal OBJECT ${NVFUSER_SRCS})
 
 if(NOT MSVC)
-  # -Werror is not enabled, because of gcc 12.2 used in manylinux image.
-  # consider enable this when we upgrade. linking comment:
-  # https://github.com/NVIDIA/Fuser/pull/3001#discussion_r1772551266
   target_compile_options(codegen_internal PRIVATE
-    -Wall -Wno-unused-function
-    # -Werror
+      -Wall -Wno-unused-function -Werror
+      # These warnings are not treated as errors because of gcc 12.2 used in
+      # manylinux image. consider enable this when we upgrade.
+      # linking comment:
+      # https://github.com/NVIDIA/Fuser/pull/3001#discussion_r1772551266
+      -Wno-error=restrict -Wno-error=stringop-overflow
   )
 endif()
 


### PR DESCRIPTION
We previously disabled compiling with `-Werror` due to a bug in GCC 12.2 which erroneously causes the compile to fail. The relevant warnings in that case were `-Wrestrict` and `-Wstringop-overflow`:
```
...

    inlined from ‘nvfuser::Val* nvfuser::rules::distributeMul(nvfuser::Val*, const nvfuser::Context&)’ at /opt/pytorch/nvfuser/csrc/expr_simplifier.cpp:2414:32:
/usr/include/c++/13/bits/stl_algobase.h:437:30: warning: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ accessing 9223372036854775800 bytes at offsets 0 and 0 overlaps 9223372036854775793 bytes at offset 7 [-Wrestrict]
  437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

...

    inlined from ‘std::unique_ptr<nvfuser::executor_utils::caching::VectorizedTensorInfo> nvfuser::executor_utils::{anonymous}::getVectorizedTensorValidationInfo(nvfuser::kir::Kernel*)’ at /opt/pytorch/nvfuser/csrc/runtime/executor_utils.cpp:328:72:
/usr/include/c++/13/bits/stl_construct.h:97:14: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
   97 |     { return ::new((void*)__location) _Tp(std::forward<_Args>(__args)...); }
```

In this PR, I'm adding `-Werror` back to the compile flags but also adding `-Wno-error=restrict -Wno-error=stringop-overflow`. With these, we will still get the warnings for these cases, but all other types of warnings will give us an error. This would have caught #3001 or #3664.

Previous discussion: https://github.com/NVIDIA/Fuser/pull/3001#discussion_r1772551266