### PR TITLE
use buffer storage params

### DIFF
--- a/csrc/scheduler/normalization_inner.cpp
+++ b/csrc/scheduler/normalization_inner.cpp
@@ -43,6 +43,7 @@ std::pair<int64_t, int64_t> getPersistentBufferSize(
   normalization_scheduler_utils::BufferProjectionStrategy project_strategy =
       normalization_scheduler_utils::isProjectBufferToInputs(
           fusion,
+          runtime_info,
           reduction_tvs,
           persistent_buffer_info,
           persistent_buffer_size_info,
@@ -58,7 +59,12 @@ std::pair<int64_t, int64_t> getPersistentBufferSize(
 
   int64_t available_persistent_buffer_size = normalization_scheduler_utils::
       getMaxRegOrSharedMemorySizeForPersistentBuffer(
-          fusion, reduction_tvs, can_use_smem_persistent);
+          fusion,
+          runtime_info,
+          reduction_tvs,
+          persistent_buffer_info,
+          can_use_smem_persistent,
+          project_persistent_buffers);
   return std::make_pair(
       persistent_buffer_size, available_persistent_buffer_size);
 }
@@ -146,7 +152,9 @@ int64_t getMaxPersistentBatch(
   // occupancy due to the limitation of the current heuristics. TODO: remove
   // this parameter when we have a better heuristic to select the best
   // persistent batch size.
-  int64_t max_batches_per_block = is_high_bandwidth_flops_ratio ? 12l : 10l;
+  int64_t max_batches_per_block =
+      normalization_scheduler_utils::getInnerPersistentMaxBatchSize(
+          is_high_bandwidth_flops_ratio);
   return std::min(max_batches_per_block, batch_size);
 }
 

--- a/csrc/scheduler/normalization_inner.cpp
+++ b/csrc/scheduler/normalization_inner.cpp
@@ -43,7 +43,7 @@ std::pair<int64_t, int64_t> getPersistentBufferSize(
   normalization_scheduler_utils::BufferProjectionStrategy project_strategy =
       normalization_scheduler_utils::isProjectBufferToInputs(
           fusion,
-          runtime_info,
+          reduction_tvs,
           persistent_buffer_info,
           persistent_buffer_size_info,
           InnerPersistentKernelScheduler::schedulerType(),
@@ -58,9 +58,7 @@ std::pair<int64_t, int64_t> getPersistentBufferSize(
 
   int64_t available_persistent_buffer_size = normalization_scheduler_utils::
       getMaxRegOrSharedMemorySizeForPersistentBuffer(
-          runtime_info,
-          persistent_buffer_info.persistent_buffers,
-          can_use_smem_persistent);
+          fusion, reduction_tvs, can_use_smem_persistent);
   return std::make_pair(
       persistent_buffer_size, available_persistent_buffer_size);
 }

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -217,7 +217,7 @@ PersistentBufferStorageParams getPersistentBufferStorageParams(
   normalization_scheduler_utils::BufferProjectionStrategy project_strategy =
       normalization_scheduler_utils::isProjectBufferToInputs(
           fusion,
-          runtime_info,
+          reduction_tvs,
           persistent_buffer_info,
           persistent_buffer_size_info,
           InnerOuterPersistentKernelScheduler::schedulerType(),

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -217,6 +217,7 @@ PersistentBufferStorageParams getPersistentBufferStorageParams(
   normalization_scheduler_utils::BufferProjectionStrategy project_strategy =
       normalization_scheduler_utils::isProjectBufferToInputs(
           fusion,
+          runtime_info,
           reduction_tvs,
           persistent_buffer_info,
           persistent_buffer_size_info,

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -727,7 +727,6 @@ int64_t roundUpSharedMemory(int64_t tv_buffer_size, int64_t data_type_size) {
   int64_t max_batches_per_block = getInnerPersistentMaxBatchSize(
       scheduler_utils::isHighBandwidthFlopsRatio());
   auto dev_prop = at::cuda::getCurrentDeviceProperties();
-  int64_t warp_size = (int64_t)dev_prop->warpSize;
   int64_t max_threads_per_block = (int64_t)dev_prop->maxThreadsPerBlock;
   int64_t max_smem = 0;
   int64_t max_vectorize_factor =

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -717,8 +717,8 @@ void checkReductionTvForScheduling(Fusion* fusion, TensorView* ref_red_tv) {
 }
 
 int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
-    SchedulerRuntimeInfo& runtime_info,
-    const std::vector<TensorView*>& persistent_buffers,
+    Fusion* fusion,
+    const std::vector<TensorView*>& reduction_tvs,
     const bool can_use_smem_persistent) {
   // Init to register file size, which is half of the full register file size
   int64_t available_persistent_buffer_size =
@@ -727,26 +727,12 @@ int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
   if (!can_use_smem_persistent) {
     return available_persistent_buffer_size;
   }
-  // Check available shared memory
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
-  const int64_t max_shared_memory_size =
-      (int64_t)dev_prop->sharedMemPerBlockOptin;
-  // Some shared memories are reserved for kernel launch overhead and
-  // reduction_broadcast_workspace. Estimation is conservative, but should
-  // be good enough. The actual threads per block is set in the heuristics
-  // and it may be smaller than maxThreadsPerBlock.
-  // TODO: More accurate estimation of available shared memory size.
-  const int64_t kernel_overhead = (int64_t)dev_prop->reservedSharedMemPerBlock;
-  int64_t max_buffer_dtype_size = 1;
-  for (auto tv : persistent_buffers) {
-    max_buffer_dtype_size = std::max(
-        max_buffer_dtype_size,
-        dataTypeSize(tv->getDataType().value(), runtime_info.getIndexType()));
-  }
-  const int64_t reduction_broadcast_workspace =
-      (int64_t)(dev_prop->maxThreadsPerBlock) * max_buffer_dtype_size;
-  const int64_t available_shared_memory_size =
-      max_shared_memory_size - kernel_overhead - reduction_broadcast_workspace;
+  int64_t smem_overhead =
+      scheduler_utils::getSharedMemoryOverheadPerBlock(fusion, reduction_tvs);
+  int64_t available_shared_memory_size =
+      (int64_t)dev_prop->sharedMemPerMultiprocessor - smem_overhead;
+
   available_persistent_buffer_size =
       std::max(available_persistent_buffer_size, available_shared_memory_size);
   return available_persistent_buffer_size;
@@ -759,7 +745,7 @@ int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
 // reasons.
 BufferProjectionStrategy isProjectBufferToInputs(
     Fusion* fusion,
-    SchedulerRuntimeInfo& runtime_info,
+    const std::vector<TensorView*>& reduction_tvs,
     const scheduler_utils::PersistentBufferInfo& persistent_buffer_info,
     const scheduler_utils::PersistentBufferSizeReturn&
         persistent_buffer_size_info,
@@ -790,9 +776,7 @@ BufferProjectionStrategy isProjectBufferToInputs(
   if (scheduler_type != SchedulerType::InnerOuterPersistent) {
     int64_t max_available_buffer =
         getMaxRegOrSharedMemorySizeForPersistentBuffer(
-            runtime_info,
-            persistent_buffer_info.persistent_buffers,
-            can_use_smem_persistent);
+            fusion, reduction_tvs, can_use_smem_persistent);
     if (max_available_buffer <
         persistent_buffer_size_info.persistent_buffer_size) {
       return BufferProjectionStrategy::ProjectToInputs;
@@ -910,7 +894,7 @@ PersistentKernelProperties getPersistentKernelProperties(
       properties.inner_most_dimension_numel == properties.total_reduction_numel;
   auto project_strategy = isProjectBufferToInputs(
       fusion,
-      runtime_info,
+      reduction_tvs,
       persistent_buffer_info,
       persistent_buffer_size_info,
       scheduler_type,

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -716,10 +716,60 @@ void checkReductionTvForScheduling(Fusion* fusion, TensorView* ref_red_tv) {
       "Tried to schedule a fusion with no tensor inputs, currently not supported.");
 }
 
+namespace {
+// For inner persistent kernel, shared memory is allocated as:
+// ceilDiv(ceilDiv(N/vect, batch), threads) * vect * batch * threads.
+// The required shared memory size is larger than buffer size when split is
+// not divisible or threads is padded. The difference is counted as roundup
+// overhead. This function estimates the maximum possible shared memory size
+// due to this round up by iterating over different batch sizes.
+int64_t roundUpSharedMemory(int64_t tv_buffer_size, int64_t data_type_size) {
+  int64_t vectorize_factor =
+      SchedulerRuntimeInfo::max_alignment_size_in_byte / data_type_size;
+  int64_t dim_size = tv_buffer_size / data_type_size;
+  int64_t after_vect = dim_size / vectorize_factor;
+  int64_t max_smem = 0;
+  int64_t max_batches_per_block = getInnerPersistentMaxBatchSize(
+      scheduler_utils::isHighBandwidthFlopsRatio());
+  auto dev_prop = at::cuda::getCurrentDeviceProperties();
+  int64_t warp_size = (int64_t)dev_prop->warpSize;
+  int64_t max_threads_per_block = (int64_t)dev_prop->maxThreadsPerBlock;
+  for (int64_t pbs = 1; pbs <= max_batches_per_block; pbs += 1) {
+    int64_t threads = ceilDiv(after_vect, pbs);
+    if (threads % warp_size != 0 && threads < max_threads_per_block) {
+      threads = ceilDiv(threads, warp_size) * warp_size;
+    }
+    max_smem =
+        std::max(max_smem, pbs * vectorize_factor * threads * data_type_size);
+  }
+  return max_smem;
+}
+int64_t sharedMemoryRoundUpOverhead(
+    SchedulerRuntimeInfo& runtime_info,
+    const scheduler_utils::PersistentBufferInfo& persistent_buffer_info,
+    const bool project_to_inputs) {
+  auto buffers = project_to_inputs
+      ? persistent_buffer_info.projectable_buffer_inputs
+      : persistent_buffer_info.persistent_buffers;
+  int64_t total_smem_overhead = 0;
+  for (auto buffer : buffers) {
+    int64_t buffer_size_regs = scheduler_utils::getPersistentBufferSizeOfTensor(
+        buffer, runtime_info, persistent_buffer_info);
+    int64_t buffer_size_smem = roundUpSharedMemory(
+        buffer_size_regs, dataTypeSize(buffer->getDataType().value()));
+    total_smem_overhead += (buffer_size_smem - buffer_size_regs);
+  }
+  return total_smem_overhead;
+}
+} // namespace
+
 int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
     Fusion* fusion,
+    SchedulerRuntimeInfo& runtime_info,
     const std::vector<TensorView*>& reduction_tvs,
-    const bool can_use_smem_persistent) {
+    const scheduler_utils::PersistentBufferInfo& persistent_buffer_info,
+    const bool can_use_smem_persistent,
+    const bool project_to_inputs) {
   // Init to register file size, which is half of the full register file size
   int64_t available_persistent_buffer_size =
       scheduler_utils::register_file_size;
@@ -730,6 +780,10 @@ int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
   int64_t smem_overhead =
       scheduler_utils::getSharedMemoryOverheadPerBlock(fusion, reduction_tvs);
+
+  smem_overhead += sharedMemoryRoundUpOverhead(
+      runtime_info, persistent_buffer_info, project_to_inputs);
+
   int64_t available_shared_memory_size =
       (int64_t)dev_prop->sharedMemPerMultiprocessor - smem_overhead;
 
@@ -745,6 +799,7 @@ int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
 // reasons.
 BufferProjectionStrategy isProjectBufferToInputs(
     Fusion* fusion,
+    SchedulerRuntimeInfo& runtime_info,
     const std::vector<TensorView*>& reduction_tvs,
     const scheduler_utils::PersistentBufferInfo& persistent_buffer_info,
     const scheduler_utils::PersistentBufferSizeReturn&
@@ -776,7 +831,12 @@ BufferProjectionStrategy isProjectBufferToInputs(
   if (scheduler_type != SchedulerType::InnerOuterPersistent) {
     int64_t max_available_buffer =
         getMaxRegOrSharedMemorySizeForPersistentBuffer(
-            fusion, reduction_tvs, can_use_smem_persistent);
+            fusion,
+            runtime_info,
+            reduction_tvs,
+            persistent_buffer_info,
+            can_use_smem_persistent,
+            false);
     if (max_available_buffer <
         persistent_buffer_size_info.persistent_buffer_size) {
       return BufferProjectionStrategy::ProjectToInputs;
@@ -894,6 +954,7 @@ PersistentKernelProperties getPersistentKernelProperties(
       properties.inner_most_dimension_numel == properties.total_reduction_numel;
   auto project_strategy = isProjectBufferToInputs(
       fusion,
+      runtime_info,
       reduction_tvs,
       persistent_buffer_info,
       persistent_buffer_size_info,
@@ -1615,6 +1676,10 @@ class PersistentBufferResolution : public IterVisitor {
 
 std::vector<TensorView*> getResolutionPointsOf(TensorView* persistent_buffer) {
   return PersistentBufferResolution::getResolutionPointsOf(persistent_buffer);
+}
+
+int64_t getInnerPersistentMaxBatchSize(bool is_high_bandwidth_flops_ratio) {
+  return is_high_bandwidth_flops_ratio ? 12l : 10l;
 }
 
 } // namespace normalization_scheduler_utils

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -286,8 +286,11 @@ void schedulePersistentKernel(
 // Get max register or shared memory size for persistent buffer
 int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
     Fusion* fusion,
+    SchedulerRuntimeInfo& runtime_info,
     const std::vector<TensorView*>& reduction_tvs,
-    const bool can_use_smem_persistent);
+    const scheduler_utils::PersistentBufferInfo& persistent_buffer_info,
+    const bool can_use_smem_persistent,
+    const bool project_to_inputs);
 
 enum class BufferProjectionStrategy {
   // Recompute persistent buffers from inputs, only need to cache inputs in
@@ -330,6 +333,7 @@ enum class BufferProjectionStrategy {
 // smaller than the original persistent buffers, this function returns true.
 BufferProjectionStrategy isProjectBufferToInputs(
     Fusion* fusion,
+    SchedulerRuntimeInfo& runtime_info,
     const std::vector<TensorView*>& reduction_tvs,
     const scheduler_utils::PersistentBufferInfo& persistent_buffer_info,
     const scheduler_utils::PersistentBufferSizeReturn&
@@ -375,5 +379,7 @@ std::vector<TensorView*> movePersistentBufferToSmem(
 // PersistentBufferTest.GetResolutionIssue1123 for a concrete example
 std::vector<TensorView*> getResolutionPointsOf(TensorView* persistent_buffer);
 
+// Return empirical maximum persistent batch size for inner persistent scheduler
+int64_t getInnerPersistentMaxBatchSize(bool is_high_bandwidth_flops_ratio);
 } // namespace normalization_scheduler_utils
 } // namespace nvfuser

--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -285,8 +285,8 @@ void schedulePersistentKernel(
 
 // Get max register or shared memory size for persistent buffer
 int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
-    SchedulerRuntimeInfo& runtime_info,
-    const std::vector<TensorView*>& persistent_buffers,
+    Fusion* fusion,
+    const std::vector<TensorView*>& reduction_tvs,
     const bool can_use_smem_persistent);
 
 enum class BufferProjectionStrategy {
@@ -330,7 +330,7 @@ enum class BufferProjectionStrategy {
 // smaller than the original persistent buffers, this function returns true.
 BufferProjectionStrategy isProjectBufferToInputs(
     Fusion* fusion,
-    SchedulerRuntimeInfo& runtime_info,
+    const std::vector<TensorView*>& reduction_tvs,
     const scheduler_utils::PersistentBufferInfo& persistent_buffer_info,
     const scheduler_utils::PersistentBufferSizeReturn&
         persistent_buffer_size_info,

--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -1363,4 +1363,52 @@ TEST_F(PersistentBufferTest, GetResolutionIssue1123) {
       std::vector<TensorView*>{tv7});
 }
 
+TEST_F(PersistentBufferTest, InnerPersistentNotEnoughSharedMemory) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  auto& fusion = *fusion_ptr;
+  FusionGuard fg(fusion_ptr.get());
+
+  auto tv0 = makeContigTensor(2, DataType::Half);
+  fusion.addInput(tv0);
+  auto tv1 = makeContigTensor(1, DataType::Half);
+  fusion.addInput(tv1);
+  auto tv2 = makeContigTensor(1, DataType::Half);
+  fusion.addInput(tv2);
+
+  auto tv3 = castOp(DataType::Float, tv0);
+  auto tvs = Welford(tv3, {1});
+  auto tv6 = tvs.avg;
+  auto tv7 = tvs.var_sum;
+  auto tv9 = broadcast(tv6, {false, true});
+  TensorView* tv10 = nullptr;
+  auto tv21 = castOp(DataType::Float, tv0);
+  tv10 = sub(tv21, tv9);
+  auto tv11 = broadcast(tv7, {false, true});
+  auto tv13 = add(tv11, IrBuilder::create<Val>(0.001));
+  auto tv14 = rsqrt(tv13);
+  auto tv15 = mul(tv10, tv14);
+  auto tv4 = castOp(DataType::Float, tv1);
+  auto tv16 = broadcast(tv4, {true, false});
+  auto tv17 = mul(tv15, tv16);
+  auto tv5 = castOp(DataType::Float, tv2);
+  auto tv18 = broadcast(tv5, {true, false});
+  auto tv19 = add(tv17, tv18);
+  auto tv20 = castOp(DataType::Half, tv19);
+
+  fusion.addOutput(tv20);
+  fusion.addOutput(tv9);
+  fusion.addOutput(tv14);
+
+  std::vector<int64_t> input_shape{2048, 80 * 1024};
+
+  auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
+  auto t0 = at::randn(input_shape, options);
+  auto t1 = at::randn({input_shape[1]}, options);
+  auto t2 = at::randn({input_shape[1]}, options);
+  std::vector<c10::IValue> inputs({t0, t1, t2});
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+}
 } // namespace nvfuser


### PR DESCRIPTION
For inner persistent scheduler:
(1) Try register persistence

- use logic size of persistent tensor

(2) If not enough register, try shared memory persistence

- estimate required smem size due to non-divisible split