### PR TITLE
Make NVFUSER_MULTIDEVICE_WAIT_DEBUGGER_AT_RANK an EnableOption.

### DIFF
--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -165,6 +165,7 @@ const std::unordered_map<std::string, EnableOption>& getEnableOptions() {
           {"reuse_zeroed_memory", EnableOption::ReuseZeroedMemory},
           {"resize_scheduler", EnableOption::ResizeScheduler},
           {"static_fusion_count", EnableOption::StaticFusionCount},
+          {"wait_debugger", EnableOption::WaitDebugger},
           {"warn_register_spill", EnableOption::WarnRegisterSpill},
       };
   return available_options;

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -106,6 +106,8 @@ enum class EnableOption {
   ReuseZeroedMemory, //! Re-use zeroed memory used for grid synchronization
   ResizeScheduler, //! Enable the resize scheduler
   StaticFusionCount, //! Enable using single static count in kernel name
+  WaitDebugger, // Used for debugging multi-GPU. The rank given in the argument
+                // will wait for `gdb attach` at the start.
   WarnRegisterSpill, //! Enable warnings of register spill
   EndOfOption //! Placeholder for counting the number of elements
 };


### PR DESCRIPTION
Using NVFUSER_ENABLE naturally comes with a type check. If the user mistyped wait_debugger, nvFuser will detect  that instead of ignore the option. 

Also, this naturally supports debugging multiple ranks with comma-separated arguments. For example,
```
mpirun -np 2 -x NVFUSER_ENABLE='wait_debugger(0,1)' bin/test_multidevice --gtest_filter=*ReduceScatter
```