### PR TITLE
Don't revert upcast for persistent schedulers to avoid increasing persistent buffer sizes

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -4838,9 +4838,10 @@ void SegmentCandidateFinder::finalize() {
   for (auto group : segmented_fusion_->groups()) {
     auto scheduler_type = group->schedulerType();
     // If the pre-upcasted tensor is a persistent buffer, revert privatized
-    // upcast changes the persistent tensor from the pre-upcasted tensor (e.g.
-    // bool) to the post-upcasted tensor (e.g. float) may leads a fusion can't
-    // be scheduled by persistent schedulders due to this increased buffer size.
+    // upcast may change the persistent tensor from the pre-upcasted type (e.g.,
+    // bool) to the post-upcasted type (e.g., float), which can increase buffer
+    // size. This increase may prevent the fusion from being scheduled by
+    // persistent schedulers.
     if (scheduler_type == SchedulerType::InnerPersistent ||
         scheduler_type == SchedulerType::OuterPersistent ||
         scheduler_type == SchedulerType::InnerOuterPersistent) {

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -4484,7 +4484,6 @@ void SegmentCandidateFinder::forwardInputs() {
       // Either way, `uop` is excluded from merging until
       // `resolveNonscalarForwardedInput` adds it back to one of the segments.
       excluded_inp_unary_exprs_.pushBack(uop);
-      std::cout << "Excluded unary expr: " << uop->toString() << std::endl;
     }
   }
 

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -4484,6 +4484,7 @@ void SegmentCandidateFinder::forwardInputs() {
       // Either way, `uop` is excluded from merging until
       // `resolveNonscalarForwardedInput` adds it back to one of the segments.
       excluded_inp_unary_exprs_.pushBack(uop);
+      std::cout << "Excluded unary expr: " << uop->toString() << std::endl;
     }
   }
 
@@ -4828,19 +4829,26 @@ void SegmentCandidateFinder::finalize() {
   //  finalize. Need to re-structure in a follow up.
 
   // Finalize connections between segmented groups
-  segmented_fusion_->finalize();
+  // segmented_fusion_->finalize();
 
   // Resolve all the scalar expressions needed in each group
-  for (auto group : segmented_fusion_->groups()) {
-    resolveScalarsInGroup(group);
-  }
+  // for (auto group : segmented_fusion_->groups()) {
+  //   resolveScalarsInGroup(group);
+  // }
 
-  for (auto group : segmented_fusion_->groups()) {
-    revertPrivatizedUpcast(group);
-  }
+  // for (auto group : segmented_fusion_->groups()) {
+  //   revertPrivatizedUpcast(group);
+  // }
 
   // Finalize each group, fill in the missing inputs, i.e. tensor dims.
   for (auto g : groups()) {
+    std::cout << "\nFinalizing group inputs:\n";
+    for(auto val: g->input_vals) {
+      std::cout << val->toString() << std::endl;
+    }
+    std::cout << "group: " << g->groupId() << std::endl;
+    g->print();
+
     g->setSchedulerType(deriveSchedulerType(g));
     g->finalize();
   }


### PR DESCRIPTION
**Change:**
Don't revert upcast for persistent schedulers to avoid increasing persistent buffer sizes

**Influence:**
Fix test `mpirun -np 1 pytest tests/python/test_multidevice.py --only-mpi -s -k transformer_backward`
Before:
```
T62_l_float[bS202{1}, iS203{2048}, iS204{12288}] (DeviceMesh{0})
   = (float)(T60_g_bool[bS196{1}, iS197{2048}, iS198{12288}] (DeviceMesh{0}));
Use T62_l_float as persistent buffer
```
After:
```
T286_l_float[bS907{1}, iS908{2048}, iS909{12288}] (DeviceMesh{0})
   = (float)(T60_g_bool[bS196{1}, iS197{2048}, iS198{12288}] (DeviceMesh{0}));
T62_l_float[bS202{1}, iS203{2048}, iS204{12288}] (DeviceMesh{0})
   = (float)(T60_g_bool[bS196{1}, iS197{2048}, iS198{12288}] (DeviceMesh{0}));
Use T60_g_bool as persistent buffer
```