### PR TITLE
[python] return output tensors and output shardings separately

### DIFF
--- a/csrc/python_frontend/distributed_tensor.cpp
+++ b/csrc/python_frontend/distributed_tensor.cpp
@@ -13,7 +13,7 @@
 
 namespace nvfuser::python_frontend {
 
-void DistributedTensor::setAxisIsShardedOn(
+void Sharding::setAxisIsShardedOn(
     const int64_t axis,
     const ParallelType parallel_type) {
   NVF_CHECK(isParallelTypeDeviceDim(parallel_type));
@@ -28,8 +28,7 @@ void DistributedTensor::setAxisIsShardedOn(
   axis_sharded_on_[parallel_type] = axis;
 }
 
-int64_t DistributedTensor::axisShardedOn(
-    const ParallelType parallel_type) const {
+int64_t Sharding::axisShardedOn(const ParallelType parallel_type) const {
   return getOrDefault(axis_sharded_on_, parallel_type, -1L);
 }
 

--- a/csrc/python_frontend/distributed_tensor.h
+++ b/csrc/python_frontend/distributed_tensor.h
@@ -17,7 +17,7 @@ namespace nvfuser::python_frontend {
 
 class Sharding {
  public:
-  explicit Sharding(DeviceMesh mesh) : mesh_(std::move(mesh)) {}
+  explicit Sharding(DeviceMesh mesh = DeviceMesh()) : mesh_(std::move(mesh)) {}
   Sharding(const Sharding&) = delete;
   Sharding& operator=(const Sharding&) = delete;
   Sharding(Sharding&&) = default;

--- a/csrc/python_frontend/distributed_tensor.h
+++ b/csrc/python_frontend/distributed_tensor.h
@@ -15,26 +15,16 @@
 
 namespace nvfuser::python_frontend {
 
-// A class that represents a distributed tensor. It wraps a local tensor, a
-// mesh, and a mapping from mesh axes to tensor axes. If the mesh is empty,
-// it degenerates into a non-distributed tensor.
-class DistributedTensor {
+class Sharding {
  public:
-  explicit DistributedTensor(
-      at::Tensor local_tensor,
-      DeviceMesh mesh = DeviceMesh())
-      : local_(std::move(local_tensor)), mesh_(std::move(mesh)) {}
-  DistributedTensor(const DistributedTensor&) = delete;
-  DistributedTensor& operator=(const DistributedTensor&) = delete;
-  DistributedTensor(DistributedTensor&&) = default;
-  DistributedTensor& operator=(DistributedTensor&&) = default;
+  explicit Sharding(DeviceMesh mesh) : mesh_(std::move(mesh)) {}
+  Sharding(const Sharding&) = delete;
+  Sharding& operator=(const Sharding&) = delete;
+  Sharding(Sharding&&) = default;
+  Sharding& operator=(Sharding&&) = default;
 
   const DeviceMesh& mesh() const {
     return mesh_;
-  }
-
-  at::Tensor local() const {
-    return local_;
   }
 
   void setAxisIsShardedOn(int64_t axis, ParallelType parallel_type);
@@ -42,7 +32,6 @@ class DistributedTensor {
   int64_t axisShardedOn(ParallelType parallel_type) const;
 
  private:
-  at::Tensor local_;
   DeviceMesh mesh_;
   std::unordered_map<ParallelType, int64_t> axis_sharded_on_;
 };

--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -344,14 +344,56 @@ void FusionDefinition::print(std::ostream& os) const {
   os << std::endl;
 }
 
-KernelArgumentHolder FusionDefinition::execute(
-    KernelArgumentHolder args,
-    std::optional<int8_t> selected_device,
-    bool override_user_schedule,
-    bool capture_debug_output,
-    bool profile,
-    std::vector<std::string> _enable_options,
-    std::vector<std::string> _disable_options) const {
+namespace {
+// Returns the output shardings of the given fusion. As a short cut, if none of
+// the outputs have a device mesh, returns an empty vector indicating single-GPU
+// execution.
+std::vector<Sharding> getOutputShardings(Fusion* fusion) {
+  std::vector<Sharding> output_shardings;
+  if (std::none_of(
+          fusion->outputs().begin(), fusion->outputs().end(), [](Val* v) {
+            if (auto* tv = dynamic_cast<TensorView*>(v)) {
+              return tv->hasDeviceMesh();
+            }
+            return false;
+          })) {
+    return output_shardings;
+  }
+
+  output_shardings.reserve(fusion->outputs().size());
+  for (Val* out_val : fusion->outputs()) {
+    if (auto* out_tv = dynamic_cast<TensorView*>(out_val)) {
+      if (fusion->getOutputAlias(out_tv).hide_output) {
+        continue;
+      }
+      const DeviceMesh& mesh = out_tv->getDeviceMesh();
+      Sharding& output_sharding = output_shardings.emplace_back(mesh);
+      if (mesh.size() > 0) {
+        for (const ParallelType parallel_type : kParallelTypeDIDs) {
+          if (const auto axis = getShardedLogicalAxis(out_tv, parallel_type);
+              axis != -1) {
+            output_sharding.setAxisIsShardedOn(axis, parallel_type);
+          }
+        }
+      }
+    } else {
+      output_shardings.emplace_back(DeviceMesh());
+    }
+  }
+
+  return output_shardings;
+}
+} // namespace
+
+std::pair<KernelArgumentHolder, std::vector<Sharding>> FusionDefinition::
+    execute(
+        KernelArgumentHolder args,
+        std::optional<int8_t> selected_device,
+        bool override_user_schedule,
+        bool capture_debug_output,
+        bool profile,
+        std::vector<std::string> _enable_options,
+        std::vector<std::string> _disable_options) const {
   debug_output_ = std::nullopt;
   std::stringstream debug_ss;
   DebugStreamGuard dsg(capture_debug_output ? debug_ss : std::cout);
@@ -453,40 +495,22 @@ KernelArgumentHolder FusionDefinition::execute(
     debug_output_ = debug_ss.str();
   }
 
-  return outputs;
-}
-
-std::vector<Sharding> FusionDefinition::getOutputShardings() {
-  FusionSchedules* scheds = fusionCache()->queryFusionSchedules(*id());
-  FusionKernelRuntime* runtime =
-      scheds->auto_gen_schedules->getMostRecentKernelRuntime();
-  Fusion* fusion = runtime->fusionSegments()->completeFusion();
-
-  std::vector<Sharding> out_shardings;
-  out_shardings.reserve(fusion->outputs().size());
-
-  for (Val* out_val : fusion->outputs()) {
+  std::vector<Sharding> output_shardings;
+  if (user_sched == nullptr) {
+    FusionKernelRuntime* runtime =
+        scheds->auto_gen_schedules->getMostRecentKernelRuntime();
+    output_shardings =
+        getOutputShardings(runtime->fusionSegments()->completeFusion());
     NVF_ERROR(
-        out_val->isA<TensorView>(),
-        "Non tensor outputs not supported currently due to lack of support of DistributedTensor in KernelArgumentHolder");
-    auto* out_tv = out_val->as<TensorView>();
-    if (fusion->getOutputAlias(out_tv).hide_output) {
-      continue;
-    }
-
-    const DeviceMesh& mesh = out_tv->getDeviceMesh();
-    Sharding& out_sharding = out_shardings.emplace_back(mesh);
-    if (mesh.size() > 0) {
-      for (const ParallelType parallel_type : kParallelTypeDIDs) {
-        if (const auto axis = getShardedLogicalAxis(out_tv, parallel_type);
-            axis != -1) {
-          out_sharding.setAxisIsShardedOn(axis, parallel_type);
-        }
-      }
-    }
+        output_shardings.empty() || output_shardings.size() == outputs.size(),
+        "Found ",
+        output_shardings.size(),
+        " output shardings but expected ",
+        outputs.size(),
+        " or 0.");
   }
 
-  return out_shardings;
+  return std::make_pair(std::move(outputs), std::move(output_shardings));
 }
 
 std::string FusionDefinition::fusionIr() {

--- a/csrc/python_frontend/fusion_definition.h
+++ b/csrc/python_frontend/fusion_definition.h
@@ -211,7 +211,7 @@ class NVF_API FusionDefinition : public FusionState {
   //! mapping) to a field of FusionDefinition and retrieve it using another
   //! method. This would be similar to getDebugOutput. I didn't choose that
   //! because it introduced a new state in the class that could get out of sync.
-  NVF_API std::vector<DistributedTensor> execute(
+  NVF_API KernelArgumentHolder execute(
       KernelArgumentHolder inputs,
       std::optional<int8_t> device,
       bool override_user_schedule,
@@ -219,6 +219,9 @@ class NVF_API FusionDefinition : public FusionState {
       bool profile,
       std::vector<std::string> _enable_options,
       std::vector<std::string> _disable_options) const;
+
+  NVF_API std::vector<Sharding> getOutputShardings();
+
   //! Return debugging output captured through exeuction with
   //! capture_debug_output=true
   std::optional<std::string> getDebugOutput() const {

--- a/csrc/python_frontend/multidevice_bindings.cpp
+++ b/csrc/python_frontend/multidevice_bindings.cpp
@@ -76,18 +76,15 @@ void bindDeviceMesh(py::module& nvfuser) {
 }
 
 void bindDistributedTensor(py::module& nvfuser) {
-  py::class_<DistributedTensor> distributed_tensor(
-      nvfuser, "DistributedTensor");
-  distributed_tensor.def_property_readonly(
-      "local", &DistributedTensor::local, "Returns the local tensor.");
+  py::class_<Sharding> distributed_tensor(nvfuser, "Sharding");
   distributed_tensor.def_property_readonly(
       "mesh",
-      &DistributedTensor::mesh,
+      &Sharding::mesh,
       "Returns the device mesh.",
       py::return_value_policy::reference);
   distributed_tensor.def(
       "axis_sharded_on",
-      &DistributedTensor::axisShardedOn,
+      &Sharding::axisShardedOn,
       R"(
       Returns the axis sharded on the given parallel type.
 

--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -198,7 +198,7 @@ class FusionDefinition(_C._FusionDefinition):
         save_repro_inputs=False,
         _enable_options: list[str] = [],
         _disable_options: list[str] = [],
-    ) -> list[torch.Tensor | DistributedTensor]:
+    ) -> list[torch.Tensor]:
         """
         Executes an nvFuser set of kernels for a given Fusion
 
@@ -314,7 +314,7 @@ class FusionDefinition(_C._FusionDefinition):
                     "Reset the FusionCache manually to avoid reusing kernels when re-executing the fusion definition with different options."
                 )
 
-            out_tensors: list[DistributedTensor] = self._execute(
+            return self._execute(
                 inputs,
                 device=device,
                 override_user_schedule=override_user_schedule,
@@ -323,10 +323,6 @@ class FusionDefinition(_C._FusionDefinition):
                 _enable_options=_enable_options,
                 _disable_options=_disable_options,
             )
-            for i, out_tensor in enumerate(out_tensors):
-                if out_tensor.mesh.size == 0:
-                    out_tensors[i] = out_tensor.local
-            return out_tensors
         except Exception as err:
             logger.exception(self._repro_error_str("executing", inputs))
             raise

--- a/tests/python/test_communication.py
+++ b/tests/python/test_communication.py
@@ -41,7 +41,7 @@ def test_allgather(multidevice_test):
     sharded = multidevice_test.shard_tensor(unsharded, 0, mesh)
 
     fd = Model()
-    (output,) = fd.execute([sharded])
+    (output,), _ = fd.execute([sharded])
     torch.testing.assert_close(output.cpu(), unsharded)
 
 
@@ -81,7 +81,7 @@ def test_allreduce(multidevice_test):
     sharded = multidevice_test.shard_tensor(unsharded, 1, mesh)
 
     fd = Model()
-    outputs = fd.execute([sharded])
+    outputs, _ = fd.execute([sharded])
     torch.testing.assert_close(outputs[0].cpu(), unsharded.sum(1))
 
 
@@ -112,7 +112,7 @@ def test_reduce_scatter(multidevice_test):
     sharded = multidevice_test.shard_tensor(unsharded, 0, mesh)
 
     fd = Model()
-    (output,) = fd.execute([sharded])
+    (output,), _ = fd.execute([sharded])
     torch.testing.assert_close(
         output, multidevice_test.shard_tensor(unsharded.sum(0), 0, mesh)
     )
@@ -154,7 +154,7 @@ def test_reduce_scatter_noncontiguous(multidevice_test):
     sharded = multidevice_test.shard_tensor(unsharded, 0, mesh)
 
     fd = Model()
-    (output,) = fd.execute([sharded])
+    (output,), _ = fd.execute([sharded])
     torch.testing.assert_close(
         output, multidevice_test.shard_tensor(unsharded.sum(0), 1, mesh)
     )

--- a/tests/python/test_communication.py
+++ b/tests/python/test_communication.py
@@ -42,7 +42,7 @@ def test_allgather(multidevice_test):
 
     fd = Model()
     (output,) = fd.execute([sharded])
-    torch.testing.assert_close(output.local.cpu(), unsharded)
+    torch.testing.assert_close(output.cpu(), unsharded)
 
 
 @pytest.mark.mpi
@@ -82,7 +82,7 @@ def test_allreduce(multidevice_test):
 
     fd = Model()
     outputs = fd.execute([sharded])
-    torch.testing.assert_close(outputs[0].local.cpu(), unsharded.sum(1))
+    torch.testing.assert_close(outputs[0].cpu(), unsharded.sum(1))
 
 
 @pytest.mark.mpi
@@ -114,7 +114,7 @@ def test_reduce_scatter(multidevice_test):
     fd = Model()
     (output,) = fd.execute([sharded])
     torch.testing.assert_close(
-        output.local, multidevice_test.shard_tensor(unsharded.sum(0), 0, mesh)
+        output, multidevice_test.shard_tensor(unsharded.sum(0), 0, mesh)
     )
 
 
@@ -156,5 +156,5 @@ def test_reduce_scatter_noncontiguous(multidevice_test):
     fd = Model()
     (output,) = fd.execute([sharded])
     torch.testing.assert_close(
-        output.local, multidevice_test.shard_tensor(unsharded.sum(0), 1, mesh)
+        output, multidevice_test.shard_tensor(unsharded.sum(0), 1, mesh)
     )

--- a/tests/python/test_dtensor.py
+++ b/tests/python/test_dtensor.py
@@ -79,8 +79,7 @@ class FusionDefinitionWrapper:
         fusion_def = self._create_fusion_definition(in_dtensors)
 
         in_tensors = [in_dtensor.to_local() for in_dtensor in in_dtensors]
-        out_tensors = fusion_def.execute(in_tensors)
-        out_shardings = fusion_def.get_output_shardings()
+        out_tensors, out_shardings = fusion_def.execute(in_tensors)
         assert len(out_tensors) == len(out_shardings)
 
         out_dtensors: list[DTensor] = []

--- a/tests/python/test_multidevice.py
+++ b/tests/python/test_multidevice.py
@@ -38,7 +38,7 @@ def test_pointwise(multidevice_test):
     class Model(FusionDefinition):
         def definition(self):
             self.t0 = self.define_tensor(
-                (-1, -1), contiguity=(False, False), dtype=DataType.Float
+                (-1, -1), contiguity=False, dtype=DataType.Float
             )
             self.t1 = self.ops.relu(self.t0)
             self.t2 = self.ops.add(self.t1, self.t1)
@@ -55,8 +55,9 @@ def test_pointwise(multidevice_test):
 
     fd = Model()
     (output,) = fd.execute([sharded_input])
-    torch.testing.assert_close(output.local.cpu(), unsharded_input.relu() * 2)
-    assert output.axis_sharded_on(nvfuser.ParallelType.mesh_x) == -1
+    (output_sharding,) = fd.get_output_shardings()
+    torch.testing.assert_close(output.cpu(), unsharded_input.relu() * 2)
+    assert output_sharding.axis_sharded_on(nvfuser.ParallelType.mesh_x) == -1
 
 
 @pytest.mark.mpi
@@ -72,8 +73,8 @@ def test_linear(multidevice_test):
         def definition(self):
             d, b, s, e = self._num_devices, self._batch, self._sequence, self._hidden
             self.inp = self.define_tensor([b, s, e])
-            self.weight = self.define_tensor([d, e, e], contiguity=[True, True, True])
-            self.bias = self.define_tensor([d, e], contiguity=[True, True])
+            self.weight = self.define_tensor([d, e, e], contiguity=True)
+            self.bias = self.define_tensor([d, e], contiguity=True)
             out = self.ops.linear(self.inp, self.weight, self.bias)
             self.add_output(out)
 
@@ -98,6 +99,7 @@ def test_linear(multidevice_test):
 
     fd = Model(d, b, s, e)
     (out_tensor,) = fd.execute([inp_tensor, weight_tensor, bias_tensor])
+    (out_sharding,) = fd.get_output_shardings()
 
     # [b, s, d*e]
     unsharded_out_tensor = torch.nn.functional.linear(
@@ -107,10 +109,8 @@ def test_linear(multidevice_test):
         rank : rank + 1
     ]
     # rtol is the same as the default for fp32. atol is slightly increased.
-    assert out_tensor.axis_sharded_on(nvfuser.ParallelType.mesh_x) == 0
-    torch.testing.assert_close(
-        out_tensor.local, expected_out_tensor, rtol=1.3e-6, atol=1e-3
-    )
+    assert out_sharding.axis_sharded_on(nvfuser.ParallelType.mesh_x) == 0
+    torch.testing.assert_close(out_tensor, expected_out_tensor, rtol=1.3e-6, atol=1e-3)
 
 
 @pytest.mark.mpi
@@ -162,9 +162,7 @@ def test_linear_loop_split(multidevice_test):
     )
     expected_out_tensor = multidevice_test.shard_tensor(unsharded_out_tensor, -1, mesh)
     # rtol is the same as the default for fp32. atol is slightly increased.
-    torch.testing.assert_close(
-        out_tensor.local, expected_out_tensor, rtol=1.3e-6, atol=1e-3
-    )
+    torch.testing.assert_close(out_tensor, expected_out_tensor, rtol=1.3e-6, atol=1e-3)
 
 
 @pytest.mark.mpi
@@ -214,9 +212,7 @@ def test_matmul_allreduce(multidevice_test):
     (in_grad,) = fd.execute([out_grad.cuda(), weight.cuda()])
     # Use the default rtol for half because the output, although being float32,
     # is a straight cast from half.
-    torch.testing.assert_close(
-        in_grad.local.cpu(), expected_in_grad, rtol=1e-3, atol=1e-2
-    )
+    torch.testing.assert_close(in_grad.cpu(), expected_in_grad, rtol=1e-3, atol=1e-2)
 
 
 @pytest.mark.mpi
@@ -263,7 +259,7 @@ def test_matmul_loop_split(multidevice_test):
     expected_out_tensor = multidevice_test.shard_tensor(unsharded_out_tensor, -1, mesh)
     # rtol is the same as the default for fp32. atol is slightly increased.
     torch.testing.assert_close(
-        out_tensor.local, expected_out_tensor.squeeze(0), rtol=1.3e-6, atol=1e-3
+        out_tensor, expected_out_tensor.squeeze(0), rtol=1.3e-6, atol=1e-3
     )
 
 
@@ -319,7 +315,7 @@ def test_matmul_allreduce_loop_split(multidevice_test):
     fd = Model()
     (out,) = fd.execute([sharded_inp, sharded_weight])
 
-    torch.testing.assert_close(out.local.cpu(), expected_out, rtol=1e-3, atol=1e-2)
+    torch.testing.assert_close(out.cpu(), expected_out, rtol=1e-3, atol=1e-2)
 
 
 class QkvFormat(Enum):
@@ -433,15 +429,15 @@ def test_sdpa(multidevice_test, qkv_format: QkvFormat):
     )
     out, q_grad, k_grad, v_grad = outs
 
-    def assert_close(actual: nvfuser.DistributedTensor, expected: torch.Tensor):
+    def assert_close(actual: torch.Tensor, expected: torch.Tensor) -> None:
         match qkv_format:
             case QkvFormat.BHSE:
-                assert actual.local.is_contiguous()
+                assert actual.is_contiguous()
             case QkvFormat.BSHE:
-                assert actual.local.transpose(2, 3).is_contiguous()
+                assert actual.transpose(2, 3).is_contiguous()
 
         # Use the default rtol for bfloat16 and a relaxed atol.
-        torch.testing.assert_close(actual.local, expected, rtol=1.6e-2, atol=1e-2)
+        torch.testing.assert_close(actual, expected, rtol=1.6e-2, atol=1e-2)
 
     assert_close(out, head_parallelize(expected_out))
     assert_close(q_grad, head_parallelize(expected_q_grad))
@@ -582,13 +578,13 @@ def test_sdpa_loop_split(multidevice_test, qkv_format: QkvFormat):
     def assert_close(actual, expected):
         match qkv_format:
             case QkvFormat.BHSE:
-                assert actual.local.is_contiguous()
+                assert actual.is_contiguous()
             case QkvFormat.BSHE:
-                assert actual.local.transpose(1, 2).is_contiguous()
+                assert actual.transpose(1, 2).is_contiguous()
 
         # Use the default rtol for bfloat16 and a relaxed atol.
         torch.testing.assert_close(
-            actual.local,
+            actual,
             multidevice_test.shard_tensor(expected, 1, mesh),
             rtol=1.6e-2,
             atol=1e-2,
@@ -995,10 +991,10 @@ class TransformerForwardFusion(FusionDefinition):
 # TODO(#2962): validate the numbers as well. Currently, the numbers are off
 # by a lot, making comparison infeasible.
 def _assert_shape_dtype(
-    t: nvfuser.DistributedTensor, expected_sizes: list[int], expected_dtype: torch.dtype
+    t: torch.Tensor, expected_sizes: list[int], expected_dtype: torch.dtype
 ) -> None:
-    assert t.local.shape == torch.Size(expected_sizes)
-    assert t.local.dtype == expected_dtype
+    assert t.shape == torch.Size(expected_sizes)
+    assert t.dtype == expected_dtype
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
[Unpacking](https://github.com/NVIDIA/Fuser/blob/22d4f9702ea4a13028776b63e5ca39fcf8d3edc1/nvfuser/__init__.py#L328) in Python is apparently slow. 

This PR changes FusionDefinition.execute to return the output tensors and the output shardings separately. This way, single-GPU programs don't pay the overhead of packing/unpacking shardings. 

As a side benefit, this allows FusionDefinition::execute to return KernelArgumentHolder, making it possible for FusionDefinition.execute to return scalars. 