### PR TITLE
extend circular buffer tests to test 1d TMA and fix index for 1dtma

### DIFF
--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -62,10 +62,12 @@ void MinimumDeviceVersion::handle(LoadStoreOp* ls_op) {
   if (ls_op->opType() == LoadStoreOpType::CpAsync) {
     ensureVersion(
         {8, 0}, "LoadStoreOpType::CpAsync requires Ampere (8.0) or newer");
-  } else if (ls_op->opType() == LoadStoreOpType::CpAsyncBulkTensorTile) {
+  } else if (
+      ls_op->opType() == LoadStoreOpType::CpAsyncBulkTensorTile ||
+      ls_op->opType() == LoadStoreOpType::CpAsyncBulk) {
     ensureVersion(
         {9, 0},
-        "LoadStoreOpType::CpAsyncBulkTensorTile requires Hopper (9.0) or newer");
+        "LoadStoreOpType::CpAsyncBulk{TensorTile} requires Hopper (9.0) or newer");
   }
 }
 

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -2145,11 +2145,14 @@ kir::TensorIndex* Index::getProducerIndex(
   bool is_producer_tma_op = producer->definition() != nullptr &&
       producer->definition()->isA<LoadStoreOp>() &&
       ir_utils::isCpAsyncBulkLoad(producer->definition());
+  bool is_consumer_tma_op = consumer->definition() != nullptr &&
+      consumer->definition()->isA<LoadStoreOp>() &&
+      ir_utils::isCpAsyncBulkLoad(consumer->definition());
 
   if (!ir_utils::hasRootToLoopLinearTransformations(producer) ||
       (consumer->definition()->isA<MmaOp>() &&
        isHopper(consumer->definition()->as<MmaOp>()->macro())) ||
-      is_producer_tma_op ||
+      is_producer_tma_op || is_consumer_tma_op ||
       GpuLower::current()->idModelOptions().producerIndex()) {
     index = GpuLower::current()->tensorIndexer().getLinearIndex(
         producer, consumer->definition(), loops);

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -2144,8 +2144,7 @@ kir::TensorIndex* Index::getProducerIndex(
   Val* index = nullptr;
   bool is_producer_tma_op = producer->definition() != nullptr &&
       producer->definition()->isA<LoadStoreOp>() &&
-      producer->definition()->as<LoadStoreOp>()->opType() ==
-          LoadStoreOpType::CpAsyncBulkTensorTile;
+      ir_utils::isCpAsyncBulkLoad(producer->definition());
 
   if (!ir_utils::hasRootToLoopLinearTransformations(producer) ||
       (consumer->definition()->isA<MmaOp>() &&
@@ -2675,15 +2674,55 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
   expected_bytes =
       GpuLower::current()->commonScalarMap().hoistScalar(expected_bytes, loops);
   Val* index = nullptr;
+  ValGroups groups_to_index = tma_info.getTMADomain();
+  // TensorIndexer needs IterDomain instead of ValGroup to work around
+  // the resize indexing issue
+  std::vector<IterDomain*> ids_to_index;
+  ids_to_index.reserve(groups_to_index.size());
+  const auto tma_all_ids = is_load ? consumer_tv->domain()->allIDs()
+                                   : producer_tv->domain()->allIDs();
+  for (const auto& group : groups_to_index) {
+    auto it = std::find_if(
+        tma_all_ids.begin(), tma_all_ids.end(), [&](IterDomain* gmem_id) {
+          return group->has(gmem_id);
+        });
+    if (it != tma_all_ids.end()) {
+      ids_to_index.push_back(*it);
+    } else {
+      ids_to_index.push_back(group->front()->as<IterDomain>());
+    }
+  }
+
+  const TensorIndexer& indexer = GpuLower::current()->tensorIndexer();
+  auto indices_inner_to_outer =
+      indexer.getIndexFor(ldst, !is_load, ids_to_index, loops);
+
+  // convert indices to linear index, note that the order of indices is inner
+  // to outer while the order of the logical domain is outer to inner.
+  auto linear_index = [&consumer_tv, &indices_inner_to_outer]() {
+    Val* stride = consumer_tv->fusion()->oneVal();
+    int64_t dim = (int64_t)consumer_tv->getLogicalDomain().size();
+    for (int64_t i = 0; i < dim; i++) {
+      auto per_dim_index = indices_inner_to_outer.at(i);
+      auto logical_id = consumer_tv->getLogicalDomain().at(dim - 1 - i);
+      auto per_dim_strided_index =
+          SimplifyingIrBuilder::mulExpr(per_dim_index, stride);
+      indices_inner_to_outer.at(i) = per_dim_strided_index;
+      stride = SimplifyingIrBuilder::mulExpr(stride, logical_id->extent());
+    }
+    return sumVals(indices_inner_to_outer);
+  };
 
   // 1D TMA without tensor map
   if (ldst->opType() == LoadStoreOpType::CpAsyncBulk) {
-    NVF_ERROR(dim == 1L, "1D TMA but got more than one indices.")
+    // NVF_ERROR(dim == 1L, "1D TMA but got more than one indices.")
     if (is_load) {
       std::stringstream ss;
       ss << "Hopper::CpAsyncBulkG2SIndex";
-      auto gmem_address = getProducerIndex(
-          producer_tv, consumer_tv, loops, rotated_loops, {}, true);
+
+      auto gmem_address = SimplifyingIrBuilder::addExpr(
+          IrBuilder::baseAddressExpr(producer_tv), linear_index());
+
       index = IrBuilder::structExpr(
           {{"raw_gmem_addr", gmem_address},
            {"bytes", expected_bytes},
@@ -2694,29 +2733,6 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
     }
   } else {
     // ND TMA with tensor map
-    ValGroups groups_to_index = tma_info.getTMADomain();
-    // TensorIndexer needs IterDomain instead of ValGroup to work around
-    // the resize indexing issue
-    std::vector<IterDomain*> ids_to_index;
-    ids_to_index.reserve(groups_to_index.size());
-    const auto tma_all_ids = is_load ? consumer_tv->domain()->allIDs()
-                                     : producer_tv->domain()->allIDs();
-    for (const auto& group : groups_to_index) {
-      auto it = std::find_if(
-          tma_all_ids.begin(), tma_all_ids.end(), [&](IterDomain* gmem_id) {
-            return group->has(gmem_id);
-          });
-      if (it != tma_all_ids.end()) {
-        ids_to_index.push_back(*it);
-      } else {
-        ids_to_index.push_back(group->front()->as<IterDomain>());
-      }
-    }
-
-    const TensorIndexer& indexer = GpuLower::current()->tensorIndexer();
-    auto indices_inner_to_outer =
-        indexer.getIndexFor(ldst, !is_load, ids_to_index, loops);
-
     auto coordinate = IrBuilder::arrayExpr(indices_inner_to_outer);
     auto descriptor = tma_info.tensorMap();
     if (is_load) {

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -2091,6 +2091,7 @@ auto tmaCircularBufferingParams() {
                 n,
                 all_types[lcg_parkmiller % all_types.size()],
                 tma_load_type);
+            lcg_parkmiller = (uint64_t)lcg_parkmiller * 48271 % 0x7fffffff;
           }
         }
       }

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -977,8 +977,13 @@ INSTANTIATE_TEST_SUITE_P(
     StagesAndPrefetches(),
     nonTMAName);
 
-using TmaCircularBufferingParams =
-    std::tuple<int64_t, int64_t, int64_t, int64_t, CircularBufferType, LoadStoreOpType>;
+using TmaCircularBufferingParams = std::tuple<
+    int64_t,
+    int64_t,
+    int64_t,
+    int64_t,
+    CircularBufferType,
+    LoadStoreOpType>;
 
 class TmaCircularBufferingTest
     : public NVFuserFixtureParamTest<TmaCircularBufferingParams> {
@@ -1705,8 +1710,7 @@ TEST_P(TmaCircularBufferingTest, Persistent) {
   fusion->addOutput(x_norm);
 
   // Load input from global to shared memory
-  TensorView* x_cache_smem =
-      x->cacheAfter(tma_load_type);
+  TensorView* x_cache_smem = x->cacheAfter(tma_load_type);
   x_cache_smem->setMemoryType(MemoryType::Shared);
 
   // Load input from shared memory to registers
@@ -2078,9 +2082,19 @@ auto tmaCircularBufferingParams() {
       for (int64_t m : {128, 500, 1024}) {
         for (int64_t n : {128, 1024}) {
           values.emplace_back(
-              i, j, m, n, all_types[lcg_parkmiller % all_types.size()], LoadStoreOpType::CpAsyncBulk);
+              i,
+              j,
+              m,
+              n,
+              all_types[lcg_parkmiller % all_types.size()],
+              LoadStoreOpType::CpAsyncBulk);
           values.emplace_back(
-              i, j, m, n, all_types[lcg_parkmiller % all_types.size()], LoadStoreOpType::CpAsyncBulkTensorTile);              
+              i,
+              j,
+              m,
+              n,
+              all_types[lcg_parkmiller % all_types.size()],
+              LoadStoreOpType::CpAsyncBulkTensorTile);
           lcg_parkmiller = (uint64_t)lcg_parkmiller * 48271 % 0x7fffffff;
         }
       }
@@ -2103,8 +2117,7 @@ std::string tmaName(
      << prefetch_distance_str << "_M_"
      << std::to_string(std::get<2>(info.param)) << "_N_"
      << std::to_string(std::get<3>(info.param)) << "_"
-     << std::get<4>(info.param) << "_"
-     << std::get<5>(info.param);
+     << std::get<4>(info.param) << "_" << std::get<5>(info.param);
   return ss.str();
 }
 


### PR DESCRIPTION
**Two changes in this PR:**
(1) circular buffer tests are extended to test both `LoadStoreOpType::CpAsyncBulkTensorTile` and `LoadStoreOpType::CpAsyncBulk`
(2) use IdModel indexing for 1D TMA, avoid offset bug when using warp specilization with prefetch