### PR TITLE
Multidimensional device mesh

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -70,7 +70,8 @@ void HostIrExecutor::compile(Fusion* fusion) {
     std::vector<Expr*> exprs = fusion->exprs();
     DeviceIdxType my_device_idx = communicator_ ? communicator_->deviceId() : 0;
     for (Expr* e : exprs) {
-      std::vector<Expr*> communications = HostIrLower::lower(cloner.clone(e), my_device_idx);
+      std::vector<Expr*> communications =
+          HostIrLower::lower(cloner.clone(e), my_device_idx);
       for (auto* communication : communications) {
         host_ir_container_->pushBackTopLevelExprs(communication);
       }

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -68,8 +68,9 @@ void HostIrExecutor::compile(Fusion* fusion) {
     }
   } else {
     std::vector<Expr*> exprs = fusion->exprs();
+    DeviceIdxType my_device_idx = communicator_ ? communicator_->deviceId() : 0;
     for (Expr* e : exprs) {
-      std::vector<Expr*> communications = HostIrLower::lower(cloner.clone(e));
+      std::vector<Expr*> communications = HostIrLower::lower(cloner.clone(e), my_device_idx);
       for (auto* communication : communications) {
         host_ir_container_->pushBackTopLevelExprs(communication);
       }

--- a/csrc/host_ir/lower.cpp
+++ b/csrc/host_ir/lower.cpp
@@ -50,6 +50,12 @@ inline c10d::ReduceOp::RedOpType getC10dReduceOpType(BinaryOpType op) {
   }
 }
 
+// Temporary helper function to check we have a 1D mesh while
+// multidimensional support is being built up.
+bool is1DMesh(const DeviceMesh& mesh) {
+  return mesh.shape().size() == 1;
+}
+
 // Adds one or zero Scatter communication to the vector 'comms'
 void lowerToScatter(
     TensorView* input_tv,
@@ -57,6 +63,7 @@ void lowerToScatter(
     std::vector<Expr*>& comms) {
   // we arbitrarily choose the first device of the sender mesh to be the root
   const DeviceMesh& receiver_mesh = output_tv->getDeviceMesh();
+  NVF_ERROR(is1DMesh(receiver_mesh), "Gather only supported on a 1D mesh. Given ", receiver_mesh);
   auto root = input_tv->getDeviceMesh().at(0);
   Team team = receiver_mesh.vector();
   if (!receiver_mesh.has(root)) {
@@ -70,7 +77,7 @@ void lowerToScatter(
 Adds zero or multiple Gather communications to the vector 'comms'
 
 Note that since the root of a Gather collective is a destination, we possibly
-need multiple Gather if the tensor is replicated in the receiver mesh.
+need multiple Gathers if the tensor is replicated in the receiver mesh.
 */
 void lowerToGather(
     TensorView* input_tv,
@@ -78,6 +85,7 @@ void lowerToGather(
     std::vector<Expr*>& comms) {
   // we create as many 'Gathers' as there are devices in the receiver mesh
   const DeviceMesh& sender_mesh = input_tv->getDeviceMesh();
+  NVF_ERROR(is1DMesh(sender_mesh), "Currently only lower Gather on a 1D mesh. Given ", sender_mesh);
   for (auto root : output_tv->getDeviceMesh().vector()) {
     Team team = sender_mesh.vector();
     if (!sender_mesh.has(root)) {
@@ -92,10 +100,11 @@ void lowerToGather(
 void lowerToAllgather(
     TensorView* input_tv,
     TensorView* output_tv,
-    std::vector<Expr*>& comms) {
-  const DeviceMesh& mesh = input_tv->getDeviceMesh();
+    std::vector<Expr*>& comms,
+    DeviceIdxType my_device_idx) {
+  Team team = input_tv->getDeviceMesh().getSlice(my_device_idx, ParallelType::DIDx);
   comms.push_back(IrBuilder::create<Communication>(
-      CommunicationType::Allgather, output_tv, input_tv, mesh.vector()));
+      CommunicationType::Allgather, output_tv, input_tv, team));
 }
 
 // Adds one or zero Broadcast communication to the vector 'comms'
@@ -105,6 +114,7 @@ void lowerToBroadcast(
     DeviceIdxType root,
     std::vector<Expr*>& comms) {
   const DeviceMesh& mesh = output_tv->getDeviceMesh();
+  NVF_ERROR(is1DMesh(mesh), "Broadcast on supported a 1D mesh. Given ", mesh);
   Team team = mesh.vector();
   if (!mesh.has(root)) {
     team.push_back(root);
@@ -123,6 +133,8 @@ void lowerToBroadcastOrSendRecv(
     std::vector<Expr*>& comms) {
   const DeviceMesh& sender_mesh = input_tv->getDeviceMesh();
   const DeviceMesh& receiver_mesh = output_tv->getDeviceMesh();
+  NVF_ERROR(is1DMesh(sender_mesh), "Broadcast on supported a 1D mesh. Given ", sender_mesh);
+  NVF_ERROR(is1DMesh(receiver_mesh), "Broadcast on supported a 1D mesh. Given ", receiver_mesh);
   if (isSharded(input_tv) && sender_mesh.size() > 1) {
     // if the inputs and ouputs are parallelized,
     // we create as many Broadcast as that will be handled in parallel
@@ -164,6 +176,8 @@ void lowerToReduce(
     std::vector<Expr*>& comms) {
   const DeviceMesh& receiver_mesh = output_tv->getDeviceMesh();
   const DeviceMesh& sender_mesh = input_tv->getDeviceMesh();
+  NVF_ERROR(is1DMesh(sender_mesh), "Broadcast on supported a 1D mesh. Given ", sender_mesh);
+  NVF_ERROR(is1DMesh(receiver_mesh), "Broadcast on supported a 1D mesh. Given ", receiver_mesh);
   const auto reduce_op_type = getC10dReduceOpType(op_type);
   // we create as many Reduces as there are devices in the receiver mesh
   for (auto root : receiver_mesh.vector()) {
@@ -185,13 +199,14 @@ void lowerToAllreduce(
     TensorView* input_tv,
     TensorView* output_tv,
     BinaryOpType op_type,
-    std::vector<Expr*>& comms) {
-  const DeviceMesh& mesh = input_tv->getDeviceMesh();
+    std::vector<Expr*>& comms,
+    DeviceIdxType my_device_idx) {
+  Team team = input_tv->getDeviceMesh().getSlice(my_device_idx, ParallelType::DIDx);
   comms.push_back(IrBuilder::create<Communication>(
       CommunicationType::Allreduce,
       output_tv,
       input_tv,
-      mesh.vector(),
+      team,
       /*root=*/-1,
       getC10dReduceOpType(op_type)));
 }
@@ -200,8 +215,9 @@ void lowerToReduceScatter(
     TensorView* input_tv,
     TensorView* output_tv,
     BinaryOpType op_type,
-    std::vector<Expr*>& comms) {
-  const DeviceMesh& mesh = input_tv->getDeviceMesh();
+    std::vector<Expr*>& comms,
+    DeviceIdxType my_device_idx) {
+  Team team = input_tv->getDeviceMesh().getSlice(my_device_idx, ParallelType::DIDx);
   auto reduction_axis = output_tv->getReductionAxis().value();
   auto scattered_axis = getShardedLogicalAxis(output_tv, ParallelType::DIDx);
   // The output tensor is sharded on scattered_axis and needs to be mapped
@@ -216,7 +232,7 @@ void lowerToReduceScatter(
       CommunicationType::ReduceScatter,
       output_tv,
       input_tv,
-      /*team=*/mesh.vector(),
+      /*team=*/team,
       /*root=*/-1,
       getC10dReduceOpType(op_type),
       scattered_axis));
@@ -233,7 +249,7 @@ TODO:
    sources
 *) Leverage the topology to ensure that the senders and recerivers are close
 */
-std::vector<Expr*> HostIrLower::lower(Expr* c) {
+std::vector<Expr*> HostIrLower::lower(Expr* c, DeviceIdxType my_device_idx) {
   FusionGuard fg(c->fusion());
 
   if (c->isOneOf<MatmulOp, LinearOp>()) {
@@ -256,7 +272,7 @@ std::vector<Expr*> HostIrLower::lower(Expr* c) {
   const DeviceMesh& receiver_mesh = output_tv->getDeviceMesh();
   const bool same_mesh = sender_mesh == receiver_mesh;
 
-  // Stores whether the I/O has its first axis parallelized on Didx
+  // Stores whether the I/O has its first axis parallelized on DIDx
   const bool is_input_sharded = isSharded(input_tv) && sender_mesh.size() > 1;
   const bool is_output_sharded =
       isSharded(output_tv) && receiver_mesh.size() > 1;
@@ -282,11 +298,11 @@ std::vector<Expr*> HostIrLower::lower(Expr* c) {
       NVF_ERROR(
           same_mesh,
           "ReduceScatter operation must have the same sender and receiver device mesh. "
-          "Insert a Set operation before or after the reduction to reshard ot another device mesh");
-      lowerToReduceScatter(input_tv, output_tv, op_type, comms);
+          "Insert a Set operation before or after the reduction to reshard to another device mesh");
+      lowerToReduceScatter(input_tv, output_tv, op_type, comms, my_device_idx);
     } else {
       if (same_mesh) {
-        lowerToAllreduce(input_tv, output_tv, op_type, comms);
+        lowerToAllreduce(input_tv, output_tv, op_type, comms, my_device_idx);
       } else {
         lowerToReduce(input_tv, output_tv, op_type, comms);
       }
@@ -296,7 +312,7 @@ std::vector<Expr*> HostIrLower::lower(Expr* c) {
       lowerToScatter(input_tv, output_tv, comms);
     } else if (is_input_sharded && !is_output_sharded) {
       if (same_mesh) {
-        lowerToAllgather(input_tv, output_tv, comms);
+        lowerToAllgather(input_tv, output_tv, comms, my_device_idx);
       } else {
         lowerToGather(input_tv, output_tv, comms);
       }
@@ -506,7 +522,7 @@ std::vector<Expr*> HostIrLower::lowerToCollectiveBasedPipelinedGemmComm(
 
 std::unique_ptr<hir::HostIrContainer> HostIrLower::lower(
     std::unique_ptr<Fusion> fusion,
-    int64_t my_device_index) {
+    DeviceIdxType my_device_index) {
   // Sharding PreSegmenter passes.
   // Note: passes run before PreSegmenter optimization passes.
   preseg_passes::OptimizationPass<
@@ -565,7 +581,7 @@ std::unique_ptr<hir::HostIrContainer> HostIrLower::lower(
           group->exprs().size() == 1,
           "Communication segments must contain only one Expr");
       for (auto* expr :
-           HostIrLower::lower(ir_cloner.clone(group->exprs().at(0)))) {
+           HostIrLower::lower(ir_cloner.clone(group->exprs().at(0)), my_device_index)) {
         // Allocate the recv buffers of communications
         if (expr->isA<Communication>()) {
           auto* communication = expr->as<Communication>();

--- a/csrc/host_ir/lower.h
+++ b/csrc/host_ir/lower.h
@@ -22,11 +22,11 @@ class HostIrLower {
   static bool canLower(Expr* expr, bool ignore_inner_resharding = false);
 
   // Lower a sharded Expr into a series of Communication.
-  static std::vector<Expr*> lower(Expr* c);
+  static std::vector<Expr*> lower(Expr* c, DeviceIdxType my_device_index);
 
   static std::unique_ptr<hir::HostIrContainer> lower(
       std::unique_ptr<Fusion> fusion,
-      int64_t my_device_index);
+      DeviceIdxType my_device_index);
 
  private:
   static std::vector<Expr*> lowerToCollectiveBasedPipelinedGemmComm(Expr* expr);

--- a/csrc/multidevice/device_mesh.cpp
+++ b/csrc/multidevice/device_mesh.cpp
@@ -69,7 +69,37 @@ void DeviceMesh::setDevices(std::vector<DeviceIdxType> devices) {
 }
 
 std::ostream& operator<<(std::ostream& out, const DeviceMesh& mesh) {
-  out << "DeviceMesh{" << mesh.vector() << "}";
+  if (mesh.shape().empty()) {
+    out << "DeviceMesh{" << mesh.vector() << "}";
+    return out;
+  }
+
+  out << "DeviceMesh";
+  size_t nDevices = std::accumulate(
+        mesh.shape().begin(), mesh.shape().end(), 1, std::multiplies<size_t>());
+  size_t nDim = mesh.shape().size();
+  std::vector<int64_t> strides = mesh.shape();
+  for (int i = nDim - 2; i >= 0; --i) {
+      strides[i] *= strides[i + 1];
+  }
+
+  for (size_t i = 0; i < nDevices; i++) {
+    for (size_t axis = 0; axis < nDim; axis++) {
+      if (i % strides[axis] == 0) {
+        out << "{";
+      }
+    }
+    out << mesh.vector().at(i);
+    if ((i+1) % strides[nDim-1] != 0) {
+      out << " ";
+    }
+    for (size_t axis = 0; axis < nDim; axis++) {
+      if ((i+1) % strides[axis] == 0) {
+        out << "}";
+      }
+    }
+  }
+
   return out;
 }
 

--- a/csrc/multidevice/device_mesh.cpp
+++ b/csrc/multidevice/device_mesh.cpp
@@ -24,8 +24,8 @@ DeviceMesh::DeviceMesh(
   if (shape.empty()) {
     shape_ = {(int64_t)devices.size()};
   } else {
-    int64_t num_devices = std::accumulate(
-        shape.begin(), shape.end(), 1, std::multiplies<>());
+    int64_t num_devices =
+        std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<>());
     NVF_ERROR(
         (int64_t)devices.size() == num_devices,
         "Specified a list of device with ",
@@ -40,7 +40,7 @@ DeviceMesh::DeviceMesh(
 
 DeviceMesh::DeviceMesh(std::initializer_list<DeviceIdxType> devices) {
   setDevices(std::vector<DeviceIdxType>(devices));
-  shape_ = {(int64_t) vector_.size()};
+  shape_ = {(int64_t)vector_.size()};
 }
 
 void DeviceMesh::setDevices(std::vector<DeviceIdxType> devices) {
@@ -62,8 +62,8 @@ void DeviceMesh::setDevices(std::vector<DeviceIdxType> devices) {
 }
 
 /*static*/ DeviceMesh DeviceMesh::createForShape(std::vector<int64_t> shape) {
-  int64_t num_devices = std::accumulate(
-      shape.begin(), shape.end(), 1, std::multiplies<>());
+  int64_t num_devices =
+      std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<>());
   std::vector<DeviceIdxType> devices(num_devices);
   std::iota(devices.begin(), devices.end(), 0);
   return DeviceMesh(devices, shape);
@@ -77,11 +77,11 @@ std::ostream& operator<<(std::ostream& out, const DeviceMesh& mesh) {
 
   out << "DeviceMesh";
   size_t ndevices = std::accumulate(
-        mesh.shape().begin(), mesh.shape().end(), 1, std::multiplies<>());
+      mesh.shape().begin(), mesh.shape().end(), 1, std::multiplies<>());
   size_t ndims = mesh.shape().size();
   std::vector<int64_t> strides = mesh.shape();
   for (size_t i = ndims - 2; i >= 0; --i) {
-      strides[i] *= strides[i + 1];
+    strides[i] *= strides[i + 1];
   }
 
   for (size_t i = 0; i < ndevices; i++) {
@@ -91,11 +91,11 @@ std::ostream& operator<<(std::ostream& out, const DeviceMesh& mesh) {
       }
     }
     out << mesh.vector().at(i);
-    if ((i+1) % strides[ndims-1] != 0) {
+    if ((i + 1) % strides[ndims - 1] != 0) {
       out << " ";
     }
     for (size_t axis = 0; axis < ndims; axis++) {
-      if ((i+1) % strides[axis] == 0) {
+      if ((i + 1) % strides[axis] == 0) {
         out << "}";
       }
     }
@@ -132,24 +132,31 @@ DeviceIdxType DeviceMesh::maxDeviceId() const {
 std::vector<DeviceIdxType> DeviceMesh::getSlice(
     DeviceIdxType device,
     ParallelType ptype) const {
-  NVF_ERROR(isParallelTypeDeviceDim(ptype),
-  "Requires a DID parallel type but received ", ptype);
-  int64_t axis = shape_.size() - 1;
-  if (ptype == ParallelType::DIDy) {
-    axis -= 1;
-  } else if (ptype == ParallelType::DIDz) {
-    axis -= 2;
-  }
-  NVF_ERROR(axis < (int64_t)shape_.size(),
+  NVF_ERROR(
+      isParallelTypeDeviceDim(ptype),
+      "Requires a DID parallel type but received ",
+      ptype);
+  size_t axis = 0;
+  // size_t axis = shape_.size() - 1;
+  // if (ptype == ParallelType::DIDy) {
+  //   axis -= 1;
+  // } else if (ptype == ParallelType::DIDz) {
+  //   axis -= 2;
+  // }
+  NVF_ERROR(
+      axis < shape_.size(),
       "DeviceMesh has ",
       shape_.size(),
-      " dimensions, but requesting slice for ", ptype);
-  int64_t offset = 0;
-  int64_t stride = 1;
-  int64_t accumulated_size = 1;
+      " dimensions, but requesting slice for ",
+      ptype);
   auto indices = getIndices(device);
-  NVF_ERROR(!indices.empty(), "Device ", device, " is not in DeviceMesh ", vector_);
-  for (int64_t i = (int64_t)shape_.size() - 1; i >= 0; i--) {
+  NVF_ERROR(
+      !indices.empty(), "Device ", device, " is not in DeviceMesh ", vector_);
+
+  size_t offset = 0;
+  size_t stride = 1;
+  size_t accumulated_size = 1;
+  for (size_t i = shape_.size() - 1; i >= 0; i--) {
     if (i > axis) {
       stride *= shape_[i];
     }
@@ -159,11 +166,11 @@ std::vector<DeviceIdxType> DeviceMesh::getSlice(
     accumulated_size *= shape_[i];
   }
 
-  std::vector<DeviceIdxType> team(shape_[axis]);
-  for (auto i : c10::irange(team.size())) {
-    team.at(i) = vector_.at(i * stride + offset);
+  std::vector<DeviceIdxType> devices(shape_[axis]);
+  for (auto i : c10::irange(devices.size())) {
+    devices.at(i) = vector_.at(i * stride + offset);
   }
-  return team;
+  return devices;
 }
 
 } // namespace nvfuser

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -17,9 +17,9 @@
 
 namespace nvfuser {
 
-// The class DeviceMesh represents a set of (unique) devices on which a Pipeline
-// Stage will be executed. For now, we only support flat meshes, but later we
-// will add support for n-dimensional meshes.
+// DeviceMesh represents a set of unique devices arranged as a dense
+// n-dimensional tensor. DeviceMesh and device parallel types determine
+// how a tensorview is sharded among devices.
 class DeviceMesh final {
  public:
   // https://google.github.io/styleguide/cppguide.html#Implicit_Conversions
@@ -32,21 +32,37 @@ class DeviceMesh final {
   // There are no such contention for std::initializer_list so I chose to
   // allow implicit conversion for that. This allows users to write `DeviceMesh
   // mesh = {1, 2};`, which is more concise.
-  explicit DeviceMesh(std::vector<DeviceIdxType> devices = {});
+  // When no shape is specified, a 1D DeviceMesh is created by default.
+  explicit DeviceMesh(
+      std::vector<DeviceIdxType> devices = {},
+      std::vector<int64_t> shape = {});
   DeviceMesh(std::initializer_list<DeviceIdxType> devices);
   DeviceMesh(const DeviceMesh&) = default;
   DeviceMesh(DeviceMesh&&) = default;
   DeviceMesh& operator=(const DeviceMesh&) = default;
   DeviceMesh& operator=(DeviceMesh&&) = default;
 
-  // Creates a device mesh of [0 .. num_devices-1]. I didn't make it a
+  // Creates a device mesh of [0 ... num_devices-1]. I didn't make it a
   // constructor because single-element initializer lists would be directed to
   // use that instead of the constructor for vectors.
   static DeviceMesh createForNumDevices(int64_t num_devices);
+  // Creates a device mesh with the specified shape with devices numbered
+  // [0 ... num_devices-1].
+  static DeviceMesh createForShape(std::vector<int64_t> shape);
 
   // Returns the number of devices in the mesh
   int64_t size() const {
     return static_cast<int64_t>(vector_.size());
+  }
+
+  // Return the size of an axis in the mesh
+  int64_t size(int64_t axis) const {
+    return shape_.at(axis);
+  }
+
+  // Returns the shape of the device mesh
+  const std::vector<int64_t>& shape() const {
+    return shape_;
   }
 
   int64_t size(ParallelType parallel_type) const;
@@ -61,7 +77,8 @@ class DeviceMesh final {
     return std::find(vector_.begin(), vector_.end(), device) != vector_.end();
   }
 
-  // Returns the index of device in the mesh, or -1 if device is not present.
+  // Returns the global index of device in the mesh, or -1 if device is not
+  // present.
   int64_t idxOf(const DeviceIdxType device) const {
     auto it = std::find(vector_.begin(), vector_.end(), device);
     if (it != vector_.end()) {
@@ -70,24 +87,43 @@ class DeviceMesh final {
     return -1;
   }
 
+  // Returns the indices of a multi-dimensional mesh, or an empty vector
+  // if device is not present
+  std::vector<int64_t> getIndices(const DeviceIdxType device) const;
+
   // Returns the device at a particular index in the mesh
   DeviceIdxType at(int64_t index) const {
     return vector_.at(index);
   }
 
   bool operator==(const DeviceMesh& other) const {
-    return vector_ == other.vector();
+    return vector_ == other.vector() && shape_ == other.shape();
   }
 
   bool operator!=(const DeviceMesh& other) const {
-    return vector_ != other.vector();
+    return vector_ != other.vector() || shape_ != other.shape();
   }
+
+  // Returns the max device id in the DeviceMesh.
+  DeviceIdxType maxDeviceId() const;
+
+  // Returns the team
+  // DeviceMesh. The team will be the group of devices involved in a
+  // communication (including device).
+  // Ex: [[0 1 2]
+  //      [3 4 5]]
+  // getTeam(4, 0) = {3, 4, 5}
+  // getTeam(4, 1) = {1, 4}
+  // TODO: this might be worth caching per TV...
+  Team getTeam(DeviceIdxType device, int64_t axis = 0) const;
 
  private:
   void setDevices(std::vector<DeviceIdxType> devices);
 
-  // stores the list of device indices
+  // stores the flattened list of device indices
   std::vector<DeviceIdxType> vector_;
+  // shape of the device mesh.
+  std::vector<int64_t> shape_;
 };
 
 std::ostream& operator<<(std::ostream& out, const DeviceMesh& mesh);

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -48,7 +48,7 @@ class DeviceMesh final {
   static DeviceMesh createForNumDevices(int64_t num_devices);
   // Creates a device mesh with the specified shape with devices numbered
   // [0 ... num_devices-1].
-  static DeviceMesh createForShape(std::vector<int64_t> shape);
+  static DeviceMesh createForShape(const std::vector<int64_t>& shape);
 
   // Returns the number of devices in the mesh
   int64_t size() const {
@@ -94,6 +94,11 @@ class DeviceMesh final {
   // Returns the device at a particular index in the mesh
   DeviceIdxType at(int64_t index) const {
     return vector_.at(index);
+  }
+
+  // Returns the rank (number of dimensions) of the mesh.
+  int64_t rank() const {
+    return static_cast<int64_t>(shape_.size());
   }
 
   bool operator==(const DeviceMesh& other) const {

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -107,22 +107,21 @@ class DeviceMesh final {
   // Returns the max device id in the DeviceMesh.
   DeviceIdxType maxDeviceId() const;
 
-  // Returns the team
-  // DeviceMesh. The team will be the group of devices involved in a
-  // communication (including device).
+  // Returns a slice of the DeviceMesh accorinding to the device parallel type
+  // that contains the device
   // Ex: [[0 1 2]
   //      [3 4 5]]
-  // getTeam(4, 0) = {3, 4, 5}
-  // getTeam(4, 1) = {1, 4}
-  // TODO: this might be worth caching per TV...
-  Team getTeam(DeviceIdxType device, int64_t axis = 0) const;
+  // getSlice(4, ParallelType::DIDx) = {3, 4, 5}
+  // getSlice(4, ParallelType::DIDy) = {1, 4}
+  // TODO: these might be worth caching per TV
+  std::vector<DeviceIdxType> getSlice(DeviceIdxType device, ParallelType ptype) const;
 
  private:
   void setDevices(std::vector<DeviceIdxType> devices);
 
   // stores the flattened list of device indices
   std::vector<DeviceIdxType> vector_;
-  // shape of the device mesh.
+  // shape of the device mesh
   std::vector<int64_t> shape_;
 };
 

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -114,7 +114,8 @@ class DeviceMesh final {
   // getSlice(4, ParallelType::DIDx) = {3, 4, 5}
   // getSlice(4, ParallelType::DIDy) = {1, 4}
   // TODO: these might be worth caching per TV
-  std::vector<DeviceIdxType> getSlice(DeviceIdxType device, ParallelType ptype) const;
+  std::vector<DeviceIdxType> getSlice(DeviceIdxType device, ParallelType ptype)
+      const;
 
  private:
   void setDevices(std::vector<DeviceIdxType> devices);

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -577,9 +577,7 @@ int64_t requestedNumberOfDevices(Fusion* fusion) {
   DeviceIdxType max_index = 0;
   for (auto tv : fusion->allTvs()) {
     if (tv->hasDeviceMesh()) {
-      for (auto d_id : tv->getDeviceMesh().vector()) {
-        max_index = std::max(max_index, d_id);
-      }
+      max_index = std::max(max_index, tv->getDeviceMesh().maxDeviceId());
     }
   }
   return static_cast<int64_t>(max_index + 1);

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1550,7 +1550,7 @@ bool isParallelTypeBlockDim(ParallelType ptype) {
 }
 
 bool isParallelTypeDeviceDim(ParallelType ptype) {
-  return ptype == ParallelType::DIDx;
+  return ptype == ParallelType::DIDx || ptype == ParallelType::DIDy || ptype == ParallelType::DIDz;
 }
 
 bool isParallelTypeThread(ParallelType ptype) {

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1554,7 +1554,8 @@ bool isParallelTypeBlockDim(ParallelType ptype) {
 }
 
 bool isParallelTypeDeviceDim(ParallelType ptype) {
-  return ptype == ParallelType::DIDx || ptype == ParallelType::DIDy || ptype == ParallelType::DIDz;
+  return ptype == ParallelType::DIDx || ptype == ParallelType::DIDy ||
+      ptype == ParallelType::DIDz;
 }
 
 bool isParallelTypeThread(ParallelType ptype) {

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -708,6 +708,10 @@ static const char* parallel_type2string(ParallelType t) {
   switch (t) {
     case ParallelType::DIDx:
       return "deviceIdx.x";
+    case ParallelType::DIDy:
+      return "deviceIdx.y";
+    case ParallelType::DIDz:
+      return "deviceIdx.z";
     case ParallelType::BIDz:
       return "blockIdx.z";
     case ParallelType::BIDy:

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -703,6 +703,8 @@ enum class TernaryOpType { Clamp, Lerp, Threshold, Where };
 
 enum class ParallelType {
   DIDx,
+  DIDy,
+  DIDz,
   BIDz,
   BIDy,
   BIDx,
@@ -741,8 +743,10 @@ static constexpr std::array<ParallelType, 3> kParallelTypeTIDs = {
     ParallelType::TIDy,
     ParallelType::TIDz};
 
-static constexpr std::array<ParallelType, 1> kParallelTypeDIDs = {
-    ParallelType::DIDx};
+static constexpr std::array<ParallelType, 3> kParallelTypeDIDs = {
+    ParallelType::DIDx,
+    ParallelType::DIDy,
+    ParallelType::DIDz};
 
 enum class MemoryType { Local, Shared, Global, Tensor };
 

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -467,6 +467,8 @@ TEST_F(OverlapDistributedMatmulTest, AG_linear) {
   torch::cuda::synchronize();
   cudaProfilerStop();
 
+  std::cout << out_ref[0][0] << std::endl;
+  std::cout << out_at[0][0] << std::endl;
   EXPECT_TRUE(torch::allclose(out_ref, out_at, 1e-1, 1e-1));
 }
 

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -467,8 +467,6 @@ TEST_F(OverlapDistributedMatmulTest, AG_linear) {
   torch::cuda::synchronize();
   cudaProfilerStop();
 
-  std::cout << out_ref[0][0] << std::endl;
-  std::cout << out_at[0][0] << std::endl;
   EXPECT_TRUE(torch::allclose(out_ref, out_at, 1e-1, 1e-1));
 }
 

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -196,7 +196,7 @@ TEST_P(ShardingTest, ComputeIndex) {
   testValidate(fusion.get(), outputs, {a_tensor}, __LINE__, __FILE__);
 }
 
-TEST_F(ShardingTest, DeviceMesh) {
+TEST_F(ShardingTest, MultiDimDeviceMesh) {
   DeviceMesh mesh({3, 4, 1, 0, 8, 2}, {2, 3});
   // Shape not consistent with number of devices
   EXPECT_ANY_THROW(DeviceMesh({1, 2}, {2, 3}));

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -208,20 +208,19 @@ TEST_F(ShardingTest, MultiDimDeviceMesh) {
   EXPECT_EQ(mesh.getIndices(8), local_indices_8);
   EXPECT_EQ(mesh.getIndices(1), local_indices_1);
 
-  std::vector<DeviceIdxType> team_axis1_group0 = {3, 4, 1};
-  std::vector<DeviceIdxType> team_axis0_group2 = {1, 2};
-  std::vector<DeviceIdxType> team_2_0 = {1, 2};
-  EXPECT_EQ(mesh.getTeam(1, 1), team_axis1_group0);
-  EXPECT_EQ(mesh.getTeam(1, 0), team_axis0_group2);
-  EXPECT_EQ(mesh.getTeam(2, 0), team_axis0_group2);
+  std::vector<DeviceIdxType> slice_didx_034 = {3, 4, 1};
+  std::vector<DeviceIdxType> slice_didy_12 = {1, 2};
+  EXPECT_EQ(mesh.getSlice(1, ParallelType::DIDx), slice_didx_034);
+  EXPECT_EQ(mesh.getSlice(1, ParallelType::DIDy), slice_didy_12);
+  EXPECT_EQ(mesh.getSlice(2, ParallelType::DIDy), slice_didy_12);
 
   DeviceMesh mesh3d = DeviceMesh::createForShape({2, 3, 4});
-  std::vector<DeviceIdxType> team_axis0_group1 = {6, 18};
-  std::vector<DeviceIdxType> team_axis1_group1 = {14, 18, 22};
-  std::vector<DeviceIdxType> team_axis2_group2 = {16, 17, 18, 19};
-  EXPECT_EQ(mesh3d.getTeam(18, 0), team_axis0_group1);
-  EXPECT_EQ(mesh3d.getTeam(18, 1), team_axis1_group1);
-  EXPECT_EQ(mesh3d.getTeam(18, 2), team_axis2_group2);
+  std::vector<DeviceIdxType> slice_didz = {6, 18};
+  std::vector<DeviceIdxType> slice_didy = {14, 18, 22};
+  std::vector<DeviceIdxType> slice_didx = {16, 17, 18, 19};
+  EXPECT_EQ(mesh3d.getSlice(18, ParallelType::DIDz), slice_didz);
+  EXPECT_EQ(mesh3d.getSlice(18, ParallelType::DIDy), slice_didx);
+  EXPECT_EQ(mesh3d.getSlice(18, ParallelType::DIDx), slice_didx);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -196,6 +196,34 @@ TEST_P(ShardingTest, ComputeIndex) {
   testValidate(fusion.get(), outputs, {a_tensor}, __LINE__, __FILE__);
 }
 
+TEST_F(ShardingTest, DeviceMesh) {
+  DeviceMesh mesh({3, 4, 1, 0, 8, 2}, {2, 3});
+  // Shape not consistent with number of devices
+  EXPECT_ANY_THROW(DeviceMesh({1, 2}, {2, 3}));
+  // Duplicates in DeviceMesh
+  EXPECT_ANY_THROW(DeviceMesh({1, 2, 0, 2}, {2, 3}));
+
+  std::vector<int64_t> local_indices_8 = {1, 1};
+  std::vector<int64_t> local_indices_1 = {0, 2};
+  EXPECT_EQ(mesh.getIndices(8), local_indices_8);
+  EXPECT_EQ(mesh.getIndices(1), local_indices_1);
+
+  std::vector<DeviceIdxType> team_axis1_group0 = {3, 4, 1};
+  std::vector<DeviceIdxType> team_axis0_group2 = {1, 2};
+  std::vector<DeviceIdxType> team_2_0 = {1, 2};
+  EXPECT_EQ(mesh.getTeam(1, 1), team_axis1_group0);
+  EXPECT_EQ(mesh.getTeam(1, 0), team_axis0_group2);
+  EXPECT_EQ(mesh.getTeam(2, 0), team_axis0_group2);
+
+  DeviceMesh mesh3d = DeviceMesh::createForShape({2, 3, 4});
+  std::vector<DeviceIdxType> team_axis0_group1 = {6, 18};
+  std::vector<DeviceIdxType> team_axis1_group1 = {14, 18, 22};
+  std::vector<DeviceIdxType> team_axis2_group2 = {16, 17, 18, 19};
+  EXPECT_EQ(mesh3d.getTeam(18, 0), team_axis0_group1);
+  EXPECT_EQ(mesh3d.getTeam(18, 1), team_axis1_group1);
+  EXPECT_EQ(mesh3d.getTeam(18, 2), team_axis2_group2);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ,
     ShardingTest,

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -219,7 +219,7 @@ TEST_F(ShardingTest, MultiDimDeviceMesh) {
   std::vector<DeviceIdxType> slice_didy = {14, 18, 22};
   std::vector<DeviceIdxType> slice_didx = {16, 17, 18, 19};
   EXPECT_EQ(mesh3d.getSlice(18, ParallelType::DIDz), slice_didz);
-  EXPECT_EQ(mesh3d.getSlice(18, ParallelType::DIDy), slice_didx);
+  EXPECT_EQ(mesh3d.getSlice(18, ParallelType::DIDy), slice_didy);
   EXPECT_EQ(mesh3d.getSlice(18, ParallelType::DIDx), slice_didx);
 }
 


### PR DESCRIPTION
1. Extends DeviceMesh to support multidimensional meshes. Representation is a flat vector of devices and a vector of shapes. Since we only have plans to support DIDx, DIDy, and DIDz this naturally restricts the max dimensions to 3D.
2. Key functionality is in `getSlice(DeviceIdxType, ParallelType)` which gives a set of devices that a tensor is sharded over and communicates with given the (device) parallel type which translates into a dimension into the mesh.
3. Trivially modifies communication lowering to analyze a slice instead of the entire mesh for collectives that use the same mesh (AllReduce, ReduceScatter, AllGather). Collectives without this property assert that it is operating over a 1D mesh.
4. Adds ParallelType's DIDy, DIDz. These are not used anywhere except to index into 2D and 3D device mesh tests.