### PR TITLE
Change build directory for clang-tidy in lintrunner

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -185,7 +185,7 @@ command = [
     'python3',
     'tools/linter/adapters/clangtidy_linter.py',
     '--binary=~/.local/bin/clang-tidy',
-    '--build_dir=./build',
+    '--build_dir=./python/build',
     '--',
     '@{{PATHSFILE}}'
 ]


### PR DESCRIPTION
This PR fixes the clang-tidy lintrunner. The `build_dir` argument needs to change from `./build` to `./python/build`.