### PR TITLE
Preserve registered extent mappings

### DIFF
--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -856,6 +856,13 @@ std::vector<TensorView*> Fusion::allTvs() {
 }
 
 void Fusion::registerExactMapping(IterDomain* id0, IterDomain* id1) {
+  NVF_ERROR(
+      id0->sameAs(id1),
+      "Invalid domains to map: ",
+      id0->toString(),
+      ", ",
+      id1->toString());
+
   if (!hasRegisteredExactMappings()) {
     manage(exact_mappings_key, DisjointSets<IterDomain*>{});
   }

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -857,7 +857,7 @@ std::vector<TensorView*> Fusion::allTvs() {
 
 void Fusion::registerExactMapping(IterDomain* id0, IterDomain* id1) {
   NVF_ERROR(
-      id0->sameAs(id1),
+      id0->extent()->sameAs(id1->extent()),
       "Invalid domains to map: ",
       id0->toString(),
       ", ",

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -873,4 +873,10 @@ DisjointSets<IterDomain*> Fusion::registeredExactMappings() const {
   return getManaged<DisjointSets<IterDomain*>>(exact_mappings_key);
 }
 
+void Fusion::resetExactMappings() {
+  if (hasRegisteredExactMappings()) {
+    stopManaging(exact_mappings_key);
+  }
+}
+
 } // namespace nvfuser

--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -856,13 +856,6 @@ std::vector<TensorView*> Fusion::allTvs() {
 }
 
 void Fusion::registerExactMapping(IterDomain* id0, IterDomain* id1) {
-  NVF_ERROR(
-      id0->sameAs(id1),
-      "Invalid domains to map: ",
-      id0->toString(),
-      ", ",
-      id1->toString());
-
   if (!hasRegisteredExactMappings()) {
     manage(exact_mappings_key, DisjointSets<IterDomain*>{});
   }

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -432,6 +432,8 @@ class NVF_API Fusion : public IrContainer {
 
   DisjointSets<IterDomain*> registeredExactMappings() const;
 
+  void resetExactMappings();
+
  protected:
   friend SegmentCandidateFinder;
   friend SegmentedFusion;

--- a/csrc/host_ir/container.cpp
+++ b/csrc/host_ir/container.cpp
@@ -54,6 +54,8 @@ KernelExecutor* HostIrContainer::getKernelExecutor(int64_t index) const {
   return kernel_executors_.at(index).get();
 }
 
+HostIrContainer::~HostIrContainer() {}
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/csrc/host_ir/container.cpp
+++ b/csrc/host_ir/container.cpp
@@ -54,8 +54,6 @@ KernelExecutor* HostIrContainer::getKernelExecutor(int64_t index) const {
   return kernel_executors_.at(index).get();
 }
 
-HostIrContainer::~HostIrContainer() {}
-
 } // namespace hir
 
 } // namespace nvfuser

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -460,7 +460,7 @@ bool hasAnyReductionOps(Fusion* fusion) {
 
 namespace {
 
-class ValReplacementMutator : private OptOutMutator {
+class ValReplacementMutator : public OptOutMutator {
  public:
   ValReplacementMutator(
       Fusion* fusion,
@@ -565,11 +565,12 @@ class ValReplacementMutator : private OptOutMutator {
 
 } // namespace
 
-void replaceValue(
+std::unordered_map<Val*, Val*> replaceValue(
     Fusion* fusion,
     const std::unordered_map<Val*, Val*>& replacement_map) {
   // NOLINTNEXTLINE(bugprone-unused-raii)
-  ValReplacementMutator(fusion, replacement_map);
+  ValReplacementMutator mutator(fusion, replacement_map);
+  return mutator.mutations_;
 }
 
 Val* getReductionInitValOf(TensorView* tv) {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -48,8 +48,10 @@ struct MatmulInputs {
 namespace nvfuser::ir_utils {
 
 // Replace values in fusion using ValReplacementMutator, it also updates fusion
-// output according to the replacement_map
-void replaceValue(
+// output according to the replacement_map. Returns the final
+// replacement map, which includes the given replacement entries as
+// well as those that are the results of the replacement.
+std::unordered_map<Val*, Val*> replaceValue(
     Fusion*,
     const std::unordered_map<Val*, Val*>& replacement_map);
 


### PR DESCRIPTION
Fusion managed exact mappings may need to be updated when iter domains are replaced. See the added test for a concrete example.

This isn't really a robust way to maintain exact mappings, but I don't have any other idea, either.