### PR TITLE
[Cuda Ipc] Add barrier at the end of `IpcHandleCache::exchangeHandles`

### DIFF
--- a/csrc/multidevice/ipc_handle.cpp
+++ b/csrc/multidevice/ipc_handle.cpp
@@ -151,6 +151,12 @@ void IpcHandleCache::exchangeHandles(
 
     insert(communication, std::move(ipc_handles));
   }
+
+  // a second barrier is needed here to ensure all ranks have received the
+  // memhandles and the keys are deleted from the store before the next call to
+  // exchangeHandles
+  // TODO: precisely select what ranks need to wait on that barrier.
+  communicator->barrier();
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -417,7 +417,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 using P2PCommunicationTest = MultiDeviceTest;
 
-TEST_F(P2PCommunicationTest, DISABLED_CudaComm) {
+TEST_F(P2PCommunicationTest, CudaComm) {
   static constexpr int kTensorSize = 8;
   static constexpr int kNumRepetitions = 32;
 

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -478,7 +478,7 @@ TEST_F(OverlapDistributedMatmulTest, AG_linear) {
   EXPECT_TRUE(torch::allclose(out_ref, out_at, 1e-1, 1e-1));
 }
 
-TEST_F(MultiDeviceTest, DISABLED_ShareIpcMemHandles) {
+TEST_F(MultiDeviceTest, ShareIpcMemHandles) {
   static constexpr int kTensorSize = 4;
   static constexpr int kNumRepetitions = 10;
 


### PR DESCRIPTION
A synchronization is needed at the `IpcHandleCache::exchangeHandles` to avoid the exporter exporting twice before the importer delete the key to the store.

Should fix a bug [observed in the CI](https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/jobs/160018431).

cc [Team thread](https://teams.microsoft.com/l/message/19:e875a0fc9d0747b9bde9715c9b6093ae@thread.tacv2/1745028577674?tenantId=43083d15-7273-40c1-b7db-39efd9ccc17a&groupId=74537292-c203-4a6d-aea0-40c527b969f7&parentMessageId=1745028577674&teamName=csarofeen-staff-and-guests&channelName=nvFuser-MultiGPU&createdTime=1745028577674) 