### PR TITLE
HostIR integration to FusionExecutorCache PR 1/n

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,7 +661,6 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_communications.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_communicator.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_host_ir.cpp
-    ${NVFUSER_ROOT}/tests/cpp/test_multidevice_host_ir_integration.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_lower_communication.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_matmul.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_pipeline.cpp
@@ -700,7 +699,12 @@ if(BUILD_TEST)
   add_test(tutorial "${NVFUSER_ROOT}/tests/cpp/test_tutorial.cpp" "")
   list(APPEND TEST_BINARIES tutorial)
 
-  add_test(test_host_ir "${NVFUSER_ROOT}/tests/cpp/test_host_irs.cpp" "")
+  set(HOSTIR_TEST_SRCS)
+  list(APPEND HOSTIR_TEST_SRCS
+    ${NVFUSER_ROOT}/tests/cpp/test_host_irs.cpp
+    ${NVFUSER_ROOT}/tests/cpp/test_host_ir_integration.cpp
+  )
+  add_test(test_host_ir "${HOSTIR_TEST_SRCS}" "")
   list(APPEND TEST_BINARIES test_host_ir)
 
   if(BUILD_PYTHON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,6 +661,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_communications.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_communicator.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_host_ir.cpp
+    ${NVFUSER_ROOT}/tests/cpp/test_multidevice_host_ir_integration.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_lower_communication.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_matmul.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_multidevice_pipeline.cpp

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -148,6 +148,7 @@ class Val;
 #define DISPATCH_FOR_ALL_HIR_EXPRS(f) \
   f(HostUnit);                        \
   f(PostOnStream);                    \
+  f(LaunchKernel);                    \
   f(SetCurrentStream);                \
   f(GetCurrentStream);                \
   f(Wait);                            \

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -46,8 +46,8 @@ class HostIrContainer final : public Fusion {
     return kernel_executors_.push_back(std::move(ke));
   }
 
-  KernelExecutor* getKernelExecutor(int64_t index) {
-    return kernel_executors_[index].get();
+  KernelExecutor* getKernelExecutor(int64_t index) const {
+    return kernel_executors_.at(index).get();
   }
 
   Stream* getDefaultStream();

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -46,7 +46,7 @@ class HostIrContainer final : public Fusion {
     return kernel_executors_.push_back(std::move(ke));
   }
 
-  KernelExecutor* getKernelExecutor(int index) {
+  KernelExecutor* getKernelExecutor(int64_t index) {
     return kernel_executors_[index].get();
   }
 

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -41,10 +41,15 @@ class HostIrContainer final : public Fusion {
     return top_level_exprs_.push_back(expr);
   }
 
+  void pushBackKernelExecutor(KernelExecutor* ke) {
+    return kernel_executors_.push_back(ke);
+  }
+
   Stream* getDefaultStream();
 
  private:
   std::vector<Expr*> top_level_exprs_;
+  std::vector<KernelExecutor*> kernel_executors_;
   Stream* default_stream_ = nullptr;
 };
 

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -9,6 +9,9 @@
 
 #include <fusion.h>
 #include <host_ir/host_ir.h>
+#include <runtime/executor.h>
+#include <runtime/executor_abstract.h>
+#include <runtime/executor_params.h>
 
 namespace nvfuser {
 
@@ -43,6 +46,10 @@ class HostIrContainer final : public Fusion {
 
   void pushBackKernelExecutor(KernelExecutor* ke) {
     return kernel_executors_.push_back(ke);
+  }
+
+  KernelExecutor* getKernelExecutor(int index) {
+    return kernel_executors_[index];
   }
 
   Stream* getDefaultStream();

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -42,19 +42,19 @@ class HostIrContainer final : public Fusion {
     return top_level_exprs_.push_back(expr);
   }
 
-  void pushBackKernelExecutor(KernelExecutor* ke) {
-    return kernel_executors_.push_back(ke);
+  void pushBackKernelExecutor(std::unique_ptr<KernelExecutor> ke) {
+    return kernel_executors_.push_back(std::move(ke));
   }
 
   KernelExecutor* getKernelExecutor(int index) {
-    return kernel_executors_[index];
+    return kernel_executors_[index].get();
   }
 
   Stream* getDefaultStream();
 
  private:
   std::vector<Expr*> top_level_exprs_;
-  std::vector<KernelExecutor*> kernel_executors_;
+  std::vector<std::unique_ptr<KernelExecutor>> kernel_executors_;
   Stream* default_stream_ = nullptr;
 };
 

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -10,8 +10,6 @@
 #include <fusion.h>
 #include <host_ir/host_ir.h>
 #include <runtime/executor.h>
-#include <runtime/executor_abstract.h>
-#include <runtime/executor_params.h>
 
 namespace nvfuser {
 

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -313,11 +313,9 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
     args.push(input_evaluation);
   }
 
-  // placeholder for storing the outputs
-  std::vector<at::Tensor> outputs;
-
   // run the compiled kernel
-  outputs = container_->getKernelExecutor(launch_kernel->getIndex())->run(args);
+  std::vector<at::Tensor> outputs =
+      container_->getKernelExecutor(launch_kernel->getIndex())->run(args);
 
   // Store the outputs in the context
   for (auto output_idx : c10::irange(outputs.size())) {

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -330,7 +330,7 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
   // run the compiled kernel
   KernelArgumentHolder args =
       KernelArgumentHolder::createKernelArgumentHolder(input_IValues);
-  outputs = ExecutorDispatch::run(container_.getKernelExecutor(launch_kernel->getIndex()), args, std::vector<at::Tensor>{});
+  outputs = ExecutorDispatch::run(container_->getKernelExecutor(launch_kernel->getIndex()), args, std::vector<at::Tensor>{});
 
   // Store the outputs in the context
   for (auto output_idx : c10::irange(outputs.size())) {

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -328,9 +328,8 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
   std::vector<at::Tensor> outputs;
 
   // run the compiled kernel
-  KernelArgumentHolder args =
-      KernelArgumentHolder::createKernelArgumentHolder(input_IValues);
-  outputs = ExecutorDispatch::run(container_->getKernelExecutor(launch_kernel->getIndex()), args, std::vector<at::Tensor>{});
+  outputs = container_->getKernelExecutor(launch_kernel->getIndex())
+                ->run(input_IValues);
 
   // Store the outputs in the context
   for (auto output_idx : c10::irange(outputs.size())) {

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -298,6 +298,10 @@ void HostIrEvaluator::handle(Synchronize* synchronize) {
   NVFUSER_CUDA_RT_SAFE_CALL(cudaEventDestroy(event));
 }
 
+void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
+
+}
+
 void HostIrEvaluator::handle(PostOnStream* post_ir) {
   std::vector<c10::IValue> input_IValues;
   for (auto& input : post_ir->inputs()) {

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -118,6 +118,7 @@ class HostIrEvaluator final : public OptOutDispatch {
   void handle(GetCurrentStream* get_current_stream) override;
   void handle(Synchronize* synchronize) override;
   void handle(PostOnStream* post_ir) override;
+  void handle(LaunchKernel* post_ir) override;
   void handle(Communication* communication) override;
   void handle(P2PCommunication* communication) override;
   void handle(Wait* wait) override;

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -122,9 +122,9 @@ bool PostOnStream::sameAs(const Statement* other) const {
 LaunchKernel::LaunchKernel(
     IrBuilderPasskey passkey,
     int64_t hic_executor_index,
-    std::vector<Val*> inputs,
-    std::vector<Val*> outputs)
-    : Expr(passkey, std::move(inputs), std::move(outputs), {}),
+    const std::vector<Val*>& inputs,
+    const std::vector<Val*>& outputs)
+    : Expr(passkey, inputs, outputs, {}),
       hic_executor_index_(hic_executor_index) {}
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(LaunchKernel)
@@ -142,10 +142,6 @@ std::string LaunchKernel::toString(int indent_size) const {
   });
   ss << "})" << std::endl;
   return ss.str();
-}
-
-int64_t LaunchKernel::getIndex() const {
-  return hic_executor_index_;
 }
 
 std::string LaunchKernel::toInlineString(int indent_size) const {

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -124,8 +124,9 @@ LaunchKernel::LaunchKernel(
     int64_t hic_executor_index,
     const std::vector<Val*>& inputs,
     const std::vector<Val*>& outputs)
-    : Expr(passkey, inputs, outputs, {}),
-      hic_executor_index_(hic_executor_index) {}
+    : Expr(passkey, inputs, outputs, {}) {
+  addDataAttribute(hic_executor_index);
+}
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(LaunchKernel)
 

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -120,16 +120,22 @@ bool PostOnStream::sameAs(const Statement* other) const {
 }
 
 LaunchKernel::LaunchKernel(
+    IrBuilderPasskey passkey,
+    int hic_executor_index,
     std::vector<Val*> inputs,
     std::vector<Val*> outputs)
-    : Expr(std::move(inputs), std::move(outputs)) {
-
+    : Expr(passkey, std::move(inputs), std::move(outputs), {}) {
+      hic_executor_index_ = hic_executor_index; // todo initializer list
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(LaunchKernel)
 
 std::string LaunchKernel::toString(int indent_size) const {
   return "";
+}
+
+int LaunchKernel::getIndex() const {
+  return hic_executor_index_;
 }
 
 std::string LaunchKernel::toInlineString(int indent_size) const {

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -119,6 +119,27 @@ bool PostOnStream::sameAs(const Statement* other) const {
   return false;
 }
 
+LaunchKernel::LaunchKernel(
+    std::vector<Val*> inputs,
+    std::vector<Val*> outputs)
+    : Expr(std::move(inputs), std::move(outputs)) {
+
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(LaunchKernel)
+
+std::string LaunchKernel::toString(int indent_size) const {
+  return "";
+}
+
+std::string LaunchKernel::toInlineString(int indent_size) const {
+  NVF_CHECK(false, "Can not be printed inline");
+}
+
+bool LaunchKernel::sameAs(const Statement* other) const {
+  return false;
+}
+
 Stream::Stream(IrBuilderPasskey passkey, Val* index)
     : Val(passkey, ValType::Stream), index_(index) {}
 

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -121,7 +121,7 @@ bool PostOnStream::sameAs(const Statement* other) const {
 
 LaunchKernel::LaunchKernel(
     IrBuilderPasskey passkey,
-    int hic_executor_index,
+    int64_t hic_executor_index,
     std::vector<Val*> inputs,
     std::vector<Val*> outputs)
     : Expr(passkey, std::move(inputs), std::move(outputs), {}),
@@ -131,12 +131,12 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(LaunchKernel)
 
 std::string LaunchKernel::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << "LaunchKernel ("
-                          << "Inputs:{";
+  indent(ss, indent_size) << "LaunchKernel("
+                          << "Inputs: {";
   std::for_each(inputs().begin(), inputs().end(), [&ss](auto input) {
     ss << input->toString(0) << ", ";
   });
-  ss << "}, Outputs:{";
+  ss << "}, Outputs: {";
   std::for_each(outputs().begin(), outputs().end(), [&ss](auto output) {
     ss << output->toString(0) << ", ";
   });
@@ -144,16 +144,12 @@ std::string LaunchKernel::toString(int indent_size) const {
   return ss.str();
 }
 
-int LaunchKernel::getIndex() const {
+int64_t LaunchKernel::getIndex() const {
   return hic_executor_index_;
 }
 
 std::string LaunchKernel::toInlineString(int indent_size) const {
   NVF_CHECK(false, "Can not be printed inline");
-}
-
-bool LaunchKernel::sameAs(const Statement* other) const {
-  return false;
 }
 
 Stream::Stream(IrBuilderPasskey passkey, Val* index)

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -125,7 +125,7 @@ LaunchKernel::LaunchKernel(
     std::vector<Val*> inputs,
     std::vector<Val*> outputs)
     : Expr(passkey, std::move(inputs), std::move(outputs), {}) {
-      hic_executor_index_ = hic_executor_index; // todo initializer list
+  hic_executor_index_ = hic_executor_index; // todo initializer list
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(LaunchKernel)

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -124,14 +124,24 @@ LaunchKernel::LaunchKernel(
     int hic_executor_index,
     std::vector<Val*> inputs,
     std::vector<Val*> outputs)
-    : Expr(passkey, std::move(inputs), std::move(outputs), {}) {
-  hic_executor_index_ = hic_executor_index; // todo initializer list
-}
+    : Expr(passkey, std::move(inputs), std::move(outputs), {}),
+      hic_executor_index_(hic_executor_index) {}
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(LaunchKernel)
 
 std::string LaunchKernel::toString(int indent_size) const {
-  return "";
+  std::stringstream ss;
+  indent(ss, indent_size) << "LaunchKernel ("
+                          << "Inputs:{";
+  std::for_each(inputs().begin(), inputs().end(), [&ss](auto input) {
+    ss << input->toString(0) << ", ";
+  });
+  ss << "}, Outputs:{";
+  std::for_each(outputs().begin(), outputs().end(), [&ss](auto output) {
+    ss << output->toString(0) << ", ";
+  });
+  ss << "})" << std::endl;
+  return ss.str();
 }
 
 int LaunchKernel::getIndex() const {

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -119,6 +119,8 @@ class LaunchKernel : public Expr {
  public:
   using Expr::Expr;
   LaunchKernel(
+      IrBuilderPasskey passkey,
+      int hic_executor_index, // TODO
       std::vector<Val*> inputs,
       std::vector<Val*> outputs);
 
@@ -135,11 +137,15 @@ class LaunchKernel : public Expr {
     return "hir::LaunchKernel";
   }
 
+  int getIndex() const;
+
   bool sameAs(const Statement* other) const override;
 
   Expr* hostOpToPost() const {
     return attributes_.at(0)->as<Expr>();
   }
+
+  int hic_executor_index_;
 };
 
 class Stream : public Val {

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -120,7 +120,9 @@ class LaunchKernel : public Expr {
   using Expr::Expr;
   LaunchKernel(
       IrBuilderPasskey passkey,
-      int hic_executor_index, // TODO
+      int64_t hic_executor_index, // Index into the HostIrContainer's vector of
+                                  // KernelExecutors--i.e., the kernel this IR
+                                  // should launch
       std::vector<Val*> inputs,
       std::vector<Val*> outputs);
 
@@ -137,15 +139,9 @@ class LaunchKernel : public Expr {
     return "hir::LaunchKernel";
   }
 
-  int getIndex() const;
+  int64_t getIndex() const;
 
-  bool sameAs(const Statement* other) const override;
-
-  Expr* hostOpToPost() const {
-    return attributes_.at(0)->as<Expr>();
-  }
-
-  int hic_executor_index_;
+  int64_t hic_executor_index_;
 };
 
 class Stream : public Val {

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -140,11 +140,8 @@ class LaunchKernel : public Expr {
   }
 
   int64_t getIndex() const {
-    return hic_executor_index_;
+    return attribute<int64_t>(0);
   }
-
- private:
-  const int64_t hic_executor_index_;
 };
 
 class Stream : public Val {

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -144,7 +144,7 @@ class LaunchKernel : public Expr {
   }
 
  private:
-  int64_t hic_executor_index_;
+  const int64_t hic_executor_index_;
 };
 
 class Stream : public Val {

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -115,6 +115,33 @@ class PostOnStream : public Expr {
   }
 };
 
+class LaunchKernel : public Expr {
+ public:
+  using Expr::Expr;
+  LaunchKernel(
+      std::vector<Val*> inputs,
+      std::vector<Val*> outputs);
+
+  LaunchKernel(const LaunchKernel& other) = delete;
+  LaunchKernel& operator=(const LaunchKernel& other) = delete;
+  LaunchKernel(LaunchKernel&& other) = delete;
+  LaunchKernel& operator=(LaunchKernel&& other) = delete;
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+  const char* getOpString() const override {
+    return "hir::LaunchKernel";
+  }
+
+  bool sameAs(const Statement* other) const override;
+
+  Expr* hostOpToPost() const {
+    return attributes_.at(0)->as<Expr>();
+  }
+};
+
 class Stream : public Val {
  public:
   // if index is provided, the IR represents the streams whose index is the

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -123,8 +123,8 @@ class LaunchKernel : public Expr {
       int64_t hic_executor_index, // Index into the HostIrContainer's vector of
                                   // KernelExecutors--i.e., the kernel this IR
                                   // should launch
-      std::vector<Val*> inputs,
-      std::vector<Val*> outputs);
+      const std::vector<Val*>& inputs,
+      const std::vector<Val*>& outputs);
 
   LaunchKernel(const LaunchKernel& other) = delete;
   LaunchKernel& operator=(const LaunchKernel& other) = delete;
@@ -139,8 +139,11 @@ class LaunchKernel : public Expr {
     return "hir::LaunchKernel";
   }
 
-  int64_t getIndex() const;
+  int64_t getIndex() const {
+    return hic_executor_index_;
+  }
 
+ private:
   int64_t hic_executor_index_;
 };
 

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -52,8 +52,7 @@ TEST_F(HostIrIntegrationTest, LaunchKernel) {
 
   HostIrEvaluator hie(std::move(hic));
 
-  at::Tensor output = at::empty({32, 32}, options);
-  auto outputs = hie.runWithInput({{hic_in, t0}, {hic_out, output}});
+  auto outputs = hie.runWithInput({{hic_in, t0}});
 
   EXPECT_TRUE(outputs[0].equal(t0));
 }

--- a/tests/cpp/test_multidevice_host_ir_integration.cpp
+++ b/tests/cpp/test_multidevice_host_ir_integration.cpp
@@ -1,0 +1,46 @@
+// clang-format off
+/*
+* SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+* All rights reserved.
+* SPDX-License-Identifier: BSD-3-Clause
+*/
+// clang-format on
+#include <fusion.h>
+#include <host_ir/container.h>
+#include <host_ir/executor.h>
+#include <ir/all_nodes.h>
+#include <ops/all_ops.h>
+#include <tests/cpp/multidevice.h>
+
+namespace nvfuser {
+
+namespace hir {
+
+using MultiDeviceHostIrIntegrationTestParams = std::tuple<bool, bool>;
+
+class MultiDeviceHostIrIntegrationTest
+    : public MultiDeviceTest,
+      public testing::WithParamInterface<MultiDeviceHostIrIntegrationTestParams> {};
+
+TEST_P(MultiDeviceHostIrIntegrationTest, test_kernel) {
+  //auto [use_fusion_executor_cache, with_sharding_annotations] = GetParam();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Manual,
+    MultiDeviceHostIrIntegrationTest,
+    testing::Combine(testing::Bool(), testing::Bool()),
+    [](const testing::TestParamInfo<MultiDeviceHostIrTestParams>& info)
+        -> std::string {
+      std::string s;
+      s += std::get<0>(info.param) ? "useFusionExecutorCache"
+                                   : "useFusionExecutor";
+      s += "_";
+      s += std::get<1>(info.param) ? "withShardingAnnotations"
+                                   : "withoutShardingAnnotations";
+      return s;
+    });
+
+} // namespace hir
+
+} // namespace nvfuser

--- a/tests/cpp/test_multidevice_host_ir_integration.cpp
+++ b/tests/cpp/test_multidevice_host_ir_integration.cpp
@@ -44,23 +44,24 @@ TEST_P(MultiDeviceHostIrIntegrationTest, test_kernel) {
   hic->pushBackKernelExecutor(ke.get());
 
   // [Step 5)a.] Create PostOnStream Irs representing executing the Fusion
-  std::vector<Val*> inputs = {tv0};
-  std::vector<Val*> outputs = {tv1};
+  std::vector<Val*> lk_inputs = {tv0};
+  std::vector<Val*> lk_outputs = {tv1};
   auto launch_kernel =
-      IrBuilder::create<LaunchKernel>(0, inputs, outputs); // todo: change to segment index instead of hardcoding index 0 in the kernel_executors_ vector
+      IrBuilder::create<LaunchKernel>(0, lk_inputs, lk_outputs); // todo: change to segment index instead of hardcoding index 0 in the kernel_executors_ vector
 
   // [Step 6)] Define the Host program
   hic->pushBackTopLevelExprs(launch_kernel);
 
   // [Step 7)] Define the Host program's global I/O
-  hic->addInput(inputs.back());
-  hic->addOutput(outputs.back());
+  hic->addInput(lk_inputs.back());
+  hic->addOutput(lk_outputs.back());
 
   // [Step 8)] Evaluate the Host program
   HostIrEvaluatorParams params;
   params.use_fusion_executor_cache = false;
   HostIrEvaluator hie(std::move(hic), communicator_, params);
 
+  at::Tensor output = at::empty({32, 32}, options);
   auto outputs = hie.runWithInput({{inputs.back(), input}, {outputs.back(), output}});
 
   // validate the obtained results

--- a/tests/cpp/test_multidevice_host_ir_integration.cpp
+++ b/tests/cpp/test_multidevice_host_ir_integration.cpp
@@ -34,7 +34,7 @@ TEST_F(MultiDeviceTest, LaunchKernel) {
   auto hic = std::make_unique<HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
 
-  hic->pushBackKernelExecutor(ke.get());
+  hic->pushBackKernelExecutor(std::move(ke));
 
   IrCloner ir_cloner(hic.get());
   auto tv2 = ir_cloner.clone(tv0);

--- a/tests/cpp/test_multidevice_host_ir_integration.cpp
+++ b/tests/cpp/test_multidevice_host_ir_integration.cpp
@@ -30,7 +30,7 @@ INSTANTIATE_TEST_SUITE_P(
     Manual,
     MultiDeviceHostIrIntegrationTest,
     testing::Combine(testing::Bool(), testing::Bool()),
-    [](const testing::TestParamInfo<MultiDeviceHostIrTestParams>& info)
+    [](const testing::TestParamInfo<MultiDeviceHostIrIntegrationTestParams>& info)
         -> std::string {
       std::string s;
       s += std::get<0>(info.param) ? "useFusionExecutorCache"


### PR DESCRIPTION
In this PR I add a vector of KernelExecutor* to HostIrContainer, and new HostIR called LaunchKernel that takes an index to the vector and launches the kernel. I also add a test to verify correctness.

This is the first in a series of PRs for integration with FusionExecutorCache.