### PR TITLE
Use a single wgmma wait_group to flush async wgmma pipeline

### DIFF
--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -1995,11 +1995,16 @@ bool allMmaInputsGuardedByMBarrier(const MmaOp* mma) {
       ir_utils::isCpAsyncBulkLoad(ir_utils::getTv(mma->inB())->definition());
 }
 
-std::vector<Expr*> getSyncExprs(AsyncOpType async_type, int64_t keep_stages) {
+std::vector<Expr*> getSyncExprs(
+    AsyncOpType async_type,
+    int64_t keep_stages,
+    bool requires_commit) {
   std::vector<Expr*> sync_exprs;
   sync_exprs.reserve(2);
-  auto commit = IrBuilder::create<kir::AsyncCommit>(async_type);
-  sync_exprs.push_back(commit);
+  if (requires_commit) {
+    auto commit = IrBuilder::create<kir::AsyncCommit>(async_type);
+    sync_exprs.push_back(commit);
+  }
   auto wait = IrBuilder::create<kir::AsyncWait>(async_type, keep_stages);
   sync_exprs.push_back(wait);
   return sync_exprs;

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -375,7 +375,8 @@ bool allMmaInputsGuardedByMBarrier(const MmaOp* mma);
 //   wgmma.wait_group.sync.aligned
 std::vector<Expr*> getSyncExprs(
     AsyncOpType async_type,
-    int64_t keep_stages = 0);
+    int64_t keep_stages = 0,
+    bool requires_commit = true);
 
 } // namespace lower_utils
 


### PR DESCRIPTION
This PR optimizes RAW sync insertion for wgmma operations.

### Problem: 
1. Inserting multiple RAW syncs for wgmma pipeline can slowdown performance.
2. Combining `wgmma.commit_group` and `wgmma.wait_group` together can cause the compiler to serialize wgmma.mma_async. `wgmma.commit_group` is required when issuing wgmma operation group. `wgmma.wait_group` is required when waiting for wgmma operation groups to finish.

### Proposed Solution:
1. Issue a single `wgmma.commit_group` after completing mma operations but before any consumer operations.
2. Add `bool requires_commit` to `lower_utils::getSyncExprs`, so the `commit` phase is optional.

### Why?
* `wgmma.wait_group 0` flushes the entire pipeline, so all wgmma operations are complete. Additional RAW syncs are unnecessary.

### Cuda Examples
<details>
<summary> From MLPBenchmarkTest.FwdHorizontalFusion/data_parallel_warpspec </summary>

### Without Fix: 4 RAW wgmma syncs
```cuda
__global__ void kernel_without_raw_sync_fix(args) {
  // Compute MMA
  
  asm volatile("wgmma.commit_group.sync.aligned;\n");
  asm volatile("wgmma.wait_group.sync.aligned %0;\n"::"n"(0LL):"memory");
  Array<__bfloat, 64, 8> T18;
  #pragma unroll
  for(nvfuser_index_t i65 = 0; i65 < 16; ++i65) {
    nvfuser_index_t i66;
    i66 = 4 * i65;
    #pragma unroll
    for(nvfuser_index_t i67 = 0; i67 < 2; ++i67) {
      nvfuser_index_t i68;
      i68 = i66 + (2 * i67);
      #pragma unroll
      for(nvfuser_index_t i69 = 0; i69 < 2; ++i69) {
        nvfuser_index_t i70;
        i70 = i68 + i69;
        Array<__bfloat, 1, 1> T23;
        T23[0]
           = __float2bfloat(T22[i70]);
        T18[i70]
           = T23[0];
      }
    }
  }
  #pragma unroll
  for(nvfuser_index_t i71 = 0; i71 < 8; ++i71) {
    asm volatile(
      "stmatrix.sync.aligned.x4.m8n8.shared.b16 [%0], {%1, %2, %3, %4};\n"
      :
      :"r"((uint32_t)((toSmem(T26) + ((((nvfuser_index_t)threadIdx.y) * 16384) + (((i71 / 4) * 8192) + ((i17 * 128) + (((((((nvfuser_index_t)threadIdx.x) % 32) / 16) + ((i71 % 4) * 2)) ^ (i17 % 8)) * 16))))))),
       "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T18[(8 * i71)]))[0]),
       "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T18[(8 * i71)]))[1]),
       "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T18[(8 * i71)]))[2]),
       "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T18[(8 * i71)]))[3])
    );
  }
  __syncthreads();
  #pragma unroll
  for(nvfuser_index_t i72 = 0; i72 < 2; ++i72) {
    asm volatile("fence.proxy.async;\n");
    if ((Hopper::electSync(4294967295U) && b26)) {
      Hopper::cpAsyncBulkTensorTileS2G((Hopper::CpAsyncBulkTensorTileS2GIndex<2>{ ptr23, (Array<nvfuser_index_t, 2, 1>{(i9 + (64 * i72)), i21}) }), (i22 + (8192 * i72)));
    }
  }
  asm volatile("wgmma.commit_group.sync.aligned;\n");
  asm volatile("wgmma.wait_group.sync.aligned %0;\n"::"n"(0LL):"memory");
  asm volatile("wgmma.commit_group.sync.aligned;\n");
  asm volatile("wgmma.wait_group.sync.aligned %0;\n"::"n"(0LL):"memory");
  asm volatile("wgmma.commit_group.sync.aligned;\n");
  asm volatile("wgmma.wait_group.sync.aligned %0;\n"::"n"(0LL):"memory");

  // Compute Epilogue
}
```
### With Fix: 1 RAW wgmma syncs
```cuda
__global__ void kernel_with_raw_sync_fix(args) {
  // Compute MMA
  
  asm volatile("wgmma.wait_group.sync.aligned %0;\n"::"n"(0LL):"memory");
  Array<__bfloat, 64, 8> T20;
  #pragma unroll
  for(nvfuser_index_t i52 = 0; i52 < 16; ++i52) {
    nvfuser_index_t i53;
    i53 = 4 * i52;
    #pragma unroll
    for(nvfuser_index_t i54 = 0; i54 < 2; ++i54) {
      nvfuser_index_t i55;
      i55 = i53 + (2 * i54);
      #pragma unroll
      for(nvfuser_index_t i56 = 0; i56 < 2; ++i56) {
        nvfuser_index_t i57;
        i57 = i55 + i56;
        Array<__bfloat, 1, 1> T25;
        T25[0]
           = __float2bfloat(T24[i57]);
        T20[i57]
           = T25[0];
      }
    }
  }
  __syncthreads();
  #pragma unroll
  for(nvfuser_index_t i58 = 0; i58 < 8; ++i58) {
    if ((b30 && (i31 < (-(16 * i58))))) {
      asm volatile(
        "stmatrix.sync.aligned.x4.m8n8.shared.b16 [%0], {%1, %2, %3, %4};\n"
        :
        :"r"((uint32_t)((toSmem(T27) + ((((nvfuser_index_t)threadIdx.y) * 16384) + (((i58 / 4) * 8192) + ((i16 * 128) + (((((((nvfuser_index_t)threadIdx.x) % 32) / 16) + ((i58 % 4) * 2)) ^ (i16 % 8)) * 16))))))),
         "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T20[(8 * i58)]))[0]),
         "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T20[(8 * i58)]))[1]),
         "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T20[(8 * i58)]))[2]),
         "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T20[(8 * i58)]))[3])
      );
    }
  }
  __syncthreads();
  #pragma unroll
  for(nvfuser_index_t i59 = 0; i59 < 2; ++i59) {
    asm volatile("fence.proxy.async;\n");
    if (((Hopper::electSync(4294967295U) && b26) && b29)) {
      Hopper::cpAsyncBulkTensorTileS2G((Hopper::CpAsyncBulkTensorTileS2GIndex<2>{ ptr19, (Array<nvfuser_index_t, 2, 1>{(i8 + (64 * i59)), i21}) }), (i18 + (8192 * i59)));
    }
  }

  // Compute Epilogue
}
```

</details>