### PR TITLE
Add NVFUSER_DUMP=sass_to_file option

### DIFF
--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -139,6 +139,7 @@ std::unordered_map<DebugDumpOption, std::vector<std::string>> Options<
       {"python_definition_segments", DebugDumpOption::PythonDefinitionSegments},
       {"python_frontend_debug", DebugDumpOption::PythonFrontendDebug},
       {"sass", DebugDumpOption::Sass},
+      {"sass_to_file", DebugDumpOption::SassToFile},
       {"segmented_fusion", DebugDumpOption::FusionSegments},
       {"segmenter_logging", DebugDumpOption::FusionSegmenterLog},
       {"scheduler_params", DebugDumpOption::SchedulerDebug},

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -70,7 +70,8 @@ enum class DebugDumpOption {
   TransformPropagator, //! When running TransformPropagator, print propagation
                        //! path and replay result
   Cubin, //! Dump compiled CUBIN
-  Sass, // Dump disassembled SASS
+  Sass, //! Dump disassembled SASS
+  SassToFile, //!< Dump disassembled SASS to File
   Ptx, //! Dump compiled PTX
   BankConflictInfo, //! Dump bank confliction info
   SyncMap, //! RAW dependency info
@@ -79,7 +80,7 @@ enum class DebugDumpOption {
   ExprSort, //! Print merging decisions on expression sorting
   ExprSortVerbose, //! Print verbose debug info on expression sorting
   LoopRotation, //! Print loop rotation log
-  Occupancy, // Dump occupancy
+  Occupancy, //! Dump occupancy
   IndexType, //! Print the index type of the launched kernel
   PredicateElimination, //! Print the predicate elimination information
   IndexingVerbose, //! Print verbose debug info on indexing

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -720,11 +720,11 @@ std::unique_ptr<executor_utils::CudaExecutable> compileSource(
           dumpCompiledCodeToFile(compiled_kernel->cubin, func_name, ".cubin");
     }
     if (isDebugDumpEnabled(DebugDumpOption::SassToFile)) {
-      compiled_kernel->sass = disassembledKernelSASS();
-      std::vector<char> sass_vec(
-          compiled_kernel->sass.begin(), compiled_kernel->sass.end());
+      std::string sass_str =
+          disassembleBinary(compiled_kernel->cubin, "-fun 1 -c");
+      compiled_kernel->sass = {sass_str.begin(), sass_str.end()};
       compiled_kernel->sass_filename =
-          dumpCompiledCodeToFile(sass_vec, func_name, ".sass");
+          dumpCompiledCodeToFile(compiled_kernel->sass, func_name, ".sass");
     }
   }
 

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -719,6 +719,13 @@ std::unique_ptr<executor_utils::CudaExecutable> compileSource(
       compiled_kernel->cubin_filename =
           dumpCompiledCodeToFile(compiled_kernel->cubin, func_name, ".cubin");
     }
+    if (isDebugDumpEnabled(DebugDumpOption::SassToFile)) {
+      compiled_kernel->sass = disassembledKernelSASS();
+      std::vector<char> sass_vec(
+          compiled_kernel->sass.begin(), compiled_kernel->sass.end());
+      compiled_kernel->sass_filename =
+          dumpCompiledCodeToFile(sass_vec, func_name, ".sass");
+    }
   }
 
   if (!compile_to_sass || isDebugDumpEnabled(DebugDumpOption::Ptx)) {

--- a/csrc/runtime/executor_utils.h
+++ b/csrc/runtime/executor_utils.h
@@ -43,6 +43,8 @@ struct CudaExecutable : public NonCopyable {
   std::string cubin_filename;
   std::string kernel_name;
   std::string compile_args;
+  std::vector<char> sass;
+  std::string sass_filename;
   long block_size = -1;
   int register_spills = -1;
 };


### PR DESCRIPTION
This adds the `NVFUSER_DUMP=sass_to_file` option which operates similar to `NVFUSER_DUMP=ptx` and `NVFUSER_DUMP=cuda_to_file`.

We currently now have five printing options:
- `cuda_kernel`
- `cuda_to_file`
- `ptx` (actually prints to .ptx file)
- `sass`
- `sass_to_file`

It would probably make sense to make these option names more uniform in a follow-up PR by renaming `cuda_kernel`->`cuda` and `ptx`->`ptx_to_file`. We could also potentially add a new `ptx` dump option that prints to screen, though I would skip this temporarily at least because it could cause unexpected behavior by diverting from file dump to screen, e.g. in CI jobs.