### PR TITLE
Update Hopper default matmul heuristic

### DIFF
--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -32,6 +32,7 @@
 #include <deque>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <type_traits>
@@ -227,6 +228,111 @@ bool fillDefaultAmpereHeuristic(
   return true;
 }
 
+// This function sets cta_tile, warp_tile, and the mma instruction for Hopper
+// problems. Our strategy is as follows:
+// 1) We use warp_tile.k=cta_tile.k=64 usually, but we also check 16, 32,
+// and 48. 2) We always use 1 or 2 math groups. For 2 math groups, the warp tile
+// is
+//    doubled in either the M or N dimension, called coopA and coopB.
+// 3) We check the three scenarios separately for 1 math group, coopA, and
+//    coopB.
+// 4) For each scenario we check all possible macros. For each possible
+//    configuration, we score it for the given problem size. The score indicates
+//    the amount of data loaded in total, including OOB accesses as if they were
+//    really loaded. This considers that data is loaded multiple times for
+//    different tiles.
+void fillOptimalHopperTileSizes(
+    MatmulParams* mparams,
+    const ProblemShape& problem_shape) {
+  const int64_t m = problem_shape[(size_t)MatmulDimRole::M];
+  const int64_t n = problem_shape[(size_t)MatmulDimRole::N];
+  const int64_t k = problem_shape[(size_t)MatmulDimRole::K];
+
+  struct TileConfig {
+    GemmTile cta;
+    GemmTile warp;
+    GemmTile instr;
+  };
+
+  // Compute how many total bytes need to be computed, summed over all tiles in
+  // the output
+  const auto bytes_transferred = [m, n, k](const GemmTile& cta) {
+    const int64_t tiles_m = ceilDiv(m, cta.m);
+    const int64_t tiles_n = ceilDiv(n, cta.n);
+    const int64_t tiles_k = ceilDiv(k, cta.k);
+
+    // This is the number of bytes that get loaded per circular buffering stage
+    // in a single tile.
+    const int64_t bytes_per_output_tile = tiles_k * (cta.m + cta.n) * cta.k;
+
+    // Now we model wave quantization of the MN tile grid. For example if there
+    // are 132 SMs, then we round up the number of tiles to a multiple of 132
+    // and then multiply the bytes per output tile by that number. The last wave
+    // might run faster than we model it here because it is not really loading
+    // that full amount of data, but it is still wasted computation and so this
+    // is how we model it. Note that we also do not model L2 locality here at
+    // all, so this number is meant as a very rough estimate of compute time for
+    // memory-bound problems.
+    const int64_t num_sms =
+        at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+    const int64_t num_waves = ceilDiv(tiles_m * tiles_n, num_sms);
+    return num_waves * num_sms * bytes_per_output_tile;
+  };
+
+  TileConfig best_config{
+      /*cta=*/{64, 64, 64}, /*warp=*/{64, 64, 64}, /*instr=*/{64, 64, 16}};
+  int64_t best_bytes_tx = std::numeric_limits<int64_t>::max();
+
+  // If two sizes result in the same number of total byte, prefer the larger CTA
+  // K. To do this we iterate backwards here.
+  for (int64_t cta_k = 256; cta_k > 0; cta_k -= 64) {
+    for (const auto& [m_ratio, n_ratio] :
+         std::vector<std::pair<int64_t, int64_t>>{
+             {2L, 1L}, // coopA
+             {1L, 2L}, // coopB
+             {1L, 1L}, // single math group
+         }) {
+      for (int64_t instr_n = 256; instr_n > 8; instr_n -= 64) {
+        // for (int64_t instr_n = 64; instr_n <= 64; instr_n += 64) {
+        const int64_t cta_m = m_ratio * 64;
+        const int64_t cta_n = n_ratio * instr_n;
+
+        const int64_t bytes_per_stage = (cta_m + cta_n) * cta_k * 2;
+        // Don't consider cases where we would need fewer than 3 load stages due
+        // to smem constraint (add 1K bytes overhead as fudge factor)
+        const int64_t smem_bytes =
+            at::cuda::getCurrentDeviceProperties()->sharedMemPerMultiprocessor;
+        if (bytes_per_stage * 3L > smem_bytes - 1024L) {
+          continue;
+        }
+
+        if (cta_m > 256 || cta_n > 256 || cta_k > 256) {
+          // CTA tile is limited to 256 is each dim
+          continue;
+        }
+        const TileConfig cfg{
+            .cta = {cta_m, cta_n, cta_k},
+            .warp = {64L, instr_n, cta_k},
+            .instr = {64L, instr_n, 16L},
+        };
+        const int64_t bytes_tx = bytes_transferred(cfg.cta);
+        if (bytes_tx < best_bytes_tx) {
+          best_bytes_tx = bytes_tx;
+          best_config = cfg;
+        }
+      }
+    }
+  }
+
+  mparams->tile_sizes.cta_tile = best_config.cta;
+  mparams->tile_sizes.warp_tile = best_config.warp;
+  mparams->mma_macro = MmaMacroEncode{
+      MmaMacroEncode::Arch::Hopper,
+      (uint16_t)64,
+      (uint16_t)best_config.instr.n,
+      (uint16_t)16};
+}
+
 bool fillDefaultHopperHeuristic(
     MatmulParams* mparams,
     const ProblemShape& problem_shape,
@@ -234,98 +340,35 @@ bool fillDefaultHopperHeuristic(
     const size_t num_problems) {
   const auto device_prop = at::cuda::getCurrentDeviceProperties();
 
-  const GemmTile instruction_tile = getMmaOpShape(mparams->mma_macro);
-  GemmTile warp_tile = {-1, -1, -1};
-  GemmTile cta_tile = {-1, -1, -1};
+  // Use non-persistent kernel
+  mparams->tiling_strategy = MatmulParams::TilingStrategy::OneTilePerCTA;
 
-  using DimType = decltype(GemmTile::m);
+  fillOptimalHopperTileSizes(mparams, problem_shape);
 
-  // We typically use larger macros on Hopper. By default we will set the
-  // warp tile equal to the macro and increase the CTA tile until we hit
-  // a limit. The limits are given by the maximum number of threads per CTA.
-
-  // k = 64 yields four wgmma instructions per warp group.
-  constexpr int64_t k_ratio = 4;
-  warp_tile = {
-      instruction_tile.m, instruction_tile.n, instruction_tile.k * k_ratio};
-
-  // The MmaOp output is a 32-bit float which requires one register per value
-
-  // total accumulator registers for warp group
-  const size_t accum_regs_per_warp_group =
-      warp_tile.m * warp_tile.n * num_problems;
-
-  // The cta tile is a multiple of the warp tile. This lambda checks that cta
-  // tile given by warp_tile and multiple fits on the SM.
-  const auto validate_cta_tile_multiple = [&](const DimType m_ratio,
-                                              const DimType n_ratio) {
-    DimType cta_m = warp_tile.m * m_ratio;
-    DimType cta_n = warp_tile.n * n_ratio;
-    DimType num_compute_warp_groups = m_ratio * n_ratio;
-
-    // This assumes warp specialization:
-    // tma warp group + compute warp groups
-    DimType num_warp_groups = num_compute_warp_groups + 1;
-
-    const int64_t threads_per_sm = num_warp_groups * 128;
-    const size_t max_registers_per_sm =
-        getRegPerThreadGivenThreadsPerSM(threads_per_sm) * threads_per_sm;
-    return
-        // We store one float per CTA tile element for each matmul problem we
-        // compute
-        num_warp_groups * accum_regs_per_warp_group < max_registers_per_sm
-        // TMA box dimensions must be less than or equal to 256
-        && cta_m <= 256 &&
-        cta_n <= 256
-        // Each warp group is 128 threads. We can only have a maximum of 1024
-        // threads per SM, or 8 warp groups.
-        && num_warp_groups <= 8 &&
-        // Don't extend the CTA tile beyond the problem size
-        cta_m <= problem_shape[(size_t)MatmulDimRole::M] &&
-        cta_n <= problem_shape[(size_t)MatmulDimRole::N];
-  };
-
-  // Note that m_ratio * n_ratio is the number of math warp groups required
-  DimType m_ratio = 1;
-  DimType n_ratio = 1;
-
-  // Always use one or two math groups. Prefer to enlarge the CTA tile in the
-  // larger of the problem dimensions
-  if (problem_shape[(size_t)MatmulDimRole::M] >=
-      problem_shape[(size_t)MatmulDimRole::N]) {
-    if (validate_cta_tile_multiple(2, 1)) {
-      m_ratio = 2;
-    }
-  } else {
-    if (validate_cta_tile_multiple(1, 2)) {
-      n_ratio = 2;
-    }
-  }
-
-  cta_tile = {warp_tile.m * m_ratio, warp_tile.n * n_ratio, warp_tile.k};
-
-  mparams->tile_sizes = {cta_tile, warp_tile};
+  const GemmTile& cta_tile = mparams->tile_sizes.cta_tile;
 
   // Use warp specialization on hopper by default
   mparams->circular_buffering_strategy =
       MatmulParams::CircularBufferingStrategy::WarpSpecialized;
 
-  // stages and async mem copy
-  mparams->circular_buffer_options.smem_circular_buffer_stage = 8;
-
   // TODO: We should take the main loop structure into account here to get a
   // more accurate estimate in case of horizontal fusion
   int64_t operand_smem_per_stage =
       (int64_t)num_problems * 2 * (cta_tile.m + cta_tile.n) * cta_tile.k;
-  // We leave a bit of space for semaphores
+  // We leave a bit of space for semaphores.
   int64_t max_operand_smem =
       (int64_t)device_prop->sharedMemPerMultiprocessor - (1L << 7);
-
-  while (mparams->circular_buffer_options.smem_circular_buffer_stage *
-             operand_smem_per_stage >
-         max_operand_smem) {
-    mparams->circular_buffer_options.smem_circular_buffer_stage--;
+  if (mparams->tiling_strategy != MatmulParams::TilingStrategy::OneTilePerCTA) {
+    // We cannot reuse memory for smem epilogue in persistent kernels.
+    for (TensorView* out : tensor_roles.at(MatmulTensorRole::OUTPUT)) {
+      max_operand_smem -= dataTypeSize(out->dtype()) * cta_tile.m * cta_tile.n;
+    }
   }
+
+  // Maximize stages such that stages*operand_smem_per_stage fits into
+  // max_operand_smem
+  mparams->circular_buffer_options.smem_circular_buffer_stage =
+      max_operand_smem / operand_smem_per_stage;
 
   mparams->circular_buffer_options.circular_buffer_smem_write =
       mparams->circular_buffer_options.smem_circular_buffer_stage > 1;
@@ -342,18 +385,23 @@ bool fillDefaultHopperHeuristic(
   int64_t Mtiles = ceilDiv(problem_shape[(size_t)MatmulDimRole::M], cta_tile.m);
   int64_t Ntiles = ceilDiv(problem_shape[(size_t)MatmulDimRole::N], cta_tile.n);
 
-  mparams->cta_order = Ntiles >= Mtiles
+  // When we choose the rasterization direction, that becomes the fast
+  // dimension. However, when we swizzle, we pull groups of a fixed size from
+  // the _other_ dimension to create a new inner dimension. We find the swizzle
+  // factor that is largest and has the least quantization when we divide that
+  // other dimension by the swizzle factor.
+  int64_t swizzled_tiles = Mtiles <= Ntiles ? Ntiles : Mtiles;
+  mparams->cta_order = Mtiles <= Ntiles
       ? MatmulParams::TileRasterizationOrder::ColumnMajor
       : MatmulParams::TileRasterizationOrder::RowMajor;
 
-  // We also swizzle the tiles as much as possible up to 4 tiles. Like choosing
+  // We also swizzle the tiles as much as possible up to 16 tiles. Like choosing
   // the rasterization order, this is used to increase L2 locality
-  mparams->grid_swizzle_factor = 4L;
-  while (Mtiles % mparams->grid_swizzle_factor != 0 ||
-         Ntiles % mparams->grid_swizzle_factor != 0) {
+  mparams->grid_swizzle_factor = std::min(swizzled_tiles, 16L);
+  while (swizzled_tiles % mparams->grid_swizzle_factor != 0) {
     // Decrease the swizzle factor if it would result in nondivisible splits,
     // since this would unnecessarily increase the grid size.
-    mparams->grid_swizzle_factor /= 2L;
+    mparams->grid_swizzle_factor--;
   }
   // TODO: grid swizzling is currently disabled on Hopper since we cannot
   // properly inline when we swizzle unmapped loop broadcasts
@@ -997,9 +1045,18 @@ std::unique_ptr<MatmulParams> getMatmulHeuristics(
     // possible.
     mparams->promote_prologue_smem_reuse = true;
 
-    // TMA allows us to avoid linear indexing
-    // TODO: verify here that we will be able to use Int32 indexing. If not,
+    // TMA allows us to nearly always avoid linear indexing.
+    // verify here that we will be able to use Int32 indexing. If not,
     // then disable use_smem_epilogue.
+    NVF_CHECK(
+        problem_shape[(size_t)MatmulDimRole::M] <=
+                std::numeric_limits<int32_t>::max() &&
+            problem_shape[(size_t)MatmulDimRole::N] <=
+                std::numeric_limits<int32_t>::max() &&
+            problem_shape[(size_t)MatmulDimRole::K] <=
+                std::numeric_limits<int32_t>::max(),
+        "Cannot safely use TMA because one of the M, N, or K dimensions overflows Int32");
+    // TODO: Setting index type like this causes launch failure
     // mparams->cparams.index_type = PrimDataType::Int32;
   }
 


### PR DESCRIPTION
On main, our default Hopper heuristic gets poor perf:
![scurve_oldheur305](https://github.com/user-attachments/assets/f92d7efb-75fa-451f-a707-21be377aab81)

This PR does some optimization to determine better tile sizes and load stages:
1) We always use instruction tile M/N equal to warp tile M/N, but warp tile K can vary from 16 to 256
2) We always use 1 or 2 math groups. When 1 math group is used the CTA tile matches the warp tile. When 2 math groups are used, the CTA tile is double the warp tile in either the M or N dimension.
3) We choose tile sizes by estimating the total amount of data transferred in the fusion, ignoring caching altogether. The configuration that minimizes bytes transferred is selected. **NOTE: currently we require all M, N, and K sizes to be multiples of 64. Other configurations are valid, but I got poor perf when enabling them.**
4) After choosing tile size, we maximize load stages, staying within the smem limits of the device.

As of d6d359be:
![scurve_newheur0306_largermacro_allmul64](https://github.com/user-attachments/assets/86033fe8-8f9e-423e-80b9-388e52c76cdc)

### Future improvements

In a future PR I would like to introduce a naive model of L2. This will be particularly useful for selecting the grid swizzle pattern.