### PR TITLE
Remove several uses of NVFUSER_DISTRIBUTED

### DIFF
--- a/csrc/multidevice/c10d_mock.h
+++ b/csrc/multidevice/c10d_mock.h
@@ -5,6 +5,19 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+
+// This file provides a mock implementation of c10d that builds but doesn't
+// function.
+//
+// nvFuser is sometimes built on a pytorch without c10d. When that
+// happens, c10d isn't linked, NVFUSER_DISTRIBUTED is undefined and the
+// multi-GPU component of nvFuser is expected to be disabled.
+//
+// Instead of adding `#ifdef NVFUSER_DISTRIBUTED` in too many places, this file
+// provides a buildable mock implementation of c10d to keep nvFuser code less
+// divergent. This implementation won't run because tests and user code are
+// guarded by Communicator::is_available.
+
 #pragma once
 
 #include <ATen/core/TensorBody.h>

--- a/csrc/multidevice/c10d_mock.h
+++ b/csrc/multidevice/c10d_mock.h
@@ -170,6 +170,21 @@ struct TCPStoreOptions {
   static constexpr uint16_t kDefaultPort = 0;
 };
 
-class TCPStore : public torch::CustomClassHolder {};
+class TCPStore : public torch::CustomClassHolder {
+ public:
+  std::vector<uint8_t> get(const std::string&) {
+    return {};
+  }
+
+  void set(const std::string&, const std::vector<uint8_t>&) {}
+
+  bool check(const std::vector<std::string>&) {
+    return false;
+  }
+
+  bool deleteKey(const std::string&) {
+    return false;
+  }
+};
 
 } // namespace c10d

--- a/csrc/multidevice/ipc_handle.cpp
+++ b/csrc/multidevice/ipc_handle.cpp
@@ -95,7 +95,6 @@ std::string IpcHandleCache::getTcpStoreKey(
 
 void IpcHandleCache::exchangeHandles(
     const std::vector<P2PCommunication*>& communications) {
-#ifdef NVFUSER_DISTRIBUTED
   Communicator* communicator = &Communicator::getInstance();
   const int64_t my_rank = communicator->deviceId();
 
@@ -152,9 +151,6 @@ void IpcHandleCache::exchangeHandles(
 
     insert(communication, std::move(ipc_handles));
   }
-#else // NVFUSER_DISTRIBUTED
-  NVF_ERROR(false, "NVFUSER_DISTRIBUTED is not defined");
-#endif // NVFUSER_DISTRIBUTED
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_multidevice_ipc.cpp
+++ b/tests/cpp/test_multidevice_ipc.cpp
@@ -34,7 +34,7 @@ TEST_F(IpcTest, IpcMemHandle) {
   if (communicator_->size() == 1) {
     GTEST_SKIP() << "Skipping test for single device";
   }
-#ifdef NVFUSER_DISTRIBUTED
+
   // Allocate and setup GPU buffers
   constexpr size_t kBufferSize = sizeof(int64_t);
   const int64_t num_devices = communicator_->size();
@@ -75,16 +75,13 @@ TEST_F(IpcTest, IpcMemHandle) {
   // Clean up
   NVFUSER_CUDA_RT_SAFE_CALL(cudaIpcCloseMemHandle(peer_d_ptr));
   NVFUSER_CUDA_RT_SAFE_CALL(cudaFree(d_ptr));
-#else // NVFUSER_DISTRIBUTED
-  GTEST_SKIP() << "NVFUSER_DISTRIBUTED is not defined";
-#endif // NVFUSER_DISTRIBUTED
 }
 
 TEST_F(IpcTest, IpcMemHandlePtrArithmeticAtReceiver) {
   if (communicator_->size() == 1) {
     GTEST_SKIP() << "Skipping test for single device";
   }
-#ifdef NVFUSER_DISTRIBUTED
+
   // TL;DR: We can do pointer arithmetic on the importer side. IOW, the pointer
   // can be used as a regular pointer on the importer side.
 
@@ -131,16 +128,13 @@ TEST_F(IpcTest, IpcMemHandlePtrArithmeticAtReceiver) {
   // Clean up
   NVFUSER_CUDA_RT_SAFE_CALL(cudaIpcCloseMemHandle(peer_d_ptr));
   NVFUSER_CUDA_RT_SAFE_CALL(cudaFree(d_ptr));
-#else // NVFUSER_DISTRIBUTED
-  GTEST_SKIP() << "NVFUSER_DISTRIBUTED is not defined";
-#endif // NVFUSER_DISTRIBUTED
 }
 
 TEST_F(IpcTest, IpcMemHandlePtrArithmeticAtSender) {
   if (communicator_->size() == 1) {
     GTEST_SKIP() << "Skipping test for single device";
   }
-#ifdef NVFUSER_DISTRIBUTED
+
   // TL;DR: We CANNOT do pointer arithmetic on the exporter side! The IPC handle
   // points to the beginning of the allocated buffer.
 
@@ -189,9 +183,6 @@ TEST_F(IpcTest, IpcMemHandlePtrArithmeticAtSender) {
   // Clean up
   NVFUSER_CUDA_RT_SAFE_CALL(cudaIpcCloseMemHandle(peer_d_ptr));
   NVFUSER_CUDA_RT_SAFE_CALL(cudaFree(d_ptr));
-#else // NVFUSER_DISTRIBUTED
-  GTEST_SKIP() << "NVFUSER_DISTRIBUTED is not defined";
-#endif // NVFUSER_DISTRIBUTED
 }
 
 // cuStreamWriteValue32 and cuStreamWaitValue32 are CUDA driver API used in the


### PR DESCRIPTION
`#ifdef NVFUSER_DISTRIBUTED` tends to be contagious if not controlled, making code diverge. 