### PR TITLE
Accomodate name change of printed kernel files

### DIFF
--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -640,10 +640,10 @@ int warnRegisterSpill(const std::string& compile_log) {
 
 void createNvrtcProgram(
     nvrtcProgram& program,
-    const std::string& id,
+    const std::string& kernel_name,
     const std::string& full_src_code) {
   std::stringstream ss;
-  ss << "__tmp_kernel_" << id << ".cu";
+  ss << "__tmp_" << kernel_name << ".cu";
   std::string name = ss.str();
   FUSER_PERF_SCOPE("executor_utils::NvrtcCreateProgram");
   NVFUSER_NVRTC_SAFE_CALL(nvrtcCreateProgram(
@@ -665,10 +665,10 @@ std::vector<char> compileNvrtcProgramToCubin(const nvrtcProgram& program) {
 // Returns the name of the dumped file.
 std::string dumpCompiledCodeToFile(
     const std::vector<char>& code,
-    const std::string& id,
+    const std::string& kernel_name,
     const std::string& suffix) {
   std::stringstream file_name;
-  file_name << "__tmp_kernel_" << id << suffix;
+  file_name << "__tmp_" << kernel_name << suffix;
   debug() << "PRINTING: " << file_name.str() << std::endl;
   std::ofstream out(file_name.str());
   NVF_ERROR(out.is_open());
@@ -689,7 +689,7 @@ std::vector<char> compileNvrtcProgramToPtx(const nvrtcProgram& program) {
 std::unique_ptr<executor_utils::CudaExecutable> compileSource(
     const std::string& full_src_code,
     const std::string& func_name,
-    const std::string& id,
+    const std::string& kernel_name,
     const bool compile_to_sass,
     NvrtcCompileDriver& nvrtc_compile) {
   std::stringstream log;
@@ -700,7 +700,7 @@ std::unique_ptr<executor_utils::CudaExecutable> compileSource(
     NVFUSER_NVRTC_SAFE_CALL(nvrtcDestroyProgram(&program));
   });
 
-  createNvrtcProgram(program, id, full_src_code);
+  createNvrtcProgram(program, kernel_name, full_src_code);
 
   NVFUSER_NVRTC_SAFE_CALL(nvrtcAddNameExpression(program, func_name.c_str()));
   log << nvrtc_compile.invoke(program, full_src_code) << std::endl;
@@ -716,7 +716,7 @@ std::unique_ptr<executor_utils::CudaExecutable> compileSource(
     compiled_kernel->cubin = compileNvrtcProgramToCubin(program);
     if (isDebugDumpEnabled(DebugDumpOption::Cubin)) {
       compiled_kernel->cubin_filename =
-          dumpCompiledCodeToFile(compiled_kernel->cubin, id, ".cubin");
+          dumpCompiledCodeToFile(compiled_kernel->cubin, kernel_name, ".cubin");
     }
   }
 
@@ -724,7 +724,7 @@ std::unique_ptr<executor_utils::CudaExecutable> compileSource(
     compiled_kernel->ptx = compileNvrtcProgramToPtx(program);
     if (isDebugDumpEnabled(DebugDumpOption::Ptx)) {
       compiled_kernel->ptx_filename =
-          dumpCompiledCodeToFile(compiled_kernel->ptx, id, ".ptx");
+          dumpCompiledCodeToFile(compiled_kernel->ptx, kernel_name, ".ptx");
     }
   }
 
@@ -810,7 +810,11 @@ std::unique_ptr<executor_utils::CudaExecutable> getCudaExecutable(
             (compile_to_sass ? compiled_kernel->cubin
                              : compiled_kernel->ptx)))) {
     compiled_kernel = compileSource(
-        full_src_code, func_name, id, compile_to_sass, nvrtc_compile_driver);
+        full_src_code,
+        func_name,
+        compiled_kernel->kernel_name,
+        compile_to_sass,
+        nvrtc_compile_driver);
     log << compiled_kernel->compile_log << std::endl;
     if (use_kernel_db) {
       auto result = kernel_db.write(

--- a/tools/codediff/compare_codegen.sh
+++ b/tools/codediff/compare_codegen.sh
@@ -122,11 +122,11 @@ scriptdir=$(mktemp -d -t codediffXXXXXX)
 cp -r "$nvfuserdir/tools/codediff/"* "$scriptdir/"
 
 movecudafiles() {
-    find . -maxdepth 1 \( -name '__tmp_kernel*.cu' -o -name '__tmp_kernel*.ptx' \) -exec mv '{}' "$1" \;
+    find . -maxdepth 1 \( -name '__tmp_nvfuser_*.cu' -o -name '__tmp_nvfuser_*.ptx' \) -exec mv '{}' "$1" \;
 }
 
 cleanup() {
-    numkernels=$(find . -maxdepth 1 -name '__tmp_kernel*.cu' -o -name '__tmp_kernel*.ptx' | wc -l)
+    numkernels=$(find . -maxdepth 1 -name '__tmp_nvfuser_*.cu' -o -name '__tmp_nvfuser_*.ptx' | wc -l)
 
     if (( numkernels > 0 ))
     then

--- a/tools/codediff/compare_codegen.sh
+++ b/tools/codediff/compare_codegen.sh
@@ -122,11 +122,11 @@ scriptdir=$(mktemp -d -t codediffXXXXXX)
 cp -r "$nvfuserdir/tools/codediff/"* "$scriptdir/"
 
 movecudafiles() {
-    find . -maxdepth 1 \( -name '__tmp_nvfuser_*.cu' -o -name '__tmp_nvfuser_*.ptx' \) -exec mv '{}' "$1" \;
+    find . -maxdepth 1 \( -name '__tmp_*.cu' -o -name '__tmp_*.ptx' \) -exec mv '{}' "$1" \;
 }
 
 cleanup() {
-    numkernels=$(find . -maxdepth 1 -name '__tmp_nvfuser_*.cu' -o -name '__tmp_nvfuser_*.ptx' | wc -l)
+    numkernels=$(find . -maxdepth 1 -name '__tmp_*.cu' -o -name '__tmp_*.ptx' | wc -l)
 
     if (( numkernels > 0 ))
     then


### PR DESCRIPTION
Generated CUDA files were previously named like `__tmp_kernel_32.cu` and `compare_codegen.sh` matched that pattern when copying kernels. That broke codediff since these filenames were changed in #3468. This PR fixes `compare_codegen.sh` to match `__tmp_*.cu` instead. It also fixes the outputs of printed PTX and cubin files so that they use the same base filenames: currently that is the previous naming scheme `__tmp_kernel_32.cu` (if using `NVFUSER_ENABLE=static_fusion_count`).

This should fix the problems seen recently in codediff CI jobs.