### PR TITLE
Disable sibling propagation by default in SetSelector to support SDPA

### DIFF
--- a/csrc/scheduler/tools/maxinfo_propagator.cpp
+++ b/csrc/scheduler/tools/maxinfo_propagator.cpp
@@ -5,10 +5,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <ir/utils.h>
 #include <logical_domain_map.h>
 #include <scheduler/tools/maxinfo_propagator.h>
-#include <ir/utils.h>
-
 
 namespace nvfuser {
 
@@ -472,7 +471,9 @@ bool SetSelector::allowP2C(TensorView* from, TensorView* to) {
 }
 
 bool SetSelector::allowSibling(TensorView* from, TensorView* to) {
-  if (ir_utils::hasUniformSiblings(from->definition())){
+  // Allow propagation between siblings if they are uniform to avoid errors in
+  // `computeInfoSibling`. This is not true for SdpaFwdOp and SdpaBwdOp.
+  if (ir_utils::hasUniformSiblings(from->definition())) {
     return true;
   }
   return false;

--- a/csrc/scheduler/tools/maxinfo_propagator.cpp
+++ b/csrc/scheduler/tools/maxinfo_propagator.cpp
@@ -86,8 +86,9 @@ void MaxInfoSpanningTree::compute_spanning_tree() {
   };
 
   auto allowSibling = [this](TensorView* from, TensorView* to) {
-    // Disable propagation between siblings if they are not uniform to avoid errors in
-    // `computeInfoSibling`. This is required for SdpaFwdOp and SdpaBwdOp.
+    // Disable propagation between siblings if they are not uniform to avoid
+    // errors in `computeInfoSibling`. This is required for SdpaFwdOp and
+    // SdpaBwdOp.
     if (!ir_utils::hasUniformSiblings(from->definition())) {
       return false;
     }
@@ -95,7 +96,7 @@ void MaxInfoSpanningTree::compute_spanning_tree() {
     if (selector_ == nullptr) {
       return true;
     }
-    
+
     return selector_->allowSibling(from, to);
   };
 

--- a/csrc/scheduler/tools/maxinfo_propagator.cpp
+++ b/csrc/scheduler/tools/maxinfo_propagator.cpp
@@ -7,6 +7,8 @@
 // clang-format on
 #include <logical_domain_map.h>
 #include <scheduler/tools/maxinfo_propagator.h>
+#include <ir/utils.h>
+
 
 namespace nvfuser {
 
@@ -470,7 +472,10 @@ bool SetSelector::allowP2C(TensorView* from, TensorView* to) {
 }
 
 bool SetSelector::allowSibling(TensorView* from, TensorView* to) {
-  return true;
+  if (ir_utils::hasUniformSiblings(from->definition())){
+    return true;
+  }
+  return false;
 }
 
 } // namespace nvfuser

--- a/csrc/scheduler/tools/maxinfo_propagator.cpp
+++ b/csrc/scheduler/tools/maxinfo_propagator.cpp
@@ -86,9 +86,16 @@ void MaxInfoSpanningTree::compute_spanning_tree() {
   };
 
   auto allowSibling = [this](TensorView* from, TensorView* to) {
+    // Disable propagation between siblings if they are not uniform to avoid errors in
+    // `computeInfoSibling`. This is required for SdpaFwdOp and SdpaBwdOp.
+    if (!ir_utils::hasUniformSiblings(from->definition())) {
+      return false;
+    }
+
     if (selector_ == nullptr) {
       return true;
     }
+    
     return selector_->allowSibling(from, to);
   };
 
@@ -471,12 +478,7 @@ bool SetSelector::allowP2C(TensorView* from, TensorView* to) {
 }
 
 bool SetSelector::allowSibling(TensorView* from, TensorView* to) {
-  // Allow propagation between siblings if they are uniform to avoid errors in
-  // `computeInfoSibling`. This is not true for SdpaFwdOp and SdpaBwdOp.
-  if (ir_utils::hasUniformSiblings(from->definition())) {
-    return true;
-  }
-  return false;
+  return true;
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -1024,39 +1024,4 @@ TEST_F(SDPATest, ComputeAt) {
   validateSdpaFwdOutputs(nvf_out, aten_out);
 }
 
-TEST_F(SDPATest, PropagateLoopSplit) {
-  NVFUSER_TEST_CUDA_ARCH_GUARD(8, 0);
-  auto fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-
-  constexpr int64_t d = 4;
-  auto mesh = DeviceMesh::createForNumDevices(d);
-  std::vector<int64_t> qkv_shape({b, s, h, e});
-
-  auto tvq = makeConcreteTensor(qkv_shape, DataType::Half);
-  auto tvk = makeConcreteTensor(qkv_shape, DataType::Half);
-  auto tvv = makeConcreteTensor(qkv_shape, DataType::Half);
-  auto output = sdpfa_fwd(
-    tvq,
-    tvk,
-    tvv,
-    /*dropout_p=*/IrBuilder::create<Val>(0.0),
-    /*is_causal=*/IrBuilder::create<Val>(false),
-    /*scale=*/nullptr);
-
-  addSdpaFwdOutputs(fusion.get(), output);
-
-  auto selected_tvs = {output.output, output.log_sumexp};
-
-  for (TensorView* tv : {tvq, tvk, tvv}) {
-    tv->split(tv, -1, /*inner_split*/=false);
-  }
-  for (TensorView* to_tv: selected_tvs){
-    TransformPropagator::propagateC2P(tvq, to);
-    debug() << to_tv->getLoopDomain() << std::endl;
-    debug() << to_tv->getAllocationDomain() << std::endl;
-    debug() << to_tv->getLogicalDomain() << std::endl;
-  }
-}
-
 } // namespace nvfuser

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -471,7 +471,7 @@ def test_sdpa(multidevice_test, qkv_format: QkvFormat):
     utils.is_pre_ampere(),
     reason="Flash Attention is only supported on Ampere and newer devices.",
 )
-@pytest.mark.parametrize("qkv_format", [QkvFormat.BHSE])
+@pytest.mark.parametrize("qkv_format", [QkvFormat.BHSE, QkvFormat.BSHE])
 @pytest.mark.mpi
 def test_sdpa_loop_split(multidevice_test, qkv_format: QkvFormat):
     d, b, s, h, e = multidevice_test.size, 2, 1024, 12, 768
@@ -528,18 +528,20 @@ def test_sdpa_loop_split(multidevice_test, qkv_format: QkvFormat):
                 self.add_output(grad)
 
         def multidevice_schedule(self) -> None:
-            for t in [
-                self.q,
-                self.k,
-                self.v,
+            input_tvs = [self.q, self.k, self.v, self.out_grad]
+            output_tvs = [
                 self.attn,
                 self.log_sumexp,
-                self.out_grad,
-                # self.q_grad,
-                # self.k_grad,
-                # self.v_grad,
-            ]:
+                self.q_grad,
+                self.k_grad,
+                self.v_grad,
+            ]
+
+            for t in input_tvs + output_tvs:
                 self.sched._set_device_mesh(t, mesh)
+
+            # Shard input tensorviews
+            for t in input_tvs:
                 self.sched.split(t, 1, d, False)
                 self.sched.parallelize(t, 1, nvfuser.ParallelType.mesh_x)
                 if self._qkv_format == QkvFormat.BSHE:
@@ -547,13 +549,16 @@ def test_sdpa_loop_split(multidevice_test, qkv_format: QkvFormat):
                     # Reorder i{S} in the allocation domain for BHSE: {i{DIDx}, i{B}, i{S}, i{H//D}, i{E//H}}
                     self.sched.reorder(t, {2: 3, 3: 2})
                 self.sched.set_allocation_as_loop(t)
-            selected_tvs = [self.q_grad, self.k_grad, self.v_grad]
-            self.sched.transform_like(self.q, selected_tvs)
-            self.sched.parallelize_like(self.q, -1, selected_tvs, {nvfuser.ParallelType.mesh_x})
-            for t in selected_tvs:
-              print (self.sched.to_string(t))
-              self.sched.set_allocation_as_loop(t)
-            # self.sched.parallelize(t, 1, nvfuser.ParallelType.mesh_x)
+
+            # Propagate sharding to output tvs
+            self.sched.transform_like(self.q, output_tvs)
+            self.sched.parallelize_like(
+                self.q, -1, output_tvs, {nvfuser.ParallelType.mesh_x}
+            )
+
+            # Set allocation as loop for output tvs
+            for t in output_tvs:
+                self.sched.set_allocation_as_loop(t)
 
     torch.cuda.set_device(multidevice_test.local_rank)
 

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -471,7 +471,7 @@ def test_sdpa(multidevice_test, qkv_format: QkvFormat):
     utils.is_pre_ampere(),
     reason="Flash Attention is only supported on Ampere and newer devices.",
 )
-@pytest.mark.parametrize("qkv_format", [QkvFormat.BHSE, QkvFormat.BSHE])
+@pytest.mark.parametrize("qkv_format", [QkvFormat.BHSE])
 @pytest.mark.mpi
 def test_sdpa_loop_split(multidevice_test, qkv_format: QkvFormat):
     d, b, s, h, e = multidevice_test.size, 2, 1024, 12, 768
@@ -535,9 +535,9 @@ def test_sdpa_loop_split(multidevice_test, qkv_format: QkvFormat):
                 self.attn,
                 self.log_sumexp,
                 self.out_grad,
-                self.q_grad,
-                self.k_grad,
-                self.v_grad,
+                # self.q_grad,
+                # self.k_grad,
+                # self.v_grad,
             ]:
                 self.sched._set_device_mesh(t, mesh)
                 self.sched.split(t, 1, d, False)
@@ -547,6 +547,13 @@ def test_sdpa_loop_split(multidevice_test, qkv_format: QkvFormat):
                     # Reorder i{S} in the allocation domain for BHSE: {i{DIDx}, i{B}, i{S}, i{H//D}, i{E//H}}
                     self.sched.reorder(t, {2: 3, 3: 2})
                 self.sched.set_allocation_as_loop(t)
+            selected_tvs = [self.q_grad, self.k_grad, self.v_grad]
+            self.sched.transform_like(self.q, selected_tvs)
+            self.sched.parallelize_like(self.q, -1, selected_tvs, {nvfuser.ParallelType.mesh_x})
+            for t in selected_tvs:
+              print (self.sched.to_string(t))
+              self.sched.set_allocation_as_loop(t)
+            # self.sched.parallelize(t, 1, nvfuser.ParallelType.mesh_x)
 
     torch.cuda.set_device(multidevice_test.local_rank)
 


### PR DESCRIPTION
This modification allows us to use `transform_like` to propagate loop domain split to other tensors in a fusion based on the input reference tensors. I will use this approach in `propagateShardings` preseg pass