### PR TITLE
Create IterDomain, TensorDomain, and TensorView bindings

### DIFF
--- a/python/python_next/bindings.cpp
+++ b/python/python_next/bindings.cpp
@@ -8,11 +8,11 @@
 
 #include <bindings.h>
 
-namespace python {
+namespace nvfuser::python {
 
 void initNvFuserPythonBindings(PyObject* module) {
   auto nvfuser = py::handle(module).cast<py::module>();
   bindFusionIr(nvfuser);
 }
 
-} // namespace python
+} // namespace nvfuser::python

--- a/python/python_next/bindings.h
+++ b/python/python_next/bindings.h
@@ -10,11 +10,11 @@
 #include <torch/csrc/jit/python/pybind.h>
 #include <torch/csrc/utils/pybind.h>
 
-namespace python {
+namespace nvfuser::python {
 
 void initNvFuserPythonBindings(PyObject* module);
 
 // Add bindings for Fusion IR
 void bindFusionIr(py::module& nvfuser);
 
-} // namespace python
+} // namespace nvfuser::python

--- a/python/python_next/extension.cpp
+++ b/python/python_next/extension.cpp
@@ -10,5 +10,5 @@
 
 PYBIND11_MODULE(PYTHON_NEXT_EXTENSION, m) {
   m.doc() = "Python bindings for NvFuser Next CPP API";
-  python::initNvFuserPythonBindings(m.ptr());
+  nvfuser::python::initNvFuserPythonBindings(m.ptr());
 }


### PR DESCRIPTION
This PR creates the bindings for `IterDomain`, `TensorDomain`, and `TensorView` bindings.
It corresponds with [Step 1: Create python bindings for basic Fusion IR](https://docs.google.com/document/d/1ftdNKu952EFmLANa36g0IrVaqAJ0eLKzgJESkQFnuVI/edit?tab=t.0#heading=h.e2plo2gt0gnb).

PR Stack:
#4403 Create IterDomain, TensorDomain, and TensorView bindings **<<< This PR.**
#4406 Add support for defineTensor
#4407 Add binding for Fusion IrContainer 
#4408 Create bindings for FusionDefinition and Add Binary op
#4409 Create python FusionDefinition for nvfuser_next