### PR TITLE
remove multiReductionInliner

### DIFF
--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -15,6 +15,7 @@
 #include <scheduler/reduction_utils.h>
 #include <scheduler/registry_utils.h>
 #include <scheduler/runtime_info.h>
+#include <scheduler/tools/inlining.h>
 #include <scheduler/utils.h>
 #include <scheduler/vectorize_helper.h>
 
@@ -1594,15 +1595,16 @@ void scheduleReduction(Fusion* fusion, const ReductionParams* rparams) {
   scheduler_utils::moveNonConcretizedBroadcastInnermost(fusion, {reference_tv});
 
   // Propagate transformations before we rfactor the other reductions
-  auto reduction_tv = reduction_tvs.at(0);
-  propagateTransformation(reference_tv);
+  reduction_scheduler_utils::propagateTransformation(reference_tv);
   // If reduction_tv is rfactored, rfactor all reductions.
   if (reference_tv != reduction_tv) {
-    propagateRFactor(reference_tv, reduction_tv, reduction_tvs);
+    reduction_scheduler_utils::propagateRFactor(
+        reference_tv, reduction_tv, reduction_tvs);
   }
 
-  const auto& unroll_vectorizable_cached_tvs = getCachedTvsToUnrollOrVectorize(
-      reference_tv, is_vectorize, cached_inputs, cached_outputs);
+  const auto& unroll_vectorizable_cached_tvs =
+      reduction_scheduler_utils::getCachedTvsToUnrollOrVectorize(
+          reference_tv, is_vectorize, cached_inputs, cached_outputs);
 
   reduction_scheduler_utils::propagateParallelization(
       reduction_tv,

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -1576,7 +1576,7 @@ void scheduleReduction(Fusion* fusion, const ReductionParams* rparams) {
   NVF_ERROR(
       reference_tv != nullptr && reduction_tv != nullptr,
       "Need these two tensor views to finish the scheduling.");
-  const bool vectorize =
+  const bool is_vectorize =
       rparams->vectorize_inner_reduction || rparams->vectorize_iter_dom;
 
   // allow iter domain grouped reduction for block and grid outer reductions.
@@ -1593,17 +1593,27 @@ void scheduleReduction(Fusion* fusion, const ReductionParams* rparams) {
 
   scheduler_utils::moveNonConcretizedBroadcastInnermost(fusion, {reference_tv});
 
-  reduction_scheduler_utils::multiReductionInliner(
-      fusion,
+  // Propagate transformations before we rfactor the other reductions
+  auto reduction_tv = reduction_tvs.at(0);
+  propagateTransformation(reference_tv);
+  // If reduction_tv is rfactored, rfactor all reductions.
+  if (reference_tv != reduction_tv) {
+    propagateRFactor(reference_tv, reduction_tv, reduction_tvs);
+  }
+
+  const auto& unroll_vectorizable_cached_tvs = getCachedTvsToUnrollOrVectorize(
+      reference_tv, is_vectorize, cached_inputs, cached_outputs);
+
+  reduction_scheduler_utils::propagateParallelization(
       reduction_tv,
       reference_tv,
       unroll,
-      vectorize,
       use_iter_grouped_reduction,
-      rparams->unroll_factor_inner_reduction,
       reduction_tvs,
-      cached_inputs,
-      cached_outputs);
+      unroll_vectorizable_cached_tvs);
+
+  // Inline the schedule
+  inlineMost();
 
   scheduler_utils::promoteProducerMemoryTypes(fusion, cached_inputs);
 

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -344,52 +344,6 @@ std::vector<int64_t> addBackBroadcasts(
   return axes;
 }
 
-void multiReductionInliner(
-    Fusion* fusion,
-    TensorView* reduction_tv,
-    TensorView* reference_tv,
-    const bool is_unroll_or_vectorization,
-    const bool vectorize,
-    const bool use_grouped_reduction,
-    const int64_t vectorizatoin_factor,
-    std::vector<TensorView*> reduction_tvs,
-    std::vector<TensorView*> cached_inputs,
-    std::vector<std::pair<TensorView*, TensorView*>> cached_outputs,
-    std::vector<TensorView*> smem_consumers,
-    std::vector<TensorView*> dummy_outputs) {
-  // Propagate transformations before we rfactor the other reductions
-  propagateTransformation(reference_tv);
-  // If reduction_tv is rfactored, rfactor all reductions.
-  if (reference_tv != reduction_tv) {
-    propagateRFactor(reference_tv, reduction_tv, reduction_tvs);
-  }
-
-  const auto& unroll_vectorizable_cached_tvs = getCachedTvsToUnrollOrVectorize(
-      reference_tv, vectorize, cached_inputs, cached_outputs);
-  reduction_scheduler_utils::propagateParallelization(
-      reduction_tv,
-      reference_tv,
-      is_unroll_or_vectorization,
-      use_grouped_reduction,
-      reduction_tvs,
-      unroll_vectorizable_cached_tvs);
-
-  // Needs special handling of vectorized loading from shared memory due to
-  // potential different data types of inputs and shared memory tensor.
-  if (vectorize) {
-    reduction_scheduler_utils::sharedMemoryConsumerVectorization(
-        smem_consumers, vectorizatoin_factor);
-  }
-
-  // Remove dummy outputs as they can inadvertently affect CA positions
-  for (auto output : dummy_outputs) {
-    fusion->removeOutput(output);
-  }
-
-  // Inline the schedule
-  inlineMost();
-}
-
 void propagateTransformation(
     TensorView* reference_tv,
     const std::unordered_set<TensorView*>& boundaryNodesSet) {

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -13,7 +13,6 @@
 #include <scheduler/reduction_utils.h>
 #include <scheduler/registry.h>
 #include <scheduler/runtime_info.h>
-#include <scheduler/tools/inlining.h>
 #include <scheduler/tools/maxinfo_propagator.h>
 #include <scheduler/utils.h>
 #include <transform_replay.h>

--- a/csrc/scheduler/reduction_utils.h
+++ b/csrc/scheduler/reduction_utils.h
@@ -27,21 +27,6 @@ TensorView* scheduleReductionTV(
     TensorView* reduction_tv,
     bool has_iter_axis);
 
-// Inlining function intended for single or multi reduction fusions.
-void multiReductionInliner(
-    Fusion* fusion,
-    TensorView* reduction_tv,
-    TensorView* reference_tv,
-    const bool unroll,
-    const bool vectorize,
-    const bool use_grouped_reduction,
-    const int64_t vectorizatoin_factor,
-    std::vector<TensorView*> reduction_tvs,
-    std::vector<TensorView*> cached_inputs,
-    std::vector<std::pair<TensorView*, TensorView*>> cached_outputs,
-    std::vector<TensorView*> smem_persistent_buffer_consumers = {},
-    std::vector<TensorView*> dummy_outputs = {});
-
 // Propagate transformations with internal cutoff boundary at boundaryNodesSet
 // in P2C forward propagate, disable propagation to TensorView in
 // boundaryNodesSet in C2P backward propagate, disable propagation from


### PR DESCRIPTION
**What?**
Code clean up, removes `multiReductionInliner()`
**why?**
This function was used in reduction scheduler and inner persistent scheduler, however, the usage are different and it takes many paras to differentiate the different usages.
This PR removes `multiReductionInliner()` and adds inlined function calls in  reduction scheduler and inner persistent scheduler, separately. This change makes further extension of inner persistent scheudler to use TMA easier.