### PR TITLE
change parent of TMATest from HopperBase to TMABase

### DIFF
--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -176,7 +176,7 @@ TEST_F(MemoryTest, RefineCachePolicy) {
 
 // Begin TMA tests
 
-using TMATest = HopperBase;
+using TMATest = TmaBase;
 
 // Check that there is an xor "^" somewhere in the kernel
 class XorFinder : private kir::IrVisitor {

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -620,6 +620,17 @@ class HopperBase : public NVFuserTest {
   }
 };
 
+// TMA is supported on Hopper and newer GPUs
+class TmaBase : public NVFuserTest {
+ protected:
+  void SetUp() override {
+    if (cudaArchGuardShouldSkip(9, 0)) {
+      GTEST_SKIP() << "skipping tests on pre-Hopper GPUs";
+    }
+    NVFuserTest::SetUp();
+  }
+};
+
 // Fixture with param class must be uniquely identified, i.e., can't be in an
 // anonymous namespace
 template <typename tParam>


### PR DESCRIPTION
**Background**
To avoid running Hopper matmul tests on Blackwell GPUs (there are unsupported ptx), `HopperBase` was changed from `Hopper & Newer` to `Hopper Only` in #3754 .

**Changes in this PR**
To still keep testing `TMA` on both Hopper and Blackwell GPUs, in this PR, the parent class of `TMATest` is changed from `HopperBase` to `TMABase`. `TMABase` allows running tests on `Hopper & Newer`