### PR TITLE
Header inclusion cleanup

### DIFF
--- a/csrc/device_lower/analysis/bank_conflict.cpp
+++ b/csrc/device_lower/analysis/bank_conflict.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <device_lower/analysis/bank_conflict.h>
 
+#include <device_lower/utils.h>
 #include <expr_evaluator.h>
 #include <ir/utils.h>
 #include <kernel_ir.h>

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -45,53 +45,6 @@ kir::IfThenElse* cloneIfThenElse(kir::IfThenElse* ite) {
 
 namespace ir_utils {
 
-TVDomainGuard::TVDomainGuard(TensorView* tv, TensorDomain* td)
-    : tv_(tv), prev_domain_(tv_->domain()) {
-  tv_->setDomain(td);
-}
-
-TVDomainGuard::TVDomainGuard(TVDomainGuard&& guard)
-    : tv_(nullptr), prev_domain_(guard.prev_domain_) {
-  std::swap(tv_, guard.tv_);
-}
-
-TVDomainGuard::~TVDomainGuard() {
-  if (tv_ != nullptr) {
-    tv_->setDomain(prev_domain_);
-  }
-}
-
-ir_utils::TVDomainGuard overrideContiguityGuard(
-    TensorView* tv,
-    bool contiguity) {
-  // Use domain guard to ignore the contiguity of the given tv.
-  TensorDomain* domain_with_specified_contiguity =
-      IrBuilder::create<TensorDomain>(
-          tv->getRootDomain(),
-          tv->getLogicalDomain(),
-          tv->getAllocationDomain(),
-          tv->getLoopDomain(),
-          TensorDomain::getContiguityFilledWith(
-              tv->getMaybeAllocationDomain(), contiguity));
-
-  return ir_utils::TVDomainGuard(tv, domain_with_specified_contiguity);
-}
-
-ir_utils::TVDomainGuard allocateToLogicalDomainGuard(
-    TensorView* tv,
-    bool contiguity) {
-  // Use domain guard to ignore the contiguity of the given tv.
-  TensorDomain* domain_with_specified_contiguity =
-      IrBuilder::create<TensorDomain>(
-          tv->getRootDomain(),
-          tv->getLogicalDomain(),
-          tv->getLoopDomain(),
-          TensorDomain::getContiguityFilledWith(
-              tv->getLogicalDomain(), contiguity));
-
-  return ir_utils::TVDomainGuard(tv, domain_with_specified_contiguity);
-}
-
 std::vector<IterDomain*> iterDomainInputsOf(
     const std::vector<IterDomain*>& input_ids,
     const std::vector<IterDomain*>& all_inputs) {

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -15,7 +15,7 @@
 #include <ir/all_nodes.h>
 #include <kernel_ir.h>
 #include <parallel_type_bitmap.h>
-#include <val_graph.h>
+#include <val_graph_nodes.h>
 
 #include <bitset>
 #include <map>
@@ -25,6 +25,7 @@
 namespace nvfuser {
 
 class ThreadPredicateMap;
+class ValGraph;
 
 namespace scope_utils {
 
@@ -37,31 +38,6 @@ kir::IfThenElse* cloneIfThenElse(kir::IfThenElse* ite);
 } // namespace scope_utils
 
 namespace ir_utils {
-
-// Somtimes we want to temporarily view a tensorview with another tensordomain.
-// This isn't a permanent transformation, but in indexing we want to index
-// producers with a consumer set of indices, so we need to view the producer
-// transformed like consumer while we index. This will set the tv with td for
-// the life of this context guard.
-class TVDomainGuard {
- private:
-  TensorView* tv_;
-  TensorDomain* prev_domain_;
-
- public:
-  explicit TVDomainGuard(TensorView* tv, TensorDomain* td);
-  TVDomainGuard(const TVDomainGuard&) = delete;
-  NVF_API TVDomainGuard(TVDomainGuard&&);
-
-  //! An utility to access the tensordomain before the temporary
-  //!  view. This is used to retrieve information, like swizzle
-  //!  information that can only be reliably kept at the original domain.
-  const TensorDomain* prevDomain() const {
-    return prev_domain_;
-  }
-
-  NVF_API ~TVDomainGuard();
-};
 
 // Create a TVDomainGuard that temporarily view a TensorView with specified
 // all-true or all-false contiguity.

--- a/csrc/evaluator_common.h
+++ b/csrc/evaluator_common.h
@@ -6,7 +6,6 @@
  */
 // clang-format on
 #pragma once
-#include <device_lower/lower2device.h>
 #include <exceptions.h>
 #include <fusion.h>
 #include <ir/all_nodes.h>

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 
 #include <debug.h>
+#include <device_lower/utils.h>
 #include <disjoint_set.h>
 #include <fusion.h>
 #include <fusion_segmenter.h>

--- a/csrc/id_model/to_string.h
+++ b/csrc/id_model/to_string.h
@@ -15,21 +15,23 @@
 
 namespace nvfuser {
 
-std::string NVF_API
-toString(const std::vector<Val*>& val_group, int indent_size = 0);
+std::string toString(const std::vector<Val*>& val_group, int indent_size = 0);
 
-std::string NVF_API
-toString(const std::vector<IterDomain*>& id_group, int indent_size = 0);
+std::string toString(
+    const std::vector<IterDomain*>& id_group,
+    int indent_size = 0);
 
-std::string NVF_API
-toString(const ValGroup& id_group, int indent_size = 0, bool with_ptr = false);
+std::string toString(
+    const ValGroup& id_group,
+    int indent_size = 0,
+    bool with_ptr = false);
 
-std::string NVF_API toString(
+std::string toString(
     const std::vector<ValGroup>& id_groups,
     int indent_size = 0,
     bool with_ptr = false);
 
-std::string NVF_API toString(
+std::string toString(
     const ValGroups& id_groups,
     int indent_size = 0,
     bool with_ptr = false);
@@ -37,30 +39,29 @@ std::string NVF_API toString(
 std::string toInlineString(const std::vector<ValGroup>& id_groups);
 std::string toInlineString(const ValGroups& id_groups);
 
-std::string NVF_API
-toString(const std::vector<Expr*>& expr_group, int indent_size = 0);
-std::string NVF_API toString(
+std::string toString(const std::vector<Expr*>& expr_group, int indent_size = 0);
+std::string toString(
     const ExprGroup& expr_group,
     int indent_size = 0,
     bool with_ptr = false);
 
-std::string NVF_API toString(
+std::string toString(
     const ValGraph& id_graph,
     const std::vector<Expr*>& expr_group,
     int indent_size = 0,
     bool with_ptr = false);
-std::string NVF_API toString(
+std::string toString(
     const ValGraph& id_graph,
     const ExprGroup& expr_groups,
     int indent_size = 0,
     bool with_ptr = false);
 
-std::string NVF_API toString(
+std::string toString(
     const ValGraph& id_graph,
     const std::vector<ExprGroup>& expr_groups,
     int indent_size = 0,
     bool with_ptr = false);
-std::string NVF_API toString(
+std::string toString(
     const ValGraph& id_graph,
     const ExprGroups& expr_groups,
     int indent_size = 0,

--- a/csrc/ir/builder.cpp
+++ b/csrc/ir/builder.cpp
@@ -9,6 +9,7 @@
 #include <fusion.h>
 #include <ir/builder.h>
 #include <ir/cloner.h>
+#include <ir/utils.h>
 #include <kernel.h>
 #include <C++20/compare>
 

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -1596,4 +1596,51 @@ int64_t getTMemLdStVectorizeSize(TensorView* consumer_tv) {
   return vec_size_in_bytes / tmem_unit_size_bytes;
 }
 
+TVDomainGuard::TVDomainGuard(TensorView* tv, TensorDomain* td)
+    : tv_(tv), prev_domain_(tv_->domain()) {
+  tv_->setDomain(td);
+}
+
+TVDomainGuard::TVDomainGuard(TVDomainGuard&& guard)
+    : tv_(nullptr), prev_domain_(guard.prev_domain_) {
+  std::swap(tv_, guard.tv_);
+}
+
+TVDomainGuard::~TVDomainGuard() {
+  if (tv_ != nullptr) {
+    tv_->setDomain(prev_domain_);
+  }
+}
+
+ir_utils::TVDomainGuard overrideContiguityGuard(
+    TensorView* tv,
+    bool contiguity) {
+  // Use domain guard to ignore the contiguity of the given tv.
+  TensorDomain* domain_with_specified_contiguity =
+      IrBuilder::create<TensorDomain>(
+          tv->getRootDomain(),
+          tv->getLogicalDomain(),
+          tv->getAllocationDomain(),
+          tv->getLoopDomain(),
+          TensorDomain::getContiguityFilledWith(
+              tv->getMaybeAllocationDomain(), contiguity));
+
+  return ir_utils::TVDomainGuard(tv, domain_with_specified_contiguity);
+}
+
+ir_utils::TVDomainGuard allocateToLogicalDomainGuard(
+    TensorView* tv,
+    bool contiguity) {
+  // Use domain guard to ignore the contiguity of the given tv.
+  TensorDomain* domain_with_specified_contiguity =
+      IrBuilder::create<TensorDomain>(
+          tv->getRootDomain(),
+          tv->getLogicalDomain(),
+          tv->getLoopDomain(),
+          TensorDomain::getContiguityFilledWith(
+              tv->getLogicalDomain(), contiguity));
+
+  return ir_utils::TVDomainGuard(tv, domain_with_specified_contiguity);
+}
+
 } // namespace nvfuser::ir_utils

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -807,4 +807,29 @@ std::optional<std::pair<int64_t, int64_t>> getPrecisionOfProducerConsumerTensors
 // double, 2 doubles, 4 floats, 8 halfs, or 16 bytes.
 int64_t getTMemLdStVectorizeSize(TensorView* consumer_tv);
 
+// Somtimes we want to temporarily view a tensorview with another tensordomain.
+// This isn't a permanent transformation, but in indexing we want to index
+// producers with a consumer set of indices, so we need to view the producer
+// transformed like consumer while we index. This will set the tv with td for
+// the life of this context guard.
+class TVDomainGuard {
+ private:
+  TensorView* tv_;
+  TensorDomain* prev_domain_;
+
+ public:
+  explicit TVDomainGuard(TensorView* tv, TensorDomain* td);
+  TVDomainGuard(const TVDomainGuard&) = delete;
+  NVF_API TVDomainGuard(TVDomainGuard&&);
+
+  //! An utility to access the tensordomain before the temporary
+  //!  view. This is used to retrieve information, like swizzle
+  //!  information that can only be reliably kept at the original domain.
+  const TensorDomain* prevDomain() const {
+    return prev_domain_;
+  }
+
+  NVF_API ~TVDomainGuard();
+};
+
 } // namespace nvfuser::ir_utils

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -12,6 +12,7 @@
 #include <cuda_utils.h>
 #include <debug.h>
 #include <device_lower/analysis/bank_conflict.h>
+#include <device_lower/lower2device.h>
 #include <disjoint_set.h>
 #include <driver_api.h>
 #include <fusion_profiler.h>
@@ -1198,6 +1199,8 @@ NVF_API CompiledKernel::CompiledKernel(
           {},
           {}) {}
 
+NVF_API CompiledKernel::~CompiledKernel() = default;
+
 void CompiledKernel::compile(const LaunchParams& lparams) {
   FUSER_PERF_SCOPE("CompiledKernel::compile");
 
@@ -1366,6 +1369,11 @@ void CompiledKernel::createKernelId() {
     ss << "_g" << group_id_;
   }
   kernel_id_ = ss.str();
+}
+
+kir::Kernel* CompiledKernel::kernel() const {
+  NVF_ERROR(lowered_);
+  return lowered_->kernel();
 }
 
 void RtcKernel::compile(

--- a/csrc/runtime/compiled_kernel.h
+++ b/csrc/runtime/compiled_kernel.h
@@ -12,7 +12,6 @@
 
 #include <c10/core/DeviceType.h>
 
-#include <device_lower/lower2device.h>
 #include <exceptions.h>
 #include <expr_evaluator.h>
 #include <fusion.h>
@@ -28,6 +27,8 @@
 #include <utils.h>
 
 namespace nvfuser {
+
+class GpuLower;
 
 //! Internal tests only. Compiles CUDA code with NVRTC directly from
 //! string. This util provides a path to test runtime code, i.e. the resource
@@ -60,6 +61,8 @@ class CompiledKernel : public NonCopyable {
  public:
   // NVF_API was added for nvfuser_extension. See examples/sinh_extension.
   CompiledKernel() = delete;
+
+  NVF_API ~CompiledKernel();
 
   NVF_API CompiledKernel(
       Fusion* fusion,
@@ -111,10 +114,7 @@ class CompiledKernel : public NonCopyable {
   using ExecutorCompileTimeInfoCache =
       executor_utils::caching::ExecutorCompileTimeInfoCache;
 
-  kir::Kernel* kernel() const {
-    NVF_ERROR(lowered_);
-    return lowered_->kernel();
-  }
+  kir::Kernel* kernel() const;
 
   //! Returns the string of the compiled kernel
   NVF_API std::string kernelString() const {
@@ -274,7 +274,7 @@ class CompiledKernel : public NonCopyable {
   // Kernel name for fusion executor
   std::string kernel_id_;
 
-  std::unique_ptr<GpuLower> lowered_ = nullptr;
+  std::unique_ptr<GpuLower> lowered_;
 
   // Track the block size this kernel was compiled with. If the block size
   // increases, recompile to adjust maxregister count.

--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -11,6 +11,8 @@
 #include <codegen.h>
 #include <debug.h>
 #include <device_lower/analysis/bank_conflict.h>
+#include <device_lower/lower2device.h>
+#include <device_lower/utils.h>
 #include <driver_api.h>
 #include <fusion_profiler.h>
 #include <global_allocator.h>

--- a/csrc/runtime/executor.h
+++ b/csrc/runtime/executor.h
@@ -6,7 +6,6 @@
  */
 // clang-format on
 #pragma once
-#include <device_lower/lower2device.h>
 #include <exceptions.h>
 #include <expr_evaluator.h>
 #include <fusion.h>
@@ -85,6 +84,8 @@ struct KernelExecutorEntry {
   // requires an array of this form.
   std::vector<void*> arg_ptrs;
 };
+
+class GpuLower;
 
 class KernelExecutor : public ExecutorAbstract {
  public:

--- a/csrc/runtime/executor_utils.cpp
+++ b/csrc/runtime/executor_utils.cpp
@@ -11,6 +11,7 @@
 
 #include <contiguity.h>
 #include <debug.h>
+#include <device_lower/lower2device.h>
 #include <device_lower/utils.h>
 #include <driver_api.h>
 #include <instrumentation.h>

--- a/csrc/runtime/executor_utils.h
+++ b/csrc/runtime/executor_utils.h
@@ -16,7 +16,6 @@
 #include <torch/csrc/jit/ir/ir.h>
 
 #include <cuda_utils.h>
-#include <device_lower/lower2device.h>
 #include <expr_evaluator.h>
 #include <fusion.h>
 #include <ir/all_nodes.h>
@@ -27,6 +26,9 @@
 #include <vector>
 
 namespace nvfuser {
+
+class GpuLower;
+
 namespace executor_utils {
 
 // I'm not happy with CudaExecutable being a struct exposing all the fields.

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <instrumentation.h>
+#include <options.h>
 #include <scheduler/debug_utils.h>
 #include <scheduler/normalization_inner_outer_multi_wave.h>
 #include <scheduler/normalization_inner_outer_tma_ws.h>

--- a/csrc/scheduler/normalization_inner_outer_multi_wave.cpp
+++ b/csrc/scheduler/normalization_inner_outer_multi_wave.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <options.h>
 #include <scheduler/normalization_utils.h>
 #include <scheduler/runtime_info.h>
 #include <scheduler/tools/inlining.h>

--- a/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
+++ b/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <ops/arith.h>
+#include <options.h>
 #include <scheduler/normalization_utils.h>
 #include <scheduler/runtime_info.h>
 #include <scheduler/tools/inlining.h>

--- a/csrc/scheduler/normalization_inner_outer_utils.cpp
+++ b/csrc/scheduler/normalization_inner_outer_utils.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 #include <instrumentation.h>
+#include <options.h>
 #include <scheduler/normalization_inner_outer_utils.h>
 #include <scheduler/normalization_utils.h>
 #include <scheduler/registry_utils.h>

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -12,6 +12,7 @@
 #include <device_lower/analysis/divisible_split.h>
 #include <expr_evaluator.h>
 #include <expr_simplifier.h>
+#include <id_model/id_model.h>
 #include <instrumentation.h>
 #include <ir/builder.h>
 #include <ir/iostream.h>

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -15,6 +15,7 @@
 
 #include <debug.h>
 #include <mma_type.h>
+#include <options.h>
 #include <tma.h>
 #include <type.h>
 

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -9,6 +9,7 @@
 
 #include <disjoint_set.h>
 #include <ir/all_nodes.h>
+#include <val_graph_nodes.h>
 
 #include <iostream>
 #include <string>
@@ -50,11 +51,6 @@ namespace nvfuser {
 // ValGraph can be used with any Val types, however, it's currenty
 // only tested with IterDomain. Some of the routines might need to be
 // extended for other Val types.
-
-using ValGroup = std::shared_ptr<VectorOfUniqueEntries<Val*>>;
-using ValGroups = VectorOfUniqueEntries<ValGroup>;
-using ExprGroup = std::shared_ptr<VectorOfUniqueEntries<Expr*>>;
-using ExprGroups = VectorOfUniqueEntries<ExprGroup>;
 
 class ValGraph {
  public:

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -56,7 +56,7 @@ using ValGroups = VectorOfUniqueEntries<ValGroup>;
 using ExprGroup = std::shared_ptr<VectorOfUniqueEntries<Expr*>>;
 using ExprGroups = VectorOfUniqueEntries<ExprGroup>;
 
-class NVF_API ValGraph {
+class ValGraph {
  public:
   ValGraph() = default;
 

--- a/csrc/val_graph_nodes.h
+++ b/csrc/val_graph_nodes.h
@@ -1,0 +1,24 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <disjoint_set.h>
+
+
+namespace nvfuser {
+
+// These types define ValGraph nodes. They are separted from
+// val_graph.h to limit header files to incldue. See val_graph.h for
+// more details.
+
+using ValGroup = std::shared_ptr<VectorOfUniqueEntries<Val*>>;
+using ValGroups = VectorOfUniqueEntries<ValGroup>;
+using ExprGroup = std::shared_ptr<VectorOfUniqueEntries<Expr*>>;
+using ExprGroups = VectorOfUniqueEntries<ExprGroup>;
+
+} // namespace nvfuser

--- a/csrc/val_graph_nodes.h
+++ b/csrc/val_graph_nodes.h
@@ -1,6 +1,6 @@
 // clang-format off
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/csrc/val_graph_nodes.h
+++ b/csrc/val_graph_nodes.h
@@ -9,7 +9,6 @@
 
 #include <disjoint_set.h>
 
-
 namespace nvfuser {
 
 // These types define ValGraph nodes. They are separted from


### PR DESCRIPTION
Follow-up to #4452 

lower2device.h includes a lot of other mostly internal headers, so I think we should avoid including it from the runtime files.