### PR TITLE
[CudaIpc 1/3]`P2PCommunication`: add backend, src and dst

### DIFF
--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -262,13 +262,13 @@ TEST_F(P2PCommHostIrTest, RingPairwiseExchange) {
   TensorView* recv_buffer = makeContigTensor(1);
 
   auto* send = IrBuilder::create<P2PCommunication>(
-      P2PCommunicationType::SEND,
       send_buffer,
-      IrBuilder::create<Val>(send_peer));
+      IrBuilder::create<Val>(send_peer),
+      IrBuilder::create<Val>(my_device_index));
 
   auto* recv = IrBuilder::create<P2PCommunication>(
-      P2PCommunicationType::RECV,
       recv_buffer,
+      IrBuilder::create<Val>(my_device_index),
       IrBuilder::create<Val>(recv_peer));
 
   auto* wait = IrBuilder::create<Wait>(recv);
@@ -316,12 +316,12 @@ TEST_F(P2PCommHostIrTest, CoalescedRingPairwiseExchange) {
 
   auto* start_coalescing = IrBuilder::create<StartCoalescing>();
   auto* send = IrBuilder::create<P2PCommunication>(
-      P2PCommunicationType::SEND,
       send_buffer,
-      IrBuilder::create<Val>(send_peer));
+      IrBuilder::create<Val>(send_peer),
+      IrBuilder::create<Val>(my_device_index));
   auto* recv = IrBuilder::create<P2PCommunication>(
-      P2PCommunicationType::RECV,
       recv_buffer,
+      IrBuilder::create<Val>(my_device_index),
       IrBuilder::create<Val>(recv_peer));
   auto* end_coalescing = IrBuilder::create<EndCoalescing>();
   auto* wait = IrBuilder::create<Wait>(end_coalescing);

--- a/tests/cpp/test_multidevice_overlap.cpp
+++ b/tests/cpp/test_multidevice_overlap.cpp
@@ -586,9 +586,9 @@ TEST_F(
 
   auto* start_coalescing = IrBuilder::create<hir::StartCoalescing>();
   auto* send = IrBuilder::create<P2PCommunication>(
-      P2PCommunicationType::SEND, src_buffer_ij, send_rank);
+      src_buffer_ij, send_rank, my_device_index_val);
   auto* recv = IrBuilder::create<P2PCommunication>(
-      P2PCommunicationType::RECV, dst_buffer_ij, recv_rank);
+      dst_buffer_ij, my_device_index_val, recv_rank);
   auto* end_coalescing = IrBuilder::create<hir::EndCoalescing>();
   auto* wait = IrBuilder::create<hir::Wait>(end_coalescing);
 
@@ -1178,9 +1178,9 @@ TEST_F(
 
   auto* start_coalescing = IrBuilder::create<hir::StartCoalescing>();
   auto* send = IrBuilder::create<P2PCommunication>(
-      P2PCommunicationType::SEND, tva_j_curr_slice, send_rank);
+      tva_j_curr_slice, send_rank, my_device_index_val);
   auto* recv = IrBuilder::create<P2PCommunication>(
-      P2PCommunicationType::RECV, tva_j_next_slice, recv_rank);
+      tva_j_next_slice, my_device_index_val, recv_rank);
   auto* end_coalescing = IrBuilder::create<hir::EndCoalescing>();
   auto* wait = IrBuilder::create<hir::Wait>(end_coalescing);
 


### PR DESCRIPTION
This PR is a small self-contained part belonging to the larger PR
- https://github.com/NVIDIA/Fuser/pull/3894

# What 

- Add the backend type as an argument to P2PCommunication* 
- Replace providing the type "send/recv" by providing the Val* src and Val* dst, which makes it fully symbolic and more practical