### PR TITLE
Add a script to run a single matmul configuration with custom MatmulParams

### DIFF
--- a/doc/dev/python_scheduling/profile_matmul.py
+++ b/doc/dev/python_scheduling/profile_matmul.py
@@ -4,7 +4,6 @@
 from nvfuser import (
     FusionDefinition,
     SchedulerType,
-    MatmulParams,
     ClusterDims,
     MatMulTileOptions,
     GemmTile,
@@ -147,7 +146,7 @@ def main():
 
     parser = argparse.ArgumentParser(
         description="""Run through a combination of matmul parameters and compare relative performance against nvjet for a single problem.""",
-        epilog="""How to run script: NVFUSER_ENABLE=fuse_matmul NVFUSER_DISABLE=matmul_expr_eval python single_matmul.py nvjet_pybench.json 1752 4720 584 NN --verbose --validate"""
+        epilog="""How to run script: NVFUSER_ENABLE=fuse_matmul NVFUSER_DISABLE=matmul_expr_eval python single_matmul.py nvjet_pybench.json 1752 4720 584 NN --verbose --validate""",
     )
     parser.add_argument("m", type=int, help="The size of M dimension")
     parser.add_argument("n", type=int, help="The size of N dimension")
@@ -202,7 +201,7 @@ def main():
         normalized_result = baseline_result / nvf_result
         print(
             f"index: {idx}, baseline(us): {baseline_result: .3e}, "
-            f"nvfuser(us):{nvf_result: 3e}, normalized(us):{normalized_result: 2f}"
+            f"nvfuser(us): {nvf_result: 3e}, normalized(us): {normalized_result: 2f}"
         )
 
 

--- a/doc/dev/python_scheduling/profile_matmul.py
+++ b/doc/dev/python_scheduling/profile_matmul.py
@@ -26,7 +26,6 @@ class Layout(IntEnum):
     NT = 1
     TN = 2
     TT = 3
-    MAX = 4
 
 
 def estimate_matmul_size(config, dtype):
@@ -147,10 +146,8 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(
-        description=(
-            "Run through a combination of matmul parameters and compare"
-            "relative performance against nvjet for a single problem."
-        )
+        description="""Run through a combination of matmul parameters and compare relative performance against nvjet for a single problem.""",
+        epilog="""How to run script: NVFUSER_ENABLE=fuse_matmul NVFUSER_DISABLE=matmul_expr_eval python single_matmul.py nvjet_pybench.json 1752 4720 584 NN --verbose --validate"""
     )
     parser.add_argument("m", type=int, help="The size of M dimension")
     parser.add_argument("n", type=int, help="The size of N dimension")
@@ -169,7 +166,7 @@ def main():
     parser.add_argument(
         "--validate",
         action="store_true",
-        help="Print matmul parameters and exceptions.",
+        help="Validate nvfuser against pytorch matmul.",
     )
     args = parser.parse_args()
 
@@ -209,17 +206,5 @@ def main():
         )
 
 
-# NOTE Scheduler _matmul_ ***rejected*** because : MatmulOp and LinearOp fusion
-# is disabled by default. Enable it using NVFUSER_ENABLE=fuse_matmul
-#
-# CMD to generate pybench json:
-# NVFUSER_ENABLE=fuse_matmul NVFUSER_DISABLE=matmul_expr_eval pytest benchmarks/python/test_matmul.py
-# -vsk 'baseline and bf16 and fullred and not 138216-236592-50664-N and not 97952-319616-3232-TT'
-# --disable-validation --benchmark-eager --benchmark-json=nvjet_pybench.json 2>&1 |
-# tee ~/nvjet_pybench.log
-#
-# Script CMD:
-# NVFUSER_ENABLE=fuse_matmul NVFUSER_DISABLE=matmul_expr_eval python single_matmul.py nvjet_pybench.json
-# 1752 4720 584 NN --verbose --validate
 if __name__ == "__main__":
     main()

--- a/doc/dev/python_scheduling/profile_matmul.py
+++ b/doc/dev/python_scheduling/profile_matmul.py
@@ -116,7 +116,7 @@ def test_matmul_nvf(
     with FusionDefinition() as presched_fd:
         matmul_fusion(presched_fd, [a, b])
 
-    scheduled_fd = custom_matmul_scheduler(presched_fd, schedule_config)
+    scheduled_fd = custom_matmul_scheduler(presched_fd, schedule_config, verbose)
 
     try:
         nvf_outputs = scheduled_fd.execute([a, b], profile=True)

--- a/doc/dev/python_scheduling/single_matmul.py
+++ b/doc/dev/python_scheduling/single_matmul.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+from nvfuser import (
+    FusionDefinition,
+    SchedulerType,
+    MatmulParams,
+    ClusterDims,
+    MatMulTileOptions,
+    GemmTile,
+    MmaMacroEncode,
+    MmaMacroArch,
+    MatmulTileRasterizationOrder,
+    MatmulCircularBufferingStrategy,
+)
+import sys
+import torch
+import math
+import itertools
+from enum import Enum
+
+
+class Layout(Enum):
+    NN = 0
+    NT = 1
+    TN = 2
+    TT = 3
+    MAX = 4
+
+
+def get_layout_enum(layout):
+    if layout == "NN":
+        return Layout.NN
+    elif layout == "NT":
+        return Layout.NT
+    elif layout == "TN":
+        return Layout.TN
+    elif layout == "TT":
+        return Layout.TT
+    else:
+        return Layout.MAX
+
+
+# machine_info - dict
+#  * node, cpu, gpu-name - string
+#  * gpu_sm_count - int
+# commit_info - dict
+#  * id, project, branch - string
+# benchmarks - list
+#  * fullname: string
+#  * params - dict
+#     * config: [M, N, K, Shape]
+#  * stats - dict
+#     * median: float
+def analyze_json(filename):
+    import pandas as pd
+    import json
+
+    def get_field(json_data, field):
+        return pd.DataFrame(json_data[field])
+
+    def _organize_by_layout(json_data):
+        benchmarks = get_field(json_data, "benchmarks")
+        data = {layout: {} for layout in Layout if layout is not Layout.MAX}
+        for row in benchmarks.itertuples():
+            M, N, K, layout = row.params["config"]
+            shape = (M, N, K)
+            time = row.stats["median"]
+            data[get_layout_enum(layout)][shape] = time
+        return data
+
+    json = json.load(open(filename))
+    return _organize_by_layout(json)
+
+
+def estimate_matmul_size(config, dtype):
+    def _estimate_size(shape, dtype):
+        return math.prod(shape) * dtype.itemsize
+
+    m, n, k, layout = config
+    total_in_gbs = 0
+    for shape in [[m, k], [n, k], [m, n]]:
+        total_in_gbs += _estimate_size(shape, dtype)
+    return total_in_gbs
+
+
+def matmul_fusion(fd: FusionDefinition, inputs: list[torch.Tensor]) -> None:
+    a = fd.from_pytorch(inputs[0])
+    b = fd.from_pytorch(inputs[1])
+    out = fd.ops.matmul(a, b)
+    fd.add_output(out)
+
+
+# These are the parameters we'll optimize
+parameter_configurations = {
+    "tile_sizes": [MatMulTileOptions(GemmTile(128, 256, 64), GemmTile(64, 256, 64))],
+    "mma_macro": [MmaMacroEncode(MmaMacroArch.hopper, 64, 256, 16)],
+    "tile_order": [MatmulTileRasterizationOrder.column_major],
+    "cluster_dims": [ClusterDims(1, 1, 1)],
+    "circular_buffer_stages": [4],
+}
+
+
+# Apply scheduler with custom parameters using decorator
+def custom_matmul_scheduler(fd, config):
+    def inner_fn():
+        # NOTE Scheduler _matmul_ ***rejected*** because : MatmulOp and LinearOp
+        # fusion is disabled by default. Enable it using
+        # NVFUSER_ENABLE=fuse_matmul
+        status, error = fd.sched.can_schedule(SchedulerType.matmul)
+        assert status, error
+
+        schedule_params = fd.sched.compute_matmul_heuristics()
+
+        # Modify original parameters
+        if config is not None:
+            tile_sizes, macro, tile_order, cluster_dims, stages = config
+            schedule_params.tile_sizes = tile_sizes
+            schedule_params.mma_macro = macro.mma_macro()
+            schedule_params.cta_order = tile_order
+            schedule_params.cluster_dims = cluster_dims
+            schedule_params.circular_buffering_strategy = (
+                MatmulCircularBufferingStrategy.warp_specialized
+            )
+            schedule_params.circular_buffer_options.circular_buffer_smem_write = (
+                stages > 1
+            )
+            schedule_params.circular_buffer_options.smem_circular_buffer_stage = stages
+            print(schedule_params)
+
+        # Schedule fusion
+        fd.sched.schedule()
+
+    fd.schedule = inner_fn
+    return fd
+
+
+def test_matmul_nvf(
+    problem_config: tuple,
+    schedule_config: tuple,
+):
+    m, n, k, layout = problem_config
+    dtype = torch.bfloat16
+
+    torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = True
+    torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = True
+
+    a = torch.randn(m, k, device="cuda", dtype=dtype)
+    b = torch.randn(k, n, device="cuda", dtype=dtype)
+
+    if layout == "NT" or layout == "NN":
+        a = a.as_strided(size=[m, k], stride=[1, m])
+    if layout == "TN" or layout == "NN":
+        b = b.as_strided(size=[k, n], stride=[1, k])
+
+    with FusionDefinition() as presched_fd:
+        matmul_fusion(presched_fd, [a, b])
+
+    scheduled_fd = custom_matmul_scheduler(presched_fd, schedule_config)
+
+    try:
+        nvf_outputs = scheduled_fd.execute([a, b], profile=True)
+    except Exception as e:
+        print(e)
+        return -1
+
+    prof = scheduled_fd.profile()
+    # convert to microseconds to match pytorch profiler units
+    return prof.kernel_profiles[0].time_ms * 1e-3
+
+
+def validation(problem_config):
+    m, n, k, layout = problem_config
+    dtype = torch.bfloat16
+
+    torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = True
+    torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = True
+
+    a = torch.randn(m, k, device="cuda", dtype=dtype)
+    b = torch.randn(k, n, device="cuda", dtype=dtype)
+
+    if layout == "NT" or layout == "NN":
+        a = a.as_strided(size=[m, k], stride=[1, m])
+    if layout == "TN" or layout == "NN":
+        b = b.as_strided(size=[k, n], stride=[1, k])
+
+    kwargs = dict(
+        _enable_options=["fuse_matmul"],
+        _disable_options=["matmul_expr_eval"],
+    )
+
+    with FusionDefinition() as presched_fd:
+        matmul_fusion(presched_fd, [a, b])
+
+    nvf_outputs = presched_fd.execute([a, b], **kwargs)
+    eager_output = torch.matmul(a, b)
+    assert torch.allclose(nvf_outputs[0], eager_output, atol=1e-2, rtol=1e-2)
+
+
+def main():
+    # nvjet_tst_128x256_64x4_1x1_h_bz_coopA_TTN
+    problem_config = (1752, 4720, 584, "NN")
+
+    device_properties = torch.cuda.get_device_properties(0)
+    # short-circuit: problem does not fit on device
+    if (
+        estimate_matmul_size(problem_config, torch.bfloat16)
+        >= device_properties.total_memory
+    ):
+        assert False
+
+    eager_data = analyze_json(sys.argv[1])
+    eager_result = eager_data[get_layout_enum(problem_config[3])][problem_config[:3]]
+
+    for scheduler_config in itertools.product(*parameter_configurations.values()):
+        nvf_result = test_matmul_nvf(problem_config, scheduler_config)
+        normalized_result = eager_result / nvf_result
+        print(
+            f"{eager_result: .3e} out of {nvf_result: 3e} is {normalized_result: 2f}."
+        )
+
+
+# NOTE Scheduler _matmul_ ***rejected*** because : MatmulOp and LinearOp fusion
+# is disabled by default. Enable it using NVFUSER_ENABLE=fuse_matmul
+#
+# CMD to generate pybench json:
+# NVFUSER_ENABLE=fuse_matmul NVFUSER_DISABLE=matmul_expr_eval pytest benchmarks/python/test_matmul.py
+# -vsk 'baseline and bf16 and fullred and not 138216-236592-50664-N and not 97952-319616-3232-TT'
+# --disable-validation --benchmark-eager --benchmark-json=nvjet_pybench.json 2>&1 |
+# tee ~/nvjet_pybench.log
+#
+# Script CMD:
+# NVFUSER_ENABLE=fuse_matmul NVFUSER_DISABLE=matmul_expr_eval python single_matmul.py nvjet_pybench.json
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a script to run a single matmul configuration with custom `MatmulParams`. It profiles the nvfuser kernel and compares its runtime against nvjet kernel runtime. The nvjet kernel runtimes are stored in a json file, generated by python benchmarks.

* Update python bindings to support constructing Matmul Options.