### PR TITLE
Fix call to fd.validate in python matmul benchmark

### DIFF
--- a/benchmarks/python/test_matmul.py
+++ b/benchmarks/python/test_matmul.py
@@ -99,7 +99,7 @@ def test_matmul_nvf_benchmark(
 
     if not disable_validation:
         eager_output = torch.matmul(a, b)
-        fd.validate([a, b], [eager_output], kwargs=kwargs)
+        fd.validate([a, b], [eager_output], **kwargs)
 
     if not disable_benchmarking:
         run_benchmark(benchmark, lambda *args: fd.execute(*args, **kwargs), [a, b])


### PR DESCRIPTION
This fixes `benchmark/python/test_matmul.py` which currently fails unless `--disable-validation` is provided.

Related to #3886