### PR TITLE
`shardAllLike` accepts a list of parallel types

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -636,7 +636,7 @@ bool isInnerResharding(Expr* expr) {
 void shardAllLike(
     TensorView* ref,
     std::vector<TensorView*> tvs,
-    std::unordered_set<ParallelType> parallel_types) {
+    const std::unordered_set<ParallelType>& parallel_types) {
   for (auto tv : tvs) {
     tv->setDeviceMesh(ref->getDeviceMesh());
   }

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -635,7 +635,7 @@ bool isInnerResharding(Expr* expr) {
 
 void shardAllLike(
     TensorView* ref,
-    std::vector<TensorView*> tvs,
+    const std::vector<TensorView*>& tvs,
     const std::unordered_set<ParallelType>& parallel_types) {
   for (auto tv : tvs) {
     tv->setDeviceMesh(ref->getDeviceMesh());

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -637,15 +637,13 @@ void shardAllLike(
     TensorView* ref,
     const std::vector<TensorView*>& tvs,
     const std::unordered_set<ParallelType>& parallel_types) {
+  if (tvs.empty()) {
+    return;
+  }
   for (auto tv : tvs) {
     tv->setDeviceMesh(ref->getDeviceMesh());
   }
-  if (parallel_types.empty()) {
-    parallel_types = {kParallelTypeDIDs.begin(), kParallelTypeDIDs.end()};
-  }
-  if (!tvs.empty()) {
-    scheduler_utils::parallelizeAllLike(ref, tvs, parallel_types);
-  }
+  scheduler_utils::parallelizeAllLike(ref, tvs, parallel_types);
 }
 
 void shardBetween(

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -633,13 +633,18 @@ bool isInnerResharding(Expr* expr) {
   return false;
 }
 
-void shardAllLike(TensorView* ref, std::vector<TensorView*> tvs) {
+void shardAllLike(
+    TensorView* ref,
+    std::vector<TensorView*> tvs,
+    std::unordered_set<ParallelType> parallel_types) {
   for (auto tv : tvs) {
     tv->setDeviceMesh(ref->getDeviceMesh());
   }
+  if (parallel_types.empty()) {
+    parallel_types = {kParallelTypeDIDs.begin(), kParallelTypeDIDs.end()};
+  }
   if (!tvs.empty()) {
-    scheduler_utils::parallelizeAllLike(
-        ref, tvs, {ParallelType::DIDx, ParallelType::Serial});
+    scheduler_utils::parallelizeAllLike(ref, tvs, parallel_types);
   }
 }
 

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -57,11 +57,15 @@ bool haveDifferentShardings(
 // Returns whether a resharding expr reshards an inner axis
 bool isInnerResharding(Expr* expr);
 
-// Shards all tensors in tvs like reference
+// Shards all tensors in tvs like reference.
+// Accepts a set of parallel types to shard on.
+// If empty, all DID parallel types are used.
 void shardAllLike(
     TensorView* ref,
-    std::vector<TensorView*> tvs,
-    std::unordered_set<ParallelType> parallel_types = {});
+    const std::vector<TensorView*>& tvs,
+    const std::unordered_set<ParallelType>& parallel_types = {
+        kParallelTypeDIDs.begin(),
+        kParallelTypeDIDs.end()});
 
 // Shards all TVs between from and to AND between TVs created inside a fusion
 // and to. This is required for (1) expressions like rng_uniform that create a

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -58,7 +58,10 @@ bool haveDifferentShardings(
 bool isInnerResharding(Expr* expr);
 
 // Shards all tensors in tvs like reference
-void shardAllLike(TensorView* ref, std::vector<TensorView*> tvs);
+void shardAllLike(
+    TensorView* ref,
+    std::vector<TensorView*> tvs,
+    std::unordered_set<ParallelType> parallel_types = {});
 
 // Shards all TVs between from and to AND between TVs created inside a fusion
 // and to. This is required for (1) expressions like rng_uniform that create a


### PR DESCRIPTION
By default, `shardAllLike` propagates all DID parallel types. This allows us to control exactly which parallel types to propagate, essential for #3838.