### PR TITLE
Pre-segmentation pass to move a take_along_axis Expr ahead of certain pointwise unary ops and squeeze ops.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/preseg_passes/insert_reshardings.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/make_resharding_contiguous.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/mark_aliases_prepare.cpp
+  ${NVFUSER_SRCS_DIR}/preseg_passes/move_gather.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/move_pad.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/move_repeat_forward.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/move_split_cat.cpp

--- a/csrc/preseg_passes/move_gather.cpp
+++ b/csrc/preseg_passes/move_gather.cpp
@@ -1,0 +1,207 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <preseg_passes/move_gather.h>
+
+#include <expr_simplifier.h>
+#include <fusion.h>
+#include <ir/builder.h>
+#include <ir/interface_nodes.h>
+#include <ir/internal_base_nodes.h>
+#include <ir/utils.h>
+#include <ops/alias.h>
+#include <ops/arith.h>
+#include <ops/indexing.h>
+#include <ops/utils.h>
+#include <transform_replay.h>
+
+namespace nvfuser::preseg_passes {
+
+namespace {
+
+bool isUnaryPointwiseOp(const Expr* expr) {
+  // Check if the expression is a UnaryOp and a pointwise operation
+  return expr->isA<UnaryOp>() && ir_utils::isPointwiseTvOp(expr);
+}
+
+bool hasGatherOp(const Fusion* fusion) {
+  auto exprs = fusion->exprs();
+  return ir_utils::filterByType<GatherOp>(exprs).size() > 0;
+}
+
+// For now we allow unary pointwise ops like cast/neg or a squeeze.
+// We only consider squeeze which has a single dim squeezed.
+std::optional<Expr*> getAllowedLookupTvDef(const GatherOp* gather_op) {
+  if (gather_op->lookupTv()->isFusionInput()) {
+    return std::nullopt;
+  }
+
+  auto producing_expr = gather_op->lookupTv()->definition();
+  NVF_ERROR(
+      producing_expr != nullptr, "Def for Lookup tensor view is nullptr.");
+
+  if (isUnaryPointwiseOp(producing_expr)) {
+    return producing_expr;
+  }
+
+  // We handle squeeze op where only one dim is squeezed.
+  if (producing_expr->isA<SqueezeOp>()) {
+    auto squeeze_op = producing_expr->as<SqueezeOp>();
+    if (std::count(
+            squeeze_op->getSqueezeDimFlags().begin(),
+            squeeze_op->getSqueezeDimFlags().end(),
+            true) == 1) {
+      return producing_expr;
+    }
+  }
+
+  return std::nullopt;
+}
+
+auto positionOfSqueezedDim(const std::vector<bool>& squeeze_dim_flags) {
+  auto it = std::find(squeeze_dim_flags.begin(), squeeze_dim_flags.end(), true);
+  return it != squeeze_dim_flags.end()
+      ? std::distance(squeeze_dim_flags.begin(), it)
+      : -1;
+}
+
+// If the def of lookUpTv is squeeze, and we're moving the squeeze to
+// after the gather/take_along_axis, then we need to add an unsqueeze
+// to the IndexTv
+auto prepareIndexTv(Fusion* fusion, GatherOp* gather_op, Expr* def) {
+  if (def->isA<SqueezeOp>()) {
+    auto squeeze_dim_flags = def->as<SqueezeOp>()->getSqueezeDimFlags();
+    auto dim = positionOfSqueezedDim(squeeze_dim_flags);
+    NVF_CHECK(dim >= 0, "Squeeze dim not found in squeeze op.");
+    return unsqueeze(gather_op->indexTv(), dim);
+  }
+  return gather_op->indexTv();
+}
+
+auto addPostGatherSqueeze(
+    Fusion* fusion,
+    GatherOp* gather,
+    TensorView* new_gather_output,
+    Expr* def,
+    Expr* dest_expr) {
+  auto new_squeeze_output =
+      squeeze(new_gather_output, def->as<SqueezeOp>()->getSqueezeDimFlags());
+  dest_expr = new_gather_output->definition();
+  return new_squeeze_output;
+}
+
+auto addPostGatherOp(
+    Fusion* fusion,
+    GatherOp* gather,
+    TensorView* new_gather_output,
+    Expr* def,
+    Expr* dest_expr) {
+  IrCloner ir_cloner(fusion);
+  auto cloned_def = static_cast<Expr*>(def->clone(&ir_cloner));
+
+  cloned_def = ir_utils::replaceValInExprInputs(
+      cloned_def, cloned_def->input(0), dest_expr->output(0));
+
+  auto cloned_output_tv = ops::newValLike(
+      cloned_def->input(0)->as<TensorView>(), cloned_def->output(0)->dtype());
+
+  cloned_def =
+      ir_utils::transferDefinitionToNewOutputs(cloned_def, {cloned_output_tv});
+
+  return cloned_def->output(0);
+}
+
+auto addOrCloneNewNodeAfterGather(
+    Fusion* fusion,
+    GatherOp* gather,
+    TensorView* new_gather_output,
+    Expr* def,
+    Expr* dest_expr) {
+  auto output_of_post_gather_op = def->isA<SqueezeOp>()
+      ? addPostGatherSqueeze(fusion, gather, new_gather_output, def, dest_expr)
+      : addPostGatherOp(fusion, gather, new_gather_output, def, dest_expr);
+
+  for (auto expr : gather->output(0)->uses()) {
+    ir_utils::replaceValInExprInputs(
+        expr, gather->output(0), output_of_post_gather_op);
+  }
+}
+
+GatherOp* moveGatherOp(Fusion* fusion, GatherOp* gather_op, Expr* def) {
+  IrCloner ir_cloner(fusion);
+
+  auto index_tv = prepareIndexTv(fusion, gather_op, def);
+
+  if (def->isA<SqueezeOp>()) {
+    auto pos =
+        positionOfSqueezedDim(def->as<SqueezeOp>()->getSqueezeDimFlags());
+    NVF_ERROR(pos >= 0, "Squeeze dim not found in squeeze op.");
+
+    // We don't handle the case where the squeezed dim was greater than the
+    // take_along_axis dim
+    NVF_CHECK(
+        pos <= gather_op->dim(), "Squeeze dim is greater than gather dim.");
+  }
+
+  auto dim_for_gather_op =
+      def->isA<SqueezeOp>() ? gather_op->dim() + 1 : gather_op->dim();
+
+  auto new_gather_op_output = takeAlongAxis(
+      static_cast<TensorView*>(def->input(0)), index_tv, dim_for_gather_op);
+
+  addOrCloneNewNodeAfterGather(
+      fusion,
+      gather_op,
+      new_gather_op_output,
+      def,
+      new_gather_op_output->definition());
+
+  fusion->removeExpr(gather_op);
+
+  return new_gather_op_output->definition()->as<GatherOp>();
+}
+
+void moveGatherOp(Fusion* fusion, GatherOp* gather_op) {
+  do {
+    auto producer = getAllowedLookupTvDef(gather_op);
+    if (!producer.has_value() || producer.value() == nullptr) {
+      return;
+    }
+
+    auto def = producer.value();
+    auto new_gather_op = moveGatherOp(fusion, gather_op, def);
+    if (new_gather_op == gather_op) {
+      return;
+    }
+    gather_op = new_gather_op;
+  } while (true);
+}
+
+} // namespace
+
+void MoveGatherPass::runPass(Fusion* fusion) {
+  if (!hasGatherOp(fusion))
+    return;
+
+  auto exprs = fusion->exprs();
+  auto gather_ops = ir_utils::filterByType<GatherOp>(exprs);
+
+  // We support this optimization on fusions
+  // with a single gather op
+  if (gather_ops.size() > 1) {
+    return;
+  }
+
+  // For now we'll only support take_along_axis
+  // not the general gather.
+  if (!gather_ops.vector().at(0)->exactSizes()) {
+    return;
+  }
+
+  moveGatherOp(fusion, gather_ops.vector()[0]);
+}
+} // namespace nvfuser::preseg_passes

--- a/csrc/preseg_passes/move_gather.h
+++ b/csrc/preseg_passes/move_gather.h
@@ -1,0 +1,24 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <preseg_passes/optimization_pass.h>
+
+namespace nvfuser::preseg_passes {
+
+// A pre-segmenter optimization that moves gather operations ahead of producer
+// unary pointwise ops such as cast.
+class MoveGatherPass : public OptimizationPass<MoveGatherPass> {
+  friend class OptimizationPass<MoveGatherPass>;
+
+ protected:
+  static void runPass(Fusion* fusion);
+  static constexpr std::string_view name() {
+    return "MoveGatherPass";
+  }
+};
+
+} // namespace nvfuser::preseg_passes

--- a/csrc/preseg_passes/pre_segmenter.cpp
+++ b/csrc/preseg_passes/pre_segmenter.cpp
@@ -18,6 +18,7 @@
 #include <preseg_passes/insert_reshardings.h>
 #include <preseg_passes/make_resharding_contiguous.h>
 #include <preseg_passes/mark_aliases_prepare.h>
+#include <preseg_passes/move_gather.h>
 #include <preseg_passes/move_pad.h>
 #include <preseg_passes/move_repeat_forward.h>
 #include <preseg_passes/move_split_cat.h>
@@ -90,6 +91,7 @@ namespace nvfuser::preseg_passes {
   OptimizationPass<SegmentInplaceUpdatePass>::runPass(fusion);
   OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>::runPass(fusion);
   OptimizationPass<MoveRepeatForwardPass>::runPass(fusion);
+  OptimizationPass<MoveGatherPass>::runPass(fusion);
 }
 
 } // namespace nvfuser::preseg_passes

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -13,6 +13,7 @@
 #include <ir/utils.h>
 #include <ops/all_ops.h>
 #include <preseg_passes/consecutive_cast.h>
+#include <preseg_passes/move_gather.h>
 #include <preseg_passes/optimization_pass.h>
 #include <preseg_passes/pre_segmenter.h>
 #include <preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h>
@@ -1268,6 +1269,174 @@ struct MatmulInputShape {
     return ss.str();
   }
 };
+
+TEST_F(PresegTest, MoveGatherOverCast) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(2, DataType::BFloat16);
+  fusion.addInput(tv0);
+  auto tv1 = makeSymbolicTensor(1, DataType::Int);
+  fusion.addInput(tv1);
+
+  auto tv2 = castOp(DataType::Float, tv0);
+  auto s3 = IrBuilder::create<Val>(-100.0, DataType::Int);
+  auto s4 = IrBuilder::create<Val>(0, DataType::Int);
+
+  auto tv3 = ne(tv1, s3);
+  auto tv4 = where(tv3, tv1, s4);
+  auto tv5 = broadcast(tv4, {false, true});
+  auto tv6 = takeAlongAxis(tv2, tv5, -1);
+  auto tv7 = squeeze(tv6, {1});
+  auto tv8 = max(tv2, {-1});
+  auto tv9 = sub(tv7, tv8);
+  fusion.addOutput(tv9);
+
+  auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0);
+  auto options_2 = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
+  auto t0 = at::randn({8, 16}, options);
+  auto t1 = at::randint(0, 5, {8}, options_2);
+
+  KernelArgumentHolder outputs_no_pass, outputs_with_pass;
+  {
+    auto new_fusion = std::make_unique<Fusion>(fusion);
+    OptimizationPassGuard<MoveGatherPass> guard(false);
+    FusionExecutorCache executor_cache(std::move(new_fusion));
+    outputs_no_pass = executor_cache.runFusionWithInputs({t0, t1});
+  }
+
+  // Now run with the pass and check outputs match.
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  outputs_with_pass = executor_cache.runFusionWithInputs({t0, t1});
+  EXPECT_TRUE(outputs_with_pass[0].as<at::Tensor>().equal(
+      outputs_no_pass[0].as<at::Tensor>()));
+
+  auto exprs = executor_cache.getMostRecentKernelRuntime()
+                   ->fusionSegments()
+                   ->completeFusion()
+                   ->exprs();
+  // Has take Along axis
+  // lookupTv is now a fusion input and of type bfloat16
+  auto gather_ops = ir_utils::filterByType<GatherOp>(exprs);
+  EXPECT_EQ(gather_ops.size(), 1);
+  auto gather_op = gather_ops.vector().at(0);
+  auto lookupTv = gather_op->lookupTv();
+  EXPECT_TRUE(lookupTv->isFusionInput());
+  EXPECT_EQ(lookupTv->getDataType(), DataType::BFloat16);
+
+  std::vector<UnaryOp*> all_cast_ops;
+  std::vector<UnaryOp*> new_cast_ops;
+  auto unary_ops = ir_utils::filterByType<UnaryOp>(exprs).vector();
+
+  // We should have two cast ops
+  std::copy_if(
+      unary_ops.begin(),
+      unary_ops.end(),
+      std::back_inserter(all_cast_ops),
+      [gather_op](UnaryOp* op) {
+        std::cout << op->toString() << std::endl;
+        return op->getUnaryOpType() == UnaryOpType::Cast;
+      });
+  EXPECT_EQ(all_cast_ops.size(), 2);
+
+  // The cast op after gather op should be a new cast op
+  // with a broadcast domain and dtype of float
+  std::copy_if(
+      unary_ops.begin(),
+      unary_ops.end(),
+      std::back_inserter(new_cast_ops),
+      [gather_op](UnaryOp* op) {
+        return op->getUnaryOpType() == UnaryOpType::Cast &&
+            op->input(0) == gather_op->output(0) &&
+            op->output(0)->getDataType() == DataType::Float &&
+            op->output(0)->as<TensorView>()->hasBroadcast();
+      });
+  EXPECT_EQ(new_cast_ops.size(), 1);
+}
+
+TEST_F(PresegTest, MoveGatherOverSqueezeAndCast) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(2, DataType::BFloat16);
+  fusion.addInput(tv0);
+  auto tv1 = makeSymbolicTensor(1, DataType::Int);
+  fusion.addInput(tv1);
+
+  tv0 = broadcast(tv0, {true, false, false});
+  tv1 = broadcast(tv1, {true, false});
+
+  auto tv2_f = castOp(DataType::Float, tv0);
+  auto tv2 = squeeze(tv2_f, {0});
+  auto tv3 = squeeze(tv1, {0});
+  auto s3 = IrBuilder::create<Val>(-100.0, DataType::Int);
+  auto s4 = IrBuilder::create<Val>(0, DataType::Int);
+
+  auto tv4 = ne(tv3, s3);
+  auto tv5 = where(tv4, tv3, s4);
+  auto tv6 = broadcast(tv5, {false, true});
+  auto tv7 = takeAlongAxis(tv2, tv6, -1);
+  auto tv9 = squeeze(tv7, {1});
+
+  auto tv10 = max(tv2_f, {-1});
+  auto tv11 = sub(tv9, tv10);
+
+  fusion.addOutput(tv11);
+
+  auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0);
+  auto options_2 = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
+  auto t0 = at::randn({8, 16}, options);
+  auto t1 = at::randint(0, 5, {8}, options_2);
+
+  KernelArgumentHolder outputs_no_pass, outputs_with_pass;
+  {
+    auto new_fusion = std::make_unique<Fusion>(fusion);
+    OptimizationPassGuard<MoveGatherPass> guard(false);
+    FusionExecutorCache executor_cache(std::move(new_fusion));
+    outputs_no_pass = executor_cache.runFusionWithInputs({t0, t1});
+  }
+
+  // Now run with the pass and check outputs match.
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  outputs_with_pass = executor_cache.runFusionWithInputs({t0, t1});
+  EXPECT_TRUE(outputs_with_pass[0].as<at::Tensor>().equal(
+      outputs_no_pass[0].as<at::Tensor>()));
+
+  auto exprs = executor_cache.getMostRecentKernelRuntime()
+                   ->fusionSegments()
+                   ->completeFusion()
+                   ->exprs();
+  // Has take Along axis
+  // lookupTv is now a fusion input and of type bfloat16
+  auto gather_ops = ir_utils::filterByType<GatherOp>(exprs);
+  EXPECT_EQ(gather_ops.size(), 1);
+  auto gather_op = gather_ops.vector().at(0);
+  auto lookupTv = gather_op->lookupTv();
+
+  // The Def of lookUp should be the broadcast Op
+  EXPECT_TRUE(lookupTv->definition()->isA<BroadcastOp>());
+
+  auto squeeze_ops = ir_utils::filterByType<SqueezeOp>(exprs).vector();
+  std::vector<SqueezeOp*> new_squeeze_ops;
+
+  // There should still be two squeeze ops
+  EXPECT_EQ(squeeze_ops.size(), 2);
+
+  // The new squeeze op after gather op should be a new cast op
+  // with a broadcast domain and dtype of float and after
+  // the cast op
+  std::copy_if(
+      squeeze_ops.begin(),
+      squeeze_ops.end(),
+      std::back_inserter(new_squeeze_ops),
+      [gather_op](SqueezeOp* op) {
+        // take_along_axis->cast->squeeze
+        return op->input(0)->definition()->input(0) == gather_op->output(0);
+      });
+  EXPECT_EQ(new_squeeze_ops.size(), 1);
+}
 
 using TranslateNoReductionMatmulTest =
     NVFuserFixtureParamTest<MatmulInputShape>;


### PR DESCRIPTION
This pass moves take_along axis ahead of certain unary pointwise ops and squeeze ops (where only a single dim is being squeezed). We also limit ourselves to a single take_along_axis in this PR. 

  tv --> cast  ---> Expr 1
               I
              V
      take_along_axis 
      
      
 Will become:
 
 tv--> cast -> Expr1
  I
  I
 V    
 take_along_axis -> cast
 
 
One benefit is, if there's no Exp1, then take_along_axis can potentially reduce the data footprint of operators that follow it.
 Another possible benefit is that in the case that Expr1 and take_along_axis are not in the segment, this optimization may reduce the temporaries being communicated between segments (at the cost of a duplicated cast).