### PR TITLE
HostIr Integration 2

### DIFF
--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -46,10 +46,11 @@ class HostIrContainer final : public Fusion {
     kernel_executors_.push_back(std::move(ke));
   }
 
-  void reserveKernelExecutors(std::vector<std::unique_ptr<KernelExecutor>>::size_type sz) {
+  void reserveKernelExecutors(
+      std::vector<std::unique_ptr<KernelExecutor>>::size_type sz) {
     kernel_executors_.resize(sz);
     for (auto& ptr : kernel_executors_) {
-        ptr = nullptr;
+      ptr = nullptr;
     }
   }
 
@@ -76,4 +77,3 @@ class HostIrContainer final : public Fusion {
 } // namespace hir
 
 } // namespace nvfuser
-

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -47,11 +47,18 @@ class HostIrContainer final : public Fusion {
   }
 
   void reserveKernelExecutors(std::vector<std::unique_ptr<KernelExecutor>>::size_type sz) {
-    kernel_executors_.reserve(sz);
+    kernel_executors_.resize(sz);
+    for (auto& ptr : kernel_executors_) {
+        ptr = nullptr;
+    }
   }
 
   void setKernelExecutor(int64_t index, std::unique_ptr<KernelExecutor> ke) {
     kernel_executors_[index] = std::move(ke);
+  }
+
+  bool hasKernelExecutor(int64_t index) const {
+    return kernel_executors_.at(index) != nullptr;
   }
 
   KernelExecutor* getKernelExecutor(int64_t index) const {

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -46,6 +46,14 @@ class HostIrContainer final : public Fusion {
     kernel_executors_.push_back(std::move(ke));
   }
 
+  void reserveKernelExecutors(std::vector<std::unique_ptr<KernelExecutor>>::size_type sz) {
+    kernel_executors_.reserve(sz);
+  }
+
+  void setKernelExecutor(int64_t index, std::unique_ptr<KernelExecutor> ke) {
+    kernel_executors_[index] = std::move(ke);
+  }
+
   KernelExecutor* getKernelExecutor(int64_t index) const {
     return kernel_executors_.at(index).get();
   }
@@ -61,3 +69,4 @@ class HostIrContainer final : public Fusion {
 } // namespace hir
 
 } // namespace nvfuser
+

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -43,7 +43,7 @@ class HostIrContainer final : public Fusion {
   }
 
   void pushBackKernelExecutor(std::unique_ptr<KernelExecutor> ke) {
-    return kernel_executors_.push_back(std::move(ke));
+    kernel_executors_.push_back(std::move(ke));
   }
 
   KernelExecutor* getKernelExecutor(int64_t index) const {

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -332,7 +332,11 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
 
   // run the compiled kernel
   std::vector<at::Tensor> outputs =
-      container_->getKernelExecutor(launch_kernel->getIndex())->run(args, launch_kernel->launch_constraints_, launch_kernel->compile_params_);
+      container_->getKernelExecutor(launch_kernel->getIndex())
+          ->run(
+              args,
+              launch_kernel->launch_constraints_,
+              launch_kernel->compile_params_);
 
   // Store the outputs in the context
   for (auto output_idx : c10::irange(outputs.size())) {

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -332,7 +332,7 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
 
   // run the compiled kernel
   std::vector<at::Tensor> outputs =
-      container_->getKernelExecutor(launch_kernel->getIndex())->run(args);
+      container_->getKernelExecutor(launch_kernel->getIndex())->run(args, launch_kernel->launch_constraints_, launch_kernel->compile_params_);
 
   // Store the outputs in the context
   for (auto output_idx : c10::irange(outputs.size())) {

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -85,8 +85,11 @@ class HostIrEvaluator final : public OptOutDispatch {
       std::unique_ptr<HostIrContainer> container,
       Communicator* communicator = nullptr,
       HostIrEvaluatorParams = HostIrEvaluatorParams());
+
   std::vector<at::Tensor> runWithInput(
       std::unordered_map<Val*, c10::IValue> val_to_IValue);
+  std::vector<at::Tensor> runWithInput(
+      std::unordered_map<Val*, const PolymorphicValue*> val_to_PValue);
 
   const std::vector<Val*>& inputs() {
     return container_->inputs();

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -122,10 +122,14 @@ bool PostOnStream::sameAs(const Statement* other) const {
 LaunchKernel::LaunchKernel(
     IrBuilderPasskey passkey,
     int64_t hic_executor_index,
+    const LaunchParams& launch_constraints,
+    CompileParams compile_params,
     const std::vector<Val*>& inputs,
     const std::vector<Val*>& outputs)
-    : Expr(passkey, inputs, outputs, {}) {
+    : Expr(passkey, inputs, outputs, {}), launch_constraints_(launch_constraints), compile_params_(compile_params) {
   addDataAttribute(hic_executor_index);
+  //launch_constraints_ = launch_constraints;
+  //compile_params_ = compile_params;
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(LaunchKernel)

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -126,10 +126,12 @@ LaunchKernel::LaunchKernel(
     CompileParams compile_params,
     const std::vector<Val*>& inputs,
     const std::vector<Val*>& outputs)
-    : Expr(passkey, inputs, outputs, {}), launch_constraints_(launch_constraints), compile_params_(compile_params) {
+    : Expr(passkey, inputs, outputs, {}),
+      launch_constraints_(launch_constraints),
+      compile_params_(compile_params) {
   addDataAttribute(hic_executor_index);
-  //launch_constraints_ = launch_constraints;
-  //compile_params_ = compile_params;
+  // launch_constraints_ = launch_constraints;
+  // compile_params_ = compile_params;
 }
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(LaunchKernel)

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -122,7 +122,7 @@ bool PostOnStream::sameAs(const Statement* other) const {
 LaunchKernel::LaunchKernel(
     IrBuilderPasskey passkey,
     int64_t hic_executor_index,
-    const LaunchParams& launch_constraints,
+    const LaunchParams launch_constraints,
     CompileParams compile_params,
     const std::vector<Val*>& inputs,
     const std::vector<Val*>& outputs)

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -11,8 +11,8 @@
 #include <ir/base_nodes.h>
 #include <ir/builder.h>
 #include <multidevice/communication.h>
-#include <atomic>
 #include <scheduler/heuristic.h>
+#include <atomic>
 
 namespace nvfuser {
 

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -12,6 +12,7 @@
 #include <ir/builder.h>
 #include <multidevice/communication.h>
 #include <atomic>
+#include <scheduler/heuristic.h>
 
 namespace nvfuser {
 
@@ -123,6 +124,8 @@ class LaunchKernel : public Expr {
       int64_t hic_executor_index, // Index into the HostIrContainer's vector of
                                   // KernelExecutors--i.e., the kernel this IR
                                   // should launch
+      const LaunchParams& launch_constraints,
+      CompileParams compile_params,
       const std::vector<Val*>& inputs,
       const std::vector<Val*>& outputs);
 
@@ -142,6 +145,9 @@ class LaunchKernel : public Expr {
   int64_t getIndex() const {
     return attribute<int64_t>(0);
   }
+
+  const LaunchParams& launch_constraints_;
+  CompileParams compile_params_;
 };
 
 class Stream : public Val {

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -124,7 +124,7 @@ class LaunchKernel : public Expr {
       int64_t hic_executor_index, // Index into the HostIrContainer's vector of
                                   // KernelExecutors--i.e., the kernel this IR
                                   // should launch
-      const LaunchParams& launch_constraints,
+      const LaunchParams launch_constraints,
       CompileParams compile_params,
       const std::vector<Val*>& inputs,
       const std::vector<Val*>& outputs);
@@ -146,7 +146,7 @@ class LaunchKernel : public Expr {
     return attribute<int64_t>(0);
   }
 
-  const LaunchParams& launch_constraints_;
+  const LaunchParams launch_constraints_;
   CompileParams compile_params_;
 };
 

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -165,6 +165,7 @@ const std::unordered_map<std::string, EnableOption>& getEnableOptions() {
           {"resize_scheduler", EnableOption::ResizeScheduler},
           {"static_fusion_count", EnableOption::StaticFusionCount},
           {"warn_register_spill", EnableOption::WarnRegisterSpill},
+          {"host_ir_lowering", EnableOption::HostIrLowering},
       };
   return available_options;
 }

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -106,6 +106,7 @@ enum class EnableOption {
   ResizeScheduler, //! Enable the resize scheduler
   StaticFusionCount, //! Enable using single static count in kernel name
   WarnRegisterSpill, //! Enable warnings of register spill
+  HostIrLowering, //! Enable FusionKernelRuntime lowering to host IR
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -430,8 +430,9 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
       auto in_clone = ir_cloner.clone(group_to_run->inputs());
       auto out_clone = ir_cloner.clone(group_to_run->outputs());
       if (hic->hasKernelExecutor(run_order_id)) {
+        auto heuristic_params = schedulers().at(run_order_id).get();
         auto launch_kernel = IrBuilder::create<nvfuser::hir::LaunchKernel>(
-            run_order_id, std::vector<Val*>{in_clone}, std::vector<Val*>{out_clone});
+            run_order_id, std::vector<Val*>{in_clone}, std::vector<Val*>{out_clone}, heuristic_params->lparams, heuristic_params->cparams);
         hic->pushBackTopLevelExprs(launch_kernel);
       } else {
         // push back segment's exprs into the container as top level expressions

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -753,10 +753,12 @@ void FusionKernelRuntime::compileKernel(
       auto launch_kernel = IrBuilder::create<nvfuser::hir::LaunchKernel>(
           0, std::vector<Val*>{hic_in}, std::vector<Val*>{hic_out});
 
+      std::cout << "adding launch kernel" << std::endl;
       hic->pushBackTopLevelExprs(launch_kernel);
     } else {
       // push back segment's exprs into the container as top level expressions
       for (auto *expr : fusion_to_run->exprs()) {
+        std::cout << "adding expr" << std::endl;
         hic->pushBackTopLevelExprs(expr);
       }
     }

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -427,19 +427,17 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
     for (int64_t run_order_id = 0; run_order_id < num_groups; ++run_order_id) {
       auto group_to_run = runtime_workspace_.group_run_order.at(run_order_id);
       auto fusion_to_run = segmented_fusion_->makeFusion(group_to_run).second;
-      auto in_clone = ir_cloner.clone(group_to_run->inputs());
-      auto out_clone = ir_cloner.clone(group_to_run->outputs());
+      auto in_clone = ir_cloner.clone(fusion_to_run->inputs());
+      auto out_clone = ir_cloner.clone(fusion_to_run->outputs());
       if (hic->hasKernelExecutor(run_order_id)) {
         auto launch_kernel = IrBuilder::create<nvfuser::hir::LaunchKernel>(
             run_order_id, std::vector<Val*>{in_clone}, std::vector<Val*>{out_clone});
         hic->pushBackTopLevelExprs(launch_kernel);
-        std::cout << "pushed back launch kernel" << std::endl;
       } else {
         // push back segment's exprs into the container as top level expressions
         for (auto *expr : fusion_to_run->exprs()) {
           auto cloned_expr = ir_cloner.clone(expr);
           hic->pushBackTopLevelExprs(cloned_expr);
-          std::cout << "pushed back some other expr" << std::endl;
         }
       }
       for (auto &input : in_clone) {
@@ -733,8 +731,6 @@ void FusionKernelRuntime::compileKernel(
   auto group_id = sg->groupId();
   auto heuristic_params = schedulers().at(group_id).get();
 
-  std::cout << "in compileKernel" << std::endl;
-
   // Check that the heuristics are matched, in the case of segmented fusion
   NVF_ERROR(!sg || heuristic_params->scheduler_type == sg->schedulerType());
 
@@ -763,10 +759,6 @@ void FusionKernelRuntime::compileKernel(
       auto ke = std::make_unique<KernelExecutor>();
       ke->compile(fusion_to_run.get(), args, heuristic_params->lparams, heuristic_params->cparams, heuristic_params->scheduler_type);
       hic->setKernelExecutor(group_id, std::move(ke));
-      std::cout << "setting index " << group_id << " to compiled kernel" << std::endl;
-    } else {
-      std::cout << "kernel executor not supported" << std::endl;
-      //nick
     }
   } else {
     // Initialize associated executors

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -288,7 +288,7 @@ std::vector<at::Tensor> FusionKernelRuntime::runWithInputs(
     ArgumentManager args_manager(
         args,
         runtime_workspace_,
-        hie_->inputs()); // nick segmented_fusion_->inputs()
+        hie_->inputs());
     return hie_->runWithInput(args_manager.getTensorMap());
   }
 
@@ -428,8 +428,6 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
     FusionGuard::setCurFusion(hic.get());
     for (int64_t run_order_id = 0; run_order_id < num_groups; ++run_order_id) {
       auto group_to_run = runtime_workspace_.group_run_order.at(run_order_id);
-      // auto fusion_to_run =
-      // segmented_fusion_->makeFusion(group_to_run).second;
       auto in_clone = ir_cloner.clone(group_to_run->inputs());
       auto out_clone = ir_cloner.clone(group_to_run->outputs());
       if (hic->hasKernelExecutor(run_order_id)) {
@@ -452,7 +450,7 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
     auto in_clone = ir_cloner.clone(segmented_fusion_->inputs());
     auto out_clone = ir_cloner.clone(segmented_fusion_->outputs());
     for (auto& input : in_clone) {
-      hic->addInput(input); // nick
+      hic->addInput(input);
     }
     for (auto& output : out_clone) {
       hic->addOutput(output);

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -440,12 +440,14 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
           hic->pushBackTopLevelExprs(cloned_expr);
         }
       }
-      for (auto &input : in_clone) {
-        hic->addInput(input); //nick
-      }
-      for (auto &output : out_clone) {
-        hic->addOutput(output);
-      }
+    }
+    auto in_clone = ir_cloner.clone(segmented_fusion_->inputs());
+    auto out_clone = ir_cloner.clone(segmented_fusion_->outputs());
+    for (auto &input : in_clone) {
+      hic->addInput(input); //nick
+    }
+    for (auto &output : out_clone) {
+      hic->addOutput(output);
     }
   }
 

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -432,7 +432,7 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
       if (hic->hasKernelExecutor(run_order_id)) {
         auto heuristic_params = schedulers().at(run_order_id).get();
         auto launch_kernel = IrBuilder::create<nvfuser::hir::LaunchKernel>(
-            run_order_id, std::vector<Val*>{in_clone}, std::vector<Val*>{out_clone}, heuristic_params->lparams, heuristic_params->cparams);
+            run_order_id, heuristic_params->lparams, heuristic_params->cparams, std::vector<Val*>{in_clone}, std::vector<Val*>{out_clone});
         hic->pushBackTopLevelExprs(launch_kernel);
       } else {
         // push back segment's exprs into the container as top level expressions

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -286,7 +286,7 @@ std::vector<at::Tensor> FusionKernelRuntime::runWithInputs(
               << std::endl;
     }
     ArgumentManager args_manager(
-        args, runtime_workspace_, segmented_fusion_->inputs());
+        args, runtime_workspace_, hie_->inputs()); //nick segmented_fusion_->inputs()
     return hie_->runWithInput(args_manager.getTensorMap());
   }
 
@@ -427,18 +427,26 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
     for (int64_t run_order_id = 0; run_order_id < num_groups; ++run_order_id) {
       auto group_to_run = runtime_workspace_.group_run_order.at(run_order_id);
       auto fusion_to_run = segmented_fusion_->makeFusion(group_to_run).second;
-      if (!HostIrExecutor::supported(fusion_to_run.get()) && !ExprEvalExecutor::supported(fusion_to_run.get())) {
-        auto hic_in = ir_cloner.clone(group_to_run->inputs());
-        auto hic_out = ir_cloner.clone(group_to_run->outputs());
+      auto in_clone = ir_cloner.clone(group_to_run->inputs());
+      auto out_clone = ir_cloner.clone(group_to_run->outputs());
+      if (hic->hasKernelExecutor(run_order_id)) {
         auto launch_kernel = IrBuilder::create<nvfuser::hir::LaunchKernel>(
-            run_order_id, std::vector<Val*>{hic_in}, std::vector<Val*>{hic_out});
+            run_order_id, std::vector<Val*>{in_clone}, std::vector<Val*>{out_clone});
         hic->pushBackTopLevelExprs(launch_kernel);
+        std::cout << "pushed back launch kernel" << std::endl;
       } else {
         // push back segment's exprs into the container as top level expressions
         for (auto *expr : fusion_to_run->exprs()) {
           auto cloned_expr = ir_cloner.clone(expr);
           hic->pushBackTopLevelExprs(cloned_expr);
+          std::cout << "pushed back some other expr" << std::endl;
         }
+      }
+      for (auto &input : in_clone) {
+        hic->addInput(input); //nick
+      }
+      for (auto &output : out_clone) {
+        hic->addOutput(output);
       }
     }
   }
@@ -725,6 +733,8 @@ void FusionKernelRuntime::compileKernel(
   auto group_id = sg->groupId();
   auto heuristic_params = schedulers().at(group_id).get();
 
+  std::cout << "in compileKernel" << std::endl;
+
   // Check that the heuristics are matched, in the case of segmented fusion
   NVF_ERROR(!sg || heuristic_params->scheduler_type == sg->schedulerType());
 
@@ -753,6 +763,10 @@ void FusionKernelRuntime::compileKernel(
       auto ke = std::make_unique<KernelExecutor>();
       ke->compile(fusion_to_run.get(), args, heuristic_params->lparams, heuristic_params->cparams, heuristic_params->scheduler_type);
       hic->setKernelExecutor(group_id, std::move(ke));
+      std::cout << "setting index " << group_id << " to compiled kernel" << std::endl;
+    } else {
+      std::cout << "kernel executor not supported" << std::endl;
+      //nick
     }
   } else {
     // Initialize associated executors

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -426,16 +426,16 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
     FusionGuard::setCurFusion(hic.get());
     for (int64_t run_order_id = 0; run_order_id < num_groups; ++run_order_id) {
       auto group_to_run = runtime_workspace_.group_run_order.at(run_order_id);
-      auto fusion_to_run = segmented_fusion_->makeFusion(group_to_run).second;
-      auto in_clone = ir_cloner.clone(fusion_to_run->inputs());
-      auto out_clone = ir_cloner.clone(fusion_to_run->outputs());
+      //auto fusion_to_run = segmented_fusion_->makeFusion(group_to_run).second;
+      auto in_clone = ir_cloner.clone(group_to_run->inputs());
+      auto out_clone = ir_cloner.clone(group_to_run->outputs());
       if (hic->hasKernelExecutor(run_order_id)) {
         auto launch_kernel = IrBuilder::create<nvfuser::hir::LaunchKernel>(
             run_order_id, std::vector<Val*>{in_clone}, std::vector<Val*>{out_clone});
         hic->pushBackTopLevelExprs(launch_kernel);
       } else {
         // push back segment's exprs into the container as top level expressions
-        for (auto *expr : fusion_to_run->exprs()) {
+        for (auto *expr : group_to_run->exprs()) {
           auto cloned_expr = ir_cloner.clone(expr);
           hic->pushBackTopLevelExprs(cloned_expr);
         }

--- a/csrc/runtime/fusion_kernel_runtime.h
+++ b/csrc/runtime/fusion_kernel_runtime.h
@@ -14,7 +14,7 @@
 #include <runtime/executor.h>
 #include <runtime/executor_kernel_arg.h>
 #include <runtime/fusion_cache_utils.h>
-#include <host_ir/container.h>
+#include <host_ir/executor.h>
 
 #include <mutex>
 #include <vector>
@@ -164,7 +164,7 @@ class FusionKernelRuntime {
   //! Interface to compile a single kernel. It is either a single kernel for a
   //! fusion or a kernel for a segmentedGrouup in a segmented fusion. Returns
   //! launch and compile parameters for kernel.
-  void compileKernel(const KernelArgumentHolder& args, SegmentedGroup* sg);
+  void compileKernel(const KernelArgumentHolder& args, SegmentedGroup* sg, nvfuser::hir::HostIrContainer* hic);
 
   std::pair<LaunchParams, CompileParams> getKernelConfig(
       const KernelArgumentHolder& args,
@@ -179,8 +179,8 @@ class FusionKernelRuntime {
   //! Executors holding compiled kernels
   std::vector<std::unique_ptr<ExecutorAbstract>> executors_;
 
-  //! Host IR container
-  std::unique_ptr<nvfuser::hir::HostIrContainer> hic_;
+  //! Host IR Evaluator
+  std::unique_ptr<nvfuser::hir::HostIrEvaluator> hie_;
 
   // A metadata copy of initial arguments used to contruct this
   // FusionKernelRuntime. Used during deserialization to schedule the fusion
@@ -239,3 +239,4 @@ class FusionKernelRuntime {
 };
 
 } // namespace nvfuser
+

--- a/csrc/runtime/fusion_kernel_runtime.h
+++ b/csrc/runtime/fusion_kernel_runtime.h
@@ -10,11 +10,11 @@
 #include <c10/util/ArrayRef.h>
 
 #include <fusion_segmenter.h>
+#include <host_ir/executor.h>
 #include <polymorphic_value.h>
 #include <runtime/executor.h>
 #include <runtime/executor_kernel_arg.h>
 #include <runtime/fusion_cache_utils.h>
-#include <host_ir/executor.h>
 
 #include <mutex>
 #include <vector>
@@ -164,7 +164,10 @@ class FusionKernelRuntime {
   //! Interface to compile a single kernel. It is either a single kernel for a
   //! fusion or a kernel for a segmentedGrouup in a segmented fusion. Returns
   //! launch and compile parameters for kernel.
-  void compileKernel(const KernelArgumentHolder& args, SegmentedGroup* sg, nvfuser::hir::HostIrContainer* hic);
+  void compileKernel(
+      const KernelArgumentHolder& args,
+      SegmentedGroup* sg,
+      nvfuser::hir::HostIrContainer* hic);
 
   std::pair<LaunchParams, CompileParams> getKernelConfig(
       const KernelArgumentHolder& args,
@@ -239,4 +242,3 @@ class FusionKernelRuntime {
 };
 
 } // namespace nvfuser
-

--- a/csrc/runtime/fusion_kernel_runtime.h
+++ b/csrc/runtime/fusion_kernel_runtime.h
@@ -14,6 +14,7 @@
 #include <runtime/executor.h>
 #include <runtime/executor_kernel_arg.h>
 #include <runtime/fusion_cache_utils.h>
+#include <host_ir/container.h>
 
 #include <mutex>
 #include <vector>
@@ -177,6 +178,9 @@ class FusionKernelRuntime {
   //! Entries indexed by groupID:
   //! Executors holding compiled kernels
   std::vector<std::unique_ptr<ExecutorAbstract>> executors_;
+
+  //! Host IR container
+  std::unique_ptr<nvfuser::hir::HostIrContainer> hic_;
 
   // A metadata copy of initial arguments used to contruct this
   // FusionKernelRuntime. Used during deserialization to schedule the fusion

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -47,7 +47,7 @@ TEST_F(HostIrIntegrationTest, LaunchKernel) {
   hic->addOutput(hic_out);
 
   auto launch_kernel = IrBuilder::create<LaunchKernel>(
-      0, std::vector<Val*>{hic_in}, std::vector<Val*>{hic_out});
+      0, std::vector<Val*>{hic_in}, std::vector<Val*>{hic_out}, LaunchParams(), CompileParams());
 
   hic->pushBackTopLevelExprs(launch_kernel);
 

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -47,7 +47,11 @@ TEST_F(HostIrIntegrationTest, LaunchKernel) {
   hic->addOutput(hic_out);
 
   auto launch_kernel = IrBuilder::create<LaunchKernel>(
-      0, LaunchParams(), CompileParams(), std::vector<Val*>{hic_in}, std::vector<Val*>{hic_out});
+      0,
+      LaunchParams(),
+      CompileParams(),
+      std::vector<Val*>{hic_in},
+      std::vector<Val*>{hic_out});
 
   hic->pushBackTopLevelExprs(launch_kernel);
 
@@ -60,8 +64,9 @@ TEST_F(HostIrIntegrationTest, LaunchKernel) {
 
 using EnableHostIrCodepath = bool;
 
-class HostIrCodepathSetTest : public NVFuserTest,
-                         public testing::WithParamInterface<EnableHostIrCodepath> {};
+class HostIrCodepathSetTest
+    : public NVFuserTest,
+      public testing::WithParamInterface<EnableHostIrCodepath> {};
 
 TEST_P(HostIrCodepathSetTest, ) {
   const auto& use_codepath = GetParam();
@@ -84,17 +89,20 @@ TEST_P(HostIrCodepathSetTest, ) {
   std::vector<at::Tensor> out_tensors =
       executor_cache.runFusionWithInputs({in_tensor});
 
-  testValidate(executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__, "");
+  testValidate(
+      executor_cache.fusion(),
+      out_tensors,
+      {in_tensor},
+      __LINE__,
+      __FILE__,
+      "");
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    ,
-    HostIrCodepathSetTest,
-    ::testing::Bool()
-);
+INSTANTIATE_TEST_SUITE_P(, HostIrCodepathSetTest, ::testing::Bool());
 
-class HostIrCodepathSumTest : public NVFuserTest,
-                         public testing::WithParamInterface<EnableHostIrCodepath> {};
+class HostIrCodepathSumTest
+    : public NVFuserTest,
+      public testing::WithParamInterface<EnableHostIrCodepath> {};
 
 TEST_P(HostIrCodepathSumTest, ) {
   const auto& use_codepath = GetParam();
@@ -117,14 +125,16 @@ TEST_P(HostIrCodepathSumTest, ) {
   std::vector<at::Tensor> out_tensors =
       executor_cache.runFusionWithInputs({in_tensor});
 
-  testValidate(executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__, "");
+  testValidate(
+      executor_cache.fusion(),
+      out_tensors,
+      {in_tensor},
+      __LINE__,
+      __FILE__,
+      "");
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    ,
-    HostIrCodepathSumTest,
-    ::testing::Bool()
-);
+INSTANTIATE_TEST_SUITE_P(, HostIrCodepathSumTest, ::testing::Bool());
 
 } // namespace hir
 

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -47,7 +47,7 @@ TEST_F(HostIrIntegrationTest, LaunchKernel) {
   hic->addOutput(hic_out);
 
   auto launch_kernel = IrBuilder::create<LaunchKernel>(
-      0, std::vector<Val*>{hic_in}, std::vector<Val*>{hic_out}, LaunchParams(), CompileParams());
+      0, LaunchParams(), CompileParams(), std::vector<Val*>{hic_in}, std::vector<Val*>{hic_out});
 
   hic->pushBackTopLevelExprs(launch_kernel);
 

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -57,6 +57,21 @@ TEST_F(HostIrIntegrationTest, LaunchKernel) {
   EXPECT_TRUE(outputs[0].equal(t0));
 }
 
+TEST_F(HostIrIntegrationTest, HostIrCodepath) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+  TensorView* in = makeSymbolicTensor(2);
+  fusion.addInput(in);
+
+  TensorView* out = set(in);
+  fusion.addOutput(out);
+
+  EnableOptionsGuard opt_guard;
+  EnableOptionsGuard::getCurOptions().set(EnableOption::HostIrLowering);
+
+  //EXPECT_TRUE(outputs[0].equal(t0));
+}
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -72,7 +72,25 @@ TEST_F(HostIrIntegrationTest, HostIrCodepath) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
-      at::randn({2, 3, 4}, at::dtype(at::kFloat).device(at::kCUDA, 0));
+      at::randn({2, 3}, at::dtype(at::kFloat).device(at::kCUDA, 0));
+  std::vector<at::Tensor> out_tensors =
+      executor_cache.runFusionWithInputs({in_tensor});
+
+  testValidate(executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__, "");
+}
+
+TEST_F(HostIrIntegrationTest, NonHostIrCodepath) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  TensorView* in = makeSymbolicTensor(2);
+  fusion->addInput(in);
+
+  TensorView* out = set(in);
+  fusion->addOutput(out);
+
+  FusionExecutorCache executor_cache(std::move(fusion));
+  at::Tensor in_tensor =
+      at::randn({2, 3}, at::dtype(at::kFloat).device(at::kCUDA, 0));
   std::vector<at::Tensor> out_tensors =
       executor_cache.runFusionWithInputs({in_tensor});
 

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -481,7 +481,7 @@ TEST_F(StreamTest, HostIrSetStream) {
 
   HostIrEvaluator hie(std::move(hic));
   setCurrentCUDAStream(c10::cuda::getDefaultCUDAStream(0));
-  hie.runWithInput({});
+  hie.runWithInput(std::unordered_map<Val*, c10::IValue>());
   EXPECT_NE(
       c10::cuda::getDefaultCUDAStream(0), c10::cuda::getCurrentCUDAStream(0));
 }
@@ -501,7 +501,7 @@ TEST_F(StreamTest, HostIrDefaultStream) {
     auto set_stream = IrBuilder::create<SetCurrentStream>(stream);
     hic->pushBackTopLevelExprs(set_stream);
     HostIrEvaluator hie(std::move(hic));
-    hie.runWithInput({});
+    hie.runWithInput(std::unordered_map<Val*, c10::IValue>());
   };
 
   setCurrentCUDAStream(c10::cuda::getDefaultCUDAStream(0));
@@ -528,7 +528,7 @@ TEST_F(StreamTest, HostIrGetCurrentStream) {
   setCurrentCUDAStream(cuda_stream);
 
   HostIrEvaluator hie(std::move(hic));
-  hie.runWithInput({});
+  hie.runWithInput(std::unordered_map<Val*, c10::IValue>());
 
   EXPECT_EQ(cuda_stream, c10::cuda::getCurrentCUDAStream(0));
 }
@@ -553,7 +553,7 @@ TEST_F(StreamTest, ByIndex) {
   hic->pushBackTopLevelExprs(IrBuilder::create<SetCurrentStream>(stream2));
 
   HostIrEvaluator hie(std::move(hic));
-  hie.runWithInput({});
+  hie.runWithInput(std::unordered_map<Val*, c10::IValue>());
 
   const std::unordered_map<
       std::variant<int64_t, Stream*>,
@@ -1048,7 +1048,7 @@ TEST_F(AllocationTest, HostIr) {
 
   HostIrEvaluator hie(std::move(hic));
 
-  auto outputs = hie.runWithInput({});
+  auto outputs = hie.runWithInput(std::unordered_map<Val*, c10::IValue>());
 
   EXPECT_EQ(sizes, outputs.at(0).sizes());
 }
@@ -1085,7 +1085,7 @@ TEST_F(AllocationTest, inHostForLoop) {
 
   HostIrEvaluator hie(std::move(hic));
 
-  auto outputs = hie.runWithInput({});
+  auto outputs = hie.runWithInput(std::unordered_map<Val*, c10::IValue>());
 
   EXPECT_EQ(sizes, outputs.at(0).sizes());
 }


### PR DESCRIPTION
This PR adds milestone 2 from Jingyue's document [Initial Integration of Host IR to FusionExecutorCache](https://docs.google.com/document/d/1QrRmN27XsVjZu7QrZWJJyRENO50878LC3MvlQY1cRYA/edit?usp=sharing)

It adds an optional codepath in FusionKernelRuntime (FKR) to lower a fusion to Host IR. When enabled, FKR will create a HostIrEvaluator, which has a container that all of the fusion's expressions are pushed to. Expressions lowered to a kernel are launched with the LaunchKernel HostIr.