### PR TITLE
Refactoring for PR #3708

### DIFF
--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -938,23 +938,7 @@ IndexingInfo TensorIndexer::computeIndex(
     const std::vector<IterDomain*>& index_ids,
     const std::vector<ForLoop*>& for_loops) const {
   const auto loop_domains = getLoopIds(expr, id_model_);
-
-  // Set aside broadcast IDs as their indices should always be zero
-  // and they may not be reachable from the loop domain
-  std::vector<IterDomain*> broadcast_index_ids;
-  std::vector<IterDomain*> non_broadcast_index_ids;
-  for (const auto index_id : index_ids) {
-    if (index_id->isBroadcast()) {
-      broadcast_index_ids.push_back(index_id);
-    } else {
-      non_broadcast_index_ids.push_back(index_id);
-    }
-  }
-
-  const ValGroups loop_groups = traversalGraph().toGroups(loop_domains);
-  const ExprPath<ExprGroup> traversal_path = IndexingTraversal::getExprsBetween(
-      expr, traversalGraph(), loop_domains, non_broadcast_index_ids);
-
+  const ExprPath<ExprGroup> traversal_path = getIndexingPath(expr, index_ids);
   const std::unordered_map<ValGroup, Val*> initial_index_map =
       getInitialIndexMap(loop_domains, for_loops);
 
@@ -994,9 +978,11 @@ IndexingInfo TensorIndexer::computeIndex(
 
   // Fill in broadcast index groups by zero
   auto index_map = index_compute.indexMap();
-  for (const auto broadcast_index_id : broadcast_index_ids) {
-    index_map[traversalGraph().toGroup(broadcast_index_id)] =
-        broadcast_index_id->fusion()->zeroVal();
+  for (const auto index_id : index_ids) {
+    if (index_id->isBroadcast()) {
+      index_map[traversalGraph().toGroup(index_id)] =
+          index_id->fusion()->zeroVal();
+    }
   }
 
   IndexingInfo info{
@@ -1262,6 +1248,25 @@ std::vector<PredicateInfo> TensorIndexer::getPredicates(
   }
 
   return info_vec;
+}
+
+ExprPath<ExprGroup> TensorIndexer::getIndexingPath(
+    const Expr* expr,
+    const std::vector<IterDomain*>& index_ids) const {
+  // Exclude broadcast IDs as their indices should always be zero
+  // and they may not be reachable from the loop domain
+  std::vector<IterDomain*> non_broadcast_index_ids;
+  for (const auto index_id : index_ids) {
+    if (!index_id->isBroadcast()) {
+      non_broadcast_index_ids.push_back(index_id);
+    }
+  }
+
+  return IndexingTraversal::getExprsBetween(
+      expr,
+      traversalGraph(),
+      getLoopIds(expr, id_model_),
+      non_broadcast_index_ids);
 }
 
 std::pair<std::vector<ValGroup>, std::vector<Val*>> TensorIndexer::

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -118,6 +118,12 @@ class TensorIndexer {
       const std::vector<ForLoop*>& for_loops,
       ForLoop* unswitched_loop = nullptr) const;
 
+  // Get the indexing traversal path for indexing a given list of IDs
+  // for a given expr
+  ExprPath<ExprGroup> getIndexingPath(
+      const Expr* expr,
+      const std::vector<IterDomain*>& index_ids) const;
+
  private:
   // Build a map of loop groups to their index Vals. See the comment
   // on loop_index_map_.


### PR DESCRIPTION
Just small minor refactoring to add `TensorIndexer::getIndexingPath`, which is required in #3708. Nothing should change with this PR itself.