### PR TITLE
Remove SegmenterEdge

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -2535,11 +2535,14 @@ SchedulerType tryMerge(
   scheduler_debug_utils::canScheduleMessage(
       "\n**Segmenter** Considering fusion:\n",
       segmented_fusion->completeFusion());
-  if (tryingToMergeSegmenterSet(segmented_fusion->completeFusion())) {
+  auto proposal = Schedule::proposeHeuristics(
+      segmented_fusion->completeFusion(), runtime_info);
+  if (b != nullptr &&
+      tryingToMergeSegmenterSet(segmented_fusion->completeFusion()) &&
+      proposal != SchedulerType::ExprEval) {
     return SchedulerType::None;
   }
-  return Schedule::proposeHeuristics(
-      segmented_fusion->completeFusion(), runtime_info);
+  return proposal;
 }
 
 SchedulerType tryMerge(

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -31,16 +31,19 @@ class SegmentCandidateFinder;
 // A directed edge on DAG,
 // Wrapper for values, edges between segmented groups which are made up
 // of Exprs. Multiple edges can exist between segmented groups.
+// Segmented Edge Use: Core edge data structure definition
 struct SegmentedEdge {
   SegmentedEdge(SegmentedGroup* from, SegmentedGroup* to, Val* val)
       : from(from), to(to), val(val) {}
 
+  // Segmented Edge Use: Edge connection points and value
   SegmentedGroup* from;
   SegmentedGroup* to;
   Val* val;
 
   void print() const;
 
+  // Segmented Edge Use: Edge comparison operators
   bool operator==(const SegmentedEdge& other) const {
     return from == other.from && to == other.to && val == other.val;
   }
@@ -95,13 +98,13 @@ class SegmentedGroup {
   }
 
   //! Returns inputs that this group shares with the original fusion
-  const auto& inputs() const {
-    return input_vals_.vector();
+  const auto& inputsTmp() const {
+    return input_vals_;
   }
 
   //! Returns outputs that this group shares with the original fusion
-  const auto& outputs() const {
-    return output_vals_.vector();
+  const auto& outputsTmp() const {
+    return output_vals_;
   }
 
   //! Returns the schedule heuristic associated with this group
@@ -150,11 +153,12 @@ class SegmentedGroup {
   bool isFusionInputGroup() const;
 
  public:
-  //! "Ancestor nodes", towards inputs of segmentedDAG
+  // Segmented Edge Use: Edge containers in group
   std::vector<SegmentedEdge*> producer_edges;
-
-  //! "Descendent nodes", towards outputs of segmentedDAG
   std::vector<SegmentedEdge*> consumer_edges;
+
+  VectorOfUniqueEntries<SegmentedGroup*> producer_groups_;
+  VectorOfUniqueEntries<SegmentedGroup*> consumer_groups_;
 
   //! Inputs of this group, they could be composite fusion inputs, or inputs
   //! from other groups
@@ -384,7 +388,7 @@ class SegmentedFusion {
   //! Unique name for segmented fusion
   size_t segmented_fusion_name_;
 
-  //! States representing segmentation
+  // Segmented Edge Use: Main edge container
   std::vector<SegmentedEdge*> edges_;
   std::vector<SegmentedGroup*> groups_;
 
@@ -402,10 +406,8 @@ class SegmentedFusion {
     std::unordered_map<SegmentedEdge*, int64_t> edges_map() const;
 
    private:
-    using GroupPtr = std::unique_ptr<SegmentedGroup>;
-    using EdgePtr = std::unique_ptr<SegmentedEdge>;
-    std::vector<GroupPtr> groups_;
-    std::vector<EdgePtr> edges_;
+    std::vector<std::unique_ptr<SegmentedGroup>> groups_;
+    std::vector<std::unique_ptr<SegmentedEdge>> edges_;
     SegmentedFusion* owning_fusion_;
   };
   Impl impl_;

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -98,12 +98,12 @@ class SegmentedGroup {
   }
 
   //! Returns inputs that this group shares with the original fusion
-  const auto& inputsTmp() const {
+  const auto& inputs() const {
     return input_vals_;
   }
 
   //! Returns outputs that this group shares with the original fusion
-  const auto& outputsTmp() const {
+  const auto& outputs() const {
     return output_vals_;
   }
 

--- a/csrc/host_ir/lower.cpp
+++ b/csrc/host_ir/lower.cpp
@@ -628,7 +628,8 @@ std::unique_ptr<hir::HostIrContainer> HostIrLower::lower(
   FusionGuard fg(hic.get());
   IrCloner ir_cloner(hic.get());
   auto clone =
-      [&ir_cloner](const std::vector<Val*>& vals) -> std::vector<Val*> {
+      [&ir_cloner](
+          const VectorOfUniqueEntries<Val*>& vals) -> std::vector<Val*> {
     std::vector<Val*> cloned_vals(vals.size());
     std::transform(
         vals.begin(), vals.end(), cloned_vals.begin(), [&ir_cloner](Val* val) {
@@ -673,7 +674,7 @@ std::unique_ptr<hir::HostIrContainer> HostIrLower::lower(
       auto host_unit = IrBuilder::create<hir::HostUnit>(
           staged_fusion->makeFusion(group).second);
       auto post_on_stream = IrBuilder::create<hir::PostOnStream>(
-          host_unit, clone(group->inputs()), clone(group->outputs()));
+          host_unit, clone(group->inputsTmp()), clone(group->outputsTmp()));
       hic->pushBackTopLevelExprs(post_on_stream);
     }
   }

--- a/csrc/host_ir/lower.cpp
+++ b/csrc/host_ir/lower.cpp
@@ -674,7 +674,7 @@ std::unique_ptr<hir::HostIrContainer> HostIrLower::lower(
       auto host_unit = IrBuilder::create<hir::HostUnit>(
           staged_fusion->makeFusion(group).second);
       auto post_on_stream = IrBuilder::create<hir::PostOnStream>(
-          host_unit, clone(group->inputsTmp()), clone(group->outputsTmp()));
+          host_unit, clone(group->inputs()), clone(group->outputs()));
       hic->pushBackTopLevelExprs(post_on_stream);
     }
   }

--- a/csrc/python_frontend/segmentation.cpp
+++ b/csrc/python_frontend/segmentation.cpp
@@ -168,8 +168,8 @@ std::unordered_map<int64_t, int64_t> SegmentationState::buildSegment(
   // Step 4) Create map from segment fusion indices to original fusion indices.
   // Step 4a) Get FusionDefinition index for cloned inputs and outputs. Map them
   // to their original fusion indices.
-  const auto& cloned_inputs = sg->inputsTmp();
-  const auto& cloned_outputs = sg->outputsTmp();
+  const auto& cloned_inputs = sg->inputs();
+  const auto& cloned_outputs = sg->outputs();
 
   std::vector<int64_t> original_python_index;
   original_python_index.reserve(cloned_inputs.size() + cloned_outputs.size());
@@ -338,7 +338,7 @@ void SegmentationState::prepareGroupOrder() {
         continue;
       }
 
-      const auto& group_inputs = group->inputsTmp();
+      const auto& group_inputs = group->inputs();
       bool ready_to_run = std::all_of(
           group_inputs.begin(),
           group_inputs.end(),
@@ -353,7 +353,7 @@ void SegmentationState::prepareGroupOrder() {
       group_run_order_.push_back(group);
 
       // Mark all outputs of SegmentedGroup as ready.
-      const auto& group_outputs = group->outputsTmp();
+      const auto& group_outputs = group->outputs();
       for (size_t group_out_i : arange(group_outputs.size())) {
         available_input.insert(group_outputs.at(group_out_i));
       }

--- a/csrc/python_frontend/segmentation.cpp
+++ b/csrc/python_frontend/segmentation.cpp
@@ -168,8 +168,8 @@ std::unordered_map<int64_t, int64_t> SegmentationState::buildSegment(
   // Step 4) Create map from segment fusion indices to original fusion indices.
   // Step 4a) Get FusionDefinition index for cloned inputs and outputs. Map them
   // to their original fusion indices.
-  const std::vector<Val*>& cloned_inputs = sg->inputs();
-  const std::vector<Val*>& cloned_outputs = sg->outputs();
+  const auto& cloned_inputs = sg->inputsTmp();
+  const auto& cloned_outputs = sg->outputsTmp();
 
   std::vector<int64_t> original_python_index;
   original_python_index.reserve(cloned_inputs.size() + cloned_outputs.size());
@@ -338,7 +338,7 @@ void SegmentationState::prepareGroupOrder() {
         continue;
       }
 
-      const std::vector<Val*>& group_inputs = group->inputs();
+      const auto& group_inputs = group->inputsTmp();
       bool ready_to_run = std::all_of(
           group_inputs.begin(),
           group_inputs.end(),
@@ -353,7 +353,7 @@ void SegmentationState::prepareGroupOrder() {
       group_run_order_.push_back(group);
 
       // Mark all outputs of SegmentedGroup as ready.
-      const std::vector<Val*>& group_outputs = group->outputs();
+      const auto& group_outputs = group->outputsTmp();
       for (size_t group_out_i : arange(group_outputs.size())) {
         available_input.insert(group_outputs.at(group_out_i));
       }

--- a/csrc/runtime/fusion_cache_utils.cpp
+++ b/csrc/runtime/fusion_cache_utils.cpp
@@ -122,7 +122,7 @@ void ArgumentManager::setLastUsedSegmentID(
     for (auto run_order_id : arange(1l, num_groups)) {
       auto group_to_run = group_run_order.at(run_order_id);
       // set/update life of vals in inputs of this group
-      for (auto val : group_to_run->inputsTmp()) {
+      for (auto val : group_to_run->inputs()) {
         // skip fusion inputs and outputs, they may be used by other fusions
         // or code
         if (!val->isFusionInput() && !val->isFusionOutput()) {
@@ -132,7 +132,7 @@ void ArgumentManager::setLastUsedSegmentID(
       // set/update life of vals in outputs of this group
       // skip the last group since its outputs are always the global outputs
       if (run_order_id < num_groups - 1) {
-        for (auto val : group_to_run->outputsTmp()) {
+        for (auto val : group_to_run->outputs()) {
           // skip fusion inputs and outputs, they may be used by other fusions
           // or code
           if (!val->isFusionInput() && !val->isFusionOutput()) {
@@ -184,7 +184,7 @@ void prepareRuntimeOrder(
       if (group_ran[group_i]) {
         continue;
       }
-      const auto& group_inputs = group->inputsTmp();
+      const auto& group_inputs = group->inputs();
       bool ready_to_run = std::all_of(
           group_inputs.begin(),
           group_inputs.end(),
@@ -192,7 +192,7 @@ void prepareRuntimeOrder(
 
       if (ready_to_run) {
         runtime_workspace.group_run_order.push_back(group);
-        const auto& group_outputs = group->outputsTmp().vector();
+        const auto& group_outputs = group->outputs().vector();
 
         // Insert graph segment output to tensor map
         for (const size_t group_out_i : arange(group_outputs.size())) {

--- a/csrc/runtime/fusion_cache_utils.cpp
+++ b/csrc/runtime/fusion_cache_utils.cpp
@@ -122,7 +122,7 @@ void ArgumentManager::setLastUsedSegmentID(
     for (auto run_order_id : arange(1l, num_groups)) {
       auto group_to_run = group_run_order.at(run_order_id);
       // set/update life of vals in inputs of this group
-      for (auto val : group_to_run->inputs()) {
+      for (auto val : group_to_run->inputsTmp()) {
         // skip fusion inputs and outputs, they may be used by other fusions
         // or code
         if (!val->isFusionInput() && !val->isFusionOutput()) {
@@ -132,7 +132,7 @@ void ArgumentManager::setLastUsedSegmentID(
       // set/update life of vals in outputs of this group
       // skip the last group since its outputs are always the global outputs
       if (run_order_id < num_groups - 1) {
-        for (auto val : group_to_run->outputs()) {
+        for (auto val : group_to_run->outputsTmp()) {
           // skip fusion inputs and outputs, they may be used by other fusions
           // or code
           if (!val->isFusionInput() && !val->isFusionOutput()) {
@@ -184,7 +184,7 @@ void prepareRuntimeOrder(
       if (group_ran[group_i]) {
         continue;
       }
-      const auto& group_inputs = group->inputs();
+      const auto& group_inputs = group->inputsTmp();
       bool ready_to_run = std::all_of(
           group_inputs.begin(),
           group_inputs.end(),
@@ -192,7 +192,7 @@ void prepareRuntimeOrder(
 
       if (ready_to_run) {
         runtime_workspace.group_run_order.push_back(group);
-        const auto& group_outputs = group->outputs();
+        const auto& group_outputs = group->outputsTmp().vector();
 
         // Insert graph segment output to tensor map
         for (const size_t group_out_i : arange(group_outputs.size())) {

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -375,7 +375,7 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
     // TODO: index mode should be updated per segmented kernel
     // Prepare input vector
     auto group_runtime_inputs =
-        args_manager.translateValsToArgs(group_to_run->inputsTmp().vector());
+        args_manager.translateValsToArgs(group_to_run->inputs().vector());
     group_runtime_inputs.setDeviceIndex(args.getDeviceIndex());
     if (group_cache_id.has_value()) {
       group_runtime_inputs.setCacheId(group_cache_id.value());
@@ -422,9 +422,7 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
 
     // map output args to tensor map
     args_manager.updateWithSegmentOutputs(
-        group_to_run->outputsTmp().vector(),
-        group_runtime_outputs,
-        run_order_id);
+        group_to_run->outputs().vector(), group_runtime_outputs, run_order_id);
   }
 
   // add all expressions and compiled kernels to the host ir container
@@ -434,8 +432,8 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
     for (int64_t run_order_id = 0; run_order_id < num_groups; ++run_order_id) {
       auto group_to_run = runtime_workspace_.group_run_order.at(run_order_id);
       if (hic->hasKernelExecutor(run_order_id)) {
-        auto in_clone = ir_cloner.clone(group_to_run->inputsTmp().vector());
-        auto out_clone = ir_cloner.clone(group_to_run->outputsTmp().vector());
+        auto in_clone = ir_cloner.clone(group_to_run->inputs().vector());
+        auto out_clone = ir_cloner.clone(group_to_run->outputs().vector());
         auto heuristic_params = schedulers().at(run_order_id).get();
         auto launch_kernel = IrBuilder::create<hir::LaunchKernel>(
             run_order_id,
@@ -533,7 +531,7 @@ std::optional<std::unique_ptr<HeuristicParamsList>> FusionKernelRuntime::
 
     // Get input arguments for SchedulerRuntimeInfo
     KernelArgumentHolder group_runtime_inputs =
-        args_manager.translateValsToArgs(group_to_run->inputsTmp().vector());
+        args_manager.translateValsToArgs(group_to_run->inputs().vector());
     group_runtime_inputs.setDeviceIndex(args.getDeviceIndex());
 
     // Create PrecomputedValues for fusion segment
@@ -601,7 +599,7 @@ std::optional<std::unique_ptr<HeuristicParamsList>> FusionKernelRuntime::
         evaluator_precomputed_values.get());
 
     args_manager.updateWithSegmentOutputs(
-        group_to_run->outputsTmp().vector(), group_runtime_outputs, group_id);
+        group_to_run->outputs().vector(), group_runtime_outputs, group_id);
   }
   return heuristics;
 }
@@ -644,7 +642,7 @@ std::unordered_map<Val*, PolymorphicValue> FusionKernelRuntime::
     // Prepare input vector
     auto group_to_run = runtime_workspace_.group_run_order.at(run_order_id);
     KernelArgumentHolder group_runtime_inputs =
-        args_manager.translateValsToArgs(group_to_run->inputsTmp().vector());
+        args_manager.translateValsToArgs(group_to_run->inputs().vector());
     group_runtime_inputs.setDeviceIndex(args.getDeviceIndex());
     if (group_cache_id.has_value()) {
       group_runtime_inputs.setCacheId(group_cache_id.value());
@@ -658,9 +656,7 @@ std::unordered_map<Val*, PolymorphicValue> FusionKernelRuntime::
         runKernelWithInput(group_runtime_inputs, group_to_run);
 
     args_manager.updateWithSegmentOutputs(
-        group_to_run->outputsTmp().vector(),
-        group_runtime_outputs,
-        run_order_id);
+        group_to_run->outputs().vector(), group_runtime_outputs, run_order_id);
   }
 
   if (isProfilerEnabled()) {

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -405,7 +405,7 @@ TEST_F(AliasTest, NotAllOutputsAlias_Pointwise) {
       const auto* ke =
           runtime->executors().at(group->groupId())->as<KernelExecutor>();
       int num_stores = 0;
-      for (auto i : arange(group->outputs().size())) {
+      for (auto i : arange(group->outputsTmp().size())) {
         if (storesToOutput(ke, i)) {
           num_stores++;
         }
@@ -483,7 +483,7 @@ TEST_F(AliasTest, Issue1452) {
       const auto& ke =
           runtime->executors().at(group->groupId())->as<KernelExecutor>();
       int num_stores = 0;
-      for (auto i : arange(group->outputs().size())) {
+      for (auto i : arange(group->outputsTmp().size())) {
         if (storesToOutput(ke, i)) {
           num_stores++;
         }
@@ -1275,8 +1275,8 @@ TEST_F(AliasTest, Bookend_InputsAndOutputs) {
           HeuristicIs(SchedulerType::PointWise)));
   for (SegmentedGroup* group : runtime->fusionSegments()->groups()) {
     if (group->schedulerType() == SchedulerType::PointWise) {
-      EXPECT_THAT(group->inputs(), SizeIs(1));
-      EXPECT_THAT(group->outputs(), SizeIs(1));
+      EXPECT_THAT(group->inputsTmp(), SizeIs(1));
+      EXPECT_THAT(group->outputsTmp(), SizeIs(1));
     }
   }
 }
@@ -1306,8 +1306,8 @@ TEST_F(AliasTest, Bookend_IntermediateTensors) {
           HeuristicIs(SchedulerType::PointWise)));
   for (SegmentedGroup* group : runtime->fusionSegments()->groups()) {
     if (group->schedulerType() == SchedulerType::PointWise) {
-      EXPECT_THAT(group->inputs(), SizeIs(1));
-      EXPECT_THAT(group->outputs(), SizeIs(1));
+      EXPECT_THAT(group->inputsTmp(), SizeIs(1));
+      EXPECT_THAT(group->outputsTmp(), SizeIs(1));
     }
   }
 }
@@ -1346,8 +1346,8 @@ TEST_F(AliasTest, Bookend_AliasesOfSameTensor) {
       Contains(HeuristicIs(SchedulerType::PointWise)).Times(1));
   for (SegmentedGroup* group : runtime->fusionSegments()->groups()) {
     if (group->schedulerType() == SchedulerType::PointWise) {
-      EXPECT_THAT(group->inputs(), SizeIs(1));
-      EXPECT_THAT(group->outputs(), SizeIs(1));
+      EXPECT_THAT(group->inputsTmp(), SizeIs(1));
+      EXPECT_THAT(group->outputsTmp(), SizeIs(1));
     }
   }
 }
@@ -1385,8 +1385,8 @@ TEST_F(AliasTest, Bookend_ReuseSegmentSet) {
           HeuristicIs(SchedulerType::ExprEval)));
   for (SegmentedGroup* group : runtime->fusionSegments()->groups()) {
     if (group->schedulerType() == SchedulerType::PointWise) {
-      EXPECT_THAT(group->inputs(), SizeIs(1));
-      EXPECT_THAT(group->outputs(), SizeIs(1));
+      EXPECT_THAT(group->inputsTmp(), SizeIs(1));
+      EXPECT_THAT(group->outputsTmp(), SizeIs(1));
     }
   }
 }

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -405,7 +405,7 @@ TEST_F(AliasTest, NotAllOutputsAlias_Pointwise) {
       const auto* ke =
           runtime->executors().at(group->groupId())->as<KernelExecutor>();
       int num_stores = 0;
-      for (auto i : arange(group->outputsTmp().size())) {
+      for (auto i : arange(group->outputs().size())) {
         if (storesToOutput(ke, i)) {
           num_stores++;
         }
@@ -483,7 +483,7 @@ TEST_F(AliasTest, Issue1452) {
       const auto& ke =
           runtime->executors().at(group->groupId())->as<KernelExecutor>();
       int num_stores = 0;
-      for (auto i : arange(group->outputsTmp().size())) {
+      for (auto i : arange(group->outputs().size())) {
         if (storesToOutput(ke, i)) {
           num_stores++;
         }
@@ -1275,8 +1275,8 @@ TEST_F(AliasTest, Bookend_InputsAndOutputs) {
           HeuristicIs(SchedulerType::PointWise)));
   for (SegmentedGroup* group : runtime->fusionSegments()->groups()) {
     if (group->schedulerType() == SchedulerType::PointWise) {
-      EXPECT_THAT(group->inputsTmp(), SizeIs(1));
-      EXPECT_THAT(group->outputsTmp(), SizeIs(1));
+      EXPECT_THAT(group->inputs(), SizeIs(1));
+      EXPECT_THAT(group->outputs(), SizeIs(1));
     }
   }
 }
@@ -1306,8 +1306,8 @@ TEST_F(AliasTest, Bookend_IntermediateTensors) {
           HeuristicIs(SchedulerType::PointWise)));
   for (SegmentedGroup* group : runtime->fusionSegments()->groups()) {
     if (group->schedulerType() == SchedulerType::PointWise) {
-      EXPECT_THAT(group->inputsTmp(), SizeIs(1));
-      EXPECT_THAT(group->outputsTmp(), SizeIs(1));
+      EXPECT_THAT(group->inputs(), SizeIs(1));
+      EXPECT_THAT(group->outputs(), SizeIs(1));
     }
   }
 }
@@ -1346,8 +1346,8 @@ TEST_F(AliasTest, Bookend_AliasesOfSameTensor) {
       Contains(HeuristicIs(SchedulerType::PointWise)).Times(1));
   for (SegmentedGroup* group : runtime->fusionSegments()->groups()) {
     if (group->schedulerType() == SchedulerType::PointWise) {
-      EXPECT_THAT(group->inputsTmp(), SizeIs(1));
-      EXPECT_THAT(group->outputsTmp(), SizeIs(1));
+      EXPECT_THAT(group->inputs(), SizeIs(1));
+      EXPECT_THAT(group->outputs(), SizeIs(1));
     }
   }
 }
@@ -1385,8 +1385,8 @@ TEST_F(AliasTest, Bookend_ReuseSegmentSet) {
           HeuristicIs(SchedulerType::ExprEval)));
   for (SegmentedGroup* group : runtime->fusionSegments()->groups()) {
     if (group->schedulerType() == SchedulerType::PointWise) {
-      EXPECT_THAT(group->inputsTmp(), SizeIs(1));
-      EXPECT_THAT(group->outputsTmp(), SizeIs(1));
+      EXPECT_THAT(group->inputs(), SizeIs(1));
+      EXPECT_THAT(group->outputs(), SizeIs(1));
     }
   }
 }


### PR DESCRIPTION
Attempting to remove the shallow class SegmenterEdge from fusion segmentation logic. I'm looking to prefer directly storing consumer and producer groups in SegmenterGroup.

I'm not sure how hard this will be so giving it a quick attempt. I'm hoping this will make it easier to connect, disconnect, and merge SegmenterGroups.