### PR TITLE
Transformer benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -796,6 +796,43 @@ if(BUILD_NVFUSER_BENCHMARK)
       -Werror -Wno-deprecated-copy
     )
   endif()
+
+  # multidevice transformer benchmark
+  if (NVFUSER_DISTRIBUTED)
+    set(MULTIDEVICE_BENCHMARK_SRCS)
+    list(APPEND MULTIDEVICE_BENCHMARK_SRCS
+      ${NVFUSER_ROOT}/benchmarks/cpp/transformer.cpp
+      ${NVFUSER_ROOT}/tests/cpp/multidevice_transformer.cpp
+      ${NVFUSER_ROOT}/tests/cpp/utils.cpp
+    )
+    add_executable(nvfuser_multidevice_bench ${MULTIDEVICE_BENCHMARK_SRCS})
+    set_target_properties(nvfuser_multidevice_bench PROPERTIES
+      C_STANDARD ${NVFUSER_C_STANDARD}
+      CUDA_STANDARD ${NVFUSER_CUDA_STANDARD}
+      CXX_STANDARD ${NVFUSER_CPP_STANDARD}
+      CXX_STANDARD_REQUIRED ON
+      CXX_VISIBILITY_PRESET hidden
+      POSITION_INDEPENDENT_CODE Yes
+      VISIBILITY_INLINES_HIDDEN Yes
+    )
+    target_include_directories(nvfuser_multidevice_bench SYSTEM PRIVATE
+      ${CMAKE_SOURCE_DIR}/third_party/benchmark/include
+      ${CMAKE_SOURCE_DIR}/third_party/flatbuffers/include
+      ${CMAKE_SOURCE_DIR}/third_party/googletest/googletest/include
+    )
+    target_include_directories(nvfuser_multidevice_bench PUBLIC ${NVFUSER_ROOT})
+    target_link_libraries(nvfuser_multidevice_bench PRIVATE
+      benchmark::benchmark
+      codegen_internal
+    )
+    add_dependencies(nvfuser_multidevice_bench flatc build_flatbuffer_config)
+    if(NOT MSVC)
+    target_compile_options(nvfuser_bench PRIVATE
+      -Wall -Wno-unused-function
+      -Werror -Wno-deprecated-copy
+    )
+    endif()
+  endif()
 endif()
 
 # --- generate runtime files

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -77,7 +77,7 @@ void forward_transformer(Communicator* communicator, bool profile, bool sequence
       shardTensor(mlp_w1, 1, mesh, communicator).unsqueeze(0),
       mlp_b1};
 
-  DistributedTransformer model = DistributedTransformer(D, B, E, H, S, kDropoutProb, kSdpaProb);
+  DistributedTransformer model(D, B, E, H, S, kDropoutProb, kSdpaProb);
   auto fec = model.forward(dtype, sequence_parallel);
   cudaSetDevice(communicator->deviceId());
 

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -177,8 +177,7 @@ void backward_transformer(Communicator* communicator, bool profile) {
       mha_linear1.to(at::kFloat),
       shardTensor(mlp_linear1, 1, mesh, communicator).unsqueeze(0)};
 
-  DistributedTransformer model =
-      DistributedTransformer(D, B, E, H, S, kDropoutProb, kSdpaProb);
+  DistributedTransformer model(D, B, E, H, S, kDropoutProb, kSdpaProb);
   auto fec = model.backward(dtype);
   std::vector<at::Tensor> outputs;
 

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -1,0 +1,231 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <cuda_profiler_api.h>
+#include <nvToolsExt.h>
+
+#include <benchmarks/cpp/utils.h>
+#include <fusion.h>
+#include <multidevice/utils.h>
+#include <ops/all_ops.h>
+#include <tests/cpp/multidevice.h>
+#include <tests/cpp/multidevice_transformer.h>
+#include <tests/cpp/utils.h>
+#include <utils.h>
+
+using namespace nvfuser;
+
+constexpr int64_t B = 1, E = 12288, H = 96, S = 2048;
+constexpr double kParamScale = 0.02;
+constexpr int64_t warmup_itrs = 10, num_itrs = 10;
+
+at::Tensor shardTensor(
+    at::Tensor tensor,
+    int64_t axis,
+    const DeviceMesh& mesh,
+    Communicator* communicator_) {
+  const auto device_id = communicator_->deviceId();
+  auto i = mesh.idxOf(device_id);
+  auto extent = tensor.size(axis);
+  auto nslices = mesh.size();
+  NVF_CHECK(
+      extent % nslices == 0, "Sharded axis must be evenly divisble by mesh");
+  auto stride = extent / nslices;
+  i = (i < 0) ? 0 : i;
+  auto slice = tensor.slice(axis, i * stride, (i + 1) * stride).contiguous();
+  // Temporary until https://github.com/NVIDIA/Fuser/issues/2563. Adds DIDx
+  // axis in front representing the sharded extent of the tensor.
+  if (stride > 1) {
+    slice = slice.unsqueeze(0);
+  }
+  return slice;
+}
+
+void forward_transformer(Communicator* communicator_, bool profile) {
+  int64_t D = communicator_->size();
+  auto dtype = DataType::BFloat16;
+  at::ScalarType at_dtype = data_type_to_aten(dtype);
+  const auto mesh = DeviceMesh::createForNumDevices(D);
+  const auto options =
+      at::TensorOptions().dtype(at_dtype).device(communicator_->device());
+
+  auto x_ = at::randn({B * S, E}, options).to(at::kFloat);
+  auto ln0_w_ = at::randn(E, options).to(at::kFloat);
+  auto ln0_b_ = at::randn(E, options).to(at::kFloat);
+  auto mha_w0_ = at::randn({3 * E, E}, options) * kParamScale;
+  auto mha_b0_ = at::randn({3 * E}, options) * kParamScale;
+  auto mha_w1_ = at::randn({E, E}, options) * kParamScale;
+  auto mha_b1_ = at::randn({E}, options) * kParamScale;
+  auto ln1_w_ = at::randn(E, options).to(at::kFloat);
+  auto ln1_b_ = at::randn(E, options).to(at::kFloat);
+  auto mlp_w0_ = at::randn({4 * E, E}, options) * kParamScale;
+  auto mlp_b0_ = at::randn({4 * E}, options) * kParamScale;
+  auto mlp_w1_ = at::randn({E, 4 * E}, options) * kParamScale;
+  auto mlp_b1_ = at::randn({E}, options) * kParamScale;
+
+  std::vector<c10::IValue> inputs = {
+      x_,
+      ln0_w_,
+      ln0_b_,
+      shardTensor(mha_w0_.view({3, E, E}), 1, mesh, communicator_)
+          .view({1, 3 * E / D, E}),
+      shardTensor(mha_b0_.view({3, E}), 1, mesh, communicator_)
+          .view({1, 3 * E / D}),
+      shardTensor(mha_w1_, 1, mesh, communicator_),
+      mha_b1_,
+      ln1_w_,
+      ln1_b_,
+      shardTensor(mlp_w0_, 0, mesh, communicator_),
+      shardTensor(mlp_b0_, 0, mesh, communicator_),
+      shardTensor(mlp_w1_, 1, mesh, communicator_),
+      mlp_b1_};
+
+  DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
+  auto fec = model.forward(dtype);
+  cudaSetDevice(communicator_->deviceId());
+
+  auto start = std::chrono::high_resolution_clock::now();
+  for (auto i : c10::irange(num_itrs + warmup_itrs)) {
+    if (i == warmup_itrs) {
+      start = std::chrono::high_resolution_clock::now();
+      if (profile) {
+        cudaProfilerStart();
+      }
+    }
+    if (i >= warmup_itrs && profile) {
+      nvtxRangePush(("Iteration" + std::to_string(i)).c_str());
+    }
+    auto outputs = fec->runFusionWithInputs(inputs);
+    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize is not blocking until kernels are finished on all
+    // devices except 0
+    // TODO: are we not waiting until all kernels are appended to the stream?
+    std::cout << outputs[0][0][0] << std::endl;
+
+    if (i > warmup_itrs && profile) {
+      nvtxRangePop();
+    }
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+
+  double foward_time =
+      std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+          .count() /
+      (double)num_itrs / 1000.0;
+  std::cout << communicator_->deviceId() << ": Average forward time "
+            << foward_time << "ms" << std::endl;
+}
+
+void backward_transformer(Communicator* communicator_, bool profile) {
+  auto dtype = DataType::BFloat16;
+  at::ScalarType at_dtype = data_type_to_aten(dtype);
+  int64_t D = communicator_->size();
+  const auto mesh = DeviceMesh::createForNumDevices(D);
+
+  const auto options =
+      at::TensorOptions().dtype(at_dtype).device(communicator_->device());
+  auto x_ = at::randn({B * S, E}, options).to(at::kFloat);
+  auto ln0_w_ = at::randn(E, options).to(at::kFloat);
+  auto ln0_b_ = at::randn(E, options).to(at::kFloat);
+  auto mha_w0_ = at::randn({3 * E, E}, options) * kParamScale;
+  auto mha_b0_ = at::randn({3 * E}, options) * kParamScale;
+  auto mha_w1_ = at::randn({E, E}, options) * kParamScale;
+  auto mha_b1_ = at::randn({E}, options) * kParamScale;
+  auto ln1_w_ = at::randn(E, options).to(at::kFloat);
+  auto ln1_b_ = at::randn(E, options).to(at::kFloat);
+  auto mlp_w0_ = at::randn({4 * E, E}, options) * kParamScale;
+  auto mlp_b0_ = at::randn({4 * E}, options) * kParamScale;
+  auto grad_ = at::randn({B * S, E}, options).to(at::kFloat) * kParamScale;
+  auto mlp_w1_ = at::randn({E, 4 * E}, options) * kParamScale;
+  auto mlp_b1_ = at::randn({E}, options) * kParamScale;
+
+  // Recomputed tensors
+  auto mlp_dropout_mask = at::rand({B * S, E}, options).lt(1.0 - 0.1);
+  auto mha_dropout_mask = at::rand({B * S, E}, options).lt(1.0 - 0.1);
+  auto sdpa_output = at::randn({B, H, S, E / H}, options);
+  auto sdpa_logsum_exp = at::randn({B, H, S}, options).to(at::kFloat);
+  auto sdpa_seed = at::scalar_tensor(1, at::kLong);
+  auto sdpa_offset = at::scalar_tensor(1, at::kLong);
+  auto ln0_mean = at::randn({B * S, 1}, options).to(at::kFloat);
+  auto ln0_rstd = at::randn({B * S, 1}, options).to(at::kFloat);
+  auto ln1_mean = at::randn({B * S, 1}, options).to(at::kFloat);
+  auto ln1_rstd = at::randn({B * S, 1}, options).to(at::kFloat);
+  auto mha_linear1 = at::rand({B * S, E}, options).to(at::kFloat);
+
+  std::vector<c10::IValue> inputs = {
+      x_,
+      grad_,
+      shardTensor(mha_w0_.view({3, E, E}), 1, mesh, communicator_)
+          .view({1, 3 * E / D, E}),
+      shardTensor(mha_b0_.view({3, E}), 1, mesh, communicator_)
+          .view({1, 3 * E / D}),
+      shardTensor(mha_w1_, 1, mesh, communicator_),
+      shardTensor(mlp_w0_, 0, mesh, communicator_),
+      shardTensor(mlp_b0_, 0, mesh, communicator_),
+      shardTensor(mlp_w1_, 1, mesh, communicator_),
+      mlp_b1_,
+      mlp_dropout_mask,
+      mha_dropout_mask,
+      shardTensor(sdpa_output, 1, mesh, communicator_),
+      shardTensor(sdpa_logsum_exp, 1, mesh, communicator_),
+      sdpa_seed,
+      sdpa_offset,
+      ln1_w_,
+      ln1_b_,
+      ln1_mean,
+      ln1_rstd,
+      ln0_w_,
+      ln0_b_,
+      ln0_mean,
+      ln0_rstd,
+      mha_linear1};
+
+  DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
+  auto fec = model.backward(dtype);
+  std::vector<at::Tensor> outputs;
+
+  cudaSetDevice(communicator_->deviceId());
+  auto start = std::chrono::high_resolution_clock::now();
+  for (auto i : c10::irange(num_itrs + warmup_itrs)) {
+    if (i == warmup_itrs) {
+      start = std::chrono::high_resolution_clock::now();
+    }
+    if (i >= warmup_itrs && profile) {
+      nvtxRangePush(("Iteration" + std::to_string(i)).c_str());
+    }
+    outputs = fec->runFusionWithInputs(inputs);
+    cudaDeviceSynchronize();
+    // cudaDeviceSynchronize is not blocking until kernels are finished on all
+    // devices except 0
+    // TODO: are we not waiting until all kernels are appended to the stream?
+    std::cout << outputs[0][0][0][0] << std::endl;
+
+    if (i > warmup_itrs && profile) {
+      nvtxRangePop();
+    }
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  if (profile) {
+    cudaProfilerStop();
+  }
+
+  double backward_time =
+      std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+          .count() /
+      (double)num_itrs / 1000.0;
+  std::cout << communicator_->deviceId() << ": Average backward time "
+            << backward_time << "ms" << std::endl;
+}
+
+int main(int argc, char** argv) {
+  // using this is as a flag for when to profile
+  bool profile = argc > 1;
+  auto communicator_ = &Communicator::getInstance();
+  forward_transformer(communicator_, profile);
+  communicator_->barrier();
+  backward_transformer(communicator_, profile);
+}

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -94,7 +94,7 @@ void forward_transformer(Communicator* communicator, bool profile) {
     // cudaDeviceSynchronize is not blocking until kernels are finished on all
     // devices except 0
     // TODO: are we not waiting until all kernels are appended to the stream?
-    std::cout << outputs[0][0][0] << std::endl;
+    //std::cout << outputs[0][0][0] << std::endl;
 
     if (i > warmup_itrs && profile) {
       nvtxRangePop();
@@ -145,8 +145,8 @@ void backward_transformer(Communicator* communicator, bool profile) {
   auto ln1_mean = at::randn({B * S, 1}, options).to(at::kFloat);
   auto ln1_rstd = at::randn({B * S, 1}, options).to(at::kFloat);
   auto mha_linear1 = at::rand({B * S, E}, options).to(at::kFloat);
-  auto mha_linear0 = at::rand({B * S, 3 * E}, options); // mha linear0    shape of mha linear0 = [B * S, 3 * E]
-  auto mlp_linear1 = at::rand({B * S, 4 * E}, options); // mlp linear1     mlp linear1 = [B * S, 4 * E]
+  auto mha_linear0 = at::rand({B * S, 3 * E}, options);
+  auto mlp_linear1 = at::rand({B * S, 4 * E}, options);
 
   std::vector<c10::IValue> at_inputs = {
       x,
@@ -192,7 +192,7 @@ void backward_transformer(Communicator* communicator, bool profile) {
     // cudaDeviceSynchronize is not blocking until kernels are finished on all
     // devices except 0
     // TODO: are we not waiting until all kernels are appended to the stream?
-    std::cout << outputs[0][0][0][0] << std::endl;
+    //std::cout << outputs[0][0][0][0] << std::endl;
 
     if (i > warmup_itrs && profile) {
       nvtxRangePop();
@@ -212,10 +212,9 @@ void backward_transformer(Communicator* communicator, bool profile) {
 }
 
 int main(int argc, char** argv) {
-  // using this is as a flag for when to profile
   bool profile = argc > 1;
   auto communicator = &Communicator::getInstance();
-  //forward_transformer(communicator, profile);
-  //communicator->barrier();
+  forward_transformer(communicator, profile);
+  communicator->barrier();
   backward_transformer(communicator, profile);
 }

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -42,36 +42,36 @@ void forward_transformer(Communicator* communicator, bool profile) {
   const auto options =
       at::TensorOptions().dtype(at_dtype).device(communicator->device());
 
-  auto x_ = at::randn({B * S, E}, options);
-  auto ln0_w_ = at::randn(E, options).to(at::kFloat);
-  auto ln0_b_ = at::randn(E, options).to(at::kFloat);
-  auto mha_w0_ = at::randn({3 * E, E}, options) * kParamScale;
-  auto mha_b0_ = at::randn({3 * E}, options) * kParamScale;
-  auto mha_w1_ = at::randn({E, E}, options) * kParamScale;
-  auto mha_b1_ = at::randn({E}, options) * kParamScale;
-  auto ln1_w_ = at::randn(E, options).to(at::kFloat);
-  auto ln1_b_ = at::randn(E, options).to(at::kFloat);
-  auto mlp_w0_ = at::randn({4 * E, E}, options) * kParamScale;
-  auto mlp_b0_ = at::randn({4 * E}, options) * kParamScale;
-  auto mlp_w1_ = at::randn({E, 4 * E}, options) * kParamScale;
-  auto mlp_b1_ = at::randn({E}, options) * kParamScale;
+  auto x = at::randn({B * S, E}, options);
+  auto ln0_w = at::randn(E, options).to(at::kFloat);
+  auto ln0_b = at::randn(E, options).to(at::kFloat);
+  auto mha_w0 = at::randn({3 * E, E}, options) * kParamScale;
+  auto mha_b0 = at::randn({3 * E}, options) * kParamScale;
+  auto mha_w1 = at::randn({E, E}, options) * kParamScale;
+  auto mha_b1 = at::randn({E}, options) * kParamScale;
+  auto ln1_w = at::randn(E, options).to(at::kFloat);
+  auto ln1_b = at::randn(E, options).to(at::kFloat);
+  auto mlp_w0 = at::randn({4 * E, E}, options) * kParamScale;
+  auto mlp_b0 = at::randn({4 * E}, options) * kParamScale;
+  auto mlp_w1 = at::randn({E, 4 * E}, options) * kParamScale;
+  auto mlp_b1 = at::randn({E}, options) * kParamScale;
 
   std::vector<c10::IValue> at_inputs = {
-      x_,
-      ln0_w_,
-      ln0_b_,
-      shardTensor(mha_w0_.view({3, E, E}), 1, mesh, communicator)
+      x,
+      ln0_w,
+      ln0_b,
+      shardTensor(mha_w0.view({3, E, E}), 1, mesh, communicator)
           .view({1, 3 * E / D, E}),
-      shardTensor(mha_b0_.view({3, E}), 1, mesh, communicator)
+      shardTensor(mha_b0.view({3, E}), 1, mesh, communicator)
           .view({1, 3 * E / D}),
-      shardTensor(mha_w1_, 1, mesh, communicator).unsqueeze(0),
-      mha_b1_,
-      ln1_w_,
-      ln1_b_,
-      shardTensor(mlp_w0_, 0, mesh, communicator).unsqueeze(0),
-      shardTensor(mlp_b0_, 0, mesh, communicator).unsqueeze(0),
-      shardTensor(mlp_w1_, 1, mesh, communicator).unsqueeze(0),
-      mlp_b1_};
+      shardTensor(mha_w1, 1, mesh, communicator).unsqueeze(0),
+      mha_b1,
+      ln1_w,
+      ln1_b,
+      shardTensor(mlp_w0, 0, mesh, communicator).unsqueeze(0),
+      shardTensor(mlp_b0, 0, mesh, communicator).unsqueeze(0),
+      shardTensor(mlp_w1, 1, mesh, communicator).unsqueeze(0),
+      mlp_b1};
 
   DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
   auto fec = model.forward(dtype);
@@ -117,20 +117,20 @@ void backward_transformer(Communicator* communicator, bool profile) {
 
   const auto options =
       at::TensorOptions().dtype(at_dtype).device(communicator->device());
-  auto x_ = at::randn({B * S, E}, options).to(at::kFloat);
-  auto ln0_w_ = at::randn(E, options).to(at::kFloat);
-  auto ln0_b_ = at::randn(E, options).to(at::kFloat);
-  auto mha_w0_ = at::randn({3 * E, E}, options) * kParamScale;
-  auto mha_b0_ = at::randn({3 * E}, options) * kParamScale;
-  auto mha_w1_ = at::randn({E, E}, options) * kParamScale;
-  auto mha_b1_ = at::randn({E}, options) * kParamScale;
-  auto ln1_w_ = at::randn(E, options).to(at::kFloat);
-  auto ln1_b_ = at::randn(E, options).to(at::kFloat);
-  auto mlp_w0_ = at::randn({4 * E, E}, options) * kParamScale;
-  auto mlp_b0_ = at::randn({4 * E}, options) * kParamScale;
-  auto grad_ = at::randn({B * S, E}, options).to(at::kFloat) * kParamScale;
-  auto mlp_w1_ = at::randn({E, 4 * E}, options) * kParamScale;
-  auto mlp_b1_ = at::randn({E}, options) * kParamScale;
+  auto x = at::randn({B * S, E}, options).to(at::kFloat);
+  auto ln0_w = at::randn(E, options).to(at::kFloat);
+  auto ln0_b = at::randn(E, options).to(at::kFloat);
+  auto mha_w0 = at::randn({3 * E, E}, options) * kParamScale;
+  auto mha_b0 = at::randn({3 * E}, options) * kParamScale;
+  auto mha_w1 = at::randn({E, E}, options) * kParamScale;
+  auto mha_b1 = at::randn({E}, options) * kParamScale;
+  auto ln1_w = at::randn(E, options).to(at::kFloat);
+  auto ln1_b = at::randn(E, options).to(at::kFloat);
+  auto mlp_w0 = at::randn({4 * E, E}, options) * kParamScale;
+  auto mlp_b0 = at::randn({4 * E}, options) * kParamScale;
+  auto grad = at::randn({B * S, E}, options).to(at::kFloat) * kParamScale;
+  auto mlp_w1 = at::randn({E, 4 * E}, options) * kParamScale;
+  auto mlp_b1 = at::randn({E}, options) * kParamScale;
 
   // Recomputed tensors
   auto mlp_dropout_mask = at::rand({B * S, E}, options).lt(1.0 - 0.1);
@@ -144,34 +144,34 @@ void backward_transformer(Communicator* communicator, bool profile) {
   auto ln1_mean = at::randn({B * S, 1}, options).to(at::kFloat);
   auto ln1_rstd = at::randn({B * S, 1}, options).to(at::kFloat);
   auto mha_linear1 = at::rand({B * S, E}, options).to(at::kFloat);
+  auto mha_linear0 = at::rand({B * S, E}, options).to(at::kFloat); // mha linear0
+  auto mlp_linear1 = at::rand({B * S, E}, options).to(at::kFloat); // mlp linear1
 
-  std::vector<c10::IValue> inputs = {
-      x_,
-      grad_,
-      shardTensor(mha_w0_.view({3, E, E}), 1, mesh, communicator)
-          .view({1, 3 * E / D, E}),
-      shardTensor(mha_b0_.view({3, E}), 1, mesh, communicator)
-          .view({1, 3 * E / D}),
-      shardTensor(mha_w1_, 1, mesh, communicator),
-      shardTensor(mlp_w0_, 0, mesh, communicator),
-      shardTensor(mlp_b0_, 0, mesh, communicator),
-      shardTensor(mlp_w1_, 1, mesh, communicator),
-      mlp_b1_,
+  std::vector<c10::IValue> at_inputs = {
+      x,
+      grad,
+      shardTensor(mha_w0.view({3, E, E}), 1, mesh, communicator).view({1, 3 * E / D, E}),
+      shardTensor(mha_w1, 1, mesh, communicator).unsqueeze(0),
+      shardTensor(mlp_w0, 0, mesh, communicator).unsqueeze(0),
+      shardTensor(mlp_w1, 1, mesh, communicator).unsqueeze(0),
       mlp_dropout_mask,
       mha_dropout_mask,
-      shardTensor(sdpa_output, 1, mesh, communicator),
-      shardTensor(sdpa_logsum_exp, 1, mesh, communicator),
+      shardTensor(sdpa_output, 1, mesh, communicator).unsqueeze(0),
+      shardTensor(sdpa_logsum_exp, 1, mesh, communicator).unsqueeze(0),
       sdpa_seed,
       sdpa_offset,
-      ln1_w_,
-      ln1_b_,
+      ln1_w,
+      ln1_b,
       ln1_mean,
       ln1_rstd,
-      ln0_w_,
-      ln0_b_,
+      ln0_w,
+      ln0_b,
       ln0_mean,
       ln0_rstd,
-      mha_linear1};
+      shardTensor(mha_linear0, 1, mesh, communicator).unsqueeze(0),
+      mha_linear1.to(at::kFloat),
+      shardTensor(mlp_linear1, 1, mesh, communicator).unsqueeze(0)
+    };
 
   DistributedTransformer model = DistributedTransformer(D, B, E, H, S);
   auto fec = model.backward(dtype);
@@ -186,7 +186,7 @@ void backward_transformer(Communicator* communicator, bool profile) {
     if (i >= warmup_itrs && profile) {
       nvtxRangePush(("Iteration" + std::to_string(i)).c_str());
     }
-    outputs = fec->runFusionWithInputs(inputs);
+    outputs = fec->runFusionWithInputs(at_inputs);
     cudaDeviceSynchronize();
     // cudaDeviceSynchronize is not blocking until kernels are finished on all
     // devices except 0
@@ -214,7 +214,7 @@ int main(int argc, char** argv) {
   // using this is as a flag for when to profile
   bool profile = argc > 1;
   auto communicator = &Communicator::getInstance();
-  forward_transformer(communicator, profile);
+  //forward_transformer(communicator, profile);
   //communicator->barrier();
-  //backward_transformer(communicator, profile);
+  backward_transformer(communicator, profile);
 }

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -90,7 +90,7 @@ void forward_transformer(Communicator* communicator, bool profile, bool sequence
       }
     }
     if (i >= warmup_itrs && profile) {
-      nvtxRangePush(("Iteration" + std::to_string(i)).c_str());
+      nvtxRangePush(("FwdIteration" + std::to_string(i)).c_str());
     }
     auto outputs = fec->runFusionWithInputs(at_inputs);
     cudaDeviceSynchronize();
@@ -99,7 +99,7 @@ void forward_transformer(Communicator* communicator, bool profile, bool sequence
     // TODO: are we not waiting until all kernels are appended to the stream?
     //std::cout << outputs[0][0][0] << std::endl;
 
-    if (i > warmup_itrs && profile) {
+    if (i >= warmup_itrs && profile) {
       nvtxRangePop();
     }
   }
@@ -188,7 +188,7 @@ void backward_transformer(Communicator* communicator, bool profile) {
       start = std::chrono::high_resolution_clock::now();
     }
     if (i >= warmup_itrs && profile) {
-      nvtxRangePush(("Iteration" + std::to_string(i)).c_str());
+      nvtxRangePush(("BwdIteration" + std::to_string(i)).c_str());
     }
     outputs = fec->runFusionWithInputs(at_inputs);
     cudaDeviceSynchronize();
@@ -197,7 +197,7 @@ void backward_transformer(Communicator* communicator, bool profile) {
     // TODO: are we not waiting until all kernels are appended to the stream?
     //std::cout << outputs[0][0][0][0] << std::endl;
 
-    if (i > warmup_itrs && profile) {
+    if (i >= warmup_itrs && profile) {
       nvtxRangePop();
     }
   }

--- a/benchmarks/cpp/transformer.cpp
+++ b/benchmarks/cpp/transformer.cpp
@@ -87,6 +87,7 @@ void forward_transformer(
   auto start = std::chrono::high_resolution_clock::now();
   for (auto i : c10::irange(num_itrs + warmup_itrs)) {
     if (i == warmup_itrs) {
+      cudaDeviceSynchronize();
       start = std::chrono::high_resolution_clock::now();
       if (profile) {
         cudaProfilerStart();
@@ -96,10 +97,12 @@ void forward_transformer(
       nvtxRangePush(("FwdIteration" + std::to_string(i)).c_str());
     }
     auto outputs = fec->runFusionWithInputs(at_inputs);
+
     if (i >= warmup_itrs && profile) {
       nvtxRangePop();
     }
   }
+  cudaDeviceSynchronize();
   auto end = std::chrono::high_resolution_clock::now();
 
   double foward_time =
@@ -183,16 +186,19 @@ void backward_transformer(Communicator* communicator, bool profile) {
   auto start = std::chrono::high_resolution_clock::now();
   for (auto i : c10::irange(num_itrs + warmup_itrs)) {
     if (i == warmup_itrs) {
+      cudaDeviceSynchronize();
       start = std::chrono::high_resolution_clock::now();
     }
     if (i >= warmup_itrs && profile) {
       nvtxRangePush(("BwdIteration" + std::to_string(i)).c_str());
     }
     outputs = fec->runFusionWithInputs(at_inputs);
+
     if (i >= warmup_itrs && profile) {
       nvtxRangePop();
     }
   }
+  cudaDeviceSynchronize();
   auto end = std::chrono::high_resolution_clock::now();
   if (profile) {
     cudaProfilerStop();


### PR DESCRIPTION
My last PR for this (https://github.com/NVIDIA/Fuser/pull/3684) added a transformer benchmark to the existing google benchmark suite, but I ran into some problems:

1. You can't profile the benchmark unless you disable the profiler by commenting out the code that enables it, otherwise there is a CUPTI_MULTIPLE_SUBSCRIBERS error
2. Google benchmark does not allow a fixed number of warmup iterations, just some amount of warmup time
3. It's helpful to only profile the measured iterations, and the benchmark framework does not give enough control for that

Because of these I opted to just update Meghan's benchmark with new ATen inputs, since she had made some changes to the model.