### PR TITLE
Porting magic zero to TensorIndexer

### DIFF
--- a/csrc/device_lower/pass/magic_zero.cpp
+++ b/csrc/device_lower/pass/magic_zero.cpp
@@ -106,18 +106,20 @@ Val* maybeUnwrapMagicZero(Val* val) {
 }
 
 bool needsMagicZero(ForLoop* loop, IterDomain* reference_domain, Val* ind) {
-  if (ind->isConstScalar()) {
-    return false;
-  }
-
   if (!GpuLower::current()->isNvFuserZeroEnabled()) {
     return false;
   }
 
-  bool ref_dom_simple =
-      reference_domain == nullptr || reference_domain->definition() != nullptr;
-  bool ind_simple =
-      ind == nullptr || (ind->definition() != nullptr && !ind->isZeroInt());
+  NVF_ERROR(ind != nullptr);
+  NVF_ERROR(reference_domain != nullptr);
+
+  if (ind->isConstScalar()) {
+    return false;
+  }
+
+  bool ref_dom_simple = reference_domain->definition() != nullptr;
+  bool ind_simple = ind->definition() != nullptr && !ind->isZeroInt();
+
   return loop->isUnrolled() && (!ref_dom_simple || !ind_simple);
 }
 

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -8,6 +8,7 @@
 #include <debug.h>
 #include <device_lower/analysis/index_compute.h>
 #include <device_lower/lower2device.h>
+#include <device_lower/pass/magic_zero.h>
 #include <device_lower/utils.h>
 #include <expr_simplifier.h>
 #include <id_model/circular_buffer_indexing.h>
@@ -187,7 +188,7 @@ Val* TensorIndexer::getLinearIndex(
   const auto& alloc_info = getIndexAllocationInfo(tv);
 
   const auto [contig_indices, contig_strides] = getContigIndexFor(
-      tv, expr, as_consumer, alloc_info, for_loops, override_index);
+      expr, as_consumer, alloc_info, for_loops, override_index);
 
   // Linearize the indices with strides.
   Val* linear_index = tv->fusion()->zeroVal();
@@ -205,6 +206,14 @@ Val* TensorIndexer::getLinearIndex(
         getOffsetForCircularBufferTensor(tv, as_consumer, for_loops);
     linear_index =
         SimplifyingIrBuilder::addExpr(linear_index, circular_buffer_offset);
+  }
+
+  if (tv->getMemoryType() == MemoryType::Global) {
+    linear_index = protectIndexWithMagicZero(linear_index, for_loops);
+  }
+
+  if (tv->getMemoryType() == MemoryType::Local) {
+    ensureStaticIndexing(for_loops, linear_index);
   }
 
   return linear_index;
@@ -401,6 +410,17 @@ std::vector<PredicateInfo> TensorIndexer::getPredicates(
         return covered_domains;
       };
 
+  auto protectPredicatesWithMagicZero = [&](PredicateInfo& info) {
+    if (info.startPredicate() != nullptr) {
+      info.startPredicate() =
+          protectIndexWithMagicZero(info.startPredicate(), for_loops);
+    }
+    if (info.stopPredicate() != nullptr) {
+      info.stopPredicate() =
+          protectIndexWithMagicZero(info.stopPredicate(), for_loops);
+    }
+  };
+
   const CircularBufferLoopStage loop_stage = getCircularBufferLoopStage(
       tv, for_loops, id_model_.idGraph(IdMappingMode::LOOP));
 
@@ -478,6 +498,8 @@ std::vector<PredicateInfo> TensorIndexer::getPredicates(
       info.loop_domains_.insert(loop_dep->front()->as<IterDomain>());
     }
 
+    protectPredicatesWithMagicZero(info);
+
     info_vec.emplace_back(info);
   }
 
@@ -527,6 +549,8 @@ std::vector<PredicateInfo> TensorIndexer::getPredicates(
       for (const auto& loop_dep : loop_deps) {
         info.loop_domains_.insert(loop_dep->front()->as<IterDomain>());
       }
+
+      protectPredicatesWithMagicZero(info);
 
       info_vec.emplace_back(info);
     }
@@ -597,33 +621,43 @@ std::pair<std::vector<ValGroup>, std::vector<Val*>> TensorIndexer::
       {contig_strides.begin(), contig_strides.end()}};
 }
 
-ValGroups TensorIndexer::getUsedLoopGroups(
-    const IndexingInfo& index_info) const {
-  ValGroups used_loop_groups;
-  for (const auto& index_id : index_info.index_ids) {
-    const ValGroups& loop_groups = index_info.loop_group_dependencies.at(
-        traversalGraph().toGroup(index_id));
-    used_loop_groups.pushBack(loop_groups);
+std::vector<ForLoop*> TensorIndexer::getUsedForLoopsOf(
+    Val* index,
+    const std::vector<ForLoop*>& for_loops) const {
+  // Grab the loop indices
+  std::vector<Val*> loop_indices;
+  loop_indices.reserve(for_loops.size());
+  for (auto for_loop : for_loops) {
+    Val* initial_loop_index = getLoopIndex(for_loop->iter_domain(), for_loops);
+    loop_indices.push_back(initial_loop_index);
   }
-  return used_loop_groups;
+
+  // Figure out which loop indices are used in index
+  const auto dep_vals = DependencyCheck::getAllValsBetween(
+      {loop_indices.begin(), loop_indices.end()}, {index});
+
+  std::vector<ForLoop*> dep_loops;
+  for (auto [i, for_loop] : enumerate(for_loops)) {
+    auto initial_loop_index = loop_indices.at(i);
+    if (std::find(dep_vals.begin(), dep_vals.end(), initial_loop_index) !=
+        dep_vals.end()) {
+      dep_loops.push_back(for_loop);
+    }
+  }
+
+  return dep_loops;
 }
 
 void TensorIndexer::ensureStaticIndexing(
     const std::vector<ForLoop*>& for_loops,
-    const IndexingInfo& index_info) const {
-  const ValGroups used_loop_groups = getUsedLoopGroups(index_info);
-
-  for (auto for_loop : for_loops) {
-    if (used_loop_groups.has(id_model_.idGraph(IdMappingMode::LOOP)
-                                 .toGroup(for_loop->iter_domain()))) {
-      for_loop->requireUnroll();
-    }
+    Val* index) const {
+  for (auto for_loop : getUsedForLoopsOf(index, for_loops)) {
+    for_loop->requireUnroll();
   }
 }
 
 std::pair<std::vector<Val*>, std::vector<Val*>> TensorIndexer::
     getContigIndexFor(
-        TensorView* tv,
         const Expr* expr,
         bool as_consumer,
         const AllocationDomainInfo& alloc_info,
@@ -678,14 +712,37 @@ std::pair<std::vector<Val*>, std::vector<Val*>> TensorIndexer::
     result.push_back(replaced_idx);
   }
 
-  // It's a bit confusing for the function named as "getContigIndexFor"
-  // to change the property of ForLoops, but the local variable of
-  // index_info is needed.
-  if (tv->getMemoryType() == MemoryType::Local) {
-    ensureStaticIndexing(for_loops, index_info);
+  return {result, contig_strides};
+}
+
+Val* TensorIndexer::protectIndexWithMagicZero(
+    Val* index,
+    const std::vector<ForLoop*>& for_loops) const {
+  if (!GpuLower::current()->isNvFuserZeroEnabled()) {
+    return index;
   }
 
-  return {result, contig_strides};
+  auto used_for_loops = getUsedForLoopsOf(index, for_loops);
+
+  for (const auto for_loop : used_for_loops | std::views::reverse) {
+    Val* initial_loop_index = getLoopIndex(for_loop->iter_domain(), for_loops);
+
+    if (!needsMagicZero(
+            for_loop, for_loop->iter_domain(), initial_loop_index)) {
+      continue;
+    }
+
+    std::unordered_map<Val*, Val*> replacement_map;
+    replacement_map.emplace(
+        initial_loop_index,
+        SimplifyingIrBuilder::addExpr(
+            initial_loop_index, GpuLower::current()->kernel()->magicZeroVal()));
+    auto protected_index =
+        ir_utils::replaceValRecursively(index, replacement_map);
+    return protected_index;
+  }
+
+  return index;
 }
 
 } // namespace nvfuser

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -95,10 +95,10 @@ class TensorIndexer {
   // Grab all for-loops whose indices are actually used in the given
   // index val. Note that IndexingInfo.loop_group_dependencies can be
   // used to find loop IDs that are connected to the index IDs, but
-  // that doesn't always mean correponding loop indicex are actually
+  // that doesn't always mean corresponding loop indices are actually
   // used in an index Val. For example, unswitch predicates replace loop indices
   // with (N - 1), where N is the extent of an unswitched ID. This
-  // funciton only grabs for-loops whose indices are indeed used.
+  // function only grabs for-loops whose indices are indeed used.
   std::vector<ForLoop*> getUsedForLoopsOf(
       Val* index,
       const std::vector<ForLoop*>& for_loops) const;

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -86,22 +86,27 @@ class TensorIndexer {
 
   // Get the contig indices of the given ID groups with their strides
   std::pair<std::vector<Val*>, std::vector<Val*>> getContigIndexFor(
-      TensorView* tv,
       const Expr* expr,
       bool as_consumer,
       const AllocationDomainInfo& alloc_info,
       const std::vector<ForLoop*>& loops,
       const std::unordered_map<IterDomain*, Val*>& override_index) const;
 
-  // Get all ValGroups of the Loop graph representing the used
-  // for-loops for the given indexing
-  ValGroups getUsedLoopGroups(const IndexingInfo& index_info) const;
+  // Grab all for-loops whose indices are actually used in the given
+  // index val. Note that IndexingInfo.loop_group_dependencies can be
+  // used to find loop IDs that are connected to the index IDs, but
+  // that doesn't always mean correponding loop indicex are actually
+  // used in an index Val. For example, unswitch predicates replace loop indices
+  // with (N - 1), where N is the extent of an unswitched ID. This
+  // funciton only grabs for-loops whose indices are indeed used.
+  std::vector<ForLoop*> getUsedForLoopsOf(
+      Val* index,
+      const std::vector<ForLoop*>& for_loops) const;
 
   // Add "pragma unroll" to for-loops whose loop indices are used for
   // the given indexing. This is meant to be used for register tensors.
-  void ensureStaticIndexing(
-      const std::vector<ForLoop*>& loops,
-      const IndexingInfo& index_info) const;
+  void ensureStaticIndexing(const std::vector<ForLoop*>& loops, Val* index)
+      const;
 
   // The AlmostExact graph is used since size-1 splits and merges
   // should not affect actual index exprs.
@@ -136,6 +141,16 @@ class TensorIndexer {
   ExprPath<ExprGroup> getIndexingPath(
       const Expr* expr,
       const std::vector<IterDomain*>& index_ids) const;
+
+  // Protect the index of the innermost loop with magic zero.
+  //
+  // NOTE: This just follows how the original indexer adds magic zero
+  // to indices.
+  //
+  // TODO: Revisit if this is still necessary.
+  Val* protectIndexWithMagicZero(
+      Val* index,
+      const std::vector<ForLoop*>& for_loops) const;
 
  private:
   // Build a map of loop groups to their index Vals. See the comment

--- a/csrc/index_compute.h
+++ b/csrc/index_compute.h
@@ -382,6 +382,10 @@ class PredicateInfo {
     return stop_predicate_;
   }
 
+  auto& stopPredicate() {
+    return stop_predicate_;
+  }
+
   const auto& stopOffset() const {
     return stop_offset_;
   }

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -3388,6 +3388,8 @@ TEST_F(NVFuserTest, FusionIssueRepro1844_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionInsertMagicZero1_CUDA) {
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
   Fusion fusion;
   FusionGuard fg(&fusion);
 


### PR DESCRIPTION
This PR just ports the magic zero WAR to `TensorIndexer`. We should revisit if magic zero is still meaningful, but for now, this is yet another PR to fill remaining missing pieces of `TensorIndexer`.

I also ended up changing some of the functions I just added in #4158. For example, `TensorIndexer::getUsedLoops`, which was added in #4158, is replaced with `getUsedForLoopsOf` since `getUsedLoops` does not guarantee a loop index is indeed used in the final index (e.g., when unswitched, loop indices are replaced with 0 or `N - 1`, where `N` is the extent of the iter domain).

NOTE: Magic zero has just been ignored in `TensorIndexer`. If it should not be used, please explicitly disable it, which is already done in [the matmul scheduler](https://github.com/NVIDIA/Fuser/blob/main/csrc/scheduler/matmul_utils.cpp#L1035).