### PR TITLE
optimize pointwise, reduction, and normalizaiton schedulers for blackwell

### DIFF
--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -214,7 +214,7 @@ PersistentBufferStorageParams getPersistentBufferStorageParams(
   // Note: in current use cases (layer norm bwd and RMS norm bwd), there are
   // outer broadcast tvs and always project to inputs.
   const auto& outer_broadcast_tvs = getOuterBroadcastTvs(fusion, reduction_tvs);
-  buffer_params.project_to_input =
+  normalization_scheduler_utils::BufferProjectionStrategy project_strategy =
       normalization_scheduler_utils::isProjectBufferToInputs(
           fusion,
           runtime_info,
@@ -223,6 +223,11 @@ PersistentBufferStorageParams getPersistentBufferStorageParams(
           InnerOuterPersistentKernelScheduler::schedulerType(),
           /*can_use_smem_persistent=*/true,
           outer_broadcast_tvs.empty());
+
+  buffer_params.project_to_input =
+      (project_strategy ==
+       normalization_scheduler_utils::BufferProjectionStrategy::
+           ProjectToInputs);
 
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
   int64_t smem_overhead = scheduler_utils::getSharedMemoryOverheadPerBlock(

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -197,7 +197,6 @@ int64_t partialReductionBufferSize(
 using ReductionType = reduction_scheduler_utils::ReductionType;
 SchedulerType getPersistentHeuristicFor(ReductionType reduction_type);
 
-// get argument passed to innerPersistentHeuristic and outerPersistentHeuristic
 struct PersistentKernelProperties {
   int64_t inner_most_dimension_numel;
   int64_t total_reduction_numel;
@@ -209,6 +208,8 @@ struct PersistentKernelProperties {
   bool project_persistent_buffers;
   PrimDataType index_type;
   bool has_exp_op;
+  bool has_rng_op;
+  bool disable_project_to_avoid_recompute;
   std::vector<TensorView*> persistent_buffers;
   std::string toString() const {
     std::stringstream ss;
@@ -220,6 +221,8 @@ struct PersistentKernelProperties {
        << "n_tensor_inputs: " << n_tensor_inputs << "\n"
        << "max_input_dtype_size: " << max_dtype_size << "\n"
        << "max allowed vectorize_factor: " << vectorize_factor << "\n"
+       << "disable_project_to_avoid_recompute: "
+       << disable_project_to_avoid_recompute << "\n"
        << "project_persistent_buffers: " << project_persistent_buffers << "\n";
     return ss.str();
   }
@@ -286,10 +289,24 @@ int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
     const std::vector<TensorView*>& persistent_buffers,
     const bool can_use_smem_persistent);
 
-// Returns true if persistent buffers are projected to inputs, meaning the
-// inputs are cached instead of the persistent buffers. The decision of
-// projection is primarily based on the required sizes of the two cases --
-// projection is done if projecting to the inputs results in a smaller size.
+enum class BufferProjectionStrategy {
+  // Recompute persistent buffers from inputs, only need to cache inputs in
+  // registers or shared memories, usually used when size of required cached
+  // inputs is smaller than the size of persistent buffers.
+  ProjectToInputs,
+  // Don't project to inputs, to avoid recompute from inputs. This saves
+  // computation cost but uses more registers or shared memories. Usually used
+  // when the required buffer size  is small and hardware has high bandwidth to
+  // flops ratio.
+  NoProjectToAvoidRecompute,
+  // Project to inputs is disabled due to other reasons, e.g. can't reduce
+  // buffer size, recompute requires very expensive rng ops, not supported due
+  // to view ops.
+  NoProjectOtherReasons
+};
+
+// Returns BufferProjectionStrategy based on buffer size, hardware, and fusion
+// ops.
 
 // This function is used by inner persistent and InnerOuter persistent
 // schedulers.
@@ -311,7 +328,7 @@ int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
 // - exp in inner normalization: only allowed to get projected if the buffer is
 // smaller than a certain size Otherwise, as long as the projected inputs are
 // smaller than the original persistent buffers, this function returns true.
-bool isProjectBufferToInputs(
+BufferProjectionStrategy isProjectBufferToInputs(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     const scheduler_utils::PersistentBufferInfo& persistent_buffer_info,

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -29,6 +29,149 @@ namespace {
 // Unused at the moment, commenting for clang tidy
 constexpr int64_t kThreadX = 128;
 
+// Get number of vectorizable non-outer broadcast inputs
+// vectorizable_inputs: all vectorizable inputs
+// break_point: the break point of the broadcast flags.
+// Used to determine the influence of inputs on unroll factor.
+// outer broadcast inputs are not counted since outer unroll is used
+// and they are only loaded once regardless of the unroll factor due to
+// the re-use across different unrolled iterations.
+int64_t getNumOfNonOuterBcastInputs(
+    std::vector<TensorView*> vectorizable_inputs,
+    int64_t break_point) {
+  if (break_point == 0) {
+    return std::max((int64_t)vectorizable_inputs.size(), 1L);
+  }
+
+  // Returns true if tv is outer broadcast tv or is used by outer broadcast
+  // op.
+  auto isUsedByOuterBcast = [&break_point](TensorView* tv) {
+    // If all the dims to the left of the break point are broadcast, then
+    // this tv is considered as an outer broadcast.
+    const auto& domains = tv->getLogicalDomain();
+    if (std::all_of(
+            domains.begin(), domains.begin() + break_point, [](IterDomain* id) {
+              return id->isBroadcast();
+            })) {
+      return true;
+    }
+    // check consumers
+    const auto& all_consumers = DependencyCheck::getAllDependentVals({tv});
+    for (auto tv : all_consumers) {
+      if (tv->definition()->isA<BroadcastOp>()) {
+        const auto& bcast_flags =
+            tv->definition()->as<BroadcastOp>()->getBroadcastDimFlags();
+
+        if (std::all_of(
+                bcast_flags.begin(),
+                bcast_flags.begin() + break_point,
+                [](bool flag) { return flag; })) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+  int64_t n_non_bcast_inputs = 0;
+  for (auto tv : vectorizable_inputs) {
+    if (!isUsedByOuterBcast(tv)) {
+      n_non_bcast_inputs++;
+    }
+  }
+  // return 1 if no non-outer broadcast inputs to avoid division by 0
+  return std::max(n_non_bcast_inputs, 1L);
+}
+
+// calculate unroll factor based on inputs and computations.
+int64_t getEmpiricalUnrollFactor(
+    Fusion* fusion,
+    int64_t break_point,
+    int64_t vectorization_bytes,
+    std::vector<TensorView*> vectorizable_inputs) {
+  // no need to unroll if no vectorizable inputs
+  if (vectorizable_inputs.empty()) {
+    return 1;
+  }
+  const auto dev_prop = at::cuda::getCurrentDeviceProperties();
+  // calculate the required bytes in flight to cover the latency.
+  // assuming 100% occupancy.
+  int64_t required_bytes_per_thread =
+      scheduler_utils::getRequiredBytesInFlight() /
+      (int64_t)dev_prop->maxThreadsPerMultiProcessor;
+  int64_t unroll_factor =
+      std::max(1L, required_bytes_per_thread / vectorization_bytes);
+  // If unroll is required, further scale up with computation cost and scale
+  // down with input counts. Won't be triggered on A100 and H100.
+  if (unroll_factor > 1) {
+    int64_t computation_factor =
+        scheduler_utils::getComputationCostFactor(fusion);
+    unroll_factor *= computation_factor;
+    int64_t n_inputs_factor =
+        getNumOfNonOuterBcastInputs(vectorizable_inputs, break_point);
+    unroll_factor = scheduler_utils::safeDiv(unroll_factor, n_inputs_factor);
+  }
+  return unroll_factor;
+}
+
+// calculate unroll factor based on total blocks to ensure we still
+// have 8 waves after unroll.
+int64_t getElementBasedUnrollFactor(int64_t total_blocks) {
+  const auto dev_prop = at::cuda::getCurrentDeviceProperties();
+  const int64_t target_waves = 8L;
+  int64_t max_block_per_sm =
+      (int64_t)dev_prop->maxThreadsPerMultiProcessor / kThreadX;
+  int64_t n_waves_wo_unroll = ceilDiv(
+      total_blocks, max_block_per_sm * (int64_t)dev_prop->multiProcessorCount);
+  int64_t n_elems_limited_unroll =
+      scheduler_utils::roundUpPow2(ceilDiv(n_waves_wo_unroll, target_waves));
+  return n_elems_limited_unroll;
+}
+
+// returns unroll factor.
+// The unroll factor is calculated based on the following:
+// (1) ensure enough bytes in flight to cover gmem access latency
+// (2) ensure enough threads for thread level parallelism (TLP)
+// (3) when kernel doesn't have enough TLP and split is not divisible, don't
+// unroll.
+int64_t getUnrollFactor(
+    Fusion* fusion,
+    int64_t break_point,
+    int64_t total_blocks,
+    int64_t vectorization_bytes,
+    bool divisible_split,
+    std::vector<TensorView*> vectorizable_io_tvs) {
+  // only consider vectorizable inputs,
+  // needs to check if it's already in the list to avoid duplication since a tv
+  // may be both input and output, e.g. NVFuserTest.FusionIssue2372_CUDA
+  std::vector<TensorView*> vectorizable_inputs;
+  for (auto* tv : vectorizable_io_tvs) {
+    if (tv->isFusionInput() &&
+        std::find(vectorizable_inputs.begin(), vectorizable_inputs.end(), tv) ==
+            vectorizable_inputs.end()) {
+      vectorizable_inputs.push_back(tv);
+    }
+  }
+
+  int64_t empirical_unroll = getEmpiricalUnrollFactor(
+      fusion, break_point, vectorization_bytes, vectorizable_inputs);
+
+  // limit unroll factor when n_elems is small to ensure enough
+  // blocks for thread level parallelism.
+  int64_t n_elems_limited_unroll = getElementBasedUnrollFactor(total_blocks);
+
+  // Avoid unrolling when the unroll factor is constrained by `n_elems` and the
+  // split is not divisible. Why? While unrolling increases instruction-level
+  // parallelism (ILP), it decreases thread-level parallelism (TLP). A
+  // non-divisible split further reduces the number of effective threads, which
+  // negatively impacts TLP. Therefore, if the kernel lacks sufficient TLP,
+  // unrolling should be avoided.
+  if (n_elems_limited_unroll < empirical_unroll && !divisible_split) {
+    return 1;
+  } else {
+    return std::min(n_elems_limited_unroll, empirical_unroll);
+  }
+}
+
 } // namespace
 
 std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
@@ -39,7 +182,6 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
 
   // Incase any buffer is of type DataType::Index
   const auto index_type = runtime_info.getIndexType();
-
   auto params = std::make_unique<PointwiseParams>();
   params->tag = "Pointwise heuristics";
   params->cparams.index_type = index_type;
@@ -155,28 +297,22 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
       });
 
   constexpr int64_t kSixteen = 16; // clang tidy
-
-  auto max_vect_unroll_factor = ceilDiv(
-      // Available unrolling based on size of data type
+  auto max_vect_factor = ceilDiv(
+      // Available vectorization based on size of data type
       (int64_t)kSixteen / max_input_dtype_size,
-      // Reduce max unrolling factor if we have many inputs/outputs to unroll
-      // as it could start consuming a lot of registers.
+      // Reduce max vectorization factor if we have many inputs/outputs to
+      // vectorize as it could start consuming a lot of registers.
       std::max(
           (scheduler_utils::lastPow2(
                (int64_t)vectorizable_inputs_outputs_entry.get().size()) >>
            2),
           (int64_t)1));
-
-  // Don't unroll at the cost of getting a full wave on the GPU
-  if (n_elems < device_multiprocessor_count * kThreadX &&
-      max_vect_unroll_factor > 1) {
-    max_vect_unroll_factor = std::min(
-        max_vect_unroll_factor,
+  // Don't vectorize at the cost of getting a full wave on the GPU
+  if (n_elems < device_multiprocessor_count * kThreadX && max_vect_factor > 1) {
+    max_vect_factor = std::min(
+        max_vect_factor,
         ceilDiv(n_elems, device_multiprocessor_count * kThreadX));
   }
-
-  auto max_vect_factor =
-      std::min(kSixteen / max_input_dtype_size, max_vect_unroll_factor);
 
   // See pointwise.h to understand what we're doing for this 2D analysis.
   // Ideal break point location
@@ -226,6 +362,8 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
     dtype_sum += (int64_t)dataTypeSize(out->getDataType().value(), index_type);
   }
 
+  // Indicates whether the fusion is outer broadcast dominated or not.
+  bool is_outer_broadcast_dominated = false;
   { // Figure out break point position. Empty scope, consider moving to a
     // separate function.
     //
@@ -239,7 +377,8 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
     // If there isn't very much parallelism available, just use 1D scheduler
     if (n_elems * 2 > device_multiprocessor_count * kThreadX) {
       int64_t min_total_transfer = std::numeric_limits<int64_t>::max();
-
+      int64_t threads_per_warp =
+          (int64_t)at::cuda::getCurrentDeviceProperties()->warpSize;
       // Don't check the inner most dimension, scheduler assumes there's always
       // an rhs
       for (const auto break_point_i : c10::irange((int64_t)ref_root.size())) {
@@ -290,7 +429,7 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
 
         // Need to be able to parallelize, don't use break if there's not
         // at least an unrolled warp.
-        if (ceilDiv(cur_right_elem_count, max_vect_unroll_factor) <=
+        if (ceilDiv(cur_right_elem_count, max_vect_factor) <=
             at::cuda::getCurrentDeviceProperties()->warpSize) {
           continue;
         }
@@ -306,17 +445,17 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
           flip_grid_binding = false;
         }
         // Min transfer found, start setting values
-        bdimx = std::min(
-            ceilDiv(cur_right_elem_count, max_vect_unroll_factor), kThreadX);
-        bdimy = 1;
-        // Put remainder in bdimy if there's at least a wave of grid level
-        // parallelism.
-        if (cur_left_elem_count > device_multiprocessor_count) {
-          bdimy = kThreadX / bdimx;
+        // Start bdimx with 1 warp, increase if split is divisible
+        int64_t after_vect = ceilDiv(cur_right_elem_count, max_vect_factor);
+        bdimx = std::min(after_vect, threads_per_warp);
+        while (bdimx * 2 <= kThreadX && bdimx * 2 <= after_vect &&
+               after_vect % (bdimx * 2) == 0) {
+          bdimx *= 2;
         }
+        bdimy = kThreadX / bdimx;
         auto remainder_left = ceilDiv(cur_left_elem_count, bdimy);
         auto remainder_right =
-            ceilDiv(cur_right_elem_count, bdimx * max_vect_unroll_factor);
+            ceilDiv(cur_right_elem_count, bdimx * max_vect_factor);
         // Use this break point
         break_point = static_cast<int>(break_point_i);
         min_total_transfer = cur_transfer_size;
@@ -324,6 +463,10 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
 
         gdim_left = remainder_left;
         gdim_right = remainder_right;
+
+        // when lhs byte multiple is smaller than rhs byte multiple,
+        // there is broadcast in the lhs, which is outer broadcast.
+        is_outer_broadcast_dominated = lhs_byte_multiple < rhs_byte_multiple;
       }
     }
   }
@@ -337,29 +480,31 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
           break_point,
           logical_reorder_map));
 
-  // preserve the old heuristic where unroll is used only when vectorization is
-  // not used. should allow to use both unroll and vectorization together in
-  // heuristics tuning.
-  if (params->vectorization_factor == 1) {
-    auto total_unroll = scheduler_utils::safeDiv(
-        max_vect_unroll_factor, params->vectorization_factor);
-    // for 1D scheduler, unroll the inner dimension
-    // since there is no outer dimension.
-    if (break_point == 0) {
-      params->unroll_factor_inner = total_unroll;
-      params->unroll_factor_outer = 1L;
-    } else {
-      // for 2D scheduler, unroll the outer dimension
-      // to prioritize resue across different rows, will
-      // be revised in heuristics tuning, e.g. unroll different
-      // dims based on the broadcast dimension.
-      params->unroll_factor_inner = 1L;
-      params->unroll_factor_outer = total_unroll;
-    }
+  // get unroll factor:
+
+  int64_t total_blocks = break_point > 0
+      ? gdim_left * gdim_right
+      : ceilDiv(n_elems / max_vect_factor, kThreadX);
+  bool divisible_split = break_point > 0
+      ? (right_elem_count % (params->vectorization_factor * bdimx) == 0)
+      : (n_elems % (params->vectorization_factor * kThreadX) == 0);
+  int64_t unroll_factor = getUnrollFactor(
+      fusion,
+      break_point,
+      total_blocks,
+      params->vectorization_factor * max_input_dtype_size,
+      divisible_split,
+      vectorizable_inputs_outputs_entry.get());
+
+  if (is_outer_broadcast_dominated) {
+    params->unroll_factor_outer = unroll_factor;
+  } else {
+    params->unroll_factor_inner = unroll_factor;
   }
+  gdim_left = ceilDiv(gdim_left, params->unroll_factor_outer);
+  gdim_right = ceilDiv(gdim_right, params->unroll_factor_inner);
 
   NVF_ERROR(right_elem_count > 0 || break_point == 0);
-  NVF_ERROR(!(bdimy > 1 && gdim_right > 1));
 
   params->break_point = break_point;
   params->flip_grid_binding = flip_grid_binding;

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -792,7 +792,7 @@ std::unique_ptr<ReductionParams> inner3dReductionHeuristic(
           total_iteration_numel,
           (int64_t)n_tensor_inputs,
           (int64_t)max_input_dtype_size,
-          vectorize_factor,
+          (int64_t)vectorize_factor,
           has_mufu_computation);
     }
   }
@@ -1318,7 +1318,7 @@ std::unique_ptr<ReductionParams> outerReductionHeuristic(
   // registers for other purposes. Test shows it leads to 50% occupancy for
   // outer reduction without fused ops and 50% occupancy for gelu backward which
   // fused 21 ops including the expensive tanh op.
-  int64_t buffer_reg_count, input_factor;
+  int64_t buffer_reg_count = 0L, input_factor = 0L;
   if (has_mufu_computation) {
     // when we have expensive ops, computation cost of each thread is already
     // high, prioritize thread level parallelism, 8 registers are reserved for
@@ -1386,7 +1386,7 @@ std::unique_ptr<ReductionParams> reductionHeuristic(
           total_iteration_numel,
           (int64_t)n_tensor_inputs,
           (int64_t)max_input_dtype_size,
-          vectorize_factor,
+          (int64_t)vectorize_factor,
           has_mufu_computation);
     } else {
       return inner3dReductionHeuristic(

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2739,6 +2739,163 @@ void reorderTensorLike(
   target_tv->reorder(old2new);
 }
 
-} // namespace scheduler_utils
+namespace {
+// Class to handle expensive operations information and calculation of unroll
+// factors
+class ExpensiveOpInfo {
+ public:
+  ExpensiveOpInfo() : n_tanh_(0), n_exp_(0), n_reciprocal_(0) {}
+  void analyzeFusion(Fusion* fusion) {
+    for (auto expr : fusion->exprs()) {
+      if (auto unary = dynamic_cast<UnaryOp*>(expr)) {
+        switch (unary->getUnaryOpType()) {
+          case UnaryOpType::Tanh:
+            n_tanh_++;
+            break;
+          case UnaryOpType::Exp:
+            n_exp_++;
+            break;
+          case UnaryOpType::Reciprocal:
+            n_reciprocal_++;
+            break;
+          default:
+            break;
+        }
+      }
+    }
+  }
 
+  std::string toString() const {
+    std::stringstream ss;
+    ss << "ExpensiveOpInfo: {";
+    ss << "n_tanh: " << n_tanh_ << ", ";
+    ss << "n_exp: " << n_exp_ << ", ";
+    ss << "n_reciprocal: " << n_reciprocal_ << "}";
+    return ss.str();
+  }
+
+  int64_t getComputationCostFactor() const {
+    auto factor =
+        n_tanh_ * f_tanh_ + n_exp_ * f_exp_ + n_reciprocal_ * f_reciprocal_;
+    factor = std::max(factor, 1);
+
+    // capped at 4 to avoid excessive unrolling which may lead to high register
+    // usage and low occupancy.
+    factor = std::min(factor, 4);
+    return factor;
+  }
+
+ private:
+  // Number of each expensive operation in the fusion
+  int n_tanh_;
+  int n_exp_;
+  int n_reciprocal_;
+
+  // Empirical factors to consider the cost of each operation
+  static constexpr int f_tanh_ = 4;
+  static constexpr int f_exp_ = 1;
+  static constexpr int f_reciprocal_ = 1;
+};
+} // namespace
+
+int64_t getComputationCostFactor(Fusion* fusion) {
+  ExpensiveOpInfo info;
+  info.analyzeFusion(fusion);
+  return info.getComputationCostFactor();
+}
+
+// Calculate hardware bandwidth and required bytes in flight based on
+// little's law. bytes_in_flight = bandwidth * latency
+int64_t getRequiredBytesInFlight() {
+  // H100, 32KB in flight @ 3352 GB/s = 9.5e-9 seconds
+  constexpr float empirical_gmem_latency = 9.5e-9;
+  const auto dev_prop = at::cuda::getCurrentDeviceProperties();
+  float hardware_bandwidth = 2 * (dev_prop->memoryBusWidth / 8) *
+      (float)dev_prop->memoryClockRate * 1e3;
+  return empirical_gmem_latency * hardware_bandwidth;
+}
+
+namespace {
+// Function to get the number of CUDA cores per SM.
+// convert {major, minor} to hex number and check the map.
+int getCoresPerSM(int major, int minor) {
+  int sm_version = (major << 4) + minor;
+  std::unordered_map<int, int> cores_per_sm_map = {
+      {0x30, 192},
+      {0x32, 192},
+      {0x35, 192},
+      {0x37, 192},
+      {0x50, 128},
+      {0x52, 128},
+      {0x53, 128},
+      {0x60, 64},
+      {0x61, 128},
+      {0x62, 128},
+      {0x70, 64},
+      {0x72, 64},
+      {0x75, 64},
+      {0x80, 64},
+      {0x86, 128},
+      {0x87, 128},
+      {0x89, 128},
+      {0x90, 128},
+      {0xa0, 128}};
+  auto it = cores_per_sm_map.find(sm_version);
+  if (it != cores_per_sm_map.end()) {
+    return it->second;
+  }
+  NVF_THROW("Unknown GPU architecture: ", major, ".", minor);
+  return 128;
+}
+} // namespace
+// Compute bandwidth flops ratio, return true if it's higher than
+// the reference value of 0.07. It returns true for B100/200 and A100.
+// Returns false for H100. The reference value is based on test of softmax,
+// layer norm, and rms norm. Treating A100 as high bandwidth to flops ratio
+// leads to better performance for softmax and dropout fused with layer norm
+// or rms norm, but caused minor regressions for layer norm or rms norm alone.
+bool isHighBandwidthFlopsRatio() {
+  // B200-XXXX-XXXX, 8.192e12 B/s, 7.47e13 flops, ratio = 0.1096
+  // A100-PCIe-80GB, 1.935e12 B/s, 1.95e13 flops, ratio = 0.0993
+  // A100-SXM4-40GB, 1.555e12 B/s, 1.95e13 flops, ratio = 0.0798
+  // H100-HBM3-80GB, 3.352e12 B/s, 6.69e13 flops, ratio = 0.0501
+  constexpr float reference_ratio = 0.07;
+  const auto dev_prop = at::cuda::getCurrentDeviceProperties();
+  // bandwidth
+  float hardware_bandwidth = 2 * (dev_prop->memoryBusWidth / 8) *
+      (float)dev_prop->memoryClockRate * 1e3;
+  // fp32 cuda core flops
+  const int cuda_core_per_sm = getCoresPerSM(dev_prop->major, dev_prop->minor);
+  const int flops_per_cycle = 2;
+  float flops = (float)dev_prop->clockRate * 1e3 *
+      dev_prop->multiProcessorCount * cuda_core_per_sm * flops_per_cycle;
+
+  float bandwidth_flops_ratio = hardware_bandwidth / flops;
+  return bandwidth_flops_ratio > reference_ratio;
+}
+
+bool hasExpensiveMUFUops(Fusion* fusion) {
+  const std::unordered_set<UnaryOpType> expensive_unary_ops{
+      UnaryOpType::Exp,
+      UnaryOpType::Tanh,
+      UnaryOpType::Reciprocal,
+      UnaryOpType::Rsqrt,
+      UnaryOpType::Log,
+      UnaryOpType::Log10,
+      UnaryOpType::Log2,
+      UnaryOpType::Sin,
+      UnaryOpType::Cos};
+
+  for (auto expr : fusion->exprs()) {
+    if (expr->isA<UnaryOp>()) {
+      if (auto unary = expr->as<UnaryOp>()) {
+        if (expensive_unary_ops.count(unary->getUnaryOpType())) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+} // namespace scheduler_utils
 } // namespace nvfuser

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2810,9 +2810,9 @@ int64_t getRequiredBytesInFlight() {
   // H100, 32KB in flight @ 3352 GB/s = 9.5e-9 seconds
   constexpr float empirical_gmem_latency = 9.5e-9;
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
-  float hardware_bandwidth = 2 * (dev_prop->memoryBusWidth / 8) *
+  float hardware_bandwidth = (float)(2 * (dev_prop->memoryBusWidth / 8)) *
       (float)dev_prop->memoryClockRate * 1e3;
-  return empirical_gmem_latency * hardware_bandwidth;
+  return (int64_t)(empirical_gmem_latency * hardware_bandwidth);
 }
 
 namespace {
@@ -2859,15 +2859,15 @@ bool isHighBandwidthFlopsRatio() {
   // A100-PCIe-80GB, 1.935e12 B/s, 1.95e13 flops, ratio = 0.0993
   // A100-SXM4-40GB, 1.555e12 B/s, 1.95e13 flops, ratio = 0.0798
   // H100-HBM3-80GB, 3.352e12 B/s, 6.69e13 flops, ratio = 0.0501
-  constexpr float reference_ratio = 0.07;
+  constexpr float reference_ratio = 0.07f;
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
   // bandwidth
-  float hardware_bandwidth = 2 * (dev_prop->memoryBusWidth / 8) *
-      (float)dev_prop->memoryClockRate * 1e3;
+  float hardware_bandwidth = (float)(2 * (dev_prop->memoryBusWidth / 8)) *
+      (float)dev_prop->memoryClockRate * 1000.f;
   // fp32 cuda core flops
   const int cuda_core_per_sm = getCoresPerSM(dev_prop->major, dev_prop->minor);
   const int flops_per_cycle = 2;
-  float flops = (float)dev_prop->clockRate * 1e3 *
+  float flops = (float)dev_prop->clockRate * 1000.f *
       dev_prop->multiProcessorCount * cuda_core_per_sm * flops_per_cycle;
 
   float bandwidth_flops_ratio = hardware_bandwidth / flops;

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2810,8 +2810,8 @@ int64_t getRequiredBytesInFlight() {
   // H100, 32KB in flight @ 3352 GB/s = 9.5e-9 seconds
   constexpr float empirical_gmem_latency = 9.5e-9;
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
-  float hardware_bandwidth = (float)(2 * (dev_prop->memoryBusWidth / 8)) *
-      (float)dev_prop->memoryClockRate * 1e3;
+  float hardware_bandwidth = 2.f * (float)dev_prop->memoryBusWidth / 8.f *
+      (float)dev_prop->memoryClockRate * 1000.f;
   return (int64_t)(empirical_gmem_latency * hardware_bandwidth);
 }
 
@@ -2862,13 +2862,14 @@ bool isHighBandwidthFlopsRatio() {
   constexpr float reference_ratio = 0.07f;
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
   // bandwidth
-  float hardware_bandwidth = (float)(2 * (dev_prop->memoryBusWidth / 8)) *
+  float hardware_bandwidth = 2.f * (float)dev_prop->memoryBusWidth / 8.f *
       (float)dev_prop->memoryClockRate * 1000.f;
   // fp32 cuda core flops
   const int cuda_core_per_sm = getCoresPerSM(dev_prop->major, dev_prop->minor);
   const int flops_per_cycle = 2;
   float flops = (float)dev_prop->clockRate * 1000.f *
-      dev_prop->multiProcessorCount * cuda_core_per_sm * flops_per_cycle;
+      (float)dev_prop->multiProcessorCount * (float)cuda_core_per_sm *
+      (float)flops_per_cycle;
 
   float bandwidth_flops_ratio = hardware_bandwidth / flops;
   return bandwidth_flops_ratio > reference_ratio;

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2855,7 +2855,7 @@ int getCoresPerSM(int major, int minor) {
 // leads to better performance for softmax and dropout fused with layer norm
 // or rms norm, but caused minor regressions for layer norm or rms norm alone.
 bool isHighBandwidthFlopsRatio() {
-  // B200-XXXX-XXXX, 8.192e12 B/s, 7.47e13 flops, ratio = 0.1096
+  // B200          , 8.192e12 B/s, 7.47e13 flops, ratio = 0.1096
   // A100-PCIe-80GB, 1.935e12 B/s, 1.95e13 flops, ratio = 0.0993
   // A100-SXM4-40GB, 1.555e12 B/s, 1.95e13 flops, ratio = 0.0798
   // H100-HBM3-80GB, 3.352e12 B/s, 6.69e13 flops, ratio = 0.0501

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -728,6 +728,24 @@ void moveNonConcretizedBroadcastInnermost(
     Fusion* fusion,
     const std::unordered_set<TensorView*>& ignored_tvs = {});
 
+// Returns a factor represents the computation cost of the given fusion.
+// Estimated using the number of MUFU operations, each weighted with a
+// predefined factor.
+int64_t getComputationCostFactor(Fusion* fusion);
+
+// Returns the required bytes in flight to saturate the memory bandwidth.
+int64_t getRequiredBytesInFlight();
+
+// Returns true if the device has a high bandwidth to compute raito.
+bool isHighBandwidthFlopsRatio();
+
+// Return true if the fusion has computation requires Floating-Point
+// Multi-Function (MUFU) units, e.g. cos, sin, exponent, logarithm, sine,
+// cosine, square root, hyperbolic tangent. Currently, we only tested tanh, exp,
+// and Reciprocal. Note that, if compiled with fast math (not supported yet) or
+// directly lowered with inlined ptx, needs to revise the inner reduction
+// heuristics which uses this function to set the optimal unroll factor.
+bool hasExpensiveMUFUops(Fusion* fusion);
 // Reorder DID parallelized axes to outermost positions. Returns
 // the position of the outermost non-DID axis.
 int64_t reorderDevicesToOuter(TensorView* tv);

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -6049,7 +6049,14 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWrite_CUDA) {
     FusionGuard fg(&fusion);
 
     std::vector<int64_t> shape0;
-    std::vector<int64_t> shape1({2, 64, 128, 2048});
+    // inner dim should be large enough to trigger the issue
+    // 10240 >= vect (4) x threads per block (512) x max unroll (5).
+    // In inner reduction, TIDx is used for the reduction axis, if it
+    // is less than 512, TIDy is used for iteration axis, this leads
+    // to a split in the iteration axis, current redundant write remover
+    // can't handle this case since it only checks the loop domain whose
+    // definition is a merge.
+    std::vector<int64_t> shape1({2, 64, 2, 10240});
     const size_t ndim = shape1.size();
     for (size_t i = 0; i < ndim; i++) {
       if (!is_broadcast[i]) {
@@ -6173,7 +6180,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteDifferentConcretizedDomains_CUDA) {
                 &fusion, SchedulerType::Reduction, aten_inputs, false);
           },
           testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
-              "Producer is required to be in Global Memory based on parallelization strategy. RAW flags: (blockIdx.x)")));
+              "Producer is required to be in Global Memory based on parallelization strategy.")));
     } else {
       FusionExecutorCache executor_cache(std::move(fusion_ptr));
       auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -7614,61 +7621,6 @@ TEST_F(NVFuserTest, IndexDataTypePromotion) {
   ee.bind(b, 299792458L);
   EXPECT_EQ(ee.evaluate(c), 299792459L);
   EXPECT_EQ(c->dtype(), DataType::Index);
-}
-
-TEST_F(NVFuserTest, FusionCrossGridInnerReductionSplitGridIteration_CUDA) {
-  // reduction size is set to 65538 to triger cross grid reduction and iter
-  // unroll. iteration size is set to a value larger than y_grid_limit to test
-  // if iter domain is split grid.
-  // This test requires significant memory. Release any cached memory
-  // from previous tests to ensure availability.
-  maybeClearAllocator(0);
-
-  DataType dtype = DataType::Float;
-  int64_t reduction_size = 65538;
-  int64_t iteration_size = scheduler_utils::y_grid_limit + 8;
-  std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
-  Fusion& fusion = *fusion_ptr.get();
-  FusionGuard fg(&fusion);
-
-  std::vector<int64_t> input_shape{iteration_size, reduction_size};
-  auto t0 = makeContigTensor(2, dtype);
-  auto t1 = sum(t0, {1});
-  fusion.addInput(t0);
-  fusion.addOutput(t1);
-
-  // Estimated_gmem is 17.18 GBytes, skip if not enough memory.
-  size_t n_elements = reduction_size * iteration_size + iteration_size * 2;
-  size_t estimated_gmem = n_elements * dataTypeSize(dtype);
-  size_t device_free, device_total;
-  cudaMemGetInfo(&device_free, &device_total);
-  if (estimated_gmem > device_free) {
-    GTEST_SKIP() << "Skipping test due to limited GPU memory. Requested: "
-                 << estimated_gmem / 1e9 << " GBytes"
-                 << ", device_free: " << device_free / 1e9 << " GBytes"
-                 << ", device_total: " << device_total / 1e9 << " GBytes";
-  }
-  auto options =
-      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
-  at::Tensor aten_input = at::randn(input_shape, options);
-
-  auto cg_results =
-      scheduleAndRun(&fusion, SchedulerType::Reduction, {aten_input});
-  auto rparams = cg_results.heuristic_params->as<ReductionParams>();
-  ASSERT_TRUE(rparams->split_grid_dim_inner_reduction)
-      << "Generated reduction is not cross grid!";
-  ASSERT_TRUE(rparams->split_grid_dim_iter_dom_outer)
-      << "Generated reduction is not split iteration domain!";
-  auto aten_outputs = aten_input.sum({1});
-  testValidate(
-      &fusion,
-      cg_results.outputs,
-      {aten_input},
-      {aten_outputs},
-      __LINE__,
-      __FILE__,
-      "",
-      rparams->lparams);
 }
 
 TEST_F(NVFuserTest, SymbolicOneBroadcasting) {

--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -891,10 +891,12 @@ TEST_F(PersistentBufferTest, SoftmaxProjectToInput) {
         scheduleAndRun(&fusion, SchedulerType::InnerPersistent, {aten_input});
     auto rparams = cg_results.heuristic_params->as<ReductionParams>();
 
-    // 24576 is the threshold to project to inputs. see deriviation in
-    // isProjectBufferToInputs()
+    // Threshold to project to inputs
+    int64_t buffer_threshold = scheduler_utils::isHighBandwidthFlopsRatio()
+        ? 24 * 1024 * 4
+        : 6 * 1024 * 4;
     bool should_project_to_input =
-        feature * dataTypeSize(DataType::Float) > 24576l;
+        feature * dataTypeSize(DataType::Float) > buffer_threshold;
     NVF_CHECK(
         rparams->project_persistent_buffers == should_project_to_input,
         should_project_to_input ? "Should project to inputs!"
@@ -1016,9 +1018,15 @@ TEST_F(PersistentBufferTest, ProjectToInputsAndBroadcastTvs2) {
   auto heuristic_params = SchedulerEntry::scheduleWith(
       fusion, SchedulerType::InnerPersistent, {t0});
   auto rparams = heuristic_params->as<ReductionParams>();
-  NVF_CHECK(
-      rparams->project_persistent_buffers,
-      "Should project persistent buffers to inputs!");
+  if (scheduler_utils::isHighBandwidthFlopsRatio()) {
+    NVF_CHECK(
+        !rparams->project_persistent_buffers,
+        "Should not project persistent buffers to inputs!");
+  } else {
+    NVF_CHECK(
+        rparams->project_persistent_buffers,
+        "Should project persistent buffers to inputs!");
+  }
 }
 
 TEST_F(PersistentBufferTest, ProjectToInputsAndBroadcastTvs3) {
@@ -1040,7 +1048,10 @@ TEST_F(PersistentBufferTest, ProjectToInputsAndBroadcastTvs3) {
   auto tv5 = add(tv1, tv4);
   fusion->addOutput(tv5);
 
-  auto tv6 = exp(tv5);
+  // Ensure there is no exp op in the fusion, otherwise
+  // project to inputs depends on the buffer size and bandwidth flops ratio of
+  // the hardware.
+  auto tv6 = mul(tv5, tv5);
   auto tv7 = sum(tv6, {1, 2});
   auto tv8 = broadcast(tv7, {false, true, true});
   auto tv9 = add(tv6, tv8);

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -613,8 +613,8 @@ class NVFuserTest : public ::testing::Test {
 class HopperBase : public NVFuserTest {
  protected:
   void SetUp() override {
-    if (cudaArchGuardShouldSkip(9, 0)) {
-      GTEST_SKIP() << "skipping tests on pre-Hopper GPUs";
+    if (cudaArchGuardShouldSkip(9, 0, 10, 0)) {
+      GTEST_SKIP() << "skipping tests on non-Hopper GPUs";
     }
     NVFuserTest::SetUp();
   }


### PR DESCRIPTION
Summary of major changes:
**1. Pointwise scheduler:** Add unroll in inner or outer dim, unroll factor is estimated from ops in the fusion & bytes in flight.
```
(1) Added function getUnrollFactor() to estimate unroll factor

// The unroll factor is calculated based on the following:
// (1) ensure enough bytes in flight to cover gmem access latency
// (2) ensure enough blocks for thread level parallelism (TLP)
// (3) don't unroll if split is not divisible and don't have enough TLP.


(2) Apply unroll to inner or outer dim
If the fusion is outer broadcast dominated, apply unroll to outer dim, otherwise, apply to inner dim.
Based on break point, when lhs byte multiple is smaller than rhs byte multiple, lhs has larger broadcast domains, the fusion is outer broadcast dominated.

(3) Revised bdimx to start from warp size to ensure divisible split of rhs elements in 2D scheduler. Performance profile is more smooth.
```
**2. Inner reduction scheduler:** 
```
(1) Add unroll on top of vectorization, unroll factor is derived from required bytes in flight.
(2) Prioritize block reduction over grid reduction, only do grid reduction when not all SMs are used.
(3) Revised to use a CTA size of \`128 or 256\`, and \`512\` is only used when the number of CTAs is small and we need more threads per CTA to saturate the SMs. This change leads to higher performance for fusions with computation expensive ops.
```


**3. Outer reduction scheduler**: Adjust unroll factor.
```
Previously, outer reduction unroll factor is derived using 8 buffer registers, after vectorization of 16 bytes, the unroll factor is 8 * 4 / 16 = 2. This is used when number of inputs <= 4. And decreased to 1 when the fusion has more than 4 inputs.
Intesad of using this dramastic change after 4 inputs, this PR changed to gradually reduce from 32 registers to 8 registers from 1 input to 4 inputs. For example, when there is 1 input, the corresponding register is 32, unroll factor is 32 x 4 / 16 = 8. Similarly, for 2 inputs, unroll factor is 32 * 4 / 16 / 2 = 4; 4 inputs, unroll factor is 2. This change only applies to fusions without expensive ops as test shows there are some regressions when the fusion has expensive ops, e.g. tanh, and no speedup is observed. The reason is because when we have expensive ops, computation cost of each thread is already high, we should prioritize thread level parallelism instead of instruction level parallelism.
```
**4. Inner persistent scheduler:**
```
(1) Added util function to return true if the device has a high bandiwidth to compute flops ratio. Based on test, the cut-off bandiwidth to compute flops ratio is set to 0.07. So it retures true for A100/B100/B200 and false for H100.

(2) When a device has high bandiwidth to compute flops ratio (A100 & B100/200), do the following optimizations:

\--(2.1) revise when should we disable project to inputs to avoid recomputation. Changed from 24KB to 96KB. Applies to softmax.

\--(2.2) reivse target occupany from 28 warps per sm to 16 warps per sm. Applies to softmax.

\--(2.3) disable magic 0. Applies to softmax

\--(2.4) revise sorting of candidates. Applies to all fusions, e.g. ln, rms norm, softmax.

The purposes of these optimizations are added in the code comments, generally they are added to reduce computation cost, increase persistent batch size (more bytes in flight)
```