### PR TITLE
Add `TMemTutorialR.PerformantVectorizedCopy`

### DIFF
--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -173,6 +173,30 @@ inline void parallelizeAllLike(
       propagate_padding);
 }
 
+inline void parallelizeAllLike(
+    TensorView* reference_tv,
+    std::initializer_list<TensorView*> selected_tvs,
+    const std::unordered_set<ParallelType>& selected_parallel_types = {},
+    bool propagate_padding = true) {
+  parallelizeAllLike(
+      reference_tv,
+      std::vector<TensorView*>(selected_tvs),
+      selected_parallel_types,
+      propagate_padding);
+}
+
+inline void parallelizeAllLike(
+    TensorView* reference_tv,
+    const std::unordered_set<ParallelType>& selected_parallel_types,
+    bool propagate_padding = true) {
+  parallelizeAllLike(
+      reference_tv,
+      -1,
+      std::vector<TensorView*>{},
+      selected_parallel_types,
+      propagate_padding);
+}
+
 // Common hyperparameters used in heuristic scheduler. These hyperparameters
 // are passed to SchedulerEntry::computeHeuristics through the
 // HeuristicDataCache. These hyperparameters alter the generation of the

--- a/doc/dev/tmem.md
+++ b/doc/dev/tmem.md
@@ -1163,6 +1163,87 @@ TEST_F(TMemTutorialR, Vectorization) {
 } /*
 ```
 
+When using tensor memory for non-matmul purposes, the allocation domain of the
+tensor memory tensor is usually dictated by the global scheduling of the
+problem, and the vectorization factor used for TMem load/store are the product
+of the unroll factor and the vectorization factor of the global memory load/store.
+The following example demonstrates a performant copy kernel
+gmem -> register -> tmem -> register -> gmem with vectorization 4 and unroll
+factor 2:<!-- */ //-->\
+```cpp
+TEST_F(TMemTutorialR, PerformantVectorizedCopy) {
+  NOT_IMPLEMENTED
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeContigTensor(1);
+  fusion.addInput(tv0);
+  auto tv1 = set(tv0);
+  auto tv2 = set(tv1);
+  auto tv3 = set(tv2);
+  auto tv4 = set(tv3);
+  fusion.addOutput(tv4);
+  tv2->setMemoryType(MemoryType::Tensor);
+
+  tv4->split(0, 4);
+  tv4->axis(1)->parallelize(ParallelType::Vectorize);
+  tv4->split(0, 128);
+  tv4->axis(1)->parallelize(ParallelType::TIDx);
+  tv4->split(0, 2);
+  tv4->axis(1)->parallelize(ParallelType::TIDy);
+  tv4->split(0, 2);
+  tv4->axis(1)->parallelize(ParallelType::Serial);
+  tv4->axis(0)->parallelize(ParallelType::BIDx);
+
+  TransformPropagatorWithCheck propagator(tv4);
+  MaxLogicalDomainInfoSpanningTree(tv4).traverse(&propagator);
+  scheduler_utils::parallelizeAllLike(
+      tv4, {ParallelType::TIDx, ParallelType::TIDy, ParallelType::BIDx});
+  tv1->axis(-1)->parallelize(ParallelType::Vectorize);
+
+  // [BIDx, Serial, TIDy, TIDx, Vec'] ->
+  //   [BIDx, TIDx, |, TIDy, Vec{Serial * Vec'}]
+  // Where the Vec' above are the vectorization dims of gmem access, not
+  // the vectorization of the tmem access, and Vec is the the vectorization
+  // of tmem access.
+  for (auto tv : {tv2, tv3}) {
+    tv->reorder({{1, 3}, {3, 1}});
+    tv->merge(-2);
+    tv->axis(-1)->parallelize(ParallelType::Vectorize);
+  }
+  tv2->setAllocationDomain(tv2->getLoopDomain(), true);
+  tv2->setTMemDimSepPos(2);
+
+  inlineMost();
+
+  if constexpr (verbose) {
+    fusion.printKernel();
+  }
+
+  KernelExecutor ke;
+
+  // Check that tv2 is allocated 32 columns. We actually only need
+  // TIDy{2} * Serial{2} * Vec'{4} = 16 columns, but 32 is the minimum
+  // unit of allocation.
+  checkAllocationSize(ke, 32);
+
+  ke.compile(&fusion);
+
+  at::Tensor t0 = at::rand({256 * 1024 * 1024}, at::kCUDA);
+  auto out = ke.run({t0});
+  EXPECT_TRUE(at::equal(out[0], t0));
+
+  // Check that vectorized PTX instructions are used
+  GpuLower gpulw(&fusion);
+  auto kernel_str = codegen::generateCudaKernel(gpulw.run());
+  std::stringstream expect_st, expect_ld;
+  expect_st << "tcgen05.st.sync.aligned.32x32b.x8.b32";
+  expect_ld << "tcgen05.ld.sync.aligned.32x32b.x8.b32";
+  EXPECT_THAT(kernel_str, ::testing::HasSubstr(expect_st.str()));
+  EXPECT_THAT(kernel_str, ::testing::HasSubstr(expect_ld.str()));
+} /*
+```
+
 <!--*/
 } // namespace nvfuser
 // \-->


### PR DESCRIPTION
Followup of https://github.com/NVIDIA/Fuser/pull/3874#issuecomment-2664791060, adding an example demonstrating how to schedule a performant copy kernel using tmem. This new test will give the reader an idea on how the special characteristics of tmem interact with the scheduling demand of vectorizing and coalescing gmem access.