### PR TITLE
Add outermost for-loop check for warp specialized register sharing

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -277,7 +277,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       const std::string& kernel_name,
       std::optional<int64_t> num_threads_per_cta) {
     code_ << "__global__ void ";
-    if (kernel_->hasManaged("warp_specialized_num_registers")) {
+    if (kernel_->hasManaged("enable_register_sharing") &&
+        kernel_->getManaged<bool>("enable_register_sharing")) {
       NVF_ERROR(
           num_threads_per_cta.has_value(),
           "__launch_bounds__ must be set for register sharing warp specialization");

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -155,7 +155,10 @@ void validateCircularBufferedTensor(const TensorView* tv) {
         break;
       }
       NVF_ERROR(
-          tv->getLoopDomain().at(axis)->isParallelized(),
+          tv->getLoopDomain().at(axis)->isThread() ||
+              tv->getLoopDomain().at(axis)->isDeviceDim() ||
+              tv->getLoopDomain().at(axis)->isBroadcast() ||
+              tv->getLoopDomain().at(axis)->isOneInt(),
           "When using register sharing with warp-specialized circular "
           "buffering, the circular buffer loop must be the outer-most "
           "for-loop.");

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -145,13 +145,10 @@ void validateCircularBufferedTensor(const TensorView* tv) {
 
   // Ensure that the warp-specialized circular buffer loop is the outer-most
   // for-loop if register sharing is enabled.
-  std::pair<int64_t, int64_t> warp_specialized_num_registers =
-      tv->circularBufferOptions().warp_specialized_num_registers;
   bool is_warp_specialized_with_register_sharing =
       std::holds_alternative<WarpSpecialized>(
           tv->circularBufferOptions().type) &&
-      (warp_specialized_num_registers.first != -1) &&
-      (warp_specialized_num_registers.second != -1);
+      tv->circularBufferOptions().warp_specialized_num_registers.has_value();
   if (is_warp_specialized_with_register_sharing) {
     for (int64_t axis : c10::irange((int64_t)tv->getLoopDomain().size())) {
       if (axis >= circular_buffer_pos) {

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -1396,15 +1396,11 @@ class CircularBufferInserter : private kir::ExprMutator {
 
     // Set default value
     GpuLower::current()->kernel()->manage("enable_register_sharing", true);
-
     auto&& [decrease_num_registers, increase_num_registers] =
         GpuLower::current()
             ->circularBufferInfo()
             .getCircularBufferOptionsFor(circular_buffer_loop->iter_domain())
             .warp_specialized_num_registers;
-    NVF_ERROR(
-        decrease_num_registers < increase_num_registers,
-        "Expected the number of registers for decrease setmaxnreg to be lower than increase setmaxnreg");
 
     // Decrease registers in load warp group
     kir::SetMaxNReg* dec_reg_load_warp = IrBuilder::create<kir::SetMaxNReg>(

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -1394,22 +1394,14 @@ class CircularBufferInserter : private kir::ExprMutator {
                     warp_specialize_on),
                 circular_buffer_loop->fusion()->oneVal()))));
 
-    // Get register configuration for warp specialized circular buffering
-    std::pair<int64_t, int64_t> warp_specialized_num_registers = {24, 240};
-    if (GpuLower::current()->kernel()->hasManaged(
-            "warp_specialized_num_registers")) {
-      warp_specialized_num_registers =
-          GpuLower::current()
-              ->kernel()
-              ->getManaged<std::pair<int64_t, int64_t>>(
-                  "warp_specialized_num_registers");
-    } else {
-      // Set default value
-      GpuLower::current()->kernel()->manage(
-          "warp_specialized_num_registers", warp_specialized_num_registers);
-    }
+    // Set default value
+    GpuLower::current()->kernel()->manage("enable_register_sharing", true);
+
     auto&& [decrease_num_registers, increase_num_registers] =
-        warp_specialized_num_registers;
+        GpuLower::current()
+            ->circularBufferInfo()
+            .getCircularBufferOptionsFor(circular_buffer_loop->iter_domain())
+            .warp_specialized_num_registers;
     NVF_ERROR(
         decrease_num_registers < increase_num_registers,
         "Expected the number of registers for decrease setmaxnreg to be lower than increase setmaxnreg");

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -1396,11 +1396,14 @@ class CircularBufferInserter : private kir::ExprMutator {
 
     // Set default value
     GpuLower::current()->kernel()->manage("enable_register_sharing", true);
+    auto& circular_buffer_options =
+        GpuLower::current()->circularBufferInfo().getCircularBufferOptionsFor(
+            circular_buffer_loop->iter_domain());
+    NVF_ERROR(
+        circular_buffer_options.warp_specialized_num_registers.has_value());
+
     auto&& [decrease_num_registers, increase_num_registers] =
-        GpuLower::current()
-            ->circularBufferInfo()
-            .getCircularBufferOptionsFor(circular_buffer_loop->iter_domain())
-            .warp_specialized_num_registers;
+        circular_buffer_options.warp_specialized_num_registers.value();
 
     // Decrease registers in load warp group
     kir::SetMaxNReg* dec_reg_load_warp = IrBuilder::create<kir::SetMaxNReg>(

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -1395,11 +1395,14 @@ class CircularBufferInserter : private kir::ExprMutator {
                 circular_buffer_loop->fusion()->oneVal()))));
 
     // Set default value
-    GpuLower::current()->kernel()->manage("enable_register_sharing", true);
     auto& circular_buffer_options =
         GpuLower::current()->circularBufferInfo().getCircularBufferOptionsFor(
             circular_buffer_loop->iter_domain());
     NVF_ERROR(
+        circular_buffer_options.warp_specialized_num_registers.has_value(),
+        "Register sharing is enabled by default for warp-specialized circular buffering.");
+    GpuLower::current()->kernel()->manage(
+        "enable_register_sharing",
         circular_buffer_options.warp_specialized_num_registers.has_value());
 
     auto&& [decrease_num_registers, increase_num_registers] =

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -637,7 +637,9 @@ class NVF_API TensorView : public Val {
   void circularBuffer(
       int64_t number_of_stages,
       int64_t prefetch_distance = -1,
-      CircularBufferType type = Pipelined(false));
+      CircularBufferType type = Pipelined(false),
+      std::optional<std::pair<int64_t, int64_t>>
+          warp_specialized_num_registers = std::nullopt);
 
   // Returns true if this tensor is circular buffered.
   bool isCircularBuffered() const {

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -289,7 +289,8 @@ struct CircularBufferOptions {
 
   bool operator==(const CircularBufferOptions& other) const {
     return type == other.type && stage == other.stage &&
-        prefetch == other.prefetch;
+        prefetch == other.prefetch &&
+        warp_specialized_num_registers == other.warp_specialized_num_registers;
   }
 };
 

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -272,6 +272,9 @@ struct CircularBufferOptions {
   int64_t stage = 0; // Size of the circular buffer (number of buffers)
   int64_t prefetch = 0; // Number of iterations ahead of the compute to
                         // prefetch, can only be < stage.
+  // The number of registers for load and compute warps respectively.
+  // Register sharing is disabled when both values are -1.
+  std::pair<int64_t, int64_t> warp_specialized_num_registers = {-1, -1};
 
   bool isEnable() const {
     return stage > 1;
@@ -293,9 +296,12 @@ struct CircularBufferOptions {
 inline std::ostream& operator<<(
     std::ostream& os,
     const CircularBufferOptions& options) {
+  auto&& [decrease_num_registers, increase_num_registers] =
+      options.warp_specialized_num_registers;
   return os << "CircularBufferOptions{ stage=" << options.stage
             << ", prefetch=" << options.prefetch << ", type=" << options.type
-            << " }";
+            << ", decrease_num_registers=" << decrease_num_registers
+            << ", increate_num_registers=" << increase_num_registers << " }";
 }
 
 //! TensorView is our primitive Tensor Type used in code generation. It can be

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -274,7 +274,8 @@ struct CircularBufferOptions {
                         // prefetch, can only be < stage.
   // The number of registers for load and compute warps respectively.
   // Register sharing is disabled when both values are -1.
-  std::pair<int64_t, int64_t> warp_specialized_num_registers = {-1, -1};
+  std::optional<std::pair<int64_t, int64_t>> warp_specialized_num_registers =
+      std::nullopt;
 
   bool isEnable() const {
     return stage > 1;
@@ -297,8 +298,14 @@ struct CircularBufferOptions {
 inline std::ostream& operator<<(
     std::ostream& os,
     const CircularBufferOptions& options) {
-  auto&& [decrease_num_registers, increase_num_registers] =
-      options.warp_specialized_num_registers;
+  int64_t decrease_num_registers = -1;
+  int64_t increase_num_registers = -1;
+  if (options.warp_specialized_num_registers.has_value()) {
+    decrease_num_registers =
+        options.warp_specialized_num_registers.value().first;
+    increase_num_registers =
+        options.warp_specialized_num_registers.value().second;
+  }
   return os << "CircularBufferOptions{ stage=" << options.stage
             << ", prefetch=" << options.prefetch << ", type=" << options.type
             << ", decrease_num_registers=" << decrease_num_registers

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1366,6 +1366,10 @@ void TensorView::circularBuffer(
   circular_buffer_options_.stage = number_of_stages;
   circular_buffer_options_.prefetch = prefetch_distance;
   circular_buffer_options_.type = type;
+
+  if (std::holds_alternative<WarpSpecialized>(type)) {
+    circular_buffer_options_.warp_specialized_num_registers = {24, 240};
+  }
 }
 
 bool TensorView::isEmptyTensor() const {

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1388,9 +1388,10 @@ void TensorView::circularBuffer(
           warp_specialized_num_registers.value().first <=
           warp_specialized_num_registers.value().second);
       circular_buffer_options_.warp_specialized_num_registers =
-          warp_specialized_num_registers.value();
+          warp_specialized_num_registers;
     } else {
-      circular_buffer_options_.warp_specialized_num_registers = {24, 240};
+      circular_buffer_options_.warp_specialized_num_registers =
+          std::make_pair(24L, 240L);
     }
   }
 }

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1368,16 +1368,13 @@ void TensorView::circularBuffer(
   circular_buffer_options_.prefetch = prefetch_distance;
   circular_buffer_options_.type = type;
 
+  NVF_ERROR(
+      !warp_specialized_num_registers.has_value() ||
+          std::holds_alternative<WarpSpecialized>(type),
+      "Setting the number of register for load and compute warp groups is only ",
+      "allowed for WarpSpecialized Circular Buffering");
   if (std::holds_alternative<WarpSpecialized>(type)) {
-    bool has_outer_for_loop = false;
-    // short-circuit
-    if (has_outer_for_loop) {
-      NVF_ERROR(
-          warp_specialized_num_registers.has_value(),
-          "Only support register sharing if warp specialized loops are not nested.");
-      return;
-    }
-
+    // Use default setting or specified value
     if (warp_specialized_num_registers.has_value()) {
       NVF_ERROR(warp_specialized_num_registers.value().first != -1);
       NVF_ERROR(warp_specialized_num_registers.value().second != -1);
@@ -1387,7 +1384,6 @@ void TensorView::circularBuffer(
       circular_buffer_options_.warp_specialized_num_registers =
           warp_specialized_num_registers.value();
     } else {
-      // Use default setting
       circular_buffer_options_.warp_specialized_num_registers = {24, 240};
     }
   }

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1372,12 +1372,18 @@ void TensorView::circularBuffer(
       !warp_specialized_num_registers.has_value() ||
           std::holds_alternative<WarpSpecialized>(type),
       "Setting the number of register for load and compute warp groups is only ",
-      "allowed for WarpSpecialized Circular Buffering");
+      "allowed for warp specialized circular buffering.");
   if (std::holds_alternative<WarpSpecialized>(type)) {
-    // Use default setting or specified value
+    // Use default setting or check and set specified value
     if (warp_specialized_num_registers.has_value()) {
-      NVF_ERROR(warp_specialized_num_registers.value().first != -1);
-      NVF_ERROR(warp_specialized_num_registers.value().second != -1);
+      auto validate_num_registers = [](int64_t a) {
+        NVF_ERROR(
+            a >= 24 && a <= 256 && a % 8 == 0,
+            "The number of registers for setmaxnreg must be between 24 and",
+            " 256 (inclusive) and be a multiple of 8.");
+      };
+      validate_num_registers(warp_specialized_num_registers.value().first);
+      validate_num_registers(warp_specialized_num_registers.value().second);
       NVF_ERROR(
           warp_specialized_num_registers.value().first <
           warp_specialized_num_registers.value().second);

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1385,7 +1385,7 @@ void TensorView::circularBuffer(
       validate_num_registers(warp_specialized_num_registers.value().first);
       validate_num_registers(warp_specialized_num_registers.value().second);
       NVF_ERROR(
-          warp_specialized_num_registers.value().first <
+          warp_specialized_num_registers.value().first <=
           warp_specialized_num_registers.value().second);
       circular_buffer_options_.warp_specialized_num_registers =
           warp_specialized_num_registers.value();

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -12,8 +12,84 @@
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
 #include <exception>
+#include <utility>
 
 namespace nvfuser {
+
+TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseCustom) {
+  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  int64_t number_of_stages = 4;
+  int64_t prefetch_distance = 1;
+  int64_t tensor_outer_dim = 128;
+  int64_t tensor_inner_dim = 128;
+  CircularBufferType circular_buffer_type = WarpSpecialized(ParallelType::TIDy);
+
+  TensorView* tv0 = makeContigTensor(2);
+  TensorView* tv1 = makeContigTensor(2);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+
+  TensorView* tv2 = add(tv0, tv1);
+  fusion->addOutput(tv2);
+
+  // Use TMA to load TV0 into shared memory
+  TensorView* tv3 = tv0->cacheAfter(LoadStoreOpType::CpAsyncBulkTensorTile);
+  tv3->setMemoryType(MemoryType::Shared);
+
+  TensorView* tv4 = tv1->cacheAfter(LoadStoreOpType::CpAsyncBulkTensorTile);
+  tv4->setMemoryType(MemoryType::Shared);
+
+  TensorView* reference = tv2;
+
+  // Constants
+  constexpr int64_t bulk_inner_dim = 32;
+
+  // [M, N] -> [M, N/bid, bid]
+  reference->split(-1, bulk_inner_dim);
+
+  TransformPropagatorWithCheck propagator(reference);
+  MaxLogicalDomainInfoSpanningTree(reference).traverse(&propagator);
+
+  // Set computeAt position
+  inlineAllAt(tv2, /*pos=*/2);
+
+  // Circular Buffer with TMA loads
+  tv3->axis(0)->parallelize(ParallelType::BIDx);
+  tv3->axis(2)->parallelize(ParallelType::Bulk);
+  tv3->circularBuffer(
+      number_of_stages,
+      prefetch_distance,
+      circular_buffer_type,
+      std::make_pair(160L, 160L));
+
+  // Load TV1 into shared memory
+  tv4->axis(0)->parallelize(ParallelType::BIDx);
+  tv4->axis(2)->parallelize(ParallelType::Bulk);
+  tv4->circularBuffer(
+      number_of_stages,
+      prefetch_distance,
+      circular_buffer_type,
+      std::make_pair(160L, 160L));
+
+  // Split reference to parallelize TMA tile
+  reference->split(-1, 32);
+  reference->axis(0)->parallelize(ParallelType::BIDx);
+  reference->axis(-1)->parallelize(ParallelType::TIDx);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({tensor_outer_dim, tensor_inner_dim}, options);
+  at::Tensor t1 = at::randn({tensor_outer_dim, tensor_inner_dim}, options);
+  at::Tensor t2 = t0 + t1;
+
+  KernelExecutor ke;
+  ke.compile(fusion.get(), {t0, t1});
+
+  std::vector<at::Tensor> cg_outputs = ke.run({t0, t1});
+  testValidate(fusion.get(), cg_outputs, {t0, t1}, {t2}, __LINE__, __FILE__);
+}
 
 using StageAndPrefetch = std::pair<int64_t, int64_t>;
 


### PR DESCRIPTION
- Add optional argument `warp_specialized_num_registers` to `circularBuffer`
- Create `RegisterSharingCircularBufferingPointwiseCustom` and `RegisterSharingCircularBufferingPointwiseNested`
- Create check to ensure that warp-specialized circular buffer loop is the outermost for-loop if register sharing is enabled.