### PR TITLE
Use `F.rms_norm` in benchmarks

### DIFF
--- a/benchmarks/python/torch_ops.py
+++ b/benchmarks/python/torch_ops.py
@@ -62,9 +62,12 @@ def nanogpt_attn(inputs: list):
 
 def rmsnorm(inputs: list):
     inp, weights = inputs
-    squared_mean = (inp**2).mean(1, keepdim=True)
-    rms_eps = torch.sqrt(squared_mean + 1e-5)
-    output = weights * (inp / rms_eps)
+    output = F.rms_norm(
+      inp,
+      inp.shape[1:],
+      weight=weights,
+      eps = 1e-5
+    )
     return output
 
 


### PR DESCRIPTION
Thunder now uses `F.rms_norm` following https://github.com/Lightning-AI/lightning-thunder/pull/1390.