### PR TITLE
Add SegmentedGroup::orderedExprs to replace groupExprPrintSorting.

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1067,7 +1067,7 @@ void detailGroupPrint(std::ostream& os, const SegmentedGroup* group) {
 
   os << std::endl << std::endl;
 
-  for (Expr* e : group->orderedExprs()) {
+  for (Expr* e : group->stablyOrderedExprs()) {
     os << e->toString();
     os << "(" << e->name() << ")" << std::endl;
   }
@@ -2595,7 +2595,7 @@ void deDuplicateScalarExprs(std::vector<Expr*>& exprs) {
 
 } // namespace
 
-std::vector<Expr*> SegmentedGroup::orderedExprs() const {
+std::vector<Expr*> SegmentedGroup::stablyOrderedExprs() const {
   // The time complexity is O((V+E)LogV) where V is the number of nodes and E
   // is the number of edges. LogV is due to the use of std::priority_queue to
   // break ties by the original order.

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -134,7 +134,7 @@ class SegmentedGroup {
 
   // Returns a toposorted list of Exprs in this group, with equal cases
   // respecting the original order.
-  std::vector<Expr*> orderedExprs() const;
+  std::vector<Expr*> stablyOrderedExprs() const;
 
   //! Returns the complete fusion inputs mapped to this segmented group's fusion
   const auto& getCompleteFusionInputs() const {

--- a/tests/cpp/test_expr_sort.cpp
+++ b/tests/cpp/test_expr_sort.cpp
@@ -202,7 +202,7 @@ TEST_F(ExprSortTest, SegmentedGroup) {
 
   SegmentedGroup* group = segmented_fusion->groups().front();
   EXPECT_THAT(
-      group->orderedExprs(),
+      group->stablyOrderedExprs(),
       ElementsAre(
           UnaryOpTypeIs(UnaryOpType::Neg),
           UnaryOpTypeIs(UnaryOpType::Sin),


### PR DESCRIPTION
The new implementation is faster. 