### PR TITLE
add HirAliasSelect

### DIFF
--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -161,7 +161,8 @@ class Val;
   f(StartCoalescing);                 \
   f(EndCoalescing);                   \
   f(ShareMemHandles);                 \
-  f(Deallocate);
+  f(Deallocate);                      \
+  f(HirAliasSelect);
 
 // Forward declarations for all Val and Expr types
 

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -678,6 +678,15 @@ void HostIrEvaluator::handle(Deallocate* deallocate) {
   invalidate(tv);
 }
 
+void HostIrEvaluator::handle(HirAliasSelect* hir_alias_select) {
+  auto index =
+      expr_evaluator_.evaluate(hir_alias_select->index()).as<int64_t>();
+  auto input = getKnownConcreteValue(hir_alias_select->in()->as<TensorView>())
+                   .as<at::Tensor>();
+  int64_t axis = hir_alias_select->axis();
+  bind(hir_alias_select->out(), input.select(axis, index));
+}
+
 void HostIrEvaluator::unhandled(Statement* stmt) {
   NVF_ERROR(stmt->isA<Expr>(), stmt, " must be an Expr");
   auto* expr = stmt->as<Expr>();

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -136,6 +136,7 @@ class HostIrEvaluator final : public OptOutDispatch {
   void handle(kir::Allocate* allocate) override;
   void handle(ShareMemHandles* share_mem_handles) override;
   void handle(Deallocate* deallocate) override;
+  void handle(HirAliasSelect* hir_alias_select) override;
   void unhandled(Statement* stmt) override;
 
   c10::cuda::CUDAStream getCUDAStream(Stream* stream);

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -378,6 +378,51 @@ std::string ShareMemHandles::toInlineString(int indent_size) const {
   NVF_THROW("Cannot be printed inline");
 }
 
+HirAliasSelect::HirAliasSelect(
+    IrBuilderPasskey passkey,
+    TensorView* in,
+    TensorView* out,
+    int64_t axis,
+    Val* index)
+    : Expr(passkey, {in, index}, {}, {}) {
+  NVF_ERROR(passkey.ir_container_ != nullptr);
+  NVF_ERROR(
+      passkey.ir_container_->isA<HostIrContainer>(),
+      this,
+      "must be registered in a HostIrContainer");
+  NVF_ERROR(
+      static_cast<int64_t>(in->getLogicalDomain().size()) > axis,
+      "Select axis ",
+      axis,
+      " is out of bounds for tensor ",
+      in->toString(),
+      " with ",
+      in->getLogicalDomain().size(),
+      " dimensions");
+  // "out" is not added as an output because the current op doesn't "define" it,
+  // but rather sets its allocation. Since "out" will be used in another
+  // producing expression, this avoids unnecessary cyclic dependencies. This
+  // ressembles how kir::Allocate treats its allocated TensorView.
+  addAttribute(out);
+  addDataAttribute(axis);
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(HirAliasSelect)
+
+std::string HirAliasSelect::toString(int indent_size) const {
+  std::stringstream ss;
+  indent(ss, indent_size) << out()->toString() << "\n";
+  indent_size++;
+  indent(ss, indent_size) << " = HirAliasSelect( " << in()->toString()
+                          << ", axis = " << in()->getLogicalDomain().at(axis())
+                          << ", index = " << index()->toString() << " )\n";
+  return ss.str();
+}
+
+std::string HirAliasSelect::toInlineString(int indent_size) const {
+  NVF_THROW("Cannot be printed inline");
+}
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -372,6 +372,49 @@ class ShareMemHandles : public Expr {
   }
 };
 
+// This op mimicks the semantics of SelectOp but is used in HIR non-SSA context
+// to index into a TensorView, returning an alias "slice" of the original
+// TensorView.
+class HirAliasSelect : public Expr {
+ public:
+  using Expr::Expr;
+  HirAliasSelect(
+      IrBuilderPasskey passkey,
+      TensorView* in,
+      TensorView* out,
+      int64_t axis,
+      Val* index);
+
+  HirAliasSelect(const HirAliasSelect& other) = delete;
+  HirAliasSelect& operator=(const HirAliasSelect& other) = delete;
+  HirAliasSelect(HirAliasSelect&& other) = delete;
+  HirAliasSelect& operator=(HirAliasSelect&& other) = delete;
+
+  NVFUSER_DECLARE_CLONE_AND_CREATE
+
+  std::string toString(int indent_size = 0) const override;
+  std::string toInlineString(int indent_size = 0) const override;
+  const char* getOpString() const override {
+    return "hir::HirAliasSelect";
+  }
+
+  TensorView* in() const {
+    return inputs().at(0)->as<TensorView>();
+  }
+
+  TensorView* out() const {
+    return attributeVal(0)->as<TensorView>();
+  }
+
+  int64_t axis() const {
+    return attribute<int64_t>(1);
+  }
+
+  Val* index() const {
+    return inputs().at(1);
+  }
+};
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -1307,6 +1307,44 @@ TEST_F(HirAlias, ThrowOnInputAlias) {
   EXPECT_ANY_THROW(HostIrEvaluator hie(std::move(hic)));
 }
 
+using HirAliasSelectHostIrTest = NVFuserTest;
+
+TEST_F(HirAliasSelectHostIrTest, SelectingTensor) {
+  constexpr int64_t ndims = 2;
+  constexpr int64_t dim = 1;
+  constexpr int64_t index = 3;
+  const std::vector<int64_t> input_sizes = {32, 32};
+
+  ASSERT_LT(dim, ndims);
+  ASSERT_EQ(input_sizes.size(), ndims);
+  ASSERT_LT(index, input_sizes.at(dim));
+
+  auto hic = std::make_unique<HostIrContainer>();
+  FusionGuard fg(hic.get());
+
+  TensorView* in = makeContigTensor(ndims);
+  TensorView* out = makeContigTensor(ndims - 1);
+  auto* index_val = IrBuilder::create<Val>(index, DataType::Index);
+  auto* select_op = IrBuilder::create<HirAliasSelect>(in, out, dim, index_val);
+
+  hic->addInput(in);
+  hic->addOutput(out);
+  hic->pushBackTopLevelExprs(select_op);
+
+  HostIrEvaluator hie(std::move(hic));
+
+  auto options = at::TensorOptions().device(at::kCUDA, 0).dtype(torch::kFloat);
+  auto in_aten = at::randn(input_sizes, options);
+  std::unordered_map<Val*, PolymorphicValue> concrete_input_buffers = {
+      {in, in_aten}};
+
+  auto out_aten = hie.runWithInput(concrete_input_buffers)[0].as<at::Tensor>();
+
+  // validate
+  auto ref_out = in_aten.select(dim, index);
+  EXPECT_TRUE(ref_out.equal(out_aten));
+}
+
 } // namespace hir
 
 } // namespace nvfuser


### PR DESCRIPTION
# What
Add a `SelectOp`-like HIR to express indexing into ATen tensor.

# Why
it is used in the context of stream lowering, see https://github.com/NVIDIA/Fuser/pull/4147 and 
 especially the discussion in https://github.com/NVIDIA/Fuser/pull/4147#discussion_r2055365814

