### PR TITLE
Remove KernelExecutor::fusion_

### DIFF
--- a/csrc/runtime/executor.h
+++ b/csrc/runtime/executor.h
@@ -144,7 +144,7 @@ class KernelExecutor : public ExecutorAbstract {
     post_lowering_hooks_.push_back(std::move(hook));
   }
 
-  // Function to query whether compilation was attempted for a `KernelExecutor`
+  // Returns whether this `KernelExecutor` has a compiled kernel to execute.
   bool isCompiled() const override {
     if (compiled_kernel_ != nullptr) {
       NVF_ERROR(compiled_kernel_->function != nullptr);

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -8068,7 +8068,7 @@ TEST_F(NVFuserTest, AvoidCachingSliceInput) {
       continue;
     }
     const auto* ke = exec->as<KernelExecutor>();
-    for (auto expr : ke->fusion()->exprs()) {
+    for (auto expr : ke->kernel()->exprs()) {
       if (expr->isA<SliceOp>()) {
         auto slice = expr->as<SliceOp>();
         EXPECT_EQ(slice->in()->getMemoryType(), MemoryType::Global);

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -4155,8 +4155,7 @@ TEST_P(ResizeSchedulerTest, PropagateSliceToInputs) {
         runtime->schedulerHeuristics()->heuristicsList().front();
     EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
     Fusion* scheduled_fusion =
-        dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())
-            ->fusion();
+        runtime->executors().at(0)->as<KernelExecutor>()->kernel();
     checkLoopDomainEquivalence(
         scheduled_fusion->outputs().at(0)->as<TensorView>());
   }
@@ -4245,8 +4244,7 @@ TEST_P(ResizeSchedulerTest, PropagateSliceToInputsWithReshape1) {
         runtime->schedulerHeuristics()->heuristicsList().front();
     EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
     Fusion* scheduled_fusion =
-        dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())
-            ->fusion();
+        runtime->executors().at(0)->as<KernelExecutor>()->kernel();
     checkLoopDomainEquivalence(
         scheduled_fusion->outputs().at(0)->as<TensorView>());
   }
@@ -4331,8 +4329,7 @@ TEST_P(ResizeSchedulerTest, PropagateSliceToInputsWithReshape2) {
         runtime->schedulerHeuristics()->heuristicsList().front();
     EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
     Fusion* scheduled_fusion =
-        dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())
-            ->fusion();
+        runtime->executors().at(0)->as<KernelExecutor>()->kernel();
     checkLoopDomainEquivalence(
         scheduled_fusion->outputs().at(0)->as<TensorView>());
   }
@@ -4441,8 +4438,7 @@ TEST_P(ResizeSchedulerTest, PropagateMultipleSlicesToInputs1) {
         runtime->schedulerHeuristics()->heuristicsList().front();
     EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
     Fusion* scheduled_fusion =
-        dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())
-            ->fusion();
+        runtime->executors().at(0)->as<KernelExecutor>()->kernel();
     checkLoopDomainEquivalence(
         scheduled_fusion->outputs().at(0)->as<TensorView>());
   }
@@ -4648,7 +4644,7 @@ TEST_F(ResizeSchedulerTest, PropagateMultipleSlicesToInputs3) {
       runtime->schedulerHeuristics()->heuristicsList().front();
   EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
   Fusion* scheduled_fusion =
-      dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())->fusion();
+      runtime->executors().at(0)->as<KernelExecutor>()->kernel();
   checkLoopDomainEquivalence(
       scheduled_fusion->outputs().at(0)->as<TensorView>());
 }
@@ -4788,8 +4784,7 @@ TEST_P(ResizeSchedulerTest, PropagateMultipleSlicesToInputs5) {
         runtime->schedulerHeuristics()->heuristicsList().front();
     EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
     Fusion* scheduled_fusion =
-        dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())
-            ->fusion();
+        runtime->executors().at(0)->as<KernelExecutor>()->kernel();
     checkLoopDomainEquivalence(
         scheduled_fusion->outputs().at(0)->as<TensorView>());
   }
@@ -4978,8 +4973,7 @@ TEST_P(ResizeSchedulerTest, SliceRotateCat) {
         runtime->schedulerHeuristics()->heuristicsList().front();
     EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
     Fusion* scheduled_fusion =
-        dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())
-            ->fusion();
+        runtime->executors().at(0)->as<KernelExecutor>()->kernel();
     checkLoopDomainEquivalence(
         scheduled_fusion->outputs().at(0)->as<TensorView>());
   }
@@ -5122,8 +5116,7 @@ TEST_P(ResizeSchedulerTest, SliceRotateCatResidual) {
         runtime->schedulerHeuristics()->heuristicsList().front();
     EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
     Fusion* scheduled_fusion =
-        dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())
-            ->fusion();
+        runtime->executors().at(0)->as<KernelExecutor>()->kernel();
     checkLoopDomainEquivalence(
         scheduled_fusion->outputs().at(0)->as<TensorView>());
   }
@@ -5310,8 +5303,7 @@ TEST_P(ResizeSchedulerTest, PropagatePadToInputs) {
         runtime->schedulerHeuristics()->heuristicsList().front();
     EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
     Fusion* scheduled_fusion =
-        dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())
-            ->fusion();
+        runtime->executors().at(0)->as<KernelExecutor>()->kernel();
     checkLoopDomainEquivalence(
         scheduled_fusion->outputs().at(0)->as<TensorView>());
   }
@@ -5412,8 +5404,7 @@ TEST_P(ResizeSchedulerTest, PropagateCatToInputs) {
         runtime->schedulerHeuristics()->heuristicsList().front();
     EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
     Fusion* scheduled_fusion =
-        dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())
-            ->fusion();
+        runtime->executors().at(0)->as<KernelExecutor>()->kernel();
     checkLoopDomainEquivalence(
         scheduled_fusion->outputs().at(0)->as<TensorView>());
   }

--- a/tests/cpp/test_rope.cpp
+++ b/tests/cpp/test_rope.cpp
@@ -924,7 +924,7 @@ TEST_F(RopeTest, EndingRepeat) {
       runtime->schedulerHeuristics()->heuristicsList().front();
   EXPECT_EQ(heuristic_param->scheduler_type, SchedulerType::Resize);
   Fusion* scheduled_fusion =
-      dynamic_cast<KernelExecutor*>(runtime->executors().at(0).get())->fusion();
+      runtime->executors().at(0)->as<KernelExecutor>()->kernel();
 
   // Check the loop domain of the reference. It should look like:
   //


### PR DESCRIPTION
It's no longer necessary after https://github.com/NVIDIA/Fuser/pull/3263. 

This partially rolls back https://github.com/NVIDIA/Fuser/pull/1930. 