### PR TITLE
Return constexpr char* from name function in OptimizationPass

### DIFF
--- a/csrc/instrumentation.h
+++ b/csrc/instrumentation.h
@@ -81,15 +81,15 @@ class Trace : public NonCopyable {
 class TraceScope : public NonCopyable {
  public:
   explicit TraceScope(const char* event_name) : event_name_(event_name) {
-    Trace::instance()->beginEvent(event_name_);
+    Trace::instance()->beginEvent(event_name_.c_str());
   }
 
   ~TraceScope() {
-    Trace::instance()->endEvent(event_name_);
+    Trace::instance()->endEvent(event_name_.c_str());
   }
 
  private:
-  const char* event_name_ = nullptr;
+  std::string event_name_ = nullptr;
 };
 
 #define FUSER_MACRO_CONCAT2(a, b) a##b

--- a/csrc/instrumentation.h
+++ b/csrc/instrumentation.h
@@ -81,15 +81,15 @@ class Trace : public NonCopyable {
 class TraceScope : public NonCopyable {
  public:
   explicit TraceScope(const char* event_name) : event_name_(event_name) {
-    Trace::instance()->beginEvent(event_name_.c_str());
+    Trace::instance()->beginEvent(event_name_);
   }
 
   ~TraceScope() {
-    Trace::instance()->endEvent(event_name_.c_str());
+    Trace::instance()->endEvent(event_name_);
   }
 
  private:
-  std::string event_name_ = nullptr;
+  const char* event_name_ = nullptr;
 };
 
 #define FUSER_MACRO_CONCAT2(a, b) a##b

--- a/csrc/preseg_passes/add_axioms.h
+++ b/csrc/preseg_passes/add_axioms.h
@@ -17,7 +17,7 @@ class AddAxiomsPass : public OptimizationPass<AddAxiomsPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "AddAxiomsPass";
   }
 };

--- a/csrc/preseg_passes/add_axioms.h
+++ b/csrc/preseg_passes/add_axioms.h
@@ -17,7 +17,7 @@ class AddAxiomsPass : public OptimizationPass<AddAxiomsPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "AddAxiomsPass";
   }
 };

--- a/csrc/preseg_passes/allocation_order_inference.h
+++ b/csrc/preseg_passes/allocation_order_inference.h
@@ -22,7 +22,7 @@ class AllocationDomainPass : public OptimizationPass<AllocationDomainPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "AllocationDomainPass";
   }
 };

--- a/csrc/preseg_passes/allocation_order_inference.h
+++ b/csrc/preseg_passes/allocation_order_inference.h
@@ -22,7 +22,7 @@ class AllocationDomainPass : public OptimizationPass<AllocationDomainPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "AllocationDomainPass";
   }
 };

--- a/csrc/preseg_passes/consecutive_cast.h
+++ b/csrc/preseg_passes/consecutive_cast.h
@@ -18,7 +18,7 @@ class ConsecutiveCastPass : public OptimizationPass<ConsecutiveCastPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr std::string name() {
+  static std::string name() {
     return "ConsecutiveCastPass";
   }
 };

--- a/csrc/preseg_passes/consecutive_cast.h
+++ b/csrc/preseg_passes/consecutive_cast.h
@@ -18,7 +18,7 @@ class ConsecutiveCastPass : public OptimizationPass<ConsecutiveCastPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "ConsecutiveCastPass";
   }
 };

--- a/csrc/preseg_passes/consecutive_cast.h
+++ b/csrc/preseg_passes/consecutive_cast.h
@@ -18,7 +18,7 @@ class ConsecutiveCastPass : public OptimizationPass<ConsecutiveCastPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr std::string name() {
     return "ConsecutiveCastPass";
   }
 };

--- a/csrc/preseg_passes/consecutive_cast.h
+++ b/csrc/preseg_passes/consecutive_cast.h
@@ -18,7 +18,7 @@ class ConsecutiveCastPass : public OptimizationPass<ConsecutiveCastPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "ConsecutiveCastPass";
   }
 };

--- a/csrc/preseg_passes/exact_mapped_extent_substitution.h
+++ b/csrc/preseg_passes/exact_mapped_extent_substitution.h
@@ -24,7 +24,7 @@ class ExactMappedExtentSubstitutionPass
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "ExactMappedExtentSubstitutionPass";
   }
 };

--- a/csrc/preseg_passes/exact_mapped_extent_substitution.h
+++ b/csrc/preseg_passes/exact_mapped_extent_substitution.h
@@ -24,7 +24,7 @@ class ExactMappedExtentSubstitutionPass
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "ExactMappedExtentSubstitutionPass";
   }
 };

--- a/csrc/preseg_passes/insert_reshardings.h
+++ b/csrc/preseg_passes/insert_reshardings.h
@@ -20,7 +20,7 @@ class InsertReshardingsPass : public OptimizationPass<InsertReshardingsPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "InsertReshardingsPass";
   }
 };

--- a/csrc/preseg_passes/insert_reshardings.h
+++ b/csrc/preseg_passes/insert_reshardings.h
@@ -20,7 +20,7 @@ class InsertReshardingsPass : public OptimizationPass<InsertReshardingsPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "InsertReshardingsPass";
   }
 };

--- a/csrc/preseg_passes/make_resharding_contiguous.h
+++ b/csrc/preseg_passes/make_resharding_contiguous.h
@@ -26,7 +26,7 @@ class MakeReshardingContiguousPass
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "MakeReshardingContiguousPass";
   }
 };

--- a/csrc/preseg_passes/make_resharding_contiguous.h
+++ b/csrc/preseg_passes/make_resharding_contiguous.h
@@ -26,7 +26,7 @@ class MakeReshardingContiguousPass
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "MakeReshardingContiguousPass";
   }
 };

--- a/csrc/preseg_passes/mark_aliases_prepare.h
+++ b/csrc/preseg_passes/mark_aliases_prepare.h
@@ -19,7 +19,7 @@ class MarkAliasesPreparePass : public OptimizationPass<MarkAliasesPreparePass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "MarkAliasesPreparePass";
   }
 };

--- a/csrc/preseg_passes/mark_aliases_prepare.h
+++ b/csrc/preseg_passes/mark_aliases_prepare.h
@@ -19,7 +19,7 @@ class MarkAliasesPreparePass : public OptimizationPass<MarkAliasesPreparePass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "MarkAliasesPreparePass";
   }
 };

--- a/csrc/preseg_passes/move_pad.h
+++ b/csrc/preseg_passes/move_pad.h
@@ -15,7 +15,7 @@ class MovePadPass : public OptimizationPass<MovePadPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "MovePadPass";
   }
 };

--- a/csrc/preseg_passes/move_pad.h
+++ b/csrc/preseg_passes/move_pad.h
@@ -15,7 +15,7 @@ class MovePadPass : public OptimizationPass<MovePadPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "MovePadPass";
   }
 };

--- a/csrc/preseg_passes/move_split_cat.h
+++ b/csrc/preseg_passes/move_split_cat.h
@@ -17,7 +17,7 @@ class MoveSplitCatPass : public OptimizationPass<MoveSplitCatPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "MoveSplitCatPass";
   }
 };

--- a/csrc/preseg_passes/move_split_cat.h
+++ b/csrc/preseg_passes/move_split_cat.h
@@ -17,7 +17,7 @@ class MoveSplitCatPass : public OptimizationPass<MoveSplitCatPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "MoveSplitCatPass";
   }
 };

--- a/csrc/preseg_passes/optimization_pass.h
+++ b/csrc/preseg_passes/optimization_pass.h
@@ -12,6 +12,7 @@
 #include <ir/interface_nodes.h>
 #include <ir/utils.h>
 #include <options.h>
+#include <string_view>
 
 #include <atomic>
 
@@ -53,7 +54,7 @@ class OptimizationPass {
       return;
     }
 
-    FUSER_PERF_SCOPE(DerivedClass::name());
+    FUSER_PERF_SCOPE(DerivedClass::name().data());
     DerivedClass::runPass(fusion);
 
     // TODO: skip the logging of the pass where the fusion has not been changed.

--- a/csrc/preseg_passes/optimization_pass.h
+++ b/csrc/preseg_passes/optimization_pass.h
@@ -53,7 +53,7 @@ class OptimizationPass {
       return;
     }
 
-    FUSER_PERF_SCOPE("OptimizationPass::DerivedClass::runPass");
+    FUSER_PERF_SCOPE(DerivedClass::name().c_str());
     DerivedClass::runPass(fusion);
 
     // TODO: skip the logging of the pass where the fusion has not been changed.

--- a/csrc/preseg_passes/optimization_pass.h
+++ b/csrc/preseg_passes/optimization_pass.h
@@ -53,7 +53,7 @@ class OptimizationPass {
       return;
     }
 
-    FUSER_PERF_SCOPE(DerivedClass::name().c_str());
+    FUSER_PERF_SCOPE(DerivedClass::name());
     DerivedClass::runPass(fusion);
 
     // TODO: skip the logging of the pass where the fusion has not been changed.

--- a/csrc/preseg_passes/optimization_pass.h
+++ b/csrc/preseg_passes/optimization_pass.h
@@ -53,7 +53,7 @@ class OptimizationPass {
       return;
     }
 
-    FUSER_PERF_SCOPE(DerivedClass::name().c_str());
+    FUSER_PERF_SCOPE("OptimizationPass::DerivedClass::runPass");
     DerivedClass::runPass(fusion);
 
     // TODO: skip the logging of the pass where the fusion has not been changed.

--- a/csrc/preseg_passes/pre_segmenter.h
+++ b/csrc/preseg_passes/pre_segmenter.h
@@ -19,7 +19,7 @@ class NVF_API PreSegmenter : public OptimizationPass<PreSegmenter> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "PreSegmenter";
   }
 };

--- a/csrc/preseg_passes/pre_segmenter.h
+++ b/csrc/preseg_passes/pre_segmenter.h
@@ -19,7 +19,7 @@ class NVF_API PreSegmenter : public OptimizationPass<PreSegmenter> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "PreSegmenter";
   }
 };

--- a/csrc/preseg_passes/propagate_shardings.h
+++ b/csrc/preseg_passes/propagate_shardings.h
@@ -23,7 +23,7 @@ class PropagateShardingsPass : public OptimizationPass<PropagateShardingsPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "PropagateShardingsPass";
   }
 };

--- a/csrc/preseg_passes/propagate_shardings.h
+++ b/csrc/preseg_passes/propagate_shardings.h
@@ -23,7 +23,7 @@ class PropagateShardingsPass : public OptimizationPass<PropagateShardingsPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "PropagateShardingsPass";
   }
 };

--- a/csrc/preseg_passes/remove_bcast_squeeze.h
+++ b/csrc/preseg_passes/remove_bcast_squeeze.h
@@ -17,7 +17,7 @@ class RemoveBcastSqueeze : public OptimizationPass<RemoveBcastSqueeze> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "RemoveBcastSqueeze";
   }
 };

--- a/csrc/preseg_passes/remove_bcast_squeeze.h
+++ b/csrc/preseg_passes/remove_bcast_squeeze.h
@@ -17,7 +17,7 @@ class RemoveBcastSqueeze : public OptimizationPass<RemoveBcastSqueeze> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "RemoveBcastSqueeze";
   }
 };

--- a/csrc/preseg_passes/remove_empty.h
+++ b/csrc/preseg_passes/remove_empty.h
@@ -20,7 +20,7 @@ class RemoveEmptyPass : public OptimizationPass<RemoveEmptyPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "RemoveEmptyPass";
   }
 };

--- a/csrc/preseg_passes/remove_empty.h
+++ b/csrc/preseg_passes/remove_empty.h
@@ -20,7 +20,7 @@ class RemoveEmptyPass : public OptimizationPass<RemoveEmptyPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "RemoveEmptyPass";
   }
 };

--- a/csrc/preseg_passes/reorder_sharded_axis.h
+++ b/csrc/preseg_passes/reorder_sharded_axis.h
@@ -25,7 +25,7 @@ class ReorderShardedAxisPass : public OptimizationPass<ReorderShardedAxisPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "ReorderShardedAxisPass";
   }
 };

--- a/csrc/preseg_passes/reorder_sharded_axis.h
+++ b/csrc/preseg_passes/reorder_sharded_axis.h
@@ -25,7 +25,7 @@ class ReorderShardedAxisPass : public OptimizationPass<ReorderShardedAxisPass> {
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "ReorderShardedAxisPass";
   }
 };

--- a/csrc/preseg_passes/segment_inplace_update.h
+++ b/csrc/preseg_passes/segment_inplace_update.h
@@ -19,7 +19,7 @@ class SegmentInplaceUpdatePass
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "SegmentInplaceUpdate";
   }
 };

--- a/csrc/preseg_passes/segment_inplace_update.h
+++ b/csrc/preseg_passes/segment_inplace_update.h
@@ -19,7 +19,7 @@ class SegmentInplaceUpdatePass
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "SegmentInplaceUpdate";
   }
 };

--- a/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h
+++ b/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h
@@ -33,7 +33,7 @@ class TranslateNoReductionMatmulToMulSqueeze
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "TranslateNoReductionMatmulToMulSqueeze";
   }
 };

--- a/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h
+++ b/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h
@@ -33,7 +33,7 @@ class TranslateNoReductionMatmulToMulSqueeze
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "TranslateNoReductionMatmulToMulSqueeze";
   }
 };

--- a/csrc/preseg_passes/translate_repeat_to_expand.h
+++ b/csrc/preseg_passes/translate_repeat_to_expand.h
@@ -46,7 +46,7 @@ class TranslateRepeatToExpand
 
  protected:
   static void runPass(Fusion* fusion);
-  static constexpr const char* name() {
+  static constexpr std::string_view name() {
     return "TranslateRepeatToExpand";
   }
 };

--- a/csrc/preseg_passes/translate_repeat_to_expand.h
+++ b/csrc/preseg_passes/translate_repeat_to_expand.h
@@ -46,7 +46,7 @@ class TranslateRepeatToExpand
 
  protected:
   static void runPass(Fusion* fusion);
-  static std::string name() {
+  static constexpr const char* name() {
     return "TranslateRepeatToExpand";
   }
 };

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -40,7 +40,7 @@ TEST_F(PresegTest, FusionTestOptimizationPassFlag) {
     static void runPass(Fusion* fusion) {
       throw std::runtime_error("running DerivedPass");
     };
-    static std::string name() {
+    static constexpr const char* name() {
       return "DerivedPass";
     }
   };

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -40,7 +40,7 @@ TEST_F(PresegTest, FusionTestOptimizationPassFlag) {
     static void runPass(Fusion* fusion) {
       throw std::runtime_error("running DerivedPass");
     };
-    static constexpr const char* name() {
+    static constexpr std::string_view name() {
       return "DerivedPass";
     }
   };


### PR DESCRIPTION
The name for the derived child class is destroyed before calling `Trace::endEvent`, so a bad name is created and chrome tracing cannot open the trace. This PR changes the return type of `OptimizationPass::name` from `std::string` to `constexpr char*`.

Error:
```
While importing:
SyntaxError: Bad control character in string literal in JSON at position 307792 (line 3203 column 14)
    at JSON.parse (<anonymous>)
    at new TraceEventImporter (chrome://tracing/tracing.js:6244:19)
    at Import.createImporter_ (chrome://tracing/tracing.js:2033:8)
    at chrome://tracing/tracing.js:2025:167
    at Task.run (chrome://tracing/tracing.js:3149:95)
    at runAnother (chrome://tracing/tracing.js:3152:371)
    at runTask (chrome://tracing/tracing.js:2913:57)
    at processIdleWork (chrome://tracing/tracing.js:2918:116)
    at window.requestIdleCallback.timeout (chrome://tracing/tracing.js:2911:81)
```