### PR TITLE
Extend `mapDeviceParalleTypeToId` to include Stream

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -147,7 +147,7 @@ std::unordered_map<ParallelType, IterDomain*> mapDeviceAndStreamParallelTypeToId
     // rDIDx{i0}, usually a product of an Allreduce or a ReduceScatter, is
     // treated as replicated. This way `iDIDx{i0} => rDIDx{i0}` is considered
     // resharding.
-    if (id->isReduction() && id->isDeviceDim()) {
+    if (id->isReduction()) {
       continue;
     }
 


### PR DESCRIPTION
1. Includes device and stream parallel types.
2. Ignores DID parallel types on reduction dimensions. In this case, the DID dimension can be present on another iterdomain. For eg, in reduce scatter.

I attempted to include all but Serial parallel type initially. However, the MMA parallel type can also be present on multiple iterdomains. So I am limiting this to device and stream parallel types.