### PR TITLE
getOutputShardings checks all TVs to decide single-GPU vs multi-GPU

### DIFF
--- a/csrc/python_frontend/fusion_definition.cpp
+++ b/csrc/python_frontend/fusion_definition.cpp
@@ -349,17 +349,15 @@ namespace {
 // the outputs have a device mesh, returns an empty vector indicating single-GPU
 // execution.
 std::vector<Sharding> getOutputShardings(Fusion* fusion) {
-  std::vector<Sharding> output_shardings;
+  std::vector<TensorView*> all_tvs = fusion->allTvs();
   if (std::none_of(
-          fusion->outputs().begin(), fusion->outputs().end(), [](Val* v) {
-            if (auto* tv = dynamic_cast<TensorView*>(v)) {
-              return tv->hasDeviceMesh();
-            }
-            return false;
-          })) {
-    return output_shardings;
+          all_tvs.begin(),
+          all_tvs.end(),
+          std::mem_fn(&TensorView::hasDeviceMesh))) {
+    return {};
   }
 
+  std::vector<Sharding> output_shardings;
   output_shardings.reserve(fusion->outputs().size());
   for (Val* out_val : fusion->outputs()) {
     if (auto* out_tv = dynamic_cast<TensorView*>(out_val)) {


### PR DESCRIPTION
We could in the future have a scalar-in-scalar-out fusion with some intermediate TensorViews being sharded. This is to make the check robust against that.