### PR TITLE
Revert "setmaxnreg requires compile time register usage"

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -295,10 +295,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       NVF_ERROR(
           num_threads_per_cta.has_value(),
           "__launch_bounds__ must be set for register sharing warp specialization");
-      // leave a space between launch bound and kernel name
-      code_ << "__launch_bounds__(/*maxThreadsPerBlock=*/"
-            << num_threads_per_cta.value()
-            << ", /*minBlocksPerMultiprocessor=*/1) ";
+      code_ << "__launch_bounds__(/*MAX_THREADS_PER_BLOCK=*/"
+            << num_threads_per_cta.value() << ") ";
     }
     if (kernel_->hasManaged("cluster_dims")) {
       auto cluster_dims =

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -17,7 +17,7 @@
 namespace nvfuser {
 
 TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseCustom) {
-  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(9, 0, 10, 0);
   std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -79,16 +79,8 @@ TEST_F(NVFuserTest, RegisterSharingCircularBufferingPointwiseCustom) {
   at::Tensor t1 = at::randn({tensor_outer_dim, tensor_inner_dim}, options);
   at::Tensor t2 = t0 + t1;
 
-  CompileParams compile_opts;
-  compile_opts.enable_ptxas_verbose = true;
-  captureStdout();
-
   KernelExecutor ke;
-  ke.compile(fusion.get(), {t0, t1}, LaunchParams(), compile_opts);
-
-  std::string output = getCapturedStdout();
-  EXPECT_EQ(output.find("'setmaxnreg' ignored"), std::string::npos)
-      << "'setmaxnreg' ignored!";
+  ke.compile(fusion.get(), {t0, t1});
 
   auto cg_outputs = ke.run({t0, t1});
   testValidate(fusion.get(), cg_outputs, {t0, t1}, {t2}, __LINE__, __FILE__);


### PR DESCRIPTION
Reverts NVIDIA/Fuser#3972

It caused some of the circular buffer tests hangs, the requested register size of `(40,240)` is too large for some of the tests.