### PR TITLE
Create separate AsyncGroup helpers for fence, commit, and wait operations

### DIFF
--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -2099,21 +2099,6 @@ bool allMmaInputsGuardedByMBarrier(const MmaOp* mma) {
       ir_utils::isCpAsyncBulkLoad(ir_utils::getTv(mma->inB())->definition());
 }
 
-std::vector<Expr*> getSyncExprs(
-    AsyncOpType async_type,
-    int64_t keep_stages,
-    bool requires_commit) {
-  std::vector<Expr*> sync_exprs;
-  sync_exprs.reserve(2);
-  if (requires_commit) {
-    auto commit = IrBuilder::create<kir::AsyncCommit>(async_type);
-    sync_exprs.push_back(commit);
-  }
-  auto wait = IrBuilder::create<kir::AsyncWait>(async_type, keep_stages);
-  sync_exprs.push_back(wait);
-  return sync_exprs;
-}
-
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -378,16 +378,6 @@ struct IterDomainDependencySorter {
 // Check if all the inputs of the given MmaOp is guarded by mbarrier
 bool allMmaInputsGuardedByMBarrier(const MmaOp* mma);
 
-// Create a list of expressions that will be used to wait for async operations.
-// For example, if op_type is AsyncOpType::WgMma, then the returned expressions
-// will be:
-//   wgmma.commit_group.sync.aligned
-//   wgmma.wait_group.sync.aligned
-std::vector<Expr*> getSyncExprs(
-    AsyncOpType async_type,
-    int64_t keep_stages = 0,
-    bool requires_commit = true);
-
 } // namespace lower_utils
 
 } // namespace nvfuser


### PR DESCRIPTION
For better pipelining of TMA store and `wgmma`, we should treat the `fence`, `commit`, and `wait` phases of `AsyncGroup` separately.
* Replace `getSyncExprs` with `getAsyncCommit` and `getAsyncWait`.
* Create `getAsyncFence` for `WgMmaFence` and `FenceAsyncProxy`.
* No change to the CUDA kernel in this PR.

### Current ToT for `HopperMatmulTest/MLPGemmPersistentBroadcastInputs.NumWarpGroups/2`
```cuda
      #pragma unroll
      for(nvfuser_index_t i57 = 0; i57 < 16; ++i57) {
        if ((b42 && (i43 < (-(16 * i57))))) {
          stmatrix4((uint32_t)((toSmem(T8) + ((((nvfuser_index_t)threadIdx.y) * 32768) + (((i57 / 4) * 8192) + ((i12 * 128) + (((((((nvfuser_index_t)threadIdx.x) % 32) / 16) + ((i57 % 4) * 2)) ^ (i12 % 8)) * 16)))))), (*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T7[(8 * i57)])));
        }
      }
      block_sync::sync<false>(dim3(128, 2, 1));
      #pragma unroll
      for(nvfuser_index_t i58 = 0; i58 < 4; ++i58) {
        fenceAsyncProxy();
        if (((Hopper::electSync(4294967295U) && b16) && b19)) {
          Hopper::cpAsyncBulkTensorTileS2G((Hopper::CpAsyncBulkTensorTileS2GIndex<2>{ ptr14, (Array<int, 2, 1>{(int32_t)((i39 + (64 * i58))), i41}) }), (i13 + (8192 * i58)));
        }
      }
      block_sync::sync<false>(dim3(128, 2, 1));
      cpAsyncBulkCommitGroup();
      cpAsyncBulkWaitGroup<0LL>();
```

Notice that we want WAR sync before `stmatrix` to overlap TMA store with `wgmma`. The `commit` and `wait` phase for TMA store are separate.
### Optimized `HopperMatmulTest/MLPGemmPersistentBroadcastInputs.NumWarpGroups/2`
```cuda
      cpAsyncBulkWaitGroup<0LL>();
      #pragma unroll
      for(nvfuser_index_t i57 = 0; i57 < 16; ++i57) {
        if ((b42 && (i43 < (-(16 * i57))))) {
          stmatrix4((uint32_t)((toSmem(T8) + ((((nvfuser_index_t)threadIdx.y) * 32768) + (((i57 / 4) * 8192) + ((i12 * 128) + (((((((nvfuser_index_t)threadIdx.x) % 32) / 16) + ((i57 % 4) * 2)) ^ (i12 % 8)) * 16)))))), (*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T7[(8 * i57)])));
        }
      }
      block_sync::sync<false>(dim3(128, 2, 1));
      fenceAsyncProxy();
      #pragma unroll
      for(nvfuser_index_t i58 = 0; i58 < 4; ++i58) {
        if (((Hopper::electSync(4294967295U) && b16) && b19)) {
          Hopper::cpAsyncBulkTensorTileS2G((Hopper::CpAsyncBulkTensorTileS2GIndex<2>{ ptr14, (Array<int, 2, 1>{(int32_t)((i39 + (64 * i58))), i41}) }), (i13 + (8192 * i58)));
           cpAsyncBulkCommitGroup();
        }
      }
```