### PR TITLE
Ring Allgather Pipelining with CudaIpc

### DIFF
--- a/tests/cpp/test_multidevice_host_ir_overlap.cpp
+++ b/tests/cpp/test_multidevice_host_ir_overlap.cpp
@@ -1172,7 +1172,7 @@ TEST_F(
 
   // Setting the DeviceMesh of the communication's I/O is artificial but
   // required at this point
-  DeviceMesh full_mesh(all_devices_);
+  DeviceMesh full_mesh(at::tensor(all_devices_));
   tva_j_curr_slice->setDeviceMesh(full_mesh);
   tva_j_next_slice->setDeviceMesh(full_mesh);
 

--- a/tests/cpp/test_multidevice_host_ir_overlap.cpp
+++ b/tests/cpp/test_multidevice_host_ir_overlap.cpp
@@ -1093,6 +1093,190 @@ TEST_F(
 
 TEST_F(
     RingAllgatherOverlapTest,
+    RingAllgatherBasedPipeliningHostIRImplementationCudaIpc) {
+  auto hic = std::make_unique<hir::HostIrContainer>();
+  FusionGuard::setCurFusion(hic.get());
+
+  TensorView* tva = makeSymbolicTensor(ta_.dim());
+  TensorView* tvb_unsharded = makeSymbolicTensor(tb_unsharded_.dim());
+  TensorView* tvc_unsharded = makeSymbolicTensor(tc_unsharded_.dim());
+  hic->addInput(tva);
+  hic->addInput(tvb_unsharded);
+  hic->addInput(tvc_unsharded);
+
+  auto* i = IrBuilder::create<Val>(DataType::Index); // for-loop running index
+  auto* start_i = hic->zeroVal();
+  auto* stop_i = tva->axis(1)->extent();
+  auto* step_i = hic->oneVal();
+  auto* for_loop_i = IrBuilder::create<ForLoop>(
+      /*IterDomain=*/tva->axis(1),
+      /*index=*/i,
+      start_i,
+      stop_i,
+      step_i,
+      /*vectorize=*/false,
+      /*vectorize_shift=*/nullptr,
+      /*unroll_required=*/false,
+      CircularBufferLoopStage::NotApplicable,
+      /*circular_buffer_loop_stage_depth=*/0);
+
+  auto* j = IrBuilder::create<Val>(DataType::Index);
+  auto* start_j = hic->zeroVal();
+  auto* stop_j = tva->axis(0)->extent();
+  auto* step_j = hic->oneVal();
+  auto* for_loop_j = IrBuilder::create<ForLoop>(
+      /*IterDomain=*/tva->axis(0),
+      /*index=*/j,
+      start_j,
+      stop_j,
+      step_j,
+      /*vectorize=*/false,
+      /*vectorize_shift=*/nullptr,
+      /*unroll_required=*/false,
+      CircularBufferLoopStage::NotApplicable,
+      /*circular_buffer_loop_stage_depth=*/0);
+
+  auto* stream_index =
+      mod(add(i, j), IrBuilder::create<Val>(params.number_of_streams));
+  auto* set_stream = IrBuilder::create<hir::SetCurrentStream>(
+      IrBuilder::create<hir::Stream>(stream_index));
+
+  auto* my_device_index_val = IrBuilder::create<Val>(my_device_index_);
+  auto* number_of_steps_per_ring_val =
+      IrBuilder::create<Val>(number_of_steps_per_ring_);
+
+  auto* send_rank = mod(
+      add(my_device_index_val, hic->oneVal()), number_of_steps_per_ring_val);
+  auto* recv_rank =
+      mod(add(number_of_steps_per_ring_val,
+              sub(my_device_index_val, hic->oneVal())),
+          number_of_steps_per_ring_val);
+
+  auto* slice_index =
+      mod(add(sub(my_device_index_val, j), number_of_steps_per_ring_val),
+          number_of_steps_per_ring_val);
+  auto* next_slice_index =
+      mod(add(sub(sub(my_device_index_val, j), hic->oneVal()),
+              number_of_steps_per_ring_val),
+          number_of_steps_per_ring_val);
+
+  TensorView* tmp1 = select(tva, 0, slice_index);
+  TensorView* tmp2 = select(tva, 0, next_slice_index);
+  TensorView* tmp3 = select(tvc_unsharded, 0, slice_index);
+  TensorView* tva_j_curr_slice = select(tmp1, 0, i);
+  TensorView* tva_j_next_slice = select(tmp2, 0, i);
+  TensorView* tvc_j = select(tmp3, 0, i);
+
+  auto* mm =
+      IrBuilder::create<MatmulOp>(tvc_j, tva_j_curr_slice, tvb_unsharded);
+
+  // Setting the DeviceMesh of the communication's I/O is artificial but
+  // required at this point
+  DeviceMesh full_mesh(all_devices_);
+  tva_j_curr_slice->setDeviceMesh(full_mesh);
+  tva_j_next_slice->setDeviceMesh(full_mesh);
+
+  auto* send = IrBuilder::create<P2PCommunication>(
+      P2PCommunicationType::SEND,
+      tva_j_curr_slice,
+      send_rank,
+      CommunicatorBackend::kCuda);
+  auto* recv = IrBuilder::create<P2PCommunication>(
+      P2PCommunicationType::RECV,
+      tva_j_next_slice,
+      recv_rank,
+      CommunicatorBackend::kCuda);
+  std::vector<P2PCommunication*> grouped_communications = {send, recv};
+  auto share_mem_handles = IrBuilder::create<hir::ShareMemHandles>(
+      std::move(grouped_communications));
+  auto* wait_send = IrBuilder::create<hir::Wait>(send);
+  auto* wait_recv = IrBuilder::create<hir::Wait>(recv);
+
+  auto* comm_cond = ne(j, sub(stop_j, hic->oneVal()));
+  auto* comm_predicate = IrBuilder::create<kir::Predicate>(comm_cond);
+  auto* if_not_last_ring_step_post_comms =
+      IrBuilder::create<kir::IfThenElse>(comm_predicate);
+  if_not_last_ring_step_post_comms->thenBody().push_back(send);
+  if_not_last_ring_step_post_comms->thenBody().push_back(recv);
+
+  auto* cond = ne(j, hic->zeroVal());
+  auto* wait_predicate = IrBuilder::create<kir::Predicate>(cond);
+  auto* if_not_first_ring_step_wait =
+      IrBuilder::create<kir::IfThenElse>(wait_predicate);
+  if_not_first_ring_step_wait->thenBody().push_back(wait_send);
+  if_not_first_ring_step_wait->thenBody().push_back(wait_recv);
+
+  std::vector<Expr*> loop_j_body = {
+      set_stream,
+      tmp1->definition(),
+      tmp2->definition(),
+      tmp3->definition(),
+      tva_j_curr_slice->definition(),
+      tva_j_next_slice->definition(),
+      tvc_j->definition(),
+      share_mem_handles,
+      if_not_first_ring_step_wait,
+      if_not_last_ring_step_post_comms,
+      mm};
+  for (Expr* expr : loop_j_body) {
+    for_loop_j->body().push_back(expr);
+  }
+  for_loop_i->body().push_back(for_loop_j);
+
+  hic->pushBackTopLevelExprs(for_loop_i);
+
+  // Synchronize all streams
+  auto* i_stream =
+      IrBuilder::create<Val>(DataType::Index); // running index of the for-loop
+  auto* start_stream = hic->zeroVal();
+  auto* stop_stream =
+      IrBuilder::create<Val>(params.number_of_streams, DataType::Index);
+  auto* step_stream = hic->oneVal();
+  auto* for_loop_stream = IrBuilder::create<ForLoop>(
+      /*IterDomain=*/makeContigConcreteTensor({params.number_of_streams})
+          ->axis(0),
+      /*index=*/i_stream,
+      start_stream,
+      stop_stream,
+      step_stream,
+      /*vectorize=*/false,
+      /*vectorize_shift=*/nullptr,
+      /*unroll_required=*/false,
+      CircularBufferLoopStage::NotApplicable,
+      /*circular_buffer_loop_stage_depth=*/0);
+  auto* sync_stream = IrBuilder::create<hir::Synchronize>(
+      IrBuilder::create<hir::Stream>(i_stream));
+  for_loop_stream->body().push_back(sync_stream);
+  hic->pushBackTopLevelExprs(for_loop_stream);
+
+  hic->addOutput(tmp1);
+  hic->addOutput(tmp2);
+  hic->addOutput(tmp3);
+  hic->addOutput(tva_j_curr_slice);
+  hic->addOutput(tva_j_next_slice);
+  hic->addOutput(tvc_j);
+
+  hir::HostIrEvaluator hie(std::move(hic), communicator_);
+
+  for ([[maybe_unused]] const auto& _  : arange(params.number_of_iterations)) {
+    // I don't know why but this seems necessary...
+    at::manual_seed(getATenRandomSeed());
+
+    initializeIO();
+
+    std::unordered_map<Val*, PolymorphicValue> inputs = {
+        {tva, ta_},
+        {tvb_unsharded, tb_unsharded_},
+        {tvc_unsharded, tc_unsharded_}};
+
+    hie.runWithInput(std::move(inputs));
+
+    validate();
+  }
+}
+
+TEST_F(
+    RingAllgatherOverlapTest,
     RingAllgatherBasedPipeliningHostIRImplementation) {
   auto hic = std::make_unique<hir::HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
@@ -1250,7 +1434,7 @@ TEST_F(
 
   hir::HostIrEvaluator hie(std::move(hic), communicator_);
 
-  for ([[maybe_unused]] const auto& _ : arange(params.number_of_iterations)) {
+  for ([[maybe_unused]] const auto& _  : arange(params.number_of_iterations)) {
     // I don't know why but this seems necessary...
     at::manual_seed(getATenRandomSeed());
 

--- a/tests/cpp/test_multidevice_host_ir_overlap.cpp
+++ b/tests/cpp/test_multidevice_host_ir_overlap.cpp
@@ -1094,6 +1094,10 @@ TEST_F(
 TEST_F(
     RingAllgatherOverlapTest,
     RingAllgatherBasedPipeliningHostIRImplementationCudaIpc) {
+  if (communicator_->size() == 1) {
+    GTEST_SKIP() << "Skipping test for single device";
+  }
+
   auto hic = std::make_unique<hir::HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
 

--- a/tests/cpp/test_multidevice_host_ir_overlap.cpp
+++ b/tests/cpp/test_multidevice_host_ir_overlap.cpp
@@ -1258,10 +1258,9 @@ TEST_F(
 
   hir::HostIrEvaluator hie(std::move(hic), communicator_);
 
-  for ([[maybe_unused]] const auto& _  : arange(params.number_of_iterations)) {
-    // I don't know why but this seems necessary...
-    at::manual_seed(getATenRandomSeed());
+  at::manual_seed(getATenRandomSeed());
 
+  for ([[maybe_unused]] const auto& _  : arange(params.number_of_iterations)) {
     initializeIO();
 
     std::unordered_map<Val*, PolymorphicValue> inputs = {
@@ -1434,7 +1433,7 @@ TEST_F(
 
   hir::HostIrEvaluator hie(std::move(hic), communicator_);
 
-  for ([[maybe_unused]] const auto& _  : arange(params.number_of_iterations)) {
+  for ([[maybe_unused]] const auto& _ : arange(params.number_of_iterations)) {
     // I don't know why but this seems necessary...
     at::manual_seed(getATenRandomSeed());
 

--- a/tests/cpp/test_multidevice_host_ir_overlap.cpp
+++ b/tests/cpp/test_multidevice_host_ir_overlap.cpp
@@ -1260,7 +1260,7 @@ TEST_F(
 
   at::manual_seed(getATenRandomSeed());
 
-  for ([[maybe_unused]] const auto& _  : arange(params.number_of_iterations)) {
+  for ([[maybe_unused]] const auto& _ : arange(params.number_of_iterations)) {
     initializeIO();
 
     std::unordered_map<Val*, PolymorphicValue> inputs = {


### PR DESCRIPTION
This PR adds a gtest for Ring Allgather Pipelining with CudaIpc. The code is similar to the existing test without CudaIpc, except that it will exchange the memhandles when necessary.