### PR TITLE
Adjust the scatter-gather tests

### DIFF
--- a/tests/cpp/test_scatter_gather.cpp
+++ b/tests/cpp/test_scatter_gather.cpp
@@ -23,7 +23,13 @@
 
 namespace nvfuser {
 
-using ScatterGatherTest = NVFuserTest;
+class ScatterGatherTest : public NVFuserTest {
+ protected:
+  void SetUp() override {
+    // To make the tests using std::rand deterministic
+    std::srand(0);
+  }
+};
 
 namespace {
 auto randomVector(int64_t low, int64_t high, int rank) {
@@ -169,7 +175,7 @@ TEST_F(ScatterGatherTest, TorchGatherAddMul) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   for (const auto is_take_along : {false, true}) {
-    for (int rank = 1; rank <= 5; ++rank) {
+    for (int rank = 1; rank <= 4; ++rank) {
       for (int dim = 0; dim < rank; ++dim) {
         auto fusion_ptr = std::make_unique<Fusion>();
         Fusion& fusion = *fusion_ptr.get();
@@ -205,7 +211,7 @@ TEST_F(ScatterGatherTest, AddGatherSumAdd) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   for (const auto is_take_along : {false, true}) {
-    for (int rank = 2; rank <= 5; ++rank) {
+    for (int rank = 2; rank <= 4; ++rank) {
       for (int dim = 0; dim < rank; ++dim) {
         auto fusion_ptr = std::make_unique<Fusion>();
         Fusion& fusion = *fusion_ptr.get();
@@ -254,7 +260,7 @@ TEST_F(ScatterGatherTest, TorchGatherSumAdd) {
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
   for (const auto is_take_along : {false, true}) {
-    for (int rank = 2; rank <= 5; ++rank) {
+    for (int rank = 2; rank <= 4; ++rank) {
       for (int dim = 0; dim < rank; ++dim) {
         auto fusion_ptr = std::make_unique<Fusion>();
         Fusion& fusion = *fusion_ptr.get();


### PR DESCRIPTION
Some intermittent errors due to using too large inputs. To make things deterministic, std::srand is done at the beginning of each test. Also, the shmoo sweeping of the rank variable is currently set to done up to 5, but reduced to 4 as that's probably just enough.