### PR TITLE
renaming arguments to avoid confusion

### DIFF
--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -1490,13 +1490,13 @@ std::unique_ptr<ReductionParams> getReductionHeuristics(
   // to be alive at the same time.
   int64_t n_tensor_inputs = 0;
   for (auto tv : unrollable_inputs_outputs) {
-    if (!tv->isFusionInput() && !tv->isFusionOutput()) {
-      continue;
-    }
     max_dtype_size_for_vectorization = std::max(
         max_dtype_size_for_vectorization,
         static_cast<int64_t>(dataTypeSize(
             tv->getDataType().value(), runtime_info.getIndexType())));
+    if (!tv->isFusionInput()) {
+      continue;
+    }
     n_tensor_inputs++;
   }
 

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -68,7 +68,7 @@ void reduceProductTo(int64_t& z, int64_t& y, int64_t& x, const int64_t max) {
 // reduction_unroll_factor for 2d inner reduction heuristics. The estimation is
 // based on properties of the fusion and hardware memory bandwidth.
 int64_t getVectUnroll(
-    const int64_t max_input_dtype_size,
+    const int64_t max_dtype_size_for_vectorization,
     const int64_t max_vectorize_factor,
     const int64_t n_tensor_inputs,
     const int64_t target_threads_per_sm,
@@ -76,7 +76,7 @@ int64_t getVectUnroll(
   // empirical value, derived from A100 & H100
   int64_t vect_factor = ceilDiv(
       // Available unrolling based on size of data type
-      (int64_t)16 / max_input_dtype_size,
+      (int64_t)16 / max_dtype_size_for_vectorization,
       // Reduce unrolling if we have many inputs, start reduction at 4 inputs
       scheduler_utils::lastPow2(std::max(n_tensor_inputs >> 2, (int64_t)1)));
 
@@ -93,7 +93,8 @@ int64_t getVectUnroll(
       scheduler_utils::getRequiredBytesInFlight();
   int64_t required_bytes_per_thread =
       ceilDiv(required_bytes_in_flight, target_threads_per_sm);
-  int64_t bytes_per_element = max_input_dtype_size * n_tensor_inputs;
+  int64_t bytes_per_element =
+      max_dtype_size_for_vectorization * n_tensor_inputs;
   int64_t unroll_vect = ceilDiv(required_bytes_per_thread, bytes_per_element);
 
   // prioritize vectorization over unrolling
@@ -113,7 +114,7 @@ int64_t getL1L2WarpSize(
     const int64_t total_reduction_numel,
     const int64_t total_iteration_numel,
     const int64_t n_tensor_inputs,
-    const int64_t max_input_dtype_size) {
+    const int64_t max_dtype_size_for_vectorization) {
   const int64_t n_elems = total_reduction_numel * total_iteration_numel;
   // Conservative value, could be set to larger based on arch if necessary.
   constexpr int64_t l1_cache = (int64_t)32 * 1024;
@@ -124,14 +125,15 @@ int64_t getL1L2WarpSize(
   // if data fits in l2 and we need more parallelization in the reduction dim,
   // we can use a smaller warp size. While thread local data fits in l1, and
   // reduction dim is really small, we can use <32 threads per warp.
-  const bool fits_in_l2 = n_elems * max_input_dtype_size * n_tensor_inputs <
+  const bool fits_in_l2 =
+      n_elems * max_dtype_size_for_vectorization * n_tensor_inputs <
       at::cuda::getCurrentDeviceProperties()->l2CacheSize;
 
   // If it fits in l2, we just want to make sure each warp uses 32Bytes. Set
   // minimum warp as 16 threads instead of 32 as if we have a small reduction
   // dim going a bit smaller than 32 usually helps.
   const int64_t warp_size_based_on_l2 =
-      fits_in_l2 ? (int64_t)32 / max_input_dtype_size : 16;
+      fits_in_l2 ? (int64_t)32 / max_dtype_size_for_vectorization : 16;
 
   // Check how many elements it would take per thread to start thrashing l1
   // set that to minimum number we want to reduce per thread.
@@ -140,7 +142,8 @@ int64_t getL1L2WarpSize(
           total_reduction_numel,
           std::max(
               l1_cache /
-                  (n_tensor_inputs * max_input_dtype_size * active_threads),
+                  (n_tensor_inputs * max_dtype_size_for_vectorization *
+                   active_threads),
               (int64_t)1)),
       (int64_t)16);
   return std::min(warp_size_based_on_l1, warp_size_based_on_l2);
@@ -154,7 +157,7 @@ std::unique_ptr<ReductionParams> inner2dReductionHeuristic(
     const int64_t total_reduction_numel,
     const int64_t total_iteration_numel,
     const int64_t n_tensor_inputs,
-    const int64_t max_input_dtype_size,
+    const int64_t max_dtype_size_for_vectorization,
     const int64_t max_vectorize_factor,
     const bool has_mufu_computation) {
   // Get device properties
@@ -169,11 +172,11 @@ std::unique_ptr<ReductionParams> inner2dReductionHeuristic(
       total_reduction_numel,
       total_iteration_numel,
       n_tensor_inputs,
-      max_input_dtype_size);
+      max_dtype_size_for_vectorization);
 
   // Set target_vect_unroll
   auto target_vect_unroll = getVectUnroll(
-      max_input_dtype_size,
+      max_dtype_size_for_vectorization,
       max_vectorize_factor,
       n_tensor_inputs,
       target_threads_per_sm,
@@ -376,7 +379,8 @@ std::unique_ptr<ReductionParams> inner2dReductionHeuristic(
             << "outer_unroll: " << outer_unroll << "\n"
             << "inner iteration: " << getInnerRemainder() << "\n"
             << "n_tensor_inputs: " << n_tensor_inputs << "\n"
-            << "max_input_dtype_size: " << max_input_dtype_size << "\n"
+            << "max_dtype_size_for_vectorization: "
+            << max_dtype_size_for_vectorization << "\n"
             << "block(" << bdimx << ", " << bdimy << ", " << 1 << ")"
             << std::endl;
     debug() << rparams->toString() << std::endl;
@@ -389,7 +393,7 @@ std::unique_ptr<ReductionParams> inner3dReductionHeuristic(
     const int64_t total_iteration_numel,
     const int64_t inner_most_dimension_numel,
     const int64_t n_tensor_inputs,
-    const int64_t max_input_dtype_size,
+    const int64_t max_dtype_size_for_vectorization,
     const size_t vectorize_factor,
     const bool has_mufu_computation) {
   // Set some targets for parallelization
@@ -407,7 +411,7 @@ std::unique_ptr<ReductionParams> inner3dReductionHeuristic(
 
   auto const max_unroll = ceilDiv(
       // Available unrolling based on size of data type
-      (int64_t)16 / (int64_t)max_input_dtype_size,
+      (int64_t)16 / (int64_t)max_dtype_size_for_vectorization,
       // Reduce unrolling if we have many inputs, start reduction at 4 inputs
       scheduler_utils::lastPow2(
           std::max((int64_t)n_tensor_inputs >> 2, (int64_t)1)));
@@ -417,7 +421,7 @@ std::unique_ptr<ReductionParams> inner3dReductionHeuristic(
       total_reduction_numel,
       total_iteration_numel,
       n_tensor_inputs,
-      max_input_dtype_size);
+      max_dtype_size_for_vectorization);
 
   // Initialization
   int64_t target_blocks = 1;
@@ -427,8 +431,8 @@ std::unique_ptr<ReductionParams> inner3dReductionHeuristic(
   // Try to set a minmum amount of work for each thread, as cross thread
   // communication is slow so it shouldn't be done for every element in the
   // reduction.
-  int64_t min_target_iterations =
-      std::max((int64_t)32 / (int64_t)max_input_dtype_size, (int64_t)1);
+  int64_t min_target_iterations = std::max(
+      (int64_t)32 / (int64_t)max_dtype_size_for_vectorization, (int64_t)1);
 
   // Start trying to break parallelization up across threads,
   // unrolling/iterations, and blocks.
@@ -770,7 +774,8 @@ std::unique_ptr<ReductionParams> inner3dReductionHeuristic(
             << "total_iteration_numel: " << total_iteration_numel << "\n"
             << "vectorize_factor: " << vectorize_factor << "\n"
             << "n_tensor_inputs: " << n_tensor_inputs << "\n"
-            << "max_input_dtype_size: " << max_input_dtype_size << "\n"
+            << "max_dtype_size_for_vectorization: "
+            << max_dtype_size_for_vectorization << "\n"
             << "block(" << bdimx << ", " << bdimy << ", " << bdimz << ")"
             << std::endl;
     debug() << rparams->toString() << std::endl;
@@ -792,7 +797,7 @@ std::unique_ptr<ReductionParams> inner3dReductionHeuristic(
           total_reduction_numel,
           total_iteration_numel,
           (int64_t)n_tensor_inputs,
-          (int64_t)max_input_dtype_size,
+          (int64_t)max_dtype_size_for_vectorization,
           (int64_t)vectorize_factor,
           has_mufu_computation);
     }
@@ -1068,7 +1073,7 @@ OuterReductionParams getGridOuterReduction(
     const int64_t total_reduction_numel,
     const int64_t total_iteration_numel,
     const int64_t n_tensor_inputs,
-    const int64_t max_input_dtype_size,
+    const int64_t max_dtype_size_for_vectorization,
     const int64_t vectorize_factor,
     const int64_t max_unroll,
     const int64_t sm_count,
@@ -1086,7 +1091,8 @@ OuterReductionParams getGridOuterReduction(
   // iter dim is really small, we can use <32 threads per warp.
   // TODO: Could get a much more accurate estimation of it the problem fits in
   // L2
-  const bool fits_in_l2 = n_elems * max_input_dtype_size * n_tensor_inputs <
+  const bool fits_in_l2 =
+      n_elems * max_dtype_size_for_vectorization * n_tensor_inputs <
       at::cuda::getCurrentDeviceProperties()->l2CacheSize;
 
   const int64_t min_warp_size = fits_in_l2 ? 16 : 32;
@@ -1254,8 +1260,8 @@ OuterReductionParams getGridOuterReduction(
     // across too many elements: In the parallel scheme [rBIDy, remainder,
     // iBIDx, rTIDy, i_unroll, r_unroll] figure out how many bytes iterations
     // across remainder stride
-    int64_t bytes_stride_remainder = max_input_dtype_size * bdimx * bdimy *
-        iter_unroll_factor * inner_reduction_unroll_factor;
+    int64_t bytes_stride_remainder = max_dtype_size_for_vectorization * bdimx *
+        bdimy * iter_unroll_factor * inner_reduction_unroll_factor;
     // Empiercally found stride shouldn't exceed 256kiB boundaries in a block
     int64_t kMaxStride = 128l * 1024l;
 
@@ -1300,7 +1306,7 @@ std::unique_ptr<ReductionParams> outerReductionHeuristic(
     const int64_t total_reduction_numel,
     const int64_t total_iteration_numel,
     const int64_t n_tensor_inputs,
-    const int64_t max_input_dtype_size,
+    const int64_t max_dtype_size_for_vectorization,
     const size_t vectorize_factor,
     const bool has_mufu_computation) {
   // WARNING: Current device for codegen may not be the target device
@@ -1339,7 +1345,7 @@ std::unique_ptr<ReductionParams> outerReductionHeuristic(
   auto const max_unroll = ceilDiv(
       // Available unrolling based on size of data type
       buffer_reg_count * scheduler_utils::bytes_per_register /
-          (int64_t)max_input_dtype_size,
+          (int64_t)max_dtype_size_for_vectorization,
       // Reduce unrolling if we have many inputs
       scheduler_utils::lastPow2(std::max(input_factor, (int64_t)1)));
 
@@ -1348,7 +1354,7 @@ std::unique_ptr<ReductionParams> outerReductionHeuristic(
       total_reduction_numel,
       total_iteration_numel,
       n_tensor_inputs,
-      max_input_dtype_size,
+      max_dtype_size_for_vectorization,
       (int64_t)vectorize_factor,
       max_unroll,
       sm_count,
@@ -1377,7 +1383,7 @@ std::unique_ptr<ReductionParams> reductionHeuristic(
     const int64_t inner_most_dimension_numel,
     const bool fastest_dim_reduction,
     const int64_t n_tensor_inputs,
-    const int64_t max_input_dtype_size,
+    const int64_t max_dtype_size_for_vectorization,
     const size_t vectorize_factor,
     const bool has_mufu_computation) {
   if (fastest_dim_reduction) {
@@ -1386,7 +1392,7 @@ std::unique_ptr<ReductionParams> reductionHeuristic(
           total_reduction_numel,
           total_iteration_numel,
           (int64_t)n_tensor_inputs,
-          (int64_t)max_input_dtype_size,
+          (int64_t)max_dtype_size_for_vectorization,
           (int64_t)vectorize_factor,
           has_mufu_computation);
     } else {
@@ -1395,7 +1401,7 @@ std::unique_ptr<ReductionParams> reductionHeuristic(
           total_iteration_numel,
           inner_most_dimension_numel,
           (int64_t)n_tensor_inputs,
-          (int64_t)max_input_dtype_size,
+          (int64_t)max_dtype_size_for_vectorization,
           vectorize_factor,
           has_mufu_computation);
     }
@@ -1406,7 +1412,7 @@ std::unique_ptr<ReductionParams> reductionHeuristic(
         total_reduction_numel,
         total_iteration_numel,
         (int64_t)n_tensor_inputs,
-        (int64_t)max_input_dtype_size,
+        (int64_t)max_dtype_size_for_vectorization,
         vectorize_factor,
         has_mufu_computation);
   }
@@ -1477,18 +1483,18 @@ std::unique_ptr<ReductionParams> getReductionHeuristics(
 
   // Base max dtype and n_tensor_inputs on tensors that are vectorizable (i.e.
   // share inner dimension with data pattern we're looking at).
-  int64_t max_dtype_size = 1;
+  int64_t max_dtype_size_for_vectorization = 1;
 
   // TODO: This might be better if it was the larger of input or outputs. Would
   // be even better if we had better analysis as not all unrolled elements have
   // to be alive at the same time.
   int64_t n_tensor_inputs = 0;
   for (auto tv : unrollable_inputs_outputs) {
-    if (!tv->isFusionInput()) {
+    if (!tv->isFusionInput() && !tv->isFusionOutput()) {
       continue;
     }
-    max_dtype_size = std::max(
-        max_dtype_size,
+    max_dtype_size_for_vectorization = std::max(
+        max_dtype_size_for_vectorization,
         static_cast<int64_t>(dataTypeSize(
             tv->getDataType().value(), runtime_info.getIndexType())));
     n_tensor_inputs++;
@@ -1505,7 +1511,7 @@ std::unique_ptr<ReductionParams> getReductionHeuristics(
       properties.inner_most_dimension_numel,
       properties.fastest_dim_reduction,
       n_tensor_inputs,
-      max_dtype_size,
+      max_dtype_size_for_vectorization,
       vectorize_factor,
       has_mufu_computation);
   heuristic->cparams.index_type = runtime_info.getIndexType();


### PR DESCRIPTION
Also, updated max_dtype_size_for_vectorization to include output TV as well.