### PR TITLE
Enable `TMABankConflictFreeTranspose`

### DIFF
--- a/tests/cpp/test_tutorial.cpp
+++ b/tests/cpp/test_tutorial.cpp
@@ -1455,7 +1455,6 @@ TEST_F(Tutorial, PointwiseBroadcastTMA) {
 }
 
 TEST_F(Tutorial, TMABankConflictFreeTranspose) {
-  GTEST_SKIP() << "This test needs new IdModel based indexing.";
   NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
 
   Fusion fusion;


### PR DESCRIPTION
Previously disabled due to lack of tensor indexer support. Tensor indexer is now fully implemented, so enable it.