### PR TITLE
[CudaIpc] Make exchange handle's barrier truely blocking

### DIFF
--- a/csrc/multidevice/c10d_mock.h
+++ b/csrc/multidevice/c10d_mock.h
@@ -198,6 +198,8 @@ class TCPStore : public torch::CustomClassHolder {
   bool deleteKey(const std::string&) {
     return false;
   }
+
+  void wait(const std::vector<std::string>& keys) {}
 };
 
 } // namespace c10d


### PR DESCRIPTION
In this PR, we fix the inter-process synchronization during ipc handle exchange.
Fix bug https://gitlab-master.nvidia.com/dl/pytorch/fuser-gh-mirror/-/jobs/166923475#L818

### explanation:

In Ipc handle exchange, we use `communicator->barrier()` to synchronize processes between set/get to the `TCPStore`. However, since 1) the communicator doesn't use tcp transport and 2) `TCPStore::set` might return before the key is available for other rank's read, strong ordering is not ensured across ranks. Thanks @nsarka for helping me understand the issue
