### PR TITLE
Remove stale exprs

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -4375,6 +4375,8 @@ void SegmentCandidateFinder::revertPrivatizedUpcast(SegmentedGroup* group) {
         maybe_deduplicate_edge(consumer_edge_to_update);
       }
 
+      std::erase(group->exprs_, uop);
+
       // Note that it should not be necessary to do anything with
       // group->output_vals since the inserted upcast ops should never produce
       // fusion outputs.


### PR DESCRIPTION
Follow-up to #3776 

This PR removes duplicated cast exprs from `SegmentedGroup`. There's nothing wrong leaving them there as they won't be picked up anyway, but `stablyOrderedExprs()`, which is used when printing `SegmentedFusion`, complains.

Not sure why this could cause codegen diffs.