### PR TITLE
Remove swizzle argument from stMatrixForMmaOutput

### DIFF
--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -672,7 +672,7 @@ void HopperMultipleMatmulScheduler::scheduleEpilogue() {
       if (store_with_stmatrix) {
         // Schedule shared memory cache; Output from StMatrix
         mma_utils::scheduleStMatrixForMmaOutput(
-            d_smem, swizzle, stmatrix_tile_m, stmatrix_tile_n);
+            d_smem, stmatrix_tile_m, stmatrix_tile_n);
       }
 
       d_smem->axis(-1)->parallelize(ParallelType::Vectorize);

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1304,7 +1304,6 @@ void scheduleTMAStoreForMmaOutput(TensorView* tv, MmaInputSmemSwizzle swizzle) {
 
 void scheduleStMatrixForMmaOutput(
     TensorView* tv,
-    MmaInputSmemSwizzle swizzle,
     int64_t tile_m,
     int64_t tile_n) {
   NVF_ERROR(

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -252,7 +252,6 @@ void scheduleTMAStoreForMmaOutput(TensorView* tv, MmaInputSmemSwizzle swizzle);
 //! registers to shared memory.
 void scheduleStMatrixForMmaOutput(
     TensorView* tv,
-    MmaInputSmemSwizzle swizzle,
     int64_t tile_m,
     int64_t tile_n);
 

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -3785,7 +3785,7 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
     // This internally calls
     // Schedule shared memory cache; Output from StMatrix
     mma_utils::scheduleStMatrixForMmaOutput(
-        tv3_shmem, store_swizzle, stmatrix_tile_m, stmatrix_tile_n);
+        tv3_shmem, stmatrix_tile_m, stmatrix_tile_n);
 
     // Schedule global memory output; Output from TMA Store
     mma_utils::scheduleTMAStoreForMmaOutput(tv3, store_swizzle);

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -3036,8 +3036,7 @@ TEST_P(StMatrixTest, Regular) {
   }
   tv1->setAllocationDomain(tv1->getLoopDomain(), true);
 
-  mma_utils::scheduleStMatrixForMmaOutput(
-      tv2, /*swizzle=*/MmaInputSmemSwizzle::None, tile_m, tile_n);
+  mma_utils::scheduleStMatrixForMmaOutput(tv2, tile_m, tile_n);
 
   tv2->axis(-1)->parallelize(ParallelType::Vectorize);
 

--- a/tests/cpp/test_mma.cpp
+++ b/tests/cpp/test_mma.cpp
@@ -543,7 +543,7 @@ TEST_P(HopperRSStmatrix, SingleTileWithTMALoadStoreStMatrix) {
 
     tv3->setLoopDomain(s.as<IterDomain*>());
   }
-  mma_utils::scheduleStMatrixForMmaOutput(tv3, swizzle, tile_m, tile_n);
+  mma_utils::scheduleStMatrixForMmaOutput(tv3, tile_m, tile_n);
   tv3->axis(-1)->parallelize(ParallelType::Vectorize);
 
   mma_utils::scheduleTMAStoreForMmaOutput(tv4, swizzle);


### PR DESCRIPTION
The `MmaInputSmemSwizzle` swizzle argument is not used by `mma_utils::stMatrixForMmaOutput` so this PR removes it.