### PR TITLE
use sharedMemPerBlockOptin not sharedMemPerMultiprocessor

### DIFF
--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -300,10 +300,10 @@ void fillOptimalHopperTileSizes(
 
         const int64_t bytes_per_stage = (cta_m + cta_n) * cta_k * 2;
         // Don't consider cases where we would need fewer than 3 load stages due
-        // to smem constraint (add 1K bytes overhead as fudge factor)
+        // to smem constraint
         const int64_t smem_bytes =
-            at::cuda::getCurrentDeviceProperties()->sharedMemPerMultiprocessor;
-        if (bytes_per_stage * 3L > smem_bytes - 1024L) {
+            at::cuda::getCurrentDeviceProperties()->sharedMemPerBlockOptin;
+        if (bytes_per_stage * 3L > smem_bytes) {
           continue;
         }
 
@@ -357,8 +357,7 @@ bool fillDefaultHopperHeuristic(
   int64_t operand_smem_per_stage =
       (int64_t)num_problems * 2 * (cta_tile.m + cta_tile.n) * cta_tile.k;
   // We leave a bit of space for semaphores.
-  int64_t max_operand_smem =
-      (int64_t)device_prop->sharedMemPerMultiprocessor - (1L << 7);
+  int64_t max_operand_smem = (int64_t)device_prop->sharedMemPerBlockOptin;
   if (mparams->tiling_strategy != MatmulParams::TilingStrategy::OneTilePerCTA) {
     // We cannot reuse memory for smem epilogue in persistent kernels.
     for (TensorView* out : tensor_roles.at(MatmulTensorRole::OUTPUT)) {

--- a/csrc/scheduler/normalization_inner_outer_multi_wave.cpp
+++ b/csrc/scheduler/normalization_inner_outer_multi_wave.cpp
@@ -143,8 +143,7 @@ void getHeuristics(
     int64_t max_blocks_per_sm_regs = scheduler_utils::safeDiv(
         threads_per_sm / warp_size, allocated_warps_per_block);
     // check shared memory limitation on blocks per sm
-    int64_t max_blocks_per_sm_smem =
-        (int64_t)dev_prop->sharedMemPerMultiprocessor /
+    int64_t max_blocks_per_sm_smem = (int64_t)dev_prop->sharedMemPerBlockOptin /
         (smem_overhead + smem_buffer_size);
     return std::min(max_blocks_per_sm_regs, max_blocks_per_sm_smem);
   };

--- a/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
+++ b/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
@@ -161,7 +161,7 @@ void getHeuristics(
   // TODO: This is a heuristic, need to be tuned.
   // Set circular buffer, n_stages and n_prefetch are tunable parameters.
   // n_stages is also limited by smem
-  int64_t max_n_copies = (int64_t)dev_prop->sharedMemPerMultiprocessor /
+  int64_t max_n_copies = (int64_t)dev_prop->sharedMemPerBlockOptin /
       (smem_overhead + smem_buffer_size);
   int64_t iter_remaining = ceilDiv(outer_dim_numel, iop.gdimy);
   int64_t n_stages_prefered = std::min(2L, iter_remaining);

--- a/csrc/scheduler/normalization_inner_outer_utils.cpp
+++ b/csrc/scheduler/normalization_inner_outer_utils.cpp
@@ -180,10 +180,10 @@ PersistentBufferStorageParams getPersistentBufferStorageParams(
            ProjectToInputs);
 
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
-  int64_t smem_overhead = scheduler_utils::getSharedMemoryOverheadPerBlock(
+  int64_t smem_overhead = scheduler_utils::getReductionSmemWorkspace(
       fusion, reduction_tvs, threads_per_block_max);
   int64_t available_smem =
-      (int64_t)dev_prop->sharedMemPerMultiprocessor - smem_overhead;
+      (int64_t)dev_prop->sharedMemPerBlockOptin - smem_overhead;
   int64_t available_regs = scheduler_utils::register_file_size_56k;
   buffer_params.smem_overhead = smem_overhead;
 

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -792,13 +792,13 @@ int64_t getMaxRegOrSharedMemorySizeForPersistentBuffer(
   }
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
   int64_t smem_overhead =
-      scheduler_utils::getSharedMemoryOverheadPerBlock(fusion, reduction_tvs);
+      scheduler_utils::getReductionSmemWorkspace(fusion, reduction_tvs);
 
   smem_overhead += sharedMemoryRoundUpOverhead(
       runtime_info, persistent_buffer_info, project_to_inputs);
 
   int64_t available_shared_memory_size =
-      (int64_t)dev_prop->sharedMemPerMultiprocessor - smem_overhead;
+      (int64_t)dev_prop->sharedMemPerBlockOptin - smem_overhead;
 
   available_persistent_buffer_size =
       std::max(available_persistent_buffer_size, available_shared_memory_size);

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -2651,7 +2651,7 @@ std::unordered_set<TensorView*> getAllTvsFrom(
   return tv_group;
 }
 
-int64_t getSharedMemoryOverheadPerBlock(
+int64_t getReductionSmemWorkspace(
     Fusion* fusion,
     const std::vector<TensorView*>& reduction_tvs,
     int64_t threads_per_block) {
@@ -2674,10 +2674,7 @@ int64_t getSharedMemoryOverheadPerBlock(
   int64_t reduction_broadcast_workspace =
       threads_per_block * dtype_size * welford_factor;
 
-  // (2) part-2, space reserved by the CUDA driver
-  int64_t smem_overhead_driver = (int64_t)dev_prop->reservedSharedMemPerBlock;
-
-  return reduction_broadcast_workspace + smem_overhead_driver;
+  return reduction_broadcast_workspace;
 }
 
 bool isResharding(Fusion* fusion) {

--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -751,7 +751,7 @@ int64_t getPersistentBufferSizeOfTensor(
 //! block (threads_per_block = -1) to calculate the overhead. The caller can
 //! specify a different value if they are sure about the max value used at
 //! runtime.
-int64_t getSharedMemoryOverheadPerBlock(
+int64_t getReductionSmemWorkspace(
     Fusion* fusion,
     const std::vector<TensorView*>& reduction_tvs,
     int64_t threads_per_block = -1);

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -184,8 +184,7 @@ const char* getNvFuserEnv(const char* env_name, const char* default_value) {
 size_t deviceAvailableSharedMemoryBytes() {
   const auto properties = at::cuda::getCurrentDeviceProperties();
   const size_t device_smem_limit = properties->sharedMemPerBlockOptin;
-  const size_t shared_memory_overhead = properties->reservedSharedMemPerBlock;
-  return device_smem_limit - shared_memory_overhead;
+  return device_smem_limit;
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -9062,6 +9062,16 @@ TEST_F(NVFuserTest, RegisteredExactMappingWithExtentReplacment) {
   }
 }
 
+// Always use sharedMemPerBlockOptin to check memory usage in nvFuser,
+// it already considers reservedSharedMemPerBlock
+TEST_F(NVFuserTest, DeviceSharedMemoryLimit) {
+  auto properties = at::cuda::getDeviceProperties(
+      c10::Device(c10::DeviceType::CUDA, 0).index());
+  int device_limit = (int)properties->sharedMemPerBlockOptin;
+  int device_total = (int)properties->sharedMemPerMultiprocessor;
+  int device_reserved = (int)properties->reservedSharedMemPerBlock;
+  EXPECT_EQ(device_limit, device_total - device_reserved);
+}
 // Test file size should be up to 10K LoC. Create a new file for more tests.
 
 } // namespace nvfuser

--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -1269,7 +1269,7 @@ TEST_F(PersistentBufferTest, SmemPersistent2DReduction) {
   fusion->addOutput(tv7);
 
   // If device doesn't have enough shared memory, skip this test
-  int64_t smem_overhead = scheduler_utils::getSharedMemoryOverheadPerBlock(
+  int64_t smem_overhead = scheduler_utils::getReductionSmemWorkspace(
       fusion.get(), scheduler_utils::getReductionTvs(fusion.get()));
   const size_t required_smem_size =
       smem_overhead + total_elements * dataTypeSize(input_dtype);
@@ -1408,7 +1408,7 @@ TEST_F(PersistentBufferTest, InnerPersistentNotEnoughSharedMemory) {
   // split.
   bool is_segmented = false;
   const auto dev_prop = at::cuda::getCurrentDeviceProperties();
-  if ((int64_t)dev_prop->sharedMemPerMultiprocessor < logic_buffer_size) {
+  if ((int64_t)dev_prop->sharedMemPerBlockOptin < logic_buffer_size) {
     is_segmented = true;
   } else {
     int64_t available_buffer_size = normalization_scheduler_utils::
@@ -1493,7 +1493,7 @@ TEST_P(LayerNormSharedMemoryTest, FusionLayerNormSharedMemoryBuffer_CUDA) {
   bool has_enough_regs_smem = true;
   if (logic_buffer_size > scheduler_utils::register_file_size) {
     const auto dev_prop = at::cuda::getCurrentDeviceProperties();
-    if ((int64_t)dev_prop->sharedMemPerMultiprocessor < logic_buffer_size) {
+    if ((int64_t)dev_prop->sharedMemPerBlockOptin < logic_buffer_size) {
       has_enough_regs_smem = false;
     } else {
       int64_t available_buffer_size = normalization_scheduler_utils::


### PR DESCRIPTION
Currently both `sharedMemPerBlockOptin` and `sharedMemPerMultiprocessor` are used and caused some confusion.
This PR removes `sharedMemPerMultiprocessor`.
Added a test to confirm `sharedMemPerBlockOptin = sharedMemPerMultiprocessor - reservedSharedMemPerBlock`