### PR TITLE
[Hopper matmul] Limit grid traversal factor to prevent suboptimal CTA order

### DIFF
--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -405,8 +405,9 @@ bool fillDefaultHopperHeuristic(
   // the rasterization order, this is used to increase L2 locality. We start at
   // swizzled_tiles-1 because if we set the swizzle factor equal to the size of
   // the non-swizzled dimension that is equivalent to simply switching
-  // cta_order.
-  int grid_traversal_factor = std::max(1L, std::min(swizzled_tiles - 1L, 16L));
+  // cta_order. The largest possible divisor of an integer i is i/2, so we
+  // start our search there (or 16, whichever is smaller).
+  int grid_traversal_factor = std::max(1L, std::min(swizzled_tiles / 2L, 16L));
   while (grid_traversal_factor > 1 &&
          swizzled_tiles % grid_traversal_factor != 0) {
     // Decrease the swizzle factor if it would result in nondivisible splits,

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -348,12 +348,6 @@ bool fillDefaultHopperHeuristic(
 
   const GemmTile& cta_tile = mparams->tile_sizes.cta_tile;
 
-  //  Use a non-persistent kernel by default for now
-  mparams->tiling_strategy = MatmulParams::TilingStrategy::OneTilePerCTA;
-
-  //  Use a non-persistent kernel by default for now
-  mparams->tiling_strategy = MatmulParams::TilingStrategy::OneTilePerCTA;
-
   // Use warp specialization on hopper by default
   mparams->circular_buffering_strategy =
       MatmulParams::CircularBufferingStrategy::WarpSpecialized;


### PR DESCRIPTION
This is a small update to our default Hopper matmul heuristic

I noticed a case where we had a 13x10 tile grid. We rightly chose row-major `cta_order` since 10 is smaller than 13 so it should be the fast dimension. However we then set `grid_traversal_factor` to 13. When we set the `grid_traversal_factor` equal to the size of the other dimension, the traversal order is no different than swapping to column major, which is no longer optimal. Instead, we should only consider swizzles that are smaller than the number of tiles in the slow dimension.

Using `benchmarks/python/test_matmul.py`:
Before: 61.8% of cublas
After: 67.4% of cublas

This is a 9% speedup.