### PR TITLE
Create Statement, Expr, and Val bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,6 +562,7 @@ if(BUILD_PYTHON)
   list(APPEND NVFUSER_PYTHON_NEXT_SRCS
     ${NVFUSER_PYTHON_NEXT_BINDINGS}/extension.cpp
     ${NVFUSER_PYTHON_NEXT_BINDINGS}/bindings.cpp
+    ${NVFUSER_PYTHON_NEXT_BINDINGS}/ir.cpp
   )
   add_library(nvf_py_next_internal OBJECT ${NVFUSER_PYTHON_NEXT_SRCS})
 

--- a/python/python_next/bindings.cpp
+++ b/python/python_next/bindings.cpp
@@ -11,7 +11,8 @@
 namespace python {
 
 void initNvFuserPythonBindings(PyObject* module) {
-  auto python_bindings = py::handle(module).cast<py::module>();
+  auto nvfuser = py::handle(module).cast<py::module>();
+  bindFusionIr(nvfuser);
 }
 
 } // namespace python

--- a/python/python_next/bindings.h
+++ b/python/python_next/bindings.h
@@ -14,4 +14,7 @@ namespace python {
 
 void initNvFuserPythonBindings(PyObject* module);
 
+// Add bindings for Fusion IR
+void bindFusionIr(py::module& nvfuser);
+
 } // namespace python

--- a/python/python_next/ir.cpp
+++ b/python/python_next/ir.cpp
@@ -1,0 +1,47 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <bindings.h>
+
+#include <fusion.h>
+#include <ir/base_nodes.h>
+
+namespace python {
+
+// For all nodes, use multiple inheritance to disable destructor with
+// std::unique_ptr<Statement, py::nodelete>. This class will
+// disable memory management because it is handled automatically by IrContainer.
+
+namespace {
+
+using namespace nvfuser;
+
+void bindBaseNodes(py::module& nvfuser) {
+  // Statement
+  py::class_<Statement, std::unique_ptr<Statement, py::nodelete>>(
+      nvfuser, "Statement")
+      .def(
+          "__str__",
+          [](Statement* self) { return self->toString(); },
+          R"(Get string representation of Statement.)");
+
+  // Val
+  py::class_<Val, Statement, std::unique_ptr<Val, py::nodelete>>(
+      nvfuser, "Val");
+
+  // Expr
+  py::class_<Expr, Statement, std::unique_ptr<Expr, py::nodelete>>(
+      nvfuser, "Expr");
+}
+
+} // namespace
+
+void bindFusionIr(py::module& nvfuser) {
+  bindBaseNodes(nvfuser);
+}
+
+} // namespace python


### PR DESCRIPTION
This PR creates the bindings for Statement, Expr, and Val bindings. It corresponds with [Step 1: Create python bindings for basic Fusion IR](https://docs.google.com/document/d/1ftdNKu952EFmLANa36g0IrVaqAJ0eLKzgJESkQFnuVI/edit?tab=t.0#heading=h.e2plo2gt0gnb).

Details:
* All nodes inherit `std::unique_ptr<[Node Name], py::nodelete>` to disable destructor. Disable memory management because it is handled automatically by `IrContainer`. A segmentation fault will occur when destroying a node twice.
* `bindBaseNodes` contains the ir nodes found in `ir/base_nodes.h`

Pythonic Changes:
* Mapped `toString` to `__str__` dunder method
* Mapped `sameAs` to `__eq__` dunder method
* Changed from CamelCase to snake_case.
* Added numpy-style docstrings

All `Statement` nodes are held by the `Fusion`, so we cannot create any tests until `Fusion` is added to direct bindings.
1. IterDomain
2. TensorDomain
3. TensorView
4. FusionGuard
5. Fusion
6. FusionExecutorCache