### PR TITLE
Relax broadcast constraint in scheduleLoopDomainsLike

### DIFF
--- a/csrc/scheduler/tools/loop_domain_scheduler.cpp
+++ b/csrc/scheduler/tools/loop_domain_scheduler.cpp
@@ -107,15 +107,6 @@ class LoopDomainScheduler {
         update_loop_domain_only_(update_loop_domain_only) {
     NVF_ERROR(!ref_loop_dom_.empty());
 
-    // For now, ref must not be a broadcast domain
-    NVF_ERROR(
-        std::none_of(
-            ref_loop_dom_.begin(),
-            ref_loop_dom_.end(),
-            [](IterDomain* id) { return id->isBroadcast(); }),
-        "Broadcast referene not supported: ",
-        toDelimitedString(ref_loop_dom_));
-
     Fusion* fusion = ref_loop_dom_.front()->fusion();
     id_model_ = std::make_unique<IdModel>(fusion, /*build_graphs=*/false);
     id_model_->buildExactGraph();


### PR DESCRIPTION
In `scheduleLoopDomainsLike`, I originally thought the reference should not have broadcast IDs, but that's not necessary the case with the RoPE cases. I'm not aware of any particular issue with allowing to have broadcast IDs, so removed the assertion and added a unit test.