### PR TITLE
NVIDIA_TF32_OVERRIDE=0 in test fixtures

### DIFF
--- a/python/nvfuser/testing/utils.py
+++ b/python/nvfuser/testing/utils.py
@@ -461,6 +461,8 @@ class NVFuserTest(TestCase):
         Setup is run once at the class level, before running any tests of the class.
         `atexit_serde_check` enables automatic serialization at the end of the test suite.
         """
+        os.environ["NVIDIA_TF32_OVERRIDE"] = "0"
+
         atexit_serde_check()
 
     # Helper function to verify the nvfuser output and make sure the string

--- a/tests/cpp/utils.cpp
+++ b/tests/cpp/utils.cpp
@@ -40,6 +40,11 @@ NVFuserTest::NVFuserTest() {
   std::srand(getCRandomSeed());
 
   EnableOptionsGuard::getCurOptions().set(EnableOption::IdModelExtraValidation);
+
+  constexpr const char* kTf32Override = "NVIDIA_TF32_OVERRIDE";
+  if (setenv(kTf32Override, "0", /*overwrite=*/1) != 0) {
+    TORCH_WARN("Failed to set ", kTf32Override, " to 0");
+  }
 }
 
 void NVFuserTest::SetUp() {

--- a/tests/python/multidevice/conftest.py
+++ b/tests/python/multidevice/conftest.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import nvfuser
+import os
 import pytest
 import torch
 import torch.distributed as dist
@@ -49,6 +50,8 @@ class MultideviceTest:
 
 @pytest.fixture
 def multidevice_test():
+    os.environ["NVIDIA_TF32_OVERRIDE"] = "0"
+
     # Reset the cache here to work around a bug in FusionDefintion.execute.
     # FusionDefinition._finalize_definition maps the same `definition` to the
     # same FusionSchedules and therefore the same FusionExecutorCache. This was


### PR DESCRIPTION
Our unit tests heavily depend on this flag and our CI already sets this when running any tests. I think it's better to set this in test fixtures instead so we don't have to remember to do so when running tests locally.