### PR TITLE
Revert "Temporarily skip the overlap test"

### DIFF
--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -102,7 +102,7 @@ def test_transformer_layer(
     overlap: bool,
 ):
     if overlap and parallelism == Parallelism.TENSOR_PARALLEL:
-        pytest.skip("Tensor parallelism doesn't support overlapping")
+        pytest.skip("Tensor parallelism doesn't support overlapping.")
 
     # Hyperparameters for GPT-3
     hidden_size = 12288

--- a/tests/python/test_transformer_engine.py
+++ b/tests/python/test_transformer_engine.py
@@ -102,10 +102,7 @@ def test_transformer_layer(
     overlap: bool,
 ):
     if overlap and parallelism == Parallelism.TENSOR_PARALLEL:
-        pytest.skip("Tensor parallelism doesn't support overlapping.")
-
-    if overlap:
-        pytest.skip("Temporarily avoid an ongoing bug in TE (http://nv/evJ).")
+        pytest.skip("Tensor parallelism doesn't support overlapping")
 
     # Hyperparameters for GPT-3
     hidden_size = 12288


### PR DESCRIPTION
Reverts NVIDIA/Fuser#3759

TE has apparently been fixed