### PR TITLE
Create kir::Continue for persistent grid short-circuit

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -3749,6 +3749,10 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     indent() << "NVFUSER_UPDATE_MAGIC_ZERO;\n";
   }
 
+  void handle(const kir::Continue* cont) final {
+    indent() << "continue;\n";
+  }
+
   void handle(const kir::Return* ret) final {
     indent() << "return;\n";
   }

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2805,6 +2805,11 @@ void IndexLowering::handle(const kir::SetMaxNReg* maxnreg) {
   pushBack(const_cast<kir::SetMaxNReg*>(maxnreg)); // NOLINT
 }
 
+void IndexLowering::handle(const kir::Continue* cont) {
+  // TODO(kir): remove the need for const_cast
+  pushBack(const_cast<kir::Continue*>(cont)); // NOLINT
+}
+
 void IndexLowering::handle(const kir::Return* ret) {
   // TODO(kir): remove the need for const_cast
   pushBack(const_cast<kir::Return*>(ret)); // NOLINT

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -77,6 +77,7 @@ class IndexLowering : private OptOutConstDispatch {
   void handle(const kir::FenceAsyncProxy*) final;
   void handle(const kir::WgMmaFence*) final;
   void handle(const kir::SetMaxNReg*) final;
+  void handle(const kir::Continue*) final;
   void handle(const kir::Return*) final;
   void handle(const kir::MBarrierInit*) final;
   void handle(const kir::MBarrierInvalidate*) final;

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -124,6 +124,7 @@ class Val;
   f(FenceAsyncProxy);                 \
   f(WgMmaFence);                      \
   f(SetMaxNReg);                      \
+  f(Continue);                        \
   f(Return);                          \
   f(MBarrierInit);                    \
   f(MBarrierInvalidate);              \

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -670,6 +670,25 @@ std::string SetMaxNReg::toInlineString(int indent_size) const {
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(SetMaxNReg)
 
+Continue::Continue(IrBuilderPasskey passkey) : Expr(passkey) {
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
+      passkey.ir_container_->isA<kir::Kernel>(),
+      "IR type only valid for Kernel container.");
+}
+
+std::string Continue::toString(int indent_size) const {
+  std::stringstream ss;
+  indent(ss, indent_size) << "continue\n";
+  return ss.str();
+}
+
+std::string Continue::toInlineString(int indent_size) const {
+  NVF_CHECK(false, "Continue can not be printed inline");
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(Continue)
+
 Return::Return(IrBuilderPasskey passkey) : Expr(passkey) {
   NVF_ERROR(passkey.ir_container_ != nullptr);
   NVF_ERROR(

--- a/csrc/kernel_ir.h
+++ b/csrc/kernel_ir.h
@@ -42,6 +42,7 @@ class GridSync;
 class FenceAsyncProxy;
 class WgMmaFence;
 class SetMaxNReg;
+class Continue;
 class Return;
 class MBarrierInit;
 class MBarrierInvalidate;
@@ -611,6 +612,22 @@ class SetMaxNReg final : public Expr {
   Val* numberOfRegisters() const {
     return input(0);
   }
+};
+
+class Continue final : public Expr {
+ public:
+  using Expr::Expr;
+
+  explicit Continue(IrBuilderPasskey passkey);
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  const char* getOpString() const override {
+    return "Continue";
+  }
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
 };
 
 class Return final : public Expr {


### PR DESCRIPTION
This PR adds support for `continue` in the generated CUDA kernels. 

**Why?** For persistent kernels, we need to efficiently skip OOB tiles to avoid unnecessary work. 

Required for: https://github.com/NVIDIA/Fuser/pull/4243