### PR TITLE
Deallocate HostIr Op and Test

### DIFF
--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -160,7 +160,8 @@ class Val;
   f(Synchronize);                     \
   f(StartCoalescing);                 \
   f(EndCoalescing);                   \
-  f(ShareMemHandles);
+  f(ShareMemHandles);                 \
+  f(Deallocate);
 
 // Forward declarations for all Val and Expr types
 

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -330,7 +330,7 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
   for (auto& input : launch_kernel->inputs()) {
     args.push(getKnownConcreteValue(input));
   }
-  
+
   // If all output buffers are known already, pass them to the executor
   for (auto& output : launch_kernel->outputs()) {
     if (expr_evaluator_.isKnown(output)) {
@@ -346,11 +346,11 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
 
   // run the compiled kernel
   outputs = container_->getKernelExecutor(launch_kernel->getIndex())
-              ->run(
-                  args,
-                  outputs,
-                  launch_kernel->launch_params(),
-                  launch_kernel->compile_params());
+                ->run(
+                    args,
+                    outputs,
+                    launch_kernel->launch_params(),
+                    launch_kernel->compile_params());
 
   if (!preallocated_outputs) {
     // Store the outputs in the context
@@ -670,8 +670,11 @@ void HostIrEvaluator::handle(kir::Allocate* allocate) {
 
 void HostIrEvaluator::handle(Deallocate* deallocate) {
   TensorView* tv = deallocate->allocation()->buffer()->as<TensorView>();
-  NVF_ERROR(expr_evaluator_.isKnown(tv), "Tried to free buffer associated with unknown TensorView", tv);
-  expr_evaluator_.invalidate(tv);
+  NVF_ERROR(
+      expr_evaluator_.isKnown(tv),
+      "Tried to free buffer associated with unknown TensorView",
+      tv);
+  invalidate(tv);
 }
 
 void HostIrEvaluator::unhandled(Statement* stmt) {

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -325,13 +325,14 @@ void HostIrEvaluator::handle(Synchronize* synchronize) {
 }
 
 void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
-  KernelArgumentHolder args, outputs;
-  bool preallocated_outputs = true;
+  KernelArgumentHolder args;
   for (auto& input : launch_kernel->inputs()) {
     args.push(getKnownConcreteValue(input));
   }
 
   // If all output buffers are known already, pass them to the executor
+  KernelArgumentHolder outputs;
+  bool preallocated_outputs = true;
   for (Val* output : launch_kernel->outputs()) {
     if (expr_evaluator_.isKnown(output)) {
       outputs.push(expr_evaluator_.evaluate(output));
@@ -671,7 +672,7 @@ void HostIrEvaluator::handle(kir::Allocate* allocate) {
 void HostIrEvaluator::handle(Deallocate* deallocate) {
   TensorView* tv = deallocate->allocation()->buffer()->as<TensorView>();
   NVF_ERROR(
-      expr_evaluator_.isKnown(tv),
+      isKnown(tv),
       "Tried to free buffer associated with unknown TensorView",
       tv);
   invalidate(tv);

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -335,7 +335,7 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
   bool preallocated_outputs = true;
   for (Val* output : launch_kernel->outputs()) {
     if (isKnown(output)) {
-      outputs.push(expr_evaluator_.evaluate(output));
+      outputs.push(getKnownConcreteValue(output));
     } else {
       outputs = {};
       preallocated_outputs = false;

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -334,7 +334,7 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
   KernelArgumentHolder outputs;
   bool preallocated_outputs = true;
   for (Val* output : launch_kernel->outputs()) {
-    if (expr_evaluator_.isKnown(output)) {
+    if (isKnown(output)) {
       outputs.push(expr_evaluator_.evaluate(output));
     } else {
       outputs = {};
@@ -652,7 +652,7 @@ void HostIrEvaluator::handle(kir::Allocate* allocate) {
       "Allocation must be on a TensorView but got ",
       allocate->buffer());
   TensorView* tv = allocate->buffer()->as<TensorView>();
-  if (expr_evaluator_.isKnown(tv)) {
+  if (isKnown(tv)) {
     return;
   }
   GlobalBufferInfo info =

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -332,7 +332,7 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
   }
 
   // If all output buffers are known already, pass them to the executor
-  for (auto& output : launch_kernel->outputs()) {
+  for (Val* output : launch_kernel->outputs()) {
     if (expr_evaluator_.isKnown(output)) {
       outputs.push(expr_evaluator_.evaluate(output));
     } else {

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -332,16 +332,16 @@ void HostIrEvaluator::handle(LaunchKernel* launch_kernel) {
 
   // If all output buffers are known already, pass them to the executor
   KernelArgumentHolder outputs;
-  bool preallocated_outputs = true;
+  bool preallocated_outputs = false;
   for (Val* output : launch_kernel->outputs()) {
     if (isKnown(output)) {
+      preallocated_outputs = true;
       outputs.push(getKnownConcreteValue(output));
-    } else {
-      outputs = {};
-      preallocated_outputs = false;
-      break;
     }
   }
+
+  NVF_ERROR(
+      outputs.empty() || outputs.size() == launch_kernel->outputs().size());
 
   args.setDeviceIndex();
 

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -670,7 +670,7 @@ void HostIrEvaluator::handle(kir::Allocate* allocate) {
 }
 
 void HostIrEvaluator::handle(Deallocate* deallocate) {
-  TensorView* tv = deallocate->allocation()->buffer()->as<TensorView>();
+  auto* tv = deallocate->allocation()->buffer()->as<TensorView>();
   NVF_ERROR(
       isKnown(tv),
       "Tried to free buffer associated with unknown TensorView",

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -135,6 +135,7 @@ class HostIrEvaluator final : public OptOutDispatch {
   void handle(LinearOp* linear) override;
   void handle(kir::Allocate* allocate) override;
   void handle(ShareMemHandles* share_mem_handles) override;
+  void handle(Deallocate* deallocate) override;
   void unhandled(Statement* stmt) override;
 
   c10::cuda::CUDAStream getCUDAStream(Stream* stream);

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -173,7 +173,7 @@ std::string Deallocate::toString(int indent_size) const {
 }
 
 std::string Deallocate::toInlineString(int indent_size) const {
-  return std::string("Deallocate");
+  return std::string("Deallocate ") + allocation()->buffer()->toInlineString();
 }
 
 Stream::Stream(IrBuilderPasskey passkey, Val* index)

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -153,9 +153,7 @@ std::string LaunchKernel::toInlineString(int indent_size) const {
   NVF_CHECK(false, "Can not be printed inline");
 }
 
-Deallocate::Deallocate(
-    IrBuilderPasskey passkey,
-    kir::Allocate* allocate)
+Deallocate::Deallocate(IrBuilderPasskey passkey, kir::Allocate* allocate)
     : Expr(passkey) {
   addAttribute(allocate);
 }
@@ -165,7 +163,7 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(Deallocate)
 std::string Deallocate::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "Deallocate {" << std::endl;
-  ss                      <<     allocation()->toString(indent_size + 1);
+  ss << allocation()->toString(indent_size + 1);
   indent(ss, indent_size) << "}" << std::endl;
   return ss.str();
 }

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -160,6 +160,10 @@ Deallocate::Deallocate(IrBuilderPasskey passkey, kir::Allocate* allocate)
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(Deallocate)
 
+const kir::Allocate* Deallocate::allocation() const {
+  return attributes_.at(0)->as<kir::Allocate>();
+}
+
 std::string Deallocate::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "Deallocate {" << std::endl;

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -153,6 +153,27 @@ std::string LaunchKernel::toInlineString(int indent_size) const {
   NVF_CHECK(false, "Can not be printed inline");
 }
 
+Deallocate::Deallocate(
+    IrBuilderPasskey passkey,
+    kir::Allocate* allocate)
+    : Expr(passkey) {
+  addAttribute(allocate);
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(Deallocate)
+
+std::string Deallocate::toString(int indent_size) const {
+  std::stringstream ss;
+  indent(ss, indent_size) << "Deallocate {" << std::endl;
+  ss                      <<     allocation()->toString(indent_size + 1);
+  indent(ss, indent_size) << "}" << std::endl;
+  return ss.str();
+}
+
+std::string Deallocate::toInlineString(int indent_size) const {
+  return std::string("Deallocate");
+}
+
 Stream::Stream(IrBuilderPasskey passkey, Val* index)
     : Val(passkey, ValType::Stream), index_(index) {}
 

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -155,6 +155,31 @@ class LaunchKernel : public Expr {
   }
 };
 
+class Deallocate : public Expr {
+ public:
+  using Expr::Expr;
+  Deallocate(
+      IrBuilderPasskey passkey,
+      kir::Allocate* allocate);
+
+  Deallocate(const Deallocate& other) = delete;
+  Deallocate& operator=(const Deallocate& other) = delete;
+  Deallocate(Deallocate&& other) = delete;
+  Deallocate& operator=(Deallocate&& other) = delete;
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+  const char* getOpString() const override {
+    return "hir::Deallocate";
+  }
+
+  const auto allocation() const {
+    return attributes_.at(0)->as<kir::Allocate>();
+  }
+};
+
 class Stream : public Val {
  public:
   // if index is provided, the IR represents the streams whose index is the

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -173,9 +173,7 @@ class Deallocate : public Expr {
     return "hir::Deallocate";
   }
 
-  const auto allocation() const {
-    return attributes_.at(0)->as<kir::Allocate>();
-  }
+  const kir::Allocate* allocation() const;
 };
 
 class Stream : public Val {

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -158,9 +158,7 @@ class LaunchKernel : public Expr {
 class Deallocate : public Expr {
  public:
   using Expr::Expr;
-  Deallocate(
-      IrBuilderPasskey passkey,
-      kir::Allocate* allocate);
+  Deallocate(IrBuilderPasskey passkey, kir::Allocate* allocate);
 
   Deallocate(const Deallocate& other) = delete;
   Deallocate& operator=(const Deallocate& other) = delete;

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -136,7 +136,7 @@ TEST_F(HostIrIntegrationTest, Deallocate) {
 
   hie.runWithInput({});
 
-  EXPECT_LE(memoryAllocated(device_index), 0);
+  EXPECT_EQ(memoryAllocated(device_index), 0);
 }
 
 } // namespace hir

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -115,7 +115,7 @@ TEST_F(HostIrIntegrationTest, Sum) {
 
 TEST_F(HostIrIntegrationTest, Deallocate) {
   const std::vector<int64_t> sizes = {8, 64};
-  uint8_t device_index = 0;
+  c10::DeviceIndex device_index = 0;
 
   resetPeakMemoryStats(device_index);
 

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -125,8 +125,8 @@ TEST_F(HostIrIntegrationTest, Deallocate) {
   for (int i = 0; i < 10; i++) {
     TensorView* tv = makeConcreteTensor(sizes);
     tv->setMemoryType(MemoryType::Global);
-    auto *allocate = IrBuilder::create<kir::Allocate>(tv, MemoryType::Global);
-    auto *deallocate = IrBuilder::create<Deallocate>(allocate);
+    auto* allocate = IrBuilder::create<kir::Allocate>(tv, MemoryType::Global);
+    auto* deallocate = IrBuilder::create<Deallocate>(allocate);
 
     hic->pushBackTopLevelExprs(allocate);
     hic->pushBackTopLevelExprs(deallocate);

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -113,6 +113,32 @@ TEST_F(HostIrIntegrationTest, Sum) {
       "");
 }
 
+TEST_F(HostIrIntegrationTest, Deallocate) {
+  const std::vector<int64_t> sizes = {8, 64};
+  uint8_t device_index = 0;
+
+  resetPeakMemoryStats(device_index);
+
+  auto hic = std::make_unique<HostIrContainer>();
+  FusionGuard fg(hic.get());
+
+  for (int i = 0; i < 10; i++) {
+    TensorView* tv = makeConcreteTensor(sizes);
+    tv->setMemoryType(MemoryType::Global);
+    auto *allocate = IrBuilder::create<kir::Allocate>(tv, MemoryType::Global);
+    auto *deallocate = IrBuilder::create<Deallocate>(allocate);
+
+    hic->pushBackTopLevelExprs(allocate);
+    hic->pushBackTopLevelExprs(deallocate);
+  }
+
+  HostIrEvaluator hie(std::move(hic));
+
+  hie.runWithInput({});
+
+  EXPECT_LE(memoryAllocated(device_index), 0);
+}
+
 } // namespace hir
 
 } // namespace nvfuser


### PR DESCRIPTION
This PR adds the Deallocate HostIr, which erases an Allocation from the expression evaluator. It also modifies LaunchKernel to take in preallocated output arguments. Lastly, it adds a gtest which allocates and deallocates a buffer in a loop, then checks the memory used is 0 bytes.