### PR TITLE
set_device before init_process_group

### DIFF
--- a/tests/python/multidevice/conftest.py
+++ b/tests/python/multidevice/conftest.py
@@ -83,7 +83,8 @@ def multidevice_test():
 def setup_default_process_group():
     communicator = nvfuser.Communicator.instance()
 
-    torch.cuda.set_device(communicator.local_rank())
+    local_rank = communicator.local_rank()
+    torch.cuda.set_device(local_rank)
 
     # The default port as used by https://github.com/pytorch/pytorch/blob/45a8b5682eb69d865cbf68c7f2f689b56b4efd53/torch/csrc/distributed/c10d/TCPStore.hpp#L51.
     dist.init_process_group(
@@ -91,6 +92,7 @@ def setup_default_process_group():
         init_method="tcp://localhost:29500",
         world_size=communicator.size(),
         rank=communicator.rank(),
+        device_id=torch.device(f"cuda:{local_rank}"),
     )
     yield
     dist.destroy_process_group()

--- a/tests/python/multidevice/conftest.py
+++ b/tests/python/multidevice/conftest.py
@@ -83,6 +83,8 @@ def multidevice_test():
 def setup_default_process_group():
     communicator = nvfuser.Communicator.instance()
 
+    torch.cuda.set_device(communicator.local_rank())
+
     # The default port as used by https://github.com/pytorch/pytorch/blob/45a8b5682eb69d865cbf68c7f2f689b56b4efd53/torch/csrc/distributed/c10d/TCPStore.hpp#L51.
     dist.init_process_group(
         backend="nccl",

--- a/tests/python/multidevice/test_deepseek_v3.py
+++ b/tests/python/multidevice/test_deepseek_v3.py
@@ -76,9 +76,6 @@ def test_transformer_layer(setup_default_process_group):
     # Disable quantization so the test can run on A100 and is made easier for nvFuser.
     delattr(config, "quantization_config")
 
-    rank = dist.get_rank()
-    torch.cuda.set_device(rank)
-
     # This ensures the input tokens are identically replicated on all ranks.
     # Otherwise, some ranks may skip an expert because they have no tokens to
     # send, while other ranks don't. This will cause a deadlock because a NCCL

--- a/tests/python/multidevice/test_dtensor.py
+++ b/tests/python/multidevice/test_dtensor.py
@@ -91,8 +91,6 @@ def test_plus_one(setup_default_process_group, multidevice_test):
     op = FusionDefinitionWrapper(define_fusion)
 
     num_devices = dist.get_world_size()
-    rank = dist.get_rank()
-    torch.cuda.set_device(rank)
 
     in_tensor = torch.randn(num_devices, 4)
     mesh = dist.device_mesh.init_device_mesh("cuda", [num_devices])
@@ -168,8 +166,6 @@ class LinearFunction(torch.autograd.Function):
 @pytest.mark.mpi
 def test_column_parallel_linear(setup_default_process_group, multidevice_test):
     d, b, s, e = dist.get_world_size(), 2, 1024, 768
-    rank = dist.get_rank()
-    torch.cuda.set_device(rank)
 
     mesh = dist.device_mesh.init_device_mesh("cuda", [d])
 
@@ -186,6 +182,7 @@ def test_column_parallel_linear(setup_default_process_group, multidevice_test):
 
     out_tensor = torch.nn.functional.linear(inp_tensor, weight_tensor)
     out_dtensor = LinearFunction.apply(inp_dtensor, weight_dtensor)
+    rank = dist.get_rank()
     assert_close(out_tensor.split(e, dim=-1)[rank], out_dtensor)
 
     (expected_grad_x, expected_grad_w) = torch.autograd.grad(
@@ -205,8 +202,6 @@ def test_column_parallel_linear(setup_default_process_group, multidevice_test):
 @pytest.mark.mpi
 def test_row_parallel_linear(setup_default_process_group, multidevice_test):
     d, b, s, e = dist.get_world_size(), 2, 1024, 768
-    rank = dist.get_rank()
-    torch.cuda.set_device(rank)
 
     mesh = dist.device_mesh.init_device_mesh("cuda", [d])
 
@@ -235,5 +230,6 @@ def test_row_parallel_linear(setup_default_process_group, multidevice_test):
         (inp_dtensor, weight_dtensor),
         torch.ones_like(out_dtensor),
     )
+    rank = dist.get_rank()
     assert_close(expected_grad_x.split(e, dim=-1)[rank], grad_x)
     assert_close(expected_grad_w.split(e, dim=-1)[rank], grad_w)

--- a/tests/python/multidevice/test_transformer_engine.py
+++ b/tests/python/multidevice/test_transformer_engine.py
@@ -2,7 +2,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import os
 import pytest
 import torch
 import torch.distributed as dist

--- a/tests/python/multidevice/test_transformer_engine.py
+++ b/tests/python/multidevice/test_transformer_engine.py
@@ -9,41 +9,6 @@ import torch.distributed as dist
 import transformer_engine.pytorch as te
 from enum import auto, Enum
 from functools import partial
-from mpi4py import MPI
-
-
-class MpiTest:
-    def __init__(self):
-        self._communicator = MPI.COMM_WORLD
-        self._local_size = int(os.environ["OMPI_COMM_WORLD_LOCAL_SIZE"])
-        self._local_rank = int(os.environ["OMPI_COMM_WORLD_LOCAL_RANK"])
-
-    @property
-    def size(self):
-        return self._communicator.size
-
-    @property
-    def rank(self):
-        return self._communicator.rank
-
-    @property
-    def local_size(self):
-        return self._local_size
-
-    @property
-    def local_rank(self):
-        return self._local_rank
-
-    def barrier(self):
-        self._communicator.barrier()
-
-
-@pytest.fixture(scope="session")
-def mpi_test():
-    fixture = MpiTest()
-    yield fixture
-    # Sync all ranks after each test for isolation.
-    fixture.barrier()
 
 
 class ComputeType(Enum):
@@ -100,9 +65,6 @@ def test_transformer_layer(
     dtype = torch.bfloat16
 
     size = dist.get_world_size()
-    rank = dist.get_rank()
-
-    torch.cuda.set_device(rank)
 
     transformer_layer = te.TransformerLayer(
         hidden_size,


### PR DESCRIPTION
as recommended by https://docs.pytorch.org/tutorials/beginner/ddp_series_multigpu.html#constructing-the-process-group

This PR also avoids some warnings during init_process_group:
```
tests/python/multidevice/test_deepseek_v3.py [rank0]:[W522 22:27:03.825695149 ProcessGroupNCCL.cpp:4789] [PG ID 0 PG GUID 0 Rank 0]  using GPU 0 as device used by this process is currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. You can specify device_id in init_process_group() to force use of a particular device.
```