### PR TITLE
nvtx2 is deprecated

### DIFF
--- a/csrc/instrumentation.h
+++ b/csrc/instrumentation.h
@@ -10,7 +10,7 @@
 #include <exceptions.h>
 #include <utils.h>
 
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 
 // NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <stdio.h>


### PR DESCRIPTION
Tested:

```bash
$ nsys profile pytest tests/python/test_pointwise.py -k test_issue_2395
$ nsys stats --report nvtx_sum report1.nsys-rep | grep FusionExecutorCache
     13.5         82349003          1  82349003.0  82349003.0  82349003  82349003          0.0  PushPop  :FusionExecutorCache::runFusionWithInputs
      2.1         12982267          1  12982267.0  12982267.0  12982267  12982267          0.0  PushPop  :FusionExecutorCache::getKernelRuntimeFor
      2.1         12946720          1  12946720.0  12946720.0  12946720  12946720          0.0  PushPop  :FusionExecutorCache::getKernelRuntimeFor::compileNewKRT
      0.0           118345          1    118345.0    118345.0    118345    118345          0.0  PushPop  :FusionExecutorCache::prepareInputs
      0.0              200          1       200.0       200.0       200       200          0.0  PushPop  :FusionExecutorCache::getKernelRuntimeFor::reuseKRT
```