### PR TITLE
Enforce shared memory alignment for TMA LoadStoreOps

### DIFF
--- a/csrc/device_lower/analysis/tma.h
+++ b/csrc/device_lower/analysis/tma.h
@@ -63,6 +63,10 @@ class TMAInfo {
     return dims_;
   }
 
+  MmaInputSmemSwizzle swizzle() const {
+    return swizzle_;
+  }
+
   std::vector<ValGroup> getTMADomain() const {
     std::vector<ValGroup> result;
     std::transform(

--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -565,7 +565,7 @@ struct AllocationInfo {
   const kir::Allocate* alias_to = nullptr;
   bool is_inner_alias = false;
   bool should_try_alias = true;
-  bool is_cp_async_bulk = false;
+  int64_t alignment = 16;
   MemoryType mem_type = MemoryType::Local;
   DataType data_type = DataType::Float;
   std::string size_expr;
@@ -767,6 +767,25 @@ class AllocationInfoMap : private kir::IrVisitor {
     collectLivenessInfoOfExpr(expr);
   }
 
+  std::optional<MmaInputSmemSwizzle> getTmaSwizzle(TensorView* tv) {
+    bool is_tma_load = tv->definition() != nullptr &&
+        ir_utils::isCpAsyncBulk(tv->definition());
+    if (is_tma_load) {
+      return GpuLower::current()->consumerToTMAInfo().at(tv).swizzle();
+    }
+
+    for (Expr* e : tv->uses()) {
+      if (ir_utils::isCpAsyncBulk(e)) {
+        TensorView* consumer_tv = ir_utils::getTvOutput(e);
+        return GpuLower::current()
+            ->consumerToTMAInfo()
+            .at(consumer_tv)
+            .swizzle();
+      }
+    }
+    return std::nullopt;
+  }
+
   void handle(ForLoop* for_loop) final {
     auto loop_info = scope_map_.getLoopScopeInfo(for_loop);
     if (!for_loop->isTrivial()) {
@@ -847,9 +866,11 @@ class AllocationInfoMap : private kir::IrVisitor {
     alloc_info->size_expr = size_print;
     alloc_info->loop_info = current_stack_.back();
     alloc_info->should_try_alias = should_try_alias;
-    alloc_info->is_cp_async_bulk =
-        (tv->definition() != nullptr &&
-         ir_utils::isCpAsyncBulk(tv->definition()));
+
+    std::optional<MmaInputSmemSwizzle> tma_swizzle = getTmaSwizzle(tv);
+    alloc_info->alignment = (tma_swizzle.has_value())
+        ? getSharedMemoryByteAlignment(tma_swizzle.value())
+        : 16;
 
     // record short cuts
     allocation_info_map_[alloc] = alloc_info;
@@ -1763,8 +1784,8 @@ class StackBasedSharedMemAllocator : kir::IrVisitor {
           SimplifyingIrBuilder::addExpr(top_alloc->address(), top_size);
       // Shared memory allocations must by 128B aligned for cpAsyncBulk
       // operations to avoid CUDA_ERROR_MISALIGNED_ADDRESS.
-      auto aligned_address = alignExpr(
-          unaligned_address, (alloc_info->is_cp_async_bulk) ? 128 : 16);
+      auto aligned_address =
+          alignExpr(unaligned_address, alloc_info->alignment);
       // TODO: hoisting of addresses using for_loops_ recorded at first write
       alloc->setAddress(aligned_address);
     }

--- a/csrc/mma_type.cpp
+++ b/csrc/mma_type.cpp
@@ -16,6 +16,22 @@ GemmTile getMmaOpShape(MmaMacro macro) {
   return {getM(macro), getN(macro), getK(macro)};
 }
 
+int64_t getSharedMemoryByteAlignment(MmaInputSmemSwizzle swizzle) {
+  switch (swizzle) {
+    case MmaInputSmemSwizzle::None:
+      return 128;
+    case MmaInputSmemSwizzle::B32:
+      return 256;
+    case MmaInputSmemSwizzle::B64:
+      return 512;
+    case MmaInputSmemSwizzle::B128:
+      return 1024;
+    default:
+      NVF_CHECK(false, "Unknown swizzle type!");
+      break;
+  }
+}
+
 int64_t getBytesFromSwizzle(MmaInputSmemSwizzle swizzle) {
   switch (swizzle) {
     case MmaInputSmemSwizzle::None:

--- a/csrc/mma_type.cpp
+++ b/csrc/mma_type.cpp
@@ -17,6 +17,9 @@ GemmTile getMmaOpShape(MmaMacro macro) {
 }
 
 int64_t getSharedMemoryByteAlignment(MmaInputSmemSwizzle swizzle) {
+  // References:
+  // https://docs.nvidia.com/cuda/parallel-thread-execution/#swizzling-modes
+  // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#table-alignment-multi-dim-tma
   switch (swizzle) {
     case MmaInputSmemSwizzle::None:
       return 128;

--- a/csrc/mma_type.h
+++ b/csrc/mma_type.h
@@ -232,6 +232,7 @@ enum class MmaInputSmemSwizzle {
 
 constexpr int64_t core_matrix_width_bytes = 16;
 
+int64_t getSharedMemoryByteAlignment(MmaInputSmemSwizzle swizzle);
 int64_t getBytesFromSwizzle(MmaInputSmemSwizzle swizzle);
 MmaInputSmemSwizzle getSwizzleFromBytes(int64_t bytes);
 


### PR DESCRIPTION
This PR enforces the bytes alignment requirements for TMA LoadStoreOps, which prevents IMA and incorrect results.

If TMA LoadStoreOp is not detected, then alignment is 16.

### TMA shared memory byte alignment
1. None: 128 bytes aligned --- This default is to prevent IMA.
2. 32 byte swizzle mode: ... the starting address is 256 bytes aligned
3. 64 byte swizzle mode: ... the starting address is 512 bytes aligned
4. 128 byte swizzle mode: ... the starting address is 1024 bytes aligned

Reference: https://docs.nvidia.com/cuda/parallel-thread-execution/#swizzling-modes