### PR TITLE
Use set allocation domains if used by TMA or MmaOp

### DIFF
--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -206,7 +206,9 @@ class AllocationDomainSetup : private kir::IrVisitor {
 
         // Honor the set allocation domain if the tensor is used by a
         // TMA store
-        if (std::ranges::any_of(tv->uses(), ir_utils::isCpAsyncBulkStore)) {
+        if (std::ranges::any_of(tv->uses(), [](Expr* expr) {
+              return ir_utils::isCpAsyncBulkStore(expr) || expr->isA<MmaOp>();
+            })) {
           use_set_allocation_domain = true;
         }
       }

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -203,6 +203,12 @@ class AllocationDomainSetup : private kir::IrVisitor {
                 tv->getAllocationDomain().begin())) {
           use_set_allocation_domain = true;
         }
+
+        // Honor the set allocation domain if the tensor is used by a
+        // TMA store
+        if (std::ranges::any_of(tv->uses(), ir_utils::isCpAsyncBulkStore)) {
+          use_set_allocation_domain = true;
+        }
       }
     }
 

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -205,7 +205,7 @@ class AllocationDomainSetup : private kir::IrVisitor {
         }
 
         // Honor the set allocation domain if the tensor is used by a
-        // TMA store
+        // TMA store or MmaOp
         if (std::ranges::any_of(tv->uses(), [](Expr* expr) {
               return ir_utils::isCpAsyncBulkStore(expr) || expr->isA<MmaOp>();
             })) {

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -3648,7 +3648,13 @@ INSTANTIATE_TEST_SUITE_P(
     testing::ValuesIn(kAllSupportedMmaLayout),
     mmaLayoutName);
 
-using HopperMatmulTest = HopperBase;
+class HopperMatmulTest : public HopperBase {
+ protected:
+  void SetUp() override {
+    HopperBase::SetUp();
+    EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+  }
+};
 
 TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
   Fusion fusion;

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -560,7 +560,6 @@ class HopperBase : public NVFuserTest {
       GTEST_SKIP() << "skipping tests on non-Hopper GPUs";
     }
     NVFuserTest::SetUp();
-    EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
   }
 };
 

--- a/tests/cpp/utils.h
+++ b/tests/cpp/utils.h
@@ -560,6 +560,7 @@ class HopperBase : public NVFuserTest {
       GTEST_SKIP() << "skipping tests on non-Hopper GPUs";
     }
     NVFuserTest::SetUp();
+    EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
   }
 };
 


### PR DESCRIPTION
TensorIndexer generates incorrect indices for shared memory tensors that are used by TMA. In that case, the set allocation domain should be honored. 

Similarly, set allocation domains are used when consumed by MmaOp. This doesn't seem to be necessary for correctness, but it seems to make sense to do so.