### PR TITLE
Print all ID expressions in tv->printTransforms

### DIFF
--- a/csrc/ir/iostream.cpp
+++ b/csrc/ir/iostream.cpp
@@ -152,15 +152,10 @@ void IrTransformPrinter::printTransforms(const TensorView* tv) {
 
   os() << " contiguity: " << tv->domain()->getContiguityString() << "\n";
 
-  const auto& from = tv->getLogicalDomain();
-  const auto& loop = tv->getLoopDomain();
-  const auto all_exp = DependencyCheck::getAllExprsBetween(
-      {from.begin(), from.end()}, {loop.begin(), loop.end()});
-
-  for (const auto exp : all_exp) {
+  for (const auto exp : tv->domain()->allExprs()) {
     os() << "  " << exp->toString();
   }
-  os() << " loop domain : (" << toDelimitedString(loop) << ")\n";
+  os() << " loop domain : (" << toDelimitedString(tv->getLoopDomain()) << ")\n";
 }
 
 std::ostream& operator<<(std::ostream& os, const Statement* stmt) {


### PR DESCRIPTION
Currently, when we call `tv->printTransforms()`, we print root->logical then logical->loop expressions. In case the allocation domain is not on the path from logical to loop, those allocation expressions were not printed at all.

This PR uses `tv->domain()->allExprs()` instead to print all the ID expressions.

For an example, see this test:
```c++
TEST_F(AllocationDomainTest, PrintTransforms) {
  auto fusion = std::make_unique<Fusion>();
  FusionGuard fg(fusion.get());

  // iS0{i0}
  auto* root0 = IterDomainBuilder(
      fusion->zeroVal(), IrBuilder::create<Val>(DataType::Index)).build();

  // iS1{ceilDiv(i0, 5)}, iS2{5} = split(iS0)
  IterDomain *logical0, *logical1;
  std::tie(logical0, logical1) = IterDomain::split(
      root0,
      IrBuilder::create<Val>(5L, DataType::Index),
      /*inner_split=*/true);

  // iS3{ceilDiv(i0, 7)}, iS4{7} = split(iS0)
  IterDomain *alloc0, *alloc1;
  std::tie(alloc0, alloc1) = IterDomain::split(
      root0,
      IrBuilder::create<Val>(7L, DataType::Index),
      /*inner_split=*/true);

  // iS5{ ceilDiv(i0, 7) * 7 } = merge(iS3, iS4)
  IterDomain* loop0 = IterDomain::merge(alloc0, alloc1);

  std::vector<IterDomain*> root{root0};
  std::vector<IterDomain*> logical{logical0, logical1};
  std::vector<IterDomain*> allocation{alloc0, alloc1};
  std::vector<IterDomain*> loop{loop0};

  auto* td = IrBuilder::create<TensorDomain>(root, logical, allocation, loop);

  auto* tv = IrBuilder::create<TensorView>(td, DataType::Float);

  std::cout << "tv: " << tv->toString() << std::endl;
  tv->printTransforms();
}
```
On TOT, this prints
```
[ RUN      ] AllocationDomainTest.PrintTransforms
tv: T0_l_float[iS5{( ( ceilDiv(i0, 7) ) * 7 )}]
 root domain : (iS0{i0})
  Split: iS0{i0} by factor 5 -> iS1{( ceilDiv(i0, 5) )}, iS2{5}
 logical domain : (iS1{( ceilDiv(i0, 5) )}, iS2{5})
 allocation domain : (iS3{( ceilDiv(i0, 7) )}, iS4{7})
 contiguity: f f
 loop domain : (iS5{( ( ceilDiv(i0, 7) ) * 7 )})
[       OK ] AllocationDomainTest.PrintTransforms (1 ms)
```
From this we cannot tell how the loop or allocation domains relate to the root or logical domains. After this PR it prints:
```
[ RUN      ] AllocationDomainTest.PrintTransforms
tv: T0_l_float[iS5{( ( ceilDiv(i0, 7) ) * 7 )}]
 root domain : (iS0{i0})
  Split: iS0{i0} by factor 5 -> iS1{( ceilDiv(i0, 5) )}, iS2{5}
 logical domain : (iS1{( ceilDiv(i0, 5) )}, iS2{5})
 allocation domain : (iS3{( ceilDiv(i0, 7) )}, iS4{7})
 contiguity: f f
  Split: iS0{i0} by factor 7 -> iS3{( ceilDiv(i0, 7) )}, iS4{7}
  Merge: iS3{( ceilDiv(i0, 7) )} and iS4{7} -> iS5{( ( ceilDiv(i0, 7) ) * 7 )}
  Split: iS0{i0} by factor 5 -> iS1{( ceilDiv(i0, 5) )}, iS2{5}
 loop domain : (iS5{( ( ceilDiv(i0, 7) ) * 7 )})
[       OK ] AllocationDomainTest.PrintTransforms (1 ms)
```

Note that currently this redundantly prints root->logical transforms since we print root->logical earlier. We could just remove that section, meaning effectively that this PR would move those expressions to the same section where loop and allocation transforms are printed.