### PR TITLE
preferredLayout takes TensorView* instead of Val*.

### DIFF
--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -473,10 +473,7 @@ void AliasAnalysisResult::finalize() {
   }
 }
 
-Layout AliasAnalysisResult::preferredLayout(const Val* v) const {
-  const auto* tv = dynamic_cast<const TensorView*>(v);
-  NVF_ERROR(tv != nullptr, "`v` is expected to be a TensorView. Found: ", v);
-
+Layout AliasAnalysisResult::preferredLayout(const TensorView* tv) const {
   if (auto i = alias_to_source_.find(tv); i != alias_to_source_.end()) {
     return i->second.second;
   }

--- a/csrc/alias_analysis.h
+++ b/csrc/alias_analysis.h
@@ -61,7 +61,7 @@ class AliasAnalysisResult {
 
   // Returns the preferred layout. If `alias` is not in `alias_to_source_`,
   // returns the `TensorView`'s initial layout.
-  Layout preferredLayout(const Val* alias) const;
+  Layout preferredLayout(const TensorView* alias) const;
 
   std::string toString(int indent_size = 0) const;
 


### PR DESCRIPTION
It currently NVF_ERRORs TensorView* anyhow. This PR simply promotes that runtime check to a compile-time check, which is a strict improvement.