### PR TITLE
Automatically save MatmulParams in extra_info in benchmarks

### DIFF
--- a/csrc/python_frontend/schedule_bindings.cpp
+++ b/csrc/python_frontend/schedule_bindings.cpp
@@ -485,6 +485,10 @@ void bindSchedule(py::class_<FusionDefinition>& fusion_def) {
         NVF_CHECK(
             self.validUse(),
             "Attempting to use a SchedOperators Op prior to definition!");
+        EnableOptionsGuard eog;
+        EnableOptionsGuard::getCurOptions().set(EnableOption::FuseMatmul);
+        DisableOptionsGuard dog;
+        DisableOptionsGuard::getCurOptions().set(DisableOption::MatmulExprEval);
         UserSchedule* sched = self.fusion_definition->userSchedule();
         HeuristicParams* parameters =
             sched->computeHeuristics(SchedulerType::Matmul);


### PR DESCRIPTION
This saves some of the MatmulParams as a flat dictionary, which makes it easy to process when converting to a dataframe for data analysis. Since this is a somewhat common thing we might like to do to enable slicing and dicing of benchmark data, we could make this more general by adding `to_dict()` methods on all our HeuristicParams classes (or better yet making them all `dataclass`es somehow?) and then adding this as an option to `run_benchmark`.