### PR TITLE
Host irs: `LinearOp` with pre-allocated output

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -545,6 +545,61 @@ void HostIrEvaluator::handle(MatmulOp* matmul) {
   }
 }
 
+void HostIrEvaluator::handle(LinearOp* linear) {
+  TensorView* in = linear->inA()->as<TensorView>();
+  TensorView* weight = linear->inB()->as<TensorView>();
+  TensorView* bias = linear->bias()->as<TensorView>();
+  TensorView* out = linear->out()->as<TensorView>();
+  NVF_ERROR(
+      expr_evaluator_.isKnown(in)
+        && expr_evaluator_.isKnown(weight)
+        && (!linear->has_bias() || expr_evaluator_.isKnown(bias)),
+      "Inputs of the Linear Op ",
+      linear->toString(),
+      "must be precomputed before being retrieved");
+
+  if (!expr_evaluator_.isKnown(out)) {
+    unhandled(linear);
+    return;
+  }
+
+  auto squeeze_device_dims = [](at::Tensor& t,
+                              int64_t num_device_dims) -> void {
+    // Record the initial shape for the error message.
+    std::vector<int64_t> shape = t.sizes().vec();
+    for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
+      NVF_CHECK(
+          t.size(0) == 1,
+          "When the weight is >2D, expect its preceding dimensions and "
+          "the bias's preceding dimensions to "
+          "be DID-parallel and therefore size-1: ",
+          shape);
+      t = t.squeeze(0);
+    }
+  };
+
+  auto in_at = expr_evaluator_.evaluate(in).as<at::Tensor>();
+  auto weight_at = expr_evaluator_.evaluate(weight).as<at::Tensor>();
+  auto bias_at = expr_evaluator_.evaluate(bias).as<at::Tensor>();
+  auto out_at = expr_evaluator_.evaluate(out).as<at::Tensor>();
+
+  // The squeezes and unsqueezes are currently required to support a sharded
+  // linear layer. Remove them after #2563.
+  auto num_device_dims = weight_at.dim() - 2;
+  squeeze_device_dims(weight_at, num_device_dims);
+  if (linear->has_bias()) {
+    squeeze_device_dims(bias_at, num_device_dims);
+    at::linear_out(out_at, in_at, weight_at, bias_at);
+  } else {
+    at::linear_out(out_at, in_at, weight_at);
+  }
+
+  for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
+    out_at = out_at.unsqueeze(0);
+  }
+  expr_evaluator_.bind(out, out_at, /*evaluate_validate=*/false);
+}
+
 void HostIrEvaluator::handle(kir::Allocate* allocate) {
   NVF_ERROR(
       allocate->buffer()->isA<TensorView>(),

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -551,9 +551,8 @@ void HostIrEvaluator::handle(LinearOp* linear) {
   TensorView* bias = linear->bias()->as<TensorView>();
   TensorView* out = linear->out()->as<TensorView>();
   NVF_ERROR(
-      expr_evaluator_.isKnown(in)
-        && expr_evaluator_.isKnown(weight)
-        && (!linear->has_bias() || expr_evaluator_.isKnown(bias)),
+      expr_evaluator_.isKnown(in) && expr_evaluator_.isKnown(weight) &&
+          (!linear->has_bias() || expr_evaluator_.isKnown(bias)),
       "Inputs of the Linear Op ",
       linear->toString(),
       "must be precomputed before being retrieved");

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -127,6 +127,7 @@ class HostIrEvaluator final : public OptOutDispatch {
   void handle(EndCoalescing* end_coalescing) override;
   void handle(kir::IfThenElse* if_then_else) override;
   void handle(MatmulOp* matmul) override;
+  void handle(LinearOp* linear) override;
   void handle(kir::Allocate* allocate) override;
   void unhandled(Statement* stmt) override;
 

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2269,7 +2269,6 @@ class LinearOp : public Expr {
       const ExpressionEvaluator& ee,
       const std::vector<PolymorphicValue>& inputs) const override;
 
- private:
   bool has_bias() const {
     return inputs().size() == 3;
   }

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -909,7 +909,6 @@ TEST_F(LinearHostIrTest, HostIrLinearOut) {
   hic->addInput(weight);
   hic->addInput(bias);
   hic->addInput(out);
-  hic->addOutput(out);
 
   hic->pushBackTopLevelExprs(linear_op);
 

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -879,7 +879,9 @@ TEST_F(LinearHostIrTest, HostIr) {
   at::Tensor weight_at = at::randn({N, K}, options);
   at::Tensor bias_at = at::randn({N}, options);
   std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
-      {hie.inputs().at(0), in_at}, {hie.inputs().at(1), weight_at}, {hie.inputs().at(2), bias_at}};
+      {hie.inputs().at(0), in_at},
+      {hie.inputs().at(1), weight_at},
+      {hie.inputs().at(2), bias_at}};
 
   auto output = hie.runWithInput(concrete_input_buffers).at(0);
 
@@ -920,7 +922,10 @@ TEST_F(LinearHostIrTest, HostIrLinearOut) {
   at::Tensor bias_at = at::randn({N}, options);
   at::Tensor out_at = at::empty({B, M, N}, options);
   std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
-      {hie.inputs().at(0), in_at}, {hie.inputs().at(1), weight_at}, {hie.inputs().at(2), bias_at}, {hie.inputs().at(3), out_at}};
+      {hie.inputs().at(0), in_at},
+      {hie.inputs().at(1), weight_at},
+      {hie.inputs().at(2), bias_at},
+      {hie.inputs().at(3), out_at}};
 
   hie.runWithInput(concrete_input_buffers);
 


### PR DESCRIPTION
We add support for `LinearOp` with pre-allocarted output in host IR, as an intermediate step towards using the comms/compute pipelined algorithm in transformer