### PR TITLE
`MakeReshardingContiguousPass` -> `FinalizeMultideviceDomainsPass`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/preseg_passes/consecutive_cast.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/exact_mapped_extent_substitution.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/insert_reshardings.cpp
-  ${NVFUSER_SRCS_DIR}/preseg_passes/make_resharding_contiguous.cpp
+  ${NVFUSER_SRCS_DIR}/preseg_passes/finalize_multidevice_domains.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/mark_aliases_prepare.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/move_pad.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/move_repeat_forward.cpp

--- a/csrc/host_ir/lower.cpp
+++ b/csrc/host_ir/lower.cpp
@@ -18,8 +18,8 @@
 #include <multidevice/utils.h>
 #include <ops/all_ops.h>
 #include <ops/utils.h>
+#include <preseg_passes/finalize_multidevice_domains.h>
 #include <preseg_passes/insert_reshardings.h>
-#include <preseg_passes/make_resharding_contiguous.h>
 #include <preseg_passes/propagate_shardings.h>
 #include <preseg_passes/reorder_sharded_axis.h>
 #include <runtime/fusion_kernel_runtime.h>
@@ -118,7 +118,7 @@ std::unique_ptr<hir::HostIrContainer> HostIrLower::lower(
   preseg_passes::OptimizationPass<
       preseg_passes::InsertReshardingsPass>::runPass(fusion.get());
   preseg_passes::OptimizationPass<
-      preseg_passes::MakeReshardingContiguousPass>::runPass(fusion.get());
+      preseg_passes::FinalizeMultideviceDomainsPass>::runPass(fusion.get());
 
   // Performs segmentation at the inter-device communications
   // Each SegmentedGroup represents a pipeline's stage, and can be either

--- a/csrc/preseg_passes/finalize_multidevice_domains.cpp
+++ b/csrc/preseg_passes/finalize_multidevice_domains.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/make_resharding_contiguous.h>
+#include <preseg_passes/finalize_multidevice_domains.h>
 
 #include <fusion.h>
 #include <ir/interface_nodes.h>
@@ -137,7 +137,7 @@ void setLoopAndAllocationDomain(TensorView* tv, bool is_resharding) {
 
 } // namespace
 
-void MakeReshardingContiguousPass::runPass(Fusion* fusion) {
+void FinalizeMultideviceDomainsPass::runPass(Fusion* fusion) {
   bool has_mesh = validateMeshes(fusion);
   if (!has_mesh) {
     return;

--- a/csrc/preseg_passes/finalize_multidevice_domains.h
+++ b/csrc/preseg_passes/finalize_multidevice_domains.h
@@ -27,14 +27,14 @@ namespace nvfuser::preseg_passes {
 // are placed together. See `setLoopAndAllocationDomain` for more details.
 // Eventually, this pass should run after `markAliasesPrepare` and
 // `AllocationDomainPass` after they are fixed.
-class MakeReshardingContiguousPass
-    : public OptimizationPass<MakeReshardingContiguousPass> {
-  friend class OptimizationPass<MakeReshardingContiguousPass>;
+class FinalizeMultideviceDomainsPass
+    : public OptimizationPass<FinalizeMultideviceDomainsPass> {
+  friend class OptimizationPass<FinalizeMultideviceDomainsPass>;
 
  protected:
   static void runPass(Fusion* fusion);
   static constexpr std::string_view name() {
-    return "MakeReshardingContiguousPass";
+    return "FinalizeMultideviceDomainsPass";
   }
 };
 

--- a/csrc/preseg_passes/pre_segmenter.cpp
+++ b/csrc/preseg_passes/pre_segmenter.cpp
@@ -15,8 +15,8 @@
 #include <preseg_passes/allocation_order_inference.h>
 #include <preseg_passes/consecutive_cast.h>
 #include <preseg_passes/exact_mapped_extent_substitution.h>
+#include <preseg_passes/finalize_multidevice_domains.h>
 #include <preseg_passes/insert_reshardings.h>
-#include <preseg_passes/make_resharding_contiguous.h>
 #include <preseg_passes/mark_aliases_prepare.h>
 #include <preseg_passes/move_pad.h>
 #include <preseg_passes/move_repeat_forward.h>
@@ -84,7 +84,7 @@ namespace nvfuser::preseg_passes {
   OptimizationPass<PropagateShardingsPass>::runPass(fusion);
   OptimizationPass<InsertReshardingsPass>::runPass(fusion);
   OptimizationPass<ReorderShardedAxisPass>::runPass(fusion);
-  OptimizationPass<MakeReshardingContiguousPass>::runPass(fusion);
+  OptimizationPass<FinalizeMultideviceDomainsPass>::runPass(fusion);
 
   OptimizationPass<RemoveBcastSqueeze>::runPass(fusion);
   OptimizationPass<SegmentInplaceUpdatePass>::runPass(fusion);

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -12,8 +12,8 @@
 #include <multidevice/executor.h>
 #include <multidevice/utils.h>
 #include <ops/all_ops.h>
+#include <preseg_passes/finalize_multidevice_domains.h>
 #include <preseg_passes/insert_reshardings.h>
-#include <preseg_passes/make_resharding_contiguous.h>
 #include <preseg_passes/propagate_shardings.h>
 #include <preseg_passes/reorder_sharded_axis.h>
 #include <tests/cpp/utils.h>
@@ -157,7 +157,7 @@ TEST_F(ShardingTest, ShardedAllocationDomain) {
   preseg_passes::OptimizationPass<
       preseg_passes::ReorderShardedAxisPass>::runPass(&fusion);
   preseg_passes::OptimizationPass<
-      preseg_passes::MakeReshardingContiguousPass>::runPass(&fusion);
+      preseg_passes::FinalizeMultideviceDomainsPass>::runPass(&fusion);
   for (auto expr : fusion.exprs()) {
     if (isResharding(expr)) {
       for (auto tv : ir_utils::filterByType<TensorView>(expr->inputs())) {
@@ -264,7 +264,8 @@ TEST_F(ShardingTest, ResidualAdd) {
       preseg_passes::PropagateShardingsPass>::runPass(fusion.get());
   // getShardedLogicalAxis uses maybeAllocationDomain to get the sharded axis.
   // Setting allocation domain here manually, which is otherwise done by
-  // MakeReshardingContiguousPass, to isolate the test to a single preseg pass.
+  // FinalizeMultideviceDomainsPass, to isolate the test to a single preseg
+  // pass.
   for (auto tv : fusion->allTvs()) {
     tv->setAllocationDomain(tv->getLoopDomain(), true);
   }


### PR DESCRIPTION
Rename to better reflect the current aim of the presegmentation pass.