### PR TITLE
Fix scheduling of split-K with smem_epilogue on Hopper

### DIFF
--- a/csrc/scheduler/hopper_multi_matmul.h
+++ b/csrc/scheduler/hopper_multi_matmul.h
@@ -124,20 +124,6 @@ class HopperMultipleMatmulScheduler : public MultipleMatmulScheduler {
       TensorView* tv,
       std::vector<MatmulDimRole>& outer_dim_roles);
 
-  //! This calls orig->cacheBefore() and also updates the broadcast graph to
-  //! reflect the new IterDomain mappings
-  TensorView* cacheBefore(
-      TensorView* orig,
-      LoadStoreOpType op_type = LoadStoreOpType::Set);
-
-  //! This calls orig->cacheAfter() and also updates the broadcast graph to
-  //! reflect the new IterDomain mappings
-  TensorView* cacheAfter(
-      TensorView* orig,
-      LoadStoreOpType op_type = LoadStoreOpType::Set,
-      CacheOp cache_op = CacheOp::AllLevels,
-      bool propagate_allocation_domain = false);
-
   //! Do block tiling for a collection of TensorViews. The tensors should be
   //! unscheduled before this method is called.
   //!   1) Axes will be ordered according to canonicalDimOrdering, and then axes

--- a/csrc/scheduler/hopper_multi_matmul.h
+++ b/csrc/scheduler/hopper_multi_matmul.h
@@ -124,6 +124,12 @@ class HopperMultipleMatmulScheduler : public MultipleMatmulScheduler {
       TensorView* tv,
       std::vector<MatmulDimRole>& outer_dim_roles);
 
+  //! This calls orig->cacheBefore() and also updates the broadcast graph to
+  //! reflect the new IterDomain mappings
+  TensorView* cacheBefore(
+      TensorView* orig,
+      LoadStoreOpType op_type = LoadStoreOpType::Set);
+
   //! This calls orig->cacheAfter() and also updates the broadcast graph to
   //! reflect the new IterDomain mappings
   TensorView* cacheAfter(

--- a/csrc/scheduler/multi_matmul.cpp
+++ b/csrc/scheduler/multi_matmul.cpp
@@ -227,4 +227,58 @@ void MultipleMatmulScheduler::cacheInputsAndOutputs(bool skip_intermediates) {
   }
 }
 
+TensorView* MultipleMatmulScheduler::cacheBefore(
+    TensorView* orig,
+    LoadStoreOpType op_type) {
+  TensorView* c = orig->cacheBefore(op_type);
+
+  const std::vector<IterDomain*> orig_logical =
+      TensorDomain::noReductions(orig->getLogicalDomain());
+  const std::vector<IterDomain*> cache_logical = c->getLogicalDomain();
+  NVF_ERROR(orig_logical.size() == cache_logical.size());
+  for (size_t i : arange(orig_logical.size())) {
+    // The domain of orig gets transferred to c and a new domain is applied to
+    // orig
+    ValGroup vg = graph_->toGroup(cache_logical[i]);
+    graph_->initializeVal(orig_logical[i], vg);
+  }
+
+  return c;
+}
+
+TensorView* MultipleMatmulScheduler::cacheAfter(
+    TensorView* orig,
+    LoadStoreOpType op_type,
+    CacheOp cache_op,
+    bool propagate_allocation_domain) {
+  const std::vector<IterDomain*> orig_alloc = orig->getMaybeAllocationDomain();
+
+  TensorView* c =
+      orig->cacheAfter(op_type, cache_op, propagate_allocation_domain);
+
+  if (propagate_allocation_domain) {
+    const std::vector<IterDomain*> cache_alloc = c->getMaybeAllocationDomain();
+    NVF_ERROR(orig_alloc.size() == cache_alloc.size());
+    for (size_t i : arange(orig_alloc.size())) {
+      ValGroup vg = graph_->toGroup(orig_alloc[i]);
+      graph_->initializeVal(cache_alloc[i], vg);
+    }
+  }
+
+  const std::vector<IterDomain*> orig_logical =
+      TensorDomain::noReductions(orig->getLogicalDomain());
+  const std::vector<IterDomain*> cache_logical = c->getLogicalDomain();
+  // in split-K we do rFactor which gives us a full = sum(partial)
+  // where partial has root domain that matches the logical domain of the
+  // original tensor. The logical domain contains Iteration transforms of the
+  // Reduction axis in the original mma output.
+  NVF_ERROR(orig_logical.size() == cache_logical.size());
+  for (size_t i : arange(orig_logical.size())) {
+    ValGroup vg = graph_->toGroup(orig_logical[i]);
+    graph_->initializeVal(cache_logical[i], vg);
+  }
+
+  return c;
+}
+
 } // namespace nvfuser

--- a/csrc/scheduler/multi_matmul.h
+++ b/csrc/scheduler/multi_matmul.h
@@ -60,6 +60,20 @@ class MultipleMatmulScheduler {
       TensorView* operand,
       int64_t vec_size) = 0;
 
+  //! This calls orig->cacheBefore() and also updates the broadcast graph to
+  //! reflect the new IterDomain mappings
+  TensorView* cacheBefore(
+      TensorView* orig,
+      LoadStoreOpType op_type = LoadStoreOpType::Set);
+
+  //! This calls orig->cacheAfter() and also updates the broadcast graph to
+  //! reflect the new IterDomain mappings
+  TensorView* cacheAfter(
+      TensorView* orig,
+      LoadStoreOpType op_type = LoadStoreOpType::Set,
+      CacheOp cache_op = CacheOp::AllLevels,
+      bool propagate_allocation_domain = false);
+
  protected:
   Fusion* fusion_;
   const MatmulParams* params_;

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -5348,7 +5348,8 @@ TEST_F(HopperMatmulTest, HSS_NT_UseScheduler) {
   auto options = at::TensorOptions().dtype(at::kHalf).device(at::kCUDA);
   auto t0 = at::randn({K, M, 1}, options);
   auto t1 = at::randn({K, 1, N}, options);
-  auto out_ref = at::matmul(t0.squeeze().t(), t1.squeeze()).to(at::kHalf);
+  auto out_ref =
+      at::matmul(t0.squeeze().t().to(at::kFloat), t1.squeeze().to(at::kFloat));
 
   MatMulTileOptions gemm_tile;
   gemm_tile.cta_tile = GemmTile(128, 256, 64);


### PR DESCRIPTION
Introduces `cacheBefore` to match `cacheAfter` utility, which just propagates entries in `graph_` corresponding to new IDs in the cached tensors. Also avoids re-scheduling tensors if they are split-K sum tensors.

There is a current limitation for 32-bit outputs where we skip stmatrix but our current vectorized stores encounter 2-way bank conflicts. This is probably not that important to perf and can be fixed in scheduling of that store in another PR.

Fixes #4159