### PR TITLE
Fix the order of accumulating logical indices

### DIFF
--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -431,11 +431,11 @@ std::vector<PredicateInfo> TensorIndexer::getPredicates(
   auto protectPredicatesWithMagicZero = [&](PredicateInfo& info) {
     if (info.startPredicate() != nullptr) {
       info.startPredicate() =
-          protectIndexWithMagicZero(info.startPredicate(), for_loops);
+          protectIndcesWithMagicZero({info.startPredicate()}, for_loops);
     }
     if (info.stopPredicate() != nullptr) {
       info.stopPredicate() =
-          protectIndexWithMagicZero(info.stopPredicate(), for_loops);
+          protectIndcesWithMagicZero({info.stopPredicate()}, for_loops);
     }
   };
 

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -431,11 +431,11 @@ std::vector<PredicateInfo> TensorIndexer::getPredicates(
   auto protectPredicatesWithMagicZero = [&](PredicateInfo& info) {
     if (info.startPredicate() != nullptr) {
       info.startPredicate() =
-          protectIndcesWithMagicZero({info.startPredicate()}, for_loops);
+          protectIndicesWithMagicZero({info.startPredicate()}, for_loops).at(0);
     }
     if (info.stopPredicate() != nullptr) {
       info.stopPredicate() =
-          protectIndcesWithMagicZero({info.stopPredicate()}, for_loops);
+          protectIndicesWithMagicZero({info.stopPredicate()}, for_loops).at(0);
     }
   };
 

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -142,7 +142,8 @@ std::vector<Val*> TensorIndexer::getIndexFor(
     const Expr* expr,
     bool as_consumer,
     const std::vector<IterDomain*>& index_ids,
-    const std::vector<ForLoop*>& for_loops) const {
+    const std::vector<ForLoop*>& for_loops,
+    bool use_magic_zero) const {
   auto info = computeIndex(expr, index_ids, for_loops);
   const auto& replacement_map = getIndexReplacementMap(
       expr, as_consumer, info.loop_ids, for_loops, info.index_map);
@@ -162,6 +163,11 @@ std::vector<Val*> TensorIndexer::getIndexFor(
     result.push_back(
         ir_utils::replaceValRecursively(it->second, replacement_map));
   }
+
+  if (use_magic_zero) {
+    result = protectIndicesWithMagicZero(result, for_loops);
+  }
+
   return result;
 }
 
@@ -210,7 +216,7 @@ Val* TensorIndexer::getLinearIndex(
   }
 
   if (tv->getMemoryType() == MemoryType::Global) {
-    linear_index = protectIndexWithMagicZero(linear_index, for_loops);
+    linear_index = protectIndicesWithMagicZero({linear_index}, for_loops).at(0);
   }
 
   if (tv->getMemoryType() == MemoryType::Local) {
@@ -634,7 +640,7 @@ std::pair<std::vector<ValGroup>, std::vector<Val*>> TensorIndexer::
 }
 
 std::vector<ForLoop*> TensorIndexer::getUsedForLoopsOf(
-    Val* index,
+    const std::vector<Val*>& indices,
     const std::vector<ForLoop*>& for_loops) const {
   // Grab the loop indices
   std::vector<Val*> loop_indices;
@@ -646,7 +652,7 @@ std::vector<ForLoop*> TensorIndexer::getUsedForLoopsOf(
 
   // Figure out which loop indices are used in index
   const auto dep_vals = DependencyCheck::getAllValsBetween(
-      {loop_indices.begin(), loop_indices.end()}, {index});
+      {loop_indices.begin(), loop_indices.end()}, indices);
 
   std::vector<ForLoop*> dep_loops;
   for (auto [i, for_loop] : enumerate(for_loops)) {
@@ -663,7 +669,7 @@ std::vector<ForLoop*> TensorIndexer::getUsedForLoopsOf(
 void TensorIndexer::ensureStaticIndexing(
     const std::vector<ForLoop*>& for_loops,
     Val* index) const {
-  for (auto for_loop : getUsedForLoopsOf(index, for_loops)) {
+  for (auto for_loop : getUsedForLoopsOf({index}, for_loops)) {
     for_loop->requireUnroll();
   }
 }
@@ -727,14 +733,14 @@ std::pair<std::vector<Val*>, std::vector<Val*>> TensorIndexer::
   return {result, contig_strides};
 }
 
-Val* TensorIndexer::protectIndexWithMagicZero(
-    Val* index,
+std::vector<Val*> TensorIndexer::protectIndicesWithMagicZero(
+    const std::vector<Val*>& indices,
     const std::vector<ForLoop*>& for_loops) const {
   if (!GpuLower::current()->isNvFuserZeroEnabled()) {
-    return index;
+    return indices;
   }
 
-  auto used_for_loops = getUsedForLoopsOf(index, for_loops);
+  auto used_for_loops = getUsedForLoopsOf(indices, for_loops);
 
   for (const auto for_loop : used_for_loops | std::views::reverse) {
     Val* initial_loop_index = getLoopIndex(for_loop->iter_domain(), for_loops);
@@ -749,12 +755,18 @@ Val* TensorIndexer::protectIndexWithMagicZero(
         initial_loop_index,
         SimplifyingIrBuilder::addExpr(
             initial_loop_index, GpuLower::current()->kernel()->magicZeroVal()));
-    auto protected_index =
-        ir_utils::replaceValRecursively(index, replacement_map);
-    return protected_index;
+
+    std::vector<Val*> protected_indices;
+    protected_indices.reserve(indices.size());
+    for (const auto index : indices) {
+      auto protected_index =
+          ir_utils::replaceValRecursively(index, replacement_map);
+      protected_indices.push_back(protected_index);
+    }
+    return protected_indices;
   }
 
-  return index;
+  return indices;
 }
 
 bool TensorIndexer::isSupported(Fusion* fusion) {

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -82,7 +82,8 @@ class TensorIndexer {
       const Expr* expr,
       bool as_consumer,
       const std::vector<IterDomain*>& index_ids,
-      const std::vector<ForLoop*>& loops) const;
+      const std::vector<ForLoop*>& loops,
+      bool use_magic_zero = false) const;
 
   // Get the contig indices of the given ID groups with their strides
   std::pair<std::vector<Val*>, std::vector<Val*>> getContigIndexFor(
@@ -93,14 +94,14 @@ class TensorIndexer {
       const std::unordered_map<IterDomain*, Val*>& override_index) const;
 
   // Grab all for-loops whose indices are actually used in the given
-  // index val. Note that IndexingInfo.loop_group_dependencies can be
+  // index vals. Note that IndexingInfo.loop_group_dependencies can be
   // used to find loop IDs that are connected to the index IDs, but
   // that doesn't always mean corresponding loop indices are actually
   // used in an index Val. For example, unswitch predicates replace loop indices
   // with (N - 1), where N is the extent of an unswitched ID. This
   // function only grabs for-loops whose indices are indeed used.
   std::vector<ForLoop*> getUsedForLoopsOf(
-      Val* index,
+      const std::vector<Val*>& indices,
       const std::vector<ForLoop*>& for_loops) const;
 
   // Add "pragma unroll" to for-loops whose loop indices are used for
@@ -148,8 +149,8 @@ class TensorIndexer {
   // to indices.
   //
   // TODO: Revisit if this is still necessary.
-  Val* protectIndexWithMagicZero(
-      Val* index,
+  std::vector<Val*> protectIndicesWithMagicZero(
+      const std::vector<Val*>& indices,
       const std::vector<ForLoop*>& for_loops) const;
 
   // Check if a given fusion can be indexed with

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1619,9 +1619,9 @@ Val* Index::getLinearLogicalIndex(
         consumer_tv->getLogicalDomain(),
         loops);
     Val* stride = consumer_tv->fusion()->oneVal();
-    for (const auto i : arange(consumer_tv->getLogicalDomain().size())) {
+    for (const auto [i, logical_id] :
+         enumerate(consumer_tv->getLogicalDomain()) | std::views::reverse) {
       auto per_dim_index = per_dim_indices.at(i);
-      auto logical_id = consumer_tv->getLogicalDomain().at(i);
       auto per_dim_strided_index =
           SimplifyingIrBuilder::mulExpr(per_dim_index, stride);
       per_dim_indices.at(i) = per_dim_strided_index;

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -1617,7 +1617,8 @@ Val* Index::getLinearLogicalIndex(
         consumer_tv->definition(),
         /*as_consumer=*/true,
         consumer_tv->getLogicalDomain(),
-        loops);
+        loops,
+        /*use_magic_zero=*/true);
     Val* stride = consumer_tv->fusion()->oneVal();
     for (const auto [i, logical_id] :
          enumerate(consumer_tv->getLogicalDomain()) | std::views::reverse) {

--- a/tests/cpp/test_rng.cpp
+++ b/tests/cpp/test_rng.cpp
@@ -66,7 +66,11 @@ at::Tensor generate_normal(int64_t size, at::ScalarType dtype) {
   return generate_random_numbers(size, dtype, RNGTest_t::Normal);
 }
 
-class RNGTest : public NVFuserTest {};
+class RNGTest : public NVFuserTest {
+  void SetUp() override {
+    EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+  }
+};
 
 TEST_F(RNGTest, ValidateWithCURand) {
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();


### PR DESCRIPTION
There's a bug in `getLinearLogicalIndex`, which causes `RNGTest.ManualScheduleValidateWithCURand2` to fail.

Also added an option to use magic zero since that's the case with the legacy indexer.

All of the codegen diff results look benign. 