### PR TITLE
Fix sinh_libtorch build error

### DIFF
--- a/csrc/id_model/to_string.h
+++ b/csrc/id_model/to_string.h
@@ -15,23 +15,21 @@
 
 namespace nvfuser {
 
-std::string toString(const std::vector<Val*>& val_group, int indent_size = 0);
+std::string NVF_API
+toString(const std::vector<Val*>& val_group, int indent_size = 0);
 
-std::string toString(
-    const std::vector<IterDomain*>& id_group,
-    int indent_size = 0);
+std::string NVF_API
+toString(const std::vector<IterDomain*>& id_group, int indent_size = 0);
 
-std::string toString(
-    const ValGroup& id_group,
-    int indent_size = 0,
-    bool with_ptr = false);
+std::string NVF_API
+toString(const ValGroup& id_group, int indent_size = 0, bool with_ptr = false);
 
-std::string toString(
+std::string NVF_API toString(
     const std::vector<ValGroup>& id_groups,
     int indent_size = 0,
     bool with_ptr = false);
 
-std::string toString(
+std::string NVF_API toString(
     const ValGroups& id_groups,
     int indent_size = 0,
     bool with_ptr = false);
@@ -39,29 +37,30 @@ std::string toString(
 std::string toInlineString(const std::vector<ValGroup>& id_groups);
 std::string toInlineString(const ValGroups& id_groups);
 
-std::string toString(const std::vector<Expr*>& expr_group, int indent_size = 0);
-std::string toString(
+std::string NVF_API
+toString(const std::vector<Expr*>& expr_group, int indent_size = 0);
+std::string NVF_API toString(
     const ExprGroup& expr_group,
     int indent_size = 0,
     bool with_ptr = false);
 
-std::string toString(
+std::string NVF_API toString(
     const ValGraph& id_graph,
     const std::vector<Expr*>& expr_group,
     int indent_size = 0,
     bool with_ptr = false);
-std::string toString(
+std::string NVF_API toString(
     const ValGraph& id_graph,
     const ExprGroup& expr_groups,
     int indent_size = 0,
     bool with_ptr = false);
 
-std::string toString(
+std::string NVF_API toString(
     const ValGraph& id_graph,
     const std::vector<ExprGroup>& expr_groups,
     int indent_size = 0,
     bool with_ptr = false);
-std::string toString(
+std::string NVF_API toString(
     const ValGraph& id_graph,
     const ExprGroups& expr_groups,
     int indent_size = 0,

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -56,7 +56,7 @@ using ValGroups = VectorOfUniqueEntries<ValGroup>;
 using ExprGroup = std::shared_ptr<VectorOfUniqueEntries<Expr*>>;
 using ExprGroups = VectorOfUniqueEntries<ExprGroup>;
 
-class ValGraph {
+class NVF_API ValGraph {
  public:
   ValGraph() = default;
 


### PR DESCRIPTION
~Don't know why but these change seem to eliminate link errors with sinh_libtorch~.

It's probably due to these two lines:

https://github.com/NVIDIA/Fuser/pull/4390/files#diff-3b542a1c1dfdbad787cd9dcda9961a37a9c2e0e5a3e4b19cebb46600ef2c4f7cR13-R14
```
#include <val_graph.h>
#include <val_graph_visitor.h>
```