### PR TITLE
Use TransformReplay directly instead of TransformPropagator

### DIFF
--- a/csrc/preseg_passes/propagate_shardings.cpp
+++ b/csrc/preseg_passes/propagate_shardings.cpp
@@ -147,7 +147,7 @@ void propagateDIDTransform(
     PropagationDirection direction) {
   TensorDomain* replayed_domain = nullptr;
   for (TensorView* tv : tvs) {
-    if (direction == PropagationDirection::Forward) {
+    if (direction == PropagationDirection::kForward) {
       replayed_domain = TransformReplay::replayCasP(tv, ref, did_pos).first;
     } else {
       replayed_domain = TransformReplay::replayPasC(tv, ref, did_pos).first;
@@ -217,7 +217,7 @@ void PropagateShardingsPass::runPass(Fusion* fusion) {
           /*ref=*/ref_input,
           /*tvs=*/outputs_without_mesh,
           /*did_pos=*/did_pos,
-          /*direction=*/PropagationDirection::Forward);
+          PropagationDirection::kForward);
 
       // Apply parallelization on the outputs without mesh.
       shardAllLike(ref_input, outputs_without_mesh, selected_parallel_types);
@@ -279,7 +279,7 @@ void PropagateShardingsPass::runPass(Fusion* fusion) {
         /*ref=*/ref_output,
         /*tvs=*/sharding_candidates,
         /*did_pos=*/did_pos,
-        /*direction=*/PropagationDirection::Backward);
+        PropagationDirection::kBackward);
     shardAllLike(ref_output, sharding_candidates);
   }
 }

--- a/csrc/preseg_passes/propagate_shardings.cpp
+++ b/csrc/preseg_passes/propagate_shardings.cpp
@@ -169,10 +169,15 @@ void propagateDIDTransform(
     int64_t did_pos,
     bool allow_c2p,
     bool allow_p2c) {
-  TransformPropagator propagator(ref, did_pos);
-  PropagateShardingsSelector selector(
-      {tvs.begin(), tvs.end()}, allow_c2p, allow_p2c);
-  MaxLogicalDomainInfoSpanningTree(ref, &selector).traverse(&propagator);
+  TensorDomain* replayed_domain = nullptr;
+  for (auto tv : tvs) {
+    if (allow_c2p) {
+      replayed_domain = TransformReplay::replayPasC(tv, ref, did_pos).first;
+    } else {
+      replayed_domain = TransformReplay::replayCasP(tv, ref, did_pos).first;
+    }
+    tv->setLoopDomain(replayed_domain->loop());
+  }
 }
 
 } // namespace

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1858,7 +1858,7 @@ bool isFakeBoundaryTensorview(
     TensorView* tv,
     const std::unordered_set<TensorView*>& selected_tv_set,
     PropagateDirection direction) {
-  if (direction == PropagateDirection::Forward) {
+  if (direction == PropagateDirection::kForward) {
     // In the case of forward propagation,
     //  a boundary tv is a fake boundary if
     //  it has any consumer tv that's in the selected
@@ -1902,7 +1902,7 @@ std::unordered_set<TensorView*> getDirectionalPropagatePathSet(
   std::unordered_set<TensorView*> boundary_tv_set(
       boundary_tvs.begin(), boundary_tvs.end());
 
-  if (direction == PropagateDirection::Forward) {
+  if (direction == PropagateDirection::kForward) {
     // In the case of forward propagation, collect all tvs
     //  that are consumers of `from_tv` and producers of
     //  boundary tvs.
@@ -2010,7 +2010,7 @@ void BoundedDirectionalTransformPropagator::backward(
   // Collect all tvs to included on the backward path as specified
   //  by boundary and options.
   auto included_tvs = getDirectionalPropagatePathSet(
-      from, to, *options, PropagateDirection::Backward);
+      from, to, *options, PropagateDirection::kBackward);
   // Actually run the propagation.
   propagate(from, pos, included_tvs, *options);
 }
@@ -2030,7 +2030,7 @@ void BoundedDirectionalTransformPropagator::forward(
   // Collect all tvs to included on the forward path as specified
   //  by boundary and options.
   auto included_tvs = getDirectionalPropagatePathSet(
-      from, to, *options, PropagateDirection::Forward);
+      from, to, *options, PropagateDirection::kForward);
 
   // Actually run the propagation.
   propagate(from, pos, included_tvs, *options);
@@ -2052,9 +2052,9 @@ void BoundedDirectionalTransformPropagator::bothWays(
   // Collect all tvs to included on the backward and forward path as specified
   //  by boundary and options.
   auto backward_included_tvs = getDirectionalPropagatePathSet(
-      from, backward_to, *options, PropagateDirection::Backward);
+      from, backward_to, *options, PropagateDirection::kBackward);
   auto forward_included_tvs = getDirectionalPropagatePathSet(
-      from, forward_to, *options, PropagateDirection::Forward);
+      from, forward_to, *options, PropagateDirection::kForward);
 
   // Combined the included tvs on both paths.
   auto included_tvs = backward_included_tvs;

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1850,11 +1850,6 @@ void transformPropagateToAllFrom(TensorView* from_tv, int64_t pos) {
 
 namespace {
 
-//! Utility enum to signify which direction
-//! BoundedDirectionalTransformPropagator
-//!  passes will propagate the transforms.
-enum class PropagateDirection { Backward = 0, Forward };
-
 //! Returns true if the given tensorview is a fake boundary
 //!  TensorView, see Note [Fake Boundary Tensorview].
 //! This function assumes and would not check that tv is a boundary

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -832,5 +832,10 @@ TensorView* getUpCastInputOf(const TensorView* buffer_tv);
 //! See device_lower/analysis/tensor_producer_aliases.h
 TensorView* scheduleInputToSkipIntermediates(TensorView* tv);
 
+//! Utility enum to signify which direction
+//! transform propagation passes will propagate the transforms.
+//! For example, in sharding propagation or
+//! BoundedDirectionalTransformPropagator.
+enum class PropagateDirection { Backward = 0, Forward };
 } // namespace scheduler_utils
 } // namespace nvfuser

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -836,6 +836,6 @@ TensorView* scheduleInputToSkipIntermediates(TensorView* tv);
 //! transform propagation passes will propagate the transforms.
 //! For example, in sharding propagation or
 //! BoundedDirectionalTransformPropagator.
-enum class PropagateDirection { Backward = 0, Forward };
+enum class PropagateDirection { kBackward = 0, kForward };
 } // namespace scheduler_utils
 } // namespace nvfuser


### PR DESCRIPTION
Since we only propagate across each expression at a time, we can directly use `TransformReplay`. This will avoid building the `MaxLogicalDomainInfoSpanningTree` or using the Propagator object.