### PR TITLE
Support Independent Compute Warp Groups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -644,6 +644,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_compute_at_map.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_compute_with.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_circular_buffering.cpp
+  ${NVFUSER_ROOT}/tests/cpp/test_circular_buffering_ping_pong.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_abstract_tensor.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_driver_api.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_dynamic_transform.cpp

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -422,7 +422,7 @@ void CircularBufferInfo::setCircularBufferInsertionPosition(
 
   NVF_ERROR(
       inner_most_circular_buffer_position < circular_buffer_tv->nDims(),
-      "Expected inner_most_circular_buffer_position <= number of tensor dimensions",
+      "Expected inner_most_circular_buffer_position <= number of tensor dimensions ",
       "but got ",
       inner_most_circular_buffer_position,
       " and ",
@@ -431,7 +431,7 @@ void CircularBufferInfo::setCircularBufferInsertionPosition(
   NVF_ERROR(
       outer_most_circular_buffer_position <=
           inner_most_circular_buffer_position,
-      "Expected outer_most_circular_buffer_position <= inner_most_circular_buffer_position",
+      "Expected outer_most_circular_buffer_position <= inner_most_circular_buffer_position ",
       "but got ",
       outer_most_circular_buffer_position,
       " and ",
@@ -519,8 +519,7 @@ Val* CircularBufferInfo::getLinearIndexRelativeForLoopStack(
     // Skip parallelized axes except for warp specialized dim
     // when warp specialized dim is used in computation branch,
     // it represents index of computation warp groups.
-    if (id->isParallelized() &&
-        (id->getParallelType() != getWarpSpecializedOn())) {
+    if (id->isThread() && (id->getParallelType() != getWarpSpecializedOn())) {
       continue;
     }
     index = SimplifyingIrBuilder::addExpr(

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -552,7 +552,7 @@ Val* CircularBufferInfo::getLinearIndexRelativeForLoopStack(
     // Skip parallelized axes except for warp specialized dim
     // when warp specialized dim is used in computation branch,
     // it represents index of computation warp groups.
-    if (id->isThread() && (id->getParallelType() != getWarpSpecializedOn())) {
+    if (id->isThread() && (id->getParallelType() != warp_specialized_on_)) {
       continue;
     }
     index = SimplifyingIrBuilder::addExpr(

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -410,11 +410,14 @@ void CircularBufferInfo::setCircularBufferInsertionPosition(
   int64_t outer_most_circular_buffer_position =
       getOuterMostCircularBufferPosition(circular_buffer_tv);
 
-  // The inner_most position is the first serial iterDomain to the left of the
-  // ComputeAt position. It can be specified in WarpSpecialized options.
+  // The default inner_most position is the first serial iterDomain to the left
+  // of the ComputeAt position. It can be specified in WarpSpecialized options.
+  // stage_slice_position is an inclusive range from
+  // [stage_slice_position, num_dimensions), so it corresponding for-loop is
+  // stage_slice_position - 1.
   int64_t inner_most_circular_buffer_position =
       (warp_specialized.stage_slice_position.has_value())
-      ? warp_specialized.stage_slice_position.value()
+      ? warp_specialized.stage_slice_position.value() - 1
       : getInnerMostCircularBufferPosition(circular_buffer_tv);
 
   NVF_ERROR(

--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -67,10 +67,6 @@ class CircularBufferInfo {
     return independent_compute_warp_groups_;
   }
 
-  ParallelType getWarpSpecializedOn() const {
-    return warp_specialized_on_;
-  }
-
   //! Returns true if the iterdomain will be realized
   //!  as a circular buffer loop.
   bool isCircularBufferedIterDomain(IterDomain* id);

--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -62,6 +62,11 @@ class CircularBufferInfo {
 
   Val* getOriginalAllocSize(const TensorView* tv);
 
+  // Returns true if the warp groups run independently.
+  bool hasIndependentComputeWarpGroups() const {
+    return independent_compute_warp_groups_;
+  }
+
   ParallelType getWarpSpecializedOn() const {
     return warp_specialized_on_;
   }
@@ -143,6 +148,10 @@ class CircularBufferInfo {
   //! The warp specialized axis for circular buffering.
   //! Only one warp specialized axis for the fusion.
   ParallelType warp_specialized_on_ = ParallelType::Serial;
+  //! If false, then the mbarrier in the ComputeWarp should be for all threads
+  //! in ComputeWarp. Otherwise, it is per warp-group or 128 threads. It is True
+  //! if the warp specialized axis is to the left of the stage_slice_position.
+  bool independent_compute_warp_groups_ = false;
 };
 
 } // namespace nvfuser

--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -62,12 +62,16 @@ class CircularBufferInfo {
 
   Val* getOriginalAllocSize(const TensorView* tv);
 
+  ParallelType getWarpSpecializedOn() const {
+    return warp_specialized_on_;
+  }
+
   //! Returns true if the iterdomain will be realized
   //!  as a circular buffer loop.
   bool isCircularBufferedIterDomain(IterDomain* id);
   //! Returns true if the fusion has warp specialized circular buffer
-  const bool& hasWarpSpecialized() const {
-    return has_warp_sepcialized_;
+  bool hasWarpSpecialized() const {
+    return warp_specialized_on_ != ParallelType::Serial;
   };
   //! Get the circular buffer options for the given axis.
   const CircularBufferOptions& getCircularBufferOptionsFor(
@@ -136,8 +140,9 @@ class CircularBufferInfo {
   //! iterdomains.
   std::unordered_map<IterDomain*, std::unordered_set<const TensorView*>>
       circular_buffer_tvs_;
-  //! True if the fusion has warp specialized circular buffer
-  bool has_warp_sepcialized_ = false;
+  //! The warp specialized axis for circular buffering.
+  //! Only one warp specialized axis for the fusion.
+  ParallelType warp_specialized_on_ = ParallelType::Serial;
 };
 
 } // namespace nvfuser

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -1004,14 +1004,18 @@ class CloneTmaCircularBufferLoopAndInsertSync
         GpuLower::current()->consumerToTMAInfo().at(consumer_tv);
     Val* expected_bytes = tma_info.tileSizeBytes();
 
+    const auto& warp_specialized =
+        std::get<WarpSpecialized>(consumer_tv->circularBufferOptions().type);
+    size_t start_idx = (warp_specialized.stage_slice_position.has_value())
+        ? warp_specialized.stage_slice_position.value()
+        : consumer_tv->getComputeAtPosition();
+
     // The expected_bytes for mbarrier::arriveExpectTX must account for all TMA
     // load operations launched for each circular buffer stage. We take the
     // product of all coordinate TMA iterDomains to the right of the circular
     // buffer axis.
     const std::vector<IterDomain*>& loop_domain = consumer_tv->getLoopDomain();
-    for (size_t idx = consumer_tv->getComputeAtPosition();
-         idx < loop_domain.size();
-         ++idx) {
+    for (size_t idx = start_idx; idx < loop_domain.size(); ++idx) {
       IterDomain* id = loop_domain.at(idx);
       if (!id->isBroadcast() && !isParallelTypeThread(id->getParallelType()) &&
           id->getParallelType() != ParallelType::Bulk) {
@@ -1448,7 +1452,25 @@ ForLoop* createArrivesForWar(ForLoop* circular_buffer_loop) {
     }
     mbarriers.pushBack(it->second);
   }
+
   auto prefetch_loop = ir_utils::createRangeLoop(opt.prefetch + 1);
+
+  // only the first compute warp group needs to set the arrive of the prefetch
+  // loop
+  const auto& cb_info = GpuLower::current()->circularBufferInfo();
+  bool independent_compute_warp_groups =
+      cb_info.hasIndependentComputeWarpGroups();
+  kir::IfThenElse* ite = nullptr;
+  if (independent_compute_warp_groups) {
+    Val* predicate_val = SimplifyingIrBuilder::eqExpr(
+        NamedScalar::getParallelIndex(cb_info.getWarpSpecializedOn()),
+        GpuLower::current()->kernel()->zeroVal());
+    kir::Predicate* predicate =
+        IrBuilder::create<kir::Predicate>(predicate_val);
+    ite = IrBuilder::create<kir::IfThenElse>(predicate);
+    prefetch_loop->body().push_back(ite);
+  }
+
   for (auto mbarrier : mbarriers) {
     auto mbarrier_to_arrive = IrBuilder::create<kir::TensorIndex>(
         mbarrier,
@@ -1456,7 +1478,11 @@ ForLoop* createArrivesForWar(ForLoop* circular_buffer_loop) {
             prefetch_loop->indexOrStartIfTrivial(), opt.stage));
     auto prefetch = IrBuilder::create<kir::MBarrierArrive>(
         /*state=*/nullptr, mbarrier_to_arrive);
-    prefetch_loop->body().push_back(prefetch);
+    if (ite != nullptr) {
+      ite->thenBody().push_back(prefetch);
+    } else {
+      prefetch_loop->body().push_back(prefetch);
+    }
   }
   return prefetch_loop;
 }

--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -258,8 +258,8 @@ Val* ParallelDimensionMap::getRawAsync(ParallelType pt) const {
 Val* ParallelDimensionMap::getNumComputeThreadsEachBlock() const {
   Val* num_threads = FusionGuard::getCurFusion()->oneVal();
   for (auto pt : kParallelTypeTIDs) {
-    // Skip warp specialized parallel type if there are computationwarp groups
-    // are independent
+    // Skip warp specialized ParallelType if the are computation warp groups
+    // are independent.
     if (isWarpSpecialized(pt) &&
         GpuLower::current()
             ->circularBufferInfo()

--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -258,6 +258,14 @@ Val* ParallelDimensionMap::getRawAsync(ParallelType pt) const {
 Val* ParallelDimensionMap::getNumComputeThreadsEachBlock() const {
   Val* num_threads = FusionGuard::getCurFusion()->oneVal();
   for (auto pt : kParallelTypeTIDs) {
+    // Skip warp specialized parallel type if there are computationwarp groups
+    // are independent
+    if (isWarpSpecialized(pt) &&
+        GpuLower::current()
+            ->circularBufferInfo()
+            .hasIndependentComputeWarpGroups()) {
+      continue;
+    }
     auto dim = getRawCompute(pt);
     if (dim == nullptr) {
       continue;

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -13,11 +13,14 @@
 #include <tests/cpp/validator.h>
 #include <exception>
 #include <utility>
+
 namespace nvfuser {
+
 // The name ping-pong comes from Warp-Specialized Persistent Ping-Pong kernels
 // for GEMM in CUTLASS. Here it is generalized to represent any warp specialized
 // kernels with multiple computation warp groups, includes GEMM and non-GEMM
 // kernels.
+//
 // For non-GEMM kernel there is no ping-pong switching between tensor cores and
 // cuda cores, but multiple warp groups work on different tiles and are
 // scheduled and synchronized separately on the same SM.
@@ -31,7 +34,7 @@ class PingPongCircularBufferingTest : public NVFuserTest {
   }
 };
 
-TEST_F(PingPongCircularBufferingTest, SimpleFusion) {
+TEST_F(PingPongCircularBufferingTest, StageSlicePositionComputeAt) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -86,10 +89,85 @@ TEST_F(PingPongCircularBufferingTest, SimpleFusion) {
   }
   fusion.printMath();
 
-  inlineSelectedAt({tv1}, tv2, /*reference_pos=*/2);
+  constexpr int64_t tv1_compute_pos = 2;
+  inlineSelectedAt({tv1}, tv2, tv1_compute_pos);
   inlineSelectedAt({tv2}, tv2, /*reference_pos=*/3);
 
-  tv1->circularBuffer(stages, stages - 1, WarpSpecialized(ParallelType::TIDy));
+  tv1->circularBuffer(
+      stages,
+      stages - 1,
+      WarpSpecialized(
+          ParallelType::TIDy, /*stage_slice_position=*/tv1_compute_pos));
+
+  KernelExecutor ke;
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
+  testValidate(&fusion_copy, cg_outputs, {t0}, __LINE__, __FILE__);
+}
+
+TEST_F(PingPongCircularBufferingTest, SimpleFusion) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  int64_t rows_per_stage = 4;
+  int64_t compute_warp_groups = 2;
+  int64_t circular_loop = 12;
+  int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+  const int dim0 =
+      rows_per_stage * compute_warp_groups * sm_count * circular_loop;
+  const int dim1 = 128;
+
+  int stages = 6;
+
+  TensorView* tv0 = makeContigConcreteTensor({dim0, dim1}, DataType::Float);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = set(tv0);
+  TensorView* tv2 = set(tv1);
+  TensorView* tv3 = add(tv2, tv2);
+  fusion.addOutput(tv3);
+
+  tv1->definition()->as<LoadStoreOp>()->setOpType(LoadStoreOpType::CpAsyncBulk);
+  tv1->setMemoryType(MemoryType::Shared);
+
+  Fusion fusion_copy = fusion;
+  auto options = at::TensorOptions().device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({dim0, dim1}, options);
+
+  for (auto tv : {tv1, tv2, tv3}) {
+    tv->split(0, rows_per_stage);
+    tv->split(0, sm_count);
+    tv->split(0, compute_warp_groups);
+
+    // [I, 2, 132, 4]
+    tv->axis(0)->parallelize(ParallelType::Serial);
+    tv->axis(2)->parallelize(ParallelType::BIDx);
+    tv->axis(3)->parallelize(ParallelType::Unroll);
+  }
+
+  tv1->axis(1)->parallelize(ParallelType::Serial);
+  tv1->axis(4)->parallelize(ParallelType::Bulk);
+
+  for (auto tv : {tv2, tv3}) {
+    tv->axis(1)->parallelize(ParallelType::TIDy);
+    tv->axis(4)->parallelize(ParallelType::TIDx);
+  }
+
+  // [I, 2, 132, 4] --> [132, I, 2, 4]
+  std::unordered_map<int64_t, int64_t> reorder_map = {{0, 1}, {1, 2}, {2, 0}};
+  for (auto tv : {tv1, tv2, tv3}) {
+    tv->reorder(reorder_map);
+  }
+
+  constexpr int64_t tv2_compute_pos = 3;
+  inlineSelectedAt({tv1}, tv2, /*reference_pos=*/2);
+  inlineSelectedAt({tv2}, tv2, tv2_compute_pos);
+
+  tv1->circularBuffer(
+      stages,
+      stages - 1,
+      WarpSpecialized(
+          ParallelType::TIDy, /*stage_slice_position=*/tv2_compute_pos));
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -1,0 +1,100 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <ops/all_ops.h>
+#include <scheduler/tools/inlining.h>
+#include <string.h>
+#include <tests/cpp/utils.h>
+#include <tests/cpp/validator.h>
+#include <exception>
+#include <utility>
+namespace nvfuser {
+// The name ping-pong comes from Warp-Specialized Persistent Ping-Pong kernels
+// for GEMM in CUTLASS. Here it is generalized to represent any warp specialized
+// kernels with multiple computation warp groups, includes GEMM and non-GEMM
+// kernels.
+// For non-GEMM kernel there is no ping-pong switching between tensor cores and
+// cuda cores, but multiple warp groups work on different tiles and are
+// scheduled and synchronized separately on the same SM.
+class PingPongCircularBufferingTest : public NVFuserTest {
+ protected:
+  void SetUp() override {
+    if (cudaArchGuardShouldSkip(9, 0)) {
+      GTEST_SKIP() << "skipping tests on pre-Hopper GPUs";
+    }
+    NVFuserTest::SetUp();
+  }
+};
+
+TEST_F(PingPongCircularBufferingTest, SimpleFusion) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  int64_t rows_per_stage = 4;
+  int64_t compute_warp_groups = 2;
+  int64_t circular_loop = 12;
+  int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+  const int dim0 =
+      rows_per_stage * compute_warp_groups * sm_count * circular_loop;
+  const int dim1 = 128;
+
+  int stages = 6;
+
+  TensorView* tv0 = makeContigConcreteTensor({dim0, dim1}, DataType::Float);
+  fusion.addInput(tv0);
+
+  TensorView* tv1 = set(tv0);
+  TensorView* tv2 = set(tv1);
+  TensorView* tv3 = add(tv2, tv2);
+  fusion.addOutput(tv3);
+
+  tv1->definition()->as<LoadStoreOp>()->setOpType(LoadStoreOpType::CpAsyncBulk);
+  tv1->setMemoryType(MemoryType::Shared);
+
+  Fusion fusion_copy = fusion;
+  auto options = at::TensorOptions().device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({dim0, dim1}, options);
+
+  for (auto tv : {tv1, tv2, tv3}) {
+    tv->split(0, rows_per_stage);
+    tv->split(0, sm_count);
+    tv->split(0, compute_warp_groups);
+
+    // [I, 2, 132, 4]
+    tv->axis(0)->parallelize(ParallelType::Serial);
+    tv->axis(2)->parallelize(ParallelType::BIDx);
+    tv->axis(3)->parallelize(ParallelType::Unroll);
+  }
+
+  tv1->axis(1)->parallelize(ParallelType::Serial);
+  tv1->axis(4)->parallelize(ParallelType::Bulk);
+
+  for (auto tv : {tv2, tv3}) {
+    tv->axis(1)->parallelize(ParallelType::TIDy);
+    tv->axis(4)->parallelize(ParallelType::TIDx);
+  }
+
+  // [I, 2, 132, 4] --> [132, I, 2, 4]
+  std::unordered_map<int64_t, int64_t> reorder_map = {{0, 1}, {1, 2}, {2, 0}};
+  for (auto tv : {tv1, tv2, tv3}) {
+    tv->reorder(reorder_map);
+  }
+  fusion.printMath();
+
+  inlineSelectedAt({tv1}, tv2, /*reference_pos=*/2);
+  inlineSelectedAt({tv2}, tv2, /*reference_pos=*/3);
+
+  tv1->circularBuffer(stages, stages - 1, WarpSpecialized(ParallelType::TIDy));
+
+  KernelExecutor ke;
+  ke.compile(&fusion, {t0});
+  auto cg_outputs = ke.run({t0});
+  testValidate(&fusion_copy, cg_outputs, {t0}, __LINE__, __FILE__);
+}
+
+} // namespace nvfuser

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -100,7 +100,7 @@ TEST_P(PingPongCircularBuffering, StageSlicePositionComputeAt) {
 INSTANTIATE_TEST_SUITE_P(
     ,
     PingPongCircularBuffering,
-    ::testing::Combine(::testing::Range(0, 6)),
+    ::testing::Combine(::testing::Range(0, 7)),
     [](const testing::TestParamInfo<PingPongCircularBufferingParams>& info) {
       std::stringstream ss;
       ss << "stage_slice_position_" << std::get<0>(info.param);

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -24,7 +24,7 @@ namespace nvfuser {
 // For non-GEMM kernel there is no ping-pong switching between tensor cores and
 // cuda cores, but multiple warp groups work on different tiles and are
 // scheduled and synchronized separately on the same SM.
-using PingPongCircularBufferingParams = std::tuple<int64_t>;
+using PingPongCircularBufferingParams = std::tuple<int>;
 using PingPongCircularBuffering =
     NVFuserFixtureParamTest<PingPongCircularBufferingParams>;
 TEST_P(PingPongCircularBuffering, StageSlicePositionComputeAt) {
@@ -100,7 +100,7 @@ TEST_P(PingPongCircularBuffering, StageSlicePositionComputeAt) {
 INSTANTIATE_TEST_SUITE_P(
     ,
     PingPongCircularBuffering,
-    ::testing::Combine(::testing::Values(2, 3)),
+    ::testing::Combine(::testing::Range(0, 6)),
     [](const testing::TestParamInfo<PingPongCircularBufferingParams>& info) {
       std::stringstream ss;
       ss << "stage_slice_position_" << std::get<0>(info.param);

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -28,7 +28,7 @@ using PingPongCircularBufferingParams = std::tuple<int>;
 using PingPongCircularBuffering =
     NVFuserFixtureParamTest<PingPongCircularBufferingParams>;
 TEST_P(PingPongCircularBuffering, StageSlicePositionComputeAt) {
-  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+  NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(9, 0, 10, 0);
 
   Fusion fusion;
   FusionGuard fg(&fusion);


### PR DESCRIPTION
This PR adds `stage_slice_position` to `struct WarpSpecialized` to control the shape of circular buffer stage. It detects the ping-pong circular buffer pattern and changes the CUDA kernel so all the compute warp groups to work independently.

Derived from #4396.

## Summary
Multiple TMA Loads can be launched for a single `mbarrier::arriveExpectTx`. Currently, we always insert the `mbarrier::arriveExpectTx` at the first serial IterDomain left of the ComputeAt position.

For ping-pong kernels, the circular buffer pipeline is parallelized by the compute warp groups. Using the computeAt position to select the `mbarrier::arriveExpectTx` position is restrictive.

Furthermore, persistent normalization and matmul kernels have different patterns, so more flexibility in defining the circular buffer stage state is required.

Essentially, we need to select an iterDomain axis in the loop domain where all iterDomains to the right define the circular buffer stage. The remaining iterDomains to the left define the traversal of the pipeline.

## Difference between Persistent Normalization and Ping-Pong Matmul 
![image](https://github.com/user-attachments/assets/807ce2cd-1150-4cfe-86b3-b39932f50ba2)

* `stage_slice_position` is iterDomain 3 for persistent normalization or `+1` from computeAt position.
* `stage_slice_position` is iterDomain 4 for ping-pong matmul or `+2` from computeAt position.

## What is stage_slice_position?

The `stage_slice_position` selects an iterDomain axis in the loop domain. All iterDomains to the right of the axis (inclusive) define the shape of the circular buffer stage. The remaining iterDomains to the left define the traversal order of the pipeline.

The `stage_slice_position` is stored in the `WarpSpecialized` struct. It is analogous for the computeAt position for iterDomain inlining and `tmem_dim_sep_pos` for Tensor Memory.

### Restrictions:
* For warp specialization, the circular buffering pass clones the outer-most serial for-loop. The `stage_slice_position` must be to the right of the outer-most serial iterDomain.
* The `stage_slice_position` must be to the left of any `ParallelType::Bulk` iterDomains.
* TODO: The `stage_slice_position` must exist in the TMA Load producer and its consumer.

## How is Independent Compute Warps detected?
Summary: If the warp specialized axis is serial in the TMA Load TensorView and is to the left of the `stage_slice_position`, then the compute warp groups are independent.

1. Get warp specialized iterDomain in consumer
2. Get ValGroup for warp specialized iterDomain in `IdMappingMode::EXACT` IterDomainGraph
3. Find corresponding producer iterDomain to warp specialized iterDomain
4. Map producer iterDomain to its integer position in the loop domain
5. Use independent warp groups if warp specialized axis is to the left of the stage_slice_position

* See `hasIndependentWarpGroups` in circular buffer analysis pass.

### Kernel changes if compute warps are independent.
* Only the first compute warp group signals the `AsyncWarp` mbarriers. See `CloneTmaCircularBufferLoopAndInsertSync::createArrivesForWar`
* Only 128 threads are required to arrive at `AsyncWarp` mbarriers. See `ParallelDimensionMap::getNumComputeThreadsEachBlock`.

## CUDA Examples

### Example 1: Cooperative: stage_slice_position == ca_pos == 2
* See `PingPongCircularBuffering.StageSlicePositionComputeAt/stage_slice_position_2`
* `T1_s_float[iblockIdx.x11{132}, iS12{12}, | stage_slice_position | , iS13{2}, iUR9{4}, iB3{128}] ca_pos( 2 )`

<details>

```cuda
  #pragma unroll
  for(nvfuser_index_t i13 = 0; i13 < 6; ++i13) {
    if (((Hopper::electSync(4294967295U) && b5) && b6)) {
      mbarrier::init(toSmem((&T4[(i13 + 6LL)])), 256U);  //  <<<<< Cooperative kernel so 256 threads.
    }
  }
  __syncthreads();
  if ((((nvfuser_index_t)threadIdx.y) >= 2)) {
    #pragma unroll 5
    for(nvfuser_index_t i14 = 0; i14 < 12; ++i14) {
      float* ptr15;
      ptr15 = ptr1 + (135168 * i14);
      uint32_t i16;
      i16 = i2 + (4096 * (i14 % 6));
      if ((((((nvfuser_index_t)threadIdx.x) / 32ULL) == 0ULL) && Hopper::electSync(4294967295U))) {
        mbarrier::waitParity(toSmem((&T4[((i14 % 6) + 6LL)])), (uint32_t)(((i14 / 6) % 2)));

        // Insert arriveExpectTX before iterDomain axis 3.
        // 2 * 4 * 128 * 4 = 4096 Bytes
        mbarrier::arriveExpectTX(toSmem((&T4[(i14 % 6)])), 4096U);

        #pragma unroll
        for(nvfuser_index_t i17 = 0; i17 < 2; ++i17) {
          float* ptr18;
          ptr18 = ptr15 + (67584 * i17);
          uint32_t i19;
          i19 = i16 + (2048 * i17);
          #pragma unroll
          for(nvfuser_index_t i20 = 0; i20 < 4; ++i20) {
            Hopper::cpAsyncBulkG2S((Hopper::CpAsyncBulkG2SIndex{ (ptr18 + (128 * i20)), 512U, toSmem((&T4[(i14 % 6)])) }), (i19 + (512 * i20)));
          }
        }
      }
    }
    return;
  } else {
    #pragma unroll
    for(nvfuser_index_t i21 = 0; i21 < 6; ++i21) {
      mbarrier::arrive(toSmem((&T4[(i21 + 6LL)])));
    }
    // do compute warp
 }
```

</details>

### Example 2: Ping-Pong: stage_slice_position == 3
* See `PingPongCircularBuffering.StageSlicePositionComputeAt/stage_slice_position_3`
* `T1_s_float[iblockIdx.x11{132}, iS12{12}, iS13{2}, | stage_slice_position |,  iUR9{4}, iB3{128}] ca_pos( 2 )`

<details>

``` cuda
  #pragma unroll
  for(nvfuser_index_t i14 = 0; i14 < 6; ++i14) {
    if (((Hopper::electSync(4294967295U) && b5) && b6)) {
      mbarrier::init(toSmem((&T4[(i14 + 6LL)])), 128U);  //  <<<<< Ping-Pong kernel so 128 threads.
    }
  }
  __syncthreads();
  if ((((nvfuser_index_t)threadIdx.y) >= 2)) {
    #pragma unroll 5
    for(nvfuser_index_t i15 = 0; i15 < 12; ++i15) {
      float* ptr16;
      ptr16 = ptr1 + (135168 * i15);
      uint32_t i17;
      i17 = i2 + (4096 * (i15 % 6));
      #pragma unroll
      for(nvfuser_index_t i18 = 0; i18 < 2; ++i18) {
        float* ptr19;
        ptr19 = ptr16 + (67584 * i18);
        uint32_t i20;
        i20 = i17 + (2048 * i18);
        if ((((((nvfuser_index_t)threadIdx.x) / 32ULL) == 0ULL) && Hopper::electSync(4294967295U))) {
          mbarrier::waitParity(toSmem((&T4[(((2 * (i15 % 3)) + i18) + 6LL)])), (uint32_t)(((i15 / 3) % 2)));

           // Insert arriveExpectTX before iterDomain axis 4.
          // 4 * 128 * 4 = 2048 Bytes
          mbarrier::arriveExpectTX(toSmem((&T4[((2 * (i15 % 3)) + i18)])), 2048U);

          #pragma unroll
          for(nvfuser_index_t i21 = 0; i21 < 4; ++i21) {
            Hopper::cpAsyncBulkG2S((Hopper::CpAsyncBulkG2SIndex{ (ptr19 + (128 * i21)), 512U, toSmem((&T4[((2 * (i15 % 3)) + i18)])) }), (i20 + (512 * i21)));
          }
        }
      }
    }
    return;
  } else {
    #pragma unroll
    for(nvfuser_index_t i22 = 0; i22 < 6; ++i22) {
      if (b7) {  //  <<<<< Ping-Pong kernel so only first compute warp group triggers mbarrier.
        mbarrier::arrive(toSmem((&T4[(i22 + 6LL)])));
      }
    }
    // do compute warp
 }
```

</details>

### Example 2: Ping-Pong: stage_slice_position == 4
* See `PingPongCircularBuffering.StageSlicePositionComputeAt/stage_slice_position_4`
* `T1_s_float[iblockIdx.x11{132}, iS12{12}, iS13{2}, iUR9{4}, | stage_slice_position |,  iB3{128}] ca_pos( 2 )`

<details>

```cuda
  #pragma unroll
  for(nvfuser_index_t i15 = 0; i15 < 6; ++i15) {
    if (((Hopper::electSync(4294967295U) && b6) && b7)) {
      mbarrier::init(toSmem((&T4[(i15 + 6LL)])), 128U);  //  <<<<< Ping-Pong kernel so 128 threads.
    }
  }
  __syncthreads();
  if ((((nvfuser_index_t)threadIdx.y) >= 2)) {
    #pragma unroll 5
    for(nvfuser_index_t i16 = 0; i16 < 12; ++i16) {
      float* ptr17;
      ptr17 = ptr2 + (135168 * i16);
      uint32_t i18;
      i18 = i3 + (4096 * (i16 % 6));
      #pragma unroll
      for(nvfuser_index_t i19 = 0; i19 < 2; ++i19) {
        float* ptr20;
        ptr20 = ptr17 + (67584 * i19);
        uint32_t i21;
        i21 = i18 + (2048 * i19);
        #pragma unroll
        for(nvfuser_index_t i22 = 0; i22 < 4; ++i22) {
          if ((((((nvfuser_index_t)threadIdx.x) / 32ULL) == 0ULL) && Hopper::electSync(4294967295U))) {
            mbarrier::waitParity(toSmem((&T4[(((((8 * i16) + (4 * i19)) + i22) % 6) + 6LL)])), (uint32_t)((((((8 * i16) + (4 * i19)) + i22) / 6) % 2)));

           // Insert arriveExpectTX before iterDomain axis 5.
            // 128 * 4 = 512 Bytes
            mbarrier::arriveExpectTX(toSmem((&T4[((((8 * i16) + (4 * i19)) + i22) % 6)])), 512U);

            Hopper::cpAsyncBulkG2S((Hopper::CpAsyncBulkG2SIndex{ (ptr20 + (128 * i22)), 512U, toSmem((&T4[((((8 * i16) + (4 * i19)) + i22) % 6)])) }), (i21 + (512 * i22)));
          }
        }
      }
    }
    return;
  } else {
    #pragma unroll
    for(nvfuser_index_t i23 = 0; i23 < 6; ++i23) {
      if (b8) {  //  <<<<< Ping-Pong kernel so only first compute warp group triggers mbarrier.
        mbarrier::arrive(toSmem((&T4[(i23 + 6LL)])));
      }
    }
```
</details>