### PR TITLE
shardAllLike requires parallel_types to be specified.

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -638,6 +638,25 @@ bool isInnerResharding(Expr* expr) {
   return false;
 }
 
+std::unordered_set<ParallelType> deviceAndStreamParallelTypes() {
+  static auto s = [&] {
+    std::unordered_set<ParallelType> s(
+        {kParallelTypeDIDs.begin(), kParallelTypeDIDs.end()});
+    s.insert(ParallelType::Stream);
+    return s;
+  }();
+  return s;
+}
+
+std::unordered_set<ParallelType> allParallelTypes() {
+  static auto s = [&] {
+    std::unordered_set<ParallelType> s = deviceAndStreamParallelTypes();
+    s.insert(ParallelType::Serial);
+    return s;
+  }();
+  return s;
+}
+
 void shardAllLike(
     TensorView* ref,
     const std::vector<TensorView*>& tvs,
@@ -687,7 +706,8 @@ void shardBetween(
 
   std::unordered_set<TensorView*> all_tvs =
       scheduler_utils::getAllTvsFrom(from, boundary);
-  shardAllLike(ref, {all_tvs.begin(), all_tvs.end()});
+  shardAllLike(
+      ref, {all_tvs.begin(), all_tvs.end()}, deviceAndStreamParallelTypes());
 }
 
 int64_t requestedNumberOfDevices(Fusion* fusion) {

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -65,15 +65,20 @@ bool haveDifferentShardings(
 // Returns whether a resharding expr reshards an inner axis
 bool isInnerResharding(Expr* expr);
 
+// Returns a set that contains DIDs and Stream.
+std::unordered_set<ParallelType> deviceAndStreamParallelTypes();
+
+// Returns all parallel types that can appear during multi-GPU scheduling, i.e.
+// DIDs, Stream, and Serial.
+std::unordered_set<ParallelType> allParallelTypes();
+
 // Shards all tensors in tvs like reference.
 // Accepts a set of parallel types to shard on.
 // If empty, all DID parallel types are used.
 void shardAllLike(
     TensorView* ref,
     const std::vector<TensorView*>& tvs,
-    const std::unordered_set<ParallelType>& parallel_types = {
-        kParallelTypeDIDs.begin(),
-        kParallelTypeDIDs.end()});
+    const std::unordered_set<ParallelType>& parallel_types);
 
 // Shards all TVs between from and to AND between TVs created inside a fusion
 // and to. This is required for (1) expressions like rng_uniform that create a

--- a/csrc/preseg_passes/insert_reshardings.cpp
+++ b/csrc/preseg_passes/insert_reshardings.cpp
@@ -29,20 +29,6 @@ bool shouldReshardAfter(Expr* expr) {
   return expr->inputs().size() == 1 && expr->outputs().size() == 1;
 }
 
-std::unordered_set<ParallelType> getParallelTypesForResharding() {
-  // Consider a reshard case:
-  // input [DIDx(i0), i1] -> op -> output [i0, DIDx(i1)]
-  // This is decomposed into:
-  // input [DIDx(i0), i1] -> op -> output [DIDx(i0), i1] -> set ->
-  // new_output [i0, DIDx(i1)] ParallelType::Serial is required here so the
-  // output is sharded as [DIDx(i0), i1] instead of [DIDx(i0), DIDx(i1)]
-  // when sharding using input as the reference.
-  std::unordered_set<ParallelType> parallel_types{
-      kParallelTypeDIDs.begin(), kParallelTypeDIDs.end()};
-  parallel_types.insert(ParallelType::Serial);
-  return parallel_types;
-}
-
 void insertReshardingSetsBefore(Fusion* fusion) {
   // Remove this after we refactor this as a pre-segmenter pass.
   FusionGuard fg(fusion);
@@ -85,7 +71,7 @@ void insertReshardingSetsBefore(Fusion* fusion) {
       expr = ir_utils::replaceValInExprInputs(expr, input, new_input);
     }
 
-    shardAllLike(output, new_inputs, getParallelTypesForResharding());
+    shardAllLike(output, new_inputs, allParallelTypes());
   }
 }
 
@@ -124,9 +110,21 @@ void insertReshardingSetsAfter(Fusion* fusion) {
       ir_utils::replaceValInAllExprInputsAndFusionOutputs(output, new_output);
       // Update shardings new_output takes output's sharding,
       // output takes input's sharding
-      shardAllLike(output, {new_output});
+      shardAllLike(output, {new_output}, deviceAndStreamParallelTypes());
 
-      shardAllLike(input, {output}, getParallelTypesForResharding());
+      // Consider a reshard case:
+      //
+      //   input [DIDx(i0), i1] -> op -> output [i0, DIDx(i1)]
+      //
+      // This is decomposed into:
+      //
+      //   input [DIDx(i0), i1] -> op -> output [DIDx(i0), i1] -> set ->
+      //   new_output [i0, DIDx(i1)]
+      //
+      // ParallelType::Serial is required here so the output is sharded as
+      // [DIDx(i0), i1] instead of [DIDx(i0), DIDx(i1)] when sharding using
+      // input as the reference.
+      shardAllLike(input, {output}, allParallelTypes());
     }
   }
 }

--- a/csrc/preseg_passes/reorder_sharded_axis.cpp
+++ b/csrc/preseg_passes/reorder_sharded_axis.cpp
@@ -67,7 +67,10 @@ void ReorderShardedAxisPass::runPass(Fusion* fusion) {
       ir_utils::replaceValInAllExprInputsAndFusionOutputs(output, new_output);
 
       // Propagate shardings from input and manually apply sharding deletions.
-      shardAllLike(input, {input_permute, output_permute, new_output});
+      shardAllLike(
+          input,
+          {input_permute, output_permute, new_output},
+          deviceAndStreamParallelTypes());
       output_permute->axis(0)->parallelize(ParallelType::Serial);
       new_output->axis(sharding_axis)->parallelize(ParallelType::Serial);
       output_permute->setDeviceMesh(output->getDeviceMesh());


### PR DESCRIPTION
It's not obvious to me which ParallelType set should be the default value, so I chose to make this argument non-optional to save me some brain power.