### PR TITLE
Insert block sync if it doesn't exist in WarAsyncWaitInserter

### DIFF
--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -1237,7 +1237,14 @@ class WarAsyncWaitInserter : private kir::ExprMutator {
             for_loop->circularBufferLoopStage() ==
                 CircularBufferLoopStage::Main) {
           NVF_ERROR(num_exprs > 1);
-          --pos;
+          if (for_loop->body().exprs().back()->isA<kir::BlockSync>()) {
+            --pos;
+          } else {
+            // Insert a sync if there is not one already
+            auto sync_expr = IrBuilder::create<kir::BlockSync>(true);
+            kir::ExprMutator::registerInsertAfter(
+                for_loop->body().exprs().back(), sync_expr, &for_loop->body());
+          }
         }
 
         Expr* expr = for_loop->body().exprs().at(pos);

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -1237,7 +1237,6 @@ class WarAsyncWaitInserter : private kir::ExprMutator {
             for_loop->circularBufferLoopStage() ==
                 CircularBufferLoopStage::Main) {
           NVF_ERROR(num_exprs > 1);
-          NVF_ERROR(for_loop->body().exprs().back()->isA<kir::BlockSync>());
           --pos;
         }
 

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -5470,7 +5470,6 @@ TEST_F(HopperMatmulTest, HSH_NT_SingleMathGroupSyncCheck) {
       }
 
      private:
-      kir::Kernel* kernel_;
       ForLoop* wait_loop_ = nullptr;
       bool next_expr_must_be_sync_ = false;
       bool passed_ = true;

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -5428,7 +5428,7 @@ TEST_F(HopperMatmulTest, HSH_NT_SingleMathGroupSyncCheck) {
       }
 
      private:
-      SyncChecker(kir::Kernel* kernel) : kernel_(kernel) {
+      SyncChecker(kir::Kernel* kernel) {
         kir::IrVisitor::handle(kernel->topLevelExprs());
       }
 

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -54,6 +54,7 @@
 #include <algorithm>
 #include <iostream>
 #include "c10/core/ScalarType.h"
+#include "kernel_ir_dispatch.h"
 #include "scheduler/matmul_heuristic.h"
 
 namespace nvfuser {
@@ -5358,6 +5359,142 @@ TEST_F(HopperMatmulTest, EpilogueSiluPersistentBroadcastInputs) {
   // Relax tolerance for larger sum due to large K
   EXPECT_TRUE(
       at::allclose(cg_outputs[0].as<at::Tensor>(), tv11_ref, 5e-2, 1e-1));
+}
+
+// Test that when we have a single math warp group we still include a block sync
+TEST_F(HopperMatmulTest, HSH_NT_SingleMathGroupSyncCheck) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  constexpr int64_t M = 2048, N = 2048, K = 8192;
+  const auto dtype = DataType::Half;
+
+  auto tv0 = makeContigConcreteTensor({-1, -1, 1}, dtype); // K, M
+  auto tv1 = makeContigConcreteTensor({-1, 1, -1}, dtype); // K, N
+  fusion.addInput(tv0);
+  fusion.addInput(tv1);
+
+  auto tv2 = fusedMultiplySum(tv0, tv1, {0});
+
+  // Reorder the accumulator as [M, N, K]
+  // [K, M, N] -> [M, N, K]
+  tv2->reorder({{-3, -1}});
+  tv2->commitLeafToLogical();
+
+  auto tv3 = castOp(DataType::Half, tv2);
+  fusion.addOutput(tv3);
+
+  auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA);
+  auto t0 = at::randn({K, M, 1}, options);
+  auto t1 = at::randn({K, 1, N}, options);
+  auto out_ref = at::matmul(t0.squeeze().t(), t1.squeeze()).to(at::kHalf);
+
+  MatMulTileOptions gemm_tile;
+  // Regardless of the instruction, this should result in 2 warp groups i.e. 256
+  // threads
+  gemm_tile.cta_tile = GemmTile(64, 64, 64);
+  gemm_tile.warp_tile = GemmTile(64, 64, 64);
+
+  MatmulParams mparams;
+  mparams.supported_vec_size = {8, 8, 8};
+  mparams.mma_macro = MmaMacro::Hopper_64_64_16;
+  mparams.tile_sizes = gemm_tile;
+  mparams.tiling_strategy = MatmulParams::TilingStrategy::OneTilePerCTA;
+  mparams.circular_buffering_strategy =
+      MatmulParams::CircularBufferingStrategy::Pipelined;
+  mparams.buffering_loop_level = MatmulParams::BufferingLoopLevel::CTATiles;
+  mparams.cta_order = MatmulParams::TileRasterizationOrder::ColumnMajor;
+  mparams.async_gmem_load_operands = true;
+  mparams.circular_buffer_options.circular_buffer_smem_write = true;
+  mparams.circular_buffer_options.circular_buffer_smem_read = false;
+  mparams.circular_buffer_options.smem_circular_buffer_stage = 3;
+  mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
+  mparams.splitk_factor = 1;
+  mparams.use_smem_epilogue = false;
+  mparams.cluster_dims = {1, 1, 1};
+  mparams.promote_prologue_smem_reuse = false;
+
+  SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
+      ->schedule(&fusion, &mparams);
+
+  KernelExecutor ke;
+
+  ke.registerPostLoweringHook([](kir::Kernel* kernel) {
+    class SyncChecker : kir::IrVisitor {
+     public:
+      static bool check(kir::Kernel* kernel) {
+        SyncChecker c(kernel);
+        return c.passed_;
+      }
+
+     private:
+      SyncChecker(kir::Kernel* kernel) : kernel_(kernel) {
+        kir::IrVisitor::handle(kernel->topLevelExprs());
+      }
+
+      ForLoop* getInnerNonTrivialLoop() {
+        for (int64_t pos = (int64_t)for_loops_.size() - 1; pos >= 0; --pos) {
+          ForLoop* loop = for_loops_.at(pos);
+          if (!loop->isTrivial()) {
+            return loop;
+          }
+        }
+        return nullptr;
+      }
+
+      using OptOutDispatch::dispatch;
+
+      void dispatch(Expr* expr) {
+        if (next_expr_must_be_sync_) {
+          if (!expr->isA<kir::BlockSync>() ||
+              getInnerNonTrivialLoop() != wait_loop_) {
+            passed_ = false;
+          }
+          next_expr_must_be_sync_ = false;
+        }
+        OptOutDispatch::dispatch(expr);
+      }
+
+      using kir::IrVisitor::handle;
+
+      void handle(kir::Asm* aop) {
+        if (aop->code().find("wgmma.wait_group") != std::string::npos) {
+          ForLoop* loop = getInnerNonTrivialLoop();
+          if (loop != nullptr) {
+            // We don't need a sync for the wait that is placed at the end of
+            // the top scope of the kernel
+            wait_loop_ = loop;
+            next_expr_must_be_sync_ = true;
+          }
+        }
+      }
+
+     private:
+      kir::Kernel* kernel_;
+      ForLoop* wait_loop_ = nullptr;
+      bool next_expr_must_be_sync_ = false;
+      bool passed_ = true;
+    };
+    EXPECT_TRUE(SyncChecker::check(kernel));
+  });
+
+  ke.compile(&fusion, {t0, t1});
+  kir::Kernel* kernel = ke.compiledKernel()->kernel();
+  ASSERT_TRUE(kernel != nullptr);
+  EXPECT_TRUE(getBankConflictInfo(kernel).empty());
+  EXPECT_FALSE(PredicatedChecker::isCpAsyncMmaPredicatedByIfThenElse(kernel));
+
+  auto cg_outputs = ke.run({t0, t1});
+
+  // Check number of launched threads matches what we expect
+  EXPECT_EQ(ke.lastLaunchParams().bdimx(), 128);
+  EXPECT_EQ(ke.lastLaunchParams().bdimy(), 1)
+      << " expected 1 warp groups (BIDy==1) but found BIDy=="
+      << ke.lastLaunchParams().bdimy();
+
+  // Relax tolerance for larger sum due to large K
+  NVF_CHECK(at::allclose(
+      cg_outputs[0].as<at::Tensor>(), out_ref, 1e-6 * K, 1e-6 * K));
 }
 
 } // namespace nvfuser


### PR DESCRIPTION
I believe this check was to ensure that if a sync did exist in the scope, that it was last, but no RAW sync is inserted when `blockDim.y == 1`.

If there is no actual RAW sync, do we need the block sync to protect against WAR for wgmma async? If so then we could instead check for its existence in the scope and insert if needed.

Fixes #4138