### PR TITLE
Support Blackwell in HopperPlus matmul scheduler: step 1 - no splitk, no smem epilogue

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -3047,7 +3047,7 @@ void IterDomain::parallelize(ParallelType t) {
         "a start of ",
         start(),
         " and extent ",
-        extent(),
+        extent()->toInlineString(),
         " .");
   }
 

--- a/csrc/scheduler/matmul_hopper+.cpp
+++ b/csrc/scheduler/matmul_hopper+.cpp
@@ -568,8 +568,13 @@ void HopperPlus::scheduleMmaResults() {
     transformLikeMmaOutputWithK(mma_result);
 
     mma_result->setMemoryType(MemoryType::Tensor);
-    mma_result->setAllocationDomain(mma_result->getLoopDomain(), true);
-    mma_result->setTMemDimSepPos(-3);
+    std::vector<IterDomain*> allocation_domain = mma_result->getLoopDomain();
+    // [Mi, (DimSep), ...others]
+    auto item = allocation_domain[allocation_domain.size() - 3];
+    allocation_domain.erase(allocation_domain.begin() + allocation_domain.size() - 3);
+    allocation_domain.insert(allocation_domain.begin(), item);
+    mma_result->setAllocationDomain(allocation_domain, true);
+    mma_result->setTMemDimSepPos(1);
 
     // auto s = mma_utils::MmaSwizzler::scheduleMmaOutputAllocation(
     //     mma_result->getLoopDomain());

--- a/csrc/scheduler/matmul_hopper+.cpp
+++ b/csrc/scheduler/matmul_hopper+.cpp
@@ -620,7 +620,7 @@ void HopperPlus::scheduleEpilogueWithoutSmemEpilogue() {
     // Vectorize the TMem load
     for (auto mma_result : mma_results_) {
       NVF_ERROR(mma_result->uses().size() == 1);
-      TensorView* tmem_ld_tv = mma_result->uses().front()->as<TensorView>();
+      TensorView* tmem_ld_tv = cacheAfter(mma_result);
       tmem_ld_tv->axis(-1)->parallelize(ParallelType::Vectorize);
     }
 

--- a/csrc/scheduler/matmul_hopper+.cpp
+++ b/csrc/scheduler/matmul_hopper+.cpp
@@ -636,11 +636,6 @@ void HopperPlus::scheduleEpilogueWithoutSmemEpilogueBlackwell() {
         scheduler_utils::BoundedDirectionalTransformPropagator::Options()
             .propagateParallelType());
 
-    // Vectorize the TMem load
-    for (auto tmem_ld_tv : tmem_ld_tvs) {
-      tmem_ld_tv->axis(-1)->parallelize(ParallelType::Vectorize);
-    }
-
     // TODO: Support vectorization_factor in MatmulParams
     if (tmem_vectorize_factor > params_->supported_vec_size.epilogue) {
       d->split(-1, params_->supported_vec_size.epilogue);
@@ -656,6 +651,10 @@ void HopperPlus::scheduleEpilogueWithoutSmemEpilogueBlackwell() {
     if (!cached_tvs.empty()) {
       scheduler_utils::parallelizeAllLike(d, -1, cached_tvs);
     }
+  }
+  // Vectorize the TMem load
+  for (auto tmem_ld_tv : tmem_ld_tvs) {
+    tmem_ld_tv->axis(-1)->parallelize(ParallelType::Vectorize);
   }
 }
 

--- a/csrc/scheduler/matmul_hopper+.cpp
+++ b/csrc/scheduler/matmul_hopper+.cpp
@@ -516,7 +516,10 @@ void HopperPlus::parallelizeBlocks(const std::vector<TensorView*>& tvs) const {
 void HopperPlus::setMmaResultAllocationDomain(TensorView* mma_result) {
   if (isBlackwell(params_->mma_macro)) {
     mma_result->setMemoryType(MemoryType::Tensor);
-    // [Mi, (DimSep), ...other]
+    // So far, we only support M128 Blackwell MMA macros. For these macros,
+    // Rows of the accumulator span all 128 lanes of TMem. That is, the
+    // allocation domain should be [Mi, (DimSep), ...other]
+    // We want to move Mi to the front of the domain.
     std::vector<IterDomain*> allocation_domain = mma_result->getLoopDomain();
     auto item = allocation_domain[allocation_domain.size() - 3];
     allocation_domain.erase(

--- a/csrc/scheduler/matmul_hopper+.cpp
+++ b/csrc/scheduler/matmul_hopper+.cpp
@@ -591,7 +591,10 @@ void HopperPlus::scheduleEpilogueWithoutSmemEpilogue() {
       splitk_sums_.empty() ? mma_results_ : splitk_sums_;
   std::vector<TensorView*> tmem_ld_tvs;
   for (auto mma_result : mma_results_) {
-    tmem_ld_tvs.push_back(cacheAfter(mma_result));
+    TensorView* tmem_ld_tv = cacheAfter(mma_result);
+    tmem_ld_tv->definition()->as<LoadStoreOp>()->setOpType(
+        LoadStoreOpType::LdTMem);
+    tmem_ld_tvs.push_back(tmem_ld_tv);
   }
   for (auto& [c, c_cache] : cached_epilogue_inputs_) {
     cached_tvs.push_back(c_cache);

--- a/csrc/scheduler/matmul_hopper+.cpp
+++ b/csrc/scheduler/matmul_hopper+.cpp
@@ -646,6 +646,9 @@ void HopperPlus::scheduleEpilogueWithoutSmemEpilogueBlackwell() {
     // be vectorized to 512 byte, but gmem load/store can only be vectorized
     // to 16 bytes. So we need to further split the last dimension and use
     // multiple vector loads/stores. for each TMem load/store.
+    // After split and parallelization:
+    // (v = tmem_vectorize_factor, vv = params_->supported_vec_size.epilogue)
+    // [..., Mo * No, Mw, Nw, Mi (TIDx), Ni / v, v/vv, vv]
     // TODO: Support vectorization_factor in MatmulParams
     if (tmem_vectorize_factor > params_->supported_vec_size.epilogue) {
       d->split(-1, params_->supported_vec_size.epilogue);

--- a/csrc/scheduler/matmul_hopper+.h
+++ b/csrc/scheduler/matmul_hopper+.h
@@ -175,8 +175,11 @@ class HopperPlus : public Common {
 
   void parallelizeBlocks(const std::vector<TensorView*>& tvs) const;
 
+  void setMmaResultAllocationDomain(TensorView* mma_result);
   void scheduleMmaResults();
 
+  void scheduleEpilogueWithoutSmemEpilogueHopper();
+  void scheduleEpilogueWithoutSmemEpilogueBlackwell();
   void scheduleEpilogueWithoutSmemEpilogue();
   void scheduleEpilogueWithSmemEpilogue();
   void scheduleEpilogue();

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3329,6 +3329,9 @@ class HopperPlusMatmulSchedulerTest
       NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(9, 0, 10, 0);
     } else {
       NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(10, 0, 11, 0);
+      if (splitk_factor > 1) {
+        GTEST_SKIP() << "SplitK is not supported for Blackwell yet.";
+      }
     }
 
     if (a_k_inner) {

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3332,6 +3332,9 @@ class HopperPlusMatmulSchedulerTest
       if (splitk_factor > 1) {
         GTEST_SKIP() << "SplitK is not supported for Blackwell yet.";
       }
+      if (use_smem_epilogue) {
+        GTEST_SKIP() << "TMA store is not supported for Blackwell yet.";
+      }
     }
 
     if (a_k_inner) {

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -3329,7 +3329,6 @@ class HopperPlusMatmulSchedulerTest
       NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(9, 0, 10, 0);
     } else {
       NVFUSER_TEST_CUDA_ARCH_RANGE_GUARD(10, 0, 11, 0);
-      GTEST_SKIP() << "Blackwell tests are not supported yet";
     }
 
     if (a_k_inner) {


### PR DESCRIPTION
Example kernel:

<details>
<summary>General/HopperPlusMatmulSchedulerTest.FusedMultiplySum/MN_512_256_128_MmaMacro_m128_n128_k16</summary>

```CUDA
// Codegen generated code
namespace tcgen05 {
__device__ __inline__ void alloc(uint32_t in0, uint32_t in1) {
  asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;\n"::"r"(in0), "r"(in1));
}
__device__ __inline__ void relinquishAllocPermit() {
  asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;\n");
}
__device__ __inline__ void mma_f16(uint32_t in0, uint64_t in1, uint64_t in2, uint32_t in3, bool in4) {
  asm volatile(
    "{\n"
    "  .reg .pred p0; \n"
    "  setp.ne.b32 p0, %4, 0;\n"
    "  tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, p0;\n"
    "}\n"
    :
    :"r"(in0),
     "l"(in1),
     "l"(in2),
     "r"(in3),
     "r"((uint32_t)(in4))
  );
}
__device__ __inline__ void commit(uint32_t in0) {
  asm volatile("tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [%0];\n"::"r"(in0));
}
__device__ __inline__ void load32x32b(Array<float, 128, 1>& out0, uint32_t in0) {
  asm(
    "tcgen05.ld.sync.aligned.32x32b.x128.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, %38, %39, %40, %41, %42, %43, %44, %45, %46, %47, %48, %49, %50, %51, %52, %53, %54, %55, %56, %57, %58, %59, %60, %61, %62, %63, %64, %65, %66, %67, %68, %69, %70, %71, %72, %73, %74, %75, %76, %77, %78, %79, %80, %81, %82, %83, %84, %85, %86, %87, %88, %89, %90, %91, %92, %93, %94, %95, %96, %97, %98, %99, %100, %101, %102, %103, %104, %105, %106, %107, %108, %109, %110, %111, %112, %113, %114, %115, %116, %117, %118, %119, %120, %121, %122, %123, %124, %125, %126, %127}, [%128];\n"
    :"=f"(out0[0]),
     "=f"(out0[1]),
     "=f"(out0[2]),
     "=f"(out0[3]),
     "=f"(out0[4]),
     "=f"(out0[5]),
     "=f"(out0[6]),
     "=f"(out0[7]),
     "=f"(out0[8]),
     "=f"(out0[9]),
     "=f"(out0[10]),
     "=f"(out0[11]),
     "=f"(out0[12]),
     "=f"(out0[13]),
     "=f"(out0[14]),
     "=f"(out0[15]),
     "=f"(out0[16]),
     "=f"(out0[17]),
     "=f"(out0[18]),
     "=f"(out0[19]),
     "=f"(out0[20]),
     "=f"(out0[21]),
     "=f"(out0[22]),
     "=f"(out0[23]),
     "=f"(out0[24]),
     "=f"(out0[25]),
     "=f"(out0[26]),
     "=f"(out0[27]),
     "=f"(out0[28]),
     "=f"(out0[29]),
     "=f"(out0[30]),
     "=f"(out0[31]),
     "=f"(out0[32]),
     "=f"(out0[33]),
     "=f"(out0[34]),
     "=f"(out0[35]),
     "=f"(out0[36]),
     "=f"(out0[37]),
     "=f"(out0[38]),
     "=f"(out0[39]),
     "=f"(out0[40]),
     "=f"(out0[41]),
     "=f"(out0[42]),
     "=f"(out0[43]),
     "=f"(out0[44]),
     "=f"(out0[45]),
     "=f"(out0[46]),
     "=f"(out0[47]),
     "=f"(out0[48]),
     "=f"(out0[49]),
     "=f"(out0[50]),
     "=f"(out0[51]),
     "=f"(out0[52]),
     "=f"(out0[53]),
     "=f"(out0[54]),
     "=f"(out0[55]),
     "=f"(out0[56]),
     "=f"(out0[57]),
     "=f"(out0[58]),
     "=f"(out0[59]),
     "=f"(out0[60]),
     "=f"(out0[61]),
     "=f"(out0[62]),
     "=f"(out0[63]),
     "=f"(out0[64]),
     "=f"(out0[65]),
     "=f"(out0[66]),
     "=f"(out0[67]),
     "=f"(out0[68]),
     "=f"(out0[69]),
     "=f"(out0[70]),
     "=f"(out0[71]),
     "=f"(out0[72]),
     "=f"(out0[73]),
     "=f"(out0[74]),
     "=f"(out0[75]),
     "=f"(out0[76]),
     "=f"(out0[77]),
     "=f"(out0[78]),
     "=f"(out0[79]),
     "=f"(out0[80]),
     "=f"(out0[81]),
     "=f"(out0[82]),
     "=f"(out0[83]),
     "=f"(out0[84]),
     "=f"(out0[85]),
     "=f"(out0[86]),
     "=f"(out0[87]),
     "=f"(out0[88]),
     "=f"(out0[89]),
     "=f"(out0[90]),
     "=f"(out0[91]),
     "=f"(out0[92]),
     "=f"(out0[93]),
     "=f"(out0[94]),
     "=f"(out0[95]),
     "=f"(out0[96]),
     "=f"(out0[97]),
     "=f"(out0[98]),
     "=f"(out0[99]),
     "=f"(out0[100]),
     "=f"(out0[101]),
     "=f"(out0[102]),
     "=f"(out0[103]),
     "=f"(out0[104]),
     "=f"(out0[105]),
     "=f"(out0[106]),
     "=f"(out0[107]),
     "=f"(out0[108]),
     "=f"(out0[109]),
     "=f"(out0[110]),
     "=f"(out0[111]),
     "=f"(out0[112]),
     "=f"(out0[113]),
     "=f"(out0[114]),
     "=f"(out0[115]),
     "=f"(out0[116]),
     "=f"(out0[117]),
     "=f"(out0[118]),
     "=f"(out0[119]),
     "=f"(out0[120]),
     "=f"(out0[121]),
     "=f"(out0[122]),
     "=f"(out0[123]),
     "=f"(out0[124]),
     "=f"(out0[125]),
     "=f"(out0[126]),
     "=f"(out0[127])
    :"r"(in0)
  );
}
__device__ __inline__ void waitLoad() {
  asm volatile("tcgen05.wait::ld.sync.aligned;\n");
}
__device__ __inline__ void dealloc(uint32_t in0, uint32_t in1) {
  asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;\n"::"r"(in0), "r"(in1));
}
} // namespace tcgen05
__global__ void nvfuser_none_f0_c0_r0_g0(Tensor<__half, 3, 3> T0, Tensor<__half, 3, 3> T1, const __grid_constant__ TensorMap var0, const __grid_constant__ TensorMap var1, Tensor<__half, 2, 2> T3) {
  alignas(16) extern __shared__ char array[];
  const unsigned smem_offset = 0;
  nvfuser_index_t i2;
  i2 = ceilDiv(T0.logical_size[0LL], 32);
  nvfuser_index_t i3;
  i3 = -1 + i2;
  nvfuser_index_t i4;
  i4 = i3 % 2;
  uint32_t i5;
  i5 = (uint32_t)(((i3 / 2) % 2));
  const TensorMap* ptr6;
  ptr6 = &var0;
  nvfuser_index_t i7;
  i7 = 128 * ((nvfuser_index_t)blockIdx.x);
  __half* T5 = reinterpret_cast<__half*>(array + smem_offset + 33792);
  uint32_t i8;
  i8 = toSmem(T5);
  const TensorMap* ptr9;
  ptr9 = &var1;
  nvfuser_index_t i10;
  i10 = 256 * ((nvfuser_index_t)blockIdx.y);
  __half* T4 = reinterpret_cast<__half*>(array + smem_offset + 1024);
  uint32_t i11;
  i11 = toSmem(T4);
  nvfuser_index_t i12;
  i12 = 8192 * ((nvfuser_index_t)threadIdx.y);
  uint32_t i13;
  i13 = i11 + i12;
  nvfuser_index_t i14;
  i14 = 128 * ((nvfuser_index_t)threadIdx.y);
  uint16_t i15;
  i15 = (uint16_t)(i14);
  Array<uint16_t, 2, 1> a16;
  a16 = Array<uint16_t, 2, 1>{0, i15};
  uint32_t i17;
  i17 = (i11 + (16384 * i4)) + i12;
  uint32_t i18;
  i18 = i8 + (8192 * i4);
  nvfuser_index_t i19;
  i19 = (((T1.logical_size[2LL] * ((nvfuser_index_t)threadIdx.x)) + ((128 * T1.logical_size[2LL]) * ((nvfuser_index_t)threadIdx.y))) + i7) + ((256 * T1.logical_size[2LL]) * ((nvfuser_index_t)blockIdx.y));
  bool b20;
  b20 = (((nvfuser_index_t)threadIdx.x) + (((nvfuser_index_t)threadIdx.y) * 128)) < 32LL;
  bool b21;
  b21 = ((nvfuser_index_t)threadIdx.x) < 32ULL;
  bool b22;
  b22 = ((nvfuser_index_t)threadIdx.y) == 0ULL;
  nvfuser_index_t i23;
  i23 = ((nvfuser_index_t)threadIdx.x) + i14;
  bool b24;
  b24 = (i23 + i10) < T0.logical_size[1LL];
  nvfuser_index_t i25;
  i25 = (7 - T1.logical_size[2LL]) + i7;
  uint32_t* T8 = reinterpret_cast<uint32_t*>(array + smem_offset + 0);
  if (b20) {
    tcgen05::alloc((uint32_t)(toSmem(T8)), 256U);
  }
  if (b20) {
    tcgen05::relinquishAllocPermit();
  }
  __syncthreads();
  TMemTensor T2(T8[0], 0, (uint16_t)(0));
  uint64_t* T10 = reinterpret_cast<uint64_t*>(array + smem_offset + 16);
  #pragma unroll
  for(nvfuser_index_t i26 = 0; i26 < 2; ++i26) {
    if (((Hopper::electSync(4294967295U) && b21) && b22)) {
      mbarrier::init(toSmem((&T10[i26])), 2U);
    }
  }
  __syncthreads();
  if (((Hopper::electSync(4294967295U) && b21) && b22)) {
    mbarrier::arriveExpectTX(toSmem((&T10[0])), 8192U);
    #pragma unroll
    for(nvfuser_index_t i27 = 0; i27 < 2; ++i27) {
      Hopper::cpAsyncBulkTensorTileG2S((Hopper::CpAsyncBulkTensorTileG2SIndex<2>{ ptr6, (Array<int, 2, 1>{(int32_t)((i7 + (64 * i27))), 0}), toSmem((&T10[0])) }), (i8 + (4096 * i27)));
    }
    mbarrier::arriveExpectTX(toSmem((&T10[0])), 16384U);
    #pragma unroll
    for(nvfuser_index_t i28 = 0; i28 < 4; ++i28) {
      Hopper::cpAsyncBulkTensorTileG2S((Hopper::CpAsyncBulkTensorTileG2SIndex<2>{ ptr9, (Array<int, 2, 1>{(int32_t)((i10 + (64 * i28))), 0}), toSmem((&T10[0])) }), (i11 + (4096 * i28)));
    }
  }
  #pragma unroll 1
  for(nvfuser_index_t i29 = 0; i29 < i3; ++i29) {
    int i30;
    i30 = (int32_t)((32 + (32 * i29)));
    nvfuser_index_t i31;
    i31 = (1 + i29) % 2;
    uint32_t i32;
    i32 = i8 + (8192 * i31);
    uint32_t i33;
    i33 = i11 + (16384 * i31);
    nvfuser_index_t i34;
    i34 = i29 % 2;
    uint32_t i35;
    i35 = i13 + (16384 * i34);
    uint32_t i36;
    i36 = i8 + (8192 * i34);
    if (((Hopper::electSync(4294967295U) && b21) && b22)) {
      mbarrier::arriveExpectTX(toSmem((&T10[((1LL + i29) % 2)])), 8192U);
      #pragma unroll
      for(nvfuser_index_t i27 = 0; i27 < 2; ++i27) {
        Hopper::cpAsyncBulkTensorTileG2S((Hopper::CpAsyncBulkTensorTileG2SIndex<2>{ ptr6, (Array<int, 2, 1>{(int32_t)((i7 + (64 * i27))), i30}), toSmem((&T10[((1LL + i29) % 2)])) }), (i32 + (4096 * i27)));
      }
      mbarrier::arriveExpectTX(toSmem((&T10[((1LL + i29) % 2)])), 16384U);
      #pragma unroll
      for(nvfuser_index_t i28 = 0; i28 < 4; ++i28) {
        Hopper::cpAsyncBulkTensorTileG2S((Hopper::CpAsyncBulkTensorTileG2SIndex<2>{ ptr9, (Array<int, 2, 1>{(int32_t)((i10 + (64 * i28))), i30}), toSmem((&T10[((1LL + i29) % 2)])) }), (i33 + (4096 * i28)));
      }
    }
    mbarrier::waitParity(toSmem((&T10[(i29 % 2)])), (uint32_t)(((i29 / 2) % 2)));
    #pragma unroll
    for(nvfuser_index_t i37 = 0; i37 < 2; ++i37) {
      nvfuser_index_t i38;
      i38 = 2048 * i37;
      uint32_t i39;
      i39 = i35 + i38;
      uint32_t i40;
      i40 = i36 + i38;
      uint64_t* T9 = reinterpret_cast<uint64_t*>(array + smem_offset + 50176);
      mbarrier::init(toSmem(T9), 1U);
      __syncthreads();
      if ((Hopper::electSync(4294967295U) && b21)) {
        tcgen05::mma_f16((uint32_t)(T2 + a16), (4611756662066249728ULL | ((262143ULL & (uint64_t)(i39)) >> 4ULL)), (4611756662066249728ULL | ((262143ULL & (uint64_t)(i40)) >> 4ULL)), 136413200U, (!((i29 == 0) && (i37 == 0))));
        tcgen05::commit(toSmem(T9));
      }
      mbarrier::waitParity(toSmem((&T9[0])), 0U);
      __syncthreads();
      mbarrier::inval(toSmem(T9));
    }
  }
  mbarrier::waitParity(toSmem((&T10[i4])), i5);
  #pragma unroll
  for(nvfuser_index_t i37 = 0; i37 < 2; ++i37) {
    nvfuser_index_t i41;
    i41 = 2048 * i37;
    uint32_t i42;
    i42 = i17 + i41;
    uint32_t i43;
    i43 = i18 + i41;
    uint64_t* T9 = reinterpret_cast<uint64_t*>(array + smem_offset + 50176);
    mbarrier::init(toSmem(T9), 1U);
    __syncthreads();
    if ((Hopper::electSync(4294967295U) && b21)) {
      tcgen05::mma_f16((uint32_t)(T2 + a16), (4611756662066249728ULL | ((262143ULL & (uint64_t)(i42)) >> 4ULL)), (4611756662066249728ULL | ((262143ULL & (uint64_t)(i43)) >> 4ULL)), 136413200U, true);
      tcgen05::commit(toSmem(T9));
    }
    mbarrier::waitParity(toSmem((&T9[0])), 0U);
    __syncthreads();
    mbarrier::inval(toSmem(T9));
  }
  #pragma unroll
  for(nvfuser_index_t i44 = 0; i44 < 2; ++i44) {
    if (((Hopper::electSync(4294967295U) && b21) && b22)) {
      mbarrier::inval(toSmem((&T10[i44])));
    }
  }
  Array<float, 128, 128> T7;
  tcgen05::load32x32b((*reinterpret_cast<Array<float, 128, 1>*>(&T7[0])), (uint32_t)(T2 + (Array<uint16_t, 2, 1>{(uint16_t)((32LL * (((nvfuser_index_t)threadIdx.x) / 32LL))), i15})));
  tcgen05::waitLoad();
  __syncthreads();
  if ((i23 < 32LL)) {
    tcgen05::dealloc(T8[0], 256U);
  }
  Array<__half, 128, 8> T6;
  #pragma unroll
  for(nvfuser_index_t i45 = 0; i45 < 128; ++i45) {
    T6[i45]
       = __float2half(T7[i45]);
  }
  #pragma unroll
  for(nvfuser_index_t i46 = 0; i46 < 16; ++i46) {
    nvfuser_index_t i47;
    i47 = 8 * i46;
    if ((b24 && (i25 < (-i47)))) {
      loadLocalToGlobal<__half, /*vec_size=*/8, /*is_volatile=*/false>( &T3[(i19 + i47)], &T6[i47]);
    }
  }
}
```
</details>