### PR TITLE
Enable register sharing by default in matmul scheduler for better performance.

### DIFF
--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -734,7 +734,7 @@ void HopperMultipleMatmulScheduler::setUpCircularBuffering() {
             "There can be at most two compute warp groups for register ",
             "sharing with warp specialization");
         constexpr int64_t num_registers_load_warp = 40;
-        constexpr int64_t num_registers_compute_warp = 224;
+        constexpr int64_t num_registers_compute_warp = 232;
         cb_type = (CircularBufferType)WarpSpecialized(
             ParallelType::TIDy,
             std::make_pair(

--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -717,11 +717,30 @@ void HopperMultipleMatmulScheduler::setUpCircularBuffering() {
 
     CircularBufferType cb_type;
     switch (params_->circular_buffering_strategy) {
-      case MatmulParams::CircularBufferingStrategy::Pipelined:
+      case MatmulParams::CircularBufferingStrategy::Pipelined: {
         cb_type = (CircularBufferType)Pipelined(false);
         break;
-      case MatmulParams::CircularBufferingStrategy::WarpSpecialized:
-        cb_type = (CircularBufferType)WarpSpecialized(ParallelType::TIDy);
+      }
+      case MatmulParams::CircularBufferingStrategy::WarpSpecialized: {
+        NVF_ERROR(
+            std::all_of(
+                mma_results_.begin(),
+                mma_results_.end(),
+                [](TensorView* tv) {
+                  IterDomain* ws_axis = tv->axis(-7);
+                  return ws_axis->getParallelType() == ParallelType::TIDy &&
+                      ws_axis->extent()->evaluate().as<int64_t>() <= 2;
+                }),
+            "There can be at most two compute warp groups for register ",
+            "sharing with warp specialization");
+        constexpr int64_t num_registers_load_warp = 40;
+        constexpr int64_t num_registers_compute_warp = 224;
+        cb_type = (CircularBufferType)WarpSpecialized(
+            ParallelType::TIDy,
+            std::make_pair(
+                num_registers_load_warp, num_registers_compute_warp));
+        break;
+      }
     }
     for (TensorView* acw_smem : acw_smems_) {
       acw_smem->circularBuffer(


### PR DESCRIPTION
# Summary
This PR makes register sharing the default option for hopper matmul scheduler. For two warp groups, the load warp group gets 40 registers, while the compute warp group gets 232 registers. The hopper matmul scheduler enforces at most two warp groups are active in matmul fusion.

# Details 
Register sharing is a matmul optimization that transfers registers from load warp group to compute warp group. The load warp group uses a single thread to launch tma loads, so it doesn't need many registers. The compute warp groups run the matrix multiplication and epilogue computation, so they can hit the register limit.

```
ptxas info    : Overriding maximum register limit 256 for 
'_ZN72_GLOBAL__N__00000000_33___tmp_nvfuser_none_f0_c0_r0_g0_cu_2efd3c58_9746224nvfuser_none_f0_c0_r0_g0ENS_6TensorINS_8__bfloatELi2ELi2EEES2_NS_9TensorMapES3_S3_S2_' 
with  168 of maxrregcount option
```
* Ptxas warning generated by `NVFUSER_DUMP=ptxas_verbose ./build/test_matmul --gtest_filter='*MLPBenchmarkTest.FwdGEMM/data_parallel_warpspec*'`

The register settings for load and compute warp groups are taken from cutlass.
https://github.com/NVIDIA/cutlass/blob/main/include/cutlass/gemm/kernel/sm90_gemm_tma_warpspecialized_cooperative.hpp#L125-L127