### PR TITLE
Misc changes on matmul tests to make it Blackwell-friendly

### DIFF
--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -3811,8 +3811,7 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
     tv1c->circularBuffer(stages, prefetch);
   }
 
-  auto inputs =
-      matmulAtInput3DHopperSS(M, N, K, layout, data_type_to_aten(dtype));
+  auto inputs = matmulAtInput3DSS(M, N, K, layout, data_type_to_aten(dtype));
 
   KernelExecutor ke;
   ke.compile(
@@ -3989,7 +3988,7 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle_NoBroadcasts) {
   ASSERT_TRUE(pred_checker.found_mma);
 
   auto [A3d, B3d] =
-      matmulAtInput3DHopperSS(M, N, K, layout, data_type_to_aten(dtype));
+      matmulAtInput3DSS(M, N, K, layout, data_type_to_aten(dtype));
   auto t0 = A3d.squeeze();
   auto t1 = B3d.squeeze();
 
@@ -5122,8 +5121,7 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle_BroadcastOp) {
     tv1c->circularBuffer(stages, prefetch);
   }
 
-  auto inputs =
-      matmulAtInput3DHopperSS(M, N, K, layout, data_type_to_aten(dtype));
+  auto inputs = matmulAtInput3DSS(M, N, K, layout, data_type_to_aten(dtype));
   inputs.first = inputs.first.squeeze();
   inputs.second = inputs.second.squeeze();
 

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3397,7 +3397,7 @@ class HopperMatmulSchedulerTest
 
 TEST_P(HopperMatmulSchedulerTest, FusedMultiplySum) {
   const auto& [A, B] =
-      matmulAtInput3DHopperSS(M, N, K, layout, data_type_to_aten(dtype));
+      matmulAtInput3DSS(M, N, K, layout, data_type_to_aten(dtype));
   inputs = {A, B};
 
   TensorView* tv0 = nullptr;
@@ -3455,7 +3455,7 @@ TEST_P(HopperMatmulSchedulerTest, FusedMultiplySum) {
 // run on hopper.
 TEST_P(HopperMatmulSchedulerTest, FusedMultiplySumBiasNeg) {
   const auto& [A, B] =
-      matmulAtInput3DHopperSS(M, N, K, layout, data_type_to_aten(dtype));
+      matmulAtInput3DSS(M, N, K, layout, data_type_to_aten(dtype));
   const auto& C = matmulAtInput2D(
       layout, TensorMatmulPos::Bias, data_type_to_aten(dtype), M, N, K);
   inputs = {A, B, C};

--- a/tests/cpp/test_mma.cpp
+++ b/tests/cpp/test_mma.cpp
@@ -633,15 +633,16 @@ INSTANTIATE_TEST_SUITE_P(
     mmaHopperRSParamsGenerator(),
     testNameHopperRS);
 
-using HopperMmaSSTestParams = std::tuple<
+using MmaSSTestParams = std::tuple<
     MmaMacro,
     PrimDataType,
     MmaLayout,
     MmaInputSmemSwizzle,
     MmaInputSmemSwizzle>;
 
-class HopperSS : public HopperBase,
-                 public ::testing::WithParamInterface<HopperMmaSSTestParams> {
+template <typename Base>
+class SSTest : public Base,
+               public ::testing::WithParamInterface<MmaSSTestParams> {
  protected:
   MmaLayout layout;
   MmaMacro macro;
@@ -650,7 +651,7 @@ class HopperSS : public HopperBase,
   MmaInputSmemSwizzle swizzle_b;
 
   void SetUp() override {
-    HopperBase::SetUp();
+    Base::SetUp();
 
     macro = std::get<0>(GetParam());
     dtype = std::get<1>(GetParam());
@@ -660,12 +661,14 @@ class HopperSS : public HopperBase,
   }
 };
 
+using HopperSS = SSTest<HopperBase>;
+
 TEST_P(HopperSS, SingleTile) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto shapes = matmulAtInputShape3DHopperSS(
-      getM(macro), getN(macro), getK(macro), layout);
+  auto shapes =
+      matmulAtInputShape3DSS(getM(macro), getN(macro), getK(macro), layout);
 
   auto tv0 = makeConcreteTensor(shapes.first, dtype);
   auto tv1 = makeConcreteTensor(shapes.second, dtype);
@@ -762,7 +765,7 @@ TEST_P(HopperSS, SingleTile) {
     tv2->setLoopDomain(s.as<IterDomain*>());
   }
 
-  auto inputs = matmulAtInput3DHopperSS(
+  auto inputs = matmulAtInput3DSS(
       getM(macro), getN(macro), getK(macro), layout, data_type_to_aten(dtype));
 
   KernelExecutor ke;
@@ -783,8 +786,8 @@ TEST_P(HopperSS, SingleTileTransposed) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto shapes = matmulAtInputShape3DHopperSS(
-      getM(macro), getN(macro), getK(macro), layout);
+  auto shapes =
+      matmulAtInputShape3DSS(getM(macro), getN(macro), getK(macro), layout);
 
   auto tv0 = makeConcreteTensor(shapes.first, dtype);
   auto tv1 = makeConcreteTensor(shapes.second, dtype);
@@ -891,7 +894,7 @@ TEST_P(HopperSS, SingleTileTransposed) {
     tv2->setLoopDomain(s.as<IterDomain*>());
   }
 
-  auto inputs = matmulAtInput3DHopperSS(
+  auto inputs = matmulAtInput3DSS(
       getM(macro), getN(macro), getK(macro), layout, data_type_to_aten(dtype));
 
   KernelExecutor ke;
@@ -911,7 +914,7 @@ TEST_P(HopperSS, MultipleTile) {
 
   constexpr int64_t num_tiles = 2;
 
-  auto shapes = matmulAtInputShape3DHopperSS(
+  auto shapes = matmulAtInputShape3DSS(
       num_tiles * getM(macro),
       num_tiles * getN(macro),
       num_tiles * getK(macro),
@@ -1066,7 +1069,7 @@ TEST_P(HopperSS, MultipleTile) {
 
   inlineMost();
 
-  auto inputs = matmulAtInput3DHopperSS(
+  auto inputs = matmulAtInput3DSS(
       num_tiles * getM(macro),
       num_tiles * getN(macro),
       num_tiles * getK(macro),
@@ -1084,8 +1087,7 @@ TEST_P(HopperSS, MultipleTile) {
   NVF_CHECK(at::allclose(cg_outputs[0].as<at::Tensor>(), tref, 1e-5, 1e-5));
 }
 
-std::string testNameHopperSS(
-    const testing::TestParamInfo<HopperMmaSSTestParams>& info) {
+std::string testNameSS(const testing::TestParamInfo<MmaSSTestParams>& info) {
   std::ostringstream os;
   auto macro = std::get<0>(info.param);
   auto dtype = std::get<1>(info.param);
@@ -1097,19 +1099,19 @@ std::string testNameHopperSS(
   return os.str();
 }
 
-auto mmaHopperSSParamsGenerator() {
+auto mmaSSParamsGenerator(const auto& all_macros) {
   // A very simple PRNG:
   // https://en.wikipedia.org/wiki/Lehmer_random_number_generator
   uint32_t lcg_parkmiller = 1;
   // Only select 1/dilute of the params, 1 means not diluting
   const uint32_t dilute = std::stoi(getNvFuserEnv("MMA_TEST_DILUTE", "8"));
-  std::vector<HopperMmaSSTestParams> params;
+  std::vector<MmaSSTestParams> params;
   std::unordered_set<MmaMacro> macros;
   std::unordered_set<PrimDataType> dtypes;
   std::unordered_set<MmaLayout> layouts;
   std::unordered_set<MmaInputSmemSwizzle> swizzle_as;
   std::unordered_set<MmaInputSmemSwizzle> swizzle_bs;
-  for (auto macro : kAllHopperMacros) {
+  for (auto macro : all_macros) {
     for (auto dtype : all_dtypes) {
       for (auto layout : kAllSupportedMmaLayout) {
         for (auto swizzle_a : kAllSmemSwizzleModes) {
@@ -1143,7 +1145,7 @@ auto mmaHopperSSParamsGenerator() {
 INSTANTIATE_TEST_SUITE_P(
     MmaTest,
     HopperSS,
-    mmaHopperSSParamsGenerator(),
-    testNameHopperSS);
+    mmaSSParamsGenerator(kAllHopperMacros),
+    testNameSS);
 
 } // namespace nvfuser

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -661,6 +661,62 @@ static auto kAllHopperMacros = std::vector<MmaMacro>{
     MmaMacro::Hopper_64_232_16, MmaMacro::Hopper_64_240_16,
     MmaMacro::Hopper_64_248_16, MmaMacro::Hopper_64_256_16};
 
+static auto kAllBlackwell1CTAM64Macros = std::vector<MmaMacro>{
+    MmaMacro::Blackwell1CTA_64_8_16,   MmaMacro::Blackwell1CTA_64_16_16,
+    MmaMacro::Blackwell1CTA_64_24_16,  MmaMacro::Blackwell1CTA_64_32_16,
+    MmaMacro::Blackwell1CTA_64_40_16,  MmaMacro::Blackwell1CTA_64_48_16,
+    MmaMacro::Blackwell1CTA_64_56_16,  MmaMacro::Blackwell1CTA_64_64_16,
+    MmaMacro::Blackwell1CTA_64_72_16,  MmaMacro::Blackwell1CTA_64_80_16,
+    MmaMacro::Blackwell1CTA_64_88_16,  MmaMacro::Blackwell1CTA_64_96_16,
+    MmaMacro::Blackwell1CTA_64_104_16, MmaMacro::Blackwell1CTA_64_112_16,
+    MmaMacro::Blackwell1CTA_64_120_16, MmaMacro::Blackwell1CTA_64_128_16,
+    MmaMacro::Blackwell1CTA_64_136_16, MmaMacro::Blackwell1CTA_64_144_16,
+    MmaMacro::Blackwell1CTA_64_152_16, MmaMacro::Blackwell1CTA_64_160_16,
+    MmaMacro::Blackwell1CTA_64_168_16, MmaMacro::Blackwell1CTA_64_176_16,
+    MmaMacro::Blackwell1CTA_64_184_16, MmaMacro::Blackwell1CTA_64_192_16,
+    MmaMacro::Blackwell1CTA_64_200_16, MmaMacro::Blackwell1CTA_64_208_16,
+    MmaMacro::Blackwell1CTA_64_216_16, MmaMacro::Blackwell1CTA_64_224_16,
+    MmaMacro::Blackwell1CTA_64_232_16, MmaMacro::Blackwell1CTA_64_240_16,
+    MmaMacro::Blackwell1CTA_64_248_16, MmaMacro::Blackwell1CTA_64_256_16};
+
+static auto kAllBlackwell1CTAM128Macros = std::vector<MmaMacro>{
+    MmaMacro::Blackwell1CTA_128_16_16,
+    MmaMacro::Blackwell1CTA_128_32_16,
+    MmaMacro::Blackwell1CTA_128_48_16,
+    MmaMacro::Blackwell1CTA_128_64_16,
+    MmaMacro::Blackwell1CTA_128_80_16,
+    MmaMacro::Blackwell1CTA_128_96_16,
+    MmaMacro::Blackwell1CTA_128_112_16,
+    MmaMacro::Blackwell1CTA_128_128_16,
+    MmaMacro::Blackwell1CTA_128_144_16,
+    MmaMacro::Blackwell1CTA_128_160_16,
+    MmaMacro::Blackwell1CTA_128_176_16,
+    MmaMacro::Blackwell1CTA_128_192_16,
+    MmaMacro::Blackwell1CTA_128_208_16,
+    MmaMacro::Blackwell1CTA_128_224_16,
+    MmaMacro::Blackwell1CTA_128_240_16,
+    MmaMacro::Blackwell1CTA_128_256_16};
+
+static auto kAllBlackwell2CTAM128Macros = std::vector<MmaMacro>{
+    MmaMacro::Blackwell2CTA_128_32_16,
+    MmaMacro::Blackwell2CTA_128_64_16,
+    MmaMacro::Blackwell2CTA_128_96_16,
+    MmaMacro::Blackwell2CTA_128_128_16,
+    MmaMacro::Blackwell2CTA_128_160_16,
+    MmaMacro::Blackwell2CTA_128_192_16,
+    MmaMacro::Blackwell2CTA_128_224_16,
+    MmaMacro::Blackwell2CTA_128_256_16};
+
+static auto kAllBlackwell2CTAM256Macros = std::vector<MmaMacro>{
+    MmaMacro::Blackwell2CTA_256_32_16,
+    MmaMacro::Blackwell2CTA_256_64_16,
+    MmaMacro::Blackwell2CTA_256_96_16,
+    MmaMacro::Blackwell2CTA_256_128_16,
+    MmaMacro::Blackwell2CTA_256_160_16,
+    MmaMacro::Blackwell2CTA_256_192_16,
+    MmaMacro::Blackwell2CTA_256_224_16,
+    MmaMacro::Blackwell2CTA_256_256_16};
+
 std::string macroToString(const MmaMacro macro);
 
 // Utility to generate matmul input tensors based on given layout
@@ -736,7 +792,7 @@ inline std::pair<at::Tensor, at::Tensor> matmulAtInput3DHopperRS(
 }
 
 inline std::pair<std::vector<int64_t>, std::vector<int64_t>>
-matmulAtInputShape3DHopperSS(int M, int N, int K, MmaLayout layout) {
+matmulAtInputShape3DSS(int M, int N, int K, MmaLayout layout) {
   switch (layout) {
     case MmaLayout::TT:
       return {{M, K, 1}, {1, K, N}};
@@ -751,14 +807,14 @@ matmulAtInputShape3DHopperSS(int M, int N, int K, MmaLayout layout) {
   }
 }
 
-inline std::pair<at::Tensor, at::Tensor> matmulAtInput3DHopperSS(
+inline std::pair<at::Tensor, at::Tensor> matmulAtInput3DSS(
     int M,
     int N,
     int K,
     MmaLayout layout,
     c10::ScalarType dtype) {
   auto options = at::TensorOptions().dtype(dtype).device(at::kCUDA, 0);
-  auto shapes = matmulAtInputShape3DHopperSS(M, N, K, layout);
+  auto shapes = matmulAtInputShape3DSS(M, N, K, layout);
   return std::make_pair(
       at::randn(shapes.first, options), at::randn(shapes.second, options));
 }


### PR DESCRIPTION
- Renames:
  - `matmulAtInput3DHopperSS` -> `matmulAtInput3DSS`
  - `HopperMmaSSTestParams` -> `MmaSSTestParams`
  - `class HopperSS : public HopperBase` -> `class SSTest : public Base`
  - `testNameHopperSS` -> `testNameSS`
  - `mmaHopperSSParamsGenerator` -> `mmaSSParamsGenerator`
- Add Blackwell macro lists to `tests/cpp/utils.h`