### PR TITLE
WAR for producer indexing of MmaOp

### DIFF
--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -195,7 +195,7 @@ Val* TensorIndexer::getLinearIndex(
   const auto& alloc_info = getIndexAllocationInfo(tv);
 
   const auto [contig_indices, contig_strides] = getContigIndexFor(
-      expr, as_consumer, alloc_info, for_loops, override_index);
+      tv, expr, as_consumer, alloc_info, for_loops, override_index);
 
   // Linearize the indices with strides.
   Val* linear_index = tv->fusion()->zeroVal();
@@ -676,6 +676,7 @@ void TensorIndexer::ensureStaticIndexing(
 
 std::pair<std::vector<Val*>, std::vector<Val*>> TensorIndexer::
     getContigIndexFor(
+        TensorView* tv,
         const Expr* expr,
         bool as_consumer,
         const AllocationDomainInfo& alloc_info,
@@ -693,8 +694,22 @@ std::pair<std::vector<Val*>, std::vector<Val*>> TensorIndexer::
     index_info.index_map.emplace(traversalGraph().toGroup(indexed_id), index);
   }
   const auto& index_map = index_info.index_map;
-  const auto& replacement_map = getIndexReplacementMap(
+  auto replacement_map = getIndexReplacementMap(
       expr, as_consumer, index_info.loop_ids, for_loops, index_map);
+
+  // War for MmaOp. The allocation domain may involve parallelized
+  // IDs, either directly or by traversal. Ideally, we should set the
+  // right allocation domain, but this seems to be a good enough WAR.
+  if (expr->isA<MmaOp>() && tv->getMemoryType() == MemoryType::Local &&
+      !as_consumer) {
+    // Replace the indices of parallelized loop IDs with zero
+    for (const auto loop_id : index_info.loop_ids) {
+      if (isParallelTypeThread(loop_id->getParallelType())) {
+        Val* loop_index = getLoopIndex(loop_id, for_loops);
+        replacement_map.emplace(loop_index, expr->fusion()->zeroVal());
+      }
+    }
+  }
 
   std::vector<ValGroup> contig_alloc_groups;
   std::vector<Val*> contig_strides;

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -87,6 +87,7 @@ class TensorIndexer {
 
   // Get the contig indices of the given ID groups with their strides
   std::pair<std::vector<Val*>, std::vector<Val*>> getContigIndexFor(
+      TensorView* tv,
       const Expr* expr,
       bool as_consumer,
       const AllocationDomainInfo& alloc_info,

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -664,6 +664,8 @@ TEST_P(MatmulTestWithLayout, AmpereMatmulRegCircularBuffer) {
 TEST_F(MatmulTest, MatmulMatmulAmpere) {
   NVFUSER_TEST_CUDA_ARCH_GUARD(8, 0);
 
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
   Fusion fusion;
   FusionGuard fg(&fusion);
   int M = 512, N = 256, K1 = 128, K2 = 128;


### PR DESCRIPTION
This fixes an indexing error for MmaOp producer tensors. It seems the true root cause may be a lack of parallelization, but that doesn't seem to cause anything with the legacy indexer. This PR partly mimics what is done by the legacy indexer in the new indexer.

### Context 
For example, in `MatmulTest.MatmulMatmulAmpere`, there is an MmaOp of:

```
T17_l_float[iS234{4}, iS236{2}, rS262{4}, rS288{2}, ithreadIdx.z280{2}, ithreadIdx.y282{2}, iS284{4}, iS286{4}, ithreadIdx.x429{32}, iMMA424{1}, iMMA423{2}, iMMA427{2}, rMMA432{2}, rMMA433{4}, rMMA431{2}] ca_pos( 2 ) produce_pos( 8 )
   = mma(T3_l___half[iS238{4}, bS240{1}, iS264{4}, iS298{2}, iS300{2}, bS302{2}, iS304{4}, bS306{4}, bS307{8}, iS400{1}, iS395{8}, iS399{4}, iS398{2}, iS401{2}, iS397{2}] ca_pos( 7 ) produce_pos( 7 ),
         T4_l___half[bS250{1}, iS252{2}, iS272{4}, iS314{2}, bS316{2}, iS318{2}, bS320{4}, iS322{4}, bS321{16}, iS415{8}, iS419{4}, iS418{2}, iS414{1}, iS417{2}] ca_pos( 8 ) produce_pos( 8 ))
```

As shown above, T3 has the CA position of 7, so it shares with the first 7 IDs of T17, which only includes TIDz and TIDy. This representation indicates T3 is not parallelized with TIDx, which makes TensorIndexer confused. The kernel code for the op generated by the TOT TensorIndexer is:

```
 asm(
              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
              :"=f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i71 + (4 * i56))]))[0]),
               "=f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i71 + (4 * i56))]))[1]),
               "=f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i71 + (4 * i56))]))[2]),
               "=f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i71 + (4 * i56))]))[3])
              :"r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T3[i22]))[0]),
               "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T3[i22]))[1]),
               "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T3[i22]))[2]),
               "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T3[i22]))[3]),
               "r"((*reinterpret_cast<Array<uint32_t, 2, 1>*>(&T4[i23]))[0]),
               "r"((*reinterpret_cast<Array<uint32_t, 2, 1>*>(&T4[i23]))[1]),
               "f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i71 + (4 * i56))]))[0]),
               "f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i71 + (4 * i56))]))[1]),
               "f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i71 + (4 * i56))]))[2]),
               "f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i71 + (4 * i56))]))[3])
            );
```

Here, `i22` is `32 *  ((nvfuser_index_t)threadIdx.x) / 4`. Using `threadIdx.x` for indexing register tensors isn't necessarily invalid, but this is not what we want here. The code generated by the legacy indexer is:

```
           asm(
              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
              :"=f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i66 + (4 * i52))]))[0]),
               "=f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i66 + (4 * i52))]))[1]),
               "=f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i66 + (4 * i52))]))[2]),
               "=f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i66 + (4 * i52))]))[3])
              :"r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T3[0]))[0]),
               "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T3[0]))[1]),
               "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T3[0]))[2]),
               "r"((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T3[0]))[3]),
               "r"((*reinterpret_cast<Array<uint32_t, 2, 1>*>(&T4[0]))[0]),
               "r"((*reinterpret_cast<Array<uint32_t, 2, 1>*>(&T4[0]))[1]),
               "f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i66 + (4 * i52))]))[0]),
               "f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i66 + (4 * i52))]))[1]),
               "f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i66 + (4 * i52))]))[2]),
               "f"((*reinterpret_cast<Array<float, 4, 1>*>(&T17[(i66 + (4 * i52))]))[3])
            );
```

As you can see, `T3` is indexed with only `0` to `3` with no threadIdx.x.

The discrepancy seems to come from the lack of parallelization of `T3`, which is defined as:

```
T3_l___half[iS238{4}, bS240{1}, iS264{4}, iS298{2}, iS300{2}, bS302{2}, iS304{4}, bS306{4}, bS307{8}, iS400{1}, iS395{8}, iS399{4}, iS398{2}, iS401{2}, iS397{2}] ca_pos( 7 ) produce_pos( 7 )
 logical domain : (iS6{512}, bS7{1}, iS8{128})
 allocation domain : (iS238{4}, bS240{1}, iS264{4}, iS298{2}, iS300{2}, bS302{2}, iS304{4}, bS306{4}, bS307{8}, iS400{1}, iS395{8}, iS399{4}, iS398{2}, iS401{2}, iS397{2})
 contiguity: t n t t t n t n n t t t t t t
  Split: iS6{512} by factor 128 -> iS238{4}, iS239{128}
  Split: bS7{1} by factor 64 -> bS240{1}, bS241{64}
  Split: iS8{128} by factor 32 -> iS264{4}, iS265{32}
  Split: iS265{32} by factor 16 -> iS298{2}, iS299{16}
  Split: iS239{128} by factor 64 -> iS300{2}, iS301{64}
  Split: bS241{64} by factor 32 -> bS302{2}, bS303{32}
  Split: iS301{64} by factor 16 -> iS304{4}, iS305{16}
  Split: bS303{32} by factor 8 -> bS306{4}, bS307{8}
  Split: iS305{16} by factor 8 -> iS394{2}, iS395{8}
  Split: iS394{2} by factor 2 -> iS400{1}, iS401{2}
  Split: iS299{16} by factor 2 -> iS396{8}, iS397{2}
  Split: iS396{8} by factor 4 -> iS398{2}, iS399{4}
 loop domain : (iS238{4}, bS240{1}, iS264{4}, iS298{2}, iS300{2}, bS302{2}, iS304{4}, bS306{4}, bS307{8}, iS400{1}, iS395{8}, iS399{4}, iS398{2}, iS401{2}, iS397{2})
```

Here, the allocation and the loop domains are the same. Since the CA position is 7, the actual allocation domain should be the remaining 8 IDs, and none of them is parallelized with TIDx. Usually this should not happen, but maybe because it's (indirectly) produced by `ldmatrix`?

```
T14_l___half[iS242{4}, iS266{4}, iS308{2}, iS310{2}, iS312{4}, ithreadIdx.x393{32}, iV390{8}] ca_pos( 5 ) produce_pos( 2 )
   = LdMatrix( T13_s___half[iS244{4}, iS268{4}, iS348{4}, ithreadIdx.z354{2}, ithreadIdx.y355{2}, ithreadIdx.x353{32}, iV351{8}] ca_pos( 2 ) produce_pos( 2 ) )
T3_l___half[iS238{4}, bS240{1}, iS264{4}, iS298{2}, iS300{2}, bS302{2}, iS304{4}, bS306{4}, bS307{8}, iS400{1}, iS395{8}, iS399{4}, iS398{2}, iS401{2}, iS397{2}] ca_pos( 7 ) produce_pos( 7 )
   = broadcast( T14_l___half[iS242{4}, iS266{4}, iS308{2}, iS310{2}, iS312{4}, ithreadIdx.x393{32}, iV390{8}] ca_pos( 5 ) produce_pos( 2 ), flags = {false, true, false} )
```

This is how `T3` and `T14` are defined. I don't think we actually should generate `T3` as size 256 buffer with 5 nested loops, but this probably doesn't matter as only `T3[0-3]` are actually used and nvrtc should be able to remove unnecessary register usage.

```
          Array<__half, 8, 8> T14;
          ldmatrix4((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T14[0])), (uint32_t)((i64 + (1024 * i50))));
          Array<__half, 256, 1> T3;
          #pragma unroll
          for(nvfuser_index_t i67 = 0; i67 < 8; ++i67) {
            nvfuser_index_t i68;
            i68 = 32 * i67;
            #pragma unroll
            for(nvfuser_index_t i69 = 0; i69 < 4; ++i69) {
              nvfuser_index_t i70;
              i70 = i68 + (8 * i69);
              #pragma unroll
              for(nvfuser_index_t i71 = 0; i71 < 2; ++i71) {
                nvfuser_index_t i72;
                i72 = i70 + (4 * i71);
                #pragma unroll
                for(nvfuser_index_t i73 = 0; i73 < 2; ++i73) {
                  nvfuser_index_t i74;
                  i74 = i72 + (2 * i73);
                  #pragma unroll
                  for(nvfuser_index_t i75 = 0; i75 < 2; ++i75) {
                    T3[(i74 + i75)] = 0.000000000e+00f;
                  }
                }
              }
            }
          }
          #pragma unroll
          for(nvfuser_index_t i67 = 0; i67 < 8; ++i67) {
            nvfuser_index_t i76;
            i76 = 32 * i67;
            #pragma unroll
            for(nvfuser_index_t i69 = 0; i69 < 4; ++i69) {
              nvfuser_index_t i77;
              i77 = i76 + (8 * i69);
              #pragma unroll
              for(nvfuser_index_t i71 = 0; i71 < 2; ++i71) {
                nvfuser_index_t i78;
                i78 = i77 + (4 * i71);
                #pragma unroll
                for(nvfuser_index_t i73 = 0; i73 < 2; ++i73) {
                  nvfuser_index_t i79;
                  i79 = i78 + (2 * i73);
                  #pragma unroll
                  for(nvfuser_index_t i75 = 0; i75 < 2; ++i75) {
                    nvfuser_index_t i80;
                    i80 = i79 + i75;
                    T3[i80]
                       = T14[i80];
                  }
                }
```

It seems to me we should parallelize `T3` in a consistent way. I'm not sure if this is an Ampere-specific problem or a generic issue with matmul scheduling, but I suspect it's related to ldmatrix, so maybe Ampere specific? 

### Fix

To workadound the problem, TensorIndexer replaces `threadIdx.x` with 0 when it's used in producer tensors of MmaOp. This is similar to the behavior of legacy indexer, where parallel indices are always replaced with 0 for register tensors.
