### PR TITLE
Fix test file names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -654,8 +654,8 @@ endfunction()
 
 if(BUILD_TEST)
   set(TEST_BINARIES)
-  add_test(nvfuser_tests "${JIT_TEST_SRCS}" "")
-  list(APPEND TEST_BINARIES nvfuser_tests)
+  add_test(test_nvfuser "${JIT_TEST_SRCS}" "")
+  list(APPEND TEST_BINARIES test_nvfuser)
 
   add_test(test_rng ${NVFUSER_ROOT}/tests/cpp/test_rng.cpp ${RNG_TEST_KERNELS})
   list(APPEND TEST_BINARIES test_rng)
@@ -703,8 +703,8 @@ if(BUILD_TEST)
   add_test(test_external_src "${NVFUSER_ROOT}/tests/cpp/test_external_src.cpp" "")
   list(APPEND TEST_BINARIES test_external_src)
 
-  add_test(tutorial "${NVFUSER_ROOT}/tests/cpp/test_tutorial.cpp" "")
-  list(APPEND TEST_BINARIES tutorial)
+  add_test(test_tutorial "${NVFUSER_ROOT}/tests/cpp/test_tutorial.cpp" "")
+  list(APPEND TEST_BINARIES test_tutorial)
 
   set(HOSTIR_TEST_SRCS)
   list(APPEND HOSTIR_TEST_SRCS

--- a/tests/cpp/test_tutorial.cpp
+++ b/tests/cpp/test_tutorial.cpp
@@ -654,6 +654,7 @@ TEST_F(Tutorial, IdModelReshapeAnalysis) {
   fusion.addOutput(tv3);
 
   IdModel id_model(&fusion);
+  id_model.buildExactGraph();
   ValGraph& exact_graph = id_model.idGraph(IdMappingMode::EXACT);
 
   // As mentioned above, we don't know any relationship between tv0


### PR DESCRIPTION
Our CI missed running `tutorial` because we have a filtering rule `./bin/test_*`. Instead of adding another filtering rule, @xwang233 suggested that we should name all tests as `test_*`, which I believe makes sense.