### PR TITLE
Clean up multi-GPU python test fixtures

### DIFF
--- a/tests/python/multidevice/conftest.py
+++ b/tests/python/multidevice/conftest.py
@@ -78,7 +78,6 @@ def multidevice_test():
 # when reinitializing process groups.
 @pytest.fixture(scope="session")
 def setup_default_process_group():
-    print("dist.init_process_group")
     communicator = nvfuser.Communicator.instance()
 
     # The default port as used by https://github.com/pytorch/pytorch/blob/45a8b5682eb69d865cbf68c7f2f689b56b4efd53/torch/csrc/distributed/c10d/TCPStore.hpp#L51.
@@ -89,5 +88,4 @@ def setup_default_process_group():
         rank=communicator.rank(),
     )
     yield
-    print("dist.destroy_process_group")
     dist.destroy_process_group()

--- a/tests/python/multidevice/conftest.py
+++ b/tests/python/multidevice/conftest.py
@@ -72,6 +72,10 @@ def multidevice_test():
 # dist.device_mesh.init_device_mesh.
 #
 # This fixture is used by multi-GPU tests that use torch.distributed.
+#
+# I use "session" instead of "module" because
+# https://github.com/pytorch/pytorch/issues/119196 reported race conditions
+# when reinitializing process groups.
 @pytest.fixture(scope="session")
 def setup_default_process_group():
     print("dist.init_process_group")

--- a/tests/python/multidevice/test_communication.py
+++ b/tests/python/multidevice/test_communication.py
@@ -5,12 +5,8 @@
 import pytest
 import torch
 
-import fixtures
 import nvfuser
 from nvfuser import DataType, FusionDefinition
-
-
-multidevice_test = fixtures.multidevice_test
 
 
 @pytest.mark.mpi

--- a/tests/python/multidevice/test_deepseek_v3.py
+++ b/tests/python/multidevice/test_deepseek_v3.py
@@ -2,7 +2,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import nvfuser
 import pytest
 import transformers
 import torch
@@ -14,23 +13,6 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
     ColwiseParallel,
 )
-
-
-# Set up the default process group for torch APIs like
-# dist.device_mesh.init_device_mesh.
-@pytest.fixture(scope="module")
-def setup_process_group():
-    communicator = nvfuser.Communicator.instance()
-
-    # The default port as used by https://github.com/pytorch/pytorch/blob/45a8b5682eb69d865cbf68c7f2f689b56b4efd53/torch/csrc/distributed/c10d/TCPStore.hpp#L51.
-    dist.init_process_group(
-        backend="nccl",
-        init_method="tcp://localhost:29500",
-        world_size=communicator.size(),
-        rank=communicator.rank(),
-    )
-    yield
-    dist.destroy_process_group()
 
 
 @contextmanager
@@ -55,7 +37,7 @@ def default_tensor_type(dtype=torch.float32, device="cpu"):
 # http://nv/eCm). I consider this a one-off, but please let me know if this
 # error becomes consistent.
 @pytest.mark.mpi
-def test_transformer_layer(setup_process_group):
+def test_transformer_layer(setup_default_process_group):
     config = transformers.AutoConfig.from_pretrained(
         "deepseek-ai/deepseek-v3", trust_remote_code=True
     )

--- a/tests/python/multidevice/test_matmul.py
+++ b/tests/python/multidevice/test_matmul.py
@@ -5,11 +5,8 @@
 import pytest
 import torch
 
-import fixtures
 import nvfuser
 from nvfuser import DataType, FusionDefinition
-
-multidevice_test = fixtures.multidevice_test
 
 
 # Avoid doing this when possible. This test started to exist before nvFuser

--- a/tests/python/multidevice/test_multidevice.py
+++ b/tests/python/multidevice/test_multidevice.py
@@ -7,12 +7,9 @@ import torch
 from enum import Enum, auto
 from torch.nn.attention import SDPBackend
 
-import fixtures
 import nvfuser
 from nvfuser import DataType, FusionDefinition
 from nvfuser.testing.utils import create_sdpa_rng_tensors, define_sdpa_rng_state
-
-multidevice_test = fixtures.multidevice_test
 
 
 @pytest.mark.mpi

--- a/tests/python/multidevice/test_overlap.py
+++ b/tests/python/multidevice/test_overlap.py
@@ -6,11 +6,8 @@ import pytest
 import torch
 import os
 
-import fixtures
 import nvfuser
 from nvfuser import DataType, FusionDefinition, CommunicatorBackend
-
-multidevice_test = fixtures.multidevice_test
 
 
 class OverlapAGMatmulStreamOutermost(FusionDefinition):

--- a/tests/python/multidevice/test_transformer_engine.py
+++ b/tests/python/multidevice/test_transformer_engine.py
@@ -58,19 +58,6 @@ class Parallelism(Enum):
     SEQUENCE_PARALLEL = auto()
 
 
-@pytest.fixture(scope="module")
-def setup_process_group(mpi_test) -> None:
-    # The default port as used by https://github.com/pytorch/pytorch/blob/45a8b5682eb69d865cbf68c7f2f689b56b4efd53/torch/csrc/distributed/c10d/TCPStore.hpp#L51.
-    dist.init_process_group(
-        backend="nccl",
-        init_method="tcp://localhost:29500",
-        world_size=mpi_test.size,
-        rank=mpi_test.rank,
-    )
-    yield
-    dist.destroy_process_group()
-
-
 # This benchmark is instrumented with cudaProfilerStart/Stop. Therefore, one
 # can collect stats of the first few non-warmup benchmark iterations using
 # ```bash
@@ -94,7 +81,7 @@ def setup_process_group(mpi_test) -> None:
     ids=["nonoverlap", "overlap"],
 )
 def test_transformer_layer(
-    setup_process_group,
+    setup_default_process_group,
     monkeypatch,
     benchmark,
     compute_type: ComputeType,


### PR DESCRIPTION
Move fixtures to conftest.py according to https://docs.pytest.org/en/7.1.x/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files

Make setup_default_process_group a common fixture