### PR TITLE
Test row parallel linear layers.

### DIFF
--- a/tests/python/multidevice/test_dtensor.py
+++ b/tests/python/multidevice/test_dtensor.py
@@ -110,6 +110,8 @@ class LinearConfig:
     out_features: int
 
 
+# I omitted biases because DeepSeek V3 uses non-biased linear layers in MLA and
+# MoE.
 def define_linear_forward(config: LinearConfig, fd: FusionDefinition) -> None:
     e_in, e_out = config.in_features, config.out_features
 

--- a/tests/python/multidevice/test_dtensor.py
+++ b/tests/python/multidevice/test_dtensor.py
@@ -114,7 +114,7 @@ def test_column_parallel_linear(setup_default_process_group, multidevice_test):
 
     def define_linear_forward(config: LinearConfig, fd: FusionDefinition) -> None:
         d, e = config.d, config.e
-        inp = fd.define_tensor([-1, -1, e])
+        inp = fd.define_tensor([-1, -1, e], contiguity=True)
         weight = fd.define_tensor([d * e, e], contiguity=True)
         bias = fd.define_tensor([d * e], contiguity=True)
         out = fd.ops.linear(inp, weight, bias)
@@ -122,7 +122,7 @@ def test_column_parallel_linear(setup_default_process_group, multidevice_test):
 
     def define_linear_backward(config: LinearConfig, fd: FusionDefinition) -> None:
         d, e = config.d, config.e
-        x = fd.define_tensor([-1, -1, e])
+        x = fd.define_tensor([-1, -1, e], contiguity=True)
         w = fd.define_tensor([d * e, e], contiguity=True)
         grad = fd.define_tensor([-1, -1, d * e], contiguity=True)
 
@@ -147,25 +147,25 @@ def test_column_parallel_linear(setup_default_process_group, multidevice_test):
             bias: DTensor,
         ):
             d = weight.device_mesh.size()
-            e = input.size(-1)
+            e = weight.size(1)
             op = FusionDefinitionWrapper(
                 partial(define_linear_forward, LinearConfig(d, e))
             )
-            outputs = op([input, weight, bias])
+            (output,)= op([input, weight, bias])
             ctx.save_for_backward(input, weight)
-            return outputs[0]
+            return output
 
         @staticmethod
         def backward(ctx, grad_output: DTensor):
-            d = grad_output.device_mesh.size()
-            e = grad_output.to_local().size(-1)
+            input, weight = ctx.saved_tensors
+
+            d = weight.device_mesh.size()
+            e = weight.size(1)
             op = FusionDefinitionWrapper(
                 partial(define_linear_backward, LinearConfig(d, e))
             )
-            input, weight = ctx.saved_tensors
-            outputs = op([input, weight, grad_output])
-            assert len(outputs) == 3
-            return (*outputs,)
+            grad_x, grad_w, grad_b = op([input, weight, grad_output])
+            return (grad_x, grad_w, grad_b)
 
     d, b, s, e = dist.get_world_size(), 2, 1024, 768
     rank = dist.get_rank()
@@ -203,3 +203,105 @@ def test_column_parallel_linear(setup_default_process_group, multidevice_test):
     assert_close(expected_grad_x, grad_x)
     assert_close(expected_grad_w.split(e, dim=0)[rank], grad_w)
     assert_close(expected_grad_b.split(e, dim=0)[rank], grad_b)
+
+
+@pytest.mark.mpi
+def test_row_parallel_linear(setup_default_process_group, multidevice_test):
+    @dataclass
+    class LinearConfig:
+        def __init__(self, num_devices: int, hidden: int):
+            self.d = num_devices
+            self.e = hidden
+
+    # FIXME: reuse definition with column_parallel_linear.
+    def define_linear_forward(config: LinearConfig, fd: FusionDefinition) -> None:
+        d, e = config.d, config.e
+        inp = fd.define_tensor([-1, -1, d * e], contiguity=True)
+        weight = fd.define_tensor([e, d * e], contiguity=True)
+        bias = fd.define_tensor([e], contiguity=True)
+        out = fd.ops.linear(inp, weight, bias)
+        fd.add_output(out)
+
+    def define_linear_backward(config: LinearConfig, fd: FusionDefinition) -> None:
+        d, e = config.d, config.e
+        x = fd.define_tensor([-1, -1, d * e], contiguity=True)
+        w = fd.define_tensor([e, d * e], contiguity=True)
+        grad = fd.define_tensor([-1, -1, e], contiguity=True)
+
+        grad_x = fd.ops.matmul(grad, w)
+
+        grad_flat_t = fd.ops.permute(fd.ops.reshape(grad, [-1, e]), [1, 0])
+        x_flat = fd.ops.reshape(x, [-1, d * e])
+        grad_w = fd.ops.matmul(grad_flat_t, x_flat)
+
+        grad_b = fd.ops.sum(grad, [0, 1])
+
+        fd.add_output(grad_x)
+        fd.add_output(grad_w)
+        fd.add_output(grad_b)
+
+    class LinearFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(
+            ctx,
+            input: DTensor,
+            weight: DTensor,
+            bias: DTensor,
+        ):
+            d = weight.device_mesh.size()
+            e = weight.size(0)
+            op = FusionDefinitionWrapper(
+                partial(define_linear_forward, LinearConfig(d, e))
+            )
+            (output,) = op([input, weight, bias])
+            ctx.save_for_backward(input, weight)
+            return output
+
+        @staticmethod
+        def backward(ctx, grad_output: DTensor):
+            input, weight = ctx.saved_tensors
+
+            d = weight.device_mesh.size()
+            e = weight.size(0)
+            op = FusionDefinitionWrapper(
+                partial(define_linear_backward, LinearConfig(d, e))
+            )
+            (grad_x, grad_w, grad_b) = op([input, weight, grad_output])
+            return (grad_x, grad_w, grad_b)
+
+    d, b, s, e = dist.get_world_size(), 2, 1024, 768
+    rank = dist.get_rank()
+    torch.cuda.set_device(rank)
+
+    mesh = dist.device_mesh.init_device_mesh("cuda", [d])
+
+    inp_tensor = torch.randn(b, s, d * e, requires_grad=True)
+    weight_tensor = torch.randn(e, d * e, requires_grad=True)
+    bias_tensor = torch.randn(e, requires_grad=True)
+
+    inp_dtensor = dist.tensor.distribute_tensor(inp_tensor, mesh, [Shard(-1)])
+    weight_dtensor = dist.tensor.distribute_tensor(weight_tensor, mesh, [Shard(-1)])
+    bias_dtensor = dist.tensor.distribute_tensor(bias_tensor, mesh, [Replicate()])
+
+    def assert_close(expected_tensor, dtensor):
+        torch.testing.assert_close(
+            expected_tensor, dtensor.to_local().cpu(), rtol=1.3e-6, atol=1e-3
+        )
+
+    out_tensor = torch.nn.functional.linear(inp_tensor, weight_tensor, bias_tensor)
+    out_dtensor = LinearFunction.apply(inp_dtensor, weight_dtensor, bias_dtensor)
+    assert_close(out_tensor, out_dtensor)
+
+    (expected_grad_x, expected_grad_w, expected_grad_b) = torch.autograd.grad(
+        out_tensor,
+        (inp_tensor, weight_tensor, bias_tensor),
+        torch.ones_like(out_tensor),
+    )
+    (grad_x, grad_w, grad_b) = torch.autograd.grad(
+        out_dtensor,
+        (inp_dtensor, weight_dtensor, bias_dtensor),
+        torch.ones_like(out_dtensor),
+    )
+    assert_close(expected_grad_x.split(e, dim=-1)[rank], grad_x)
+    assert_close(expected_grad_w.split(e, dim=-1)[rank], grad_w)
+    assert_close(expected_grad_b, grad_b)


### PR DESCRIPTION
I removed biases because they are not used in DS. See https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/configuration_deepseek.py#L150, https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/modeling_deepseek.py#L383-L385 and other occurrences of `bias=False` in the same file. 