### PR TITLE
Cache data members in `FusionKernelRuntime` to avoid large step overheads with fusions lots of args and segments

### DIFF
--- a/csrc/runtime/fusion_cache_utils.cpp
+++ b/csrc/runtime/fusion_cache_utils.cpp
@@ -29,6 +29,9 @@ void encodeBuffer(T value, std::string& buffer) {
   }
 }
 } // namespace
+ArgumentManager::ArgumentManager() :
+  tensor_map_(),
+  vals_last_used_at_segment_() { }
 
 ArgumentManager::ArgumentManager(
     const KernelArgumentHolder& args,
@@ -38,6 +41,16 @@ ArgumentManager::ArgumentManager(
   mapFusionInputsToArgs(
       fusion_inputs, args, runtime_workspace.group_extent_binding_order);
   setLastUsedSegmentID(runtime_workspace.group_run_order);
+}
+
+void ArgumentManager::update(
+    const KernelArgumentHolder& args,
+    const std::vector<Val*>& fusion_inputs) {
+  auto original_args_size = args.size();
+  // Bind args in the tensor_map
+  for (const auto i : c10::irange(original_args_size)) {
+    tensor_map_[fusion_inputs[i]] = args[i];
+  }
 }
 
 const PolymorphicValue& ArgumentManager::checkTensorMap(Val* v) const {

--- a/csrc/runtime/fusion_cache_utils.h
+++ b/csrc/runtime/fusion_cache_utils.h
@@ -85,6 +85,7 @@ struct PairPointerEquals {
 // updateWithSegmentOutputs.
 class ArgumentManager {
  public:
+  ArgumentManager();
   ArgumentManager(
       const KernelArgumentHolder& args,
       const RuntimeWorkSpace& runtime_workspace,
@@ -97,6 +98,7 @@ class ArgumentManager {
   // Allow move operations
   ArgumentManager(ArgumentManager&&) = default;
   ArgumentManager& operator=(ArgumentManager&&) = default;
+  void update(const KernelArgumentHolder& args, const std::vector<Val*>& fusion_inputs);
 
   // This map is only taken on destruction. It might be good to steal the tensor
   // map instead of make a copy.

--- a/csrc/runtime/fusion_kernel_runtime.h
+++ b/csrc/runtime/fusion_kernel_runtime.h
@@ -62,7 +62,7 @@ class FusionKernelRuntime {
   void evictCache(size_t input_id);
 
   //! query if we have already attempted compilation
-  bool isCompiled() const;
+  bool isCompiled();
 
   //! Serialize Fusion Kernel Runtime using flatbuffers
   flatbuffers::Offset<serde::FusionKernelRuntime> serialize(
@@ -236,6 +236,13 @@ class FusionKernelRuntime {
 
   // Whether to auto schedule the Fusion. If set to false, scheduling is skipped
   const bool auto_schedule_;
+  
+  // Keep track of whether we have compiled all segments as queries for fusions
+  // with many segments can create a lot of host overhead
+  bool compiled_ = false;
+
+  // Hold onto argument construction as it is expensive when on the hot path of execution.
+  ArgumentManager args_manager_;
 };
 
 } // namespace nvfuser


### PR DESCRIPTION
Added caching for the following:
1. The query for whether each segment is compiled becomes expensive with a large number of segments as is found in full model definitions given to nvFuser in one `FusionDefinition`.
2. The local construction of args in the `ArgsManager` is expensive for full models in one definition can have a large number of weights that are fed to nvFuser as arguments.