### PR TITLE
don't unroll if for loop has reduction

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2572,6 +2572,9 @@ class ForLoop final : public Expr {
   //! True if loop is grouped reduction/welford
   bool isGroup() const;
 
+  //! True if loop has reduction
+  bool hasReduction() const;
+
   //! Returns the stage of a circular buffered iterdomain
   //!  that this for loop materializes.
   auto circularBufferLoopStage() const {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5040,6 +5040,10 @@ bool ForLoop::isUnrolled() const {
     return false;
   }
 
+  if (hasReduction()) {
+    return false;
+  }
+
   return true;
 }
 
@@ -5183,6 +5187,17 @@ bool ForLoop::isGroup() const {
   return ExprFinder::exists(
       this,
       {typeid(GroupedReductionOp),
+       typeid(kir::GroupedGridReduction),
+       typeid(kir::GroupedGridWelford)});
+}
+
+bool ForLoop::hasReduction() const {
+  return ExprFinder::exists(
+      this,
+      {typeid(ReductionOp),
+       typeid(WelfordOp),
+       typeid(GroupedReductionOp),
+       typeid(kir::GridWelford),
        typeid(kir::GroupedGridReduction),
        typeid(kir::GroupedGridWelford)});
 }


### PR DESCRIPTION
Solve issue https://github.com/NVIDIA/Fuser/issues/3629
Thunder generates concrete fusion for rms norm backward, the grid stride loop over outer dim is unrolled as:
```
  #pragma unroll
  for(nvfuser_index_t i31 = 0; i31 < 32; ++i31) {
       complex memory loads & block reductions
  }
```
There is no register spill, but the compiler may re-order exprs when processing this unroll and leads to a low performance of only 37% SOL. If I close unroll by changing to
```
  #pragma unroll 1
  for(nvfuser_index_t i31 = 0; i31 < 32; ++i31) {
```
The performance is increased from 37% to 82% SOL.

TODO: Further tests of other hidden sizes showed the performance gap between concrete fusion and symbolic fusion is gone.