### PR TITLE
Revert "Revert "add register count checks for warp specialization with register sharing""

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -295,6 +295,25 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       NVF_ERROR(
           num_threads_per_cta.has_value(),
           "__launch_bounds__ must be set for register sharing warp specialization");
+
+      int64_t initial_reg_count =
+          getRegPerThreadGivenThreadsPerSM(num_threads_per_cta.value());
+      auto [decreased_reg_count, increased_register_count] =
+          kernel_->summary().dec_inc_register_usage;
+      NVF_ERROR(
+          initial_reg_count >= decreased_reg_count,
+          "Undefined behavior to decrease register count from ",
+          initial_reg_count,
+          " to ",
+          decreased_reg_count);
+      NVF_ERROR(
+          initial_reg_count <= increased_register_count,
+          "Undefined behavior to increase register count from ",
+          initial_reg_count,
+          " to ",
+          increased_register_count);
+
+      // leave a space between launch bound and kernel name
       code_ << "__launch_bounds__(/*maxThreadsPerBlock=*/"
             << num_threads_per_cta.value()
             << ", /*minBlocksPerMultiprocessor=*/1) ";

--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -277,6 +277,14 @@ class GpuLower : public NonCopyable {
     return tmem_info_;
   }
 
+  const std::pair<int64_t, int64_t>& decIncRegisterUsage() const {
+    return dec_inc_register_usage;
+  }
+
+  std::pair<int64_t, int64_t>& decIncRegisterUsage() {
+    return dec_inc_register_usage;
+  }
+
   // Register a boolean Val as a predicate to validate at the run time. Optional
   // validation error messages can be given as args.
   template <typename... Args>
@@ -399,6 +407,7 @@ class GpuLower : public NonCopyable {
   std::unique_ptr<IdModel> id_model_;
   std::unique_ptr<TensorIndexer> tensor_indexer_;
   std::unordered_map<TensorView*, const TMAInfo> consumer_to_tma_info_;
+  std::pair<int64_t, int64_t> dec_inc_register_usage = {-1, -1};
 
   // Track which tensor views are inputs or outputs of a vectorized operation
   // and their maximum vectorized access size

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -1410,7 +1410,8 @@ class CircularBufferInserter : private kir::ExprMutator {
       auto&& [decrease_num_registers, increase_num_registers] =
           std::get<WarpSpecialized>(circular_buffer_options.type)
               .num_registers.value();
-
+      GpuLower::current()->decIncRegisterUsage() =
+          std::make_pair(decrease_num_registers, increase_num_registers);
       // Decrease registers in load warp group
       kir::SetMaxNReg* dec_reg_load_warp = IrBuilder::create<kir::SetMaxNReg>(
           IrBuilder::create<Val>(decrease_num_registers, DataType::Index),

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -391,6 +391,7 @@ void Kernel::finalize(std::vector<Expr*> top_level_exprs) {
   summary_.min_device_version = GpuLower::current()->minDeviceVersion();
   summary_.min_device_version_reason =
       GpuLower::current()->minDeviceVersionReason();
+  summary_.dec_inc_register_usage = GpuLower::current()->decIncRegisterUsage();
   parameters_ = GpuLower::current()->allKnownVals();
   parameters_.insert(parameters_.end(), outputs().begin(), outputs().end());
   for (auto alloc : summary_.global_allocations) {

--- a/csrc/kernel.h
+++ b/csrc/kernel.h
@@ -132,6 +132,9 @@ struct KernelSummary {
   //! Do we have any possibly narrowing casts from DataType::Index variables?
   //! These need to be validated to prevent overflow.
   bool has_narrowing_index_casts = false;
+
+  //! adjusted register usage for tma load and computation warp groups
+  std::pair<int64_t, int64_t> dec_inc_register_usage = {-1, -1};
 };
 
 class KernelPerformanceProfile {

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -132,7 +132,8 @@ int64_t getRegPerThreadGivenThreadsPerSM(int64_t threads_per_sm) {
   // clamp down to register allocation granularity at warp level
   int64_t effective_max_reg_per_warp = max_reg_per_warp /
       reg_allocation_granularity * reg_allocation_granularity;
-  return effective_max_reg_per_warp / warp_size;
+  constexpr int64_t max_reg_count = 255;
+  return std::min(max_reg_count, effective_max_reg_per_warp / warp_size);
 }
 
 int64_t getThreadsPerSMGivenRegPerThread(int64_t reg_per_thread) {


### PR DESCRIPTION
Reverts NVIDIA/Fuser#4093
Matmul scheduler is fixed in #4094 