### PR TITLE
Add option to insert resharding after

### DIFF
--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -356,6 +356,7 @@ IterDomain* newOutputIterDomain(
 
     NVF_ERROR(
         id->getParallelType() == ParallelType::Serial ||
+            id->getParallelType() == ParallelType::Stream ||
             isParallelTypeDeviceDim(id->getParallelType()),
         id->getParallelType(),
         " is not expected when building ops.");

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -171,6 +171,7 @@ const std::unordered_map<std::string, EnableOption>& getEnableOptions() {
           {"warn_register_spill", EnableOption::WarnRegisterSpill},
           {"ws_normalization", EnableOption::WarpSpecializedNormalization},
           {"host_ir_lowering", EnableOption::HostIrLowering},
+          {"insert_resharding_after", EnableOption::InsertReshardingAfter},
       };
   return available_options;
 }

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -114,6 +114,7 @@ enum class EnableOption {
   WarnRegisterSpill, //! Enable warnings of register spill
   WarpSpecializedNormalization, //! Enable warp specialized persistent kernel
   HostIrLowering, //! Enable FusionKernelRuntime lowering to host IR
+  InsertReshardingAfter,
   EndOfOption //! Placeholder for counting the number of elements
 };
 


### PR DESCRIPTION
Add an option to force `insertReshardingPass` to insert a `SetOp` **after** the resharding Expr, rather than before. This can be useful in many contexts, especially the one of TP-Columnwise where and Allgather+matmul is required. In this case, depending on the dimensions, placing the AG after gives a significant performance boost. cf the following data measured with [DDLB](https://github.com/samnordmann/ddlb) on dgx 8*h100, M=64k, N=1k, K=16k, dtype:float16,
```
Detailed Results:
                                                      config Throughput (TFLOPS)  mean_time (ms)  std_time  min_time  max_time
0                    pytorch (backend=nccl, order=AG_before)       242.7 (±12.2)        9.059688  0.227873  8.143488  9.304096
1                     pytorch (backend=nccl, order=AG_after)      948.8 (±547.1)        2.317774  0.668216  2.049632  4.977664
2                    fuser (algorithm=default, backend=nccl)        269.9 (±1.4)        8.147707  0.020456  8.101984  8.182304
3  fuser (algorithm=coll_pipeline, s=2, backend=ucc/tl/nccl)        308.4 (±1.9)        7.130434  0.021704  7.103072  7.181632
4  fuser (algorithm=coll_pipeline, s=8, backend=ucc/tl/nccl)       328.0 (±13.2)        6.703474  0.134646  6.581056  7.036928
5                                compute_only (size=sharded)      6508.9 (±20.3)        0.337848  0.000528  0.336896  0.339072
6                              compute_only (size=unsharded)       793.1 (±36.8)        2.772765  0.064373  2.709760  2.893088
```