### PR TITLE
replace nvfuser_tests with test_nvfuser

### DIFF
--- a/manual_ci.sh
+++ b/manual_ci.sh
@@ -19,7 +19,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 run_test './bin/lib/dynamic_type/test_dynamic_type_17'
 run_test './bin/lib/dynamic_type/test_dynamic_type_20'
-run_test './bin/nvfuser_tests'
+run_test './bin/test_nvfuser'
 run_test './bin/test_rng'
 run_test './bin/test_host_ir'
 if type -p mpirun > /dev/null

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 #     Skips python API target `libnvfuser.so`, i.e. `_C.cpython-xxx.so`
 #
 #   --no-test
-#     Skips cpp tests `nvfuser_tests`
+#     Skips cpp tests `test_nvfuser`
 #
 #   --no-benchmark
 #     Skips benchmark target `nvfuser_bench`
@@ -414,7 +414,7 @@ def main():
             "contrib/nn/*",
             # TODO(crcrpar): it'd be better to ship the following two binaries.
             # Would need some change in CMakeLists.txt.
-            # "bin/nvfuser_tests",
+            # "bin/test_nvfuser",
             # "bin/nvfuser_bench"
         ]
 

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -565,7 +565,7 @@ class NVFuserTest : public ::testing::Test {
       auto test_info = ::testing::UnitTest::GetInstance()->current_test_info();
       std::cerr << "To reproduce: NVFUSER_TEST_RANDOM_SEED=" << getCRandomSeed()
                 << " NVFUSER_TEST_ATEN_RANDOM_SEED=" << getATenRandomSeed()
-                << " nvfuser_tests --gtest_filter='"
+                << " test_nvfuser --gtest_filter='"
                 << test_info->test_suite_name() << "." << test_info->name()
                 << "'" << std::endl;
     }

--- a/tools/codediff/codediff.py
+++ b/tools/codediff/codediff.py
@@ -330,7 +330,7 @@ class LogParser:
 
 
 class LogParserGTest(LogParser):
-    """Parse output of googletest binaries like nvfuser_tests"""
+    """Parse output of googletest binaries like test_nvfuser"""
 
     def parse_line(self, line):
         if super().parse_line(line):

--- a/tools/codediff/compare_codegen.sh
+++ b/tools/codediff/compare_codegen.sh
@@ -20,7 +20,7 @@
 # rest of the command line as the test to run. For example, to compare the
 # generated code for a single binary test, you could use:
 #
-#   tools/compare_codegen.sh -- build/nvfuser_tests --gtest_filter='*TestFoo*'
+#   tools/compare_codegen.sh -- build/test_nvfuser --gtest_filter='*TestFoo*'
 #
 # or to run all benchmarks you can use:
 #
@@ -223,7 +223,7 @@ collect_kernels() {
 
         # binary tests
         "${bashcmd[@]}" -o "$binarytestdir" -- \
-            "$nvfuserdir/build/nvfuser_tests" --gtest_color=yes
+            "$nvfuserdir/build/test_nvfuser" --gtest_color=yes
     fi
 }
 

--- a/tools/codediff/run_command.sh
+++ b/tools/codediff/run_command.sh
@@ -29,7 +29,7 @@ directory.
 The diff_report.py tool will parse the STDOUT of these commands to collect
 information about CUDA kernels and group them appropriately. It must know what
 type of command this is in order to do so properly. By default, we look for
-nvfuser_tests, nvfuser_bench, pytest, and python_tests as substrings in the
+test_nvfuser, nvfuser_bench, pytest, and python_tests as substrings in the
 given command. If this fails, you may provide the -t option to record a
 different command type. See diff_report.py (CommandType) for possible types.
 EOF
@@ -209,7 +209,7 @@ echo "$testcmd" > "$testdir/command"
 if [[ -z $commandtype ]]
 then
     case "$testcmd" in
-        *nvfuser_tests*)
+        *test_nvfuser*)
             commandtype="GOOGLETEST"
             ;;
         *nvfuser_bench*)


### PR DESCRIPTION
Following https://github.com/NVIDIA/Fuser/pull/3881, this PR replaces all `nvfuser_tests` with `test_nvfuser`