### PR TITLE
fix smem buffer size and indexing for pingpong

### DIFF
--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -588,8 +588,9 @@ Val* CircularBufferInfo::getLinearIndex(
 
   // short-circuit: return index for inner-most for-loop if not warp specialized
   // with register sharing
-  bool is_warp_specialized = std::holds_alternative<WarpSpecialized>(
-      circular_buffer_tv->circularBufferOptions().type);
+  auto circular_buffer_type = circular_buffer_tv->circularBufferOptions().type;
+  bool is_warp_specialized =
+      std::holds_alternative<WarpSpecialized>(circular_buffer_type);
   if (!is_warp_specialized) {
     return loops[inner_loop_index]->indexOrStartIfTrivial();
   }
@@ -600,7 +601,10 @@ Val* CircularBufferInfo::getLinearIndex(
       getForLoopIndex(circular_buffer_tv, loops, /*is_inner_most_axis=*/false);
 
   // Calculate insertion position.
-  int64_t insertion_position = inner_loop_index - outer_loop_index + 1;
+  auto warp_specialized = std::get<WarpSpecialized>(circular_buffer_type);
+  int64_t insertion_position = warp_specialized.stage_slice_position.has_value()
+      ? warp_specialized.stage_slice_position.value() - 1
+      : inner_loop_index - outer_loop_index + 1;
   return getLinearIndexRelativeForLoopStack(
       loops, insertion_position, /*start=*/outer_loop_index);
 }

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -588,7 +588,8 @@ Val* CircularBufferInfo::getLinearIndex(
 
   // short-circuit: return index for inner-most for-loop if not warp specialized
   // with register sharing
-  const auto& circular_buffer_type = circular_buffer_tv->circularBufferOptions().type;
+  const auto& circular_buffer_type =
+      circular_buffer_tv->circularBufferOptions().type;
   bool is_warp_specialized =
       std::holds_alternative<WarpSpecialized>(circular_buffer_type);
   if (!is_warp_specialized) {
@@ -600,11 +601,16 @@ Val* CircularBufferInfo::getLinearIndex(
   int64_t outer_loop_index =
       getForLoopIndex(circular_buffer_tv, loops, /*is_inner_most_axis=*/false);
 
-  // Calculate insertion position.
+  // The inner_loop_index is the for-loop where the mbarrier arrive and wait
+  // operations are inserted in circular buffering pass. Use
+  // stage_slice_position if available. Otherwise, the default value is the
+  // first serial for-loop to the left of compute_at_position.
   auto warp_specialized = std::get<WarpSpecialized>(circular_buffer_type);
-  int64_t insertion_position = warp_specialized.stage_slice_position.has_value()
-      ? warp_specialized.stage_slice_position.value() - 1
-      : inner_loop_index - outer_loop_index + 1;
+  if (warp_specialized.stage_slice_position.has_value()) {
+    inner_loop_index = warp_specialized.stage_slice_position.value() - 1;
+  }
+  // Calculate insertion position.
+  int64_t insertion_position = inner_loop_index - outer_loop_index + 1;
   return getLinearIndexRelativeForLoopStack(
       loops, insertion_position, /*start=*/outer_loop_index);
 }

--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -588,7 +588,7 @@ Val* CircularBufferInfo::getLinearIndex(
 
   // short-circuit: return index for inner-most for-loop if not warp specialized
   // with register sharing
-  auto circular_buffer_type = circular_buffer_tv->circularBufferOptions().type;
+  const auto& circular_buffer_type = circular_buffer_tv->circularBufferOptions().type;
   bool is_warp_specialized =
       std::holds_alternative<WarpSpecialized>(circular_buffer_type);
   if (!is_warp_specialized) {

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -803,10 +803,10 @@ AllocPosInfo getAllocPosInfo(
   int64_t compute_pos = tv->getComputeAtPosition();
   // For warp specialized circular buffers its stage_slice_position controls the
   // buffer size for each stage.
-  if (tv->isCircularBuffered() &&
-      gpu_lower->circularBufferInfo().hasWarpSpecialized()) {
+  const auto& circular_buffer_type = tv->circularBufferOptions().type;
+  if (std::holds_alternative<WarpSpecialized>(circular_buffer_type)) {
     const auto& warp_specialized =
-        std::get<WarpSpecialized>(tv->circularBufferOptions().type);
+        std::get<WarpSpecialized>(circular_buffer_type);
     if (warp_specialized.stage_slice_position.has_value()) {
       compute_pos = warp_specialized.stage_slice_position.value();
     }

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -800,9 +800,19 @@ AllocPosInfo getAllocPosInfo(
   auto gpu_lower = GpuLower::current();
 
   bool outer_alloc_found = false;
-
+  int64_t compute_pos = tv->getComputeAtPosition();
+  // For warp specialized circular buffers its stage_slice_position controls the
+  // buffer size for each stage.
+  if (tv->isCircularBuffered() &&
+      gpu_lower->circularBufferInfo().hasWarpSpecialized()) {
+    const auto& warp_specialized =
+        std::get<WarpSpecialized>(tv->circularBufferOptions().type);
+    if (warp_specialized.stage_slice_position.has_value()) {
+      compute_pos = warp_specialized.stage_slice_position.value();
+    }
+  }
   for (auto fl : for_loops) {
-    if (info.alloc_pos == tv->getComputeAtPosition()) {
+    if (info.alloc_pos == compute_pos) {
       DEBUG_LOG("Break at info.alloc_pos = ", info.alloc_pos);
       break;
     }

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -124,6 +124,13 @@ TEST_P(PingPongCircularBuffering, StageSlicePositionComputeAt) {
 
   auto out_ref = t0 + t0;
   auto cg_outputs = ke.run({t0});
+  // check shared memory size
+  int64_t smem_buffer_size = dim1 * sizeof(float) * rows_per_stage * stages;
+  int64_t smem_barrier_size = 128;
+  EXPECT_EQ(ke.lastLaunchParams().smem(), smem_buffer_size + smem_barrier_size)
+      << "Shared memory size err, expected "
+      << smem_buffer_size + smem_barrier_size << ", got "
+      << ke.lastLaunchParams().smem();
   testValidate(fusion.get(), cg_outputs, {t0}, {out_ref}, __LINE__, __FILE__);
 }
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -62,7 +62,7 @@ TEST_P(PingPongCircularBuffering, StageSlicePositionComputeAt) {
     // [I, 2, 132, 4]
     tv->axis(0)->parallelize(ParallelType::Serial);
     tv->axis(2)->parallelize(ParallelType::BIDx);
-    tv->axis(3)->parallelize(ParallelType::Unroll);
+    tv->axis(3)->parallelize(ParallelType::Serial);
   }
 
   tv1->axis(1)->parallelize(ParallelType::Serial);
@@ -125,7 +125,16 @@ TEST_P(PingPongCircularBuffering, StageSlicePositionComputeAt) {
   auto out_ref = t0 + t0;
   auto cg_outputs = ke.run({t0});
   // check shared memory size
-  int64_t smem_buffer_size = dim1 * sizeof(float) * rows_per_stage * stages;
+  int64_t size_per_row = dim1 * sizeof(float);
+  int64_t rows_per_sync = 0;
+  if (stage_slice_position == 2) {
+    rows_per_sync = rows_per_stage * compute_warp_groups;
+  } else if (stage_slice_position == 3) {
+    rows_per_sync = rows_per_stage;
+  } else if (stage_slice_position == 4) {
+    rows_per_sync = 1;
+  }
+  int64_t smem_buffer_size = size_per_row * stages * rows_per_sync;
   int64_t smem_barrier_size = 128;
   EXPECT_EQ(ke.lastLaunchParams().smem(), smem_buffer_size + smem_barrier_size)
       << "Shared memory size err, expected "


### PR DESCRIPTION
### Calculate allocated shared memory size accounting for `stage_slice_position`
**Issue:**
The current main branch allocates memory based on `tv->getComputeAtPosition();`, which is equivalent to `size_per_stage × stages × number_of_computation_warp_groups` for cases with multiple computation warp groups. However, this should be revised to `size_per_stage × stages`, since different warp groups operate on different circular buffer stages.

For example, for `T1_s_float[iblockIdx.x11{132}, iS12{12}, iS13{2}, | stage_slice_position |, iUR9{4}, iB3{128}] ca_pos( 2 )`, the current allocation is `iB3{128} × iUR9{4} × iS13{2} × circular_stages`. This should be corrected to `iB3{128} × iUR9{4}  × circular_stages`.

More generally, the allocated size should depends on `stage_slice_position` not `ca_pos`

**Fix:**
Update `getAllocPosInfo()` and `CircularBufferInfo::getLinearIndex()` to account for `stage_slice_position`.
The influence of   `stage_slice_position` on allocated shared memory size is illustrated in the following figure.
![image](https://github.com/user-attachments/assets/8aae433b-3c38-4c5f-8f37-efafec52539c)

**Test:**  revised `PingPongCircularBuffering` allocated smem size depends on `stage_slice_position`
```
  // check shared memory size
  int64_t size_per_row = dim1 * sizeof(float);
  int64_t rows_per_sync = 0;
  if(stage_slice_position == 2) {
    rows_per_sync = rows_per_stage * compute_warp_groups;
  } else if (stage_slice_position == 3) {
    rows_per_stage = rows_per_stage;
  } else if (stage_slice_position == 4) {
    rows_per_sync = 1;
  }
  int64_t smem_buffer_size = size_per_row * stages * rows_per_sync;
```