### PR TITLE
Always specify -DNVFUSER_BUILD_WITH_ASAN to cmake

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -413,6 +413,9 @@ def cmake(config, relative_path):
 
     pytorch_use_distributed = get_pytorch_use_distributed()
 
+    def on_or_off(flag: bool) -> str:
+        return "ON" if flag else "OFF"
+
     # generate cmake directory
     cmd_str = [
         get_cmake_bin(),
@@ -421,6 +424,7 @@ def cmake(config, relative_path):
         f"-DCMAKE_INSTALL_PREFIX={install_prefix}",
         f"-DNVFUSER_CPP_STANDARD={config.cpp_standard}",
         f"-DUSE_DISTRIBUTED={pytorch_use_distributed}",
+        f"-DNVFUSER_BUILD_WITH_ASAN={on_or_off(config.build_with_asan)}",
         "-B",
         cmake_build_dir,
     ]
@@ -438,8 +442,6 @@ def cmake(config, relative_path):
         cmd_str.append(f"-DPython_EXECUTABLE={sys.executable}")
     if not config.no_benchmark:
         cmd_str.append("-DBUILD_NVFUSER_BENCHMARK=ON")
-    if config.build_with_asan:
-        cmd_str.append("-DNVFUSER_BUILD_WITH_ASAN=ON")
     if config.build_without_distributed:
         cmd_str.append("-DNVFUSER_DISTRIBUTED=OFF")
     if config.build_with_system_nvtx:


### PR DESCRIPTION
This might just show my ignorance of CMake. Let me know if you have a better fix. 

# Symptom

When I run `python setup.py --build-with-asan` and then `python setup.py`, the second build still has asan enabled. 

# Investigation

The first build runs `cmake -DNVFUSER_BUILD_WITH_ASAN=ON`, which adds `NVFUSER_BUILD_WITH_ASAN:BOOL=ON` to CMakeLists.txt

The second build runs `cmake` without `-DNVFUSER_BUILD_WITH_ASAN` specified. `cmake` chooses to use the cached value and therefore doesn't change the existing `NVFUSER_BUILD_WITH_ASAN:BOOL=ON` in CMakeLists.txt to `OFF`. 

# Proposed solution

Let `setup.py` always specify `-DNVFUSER_BUILD_WITH_ASAN`. 