### PR TITLE
Remove tests with inner sharded dimensions when using MultiDeviceExecutor

### DIFF
--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -97,7 +97,6 @@ void PipelineTest::validate(bool validate_with_prescribed_values) {
         shardTensor(ref_unsharded_outputs[i].as<at::Tensor>(), output_tv);
     auto obtained_output = outputs[i].as<at::Tensor>();
     
-    EXPECT_EQ(ref_output.sizes(), obtained_output.sizes()) << "Sizes are not equal: Ref: " << ref_output.sizes() << " Output: " << obtained_output.sizes() << std::endl;
     EXPECT_EQ(ref_output.strides(), obtained_output.strides()) << "Strides are not equal: Ref: " << ref_output.strides() << " Output: " << obtained_output.strides() << std::endl;
 
     EXPECT_TRUE(torch::allclose(ref_output, obtained_output))

--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -27,6 +27,8 @@
 #include <kernel_ir.h>
 #include <logical_domain_map.h>
 #include <ops/all_ops.h>
+#include <preseg_passes/optimization_pass.h>
+#include <preseg_passes/reorder_sharded_axis.h>
 #include <runtime/executor.h>
 #include <runtime/executor_params.h>
 #include <runtime/fusion_executor_cache.h>
@@ -37,8 +39,6 @@
 #include <tests/cpp/multidevice.h>
 #include <transform_replay.h>
 #include <transform_rfactor.h>
-#include <preseg_passes/optimization_pass.h>
-#include <preseg_passes/reorder_sharded_axis.h>
 
 namespace nvfuser {
 
@@ -61,8 +61,9 @@ class PipelineTest : public MultiDeviceTest {
   KernelArgumentHolder ref_unsharded_outputs;
   hir::HostIrEvaluatorParams host_ir_executor_params;
 
-  private:
-    preseg_passes::OptimizationPassGuard<preseg_passes::ReorderShardedAxisPass> optimization_guard_;
+ private:
+  preseg_passes::OptimizationPassGuard<preseg_passes::ReorderShardedAxisPass>
+      optimization_guard_;
 };
 
 void PipelineTest::validate(bool validate_with_prescribed_values) {
@@ -96,8 +97,10 @@ void PipelineTest::validate(bool validate_with_prescribed_values) {
     auto ref_output =
         shardTensor(ref_unsharded_outputs[i].as<at::Tensor>(), output_tv);
     auto obtained_output = outputs[i].as<at::Tensor>();
-    
-    EXPECT_EQ(ref_output.strides(), obtained_output.strides()) << "Strides are not equal: Ref: " << ref_output.strides() << " Output: " << obtained_output.strides() << std::endl;
+
+    EXPECT_EQ(ref_output.strides(), obtained_output.strides())
+        << "Strides are not equal: Ref: " << ref_output.strides()
+        << " Output: " << obtained_output.strides() << std::endl;
 
     EXPECT_TRUE(torch::allclose(ref_output, obtained_output))
         << "Device " << communicator_->deviceId() << " has unexpected output "

--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -37,13 +37,14 @@
 #include <tests/cpp/multidevice.h>
 #include <transform_replay.h>
 #include <transform_rfactor.h>
+#include <preseg_passes/optimization_pass.h>
+#include <preseg_passes/reorder_sharded_axis.h>
 
 namespace nvfuser {
 
 class PipelineTest : public MultiDeviceTest {
  protected:
   PipelineTest();
-
   // Utility function used for validation in the tests. It compares the
   // (sharded) outputs with ref_unsharded_outputs. if
   // validate_with_prescribed_values is true, ref_unsharded_outputs is assumed
@@ -59,6 +60,9 @@ class PipelineTest : public MultiDeviceTest {
   KernelArgumentHolder outputs;
   KernelArgumentHolder ref_unsharded_outputs;
   hir::HostIrEvaluatorParams host_ir_executor_params;
+
+  private:
+    preseg_passes::OptimizationPassGuard<preseg_passes::ReorderShardedAxisPass> optimization_guard_;
 };
 
 void PipelineTest::validate(bool validate_with_prescribed_values) {
@@ -92,6 +96,10 @@ void PipelineTest::validate(bool validate_with_prescribed_values) {
     auto ref_output =
         shardTensor(ref_unsharded_outputs[i].as<at::Tensor>(), output_tv);
     auto obtained_output = outputs[i].as<at::Tensor>();
+    
+    EXPECT_EQ(ref_output.sizes(), obtained_output.sizes()) << "Sizes are not equal: Ref: " << ref_output.sizes() << " Output: " << obtained_output.sizes() << std::endl;
+    EXPECT_EQ(ref_output.strides(), obtained_output.strides()) << "Strides are not equal: Ref: " << ref_output.strides() << " Output: " << obtained_output.strides() << std::endl;
+
     EXPECT_TRUE(torch::allclose(ref_output, obtained_output))
         << "Device " << communicator_->deviceId() << " has unexpected output "
         << i << " corresponding to tv " << output_tv
@@ -151,7 +159,7 @@ void PipelineTest::executeAndValidate(bool validate_with_prescribed_values) {
   validate(validate_with_prescribed_values);
 }
 
-PipelineTest::PipelineTest() {
+PipelineTest::PipelineTest() : optimization_guard_(false) {
   fusion = std::make_unique<Fusion>();
 }
 
@@ -347,7 +355,7 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(true),
         testing::Values(false),
         testing::Values(false),
-        testing::Values(0, 1),
+        testing::Values(0),
         testing::Bool()));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -360,7 +368,7 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(false),
         testing::Values(true),
         testing::Values(false),
-        testing::Values(0, 1),
+        testing::Values(0),
         testing::Bool()));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -426,7 +434,7 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(true),
         testing::Values(true),
         testing::Values(true),
-        testing::Values(0, 1),
+        testing::Values(0),
         testing::Values(false)));
 
 // TODO: Distributed reduction tests using fusion executor cache are failing


### PR DESCRIPTION
Prep PR for Issue #3900.

I am modifying the `reorderShardedAxisPass` to set allocation domain consistent with the memory layout requirements of ProcessGroup NCCL and UCC, without changing the logical shape (see PR #4170 for example).

MultiDeviceExecutor does not respect allocation domain, hence, removing these tests. Issue #4453.