### PR TITLE
Flush debug print to avoid truncated output

### DIFF
--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -419,6 +419,8 @@ std::ostream& Fusion::print(std::ostream& os, bool include_tensor_transforms)
   }
   os << "} // %kernel\n";
 
+  os << std::flush;
+
   return os;
 }
 
@@ -431,6 +433,8 @@ void Fusion::printKernel(const CompileParams& compile_params) {
   GpuLower lower(this, compile_params);
   lower.run();
   debug() << codegen::generateCudaKernel(lower.kernel());
+
+  debug() << std::flush;
 }
 
 std::unordered_map<
@@ -538,6 +542,8 @@ void Fusion::printMath(bool from_outputs_only) {
     debug() << expr;
   }
   debug() << "} // %kernel_math \n\n";
+
+  debug() << std::flush;
 }
 
 std::vector<Val*> Fusion::inputsAndCreated() {


### PR DESCRIPTION
Quite commonly, debug dump like `NVFUSER_DUMP=fusion_ir_math` gets truncated when a device-side error happens. This should at least avoid that with some of fusion dump.