### PR TITLE
[Hopper matmul] Account for persistence when computing max circ buffer stages

### DIFF
--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -408,6 +408,7 @@ class MatmulParams : public HeuristicParams {
        << "Use shared memory epilogue: " << use_smem_epilogue << "\n"
        << "Promote re-use of prologue shared memory: "
        << promote_prologue_smem_reuse << "\n"
+       << "Use ldmatrix/stmatrix in epilogue: " << use_ldst_matrix << "\n"
        << "Split-K factor: " << splitk_factor << "\n"
        << "====================================\n";
     return ss.str();

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -140,7 +140,9 @@ void limitCircularBufferingSmemOperands(
     // in rare cases
     num_tiles_per_cta = ceilDiv(tiles_m * tiles_n, num_sms);
   }
-  int64_t stages = k_stages_per_tile * num_tiles_per_cta;
+  int64_t stages = std::min(
+      (int64_t)mparams->circular_buffer_options.smem_circular_buffer_stage,
+      k_stages_per_tile * num_tiles_per_cta);
 
   mparams->circular_buffer_options.circular_buffer_smem_write = (stages != 1);
   mparams->circular_buffer_options.smem_circular_buffer_stage = (int)stages;

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -144,6 +144,11 @@ void limitCircularBufferingSmemOperands(
       (int64_t)mparams->circular_buffer_options.smem_circular_buffer_stage,
       k_stages_per_tile * num_tiles_per_cta);
 
+  // Limit to 8 stages, even though in some cases we could use more. This is
+  // needed because mbarrier initialization has a penalty and we do not expect
+  // performance gains beyond 8 stages.
+  stages = std::min(stages, 8L);
+
   mparams->circular_buffer_options.circular_buffer_smem_write = (stages != 1);
   mparams->circular_buffer_options.smem_circular_buffer_stage = (int)stages;
 }


### PR DESCRIPTION
Currently we limit the number of circular buffering stages in our heuristic to the number of stages per tile. Since mbarriers have an smem overhead as well as a latency overhead due to initialization/invalidation we should not use more stages than needed for a given problem. However, when we use persistent CTAs we are able to circular buffer across _tiles_ as well, so the limit should be increased to the number of stages per tile times the max number of tiles per SM. That is what this PR does.

It also includes a minor refactor where I created `maximizeHopperOperandStages` where I try and maximize the number of stages used given the CTA tile size and available smem. These two utilities can be used in sequence to automatically set the number of stages.
