### PR TITLE
Always build an IdModel during lowering

### DIFF
--- a/csrc/device_lower/id_model_options.h
+++ b/csrc/device_lower/id_model_options.h
@@ -16,7 +16,7 @@ namespace nvfuser {
 class IdModelOptions {
  public:
   IdModelOptions()
-      : build_id_model_(isOptionDisabled(EnableOption::IdModel)),
+      : build_id_model_(isOptionDisabled(DisableOption::IdModel)),
         consumer_index_(
             isIdModelOptionEnabled(IdModelEnableOption::ConsumerIndex)),
         producer_index_(

--- a/csrc/device_lower/id_model_options.h
+++ b/csrc/device_lower/id_model_options.h
@@ -16,7 +16,7 @@ namespace nvfuser {
 class IdModelOptions {
  public:
   IdModelOptions()
-      : build_id_model_(isOptionDisabled(DisableOption::IdModel)),
+      : build_id_model_(!isOptionDisabled(DisableOption::IdModel)),
         consumer_index_(
             isIdModelOptionEnabled(IdModelEnableOption::ConsumerIndex)),
         producer_index_(

--- a/csrc/device_lower/id_model_options.h
+++ b/csrc/device_lower/id_model_options.h
@@ -16,7 +16,7 @@ namespace nvfuser {
 class IdModelOptions {
  public:
   IdModelOptions()
-      : build_id_model_(isOptionEnabled(EnableOption::IdModel)),
+      : build_id_model_(isOptionDisabled(EnableOption::IdModel)),
         consumer_index_(
             isIdModelOptionEnabled(IdModelEnableOption::ConsumerIndex)),
         producer_index_(
@@ -108,16 +108,23 @@ class IdModelOptions {
 
  private:
   void ensureConsistency() {
-    // TensorIndexer is required if these options are enabled
-    build_tensor_indexer_ = build_tensor_indexer_ || consumer_index_ ||
-        producer_index_ || inline_predicate_ || unswitch_predicate_ || loop_;
-    // Similarly, IdModel needs to be built if TensorIndexer is used
-    build_id_model_ = build_id_model_ || build_tensor_indexer_;
+    if (!build_id_model_) {
+      build_tensor_indexer_ = false;
+      consumer_index_ = false;
+      producer_index_ = false;
+      inline_predicate_ = false;
+      unswitch_predicate_ = false;
+      loop_ = false;
+    } else {
+      // TensorIndexer is required if these options are enabled
+      build_tensor_indexer_ = build_tensor_indexer_ || consumer_index_ ||
+          producer_index_ || inline_predicate_ || unswitch_predicate_ || loop_;
+    }
   }
 
  private:
   // Build IdModel
-  bool build_id_model_ = false;
+  bool build_id_model_ = true;
   // Build TensorIndexer
   bool build_tensor_indexer_ = false;
   // Globally enables consumer indexing.

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -487,12 +487,9 @@ void GpuLower::analysis(Fusion* fusion) {
   // information.
   compute_at_map_ = std::make_shared<ComputeAtMap>(fusion_);
 
-  // Transitory testing of IdModel if enabled. No existing
-  // functionality should be affected. New IterDomains may be created,
-  // so it is expected that generated code may use diffrent variable
-  // names
+  // New IterDomains may be created, so it is expected that generated
+  // code may use diffrent variable names
   if (idModelOptions().buildIdModel()) {
-    // Enable validation in the DEBUG build mode
     id_model_ = std::make_unique<IdModel>(
         fusion_,
         /*build_graphs=*/true,

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -491,15 +491,12 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  if (idModelOptions().buildIdModel()) {
-    // Enable validation in the DEBUG build mode
-    id_model_ = std::make_unique<IdModel>(
-        fusion_,
-        /*build_graphs=*/true,
-        /*allow_self_mapping=*/false,
-        /*validate=*/false);
-    id_model_->validateAndPropagatePType();
-  }
+  id_model_ = std::make_unique<IdModel>(
+      fusion_,
+      /*build_graphs=*/true,
+      /*allow_self_mapping=*/false,
+      /*validate=*/false);
+  id_model_->validateAndPropagatePType();
 
   resolveComputeWith(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "resolveComputeWith");

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -491,12 +491,15 @@ void GpuLower::analysis(Fusion* fusion) {
   // functionality should be affected. New IterDomains may be created,
   // so it is expected that generated code may use diffrent variable
   // names
-  id_model_ = std::make_unique<IdModel>(
-      fusion_,
-      /*build_graphs=*/true,
-      /*allow_self_mapping=*/false,
-      /*validate=*/false);
-  id_model_->validateAndPropagatePType();
+  if (idModelOptions().buildIdModel()) {
+    // Enable validation in the DEBUG build mode
+    id_model_ = std::make_unique<IdModel>(
+        fusion_,
+        /*build_graphs=*/true,
+        /*allow_self_mapping=*/false,
+        /*validate=*/false);
+    id_model_->validateAndPropagatePType();
+  }
 
   resolveComputeWith(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "resolveComputeWith");

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -753,7 +753,6 @@ class VectorizeValidator : public OptInDispatch {
     // Validate producer
     if (GpuLower::current()->hasIdModel()) {
       // No need to do replayPasC when using IdModel
-      NVF_ERROR(tv_def->input(0) == producer_tv);
       vectorized_set_info.vectorized_producer_alloc_id =
           getAndValidateVectorizedIdInAllocationDomain(
               v_id, producer_tv, "producer", tv_def);

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -197,6 +197,7 @@ const std::unordered_map<std::string, DisableOption>& getDisableOptions() {
           {"fma", DisableOption::Fma},
           {"grouped_grid_welford_outer_opt",
            DisableOption::GroupedGridWelfordOuterOpt},
+          {"id_model", DisableOption::IdModel},
           {"index_hoist", DisableOption::IndexHoist},
           {"magic_zero", DisableOption::MagicZero},
           {"matmul_expr_eval", DisableOption::MatmulExprEval},

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -123,6 +123,7 @@ enum class DisableOption {
   Fma, //! Disable FMA instructions
   GroupedGridWelfordOuterOpt, //! Disable use of outer-optimized
                               //! grouped grid welford kernel
+  IdModel, //! Disable IdModel
   IndexHoist, //! Disable index hoisting
   MagicZero, //! Disable nvfuser_zero
   MatmulExprEval, //! Disable ATen evaluation for the entire fusion containing


### PR DESCRIPTION
Changed to build an IdModel at the beginning of lowering by default. Also added a Disable option to disable it just in case.

## Host benchmark change

These results are all collected on my workstation. The "steady" and "dynamic" results can be ignored as they shouldn't be impacted by this change. Not quite stable, but we can say that generally, as expected, there's some latency increase. For example, in the case of the adaptive layernorm, it increased to 258,445.3081 from 247,156.3010. Not too concerning, I would say.

### test_adaptive_layernorm_fwd_benchmark
Before
```
---------------------------------------------------------------------------------------------------------------------- benchmark: 3 tests ----------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                             Min                     Max                    Mean              StdDev                  Median                 IQR            Outliers          OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='steady']           55.9650 (1.0)           64.7630 (1.0)           58.3861 (1.0)        2.7513 (1.0)           57.5385 (1.0)        2.1740 (1.0)           2;1  17,127.3642 (1.0)          10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='dynamic']         265.0790 (4.74)         344.6400 (5.32)         287.0931 (4.92)      29.8400 (10.85)        273.1250 (4.75)      25.2780 (11.63)         2;2   3,483.1906 (0.20)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='compile']     246,636.5760 (>1000.0)  248,338.8650 (>1000.0)  247,156.3010 (>1000.0)  475.2600 (172.74)   247,077.9530 (>1000.0)  406.1150 (186.81)        2;1       4.0460 (0.00)         10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After
```
---------------------------------------------------------------------------------------------------------------------- benchmark: 3 tests ----------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                             Min                     Max                    Mean              StdDev                  Median                 IQR            Outliers          OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='steady']           55.1640 (1.0)           62.5580 (1.0)           57.6277 (1.0)        2.7121 (1.0)           56.4765 (1.0)        2.3150 (1.0)           2;2  17,352.7661 (1.0)          10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='dynamic']         264.9290 (4.80)         333.2190 (5.33)         282.2630 (4.90)      25.8932 (9.55)         269.9940 (4.78)      11.4020 (4.93)          2;2   3,542.7952 (0.20)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='compile']     258,101.2530 (>1000.0)  259,468.3500 (>1000.0)  258,445.3081 (>1000.0)  414.7814 (152.94)   258,336.7120 (>1000.0)  452.9860 (195.67)        1;1       3.8693 (0.00)         10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### test_pointwise_ops_benchmark
Before
```
----------------------------------------------------------------------------------------------------------------------- benchmark: 12 tests ------------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                                 Min                     Max                    Mean              StdDev                  Median                 IQR            Outliers          OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=2]            31.9400 (1.0)           39.4440 (1.05)          33.6323 (1.0)        2.3660 (1.12)          32.7870 (1.00)       1.8140 (1.28)          1;1  29,733.3218 (1.0)          10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=8]            32.1410 (1.01)          37.7310 (1.0)           33.7538 (1.00)       2.1192 (1.0)           32.9125 (1.01)       1.4130 (1.0)           2;2  29,626.2939 (1.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=16]           32.1900 (1.01)          42.2100 (1.12)          34.6562 (1.03)       3.3260 (1.57)          33.3825 (1.02)       2.6350 (1.86)          2;1  28,854.8658 (0.97)         10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=4]            32.2910 (1.01)          40.3260 (1.07)          33.7265 (1.00)       2.4587 (1.16)          32.6410 (1.0)        1.6140 (1.14)          1;1  29,650.2750 (1.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=2]           99.9080 (3.13)         130.4560 (3.46)         110.5566 (3.29)      12.4059 (5.85)         104.6175 (3.21)      25.5780 (18.10)         3;0   9,045.1407 (0.30)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=4]          105.4590 (3.30)         139.9740 (3.71)         117.9203 (3.51)      14.1303 (6.67)         112.0265 (3.43)      29.0350 (20.55)         3;0   8,480.3041 (0.29)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=8]          119.7260 (3.75)         169.9310 (4.50)         137.5424 (4.09)      21.1644 (9.99)         126.8290 (3.89)      42.4900 (30.07)         3;0   7,270.4853 (0.24)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=16]         144.5630 (4.53)         217.2990 (5.76)         170.7840 (5.08)      30.8645 (14.56)        155.7235 (4.77)      61.7460 (43.70)         3;0   5,855.3494 (0.20)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=2]       91,031.6720 (>1000.0)   92,067.2850 (>1000.0)   91,277.9149 (>1000.0)  301.7341 (142.38)    91,191.5785 (>1000.0)  155.8540 (110.30)        1;1      10.9556 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=4]      126,104.9600 (>1000.0)  126,880.7620 (>1000.0)  126,488.5463 (>1000.0)  249.5668 (117.76)   126,516.2845 (>1000.0)  374.3460 (264.93)        3;0       7.9059 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=8]      199,176.8660 (>1000.0)  200,028.3500 (>1000.0)  199,606.4285 (>1000.0)  246.8421 (116.48)   199,600.4895 (>1000.0)  234.2210 (165.76)        3;0       5.0099 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=16]     377,038.8300 (>1000.0)  378,995.8800 (>1000.0)  378,404.2305 (>1000.0)  587.9176 (277.42)   378,516.9065 (>1000.0)  642.0700 (454.40)        2;1       2.6427 (0.00)         10           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After
```
------------------------------------------------------------------------------------------------------------------------ benchmark: 12 tests -------------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                                 Min                     Max                    Mean              StdDev                  Median                   IQR            Outliers          OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=8]            31.5590 (1.0)           37.7010 (1.0)           32.9540 (1.0)        1.8086 (1.08)          32.3960 (1.01)         1.1630 (1.47)          1;1  30,345.3299 (1.0)          10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=2]            31.5800 (1.00)          37.9220 (1.01)          33.1165 (1.00)       1.9586 (1.17)          32.2105 (1.0)          1.7330 (2.19)          1;1  30,196.4278 (1.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=4]            31.7400 (1.01)          37.9920 (1.01)          33.5684 (1.02)       1.6704 (1.0)           32.9925 (1.02)         0.7920 (1.0)           2;1  29,789.9215 (0.98)         10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=16]           32.5320 (1.03)          38.5930 (1.02)          33.9490 (1.03)       1.7263 (1.03)          33.6985 (1.05)         1.2120 (1.53)          1;1  29,455.9486 (0.97)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=2]           98.5160 (3.12)         129.0430 (3.42)         110.3531 (3.35)      11.8664 (7.10)         103.9560 (3.23)        23.5840 (29.78)         3;0   9,061.8206 (0.30)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=4]          104.5070 (3.31)         136.0160 (3.61)         116.3854 (3.53)      13.1650 (7.88)         109.1960 (3.39)        27.0400 (34.14)         3;0   8,592.1430 (0.28)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=8]          121.1980 (3.84)         165.1110 (4.38)         136.5435 (4.14)      18.7749 (11.24)        127.0895 (3.95)        40.3560 (50.95)         3;0   7,323.6734 (0.24)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=16]         146.7860 (4.65)         219.7540 (5.83)         171.4670 (5.20)      28.8541 (17.27)        157.4215 (4.89)        55.8360 (70.50)         3;0   5,832.0260 (0.19)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=2]       92,224.5300 (>1000.0)   93,291.3600 (>1000.0)   92,533.1968 (>1000.0)  311.2985 (186.36)    92,468.3195 (>1000.0)    145.2550 (183.40)        1;2      10.8069 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=4]      127,693.1110 (>1000.0)  128,292.9420 (>1000.0)  128,043.4041 (>1000.0)  199.6172 (119.50)   128,045.4050 (>1000.0)    298.5430 (376.95)        4;0       7.8099 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=8]      202,026.4840 (>1000.0)  203,176.7130 (>1000.0)  202,621.8437 (>1000.0)  381.7398 (228.53)   202,611.1060 (>1000.0)    711.9940 (898.98)        5;0       4.9353 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=16]     383,402.3910 (>1000.0)  385,281.6840 (>1000.0)  384,451.0937 (>1000.0)  641.0583 (383.78)   384,677.9850 (>1000.0)  1,083.3800 (>1000.0)       4;0       2.6011 (0.00)         10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### test_many_segment_benchmark[

Before
```
------------------------------------------------------------------------------------------------------------------- benchmark: 3 tests -------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                   Min                     Max                    Mean                StdDev                  Median                    IQR            Outliers         OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_many_segment_benchmark[host_bench_mode='steady']          323.4600 (1.0)          798.1540 (1.0)          603.2347 (1.0)        186.9736 (1.0)          668.6350 (1.0)         282.3320 (2.44)          3;0  1,657.7296 (1.0)          10           1
test_many_segment_benchmark[host_bench_mode='dynamic']         876.7620 (2.71)       2,075.9520 (2.60)       1,079.8419 (1.79)       366.0222 (1.96)         948.7025 (1.42)        115.5270 (1.0)           1;2    926.0615 (0.56)         10           1
test_many_segment_benchmark[host_bench_mode='compile']     310,145.6190 (958.84)   332,383.5060 (416.44)   321,468.7426 (532.91)   7,850.4585 (41.99)    320,625.0930 (479.52)   11,921.6760 (103.19)        4;0      3.1107 (0.00)         10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


```

After
```
------------------------------------------------------------------------------------------------------------------- benchmark: 3 tests ------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                   Min                     Max                    Mean                StdDev                  Median                   IQR            Outliers         OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_many_segment_benchmark[host_bench_mode='steady']          310.6860 (1.0)          793.5150 (1.0)          593.1617 (1.0)        223.2072 (4.28)         746.6520 (1.0)        432.6640 (4.58)          4;0  1,685.8809 (1.0)          10           1
test_many_segment_benchmark[host_bench_mode='dynamic']         904.3950 (2.91)       1,023.2780 (1.29)         952.9839 (1.61)        52.1730 (1.0)          923.7960 (1.24)        94.5270 (1.0)           2;0  1,049.3357 (0.62)         10           1
test_many_segment_benchmark[host_bench_mode='compile']     315,615.9010 (>1000.0)  328,699.6750 (414.23)   322,277.9189 (543.32)   4,192.6686 (80.36)    322,830.1745 (432.37)   4,944.1970 (52.30)         4;0      3.1029 (0.00)         10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


```