### PR TITLE
Minor refactor to HopperPlus in preparation for ping-pong matmul

### DIFF
--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -272,7 +272,7 @@ class MatmulParams : public HeuristicParams {
               // contributions from each portion. Also called split-K.
     WarpTiles // All warp tiles in a K loop for each math warp group are
               // iterated over then the next math warp group's warp tile is
-              // processed. Also called ping-pong or alternating stratgy.
+              // processed. Also called ping-pong or alternating strategy.
   } buffering_loop_level = BufferingLoopLevel::CTATiles;
 
   //! Whether to do regular circular buffering (pipelined) or warp

--- a/csrc/scheduler/matmul_hopper+.h
+++ b/csrc/scheduler/matmul_hopper+.h
@@ -80,6 +80,16 @@ class HopperPlus : public Common {
  private:
   void validate() const;
 
+  bool isCooperative() const {
+    return params_->buffering_loop_level ==
+        MatmulParams::BufferingLoopLevel::CTATiles;
+  }
+
+  bool isPingPong() const {
+    return params_->buffering_loop_level ==
+        MatmulParams::BufferingLoopLevel::WarpTiles;
+  }
+
   // Including current tensor naming convention for reference,
   //  this is very temporary and will change over time and
   //  in fact the whole body of this function will


### PR DESCRIPTION
- Create `isCooperative` and `isPingPong` checks in `HopperPlus`.
- Guard all existing `ParallelType::TIDy` with `isCooperative`
- Create `findFirstRole` helper function to find the first `MatmulDimRole` from left to right in a vector of roles. It is used in `reorderBlockTileTraversal` and will be used in `schedulePingPong`.