### PR TITLE
Add WAR sync for wgmma expressions in compute warp 

### DIFF
--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -4506,9 +4506,7 @@ TEST_P(MLPBenchmarkTest, FwdHorizontalFusion) {
   // Relax tolerance for larger sum due to large K
   EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
   EXPECT_TRUE(cg_outputs[1].allclose(tv10_ref, 1e-6 * K, 1e-6 * K));
-  // TODO Incorrect results because of WAR hazard between aliased shared memory
-  // between tv3 and tv12
-  // EXPECT_TRUE(cg_outputs[2].allclose(tv12_ref, 1e-2, 1e-1));
+  EXPECT_TRUE(cg_outputs[2].allclose(tv12_ref, 5e-2, 1e-1));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -4324,9 +4324,13 @@ TEST_P(MLPBenchmarkTest, FwdGEMM) {
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
+  if (!test_params.warp_specialization) {
+    GTEST_SKIP()
+        << "Sync error with pipelined circular buffering causes incorrect results";
+  }
+
   // Relax tolerance for larger sum due to large K
-  // TODO Incorrect results because incorrect placement of wgmma syncs
-  // EXPECT_TRUE(cg_outputs[0].allclose(out_ref, 1e-6 * K, 1e-6 * K));
+  EXPECT_TRUE(cg_outputs[0].allclose(out_ref, 1e-6 * K, 1e-6 * K));
 }
 
 TEST_P(MLPBenchmarkTest, FwdEpilogueFusion) {
@@ -4402,10 +4406,14 @@ TEST_P(MLPBenchmarkTest, FwdEpilogueFusion) {
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
+  if (!test_params.warp_specialization) {
+    GTEST_SKIP()
+        << "Sync error with pipelined circular buffering causes incorrect results";
+  }
+
   // Relax tolerance for larger sum due to large K
-  // TODO Incorrect results because incorrect placement of wgmma syncs
-  // EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
-  // EXPECT_TRUE(cg_outputs[1].allclose(tv11_ref, 1e-2, 1e-2));
+  EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
+  EXPECT_TRUE(cg_outputs[1].allclose(tv11_ref, 1e-2, 1e-2));
 }
 
 TEST_P(MLPBenchmarkTest, FwdHorizontalFusion) {
@@ -4490,12 +4498,16 @@ TEST_P(MLPBenchmarkTest, FwdHorizontalFusion) {
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
-  // TODO Incorrect results because incorrect placement of wgmma syncs
+  if (!test_params.warp_specialization) {
+    GTEST_SKIP()
+        << "Sync error with pipelined circular buffering causes incorrect results";
+  }
+
+  // Relax tolerance for larger sum due to large K
+  EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
+  EXPECT_TRUE(cg_outputs[1].allclose(tv10_ref, 1e-6 * K, 1e-6 * K));
   // TODO Incorrect results because of WAR hazard between aliased shared memory
   // between tv3 and tv12
-  // Relax tolerance for larger sum due to large K
-  // EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
-  // EXPECT_TRUE(cg_outputs[1].allclose(tv10_ref, 1e-6 * K, 1e-6 * K));
   // EXPECT_TRUE(cg_outputs[2].allclose(tv12_ref, 1e-2, 1e-1));
 }
 


### PR DESCRIPTION
# Summary
This PR adds special logic to `WarAsyncWaitInserter` that handles warp specialized circular buffering. This logic inserts the missing `wgmma` WAR sync before `mbarrier::arrive` in `ComputeWarp` for-loop.

Fixes https://github.com/NVIDIA/Fuser/issues/3561

# Details
The for-loop for the k dimension in matmul expressions is circular buffered. TMA loads are launched to load mma operands into shared memory, which are consumed by mma expression. A WAR sync is necessary for the wgmma expession to avoid overwriting the circular buffer stage while it is being read.

Special logic is required for warp specialized circular buffering because the TMA loads and wgmma ops are separated by an `IfThenElse`. `kir::ExprMutator` traverses the fusion in depth-wise order, so TMA loads in the `LoadWarp` are detected before the wgmma expressions in the `ComputeWarp`.

The `handleComputeWarp` function inserts `wgmma.commit_group` and `wgmma.wait_group` expressions before the `mbarrier::arrive`, which allows load warp to launch next TMA load. First, we commit all the wgmma expressions issued in this iteration of the for-loop. Then, we wait for some number of wgmma expressions based on number of circular buffer stages and number of prefetch stages.

## Cuda Example
```cuda
  if ((((nvfuser_index_t)threadIdx.y) == 2)) {
    #pragma unroll 3
    for(nvfuser_index_t i24 = 0; i24 < i3; ++i24) {
      if ((Hopper::electSync(4294967295U) && b16)) {
        mbarrier::waitParity(...);
        mbarrier::arriveExpectTX(...);
        // TMA load operand A
        mbarrier::arriveExpectTX(...);
        // TMA load operand B
      }
    }
  } else {
    #pragma unroll
    for(nvfuser_index_t i26 = 0; i26 < 4; ++i26) {
      mbarrier::arrive(...);
    }
    #pragma unroll 3
    for(nvfuser_index_t i27 = 0; i27 < i3; ++i27) {
      mbarrier::waitParity(...);
      #pragma unroll
      for(nvfuser_index_t i31 = 0; i31 < 4; ++i31) {
          // wgmma.mma_async.sync.aligned.m64n256k16.f32.bf16.bf16 
      }
      // <<< NEW: Commit all wgmma expressions to group
      asm volatile("wgmma.commit_group.sync.aligned;\n");

      // <<< NEW: Wait for some wgmma expression to finish
      asm volatile("wgmma.wait_group.sync.aligned %0;\n"::"n"(0LL):"memory");  

      mbarrier::arrive(...);  // <<< Release LoadWarp
    }
  }
```