### PR TITLE
Do not build all ID graphs automatically

### DIFF
--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -866,33 +866,29 @@ void IdModel::buildAllGraphs() {
   buildLoopGraph();
 }
 
-void IdModel::buildGraph(IdMappingMode mode) {
+ValGraph& IdModel::buildGraph(IdMappingMode mode) {
   switch (mode) {
     case IdMappingMode::EXACT:
-      buildExactGraph();
-      break;
+      return buildExactGraph();
     case IdMappingMode::ALMOSTEXACT:
-      buildAlmostExactGraph();
-      break;
+      return buildAlmostExactGraph();
     case IdMappingMode::BROADCAST:
-      buildBroadcastGraph();
-      break;
+      return buildBroadcastGraph();
     case IdMappingMode::PERMISSIVE:
-      buildPermissiveGraph();
-      break;
+      return buildPermissiveGraph();
     case IdMappingMode::LOOP:
-      buildLoopGraph();
-      break;
+      return buildLoopGraph();
     default:
       NVF_THROW("Unsupported mode: ", mode);
   }
 }
 
-void IdModel::maybeBuildGraph(IdMappingMode mode) {
-  if (id_graphs_.find(mode) != id_graphs_.end()) {
-    return;
+ValGraph& IdModel::maybeBuildGraph(IdMappingMode mode) {
+  auto it = id_graphs_.find(mode);
+  if (it != id_graphs_.end()) {
+    return it->second;
   } else {
-    buildGraph(mode);
+    return buildGraph(mode);
   }
 }
 

--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -115,7 +115,7 @@ class IdModel : public PolymorphicBase {
   IdModel(
       const std::vector<Expr*>& exprs,
       const std::vector<TensorView*>& additional_tvs = {},
-      bool build_graphs = true,
+      bool build_graphs = false,
       bool allow_self_mapping = false,
       LoopPromotionMapBuilderCallback* loop_promotion_map_builder_callback =
           nullptr);
@@ -128,7 +128,7 @@ class IdModel : public PolymorphicBase {
   // transition from the current ComputeAtMap.
   IdModel(
       Fusion* fusion,
-      bool build_graphs = true,
+      bool build_graphs = false,
       bool allow_self_mapping = false,
       bool validate = false,
       LoopPromotionMapBuilderCallback* loop_promotion_map_builder_callback =
@@ -205,10 +205,10 @@ class IdModel : public PolymorphicBase {
   ValGraph& buildLoopGraph(bool force_full_loop_promotion_analysis = false);
 
   // Build a graph. Dependent graphs are also built if not yet done.
-  void buildGraph(IdMappingMode mode);
+  ValGraph& buildGraph(IdMappingMode mode);
 
   // Build a graph if not already built
-  void maybeBuildGraph(IdMappingMode mode);
+  ValGraph& maybeBuildGraph(IdMappingMode mode);
 
   // Iterates over all IterDomains in id_definitions_ and calls initializeVal on
   // a new ValGraph and returns it.

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -915,7 +915,7 @@ std::unique_ptr<MatmulParams> getMatmulHeuristics(
   mma_utils::MatmulPattern& pattern = patterns.front();
 
   // IdModel is used to analyze problem shape & layout
-  IdModel id_model(fusion);
+  IdModel id_model(fusion, /*build_graphs=*/false);
   id_model.maybeBuildGraph(IdMappingMode::BROADCAST);
 
   const mma_utils::DimRolesMap id_roles = pattern.getDimRoles(id_model);
@@ -1098,7 +1098,7 @@ std::string getMatmulCompileTimeRejectReason(Fusion* fusion) {
 
   // #3
   // Prepare an IdModel which will be reused to check remaining conditions
-  IdModel id_model(fusion);
+  IdModel id_model(fusion, /*build_graphs=*/false);
   const auto id_roles = patterns.front().getDimRoles(id_model);
   const mma_utils::TensorRolesMapOpt tensor_roles_opt =
       mma_utils::getTensorRoles(fusion, id_model, id_roles);

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1349,7 +1349,7 @@ MatmulOperandInnerDimsOpt getOperandInnerDims(Fusion* fusion) {
     TORCH_WARN("TODO: Update getOperandInnerDims for multiple patterns");
   }
   const MatmulPattern& pattern = patterns[0];
-  IdModel id_model(fusion);
+  IdModel id_model(fusion, /*build_graphs=*/false);
   const auto id_roles = pattern.getDimRoles(id_model);
   const auto tensor_roles_opt = getTensorRoles(fusion, id_model, id_roles);
   if (!tensor_roles_opt.isValid()) {
@@ -2105,8 +2105,7 @@ DimRolesMap matmulOrLinearOpDimRoles(
 } // namespace
 
 DimRolesMap MatmulPattern::getDimRoles(IdModel& id_model) const {
-  id_model.maybeBuildGraph(IdMappingMode::BROADCAST);
-  const ValGraph& graph = id_model.idGraph(IdMappingMode::BROADCAST);
+  const ValGraph& graph = id_model.maybeBuildGraph(IdMappingMode::BROADCAST);
 
   // There are four types of ValGroup involved in a MatmulPattern: M, N, K, and
   // Batch. These are enumerated in the MatmulDimRole enum class. They are

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2581,9 +2581,10 @@ bool isResharding(Fusion* fusion) {
 void moveNonConcretizedBroadcastInnermost(
     Fusion* fusion,
     const std::unordered_set<TensorView*>& ignored_tvs) {
-  IdModel id_model(fusion);
-  const auto& exact_graph = id_model.idGraph(IdMappingMode::EXACT);
-  const auto& permissive_graph = id_model.idGraph(IdMappingMode::PERMISSIVE);
+  IdModel id_model(fusion, /*build_graphs=*/false);
+  const auto& exact_graph = id_model.maybeBuildGraph(IdMappingMode::EXACT);
+  const auto& permissive_graph =
+      id_model.maybeBuildGraph(IdMappingMode::PERMISSIVE);
 
   // This function is meant to be used as a preprocessing step of each
   // segment scheduling. The goal is to find unmapped non-concretized

--- a/tests/cpp/test_bfs.cpp
+++ b/tests/cpp/test_bfs.cpp
@@ -48,8 +48,8 @@ TEST_F(BFSTest, ValGraphBFS1) {
   // tv1: [i0*i1/4, 4]
   // tv2: [i1*i0/4, 4]
 
-  const IdModel id_model(fusion.get());
-  const ValGraph& graph = id_model.idGraph(IdMappingMode::EXACT);
+  IdModel id_model(fusion.get(), /*build_models=*/false);
+  const ValGraph& graph = id_model.buildExactGraph();
 
   ValGroups tv0_loop_groups = graph.toGroups(tv0->getLoopDomain());
   ValGroups tv1_loop_groups = graph.toGroups(tv1->getLoopDomain());
@@ -117,8 +117,8 @@ TEST_F(BFSTest, ValGraphBFS2) {
   // tv0: [i0, i1, i2]
   // tv1: [i0*(i1*i2)]
 
-  const IdModel id_model(fusion.get());
-  const ValGraph& graph = id_model.idGraph(IdMappingMode::EXACT);
+  IdModel id_model(fusion.get(), /*build_models=*/false);
+  const ValGraph& graph = id_model.buildExactGraph();
 
   ValGroups tv0_loop_groups = graph.toGroups(tv0->getLoopDomain());
   ValGroups tv1_loop_groups = graph.toGroups(tv1->getLoopDomain());
@@ -179,8 +179,8 @@ TEST_F(BFSTest, ValGraphBFS3) {
   // Traversal from tv4 to tv0 can be {tv4 -> tv1 -> tv0} or {tv4 ->
   // tv3 -> tv2 -> tv0}. The former should be seletected as it's shorter
 
-  const IdModel id_model(fusion.get());
-  const ValGraph& graph = id_model.idGraph(IdMappingMode::EXACT);
+  IdModel id_model(fusion.get(), /*build_models=*/false);
+  const ValGraph& graph = id_model.buildExactGraph();
 
   ValGroups tv4_groups = graph.toGroups(tv4->getLoopDomain());
   ValGroups tv0_groups = graph.toGroups(tv0->getLoopDomain());
@@ -225,8 +225,8 @@ TEST_F(BFSTest, ValGraphBFS4) {
 
   // Make sure the BFS traversal should still work even with a cycle.
 
-  const IdModel id_model(fusion.get());
-  const ValGraph& graph = id_model.idGraph(IdMappingMode::EXACT);
+  IdModel id_model(fusion.get(), /*build_models=*/false);
+  const ValGraph& graph = id_model.buildExactGraph();
 
   ValGroups tv4_groups = graph.toGroups(tv4->getLoopDomain());
   ValGroups tv0_groups = graph.toGroups(tv0->getLoopDomain());

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -8598,8 +8598,8 @@ TEST_F(NVFuserTest, MoveNonConcretizedBroadcastInNormalization) {
   // the loop domain, preventing uniform inlining. Check if the
   // outermost loop domains of all tensors are mapped and inlined.
   auto ref_outermost = tv7->getLoopDomain().at(0);
-  IdModel id_model(&fusion);
-  const auto& exact_graph = id_model.idGraph(IdMappingMode::EXACT);
+  IdModel id_model(&fusion, /*build_graphs=*/false);
+  const auto& exact_graph = id_model.buildExactGraph();
   for (auto tv : fusion.allTvs()) {
     if (tv->isFusionInput()) {
       continue;
@@ -8659,8 +8659,8 @@ TEST_F(NVFuserTest, MoveNonConcretizedBroadcastInPointwise) {
   // the loop domain, preventing uniform inlining. Check if the
   // outermost loop domains of all tensors are mapped and inlined.
   auto ref_outermost = tv5->getLoopDomain().at(0);
-  IdModel id_model(&fusion);
-  const auto& exact_graph = id_model.idGraph(IdMappingMode::EXACT);
+  IdModel id_model(&fusion, /*build_graphs=*/false);
+  const auto& exact_graph = id_model.buildExactGraph();
   for (auto tv : fusion.allTvs()) {
     if (tv->isFusionInput()) {
       continue;
@@ -8719,8 +8719,8 @@ TEST_F(NVFuserTest, MoveNonConcretizedBroadcastInReduction) {
   // the loop domain, preventing uniform inlining. Check if the
   // outermost loop domains of all tensors are mapped and inlined.
   auto ref_outermost = tv6->getLoopDomain().at(0);
-  IdModel id_model(&fusion);
-  const auto& exact_graph = id_model.idGraph(IdMappingMode::EXACT);
+  IdModel id_model(&fusion, /*build_graphs=*/false);
+  const auto& exact_graph = id_model.buildExactGraph();
   for (auto tv : fusion.allTvs()) {
     if (tv->isFusionInput()) {
       continue;

--- a/tests/cpp/test_loop_domain_scheduling.cpp
+++ b/tests/cpp/test_loop_domain_scheduling.cpp
@@ -72,7 +72,7 @@ TEST_F(LoopDomainSchedulingTest, ReshapeSplitThenMerge) {
 
   inlineMost();
 
-  IdModel id_model(&fusion);
+  IdModel id_model(&fusion, /*build_models=*/true);
 
   ref = tv1->getLoopDomain();
   for (auto tv : fusion.allTvs()) {
@@ -139,7 +139,8 @@ TEST_F(LoopDomainSchedulingTest, Slice) {
   }
 
   inlineMost();
-  IdModel id_model(&fusion);
+  IdModel id_model(&fusion, /*build_models=*/false);
+  id_model.buildExactGraph();
 
   ref_loop = tv0->getLoopDomain();
 

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -23,12 +23,12 @@ namespace nvfuser {
 using Sizes = std::vector<int64_t>;
 using MatmulNodeParamType = std::tuple<Sizes, Sizes>;
 
-class MatmulNodeParametrizedTest
+class MatmulNodeParameterizedTest
     : public NVFuserFixtureParamTest<MatmulNodeParamType> {
  protected:
   // Allocation order set by the pass breaks matmul tests
   // see issue https://github.com/NVIDIA/Fuser/issues/1810
-  MatmulNodeParametrizedTest() : optimization_guard_(false) {}
+  MatmulNodeParameterizedTest() : optimization_guard_(false) {}
 
  private:
   preseg_passes::OptimizationPassGuard<preseg_passes::AllocationDomainPass>
@@ -55,7 +55,7 @@ void checkMatmulOpIdMapping(
     TensorView* B,
     TensorView* output) {
   IdModel id_model(fusion);
-  const ValGraph& vg = id_model.idGraph(IdMappingMode::EXACT);
+  const ValGraph& vg = id_model.buildExactGraph();
   vg.validateConsistency();
 
   // If K is Broadcast then we will not have a reduction dim.
@@ -109,7 +109,7 @@ void checkLinearOpIdMapping(
     TensorView* bias,
     TensorView* output) {
   IdModel id_model(fusion);
-  const ValGraph& vg = id_model.idGraph(IdMappingMode::EXACT);
+  const ValGraph& vg = id_model.buildExactGraph();
   vg.validateConsistency();
 
   // input: [* , in_features]
@@ -144,7 +144,7 @@ void checkLinearOpIdMapping(
   }
 }
 
-TEST_P(MatmulNodeParametrizedTest, MatmulNodeConcrete) {
+TEST_P(MatmulNodeParameterizedTest, MatmulNodeConcrete) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -170,7 +170,7 @@ TEST_P(MatmulNodeParametrizedTest, MatmulNodeConcrete) {
   EXPECT_TRUE(at::allclose(out[0], out_ref));
 }
 
-TEST_P(MatmulNodeParametrizedTest, MatmulNodeSymbolic) {
+TEST_P(MatmulNodeParameterizedTest, MatmulNodeSymbolic) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -298,7 +298,7 @@ constexpr int64_t b = 128, m = 64, k = 32, n = 16;
 // Parametrize a_shape and b_shape
 INSTANTIATE_TEST_SUITE_P(
     ,
-    MatmulNodeParametrizedTest,
+    MatmulNodeParameterizedTest,
     testing::Combine(
         testing::Values(
             Sizes({k}),
@@ -315,7 +315,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Test case where K=1
 INSTANTIATE_TEST_SUITE_P(
     ReductionAxisIsOne,
-    MatmulNodeParametrizedTest,
+    MatmulNodeParameterizedTest,
     testing::Combine(
         testing::Values(
             Sizes({1}),

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -68,8 +68,8 @@ auto validateSdpaFwdOutputs = [](std::vector<at::Tensor> nvf_out,
 
 // Check SDPAFwdOp mapping in IdModel and ComputeAtMap.
 void checkSdpaFwdMapping(Fusion* fusion, Expr* op) {
-  IdModel id_model(fusion);
-  const ValGraph& vg = id_model.idGraph(IdMappingMode::EXACT);
+  IdModel id_model(fusion, /*build_graphs=*/false);
+  const ValGraph& vg = id_model.buildExactGraph();
   vg.validateConsistency();
 
   ComputeAtMap compute_at_map(fusion);
@@ -135,8 +135,8 @@ void checkSdpaFwdMapping(Fusion* fusion, Expr* op) {
 
 // Check SDPABwdOp mapping in IdModel and ComputeAtMap.
 void checkSdpaBwdMapping(Fusion* fusion, Expr* op) {
-  IdModel id_model(fusion);
-  const ValGraph& vg = id_model.idGraph(IdMappingMode::EXACT);
+  IdModel id_model(fusion, /*build_graphs=*/false);
+  const ValGraph& vg = id_model.buildExactGraph();
   vg.validateConsistency();
 
   ComputeAtMap compute_at_map(fusion);


### PR DESCRIPTION
This is just a cleanup PR. Changed `IdModel` to not build the full set of graphs by default since most of the times we just want to build the EXACT or BROADCAST graphs.

The `false` argument of `/*build_graphs=*/` can be omitted, but I didn't change that for clarity.