### PR TITLE
Remove KernelSummary::has_dynamic_local_memory_allocations

### DIFF
--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -112,7 +112,6 @@ class KernelIrScanner : private IrVisitor {
         break;
       case MemoryType::Local:
         if (!allocate->size()->isConstInt()) {
-          summary_.has_dynamic_local_memory_allocations = true;
           summary_.dynamic_lmem_allocations.emplace_back(allocate);
         }
         break;

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -112,7 +112,7 @@ class KernelIrScanner : private IrVisitor {
         break;
       case MemoryType::Local:
         if (!allocate->size()->isConstInt()) {
-          summary_.dynamic_lmem_allocations.emplace_back(allocate);
+          summary_.dynamic_lmem_allocations.push_back(allocate);
         }
         break;
       case MemoryType::Tensor:

--- a/csrc/kernel.h
+++ b/csrc/kernel.h
@@ -84,11 +84,7 @@ struct KernelSummary {
   //! Largest shared memory buffer base type
   DataType largest_smem_data_type = DataType::Null;
 
-  //! Do we have allocations of dynamic local memory?
-  bool has_dynamic_local_memory_allocations = false;
-
   //! List of dynamic local memory buffers.
-  //! Only used for debugging.
   std::vector<const kir::Allocate*> dynamic_lmem_allocations;
 
   //! Validations needed and information about them. For example, a pair of

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -1302,7 +1302,7 @@ void CompiledKernel::compile(int64_t block_size) {
         "The static shared memory allocation is larger than available memory.");
   }
 
-  if (kernel_summary.has_dynamic_local_memory_allocations) {
+  if (!kernel_summary.dynamic_lmem_allocations.empty()) {
     std::stringstream ss;
     ss << "Allocations must be based on constant integers for local memory. However, found: ";
     for (auto alloc : kernel_summary.dynamic_lmem_allocations) {


### PR DESCRIPTION
It's subsumed by KernelSummary::dynamic_lmem_allocations.