### PR TITLE
Benchmark for distributed matmul with overlap

### DIFF
--- a/benchmarks/python/benchmark_overlap.py
+++ b/benchmarks/python/benchmark_overlap.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+import pytest
+import torch
+import nvfuser
+from nvfuser import FusionDefinition, CommunicatorBackend
+from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from .core import BENCHMARK_CONFIG, clear_l2_cache
+
+
+class CUDAEventTimer:
+    """Custom CUDA event-based timer for accurate GPU timing.
+
+    This timer uses CUDA events to measure elapsed time between operations,
+    providing more accurate GPU timing than CPU-based timing methods.
+    """
+
+    def __init__(self):
+        self.start_event = torch.cuda.Event(enable_timing=True)
+        self.end_event = torch.cuda.Event(enable_timing=True)
+        self.is_running = False
+
+    def __call__(self):
+        """Record timing events and compute elapsed time.
+
+        Returns:
+            float: Elapsed time in seconds
+        """
+        if self.is_running:
+            self.end_event.record()
+            torch.cuda.synchronize()
+            elapsed_ms = self.start_event.elapsed_time(self.end_event)
+            self.is_running = False
+            return elapsed_ms / 1000.0  # Convert ms to seconds
+        else:
+            self.start_event.record()
+            self.is_running = True
+            return 0.0
+
+    def cleanup(self):
+        """Ensure timer is not running and synchronize CUDA."""
+        if self.is_running:
+            self.end_event.record()
+            torch.cuda.synchronize()
+            self.is_running = False
+
+
+def benchmark_cuda_events_pedantic(
+    benchmark, benchmark_fn, inputs, rounds, warmup_rounds
+):
+    """Wrapper for benchmark_cuda_events that uses pytest's pedantic method with CUDA events.
+
+    Args:
+        benchmark: pytest-benchmark fixture
+        benchmark_fn: Function to benchmark
+        inputs: List of inputs to pass to benchmark_fn
+        rounds: Number of rounds to run
+        warmup_rounds: Number of warmup rounds
+    """
+
+    def setup():
+        clear_l2_cache()
+        return inputs, {}
+
+    def wrapped_fn(*args):
+        benchmark_fn(*args[0])
+        return None
+
+    # Set our custom CUDA event timer
+    benchmark._timer = CUDAEventTimer()
+
+    benchmark.pedantic(
+        wrapped_fn,
+        setup=setup,
+        rounds=rounds,
+        warmup_rounds=warmup_rounds,
+        iterations=1,
+    )
+
+
+class OverlapAGMatmulStreamOutermost(FusionDefinition):
+    """Fusion definition for overlapping all-gather with matrix multiplication.
+
+    This fusion implements a matrix multiplication operation with overlapping
+    all-gather communication, using stream parallelism for the outermost dimension.
+    """
+
+    def __init__(self, m, k, n, s, num_devices, communication_backend, dtype):
+        super().__init__(
+            use_multidevice_executor=True, backend_type=communication_backend
+        )
+        self.m = m
+        self.k = k
+        self.n = n
+        self.s = s
+        self._num_devices = num_devices
+        self.dtype = dtype
+
+    def definition(self) -> None:
+        m, k, n, s, d = self.m, self.k, self.n, self.s, self._num_devices
+        self.x = self.define_tensor(
+            shape=[s, d, m // (s * d), k],
+            contiguity=True,
+            dtype=torch_dtype_to_nvfuser_dtype(self.dtype),
+        )
+        self.weight = self.define_tensor(
+            shape=[n, k],
+            contiguity=True,
+            dtype=torch_dtype_to_nvfuser_dtype(self.dtype),
+        )
+        self.bias = self.define_tensor(
+            shape=[n], contiguity=True, dtype=torch_dtype_to_nvfuser_dtype(self.dtype)
+        )
+        self.out = self.ops.linear(self.x, self.weight, self.bias)
+        self.add_output(self.out)
+
+    def multidevice_schedule(self):
+        mesh = nvfuser.DeviceMesh(range(self._num_devices))
+        for tv in [self.x, self.weight, self.bias, self.out]:
+            self.sched._set_device_mesh(tv, mesh)
+        self.sched.parallelize(self.x, 1, nvfuser.ParallelType.mesh_x)
+        self.sched.parallelize(self.out, 0, nvfuser.ParallelType.stream)
+
+
+class MultideviceSettings:
+    """Settings and utilities for multi-device execution."""
+
+    def __init__(self):
+        self._communicator = nvfuser.Communicator.instance()
+        torch.manual_seed(0)
+
+    @property
+    def communicator(self):
+        return self._communicator
+
+    @property
+    def size(self):
+        return self._communicator.size()
+
+    @property
+    def rank(self):
+        return self._communicator.rank()
+
+    @property
+    def local_size(self):
+        return self._communicator.local_size()
+
+    @property
+    def local_rank(self):
+        return self._communicator.local_rank()
+
+    def shard_tensor(
+        self, t: torch.Tensor, dim: int, mesh: nvfuser.DeviceMesh
+    ) -> torch.Tensor:
+        assert t.is_cpu, (
+            "This is not strictly required but it's a general good practice "
+            "for unit tests to create unsharded data on CPU to reduce GPU "
+            "memory footprint."
+        )
+        return mesh.shard_tensor(t, dim, self.rank).cuda(self.rank)
+
+
+@pytest.fixture
+def multidevice_settings():
+    return MultideviceSettings()
+
+
+@pytest.mark.mpi
+@pytest.mark.parametrize(
+    "backend_type", [CommunicatorBackend.ucc, CommunicatorBackend.nccl]
+)
+@pytest.mark.parametrize("s", [1, 8])
+@pytest.mark.parametrize("m", [2**16])
+@pytest.mark.parametrize("k", [2**12, 2**16])
+@pytest.mark.parametrize("n", [2**10])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+def test_overlap_allgather_matmul_stream_outermost(
+    benchmark,
+    multidevice_settings,
+    backend_type,
+    s,
+    m,
+    k,
+    n,
+    dtype,
+    validate_output=False,
+):
+    """Test overlapping all-gather with matrix multiplication using stream parallelism.
+
+    Args:
+        benchmark: pytest-benchmark fixture
+        multidevice_settings: Settings for multi-device execution
+        backend_type: Communication backend to use
+        s: Number of streams
+        m: Matrix dimension m
+        k: Matrix dimension k
+        n: Matrix dimension n
+        dtype: Data type for computation
+        validate_output: Whether to validate output against reference
+    """
+    nvfuser.FusionCache.reset()
+
+    d = multidevice_settings.size
+    assert m % (s * d) == 0
+    os.environ["UCC_CL_BASIC_TLS"] = "nccl"
+    torch.cuda.set_device(multidevice_settings.local_rank)
+
+    # Create input tensors
+    x_unsharded = torch.testing.make_tensor(
+        s, d, m // (s * d), k, dtype=dtype, device="cpu"
+    )
+    x = multidevice_settings.shard_tensor(
+        x_unsharded, 1, nvfuser.DeviceMesh(range(multidevice_settings.size))
+    )
+    weight = torch.testing.make_tensor(n, k, dtype=dtype, device="cuda")
+    bias = torch.testing.make_tensor(n, dtype=dtype, device="cuda")
+    inputs = [x, weight, bias]
+
+    # Create fusion definition
+    fd = OverlapAGMatmulStreamOutermost(m, k, n, s, d, backend_type, dtype)
+
+    if validate_output:
+        outputs, _ = fd.execute([inputs])
+        out = outputs[0].cpu()
+        assert out.dtype == dtype
+        assert out.shape == torch.Size([s, d, m // (s * d), n])
+        out_ref = torch.nn.functional.linear(x_unsharded, weight.cpu(), bias.cpu())
+        torch.testing.assert_close(out, out_ref, rtol=float("inf"), atol=1e-1)
+
+    def benchmark_fn(*args):
+        outputs, _ = fd.execute(args)
+        return outputs[0]
+
+    benchmark_cuda_events_pedantic(
+        benchmark,
+        benchmark_fn,
+        [inputs],
+        warmup_rounds=BENCHMARK_CONFIG["warmup_rounds"],
+        rounds=BENCHMARK_CONFIG["rounds"],
+    )


### PR DESCRIPTION
Add a benchmark unit test for AG+Matmul with/without overlap. The test uses pytest framework and defines a custom Timer based on Cuda Events.

Results obtained show significant performance benefits of pipelining with ucc for large matrices. Results obtained for DGX 8* H100 GPU:

```
--------------------------------------------------------------------------------------------------------------------------------------------- benchmark: 16 tests ---------------------------------------------------------------------------------------------------------------------------------------------
Name (time in ms)                                                                                                                                 Min                Max               Mean             StdDev             Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float16-n=1024-k=4096-m=65536-s=1-backend_type=<CommunicatorBackend.nccl: 0>]       2.7351 (1.0)       2.9785 (1.0)       2.8138 (1.0)       0.0803 (6.58)      2.7779 (1.0)      0.1096 (5.56)          2;0  355.3866 (1.0)          10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float16-n=1024-k=4096-m=65536-s=1-backend_type=<CommunicatorBackend.ucc: 1>]        3.0713 (1.12)      3.4526 (1.16)      3.1341 (1.11)      0.1131 (9.28)      3.1061 (1.12)     0.0199 (1.01)          1;1  319.0726 (0.90)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float16-n=1024-k=4096-m=65536-s=8-backend_type=<CommunicatorBackend.nccl: 0>]       3.1446 (1.15)      5.8581 (1.97)      3.4676 (1.23)      0.8425 (69.11)     3.1833 (1.15)     0.0784 (3.98)          1;2  288.3866 (0.81)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float16-n=1024-k=4096-m=65536-s=8-backend_type=<CommunicatorBackend.ucc: 1>]        3.2604 (1.19)      3.3357 (1.12)      3.2910 (1.17)      0.0235 (1.93)      3.2854 (1.18)     0.0339 (1.72)          2;0  303.8600 (0.86)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float32-n=1024-k=4096-m=65536-s=8-backend_type=<CommunicatorBackend.ucc: 1>]        4.1977 (1.53)      4.2335 (1.42)      4.2148 (1.50)      0.0122 (1.0)       4.2161 (1.52)     0.0225 (1.14)          2;0  237.2606 (0.67)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float32-n=1024-k=4096-m=65536-s=1-backend_type=<CommunicatorBackend.nccl: 0>]       4.7256 (1.73)      4.7770 (1.60)      4.7476 (1.69)      0.0191 (1.56)      4.7482 (1.71)     0.0383 (1.94)          5;0  210.6325 (0.59)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float32-n=1024-k=4096-m=65536-s=1-backend_type=<CommunicatorBackend.ucc: 1>]        4.7307 (1.73)     41.2299 (13.84)     8.3965 (2.98)     11.5365 (946.41)    4.7438 (1.71)     0.0197 (1.0)           1;2  119.0973 (0.34)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float32-n=1024-k=4096-m=65536-s=8-backend_type=<CommunicatorBackend.nccl: 0>]       5.1204 (1.87)      5.4672 (1.84)      5.3154 (1.89)      0.1009 (8.28)      5.3345 (1.92)     0.1097 (5.56)          4;0  188.1342 (0.53)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float16-n=1024-k=65536-m=65536-s=8-backend_type=<CommunicatorBackend.ucc: 1>]      25.0230 (9.15)     25.8178 (8.67)     25.4180 (9.03)      0.3072 (25.20)    25.4278 (9.15)     0.5594 (28.38)         2;0   39.3422 (0.11)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float16-n=1024-k=65536-m=65536-s=8-backend_type=<CommunicatorBackend.nccl: 0>]     33.9819 (12.42)    35.5789 (11.95)    35.2329 (12.52)     0.4613 (37.84)    35.3931 (12.74)    0.2792 (14.16)         1;1   28.3826 (0.08)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float16-n=1024-k=65536-m=65536-s=1-backend_type=<CommunicatorBackend.ucc: 1>]      34.2042 (12.51)    34.8641 (11.71)    34.4020 (12.23)     0.1912 (15.69)    34.3466 (12.36)    0.2033 (10.31)         2;1   29.0681 (0.08)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float16-n=1024-k=65536-m=65536-s=1-backend_type=<CommunicatorBackend.nccl: 0>]     34.2332 (12.52)    34.5607 (11.60)    34.3961 (12.22)     0.1131 (9.28)     34.3828 (12.38)    0.1795 (9.10)          4;0   29.0731 (0.08)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float32-n=1024-k=65536-m=65536-s=8-backend_type=<CommunicatorBackend.ucc: 1>]      47.2971 (17.29)    47.6112 (15.98)    47.4518 (16.86)     0.0900 (7.38)     47.4569 (17.08)    0.1091 (5.53)          3;0   21.0740 (0.06)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float32-n=1024-k=65536-m=65536-s=8-backend_type=<CommunicatorBackend.nccl: 0>]     62.3246 (22.79)    68.5419 (23.01)    67.2244 (23.89)     2.1432 (175.82)   68.4183 (24.63)    2.9840 (151.38)        1;0   14.8755 (0.04)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float32-n=1024-k=65536-m=65536-s=1-backend_type=<CommunicatorBackend.ucc: 1>]      65.0065 (23.77)    65.7736 (22.08)    65.4415 (23.26)     0.2386 (19.58)    65.4146 (23.55)    0.3241 (16.44)         3;0   15.2808 (0.04)         10           1
test_overlap_allgather_matmul_stream_outermost[dtype=torch.float32-n=1024-k=65536-m=65536-s=1-backend_type=<CommunicatorBackend.nccl: 0>]     65.0892 (23.80)    65.7982 (22.09)    65.3787 (23.23)     0.2185 (17.92)    65.3707 (23.53)    0.2645 (13.42)         3;0   15.2955 (0.04)         10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```