### PR TITLE
FusionDefinition.execute returns output shardings. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ endif()
 
 if(BUILD_PYTHON)
   list(APPEND NVFUSER_SRCS
+    ${NVFUSER_SRCS_DIR}/python_frontend/distributed_tensor.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_cache.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_definition.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/fusion_state.cpp

--- a/csrc/python_frontend/distributed_tensor.cpp
+++ b/csrc/python_frontend/distributed_tensor.cpp
@@ -1,0 +1,25 @@
+#include <exceptions.h>
+#include <python_frontend/distributed_tensor.h>
+#include <utils.h>
+
+namespace nvfuser::python_frontend {
+
+void DistributedTensor::setAxisIsShardedOn(
+    const int64_t axis,
+    const ParallelType parallel_type) {
+  const auto i = axis_sharded_on_.find(parallel_type);
+  NVF_CHECK(
+      i == axis_sharded_on_.end(),
+      "Parallel type ",
+      parallel_type,
+      " was already used to shard axis ",
+      i->second);
+  axis_sharded_on_[parallel_type] = axis;
+}
+
+int64_t DistributedTensor::axisShardedOn(
+    const ParallelType parallel_type) const {
+  return getOrDefault(axis_sharded_on_, parallel_type, -1L);
+}
+
+} // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/distributed_tensor.cpp
+++ b/csrc/python_frontend/distributed_tensor.cpp
@@ -8,6 +8,7 @@
 
 #include <exceptions.h>
 #include <python_frontend/distributed_tensor.h>
+#include <type.h>
 #include <utils.h>
 
 namespace nvfuser::python_frontend {
@@ -15,6 +16,7 @@ namespace nvfuser::python_frontend {
 void DistributedTensor::setAxisIsShardedOn(
     const int64_t axis,
     const ParallelType parallel_type) {
+  NVF_CHECK(isParallelTypeDeviceDim(parallel_type));
   const auto i = axis_sharded_on_.find(parallel_type);
   NVF_CHECK(
       i == axis_sharded_on_.end(),

--- a/csrc/python_frontend/distributed_tensor.cpp
+++ b/csrc/python_frontend/distributed_tensor.cpp
@@ -1,3 +1,11 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
 #include <exceptions.h>
 #include <python_frontend/distributed_tensor.h>
 #include <utils.h>

--- a/csrc/python_frontend/distributed_tensor.cpp
+++ b/csrc/python_frontend/distributed_tensor.cpp
@@ -17,6 +17,7 @@ void DistributedTensor::setAxisIsShardedOn(
     const int64_t axis,
     const ParallelType parallel_type) {
   NVF_CHECK(isParallelTypeDeviceDim(parallel_type));
+  NVF_CHECK(mesh_.size() > 0, "Cannot shard a non-distributed tensor.");
   const auto i = axis_sharded_on_.find(parallel_type);
   NVF_CHECK(
       i == axis_sharded_on_.end(),

--- a/csrc/python_frontend/distributed_tensor.h
+++ b/csrc/python_frontend/distributed_tensor.h
@@ -14,6 +14,9 @@
 
 namespace nvfuser::python_frontend {
 
+// A class that represents a distributed tensor. It wraps a local tensor, a
+// mesh, and a mapping from mesh axes to tensor axes. If the mesh is empty,
+// it degenerates into a non-distributed tensor.
 class DistributedTensor {
  public:
   explicit DistributedTensor(

--- a/csrc/python_frontend/distributed_tensor.h
+++ b/csrc/python_frontend/distributed_tensor.h
@@ -1,0 +1,46 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <ATen/core/TensorBody.h>
+
+#include <multidevice/device_mesh.h>
+#include <type.h>
+
+namespace nvfuser::python_frontend {
+
+class DistributedTensor {
+ public:
+  explicit DistributedTensor(
+      at::Tensor local_tensor,
+      const DeviceMesh& mesh = DeviceMesh())
+      : local_(local_tensor), mesh_(mesh) {}
+  DistributedTensor(const DistributedTensor&) = delete;
+  DistributedTensor& operator=(const DistributedTensor&) = delete;
+  DistributedTensor(DistributedTensor&&) = default;
+  DistributedTensor& operator=(DistributedTensor&&) = default;
+
+  const DeviceMesh& mesh() const {
+    return mesh_;
+  }
+
+  at::Tensor local() const {
+    return local_;
+  }
+
+  void setAxisIsShardedOn(int64_t axis, ParallelType parallel_type);
+
+  int64_t axisShardedOn(ParallelType parallel_type) const;
+
+ private:
+  at::Tensor local_;
+  DeviceMesh mesh_;
+  std::unordered_map<ParallelType, int64_t> axis_sharded_on_;
+};
+
+} // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/distributed_tensor.h
+++ b/csrc/python_frontend/distributed_tensor.h
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+
 #pragma once
 
 #include <ATen/core/TensorBody.h>

--- a/csrc/python_frontend/distributed_tensor.h
+++ b/csrc/python_frontend/distributed_tensor.h
@@ -22,8 +22,8 @@ class DistributedTensor {
  public:
   explicit DistributedTensor(
       at::Tensor local_tensor,
-      const DeviceMesh& mesh = DeviceMesh())
-      : local_(local_tensor), mesh_(mesh) {}
+      DeviceMesh mesh = DeviceMesh())
+      : local_(std::move(local_tensor)), mesh_(std::move(mesh)) {}
   DistributedTensor(const DistributedTensor&) = delete;
   DistributedTensor& operator=(const DistributedTensor&) = delete;
   DistributedTensor(DistributedTensor&&) = default;

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -474,7 +474,8 @@ std::vector<DistributedTensor> FusionDefinition::execute(
       const at::Tensor& out_tensor = out_tensors.at(tensor_index);
       tensor_index++;
       const DeviceMesh& mesh = out_tv->getDeviceMesh();
-      DistributedTensor out_dtensor(out_tensor, mesh);
+      DistributedTensor& out_dtensor =
+          out_dtensors.emplace_back(out_tensor, mesh);
 
       if (mesh.size() > 0) {
         for (const ParallelType parallel_type : kParallelTypeDIDs) {
@@ -484,8 +485,6 @@ std::vector<DistributedTensor> FusionDefinition::execute(
           }
         }
       }
-
-      out_dtensors.push_back(std::move(out_dtensor));
     }
     NVF_ERROR(out_dtensors.size() == out_tensors.size());
   } else {

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -456,24 +456,23 @@ std::vector<DistributedTensor> FusionDefinition::execute(
     debug_output_ = debug_ss.str();
   }
 
+  // Convert `at::Tensor`s to `DistributedTensor`s.
   std::vector<DistributedTensor> out_dtensors;
   out_dtensors.reserve(out_tensors.size());
   if (user_sched == nullptr) {
     FusionKernelRuntime* runtime =
         scheds->auto_gen_schedules->getMostRecentKernelRuntime();
-    NVF_ERROR(runtime != nullptr);
     Fusion* fusion = runtime->fusionSegments()->completeFusion();
-    NVF_ERROR(fusion != nullptr);
 
-    int64_t i = 0;
+    int64_t tensor_index = 0;
     for (Val* out_val : fusion->outputs()) {
       auto* out_tv = out_val->as<TensorView>();
       if (fusion->getOutputAlias(out_tv).hide_output) {
         continue;
       }
 
-      const at::Tensor& out_tensor = out_tensors.at(i);
-      i++;
+      const at::Tensor& out_tensor = out_tensors.at(tensor_index);
+      tensor_index++;
       const DeviceMesh& mesh = out_tv->getDeviceMesh();
       DistributedTensor out_dtensor(out_tensor, mesh);
 

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -193,7 +193,24 @@ class NVF_API FusionDefinition : public FusionState {
   NVF_API void finalizeMultideviceSchedule();
   //! Prints a python function representing the definition
   NVF_API void print(std::ostream& os) const;
-  //! Executes a fusion if a valid definition or cache lookup occurred prior
+  //! Executes a fusion if a valid definition or cache lookup occurred prior.
+  //!
+  //! This method returns a list of `DistributedTensor`s. Each
+  //! `DistributedTensor` is either the local view of a distributed tensor
+  //! (when the mesh is non-empty) or a non-distributed tensor
+  //! (when the mesh is empty).
+  //!
+  //! Alternatives considered:
+  //! 1. Return std::vector<std::variant<at::Tensor, DistributedTensor>>.
+  //! Because DistributedTensor can also represent a non-distributed tensor, I
+  //! chose the current API for simplicity -- C++ is more verbose than Python
+  //! when dealing with dynamic types.
+  //! 2. Return std::variant<std::vector<at::Tensor>,
+  //! std::vector<DistributedTensor>>. Same reason.
+  //! 3. Store output shardings (i.e. the mesh and the mesh-to-tenseor-axis
+  //! mapping) to a field of FusionDefinition and retrieve it using another
+  //! method. This would be similar to getDebugOutput. I didn't choose that
+  //! because it introduced a new state in the class that could get out of sync.
   NVF_API std::vector<DistributedTensor> execute(
       const at::ArrayRef<c10::IValue>& inputs,
       std::optional<int8_t> device,

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -7,11 +7,12 @@
 // clang-format on
 #pragma once
 
-#include <exceptions.h>
 #include <functional>
 #include <iostream>
 #include <unordered_map>
 
+#include <exceptions.h>
+#include <python_frontend/distributed_tensor.h>
 #include <python_frontend/fusion_state.h>
 #include <python_frontend/segmentation.h>
 #include <visibility.h>
@@ -193,7 +194,7 @@ class NVF_API FusionDefinition : public FusionState {
   //! Prints a python function representing the definition
   NVF_API void print(std::ostream& os) const;
   //! Executes a fusion if a valid definition or cache lookup occurred prior
-  NVF_API std::vector<at::Tensor> execute(
+  NVF_API std::vector<DistributedTensor> execute(
       const at::ArrayRef<c10::IValue>& inputs,
       std::optional<int8_t> device,
       bool override_user_schedule,

--- a/csrc/python_frontend/multidevice_bindings.cpp
+++ b/csrc/python_frontend/multidevice_bindings.cpp
@@ -71,11 +71,29 @@ void bindDeviceMesh(py::module& nvfuser) {
       py::arg("device_id"));
 }
 
+void bindDistributedTensor(py::module& nvfuser) {
+  py::class_<DistributedTensor> distributed_tensor(
+      nvfuser, "DistributedTensor");
+  distributed_tensor.def(
+      "local", &DistributedTensor::local, "Returns the local torch.Tensor.");
+  distributed_tensor.def(
+      "mesh",
+      &DistributedTensor::mesh,
+      "Returns the device mesh.",
+      py::return_value_policy::reference);
+  distributed_tensor.def(
+      "axis_sharded_on",
+      &DistributedTensor::axisShardedOn,
+      "Returns the axis sharded on the given parallel type. If the distributed tensor is replicated on that parallel type, returns -1.",
+      py::arg("parallel_type"));
+}
+
 } // namespace
 
 void bindMultidevice(py::module& nvfuser) {
   bindCommunicator(nvfuser);
   bindDeviceMesh(nvfuser);
+  bindDistributedTensor(nvfuser);
 }
 
 } // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/multidevice_bindings.cpp
+++ b/csrc/python_frontend/multidevice_bindings.cpp
@@ -73,7 +73,7 @@ void bindDeviceMesh(py::module& nvfuser) {
 
 void bindDistributedTensor(py::module& nvfuser) {
   py::class_<DistributedTensor> distributed_tensor(
-      nvfuser, "DistributedTensor");
+      nvfuser, "_DistributedTensor");
   distributed_tensor.def(
       "local", &DistributedTensor::local, "Returns the local torch.Tensor.");
   distributed_tensor.def(

--- a/csrc/python_frontend/multidevice_bindings.cpp
+++ b/csrc/python_frontend/multidevice_bindings.cpp
@@ -77,13 +77,22 @@ void bindDeviceMesh(py::module& nvfuser) {
 
 void bindDistributedTensor(py::module& nvfuser) {
   py::class_<DistributedTensor> distributed_tensor(
-      nvfuser, "_DistributedTensor");
-  distributed_tensor.def_property_readonly("local", &DistributedTensor::local);
+      nvfuser, "DistributedTensor");
   distributed_tensor.def_property_readonly(
-      "mesh", &DistributedTensor::mesh, py::return_value_policy::reference);
+      "local", &DistributedTensor::local, "Returns the local tensor.");
+  distributed_tensor.def_property_readonly(
+      "mesh",
+      &DistributedTensor::mesh,
+      "Returns the device mesh.",
+      py::return_value_policy::reference);
   distributed_tensor.def(
       "axis_sharded_on",
       &DistributedTensor::axisShardedOn,
+      R"(
+      Returns the axis sharded on the given parallel type.
+
+      If the distributed tensor is replicated on that parallel type, returns -1.
+      )",
       py::arg("parallel_type"));
 }
 

--- a/csrc/python_frontend/multidevice_bindings.cpp
+++ b/csrc/python_frontend/multidevice_bindings.cpp
@@ -51,14 +51,18 @@ void bindCommunicator(py::module& nvfuser) {
 }
 
 void bindDeviceMesh(py::module& nvfuser) {
-  py::class_<DeviceMesh> device_mesh_class(nvfuser, "DeviceMesh");
-  device_mesh_class.def(py::init<std::vector<int64_t>>());
-  device_mesh_class.def("__repr__", [](const DeviceMesh& self) {
+  py::class_<DeviceMesh> device_mesh(nvfuser, "DeviceMesh");
+  device_mesh.def(py::init<std::vector<int64_t>>());
+  device_mesh.def("__repr__", [](const DeviceMesh& self) {
     std::stringstream ss;
     ss << self;
     return ss.str();
   });
-  device_mesh_class.def(
+  device_mesh.def_property_readonly(
+      "size",
+      [](const DeviceMesh& self) -> int64_t { return self.size(); },
+      "Returns the size of the mesh.");
+  device_mesh.def(
       "shard_tensor",
       [](const DeviceMesh& self,
          at::Tensor tensor,
@@ -74,17 +78,12 @@ void bindDeviceMesh(py::module& nvfuser) {
 void bindDistributedTensor(py::module& nvfuser) {
   py::class_<DistributedTensor> distributed_tensor(
       nvfuser, "_DistributedTensor");
-  distributed_tensor.def(
-      "local", &DistributedTensor::local, "Returns the local torch.Tensor.");
-  distributed_tensor.def(
-      "mesh",
-      &DistributedTensor::mesh,
-      "Returns the device mesh.",
-      py::return_value_policy::reference);
+  distributed_tensor.def_property_readonly("local", &DistributedTensor::local);
+  distributed_tensor.def_property_readonly(
+      "mesh", &DistributedTensor::mesh, py::return_value_policy::reference);
   distributed_tensor.def(
       "axis_sharded_on",
       &DistributedTensor::axisShardedOn,
-      "Returns the axis sharded on the given parallel type. If the distributed tensor is replicated on that parallel type, returns -1.",
       py::arg("parallel_type"));
 }
 

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -543,9 +543,12 @@ NVF_API char* getNvFuserEnv(const char* env_name);
 
 // Returns the mapped value or the default.
 template <typename K, typename V>
-V getOrDefault(const std::unordered_map<K, V>& map, const K& key) {
+const V& getOrDefault(
+    const std::unordered_map<K, V>& map,
+    const K& key,
+    const V& default_value = V()) {
   const auto i = map.find(key);
-  return i == map.end() ? V() : i->second;
+  return i == map.end() ? default_value : i->second;
 }
 
 size_t deviceAvailableSharedMemoryBytes();

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -372,7 +372,8 @@ class FusionDefinition(_C._FusionDefinition):
                 _enable_options=_enable_options,
                 _disable_options=_disable_options,
             )
-            out_tensors = []
+
+            out_tensors: list[torch.Tensor] = []
             for out_dtensor in out_dtensors:
                 if out_dtensor.mesh.size == 0:
                     out_tensors.append(out_dtensor.local)

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 import sys
-from typing import Callable, Optional, Union, List  # noqa: F401
+from typing import Callable, Optional, Union, List, Iterable  # noqa: F401
 import warnings
 
 import torch

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -198,7 +198,7 @@ class FusionDefinition(_C._FusionDefinition):
         save_repro_inputs=False,
         _enable_options: list[str] = [],
         _disable_options: list[str] = [],
-    ):
+    ) -> list[torch.Tensor | _C.DistributedTensor]:
         """
         Executes an nvFuser set of kernels for a given Fusion
 
@@ -306,8 +306,6 @@ class FusionDefinition(_C._FusionDefinition):
         if hasattr(self, "segments") and len(self.segments) > 0:
             return self._execute_segments(inputs, device=device, profile=profile)
 
-        results = None
-
         try:
             if print_repro:
                 print(self.repro_script_for(inputs))
@@ -316,7 +314,7 @@ class FusionDefinition(_C._FusionDefinition):
                     "Reset the FusionCache manually to avoid reusing kernels when re-executing the fusion definition with different options."
                 )
 
-            results = self._execute(
+            out_tensors = self._execute(
                 inputs,
                 device=device,
                 override_user_schedule=override_user_schedule,
@@ -325,7 +323,10 @@ class FusionDefinition(_C._FusionDefinition):
                 _enable_options=_enable_options,
                 _disable_options=_disable_options,
             )
-            return results
+            for i, out_dtensor in enumerate(out_tensors):
+                if out_dtensor.mesh().size() == 0:
+                    out_tensors[i] = out_dtensor.local()
+            return out_tensors
         except Exception as err:
             logger.exception(self._repro_error_str("executing", inputs))
             raise

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -198,7 +198,7 @@ class FusionDefinition(_C._FusionDefinition):
         save_repro_inputs=False,
         _enable_options: list[str] = [],
         _disable_options: list[str] = [],
-    ) -> list[torch.Tensor]:
+    ) -> list[torch.Tensor | DistributedTensor]:
         """
         Executes an nvFuser set of kernels for a given Fusion
 
@@ -314,7 +314,7 @@ class FusionDefinition(_C._FusionDefinition):
                     "Reset the FusionCache manually to avoid reusing kernels when re-executing the fusion definition with different options."
                 )
 
-            out_tensors: Iterable[DistributedTensor] = self._execute(
+            out_tensors: list[DistributedTensor] = self._execute(
                 inputs,
                 device=device,
                 override_user_schedule=override_user_schedule,

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 import sys
-from typing import Callable, Iterable
+from typing import Callable
 import warnings
 
 import torch

--- a/tests/python/multidevice_fixtures.py
+++ b/tests/python/multidevice_fixtures.py
@@ -51,4 +51,4 @@ def multidevice_test():
     fixture = MultideviceTest()
     yield fixture
     # Sync all ranks after each test for isolation.
-    fixture.communicator.barrier()
+    # fixture.communicator.barrier()

--- a/tests/python/multidevice_fixtures.py
+++ b/tests/python/multidevice_fixtures.py
@@ -51,4 +51,4 @@ def multidevice_test():
     fixture = MultideviceTest()
     yield fixture
     # Sync all ranks after each test for isolation.
-    # fixture.communicator.barrier()
+    fixture.communicator.barrier()

--- a/tests/python/test_communication.py
+++ b/tests/python/test_communication.py
@@ -41,8 +41,8 @@ def test_allgather(multidevice_test):
     sharded = multidevice_test.shard_tensor(unsharded, 0, mesh)
 
     fd = Model()
-    outputs = fd.execute([sharded])
-    torch.testing.assert_close(outputs[0].cpu(), unsharded)
+    (output,) = fd.execute([sharded])
+    torch.testing.assert_close(output.local.cpu(), unsharded)
 
 
 @pytest.mark.mpi
@@ -66,8 +66,8 @@ def test_allreduce(multidevice_test):
     sharded = multidevice_test.shard_tensor(unsharded, 0, mesh)
 
     fd = Model()
-    outputs = fd.execute([sharded])
-    torch.testing.assert_close(outputs[0].cpu(), unsharded.sum(0))
+    (output,) = fd.execute([sharded])
+    torch.testing.assert_close(output.local.cpu(), unsharded.sum(0))
 
 
 @pytest.mark.mpi
@@ -97,9 +97,9 @@ def test_reduce_scatter(multidevice_test):
     sharded = multidevice_test.shard_tensor(unsharded, 0, mesh)
 
     fd = Model()
-    outputs = fd.execute([sharded])
+    (output,) = fd.execute([sharded])
     torch.testing.assert_close(
-        outputs[0], multidevice_test.shard_tensor(unsharded.sum(0), 0, mesh)
+        output.local, multidevice_test.shard_tensor(unsharded.sum(0), 0, mesh)
     )
 
 
@@ -139,7 +139,7 @@ def test_reduce_scatter_noncontiguous(multidevice_test):
     sharded = multidevice_test.shard_tensor(unsharded, 0, mesh)
 
     fd = Model()
-    outputs = fd.execute([sharded])
+    (output,) = fd.execute([sharded])
     torch.testing.assert_close(
-        outputs[0], multidevice_test.shard_tensor(unsharded.sum(0), 1, mesh)
+        output.local, multidevice_test.shard_tensor(unsharded.sum(0), 1, mesh)
     )

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -10,7 +10,7 @@ from torch.nn.attention import SDPBackend
 import multidevice_fixtures
 import nvfuser
 import utils
-from nvfuser import DataType, FusionDefinition
+from nvfuser import DataType, FusionDefinition, DistributedTensor
 
 
 multidevice_test = multidevice_fixtures.multidevice_test
@@ -54,8 +54,9 @@ def test_pointwise(multidevice_test):
     sharded_input = multidevice_test.shard_tensor(unsharded_input, 0, mesh)
 
     fd = Model()
-    outputs = fd.execute([sharded_input])
-    torch.testing.assert_close(outputs[0].cpu(), unsharded_input.relu() * 2)
+    outputs: list[DistributedTensor] = fd.execute([sharded_input])
+    torch.testing.assert_close(outputs[0].local().cpu(), unsharded_input.relu() * 2)
+    assert outputs[0].axis_sharded_on(nvfuser.ParallelType.mesh_x) == -1
 
 
 @pytest.mark.mpi
@@ -106,8 +107,9 @@ def test_linear(multidevice_test):
         rank : rank + 1
     ]
     # rtol is the same as the default for fp32. atol is slightly increased.
+    assert out_tensors[0].axis_sharded_on(nvfuser.ParallelType.mesh_x) == 0
     torch.testing.assert_close(
-        out_tensors[0], expected_out_tensor, rtol=1.3e-6, atol=1e-3
+        out_tensors[0].local(), expected_out_tensor, rtol=1.3e-6, atol=1e-3
     )
 
 
@@ -169,7 +171,7 @@ def test_linear_loop_split(multidevice_test):
     expected_out_tensor = multidevice_test.shard_tensor(unsharded_out_tensor, -1, mesh)
     # rtol is the same as the default for fp32. atol is slightly increased.
     torch.testing.assert_close(
-        out_tensors[0], expected_out_tensor, rtol=1.3e-6, atol=1e-3
+        out_tensors[0].local(), expected_out_tensor, rtol=1.3e-6, atol=1e-3
     )
 
 
@@ -220,7 +222,9 @@ def test_matmul_allreduce(multidevice_test):
     (in_grad,) = fd.execute([out_grad.cuda(), weight.cuda()])
     # Use the default rtol for half because the output, although being float32,
     # is a straight cast from half.
-    torch.testing.assert_close(in_grad.cpu(), expected_in_grad, rtol=1e-3, atol=1e-2)
+    torch.testing.assert_close(
+        in_grad.local().cpu(), expected_in_grad, rtol=1e-3, atol=1e-2
+    )
 
 
 class QkvFormat(Enum):
@@ -335,6 +339,7 @@ def test_sdpa(multidevice_test, qkv_format: QkvFormat):
     out, q_grad, k_grad, v_grad = outs
 
     def assert_close(actual, expected):
+        actual = actual.local()
         match qkv_format:
             case QkvFormat.BHSE:
                 assert actual.is_contiguous()
@@ -744,10 +749,10 @@ class TransformerForwardFusion(FusionDefinition):
 # TODO(#2962): validate the numbers as well. Currently, the numbers are off
 # by a lot, making comparison infeasible.
 def _assert_shape_dtype(
-    t: torch.Tensor, expected_sizes: list[int], expected_dtype: torch.dtype
+    t: DistributedTensor, expected_sizes: list[int], expected_dtype: torch.dtype
 ) -> None:
-    assert t.shape == torch.Size(expected_sizes)
-    assert t.dtype == expected_dtype
+    assert t.local().shape == torch.Size(expected_sizes)
+    assert t.local().dtype == expected_dtype
 
 
 @pytest.mark.skipif(

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -10,7 +10,7 @@ from torch.nn.attention import SDPBackend
 import multidevice_fixtures
 import nvfuser
 import utils
-from nvfuser import DataType, FusionDefinition, DistributedTensor
+from nvfuser import DataType, FusionDefinition
 
 
 multidevice_test = multidevice_fixtures.multidevice_test


### PR DESCRIPTION
This is done by adding a `nvfuser.DistributedTensor` that wraps a local tensor, a mesh and a mesh-axis-to-tensor-axis mapping. 