### PR TITLE
add register sharing to warp specialized normalization kernel

### DIFF
--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -105,6 +105,10 @@ constexpr int64_t roundUpToN(const int64_t x, const int64_t n) {
   return x % n == 0 ? x : x + (n - x % n);
 }
 
+constexpr int64_t roundDownToN(const int64_t x, const int64_t n) {
+  return x % n == 0 ? x : x - x % n;
+}
+
 // Div x by y, but min at 1
 inline int64_t safeDiv(const int64_t x, const int64_t y) {
   return std::max(x / y, (int64_t)1);


### PR DESCRIPTION
Add register sharing to warp specialized normalization kernel when there are more than 256 threads in each CTA.
If threads per CTA <= 256, each thread can use 256 registers, no need to enable register sharing.
The `tma_branch_registers` is set to `32`, which is a tunable heuristic parameter.