### PR TITLE
Create python FusionDefinition for nvfuser_next

### DIFF
--- a/python/nvfuser_direct/__init__.py
+++ b/python/nvfuser_direct/__init__.py
@@ -18,3 +18,95 @@ if pytorch_lib_dir not in sys.path:
 
 from . import _C_DIRECT  # noqa: F401,F403
 from ._C_DIRECT import *  # noqa: F401,F403
+
+
+class FusionDefinition:
+    """
+    A class for defining and executing fused operations in nvFuser.
+    This class provides a context manager interface for defining fused operations,
+    managing inputs/outputs, and executing the fusion with PyTorch tensors.
+    Examples
+    --------
+    >>> with FusionDefinition() as fd:
+    ...     t0 = fd.define_tensor()
+    ...     t1 = fd.ops.relu(t0)
+    ...     fd.add_output(t1)
+    >>> outputs = fd.execute([input_tensor])
+    """
+
+    def __init__(self):
+        """
+        Initialize a new FusionDefinition instance.
+        """
+        super(FusionDefinition, self).__init__()
+        # Monkey patching nvfuser_direct.ops submodule to mimic python_frontend
+        # FusionDefinition.ops API. This is to maintain backwards compatibilty.
+        self.ops = _C_DIRECT.ops
+        self.fusion = _C_DIRECT.Fusion()
+        self.fusion_guard = None
+
+    def __enter__(self):
+        """
+        Enter the context manager.
+        Returns
+        -------
+        FusionDefinition
+            The FusionDefinition instance
+        """
+        self.fusion_guard = _C_DIRECT.FusionGuard(self.fusion)
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        """
+        Exit the context manager and handle any exceptions.
+        This method is called when exiting the 'with' block, whether normally or due to an exception.
+        The arguments provide information about any exception that occurred:
+        Parameters
+        ----------
+        excecption_type : type or None
+            The type of the exception (e.g., ValueError, TypeError).
+            None if no exception occurred.
+        exception_value : Exception or None
+            The actual exception object.
+            None if no exception occurred.
+        exception_traceback : traceback or None
+            The traceback object containing the call stack.
+            None if no exception occurred.
+        """
+        self.fusion_guard = None
+        if exception_type is not None:
+            print(f"Exception occurred: {exception_type.__name__}: {exception_value}")
+            if exception_traceback is not None:
+                # Format the traceback and print it
+                print("Traceback (most recent call last):")
+                traceback.print_tb(exception_traceback)
+
+    def define_tensor(self, *args, **kwargs):
+        """
+        Define a new tensor input for the fusion.
+        Parameters
+        ----------
+        *args
+            Positional arguments passed to _C_DIRECT.define_tensor
+        **kwargs
+            Keyword arguments passed to _C_DIRECT.define_tensor
+        Returns
+        -------
+        Tensor
+            The defined tensor
+        """
+        tv = _C_DIRECT.define_tensor(*args, **kwargs)
+        self.fusion.add_input(tv)
+        return tv
+
+    def add_output(self, *args, **kwargs):
+        """
+        Add an output to the fusion.
+        Parameters
+        ----------
+        *args
+            Positional arguments passed to fusion.add_output
+        **kwargs
+            Keyword arguments passed to fusion.add_output
+        """
+        self.fusion.add_output(*args, **kwargs)

--- a/tests/python_direct/test_import.py
+++ b/tests/python_direct/test_import.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# Owner(s): ["module: nvfuser"]
+
+
+def test_import_correct():
+    try:
+        import nvfuser_direct  # noqa: F401
+    except Exception as e:
+        raise RuntimeError("Failed to import nvfuser_direct.")
+
+
+def test_import_conflict_direct_then_nvfuser():
+    try:
+        import nvfuser_direct  # noqa: F401
+        import nvfuser  # noqa: F401
+    except AssertionError as e:
+        expected_msg = (
+            "Cannot import nvfuser if nvfuser_direct module is already imported."
+        )
+        assert expected_msg in str(e)
+        return
+    raise AssertionError("Expected AssertionError from imports.")

--- a/tests/python_direct/test_python_direct.py
+++ b/tests/python_direct/test_python_direct.py
@@ -3,22 +3,50 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Owner(s): ["module: nvfuser"]
 
-
-def test_import_correct():
-    try:
-        import nvfuser_direct  # noqa: F401
-    except Exception as e:
-        raise RuntimeError("Failed to import nvfuser_direct.")
+from nvfuser_direct import FusionDefinition
 
 
-def test_import_conflict_direct_then_nvfuser():
-    try:
-        import nvfuser_direct  # noqa: F401
-        import nvfuser  # noqa: F401
-    except AssertionError as e:
-        expected_msg = (
-            "Cannot import nvfuser if nvfuser_direct module is already imported."
+def test_fusion_definition():
+    with FusionDefinition() as fd:
+        tv0 = fd.define_tensor(
+            shape=[2, 4, 8],
         )
-        assert expected_msg in str(e)
-        return
-    raise AssertionError("Expected AssertionError from imports.")
+        tv1 = fd.define_tensor(
+            shape=[2, 4, 8],
+        )
+        tv2 = fd.ops.add(tv0, tv1)
+        fd.add_output(tv2)
+
+    # Test fusion math representation
+    prescheduled_fusion_definition = """Inputs:
+  T0_g_float[iS0{2}, iS1{4}, iS2{8}]
+  T1_g_float[iS3{2}, iS4{4}, iS5{8}]
+Outputs:
+  T2_g_float[iS6{2}, iS7{4}, iS8{8}]
+
+%kernel_math {
+T2_g_float[iS6{2}, iS7{4}, iS8{8}]
+   = T0_g_float[iS0{2}, iS1{4}, iS2{8}]
+   + T1_g_float[iS3{2}, iS4{4}, iS5{8}];
+} // %kernel_math \n\n"""
+    assert fd.fusion.print_math() == prescheduled_fusion_definition
+
+    # Test TensorView string representation
+    assert str(tv0) == r"T0_g_float[iS0{2}, iS1{4}, iS2{8}]"
+    assert str(tv1) == r"T1_g_float[iS3{2}, iS4{4}, iS5{8}]"
+    assert str(tv2) == r"T2_g_float[iS6{2}, iS7{4}, iS8{8}]"
+
+    # Test TensorDomain string representation
+    assert str(tv0.domain()) == r"[iS0{2}, iS1{4}, iS2{8}]"
+    assert str(tv1.domain()) == r"[iS3{2}, iS4{4}, iS5{8}]"
+    assert str(tv2.domain()) == r"[iS6{2}, iS7{4}, iS8{8}]"
+
+    # Test IterDomain string representation
+    assert str(tv0.axis(0)) == r"iS0{2}"
+    assert str(tv1.axis(0)) == r"iS3{2}"
+    assert str(tv2.axis(0)) == r"iS6{2}"
+
+    # Test axis extents
+    assert str(tv0.axis(0).extent()) == r"2"
+    assert str(tv1.axis(0).extent()) == r"2"
+    assert str(tv2.axis(0).extent()) == r"2"

--- a/tests/python_direct/test_python_direct.py
+++ b/tests/python_direct/test_python_direct.py
@@ -6,7 +6,7 @@
 from nvfuser_direct import FusionDefinition
 
 
-def test_fusion_definition():
+def test_fusion_definition_print():
     with FusionDefinition() as fd:
         tv0 = fd.define_tensor(
             shape=[2, 4, 8],


### PR DESCRIPTION
This PR creates the python class `FusionDefinition` and adds `test_fusion_definition` to exercise the support Fusion Ir bindings.

PR Stack:
#4403 Create IterDomain, TensorDomain, and TensorView bindings
#4406 Add support for define_tensor
#4407 Add binding for Fusion IrContainer 
#4408 Create bindings for FusionDefinition and Add Binary op
#4409 Create python FusionDefinition for nvfuser_next **<<< This PR.**
#4513 Add bindings for FusionExecutorCache 