### PR TITLE
Use nvfuser.Comunicator in python tests

### DIFF
--- a/csrc/python_frontend/communicator_bindings.cpp
+++ b/csrc/python_frontend/communicator_bindings.cpp
@@ -37,6 +37,14 @@ void bindCommunicator(py::module& nvfuser) {
       "local_rank",
       &Communicator::local_rank,
       "Returns the in-node rank associated with the current process.");
+  communicator.def(
+      "barrier",
+      [](Communicator& self) {
+        // Communicator::barrier takes an optional backend argument, which we
+        // don't use yet.
+        self.barrier();
+      },
+      "Performs a blocking barrier across all ranks.");
 }
 
 } // namespace nvfuser::python_frontend

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -7,23 +7,22 @@ import torch
 from enum import Enum, auto
 from torch.nn.attention import SDPBackend
 
-import mpi_fixtures
+import multidevice_fixtures
 import nvfuser
 import utils
 from nvfuser import DataType, FusionDefinition
 
 
-mpi_test = mpi_fixtures.mpi_test
+multidevice_test = multidevice_fixtures.multidevice_test
 
 
 @pytest.mark.mpi
-def test_sizes_and_ranks():
-    comm = nvfuser.Communicator.instance()
+def test_sizes_and_ranks(multidevice_test):
     size, rank, local_size, local_rank = (
-        comm.size(),
-        comm.rank(),
-        comm.local_size(),
-        comm.local_rank(),
+        multidevice_test.size,
+        multidevice_test.rank,
+        multidevice_test.local_size,
+        multidevice_test.local_rank,
     )
     assert size > 0
     assert rank >= 0 and rank < size
@@ -32,8 +31,8 @@ def test_sizes_and_ranks():
 
 
 @pytest.mark.mpi
-def test_pointwise(mpi_test):
-    num_devices = mpi_test.size
+def test_pointwise(multidevice_test):
+    num_devices = multidevice_test.size
     mesh = nvfuser.DeviceMesh(range(num_devices))
 
     class Model(FusionDefinition):
@@ -52,7 +51,7 @@ def test_pointwise(mpi_test):
             self.sched.parallelize(self.t0, 0, nvfuser.ParallelType.mesh_x)
 
     unsharded_input = torch.randn(num_devices, 4)
-    sharded_input = mpi_test.shard_tensor(unsharded_input, 0, mesh)
+    sharded_input = multidevice_test.shard_tensor(unsharded_input, 0, mesh)
 
     fd = Model()
     outputs = fd.execute([sharded_input])
@@ -60,7 +59,7 @@ def test_pointwise(mpi_test):
 
 
 @pytest.mark.mpi
-def test_linear(mpi_test):
+def test_linear(multidevice_test):
     class Model(FusionDefinition):
         def __init__(self, num_devices, batch, sequence, hidden):
             super().__init__()
@@ -84,10 +83,10 @@ def test_linear(mpi_test):
             for t in [self.weight, self.bias]:
                 self.sched.parallelize(t, 0, nvfuser.ParallelType.mesh_x)
 
-    d = mpi_test.size
-    rank = mpi_test.rank
+    d = multidevice_test.size
+    rank = multidevice_test.rank
 
-    torch.cuda.set_device(mpi_test.local_rank)
+    torch.cuda.set_device(multidevice_test.local_rank)
 
     b, s, e = 2, 1024, 768
     inp_tensor = torch.randn(b, s, e, device="cuda")
@@ -113,8 +112,8 @@ def test_linear(mpi_test):
 
 
 @pytest.mark.mpi
-def test_matmul_allreduce(mpi_test):
-    d, b, s, e = mpi_test.size, 1, 4, 8
+def test_matmul_allreduce(multidevice_test):
+    d, b, s, e = multidevice_test.size, 1, 4, 8
 
     class Model(FusionDefinition):
         def definition(self) -> None:
@@ -138,9 +137,9 @@ def test_matmul_allreduce(mpi_test):
                 self.sched._set_device_mesh(t, mesh)
                 self.sched.parallelize(t, 0, nvfuser.ParallelType.mesh_x)
 
-    rank = mpi_test.rank
+    rank = multidevice_test.rank
 
-    torch.cuda.set_device(mpi_test.local_rank)
+    torch.cuda.set_device(multidevice_test.local_rank)
 
     unsharded_out_grad = torch.randn(b * s, d * e, dtype=torch.half, device="cpu")
     unsharded_weight = torch.randn(d * e, e, dtype=torch.half, device="cpu")
@@ -173,8 +172,8 @@ class QkvFormat(Enum):
 )
 @pytest.mark.parametrize("qkv_format", [QkvFormat.BHSE, QkvFormat.BSHE])
 @pytest.mark.mpi
-def test_sdpa(mpi_test, qkv_format: QkvFormat):
-    d, b, s, h, e = mpi_test.size, 2, 1024, 12, 768
+def test_sdpa(multidevice_test, qkv_format: QkvFormat):
+    d, b, s, h, e = multidevice_test.size, 2, 1024, 12, 768
 
     if h % d != 0:
         pytest.skip(f"We only support even split, so {h} has to be divisible by {d}.")
@@ -233,7 +232,7 @@ def test_sdpa(mpi_test, qkv_format: QkvFormat):
                 self.sched._set_device_mesh(t, mesh)
                 self.sched.parallelize(t, 0, nvfuser.ParallelType.mesh_x)
 
-    torch.cuda.set_device(mpi_test.local_rank)
+    torch.cuda.set_device(multidevice_test.local_rank)
 
     def make_unsharded_tensor() -> torch.Tensor:
         return torch.randn(b, h, s, e // h, dtype=torch.bfloat16, device="cuda")
@@ -248,7 +247,7 @@ def test_sdpa(mpi_test, qkv_format: QkvFormat):
         expected_out.backward(out_grad)
         expected_q_grad, expected_k_grad, expected_v_grad = q.grad, k.grad, v.grad
 
-    rank = mpi_test.rank
+    rank = multidevice_test.rank
 
     # Head-parallelize Q, K, V or the attention output of an SDPA.
     def head_parallelize(t: torch.Tensor) -> torch.Tensor:
@@ -694,9 +693,9 @@ def _assert_shape_dtype(
     reason="Flash Attention is only supported on Ampere and newer devices.",
 )
 @pytest.mark.mpi
-def test_transformer_forward(mpi_test, benchmark):
-    d = mpi_test.size
-    rank = mpi_test.rank
+def test_transformer_forward(multidevice_test, benchmark):
+    d = multidevice_test.size
+    rank = multidevice_test.rank
 
     b, s, h, e = 1, 2048, 96, 12288
 
@@ -715,7 +714,7 @@ def test_transformer_forward(mpi_test, benchmark):
         "error. So I use `assert` instead of `pytest.skip`."
     )
 
-    torch.cuda.set_device(mpi_test.local_rank)
+    torch.cuda.set_device(multidevice_test.local_rank)
 
     # To reduce memory footprint, create unsharded data on CPU and copy only
     # the needed slice to GPU.
@@ -1281,13 +1280,13 @@ class TransformerBackwardFusion(FusionDefinition):
     reason="Flash Attention is only supported on Ampere and newer devices.",
 )
 @pytest.mark.mpi
-def test_transformer_backward(mpi_test, benchmark):
-    d = mpi_test.size
-    rank = mpi_test.rank
+def test_transformer_backward(multidevice_test, benchmark):
+    d = multidevice_test.size
+    rank = multidevice_test.rank
 
     b, s, h, e = 1, 2048, 96, 12288
 
-    torch.cuda.set_device(mpi_test.local_rank)
+    torch.cuda.set_device(multidevice_test.local_rank)
 
     mlp_linear0_out = torch.testing.make_tensor(
         d, b, s, e * 4 // d, dtype=torch.bfloat16, device="cpu"

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -18,10 +18,6 @@ class MpiTest:
         self._local_size = int(os.environ["OMPI_COMM_WORLD_LOCAL_SIZE"])
         self._local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
 
-        # This way, when individual tests create unsharded input, each rank
-        # receives the same data.
-        torch.manual_seed(0)
-
     @property
     def size(self):
         return self._communicator.size

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -2,19 +2,52 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import os
 import pytest
 import torch
 import torch.distributed as dist
+import transformer_engine.pytorch as te
 from enum import auto, Enum
 from functools import partial
+from mpi4py import MPI
 
 
-import transformer_engine.pytorch as te
+class MpiTest:
+    def __init__(self):
+        self._communicator = MPI.COMM_WORLD
+        self._local_size = int(os.environ["OMPI_COMM_WORLD_LOCAL_SIZE"])
+        self._local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
 
-import mpi_fixtures
+        # This way, when individual tests create unsharded input, each rank
+        # receives the same data.
+        torch.manual_seed(0)
+
+    @property
+    def size(self):
+        return self._communicator.size
+
+    @property
+    def rank(self):
+        return self._communicator.rank
+
+    @property
+    def local_size(self):
+        return self._local_size
+
+    @property
+    def local_rank(self):
+        return self._local_rank
+
+    def barrier(self):
+        self._communicator.barrier()
 
 
-mpi_test = mpi_fixtures.mpi_test
+@pytest.fixture(scope="session")
+def mpi_test():
+    fixture = MpiTest()
+    yield fixture
+    # Sync all ranks after each test for isolation.
+    fixture.barrier()
 
 
 class ComputeType(Enum):


### PR DESCRIPTION
except for test_transformer_engine.py. That test still uses the old mpi_test fixture, because it's a performance baseline that's intended to not depend on nvFuser for easy debugging.

For #3091 and #3092