### PR TITLE
Fix C++23 backport of `zip` and `enumerate`

### DIFF
--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -19,6 +19,8 @@
 #include <type.h>
 
 #include <c10/core/thread_pool.h>
+
+#include <concepts>
 #include <deque>
 #include <iterator>
 #include <memory>
@@ -621,86 +623,187 @@ void checkAllEqual(std::initializer_list<T> elements) {
 
 #if __cplusplus >= 202302L
 
+using std::views::enumerate;
 using std::views::zip;
 
 #else
 
 namespace views {
-
-template <std::ranges::input_range... Rs>
+template <std::ranges::view... Rs>
 class zip_view : public std::ranges::view_interface<zip_view<Rs...>> {
  private:
   std::tuple<Rs...> bases;
 
-  // Iterator for begin()
-  struct begin_iterator {
+  static constexpr bool is_bidirectional = (std::ranges::bidirectional_range<Rs> && ...);
+
+  struct iterator {
     std::tuple<std::ranges::iterator_t<Rs>...> iterators;
 
     using value_type = std::tuple<std::ranges::range_value_t<Rs>...>;
     using reference = std::tuple<std::ranges::range_reference_t<Rs>...>;
     using difference_type = std::ptrdiff_t;
+    using iterator_category = std::conditional_t<is_bidirectional, 
+                                                 std::bidirectional_iterator_tag, 
+                                                 std::input_iterator_tag>;
 
-    begin_iterator& operator++() {
+    iterator& operator++() {
       std::apply([](auto&... it) { ((++it), ...); }, iterators);
       return *this;
     }
 
-    reference operator*() const {
-      return std::apply(
-          [](auto&... it) -> reference { return {*it...}; }, iterators);
+    iterator operator++(int) { 
+      iterator temp = *this;
+      ++(*this);
+      return temp;
     }
 
-    bool operator==(const begin_iterator& other) const {
-      return iterators == other.iterators;
+    // Enable bidirectional iteration only if `is_bidirectional` is true
+    iterator& operator--() requires is_bidirectional {
+      std::apply([](auto&... it) { ((--it), ...); }, iterators);
+      return *this;
     }
+
+    iterator operator--(int) requires is_bidirectional {
+      iterator temp = *this;
+      --(*this);
+      return temp;
+    }
+
+    reference operator*() const {
+      return std::apply([](auto&... it) -> reference { return {*it...}; }, iterators);
+    }
+
+    bool operator==(const iterator& other) const = default;
   };
 
-  // Sentinel for end()
-  struct end_iterator {
+  struct sentinel {
     std::tuple<std::ranges::sentinel_t<Rs>...> sentinels;
 
-    bool operator==(const begin_iterator& it) const {
+    bool operator==(const iterator& it) const {
       return compare(it, std::make_index_sequence<sizeof...(Rs)>{});
     }
 
    private:
     template <std::size_t... I>
-    bool compare(const begin_iterator& it, std::index_sequence<I...>) const {
+    bool compare(const iterator& it, std::index_sequence<I...>) const {
       return ((std::get<I>(it.iterators) == std::get<I>(sentinels)) || ...);
     }
   };
 
  public:
-  explicit zip_view(Rs&&... ranges)
-      : bases{std::forward<Rs>(ranges)...} {} // Ensure perfect forwarding
+  zip_view() = default;
+  explicit zip_view(Rs... ranges) : bases{std::move(ranges)...} {}
 
-  auto begin() {
-    return begin_iterator{std::apply(
-        [](auto&... r) { return std::tuple{std::ranges::begin(r)...}; },
-        bases)};
+  auto begin() { 
+    return iterator{std::apply([](auto&... r) { return std::tuple{std::ranges::begin(r)...}; }, bases)};
   }
 
-  auto end() {
-    return end_iterator{std::apply(
-        [](auto&... r) { return std::tuple{std::ranges::end(r)...}; }, bases)};
+  auto end() { 
+    return sentinel{std::apply([](auto&... r) { return std::tuple{std::ranges::end(r)...}; }, bases)};
   }
 };
 
-template <std::ranges::input_range... Rs>
-zip_view(Rs&&...) -> zip_view<Rs...>;
+// Deduction guide
+template <std::ranges::viewable_range... Rs>
+zip_view(Rs&&...) -> zip_view<std::views::all_t<Rs>...>;
 
-template <std::ranges::input_range... Rs>
+// Helper function
+template <std::ranges::viewable_range... Rs>
 auto zip(Rs&&... rs) {
   return zip_view{std::forward<Rs>(rs)...};
 }
+
+template<std::ranges::view V>
+class enumerate_view : public std::ranges::view_interface<enumerate_view<V>> {
+private:
+    V base_;
+
+    // Base iterator
+    template <typename BaseIterator, bool IsBidirectional>
+    struct iterator_base {
+        using base_iterator = BaseIterator;
+        using value_type = std::pair<std::size_t, std::ranges::range_reference_t<V>>;
+        using reference = std::pair<std::size_t, std::ranges::range_reference_t<V>>;
+        using difference_type = std::ranges::range_difference_t<V>;
+        using iterator_category = std::conditional_t<IsBidirectional, 
+                                                     std::bidirectional_iterator_tag, 
+                                                     std::forward_iterator_tag>;
+
+        base_iterator current_;
+        std::size_t index_;
+
+        iterator_base() = default;
+        iterator_base(base_iterator current, std::size_t index) : current_(current), index_(index) {}
+
+        reference operator*() const {
+            return {index_, *current_};
+        }
+
+        iterator_base& operator++() {
+            ++current_;
+            ++index_;
+            return *this;
+        }
+
+        iterator_base operator++(int) { 
+            iterator_base tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        // Enable bidirectional iteration only if IsBidirectional == true
+        iterator_base& operator--() requires IsBidirectional {
+            --current_;
+            --index_;
+            return *this;
+        }
+
+        iterator_base operator--(int) requires IsBidirectional {
+            iterator_base tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        bool operator==(const iterator_base& other) const = default;
+    };
+
+    struct sentinel {
+        std::ranges::sentinel_t<V> end_;
+
+        bool operator==(const auto& it) const {
+            return it.current_ == end_;
+        }
+    };
+
+    using base_iterator = std::ranges::iterator_t<V>;
+    static constexpr bool is_bidirectional = std::ranges::bidirectional_range<V>;
+
+    using iterator_type = iterator_base<base_iterator, is_bidirectional>;
+
+public:
+    enumerate_view() = default;
+    explicit enumerate_view(V base) : base_(std::move(base)) {}
+
+    auto begin() { return iterator_type{std::ranges::begin(base_), 0}; }
+    auto end() { return sentinel{std::ranges::end(base_)}; }  // Use sentinel for forward iterators
+
+    V base() const & { return base_; }
+    V base() && { return std::move(base_); }
+};
+
+// Deduction guide
+template <std::ranges::viewable_range R>
+enumerate_view(R&&) -> enumerate_view<std::views::all_t<R>>;
+
+auto enumerate(std::ranges::viewable_range auto&& r) {
+  return enumerate_view{std::forward<decltype(r)>(r)};
+};
+
 } // namespace views
+
 using views::zip;
+using views::enumerate;
 
 #endif // C++23
-
-auto enumerate(auto&& range) {
-  return zip(
-      std::views::iota((int64_t)0), std::forward<decltype(range)>(range));
-}
 
 } // namespace nvfuser

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -795,6 +795,7 @@ public:
 template <std::ranges::viewable_range R>
 enumerate_view(R&&) -> enumerate_view<std::views::all_t<R>>;
 
+// Helper function
 auto enumerate(std::ranges::viewable_range auto&& r) {
   return enumerate_view{std::forward<decltype(r)>(r)};
 };

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -21,6 +21,7 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <forward_list>
 #include <fstream>
 #include <list>
 #include <random>
@@ -2010,8 +2011,41 @@ TEST_F(TestCpp23BackPort, ZipDifferentWaysToSayZeroToTen) {
   EXPECT_EQ(counter, 10);
 }
 
-TEST_F(NVFuserTest, Enumerate) {
+TEST_F(TestCpp23BackPort, ZipWithReverse) {
   std::vector<int> v{1, 2, 3, 4, 5};
+  std::vector<int> v2{5, 4, 3, 2, 1};
+
+  int64_t count = 0;
+  for (auto&& [x, y] : zip(v, v2)) {
+    EXPECT_EQ(x, 6 - y);
+    EXPECT_EQ(x, count + 1);
+    count++;
+  }
+  EXPECT_EQ(count, 5);
+
+  count = 0;
+  for (auto&& [x, y] : zip(v, v2) | std::views::reverse) {
+    EXPECT_EQ(x, 6 - y);
+    EXPECT_EQ(x, 5 - count);
+    count++;
+  }
+  EXPECT_EQ(count, 5);
+
+  count = 0;
+  std::forward_list<int> fl{1, 2, 3, 4, 5};
+  for (auto&& [x, y] : zip(v, fl)) {
+    EXPECT_EQ(x, y);
+    EXPECT_EQ(x, count + 1);
+    count++;
+  }
+  EXPECT_EQ(count, 5);
+
+  // Can not do zip(v, fl) | std::views::reverse because fl is not bidirectional
+}
+
+TEST_F(TestCpp23BackPort, Enumerate) {
+  std::vector<int> v{1, 2, 3, 4, 5};
+
   int64_t count = 0;
   for (auto&& [i, x] : enumerate(v)) {
     EXPECT_EQ(i, count);
@@ -2019,6 +2053,23 @@ TEST_F(NVFuserTest, Enumerate) {
     count++;
   }
   EXPECT_EQ(count, 5);
+
+  count = 0;
+  for (auto&& [i, x] : enumerate(v) | std::views::reverse) {
+    EXPECT_EQ(i + 1, x);
+    EXPECT_EQ(i, 4 - count);
+    count++;
+  }
+  EXPECT_EQ(count, 5);
+
+  std::forward_list<int> fl{1, 2, 3, 4, 5};
+  for (auto&& [i, x] : enumerate(fl)) {
+    EXPECT_EQ(i + 1, x);
+  }
+  EXPECT_EQ(count, 5);
+
+  // Can not do enumerate(fl) | std::views::reverse because fl is not
+  // bidirectional
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
The current implementation can not be composed with `reverse`, like `zip(v, w) | std::views::reverse`, which is different from C++23's behavior. This PR fixes that issue by add the missing `operator--` when the input views are bidirectional. I also added `enumerate_view` and uses it to implement `enumerate`. This implementation is closer to how C++23 implements `enumerate`.