### PR TITLE
Fix slice to empty not being converted to FullOp

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -9,6 +9,7 @@
 #include <dynamic_transform.h>
 #include <expr_evaluator.h>
 #include <fusion.h>
+#include <ir/builder.h>
 #include <ir/cloner.h>
 #include <ir/utils.h>
 #include <logical_domain_map.h>
@@ -708,6 +709,9 @@ class DynamicTransformConcretizer : public OptOutMutator {
 };
 
 void DynamicTransformConcretizer::concretize() {
+  // Registers replacement of all empty extents with zeroVal()
+  concretizeEmptyExtents();
+
   // Concretize all dynamic reshape ops
   concretizeReshape();
 
@@ -716,9 +720,6 @@ void DynamicTransformConcretizer::concretize() {
 
   // Overwrite expanded IterDomains for dynamic expand ops
   concretizeExpand();
-
-  // Registers replacement of all empty extents with zeroVal()
-  concretizeEmptyExtents();
 
   // Set IterTypes for factory op outputs
   concretizeFactoryOutputs();
@@ -942,10 +943,26 @@ void DynamicTransformConcretizer::concretizeResize() {
     auto def = id->definition()->as<Resize>();
     auto new_id = IterDomain::resize(
         def->in(),
-        def->leftExpand(),
-        def->rightExpand(),
+        maybeMutated(def->leftExpand()),
+        maybeMutated(def->rightExpand()),
         id->isRFactorProduct(),
         iter_type);
+
+    if (maybeMutated(def->in()->extent()) != def->in()->extent()) {
+      // Note: if the extent of id is mutated, for example by the
+      // concretizeEmptyExtents pass, we should also use the mutated extent to
+      // compute the output extent.
+      Val* new_extent = SimplifyingIrBuilder::addExpr(
+          maybeMutated(def->leftExpand()),
+          SimplifyingIrBuilder::addExpr(
+              maybeMutated(def->in()->extent()),
+              maybeMutated(def->rightExpand())));
+      IterDomain* replacement =
+          IterDomainBuilder(new_id).extent(new_extent).build();
+      ir_utils::transferDefinitionToNewOutputs(
+          new_id->definition(), {replacement});
+      new_id = replacement;
+    }
 
     registerConcretization(id, new_id);
   }
@@ -988,11 +1005,12 @@ void DynamicTransformConcretizer::concretizeExpand() {
       // expandedExtent.
       IterDomain* symbolic_id = out_logical[i];
       Val* one = FusionGuard::getCurFusion()->oneVal(DataType::Index);
-      IterDomain* concretized_id = IterDomainBuilder(symbolic_id)
-                                       .iter_type(IterType::Broadcast)
-                                       .extent(one)
-                                       .expanded_extent(symbolic_id->extent())
-                                       .build();
+      IterDomain* concretized_id =
+          IterDomainBuilder(symbolic_id)
+              .iter_type(IterType::Broadcast)
+              .extent(one)
+              .expanded_extent(maybeMutated(symbolic_id->extent()))
+              .build();
       registerConcretization(symbolic_id, concretized_id);
     }
   }

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -5963,4 +5963,36 @@ TEST_F(ResizeTest, DoNotFuseResizeAndIndexOps) {
   }
 }
 
+TEST_F(ResizeTest, SliceToZero) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  auto& fusion = *fusion_ptr;
+  FusionGuard fg(fusion_ptr.get());
+
+  auto tv0 = makeSymbolicTensor(1);
+  fusion.addInput(tv0);
+
+  auto tv1 = slice(tv0, {{fusion.zeroVal(), fusion.zeroVal()}});
+  fusion.addOutput(tv1);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({128}, options);
+  std::vector<c10::IValue> inputs({t0});
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+
+  FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
+  ASSERT_EQ(runtime->fusionSegments()->groups().size(), 1)
+      << "Unexpected segmentation";
+  EXPECT_EQ(
+      runtime->schedulerHeuristics()->at(0)->scheduler_type,
+      SchedulerType::NoOp);
+  // There should be a single TV expr, which is a FullOp
+  const std::vector<Expr*>& exprs =
+      runtime->fusionSegments()->completeFusion()->exprs();
+  ASSERT_EQ(exprs.size(), 1);
+  EXPECT_TRUE(exprs.at(0)->isA<FullOp>());
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
This fixes an issue noticed by @naoyam, where a simple fusion containing a dynamic slice does not get properly converted to a NoOp in the case when the output size is zero. This was happening because the resized iterdomain was being concretized as `Iteration` first, after which the extent was replaced by zero. However, the extent that was replaced in that case was the old one, not the extent of the replaced IterDomain. The fix is to first concretize empty extents as zero before doing anything else, then taking care to respect mutated extents when doing other concretizations. In particular, we need to doctor the extents that get resized if their inputs' extents have already been concretized.