### PR TITLE
Avoid KeyError in python tests with DEBUG_SERDE=disable

### DIFF
--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -379,7 +379,8 @@ def nvfusertest_serde_check(test_fn: Callable):
     if disable_serde:
 
         def inner_fn(*args, **kwargs):
-            kwargs.pop("skip_serde_check")
+            # Remove skip_serde_check if it was given
+            kwargs.pop("skip_serde_check", None)
             return test_fn(*args, **kwargs)
 
         return inner_fn


### PR DESCRIPTION
This fixes a bug introduced in #3967 that is only exposed when the environment variable `DEBUG_SERDE=disable` is given when running the python tests. This is the case for the codediff CI jobs, so it is currently causing codediff failures.