### PR TITLE
Use `= default` when possible

### DIFF
--- a/csrc/host_ir/container.cpp
+++ b/csrc/host_ir/container.cpp
@@ -20,8 +20,7 @@ namespace nvfuser {
 
 namespace hir {
 
-// NOLINTNEXTLINE (modernize-use-equals-default)
-HostIrContainer::~HostIrContainer() {}
+HostIrContainer::~HostIrContainer() = default;
 
 Stream* HostIrContainer::getDefaultStream() {
   if (!default_stream_) {


### PR DESCRIPTION
Follow up to #3761. I didn't know we could use `= default` in cpp files too.