### PR TITLE
Add a hard-coded TMem data path pattern matcher

### DIFF
--- a/csrc/device_lower/analysis/tensor_memory.cpp
+++ b/csrc/device_lower/analysis/tensor_memory.cpp
@@ -30,6 +30,8 @@ const TMemAlllocationInfo::Region::TVInfo& TMemAlllocationInfo::getTVInfo(
   NVF_ERROR(false, "TensorView not found in TMemAlllocationInfo");
 }
 
+namespace {
+
 // Returns the lane and column allocation domain that is actually allocated.
 std::pair<std::vector<IterDomain*>, std::vector<IterDomain*>> getTMemAllocation(
     TensorView* tv) {
@@ -181,6 +183,13 @@ TMemAlllocationInfo computeTMemAlllocationInfo(Fusion* fusion) {
   return result;
 }
 
+// Infer the data path of TMem load/store operations from the loop domain of
+// the consumer and the allocation domain of the TMem tensor. Based on the
+// parallelization of the loop domain and the IterDomain transformations between
+// the loop domain and the lane-allocation domain, we can tell which thread
+// accesses which part of the TMem tensor. This information is used to check if
+// the data access falls into one of the supported patterns, and if so, which
+// pattern it is.
 std::pair<
     std::unordered_map<TensorView*, TMemRegisterDataPath>,
     std::unordered_map<TensorView*, TMemRegisterDataPath>>
@@ -258,6 +267,8 @@ computeTMemLdStDataPath(Fusion* fusion) {
   }
   return {std::move(load_data_path), std::move(store_data_path)};
 }
+
+} // namespace
 
 TensorMemoryInfo computeTMemInfo(Fusion* fusion) {
   TensorMemoryInfo result;

--- a/csrc/device_lower/analysis/tensor_memory.h
+++ b/csrc/device_lower/analysis/tensor_memory.h
@@ -7,6 +7,9 @@
 // clang-format on
 #pragma once
 
+#include <type.h>
+
+#include <unordered_map>
 #include <vector>
 
 namespace nvfuser {
@@ -16,7 +19,7 @@ class TensorView;
 class Fusion;
 class IterDomain;
 
-// Information used to lower tensor memory. So far, it is just about allocation.
+// Information used to lower tensor memory.
 struct TensorMemoryInfo;
 TensorMemoryInfo computeTMemInfo(Fusion* fusion);
 
@@ -156,11 +159,15 @@ struct TMemAlllocationInfo {
     std::vector<TVInfo> covered_tensors;
   };
   std::vector<Region> regions;
+
+  const Region::TVInfo& getTVInfo(TensorView* tv) const;
 };
 
 // The actual definition of TensorMemoryInfo.
 struct TensorMemoryInfo {
   TMemAlllocationInfo allocation;
+  std::unordered_map<TensorView*, TMemRegisterDataPath> load_data_path;
+  std::unordered_map<TensorView*, TMemRegisterDataPath> store_data_path;
 };
 
 } // namespace nvfuser

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2151,12 +2151,13 @@ void IndexLowering::handle(const LoadStoreOp* ldst) {
         NVF_ERROR(
             dataTypeSize(ldst->out()->dtype()) == 4,
             "For now, we only support 32-bit types in tmem");
-        // TODO: hard code size 1 for now.
         // According to the specification of tcgen05.{ld,st}, the register
         // operand must be viewed as a vector of 32-bit elements.
         // See:
         // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tensor-memory-and-register-load-store-instructions
-        as_type = ArrayType{std::make_shared<DataType>(ldst->in()->dtype()), 1};
+        as_type = ArrayType{
+            std::make_shared<DataType>(ldst->in()->dtype()),
+            (size_t)ir_utils::getVectorizeSize(ldst->out()->as<TensorView>())};
       }
       if (auto tv = dynamic_cast<TensorView*>(ldst->in());
           tv != nullptr && tv->getMemoryType() == MemoryType::Tensor) {

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1671,4 +1671,21 @@ int max_digits10(DataType dtype) {
   }
 }
 
+std::ostream& operator<<(std::ostream& os, TMemRegisterDataPath dp) {
+  switch (dp) {
+    case TMemRegisterDataPath::Path32x32b:
+      return os << "32x32b";
+    case TMemRegisterDataPath::Path16x64b:
+      return os << "16x64b";
+    case TMemRegisterDataPath::Path16x128b:
+      return os << "16x128b";
+    case TMemRegisterDataPath::Path16x256b:
+      return os << "16x256b";
+    case TMemRegisterDataPath::Path16x32bx2:
+      return os << "16x32bx2";
+    default:
+      NVF_THROW("Unknown TMemRegisterDataPath");
+  }
+}
+
 } // namespace nvfuser

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -1122,6 +1122,12 @@ constexpr auto toUnderlying(E e) noexcept {
 
 enum class AsyncOpType { NotAsync, CpAsync, CpAsyncBulk, WgMma };
 
+// Data path between TMem and register file. Tensor memory is not a general
+// byte-addressable memory like other memory types. The register <-> TMem
+// data transfer must follow one of the following specific patterns which has
+// well-defined specification about which thread's which register access to
+// which part of TMem. See:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-memory-layout
 enum class TMemRegisterDataPath {
   Path32x32b,
   Path16x64b,

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -1122,4 +1122,14 @@ constexpr auto toUnderlying(E e) noexcept {
 
 enum class AsyncOpType { NotAsync, CpAsync, CpAsyncBulk, WgMma };
 
+enum class TMemRegisterDataPath {
+  Path32x32b,
+  Path16x64b,
+  Path16x128b,
+  Path16x256b,
+  Path16x32bx2,
+};
+
+std::ostream& operator<<(std::ostream&, TMemRegisterDataPath);
+
 } // namespace nvfuser


### PR DESCRIPTION
Today, we are hard coding the data path and vectorization size as `32x32b` and `1` in `inline_ptx.cpp`.

This PR moves one step further: it adds a hard-code pattern matcher `computeTMemLdStDataPath` that always outputs `32x32b` for data path, and uses `ir_utils::getVectorizeSize` to compute vectorization size. Now `inline_ptx.cpp` will use the information from the analysis of `computeTMemLdStDataPath` to generate PTX instructions. This makes our system less-hard-coded, although it is still hard coded.