### PR TITLE
Fix reference reordering in resize scheduler

### DIFF
--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -447,14 +447,13 @@ void ResizeScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
               !alloc_id->isDeviceDim();
         });
 
-    std::vector<int64_t> permutation;
     // Reorder the reference as the allocation domain of the largest fusion
     // input. In order to avoid reordering the innermost ID, only
     // consider the rest of IDs. This matters when the innermost ID of
     // the input is not mapped with the reference innermost ID. see
     // ResizeTest.ReorderLikeInputShouldNotMoveInnermostID for a
     // concrete example.
-    permutation = scheduler_utils::reorderDomainLike(
+    auto permutation = scheduler_utils::reorderDomainLike(
         {ref_tv->getLoopDomain().begin(),
          ref_tv->getLoopDomain().begin() + ref_tv->getLoopDomain().size() - 1},
         ref_alloc);

--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -435,7 +435,7 @@ void ResizeScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
   // performance could be lowered. This should generally be more
   // important to optimize the read performance, but more robust
   // decision would be needed.
-  if (largest_input != nullptr && ref_tv->getLogicalDomain().size() > 1) {
+  if (largest_input != nullptr && ref_tv->getLoopDomain().size() > 1) {
     std::vector<IterDomain*> ref_alloc;
     ref_alloc.reserve(largest_input->getMaybeAllocationDomain().size());
     std::copy_if(
@@ -447,12 +447,18 @@ void ResizeScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
               !alloc_id->isDeviceDim();
         });
 
+    std::vector<int64_t> permutation;
     // Reorder the reference as the allocation domain of the largest fusion
-    // input
-    auto permutation = scheduler_utils::reorderDomainLike(
+    // input. In order to avoid reordering the innermost ID, only
+    // consider the rest of IDs. This matters when the innermost ID of
+    // the input is not mapped with the reference innermost ID. see
+    // ResizeTest.ReorderLikeInputShouldNotMoveInnermostID for a
+    // concrete example.
+    permutation = scheduler_utils::reorderDomainLike(
         {ref_tv->getLoopDomain().begin(),
          ref_tv->getLoopDomain().begin() + ref_tv->getLoopDomain().size() - 1},
         ref_alloc);
+    // Keep the innermost ID as is
     permutation.push_back(ref_tv->getLoopDomain().size() - 1);
     ref_tv->reorder(permutation);
   }

--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -449,8 +449,12 @@ void ResizeScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
 
     // Reorder the reference as the allocation domain of the largest fusion
     // input
-    ref_tv->reorder(
-        scheduler_utils::reorderDomainLike(ref_tv->getLoopDomain(), ref_alloc));
+    auto permutation = scheduler_utils::reorderDomainLike(
+        {ref_tv->getLoopDomain().begin(),
+         ref_tv->getLoopDomain().begin() + ref_tv->getLoopDomain().size() - 1},
+        ref_alloc);
+    permutation.push_back(ref_tv->getLoopDomain().size() - 1);
+    ref_tv->reorder(permutation);
   }
 
   const int64_t bdimx = 128;

--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -435,7 +435,7 @@ void ResizeScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
   // performance could be lowered. This should generally be more
   // important to optimize the read performance, but more robust
   // decision would be needed.
-  if (largest_input != nullptr) {
+  if (largest_input != nullptr && ref_tv->getLogicalDomain().size() > 1) {
     std::vector<IterDomain*> ref_alloc;
     ref_alloc.reserve(largest_input->getMaybeAllocationDomain().size());
     std::copy_if(

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2848,9 +2848,23 @@ std::vector<int64_t> reorderDomainLike(
     }
   }
 
-  NVF_ERROR(std::ranges::all_of(permutation, [&](int64_t pos) {
-    return pos >= 0 && pos < (int64_t)permutation.size();
-  }));
+  if (permutation.size() < ordered_domain.size()) {
+    std::vector<int64_t> packed_permutation(permutation.size());
+    std::iota(packed_permutation.begin(), packed_permutation.end(), 0);
+    std::ranges::sort(packed_permutation, [&](int64_t x, int64_t y) {
+      return permutation.at(x) < permutation.at(y);
+    });
+    permutation = packed_permutation;
+  }
+
+  NVF_ERROR(
+      std::ranges::all_of(
+          permutation,
+          [&](int64_t pos) {
+            return pos >= 0 && pos < (int64_t)permutation.size();
+          }),
+      "Invalid permutation: ",
+      toDelimitedString(permutation));
 
   return permutation;
 }

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2864,11 +2864,8 @@ std::vector<int64_t> reorderDomainLike(
   }
 
   NVF_ERROR(
-      std::ranges::all_of(
-          permutation,
-          [&](int64_t pos) {
-            return pos >= 0 && pos < (int64_t)permutation.size();
-          }),
+      std::ranges::is_permutation(
+          permutation, std::ranges::iota_view(0, (int64_t)permutation.size())),
       "Invalid permutation: ",
       toDelimitedString(permutation));
 


### PR DESCRIPTION
In the resize scheduler, there's an assumption that, when reordering the reference tensor using an input tensor, the innermost ID of the reference is reachable from the IDs of the input tensor. That's actually not the case when the innermost ID is repeated, which hits [this assertion](https://github.com/NVIDIA/Fuser/blob/main/csrc/scheduler/resize.cpp#L509).

This PR ensures the innermost reference ID always stays at the innermost position by excluding it from reordering.