### PR TITLE
Disable register sharing with only one math warp group

### DIFF
--- a/csrc/scheduler/hopper_multi_matmul.cpp
+++ b/csrc/scheduler/hopper_multi_matmul.cpp
@@ -751,23 +751,34 @@ void HopperMultipleMatmulScheduler::setUpCircularBuffering() {
       case MatmulParams::CircularBufferingStrategy::WarpSpecialized: {
         if (params_->tiling_strategy ==
             MatmulParams::TilingStrategy::OneTilePerCTA) {
+          int64_t num_math_warp_groups = 1L;
+          NVF_ERROR(!mma_results_.empty());
+          for (IterDomain* id : mma_results_.front()->getLoopDomain()) {
+            if (id->getParallelType() == ParallelType::TIDy) {
+              num_math_warp_groups *= id->extent()->evaluate().as<int64_t>();
+            }
+          }
           NVF_ERROR(
-              std::all_of(
-                  mma_results_.begin(),
-                  mma_results_.end(),
-                  [](TensorView* tv) {
-                    IterDomain* ws_axis = tv->axis(-7);
-                    return ws_axis->getParallelType() == ParallelType::TIDy &&
-                        ws_axis->extent()->evaluate().as<int64_t>() <= 2;
-                  }),
+              num_math_warp_groups <= 2,
               "There can be at most two compute warp groups for register ",
               "sharing with warp specialization");
-          constexpr int64_t num_registers_load_warp = 40;
-          constexpr int64_t num_registers_compute_warp = 232;
-          cb_type = (CircularBufferType)WarpSpecialized(
-              ParallelType::TIDy,
-              std::make_pair(
-                  num_registers_load_warp, num_registers_compute_warp));
+          if (num_math_warp_groups == 1) {
+            // Disable register sharing when there is only one math warp group.
+            // In such case we will have 128 math threads and 128 dma threads,
+            // for a total of 256 threads per CTA. The register file size on
+            // Hopper is 64K registers, which is filled when a 256-thread CTA
+            // has 256 registers per thread. Since 256 is already the maximum
+            // number of registers per thread even with register sharing, there
+            // is no point in doing register sharing to try and increase it.
+            cb_type = (CircularBufferType)WarpSpecialized(ParallelType::TIDy);
+          } else {
+            constexpr int64_t num_registers_load_warp = 40;
+            constexpr int64_t num_registers_compute_warp = 232;
+            cb_type = (CircularBufferType)WarpSpecialized(
+                ParallelType::TIDy,
+                std::make_pair(
+                    num_registers_load_warp, num_registers_compute_warp));
+          }
         } else {
           // Persistent kernels cannot yet use register sharing
           cb_type = (CircularBufferType)WarpSpecialized(ParallelType::TIDy);


### PR DESCRIPTION
In a case like this, there are 128 math threads and 128 dma threads per CTA, so 256 threads total per CTA. On Hopper, the register file holds 64K registers, which is 256*256, meaning in this case there is no sense in trying to increase registers for the math threads (you cannot increase past 256 registers per thread).

With this, I believe we can revert the reversion of #4061