### PR TITLE
Indexing for TMem ld and st

### DIFF
--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -483,7 +483,7 @@ class ScopeMap : private kir::IrVisitor {
   }
 
   void handle(kir::IfThenElse* ite) final {
-    NVF_THROW("lower_alias_memory: no support for IfThenElse at this phase.");
+    kir::IrVisitor::handle(ite);
   }
 
   //! Factory function for internal loop information data
@@ -786,7 +786,7 @@ class AllocationInfoMap : private kir::IrVisitor {
   }
 
   void handle(kir::IfThenElse* ite) final {
-    NVF_THROW("lower_alias_memory: no support for IfThenElse at this phase.");
+    kir::IrVisitor::handle(ite);
   }
 
   // Generate allocation info for allocation after some pre-filtering

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -991,6 +991,8 @@ std::vector<Expr*> insertTMemRegionAllocsAndDeallocs(
                         region->num_columns},
                     kir::Asm::Options{/*volatile=*/true});
                 registerInsertAfter(expr, tcgen05_dealloc_expr, current_scope);
+                auto block_sync = IrBuilder::create<kir::BlockSync>();
+                registerInsertAfter(expr, block_sync, current_scope);
               };
         }
       }

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -840,6 +840,8 @@ class AllocationInserter : public kir::ExprMutator {
 
 namespace {
 
+// Create `if (is first warp)`, depending on whether the parallel types are
+// used in the schedule, the generated code may be different.
 kir::IfThenElse* createFirstWarpITE() {
   const auto& pdim = GpuLower::current()->parallelDimensionMap();
   Val* tid = FusionGuard::getCurFusion()->zeroVal();

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -819,10 +819,8 @@ class AllocationInserter : public kir::ExprMutator {
     lower_alloc_info_map[alloc_expr] = std::move(lower_alloc_info_ptr);
   }
 
-  void handle(kir::IfThenElse*) final {
-    NVF_THROW(
-        "Pass does not support conditional statements, ",
-        "this pass should be run before any conditionals are placed in code.");
+  void handle(kir::IfThenElse* ite) final {
+    kir::ExprMutator::handle(ite);
   }
 
   AllocationInserter(const std::vector<Expr*>& exprs)
@@ -839,6 +837,42 @@ class AllocationInserter : public kir::ExprMutator {
     return inserter.exprs_;
   }
 };
+
+namespace {
+
+kir::IfThenElse* createFirstWarpITE() {
+  const auto& pdim = GpuLower::current()->parallelDimensionMap();
+  Val* tid = FusionGuard::getCurFusion()->zeroVal();
+  Val* bdimx = pdim.getRaw(ParallelType::TIDx);
+  Val* bdimy = pdim.getRaw(ParallelType::TIDy);
+  Val* bdimz = pdim.getRaw(ParallelType::TIDz);
+  if (bdimx != nullptr) {
+    tid = NamedScalar::getParallelIndex(ParallelType::TIDx);
+  }
+  if (bdimy != nullptr) {
+    Val* tidy = NamedScalar::getParallelIndex(ParallelType::TIDy);
+    if (bdimx != nullptr) {
+      tidy = SimplifyingIrBuilder::mulExpr(tidy, bdimx);
+    }
+    tid = SimplifyingIrBuilder::addExpr(tid, tidy);
+  }
+  if (bdimz != nullptr) {
+    Val* tidz = NamedScalar::getParallelIndex(ParallelType::TIDz);
+    if (bdimy != nullptr) {
+      tidz = SimplifyingIrBuilder::mulExpr(tidz, bdimy);
+    }
+    if (bdimx != nullptr) {
+      tidz = SimplifyingIrBuilder::mulExpr(tidz, bdimx);
+    }
+    tid = SimplifyingIrBuilder::addExpr(tid, tidz);
+  }
+  Val* first_warp =
+      SimplifyingIrBuilder::ltExpr(tid, IrBuilder::create<Val>(32));
+  kir::Predicate* pred = IrBuilder::create<kir::Predicate>(first_warp);
+  return IrBuilder::create<kir::IfThenElse>(pred);
+}
+
+} // namespace
 
 // Insert IR nodes that allocate and deallocate TMem regions.
 // See note [Tensor Memory Allocation] for the overall design.
@@ -862,19 +896,23 @@ std::vector<Expr*> insertTMemRegionAllocsAndDeallocs(
           IrBuilder::create<kir::Allocate>(region.address, MemoryType::Shared);
       prologue.push_back(address_alloc_expr);
       // the tcgen05.alloc instruction
+      auto first_warp = createFirstWarpITE();
       auto alloc_expr =
           IrBuilder::create<kir::AllocTMem>(region.address, region.num_columns);
-      prologue.push_back(alloc_expr);
+      first_warp->thenBody().push_back(alloc_expr);
+      prologue.push_back(first_warp);
     }
 
     if (!regions.empty()) {
       // Relinquish the right to allocate after all regions have been allocated
+      auto first_warp = createFirstWarpITE();
       auto tcgen05_relinquish_expr = IrBuilder::create<kir::Asm>(
           "tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned",
           std::vector<Val*>{},
           std::vector<Val*>{},
           kir::Asm::Options{/*volatile=*/true});
-      prologue.push_back(tcgen05_relinquish_expr);
+      first_warp->thenBody().push_back(tcgen05_relinquish_expr);
+      prologue.push_back(first_warp);
 
       // Block sync that makes allocation visible to all threads
       auto block_sync = IrBuilder::create<kir::BlockSync>();
@@ -982,6 +1020,7 @@ std::vector<Expr*> insertTMemRegionAllocsAndDeallocs(
           auto current_scope = scope_.empty() ? nullptr : scope_.back();
           region_to_register_dealloc_map_[region] =
               [this, expr, region, current_scope]() {
+                auto first_warp = createFirstWarpITE();
                 auto tcgen05_dealloc_expr = IrBuilder::create<kir::Asm>(
                     "tcgen05.dealloc.cta_group::1.sync.aligned.b32",
                     std::vector<Val*>{},
@@ -990,7 +1029,8 @@ std::vector<Expr*> insertTMemRegionAllocsAndDeallocs(
                             region->address, expr->fusion()->zeroVal()),
                         region->num_columns},
                     kir::Asm::Options{/*volatile=*/true});
-                registerInsertAfter(expr, tcgen05_dealloc_expr, current_scope);
+                first_warp->thenBody().push_back(tcgen05_dealloc_expr);
+                registerInsertAfter(expr, first_warp, current_scope);
                 auto block_sync = IrBuilder::create<kir::BlockSync>();
                 registerInsertAfter(expr, block_sync, current_scope);
               };

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2240,7 +2240,6 @@ void IndexLowering::handle(const LoadStoreOp* ldst) {
       }
       if (auto tv = dynamic_cast<TensorView*>(ldst->out());
           tv != nullptr && tv->getMemoryType() == MemoryType::Tensor) {
-        // TODO: hard coded index zero for now.
         auto index = indexTMemLdSt(tv, tv, for_loops_);
         out = IrBuilder::create<kir::TensorIndex>(
             tv, index, DataType::TMemAddress);

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2122,8 +2122,9 @@ Val* indexTMemLdSt(
 
   Val* lane_index = get_index_for(lane_allocation_domain);
   // Only provide the beginning address of the lane
-  lane_index =
-      SimplifyingIrBuilder::divExpr(lane_index, IrBuilder::create<Val>(32));
+  Val* thirty_two = IrBuilder::create<Val>(32);
+  lane_index = SimplifyingIrBuilder::mulExpr(
+      SimplifyingIrBuilder::divExpr(lane_index, thirty_two), thirty_two);
   lane_index =
       SimplifyingIrBuilder::maybeCastExpr(DataType::UInt16, lane_index);
 

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2121,7 +2121,7 @@ Val* indexTMemLdSt(
   };
 
   Val* lane_index = get_index_for(lane_allocation_domain);
-  // Only provide the beginning address of the lane
+  // All threads must provide the beginning address of the lane: i / 32 * 32
   Val* thirty_two = IrBuilder::create<Val>(32);
   lane_index = SimplifyingIrBuilder::mulExpr(
       SimplifyingIrBuilder::divExpr(lane_index, thirty_two), thirty_two);

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -625,10 +625,8 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
     }
   }
 
-  void handle(kir::IfThenElse*) final {
-    NVF_THROW(
-        "Pass does not support conditional statements, ",
-        "this pass should be run before any conditionals are placed in code.");
+  void handle(kir::IfThenElse* ite) final {
+    kir::ExprMutator::handle(ite);
   }
 
   // Return a set of expressions that modify shared-memory

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -425,6 +425,7 @@ const std::string Asm::utility() const {
        "tmem::alloc"},
       {"tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned",
        "tmem::relinquishAllocPermit"},
+      {"tcgen05.dealloc.cta_group::1.sync.aligned.b32", "tmem::dealloc"},
       {"wgmma.fence.sync.aligned", "wgmma::fence"},
       {"fence.proxy.async", "fenceAsyncProxy"},
       {"wgmma.commit_group.sync.aligned", "wgmma::commit"},

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1529,8 +1529,10 @@ std::string typePrefix(const DataType data_type) {
     case DataType::Index:
     case DataType::Int:
     case DataType::Int32:
+    case DataType::Int16:
     case DataType::UInt64:
     case DataType::UInt32:
+    case DataType::UInt16:
     case DataType::SMemAddress:
       return "i";
     case DataType::ComplexFloat:

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1529,7 +1529,7 @@ std::string typePrefix(const DataType data_type) {
     case DataType::Index:
     case DataType::Int:
     case DataType::Int32:
-    case DataType::Int16:
+    case DataType::Short:
     case DataType::UInt64:
     case DataType::UInt32:
     case DataType::UInt16:

--- a/doc/dev/tmem.md
+++ b/doc/dev/tmem.md
@@ -1107,6 +1107,7 @@ TEST_F(TMemTutorialR, Transpose) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
+  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({128, 2, 2}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0.transpose(1, 2)));

--- a/doc/dev/tmem.md
+++ b/doc/dev/tmem.md
@@ -1106,6 +1106,7 @@ TEST_F(TMemTutorialR, Transpose) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
+  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({128, 2, 2}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0.transpose(1, 2)));

--- a/doc/dev/tmem.md
+++ b/doc/dev/tmem.md
@@ -763,7 +763,6 @@ TEST_F(TMemTutorialR, WarpGroupXYColZ) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({8, 16, 8}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -1107,7 +1106,6 @@ TEST_F(TMemTutorialR, Transpose) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({128, 2, 2}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0.transpose(1, 2)));
@@ -1262,7 +1260,6 @@ TEST_F(TMemTutorialR, PerformantVectorizedCopy) {
 
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({256 * 1024 * 1024}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));

--- a/doc/dev/tmem.md
+++ b/doc/dev/tmem.md
@@ -1176,6 +1176,7 @@ TEST_F(TMemTutorialR, Vectorization) {
 
       ke.compile(&fusion);
 
+      NOT_IMPLEMENTED
       at::Tensor t0 = at::rand({128, 256}, at::kCUDA);
       auto out = ke.run({t0});
       EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -1260,6 +1261,7 @@ TEST_F(TMemTutorialR, PerformantVectorizedCopy) {
 
   ke.compile(&fusion);
 
+  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({256 * 1024 * 1024}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));

--- a/doc/dev/tmem.md
+++ b/doc/dev/tmem.md
@@ -983,6 +983,7 @@ TEST_F(TMemTutorialR, Complicated1) {
 
   ke.compile(&fusion);
 
+  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({4096, 4096}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -1064,6 +1065,7 @@ TEST_F(TMemTutorialR, Complicated2) {
 
   ke.compile(&fusion);
 
+  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({4096, 4096}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));

--- a/doc/dev/tmem.md
+++ b/doc/dev/tmem.md
@@ -763,6 +763,7 @@ TEST_F(TMemTutorialR, WarpGroupXYColZ) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
+  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({8, 16, 8}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));

--- a/doc/dev/tmem.md
+++ b/doc/dev/tmem.md
@@ -684,7 +684,6 @@ TEST_F(TMemTutorialR, WarpXYZ) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({2, 4, 4, 2}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -725,7 +724,6 @@ TEST_F(TMemTutorialR, WarpGroupXYZ) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({2, 8, 8, 2}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -765,7 +763,6 @@ TEST_F(TMemTutorialR, WarpGroupXYColZ) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({8, 16, 8}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -805,7 +802,6 @@ TEST_F(TMemTutorialR, WarpGroupXColYZ) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({128, 2, 2}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -851,7 +847,6 @@ TEST_F(TMemTutorialR, X1WarpGroupYColZ) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({1, 128, 2}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -987,7 +982,6 @@ TEST_F(TMemTutorialR, Complicated1) {
 
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({4096, 4096}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -1069,7 +1063,6 @@ TEST_F(TMemTutorialR, Complicated2) {
 
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({4096, 4096}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -1111,7 +1104,6 @@ TEST_F(TMemTutorialR, Transpose) {
   KernelExecutor ke;
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({128, 2, 2}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0.transpose(1, 2)));
@@ -1181,7 +1173,6 @@ TEST_F(TMemTutorialR, Vectorization) {
 
       ke.compile(&fusion);
 
-      NOT_IMPLEMENTED
       at::Tensor t0 = at::rand({128, 256}, at::kCUDA);
       auto out = ke.run({t0});
       EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));
@@ -1266,7 +1257,6 @@ TEST_F(TMemTutorialR, PerformantVectorizedCopy) {
 
   ke.compile(&fusion);
 
-  NOT_IMPLEMENTED
   at::Tensor t0 = at::rand({256 * 1024 * 1024}, at::kCUDA);
   auto out = ke.run({t0});
   EXPECT_TRUE(at::equal(out[0].as<at::Tensor>(), t0));

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -2893,11 +2893,8 @@ void testTMemAddKernel(bool same_region) {
     auto check_pass = [same_region](const std::vector<Expr*>& exprs) {
       int64_t num_allocs =
           std::count_if(exprs.begin(), exprs.end(), [](Expr* expr) {
-            auto asm_ = dynamic_cast<kir::Asm*>(expr);
-            if (asm_ == nullptr) {
-              return false;
-            }
-            return asm_->code().find("tcgen05.alloc") != std::string::npos;
+            std::string str = expr->toString();
+            return str.find("tcgen05.alloc") != std::string::npos;
           });
       EXPECT_EQ(num_allocs, same_region ? 1 : 2);
       int64_t num_deallocs = 0;


### PR DESCRIPTION
This PR adds the indexing of TMem load and store, and enables the tests that are now passing. Note that there are still tests disabled, and I believe the failing reason is due to missing block sync, not indexing.