### PR TITLE
Respect `min` and `max` of inputs to create more precise repro scripts

### DIFF
--- a/python/nvfuser/__init__.py
+++ b/python/nvfuser/__init__.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 from typing import Callable
+from numbers import Number
 import warnings
 
 import torch
@@ -53,6 +54,51 @@ def disable_automatic_serialization():
     import atexit
 
     atexit.unregister(_C.serialize)
+
+
+# NOTE(crcrpar): The main motivation of this dataclass is to avoid unexpected negative values being supplied to indexing such as embedding.
+# See NVIDIA/Fuser#4529.
+class InputReproducer:
+    low: Number
+    high: Number
+    device: torch.device
+    dtype: torch.dtype
+    size: tuple[int, ...]
+    strides: tuple[int, ...]
+    is_contiguous: bool
+
+    def __init__(self, tensor: torch.Tensor) -> None:
+        if type(tensor) is not torch.Tensor:
+            msg = f"Repro script only supports {torch.Tensor} but {type(tensor)}"
+            raise RuntimeError(msg)
+        self.low, self.high = InputReproducer.get_min_and_max(tensor)
+        self.dtype = tensor.dtype
+        self.device = tensor.device
+        self.size = tuple(tensor.size())
+        self.strides = tuple(tensor.stride())
+        self.is_contiguous = tensor.is_contiguous()
+
+    @torch.inference_mode()
+    @staticmethod
+    def get_min_and_max(tensor: torch.Tensor) -> tuple[Number | None, Number | None]:
+        if tensor.dtype is torch.bool:
+            return 0, 2
+
+        t = tensor
+        if t.dtype.is_floating_point and t.dtype.itemsize == 1:
+            t = t.float()
+
+        min_max = torch.aminmax(t)
+        return min_max[0].cpu().item(), min_max[1].cpu().item()
+
+    def to_make_tensor_str(self) -> str:
+        if self.is_contiguous:
+            return f"torch.testing.make_tensor({self.size}, dtype={self.dtype}, device={self.device}, low={self.low}, high={self.high},)"
+        if self.dtype.is_floating_point:
+            return f"torch.randn({self.size}, dtype={self.dtype}, device={self.device}).as_strided({self.size}, {self.strides})"
+        else:
+            return f"torch.randint({self.low}, {self.high}, {self.size}, dtype={self.dtype}, device={self.device},).as_strided({self.size}, {self.strides})"
+
 
 
 class FusionDefinition(_C._FusionDefinition):
@@ -311,10 +357,7 @@ class FusionDefinition(_C._FusionDefinition):
                     self._finalize_schedule(inputs)
 
         if save_repro_inputs:
-            from torch._subclasses.fake_tensor import FakeTensorMode
-
-            fake_mode = FakeTensorMode()
-            self.fake_inputs = [fake_mode.from_tensor(inp) for inp in inputs]
+            self.last_input_reproducers = [InputReproducer(tensor) for tensor in inputs]
 
         if hasattr(self, "segments") and len(self.segments) > 0:
             return self._execute_segments(inputs, device=device, profile=profile)
@@ -497,12 +540,12 @@ class FusionDefinition(_C._FusionDefinition):
 
     def last_repro_script(self) -> str:
         assert (
-            self.fake_inputs is not None
+            self.last_input_reproducers is not None
         ), "fd.last_repro_script() cannot provide a repro because fd.execute(inputs, save_repro_state=True) was not executed!"
-        script = self.repro_script_for(self.fake_inputs)
+        script = self.repro_script_for(self.last_input_reproducers)
         return script
 
-    def repro_script_for(self, inputs: list | None = None) -> str:
+    def repro_script_for(self, inputs: list[torch.Tensor] | list[InputReproducer] | None = None) -> str:
         msg = "# CUDA devices:\n"
         for i in range(torch.cuda.device_count()):
             msg += f"#  {i}: {torch.cuda.get_device_name(i)}\n"
@@ -541,6 +584,8 @@ class FusionDefinition(_C._FusionDefinition):
                                 f"    torch.randint(0, {upper_bound}, ({sz},), dtype={i.dtype}, device='{i.device}')"
                                 f".as_strided({tuple(i.size())}, {tuple(i.stride())}),\n"
                             )
+                elif isinstance(i, InputReproducer):
+                    msg += f"    {i.to_make_tensor_str()},\n"
                 else:
                     input_as_string = str(i)
                     # `nan` and `inf` are stringified as is, which are not

--- a/python/nvfuser/__init__.py
+++ b/python/nvfuser/__init__.py
@@ -562,6 +562,7 @@ class FusionDefinition(_C._FusionDefinition):
         if inputs is not None:
             msg += "\ninputs = [\n"
             for i in inputs:
+                # TODO(crcrpar): Think about how to support tensor wrapper subclasses such as DTensor
                 if isinstance(i, torch.Tensor):
                     i = InputReproducer(i)
                 if isinstance(i, InputReproducer):

--- a/python/nvfuser/__init__.py
+++ b/python/nvfuser/__init__.py
@@ -563,28 +563,8 @@ class FusionDefinition(_C._FusionDefinition):
             msg += "\ninputs = [\n"
             for i in inputs:
                 if isinstance(i, torch.Tensor):
-                    if i.is_contiguous():
-                        msg += f"    torch.testing.make_tensor({tuple(i.size())}, dtype={i.dtype}, device='{i.device}'),\n"
-                    else:
-                        # max linear index determines number of elements to generate
-                        sz = 1
-                        for szi, stri in zip(i.size(), i.stride()):
-                            if szi == 0:
-                                sz = 0
-                                break
-                            sz += (szi - 1) * stri
-                        if i.dtype.is_floating_point:
-                            msg += (
-                                f"    torch.randn({sz}, dtype={i.dtype}, device='{i.device}')"
-                                f".as_strided({tuple(i.size())}, {tuple(i.stride())}),\n"
-                            )
-                        else:
-                            upper_bound = 2 if i.dtype == torch.bool else 10
-                            msg += (
-                                f"    torch.randint(0, {upper_bound}, ({sz},), dtype={i.dtype}, device='{i.device}')"
-                                f".as_strided({tuple(i.size())}, {tuple(i.stride())}),\n"
-                            )
-                elif isinstance(i, InputReproducer):
+                    i = InputReproducer(i)
+                if isinstance(i, InputReproducer):
                     msg += f"    {i.to_make_tensor_str()},\n"
                 else:
                     input_as_string = str(i)

--- a/python/nvfuser/__init__.py
+++ b/python/nvfuser/__init__.py
@@ -61,7 +61,7 @@ def disable_automatic_serialization():
 class InputReproducer:
     low: Number
     high: Number
-    device: torch.device
+    device: str
     dtype: torch.dtype
     size: tuple[int, ...]
     strides: tuple[int, ...]
@@ -73,7 +73,7 @@ class InputReproducer:
             raise RuntimeError(msg)
         self.low, self.high = InputReproducer.get_min_and_max(tensor)
         self.dtype = tensor.dtype
-        self.device = tensor.device
+        self.device = f'"{str(tensor.device)}"'
         self.size = tuple(tensor.size())
         self.strides = tuple(tensor.stride())
         self.is_contiguous = tensor.is_contiguous()


### PR DESCRIPTION
Related: #4529

When an nvfuser fusion definition takes signed int tensors as inputs, it's possible that those int tensors have a solid value range e.g. [0, some_large_number) for embedding, the `FusionDefinition.last_repro_script` seems to have lost such range information as it uses `FusionDefinition.fake_inputs` that is generated by casting all the input tensors, leading to a loss of actual values.

Inspired by lightning-thunder's [`ExampleInputMetaData`](https://github.com/Lightning-AI/lightning-thunder/blob/4741b440d0e9e187b765e7dd9b0a23b3c2b6d7bc/thunder/dynamo/utils.py#L89), I rather store the range info in a dataclass that can give us a string of `make_tensor` or equivalents to get tensors of the same value range.

For the same fusion definition as #4529, running the fusion definition as follows
```python
inputs = [
    torch.randint(0, 10, (16,), dtype=torch.int32, device='cuda:0'),
    torch.testing.make_tensor((151936, 2048), dtype=torch.bfloat16, device='cuda:0'),
    torch.testing.make_tensor((2048,), dtype=torch.bfloat16, device='cuda:0'),
    torch.testing.make_tensor((2560, 2048), dtype=torch.bfloat16, device='cuda:0'),
    torch.testing.make_tensor((2560,), dtype=torch.bfloat16, device='cuda:0'),
]
fd.execute(inputs, save_repro_inputs=True, print_repro=True)
```
both `fd.last_repro_script()` and the `fd.execute` return
```python
inputs = [
    torch.testing.make_tensor((16,), dtype=torch.int32, device="cuda:0", low=0, high=7,),
    torch.testing.make_tensor((151936, 2048), dtype=torch.bfloat16, device="cuda:0", low=-9.0, high=8.9375,),
    torch.testing.make_tensor((2048,), dtype=torch.bfloat16, device="cuda:0", low=-9.0, high=8.9375,),
    torch.testing.make_tensor((2560, 2048), dtype=torch.bfloat16, device="cuda:0", low=-9.0, high=8.9375,),
    torch.testing.make_tensor((2560,), dtype=torch.bfloat16, device="cuda:0", low=-9.0, high=8.9375,),
]
```