### PR TITLE
Create block sync that runs inside of warp specialized IfThenElse

### DIFF
--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -38,7 +38,7 @@ bool isWithinComputeWarp(const std::vector<ForLoop*> for_loops) {
 // Return true if any for loop is ComputeWarp.
 // Return false if any for loop is LoadWarp.
 // Return std:nullopt if none of the for loops are a warp specialized stage.
-std::optional<bool> isOptionalLoadOrComputeSync(
+std::optional<bool> isOptionalComputeSync(
     const std::vector<ForLoop*> for_loops) {
   bool contains_load_warp = isWithinLoadWarp(for_loops);
   bool contains_compute_warp = isWithinComputeWarp(for_loops);
@@ -325,7 +325,7 @@ class WarSyncInserter : private kir::ExprMutator {
       // specialization
       for_loops_.push_back(for_loop);
       auto sync_expr = IrBuilder::create<kir::BlockSync>(
-          /*war_sync=*/true, isOptionalLoadOrComputeSync(for_loops_));
+          /*war_sync=*/true, isOptionalComputeSync(for_loops_));
       for_loops_.pop_back();
       kir::ExprMutator::registerInsertAfter(
           for_loop->body().exprs().back(), sync_expr, &for_loop->body());
@@ -576,7 +576,7 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
             sync_bitmap, maybe_alloc->buffer());
       } else {
         sync_expr = IrBuilder::create<kir::BlockSync>(
-            /*war_sync=*/false, isOptionalLoadOrComputeSync(for_loops_));
+            /*war_sync=*/false, isOptionalComputeSync(for_loops_));
       }
 
       insertSyncExpr(last_writes, expr, sync_expr, maybe_alloc);

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -43,7 +43,7 @@ std::optional<bool> isOptionalLoadOrComputeSync(
   bool contains_load_warp = isWithinLoadWarp(for_loops);
   bool contains_compute_warp = isWithinComputeWarp(for_loops);
   NVF_ERROR(
-      contains_load_warp || contains_compute_warp,
+      !contains_load_warp || !contains_compute_warp,
       "The list of for-loops contains both LoadWarp and ComputeWarp stages.");
   if (isWithinLoadWarp(for_loops)) {
     return false;

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -321,8 +321,12 @@ class WarSyncInserter : private kir::ExprMutator {
 
     // WAR Sync is necessary in this loop, register its insertion.
     if (insert_sync) {
+      // Temporarily add the current for-loop to for_loops to check for warp
+      // specialization
+      for_loops_.push_back(for_loop);
       auto sync_expr = IrBuilder::create<kir::BlockSync>(
           /*war_sync=*/true, isOptionalLoadOrComputeSync(for_loops_));
+      for_loops_.pop_back();
       kir::ExprMutator::registerInsertAfter(
           for_loop->body().exprs().back(), sync_expr, &for_loop->body());
       handle(sync_expr);

--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -20,6 +20,40 @@ namespace nvfuser {
 
 namespace {
 
+// Determine if any for loop is a LoadWarp circular buffering stage
+bool isWithinLoadWarp(const std::vector<ForLoop*> for_loops) {
+  return std::any_of(for_loops.begin(), for_loops.end(), [](ForLoop* fl) {
+    return fl->circularBufferLoopStage() == CircularBufferLoopStage::LoadWarp;
+  });
+}
+
+// Determine if any for loop is a ComputeWarp circular buffering stage
+bool isWithinComputeWarp(const std::vector<ForLoop*> for_loops) {
+  return std::any_of(for_loops.begin(), for_loops.end(), [](ForLoop* fl) {
+    return fl->circularBufferLoopStage() ==
+        CircularBufferLoopStage::ComputeWarp;
+  });
+}
+
+// Return true if any for loop is ComputeWarp.
+// Return false if any for loop is LoadWarp.
+// Return std:nullopt if none of the for loops are a warp specialized stage.
+std::optional<bool> isOptionalLoadOrComputeSync(
+    const std::vector<ForLoop*> for_loops) {
+  bool contains_load_warp = isWithinLoadWarp(for_loops);
+  bool contains_compute_warp = isWithinComputeWarp(for_loops);
+  NVF_ERROR(
+      contains_load_warp || contains_compute_warp,
+      "The list of for-loops contains both LoadWarp and ComputeWarp stages.");
+  if (isWithinLoadWarp(for_loops)) {
+    return false;
+  } else if (isWithinComputeWarp(for_loops)) {
+    return true;
+  } else {
+    return std::nullopt;
+  }
+}
+
 // Tensor memory is similar to shared memory because they are both
 // shared between threads in a block. In that sense, we can consider
 // tensor memory as special type of shared memory. In this file, we use
@@ -287,7 +321,8 @@ class WarSyncInserter : private kir::ExprMutator {
 
     // WAR Sync is necessary in this loop, register its insertion.
     if (insert_sync) {
-      auto sync_expr = IrBuilder::create<kir::BlockSync>(true);
+      auto sync_expr = IrBuilder::create<kir::BlockSync>(
+          /*war_sync=*/true, isOptionalLoadOrComputeSync(for_loops_));
       kir::ExprMutator::registerInsertAfter(
           for_loop->body().exprs().back(), sync_expr, &for_loop->body());
       handle(sync_expr);
@@ -536,7 +571,8 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         sync_expr = IrBuilder::create<kir::GridSync>(
             sync_bitmap, maybe_alloc->buffer());
       } else {
-        sync_expr = IrBuilder::create<kir::BlockSync>(false); // is not war sync
+        sync_expr = IrBuilder::create<kir::BlockSync>(
+            /*war_sync=*/false, isOptionalLoadOrComputeSync(for_loops_));
       }
 
       insertSyncExpr(last_writes, expr, sync_expr, maybe_alloc);

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -488,7 +488,10 @@ class BlockSync final : public Expr {
  public:
   using Expr::Expr;
 
-  explicit BlockSync(IrBuilderPasskey passkey, bool war_sync = false);
+  explicit BlockSync(
+      IrBuilderPasskey passkey,
+      bool war_sync = false,
+      std::optional<bool> optional_compute_or_load_sync = std::nullopt);
 
   const char* getOpString() const override {
     return "BlockSync";
@@ -502,6 +505,20 @@ class BlockSync final : public Expr {
   // TODO: war_sync_ is only used for testing/validation purposes.
   bool isWarHazardSync() const {
     return attribute<bool>(0);
+  }
+
+  std::optional<bool> warpSpecializedState() const {
+    return attribute<std::optional<bool>>(1);
+  }
+
+  bool isComputeWarpSync() const {
+    return attribute<std::optional<bool>>(1).value_or(false);
+  }
+
+  bool isLoadWarpSync() const {
+    auto optional_compute_or_load_sync = attribute<std::optional<bool>>(1);
+    return optional_compute_or_load_sync.has_value() &&
+        !optional_compute_or_load_sync.value();
   }
 };
 

--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -269,10 +269,18 @@ bool ParallelDimensionMap::isExact(ParallelType pt) const {
 Val* ParallelDimensionMap::getRawCompute(ParallelType pt) const {
   Val* raw = getRaw(pt);
   if (warp_specialized_types_.count(pt)) {
-    auto padded_val = getWarpSpecializationPaddedVal(pt);
+    int64_t padded_val = getWarpSpecializationPaddedVal(pt);
     return SimplifyingIrBuilder::addExpr(raw, -padded_val);
   }
   return raw;
+}
+
+Val* ParallelDimensionMap::getRawLoad(ParallelType pt) const {
+  if (warp_specialized_types_.count(pt)) {
+    return IrBuilder::create<Val>(
+        getWarpSpecializationPaddedVal(pt), DataType::Index);
+  }
+  return getRaw(pt);
 }
 
 Val* ParallelDimensionMap::getNumComputeThreadsEachBlock() const {

--- a/csrc/parallel_dimension_map.h
+++ b/csrc/parallel_dimension_map.h
@@ -44,11 +44,19 @@ class ParallelDimensionMap {
   //! Get the "compute" parallel dimension on the given ParallelType. In case
   //! of no warp specialization, this is the same as getRaw(pt). If we are doing
   //! warp specialization on pt without register sharing, the result is
-  //! getRaw(pt) - 1, because the last of pt is used for loading circular buffer
-  //! tensors. If register sharing is also used, difference padded threads are
-  //! required for different cta shapes.
+  //! getRaw(pt) - padded, because the last of pt is used for loading circular
+  //! buffer tensors. If register sharing is also used, difference padded
+  //! threads are required for different cta shapes.
   Val* getRawCompute(ParallelType pt) const;
 
+  //! Get the "load" parallel dimension on the given ParallelType. In case
+  //! of no warp specialization, this is the same as getRaw(pt). If we are doing
+  //! warp specialization on pt, the result is 1, because the last of pt is used
+  //! for loading circular buffer tensors.
+  Val* getRawLoad(ParallelType pt) const;
+
+  //! The padded val ensures that CTA has 128 threads for the LoadWarp. This
+  //! function returns the padded val for the warp specialized ParallelType.
   int64_t getWarpSpecializationPaddedVal(ParallelType pt) const;
 
   //! Get the number of threads per each CTA used for computation. When there is


### PR DESCRIPTION
This PR modifies the `RAW` and `WAR` sync passes to insert `kir::BlockSync` nodes that track if it's inside a warp-specialized for-loop. 

## Details
- Add `optional_compute_or_load_sync` attribute to `kir::BlockSync` node.
- If the attribute is `std::nullopt`, then it is a regular block sync. If `true`, then it is inside a `ComputeWarp`. If `false`, then it is inside a `LoadWarp`.
- When creating the CUDA kernel, the correct number of threads is generated using `parallel_dimension_map`.
- Created `BarSyncWarpSpecializedPointwise` to test that the block syncs are added correctly to the `ComputeWarp`.
- I added support for block syncs in `LoadWarp`. However, since only TMA Loads are cloned to `LoadWarp`, I couldn't create a unit test.

## CUDA Kernel Sample

```cuda
__global__ void cuda_kernel(args) {
  // boilerplate
  #pragma unroll
  for(nvfuser_index_t i13 = 0; i13 < 4; ++i13) {
    if (((Hopper::electSync(4294967295U) && b9) && b10)) {
      mbarrier::init(toSmem((&T6[i13])), 2U);
    }
  }
  #pragma unroll
  for(nvfuser_index_t i14 = 0; i14 < 4; ++i14) {
    if (((Hopper::electSync(4294967295U) && b9) && b10)) {
      mbarrier::init(toSmem((&T6[(i14 + 4LL)])), 256U);
    }
  }
  __syncthreads();
  if ((((nvfuser_index_t)threadIdx.y) == 1)) {
    #pragma unroll 1
    for(nvfuser_index_t i15 = 0; i15 < i2; ++i15) {
      nvfuser_index_t i16;
      i16 = 1024 * (i15 % 4);
      if ((Hopper::electSync(4294967295U) && b9)) {
        // load something
      }
    }
  } else {
    #pragma unroll
    for(nvfuser_index_t i17 = 0; i17 < 2; ++i17) {
      mbarrier::arrive(toSmem((&T6[(i17 + 4LL)])));
    }
    #pragma unroll 1
    for(nvfuser_index_t i18 = 0; i18 < i2; ++i18) {
      // do something
      mbarrier::arrive(toSmem((&T6[(((2LL + i18) % 4) + 4LL)])));
      block_sync::sync<false>(dim3(256, 1, 1));
      if ((b11 && ((((nvfuser_index_t)threadIdx.x) + i20) < T0.logical_size[1LL]))) {
        T3[(i8 + i20)]
           = expf(T2[((nvfuser_index_t)threadIdx.x)]);
      }
      block_sync::sync<false>(dim3(256, 1, 1));
    }
  }
  #pragma unroll
  for(nvfuser_index_t i23 = 0; i23 < 4; ++i23) {
    if (((Hopper::electSync(4294967295U) && b9) && b10)) {
      mbarrier::inval(toSmem((&T6[(i23 + 4LL)])));
    }
  }
  #pragma unroll
  for(nvfuser_index_t i24 = 0; i24 < 4; ++i24) {
    if (((Hopper::electSync(4294967295U) && b9) && b10)) {
      mbarrier::inval(toSmem((&T6[i24])));
    }
  }
}
```