### PR TITLE
Avoid redundant integer conversion in Python `FusionDefinition.execute()`

### DIFF
--- a/nvfuser/__init__.py
+++ b/nvfuser/__init__.py
@@ -251,7 +251,7 @@ class FusionDefinition(_C._FusionDefinition):
         """
         self.profiled = profile
 
-        if device is not None:
+        if not isinstance(device, int) and device is not None:
             if not isinstance(device, torch.device):
                 device = torch.device(device)
             assert (


### PR DESCRIPTION
Small change in python execute function to avoid setting a torch.device call with an integer and then converting back to an integer.