### PR TITLE
Don't try to index broadcast IDs as they should always be zero and there may not be a valid path from loop IDs

### DIFF
--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -940,11 +940,9 @@ IndexingInfo TensorIndexer::computeIndex(
   const auto loop_domains = getLoopIds(expr, id_model_);
 
   // Set aside broadcast IDs as their indices should always be zero
-  // and there may not be reachable from the loop domain
+  // and they may not be reachable from the loop domain
   std::vector<IterDomain*> broadcast_index_ids;
-  broadcast_index_ids.reserve(index_ids.size());
   std::vector<IterDomain*> non_broadcast_index_ids;
-  non_broadcast_index_ids.reserve(index_ids.size());
   for (const auto index_id : index_ids) {
     if (index_id->isBroadcast()) {
       broadcast_index_ids.push_back(index_id);


### PR DESCRIPTION
Fixes #3688 

The error of #3688 is because some of the broadcast logical IDs are not reachable when indexing. Specifically, this happened when indexing the logical IDs of a consumer tensor of a pad op. https://github.com/NVIDIA/Fuser/blob/main/csrc/device_lower/pass/index.cpp#L2698-L2699

When a consumer has broadcast logical IDs, they may not be reachable from the loop domain when inlined, and that's why the indexing traversal fails as seen in #3688. Note that for usual indexing paths such as `getLinearIndex` and `getPredicates`, they always filter out broadcast IDs from indexing because they should always use zero.

This PR always excludes broadcast IDs from indexing by changing `computeIndex`, which is the common indexing interface for all use cases including `getLinearIndex`, `getPredicates`, `getIndexFor`, etc. 

To be honest, I'm not 100% confident if we should really always ignore broadcast IDs, but I'm not aware of any concrete counter cases. Given that, this seems to be the most reasonable fix to me.
