### PR TITLE
Use _enable_options in benchmarks/python/test_matmul.py

### DIFF
--- a/benchmarks/python/test_matmul.py
+++ b/benchmarks/python/test_matmul.py
@@ -93,9 +93,13 @@ def test_matmul_nvf_benchmark(
     with FusionDefinition() as fd:
         matmul_fusion(fd, [a, b])
 
+    kwargs = dict(
+        _enable_options=["fuse_matmul"], _disable_options=["matmul_expr_eval"]
+    )
+
     if not disable_validation:
         eager_output = torch.matmul(a, b)
-        fd.validate([a, b], [eager_output])
+        fd.validate([a, b], [eager_output], kwargs=kwargs)
 
     if not disable_benchmarking:
-        run_benchmark(benchmark, fd.execute, [a, b])
+        run_benchmark(benchmark, lambda *args: fd.execute(*args, **kwargs), [a, b])

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -568,7 +568,7 @@ class FusionDefinition(_C._FusionDefinition):
             inputs: A list of inputs expected by the fusion definition
             reference_outputs: A list of reference outputs to validate against
         """
-        fusion_outputs = self.execute(inputs)
+        fusion_outputs = self.execute(inputs, **kwargs)
         assert len(fusion_outputs) == len(
             reference_outputs
         ), f"Expected {len(fusion_outputs)} reference outputs for validation."


### PR DESCRIPTION
This small PR makes it so that python matmul benchmarks are run properly even when no `NVFUSER_ENABLE` or `NVFUSER_DISABLE` env var are set.