### PR TITLE
Alias analysis propagates allocation of intermediate tensors.

### DIFF
--- a/csrc/alias_analysis.h
+++ b/csrc/alias_analysis.h
@@ -57,9 +57,7 @@ class AliasAnalysisResult {
   void add(const TensorView* alias, TensorView* source, Layout&& layout);
 
   // Computes transitive aliases and caches them in `alias_to_root_`.
-  // See `findAliases` for the meaning of
-  // `can_override_empty_allocation_domain`.
-  void finalize(bool can_override_empty_allocation_domain);
+  void finalize();
 
   // Returns the preferred layout. If `alias` is not in `alias_to_source_`,
   // returns the `TensorView`'s initial layout.

--- a/csrc/alias_analysis.h
+++ b/csrc/alias_analysis.h
@@ -84,10 +84,10 @@ class AliasAnalysisResult {
 
 // Before segmentation, we treat an empty allocation domain as undetermined and
 // can override it to any layout. After segmentation, we treat an empty
-// allocation domain as canonical, i.e., major-to-minor and contiguous. We have
-// to be conservative after segmentation, because a scheduler changing the
-// allocation domain of a segment boundary may invalidate heuristics of its
-// upstream/downstream segment.
+// allocation domain as the same as logical, i.e., major-to-minor and
+// contiguous. We have to be conservative after segmentation, because a
+// scheduler changing the allocation domain of a segment boundary may
+// invalidate heuristics of its upstream/downstream segment.
 //
 // For example,
 // ```
@@ -106,7 +106,7 @@ class AliasAnalysisResult {
 // enable aliases; the latter, used by ExprEvalScheduler, calls
 // Fusion::aliasOutputToInput to mark aliases.
 enum class EmptyAllocationAs {
-  kCanonical,
+  kLogical,
   kUndetermined,
 };
 

--- a/csrc/preseg_passes/mark_aliases_prepare.cpp
+++ b/csrc/preseg_passes/mark_aliases_prepare.cpp
@@ -122,7 +122,7 @@ void insertSegmentSetAfter(
 
 void MarkAliasesPreparePass::runPass(Fusion* fusion) {
   const AliasAnalysisResult analysis =
-      findAliases(fusion, /*can_override_empty_allocation_domain=*/true);
+      findAliases(fusion, EmptyAllocationAs::kUndetermined);
   if (isDebugDumpEnabled(DebugDumpOption::PreSegmenterLogging)) {
     debug() << "Alias analysis result:" << std::endl;
     debug() << analysis.toString(/*indent_size=*/1) << std::endl;

--- a/csrc/scheduler/expr_eval_sched.cpp
+++ b/csrc/scheduler/expr_eval_sched.cpp
@@ -18,7 +18,7 @@ namespace nvfuser {
 namespace {
 bool allOutputsArePointerArithmetics(Fusion* fusion) {
   const AliasAnalysisResult analysis =
-      findAliases(fusion, EmptyAllocationAs::kCanonical);
+      findAliases(fusion, EmptyAllocationAs::kLogical);
 
   auto is_pointer_arithmetic = [&](TensorView* out) -> bool {
     // Check out has an alias and out is not an inplace update target.

--- a/csrc/scheduler/expr_eval_sched.cpp
+++ b/csrc/scheduler/expr_eval_sched.cpp
@@ -18,7 +18,7 @@ namespace nvfuser {
 namespace {
 bool allOutputsArePointerArithmetics(Fusion* fusion) {
   const AliasAnalysisResult analysis =
-      findAliases(fusion, /*can_override_empty_allocation_domain=*/false);
+      findAliases(fusion, EmptyAllocationAs::kCanonical);
 
   auto is_pointer_arithmetic = [&](TensorView* out) -> bool {
     // Check out has an alias and out is not an inplace update target.

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -26,7 +26,7 @@ void markAliases(Fusion* fusion) {
   }
 
   const AliasAnalysisResult analysis =
-      findAliases(fusion, /*can_override_empty_allocation_domain=*/false);
+      findAliases(fusion, EmptyAllocationAs::kCanonical);
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerVerbose)) {
     vlog("Alias analysis result:\n", analysis.toString(/*indent_size=*/1));
   }

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -26,7 +26,7 @@ void markAliases(Fusion* fusion) {
   }
 
   const AliasAnalysisResult analysis =
-      findAliases(fusion, EmptyAllocationAs::kCanonical);
+      findAliases(fusion, EmptyAllocationAs::kLogical);
   if (isDebugDumpEnabled(DebugDumpOption::SchedulerVerbose)) {
     vlog("Alias analysis result:\n", analysis.toString(/*indent_size=*/1));
   }

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -333,10 +333,12 @@ TEST_F(AliasTest, DuplicateOutputsSegmentedFusion) {
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
   // Verify aliasing among duplicated outputs
-  EXPECT_TRUE(out_tensors[0].as<at::Tensor>().is_alias_of(
-      out_tensors[1].as<at::Tensor>()));
-  EXPECT_TRUE(out_tensors[2].as<at::Tensor>().is_alias_of(
-      out_tensors[3].as<at::Tensor>()));
+  EXPECT_TRUE(
+      out_tensors[0].as<at::Tensor>().is_alias_of(
+          out_tensors[1].as<at::Tensor>()));
+  EXPECT_TRUE(
+      out_tensors[2].as<at::Tensor>().is_alias_of(
+          out_tensors[3].as<at::Tensor>()));
 
   // Verify segmentation
   EXPECT_EQ(
@@ -569,12 +571,15 @@ TEST_F(AliasTest, DuplicateOutputsComplex) {
   ASSERT_EQ(out_tensors.size(), 4);
 
   // Verify aliases among outputs.
-  EXPECT_TRUE(out_tensors[0].as<at::Tensor>().is_alias_of(
-      out_tensors[1].as<at::Tensor>()));
-  EXPECT_FALSE(out_tensors[0].as<at::Tensor>().is_alias_of(
-      out_tensors[2].as<at::Tensor>()));
-  EXPECT_TRUE(out_tensors[0].as<at::Tensor>().is_alias_of(
-      out_tensors[3].as<at::Tensor>()));
+  EXPECT_TRUE(
+      out_tensors[0].as<at::Tensor>().is_alias_of(
+          out_tensors[1].as<at::Tensor>()));
+  EXPECT_FALSE(
+      out_tensors[0].as<at::Tensor>().is_alias_of(
+          out_tensors[2].as<at::Tensor>()));
+  EXPECT_TRUE(
+      out_tensors[0].as<at::Tensor>().is_alias_of(
+          out_tensors[3].as<at::Tensor>()));
 
   // Verify output values.
   testValidate(
@@ -692,8 +697,9 @@ TEST_F(AliasTest, OutputAliasesAnotherOutput) {
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
   ASSERT_EQ(out_tensors.size(), 2);
-  EXPECT_TRUE(out_tensors[1].as<at::Tensor>().is_alias_of(
-      out_tensors[0].as<at::Tensor>()));
+  EXPECT_TRUE(
+      out_tensors[1].as<at::Tensor>().is_alias_of(
+          out_tensors[0].as<at::Tensor>()));
 }
 
 TEST_F(AliasTest, OutputNotAliasedByAnotherOutputShouldNotBeSegmented) {
@@ -1429,8 +1435,9 @@ TEST_F(AliasTest, QKVSplitBackprop) {
   auto out_tensors = executor_cache.runFusionWithInputs(args);
   testValidate(executor_cache.fusion(), out_tensors, args, __LINE__, __FILE__);
 
-  EXPECT_TRUE(out_tensors[2].as<at::Tensor>().is_alias_of(
-      out_tensors[1].as<at::Tensor>()));
+  EXPECT_TRUE(
+      out_tensors[2].as<at::Tensor>().is_alias_of(
+          out_tensors[1].as<at::Tensor>()));
 }
 
 TEST_F(AliasTest, Bookend_Issue2375) {
@@ -1545,7 +1552,6 @@ TEST_F(AliasTest, TrivialInplaceUpdateNoSegmentation) {
 }
 
 TEST_F(AliasTest, ReshapeInplaceUpdateNoSegmentation) {
-  // testing a complete fusion
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -1571,10 +1577,11 @@ TEST_F(AliasTest, ReshapeInplaceUpdateNoSegmentation) {
   ASSERT_EQ(out_tensors.size(), 1);
 
   // Verify inplace update
-  EXPECT_TRUE(out_tensors[0]
-                  .as<at::Tensor>()
-                  .as_strided({2, 3, 4}, {12, 4, 1})
-                  .equal(in_tensor));
+  EXPECT_TRUE(
+      out_tensors[0]
+          .as<at::Tensor>()
+          .as_strided({2, 3, 4}, {12, 4, 1})
+          .equal(in_tensor));
 
   // Verify no segmentation
   EXPECT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented());
@@ -1613,6 +1620,35 @@ TEST_F(AliasTest, FusionEmpty) {
   EXPECT_THAT(
       runtime->fusionSegments()->groups(),
       UnorderedElementsAre(HeuristicIs(SchedulerType::ExprEval)));
+}
+
+TEST_F(AliasTest, IntermediateTensorWithAllocation) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({15, 2});
+  TensorView* x = transpose(in);
+  x = segment_set(x);
+  TensorView* out = reshape(x, {2, 15}, {2, 3, 5});
+  fusion->addInput(in);
+  fusion->addOutput(out);
+
+  x->setAllocationDomain(x->getLogicalDomain(), true);
+
+  FusionExecutorCache executor_cache(std::move(fusion));
+  at::Tensor in_tensor =
+      at::randn({15, 2}, at::dtype(at::kFloat).device(at::kCUDA));
+  auto out_tensors = executor_cache.runFusionWithInputs({in_tensor});
+
+  testValidate(
+      executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
+
+  FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
+  EXPECT_THAT(
+      runtime->fusionSegments()->groups(),
+      UnorderedElementsAre(
+          HeuristicIs(SchedulerType::PointWise),
+          HeuristicIs(SchedulerType::ExprEval)));
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_alias.cpp
+++ b/tests/cpp/test_alias.cpp
@@ -333,12 +333,10 @@ TEST_F(AliasTest, DuplicateOutputsSegmentedFusion) {
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
   // Verify aliasing among duplicated outputs
-  EXPECT_TRUE(
-      out_tensors[0].as<at::Tensor>().is_alias_of(
-          out_tensors[1].as<at::Tensor>()));
-  EXPECT_TRUE(
-      out_tensors[2].as<at::Tensor>().is_alias_of(
-          out_tensors[3].as<at::Tensor>()));
+  EXPECT_TRUE(out_tensors[0].as<at::Tensor>().is_alias_of(
+      out_tensors[1].as<at::Tensor>()));
+  EXPECT_TRUE(out_tensors[2].as<at::Tensor>().is_alias_of(
+      out_tensors[3].as<at::Tensor>()));
 
   // Verify segmentation
   EXPECT_EQ(
@@ -571,15 +569,12 @@ TEST_F(AliasTest, DuplicateOutputsComplex) {
   ASSERT_EQ(out_tensors.size(), 4);
 
   // Verify aliases among outputs.
-  EXPECT_TRUE(
-      out_tensors[0].as<at::Tensor>().is_alias_of(
-          out_tensors[1].as<at::Tensor>()));
-  EXPECT_FALSE(
-      out_tensors[0].as<at::Tensor>().is_alias_of(
-          out_tensors[2].as<at::Tensor>()));
-  EXPECT_TRUE(
-      out_tensors[0].as<at::Tensor>().is_alias_of(
-          out_tensors[3].as<at::Tensor>()));
+  EXPECT_TRUE(out_tensors[0].as<at::Tensor>().is_alias_of(
+      out_tensors[1].as<at::Tensor>()));
+  EXPECT_FALSE(out_tensors[0].as<at::Tensor>().is_alias_of(
+      out_tensors[2].as<at::Tensor>()));
+  EXPECT_TRUE(out_tensors[0].as<at::Tensor>().is_alias_of(
+      out_tensors[3].as<at::Tensor>()));
 
   // Verify output values.
   testValidate(
@@ -697,9 +692,8 @@ TEST_F(AliasTest, OutputAliasesAnotherOutput) {
       executor_cache.fusion(), out_tensors, {in_tensor}, __LINE__, __FILE__);
 
   ASSERT_EQ(out_tensors.size(), 2);
-  EXPECT_TRUE(
-      out_tensors[1].as<at::Tensor>().is_alias_of(
-          out_tensors[0].as<at::Tensor>()));
+  EXPECT_TRUE(out_tensors[1].as<at::Tensor>().is_alias_of(
+      out_tensors[0].as<at::Tensor>()));
 }
 
 TEST_F(AliasTest, OutputNotAliasedByAnotherOutputShouldNotBeSegmented) {
@@ -1435,9 +1429,8 @@ TEST_F(AliasTest, QKVSplitBackprop) {
   auto out_tensors = executor_cache.runFusionWithInputs(args);
   testValidate(executor_cache.fusion(), out_tensors, args, __LINE__, __FILE__);
 
-  EXPECT_TRUE(
-      out_tensors[2].as<at::Tensor>().is_alias_of(
-          out_tensors[1].as<at::Tensor>()));
+  EXPECT_TRUE(out_tensors[2].as<at::Tensor>().is_alias_of(
+      out_tensors[1].as<at::Tensor>()));
 }
 
 TEST_F(AliasTest, Bookend_Issue2375) {
@@ -1577,11 +1570,10 @@ TEST_F(AliasTest, ReshapeInplaceUpdateNoSegmentation) {
   ASSERT_EQ(out_tensors.size(), 1);
 
   // Verify inplace update
-  EXPECT_TRUE(
-      out_tensors[0]
-          .as<at::Tensor>()
-          .as_strided({2, 3, 4}, {12, 4, 1})
-          .equal(in_tensor));
+  EXPECT_TRUE(out_tensors[0]
+                  .as<at::Tensor>()
+                  .as_strided({2, 3, 4}, {12, 4, 1})
+                  .equal(in_tensor));
 
   // Verify no segmentation
   EXPECT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented());


### PR DESCRIPTION
The previous version checks allocation of intermediate tensors in finalization stage and doesn't try to propagate it in dispatching stage. 

The most immediate use case is to be able to run mark-aliases-prepare after reorder-sharded-axis. Reorder-sharded-axis sets allocation so scattered/gathered dimensions are allocated outermost for NCCL and UCC. It's beneficial for mark-aliases-prepare to respect these allocations even though they are on intermediate tensors. 

There may be other benefits, e.g., making fd.ops.stride_order(sdpa_out) more effective as a performance hint. 