### PR TITLE
Cleaning up test_gpu_indexing_ops.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,12 +577,12 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_gpu3.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_gpu_compute_with.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_gpu_fused_reduction.cpp
-  ${NVFUSER_ROOT}/tests/cpp/test_gpu_indexing_ops.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_gpu_outer_reduction.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_gpu_transpose.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_id_model.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_indexing.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_indexing_advanced.cpp
+  ${NVFUSER_ROOT}/tests/cpp/test_index_select.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_inlining.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_interval_analysis.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_iter_visitor.cpp
@@ -611,6 +611,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_scatter_gather.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_sdpa_node.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_segmentation.cpp
+  ${NVFUSER_ROOT}/tests/cpp/test_select.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_serial_gridreduce.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_sharding.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_smem_reuse.cpp

--- a/tests/cpp/test_index_select.cpp
+++ b/tests/cpp/test_index_select.cpp
@@ -15,108 +15,9 @@
 
 namespace nvfuser {
 
-TEST_F(NVFuserTest, FusionSelectOpPointwise_CUDA) {
-  auto fusion_ptr = std::make_unique<Fusion>();
-  Fusion& fusion = *fusion_ptr.get();
-  FusionGuard fg(&fusion);
+using IndexSelectTest = NVFuserTest;
 
-  auto tv0 = makeSymbolicTensor(3);
-  auto index = IrBuilder::create<Val>(DataType::Int);
-  fusion.addInput(tv0);
-  fusion.addInput(index);
-
-  auto tv1 = select(tv0, 0, index);
-  auto tv2 = select(tv0, 1, index);
-  auto tv3 = select(tv0, 2, index);
-  fusion.addOutput(tv1);
-  fusion.addOutput(tv2);
-  fusion.addOutput(tv3);
-
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-
-  int x = 31, y = 65, z = 103, idx = 21;
-
-  at::Tensor t0 = at::randn({x, y, z}, options);
-
-  FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
-
-  testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
-}
-
-TEST_F(NVFuserTest, FusionSelectOpReduction_CUDA) {
-  auto fusion_ptr = std::make_unique<Fusion>();
-  Fusion& fusion = *fusion_ptr.get();
-  FusionGuard fg(&fusion);
-
-  auto tv0 = makeSymbolicTensor(3);
-  auto index = IrBuilder::create<Val>(DataType::Int);
-  fusion.addInput(tv0);
-  fusion.addInput(index);
-
-  auto tv1 = select(tv0, 0, index);
-  auto tv2 = select(tv0, 1, index);
-  auto tv3 = select(tv0, 2, index);
-
-  auto tv4 = sum(tv1, {0});
-  auto tv5 = sum(tv2, {1});
-  auto tv6 = sum(tv3, {0, 1});
-
-  fusion.addOutput(tv4);
-  fusion.addOutput(tv5);
-  fusion.addOutput(tv6);
-
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-
-  int x = 31, y = 65, z = 103, idx = 21;
-
-  at::Tensor t0 = at::randn({x, y, z}, options);
-
-  FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
-
-  testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
-}
-
-TEST_F(NVFuserTest, FusionSelectOpPersistent_CUDA) {
-  auto fusion_ptr = std::make_unique<Fusion>();
-  Fusion& fusion = *fusion_ptr.get();
-  FusionGuard fg(&fusion);
-
-  auto tv0 = makeSymbolicTensor(3);
-  auto index = IrBuilder::create<Val>(DataType::Int);
-  fusion.addInput(tv0);
-  fusion.addInput(index);
-
-  auto tv1 = select(tv0, 0, index);
-  auto tv2 = select(tv0, 1, index);
-  auto tv3 = select(tv0, 2, index);
-
-  auto tv4 = sum(tv1, {0}, true);
-  auto tv5 = sum(tv2, {1}, true);
-  auto tv6 = sum(tv3, {0, 1}, true);
-
-  auto tv7 = add(tv1, tv4);
-  auto tv8 = add(tv2, tv5);
-  auto tv9 = add(tv3, tv6);
-
-  fusion.addOutput(tv7);
-  fusion.addOutput(tv8);
-  fusion.addOutput(tv9);
-
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-
-  int x = 31, y = 65, z = 103, idx = 21;
-
-  at::Tensor t0 = at::randn({x, y, z}, options);
-
-  FusionExecutorCache executor_cache(std::move(fusion_ptr));
-  auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
-
-  testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
-}
-
-TEST_F(NVFuserTest, FusionIndexSelectSimple_CUDA) {
+TEST_F(IndexSelectTest, Simple1) {
   for (int i = 0; i < 5; ++i) {
     // fix seed
     std::srand(i);
@@ -152,7 +53,7 @@ TEST_F(NVFuserTest, FusionIndexSelectSimple_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionIndexSelect_CUDA) {
+TEST_F(IndexSelectTest, Simple2) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
@@ -189,7 +90,7 @@ TEST_F(NVFuserTest, FusionIndexSelect_CUDA) {
 // Test 1D schedule
 // If (n_elems * 2 > device_multiprocessor_count * kThreadX), just use 1D
 // scheduler or use 2D scheduler
-TEST_F(NVFuserTest, FusionIndexSelect1DSch_CUDA) {
+TEST_F(IndexSelectTest, 1DSchedule) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
@@ -221,7 +122,7 @@ TEST_F(NVFuserTest, FusionIndexSelect1DSch_CUDA) {
   testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
 }
 
-TEST_F(NVFuserTest, FusionIndexSelect3DTv_CUDA) {
+TEST_F(IndexSelectTest, 3DTensor) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
@@ -256,7 +157,7 @@ TEST_F(NVFuserTest, FusionIndexSelect3DTv_CUDA) {
   testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
 }
 
-TEST_F(NVFuserTest, FusionIndexSelectCanSch_CUDA) {
+TEST_F(IndexSelectTest, CanSchedule) {
   // fix seed
   // dimensionality of the problem
   int nDims = 2;
@@ -350,7 +251,7 @@ TEST_F(NVFuserTest, FusionIndexSelectCanSch_CUDA) {
   NVF_CHECK(sch_pass == true && sch_fail == false && sch_sum_fail == false);
 }
 
-TEST_F(NVFuserTest, FusionIndexSelect_Sum_CUDA) {
+TEST_F(IndexSelectTest, Sum) {
   Fusion fusion;
   FusionGuard fg(&fusion);
   // dimensionality of the problem
@@ -393,7 +294,7 @@ TEST_F(NVFuserTest, FusionIndexSelect_Sum_CUDA) {
   NVF_CHECK(output_ref.allclose(cg_output));
 }
 
-TEST_F(NVFuserTest, FusionIndexSelectIdxTvFuseable_CUDA) {
+TEST_F(IndexSelectTest, IdxTvFuseable) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
@@ -432,7 +333,7 @@ TEST_F(NVFuserTest, FusionIndexSelectIdxTvFuseable_CUDA) {
   testValidate(&fusion, cg_outputs, args, __LINE__, __FILE__);
 }
 
-TEST_F(NVFuserTest, FusionIndexSelectDim1InRank2_CUDA) {
+TEST_F(IndexSelectTest, Dim1InRank2) {
   for (int i = 0; i < 5; ++i) {
     // fix seed
     std::srand(i);
@@ -472,7 +373,7 @@ TEST_F(NVFuserTest, FusionIndexSelectDim1InRank2_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionIndexSelectDim2InRank3_CUDA) {
+TEST_F(IndexSelectTest, Dim2InRank3) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
@@ -507,7 +408,7 @@ TEST_F(NVFuserTest, FusionIndexSelectDim2InRank3_CUDA) {
   testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
 }
 
-TEST_F(NVFuserTest, FusionIndexSelectDim1InRank3_CUDA) {
+TEST_F(IndexSelectTest, Dim1InRank3) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
@@ -542,7 +443,7 @@ TEST_F(NVFuserTest, FusionIndexSelectDim1InRank3_CUDA) {
   testValidate(&fusion, cg_outputs, {t1, t0, idx}, __LINE__, __FILE__);
 }
 
-TEST_F(NVFuserTest, FusionIndexSelectDim2InRank4_CUDA) {
+TEST_F(IndexSelectTest, Dim2InRank4) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
@@ -579,7 +480,7 @@ TEST_F(NVFuserTest, FusionIndexSelectDim2InRank4_CUDA) {
 }
 
 // Repro of issue #961
-TEST_F(NVFuserTest, IndexSelectBroadcastIndex_CUDA) {
+TEST_F(IndexSelectTest, BroadcastIndex) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
@@ -606,7 +507,7 @@ TEST_F(NVFuserTest, IndexSelectBroadcastIndex_CUDA) {
 }
 
 // See #1049
-TEST_F(NVFuserTest, MultipleIndexSelectIssue_CUDA) {
+TEST_F(IndexSelectTest, MultipleIndexSelectIssue) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);

--- a/tests/cpp/test_select.cpp
+++ b/tests/cpp/test_select.cpp
@@ -1,0 +1,121 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <csrc/exceptions.h>
+#include <gtest/gtest.h>
+
+#include <ops/all_ops.h>
+#include <runtime/fusion_executor_cache.h>
+#include <tests/cpp/utils.h>
+#include <tests/cpp/validator.h>
+
+namespace nvfuser {
+
+using SelectTest = NVFuserTest;
+
+TEST_F(SelectTest, Pointwise) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(3);
+  auto index = IrBuilder::create<Val>(DataType::Int);
+  fusion.addInput(tv0);
+  fusion.addInput(index);
+
+  auto tv1 = select(tv0, 0, index);
+  auto tv2 = select(tv0, 1, index);
+  auto tv3 = select(tv0, 2, index);
+  fusion.addOutput(tv1);
+  fusion.addOutput(tv2);
+  fusion.addOutput(tv3);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+
+  int x = 31, y = 65, z = 103, idx = 21;
+
+  at::Tensor t0 = at::randn({x, y, z}, options);
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
+
+  testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
+}
+
+TEST_F(SelectTest, Reduction) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(3);
+  auto index = IrBuilder::create<Val>(DataType::Int);
+  fusion.addInput(tv0);
+  fusion.addInput(index);
+
+  auto tv1 = select(tv0, 0, index);
+  auto tv2 = select(tv0, 1, index);
+  auto tv3 = select(tv0, 2, index);
+
+  auto tv4 = sum(tv1, {0});
+  auto tv5 = sum(tv2, {1});
+  auto tv6 = sum(tv3, {0, 1});
+
+  fusion.addOutput(tv4);
+  fusion.addOutput(tv5);
+  fusion.addOutput(tv6);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+
+  int x = 31, y = 65, z = 103, idx = 21;
+
+  at::Tensor t0 = at::randn({x, y, z}, options);
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
+
+  testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
+}
+
+TEST_F(SelectTest, Persistent) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(3);
+  auto index = IrBuilder::create<Val>(DataType::Int);
+  fusion.addInput(tv0);
+  fusion.addInput(index);
+
+  auto tv1 = select(tv0, 0, index);
+  auto tv2 = select(tv0, 1, index);
+  auto tv3 = select(tv0, 2, index);
+
+  auto tv4 = sum(tv1, {0}, true);
+  auto tv5 = sum(tv2, {1}, true);
+  auto tv6 = sum(tv3, {0, 1}, true);
+
+  auto tv7 = add(tv1, tv4);
+  auto tv8 = add(tv2, tv5);
+  auto tv9 = add(tv3, tv6);
+
+  fusion.addOutput(tv7);
+  fusion.addOutput(tv8);
+  fusion.addOutput(tv9);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+
+  int x = 31, y = 65, z = 103, idx = 21;
+
+  at::Tensor t0 = at::randn({x, y, z}, options);
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto cg_outputs = executor_cache.runFusionWithInputs({t0, idx});
+
+  testValidate(&fusion, cg_outputs, {t0, idx}, __LINE__, __FILE__);
+}
+
+} // namespace nvfuser


### PR DESCRIPTION
Just moving tests and renaming.

test_gpu_indexing_ops.cpp has tests of `select` and `index_select`. Moved them to their own files.