### PR TITLE
format genPowerWithMul

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1025,7 +1025,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
             code_ << "\n";
             indent() << kTab << "= " << lhs;
           } else {
-            indent() << "\n" << kTab << "* " << lhs;
+            code_ << "\n";
+            indent() << kTab << "* " << lhs;
           }
         }
       }


### PR DESCRIPTION
Minor change to `genPowerWithMul()`, to ensure a new line is added before indentation. Generated code changes from
```
        T4[0]
          = T2[0]        
  * T2[0];
```
to
```
        T4[0]
          = T2[0]
          * T2[0];
```

Bad format was introdued in https://github.com/NVIDIA/Fuser/pull/3774 by accident.