### PR TITLE
fix fallback at::index_put API on nightly

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -217,7 +217,8 @@ std::vector<PolymorphicValue> IndexPutAccumulateOp::evaluate(
     const std::vector<PolymorphicValue>& inputs) const {
   return {at::index_put(
       /*self=*/inputs.at(0).as<at::Tensor>(),
-      /*indices=*/{inputs.at(1).as<at::Tensor>()},
+      // NOTE: aten API doesn't allow the broadcast dimension
+      /*indices=*/{inputs.at(1).as<at::Tensor>().squeeze(-1)},
       /*values=*/inputs.at(2).as<at::Tensor>(),
       /*accumulate=*/true)};
 }


### PR DESCRIPTION
Nightly pytorch no longer supports broadcast on index tensor.

Our IndexPutAccumulateOp has
```
self [ vocab, hidden ]
index [ seq, broadcast ]
value [ seq, hidden ]
```

This won't work with `at::index_put`, we need to change index to `index [ seq ]`