### PR TITLE
Show codegen generated utilities in error message

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -168,6 +168,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     codegen.endBlock();
     NVF_CHECK(codegen.block_nest_level_ == 0);
     std::stringstream final_code;
+    final_code << "// Codegen generated utilities\n";
     for (const auto& [ns, code] : codegen.utilities_) {
       if (!ns.empty()) {
         final_code << "namespace " << ns << " {\n"

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -168,7 +168,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     codegen.endBlock();
     NVF_CHECK(codegen.block_nest_level_ == 0);
     std::stringstream final_code;
-    final_code << "// Codegen generated utilities\n";
+    final_code << "// Codegen generated code\n";
     for (const auto& [ns, code] : codegen.utilities_) {
       if (!ns.empty()) {
         final_code << "namespace " << ns << " {\n"

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -164,8 +164,8 @@ class NvrtcCompileDriver {
     char* log_buf = log_backing_buf.data();
     NVFUSER_NVRTC_SAFE_CALL(nvrtcGetProgramLog(program, log_buf));
     if (result != NVRTC_SUCCESS) {
-      // Print CUDA starting at first global function
-      size_t kernel_start = src.find("__global__");
+      // Print CUDA starting at generated utility
+      size_t kernel_start = src.find("// Codegen generated utilities");
       NVF_THROW(
           "\n",
           src.substr(kernel_start),

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -165,7 +165,7 @@ class NvrtcCompileDriver {
     NVFUSER_NVRTC_SAFE_CALL(nvrtcGetProgramLog(program, log_buf));
     if (result != NVRTC_SUCCESS) {
       // Print CUDA starting at generated utility
-      size_t kernel_start = src.find("// Codegen generated utilities");
+      size_t kernel_start = src.find("// Codegen generated code");
       NVF_THROW(
           "\n",
           src.substr(kernel_start),

--- a/tests/cpp/test_loop_rotation.cpp
+++ b/tests/cpp/test_loop_rotation.cpp
@@ -33,7 +33,7 @@ TEST_F(LoopRotationTest, RotateInner) {
   scheduler_utils::rotateLoop(tv4, -1, {tv1, tv2});
 
   const std::string expected_kernel = R"(
-// Codegen generated utilities
+// Codegen generated code
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   #pragma unroll 1
@@ -100,7 +100,7 @@ TEST_F(LoopRotationTest, RotateOuter) {
   scheduler_utils::rotateLoop(tv4, 0, {tv1, tv2});
 
   const std::string expected_kernel = R"(
-// Codegen generated utilities
+// Codegen generated code
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   Array<float, 3LL, 1> T1;
@@ -198,7 +198,7 @@ TEST_F(LoopRotationTest, NonDivisibleSplit) {
   scheduler_utils::rotateLoop(tv4, 0, {tv1, tv2});
 
   const std::string expected_kernel = R"(
-// Codegen generated utilities
+// Codegen generated code
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   nvfuser_index_t i0;
@@ -305,7 +305,7 @@ TEST_F(LoopRotationTest, CircularBuffered) {
   scheduler_utils::rotateLoop(tv4, 0, {tv2});
 
   const std::string expected_kernel = R"(
-// Codegen generated utilities
+// Codegen generated code
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   nvfuser_index_t i0;
@@ -417,7 +417,7 @@ TEST_F(LoopRotationTest, SelectCircularBufferLoad) {
   scheduler_utils::rotateLoop(tv4, 0, {tv1, tv2});
 
   const std::string expected_kernel = R"(
-// Codegen generated utilities
+// Codegen generated code
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   nvfuser_index_t i0;
@@ -568,7 +568,7 @@ TEST_F(LoopRotationTest, MultipleCircularBuffer) {
   scheduler_utils::rotateLoop(tv3, 0, {tv1});
 
   const std::string expected_kernel = R"(
-// Codegen generated utilities
+// Codegen generated code
 
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T3) {
   alignas(16) extern __shared__ char array[];

--- a/tests/cpp/test_loop_rotation.cpp
+++ b/tests/cpp/test_loop_rotation.cpp
@@ -33,6 +33,7 @@ TEST_F(LoopRotationTest, RotateInner) {
   scheduler_utils::rotateLoop(tv4, -1, {tv1, tv2});
 
   const std::string expected_kernel = R"(
+// Codegen generated utilities
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   #pragma unroll 1
@@ -99,6 +100,7 @@ TEST_F(LoopRotationTest, RotateOuter) {
   scheduler_utils::rotateLoop(tv4, 0, {tv1, tv2});
 
   const std::string expected_kernel = R"(
+// Codegen generated utilities
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   Array<float, 3LL, 1> T1;
@@ -196,6 +198,7 @@ TEST_F(LoopRotationTest, NonDivisibleSplit) {
   scheduler_utils::rotateLoop(tv4, 0, {tv1, tv2});
 
   const std::string expected_kernel = R"(
+// Codegen generated utilities
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   nvfuser_index_t i0;
@@ -302,6 +305,7 @@ TEST_F(LoopRotationTest, CircularBuffered) {
   scheduler_utils::rotateLoop(tv4, 0, {tv2});
 
   const std::string expected_kernel = R"(
+// Codegen generated utilities
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   nvfuser_index_t i0;
@@ -413,6 +417,7 @@ TEST_F(LoopRotationTest, SelectCircularBufferLoad) {
   scheduler_utils::rotateLoop(tv4, 0, {tv1, tv2});
 
   const std::string expected_kernel = R"(
+// Codegen generated utilities
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T4) {
   NVFUSER_DEFINE_MAGIC_ZERO;
   nvfuser_index_t i0;
@@ -563,6 +568,7 @@ TEST_F(LoopRotationTest, MultipleCircularBuffer) {
   scheduler_utils::rotateLoop(tv3, 0, {tv1});
 
   const std::string expected_kernel = R"(
+// Codegen generated utilities
 
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T3) {
   alignas(16) extern __shared__ char array[];

--- a/tests/cpp/test_scalar_hoisting.cpp
+++ b/tests/cpp/test_scalar_hoisting.cpp
@@ -295,6 +295,7 @@ TEST_F(ScalarHoistTest, IndexHoist3) {
   auto cg_outputs = ke.run({t0});
 
   const std::string expected_kernel = R"(
+// Codegen generated utilities
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T2) {
   nvfuser_index_t i0;
   i0 = ((nvfuser_index_t)threadIdx.x) + (256LL * ((nvfuser_index_t)blockIdx.x));
@@ -374,6 +375,7 @@ TEST_F(ScalarHoistTest, ARange) {
   auto cg_outputs = ke.run({start, end, step});
 
   const std::string expected_kernel = R"(
+// Codegen generated utilities
 __global__ void CUDAGeneratedKernel(int64_t i0, int64_t i1, int64_t i2, Tensor<int64_t, 1, 1> T0, Tensor<int64_t, 1, 1> T1) {
   int64_t i3;
   i3 = i1 - i0;

--- a/tests/cpp/test_scalar_hoisting.cpp
+++ b/tests/cpp/test_scalar_hoisting.cpp
@@ -295,7 +295,7 @@ TEST_F(ScalarHoistTest, IndexHoist3) {
   auto cg_outputs = ke.run({t0});
 
   const std::string expected_kernel = R"(
-// Codegen generated utilities
+// Codegen generated code
 __global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T2) {
   nvfuser_index_t i0;
   i0 = ((nvfuser_index_t)threadIdx.x) + (256LL * ((nvfuser_index_t)blockIdx.x));
@@ -375,7 +375,7 @@ TEST_F(ScalarHoistTest, ARange) {
   auto cg_outputs = ke.run({start, end, step});
 
   const std::string expected_kernel = R"(
-// Codegen generated utilities
+// Codegen generated code
 __global__ void CUDAGeneratedKernel(int64_t i0, int64_t i1, int64_t i2, Tensor<int64_t, 1, 1> T0, Tensor<int64_t, 1, 1> T1) {
   int64_t i3;
   i3 = i1 - i0;


### PR DESCRIPTION
Example error message:

```CUDA
[ RUN      ] TMemTest.AddKernelSameRegion
unknown file: Failure
C++ exception with description " INTERNAL ASSERT FAILED at "/home/gaoxiang/Fuser/csrc/runtime/compiled_kernel.cpp":169, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues. 
// Codegen generated utilities

namespace tmem {
__device__ __inline__ void alloc(uint32_t in0, uint32_t in1) {
  asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;\n"::"r"(in0), "r"(in1));
}
__device__ __inline__ void relinquishAllocPermit() {
  asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;\n");
}
__device__ __inline__ void store(uint32_t in0, Array<float, 1, 1> in1) {
  asm volatile(
    "tcgen05.st.sync.aligned.32x32b.x1.b32 [%0], {%1};\n"
    :
    :"r"(in0),
     "f"(in1[0])
  );
}
__device__ __inline__ void waitStore() {
  asm volatile("tcgen05.wait::st.sync.aligned;\n");
}
__device__ __inline__ void load(Array<float, 1, 1>& out0, uint32_t in0) {
  asm(
    "tcgen05.ld.sync.aligned.32x32b.x1.b32 {%0}, [%1];\n"
    :"=f"(out0[0])
    :"r"(in0)
  );
}
__device__ __inline__ void waitLoad() {
  asm volatile("tcgen05.wait::ld.sync.aligned;\n");
}
} // namespace tmem
__global__ void nvfuser_none_f0_c0_r0_g0(Tensor<float, 1, 1> T0, Tensor<float, 1, 1> T4, Tensor<float, 1, 1> T9) {
  alignas(16) extern __shared__ char array[];
  const unsigned smem_offset = 0;
  nvfuser_index_t i0;
  i0 = ((nvfuser_index_t)threadIdx.x) + (32 * ((nvfuser_index_t)blockIdx.x));
  bool b1;
  b1 = i0 < T0.logical_size[0LL];
  uint32_t* T10 = reinterpret_cast<uint32_t*>(array + smem_offset + 0);
  tmem::alloc((uint32_t)(toSmem(T10)), (uint32_t)(32));
  tmem::relinquishAllocPermit();
  __syncthreads();
  Array<float, 1, 1> T1;
  T1[0] = 0;
  if (b1) {
    T1[0]
       = T0[((T0.alloc_stride[0LL] * ((nvfuser_index_t)threadIdx.x)) + ((32 * T0.alloc_stride[0LL]) * ((nvfuser_index_t)blockIdx.x)))];
  }
  TMemTensor T2(T10[0], 0, (uint16_t)(0));
  tmem::store((uint32_t)(T2 + Array<uint16_t, 2, 1>{0, 0}), (*reinterpret_cast<Array<float, 1, 1>*>(&T1[0])));
  tmem::waitStore();
  Array<float, 1, 1> T3;
  tmem::load((*reinterpret_cast<Array<float, 1, 1>*>(&T3[0])), (uint32_t)(T2 + Array<uint16_t, 2, 1>{0, 0}));
  tmem::waitLoad();
  asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;\n"::"r"(T10[0]), "r"((uint32_t)(32)));
  Array<float, 1, 1> T5;
  T5[0] = 0;
  if (b1) {
    T5[0]
       = T4[((T4.alloc_stride[0LL] * ((nvfuser_index_t)threadIdx.x)) + ((32 * T4.alloc_stride[0LL]) * ((nvfuser_index_t)blockIdx.x)))];
  }
  TMemTensor T6(T10[0], 0, (uint16_t)(1));
  tmem::store((uint32_t)(T6 + Array<uint16_t, 2, 1>{0, 0}), (*reinterpret_cast<Array<float, 1, 1>*>(&T5[0])));
  tmem::waitStore();
  Array<float, 1, 1> T7;
  tmem::load((*reinterpret_cast<Array<float, 1, 1>*>(&T7[0])), (uint32_t)(T6 + Array<uint16_t, 2, 1>{0, 0}));
  tmem::waitLoad();
  Array<float, 1, 1> T8;
  T8[0]
    = T3[0]
    + T7[0];
  if (b1) {
    T9[i0]
       = T8[0];
  }
}
}

CUDA NVRTC compile error: ptxas application ptx input, line 48; error   : Instruction 'tcgen05.alloc' not supported on .target 'sm_89'
ptxas application ptx input, line 48; error   : Feature '.cta_group::1' not supported on .target 'sm_89'
ptxas application ptx input, line 52; error   : Instruction 'tcgen05.relinquish_alloc_permit' not supported on .target 'sm_89'
ptxas application ptx input, line 52; error   : Feature '.cta_group::1' not supported on .target 'sm_89'
ptxas application ptx input, line 69; error   : Feature '.32x32b' not supported on .target 'sm_89'
ptxas application ptx input, line 69; error   : Instruction 'tcgen05.st' not supported on .target 'sm_89'
ptxas application ptx input, line 73; error   : Instruction 'tcgen05.wait' not supported on .target 'sm_89'
ptxas application ptx input, line 77; error   : Feature '.32x32b' not supported on .target 'sm_89'
ptxas application ptx input, line 77; error   : Instruction 'tcgen05.ld' not supported on .target 'sm_89'
ptxas application ptx input, line 81; error   : Instruction 'tcgen05.wait' not supported on .target 'sm_89'
ptxas application ptx input, line 86; error   : Instruction 'tcgen05.dealloc' not supported on .target 'sm_89'
ptxas application ptx input, line 86; error   : Feature '.cta_group::1' not supported on .target 'sm_89'
ptxas application ptx input, line 101; error   : Feature '.32x32b' not supported on .target 'sm_89'
ptxas application ptx input, line 101; error   : Instruction 'tcgen05.st' not supported on .target 'sm_89'
ptxas application ptx input, line 105; error   : Instruction 'tcgen05.wait' not supported on .target 'sm_89'
ptxas application ptx input, line 109; error   : Feature '.32x32b' not supported on .target 'sm_89'
ptxas application ptx input, line 109; error   : Instruction 'tcgen05.ld' not supported on .target 'sm_89'
ptxas application ptx input, line 113; error   : Instruction 'tcgen05.wait' not supported on .target 'sm_89'
ptxas fatal   : Ptx assembly aborted due to errors

Exception raised from invoke at /home/gaoxiang/Fuser/csrc/runtime/compiled_kernel.cpp:169 (most recent call first):
frame #0: <unknown function> + 0x1f3e89 (0x5f8f19a46e89 in ./bin/test_nvfuser)
frame #1: <unknown function> + 0x5fc9ac (0x5f8f19e4f9ac in ./bin/test_nvfuser)
frame #2: <unknown function> + 0x920965 (0x5f8f1a173965 in ./bin/test_nvfuser)
frame #3: <unknown function> + 0x923318 (0x5f8f1a176318 in ./bin/test_nvfuser)
frame #4: <unknown function> + 0x935e30 (0x5f8f1a188e30 in ./bin/test_nvfuser)
frame #5: <unknown function> + 0x100f4f9 (0x5f8f1a8624f9 in ./bin/test_nvfuser)
frame #6: <unknown function> + 0x1267437 (0x5f8f1aaba437 in ./bin/test_nvfuser)
frame #7: <unknown function> + 0x1250676 (0x5f8f1aaa3676 in ./bin/test_nvfuser)
frame #8: <unknown function> + 0x12508b5 (0x5f8f1aaa38b5 in ./bin/test_nvfuser)
frame #9: <unknown function> + 0x125115b (0x5f8f1aaa415b in ./bin/test_nvfuser)
frame #10: <unknown function> + 0x125ee25 (0x5f8f1aab1e25 in ./bin/test_nvfuser)
frame #11: <unknown function> + 0x1267ac7 (0x5f8f1aabaac7 in ./bin/test_nvfuser)
frame #12: <unknown function> + 0x125099f (0x5f8f1aaa399f in ./bin/test_nvfuser)
frame #13: <unknown function> + 0x3cafcb (0x5f8f19c1dfcb in ./bin/test_nvfuser)
frame #14: <unknown function> + 0x27488 (0x7a5456a35488 in /usr/lib/libc.so.6)
frame #15: __libc_start_main + 0x8c (0x7a5456a3554c in /usr/lib/libc.so.6)
frame #16: <unknown function> + 0x3cb535 (0x5f8f19c1e535 in ./bin/test_nvfuser)
" thrown in the test body.

To reproduce: NVFUSER_TEST_RANDOM_SEED=1740626485 NVFUSER_TEST_ATEN_RANDOM_SEED=0 test_nvfuser --gtest_filter='TMemTest.AddKernelSameRegion'
[  FAILED  ] TMemTest.AddKernelSameRegion (67 ms)
```