### PR TITLE
Don't skip the full loop promotion analysis just because there's no root resolution map

### DIFF
--- a/csrc/id_model/loop_promotion.cpp
+++ b/csrc/id_model/loop_promotion.cpp
@@ -146,8 +146,7 @@ std::unordered_map<ValGroup, IterDomain*> LoopPromotionMapBuilder::build() {
   // analysis. These are not comprehensive. Should add more conditions
   // if necessary.
   if (!force_full_loop_promotion_analysis_ &&
-      (inlining_info_.p2c_root_broadcast_resolution_map.empty() ||
-       isLoopGraphAlmostUniform(id_model_))) {
+      isLoopGraphAlmostUniform(id_model_)) {
     return buildWithNoBroadcast();
   }
 

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -2672,4 +2672,38 @@ TEST_F(IdModelTest, LoopGraphWithSetLoopDomain) {
   }
 }
 
+// Repro for the shortcut logic based on
+// inlining_info_.p2c_root_broadcast_resolution_map.
+TEST_F(IdModelTest, LoopPromotionCyclicGraphWar) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(1);
+  fusion.addInput(tv0);
+
+  auto tv1 = set(tv0);
+  auto tv2 = broadcast(tv1, {true, false});
+  auto tv3 = sin(tv2);
+  fusion.addOutput(tv3);
+
+  tv3->flatten();
+  tv3->split(0, 4);
+  TransformPropagatorWithCheck propagator(tv3);
+  MaxLogicalDomainInfoSpanningTree(tv3).traverse(&propagator);
+
+  inlineMost();
+
+  IdModel id_model(&fusion);
+
+  for (auto tv : {tv1, tv2, tv3}) {
+    for (const auto i : c10::irange(tv->getLoopDomain().size())) {
+      auto promotion_id = getLoopPromotion(tv->getLoopDomain().at(i), id_model);
+      EXPECT_TRUE(
+          id_model.idGraph(IdMappingMode::EXACT)
+              .disjointValSets()
+              .strictAreMapped(promotion_id, tv3->getLoopDomain().at(i)));
+    }
+  }
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
I really want to spend some significant time to redesign the loop promotion so that we don't need the loop promotion WAR for cyclic graphs, but just found a simple bug with the WAR. Specifically, for whatever reasons, I thought it's safe to skip the full analysis whenever `inlining_info_.p2c_root_broadcast_resolution_map` is empty and just thought it's fine to pick which ID out of a loop group as its promotion ID. This map is filled when a broadcast ID is used with a concrete ID, so I think I thought if that's empty, there's no inlining, so there should be nothing to worry about.

However, that is not actually right. Even if a broadcast is not concretized, if its merged with a concrete ID, we can't just randomly pick an ID as the promotion. For example, here's a snippet from the added test:

```
  auto tv0 = makeSymbolicTensor(1);
  fusion.addInput(tv0);

  auto tv1 = set(tv0);
  auto tv2 = broadcast(tv1, {true, false});
  auto tv3 = sin(tv2);
  fusion.addOutput(tv3);

  tv3->flatten();
  tv3->split(0, 4);
  TransformPropagatorWithCheck propagator(tv3);
  MaxLogicalDomainInfoSpanningTree(tv3).traverse(&propagator);

  inlineMost();
```

In this case, the fusion IR looks like:

```
%kernel {
T1_l_float[iS12{( ceilDiv(i0, 4) )}, iS13{4}] ca_pos( 2 )
   = Set( T0_g_float[iS14{( ceilDiv(i0, 4) )}, iS15{4}], cache_op=Streaming )
T2_l_float[iS10{( ceilDiv(i0, 4) )}, iS11{4}] ca_pos( 2 ) produce_pos( 2 )
   = broadcast( T1_l_float[iS12{( ceilDiv(i0, 4) )}, iS13{4}] ca_pos( 2 ), flags = {true, false} )
T3_g_float[iS7{( ceilDiv(i0, 4) )}, iS8{4}] ca_pos( 2 ) produce_pos( 2 )
   = sinf(T2_l_float[iS10{( ceilDiv(i0, 4) )}, iS11{4}] ca_pos( 2 ) produce_pos( 2 ));

TransformPrinter :
T0_g_float[iS14{( ceilDiv(i0, 4) )}, iS15{4}]
 logical domain : (iS0{i0})
 contiguity: f
  Split: iS0{i0} by factor 4 -> iS14{( ceilDiv(i0, 4) )}, iS15{4}
 loop domain : (iS14{( ceilDiv(i0, 4) )}, iS15{4})
T1_l_float[iS12{( ceilDiv(i0, 4) )}, iS13{4}] ca_pos( 2 )
 logical domain : (iS1{i0})
 contiguity: t
  Split: iS1{i0} by factor 4 -> iS12{( ceilDiv(i0, 4) )}, iS13{4}
 loop domain : (iS12{( ceilDiv(i0, 4) )}, iS13{4})
T2_l_float[iS10{( ceilDiv(i0, 4) )}, iS11{4}] ca_pos( 2 ) produce_pos( 2 )
 logical domain : (bS2{1}, iS3{i0})
 contiguity: n t
  Merge: bS2{1} and iS3{i0} -> iS9{i0}
  Split: iS9{i0} by factor 4 -> iS10{( ceilDiv(i0, 4) )}, iS11{4}
 loop domain : (iS10{( ceilDiv(i0, 4) )}, iS11{4})
T3_g_float[iS7{( ceilDiv(i0, 4) )}, iS8{4}] ca_pos( 2 ) produce_pos( 2 )
 logical domain : (bS4{1}, iS5{i0})
 contiguity: n t
  Merge: bS4{1} and iS5{i0} -> iS6{i0}
  Split: iS6{i0} by factor 4 -> iS7{( ceilDiv(i0, 4) )}, iS8{4}
 loop domain : (iS7{( ceilDiv(i0, 4) )}, iS8{4})
} // %kernel
```

As you can see, for example, the outermost IDs are all mapped in the loop group since they are all inlined: `{iS12, iS10, iS7}`. Since this fusion has no concretization of the broadcast IDs initially introduced at `T2`, [this path](https://github.com/NVIDIA/Fuser/pull/3730/files#diff-89522f3f5461bae9ff9210496c22e47788a478181ffb31d209a9355140b0f908L151) is going to be taken. The logic of `buildWithNoBroadcast` is designed to be pretty simple because it's supposed to be only used when all IDs of a loop group are exact mapped (except for broadcast IDs, which are just ignored). Clearly, in this case, we can't just arbitrary pick any ID for this loop group of `{iS12, iS10, iS7}`. `iS10` and `iS7` are valid promotion IDs, whereas `iS12` is not since it lacks the broadcast ID.