### PR TITLE
Add the NVF_ERROR_EQ macro

### DIFF
--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -10,6 +10,7 @@
 
 #include <alias_analysis.h>
 #include <dispatch.h>
+#include <exceptions.h>
 #include <fusion.h>
 #include <ir/interface_nodes.h>
 #include <ir/internal_base_nodes.h>
@@ -289,11 +290,10 @@ void AliasFinder::handle(const SliceOp* slice) {
   std::unordered_map<IterDomain*, IterDomain*> out_root_to_logical;
   {
     const std::vector<IterDomain*>& out_logical = out->getLogicalDomain();
-    const auto out_rank = out_root.size();
-    NVF_ERROR(out_logical.size() == out_rank);
-    out_root_to_logical.reserve(out_rank);
-    for (auto i : c10::irange(out_rank)) {
-      out_root_to_logical[out_root[i]] = out_logical[i];
+    NVF_ERROR_EQ(out_root.size(), out_logical.size());
+    out_root_to_logical.reserve(out_root.size());
+    for (auto&& [root_id, logical_id] : zip(out_root, out_logical)) {
+      out_root_to_logical[root_id] = logical_id;
     }
   }
 

--- a/csrc/exceptions.h
+++ b/csrc/exceptions.h
@@ -269,6 +269,16 @@ inline const char* nvfCheckMsgImpl(const char* /*msg*/, const char* args) {
     NVF_THROW(__VA_ARGS__)   \
   }
 
+#define NVF_ERROR_EQ(lhs, rhs, ...)                             \
+  NVF_ERROR(                                                    \
+      (lhs) == (rhs),                                           \
+      "Expected " #lhs " and " #rhs " to be equal, but found ", \
+      (lhs),                                                    \
+      " vs ",                                                   \
+      (rhs),                                                    \
+      ". ",                                                     \
+      ##__VA_ARGS__)
+
 #define NVF_CHECK_MSG(cond, type, ...) \
   (nvfuser::nvfCheckMsgImpl(           \
       "Expected " #cond " to be true, but got false.  ", ##__VA_ARGS__))


### PR DESCRIPTION
which always prints out lhs and rhs for better error messages.

For #1169