### PR TITLE
[RFC] Create a basic binding for CPP Fusion in python frontend using Gemini

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,7 @@ if(BUILD_PYTHON)
   # nvfuser python API sources
   set(NVFUSER_PYTHON_SRCS)
   list(APPEND NVFUSER_PYTHON_SRCS
+    ${NVFUSER_SRCS_DIR}/python_frontend/fusion_bindings.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/multidevice_bindings.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/python_bindings.cpp
     ${NVFUSER_SRCS_DIR}/python_frontend/python_bindings_extension.cpp

--- a/csrc/python_frontend/fusion_bindings.cpp
+++ b/csrc/python_frontend/fusion_bindings.cpp
@@ -230,6 +230,11 @@ void bindInternalBaseNodes(py::module& nvfuser) {
           "is_device_dim",
           &nvfuser::IterDomain::isDeviceDim,
           "Return if this iter domain is device dimension")
+      .def(
+        "parallelize",
+        &nvfuser::IterDomain::parallelize,
+        py::arg("t"),
+        "")
       .def("get_parallel_type", &nvfuser::IterDomain::getParallelType, "")
       .def("get_iter_type", &nvfuser::IterDomain::getIterType, "")
       .def("start", &nvfuser::IterDomain::start, "")

--- a/csrc/python_frontend/fusion_bindings.cpp
+++ b/csrc/python_frontend/fusion_bindings.cpp
@@ -1,0 +1,92 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <ir/container.h>
+#include <python_frontend/python_bindings.h>
+
+namespace nvfuser::python_frontend {
+
+namespace {
+void bindIrContainer(py::module& nvfuser) {
+  py::class_<nvfuser::IrContainer>(nvfuser, "IrContainer")
+      .def(py::init<>(), "Constructor for IrContainer")
+      .def(
+          "in_container",
+          &nvfuser::IrContainer::inContainer,
+          "Check if the statement is in the container.")
+      .def(
+          "deterministic_vals",
+          &nvfuser::IrContainer::deterministic_vals,
+          "Return values in insertion order.")
+      .def(
+          "deterministic_exprs",
+          &nvfuser::IrContainer::deterministic_exprs,
+          "Return expressions in insertion order.")
+      .def(
+          "deterministic_vals_map",
+          &nvfuser::IrContainer::deterministic_vals_map,
+          "Return mapping from value to integer ID.")
+      .def(
+          "deterministic_exprs_map",
+          &nvfuser::IrContainer::deterministic_exprs_map,
+          "Return mapping from expression to integer ID.")
+      .def(
+          "zero_val",
+          (nvfuser::Val * (nvfuser::IrContainer::*)()) &
+              nvfuser::IrContainer::zeroVal,
+          "Return the zero value.")
+      .def(
+          "zero_val",
+          (nvfuser::Val * (nvfuser::IrContainer::*)(nvfuser::DataType)) &
+              nvfuser::IrContainer::zeroVal,
+          "Return the zero value with the specified data type.")
+      .def(
+          "one_val",
+          (nvfuser::Val * (nvfuser::IrContainer::*)()) &
+              nvfuser::IrContainer::oneVal,
+          "Return the one value.")
+      .def(
+          "one_val",
+          (nvfuser::Val * (nvfuser::IrContainer::*)(nvfuser::DataType)) &
+              nvfuser::IrContainer::oneVal,
+          "Return the one value with the specified data type.")
+      .def(
+          "false_val",
+          &nvfuser::IrContainer::falseVal,
+          "Return the false value.")
+      .def("true_val", &nvfuser::IrContainer::trueVal, "Return the true value.")
+      .def(
+          "magic_zero_val",
+          &nvfuser::IrContainer::magicZeroVal,
+          "Return the magic zero value.")
+      .def(
+          "metadata_of",
+          &nvfuser::IrContainer::metadataOf,
+          "Return the metadata of the value.")
+      .def("axioms", &nvfuser::IrContainer::axioms, "Return the axioms.")
+      .def(
+          "assume_positive",
+          &nvfuser::IrContainer::assumePositive,
+          "Assume the value is positive.")
+      .def(
+          "assume_non_negative",
+          &nvfuser::IrContainer::assumeNonNegative,
+          "Assume the value is non-negative.")
+      .def(
+          "unordered_exprs",
+          &nvfuser::IrContainer::unordered_exprs,
+          "Return the set of unordered expressions.")
+      .def("vals", &nvfuser::IrContainer::vals, "Return the set of values.");
+}
+
+} // namespace
+
+void bindFusion(py::module& nvfuser) {
+  bindIrContainer(nvfuser);
+}
+
+} // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/fusion_bindings.cpp
+++ b/csrc/python_frontend/fusion_bindings.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <ir/base_nodes.h>
 #include <ir/container.h>
 #include <python_frontend/python_bindings.h>
 
@@ -12,6 +13,140 @@ namespace nvfuser::python_frontend {
 
 namespace {
 void bindIrContainer(py::module& nvfuser) {
+  // Statement
+  py::class_<nvfuser::Statement>(nvfuser, "Statement")
+      .def(
+          "name",
+          &nvfuser::Statement::name,
+          "Return the int that represents its name")
+      .def(
+          "is_val",
+          &nvfuser::Statement::isVal,
+          "Short cut to figure out if it is a value")
+      .def(
+          "is_expr",
+          &nvfuser::Statement::isExpr,
+          "Short cut to figure out if it is an expression")
+      .def(
+          "fusion",
+          &nvfuser::Statement::fusion,
+          "Return the fusion this statement belongs to")
+      .def(
+          "container",
+          &nvfuser::Statement::container,
+          "Return the container this statement belongs to")
+      .def(
+          "same_type",
+          &nvfuser::Statement::sameType,
+          "Return if this statement is the same type as another statement")
+      .def(
+          "same_as",
+          &nvfuser::Statement::sameAs,
+          "Return if this statement is the same as another statement")
+      .def(
+          "to_string",
+          &nvfuser::Statement::toString,
+          "Return the string representation of the statement");
+
+  // Val
+  py::class_<nvfuser::Val, nvfuser::Statement>(nvfuser, "Val")
+      .def("vtype", &nvfuser::Val::vtype, "Return the ValType of the value")
+      .def("dtype", &nvfuser::Val::dtype, "Return the DataType of the value")
+      .def(
+          "is_symbolic",
+          &nvfuser::Val::isSymbolic,
+          "Returns if the value is symbolic")
+      .def(
+          "is_scalar",
+          &nvfuser::Val::isScalar,
+          "Returns if the Val is a scalar")
+      .def(
+          "is_const_scalar",
+          &nvfuser::Val::isConstScalar,
+          "Returns if all dependencies are constant scalars")
+      .def(
+          "is_const_int",
+          &nvfuser::Val::isConstInt,
+          "Returns if all dependencies are constant integers")
+      .def(
+          "is_integral_scalar",
+          &nvfuser::Val::isIntegralScalar,
+          "Returns if it is an integral scalar")
+      .def(
+          "is_floating_point_scalar",
+          &nvfuser::Val::isFloatingPointScalar,
+          "Returns if it is a floating point scalar")
+      .def("is_a_bool", &nvfuser::Val::isABool, "Returns if it is a boolean")
+      .def(
+          "evaluate",
+          &nvfuser::Val::evaluate,
+          "If this Val's history is comprised only of constant values, will return a PolymorphicValue.")
+      .def(
+          "is_const",
+          &nvfuser::Val::isConst,
+          "Returns if no dependencies and is a constant scalar.")
+      .def("is_zero", &nvfuser::Val::isZero, "Returns if the value is zero")
+      .def(
+          "is_zero_int",
+          &nvfuser::Val::isZeroInt,
+          "Returns if the value is zero integer")
+      .def("is_one", &nvfuser::Val::isOne, "Returns if the value is one")
+      .def(
+          "is_one_int",
+          &nvfuser::Val::isOneInt,
+          "Returns if the value is one integer")
+      .def("is_true", &nvfuser::Val::isTrue, "Returns if the value is true")
+      .def("is_false", &nvfuser::Val::isFalse, "Returns if the value is false")
+      .def(
+          "definition",
+          &nvfuser::Val::definition,
+          "Returns the Expr that this value is an output of, returns nullptr if none was found")
+      .def(
+          "uses",
+          &nvfuser::Val::uses,
+          "Returns the Exprs for which this is an input.")
+      .def(
+          "is_fusion_input",
+          &nvfuser::Val::isFusionInput,
+          "Returns if the value is a fusion input")
+      .def(
+          "is_fusion_output",
+          &nvfuser::Val::isFusionOutput,
+          "Returns if the value is a fusion output");
+
+  // Expr
+  py::class_<nvfuser::Expr, nvfuser::Statement>(nvfuser, "Expr")
+      .def(
+          "input",
+          &nvfuser::Expr::input,
+          py::arg("index"),
+          "Returns the input at the given index.\n"
+          "Args:\n"
+          "    index (int): The index of the input to retrieve.")
+      .def(
+          "output",
+          &nvfuser::Expr::output,
+          py::arg("index"),
+          "Returns the output at the given index.\n"
+          "Args:\n"
+          "    index (int): The index of the output to retrieve.")
+      .def(
+          "attribute_val",
+          &nvfuser::Expr::attributeVal,
+          "Returns the attribute value at the given index")
+      .def(
+          "same_op",
+          &nvfuser::Expr::sameOp,
+          "Check that if this and other are the same operator.")
+      .def(
+          "same_as",
+          &nvfuser::Expr::sameAs,
+          "Return if this and other are the same")
+      .def(
+          "get_op_string",
+          &nvfuser::Expr::getOpString,
+          "Get the name of an expression");
+
   py::class_<nvfuser::IrContainer>(nvfuser, "IrContainer")
       .def(py::init<>(), "Constructor for IrContainer")
       .def(

--- a/csrc/python_frontend/fusion_bindings.cpp
+++ b/csrc/python_frontend/fusion_bindings.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <ir/base_nodes.h>
 #include <ir/container.h>
+#include <ir/interface_nodes.h>
 #include <ir/internal_base_nodes.h>
 #include <python_frontend/python_bindings.h>
 
@@ -230,11 +231,7 @@ void bindInternalBaseNodes(py::module& nvfuser) {
           "is_device_dim",
           &nvfuser::IterDomain::isDeviceDim,
           "Return if this iter domain is device dimension")
-      .def(
-        "parallelize",
-        &nvfuser::IterDomain::parallelize,
-        py::arg("t"),
-        "")
+      .def("parallelize", &nvfuser::IterDomain::parallelize, py::arg("t"), "")
       .def("get_parallel_type", &nvfuser::IterDomain::getParallelType, "")
       .def("get_iter_type", &nvfuser::IterDomain::getIterType, "")
       .def("start", &nvfuser::IterDomain::start, "")
@@ -432,6 +429,458 @@ void bindInternalBaseNodes(py::module& nvfuser) {
       .def("r_factor", &TensorDomain::rFactor, "Apply rFactor");
 }
 
+void bindInterfaceNodes(py::module& nvfuser) {
+  py::class_<nvfuser::TensorView>(nvfuser, "TensorView")
+      .def(
+          py::init<
+              nvfuser::IrBuilderPasskey,
+              nvfuser::TensorDomain*,
+              nvfuser::DataType,
+              nvfuser::MemoryType>(),
+          py::arg("passkey"),
+          py::arg("domain"),
+          py::arg("dtype"),
+          py::arg("mtype") = nvfuser::MemoryType::Local,
+          "Constructor for TensorView")
+      .def("to_string", &nvfuser::TensorView::toString, "Convert to string")
+      .def(
+          "to_inline_string",
+          &nvfuser::TensorView::toInlineString,
+          "Convert to inline string")
+      .def(
+          "print_transforms",
+          &nvfuser::TensorView::printTransforms,
+          "Print transformations")
+      .def(
+          "domain",
+          &nvfuser::TensorView::domain,
+          py::return_value_policy::reference,
+          "Get the TensorDomain") // Assuming you want to return a reference
+      .def(
+          "set_contiguity",
+          static_cast<void (nvfuser::TensorView::*)(
+              const std::vector<std::optional<bool>>&)>(
+              &nvfuser::TensorView::setContiguity),
+          "Set contiguity (vector version)") // Overloaded function
+      .def(
+          "set_contiguity",
+          static_cast<void (nvfuser::TensorView::*)(bool)>(
+              &nvfuser::TensorView::setContiguity),
+          "Set contiguity (bool version)") // Overloaded function
+      .def(
+          "get_contiguity",
+          &nvfuser::TensorView::getContiguity,
+          "Get contiguity")
+      .def(
+          "has_reduction",
+          &nvfuser::TensorView::hasReduction,
+          "Check if has reduction")
+      .def(
+          "has_block_reduction",
+          &nvfuser::TensorView::hasBlockReduction,
+          "Check if has block reduction")
+      .def(
+          "has_grid_reduction",
+          &nvfuser::TensorView::hasGridReduction,
+          "Check if has grid reduction")
+      .def(
+          "has_broadcast",
+          &nvfuser::TensorView::hasBroadcast,
+          "Check if has broadcast")
+      .def("has_root", &nvfuser::TensorView::hasRoot, "Check if has root")
+      .def(
+          "has_allocation",
+          &nvfuser::TensorView::hasAllocation,
+          "Check if has allocation")
+      .def(
+          "is_zero_dim",
+          &nvfuser::TensorView::isZeroDim,
+          "Check if zero dimensional")
+      .def(
+          "is_empty_tensor",
+          &nvfuser::TensorView::isEmptyTensor,
+          "Check if empty tensor")
+      .def(
+          "get_reduction_axis",
+          &nvfuser::TensorView::getReductionAxis,
+          "Get reduction axis")
+      .def(
+          "get_root_domain",
+          &nvfuser::TensorView::getRootDomain,
+          py::return_value_policy::reference,
+          "Get root domain")
+      .def(
+          "get_maybe_root_domain",
+          &nvfuser::TensorView::getMaybeRootDomain,
+          py::return_value_policy::reference,
+          "Get maybe root domain")
+      .def(
+          "get_logical_domain",
+          &nvfuser::TensorView::getLogicalDomain,
+          py::return_value_policy::reference,
+          "Get logical domain")
+      .def(
+          "get_allocation_domain",
+          &nvfuser::TensorView::getAllocationDomain,
+          py::return_value_policy::reference,
+          "Get allocation domain")
+      .def(
+          "get_loop_domain",
+          &nvfuser::TensorView::getLoopDomain,
+          py::return_value_policy::reference,
+          "Get loop domain")
+      .def(
+          "get_initial_loop_domain",
+          &nvfuser::TensorView::getInitialLoopDomain,
+          py::return_value_policy::reference,
+          "Get initial loop domain")
+      .def(
+          "get_maybe_allocation_domain",
+          &nvfuser::TensorView::getMaybeAllocationDomain,
+          py::return_value_policy::reference,
+          "Get maybe allocation domain")
+      .def(
+          "set_loop_domain",
+          &nvfuser::TensorView::setLoopDomain,
+          "Set loop domain")
+      .def(
+          "set_allocation_domain",
+          static_cast<void (nvfuser::TensorView::*)(
+              std::vector<nvfuser::IterDomain*>,
+              std::vector<std::optional<bool>>)>(
+              &nvfuser::TensorView::setAllocationDomain),
+          "Set allocation domain (vector version)") // Overloaded function
+      .def(
+          "set_allocation_domain",
+          static_cast<void (nvfuser::TensorView::*)(
+              std::vector<nvfuser::IterDomain*>, bool)>(
+              &nvfuser::TensorView::setAllocationDomain),
+          "Set allocation domain (bool version)") // Overloaded function
+      .def(
+          "axis",
+          &nvfuser::TensorView::axis,
+          py::return_value_policy::reference,
+          "Get axis")
+      .def(
+          "has_compute_at",
+          &nvfuser::TensorView::hasComputeAt,
+          "Check if has computeAt")
+      .def(
+          "has_max_producer_position",
+          &nvfuser::TensorView::hasMaxProducerPosition,
+          "Check if has max producer position")
+      .def("n_dims", &nvfuser::TensorView::nDims, "Get number of dimensions")
+      .def(
+          "set_cpu_scalar",
+          &nvfuser::TensorView::setCpuScalar,
+          "Set CPU scalar")
+      .def(
+          "is_cpu_scalar",
+          &nvfuser::TensorView::isCpuScalar,
+          "Check if is CPU scalar")
+      .def(
+          "get_compute_at_position",
+          &nvfuser::TensorView::getComputeAtPosition,
+          "Get computeAt position")
+      .def(
+          "get_max_producer_position",
+          &nvfuser::TensorView::getMaxProducerPosition,
+          "Get max producer position")
+      .def(
+          "get_maybe_max_producer_position",
+          &nvfuser::TensorView::getMaybeMaxProducerPosition,
+          "Get maybe max producer position")
+      .def(
+          "clear_reduction_iter_domains",
+          &nvfuser::TensorView::clearReductionIterDomains,
+          "Clear reduction iter domains")
+      .def(
+          "compute_at",
+          &nvfuser::TensorView::computeAt,
+          py::return_value_policy::reference,
+          "Compute at")
+      .def(
+          "broadcast",
+          static_cast<nvfuser::TensorView* (nvfuser::TensorView::*)(int64_t,
+                                                                    int64_t)>(
+              &nvfuser::TensorView::broadcast),
+          py::return_value_policy::reference,
+          "Broadcast (int64_t version)") // Overloaded function
+      .def(
+          "broadcast",
+          static_cast<nvfuser::TensorView* (
+              nvfuser::TensorView::*)(int64_t, nvfuser::Val*)>(
+              &nvfuser::TensorView::broadcast),
+          py::return_value_policy::reference,
+          "Broadcast (Val* version)") // Overloaded function
+      .def(
+          "split",
+          static_cast<nvfuser::TensorView* (
+              nvfuser::TensorView::*)(int64_t, int64_t, bool)>(
+              &nvfuser::TensorView::split),
+          py::return_value_policy::reference,
+          "Split (int64_t version)") // Overloaded function
+      .def(
+          "split",
+          static_cast<nvfuser::TensorView* (
+              nvfuser::TensorView::*)(int64_t, nvfuser::Val*, bool)>(
+              &nvfuser::TensorView::split),
+          py::return_value_policy::reference,
+          "Split (Val* version)") // Overloaded function
+      .def(
+          "merge",
+          static_cast<nvfuser::TensorView* (nvfuser::TensorView::*)(int64_t,
+                                                                    int64_t)>(
+              &nvfuser::TensorView::merge),
+          py::return_value_policy::reference,
+          "Merge (two axes)") // Overloaded function
+      .def(
+          "merge",
+          static_cast<nvfuser::TensorView* (nvfuser::TensorView::*)(int64_t)>(
+              &nvfuser::TensorView::merge),
+          py::return_value_policy::reference,
+          "Merge (one axis)") // Overloaded function
+      .def(
+          "flatten",
+          &nvfuser::TensorView::flatten,
+          py::return_value_policy::reference,
+          "Flatten")
+      .def(
+          "reorder",
+          static_cast<nvfuser::TensorView* (
+              nvfuser::
+                  TensorView::*)(const std::unordered_map<int64_t, int64_t>&)>(
+              &nvfuser::TensorView::reorder),
+          py::return_value_policy::reference,
+          "Reorder (unordered_map version)") // Overloaded function
+      .def(
+          "reorder",
+          static_cast<nvfuser::TensorView* (
+              nvfuser::TensorView::*)(const std::initializer_list<
+                                      std::pair<const int64_t, int64_t>>&)>(
+              &nvfuser::TensorView::reorder),
+          py::return_value_policy::reference,
+          "Reorder (initializer_list of pairs version)") // Overloaded function
+      .def(
+          "reorder",
+          static_cast<nvfuser::TensorView* (
+              nvfuser::TensorView::*)(const std::vector<int64_t>&)>(
+              &nvfuser::TensorView::reorder),
+          py::return_value_policy::reference,
+          "Reorder (vector version)") // Overloaded function
+      .def(
+          "reorder",
+          static_cast<nvfuser::TensorView* (
+              nvfuser::TensorView::*)(const std::initializer_list<int64_t>&)>(
+              &nvfuser::TensorView::reorder),
+          py::return_value_policy::reference,
+          "Reorder (initializer_list version)") // Overloaded function
+      .def(
+          "swizzle",
+          static_cast<nvfuser::TensorView* (
+              nvfuser::TensorView::*)(nvfuser::SwizzleType, int64_t, int64_t)>(
+              &nvfuser::TensorView::swizzle),
+          py::return_value_policy::reference,
+          "Swizzle (SwizzleType version)") // Overloaded function
+      .def(
+          "swizzle",
+          static_cast<nvfuser::TensorView* (
+              nvfuser::TensorView::*)(nvfuser::Swizzle2DType,
+                                      int64_t,
+                                      int64_t,
+                                      nvfuser::SwizzleMode)>(
+              &nvfuser::TensorView::swizzle),
+          py::return_value_policy::reference,
+          "Swizzle (Swizzle2DType version)") // Overloaded function
+      .def(
+          "resize",
+          &nvfuser::TensorView::resize,
+          py::return_value_policy::reference,
+          "Resize")
+      .def(
+          "r_factor",
+          static_cast<nvfuser::TensorView* (
+              nvfuser::TensorView::*)(const std::vector<int64_t>&)>(
+              &nvfuser::TensorView::rFactor),
+          "R factor (single output)") // Overloaded function
+      .def(
+          "r_factor",
+          static_cast<std::vector<nvfuser::TensorView*> (
+              nvfuser::TensorView::*)(
+              const std::vector<int64_t>&,
+              const std::vector<nvfuser::TensorView*>&)>(
+              &nvfuser::TensorView::rFactor),
+          "R factor (multi-output)") // Overloaded function
+      .def(
+          "cache_before",
+          &nvfuser::TensorView::cacheBefore,
+          py::return_value_policy::reference,
+          "Cache before")
+      .def(
+          "cache_after",
+          &nvfuser::TensorView::cacheAfter,
+          py::return_value_policy::reference,
+          "Cache after")
+      .def(
+          "cache_fork",
+          &nvfuser::TensorView::cacheFork,
+          py::return_value_policy::reference,
+          "Cache fork")
+      .def(
+          "get_memory_type",
+          &nvfuser::TensorView::getMemoryType,
+          "Get memory type")
+      .def(
+          "set_memory_type",
+          &nvfuser::TensorView::setMemoryType,
+          "Set memory type")
+      .def(
+          "circular_buffer",
+          &nvfuser::TensorView::circularBuffer,
+          "Apply circular buffer")
+      .def(
+          "is_circular_buffered",
+          &nvfuser::TensorView::isCircularBuffered,
+          "Check if circular buffered")
+      .def(
+          "circular_buffer_options",
+          &nvfuser::TensorView::circularBufferOptions,
+          "Get circular buffer options")
+      .def(
+          "apply_mma_swizzle",
+          static_cast<void (nvfuser::TensorView::*)(nvfuser::MmaOperand)>(
+              &nvfuser::TensorView::applyMmaSwizzle),
+          "Apply MMA swizzle (MmaOperand version)") // Overloaded function
+      .def(
+          "apply_mma_swizzle",
+          static_cast<void (nvfuser::TensorView::*)(
+              nvfuser::MmaInputSmemSwizzle)>(
+              &nvfuser::TensorView::applyMmaSwizzle),
+          "Apply MMA swizzle (MmaInputSmemSwizzle version)") // Overloaded
+                                                             // function
+      .def(
+          "swizzle_tma_box",
+          &nvfuser::TensorView::swizzleTMABox,
+          "Swizzle TMA box")
+      .def(
+          "apply_mma_swizzle_for_tma_load",
+          &nvfuser::TensorView::applyMmaSwizzleForTMALoad,
+          "Apply MMA swizzle for TMA load")
+      .def(
+          "has_swizzle_op",
+          &nvfuser::TensorView::hasSwizzleOp,
+          "Check if has swizzle op")
+      .def(
+          "set_has_swizzle_op",
+          &nvfuser::TensorView::setHasSwizzleOp,
+          "Set has swizzle op")
+      .def("compute_with", &nvfuser::TensorView::computeWith, "Compute with")
+      .def(
+          "resolve_compute_with",
+          &nvfuser::TensorView::resolveComputeWith,
+          "Resolve compute with")
+      .def(
+          "has_compute_with",
+          &nvfuser::TensorView::hasComputeWith,
+          "Check if has compute with")
+      .def(
+          "has_resolved_compute_with",
+          &nvfuser::TensorView::hasResolvedComputeWith,
+          "Check if has resolved compute with")
+      .def(
+          "is_computed_with",
+          &nvfuser::TensorView::isComputedWith,
+          "Check if is computed with")
+      .def(
+          "get_compute_with_consumers",
+          &nvfuser::TensorView::getComputeWithConsumers,
+          py::return_value_policy::reference,
+          "Get compute with consumers")
+      .def(
+          "get_compute_with_position",
+          &nvfuser::TensorView::getComputeWithPosition,
+          "Get compute with position")
+      .def(
+          "get_max_compute_position",
+          &nvfuser::TensorView::getMaxComputePosition,
+          "Get max compute position")
+      .def(
+          "get_compute_position",
+          &nvfuser::TensorView::getComputePosition,
+          "Get compute position")
+      .def(
+          "commit_leaf_to_logical",
+          &nvfuser::TensorView::commitLeafToLogical,
+          "Commit leaf to logical")
+      .def("promote_reuse", &nvfuser::TensorView::promoteReuse, "Promote reuse")
+      .def(
+          "should_promote_reuse",
+          &nvfuser::TensorView::shouldPromoteReuse,
+          "Check if should promote reuse")
+      .def(
+          "set_device_mesh",
+          &nvfuser::TensorView::setDeviceMesh,
+          "Set device mesh")
+      .def(
+          "get_device_mesh",
+          &nvfuser::TensorView::getDeviceMesh,
+          "Get device mesh")
+      .def(
+          "has_device_mesh",
+          &nvfuser::TensorView::hasDeviceMesh,
+          "Check if has device mesh")
+      .def(
+          "get_tmem_dim_sep_pos",
+          &nvfuser::TensorView::getTMemDimSepPos,
+          "Get TMEM dimension separator position")
+      .def(
+          "set_tmem_dim_sep_pos",
+          &nvfuser::TensorView::setTMemDimSepPos,
+          "Set TMEM dimension separator position");
+
+  py::class_<nvfuser::TensorViewBuilder>(nvfuser, "TensorViewBuilder")
+      .def(py::init<>(), "Constructor for TensorViewBuilder")
+      .def(
+          "n_dims",
+          &nvfuser::TensorViewBuilder::ndims,
+          "Set number of dimensions")
+      .def("dtype", &nvfuser::TensorViewBuilder::dtype, "Set data type")
+      .def(
+          "contiguity",
+          static_cast<nvfuser::TensorViewBuilder& (
+              nvfuser::TensorViewBuilder::*)(std::vector<std::optional<bool>>)>(
+              &nvfuser::TensorViewBuilder::contiguity),
+          "Set contiguity (vector version)") // Overloaded function
+      .def(
+          "contiguity",
+          static_cast<nvfuser::TensorViewBuilder& (
+              nvfuser::TensorViewBuilder::*)(bool)>(
+              &nvfuser::TensorViewBuilder::contiguity),
+          "Set contiguity (bool version)") // Overloaded function
+      .def(
+          "shape",
+          static_cast<nvfuser::TensorViewBuilder& (
+              nvfuser::TensorViewBuilder::*)(std::vector<nvfuser::Val*>)>(
+              &nvfuser::TensorViewBuilder::shape),
+          "Set shape (Val* version)") // Overloaded function
+      .def(
+          "shape",
+          static_cast<nvfuser::TensorViewBuilder& (
+              nvfuser::TensorViewBuilder::*)(const std::vector<int64_t>&)>(
+              &nvfuser::TensorViewBuilder::shape),
+          "Set shape (int64_t version)") // Overloaded function
+      .def("expanded", &nvfuser::TensorViewBuilder::expanded, "Set expanded")
+      .def(
+          "stride_order",
+          &nvfuser::TensorViewBuilder::strideOrder,
+          "Set stride order")
+      .def(
+          "build",
+          &nvfuser::TensorViewBuilder::build,
+          py::return_value_policy::reference,
+          "Build TensorView");
+}
+
 void bindIrContainer(py::module& nvfuser) {
   py::class_<nvfuser::IrContainer>(nvfuser, "IrContainer")
       .def(py::init<>(), "Constructor for IrContainer")
@@ -510,6 +959,7 @@ void bindFusion(py::module& nvfuser) {
   bindIrContainer(nvfuser);
   bindBaseNodes(nvfuser);
   bindInternalBaseNodes(nvfuser);
+  bindInterfaceNodes(nvfuser);
 }
 
 } // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/fusion_bindings.cpp
+++ b/csrc/python_frontend/fusion_bindings.cpp
@@ -293,7 +293,7 @@ void bindInternalBaseNodes(py::module& nvfuser) {
           &nvfuser::IterDomain::isBulk,
           "Marks that this id represents an instruction loop, cp.async.bulk use only.");
 
-  py::class_<TensorDomain>(nvfuser, "TensorDomain")
+  py::class_<nvfuser::TensorDomain, nvfuser::Val>(nvfuser, "TensorDomain")
       .def("__eq__", &TensorDomain::operator==, "Equality operator")
       .def("__ne__", &TensorDomain::operator!=, "Inequality operator")
       .def("n_dims", &TensorDomain::nDims, "Number of dimensions")
@@ -432,7 +432,7 @@ void bindInternalBaseNodes(py::module& nvfuser) {
 }
 
 void bindInterfaceNodes(py::module& nvfuser) {
-  py::class_<nvfuser::TensorView>(nvfuser, "TensorView")
+  py::class_<nvfuser::TensorView, nvfuser::Val>(nvfuser, "TensorView")
       .def(
           py::init<
               nvfuser::IrBuilderPasskey,
@@ -959,7 +959,7 @@ void bindIrContainer(py::module& nvfuser) {
 
   // NOTE: manage, get_managed, get_managed_safe, stop_managing, has_managed are
   // template functions. Pybind requires explicit template specialization.
-  py::class_<nvfuser::Fusion>(nvfuser, "Fusion")
+  py::class_<nvfuser::Fusion, nvfuser::IrContainer>(nvfuser, "Fusion")
       .def(py::init<>(), "Constructor for Fusion")
       .def("clear", &nvfuser::Fusion::clear, "Clear the fusion")
       .def("remove_expr", &nvfuser::Fusion::removeExpr, "Remove an expression")

--- a/csrc/python_frontend/fusion_bindings.cpp
+++ b/csrc/python_frontend/fusion_bindings.cpp
@@ -288,6 +288,143 @@ void bindInternalBaseNodes(py::module& nvfuser) {
           "is_bulk",
           &nvfuser::IterDomain::isBulk,
           "Marks that this id represents an instruction loop, cp.async.bulk use only.");
+
+  py::class_<TensorDomain>(nvfuser, "TensorDomain")
+      .def("__eq__", &TensorDomain::operator==, "Equality operator")
+      .def("__ne__", &TensorDomain::operator!=, "Inequality operator")
+      .def("n_dims", &TensorDomain::nDims, "Number of dimensions")
+      .def(
+          "same_as",
+          (bool(TensorDomain::*)(const Statement*) const) &
+              TensorDomain::sameAs,
+          "Check if same as Statement")
+      .def(
+          "same_as",
+          (bool (*)(
+              const std::vector<IterDomain*>&,
+              const std::vector<IterDomain*>&))&TensorDomain::sameAs,
+          "Check if same as IterDomains")
+      .def(
+          "to_string",
+          (std::string(TensorDomain::*)(int, bool)
+               const)&TensorDomain::toString,
+          py::arg("indent_size") = 0,
+          py::arg("loop_only") = false,
+          "String representation")
+      .def(
+          "to_string",
+          (std::string(TensorDomain::*)(int) const)&TensorDomain::toString,
+          py::arg("indent_size") = 0,
+          "String representation")
+      .def(
+          "to_inline_string",
+          &TensorDomain::toInlineString,
+          py::arg("indent_size") = 0,
+          "Inline string representation")
+      .def("contiguity", &TensorDomain::contiguity, "Contiguity vector")
+      .def("stride_order", &TensorDomain::strideOrder, "Stride order")
+      .def("set_contiguity", &TensorDomain::setContiguity, "Set contiguity")
+      .def(
+          "get_contiguity_string",
+          &TensorDomain::getContiguityString,
+          "Contiguity string")
+      .def(
+          "has_block_reduction",
+          &TensorDomain::hasBlockReduction,
+          "Has block reduction")
+      .def(
+          "has_grid_reduction",
+          &TensorDomain::hasGridReduction,
+          "Has grid reduction")
+      .def(
+          "has_block_broadcast",
+          &TensorDomain::hasBlockBroadcast,
+          "Has block broadcast")
+      .def(
+          "has_grid_broadcast",
+          &TensorDomain::hasGridBroadcast,
+          "Has grid broadcast")
+      .def("has_root", &TensorDomain::hasRoot, "Has root")
+      .def("has_allocation", &TensorDomain::hasAllocation, "Has allocation")
+      .def(
+          "has_view_like_r_factor",
+          &TensorDomain::hasViewLikeRFactor,
+          "Has view-like rfactor")
+      .def("has_vectorize", &TensorDomain::hasVectorize, "Has vectorize")
+      .def(
+          "has_symbolic_axis",
+          &TensorDomain::hasSymbolicAxis,
+          "Has symbolic axis")
+      .def(
+          "get_reduction_axis",
+          &TensorDomain::getReductionAxis,
+          "Reduction axis")
+      .def("root", &TensorDomain::root, "Root domain")
+      .def("maybe_root", &TensorDomain::maybeRoot, "Maybe root domain")
+      .def("is_root", &TensorDomain::isRoot, "Is root ID")
+      .def("is_maybe_root", &TensorDomain::isMaybeRoot, "Is maybe root ID")
+      .def("logical", &TensorDomain::logical, "Logical domain")
+      .def("is_logical", &TensorDomain::isLogical, "Is logical ID")
+      .def("allocation", &TensorDomain::allocation, "Allocation domain")
+      .def("is_allocation", &TensorDomain::isAllocation, "Is allocation ID")
+      .def("loop", &TensorDomain::loop, "Loop domain")
+      .def("initial_loop", &TensorDomain::initialLoop, "Initial loop domain")
+      .def("is_loop", &TensorDomain::isLoop, "Is loop ID")
+      .def(
+          "is_initial_loop", &TensorDomain::isInitialLoop, "Is initial loop ID")
+      .def("all_ids", &TensorDomain::allIDs, "All IDs")
+      .def("all_exprs", &TensorDomain::allExprs, "All ID expressions")
+      .def("all_statements", &TensorDomain::allStatements, "All ID statements")
+      .def(
+          "maybe_allocation",
+          &TensorDomain::maybeAllocation,
+          "Maybe allocation domain")
+      .def("additional_ids", &TensorDomain::additionalIDs, "Additional IDs")
+      .def("set_loop_domain", &TensorDomain::setLoopDomain, "Set loop domain")
+      .def(
+          "set_allocation_domain",
+          (void(TensorDomain::*)(
+              std::vector<IterDomain*>, std::vector<std::optional<bool>>)) &
+              TensorDomain::setAllocationDomain,
+          "Set allocation domain")
+      .def(
+          "set_allocation_domain",
+          (void(TensorDomain::*)(std::vector<IterDomain*>, bool)) &
+              TensorDomain::setAllocationDomain,
+          "Set allocation domain")
+      .def("reset_domains", &TensorDomain::resetDomains, "Reset domains")
+      .def("axis", &TensorDomain::axis, "Get axis")
+      .def("pos_of", &TensorDomain::posOf, "Position of IterDomain")
+      .def(
+          "root_pos_of",
+          &TensorDomain::rootPosOf,
+          "Position of root IterDomain")
+      .def("broadcast", &TensorDomain::broadcast, "Broadcast IterDomain")
+      .def("split", &TensorDomain::split, "Split axis")
+      .def("merge", &TensorDomain::merge, "Merge axes")
+      .def("reorder", &TensorDomain::reorder, "Reorder axes")
+      .def(
+          "swizzle",
+          (void(TensorDomain::*)(SwizzleType, int64_t, int64_t)) &
+              TensorDomain::swizzle,
+          "Apply 2D swizzle")
+      .def(
+          "swizzle",
+          (void(TensorDomain::*)(
+              Swizzle2DType, int64_t, int64_t, SwizzleMode)) &
+              TensorDomain::swizzle,
+          "Apply 2D swizzle")
+      .def("resize", &TensorDomain::resize, "Resize axis")
+      .def("view", &TensorDomain::view, "Transform TensorView")
+      .def("flatten", &TensorDomain::flatten, "Flatten dimensions")
+      .def("ordered_as", &TensorDomain::orderedAs, "Reorder IterDomains")
+      .def(
+          "no_devices", &TensorDomain::noDevices, "IterDomains with no devices")
+      .def(
+          "get_contiguity_filled_with",
+          &TensorDomain::getContiguityFilledWith,
+          "Contiguity filled with value")
+      .def("r_factor", &TensorDomain::rFactor, "Apply rFactor");
 }
 
 void bindIrContainer(py::module& nvfuser) {

--- a/csrc/python_frontend/fusion_bindings.cpp
+++ b/csrc/python_frontend/fusion_bindings.cpp
@@ -10,6 +10,7 @@
 #include <ir/container.h>
 #include <ir/interface_nodes.h>
 #include <ir/internal_base_nodes.h>
+#include <ops/all_ops.h>
 #include <python_frontend/python_bindings.h>
 
 namespace nvfuser::python_frontend {
@@ -1109,13 +1110,24 @@ void bindIrContainer(py::module& nvfuser) {
           "Reset exact mappings");
 }
 
+void bindOperations(py::module& nvfuser) {
+  py::module ops = nvfuser.def_submodule("ops", "CPP Fusion Operations");
+  // Add functions to the submodule
+  ops.def("add", static_cast<nvfuser::Val* (*)(nvfuser::Val*, nvfuser::Val*)>(nvfuser::add), "Add two Vals");
+  ops.def("add", static_cast<nvfuser::TensorView* (*)(nvfuser::TensorView*, nvfuser::Val*)>(nvfuser::add), "Add TensorView and Val");
+  ops.def("add", static_cast<nvfuser::TensorView* (*)(nvfuser::Val*, nvfuser::TensorView*)>(nvfuser::add), "Add Val and TensorView");
+  ops.def("add", static_cast<nvfuser::TensorView* (*)(nvfuser::TensorView*, nvfuser::TensorView*)>(nvfuser::add), "Add two TensorViews");
+}
+
 } // namespace
 
 void bindFusion(py::module& nvfuser) {
-  bindIrContainer(nvfuser);
-  bindBaseNodes(nvfuser);
-  bindInternalBaseNodes(nvfuser);
-  bindInterfaceNodes(nvfuser);
+  py::module fusion = nvfuser.def_submodule("fusion", "CPP Fusion");
+  bindIrContainer(fusion);
+  bindBaseNodes(fusion);
+  bindInternalBaseNodes(fusion);
+  bindInterfaceNodes(fusion);
+  bindOperations(fusion);
 }
 
 } // namespace nvfuser::python_frontend

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -3713,6 +3713,8 @@ void initNvFuserPythonBindings(PyObject* module) {
   bindSchedule(fusion_def);
 
   bindMultidevice(nvfuser);
+
+  bindFusion(nvfuser);
 }
 
 void cleanup() {

--- a/csrc/python_frontend/python_bindings.h
+++ b/csrc/python_frontend/python_bindings.h
@@ -20,6 +20,9 @@ NVF_API void initNvFuserPythonBindings(PyObject* module);
 // Add bindings for multi-GPU capabilities, e.g., DeviceMesh and Communicator.
 void bindMultidevice(py::module& nvfuser);
 
+// Add bindings for CPP Fusion
+void bindFusion(py::module& nvfuser);
+
 void bindSchedule(py::class_<FusionDefinition>& fusion_def);
 
 NVF_API void cleanup();

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,14 @@
+from nvfuser import fusion
+
+f = fusion.Fusion()
+fg = fusion.FusionGuard(f)
+
+tv0 = fusion.TensorViewBuilder().n_dims(1).shape([10]).contiguity(True).build()
+tv1 = fusion.TensorViewBuilder().n_dims(1).shape([10]).contiguity(True).build()
+f.add_input(tv0)
+f.add_input(tv1)
+
+tv2 = fusion.ops.add(tv0, tv1)
+f.add_output(tv2)
+
+f.print_math()


### PR DESCRIPTION
This PR is a rapid prototype of `Create a basic binding for CPP Fusion in python frontend` using Google Gemini.

## How I am using Google Gemini?
1. Upload header files to Google Gemini
1. Initial Prompt: `Create PYBIND11_MODULE for cpp class in some_file.txt?`
2. Add docstrings
3. Can you convert all string names to snake_case?

## Python code demo
```python
from nvfuser import fusion

f = fusion.Fusion()
fg = fusion.FusionGuard(f)

tv0 = fusion.TensorViewBuilder().n_dims(1).shape([10]).contiguity(True).build()
tv1 = fusion.TensorViewBuilder().n_dims(1).shape([10]).contiguity(True).build()
f.add_input(tv0)
f.add_input(tv1)

tv2 = fusion.ops.add(tv0, tv1)
f.add_output(tv2)

f.print_math()
```

## Output
```
Inputs:
  T0_g_float[iS0{10}]
  T1_g_float[iS1{10}]
Outputs:
  T2_g_float[iS2{10}]

%kernel_math {
T2_g_float[iS2{10}]
   = T0_g_float[iS0{10}]
   + T1_g_float[iS1{10}];
} // %kernel_math 
```