### PR TITLE
Transformer benchmark forward

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -755,6 +755,7 @@ if(BUILD_NVFUSER_BENCHMARK)
     ${NVFUSER_ROOT}/benchmarks/cpp/softmax_backward.cpp
     ${NVFUSER_ROOT}/benchmarks/cpp/softmax_dropout.cpp
     ${NVFUSER_ROOT}/benchmarks/cpp/timm.cpp
+    ${NVFUSER_ROOT}/benchmarks/cpp/transformer.cpp
     ${NVFUSER_ROOT}/benchmarks/cpp/transpose.cpp
     ${NVFUSER_ROOT}/benchmarks/cpp/utils.cpp
     ${NVFUSER_ROOT}/tests/cpp/utils.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -759,6 +759,7 @@ if(BUILD_NVFUSER_BENCHMARK)
     ${NVFUSER_ROOT}/benchmarks/cpp/transpose.cpp
     ${NVFUSER_ROOT}/benchmarks/cpp/utils.cpp
     ${NVFUSER_ROOT}/tests/cpp/utils.cpp
+    ${NVFUSER_ROOT}/tests/cpp/multidevice_transformer.cpp
   )
 
   add_executable(nvfuser_bench ${BENCHMARK_SRCS})

--- a/benchmarks/cpp/main.cpp
+++ b/benchmarks/cpp/main.cpp
@@ -69,6 +69,7 @@ void addGPUBenchmarkContext() {
 
 // Copied from BENCHMARK_MAIN with extra custom settings
 int main(int argc, char** argv) {
+  Communicator* communicator_ = &Communicator::getInstance();
   ::benchmark::Initialize(&argc, argv);
   if (::benchmark::ReportUnrecognizedArguments(argc, argv)) {
     return 1;
@@ -90,6 +91,13 @@ int main(int argc, char** argv) {
 
   ::benchmark::RunSpecifiedBenchmarks();
 
+  printf("calling comm cleanup, size=%ld, did=%ld\n", communicator_->size(), communicator_->deviceId());
+  Communicator::getInstance().cleanup();
+  printf("done calling comm cleanup, size=%ld, did=%ld\n", communicator_->size(), communicator_->deviceId());
+
   ::benchmark::Shutdown();
+
+
+
   return 0;
 }

--- a/benchmarks/cpp/main.cpp
+++ b/benchmarks/cpp/main.cpp
@@ -69,7 +69,6 @@ void addGPUBenchmarkContext() {
 
 // Copied from BENCHMARK_MAIN with extra custom settings
 int main(int argc, char** argv) {
-  Communicator* communicator_ = &Communicator::getInstance();
   ::benchmark::Initialize(&argc, argv);
   if (::benchmark::ReportUnrecognizedArguments(argc, argv)) {
     return 1;
@@ -91,13 +90,9 @@ int main(int argc, char** argv) {
 
   ::benchmark::RunSpecifiedBenchmarks();
 
-  printf("calling comm cleanup, size=%ld, did=%ld\n", communicator_->size(), communicator_->deviceId());
   Communicator::getInstance().cleanup();
-  printf("done calling comm cleanup, size=%ld, did=%ld\n", communicator_->size(), communicator_->deviceId());
 
   ::benchmark::Shutdown();
-
-
 
   return 0;
 }

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -51,7 +51,7 @@ static void setupTransformerForward(Fusion* fusion, DataType dtype) {
   std::unique_ptr<DistributedTransformer> model = std::make_unique<DistributedTransformer>(
         D, B, E, H, S, kDropoutProb, kSdpaProb);
 
-  model->setupForward(fusion, dtype, /*sequence_parallel*/false);
+  model->setupForward(fusion, dtype, /*sequence_parallel=*/false);
 }
 
 static std::vector<at::Tensor> reference_mlp(

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 
 #include <benchmarks/cpp/utils.h>
+#include <csrc/multidevice/utils.h>
 #include <tests/cpp/utils.h>
 #include <tests/cpp/multidevice_transformer.h>
 
@@ -53,6 +54,61 @@ static void setupTransformerForward(Fusion* fusion, DataType dtype) {
   model->setupForward(fusion, dtype, /*sequence_parallel*/false);
 }
 
+static std::vector<at::Tensor> reference_mlp(
+    at::Tensor x,
+    at::Tensor w0,
+    at::Tensor b0,
+    at::Tensor w1,
+    at::Tensor b1) {
+  auto at_dtype = w0.dtype();
+  auto linear0 = at::linear(x, w0, b0);
+  auto gelu = at::gelu(linear0.to(at::kFloat), "tanh").to(at_dtype);
+  auto linear1 = at::linear(gelu, w1, b1).to(at::kFloat);
+  auto [dropout, mask] = at::native_dropout(linear1, kDropoutProb, true);
+  return {linear0, gelu, linear1, dropout, mask};
+}
+
+static std::vector<at::Tensor> reference_mha(
+    at::Tensor x,
+    at::Tensor w0,
+    at::Tensor b0,
+    at::Tensor w1,
+    at::Tensor b1) {
+  auto linear0 = at::linear(x, w0, b0);
+  auto qkv = linear0.view({B, S, 3 * E}).split(E, 2);
+  for (auto i = 0; i < 3; i++) {
+    qkv[i] = qkv[i].reshape({B, S, H, E / H}).transpose(1, 2);
+  }
+  auto sdpa_out = at::_scaled_dot_product_flash_attention(
+      qkv[0], qkv[1], qkv[2], kSdpaProb, true, false, kSdpaScale);
+  auto sdpa = std::get<0>(sdpa_out);
+  // Reassemble heads (B, H, S, E/H) to (B, S, H, E/H) to (B, S, E)
+  auto y = sdpa.transpose(1, 2).reshape({B * S, E});
+  auto linear1 = at::linear(y, w1, b1).to(at::kFloat);
+  auto [dropout, mask] = at::native_dropout(linear1, kDropoutProb, true);
+  return {linear0, sdpa, linear1, dropout, mask};
+}
+
+static at::Tensor transformerShardTensor_Mesh(
+    at::Tensor tensor,
+    const int64_t axis,
+    const DeviceMesh& mesh,
+    Communicator* communicator_) {
+  const auto device_id = communicator_->deviceId();
+  return nvfuser::shardTensor(tensor, axis, mesh, device_id);
+}
+
+static at::Tensor transformerShardTensor(at::Tensor tensor, TensorView* tv, Communicator* communicator_) {
+  if (!isSharded(tv)) {
+    return tensor;
+  }
+  NVF_ERROR(tv->hasDeviceMesh(), "`tv` has no DeviceMesh: ", tv);
+  return transformerShardTensor_Mesh(
+      tensor,
+      getShardedLogicalAxis(tv, ParallelType::DIDx),
+      tv->getDeviceMesh(), communicator_);
+}
+
 static void NvFuserScheduler_TransformerFwd(
     benchmark::State& benchmark_state,
     FusionExecutorCache* executor_cache,
@@ -76,6 +132,67 @@ static void NvFuserScheduler_TransformerFwd(
 
   benchmark_state.SetBytesProcessed(
       bytes * int64_t(benchmark_state.iterations()));*/
+
+  Communicator* communicator_ = &Communicator::getInstance(); // nick TODO call Communicator::getInstance().cleanup() somewhere before program exit
+  const int64_t D = communicator_->size(); // number of devices
+
+  at::ScalarType at_dtype = data_type_to_aten(dtype);
+  const auto mesh = DeviceMesh::createForNumDevices(D);
+  constexpr float kEps = 1e-5;
+  std::vector<int64_t> norm_shape{E};
+
+  const auto options =
+      at::TensorOptions().dtype(at_dtype).device(communicator_->device());
+  auto x_ = at::randn({B * S, E}, options);
+  auto ln0_w_ = at::randn(E, options).to(at::kFloat);
+  auto ln0_b_ = at::randn(E, options).to(at::kFloat);
+  auto mha_w0_ = at::randn({3 * E, E}, options) * kParamScale;
+  auto mha_b0_ = at::randn({3 * E}, options) * kParamScale;
+  auto mha_w1_ = at::randn({E, E}, options) * kParamScale;
+  auto mha_b1_ = at::randn({E}, options) * kParamScale;
+  auto ln1_w_ = at::randn(E, options).to(at::kFloat);
+  auto ln1_b_ = at::randn(E, options).to(at::kFloat);
+  auto mlp_w0_ = at::randn({4 * E, E}, options) * kParamScale;
+  auto mlp_b0_ = at::randn({4 * E}, options) * kParamScale;
+  auto mlp_w1_ = at::randn({E, 4 * E}, options) * kParamScale;
+  auto mlp_b1_ = at::randn({E}, options) * kParamScale;
+
+  at::manual_seed(getATenRandomSeed());
+  auto x_float_ = x_.to(at::kFloat);
+  auto ln0_ = at::native_layer_norm(x_float_, norm_shape, ln0_w_, ln0_b_, kEps);
+  auto ln0_out_ = std::get<0>(ln0_);
+
+  auto mha_out_ = reference_mha(
+      ln0_out_.to(at_dtype), mha_w0_, mha_b0_, mha_w1_, mha_b1_)[3];
+
+  auto resid0_ = mha_out_ + x_float_;
+  auto ln1_ = at::native_layer_norm(resid0_, norm_shape, ln1_w_, ln1_b_, kEps);
+  auto ln1_out_ = std::get<0>(ln1_);
+
+  auto mlp_out_ = reference_mlp(
+      ln1_out_.to(at_dtype), mlp_w0_, mlp_b0_, mlp_w1_, mlp_b1_)[3];
+  auto at_out = (resid0_ + mlp_out_).to(at_dtype);
+
+  std::vector<c10::IValue> at_inputs = {
+      x_,
+      ln0_w_,
+      ln0_b_,
+      transformerShardTensor_Mesh(mha_w0_.view({3, E, E}), 1, mesh, communicator_).view({1, 3 * E / D, E}),
+      transformerShardTensor_Mesh(mha_b0_.view({3, E}), 1, mesh, communicator_).view({1, 3 * E / D}),
+      transformerShardTensor_Mesh(mha_w1_, 1, mesh, communicator_).unsqueeze(0),
+      mha_b1_,
+      ln1_w_,
+      ln1_b_,
+      transformerShardTensor_Mesh(mlp_w0_, 0, mesh, communicator_).unsqueeze(0),
+      transformerShardTensor_Mesh(mlp_b0_, 0, mesh, communicator_).unsqueeze(0),
+      transformerShardTensor_Mesh(mlp_w1_, 1, mesh, communicator_).unsqueeze(0),
+      mlp_b1_};
+
+  auto bytes =
+      runBenchmarkIterations(benchmark_state, executor_cache, at_inputs);
+
+  benchmark_state.SetBytesProcessed(
+      bytes * int64_t(benchmark_state.iterations()));
 }
 
 //------------------------------------------------------------------------------

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -1,0 +1,111 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <device_lower/lower2device.h>
+#include <fusion.h>
+#include <ir/all_nodes.h>
+#include <ir/builder.h>
+#include <ir/utils.h>
+#include <ops/all_ops.h>
+#include <runtime/executor.h>
+#include <scheduler/all_schedulers.h>
+#include <scheduler/utils.h>
+
+#include <benchmark/benchmark.h>
+
+#include <cuda_runtime.h>
+
+#include <sstream>
+
+#include <benchmarks/cpp/utils.h>
+#include <tests/cpp/utils.h>
+
+using namespace nvfuser;
+
+// Return reduction tensor view and output of reduction
+static void setupDivMaxSoftmaxDropoutForward(Fusion* fusion, DataType dtype) {
+  FusionGuard fg(fusion);
+
+  bool is_fp16 = dtype == DataType::Half;
+
+  TensorView* tv0 = TensorViewBuilder()
+                        .ndims(4)
+                        .dtype(dtype)
+                        .contiguity({true, std::nullopt, std::nullopt, true})
+                        .shape({-1, 1, 1, -1})
+                        .build();
+  TensorView* tv1 = makeContigTensor(4, dtype);
+
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+
+  // TODO: should be input
+  auto d16 = IrBuilder::create<Val>(1.0);
+
+  if (is_fp16) {
+    tv0 = castOp(DataType::Float, tv0);
+    tv1 = castOp(DataType::Float, tv1);
+  }
+
+  auto tv2 = div(tv1, d16);
+  auto tv3 = add(tv2, tv0);
+
+  auto tv10 = softmax(tv3, 3);
+  auto dropout_tvs = dropout(tv10, IrBuilder::create<Val>(0.9));
+  auto tv12 = dropout_tvs.mask;
+  auto tv14 = dropout_tvs.output;
+
+  if (is_fp16) {
+    tv14 = castOp(DataType::Half, tv14);
+    tv10 = castOp(DataType::Half, tv10);
+    tv3 = castOp(DataType::Half, tv3);
+  }
+
+  fusion->addOutput(tv14);
+  fusion->addOutput(tv12);
+  fusion->addOutput(tv10);
+  fusion->addOutput(tv3);
+}
+
+static void NvFuserScheduler_DivMaxSoftDropFwd(
+    benchmark::State& benchmark_state,
+    FusionExecutorCache* executor_cache,
+    DataType dtype) {
+  auto w = benchmark_state.range(0);
+  auto x = benchmark_state.range(1);
+  auto y = benchmark_state.range(2);
+  auto z = benchmark_state.range(3);
+
+  at::manual_seed(0);
+  auto options =
+      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+
+  at::Tensor t0 = at::randn({w, 1, 1, z}, options);
+  at::Tensor t1 = at::randn({w, x, y, z}, options);
+
+  std::vector<c10::IValue> at_inputs = {t0, t1};
+
+  auto bytes =
+      runBenchmarkIterations(benchmark_state, executor_cache, at_inputs);
+
+  benchmark_state.SetBytesProcessed(
+      bytes * int64_t(benchmark_state.iterations()));
+}
+
+//------------------------------------------------------------------------------
+
+NVFUSER_BENCHMARK_DEFINE(
+    nick_transformer,
+    setupDivMaxSoftmaxDropoutForward,
+    NvFuserScheduler_DivMaxSoftDropFwd,
+    DataType::Float);
+
+NVFUSER_BENCHMARK_RUN(nick_transformer)
+    // ->RangeMultiplier(2)
+    ->Ranges({{8, 8}, {16, 16}, {128, 128}, {128, 128}})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseManualTime();

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -54,7 +54,7 @@ void setupTransformerForward(Fusion* fusion, DataType dtype) {
   model->setupForward(fusion, dtype, /*sequence_parallel=*/false);
 }
 
-static at::Tensor transformerShardTensor_Mesh(
+at::Tensor transformerShardTensor_Mesh(
     at::Tensor tensor,
     const int64_t axis,
     const DeviceMesh& mesh,
@@ -63,7 +63,7 @@ static at::Tensor transformerShardTensor_Mesh(
   return nvfuser::shardTensor(tensor, axis, mesh, device_id);
 }
 
-static void transformerFwd(
+void transformerFwd(
     benchmark::State& benchmark_state,
     FusionExecutorCache* executor_cache,
     DataType dtype) {
@@ -119,7 +119,7 @@ static void transformerFwd(
 NVFUSER_BENCHMARK_DEFINE(
     TransformerForward,
     setupTransformerForward,
-    NvFuserScheduler_TransformerFwd,
+    transformerFwd,
     DataType::BFloat16);
 
 NVFUSER_BENCHMARK_RUN(TransformerForward)

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -23,23 +23,23 @@
 
 #include <benchmarks/cpp/utils.h>
 #include <csrc/multidevice/utils.h>
-#include <tests/cpp/utils.h>
 #include <tests/cpp/multidevice_transformer.h>
+#include <tests/cpp/utils.h>
 
 using namespace nvfuser;
 
 namespace {
 // Note: We test on smaller model and input sizes to avoid high error
 // accumulation for validation.
-  constexpr int64_t B = 2, E = 768, H = 16, S = 128;
+constexpr int64_t B = 2, E = 768, H = 16, S = 128;
 // Note: Dropout probabilities are set to 0. Since the dropout mask is sharded
 // it throws off the seed offset between the sharded nvFuser program and the
 // unsharded reference.
-  constexpr double kDropoutProb = 0.0, kSdpaProb = 0.0, kSdpaScale = 1e-3;
+constexpr double kDropoutProb = 0.0, kSdpaProb = 0.0, kSdpaScale = 1e-3;
 // Note parameters scaled by kParamScale following weight initialization
 // recommendations:
 // https://huggingface.co/docs/transformers/en/model_doc/gpt2#transformers.GPT2Config.initializer_range
-  constexpr double kParamScale = 0.02;
+constexpr double kParamScale = 0.02;
 } // namespace
 
 // Return reduction tensor view and output of reduction
@@ -49,7 +49,7 @@ void setupTransformerForward(Fusion* fusion, DataType dtype) {
   const int64_t D = communicator_->size(); // number of devices
 
   auto model = std::make_unique<DistributedTransformer>(
-        D, B, E, H, S, kDropoutProb, kSdpaProb);
+      D, B, E, H, S, kDropoutProb, kSdpaProb);
 
   model->setupForward(fusion, dtype, /*sequence_parallel=*/false);
 }
@@ -96,8 +96,11 @@ void transformerFwd(
       x_,
       ln0_w_,
       ln0_b_,
-      transformerShardTensor_Mesh(mha_w0_.view({3, E, E}), 1, mesh, communicator_).view({1, 3 * E / D, E}),
-      transformerShardTensor_Mesh(mha_b0_.view({3, E}), 1, mesh, communicator_).view({1, 3 * E / D}),
+      transformerShardTensor_Mesh(
+          mha_w0_.view({3, E, E}), 1, mesh, communicator_)
+          .view({1, 3 * E / D, E}),
+      transformerShardTensor_Mesh(mha_b0_.view({3, E}), 1, mesh, communicator_)
+          .view({1, 3 * E / D}),
       transformerShardTensor_Mesh(mha_w1_, 1, mesh, communicator_).unsqueeze(0),
       mha_b1_,
       ln1_w_,

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -112,27 +112,7 @@ static at::Tensor transformerShardTensor(at::Tensor tensor, TensorView* tv, Comm
 static void NvFuserScheduler_TransformerFwd(
     benchmark::State& benchmark_state,
     FusionExecutorCache* executor_cache,
-    DataType dtype) { /*
-  auto w = benchmark_state.range(0);
-  auto x = benchmark_state.range(1);
-  auto y = benchmark_state.range(2);
-  auto z = benchmark_state.range(3);
-
-  at::manual_seed(0);
-  auto options =
-      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
-
-  at::Tensor t0 = at::randn({w, 1, 1, z}, options);
-  at::Tensor t1 = at::randn({w, x, y, z}, options);
-
-  std::vector<c10::IValue> at_inputs = {t0, t1};
-
-  auto bytes =
-      runBenchmarkIterations(benchmark_state, executor_cache, at_inputs);
-
-  benchmark_state.SetBytesProcessed(
-      bytes * int64_t(benchmark_state.iterations()));*/
-
+    DataType dtype) {
   Communicator* communicator_ = &Communicator::getInstance(); // nick TODO call Communicator::getInstance().cleanup() somewhere before program exit
   const int64_t D = communicator_->size(); // number of devices
 

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -201,7 +201,7 @@ NVFUSER_BENCHMARK_DEFINE(
     TransformerForward,
     setupTransformerForward,
     NvFuserScheduler_TransformerFwd,
-    DataType::Float);
+    DataType::BFloat16);
 
 NVFUSER_BENCHMARK_RUN(TransformerForward)
     // ->RangeMultiplier(2)

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -48,7 +48,7 @@ static void setupTransformerForward(Fusion* fusion, DataType dtype) {
 
   const int64_t D = communicator_->size(); // number of devices
 
-  std::unique_ptr<DistributedTransformer> model = std::make_unique<DistributedTransformer>(
+  auto model = std::make_unique<DistributedTransformer>(
         D, B, E, H, S, kDropoutProb, kSdpaProb);
 
   model->setupForward(fusion, dtype, /*sequence_parallel=*/false);

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -116,6 +116,10 @@ static void NvFuserScheduler_TransformerFwd(
   Communicator* communicator_ = &Communicator::getInstance(); // nick TODO call Communicator::getInstance().cleanup() somewhere before program exit
   const int64_t D = communicator_->size(); // number of devices
 
+  printf("did=%ld in fwd before barrier\n", communicator_->deviceId());fflush(0);
+  communicator_->barrier();
+  printf("did=%ld in fwd after barrier\n", communicator_->deviceId());fflush(0);
+
   at::ScalarType at_dtype = data_type_to_aten(dtype);
   const auto mesh = DeviceMesh::createForNumDevices(D);
   constexpr float kEps = 1e-5;

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -53,15 +53,15 @@ void setupTransformerForward(Fusion* fusion, DataType dtype) {
 }
 
 namespace {
-  at::Tensor shardTensor(
-      at::Tensor tensor,
-      const int64_t axis,
-      const DeviceMesh& mesh,
-      Communicator* communicator) {
+at::Tensor shardTensor(
+    at::Tensor tensor,
+    const int64_t axis,
+    const DeviceMesh& mesh,
+    Communicator* communicator) {
   const auto device_id = communicator->deviceId();
   return nvfuser::shardTensor(tensor, axis, mesh, device_id);
 }
-}
+} // namespace
 
 void transformerFwd(
     benchmark::State& benchmark_state,
@@ -96,8 +96,7 @@ void transformerFwd(
       x_,
       ln0_w_,
       ln0_b_,
-      shardTensor(
-          mha_w0_.view({3, E, E}), 1, mesh, communicator)
+      shardTensor(mha_w0_.view({3, E, E}), 1, mesh, communicator)
           .view({1, 3 * E / D, E}),
       shardTensor(mha_b0_.view({3, E}), 1, mesh, communicator)
           .view({1, 3 * E / D}),

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -74,7 +74,7 @@ static at::Tensor transformerShardTensor(at::Tensor tensor, TensorView* tv, Comm
       tv->getDeviceMesh(), communicator_);
 }
 
-static void NvFuserScheduler_TransformerFwd(
+static void transformerFwd(
     benchmark::State& benchmark_state,
     FusionExecutorCache* executor_cache,
     DataType dtype) {

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -48,8 +48,6 @@ static void setupTransformerForward(Fusion* fusion, DataType dtype) {
 
   const int64_t D = communicator_->size(); // number of devices
 
-  ProfilerOptionsGuard::getCurOptions().set(ProfilerOption::EnableNocupti);
-
   std::unique_ptr<DistributedTransformer> model = std::make_unique<DistributedTransformer>(
         D, B, E, H, S, kDropoutProb, kSdpaProb);
 

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -34,7 +34,7 @@ constexpr int64_t B = 2, E = 768, H = 16, S = 128;
 // Note: Dropout probabilities are set to 0. Since the dropout mask is sharded
 // it throws off the seed offset between the sharded nvFuser program and the
 // unsharded reference.
-constexpr double kDropoutProb = 0.0, kSdpaProb = 0.0, kSdpaScale = 1e-3;
+constexpr double kDropoutProb = 0.0, kSdpaProb = 0.0;
 // Note parameters scaled by kParamScale following weight initialization
 // recommendations:
 // https://huggingface.co/docs/transformers/en/model_doc/gpt2#transformers.GPT2Config.initializer_range

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -193,8 +193,6 @@ Communicator::Communicator(
   is_available_ = parseEnv(
       rank_, size_, local_rank_, local_size_, master_addr_, master_port_);
 
-  printf("rank=%ld, size=%ld, local_rank_=%ld, local_size_=%ld\n", rank_, size_, local_rank_, local_size_);
-
   if (!is_available_) {
     return;
   }
@@ -234,15 +232,11 @@ void Communicator::cleanup() {
       "likely because Communicator::cleanup was called more than once");
   cleaned_up = true;
 
-  printf("entered cleanup on rank %ld\n", rank_);
-
   // Without this, the TCPStore server can be cleaned up before TCPStore
   // clients are created, causing an hang. This happened with
   // test_multidevice.py::test_sizes_and_ranks.
   if (is_available()) {
-    printf("calling barrier on rank %ld\n", rank_);
     barrier();
-    printf("done calling barrier on rank %ld\n", rank_);
   }
 
   store_ = nullptr;
@@ -257,9 +251,7 @@ void Communicator::cleanup() {
     // Call shutdown before destructing a ProcessGroupNCCL as instructed by
     // https://github.com/pytorch/pytorch/blob/e62073d7997c9e63896cb5289ffd0874a8cc1838/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1164-L1170.
     if (auto* pg_nccl = dynamic_cast<c10d::ProcessGroupNCCL*>(backend.get())) {
-      printf("pg shutdown on rank %ld\n", rank_);
       pg_nccl->shutdown();
-      printf("done calling pg shutdown on rank %ld\n", rank_);
     }
   }
 #endif

--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -193,6 +193,8 @@ Communicator::Communicator(
   is_available_ = parseEnv(
       rank_, size_, local_rank_, local_size_, master_addr_, master_port_);
 
+  printf("rank=%ld, size=%ld, local_rank_=%ld, local_size_=%ld\n", rank_, size_, local_rank_, local_size_);
+
   if (!is_available_) {
     return;
   }
@@ -232,11 +234,15 @@ void Communicator::cleanup() {
       "likely because Communicator::cleanup was called more than once");
   cleaned_up = true;
 
+  printf("entered cleanup on rank %ld\n", rank_);
+
   // Without this, the TCPStore server can be cleaned up before TCPStore
   // clients are created, causing an hang. This happened with
   // test_multidevice.py::test_sizes_and_ranks.
   if (is_available()) {
+    printf("calling barrier on rank %ld\n", rank_);
     barrier();
+    printf("done calling barrier on rank %ld\n", rank_);
   }
 
   store_ = nullptr;
@@ -251,7 +257,9 @@ void Communicator::cleanup() {
     // Call shutdown before destructing a ProcessGroupNCCL as instructed by
     // https://github.com/pytorch/pytorch/blob/e62073d7997c9e63896cb5289ffd0874a8cc1838/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1164-L1170.
     if (auto* pg_nccl = dynamic_cast<c10d::ProcessGroupNCCL*>(backend.get())) {
+      printf("pg shutdown on rank %ld\n", rank_);
       pg_nccl->shutdown();
+      printf("done calling pg shutdown on rank %ld\n", rank_);
     }
   }
 #endif

--- a/tests/cpp/multidevice_transformer.cpp
+++ b/tests/cpp/multidevice_transformer.cpp
@@ -395,7 +395,7 @@ std::vector<TensorView*> DistributedTransformer::mha_backwards(
 /* NVFuser benchmark manages the unique_ptr for Fusion and FusionExecutorCache,
    so update the raw pointer with this setupForward function */
 void DistributedTransformer::setupForward(
-    Fusion *fusion,
+    Fusion* fusion,
     DataType dtype,
     bool sequence_parallel) {
   FusionGuard fg(fusion);

--- a/tests/cpp/multidevice_transformer.h
+++ b/tests/cpp/multidevice_transformer.h
@@ -45,6 +45,10 @@ class DistributedTransformer {
         kDropoutProb(dropout_prob),
         kSdpaProb(sdpa_dropout_prob) {}
 
+  void setupForward(
+      Fusion *fusion,
+      DataType dtype,
+      bool sequence_parallel = false);
   std::unique_ptr<FusionExecutorCache> forward(
       DataType dtype,
       bool sequence_parallel = false);

--- a/tests/cpp/multidevice_transformer.h
+++ b/tests/cpp/multidevice_transformer.h
@@ -46,7 +46,7 @@ class DistributedTransformer {
         kSdpaProb(sdpa_dropout_prob) {}
 
   void setupForward(
-      Fusion *fusion,
+      Fusion* fusion,
       DataType dtype,
       bool sequence_parallel = false);
   std::unique_ptr<FusionExecutorCache> forward(

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -12,6 +12,7 @@
 
 #include <fusion.h>
 #include <ops/all_ops.h>
+#include <multidevice/communicator.h>
 #include <tests/cpp/multidevice.h>
 #include <tests/cpp/multidevice_transformer.h>
 #include <tests/cpp/validator.h>

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -11,8 +11,8 @@
 #include <gtest/gtest.h>
 
 #include <fusion.h>
-#include <ops/all_ops.h>
 #include <multidevice/communicator.h>
+#include <ops/all_ops.h>
 #include <tests/cpp/multidevice.h>
 #include <tests/cpp/multidevice_transformer.h>
 #include <tests/cpp/validator.h>


### PR DESCRIPTION
In this PR I added Meghan's transformer test as a benchmark. ~~It works for one process, but with > 1 processes it seems there's a hang in `cuptiActivityDisable` in the profiler. I'm opening the PR now as a draft to ask for comments on the code itself and ideas why cupti might be causing a hang. Here's the backtrace:~~

```
(gdb) bt
#0  0x00007f0f3a84fc25 in ?? () from /usr/local/cuda/compat/lib.real/libcuda.so.1
#1  0x00007f0f3b1d633e in ?? () from /usr/local/cuda/compat/lib.real/libcuda.so.1
#2  0x00007f0f3a6c57bc in ?? () from /usr/local/cuda/compat/lib.real/libcuda.so.1
#3  0x00007f0f3a774712 in ?? () from /usr/local/cuda/compat/lib.real/libcuda.so.1
#4  0x00007f0f3b197315 in ?? () from /usr/local/cuda/compat/lib.real/libcuda.so.1
#5  0x00007f10318fc867 in ?? () from /usr/local/cuda/lib64/libcupti.so.12
#6  0x00007f0f3a91ca90 in ?? () from /usr/local/cuda/compat/lib.real/libcuda.so.1
#7  0x00007f10318fcf72 in ?? () from /usr/local/cuda/lib64/libcupti.so.12
#8  0x00007f103190017a in ?? () from /usr/local/cuda/lib64/libcupti.so.12
#9  0x00007f10319002c5 in ?? () from /usr/local/cuda/lib64/libcupti.so.12
#10 0x00007f10319004c5 in cuptiActivityDisable () from /usr/local/cuda/lib64/libcupti.so.12
#11 0x0000558d644f2e42 in nvfuser::FusionProfiler::stop () at /opt/pytorch/Fuser/csrc/fusion_profiler.cpp:728
#12 0x0000558d64218788 in nvfuser::FusionExecutorCache::runFusionWithInputs (this=0x558d69c95ed0, inputs=..., forced_index_type=std::optional [no contained value], selected_device=std::optional [no contained value]) at /opt/pytorch/Fuser/csrc/runtime/fusion_executor_cache.cpp:102
#13 0x0000558d648142f7 in runBenchmarkIterations (benchmark_state=..., executor_cache=0x558d69c95ed0, aten_inputs=std::vector of length 13, capacity 13 = {...}) at /opt/pytorch/Fuser/benchmarks/cpp/utils.cpp:212
#14 0x0000558d647d02bd in NvFuserScheduler_TransformerFwd (benchmark_state=..., executor_cache=0x558d69c95ed0, dtype=...) at /opt/pytorch/Fuser/benchmarks/cpp/transformer.cpp:174
#15 0x0000558d647d0f58 in TransformerForward___GRAPH_TransformerForward_Benchmark::BenchmarkCase (this=0x558d69c04f50, benchmark_state=...) at /opt/pytorch/Fuser/benchmarks/cpp/transformer.cpp:182
#16 0x0000558d646221ac in benchmark::Fixture::Run (this=0x558d69c04f50, st=...) at /opt/pytorch/Fuser/third_party/benchmark/include/benchmark/benchmark.h:1217
#17 0x0000558d648814ea in benchmark::internal::BenchmarkInstance::Run (this=0x558d69c16890, iters=1000, thread_id=0, timer=0x7ffd47f99490, manager=0x558d689adf40, perf_counters_measurement=0x0) at /opt/pytorch/Fuser/third_party/benchmark/src/benchmark_api_internal.cc:92
#18 0x0000558d6485f88b in benchmark::internal::(anonymous namespace)::RunInThread (b=0x558d69c16890, iters=1000, thread_id=0, manager=0x558d689adf40, perf_counters_measurement=0x0) at /opt/pytorch/Fuser/third_party/benchmark/src/benchmark_runner.cc:126
#19 0x0000558d648602c4 in benchmark::internal::BenchmarkRunner::DoNIterations (this=0x558d65be0f50) at /opt/pytorch/Fuser/third_party/benchmark/src/benchmark_runner.cc:191
#20 0x0000558d64860a67 in benchmark::internal::BenchmarkRunner::DoOneRepetition (this=0x558d65be0f50) at /opt/pytorch/Fuser/third_party/benchmark/src/benchmark_runner.cc:283
#21 0x0000558d648414b3 in benchmark::internal::(anonymous namespace)::RunBenchmarks (benchmarks=std::vector of length 1, capacity 1 = {...}, display_reporter=0x558d69c189b0, file_reporter=0x0) at /opt/pytorch/Fuser/third_party/benchmark/src/benchmark.cc:350
#22 0x0000558d64842307 in benchmark::RunSpecifiedBenchmarks (display_reporter=0x558d69c189b0, file_reporter=0x0, spec="TransformerForward") at /opt/pytorch/Fuser/third_party/benchmark/src/benchmark.cc:507
#23 0x0000558d64841b24 in benchmark::RunSpecifiedBenchmarks () at /opt/pytorch/Fuser/third_party/benchmark/src/benchmark.cc:432
#24 0x0000558d6471e381 in main (argc=1, argv=0x7ffd47f9c798) at /opt/pytorch/Fuser/benchmarks/cpp/main.cpp:92
```

~~The output with 2 ranks looks like this:~~

```
did=0 in fwd
did=1 in fwd
did=0 in fwd
did=1 in fwd
did=0 in fwd
did=1 in fwd
did=0 in fwd
did=1 in fwd
---------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                       Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------------------------------------
TransformerForward___GRAPH/TransformerForward/8/16/128/128/manual_time       2076 us         6300 us          345 bytes_per_second=4.94844G/s
calling comm cleanup, size=2, did=0
entered cleanup on rank 0
calling barrier on rank 0
done calling barrier on rank 0
pg shutdown on rank 0
```