### PR TITLE
Wait for parallel threads in compileFusionParallel

### DIFF
--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -415,6 +415,7 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
           thread_pool_error_message = ss.str();
         }
       });
+      getThreadPool()->waitWorkComplete();
     }
 
     auto fusion_to_run = segmented_fusion_->makeFusion(group_to_run).second;


### PR DESCRIPTION
I believe this has been an unexposed issue. I ran into it because my HostIr changes will immediately afterwards use the result of the compile. Since there was no wait, the result was incorrect.

Requesting @rdspring1 's review as well