### PR TITLE
Fix WAR async issue with pipelined circular buffering

### DIFF
--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -1209,7 +1209,7 @@ class WarAsyncWaitInserter : private kir::ExprMutator {
 
         // Default position is last expression in for loop
         size_t num_exprs = for_loop->body().exprs().size();
-        int64_t pos = num_exprs - 1;
+        size_t pos = num_exprs - 1;
 
         // The sync qualifier in the `wgmma.wait_group` ptx instruction only
         // guarantees that a warp executes the instruction. The entire warp

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -4324,11 +4324,6 @@ TEST_P(MLPBenchmarkTest, FwdGEMM) {
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
-  if (!test_params.warp_specialization) {
-    GTEST_SKIP()
-        << "Sync error with pipelined circular buffering causes incorrect results";
-  }
-
   // Relax tolerance for larger sum due to large K
   EXPECT_TRUE(cg_outputs[0].allclose(out_ref, 1e-6 * K, 1e-6 * K));
 }
@@ -4405,11 +4400,6 @@ TEST_P(MLPBenchmarkTest, FwdEpilogueFusion) {
   auto cg_outputs = ke.run(inputs);
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
-
-  if (!test_params.warp_specialization) {
-    GTEST_SKIP()
-        << "Sync error with pipelined circular buffering causes incorrect results";
-  }
 
   // Relax tolerance for larger sum due to large K
   EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -4506,9 +4506,7 @@ TEST_P(MLPBenchmarkTest, FwdHorizontalFusion) {
   // Relax tolerance for larger sum due to large K
   EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
   EXPECT_TRUE(cg_outputs[1].allclose(tv10_ref, 1e-6 * K, 1e-6 * K));
-  // TODO Incorrect results because of WAR hazard between aliased shared memory
-  // between tv3 and tv12
-  // EXPECT_TRUE(cg_outputs[2].allclose(tv12_ref, 1e-2, 1e-1));
+  EXPECT_TRUE(cg_outputs[2].allclose(tv12_ref, 5e-2, 1e-1));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -4029,8 +4029,8 @@ TEST_F(HopperMatmulTest, HSH_NT_UseScheduler) {
   auto out_ref = at::matmul(a_ref.squeeze().t(), b_ref.squeeze()).to(at::kHalf);
 
   MatMulTileOptions gemm_tile;
-  gemm_tile.cta_tile = GemmTile(128, 256, 32);
-  gemm_tile.warp_tile = GemmTile(64, 256, 32);
+  gemm_tile.cta_tile = GemmTile(128, 256, 64);
+  gemm_tile.warp_tile = GemmTile(64, 256, 64);
 
   MatmulParams mparams;
   mparams.supported_vec_size = {8, 8, 8};
@@ -4086,8 +4086,8 @@ TEST_F(HopperMatmulTest, HSH_TN_UseScheduler) {
   auto out_ref = at::matmul(a_ref.squeeze(), b_ref.squeeze().t()).to(at::kHalf);
 
   MatMulTileOptions gemm_tile;
-  gemm_tile.cta_tile = GemmTile(128, 256, 32);
-  gemm_tile.warp_tile = GemmTile(64, 256, 32);
+  gemm_tile.cta_tile = GemmTile(128, 256, 64);
+  gemm_tile.warp_tile = GemmTile(64, 256, 64);
 
   MatmulParams mparams;
   mparams.supported_vec_size = {8, 8, 8};
@@ -4149,8 +4149,8 @@ TEST_F(HopperMatmulTest, HSH_NN_UseScheduler) {
       at::matmul(a_ref.squeeze().t(), b_ref.squeeze().t()).to(at::kHalf);
 
   MatMulTileOptions gemm_tile;
-  gemm_tile.cta_tile = GemmTile(128, 256, 32);
-  gemm_tile.warp_tile = GemmTile(64, 256, 32);
+  gemm_tile.cta_tile = GemmTile(128, 256, 64);
+  gemm_tile.warp_tile = GemmTile(64, 256, 64);
 
   MatmulParams mparams;
   mparams.supported_vec_size = {8, 8, 8};
@@ -4211,8 +4211,8 @@ TEST_F(HopperMatmulTest, HSH_TT_UseScheduler) {
   auto out_ref = at::matmul(a_ref.squeeze(), b_ref.squeeze()).to(at::kHalf);
 
   MatMulTileOptions gemm_tile;
-  gemm_tile.cta_tile = GemmTile(128, 256, 32);
-  gemm_tile.warp_tile = GemmTile(64, 256, 32);
+  gemm_tile.cta_tile = GemmTile(128, 256, 64);
+  gemm_tile.warp_tile = GemmTile(64, 256, 64);
 
   MatmulParams mparams;
   mparams.supported_vec_size = {8, 8, 8};
@@ -4324,11 +4324,6 @@ TEST_P(MLPBenchmarkTest, FwdGEMM) {
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
-  if (!test_params.warp_specialization) {
-    GTEST_SKIP()
-        << "Sync error with pipelined circular buffering causes incorrect results";
-  }
-
   // Relax tolerance for larger sum due to large K
   EXPECT_TRUE(cg_outputs[0].allclose(out_ref, 1e-6 * K, 1e-6 * K));
 }
@@ -4405,11 +4400,6 @@ TEST_P(MLPBenchmarkTest, FwdEpilogueFusion) {
   auto cg_outputs = ke.run(inputs);
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
-
-  if (!test_params.warp_specialization) {
-    GTEST_SKIP()
-        << "Sync error with pipelined circular buffering causes incorrect results";
-  }
 
   // Relax tolerance for larger sum due to large K
   EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
@@ -4497,11 +4487,6 @@ TEST_P(MLPBenchmarkTest, FwdHorizontalFusion) {
   auto cg_outputs = ke.run(inputs);
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
-
-  if (!test_params.warp_specialization) {
-    GTEST_SKIP()
-        << "Sync error with pipelined circular buffering causes incorrect results";
-  }
 
   // Relax tolerance for larger sum due to large K
   EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -4324,9 +4324,13 @@ TEST_P(MLPBenchmarkTest, FwdGEMM) {
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
+  if (!test_params.warp_specialization) {
+    GTEST_SKIP()
+        << "Sync error with pipelined circular buffering causes incorrect results";
+  }
+
   // Relax tolerance for larger sum due to large K
-  // TODO Incorrect results because incorrect placement of wgmma syncs
-  // EXPECT_TRUE(cg_outputs[0].allclose(out_ref, 1e-6 * K, 1e-6 * K));
+  EXPECT_TRUE(cg_outputs[0].allclose(out_ref, 1e-6 * K, 1e-6 * K));
 }
 
 TEST_P(MLPBenchmarkTest, FwdEpilogueFusion) {
@@ -4402,10 +4406,14 @@ TEST_P(MLPBenchmarkTest, FwdEpilogueFusion) {
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
+  if (!test_params.warp_specialization) {
+    GTEST_SKIP()
+        << "Sync error with pipelined circular buffering causes incorrect results";
+  }
+
   // Relax tolerance for larger sum due to large K
-  // TODO Incorrect results because incorrect placement of wgmma syncs
-  // EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
-  // EXPECT_TRUE(cg_outputs[1].allclose(tv11_ref, 1e-2, 1e-2));
+  EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
+  EXPECT_TRUE(cg_outputs[1].allclose(tv11_ref, 1e-2, 1e-2));
 }
 
 TEST_P(MLPBenchmarkTest, FwdHorizontalFusion) {
@@ -4490,12 +4498,16 @@ TEST_P(MLPBenchmarkTest, FwdHorizontalFusion) {
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
-  // TODO Incorrect results because incorrect placement of wgmma syncs
+  if (!test_params.warp_specialization) {
+    GTEST_SKIP()
+        << "Sync error with pipelined circular buffering causes incorrect results";
+  }
+
+  // Relax tolerance for larger sum due to large K
+  EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
+  EXPECT_TRUE(cg_outputs[1].allclose(tv10_ref, 1e-6 * K, 1e-6 * K));
   // TODO Incorrect results because of WAR hazard between aliased shared memory
   // between tv3 and tv12
-  // Relax tolerance for larger sum due to large K
-  // EXPECT_TRUE(cg_outputs[0].allclose(tv3_ref, 1e-6 * K, 1e-6 * K));
-  // EXPECT_TRUE(cg_outputs[1].allclose(tv10_ref, 1e-6 * K, 1e-6 * K));
   // EXPECT_TRUE(cg_outputs[2].allclose(tv12_ref, 1e-2, 1e-1));
 }
 


### PR DESCRIPTION
This PR is stacked on #3863. When CTA tile k dimension is 64, incorrect results occur with pipelined circular buffering. The fix is to insert the wgmma WAR sync expressions before `kir::BlockSync`.

## Why?
> The mandatory .sync qualifier indicates that wgmma.wait_group instruction causes the executing thread to wait until all threads in the warp execute the same wgmma.wait_group instruction before resuming execution.

The `wgmma.wait_group` ptx instruction only guarantees that a warp executes the instruction together. The entire warp group must complete `wgmma` instruction before loading next circular buffer stage.

## Cuda Kernel Changes
From failing example: `./build/test_matmul --gtest_filter='*MLPBenchmarkTest.FwdGEMM/data_parallel_non_warpspec*'`

## Incorrect results --- Main Loop with pipelined circular buffering
```cuda
  #pragma unroll 3
  for(nvfuser_index_t i20 = 0; i20 < i4; ++i20) {
    if (((Hopper::electSync(4294967295U) && b16) && b17)) {
      mbarrier::arriveExpectTX(...);
      Hopper::cpAsyncBulkTensorTileG2S(...);
      mbarrier::arriveExpectTX(toSmem(...);
      Hopper::cpAsyncBulkTensorTileG2S(...);
    }
    mbarrier::waitParity(toSmem((&T9[(i20 % 4)])), (uint32_t)(((i20 / 4) % 2)));
    #pragma unroll
    for(nvfuser_index_t i25 = 0; i25 < 4; ++i25) {
      nvfuser_index_t i26;
      i26 = 32 * i25;
      uint32_t i27;
      i27 = i23 + i26;
      uint32_t i28;
      i28 = i24 + i26;
      asm volatile("wgmma.fence.sync.aligned;\n");
      /// wgmma.mma_async.sync.aligned.m64n256k16.f32.bf16.bf16
    }
    __syncthreads();  // <<< blocksync BEFORE wgmma sync
    asm volatile("wgmma.commit_group.sync.aligned;\n");
    asm volatile("wgmma.wait_group.sync.aligned %0;\n"::"n"(0LL):"memory");
  }
```

## Correct results --- Main Loop with pipelined circular buffering
```cuda
  #pragma unroll 3
  for(nvfuser_index_t i20 = 0; i20 < i4; ++i20) {
    if (((Hopper::electSync(4294967295U) && b16) && b17)) {
      mbarrier::arriveExpectTX(...);
      Hopper::cpAsyncBulkTensorTileG2S(...);
      mbarrier::arriveExpectTX(toSmem(...);
      Hopper::cpAsyncBulkTensorTileG2S(...);
    }
    mbarrier::waitParity(toSmem((&T9[(i20 % 4)])), (uint32_t)(((i20 / 4) % 2)));
    #pragma unroll
    for(nvfuser_index_t i25 = 0; i25 < 4; ++i25) {
      nvfuser_index_t i26;
      i26 = 32 * i25;
      uint32_t i27;
      i27 = i23 + i26;
      uint32_t i28;
      i28 = i24 + i26;
      asm volatile("wgmma.fence.sync.aligned;\n");
      /// wgmma.mma_async.sync.aligned.m64n256k16.f32.bf16.bf16
    }
    asm volatile("wgmma.commit_group.sync.aligned;\n");
    asm volatile("wgmma.wait_group.sync.aligned %0;\n"::"n"(0LL):"memory");
    __syncthreads();  // <<< blocksync AFTER wgmma sync
  }
```