### PR TITLE
Add missing handle for EmbeddingFwdOp

### DIFF
--- a/csrc/logical_domain_map.h
+++ b/csrc/logical_domain_map.h
@@ -522,6 +522,10 @@ class ComputeAtLogicalDomainMapBuilder : private BackwardVisitor {
     mapPointwiseLikeOp(op);
   }
 
+  void handle(EmbeddingFwdOp* op) override {
+    mapPointwiseLikeOp(op);
+  }
+
   void handle(TensorView* tv) override;
 
   //! Maps all pending mappings.


### PR DESCRIPTION
Fixes #4013 

`ComputeAtLogicalDomainMap` needs `handle` for `EmbeddingFwdOp` to analyze broadcast resolutions.
