### PR TITLE
Tensor memory allocation analysis

### DIFF
--- a/csrc/device_lower/analysis/tensor_memory.cpp
+++ b/csrc/device_lower/analysis/tensor_memory.cpp
@@ -147,7 +147,7 @@ TensorMemoryInfo computeTMemInfo(Fusion* fusion) {
           max_lanes,
           " available.");
     }
-    constexpr int64_t unit_of_allocation = 512;
+    constexpr int64_t unit_of_allocation = 32;
     Val* unit_of_allocation_val = IrBuilder::create<Val>(unit_of_allocation);
     region.num_columns = SimplifyingIrBuilder::maxExpr(
         unit_of_allocation_val, region.num_columns);

--- a/csrc/device_lower/analysis/tensor_memory.cpp
+++ b/csrc/device_lower/analysis/tensor_memory.cpp
@@ -17,6 +17,7 @@
 
 namespace nvfuser {
 
+// Returns the lane and column allocation domain that is actually allocated.
 std::pair<std::vector<IterDomain*>, std::vector<IterDomain*>> getTMemAllocation(
     TensorView* tv) {
   NVF_ERROR(tv->getMemoryType() == MemoryType::Tensor);

--- a/csrc/device_lower/analysis/tensor_memory.cpp
+++ b/csrc/device_lower/analysis/tensor_memory.cpp
@@ -7,11 +7,57 @@
 // clang-format on
 
 #include <device_lower/analysis/tensor_memory.h>
+#include <device_lower/lower2device.h>
 #include <fusion.h>
 #include <ir/all_nodes.h>
 #include <type.h>
 
+#include <utility>
+#include <vector>
+
 namespace nvfuser {
+
+std::pair<std::vector<IterDomain*>, std::vector<IterDomain*>> getTMemAllocation(
+    TensorView* tv) {
+  NVF_ERROR(tv->getMemoryType() == MemoryType::Tensor);
+  // Get all compute-at IDs
+  const auto& loop_domain = tv->getLoopDomain();
+  std::unordered_set<IterDomain*> ca_ids(
+      loop_domain.begin(), loop_domain.begin() + tv->getComputeAtPosition());
+  // Filter allocation domain
+  std::vector<IterDomain*> lane;
+  std::vector<IterDomain*> column;
+  const auto& raw_allocation_domain = tv->getMaybeAllocationDomain();
+  const int64_t dimsep = tv->getTMemDimSepPos();
+  for (int64_t i : c10::irange((int64_t)raw_allocation_domain.size())) {
+    std::vector<IterDomain*>& target = i < dimsep ? lane : column;
+    IterDomain* id = raw_allocation_domain[i];
+    ParallelType p_type = id->getParallelType();
+    if (ir_utils::isMemorySharedAcross(MemoryType::Tensor, p_type)) {
+      target.push_back(id);
+      continue;
+    }
+    if (id->isBroadcast() || id->isReduction() || id->extent()->isOneInt() ||
+        ir_utils::isMemoryPartitionedAcross(MemoryType::Tensor, p_type) ||
+        ca_ids.count(id)) {
+      continue;
+    }
+    target.push_back(id);
+  }
+  return {lane, column};
+}
+
+Val* productOfExtents(const std::vector<IterDomain*>& domain) {
+  Fusion* fusion = FusionGuard::getCurFusion();
+  if (domain.empty()) {
+    return fusion->oneVal();
+  }
+  Val* product = fusion->oneVal();
+  for (IterDomain* id : domain) {
+    product = SimplifyingIrBuilder::mulExpr(product, id->extent());
+  }
+  return product;
+}
 
 // See note [Tensor Memory Allocation] for the overall design.
 TensorMemoryInfo computeTMemInfo(Fusion* fusion) {
@@ -57,6 +103,7 @@ TensorMemoryInfo computeTMemInfo(Fusion* fusion) {
   // Step 2: Compute the allocation information for tensor memory. That is, for
   // each partition, we create a Region object and fill in the necessary
   // information.
+  Val* total_num_columns = fusion->zeroVal();
   using Region = TMemAlllocationInfo::Region;
   std::vector<Region>& regions = result.allocation.regions;
   for (const auto& partition : partitions) {
@@ -72,22 +119,51 @@ TensorMemoryInfo computeTMemInfo(Fusion* fusion) {
     region.address->setMemoryType(MemoryType::Shared);
 
     // Assign each tensor in the region a whole 128 lanes and N columns.
-    region.num_columns = region.address->fusion()->zeroVal(DataType::UInt16);
+    region.num_columns = fusion->zeroVal();
     for (auto tv : partition) {
-      // TODO: right now we hardcode the number of columns of each tensor to
-      // be 32. This is definitely not correct.
-      Val* num_columns = IrBuilder::create<Val>(32, DataType::UInt16);
       region.covered_tensors.emplace_back();
       auto& covered_tensor = region.covered_tensors.back();
       covered_tensor.tensor = tv;
+      std::tie(
+          covered_tensor.lane_allocation, covered_tensor.column_allocation) =
+          getTMemAllocation(tv);
+      Val* num_columns = productOfExtents(covered_tensor.column_allocation);
       covered_tensor.lane_offset = tv->fusion()->zeroVal(DataType::UInt16);
-      covered_tensor.column_offset = region.num_columns;
+      covered_tensor.column_offset =
+          IrBuilder::maybeCastExpr(DataType::UInt16, region.num_columns);
       region.num_columns =
           SimplifyingIrBuilder::addExpr(region.num_columns, num_columns);
+
+      // Validate lane allocation
+      Val* num_lanes = productOfExtents(covered_tensor.lane_allocation);
+      constexpr int64_t max_lanes = 128;
+      Val* max_lanes_val = IrBuilder::create<Val>(max_lanes);
+      GpuLower::current()->validate(
+          SimplifyingIrBuilder::leExpr(num_lanes, max_lanes_val),
+          "Not enough tensor memory lanes: tried to allocate ",
+          num_lanes->toInlineString(),
+          ", but only ",
+          max_lanes,
+          " available.");
     }
+    constexpr int64_t unit_of_allocation = 512;
+    Val* unit_of_allocation_val = IrBuilder::create<Val>(unit_of_allocation);
+    region.num_columns = SimplifyingIrBuilder::maxExpr(
+        unit_of_allocation_val, region.num_columns);
+    total_num_columns =
+        SimplifyingIrBuilder::addExpr(total_num_columns, region.num_columns);
     region.num_columns =
         IrBuilder::maybeCastExpr(DataType::UInt32, region.num_columns);
   }
+  constexpr int64_t max_columns = 512;
+  Val* max_columns_val = IrBuilder::create<Val>(max_columns);
+  GpuLower::current()->validate(
+      SimplifyingIrBuilder::leExpr(total_num_columns, max_columns_val),
+      "Not enough tensor memory columns: tried to allocate ",
+      total_num_columns->toInlineString(),
+      ", but only ",
+      max_columns,
+      " available.");
 
   return result;
 }

--- a/csrc/device_lower/analysis/tensor_memory.h
+++ b/csrc/device_lower/analysis/tensor_memory.h
@@ -14,6 +14,7 @@ namespace nvfuser {
 class Val;
 class TensorView;
 class Fusion;
+class IterDomain;
 
 // Information used to lower tensor memory. So far, it is just about allocation.
 struct TensorMemoryInfo;
@@ -141,8 +142,14 @@ struct TMemAlllocationInfo {
     // The TMem TensorViews covered by this region. Each region can be used to
     // store multiple TensorViews. The (lane_offset, column_offset) specifies
     // the starting offset of each TensorView in this region.
+    // The lane_allocation is the part of allocation domain on the left of the
+    // TMem dimsep position that is actually being allocated.
+    // The column_allocation is the part of allocation domain on the right of
+    // the TMem dimsep position that is actually being allocated.
     struct TVInfo {
       TensorView* tensor;
+      std::vector<IterDomain*> lane_allocation;
+      std::vector<IterDomain*> column_allocation;
       Val* lane_offset;
       Val* column_offset;
     };

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -121,7 +121,8 @@ TensorView::TensorView(const TensorView* src, IrCloner* ir_cloner)
       compute_with_consumers_(ir_cloner->clone(src->compute_with_consumers_)),
       compute_with_pos_(src->compute_with_pos_),
       promote_reuse_(src->promote_reuse_),
-      mesh_(src->mesh_) {}
+      mesh_(src->mesh_),
+      tmem_dim_sep_pos_(src->tmem_dim_sep_pos_) {}
 
 void TensorView::printTransforms() const {
   IrTransformPrinter(std::cout).printTransforms(this);

--- a/doc/dev/tmem.md
+++ b/doc/dev/tmem.md
@@ -332,7 +332,6 @@ data path between gmem and tmem, so we have to use registers as transfer
 station.<!-- */ //-->\
 ```cpp
 TEST_F(TMemTutorialC, TooManyLanes) {
-  NOT_IMPLEMENTED
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -357,7 +356,7 @@ TEST_F(TMemTutorialC, TooManyLanes) {
   // Tries to allocate (429, 17) for tv2.
   EXPECT_THAT(
       [&]() { KernelExecutor().compile(&fusion); },
-      ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfError>(::testing::HasSubstr(
           "Not enough tensor memory lanes: tried to allocate 429, but only 128 available.")));
 } /*
 ```
@@ -379,7 +378,6 @@ lanes `128`.
 Now let's take a look at another example:<!-- */ //-->\
 ```cpp
 TEST_F(TMemTutorialC, TooManyCols) {
-  NOT_IMPLEMENTED
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -405,7 +403,7 @@ TEST_F(TMemTutorialC, TooManyCols) {
   // Tries to allocate (32, 1105) for tv2.
   EXPECT_THAT(
       [&]() { KernelExecutor().compile(&fusion); },
-      ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfError>(::testing::HasSubstr(
           "Not enough tensor memory columns: tried to allocate 1105, but only 512 available.")));
 } /*
 ```
@@ -503,7 +501,7 @@ TEST_F(TMemTutorialC, NotWarpCollective) {
 
   EXPECT_THAT(
       [&]() { KernelExecutor().compile(&fusion); },
-      ::testing::ThrowsMessage<std::runtime_error>(
+      ::testing::ThrowsMessage<nvfError>(
           ::testing::HasSubstr("TMem load/store must be warp collective.")));
 } /*
 ```
@@ -533,7 +531,7 @@ TEST_F(TMemTutorialC, NotContiguous) {
 
   EXPECT_THAT(
       [&]() { KernelExecutor().compile(&fusion); },
-      ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfError>(::testing::HasSubstr(
           "Invalid data access pattern in TMem load/store.")));
 } /*
 ```
@@ -567,7 +565,7 @@ TEST_F(TMemTutorialC, OneLane) {
 
   EXPECT_THAT(
       [&]() { KernelExecutor().compile(&fusion); },
-      ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfError>(::testing::HasSubstr(
           "Invalid data access pattern in TMem load/store.")));
 } /*
 ```
@@ -599,7 +597,7 @@ TEST_F(TMemTutorialC, WrongSubpartition) {
 
   EXPECT_THAT(
       [&]() { KernelExecutor().compile(&fusion); },
-      ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfError>(::testing::HasSubstr(
           "Invalid data access pattern in TMem load/store.")));
 } /*
 ```
@@ -632,7 +630,7 @@ TEST_F(TMemTutorialC, WrongSubpartition2) {
 
   EXPECT_THAT(
       [&]() { KernelExecutor().compile(&fusion); },
-      ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(
+      ::testing::ThrowsMessage<nvfError>(::testing::HasSubstr(
           "Invalid data access pattern in TMem load/store.")));
 } /*
 ```

--- a/runtime/tensor_memory.cu
+++ b/runtime/tensor_memory.cu
@@ -19,6 +19,13 @@ struct TMemTensor {
 
  public:
   uint32_t static add(uint32_t base, Array<uint16_t, 2> offset) {
+    // Mentally, it makes more sense to think of TMem address as (lane, column)
+    // but because GPUs are little-endian, the address is stored in reverse
+    // order as (column, lane). So we swap the order of the offset before adding it
+    // to the base address.
+    uint16_t tmp = offset[0];
+    offset[0] = offset[1];
+    offset[1] = tmp;
     return base + *reinterpret_cast<const uint32_t*>(&offset);
   }
 

--- a/runtime/tensor_memory.cu
+++ b/runtime/tensor_memory.cu
@@ -21,8 +21,8 @@ struct TMemTensor {
   uint32_t static add(uint32_t base, Array<uint16_t, 2> offset) {
     // Mentally, it makes more sense to think of TMem address as (lane, column)
     // but because GPUs are little-endian, the address is stored in reverse
-    // order as (column, lane). So we swap the order of the offset before adding it
-    // to the base address.
+    // order as (column, lane). So we swap the order of the offset before adding
+    // it to the base address.
     uint16_t tmp = offset[0];
     offset[0] = offset[1];
     offset[1] = tmp;

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -2877,7 +2877,7 @@ void testTMemAddKernel(bool same_region) {
   tv9->axis(0)->parallelize(ParallelType::BIDx);
   tv9->axis(1)->parallelize(ParallelType::TIDx);
 
-  scheduler_utils::parallelizeAllLike(tv9, {tv1, tv2});
+  scheduler_utils::parallelizeAllLike(tv9);
 
   for (auto tv : {tv2, tv6}) {
     tv->setAllocationDomain(tv->getLoopDomain(), true);

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -2823,6 +2823,9 @@ TEST_F(TMemTest, GmemRegTMemRegGmemCopy) {
 
   scheduler_utils::parallelizeAllLike(tv4, {tv1, tv2, tv3});
 
+  tv2->setAllocationDomain(tv2->getLoopDomain(), true);
+  tv2->setTMemDimSepPos(-1);
+
   inlineMost();
 
   KernelExecutor ke;
@@ -2875,6 +2878,11 @@ void testTMemAddKernel(bool same_region) {
   tv9->axis(1)->parallelize(ParallelType::TIDx);
 
   scheduler_utils::parallelizeAllLike(tv9, {tv1, tv2});
+
+  for (auto tv : {tv2, tv6}) {
+    tv->setAllocationDomain(tv->getLoopDomain(), true);
+    tv->setTMemDimSepPos(-1);
+  }
 
   inlineMost();
 


### PR DESCRIPTION
This PR updates the logic in the tensor memory lowering analysis to remove the hardcoded "32 columns". We are now doing a real analysis on the allocation domain, and compute the number of columns based on the schedule. This PR also adds validations of the allocations. 

As a result, we can enables two tests: `TooManyLanes`, `TooManyCols`.