### PR TITLE
Fix gcc 14.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,7 +310,7 @@ if(NOT MSVC)
           # manylinux image. consider enable this when we upgrade.
           # linking comment:
           # https://github.com/NVIDIA/Fuser/pull/3001#discussion_r1772551266
-          -Wno-error=restrict -Wno-error=stringop-overflow)
+          -Wno-error=restrict -Wno-error=stringop-overflow -Wno-error=maybe-uninitialized)
   else()
       target_compile_options(codegen_internal PRIVATE
           -Wall -Wno-unused-function -Werror)


### PR DESCRIPTION
Upgraded to gcc 14.2.1, seeing some new failure:
```
[195/505] Building CXX object CMakeFiles/codegen_internal.dir/csrc/device_lower/pass/index.cpp.o
In file included from /home/gaoxiang/Fuser/csrc/iter_visitor.h:13,
                 from /home/gaoxiang/Fuser/csrc/fusion.h:18,
                 from /home/gaoxiang/Fuser/csrc/device_lower/analysis/index_compute.h:11,
                 from /home/gaoxiang/Fuser/csrc/device_lower/pass/index.cpp:8:
/home/gaoxiang/Fuser/csrc/bfs.h: In function ‘std::unordered_set<typename BFSType::ValType> nvfuser::projectTo(const typename BFSType::ValType&, const std::vector<typename BFSType::ValType>&, Direction, const AdditionalArgs& ...) [with BFSType = ValGraphBFS; AdditionalArgs = {ValGraph}]’:
/home/gaoxiang/Fuser/csrc/bfs.h:899:10: warning: ‘((const nvfuser::type*)<unknown>)[4611686018427387902]’ may be used uninitialized [-Wmaybe-uninitialized]
  899 |     auto from = getOutputsOfExpr(
      |          ^~~~
[198/505] Building CXX object CMakeFiles/codegen_internal.dir/csrc/device_lower/utils.cpp.o
/home/gaoxiang/Fuser/csrc/device_lower/utils.cpp: In function ‘nvfuser::Val* nvfuser::lower_utils::proveLinearAndGetStride(const nvfuser::ValGraph&, const nvfuser::ValGroup&, const nvfuser::ValGroups&)’:
/home/gaoxiang/Fuser/csrc/device_lower/utils.cpp:1958:51: warning: ‘((const nvfuser::type*)<unknown>)[4611686018427387902]’ may be used uninitialized [-Wmaybe-uninitialized]
 1958 |     auto from = fromGroups(id_graph, eg, direction);
```

This happens on both C++17 and C++20