### PR TITLE
Fix segmenter complexity in resetLevels

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -2087,7 +2087,7 @@ void SegmentCandidateFinder::resetLevels() {
   // The solution to this is to start from expressions where all producer edges
   // are inputs.
 
-  // Mark all input groups as viisted and mark their level as 0
+  // Mark all input groups as visited and mark their level as 0
   // Initialize all other groups as not visited and level as 0
   for (auto group : groups()) {
     group->level_ = 0;
@@ -2114,8 +2114,7 @@ void SegmentCandidateFinder::resetLevels() {
       continue;
     }
 
-    if (visiting->producer_edges.size() > 0 &&
-        std::any_of(
+    if (std::any_of(
             visiting->producer_edges.begin(),
             visiting->producer_edges.end(),
             [&](SegmentedEdge* dep) { return !dep->from->visited_; })) {

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -564,8 +564,6 @@ class SegmentCandidateFinder {
       SegmentCandidateFinderOptions options,
       bool multi_device = false);
 
-  void resetTraversal();
-
   void resetLevels();
 
   SegmentedGroup* mergeNodes();
@@ -713,9 +711,6 @@ class SegmentCandidateFinder {
 
   //! options to configure and debug the segment process
   SegmentCandidateFinderOptions options_;
-
-  std::deque<SegmentedGroup*> to_visit_;
-  std::vector<SegmentedGroup*> next_to_visit_;
 
   std::unordered_set<SegmentedGroup*> clean_up_groups_;
   std::unordered_set<SegmentedEdge*> clean_up_edges_;


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/Fuser/issues/3510 
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/1490

With the repro from https://github.com/Lightning-AI/lightning-thunder/issues/1490 and n_layers=25 this PR takes it the time from 28.7s to 4.9s

There were two problems in `SegmentCandidateFinder::resetLevels` compounding to get terrible algorithmic complexity.
First is that there was n^2 traversal of the graph due to the way started the traversal, the second was we would reprocess nodes after they would be visited, adding in other nodes as they would be visited. I haven't even tried to figure out how bad the complexity is between the two, but given the timings above and how simple this function is supposed to be it's easy to imagine it was really bad.

Before this PR:
```
     13.4      26447598997          1  26447598997.0  26447598997.0  26447598997  26447598997           0.0  PushPop  :FusionExecutorCache::runFusionWithInputs
     12.8      25395216514          1  25395216514.0  25395216514.0  25395216514  25395216514           0.0  PushPop  :FusionExecutorCache::getKernelRuntimeFor
     12.8      25395214402          1  25395214402.0  25395214402.0  25395214402  25395214402           0.0  PushPop  :FusionExecutorCache::getKernelRuntimeFor::compileNewKRT
     12.8      25394183421          1  25394183421.0  25394183421.0  25394183421  25394183421           0.0  PushPop  :FusionKernelRuntime::FusionKernelRuntime
     12.8      25249969392          1  25249969392.0  25249969392.0  25249969392  25249969392           0.0  PushPop  :Finding valid fusion segment solutions
     12.6      24909782451          2  12454891225.5  12454891225.5  10389280887  14520501564  2921214155.3  PushPop  :SegmentCandidateFinder::resetLevels
      3.7       7335628950         52    141069787.5     87085662.5      2009233    916902441   164966544.8  PushPop  :FusionKernelRuntime::compileFusionParallel
      3.2       6360149903         51    124708821.6     38573044.0      2004428    319391178   124308431.2  PushPop  :FusionKernelRuntime::compileKernel
      3.0       6004675361         51    117738732.6     16435979.0      1047101    312578444   121517087.8  PushPop  :ExecutorDispatch::compile2
      3.0       5896441165         25    235857646.6    239232680.0    100924377    312577050    47182247.8  PushPop  :KernelExecutor::compile
      2.8       5524488781         25    220979551.2    229170835.0     61309814    300694497    54677924.8  PushPop  :CompiledKernel::compile
      2.8       5513213651         25    220528546.0    228974177.0     60260059    299958523    54927401.8  PushPop  :executor_utils::NVRTC
```

After adding:

```
if(visit->visited_) {
     continue;
}
```

to `resetLevels`.
```
       Time (%)  Total Time (ns)  Instances    Avg (ns)      Med (ns)     Min (ns)    Max (ns)   StdDev (ns)   Style                                  Range
 --------  ---------------  ---------  ------------  ------------  ----------  ----------  -----------  -------  -------------------------------------------------------------------
     14.9       7294178175         52   140272657.2    87229392.0     2045091   913980957  164587781.8  PushPop  :FusionKernelRuntime::compileFusionParallel
     13.0       6364187621         51   124787992.6    45193614.0     2039199   317727663  124180298.0  PushPop  :FusionKernelRuntime::compileKernel
     12.3       6028001899         51   118196115.7    24803988.0     1066330   306593000  121456535.4  PushPop  :ExecutorDispatch::compile2
     12.1       5922614608         25   236904584.3   238780752.0   109983950   306591844   43550603.9  PushPop  :KernelExecutor::compile
     11.3       5511183407         25   220447336.3   228665078.0    68501777   294961692   51986834.7  PushPop  :CompiledKernel::compile
     11.2       5478911725         25   219156469.0   228450712.0    64438383   294228549   53733578.6  PushPop  :executor_utils::NVRTC
     11.2       5473327778         25   218933111.1   228285238.0    63876781   293953370   53812159.4  PushPop  :executor_utils::Nvrtc::CompileProgram
     ...
      0.0            16710          2        8355.0        8355.0        6844        9866       2136.9  PushPop  :SegmentCandidateFinder::resetLevels
     ...      
```

After this PR:
```
     14.5       7254234573         52   139504511.0    76337080.5     1967126   908701792  163994898.0  PushPop  :FusionKernelRuntime::compileFusionParallel
     12.6       6304263164         51   123613003.2    38262907.0     1961977   316095090  123739242.8  PushPop  :FusionKernelRuntime::compileKernel
     12.0       5979988551         51   117254677.5    18344057.0     1038455   309230974  121047885.3  PushPop  :ExecutorDispatch::compile2
     11.8       5880748784         25   235229951.4   238802458.0    90125951   309229997   45371595.9  PushPop  :KernelExecutor::compile
     11.0       5479491369         25   219179654.8   228475628.0    60414068   297299621   53836046.8  PushPop  :CompiledKernel::compile
     10.9       5468891995         25   218755679.8   228271070.0    59378263   296589538   54059620.4  PushPop  :executor_utils::NVRTC
     10.9       5462278716         25   218491148.6   228096477.0    58236348   296302474   54226976.9  PushPop  :executor_utils::Nvrtc::CompileProgram
     ...
     0.0             6233          2        3116.5        3116.5        2793        3440        457.5  PushPop  :SegmentCandidateFinder::resetLevels
     ...
```