### PR TITLE
Clear expanded extent in TensorDomain::flatten

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3785,6 +3785,7 @@ TensorDomain* TensorDomain::flatten(int64_t start_dim, int64_t end_dim) {
                           (is_rfactor_dim && inp_id->isBroadcast())
                               ? IterType::Iteration
                               : inp_id->getIterType())
+                      .expanded_extent(nullptr)
                       .build();
     new_root_domain.push_back(out_id);
   }


### PR DESCRIPTION
This doesn't seem to break anything, but it's just strange to have iter domains like `iS1{8 ex 8}`, i.e., a concrete iter domain that appears to be extended to the same actual extent.