### PR TITLE
Temporarily disable a take_along_axis test

### DIFF
--- a/tests/cpp/test_scatter_gather.cpp
+++ b/tests/cpp/test_scatter_gather.cpp
@@ -820,7 +820,9 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization1) {
 //
 // NOTE: Temporarily disabled as it results in non-deterministic
 // validaiton errors (https://github.com/NVIDIA/Fuser/issues/4003).
-TEST_F(ScatterGatherTest, DISABLED_TakeAlongAxisIntermediateTensorNormalization2) {
+TEST_F(
+    ScatterGatherTest,
+    DISABLED_TakeAlongAxisIntermediateTensorNormalization2) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);

--- a/tests/cpp/test_scatter_gather.cpp
+++ b/tests/cpp/test_scatter_gather.cpp
@@ -817,7 +817,10 @@ TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization1) {
 // take_along_dim to broadcast, squeeze, then normalization. Segmented
 // as the input dim to take_along_dim cannot be scheduled by the
 // reduction tv
-TEST_F(ScatterGatherTest, TakeAlongAxisIntermediateTensorNormalization2) {
+//
+// NOTE: Temporarily disabled as it results in non-deterministic
+// validaiton errors (https://github.com/NVIDIA/Fuser/issues/4003).
+TEST_F(ScatterGatherTest, DISABLED_TakeAlongAxisIntermediateTensorNormalization2) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);


### PR DESCRIPTION
Failing likely due to a race condition (#4003)

This should be enabled back as part of the ongoing work on cross entropy.