### PR TITLE
Reuse resetLevels to validateDAG of segmented fusion.

### DIFF
--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -377,12 +377,6 @@ class SegmentedFusion {
   //! Grab edges with val
   std::vector<SegmentedEdge*> getEdgesByVal(Val* val) const;
 
-  //! Make sure it's a DAG and optionally disjoint
-  void validate(bool require_disjoint = true) const;
-
-  //! Same as validate but only enabled when NDEBUG is undefined
-  void validateIfDebug(bool require_disjoint = true) const;
-
   //! Serialize SegmentedFusion using flatbuffers
   flatbuffers::Offset<serde::SegmentedFusion> serialize(
       flatbuffers::FlatBufferBuilder& builder) const;
@@ -390,10 +384,9 @@ class SegmentedFusion {
   //! Deserialize SegmentedFusion using flatbuffers
   void deserialize(const serde::SegmentedFusion* buffer);
 
- private:
-  void validateDAG() const;
   void validateDisjoint() const;
 
+ private:
   //! Serialize SegmentedEdge using flatbuffers
   flatbuffers::Offset<serde::SegmentedEdge> serialize(
       flatbuffers::FlatBufferBuilder& builder,
@@ -555,6 +548,10 @@ class SegmentCandidateFinder {
   NVF_API static bool translateWelfordInFusion(
       Fusion* fusion,
       const KernelArgumentHolder& runtime_inputs);
+
+  //! Validate the graph is a DAG, and if require_disjoint that exprs are
+  //! disjoint
+  void validateIfDebug(bool require_disjoint = false);
 
  private:
   // Perform segmentation on and take ownership of the given fusion

--- a/tests/cpp/test_resharding.cpp
+++ b/tests/cpp/test_resharding.cpp
@@ -64,7 +64,7 @@ class ReshardingTest : public NVFuserFixtureParamTest<ReshardingTestParams> {
     }
     // checks that the segments are disjoints and that the graph of segment is
     // acyclic
-    segmented_fusion->validate();
+    segmented_fusion->validateDisjoint();
   }
 
   std::unique_ptr<Fusion> fusion_;


### PR DESCRIPTION
Similar to how resetLevels had relatively poor complexity and performance the validateDAG pass in fusion segmenter also does, it's not as bad, but scales poorly when trying to get a full llama model into nvFuser.

Should be merged after https://github.com/NVIDIA/Fuser/pull/4049

For https://github.com/kevinstephano/thunder_model_blocks
`python thunder_model_blocks/llama/llama_model_inference.py --execs Thunder-nvFuser-more-ops`
with `config.num_hidden_layers=5`:

Before using resetLevels to check DAG:
```
 Time (%)  Total Time (ns)  Instances    Avg (ns)       Med (ns)      Min (ns)     Max (ns)    StdDev (ns)   Style                                  Range
 --------  ---------------  ---------  -------------  -------------  -----------  -----------  -----------  -------  -------------------------------------------------------------------
     10.5      55103857302          1  55103857302.0  55103857302.0  55103857302  55103857302          0.0  PushPop  :Executor: Thunder-nvFuser-more-ops
      9.6      50320724315          1  50320724315.0  50320724315.0  50320724315  50320724315          0.0  PushPop  :FusionExecutorCache::runFusionWithInputs
      9.3      48491137722          1  48491137722.0  48491137722.0  48491137722  48491137722          0.0  PushPop  :FusionExecutorCache::getKernelRuntimeFor
      9.3      48491135867          1  48491135867.0  48491135867.0  48491135867  48491135867          0.0  PushPop  :FusionExecutorCache::getKernelRuntimeFor::compileNewKRT
      9.3      48483689725          1  48483689725.0  48483689725.0  48483689725  48483689725          0.0  PushPop  :FusionKernelRuntime::FusionKernelRuntime
      9.0      47113745496          1  47113745496.0  47113745496.0  47113745496  47113745496          0.0  PushPop  :SegmentCandidateFinder::SegmentCandidateFinder
      9.0      47091624356          1  47091624356.0  47091624356.0  47091624356  47091624356          0.0  PushPop  :SegmentCandidateFinder::findSegments
      6.8      35486705067          1  35486705067.0  35486705067.0  35486705067  35486705067          0.0  PushPop  :SegmentCandidateFinder::validate
      6.8      35486684286          1  35486684286.0  35486684286.0  35486684286  35486684286          0.0  PushPop  :SegmentCandidateFinder::validateDAG
      2.4      12625926073         88    143476432.6     24254055.5     15488383   1568292216  200711019.4  PushPop  :FusionKernelRuntime::compileFusionParallel
      2.1      11051048830         87    127023549.8     24034735.0     15481031    488028368  129875267.8  PushPop  :FusionKernelRuntime::compileKernel
      1.8       9636561644       2679      3597074.1      1250097.0       272517     72463842    6631266.6  PushPop  :SegmentCandidateFinder::codeGenSupportedMerge
      1.7       9056089754         87    104092985.7     13871575.0      8471553    349467809  113577226.6  PushPop  :ExecutorDispatch::compile2
      1.6       8426477239         36    234068812.2    233749092.0    106861664    349465542   44473827.9  PushPop  :KernelExecutor::compile
      1.2       6355882012      31010       204962.3        19359.5          100      4837863     428004.7  PushPop  :registry.cpp::checkCanSchedule<T>
      1.2       6157328806       1611      3822053.9          683.0           97     70120260   12710465.4  PushPop  :SegmentCandidateFinder::trySetUpMerge
      1.2       6136876446         36    170468790.2    179046023.5     79149889    227741033   27126415.2  PushPop  :CompiledKernel::compile
      1.2       6110348786         36    169731910.7    178234129.5     77481131    227245174   27327495.4  PushPop  :executor_utils::NVRTC
```

After using resetLevels from https://github.com/NVIDIA/Fuser/pull/4049 to check DAG:
```
 Time (%)  Total Time (ns)  Instances    Avg (ns)       Med (ns)      Min (ns)     Max (ns)    StdDev (ns)   Style
 --------  ---------------  ---------  -------------  -------------  -----------  -----------  -----------  -------  -------------------------------------------------------------------
      9.6      19684746835          1  19684746835.0  19684746835.0  19684746835  19684746835          0.0  PushPop  :Executor: Thunder-nvFuser-more-ops
      7.3      14909718567          1  14909718567.0  14909718567.0  14909718567  14909718567          0.0  PushPop  :FusionExecutorCache::runFusionWithInputs
      6.3      12986643712          1  12986643712.0  12986643712.0  12986643712  12986643712          0.0  PushPop  :FusionExecutorCache::getKernelRuntimeFor
      6.3      12986641416          1  12986641416.0  12986641416.0  12986641416  12986641416          0.0  PushPop  :FusionExecutorCache::getKernelRuntimeFor::compileNewKRT
      6.3      12979412299          1  12979412299.0  12979412299.0  12979412299  12979412299          0.0  PushPop  :FusionKernelRuntime::FusionKernelRuntime
      6.2      12755178109         88    144945205.8     26049386.5     15039160   1580001915  202243409.5  PushPop  :FusionKernelRuntime::compileFusionParallel
      5.6      11594217473          1  11594217473.0  11594217473.0  11594217473  11594217473          0.0  PushPop  :SegmentCandidateFinder::SegmentCandidateFinder
      5.6      11571405726          1  11571405726.0  11571405726.0  11571405726  11571405726          0.0  PushPop  :SegmentCandidateFinder::findSegments
      5.4      11163339750         87    128314250.0     25650141.0     15030676    494135338  130806929.4  PushPop  :FusionKernelRuntime::compileKernel
      4.7       9611666196       2679      3587781.3      1237413.0       276184     72878966    6624298.5  PushPop  :SegmentCandidateFinder::codeGenSupportedMerge
      4.4       9124969377         87    104884705.5     15544430.0      8289242    349583864  114744503.0  PushPop  :ExecutorDispatch::compile2
      4.1       8456936454         36    234914901.5    236358121.0    102008150    349582519   50417257.5  PushPop  :KernelExecutor::compile
      3.1       6311851980      31010       203542.5        18832.5           98      4485237     425721.1  PushPop  :registry.cpp::checkCanSchedule<T>
      3.0       6157499337         36    171041648.3    180701101.5     70034341    222618788   30773984.7  PushPop  :CompiledKernel::compile
      3.0       6136807446       1611      3809315.6          686.0           95     70305466   12674628.6  PushPop  :SegmentCandidateFinder::trySetUpMerge
      3.0       6132971152         36    170360309.8    180052942.5     67962359    222372913   30958997.0  PushPop  :executor_utils::NVRTC

```
