### PR TITLE
Align smem buffer for TMA store at 128B

### DIFF
--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -843,7 +843,10 @@ class AllocationInfoMap : private kir::IrVisitor {
     alloc_info->should_try_alias = should_try_alias;
     alloc_info->is_cp_async_bulk =
         (tv->definition() != nullptr &&
-         ir_utils::isCpAsyncBulk(tv->definition()));
+         (ir_utils::isCpAsyncBulk(tv->definition()) ||
+          std::any_of(tv->uses().begin(), tv->uses().end(), [](Expr* expr) {
+            return ir_utils::isCpAsyncBulk(expr);
+          })));
 
     // record short cuts
     allocation_info_map_[alloc] = alloc_info;

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -5230,7 +5230,7 @@ TEST_F(HopperMatmulTest, AlignTMAStore) {
 
   KernelExecutor ke;
   ke.compile(&fusion, inputs);
-  outputs = ke.run(inputs);
+  auto outputs = ke.run(inputs);
   EXPECT_TRUE(at::allclose(outputs[0].as<at::Tensor>(), out_ref, 1e-5, 1e-5));
 }
 


### PR DESCRIPTION
Previously, #3023 addressed this for TMA loads. This PR tweaks it to also cover the producer smem buffer.

Fixes #3966 