### PR TITLE
Enable previously-failing symbolic allocation split test

### DIFF
--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -1487,11 +1487,8 @@ TEST_F(AllocationDomainTest, InputAllocationIsSplitReorderMerge) {
           ::testing::HasSubstr("Merging of discontiguous dimensions")));
 }
 
-// TODO(#3480): the test fails as is. The symbolic IterDomains in
-// loop/allocation are not concretized. I tried to change
-// DynamicTransformConcretizer::mutate to grab all expressions between root and
-// allocation but still couldn't get it to work.
-TEST_F(AllocationDomainTest, DISABLED_InputAllocationIsSplit_Symbolic) {
+// https://github.com/NVIDIA/Fuser/issues/3480
+TEST_F(AllocationDomainTest, InputAllocationIsSplit_Symbolic) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 


### PR DESCRIPTION
This was fixed in the interim, either by some work on `replaceSymbolicSizes` or by #2706.

Fixes #3480