### PR TITLE
Move `num_registers` configuration from `struct CircularBufferOptions` to `struct WarpSpecialized`

### DIFF
--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -145,13 +145,13 @@ void validateCircularBufferedTensor(const TensorView* tv) {
 
   // Ensure that the warp-specialized circular buffer loop is the outer-most
   // for-loop if register sharing is enabled.
-  if (std::holds_alternative<WarpSpecialized>(tv->circularBufferOptions().type)) {
-    // short-circuit: register sharing is not used.
-    if (!std::get<WarpSpecialized>(tv->circularBufferOptions().type).num_registers.has_value()) {
-      break;
-    }
+  if (std::holds_alternative<WarpSpecialized>(
+          tv->circularBufferOptions().type) &&
+      std::get<WarpSpecialized>(tv->circularBufferOptions().type)
+          .num_registers.has_value()) {
     for (int64_t axis : c10::irange((int64_t)tv->getLoopDomain().size())) {
-      // short-circuit: only check IterDomains to the left of the circular buffer position
+      // short-circuit: only check IterDomains to the left of the circular
+      // buffer position
       if (axis >= circular_buffer_pos) {
         break;
       }

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -1398,12 +1398,18 @@ class CircularBufferInserter : private kir::ExprMutator {
     auto& circular_buffer_options =
         GpuLower::current()->circularBufferInfo().getCircularBufferOptionsFor(
             circular_buffer_loop->iter_domain());
-    bool enable_register_sharing = std::holds_alternative<WarpSpecialized>(circular_buffer_options.type) && std::get<WarpSpecialized>(circular_buffer_options.type).num_registers.has_value();
+    bool enable_register_sharing =
+        std::holds_alternative<WarpSpecialized>(circular_buffer_options.type) &&
+        std::get<WarpSpecialized>(circular_buffer_options.type)
+            .num_registers.has_value();
 
-    GpuLower::current()->kernel()->manage("enable_register_sharing", enable_register_sharing);
+    GpuLower::current()->kernel()->manage(
+        "enable_register_sharing", enable_register_sharing);
 
     if (enable_register_sharing) {
-      auto&& [decrease_num_registers, increase_num_registers] = std::get<WarpSpecialized>(circular_buffer_options.type).num_registers.value();
+      auto&& [decrease_num_registers, increase_num_registers] =
+          std::get<WarpSpecialized>(circular_buffer_options.type)
+              .num_registers.value();
 
       // Decrease registers in load warp group
       kir::SetMaxNReg* dec_reg_load_warp = IrBuilder::create<kir::SetMaxNReg>(
@@ -1414,7 +1420,7 @@ class CircularBufferInserter : private kir::ExprMutator {
       // Increase registers in compute warp group
       kir::SetMaxNReg* inc_reg_load_warp = IrBuilder::create<kir::SetMaxNReg>(
           IrBuilder::create<Val>(increase_num_registers, DataType::Index),
-          /*increase_registers*/true);
+          /*increase_registers*/ true);
       warp_dispatch_ite->elseBody().push_back(inc_reg_load_warp);
     }
 

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -242,7 +242,7 @@ struct WarpSpecialized {
   WarpSpecialized() = default;
 
   void validateRegisterSharing() {
-    // short-circuit: register sharing is not used. 
+    // short-circuit: register sharing is not used.
     if (!num_registers.has_value()) {
       return;
     }
@@ -286,8 +286,9 @@ inline std::ostream& operator<<(
   if (warp_specialized.num_registers.has_value()) {
     auto&& [decrease_num_reg, increase_num_reg] =
         warp_specialized.num_registers.value();
-    num_registers =
-        "RegisterSharing_" + decrease_num_reg + "_" + increase_num_reg;
+    std::stringstream s;
+    s << "RegisterSharing_" << decrease_num_reg << "_" << increase_num_reg;
+    num_registers = s.str();
   }
   return os << "WarpSpecializedOn" << parallel_type_str << num_registers;
 }

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -25,7 +25,8 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseCustom) {
   int64_t prefetch_distance = 1;
   int64_t tensor_outer_dim = 128;
   int64_t tensor_inner_dim = 128;
-  CircularBufferType circular_buffer_type = WarpSpecialized(ParallelType::TIDy, std::make_pair(160L, 160L));
+  CircularBufferType circular_buffer_type =
+      WarpSpecialized(ParallelType::TIDy, std::make_pair(160L, 160L));
 
   TensorView* tv0 = makeContigTensor(2);
   TensorView* tv1 = makeContigTensor(2);
@@ -60,17 +61,13 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseCustom) {
   tv3->axis(0)->parallelize(ParallelType::BIDx);
   tv3->axis(2)->parallelize(ParallelType::Bulk);
   tv3->circularBuffer(
-      number_of_stages,
-      prefetch_distance,
-      circular_buffer_type);
+      number_of_stages, prefetch_distance, circular_buffer_type);
 
   // Load TV1 into shared memory
   tv4->axis(0)->parallelize(ParallelType::BIDx);
   tv4->axis(2)->parallelize(ParallelType::Bulk);
   tv4->circularBuffer(
-      number_of_stages,
-      prefetch_distance,
-      circular_buffer_type);
+      number_of_stages, prefetch_distance, circular_buffer_type);
 
   // Split reference to parallelize TMA tile
   reference->split(-1, 32);
@@ -98,7 +95,8 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseNested) {
   int64_t prefetch_distance = 1;
   int64_t tensor_outer_dim = 128;
   int64_t tensor_inner_dim = 128;
-  CircularBufferType circular_buffer_type = WarpSpecialized(ParallelType::TIDy, std::make_pair(160L, 160L));
+  CircularBufferType circular_buffer_type =
+      WarpSpecialized(ParallelType::TIDy, std::make_pair(160L, 160L));
 
   TensorView* tv0 = makeContigTensor(2);
   TensorView* tv1 = makeContigTensor(2);
@@ -133,17 +131,13 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseNested) {
   // tv3->axis(0)->parallelize(ParallelType::BIDx);
   tv3->axis(2)->parallelize(ParallelType::Bulk);
   tv3->circularBuffer(
-      number_of_stages,
-      prefetch_distance,
-      circular_buffer_type);
+      number_of_stages, prefetch_distance, circular_buffer_type);
 
   // Load TV1 into shared memory
   // tv4->axis(0)->parallelize(ParallelType::BIDx);
   tv4->axis(2)->parallelize(ParallelType::Bulk);
   tv4->circularBuffer(
-      number_of_stages,
-      prefetch_distance,
-      circular_buffer_type);
+      number_of_stages, prefetch_distance, circular_buffer_type);
 
   // Split reference to parallelize TMA tile
   reference->split(-1, 32);

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -25,7 +25,7 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseCustom) {
   int64_t prefetch_distance = 1;
   int64_t tensor_outer_dim = 128;
   int64_t tensor_inner_dim = 128;
-  CircularBufferType circular_buffer_type = WarpSpecialized(ParallelType::TIDy);
+  CircularBufferType circular_buffer_type = WarpSpecialized(ParallelType::TIDy, std::make_pair(160L, 160L));
 
   TensorView* tv0 = makeContigTensor(2);
   TensorView* tv1 = makeContigTensor(2);
@@ -62,8 +62,7 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseCustom) {
   tv3->circularBuffer(
       number_of_stages,
       prefetch_distance,
-      circular_buffer_type,
-      std::make_pair(160L, 160L));
+      circular_buffer_type);
 
   // Load TV1 into shared memory
   tv4->axis(0)->parallelize(ParallelType::BIDx);
@@ -71,8 +70,7 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseCustom) {
   tv4->circularBuffer(
       number_of_stages,
       prefetch_distance,
-      circular_buffer_type,
-      std::make_pair(160L, 160L));
+      circular_buffer_type);
 
   // Split reference to parallelize TMA tile
   reference->split(-1, 32);
@@ -100,7 +98,7 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseNested) {
   int64_t prefetch_distance = 1;
   int64_t tensor_outer_dim = 128;
   int64_t tensor_inner_dim = 128;
-  CircularBufferType circular_buffer_type = WarpSpecialized(ParallelType::TIDy);
+  CircularBufferType circular_buffer_type = WarpSpecialized(ParallelType::TIDy, std::make_pair(160L, 160L));
 
   TensorView* tv0 = makeContigTensor(2);
   TensorView* tv1 = makeContigTensor(2);
@@ -137,8 +135,7 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseNested) {
   tv3->circularBuffer(
       number_of_stages,
       prefetch_distance,
-      circular_buffer_type,
-      std::make_pair(160L, 160L));
+      circular_buffer_type);
 
   // Load TV1 into shared memory
   // tv4->axis(0)->parallelize(ParallelType::BIDx);
@@ -146,8 +143,7 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseNested) {
   tv4->circularBuffer(
       number_of_stages,
       prefetch_distance,
-      circular_buffer_type,
-      std::make_pair(160L, 160L));
+      circular_buffer_type);
 
   // Split reference to parallelize TMA tile
   reference->split(-1, 32);
@@ -2010,7 +2006,9 @@ auto tmaCircularBufferingParams() {
       Pipelined(false),
       Pipelined(true),
       WarpSpecialized(ParallelType::TIDx),
-      WarpSpecialized(ParallelType::TIDy)};
+      WarpSpecialized(ParallelType::TIDy),
+      WarpSpecialized(ParallelType::TIDx, std::make_pair(40, 240)),
+      WarpSpecialized(ParallelType::TIDy, std::make_pair(40, 240))};
   std::vector<TmaCircularBufferingParams> values;
   for (int64_t i : {2, 4}) {
     for (int64_t j : c10::irange(-i, i)) {


### PR DESCRIPTION
- When `num_registers` is `std::nullopt` in `struct WarpSpecialized`, register sharing is not applied.
- Add `std::optional<std::pair<int64_t, int64_t>> num_registers` field to `struct WarpSpecialized`
- Add `std::nullopt` and default register sharing option to `tmaCircularBufferingParams`, so both configurations are tested in `Hopper/TmaCircularBufferingTest`