### PR TITLE
Enable TensorIndexer in test_pointwise

### DIFF
--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -20,7 +20,11 @@
 
 namespace nvfuser {
 
-using PointwiseTest = NVFuserTest;
+class PointwiseTest : public NVFuserTest {
+  void SetUp() override {
+    EnableOptionsGuard::getCurOptions().set(EnableOption::IdModel, {"all"});
+  }
+};
 
 namespace {
 


### PR DESCRIPTION
Enabled TensorIndexer for the pointwise tests

Code diffs are only due to more aggressive uses of vectorization info.

```
-    for(nvfuser_index_t i6 = 0; i6 < 4; ++i6) {
-      if ((i4 < (-(i6 + nvfuser_zero)))) {
-        T9[i6]
+    for(nvfuser_index_t i5 = 0; i5 < 4; ++i5) {
+      if (b4) {
+        T9[i5]
            = T1[i0];
       }
     }
```

In this case, this loop is exactly mapped with a vectorized loop ID, which guarantees the divisibility of the split that produces this ID of extent 4, which means the predicate can be simplified by [this](https://github.com/NVIDIA/Fuser/blob/main/csrc/id_model/predicate_indexing.cpp#L193-L222).