### PR TITLE
Trace all ExprssionEvaluator::evaluate

### DIFF
--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -257,6 +257,7 @@ PolymorphicValue ExpressionEvaluator::evaluate(const Val* value) const {
 const PolymorphicValue& ExpressionEvaluator::evaluate(
     const Val* value,
     std::unordered_map<const Val*, PolymorphicValue>& known_values) const {
+  FUSER_PERF_SCOPE("ExpressionEvaluator::evaluate");
   if (precomputed_values_ && precomputed_values_->hasValidValues()) {
     if (precomputed_values_->getMaybeValueFor(value).hasValue()) {
       return precomputed_values_->getMaybeValueFor(value);
@@ -267,7 +268,6 @@ const PolymorphicValue& ExpressionEvaluator::evaluate(
       getValue(value, known_values);
   if (!maybe_concrete_value.get().hasValue()) {
     if (auto def = value->definition()) {
-      FUSER_PERF_SCOPE("ExpressionEvaluator::evaluate");
       auto outputs = def->evaluate(*this, known_values);
       for (auto i : arange(def->outputs().size())) {
         known_values[def->output(i)] = std::move(outputs[i]);


### PR DESCRIPTION
With this, I'm able to capture more ExpressionEvaluator::evaluate calls for #4431 

Host latency changes are neutral. 

Before: 
```
-------------------------------------------------------------------------------------------------------------------------- benchmark: 18 tests --------------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                                 Min                     Max                    Mean                 StdDev                  Median                   IQR            Outliers          OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=4]            12.3940 (1.0)           14.8680 (1.0)           13.2010 (1.00)          0.6774 (1.0)           13.1395 (1.02)         0.4720 (1.0)           3;1  75,751.8370 (1.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=8]            12.4430 (1.00)          15.5390 (1.05)          13.2902 (1.01)          0.9309 (1.37)          12.9250 (1.0)          0.7820 (1.66)          1;1  75,243.4124 (0.99)         10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=2]            12.4940 (1.01)          15.1890 (1.02)          13.1549 (1.0)           0.7930 (1.17)          12.9800 (1.00)         0.7010 (1.49)          1;1  76,017.3015 (1.0)          10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=16]           12.5740 (1.01)          15.6100 (1.05)          13.2721 (1.01)          0.9019 (1.33)          13.0145 (1.01)         0.7010 (1.49)          1;1  75,346.0266 (0.99)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='steady']               16.3610 (1.32)          19.4370 (1.31)          17.2765 (1.31)          0.9169 (1.35)          17.0420 (1.32)         1.1520 (2.44)          1;0  57,882.0942 (0.76)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=2]           23.8350 (1.92)          30.2580 (2.04)          26.0746 (1.98)          2.4078 (3.55)          25.1480 (1.95)         2.8860 (6.11)          2;0  38,351.4992 (0.50)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=4]           24.5060 (1.98)          34.0240 (2.29)          26.7026 (2.03)          2.8161 (4.16)          25.6285 (1.98)         1.6320 (3.46)          1;1  37,449.5367 (0.49)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=8]           26.4810 (2.14)          30.7080 (2.07)          28.2034 (2.14)          1.4936 (2.20)          27.6525 (2.14)         2.6760 (5.67)          4;0  35,456.7180 (0.47)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=16]          31.2790 (2.52)          44.3040 (2.98)          34.7660 (2.64)          4.2091 (6.21)          33.4735 (2.59)         3.8580 (8.17)          2;1  28,763.7347 (0.38)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='dynamic']              63.6410 (5.13)          72.8880 (4.90)          67.9579 (5.17)          3.2650 (4.82)          68.3795 (5.29)         5.9510 (12.61)         5;0  14,714.9927 (0.19)         10           1
test_many_segment_benchmark[host_bench_mode='steady']                        115.3390 (9.31)         130.2270 (8.76)         120.4356 (9.16)          4.5829 (6.77)         118.9510 (9.20)         5.4100 (11.46)         2;0   8,303.1927 (0.11)         10           1
test_many_segment_benchmark[host_bench_mode='dynamic']                       212.3030 (17.13)        244.0030 (16.41)        219.3692 (16.68)         9.6238 (14.21)        215.2735 (16.66)        7.8560 (16.64)         1;1   4,558.5251 (0.06)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=2]       29,904.9950 (>1000.0)   59,420.0100 (>1000.0)   34,040.8425 (>1000.0)   8,976.1706 (>1000.0)   31,556.3650 (>1000.0)  1,571.9030 (>1000.0)       1;1      29.3765 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=4]       36,337.7130 (>1000.0)   36,824.4370 (>1000.0)   36,546.4698 (>1000.0)     142.2648 (210.01)    36,517.9505 (>1000.0)    183.9680 (389.76)        3;0      27.3624 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=8]       46,387.6670 (>1000.0)   47,555.8340 (>1000.0)   46,685.2951 (>1000.0)     424.2994 (626.34)    46,511.0165 (>1000.0)    157.3880 (333.45)        2;2      21.4200 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=16]      84,924.0830 (>1000.0)  246,911.6630 (>1000.0)  101,584.8945 (>1000.0)  51,065.6370 (>1000.0)   85,248.1440 (>1000.0)    695.0090 (>1000.0)       1;1       9.8440 (0.00)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='compile']         107,141.0580 (>1000.0)  146,287.3920 (>1000.0)  115,396.6248 (>1000.0)  16,037.2446 (>1000.0)  107,917.9675 (>1000.0)  1,068.7870 (>1000.0)       2;2       8.6658 (0.00)         10           1
test_many_segment_benchmark[host_bench_mode='compile']                   153,900.2620 (>1000.0)  174,684.2770 (>1000.0)  159,320.2642 (>1000.0)   6,684.9289 (>1000.0)  156,349.7000 (>1000.0)  9,594.9700 (>1000.0)       1;0       6.2767 (0.00)         10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After:
```
-------------------------------------------------------------------------------------------------------------------------- benchmark: 18 tests --------------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                                 Min                     Max                    Mean                 StdDev                  Median                   IQR            Outliers          OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=4]            12.2340 (1.0)           14.1470 (1.0)           12.9095 (1.0)           0.5855 (1.0)           12.7140 (1.0)          0.6210 (1.59)          4;0  77,462.3339 (1.0)          10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=2]            12.2540 (1.00)          14.8680 (1.05)          13.2100 (1.02)          0.9203 (1.57)          12.9590 (1.02)         1.0420 (2.66)          3;0  75,700.2271 (0.98)         10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=8]            12.5240 (1.02)          15.1790 (1.07)          13.1101 (1.02)          0.8571 (1.46)          12.7495 (1.00)         0.3910 (1.0)           2;2  76,277.0688 (0.98)         10           1
test_pointwise_ops_benchmark[host_bench_mode='steady'-num_iters=16]           12.7240 (1.04)          18.5450 (1.31)          13.9004 (1.08)          1.7611 (3.01)          13.3205 (1.05)         1.0120 (2.59)          1;1  71,940.3758 (0.93)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='steady']               16.3710 (1.34)          19.4770 (1.38)          17.4192 (1.35)          0.8722 (1.49)          17.2430 (1.36)         0.7520 (1.92)          2;1  57,407.9177 (0.74)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=2]           23.9950 (1.96)          26.4500 (1.87)          24.9854 (1.94)          0.8384 (1.43)          24.8520 (1.95)         1.4330 (3.66)          3;0  40,023.3737 (0.52)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=4]           25.1780 (2.06)          28.5940 (2.02)          26.3190 (2.04)          1.1414 (1.95)          25.8490 (2.03)         1.9430 (4.97)          3;0  37,995.3646 (0.49)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=8]           26.9210 (2.20)          32.5220 (2.30)          29.2204 (2.26)          1.9068 (3.26)          28.9650 (2.28)         2.8160 (7.20)          3;0  34,222.6664 (0.44)         10           1
test_pointwise_ops_benchmark[host_bench_mode='dynamic'-num_iters=16]          31.4300 (2.57)          34.7860 (2.46)          32.8041 (2.54)          1.3081 (2.23)          32.1355 (2.53)         2.2440 (5.74)          3;0  30,483.9944 (0.39)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='dynamic']              64.7320 (5.29)          90.4520 (6.39)          70.7501 (5.48)          7.9168 (13.52)         67.6835 (5.32)         4.5780 (11.71)         1;2  14,134.2556 (0.18)         10           1
test_many_segment_benchmark[host_bench_mode='steady']                        115.5090 (9.44)         126.2500 (8.92)         120.2190 (9.31)          3.3987 (5.80)         120.0725 (9.44)         6.1410 (15.71)         4;0   8,318.1527 (0.11)         10           1
test_many_segment_benchmark[host_bench_mode='dynamic']                       209.1370 (17.09)        229.7160 (16.24)        220.7748 (17.10)         6.1780 (10.55)        219.3410 (17.25)        8.2760 (21.17)         3;0   4,529.5025 (0.06)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=2]       29,799.2640 (>1000.0)   31,024.9890 (>1000.0)   30,111.9693 (>1000.0)     373.2236 (637.43)    29,960.7800 (>1000.0)    223.6550 (572.01)        1;2      33.2094 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=4]       34,708.4290 (>1000.0)   81,057.6860 (>1000.0)   40,369.1453 (>1000.0)  14,310.9070 (>1000.0)   35,914.7535 (>1000.0)  1,156.9960 (>1000.0)       1;1      24.7714 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=8]       44,449.8140 (>1000.0)  126,211.6470 (>1000.0)   52,962.4931 (>1000.0)  25,741.5386 (>1000.0)   44,606.1700 (>1000.0)  1,039.0310 (>1000.0)       1;1      18.8813 (0.00)         10           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=16]      80,742.5390 (>1000.0)  239,716.8020 (>1000.0)   97,024.9335 (>1000.0)  50,139.2521 (>1000.0)   80,983.4055 (>1000.0)  1,180.3300 (>1000.0)       1;1      10.3066 (0.00)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='compile']         107,160.8160 (>1000.0)  145,568.9560 (>1000.0)  111,352.5062 (>1000.0)  12,025.1789 (>1000.0)  107,655.1995 (>1000.0)    493.0760 (>1000.0)       1;1       8.9805 (0.00)         10           1
test_many_segment_benchmark[host_bench_mode='compile']                   155,138.5470 (>1000.0)  165,964.6090 (>1000.0)  158,963.2038 (>1000.0)   3,946.4717 (>1000.0)  158,014.7945 (>1000.0)  3,897.2850 (>1000.0)       2;2       6.2908 (0.00)         10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```