### PR TITLE
Revert "Limit CTA tile K dimension to problem K + 15 (#4458)"

### DIFF
--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -287,16 +287,7 @@ void fillOptimalHopperTileSizes(
   // If two sizes result in the same number of total byte, prefer the larger CTA
   // K. To do this we iterate backwards here.
   constexpr int64_t reserved_mbarrier_bytes = 1024L;
-  for (int64_t cta_k = 256; cta_k > 0; cta_k -= 16) {
-    if ( // Only consider cta_k in 16, 32, 48, 64, 128, 192, 256
-        (cta_k > 64 && cta_k % 64 != 0) || cta_k > k + 15) {
-      // There is no reason to use a larger CTA tile than K + 15 since K+16
-      // would include an extra instruction which is unnecessary. We do allow
-      // cta_k larger than k though in order to catch cases like K=248 which we
-      // can compute in a single K=256 tile even though the last instruction
-      // tile is half empty.
-      continue;
-    }
+  for (int64_t cta_k = 256; cta_k > 0; cta_k -= 64) {
     for (const auto& [m_ratio, n_ratio] :
          std::vector<std::pair<int64_t, int64_t>>{
              {2L, 1L}, // coopA


### PR DESCRIPTION
This reverts commit 6b5de266ab25fbb61930f1fc935a04764ce19aa9 (PR #4458)

That change increased perf on a small private problem set, but it drastically reduced perf on `benchmarks/python/test_matmul.py` from 60% to 40% compared to eager. Until this is better understood, I'd like to revert the change and follow it up with an improved PR.