### PR TITLE
Fix liveness of TMem address smem TV

### DIFF
--- a/csrc/device_lower/pass/alias_memory.cpp
+++ b/csrc/device_lower/pass/alias_memory.cpp
@@ -290,12 +290,8 @@ class BufferReuseDebugPrinter {
   }
 
   void handle(const kir::IfThenElse* node) {
-    // This pass doesn't yet need to handle
-    //  ite but could fill in the blank here
-    //  if this printer can be used for
-    //  other passes or we have more
-    //  complex ite pattern.
-    NVF_THROW("unsupported");
+    indent();
+    os_ << "IF " << node->predicate()->toString() << ":\n";
   }
 
   void printAllocInfo(const kir::Allocate* alloc);
@@ -811,7 +807,13 @@ class AllocationInfoMap : private kir::IrVisitor {
     // TODO: Currently we just naively dispatch into the IfThenElse node
     // assuming that this does not affect the analysis. For now, this assumption
     // is true, but in the future, we might need to revisit this.
+    if (debug_printer_) {
+      debug_printer_->pushScope();
+    }
     kir::IrVisitor::handle(ite);
+    if (debug_printer_) {
+      debug_printer_->popScope();
+    }
   }
 
   // Generate allocation info for allocation after some pre-filtering
@@ -935,8 +937,6 @@ class AllocationInfoMap : private kir::IrVisitor {
     if (expr->isOneOf<kir::MBarrierInit, kir::MBarrierInvalidate>()) {
       collectLivenessInfoOfExprMBarrier(expr);
       return;
-    } else if (!ir_utils::isTvOp(expr)) {
-      return;
     }
 
     const auto expr_pos = scope_map_.getExprPos(expr);
@@ -944,7 +944,11 @@ class AllocationInfoMap : private kir::IrVisitor {
     // Collect all tv's that resolves broadcast in this
     //  expr. The current analysis isn't enough to capture
     //  their liveness range.
-    for (auto input_tv : ir_utils::filterByType<TensorView>(expr->inputs())) {
+    for (Val* input : expr->inputs()) {
+      TensorView* input_tv = ir_utils::getTv(input);
+      if (!input_tv) {
+        continue;
+      }
       auto alloc_info = getAllocInfoFromTV(input_tv);
       if (alloc_info) {
         if (!isSerialBroadcastResolution(input_tv, for_loops_)) {
@@ -967,7 +971,11 @@ class AllocationInfoMap : private kir::IrVisitor {
         }
       }
     }
-    for (auto output_tv : ir_utils::filterByType<TensorView>(expr->outputs())) {
+    for (Val* output : expr->outputs()) {
+      TensorView* output_tv = ir_utils::getTv(output);
+      if (!output_tv) {
+        continue;
+      }
       auto alloc_info = getAllocInfoFromTV(output_tv);
       if (alloc_info) {
         // Reductions use outputs as read-write parameters, so their

--- a/tests/cpp/test_tmem.cpp
+++ b/tests/cpp/test_tmem.cpp
@@ -239,14 +239,14 @@ TEST_F(TMemTest, InexactParallelType) {
 
   auto tv0 = makeContigConcreteTensor({2, 33});
   fusion.addInput(tv0);
-  auto tv1 = set(tv0); // gmem
+  auto tv1 = set(tv0); // smem
   auto tv2 = set(tv1); // register
   auto tv3 = set(tv2); // tmem
   auto tv4 = set(tv3); // register
   auto tv5 = set(tv4); // gmem
   fusion.addOutput(tv5);
 
-  tv1->setMemoryType(MemoryType::Global);
+  tv1->setMemoryType(MemoryType::Shared);
   tv3->setMemoryType(MemoryType::Tensor);
   tv3->definition()->as<LoadStoreOp>()->setOpType(LoadStoreOpType::StTMem);
   tv4->definition()->as<LoadStoreOp>()->setOpType(LoadStoreOpType::LdTMem);


### PR DESCRIPTION
To use TMem, we must have a smem tensor for storing the address of TMem, and uses `smem_tv[0] = tcgen05::alloc()` to store the allocated TMem address. The liveness of this smem tv should be from the `tcgen05::alloc` to the `tcgen05::dealloc`. However, we are currently unable to get that due to `tcgen05::dealloc(smem_tv[0])` is not a "TV Op". Due to this bug, the smem address tensor is allocated overlapping with other smem tensors. This PR fixes this bug by handling both TV Op or non-TV op correctly.