### PR TITLE
[Python test] add `conftest.py` to improve printing

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+
+def pytest_make_parametrize_id(config, val, argname):
+    return f"{argname}={val}"

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -2,8 +2,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import pytest
-
 
 def pytest_make_parametrize_id(config, val, argname):
     return f"{argname}={val}"


### PR DESCRIPTION
prints the parameters in the test properly, e.g., taking the example from https://github.com/NVIDIA/Fuser/pull/3928

> [s=1-backend_type=CommunicatorBackend.ucc]

instead of 

> [1-backend_type1]