### PR TITLE
Skip initialization for Hopper & Blackwell matmul

### DIFF
--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -374,9 +374,7 @@ class LowerToInlinePtx : public kir::ExprMutator {
             SimplifyingIrBuilder::bitwiseOrExpr(n, m)));
 
     // Switch between C = A * B and C = A * B + C.
-    // TODO: For now, we always use the former, because we do not have a good
-    // way to zero out the accumulator yet.
-    Val* enable_input_d = IrBuilder::create<Val>(false, DataType::Bool);
+    Val* enable_input_d = getUseInputAcc(mma);
 
     // Do MMA
     registerInsertBefore(

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -268,7 +268,7 @@ class LowerToInlinePtx : public kir::ExprMutator {
     }
     for (auto fl : for_loops_) {
       if (fl->isTrivial() ||
-          std::ranges::any_of(reduction_ids, [fl](IterDomain* id) {
+          !std::ranges::any_of(reduction_ids, [fl](IterDomain* id) {
             return GpuLower::current()
                 ->idModel()
                 .idGraph(IdMappingMode::LOOP)

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -59,10 +59,11 @@ class LowerToInlinePtx : public kir::ExprMutator {
               wait->ptx(),
               std::vector<Val*>{},
               std::vector<Val*>{IrBuilder::create<Val>(wait->keepStages())},
-              kir::Asm::Options{/*volatile=*/true,
-                                /*memory=*/wait->memory(),
-                                /*readable_outputs=*/{},
-                                /*immediate_inputs=*/{0}}));
+              kir::Asm::Options{
+                  /*volatile=*/true,
+                  /*memory=*/wait->memory(),
+                  /*readable_outputs=*/{},
+                  /*immediate_inputs=*/{0}}));
     }
   }
 
@@ -121,10 +122,11 @@ class LowerToInlinePtx : public kir::ExprMutator {
                   ldst->in(),
                   IrBuilder::create<Val>(vec_size),
                   invertedPredicate(ldst->predicate())},
-              kir::Asm::Options{/*volatile=*/true,
-                                /*memory=*/false,
-                                /*readable_outputs=*/{},
-                                /*immediate_inputs=*/{2}}));
+              kir::Asm::Options{
+                  /*volatile=*/true,
+                  /*memory=*/false,
+                  /*readable_outputs=*/{},
+                  /*immediate_inputs=*/{2}}));
     } else if (ldst->opType() == LoadStoreOpType::LdTMem) {
       const auto& tmem_info = GpuLower::current()->tmemInfo();
       std::stringstream ptx_ss;
@@ -275,7 +277,8 @@ class LowerToInlinePtx : public kir::ExprMutator {
       Val* loop_index = GpuLower::current()->tensorIndexer().getLoopIndex(
           fl->iter_domain(), for_loops_);
       dont_use_input_acc = SimplifyingIrBuilder::logicalAndExpr(
-          dont_use_input_acc, SimplifyingIrBuilder::eqExpr(loop_index, fl->start()));
+          dont_use_input_acc,
+          SimplifyingIrBuilder::eqExpr(loop_index, fl->start()));
     }
     return SimplifyingIrBuilder::logicalNotExpr(dont_use_input_acc);
   }
@@ -325,10 +328,11 @@ class LowerToInlinePtx : public kir::ExprMutator {
             inst_ss.str(),
             std::vector<Val*>{mma->out()},
             inputs,
-            kir::Asm::Options{/*volatile=*/true,
-                              /*memory=*/false,
-                              /*readable_outputs=*/{0},
-                              /*immediate_inputs=*/{3, 4, 5, 6}}));
+            kir::Asm::Options{
+                /*volatile=*/true,
+                /*memory=*/false,
+                /*readable_outputs=*/{0},
+                /*immediate_inputs=*/{3, 4, 5, 6}}));
     registerRemove(mma);
   }
 
@@ -372,10 +376,11 @@ class LowerToInlinePtx : public kir::ExprMutator {
             ptx,
             std::vector<Val*>{},
             std::vector<Val*>{maxnreg->numberOfRegisters()},
-            kir::Asm::Options{/*volatile=*/true,
-                              /*memory=*/false,
-                              /*readable_outputs=*/{},
-                              /*immediate_inputs=*/{0}}));
+            kir::Asm::Options{
+                /*volatile=*/true,
+                /*memory=*/false,
+                /*readable_outputs=*/{},
+                /*immediate_inputs=*/{0}}));
   }
 
   void handle(kir::AllocTMem* alloc) final {

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -269,6 +269,7 @@ class LowerToInlinePtx : public kir::ExprMutator {
       // The Epilogue loop is never the first iteration.
       if (fl->circularBufferLoopStage() == CircularBufferLoopStage::Epilog) {
         dont_use_input_acc = mma->fusion()->falseVal();
+        break;
       }
       // Skip trivial loops as they are always the first iteration.
       if (fl->isTrivial()) {

--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -278,7 +278,7 @@ class LowerToInlinePtx : public kir::ExprMutator {
         continue;
       }
       // The Epilogue loop is never the first iteration.
-      if (fl->circularBufferLoopStage() == CircularBufferLoopStage::Epilogue) {
+      if (fl->circularBufferLoopStage() == CircularBufferLoopStage::Epilog) {
         use_input_acc = mma->fusion()->falseVal();
       }
       Val* loop_index = GpuLower::current()->tensorIndexer().getLoopIndex(


### PR DESCRIPTION
Instead of explicitly initializing to zero, we use `mma(use-input-d=is_not_first_iteration)`