### PR TITLE
Refactor adjustMappingsForWarpSpecialization

### DIFF
--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -149,6 +149,20 @@ void ParallelDimensionMap::adjustMappingsForWarpPadding() {
   exact_types_.erase(ParallelType::TIDx);
 }
 
+int64_t ParallelDimensionMap::getThreadsCountInDim(ParallelType pt) {
+  if (!dim_map_.contains(pt)) {
+    return 1;
+  }
+  if (dim_map_.at(pt)->isConstScalar()) {
+    return dim_map_.at(pt)->value().as<int64_t>();
+  }
+  // Return -1 for dynamic dimensions, this disables register sharing on
+  // dynamic dimensions since we can't guarantee the number of threads is
+  // divisible by 128. We may allow this in the future and delegate this
+  // check to a point where the launch parameters are known.
+  return -1;
+}
+
 void ParallelDimensionMap::adjustMappingsForWarpSpecialization() {
   // shortcut for case without register sharing
   if (!ws_with_register_sharing_pt_.has_value()) {
@@ -173,22 +187,6 @@ void ParallelDimensionMap::adjustMappingsForWarpSpecialization() {
     }
     return;
   }
-  // For register sharing, require contiguous 128 threads calling the same
-  // setreg instruction.
-  // Not used: 1, Const: n, Dynamic: -1
-  auto get_threads_count_in_dim = [&](ParallelType pt) {
-    if (!dim_map_.contains(pt)) {
-      return 1L;
-    }
-    if (dim_map_.at(pt)->isConstScalar()) {
-      return dim_map_.at(pt)->value().as<int64_t>();
-    }
-    // Return -1 for dynamic dimensions, this disables register sharing on
-    // dynamic dimensions since we can't guarantee the number of threads is
-    // divisible by 128. We may allow this in the future and delegate this
-    // check to a point where the launch parameters are known.
-    return -1L;
-  };
   // Warp specialization with register sharing on parallel type pt
   // index = TIDx + TIDy * bdimx + TIDz * bdimx * bdimy
   auto pt = ws_with_register_sharing_pt_.value();
@@ -200,16 +198,16 @@ void ParallelDimensionMap::adjustMappingsForWarpSpecialization() {
   if (pt == ParallelType::TIDx) {
     // If on TIDx, pad by 128
     pad_n_threads = 128;
-    after_pad = get_threads_count_in_dim(pt) + pad_n_threads;
+    after_pad = getThreadsCountInDim(pt) + pad_n_threads;
     NVF_ERROR(
         after_pad % 128 == 0,
         "Illegal register sharing on TIDx, bdimx = ",
         after_pad);
   } else if (pt == ParallelType::TIDy) {
     // If on TIDy, pad by 128 / bdimx
-    int64_t bdimx = get_threads_count_in_dim(ParallelType::TIDx);
+    int64_t bdimx = getThreadsCountInDim(ParallelType::TIDx);
     pad_n_threads = scheduler_utils::safeDiv(128, bdimx);
-    after_pad = get_threads_count_in_dim(pt) + pad_n_threads;
+    after_pad = getThreadsCountInDim(pt) + pad_n_threads;
     NVF_ERROR(
         (after_pad * bdimx) % 128 == 0,
         "Illegal register sharing on TIDy, bdimx = ",
@@ -218,10 +216,10 @@ void ParallelDimensionMap::adjustMappingsForWarpSpecialization() {
         after_pad);
   } else if (pt == ParallelType::TIDz) {
     // If on TIDz, pad by 128 / (bdimx * bdimy)
-    int64_t bdimx = get_threads_count_in_dim(ParallelType::TIDx);
-    int64_t bdimy = get_threads_count_in_dim(ParallelType::TIDy);
+    int64_t bdimx = getThreadsCountInDim(ParallelType::TIDx);
+    int64_t bdimy = getThreadsCountInDim(ParallelType::TIDy);
     pad_n_threads = scheduler_utils::safeDiv(128, bdimx * bdimy);
-    after_pad = get_threads_count_in_dim(pt) + pad_n_threads;
+    after_pad = getThreadsCountInDim(pt) + pad_n_threads;
     NVF_ERROR(
         (after_pad * bdimx * bdimy) % 128 == 0,
         "Illegal register sharing on TIDz, bdimx = ",

--- a/csrc/parallel_dimension_map.h
+++ b/csrc/parallel_dimension_map.h
@@ -83,6 +83,10 @@ class ParallelDimensionMap {
   }
 
  private:
+  //! Get number of threads for ParallelType axis
+  //! Not used: 1, Const: n, Dynamic: -1
+  int64_t getThreadsCountInDim(ParallelType pt);
+
   //! TIDx may need to be marked as non-exact as it may be padded to a
   //! multiple of the warp size.
   void adjustMappingsForWarpPadding();

--- a/csrc/parallel_dimension_map.h
+++ b/csrc/parallel_dimension_map.h
@@ -85,7 +85,7 @@ class ParallelDimensionMap {
  private:
   //! Get number of threads for ParallelType axis
   //! Not used: 1, Const: n, Dynamic: -1
-  int64_t getThreadsCountInDim(ParallelType pt);
+  int64_t getThreadCountInDim(ParallelType pt);
 
   //! TIDx may need to be marked as non-exact as it may be padded to a
   //! multiple of the warp size.

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -2256,15 +2256,38 @@ INSTANTIATE_TEST_SUITE_P(
     tmaCircularBufferingParams(),
     tmaName);
 
-using RegisterSharingTestParams = std::tuple<dim3, ParallelType>;
-using TmaRegisterSharingTest =
-    NVFuserFixtureParamTest<RegisterSharingTestParams>;
-TEST_P(TmaRegisterSharingTest, RegisterSharingCtaShapes) {
+namespace {
+
+// warp specialization with register sharing requires
+// all threads in the same warp group execute the same
+// register adjustment instruction. So the number of padded
+// threads for TMA loading branch depends on CTA shape &
+// warp specialization dimension.
+// index = TIDx + TIDy * bdimx + TIDz * bdimx * bdimy
+// total = bdimx * bdimy * bdimz
+// Pad on x: bdimx += 128
+// Pad on y: bdimy += 128/bdimx
+// Pad on z: bdimz += 128/(bdimx * bdimy)
+int64_t getTmaBranchThreads(ParallelType ws_pt, dim3 bdim) {
+  if (ws_pt == ParallelType::TIDx) {
+    return 128L * bdim.y * bdim.z;
+  } else if (ws_pt == ParallelType::TIDy) {
+    return scheduler_utils::safeDiv(128, bdim.x) * bdim.x * bdim.z;
+  } else if (ws_pt == ParallelType::TIDz) {
+    return scheduler_utils::safeDiv(128, bdim.x * bdim.y) * bdim.x * bdim.y;
+  } else {
+    NVF_THROW("TMA register sharing only supports TIDx, TIDy, and TIDz");
+  }
+}
+
+} // namespace
+
+TEST_F(NVFuserTest, TmaRegisterSharingDynamicShapeExpectFail) {
   NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
   int64_t gdimx = 2;
-  auto [bdim, ws_pt] = GetParam();
-  int64_t bdimx = bdim.x, bdimy = bdim.y, bdimz = bdim.z;
-  int64_t n_computation_threads = bdimx * bdimy * bdimz;
+  dim3 bdim = dim3(32, 4, 2);
+  ParallelType ws_pt = ParallelType::TIDx;
+  int64_t n_computation_threads = bdim.x * bdim.y * bdim.z;
   std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -2279,8 +2302,8 @@ TEST_P(TmaRegisterSharingTest, RegisterSharingCtaShapes) {
 
   // [I1, I2] -> [gdimx, I1/gdimx, I2/bdimx/bdimy, bdimy, bdimx]
   tv2->split(0, gdimx, false);
-  tv2->split(2, bdimx);
-  tv2->split(2, bdimy);
+  tv2->split(2, bdim.x);
+  tv2->split(2, bdim.y);
   tv2->axis(-1)->parallelize(ParallelType::TIDx);
   tv2->axis(-2)->parallelize(ParallelType::TIDy);
   tv2->axis(-3)->parallelize(ParallelType::TIDz);
@@ -2294,41 +2317,90 @@ TEST_P(TmaRegisterSharingTest, RegisterSharingCtaShapes) {
   // Set inlineAt before applying circular buffer
   inlineAllAt(tv1, /*pos=*/2);
 
-  // warp specialization with register sharing requires
-  // all threads in the same warp group execute the same
-  // register adjustment instruction. So the number of padded
-  // threads for TMA loading branch depends on CTA shape &
-  // warp specialization dimension.
-  // index = TIDx + TIDy * bdimx + TIDz * bdimx * bdimy
-  // total = bdimx * bdimy * bdimz
-  // Pad on x: bdimx += 128
-  // Pad on y: bdimy += 128/bdimx
-  // Pad on z: bdimz += 128/(bdimx * bdimy)
-  auto get_tma_branch_threads = [&](ParallelType ws_pt) {
-    if (ws_pt == ParallelType::TIDx) {
-      return (int64_t)128 * bdimy * bdimz;
-    } else if (ws_pt == ParallelType::TIDy) {
-      return scheduler_utils::safeDiv(128, bdimx) * bdimx * bdimz;
-    } else if (ws_pt == ParallelType::TIDz) {
-      return scheduler_utils::safeDiv(128, bdimx * bdimy) * bdimx * bdimy;
-    } else {
-      NVF_THROW("TMA register sharing only supports TIDx, TIDy, and TIDz");
-    }
-  };
   // adjust register usage, assuming computation threads increase register
   // usage by 8, then each tma branch threads should reduce by:
   // 8 * n_computation / n_tma_branch_threads
-  int64_t n_tma_branch_threads = get_tma_branch_threads(ws_pt);
+  int64_t n_tma_branch_threads = getTmaBranchThreads(ws_pt, bdim);
   int64_t n_total_threads = n_computation_threads + n_tma_branch_threads;
   int64_t initial_reg_count = getRegPerThreadGivenThreadsPerSM(n_total_threads);
   EXPECT_TRUE(initial_reg_count % 8 == 0 || initial_reg_count == 255);
   int64_t compute_reg_count = initial_reg_count + 8;
   int64_t tma_reg_count =
       initial_reg_count - (n_computation_threads / n_tma_branch_threads) * 8;
+
   CircularBufferType circular_buffer_type =
       WarpSpecialized(ws_pt, std::make_pair(tma_reg_count, compute_reg_count));
   int64_t n_stages = 2;
-  tv1->circularBuffer(n_stages, 1, circular_buffer_type);
+  tv1->circularBuffer(n_stages, /*prefetch_distance=*/1, circular_buffer_type);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({n_stages * gdimx, n_computation_threads}, options);
+  at::Tensor t1 = t0 * t0;
+  KernelExecutor ke;
+  try {
+    ke.compile(fusion.get(), {t0});
+  } catch (const std::exception& e) {
+    const char* reference =
+        R"(Detected dynamic size for parallel type threadIdx.z in warp specialization kernel.)";
+    const char* str_match_pointer = strstr(e.what(), reference);
+    ASSERT_TRUE(str_match_pointer != nullptr);
+    return;
+  }
+  FAIL() << "Expected exception during compilation";
+}
+
+using RegisterSharingTestParams = std::tuple<dim3, ParallelType>;
+using TmaRegisterSharingTest =
+    NVFuserFixtureParamTest<RegisterSharingTestParams>;
+TEST_P(TmaRegisterSharingTest, RegisterSharingCtaShapes) {
+  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+  int64_t gdimx = 2;
+  auto [bdim, ws_pt] = GetParam();
+  int64_t n_computation_threads = bdim.x * bdim.y * bdim.z;
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeContigTensor(2);
+  fusion->addInput(tv0);
+
+  auto tv1 = set(tv0);
+  tv1->setMemoryType(MemoryType::Shared);
+  tv1->definition()->as<LoadStoreOp>()->setOpType(LoadStoreOpType::CpAsyncBulk);
+  auto tv2 = mul(tv1, tv1);
+  fusion->addOutput(tv2);
+
+  // [I1, I2] -> [gdimx, I1/gdimx, I2/bdimx/bdimy, bdimy, bdimx]
+  tv2->split(0, gdimx, false);
+  tv2->split(2, bdim.x);
+  tv2->split(2, bdim.y);
+  tv2->axis(-1)->parallelize(ParallelType::TIDx);
+  tv2->axis(-2)->parallelize(ParallelType::TIDy);
+  tv2->axis(-3)->parallelize(ParallelType::TIDz);
+  tv2->axis(0)->parallelize(ParallelType::BIDx);
+
+  // [I1, I2] -> [gdimx, I1/gdimx, I2]
+  tv1->split(0, gdimx, false);
+  tv1->axis(0)->parallelize(ParallelType::BIDx);
+  tv1->axis(2)->parallelize(ParallelType::Bulk);
+
+  // Set inlineAt before applying circular buffer
+  inlineAllAt(tv1, /*pos=*/2);
+
+  // adjust register usage, assuming computation threads increase register
+  // usage by 8, then each tma branch threads should reduce by:
+  // 8 * n_computation / n_tma_branch_threads
+  int64_t n_tma_branch_threads = getTmaBranchThreads(ws_pt, bdim);
+  int64_t n_total_threads = n_computation_threads + n_tma_branch_threads;
+  int64_t initial_reg_count = getRegPerThreadGivenThreadsPerSM(n_total_threads);
+  EXPECT_TRUE(initial_reg_count % 8 == 0 || initial_reg_count == 255);
+  int64_t compute_reg_count = initial_reg_count + 8;
+  int64_t tma_reg_count =
+      initial_reg_count - (n_computation_threads / n_tma_branch_threads) * 8;
+
+  CircularBufferType circular_buffer_type =
+      WarpSpecialized(ws_pt, std::make_pair(tma_reg_count, compute_reg_count));
+  int64_t n_stages = 2;
+  tv1->circularBuffer(n_stages, /*prefetch_distance=*/1, circular_buffer_type);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   at::Tensor t0 = at::randn({n_stages * gdimx, n_computation_threads}, options);
@@ -2338,7 +2410,7 @@ TEST_P(TmaRegisterSharingTest, RegisterSharingCtaShapes) {
     ke.compile(fusion.get(), {t0});
   } catch (const std::exception& e) {
     const char* reference = R"(Illegal register sharing on TIDx)";
-    if ((bdimx % 128 || 128 % bdimx) && ws_pt == ParallelType::TIDx) {
+    if ((bdim.x % 128 || 128 % bdim.x) && ws_pt == ParallelType::TIDx) {
       const char* str_match_pointer = strstr(e.what(), reference);
       ASSERT_TRUE(str_match_pointer != nullptr);
       return;


### PR DESCRIPTION
This PR refactors `adjustMappingsForWarpSpecialization` for future multi-role specialization support.
* Change `get_threads_count_in_dim` lambda to `ParallelDimensionMap::getThreadCountInDim` private member function.

## Enforce that all thread dimensions are static for register sharing.
* Create `TEST_F(NVFuserTest, TmaRegisterSharingDynamicShapesExpectFail)` to test for assertion.
* Rename `TEST_P(TmaRegisterSharingTest, RegisterSharingCtaShapes)` to `TEST_P(TmaRegisterSharing, CtaShapeShmoo)`
* Change `TEST_P(TmaRegisterSharing, CtaShapeShmoo)` to have static thread dimensions.