### PR TITLE
add packed warp reduction

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -2939,6 +2939,49 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
              << ";\n";
   }
 
+  void genGroupedWarpReduction(
+      const int num_grouped_iterations,
+      kir::TensorIndex* output,
+      kir::TensorIndex* input,
+      const Val* init,
+      BinaryOpType reduction_op_type,
+      kir::Predicate* read_pred,
+      std::pair<IterDomain*, IterDomain*> reduction_dims) {
+    ArgumentBuilder func_args;
+    func_args.arg(genVariableNameConvertAlignedArray(output));
+    func_args.arg(genVariableNameConvertAlignedArray(input));
+    func_args.arg(genReductionOp(reduction_op_type, output->dtype()));
+    func_args.arg(genStaticCast(genPtrType(output->dtype()), "shared_mem"));
+    NVF_ERROR(read_pred != nullptr && read_pred->hasValue());
+    func_args.arg(genInline(read_pred));
+    func_args.arg(genStaticCast(output->dtype(), genInline(init)));
+    func_args.arg(genComputeBlockDim());
+
+    ArgumentBuilder template_args;
+    if (reduction_dims.first->getParallelType() == ParallelType::TIDx &&
+        reduction_dims.second == nullptr) {
+      template_args.arg(
+          kernel_->getWarpPaddedParallelInfo().is_tidx_single_warp);
+      template_args.arg(isAligned());
+      template_args.arg(num_grouped_iterations);
+      indent() << genCall(
+                      "warp::iterGroupedWarpReduce", template_args, func_args)
+               << ";\n";
+    } else if (
+        reduction_dims.first->getParallelType() == ParallelType::TIDx &&
+        reduction_dims.second->getParallelType() == ParallelType::TIDy) {
+      auto bdimx = reduction_dims.first->extent()->evaluate();
+      auto bdimy = reduction_dims.second->extent()->evaluate();
+      template_args.arg(bdimx);
+      template_args.arg(bdimy);
+      template_args.arg(isAligned());
+      indent() << genCall("warp::warpReduceTIDXY", template_args, func_args)
+               << ";\n";
+    } else {
+      NVF_ERROR(false, "Invalid warp reduction dims");
+    }
+  }
+
   void handle(const GroupedReductionOp* grouped_rop) final {
     const auto num_grouped_iterations =
         getGroupedLoopIndexConcreteIntSets().size();
@@ -2959,14 +3002,26 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       NVF_ERROR(
           has_block_reduce,
           "To use IterGroupedBlockReduction, must have block reduce!");
-      return genIterGroupedBlockReduction(
-          (int)num_grouped_iterations,
-          output,
-          input,
-          grouped_rop->initVal(0),
-          op_type,
-          grouped_rop->predicate(),
-          grouped_rop->writePredicate());
+      if (auto reduction_ids =
+              ir_utils::getMaybeWarpReductionDim(output, input)) {
+        return genGroupedWarpReduction(
+            (int)num_grouped_iterations,
+            output,
+            input,
+            grouped_rop->initVal(0),
+            op_type,
+            grouped_rop->predicate(),
+            reduction_ids.value());
+      } else {
+        return genIterGroupedBlockReduction(
+            (int)num_grouped_iterations,
+            output,
+            input,
+            grouped_rop->initVal(0),
+            op_type,
+            grouped_rop->predicate(),
+            grouped_rop->writePredicate());
+      }
     }
 
     for (const auto i : c10::irange(num_grouped_exprs)) {

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -473,6 +473,23 @@ void clearUnrollVectorizationAddGroupReduction(
     const std::unordered_set<TensorView*>& unroll_vectorizable_cached_tvs) {
   std::vector<TensorView*> rfactor_and_reduction_tvs = {
       reference_tv, reduction_tv};
+
+  bool is_inner_reduction =
+      scheduler_utils::isFastestDimReduction(reduction_tv);
+  auto convertParallelToGrouped = [&is_inner_reduction](IterDomain* id) {
+    auto pt = id->getParallelType();
+    // For outer reduction, convert inner dim vectorization to group.
+    // For inner reduction, convert outer dim unroll to group.
+    if (!is_inner_reduction && pt == ParallelType::Vectorize) {
+      return true;
+    } else if (
+        is_inner_reduction && pt == ParallelType::Unroll &&
+        !id->isReduction()) {
+      return true;
+    }
+    return false;
+  };
+
   for (auto tv : rfactor_and_reduction_tvs) {
     if (unroll_vectorizable_cached_tvs.count(tv) != 0) {
       continue;
@@ -482,7 +499,7 @@ void clearUnrollVectorizationAddGroupReduction(
       if (use_grouped_reduction &&
           std::find(reduction_tvs.begin(), reduction_tvs.end(), tv) !=
               reduction_tvs.end() &&
-          id->getParallelType() == ParallelType::Vectorize) {
+          convertParallelToGrouped(id)) {
         tv->axis(i)->parallelize(ParallelType::Group);
         for (auto sibling : ir_utils::siblingTvsOf(tv)) {
           sibling->axis(i)->parallelize(ParallelType::Group);

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -478,16 +478,13 @@ void clearUnrollVectorizationAddGroupReduction(
       scheduler_utils::isFastestDimReduction(reduction_tv);
   auto convertParallelToGrouped = [&is_inner_reduction](IterDomain* id) {
     auto pt = id->getParallelType();
-    // For outer reduction, convert inner dim vectorization to group.
     // For inner reduction, convert outer dim unroll to group.
-    if (!is_inner_reduction && pt == ParallelType::Vectorize) {
-      return true;
-    } else if (
-        is_inner_reduction && pt == ParallelType::Unroll &&
-        !id->isReduction()) {
-      return true;
+    // For outer reduction, convert inner dim vectorization to group.
+    if (is_inner_reduction) {
+      return pt == ParallelType::Unroll && !id->isReduction();
+    } else {
+      return pt == ParallelType::Vectorize;
     }
-    return false;
   };
 
   for (auto tv : rfactor_and_reduction_tvs) {

--- a/tests/cpp/test_reduction_pointwise.cpp
+++ b/tests/cpp/test_reduction_pointwise.cpp
@@ -127,19 +127,27 @@ TEST_F(PointwiseFusedReductionTest, OuterReductionBroadcast) {
   ReductionBroadcast(reduction_dim);
 }
 
-TEST_F(NVFuserTest, InnerReductionUnrollVectorization) {
+// dtype, group_factor, inner dim size
+using IterGroupedParams = std::tuple<DataType, int64_t, int64_t>;
+using IterGroupedInnerReduction = NVFuserFixtureParamTest<IterGroupedParams>;
+TEST_P(IterGroupedInnerReduction, VariedGroupFactor) {
+  auto [dtype, group_factor, dim1] = GetParam();
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
-  auto tv0 = makeContigTensor(2);
+  auto tv0 = makeContigTensor(2, dtype);
   fusion->addInput(tv0);
+  tv0 = maybeCastOp(DataType::Float, tv0);
   auto tv1 = sum(tv0, {1});
   fusion->addOutput(tv1);
 
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor t0 = at::randn({256, 10240}, options);
+  auto options =
+      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({16384, dim1}, options);
 
-  // Generate heuristics & enforce unroll on top of vectorization
+  // Generate heuristics, then:
+  // (1) enforce unroll on top of vectorization
+  // (2) enforce unroll on iter domain, which turns into grouped
   SchedulerRuntimeInfo runtime_info(fusion.get(), {t0});
   auto scheduler_instance =
       SchedulerEntry::makeSchedulerInstance(SchedulerType::Reduction);
@@ -147,15 +155,63 @@ TEST_F(NVFuserTest, InnerReductionUnrollVectorization) {
       scheduler_instance->computeHeuristics(fusion.get(), runtime_info);
   auto rparams = heuristic_params->as<ReductionParams>();
   EXPECT_TRUE(rparams->vectorize_inner_reduction);
-  rparams->unroll_factor_top_of_vectorization = 2;
+
+  // must disable TIDy to use grouped reduction
+  if (group_factor > 1) {
+    rparams->unroll_factor_iter_dom = group_factor;
+    rparams->multiple_reds_per_blk = 1;
+    rparams->block_dim_iter_dom = ParallelType::Serial;
+    rparams->lparams.bindUnsafe(
+        LaunchParams::UNINITIALIZED_VAL, ParallelType::TIDy);
+  }
 
   // Schedule, compile, run, validate
   auto fusion_copy = *fusion;
   scheduler_instance->schedule(fusion.get(), rparams);
+
+  // lowering & check iteration grouped reductions
+  if (group_factor > 1) {
+    GpuLower gpulw(fusion.get());
+    // only support grouping pow2 iterations
+    if (group_factor & (group_factor - 1)) {
+      EXPECT_THAT(
+          [&]() { gpulw.run(); },
+          testing::ThrowsMessage<nvfuser::nvfError>(testing::HasSubstr(
+              "Iteration grouped reduction only support grouping 2, 4, 8, or 16 iterations")));
+      return;
+    } else {
+      gpulw.run();
+      NVF_CHECK(
+          gpulw.kernel()->summary().has_iter_grouped_reductions,
+          "There must be iter domain grouped reductions.");
+      NVF_CHECK(
+          gpulw.kernel()->summary().num_grouped_iterations ==
+              rparams->unroll_factor_iter_dom,
+          "Expected ",
+          rparams->unroll_factor_iter_dom,
+          " grouped iterations, found ",
+          gpulw.kernel()->summary().num_grouped_iterations);
+    }
+  }
+
   KernelExecutor ke;
   ke.compile(fusion.get(), {t0}, rparams->lparams);
   auto cg_outputs = ke.run({t0}, {}, rparams->lparams);
   testValidate(&fusion_copy, cg_outputs, {t0}, __LINE__, __FILE__);
 }
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    IterGroupedInnerReduction,
+    ::testing::Combine(
+        ::testing::Values(DataType::Half, DataType::Float),
+        ::testing::Values(1L, 2L, 3L, 4L, 8L, 16L),
+        ::testing::Values(1024L, 2048L, 8192L, 16384L)),
+    [](const testing::TestParamInfo<IterGroupedParams>& info) -> std::string {
+      std::stringstream ss;
+      ss << "dtype_" << std::get<0>(info.param);
+      ss << "_factor_" << std::get<1>(info.param);
+      ss << "_reduction_size_" << std::get<2>(info.param);
+      return sanitizeTestName(ss.str());
+    });
 
 } // namespace nvfuser


### PR DESCRIPTION
Added a new runtime reduction function `iterGroupedWarpReduce`, to pack computation data type (e.g. float32) into `uint64_t` to save number of shfls in warp reduction.

Previously, for multi reductions per block, we map `[Iter, Redu]` to [TIDy, TIDx], with this new function, we can change to [S, TIDx]. Then, we need to call the reduction `S` times, but we can pack `float` into `unit64`, which reduces number of shfls by half.

Only added runtime function & tests, not used in heuristics yet.
