### PR TITLE
Map CGA dims using 3D grid in persistent Hopper matmul

### DIFF
--- a/csrc/scheduler/matmul_hopper+.cpp
+++ b/csrc/scheduler/matmul_hopper+.cpp
@@ -435,33 +435,88 @@ std::vector<std::vector<MatmulDimRole>> HopperPlus::blockTileTensors(
       merged_roles =
           mma_utils::makeTile(tv, params_->tile_sizes.cta_tile, merged_roles);
 
-      // TODO: This merge is only used for non-persistent schedules
-      // Now merge the 3 CGA/CTA split outer dims back with the outermost dims.
-      // This is important since we need single dims to bind to.
-      // For example we might have Mo, No, Mcga, Ncga, Mcta, Ncta, and we need
-      // this to be Mo*Mcga, No*Ncga, Mcta, Ncta instead.
-      int64_t outer_mnk_pos = 0; // 0 in the example above
-      int64_t almost_outer_mnk_pos = 0; // 2 in the example above
-      while (merged_roles.at((size_t)outer_mnk_pos) == MatmulDimRole::Batch) {
-        outer_mnk_pos++;
-      }
-      std::unordered_set<MatmulDimRole> outer_roles;
-      while (almost_outer_mnk_pos < (int64_t)merged_roles.size()) {
-        // Find first repeated role position
-        MatmulDimRole role = merged_roles.at((size_t)almost_outer_mnk_pos);
-        if (outer_roles.count(role)) {
+      switch (params_->tiling_strategy) {
+        case MatmulParams::TilingStrategy::OneTilePerCTA: {
+          // NOTE: This merge is only used for non-persistent schedules
+          // Now merge the 3 CGA/CTA split outer dims back with the outermost
+          // dims. This is important since we need single dims to bind to. For
+          // example we might have Mo, No, Mcga, Ncga, Mcta, Ncta, and we need
+          // this to be Mo*Mcga, No*Ncga, Mcta, Ncta instead.
+          int64_t outer_mnk_pos = 0; // 0 in the example above
+          int64_t almost_outer_mnk_pos = 0; // 2 in the example above
+          while (merged_roles.at((size_t)outer_mnk_pos) ==
+                 MatmulDimRole::Batch) {
+            outer_mnk_pos++;
+          }
+          std::unordered_set<MatmulDimRole> outer_roles;
+          while (almost_outer_mnk_pos < (int64_t)merged_roles.size()) {
+            // Find first repeated role position
+            MatmulDimRole role = merged_roles.at((size_t)almost_outer_mnk_pos);
+            if (outer_roles.count(role)) {
+              break;
+            }
+            almost_outer_mnk_pos++;
+            outer_roles.insert(role);
+          }
+          NVF_ERROR(
+              almost_outer_mnk_pos < (int64_t)merged_roles.size(),
+              "Because of tiling, we expect repeated roles");
+          for (int64_t i : std::views::reverse(
+                   arange(outer_mnk_pos, almost_outer_mnk_pos))) {
+            tv->merge(i, i + (almost_outer_mnk_pos - outer_mnk_pos));
+            merged_roles.erase(merged_roles.begin() + (size_t)i);
+          }
           break;
         }
-        almost_outer_mnk_pos++;
-        outer_roles.insert(role);
-      }
-      NVF_ERROR(
-          almost_outer_mnk_pos < (int64_t)merged_roles.size(),
-          "Because of tiling, we expect repeated roles");
-      for (int64_t i :
-           std::views::reverse(arange(outer_mnk_pos, almost_outer_mnk_pos))) {
-        tv->merge(i, i + (almost_outer_mnk_pos - outer_mnk_pos));
-        merged_roles.erase(merged_roles.begin() + (size_t)i);
+        case MatmulParams::TilingStrategy::DistributeTilesAcrossSMs: {
+          // Do not merge CGA dims since we will map them to BIDy/BIDz instead
+          // However, We do move the CGA dims outside the serial K loop
+          // dimension in order to simplify downstream scheduling.
+          //
+          // For example, at this point we might have
+          //     T7_s___bfloat[
+          //       iS34{( ( ceilDiv(i0, 256) ) * 8 )},
+          //       bS32{1},
+          //       iS26{( ceilDiv(i1, 64) )},  // serial K loop
+          //       iS39{2},  // cga dims
+          //       bS37{1},
+          //       iS35{1},
+          //       iS40{128},  // cta tile
+          //       bS38{256},
+          //       iS36{64}
+          //       ]
+          // We need to reorder this to be
+          //     T7_s___bfloat[
+          //       iS34{( ( ceilDiv(i0, 256) ) * 8 )},
+          //       bS32{1},
+          //       iS39{2},  // cga dims
+          //       bS37{1},
+          //       iS35{1},
+          //       iS26{( ceilDiv(i1, 64) )},  // serial K loop
+          //       iS40{128},  // cta tile
+          //       bS38{256},
+          //       iS36{64}
+          //       ]
+
+          if (merged_roles.back() == MatmulDimRole::K) {
+            tv->reorder({{-7, -4}, {-6, -7}, {-5, -6}, {-4, -5}});
+            NVF_ERROR(
+                merged_roles[merged_roles.size() - 7] == MatmulDimRole::K);
+            NVF_ERROR(
+                merged_roles[merged_roles.size() - 6] == MatmulDimRole::M);
+            NVF_ERROR(
+                merged_roles[merged_roles.size() - 5] == MatmulDimRole::N);
+            NVF_ERROR(
+                merged_roles[merged_roles.size() - 4] == MatmulDimRole::K);
+            merged_roles[merged_roles.size() - 7] = MatmulDimRole::M;
+            merged_roles[merged_roles.size() - 6] = MatmulDimRole::N;
+            merged_roles[merged_roles.size() - 5] = MatmulDimRole::K;
+            merged_roles[merged_roles.size() - 4] = MatmulDimRole::K;
+          }
+          break;
+        }
+        default:
+          NVF_THROW("Unsupported tiling strategy");
       }
     } else {
       // no cga split
@@ -520,9 +575,7 @@ std::vector<std::vector<MatmulDimRole>> HopperPlus::blockTileTensors(
         merged_roles.erase(merged_roles.begin());
       }
 
-      const int64_t num_sms =
-          at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-      tv->split(num_device_dims_, num_sms);
+      tv->split(num_device_dims_, numCGAs());
     } else {
       NVF_THROW("Unsupported tiling strategy");
     }
@@ -530,6 +583,14 @@ std::vector<std::vector<MatmulDimRole>> HopperPlus::blockTileTensors(
     all_merged_roles.push_back(merged_roles);
   }
   return all_merged_roles;
+}
+
+int64_t HopperPlus::numCGAs() const {
+  const int64_t num_sms =
+      at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+  return num_sms /
+      (params_->cluster_dims.x * params_->cluster_dims.y *
+       params_->cluster_dims.z);
 }
 
 void HopperPlus::inspectPrologues() const {
@@ -594,8 +655,28 @@ void HopperPlus::parallelizeBlocks(const std::vector<TensorView*>& tvs) const {
         break;
       case MatmulParams::TilingStrategy::DistributeTilesAcrossSMs:
       case MatmulParams::TilingStrategy::DistributeStagesAcrossSMs:
-        // For persistent kernels, we just parallelize the SM dimension
-        tv->axis(num_device_dims_ + 1)->parallelize(ParallelType::BIDx);
+        // For persistent kernels, we parallelize BIDx, and if cluster_dims is
+        // non-trivial then we also bind BIDy and BIDz
+        if (params_->cluster_dims.x != 1 || params_->cluster_dims.y != 1) {
+          tv->axis(num_device_dims_ + 1)->parallelize(ParallelType::BIDz);
+          switch (params_->cta_order) {
+            // TODO: Should we instead check the roles of these dimensions to
+            // take the outermost two M or N axes?
+            case MatmulParams::TileRasterizationOrder::ColumnMajor:
+              tv->axis(num_device_dims_ + 2)->parallelize(ParallelType::BIDx);
+              tv->axis(num_device_dims_ + 3)->parallelize(ParallelType::BIDy);
+              break;
+            case MatmulParams::TileRasterizationOrder::RowMajor:
+              tv->axis(num_device_dims_ + 2)->parallelize(ParallelType::BIDy);
+              tv->axis(num_device_dims_ + 3)->parallelize(ParallelType::BIDx);
+              break;
+            default:
+              NVF_THROW(
+                  "Invalid TileRasterizationOrder passed to Matmul scheduler");
+          }
+        } else {
+          tv->axis(num_device_dims_ + 1)->parallelize(ParallelType::BIDx);
+        }
         break;
     }
   }

--- a/csrc/scheduler/matmul_hopper+.h
+++ b/csrc/scheduler/matmul_hopper+.h
@@ -163,6 +163,10 @@ class HopperPlus : public Common {
     }
   }
 
+  //! Computes the number of CGAs we can launch in a single wave on the current
+  //! device
+  int64_t numCGAs() const;
+
   //! Schedule the loads of all operands from global memory to shared memory.
   //! Starting from the basic tiled schedule, we swizzle the operand memory.
   //! Note that the cache op and LoadStoreOpType are already set during


### PR DESCRIPTION
Stacked on #4405.

Given something like `cluster_dims = {4, 2, 1}`, this PR creates a 3D grid of size `{4, 2, 66}` (assuming 132 SMs). This makes it trivial to launch the proper number of CTAs and can simplify indexing for finding the position within the CGA. That is not currently needed but it would be if we want to do explicit multicast or broadcasting within a CGA.