### PR TITLE
Translate matmul to multiply and squeeze

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/preseg_passes/remove_empty.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/reorder_sharded_axis.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/segment_inplace_update.cpp
+  ${NVFUSER_SRCS_DIR}/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/translate_repeat_to_expand.cpp
   ${NVFUSER_SRCS_DIR}/rng.cpp
   ${NVFUSER_SRCS_DIR}/runtime/allocations.cpp

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -4208,9 +4208,6 @@ void SegmentCandidateFinder::findSegments() {
 }
 
 void SegmentCandidateFinder::privatizeUpcast() {
-  if (getenv("DISABLE_PRIVATIZE")) {
-    return;
-  }
   // Insert castOp to complete_fusion_
   FusionGuard fg(segmented_fusion_->complete_fusion_.get());
 

--- a/csrc/preseg_passes/pre_segmenter.cpp
+++ b/csrc/preseg_passes/pre_segmenter.cpp
@@ -25,6 +25,7 @@
 #include <preseg_passes/remove_empty.h>
 #include <preseg_passes/reorder_sharded_axis.h>
 #include <preseg_passes/segment_inplace_update.h>
+#include <preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h>
 #include <preseg_passes/translate_repeat_to_expand.h>
 
 namespace nvfuser::preseg_passes {
@@ -82,6 +83,7 @@ namespace nvfuser::preseg_passes {
   OptimizationPass<AllocationDomainPass>::runPass(fusion);
   OptimizationPass<RemoveBcastSqueeze>::runPass(fusion);
   OptimizationPass<SegmentInplaceUpdatePass>::runPass(fusion);
+  OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>::runPass(fusion);
 }
 
 } // namespace nvfuser::preseg_passes

--- a/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
+++ b/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
@@ -11,7 +11,6 @@
 #include <ops/all_ops.h>
 #include <preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h>
 
-#include <unordered_map>
 #include <vector>
 
 namespace nvfuser::preseg_passes {
@@ -21,11 +20,9 @@ namespace {
 // Translation algorithm overview:
 //
 // Step 1: Inspection. Traverses the given fusion and looks for a
-// sequence of ops that correspond to a repeatition. See
-// RepeatToExpandTranslator::inspect() for more details.
+// sequence of MatmulOps with K=1.
 //
-// Step 2: Apply the translation in a reverse topologial order. See
-// RepeatToExpandTranslator::translate() for more details.
+// Step 2: Apply the translation.
 class NoReductionMatmulToMulSqueezeTranslator {
  public:
   NoReductionMatmulToMulSqueezeTranslator(Fusion* fusion) : fusion_(fusion) {}
@@ -36,10 +33,7 @@ class NoReductionMatmulToMulSqueezeTranslator {
   }
 
  private:
-  // Traverse through the fusion and gather all patterns of a pad
-  // followed by a concat. If a single concat op has multiple pad
-  // inputs that resize the same iter domain of the same input tensor,
-  // that must correspond to a repetition.
+  // Traverse through the fusion and gather all MatmulOps with K=1.
   void inspect() {
     const auto exprs = fusion_->exprs();
 
@@ -72,33 +66,46 @@ class NoReductionMatmulToMulSqueezeTranslator {
           "Unexpected broadcast dimension: ",
           k_id_a->toString());
 
-      std::cerr << "No-reduction matmul detected: " << matmul->toString();
       no_reduction_matmul_.push_back(matmul);
     }
   }
 
-  // For each detected repetition, replace the output with a repeat
-  // output.
+  // For each detected MatmulOp, apply the translation of mul+squeeze.
   void translate() {
     for (auto matmul : no_reduction_matmul_) {
-      std::cerr << "Translating: " << matmul->toString();
       auto in_a = matmul->inA();
       auto in_b = matmul->inB();
 
-      auto ndims_a =
+      // Given:
+      //
+      // out = MatmulOp(in_a, in_b)
+      //
+      // We broadcast in_a and in_b as necessary and do a pointwise
+      // multiplication and squeeze the K dimension. If there's no
+      // batch dimensions, either A or B would need to be
+      // broadcasted. Batch dimensions make things a little more
+      // complicated, but we align the batch dimensions of A and B by
+      // following the steps of torch.matmul
+      // (https://pytorch.org/docs/stable/generated/torch.matmul.html).
+
+      const auto ndims_a =
           (int64_t)(TensorDomain::noReductions(in_a->getLogicalDomain())
                         .size());
-      auto ndims_b =
+      const auto ndims_b =
           (int64_t)(TensorDomain::noReductions(in_b->getLogicalDomain())
                         .size());
-      auto batch_ndims_a = std::max(ndims_a - 2, (int64_t)0);
-      auto matrix_ndims_a = std::min(ndims_a, (int64_t)2);
-      auto batch_ndims_b = std::max(ndims_b - 2, (int64_t)0);
-      auto matrix_ndims_b = std::min(ndims_b, (int64_t)2);
+      const auto batch_ndims_a = std::max(ndims_a - 2, (int64_t)0);
+      const auto matrix_ndims_a = std::min(ndims_a, (int64_t)2);
+      const auto batch_ndims_b = std::max(ndims_b - 2, (int64_t)0);
+      const auto matrix_ndims_b = std::min(ndims_b, (int64_t)2);
 
-      // std::vector<bool> bc_flags_a(ndims_a, false);
-      // std::vector<bool> bc_flags_b(ndims_b, false);
+      // Broadcast flags used to broadcast in_a. The number of false
+      // flags should be equal to batch_ndims_a + matrix_ndims_a. The
+      // vector is prepended with true if in_a misses some of the
+      // batch dimensions.
       std::vector<bool> bc_flags_a;
+
+      // Broadcast flags used to broadcast in_b.
       std::vector<bool> bc_flags_b;
 
       // Align the batch dimensions
@@ -117,6 +124,7 @@ class NoReductionMatmulToMulSqueezeTranslator {
         }
       }
 
+      // Fill the false flags for the existing IDs
       for ([[maybe_unused]] const auto i :
            c10::irange(batch_ndims_a + matrix_ndims_a)) {
         bc_flags_a.push_back(false);
@@ -127,11 +135,39 @@ class NoReductionMatmulToMulSqueezeTranslator {
         bc_flags_b.push_back(false);
       }
 
-      // If a is 2-dimensional and b is 1-dimensional, the output is a
-      // mat-vec multiply, i.e.:
+      // Add true flags if necessary for the matrix dimensions and
+      // apply the mul+squeeze pattern. Do this based on three
+      // different cases.
+      //
+      // Case 1: in_a is a 2-dimension matrix and in_b is
+      // 1-dimensional (ignoring batch dimensions). In this case, the
+      // output is just a matrix-vector multiply, i.e.,
       //
       // [M, b1] * [b1] => [M, b1] * [b2, b1] => [M, b1] => [M]
+      //
+      // Here, we insert one broadcast ID to in_b and apply the
+      // mul-squeeze pattern.
+      //
+      // Case 2: in_a is 1-dimensional and b is 2-dimensional, i.e.:
+      //
+      // [b1] * [b1, N] => [b1, b2] * [b1, N] => [b1, N] => [N]
+      //
+      // Here, we insert one broadcast ID to in_a and apply the
+      // mul-squeeze pattern.
+      //
+      //
+      // Case 3: Both in_a and in_b are 2-dimensional. In this case,
+      // we insert a broadcast ID to each of the inputs.
+      //
+      // [M, b1] * [b1, N] => [M, b2, b1] * [b3, N, b1] => [M, N, b1]
+      // => [M, N]
+      //
+      // It may be possible to combine these three cases to reduce
+      // repeated code, but having three separated cases seems to make
+      // it easier to understand the logic.
+
       if (matrix_ndims_a == 2 && matrix_ndims_b == 1) {
+        // Case 1
         if (std::any_of(bc_flags_a.begin(), bc_flags_a.end(), [](bool flag) {
               return flag;
             })) {
@@ -145,9 +181,7 @@ class NoReductionMatmulToMulSqueezeTranslator {
         squeeze_flags.back() = true;
         IrBuilder::create<SqueezeOp>(matmul->out(), out, squeeze_flags);
       } else if (matrix_ndims_a == 1 && matrix_ndims_b == 2) {
-        // a is 1-dimensional and b is 2-dimensional, i.e.:
-        //
-        // [b1] * [b1, N] => [b1, b2] * [b1, N] => [b1, N] => [N]
+        // Case 2
         bc_flags_a.push_back(true);
         in_a = broadcast(in_a, bc_flags_a);
         if (std::any_of(bc_flags_b.begin(), bc_flags_b.end(), [](bool flag) {
@@ -161,30 +195,20 @@ class NoReductionMatmulToMulSqueezeTranslator {
         IrBuilder::create<SqueezeOp>(matmul->out(), out, squeeze_flags);
         continue;
       } else {
-        // [M, b1] * [b1, N] => [M, b2, b1] * [b3, N, b1] => [M, N,
-        // b1] => [M, N]
-
+        // Case 3
         bc_flags_a.push_back(false);
         *(bc_flags_a.rbegin() + 1) = true;
-        std::cerr << "Broadcasting a: " << in_a->toString() << bc_flags_a
-                  << "\n";
         auto in_a_bc = broadcast(in_a, bc_flags_a);
 
         auto in_b_t = transpose(in_b, -2, -1);
         bc_flags_b.push_back(false);
         *(bc_flags_b.rbegin() + 2) = true;
-        std::cerr << "Broadcasting b: " << in_b->toString() << bc_flags_b
-                  << "\n";
         auto in_b_bc = broadcast(in_b_t, bc_flags_b);
 
         auto out = mul(in_a_bc, in_b_bc);
         std::vector<bool> to_squeeze(out->nDims(), false);
         to_squeeze.back() = true;
-        std::cerr << "Squeezing " << out->toString() << " with "
-                  << toDelimitedString(to_squeeze) << "\n";
-        auto squeeze =
-            IrBuilder::create<SqueezeOp>(matmul->out(), out, to_squeeze);
-        std::cerr << "Replaced with: " << squeeze->toString();
+        IrBuilder::create<SqueezeOp>(matmul->out(), out, to_squeeze);
       }
     }
   }

--- a/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
+++ b/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
@@ -1,0 +1,181 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <ir/utils.h>
+#include <iter_visitor.h>
+#include <logical_domain_map.h>
+#include <ops/all_ops.h>
+#include <preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h>
+
+#include <unordered_map>
+#include <vector>
+
+namespace nvfuser::preseg_passes {
+
+namespace {
+
+// Translation algorithm overview:
+//
+// Step 1: Inspection. Traverses the given fusion and looks for a
+// sequence of ops that correspond to a repeatition. See
+// RepeatToExpandTranslator::inspect() for more details.
+//
+// Step 2: Apply the translation in a reverse topologial order. See
+// RepeatToExpandTranslator::translate() for more details.
+class NoReductionMatmulToMulSqueezeTranslator {
+ public:
+  NoReductionMatmulToMulSqueezeTranslator(Fusion* fusion) : fusion_(fusion) {}
+
+  void run() {
+    inspect();
+    translate();
+  }
+
+ private:
+  // Traverse through the fusion and gather all patterns of a pad
+  // followed by a concat. If a single concat op has multiple pad
+  // inputs that resize the same iter domain of the same input tensor,
+  // that must correspond to a repetition.
+  void inspect() {
+    const auto exprs = fusion_->exprs();
+
+    for (auto matmul : ir_utils::filterByType<MatmulOp>(exprs)) {
+      // Find the K dimension
+      auto in_a = matmul->inA();
+      auto in_b = matmul->inB();
+
+      auto domain_a = TensorDomain::noReductions(in_a->getLogicalDomain());
+      auto domain_b = TensorDomain::noReductions(in_b->getLogicalDomain());
+
+      auto ndims_a = domain_a.size();
+      auto ndims_b = domain_b.size();
+
+      if (ndims_a == 1 && ndims_b == 1) {
+        // Dot product. Should this be translated to a reduction as
+        // well?
+        continue;
+      }
+
+      IterDomain* k_id_a = domain_a.back();
+
+      if (!k_id_a->isBroadcast()) {
+        continue;
+      }
+
+      std::cerr << "No-reduction matmul detected: " << matmul->toString();
+      no_reduction_matmul_.push_back(matmul);
+    }
+  }
+
+  // For each detected repetition, replace the output with a repeat
+  // output.
+  void translate() {
+    for (auto matmul : no_reduction_matmul_) {
+      std::cerr << "Translating: " << matmul->toString();
+      auto in_a = matmul->inA();
+      auto in_b = matmul->inB();
+
+      auto ndims_a =
+          (int64_t)(TensorDomain::noReductions(in_a->getLogicalDomain())
+                        .size());
+      auto ndims_b =
+          (int64_t)(TensorDomain::noReductions(in_b->getLogicalDomain())
+                        .size());
+
+      auto batch_ndims_a = std::max(ndims_a - 2, (int64_t)0);
+      auto matrix_ndims_a = std::min(ndims_a, (int64_t)2);
+      auto batch_ndims_b = std::max(ndims_b - 2, (int64_t)0);
+      auto matrix_ndims_b = std::min(ndims_b, (int64_t)2);
+
+      // Align the batch dimensions
+      auto missing_batch_ndims = std::abs(batch_ndims_a - batch_ndims_b);
+      if (missing_batch_ndims) {
+        if (batch_ndims_a < batch_ndims_b) {
+          std::vector<bool> bc_flags(ndims_a + missing_batch_ndims, false);
+          for (const auto i : c10::irange(missing_batch_ndims)) {
+            bc_flags.at(i) = true;
+          }
+          in_a = broadcast(in_a, bc_flags);
+          batch_ndims_a += missing_batch_ndims;
+          ndims_a += missing_batch_ndims;
+        } else {
+          std::vector<bool> bc_flags(ndims_b + missing_batch_ndims, false);
+          for (const auto i : c10::irange(missing_batch_ndims)) {
+            bc_flags.at(i) = true;
+          }
+          in_b = broadcast(in_b, bc_flags);
+          batch_ndims_b += missing_batch_ndims;
+          ndims_b += missing_batch_ndims;
+        }
+
+        std::cerr << "Batch dims aligned: " << in_a->toString() << ", "
+                  << in_b->toString() << "\n";
+      }
+
+      // If a is 2-dimensional and b is 1-dimensional, the output is a
+      // mat-vec multiply, i.e.:
+      //
+      // [M, b1] * [b1] => [M, b1] * [b2, b1] => [M, b1] => [M]
+      if (matrix_ndims_a == 2 && matrix_ndims_b == 1) {
+        std::vector<bool> bc_flags(ndims_b + 1, false);
+        *(bc_flags.rbegin() + 1) = true;
+        in_b = broadcast(in_b, bc_flags);
+        auto out = mul(in_a, in_b);
+        std::vector<bool> squeeze_flags(out->nDims(), false);
+        squeeze_flags.back() = true;
+        IrBuilder::create<SqueezeOp>(matmul->out(), out, squeeze_flags);
+        continue;
+      }
+
+      // a is 1-dimensional and b is 2-dimensional, i.e.:
+      //
+      // [b1] * [b1, N] => [b1, b2] * [b1, N] => [b1, N] => [N]
+      if (matrix_ndims_a == 1 && matrix_ndims_b == 2) {
+        std::vector<bool> bc_flags(ndims_a + 1, false);
+        bc_flags.back() = true;
+        in_a = broadcast(in_a, bc_flags);
+        auto out = mul(in_a, in_b);
+        std::vector<bool> squeeze_flags(out->nDims(), false);
+        *(squeeze_flags.rbegin() + 1) = true;
+        IrBuilder::create<SqueezeOp>(matmul->out(), out, squeeze_flags);
+        continue;
+      }
+
+      std::vector<bool> bcast_flags_a(ndims_a + 1, false);
+      std::vector<bool> bcast_flags_b(ndims_b + 1, false);
+
+      *(bcast_flags_a.rbegin() + 1) = true;
+      auto in_a_bc = broadcast(in_a, bcast_flags_a);
+
+      auto in_b_t = transpose(in_b, -2, -1);
+      *(bcast_flags_b.rbegin() + 2) = true;
+      auto in_b_bc = broadcast(in_b_t, bcast_flags_b);
+
+      auto out = mul(in_a_bc, in_b_bc);
+      std::vector<bool> to_squeeze(out->nDims(), false);
+      to_squeeze.back() = true;
+      std::cerr << "Squeezing " << out->toString() << " with "
+                << toDelimitedString(to_squeeze) << "\n";
+      IrBuilder::create<SqueezeOp>(matmul->out(), out, to_squeeze);
+    }
+  }
+
+ private:
+  Fusion* fusion_ = nullptr;
+  // Map of concat exprs to their info about repetition
+  std::vector<MatmulOp*> no_reduction_matmul_;
+};
+
+} // namespace
+
+void TranslateNoReductionMatmulToMulSqueeze::runPass(Fusion* fusion) {
+  FusionGuard fg(fusion);
+  NoReductionMatmulToMulSqueezeTranslator translator(fusion);
+  translator.run();
+}
+
+} // namespace nvfuser::preseg_passes

--- a/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
+++ b/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
@@ -62,9 +62,15 @@ class NoReductionMatmulToMulSqueezeTranslator {
 
       IterDomain* k_id_a = domain_a.back();
 
-      if (!k_id_a->isBroadcast()) {
+      if (!k_id_a->isBroadcast() || k_id_a->hasExpandedExtent()) {
         continue;
       }
+
+      // There should be no case where this extent is not one.
+      NVF_ERROR(
+          k_id_a->extent()->isOneInt(),
+          "Unexpected broadcast dimension: ",
+          k_id_a->toString());
 
       std::cerr << "No-reduction matmul detected: " << matmul->toString();
       no_reduction_matmul_.push_back(matmul);

--- a/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h
+++ b/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h
@@ -1,0 +1,54 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <exceptions.h>
+#include <preseg_passes/optimization_pass.h>
+
+namespace nvfuser::preseg_passes {
+
+// Translate concat-based repetitions to expand and reshape ops.
+//
+// For example, given the following fusion:
+//
+// t0 = [i0];
+// t1 = cat({t0, t0}, -1);
+//
+// It will be translated to:
+//
+// t0 = [i0]
+// t2 = broadcast(t0, {true, false});
+// t3 = expand(t2, {2, i0});
+// t4 = reshape(t3, {2 * i0});
+//
+// And all uses of t1 will be replaced by t4. This pattern commonly
+// appears in RoPE, e.g.,
+// https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L136.
+// While the resize scheduler should be able to handle these patterns for
+// pointwise-only segments, it is currently limited to only pointwise
+// fusions only. This translation should promote larger fusions
+// as it is not specific to any surrounding ops.
+//
+// Note that there's a potential downside compared to handling cat ops
+// directly. Since insertion of broadcast IDs is not represented as
+// Fusion IR expressions, a fusion may have more disconnected ID
+// graphs after the translation, which may cause a segmentation that
+// could be avoided with the original fusion. See
+// PresegTest.TranslateRepeatToExpand4 for a concrete example.
+class TranslateNoReductionMatmulToMulSqueeze
+    : public OptimizationPass<TranslateNoReductionMatmulToMulSqueeze> {
+  friend class OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>;
+
+ protected:
+  static void runPass(Fusion* fusion);
+  static std::string name() {
+    return "TranslateNoReductionMatmulToMulSqueeze";
+  }
+};
+
+} // namespace nvfuser::preseg_passes

--- a/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h
+++ b/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h
@@ -12,34 +12,21 @@
 
 namespace nvfuser::preseg_passes {
 
-// Translate concat-based repetitions to expand and reshape ops.
+// Translate MatmulOp to multiply and squeeze when K=1.
 //
 // For example, given the following fusion:
 //
-// t0 = [i0];
-// t1 = cat({t0, t0}, -1);
+// t0 = [i0, b1];
+// t1 = [b2, i3];
+// t2 = matmul(t0, t1);
 //
 // It will be translated to:
 //
-// t0 = [i0]
-// t2 = broadcast(t0, {true, false});
-// t3 = expand(t2, {2, i0});
-// t4 = reshape(t3, {2 * i0});
-//
-// And all uses of t1 will be replaced by t4. This pattern commonly
-// appears in RoPE, e.g.,
-// https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L136.
-// While the resize scheduler should be able to handle these patterns for
-// pointwise-only segments, it is currently limited to only pointwise
-// fusions only. This translation should promote larger fusions
-// as it is not specific to any surrounding ops.
-//
-// Note that there's a potential downside compared to handling cat ops
-// directly. Since insertion of broadcast IDs is not represented as
-// Fusion IR expressions, a fusion may have more disconnected ID
-// graphs after the translation, which may cause a segmentation that
-// could be avoided with the original fusion. See
-// PresegTest.TranslateRepeatToExpand4 for a concrete example.
+// t3 = broadcast(t0) // [i0, b4, b1]
+// t4 = transpose(t1) // [i3, b2]
+// t5 = broadcast(t4) // [b5, i3, b2]
+// t6 = mul(t3, t5) // [i0, i3, b1]
+// t2 = squeeze(t6) // [i0, i3]
 class TranslateNoReductionMatmulToMulSqueeze
     : public OptimizationPass<TranslateNoReductionMatmulToMulSqueeze> {
   friend class OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>;

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -1309,6 +1309,7 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.toString();
     });
 
+// Test the translation of MatmulOp when K=1
 TEST_P(TranslateNoReductionMatmulTest, Test) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr;
@@ -1324,10 +1325,8 @@ TEST_P(TranslateNoReductionMatmulTest, Test) {
   auto tv2 = matmul(tv0, tv1);
   fusion.addOutput(tv2);
 
-  fusion.printMath();
-
   {
-    // Make sure pad and cat no longer exist
+    // Make sure MmaOp no longer exists
     Fusion fusion_copy = fusion;
     OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>::runPass(
         &fusion_copy);

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -15,6 +15,7 @@
 #include <preseg_passes/consecutive_cast.h>
 #include <preseg_passes/optimization_pass.h>
 #include <preseg_passes/pre_segmenter.h>
+#include <preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h>
 #include <preseg_passes/translate_repeat_to_expand.h>
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
@@ -1274,6 +1275,85 @@ TEST_F(PresegTest, FusionTestCastOptimizationMetaOp6) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto outputs = executor_cache.runFusionWithInputs(inputs);
   testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+}
+
+struct MatmulInputShape {
+  std::vector<int64_t> shape_a;
+  std::vector<int64_t> shape_b;
+  std::string toString() const {
+    std::stringstream ss;
+    ss << toDelimitedString(shape_a, "x") << "_"
+       << toDelimitedString(shape_b, "x");
+    return ss.str();
+  }
+};
+
+using TranslateNoReductionMatmulTest =
+    NVFuserFixtureParamTest<MatmulInputShape>;
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    TranslateNoReductionMatmulTest,
+    testing::Values(
+        MatmulInputShape{{8, 1}, {1, 16}},
+        MatmulInputShape{{8, 1}, {1}},
+        MatmulInputShape{{1}, {1, 8}},
+        MatmulInputShape{{2, 3, 1}, {2, 1, 4}},
+        MatmulInputShape{{2, 3, 4, 1}, {2, 3, 1, 5}},
+        MatmulInputShape{{4, 1}, {2, 1, 5}},
+        MatmulInputShape{{4, 1}, {2, 3, 1, 5}},
+        MatmulInputShape{{1}, {2, 3, 1, 5}},
+        MatmulInputShape{{3, 4, 1}, {1}},
+        MatmulInputShape{{2, 3, 4, 1}, {1}}),
+    [](const testing::TestParamInfo<MatmulInputShape>& info) {
+      return info.param.toString();
+    });
+
+TEST_P(TranslateNoReductionMatmulTest, Test) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr;
+  FusionGuard fg(&fusion);
+
+  const auto config = GetParam();
+
+  auto tv0 = makeContigConcreteTensor(config.shape_a);
+  fusion.addInput(tv0);
+  auto tv1 = makeContigConcreteTensor(config.shape_b);
+  fusion.addInput(tv1);
+
+  auto tv2 = matmul(tv0, tv1);
+  fusion.addOutput(tv2);
+
+  fusion.printMath();
+
+  {
+    // Make sure pad and cat no longer exist
+    Fusion fusion_copy = fusion;
+    OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>::runPass(
+        &fusion_copy);
+    fusion_copy.printMath();
+    auto new_exprs = fusion_copy.exprs();
+    EXPECT_EQ(
+        std::find_if(
+            new_exprs.begin(),
+            new_exprs.end(),
+            [](Expr* new_expr) { return new_expr->isA<MatmulOp>(); }),
+        new_exprs.end());
+  }
+
+  auto options = at::TensorOptions().device(at::kCUDA, 0);
+  auto t0 = at::randn(config.shape_a, options);
+  auto t1 = at::randn(config.shape_b, options);
+  std::vector<c10::IValue> inputs = {t0, t1};
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+
+  // Should be scheduled as a pointwise kernel
+  FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
+  EXPECT_THAT(
+      runtime->fusionSegments()->groups(),
+      ElementsAre(HeuristicIs(SchedulerType::PointWise)));
 }
 
 } // namespace nvfuser::preseg_passes

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -1326,7 +1326,7 @@ TEST_P(TranslateNoReductionMatmulTest, Test) {
   fusion.addOutput(tv2);
 
   {
-    // Make sure MmaOp no longer exists
+    // Make sure MatmulOp no longer exists
     Fusion fusion_copy = fusion;
     OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>::runPass(
         &fusion_copy);

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -1330,7 +1330,6 @@ TEST_P(TranslateNoReductionMatmulTest, Test) {
     Fusion fusion_copy = fusion;
     OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>::runPass(
         &fusion_copy);
-    fusion_copy.printMath();
     auto new_exprs = fusion_copy.exprs();
     EXPECT_EQ(
         std::find_if(

--- a/tests/python/test_matmul.py
+++ b/tests/python/test_matmul.py
@@ -165,10 +165,10 @@ class TestMatmul(NVFuserTest):
 
         inputs = [
             torch.randn((2 * 32,), dtype=torch.float32, device="cuda:0").as_strided(
-                (2, 32, 1), (32, 1, 0)
+                (2, 32, 1), (32, 1, 32)
             ),
             torch.randn((2 * 16,), dtype=torch.float32, device="cuda:0").as_strided(
-                (2, 1, 16), (16, 0, 1)
+                (2, 1, 16), (16, 16, 1)
             ),
         ]
         self.exec_nvfuser(fusion_func, inputs)

--- a/tests/python/test_matmul.py
+++ b/tests/python/test_matmul.py
@@ -164,11 +164,11 @@ class TestMatmul(NVFuserTest):
             fd.add_output(T4)
 
         inputs = [
-            torch.randn((262400,), dtype=torch.float32, device="cuda:0").as_strided(
-                (1025, 256, 1), (256, 1, 256)
+            torch.randn((2 * 32,), dtype=torch.float32, device="cuda:0").as_strided(
+                (2, 32, 1), (32, 1, 0)
             ),
-            torch.randn((1049600,), dtype=torch.float32, device="cuda:0").as_strided(
-                (1025, 1, 1024), (1024, 1024, 1)
+            torch.randn((2 * 16,), dtype=torch.float32, device="cuda:0").as_strided(
+                (2, 1, 16), (16, 0, 1)
             ),
         ]
         self.exec_nvfuser(fusion_func, inputs)


### PR DESCRIPTION
When `MatmulOp` has `k=1`, there's no reduction, so it can be translated to a pointwise multiplication and a squeeze. It may not matter much by itself, but the mul+squeeze case can be easily fused with other operations, which is important in some of the RoPE benchmark cases as can be seen in the below performance results.

Closes #3646 

## Performance benefit

On H100 with #3776.

### Phi3 RoPE forward

Before:

```
------------------------------------------------------------------------------------------------------------------- benchmark: 2 tests -------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                                         Min                Max               Mean            StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rope_fwd_benchmark[executor='thunder'-variation='hf_phi3_rope']                  96.2570 (1.12)     99.9370 (1.14)     98.9344 (1.14)     1.0756 (2.68)     99.2645 (1.14)     0.9920 (1.73)          1;1       10.1077 (0.88)         10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After:

```
------------------------------------------------------------------------------------------------------------------- benchmark: 2 tests -------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                                         Min                Max               Mean            StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rope_fwd_benchmark[executor='thunder'-variation='hf_phi3_rope']                  89.9210 (1.04)     92.7360 (1.06)     91.5839 (1.06)     0.8385 (2.20)     91.7435 (1.06)     0.9600 (1.31)          3;0       10.9189 (0.95)         10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Mistral RoPE foward

Before:

```
----------------------------------------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                                                 Min                Max               Mean            StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rope_fwd_benchmark[executor='thunder'-variation='hf_mistral_nemo_rope']                  73.3740 (1.0)      75.8060 (1.0)      74.6332 (1.0)      0.7416 (1.41)     74.7675 (1.0)      0.9600 (1.11)          3;0       13.3989 (1.0)          10           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After

```
----------------------------------------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                                                 Min                Max               Mean            StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_rope_fwd_benchmark[executor='thunder'-variation='hf_mistral_nemo_rope']                  64.9610 (1.0)      67.0400 (1.0)      65.8015 (1.0)      0.6379 (1.03)     65.7125 (1.0)      0.8660 (1.00)          3;0       15.1972 (1.0)          10           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
