### PR TITLE
Modify matmul scheduler to schedule alternate_loop_domain for ldstmatrix

### DIFF
--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1827,253 +1827,6 @@ Val* hardCodedSharedMemoryIndexForLdStMatrix(
   return IrBuilder::create<kir::TensorIndex>(smem_tv, smem_index);
 }
 
-// Goal: Store (tma_m, tma_n) row-major tile in shared memory using stmatrix
-// (stsm_m_tile, stsm_n_tile)
-//
-// Let shared_memory tile be (tma_m = 64, tma_n = 128).
-// Let StMatrix tile be (stsm_m_tile = 16, stsm_n_tile = 16).
-// Let dtype be fp16 or bf16, so dtype_size is 2B.
-//
-// To avoid shared memory bank conflicts, apply swizzle on stmatrix and
-// tma store operations. Let swizzle be MmaInputSmemSwizzle::B128.
-//
-// For the TMA store, create box for 128B swizzle.
-// Let inner_tile_size = getBytesFromSwizzle(swizzle) / dtype_size = 64.
-//
-// Given shared memory tile [M(64), N(128)], split inner dimension by
-// inner_tile_size and reorder dimensions to get [NO(2), M(64), NI(64)].
-// The TMA Box is [M, NI]. Apply swizzle to the box using swizzleTMABox.
-//
-// Each ThreadIdx.y handles a (tma_m, tma_n) tile.
-// To account for the threadIdx.y, we have to add it to the offset:
-//   offset_from_tdy = threadIdx.y * tma_m * tma_n * 2 (half)
-//
-// Now, lets apply stmatrix tile (16, 16) to the TMA Box [NO(2), M(64), NI(64)].
-//   [NO(2), MO(4), MI(16), NIO(4), NII(16)].
-//
-// A warp group of 128 threads contains four warps. StMatrix is a warp-level
-// operation, so four StMatrix operations can be issued simultaneously by the
-// warp group. Those four warps are applied for the MO dimension.
-//
-// [NO(2), MO(4) - TDX, MI(16) - StMatrix, NIO(4), NII(16) - StMatrix].
-// Virtually, there are 2 for-loops of size NO(2) and NIO(4).
-//
-// The Input TensorView for StMatrix after scheduleMmaOutputAllocation is
-// [128(TIDx), 8(n), 2, 2]. Given this domain, there is a serial for-loop of
-// size 8.
-//
-// Get indices for virtual for-loops given the serial for-loop:
-//   outer_index = loop->index() / NIO(4)
-//   inner_index = loop->index() % NIO(4)
-//
-// The allocation domain of the shared memory tensor must match the loop domain
-// of the global memory tensor when applying swizzle to the TMA store. The loop
-// domain is scheduled as [NO(2), M(64), NI(64)]. Therefore, we must store the
-// data in shared memory in [M(64), NI(64)] contiguous tiles.
-//
-// NOTE: This offset is skipped if for-loop is trivial
-// To account for the outer_index, we have to add it to the offset:
-//   offset_from_outer_index = outer_index * tma_m * NI(64) * 2 (half)
-//
-// Since the warp group can launch 4 stmatrix operation in parallel, associate
-// each thread with a warp.
-//   warp_id = TDX / 32
-//
-// Since StMatrix is a warp-level operation, associate each thread with its
-// lane in the warp.
-//   lane_id = TDX % 32
-//
-// The TMA Box is [M(64), NI(64)]. When each warp applies stmatrix.x4, the box
-// is reshaped as such [MO(4) - TDX, MI(16) - STSM, NIO(4), NII(16) - STSM].
-//
-// The four warps handle MI(16) rows of the box. Each iteration of the
-// for-loop handles NII(16) columns of the box.
-//
-//    0       16      32     48       64
-// 0  *********************************
-//    *       *       *       *       *
-//    *       *       *       *       *
-// W0 *  I0   *  I1   *  I2   *   I3  *
-//    *       *       *       *       *
-//    *       *       *       *       *
-// 16 *********************************
-//    *       *       *       *       *
-//    *       *       *       *       *
-// W1 *  I0   *  I1   *  I2   *   I3  *
-//    *       *       *       *       *
-//    *       *       *       *       *
-// 32 *********************************
-//    *       *       *       *       *
-//    *       *       *       *       *
-// W2 *  I0   *  I1   *  I2   *   I3  *
-//    *       *       *       *       *
-//    *       *       *       *       *
-// 48 *********************************
-//    *       *       *       *       *
-//    *       *       *       *       *
-// W3 *  I0   *  I1   *  I2   *   I3  *
-//    *       *       *       *       *
-//    *       *       *       *       *
-// 64 *********************************
-//
-// Calculate row in the TMA Box [M(64), NI(64)]:
-//   row_for_the_warp = warp_id * stsm_m_tile(16)
-//   row_for_the_lane = lane_id % stsm_m_tile(16)
-//   row = row_for_the_warp + row_for_the_lane
-//
-// Calculate column in the TMA Box [M(64), NI(64)]:
-//   column_for_the_lane = lane_id / stsm_n_tile(16)
-//   number_of_columns_per_stsm_x4 = stsm_n_tile(16) / stsm_column_size(8)
-//   column_for_the_nio_loop = inner_index * number_of_columns_per_stsm_x4
-//   column = column_for_the_lane + column_for_the_nio_loop
-//
-// The 128B swizzle is applied to a (8, 64) matrix of dtype fp16 or bf16.
-// The  size of fp16 and bf16 is 2B. The 64 elements along the inner dimension
-// contain 128B, which fill all 32 4B shared memory banks. Contiguous sections
-// of 8 elements are grouped together into 16B megabanks. The 16B megabank
-// corresponds with the 128-bit vectorized load. The 8 megabanks are swizzled
-// with the 8 rows of the matrix to avoid bank conflicts. This swizzle pattern
-// is repeated along the rows of the TMA box.
-//
-// The number of distinct swizzle rows is number of bytes for swizzle divided by
-// size of megabank (16B). The number of times a swizzle pattern is repeated to
-// fill core (8, 8) matrix is number of swizzle rows (8) divided by number of
-// distinct rows.
-//
-// Swizzle column
-//   row_in_swizzle_pattern = (row % swizzle_row_size(8)) / swizzle_repetitions
-//   swizzle_col = column XOR row_in_swizzle_pattern
-//
-// Calculate Tile Offset
-//   row_offset = row * NI(64) * 2(half)
-//   column_offset = column * swizzle_size(8) * 2(half)
-//   tile_offset = row_offset + column_offset
-//
-// Get shared memory offset
-//   smem_offset = offset_from_tdy + offset_from_outer_index + tile_offset
-Val* hardCodedSharedMemoryIndexForLdStMatrixSwizzle(
-    TensorView* smem_tv,
-    ForLoop* loop,
-    const int64_t stsm_m_tile,
-    const int64_t stsm_n_tile,
-    const int64_t tma_m,
-    const int64_t tma_n) {
-  NVF_ERROR(
-      (stsm_m_tile == 8 && stsm_n_tile == 8) ||
-          (stsm_m_tile == 16 && stsm_n_tile == 8) ||
-          (stsm_m_tile == 16 && stsm_n_tile == 16),
-      "size not currently supported for stmatrix");
-
-  NVF_ERROR(
-      dataTypeSizeByte(smem_tv->dtype()) == 2,
-      "we only support 16-bit types in stmatrix");
-
-  MmaInputSmemSwizzle swizzle = getSwizzle(smem_tv);
-  int64_t swizzle_bytes = getBytesFromSwizzle(swizzle);
-
-  // Constants
-  constexpr int64_t dtype_size = 2;
-  constexpr int64_t warp_size = 32;
-  constexpr int64_t swizzle_row_size = 8;
-  constexpr int64_t stsm_column_size = 8;
-  constexpr int64_t max_stsm_n_tile = 16;
-  constexpr int64_t megabank_size_bytes = 16;
-
-  // Derived constants
-  const int64_t swizzle_n_tile = swizzle_bytes / dtype_size;
-  const int64_t distinct_swizzle_row_size = swizzle_bytes / megabank_size_bytes;
-  constexpr int64_t stsm_column_stride = stsm_column_size * dtype_size;
-  const int64_t swizzle_n_iter = swizzle_n_tile / stsm_n_tile;
-  const int64_t swizzle_n_tile_stride = swizzle_n_tile * dtype_size;
-  const int64_t stsm_n_tile_stride = stsm_n_tile / stsm_column_size;
-  const int64_t tile_stride = tma_m * swizzle_n_tile * dtype_size;
-  const int64_t tdy_stride = tma_m * tma_n * dtype_size;
-
-  // NvFuser Val for constants
-  Val* warp_size_val = IrBuilder::create<Val>(warp_size, DataType::Index);
-  Val* stsm_m_tile_val = IrBuilder::create<Val>(stsm_m_tile, DataType::Index);
-  Val* max_stsm_n_tile_val =
-      IrBuilder::create<Val>(max_stsm_n_tile, DataType::Index);
-  Val* stsm_n_tile_stride_val =
-      IrBuilder::create<Val>(stsm_n_tile_stride, DataType::Index);
-  Val* swizzle_row_size_val =
-      IrBuilder::create<Val>(swizzle_row_size, DataType::Index);
-  Val* stsm_column_stride_val =
-      IrBuilder::create<Val>(stsm_column_stride, DataType::Index);
-  Val* swizzle_n_tile_stride_val =
-      IrBuilder::create<Val>(swizzle_n_tile_stride, DataType::Index);
-  Val* tile_stride_val = IrBuilder::create<Val>(tile_stride, DataType::Index);
-  Val* tdy_stride_val = IrBuilder::create<Val>(tdy_stride, DataType::Index);
-  Val* swizzle_n_iter_val =
-      IrBuilder::create<Val>(swizzle_n_iter, DataType::Index);
-
-  // Derived Constants
-  NamedScalar* TDX =
-      IrBuilder::create<NamedScalar>("threadIdx.x", DataType::Index);
-  NamedScalar* TDY =
-      IrBuilder::create<NamedScalar>("threadIdx.y", DataType::Index);
-  Val* warp_id = SimplifyingIrBuilder::divExpr(TDX, warp_size_val);
-  Val* lane_id = SimplifyingIrBuilder::modExpr(TDX, warp_size_val);
-
-  Val* inner_index =
-      SimplifyingIrBuilder::modExpr(loop->index(), swizzle_n_iter_val);
-
-  // Calculate Row
-  Val* warp_row = SimplifyingIrBuilder::mulExpr(warp_id, stsm_m_tile_val);
-  Val* lane_row = SimplifyingIrBuilder::modExpr(lane_id, stsm_m_tile_val);
-  Val* row = SimplifyingIrBuilder::addExpr(warp_row, lane_row);
-  // Hoist row value for reuse and readability
-  row = GpuLower::current()->commonScalarMap().hoistScalar(row, {loop});
-
-  // Calculate Column
-  Val* lane_col = SimplifyingIrBuilder::divExpr(lane_id, max_stsm_n_tile_val);
-  Val* iter_col =
-      SimplifyingIrBuilder::mulExpr(inner_index, stsm_n_tile_stride_val);
-  Val* col = SimplifyingIrBuilder::addExpr(lane_col, iter_col);
-
-  // Swizzle Column
-  Val* row_in_swizzle_pattern =
-      SimplifyingIrBuilder::modExpr(row, swizzle_row_size_val);
-
-  // The swizzle pattern is repeated to fill (8, 8) matrix for 64B and 32B
-  // swizzles. swizzle_row_iter is the number of repetitions to fill 8 rows
-  // with distict swizzle rows.
-  const int64_t swizzle_row_iter = swizzle_row_size / distinct_swizzle_row_size;
-  if (swizzle_row_iter > 1) {
-    Val* swizzle_row_iter_val =
-        IrBuilder::create<Val>(swizzle_row_iter, DataType::Index);
-    row_in_swizzle_pattern = SimplifyingIrBuilder::divExpr(
-        row_in_swizzle_pattern, swizzle_row_iter_val);
-  }
-  Val* swizzle_col = bitwise_xor(col, row_in_swizzle_pattern);
-
-  // Calculate Tile Offset
-  Val* row_offset =
-      SimplifyingIrBuilder::mulExpr(row, swizzle_n_tile_stride_val);
-  Val* col_offset =
-      SimplifyingIrBuilder::mulExpr(swizzle_col, stsm_column_stride_val);
-  Val* offset = SimplifyingIrBuilder::addExpr(row_offset, col_offset);
-
-  // Calculate Tile offset
-  // Skip tile offset if loop is trivial.
-  if (!loop->stop()->isOneInt()) {
-    Val* outer_index =
-        SimplifyingIrBuilder::divExpr(loop->index(), swizzle_n_iter_val);
-    Val* tile_offset =
-        SimplifyingIrBuilder::mulExpr(outer_index, tile_stride_val);
-    offset = SimplifyingIrBuilder::addExpr(tile_offset, offset);
-  }
-
-  // Calculate TDY offset
-  Val* tdy_offset = SimplifyingIrBuilder::mulExpr(TDY, tdy_stride_val);
-  offset = SimplifyingIrBuilder::addExpr(tdy_offset, offset);
-
-  // Create shared memory TensorIndex
-  Val* smem_index = SimplifyingIrBuilder::addExpr(
-      IrBuilder::baseAddressExpr(smem_tv), offset);
-  return IrBuilder::create<kir::TensorIndex>(smem_tv, smem_index);
-}
-
 Val* indexTMemLdSt(
     TensorView* tmem_tv,
     TensorView* consumer_tv,
@@ -2160,51 +1913,49 @@ void IndexLowering::handle(const LoadStoreOp* ldst) {
       is_tma_ldmatrix = ir_utils::isCpAsyncBulkLoad(in_tv->definition());
       if (is_tma_ldmatrix) {
         NVF_ERROR(
+            in_tv->getLogicalDomain().size() >= 2,
+            "We only support 2D inputs ldmatrix");
+        NVF_ERROR(
             ldst->fusion()->hasManaged("ldst_matrix_m_tile") &&
-                ldst->fusion()->hasManaged("ldst_matrix_n_tile") &&
-                ldst->fusion()->hasManaged("ldst_matrix_m_smem") &&
-                ldst->fusion()->hasManaged("ldst_matrix_n_smem"),
+                ldst->fusion()->hasManaged("ldst_matrix_n_tile"),
             "We support ldmatrix only when tiling information is passed via "
             "fusion managed cache");
-        auto m_tile = ldst->fusion()->getManaged<int64_t>("ldst_matrix_m_tile");
-        auto n_tile = ldst->fusion()->getManaged<int64_t>("ldst_matrix_n_tile");
-        auto m = ldst->fusion()->getManaged<int64_t>("ldst_matrix_m_smem");
-        auto n = ldst->fusion()->getManaged<int64_t>("ldst_matrix_n_smem");
+        auto ldst_m_tile =
+            ldst->fusion()->getManaged<int64_t>("ldst_matrix_m_tile");
+        auto ldst_n_tile =
+            ldst->fusion()->getManaged<int64_t>("ldst_matrix_n_tile");
 
         MmaInputSmemSwizzle swizzle = getSwizzle(in_tv);
         switch (swizzle) {
-          case MmaInputSmemSwizzle::None:
+          case MmaInputSmemSwizzle::None: {
+            int64_t m =
+                ldst->fusion()->getManaged<int64_t>("ldst_matrix_m_smem");
+            int64_t n =
+                ldst->fusion()->getManaged<int64_t>("ldst_matrix_n_smem");
             in = hardCodedSharedMemoryIndexForLdStMatrix(
-                in_tv, for_loops_[for_loops_.size() - 3], m_tile, n_tile, m, n);
-            break;
+                in_tv,
+                for_loops_[for_loops_.size() - 3],
+                ldst_m_tile,
+                ldst_n_tile,
+                m,
+                n);
+          } break;
           case MmaInputSmemSwizzle::B128:
           case MmaInputSmemSwizzle::B64:
           case MmaInputSmemSwizzle::B32: {
-            NVF_ERROR(ldst->out()->isA<TensorView>());
-            TensorView* out_tv = ldst->out()->as<TensorView>();
-            if (out_tv->getAlternateLoopDomain().has_value()) {
-              Val* index = GpuLower::current()->tensorIndexer().getLinearIndex(
-                  in_tv, ldst, for_loops_);
-              Val* offset = SimplifyingIrBuilder::mulExpr(
-                  index, dataTypeSizeByte(in_tv->dtype()));
-              Val* smem_index =
-                  IrBuilder::addExpr(IrBuilder::baseAddressExpr(in_tv), offset);
-              in = IrBuilder::create<kir::TensorIndex>(in_tv, smem_index);
-            } else {
-              in = hardCodedSharedMemoryIndexForLdStMatrixSwizzle(
-                  in_tv,
-                  for_loops_[for_loops_.size() - 3],
-                  m_tile,
-                  n_tile,
-                  m,
-                  n);
-            }
+            Val* index = GpuLower::current()->tensorIndexer().getLinearIndex(
+                in_tv, ldst, for_loops_);
+            Val* offset = SimplifyingIrBuilder::mulExpr(
+                index, dataTypeSizeByte(in_tv->dtype()));
+            Val* smem_index =
+                IrBuilder::addExpr(IrBuilder::baseAddressExpr(in_tv), offset);
+            in = IrBuilder::create<kir::TensorIndex>(in_tv, smem_index);
           } break;
           default:
             NVF_ERROR("Unsupported Swizzle Type for StMatrix");
         }
 
-        auto num_regs = (m_tile) / 8 * (n_tile) / 8;
+        auto num_regs = (ldst_m_tile) / 8 * (ldst_n_tile) / 8;
         auto as_type = ArrayType{
             std::make_shared<DataType>(DataType::UInt32),
             static_cast<size_t>(num_regs)};
@@ -2221,54 +1972,48 @@ void IndexLowering::handle(const LoadStoreOp* ldst) {
       NVF_ERROR(
           ldst->out()->as<TensorView>()->getLogicalDomain().size() >= 2,
           "We only support 2D inputs stmatrix");
-
       NVF_ERROR(
           ldst->fusion()->hasManaged("ldst_matrix_m_tile") &&
-              ldst->fusion()->hasManaged("ldst_matrix_n_tile") &&
-              ldst->fusion()->hasManaged("ldst_matrix_m_smem") &&
-              ldst->fusion()->hasManaged("ldst_matrix_n_smem"),
+              ldst->fusion()->hasManaged("ldst_matrix_n_tile"),
           "We support stmatrix only when tiling information is passed via "
           "fusion managed cache");
-      auto m_tile = ldst->fusion()->getManaged<int64_t>("ldst_matrix_m_tile");
-      auto n_tile = ldst->fusion()->getManaged<int64_t>("ldst_matrix_n_tile");
-      auto m = ldst->fusion()->getManaged<int64_t>("ldst_matrix_m_smem");
-      auto n = ldst->fusion()->getManaged<int64_t>("ldst_matrix_n_smem");
+      int64_t ldst_m_tile =
+          ldst->fusion()->getManaged<int64_t>("ldst_matrix_m_tile");
+      int64_t ldst_n_tile =
+          ldst->fusion()->getManaged<int64_t>("ldst_matrix_n_tile");
 
       // Get the index for the output of stmatrix.
       NVF_ERROR(ldst->out()->isA<TensorView>());
       TensorView* out_tv = ldst->out()->as<TensorView>();
       MmaInputSmemSwizzle swizzle = getSwizzle(out_tv);
       switch (swizzle) {
-        case MmaInputSmemSwizzle::None:
+        case MmaInputSmemSwizzle::None: {
+          int64_t m = ldst->fusion()->getManaged<int64_t>("ldst_matrix_m_smem");
+          int64_t n = ldst->fusion()->getManaged<int64_t>("ldst_matrix_n_smem");
           out = hardCodedSharedMemoryIndexForLdStMatrix(
-              out_tv, for_loops_[for_loops_.size() - 3], m_tile, n_tile, m, n);
-          break;
+              out_tv,
+              for_loops_[for_loops_.size() - 3],
+              ldst_m_tile,
+              ldst_n_tile,
+              m,
+              n);
+        } break;
         case MmaInputSmemSwizzle::B128:
         case MmaInputSmemSwizzle::B64:
-        case MmaInputSmemSwizzle::B32:
-          if (out_tv->getAlternateLoopDomain().has_value()) {
-            Val* index = GpuLower::current()->tensorIndexer().getLinearIndex(
-                out_tv, ldst, for_loops_);
-            Val* offset = SimplifyingIrBuilder::mulExpr(
-                index, dataTypeSizeByte(out_tv->dtype()));
-            Val* smem_index =
-                IrBuilder::addExpr(IrBuilder::baseAddressExpr(out_tv), offset);
-            out = IrBuilder::create<kir::TensorIndex>(out_tv, smem_index);
-          } else {
-            out = hardCodedSharedMemoryIndexForLdStMatrixSwizzle(
-                out_tv,
-                for_loops_[for_loops_.size() - 3],
-                m_tile,
-                n_tile,
-                m,
-                n);
-          }
-          break;
+        case MmaInputSmemSwizzle::B32: {
+          Val* index = GpuLower::current()->tensorIndexer().getLinearIndex(
+              out_tv, ldst, for_loops_);
+          Val* offset = SimplifyingIrBuilder::mulExpr(
+              index, dataTypeSizeByte(out_tv->dtype()));
+          Val* smem_index =
+              IrBuilder::addExpr(IrBuilder::baseAddressExpr(out_tv), offset);
+          out = IrBuilder::create<kir::TensorIndex>(out_tv, smem_index);
+        } break;
         default:
           NVF_ERROR("Unsupported Swizzle Type for StMatrix");
       }
 
-      auto num_regs = (m_tile) / 8 * (n_tile) / 8;
+      auto num_regs = (ldst_m_tile) / 8 * (ldst_n_tile) / 8;
       auto as_type = ArrayType{
           std::make_shared<DataType>(DataType::UInt32),
           static_cast<size_t>(num_regs)};

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -938,8 +938,17 @@ bool isSharedMemoryTvForLdStMatrix(TensorView* tv, const Expr* expr) {
   TensorView* output_tv = ir_utils::getTvOutput(expr);
   NVF_ERROR(output_tv != nullptr);
 
-  // alternate_loop_domain is optional for now.
-  return output_tv->getAlternateLoopDomain().has_value();
+  // alternate_loop_domain is optional for ldmatrix.
+  if (ir_utils::isLdMatrixOp(expr)) {
+    return output_tv->getAlternateLoopDomain().has_value();
+  }
+
+  NVF_ERROR(
+      output_tv->getAlternateLoopDomain().has_value(),
+      "Expected the alternate loop domain to be defined for the output "
+      "TensorView of ",
+      expr->toString());
+  return true;
 }
 
 } // namespace

--- a/csrc/scheduler/mma_utils.h
+++ b/csrc/scheduler/mma_utils.h
@@ -256,6 +256,13 @@ void scheduleLdStMatrixForMmaOutput(
     int64_t tile_m,
     int64_t tile_n);
 
+// Apply to the TensorView after block tiling and parallelization, but before
+// applying mma allocation to loop domain.
+AbstractTensor scheduleLdStMatrixSharedMemory(
+    TensorView* tv,
+    int64_t ldst_tile_m,
+    int64_t ldst_tile_n);
+
 void checkDimSize(
     TensorView* tv,
     std::vector<int64_t> axis,

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -3690,7 +3690,7 @@ MatmulParams defaultHopperParams() {
   return mparams;
 }
 
-TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
+TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle_Basic) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -3699,9 +3699,6 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
   constexpr auto layout = MmaLayout::NT; // [K, M] x [K, N] -> [M, N]
   constexpr auto swizzle = MmaInputSmemSwizzle::B128;
   const auto dtype = DataType::Half;
-
-  constexpr bool use_smem_epilogue = false;
-  constexpr bool use_warp_specialization = true;
 
   constexpr int64_t stages = 4;
   constexpr int64_t prefetch = 3;
@@ -3746,20 +3743,9 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
   auto tv1c = tv1->cacheAfter(LoadStoreOpType::CpAsyncBulkTensorTile);
   tv1c->setMemoryType(MemoryType::Shared);
 
-  TensorView *tv3c = nullptr, *tv3_shmem = nullptr;
-  if (use_smem_epilogue) {
-    tv3_shmem = tv3->cacheBefore();
-    tv3c = tv3_shmem->cacheBefore();
-    tv3_shmem->setMemoryType(MemoryType::Shared);
-    tv3c->setMemoryType(MemoryType::Local);
-    tv3_shmem->definition()->as<LoadStoreOp>()->setOpType(
-        LoadStoreOpType::StMatrix);
-    tv3->definition()->as<LoadStoreOp>()->setOpType(
-        LoadStoreOpType::CpAsyncBulkTensorTile);
-  } else {
-    tv3c = tv3->cacheBefore();
-    tv3c->setMemoryType(MemoryType::Local);
-  }
+  TensorView* tv3c = nullptr;
+  tv3c = tv3->cacheBefore();
+  tv3c->setMemoryType(MemoryType::Local);
 
   // gmem [K, M, 1] -TMA-> smem [K, M, 1]
   // gmem [K, 1, N] -TMA-> smem [K, 1, N]
@@ -3812,47 +3798,17 @@ TEST_F(HopperMatmulTest, HSH_NT_128BSwizzle) {
     tv2->axis(-3)->parallelize(ParallelType::Mma);
   }
 
-  if (!use_smem_epilogue) {
-    for (auto tv : {tv3c, tv3}) {
-      auto s = mma_utils::MmaSwizzler::scheduleMmaOutputAllocation(
-          tv->getLoopDomain());
-      tv->setLoopDomain(s.as<IterDomain*>());
-    }
-    tv3->axis(-1)->parallelize(ParallelType::Vectorize);
-  } else {
+  for (auto tv : {tv3c, tv3}) {
     auto s = mma_utils::MmaSwizzler::scheduleMmaOutputAllocation(
-        tv3c->getLoopDomain());
-    tv3c->setLoopDomain(s.as<IterDomain*>());
-    tv3c->setAllocationDomain(s.as<IterDomain*>(), true);
-
-    constexpr int64_t stmatrix_tile_m = 16;
-    constexpr int64_t stmatrix_tile_n = 16;
-    fusion.manage("ldst_matrix_m_tile", stmatrix_tile_m);
-    fusion.manage("ldst_matrix_n_tile", stmatrix_tile_n);
-    fusion.manage("ldst_matrix_m_smem", getM(macro));
-    fusion.manage("ldst_matrix_n_smem", getN(macro));
-
-    MmaInputSmemSwizzle store_swizzle =
-        mma_utils::tmaSwizzleSharedMemory(tv3_shmem);
-
-    // This internally calls
-    // Schedule shared memory cache; Output from StMatrix
-    mma_utils::scheduleLdStMatrixForMmaOutput(
-        tv3_shmem, stmatrix_tile_m, stmatrix_tile_n);
-
-    // Schedule global memory output; Output from TMA Store
-    mma_utils::scheduleTMAStoreForMmaOutput(tv3, store_swizzle);
+        tv->getLoopDomain());
+    tv->setLoopDomain(s.as<IterDomain*>());
   }
+  tv3->axis(-1)->parallelize(ParallelType::Vectorize);
 
   inlineMost();
 
-  if (use_warp_specialization) {
-    tv0c->circularBuffer(stages, prefetch, WarpSpecialized(ParallelType::TIDy));
-    tv1c->circularBuffer(stages, prefetch, WarpSpecialized(ParallelType::TIDy));
-  } else {
-    tv0c->circularBuffer(stages, prefetch);
-    tv1c->circularBuffer(stages, prefetch);
-  }
+  tv0c->circularBuffer(stages, prefetch, WarpSpecialized(ParallelType::TIDy));
+  tv1c->circularBuffer(stages, prefetch, WarpSpecialized(ParallelType::TIDy));
 
   auto inputs = matmulAtInput3DSS(M, N, K, layout, data_type_to_aten(dtype));
 
@@ -4723,8 +4679,8 @@ TEST_F(HopperMatmulTest, HSH_NT_UseScheduler_MultipleInstructionsPerWarpTile) {
   MatMulTileOptions gemm_tile;
   // Regardless of the instruction, this should result in 2 warp groups i.e. 256
   // threads
-  gemm_tile.cta_tile = GemmTile(256, 256, 32);
-  gemm_tile.warp_tile = GemmTile(128, 128, 32);
+  gemm_tile.cta_tile = GemmTile(256, 256, 16);
+  gemm_tile.warp_tile = GemmTile(128, 128, 16);
 
   MatmulParams mparams;
   mparams.supported_vec_size = {8, 8, 8};
@@ -4737,10 +4693,7 @@ TEST_F(HopperMatmulTest, HSH_NT_UseScheduler_MultipleInstructionsPerWarpTile) {
   mparams.circular_buffer_options.smem_circular_buffer_stage = 4;
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
-  // NOTE: disabling smem use for this test since we currrently hit a bank
-  // conflict.
-  // TODO: enable smem epilogue once stmatrix is updated
-  mparams.use_smem_epilogue = false;
+  mparams.use_smem_epilogue = true;
   mparams.cluster_dims = {2, 1, 1};
   mparams.promote_prologue_smem_reuse = false;
 

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -2941,6 +2941,9 @@ TEST_P(StMatrixTest, Regular) {
   tv0->split(0, 32);
   tv0->axis(1)->parallelize(ParallelType::TIDx);
 
+  // TODO Set alternate loop domain here once idModel support
+  // MmaInputSmemSwizzle::None
+
   for (auto tv : {tv1, tv2}) {
     auto s = mma_utils::MmaSwizzler::scheduleMmaOutputAllocation(
         tv->getLoopDomain());


### PR DESCRIPTION
This last PR modifies the matmul scheduler to use IdModel to generate the shared memory address for `ldmatrix` or `stmatrix`.

PR Stack:
1. #4578
2. #4579
3. #4551  **<<< This PR**

## Details
- Remove hardcoded index for 32B, 64B, 128B swizzle. The non-swizzle path still uses `hardCodedSharedMemoryIndexForLdStMatrix`. 
- Added `mma_utils::scheduleLdStMatrixSharedMemory` to create the `alternate_loop_domain` for the output TensorView of `ldmatrix` or `stmatrix`.

## CUDA Performance and Generated Kernel
* Test: `HopperMatmulTest/MLPGemmPersistentBroadcastInputs.NumWarpGroups/2`

<details>

<summary> Performance summary by nsys nvprof </summary>

Name | Avg (ms) | SOL (%) 
-- | -- | -- 
nvfuser_none_f0_c0_r0_g0 | 1.4783 | 97.9
nvjet_tst_320x128_64x3_1x2_h_bz_coopB_TNT | 1.4486 | N/A

</details>

<details>

<summary> Generated Kernel </summary>

```cuda
__global__ void __launch_bounds__(/*maxThreadsPerBlock=*/384, /*minBlocksPerMultiprocessor=*/1) nvfuser_none_f0_c0_r0_g0(Tensor<__bfloat, 3, 3> T0, Tensor<__bfloat, 3, 3> T1, Tensor<__bfloat, 3, 3> T2, const __grid_constant__ TensorMap var0, const __grid_constant__ TensorMap var1, const __grid_constant__ TensorMap var2, Tensor<__bfloat, 2, 2> T4) {
  alignas(16) extern __shared__ char array[];
  const unsigned smem_offset = 0;
  nvfuser_index_t i3;
  i3 = ceilDiv((ceilDiv(T1.logical_size[1LL], 256)), 8);
  nvfuser_index_t i4;
  i4 = (128 * (ceilDiv((ceilDiv(T0.logical_size[0LL], 128)), 16))) * i3;
  nvfuser_index_t i5;
  i5 = ceilDiv(i4, 132);
  nvfuser_index_t i6;
  i6 = ceilDiv(T0.logical_size[2LL], 64);
  const TensorMap* ptr7;
  ptr7 = &var0;
  __bfloat* T6 = reinterpret_cast<__bfloat*>(array + smem_offset + 115712);
  uint32_t i8;
  i8 = toSmem(T6);
  const TensorMap* ptr9;
  ptr9 = &var1;
  __bfloat* T5 = reinterpret_cast<__bfloat*>(array + smem_offset + 66560);
  uint32_t i10;
  i10 = toSmem(T5);
  uint32_t i11;
  i11 = i10 + (8192 * ((nvfuser_index_t)threadIdx.y));
  __bfloat* T8 = reinterpret_cast<__bfloat*>(array + smem_offset + 1024);
  uint32_t i12;
  i12 = toSmem(T8) + (32768 * ((nvfuser_index_t)threadIdx.y));
  const TensorMap* ptr13;
  ptr13 = &var2;
  nvfuser_index_t i14;
  i14 = 64 * ((nvfuser_index_t)threadIdx.y);
  bool b15;
  b15 = ((nvfuser_index_t)threadIdx.x) < 32ULL;
  bool b16;
  b16 = ((nvfuser_index_t)threadIdx.y) == 0ULL;
  bool b17;
  b17 = ((nvfuser_index_t)threadIdx.y) < 2;
  nvfuser_index_t i18;
  i18 = ((8 + (16 * (((nvfuser_index_t)threadIdx.x) / 32))) + ((((nvfuser_index_t)threadIdx.x) / 4) % 8)) + i14;
  nvfuser_index_t i19;
  i19 = (9 - T1.logical_size[1LL]) + (2 * (((nvfuser_index_t)threadIdx.x) % 4));
  bool b20;
  b20 = b15 && b17;
  uint64_t* T9 = reinterpret_cast<uint64_t*>(array + smem_offset + 0);
  #pragma unroll
  for(nvfuser_index_t i21 = 0; i21 < 3; ++i21) {
    if (((Hopper::electSync(4294967295U) && b15) && b16)) {
      mbarrier::init(toSmem((&T9[i21])), 2U);
    }
  }
  #pragma unroll
  for(nvfuser_index_t i22 = 0; i22 < 3; ++i22) {
    if (((Hopper::electSync(4294967295U) && b15) && b16)) {
      mbarrier::init(toSmem((&T9[(i22 + 3LL)])), 256U);
    }
  }
  __syncthreads();
  if ((((nvfuser_index_t)threadIdx.y) >= 2)) {
    decreaseRegisters<40>();
    #pragma unroll 2
    for(nvfuser_index_t i23 = 0; i23 < i5; ++i23) {
      nvfuser_index_t i24;
      i24 = ((nvfuser_index_t)blockIdx.x) + (132 * i23);
      nvfuser_index_t i25;
      i25 = i24 % 128;
      nvfuser_index_t i26;
      i26 = i24 / 128;
      int i27;
      i27 = (int32_t)(((256 * (i25 % 8)) + (2048 * (i26 % i3))));
      nvfuser_index_t i28;
      i28 = i6 * i23;
      int i29;
      i29 = (int32_t)(((128 * (i25 / 8)) + (2048 * (i26 / i3))));
      if ((i24 >= i4)) {
        continue;
      }
      #pragma unroll 1
      for(nvfuser_index_t i30 = 0; i30 < i6; ++i30) {
        nvfuser_index_t i31;
        i31 = (i28 + i30) % 3;
        if ((((((nvfuser_index_t)threadIdx.x) / 32ULL) == 0ULL) && Hopper::electSync(4294967295U))) {
          mbarrier::waitParity(toSmem((&T9[((((i6 * i23) + i30) % 3) + 3LL)])), (uint32_t)(((((i6 * i23) + i30) / 3) % 2)));
          mbarrier::arriveExpectTX(toSmem((&T9[(((i6 * i23) + i30) % 3)])), 32768U);
          Hopper::cpAsyncBulkTensorTileG2S((Hopper::CpAsyncBulkTensorTileG2SIndex<2>{ ptr7, (Array<int, 2, 1>{(int32_t)((64 * i30)), i27}), toSmem((&T9[(((i6 * i23) + i30) % 3)])) }), (i8 + (32768 * i31)));
          mbarrier::arriveExpectTX(toSmem((&T9[(((i6 * i23) + i30) % 3)])), 16384U);
          Hopper::cpAsyncBulkTensorTileG2S((Hopper::CpAsyncBulkTensorTileG2SIndex<2>{ ptr9, (Array<int, 2, 1>{(int32_t)((64 * i30)), i29}), toSmem((&T9[(((i6 * i23) + i30) % 3)])) }), (i10 + (16384 * i31)));
        }
      }
    }
    return;
  } else {
    increaseRegisters<232>();
    #pragma unroll
    for(nvfuser_index_t i32 = 0; i32 < 3; ++i32) {
      mbarrier::arrive(toSmem((&T9[(i32 + 3LL)])));
    }
    #pragma unroll 2
    for(nvfuser_index_t i33 = 0; i33 < i5; ++i33) {
      nvfuser_index_t i34;
      i34 = i6 * i33;
      nvfuser_index_t i35;
      i35 = ((nvfuser_index_t)blockIdx.x) + (132 * i33);
      nvfuser_index_t i36;
      i36 = i35 % 128;
      nvfuser_index_t i37;
      i37 = i35 / 128;
      nvfuser_index_t i38;
      i38 = 256 * (i36 % 8);
      nvfuser_index_t i39;
      i39 = 2048 * (i37 % i3);
      nvfuser_index_t i40;
      i40 = i38 + i39;
      nvfuser_index_t i41;
      i41 = 128 * (i36 / 8);
      nvfuser_index_t i42;
      i42 = 2048 * (i37 / i3);
      int i43;
      i43 = (int32_t)(((i14 + i41) + i42));
      bool b44;
      b44 = b17 && (((i18 + i41) + i42) < T0.logical_size[0LL]);
      nvfuser_index_t i45;
      i45 = (i19 + i38) + i39;
      if ((i35 >= i4)) {
        continue;
      }
      Array<float, 128, 1> T3;
      #pragma unroll 1
      for(nvfuser_index_t i30 = 0; i30 < i6; ++i30) {
        nvfuser_index_t i46;
        i46 = (i34 + i30) % 3;
        uint32_t i47;
        i47 = i11 + (16384 * i46);
        uint32_t i48;
        i48 = i8 + (32768 * i46);
        mbarrier::waitParity(toSmem((&T9[(((i6 * i33) + i30) % 3)])), (uint32_t)(((((i6 * i33) + i30) / 3) % 2)));
        #pragma unroll
        for(nvfuser_index_t i49 = 0; i49 < 4; ++i49) {
          nvfuser_index_t i50;
          i50 = 32 * i49;
          uint32_t i51;
          i51 = i47 + i50;
          uint32_t i52;
          i52 = i48 + i50;
          wgmma::fence();
          wgmma::m64n256k16BF16<1, 1, 0, 0>((*reinterpret_cast<Array<float, 128, 1>*>(&T3[0])), (4611686293305294848ULL | ((262143ULL & (uint64_t)(i51)) >> 4ULL)), (4611686293305294848ULL | ((262143ULL & (uint64_t)(i52)) >> 4ULL)), (!((i30 == 0) && (i49 == 0))));
        }
        wgmma::commit();
        wgmma::wait<0LL>();
        mbarrier::arrive(toSmem((&T9[((((i6 * i33) + i30) % 3) + 3LL)])));
      }
      wgmma::wait<0LL>();
      Array<__bfloat, 128, 8> T7;
      #pragma unroll
      for(nvfuser_index_t i53 = 0; i53 < 32; ++i53) {
        nvfuser_index_t i54;
        i54 = 4 * i53;
        #pragma unroll
        for(nvfuser_index_t i55 = 0; i55 < 2; ++i55) {
          nvfuser_index_t i56;
          i56 = i54 + (2 * i55);
          #pragma unroll
          for(nvfuser_index_t i57 = 0; i57 < 2; ++i57) {
            nvfuser_index_t i58;
            i58 = i56 + i57;
            T7[i58]
               = __float2bfloat(T3[i58]);
          }
        }
      }
      #pragma unroll
      for(nvfuser_index_t i59 = 0; i59 < 16; ++i59) {
        if ((b44 && (i45 < (-(16 * i59))))) {
          stmatrix4((uint32_t)((toSmem(T8) + (((((((((nvfuser_index_t)threadIdx.y) * 16384) + ((i59 / 4) * 4096)) + ((((((((nvfuser_index_t)threadIdx.x) / 16) / 2) * 16) + (((nvfuser_index_t)threadIdx.x) % 16)) / 8) * 512)) + ((((((((nvfuser_index_t)threadIdx.x) / 16) / 2) * 16) + (((nvfuser_index_t)threadIdx.x) % 16)) % 8) * 64)) + (((((((((nvfuser_index_t)threadIdx.x) / 16) / 2) * 16) + (((nvfuser_index_t)threadIdx.x) % 16)) % 8) ^ ((((i59 % 4) * 16) + ((((((nvfuser_index_t)threadIdx.x) / 16) % 2) * 8) + 0)) / 8)) * 8)) + ((((i59 % 4) * 16) + ((((((nvfuser_index_t)threadIdx.x) / 16) % 2) * 8) + 0)) % 8)) * 2LL))), (*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T7[(8 * i59)])));
        }
      }
      block_sync::sync<false>(dim3(128, 2, 1));
      #pragma unroll
      for(nvfuser_index_t i60 = 0; i60 < 4; ++i60) {
        fenceAsyncProxy();
        if (b20) {
          Hopper::cpAsyncBulkTensorTileS2G((Hopper::CpAsyncBulkTensorTileS2GIndex<2>{ ptr13, (Array<int, 2, 1>{(int32_t)((i40 + (64 * i60))), i43}) }), (i12 + (8192 * i60)));
        }
      }
      block_sync::sync<false>(dim3(128, 2, 1));
      cpAsyncBulkCommitGroup();
      cpAsyncBulkWaitGroup<0LL>();
    }
  }
  #pragma unroll
  for(nvfuser_index_t i61 = 0; i61 < 3; ++i61) {
    if (((Hopper::electSync(4294967295U) && b15) && b16)) {
      mbarrier::inval(toSmem((&T9[(i61 + 3LL)])));
    }
  }
  #pragma unroll
  for(nvfuser_index_t i62 = 0; i62 < 3; ++i62) {
    if (((Hopper::electSync(4294967295U) && b15) && b16)) {
      mbarrier::inval(toSmem((&T9[i62])));
    }
  }
  cpAsyncBulkCommitGroup();
  cpAsyncBulkWaitGroup<0LL>();
}
```

</details>

## Issues with ldstmatrix.x2 (16, 8) 
* We cannot use `ldstmatrix.x4 (16, 16)` matrix completely for the non-swizzle path. Some part of the tile must use `ldstmatrix.x2 (16, 8)`.
* The shared memory address for `ldstmatrix.x2 (16, 8)` matrix requires different stride pattern to generate garbage values for threads 16 - 31 of the warp.
* Supporting this is left for a follow-up PR.