### PR TITLE
Generate inline asm as utility function

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -3260,7 +3260,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       if (!utility_generated) {
         const auto& outputs = asm_->outputs();
         const auto& inputs = asm_->inputs();
-        utilities_ << "void " << utility_name << "(";
+        utilities_ << "__device__ __inline__ void " << utility_name << "(";
         for (auto out_i : c10::irange(outputs.size())) {
           if (out_i > 0) {
             utilities_ << ", ";

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -409,6 +409,22 @@ std::string Asm::toInlineString(int indent_size) const {
   NVF_CHECK(false, "Asm op can not be printed inline");
 }
 
+const std::string Asm::utility() const {
+  static const std::unordered_map<std::string, std::string> ptx_to_utility{
+      {"tcgen05.wait::ld.sync.aligned", "waitTMemLoad"},
+      {"tcgen05.wait::st.sync.aligned", "waitTMemStore"},
+      {"tcgen05.ld.sync.aligned.32x32b.x1.b32", "loadTMem"},
+      {"tcgen05.st.sync.aligned.32x32b.x1.b32", "storeTMem"},
+      {"tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32", "allocTMem"},
+      {"tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned",
+       "relinquishTMemAllocPermit"}};
+  auto it = ptx_to_utility.find(code());
+  if (it != ptx_to_utility.end()) {
+    return it->second;
+  }
+  return "";
+}
+
 NVFUSER_DEFINE_CLONE_AND_CREATE(Asm)
 
 AllocTMem::AllocTMem(IrBuilderPasskey passkey, Val* address, Val* num_columns)

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -211,6 +211,8 @@ class Asm final : public Expr {
     return attribute<std::string>(0);
   }
 
+  const std::string utility() const;
+
   const Options& options() const {
     return attribute<Options>(1);
   }

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -211,6 +211,9 @@ class Asm final : public Expr {
     return attribute<std::string>(0);
   }
 
+  // The name of the utility function that we want to wrap the inline PTX code
+  // in. If this is empty, then the inline PTX code will be emitted directly
+  // into the kernel.
   const std::string utility() const;
 
   const Options& options() const {

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -624,7 +624,7 @@ class BlackwellBase : public NVFuserTest {
  protected:
   void SetUp() override {
     if (cudaArchGuardShouldSkip(10, 0)) {
-      // GTEST_SKIP() << "skipping tests on non-Blackwell GPUs";
+      GTEST_SKIP() << "skipping tests on non-Blackwell GPUs";
     }
     NVFuserTest::SetUp();
   }

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -624,7 +624,7 @@ class BlackwellBase : public NVFuserTest {
  protected:
   void SetUp() override {
     if (cudaArchGuardShouldSkip(10, 0)) {
-      GTEST_SKIP() << "skipping tests on non-Blackwell GPUs";
+      // GTEST_SKIP() << "skipping tests on non-Blackwell GPUs";
     }
     NVFuserTest::SetUp();
   }


### PR DESCRIPTION
This PR modifies `codegen.cpp` to allowing wrapping inline asm as utility functions.

A new method `utility` is added to `kir::Asm`, which either returns an empty string, which indicate that we should generate the PTX code directly into the kernel, or some valid identifier, which will be the name of the utility function that this PTX will be wrapped as.

In `CudaKernelGenerator`, instead of having a single string stream `code_`,  we now have two string streams `utility_` and `code_`, where `utility_` will hold all utilities generated by the codegen. Today, the utility section only contains PTX wrappers, but in the future, we can extent it to include more items as needed.

By generating utilities on the fly as needed, we can have the benefit of both the better readability of the kernel, and the shorter length of the generated CUDA string.

Example code:
```CUDA
void allocTMem(uint32_t in0, uint32_t in1) {
  asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;\n"::"r"(in0), "r"(in1));
}
void relinquishTMemAllocPermit() {
  asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;\n");
}
void storeTMem(uint32_t in0, Array<float, 1, 1> in1) {
  asm volatile(
    "tcgen05.st.sync.aligned.32x32b.x1.b32 [%0], {%1};\n"
    :
    :"r"(in0),
     "f"(in1[0])
  );
}
void waitTMemStore() {
  asm volatile("tcgen05.wait::st.sync.aligned;\n");
}
void loadTMem(Array<float, 1, 1>& out0, uint32_t in0) {
  asm(
    "tcgen05.ld.sync.aligned.32x32b.x1.b32 {%0}, [%1];\n"
    :"=f"(out0[0])
    :"r"(in0)
  );
}
void waitTMemLoad() {
  asm volatile("tcgen05.wait::ld.sync.aligned;\n");
}
__global__ void nvfuser_none_f0_c0_r0_g0(Tensor<float, 1, 1> T0, Tensor<float, 1, 1> T4, Tensor<float, 1, 1> T9) {
  alignas(16) extern __shared__ char array[];
  const unsigned smem_offset = 0;
  nvfuser_index_t i0;
  i0 = ((nvfuser_index_t)threadIdx.x) + (32 * ((nvfuser_index_t)blockIdx.x));
  bool b1;
  b1 = i0 < T0.logical_size[0LL];
  uint32_t* T10 = reinterpret_cast<uint32_t*>(array + smem_offset + 0);
  allocTMem((uint32_t)(toSmem(T10)), (uint32_t)(64));
  relinquishTMemAllocPermit();
  __syncthreads();
  Array<float, 1, 1> T1;
  T1[0] = 0;
  if (b1) {
    T1[0]
       = T0[((T0.alloc_stride[0LL] * ((nvfuser_index_t)threadIdx.x)) + ((32 * T0.alloc_stride[0LL]) * ((nvfuser_index_t)blockIdx.x)))];
  }
  TMemTensor T2(T10[0], 0, 0);
  storeTMem((uint32_t)(T2 + Array<uint16_t, 2, 1>{0, 0}), (*reinterpret_cast<Array<float, 1, 1>*>(&T1[0])));
  waitTMemStore();
  Array<float, 1, 1> T3;
  loadTMem((*reinterpret_cast<Array<float, 1, 1>*>(&T3[0])), (uint32_t)(T2 + Array<uint16_t, 2, 1>{0, 0}));
  waitTMemLoad();
  Array<float, 1, 1> T5;
  T5[0] = 0;
  if (b1) {
    T5[0]
       = T4[((T4.alloc_stride[0LL] * ((nvfuser_index_t)threadIdx.x)) + ((32 * T4.alloc_stride[0LL]) * ((nvfuser_index_t)blockIdx.x)))];
  }
  TMemTensor T6(T10[0], 0, 32);
  storeTMem((uint32_t)(T6 + Array<uint16_t, 2, 1>{0, 0}), (*reinterpret_cast<Array<float, 1, 1>*>(&T5[0])));
  waitTMemStore();
  Array<float, 1, 1> T7;
  loadTMem((*reinterpret_cast<Array<float, 1, 1>*>(&T7[0])), (uint32_t)(T6 + Array<uint16_t, 2, 1>{0, 0}));
  waitTMemLoad();
  Array<float, 1, 1> T8;
  T8[0]
    = T3[0]
    + T7[0];
  if (b1) {
    T9[i0]
       = T8[0];
  }
}
```

I suggest reviewing this PR hiding whitespaces:
![image](https://github.com/NVIDIA/Fuser/assets/1032377/892cfeff-f080-49a0-9846-319632538339)