### PR TITLE
Change `c10::irange` to `arange`

### DIFF
--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -149,7 +149,7 @@ std::pair<bool, std::optional<bool>> mergeContiguity(
       PairwiseLogicalDomainMap(in, out).mapProducerToConsumer();
 
   Layout preferred_out_layout;
-  for (const auto i : c10::irange(preferred_in_layout.size())) {
+  for (const auto i : arange(preferred_in_layout.size())) {
     IterDomain* in_alloc_id = preferred_in_layout.allocation_domain[i];
     IterDomain* out_root_id = getOrDefault(in_logical_to_out_root, in_alloc_id);
     if (out_root_id == nullptr) {
@@ -176,7 +176,7 @@ void AliasFinder::handle(const ViewOp* view) {
   }
 
   LinkedHashMap<IterDomain*, std::optional<bool>> allocation_to_contiguity;
-  for (const auto i : c10::irange(out_root_layout->size())) {
+  for (const auto i : arange(out_root_layout->size())) {
     if (!out_root_layout->contiguity[i].has_value() &&
         !out_root_layout->allocation_domain[i]->isBroadcast()) {
       // TODO(#1126): Due to #1126, `out_root` materializes an expanded
@@ -352,7 +352,7 @@ void AliasFinder::handle(const BroadcastOp* bcast) {
 
   // Put new, broadcast dimensions to the end.
   const std::vector<IterDomain*> out_logical = out->getLogicalDomain();
-  for (const auto i : c10::irange(out_logical.size())) {
+  for (const auto i : arange(out_logical.size())) {
     if (bcast->isBroadcastDim(i)) {
       out_layout->allocation_domain.push_back(out_logical[i]);
       out_layout->contiguity.emplace_back(std::nullopt);
@@ -550,7 +550,7 @@ bool Layout::isCompliantWith(const Layout& required) const {
     return false;
   }
 
-  for (const auto i : c10::irange(allocation_domain.size())) {
+  for (const auto i : arange(allocation_domain.size())) {
     if (!contiguityIsCompliant(contiguity[i], required.contiguity[i])) {
       return false;
     }

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -57,7 +57,7 @@ class ArgumentBuilder {
   //! Build an argument list where each argument has its own line
   ArgumentBuilder(int indent_level, const char* tab) {
     std::stringstream ss;
-    for (const auto i : c10::irange(indent_level)) {
+    for (const auto i : arange(indent_level)) {
       (void)i; // Suppress unused variable warning
       ss << tab;
     }
@@ -335,7 +335,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     // Generate parameter declarations
     kernel_params_.reserve(kernel_->parameters().size());
     unsigned int duplicate_counter = 0;
-    for (auto i : c10::irange(kernel_->parameters().size())) {
+    for (auto i : arange(kernel_->parameters().size())) {
       std::stringstream var_name_ss;
       auto param = kernel_->parameters().at(i);
       kernel_params_.insert(param);
@@ -557,7 +557,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   std::ostream& indent() {
-    for (const auto i : c10::irange(block_nest_level_)) {
+    for (const auto i : arange(block_nest_level_)) {
       (void)i; // Suppress unused variable warning
       code_ << kTab;
     }
@@ -817,7 +817,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     }
     auto dtype = std::get<StructType>(sop->output(0)->dtype().type);
     code_ << dtype.name << "{ ";
-    for (auto i : c10::irange(sop->inputs().size())) {
+    for (auto i : arange(sop->inputs().size())) {
       if (i > 0) {
         code_ << ", ";
       }
@@ -906,7 +906,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       // Generate other datatypes in double
     }
     code_ << "(" << gen(rop->input(0));
-    for (auto inp_i : c10::irange(1, rop->inputs().size())) {
+    for (auto inp_i : arange(1, rop->inputs().size())) {
       code_ << ", " << gen(rop->input(inp_i));
     }
     code_ << ");\n";
@@ -2106,8 +2106,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     ArgumentBuilder func_args(block_nest_level_ + 1, kTab);
 
     // Append arguments for each reduction
-    for (const auto i :
-         c10::irange(grouped_grop->numHorizontallyGroupedExprs())) {
+    for (const auto i : arange(grouped_grop->numHorizontallyGroupedExprs())) {
       NVF_ERROR(
           grouped_grop->reduction_buffers().at(i)->buffer()->isA<TensorView>());
       const auto work_buffer =
@@ -2221,7 +2220,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     for (const auto& index_values : index_val_sets) {
       NVF_ERROR(loop_indices.size() == index_values.size());
       std::unordered_map<const Val*, int64_t> index_val_map;
-      for (const auto i : c10::irange(loop_indices.size())) {
+      for (const auto i : arange(loop_indices.size())) {
         auto loop_index = loop_indices.at(i);
         auto index_val = index_values.at(i);
         index_val_map.emplace(loop_index, index_val);
@@ -2280,15 +2279,14 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     ArgumentBuilder write_preds;
 
     for (const auto expr_index :
-         c10::irange(grouped_grop->numHorizontallyGroupedExprs())) {
+         arange(grouped_grop->numHorizontallyGroupedExprs())) {
       const auto data_type = grouped_grop->outputs().at(expr_index)->dtype();
       NVF_ERROR(grouped_grop->reduction_buffers()
                     .at(expr_index)
                     ->buffer()
                     ->isA<TensorView>());
 
-      for (const auto& group_index :
-           c10::irange(index_replacement_maps.size())) {
+      for (const auto& group_index : arange(index_replacement_maps.size())) {
         // Set the index replacement map with the concrete values of
         // indices of grouped loops.
         index_replacement_map_ = index_replacement_maps.at(group_index);
@@ -2422,13 +2420,12 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     auto init_vals = grouped_gwop->initVals();
 
     for (const auto expr_index :
-         c10::irange(grouped_gwop->numHorizontallyGroupedExprs())) {
+         arange(grouped_gwop->numHorizontallyGroupedExprs())) {
       const auto& output = output_vals.at(expr_index);
       const auto& input = input_vals.at(expr_index);
       const auto& init = init_vals.at(expr_index);
 
-      for (const auto& group_index :
-           c10::irange(index_replacement_maps.size())) {
+      for (const auto& group_index : arange(index_replacement_maps.size())) {
         // Set the index replacement map with the concrete values of
         // indices of grouped loops.
         index_replacement_map_ = index_replacement_maps.at(group_index);
@@ -2442,7 +2439,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
                std::to_string(group_index));
 
         // Setup arguments for avg, var, and N
-        for (const auto i : c10::irange(3)) {
+        for (const auto i : arange(3)) {
           out_args[i].arg(gen(output.get(i)));
           in_args[i].arg(gen(input.get(i)));
           init_args[i].arg(gen(init.get(i)));
@@ -2589,7 +2586,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     func_args.arg(genComputeBlockDim());
 
     // global buf
-    for (const auto i : c10::irange(3)) {
+    for (const auto i : arange(3)) {
       const auto work_buffer = grouped_gwop->reduction_buffers()[i]
                                    .at(0)
                                    ->buffer()
@@ -3005,7 +3002,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           grouped_rop->writePredicate());
     }
 
-    for (const auto i : c10::irange(num_grouped_exprs)) {
+    for (const auto i : arange(num_grouped_exprs)) {
       NVF_ERROR(grouped_rop->output(i)->isA<kir::TensorIndex>());
 
       const auto output = grouped_rop->output(i)->as<kir::TensorIndex>();
@@ -3267,7 +3264,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     // Indentation for the PTX code
     int utility_block_nest_level = 1;
     std::function<std::ostream&()> indent_utility = [&]() -> std::ostream& {
-      for (auto _ : c10::irange(utility_block_nest_level)) {
+      for (auto _ : arange(utility_block_nest_level)) {
         (void)_;
         utilities << kTab;
       }
@@ -3294,7 +3291,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         if (!asm_->options().immediate_inputs.empty()) {
           utilities << "template <";
           bool first = true;
-          for (auto in_i : c10::irange((int64_t)inputs.size())) {
+          for (auto in_i : arange((int64_t)inputs.size())) {
             if (asm_->options().immediate_inputs.count(in_i)) {
               if (!first) {
                 utilities << ", ";
@@ -3306,7 +3303,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           utilities << ">\n";
         }
         utilities << "__device__ __inline__ void " << utility_name_no_ns << "(";
-        for (auto out_i : c10::irange(outputs.size())) {
+        for (auto out_i : arange(outputs.size())) {
           if (out_i > 0) {
             utilities << ", ";
           }
@@ -3315,7 +3312,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         if (!outputs.empty()) {
           utilities << ", ";
         }
-        for (auto in_i : c10::irange((int64_t)inputs.size())) {
+        for (auto in_i : arange((int64_t)inputs.size())) {
           if (asm_->options().immediate_inputs.count(in_i)) {
             continue;
           }
@@ -3427,7 +3424,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
               auto reg_dtype = get_type_or_index_type(register_);
               if (std::holds_alternative<ArrayType>(reg_dtype.type)) {
                 for (auto i :
-                     c10::irange(std::get<ArrayType>(reg_dtype.type).size)) {
+                     arange(std::get<ArrayType>(reg_dtype.type).size)) {
                   if (i > 0) {
                     next_line();
                   }

--- a/csrc/compute_at.cpp
+++ b/csrc/compute_at.cpp
@@ -66,7 +66,7 @@ std::set<T> set_intersection(const std::set<T>& set1, const std::set<T>& set2) {
 std::deque<std::deque<TensorView*>> tvChains(
     std::deque<std::deque<Val*>> val_chains) {
   std::deque<std::deque<TensorView*>> tv_chains(val_chains.size());
-  for (const auto i : c10::irange(val_chains.size())) {
+  for (const auto i : arange(val_chains.size())) {
     auto tv_iterable = ir_utils::filterByType<TensorView>(val_chains[i]);
     tv_chains[i] =
         std::deque<TensorView*>(tv_iterable.begin(), tv_iterable.end());

--- a/csrc/compute_at.cpp
+++ b/csrc/compute_at.cpp
@@ -15,8 +15,6 @@
 #include <scheduler/tools/inlining.h>
 #include <transform_iter.h>
 
-#include <c10/util/irange.h>
-
 namespace nvfuser {
 
 // Simple selector that only propagates across tensor views in the provided

--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -216,7 +216,7 @@ void IterDomainGraph::mapThroughExpr(Expr* first, Expr* second, bool forward) {
       first->toString(),
       "\nand\n",
       second->toString());
-  for (auto out_i : c10::irange(first_ids.size())) {
+  for (auto out_i : arange(first_ids.size())) {
     exact_nodes_.mapEntries(first_ids[out_i], second_ids[out_i]);
     permissive_nodes_.mapEntries(first_ids[out_i], second_ids[out_i]);
     permissive_resize_nodes_.mapEntries(first_ids[out_i], second_ids[out_i]);
@@ -393,7 +393,7 @@ void IterDomainGraph::build(Fusion* fusion) {
           // p->f, c->c
           std::unordered_map<IterDomain*, IterDomain*> c2f_root_map;
           for (const auto i :
-               c10::irange(first_output_tv->getMaybeRootDomain().size())) {
+               arange(first_output_tv->getMaybeRootDomain().size())) {
             c2f_root_map.insert(std::make_pair(
                 c_tv->getMaybeRootDomain()[i],
                 first_output_tv->getMaybeRootDomain()[i]));
@@ -504,7 +504,7 @@ void IterDomainGraph::build(Fusion* fusion) {
 
         for (auto& dset : permissive_disjoint_sets.disjointSets()) {
           auto& vec = dset->vector();
-          for (auto i : c10::irange(vec.size())) {
+          for (auto i : arange(vec.size())) {
             auto id1 = vec[i];
             permissive_nodes_.mapEntries(id1, vec[0]);
 
@@ -513,7 +513,7 @@ void IterDomainGraph::build(Fusion* fusion) {
             //  or p_id is swizzle output.
             mapMaybeSwizzleOp(permissive_nodes_, id1);
 
-            for (auto j : c10::irange(i + 1, vec.size())) {
+            for (auto j : arange(i + 1, vec.size())) {
               auto id2 = vec[j];
               if (p_ids.count(id1) && c_ids.count(id2)) {
                 if (idIsAComputeAtLeafDomain(id1, p_tv, c_tv) &&
@@ -538,11 +538,11 @@ void IterDomainGraph::build(Fusion* fusion) {
         // permissive-resize mappings.
         for (auto& dset : permissive_resize_disjoint_sets.disjointSets()) {
           auto& vec = dset->vector();
-          for (auto i : c10::irange(vec.size())) {
+          for (auto i : arange(vec.size())) {
             auto id1 = vec[i];
             permissive_resize_nodes_.mapEntries(id1, vec[0]);
             mapMaybeSwizzleOp(permissive_resize_nodes_, id1);
-            for (auto j : c10::irange(i + 1, vec.size())) {
+            for (auto j : arange(i + 1, vec.size())) {
               auto id2 = vec[j];
               if (p_ids.count(id1) && c_ids.count(id2)) {
                 consumers_.at(id1).pushBack(id2);
@@ -651,7 +651,7 @@ void IterDomainGraph::build(Fusion* fusion) {
   for (auto prop_forward : {true, false}) {
     std::unordered_set<Expr*> visited_exprs;
 
-    for (auto logical_id_i : c10::irange(logical_id_order.size())) {
+    for (auto logical_id_i : arange(logical_id_order.size())) {
       auto first_logical_id = prop_forward
           ? logical_id_order[logical_id_i]
           : logical_id_order[logical_id_order.size() - 1 - logical_id_i];
@@ -881,8 +881,8 @@ void ComputeAtMap::allocateIndexVariables() {
       // Allocate index variable for each stage of the circular buffered loop.
       circular_buffered_loop_index_variable_map_[loop_disjoint_set.get()] =
           std::make_unique<CircularBufferIndices>();
-      for (auto i : c10::irange(
-               static_cast<int>(CircularBufferLoopStage::EndOfStages))) {
+      for (auto i :
+           arange(static_cast<int>(CircularBufferLoopStage::EndOfStages))) {
         auto stage = static_cast<CircularBufferLoopStage>(i);
         circular_buffered_loop_index_variable_map_[loop_disjoint_set.get()]
             ->emplace(stage, IrBuilder::create<Val>(DataType::Index));
@@ -1260,7 +1260,7 @@ bool ComputeAtMap::areExactExprs(Expr* expr_1, Expr* expr_2) {
           expr_1->outputs().size() == expr_2->outputs().size(),
       "Expr traversal doesn't support variable number of inputs and outputs.");
 
-  for (auto input_i : c10::irange(expr_1->inputs().size())) {
+  for (auto input_i : arange(expr_1->inputs().size())) {
     if (expr_1->inputs()[input_i]->isA<IterDomain>() &&
         !areMapped(
             expr_1->inputs()[input_i]->as<IterDomain>(),
@@ -1271,7 +1271,7 @@ bool ComputeAtMap::areExactExprs(Expr* expr_1, Expr* expr_2) {
     }
   }
 
-  for (auto output_i : c10::irange(expr_1->outputs().size())) {
+  for (auto output_i : arange(expr_1->outputs().size())) {
     if (expr_1->outputs()[output_i]->isA<IterDomain>() &&
         !areMapped(
             expr_1->outputs()[output_i]->as<IterDomain>(),

--- a/csrc/contiguity.cpp
+++ b/csrc/contiguity.cpp
@@ -22,7 +22,7 @@ OrderedIdInformation::OrderedIdInformation(
   }
 
   // Grab allocation ids and initialize them.
-  for (const auto alloc_i : c10::irange(alloc_domain.size())) {
+  for (const auto alloc_i : arange(alloc_domain.size())) {
     auto alloc_id = alloc_domain[alloc_i]->as<IterDomain>();
 
     // Initialize id_to_alloc_ids to map allocs to themselves
@@ -508,7 +508,7 @@ void ContigIDs::build(const std::vector<IterDomain*>& ids) {
       " != ",
       alloc_contiguity_.size());
 
-  for (const auto alloc_domain_i : c10::irange(alloc_domain_.size())) {
+  for (const auto alloc_domain_i : arange(alloc_domain_.size())) {
     auto alloc_domain_id = alloc_domain_.at(alloc_domain_i);
     if (alloc_domain_id->isBroadcast()) {
       NVF_ERROR(!alloc_contiguity_.at(alloc_domain_i).has_value());
@@ -599,7 +599,7 @@ void ContigIDs::handle(Merge* merge) {
   bool is_indexing_pass = !ignore_consistent_ordering_;
 
   IterDomain* last_alloc = nullptr;
-  for (auto alloc_id_i : c10::irange(alloc_domain_.size())) {
+  for (auto alloc_id_i : arange(alloc_domain_.size())) {
     auto alloc_id = alloc_domain_[alloc_id_i];
     if (alloc_id->isBroadcast()) {
       NVF_ERROR(!alloc_contiguity_.at(alloc_id_i).has_value());

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -170,7 +170,7 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
         TensorDomain::noReductions(inp_tv->getLogicalDomain());
     const std::vector<IterDomain*>& out_root = out_tv->getMaybeRootDomain();
     NVF_ERROR(inp_logical.size() == out_root.size());
-    for (auto i : c10::irange((int64_t)out_root.size())) {
+    for (auto i : arange((int64_t)out_root.size())) {
       IterDomain* out_id = out_root[i];
       if (!out_id->isSymbolic()) {
         continue;
@@ -222,7 +222,7 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
     // Vals. These will be the inputs that are explicitly used in the cache ID
     // for KernelArgumentHolder.
     auto dyn_vals = info_.getRootDynamicVals();
-    for (const auto i : c10::irange((int64_t)info_.fusion()->inputs().size())) {
+    for (const auto i : arange((int64_t)info_.fusion()->inputs().size())) {
       auto input = info_.fusion()->inputs().at(i);
       if (dyn_vals.find(input) != dyn_vals.end()) {
         info_.scalar_inputs_affecting_concretization_.insert(i);
@@ -275,7 +275,7 @@ DynamicTransformConcretizationInfo::DynamicTransformConcretizationInfo(
   analyzeFactoryOutputs(expr_eval);
 
   auto maybe_zero_extents = initial_info_->getMaybeZeroExtents();
-  for (auto i : c10::irange((int64_t)maybe_zero_extents.size())) {
+  for (auto i : arange((int64_t)maybe_zero_extents.size())) {
     auto ext = maybe_zero_extents.at(i);
     auto ext_opt = expr_eval->evaluate(ext);
     NVF_ERROR(
@@ -291,7 +291,7 @@ DynamicTransformConcretizationInfo::DynamicTransformConcretizationInfo(
 void DynamicTransformConcretizationInfo::analyzeReshapes(
     ExpressionEvaluator* expr_eval) {
   const auto& reshape_tvs = initial_info_->getDynamicReshapedTensorViews();
-  for (const auto tv_index : c10::irange((int64_t)reshape_tvs.size())) {
+  for (const auto tv_index : arange((int64_t)reshape_tvs.size())) {
     auto out_tv = reshape_tvs.at(tv_index);
     auto op = out_tv->definition()->as<ViewOp>();
     auto inp_tv = op->in()->as<TensorView>();
@@ -312,7 +312,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
     // Determine input shape using expr evaluator
     std::vector<int64_t> inp_shape(inp_dom.size(), 0);
     bool is_empty = false;
-    for (const auto i : c10::irange((int64_t)inp_dom.size())) {
+    for (const auto i : arange((int64_t)inp_dom.size())) {
       auto inp_id = inp_dom.at(i);
       // This should have been validated when initially creating reshape
       // op, but just in case
@@ -345,7 +345,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
     // one domain of extent -1
     std::vector<int64_t> out_shape(out_dom.size(), 0);
     std::vector<int64_t> out_symbolic_sizes;
-    for (const auto i : c10::irange((int64_t)out_dom.size())) {
+    for (const auto i : arange((int64_t)out_dom.size())) {
       auto out_id = out_dom.at(i);
       auto extent_val = expr_eval->evaluate(out_id->extent());
       NVF_ERROR(
@@ -391,7 +391,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
 void DynamicTransformConcretizationInfo::analyzeResizes(
     ExpressionEvaluator* expr_eval) {
   const auto& resize_ids = initial_info_->getDynamicResizedIterDomains();
-  for (const auto id_index : c10::irange((int64_t)resize_ids.size())) {
+  for (const auto id_index : arange((int64_t)resize_ids.size())) {
     auto out_id = resize_ids.at(id_index);
     auto op = out_id->definition()->as<Resize>();
 
@@ -428,7 +428,7 @@ void DynamicTransformConcretizationInfo::analyzeExpands(
     ExpressionEvaluator* expr_eval) {
   const std::vector<TensorView*>& expanded_tvs =
       initial_info_->getDynamicExpandedTensorViews();
-  for (const auto tv_index : c10::irange((int64_t)expanded_tvs.size())) {
+  for (const auto tv_index : arange((int64_t)expanded_tvs.size())) {
     const TensorView* out_tv = expanded_tvs.at(tv_index);
     const TensorView* inp_tv = out_tv->definition()->as<ExpandOp>()->in();
 
@@ -439,7 +439,7 @@ void DynamicTransformConcretizationInfo::analyzeExpands(
     NVF_ERROR(out_root.size() == inp_logical.size());
     std::vector<bool> expand_axes;
     expand_axes.reserve(out_root.size());
-    for (int64_t i : c10::irange((int64_t)out_root.size())) {
+    for (int64_t i : arange((int64_t)out_root.size())) {
       const IterDomain* inp_id = inp_logical[i];
       const IterDomain* out_id = out_root[i];
       if (out_id->isIteration()) {
@@ -476,11 +476,11 @@ void DynamicTransformConcretizationInfo::analyzeFactoryOutputs(
   const std::vector<TensorView*>& factory_tvs =
       initial_info_->getDynamicFactoryOutputs();
   factory_output_itertypes_.reserve(factory_tvs.size());
-  for (const auto tv_index : c10::irange((int64_t)factory_tvs.size())) {
+  for (const auto tv_index : arange((int64_t)factory_tvs.size())) {
     const TensorView* tv = factory_tvs.at(tv_index);
     const std::vector<IterDomain*>& logical_dom = tv->getLogicalDomain();
     std::vector<std::pair<int64_t, IterType>> conc_iter_types;
-    for (int64_t pos : c10::irange((int64_t)logical_dom.size())) {
+    for (int64_t pos : arange((int64_t)logical_dom.size())) {
       const IterDomain* id = logical_dom[pos];
       if (!id->isSymbolic()) {
         continue;
@@ -516,7 +516,7 @@ bool DynamicTransformConcretizationInfo::operator==(
     return false;
   }
 
-  for (const auto i : c10::irange((int64_t)reshape_transforms_.size())) {
+  for (const auto i : arange((int64_t)reshape_transforms_.size())) {
     const auto& analysis = reshape_transforms_.at(i);
     const auto& other_analysis = other.reshape_transforms_.at(i);
     if (analysis != other_analysis) {
@@ -524,7 +524,7 @@ bool DynamicTransformConcretizationInfo::operator==(
     }
   }
 
-  for (const auto i : c10::irange((int64_t)resize_itertypes_.size())) {
+  for (const auto i : arange((int64_t)resize_itertypes_.size())) {
     const auto& itertype = resize_itertypes_.at(i);
     const auto& other_itertype = other.resize_itertypes_.at(i);
     if (itertype != other_itertype) {
@@ -536,7 +536,7 @@ bool DynamicTransformConcretizationInfo::operator==(
     return false;
   }
 
-  for (const auto i : c10::irange((int64_t)expand_axes_.size())) {
+  for (const auto i : arange((int64_t)expand_axes_.size())) {
     const auto& expand_axes = expand_axes_.at(i);
     const auto& other_expand_axes = other.expand_axes_.at(i);
     if (expand_axes != other_expand_axes) {
@@ -544,7 +544,7 @@ bool DynamicTransformConcretizationInfo::operator==(
     }
   }
 
-  for (const auto i : c10::irange((int64_t)empty_extents_.size())) {
+  for (const auto i : arange((int64_t)empty_extents_.size())) {
     const auto& ee = empty_extents_.at(i);
     const auto& other_ee = other.empty_extents_.at(i);
     if (ee != other_ee) {
@@ -609,7 +609,7 @@ std::string DynamicTransformConcretizationInfo::toString() const {
   NVF_ERROR(
       factory_output_itertypes_.size() ==
       initial_info_->getDynamicFactoryOutputs().size());
-  for (int64_t i : c10::irange((int64_t)factory_output_itertypes_.size())) {
+  for (int64_t i : arange((int64_t)factory_output_itertypes_.size())) {
     TensorView* tv = initial_info_->getDynamicFactoryOutputs().at(i);
     indent(ss, 2) << tv->toString() << std::endl;
     for (const auto& [pos, iter_type] : factory_output_itertypes_.at(i)) {
@@ -864,7 +864,7 @@ TensorView* DynamicTransformConcretizer::concretizeEmptyReshape(
       incomplete_out_tv->getLogicalDomain();
   NVF_ERROR(symbolic_sizes.size() == old_logical.size());
   new_shape.reserve(incomplete_out_tv->getLogicalDomain().size());
-  for (size_t i : c10::irange(old_logical.size())) {
+  for (size_t i : arange(old_logical.size())) {
     int64_t symbolic_size = symbolic_sizes[i];
     if (symbolic_size == 0l) {
       new_shape.push_back(inp_tv->fusion()->zeroVal(DataType::Index));
@@ -882,7 +882,7 @@ TensorView* DynamicTransformConcretizer::concretizeEmptyReshape(
   const std::vector<IterDomain*>& new_logical =
       concrete_reshape_out_tv->getLogicalDomain();
   NVF_ERROR(symbolic_sizes.size() == new_logical.size());
-  for (size_t i : c10::irange(symbolic_sizes.size())) {
+  for (size_t i : arange(symbolic_sizes.size())) {
     int64_t symbolic_size = symbolic_sizes[i];
     IterType iter_type =
         symbolic_size == 1l ? IterType::Broadcast : IterType::Iteration;
@@ -982,7 +982,7 @@ void DynamicTransformConcretizer::concretizeExpand() {
     std::vector<IterDomain*> out_logical =
         TensorDomain::noReductions(symbolic_out_tv->getLogicalDomain());
     NVF_ERROR(axis_is_expanded.size() == out_logical.size());
-    for (int64_t i : c10::irange((int64_t)out_logical.size())) {
+    for (int64_t i : arange((int64_t)out_logical.size())) {
       if (!axis_is_expanded[i]) {
         // Propagate as usual for non-expanded IterDomains
         continue;
@@ -1008,7 +1008,7 @@ void DynamicTransformConcretizer::concretizeFactoryOutputs() {
       info_->initialInfo()->getDynamicFactoryOutputs();
   const auto& pair_vecs = info_->getFactoryOutputIterTypes();
   NVF_ERROR(factory_tvs.size() == pair_vecs.size());
-  for (const int64_t i : c10::irange((int64_t)factory_tvs.size())) {
+  for (const int64_t i : arange((int64_t)factory_tvs.size())) {
     TensorView* tv = factory_tvs[i];
     const std::vector<std::pair<int64_t, IterType>>& pair_vec = pair_vecs[i];
     for (auto& [pos, iter_type] : pair_vec) {
@@ -1095,7 +1095,7 @@ void DynamicTransformConcretizer::mutate(TensorView* tv) {
       IterType iter_type = IterType::Symbolic;
       const auto input_ids =
           ir_utils::filterByType<IterDomain>(expr->inputs()).vector();
-      for (auto i : c10::irange((int64_t)input_ids.size())) {
+      for (auto i : arange((int64_t)input_ids.size())) {
         auto inp_id = input_ids.at(i);
         auto updated_id = maybeMutated(inp_id)->as<IterDomain>();
         NVF_CHECK(
@@ -1209,7 +1209,7 @@ void DynamicTransformConcretizer::mutate(TensorDomain* td) {
       new_maybe_alloc.size() == original_alloc.size(),
       "rank of allocation domain shouldn't change in concretization");
 
-  for (const auto i : c10::irange((int64_t)original_alloc.size())) {
+  for (const auto i : arange((int64_t)original_alloc.size())) {
     auto original_id = original_alloc.at(i);
     if (original_id->getIterType() != IterType::Symbolic) {
       continue;
@@ -1348,7 +1348,7 @@ bool DynamicTransformConcretizer::propagateFromProducerToConsumer(
 
   bool is_concretized = false;
 
-  for (const auto i : c10::irange((int64_t)root_domain.size())) {
+  for (const auto i : arange((int64_t)root_domain.size())) {
     auto root_id = root_domain.at(i);
     if (root_id->getIterType() != IterType::Symbolic) {
       continue;

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -187,7 +187,7 @@ void PrecomputedValues::bindValues(
   NVF_ERROR(
       args.size() == inputs.size(), "kernel inputs size does not match args");
 
-  for (const auto i : c10::irange((int64_t)inputs.size())) {
+  for (const auto i : arange((int64_t)inputs.size())) {
     const auto input = inputs[i];
     NVF_ERROR(input != nullptr);
     if (auto* tv = dynamic_cast<TensorView*>(input)) {
@@ -210,7 +210,7 @@ void PrecomputedValues::initializeValueList(
   values_ = std::vector<PolymorphicValue>(num_of_values_, PolymorphicValue());
 
   // Fill in constants and assign evaluator indices
-  for (const auto i : c10::irange(num_of_values_)) {
+  for (const auto i : arange(num_of_values_)) {
     // Use an expression evaluator to test if value is const
     // Structs must be bound directly
     if (!isStructType(sorted_value_list[i]->dtype()) &&
@@ -236,7 +236,7 @@ const PolymorphicValue& PrecomputedValues::getMaybeValueFor(
 
 void PrecomputedValues::print() const {
   debug() << "Precomputed Values:\n";
-  for (auto i : c10::irange(symbols_.size())) {
+  for (auto i : arange(symbols_.size())) {
     if (defined_[i]) {
       debug() << symbols_[i]->toInlineString() << " = "
               << PolymorphicValue_functions::toString(values_[i]) << std::endl;
@@ -282,7 +282,7 @@ PrecomputedValues PrecomputedValues::clone(IrCloner& ir_cloner) const {
       pv.binding_log_.end(), binding_log_.begin(), binding_log_.end());
 
   pv.symbols_.resize(symbols_.size());
-  for (const auto i : c10::irange(symbols_.size())) {
+  for (const auto i : arange(symbols_.size())) {
     pv.symbols_[i] = ir_cloner.clone(symbols_[i]);
   }
 
@@ -350,8 +350,7 @@ void PrecomputedValues::bindTensorMetaData(
       "Something went wrong configuring launch. Inputs do not match.");
 
   std::vector<int64_t> logical_sizes = unshardedSizes(tv, tensor.sizes());
-  for (const auto dim :
-       c10::irange(static_cast<int64_t>(logical_domain.size()))) {
+  for (const auto dim : arange(static_cast<int64_t>(logical_domain.size()))) {
     IterDomain* id = logical_domain[dim];
     const auto dim_size = logical_sizes.at(dim);
     if (id->isBroadcast()) {
@@ -442,7 +441,7 @@ void NaiveValueMachine::copyFrom(const NaiveValueMachine& other) {
 }
 
 void NaiveValueMachine::run() {
-  for (const auto i : c10::irange(num_of_instructions_)) {
+  for (const auto i : arange(num_of_instructions_)) {
     // Skip this instruction if the dest location
     //  has already been computed or is constant.
     if (precomputed_values_.defined_[dest_[i]] ||

--- a/csrc/exceptions.cpp
+++ b/csrc/exceptions.cpp
@@ -13,6 +13,7 @@
 #include <exceptions.h>
 #include <execinfo.h>
 
+#include <utils.h>
 #include <cstdlib>
 #include <functional>
 #include <iostream>
@@ -191,7 +192,7 @@ std::string _get_backtrace(
   // Toggles to true after the first skipped python frame.
   bool has_skipped_python_frames = false;
 
-  for (const auto frame_number : c10::irange(callstack.size())) {
+  for (const auto frame_number : arange(callstack.size())) {
     const auto frame = parse_frame_information(symbols[frame_number]);
 
     if (skip_python_frames && frame && is_python_frame(*frame)) {

--- a/csrc/exceptions.cpp
+++ b/csrc/exceptions.cpp
@@ -8,7 +8,6 @@
 // This is a refactor of the NVF_ERROR and NVF_CHECK macros
 // from PyTorch for implementing NVFuser specific macros.
 
-#include <c10/util/irange.h>
 #include <cxxabi.h>
 #include <exceptions.h>
 #include <execinfo.h>

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -34,7 +34,7 @@ std::string getInputPosString(const Val* val) {
   // Get position
   const std::vector<Val*>& inputs = val->fusion()->inputs();
   int64_t pos = -1;
-  for (size_t i : c10::irange(inputs.size())) {
+  for (size_t i : arange(inputs.size())) {
     if (inputs[i] == val) {
       pos = (int64_t)i;
       break;
@@ -146,7 +146,7 @@ void ExpressionEvaluator::bindTensorDomain(
       t.dim());
 
   std::vector<int64_t> logical_sizes = unshardedSizes(tv, t.sizes());
-  for (auto i : c10::irange(t.dim())) {
+  for (auto i : arange(t.dim())) {
     auto id = logical_domain[i];
     if (id->isBroadcast()) {
       bind_(id->extent(), 1, evaluate_validate);
@@ -269,7 +269,7 @@ const PolymorphicValue& ExpressionEvaluator::evaluate(
     if (auto def = value->definition()) {
       FUSER_PERF_SCOPE("ExpressionEvaluator::evaluate");
       auto outputs = def->evaluate(*this, known_values);
-      for (auto i : c10::irange(def->outputs().size())) {
+      for (auto i : arange(def->outputs().size())) {
         known_values[def->output(i)] = std::move(outputs[i]);
       }
       maybe_concrete_value = getValue(value, known_values);

--- a/csrc/expr_simplifier.cpp
+++ b/csrc/expr_simplifier.cpp
@@ -1823,7 +1823,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
     }
     if (op == BinaryOpType::Add) { // a + (-a) -> 0
       std::vector<std::tuple<Val*, Val*, size_t>> inv_inputs;
-      for (size_t idx : c10::irange(fop->inputs().size())) {
+      for (size_t idx : arange(fop->inputs().size())) {
         auto inp = fop->input(idx);
         auto def = inp->definition();
         if (auto inv = dynamic_cast<UnaryOp*>(def)) {
@@ -1834,7 +1834,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       }
       std::unordered_set<size_t> remove;
       for (auto [orig, inv, idx] : inv_inputs) {
-        for (size_t idx2 : c10::irange(fop->inputs().size())) {
+        for (size_t idx2 : arange(fop->inputs().size())) {
           auto inp = fop->input(idx2);
           if (remove.count(idx) || remove.count(idx2)) {
             continue;
@@ -1847,7 +1847,7 @@ Val* eliminateTrivialComputation(Val* value, const Context& context) {
       }
       if (!remove.empty()) {
         std::vector<Val*> new_inputs;
-        for (size_t idx : c10::irange(fop->inputs().size())) {
+        for (size_t idx : arange(fop->inputs().size())) {
           if (!remove.count(idx)) {
             new_inputs.emplace_back(fop->input(idx));
           }
@@ -2214,14 +2214,14 @@ Val* distributeDivisibleDivMod(Val* value, const Context& context) {
   if (!fop) {
     return value;
   }
-  for (auto i : c10::irange(fop->inputs().size())) {
+  for (auto i : arange(fop->inputs().size())) {
     Val* divisible_term = fop->input(i);
     if (!prove::isMultipleOf(divisible_term, rhs)) {
       continue;
     }
     std::vector<Val*> other_terms;
     other_terms.reserve(fop->inputs().size() - 1);
-    for (auto j : c10::irange(fop->inputs().size())) {
+    for (auto j : arange(fop->inputs().size())) {
       if (j == i) {
         continue;
       }
@@ -2581,7 +2581,7 @@ Val* fundamentalDivisionWithRemainderProperty(
     if (fmul == nullptr) {
       return result;
     }
-    for (auto j : c10::irange(fmul->inputs().size())) {
+    for (auto j : arange(fmul->inputs().size())) {
       auto vmul = fmul->input(j);
       if (!isIntegralType(*vmul->getDataType())) {
         continue;
@@ -2594,7 +2594,7 @@ Val* fundamentalDivisionWithRemainderProperty(
         auto a = bop->lhs();
         auto b = bop->rhs();
         std::vector<Val*> other_terms;
-        for (auto k : c10::irange(fmul->inputs().size())) {
+        for (auto k : arange(fmul->inputs().size())) {
           if (j == k) {
             continue;
           }
@@ -2618,7 +2618,7 @@ Val* fundamentalDivisionWithRemainderProperty(
   };
   // Find a / b * b or a / b * (b*c)
   std::vector<std::tuple<size_t, Val*, Val*, Val*>> divmuls;
-  for (auto i : c10::irange(fadd->inputs().size())) {
+  for (auto i : arange(fadd->inputs().size())) {
     auto vadd = fadd->input(i);
     if (!isIntegralType(*vadd->getDataType())) {
       continue;
@@ -2629,7 +2629,7 @@ Val* fundamentalDivisionWithRemainderProperty(
   }
   // Find a % b or a % b * c
   std::vector<std::tuple<size_t, Val*, Val*, Val*>> modmuls;
-  for (auto i : c10::irange(fadd->inputs().size())) {
+  for (auto i : arange(fadd->inputs().size())) {
     auto vadd = fadd->input(i);
     if (!isIntegralType(*vadd->getDataType())) {
       continue;
@@ -2673,7 +2673,7 @@ Val* fundamentalDivisionWithRemainderProperty(
         // As: [1] + [2] + a * c ... + ...  + ...
         Val* ac = maybeFlattenedOpOf(BinaryOpType::Mul, {a1, c});
         std::vector<Val*> terms{ac};
-        for (auto k : c10::irange(fadd->inputs().size())) {
+        for (auto k : arange(fadd->inputs().size())) {
           if (k == i || k == j) {
             continue;
           }
@@ -2719,8 +2719,8 @@ Val* cancelTermsInPredicate(Val* value, const Context& context) {
 
   std::vector<bool> common_lhs_terms(lhs_terms.size(), false);
   std::vector<bool> common_rhs_terms(rhs_terms.size(), false);
-  for (const auto lhs_i : c10::irange(lhs_terms.size())) {
-    for (const auto rhs_i : c10::irange(rhs_terms.size())) {
+  for (const auto lhs_i : arange(lhs_terms.size())) {
+    for (const auto rhs_i : arange(rhs_terms.size())) {
       // Make sure no multiple LHS terms are removed for the same RHS term
       if (common_rhs_terms.at(rhs_i)) {
         continue;
@@ -2741,14 +2741,14 @@ Val* cancelTermsInPredicate(Val* value, const Context& context) {
   }
 
   std::vector<Val*> new_lhs_terms;
-  for (const auto i : c10::irange(lhs_terms.size())) {
+  for (const auto i : arange(lhs_terms.size())) {
     if (!common_lhs_terms.at(i)) {
       new_lhs_terms.push_back(lhs_terms[i]);
     }
   }
 
   std::vector<Val*> new_rhs_terms;
-  for (const auto i : c10::irange(rhs_terms.size())) {
+  for (const auto i : arange(rhs_terms.size())) {
     if (!common_rhs_terms.at(i)) {
       new_rhs_terms.push_back(rhs_terms[i]);
     }

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -227,7 +227,7 @@ std::vector<SegmentedGroup::NeighborGroup> SegmentedGroup::
   std::vector<bool> can_merge(neighbors.size(), true);
 
   // Find neighbors with a level that is only 1 differant than this groups level
-  for (const auto i : c10::irange(neighbors.size())) {
+  for (const auto i : arange(neighbors.size())) {
     if (std::abs(neighbors[i].group->level_ - level_) > 1) {
       can_merge[i] = false;
     }
@@ -236,7 +236,7 @@ std::vector<SegmentedGroup::NeighborGroup> SegmentedGroup::
   // Check neighbor of neighbors we're considering, if any of them are merged
   // with another node, make sure the resulting edge wouldn't have a level
   // difference of 1
-  for (const auto i : c10::irange(neighbors.size())) {
+  for (const auto i : arange(neighbors.size())) {
     if (!can_merge[i]) {
       continue;
     }
@@ -270,7 +270,7 @@ std::vector<SegmentedGroup::NeighborGroup> SegmentedGroup::
   }
 
   std::vector<NeighborGroup> merge_candidates;
-  for (const auto i : c10::irange(neighbors.size())) {
+  for (const auto i : arange(neighbors.size())) {
     if (can_merge[i]) {
       merge_candidates.push_back(neighbors[i]);
     }
@@ -379,7 +379,7 @@ std::ostream& operator<<(std::ostream& os, const SegmentedGroup* group) {
       [](auto expr_a, auto expr_b) -> bool {
         return expr_a->name() < expr_b->name();
       });
-  for (const auto i : c10::irange(expr_to_print.size())) {
+  for (const auto i : arange(expr_to_print.size())) {
     os << expr_to_print[i]->name();
     if (i + 1 != expr_to_print.size()) {
       os << ", ";
@@ -607,7 +607,7 @@ void SegmentedFusion::deserialize(const serde::SegmentedFusion* buffer) {
   }
 
   // Create segmented edges
-  for (auto idx : c10::irange(buffer->edges()->size())) {
+  for (auto idx : arange(buffer->edges()->size())) {
     auto se_fb = buffer->edges()->Get(idx);
     newEdge(
         groups_.at(se_fb->from_segmented_group()),
@@ -616,7 +616,7 @@ void SegmentedFusion::deserialize(const serde::SegmentedFusion* buffer) {
   }
 
   // Deserialize segmented groups
-  for (auto idx : c10::irange(buffer->groups()->size())) {
+  for (auto idx : arange(buffer->groups()->size())) {
     auto sg_fb = buffer->groups()->Get(idx);
     groups_.at(idx)->deserialize(sg_fb, vals, exprs, groups_, edges_);
   }
@@ -1115,7 +1115,7 @@ void detailGroupPrint(std::ostream& os, const SegmentedGroup* group) {
 
   auto expr_to_print = groupExprPrintSorting(group->exprs());
 
-  for (const auto i : c10::irange(expr_to_print.size())) {
+  for (const auto i : arange(expr_to_print.size())) {
     os << expr_to_print[i]->toString();
     os << "(" << expr_to_print[i]->name() << ")" << std::endl;
   }
@@ -1600,7 +1600,7 @@ GroupSet GroupDependencyAnalysis::getCommonProducersOf(
 
   // Get intersection of producers
   GroupSet common_producers = *(known_producers_of_.at(groups[0]));
-  for (const auto i : c10::irange(1, groups.size())) {
+  for (const auto i : arange(1, groups.size())) {
     common_producers = groupSetIntersection(
         common_producers, *(known_producers_of_.at(groups[i])));
   }
@@ -1768,7 +1768,7 @@ std::ostream& operator<<(
 
   // Do a reverse look up to check the order of sorted groups
   std::unordered_map<SegmentedGroup*, size_t> group_order;
-  for (const auto i : c10::irange(sorted_groups_to_print.size())) {
+  for (const auto i : arange(sorted_groups_to_print.size())) {
     group_order[sorted_groups_to_print[i]] = i;
   }
 
@@ -1864,7 +1864,7 @@ void eraseInputDistinctRootDomains(Fusion* fusion) {
       // consistently with the mapping from the old TensorView logical domain to
       // its allocation domain
       std::unordered_map<IterDomain*, IterDomain*> old_to_new;
-      for (const auto i : c10::irange(logical.size())) {
+      for (const auto i : arange(logical.size())) {
         old_to_new.emplace(logical[i], new_logical_domain[i]);
       }
 
@@ -1920,7 +1920,7 @@ void eraseInputDistinctRootDomains(Fusion* fusion) {
     // Remove reduction domains from new_td
     if (new_td->hasReduction()) {
       std::vector<std::optional<bool>> no_red_contiguity;
-      for (size_t i : c10::irange(new_td->maybeAllocation().size())) {
+      for (size_t i : arange(new_td->maybeAllocation().size())) {
         if (new_td->maybeAllocation()[i]->isReduction()) {
           continue;
         }
@@ -2940,7 +2940,7 @@ bool TranslateApplicableWelford::wouldTranslateToPersistent(
     // If only average is used from welford, we should still translate, but we
     // might not detect persistence if variance isn't actually used/marked as an
     // output in the test.
-    for (auto outs_i : c10::irange(welford_avgs.size())) {
+    for (auto outs_i : arange(welford_avgs.size())) {
       auto avg = welford_avgs[outs_i];
       auto var = welford_vars[outs_i];
       if (avg->uses().empty()) {
@@ -3005,7 +3005,7 @@ void TranslateApplicableWelford::translateSingleWelford(WelfordOp* welford) {
   //  counting.
   Val* num_features = IrBuilder::create<Val>(1.0);
   std::vector<bool> broadcast_mask(in_logical.size(), false);
-  for (const auto i : c10::irange((int64_t)in_logical.size())) {
+  for (const auto i : arange((int64_t)in_logical.size())) {
     if (out_logical.at(i)->isReduction()) {
       red_axes.push_back(i);
       broadcast_mask[i] = true;
@@ -3119,7 +3119,7 @@ class CombineReductions {
       // Merge one pair of reduction groups at a time, and need
       //  the pass to update dependency info along the way to avoid cycles
       for (const auto first_group_index :
-           c10::irange(groups_with_reductions_.size())) {
+           arange(groups_with_reductions_.size())) {
         if (merged_groups) {
           // Need to break and re-enter this loop because
           // groups_with_reductions_ will be updated
@@ -3131,8 +3131,8 @@ class CombineReductions {
         auto first_group_signature =
             group_reduction_signature_map_.at(first_group);
 
-        for (const auto second_group_index : c10::irange(
-                 first_group_index + 1, groups_with_reductions_.size())) {
+        for (const auto second_group_index :
+             arange(first_group_index + 1, groups_with_reductions_.size())) {
           if (merged_groups) {
             // Need to break and re-enter this loop because
             // groups_with_reductions_ will be updated
@@ -3480,7 +3480,7 @@ class CombineReductions {
         return false;
       }
 
-      for (const auto i : c10::irange(reduction_axes_.size())) {
+      for (const auto i : arange(reduction_axes_.size())) {
         if (reduction_axes_[i] != reduction_signature->reduction_axes_[i]) {
           return false;
         }
@@ -3531,7 +3531,7 @@ class CombineReductions {
       auto& root_domain = out_tv->getLogicalDomain();
       root_domain_size_ = root_domain.size();
 
-      for (const auto i : c10::irange(root_domain_size_)) {
+      for (const auto i : arange(root_domain_size_)) {
         if (root_domain[i]->isReduction()) {
           reduction_axes_.push_back(i);
         }
@@ -4226,7 +4226,7 @@ void SegmentCandidateFinder::privatizeUpcast() {
       continue;
     }
 
-    for (const auto i : c10::irange(expr->inputs().size())) {
+    for (const auto i : arange(expr->inputs().size())) {
       auto maybe_upcast_out_tv = dynamic_cast<TensorView*>(expr->input(i));
       if (maybe_upcast_out_tv == nullptr) {
         continue;

--- a/csrc/grouped_reduction.cpp
+++ b/csrc/grouped_reduction.cpp
@@ -30,7 +30,7 @@ namespace {
 // Return if ref and other are transformed in the same way.
 bool hasMatchingTransformations(TensorView* ref, TensorView* other) {
   std::unordered_map<IterDomain*, IterDomain*> ref_2_other;
-  for (const auto i : c10::irange(ref->getLogicalDomain().size())) {
+  for (const auto i : arange(ref->getLogicalDomain().size())) {
     ref_2_other.emplace(
         ref->getLogicalDomain().at(i), other->getLogicalDomain().at(i));
   }
@@ -39,7 +39,7 @@ bool hasMatchingTransformations(TensorView* ref, TensorView* other) {
                     other->getLoopDomain(), ref->getLoopDomain(), ref_2_other)
                     .getIterDomainEquivalence();
 
-  for (const auto i : c10::irange(ref->nDims())) {
+  for (const auto i : arange(ref->nDims())) {
     if (!replay.permissiveAreMapped(ref->axis(i), other->axis(i))) {
       return false;
     }
@@ -76,7 +76,7 @@ bool validateReductionGrouping(
   // condition and could be made more flexible
   const auto uses_of_ref =
       ref_tv->hasComputeWith() ? ref_tv->uses() : std::vector<Expr*>();
-  for (const auto i : c10::irange(inputs.size())) {
+  for (const auto i : arange(inputs.size())) {
     auto output_tv = outputs.at(i)->as<TensorView>();
     const auto& output_domain = output_tv->getLogicalDomain();
     if (ref_tv == output_tv) {
@@ -102,7 +102,7 @@ bool validateReductionGrouping(
         output_tv->nDims(),
         ". Invalid output tensor: ",
         output_tv->toString());
-    for (const auto i : c10::irange(num_logical_dims)) {
+    for (const auto i : arange(num_logical_dims)) {
       auto ref_id = ref_domain.at(i);
       auto output_id = output_domain.at(i);
       // If an IterDomain is broadcast, require the other
@@ -216,7 +216,7 @@ bool groupReductions(
   std::vector<Val*> outputs(num_reductions);
   std::vector<Val*> inputs(num_reductions);
 
-  for (const auto i : c10::irange(num_reductions)) {
+  for (const auto i : arange(num_reductions)) {
     auto reduction_out = reduction_outputs.at(i);
     GROUP_REDUCTION_CHECK(
         error_on_failure,

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -8,7 +8,6 @@
 #include <index_compute.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/util/irange.h>
 
 #include <contiguity.h>
 #include <device_lower/analysis/index_compute.h>

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1325,7 +1325,7 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
   // Global striding
   std::vector<Val*> strided_inds(
       alloc_dom.size(), GpuLower::current()->kernel()->zeroVal());
-  for (const auto i : c10::irange(alloc_dom.size())) {
+  for (const auto i : arange(alloc_dom.size())) {
     Val* alloc_ind = alloc_indices.at(i);
 
     if (alloc_ind->isZeroInt()) {
@@ -1523,7 +1523,7 @@ std::vector<Val*> Index::getNonGlobalProducerStridedIndices(
     is_mma_allocation = [](const IterDomain* id) { return false; };
   }
 
-  for (const auto i : c10::irange(alloc_dom.size())) {
+  for (const auto i : arange(alloc_dom.size())) {
     if (skip_indexing.count(alloc_dom[i])) {
       continue;
     }
@@ -1549,7 +1549,7 @@ std::vector<Val*> Index::getNonGlobalProducerStridedIndices(
 
     // Compute striding for this index.
     Val* stride = nullptr;
-    for (const auto j : c10::irange(i + 1, alloc_dom.size())) {
+    for (const auto j : arange(i + 1, alloc_dom.size())) {
       if (skip_indexing.count(alloc_dom[j])) {
         continue;
       }
@@ -1619,7 +1619,7 @@ Val* Index::getLinearLogicalIndex(
         consumer_tv->getLogicalDomain(),
         loops);
     Val* stride = consumer_tv->fusion()->oneVal();
-    for (const auto i : c10::irange(consumer_tv->getLogicalDomain().size())) {
+    for (const auto i : arange(consumer_tv->getLogicalDomain().size())) {
       auto per_dim_index = per_dim_indices.at(i);
       auto logical_id = consumer_tv->getLogicalDomain().at(i);
       auto per_dim_strided_index =
@@ -1688,7 +1688,7 @@ std::vector<Val*> Index::getStrides(TensorView* tv) {
       alloc_dom.size(), GpuLower::current()->kernel()->oneVal());
   {
     int stride_i = 0;
-    for (const auto i : c10::irange(alloc_dom.size())) {
+    for (const auto i : arange(alloc_dom.size())) {
       if (alloc_dom[i]->isReduction() || alloc_dom[i]->isStride()) {
         strides[i] = GpuLower::current()->kernel()->oneVal();
         continue;
@@ -1701,7 +1701,7 @@ std::vector<Val*> Index::getStrides(TensorView* tv) {
 
   NVF_ERROR(alloc_dom.size() == tv->domain()->contiguity().size());
   Val* cur_contig_stride = GpuLower::current()->kernel()->oneVal();
-  for (const auto i : c10::irange(alloc_dom.size())) {
+  for (const auto i : arange(alloc_dom.size())) {
     auto dim = alloc_dom.size() - i - 1;
     if (alloc_dom[dim]->isReduction() || alloc_dom[dim]->isStride()) {
       continue;
@@ -1741,7 +1741,7 @@ std::vector<Val*> Index::getConsumerAllocationIndices(
 
   std::vector<Val*> alloc_inds(
       alloc_dom.size(), GpuLower::current()->kernel()->zeroVal());
-  for (const auto i : c10::irange(alloc_dom.size())) {
+  for (const auto i : arange(alloc_dom.size())) {
     // See a comment in indexing to allocation domains in
     // getGlobalProducerIndex.
     if (alloc_dom[i]->isReduction() || alloc_dom[i]->isBroadcast() ||
@@ -1847,7 +1847,7 @@ std::vector<Val*> Index::getProducerAllocationIndices(
   std::vector<Val*> alloc_inds(
       alloc_dom.size(), GpuLower::current()->kernel()->zeroVal());
 
-  for (const auto i : c10::irange(alloc_dom.size())) {
+  for (const auto i : arange(alloc_dom.size())) {
     auto override_it = override_index.find(alloc_dom[i]);
     const bool is_overriden = override_it != override_index.end();
 
@@ -1901,7 +1901,7 @@ std::vector<Val*> Index::getGlobalConsumerStridedIndices(
       loops.empty() ? nullptr : loops.back()->vectorize_shift();
   std::vector<Val*> strided_inds(
       alloc_inds.size(), GpuLower::current()->kernel()->zeroVal());
-  for (const auto i : c10::irange(alloc_inds.size())) {
+  for (const auto i : arange(alloc_inds.size())) {
     auto override_it = override_index.find((int)i);
     if (override_it != override_index.end()) {
       alloc_inds[i] = override_it->second;
@@ -1965,7 +1965,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
   const auto& alloc_dom = consumer_tv->getMaybeAllocationDomain();
   std::vector<Val*> strided_inds(
       alloc_dom.size(), GpuLower::current()->kernel()->zeroVal());
-  for (const auto i : c10::irange(alloc_dom.size())) {
+  for (const auto i : arange(alloc_dom.size())) {
     if (alloc_dom[i]->isReduction() || alloc_dom[i]->isBroadcast() ||
         alloc_dom[i]->isStride() || alloc_dom[i]->isDeviceDim() ||
         (alloc_dom[i]->isThread() &&
@@ -1998,7 +1998,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
 
     // Compute striding for this index.
     Val* stride = nullptr;
-    for (const auto j : c10::irange(i + 1, alloc_dom.size())) {
+    for (const auto j : arange(i + 1, alloc_dom.size())) {
       if (alloc_dom[j]->isBroadcast() || alloc_dom[j]->isReduction() ||
           alloc_dom[j]->isDeviceDim() || alloc_dom[j]->isStride()) {
         continue;
@@ -2326,7 +2326,7 @@ std::vector<PredicateDomainInfo> getPredicateContigIds(
   }
 
   std::unordered_set<IterDomain*> final_ids;
-  for (auto root_i : c10::irange(consumer_root_domain.size())) {
+  for (auto root_i : arange(consumer_root_domain.size())) {
     auto root_id = consumer_root_domain[root_i];
     if (root_id->maybePartial()) {
       final_ids.insert(root_id);
@@ -2733,7 +2733,7 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
     // These are the box coordinates of the TMA box, which must be of type
     // int32_t. Possible overflow in each of these dims should be checked
     // elsewhere.
-    for (size_t i : c10::irange(indices_inner_to_outer.size())) {
+    for (size_t i : arange(indices_inner_to_outer.size())) {
       indices_inner_to_outer[i] =
           IrBuilder::maybeCastExpr(DataType::Int32, indices_inner_to_outer[i]);
     }

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1275,7 +1275,7 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
   std::vector<Val*> strides(alloc_dom.size(), nullptr);
   {
     int stride_i = 0;
-    for (const auto i : c10::irange(alloc_dom.size())) {
+    for (const auto i : arange(alloc_dom.size())) {
       if (alloc_dom[i]->isReduction()) {
         strides[i] = GpuLower::current()->kernel()->oneVal();
         continue;
@@ -1289,7 +1289,7 @@ std::vector<Val*> Index::getGlobalProducerStridedIndices(
 
   NVF_ERROR(alloc_dom.size() == producer_tv->domain()->contiguity().size());
   Val* cur_contig_stride = GpuLower::current()->kernel()->oneVal();
-  for (const auto i : c10::irange(alloc_dom.size())) {
+  for (const auto i : arange(alloc_dom.size())) {
     auto dim = alloc_dom.size() - i - 1;
     if (alloc_dom[dim]->isReduction()) {
       continue;

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -20,8 +20,6 @@
 
 #include <torch/csrc/jit/ir/ir.h>
 
-#include <c10/util/irange.h>
-
 #include <iostream>
 #include <string>
 #include <unordered_map>

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -150,7 +150,7 @@ bool Val::sameAs(const Statement* other) const {
     }
     // For definition with multiple outputs, only outputs at the same position
     // could be the same
-    for (auto i : c10::irange(definition_->outputs().size())) {
+    for (auto i : arange(definition_->outputs().size())) {
       if ((definition_->output(i) == this) !=
           (other_val->definition_->output(i) == other_val)) {
         return false;
@@ -313,7 +313,7 @@ bool Expr::sameOp(const Expr* other) const {
       attributes().size() != other->attributes().size()) {
     return false;
   }
-  for (const auto i : c10::irange(attributes().size())) {
+  for (const auto i : arange(attributes().size())) {
     if (!attribute(i)->sameAs(other->attribute(i))) {
       return false;
     }
@@ -332,7 +332,7 @@ bool Expr::sameAs(const Statement* other) const {
   if (!sameOp(other_expr)) {
     return false;
   }
-  for (const auto i : c10::irange(inputs().size())) {
+  for (const auto i : arange(inputs().size())) {
     if (!input(i)->sameAs(other_expr->input(i))) {
       return false;
     }

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -978,7 +978,7 @@ class GroupedReductionOp : public Expr {
     auto size = numHorizontallyGroupedExprs();
     std::vector<Val*> result;
     result.reserve(size);
-    for (auto i : c10::irange(2, 2 + size)) {
+    for (auto i : arange(2, 2 + size)) {
       result.emplace_back(attribute(i)->as<Val>());
     }
     return result;
@@ -1277,7 +1277,7 @@ class GroupedWelfordOp : public Expr {
     std::vector<WelfordTriplet> result;
     auto size = outputs().size() / 3;
     result.reserve(size);
-    for (auto i : c10::irange(size)) {
+    for (auto i : arange(size)) {
       result.emplace_back(outAvg(i), outVar(i), outN(i));
     }
     return result;
@@ -1287,7 +1287,7 @@ class GroupedWelfordOp : public Expr {
     std::vector<WelfordTriplet> result;
     auto size = inputs().size() / 3;
     result.reserve(size);
-    for (auto i : c10::irange(size)) {
+    for (auto i : arange(size)) {
       result.emplace_back(inAvg(i), inVar(i), inN(i));
     }
     return result;
@@ -1297,7 +1297,7 @@ class GroupedWelfordOp : public Expr {
     std::vector<WelfordTriplet> result;
     auto size = inputs().size() / 3;
     result.reserve(size);
-    for (auto i : c10::irange(size)) {
+    for (auto i : arange(size)) {
       result.emplace_back(initAvg(i), initVar(i), initN(i));
     }
     return result;

--- a/csrc/ir/iostream.cpp
+++ b/csrc/ir/iostream.cpp
@@ -18,8 +18,6 @@
 #include <kernel.h>
 #include <utils.h>
 
-#include <c10/util/irange.h>
-
 namespace nvfuser {
 
 // Make sure we can inline something, before we attempt to.

--- a/csrc/ir/iostream.h
+++ b/csrc/ir/iostream.h
@@ -33,7 +33,7 @@ static constexpr char const* kTab = "  ";
 
 // Indent the generated code
 inline std::ostream& indent(std::ostream& os, int indent_size) {
-  for (const auto _ : c10::irange(indent_size)) {
+  for (const auto _ : arange(indent_size)) {
     (void)_; // Suppress unused variable warning
     os << "  ";
   }

--- a/csrc/ir/iostream.h
+++ b/csrc/ir/iostream.h
@@ -12,8 +12,6 @@
 
 #include <dispatch.h>
 
-#include <c10/util/irange.h>
-
 #include <iostream>
 
 namespace nvfuser {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -25,7 +25,6 @@
 #include <transform_view.h>
 #include <type.h>
 
-#include <c10/util/irange.h>
 #include <torch/nn/options/embedding.h>
 
 #include <complex>

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -53,7 +53,7 @@ std::string FullOp::toString(int indent_size) const {
   indent(ss, indent_size) << output(0)->toString() << "\n";
   indent_size++;
   indent(ss, indent_size) << " = full({";
-  for (auto i : c10::irange(inputs().size())) {
+  for (auto i : arange(inputs().size())) {
     if (i == inputs().size() - 1) {
       ss << "}";
     }
@@ -74,7 +74,7 @@ std::vector<PolymorphicValue> FullOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   std::vector<int64_t> shape;
-  for (auto i : c10::irange(inputs.size() - 1)) {
+  for (auto i : arange(inputs.size() - 1)) {
     shape.push_back(inputs.at(i).as<int64_t>());
   }
   DataType dtype = getFillValue()->getDataType().value();
@@ -1012,7 +1012,7 @@ StructConstruct::StructConstruct(
 std::string StructConstruct::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << out()->toString() << " = { ";
-  for (int64_t i : c10::irange((int64_t)inputs().size())) {
+  for (int64_t i : arange((int64_t)inputs().size())) {
     if (i > 0) {
       ss << ", ";
     }
@@ -1025,7 +1025,7 @@ std::string StructConstruct::toString(int indent_size) const {
 std::string StructConstruct::toInlineString(int indent_size) const {
   std::stringstream ss;
   ss << "{ ";
-  for (int64_t i : c10::irange((int64_t)inputs().size())) {
+  for (int64_t i : arange((int64_t)inputs().size())) {
     if (i > 0) {
       ss << ", ";
     }
@@ -1045,7 +1045,7 @@ std::vector<PolymorphicValue> StructConstruct::evaluate(
       " inputs");
   PolymorphicValue struct_ =
       std::get<StructType>(output(0)->dtype().type).create();
-  for (int64_t i : c10::irange((int64_t)inputs.size())) {
+  for (int64_t i : arange((int64_t)inputs.size())) {
     struct_->*attribute<std::string>(i) = inputs.at(i);
   }
   return {std::move(struct_)};
@@ -1242,7 +1242,7 @@ BroadcastOp::BroadcastOp(
 
     auto out_size = is_broadcast_dims.size();
     auto num_new_broadcasts = 0;
-    for (const auto i : c10::irange(out_size)) {
+    for (const auto i : arange(out_size)) {
       if (is_broadcast_dims[i]) {
         num_new_broadcasts++;
         auto id = out_dom[i];
@@ -1346,7 +1346,7 @@ SqueezeOp::SqueezeOp(
 
   int64_t in_size = (int64_t)is_squeeze_dims.size();
   auto num_removed_broadcasts = 0;
-  for (const auto i : c10::irange(is_squeeze_dims.size())) {
+  for (const auto i : arange(is_squeeze_dims.size())) {
     if (is_squeeze_dims[i]) {
       num_removed_broadcasts++;
       auto id = in_dom[i];
@@ -1411,7 +1411,7 @@ std::vector<PolymorphicValue> SqueezeOp::evaluate(
       (int64_t)is_squeeze_dims.size() == in.dim(),
       "The dimensions of input tensor and does not match with is_squeeze_dims");
   at::Tensor out = in;
-  for (int64_t i : c10::irange((int64_t)is_squeeze_dims.size())) {
+  for (int64_t i : arange((int64_t)is_squeeze_dims.size())) {
     if (is_squeeze_dims[i]) {
       if (in.stride(i) == 0) {
         // If the input dimension is expanded in this dimension, undo the expand
@@ -1448,7 +1448,7 @@ void SqueezeOp::checkConcretization(Val* old_val, Val* new_val) const {
       " but expected ",
       old_tv->getLogicalDomain().size());
   auto flags = getSqueezeDimFlags();
-  for (auto i : c10::irange(flags.size())) {
+  for (auto i : arange(flags.size())) {
     if (!flags.at(i)) {
       continue;
     }
@@ -1531,7 +1531,7 @@ std::vector<PolymorphicValue> ReductionOp::evaluate(
       "Evaluation for rFactored reductions is not supported.");
 
   std::vector<int64_t> reduction_axes;
-  for (const auto i : c10::irange(int64_t(output->getLogicalDomain().size()))) {
+  for (const auto i : arange(int64_t(output->getLogicalDomain().size()))) {
     auto ax = output->getLogicalDomain().at(i);
     if (ax->isReduction()) {
       reduction_axes.push_back(i);
@@ -1587,7 +1587,7 @@ std::string GroupedReductionOp::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "GroupedReductionOp(\n";
   ++indent_size;
-  for (const auto i : c10::irange(numHorizontallyGroupedExprs())) {
+  for (const auto i : arange(numHorizontallyGroupedExprs())) {
     indent(ss, indent_size)
         << output(i)->toString() << " = reduction( " << input(i)->toString()
         << ", op = " << getReductionOpType(i)
@@ -1617,7 +1617,7 @@ std::vector<PolymorphicValue> GroupedReductionOp::evaluate(
   const auto num_reductions = numHorizontallyGroupedExprs();
   std::vector<PolymorphicValue> grouped_reduction_out;
   grouped_reduction_out.reserve(num_reductions);
-  for (const auto i : c10::irange(num_reductions)) {
+  for (const auto i : arange(num_reductions)) {
     const auto& in_tensor = inputs.at(i).as<at::Tensor>();
     const auto out_tv = output(i)->as<TensorView>();
     NVF_ERROR(
@@ -1625,8 +1625,7 @@ std::vector<PolymorphicValue> GroupedReductionOp::evaluate(
         "Evaluation for rFactored reductions is not supported.");
 
     std::vector<int64_t> reduction_axes;
-    for (const auto id :
-         c10::irange(int64_t(out_tv->getLogicalDomain().size()))) {
+    for (const auto id : arange(int64_t(out_tv->getLogicalDomain().size()))) {
       auto ax = out_tv->getLogicalDomain().at(id);
       if (ax->isReduction()) {
         reduction_axes.push_back(id);
@@ -1677,7 +1676,7 @@ std::vector<WelfordTriplet> WelfordTriplet::clone(
     const std::vector<WelfordTriplet>& src,
     IrCloner* ir_cloner) {
   std::vector<WelfordTriplet> cloned(src.size());
-  for (const auto i : c10::irange(src.size())) {
+  for (const auto i : arange(src.size())) {
     cloned.at(i) = src.at(i).clone(ir_cloner);
   }
   return cloned;
@@ -1846,7 +1845,7 @@ std::vector<PolymorphicValue> WelfordOp::evaluate(
 
   int64_t N = 1;
   std::vector<int64_t> reduction_axes;
-  for (const auto i : c10::irange(int64_t(out_tv->getLogicalDomain().size()))) {
+  for (const auto i : arange(int64_t(out_tv->getLogicalDomain().size()))) {
     auto ax = out_tv->getLogicalDomain().at(i);
     if (ax->isReduction()) {
       reduction_axes.push_back(i);
@@ -1882,7 +1881,7 @@ GroupedWelfordOp::GroupedWelfordOp(
       ", Given: ",
       init_vals.size());
 
-  for (const auto i : c10::irange(num_grouped_ops)) {
+  for (const auto i : arange(num_grouped_ops)) {
     // Check output type
     NVF_ERROR(
         output_vals[i].avg()->getValType().value() == ValType::TensorView ||
@@ -1958,7 +1957,7 @@ GroupedWelfordOp::GroupedWelfordOp(
   }
 
   addDataAttribute(is_allreduce);
-  for (const auto i : c10::irange(num_grouped_ops)) {
+  for (const auto i : arange(num_grouped_ops)) {
     addOutput(output_vals[i].avg());
     addOutput(output_vals[i].var());
     addOutput(output_vals[i].N());
@@ -1975,7 +1974,7 @@ std::string GroupedWelfordOp::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "GroupedWelford(\n";
   ++indent_size;
-  for (const auto i : c10::irange(numHorizontallyGroupedExprs())) {
+  for (const auto i : arange(numHorizontallyGroupedExprs())) {
     indent(ss, indent_size) << outAvg(i)->toString() << " (Avg),\n";
     indent(ss, indent_size) << outVar(i)->toString() << " (Var),\n";
     indent(ss, indent_size) << outN(i)->toString() << " (Count)\n";
@@ -2001,7 +2000,7 @@ std::string GroupedWelfordOp::toInlineString(int indent_size) const {
 }
 
 int GroupedWelfordOp::getExprIndexOfOutput(Val* output_val) const {
-  for (const auto expr_idx : c10::irange(numHorizontallyGroupedExprs())) {
+  for (const auto expr_idx : arange(numHorizontallyGroupedExprs())) {
     if (outputVals().at(expr_idx).getNameOf(output_val).has_value()) {
       return (int)expr_idx;
     }
@@ -2026,7 +2025,7 @@ MmaOp::AxisMapping MmaOp::AxisMapping::trivialMapping(size_t dimension) {
   AxesData a_axes, b_axes;
   a_axes.reserve(dimension);
   b_axes.reserve(dimension);
-  for (size_t i : c10::irange(dimension)) {
+  for (size_t i : arange(dimension)) {
     a_axes.push_back((int64_t)i);
     b_axes.push_back((int64_t)i);
   }
@@ -2142,7 +2141,7 @@ std::vector<PolymorphicValue> ExpandOp::evaluate(
     const std::vector<PolymorphicValue>& inputs) const {
   const auto& in = inputs.at(0).as<at::Tensor>();
   std::vector<int64_t> expanded_size;
-  for (auto i : c10::irange(1, inputs.size())) {
+  for (auto i : arange(1, inputs.size())) {
     expanded_size.push_back((int64_t)inputs.at(i));
   }
   return {in.expand(expanded_size)};
@@ -2167,7 +2166,7 @@ RepeatOp::RepeatOp(IrBuilderPasskey passkey, TensorView* out, TensorView* in)
       "Output should not have reduction IDs.");
 
   bool repetition_found = false;
-  for (const auto i : c10::irange(in_domain.size())) {
+  for (const auto i : arange(in_domain.size())) {
     if (in_domain.at(i)->isBroadcast() && !out_domain.at(i)->isBroadcast()) {
       NVF_ERROR(!in_domain.at(i)->hasExpandedExtent());
       NVF_ERROR(in_domain.at(i)->extent()->isOneInt());
@@ -2209,7 +2208,7 @@ std::vector<PolymorphicValue> RepeatOp::evaluate(
   multipliers.reserve(out()->getLogicalDomain().size());
   const auto c2p =
       PairwiseLogicalDomainMap(in(), out()).mapConsumerToProducer();
-  for (const auto i : c10::irange(out()->getLogicalDomain().size())) {
+  for (const auto i : arange(out()->getLogicalDomain().size())) {
     auto out_id = out()->getLogicalDomain().at(i);
     auto inp_id = c2p.at(out_id);
     auto out_extent = ee.evaluate(out_id->extent()).as<int64_t>();
@@ -3074,7 +3073,7 @@ void validateContiguity(
       contiguity.size(),
       " but needed one of size ",
       allocation_domain.size());
-  for (auto i : c10::irange(contiguity.size())) {
+  for (auto i : arange(contiguity.size())) {
     bool expect_null =
         (allocation_domain.at(i)->isBroadcast() ||
          allocation_domain.at(i)->isReduction());
@@ -3186,7 +3185,7 @@ TensorDomain::TensorDomain(
         "stride_order is not a valid: " + toDelimitedString(stride_order));
 
     allocation_domain_.resize(rank, nullptr);
-    for (auto i : c10::irange(rank)) {
+    for (auto i : arange(rank)) {
       allocation_domain_[rank - 1 - stride_order[i]] = logical_domain_[i];
     }
   }
@@ -3360,31 +3359,31 @@ bool TensorDomain::sameAs(const Statement* const other) const {
     return false;
   }
 
-  for (const auto i : c10::irange(nDims())) {
+  for (const auto i : arange(nDims())) {
     if (!(axis(i)->sameAs(other_td->axis(i)))) {
       return false;
     }
   }
 
-  for (const auto i : c10::irange(root().size())) {
+  for (const auto i : arange(root().size())) {
     if (!(root()[i]->sameAs(other_td->root()[i]))) {
       return false;
     }
   }
 
-  for (const auto i : c10::irange(logical().size())) {
+  for (const auto i : arange(logical().size())) {
     if (!(logical()[i]->sameAs(other_td->logical()[i]))) {
       return false;
     }
   }
 
-  for (const auto i : c10::irange(allocation().size())) {
+  for (const auto i : arange(allocation().size())) {
     if (!(allocation()[i]->sameAs(other_td->allocation()[i]))) {
       return false;
     }
   }
 
-  for (const auto i : c10::irange(loop().size())) {
+  for (const auto i : arange(loop().size())) {
     if (!(loop()[i]->sameAs(other_td->loop()[i]))) {
       return false;
     }
@@ -3444,7 +3443,7 @@ void TensorDomain::setContiguity(
   NVF_ERROR(
       maybeAllocation().size() == contig.size(),
       "Invalid size of contiguity vector");
-  for (auto i : c10::irange(contig.size())) {
+  for (auto i : arange(contig.size())) {
     NVF_CHECK(
         maybeAllocation().at(i)->isBroadcast() != contig.at(i).has_value(),
         "The contiguity of a broadcast dimension must be None. "
@@ -3463,7 +3462,7 @@ std::vector<int64_t> TensorDomain::strideOrder() const {
   std::vector<int64_t> stride_order;
   stride_order.reserve(logical_domain_.size());
 
-  for (size_t logical_idx : c10::irange(logical_domain_.size())) {
+  for (size_t logical_idx : arange(logical_domain_.size())) {
     IterDomain* logical_id = logical_domain_.at(logical_idx);
     auto alloc_iter = std::find(
         allocation_domain_.begin(), allocation_domain_.end(), logical_id);
@@ -3806,7 +3805,7 @@ TensorDomain* TensorDomain::flatten(int64_t start_dim, int64_t end_dim) {
 
   std::vector<IterDomain*> new_root_domain;
   new_root_domain.reserve(inp_domain.size());
-  for (auto i : c10::irange((int64_t)inp_domain.size())) {
+  for (auto i : arange((int64_t)inp_domain.size())) {
     bool is_rfactor_dim = i >= start_dim && i <= end_dim;
     auto inp_id = inp_domain[i];
     auto out_id = IterDomainBuilder(inp_id)
@@ -3826,12 +3825,12 @@ TensorDomain* TensorDomain::flatten(int64_t start_dim, int64_t end_dim) {
 
   std::vector<IterDomain*> logical_domain;
   logical_domain.reserve(new_root_domain.size() - (end_dim - start_dim));
-  for (auto i : c10::irange(start_dim)) {
+  for (auto i : arange(start_dim)) {
     logical_domain.push_back(new_root_domain[i]);
   }
 
   IterDomain* merged_id = new_root_domain[start_dim];
-  for (auto i : c10::irange(start_dim + 1, end_dim + 1)) {
+  for (auto i : arange(start_dim + 1, end_dim + 1)) {
     IterDomain* new_merged_id =
         IterDomainBuilder(
             merged_id->container()->zeroVal(),
@@ -3843,7 +3842,7 @@ TensorDomain* TensorDomain::flatten(int64_t start_dim, int64_t end_dim) {
   }
   logical_domain.push_back(merged_id);
 
-  for (auto i : c10::irange(end_dim + 1, inp_domain.size())) {
+  for (auto i : arange(end_dim + 1, inp_domain.size())) {
     logical_domain.push_back(new_root_domain[i]);
   }
 
@@ -3896,11 +3895,11 @@ std::vector<IterDomain*> TensorDomain::allIDs() const {
 
   // We only care about IDs on the shortest path between domains
   std::unordered_multimap<IterDomain*, IterDomain*> out2in;
-  for (auto i : c10::irange(all_domains.size() - 1)) {
+  for (auto i : arange(all_domains.size() - 1)) {
     if (all_domains[i]->empty()) {
       continue;
     }
-    for (auto j : c10::irange(i + 1, all_domains.size())) {
+    for (auto j : arange(i + 1, all_domains.size())) {
       if (all_domains[j]->empty()) {
         continue;
       }
@@ -4288,7 +4287,7 @@ std::string PadOp::toInlineString(int indent_size) const {
 std::vector<int64_t> PadOp::getPaddedAxes() const {
   auto num_dims = (int64_t)out()->as<TensorView>()->getLogicalDomain().size();
   std::vector<int64_t> padded_axes;
-  for (const auto i : c10::irange(num_dims)) {
+  for (const auto i : arange(num_dims)) {
     auto [left_pad, right_pad] = getPadWidths(i);
     // Filter out non-padded dimension
     if (left_pad->isZeroInt() && right_pad->isZeroInt()) {
@@ -4402,7 +4401,7 @@ std::vector<Slice> SliceOp::getRanges() const {
   auto ndims = num_range_vals / 3;
   std::vector<Slice> ranges(ndims);
   auto range_val_it = getRangeInputBegin();
-  for (const auto i : c10::irange(ndims)) {
+  for (const auto i : arange(ndims)) {
     ranges.at(i) = Slice{
         .start = *range_val_it,
         .stop = *(range_val_it + 1),
@@ -4419,7 +4418,7 @@ std::vector<PolymorphicValue> SliceOp::evaluate(
   std::vector<at::indexing::TensorIndex> ranges;
   auto ranges_offset = getRangeInputOffset();
   auto num_dims = in.dim();
-  for (const auto i : c10::irange(num_dims)) {
+  for (const auto i : arange(num_dims)) {
     auto start = (int64_t)inputs.at(ranges_offset + 3 * i);
     auto stop = (int64_t)inputs.at(ranges_offset + 3 * i + 1);
     auto step = (int64_t)inputs.at(ranges_offset + 3 * i + 2);
@@ -4575,7 +4574,7 @@ int64_t getRFactorDeviceDimensionIndex(const TensorView* tv) {
   // an at::Tensor axis.
   auto logical = TensorDomain::noReductions(tv->getLogicalDomain());
   int64_t rfactor_did_idx = -1;
-  for (auto idx : c10::irange(static_cast<int64_t>(logical.size()))) {
+  for (auto idx : arange(static_cast<int64_t>(logical.size()))) {
     IterDomain* id = logical.at(idx);
     if (id->isRFactorProduct() && id->isDeviceDim()) {
       NVF_ERROR(
@@ -4659,7 +4658,7 @@ std::vector<PolymorphicValue> LinearOp::evaluate(
                                 int64_t num_device_dims) -> void {
     // Record the initial shape for the error message.
     std::vector<int64_t> shape = t.sizes().vec();
-    for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
+    for ([[maybe_unused]] auto _ : arange(num_device_dims)) {
       NVF_CHECK(
           t.size(0) == 1,
           "When the weight is >2D, expect its preceding dimensions and "
@@ -4684,7 +4683,7 @@ std::vector<PolymorphicValue> LinearOp::evaluate(
     out_tensor = at::linear(in, weight);
   }
 
-  for ([[maybe_unused]] auto _ : c10::irange(num_device_dims)) {
+  for ([[maybe_unused]] auto _ : arange(num_device_dims)) {
     out_tensor = out_tensor.unsqueeze(0);
   }
 
@@ -5347,7 +5346,7 @@ std::vector<PolymorphicValue> SdpaBwdOp::evaluate(
   }
 
   std::vector<at::Tensor> bwd_inputs;
-  for (auto idx : c10::irange(6)) {
+  for (auto idx : arange(6)) {
     auto in_tensor = inputs.at(idx).as<at::Tensor>();
     // Removing the size 1 from sharded axis from tensors.
     if (first_dim_is_did) {

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -154,7 +154,7 @@ std::vector<int64_t> normalizeOld2New(
 
   // All available new positions
   std::set<int64_t> all_positions;
-  for (auto i : c10::irange(ndims)) {
+  for (auto i : arange(ndims)) {
     all_positions.insert((int64_t)i);
   }
 
@@ -236,7 +236,7 @@ Expr* transferDefinitionToNewOutputs(
       new_outputs.size() == expr->outputs().size(),
       "Number of new outputs must match old outputs");
   OptOutMutator mutator;
-  for (const auto i : c10::irange(new_outputs.size())) {
+  for (const auto i : arange(new_outputs.size())) {
     auto old_output = expr->outputs().at(i);
     auto new_output = new_outputs.at(i);
     if (new_output == old_output) {
@@ -717,7 +717,7 @@ bool isSqueezeInput(const TensorView* tv) {
 bool isSqueezedID(const TensorView* tv, const IterDomain* id) {
   auto logical_dom = TensorDomain::noReductions(tv->getLogicalDomain());
   auto squeezes = ir_utils::filterByType<SqueezeOp>(tv->uses());
-  for (auto i : c10::irange(logical_dom.size())) {
+  for (auto i : arange(logical_dom.size())) {
     if (logical_dom[i] != id) {
       continue;
     }
@@ -1526,7 +1526,7 @@ std::vector<IterDomain*> strideOrderToAllocation(
   auto rank = stride_order.size();
   std::vector<IterDomain*> allocation_domain_no_red(rank);
 
-  for (auto idx : c10::irange(rank)) {
+  for (auto idx : arange(rank)) {
     allocation_domain_no_red[rank - 1 - stride_order[idx]] =
         logical_domain_no_red[idx];
   }
@@ -1538,7 +1538,7 @@ std::vector<IterDomain*> strideOrderToAllocation(
   // Insert reduction axis at the original index in allocation domain
   std::vector<IterDomain*> allocation_domain(logical_domain.size());
   auto idx_no_red = 0;
-  for (auto idx : c10::irange(logical_domain.size())) {
+  for (auto idx : arange(logical_domain.size())) {
     if (logical_domain.at(idx)->isReduction()) {
       allocation_domain[idx] = logical_domain[idx];
     } else {

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -311,7 +311,7 @@ const char* getPTXConstraints(Val* value) {
 
 std::vector<std::pair<std::string, Val*>> Asm::constraintsAndOutputs() const {
   std::vector<std::pair<std::string, Val*>> result;
-  for (auto i : c10::irange((int64_t)(outputs().size()))) {
+  for (auto i : arange((int64_t)(outputs().size()))) {
     std::string prefix;
     if (options().readable_outputs.count(i) > 0) {
       prefix = "+";
@@ -326,7 +326,7 @@ std::vector<std::pair<std::string, Val*>> Asm::constraintsAndOutputs() const {
 }
 std::vector<std::pair<std::string, Val*>> Asm::constraintsAndInputs() const {
   std::vector<std::pair<std::string, Val*>> result;
-  for (int64_t i : c10::irange((int64_t)inputs().size())) {
+  for (int64_t i : arange((int64_t)inputs().size())) {
     auto in = input(i);
     const char* constraint = nullptr;
     if (options().immediate_inputs.count(i) > 0) {
@@ -358,7 +358,7 @@ std::string Asm::parameters() const {
     } else if (std::holds_alternative<ArrayType>(dtype.type)) {
       auto type = std::get<ArrayType>(dtype.type);
       ss << "{";
-      for (auto i : c10::irange(type.size)) {
+      for (auto i : arange(type.size)) {
         if (i > 0) {
           ss << ", ";
         }
@@ -1143,7 +1143,7 @@ std::string GroupedGridReduction::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "GroupedGridReduction(\n";
   ++indent_size;
-  for (const auto i : c10::irange(numHorizontallyGroupedExprs())) {
+  for (const auto i : arange(numHorizontallyGroupedExprs())) {
     indent(ss, indent_size)
         << output(i)->toString() << " = reduction( " << input(i)->toString()
         << ", op = " << getReductionOpType(i)
@@ -1339,7 +1339,7 @@ GroupedGridWelford::GroupedGridWelford(
   addDataAttribute(ParallelTypeBitmap{});
   NVF_ERROR(reduction_buffers[0].size() == reduction_buffers[1].size());
   NVF_ERROR(reduction_buffers[0].size() == reduction_buffers[2].size());
-  for (auto i : c10::irange(reduction_buffers[0].size())) {
+  for (auto i : arange(reduction_buffers[0].size())) {
     addAttribute(reduction_buffers[0].at(i));
     addAttribute(reduction_buffers[1].at(i));
     addAttribute(reduction_buffers[2].at(i));
@@ -1393,7 +1393,7 @@ std::string GroupedGridWelford::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "GroupedGridWelford(\n";
   ++indent_size;
-  for (const auto i : c10::irange(numHorizontallyGroupedExprs())) {
+  for (const auto i : arange(numHorizontallyGroupedExprs())) {
     indent(ss, indent_size) << outAvg(i)->toString() << " (Avg),\n";
     indent(ss, indent_size) << outVar(i)->toString() << " (Var),\n";
     indent(ss, indent_size) << outN(i)->toString() << " (Count)\n";
@@ -1685,7 +1685,7 @@ std::string RNGOp::toString(int indent_size) const {
   std::stringstream ss;
   ss << output(0)->toString() << " = " << getRNGOpType() << "("
      << input(0)->toString();
-  for (auto inp_i : c10::irange(1, inputs().size())) {
+  for (auto inp_i : arange(1, inputs().size())) {
     ss << ", " << input(inp_i)->toString();
   }
   ss << ")\n";
@@ -1695,7 +1695,7 @@ std::string RNGOp::toString(int indent_size) const {
 std::string RNGOp::toInlineString(int indent_size) const {
   std::stringstream ss;
   ss << getRNGOpType() << "(" << input(0)->toString();
-  for (auto inp_i : c10::irange(1, inputs().size())) {
+  for (auto inp_i : arange(1, inputs().size())) {
     ss << ", " << input(inp_i)->toString();
   }
   ss << ")";

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -1094,7 +1094,7 @@ class GroupedGridReduction final : public GroupedReductionOp {
     auto size = outputs().size();
     std::vector<Allocate*> result;
     result.reserve(size);
-    for (auto i : c10::irange(offset, offset + size)) {
+    for (auto i : arange(offset, offset + size)) {
       result.emplace_back(attribute(i)->as<Allocate>());
     }
     return result;
@@ -1298,7 +1298,7 @@ class GroupedGridWelford final : public GroupedWelfordOp {
     result[0].reserve(size);
     result[1].reserve(size);
     result[2].reserve(size);
-    for (auto i : c10::irange(size)) {
+    for (auto i : arange(size)) {
       result[0].emplace_back(attribute(offset + i * 3)->as<Allocate>());
       result[1].emplace_back(attribute(offset + i * 3 + 1)->as<Allocate>());
       result[2].emplace_back(attribute(offset + i * 3 + 2)->as<Allocate>());

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -174,7 +174,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
   auto pairwiseMapAllIds = [&](std::vector<IterDomain*> producer_ids,
                                std::vector<IterDomain*> consumer_ids) {
     NVF_ERROR(producer_ids.size() == consumer_ids.size());
-    for (auto idx : c10::irange(consumer_ids.size())) {
+    for (auto idx : arange(consumer_ids.size())) {
       IterDomain* producer_id = producer_ids.at(idx);
       IterDomain* consumer_id = consumer_ids.at(idx);
       if (producer_id == nullptr) {
@@ -190,7 +190,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
         ? mma->axisMapping().a_axes
         : mma->axisMapping().b_axes;
     NVF_ERROR(operand_axes.size() == consumer_root.size());
-    for (size_t idx : c10::irange(operand_axes.size())) {
+    for (size_t idx : arange(operand_axes.size())) {
       int64_t operand_pos = operand_axes[idx];
       if (operand_pos == -1) {
         continue;
@@ -267,7 +267,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     }
     size_t num_device_dim = producer_logical.at(0)->isDeviceDim() ? 1 : 0;
     // Map N, H from any input (query/key/value)
-    for (auto idx : c10::irange(consumer_root.size())) {
+    for (auto idx : arange(consumer_root.size())) {
       if (idx < (2 + num_device_dim)) {
         updatePairwiseLogicalDomainMap(
             producer_logical.at(idx), consumer_root.at(idx));
@@ -316,7 +316,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     size_t num_device_dim =
         !producer_logical.empty() && producer_logical.at(0)->isDeviceDim() ? 1
                                                                            : 0;
-    for (auto idx : c10::irange(producer_logical.size())) {
+    for (auto idx : arange(producer_logical.size())) {
       // Map N, H from all producers to consumers
       // producer/consumer[2] = L/S
       // producer/consumer[3] = E/Ev
@@ -339,7 +339,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     //   output = [*, embedding_dim]
     auto ndims_out = consumer_root.size();
     if (producer_tv_->sameAs(op->in())) {
-      for (auto idx : c10::irange(ndims_out - 1)) {
+      for (auto idx : arange(ndims_out - 1)) {
         updatePairwiseLogicalDomainMap(
             producer_logical.at(idx), consumer_root.at(idx));
       }

--- a/csrc/mutator.cpp
+++ b/csrc/mutator.cpp
@@ -5,12 +5,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <c10/util/irange.h>
 #include <exceptions.h>
 #include <fusion.h>
 #include <ir/all_nodes.h>
 #include <ir/builder.h>
-
+#include <utils.h>
 #include <vector>
 
 /*
@@ -219,19 +218,19 @@ Expr* OptOutMutator::mutateExpr(
   }
 
   bool all_same = true;
-  for (auto i : c10::irange(op->outputs().size())) {
+  for (auto i : arange(op->outputs().size())) {
     if (!all_same) {
       break;
     }
     all_same = all_same && mutated_outputs[i] == op->output(i);
   }
-  for (auto i : c10::irange(op->inputs().size())) {
+  for (auto i : arange(op->inputs().size())) {
     if (!all_same) {
       break;
     }
     all_same = all_same && mutated_inputs[i] == op->input(i);
   }
-  for (auto i : c10::irange(op->attributes().size())) {
+  for (auto i : arange(op->attributes().size())) {
     if (!all_same) {
       break;
     }

--- a/csrc/polymorphic_value.cpp
+++ b/csrc/polymorphic_value.cpp
@@ -25,7 +25,7 @@ bool StructHandle::operator==(const StructHandle& other) const {
   if (this_type.fields.size() != other_type.fields.size()) {
     return false;
   }
-  for (size_t i : c10::irange(this_type.fields.size())) {
+  for (size_t i : arange(this_type.fields.size())) {
     // Check that fields are in same position, have same type, and have same
     // value (recursive)
     const StructType::FieldInfo& fa = this_type.fields.at(i);
@@ -53,7 +53,7 @@ std::string toString(const PolymorphicValue& v) {
     StructType type = (v->*&StructHandle::type)();
     ss << "StructHandle<" << type.name << ">{";
     bool first = true;
-    for (size_t i : c10::irange(type.fields.size())) {
+    for (size_t i : arange(type.fields.size())) {
       if (first) {
         first = false;
       } else {

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -19,7 +19,6 @@
 #include <ops/arith.h>
 #include <transform_iter.h>
 
-#include <c10/util/irange.h>
 #include <device_lower/utils.h>
 
 namespace nvfuser {

--- a/csrc/predicate_compute.cpp
+++ b/csrc/predicate_compute.cpp
@@ -246,7 +246,7 @@ ParallelizedDomainPredicate::getPredicateMap(
   auto unswitch_protected_loop_ids =
       getUnswitchProtectedParallelLoopIds(expr, loops, unswitched_loop);
 
-  for (const auto i : c10::irange(loops.size())) {
+  for (const auto i : arange(loops.size())) {
     auto loop = loops[i];
 
     // Parallel dimensions need not be predicated if fully unswitched.
@@ -774,7 +774,7 @@ Val* PredicateCompute::getInlinePredicate(
   }
 
   Val* cond = preds[0];
-  for (const auto i : c10::irange(1, preds.size())) {
+  for (const auto i : arange(1, preds.size())) {
     cond = SimplifyingIrBuilder::logicalAndExpr(cond, preds[i]);
   }
 

--- a/csrc/preseg_passes/allocation_order_inference.cpp
+++ b/csrc/preseg_passes/allocation_order_inference.cpp
@@ -158,7 +158,7 @@ void mapAllocationDomain(
   // initialize new target allocation domain with nullptr
   std::vector<IterDomain*> target_alloc_domain(
       target_logical_domain.size(), nullptr);
-  for (auto i : c10::irange(target_logical_domain.size())) {
+  for (auto i : arange(target_logical_domain.size())) {
     // sharp-edges 1
     // preserves non-mapped reduction id in its original position
     if (target_logical_domain[i]->isReduction() &&

--- a/csrc/preseg_passes/consecutive_cast.cpp
+++ b/csrc/preseg_passes/consecutive_cast.cpp
@@ -97,7 +97,7 @@ Val* replayMetaOnNewInput(
 
     // creating map from original to replayed ID
     std::unordered_map<IterDomain*, IterDomain*> id_map;
-    for (const auto i : c10::irange(meta_tv_out_root_domain.size())) {
+    for (const auto i : arange(meta_tv_out_root_domain.size())) {
       id_map[meta_tv_out_root_domain[i]] = replayed_root_domain[i];
     }
 

--- a/csrc/preseg_passes/move_pad.cpp
+++ b/csrc/preseg_passes/move_pad.cpp
@@ -129,7 +129,7 @@ Val* replaceCatOpWithBinaryOp(const std::vector<Val*>& inputs) {
   Val* (*binary_op)(Val*, Val*) =
       isBooleanType(data_type) ? logical_or_resolved : add_resolved;
   Val* res = inputs[0];
-  for (auto i : c10::irange(1, inputs.size())) {
+  for (auto i : arange(1, inputs.size())) {
     res = binary_op(res, inputs[i]);
   }
   // restore data type if it's promoted by BinaryOp.
@@ -242,9 +242,9 @@ TensorView* replayConcretePad(
     merged_pad_widths = vec_pad_widths.at(0);
   } else {
     merged_pad_widths.reserve(rank * 2);
-    for (const auto i : c10::irange(2 * rank)) {
+    for (const auto i : arange(2 * rank)) {
       Val* merged_pad_width = nullptr;
-      for (const auto idx : c10::irange(vec_pad_widths.size())) {
+      for (const auto idx : arange(vec_pad_widths.size())) {
         // skipping zero pad;
         Val* pad_width = vec_pad_widths[idx].at(i);
         if (pad_width->isZeroInt()) {
@@ -263,7 +263,7 @@ TensorView* replayConcretePad(
   // construct TensorDomain for output TV.
   std::vector<IterDomain*> merged_root_ids;
   std::vector<IterDomain*> merged_logical_ids;
-  for (const auto i : c10::irange(rank)) {
+  for (const auto i : arange(rank)) {
     Val* left_pad = merged_pad_widths.at(i * 2);
     Val* right_pad = merged_pad_widths.at(i * 2 + 1);
     IterDomain* inp_id = inp_dom.at(i);

--- a/csrc/preseg_passes/move_split_cat.cpp
+++ b/csrc/preseg_passes/move_split_cat.cpp
@@ -257,7 +257,7 @@ TensorView* slicesFormSplit(
     }
 
     // Check only the split axis is sliced.
-    for (auto j : c10::irange(
+    for (auto j : arange(
              static_cast<int64_t>(slice->out()->getMaybeRootDomain().size()))) {
       const bool sliced =
           (slice->out()->getMaybeRootDomain()[j] !=

--- a/csrc/preseg_passes/remove_bcast_squeeze.cpp
+++ b/csrc/preseg_passes/remove_bcast_squeeze.cpp
@@ -135,7 +135,7 @@ std::optional<AxisOp> getSimplifiedOpType(const AxisOps& ops) {
 std::vector<bool> nonPreservedDims(const AxisOps& ops) {
   std::vector<bool> flags;
   flags.reserve(ops.size());
-  for (size_t i : c10::irange(ops.size())) {
+  for (size_t i : arange(ops.size())) {
     flags.push_back(ops[i] != AxisOp::PRESERVE);
   }
   return flags;
@@ -379,7 +379,7 @@ TensorView* maybeDoReplacement(TensorView* orig) {
   // Therefore, if resharding is needed, instead of replacing `orig` with
   // `replacement`, we link them with a resharding `set`.
   bool needs_resharding = false;
-  for (size_t i : c10::irange(old_loop.size())) {
+  for (size_t i : arange(old_loop.size())) {
     if (old_loop[i]->getParallelType() != new_loop[i]->getParallelType()) {
       NVF_ERROR(
           old_loop[i]->isDeviceDim() || new_loop[i]->isDeviceDim(),

--- a/csrc/preseg_passes/remove_empty.cpp
+++ b/csrc/preseg_passes/remove_empty.cpp
@@ -56,7 +56,7 @@ class EmptyTensorRemover : public DeadCodeRemover {
   //! `emptyAxes(TensorDomain::noReductions(tv->getLogicalDomain()))`
   std::vector<int64_t> emptyAxes(const std::vector<IterDomain*>& domain) {
     std::vector<int64_t> empty_axes;
-    for (auto ax : c10::irange(domain.size())) {
+    for (auto ax : arange(domain.size())) {
       auto id = domain.at(ax);
       PolymorphicValue extent =
           expr_eval_.evaluate(id->getMaybeExpandedExtent());

--- a/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
+++ b/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
@@ -112,13 +112,11 @@ class NoReductionMatmulToMulSqueezeTranslator {
       auto missing_batch_ndims = std::abs(batch_ndims_a - batch_ndims_b);
       if (missing_batch_ndims) {
         if (batch_ndims_a < batch_ndims_b) {
-          for ([[maybe_unused]] const auto i :
-               c10::irange(missing_batch_ndims)) {
+          for ([[maybe_unused]] const auto i : arange(missing_batch_ndims)) {
             bc_flags_a.push_back(true);
           }
         } else {
-          for ([[maybe_unused]] const auto i :
-               c10::irange(missing_batch_ndims)) {
+          for ([[maybe_unused]] const auto i : arange(missing_batch_ndims)) {
             bc_flags_b.push_back(true);
           }
         }
@@ -126,12 +124,12 @@ class NoReductionMatmulToMulSqueezeTranslator {
 
       // Fill the false flags for the existing IDs
       for ([[maybe_unused]] const auto i :
-           c10::irange(batch_ndims_a + matrix_ndims_a)) {
+           arange(batch_ndims_a + matrix_ndims_a)) {
         bc_flags_a.push_back(false);
       }
 
       for ([[maybe_unused]] const auto i :
-           c10::irange(batch_ndims_b + matrix_ndims_b)) {
+           arange(batch_ndims_b + matrix_ndims_b)) {
         bc_flags_b.push_back(false);
       }
 

--- a/csrc/preseg_passes/translate_repeat_to_expand.cpp
+++ b/csrc/preseg_passes/translate_repeat_to_expand.cpp
@@ -59,7 +59,7 @@ class RepeatToExpandTranslator {
       // Not supported if there are multiple expanded logical IDs
       IterDomain* out_padded_root_id = nullptr;
       bool multiple_resizes_found = false;
-      for (const auto i : c10::irange(pad_out->getLogicalDomain().size())) {
+      for (const auto i : arange(pad_out->getLogicalDomain().size())) {
         auto out_logical_id = pad_out->getLogicalDomain().at(i);
         auto resize = dynamic_cast<Resize*>(out_logical_id->definition());
         if (resize == nullptr) {

--- a/csrc/python_frontend/fusion_record.h
+++ b/csrc/python_frontend/fusion_record.h
@@ -413,7 +413,7 @@ struct SliceOpRecord : RecordFunctor {
     const std::vector<Val*>& stride =
         fd.getFusionStateVector(args_.at(3).index);
     std::vector<Slice> vec_slice;
-    for (const auto idx : c10::irange(arg->domain()->noReductions().size())) {
+    for (const auto idx : arange(arg->domain()->noReductions().size())) {
       // NOTE: there's an extra move, we can use emplace_back if we go write
       // some constructors for Slice.
       Val* start_idx = start.at(idx);
@@ -794,7 +794,7 @@ struct BroadcastInDimOpRecord : RecordFunctor {
         arg->toString());
 
     std::vector<bool> is_broadcast_dim(output_ndims_, true);
-    for (const auto idx : c10::irange(broadcast_dims_.size())) {
+    for (const auto idx : arange(broadcast_dims_.size())) {
       if (idx > 0) {
         NVF_CHECK(
             broadcast_dims_[idx - 1] < broadcast_dims_[idx],
@@ -1327,7 +1327,7 @@ struct TensorRecord : RecordFunctor {
     auto rank = shape_.size();
     std::vector<bool> is_expand(rank);
 
-    for (const auto index : c10::irange(rank)) {
+    for (const auto index : arange(rank)) {
       // since contiguity_ vector is given to the corresponding order in alloc
       // domain, while is_expand is given to root domain, we need to map it
       // correctly with `contig_index` and `index`.
@@ -1489,7 +1489,7 @@ struct OutputRecord : RecordFunctor {
   //! | stride_order hash                              |
   size_t hash() const final {
     size_t stride_order_hash = 0;
-    for (auto i : c10::irange(stride_order_.size())) {
+    for (auto i : arange(stride_order_.size())) {
       stride_order_hash = (stride_order_hash << 4) | stride_order_[i];
     }
     return RecordFunctor::hash() | (stride_order_hash & 0xffffffff);
@@ -1617,7 +1617,7 @@ struct ReductionOpRecord : RecordFunctor {
     size_t axes_hash = 0;
     // Normally I would make a little endian hash of the axes but I do not
     // know the size of the tensor based on just the record information.
-    for (auto i : c10::irange(axes_.size())) {
+    for (auto i : arange(axes_.size())) {
       axes_hash |= (1 << axes_[i]);
     }
 
@@ -2163,7 +2163,7 @@ struct NormOpRecord : RecordFunctor {
     size_t axes_hash = 0;
     // Normally I would make a little endian hash of the axes but I do not
     // know the size of the tensor based on just the record information.
-    for (auto i : c10::irange(axes_.size())) {
+    for (auto i : arange(axes_.size())) {
       axes_hash |= (1 << axes_[i]);
     }
     return result | (static_cast<size_t>(keep_dim_) << 28) |
@@ -2484,7 +2484,7 @@ struct TensorSizesRecord : RecordFunctor {
   void operator()(FusionState& fd) final {
     auto arg = fd.getFusionState(args_.at(0).index)->as<TensorView>();
     auto sizes = shape(arg);
-    for (const auto idx : c10::irange(sizes.size())) {
+    for (const auto idx : arange(sizes.size())) {
       fd.setFusionState(outputs_.at(idx).index, sizes[idx]);
     }
   }

--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -594,7 +594,7 @@ void dumpFusionArgs(
     const KernelArgumentHolder& outputs) {
   debug() << "Arguments for fusion" << fusion_id << ":" << std::endl
           << "Inputs:" << std::endl;
-  for (auto i : c10::irange(args.size())) {
+  for (auto i : arange(args.size())) {
     debug() << "  " << args[i] << std::endl;
   }
   debug() << "Outputs:" << std::endl;
@@ -622,7 +622,7 @@ void dumpKernelArgs(
   debug() << "Arguments for fusion " << fusion_id << " group " << group_id
           << ":" << std::endl
           << "Inputs:" << std::endl;
-  for (auto i : c10::irange(num_inputs)) {
+  for (auto i : arange(num_inputs)) {
     debug() << "  " << toString(args[i]) << std::endl;
   }
   debug() << "Outputs:" << std::endl;
@@ -632,7 +632,7 @@ void dumpKernelArgs(
             << std::endl;
   }
   debug() << "Intermediate global buffers:" << std::endl;
-  for (const auto i : c10::irange(intermediates.size())) {
+  for (const auto i : arange(intermediates.size())) {
     const auto& zero_init = intermediates_info.at(i).zero_init;
     const auto& resets_to_zero = intermediates_info.at(i).resets_to_zero;
     debug() << "  " << PolymorphicValue_functions::toString(intermediates[i])
@@ -692,8 +692,7 @@ void KernelExecutor::initializeExecutorEntry(
       compiled_kernel_->kernel()->inputs().size(),
       " got: ",
       args.size());
-  for (auto inp_idx :
-       c10::irange(compiled_kernel_->kernel()->inputs().size())) {
+  for (auto inp_idx : arange(compiled_kernel_->kernel()->inputs().size())) {
     auto input = compiled_kernel_->kernel()->inputs()[inp_idx];
     if (auto input_tv = dynamic_cast<TensorView*>(input)) {
       auto at_tensor = args[inp_idx].as<at::Tensor>();
@@ -736,7 +735,7 @@ void KernelExecutor::initializeExecutorEntry(
     // Need to save the information necessary for allocations as
     // future uses of this KernelExecutorEntry may not be provided with
     // allocated outputs
-    for (auto output_idx : c10::irange(output_args.size())) {
+    for (auto output_idx : arange(output_args.size())) {
       NVF_ERROR(
           output_args[output_idx].hasValue() &&
               output_args[output_idx].is<at::Tensor>(),
@@ -955,7 +954,7 @@ KernelArgumentHolder KernelExecutor::resolveTMA(
   NVF_ERROR(
       entry.inputs.size() == compiled_kernel_->kernel()->inputs().size(),
       "Input size mismatch");
-  for (auto inp_idx : c10::irange(entry.inputs.size())) {
+  for (auto inp_idx : arange(entry.inputs.size())) {
     expr_eval.bind(
         compiled_kernel_->kernel()->inputs()[inp_idx], args[arg_idx++]);
   }
@@ -963,7 +962,7 @@ KernelArgumentHolder KernelExecutor::resolveTMA(
   NVF_ERROR(
       entry.outputs.size() == compiled_kernel_->kernel()->outputs().size(),
       "Output size mismatch");
-  for (auto out_idx : c10::irange(entry.outputs.size())) {
+  for (auto out_idx : arange(entry.outputs.size())) {
     expr_eval.bind(
         compiled_kernel_->kernel()->outputs()[out_idx], args[arg_idx++]);
   }
@@ -1075,7 +1074,7 @@ KernelArgumentHolder KernelExecutor::run(
       }
 
       for (const auto i :
-           c10::irange(compiled_kernel_->kernel()->outputs().size())) {
+           arange(compiled_kernel_->kernel()->outputs().size())) {
         auto param = compiled_kernel_->kernel()->outputs()[i];
         if (!param->isA<TensorView>()) {
           continue;
@@ -1109,7 +1108,7 @@ KernelArgumentHolder KernelExecutor::run(
     // This is simply because the convention used is that allocation
     // sizes/strides are optional, logical are not.
     for (const auto intermediate_i :
-         c10::irange(executor_entry->intermediates.size())) {
+         arange(executor_entry->intermediates.size())) {
       const auto& buf_info = executor_entry->intermediates.at(intermediate_i);
       bool has_expansion = false;
       std::vector<int64_t> unexpanded_sizes;
@@ -1117,8 +1116,7 @@ KernelArgumentHolder KernelExecutor::run(
       NVF_ERROR(
           buf_info.shape_info.logical_sizes.size() ==
           buf_info.shape_info.logical_strides.size())
-      for (const auto j :
-           c10::irange(buf_info.shape_info.logical_sizes.size())) {
+      for (const auto j : arange(buf_info.shape_info.logical_sizes.size())) {
         if (buf_info.shape_info.logical_strides[j] == 0) {
           has_expansion = true;
           unexpanded_sizes.push_back(1L);
@@ -1542,7 +1540,7 @@ void KernelExecutor::deserialize(
   compiled_kernel_->deserialize(buffer);
 
   // GlobalBufferInfo requires lowered kernel before deserialization
-  for (auto idx : c10::irange(buffer->executor_entry_lookup_keys()->size())) {
+  for (auto idx : arange(buffer->executor_entry_lookup_keys()->size())) {
     executor_entry_lookup_.emplace(
         buffer->executor_entry_lookup_keys()->Get(idx),
         deserialize(buffer->executor_entry_lookup_values()->Get(idx)));

--- a/csrc/runtime/executor_kernel_arg.cpp
+++ b/csrc/runtime/executor_kernel_arg.cpp
@@ -23,7 +23,7 @@ namespace {
 
 PrimDataType getSmallestIndexType(const at::Tensor& tensor) {
   KernelIndexTypeCompute index_type_helper;
-  for (const auto dim_i : c10::irange(tensor.ndimension())) {
+  for (const auto dim_i : arange(tensor.ndimension())) {
     auto size = tensor.size(dim_i);
     auto stride = tensor.stride(dim_i);
     if (index_type_helper.addDim(size, stride) == PrimDataType::Int) {
@@ -366,7 +366,7 @@ std::vector<std::byte> tensorToBytes(
 int64_t computeBytes(const KernelArgumentHolder& args) {
   int64_t num_bytes = 0;
   // Figure how many bytes are inputs, outputs, and temporary buffers
-  for (auto i : c10::irange(args.size())) {
+  for (auto i : arange(args.size())) {
     if (args[i].is<at::Tensor>()) {
       auto t = args[i].as<at::Tensor>();
       num_bytes += static_cast<int64_t>(t.storage().nbytes());

--- a/csrc/runtime/fusion_cache_utils.cpp
+++ b/csrc/runtime/fusion_cache_utils.cpp
@@ -23,7 +23,7 @@ namespace {
 template <typename T>
 void encodeBuffer(T value, std::string& buffer) {
   const char* v = reinterpret_cast<char*>(&value);
-  for (const auto i : c10::irange(sizeof(T))) {
+  for (const auto i : arange(sizeof(T))) {
     (void)i; // Suppress unused variable warning
     buffer.push_back(*(v++));
   }
@@ -74,7 +74,7 @@ void ArgumentManager::updateWithSegmentOutputs(
   NVF_ERROR(
       group_outputs.size() == group_runtime_outputs.size(),
       "Output size does not match.");
-  for (const size_t group_out_i : c10::irange(group_outputs.size())) {
+  for (const size_t group_out_i : arange(group_outputs.size())) {
     tensor_map_.emplace(
         group_outputs[group_out_i], group_runtime_outputs[group_out_i]);
   }
@@ -94,13 +94,13 @@ void ArgumentManager::mapFusionInputsToArgs(
   int extent_index = 0;
   auto original_args_size = args.size();
   // Bind args in the tensor_map
-  for (const auto i : c10::irange(original_args_size)) {
+  for (const auto i : arange(original_args_size)) {
     tensor_map_.emplace(fusion_inputs[i], args[i]);
     // Bind tensorview inputs values in case some segmented group
     //  needs it down the road.
     if (args[i].is<at::Tensor>()) {
       auto rank = args[i].as<at::Tensor>().dim();
-      for (const auto dim : c10::irange(rank)) {
+      for (const auto dim : arange(rank)) {
         tensor_map_.emplace(
             group_extent_binding_order[extent_index++],
             args[i].as<at::Tensor>().size(dim));
@@ -119,7 +119,7 @@ void ArgumentManager::setLastUsedSegmentID(
     // start from the 2nd group, since the input of the first group is always
     // the global input and its outputs are always used by at least one of the
     // following groups
-    for (auto run_order_id : c10::irange(1l, num_groups)) {
+    for (auto run_order_id : arange(1l, num_groups)) {
       auto group_to_run = group_run_order.at(run_order_id);
       // set/update life of vals in inputs of this group
       for (auto val : group_to_run->inputs()) {
@@ -156,14 +156,14 @@ void prepareRuntimeOrder(
   std::unordered_set<Val*> available_input;
 
   // setup the order tensor dimensions are bound
-  for (const size_t i : c10::irange(segmented_fusion->inputs().size())) {
+  for (const size_t i : arange(segmented_fusion->inputs().size())) {
     auto input_val = segmented_fusion->inputs()[i];
     available_input.insert(input_val);
 
     if (auto input_tv = dynamic_cast<TensorView*>(input_val)) {
       auto logical_dom =
           TensorDomain::noReductions(input_tv->getLogicalDomain());
-      for (const size_t dim : c10::irange(logical_dom.size())) {
+      for (const size_t dim : arange(logical_dom.size())) {
         const auto extent = logical_dom[dim]->getMaybeExpandedExtent();
         available_input.insert(extent);
         runtime_workspace.group_extent_binding_order.push_back(extent);
@@ -179,8 +179,7 @@ void prepareRuntimeOrder(
     bool one_ran = false;
 
     // Find the first segment with all inputs available to run
-    for (const size_t group_i :
-         c10::irange(segmented_fusion->groups().size())) {
+    for (const size_t group_i : arange(segmented_fusion->groups().size())) {
       auto& group = segmented_fusion->groups()[group_i];
       if (group_ran[group_i]) {
         continue;
@@ -196,7 +195,7 @@ void prepareRuntimeOrder(
         const auto& group_outputs = group->outputs();
 
         // Insert graph segment output to tensor map
-        for (const size_t group_out_i : c10::irange(group_outputs.size())) {
+        for (const size_t group_out_i : arange(group_outputs.size())) {
           available_input.insert(group_outputs[group_out_i]);
         }
         group_ran[group_i] = true;
@@ -258,7 +257,7 @@ void InputsIdLookup::deserialize(const serde::InputsIdLookup* buffer) {
     used_entry_iterators.emplace_back(std::prev(used_entry_.end()));
   }
 
-  for (auto idx : c10::irange(buffer->encoding_lookup_keys()->size())) {
+  for (auto idx : arange(buffer->encoding_lookup_keys()->size())) {
     auto fb_encoding_lookup_str = buffer->encoding_lookup_keys()->Get(idx);
     auto fb_encoding_entry = buffer->encoding_lookup_values()->Get(idx);
 
@@ -279,7 +278,7 @@ InputsIdLookup::IdLookupReturn InputsIdLookup::lookupId(
   encoding_.clear();
   encodeBuffer(args.getDeviceIndex(), encoding_);
 
-  for (const auto i : c10::irange(args.size())) {
+  for (const auto i : arange(args.size())) {
     const auto& arg = args[i];
     if (arg.is<at::Tensor>()) {
       const auto& input_tensor = arg.as<at::Tensor>();

--- a/csrc/scheduler/tools/abstract_tensor.h
+++ b/csrc/scheduler/tools/abstract_tensor.h
@@ -65,7 +65,7 @@ struct DispatchSplit {
       std::vector<AbstractId> inner_result;
       outer_result.reserve(in.size());
       inner_result.reserve(in.size());
-      for (auto i : c10::irange(in.size())) {
+      for (auto i : arange(in.size())) {
         auto [outer, inner] =
             AbstractId::dispatch((*this), in[i], factor, inner_split);
         outer_result.emplace_back(outer);
@@ -118,14 +118,14 @@ struct DispatchMerge {
           "Can not merge vectors of AbstractId of different size.");
       std::vector<AbstractId> result;
       result.reserve(lhs.size());
-      for (auto i : c10::irange(lhs.size())) {
+      for (auto i : arange(lhs.size())) {
         result.emplace_back(AbstractId::dispatch((*this), lhs[i], rhs[i]));
       }
       return result;
     } else if constexpr (std::is_same_v<L, std::vector<AbstractId>>) {
       std::vector<AbstractId> result;
       result.reserve(lhs.size());
-      for (auto i : c10::irange(lhs.size())) {
+      for (auto i : arange(lhs.size())) {
         result.emplace_back(
             AbstractId::dispatch((*this), lhs[i], std::forward<RHS>(rhs)));
       }
@@ -133,7 +133,7 @@ struct DispatchMerge {
     } else if constexpr (std::is_same_v<R, std::vector<AbstractId>>) {
       std::vector<AbstractId> result;
       result.reserve(rhs.size());
-      for (auto i : c10::irange(rhs.size())) {
+      for (auto i : arange(rhs.size())) {
         result.emplace_back(
             AbstractId::dispatch((*this), std::forward<LHS>(lhs), rhs[i]));
       }
@@ -196,7 +196,7 @@ struct DispatchSwizzle {
       std::vector<AbstractId> result_y;
       result_x.reserve(lhs.size());
       result_y.reserve(lhs.size());
-      for (auto i : c10::irange(lhs.size())) {
+      for (auto i : arange(lhs.size())) {
         auto [out_x, out_y] =
             AbstractId::dispatch((*this), swizzle_type, lhs[i], rhs[i]);
         result_x.emplace_back(out_x);
@@ -208,7 +208,7 @@ struct DispatchSwizzle {
       std::vector<AbstractId> result_y;
       result_x.reserve(lhs.size());
       result_y.reserve(lhs.size());
-      for (auto i : c10::irange(lhs.size())) {
+      for (auto i : arange(lhs.size())) {
         auto [out_x, out_y] = AbstractId::dispatch(
             (*this), swizzle_type, lhs[i], std::forward<RHS>(rhs));
         result_x.emplace_back(out_x);
@@ -220,7 +220,7 @@ struct DispatchSwizzle {
       std::vector<AbstractId> result_y;
       result_x.reserve(rhs.size());
       result_y.reserve(rhs.size());
-      for (auto i : c10::irange(rhs.size())) {
+      for (auto i : arange(rhs.size())) {
         auto [out_x, out_y] = AbstractId::dispatch(
             (*this), swizzle_type, std::forward<LHS>(lhs), rhs[i]);
         result_x.emplace_back(out_x);
@@ -281,7 +281,7 @@ struct DispatchLegacySwizzle {
       std::vector<AbstractId> result_y;
       result_x.reserve(lhs.size());
       result_y.reserve(lhs.size());
-      for (auto i : c10::irange(lhs.size())) {
+      for (auto i : arange(lhs.size())) {
         auto [out_x, out_y] =
             AbstractId::dispatch((*this), swizzle_type, lhs[i], rhs[i]);
         result_x.emplace_back(out_x);
@@ -293,7 +293,7 @@ struct DispatchLegacySwizzle {
       std::vector<AbstractId> result_y;
       result_x.reserve(lhs.size());
       result_y.reserve(lhs.size());
-      for (auto i : c10::irange(lhs.size())) {
+      for (auto i : arange(lhs.size())) {
         auto [out_x, out_y] = AbstractId::dispatch(
             (*this), swizzle_type, lhs[i], std::forward<RHS>(rhs));
         result_x.emplace_back(out_x);
@@ -305,7 +305,7 @@ struct DispatchLegacySwizzle {
       std::vector<AbstractId> result_y;
       result_x.reserve(rhs.size());
       result_y.reserve(rhs.size());
-      for (auto i : c10::irange(rhs.size())) {
+      for (auto i : arange(rhs.size())) {
         auto [out_x, out_y] = AbstractId::dispatch(
             (*this), swizzle_type, std::forward<LHS>(lhs), rhs[i]);
         result_x.emplace_back(out_x);
@@ -551,7 +551,7 @@ class AbstractTensorWithInfo {
     std::vector<std::pair<AbstractId, Info>> result;
     NVF_ERROR(domain_.size() == info_.size());
     result.reserve(domain_.size());
-    for (size_t i : c10::irange(domain_.size())) {
+    for (size_t i : arange(domain_.size())) {
       result.emplace_back(domain_[i], info_[i]);
     }
     return result;
@@ -776,7 +776,7 @@ class AbstractTensorWithInfo {
     to = wrapDim(to, (int64_t)domain_.size());
     NVF_CHECK(from <= to, "Invalid flatten range. From: ", from, " To: ", to);
     int64_t num_merges = to - from;
-    for (auto _ : c10::irange(num_merges)) {
+    for (auto _ : arange(num_merges)) {
       (void)_;
       merge(from);
     }
@@ -856,7 +856,7 @@ class AbstractTensorWithInfo {
     // unzip the AbstractTensor, broadcast the non-vector items. Re-use info for
     // all the unzipped AbstractTensors
     result.resize(size);
-    for (auto i : c10::irange(size)) {
+    for (auto i : arange(size)) {
       for (const auto& aid : domain_) {
         if (aid.is<std::vector>()) {
           result[i].domain_.emplace_back(aid[i]);
@@ -893,7 +893,7 @@ class AbstractTensorWithInfo {
     AbstractTensorWithInfo result;
     result.info_ = std::move(tensors[0].info_);
     result.domain_.reserve(tensors[0].domain_.size());
-    for (auto i : c10::irange(tensors[0].domain_.size())) {
+    for (auto i : arange(tensors[0].domain_.size())) {
       std::vector<AbstractId> ids;
       ids.reserve(tensors.size());
       for (auto& tensor : tensors) {
@@ -933,7 +933,7 @@ class AbstractTensorWithInfo {
     NVF_CHECK(
         info_ == tensor.info_, "Cannot add a new row with mismatched info");
 
-    for (auto i : c10::irange(size())) {
+    for (auto i : arange(size())) {
       domain_[i].template as<std::vector>().emplace_back(
           std::move(tensor.domain_[i]));
     }

--- a/csrc/serde/Serde.md
+++ b/csrc/serde/Serde.md
@@ -284,7 +284,7 @@ while (!queue.empty()) {
 }
 
 // Deserialize terminal_nodes field in the FusionCache table
-for (auto idx : c10::irange(fusions_.size())) {
+for (auto idx : arange(fusions_.size())) {
   // Add trie_node from bfs_order to terminal_nodes_
   // Get FusionExecutorCache for terminal TrieNode
   // Deserialize FusionExecutorCache

--- a/csrc/serde/polymorphic_value.cpp
+++ b/csrc/serde/polymorphic_value.cpp
@@ -145,14 +145,14 @@ flatbuffers::Offset<PolymorphicValue> serializePolymorphicValue(
       // Convert IntArrayRef to std::vector for flatbuffer compatibility
       std::vector<int64_t> sizes_fb;
       sizes_fb.reserve(tensor.ndimension());
-      for (auto dim : c10::irange(tensor.ndimension())) {
+      for (auto dim : arange(tensor.ndimension())) {
         sizes_fb.push_back(tensor.size(dim));
       }
 
       // Convert IntArrayRef to std::vector for flatbuffer compatibility
       std::vector<int64_t> strides_fb;
       strides_fb.reserve(tensor.ndimension());
-      for (auto dim : c10::irange(tensor.ndimension())) {
+      for (auto dim : arange(tensor.ndimension())) {
         strides_fb.push_back(tensor.stride(dim));
       }
 

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -571,7 +571,7 @@ TensorView* TensorView::flatten(int64_t from, int64_t to) {
   to = wrapDim(to);
   NVF_CHECK(from <= to, "Invalid flatten range. From: ", from, " To: ", to);
   int64_t num_merges = to - from;
-  for (auto _ : c10::irange(num_merges)) {
+  for (auto _ : arange(num_merges)) {
     (void)_;
     merge(from);
   }
@@ -864,7 +864,7 @@ TensorView* TensorView::multiOutputRFactorHelper(
 
     // construct a trivial logical domain map
     std::unordered_map<IterDomain*, IterDomain*> id_map;
-    for (const auto i : c10::irange(logical.size())) {
+    for (const auto i : arange(logical.size())) {
       id_map[this_logical[i]] = logical[i];
     }
 
@@ -927,7 +927,7 @@ std::vector<TensorView*> TensorView::rFactor(
       definition()->outputs().size() == tvs.size(),
       "Rfactor of a multi-output reduction not used correctly");
 
-  for (const auto i : c10::irange(tvs.size())) {
+  for (const auto i : arange(tvs.size())) {
     NVF_CHECK(
         definition()->output(i) == tvs.at(i),
         "Rfactor of a multi-output reduction not used correctly");
@@ -946,13 +946,13 @@ std::vector<TensorView*> TensorView::rFactor(
 
   // Make sure this gets rfactored last so everybody gets
   //  replayed correctly
-  for (const auto i : c10::irange(tvs.size())) {
+  for (const auto i : arange(tvs.size())) {
     if (this != tvs.at(i)) {
       rf_tvs.at(i) = multiOutputRFactorHelper(tvs.at(i), axes);
     }
   }
 
-  for (const auto i : c10::irange(tvs.size())) {
+  for (const auto i : arange(tvs.size())) {
     if (this == tvs.at(i)) {
       rf_tvs.at(i) = multiOutputRFactorHelper(tvs.at(i), axes);
     }
@@ -1297,7 +1297,7 @@ void TensorView::clearReductionIterDomains() {
   std::vector<IterDomain*> new_logical;
   std::vector<IterDomain*> new_alloc;
   std::vector<std::optional<bool>> new_contig;
-  for (const auto i : c10::irange(logical.size())) {
+  for (const auto i : arange(logical.size())) {
     auto root_i = logical.at(i);
     if (!root_i->isReduction()) {
       new_logical.push_back(root_i);
@@ -1555,7 +1555,7 @@ TensorViewBuilder& TensorViewBuilder::expanded(std::vector<bool> expanded) {
 TensorView* TensorViewBuilder::build() const {
   // Build the domain
   std::vector<IterDomain*> domain(ndims_, nullptr);
-  for (const auto i : c10::irange(ndims_)) {
+  for (const auto i : arange(ndims_)) {
     bool is_expanded = false;
     Val* extent = nullptr;
     Val* expanded_extent = nullptr;

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <c10/util/irange.h>
 #include <compute_at.h>
 #include <device_lower/analysis/circular_buffer.h>
 #include <device_lower/lower2device.h>

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -10,8 +10,6 @@
 #include <logical_domain_map.h>
 #include <transform_iter.h>
 
-#include <c10/util/irange.h>
-
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -504,7 +504,7 @@ BestEffortReplay::BestEffortReplay(
     bool missing_replay_input = false;
 
     // Map target_expr inputs to replay domain directly
-    for (const auto t_i : c10::irange(target_id_inps.size())) {
+    for (const auto t_i : arange(target_id_inps.size())) {
       // There might not be a mapping, that could be okay (depends on rfactor
       // checking).
       auto it = target2replay_id_map_.find(target_id_inps[t_i]);
@@ -644,7 +644,7 @@ BestEffortReplay::BestEffortReplay(
     }
 
     // Take replay expr inputs out of map:
-    for (const auto t_i : c10::irange(target_id_inps.size())) {
+    for (const auto t_i : arange(target_id_inps.size())) {
       auto t_inp = target_id_inps[t_i];
       auto r_orig_inp = target2replay_id_map_.at(t_inp);
       auto r_maybe_forwarded_inp = replay_inps[t_i];
@@ -661,7 +661,7 @@ BestEffortReplay::BestEffortReplay(
     }
 
     // Add outputs to map.
-    for (const auto i : c10::irange(target_expr->outputs().size())) {
+    for (const auto i : arange(target_expr->outputs().size())) {
       auto t_out = target_expr->output(i);
       auto r_out = replay_expr->output(i);
       if (t_out->getValType() == ValType::IterDomain &&
@@ -712,7 +712,7 @@ int64_t BestEffortReplay::findFirstMismatchedID(
 
   BestEffortReplay ber(td2->loop(), td1->loop(), id_map);
   for (const auto i :
-       c10::irange((int64_t)std::max(td1->loop().size(), td2->loop().size()))) {
+       arange((int64_t)std::max(td1->loop().size(), td2->loop().size()))) {
     if (ber.getReplay().find(td1->axis(i)) == ber.getReplay().end()) {
       return i;
     }
@@ -773,7 +773,7 @@ ForwardingInfo::ForwardingInfo(
   //
   // Initialize which id's should beforwarded.
   std::unordered_set<IterDomain*> forwarded_ids;
-  for (auto i : c10::irange(active_dim_flags->size())) {
+  for (auto i : arange(active_dim_flags->size())) {
     if (active_dim_flags->at(i)) {
       forwarded_ids.emplace(active_logical_dom.at(i));
     }

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -308,7 +308,7 @@ void TransformReplay::selfReplay(
     }
 
     // Pushing the mapped IDs and corresponding contiguity flags
-    for (size_t i : c10::irange(self_allocation.size())) {
+    for (size_t i : arange(self_allocation.size())) {
       IterDomain* id = self_allocation[i];
       if (id->isReduction()) {
         continue;
@@ -892,7 +892,7 @@ std::pair<TensorDomain*, int64_t> TransformReplay::replayCasP(
     std::vector<std::optional<bool>> new_contiguity;
     new_contiguity.reserve(producer_rank);
 
-    for (auto i : c10::irange(producer_rank)) {
+    for (auto i : arange(producer_rank)) {
       IterDomain* alloc_id = producer->getAllocationDomain()[i];
       // We won't find reduction IterDomains in the map. See
       // AllocationDomainTest.CacheBefore.
@@ -1350,7 +1350,7 @@ TensorDomain* fullReplay(
       old_domain->maybeRoot().size(),
       " vs ",
       new_root.size());
-  for (auto i : c10::irange(new_root.size())) {
+  for (auto i : arange(new_root.size())) {
     old_root_to_new[old_domain->maybeRoot()[i]] = new_root[i];
   }
   NVF_CHECK(

--- a/csrc/transform_rfactor.cpp
+++ b/csrc/transform_rfactor.cpp
@@ -353,7 +353,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
   std::unordered_map<IterDomain*, IterDomain*> original_to_producer_root_map;
 
   {
-    for (auto i : c10::irange(original_td_root.size())) {
+    for (auto i : arange(original_td_root.size())) {
       auto id = original_td_root[i];
       // If this is an rfactor root, it will be a reduction in this stage
       if (rfactor_root_axes.find(id) != rfactor_root_axes.end()) {
@@ -400,7 +400,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
 
   std::vector<IterDomain*> new_producer_domain(original_td->nDims(), nullptr);
   {
-    for (auto i : c10::irange(original_td->nDims())) {
+    for (auto i : arange(original_td->nDims())) {
       auto orig_id = original_td->axis(i);
       auto replayed_id_it = original_to_producer_id_map.find(orig_id);
       NVF_ERROR(
@@ -477,7 +477,7 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
 
   {
     // Construct the new consumer domain
-    for (auto i : c10::irange(original_td->nDims())) {
+    for (auto i : arange(original_td->nDims())) {
       auto orig_id = original_td->axis(i);
       auto replayed_id_it = original_to_consumer_map.find(orig_id);
       if (replayed_id_it != original_to_consumer_map.end()) {

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -365,7 +365,7 @@ class AnalyzeViewTransformation {
     AnalyzeViewConstraint constraint;
     constraint.original_constraint =
         std::vector<int64_t>(original_view_.begin(), original_view_.end());
-    for (auto i : c10::irange(constraint.original_constraint.size())) {
+    for (auto i : arange(constraint.original_constraint.size())) {
       if (constraint.original_constraint[i] != 1) {
         constraint.original_constraint[i] = 0;
       }
@@ -373,7 +373,7 @@ class AnalyzeViewTransformation {
 
     constraint.new_constraint =
         std::vector<int64_t>(new_view_.begin(), new_view_.end());
-    for (auto i : c10::irange(constraint.new_constraint.size())) {
+    for (auto i : arange(constraint.new_constraint.size())) {
       if (constraint.new_constraint[i] != 1) {
         constraint.new_constraint[i] = 0;
       }
@@ -684,7 +684,7 @@ TensorDomain* createViewDomain(
       TensorDomain::noReductions(original_domain->logical());
 
   // Apply squeeze.
-  for (auto id_i : c10::irange(orig_logical_domain.size())) {
+  for (auto id_i : arange(orig_logical_domain.size())) {
     if (!view_analysis.squeeze_axes.at(id_i)) {
       auto id = orig_logical_domain.at(id_i);
       new_root_domain.push_back(id->cloneWithoutRFactor());
@@ -836,7 +836,7 @@ bool AnalyzeViewResult::operator==(const AnalyzeViewResult& other) const {
     return false;
   }
 
-  for (const auto i : c10::irange(transforms.size())) {
+  for (const auto i : arange(transforms.size())) {
     auto transform = transforms.at(i);
     auto other_transform = other.transforms.at(i);
     if (transform->isA<SplitTransform>()) {
@@ -863,7 +863,7 @@ bool AnalyzeViewResult::operator==(const AnalyzeViewResult& other) const {
 size_t AnalyzeViewResult::hash() const {
   auto bool_vec_hash = [](const std::vector<bool>& vec) -> size_t {
     size_t hash = 0;
-    for (const auto i : c10::irange(vec.size())) {
+    for (const auto i : arange(vec.size())) {
       hash = (hash << 1) + static_cast<size_t>(vec.at(i));
     }
     return hash;

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <iostream>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
@@ -221,7 +222,7 @@ bool StructType::operator==(const StructType& other) const {
   if (fields.size() != other.fields.size()) {
     return false;
   }
-  for (auto i : c10::irange(fields.size())) {
+  for (auto i : std::ranges::iota_view(0u, fields.size())) {
     if (fields[i].name != other.fields[i].name ||
         *fields[i].type != *other.fields[i].type ||
         fields[i].used_in_kernel != other.fields[i].used_in_kernel) {
@@ -511,7 +512,7 @@ inline bool isCompatibleDataType(DataType dtype, DataType dtype2) {
     if (struct_type.fields.size() != struct_type2.fields.size()) {
       return false;
     }
-    for (auto i : c10::irange(struct_type.fields.size())) {
+    for (auto i : std::ranges::iota_view(0u, struct_type.fields.size())) {
       if (struct_type.fields[i].name != struct_type2.fields[i].name ||
           !isCompatibleDataType(
               *struct_type.fields[i].type, *struct_type2.fields[i].type)) {

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -605,7 +605,7 @@ auto arange(auto start, auto end) {
   static_assert(std::is_integral<decltype(end)>());
   // If start and end are the same type, use the range directly
   if constexpr (std::is_same_v<decltype(start), decltype(end)>) {
-      return std::ranges::iota_view(start, end);
+    return std::ranges::iota_view(start, end);
   }
   return std::ranges::iota_view(decltype(end)(start), end);
 }

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -599,6 +599,23 @@ T pow(T a, T b) {
   }
 }
 
+// Returns a range of integers [start, end)
+auto arange(auto start, auto end) {
+  static_assert(std::is_integral<decltype(start)>());
+  static_assert(std::is_integral<decltype(end)>());
+  // If start and end are the same type, use the range directly
+  if constexpr (std::is_same_v<decltype(start), decltype(end)>) {
+      return std::ranges::iota_view(start, end);
+  }
+  return std::ranges::iota_view(decltype(end)(start), end);
+}
+
+// Returns a range of integers [0, end)
+auto arange(auto end) {
+  static_assert(std::is_integral<decltype(end)>());
+  return std::ranges::iota_view(decltype(end)(0), end);
+}
+
 // Returns true if given number is power of 2
 constexpr bool isPowOf2(int64_t x) {
   return x > 1 && (x & (x - 1)) == 0;

--- a/csrc/val_graph.cpp
+++ b/csrc/val_graph.cpp
@@ -353,7 +353,7 @@ bool ValGraph::exprsMap(Expr* first, Expr* second, bool forward) const {
       first->toString(),
       second->toString());
 
-  for (const auto i : c10::irange(first_vals.size())) {
+  for (const auto i : arange(first_vals.size())) {
     if (!disjointValSets().permissiveAreMapped(
             first_vals.at(i), second_vals.at(i))) {
       return false;
@@ -562,7 +562,7 @@ bool ValGraph::mapThroughExpr(Expr* first, Expr* second, bool forward) {
       first->toString(),
       "\nand\n",
       second->toString());
-  for (auto out_i : c10::irange(first_ids.size())) {
+  for (auto out_i : arange(first_ids.size())) {
     mapVals(first_ids[out_i], second_ids[out_i]);
   }
 
@@ -578,8 +578,8 @@ void ValGraph::setUnmappable(const std::vector<Val*>& vals) {
   if (vals.size() < 2) {
     return;
   }
-  for (const auto i : c10::irange(vals.size() - 1)) {
-    for (const auto j : c10::irange(i + 1, vals.size())) {
+  for (const auto i : arange(vals.size() - 1)) {
+    for (const auto j : arange(i + 1, vals.size())) {
       setUnmappable(vals.at(i), vals.at(j));
     }
   }


### PR DESCRIPTION
This PR moves from `c10::irange` to `arange` utility that wraps around `std::ranges::iota_view`. The only exception is in `type.h` where a circular dependency forced using `std::ranges::iota_view` directly.

```cpp
// Returns a range of integers [start, end)
auto arange(auto start, auto end) {
  static_assert(std::is_integral<decltype(start)>());
  static_assert(std::is_integral<decltype(end)>());
  // If start and end are the same type, use the range directly
  if constexpr (std::is_same_v<decltype(start), decltype(end)>) {
    return std::ranges::iota_view(start, end);
  }
  return std::ranges::iota_view(decltype(end)(start), end);
}

// Returns a range of integers [0, end)
auto arange(auto end) {
  static_assert(std::is_integral<decltype(end)>());
  return std::ranges::iota_view(decltype(end)(0), end);
}
```