### PR TITLE
Fix a bug in tracing

### DIFF
--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -1108,7 +1108,7 @@ void initNvFuserPythonBindings(PyObject* module) {
           [](FusionDefinition& self) {
             self.finalizeDefinition();
             // Mark the end of a definition
-            inst::Trace::instance()->endEvent(nullptr);
+            inst::Trace::instance()->endEvent("FusionDefinition Definition");
           })
       .def(
           "_exist_schedule",


### PR DESCRIPTION
It should match the beginEvent in _setup_definition. 