### PR TITLE
removing unused logic related to IterType::Stride

### DIFF
--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -1317,8 +1317,8 @@ class LoopIndexingPreferredPathCompute : public IterVisitor {
           GpuLower::current()->caMap()->getConcreteMappedID(
               mapped_id, IdMappingMode::EXACT);
       if (all_concrete_ids.count(concrete_original_id)) {
-        if (original_id->isBroadcast() || original_id->isReduction() ||
-            original_id->isStride()) {
+        if (original_id->isBroadcast() || original_id->isReduction()
+            ) {
           continue;
         }
         compute.preferred_path_.insert(concrete_original_id);

--- a/csrc/device_lower/analysis/index_compute.cpp
+++ b/csrc/device_lower/analysis/index_compute.cpp
@@ -1317,8 +1317,7 @@ class LoopIndexingPreferredPathCompute : public IterVisitor {
           GpuLower::current()->caMap()->getConcreteMappedID(
               mapped_id, IdMappingMode::EXACT);
       if (all_concrete_ids.count(concrete_original_id)) {
-        if (original_id->isBroadcast() || original_id->isReduction()
-            ) {
+        if (original_id->isBroadcast() || original_id->isReduction()) {
           continue;
         }
         compute.preferred_path_.insert(concrete_original_id);

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -51,7 +51,7 @@ bool mayRequireAllocation(const TensorView* tv, IterDomain* id) {
   // - Reduction: Check the original ID, not the promotion, which may
   //   be a reduction ID even though the original ID is not a reduction
   return !isPartitionedLoop(tv, id) && !isSizeOneDomain(id) &&
-      !id->isReduction() && !id->isStride();
+      !id->isReduction();
 }
 
 // Get the allocation stride of a given allocation domain

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -255,14 +255,14 @@ void IndexCompute::handle(Merge* merge) {
           // I don't think reductions can be in here, but strictly matching the
           // logic in the indexing functions like
           // getNonGlobalConsumerStridedIndices
-          return id->isBroadcast() || id->isReduction() ;
+          return id->isBroadcast() || id->isReduction();
         })) {
       index_map_[*(input_ids.end() - 1)] = out_ind;
     } else {
       for (auto id_it = input_ids.rbegin(); id_it != input_ids.rend();
            id_it++) {
         auto id = *id_it;
-        if (id->isBroadcast() || id->isReduction() ) {
+        if (id->isBroadcast() || id->isReduction()) {
           continue;
         } else {
           index_map_[id] = out_ind;
@@ -1744,8 +1744,7 @@ std::vector<Val*> Index::getConsumerAllocationIndices(
   for (const auto i : c10::irange(alloc_dom.size())) {
     // See a comment in indexing to allocation domains in
     // getGlobalProducerIndex.
-    if (alloc_dom[i]->isReduction() || alloc_dom[i]->isBroadcast()
-        ) {
+    if (alloc_dom[i]->isReduction() || alloc_dom[i]->isBroadcast()) {
       continue;
     }
 
@@ -2000,7 +1999,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
     Val* stride = nullptr;
     for (const auto j : c10::irange(i + 1, alloc_dom.size())) {
       if (alloc_dom[j]->isBroadcast() || alloc_dom[j]->isReduction() ||
-          alloc_dom[j]->isDeviceDim() ) {
+          alloc_dom[j]->isDeviceDim()) {
         continue;
       }
 

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -255,14 +255,14 @@ void IndexCompute::handle(Merge* merge) {
           // I don't think reductions can be in here, but strictly matching the
           // logic in the indexing functions like
           // getNonGlobalConsumerStridedIndices
-          return id->isBroadcast() || id->isReduction() || id->isStride();
+          return id->isBroadcast() || id->isReduction() ;
         })) {
       index_map_[*(input_ids.end() - 1)] = out_ind;
     } else {
       for (auto id_it = input_ids.rbegin(); id_it != input_ids.rend();
            id_it++) {
         auto id = *id_it;
-        if (id->isBroadcast() || id->isReduction() || id->isStride()) {
+        if (id->isBroadcast() || id->isReduction() ) {
           continue;
         } else {
           index_map_[id] = out_ind;
@@ -1225,7 +1225,7 @@ void ensureStaticIndexing(
         tv->getLoopDomain().begin(),
         tv->getLoopDomain().end(),
         [loop_id, &id_map](IterDomain* id) {
-          if (id->isBroadcast() || id->isReduction() || id->isStride()) {
+          if (id->isBroadcast() || id->isReduction()) {
             return false;
           }
           auto id_replacement = id_map.find(id);
@@ -1491,7 +1491,7 @@ std::vector<Val*> Index::getNonGlobalProducerStridedIndices(
   for (auto alloc_id : alloc_dom) {
     // Already taken care of because we can detect no indexing required
     if (alloc_id->isBroadcast() || alloc_id->isReduction() ||
-        alloc_id->isStride() || alloc_id->isDeviceDim() ||
+        alloc_id->isDeviceDim() ||
         (alloc_id->isThread() &&
          producer_tv->getMemoryType() == MemoryType::Local)) {
       skip_indexing.insert(alloc_id);
@@ -1689,7 +1689,7 @@ std::vector<Val*> Index::getStrides(TensorView* tv) {
   {
     int stride_i = 0;
     for (const auto i : c10::irange(alloc_dom.size())) {
-      if (alloc_dom[i]->isReduction() || alloc_dom[i]->isStride()) {
+      if (alloc_dom[i]->isReduction()) {
         strides[i] = GpuLower::current()->kernel()->oneVal();
         continue;
       }
@@ -1703,7 +1703,7 @@ std::vector<Val*> Index::getStrides(TensorView* tv) {
   Val* cur_contig_stride = GpuLower::current()->kernel()->oneVal();
   for (const auto i : c10::irange(alloc_dom.size())) {
     auto dim = alloc_dom.size() - i - 1;
-    if (alloc_dom[dim]->isReduction() || alloc_dom[dim]->isStride()) {
+    if (alloc_dom[dim]->isReduction()) {
       continue;
     }
 
@@ -1744,8 +1744,8 @@ std::vector<Val*> Index::getConsumerAllocationIndices(
   for (const auto i : c10::irange(alloc_dom.size())) {
     // See a comment in indexing to allocation domains in
     // getGlobalProducerIndex.
-    if (alloc_dom[i]->isReduction() || alloc_dom[i]->isBroadcast() ||
-        alloc_dom[i]->isStride()) {
+    if (alloc_dom[i]->isReduction() || alloc_dom[i]->isBroadcast()
+        ) {
       continue;
     }
 
@@ -1967,7 +1967,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
       alloc_dom.size(), GpuLower::current()->kernel()->zeroVal());
   for (const auto i : c10::irange(alloc_dom.size())) {
     if (alloc_dom[i]->isReduction() || alloc_dom[i]->isBroadcast() ||
-        alloc_dom[i]->isStride() || alloc_dom[i]->isDeviceDim() ||
+        alloc_dom[i]->isDeviceDim() ||
         (alloc_dom[i]->isThread() &&
          consumer_tv->getMemoryType() == MemoryType::Local)) {
       continue;
@@ -2000,7 +2000,7 @@ std::vector<Val*> Index::getNonGlobalConsumerStridedIndices(
     Val* stride = nullptr;
     for (const auto j : c10::irange(i + 1, alloc_dom.size())) {
       if (alloc_dom[j]->isBroadcast() || alloc_dom[j]->isReduction() ||
-          alloc_dom[j]->isDeviceDim() || alloc_dom[j]->isStride()) {
+          alloc_dom[j]->isDeviceDim() ) {
         continue;
       }
 

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -194,7 +194,7 @@ class IterDomain : public Val {
   }
 
   bool isStride() const {
-    return getIterType() == IterType::Stride;
+    return false;
   }
 
   bool isVectorComponent() const {
@@ -314,11 +314,6 @@ class IterDomain : public Val {
   bool isImplicitBroadcast() const {
     return isBroadcast() && extent()->isOneInt();
   }
-
-  //! Split for stride by a given factor. It effectively does an inner
-  //! split by the factor and sets the inner domain as a Stride
-  //! domain.
-  std::pair<IterDomain*, IterDomain*> stridedSplit(int64_t factor);
 
   //! Marks that this id represents a
   //!  instruction loop, mma use only.

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -193,10 +193,6 @@ class IterDomain : public Val {
     return getIterType() == IterType::GatherScatter;
   }
 
-  bool isStride() const {
-    return false;
-  }
-
   bool isVectorComponent() const {
     return getIterType() == IterType::VectorComponent;
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2689,10 +2689,6 @@ IterDomain* IterDomain::merge(
       ", Inner: ",
       inner->toString());
 
-  NVF_CHECK(
-      !outer->isStride() && !inner->isStride(),
-      "No support for merging stride domains");
-
   // By default, if not specified, don't create rfactor
   // outputs. Reshape transformations should propagate the flag, which
   // should explicitly specify the flag
@@ -3501,7 +3497,7 @@ bool TensorDomain::hasViewLikeRFactor() const {
   // If there's an logical domain and no rfactor product is a reduction, this is
   // a view like rfactor
   return std::none_of(logical().begin(), logical().end(), [](IterDomain* id) {
-    return (id->isReduction() || id->isStride()) && id->isRFactorProduct();
+    return id->isReduction() && id->isRFactorProduct();
   });
 }
 
@@ -3706,7 +3702,7 @@ std::vector<IterDomain*> TensorDomain::noReductions(
       td.begin(),
       td.end(),
       std::back_inserter(noReductionDomain),
-      [](IterDomain* id) { return !id->isReduction() && !id->isStride(); });
+      [](IterDomain* id) { return !id->isReduction(); });
   return noReductionDomain;
 }
 
@@ -5101,7 +5097,7 @@ Val* ForLoop::simplifiedStop() const {
 bool ForLoop::isTrivial() const {
   // These loops are not materialized
   if (vectorize() || iter_domain()->isBroadcast() ||
-      iter_domain()->isStride() || iter_domain()->isMma() ||
+      iter_domain()->isMma() ||
       iter_domain()->isBulk() || iter_domain()->isDeviceDim()) {
     return true;
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2819,20 +2819,6 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
   return {ido, idi};
 }
 
-std::pair<IterDomain*, IterDomain*> IterDomain::stridedSplit(int64_t factor) {
-  // Use partial split so that only valid values are retained
-  auto split_out = IterDomain::split(
-      this,
-      IrBuilder::createInContainer<Val>(container(), factor, DataType::Index),
-      true,
-      true);
-
-  split_out.second->iter_type_ = IterType::Stride;
-  split_out.first->is_rfactor_domain_ = true;
-  split_out.second->is_rfactor_domain_ = true;
-  return split_out;
-}
-
 std::pair<IterDomain*, IterDomain*> IterDomain::swizzle(
     SwizzleType swizzle_type,
     IterDomain* in_x,

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5096,8 +5096,7 @@ Val* ForLoop::simplifiedStop() const {
 
 bool ForLoop::isTrivial() const {
   // These loops are not materialized
-  if (vectorize() || iter_domain()->isBroadcast() ||
-      iter_domain()->isMma() ||
+  if (vectorize() || iter_domain()->isBroadcast() || iter_domain()->isMma() ||
       iter_domain()->isBulk() || iter_domain()->isDeviceDim()) {
     return true;
   }

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -147,14 +147,8 @@ IterType promoteIterType(IterType type1, IterType type2) {
   // Stride: Shold not appear here
   // VectorComponent: Converted to Iteration
 
-  NVF_ERROR(
-      type1 != IterType::Reduction,
-      "Invalid IterType: ",
-      type1)
-  NVF_ERROR(
-      type2 != IterType::Reduction,
-      "Invalid IterType: ",
-      type2);
+  NVF_ERROR(type1 != IterType::Reduction, "Invalid IterType: ", type1)
+  NVF_ERROR(type2 != IterType::Reduction, "Invalid IterType: ", type2);
 
   // Do not propagate GatherScatter and VectorComponent
   if (type1 == IterType::VectorComponent || type1 == IterType::GatherScatter) {

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -148,11 +148,11 @@ IterType promoteIterType(IterType type1, IterType type2) {
   // VectorComponent: Converted to Iteration
 
   NVF_ERROR(
-      type1 != IterType::Reduction && type1 != IterType::Stride,
+      type1 != IterType::Reduction,
       "Invalid IterType: ",
       type1)
   NVF_ERROR(
-      type2 != IterType::Reduction && type2 != IterType::Stride,
+      type2 != IterType::Reduction,
       "Invalid IterType: ",
       type2);
 

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -618,7 +618,7 @@ std::pair<std::vector<int64_t>, std::vector<int64_t>> inferAllocationShape(
 
   // Allocate the allocation domain
   for (const auto id : tv->getMaybeAllocationDomain()) {
-    if (id->isReduction() || id->isStride()) {
+    if (id->isReduction()) {
       continue;
     }
 

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -1056,7 +1056,7 @@ bool requiresDisabledParamCache(const kir::Kernel* kernel) {
     // See issue https://github.com/csarofeen/pytorch/issues/2002
     for (const auto id : logical_domain) {
       Val* extent = nullptr;
-      if (id->isReduction() || id->isStride() || id->isDeviceDim()) {
+      if (id->isReduction() || id->isDeviceDim()) {
         continue;
       } else if (id->isBroadcast() && id->hasExpandedExtent()) {
         extent = id->expandedExtent();

--- a/csrc/scheduler/registry_utils.cpp
+++ b/csrc/scheduler/registry_utils.cpp
@@ -131,7 +131,7 @@ PrimDataType getTensorIndexType(TensorView* tv, ExpressionEvaluator& ee) {
   KernelIndexTypeCompute index_type_helper;
   for (auto i = tv->getLogicalDomain().size(); i > 0; --i) {
     auto id = tv->getLogicalDomain().at(i - 1);
-    if (id->isReduction() || id->isStride() || id->isBroadcast()) {
+    if (id->isReduction() || id->isBroadcast()) {
       continue;
     }
 

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -814,8 +814,6 @@ static const char* iter_type2string(IterType t) {
       return "r";
     case IterType::Broadcast:
       return "b";
-    case IterType::Stride:
-      return "s";
     case IterType::GatherScatter:
       return "n";
     case IterType::VectorComponent:

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -754,7 +754,6 @@ enum class IterType {
   Iteration,
   Reduction,
   Broadcast,
-  Stride,
   GatherScatter,
   VectorComponent,
   Symbolic


### PR DESCRIPTION
`stridedSplit` has no use in our code base, which means IterType::Stride is never used neither.
Removing dead logic.