### PR TITLE
Fix non-deterministic incomplete alias analysis

### DIFF
--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -445,7 +445,7 @@ void AliasAnalysisResult::finalize(
     // as an alias op, since we will have a set operation on it.
     if (alias->fusion()->getOutputAlias(alias).type ==
         AllocationType::ReuseBuffer) {
-      return;
+      continue;
     }
 
     // Walks up the `alias_to_source_` chain.


### PR DESCRIPTION
The alias analysis pass has a `return` where there should be a `continue`. The loop is traversing over a `std::unordered_map` so the order differs from run to run. When we hit the return it will short-circuit the function, leading us to skip subsequent aliases that would be marked in other traversal orders. This has been causing failures in codediff in the `tests/python/test_python_frontend.py::TestNvFuserFrontend::test_bcast_squeeze_replace_aliased_output` test.