### PR TITLE
Cover more command strings in run_command.sh

### DIFF
--- a/tools/codediff/run_command.sh
+++ b/tools/codediff/run_command.sh
@@ -5,6 +5,14 @@
 #
 # run_command.sh - run a single command and record environment info
 #
+
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]
+then
+    # Required for fallthrough token ;& in case statements
+    echo "This script requires bash 4.0+"
+    exit 1
+fi
+
 set -e
 set -o pipefail
 usage() {
@@ -210,14 +218,21 @@ if [[ -z $commandtype ]]
 then
     case "$testcmd" in
         *test_nvfuser*)
+            ;&
+        *tutorial_*)
+            ;&
+        *split_binary_nvfuser_tests*)
             commandtype="GOOGLETEST"
             ;;
+        *split_nvbench*)
+            ;&
         *nvfuser_bench*)
             commandtype="GOOGLEBENCH"
             ;;
         *pytest*)
-            commandtype="PYTEST"
-            ;;
+            ;&
+        *tests/python*)
+            ;&
         *python_tests*)
             commandtype="PYTEST"
             ;;


### PR DESCRIPTION
This fixes a bug in codediff CI where we currently do not recognize some tests as GOOGLETEST because they are launched through a script that shards the tests. This adds a substring to match that case and adds a couple other cases.