### PR TITLE
Modify IdModel Loop map to be aware of `stage_slice_position`

### DIFF
--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -776,21 +776,24 @@ std::vector<AsyncWarp> createAsyncWarps(const std::vector<Expr*>& exprs) {
   std::vector<AsyncWarp> async_warps;
 
   // Gather all async operations.
+  // TODO Add support for blackwell MmaOp
   std::vector<Expr*> async_warp_exprs;
   std::copy_if(
       exprs.begin(),
       exprs.end(),
       std::back_inserter(async_warp_exprs),
-      [](Expr* e) {
-        // TODO Add support for blackwell MmaOp
-        return ir_utils::isCpAsyncBulkLoad(e);
-      });
+      [](Expr* e) { return ir_utils::isCpAsyncBulkLoad(e); });
 
-  // short-circuit: no async operations detected.
+  // short-circuit: No async operations detected.
   if (async_warp_exprs.size() <= 1) {
     return async_warps;
   }
 
+  // TODO Divide into operations into separate AsyncWarps for multi-role
+  // specialization. The current assumption is a single AsyncWarp with same
+  // stage_slice_position.
+
+  // Get TensorViews for async warps.
   std::vector<TensorView*> async_warp_tvs;
   std::transform(
       async_warp_exprs.begin(),
@@ -826,9 +829,6 @@ std::vector<AsyncWarp> createAsyncWarps(const std::vector<Expr*>& exprs) {
   NVF_ERROR(async_warp_tv != nullptr);
   int64_t stage_slice_position = stage_slice_positions.front();
 
-  // TODO Divide into AsyncWarps for multi-role specialization
-  // The current assumption is a single AsyncWarp with same
-  // stage_slice_position. Get TensorViews for async warps
   async_warps.emplace_back(
       async_warp_exprs, async_warp_tvs, stage_slice_position);
   return async_warps;

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -585,6 +585,9 @@ int64_t getForLoopIndex(
 Val* CircularBufferInfo::getLinearIndex(
     TensorView* circular_buffer_tv,
     const std::vector<ForLoop*>& loops) const {
+  int64_t compute_at_loop_index =
+      getForLoopIndex(circular_buffer_tv, loops, /*is_inner_most_axis=*/true);
+
   // short-circuit: return index for inner-most for-loop if not warp specialized
   // with register sharing
   const auto& circular_buffer_type =
@@ -592,14 +595,11 @@ Val* CircularBufferInfo::getLinearIndex(
   bool is_warp_specialized =
       std::holds_alternative<WarpSpecialized>(circular_buffer_type);
   if (!is_warp_specialized) {
-    int64_t loop_index =
-        getForLoopIndex(circular_buffer_tv, loops, /*is_inner_most_axis=*/true);
-    return loops[loop_index]->indexOrStartIfTrivial();
+    return loops[compute_at_loop_index]->indexOrStartIfTrivial();
   }
 
   // The inner-most and outer-most for loops can be different.
   // Get outer-most for-loop index.
-  auto warp_specialized = std::get<WarpSpecialized>(circular_buffer_type);
   int64_t outer_loop_index =
       getForLoopIndex(circular_buffer_tv, loops, /*is_inner_most_axis=*/false);
 
@@ -607,9 +607,10 @@ Val* CircularBufferInfo::getLinearIndex(
   // operations are inserted in circular buffering pass. Use
   // stage_slice_position if available. Otherwise, the default value is the
   // first serial for-loop to the left of compute_at_position.
+  auto warp_specialized = std::get<WarpSpecialized>(circular_buffer_type);
   int64_t inner_loop_index = (warp_specialized.stage_slice_position.has_value())
       ? warp_specialized.stage_slice_position.value() - 1
-      : getForLoopIndex(circular_buffer_tv, loops, /*is_inner_most_axis=*/true);
+      : compute_at_loop_index;
 
   // Calculate insertion position.
   int64_t insertion_position = inner_loop_index - outer_loop_index + 1;

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -585,9 +585,6 @@ int64_t getForLoopIndex(
 Val* CircularBufferInfo::getLinearIndex(
     TensorView* circular_buffer_tv,
     const std::vector<ForLoop*>& loops) const {
-  int64_t inner_loop_index =
-      getForLoopIndex(circular_buffer_tv, loops, /*is_inner_most_axis=*/true);
-
   // short-circuit: return index for inner-most for-loop if not warp specialized
   // with register sharing
   const auto& circular_buffer_type =
@@ -595,7 +592,9 @@ Val* CircularBufferInfo::getLinearIndex(
   bool is_warp_specialized =
       std::holds_alternative<WarpSpecialized>(circular_buffer_type);
   if (!is_warp_specialized) {
-    return loops[inner_loop_index]->indexOrStartIfTrivial();
+    int64_t loop_index =
+        getForLoopIndex(circular_buffer_tv, loops, /*is_inner_most_axis=*/true);
+    return loops[loop_index]->indexOrStartIfTrivial();
   }
 
   // The inner-most and outer-most for loops can be different.
@@ -608,14 +607,12 @@ Val* CircularBufferInfo::getLinearIndex(
   // operations are inserted in circular buffering pass. Use
   // stage_slice_position if available. Otherwise, the default value is the
   // first serial for-loop to the left of compute_at_position.
-  auto warp_specialized = std::get<WarpSpecialized>(circular_buffer_type);
-  if (warp_specialized.stage_slice_position.has_value()) {
-    inner_loop_index = warp_specialized.stage_slice_position.value() - 1;
-  }
+  int64_t inner_loop_index = (warp_specialized.stage_slice_position.has_value())
+      ? warp_specialized.stage_slice_position.value() - 1
+      : getForLoopIndex(circular_buffer_tv, loops, /*is_inner_most_axis=*/true);
+
   // Calculate insertion position.
-  int64_t insertion_position = warp_specialized.stage_slice_position.has_value()
-          ? warp_specialized.stage_slice_position.value() - 1
-                : inner_loop_index - outer_loop_index + 1;
+  int64_t insertion_position = inner_loop_index - outer_loop_index + 1;
   return getLinearIndexRelativeForLoopStack(
       loops, insertion_position, /*start=*/outer_loop_index);
 }

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -600,6 +600,7 @@ Val* CircularBufferInfo::getLinearIndex(
 
   // The inner-most and outer-most for loops can be different.
   // Get outer-most for-loop index.
+  auto warp_specialized = std::get<WarpSpecialized>(circular_buffer_type);
   int64_t outer_loop_index =
       getForLoopIndex(circular_buffer_tv, loops, /*is_inner_most_axis=*/false);
 
@@ -612,7 +613,9 @@ Val* CircularBufferInfo::getLinearIndex(
     inner_loop_index = warp_specialized.stage_slice_position.value() - 1;
   }
   // Calculate insertion position.
-  int64_t insertion_position = inner_loop_index - outer_loop_index + 1;
+  int64_t insertion_position = warp_specialized.stage_slice_position.has_value()
+          ? warp_specialized.stage_slice_position.value() - 1
+                : inner_loop_index - outer_loop_index + 1;
   return getLinearIndexRelativeForLoopStack(
       loops, insertion_position, /*start=*/outer_loop_index);
 }

--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -22,7 +22,8 @@ struct AsyncWarp {
 };
 
 // This helper function scans through all expressions, finds mbarrier async
-// operations, and gather them into separate AsyncWarps.
+// operations such as TMA Loads and Blackwell UTCMMA, and gather them into
+// separate AsyncWarps.
 std::vector<AsyncWarp> createAsyncWarps(const std::vector<Expr*>& exprs);
 
 IterDomain* getCircularBufferAxis(const TensorView* tv);

--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -18,9 +18,12 @@ namespace nvfuser {
 // Track information for each individual AsyncWarp. Currently, only one
 // AsyncWarp is supported.
 struct AsyncWarp {
+  // All the expressions in the AsyncWarp
   std::vector<Expr*> exprs;
+  // The corresponding output TensorView for all expressions.
   std::vector<TensorView*> tvs;
-  int64_t stage_slice_position;
+  // The common stage_slice_position for all TensorViews.
+  int64_t stage_slice_position = -1;
 };
 
 // This helper function scans through all expressions, finds mbarrier async

--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -15,6 +15,16 @@
 
 namespace nvfuser {
 
+struct AsyncWarp {
+  std::vector<Expr*> exprs;
+  std::vector<TensorView*> tvs;
+  int64_t stage_slice_position;
+};
+
+// This helper function scans through all expressions, finds mbarrier async
+// operations, and gather them into separate AsyncWarps.
+std::vector<AsyncWarp> createAsyncWarps(const std::vector<Expr*>& exprs);
+
 IterDomain* getCircularBufferAxis(const TensorView* tv);
 
 void validateCircularBufferedTensor(const TensorView* tv);

--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -15,10 +15,57 @@
 
 namespace nvfuser {
 
-// Track information for each individual AsyncWarp. Currently, only one
-// AsyncWarp is supported.
+// Warp specialization pads the CTA with 128 threads to support register
+// sharing. This warp group is divided into four warps that run independently.
+// These four warps are colloquially called AsyncWarp, and this struct tracks
+// information for each individual warp.
+//
+// For example, take this Blackwell matrix multiplication kernel:
+// if AsyncWarp:
+//   decreaseRegisters()
+//   if warp_id == 0:
+//     mbarrier::wait(empty_operands)
+//     mbarrier::arriveExpectTx(full_operands)
+//     tma_load(A)
+//     tma_load(b)
+//   elif warp_id == 1:
+//     mbarrier::wait(full_operands)
+//     mbarrier::wait(empty_tmem_output)
+//     tcgen05::utcmma(A_smem, B_smem)
+//     mbarrier::arrive(full_tmem_output)
+//   elif warp_id == 2:
+//     mbarrier::wait(empty_epilogue_input)
+//     mbarrier::arriveExpectTx(full_epilogue_input)
+//     tma_load(epilogue_input)
+//   elif warp_id == 3:
+//     return;
+//   return;
+// else:  # ComputeWarp
+//   increaseRegisters()
+//   mbarrier::wait(full_tmem_output)
+//   # load from tmem to registers
+//   mbarrier::wait(epilogue_input)
+//   # compute epilogue
+//   # stmatrix to move from registers to shared memory
+//   # tma_store to move from shared to global memory
+//
+// Three independent warps are active in the AsyncWarp warp group, so
+// createAsyncWarps will filter all expressions to create three AsyncWarp
+// structs.
+//
+// Here are the individual AsyncWarp structs and their constituent expressions:
+//  1. AsyncWarp0: tma_load(A) and tma_load(B).
+//  2. AsyncWarp1: tcgen05::utcmma
+//  3. AsyncWarp2: tma_load(epilogue_input)
+//  4. AsyncWarp3: Empty.
+//
+// Current implementation Details:
+//  1. Only the mbarrier async operations in each warp is tracked in the
+//  AsyncWarp struct. Consumer uses are not recorded.
+//  2. Empty AsyncWarps are not tracked.
+//  3. Only one AsyncWarp is supported.
 struct AsyncWarp {
-  // All the expressions in the AsyncWarp
+  // All the expressions in the AsyncWarp.
   std::vector<Expr*> exprs;
   // The corresponding output TensorView for all expressions.
   std::vector<TensorView*> tvs;

--- a/csrc/device_lower/analysis/circular_buffer.h
+++ b/csrc/device_lower/analysis/circular_buffer.h
@@ -15,6 +15,8 @@
 
 namespace nvfuser {
 
+// Track information for each individual AsyncWarp. Currently, only one
+// AsyncWarp is supported.
 struct AsyncWarp {
   std::vector<Expr*> exprs;
   std::vector<TensorView*> tvs;

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -972,6 +972,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
     // Use the if-then-else with electSync() predicate for the arrive expect
     // and cpAsyncBulk operations.
     kir::IfThenElse* if_expr = getElectSyncIfThenElse();
+    std::cout << "addTmaLoadBlock\t" << if_expr->toString() << std::endl;
 
     // Wait for WAR
     if (usesMBarrierForWAR()) {
@@ -990,6 +991,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
     // Arrive expect tx for RAW
     if_expr->thenBody().push_back(mbarrier_arrive_tx_);
     if_expr->thenBody().push_back(expr);
+    std::cout << "addTmaLoadBlock\t" << if_expr->toString() << std::endl;
 
     mbarrier_arrive_tx_ = nullptr;
   }

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -972,7 +972,6 @@ class CloneTmaCircularBufferLoopAndInsertSync
     // Use the if-then-else with electSync() predicate for the arrive expect
     // and cpAsyncBulk operations.
     kir::IfThenElse* if_expr = getElectSyncIfThenElse();
-    std::cout << "addTmaLoadBlock\t" << if_expr->toString() << std::endl;
 
     // Wait for WAR
     if (usesMBarrierForWAR()) {
@@ -991,7 +990,6 @@ class CloneTmaCircularBufferLoopAndInsertSync
     // Arrive expect tx for RAW
     if_expr->thenBody().push_back(mbarrier_arrive_tx_);
     if_expr->thenBody().push_back(expr);
-    std::cout << "addTmaLoadBlock\t" << if_expr->toString() << std::endl;
 
     mbarrier_arrive_tx_ = nullptr;
   }

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -728,6 +728,24 @@ MmaInputSmemSwizzle getSwizzleMode(TensorView* tv) {
   return MmaInputSmemSwizzle::None;
 }
 
+std::optional<int64_t> getStageSlicePosition(const TensorView* tv) {
+  NVF_ERROR(tv != nullptr);
+
+  bool is_warp_specialized =
+      std::holds_alternative<WarpSpecialized>(tv->circularBufferOptions().type);
+  if (!is_warp_specialized) {
+    return std::nullopt;
+  }
+
+  const auto& warp_specialized =
+      std::get<WarpSpecialized>(tv->circularBufferOptions().type);
+  if (!warp_specialized.stage_slice_position.has_value()) {
+    return std::nullopt;
+  }
+
+  return warp_specialized.stage_slice_position.value();
+}
+
 } // namespace ir_utils
 
 namespace lower_utils {

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -176,8 +176,8 @@ bool isTMAOrMMASmemTv(TensorView* tv);
 //! an input of an MmaOp, or the smem tv of TMA load/store.
 MmaInputSmemSwizzle getSwizzleMode(TensorView* tv);
 
-// Get the stage_slice_position if it defined in the WarpSpecialized circular
-// buffer options struct
+//! Get the stage_slice_position if it is defined in the WarpSpecialized
+//! circular buffer options struct.
 std::optional<int64_t> getStageSlicePosition(const TensorView* tv);
 
 } // namespace ir_utils

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -176,6 +176,10 @@ bool isTMAOrMMASmemTv(TensorView* tv);
 //! an input of an MmaOp, or the smem tv of TMA load/store.
 MmaInputSmemSwizzle getSwizzleMode(TensorView* tv);
 
+// Get the stage_slice_position if it defined in the WarpSpecialized circular
+// buffer options struct
+std::optional<int64_t> getStageSlicePosition(const TensorView* tv);
+
 } // namespace ir_utils
 
 namespace lower_utils {

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -738,7 +738,21 @@ std::vector<std::pair<IterDomain*, IterDomain*>> resolvedRootBroadcasts(
 //
 // The CTA shape is (TIDx = 128, TIDy = 3, TIDz = 1) for this example.
 //
-// Here is the Warp-Specialized kernel structure:
+// Before circular-buffer pass:
+// FOR outer_persistent:
+//   << compute_at_position(1)
+//   FOR SERIAL(2):
+//     << stage_slice_position(2)
+//     tv0_smem = tma_load(tv0)
+//     tv1_smem = tma_load(tv1)
+//   END FOR
+//   FOR TIDy(2):
+//     << stage_slice_position(2)
+//     tv2 = add(tv0_smem, tv1_smem)
+//   END FOR
+// END FOR
+//
+// Here is the Warp-Specialized kernel structure after circular-buffer pass:
 // IF AsyncWarp:
 //   FOR outer_persistent:
 //     << compute_at_position(1)

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -738,7 +738,7 @@ std::vector<std::pair<IterDomain*, IterDomain*>> resolvedRootBroadcasts(
 //
 // The CTA shape is (TIDx = 128, TIDy = 3, TIDz = 1) for this example.
 //
-// Before circular-buffer pass:
+// Here is kernel structure before circular-buffer pass:
 // FOR outer_persistent:
 //   << compute_at_position(1)
 //   FOR SERIAL(2):

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -766,8 +766,7 @@ void buildAsyncWarpInliningInfo(
             ir_utils::getStageSlicePosition(tv);
         return opt_stage_slice_position.value_or(-1);
       });
-  NVF_ERROR(
-      stage_slice_positions.size() > 1 && stage_slice_positions.front() > -1);
+  NVF_ERROR(stage_slice_positions.size() > 1);
   NVF_ERROR(std::all_of(
       stage_slice_positions.begin() + 1,
       stage_slice_positions.end(),
@@ -776,6 +775,11 @@ void buildAsyncWarpInliningInfo(
   TensorView* async_warp_tv = async_warp_tvs.front();
   NVF_ERROR(async_warp_tv != nullptr);
   int64_t stage_slice_position = stage_slice_positions.front();
+
+  // short-circuit: stage_slice_position is not used.
+  if (stage_slice_position == -1) {
+    return;
+  }
 
   VectorOfUniqueEntries<IterDomain*> all_inline_deps(
       async_warp_tv->getLoopDomain().begin(),

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -708,6 +708,98 @@ std::vector<std::pair<IterDomain*, IterDomain*>> resolvedRootBroadcasts(
   return resolved_bcast_domains;
 }
 
+// The compute_at_position is defined from producer to consumer. Thus, sibling
+// TMA load operations cannot be inlined unless they are inlined with their
+// consumer.
+//
+// For ping-pong warp specialized kernels, the compute_at_position must be to
+// the left of the warp-specialized thread axis because of parallel type
+// propagation rules. See PingPongCircularBuffering.ProducerWarpSpecializedError
+// for an example.
+//
+// This helper function inlines sibling asynchronous operations such as TMA
+// Loads based on stage_slice_position.
+//
+// TODO Support UTCMMA based on producer-consumer relationships
+void buildAsyncWarpInliningInfo(
+    StatefulInliningInfo& info,
+    const std::vector<Expr*>& exprs,
+    const ValGraph& permissive_graph) {
+  // Gather all async operations.
+  std::vector<Expr*> async_warp;
+  std::copy_if(
+      exprs.begin(), exprs.end(), std::back_inserter(async_warp), [](Expr* e) {
+        // TODO Add support for blackwell MmaOp
+        return ir_utils::isCpAsyncBulkLoad(e);
+      });
+
+  // short-circuit: no async operations detected.
+  if (async_warp.size() <= 1) {
+    return;
+  }
+
+  // TODO Divide into AsyncWarps for multi-role specialization
+  // The current assumption is a single AsyncWarp with same
+  // stage_slice_position. Get TensorViews for async warps
+  std::vector<TensorView*> async_warp_tvs;
+  std::transform(
+      async_warp.begin(),
+      async_warp.end(),
+      std::back_inserter(async_warp_tvs),
+      [](Expr* e) {
+        auto output_tvs =
+            ir_utils::filterByType<TensorView>(e->outputs()).vector();
+        NVF_ERROR(output_tvs.size() == 1);
+        return output_tvs.front();
+      });
+  NVF_ERROR(async_warp_tvs.size() > 1);
+
+  // Check that all operations in the same warp have the same
+  // stage_slice_position.
+  std::vector<int64_t> stage_slice_positions;
+  std::transform(
+      async_warp_tvs.begin(),
+      async_warp_tvs.end(),
+      std::back_inserter(stage_slice_positions),
+      [](TensorView* tv) {
+        std::optional<int64_t> opt_stage_slice_position =
+            ir_utils::getStageSlicePosition(tv);
+        return opt_stage_slice_position.value_or(-1);
+      });
+  NVF_ERROR(
+      stage_slice_positions.size() > 1 && stage_slice_positions.front() > -1);
+  NVF_ERROR(std::all_of(
+      stage_slice_positions.begin() + 1,
+      stage_slice_positions.end(),
+      [&](int64_t v) { return v == stage_slice_positions.front(); }));
+
+  TensorView* async_warp_tv = async_warp_tvs.front();
+  NVF_ERROR(async_warp_tv != nullptr);
+  int64_t stage_slice_position = stage_slice_positions.front();
+
+  VectorOfUniqueEntries<IterDomain*> all_inline_deps(
+      async_warp_tv->getLoopDomain().begin(),
+      async_warp_tv->getLoopDomain().begin() + stage_slice_position);
+  info.ordered_sibling_ids.pushBack(all_inline_deps);
+
+  auto all_tv_ids = async_warp_tv->domain()->allIDs();
+  for (const auto i : arange(1, async_warp_tvs.size())) {
+    auto tv_i = async_warp_tvs.at(i);
+    auto all_tv_i_ids = tv_i->domain()->allIDs();
+
+    auto sibling_map =
+        permissive_graph.buildMapBetween(all_tv_ids, all_tv_i_ids);
+    for (const auto& [tv_id_1, tv_ids] : sibling_map) {
+      // Note that tv_ids can have multiple domains as this graph
+      // is a Permissive graph and there may be broadcast merged
+      // domains
+      if (!tv_ids.empty() && all_inline_deps.has(tv_id_1->as<IterDomain>())) {
+        info.sibling_maps[tv_id_1->as<IterDomain>()].pushBack(tv_ids);
+      }
+    }
+  }
+}
+
 } // namespace
 
 // Grab inlining relationships
@@ -802,80 +894,7 @@ StatefulInliningInfo buildStatefulInliningInfo(
     }
   }
 
-  // Gather all async operations.
-  std::vector<Expr*> async_warp;
-  std::copy_if(
-      exprs.begin(), exprs.end(), std::back_inserter(async_warp), [](Expr* e) {
-        // TODO Add support for blackwell MmaOp
-        return ir_utils::isCpAsyncBulkLoad(e);
-      });
-
-  // short-circuit: no async operations detected.
-  if (async_warp.size() <= 1) {
-    return info;
-  }
-
-  // TODO Divide into AsyncWarps for multi-role specialization
-  // The current assumption is a single AsyncWarp with same
-  // stage_slice_position. Get TensorViews for async warps
-  std::vector<TensorView*> async_warp_tvs;
-  std::transform(
-      async_warp.begin(),
-      async_warp.end(),
-      std::back_inserter(async_warp_tvs),
-      [](Expr* e) {
-        auto output_tvs =
-            ir_utils::filterByType<TensorView>(e->outputs()).vector();
-        NVF_ERROR(output_tvs.size() == 1);
-        return output_tvs.front();
-      });
-  NVF_ERROR(async_warp_tvs.size() > 1);
-
-  // Check that all operations in the same warp have the same
-  // stage_slice_position.
-  std::vector<int64_t> stage_slice_positions;
-  std::transform(
-      async_warp_tvs.begin(),
-      async_warp_tvs.end(),
-      std::back_inserter(stage_slice_positions),
-      [](TensorView* tv) {
-        std::optional<int64_t> opt_stage_slice_position =
-            ir_utils::getStageSlicePosition(tv);
-        return opt_stage_slice_position.value_or(-1);
-      });
-  NVF_ERROR(
-      stage_slice_positions.size() > 1 && stage_slice_positions.front() > -1);
-  NVF_ERROR(std::all_of(
-      stage_slice_positions.begin() + 1,
-      stage_slice_positions.end(),
-      [&](int64_t v) { return v == stage_slice_positions.front(); }));
-
-  TensorView* async_warp_tv = async_warp_tvs.front();
-  NVF_ERROR(async_warp_tv != nullptr);
-  int64_t stage_slice_position = stage_slice_positions.front();
-
-  VectorOfUniqueEntries<IterDomain*> all_inline_deps(
-      async_warp_tv->getLoopDomain().begin(),
-      async_warp_tv->getLoopDomain().begin() + stage_slice_position);
-  info.ordered_sibling_ids.pushBack(all_inline_deps);
-
-  auto all_tv_ids = async_warp_tv->domain()->allIDs();
-  for (const auto i : arange(1, async_warp_tvs.size())) {
-    auto tv_i = async_warp_tvs.at(i);
-    auto all_tv_i_ids = tv_i->domain()->allIDs();
-
-    auto sibling_map =
-        permissive_graph.buildMapBetween(all_tv_ids, all_tv_i_ids);
-    for (const auto& [tv_id_1, tv_ids] : sibling_map) {
-      // Note that tv_ids can have multiple domains as this graph
-      // is a Permissive graph and there may be broadcast merged
-      // domains
-      if (!tv_ids.empty() && all_inline_deps.has(tv_id_1->as<IterDomain>())) {
-        info.sibling_maps[tv_id_1->as<IterDomain>()].pushBack(tv_ids);
-      }
-    }
-  }
-
+  buildAsyncWarpInliningInfo(info, exprs, permissive_graph);
   return info;
 }
 

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -12,6 +12,7 @@
 #include <id_model/utils.h>
 #include <id_model/validation_utils.h>
 
+#include <device_lower/analysis/circular_buffer.h>
 #include <device_lower/analysis/trivial_broadcast.h>
 #include <device_lower/lower2device.h>
 #include <device_lower/utils.h>
@@ -706,76 +707,6 @@ std::vector<std::pair<IterDomain*, IterDomain*>> resolvedRootBroadcasts(
     resolved_bcast_domains.emplace_back(p_id, c_id);
   }
   return resolved_bcast_domains;
-}
-
-struct AsyncWarp {
-  std::vector<Expr*> exprs;
-  std::vector<TensorView*> tvs;
-  int64_t stage_slice_position;
-};
-
-// Scan through all expressions. Find mbarrier async operations. Gather into
-// separate AsyncWarps.
-std::vector<AsyncWarp> createAsyncWarps(const std::vector<Expr*>& exprs) {
-  std::vector<AsyncWarp> async_warps;
-
-  // Gather all async operations.
-  std::vector<Expr*> async_warp_exprs;
-  std::copy_if(
-      exprs.begin(),
-      exprs.end(),
-      std::back_inserter(async_warp_exprs),
-      [](Expr* e) {
-        // TODO Add support for blackwell MmaOp
-        return ir_utils::isCpAsyncBulkLoad(e);
-      });
-
-  // short-circuit: no async operations detected.
-  if (async_warp_exprs.size() <= 1) {
-    return async_warps;
-  }
-
-  std::vector<TensorView*> async_warp_tvs;
-  std::transform(
-      async_warp_exprs.begin(),
-      async_warp_exprs.end(),
-      std::back_inserter(async_warp_tvs),
-      [](Expr* e) {
-        auto output_tvs =
-            ir_utils::filterByType<TensorView>(e->outputs()).vector();
-        NVF_ERROR(output_tvs.size() == 1);
-        return output_tvs.front();
-      });
-  NVF_ERROR(async_warp_tvs.size() > 1);
-
-  // Check that all operations in the same warp have the same
-  // stage_slice_position.
-  std::vector<int64_t> stage_slice_positions;
-  std::transform(
-      async_warp_tvs.begin(),
-      async_warp_tvs.end(),
-      std::back_inserter(stage_slice_positions),
-      [](TensorView* tv) {
-        std::optional<int64_t> opt_stage_slice_position =
-            ir_utils::getStageSlicePosition(tv);
-        return opt_stage_slice_position.value_or(-1);
-      });
-  NVF_ERROR(stage_slice_positions.size() > 1);
-  NVF_ERROR(std::all_of(
-      stage_slice_positions.begin() + 1,
-      stage_slice_positions.end(),
-      [&](int64_t v) { return v == stage_slice_positions.front(); }));
-
-  TensorView* async_warp_tv = async_warp_tvs.front();
-  NVF_ERROR(async_warp_tv != nullptr);
-  int64_t stage_slice_position = stage_slice_positions.front();
-
-  // TODO Divide into AsyncWarps for multi-role specialization
-  // The current assumption is a single AsyncWarp with same
-  // stage_slice_position. Get TensorViews for async warps
-  async_warps.emplace_back(
-      async_warp_exprs, async_warp_tvs, stage_slice_position);
-  return async_warps;
 }
 
 // The compute_at_position is defined from producer to consumer. Thus, sibling

--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -715,13 +715,57 @@ std::vector<std::pair<IterDomain*, IterDomain*>> resolvedRootBroadcasts(
 //
 // For ping-pong warp specialized kernels, the compute_at_position must be to
 // the left of the warp-specialized thread axis because of parallel type
-// propagation rules. See PingPongCircularBuffering.ProducerWarpSpecializedError
-// for an example.
+// propagation rules. If not, the warp-specialized thread axis will incorrectly
+// appear in the AsyncWarp. For example, see
+// PingPongCircularBuffering.ProducerWarpSpecializedError.
 //
-// This helper function inlines sibling asynchronous operations such as TMA
-// Loads based on stage_slice_position.
+// buildAsyncWarpInliningInfo inlines sibling asynchronous operations such as
+// TMA Loads based on stage_slice_position.
 //
-// TODO Support UTCMMA based on producer-consumer relationships
+// For example, say you have a fusion definition: tv2 = add(tv0, tv1)
+// The fusion's schedule loads tv0 and tv1 to shared memory with TMA and creates
+// a warp specialized pipeline using the TIDy thread axis.
+//
+// Let the iterDomain schedule for the TensorViews be:
+// * tv0_smem[outer_persistent, serial(2), bulk(128)] = tma_load(tv0)
+// * tv1_smem[outer_persistent, serial(2), bulk(128)] = tma_load(tv1)
+// * tv2[outer_persistent, TIDy(2), TIDx(128)] = add(tv0_smem, tv1_smem)
+//
+// Let the compute_at_position be 1 because the tma loads and add operation
+// share the outer-most for-loop. Let the stage_slice_position be 2, so the
+// kernel loads 128 elements of tv0 and tv1 asynchronously and compute two warp
+// groups in parallel.
+//
+// The CTA shape is (TIDx = 128, TIDy = 3, TIDz = 1) for this example.
+//
+// Here is the Warp-Specialized kernel structure:
+// IF AsyncWarp:
+//   FOR outer_persistent:
+//     << compute_at_position(1)
+//     FOR SERIAL(2):
+//       << stage_slice_position(2)
+//       mbarrier::wait(empty)
+//       mbarrier::arriveExpectTx(full)
+//       tv0_smem = tma_load(tv0)
+//       tv1_smem = tma_load(tv1)
+//     END FOR
+//   END FOR
+// ELSE:
+//   FOR outer_persistent:
+//     << compute_at_position(1)
+//     FOR TIDy(2):
+//       << stage_slice_position(2)
+//       mbarrier::wait(full)
+//       tv2 = add(tv0_smem, tv1_smem)
+//       mbarrier::arrive(empty)
+//     END FOR
+//   END FOR
+// END IF
+//
+// The two TMA loads for tv0 and tv1 are assigned the same mbarrier, so they
+// must be issued in the same for-loop. This helper function updates
+// ordered_sibling_ids and sibling_maps in StatefulInliningInfo to create this
+// sibling relationship in the LOOP graph.
 void buildAsyncWarpInliningInfo(
     StatefulInliningInfo& info,
     const std::vector<Expr*>& exprs,
@@ -751,23 +795,24 @@ void buildAsyncWarpInliningInfo(
   TensorView* async_warp_tv = async_warp.tvs.front();
   NVF_ERROR(async_warp_tv != nullptr);
 
-  VectorOfUniqueEntries<IterDomain*> all_inline_deps(
+  // Gather all loop iterDomains to the left of the stage_slice_position.
+  VectorOfUniqueEntries<IterDomain*> stage_slice_position_ids(
       async_warp_tv->getLoopDomain().begin(),
       async_warp_tv->getLoopDomain().begin() + async_warp.stage_slice_position);
-  info.ordered_sibling_ids.pushBack(all_inline_deps);
+  info.ordered_sibling_ids.pushBack(stage_slice_position_ids);
 
-  auto all_tv_ids = async_warp_tv->domain()->allIDs();
-  for (const auto i : arange(1, async_warp.tvs.size())) {
-    auto tv_i = async_warp.tvs.at(i);
-    auto all_tv_i_ids = tv_i->domain()->allIDs();
+  // For all TensorViews in the AsyncWarp, build an iterDomain mapping between
+  // the first TensorView and all other TensorViews.
+  std::vector<IterDomain*> all_tv_ids = async_warp_tv->domain()->allIDs();
+  for (size_t i : arange(1, async_warp.tvs.size())) {
+    TensorView* tv_i = async_warp.tvs.at(i);
+    std::vector<IterDomain*> all_tv_i_ids = tv_i->domain()->allIDs();
 
-    auto sibling_map =
+    std::unordered_map<Val*, VectorOfUniqueEntries<Val*>> sibling_map =
         permissive_graph.buildMapBetween(all_tv_ids, all_tv_i_ids);
     for (const auto& [tv_id_1, tv_ids] : sibling_map) {
-      // Note that tv_ids can have multiple domains as this graph
-      // is a Permissive graph and there may be broadcast merged
-      // domains
-      if (!tv_ids.empty() && all_inline_deps.has(tv_id_1->as<IterDomain>())) {
+      if (!tv_ids.empty() &&
+          stage_slice_position_ids.has(tv_id_1->as<IterDomain>())) {
         info.sibling_maps[tv_id_1->as<IterDomain>()].pushBack(tv_ids);
       }
     }

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -309,108 +309,6 @@ TEST_F(PingPongCircularBuffering, ProducerConsumerDifferentError) {
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
-using SiblingPingPongCircularBuffering =
-    NVFuserFixtureParamTest<PingPongCircularBufferingParams>;
-TEST_P(SiblingPingPongCircularBuffering, TwoTmaLoads) {
-  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
-
-  // Incorrect results for IdModel
-  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
-
-  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
-  FusionGuard fg(fusion.get());
-
-  constexpr int64_t rows_per_stage = 4;
-  constexpr int64_t compute_warp_groups = 2;
-  constexpr int64_t circular_loop = 12;
-  int64_t sm_count =
-      at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-  const int64_t dim0 =
-      rows_per_stage * compute_warp_groups * sm_count * circular_loop;
-  constexpr int64_t dim1 = 128;
-  constexpr int64_t stages = 6;
-
-  TensorView* tv0 = makeContigConcreteTensor({dim0, dim1}, DataType::Float);
-  TensorView* tv1 = makeContigConcreteTensor({dim0, dim1}, DataType::Float);
-  fusion->addInput(tv0);
-  fusion->addInput(tv1);
-  TensorView* tv6 = add(tv0, tv1);
-  fusion->addOutput(tv6);
-
-  // Create Cache Tensors
-  TensorView* tv2 = tv0->cacheAfter(LoadStoreOpType::CpAsyncBulk);
-  TensorView* tv3 = tv1->cacheAfter(LoadStoreOpType::CpAsyncBulk);
-  TensorView* tv4 = tv2->cacheAfter();
-  TensorView* tv5 = tv2->cacheAfter();
-  TensorView* tv7 = tv6->cacheBefore();
-
-  // Move first level cache to shared memory
-  tv2->setMemoryType(MemoryType::Shared);
-  tv3->setMemoryType(MemoryType::Shared);
-
-  for (TensorView* tv : {tv2, tv3, tv4, tv5, tv6, tv7}) {
-    tv->split(0, rows_per_stage);
-    tv->split(0, sm_count);
-    tv->split(0, compute_warp_groups);
-    // [I, 2, 132, 4]
-    tv->axis(0)->parallelize(ParallelType::Serial);
-    tv->axis(1)->parallelize(ParallelType::TIDy);
-    tv->axis(2)->parallelize(ParallelType::BIDy);
-    tv->axis(3)->parallelize(ParallelType::Unroll);
-    tv->axis(4)->parallelize(ParallelType::TIDx);
-    if (tv == tv2 || tv == tv3) {
-      tv->axis(1)->parallelize(ParallelType::Serial);
-      tv->axis(4)->parallelize(ParallelType::Bulk);
-    }
-  }
-
-  // Reorder Axes
-  // [I, 2, 132, 4] --> [132, I, 2, 4]
-  std::unordered_map<int64_t, int64_t> reorder_map;
-  reorder_map[0] = 1;
-  reorder_map[1] = 2;
-  reorder_map[2] = 0;
-  for (TensorView* tv : {tv2, tv3, tv4, tv5, tv6, tv7}) {
-    tv->reorder(reorder_map);
-  }
-
-  // Inline Step
-  for (TensorView* tv : {tv2, tv3}) {
-    inlineSelectedAt({tv}, tv, 2);
-  }
-
-  for (TensorView* tv : {tv4, tv5, tv6, tv7}) {
-    inlineSelectedAt({tv}, tv, 3);
-  }
-
-  auto [stage_slice_position] = GetParam();
-  for (auto tv : {tv2, tv3}) {
-    tv->circularBuffer(
-        stages,
-        stages - 1,
-        WarpSpecialized(ParallelType::TIDy, stage_slice_position));
-  }
-
-  auto options = at::TensorOptions().device(at::kCUDA, 0);
-  at::Tensor t0 = at::randn({dim0, dim1}, options);
-  at::Tensor t1 = at::randn({dim0, dim1}, options);
-  at::Tensor t2 = t0 + t1;
-
-  KernelExecutor ke;
-  ke.compile(fusion.get(), {t0, t1});
-  auto cg_outputs = ke.run({t0, t1});
-  testValidate(fusion.get(), cg_outputs, {t0, t1}, {t2}, __LINE__, __FILE__);
-}
-INSTANTIATE_TEST_SUITE_P(
-    ,
-    SiblingPingPongCircularBuffering,
-    ::testing::Combine(testing::Range(2, 4)),
-    [](const testing::TestParamInfo<PingPongCircularBufferingParams>& info) {
-      std::stringstream ss;
-      ss << "stage_slice_position_" << std::get<0>(info.param);
-      return sanitizeTestName(ss.str());
-    });
-
 using SiblingPingPongCircularBufferingInnerSplit =
     NVFuserFixtureParamTest<PingPongCircularBufferingParams>;
 TEST_P(SiblingPingPongCircularBufferingInnerSplit, TwoTmaLoads) {
@@ -507,6 +405,7 @@ TEST_P(SiblingPingPongCircularBufferingInnerSplit, TwoTmaLoads) {
   testValidate(fusion.get(), cg_outputs, {t0, t1}, {t2}, __LINE__, __FILE__);
 }
 // Stage_Split_Position 2 does not work currently with multiple TMA loads.
+// TODO: Enable after supporting multi-role specialization.
 INSTANTIATE_TEST_SUITE_P(
     ,
     SiblingPingPongCircularBufferingInnerSplit,

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -429,16 +429,16 @@ TEST_P(SiblingPingPongCircularBuffering, TwoTmaLoads) {
           [&](int64_t pos) {
             return loop_graph.toGroup(tv2->axis(pos))->has(tv3->axis(pos));
           }),
-      "Expected sibling iterDomains to the left of stage_slice_position to "
-      "belong to the same ValGroup in LOOP map");
+      "Expected all sibling iterDomains to the left of stage_slice_position to "
+      "belong to the same ValGroup in LOOP map.");
   NVF_ERROR(
       std::ranges::all_of(
           std::ranges::iota_view{stage_slice_position, tv2->nDims()},
           [&](int64_t pos) {
             return !loop_graph.toGroup(tv2->axis(pos))->has(tv3->axis(pos));
           }),
-      "Expected sibling iterDomains to the right of and including "
-      "stage_slice_position to belong to the same ValGroup in LOOP map");
+      "Expected all sibling iterDomains to the right of and including the "
+      "stage_slice_position not to belong to the same ValGroup in LOOP map.");
 }
 // Stage_Split_Position 2 does not work currently with multiple TMA loads.
 // TODO: Enable after supporting multi-role specialization.

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -306,4 +306,212 @@ TEST_F(PingPongCircularBuffering, ProducerConsumerDifferentError) {
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
+using SiblingPingPongCircularBuffering =
+    NVFuserFixtureParamTest<PingPongCircularBufferingParams>;
+TEST_P(SiblingPingPongCircularBuffering, TwoTmaLoads) {
+  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+
+  // Incorrect results for IdModel
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  constexpr int64_t rows_per_stage = 4;
+  constexpr int64_t compute_warp_groups = 2;
+  constexpr int64_t circular_loop = 12;
+  int64_t sm_count =
+      at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+  const int64_t dim0 =
+      rows_per_stage * compute_warp_groups * sm_count * circular_loop;
+  constexpr int64_t dim1 = 128;
+  constexpr int64_t stages = 6;
+
+  TensorView* tv0 = makeContigConcreteTensor({dim0, dim1}, DataType::Float);
+  TensorView* tv1 = makeContigConcreteTensor({dim0, dim1}, DataType::Float);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  TensorView* tv6 = add(tv0, tv1);
+  fusion->addOutput(tv6);
+
+  // Create Cache Tensors
+  TensorView* tv2 = tv0->cacheAfter(LoadStoreOpType::CpAsyncBulk);
+  TensorView* tv3 = tv1->cacheAfter(LoadStoreOpType::CpAsyncBulk);
+  TensorView* tv4 = tv2->cacheAfter();
+  TensorView* tv5 = tv2->cacheAfter();
+  TensorView* tv7 = tv6->cacheBefore();
+
+  // Move first level cache to shared memory
+  tv2->setMemoryType(MemoryType::Shared);
+  tv3->setMemoryType(MemoryType::Shared);
+
+  for (TensorView* tv : {tv2, tv3, tv4, tv5, tv6, tv7}) {
+    tv->split(0, rows_per_stage);
+    tv->split(0, sm_count);
+    tv->split(0, compute_warp_groups);
+    // [I, 2, 132, 4]
+    tv->axis(0)->parallelize(ParallelType::Serial);
+    tv->axis(1)->parallelize(ParallelType::TIDy);
+    tv->axis(2)->parallelize(ParallelType::BIDy);
+    tv->axis(3)->parallelize(ParallelType::Unroll);
+    tv->axis(4)->parallelize(ParallelType::TIDx);
+    if (tv == tv2 || tv == tv3) {
+      tv->axis(1)->parallelize(ParallelType::Serial);
+      tv->axis(4)->parallelize(ParallelType::Bulk);
+    }
+  }
+
+  // Reorder Axes
+  // [I, 2, 132, 4] --> [132, I, 2, 4]
+  std::unordered_map<int64_t, int64_t> reorder_map;
+  reorder_map[0] = 1;
+  reorder_map[1] = 2;
+  reorder_map[2] = 0;
+  for (TensorView* tv : {tv2, tv3, tv4, tv5, tv6, tv7}) {
+    tv->reorder(reorder_map);
+  }
+
+  // Inline Step
+  for (TensorView* tv : {tv2, tv3}) {
+    inlineSelectedAt({tv}, tv, 2);
+  }
+
+  for (TensorView* tv : {tv4, tv5, tv6, tv7}) {
+    inlineSelectedAt({tv}, tv, 3);
+  }
+
+  auto [stage_slice_position] = GetParam();
+  for (auto tv : {tv2, tv3}) {
+    tv->circularBuffer(
+        stages,
+        stages - 1,
+        WarpSpecialized(ParallelType::TIDy, stage_slice_position));
+  }
+
+  auto options = at::TensorOptions().device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({dim0, dim1}, options);
+  at::Tensor t1 = at::randn({dim0, dim1}, options);
+  at::Tensor t2 = t0 + t1;
+
+  KernelExecutor ke;
+  ke.compile(fusion.get(), {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
+  testValidate(fusion.get(), cg_outputs, {t0, t1}, {t2}, __LINE__, __FILE__);
+}
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    SiblingPingPongCircularBuffering,
+    ::testing::Combine(testing::Range(2, 4)),
+    [](const testing::TestParamInfo<PingPongCircularBufferingParams>& info) {
+      std::stringstream ss;
+      ss << "stage_slice_position_" << std::get<0>(info.param);
+      return sanitizeTestName(ss.str());
+    });
+
+using SiblingPingPongCircularBufferingInnerSplit =
+    NVFuserFixtureParamTest<PingPongCircularBufferingParams>;
+TEST_P(SiblingPingPongCircularBufferingInnerSplit, TwoTmaLoads) {
+  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+
+  // Incorrect results for IdModel
+  EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+
+  std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  constexpr int64_t rows_per_stage = 4;
+  constexpr int64_t compute_warp_groups = 2;
+  constexpr int64_t inner_split = 3;
+  constexpr int64_t circular_loop = 12;
+  int64_t sm_count =
+      at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+  const int64_t dim0 =
+      rows_per_stage * compute_warp_groups * sm_count * circular_loop;
+  constexpr int64_t dim1 = 128;
+  constexpr int64_t stages = 6;
+
+  TensorView* tv0 = makeContigConcreteTensor({dim0, dim1}, DataType::Float);
+  TensorView* tv1 = makeContigConcreteTensor({dim0, dim1}, DataType::Float);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  TensorView* tv6 = add(tv0, tv1);
+  fusion->addOutput(tv6);
+
+  // Create Cache Tensors
+  TensorView* tv2 = tv0->cacheAfter(LoadStoreOpType::CpAsyncBulk);
+  TensorView* tv3 = tv1->cacheAfter(LoadStoreOpType::CpAsyncBulk);
+  TensorView* tv4 = tv2->cacheAfter();
+  TensorView* tv5 = tv2->cacheAfter();
+  TensorView* tv7 = tv6->cacheBefore();
+
+  // Move first level cache to shared memory
+  tv2->setMemoryType(MemoryType::Shared);
+  tv3->setMemoryType(MemoryType::Shared);
+
+  for (TensorView* tv : {tv2, tv3, tv4, tv5, tv6, tv7}) {
+    tv->split(0, rows_per_stage);
+    tv->split(0, sm_count);
+    tv->split(0, compute_warp_groups);
+    tv->split(0, inner_split);
+    // [I, 3, 2, 132, 4]
+    tv->axis(0)->parallelize(ParallelType::Serial);
+    tv->axis(2)->parallelize(ParallelType::TIDy);
+    tv->axis(3)->parallelize(ParallelType::BIDy);
+    tv->axis(4)->parallelize(ParallelType::Unroll);
+    tv->axis(5)->parallelize(ParallelType::TIDx);
+    if (tv == tv2 || tv == tv3) {
+      tv->axis(2)->parallelize(ParallelType::Serial);
+      tv->axis(5)->parallelize(ParallelType::Bulk);
+    }
+  }
+
+  // Reorder Axes
+  // [I, 3, 2, 132, 4] --> [132, I, 3, 2, 4]
+  std::unordered_map<int64_t, int64_t> reorder_map;
+  reorder_map[0] = 1;
+  reorder_map[1] = 2;
+  reorder_map[2] = 3;
+  reorder_map[3] = 0;
+  for (TensorView* tv : {tv2, tv3, tv4, tv5, tv6, tv7}) {
+    tv->reorder(reorder_map);
+  }
+
+  // Inline Step
+  for (TensorView* tv : {tv2, tv3}) {
+    inlineSelectedAt({tv}, tv, 3);
+  }
+
+  for (TensorView* tv : {tv4, tv5, tv6, tv7}) {
+    inlineSelectedAt({tv}, tv, 4);
+  }
+
+  auto [stage_slice_position] = GetParam();
+  for (auto tv : {tv2, tv3}) {
+    tv->circularBuffer(
+        stages,
+        stages - 1,
+        WarpSpecialized(ParallelType::TIDy, stage_slice_position));
+  }
+
+  auto options = at::TensorOptions().device(at::kCUDA, 0);
+  at::Tensor t0 = at::randn({dim0, dim1}, options);
+  at::Tensor t1 = at::randn({dim0, dim1}, options);
+  at::Tensor t2 = t0 + t1;
+
+  KernelExecutor ke;
+  ke.compile(fusion.get(), {t0, t1});
+  auto cg_outputs = ke.run({t0, t1});
+  testValidate(fusion.get(), cg_outputs, {t0, t1}, {t2}, __LINE__, __FILE__);
+}
+// Stage_Split_Position 2 does not work currently with multiple TMA loads.
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    SiblingPingPongCircularBufferingInnerSplit,
+    ::testing::Combine(testing::Range(3, 5)),
+    [](const testing::TestParamInfo<PingPongCircularBufferingParams>& info) {
+      std::stringstream ss;
+      ss << "stage_slice_position_" << std::get<0>(info.param);
+      return sanitizeTestName(ss.str());
+    });
+
 } // namespace nvfuser


### PR DESCRIPTION
For ping-pong warp specialized kernels, the `compute_at_position` must be to the left of the warp-specialized thread axis because of parallel type propagation rules. If not, the warp-specialized thread axis will incorrectly appear in the `AsyncWarp`. For example, see `TEST_F(PingPongCircularBuffering, ProducerWarpSpecializedError)`.

The `compute_at_position` is defined from producer to consumer. Thus, sibling TMA load operations cannot be inlined unless they are inlined with their consumer.

This PR uses the `stage_slice_position` to inline AsyncWarp operations together. #4460 added the concept of `stage_slice_position`, which defines the shape of circular buffer stage and how the `mbarrier` synchronization is inserted in `AsyncWarp` and `ComputeWarp`.

## Detailed changes:
* In the circular-buffer analysis pass, `createAsyncWarps` groups warp-specialized async operations into separate warps. At the moment, **only one warp** is created but this will change with multi-role specialization for Blackwell.
* In IdModel, `buildAsyncWarpInliningInfo` updates `ordered_sibling_ids` and `sibling_maps` in `StatefulInliningInfo` to create the sibling relationship in the LOOP graph.
* Created `TEST_P(SiblingPingPongCircularBuffering, TwoTmaLoads)` to test inlining two sibling TMA loads based on `stage_slice_position`.
* The tests only works when IdModel is enabled. #4555 updates the `ComputeAtMap:: allocateIndexVariables` to remove the `GTEST_SKIP`.

## Example: `tv2 = add(tv0, tv1)`
The fusion's schedule loads `tv0` and `tv1` to shared memory with TMA and creates a warp specialized pipeline using the `TIDy` thread axis.

Let the iterDomain schedule for the TensorViews be:
* `tv0_smem[outer_persistent, serial(2), bulk(128)] = tma_load(tv0)`
* `tv1_smem[outer_persistent, serial(2), bulk(128)] = tma_load(tv1)`
* `tv2[outer_persistent, TIDy(2), TIDx(128)] = add(tv0_smem, tv1_smem)`

Let the `compute_at_position` be 1 because the tma loads and add operation share the outer-most for-loop. Let the `stage_slice_position` be 2, so the kernel loads 128 elements of tv0 and tv1 asynchronously and compute two warp
groups in parallel.

The CTA shape is `(TIDx = 128, TIDy = 3, TIDz = 1)`.

Here is the Warp-Specialized kernel structure:
```python
if threadIdx.y == 2: # AsyncWarp
  for idx in range(outer_persistent):  # compute_at_position(1)
    for jdx in range(2):  # stage_slice_position(2)
      mbarrier::wait(empty)
      mbarrier::arriveExpectTx(full)
      tv0_smem = tma_load(tv0)
      tv1_smem = tma_load(tv1)
else:
  for idx in range(outer_persistent): # compute_at_position(1)
    for TIDy(2): # stage_slice_position(2)
      mbarrier::wait(full)
      tv2 = add(tv0_smem, tv1_smem)
      mbarrier::arrive(empty)
```