### PR TITLE
remove redundant cast in a test

### DIFF
--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -1479,15 +1479,11 @@ TEST_P(LayerNormSharedMemoryTest, FusionLayerNormSharedMemoryBuffer_CUDA) {
   fusion.addInput(input);
   fusion.addInput(weight);
   fusion.addInput(bias);
-  if (dtype == DataType::Half) {
-    input = castOp(DataType::Float, input);
-    weight = castOp(DataType::Float, weight);
-    bias = castOp(DataType::Float, bias);
-  }
+  input = maybeCastOp(DataType::Float, input);
+  weight = maybeCastOp(DataType::Float, weight);
+  bias = maybeCastOp(DataType::Float, bias);
   auto result = layer_norm(input, norm_shape, weight, bias, eps_ptr);
-  if (dtype == DataType::Half) {
-    result.output = castOp(DataType::Half, result.output);
-  }
+  result.output = maybeCastOp(dtype, result.output);
   fusion.addOutput(result.output);
   fusion.addOutput(result.mean);
   fusion.addOutput(result.invstd);

--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -20,7 +20,7 @@
 namespace nvfuser {
 
 using testing::Contains;
-using testing::ElementsAre;
+using testing::UnorderedElementsAre;
 using PersistentBufferTest = NVFuserTest;
 
 TEST_F(PersistentBufferTest, FusionPersistentBufferCalculation1_CUDA) {

--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -1541,7 +1541,7 @@ TEST_P(LayerNormSharedMemoryTest, FusionLayerNormSharedMemoryBuffer_CUDA) {
   if (has_enough_regs_smem) {
     EXPECT_THAT(
         runtime->fusionSegments()->groups(),
-        ElementsAre(HeuristicIs(SchedulerType::InnerPersistent)));
+        UnorderedElementsAre(HeuristicIs(SchedulerType::InnerPersistent)));
     Fusion* scheduled_fusion = runtime->executors()
                                    .back()
                                    ->as<KernelExecutor>()


### PR DESCRIPTION
I was wondering why there is an additional no op scheduler when the input data is `float32`. It turns out due to the redundant cast, we only need the cast when the input is `float16`.
This PR removes that cast for fp32.