### PR TITLE
Reduce the number of iterations

### DIFF
--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -394,8 +394,8 @@ TEST_F(OverlapDistributedMatmulTest, AG_matmul) {
 
   at::Tensor t2;
 
-  constexpr int64_t kNumberOfIterations = 20;
-  constexpr int64_t kNumberOfWarmupIterations = 5;
+  constexpr int64_t kNumberOfIterations = 2;
+  constexpr int64_t kNumberOfWarmupIterations = 1;
   for (auto i : c10::irange(kNumberOfIterations)) {
     if (i == kNumberOfWarmupIterations) {
       cudaProfilerStart();
@@ -454,8 +454,8 @@ TEST_F(OverlapDistributedMatmulTest, AG_linear) {
 
   at::Tensor out_at;
 
-  constexpr int64_t kNumberOfIterations = 20;
-  constexpr int64_t kNumberOfWarmupIterations = 5;
+  constexpr int64_t kNumberOfIterations = 2;
+  constexpr int64_t kNumberOfWarmupIterations = 1;
   for (auto i : c10::irange(kNumberOfIterations)) {
     if (i == kNumberOfWarmupIterations) {
       cudaProfilerStart();


### PR DESCRIPTION
Each test takes >50 seconds on CI currently. While I understand more iterations are needed to get a stable reading on time, CI doesn't read time so doing so by default is a waste.

Consider adding a flag to control the number of iterations, or create a separate benchmark with the fusion definition extracted.

cc @samnordmann 