### PR TITLE
Move `waitForDebugger utility to communicator 

### DIFF
--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -8,6 +8,7 @@
 #include <cuda_utils.h>
 #include <multidevice/communicator.h>
 #include <options.h>
+#include <utils.h>
 
 #include <netdb.h>
 #include <map>
@@ -222,6 +223,89 @@ Communicator::Communicator(
 #ifdef USE_C10D_NCCL
   nccl_available_ = true;
 #endif
+}
+
+namespace {
+void waitForDebuggerAtRank(Communicator* communicator, DeviceIdxType rank) {
+  NVF_CHECK(
+      rank >= 0 && rank < communicator->size(),
+      "rank=",
+      rank,
+      " must be in the range of [0,",
+      communicator->size(),
+      ").");
+
+  if (communicator->deviceId() == rank) {
+    volatile bool waiting = true;
+    auto pid = getpid();
+    std::cerr << "Process " << pid
+              << " is waiting for the debugger. To continue debugging, "
+              << "start gdb, `attach " << pid
+              << "`, `set var waiting=false`, and `fini`." << std::endl;
+    while (waiting) { // Please change `waiting` in the debugger.
+    }
+    std::cerr << "Process " << getpid() << " finished waiting." << std::endl;
+  }
+
+  if (communicator->is_available()) {
+    communicator->barrier();
+  }
+}
+} // namespace
+
+Communicator& Communicator::getInstance() {
+  // This isn't the best practice to use singleton. Ideally, we'd like to
+  // ```
+  // static Communicator communicator;
+  // ```
+  // and let the destructor clean it up at program exit after `main` returns.
+  // This however would cause a "driver shutting down" error, likely because
+  // another static variable destructor shuts down the CUDA driver before
+  // ~Communicator. Note that the order of static variable destruction
+  // across translation units is undefined.
+  //
+  // Therefore, we `new Communicator()` as a raw pointer and let the user
+  // call Communicator::getInstance().cleanup() to clean up the Communicator
+  // explicitly before the end of `main`. For example, the cleanup method is
+  // called via MultiDeviceTestEnvironment::TearDown in C++ unit tests and
+  // nvfuser._cleanup() in Python.
+  static auto* communicator = new Communicator();
+
+  // NVFUSER_MULTIDEVICE_WAIT_DEBUGGER_AT_RANK can be used to attach gdb to one
+  // of the processes for debugging.
+  //
+  // When an mpirun fails, it usually prints out something like
+  // ```
+  // mpirun detected that one or more processes exited with non-zero status,
+  // thus causing the job to be terminated. The first process to do so was:
+  //
+  //   Process name: [[17665,1],0]
+  //   Exit code:    1
+  // ```
+  // The last bit of the process name (0 in this case) is the rank of the first
+  // failing process, and usually the rank to debug.
+  //
+  // Sometimes, multiple processes fail, and a failed, non-gdb'ed process can
+  // cause `mpirun` to terminate the entire job including the process being
+  // gdb'ed. For that, I use `mpirun -continuous` so `mpirun` keeps running the
+  // process being gdb'ed.
+
+  char* rank_to_debug_str = getNvFuserEnv("MULTIDEVICE_WAIT_DEBUGGER_AT_RANK");
+  if (rank_to_debug_str != nullptr) {
+    const DeviceIdxType rank_to_debug = std::stol(rank_to_debug_str);
+
+    static std::once_flag once;
+    std::call_once(once, [&]() {
+      // Catch exceptions so call_once always flips `once` and executes this
+      // functor only once.
+      try {
+        waitForDebuggerAtRank(communicator, rank_to_debug);
+      } catch (const std::exception& e) {
+        TORCH_WARN("Failed to wait for debugger: ", e.what());
+      }
+    });
+  }
+  return *communicator;
 }
 
 void Communicator::cleanup() {

--- a/csrc/multidevice/communicator.h
+++ b/csrc/multidevice/communicator.h
@@ -50,25 +50,7 @@ constexpr int comm_server_local_rank_default = 0;
 
 class Communicator {
  public:
-  static Communicator& getInstance() {
-    // This isn't the best practice to use singleton. Ideally, we'd like to
-    // ```
-    // static Communicator communicator;
-    // ```
-    // and let the destructor clean it up at program exit after `main` returns.
-    // This however would cause a "driver shutting down" error, likely because
-    // another static variable destructor shuts down the CUDA driver before
-    // ~Communicator. Note that the order of static variable destruction
-    // across translation units is undefined.
-    //
-    // Therefore, we `new Communicator()` as a raw pointer and let the user
-    // call Communicator::getInstance().cleanup() to clean up the Communicator
-    // explicitly before the end of `main`. For example, the cleanup method is
-    // called via MultiDeviceTestEnvironment::TearDown in C++ unit tests and
-    // nvfuser._cleanup() in Python.
-    static auto* communicator = new Communicator();
-    return *communicator;
-  }
+  static Communicator& getInstance();
 
   Communicator(const Communicator&) = delete;
   Communicator& operator=(const Communicator&) = delete;

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -43,9 +43,6 @@ class MultiDeviceTest : public NVFuserTest {
   c10::TensorOptions tensor_options;
   bool debug_print;
   bool disable_skip;
-
- private:
-  void waitForDebuggerAtRank(DeviceIdxType rank);
 };
 
 } // namespace nvfuser


### PR DESCRIPTION
This allows using `NVFUSER_MULTIDEVICE_WAIT_DEBUGGER_AT_RANK` for debugging python tests.

Note, when using `pytest`, it captures all the outputs and requires an additional `-s` flag to dump to stdout. If using the above utility, do:
`NVFUSER_MULTIDEVICE_WAIT_DEBUGGER_AT_RANK=0 mpirun -np 2 pytest tests/python/test_multidevice.py --with-mpi -s` 
This allows us to view the following instructions on how to attach to a pid:

```
Process 1761887 is waiting for the debugger. To continue debugging, start gdb, `attach 1761887`, `set var waiting=false`, and `fini`.
```