### PR TITLE
Remove space to make generated code look better

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -617,7 +617,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           value);
       auto atype = std::get<ArrayType>(dtype.type);
       auto dims = static_cast<int64_t>(value.as<std::vector>().size());
-      code_ << "{ ";
+      code_ << "{";
       for (auto i = 0; i < dims; i++) {
         if (i > 0) {
           code_ << ", ";


### PR DESCRIPTION
Currently, it is generating things like: `Array<int, 2>{ 1, 2}`, super ugly.