### PR TITLE
Expand ComputeAtMap exact and almost_exact disjointsets by IdModel

### DIFF
--- a/csrc/compute_at_map.cpp
+++ b/csrc/compute_at_map.cpp
@@ -730,9 +730,6 @@ void IterDomainGraph::build(Fusion* fusion) {
     const ValGraph& exact_graph = GpuLower::current()->idModel().idGraph(mode);
     for (const auto& exact_vals :
          exact_graph.disjointValSets().disjointSets()) {
-      if (exact_vals->empty()) {
-        continue;
-      }
       IterDomain* first_id = nullptr;
       for (const auto& val : *exact_vals) {
         auto id = val->as<IterDomain>();
@@ -741,7 +738,6 @@ void IterDomainGraph::build(Fusion* fusion) {
         }
         if (first_id == nullptr) {
           first_id = id;
-          continue;
         } else if (!nodes.strictAreMapped(first_id, id)) {
           // std::cerr << "IdModel map: " << first_id->toString() << ", "
           //<< id->toString() << "\n";
@@ -752,6 +748,7 @@ void IterDomainGraph::build(Fusion* fusion) {
   };
 
   expand_by_id_model(exact_nodes_, IdMappingMode::EXACT);
+  expand_by_id_model(permissive_nodes_, IdMappingMode::EXACT);
 
   innermost_nodes_ = permissive_resize_nodes_;
   // Build almost exact map by forwarding through broadcast axes

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -494,12 +494,6 @@ void GpuLower::analysis(Fusion* fusion) {
   replaceSymbolicSizes(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "replaceSymbolicSizes");
 
-  // Build what's refered to as the compute at map. This map contains the
-  // mappings of all iteration domains across the fusion. There are three types
-  // of mappings Permissive, Exact, and Loop, see compute_at_map.h/cpp for more
-  // information.
-  compute_at_map_ = std::make_shared<ComputeAtMap>(fusion_);
-
   // New IterDomains may be created, so it is expected that generated
   // code may use diffrent variable names
   if (idModelOptions().buildIdModel()) {
@@ -510,6 +504,12 @@ void GpuLower::analysis(Fusion* fusion) {
         /*validate=*/false);
     id_model_->validateAndPropagatePType();
   }
+
+  // Build what's refered to as the compute at map. This map contains the
+  // mappings of all iteration domains across the fusion. There are three types
+  // of mappings Permissive, Exact, and Loop, see compute_at_map.h/cpp for more
+  // information.
+  compute_at_map_ = std::make_shared<ComputeAtMap>(fusion_);
 
   resolveComputeWith(fusion_);
   dumpExprsIfEnabled(fusion_->exprs(), "resolveComputeWith");

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -509,6 +509,8 @@ void GpuLower::analysis(Fusion* fusion) {
   // mappings of all iteration domains across the fusion. There are three types
   // of mappings Permissive, Exact, and Loop, see compute_at_map.h/cpp for more
   // information.
+  //
+  // Depends on IdModel
   compute_at_map_ = std::make_shared<ComputeAtMap>(fusion_);
 
   resolveComputeWith(fusion_);


### PR DESCRIPTION
`ComputeAtMap` is considered almost deprecated but the gap with `IdModel` results in small but many changes in generated index exprs, mainly because some mappings are missed in `ComputeAtMap`, which then results in different index exprs. 

To make the transition from the legacy indexer smoother, this PR augments the exact and almost-exact disjoint sets of `ComputeAtMap` with the exact and almost-exact graphs of `IdModel`, respectively. This should make the code diff results cleaner when comparing the legacy and the new indexers.