### PR TITLE
Don't link lib_kernels.so against codegen_internal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,7 +637,7 @@ if(BUILD_TEST)
 
   # CUDA 11 does not support C++20, so hard code C++17 here
   set_property(TARGET ${RNG_TEST_KERNELS} PROPERTY CXX_STANDARD 17)
-  target_link_libraries(${RNG_TEST_KERNELS} PRIVATE torch ${TORCH_LIBRARIES} codegen_internal)
+  target_link_libraries(${RNG_TEST_KERNELS} PRIVATE torch ${TORCH_LIBRARIES})
   target_include_directories(${RNG_TEST_KERNELS} PRIVATE "${NVFUSER_ROOT}")
 endif()
 


### PR DESCRIPTION
That file is the result of tests/cpp/rng_kernels.cu, which does not use anything from nvfuser so it does not need to be linked against nvfuser. Doing so causes a multiply defined symbol, leading to this type of asan error:
https://github.com/google/sanitizers/wiki/AddressSanitizerOneDefinitionRuleViolation.

NOTE: It seems `$NVFUSER_TESTS` is never set in CMakeLists.txt. I am unsure what the original intended name was for this file but I think we should just hardcode that name instead of the current version which leads to `lib_kernels.so` being generated..

Fixes #4369.