### PR TITLE
setmaxnreg requires compile time register usage

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -295,7 +295,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           num_threads_per_cta.has_value(),
           "__launch_bounds__ must be set for register sharing warp specialization");
       code_ << "__launch_bounds__(/*MAX_THREADS_PER_BLOCK=*/"
-            << num_threads_per_cta.value() << ") ";
+            << num_threads_per_cta.value() << ", /*MAX_BLOCKS_PER_SM=*/ 1) ";
     }
     if (kernel_->hasManaged("cluster_dims")) {
       auto cluster_dims =

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -294,8 +294,10 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       NVF_ERROR(
           num_threads_per_cta.has_value(),
           "__launch_bounds__ must be set for register sharing warp specialization");
-      code_ << "__launch_bounds__(/*MAX_THREADS_PER_BLOCK=*/"
-            << num_threads_per_cta.value() << ", /*MAX_BLOCKS_PER_SM=*/ 1) ";
+      // leave a space between launch bound and kernel name
+      code_ << "__launch_bounds__(/*maxThreadsPerBlock=*/"
+            << num_threads_per_cta.value()
+            << ", /*minBlocksPerMultiprocessor=*/1) ";
     }
     if (kernel_->hasManaged("cluster_dims")) {
       auto cluster_dims =


### PR DESCRIPTION
Register sharing using `setmaxnreg` requires compile time register usage, it was set by adding `__launch_bounds__(/*MAX_THREADS_PER_BLOCK=*/)` in https://github.com/NVIDIA/Fuser/pull/3669, however, we also need to add `MIN_BLOCKS_PER_SM` to calculate register usage per thread, otherwise, the compiler ignores `setmaxnreg`.

Before this PR, the test `RegisterSharingCircularBufferingPointwiseCustom` outputs `ptxas info    : (C7508) Potential Performance Loss: 'setmaxnreg' ignored; unable to determine register count at entry.` if compiled with ptxas_verbose.

Add hardcode `MIN_BLOCKS_PER_SM = 1`, it is only used for case with register sharing.