### PR TITLE
Create SetMaxNReg and Return kir nodes

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -3510,6 +3510,10 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     indent() << "NVFUSER_UPDATE_MAGIC_ZERO;\n";
   }
 
+  void handle(const kir::Return* ret) final {
+    indent() << "return;\n";
+  }
+
  private:
   std::stringstream code_;
   const kir::Kernel* kernel_;

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2583,6 +2583,16 @@ void IndexLowering::handle(const kir::WgMmaFence* fence) {
   pushBack(const_cast<kir::WgMmaFence*>(fence)); // NOLINT
 }
 
+void IndexLowering::handle(const kir::MaxNReg* maxnreg) {
+  // TODO(kir): remove the need for const_cast
+  pushBack(const_cast<kir::MaxNReg*>(maxnreg)); // NOLINT
+}
+
+void IndexLowering::handle(const kir::Return* ret) {
+  // TODO(kir): remove the need for const_cast
+  pushBack(const_cast<kir::Return*>(ret)); // NOLINT
+}
+
 void IndexLowering::handle(const kir::AsyncCommit* commit) {
   // TODO(kir): remove the need for const_cast
   pushBack(const_cast<kir::AsyncCommit*>(commit)); // NOLINT

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2583,9 +2583,9 @@ void IndexLowering::handle(const kir::WgMmaFence* fence) {
   pushBack(const_cast<kir::WgMmaFence*>(fence)); // NOLINT
 }
 
-void IndexLowering::handle(const kir::MaxNReg* maxnreg) {
+void IndexLowering::handle(const kir::SetMaxNReg* maxnreg) {
   // TODO(kir): remove the need for const_cast
-  pushBack(const_cast<kir::MaxNReg*>(maxnreg)); // NOLINT
+  pushBack(const_cast<kir::SetMaxNReg*>(maxnreg)); // NOLINT
 }
 
 void IndexLowering::handle(const kir::Return* ret) {

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -75,7 +75,7 @@ class IndexLowering : private OptOutConstDispatch {
   void handle(const kir::GridSync*) final;
   void handle(const kir::FenceAsyncProxy*) final;
   void handle(const kir::WgMmaFence*) final;
-  void handle(const kir::MaxNReg*) final;
+  void handle(const kir::SetMaxNReg*) final;
   void handle(const kir::Return*) final;
   void handle(const kir::MBarrierInit*) final;
   void handle(const kir::MBarrierInvalidate*) final;

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -75,6 +75,8 @@ class IndexLowering : private OptOutConstDispatch {
   void handle(const kir::GridSync*) final;
   void handle(const kir::FenceAsyncProxy*) final;
   void handle(const kir::WgMmaFence*) final;
+  void handle(const kir::MaxNReg*) final;
+  void handle(const kir::Return*) final;
   void handle(const kir::MBarrierInit*) final;
   void handle(const kir::MBarrierInvalidate*) final;
   void handle(const kir::MBarrierArrive*) final;

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -272,6 +272,19 @@ class LowerToInlinePtx : public kir::ExprMutator {
             std::vector<Val*>{},
             kir::Asm::Options{/*volatile=*/true}));
   }
+
+  void handle(kir::MaxNReg* maxnreg) final {
+    std::string ptx = (maxnreg->increaseRegisters())
+        ? "setmaxnreg.inc.sync.aligned.u32"
+        : "setmaxnreg.dec.sync.aligned.u32";
+    registerReplace(
+        maxnreg,
+        IrBuilder::create<kir::Asm>(
+            ptx,
+            std::vector<Val*>{},
+            std::vector<Val*>{maxnreg->numberOfRegisters()},
+            kir::Asm::Options{/*volatile=*/true}));
+  }
 };
 
 std::vector<Expr*> lowerToInlinePtx(const std::vector<Expr*>& exprs) {

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -273,7 +273,7 @@ class LowerToInlinePtx : public kir::ExprMutator {
             kir::Asm::Options{/*volatile=*/true}));
   }
 
-  void handle(kir::MaxNReg* maxnreg) final {
+  void handle(kir::SetMaxNReg* maxnreg) final {
     std::string ptx = (maxnreg->increaseRegisters())
         ? "setmaxnreg.inc.sync.aligned.u32"
         : "setmaxnreg.dec.sync.aligned.u32";

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -120,6 +120,8 @@ class Val;
   f(GridSync);                        \
   f(FenceAsyncProxy);                 \
   f(WgMmaFence);                      \
+  f(MaxNReg);                         \
+  f(Return);                          \
   f(MBarrierInit);                    \
   f(MBarrierInvalidate);              \
   f(MBarrierArrive);                  \

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -120,7 +120,7 @@ class Val;
   f(GridSync);                        \
   f(FenceAsyncProxy);                 \
   f(WgMmaFence);                      \
-  f(MaxNReg);                         \
+  f(SetMaxNReg);                      \
   f(Return);                          \
   f(MBarrierInit);                    \
   f(MBarrierInvalidate);              \

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -485,6 +485,47 @@ std::string WgMmaFence::toInlineString(int indent_size) const {
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(WgMmaFence)
 
+MaxNReg::MaxNReg(
+    IrBuilderPasskey passkey,
+    Val* number_of_registers,
+    bool increase_registers)
+    : Expr(passkey) {
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
+      passkey.ir_container_->isA<kir::Kernel>(),
+      "IR type only valid for Kernel container.");
+  addInput(number_of_registers);
+  addDataAttribute(increase_registers);
+}
+
+std::string MaxNReg::toString(int indent_size) const {
+  return (increaseRegisters()) ? "setmaxnreg.inc.sync.aligned.u32"
+                               : "setmaxnreg.dec.sync.aligned.u32";
+}
+
+std::string MaxNReg::toInlineString(int indent_size) const {
+  NVF_CHECK(false, "MaxNReg can not be printed inline");
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(MaxNReg)
+
+Return::Return(IrBuilderPasskey passkey) : Expr(passkey) {
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
+      passkey.ir_container_->isA<kir::Kernel>(),
+      "IR type only valid for Kernel container.");
+}
+
+std::string Return::toString(int indent_size) const {
+  return "return";
+}
+
+std::string Return::toInlineString(int indent_size) const {
+  NVF_CHECK(false, "Return can not be printed inline");
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(Return)
+
 MBarrierInit::MBarrierInit(
     IrBuilderPasskey passkey,
     Val* mbarrier,

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -485,7 +485,7 @@ std::string WgMmaFence::toInlineString(int indent_size) const {
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(WgMmaFence)
 
-MaxNReg::MaxNReg(
+SetMaxNReg::SetMaxNReg(
     IrBuilderPasskey passkey,
     Val* number_of_registers,
     bool increase_registers)
@@ -498,16 +498,16 @@ MaxNReg::MaxNReg(
   addDataAttribute(increase_registers);
 }
 
-std::string MaxNReg::toString(int indent_size) const {
+std::string SetMaxNReg::toString(int indent_size) const {
   return (increaseRegisters()) ? "setmaxnreg.inc.sync.aligned.u32"
                                : "setmaxnreg.dec.sync.aligned.u32";
 }
 
-std::string MaxNReg::toInlineString(int indent_size) const {
-  NVF_CHECK(false, "MaxNReg can not be printed inline");
+std::string SetMaxNReg::toInlineString(int indent_size) const {
+  NVF_CHECK(false, "SetMaxNReg can not be printed inline");
 }
 
-NVFUSER_DEFINE_CLONE_AND_CREATE(MaxNReg)
+NVFUSER_DEFINE_CLONE_AND_CREATE(SetMaxNReg)
 
 Return::Return(IrBuilderPasskey passkey) : Expr(passkey) {
   NVF_ERROR(passkey.ir_container_ != nullptr);

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -41,7 +41,7 @@ class BlockSync;
 class GridSync;
 class FenceAsyncProxy;
 class WgMmaFence;
-class MaxNReg;
+class SetMaxNReg;
 class Return;
 class MBarrierInit;
 class MBarrierInvalidate;
@@ -472,11 +472,11 @@ class WgMmaFence final : public Expr {
 };
 
 // PTX: setmaxnreg.inc.sync.aligned.u32 and setmaxnreg.dec.sync.aligned.u32
-class MaxNReg final : public Expr {
+class SetMaxNReg final : public Expr {
  public:
   using Expr::Expr;
 
-  explicit MaxNReg(
+  explicit SetMaxNReg(
       IrBuilderPasskey passkey,
       Val* number_of_registers,
       bool increase_registers);
@@ -484,7 +484,7 @@ class MaxNReg final : public Expr {
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
   const char* getOpString() const override {
-    return (increaseRegisters()) ? "IncMaxNReg" : "DecMaxNReg";
+    return (increaseRegisters()) ? "IncSetMaxNReg" : "DecSetMaxNReg";
   }
 
   std::string toString(int indent_size = 0) const override;

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -41,6 +41,8 @@ class BlockSync;
 class GridSync;
 class FenceAsyncProxy;
 class WgMmaFence;
+class MaxNReg;
+class Return;
 class MBarrierInit;
 class MBarrierInvalidate;
 class MBarrierArrive;
@@ -463,6 +465,50 @@ class WgMmaFence final : public Expr {
 
   const char* getOpString() const override {
     return "WgMmaFence";
+  }
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+};
+
+// PTX: setmaxnreg.inc.sync.aligned.u32 and setmaxnreg.dec.sync.aligned.u32
+class MaxNReg final : public Expr {
+ public:
+  using Expr::Expr;
+
+  explicit MaxNReg(
+      IrBuilderPasskey passkey,
+      Val* number_of_registers,
+      bool increase_registers);
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  const char* getOpString() const override {
+    return (increaseRegisters()) ? "IncMaxNReg" : "DecMaxNReg";
+  }
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+
+  bool increaseRegisters() const {
+    return attribute<bool>(0);
+  }
+
+  Val* numberOfRegisters() const {
+    return input(0);
+  }
+};
+
+class Return final : public Expr {
+ public:
+  using Expr::Expr;
+
+  explicit Return(IrBuilderPasskey passkey);
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  const char* getOpString() const override {
+    return "Return";
   }
 
   std::string toString(int indent_size = 0) const override;


### PR DESCRIPTION
This PR adds `kir::SetMaxNReg` and `kir::Return` nodes for register sharing with warp specialization.

`kir::SetMaxNReg` corresponds with [setmaxnreg](https://docs.nvidia.com/cuda/parallel-thread-execution/#miscellaneous-instructions-setmaxnreg) ptx instruction to add a compiler hint to increase or decrease the number of registers in a warp group.

`kir::Return` corresponds with an empty `return` statement. It is necessary to terminate the load warps early. Otherwise, cuda kernel will have poor performance.