### PR TITLE
Extend the shortcut logic for loop promotion with cyclic graphs

### DIFF
--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -754,7 +754,7 @@ void IdModel::initializeLoopGraph(const StatefulInliningInfo& info) {
   }
 }
 
-ValGraph& IdModel::buildLoopGraph() {
+ValGraph& IdModel::buildLoopGraph(bool force_full_loop_promotion_analysis) {
   // Make sure the depedent graphs are already built
   maybeBuildGraph(IdMappingMode::EXACT);
   maybeBuildGraph(IdMappingMode::PERMISSIVE);
@@ -767,7 +767,10 @@ ValGraph& IdModel::buildLoopGraph() {
   validateLoopGraphHasNoSelfMappedLeafDomains();
 
   loop_promotion_map_ = LoopPromotionMapBuilder::get(
-      *this, inlining_info, loop_promotion_map_builder_callback_);
+      *this,
+      inlining_info,
+      loop_promotion_map_builder_callback_,
+      force_full_loop_promotion_analysis);
 
   // New domains are added. Make sure there's still no self mapping in
   // the loop domains

--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -198,7 +198,11 @@ class IdModel : public PolymorphicBase {
   // Fills disjoint_ids_[IdMappingMode::LOOP]. Map only inlined
   // domains that are mapped in the permissive graph. Build the Exact
   // and Permissive graphs as well if not yet done.
-  ValGraph& buildLoopGraph();
+  //
+  // (For debugging only) When force_full_loop_promotion_analysis is
+  // true, it always performs the full loop promotion analysis even
+  // when it's possible to take a quicker shortcut.
+  ValGraph& buildLoopGraph(bool force_full_loop_promotion_analysis = false);
 
   // Build a graph. Dependent graphs are also built if not yet done.
   void buildGraph(IdMappingMode mode);

--- a/csrc/id_model/loop_promotion.h
+++ b/csrc/id_model/loop_promotion.h
@@ -48,16 +48,22 @@ class LoopPromotionMapBuilder {
   // Build a map of loop groups to IterDomains that represent actual
   // loops. The map is built based on the broadcast resolution with
   // root domains between inlined producer and consumer tensors.
+  //
+  // (For debugging only) When force_full_loop_promotion_analysis is
+  // true, it always performs the full loop promotion analysis even
+  // when it's possible to take a quicker shortcut.
   static std::unordered_map<ValGroup, IterDomain*> get(
       IdModel& id_model,
       const StatefulInliningInfo& inlining_info,
-      LoopPromotionMapBuilderCallback* callback = nullptr);
+      LoopPromotionMapBuilderCallback* callback = nullptr,
+      bool force_full_loop_promotion_analysis = false);
 
  private:
   LoopPromotionMapBuilder(
       IdModel& id_model,
       const StatefulInliningInfo& inlining_info,
-      LoopPromotionMapBuilderCallback* callback = nullptr);
+      LoopPromotionMapBuilderCallback* callback = nullptr,
+      bool force_full_loop_promotion_analysis = false);
 
   std::unordered_map<ValGroup, IterDomain*> build();
 
@@ -164,6 +170,11 @@ class LoopPromotionMapBuilder {
   IdModel& id_model_;
   const StatefulInliningInfo& inlining_info_;
   LoopPromotionMapBuilderCallback* callback_ = nullptr;
+
+  // (For debugging only) When force_full_loop_promotion_analysis_ is
+  // true, it always performs the full loop promotion analysis even
+  // when it's possible to take a quicker shortcut.
+  bool force_full_loop_promotion_analysis_ = false;
 };
 
 } // namespace nvfuser

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -135,7 +135,7 @@ class IdModelTester : public LoopPromotionMapBuilderCallback {
         /*loop_promotion_map_builder_callback=*/this);
 
     // Only build the loop graph
-    id_model->buildLoopGraph();
+    id_model->buildLoopGraph(/*force_full_loop_promotion_analysis=*/true);
   }
 
   void postStep1(


### PR DESCRIPTION
This PR extends the condition to skip the full loop promotion analysis. Specifically, previously, it skips only if each loop group has a single exact group, in which case it's obvious any ID can be a promotion ID. That has been good enough so far, but I'm discovering a case where I can't avoid having a loop group that includes both concrete and broadcast IDs. As long as each loop group has only one single concrete exact group, loop promotion is still a trivial problem since we can just pick any ID from the concrete group.

This change should have no actual change but since different IDs may be picked as promotion IDs, actual generated code may look different, but differences should be just variable name changes.