### PR TITLE
Rename TorchGather to Gather

### DIFF
--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -347,7 +347,7 @@ void IndexLowering::handle(const IndexSelectOp* sop) {
   GpuLower::current()->propagateExprInfo(sop, back());
 }
 
-void IndexLowering::handle(const TorchGatherOp* top) {
+void IndexLowering::handle(const GatherOp* top) {
   auto lowered_index = lowerSrcIndex(top->input(1), top->output(0));
   lowered_index = IrBuilder::maybeCastExpr(DataType::Index, lowered_index);
 

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -53,7 +53,7 @@ class IndexLowering : private OptOutConstDispatch {
   void handle(const TensorConstruct*) final;
   void handle(const SelectOp*) final;
   void handle(const IndexSelectOp*) final;
-  void handle(const TorchGatherOp*) final;
+  void handle(const GatherOp*) final;
   void handle(const ScatterOp*) final;
   void handle(const RNGOp*) final;
   void handle(const ReductionOp*) final;

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -143,7 +143,7 @@ bool isTvOp(const Expr* expr) {
           TensorConstruct,
           SelectOp,
           IndexSelectOp,
-          TorchGatherOp,
+          GatherOp,
           ScatterOp,
           RNGOp,
           FullOp,

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -84,7 +84,7 @@ class Val;
   f(TensorConstruct);             \
   f(SelectOp);                    \
   f(IndexSelectOp);               \
-  f(TorchGatherOp);               \
+  f(GatherOp);                    \
   f(ScatterOp);                   \
   f(RNGOp);                       \
   f(ReductionOp);                 \

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1328,7 +1328,7 @@ std::vector<SegmentedEdge*> SegmentedFusion::castInputOutputToLowerPrecision(
                          SelectOp,
                          SliceOp,
                          IndexSelectOp,
-                         TorchGatherOp>() &&
+                         GatherOp>() &&
                   edge_val_use_expr->input(0) == edge_tv;
             }),
         uses_to_modify.end());

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -129,7 +129,7 @@ class IndexSelectOp : public Expr {
   }
 };
 
-class NVF_API TorchGatherOp : public Expr {
+class NVF_API GatherOp : public Expr {
  public:
   using Expr::Expr;
 
@@ -138,7 +138,7 @@ class NVF_API TorchGatherOp : public Expr {
   //! tensor. It's true in the case of torch.take_along_dim and
   //! numpy_take_along_axis. torch.take_along_axis does not guarantee
   //! they are the same.
-  TorchGatherOp(
+  GatherOp(
       IrBuilderPasskey,
       Val* out,
       Val* in,
@@ -149,7 +149,7 @@ class NVF_API TorchGatherOp : public Expr {
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
   const char* getOpString() const override {
-    return "TorchGatherOp";
+    return "GatherOp";
   }
 
   std::string toString(int indent_size = 0) const override;

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -135,9 +135,7 @@ class NVF_API GatherOp : public Expr {
 
   //! Parameter exact_sizes indicates whether the non-indexed domains
   //! of the index tensor have the same extents of those of the input
-  //! tensor. It's true in the case of torch.take_along_dim and
-  //! numpy_take_along_axis. torch.take_along_axis does not guarantee
-  //! they are the same.
+  //! tensor. It's true in the case of take_along_axis.
   GatherOp(
       IrBuilderPasskey,
       Val* out,

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -178,7 +178,7 @@ std::vector<PolymorphicValue> IndexSelectOp::evaluate(
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(IndexSelectOp)
 
-TorchGatherOp::TorchGatherOp(
+GatherOp::GatherOp(
     IrBuilderPasskey passkey,
     Val* out,
     Val* in,
@@ -193,7 +193,7 @@ TorchGatherOp::TorchGatherOp(
   addDataAttribute(exact_sizes);
 }
 
-std::string TorchGatherOp::toString(int indent_size) const {
+std::string GatherOp::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << output(0)->toString() << "\n";
   indent_size++;
@@ -208,19 +208,19 @@ std::string TorchGatherOp::toString(int indent_size) const {
   return ss.str();
 }
 
-std::string TorchGatherOp::toInlineString(int indent_size) const {
+std::string GatherOp::toInlineString(int indent_size) const {
   NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
-IterDomain* TorchGatherOp::getIndexedID() const {
+IterDomain* GatherOp::getIndexedID() const {
   return TensorDomain::noReductions(lookupTv()->getLogicalDomain()).at(dim());
 }
 
-IterDomain* TorchGatherOp::getConsumerOfIndexedID() const {
+IterDomain* GatherOp::getConsumerOfIndexedID() const {
   return ir_utils::getTvOutput(this)->getLogicalDomain().at(dim());
 }
 
-std::vector<PolymorphicValue> TorchGatherOp::evaluate(
+std::vector<PolymorphicValue> GatherOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   const auto& input = inputs.at(0).as<at::Tensor>();
@@ -233,7 +233,7 @@ std::vector<PolymorphicValue> TorchGatherOp::evaluate(
   }
 }
 
-NVFUSER_DEFINE_CLONE_AND_CREATE(TorchGatherOp)
+NVFUSER_DEFINE_CLONE_AND_CREATE(GatherOp)
 
 ScatterOp::ScatterOp(
     IrBuilderPasskey passkey,

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1551,8 +1551,9 @@ std::vector<IterDomain*> strideOrderToAllocation(
 
 std::optional<std::pair<int64_t, int64_t>> getPrecisionOfProducerConsumerTensors(
     UnaryOp* uop) {
+  NVF_CHECK(uop != nullptr);
   NVF_CHECK(
-      uop != nullptr && uop->getUnaryOpType() == UnaryOpType::Cast,
+      uop->getUnaryOpType() == UnaryOpType::Cast,
       "Invalid expr: ",
       uop->toString());
 

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -745,7 +745,7 @@ IterDomain* getIndexedProducerID(const Expr* expr) {
     return select->getIndexedID();
   } else if (auto index_select = dynamic_cast<const IndexSelectOp*>(expr)) {
     return index_select->getIndexedID();
-  } else if (auto gather = dynamic_cast<const TorchGatherOp*>(expr)) {
+  } else if (auto gather = dynamic_cast<const GatherOp*>(expr)) {
     return gather->getIndexedID();
   } else {
     return nullptr;
@@ -755,7 +755,7 @@ IterDomain* getIndexedProducerID(const Expr* expr) {
 IterDomain* getConsumerOfIndexedProducerID(const Expr* expr) {
   if (auto index_select = dynamic_cast<const IndexSelectOp*>(expr)) {
     return index_select->getConsumerOfIndexedID();
-  } else if (auto gather = dynamic_cast<const TorchGatherOp*>(expr)) {
+  } else if (auto gather = dynamic_cast<const GatherOp*>(expr)) {
     return gather->getConsumerOfIndexedID();
   } else {
     return nullptr;
@@ -791,10 +791,10 @@ bool isIndexSelectIndicesTv(const TensorView* tv) {
   return false;
 }
 
-bool isTorchGatherLookupTv(const Val* tv) {
+bool isGatherLookupTv(const Val* tv) {
   for (auto expr : tv->uses()) {
-    if (expr->isA<TorchGatherOp>()) {
-      auto idx_sel = expr->as<TorchGatherOp>();
+    if (expr->isA<GatherOp>()) {
+      auto idx_sel = expr->as<GatherOp>();
       if (idx_sel->lookupTv() == tv) {
         return true;
       }

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -415,11 +415,11 @@ bool isSqueezeInput(const TensorView* tv);
 bool isSqueezedID(const TensorView* tv, const IterDomain* id);
 
 // Test if the given ID in the given tensor is indirectly accessed by,
-// e.g., indexSelect, torchGather and scatter
+// e.g., indexSelect, gather and scatter
 bool isIndexedID(const TensorView* tv, const IterDomain* id);
 
 // Test if the given ID in the given tensor is indirectly read by,
-// e.g., indexSelect and torchGather
+// e.g., indexSelect gather
 bool isIndexedProducerID(const TensorView* tv, const IterDomain* id);
 
 // Test if the given ID in the given tensor is indirectly written to by,
@@ -427,7 +427,7 @@ bool isIndexedProducerID(const TensorView* tv, const IterDomain* id);
 bool isIndexedConsumerID(const TensorView* tv, const IterDomain* id);
 
 // Return a producer ID, if any, that is indirectly accessed by, e.g.,
-// indexSelect and torchGather.
+// indexSelect and gather.
 IterDomain* getIndexedProducerID(const Expr* expr);
 
 // Return the corresponding consumer if of a producer ID that is
@@ -440,7 +440,7 @@ bool isIndexSelectLookupTv(const TensorView* tv);
 // Check if the given tv is third argment of indexSelect(lookup, dim, indices)
 bool isIndexSelectIndicesTv(const TensorView* tv);
 
-bool isTorchGatherLookupTv(const Val* tv);
+bool isGatherLookupTv(const Val* tv);
 
 std::string varName(const Val* val);
 

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -92,8 +92,7 @@ std::pair<IterDomain*, bool> getIndexedDomainInfo(
       indexed_id = sop->getIndexedID();
       has_consumer_id = true;
     }
-  } else if (
-      auto gop = dynamic_cast<TorchGatherOp*>(consumer_tv->definition())) {
+  } else if (auto gop = dynamic_cast<GatherOp*>(consumer_tv->definition())) {
     if (producer_tv == gop->lookupTv()) {
       indexed_id = gop->getIndexedID();
       has_consumer_id = true;
@@ -373,7 +372,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     }
 
     // Condition 2: Different extents
-    if (auto gop = dynamic_cast<TorchGatherOp*>(consumer_tv_->definition());
+    if (auto gop = dynamic_cast<GatherOp*>(consumer_tv_->definition());
         gop != nullptr && !gop->exactSizes() &&
         producer_tv_ == gop->lookupTv() && producer_id != indexed_producer_id &&
         !map_different_extents_) {

--- a/csrc/logical_domain_map.h
+++ b/csrc/logical_domain_map.h
@@ -466,7 +466,7 @@ class ComputeAtLogicalDomainMapBuilder : private BackwardVisitor {
     mapPointwiseLikeOp(op);
   }
 
-  void handle(TorchGatherOp* op) override {
+  void handle(GatherOp* op) override {
     mapPointwiseLikeOp(op);
   }
 

--- a/csrc/ops/indexing.cpp
+++ b/csrc/ops/indexing.cpp
@@ -101,7 +101,7 @@ TensorView* indexSelect(
 }
 
 // torch.gather
-TensorView* torchGather(TensorView* inp, int64_t dim, TensorView* index) {
+TensorView* gather(TensorView* inp, int64_t dim, TensorView* index) {
   auto inp_domain = TensorDomain::noReductions(inp->getLogicalDomain());
   auto idx_domain = TensorDomain::noReductions(index->getLogicalDomain());
   NVF_CHECK(
@@ -128,7 +128,7 @@ TensorView* torchGather(TensorView* inp, int64_t dim, TensorView* index) {
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       inp->getDataType().value());
 
-  IrBuilder::create<TorchGatherOp>(out_tensor, inp, dim, index, false);
+  IrBuilder::create<GatherOp>(out_tensor, inp, dim, index, false);
   return out_tensor->as<TensorView>();
 }
 
@@ -237,7 +237,7 @@ TensorView* takeAlongAxis(TensorView* inp, TensorView* index, int64_t dim) {
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       inp->getDataType().value());
 
-  IrBuilder::create<TorchGatherOp>(out_tensor, inp, dim, index, true);
+  IrBuilder::create<GatherOp>(out_tensor, inp, dim, index, true);
 
   return out_tensor->as<TensorView>();
 }

--- a/csrc/ops/indexing.h
+++ b/csrc/ops/indexing.h
@@ -24,10 +24,7 @@ NVF_API TensorView* indexSelect(
     TensorView* index);
 
 // torch.gather
-NVF_API TensorView* torchGather(
-    TensorView* input,
-    int64_t dim,
-    TensorView* index);
+NVF_API TensorView* gather(TensorView* input, int64_t dim, TensorView* index);
 
 // torch.scatter
 TensorView* scatterOp(

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1,4 +1,4 @@
-// clang-format off
+ // clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
@@ -1843,8 +1843,8 @@ struct SelectOpRecord : RecordFunctor {
   int64_t dim_;
 };
 
-struct TorchGatherOpRecord : RecordFunctor {
-  TorchGatherOpRecord(
+struct GatherOpRecord : RecordFunctor {
+  GatherOpRecord(
       std::vector<State> _args,
       std::vector<State> _outputs,
       int64_t dim)
@@ -1852,24 +1852,24 @@ struct TorchGatherOpRecord : RecordFunctor {
             std::move(_args),
             std::move(_outputs),
             "ops.gather",
-            serde::RecordType::TorchGatherOp),
+            serde::RecordType::GatherOp),
         dim_(dim) {}
-  ~TorchGatherOpRecord() override = default;
+  ~GatherOpRecord() override = default;
   RecordFunctor* clone() final {
-    return new TorchGatherOpRecord(*this);
+    return new GatherOpRecord(*this);
   }
 
   void operator()(FusionState& fd) final {
     auto arg1 = fd.getFusionState(args_.at(0).index)->template as<TensorView>();
     auto arg3 = fd.getFusionState(args_.at(1).index)->template as<TensorView>();
 
-    Val* output = torchGather(arg1, dim_, arg3);
+    Val* output = gather(arg1, dim_, arg3);
     fd.setFusionState(outputs_.at(0).index, output);
   }
 
   bool operator==(const RecordFunctor& other) const final {
     auto result = false;
-    if (auto child_ptr = dynamic_cast<const TorchGatherOpRecord*>(&other)) {
+    if (auto child_ptr = dynamic_cast<const GatherOpRecord*>(&other)) {
       result = RecordFunctor::operator==(other) && dim_ == child_ptr->dim_;
     }
     return result;
@@ -1895,7 +1895,7 @@ struct TorchGatherOpRecord : RecordFunctor {
   int64_t dim_;
 };
 
-//! Similar to TorchGatherOpRecord but enforces that non-index dimension
+//! Similar to GatherOpRecord but enforces that non-index dimension
 //! extents match between index tensor and value tensor.
 struct TakeAlongAxisOpRecord : RecordFunctor {
   TakeAlongAxisOpRecord(

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -1,4 +1,4 @@
- // clang-format off
+// clang-format off
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.

--- a/csrc/python_frontend/python_bindings.cpp
+++ b/csrc/python_frontend/python_bindings.cpp
@@ -3137,7 +3137,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             dim);
         FusionDefinition* fd = self.fusion_definition;
         Tensor output = fd->defineTensor(arg1.dims);
-        fd->defineRecord(new TorchGatherOpRecord(
+        fd->defineRecord(new GatherOpRecord(
             {
                 fd->recordingState(arg1()),
                 fd->recordingState(index()),

--- a/csrc/python_frontend/translation.cpp
+++ b/csrc/python_frontend/translation.cpp
@@ -1117,13 +1117,13 @@ class FusionTranslator : public OptInConstDispatch {
         sop->dim()));
   }
 
-  // Map TorchGatherOp to python frontend
-  void handle(const TorchGatherOp* gop) final {
+  // Map GatherOp to python frontend
+  void handle(const GatherOp* gop) final {
     TensorView* out_tv = gop->output(0)->as<TensorView>();
     Tensor output = fd_->defineTensor(out_tv->nDims());
     map_val_to_fd_index_.emplace(out_tv, output());
 
-    fd_->defineRecord(new TorchGatherOpRecord(
+    fd_->defineRecord(new GatherOpRecord(
         {fd_->recordingState(map_val_to_fd_index_.at(gop->lookupTv())),
          fd_->recordingState(map_val_to_fd_index_.at(gop->indexTv()))},
         {fd_->recordingState(output())},

--- a/csrc/scheduler/registry_utils.cpp
+++ b/csrc/scheduler/registry_utils.cpp
@@ -169,13 +169,12 @@ bool rejectScheduleForMemoryPromotion(
     Fusion* fusion,
     SchedulerType scheduler_type) {
   for (auto expr : fusion->exprs()) {
-    if (expr->isOneOf<SelectOp, IndexSelectOp, TorchGatherOp>()) {
+    if (expr->isOneOf<SelectOp, IndexSelectOp, GatherOp>()) {
       // For now, only relax the input requirement when it's
       // takeAlongAxis. Also since this would require memory
       // promotion, i.e., persistent global sync in the case of
       // block-parallel ops, it needs to be explictly enabled.
-      if (expr->isA<TorchGatherOp>() &&
-          expr->as<TorchGatherOp>()->exactSizes() &&
+      if (expr->isA<GatherOp>() && expr->as<GatherOp>()->exactSizes() &&
           isOptionEnabled(EnableOption::MemoryPromotion)) {
         continue;
       }
@@ -1016,8 +1015,7 @@ bool SchedulerTopologyChecker::hasResizeAndIndexOps(Fusion* fusion) {
   for (auto expr : fusion->exprs()) {
     if (scheduler_tools::isResizeBasedOp(expr)) {
       has_resize = true;
-    } else if (
-        expr->isOneOf<TorchGatherOp, ScatterOp, IndexSelectOp, SelectOp>()) {
+    } else if (expr->isOneOf<GatherOp, ScatterOp, IndexSelectOp, SelectOp>()) {
       has_index_op = true;
     }
 

--- a/csrc/scheduler/tools/domain_map.cpp
+++ b/csrc/scheduler/tools/domain_map.cpp
@@ -41,7 +41,7 @@ bool canIgnoreIndexedInputDomainID(
                ->isBroadcast()) {
         return false;
       }
-    } else if (auto gather = dynamic_cast<TorchGatherOp*>(use)) {
+    } else if (auto gather = dynamic_cast<GatherOp*>(use)) {
       // TODO: Remove this. Once slice is used for torchGather, this
       // should not be necessary. For now, it is necessary to not
       // break the existing torchGather tests
@@ -79,7 +79,7 @@ getIndexedConsumerToProducerMap(Fusion* fusion, const ComputeAtMap& ca_map) {
       indexed_id_map;
 
   for (auto expr : fusion->exprs()) {
-    if (auto gather = dynamic_cast<TorchGatherOp*>(expr)) {
+    if (auto gather = dynamic_cast<GatherOp*>(expr)) {
       auto p_id = gather->getIndexedID();
       auto c_id = gather->getConsumerOfIndexedID();
       indexed_id_map.emplace(

--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -56,13 +56,13 @@ bool TransposeScheduler::canScheduleCompileTime(Fusion* fusion) {
       return false;
     }
   }
-  for (auto torch_gather : ir_utils::getOpsOfType<TorchGatherOp>(fusion)) {
+  for (auto torch_gather : ir_utils::getOpsOfType<GatherOp>(fusion)) {
     auto inner = TensorDomain::noReductions(
         torch_gather->input(0)->as<TensorView>()->getMaybeAllocationDomain());
     if (torch_gather->getIndexedID() == inner[inner.size() - 1]) {
       scheduler_debug_utils::canScheduleRejectReason(
           schedulerType(),
-          "TorchGatherOp on inner dim is not supported by transpose scheduler yet."
+          "GatherOp on inner dim is not supported by transpose scheduler yet."
           "In transpose scheduler, we want to leave the select dim alone, instead of creating a tile for it.");
       return false;
     }

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -580,7 +580,7 @@ PersistentBufferInfo persistentBuffers(Fusion* fusion) {
     for (auto consumer : consumers) {
       if (dynamic_cast<SelectOp*>(consumer->definition()) ||
           dynamic_cast<IndexSelectOp*>(consumer->definition()) ||
-          dynamic_cast<TorchGatherOp*>(consumer->definition())) {
+          dynamic_cast<GatherOp*>(consumer->definition())) {
         continue;
       }
       bool consumer_mappable = true;
@@ -1196,7 +1196,7 @@ std::vector<TensorView*> cacheInputs(Fusion* fusion, bool unroll) {
   // If we're going to unroll, make a cache of the inputs
   auto in_tvs = ir_utils::filterByType<TensorView>(fusion->inputs());
   for (auto tv : in_tvs) {
-    if (tv->uses().empty() || ir_utils::isTorchGatherLookupTv(tv) ||
+    if (tv->uses().empty() || ir_utils::isGatherLookupTv(tv) ||
         ir_utils::isIndexSelectLookupTv(tv) ||
         ir_utils::isTvUsedByOpsOfType<SelectOp>(tv)) {
       // Right now, tensors that are input to the select, gather and
@@ -1572,7 +1572,7 @@ std::vector<TensorView*> getInputsOutputsWithInnerDim(
        ir_utils::filterByType<TensorView>(reference_tv->fusion()->inputs())) {
     // for indexSelect(lookup_tv, dim, index_tv) op
     // ignore it's lookup_tv.
-    if (ir_utils::isTorchGatherLookupTv(input_tv) ||
+    if (ir_utils::isGatherLookupTv(input_tv) ||
         ir_utils::isIndexSelectLookupTv(input_tv)) {
       continue;
     }
@@ -2318,7 +2318,7 @@ getNonPointwiseProducerConsumerPairs(Fusion* fusion) {
     if (consumer->isFusionInput()) {
       continue;
     }
-    if (auto gather = dynamic_cast<TorchGatherOp*>(consumer->definition())) {
+    if (auto gather = dynamic_cast<GatherOp*>(consumer->definition())) {
       tvs.emplace_back(gather->lookupTv(), consumer);
     } else if (
         auto index_select =

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -49,7 +49,7 @@ enum RecordType: int {
     IotaOp,
     IndexSelectOp,
     SelectOp,
-    TorchGatherOp,
+    GatherOp,
     TakeAlongAxisOp,
     Unary_TV,
     Unary_VAL,
@@ -274,7 +274,7 @@ table Dtype {
   dtype: long;
 }
 
-// Data for TorchGatherOpRecord, TakeAlongAxisOpRecord, and IndexSelectOpRecord
+// Data for GatherOpRecord, TakeAlongAxisOpRecord, and IndexSelectOpRecord
 table Dimension {
   dim: long;
 }

--- a/csrc/serde/fusion_record.cpp
+++ b/csrc/serde/fusion_record.cpp
@@ -448,13 +448,13 @@ void RecordFunctorFactory::registerAllParsers() {
   };
   registerParser(RecordType::IotaOp, deserializeIotaRecord);
 
-  auto deserializeTorchGatherRecord = [](const RecordFunctor* buffer) {
-    return new python_frontend::TorchGatherOpRecord(
+  auto deserializeGatherRecord = [](const RecordFunctor* buffer) {
+    return new python_frontend::GatherOpRecord(
         parseStateArgs(buffer->args()),
         parseStateArgs(buffer->outputs()),
         buffer->data_as_Dimension()->dim());
   };
-  registerParser(RecordType::TorchGatherOp, deserializeTorchGatherRecord);
+  registerParser(RecordType::GatherOp, deserializeGatherRecord);
 
   auto deserializeTakeAlongAxisRecord = [](const RecordFunctor* buffer) {
     return new python_frontend::TakeAlongAxisOpRecord(

--- a/tests/cpp/test_gpu_fused_reduction.cpp
+++ b/tests/cpp/test_gpu_fused_reduction.cpp
@@ -2562,7 +2562,7 @@ TEST_F(NVFuserTest, FusionCrossEntropyGatherPattern_CUDA) {
   fusion.addInput(labels);
 
   auto tv2 = broadcast(labels, {false, true});
-  auto tv3 = torchGather(log_probs, 1, tv2);
+  auto tv3 = gather(log_probs, 1, tv2);
   auto tv4 = squeeze(tv3, std::vector<bool>({false, true}));
 
   fusion.addOutput(tv4);

--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -5814,7 +5814,7 @@ TEST_F(ResizeTest, DoNotFuseResizeAndIndexOps) {
       if (scheduler_tools::isResizeBasedOp(expr)) {
         has_resize = true;
       } else if (
-          expr->isOneOf<TorchGatherOp, ScatterOp, IndexSelectOp, SelectOp>()) {
+          expr->isOneOf<GatherOp, ScatterOp, IndexSelectOp, SelectOp>()) {
         has_index_op = true;
       }
     }


### PR DESCRIPTION
We used to have `gather` for a different op, which we removed.