### PR TITLE
Add `zip` and `enumerate` as utility

### DIFF
--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -649,7 +649,7 @@ class iota {
   iterator begin() const {
     return iterator(start);
   }
-  std::default_sentinel_t end() const { return std::unreachable_sentinel; }
+  auto end() const { return std::unreachable_sentinel; }
   int64_t start;
   iota(int64_t start) : start(start) {}
 };

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -746,7 +746,7 @@ using views::zip;
 #endif
 
 auto enumerate(auto&& range) {
-  return zip(views::iota(0LL), std::forward<decltype(range)>(range));
+  return zip(views::iota((int64_t)0), std::forward<decltype(range)>(range));
 }
 
 } // namespace nvfuser

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -626,9 +626,43 @@ using std::views::zip;
 
 #else
 
+#if !defined(__clang__) || (__clang_major__ > 14)
+using std::views::iota;
+#else
+// Workaround for Clang 14
+class iota {
+ public:
+  class iterator {
+   public:
+    using value_type = int;
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::input_iterator_tag;
+    int64_t value;
+    iterator(int64_t start) : value(start) {}
+    int64_t operator*() const { return value; }
+    iterator& operator++() { ++value; return *this; }
+    iterator operator++(int) { iterator temp = *this; ++value; return temp; }
+    template<typename T>
+    bool operator==(T) const { return false; }
+  };
+
+  iterator begin() const {
+    return iterator(start);
+  }
+  std::default_sentinel_t end() const { return std::unreachable_sentinel; }
+  int64_t start;
+  iota(int64_t start) : start(start) {}
+};
+#endif
+
 namespace views {
 template <std::ranges::input_range... Rs>
+#if !defined(__clang__) || (__clang_major__ > 14)
 class zip_view : public std::ranges::view_interface<zip_view<Rs...>> {
+#else
+// Workaround for Clang 14
+class zip_view {
+#endif
  private:
   std::tuple<Rs...> bases;
 
@@ -699,7 +733,7 @@ using views::zip;
 #endif
 
 auto enumerate(auto&& range) {
-  return zip(std::views::iota(0), std::forward<decltype(range)>(range));
+  return zip(iota(0LL), std::forward<decltype(range)>(range));
 }
 
 } // namespace nvfuser

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -626,6 +626,7 @@ using std::views::zip;
 
 #else
 
+namespace views {
 #if !defined(__clang__) || (__clang_major__ > 14)
 using std::views::iota;
 #else
@@ -668,7 +669,6 @@ class iota {
 };
 #endif
 
-namespace views {
 template <std::ranges::input_range... Rs>
 #if !defined(__clang__) || (__clang_major__ > 14)
 class zip_view : public std::ranges::view_interface<zip_view<Rs...>> {
@@ -746,7 +746,7 @@ using views::zip;
 #endif
 
 auto enumerate(auto&& range) {
-  return zip(iota(0LL), std::forward<decltype(range)>(range));
+  return zip(views::iota(0LL), std::forward<decltype(range)>(range));
 }
 
 } // namespace nvfuser

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -639,17 +639,30 @@ class iota {
     using iterator_category = std::input_iterator_tag;
     int64_t value;
     iterator(int64_t start) : value(start) {}
-    int64_t operator*() const { return value; }
-    iterator& operator++() { ++value; return *this; }
-    iterator operator++(int) { iterator temp = *this; ++value; return temp; }
-    template<typename T>
-    bool operator==(T) const { return false; }
+    int64_t operator*() const {
+      return value;
+    }
+    iterator& operator++() {
+      ++value;
+      return *this;
+    }
+    iterator operator++(int) {
+      iterator temp = *this;
+      ++value;
+      return temp;
+    }
+    template <typename T>
+    bool operator==(T) const {
+      return false;
+    }
   };
 
   iterator begin() const {
     return iterator(start);
   }
-  auto end() const { return std::unreachable_sentinel; }
+  auto end() const {
+    return std::unreachable_sentinel;
+  }
   int64_t start;
   iota(int64_t start) : start(start) {}
 };

--- a/examples/sinh_extension/setup.py
+++ b/examples/sinh_extension/setup.py
@@ -38,7 +38,7 @@ setup(
             library_dirs=[nvfuser_lib_dir],
             extra_link_args=[f"-Wl,-rpath,{nvfuser_lib_dir}"],
             sources=["main.cpp"],
-            extra_compile_args={'cxx': ['-std=c++20']},
+            extra_compile_args={"cxx": ["-std=c++20"]},
         )
     ],
     cmdclass={"build_ext": BuildExtension},

--- a/examples/sinh_extension/setup.py
+++ b/examples/sinh_extension/setup.py
@@ -38,7 +38,7 @@ setup(
             library_dirs=[nvfuser_lib_dir],
             extra_link_args=[f"-Wl,-rpath,{nvfuser_lib_dir}"],
             sources=["main.cpp"],
-            extra_compile_args={'cxx': ['-std=c++20']}
+            extra_compile_args={'cxx': ['-std=c++20']},
         )
     ],
     cmdclass={"build_ext": BuildExtension},

--- a/examples/sinh_extension/setup.py
+++ b/examples/sinh_extension/setup.py
@@ -38,6 +38,7 @@ setup(
             library_dirs=[nvfuser_lib_dir],
             extra_link_args=[f"-Wl,-rpath,{nvfuser_lib_dir}"],
             sources=["main.cpp"],
+            extra_compile_args={'cxx': ['-std=c++20']}
         )
     ],
     cmdclass={"build_ext": BuildExtension},

--- a/examples/sinh_libtorch/CMakeLists.txt
+++ b/examples/sinh_libtorch/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(sinh_example LANGUAGES CXX)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 find_package(Torch REQUIRED)
 find_package(Nvfuser REQUIRED)

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -1696,7 +1696,10 @@ TEST_F(TestCpp23BackPort, ZipDifferentWaysToSayZeroToTen) {
   int64_t counter = 0;
   auto english_it = english.begin();
   for (auto&& [i, e, s, iota] :
-       zip(integer, english, set_theoretic_zero_to_inf, views::iota(0LL))) {
+       zip(integer,
+           english,
+           set_theoretic_zero_to_inf,
+           views::iota((int64_t)0))) {
     static_assert(std::is_same_v<decltype(i), int64_t&>);
     static_assert(std::is_same_v<decltype(e), std::string&>);
     static_assert(std::is_same_v<decltype(s), SetTheoreticNaturalNumber>);

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -1675,30 +1675,32 @@ TEST_F(TestCpp23BackPort, ZipDifferentWaysToSayZeroToTen) {
     }
   };
   static_assert(std::input_iterator<SetTheoreticNaturalNumber>);
+#if !defined(__clang__) || (__clang_major__ > 14)
   struct ZeroToInf : std::ranges::view_interface<ZeroToInf> {
+#else
+  // Workaround for Clang 14
+  struct ZeroToInf {
+#endif
     SetTheoreticNaturalNumber begin() {
       return SetTheoreticNaturalNumber();
     }
     auto end() {
       return std::unreachable_sentinel;
-      // SetTheoreticNaturalNumber invalid_natural_number({{{}}});
-      // return invalid_natural_number;
     }
   } set_theoretic_zero_to_inf;
+#if !defined(__clang__) || (__clang_major__ > 14)
   static_assert(std::ranges::input_range<ZeroToInf>);
   static_assert(std::ranges::view<ZeroToInf>);
+#endif
 
   int64_t counter = 0;
   auto english_it = english.begin();
   for (auto&& [i, e, s, iota] :
-       zip(integer,
-           english,
-           set_theoretic_zero_to_inf,
-           std::ranges::iota_view(0))) {
+       zip(integer, english, set_theoretic_zero_to_inf, iota(0LL))) {
     static_assert(std::is_same_v<decltype(i), int64_t&>);
     static_assert(std::is_same_v<decltype(e), std::string&>);
     static_assert(std::is_same_v<decltype(s), SetTheoreticNaturalNumber>);
-    static_assert(std::is_same_v<decltype(iota), int>);
+    static_assert(std::is_same_v<decltype(iota), int64_t>);
     EXPECT_EQ(i, counter);
     EXPECT_EQ(&i, &integer[counter]);
     EXPECT_EQ(&e, &*english_it);

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -1630,7 +1630,7 @@ TEST_F(NVFuserTest, ProveLinearAndGetStride) {
 
 using TestCpp23BackPort = NVFuserTest;
 
-TEST_F(TestCpp23BackPort, DifferentWaysToSayZeroToTen) {
+TEST_F(TestCpp23BackPort, ZipDifferentWaysToSayZeroToTen) {
   // vector of integers
   std::vector<int64_t> integer{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
@@ -1679,15 +1679,18 @@ TEST_F(TestCpp23BackPort, DifferentWaysToSayZeroToTen) {
     SetTheoreticNaturalNumber begin() {
       return SetTheoreticNaturalNumber();
     }
-    SetTheoreticNaturalNumber end() {
-      SetTheoreticNaturalNumber invalid_natural_number({{{}}});
-      return invalid_natural_number;
+    auto end() {
+      return std::unreachable_sentinel;
+      // SetTheoreticNaturalNumber invalid_natural_number({{{}}});
+      // return invalid_natural_number;
     }
   } set_theoretic_zero_to_inf;
   static_assert(std::ranges::input_range<ZeroToInf>);
   static_assert(std::ranges::view<ZeroToInf>);
 
-  for (auto&& [i, e, s, itoa] :
+  int64_t counter = 0;
+  auto english_it = english.begin();
+  for (auto&& [i, e, s, iota] :
        zip(integer,
            english,
            set_theoretic_zero_to_inf,
@@ -1695,9 +1698,244 @@ TEST_F(TestCpp23BackPort, DifferentWaysToSayZeroToTen) {
     static_assert(std::is_same_v<decltype(i), int64_t&>);
     static_assert(std::is_same_v<decltype(e), std::string&>);
     static_assert(std::is_same_v<decltype(s), SetTheoreticNaturalNumber>);
-    static_assert(std::is_same_v<decltype(itoa), int>);
-    std::cout << i << std::endl;
+    static_assert(std::is_same_v<decltype(iota), int>);
+    EXPECT_EQ(i, counter);
+    EXPECT_EQ(&i, &integer[counter]);
+    EXPECT_EQ(&e, &*english_it);
+    EXPECT_EQ(iota, counter);
+    switch (counter) {
+      case 0: {
+        EXPECT_EQ(e, "zero");
+        SetTheoreticNaturalNumber expect = {};
+        EXPECT_EQ(s, expect);
+        break;
+      }
+      case 1: {
+        EXPECT_EQ(e, "one");
+        SetTheoreticNaturalNumber expect = {{}};
+        EXPECT_EQ(s, expect);
+        break;
+      }
+      case 2: {
+        EXPECT_EQ(e, "two");
+        SetTheoreticNaturalNumber expect = {{}, {{}}};
+        EXPECT_EQ(s, expect);
+        break;
+      }
+      case 3: {
+        EXPECT_EQ(e, "three");
+        SetTheoreticNaturalNumber expect = {{}, {{}}, {{}, {{}}}};
+        EXPECT_EQ(s, expect);
+        break;
+      }
+      case 4: {
+        EXPECT_EQ(e, "four");
+        SetTheoreticNaturalNumber expect = {
+            {}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}};
+        EXPECT_EQ(s, expect);
+        break;
+      }
+      case 5: {
+        EXPECT_EQ(e, "five");
+        SetTheoreticNaturalNumber expect = {
+            {},
+            {{}},
+            {{}, {{}}},
+            {{}, {{}}, {{}, {{}}}},
+            {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}};
+        EXPECT_EQ(s, expect);
+        break;
+      }
+      case 6: {
+        EXPECT_EQ(e, "six");
+        SetTheoreticNaturalNumber expect = {
+            {},
+            {{}},
+            {{}, {{}}},
+            {{}, {{}}, {{}, {{}}}},
+            {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+            {{},
+             {{}},
+             {{}, {{}}},
+             {{}, {{}}, {{}, {{}}}},
+             {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}}};
+        EXPECT_EQ(s, expect);
+        break;
+      }
+      case 7: {
+        EXPECT_EQ(e, "seven");
+        SetTheoreticNaturalNumber expect = {
+            {},
+            {{}},
+            {{}, {{}}},
+            {{}, {{}}, {{}, {{}}}},
+            {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+            {{},
+             {{}},
+             {{}, {{}}},
+             {{}, {{}}, {{}, {{}}}},
+             {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}},
+            {{},
+             {{}},
+             {{}, {{}}},
+             {{}, {{}}, {{}, {{}}}},
+             {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+             {{},
+              {{}},
+              {{}, {{}}},
+              {{}, {{}}, {{}, {{}}}},
+              {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}}}};
+        EXPECT_EQ(s, expect);
+        break;
+      }
+      case 8: {
+        EXPECT_EQ(e, "eight");
+        SetTheoreticNaturalNumber expect = {
+            {},
+            {{}},
+            {{}, {{}}},
+            {{}, {{}}, {{}, {{}}}},
+            {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+            {{},
+             {{}},
+             {{}, {{}}},
+             {{}, {{}}, {{}, {{}}}},
+             {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}},
+            {{},
+             {{}},
+             {{}, {{}}},
+             {{}, {{}}, {{}, {{}}}},
+             {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+             {{},
+              {{}},
+              {{}, {{}}},
+              {{}, {{}}, {{}, {{}}}},
+              {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}}},
+            {{},
+             {{}},
+             {{}, {{}}},
+             {{}, {{}}, {{}, {{}}}},
+             {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+             {{},
+              {{}},
+              {{}, {{}}},
+              {{}, {{}}, {{}, {{}}}},
+              {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}},
+             {{},
+              {{}},
+              {{}, {{}}},
+              {{}, {{}}, {{}, {{}}}},
+              {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+              {{},
+               {{}},
+               {{}, {{}}},
+               {{}, {{}}, {{}, {{}}}},
+               {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}}}}};
+        EXPECT_EQ(s, expect);
+        break;
+      }
+      case 9: {
+        EXPECT_EQ(e, "nine");
+        SetTheoreticNaturalNumber expect = {
+            {},
+            {{}},
+            {{}, {{}}},
+            {{}, {{}}, {{}, {{}}}},
+            {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+            {{},
+             {{}},
+             {{}, {{}}},
+             {{}, {{}}, {{}, {{}}}},
+             {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}},
+            {{},
+             {{}},
+             {{}, {{}}},
+             {{}, {{}}, {{}, {{}}}},
+             {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+             {{},
+              {{}},
+              {{}, {{}}},
+              {{}, {{}}, {{}, {{}}}},
+              {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}}},
+            {{},
+             {{}},
+             {{}, {{}}},
+             {{}, {{}}, {{}, {{}}}},
+             {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+             {{},
+              {{}},
+              {{}, {{}}},
+              {{}, {{}}, {{}, {{}}}},
+              {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}},
+             {{},
+              {{}},
+              {{}, {{}}},
+              {{}, {{}}, {{}, {{}}}},
+              {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+              {{},
+               {{}},
+               {{}, {{}}},
+               {{}, {{}}, {{}, {{}}}},
+               {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}}}},
+            {{},
+             {{}},
+             {{}, {{}}},
+             {{}, {{}}, {{}, {{}}}},
+             {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+             {{},
+              {{}},
+              {{}, {{}}},
+              {{}, {{}}, {{}, {{}}}},
+              {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}},
+             {{},
+              {{}},
+              {{}, {{}}},
+              {{}, {{}}, {{}, {{}}}},
+              {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+              {{},
+               {{}},
+               {{}, {{}}},
+               {{}, {{}}, {{}, {{}}}},
+               {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}}},
+             {{},
+              {{}},
+              {{}, {{}}},
+              {{}, {{}}, {{}, {{}}}},
+              {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+              {{},
+               {{}},
+               {{}, {{}}},
+               {{}, {{}}, {{}, {{}}}},
+               {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}},
+              {{},
+               {{}},
+               {{}, {{}}},
+               {{}, {{}}, {{}, {{}}}},
+               {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}},
+               {{},
+                {{}},
+                {{}, {{}}},
+                {{}, {{}}, {{}, {{}}}},
+                {{}, {{}}, {{}, {{}}}, {{}, {{}}, {{}, {{}}}}}}}}}};
+        EXPECT_EQ(s, expect);
+        break;
+      }
+    }
+    counter++;
+    english_it++;
   }
+  EXPECT_EQ(counter, 10);
+}
+
+TEST_F(NVFuserTest, Enumerate) {
+  std::vector<int> v{1, 2, 3, 4, 5};
+  int64_t count = 0;
+  for (auto&& [i, x] : enumerate(v)) {
+    EXPECT_EQ(i, count);
+    EXPECT_EQ(x, count + 1);
+    count++;
+  }
+  EXPECT_EQ(count, 5);
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -1696,7 +1696,7 @@ TEST_F(TestCpp23BackPort, ZipDifferentWaysToSayZeroToTen) {
   int64_t counter = 0;
   auto english_it = english.begin();
   for (auto&& [i, e, s, iota] :
-       zip(integer, english, set_theoretic_zero_to_inf, iota(0LL))) {
+       zip(integer, english, set_theoretic_zero_to_inf, views::iota(0LL))) {
     static_assert(std::is_same_v<decltype(i), int64_t&>);
     static_assert(std::is_same_v<decltype(e), std::string&>);
     static_assert(std::is_same_v<decltype(s), SetTheoreticNaturalNumber>);


### PR DESCRIPTION
Add `zip` and `enumerate` as a convenient utility, which have the same behavior as Python's `zip` and `enumerate`. This PR also drop support for C++17.