### PR TITLE
Add a backprop test

### DIFF
--- a/tests/python/test_deepseek_v3.py
+++ b/tests/python/test_deepseek_v3.py
@@ -28,8 +28,12 @@ def test_transformer_layer():
     config = transformers.AutoConfig.from_pretrained(
         "deepseek-ai/deepseek-v3", trust_remote_code=True
     )
+
+    # Create only one layer which is sufficient for the test.
     config.num_hidden_layers = 1
+    # Without this, the first and only layer will have a dense MLP instead of MoE.
     config.first_k_dense_replace = 0
+    # Disable quantization so the test can run on A100 and is made easier for nvFuser.
     delattr(config, "quantization_config")
 
     with default_tensor_type(dtype=config.torch_dtype, device="cuda"):

--- a/tests/python/test_deepseek_v3.py
+++ b/tests/python/test_deepseek_v3.py
@@ -44,7 +44,7 @@ def test_transformer_layer():
         transformer_layer = model.layers[0]
 
         batch_size = 1
-        seq_len = 4096
+        seq_len = 2048
         inp = torch.randn(batch_size, seq_len, config.hidden_size)
         mask = transformers.modeling_attn_mask_utils._prepare_4d_causal_attention_mask(
             None, [batch_size, seq_len], inp, past_key_values_length=0
@@ -52,5 +52,5 @@ def test_transformer_layer():
         (out,) = transformer_layer(inp, attention_mask=mask)
 
         assert out.size() == (batch_size, seq_len, config.hidden_size)
-        assert out.dtype == torch.bfloat16
+        assert out.dtype == config.torch_dtype
         assert out.is_cuda

--- a/tests/python/test_deepseek_v3.py
+++ b/tests/python/test_deepseek_v3.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+import pytest
+import torch
+import urllib.request
+from contextlib import contextmanager
+
+
+def download_as_module(url, module_name):
+    urllib.request.urlretrieve(url, f"{module_name}.py")
+
+
+@pytest.fixture(scope="module")
+def model():
+    download_as_module(
+        "https://huggingface.co/deepseek-ai/DeepSeek-V3/resolve/main/inference/kernel.py",
+        "kernel",
+    )
+    download_as_module(
+        "https://huggingface.co/deepseek-ai/DeepSeek-V3/resolve/main/inference/model.py",
+        "deepseek_v3_model",
+    )
+    import deepseek_v3_model
+
+    yield deepseek_v3_model
+
+    del deepseek_v3_model
+
+    os.remove("deepseek_v3_model.py")
+    os.remove("kernel.py")
+
+
+@contextmanager
+def default_tensor_type(dtype=torch.float32, device="cpu"):
+    # Save
+    prev_dtype = torch.get_default_dtype()
+    prev_device = torch.get_default_device()
+
+    # Set
+    torch.set_default_dtype(dtype)
+    torch.set_default_device(device)
+
+    yield
+
+    # Restore
+    torch.set_default_dtype(prev_dtype)
+    torch.set_default_device(prev_device)
+
+
+def test_transformer_block(model):
+    args = model.ModelArgs(dim=7168)
+
+    dtype = torch.float8_e4m3fn if args.dtype == "fp8" else torch.bfloat16
+    with default_tensor_type(dtype=dtype, device="cuda"):
+        transformer_block = model.Block(10, args)
+
+        batch_size = 1
+        assert batch_size <= args.max_batch_size
+        seq_len = 4096
+        assert seq_len <= args.max_seq_len
+        inp = torch.randn(batch_size, seq_len, args.dim)
+        start_pos = 0
+        freq_cis = model.precompute_freqs_cis(args)
+        mask = torch.full((seq_len, seq_len), float("-inf")).triu_(1)
+
+    out = transformer_block(
+        inp, start_pos, freq_cis[start_pos : start_pos + seq_len], mask
+    )
+    assert out.size() == (batch_size, seq_len, args.dim)
+    assert out.dtype == torch.bfloat16
+    assert out.is_cuda


### PR DESCRIPTION
It requires a patch to run and therefore xfails by default. However,
it's still useful to run backprop with a patch to collect shapes and
layouts.
