### PR TITLE
Renames on matmul schedulers to prepare for Blackwell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,8 +238,8 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/scheduler/mark_aliases.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/matmul.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/multi_matmul.cpp
-  ${NVFUSER_SRCS_DIR}/scheduler/ampere_multi_matmul.cpp
-  ${NVFUSER_SRCS_DIR}/scheduler/hopper_multi_matmul.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/multi_matmul_ampere-.cpp
+  ${NVFUSER_SRCS_DIR}/scheduler/multi_matmul_hopper+.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/matmul_heuristic_plugin.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/matmul_utils.cpp
   ${NVFUSER_SRCS_DIR}/scheduler/mma_utils.cpp

--- a/csrc/scheduler/multi_matmul.cpp
+++ b/csrc/scheduler/multi_matmul.cpp
@@ -8,8 +8,8 @@
 
 #include <ATen/cuda/CUDAContext.h>
 #include <multidevice/utils.h>
-#include <scheduler/ampere_multi_matmul.h>
-#include <scheduler/hopper_multi_matmul.h>
+#include <scheduler/multi_matmul_ampere-.h>
+#include <scheduler/multi_matmul_hopper+.h>
 #include <scheduler/utils.h>
 
 namespace nvfuser {
@@ -142,9 +142,9 @@ void scheduleMultipleMatmuls(Fusion* fusion, const MatmulParams* params) {
   const auto device_prop = at::cuda::getCurrentDeviceProperties();
   const int cc = device_prop->major * 10 + device_prop->minor;
   if (cc >= 75 && cc < 90) {
-    AmpereMultipleMatmulScheduler(fusion, params).run();
-  } else if (cc >= 90 && cc < 100) {
-    HopperMultipleMatmulScheduler(fusion, params).run();
+    AmpereMinusMultipleMatmulScheduler(fusion, params).run();
+  } else if (cc >= 90 && cc < 110) {
+    HopperPlusMultipleMatmulScheduler(fusion, params).run();
   } else {
     NVF_THROW(
         "The matrix multiplication scheduler is unavailable for this device: ",

--- a/csrc/scheduler/multi_matmul.h
+++ b/csrc/scheduler/multi_matmul.h
@@ -16,8 +16,8 @@
 
 namespace nvfuser {
 
-// Base class for AmpereMultipleMatmulScheduler and
-// HopperMultipleMatmulScheduler
+// Base class for AmpereMinusMultipleMatmulScheduler and
+// HopperPlusMultipleMatmulScheduler
 class MultipleMatmulScheduler {
  public:
   MultipleMatmulScheduler(Fusion* fusion, const MatmulParams* params)

--- a/csrc/scheduler/multi_matmul_ampere-.cpp
+++ b/csrc/scheduler/multi_matmul_ampere-.cpp
@@ -10,11 +10,11 @@
 #include <id_model/schedule.h>
 #include <instrumentation.h>
 #include <ir/utils.h>
-#include <scheduler/multi_matmul_ampere-.h>
 #include <scheduler/debug_utils.h>
 #include <scheduler/matmul.h>
 #include <scheduler/matmul_utils.h>
 #include <scheduler/mma_utils.h>
+#include <scheduler/multi_matmul_ampere-.h>
 #include <scheduler/tools/abstract_tensor.h>
 #include <scheduler/tools/inlining.h>
 #include <scheduler/utils.h>

--- a/csrc/scheduler/multi_matmul_ampere-.h
+++ b/csrc/scheduler/multi_matmul_ampere-.h
@@ -63,11 +63,11 @@ namespace nvfuser {
 //
 // Each of the named tensors above is scheduled differently. We schedule them
 // by building AbstractTensors for each tensor category; these are held in
-// AmpereMultipleMatmulScheduler::schedules_.
+// AmpereMinusMultipleMatmulScheduler::schedules_.
 // TODO: Inherit from SchedulerEntry
-class AmpereMultipleMatmulScheduler : public MultipleMatmulScheduler {
+class AmpereMinusMultipleMatmulScheduler : public MultipleMatmulScheduler {
  public:
-  AmpereMultipleMatmulScheduler(Fusion* fusion, const MatmulParams* params)
+  AmpereMinusMultipleMatmulScheduler(Fusion* fusion, const MatmulParams* params)
       : MultipleMatmulScheduler(fusion, params) {
     validate();
   }

--- a/csrc/scheduler/multi_matmul_hopper+.cpp
+++ b/csrc/scheduler/multi_matmul_hopper+.cpp
@@ -11,11 +11,11 @@
 #include <instrumentation.h>
 #include <ir/utils.h>
 #include <scheduler/debug_utils.h>
-#include <scheduler/multi_matmul_hopper+.h>
 #include <scheduler/matmul.h>
 #include <scheduler/matmul_heuristic.h>
 #include <scheduler/matmul_utils.h>
 #include <scheduler/mma_utils.h>
+#include <scheduler/multi_matmul_hopper+.h>
 #include <scheduler/tools/abstract_tensor.h>
 #include <scheduler/tools/inlining.h>
 #include <scheduler/utils.h>
@@ -96,7 +96,8 @@ void HopperPlusMultipleMatmulScheduler::transformLikeMmaOutputWithoutK(
   // After Parallelize: [..., Mo * No (TIDy), Mw, Nw, Mi, Ni]
 }
 
-MatmulDimRole HopperPlusMultipleMatmulScheduler::findMatmulDimRole(IterDomain* id) {
+MatmulDimRole HopperPlusMultipleMatmulScheduler::findMatmulDimRole(
+    IterDomain* id) {
   ValGroup vg = graph_->toGroup(id);
   auto it = id_roles_.find(vg);
   NVF_ERROR(it != id_roles_.end());

--- a/csrc/scheduler/multi_matmul_hopper+.cpp
+++ b/csrc/scheduler/multi_matmul_hopper+.cpp
@@ -11,7 +11,7 @@
 #include <instrumentation.h>
 #include <ir/utils.h>
 #include <scheduler/debug_utils.h>
-#include <scheduler/hopper_multi_matmul.h>
+#include <scheduler/multi_matmul_hopper+.h>
 #include <scheduler/matmul.h>
 #include <scheduler/matmul_heuristic.h>
 #include <scheduler/matmul_utils.h>
@@ -30,7 +30,7 @@
 
 namespace nvfuser {
 
-void HopperMultipleMatmulScheduler::transformLikeMmaOutputWithK(
+void HopperPlusMultipleMatmulScheduler::transformLikeMmaOutputWithK(
     TensorView* tv) {
   NVF_ERROR(tv->axis(-1)->isReduction(), "Inner axis should be Reduction.");
   // The input is originally block tiled so that the inner dims are the CTA tile
@@ -64,7 +64,7 @@ void HopperMultipleMatmulScheduler::transformLikeMmaOutputWithK(
   // After Parallelize: [..., Mo * No (TIDy), Mw, Nw, Kw, Mi, Ni, Ki]
 }
 
-void HopperMultipleMatmulScheduler::transformLikeMmaOutputWithoutK(
+void HopperPlusMultipleMatmulScheduler::transformLikeMmaOutputWithoutK(
     TensorView* tv) {
   NVF_ERROR(
       tv->domain()->loop().size() >= 4,
@@ -96,37 +96,36 @@ void HopperMultipleMatmulScheduler::transformLikeMmaOutputWithoutK(
   // After Parallelize: [..., Mo * No (TIDy), Mw, Nw, Mi, Ni]
 }
 
-MatmulDimRole HopperMultipleMatmulScheduler::findMatmulDimRole(IterDomain* id) {
+MatmulDimRole HopperPlusMultipleMatmulScheduler::findMatmulDimRole(IterDomain* id) {
   ValGroup vg = graph_->toGroup(id);
   auto it = id_roles_.find(vg);
   NVF_ERROR(it != id_roles_.end());
   return it->second;
 }
 
-void HopperMultipleMatmulScheduler::validate() const {
+void HopperPlusMultipleMatmulScheduler::validate() const {
   const auto device_prop = at::cuda::getCurrentDeviceProperties();
   const int cc = device_prop->major * 10 + device_prop->minor;
-  NVF_ERROR(
-      cc >= 90 && cc < 100, "This matmul scheduler is restricted to Hopper.");
+  NVF_ERROR(cc >= 90, "This matmul scheduler is restricted to Hopper.");
 
   if (params_->tiling_strategy != MatmulParams::TilingStrategy::OneTilePerCTA) {
     NVF_CHECK(
         params_->splitk_factor == 1,
-        "Hopper matmul scheduler does not support scheduling persistent split-K kernels");
+        "Hopper+ matmul scheduler does not support scheduling persistent split-K kernels");
   }
 
   NVF_CHECK(
       params_->tiling_strategy !=
           MatmulParams::TilingStrategy::DistributeStagesAcrossSMs,
-      "Hopper matmul scheduler does not support distributing stages across SMs a la stream-K");
+      "Hopper+ matmul scheduler does not support distributing stages across SMs a la stream-K");
 
   NVF_CHECK(
       params_->buffering_loop_level ==
           MatmulParams::BufferingLoopLevel::CTATiles,
-      "Hopper matmul scheduler only supports cooperatively buffering at the CTA level (no ping-pong)");
+      "Hopper+ matmul scheduler only supports cooperatively buffering at the CTA level (no ping-pong)");
 }
 
-void HopperMultipleMatmulScheduler::run() {
+void HopperPlusMultipleMatmulScheduler::run() {
   // Finds matmul patterns and translates them to MmaOps, then finds tensor
   // and dimension roles for all tensors in the fusion
   findPatterns();
@@ -169,7 +168,7 @@ void HopperMultipleMatmulScheduler::run() {
   setUpCircularBuffering();
 }
 
-void HopperMultipleMatmulScheduler::reorderBlockTileTraversal(
+void HopperPlusMultipleMatmulScheduler::reorderBlockTileTraversal(
     TensorView* tv,
     std::vector<MatmulDimRole>& outer_dim_roles) {
   NVF_ERROR(params_->grid_traversal_factor.first >= 1);
@@ -320,7 +319,7 @@ void HopperMultipleMatmulScheduler::reorderBlockTileTraversal(
   }
 }
 
-std::vector<std::vector<MatmulDimRole>> HopperMultipleMatmulScheduler::
+std::vector<std::vector<MatmulDimRole>> HopperPlusMultipleMatmulScheduler::
     blockTileTensors(const std::vector<TensorView*>& tvs) {
   if (canonical_dim_ordering_.empty()) {
     canonical_dim_ordering_ =
@@ -410,7 +409,7 @@ std::vector<std::vector<MatmulDimRole>> HopperMultipleMatmulScheduler::
   return all_merged_roles;
 }
 
-void HopperMultipleMatmulScheduler::inspectPrologues() const {
+void HopperPlusMultipleMatmulScheduler::inspectPrologues() const {
   for (TensorView* mma_result : mma_results_) {
     for (Val* v : mma_result->definition()->inputs()) {
       TensorView* op_input = v->as<TensorView>();
@@ -427,10 +426,10 @@ void HopperMultipleMatmulScheduler::inspectPrologues() const {
   }
 }
 
-void HopperMultipleMatmulScheduler::scheduleOperands() {
+void HopperPlusMultipleMatmulScheduler::scheduleOperands() {
   NVF_CHECK(
       params_->async_gmem_load_operands,
-      "Hopper matmul scheduler currently requires TMA to be enabled");
+      "Hopper+ matmul scheduler currently requires TMA to be enabled");
   auto scheduleBranch = [&](const std::vector<TensorView*>& gmem_operands,
                             const std::vector<TensorView*>& smem_operands,
                             MmaOperand operand_type) {
@@ -449,7 +448,7 @@ void HopperMultipleMatmulScheduler::scheduleOperands() {
   scheduleBranch(bs_, bcw_smems_, MmaOperand::B);
 }
 
-void HopperMultipleMatmulScheduler::parallelizeBlocks(
+void HopperPlusMultipleMatmulScheduler::parallelizeBlocks(
     const std::vector<TensorView*>& tvs) const {
   for (TensorView* tv : tvs) {
     switch (params_->tiling_strategy) {
@@ -485,11 +484,11 @@ void HopperMultipleMatmulScheduler::parallelizeBlocks(
   }
 }
 
-void HopperMultipleMatmulScheduler::scheduleMmaResults() {
+void HopperPlusMultipleMatmulScheduler::scheduleMmaResults() {
   GemmTile instruction_tile = getMmaOpShape(params_->mma_macro);
   NVF_CHECK(
       params_->tile_sizes.cta_tile.k == params_->tile_sizes.warp_tile.k,
-      "CTA tile must match warp tile K dimension for Hopper matmul but found ",
+      "CTA tile must match warp tile K dimension for Hopper+ matmul but found ",
       toString(params_->tile_sizes));
   // If cta_tile is not divisible by instruction tile the mma instruction will
   // be predicated.
@@ -548,7 +547,7 @@ void HopperMultipleMatmulScheduler::scheduleMmaResults() {
   }
 }
 
-void HopperMultipleMatmulScheduler::scheduleEpilogue() {
+void HopperPlusMultipleMatmulScheduler::scheduleEpilogue() {
   std::vector<TensorView*> cached_tvs;
   // Apply LdMatrix to any epilogue inputs loaded to smem with TMA.
   std::vector<TensorView*> tma_load_epilogue_inputs;
@@ -757,7 +756,7 @@ void HopperMultipleMatmulScheduler::scheduleEpilogue() {
   }
 }
 
-void HopperMultipleMatmulScheduler::scheduleSplitKSum() {
+void HopperPlusMultipleMatmulScheduler::scheduleSplitKSum() {
   if (params_->splitk_factor == 1) {
     return;
   }
@@ -773,7 +772,7 @@ void HopperMultipleMatmulScheduler::scheduleSplitKSum() {
   }
 }
 
-void HopperMultipleMatmulScheduler::setUpInlining() {
+void HopperPlusMultipleMatmulScheduler::setUpInlining() {
   // auto inline for all tensors except register tensors
   std::unordered_set<TensorView*> smem_loads_and_mma_inputs;
   inlineMost(ir_utils::allTvsExcept(fusion_, smem_loads_and_mma_inputs));
@@ -788,7 +787,7 @@ void HopperMultipleMatmulScheduler::setUpInlining() {
   }
 }
 
-void HopperMultipleMatmulScheduler::setUpCircularBuffering() {
+void HopperPlusMultipleMatmulScheduler::setUpCircularBuffering() {
   // Propagate mma output swizzle and parallelization down the DAG
   if (params_->circular_buffer_options.circular_buffer_smem_write) {
     NVF_ERROR(
@@ -868,7 +867,7 @@ void HopperMultipleMatmulScheduler::setUpCircularBuffering() {
     }
   }
 
-  // NOTE: circular_buffer_smem_read is ignored for Hopper matmul since we do
+  // NOTE: circular_buffer_smem_read is ignored for Hopper+ matmul since we do
   // not do any cache reads
 
   /*
@@ -889,7 +888,7 @@ void HopperMultipleMatmulScheduler::setUpCircularBuffering() {
   */
 }
 
-void HopperMultipleMatmulScheduler::setOperandSmemLoadAndCacheOps(
+void HopperPlusMultipleMatmulScheduler::setOperandSmemLoadAndCacheOps(
     TensorView* operand,
     int64_t vec_size) {
   auto* lsop = operand->definition()->as<LoadStoreOp>();

--- a/csrc/scheduler/multi_matmul_hopper+.h
+++ b/csrc/scheduler/multi_matmul_hopper+.h
@@ -64,11 +64,11 @@ namespace nvfuser {
 //
 // Each of the named tensors above is scheduled differently. We schedule them
 // by building AbstractTensors for each tensor category; these are held in
-// HopperMultipleMatmulScheduler::schedules_.
+// HopperPlusMultipleMatmulScheduler::schedules_.
 // TODO: Inherit from SchedulerEntry
-class HopperMultipleMatmulScheduler : public MultipleMatmulScheduler {
+class HopperPlusMultipleMatmulScheduler : public MultipleMatmulScheduler {
  public:
-  HopperMultipleMatmulScheduler(Fusion* fusion, const MatmulParams* params)
+  HopperPlusMultipleMatmulScheduler(Fusion* fusion, const MatmulParams* params)
       : MultipleMatmulScheduler(fusion, params) {
     validate();
   }

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3248,7 +3248,9 @@ TEST_F(MatmulSchedulerTest, OperandOrderIssue2434) {
   NVF_CHECK(at::allclose(cg_outputs[0].as<at::Tensor>(), tref, 0.0001, 0.0001));
 }
 
-using HopperMatmulSchedulerTestParams = std::tuple<
+// Matmul test for Hopper+ (Hopper, Blackwell)
+
+using HopperPlusMatmulSchedulerTestParams = std::tuple<
     bool, // use_smem_epilogue
     bool, // a_k_inner
     bool, // b_k_inner
@@ -3259,8 +3261,8 @@ using HopperMatmulSchedulerTestParams = std::tuple<
     int64_t // SplitK Factor
     >;
 
-std::string hopperTestName(
-    const testing::TestParamInfo<HopperMatmulSchedulerTestParams>& info) {
+std::string hopperPlusTestName(
+    const testing::TestParamInfo<HopperPlusMatmulSchedulerTestParams>& info) {
   std::ostringstream os;
   bool use_smem_epilogue;
   bool a_k_inner, b_k_inner;
@@ -3290,26 +3292,29 @@ std::string hopperTestName(
 }
 
 std::string hopperTestNameSwizzle(
-    const testing::TestParamInfo<HopperMatmulSchedulerTestParams>& info) {
+    const testing::TestParamInfo<HopperPlusMatmulSchedulerTestParams>& info) {
   std::unordered_map<MmaMacro, std::string> mma_macro_to_swizzle_str_map = {
       {MmaMacro::Hopper_64_256_16, "128BSwizzle"},
       {MmaMacro::Hopper_64_128_16, "128BSwizzle"},
       {MmaMacro::Hopper_64_64_16, "128BSwizzle"},
       {MmaMacro::Hopper_64_32_16, "64BSwizzle"},
-      {MmaMacro::Hopper_64_16_16, "32BSwizzle"}};
+      {MmaMacro::Hopper_64_16_16, "32BSwizzle"},
+      {MmaMacro::Blackwell_128_256_16, "128BSwizzle"},
+      {MmaMacro::Blackwell_128_128_16, "128BSwizzle"},
+      {MmaMacro::Blackwell_128_64_16, "128BSwizzle"},
+      {MmaMacro::Blackwell_128_32_16, "64BSwizzle"},
+      {MmaMacro::Blackwell_128_16_16, "32BSwizzle"}};
   MmaMacro mma_macro = std::get<6>(info.param);
   std::ostringstream os;
-  os << hopperTestName(info);
+  os << hopperPlusTestName(info);
   os << "_" << mma_macro_to_swizzle_str_map.at(mma_macro);
   return os.str();
 }
 
-class HopperMatmulSchedulerTest
-    : public NVFuserFixtureParamTest<HopperMatmulSchedulerTestParams> {
+class HopperPlusMatmulSchedulerTest
+    : public NVFuserFixtureParamTest<HopperPlusMatmulSchedulerTestParams> {
  protected:
   void SetUp() {
-    NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(9, 0, 10, 0);
-
     std::tie(
         use_smem_epilogue,
         a_k_inner,
@@ -3319,6 +3324,7 @@ class HopperMatmulSchedulerTest
         K,
         mma_macro,
         splitk_factor) = GetParam();
+    NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(9, 0, 10, 0);
 
     if (a_k_inner) {
       layout = b_k_inner ? MmaLayout::TN : MmaLayout::TT;
@@ -3395,7 +3401,7 @@ class HopperMatmulSchedulerTest
   at::Tensor tref;
 };
 
-TEST_P(HopperMatmulSchedulerTest, FusedMultiplySum) {
+TEST_P(HopperPlusMatmulSchedulerTest, FusedMultiplySum) {
   const auto& [A, B] =
       matmulAtInput3DSS(M, N, K, layout, data_type_to_aten(dtype));
   inputs = {A, B};
@@ -3453,7 +3459,7 @@ TEST_P(HopperMatmulSchedulerTest, FusedMultiplySum) {
 
 // TODO: Remove this test once the architecture agnostic can be
 // run on hopper.
-TEST_P(HopperMatmulSchedulerTest, FusedMultiplySumBiasNeg) {
+TEST_P(HopperPlusMatmulSchedulerTest, FusedMultiplySumBiasNeg) {
   const auto& [A, B] =
       matmulAtInput3DSS(M, N, K, layout, data_type_to_aten(dtype));
   const auto& C = matmulAtInput2D(
@@ -3522,7 +3528,7 @@ TEST_P(HopperMatmulSchedulerTest, FusedMultiplySumBiasNeg) {
 
 INSTANTIATE_TEST_SUITE_P(
     General,
-    HopperMatmulSchedulerTest,
+    HopperPlusMatmulSchedulerTest,
     testing::Combine(
         testing::Bool(), // use_smem_epilogue
         testing::Bool(), // a_k_inner
@@ -3530,14 +3536,14 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(512), // M
         testing::Values(256), // N
         testing::Values(128), // K
-        testing::Values(MmaMacro::Hopper_64_128_16), // mma_macros
+        testing::Values(MmaMacro::Hopper_64_128_16, MmaMacro::Blackwell_128_128_16), // mma_macros
         testing::Values(1, 2) // SplitK Factor
         ),
-    hopperTestName);
+    hopperPlusTestName);
 
 INSTANTIATE_TEST_SUITE_P(
     Swizzle,
-    HopperMatmulSchedulerTest,
+    HopperPlusMatmulSchedulerTest,
     testing::Combine(
         testing::Values(true), // use_smem_epilogue
         testing::Bool(), // a_k_inner
@@ -3550,9 +3556,14 @@ INSTANTIATE_TEST_SUITE_P(
             MmaMacro::Hopper_64_128_16,
             MmaMacro::Hopper_64_64_16,
             MmaMacro::Hopper_64_32_16,
-            MmaMacro::Hopper_64_16_16), // mma_macros
+            MmaMacro::Hopper_64_16_16,
+            MmaMacro::Blackwell_128_256_16,
+            MmaMacro::Blackwell_128_128_16,
+            MmaMacro::Blackwell_128_64_16,
+            MmaMacro::Blackwell_128_32_16,
+            MmaMacro::Blackwell_128_16_16), // mma_macros
         testing::Values(1) // SplitK Factor
         ),
-    hopperTestNameSwizzle);
+    hopperPlusTestNameSwizzle);
 
 } // namespace nvfuser

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3291,7 +3291,7 @@ std::string hopperPlusTestName(
   return os.str();
 }
 
-std::string hopperTestNameSwizzle(
+std::string hopperPlusTestNameSwizzle(
     const testing::TestParamInfo<HopperPlusMatmulSchedulerTestParams>& info) {
   std::unordered_map<MmaMacro, std::string> mma_macro_to_swizzle_str_map = {
       {MmaMacro::Hopper_64_256_16, "128BSwizzle"},
@@ -3299,11 +3299,11 @@ std::string hopperTestNameSwizzle(
       {MmaMacro::Hopper_64_64_16, "128BSwizzle"},
       {MmaMacro::Hopper_64_32_16, "64BSwizzle"},
       {MmaMacro::Hopper_64_16_16, "32BSwizzle"},
-      {MmaMacro::Blackwell_128_256_16, "128BSwizzle"},
-      {MmaMacro::Blackwell_128_128_16, "128BSwizzle"},
-      {MmaMacro::Blackwell_128_64_16, "128BSwizzle"},
-      {MmaMacro::Blackwell_128_32_16, "64BSwizzle"},
-      {MmaMacro::Blackwell_128_16_16, "32BSwizzle"}};
+      {MmaMacro::Blackwell1CTA_128_256_16, "128BSwizzle"},
+      {MmaMacro::Blackwell1CTA_128_128_16, "128BSwizzle"},
+      {MmaMacro::Blackwell1CTA_128_64_16, "128BSwizzle"},
+      {MmaMacro::Blackwell1CTA_128_32_16, "64BSwizzle"},
+      {MmaMacro::Blackwell1CTA_128_16_16, "32BSwizzle"}};
   MmaMacro mma_macro = std::get<6>(info.param);
   std::ostringstream os;
   os << hopperPlusTestName(info);
@@ -3538,7 +3538,7 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(128), // K
         testing::Values(
             MmaMacro::Hopper_64_128_16,
-            MmaMacro::Blackwell_128_128_16), // mma_macros
+            MmaMacro::Blackwell1CTA_128_128_16), // mma_macros
         testing::Values(1, 2) // SplitK Factor
         ),
     hopperPlusTestName);
@@ -3559,11 +3559,11 @@ INSTANTIATE_TEST_SUITE_P(
             MmaMacro::Hopper_64_64_16,
             MmaMacro::Hopper_64_32_16,
             MmaMacro::Hopper_64_16_16,
-            MmaMacro::Blackwell_128_256_16,
-            MmaMacro::Blackwell_128_128_16,
-            MmaMacro::Blackwell_128_64_16,
-            MmaMacro::Blackwell_128_32_16,
-            MmaMacro::Blackwell_128_16_16), // mma_macros
+            MmaMacro::Blackwell1CTA_128_256_16,
+            MmaMacro::Blackwell1CTA_128_128_16,
+            MmaMacro::Blackwell1CTA_128_64_16,
+            MmaMacro::Blackwell1CTA_128_32_16,
+            MmaMacro::Blackwell1CTA_128_16_16), // mma_macros
         testing::Values(1) // SplitK Factor
         ),
     hopperPlusTestNameSwizzle);

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3324,7 +3324,13 @@ class HopperPlusMatmulSchedulerTest
         K,
         mma_macro,
         splitk_factor) = GetParam();
-    NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(9, 0, 10, 0);
+
+    if (isHopper(mma_macro)) {
+      NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(9, 0, 10, 0);
+    } else {
+      NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(10, 0, 11, 0);
+      GTEST_SKIP() << "Blackwell tests are not supported yet";
+    }
 
     if (a_k_inner) {
       layout = b_k_inner ? MmaLayout::TN : MmaLayout::TT;

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3536,7 +3536,9 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(512), // M
         testing::Values(256), // N
         testing::Values(128), // K
-        testing::Values(MmaMacro::Hopper_64_128_16, MmaMacro::Blackwell_128_128_16), // mma_macros
+        testing::Values(
+            MmaMacro::Hopper_64_128_16,
+            MmaMacro::Blackwell_128_128_16), // mma_macros
         testing::Values(1, 2) // SplitK Factor
         ),
     hopperPlusTestName);


### PR DESCRIPTION
Renames:
- Ampere -> Ampere- (Turing & Ampere)
- Hopper -> Hopper+ (Hopper & Blackwell)

I am planning to use the same class for Hopper and Blackwell, because I expect the scheduling to be mostly the same.