### PR TITLE
[Multidevice] Add backend type to Communication and expose to API

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -69,7 +69,8 @@ void HostIrExecutor::compile(Fusion* fusion) {
   } else {
     std::vector<Expr*> exprs = fusion->exprs();
     for (Expr* e : exprs) {
-      std::vector<Expr*> communications = HostIrLower::lower(cloner.clone(e));
+      HostIrLower lower;
+      std::vector<Expr*> communications = lower.lower(cloner.clone(e));
       for (auto* communication : communications) {
         host_ir_container_->pushBackTopLevelExprs(communication);
       }
@@ -415,8 +416,13 @@ void HostIrEvaluator::handle(Communication* communication) {
   at::Tensor output_tensor =
       getKnownTensorOrUndefined(communication->output(0), expr_evaluator_);
 
+  CommunicatorBackend backend_type = communication->backend();
+  if (backend_type != CommunicatorBackend::kCuda) {
+    NVF_ERROR(communication->type() == CommunicationType::Allgather);
+  }
+
   c10d::Backend* backend =
-      communicator_->getBackendForTeam(communication->team(), std::nullopt);
+      communicator_->getBackendForTeam(communication->team(), backend_type);
   works_[communication] = postSingleCommunication(
       communication,
       communicator_->deviceId(),

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -417,10 +417,6 @@ void HostIrEvaluator::handle(Communication* communication) {
       getKnownTensorOrUndefined(communication->output(0), expr_evaluator_);
 
   CommunicatorBackend backend_type = communication->backend();
-  if (backend_type != CommunicatorBackend::kCuda) {
-    NVF_ERROR(communication->type() == CommunicationType::Allgather);
-  }
-
   c10d::Backend* backend =
       communicator_->getBackendForTeam(communication->team(), backend_type);
   works_[communication] = postSingleCommunication(

--- a/csrc/host_ir/lower.cpp
+++ b/csrc/host_ir/lower.cpp
@@ -304,6 +304,10 @@ std::vector<Expr*> HostIrLower::lower(Expr* c) {
       lowerToBroadcastOrSendRecv(input_tv, output_tv, comms);
     }
   }
+
+  std::for_each(comms.begin(), comms.end(), [this](Expr* comm) {
+    comm->as<Communication>()->backend() = params_.communicator_backend;
+  });
   return comms;
 }
 
@@ -471,7 +475,11 @@ std::vector<Expr*> HostIrLower::lowerToCollectiveBasedPipelinedGemmComm(
       CommunicationType::Allgather,
       /*out=*/tva_allgathered_j,
       /*in=*/tva_j,
-      /*team=*/tva->getDeviceMesh().vector());
+      /*team=*/tva->getDeviceMesh().vector(),
+      /*root=*/-1,
+      /*red_op=*/RedOpType::UNUSED,
+      /*scattered_axis=*/-1,
+      params_.communicator_backend);
   auto* wait = IrBuilder::create<hir::Wait>(communication);
 
   Expr* compute = nullptr;

--- a/csrc/host_ir/lower.cpp
+++ b/csrc/host_ir/lower.cpp
@@ -64,7 +64,14 @@ void lowerToScatter(
     team.push_back(root);
   }
   comms.push_back(IrBuilder::create<Communication>(
-      CommunicationType::Scatter, output_tv, input_tv, team, root, c10d::ReduceOp::RedOpType::UNUSED, /*scatter_axis=*/-1, params.communicator_backend));
+      CommunicationType::Scatter,
+      output_tv,
+      input_tv,
+      team,
+      root,
+      c10d::ReduceOp::RedOpType::UNUSED,
+      /*scatter_axis=*/-1,
+      params.communicator_backend));
 }
 
 /*
@@ -86,7 +93,14 @@ void lowerToGather(
       team.push_back(root);
     }
     comms.push_back(IrBuilder::create<Communication>(
-        CommunicationType::Gather, output_tv, input_tv, team, root, c10d::ReduceOp::RedOpType::UNUSED, /*scatter_axis=*/-1, params.communicator_backend));
+        CommunicationType::Gather,
+        output_tv,
+        input_tv,
+        team,
+        root,
+        c10d::ReduceOp::RedOpType::UNUSED,
+        /*scatter_axis=*/-1,
+        params.communicator_backend));
   }
 }
 
@@ -98,7 +112,14 @@ void lowerToAllgather(
     std::vector<Expr*>& comms) {
   const DeviceMesh& mesh = input_tv->getDeviceMesh();
   comms.push_back(IrBuilder::create<Communication>(
-      CommunicationType::Allgather, output_tv, input_tv, mesh.vector(), /*root=*/-1, c10d::ReduceOp::RedOpType::UNUSED, /*scatter_axis=*/-1, params.communicator_backend));
+      CommunicationType::Allgather,
+      output_tv,
+      input_tv,
+      mesh.vector(),
+      /*root=*/-1,
+      c10d::ReduceOp::RedOpType::UNUSED,
+      /*scatter_axis=*/-1,
+      params.communicator_backend));
 }
 
 // Adds one or zero Broadcast communication to the vector 'comms'
@@ -114,7 +135,14 @@ void lowerToBroadcast(
     team.push_back(root);
   }
   comms.push_back(IrBuilder::create<Communication>(
-      CommunicationType::Broadcast, output_tv, input_tv, team, root, c10d::ReduceOp::RedOpType::UNUSED, /*scatter_axis=*/-1, params.communicator_backend));
+      CommunicationType::Broadcast,
+      output_tv,
+      input_tv,
+      team,
+      root,
+      c10d::ReduceOp::RedOpType::UNUSED,
+      /*scatter_axis=*/-1,
+      params.communicator_backend));
 }
 
 // Adds several Broadcast or SendRecv communications to the vector 'comms'
@@ -148,8 +176,7 @@ void lowerToBroadcastOrSendRecv(
           /*root=*/sender,
           c10d::ReduceOp::RedOpType::UNUSED,
           /*scatter_axis=*/-1,
-          params.communicator_backend
-          ));
+          params.communicator_backend));
     }
   } else {
     // Either of the following two cases is happening.

--- a/csrc/host_ir/lower.h
+++ b/csrc/host_ir/lower.h
@@ -14,22 +14,30 @@
 
 namespace nvfuser {
 
+struct HostIrLowerParams {
+  CommunicatorBackend communicator_backend = CommunicatorBackend::kNccl;
+};
+
 class HostIrLower {
  public:
+  HostIrLower(HostIrLowerParams params = HostIrLowerParams())
+      : params_(params) {}
+
   // The flag `ignore_inner_resharding` is useful because the preseg passes
   // `InsertReshardingsPass` and `ReorderShardedAxisPass` want different
   // behaviors
   static bool canLower(Expr* expr, bool ignore_inner_resharding = false);
 
   // Lower a sharded Expr into a series of Communication.
-  static std::vector<Expr*> lower(Expr* c);
+  std::vector<Expr*> lower(Expr* c);
 
-  static std::unique_ptr<hir::HostIrContainer> lower(
+  std::unique_ptr<hir::HostIrContainer> lower(
       std::unique_ptr<Fusion> fusion,
       int64_t my_device_index);
 
  private:
-  static std::vector<Expr*> lowerToCollectiveBasedPipelinedGemmComm(Expr* expr);
+  std::vector<Expr*> lowerToCollectiveBasedPipelinedGemmComm(Expr* expr);
+  HostIrLowerParams params_;
 };
 
 } // namespace nvfuser

--- a/csrc/host_ir/lower.h
+++ b/csrc/host_ir/lower.h
@@ -20,8 +20,8 @@ struct HostIrLowerParams {
 
 class HostIrLower {
  public:
-  HostIrLower(HostIrLowerParams params = HostIrLowerParams())
-      : params_(params) {}
+  explicit HostIrLower(HostIrLowerParams params = HostIrLowerParams())
+      : params_(std::move(params)) {}
 
   // The flag `ignore_inner_resharding` is useful because the preseg passes
   // `InsertReshardingsPass` and `ReorderShardedAxisPass` want different
@@ -37,7 +37,7 @@ class HostIrLower {
 
  private:
   std::vector<Expr*> lowerToCollectiveBasedPipelinedGemmComm(Expr* expr);
-  HostIrLowerParams params_;
+  const HostIrLowerParams params_;
 };
 
 } // namespace nvfuser

--- a/csrc/host_ir/lower.h
+++ b/csrc/host_ir/lower.h
@@ -20,7 +20,7 @@ struct HostIrLowerParams {
 
 class HostIrLower {
  public:
-  explicit HostIrLower(HostIrLowerParams params = HostIrLowerParams())
+  explicit HostIrLower(const HostIrLowerParams& params = HostIrLowerParams())
       : params_(params) {}
 
   // The flag `ignore_inner_resharding` is useful because the preseg passes

--- a/csrc/host_ir/lower.h
+++ b/csrc/host_ir/lower.h
@@ -21,7 +21,7 @@ struct HostIrLowerParams {
 class HostIrLower {
  public:
   explicit HostIrLower(HostIrLowerParams params = HostIrLowerParams())
-      : params_(std::move(params)) {}
+      : params_(params) {}
 
   // The flag `ignore_inner_resharding` is useful because the preseg passes
   // `InsertReshardingsPass` and `ReorderShardedAxisPass` want different

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -145,7 +145,8 @@ Communication::Communication(
     Team team,
     DeviceIdxType root,
     RedOpType red_op,
-    int64_t scattered_axis)
+    int64_t scattered_axis,
+    CommunicatorBackend backend)
     : Expr(passkey) {
   NVF_ERROR(
       in->getDeviceMesh().size() > 0,
@@ -161,6 +162,7 @@ Communication::Communication(
   addDataAttribute(root);
   addDataAttribute(red_op);
   addDataAttribute(scattered_axis);
+  addDataAttribute(backend);
 
   validate();
 }

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -193,7 +193,7 @@ int64_t Communication::getRootRelativeIndex() {
   return getRelativeIndex(team(), root());
 }
 
-std::string Communication::toString(const int indent_size) const {
+std::string Communication::toInlineString(const int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "Communication " << name() << " ("
                           << "type=" << type() << ", "
@@ -207,12 +207,13 @@ std::string Communication::toString(const int indent_size) const {
   if (!outputs().empty()) {
     ss << ", output=" << out();
   }
-  ss << ")\n";
+  ss << ", backend=" << backend();
+  ss << ")";
   return ss.str();
 }
 
-std::string Communication::toInlineString(int indent_size) const {
-  return toString(indent_size);
+std::string Communication::toString(int indent_size) const {
+  return toInlineString(indent_size) + "\n";
 }
 
 std::ostream& operator<<(std::ostream& os, const P2PCommunicationType& type) {

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -112,6 +112,10 @@ class Communication : public Expr {
     return attribute<CommunicatorBackend>(5);
   }
 
+  const CommunicatorBackend& backend() const {
+    return attribute<CommunicatorBackend>(5);
+  }
+
   // PyTorch's process group expects the root to be specified
   // as an integer between 0 and world_size-1. We choose it to be
   // the device's relative index within the team

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -59,7 +59,8 @@ class Communication : public Expr {
                  // sharding.
       DeviceIdxType root = -1,
       RedOpType red_op = RedOpType::UNUSED,
-      int64_t scattered_axis = -1);
+      int64_t scattered_axis = -1,
+      CommunicatorBackend backend = CommunicatorBackend::kNccl);
 
   Communication(const Communication& other) = delete;
   Communication& operator=(const Communication& other) = delete;
@@ -105,6 +106,10 @@ class Communication : public Expr {
 
   int64_t scatteredAxis() const {
     return attribute<int64_t>(4);
+  }
+
+  CommunicatorBackend& backend() {
+    return attribute<CommunicatorBackend>(5);
   }
 
   // PyTorch's process group expects the root to be specified

--- a/csrc/multidevice/communication.h
+++ b/csrc/multidevice/communication.h
@@ -108,11 +108,7 @@ class Communication : public Expr {
     return attribute<int64_t>(4);
   }
 
-  CommunicatorBackend& backend() {
-    return attribute<CommunicatorBackend>(5);
-  }
-
-  const CommunicatorBackend& backend() const {
+  CommunicatorBackend backend() const {
     return attribute<CommunicatorBackend>(5);
   }
 

--- a/csrc/multidevice/executor.cpp
+++ b/csrc/multidevice/executor.cpp
@@ -23,13 +23,14 @@ namespace nvfuser {
 MultiDeviceExecutor::MultiDeviceExecutor(
     std::unique_ptr<Fusion> fusion,
     Communicator& comm,
-    hir::HostIrEvaluatorParams params)
+    MultiDeviceExecutorParams params)
     : comm_(comm) {
+  HostIrLower lower(params.lower);
   std::unique_ptr<hir::HostIrContainer> hic =
-      HostIrLower::lower(std::move(fusion), comm.deviceId());
+      lower.lower(std::move(fusion), comm.deviceId());
   // Create the HostIrEvaluator representing the host program
-  host_ir_executor_ =
-      std::make_unique<hir::HostIrEvaluator>(std::move(hic), &comm, params);
+  host_ir_executor_ = std::make_unique<hir::HostIrEvaluator>(
+      std::move(hic), &comm, params.executor);
 }
 
 std::vector<at::Tensor> MultiDeviceExecutor::runWithInput(

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -21,8 +21,8 @@
 namespace nvfuser {
 
 struct MultiDeviceExecutorParams {
-  hir::HostIrEvaluatorParams executor = hir::HostIrEvaluatorParams();
-  HostIrLowerParams lower = HostIrLowerParams();
+  hir::HostIrEvaluatorParams executor;
+  HostIrLowerParams lower;
 };
 
 /*

--- a/csrc/multidevice/executor.h
+++ b/csrc/multidevice/executor.h
@@ -12,12 +12,18 @@
 #include <fusion.h>
 #include <fusion_segmenter.h>
 #include <host_ir/executor.h>
+#include <host_ir/lower.h>
 #include <ir/cloner.h>
 #include <multidevice/communication.h>
 #include <multidevice/communicator.h>
 #include <multidevice/multidevice.h>
 
 namespace nvfuser {
+
+struct MultiDeviceExecutorParams {
+  hir::HostIrEvaluatorParams executor = hir::HostIrEvaluatorParams();
+  HostIrLowerParams lower = HostIrLowerParams();
+};
 
 /*
   The MultiDeviceExecutor executes a Fusion on a multi-device setting.
@@ -74,7 +80,7 @@ class MultiDeviceExecutor {
   MultiDeviceExecutor(
       std::unique_ptr<Fusion> fusion,
       Communicator& comm,
-      hir::HostIrEvaluatorParams params = hir::HostIrEvaluatorParams());
+      MultiDeviceExecutorParams params = MultiDeviceExecutorParams());
 
   // Run the fusion on several devices with the given global inputs
   std::vector<at::Tensor> runWithInput(const std::vector<c10::IValue>& inputs);

--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -124,10 +124,10 @@ void PipelineTest::executeAndValidate(bool validate_with_prescribed_values) {
     std::cout << ss.str() << std::endl;
   }
 
+  MultiDeviceExecutorParams params;
+  params.executor = host_ir_executor_params;
   runtime = std::make_unique<MultiDeviceExecutor>(
-      std::make_unique<Fusion>(*fusion),
-      *communicator_,
-      host_ir_executor_params);
+      std::make_unique<Fusion>(*fusion), *communicator_, params);
   auto error_msg = runtime->validate();
   if (error_msg != "") {
     GTEST_SKIP() << error_msg;
@@ -152,7 +152,6 @@ void PipelineTest::executeAndValidate(bool validate_with_prescribed_values) {
 
 PipelineTest::PipelineTest() {
   fusion = std::make_unique<Fusion>();
-  communicator_->setDefaultBackend(CommunicatorBackend::kNccl);
 }
 
 // To run the following tests on several devices, pytorch must be installed with


### PR DESCRIPTION
Add a way to specify the communication type per `Communication*` and expose the option at the API throuhg `MultiDeviceExecutor` and `HostIrLower`