### PR TITLE
Fix TensorIndexer for circular buffering

### DIFF
--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -1186,15 +1186,17 @@ void IdModel::allocateLoopIndexVariables() {
 
     if (GpuLower::current()->circularBufferInfo().isCircularBufferedIterDomain(
             loop_group->front()->as<IterDomain>())) {
-      // Allocate index variable for each stage of the circular buffered loop.
+      // Allocate index variable for each stage of the circular
+      // buffered loop.
+      auto indices = std::make_unique<CircularBufferIndices>();
+      for (auto i :
+           arange(static_cast<int>(CircularBufferLoopStage::EndOfStages))) {
+        indices->emplace(
+            static_cast<CircularBufferLoopStage>(i),
+            IrBuilder::create<Val>(DataType::Index));
+      }
       circular_buffered_loop_index_variable_map_[loop_group] =
-          std::make_unique<CircularBufferIndices>(CircularBufferIndices(
-              {{CircularBufferLoopStage::Prolog,
-                IrBuilder::create<Val>(DataType::Index)},
-               {CircularBufferLoopStage::Main,
-                IrBuilder::create<Val>(DataType::Index)},
-               {CircularBufferLoopStage::Epilog,
-                IrBuilder::create<Val>(DataType::Index)}}));
+          std::move(indices);
       continue;
     }
 

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -185,6 +185,7 @@ class CircularBufferingTest : public NVFuserFixtureParamTest<StageAndPrefetch> {
     number_of_stages = std::get<0>(GetParam());
     prefetch_distance = std::get<1>(GetParam());
     NVFuserTest::SetUp();
+    EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
   }
 };
 


### PR DESCRIPTION
Loop indices for newly added stages were missing.

Also changed to use `TensorIndexer` with `CircularBufferTest`.

The code diff results show many changes. As far as I can see, none of them seems problematic as they are all one of:

- Bug in the legacy indexer (#4189)
- Different insertion of `nvfuser_zero`. I'm not sure why, but I don't think it's worthwhile investigating in the context of circular buffering.
- Different replacement of predicate indices for IDs that are exact mapped with vectorized IDs. The legacy indexer replaces it with `N - 1` for both the start and stop predicates, whereas the new indexer uses 0 for the start predicate. Both are valid.