### PR TITLE
Update sinh extension to use pyproject.toml

### DIFF
--- a/examples/sinh_extension/README.md
+++ b/examples/sinh_extension/README.md
@@ -7,7 +7,11 @@
 # Build
 
 ```
-python setup.py install
+# Install Pytorch with CUDA
+pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128
+
+# --no-build-isolation flag is required to use PyTorch with CUDA
+pip install --no-build-isolation .
 ```
 
 # Test

--- a/examples/sinh_extension/nvfuser_extension/__init__.py
+++ b/examples/sinh_extension/nvfuser_extension/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from . import nvfuser_extension  # noqa: F401
+from nvfuser_extension import *  # noqa: F401,F403

--- a/examples/sinh_extension/pyproject.toml
+++ b/examples/sinh_extension/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = [
+    "torch",             # Required for CUDAExtension/BuildExtension
+    "setuptools>=61.0", # Use a reasonably modern setuptools
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nvfuser_extension"
+# Version is REQUIRED in pyproject.toml.
+version = "0.1.0"
+description = "A C++/CUDA extension using nvfuser" # Add a short description
+readme = "README.md" # Specify your README file
+# List packages required for your code to RUN (not build)
+dependencies = [
+    "torch",            # Assumed runtime dependency for a CUDA extension
+    "nvfuser"           # Used in setup.py to find paths, likely needed at runtime too
+]
+requires-python = ">=3.12"
+
+[tool.setuptools]
+# Tell setuptools to find packages automatically in the current directory
+# This ensures the Python part of your package is included alongside the extension.
+packages = ["nvfuser_extension"]

--- a/examples/sinh_extension/setup.py
+++ b/examples/sinh_extension/setup.py
@@ -26,15 +26,15 @@ flatbuffers_dir = os.path.join(
     "include",
 )
 
-# Ensure nvfuser_common is installed before trying to find its path
+# Ensure nvfuser is installed before trying to find its path
 try:
-    nvfuser_common_spec = importlib.util.find_spec("nvfuser_common")
-    if nvfuser_common_spec is None or nvfuser_common_spec.origin is None:
-        raise ImportError("Could not find nvfuser_common. Is it installed?")
-    nvfuser_lib_dir = str(pathlib.Path(nvfuser_common_spec.origin).parent / "lib")
+    nvfuser_spec = importlib.util.find_spec("nvfuser")
+    if nvfuser_spec is None or nvfuser_spec.origin is None:
+        raise ImportError("Could not find nvfuser. Is it installed?")
+    nvfuser_lib_dir = str(pathlib.Path(nvfuser_spec.origin).parent / "lib")
 except ImportError as e:
-    print(f"Error finding nvfuser_common path: {e}")
-    print("Ensure 'nvfuser_common' is installed in the build environment.")
+    print(f"Error finding nvfuser path: {e}")
+    print("Ensure 'nvfuser' is installed in the build environment.")
     raise e
 
 

--- a/examples/sinh_extension/setup.py
+++ b/examples/sinh_extension/setup.py
@@ -1,12 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
-from setuptools import setup
-from torch.utils.cpp_extension import BuildExtension, CUDAExtension
-
 import os
 import pathlib
 import importlib.util
+from setuptools import setup
+
+try:
+    from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+except ImportError:
+    raise RuntimeError("PyTorch cpp_extension is required for building this package.")
 
 nvfuser_csrc_dir = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "..", "csrc"
@@ -23,15 +26,55 @@ flatbuffers_dir = os.path.join(
     "include",
 )
 
-nvfuser_lib_dir = str(
-    pathlib.Path(importlib.util.find_spec("nvfuser").origin).parent / "lib"
-)
+# Ensure nvfuser_common is installed before trying to find its path
+try:
+    nvfuser_common_spec = importlib.util.find_spec("nvfuser_common")
+    if nvfuser_common_spec is None or nvfuser_common_spec.origin is None:
+        raise ImportError("Could not find nvfuser_common. Is it installed?")
+    nvfuser_lib_dir = str(pathlib.Path(nvfuser_common_spec.origin).parent / "lib")
+except ImportError as e:
+    print(f"Error finding nvfuser_common path: {e}")
+    print("Ensure 'nvfuser_common' is installed in the build environment.")
+    raise e
+
+
+# Inherit from PyTorch BuildExtension
+# Modify build_extension from setuptools.command.build_ext to move shared
+# library to nvfuser_extension package
+class custom_build_ext(BuildExtension):
+    def build_extension(self, ext):
+        # Handle different os and cpu arch
+        def _find_library_path():
+            for item in os.listdir("build"):
+                if item.startswith("lib"):
+                    return item
+            raise RuntimeException("Cannot find lib in build directory")
+
+        # Call PyTorch BuildExtension first that overloads
+        # setuptools.command.build_ext
+        super().build_extension(ext)
+        if ext.name == "nvfuser_extension":
+            # Copy files on necessity.
+            filename = self.get_ext_filename(self.get_ext_fullname(ext.name))
+            fileext = os.path.splitext(filename)[1]
+
+            extension_path = os.path.join("./build/", _find_library_path(), filename)
+            assert os.path.exists(extension_path)
+
+            install_dst = os.path.join("nvfuser_extension", filename)
+            if not os.path.exists(os.path.dirname(install_dst)):
+                os.makedirs(os.path.dirname(install_dst))
+            self.copy_file(extension_path, install_dst)
+
 
 setup(
-    name="nvfuser_extension",
+    # Name is now in pyproject.toml
+    # Version is now in pyproject.toml
     ext_modules=[
         CUDAExtension(
-            name="nvfuser_extension",
+            name="nvfuser_extension",  # The name of the *compiled* module
+            # pkg tells setuptools where the compiled module should go.
+            # Assumes you have a Python package directory named 'nvfuser_extension'
             pkg="nvfuser_extension",
             include_dirs=[nvfuser_csrc_dir, dynamic_type_dir, flatbuffers_dir],
             libraries=["nvfuser_codegen"],
@@ -41,5 +84,6 @@ setup(
             extra_compile_args={"cxx": ["-std=c++20"]},
         )
     ],
-    cmdclass={"build_ext": BuildExtension},
+    # Keep cmdclass to use custom build extension logic
+    cmdclass={"build_ext": custom_build_ext},
 )


### PR DESCRIPTION
This PR updates the `sinh_extension` example to use `pyproject.toml`. It fixes the failing test `jit_examples_sinh_extension_20`, which fails because `python setup.py install` is depreciated with ToT of `setuptools`.

The new build command is `pip install --no-build-isolation .`