### PR TITLE
Clean up types in tests, in preparation for changing APIs.

### DIFF
--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -53,8 +53,7 @@ TEST_F(AliasTest, View) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
       at::randn({2, 3, 4}, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
   at::Tensor out_tensor = out_tensors[0];
 
@@ -85,8 +84,7 @@ TEST_F(AliasTest, View_AliasForSameLayout) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
       at::randn({60}).cuda().as_strided({2, 3, 4}, {2, 20, 5});
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
   at::Tensor out_tensor = out_tensors[0];
   testValidate(
@@ -111,8 +109,7 @@ TEST_F(AliasTest, View_AliasForCompliantLayout) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3, 4}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
   at::Tensor out_tensor = out_tensors[0];
   testValidate(
@@ -140,8 +137,7 @@ TEST_F(AliasTest, View_NoAliasForIncompliantLayout) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
       at::randn({2, 3, 4}, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
   at::Tensor out_tensor = out_tensors[0];
 
@@ -169,8 +165,7 @@ TEST_F(AliasTest, ViewPermute) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
       at::randn({2, 3, 4}, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
   at::Tensor out_tensor = out_tensors[0];
 
@@ -198,8 +193,7 @@ TEST_F(AliasTest, DuplicateOutputs) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
       at::randn(in_shape, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 2);
   at::Tensor out_tensor_0 = out_tensors[0];
   at::Tensor out_tensor_1 = out_tensors[1];
@@ -288,8 +282,7 @@ TEST_F(AliasTest, SliceViewPermute) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({batches, seq_length, features * 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   EXPECT_EQ(out_tensors.size(), 3);
 
   for (const auto& out_tensor : out_tensors) {
@@ -333,8 +326,7 @@ TEST_F(AliasTest, DuplicateOutputsSegmentedFusion) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
       at::randn(in_shape, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -384,8 +376,7 @@ TEST_F(AliasTest, NotAllOutputsAlias_Pointwise) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -446,8 +437,7 @@ TEST_F(AliasTest, NotAllOutputsAlias_Reduction) {
       at::randn({16 * 12 * 128 * 192})
           .cuda()
           .as_strided({16, 12, 128, 192}, {128 * 12 * 192, 192, 12 * 192, 1});
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -470,8 +460,7 @@ TEST_F(AliasTest, Issue1452) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({1024, 1024}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -517,8 +506,7 @@ TEST_F(AliasTest, AliasOutputBeforeNonAliasOutput) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
 
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -546,8 +534,7 @@ TEST_F(AliasTest, Set_NoAliasForIncompatibleLayout) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3, 5}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
   at::Tensor out_tensor = out_tensors[0];
 
@@ -574,8 +561,7 @@ TEST_F(AliasTest, DuplicateOutputsComplex) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3, 5}).cuda();
 
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 4);
 
   // Verify aliases among outputs.
@@ -619,8 +605,7 @@ TEST_F(AliasTest, AliasInSegment) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -644,8 +629,7 @@ TEST_F(AliasTest, TrivialInputForwarding) {
   at::Tensor t1 = at::randn({10, 4}).cuda();
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  std::vector<at::Tensor> cg_outputs =
-      executor_cache.runFusionWithInputs({t0, t1});
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   EXPECT_EQ(cg_outputs[0].data_ptr(), t0.data_ptr());
   testValidate(
@@ -696,8 +680,7 @@ TEST_F(AliasTest, OutputAliasesAnotherOutput) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3, 5}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -722,8 +705,7 @@ TEST_F(AliasTest, OutputNotAliasedByAnotherOutputShouldNotBeSegmented) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3, 5}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -751,8 +733,7 @@ TEST_F(AliasTest, ManyAliasesBetweenOutputs) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3, 5}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
   ASSERT_EQ(out_tensors.size(), 4);
@@ -787,8 +768,7 @@ TEST_F(AliasTest, DoNotOverSegment_Straightline) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -820,8 +800,7 @@ TEST_F(AliasTest, DoNotOverSegment_WithForks) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -952,8 +931,7 @@ TEST_F(AliasTest, SourceIsBothInputAndOutput) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -1032,8 +1010,7 @@ TEST_F(AliasTest, ReuseBuffer_AliasAcrossSegments) {
   FusionExecutorCache executor_cache(std::move(fusion));
   // Make a copy of `t0` because `t0` will be in-place updated.
   at::Tensor original_t0 = t0.clone();
-  std::vector<at::Tensor> outputs =
-      executor_cache.runFusionWithInputs({t0, t1, t2});
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
   testValidate(
       executor_cache.fusion(),
       outputs,
@@ -1196,11 +1173,11 @@ TEST_F(AliasTest, KernelExecutor) {
 
   ExprEvalExecutor ee;
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor in_tensor = at::randn({10, 10}, options);
+  at::Tensor t0 = at::randn({10, 10}, options);
   ee.compile(&fusion);
-  auto args = KernelArgumentHolder({in_tensor});
+  KernelArgumentHolder args({t0});
   at::Tensor out_tensor = ee.run(args)[0];
-  EXPECT_EQ(out_tensor.data_ptr(), in_tensor.data_ptr());
+  EXPECT_EQ(out_tensor.data_ptr(), t0.data_ptr());
 }
 
 TEST_F(AliasTest, InplaceUpdate) {
@@ -1242,8 +1219,7 @@ TEST_F(AliasTest, Bookend_SegmentSetPreservesAllocation) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({3, 2}).cuda().transpose(0, 1);
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -1265,8 +1241,7 @@ TEST_F(AliasTest, Bookend_InputsAndOutputs) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -1306,8 +1281,7 @@ TEST_F(AliasTest, Bookend_IntermediateTensors) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -1342,8 +1316,7 @@ TEST_F(AliasTest, Bookend_AliasesOfSameTensor) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -1379,8 +1352,7 @@ TEST_F(AliasTest, Bookend_ReuseSegmentSet) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3, 5}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -1426,14 +1398,13 @@ TEST_F(AliasTest, QKVSplitBackprop) {
   fusion->addOutput(permute_out);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  std::vector<c10::IValue> in_tensors;
+  std::vector<c10::IValue> aten_inputs;
   for (int i = 0; i < 3; i++) {
-    in_tensors.push_back(at::randn({b, s, h * f}).cuda());
+    aten_inputs.push_back(at::randn({b, s, h * f}).cuda());
   }
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs(in_tensors);
+  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
   testValidate(
-      executor_cache.fusion(), out_tensors, in_tensors, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
 
   EXPECT_TRUE(out_tensors[2].is_alias_of(out_tensors[1]));
 }
@@ -1532,8 +1503,7 @@ TEST_F(AliasTest, TrivialInplaceUpdateNoSegmentation) {
   at::Tensor in_tensor =
       at::randn(in_shape, at::dtype(at::kFloat).device(at::kCUDA, 0));
   at::Tensor original_tensor = in_tensor.clone();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
 
   // Verify inplace update
@@ -1573,8 +1543,7 @@ TEST_F(AliasTest, ReshapeInplaceUpdateNoSegmentation) {
   at::Tensor in_tensor =
       at::randn(in_shape, at::dtype(at::kFloat).device(at::kCUDA, 0));
   at::Tensor original_tensor = in_tensor.clone();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
 
   // Verify inplace update

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -1067,7 +1067,7 @@ TEST_F(AllocationDomainTest, TransposeMatrix) {
   at::Tensor t0 = at::randn(in_shape, options);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  std::vector<at::Tensor> outputs = executor_cache.runFusionWithInputs({t0});
+  auto outputs = executor_cache.runFusionWithInputs({t0});
   at::Tensor t1 = outputs[0];
 
   auto get_data = [](const at::Tensor& t) -> std::vector<float> {

--- a/tests/cpp/test_dynamic_transform.cpp
+++ b/tests/cpp/test_dynamic_transform.cpp
@@ -827,7 +827,7 @@ void reductionDynamicViewAddFusion(
     std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
     // Add input scalars describing the reshape size for concretization
     for (size_t i : c10::irange(output_dims)) {
-      aten_inputs.emplace_back(output_shape[i]);
+      aten_inputs.push_back(output_shape[i]);
     }
 
     auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -940,7 +940,7 @@ void reductionDynamicPadAddFusion(
     std::vector<c10::IValue> aten_inputs = {at_x};
     // Add input scalars describing the reshape size for concretization
     for (size_t i : c10::irange(pad_widths.size())) {
-      aten_inputs.emplace_back(pad_widths[i]);
+      aten_inputs.push_back(pad_widths[i]);
     }
 
     auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -1299,11 +1299,10 @@ TEST_F(NVFuserTest, ConcretizeConstantExtents) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4096, 12288}, options);
-  std::vector<c10::IValue> inputs = {t0};
 
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Test that dynamic reductions that should result in squeezes are handled
@@ -1336,11 +1335,10 @@ TEST_F(NVFuserTest, DynamicSqueezeTrivialReduction) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({2, 2, 9}, options);
-  std::vector<c10::IValue> inputs = {t0};
 
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Same as above but for Welford ops
@@ -1374,11 +1372,10 @@ TEST_F(NVFuserTest, DynamicSqueezeTrivialWelford) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({2, 2, 9}, options);
-  std::vector<c10::IValue> inputs = {t0};
 
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -1142,7 +1142,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt1_CUDA) {
 
   at::Tensor aten_input = at::randn({129, 127}, options);
 
-  std::vector<at::Tensor> cg_outputs = {
+  auto cg_outputs = {
       at::empty_like(aten_input, options), at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
@@ -1249,15 +1249,13 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt3_CUDA) {
   at::Tensor t0 = at::randn({129, 127, 63, 65}, options);
   at::Tensor t1 = at::rand_like(t0, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   at::Tensor cg_output = at::empty_like(t0, options);
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  ke.run(aten_inputs, {cg_output});
+  ke.compile(&fusion, {t0, t1});
+  ke.run({t0, t1}, {cg_output});
 
-  testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, {cg_output}, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionAdvancedComputeAt4_CUDA) {
@@ -1315,13 +1313,11 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt4_CUDA) {
   at::Tensor t2 = at::rand_like(t0, options);
   at::Tensor t3 = at::rand_like(t0, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2, t3};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, t2, t3});
+  auto cg_outputs = ke.run({t0, t1, t2, t3});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1, t2, t3}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionAdvancedComputeAt5_CUDA) {
@@ -1351,13 +1347,11 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt5_CUDA) {
   at::Tensor t0 = at::randn({63, 65}, options);
   at::Tensor t1 = at::rand_like(t0, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionAdvancedComputeAt6_CUDA) {
@@ -1386,13 +1380,11 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt6_CUDA) {
   at::Tensor t0 = at::randn({63, 65}, options);
   at::Tensor t1 = at::rand_like(t0, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionAdvancedComputeAt7_CUDA) {
@@ -1447,13 +1439,11 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt7_CUDA) {
   auto t2 = at::randn({numel_x}, options);
   auto t6 = at::randn({numel_x, numel_y}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t2, t6};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t2, t6});
+  auto cg_outputs = ke.run({t0, t2, t6});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t2, t6}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionAdvancedComputeAt8_CUDA) {
@@ -1503,13 +1493,11 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAt8_CUDA) {
   auto t2 = at::randn({numel_x}, options);
   auto t6 = at::randn({numel_x, numel_y}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t2, t6};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t2, t6});
+  auto cg_outputs = ke.run({t0, t2, t6});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t2, t6}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionComputeAtMultiConsumers_CUDA) {
@@ -1571,7 +1559,7 @@ TEST_F(NVFuserTest, FusionComputeAtMultiConsumers_CUDA) {
 
   at::Tensor aten_input = at::randn({1000}, options);
 
-  std::vector<at::Tensor> cg_outputs = {
+  auto cg_outputs = {
       at::empty_like(aten_input, options), at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
@@ -1639,7 +1627,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer1_CUDA) {
 
   at::Tensor aten_input = at::randn({1000}, options);
 
-  std::vector<at::Tensor> cg_outputs = {
+  auto cg_outputs = {
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options)};
@@ -1797,7 +1785,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer3_CUDA) {
 
   at::Tensor aten_input = at::randn({129, 127}, options);
 
-  std::vector<at::Tensor> cg_outputs = {
+  auto cg_outputs = {
       at::empty_like(aten_input, options), at::empty_like(aten_input, options)};
 
   KernelExecutor ke;
@@ -1858,7 +1846,7 @@ TEST_F(NVFuserTest, FusionComputeAtNoCommonConsumer_CUDA) {
 
   at::Tensor aten_input = at::randn({1000}, options);
 
-  std::vector<at::Tensor> cg_outputs = {
+  auto cg_outputs = {
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options),
@@ -2704,11 +2692,7 @@ TEST_F(NVFuserTest, FusionFp8CastOps_CUDA) {
       auto options =
           at::TensorOptions().dtype(at_src_type).device(at::kCUDA, 0);
 
-      at::Tensor input1 = at::randn({1, 4}, options);
-
-      // std::array<c10::IValue, 1> inputs = {input1};
-      // const c10::ArrayRef<c10::IValue> input_ivalues(inputs);
-      std::vector<c10::IValue> inputs = {input1};
+      at::Tensor t0 = at::randn({1, 4}, options);
 
       KernelExecutor ke;
 #if (CUDA_VERSION >= 12010)
@@ -2719,14 +2703,14 @@ TEST_F(NVFuserTest, FusionFp8CastOps_CUDA) {
       if (true) {
 #endif
         ASSERT_THAT(
-            [&]() { ke.compile(&fusion, inputs); },
+            [&]() { ke.compile(&fusion, {t0}); },
             testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
                 "Reason: Fusion contains Float8_xxx values")));
       } else {
-        ke.compile(&fusion, inputs);
-        auto outputs = ke.run(inputs);
+        ke.compile(&fusion, {t0});
+        auto outputs = ke.run({t0});
 
-        at::Tensor ref_output = input1.to(at_fp8_type).to(at_src_type);
+        at::Tensor ref_output = t0.to(at_fp8_type).to(at_src_type);
 
         NVF_CHECK(
             outputs[0].equal(ref_output),
@@ -3333,12 +3317,10 @@ TEST_F(NVFuserTest, FusionBranches_CUDA) {
   tv5->axis(-1)->parallelize(ParallelType::TIDx);
   tv6->axis(-1)->parallelize(ParallelType::TIDx);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
+  ke.compile(&fusion, {t0, t1, t2});
+  auto cg_outputs = ke.run({t0, t1, t2});
 
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
-
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSimpleBCast1_CUDA) {
@@ -3379,13 +3361,11 @@ TEST_F(NVFuserTest, FusionSimpleBCast1_CUDA) {
   at::Tensor t2 = at::randn({y, z}, options);
   at::Tensor t3 = at::randn({y, z}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t2, t3};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t2, t3});
+  auto cg_outputs = ke.run({t0, t2, t3});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t2, t3}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSimpleBCast2_CUDA) {
@@ -3431,13 +3411,11 @@ TEST_F(NVFuserTest, FusionSimpleBCast2_CUDA) {
 
   at::Tensor cg_output = at::empty({x, y, z}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t4};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  ke.run(aten_inputs, {cg_output});
+  ke.compile(&fusion, {t0, t1, t4});
+  ke.run({t0, t1, t4}, {cg_output});
 
-  testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, {cg_output}, {t0, t1, t4}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSimpleBCast3_CUDA) {
@@ -3472,14 +3450,13 @@ TEST_F(NVFuserTest, FusionSimpleBCast3_CUDA) {
   at::Tensor t0 = at::randn({y, 1}, options);
   at::Tensor t2 = at::randn({x, y, z}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t2};
   at::Tensor cg_output = at::empty({x, y, z}, options);
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  ke.run(aten_inputs, {cg_output});
+  ke.compile(&fusion, {t0, t2});
+  ke.run({t0, t2}, {cg_output});
 
-  testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, {cg_output}, {t0, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSimpleBCast4_CUDA) {
@@ -3518,13 +3495,11 @@ TEST_F(NVFuserTest, FusionSimpleBCast4_CUDA) {
 
   at::Tensor cg_output = at::empty({x, y, z}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  ke.run(aten_inputs, {cg_output});
+  ke.compile(&fusion, {t0, t1});
+  ke.run({t0, t1}, {cg_output});
 
-  testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, {cg_output}, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSimpleBCast5_CUDA) {
@@ -3558,13 +3533,11 @@ TEST_F(NVFuserTest, FusionSimpleBCast5_CUDA) {
 
   at::Tensor cg_output = at::empty({m, k, n}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  ke.run(aten_inputs, {cg_output});
+  ke.compile(&fusion, {t0, t1});
+  ke.run({t0, t1}, {cg_output});
 
-  testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, {cg_output}, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionComplexBCast1_CUDA) {
@@ -3610,13 +3583,11 @@ TEST_F(NVFuserTest, FusionComplexBCast1_CUDA) {
   at::Tensor t3 = at::randn({y, z}, options);
   at::Tensor t6 = at::randn({x, y, z}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t3, t6};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t3, t6});
+  auto cg_outputs = ke.run({t0, t3, t6});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t3, t6}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionComplexBCast2_CUDA) {
@@ -4547,11 +4518,9 @@ TEST_F(NVFuserTest, FusionGridReduction9_CUDA) {
   at::Tensor t0 = at::randn({numel_x, numel_y}, options);
   at::Tensor t2 = at::randn({numel_x}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t2};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_output = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t2});
+  auto cg_output = ke.run({t0, t2});
 
   testValidate(&fusion, cg_output, {t0, t2}, __LINE__, __FILE__);
 }
@@ -4867,14 +4836,13 @@ TEST_F(NVFuserTest, FusionZeroDimBroadcast_CUDA) {
   at::Tensor t0 = at::randn({}, options);
   at::Tensor t1 = at::randn({10, 10}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
   at::Tensor cg_output = at::empty({}, options);
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  ke.run(aten_inputs, {cg_output});
+  ke.compile(&fusion, {t0, t1});
+  ke.run({t0, t1}, {cg_output});
 
-  testValidate(&fusion, {cg_output}, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, {cg_output}, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionZeroDimReduction_CUDA) {
@@ -4956,13 +4924,12 @@ TEST_F(NVFuserTest, FusionBCastAfterReduce_CUDA) {
   auto t3 = t0.to(at::kDouble).sum({1}).unsqueeze(-1).expand({x, y});
   auto aten_output = t3.add(t4);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t4};
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t4});
   auto cg_outputs = ke.run({t0, t4});
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, t4}, {aten_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionOutputBroadcast_CUDA) {
@@ -5663,13 +5630,11 @@ TEST_F(NVFuserTest, FusionCacheIndirect_CUDA) {
   at::Tensor t2 = at::randn({M, N}, options);
   at::Tensor t3 = at::randn({M, N}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2, t3};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, t2, t3});
+  auto cg_outputs = ke.run({t0, t1, t2, t3});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1, t2, t3}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionCacheBcast_CUDA) {
@@ -5719,13 +5684,12 @@ TEST_F(NVFuserTest, FusionCacheBcast_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({M}, options);
   at::Tensor t1 = at::randn({N}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionCacheMultiConsumer_CUDA) {
@@ -5808,13 +5772,11 @@ TEST_F(NVFuserTest, FusionSmem_CUDA) {
   at::Tensor t0 = at::randn({M, N}, options);
   at::Tensor t1 = at::randn({M, N}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1});
   auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 
   NVF_CHECK(
       ke.compiledKernel()->kernel()->summary().war_hazard_syncs_count == 0);
@@ -5927,7 +5889,6 @@ TEST_F(NVFuserTest, FusionSmemBlockGemm_CUDA) {
   at::Tensor t0 = at::randn({M, K}, options);
   at::Tensor t1 = at::randn({K, N}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
   at::Tensor aten_output = at::matmul(t0.to(at::kDouble), t1.to(at::kDouble));
 
   KernelExecutor ke;
@@ -5935,7 +5896,7 @@ TEST_F(NVFuserTest, FusionSmemBlockGemm_CUDA) {
   auto cg_outputs = ke.run({t0, t1});
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, t1}, {aten_output}, __LINE__, __FILE__);
 
   NVF_CHECK(
       ke.compiledKernel()->kernel()->summary().war_hazard_syncs_count == 0);
@@ -6018,14 +5979,12 @@ TEST_F(NVFuserTest, FusionSmemBlockGemmCache_CUDA) {
   at::Tensor t1 = at::randn({K, N}, options);
   at::Tensor aten_output = at::matmul(t0.to(at::kDouble), t1.to(at::kDouble));
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, t1}, {aten_output}, __LINE__, __FILE__);
 
   NVF_CHECK(
       ke.compiledKernel()->kernel()->summary().war_hazard_syncs_count == 0);
@@ -7333,16 +7292,15 @@ TEST_F(NVFuserTest, FusionSmemDynamicPwiseMulSymbolicArgWAR_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({M, K}, options);
   at::Tensor t1 = at::randn({K, N}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1, BSX};
 
   LaunchParams lparams(-1, -1, -1, BSX, -1, -1);
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs, lparams);
-  auto cg_outputs = ke.run(aten_inputs, lparams);
+  ke.compile(&fusion, {t0, t1, BSX}, lparams);
+  auto cg_outputs = ke.run({t0, t1, BSX}, lparams);
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, __LINE__, __FILE__, "", lparams);
+      &fusion, cg_outputs, {t0, t1, BSX}, __LINE__, __FILE__, "", lparams);
 
   NVF_CHECK(
       ke.compiledKernel()->kernel()->summary().war_hazard_syncs_count == 1);

--- a/tests/cpp/test_gpu2.cpp
+++ b/tests/cpp/test_gpu2.cpp
@@ -139,13 +139,11 @@ TEST_F(NVFuserTest, FusionGlobalIntermediateDefaultSchedule_CUDA) {
   at::Tensor t2 = at::randn({M, N}, options);
   at::Tensor t3 = at::randn({M, N}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2, t3};
-
   KernelExecutor ke;
   ke.compile(&fusion, {t0, t1, t2, t3});
   auto cg_outputs = ke.run({t0, t1, t2, t3});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1, t2, t3}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionConstCheck_CUDA) {
@@ -305,7 +303,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder1_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor aten_input = at::randn({10, 10}, options);
 
-  std::vector<at::Tensor> cg_outputs = {
+  auto cg_outputs = {
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options)};
@@ -342,7 +340,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder2_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor aten_input = at::randn({10, 10}, options);
 
-  std::vector<at::Tensor> cg_outputs = {
+  auto cg_outputs = {
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options)};
@@ -394,7 +392,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder3_CUDA) {
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     at::Tensor aten_input = at::randn({100}, options);
 
-    std::vector<at::Tensor> cg_outputs = {
+    auto cg_outputs = {
         at::empty_like(aten_input, options),
         at::empty_like(aten_input, options),
         at::empty_like(aten_input, options)};
@@ -436,18 +434,17 @@ TEST_F(NVFuserTest, FusionTraversalOrder4_CUDA) {
   at::Tensor t0 = at::randn({100}, options);
   at::Tensor t4 = at::rand_like(t0, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t4};
-  std::vector<at::Tensor> cg_outputs = {
+  auto cg_outputs = {
       at::empty_like(t0, options),
       at::empty_like(t0, options),
       at::empty_like(t0, options),
       at::empty_like(t0, options)};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  ke.run(aten_inputs, cg_outputs);
+  ke.compile(&fusion, {t0, t4});
+  ke.run({t0, t4}, cg_outputs);
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t4}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTraversalOrder5_CUDA) {
@@ -471,7 +468,7 @@ TEST_F(NVFuserTest, FusionTraversalOrder5_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor aten_input = at::randn({100}, options);
-  std::vector<at::Tensor> cg_outputs = {
+  auto cg_outputs = {
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options),
       at::empty_like(aten_input, options)};
@@ -616,7 +613,7 @@ TEST_F(NVFuserTest, FusionThreadPredicate_CUDA) {
 
   std::vector<at::Tensor> aten_outputs = {t3, t2};
 
-  std::vector<at::Tensor> cg_outputs = {
+  auto cg_outputs = {
       at::empty_like(aten_input, options), at::empty({numel_x}, options)};
 
   KernelExecutor ke;
@@ -899,11 +896,8 @@ TEST_F(NVFuserTest, FusionTrivialReduction2_CUDA) {
   at::Tensor t0 = at::randn({y, z}, options);
   at::Tensor t1 = at::randn({w, x, y, z}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0, t1});
+  testValidate(&fusion, cg_outputs.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTrivialReduction3_CUDA) {
@@ -926,11 +920,8 @@ TEST_F(NVFuserTest, FusionTrivialReduction3_CUDA) {
   at::Tensor t0 = at::randn({y, z}, options);
   at::Tensor t1 = at::randn({v, w, x, y, z}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0, t1});
+  testValidate(&fusion, cg_outputs.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionInputsIdLookup_CUDA) {
@@ -1155,10 +1146,10 @@ TEST_F(NVFuserTest, FusionBiasGeluFwd_CUDA) {
   auto at_input = at::randn(input_shape, options);
   auto at_bias = at::randn(bias_shape, options);
 
-  std::vector<c10::IValue> aten_inputs = {at_bias, at_input};
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {at_bias, at_input});
+  testValidate(
+      &fusion, cg_outputs.outputs, {at_bias, at_input}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBiasGeluBwd_CUDA) {
@@ -1221,18 +1212,16 @@ TEST_F(NVFuserTest, FusionBiasGeluBwd_CUDA) {
   auto at_bias = at::randn(bias_shape, options);
   auto at_grad = at::randn(input_shape, options);
 
-  std::vector<c10::IValue> aten_inputs = {at_grad, at_bias, at_input};
-
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
+  auto cg_outputs = scheduleAndRun(
+      &fusion, SchedulerType::PointWise, {at_grad, at_bias, at_input});
   auto tolerance_overwrite = ValidationConstants();
   // bump tolerance
   tolerance_overwrite.base_float_abs_tol = 3e-6;
   tolerance_overwrite.base_float_rel_tol = 4e-3;
   testValidate(
       &fusion,
-      cg_outputs,
-      aten_inputs,
+      cg_outputs.outputs,
+      {at_grad, at_bias, at_input},
       __LINE__,
       __FILE__,
       "",
@@ -1279,13 +1268,11 @@ TEST_F(NVFuserTest, FusionIssue459_CUDA) {
   auto t0 = at::randn({numel_x}, options);
   auto t1 = at::randn({numel_y, numel_x}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   nvfuser::KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSmemIndexingSimple_CUDA) {
@@ -1420,14 +1407,17 @@ TEST_F(NVFuserTest, FusionSmemIndexing_CUDA) {
       mul(t0.unsqueeze(2), t1.unsqueeze(0)).to(at::kDouble).sum(1);
 
   // A, B, m_tile_dim, split_k, intra_cta_tile
-  std::vector<c10::IValue> aten_inputs = {t0, t1, 3, 4, 5};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, 3, 4, 5});
+  auto cg_outputs = ke.run({t0, t1, 3, 4, 5});
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion,
+      cg_outputs,
+      {t0, t1, 3, 4, 5},
+      {aten_output},
+      __LINE__,
+      __FILE__);
 }
 
 // Reproducer of issue 408
@@ -1595,17 +1585,21 @@ TEST_F(NVFuserTest, FusionIssue367_CUDA) {
   at::Tensor t0 = at::randn({M, K}, options);
   at::Tensor t1 = at::randn({K, N}, options);
 
-  // A, B, m, split_k, block_k
-  std::vector<c10::IValue> aten_inputs = {t0, t1, 2, 2, 3};
   at::Tensor aten_output =
       mul(t0.unsqueeze(2), t1.unsqueeze(0)).to(at::kDouble).sum(1);
 
+  // A, B, m, split_k, block_k
   nvfuser::KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, 2, 2, 3});
+  auto cg_outputs = ke.run({t0, t1, 2, 2, 3});
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion,
+      cg_outputs,
+      {t0, t1, 2, 2, 3},
+      {aten_output},
+      __LINE__,
+      __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue468_CUDA) {
@@ -1676,13 +1670,11 @@ TEST_F(NVFuserTest, FusionIssue363_CUDA) {
   at::Tensor t0 = at::randn({M, K}, options);
   at::Tensor t1 = at::randn({K, N}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   nvfuser::KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue484_CUDA) {
@@ -1769,13 +1761,11 @@ TEST_F(NVFuserTest, FusionIssue382_CUDA) {
   auto t0 = at::randn({numel_x, numel_y}, options);
   auto t3 = at::randn({numel_x, numel_y, numel_z}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t3};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t3});
+  auto cg_outputs = ke.run({t0, t3});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t3}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue507_CUDA) {
@@ -1836,13 +1826,12 @@ TEST_F(NVFuserTest, FusionIssue532_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({M}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionLoopUnswitch_CUDA) {
@@ -1865,13 +1854,12 @@ TEST_F(NVFuserTest, FusionLoopUnswitch_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({M}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue549_CUDA) {
@@ -3031,11 +3019,9 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed3_CUDA) {
   at::Tensor t0 = at::randn({129, 127, 63, 65}, options);
   at::Tensor t1 = at::rand_like(t0, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto t0_t = t0.permute({3, 0, 1, 2});
   auto t1_t = t1.permute({3, 0, 1, 2});
@@ -3043,7 +3029,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed3_CUDA) {
   auto aten_output = t2.mul(t0_t);
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, t1}, {aten_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed4_CUDA) {
@@ -3109,11 +3095,9 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed4_CUDA) {
   at::Tensor t2 = at::rand_like(t0, options);
   at::Tensor t3 = at::rand_like(t0, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2, t3};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, t2, t3});
+  auto cg_outputs = ke.run({t0, t1, t2, t3});
 
   auto t0_t = t0.permute({3, 0, 1, 2});
   auto t1_t = t1.permute({3, 0, 1, 2});
@@ -3124,7 +3108,7 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed4_CUDA) {
   auto aten_output = t5.sub(t0_t);
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, t1, t2, t3}, {aten_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed5_CUDA) {
@@ -3157,17 +3141,15 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed5_CUDA) {
   at::Tensor t0 = at::randn({63, 65}, options);
   at::Tensor t1 = at::rand_like(t0, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto t2 = t0.t().add(2.0);
   auto aten_output = t1.t().mul(t2);
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, t1}, {aten_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed6_CUDA) {
@@ -3199,17 +3181,15 @@ TEST_F(NVFuserTest, FusionAdvancedComputeAtTransposed6_CUDA) {
   at::Tensor t0 = at::randn({63, 65}, options);
   at::Tensor t1 = at::rand_like(t0, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto t2 = t0.t().add(2.0);
   auto aten_output = t1.t().mul(t2);
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, t1}, {aten_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSegmentReducePointwise_CUDA) {
@@ -3423,16 +3403,16 @@ TEST_F(NVFuserTest, FusionSimpleVectorizeUnroll_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
-  at::Tensor input1 = at::randn({64, 2, 128}, options);
-  at::Tensor input2 = at::rand_like(input1);
-  at::Tensor output = at::empty_like(input1);
+  at::Tensor t1 = at::randn({64, 2, 128}, options);
+  at::Tensor t2 = at::rand_like(t1);
+  at::Tensor output = at::empty_like(t1);
 
   KernelExecutor ke;
-  ke.compile(&fusion, {input1, input2});
-  ke.run({input1, input2}, {output});
+  ke.compile(&fusion, {t1, t2});
+  ke.run({t1, t2}, {output});
 
-  at::Tensor tv2_ref = input2 + 2.0;
-  at::Tensor output_ref = input1 + tv2_ref;
+  at::Tensor tv2_ref = t2 + 2.0;
+  at::Tensor output_ref = t1 + tv2_ref;
 
   NVF_CHECK(output_ref.equal(output));
 }
@@ -3650,13 +3630,12 @@ TEST_F(NVFuserTest, FusionIssue633_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({dx, dy, dz}, options);
   at::Tensor t1 = at::randn({dx, dy, 1}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBroadcastAcrossComputeAt_CUDA) {
@@ -3683,13 +3662,12 @@ TEST_F(NVFuserTest, FusionBroadcastAcrossComputeAt_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({shape[0]}, options);
   at::Tensor t1 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwise_CUDA) {
@@ -3732,13 +3710,11 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwise_CUDA) {
   at::Tensor t0 = at::randn({bx, by}, options);
   at::Tensor t1 = at::randn({bx, by}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeContig_CUDA) {
@@ -3788,13 +3764,11 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeContig_CUDA) {
   at::Tensor t0 = at::randn({n, c, h, w}, options);
   at::Tensor t1 = at::randn({n, c, h, w}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicPass_CUDA) {
@@ -3849,13 +3823,11 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicPass_CUDA) {
   at::Tensor t0 = at::randn({n, c, h, w}, options);
   at::Tensor t1 = at::randn({n, c, h, w}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicFail_CUDA) {
@@ -3909,8 +3881,6 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedPointwiseMergeSymbolicFail_CUDA) {
   const int w = 23;
   at::Tensor t0 = at::randn({n, c, h, w}, options);
   at::Tensor t1 = at::randn({1, 1, 1, w}, options);
-
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
   // TODO: throw assertion - cannot merge non-contiguous vectorization axes
@@ -3966,15 +3936,13 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedRFactor_CUDA) {
   at::Tensor t0 = at::randn({bx, by}, options);
   at::Tensor t1 = at::randn({bx, by}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto aten_output = t0.add(t1).sum(1);
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, t1}, {aten_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedWrongDimFail_CUDA) {
@@ -4058,13 +4026,12 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStride_CUDA) {
       at::randn({bx, by}, options).index({"...", at::indexing::Slice(3)});
   at::Tensor t1 =
       at::randn({bx, by}, options).index({"...", at::indexing::Slice(3)});
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizeMisalignedStrideFail_CUDA) {
@@ -4112,14 +4079,13 @@ TEST_F(NVFuserTest, FusionVectorizeMisalignedStrideFail_CUDA) {
       at::randn({bx, by}, options).index({"...", at::indexing::Slice(3)});
   at::Tensor t1 =
       at::randn({bx, by}, options).index({"...", at::indexing::Slice(3)});
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
+  ke.compile(&fusion, {t0, t1});
 
   // Failure because the input + output tensors do not have the same stride
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.run(aten_inputs));
+  ASSERT_ANY_THROW(ke.run({t0, t1}));
 }
 
 TEST_F(NVFuserTest, FusionVectorization1_CUDA) {
@@ -4159,13 +4125,11 @@ TEST_F(NVFuserTest, FusionVectorization1_CUDA) {
   at::Tensor t0 = at::randn({bx, by}, options);
   at::Tensor t1 = at::randn({bx, by}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorization2_CUDA) {
@@ -4246,24 +4210,22 @@ TEST_F(NVFuserTest, FusionVectorization3_CUDA) {
   const int by = 2049;
   at::Tensor t0 = at::randn({bx, by}, options);
   at::Tensor t1 = at::randn({bx, by}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
+  ke.compile(&fusion, {t0, t1});
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.run(aten_inputs));
+  ASSERT_ANY_THROW(ke.run({t0, t1}));
 
-  aten_inputs[0] = t0.index({"...", at::indexing::Slice(1)});
-  aten_inputs[1] = t1.index({"...", at::indexing::Slice(1)});
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(ke.run(aten_inputs));
+  ASSERT_ANY_THROW(ke.run(
+      {t0.index({"...", at::indexing::Slice(1)}),
+       t1.index({"...", at::indexing::Slice(1)})}));
 
   t0 = at::randn({bx, 2048}, options).index({"...", at::indexing::Slice(4)});
   t1 = at::randn({bx, 2048}, options).index({"...", at::indexing::Slice(4)});
-  aten_inputs = {t0, t1};
-  auto cg_outputs = ke.run(aten_inputs);
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionVectorizationRFactor_CUDA) {
@@ -4311,19 +4273,17 @@ TEST_F(NVFuserTest, FusionVectorizationRFactor_CUDA) {
   at::Tensor t0 = at::randn({bx, by}, options);
   at::Tensor t1 = at::randn({bx, by}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto aten_output = t0.add(t1).sum(1);
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {aten_output}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, t1}, {aten_output}, __LINE__, __FILE__);
 
   auto t3 = t0.add(t1).sum(1);
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {t3}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, {t3}, __LINE__, __FILE__);
 }
 
 // Unswitched loops with extent one may omit else clause.
@@ -4374,13 +4334,12 @@ TEST_F(NVFuserTest, FusionSizeOneLoop1_CUDA) {
   at::Tensor t0 = at::randn({x}, options);
   at::Tensor t1 = at::randn({x, y}, options);
   at::Tensor t2 = at::randn({z, x, y}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, t2});
+  auto cg_outputs = ke.run({t0, t1, t2});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 // The unswitched loop has extent one but inner loops don't. The else
@@ -4408,13 +4367,12 @@ TEST_F(NVFuserTest, FusionSizeOneLoop2_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({x}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionValidateParallelize1_CUDA) {
@@ -4649,14 +4607,14 @@ TEST_F(NVFuserTest, FusionValidateParallelize8_CUDA) {
   tv2->computeAt(tv4, -1);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::arange(64, options).view({32, 2});
-  at::Tensor input1 = at::arange(32, options) * 0.01;
+  at::Tensor t0 = at::arange(64, options).view({32, 2});
+  at::Tensor t1 = at::arange(32, options) * 0.01;
 
   KernelExecutor ke;
-  ke.compile(&fusion, {input0, input1});
-  auto outputs = ke.run({input0, input1});
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, {input0, input1}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionValidateParallelize9_CUDA) {
@@ -4739,13 +4697,12 @@ TEST_F(NVFuserTest, FusionValidateParallelize10_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({s0}, options);
   at::Tensor t1 = at::randn({s0, s1}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Similar to ValidateParallelize10, tv2 has a shared loop axis
@@ -4785,13 +4742,12 @@ TEST_F(NVFuserTest, FusionValidateParallelize11_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({s0}, options);
   at::Tensor t1 = at::randn({s0, s1}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionDAGMerging_CUDA) {
@@ -4899,12 +4855,11 @@ TEST_F(NVFuserTest, FusionBlockReduceInSerialLoop_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({M, N, K}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBlockWelfordInSerialLoop_CUDA) {
@@ -4928,15 +4883,13 @@ TEST_F(NVFuserTest, FusionBlockWelfordInSerialLoop_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({M, N, K}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
   at::Tensor aten_avg = t0.mean({1, 2});
   at::Tensor aten_M2 = t0.var({1, 2}, false) * N * K;
-  testValidate(
-      &fusion, outputs, aten_inputs, {aten_avg, aten_M2}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, {aten_avg, aten_M2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionReductionPredicate_CUDA) {
@@ -5064,13 +5017,12 @@ TEST_F(NVFuserTest, FusionIssue757_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({numel_x, numel_y}, options);
   at::Tensor t3 = at::randn({numel_x, numel_y}, options);
-  std::vector<c10::IValue> inputs = {t0, t3};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0, t3});
+  auto outputs = ke.run({t0, t3});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t3}, __LINE__, __FILE__);
 }
 
 // See issue #759
@@ -5102,13 +5054,12 @@ TEST_F(NVFuserTest, FusionPredicatedBlockBroadcast_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({numel_x, numel_y}, options);
   at::Tensor t3 = at::randn({numel_x, numel_y}, options);
-  std::vector<c10::IValue> inputs = {t0, t3};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0, t3});
+  auto outputs = ke.run({t0, t3});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t3}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSegmentVerticalMerge_CUDA) {
@@ -5298,11 +5249,10 @@ TEST_F(NVFuserTest, FusionSingleElement_CUDA) {
   fusion.addOutput(tv2);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input = at::randn({}, options);
-  std::vector<c10::IValue> aten_inputs = {input};
+  at::Tensor t0 = at::randn({}, options);
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {t0}).outputs;
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBNBackwardRepro_CUDA) {
@@ -5359,19 +5309,18 @@ TEST_F(NVFuserTest, FusionBNBackwardRepro_CUDA) {
   fusion.addOutput(grads.grad_bias);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({batch, c, h, w}, options);
-  at::Tensor input1 = at::randn({c}, options);
-  at::Tensor input2 = at::randn_like(input1);
-  at::Tensor input3 = at::randn_like(input1);
-  at::Tensor input4 = at::randn_like(input1);
-  at::Tensor input5 = at::randn_like(input1);
-  at::Tensor input6 = at::randn_like(input0);
-  at::Tensor input7 = at::randn_like(input0);
+  at::Tensor t0 = at::randn({batch, c, h, w}, options);
+  at::Tensor t1 = at::randn({c}, options);
+  at::Tensor t2 = at::randn_like(t1);
+  at::Tensor t3 = at::randn_like(t1);
+  at::Tensor t4 = at::randn_like(t1);
+  at::Tensor t5 = at::randn_like(t1);
+  at::Tensor t6 = at::randn_like(t0);
+  at::Tensor t7 = at::randn_like(t0);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  std::vector<c10::IValue> inputs = {
-      input0, input1, input2, input3, input4, input5, input6, input7};
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs =
+      executor_cache.runFusionWithInputs({t0, t1, t2, t3, t4, t5, t6, t7});
 }
 
 // TODO: We only changed inputs, merge this with the test above.
@@ -5427,19 +5376,18 @@ TEST_F(NVFuserTest, FusionBNBackwardRepro2_CUDA) {
   fusion.addOutput(grads.grad_bias);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({batch, c, h, w}, options);
-  at::Tensor input1 = at::randn({c}, options);
-  at::Tensor input2 = at::randn_like(input1);
-  at::Tensor input3 = at::randn_like(input1);
-  at::Tensor input4 = at::randn_like(input1);
-  at::Tensor input5 = at::randn_like(input1);
-  at::Tensor input6 = at::randn_like(input0);
-  at::Tensor input7 = at::randn_like(input0);
+  at::Tensor t0 = at::randn({batch, c, h, w}, options);
+  at::Tensor t1 = at::randn({c}, options);
+  at::Tensor t2 = at::randn_like(t1);
+  at::Tensor t3 = at::randn_like(t1);
+  at::Tensor t4 = at::randn_like(t1);
+  at::Tensor t5 = at::randn_like(t1);
+  at::Tensor t6 = at::randn_like(t0);
+  at::Tensor t7 = at::randn_like(t0);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  std::vector<c10::IValue> inputs = {
-      input0, input1, input2, input3, input4, input5, input6, input7};
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs =
+      executor_cache.runFusionWithInputs({t0, t1, t2, t3, t4, t5, t6, t7});
 }
 
 TEST_F(NVFuserTest, FusionBNRepro_CUDA) {
@@ -5486,32 +5434,23 @@ TEST_F(NVFuserTest, FusionBNRepro_CUDA) {
   fusion.addOutput(result.invstd);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({batch, c, h, w}, options);
-  at::Tensor input2 = at::randn({c}, options);
-  at::Tensor input3 = at::randn_like(input2);
-  at::Tensor input4 = at::randn_like(input2);
-  at::Tensor input5 = at::randn_like(input2);
+  at::Tensor t1 = at::randn({batch, c, h, w}, options);
+  at::Tensor t2 = at::randn({c}, options);
+  at::Tensor t3 = at::randn_like(t2);
+  at::Tensor t4 = at::randn_like(t2);
+  at::Tensor t5 = at::randn_like(t2);
 
-  auto input1_ref = input1.clone();
-  auto input2_ref = input2.clone();
-  auto input3_ref = input3.clone();
-  auto input4_ref = input4.clone();
-  auto input5_ref = input5.clone();
+  auto t1_ref = t1.clone();
+  auto t2_ref = t2.clone();
+  auto t3_ref = t3.clone();
+  auto t4_ref = t4.clone();
+  auto t5_ref = t5.clone();
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  std::vector<c10::IValue> aten_inputs = {
-      input1, input2, input3, input4, input5};
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t1, t2, t3, t4, t5});
 
   auto at_results = at::native_batch_norm(
-      input1_ref,
-      input2_ref,
-      input3_ref,
-      input4_ref,
-      input5_ref,
-      kTraining,
-      kMomentum,
-      kEps);
+      t1_ref, t2_ref, t3_ref, t4_ref, t5_ref, kTraining, kMomentum, kEps);
 
   auto at_output = std::get<0>(at_results);
   auto at_mean = std::get<1>(at_results);
@@ -5520,7 +5459,12 @@ TEST_F(NVFuserTest, FusionBNRepro_CUDA) {
   std::vector<at::Tensor> aten_outputs = {at_output, at_mean, at_invstd};
 
   testValidate(
-      &fusion, cg_outputs, aten_inputs, aten_outputs, __LINE__, __FILE__);
+      &fusion,
+      cg_outputs,
+      {t1, t2, t3, t4, t5},
+      aten_outputs,
+      __LINE__,
+      __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBNRepro2_CUDA) {
@@ -5559,19 +5503,18 @@ TEST_F(NVFuserTest, FusionBNRepro2_CUDA) {
   fusion.addOutput(result.invstd);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({batch, c, h, w}, options);
+  at::Tensor t1 = at::randn({batch, c, h, w}, options);
 
-  auto input1_ref = input1.clone();
+  auto t1_ref = t1.clone();
   at::Tensor r_m;
   at::Tensor r_v;
   at::Tensor weight;
   at::Tensor bias;
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  std::vector<c10::IValue> aten_inputs = {input1};
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionZeroSizeTensorPW_CUDA) {
@@ -5596,15 +5539,13 @@ TEST_F(NVFuserTest, FusionZeroSizeTensorPW_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
-  at::Tensor input0 = at::randn({2}, options);
-  at::Tensor input1 = at::randn({0}, options);
-  std::vector<c10::IValue> aten_inputs = {input0, input1};
+  at::Tensor t0 = at::randn({2}, options);
+  at::Tensor t1 = at::randn({0}, options);
 
   // Fails at schedule pointwise because our (maybe only) size-0 check is in
   // binding input sizes which the scheduler ends up calling.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
-  ASSERT_ANY_THROW(SchedulerEntry::scheduleWith(
-      &fusion, SchedulerType::PointWise, aten_inputs));
+  ASSERT_ANY_THROW(scheduleAndRun(&fusion, SchedulerType::PointWise, {t0, t1}));
 }
 
 TEST_F(NVFuserTest, FusionZeroSizeTensorReduction_CUDA) {
@@ -5625,18 +5566,16 @@ TEST_F(NVFuserTest, FusionZeroSizeTensorReduction_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
-  at::Tensor input0 = at::randn({2, 4}, options);
-  at::Tensor input1 = at::randn({0}, options);
-  std::vector<c10::IValue> aten_inputs({input0, input1});
-  auto cg_results =
-      scheduleAndRun(&fusion, SchedulerType::Reduction, aten_inputs, false);
-  auto aten_output2 = input0.sum({1});
+  at::Tensor t0 = at::randn({2, 4}, options);
+  at::Tensor t1 = at::randn({0}, options);
+  auto cg_results = scheduleAndRun(&fusion, SchedulerType::Reduction, {t0, t1});
+  auto aten_output2 = t0.sum({1});
   at::Tensor aten_output3 = at::empty({0}, options);
 
   testValidate(
       &fusion,
       cg_results.outputs,
-      aten_inputs,
+      {t0, t1},
       {aten_output2, aten_output3},
       __LINE__,
       __FILE__,
@@ -5664,18 +5603,18 @@ TEST_F(NVFuserTest, FusionZeroSizeTensorNormalization_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
-  at::Tensor input0 = at::randn({2, 4}, options);
-  at::Tensor input1 = at::randn({0}, options);
+  at::Tensor t0 = at::randn({2, 4}, options);
+  at::Tensor t1 = at::randn({0}, options);
 
-  auto cg_results = scheduleAndRun(
-      &fusion, SchedulerType::OuterPersistent, {input0, input1}, false);
-  auto aten_output2 = input0.sum({0}).add(input0);
+  auto cg_results =
+      scheduleAndRun(&fusion, SchedulerType::OuterPersistent, {t0, t1}, false);
+  auto aten_output2 = t0.sum({0}).add(t0);
   at::Tensor aten_output3 = at::empty({0}, options);
 
   testValidate(
       &fusion,
       cg_results.outputs,
-      {input0, input1},
+      {t0, t1},
       {aten_output2, aten_output3},
       __LINE__,
       __FILE__,
@@ -6004,16 +5943,15 @@ TEST_F(NVFuserTest, FusionSimpleWarp_CUDA) {
   tv0->computeAt(tv3, -1, ComputeAtMode::MostInlined);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({16, 128}, options);
+  at::Tensor t1 = at::randn({16, 128}, options);
 
-  auto at_output = input1.sum({1}, true).add(input1);
+  auto at_output = t1.sum({1}, true).add(t1);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
 
-  testValidate(
-      fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
+  testValidate(fusion.get(), outputs, {t1}, {at_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSimpleWarpPad_CUDA) {
@@ -6053,15 +5991,14 @@ TEST_F(NVFuserTest, FusionSimpleWarpPad_CUDA) {
   tv0->computeAt(tv3, -1, ComputeAtMode::MostInlined);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({16, 127}, options);
+  at::Tensor t1 = at::randn({16, 127}, options);
 
-  auto at_output = input1.sum({1}, true).add(input1);
+  auto at_output = t1.sum({1}, true).add(t1);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
-  testValidate(
-      fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
+  testValidate(fusion.get(), outputs, {t1}, {at_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionWarpPadMergeSplit_CUDA) {
@@ -6098,15 +6035,14 @@ TEST_F(NVFuserTest, FusionWarpPadMergeSplit_CUDA) {
   tv0->computeAt(tv3, -1, ComputeAtMode::MostInlined);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({16, 17, 128}, options);
+  at::Tensor t1 = at::randn({16, 17, 128}, options);
 
-  auto at_output = input1.sum({1, 2}, true).add(input1);
+  auto at_output = t1.sum({1, 2}, true).add(t1);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
-  testValidate(
-      fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
+  testValidate(fusion.get(), outputs, {t1}, {at_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSerialWarpReduction_CUDA) {
@@ -6140,15 +6076,14 @@ TEST_F(NVFuserTest, FusionSerialWarpReduction_CUDA) {
   tv0->computeAt(tv3, -1, ComputeAtMode::MostInlined);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({16, 17, 128}, options);
+  at::Tensor t1 = at::randn({16, 17, 128}, options);
 
-  auto at_output = input1.sum({1, 2}, true).add(input1);
+  auto at_output = t1.sum({1, 2}, true).add(t1);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
-  testValidate(
-      fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
+  testValidate(fusion.get(), outputs, {t1}, {at_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTrivialWarpReduction_CUDA) {
@@ -6185,15 +6120,14 @@ TEST_F(NVFuserTest, FusionTrivialWarpReduction_CUDA) {
   tv0->computeAt(tv3, -1, ComputeAtMode::MostInlined);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({17, 18, 128, 1}, options);
+  at::Tensor t1 = at::randn({17, 18, 128, 1}, options);
 
-  auto at_output = input1.sum({1, 2, 3}, true).add(input1);
+  auto at_output = t1.sum({1, 2, 3}, true).add(t1);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
-  testValidate(
-      fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
+  testValidate(fusion.get(), outputs, {t1}, {at_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionMultipleDimBinding_CUDA) {
@@ -6239,19 +6173,19 @@ TEST_F(NVFuserTest, FusionMultipleDimBinding_CUDA) {
   tv0->computeAt(tv3, -1, ComputeAtMode::MostInlined);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({16, 128}, options);
-  at::Tensor input2 = at::randn({16, 128}, options);
+  at::Tensor t1 = at::randn({16, 128}, options);
+  at::Tensor t2 = at::randn({16, 128}, options);
 
-  auto at_output = input1.sum({1}, true).add(input1);
+  auto at_output = t1.sum({1}, true).add(t1);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1, input2});
-  auto outputs = ke.run({input1, input2});
+  ke.compile(fusion.get(), {t1, t2});
+  auto outputs = ke.run({t1, t2});
   testValidate(
       fusion.get(),
       outputs,
-      {input1, input2},
-      {at_output, input1 + input2},
+      {t1, t2},
+      {at_output, t1 + t2},
       __LINE__,
       __FILE__);
 }
@@ -6280,12 +6214,12 @@ TEST_F(NVFuserTest, FusionPadNoWarpReduce_CUDA) {
   tv3->axis(0)->parallelize(ParallelType::TIDy);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({16, 31}, options);
+  at::Tensor t1 = at::randn({16, 31}, options);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
-  testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
+  testValidate(fusion.get(), outputs, {t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionWarpMutipleThreadDim_CUDA) {
@@ -6313,15 +6247,14 @@ TEST_F(NVFuserTest, FusionWarpMutipleThreadDim_CUDA) {
   tv0->computeAt(tv2, 2);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({16, 31}, options);
+  at::Tensor t1 = at::randn({16, 31}, options);
 
-  auto at_output = (input1 + 1).sum({1});
+  auto at_output = (t1 + 1).sum({1});
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
-  testValidate(
-      fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
+  testValidate(fusion.get(), outputs, {t1}, {at_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionWarpReduceUnrollOuterLoop_CUDA) {
@@ -6364,15 +6297,14 @@ TEST_F(NVFuserTest, FusionWarpReduceUnrollOuterLoop_CUDA) {
   tv0->computeAt(tv3, -1, ComputeAtMode::MostInlined);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({16, 128}, options);
+  at::Tensor t1 = at::randn({16, 128}, options);
 
-  auto at_output = input1.sum({1}, true).add(input1);
+  auto at_output = t1.sum({1}, true).add(t1);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
-  testValidate(
-      fusion.get(), outputs, {input1}, {at_output}, __LINE__, __FILE__);
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
+  testValidate(fusion.get(), outputs, {t1}, {at_output}, __LINE__, __FILE__);
 }
 
 // Repro of issue #1579
@@ -6459,14 +6391,12 @@ TEST_F(NVFuserTest, FusionSegfaultReduction_CUDA) {
   fusion.addOutput(output1);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({batch, c, h, w}, options);
-  at::Tensor input1 = at::randn({batch, c, h, w}, options);
+  at::Tensor t0 = at::randn({batch, c, h, w}, options);
+  at::Tensor t1 = at::randn({batch, c, h, w}, options);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  std::vector<c10::IValue> inputs = {input0, input1};
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBufferReuseBroadCastMultiVisit_CUDA) {
@@ -6755,11 +6685,10 @@ TEST_F(NVFuserTest, FusionIssue1016_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({numel_x, numel_y}, options);
-  std::vector<c10::IValue> inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
   testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
@@ -6786,13 +6715,12 @@ TEST_F(NVFuserTest, FusionIssue1021_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({10}, options);
-  std::vector<c10::IValue> inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Reproducer of issue #1053
@@ -6818,16 +6746,16 @@ TEST_F(NVFuserTest, FusionNonUniqueThreadDim_CUDA) {
   tv2->axis(0)->parallelize(ParallelType::TIDx);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({32}, options);
+  at::Tensor t1 = at::randn({32}, options);
 
-  auto at_tv1 = (input1).sum({0});
-  auto at_tv2 = input1 + 1;
+  auto at_tv1 = (t1).sum({0});
+  auto at_tv2 = t1 + 1;
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
   testValidate(
-      fusion.get(), outputs, {input1}, {at_tv1, at_tv2}, __LINE__, __FILE__);
+      fusion.get(), outputs, {t1}, {at_tv1, at_tv2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionParallelDimensionMap1_CUDA) {
@@ -6858,13 +6786,13 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap1_CUDA) {
       pdmap.get(ParallelType::TIDx)->as<NamedScalar>()->name() == "blockDim.x");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({32}, options);
+  at::Tensor t1 = at::randn({32}, options);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
 
-  testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
+  testValidate(fusion.get(), outputs, {t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionParallelDimensionMap2_CUDA) {
@@ -6894,14 +6822,14 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap2_CUDA) {
       pdmap.get(ParallelType::TIDx)->as<NamedScalar>()->name() == "blockDim.x");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({11}, options);
-  at::Tensor input2 = at::randn({11, 13}, options);
+  at::Tensor t1 = at::randn({11}, options);
+  at::Tensor t2 = at::randn({11, 13}, options);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1, input2});
-  auto outputs = ke.run({input1, input2});
+  ke.compile(fusion.get(), {t1, t2});
+  auto outputs = ke.run({t1, t2});
 
-  testValidate(fusion.get(), outputs, {input1, input2}, __LINE__, __FILE__);
+  testValidate(fusion.get(), outputs, {t1, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionParallelDimensionMap3_CUDA) {
@@ -6943,13 +6871,13 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap3_CUDA) {
   ASSERT_EQ(pdmap.get(ParallelType::TIDy)->value(), 10);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({13}, options);
+  at::Tensor t1 = at::randn({13}, options);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {input1});
-  auto outputs = ke.run({input1});
+  ke.compile(fusion.get(), {t1});
+  auto outputs = ke.run({t1});
 
-  testValidate(fusion.get(), outputs, {input1}, __LINE__, __FILE__);
+  testValidate(fusion.get(), outputs, {t1}, __LINE__, __FILE__);
 }
 
 // Parallelizing merged broadcast domains
@@ -6988,14 +6916,14 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap4_CUDA) {
       pdmap.get(ParallelType::TIDx)->as<NamedScalar>()->name() == "blockDim.x");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({13}, options);
-  at::Tensor input2 = at::randn({15, 13}, options);
+  at::Tensor t1 = at::randn({13}, options);
+  at::Tensor t2 = at::randn({15, 13}, options);
 
   KernelExecutor ke;
-  ke.compile(&fusion, {input1, input2});
-  auto outputs = ke.run({input1, input2});
+  ke.compile(&fusion, {t1, t2});
+  auto outputs = ke.run({t1, t2});
 
-  testValidate(&fusion, outputs, {input1, input2}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t1, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionParallelDimensionMap5_CUDA) {
@@ -7032,14 +6960,14 @@ TEST_F(NVFuserTest, FusionParallelDimensionMap5_CUDA) {
       pdmap.get(ParallelType::TIDy)->as<NamedScalar>()->name() == "blockDim.y");
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({13}, options);
-  at::Tensor input2 = at::randn({13, 15}, options);
+  at::Tensor t1 = at::randn({13}, options);
+  at::Tensor t2 = at::randn({13, 15}, options);
 
   KernelExecutor ke;
-  ke.compile(&fusion, {input1, input2});
-  auto outputs = ke.run({input1, input2});
+  ke.compile(&fusion, {t1, t2});
+  auto outputs = ke.run({t1, t2});
 
-  testValidate(&fusion, outputs, {input1, input2}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t1, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSegmenterCombineReductionsCycleRepro_CUDA) {
@@ -7134,10 +7062,7 @@ TEST_F(NVFuserTest, FusionSegmenterCombineReductionsCycleRepro_CUDA) {
   std::vector<at::Tensor> aten_inputs = {
       at_t0, at_t1, at_t3, at_t5, at_t7, at_t11, at_t13, at_t15, at_t17};
 
-  KernelArgumentHolder args;
-  args.setDeviceIndex(0);
-  args.push(aten_inputs);
-  args.push(at_d56);
+  KernelArgumentHolder args({aten_inputs, at_d56});
 
   for (auto i : c10::irange(5)) {
     (void)i; // Suppress unused variable warning
@@ -7187,13 +7112,12 @@ TEST_F(NVFuserTest, FusionSerialAndParallelIndexing_CUDA) {
   const int nx = 11;
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({nx}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Repro of issue #1105
@@ -7240,13 +7164,12 @@ TEST_F(NVFuserTest, FusionWARSyncAliasedSmem_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({17}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue1099_CUDA) {
@@ -7291,13 +7214,12 @@ TEST_F(NVFuserTest, FusionIssue1099_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({17}, options);
   at::Tensor t3 = at::randn({19}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t3};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t3});
+  auto outputs = ke.run({t0, t3});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t3}, __LINE__, __FILE__);
 }
 
 // Repro of issue #1080
@@ -7333,13 +7255,12 @@ TEST_F(NVFuserTest, FusionUnswitchPredicate_CUDA) {
   const int ny = 10;
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({nx, ny}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue1189_CUDA) {
@@ -7405,13 +7326,12 @@ TEST_F(NVFuserTest, FusionIssue1052_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({10}, options);
   at::Tensor t1 = at::randn({100}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Repro of issue #1115
@@ -7435,11 +7355,11 @@ TEST_F(NVFuserTest, FusionPointwiseBroadcast_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor at_x = at::randn(input_shape, options);
   at::Tensor at_bias = at::randn(input_shape, options);
-  std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
 
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {at_x, at_bias});
+  testValidate(
+      &fusion, cg_outputs.outputs, {at_x, at_bias}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionPointwiseVectorize_CUDA) {
@@ -7511,13 +7431,12 @@ TEST_F(NVFuserTest, FusionSmemAliasSerial_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({10}, options);
   at::Tensor t4 = at::randn({1024}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t4};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t4});
+  auto outputs = ke.run({t0, t4});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t4}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions_CUDA) {
@@ -7541,13 +7460,12 @@ TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({17}, options);
   at::Tensor t2 = at::randn({19}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t2};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t2});
+  auto outputs = ke.run({t0, t2});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionGridWelfordWithNonExactParallelDimensions_CUDA) {
@@ -7571,16 +7489,15 @@ TEST_F(NVFuserTest, FusionGridWelfordWithNonExactParallelDimensions_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({17}, options);
   at::Tensor t2 = at::randn({19}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t2};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t2});
+  auto outputs = ke.run({t0, t2});
 
   auto ref1 = t0 + 1;
   auto ref2 = mean(t2, {0});
 
-  testValidate(&fusion, outputs, aten_inputs, {ref1, ref2}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t2}, {ref1, ref2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions2_CUDA) {
@@ -7621,10 +7538,9 @@ TEST_F(NVFuserTest, FusionGridReductionWithNonExactParallelDimensions2_CUDA) {
   at::Tensor t0 = at::randn({2, 3}, options);
   at::Tensor t2 = at::randn({5, 6, 7}, options);
   at::Tensor t4 = at::randn({8, 9, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t2, t4};
-  auto outputs = ke.run(aten_inputs);
+  auto outputs = ke.run({t0, t2, t4});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t2, t4}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionGridWelfordWithNonExactParallelDimensions2_CUDA) {
@@ -7665,15 +7581,14 @@ TEST_F(NVFuserTest, FusionGridWelfordWithNonExactParallelDimensions2_CUDA) {
   at::Tensor t0 = at::randn({2, 3}, options);
   at::Tensor t2 = at::randn({5, 6, 7}, options);
   at::Tensor t4 = at::randn({8, 9, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t2, t4};
-  auto outputs = ke.run(aten_inputs);
+  auto outputs = ke.run({t0, t2, t4});
 
   auto ref1 = t0.mean(at::IntArrayRef{0, 1});
   auto ref2 = t2 + 1;
   auto ref3 = t4 + 1;
 
   testValidate(
-      &fusion, outputs, aten_inputs, {ref1, ref2, ref3}, __LINE__, __FILE__);
+      &fusion, outputs, {t0, t2, t4}, {ref1, ref2, ref3}, __LINE__, __FILE__);
 }
 
 // Repro of issue #1102
@@ -7725,16 +7640,15 @@ TEST_F(NVFuserTest, FusionPredicateParallelizedDomains_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({17}, options);
   at::Tensor t4 = at::randn({19}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t4};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t4});
+  auto outputs = ke.run({t0, t4});
 
   auto ref1 = t0 + 3;
   auto ref2 = sum(t4 + 4);
 
-  testValidate(&fusion, outputs, aten_inputs, {ref1, ref2}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t4}, {ref1, ref2}, __LINE__, __FILE__);
 }
 
 // Repro of #1102 and #1129
@@ -7787,13 +7701,12 @@ TEST_F(NVFuserTest, FusionSmemPredicateUnswitch_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({17}, options);
   at::Tensor t1 = at::randn({19}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Repro of issue #1136
@@ -7836,11 +7749,10 @@ TEST_F(NVFuserTest, FusionFloatPow_CUDA) {
   at::Tensor t0 = at::randn({1000}, options);
   // Negative inputs cause nan in Fuesr as use_fast_math is enabled
   t0 = abs(t0);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
   auto p4 = at::pow(t0, 4);
   auto p2 = at::pow(t0, 2);
@@ -7848,12 +7760,7 @@ TEST_F(NVFuserTest, FusionFloatPow_CUDA) {
   auto t6 = t0 + std::pow(3, 3);
 
   testValidate(
-      &fusion,
-      outputs,
-      aten_inputs,
-      {p4, p2, p2, p3, p3, t6},
-      __LINE__,
-      __FILE__);
+      &fusion, outputs, {t0}, {p4, p2, p2, p3, p3, t6}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue1127_CUDA) {
@@ -7905,13 +7812,12 @@ TEST_F(NVFuserTest, FusionThreadPredicateUnswitch_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({10, 1024}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionNonContigOutputs_CUDA) {
@@ -7955,11 +7861,10 @@ TEST_F(NVFuserTest, FusionTestWarpSoftMax_CUDA) {
 
   // Setup runtime input
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor aten_input = at::randn({8, 16 * 197}, options);
-  std::vector<c10::IValue> aten_inputs({aten_input});
+  at::Tensor t0 = at::randn({8, 16 * 197}, options);
 
   // Schedule through magic scheduler
-  SchedulerRuntimeInfo runtime_info(&fusion, aten_inputs);
+  SchedulerRuntimeInfo runtime_info(&fusion, {t0});
   NVF_CHECK(Schedule::canSchedule(
       SchedulerType::InnerPersistent, &fusion, runtime_info));
   auto scheduler =
@@ -7979,10 +7884,10 @@ TEST_F(NVFuserTest, FusionTestWarpSoftMax_CUDA) {
 
   // Test result
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
-  auto ref_output = at::_softmax(aten_input, 1, false);
-  testValidate(&fusion, outputs, aten_inputs, {ref_output}, __LINE__, __FILE__);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
+  auto ref_output = at::_softmax(t0, 1, false);
+  testValidate(&fusion, outputs, {t0}, {ref_output}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue1133_CUDA) {
@@ -8050,17 +7955,16 @@ TEST_F(NVFuserTest, FusionIssue1133_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({99, 101}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
   auto ref = (t0 + 1).sum({1}) + 1;
 
   GTEST_SKIP() << "NOTE: disabling 1133 test for cuda12.2 failure. "
                << "See issue: https://github.com/NVIDIA/Fuser/issues/615";
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionRfactorContigIDs_CUDA) {
@@ -8084,15 +7988,14 @@ TEST_F(NVFuserTest, FusionRfactorContigIDs_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({99, 101}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
   auto ref = t0.sum({1});
 
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIssue1223_CUDA) {

--- a/tests/cpp/test_gpu2.cpp
+++ b/tests/cpp/test_gpu2.cpp
@@ -5568,15 +5568,16 @@ TEST_F(NVFuserTest, FusionZeroSizeTensorReduction_CUDA) {
 
   at::Tensor t0 = at::randn({2, 4}, options);
   at::Tensor t1 = at::randn({0}, options);
-  auto cg_results = scheduleAndRun(&fusion, SchedulerType::Reduction, {t0, t1});
-  auto aten_output2 = t0.sum({1});
-  at::Tensor aten_output3 = at::empty({0}, options);
+  auto cg_results =
+      scheduleAndRun(&fusion, SchedulerType::Reduction, {t0, t1}, false);
+  auto t2 = t0.sum({1});
+  at::Tensor t3 = at::empty({0}, options);
 
   testValidate(
       &fusion,
       cg_results.outputs,
       {t0, t1},
-      {aten_output2, aten_output3},
+      {t2, t3},
       __LINE__,
       __FILE__,
       "",
@@ -5608,14 +5609,14 @@ TEST_F(NVFuserTest, FusionZeroSizeTensorNormalization_CUDA) {
 
   auto cg_results =
       scheduleAndRun(&fusion, SchedulerType::OuterPersistent, {t0, t1}, false);
-  auto aten_output2 = t0.sum({0}).add(t0);
-  at::Tensor aten_output3 = at::empty({0}, options);
+  auto t2 = t0.sum({0}).add(t0);
+  at::Tensor t3 = at::empty({0}, options);
 
   testValidate(
       &fusion,
       cg_results.outputs,
       {t0, t1},
-      {aten_output2, aten_output3},
+      {t2, t3},
       __LINE__,
       __FILE__,
       "",
@@ -7062,7 +7063,9 @@ TEST_F(NVFuserTest, FusionSegmenterCombineReductionsCycleRepro_CUDA) {
   std::vector<at::Tensor> aten_inputs = {
       at_t0, at_t1, at_t3, at_t5, at_t7, at_t11, at_t13, at_t15, at_t17};
 
-  KernelArgumentHolder args({aten_inputs, at_d56});
+  KernelArgumentHolder args;
+  args.push({aten_inputs});
+  args.push(PolymorphicValue(at_d56));
 
   for (auto i : c10::irange(5)) {
     (void)i; // Suppress unused variable warning

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -529,13 +529,12 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization1_CUDA) {
   auto t0 = at::randn({10, 1}, options);
   auto t1 = at::randn({10, 20}, options);
   auto t2 = at::randn({10, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, t2});
+  auto outputs = ke.run({t0, t1, t2});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBroadcastConcretization2_CUDA) {
@@ -572,15 +571,14 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization2_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({10, 11}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
   auto t3 = t0.sum().unsqueeze(-1).unsqueeze(-1);
 
-  testValidate(&fusion, outputs, aten_inputs, {t3}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, {t3}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionBroadcastConcretization3_CUDA) {
@@ -617,13 +615,12 @@ TEST_F(NVFuserTest, FusionBroadcastConcretization3_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(input_shape, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Merging non-broadcast and broadcast domains
@@ -2540,13 +2537,12 @@ TEST_F(NVFuserTest, FusionUnsqueeze1_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({10, 11}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSqueeze1_CUDA) {
@@ -2575,13 +2571,12 @@ TEST_F(NVFuserTest, FusionSqueeze1_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({10, 11}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionContigPredicate_CUDA) {
@@ -2666,10 +2661,9 @@ TEST_F(NVFuserTest, FusionRepro1713_CUDA) {
   // with a different extent at the second axis
   at::Tensor t1 = at::randn({1024, 123}, options);
   at::Tensor t2 = at::randn({1024}, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   testValidate(
       executor_cache.fusion(), cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
@@ -2861,10 +2855,8 @@ TEST_F(NVFuserTest, FusionReproNoncontigBroadcast_CUDA) {
 
   fusion->addOutput(tv2);
 
-  std::vector<c10::IValue> aten_inputs({t0, t1});
-
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   testValidate(
       executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -3017,13 +3009,11 @@ TEST_F(NVFuserTest, FusionIgnoreZeroDimReduction_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({12345}, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Repro of issue #1770
@@ -3045,20 +3035,14 @@ TEST_F(NVFuserTest, FusionIssue1770Repro_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn(shape, options);
   at::Tensor t1 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   auto ref = where(t0 >= t1, 1.0, 2.0);
 
   testValidate(
-      executor_cache.fusion(),
-      cg_outputs,
-      aten_inputs,
-      {ref},
-      __LINE__,
-      __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTransformPropagatorSelector_CUDA) {
@@ -3395,13 +3379,12 @@ TEST_F(NVFuserTest, FusionIssueRepro1844_CUDA) {
   at::Tensor b = at::randn(shape, options);
   at::Tensor c = at::randn(shape, options);
   auto mask = at::gt(c, 0.0f);
-  std::vector<c10::IValue> aten_inputs = {a, b, mask};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({a, b, mask});
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, {a, b, mask}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionInsertMagicZero1_CUDA) {
@@ -3479,14 +3462,13 @@ TEST_F(NVFuserTest, FusionExpandRepro1860_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
-  at::Tensor input1 = at::randn({1, 2, 3}, options);
-  at::Tensor input2 = at::randn({1, 2, 3}, options);
-  at::Tensor input3 = at::randn({1, 2, 3}, options);
-  at::Tensor input4 = at::randn({1, 1, 1}, options).expand({1, 2, 3});
-  std::vector<c10::IValue> aten_inputs = {input1, input2, input3, input4};
+  at::Tensor t1 = at::randn({1, 2, 3}, options);
+  at::Tensor t2 = at::randn({1, 2, 3}, options);
+  at::Tensor t3 = at::randn({1, 2, 3}, options);
+  at::Tensor t4 = at::randn({1, 1, 1}, options).expand({1, 2, 3});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t1, t2, t3, t4});
 }
 
 TEST_F(NVFuserTest, FusionExpandReduce_CUDA) {
@@ -3567,14 +3549,12 @@ TEST_F(NVFuserTest, FusionExpandBadShapeTest_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   // Incompatible shapes
-  at::Tensor input1 = at::randn({2, 3}, options);
+  at::Tensor t1 = at::randn({2, 3}, options);
   // Passing expand size of 5, not 10. Should cause an error
-  at::Tensor input4 = at::randn({2, 1}, options).expand({2, 5});
-
-  std::vector<c10::IValue> aten_inputs = {input1, input4};
+  at::Tensor t4 = at::randn({2, 1}, options).expand({2, 5});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  ASSERT_ANY_THROW(executor_cache.runFusionWithInputs(aten_inputs));
+  ASSERT_ANY_THROW(executor_cache.runFusionWithInputs({t1, t4}));
 }
 
 TEST_F(
@@ -3597,11 +3577,9 @@ TEST_F(
   at::Tensor t0 = at::randn({100, 100, 10}, options);
   at::Tensor t1 = at::randn({10, 20}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
-
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {t0, t1}).outputs;
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionPrint_CUDA) {
@@ -3768,12 +3746,12 @@ TEST_F(NVFuserTest, FusionScheduleTransposeRepro1_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor input0 = at::randn({1, 1, 333, 1}, options);
-  at::Tensor input1 = at::randn({1, 1, 333, 1}, options);
+  at::Tensor t1 = at::randn({1, 1, 333, 1}, options);
 
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::Transpose, {input0, input1}, false)
+      scheduleAndRun(&fusion, SchedulerType::Transpose, {input0, t1}, false)
           .outputs;
-  testValidate(&fusion, cg_outputs, {input0, input1}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {input0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionPredicateUnshare_CUDA) {
@@ -3846,10 +3824,7 @@ TEST_F(NVFuserTest, AsyncCompilation_CUDA) {
   at::Tensor t2 = at::randn({8, 5}, options);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
-
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   NVF_CHECK(
       executor_cache.getMostRecentKernelRuntime()->isSegmented(),
@@ -3862,7 +3837,7 @@ TEST_F(NVFuserTest, AsyncCompilation_CUDA) {
       "segmentation didn't happen as expected");
 
   testValidate(
-      executor_cache.fusion(), outputs, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionMergeBroadcastingTrivialReduction1_CUDA) {
@@ -3990,13 +3965,12 @@ TEST_F(NVFuserTest, FusionReplayTrivialReductionAndBroadcast2_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(fusion_ptr.get(), aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(fusion_ptr.get(), {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionSimpleAmperePipeline_CUDA) {
@@ -4020,7 +3994,7 @@ TEST_F(NVFuserTest, FusionSimpleAmperePipeline_CUDA) {
   tv_cache->circularBuffer(10);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input1 = at::randn({255}, options);
+  at::Tensor t1 = at::randn({255}, options);
 
   // Add check that the cp async op has an inlined predicate.
   class InlinedCpAsyncPredChecker : public kir::IrVisitor {
@@ -4058,17 +4032,17 @@ TEST_F(NVFuserTest, FusionSimpleAmperePipeline_CUDA) {
   // requires ampere+ GPU
   if (!deviceMajorMinorCheck(8)) {
     ASSERT_THAT(
-        [&]() { ke.compile(&fusion, {input1}); },
+        [&]() { ke.compile(&fusion, {t1}); },
         testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
             "Reason: LoadStoreOpType::CpAsync requires Ampere")));
     GTEST_SKIP() << "skipping tests on pre-AMPERE GPUs";
   } else {
-    ke.compile(&fusion, {input1});
+    ke.compile(&fusion, {t1});
   }
 
-  auto cg_outputs = ke.run({input1});
+  auto cg_outputs = ke.run({t1});
 
-  testValidate(&fusion, cg_outputs, {input1}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionExpandedInput_CUDA) {
@@ -4246,58 +4220,13 @@ TEST_F(NVFuserTest, FusionRepro2094_CUDA) {
   }
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  std::vector<c10::IValue> inputs;
-  std::vector<at::Tensor> outputs;
-
-  {
-    auto t0 = at::randn({768}, options);
-    inputs.push_back((c10::IValue)t0);
-    auto t1 = at::randn({768}, options);
-    inputs.push_back((c10::IValue)t1);
-    auto t2 = at::randn({1024, 768}, options).to(at::ScalarType::Half);
-    inputs.push_back((c10::IValue)t2);
-    auto t3 = t0.unsqueeze(0).unsqueeze(1).expand({1, 1024, 768});
-    auto t4 = t1.unsqueeze(0).unsqueeze(1).expand({1, 1024, 768});
-    auto t5 = t2.view({1, 1024, 768});
-    auto t6 = t5.to(at::ScalarType::Float);
-    auto s7 = 0.5;
-    auto t8 = at::mul(t6, s7);
-    auto s9 = 0.707107;
-    auto t10 = at::mul(t6, s9);
-    auto t11 = at::erf(t10);
-    auto s12 = 1.0;
-    auto t13 = at::add(t11, s12);
-    auto t14 = at::mul(t8, t13);
-    auto t15 = t14.to(at::ScalarType::Half);
-    auto t16 = t15.to(at::ScalarType::Float);
-    auto t17_t18 =
-        at::var_mean(t16, {2}, /*unbiased*/ false, /*keepdim*/ false);
-    auto t17 = std::get<0>(t17_t18);
-    auto t18 = std::get<1>(t17_t18);
-    auto t19 = t17.unsqueeze(2).expand({1, 1024, 1});
-    auto t20 = t18.unsqueeze(2).expand({1, 1024, 1});
-    auto s21 = 1e-05;
-    auto t22 = at::add(t19, s21);
-    auto t23 = t20.expand({1, 1024, 768});
-    auto t24 = at::rsqrt(t22);
-    auto t25 = at::sub(t16, t23);
-    auto t26 = t24.expand({1, 1024, 768});
-    auto t27 = at::mul(t25, t26);
-    auto t28 = at::mul(t27, t3);
-    auto t29 = at::add(t28, t4);
-    auto t30 = t29.to(at::ScalarType::Float);
-    auto t31 = t30.to(at::ScalarType::Half);
-    auto t32 = t31.view({1024, 768});
-    outputs.push_back(t5);
-    outputs.push_back(t16);
-    outputs.push_back(t20);
-    outputs.push_back(t24);
-    outputs.push_back(t32);
-  }
+  auto t0 = at::randn({768}, options);
+  auto t1 = at::randn({768}, options);
+  auto t2 = at::randn({1024, 768}, options).to(at::ScalarType::Half);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(fusion, cg_outputs, inputs, outputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
+  testValidate(fusion, cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 // https://github.com/csarofeen/pytorch/issues/2068
@@ -4698,18 +4627,16 @@ TEST_F(NVFuserTest, FusionIssue2372_CUDA) {
   at::Tensor var = at::rand({C}, options);
   double eps = 1e-5;
 
-  std::vector<c10::IValue> aten_inputs = {x, mean, var, eps};
-
   auto eager_diff = x - mean.view({1, 1, 1, 1, -1});
   auto eager_invstd = at::rsqrt(var + eps);
   auto eager_x_normed = eager_diff * eager_invstd.view({1, 1, 1, 1, -1});
 
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {x, mean, var, eps});
   // testValidate currently fails since cg_outputs[1] is an empty tensor
-  ASSERT_TRUE(at::allclose(cg_outputs[0], eager_x_normed));
-  // ASSERT_TRUE(at::equal(cg_outputs[1], mean));
-  ASSERT_TRUE(at::allclose(cg_outputs[2], eager_invstd));
+  ASSERT_TRUE(at::allclose(cg_outputs.outputs[0], eager_x_normed));
+  // ASSERT_TRUE(at::equal(cg_outputs.outputs[1], mean));
+  ASSERT_TRUE(at::allclose(cg_outputs.outputs[2], eager_invstd));
 }
 
 TEST_F(NVFuserTest, FusionIssue2075_CUDA) {
@@ -4983,11 +4910,9 @@ TEST_F(NVFuserTest, FusionIssue2163ReproInvalidAlias_CUDA) {
   auto at_input = at::randn({N, C}, options_float);
   auto at_weight = at::randn({C}, options_float);
 
-  std::vector<c10::IValue> aten_inputs({at_input, at_weight});
-
   KernelExecutor ke;
-  ke.compile(fusion_ptr.get(), aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(fusion_ptr.get(), {at_input, at_weight});
+  auto cg_outputs = ke.run({at_input, at_weight});
   auto cg_output = cg_outputs.at(0);
 
   auto ref_x_sub_mean = at_input - at_input.sum({0}).unsqueeze(0);
@@ -4996,7 +4921,7 @@ TEST_F(NVFuserTest, FusionIssue2163ReproInvalidAlias_CUDA) {
   testValidate(
       ke.compiledKernel()->kernel(),
       {cg_output},
-      aten_inputs,
+      {at_input, at_weight},
       {ref_y},
       __LINE__,
       __FILE__,
@@ -5077,13 +5002,11 @@ TEST_F(NVFuserTest, FusionFloatingPointType_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({2}, options);
 
-  std::vector<c10::IValue> inputs({t0});
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
-  testValidate(&fusion, cg_outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIntegerType_CUDA) {
@@ -5143,11 +5066,9 @@ TEST_F(NVFuserTest, FusionIntegerType_CUDA) {
   auto options = at::TensorOptions().dtype(at::kInt).device(at::kCUDA, 0);
   at::Tensor t0 = at::randint(10, {10}, options);
 
-  std::vector<c10::IValue> inputs({t0});
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto i2 = int64_val;
   auto i3 = int_val;
@@ -5408,14 +5329,11 @@ TEST_F(NVFuserTest, FusionFloatConstantWhere_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::arange(4, options) > 1.0;
 
-  std::vector<c10::IValue> aten_inputs = {t0};
-
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
+  auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
   auto ref = at::where(t0, (float)3.0, (float)5.0);
   // testValidate does not check that dtypes match
-  NVF_CHECK(cg_outputs[0].dtype() == ref.dtype());
-  testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  NVF_CHECK(cg_outputs.outputs[0].dtype() == ref.dtype());
+  testValidate(&fusion, cg_outputs.outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionCpAsyncCommitWait_CUDA) {
@@ -5518,11 +5436,9 @@ TEST_F(NVFuserTest, FusionClearThreadPredicateByRAWSync_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({10, 11}, options);
 
-  std::vector<c10::IValue> inputs = {t0};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto t3 = t0.sum({1}).sum({0});
   auto t6 = t0.sum({1});
@@ -5530,7 +5446,7 @@ TEST_F(NVFuserTest, FusionClearThreadPredicateByRAWSync_CUDA) {
   testValidate(
       ke.compiledKernel()->kernel(),
       cg_outputs,
-      inputs,
+      {t0},
       {t3, t6},
       __LINE__,
       __FILE__);
@@ -5646,11 +5562,9 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitShared_CUDA) {
   at::Tensor t0 = at::randn({2}, options);
   at::Tensor t1 = at::randn({10000}, options);
 
-  std::vector<c10::IValue> inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref_t1 = t0.sum({0});
   auto ref_t4 = t1.exp();
@@ -5658,7 +5572,7 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitShared_CUDA) {
   testValidate(
       ke.compiledKernel()->kernel(),
       cg_outputs,
-      inputs,
+      {t0, t1},
       {ref_t1, ref_t4},
       __LINE__,
       __FILE__);
@@ -5705,11 +5619,9 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitGlobal_CUDA) {
   at::Tensor t0 = at::randn({2}, options);
   at::Tensor t1 = at::randn({10000}, options);
 
-  std::vector<c10::IValue> inputs = {t0, t1};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref_t1 = t0.sum({0});
   auto ref_t3 = t1.exp();
@@ -5717,7 +5629,7 @@ TEST_F(NVFuserTest, FusionPredicateReductionInitGlobal_CUDA) {
   testValidate(
       ke.compiledKernel()->kernel(),
       cg_outputs,
-      inputs,
+      {t0, t1},
       {ref_t1, ref_t3},
       __LINE__,
       __FILE__);
@@ -5770,25 +5682,23 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
     tv2->axis(2)->parallelize(ParallelType::TIDx);
 
     auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-    at::Tensor t0 = at::randn({999}, options).ge(0);
-    std::vector<c10::IValue> small_inputs = {t0};
+    at::Tensor t_small = at::randn({999}, options).ge(0);
 
-    at::Tensor t0_large =
+    at::Tensor t_large =
         at::randn({std::numeric_limits<int>::max()}, options).ge(0);
-    std::vector<c10::IValue> large_inputs = {t0_large};
 
     NVF_CHECK(
-        KernelArgumentHolder(large_inputs).getSmallestIndexTypeOfArguments() ==
+        KernelArgumentHolder({t_large}).getSmallestIndexTypeOfArguments() ==
         PrimDataType::Int);
     NVF_CHECK(
-        KernelArgumentHolder(small_inputs).getSmallestIndexTypeOfArguments() ==
+        KernelArgumentHolder({t_small}).getSmallestIndexTypeOfArguments() ==
         PrimDataType::Int32);
 
     {
       KernelExecutor ke;
       // Lower the kernel with large inputs and int64 index type.
       CompileParams compile_opts = {.index_type = PrimDataType::Int};
-      ke.compile(&fusion, large_inputs, LaunchParams(), compile_opts);
+      ke.compile(&fusion, {t_large}, LaunchParams(), compile_opts);
 
       NVF_CHECK(
           ke.compiledKernel()->kernel()->indexType() == PrimDataType::Int,
@@ -5797,15 +5707,15 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
 
       // Since the index type is int64, both small and large inputs
       // should work fine
-      ke.run(small_inputs);
-      ke.run(large_inputs);
+      ke.run({t_small});
+      ke.run({t_large});
     }
 
     {
       KernelExecutor ke;
       // Lower the kernel with small inputs and int64 index type.
       CompileParams compile_opts = {.index_type = PrimDataType::Int};
-      ke.compile(&fusion, small_inputs, LaunchParams(), compile_opts);
+      ke.compile(&fusion, {t_small}, LaunchParams(), compile_opts);
 
       NVF_CHECK(
           ke.compiledKernel()->kernel()->indexType() == PrimDataType::Int,
@@ -5814,15 +5724,15 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
 
       // Since the index type is int64, both small and large inputs
       // should work fine
-      ke.run(small_inputs);
-      ke.run(large_inputs);
+      ke.run({t_small});
+      ke.run({t_large});
     }
 
     {
       KernelExecutor ke;
       LaunchParams launch_params;
       CompileParams compile_opts = {.index_type = PrimDataType::Int32};
-      ke.compile(&fusion, small_inputs, launch_params, compile_opts);
+      ke.compile(&fusion, {t_small}, launch_params, compile_opts);
 
       NVF_CHECK(
           ke.compiledKernel()->kernel()->indexType() == PrimDataType::Int32,
@@ -5831,13 +5741,13 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
 
       // This should complete successfully as the arguments are small
       // enough to use the int32 index type
-      ke.run(small_inputs);
+      ke.run({t_small});
 
       // This should fail as the Kernel is already compiled for Int32, but
       // the arguments are too large
       CompileParams compile_opts_large = {.index_type = PrimDataType::Int};
       EXPECT_THAT(
-          [&]() { ke.run(large_inputs, launch_params, compile_opts_large); },
+          [&]() { ke.run({t_large}, launch_params, compile_opts_large); },
           testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
               "Kernel index type and compilation index type don't match")));
     }
@@ -5849,7 +5759,7 @@ TEST_F(NVFuserTest, FusionCompileIndexType_CUDA) {
       // This should fail due to the conflict
       EXPECT_THAT(
           [&]() {
-            ke.compile(&fusion, large_inputs, LaunchParams(), compile_opts);
+            ke.compile(&fusion, {t_large}, LaunchParams(), compile_opts);
           },
           testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
               "Compilation with int32 is requested but int64 is required for the arguments")));
@@ -5886,10 +5796,9 @@ TEST_F(NVFuserTest, FusionExecutorCacheIndexType1_CUDA) {
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({2024, 1024}, options);
   at::Tensor t1 = at::randn({2024, 1024}, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   auto kernel_runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(kernel_runtime->getIndexType() == PrimDataType::Int);
@@ -5927,15 +5836,14 @@ TEST_F(NVFuserTest, FusionExecutorCacheIndexType2_CUDA) {
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({2024, 1024}, options);
   at::Tensor t1 = at::randn({2024, 1024}, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  executor_cache.runFusionWithInputs(aten_inputs);
+  executor_cache.runFusionWithInputs({t0, t1});
   auto kernel_runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(kernel_runtime->getIndexType() == PrimDataType::Int);
 
   // Running again with forced type of Int32
-  executor_cache.runFusionWithInputs(aten_inputs, PrimDataType::Int32);
+  executor_cache.runFusionWithInputs({t0, t1}, PrimDataType::Int32);
   kernel_runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(kernel_runtime->getIndexType() == PrimDataType::Int32);
 }
@@ -6051,10 +5959,9 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteBroadcastedSoftmaxInput_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::ones(shape0, options);
   at::Tensor t1 = at::ones(shape1, options);
-  std::vector<c10::IValue> inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   // check thread_pred and write_stride
   const auto* ke = onlyKernelExecutorInMostRecentRuntime(executor_cache);
@@ -6074,7 +5981,8 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteBroadcastedSoftmaxInput_CUDA) {
     }
   }
 
-  testValidate(executor_cache.fusion(), cg_outputs, inputs, __LINE__, __FILE__);
+  testValidate(
+      executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionAvoidRedundantWrite_CUDA) {
@@ -6114,10 +6022,9 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWrite_CUDA) {
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     at::Tensor t0 = at::randn(shape0, options);
     at::Tensor t1 = at::randn(shape1, options);
-    std::vector<c10::IValue> inputs = {t0, t1};
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
+    auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
     // check thread_pred and write_stride
     const auto* ke = onlyKernelExecutorInMostRecentRuntime(executor_cache);
@@ -6139,7 +6046,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWrite_CUDA) {
     }
 
     testValidate(
-        executor_cache.fusion(), cg_outputs, inputs, __LINE__, __FILE__);
+        executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
   };
 
   // Test case where [B1,I2,I3] is merged to [B1I2I3]
@@ -6206,26 +6113,29 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteDifferentConcretizedDomains_CUDA) {
     at::Tensor t0 = at::randn(shape0, options);
     at::Tensor t1 = at::randn(shape1, options);
     at::Tensor t2 = at::randn(shape2, options);
-    std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
     if (direct_lowering) {
       // it should be segmented, if directly lowered, it should throw an error
       EXPECT_THAT(
           [&]() {
             scheduleAndRun(
-                &fusion, SchedulerType::Reduction, aten_inputs, false);
+                &fusion, SchedulerType::Reduction, {t0, t1, t2}, false);
           },
           testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
               "Producer is required to be in Global Memory based on parallelization strategy.")));
     } else {
       FusionExecutorCache executor_cache(std::move(fusion_ptr));
-      auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+      auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
       auto optimized_fusion = executor_cache.getMostRecentKernelRuntime();
       NVF_CHECK(optimized_fusion->isSegmented(), "segmentation didn't happen!");
 
       testValidate(
-          executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+          executor_cache.fusion(),
+          cg_outputs,
+          {t0, t1, t2},
+          __LINE__,
+          __FILE__);
     }
   };
   runTest(true);
@@ -6267,11 +6177,10 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteNonOutput_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({32}, options);
   at::Tensor t1 = at::randn({32, 64}, options);
-  std::vector<c10::IValue> inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(fusion_ptr.get(), inputs);
-  auto cg_outputs = ke.run(inputs);
+  ke.compile(fusion_ptr.get(), {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   // check thread_pred
   auto kernel = ke.compiledKernel()->kernel();
@@ -6289,7 +6198,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteNonOutput_CUDA) {
     }
   }
 
-  testValidate(fusion_ptr.get(), cg_outputs, inputs, __LINE__, __FILE__);
+  testValidate(fusion_ptr.get(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Test case where the merge order is random
@@ -6331,11 +6240,10 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteNonNeighbor_CUDA) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({8, 10, 12}, options);
   at::Tensor t1 = at::randn({8, 7, 10, 12, 9}, options);
-  std::vector<c10::IValue> inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(fusion_ptr.get(), inputs);
-  auto cg_outputs = ke.run(inputs);
+  ke.compile(fusion_ptr.get(), {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   // check thread_pred
   auto kernel = ke.compiledKernel()->kernel();
@@ -6353,7 +6261,7 @@ TEST_F(NVFuserTest, FusionAvoidRedundantWriteNonNeighbor_CUDA) {
     }
   }
 
-  testValidate(fusion_ptr.get(), cg_outputs, inputs, __LINE__, __FILE__);
+  testValidate(fusion_ptr.get(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Test for ir_utils::validateDomainEquivalence. We could consider
@@ -6865,13 +6773,12 @@ TEST_F(NVFuserTest, DoublePrecisionNorm_CUDA) {
       at::TensorOptions().dtype(data_type_to_aten(dt)).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({11}, options);
   at::Tensor t1 = at::randn({11}, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // delete intermediate tensors between segments to reduce memory usage of large
@@ -6945,12 +6852,11 @@ TEST_F(NVFuserTest, FusionMinMaxNanPropagation_CUDA) {
         // tensor that is ones except the diagonal, which are nans
         auto at_x = at::eye(size, options);
         at_x = (1 - at_x) / (1 - at_x);
-        std::vector<c10::IValue> inputs{at_x};
 
-        auto nvf_outputs = executor_cache.runFusionWithInputs(inputs);
+        auto nvf_outputs = executor_cache.runFusionWithInputs({at_x});
 
         testValidate(
-            executor_cache.fusion(), nvf_outputs, inputs, __LINE__, __FILE__);
+            executor_cache.fusion(), nvf_outputs, {at_x}, __LINE__, __FILE__);
       }
     }
   }
@@ -7122,11 +7028,11 @@ TEST_F(NVFuserTest, IntegerDivision_CUDA) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor input0 = (at::randn({1024 * 1024}, options) * 1024).to(at::kLong);
-  at::Tensor input1 = (at::randn({1024 * 1024}, options) * 1024).to(at::kLong);
-  auto div_expect = at::div(input0, input1, "trunc");
-  auto truediv_expect = at::true_divide(input0, input1);
+  at::Tensor t1 = (at::randn({1024 * 1024}, options) * 1024).to(at::kLong);
+  auto div_expect = at::div(input0, t1, "trunc");
+  auto truediv_expect = at::true_divide(input0, t1);
 
-  auto cg_outputs = executor_cache.runFusionWithInputs({input0, input1});
+  auto cg_outputs = executor_cache.runFusionWithInputs({input0, t1});
 
   ASSERT_TRUE(cg_outputs.at(0).scalar_type() == at::kLong);
   ASSERT_TRUE(cg_outputs.at(1).scalar_type() == at::kFloat);
@@ -7134,7 +7040,7 @@ TEST_F(NVFuserTest, IntegerDivision_CUDA) {
   testValidate(
       executor_cache.fusion(),
       cg_outputs,
-      {input0, input1},
+      {input0, t1},
       {div_expect, truediv_expect},
       __LINE__,
       __FILE__);
@@ -7403,28 +7309,20 @@ TEST_F(NVFuserTest, FusionInstanceNormNHWC_CUDA) {
   }
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-  std::vector<c10::IValue> inputs;
-  std::vector<at::Tensor> outputs;
 
-  {
-    auto t0 = at::randn(shape, options);
-    auto t1 = at::randn(shape[3], options);
-    auto t2 = at::randn(shape[3], options);
-    inputs.emplace_back(t0);
-    inputs.emplace_back(t1);
-    inputs.emplace_back(t2);
+  auto t0 = at::randn(shape, options);
+  auto t1 = at::randn(shape[3], options);
+  auto t2 = at::randn(shape[3], options);
 
-    auto var_mean = at::var_mean(t0, {1, 2}, 0, true);
-    auto var = std::get<0>(var_mean);
-    auto mean = std::get<1>(var_mean);
-    auto t3 = (t0 - mean) / sqrt(var + k_eps);
-    auto t4 = t3 * t1 + t2;
-    outputs.push_back(t4);
-  }
+  auto var_mean = at::var_mean(t0, {1, 2}, 0, true);
+  auto var = std::get<0>(var_mean);
+  auto mean = std::get<1>(var_mean);
+  auto t3 = (t0 - mean) / sqrt(var + k_eps);
+  auto t4 = t3 * t1 + t2;
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(fusion, cg_outputs, inputs, outputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
+  testValidate(fusion, cg_outputs, {t0, t1, t2}, {t4}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, VectorizeBackToBackReductions) {
@@ -7691,14 +7589,13 @@ TEST_F(NVFuserTest, VectorizationStrideValidation) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options).expand({-1, 5, -1});
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
+  ke.compile(&fusion, {t0});
 
   // This previously triggered a false positive error with the stride
   // validation
-  auto cg_outputs = ke.run(aten_inputs);
+  auto cg_outputs = ke.run({t0});
 
   ASSERT_TRUE(cg_outputs[0].equal(t0));
 }
@@ -7844,12 +7741,10 @@ TEST_F(NVFuserTest, Reduction3DWithBroadcast) {
 
   auto options = at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0);
   auto t0 = at::randn({8, 7, 5, 1}, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   auto cg_outputs =
-      scheduleAndRun(fusion, SchedulerType::Reduction, aten_inputs).outputs;
-  testValidate(
-      unsched_fusion_ptr.get(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(fusion, SchedulerType::Reduction, {t0}).outputs;
+  testValidate(unsched_fusion_ptr.get(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Test 3D reductions with constant domains.
@@ -7884,14 +7779,12 @@ TEST_F(NVFuserTest, Reduction3DConstantIterationDomain) {
   auto t0 =
       at::randn({x, y, z, w, h}, options)
           .as_strided({x, y, z, w, h}, {w * h * z * y, w * h * z, w * h, 1, w});
-  std::vector<c10::IValue> inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto ref = t0.to(at::kDouble).sum({2, 4});
-  testValidate(
-      executor_cache.fusion(), cg_outputs, inputs, {ref}, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // don't cache if the input tv is used by slice.
@@ -7946,10 +7839,9 @@ TEST_F(NVFuserTest, AvoidCachingSliceInput) {
                      .device(at::kCUDA, 0);
   auto t0 = at::randn({batch_size, hidden_size}, options);
   auto t1 = at::randn({eight * fiveTwelve * twenty}, options);
-  std::vector<c10::IValue> inputs{t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
   // check segmentation and sliced tvs are not cached if not scheduled by
   // the resize scheduler
   auto kernel_runtime = executor_cache.getMostRecentKernelRuntime();
@@ -8512,11 +8404,10 @@ TEST_F(NVFuserTest, ReplayRFactorMergeBcast) {
     fusion.addOutput(tv1);
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     at::Tensor at_x = at::ones(input_shape, options);
-    std::vector<c10::IValue> aten_inputs = {at_x};
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+    auto outputs = executor_cache.runFusionWithInputs({at_x});
 
-    testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+    testValidate(&fusion, outputs, {at_x}, __LINE__, __FILE__);
   }
 }
 
@@ -8546,13 +8437,12 @@ TEST_F(NVFuserTest, MultipleDifferentSizeGridReduction) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   const at::Tensor t0 = at::randn({128}, options);
   const at::Tensor t1 = at::randn({192}, options);
-  const std::vector<c10::IValue> inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // See PR #2799
@@ -8575,13 +8465,11 @@ TEST_F(NVFuserTest, MoveNonConcretizedBroadcastInNormalization) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({128, 1024}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   auto fusion_copy = fusion;
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::InnerPersistent, aten_inputs)
-          .outputs;
-  testValidate(&fusion_copy, cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::InnerPersistent, {t0});
+  testValidate(&fusion_copy, cg_outputs.outputs, {t0}, __LINE__, __FILE__);
 
   // tv2 and tv3 have non-concretized broadcasts. Make sure they are
   // moved to the innermost position of the loop domain
@@ -8633,12 +8521,11 @@ TEST_F(NVFuserTest, MoveNonConcretizedBroadcastInPointwise) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor input0 = at::randn({1024}, options);
-  at::Tensor input1 = at::randn({1024}, options);
+  at::Tensor t1 = at::randn({1024}, options);
 
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, {input0, input1})
-          .outputs;
-  testValidate(&fusion, cg_outputs, {input0, input1}, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {input0, t1}).outputs;
+  testValidate(&fusion, cg_outputs, {input0, t1}, __LINE__, __FILE__);
 
   // tv2 and tv3 have non-concretized broadcasts. Make sure they are
   // moved to the innermost position of the loop domain
@@ -8696,13 +8583,11 @@ TEST_F(NVFuserTest, MoveNonConcretizedBroadcastInReduction) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({32, 1024}, options);
   at::Tensor t1 = at::randn({32, 1024}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   Fusion fusion_copy = fusion;
 
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::Reduction, aten_inputs).outputs;
-  testValidate(&fusion_copy, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::Reduction, {t0, t1});
+  testValidate(&fusion_copy, cg_outputs.outputs, {t0, t1}, __LINE__, __FILE__);
 
   // tv2 and tv3 have non-concretized broadcasts. Make sure they are
   // moved to the innermost position of the loop domain
@@ -8800,12 +8685,11 @@ TEST_F(NVFuserTest, Issue2685Repro) {
   at::Tensor t1 = at::randn(shape[1], options);
   at::Tensor t2 = at::randn(shape[1], options);
   at::Tensor t10 = at::randn(shape, options).unsqueeze(-1);
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2, t10};
   Fusion fusion_copy = fusion;
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::InnerPersistent, aten_inputs)
-          .outputs;
-  testValidate(&fusion_copy, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = scheduleAndRun(
+      &fusion, SchedulerType::InnerPersistent, {t0, t1, t2, t10});
+  testValidate(
+      &fusion_copy, cg_outputs.outputs, {t0, t1, t2, t10}, __LINE__, __FILE__);
 }
 
 // Check that extents are properly replaced by replaceSymbolicSizes lowering
@@ -9188,11 +9072,10 @@ TEST_F(NVFuserTest, RepeatBroadcast) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({10}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Repeating a non-broadcast ID. Should be translated to broadcast +
@@ -9219,11 +9102,10 @@ TEST_F(NVFuserTest, RepeatNonBroadcast) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({10}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Repeating a mix of broadcast and non-broadcast IDs
@@ -9241,11 +9123,10 @@ TEST_F(NVFuserTest, RepeatBroadcastAndNonBroadcast) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, CastPrecision) {

--- a/tests/cpp/test_gpu_fused_reduction.cpp
+++ b/tests/cpp/test_gpu_fused_reduction.cpp
@@ -1676,11 +1676,10 @@ TEST_F(NVFuserTest, FusionGroupedReductionChannelsLastBatchNormLike_CUDA) {
   auto t0 = at::randn(shape, options_half);
   auto t1 = at::randn(shape, options_half);
   auto t2 = at::randn({shape.back()}, options_float);
-  std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, t2});
+  auto outputs = ke.run({t0, t1, t2});
 
   auto t0_double = t0.to(at::kDouble);
   auto t1_double = t1.to(at::kDouble);
@@ -1696,7 +1695,7 @@ TEST_F(NVFuserTest, FusionGroupedReductionChannelsLastBatchNormLike_CUDA) {
   testValidate(
       ke.compiledKernel()->kernel(),
       outputs,
-      aten_inputs,
+      {t0, t1, t2},
       {t5, t9},
       __LINE__,
       __FILE__);
@@ -1813,11 +1812,10 @@ TEST_F(
   auto t0 = at::randn(shape, options_half);
   auto t1 = at::randn(shape, options_half);
   auto t2 = at::randn({shape.back()}, options_float);
-  std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, t2});
+  auto outputs = ke.run({t0, t1, t2});
 
   auto t0_double = t0.to(at::kDouble);
   auto t1_double = t1.to(at::kDouble);
@@ -1838,7 +1836,7 @@ TEST_F(
   testValidate(
       ke.compiledKernel()->kernel(),
       outputs,
-      aten_inputs,
+      {t0, t1, t2},
       {t11, t13},
       __LINE__,
       __FILE__);
@@ -2534,13 +2532,12 @@ TEST_F(NVFuserTest, FusionGeluBwdReduction_CUDA) {
   auto at_output_pointwise = at::gelu_backward(at_grad, at_x, "tanh");
   auto at_output_reduction = at_output_pointwise.sum({0});
 
-  std::vector<c10::IValue> aten_inputs({at_grad, at_xvar});
   auto cg_results =
-      scheduleAndRun(&fusion, SchedulerType::Reduction, aten_inputs);
+      scheduleAndRun(&fusion, SchedulerType::Reduction, {at_grad, at_xvar});
   testValidate(
       &fusion,
       cg_results.outputs,
-      aten_inputs,
+      {at_grad, at_xvar},
       {at_output_pointwise, at_output_reduction},
       __LINE__,
       __FILE__,
@@ -2585,15 +2582,20 @@ TEST_F(NVFuserTest, FusionCrossEntropyGatherPattern_CUDA) {
   auto at_log_probs = at::randn({batch_size, num_classes}, options);
   auto at_labels =
       at::randint(0, num_classes, {batch_size}, options.dtype(at::kLong));
-  std::vector<c10::IValue> inputs = {at_log_probs, at_labels};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto cg_outputs = ke.run(inputs);
+  ke.compile(&fusion, {at_log_probs, at_labels});
+  auto cg_outputs = ke.run({at_log_probs, at_labels});
 
   auto ref = at::gather(at_log_probs, 1, at_labels.unsqueeze(1)).squeeze();
 
-  testValidate(&fusion, cg_outputs, inputs, {ref}, __LINE__, __FILE__);
+  testValidate(
+      &fusion,
+      cg_outputs,
+      {at_log_probs, at_labels},
+      {ref},
+      __LINE__,
+      __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionTensorRankLimit) {
@@ -2612,13 +2614,11 @@ TEST_F(NVFuserTest, FusionTensorRankLimit) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn(input_shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_gpu_indexing_ops.cpp
+++ b/tests/cpp/test_gpu_indexing_ops.cpp
@@ -143,14 +143,12 @@ TEST_F(NVFuserTest, FusionIndexSelectSimple_CUDA) {
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
 
-    at::Tensor input0 = at::randn({nElem, nFeat}, options); // lookup
-    at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-
-    std::vector<c10::IValue> aten_inputs = {input0, input_idx};
+    at::Tensor t0 = at::randn({nElem, nFeat}, options); // lookup
+    at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-    testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+    auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
+    testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
   }
 }
 
@@ -178,17 +176,14 @@ TEST_F(NVFuserTest, FusionIndexSelect_CUDA) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({nElem, nFeat}, options); // lookup
-  at::Tensor input1 =
-      at::randn({nElem_select, nFeat}, options); // output&elemwise
+  at::Tensor t0 = at::randn({nElem, nFeat}, options); // lookup
+  at::Tensor t1 = at::randn({nElem_select, nFeat}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-  at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-
-  std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
+  at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t1, t0, idx});
+  testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
 }
 
 // Test 1D schedule
@@ -216,17 +211,14 @@ TEST_F(NVFuserTest, FusionIndexSelect1DSch_CUDA) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({nElem, nFeat}, options); // lookup
-  at::Tensor input1 =
-      at::randn({nElem_select, nFeat}, options); // output&elemwise
+  at::Tensor t0 = at::randn({nElem, nFeat}, options); // lookup
+  at::Tensor t1 = at::randn({nElem_select, nFeat}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-  at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-
-  std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
+  at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t1, t0, idx});
+  testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIndexSelect3DTv_CUDA) {
@@ -253,17 +245,15 @@ TEST_F(NVFuserTest, FusionIndexSelect3DTv_CUDA) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({nElem, nFeat0, nFeat1}, options); // lookup
-  at::Tensor input1 =
+  at::Tensor t0 = at::randn({nElem, nFeat0, nFeat1}, options); // lookup
+  at::Tensor t1 =
       at::randn({nElem_select, nFeat0, nFeat1}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-  at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-
-  std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
+  at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t1, t0, idx});
+  testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIndexSelectCanSch_CUDA) {
@@ -296,15 +286,14 @@ TEST_F(NVFuserTest, FusionIndexSelectCanSch_CUDA) {
   fusion_fail.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({nElem, nFeat}, options); // lookup
-  at::Tensor input_pre = at::rand_like(input0);
+  at::Tensor t0 = at::randn({nElem, nFeat}, options); // lookup
+  at::Tensor input_pre = at::rand_like(t0);
 
-  at::Tensor input1 =
-      at::randn({nElem_select, nFeat}, options); // output&elemwise
+  at::Tensor t1 = at::randn({nElem_select, nFeat}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-  at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
+  at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
   at::Tensor output = at::zeros({nElem_select, nFeat}, options);
-  std::vector<c10::IValue> aten_inputs = {input_pre, input1, input0, input_idx};
+  std::vector<c10::IValue> aten_inputs = {input_pre, t1, t0, idx};
 
   // Schedule through magic scheduler
   SchedulerRuntimeInfo runtime_info(&fusion_fail, aten_inputs);
@@ -332,8 +321,7 @@ TEST_F(NVFuserTest, FusionIndexSelectCanSch_CUDA) {
   auto tv_sum_3 = sum(tv_sum_add, {1});
   // Register your outputs
   fusion_sum_fail.addOutput(tv_sum_3);
-  std::vector<c10::IValue> aten_sum_inputs = {
-      input_pre, input1, input0, input_idx};
+  std::vector<c10::IValue> aten_sum_inputs = {input_pre, t1, t0, idx};
   // Schedule through magic scheduler
   SchedulerRuntimeInfo runtime_sum_info(&fusion_sum_fail, aten_sum_inputs);
   auto sch_sum_fail = Schedule::canSchedule(
@@ -355,8 +343,7 @@ TEST_F(NVFuserTest, FusionIndexSelectCanSch_CUDA) {
   // Register your outputs
   fusion_pass.addOutput(tv3_p);
   // Schedule through magic scheduler
-  std::vector<c10::IValue> aten_inputs_pass = {input1, input0, input_idx};
-  SchedulerRuntimeInfo runtime_info_pass(&fusion_pass, aten_inputs_pass);
+  SchedulerRuntimeInfo runtime_info_pass(&fusion_pass, {t1, t0, idx});
   auto sch_pass = Schedule::canSchedule(
       SchedulerType::PointWise, &fusion_pass, runtime_info_pass);
 
@@ -386,22 +373,20 @@ TEST_F(NVFuserTest, FusionIndexSelect_Sum_CUDA) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({nElem, nFeat}, options); // lookup
-  at::Tensor input1 =
-      at::randn({nElem_select, nFeat}, options); // output&elemwise
+  at::Tensor t0 = at::randn({nElem, nFeat}, options); // lookup
+  at::Tensor t1 = at::randn({nElem_select, nFeat}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-  at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
+  at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
   at::Tensor cg_output = at::zeros({nElem_select}, options);
 
-  std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
   auto heuristic_params = SchedulerEntry::scheduleWith(
-      &fusion, SchedulerType::Reduction, aten_inputs);
+      &fusion, SchedulerType::Reduction, {t1, t0, idx});
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs, heuristic_params->lparams);
-  ke.run(aten_inputs, {cg_output}, heuristic_params->lparams);
+  ke.compile(&fusion, {t1, t0, idx}, heuristic_params->lparams);
+  ke.run({t1, t0, idx}, {cg_output}, heuristic_params->lparams);
 
-  auto tv0_ref = at::index_select(input0, 0, input_idx);
-  at::Tensor tv2_ref = tv0_ref * input1;
+  auto tv0_ref = at::index_select(t0, 0, idx);
+  at::Tensor tv2_ref = tv0_ref * t1;
   at::Tensor output_add = tv2_ref + 17.0;
   at::Tensor output_ref = output_add.sum({1});
 
@@ -434,15 +419,13 @@ TEST_F(NVFuserTest, FusionIndexSelectIdxTvFuseable_CUDA) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({nElem, nFeat}, options); // lookup
-  at::Tensor input1 =
-      at::randn({nElem_select, nFeat}, options); // output&elemwise
+  at::Tensor t0 = at::randn({nElem, nFeat}, options); // lookup
+  at::Tensor t1 = at::randn({nElem_select, nFeat}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-  at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-  auto input_idx_pre = at::zeros({nElem_select}, options_i);
+  at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
+  auto idx_pre = at::zeros({nElem_select}, options_i);
 
-  std::vector<c10::IValue> aten_inputs = {
-      input1, input0, input_idx, input_idx_pre};
+  std::vector<c10::IValue> aten_inputs = {t1, t0, idx, idx_pre};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
@@ -477,17 +460,15 @@ TEST_F(NVFuserTest, FusionIndexSelectDim1InRank2_CUDA) {
     fusion.addOutput(tv3);
 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-    at::Tensor input0 = at::randn({nFeat, nElem}, options); // lookup
-    at::Tensor input1 =
+    at::Tensor t0 = at::randn({nFeat, nElem}, options); // lookup
+    at::Tensor t1 =
         at::randn({nFeat, nElem_select}, options); // output&elemwise
     auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-    at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-
-    std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
+    at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-    testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+    auto cg_outputs = executor_cache.runFusionWithInputs({t1, t0, idx});
+    testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
   }
 }
 
@@ -515,17 +496,15 @@ TEST_F(NVFuserTest, FusionIndexSelectDim2InRank3_CUDA) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({nFeat0, nFeat1, nElem}, options); // lookup
-  at::Tensor input1 =
+  at::Tensor t0 = at::randn({nFeat0, nFeat1, nElem}, options); // lookup
+  at::Tensor t1 =
       at::randn({nFeat0, nFeat1, nElem_select}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-  at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-
-  std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
+  at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t1, t0, idx});
+  testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIndexSelectDim1InRank3_CUDA) {
@@ -552,17 +531,15 @@ TEST_F(NVFuserTest, FusionIndexSelectDim1InRank3_CUDA) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({nFeat0, nElem, nFeat1}, options); // lookup
-  at::Tensor input1 =
+  at::Tensor t0 = at::randn({nFeat0, nElem, nFeat1}, options); // lookup
+  at::Tensor t1 =
       at::randn({nFeat0, nElem_select, nFeat1}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-  at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-
-  std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
+  at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t1, t0, idx});
+  testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, FusionIndexSelectDim2InRank4_CUDA) {
@@ -590,18 +567,15 @@ TEST_F(NVFuserTest, FusionIndexSelectDim2InRank4_CUDA) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 =
-      at::randn({nFeat0, nElem, nFeat1, nFeat2}, options); // lookup
-  at::Tensor input1 = at::randn(
+  at::Tensor t0 = at::randn({nFeat0, nElem, nFeat1, nFeat2}, options); // lookup
+  at::Tensor t1 = at::randn(
       {nFeat0, nElem_select, nFeat1, nFeat2}, options); // output&elemwise
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-  at::Tensor input_idx = at::randint(0, nElem, (nElem_select), options_i);
-
-  std::vector<c10::IValue> aten_inputs = {input1, input0, input_idx};
+  at::Tensor idx = at::randint(0, nElem, (nElem_select), options_i);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t1, t0, idx});
+  testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
 }
 
 // Repro of issue #961
@@ -623,9 +597,8 @@ TEST_F(NVFuserTest, IndexSelectBroadcastIndex_CUDA) {
   auto t0 = at::randint(100, {1}, options_long);
   auto t1 = at::randn({100, 100}, options);
 
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   auto ref = at::index_select(t1, 0, t0);
 
@@ -658,17 +631,16 @@ TEST_F(NVFuserTest, MultipleIndexSelectIssue_CUDA) {
   auto t0 = at::randn(shape1, options);
   auto t1 = at::randn(shape1, options);
   auto t2 = at::randint(0, shape1[0], shape2, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   ASSERT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented())
       << "Should not segmented";
 
   auto ref = at::index_select(t0, 0, t2) + at::index_select(t1, 0, t2);
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_gpu_outer_reduction.cpp
+++ b/tests/cpp/test_gpu_outer_reduction.cpp
@@ -2165,9 +2165,7 @@ TEST_F(OuterReductionTest, IterGroupedBlockReduction) {
       at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
 
-  std::vector<c10::IValue> aten_inputs({t0});
-
-  SchedulerRuntimeInfo runtime_info(&fusion, aten_inputs);
+  SchedulerRuntimeInfo runtime_info(&fusion, {t0});
   NVF_ERROR(
       Schedule::canSchedule(SchedulerType::Reduction, &fusion, runtime_info));
   auto scheduler =
@@ -2184,8 +2182,8 @@ TEST_F(OuterReductionTest, IterGroupedBlockReduction) {
 
   scheduler->schedule(&fusion, rparams);
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs, heuristic_params->lparams);
-  auto cg_outputs = ke.run(aten_inputs, heuristic_params->lparams);
+  ke.compile(&fusion, {t0}, heuristic_params->lparams);
+  auto cg_outputs = ke.run({t0}, heuristic_params->lparams);
 
   // lowering & check iteration grouped reductions
   NVF_CHECK(
@@ -2202,7 +2200,7 @@ TEST_F(OuterReductionTest, IterGroupedBlockReduction) {
   testValidate(
       &fusion,
       cg_outputs,
-      aten_inputs,
+      {t0},
       {t0.to(at::kFloat).sum(0)},
       __LINE__,
       __FILE__,

--- a/tests/cpp/test_gpu_transpose.cpp
+++ b/tests/cpp/test_gpu_transpose.cpp
@@ -1011,10 +1011,9 @@ TEST_F(TransposeTest, UnswitchPredicateIssueRepro667) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
@@ -1041,10 +1040,9 @@ TEST_F(TransposeTest, TransposeAggregatedVectorizationWidth) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
@@ -1083,10 +1081,9 @@ TEST_F(TransposeTest, ViewTransposeReshape) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
@@ -1116,10 +1113,9 @@ TEST_F(TransposeTest, ReshapePermuteTransposeScheduler) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
@@ -1134,8 +1130,7 @@ TEST_F(TransposeTest, ReshapePermuteTransposeScheduler) {
       "Unexpected heuristic: ",
       heuristic);
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(
@@ -1161,10 +1156,9 @@ TEST_F(
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
@@ -1179,8 +1173,7 @@ TEST_F(
       "Unexpected heuristic: ",
       heuristic);
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Test reshape with small transpose dimension
@@ -1238,10 +1231,9 @@ TEST_F(TransposeTest, ViewTransposeMergedInnermostOnGroupTwo) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
@@ -1273,10 +1265,9 @@ TEST_F(TransposeTest, TransposeSplitAggregatedVectorizationWidth) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");
@@ -1324,10 +1315,9 @@ TEST_F(TransposeTest, ReductionIterDomainOnInputsIssue1659) {
 
   auto t0 = at::randn({1024, 512, 1}, options);
   auto t1 = at::randn({1024, 1, 512}, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(runtime->isSegmented(), "Segmentation expected");

--- a/tests/cpp/test_gpu_view.cpp
+++ b/tests/cpp/test_gpu_view.cpp
@@ -71,11 +71,11 @@ TEST_F(GpuViewTest, FusionViewDtypeSameSizeOutput) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor at_x = at::randn(input_shape, options);
   at::Tensor at_bias = at::randn(input_shape, options);
-  std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
 
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {at_x, at_bias})
+          .outputs;
+  testValidate(&fusion, cg_outputs, {at_x, at_bias}, __LINE__, __FILE__);
 }
 
 TEST_F(GpuViewTest, FusionViewDtypeFailMismatchSize) {
@@ -132,13 +132,12 @@ TEST_F(GpuViewTest, FusionViewAsRealOutput) {
   at::Tensor at_x = at::randn(input_shape, in_options);
   at::Tensor at_bias = at::randn(input_shape, in_options);
   at::Tensor at_y = at::randn(output_shape, out_options);
-  std::vector<c10::IValue> aten_inputs = {at_x, at_bias, at_y};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {at_x, at_bias, at_y});
+  auto outputs = ke.run({at_x, at_bias, at_y});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {at_x, at_bias, at_y}, __LINE__, __FILE__);
 }
 
 TEST_F(GpuViewTest, FusionReshapeRfactorExtentReplacement) {
@@ -186,11 +185,11 @@ TEST_F(GpuViewTest, FusionReshapeOutput) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor at_x = at::randn(input_shape, options);
   at::Tensor at_bias = at::randn(input_shape, options);
-  std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
 
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {at_x, at_bias})
+          .outputs;
+  testValidate(&fusion, cg_outputs, {at_x, at_bias}, __LINE__, __FILE__);
 }
 
 TEST_F(GpuViewTest, FusionReshapeFailMismatchSize) {
@@ -277,12 +276,11 @@ void reductionViewAddFusion(
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor at_x = at::randn(input_shape, options);
   at::Tensor at_bias = at::randn(bias_shape, options);
-  std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({at_x, at_bias});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {at_x, at_bias}, __LINE__, __FILE__);
 }
 
 typedef std::vector<int64_t> shape_t;
@@ -443,12 +441,11 @@ void persistentViewAddFusion(
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     at::Tensor at_x = at::randn(inferred_input, options);
     at::Tensor at_bias = at::randn(bias_shape, options);
-    std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+    auto outputs = executor_cache.runFusionWithInputs({at_x, at_bias});
 
-    testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+    testValidate(&fusion, outputs, {at_x, at_bias}, __LINE__, __FILE__);
   }
 }
 
@@ -494,11 +491,11 @@ void addViewGeluFusion(
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     at::Tensor at_x = at::randn(input_shape, options);
     at::Tensor at_bias = at::randn(input_shape, options);
-    std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
 
     auto cg_outputs =
-        scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-    testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        scheduleAndRun(&fusion, SchedulerType::PointWise, {at_x, at_bias})
+            .outputs;
+    testValidate(&fusion, cg_outputs, {at_x, at_bias}, __LINE__, __FILE__);
   }
 }
 
@@ -560,11 +557,11 @@ void geluViewAddFusion(
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     at::Tensor at_x = at::randn(inferred_input, options);
     at::Tensor at_bias = at::randn(inferred_output, options);
-    std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
 
     auto cg_outputs =
-        scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-    testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        scheduleAndRun(&fusion, SchedulerType::PointWise, {at_x, at_bias})
+            .outputs;
+    testValidate(&fusion, cg_outputs, {at_x, at_bias}, __LINE__, __FILE__);
   }
 }
 
@@ -600,11 +597,11 @@ void geluViewBinaryAddFusion(
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     at::Tensor at_x = at::randn(input_shape1, options);
     at::Tensor at_bias = at::randn(input_shape2, options);
-    std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
 
     auto cg_outputs =
-        scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-    testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        scheduleAndRun(&fusion, SchedulerType::PointWise, {at_x, at_bias})
+            .outputs;
+    testValidate(&fusion, cg_outputs, {at_x, at_bias}, __LINE__, __FILE__);
   }
 }
 
@@ -666,12 +663,11 @@ TEST_F(GpuViewTest, FusionReshapeConcreteDomain2) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor at_x = at::randn(input_shape, options);
   at::Tensor at_bias = at::randn(output_shape, options);
-  std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({at_x, at_bias});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {at_x, at_bias}, __LINE__, __FILE__);
 }
 
 // Repro of issue #1608
@@ -702,12 +698,11 @@ TEST_F(GpuViewTest, FusionReshapeConcreteDomain3) {
   at::Tensor at_x = at::randn(input_shape, options);
   at::Tensor at_y = at::randn(bcast_shape, options);
   at::Tensor at_z = at::randn(other_shape, options);
-  std::vector<c10::IValue> aten_inputs = {at_x, at_y, at_z};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({at_x, at_y, at_z});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {at_x, at_y, at_z}, __LINE__, __FILE__);
 }
 
 TEST_F(GpuViewTest, FusionReshapeConcreteDomain4) {
@@ -844,17 +839,16 @@ TEST_F(GpuViewTest, FusionFlattenAfterUnsqueezeOutput) {
   auto options = at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0);
   at::Tensor at_x = at::randn(input_shape, options);
   at::Tensor at_bias = at::randn(input_shape, options);
-  std::vector<c10::IValue> aten_inputs = {at_x, at_bias};
 
   x_reshape->split(0, 4);
   x_add_bias->computeAt(x_reshape, 1);
   x_reshape->axis(0)->parallelize(ParallelType::TIDx);
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {at_x, at_bias});
+  auto outputs = ke.run({at_x, at_bias});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {at_x, at_bias}, __LINE__, __FILE__);
 }
 
 TEST_F(GpuViewTest, FusionComputeAtLogicalDomainMapWithView) {
@@ -912,18 +906,17 @@ TEST_F(GpuViewTest, FusionExpandRepro) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor at_x = at::randn(input_shape1, options);
   at::Tensor at_y = at::randn(input_shape2, options);
-  std::vector<c10::IValue> aten_inputs = {at_x, at_y};
 
   KernelExecutor ke;
   ke.compile(&fusion);
   LaunchParams l_params;
-  auto outputs = ke.run(aten_inputs, {}, l_params, {});
+  auto outputs = ke.run({at_x, at_y}, {}, l_params, {});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {at_x, at_y}, __LINE__, __FILE__);
 
   // second run to verify cached output allocation
-  outputs = ke.run(aten_inputs, {}, l_params, {});
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  outputs = ke.run({at_x, at_y}, {}, l_params, {});
+  testValidate(&fusion, outputs, {at_x, at_y}, __LINE__, __FILE__);
 }
 
 TEST_F(GpuViewTest, FusionExpandView1) {
@@ -2196,11 +2189,9 @@ TEST_F(GpuViewTest, FusionReshapeZeroDimInput) {
 
   at::Tensor at_y = at::randn({2, 3, 4}).to(options);
 
-  std::vector<c10::IValue> aten_inputs = {at_x, at_y};
-
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {at_x, at_y}).outputs;
+  testValidate(&fusion, cg_outputs, {at_x, at_y}, __LINE__, __FILE__);
 }
 
 TEST_F(GpuViewTest, FusionReshapeZeroDimOutput) {
@@ -2231,11 +2222,10 @@ TEST_F(GpuViewTest, FusionReshapeZeroDimOutput) {
       at::randn({1}).to(options)[0]; // indexing to get zero-dim tensor
   NVF_ERROR(at_z.ndimension() == 0);
 
-  std::vector<c10::IValue> aten_inputs = {at_x, at_y, at_z};
-
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {at_x, at_y, at_z})
+          .outputs;
+  testValidate(&fusion, cg_outputs, {at_x, at_y, at_z}, __LINE__, __FILE__);
 }
 
 TEST_F(GpuViewTest, FusionReshapeZeroDimInputOutput) {
@@ -2262,11 +2252,9 @@ TEST_F(GpuViewTest, FusionReshapeZeroDimInputOutput) {
   at::Tensor at_y = at::randn({1}).to(options)[0];
   NVF_ERROR(at_x.ndimension() == 0 && at_y.ndimension() == 0);
 
-  std::vector<c10::IValue> aten_inputs = {at_x, at_y};
-
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {at_x, at_y}).outputs;
+  testValidate(&fusion, cg_outputs, {at_x, at_y}, __LINE__, __FILE__);
 }
 
 TEST_F(GpuViewTest, ReshapeOfReshape) {
@@ -2285,10 +2273,9 @@ TEST_F(GpuViewTest, ReshapeOfReshape) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(!runtime->isSegmented(), "Segmentation not expected");

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -30,9 +30,8 @@ TEST_F(HostIrIntegrationTest, LaunchKernel) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({32, 32}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
   auto ke = std::make_unique<KernelExecutor>();
-  ke->compile(&fusion, aten_inputs);
+  ke->compile(&fusion, {t0});
 
   auto hic = std::make_unique<HostIrContainer>(1);
   FusionGuard::setCurFusion(hic.get());
@@ -77,8 +76,7 @@ TEST_F(HostIrIntegrationTest, Set) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
       at::randn({2, 3}, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
 
   testValidate(
       executor_cache.fusion(),
@@ -104,8 +102,7 @@ TEST_F(HostIrIntegrationTest, Sum) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
       at::randn({2, 3}, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
 
   testValidate(
       executor_cache.fusion(),

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -133,10 +133,10 @@ TEST_P(HostIrTest, SingleFusion) {
 
   // define concrete inputs and compute ref output for validation
   auto options = at::TensorOptions().device(at::kCUDA, 0);
-  c10::IValue input = at::randn(input_sizes, options);
-  auto ref_output = at::sum(input.toTensor() * 2, {0});
+  auto t0 = at::randn(input_sizes, options);
+  auto ref_output = at::sum(t0 * 2, {0});
 
-  auto outputs = hie.runWithInput({{post_on_stream->inputs().at(0), input}});
+  auto outputs = hie.runWithInput({{post_on_stream->inputs().at(0), t0}});
 
   // validate the obtained results
   GTEST_EXPECT_TRUE(torch::allclose(ref_output, outputs.at(0)));
@@ -230,11 +230,10 @@ TEST_P(HostIrTest, TwoFusions) {
 
   // define concrete inputs and compute ref output for validation
   auto options = at::TensorOptions().device(at::kCUDA, 0);
-  c10::IValue input = at::randn(input_sizes_0, options);
-  auto ref_output =
-      at::sum(at::relu(input.toTensor()), at::OptionalIntArrayRef({0, 1})) * 2;
+  auto t0 = at::randn(input_sizes_0, options);
+  auto ref_output = at::sum(at::relu(t0), at::OptionalIntArrayRef({0, 1})) * 2;
 
-  auto outputs = hie.runWithInput({{post_on_stream_0->inputs().at(0), input}});
+  auto outputs = hie.runWithInput({{post_on_stream_0->inputs().at(0), t0}});
 
   // validate the obtained results
   GTEST_EXPECT_TRUE(torch::allclose(ref_output, outputs.at(0)));
@@ -354,21 +353,19 @@ TEST_P(HostIrTest, ThreeFusions) {
 
   // define concrete inputs and compute ref output for validation
   auto options = at::TensorOptions().device(at::kCUDA, 0);
-  c10::IValue tv0_0_ref_ivalue = at::randn(input_sizes_0, options);
-  at::Tensor tv0_0_ref = tv0_0_ref_ivalue.toTensor();
-  auto tv1_0_ref = tv0_0_ref + tv0_0_ref;
-  auto tv2_0_ref = at::sum(tv1_0_ref, {0});
-  auto tv0_1_ref = tv1_0_ref;
-  auto tv2_1_ref = at::sum(tv0_1_ref * tv0_1_ref, {0});
-  auto tv0_2_ref = tv2_0_ref;
-  auto tv1_2_ref = tv2_1_ref;
-  auto tv2_2_ref = tv0_2_ref + tv1_2_ref;
+  auto t0_0 = at::randn(input_sizes_0, options);
+  auto t1_0 = t0_0 + t0_0;
+  auto t2_0 = at::sum(t1_0, {0});
+  auto t0_1 = t1_0;
+  auto t2_1 = at::sum(t0_1 * t0_1, {0});
+  auto t0_2 = t2_0;
+  auto t1_2 = t2_1;
+  auto t2_2 = t0_2 + t1_2;
 
-  auto outputs =
-      hie.runWithInput({{post_on_stream_0->inputs().at(0), tv0_0_ref_ivalue}});
+  auto outputs = hie.runWithInput({{post_on_stream_0->inputs().at(0), t0_0}});
 
   // validate the obtained results
-  GTEST_EXPECT_TRUE(torch::allclose(tv2_2_ref, outputs.at(0)));
+  GTEST_EXPECT_TRUE(torch::allclose(t2_2, outputs.at(0)));
 }
 
 // This unit test the for-loop IR by implementing a program that could be
@@ -659,11 +656,11 @@ TEST_P(StreamHostIrTest, SingleFusionMultipleStreams) {
 
   // define concrete inputs and compute ref output for validation
   auto options = at::TensorOptions().device(at::kCUDA, 0);
-  c10::IValue input = at::randn(input_sizes, options);
-  auto ref_output = at::sum(input.toTensor() * 2, {0});
+  auto t0 = at::randn(input_sizes, options);
+  auto ref_output = at::sum(t0 * 2, {0});
 
   std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
-      {post_on_stream_inputs.at(0), input}};
+      {post_on_stream_inputs.at(0), t0}};
 
   setCurrentCUDAStream(c10::cuda::getDefaultCUDAStream(0));
 
@@ -740,18 +737,17 @@ TEST_P(SliceHostIrTest, SlicingTensor) {
   HostIrEvaluator hie(std::move(hic));
 
   auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
-  c10::IValue input = at::randn(input_sizes, options);
+  auto t0 = at::randn(input_sizes, options);
   std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
-      {hie.inputs().at(0), input}};
+      {hie.inputs().at(0), t0}};
 
   auto output = hie.runWithInput(concrete_input_buffers).at(0);
 
   // validate
-  at::Tensor input_aten = input.toTensor();
   std::vector<at::indexing::TensorIndex> ranges_aten(
-      input_aten.dim(), at::indexing::Slice());
+      t0.dim(), at::indexing::Slice());
   ranges_aten.at(axis) = at::indexing::Slice(start, stop, step);
-  auto ref_output = input_aten.index(ranges_aten);
+  auto ref_output = t0.index(ranges_aten);
   if (put_slice_op_in_top_level_expr) {
     EXPECT_TRUE(ref_output.equal(output));
   } else {
@@ -785,28 +781,28 @@ TEST_F(MatmulHostIrTest, HostIr) {
   auto hic = std::make_unique<HostIrContainer>();
   FusionGuard fg(hic.get());
 
-  TensorView* a = makeContigTensor(3);
-  TensorView* b = makeContigTensor(3);
-  TensorView* c = matmul(a, b);
+  TensorView* tv0 = makeContigTensor(3);
+  TensorView* tv1 = makeContigTensor(3);
+  TensorView* tv2 = matmul(tv0, tv1);
 
-  hic->addInput(a);
-  hic->addInput(b);
-  hic->addOutput(c);
+  hic->addInput(tv0);
+  hic->addInput(tv1);
+  hic->addOutput(tv2);
 
-  hic->pushBackTopLevelExprs(c->definition());
+  hic->pushBackTopLevelExprs(tv2->definition());
 
   HostIrEvaluator hie(std::move(hic));
 
   auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
-  at::Tensor a_tensor = at::randn({H, M, K}, options);
-  at::Tensor b_tensor = at::randn({H, K, N}, options);
+  auto t0 = at::randn({H, M, K}, options);
+  auto t1 = at::randn({H, K, N}, options);
   std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
-      {hie.inputs().at(0), a_tensor}, {hie.inputs().at(1), b_tensor}};
+      {hie.inputs().at(0), t0}, {hie.inputs().at(1), t1}};
 
   auto output = hie.runWithInput(concrete_input_buffers).at(0);
 
   // validate
-  auto ref_output = at::matmul(a_tensor, b_tensor);
+  auto ref_output = at::matmul(t0, t1);
 
   EXPECT_TRUE(ref_output.allclose(output));
 }
@@ -820,33 +816,33 @@ TEST_F(MatmulHostIrTest, HostIrMatmulOut) {
   auto hic = std::make_unique<HostIrContainer>();
   FusionGuard fg(hic.get());
 
-  TensorView* a = makeContigTensor(3);
-  TensorView* b = makeContigTensor(3);
-  TensorView* c = makeContigTensor(3);
-  auto* matmul = IrBuilder::create<MatmulOp>(c, a, b);
+  TensorView* tv0 = makeContigTensor(3);
+  TensorView* tv1 = makeContigTensor(3);
+  TensorView* tv2 = makeContigTensor(3);
+  auto* matmul = IrBuilder::create<MatmulOp>(tv2, tv0, tv1);
 
-  hic->addInput(a);
-  hic->addInput(b);
-  hic->addInput(c);
-  hic->addOutput(c);
+  hic->addInput(tv0);
+  hic->addInput(tv1);
+  hic->addInput(tv2);
+  hic->addOutput(tv2);
 
   hic->pushBackTopLevelExprs(matmul);
 
   HostIrEvaluator hie(std::move(hic));
 
   auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
-  at::Tensor a_tensor = at::randn({H, M, K}, options);
-  at::Tensor b_tensor = at::randn({H, K, N}, options);
-  at::Tensor c_tensor = at::randn({H, M, N}, options);
+  at::Tensor t0 = at::randn({H, M, K}, options);
+  at::Tensor t1 = at::randn({H, K, N}, options);
+  at::Tensor t2 = at::randn({H, M, N}, options);
   std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
-      {a, a_tensor}, {b, b_tensor}, {c, c_tensor}};
+      {tv0, t0}, {tv1, t1}, {tv2, t2}};
 
   hie.runWithInput(concrete_input_buffers);
 
   // validate
-  auto ref_output = at::matmul(a_tensor, b_tensor);
+  auto ref_output = at::matmul(t0, t1);
 
-  EXPECT_TRUE(ref_output.allclose(c_tensor));
+  EXPECT_TRUE(ref_output.allclose(t2));
 }
 
 using LinearHostIrTest = NVFuserTest;
@@ -875,9 +871,9 @@ TEST_F(LinearHostIrTest, HostIr) {
   HostIrEvaluator hie(std::move(hic));
 
   auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
-  at::Tensor in_at = at::randn({B, M, K}, options);
-  at::Tensor weight_at = at::randn({N, K}, options);
-  at::Tensor bias_at = at::randn({N}, options);
+  auto in_at = at::randn({B, M, K}, options);
+  auto weight_at = at::randn({N, K}, options);
+  auto bias_at = at::randn({N}, options);
   std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
       {hie.inputs().at(0), in_at},
       {hie.inputs().at(1), weight_at},
@@ -917,10 +913,10 @@ TEST_F(LinearHostIrTest, HostIrLinearOut) {
   HostIrEvaluator hie(std::move(hic));
 
   auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
-  at::Tensor in_at = at::randn({B, M, K}, options);
-  at::Tensor weight_at = at::randn({N, K}, options);
-  at::Tensor bias_at = at::randn({N}, options);
-  at::Tensor out_at = at::empty({B, M, N}, options);
+  auto in_at = at::randn({B, M, K}, options);
+  auto weight_at = at::randn({N, K}, options);
+  auto bias_at = at::randn({N}, options);
+  auto out_at = at::empty({B, M, N}, options);
   std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
       {hie.inputs().at(0), in_at},
       {hie.inputs().at(1), weight_at},
@@ -967,15 +963,14 @@ TEST_P(SelectHostIrTest, SelectingTensor) {
   HostIrEvaluator hie(std::move(hic));
 
   auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
-  c10::IValue input = at::randn(input_sizes, options);
+  auto t0 = at::randn(input_sizes, options);
   std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
-      {hie.inputs().at(0), input}};
+      {hie.inputs().at(0), t0}};
 
   auto output = hie.runWithInput(concrete_input_buffers).at(0);
 
   // validate
-  at::Tensor input_aten = input.toTensor();
-  auto ref_output = input_aten.select(dim, index);
+  auto ref_output = t0.select(dim, index);
   if (put_select_op_in_top_level_expr) {
     EXPECT_TRUE(ref_output.equal(output));
   } else {
@@ -1022,15 +1017,14 @@ TEST_F(ViewTest, SimpleReshape) {
   auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
   constexpr int64_t kX = 32;
   constexpr int64_t kY = 64;
-  auto input_aten = at::randn({kX, kY}, options);
-  std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {
-      {input, input_aten}};
+  auto t0 = at::randn({kX, kY}, options);
+  std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {{input, t0}};
 
   auto outputs = hie.runWithInput(concrete_input_buffers);
 
   // validate
-  EXPECT_TRUE(outputs[0].equal(at::reshape(input_aten, {kX * kY})));
-  EXPECT_TRUE(outputs[1].equal(at::reshape(input_aten, {kY, kX})));
+  EXPECT_TRUE(outputs[0].equal(at::reshape(t0, {kX * kY})));
+  EXPECT_TRUE(outputs[1].equal(at::reshape(t0, {kY, kX})));
 }
 
 using ReductionHostIrTest = NVFuserTest;
@@ -1041,23 +1035,23 @@ TEST_F(ReductionHostIrTest, Sum) {
   auto hic = std::make_unique<HostIrContainer>();
   FusionGuard fg(hic.get());
 
-  TensorView* a = makeContigTensor(1);
-  TensorView* b = sum(a, {0});
+  TensorView* tv0 = makeContigTensor(1);
+  TensorView* tv1 = sum(tv0, {0});
 
-  hic->addInput(a);
-  hic->addOutput(b);
-  hic->pushBackTopLevelExprs(b->definition());
+  hic->addInput(tv0);
+  hic->addOutput(tv1);
+  hic->pushBackTopLevelExprs(tv1->definition());
 
   HostIrEvaluator hie(std::move(hic));
 
   auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
-  auto a_aten = at::randn({kTensorSize}, options);
-  std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {{a, a_aten}};
+  auto t0 = at::randn({kTensorSize}, options);
+  std::unordered_map<Val*, c10::IValue> concrete_input_buffers = {{tv0, t0}};
 
   auto outputs = hie.runWithInput(concrete_input_buffers);
 
   // validate
-  EXPECT_TRUE(outputs[0].equal(at::sum(a_aten, 0)));
+  EXPECT_TRUE(outputs[0].equal(at::sum(t0, 0)));
 }
 
 using IfThenElseTest = NVFuserTest;

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -3093,16 +3093,15 @@ TEST_F(PredicateIndexingTest, DoubleBuffering1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({1000}, options);
-  std::vector<c10::IValue> inputs = {t0};
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Same fusion ad IndexingTest.CircularBuffering1
@@ -3192,16 +3191,15 @@ TEST_F(PredicateIndexingTest, CircularBuffering1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({1000}, options);
-  std::vector<c10::IValue> inputs = {t0};
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Same fusion as IndexingTest.CircularBuffering2. Combination of
@@ -3360,16 +3358,15 @@ TEST_F(PredicateIndexingTest, UnrolledCircularBuffering) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({1000}, options);
-  std::vector<c10::IValue> inputs = {t0};
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Completely unswitched circular buffering
@@ -3436,16 +3433,15 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({99}, options);
-  std::vector<c10::IValue> inputs = {t0};
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Mostly the same as UnswitchedCircularBuffering1 but with Vectorize
@@ -3522,16 +3518,15 @@ TEST_F(PredicateIndexingTest, UnswitchedCircularBuffering2) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({1000}, options);
-  std::vector<c10::IValue> inputs = {t0};
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Test circular buffering with unswitch. This fusion has a non
@@ -3625,16 +3620,15 @@ TEST_P(PredicateIndexingTest, UnswitchedCircularBuffering3) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({1000}, options);
   at::Tensor t1 = at::randn({1000}, options);
-  std::vector<c10::IValue> inputs = {t0, t1};
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -3800,13 +3794,12 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplit1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({999}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Mostly same pattern as NonDivisibleSplit1 but with unswitch. The
@@ -3892,13 +3885,12 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithUnswitch) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({999}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Testing non divisible split predicate with circular buffering
@@ -3987,13 +3979,12 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithCircularBuffering) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({999}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Non divisible split with unswitched circular buffering. The non divisible
@@ -4098,13 +4089,12 @@ TEST_F(
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({999}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Repro of unswitch predicate issue #681
@@ -4132,7 +4122,6 @@ TEST_P(PredicateIndexingTest, UnswitchPredicateIssueRepro681) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   struct GetReference : AbstractGetReference {
     GetReference(const TensorIndexer& indexer, const IdModel& id_model)
@@ -4186,12 +4175,12 @@ TEST_P(PredicateIndexingTest, UnswitchPredicateIssueRepro681) {
   }
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
   auto ref = t0.to(at::kDouble).sum();
 
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
 // Testing unswitched non-divisible predicates. For a given tensor,
@@ -4340,16 +4329,15 @@ TEST_F(PredicateIndexingTest, NonDivisibleSplitWithUnswitchAndBroadcast) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({5}, options);
   at::Tensor t1 = at::randn({5, 100}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PredicateIndexingTest, UnswitchConsolidationDifferentThreading) {
@@ -4463,16 +4451,15 @@ TEST_F(PredicateIndexingTest, UnswitchConsolidationDifferentThreading) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({1000}, options);
   at::Tensor t1 = at::randn({1000}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Same fusion as SimplePointwise1 but with contig indexing
@@ -4887,13 +4874,12 @@ TEST_F(ContigIndexingTest, ConcretizedBroadcastMerge) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({5, 6}, options);
   auto t1 = at::randn({5, 6, 7}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(ContigPredicateIndexingTest, SimplePointwise1) {
@@ -5116,13 +5102,12 @@ TEST_F(ContigPredicateIndexingTest, NonDivisibleSplit1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({10, 20}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(IndexingTest, PerDimLogicalIndices) {
@@ -5281,12 +5266,12 @@ TEST_F(IndexingTest, Issue3374) {
   auto t1 = at::randn(shape2, options);
   auto t2 = at::randn(shape3, options);
   auto t3 = at::randn(shape3, options);
-  std::vector<c10::IValue> inputs{t0, t1, t2, t3};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2, t3});
 
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  testValidate(
+      executor_cache.fusion(), outputs, {t0, t1, t2, t3}, __LINE__, __FILE__);
 }
 
 // Repro of issue #3299
@@ -5316,12 +5301,11 @@ TEST_F(IndexingTest, Issue3299) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape1, options);
-  std::vector<c10::IValue> inputs{t0};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(IndexingTest, ResizeRotation) {
@@ -5389,13 +5373,12 @@ TEST_F(IndexingTest, ResizeRotation) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({i0}, options);
-  std::vector<c10::IValue> inputs{t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PredicateIndexingTest, VectorizedResizeRotation) {
@@ -5488,13 +5471,12 @@ TEST_F(PredicateIndexingTest, VectorizedResizeRotation) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({i0}, options);
-  std::vector<c10::IValue> inputs{t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Repro of issue #3505. The indexing WAR for resize triggered an
@@ -5534,13 +5516,12 @@ TEST_F(IndexingTest, Issue3505Repro1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({i1, i2}, options);
   auto t1 = at::randn({i0, i1 / 2, i2 / 2}, options);
-  std::vector<c10::IValue> inputs{t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Another repro of issue #3505
@@ -5582,13 +5563,12 @@ TEST_F(IndexingTest, Issue3505Repro2) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({i0}, options);
   auto t1 = at::randn({i1, i0 / 2}, options);
-  std::vector<c10::IValue> inputs{t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(IndexingTest, AlmostExactIndexingUpdate) {
@@ -5620,13 +5600,12 @@ TEST_F(IndexingTest, AlmostExactIndexingUpdate) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({4, 8}, options);
-  std::vector<c10::IValue> inputs{t0};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Small repro of
@@ -5658,12 +5637,11 @@ TEST_F(IndexingTest, BroadcastLogicalDomainIndexing) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape1, options);
   auto t1 = at::randn(shape2, options);
-  std::vector<c10::IValue> inputs{t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  ke.compile(&fusion, {t0, t1});
+  auto outputs = ke.run({t0, t1});
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(IndexingTest, Rng) {
@@ -5686,15 +5664,14 @@ TEST_F(IndexingTest, Rng) {
   fusion.addOutput(tv0);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  std::vector<c10::IValue> inputs{1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({1});
 
   at::manual_seed(0);
   at::Tensor randn_sample = at::randn({1}, options);
 
-  testValidate(&fusion, outputs, inputs, {randn_sample}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {1}, {randn_sample}, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_loop_domain_scheduling.cpp
+++ b/tests/cpp/test_loop_domain_scheduling.cpp
@@ -103,13 +103,12 @@ TEST_F(LoopDomainSchedulingTest, ReshapeSplitThenMerge) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({10}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
 
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Test loop domain scheduling with slice. More test cases can also be
@@ -167,11 +166,10 @@ TEST_F(LoopDomainSchedulingTest, Slice) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
 
@@ -337,11 +335,10 @@ TEST_F(LoopDomainSchedulingTest, ManyReshape) {
 
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
     auto t0 = at::randn({12}, options);
-    std::vector<c10::IValue> aten_inputs({t0});
 
     KernelExecutor ke;
-    ke.compile(&fusion, aten_inputs);
-    auto cg_outputs = ke.run(aten_inputs);
+    ke.compile(&fusion, {t0});
+    auto cg_outputs = ke.run({t0});
 
     auto ref = t0 * 2;
     EXPECT_TRUE(ref.equal(cg_outputs[0]));
@@ -593,12 +590,11 @@ TEST_F(LoopDomainSchedulingTest, CancelReshape1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Cancelling chained reshape ops
@@ -648,12 +644,11 @@ TEST_F(LoopDomainSchedulingTest, CancelReshape2) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Two reshapes that get merged by a binary op
@@ -691,12 +686,11 @@ TEST_F(LoopDomainSchedulingTest, CancelReshape3) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
-  auto outputs = ke.run(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  ke.compile(&fusion, {t0});
+  auto outputs = ke.run({t0});
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Resize should prevent cancellation

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -3032,19 +3032,18 @@ TEST_P(MatmulTestWithLayout, FusionAmpereMatmulSplitKBias_CUDA) {
       SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
           ->schedule(&fusion, &mparams);
 
-      auto [aten_a, aten_b] = matmulAtInput3DTuring(M, N, K, layout);
-      at::Tensor aten_bias = at::randn({M}, aten_a.options());
-      std::vector<c10::IValue> inputs = {aten_a, aten_b, aten_bias};
+      auto [t0, t1] = matmulAtInput3DTuring(M, N, K, layout);
+      at::Tensor bias = at::randn({M}, t0.options());
 
       KernelExecutor ke;
-      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(7, 5, ke.compile(&fusion, inputs));
+      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+          7, 5, ke.compile(&fusion, {t0, t1, bias}));
       EXPECT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
-      auto cg_outputs = ke.run(inputs);
+      auto cg_outputs = ke.run({t0, t1, bias});
       ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
           ke.compiledKernel()->kernel()));
       auto tref = atBiasEpilogue(
-          atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout),
-          aten_bias);
+          atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout), bias);
 
       // Relax tolerance for larger sum due to large K
       EXPECT_TRUE(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
@@ -3090,21 +3089,18 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulBatchSplitK) {
       SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
           ->schedule(&fusion, &mparams);
 
-      at::Tensor aten_a =
+      auto t0 =
           matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
-      at::Tensor aten_b =
+      auto t1 =
           matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
 
-      std::vector<c10::IValue> inputs = {aten_a, aten_b};
-
       KernelExecutor ke;
-      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(7, 5, ke.compile(&fusion, inputs));
+      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(7, 5, ke.compile(&fusion, {t0, t1}));
       ASSERT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
       ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
           ke.compiledKernel()->kernel()));
-      auto cg_outputs = ke.run(inputs);
-      auto tref =
-          atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout);
+      auto cg_outputs = ke.run({t0, t1});
+      auto tref = atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout);
 
       // Relax tolerance for larger sum due to large K
       EXPECT_TRUE(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
@@ -3154,23 +3150,21 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulBatchSplitKBias) {
       SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
           ->schedule(&fusion, &mparams);
 
-      at::Tensor aten_a =
+      auto t0 =
           matmulAtInput2D(layout, TensorMatmulPos::A, at::kHalf, M, N, K, B);
-      at::Tensor aten_b =
+      auto t1 =
           matmulAtInput2D(layout, TensorMatmulPos::B, at::kHalf, M, N, K, B);
-      at::Tensor aten_bias = at::randn({M}, aten_a.options());
-
-      std::vector<c10::IValue> inputs = {aten_a, aten_b, aten_bias};
+      at::Tensor bias = at::randn({M}, t0.options());
 
       KernelExecutor ke;
-      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(7, 5, ke.compile(&fusion, inputs));
+      NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
+          7, 5, ke.compile(&fusion, {t0, t1, bias}));
       ASSERT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
       ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
           ke.compiledKernel()->kernel()));
-      auto cg_outputs = ke.run(inputs);
+      auto cg_outputs = ke.run({t0, t1, bias});
       auto tref = atBiasEpilogue(
-          atMatmul(aten_a.to(at::kFloat), aten_b.to(at::kFloat), layout),
-          aten_bias);
+          atMatmul(t0.to(at::kFloat), t1.to(at::kFloat), layout), bias);
 
       // Relax tolerance for larger sum due to large K
       EXPECT_TRUE(cg_outputs[0].allclose(tref, 1e-6 * K, 1e-6 * K));
@@ -3433,21 +3427,20 @@ TEST_F(MatmulTest, MultipleConsecutiveDims) {
       ->schedule(&fusion, &mparams);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-  at::Tensor A = at::randn({M1, M2, K}, options);
-  at::Tensor B = at::randn({N1, N2, K}, options);
-  std::vector<c10::IValue> inputs{A, B};
+  auto t0 = at::randn({M1, M2, K}, options);
+  auto t1 = at::randn({N1, N2, K}, options);
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8, 0, ke.compile(&fusion, inputs, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
   ASSERT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1});
   auto tref = at::reshape(
       at::linear(
-          at::reshape(A.to(at::kFloat), {M1 * M2, K}),
-          at::reshape(B.to(at::kFloat), {N1 * N2, K})),
+          at::reshape(t0.to(at::kFloat), {M1 * M2, K}),
+          at::reshape(t1.to(at::kFloat), {N1 * N2, K})),
       {M1, M2, N1, N2});
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
@@ -3498,19 +3491,18 @@ TEST_F(MatmulTest, DISABLED_MultipleNonConsecutiveMDims) {
       ->schedule(&fusion, &mparams);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-  at::Tensor A = at::randn({M1, K, M2}, options);
-  at::Tensor B = at::randn({N, K}, options);
-  std::vector<c10::IValue> inputs{A, B};
+  auto t0 = at::randn({M1, K, M2}, options);
+  auto t1 = at::randn({N, K}, options);
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8, 0, ke.compile(&fusion, inputs, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
   ASSERT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
-  auto cg_outputs = ke.run(inputs);
-  auto Apermuted = A.permute({{1, 2}}).reshape({M1 * M2, K});
-  auto tref = at::linear(Apermuted.to(at::kFloat), B.to(at::kFloat))
+  auto cg_outputs = ke.run({t0, t1});
+  auto Apermuted = t0.permute({{1, 2}}).reshape({M1 * M2, K});
+  auto tref = at::linear(Apermuted.to(at::kFloat), t1.to(at::kFloat))
                   .reshape({M1, M2, N})
                   .permute({{1, 2}});
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
@@ -3563,19 +3555,18 @@ TEST_F(MatmulTest, DISABLED_MultipleNonConsecutiveNDims) {
       ->schedule(&fusion, &mparams);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-  at::Tensor A = at::randn({M, K}, options);
-  at::Tensor B = at::randn({N1, K, N2}, options);
-  std::vector<c10::IValue> inputs{A, B};
+  auto t0 = at::randn({M, K}, options);
+  auto t1 = at::randn({N1, K, N2}, options);
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8, 0, ke.compile(&fusion, inputs, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
   ASSERT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
-  auto cg_outputs = ke.run(inputs);
-  auto Bpermuted = B.permute({{1, 2}}).reshape({N1 * N2, K});
-  auto tref = at::linear(A.to(at::kFloat), Bpermuted.to(at::kFloat))
+  auto cg_outputs = ke.run({t0, t1});
+  auto Bpermuted = t1.permute({{1, 2}}).reshape({N1 * N2, K});
+  auto tref = at::linear(t0.to(at::kFloat), Bpermuted.to(at::kFloat))
                   .reshape({M, N1, N2});
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
@@ -3622,19 +3613,18 @@ TEST_F(MatmulTest, MultipleMDimsBatch) {
       ->schedule(&fusion, &mparams);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-  at::Tensor A = at::randn({M1, Batch, M2, K}, options);
-  at::Tensor B = at::randn({Batch, N, K}, options);
-  std::vector<c10::IValue> inputs{A, B};
+  auto t0 = at::randn({M1, Batch, M2, K}, options);
+  auto t1 = at::randn({Batch, N, K}, options);
 
   KernelExecutor ke;
   NVFUSER_TEST_CUDA_ARCH_COMPILE_CHECK(
-      8, 0, ke.compile(&fusion, inputs, LaunchParams(), matmul_cparams));
+      8, 0, ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams));
   ASSERT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1});
   auto tref =
-      at::matmul(A.to(at::kFloat), at::permute(B.to(at::kFloat), {0, 2, 1}));
+      at::matmul(t0.to(at::kFloat), at::permute(t1.to(at::kFloat), {0, 2, 1}));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 
@@ -3990,14 +3980,13 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle_NoBroadcasts) {
 
   auto [A3d, B3d] =
       matmulAtInput3DHopperSS(M, N, K, layout, data_type_to_aten(dtype));
-  at::Tensor A = A3d.squeeze();
-  at::Tensor B = B3d.squeeze();
-  std::vector<c10::IValue> inputs{A, B};
+  auto t0 = A3d.squeeze();
+  auto t1 = B3d.squeeze();
 
   KernelExecutor ke;
-  ke.compile(&fusion, inputs, LaunchParams(), matmul_cparams);
-  auto cg_outputs = ke.run(inputs);
-  auto tref = atMatmul(A, B, layout);
+  ke.compile(&fusion, {t0, t1}, LaunchParams(), matmul_cparams);
+  auto cg_outputs = ke.run({t0, t1});
+  auto tref = atMatmul(t0, t1, layout);
   EXPECT_TRUE(at::allclose(cg_outputs[0], tref, 1e-5, 1e-5));
 }
 
@@ -4024,9 +4013,9 @@ TEST_F(HopperMatmulTest, HSH_NT_UseScheduler) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA);
-  auto a_ref = at::randn({K, M, 1}, options);
-  auto b_ref = at::randn({K, 1, N}, options);
-  auto out_ref = at::matmul(a_ref.squeeze().t(), b_ref.squeeze()).to(at::kHalf);
+  auto t0 = at::randn({K, M, 1}, options);
+  auto t1 = at::randn({K, 1, N}, options);
+  auto out_ref = at::matmul(t0.squeeze().t(), t1.squeeze()).to(at::kHalf);
 
   MatMulTileOptions gemm_tile;
   gemm_tile.cta_tile = GemmTile(128, 256, 64);
@@ -4050,12 +4039,10 @@ TEST_F(HopperMatmulTest, HSH_NT_UseScheduler) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
-  std::vector<c10::IValue> inputs = {a_ref, b_ref};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
+  ke.compile(&fusion, {t0, t1});
   EXPECT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1});
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
@@ -4081,9 +4068,9 @@ TEST_F(HopperMatmulTest, HSH_TN_UseScheduler) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA);
-  auto a_ref = at::randn({M, 1, K}, options);
-  auto b_ref = at::randn({1, N, K}, options);
-  auto out_ref = at::matmul(a_ref.squeeze(), b_ref.squeeze().t()).to(at::kHalf);
+  auto t0 = at::randn({M, 1, K}, options);
+  auto t1 = at::randn({1, N, K}, options);
+  auto out_ref = at::matmul(t0.squeeze(), t1.squeeze().t()).to(at::kHalf);
 
   MatMulTileOptions gemm_tile;
   gemm_tile.cta_tile = GemmTile(128, 256, 64);
@@ -4107,12 +4094,10 @@ TEST_F(HopperMatmulTest, HSH_TN_UseScheduler) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
-  std::vector<c10::IValue> inputs = {a_ref, b_ref};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
+  ke.compile(&fusion, {t0, t1});
   EXPECT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1});
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
@@ -4143,10 +4128,9 @@ TEST_F(HopperMatmulTest, HSH_NN_UseScheduler) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA);
-  auto a_ref = at::randn({1, K, M}, options);
-  auto b_ref = at::randn({N, K, 1}, options);
-  auto out_ref =
-      at::matmul(a_ref.squeeze().t(), b_ref.squeeze().t()).to(at::kHalf);
+  auto t0 = at::randn({1, K, M}, options);
+  auto t1 = at::randn({N, K, 1}, options);
+  auto out_ref = at::matmul(t0.squeeze().t(), t1.squeeze().t()).to(at::kHalf);
 
   MatMulTileOptions gemm_tile;
   gemm_tile.cta_tile = GemmTile(128, 256, 64);
@@ -4170,12 +4154,10 @@ TEST_F(HopperMatmulTest, HSH_NN_UseScheduler) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
-  std::vector<c10::IValue> inputs = {a_ref, b_ref};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
+  ke.compile(&fusion, {t0, t1});
   EXPECT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1});
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
@@ -4206,9 +4188,9 @@ TEST_F(HopperMatmulTest, HSH_TT_UseScheduler) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA);
-  auto a_ref = at::randn({M, K, 1}, options);
-  auto b_ref = at::randn({1, K, N}, options);
-  auto out_ref = at::matmul(a_ref.squeeze(), b_ref.squeeze()).to(at::kHalf);
+  auto t0 = at::randn({M, K, 1}, options);
+  auto t1 = at::randn({1, K, N}, options);
+  auto out_ref = at::matmul(t0.squeeze(), t1.squeeze()).to(at::kHalf);
 
   MatMulTileOptions gemm_tile;
   gemm_tile.cta_tile = GemmTile(128, 256, 64);
@@ -4232,12 +4214,10 @@ TEST_F(HopperMatmulTest, HSH_TT_UseScheduler) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
-  std::vector<c10::IValue> inputs = {a_ref, b_ref};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
+  ke.compile(&fusion, {t0, t1});
   EXPECT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1});
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
@@ -4283,9 +4263,9 @@ TEST_P(MLPBenchmarkTest, FwdGEMM) {
   fusion.addOutput(tv2);
 
   auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA);
-  auto a_ref = at::randn({M, K}, options);
-  auto b_ref = at::randn({N, K}, options);
-  auto out_ref = at::linear(a_ref, b_ref);
+  auto t0 = at::randn({M, K}, options);
+  auto t1 = at::randn({N, K}, options);
+  auto out_ref = at::linear(t0, t1);
 
   MatMulTileOptions gemm_tile;
   gemm_tile.cta_tile = GemmTile(128, 256, 64);
@@ -4315,12 +4295,10 @@ TEST_P(MLPBenchmarkTest, FwdGEMM) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
-  std::vector<c10::IValue> inputs = {a_ref, b_ref};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
+  ke.compile(&fusion, {t0, t1});
   EXPECT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1});
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
@@ -4356,11 +4334,11 @@ TEST_P(MLPBenchmarkTest, FwdEpilogueFusion) {
   fusion.addOutput(tv11);
 
   auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA);
-  auto a_ref = at::randn({M, K}, options);
-  auto b_ref = at::randn({N, K}, options);
+  auto t0 = at::randn({M, K}, options);
+  auto t1 = at::randn({N, K}, options);
   auto c_ref = at::randn({M, N}, options);
 
-  auto tv3_ref = at::linear(a_ref, b_ref);
+  auto tv3_ref = at::linear(t0, t1);
   auto tv4_ref = tv3_ref.to(at::kFloat);
   auto tv11_ref =
       (tv4_ref * (1. / (1.0 + at::exp(-tv4_ref))) * c_ref).to(at::kBFloat16);
@@ -4392,12 +4370,10 @@ TEST_P(MLPBenchmarkTest, FwdEpilogueFusion) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
-  std::vector<c10::IValue> inputs = {a_ref, b_ref, c_ref};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
+  ke.compile(&fusion, {t0, t1, c_ref});
   EXPECT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1, c_ref});
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
@@ -4441,13 +4417,13 @@ TEST_P(MLPBenchmarkTest, FwdHorizontalFusion) {
   fusion.addOutput(tv12);
 
   auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA);
-  auto a_ref = at::randn({M, K}, options);
-  auto b_ref = at::randn({N, K}, options);
+  auto t0 = at::randn({M, K}, options);
+  auto t1 = at::randn({N, K}, options);
   auto c_ref = at::randn({N, K}, options);
 
-  auto tv3_ref = at::linear(a_ref, b_ref);
+  auto tv3_ref = at::linear(t0, t1);
   auto tv4_ref = tv3_ref.to(at::kFloat);
-  auto tv10_ref = at::linear(a_ref, c_ref);
+  auto tv10_ref = at::linear(t0, c_ref);
   auto tv12_ref =
       (tv4_ref * (1. / (1.0 + at::exp(-tv4_ref))) * tv10_ref.to(at::kFloat))
           .to(at::kBFloat16);
@@ -4479,12 +4455,10 @@ TEST_P(MLPBenchmarkTest, FwdHorizontalFusion) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
-  std::vector<c10::IValue> inputs = {a_ref, b_ref, c_ref};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
+  ke.compile(&fusion, {t0, t1, c_ref});
   EXPECT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1, c_ref});
   ASSERT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(
       ke.compiledKernel()->kernel()));
 
@@ -4539,9 +4513,9 @@ TEST_F(HopperMatmulTest, HSH_NT_UseScheduler_MultipleInstructionsPerWarpTile) {
   fusion.addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA);
-  auto a_ref = at::randn({K, M, 1}, options);
-  auto b_ref = at::randn({K, 1, N}, options);
-  auto out_ref = at::matmul(a_ref.squeeze().t(), b_ref.squeeze()).to(at::kHalf);
+  auto t0 = at::randn({K, M, 1}, options);
+  auto t1 = at::randn({K, 1, N}, options);
+  auto out_ref = at::matmul(t0.squeeze().t(), t1.squeeze()).to(at::kHalf);
 
   MatMulTileOptions gemm_tile;
   // Regardless of the instruction, this should result in 2 warp groups i.e. 256
@@ -4570,16 +4544,14 @@ TEST_F(HopperMatmulTest, HSH_NT_UseScheduler_MultipleInstructionsPerWarpTile) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
-  std::vector<c10::IValue> inputs = {a_ref, b_ref};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
+  ke.compile(&fusion, {t0, t1});
   kir::Kernel* kernel = ke.compiledKernel()->kernel();
   ASSERT_TRUE(kernel != nullptr);
   EXPECT_TRUE(getBankConflictInfo(kernel).empty());
   EXPECT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(kernel));
 
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1});
 
   // Check number of launched threads matches what we expect
   EXPECT_EQ(ke.lastLaunchParams().bdimx(), 128);
@@ -4610,10 +4582,10 @@ TEST_F(HopperMatmulTest, ScheduleWithTranslation) {
   fusion.addOutput(tv2);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA);
-  auto a_ref = at::randn({M, K}, options);
-  // auto b_ref = at::randn({N, K}, options).t();
-  auto b_ref = at::randn({K, N}, options);
-  auto out_ref = at::matmul(a_ref, b_ref);
+  auto t0 = at::randn({M, K}, options);
+  // auto t1 = at::randn({N, K}, options).t();
+  auto t1 = at::randn({K, N}, options);
+  auto out_ref = at::matmul(t0, t1);
 
   MatMulTileOptions gemm_tile;
   gemm_tile.cta_tile = GemmTile(128, 256, 16);
@@ -4637,16 +4609,14 @@ TEST_F(HopperMatmulTest, ScheduleWithTranslation) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
-  std::vector<c10::IValue> inputs = {a_ref, b_ref};
-
   KernelExecutor ke;
-  ke.compile(&fusion, inputs);
+  ke.compile(&fusion, {t0, t1});
   kir::Kernel* kernel = ke.compiledKernel()->kernel();
   ASSERT_TRUE(kernel != nullptr);
   EXPECT_TRUE(getBankConflictInfo(kernel).empty());
   EXPECT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(kernel));
 
-  auto cg_outputs = ke.run(inputs);
+  auto cg_outputs = ke.run({t0, t1});
 
   // Relax tolerance for larger sum due to large K
   EXPECT_TRUE(cg_outputs[0].allclose(out_ref, 1e-6 * K, 1e-6 * K));

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2720,8 +2720,8 @@ TEST_F(MatmulSchedulerTest, PreBroadcastMmaBiasNeg) {
       ->schedule(fusion.get(), &mparams);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
-  auto outputs = ke.run({t0, t1});
+  ke.compile(fusion.get(), {t0, t1, c}, LaunchParams(), matmul_cparams);
+  auto outputs = ke.run({t0, t1, c});
 
   NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
 }

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2701,7 +2701,6 @@ TEST_F(MatmulSchedulerTest, PreBroadcastMmaBiasNeg) {
       atBiasEpilogue(
           at::matmul(a.to(at::kFloat), b.to(at::kFloat).t()), c.to(at::kFloat))
           .neg_();
-  std::vector<c10::IValue> inputs{t0, t1, c};
 
   MatmulParams mparams;
   mparams.supported_vec_size = {8, 8, 4};
@@ -2721,8 +2720,8 @@ TEST_F(MatmulSchedulerTest, PreBroadcastMmaBiasNeg) {
       ->schedule(fusion.get(), &mparams);
 
   KernelExecutor ke;
-  ke.compile(fusion.get(), inputs, LaunchParams(), matmul_cparams);
-  auto outputs = ke.run(inputs);
+  ke.compile(fusion.get(), {t0, t1}, LaunchParams(), matmul_cparams);
+  auto outputs = ke.run({t0, t1});
 
   NVF_CHECK(outputs[0].allclose(tref, 0.001, 0.001));
 }
@@ -2753,18 +2752,17 @@ TEST_F(MatmulSchedulerTest, EpilogueFusionInt64Indexing) {
   const int M = 1 << 16, N = 1 << 15, K = 1 << 8;
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA);
-  at::Tensor a = at::randn({M, K}, options);
-  at::Tensor b = at::randn({K, N}, options);
-  std::vector<c10::IValue> inputs{a, b};
+  at::Tensor t0 = at::randn({M, K}, options);
+  at::Tensor t1 = at::randn({K, N}, options);
 
-  at::Tensor tref = -at::matmul(a, b);
+  at::Tensor tref = -at::matmul(t0, t1);
 
   FusionExecutorCache executor_cache(std::move(fusion));
 
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   testValidate(
-      executor_cache.fusion(), outputs, inputs, {tref}, __LINE__, __FILE__);
+      executor_cache.fusion(), outputs, {t0, t1}, {tref}, __LINE__, __FILE__);
 
   if (!cudaArchGuardShouldSkip(9, 0)) {
     // The Hopper matmul scheduler should reject this fusion since it requires
@@ -2829,9 +2827,8 @@ TEST_P(MatmulFusionTest, Llama2FFN) {
   auto t0 = at::randn({M, K}, options);
   auto t1 = at::randn({K, N}, options);
   auto t2 = at::randn({K, N}, options);
-  std::vector<c10::IValue> inputs{t0, t1, t2};
 
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   at::Tensor t3, t4;
   if (fusion_enabled) {
@@ -3232,13 +3229,12 @@ TEST_F(MatmulSchedulerTest, OperandOrderIssue2434) {
   fusion->addOutput(mm);
 
   auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA);
-  auto x_ref = at::randn({M, K}, options);
-  auto y_ref = at::randn({N, K}, options);
-  std::vector<c10::IValue> inputs{x_ref, y_ref};
+  auto t0 = at::randn({M, K}, options);
+  auto t1 = at::randn({N, K}, options);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
-  auto tref = at::linear(x_ref.to(at::kFloat), y_ref.to(at::kFloat));
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
+  auto tref = at::linear(t0.to(at::kFloat), t1.to(at::kFloat));
   NVF_CHECK(cg_outputs[0].allclose(tref, 0.0001, 0.0001));
 }
 

--- a/tests/cpp/test_move_pad.cpp
+++ b/tests/cpp/test_move_pad.cpp
@@ -39,16 +39,15 @@ TEST_F(MovePadTest, UnaryCat) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4, 10}, options);
   at::Tensor t1 = at::randn({2, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_EQ(runtime->fusionSegments()->groups().size(), 1);
 
   testValidate(
-      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(MovePadTest, BinaryCat) {
@@ -70,16 +69,15 @@ TEST_F(MovePadTest, BinaryCat) {
   at::Tensor t0 = at::randn({4, 10}, options);
   at::Tensor t1 = at::randn({4, 10}, options);
   at::Tensor t2 = at::randn({2, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_EQ(runtime->fusionSegments()->groups().size(), 1);
 
   testValidate(
-      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(MovePadTest, BinaryBroadcastOnNonCatDim) {
@@ -105,10 +103,9 @@ TEST_F(MovePadTest, BinaryBroadcastOnNonCatDim) {
   at::Tensor t0 = at::randn({4, 10}, options);
   at::Tensor t1 = at::randn({10}, options);
   at::Tensor t2 = at::randn({4, 5}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   // ensure that we propagate the pad across binary operation and the first
   // segment is no-op
@@ -120,7 +117,7 @@ TEST_F(MovePadTest, BinaryBroadcastOnNonCatDim) {
           HeuristicIs(SchedulerType::PointWise)));
 
   testValidate(
-      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(MovePadTest, BinaryBroadcastOnCatDim) {
@@ -145,16 +142,15 @@ TEST_F(MovePadTest, BinaryBroadcastOnCatDim) {
   at::Tensor t0 = at::randn({4, 10}, options);
   at::Tensor t1 = at::randn({10}, options);
   at::Tensor t2 = at::randn({2, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_EQ(runtime->fusionSegments()->groups().size(), 2);
 
   testValidate(
-      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 TEST_F(MovePadTest, PadReplayOnMultipleUsesCase0) {
@@ -181,16 +177,15 @@ TEST_F(MovePadTest, PadReplayOnMultipleUsesCase0) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4, 10}, options);
   at::Tensor t1 = at::randn({1, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_EQ(runtime->fusionSegments()->groups().size(), 1);
 
   testValidate(
-      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(MovePadTest, PadReplayOnMultipleUsesCase1) {
@@ -218,13 +213,12 @@ TEST_F(MovePadTest, PadReplayOnMultipleUsesCase1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4, 10}, options);
   at::Tensor t1 = at::randn({4, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1});
 
   testValidate(
-      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(MovePadTest, CascadePadCase0) {
@@ -268,18 +262,16 @@ TEST_F(MovePadTest, CascadePadCase0) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   Fusion* complete_fusion = runtime->fusionSegments()->completeFusion();
   std::vector<Expr*> exprs = complete_fusion->exprs();
   EXPECT_THAT(exprs, Contains(Property(&Expr::isA<PadOp>, IsTrue())).Times(1));
 
-  testValidate(
-      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(MovePadTest, CascadePadCase1) {
@@ -307,18 +299,16 @@ TEST_F(MovePadTest, CascadePadCase1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   Fusion* complete_fusion = runtime->fusionSegments()->completeFusion();
   std::vector<Expr*> exprs = complete_fusion->exprs();
   EXPECT_THAT(exprs, Contains(Property(&Expr::isA<PadOp>, IsTrue())).Times(2));
 
-  testValidate(
-      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(MovePadTest, CascadePadCase2) {
@@ -365,13 +355,11 @@ TEST_F(MovePadTest, CascadePadCase2) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(
-      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(MovePadTest, NotMergeNegativePad) {
@@ -398,13 +386,11 @@ TEST_F(MovePadTest, NotMergeNegativePad) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4, 10}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(
-      executor_cache.fusion(), out_tensors, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(MovePadTest, BooleanCat) {
@@ -426,10 +412,9 @@ TEST_F(MovePadTest, BooleanCat) {
   at::Tensor t0 = at::randn({4, 10}, options) > 0.5;
   at::Tensor t1 = at::randn({4, 10}, options) > 0.5;
   at::Tensor t2 = at::randn({2, 10}, options) > 0.5;
-  std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto out_tensors = executor_cache.runFusionWithInputs(aten_inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_EQ(runtime->fusionSegments()->groups().size(), 1);
@@ -442,7 +427,7 @@ TEST_F(MovePadTest, BooleanCat) {
   testValidate(
       executor_cache.fusion(),
       out_tensors,
-      aten_inputs,
+      {t0, t1, t2},
       {ref},
       __LINE__,
       __FILE__);
@@ -472,12 +457,11 @@ TEST_F(MovePadTest, Issue3597Repro) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({5, 10}, options);
   auto t1 = at::randn({4, 10}, options);
-  std::vector<c10::IValue> inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -390,7 +390,7 @@ TEST_F(OverlapDistributedMatmulTest, AG_matmul) {
   auto t0 = t0_unsharded.slice(
       1, communicator_->deviceId(), communicator_->deviceId() + 1);
   auto t1 = at::randn({K, N}, tensor_options);
-  auto tc_ref = at::matmul(t0, t1);
+  auto t2_ref = at::matmul(t0_unsharded, t1);
 
   at::Tensor t2;
 
@@ -404,7 +404,7 @@ TEST_F(OverlapDistributedMatmulTest, AG_matmul) {
   }
   cudaProfilerStop();
 
-  EXPECT_TRUE(torch::allclose(tc_ref, t2, 1e-2, 1e-2));
+  EXPECT_TRUE(torch::allclose(t2_ref, t2, 1e-2, 1e-2));
 }
 
 TEST_F(OverlapDistributedMatmulTest, AG_linear) {

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -117,10 +117,10 @@ TEST_P(MultiDeviceHostIrTest, SingleFusionSingleComm) {
   HostIrEvaluator hie(std::move(hic), communicator_, params);
 
   auto options = at::TensorOptions().device(communicator_->device());
-  at::Tensor unsharded_input = at::randn(unsharded_input_sizes, options);
-  c10::IValue input = unsharded_input.slice(
+  auto unsharded_input = at::randn(unsharded_input_sizes, options);
+  auto input = unsharded_input.slice(
       0, communicator_->deviceId(), communicator_->deviceId() + 1);
-  at::Tensor output = at::empty(unsharded_input_sizes, options);
+  auto output = at::empty(unsharded_input_sizes, options);
   auto ref_output = unsharded_input * 2;
 
   auto outputs = hie.runWithInput(
@@ -212,10 +212,10 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   HostIrEvaluator hie(std::move(hic), communicator_, params);
 
   auto options = at::TensorOptions().device(communicator_->device());
-  at::Tensor unsharded_input = at::randn(unsharded_input_sizes, options);
-  c10::IValue input = unsharded_input.slice(
+  auto unsharded_input = at::randn(unsharded_input_sizes, options);
+  auto input = unsharded_input.slice(
       0, communicator_->deviceId(), communicator_->deviceId() + 1);
-  at::Tensor output = at::empty(unsharded_input_sizes, options);
+  auto output = at::empty(unsharded_input_sizes, options);
   auto ref_output = unsharded_input * 2;
 
   auto outputs = hie.runWithInput(
@@ -366,34 +366,33 @@ TEST_F(OverlapDistributedMatmulTest, AG_matmul) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
-  TensorView* a = makeContigTensor(4); //[S, DIDx(D), M/(S*D), K]
-  TensorView* b = makeContigTensor(2); //[K, N]
-  TensorView* c = matmul(a, b); //[S, D, M/(S*D), N]
+  TensorView* tv0 = makeContigTensor(4); //[S, DIDx(D), M/(S*D), K]
+  TensorView* tv1 = makeContigTensor(2); //[K, N]
+  TensorView* tv2 = matmul(tv0, tv1); //[S, D, M/(S*D), N]
 
-  fusion->addInput(a);
-  fusion->addInput(b);
-  fusion->addOutput(c);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addOutput(tv2);
 
   auto mesh = DeviceMesh::createForNumDevices(D);
-  a->setDeviceMesh(mesh);
-  b->setDeviceMesh(mesh);
-  c->setDeviceMesh(mesh);
+  tv0->setDeviceMesh(mesh);
+  tv1->setDeviceMesh(mesh);
+  tv2->setDeviceMesh(mesh);
 
-  a->axis(1)->parallelize(ParallelType::DIDx);
-  c->axis(0)->parallelize(ParallelType::Stream);
+  tv0->axis(1)->parallelize(ParallelType::DIDx);
+  tv2->axis(0)->parallelize(ParallelType::Stream);
 
   MultiDeviceExecutor executor(std::move(fusion), *communicator_);
 
   auto tensor_options =
       at::TensorOptions().dtype(at::kFloat).device(communicator_->device());
-  at::Tensor ta_unsharded = at::randn({S, D, M / (S * D), K}, tensor_options);
-  at::Tensor ta = ta_unsharded.slice(
+  auto t0_unsharded = at::randn({S, D, M / (S * D), K}, tensor_options);
+  auto t0 = t0_unsharded.slice(
       1, communicator_->deviceId(), communicator_->deviceId() + 1);
-  at::Tensor tb = at::randn({K, N}, tensor_options);
-  at::Tensor tc_ref = at::matmul(ta_unsharded, tb);
+  auto t1 = at::randn({K, N}, tensor_options);
+  auto tc_ref = at::matmul(t0, t1);
 
-  std::vector<c10::IValue> inputs = {ta, tb};
-  at::Tensor tc;
+  at::Tensor t2;
 
   constexpr int64_t kNumberOfIterations = 20;
   constexpr int64_t kNumberOfWarmupIterations = 5;
@@ -401,11 +400,11 @@ TEST_F(OverlapDistributedMatmulTest, AG_matmul) {
     if (i == kNumberOfWarmupIterations) {
       cudaProfilerStart();
     }
-    tc = executor.runWithInput(inputs).at(0);
+    t2 = executor.runWithInput({t0, t1}).at(0);
   }
   cudaProfilerStop();
 
-  EXPECT_TRUE(torch::allclose(tc_ref, tc, 1e-2, 1e-2));
+  EXPECT_TRUE(torch::allclose(tc_ref, t2, 1e-2, 1e-2));
 }
 
 TEST_F(OverlapDistributedMatmulTest, AG_linear) {
@@ -453,7 +452,6 @@ TEST_F(OverlapDistributedMatmulTest, AG_linear) {
   at::Tensor bias_at = at::randn({N}, tensor_options);
   at::Tensor out_ref = at::linear(in_at_unsharded, weight_at, bias_at);
 
-  std::vector<c10::IValue> inputs = {in_at, weight_at, bias_at};
   at::Tensor out_at;
 
   constexpr int64_t kNumberOfIterations = 20;
@@ -462,7 +460,7 @@ TEST_F(OverlapDistributedMatmulTest, AG_linear) {
     if (i == kNumberOfWarmupIterations) {
       cudaProfilerStart();
     }
-    out_at = executor.runWithInput(inputs).at(0);
+    out_at = executor.runWithInput({in_at, weight_at, bias_at}).at(0);
   }
   torch::cuda::synchronize();
   cudaProfilerStop();

--- a/tests/cpp/test_multidevice_matmul.cpp
+++ b/tests/cpp/test_multidevice_matmul.cpp
@@ -384,7 +384,7 @@ TEST_F(DistributedMatmulTest, PresegPreservesSharding) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   std::vector<c10::IValue> inputs({x_tensor, sharded_w_tensor});
-  std::vector<at::Tensor> outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs(inputs);
 
   at::Tensor expected_mm_t_tensor =
       atMatmul(x_tensor, w_tensor.view({mesh.size() * 36, 48}), MmaLayout::TN)
@@ -427,7 +427,7 @@ TEST_F(DistributedMatmulTest, AnnotateWeightOnly) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   std::vector<c10::IValue> inputs({x_tensor, sharded_w_tensor});
-  std::vector<at::Tensor> outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs(inputs);
 
   at::Tensor expected_y_tensor = at::matmul(x_tensor, w_tensor);
   testValidate(
@@ -490,8 +490,7 @@ TEST_F(DistributedMatmulTest, RowParallelLinear) {
     auto sharded_w = shardTensor(w_tensor, w);
 
     std::vector<c10::IValue> in_tensors({sharded_x, sharded_w});
-    std::vector<at::Tensor> out_tensors =
-        executor_cache.runFusionWithInputs(in_tensors);
+    auto out_tensors = executor_cache.runFusionWithInputs(in_tensors);
 
     at::Tensor expected_y_tensor = at::linear(x_tensor, w_tensor);
     testValidate(

--- a/tests/cpp/test_multidevice_sharding.cpp
+++ b/tests/cpp/test_multidevice_sharding.cpp
@@ -60,20 +60,14 @@ TEST_P(MultiDeviceReductionTest, UnshardedInput_ShardedOutput) {
   }
 
   auto x0 = at::randn(input_shape, tensor_options);
-  std::vector<c10::IValue> inputs = {x0};
   auto x1 = shardTensor(x0, tv1);
   auto x2 = x1 + x1;
   auto x3 = shardTensor(at::sum(x0 + x0, {sharded_input_dim}), tv3);
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({x0});
 
   testValidate(
-      executor_cache.fusion(),
-      outputs,
-      inputs,
-      {x1, x2, x3},
-      __LINE__,
-      __FILE__);
+      executor_cache.fusion(), outputs, {x0}, {x1, x2, x3}, __LINE__, __FILE__);
 }
 
 // Test multidevice fusion with sharded input and replicated intermediates and

--- a/tests/cpp/test_no_op.cpp
+++ b/tests/cpp/test_no_op.cpp
@@ -38,10 +38,8 @@ TEST_F(NoOpTest, FusionNullScheduler) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({1, 1, 1}, options);
 
-  std::vector<c10::IValue> aten_inputs({t0});
-
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto t1 = t0.sum({0, 1, 2});
 
@@ -71,10 +69,8 @@ TEST_F(NoOpTest, FusionNullScheduler2) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({0, 1, 9223372036854775807L}, options);
 
-  std::vector<c10::IValue> aten_inputs({t0});
-
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 
@@ -103,10 +99,8 @@ TEST_F(NoOpTest, FusionNullScheduler3) {
   at::Tensor t0 = at::randn({}, options);
   at::Tensor t1 = at::randn({}, options);
 
-  std::vector<c10::IValue> aten_inputs({t0, t1});
-
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   testValidate(
       executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -134,10 +128,8 @@ TEST_F(NoOpTest, FusionReducingZeroElements) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({0, 1, 9223372036854775807L}, options);
 
-  std::vector<c10::IValue> aten_inputs({t0});
-
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
@@ -157,10 +149,8 @@ TEST_F(NoOpTest, FusionEmpty) {
   at::Tensor t0 = at::randn({10, 10, 10}, options);
   at::Tensor t1 = at::randn({10, 10, 10}, options);
 
-  std::vector<c10::IValue> aten_inputs({t0, t1});
-
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   testValidate(
       executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
@@ -189,8 +179,7 @@ TEST_F(NoOpTest, View) {
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
       at::randn({2, 3, 4}, at::dtype(at::kFloat).device(at::kCUDA, 0));
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
   at::Tensor out_tensor = out_tensors[0];
 

--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -467,12 +467,12 @@ TEST_F(
   at::Tensor aten_input = at::randn(input_shape, options);
   c10::optional<at::Tensor> aten_weight = at::randn({input_shape[1]}, options);
   c10::optional<at::Tensor> aten_bias = at::randn({input_shape[1]}, options);
-  std::vector<c10::IValue> aten_inputs{aten_input, aten_weight, aten_bias};
   auto aten_outputs = at::native_layer_norm(
       aten_input, norm_shape, aten_weight, aten_bias, kEps);
 
   // welford translate
-  KernelArgumentHolder runtime_inputs = KernelArgumentHolder(aten_inputs);
+  KernelArgumentHolder runtime_inputs =
+      KernelArgumentHolder({aten_input, aten_weight, aten_bias});
   bool isTranslated =
       SegmentCandidateFinder::translateWelfordInFusion(&fusion, runtime_inputs);
   NVF_ERROR(isTranslated);
@@ -489,13 +489,15 @@ TEST_F(
       persistent_buffer_info.projectable_buffer_inputs[0] == input_half,
       "persistent buffer should be projected to input!");
 
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::InnerPersistent, aten_inputs)
-          .outputs;
+  auto cg_outputs = scheduleAndRun(
+                        &fusion,
+                        SchedulerType::InnerPersistent,
+                        {aten_input, aten_weight, aten_bias})
+                        .outputs;
   testValidate(
       &fusion,
       cg_outputs,
-      aten_inputs,
+      {aten_input, aten_weight, aten_bias},
       {std::get<0>(aten_outputs),
        std::get<1>(aten_outputs),
        std::get<2>(aten_outputs)},
@@ -569,34 +571,25 @@ TEST_F(PersistentBufferTest, FusionLayerNormFusedOpsRedundantCast_CUDA) {
   }
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-  std::vector<c10::IValue> inputs;
-  std::vector<at::Tensor> outputs;
 
-  {
-    auto t0 = at::randn({hidden_size}, options);
-    auto t1 = at::randn({batch_size, hidden_size}, options);
-    auto t2 = at::randn({hidden_size}, options);
-    auto t3 = at::randn({hidden_size}, options);
-    auto t4 = at::randn({hidden_size}, options);
-    inputs.emplace_back(t0);
-    inputs.emplace_back(t1);
-    inputs.emplace_back(t2);
-    inputs.emplace_back(t3);
-    inputs.emplace_back(t4);
-    auto t5 = t0.unsqueeze(0).expand({batch_size, hidden_size});
-    auto t6 = t1.to(at::kFloat);
-    auto t7 = t5.to(at::kFloat);
-    auto t8 = at::add(t6, t7);
-    auto t9 = t8.to(at::kHalf);
-    auto t10 = t2.unsqueeze(0).expand({batch_size, hidden_size});
-    auto t11 = t9.to(at::kFloat);
-    auto t12 = t10.to(at::kFloat);
-    auto t13 = at::add(t11, t12);
-    auto t14 = t13.to(at::kHalf);
-    auto aten_outputs = at::native_layer_norm(t14, {hidden_size}, t4, t3, kEps);
-    auto t33 = std::get<0>(aten_outputs);
-    outputs.emplace_back(t33);
-  }
+  auto t0 = at::randn({hidden_size}, options);
+  auto t1 = at::randn({batch_size, hidden_size}, options);
+  auto t2 = at::randn({hidden_size}, options);
+  auto t3 = at::randn({hidden_size}, options);
+  auto t4 = at::randn({hidden_size}, options);
+
+  auto t5 = t0.unsqueeze(0).expand({batch_size, hidden_size});
+  auto t6 = t1.to(at::kFloat);
+  auto t7 = t5.to(at::kFloat);
+  auto t8 = at::add(t6, t7);
+  auto t9 = t8.to(at::kHalf);
+  auto t10 = t2.unsqueeze(0).expand({batch_size, hidden_size});
+  auto t11 = t9.to(at::kFloat);
+  auto t12 = t10.to(at::kFloat);
+  auto t13 = at::add(t11, t12);
+  auto t14 = t13.to(at::kHalf);
+  auto aten_outputs = at::native_layer_norm(t14, {hidden_size}, t4, t3, kEps);
+  auto t33 = std::get<0>(aten_outputs);
 
   auto persistent_buffer_info = scheduler_utils::persistentBuffers(fusion);
   NVF_CHECK(
@@ -605,7 +598,7 @@ TEST_F(PersistentBufferTest, FusionLayerNormFusedOpsRedundantCast_CUDA) {
 
   // The buffer size should only count 1 buffer because the other one is
   // projected to its producer.
-  SchedulerRuntimeInfo runtime_info(fusion, inputs);
+  SchedulerRuntimeInfo runtime_info(fusion, {t0, t1, t2, t3, t4});
   auto persistent_buffer_size =
       persistentBufferSize(fusion, runtime_info, persistent_buffer_info);
   NVF_CHECK(
@@ -614,8 +607,9 @@ TEST_F(PersistentBufferTest, FusionLayerNormFusedOpsRedundantCast_CUDA) {
       "Persistent buffer size is not correct!");
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(fusion, cg_outputs, inputs, outputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2, t3, t4});
+  testValidate(
+      fusion, cg_outputs, {t0, t1, t2, t3, t4}, {t33}, __LINE__, __FILE__);
 }
 
 TEST_F(PersistentBufferTest, FusionRecomputePersistentBuffer_CUDA) {
@@ -648,27 +642,18 @@ TEST_F(PersistentBufferTest, FusionRecomputePersistentBuffer_CUDA) {
   }
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  std::vector<c10::IValue> inputs;
-  std::vector<at::Tensor> outputs;
 
-  {
-    auto t0 = at::randn({batch_size, hidden_size}, options);
-    auto t1 = at::randn({batch_size, hidden_size}, options);
-    inputs.emplace_back(t0);
-    inputs.emplace_back(t1);
+  auto t0 = at::randn({batch_size, hidden_size}, options);
+  auto t1 = at::randn({batch_size, hidden_size}, options);
 
-    auto t2 = t0.add(t1);
-    auto t3 = t2.to(at::kHalf);
-    auto t4 = t3.to(at::kFloat);
-    auto t5 = t4.sum({1});
-    auto t6 = t5.unsqueeze(1).expand({batch_size, hidden_size});
-    auto t7 = t4.add(t6);
-    auto t8 = t3.to(at::kFloat);
-    auto t9 = t8.add(t6);
-
-    outputs.emplace_back(t7);
-    outputs.emplace_back(t9);
-  }
+  auto t2 = t0.add(t1);
+  auto t3 = t2.to(at::kHalf);
+  auto t4 = t3.to(at::kFloat);
+  auto t5 = t4.sum({1});
+  auto t6 = t5.unsqueeze(1).expand({batch_size, hidden_size});
+  auto t7 = t4.add(t6);
+  auto t8 = t3.to(at::kFloat);
+  auto t9 = t8.add(t6);
 
   auto persistent_buffer_info1 = scheduler_utils::persistentBuffers(fusion);
   NVF_CHECK(
@@ -682,8 +667,8 @@ TEST_F(PersistentBufferTest, FusionRecomputePersistentBuffer_CUDA) {
       "After project to other buffers, should have one persistent buffer!");
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(fusion, cg_outputs, inputs, outputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
+  testValidate(fusion, cg_outputs, {t0, t1}, {t7, t9}, __LINE__, __FILE__);
 }
 
 TEST_F(PersistentBufferTest, ProjectPersistentBufferMultiScopes) {
@@ -735,7 +720,6 @@ TEST_F(PersistentBufferTest, ProjectPersistentBufferMultiScopes) {
   auto t0 = at::randn({batch_size, hidden_size}, options);
   auto t1 = at::randn({batch_size, hidden_size}, options);
   auto t2 = at::randn({batch_size, hidden_size}, options);
-  std::vector<c10::IValue> aten_inputs{t0, t1, t2};
 
   // The persistent buffers in this fusion are: tv3, tv7, tv12, and tv17. Note
   // that tv7 can be projected back to its producer, tv3. When calculating the
@@ -748,7 +732,7 @@ TEST_F(PersistentBufferTest, ProjectPersistentBufferMultiScopes) {
   // tv12 and tv17. The max buffer size is based on tv12 and tv17. There is no
   // projectable buffer needs to be deducted in this scope.
   auto persistent_info = scheduler_utils::persistentBuffers(fusion);
-  SchedulerRuntimeInfo runtime_info(fusion, aten_inputs);
+  SchedulerRuntimeInfo runtime_info(fusion, {t0, t1, t2});
   auto persistent_buffer_size =
       persistentBufferSize(fusion, runtime_info, persistent_info);
   auto calculated_size = persistent_buffer_size.persistent_buffer_size;
@@ -757,7 +741,7 @@ TEST_F(PersistentBufferTest, ProjectPersistentBufferMultiScopes) {
   EXPECT_EQ(calculated_size, expected_size)
       << "Buffer size calculation failure";
   auto heuristic_params = SchedulerEntry::scheduleWith(
-      fusion, SchedulerType::InnerPersistent, aten_inputs);
+      fusion, SchedulerType::InnerPersistent, {t0, t1, t2});
   auto rparams = heuristic_params->as<ReductionParams>();
   NVF_CHECK(
       !rparams->project_persistent_buffers,
@@ -811,7 +795,6 @@ TEST_F(PersistentBufferTest, ChainProjectionToPersistentProducer) {
   auto t0 = at::randn({batch_size, hidden_size}, options);
   auto t1 = at::randn({batch_size, hidden_size}, options);
   auto t2 = at::randn({batch_size, hidden_size}, options);
-  std::vector<c10::IValue> aten_inputs{t0, t1, t2};
   auto t3 = t0.to(at::kFloat) + t1.to(at::kFloat) + t2.to(at::kFloat);
   auto t4 = at::sum(t3, {1}, true);
   auto t5 = t3 + t4;
@@ -827,7 +810,7 @@ TEST_F(PersistentBufferTest, ChainProjectionToPersistentProducer) {
   // tv15 to tv11, then project tv11 to tv7.
   // After projection, tv7 is the only buffer.
   auto persistent_info = scheduler_utils::persistentBuffers(fusion);
-  SchedulerRuntimeInfo runtime_info(fusion, aten_inputs);
+  SchedulerRuntimeInfo runtime_info(fusion, {t0, t1, t2});
   auto persistent_buffer_size =
       persistentBufferSize(fusion, runtime_info, persistent_info);
   auto calculated_size = persistent_buffer_size.persistent_buffer_size;
@@ -843,7 +826,7 @@ TEST_F(PersistentBufferTest, ChainProjectionToPersistentProducer) {
   // If project to inputs, there are 3 fp16 tvs, which is larger than 1 fp32.
   // So, shouldn't project to inputs.
   auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::InnerPersistent, aten_inputs);
+      scheduleAndRun(fusion, SchedulerType::InnerPersistent, {t0, t1, t2});
   auto rparams = cg_results.heuristic_params->as<ReductionParams>();
 
   NVF_CHECK(
@@ -852,7 +835,7 @@ TEST_F(PersistentBufferTest, ChainProjectionToPersistentProducer) {
   testValidate(
       fusion,
       cg_results.outputs,
-      aten_inputs,
+      {t0, t1, t2},
       {t5, t8, t11},
       __LINE__,
       __FILE__);
@@ -1257,15 +1240,13 @@ TEST_F(PersistentBufferTest, SmemPersistentNotSupportedIn3DReduction) {
   auto t0 = at::randn(input_shape, options);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  std::vector<c10::IValue> aten_inputs = {t0};
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   // should be segmented since buffer size is larger than 32K and smem
   // persistent is not supported yet for 3D reduction.
   EXPECT_TRUE(executor_cache.getMostRecentKernelRuntime()->isSegmented());
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PersistentBufferTest, SmemPersistent2DReduction) {
@@ -1298,8 +1279,7 @@ TEST_F(PersistentBufferTest, SmemPersistent2DReduction) {
                      .dtype(data_type_to_aten(input_dtype))
                      .device(at::kCUDA, 0);
   auto t0 = at::randn(input_shape, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
-  SchedulerRuntimeInfo runtime_info(fusion.get(), aten_inputs);
+  SchedulerRuntimeInfo runtime_info(fusion.get(), {t0});
   ASSERT_TRUE(Schedule::canSchedule(
       SchedulerType::InnerPersistent, fusion.get(), runtime_info));
   auto scheduler =
@@ -1312,7 +1292,7 @@ TEST_F(PersistentBufferTest, SmemPersistent2DReduction) {
 
   // Run the fusion and validate the results
   KernelExecutor ke;
-  ke.compile(fusion.get(), aten_inputs);
+  ke.compile(fusion.get(), {t0});
   // Shared memory access should be vectorized.
   // getBankConflictInfo(ke.compiledKernel()->kernel()) triggers error
   // "std::get: wrong index for variant" when trying to evaluate index with:
@@ -1328,9 +1308,9 @@ TEST_F(PersistentBufferTest, SmemPersistent2DReduction) {
     }
   }
   auto cg_outputs =
-      ke.run(aten_inputs, heuristic_params->as<ReductionParams>()->lparams);
+      ke.run({t0}, heuristic_params->as<ReductionParams>()->lparams);
   auto t1 = t0 / t0.sum({1, 2, 3}, true);
-  testValidate(fusion.get(), cg_outputs, aten_inputs, {t1}, __LINE__, __FILE__);
+  testValidate(fusion.get(), cg_outputs, {t0}, {t1}, __LINE__, __FILE__);
 }
 
 // C++ version of the simplified repro of issue #1123
@@ -1407,13 +1387,12 @@ TEST_F(PersistentBufferTest, InnerPersistentNotEnoughSharedMemory) {
   auto t0 = at::randn(input_shape, options);
   auto t1 = at::randn({input_shape[1]}, options);
   auto t2 = at::randn({input_shape[1]}, options);
-  std::vector<c10::IValue> inputs({t0, t1, t2});
 
   // The logic size of the persistent buffer in this fusion is 80 * 1024 * 2
   // bytes. Inner persistent scheduler allows 32 * 1024 * 4 bytes for register
   // persistent, so it should use shared memory persistent buffer if there are
   // enough shared memory. Otherwise, it will be segmented.
-  SchedulerRuntimeInfo runtime_info(&fusion, inputs);
+  SchedulerRuntimeInfo runtime_info(&fusion, {t0, t1, t2});
   auto persistent_buffer_info = scheduler_utils::persistentBuffers(&fusion);
   auto persistent_buffer_size =
       persistentBufferSize(&fusion, runtime_info, persistent_buffer_info);
@@ -1443,7 +1422,7 @@ TEST_F(PersistentBufferTest, InnerPersistentNotEnoughSharedMemory) {
   }
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   // check segmentation, if not segmented, further check shared memory
   // persistence
@@ -1455,7 +1434,7 @@ TEST_F(PersistentBufferTest, InnerPersistentNotEnoughSharedMemory) {
     ASSERT_TRUE(
         params->as<ReductionParams>()->smem_persistent_buffers.size() > 0);
   }
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 using TestParam = std::tuple<DataType, int64_t>;
@@ -1492,15 +1471,15 @@ TEST_P(LayerNormSharedMemoryTest, FusionLayerNormSharedMemoryBuffer_CUDA) {
   at::Tensor aten_input = at::randn(input_shape, options);
   c10::optional<at::Tensor> aten_weight = at::randn({input_shape[1]}, options);
   c10::optional<at::Tensor> aten_bias = at::randn({input_shape[1]}, options);
-  std::vector<c10::IValue> aten_inputs = {aten_input, aten_weight, aten_bias};
 
   // try translate Welford in fusion
-  KernelArgumentHolder runtime_inputs = KernelArgumentHolder(aten_inputs);
+  KernelArgumentHolder runtime_inputs =
+      KernelArgumentHolder({aten_input, aten_weight, aten_bias});
   SegmentCandidateFinder::translateWelfordInFusion(&fusion, runtime_inputs);
   auto fusion_copy = fusion;
 
   // check persistent buffer size
-  SchedulerRuntimeInfo runtime_info(&fusion, aten_inputs);
+  SchedulerRuntimeInfo runtime_info(&fusion, runtime_inputs);
   auto persistent_buffer_info = scheduler_utils::persistentBuffers(&fusion);
   auto persistent_buffer_size =
       persistentBufferSize(&fusion, runtime_info, persistent_buffer_info);
@@ -1530,7 +1509,8 @@ TEST_P(LayerNormSharedMemoryTest, FusionLayerNormSharedMemoryBuffer_CUDA) {
 
   // check segmentation and smem usage
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs =
+      executor_cache.runFusionWithInputs({aten_input, aten_weight, aten_bias});
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   if (has_enough_regs_smem) {
     EXPECT_THAT(
@@ -1557,7 +1537,13 @@ TEST_P(LayerNormSharedMemoryTest, FusionLayerNormSharedMemoryBuffer_CUDA) {
         runtime->fusionSegments()->groups(),
         Contains(HeuristicIs(SchedulerType::Reduction)));
   }
-  testValidate(&fusion_copy, cg_outputs, aten_inputs, __LINE__, __FILE__, "");
+  testValidate(
+      &fusion_copy,
+      cg_outputs,
+      {aten_input, aten_weight, aten_bias},
+      __LINE__,
+      __FILE__,
+      "");
 }
 INSTANTIATE_TEST_SUITE_P(
     PersistentBufferTest,

--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -80,12 +80,12 @@ TEST_F(PointwiseTest, VectorizeStrideContiguity2D) {
     auto size = pair.first;
     auto vec = pair.second;
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-    at::Tensor input0 = at::randn({1000000, size}, options).narrow(1, 0, 16);
-    auto cg_outputs = executor_cache.runFusionWithInputs({input0});
+    at::Tensor t0 = at::randn({1000000, size}, options).narrow(1, 0, 16);
+    auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
     EXPECT_EQ(getVecSizeForPointwise(executor_cache), vec);
 
-    testValidate(fusion, cg_outputs, {input0}, __LINE__, __FILE__);
+    testValidate(fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
 
@@ -108,12 +108,12 @@ TEST_F(PointwiseTest, VectorizeStrideContiguity3D) {
     auto size = pair.first;
     auto vec = pair.second;
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-    at::Tensor input0 = at::randn({1000000, size, 3}, options).narrow(1, 0, 8);
-    auto cg_outputs = executor_cache.runFusionWithInputs({input0});
+    at::Tensor t0 = at::randn({1000000, size, 3}, options).narrow(1, 0, 8);
+    auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
     EXPECT_EQ(getVecSizeForPointwise(executor_cache), vec);
 
-    testValidate(fusion, cg_outputs, {input0}, __LINE__, __FILE__);
+    testValidate(fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
 
@@ -141,14 +141,14 @@ TEST_F(PointwiseTest, VectorizeStrideContiguity5D) {
     auto size1 = std::get<0>(tup);
     auto size2 = std::get<1>(tup);
     auto vec = std::get<2>(tup);
-    at::Tensor input0 = at::randn({4, size1, 12345, size2, 3}, options)
-                            .narrow(1, 0, 8)
-                            .narrow(3, 0, 4);
-    auto cg_outputs = executor_cache.runFusionWithInputs({input0});
+    at::Tensor t0 = at::randn({4, size1, 12345, size2, 3}, options)
+                        .narrow(1, 0, 8)
+                        .narrow(3, 0, 4);
+    auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
     EXPECT_EQ(getVecSizeForPointwise(executor_cache), vec);
 
-    testValidate(fusion, cg_outputs, {input0}, __LINE__, __FILE__);
+    testValidate(fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
 
@@ -203,11 +203,10 @@ TEST_F(PointwiseTest, VectorizeStrideMisalignedBase) {
     }
     alloc_size += align;
     at::Tensor flat = at::randn({alloc_size}, options);
-    at::Tensor input0 =
-        flat.as_strided(shape, stride, /*storage_offset=*/align);
-    auto cg_outputs = executor_cache.runFusionWithInputs({input0});
+    at::Tensor t0 = flat.as_strided(shape, stride, /*storage_offset=*/align);
+    auto cg_outputs = executor_cache.runFusionWithInputs({t0});
     EXPECT_EQ(getVecSizeForPointwise(executor_cache), vec);
-    testValidate(fusion, cg_outputs, {input0}, __LINE__, __FILE__);
+    testValidate(fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
 
@@ -249,11 +248,11 @@ TEST_F(PointwiseTest, VectorizeStrideContiguitySelfOverlapping) {
     std::vector<int64_t> shape = {4, 4, 12345, size, 3};
     std::vector<int64_t> stride = {
         stride1, (int64_t)stride2 * 12345, (int64_t)stride2, 3, 1};
-    at::Tensor input0 = at::empty_strided(shape, stride, options);
-    input0.random_();
-    auto cg_outputs = executor_cache.runFusionWithInputs({input0});
+    at::Tensor t0 = at::empty_strided(shape, stride, options);
+    t0.random_();
+    auto cg_outputs = executor_cache.runFusionWithInputs({t0});
     EXPECT_EQ(getVecSizeForPointwise(executor_cache), vec);
-    testValidate(fusion, cg_outputs, {input0}, __LINE__, __FILE__);
+    testValidate(fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
 
@@ -275,11 +274,11 @@ TEST_F(PointwiseTest, VectorizeAllocationDomain) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 =
+  at::Tensor t0 =
       at::empty_strided({1024, 128, 25}, {128 * 25, 1, 128}, options);
-  auto cg_outputs = executor_cache.runFusionWithInputs({input0});
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
   EXPECT_EQ(getVecSizeForPointwise(executor_cache), 4);
-  testValidate(fusion, cg_outputs, {input0}, __LINE__, __FILE__);
+  testValidate(fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // All inputs & outputs share the same allocation domain permutation from root
@@ -311,21 +310,19 @@ TEST_F(PointwiseTest, Issue1567VectorizeAllocationDomain) {
   fusion->addOutput(tv3);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 =
+  at::Tensor t0 =
       at::empty_strided({1024, 128, 25}, {128 * 25, 1, 128}, options);
-  at::Tensor input1 = at::empty_strided({1, 128, 1}, {128, 1, 128}, options);
-  std::vector<c10::IValue> aten_inputs = {input0, input1};
+  at::Tensor t1 = at::empty_strided({1, 128, 1}, {128, 1, 128}, options);
 
   // NOTE force pointwise scheduler here just for testing purpose
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0, t1});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
 
   EXPECT_EQ(pparams->vectorization_factor, 4);
   EXPECT_TRUE(hasVectorizationCache(tv0));
   EXPECT_TRUE(hasVectorizationCache(tv1));
 
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(fusion, cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, Issue1567VectorizationFactorAnalysisCase0) {
@@ -346,20 +343,19 @@ TEST_F(PointwiseTest, Issue1567VectorizationFactorAnalysisCase0) {
   fusion->addOutput(tv2);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({1024, 2, 1}, options);
-  at::Tensor input1 = at::randn({1024, 2, 512}, options);
-  std::vector<c10::IValue> aten_inputs = {input0, input1};
+  at::Tensor t0 = at::randn({1024, 2, 1}, options);
+  at::Tensor t1 = at::randn({1024, 2, 512}, options);
 
   // NOTE force pointwise scheduler here just for testing purpose
   auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs, false);
+      scheduleAndRun(fusion, SchedulerType::PointWise, {t0, t1}, false);
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
 
   EXPECT_EQ(pparams->vectorization_factor, 4);
   EXPECT_FALSE(hasVectorizationCache(tv0));
   EXPECT_TRUE(hasVectorizationCache(tv1));
 
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(fusion, cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, Issue1567VectorizationFactorAnalysisCase1) {
@@ -380,20 +376,18 @@ TEST_F(PointwiseTest, Issue1567VectorizationFactorAnalysisCase1) {
   fusion->addOutput(tv2);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({1024, 1, 2}, options);
-  at::Tensor input1 = at::randn({1024, 512, 2}, options);
-  std::vector<c10::IValue> aten_inputs = {input0, input1};
+  at::Tensor t0 = at::randn({1024, 1, 2}, options);
+  at::Tensor t1 = at::randn({1024, 512, 2}, options);
 
   // NOTE force pointwise scheduler here just for testing purpose
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0, t1});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
 
   EXPECT_EQ(pparams->vectorization_factor, 2);
   EXPECT_TRUE(hasVectorizationCache(tv0));
   EXPECT_TRUE(hasVectorizationCache(tv1));
 
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(fusion, cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, Issue1567VectorizationFactorAnalysisCase2) {
@@ -420,20 +414,18 @@ TEST_F(PointwiseTest, Issue1567VectorizationFactorAnalysisCase2) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({1024, 1, 2}, options);
-  at::Tensor input1 = at::empty_strided({1024, 512, 2}, {2, 2048, 1}, options);
-  std::vector<c10::IValue> aten_inputs = {input0, input1};
+  at::Tensor t0 = at::randn({1024, 1, 2}, options);
+  at::Tensor t1 = at::empty_strided({1024, 512, 2}, {2, 2048, 1}, options);
 
   // NOTE force pointwise scheduler here just for testing purpose
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0, t1});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
 
   EXPECT_EQ(pparams->vectorization_factor, 4);
   EXPECT_TRUE(hasVectorizationCache(tv0));
   EXPECT_TRUE(hasVectorizationCache(tv1));
 
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(fusion, cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, VIssue1567ectorizationFactorAnalysisCase3) {
@@ -457,20 +449,18 @@ TEST_F(PointwiseTest, VIssue1567ectorizationFactorAnalysisCase3) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::randn({1, 1024, 2}, options);
-  at::Tensor input1 = at::randn({512, 1024, 2}, options);
-  std::vector<c10::IValue> aten_inputs = {input0, input1};
+  at::Tensor t0 = at::randn({1, 1024, 2}, options);
+  at::Tensor t1 = at::randn({512, 1024, 2}, options);
 
   // NOTE force pointwise scheduler here just for testing purpose
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0, t1});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
 
   EXPECT_EQ(pparams->vectorization_factor, 2);
   EXPECT_TRUE(hasVectorizationCache(tv0));
   EXPECT_TRUE(hasVectorizationCache(tv1));
 
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(fusion, cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 namespace {
@@ -521,11 +511,10 @@ TEST_F(PointwiseTest, ShardedPointwise) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   for (auto input_size : input_sizes) {
-    at::Tensor input0 = at::randn(input_size, options);
-    at::Tensor input1 = at::randn({input_size[1], input_size[2]}, options);
+    at::Tensor t0 = at::randn(input_size, options);
+    at::Tensor t1 = at::randn({input_size[1], input_size[2]}, options);
 
-    std::vector<c10::IValue> sharded_inputs = {
-        input0.unsqueeze(sharded_dim), input1};
+    std::vector<c10::IValue> sharded_inputs = {t0.unsqueeze(sharded_dim), t1};
 
     auto pwise_scheduler =
         SchedulerEntry::makeSchedulerInstance(SchedulerType::PointWise);
@@ -537,8 +526,7 @@ TEST_F(PointwiseTest, ShardedPointwise) {
     auto sharded_pparams = sharded_params->as<PointwiseParams>();
 
     Fusion unsharded_fusion = createPointwiseFusion(false);
-    SchedulerRuntimeInfo unsharded_runtime_info(
-        &unsharded_fusion, {input0, input1});
+    SchedulerRuntimeInfo unsharded_runtime_info(&unsharded_fusion, {t0, t1});
     auto unsharded_params = pwise_scheduler->computeHeuristics(
         &unsharded_fusion, unsharded_runtime_info);
     auto unsharded_pparams = unsharded_params->as<PointwiseParams>();
@@ -594,12 +582,11 @@ TEST_F(PointwiseTest, VectorizeWithBroadcastAndReshape1) {
   fusion->addOutput(tv4);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  auto input0 = at::randn(shape1, options);
-  auto input1 = at::randn(shape2, options);
-  std::vector<c10::IValue> aten_inputs({input0, input1});
+  auto t0 = at::randn(shape1, options);
+  auto t1 = at::randn(shape2, options);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   EXPECT_EQ(getVecSizeForPointwise(executor_cache), 4);
 }
@@ -639,13 +626,12 @@ TEST_F(PointwiseTest, VectorizeWithBroadcastAndReshape2) {
   fusion->addOutput(tv7);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  auto input0 = at::randn(shape1, options);
-  auto input1 = at::randn(shape1, options);
-  auto input2 = at::randn(shape2, options);
-  std::vector<c10::IValue> aten_inputs({input0, input1, input2});
+  auto t0 = at::randn(shape1, options);
+  auto t1 = at::randn(shape1, options);
+  auto t2 = at::randn(shape2, options);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   EXPECT_EQ(getVecSizeForPointwise(executor_cache), 4);
 }
@@ -696,10 +682,9 @@ TEST_P(PointwiseParamsTest, UnrollOnTopOfVectorize) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({dim0, dim1}, options);
   auto t1 = at::randn({dim1}, options);
-  std::vector<c10::IValue> runtime_inputs{t0, t1};
 
   // Generate heuristics
-  SchedulerRuntimeInfo runtime_info(fusion.get(), runtime_inputs);
+  SchedulerRuntimeInfo runtime_info(fusion.get(), {t0, t1});
   auto scheduler_instance =
       SchedulerEntry::makeSchedulerInstance(SchedulerType::PointWise);
   auto heuristic_params =
@@ -717,13 +702,13 @@ TEST_P(PointwiseParamsTest, UnrollOnTopOfVectorize) {
   // Schedule, compile, run, validate
   scheduler_instance->schedule(fusion.get(), pparams);
   KernelExecutor ke;
-  ke.compile(fusion.get(), runtime_inputs, pparams->lparams);
-  auto cg_outputs = ke.run(runtime_inputs, pparams->lparams);
+  ke.compile(fusion.get(), {t0, t1}, pparams->lparams);
+  auto cg_outputs = ke.run({t0, t1}, pparams->lparams);
   const auto& lparams = ke.lastLaunchParams();
   ASSERT_EQ(lparams.gdimy(), dim0 / unroll_outer);
   ASSERT_EQ(
       lparams.gdimx(), dim1 / vect_factor / lparams.bdimx() / unroll_inner);
-  testValidate(fusion.get(), cg_outputs, runtime_inputs, __LINE__, __FILE__);
+  testValidate(fusion.get(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 INSTANTIATE_TEST_SUITE_P(
     ,
@@ -763,7 +748,7 @@ int64_t getUnrollFactor(int64_t n_inputs_factor, int64_t computation_factor) {
 // of blocks. For device with high bandwidh, unroll factor is 2 when
 // there is only one input tensor, scaled up by computation factor and
 // scaled down by number of input tensors.
-TEST_F(PointwiseTest, HeuristicsInput1Compute1Unroll2) {
+TEST_F(PointwiseTest, Heuristicst1Compute1Unroll2) {
   auto dev_prop = at::cuda::getCurrentDeviceProperties();
   int64_t vect = 4;
   int64_t threads = 128;
@@ -782,18 +767,16 @@ TEST_F(PointwiseTest, HeuristicsInput1Compute1Unroll2) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({dim0, dim1}, options);
-  std::vector<c10::IValue> runtime_inputs{t0};
 
   auto cg_results =
-      scheduleAndRun(fusion.get(), SchedulerType::PointWise, runtime_inputs);
+      scheduleAndRun(fusion.get(), SchedulerType::PointWise, {t0});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
   ASSERT_EQ(pparams->vectorization_factor, vect);
   ASSERT_EQ(pparams->unroll_factor_inner, unroll);
-  testValidate(
-      fusion.get(), cg_results.outputs, runtime_inputs, __LINE__, __FILE__);
+  testValidate(fusion.get(), cg_results.outputs, {t0}, __LINE__, __FILE__);
 }
 
-TEST_F(PointwiseTest, HeuristicsInput1Compute2Unroll4) {
+TEST_F(PointwiseTest, Heuristicst1Compute2Unroll4) {
   auto dev_prop = at::cuda::getCurrentDeviceProperties();
   int64_t vect = 4;
   int64_t threads = 128;
@@ -819,15 +802,13 @@ TEST_F(PointwiseTest, HeuristicsInput1Compute2Unroll4) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({dim0, dim1}, options);
   auto t1 = at::randn({dim1}, options);
-  std::vector<c10::IValue> runtime_inputs{t0, t1};
 
   auto cg_results =
-      scheduleAndRun(fusion.get(), SchedulerType::PointWise, runtime_inputs);
+      scheduleAndRun(fusion.get(), SchedulerType::PointWise, {t0, t1});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
   ASSERT_EQ(pparams->vectorization_factor, vect);
   ASSERT_EQ(pparams->unroll_factor_outer, unroll);
-  testValidate(
-      fusion.get(), cg_results.outputs, runtime_inputs, __LINE__, __FILE__);
+  testValidate(fusion.get(), cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, HeuristicsInput2Compute4Unroll4) {
@@ -853,14 +834,12 @@ TEST_F(PointwiseTest, HeuristicsInput2Compute4Unroll4) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({dim0, dim1}, options);
   auto t1 = at::randn({dim0, dim1}, options);
-  std::vector<c10::IValue> runtime_inputs{t0, t1};
   auto cg_results =
-      scheduleAndRun(fusion.get(), SchedulerType::PointWise, runtime_inputs);
+      scheduleAndRun(fusion.get(), SchedulerType::PointWise, {t0, t1});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
   ASSERT_EQ(pparams->vectorization_factor, vect);
   ASSERT_EQ(pparams->unroll_factor_inner, unroll);
-  testValidate(
-      fusion.get(), cg_results.outputs, runtime_inputs, __LINE__, __FILE__);
+  testValidate(fusion.get(), cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, VectorizePadLoweringPermuted) {
@@ -889,10 +868,9 @@ TEST_F(PointwiseTest, VectorizePadLoweringPermuted) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 =
       at::randn({1024 * 1024}, options).as_strided({1024, 1024}, {1, 1024});
-  std::vector<c10::IValue> aten_inputs({t0});
 
   auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
+      scheduleAndRun(&fusion, SchedulerType::PointWise, {t0}).outputs;
   // check that we vectorize 4
   bool found_vectorize = false;
   for (auto id : fusion.outputs().at(0)->as<TensorView>()->getLoopDomain()) {
@@ -903,7 +881,7 @@ TEST_F(PointwiseTest, VectorizePadLoweringPermuted) {
     }
   }
   EXPECT_TRUE(found_vectorize);
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, DomainMapTestEg0) {
@@ -952,11 +930,9 @@ TEST_F(PointwiseTest, DomainMapTestEg0) {
   // validate generated kernel
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4, 7}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
   // NOTE force pointwise scheduler here for unit test
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0});
+  testValidate(fusion, cg_results.outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, DomainMapTestEg1) {
@@ -997,11 +973,9 @@ TEST_F(PointwiseTest, DomainMapTestEg1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({2, 4}, options);
   at::Tensor t1 = at::randn({3, 2, 4}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
   // NOTE force pointwise scheduler here for unit test
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0, t1});
+  testValidate(fusion, cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, DomainMapTestEg2) {
@@ -1042,11 +1016,9 @@ TEST_F(PointwiseTest, DomainMapTestEg2) {
   // validate generated kernel
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({4, 7}, options);
-  std::vector<c10::IValue> aten_inputs = {t0};
   // NOTE force pointwise scheduler here for unit test
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0});
+  testValidate(fusion, cg_results.outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, DomainMapFactory) {
@@ -1090,9 +1062,9 @@ TEST_F(PointwiseTest, DomainMapFactory) {
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor input0 = at::empty_strided({25}, {1}, options);
-  at::Tensor input1 = at::empty_strided({7, 25}, {25, 1}, options);
-  auto cg_outputs = executor_cache.runFusionWithInputs({input0, input1});
+  at::Tensor t0 = at::empty_strided({25}, {1}, options);
+  at::Tensor t1 = at::empty_strided({7, 25}, {25, 1}, options);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   SegmentedFusion* segmented_fusion = runtime->fusionSegments();
@@ -1163,7 +1135,7 @@ TEST_F(PointwiseTest, DomainMapFactory) {
     }
   }
 
-  testValidate(fusion, cg_outputs, {input0, input1}, __LINE__, __FILE__);
+  testValidate(fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, DomainMapPad0) {
@@ -1208,11 +1180,9 @@ TEST_F(PointwiseTest, DomainMapPad0) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::empty_strided({1, 5}, {5, 1}, options);
   at::Tensor t1 = at::empty_strided({7, 1, 5}, {5, 5, 1}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
   // NOTE force pointwise scheduler here for unit test
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0, t1});
+  testValidate(fusion, cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, DomainMapPad1) {
@@ -1259,11 +1229,9 @@ TEST_F(PointwiseTest, DomainMapPad1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::empty_strided({1, 5}, {5, 1}, options);
   at::Tensor t1 = at::empty_strided({2, 3, 4, 1}, {12, 4, 1, 1}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
   // NOTE force pointwise scheduler here for unit test
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0, t1});
+  testValidate(fusion, cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, DomainMapSlice0) {
@@ -1308,11 +1276,9 @@ TEST_F(PointwiseTest, DomainMapSlice0) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({2, 4}, options);
   at::Tensor t1 = at::randn({2, 4}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
   // NOTE force pointwise scheduler here for unit test
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0, t1});
+  testValidate(fusion, cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PointwiseTest, DomainMapSlice1) {
@@ -1357,11 +1323,9 @@ TEST_F(PointwiseTest, DomainMapSlice1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({2, 2, 4}, options);
   at::Tensor t1 = at::randn({2, 4}, options);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
   // NOTE force pointwise scheduler here for unit test
-  auto cg_results =
-      scheduleAndRun(fusion, SchedulerType::PointWise, aten_inputs);
-  testValidate(fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_results = scheduleAndRun(fusion, SchedulerType::PointWise, {t0, t1});
+  testValidate(fusion, cg_results.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(NVFuserTest, DomainMapBroadcastIssue3653) {
@@ -1392,16 +1356,15 @@ TEST_F(NVFuserTest, DomainMapBroadcastIssue3653) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({2, 4, 8}, options);
   auto t1 = at::randn({2}, options);
-  std::vector<c10::IValue> inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   NVF_CHECK(!runtime->isSegmented());
 
   testValidate(
-      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1}, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -348,7 +348,7 @@ TEST_F(PresegTest, FusionTestCastOptimization) {
     // (input)float -> half -> bfloat16 -> half
     fusion->addOutput(tv);
     OptimizationPass<PreSegmenter>::runPass(fusion.get());
-    // simplified as (input)float -> half -> bfloat -> half
+    // simplified as (input)float -> half -> bfloat16 -> half
     auto ref_tv = castOp(DataType::Half, tv0);
     ref_tv = castOp(DataType::BFloat16, ref_tv);
     ref_tv = castOp(DataType::Half, ref_tv);
@@ -369,10 +369,9 @@ TEST_F(PresegTest, FusionRemoveEmptyOutput) {
   fusion.addOutput(tv1);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at0 = at::randn({0, 3}, options);
-  std::vector<c10::IValue> aten_inputs = {at0};
+  at::Tensor t0 = at::randn({0, 3}, options);
 
-  auto args = KernelArgumentHolder(aten_inputs);
+  auto args = KernelArgumentHolder({t0});
   FusionKernelRuntime runtime(std::move(fusion_ptr), args);
 
   // In the FusionKernelRuntime, before segmentation a number of optimization
@@ -388,7 +387,7 @@ TEST_F(PresegTest, FusionRemoveEmptyOutput) {
   runtime.compileFusionParallel(args);
   auto outputs = runtime.runWithInputs(args);
 
-  testValidate(preseg_fusion, outputs, aten_inputs, {at0}, __LINE__, __FILE__);
+  testValidate(preseg_fusion, outputs, {t0}, {t0}, __LINE__, __FILE__);
 }
 
 // Test that we replace empty reduction with full
@@ -404,10 +403,9 @@ TEST_F(PresegTest, FusionRemoveEmptyReduction) {
   fusion.addOutput(tv1);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at0 = at::randn({0, 3}, options);
-  std::vector<c10::IValue> aten_inputs = {at0};
+  at::Tensor t0 = at::randn({0, 3}, options);
 
-  auto args = KernelArgumentHolder(aten_inputs);
+  auto args = KernelArgumentHolder({t0});
   FusionKernelRuntime runtime(std::move(fusion_ptr), args);
 
   auto preseg_fusion = runtime.fusionSegments()->completeFusion();
@@ -418,7 +416,7 @@ TEST_F(PresegTest, FusionRemoveEmptyReduction) {
   runtime.compileFusionParallel(args);
   auto outputs = runtime.runWithInputs(args);
 
-  testValidate(preseg_fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(preseg_fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // In this test, a reduction over a non-empty axis occurs first, followed by a
@@ -437,10 +435,9 @@ TEST_F(PresegTest, FusionRemoveEmptyReductionWithNonReduction) {
   fusion.addOutput(tv2);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at0 = at::randn({0, 3, 2}, options);
-  std::vector<c10::IValue> aten_inputs = {at0};
+  at::Tensor t0 = at::randn({0, 3, 2}, options);
 
-  auto args = KernelArgumentHolder(aten_inputs);
+  auto args = KernelArgumentHolder({t0});
   FusionKernelRuntime runtime(std::move(fusion_ptr), args);
 
   auto preseg_fusion = runtime.fusionSegments()->completeFusion();
@@ -451,7 +448,7 @@ TEST_F(PresegTest, FusionRemoveEmptyReductionWithNonReduction) {
   runtime.compileFusionParallel(args);
   auto outputs = runtime.runWithInputs(args);
 
-  testValidate(preseg_fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(preseg_fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Test that we replace empty Welford with full
@@ -469,10 +466,9 @@ TEST_F(PresegTest, FusionRemoveEmptyWelford) {
   fusion.addOutput(var);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at0 = at::randn({0, 3}, options);
-  std::vector<c10::IValue> aten_inputs = {at0};
+  at::Tensor t0 = at::randn({0, 3}, options);
 
-  auto args = KernelArgumentHolder(aten_inputs);
+  auto args = KernelArgumentHolder({t0});
   FusionKernelRuntime runtime(std::move(fusion_ptr), args);
 
   auto preseg_fusion = runtime.fusionSegments()->completeFusion();
@@ -494,8 +490,8 @@ TEST_F(PresegTest, FusionRemoveEmptyWelford) {
   testValidate(
       preseg_fusion,
       outputs,
-      aten_inputs,
-      {at::mean(at0, 0), at::var(at0, 0)},
+      {t0},
+      {at::mean(t0, 0), at::var(t0, 0)},
       __LINE__,
       __FILE__);
 }
@@ -522,12 +518,11 @@ TEST_F(PresegTest, FusionRemoveEmptyCat) {
   fusion.addOutput(tv4);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at0 = at::randn({0, 3}, options);
-  at::Tensor at1 = at::randn({2, 3}, options);
-  at::Tensor at2 = at::randn({4, 3}, options);
-  std::vector<c10::IValue> aten_inputs = {at0, at1, at2};
+  at::Tensor t0 = at::randn({0, 3}, options);
+  at::Tensor t1 = at::randn({2, 3}, options);
+  at::Tensor t2 = at::randn({4, 3}, options);
 
-  auto args = KernelArgumentHolder(aten_inputs);
+  auto args = KernelArgumentHolder({t0, t1, t2});
   FusionKernelRuntime runtime(std::move(fusion_ptr), args);
 
   auto preseg_fusion = runtime.fusionSegments()->completeFusion();
@@ -543,7 +538,7 @@ TEST_F(PresegTest, FusionRemoveEmptyCat) {
   runtime.compileFusionParallel(args);
   auto outputs = runtime.runWithInputs(args);
 
-  testValidate(preseg_fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(preseg_fusion, outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 // Test that we replace empty tensors in pad properly
@@ -564,10 +559,9 @@ TEST_F(PresegTest, FusionRemoveEmptyPad) {
   fusion.addOutput(tv1);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at0 = at::randn({3, 0}, options);
-  std::vector<c10::IValue> aten_inputs = {at0};
+  at::Tensor t0 = at::randn({3, 0}, options);
 
-  auto args = KernelArgumentHolder(aten_inputs);
+  auto args = KernelArgumentHolder({t0});
   FusionKernelRuntime runtime(std::move(fusion_ptr), args);
 
   auto preseg_fusion = runtime.fusionSegments()->completeFusion();
@@ -581,7 +575,7 @@ TEST_F(PresegTest, FusionRemoveEmptyPad) {
   runtime.compileFusionParallel(args);
   auto outputs = runtime.runWithInputs(args);
 
-  testValidate(preseg_fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(preseg_fusion, outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Test that we replace empty tensors in matmuls properly
@@ -608,11 +602,10 @@ TEST_F(PresegTest, FusionRemoveEmptyMatmul) {
   fusion.addOutput(tv2);
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
-  at::Tensor at0 = at::randn({16, 0}, options);
-  at::Tensor at1 = at::randn({0, 8}, options);
-  std::vector<c10::IValue> aten_inputs = {at0, at1};
+  at::Tensor t0 = at::randn({16, 0}, options);
+  at::Tensor t1 = at::randn({0, 8}, options);
 
-  auto args = KernelArgumentHolder(aten_inputs);
+  auto args = KernelArgumentHolder({t0, t1});
   FusionKernelRuntime runtime(std::move(fusion_ptr), args);
 
   auto preseg_fusion = runtime.fusionSegments()->completeFusion();
@@ -626,7 +619,7 @@ TEST_F(PresegTest, FusionRemoveEmptyMatmul) {
   runtime.compileFusionParallel(args);
   auto outputs = runtime.runWithInputs(args);
 
-  testValidate(preseg_fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(preseg_fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(PresegTest, ReplaceOutput) {
@@ -803,10 +796,9 @@ TEST_F(PresegTest, TranslateRepeatToExpand1) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({32}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 
   // Should be scheduled as a pointwise kernel
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
@@ -844,10 +836,9 @@ TEST_F(PresegTest, TranslateRepeatToExpand2) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({32}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 
   // Should be scheduled as a pointwise kernel
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
@@ -885,10 +876,9 @@ TEST_F(PresegTest, TranslateRepeatToExpand3) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({4, 8}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 
   // Should be scheduled as a pointwise kernel
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
@@ -933,10 +923,9 @@ TEST_F(PresegTest, TranslateRepeatToExpand4) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({4, 8}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 
   // Should be segmented to two pointwise kernels
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
@@ -973,10 +962,9 @@ TEST_F(PresegTest, TranslateRepeatToExpand5) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({32}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 
   // Should be scheduled as a pointwise kernel
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
@@ -1021,10 +1009,9 @@ TEST_F(PresegTest, TranslateRepeatToExpand6) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({32, 1}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 
   // Should be scheduled as a pointwise kernel
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
@@ -1065,10 +1052,9 @@ TEST_F(PresegTest, FusionTestCastOptimizationMetaOp0) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({2, 4}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PresegTest, FusionTestCastOptimizationMetaOp1) {
@@ -1089,14 +1075,13 @@ TEST_F(PresegTest, FusionTestCastOptimizationMetaOp1) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({2, 4}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
   bool is_segmented =
       executor_cache.getMostRecentKernelRuntime()->isSegmented();
   NVF_CHECK(!is_segmented, "Fusion should not be segmented");
 
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PresegTest, FusionTestCastOptimizationMetaOp2) {
@@ -1118,14 +1103,13 @@ TEST_F(PresegTest, FusionTestCastOptimizationMetaOp2) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({2, 4}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
   bool is_segmented =
       executor_cache.getMostRecentKernelRuntime()->isSegmented();
   NVF_CHECK(!is_segmented, "Fusion should not be segmented");
 
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PresegTest, FusionTestCastOptimizationMetaOp3) {
@@ -1144,10 +1128,9 @@ TEST_F(PresegTest, FusionTestCastOptimizationMetaOp3) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({2, 4}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PresegTest, FusionTestCastOptimizationMetaOp4) {
@@ -1184,11 +1167,10 @@ TEST_F(PresegTest, FusionTestCastOptimizationMetaOp4) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({2, 3, 4}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
   ASSERT_TRUE(outputs[0].is_contiguous(at::MemoryFormat::ChannelsLast));
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PresegTest, FusionTestCastOptimizationMetaOp5) {
@@ -1225,10 +1207,9 @@ TEST_F(PresegTest, FusionTestCastOptimizationMetaOp5) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn({2, 3, 4}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(PresegTest, FusionTestCastOptimizationMetaOp6) {
@@ -1271,10 +1252,9 @@ TEST_F(PresegTest, FusionTestCastOptimizationMetaOp6) {
 
   auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(at::kHalf);
   auto t0 = at::randn({2, 3, 4}, options);
-  std::vector<c10::IValue> inputs = {t0};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
 }
 
 struct MatmulInputShape {
@@ -1342,10 +1322,9 @@ TEST_P(TranslateNoReductionMatmulTest, Test) {
   auto options = at::TensorOptions().device(at::kCUDA, 0);
   auto t0 = at::randn(config.shape_a, options);
   auto t1 = at::randn(config.shape_b, options);
-  std::vector<c10::IValue> inputs = {t0, t1};
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  testValidate(executor_cache.fusion(), outputs, {t0, t1}, __LINE__, __FILE__);
 
   // Should be scheduled as a pointwise kernel
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();

--- a/tests/cpp/test_reduction_pointwise.cpp
+++ b/tests/cpp/test_reduction_pointwise.cpp
@@ -138,10 +138,9 @@ TEST_F(NVFuserTest, InnerReductionUnrollVectorization) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({256, 10240}, options);
-  std::vector<c10::IValue> runtime_inputs({t0});
 
   // Generate heuristics & enforce unroll on top of vectorization
-  SchedulerRuntimeInfo runtime_info(fusion.get(), runtime_inputs);
+  SchedulerRuntimeInfo runtime_info(fusion.get(), {t0});
   auto scheduler_instance =
       SchedulerEntry::makeSchedulerInstance(SchedulerType::Reduction);
   auto heuristic_params =
@@ -154,9 +153,9 @@ TEST_F(NVFuserTest, InnerReductionUnrollVectorization) {
   auto fusion_copy = *fusion;
   scheduler_instance->schedule(fusion.get(), rparams);
   KernelExecutor ke;
-  ke.compile(fusion.get(), runtime_inputs, rparams->lparams);
-  auto cg_outputs = ke.run(runtime_inputs, rparams->lparams);
-  testValidate(&fusion_copy, cg_outputs, runtime_inputs, __LINE__, __FILE__);
+  ke.compile(fusion.get(), {t0}, rparams->lparams);
+  auto cg_outputs = ke.run({t0}, rparams->lparams);
+  testValidate(&fusion_copy, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_remove_bcast_squeeze.cpp
+++ b/tests/cpp/test_remove_bcast_squeeze.cpp
@@ -96,8 +96,7 @@ TEST_F(RemoveBcastSqueezeTest, BcastSqueezeMultipleUses) {
   at::Tensor t0 = at::ones({3, 4}, options);
   at::Tensor t1 = t0.unsqueeze(-1);
   FusionExecutorCache executor_cache(std::move(fusion));
-  std::vector<at::Tensor> outputs =
-      executor_cache.runFusionWithInputs({t0, t1});
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
   testValidate(executor_cache.fusion(), outputs, {t0, t1}, __LINE__, __FILE__);
 }
 

--- a/tests/cpp/test_replay.cpp
+++ b/tests/cpp/test_replay.cpp
@@ -47,8 +47,7 @@ TEST_F(ReplayTest, HorizontallyMergeReshapeAndPermute) {
   at::Tensor in_tensor = at::randn({4, 5}, options);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
   auto out_tensor = out_tensors[0];
 
@@ -87,8 +86,7 @@ TEST_F(ReplayTest, HorizontallyMergeReshapeAndNeg) {
   at::Tensor in_tensor = at::randn({4, 5}, options);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   ASSERT_EQ(out_tensors.size(), 1);
   auto out_tensor = out_tensors[0];
 

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -102,14 +102,13 @@ TEST_F(ResizeTest, Pad1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(t0, {1, 1});
 
@@ -134,14 +133,13 @@ TEST_F(ResizeTest, Pad2) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(t0, {1, 1});
 
@@ -183,16 +181,15 @@ TEST_F(ResizeTest, Pad3) {
 
   auto t0 = at::randn(shape, options);
   auto t1 = at::randn(padded_shape, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // pad + parallelization
@@ -213,14 +210,13 @@ TEST_F(ResizeTest, Pad4) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(t0, {1, 1});
 
@@ -264,14 +260,13 @@ TEST_F(ResizeTest, Pad5) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(t0, {1, 1});
 
@@ -311,16 +306,15 @@ TEST_F(ResizeTest, Pad6) {
 
   auto t0 = at::randn(shape, options);
   auto t1 = at::randn(padded_shape, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // pad + unswitch. Having different extents in an unswitched loop nest
@@ -358,16 +352,15 @@ TEST_F(ResizeTest, Pad7) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Disable for now. Unclear what would be the best way to handle
@@ -406,15 +399,14 @@ TEST_F(ResizeTest, Pad8) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(999, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(t0, {0, 1}) + at::pad(t0, {1, 0});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 #endif
 
@@ -433,13 +425,12 @@ TEST_F(ResizeTest, PadScheduler1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto ref = at::pad(t0, {1, 1});
 
@@ -468,16 +459,15 @@ TEST_F(ResizeTest, PadScheduler2) {
 
   auto t0 = at::randn(shape, options);
   auto t1 = at::randn(padded_shape, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Disabled due to the same reason as Pad8
@@ -500,17 +490,16 @@ TEST_F(ResizeTest, PadScheduler3) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(999, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto ref = at::pad(t0, {0, 1}) + at::pad(t0, {1, 0});
 
   testValidate(
       executor_cache.fusion(),
       cg_outputs,
-      aten_inputs,
+      {t0},
       {ref},
       __LINE__,
       __FILE__);
@@ -546,16 +535,15 @@ TEST_F(ResizeTest, PadScheduler4) {
 
   auto t0 = at::randn(shape, options);
   std::vector<int64_t> pad_extents{1, 1};
-  std::vector<c10::IValue> aten_inputs({t0, 1, 1});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, 1, 1});
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0, 1, 1}, __LINE__, __FILE__);
 }
 
 // Pad a broadcast
@@ -582,16 +570,14 @@ TEST_F(ResizeTest, PadBroadcastInput) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Trivial cat
@@ -615,11 +601,10 @@ TEST_F(ResizeTest, Cat1) {
 
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref = at::cat({t0, t1}, 0);
 
@@ -647,11 +632,10 @@ TEST_F(ResizeTest, Cat2) {
 
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref = at::cat({t0, t1}, 0);
 
@@ -688,11 +672,10 @@ TEST_F(ResizeTest, Cat3) {
 
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref = at::cat({t0, t1}, 1);
 
@@ -732,11 +715,10 @@ TEST_F(ResizeTest, Cat4) {
 
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref = at::cat({t0, t1}, 1);
 
@@ -781,13 +763,12 @@ TEST_F(ResizeTest, Cat5) {
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
   auto t2 = at::randn(shape2, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, t2});
+  auto cg_outputs = ke.run({t0, t1, t2});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 // Cat 3 tensors
@@ -825,11 +806,10 @@ TEST_F(ResizeTest, Cat6) {
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
   auto t2 = at::randn(shape2, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1, t2});
+  auto cg_outputs = ke.run({t0, t1, t2});
 
   auto ref = at::cat({t0, t1, t2}, 0);
 
@@ -915,10 +895,9 @@ TEST_F(ResizeTest, CatScheduler1) {
 
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   auto ref = at::cat({t0, t1}, 0);
 
@@ -951,13 +930,12 @@ TEST_F(ResizeTest, CatScheduler2) {
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
   auto t2 = at::randn(shape2, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 // Auto scheduled version of Cat6
@@ -985,10 +963,9 @@ TEST_F(ResizeTest, CatScheduler3) {
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
   auto t2 = at::randn(shape2, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1, t2});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   auto ref = at::cat({t0, t1, t2}, 0);
 
@@ -1015,11 +992,10 @@ TEST_F(ResizeTest, Slice1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
 
@@ -1046,13 +1022,12 @@ TEST_F(ResizeTest, Slice2) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // "Trivial" slice is converted to Set
@@ -1144,15 +1119,14 @@ TEST_F(ResizeTest, Slice4) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = (t0 + 1).to(at::kDouble).sum({1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
 // Multiple slices of the same tensor with the same arguments
@@ -1199,11 +1173,10 @@ TEST_F(ResizeTest, Slice5) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto t1 = t0.index(
       {at::indexing::Slice(0, at::indexing::None),
@@ -1214,7 +1187,7 @@ TEST_F(ResizeTest, Slice5) {
        at::indexing::Slice(1, shape[1] - 1)});
   auto t4 = t3.to(at::kDouble).sum({1});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, {t2, t4}, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, {t2, t4}, __LINE__, __FILE__);
 }
 
 std::vector<std::pair<int64_t, int64_t>> slice_cases(
@@ -1251,13 +1224,12 @@ TEST_F(ResizeTest, SliceConstantShmoo) {
     auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
     auto t0 = at::randn(shape, options);
-    std::vector<c10::IValue> aten_inputs({t0});
 
     KernelExecutor ke;
-    ke.compile(&fusion, aten_inputs);
-    auto cg_outputs = ke.run(aten_inputs);
+    ke.compile(&fusion, {t0});
+    auto cg_outputs = ke.run({t0});
 
-    testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+    testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
   }
 }
 
@@ -1374,10 +1346,9 @@ TEST_F(ResizeTest, SliceScheduler1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
 
@@ -1598,13 +1569,12 @@ TEST_F(ResizeTest, CatReduceScheduler1) {
 
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(ResizeTest, CatSoftmaxScheduler1) {
@@ -1628,13 +1598,12 @@ TEST_F(ResizeTest, CatSoftmaxScheduler1) {
 
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(ResizeTest, ReductionSliceScheduler1) {
@@ -1657,13 +1626,11 @@ TEST_F(ResizeTest, ReductionSliceScheduler1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape0, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Softmax followed by slicing of a non-normalized dimension
@@ -1688,13 +1655,11 @@ TEST_F(ResizeTest, SoftmaxSliceScheduler1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape0, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Softmax followed by slicing of a normalized dimension
@@ -1719,13 +1684,11 @@ TEST_F(ResizeTest, SoftmaxSliceScheduler2) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape0, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Same as Pad1 but pad by specified value
@@ -1747,14 +1710,13 @@ TEST_F(ResizeTest, PadWithValue) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(t0, {1, 1}, "constant", 2);
 
@@ -1782,13 +1744,12 @@ TEST_F(ResizeTest, PadToEmptyTensor) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto ref = at::pad(t0, {-1, -1}, "constant", 2);
 
@@ -1814,14 +1775,13 @@ TEST_F(ResizeTest, PadHalfWithDoubleValue) {
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
 
   auto t0 = at::ones(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(t0, {1, 1}, "constant", 2.5);
 
@@ -1873,10 +1833,9 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT1) {
 
   auto t0 = at::randn(input_shape0, options);
   auto t1 = at::randn(input_shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   const auto* ke = onlyKernelExecutorInMostRecentRuntime(executor_cache);
   auto kernel = ke->compiledKernel()->kernel();
@@ -1885,7 +1844,7 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT1) {
       "Grid sync should not be used as slicing input should avoid input caching");
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Similar to FusionSliceForNanoGPT1 but the input to slice is an
@@ -1935,10 +1894,9 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT2) {
 
   auto t0 = at::randn(input_shape0, options);
   auto t1 = at::randn(input_shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   const auto* ke = onlyKernelExecutorInMostRecentRuntime(executor_cache);
   auto kernel = ke->compiledKernel()->kernel();
@@ -2002,7 +1960,7 @@ TEST_F(ResizeTest, FusionSliceForNanoGPT2) {
       known_slice_producer->toString());
 
   testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // C++ version of TestNvFuserFrontend.test_nanogpt_split_mha_linears
@@ -2065,12 +2023,10 @@ TEST_F(ResizeTest, ResizeReshapeAndSlice) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_FALSE(runtime->isSegmented());
@@ -2110,12 +2066,10 @@ TEST_F(ResizeTest, DISABLED_ResizePermuteAndSlice) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 
   EXPECT_THAT(
       executor_cache.getMostRecentKernelRuntime()->fusionSegments()->groups(),
@@ -2174,10 +2128,9 @@ TEST_F(ResizeTest, FusionSizeZeroSliceSplitSchedule) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
   KernelExecutor ke;
 
   auto ref0 = t0.index({at::indexing::Slice(0, 2)});
@@ -2226,9 +2179,8 @@ TEST_F(ResizeTest, FusionSizeZeroSliceSplit) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
-  auto cg_outputs = ke.run(aten_inputs);
+  auto cg_outputs = ke.run({t0});
 
   auto ref0 = t0.index({at::indexing::Slice(2, 2), at::indexing::Slice(0, 5)});
 
@@ -2265,9 +2217,8 @@ TEST_F(ResizeTest, FusionSqueezeSymbolic) {
   at::manual_seed(0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0, 20});
 
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, 20});
 
   auto ref0 = t0.flatten();
 
@@ -2310,10 +2261,9 @@ TEST_F(ResizeTest, MultiSliceEmpty) {
   at::manual_seed(0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto ref0 = t0.index({at::indexing::Slice(0, 1)});
   auto ref1 = t0.index({at::indexing::Slice(0, 0)});
@@ -2360,10 +2310,7 @@ TEST_F(ResizeTest, SliceVectorization) {
   at::Tensor t0 = at::randn(N + 8, options);
   at::Tensor t1 = at::randn(N, options);
 
-  std::vector<c10::IValue> inputs = {t0, t1};
-
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, inputs).outputs;
+  auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0, t1});
   // check that we vectorize 4
   bool found_vectorize = false;
   for (auto id : fusion.outputs().at(0)->as<TensorView>()->getLoopDomain()) {
@@ -2378,8 +2325,8 @@ TEST_F(ResizeTest, SliceVectorization) {
   auto ref = t0.narrow(0, 1, N) + t1;
 
   // testValidate does not check that dtypes match
-  EXPECT_EQ(cg_outputs[0].dtype(), ref.dtype());
-  testValidate(&fusion, cg_outputs, inputs, __LINE__, __FILE__);
+  EXPECT_EQ(cg_outputs.outputs[0].dtype(), ref.dtype());
+  testValidate(&fusion, cg_outputs.outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Concretize a symbolic pad that results in a broadcast (static pads)
@@ -2432,13 +2379,12 @@ TEST_F(ResizeTest, ResizePadToBroadcastStatic) {
 
   auto t0 = at::randn(t0_size, options);
   auto t1 = at::randn(t1_size, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   auto concretized_fusion = runtime->fusionSegments()->completeFusion();
@@ -2451,7 +2397,7 @@ TEST_F(ResizeTest, ResizePadToBroadcastStatic) {
     EXPECT_EQ(conc_t2->axis(i)->getIterType(), expected_itertypes.at(i));
   }
 
-  testValidate(concretized_fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(concretized_fusion, cg_outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Concretize a symbolic pad that results in a broadcast (dynamic pads)
@@ -2496,10 +2442,7 @@ TEST_F(ResizeTest, ResizePadToBroadcastDynamic) {
   auto t1 = at::randn({2, 4, 4, 3, 5}, options);
   // Keep dimension 0, pad to broadcast in dimension 1 and 3. Pad with zero in
   // dimension 2. Trim by one element in dimension 4.
-  std::vector<c10::IValue> aten_inputs({
-      t0,
-      t1,
-  });
+  std::vector<c10::IValue> aten_inputs({t0, t1});
   aten_inputs.insert(aten_inputs.end(), pad_widths.begin(), pad_widths.end());
 
   EnableOptionsGuard enable_options_guard;
@@ -2545,12 +2488,11 @@ TEST_F(ResizeTest, ResizePadToBroadcastIssue596) {
 
   auto t0 = at::randn({2}, options);
   auto t1 = at::randn({3}, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
-  auto args = KernelArgumentHolder(aten_inputs);
+  auto args = KernelArgumentHolder({t0, t1});
   FusionKernelRuntime runtime(std::move(fusion), args);
   runtime.compileFusionParallel(args);
   auto cg_outputs = runtime.runWithInputs(args);
@@ -2558,7 +2500,7 @@ TEST_F(ResizeTest, ResizePadToBroadcastIssue596) {
   testValidate(
       runtime.fusionSegments()->completeFusion(),
       cg_outputs,
-      aten_inputs,
+      {t0, t1},
       __LINE__,
       __FILE__);
 }
@@ -2585,10 +2527,9 @@ TEST_F(ResizeTest, SliceAndReshape1) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto t1 = t0.index(
       {at::indexing::Slice(0, at::indexing::None),
@@ -2621,10 +2562,9 @@ TEST_F(ResizeTest, SliceAndReshape2) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto t1 = t0.index(
       {at::indexing::Slice(0, at::indexing::None),
@@ -2656,10 +2596,8 @@ TEST_F(ResizeTest, Slice1DVectorize) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
-  auto cg_results =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs);
+  auto cg_results = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
   // check vectorization
   ASSERT_EQ(pparams->vectorization_factor, 4)
@@ -2669,7 +2607,7 @@ TEST_F(ResizeTest, Slice1DVectorize) {
       Contains(Property(&IterDomain::getParallelType, ParallelType::Vectorize)))
       << "Failed to vectorize: " << tv1;
 
-  testValidate(&fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_results.outputs, {t0}, __LINE__, __FILE__);
 }
 
 // An input is sliced twice. Both should be vectorizable.
@@ -2700,10 +2638,8 @@ TEST_F(ResizeTest, Slice1DVectorize2) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
-  auto cg_results =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs);
+  auto cg_results = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
   // check vectorization
   ASSERT_EQ(pparams->vectorization_factor, 4)
@@ -2713,7 +2649,7 @@ TEST_F(ResizeTest, Slice1DVectorize2) {
       Contains(Property(&IterDomain::getParallelType, ParallelType::Vectorize)))
       << "Failed to vectorize: " << tv1;
 
-  testValidate(&fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_results.outputs, {t0}, __LINE__, __FILE__);
 }
 
 // An input is sliced twice. Both should be vectorizable.
@@ -2758,11 +2694,10 @@ TEST_F(ResizeTest, Slice1DVectorize2Manual) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref_t1 =
       t0.index({at::indexing::Slice(slice_offset, shape[0] - slice_offset)});
@@ -2795,10 +2730,8 @@ TEST_F(ResizeTest, Slice1DVectorize3) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
-  auto cg_results =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs);
+  auto cg_results = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
   // check vectorization
   ASSERT_EQ(pparams->vectorization_factor, 4)
@@ -2808,7 +2741,7 @@ TEST_F(ResizeTest, Slice1DVectorize3) {
       Contains(Property(&IterDomain::getParallelType, ParallelType::Vectorize)))
       << "Failed to vectorize: " << tv1;
 
-  testValidate(&fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_results.outputs, {t0}, __LINE__, __FILE__);
 }
 
 // An input is sliced and also entirely read. Both should be vectorizable.
@@ -2848,11 +2781,10 @@ TEST_F(ResizeTest, Slice1DVectorize3Manual) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref =
       t0.index({at::indexing::Slice(slice_offset, shape[0] - slice_offset)});
@@ -2924,10 +2856,8 @@ TEST_F(ResizeTest, Slice2DVectorize1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
-  auto cg_results =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs);
+  auto cg_results = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
   // check vectorization
   ASSERT_EQ(pparams->vectorization_factor, 4)
@@ -2937,7 +2867,7 @@ TEST_F(ResizeTest, Slice2DVectorize1) {
       Contains(Property(&IterDomain::getParallelType, ParallelType::Vectorize)))
       << "Failed to vectorize: " << tv1;
 
-  testValidate(&fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_results.outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Fully contiguous tensor, but a sliced domain makes the domain to
@@ -2961,16 +2891,14 @@ TEST_F(ResizeTest, Slice3DVectorize1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
-  auto cg_results =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs);
+  auto cg_results = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
 
   ASSERT_EQ(pparams->vectorization_factor, 1)
       << "Unexpected factor of vectorization";
 
-  testValidate(&fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_results.outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Similar to Slice3DVectorize2 but with a middle broadcast
@@ -2995,16 +2923,14 @@ TEST_F(ResizeTest, Slice3DVectorize2) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
-  auto cg_results =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs);
+  auto cg_results = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
   // check vectorization
   ASSERT_EQ(pparams->vectorization_factor, 1)
       << "Unexpected factor of vectorization";
 
-  testValidate(&fusion, cg_results.outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_results.outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Repro of issue 540 without transpose
@@ -3077,11 +3003,10 @@ TEST_F(ResizeTest, SliceAndReshapeRepro540Manual) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   for (const auto i : c10::irange(3)) {
     auto slice_out_ref = t0.index(
@@ -3123,11 +3048,10 @@ TEST_F(ResizeTest, ReshapeToPad) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at_x = at::randn({4, 3}, options);
-  std::vector<c10::IValue> aten_inputs = {at_x, 1, 1, 3, 4};
-  auto at_y = at::pad(at_x.reshape({3, 4}), {0, 1, 0, 1});
+  at::Tensor t0 = at::randn({4, 3}, options);
+  auto at_y = at::pad(t0.reshape({3, 4}), {0, 1, 0, 1});
 
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, 1, 1, 3, 4});
 
   auto seg_fusion =
       executor_cache.getMostRecentKernelRuntime()->fusionSegments();
@@ -3136,7 +3060,7 @@ TEST_F(ResizeTest, ReshapeToPad) {
   testValidate(
       executor_cache.fusion(),
       outputs,
-      aten_inputs,
+      {t0, 1, 1, 3, 4},
       {at_y},
       __LINE__,
       __FILE__);
@@ -3167,10 +3091,9 @@ TEST_F(ResizeTest, ReshapeToSlice) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor at_x = at::randn({4, 3}, options);
-  std::vector<c10::IValue> aten_inputs = {at_x, 3, 2, 3, 4};
   auto at_y = at::slice(at::slice(at_x.reshape({3, 4}), 0, 0, 3), 1, 0, 2);
 
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({at_x, 3, 2, 3, 4});
 
   // Assert that we segmented into two segments
   auto seg_fusion =
@@ -3181,7 +3104,7 @@ TEST_F(ResizeTest, ReshapeToSlice) {
   testValidate(
       executor_cache.fusion(),
       outputs,
-      aten_inputs,
+      {at_x, 3, 2, 3, 4},
       {at_y},
       __LINE__,
       __FILE__);
@@ -3209,11 +3132,10 @@ TEST_F(ResizeTest, CatOfBroadcast) {
 
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref = at::cat({t0, t1}, 0);
 
@@ -3246,11 +3168,10 @@ TEST_F(ResizeTest, CatOfExpandedBroadcast) {
 
   auto t0 = at::randn(shape0, options);
   auto t1 = at::randn(shape1, options);
-  std::vector<c10::IValue> aten_inputs({t0, t1});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
 
   auto ref = at::cat({at::expand_copy(t0, shape0e), t1}, 0);
 
@@ -3292,16 +3213,14 @@ TEST_F(ResizeTest, PadExpandedEmpty) {
   auto options = at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0);
 
   auto t0 = at::randn({0}, options).as_strided({2, 0, 3}, {0, 0, 0});
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
-  testValidate(
-      executor_cache.fusion(), cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(executor_cache.fusion(), cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Test that we can pad properly along broadcast dims
@@ -3321,16 +3240,15 @@ TEST_F(ResizeTest, PadOfBroadcast) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape0, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 // Test that we can cat along broadcast dims that have been expanded
@@ -3353,16 +3271,15 @@ TEST_F(ResizeTest, PadOfExpandedBroadcast) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape0, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   EnableOptionsGuard enable_options_guard;
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(ResizeTest, DynamicReshapeIssue1393) {
@@ -3401,8 +3318,7 @@ TEST_F(ResizeTest, DynamicReshapeIssue1393) {
   at::Tensor t1 = at::randn({4}, options).as_strided({3, 4}, {0, 1});
   auto ref = t0.add(t1).as_strided({3, 4, 5}, {4, 1, 0});
 
-  std::vector<c10::IValue> aten_inputs({t0, t1});
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   testValidate(fusion, outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
@@ -3442,20 +3358,14 @@ TEST_F(ResizeTest, SqueezeSlicedExpand) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
   auto t0 = at::randn(shape0, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 
   auto ref = at::squeeze(at::slice(t0, 1, 2, 3), 1);
 
   testValidate(
-      executor_cache.fusion(),
-      cg_outputs,
-      aten_inputs,
-      {ref},
-      __LINE__,
-      __FILE__);
+      executor_cache.fusion(), cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
 
 // Vectorization through pad is supported now!
@@ -3476,11 +3386,10 @@ TEST_F(ResizeTest, PadVectorization) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn(shape, options);
-  std::vector<c10::IValue> inputs({t0});
 
   // The pointwise scheduler should tell the vectorization factor is
   // 4.
-  auto cg_results = scheduleAndRun(&fusion, SchedulerType::PointWise, inputs);
+  auto cg_results = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
   auto pparams = cg_results.heuristic_params->as<PointwiseParams>();
 
   ASSERT_EQ(pparams->vectorization_factor, 4)
@@ -3497,7 +3406,7 @@ TEST_F(ResizeTest, PadVectorization) {
       Contains(Property(&IterDomain::getParallelType, ParallelType::Vectorize)))
       << "Failed to vectorize: " << tv2;
 
-  testValidate(&fusion, cg_results.outputs, inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_results.outputs, {t0}, __LINE__, __FILE__);
 }
 
 // MemoryPromotion generates code with volatile T. This test ensures that our
@@ -3540,10 +3449,8 @@ TEST_F(ResizeTest, CatMemoryPromotionReducedFloating) {
     at::Tensor t0 = at::randn({4, 8}, options).to(data_type_to_aten(dtype));
     at::Tensor t1 = at::randn({4, 12}, options).to(data_type_to_aten(dtype));
 
-    std::vector<c10::IValue> aten_inputs = {t0, t1};
-
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+    auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
     EXPECT_EQ(cg_outputs.size(), 1);
     EXPECT_EQ(cg_outputs[0].dtype(), data_type_to_aten(dtype));
@@ -3557,7 +3464,7 @@ TEST_F(ResizeTest, CatMemoryPromotionReducedFloating) {
     testValidate(
         executor_cache.fusion(),
         {cg_outputs[0].to(at::kFloat)},
-        aten_inputs,
+        {t0, t1},
         {ref},
         __LINE__,
         __FILE__,
@@ -3627,8 +3534,7 @@ TEST_F(ResizeTest, Issue2552) {
   auto options = at::dtype(at::kFloat).device(at::kCUDA);
   at::Tensor x_tensor = at::randn({1, 3}, options);
   at::Tensor y_tensor = at::randn({1, 3}, options);
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({x_tensor, y_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({x_tensor, y_tensor});
   testValidate(
       executor_cache.fusion(),
       out_tensors,
@@ -3740,11 +3646,10 @@ TEST_F(ResizeTest, SliceScheduledLikeProducer) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = t0.index({at::indexing::Slice(1, shape[0] - 1)});
 
@@ -3788,11 +3693,10 @@ TEST_F(ResizeTest, PadScheduledLikeConsumer) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(t0 + 1, {1, 1}) + 1;
 
@@ -3840,11 +3744,10 @@ TEST_F(ResizeTest, SliceThenPadLeftHalf) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(
       t0.index({at::indexing::Slice(0, shape[0] / 2)}), {0, shape[0] / 2});
@@ -3895,11 +3798,10 @@ TEST_F(ResizeTest, SliceThenPadRightHalf) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(
       t0.index({at::indexing::Slice(shape[0] / 2, shape[0])}),
@@ -3959,11 +3861,10 @@ TEST_F(ResizeTest, SliceThenConcat) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   EXPECT_TRUE(t0.equal(cg_outputs[0]));
 }
@@ -4053,11 +3954,10 @@ TEST_F(ResizeTest, SliceSliceConcatConcat) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({i0}, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::concat(
       {at::slice(t0, 0, 0, rope_size / 2) + 1,
@@ -4096,7 +3996,6 @@ TEST_P(ResizeSchedulerTest, PropagateSliceToInputs) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 100}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   const bool use_scheduler = GetParam();
 
@@ -4135,14 +4034,14 @@ TEST_P(ResizeSchedulerTest, PropagateSliceToInputs) {
     ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
 
     KernelExecutor ke;
-    ke.compile(&fusion, inputs);
-    auto outputs = ke.run(inputs);
-    testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+    ke.compile(&fusion, {t0});
+    auto outputs = ke.run({t0});
+    testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
   } else {
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+    auto out_tensors = executor_cache.runFusionWithInputs({t0});
     testValidate(
-        executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+        executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
     FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
     EXPECT_FALSE(runtime->isSegmented());
     const auto& heuristic_param =
@@ -4188,7 +4087,6 @@ TEST_P(ResizeSchedulerTest, PropagateSliceToInputsWithReshape1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> inputs({t0});
 
   const bool use_scheduler = GetParam();
 
@@ -4227,14 +4125,14 @@ TEST_P(ResizeSchedulerTest, PropagateSliceToInputsWithReshape1) {
     ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
 
     KernelExecutor ke;
-    ke.compile(&fusion, inputs);
-    auto outputs = ke.run(inputs);
-    testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+    ke.compile(&fusion, {t0});
+    auto outputs = ke.run({t0});
+    testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
   } else {
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+    auto out_tensors = executor_cache.runFusionWithInputs({t0});
     testValidate(
-        executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+        executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
     FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
     EXPECT_FALSE(runtime->isSegmented());
     const auto& heuristic_param =
@@ -4279,7 +4177,6 @@ TEST_P(ResizeSchedulerTest, PropagateSliceToInputsWithReshape2) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> inputs({t0});
 
   const bool use_scheduler = GetParam();
 
@@ -4315,14 +4212,14 @@ TEST_P(ResizeSchedulerTest, PropagateSliceToInputsWithReshape2) {
     ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
 
     KernelExecutor ke;
-    ke.compile(&fusion, inputs);
-    auto outputs = ke.run(inputs);
-    testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+    ke.compile(&fusion, {t0});
+    auto outputs = ke.run({t0});
+    testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
   } else {
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+    auto out_tensors = executor_cache.runFusionWithInputs({t0});
     testValidate(
-        executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+        executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
     FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
     EXPECT_FALSE(runtime->isSegmented());
     const auto& heuristic_param =
@@ -4369,7 +4266,6 @@ TEST_P(ResizeSchedulerTest, PropagateMultipleSlicesToInputs1) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 100}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   const bool use_scheduler = GetParam();
 
@@ -4420,9 +4316,9 @@ TEST_P(ResizeSchedulerTest, PropagateMultipleSlicesToInputs1) {
     ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
 
     KernelExecutor ke;
-    ke.compile(&fusion, inputs);
-    auto outputs = ke.run(inputs);
-    testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+    ke.compile(&fusion, {t0});
+    auto outputs = ke.run({t0});
+    testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
   } else {
     // Make sure all slices are detected as exclusive
     IdModel id_model(&fusion, /*build_graphs=*/false);
@@ -4432,9 +4328,9 @@ TEST_P(ResizeSchedulerTest, PropagateMultipleSlicesToInputs1) {
     EXPECT_TRUE(non_exclusive_resize_info.empty());
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+    auto out_tensors = executor_cache.runFusionWithInputs({t0});
     testValidate(
-        executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+        executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
     FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
     EXPECT_FALSE(runtime->isSegmented());
     const auto& heuristic_param =
@@ -4547,12 +4443,10 @@ TEST_F(ResizeSchedulerTest, PropagateMultipleSlicesToInputs2) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 100}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
-  testValidate(
-      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
 
   // While the slices can be transformed to be all exclusive, it is
   // currently segmented as the output has differet shapes. Both
@@ -4638,12 +4532,11 @@ TEST_F(ResizeSchedulerTest, PropagateMultipleSlicesToInputs3) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 100}, options);
   auto t1 = at::randn({16}, options);
-  std::vector<c10::IValue> inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1});
   testValidate(
-      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1}, __LINE__, __FILE__);
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_FALSE(runtime->isSegmented());
   const auto& heuristic_param =
@@ -4733,7 +4626,6 @@ TEST_P(ResizeSchedulerTest, PropagateMultipleSlicesToInputs5) {
   fusion.addOutput(tv4);
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 100}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   const bool use_scheduler = GetParam();
 
@@ -4772,9 +4664,9 @@ TEST_P(ResizeSchedulerTest, PropagateMultipleSlicesToInputs5) {
     ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
 
     KernelExecutor ke;
-    ke.compile(&fusion, inputs);
-    auto outputs = ke.run(inputs);
-    testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+    ke.compile(&fusion, {t0});
+    auto outputs = ke.run({t0});
+    testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
   } else {
     // The two slices do not conflict
     IdModel id_model(&fusion, /*build_graphs=*/false);
@@ -4784,9 +4676,9 @@ TEST_P(ResizeSchedulerTest, PropagateMultipleSlicesToInputs5) {
     EXPECT_TRUE(non_exclusive_resize_info.empty());
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+    auto out_tensors = executor_cache.runFusionWithInputs({t0});
     testValidate(
-        executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+        executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
     FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
     EXPECT_FALSE(runtime->isSegmented());
     const auto& heuristic_param =
@@ -4834,7 +4726,6 @@ TEST_F(ResizeSchedulerTest, PropagateMultipleSlicesToInputs6) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 100}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   // The two slices do not conflict
   IdModel id_model(&fusion, /*build_graphs=*/false);
@@ -4852,9 +4743,8 @@ TEST_F(ResizeSchedulerTest, PropagateMultipleSlicesToInputs6) {
   // segment consisting of tv2 and tv3 slices. Another is a pointwise
   // segment for tv5.
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
-  testValidate(
-      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   const auto& heuristic_list = runtime->schedulerHeuristics()->heuristicsList();
   EXPECT_EQ(heuristic_list.size(), 2);
@@ -4900,7 +4790,6 @@ TEST_P(ResizeSchedulerTest, SliceRotateCat) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 100}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   fusion.addOutput(tv5);
 
@@ -4951,9 +4840,9 @@ TEST_P(ResizeSchedulerTest, SliceRotateCat) {
     ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
 
     KernelExecutor ke;
-    ke.compile(&fusion, inputs);
-    auto outputs = ke.run(inputs);
-    testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+    ke.compile(&fusion, {t0});
+    auto outputs = ke.run({t0});
+    testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
   } else {
     // tv1 is not considered exclusive as tv0 is also a consumer of
     // tv3. Same for tv3. While the common input, tv0, is a fusion
@@ -4976,9 +4865,9 @@ TEST_P(ResizeSchedulerTest, SliceRotateCat) {
     EXPECT_EQ(non_exclusive_resize_info.size(), 2);
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+    auto out_tensors = executor_cache.runFusionWithInputs({t0});
     testValidate(
-        executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+        executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
     FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
     EXPECT_FALSE(runtime->isSegmented());
     const auto& heuristic_param =
@@ -5037,7 +4926,6 @@ TEST_P(ResizeSchedulerTest, SliceRotateCatResidual) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> inputs({t0});
 
   const bool use_scheduler = GetParam();
 
@@ -5097,9 +4985,9 @@ TEST_P(ResizeSchedulerTest, SliceRotateCatResidual) {
     ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
 
     KernelExecutor ke;
-    ke.compile(&fusion, inputs);
-    auto outputs = ke.run(inputs);
-    testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+    ke.compile(&fusion, {t0});
+    auto outputs = ke.run({t0});
+    testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
   } else {
     // tv1 is not considered exclusive as tv0 is also a consumer of
     // tv3. Same for tv3. While the common input, tv0, is a fusion
@@ -5122,9 +5010,9 @@ TEST_P(ResizeSchedulerTest, SliceRotateCatResidual) {
     EXPECT_EQ(non_exclusive_resize_info.size(), 2);
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+    auto out_tensors = executor_cache.runFusionWithInputs({t0});
     testValidate(
-        executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+        executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
     FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
     EXPECT_FALSE(runtime->isSegmented());
     const auto& heuristic_param =
@@ -5187,7 +5075,6 @@ TEST_F(ResizeSchedulerTest, SliceRotateCatTwice) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 100}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   // tv1 is not considered exclusive as tv0 is also a consumer of
   // tv3. Same for tv3. While the common input, tv0, is a fusion
@@ -5227,9 +5114,8 @@ TEST_F(ResizeSchedulerTest, SliceRotateCatTwice) {
   EXPECT_EQ(non_exclusive_resize_info.size(), 4);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
-  testValidate(
-      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_FALSE(runtime->isSegmented());
@@ -5262,7 +5148,6 @@ TEST_P(ResizeSchedulerTest, PropagatePadToInputs) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 100}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   const bool use_scheduler = GetParam();
 
@@ -5301,9 +5186,9 @@ TEST_P(ResizeSchedulerTest, PropagatePadToInputs) {
     ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
 
     KernelExecutor ke;
-    ke.compile(&fusion, inputs);
-    auto outputs = ke.run(inputs);
-    testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+    ke.compile(&fusion, {t0});
+    auto outputs = ke.run({t0});
+    testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
   } else {
     IdModel id_model(&fusion, /*build_graphs=*/false);
     const auto& exact_graph = id_model.buildExactGraph();
@@ -5312,9 +5197,9 @@ TEST_P(ResizeSchedulerTest, PropagatePadToInputs) {
     EXPECT_TRUE(non_exclusive_resize_info.empty());
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+    auto out_tensors = executor_cache.runFusionWithInputs({t0});
     testValidate(
-        executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+        executor_cache.fusion(), out_tensors, {t0}, __LINE__, __FILE__);
     FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
     EXPECT_FALSE(runtime->isSegmented());
     const auto& heuristic_param =
@@ -5358,7 +5243,6 @@ TEST_P(ResizeSchedulerTest, PropagateCatToInputs) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 100}, options);
   auto t1 = at::randn({16, 100}, options);
-  std::vector<c10::IValue> inputs({t0, t1});
 
   const bool use_scheduler = GetParam();
 
@@ -5405,9 +5289,9 @@ TEST_P(ResizeSchedulerTest, PropagateCatToInputs) {
     ref_tv->axis(-2)->parallelize(ParallelType::BIDx);
 
     KernelExecutor ke;
-    ke.compile(&fusion, inputs);
-    auto outputs = ke.run(inputs);
-    testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+    ke.compile(&fusion, {t0, t1});
+    auto outputs = ke.run({t0, t1});
+    testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
   } else {
     IdModel id_model(&fusion, /*build_graphs=*/false);
     const auto& exact_graph = id_model.buildExactGraph();
@@ -5416,9 +5300,9 @@ TEST_P(ResizeSchedulerTest, PropagateCatToInputs) {
     EXPECT_TRUE(non_exclusive_resize_info.empty());
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+    auto out_tensors = executor_cache.runFusionWithInputs({t0, t1});
     testValidate(
-        executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+        executor_cache.fusion(), out_tensors, {t0, t1}, __LINE__, __FILE__);
     FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
     EXPECT_FALSE(runtime->isSegmented());
     const auto& heuristic_param =
@@ -5457,11 +5341,10 @@ TEST_F(ResizeTest, VectorizePadLowering) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
 
   auto ref = at::pad(t0, {4, 4});
   ASSERT_TRUE(ref.equal(cg_outputs[0]));
@@ -5492,11 +5375,10 @@ TEST_F(ResizeTest, VectorizeWhereLowering) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({at::Scalar(false), t0});
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
-  auto cg_outputs = ke.run(aten_inputs);
+  ke.compile(&fusion, {false, t0});
+  auto cg_outputs = ke.run({false, t0});
 
   // Note: we cannot use at::where, because aten only support tensor as
   // predicate.
@@ -5518,9 +5400,7 @@ TEST_F(ResizeTest, VectorizeFactorFour) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
+  auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
 
   // check that we vectorize 4
   bool found_vectorize = false;
@@ -5537,7 +5417,7 @@ TEST_F(ResizeTest, VectorizeFactorFour) {
   }
   EXPECT_TRUE(found_vectorize);
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs.outputs, {t0}, __LINE__, __FILE__);
 }
 
 // This test is to check that the pad extent is used to limit the vectorization
@@ -5558,9 +5438,7 @@ TEST_F(ResizeTest, VectorizeFactorTwo) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
+  auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
 
   // check that we vectorize 2
   bool found_vectorize = false;
@@ -5577,7 +5455,7 @@ TEST_F(ResizeTest, VectorizeFactorTwo) {
   }
   EXPECT_TRUE(found_vectorize);
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs.outputs, {t0}, __LINE__, __FILE__);
 }
 
 // This test is to check that the pad with 0-extent
@@ -5597,9 +5475,7 @@ TEST_F(ResizeTest, VectorizeFactorTwoPadZeroExtent) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
+  auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
 
   // check that we vectorize 2
   bool found_vectorize = false;
@@ -5616,7 +5492,7 @@ TEST_F(ResizeTest, VectorizeFactorTwoPadZeroExtent) {
   }
   EXPECT_TRUE(found_vectorize);
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs.outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(ResizeTest, VectorizePadNonInnermost) {
@@ -5641,9 +5517,7 @@ TEST_F(ResizeTest, VectorizePadNonInnermost) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
+  auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
 
   // check that we vectorize 4
   bool found_vectorize = false;
@@ -5660,7 +5534,7 @@ TEST_F(ResizeTest, VectorizePadNonInnermost) {
   }
   EXPECT_TRUE(found_vectorize);
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs.outputs, {t0}, __LINE__, __FILE__);
 }
 
 TEST_F(ResizeTest, PadAndCacheUses) {
@@ -5680,9 +5554,7 @@ TEST_F(ResizeTest, PadAndCacheUses) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
-  std::vector<c10::IValue> aten_inputs({t0});
-  auto cg_outputs =
-      scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
+  auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
 
   // check that pad vectorize 4
   bool found_vectorize = false;
@@ -5713,7 +5585,7 @@ TEST_F(ResizeTest, PadAndCacheUses) {
   }
   EXPECT_TRUE(found_vectorize);
 
-  testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, cg_outputs.outputs, {t0}, __LINE__, __FILE__);
 }
 
 // we cannot yet test this one, as pad in the middle causes segmentation
@@ -5741,16 +5613,14 @@ TEST_F(ResizeTest, PadAndCacheUses) {
 //
 //   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 //   auto t0 = at::randn(shape, options);
-//   std::vector<c10::IValue> aten_inputs({t0});
-//   auto cg_outputs =
-//       scheduleAndRun(&fusion, SchedulerType::PointWise, aten_inputs).outputs;
+//   auto cg_outputs = scheduleAndRun(&fusion, SchedulerType::PointWise, {t0});
 //
 //   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-//   auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+//   auto cg_outputs = executor_cache.runFusionWithInputs({t0});
 //
 //   auto ref = at::pad(t0.relu(), {0, 0, 4, 4, 0, 0});
 //
-//   NVF_CHECK(ref.equal(cg_outputs[0]));
+//   NVF_CHECK(ref.equal(cg_outputs.outputs[0]));
 //   // TODO: check vectorization factor
 // }
 
@@ -5796,11 +5666,10 @@ TEST_F(ResizeTest, TraversalForInliningPosition) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({16}, options);
   auto t1 = at::randn({8}, options);
-  std::vector<c10::IValue> inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 
   // Make sure all the tensors are at least inlined at some
   // position. The cache of tv1 was not inlined at all due to the issue.
@@ -5905,11 +5774,10 @@ TEST_F(ResizeTest, Repro3801) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({1, 16}, options);
   auto t1 = at::randn({1, 4, 3, 1, 16}, options);
-  std::vector<c10::IValue> inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Mixing resize and index ops is not supported yet.Specifically,
@@ -5935,11 +5803,10 @@ TEST_F(ResizeTest, DoNotFuseResizeAndIndexOps) {
   auto options_int = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn({128, 4095}, options);
   auto t1 = at::randint(0, 128, {1, 4096}, options_int);
-  std::vector<c10::IValue> inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(executor_cache.fusion(), outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  testValidate(executor_cache.fusion(), outputs, {t0, t1}, __LINE__, __FILE__);
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
 

--- a/tests/cpp/test_rng.cpp
+++ b/tests/cpp/test_rng.cpp
@@ -468,10 +468,9 @@ TEST_F(RNGTest, FunctionalUniform) {
 
       auto ref1 = generate_uniform(size, at::kDouble) * 2 - 1;
 
-      std::vector<c10::IValue> aten_inputs({size, -1.0, 1.0, 0, 0});
-
       at::manual_seed(0);
-      auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+      auto cg_outputs =
+          executor_cache.runFusionWithInputs({size, -1.0, 1.0, 0, 0});
 
       std::vector<at::Tensor> aten_outputs;
       if (do_stochastic) {
@@ -483,7 +482,7 @@ TEST_F(RNGTest, FunctionalUniform) {
       testValidate(
           executor_cache.fusion(),
           cg_outputs,
-          aten_inputs,
+          {size, -1.0, 1.0, 0, 0},
           aten_outputs,
           __LINE__,
           __FILE__);

--- a/tests/cpp/test_rope.cpp
+++ b/tests/cpp/test_rope.cpp
@@ -169,12 +169,11 @@ TEST_P(MistralRopeTest, Fwd1) {
   auto t0 = at::randn(shape1, options_bf16);
   auto t1 = at::randn(shape2, options_bf16);
   auto t2 = at::randn(shape3, options_float).to(at::kLong);
-  std::vector<c10::IValue> inputs({t0, t1, t2});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2});
   testValidate(
-      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 // Mistral forward after matmul
@@ -435,12 +434,11 @@ TEST_P(MistralRopeTest, Fwd2) {
   auto t0 = at::randn(shape1, options_bf16);
   auto t1 = at::randn(shape2, options_bf16);
   auto t2 = at::randn(shape3, options_fp32);
-  std::vector<c10::IValue> inputs({t0, t1, t2});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2});
   testValidate(
-      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 // clang-format off
@@ -729,12 +727,11 @@ TEST_P(MistralRopeTest, Bwd) {
   auto t1 = at::randn(shape1, options_fp32);
   auto t2 = at::randn(shape2, options_bf16);
   auto t3 = at::randn(shape3, options_bf16);
-  std::vector<c10::IValue> inputs({t0, t1, t2, t3});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2});
   testValidate(
-      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 using Phi3RopeTest = RopeTest;
@@ -986,12 +983,11 @@ TEST_P(Phi3RopeTest, Fwd) {
   auto t0 = at::randn(qkv_shape, options_bf16);
   auto t1 = at::randn({head_dim / 2}, options_bf16);
   auto t2 = at::arange(seq_len, options_int).unsqueeze(0);
-  std::vector<c10::IValue> inputs({t0, t1, t2});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2});
   testValidate(
-      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+      executor_cache.fusion(), out_tensors, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 // clang-format off
@@ -1216,12 +1212,15 @@ TEST_P(Phi3RopeTest, Bwd) {
   auto t3 = at::randn({seq_len, head_dim}, options_bf16)
                 .as_strided({shape}, {0, 0, head_dim, 1});
   auto t4 = at::randn(shape, options_bf16);
-  std::vector<c10::IValue> inputs({t0, t1, t2, t3, t4});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs(inputs);
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2, t3, t4});
   testValidate(
-      executor_cache.fusion(), out_tensors, inputs, __LINE__, __FILE__);
+      executor_cache.fusion(),
+      out_tensors,
+      {t0, t1, t2, t3, t4},
+      __LINE__,
+      __FILE__);
 }
 
 using LitgptRopeTest = RopeTest;
@@ -1371,11 +1370,10 @@ TEST_P(LitgptRopeTest, Fwd) {
   auto t0 = at::randn(input_shape, options);
   auto t1 = at::randn({config.seq_length, config.rope_n_elem}, options);
   auto t2 = at::randn({config.seq_length, config.rope_n_elem}, options);
-  std::vector<c10::IValue> inputs({t0, t1, t2});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
+  testValidate(&fusion, outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 // clang-format off
@@ -1617,11 +1615,10 @@ TEST_P(LitgptRopeTest, Bwd) {
   auto t1 = at::randn({2, n_head, seq_len, head_dim}, options);
   auto t2 = at::randn({2, n_head, seq_len, head_dim}, options);
   auto t3 = at::randn({seq_len, head_dim}, options);
-  std::vector<c10::IValue> inputs({t0, t1, t2, t3});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2, t3});
+  testValidate(&fusion, outputs, {t0, t1, t2, t3}, __LINE__, __FILE__);
 }
 
 // Testing the scheduling of an ending repeat pattern, which is
@@ -1642,11 +1639,10 @@ TEST_F(RopeTest, EndingRepeat) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn(shape1, options);
-  std::vector<c10::IValue> inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_FALSE(runtime->isSegmented());

--- a/tests/cpp/test_rope.cpp
+++ b/tests/cpp/test_rope.cpp
@@ -729,9 +729,13 @@ TEST_P(MistralRopeTest, Bwd) {
   auto t3 = at::randn(shape3, options_bf16);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2});
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1, t2, t3});
   testValidate(
-      executor_cache.fusion(), out_tensors, {t0, t1, t2}, __LINE__, __FILE__);
+      executor_cache.fusion(),
+      out_tensors,
+      {t0, t1, t2, t3},
+      __LINE__,
+      __FILE__);
 }
 
 using Phi3RopeTest = RopeTest;

--- a/tests/cpp/test_scatter_gather.cpp
+++ b/tests/cpp/test_scatter_gather.cpp
@@ -112,14 +112,14 @@ TEST_F(ScatterGatherTest, Scatter1DIndexZerosSelfTvSameShape) {
 
     at::Tensor idx_1 = at::randint(0, 24, idx_dims[test_id], options_i);
     at::Tensor idx_2 = idx - idx_1;
-    at::Tensor input = at::randn(input_dims[test_id], options);
+    at::Tensor t0 = at::randn(input_dims[test_id], options);
     at::Tensor src = at::randn(src_dims[test_id], options);
 
-    std::vector<c10::IValue> aten_inputs = {input, idx_1, idx_2, src};
-
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-    testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+    auto cg_outputs =
+        executor_cache.runFusionWithInputs({t0, idx_1, idx_2, src});
+    testValidate(
+        &fusion, cg_outputs, {t0, idx_1, idx_2, src}, __LINE__, __FILE__);
   }
 }
 
@@ -152,16 +152,13 @@ TEST_F(ScatterGatherTest, TorchGatherAllRankAllSelectedDim) {
         auto input_dims = randomVector(2, max_dim_size, rank);
         auto index_dims =
             randomIndexVector(input_dims, 1, rank, is_take_along, dim);
-        at::Tensor input = at::randn(input_dims, options);
-        at::Tensor input_idx =
-            at::randint(0, input_dims[dim], index_dims, options_i);
+        at::Tensor t0 = at::randn(input_dims, options);
+        at::Tensor idx = at::randint(0, input_dims[dim], index_dims, options_i);
         at::Tensor output = at::zeros(index_dims, options);
 
-        std::vector<c10::IValue> aten_inputs = {input, input_idx};
-
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
-        auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-        testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
+        testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
       }
     }
   }
@@ -192,15 +189,12 @@ TEST_F(ScatterGatherTest, TorchGatherAddMul) {
         auto index_dims =
             randomIndexVector(input_dims, 1, rank, is_take_along, dim);
 
-        at::Tensor input = at::randn(input_dims, options); // lookup
-        at::Tensor input_idx =
-            at::randint(0, input_dims[dim], index_dims, options_i);
-
-        std::vector<c10::IValue> aten_inputs = {input, input_idx};
+        at::Tensor t0 = at::randn(input_dims, options); // lookup
+        at::Tensor idx = at::randint(0, input_dims[dim], index_dims, options_i);
 
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
-        auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-        testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
+        testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
       }
     }
   }
@@ -241,10 +235,15 @@ TEST_F(ScatterGatherTest, AddGatherSumAdd) {
         at::Tensor t_idx_2 =
             at::randint(0, input_dims[dim] / 2, index_dims, options_i);
 
-        std::vector<c10::IValue> aten_inputs = {t_lookup, t_idx_1, t_idx_2};
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
-        auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-        testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        auto cg_outputs =
+            executor_cache.runFusionWithInputs({t_lookup, t_idx_1, t_idx_2});
+        testValidate(
+            &fusion,
+            cg_outputs,
+            {t_lookup, t_idx_1, t_idx_2},
+            __LINE__,
+            __FILE__);
       }
     }
   }
@@ -284,16 +283,13 @@ TEST_F(ScatterGatherTest, TorchGatherSumAdd) {
           input2_dims[idim] = index_dims[idim + 1];
         }
 
-        at::Tensor input = at::randn(input_dims, options); // lookup
-        at::Tensor input2 = at::randn(input2_dims, options); // lookup
-        at::Tensor input_idx =
-            at::randint(0, input_dims[dim], index_dims, options_i);
-
-        std::vector<c10::IValue> aten_inputs = {input, input_idx, input2};
+        at::Tensor t0 = at::randn(input_dims, options); // lookup
+        at::Tensor t1 = at::randn(input2_dims, options); // lookup
+        at::Tensor idx = at::randint(0, input_dims[dim], index_dims, options_i);
 
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
-        auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-        testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx, t1});
+        testValidate(&fusion, cg_outputs, {t0, idx, t1}, __LINE__, __FILE__);
       }
     }
   }
@@ -325,15 +321,12 @@ TEST_F(ScatterGatherTest, TorchGatherAddMulHugeSize) {
         auto index_dims =
             randomIndexVector(input_dims, 1, rank, is_take_along, dim);
 
-        at::Tensor input = at::randn(input_dims, options); // lookup
-        at::Tensor input_idx =
-            at::randint(0, input_dims[dim], index_dims, options_i);
-
-        std::vector<c10::IValue> aten_inputs = {input, input_idx};
+        at::Tensor t0 = at::randn(input_dims, options); // lookup
+        at::Tensor idx = at::randint(0, input_dims[dim], index_dims, options_i);
 
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
-        auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-        testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
+        testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
       }
     }
   }
@@ -391,22 +384,19 @@ TEST_F(ScatterGatherTest, TorchGatherIndexTvExtentIsOne) {
   auto tv_out = mul(tv_add, tv_in2);
   fusion.addOutput(tv_out);
 
-  at::Tensor input_1 = at::randn(input_dims, options);
-  at::Tensor input_2 = at::randn(index_dims, options);
-  at::Tensor input_idx =
-      at::randint(0, max_selected_index, index_dims, options_i);
+  at::Tensor t0 = at::randn(input_dims, options);
+  at::Tensor t1 = at::randn(index_dims, options);
+  at::Tensor idx = at::randint(0, max_selected_index, index_dims, options_i);
   at::Tensor output = at::zeros(index_dims, options);
 
-  auto t_gather = at::gather(input_1, 1, input_idx);
+  auto t_gather = at::gather(t0, 1, idx);
   auto t_add = at::clamp(t_gather, -1, 1);
-  auto tv_out_ref = at::mul(input_2, t_add);
-
-  std::vector<c10::IValue> aten_inputs = {input_1, input_idx, input_2};
+  auto tv_out_ref = at::mul(t1, t_add);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx, t1});
   testValidate(
-      &fusion, cg_outputs, aten_inputs, {tv_out_ref}, __LINE__, __FILE__);
+      &fusion, cg_outputs, {t0, idx, t1}, {tv_out_ref}, __LINE__, __FILE__);
 }
 
 // Test takeAlongAxis with a broadcast index tensor
@@ -439,12 +429,11 @@ TEST_F(ScatterGatherTest, TakeAlongBroadcastIndex) {
     at::Tensor t0 = at::randn(input_dims, options);
     at::Tensor t1 = at::randint(0, input_dims[1], index_dims, options_i);
     at::Tensor t2 = at::randn(out_dims, options);
-    std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
     FusionExecutorCache executor_cache(std::move(fusion_ptr));
-    auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
+    auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
-    testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+    testValidate(&fusion, cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
   }
 }
 
@@ -497,12 +486,10 @@ TEST_F(ScatterGatherTest, GatherBroadcastInput) {
         at::Tensor t0 = at::randn(input_dims, options);
         at::Tensor t1 = at::randint(0, input_dims[1], index_dims, options_i);
         at::Tensor t2 = at::randn(out_dims, options);
-        std::vector<c10::IValue> aten_inputs = {t0, t1, t2};
 
         FusionExecutorCache executor_cache(std::move(fusion_ptr));
-        auto cg_outputs = executor_cache.runFusionWithInputs(aten_inputs);
-
-        testValidate(&fusion, cg_outputs, aten_inputs, __LINE__, __FILE__);
+        auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
+        testValidate(&fusion, cg_outputs, {t0, t1, t2}, __LINE__, __FILE__);
       }
     }
   }
@@ -584,14 +571,13 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorPointwise1) {
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   auto t1 = at::randint(0, shape[1], {shape[0]}, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   KernelExecutor ke;
-  ke.compile(&fusion, aten_inputs);
+  ke.compile(&fusion, {t0, t1});
 
-  auto outputs = ke.run(aten_inputs);
+  auto outputs = ke.run({t0, t1});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Same as the above but with the pointwise scheduler
@@ -619,15 +605,14 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorPointwise2) {
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   auto t1 = at::randint(0, shape[1], {shape[0]}, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(), {SchedulerType::PointWise});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Reduction then takeAlongAxis. This is currently segmented due to
@@ -653,16 +638,15 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction1) {
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   auto t1 = at::randint(0, shape[0], {2}, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(),
       {SchedulerType::Reduction, SchedulerType::PointWise});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // takeAlongAxis to broadcast, squeeze, then reduction. Segmented
@@ -693,16 +677,15 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction2) {
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   auto t1 = at::randint(0, shape[1], {shape[0]}, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(),
       {SchedulerType::PointWise, SchedulerType::Reduction});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // takeAlongAxis then reduction. Should not be segmented.
@@ -732,15 +715,14 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorReduction3) {
   auto t0 = at::randn(shape_before_gather, options);
   auto t1 =
       at::randint(0, shape_before_gather[1], shape_after_gather, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(), {SchedulerType::Reduction});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Similar to TakeAlongAxisIntermediateTensorReduction2, but no
@@ -774,15 +756,14 @@ TEST_F(ScatterGatherTest, DISABLED_TakeAlongAxisIntermediateTensorReduction4) {
   auto t0 = at::randn(shape_before_gather, options);
   auto t1 =
       at::randint(0, shape_before_gather[1], shape_after_gather, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(), {SchedulerType::Reduction});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // Normalization then takeAlongAxis
@@ -812,10 +793,9 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization1) {
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   auto t1 = at::randint(0, shape[1], {shape[0]}, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(),
@@ -825,7 +805,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization1) {
   auto ref = at::take_along_dim(
       t0_d / t0_d.sum({1}).unsqueeze(-1), t1.unsqueeze(-1), 1);
 
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
 
 // take_along_dim to broadcast, squeeze, then normalization. Segmented
@@ -856,10 +836,9 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization2) {
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   auto t1 = at::randint(0, shape[1], {shape[0]}, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(),
@@ -869,7 +848,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization2) {
                 .squeeze(1);
   auto ref = t5 / t5.sum({0}).unsqueeze(0);
 
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
 
 // takeAlongAxis then normalization. Should not be segmented.
@@ -901,10 +880,9 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization3) {
   auto t0 = at::randn(shape_before_gather, options);
   auto t1 =
       at::randint(0, shape_before_gather[1], shape_after_gather, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(),
@@ -913,7 +891,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization3) {
   auto t3 = at::take_along_dim(t0.to(at::kDouble) + 1, t1, 1);
   auto ref = t3 / t3.sum({1}).unsqueeze(-1);
 
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
 
 // Normalization, then takeAlongAxis, then reduction. Similar
@@ -943,10 +921,9 @@ TEST_F(
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   auto t1 = at::randint(0, shape[1], {shape[0], 1}, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   // The reduction patterns of the normalization and the final
   // reduction are different, so they are segmented out
@@ -958,7 +935,7 @@ TEST_F(
   auto t5 = at::take_along_dim(t0_d / t0_d.sum({1}).unsqueeze(-1), t1, 1);
   auto ref = t5.sum();
 
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
 
 // Similar to
@@ -995,10 +972,9 @@ TEST_F(
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   auto t1 = at::randint(0, shape[1], {shape[0]}, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(),
@@ -1009,7 +985,7 @@ TEST_F(
       t0_d / t0_d.sum({1}).unsqueeze(-1), t1.unsqueeze(-1), 1);
   auto ref = (t0_d + t6).sum({1});
 
-  testValidate(&fusion, outputs, aten_inputs, {ref}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
 
 // takeAlongAxis then transpose
@@ -1046,15 +1022,14 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose1) {
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   auto t1 = at::randint(0, shape[0], {shape[1], shape[2]}, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(), {SchedulerType::Transpose});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // transpose then takeAlongAxis. Currently failed to pick the
@@ -1089,15 +1064,14 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose2) {
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape, options);
   auto t1 = at::randint(0, shape[0], {10, shape[2], shape[1]}, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(), {SchedulerType::PointWise});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 // transpose the dimension produced by takeAlongAxis. Currently not
@@ -1134,17 +1108,16 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorTranspose3) {
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   auto t0 = at::randn(shape_before, options);
   auto t1 = at::randint(0, shape_before[2], shape_after, options_i);
-  std::vector<c10::IValue> aten_inputs = {t0, t1};
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   // Transpose scheduler should work for this case but not currently
   // supported
   validateSegmentation(
       executor_cache.getMostRecentKernelRuntime(), {SchedulerType::PointWise});
 
-  testValidate(&fusion, outputs, aten_inputs, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(ScatterGatherTest, TakeAlongAxisCrossEntropyLoss) {
@@ -1189,11 +1162,10 @@ TEST_F(ScatterGatherTest, TakeAlongAxisCrossEntropyLoss) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({128, 371}, options);
   auto t1 = at::randint(371, {128}, options).to(at::ScalarType::Long);
-  std::vector<c10::IValue> inputs({t0, t1});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
 
-  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   auto kernel_runtime = executor_cache.getMostRecentKernelRuntime();
 
@@ -1221,7 +1193,7 @@ TEST_F(ScatterGatherTest, TakeAlongAxisCrossEntropyLoss) {
   //   mean -> 1
   //   sum  -> 2
   auto ref = at::cross_entropy_loss_symint(t0, t1, {}, 1, 5, 0.0);
-  testValidate(fusion, cg_outputs, inputs, {ref}, __LINE__, __FILE__);
+  testValidate(fusion, cg_outputs, {t0, t1}, {ref}, __LINE__, __FILE__);
 }
 
 // Test grouped reduction on IterType::GatherScatter
@@ -1254,13 +1226,12 @@ TEST_F(ScatterGatherTest, GatherIterGoupedReduction) {
     input2_dims[idim] = index_dims[idim + 1];
   }
 
-  at::Tensor input = at::randn(input_dims, options);
-  at::Tensor input_idx = at::randint(0, input_dims[dim], index_dims, options_i);
-  std::vector<c10::IValue> aten_inputs = {input, input_idx};
+  at::Tensor t0 = at::randn(input_dims, options);
+  at::Tensor idx = at::randint(0, input_dims[dim], index_dims, options_i);
 
   auto reduction_scheduler =
       SchedulerEntry::makeSchedulerInstance(SchedulerType::Reduction);
-  SchedulerRuntimeInfo runtime_info(&fusion, aten_inputs);
+  SchedulerRuntimeInfo runtime_info(&fusion, {t0, idx});
   auto heuristic_params =
       reduction_scheduler->computeHeuristics(&fusion, runtime_info);
   auto rparams = heuristic_params->as<ReductionParams>();
@@ -1295,14 +1266,14 @@ TEST_F(ScatterGatherTest, GatherIterGoupedReduction) {
 
   KernelExecutor ke;
   auto lparams = rparams->lparams;
-  ke.compile(&fusion, aten_inputs, lparams);
-  auto cg_outputs = ke.run(aten_inputs, lparams);
+  ke.compile(&fusion, {t0, idx}, lparams);
+  auto cg_outputs = ke.run({t0, idx}, lparams);
 
-  auto t_gather = at::gather(input, dim, input_idx);
+  auto t_gather = at::gather(t0, dim, idx);
   testValidate(
       &fusion,
       cg_outputs,
-      aten_inputs,
+      {t0, idx},
       {t_gather.sum(0)},
       __LINE__,
       __FILE__,

--- a/tests/cpp/test_segmentation.cpp
+++ b/tests/cpp/test_segmentation.cpp
@@ -41,17 +41,16 @@ TEST_F(SegmentationTest, Issue1284_Repro1) {
   fusion.addOutput(out_1);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at_in_0 = at::randn(input_shape_0, options);
-  at::Tensor at_in_1 = at::randn(input_shape_1, options);
-  std::vector<c10::IValue> aten_inputs = {at_in_0, at_in_1};
+  at::Tensor t0 = at::randn(input_shape_0, options);
+  at::Tensor t1 = at::randn(input_shape_1, options);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_EQ(runtime->fusionSegments()->groups().size(), 2);
 
-  testValidate(&fusion, outputs, {at_in_0, at_in_1}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1}, __LINE__, __FILE__);
 }
 
 TEST_F(SegmentationTest, Issue1284_Repro2) {
@@ -78,20 +77,17 @@ TEST_F(SegmentationTest, Issue1284_Repro2) {
   fusion.addOutput(out_1);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor at_in_0 = at::randn(input_shape_0, options);
-  at::Tensor at_in_1 = at::randn(input_shape_1, options);
-  at::Tensor at_in_2 = at::randn(input_shape_2, options);
-
-  std::vector<c10::IValue> aten_inputs = {at_in_0, at_in_1, at_in_2};
+  at::Tensor t0 = at::randn(input_shape_0, options);
+  at::Tensor t1 = at::randn(input_shape_1, options);
+  at::Tensor t2 = at::randn(input_shape_2, options);
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(aten_inputs);
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1, t2});
 
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_EQ(runtime->fusionSegments()->groups().size(), 2);
 
-  testValidate(
-      &fusion, outputs, {at_in_0, at_in_1, at_in_2}, __LINE__, __FILE__);
+  testValidate(&fusion, outputs, {t0, t1, t2}, __LINE__, __FILE__);
 }
 
 // Test forced segmentation hint
@@ -149,8 +145,7 @@ TEST_F(SegmentationTest, SegmentHintOnNonTerminatingOutput) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
@@ -199,8 +194,7 @@ TEST_F(SegmentationTest, EnforceSegmentationByCachingBeforeAndAfter) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(),
       out_tensors,
@@ -230,8 +224,7 @@ TEST_F(SegmentationTest, SetAllocationDomainOnSegmentBoundary) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3, 5}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 }
@@ -263,8 +256,7 @@ TEST_F(SegmentationTest, InputForwardingUntilBinary) {
 
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA, 0);
   at::Tensor in_tensor = at::randn({2, 3}, options);
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor, in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor, in_tensor});
   testValidate(
       executor_cache.fusion(),
       out_tensors,
@@ -298,8 +290,7 @@ TEST_F(SegmentationTest, InputForwardingUntilOutput) {
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor in_tensor = at::randn({2, 3}, options);
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor, in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor, in_tensor});
   testValidate(
       executor_cache.fusion(),
       out_tensors,
@@ -697,8 +688,7 @@ TEST_F(SegmentationTest, ForwardInputsToSegmenterSetIssue2658) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor = at::randn({2, 3}).cuda();
-  std::vector<at::Tensor> out_tensors =
-      executor_cache.runFusionWithInputs({in_tensor});
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
   testValidate(
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 }
@@ -723,11 +713,10 @@ TEST_F(NVFuserTest, PrivatizeUpcast) {
 
   auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 32}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 
   // There must be three segments, one with ExprEvalExecutor and two
   // with KernelExecutor.
@@ -770,11 +759,10 @@ TEST_F(NVFuserTest, RevertPrivatizedUpcast) {
 
   auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0);
   auto t0 = at::randn({16, 32}, options);
-  std::vector<c10::IValue> inputs({t0});
 
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto outputs = executor_cache.runFusionWithInputs(inputs);
-  testValidate(&fusion, outputs, inputs, __LINE__, __FILE__);
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(&fusion, outputs, {t0}, __LINE__, __FILE__);
 
   // There must be two segments, one with ExprEvalExecutor and another
   // with KernelExecutor.

--- a/tests/cpp/test_swizzle.cpp
+++ b/tests/cpp/test_swizzle.cpp
@@ -738,7 +738,7 @@ TEST_F(SwizzleTest, Transpose1) {
   KernelExecutor ke;
   ke.compile(&fusion, {t});
   EXPECT_TRUE(getBankConflictInfo(ke.compiledKernel()->kernel()).empty());
-  std::vector<at::Tensor> outputs = ke.run({t});
+  auto outputs = ke.run({t});
   EXPECT_TRUE(at::equal(t.t(), outputs[0]));
 }
 

--- a/tests/cpp/test_tensor_factories.cpp
+++ b/tests/cpp/test_tensor_factories.cpp
@@ -519,11 +519,10 @@ TEST_F(TensorFactoryTest, FactoryBroadcast) {
 
   const auto options =
       at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  auto in = at::randn({100}, options);
-  std::vector<c10::IValue> inputs{1, in};
+  auto t0 = at::randn({100}, options);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  auto cg_outputs = executor_cache.runFusionWithInputs(inputs);
+  auto cg_outputs = executor_cache.runFusionWithInputs({1, t0});
 
   at::manual_seed(0);
   at::Tensor randn_sample = at::randn({1}, options);
@@ -533,13 +532,13 @@ TEST_F(TensorFactoryTest, FactoryBroadcast) {
   testValidate(
       executor_cache.fusion(),
       cg_outputs,
-      inputs,
-      {in,
-       in + 1,
-       in + randn_sample,
-       in + randn_sample,
-       in + rand_sample,
-       in + rand_sample},
+      {1, t0},
+      {t0,
+       t0 + 1,
+       t0 + randn_sample,
+       t0 + randn_sample,
+       t0 + rand_sample,
+       t0 + rand_sample},
       __LINE__,
       __FILE__);
 }


### PR DESCRIPTION
In tests auto output type when possible, remove c10::IValue for inputs where possible.