### PR TITLE
Generate ldstmatrix shared memory address using IdModel

### DIFF
--- a/csrc/id_model/id_model.cpp
+++ b/csrc/id_model/id_model.cpp
@@ -531,11 +531,6 @@ ValGraph& IdModel::buildAlmostExactGraph() {
         {tv->getLogicalDomain().begin(), tv->getLogicalDomain().end()});
     almost_exact_graph.setUnmappable(
         {tv->getLoopDomain().begin(), tv->getLoopDomain().end()});
-    if (tv->getAlternateLoopDomain().has_value()) {
-      almost_exact_graph.setUnmappable(
-          {tv->getAlternateLoopDomain().value().begin(),
-           tv->getAlternateLoopDomain().value().end()});
-    }
   }
 
   // Maps iter domain pairs returned by calling that return mappings from
@@ -856,8 +851,6 @@ StatefulInliningInfo buildStatefulInliningInfo(
          ir_utils::filterByType<TensorView>(expr->inputs())) {
       const auto& producer_logical = producer_tv->getLogicalDomain();
       const auto& producer_domain = producer_tv->domain()->loop();
-      const auto& alternate_producer_domain =
-          producer_tv->getAlternateLoopDomain();
 
       // Broadcast forwarding is not applied when the loop domain is
       // not fully derived from the logical domain. In that case, the
@@ -890,14 +883,6 @@ StatefulInliningInfo buildStatefulInliningInfo(
               producer_tv->getLoopDomain().begin(),
               producer_tv->getLoopDomain().begin() +
                   producer_tv->getComputePosition(consumer_tv));
-        }
-        // NOTE The alternate producer loop domain is not fully-derived.
-        if (alternate_producer_domain.has_value()) {
-          VectorOfUniqueEntries<IterDomain*> alternate_producer_ca_deps(
-              alternate_producer_domain.value().begin(),
-              alternate_producer_domain.value().begin() +
-                  producer_tv->getComputePosition(consumer_tv));
-          all_producer_ca_deps.pushBack(alternate_producer_ca_deps);
         }
         info.ordered_p_ca_ids.pushBack(all_producer_ca_deps);
 

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -84,6 +84,9 @@ void TensorIndexer::buildLoopIndexMap() {
     const std::vector<IterDomain*>& alternate_loop_domain =
         tv_output->getAlternateLoopDomain().value();
     const std::vector<IterDomain*>& loop_domain = tv_output->getLoopDomain();
+    // NOTE For scheduling ldmatrix and stmatrix, the assumption is the original
+    // and alternate loop domains have the same number of iterDomains. This
+    // assertion may not be strictly necessary.
     NVF_ERROR(alternate_loop_domain.size() == loop_domain.size());
     for (auto&& [alt_loop_id, loop_id] :
          zip(alternate_loop_domain, loop_domain)) {

--- a/csrc/id_model/indexing.cpp
+++ b/csrc/id_model/indexing.cpp
@@ -76,6 +76,31 @@ void TensorIndexer::buildLoopIndexMap() {
 
       loop_index_map_[loop_group] = loop_index;
     }
+
+    if (!tv_output->getAlternateLoopDomain().has_value()) {
+      continue;
+    }
+
+    const std::vector<IterDomain*>& alternate_loop_domain =
+        tv_output->getAlternateLoopDomain().value();
+    const std::vector<IterDomain*>& loop_domain = tv_output->getLoopDomain();
+    NVF_ERROR(alternate_loop_domain.size() == loop_domain.size());
+    for (auto&& [alt_loop_id, loop_id] :
+         zip(alternate_loop_domain, loop_domain)) {
+      const ValGroup& alt_loop_group =
+          id_model_.idGraph(IdMappingMode::LOOP).toGroup(alt_loop_id);
+      if (loop_index_map_.find(alt_loop_group) != loop_index_map_.end()) {
+        // Index already assigned for alternate loop iterDomain
+        continue;
+      }
+      // Map alternate loop iterDomain to the index variable for the original
+      // loop iterDomain.
+      const ValGroup& loop_group =
+          id_model_.idGraph(IdMappingMode::LOOP).toGroup(loop_id);
+      auto loop_index_iter = loop_index_map_.find(loop_group);
+      NVF_ERROR(loop_index_iter != loop_index_map_.end());
+      loop_index_map_[alt_loop_group] = loop_index_iter->second;
+    }
   }
 }
 
@@ -251,9 +276,11 @@ std::vector<IterDomain*> TensorIndexer::getLoopDomains(const Expr* expr) const {
 IndexingInfo TensorIndexer::computeIndex(
     const Expr* expr,
     const std::vector<IterDomain*>& index_ids,
-    const std::vector<ForLoop*>& for_loops) const {
-  const auto loop_ids = getLoopIds(expr, id_model_);
-  const ExprPath<ExprGroup> traversal_path = getIndexingPath(expr, index_ids);
+    const std::vector<ForLoop*>& for_loops,
+    bool use_alternate_loop_domain) const {
+  const auto loop_ids = getLoopIds(expr, id_model_, use_alternate_loop_domain);
+  const ExprPath<ExprGroup> traversal_path =
+      getIndexingPath(expr, index_ids, use_alternate_loop_domain);
   const std::unordered_map<ValGroup, Val*> initial_index_map =
       getInitialIndexMap(loop_ids, for_loops);
 
@@ -785,7 +812,8 @@ std::vector<PredicateInfo> TensorIndexer::getPredicates(
 
 ExprPath<ExprGroup> TensorIndexer::getIndexingPath(
     const Expr* expr,
-    const std::vector<IterDomain*>& index_ids) const {
+    const std::vector<IterDomain*>& index_ids,
+    bool use_alternate_loop_domain) const {
   // Exclude broadcast IDs as their indices should always be zero
   // and they may not be reachable from the loop domain
   std::vector<IterDomain*> non_broadcast_index_ids;
@@ -798,7 +826,7 @@ ExprPath<ExprGroup> TensorIndexer::getIndexingPath(
   return IndexingTraversal::getExprsBetween(
       expr,
       traversalGraph(),
-      getLoopIds(expr, id_model_),
+      getLoopIds(expr, id_model_, use_alternate_loop_domain),
       non_broadcast_index_ids);
 }
 
@@ -888,6 +916,31 @@ void TensorIndexer::ensureStaticIndexing(
   }
 }
 
+namespace {
+
+// Use alternate loop domain for the shared memory tensor for ldmatrix and
+// stmatrix.
+bool isSharedMemoryTvForLdStMatrix(TensorView* tv, const Expr* expr) {
+  // short-circuit: not (ldmatrix or stmatrix)
+  if (!ir_utils::isLdMatrixOp(expr) && !ir_utils::isStMatrixOp(expr)) {
+    return false;
+  }
+  // short-circuit: only the shared memory TensorView uses alternate loop
+  // domain. For ldmatrix, it is the input TensorView. For stmatrix, it is the
+  // output TensorView.
+  if (tv->getMemoryType() != MemoryType::Shared) {
+    return false;
+  }
+
+  TensorView* output_tv = ir_utils::getTvOutput(expr);
+  NVF_ERROR(output_tv != nullptr);
+
+  // alternate_loop_domain is optional for now.
+  return output_tv->getAlternateLoopDomain().has_value();
+}
+
+} // namespace
+
 std::pair<std::vector<Val*>, std::vector<Val*>> TensorIndexer::
     getContigIndexFor(
         TensorView* tv,
@@ -903,7 +956,8 @@ std::pair<std::vector<Val*>, std::vector<Val*>> TensorIndexer::
       indexed_ids.push_back(id);
     }
   }
-  auto index_info = computeIndex(expr, indexed_ids, for_loops);
+  auto index_info = computeIndex(
+      expr, indexed_ids, for_loops, isSharedMemoryTvForLdStMatrix(tv, expr));
   for (const auto& [indexed_id, index] : override_index) {
     index_info.index_map.emplace(traversalGraph().toGroup(indexed_id), index);
   }

--- a/csrc/id_model/indexing.h
+++ b/csrc/id_model/indexing.h
@@ -142,7 +142,8 @@ class TensorIndexer {
   // for a given expr
   ExprPath<ExprGroup> getIndexingPath(
       const Expr* expr,
-      const std::vector<IterDomain*>& index_ids) const;
+      const std::vector<IterDomain*>& index_ids,
+      bool use_alternate_loop_domain = false) const;
 
   ExprPath<ExprGroup> getPredicateIndexingPath(TensorView* tv, const Expr* expr)
       const;
@@ -175,7 +176,8 @@ class TensorIndexer {
   IndexingInfo computeIndex(
       const Expr* expr,
       const std::vector<IterDomain*>& index_ids,
-      const std::vector<ForLoop*>& for_loops) const;
+      const std::vector<ForLoop*>& for_loops,
+      bool use_alternate_loop_domain = false) const;
 
   // Propagate the loop indices of a given list of loop domains to the
   // traversal graph (i.e., the AlmostExact graph). Uses the loop

--- a/csrc/id_model/utils.h
+++ b/csrc/id_model/utils.h
@@ -113,13 +113,24 @@ inline IterDomain* getLoopPromotion(
 // producer-based indexing.
 inline std::vector<IterDomain*> getLoopIds(
     const Expr* expr,
-    const IdModel& id_model) {
+    const IdModel& id_model,
+    bool use_alternate_loop_domain = false) {
   // Assume consumer-based indexing. Needs to revisit for ops like
   // scatter
   NVF_ERROR(!expr->outputs().empty());
   auto output_tv = ir_utils::getTvOutput(expr);
   NVF_ERROR(output_tv != nullptr);
-  auto loop_ids = output_tv->getLoopDomain();
+
+  NVF_ERROR(
+      !use_alternate_loop_domain ||
+          output_tv->getAlternateLoopDomain().has_value(),
+      "getLoopIds is attempting to use alternate loop domain, "
+      "but it does not exist for ",
+      output_tv->toString());
+
+  auto loop_ids = (use_alternate_loop_domain)
+      ? output_tv->getAlternateLoopDomain().value()
+      : output_tv->getLoopDomain();
 
   for (auto& loop_id : loop_ids) {
     loop_id = getLoopPromotion(loop_id, id_model);

--- a/doc/dev/ldmatrix_stmatrix.md
+++ b/doc/dev/ldmatrix_stmatrix.md
@@ -35,8 +35,6 @@ LdMatrix, StMatrix, TMA, and WGMMA
 
 namespace nvfuser {
 
-using HopperLdStMatrixTutorial = HopperBase;
-
 /* -->
 
 # LdMatrix and StMatrix Support in NVFuser
@@ -241,7 +239,9 @@ TensorView with a ldmatrix or stmatrix definition. The layout is based on the
 register accumulation layout for wgmma and the hard-coded index supported by
 the indexing pass. <!-- */ //-->\
 ```cpp
-AbstractTensor scheduleLdStMatrix(TensorView* tv) {
+AbstractTensor scheduleLdStMatrixBase(
+    TensorView* tv,
+    MmaInputSmemSwizzle swizzle) {
   // Assume the input TensorView is block tiled. e.g., The last two iterDomains
   // are the warp tile except for k dimension.
   // The CTA tile is (128, 256).
@@ -254,15 +254,90 @@ AbstractTensor scheduleLdStMatrix(TensorView* tv) {
   // (GM, GN, cta_m(2), cta_n(1), m(64), n(256))
 
   // Split by TMA shared memory box
-  abstract_tensor.split(-1, 64);
+  DataType dtype = tv->getDataType().value();
+  int64_t smem_box_size = getBytesFromSwizzle(swizzle) / dataTypeSizeByte(dtype);
+  abstract_tensor.split(-1, smem_box_size);
   abstract_tensor.reorder({{-2, -3}, {-3, -2}});
   // (GM, GN, cta_m(2), cta_n(1), no(4), m(64), ni(64))
 
   // Split by (16, 16) matrix for LdStMatrix.x4
+  int64_t ldst_matrix_tile_n = (swizzle == MmaInputSmemSwizzle::None) ? 8 : 16;
   abstract_tensor.split(-2, 16);
-  abstract_tensor.split(-1, 16);
+  abstract_tensor.split(-1, ldst_matrix_tile_n);
   abstract_tensor.reorder({{-2, -3}, {-3, -2}});
   // (GM, GN, cta_m(2), cta_n(1), no(4), mo(4), nio(4), mi(16), nii(16))
+
+  return abstract_tensor;
+}
+
+AbstractTensor scheduleLdStMatrixSharedMemory(
+    const AbstractTensor& base_tensor) {
+  // Assume the input TensorView is block tiled. e.g., The last two iterDomains
+  // are the warp tile except for k dimension.
+  // The CTA tile is (128, 256).
+  // The Warp tile is (64, 256).
+  // The TMA box is (64, 64).
+  // The LdStMatrix.x4 tile is (16, 16).
+  // The core matrix for wgmma and LdStMatrix is (8, 8).
+
+  // Initial Abstract Tensor
+  AbstractTensor abstract_tensor(base_tensor);
+  // (GM, GN, cta_m(2), cta_n(1), no(4), mo(4), nio(4), mi(16), nii(16))
+  // Omit (GM, GN, cta_m(2), cta_n(1)) after this for brevity.
+
+  // For shared memory addressing, each thread specifies a row for each (8, 8)
+  // matrix. e.g., For stmatrix.x4, 32 threads move a (16, 16) matrix.
+
+  // Inside the tile box [16, 16], we can think of it as 4 8x8 tiles:
+  // *****************
+  // *       *       *
+  // *       *       *
+  // *  T0   *  T2   *
+  // *       *       *
+  // *       *       *
+  // *****************
+  // *       *       *
+  // *       *       *
+  // *  T1   *  T3   *
+  // *       *       *
+  // *       *       *
+  // *****************
+
+  // Split inner-dimension by 8 to traverse the rows of the (8, 8) matrices.
+  abstract_tensor.split(-1, 8);
+  // (no(4), mo(4), nio(4), mi(16), niio(2), niii(8))
+
+  // The tile is stored in row-major order, so issue four stmatrix.x4
+  // operations along the M dimension for a 128 thread warp group.
+  // Also, traverse along 16 rows first before moving along column dimension.
+  abstract_tensor.reorder({{-5, -4}, {-4, -5}, {-3, -2}, {-2, -3}});
+  // (no(4), nio(4), mo(4), niio(2), mi(16), niii(8))
+
+  abstract_tensor.merge(-4, -3);
+  abstract_tensor.merge(-3, -2);
+  // (no(4), nio(4), (niio * mo * mi)(128), niii(8))
+
+  // Merge no and nio to create a single serial IterDomain
+  // This ^^^ is an artifact of matmul scheduling functions.
+  abstract_tensor.merge(-4, -3);
+  // (no * nio)(16), (niio * mo * mi)(128), niii(8))
+
+  return abstract_tensor;
+}
+
+AbstractTensor scheduleLdStMatrixRegisters(const AbstractTensor& base_tensor) {
+  // Assume the input TensorView is block tiled. e.g., The last two iterDomains
+  // are the warp tile except for k dimension.
+  // The CTA tile is (128, 256).
+  // The Warp tile is (64, 256).
+  // The TMA box is (64, 64).
+  // The LdStMatrix.x4 tile is (16, 16).
+  // The core matrix for wgmma and LdStMatrix is (8, 8).
+
+  // Initial Abstract Tensor
+  AbstractTensor abstract_tensor(base_tensor);
+  // (GM, GN, cta_m(2), cta_n(1), no(4), mo(4), nio(4), mi(16), nii(16))
+  // Omit (GM, GN, cta_m(2), cta_n(1)) after this for brevity.
 
   // Split (16, 16) matrix into four (8, 8) sub-matrices
   abstract_tensor.split(-2, 8);
@@ -287,8 +362,7 @@ AbstractTensor scheduleLdStMatrix(TensorView* tv) {
   // *       *       *
   // *****************
   abstract_tensor.reorder({{-5, -2}, {-4, -5}, {-2, -4}});
-  // (GM, GN, cta_m(2), cta_n(1), no(4), mo(4), nio(4), mii(8), niiio(4),
-  // niio(2), mio(2), niiii(2))
+  // (no(4), mo(4), nio(4), mii(8), niiio(4), niio(2), mio(2), niiii(2))
 
   // For an (16, 16) matrix, each register will hold 8 values. The LdStMatrix
   // instruction will load or store these values with a single instruction. We
@@ -296,8 +370,7 @@ AbstractTensor scheduleLdStMatrix(TensorView* tv) {
   // iterDomains together and then applying ParallelType::Vectorize.
   abstract_tensor.merge(-2, -1);
   abstract_tensor.merge(-2, -1);
-  // (GM, GN, cta_m(2), cta_n(1), no(4), mo(4), nio(4), mii(8), niiio(4), (niio
-  // * mio * niiii)(8))
+  // (no(4), mo(4), nio(4), mii(8), niiio(4), (niio * mio * niiii)(8))
 
   // Reorder iterDomains so the serial IterDomain for (CTA_N / TMA_N) and
   // (TMA_N and LDST_N) are adjacent.
@@ -307,18 +380,25 @@ AbstractTensor scheduleLdStMatrix(TensorView* tv) {
   // (64, 16) tile. Merge mio, miii, and niiio iterDomains together.
   abstract_tensor.merge(-4, -3);
   abstract_tensor.merge(-3, -2);
-  // (GM, GN, cta_m(2), cta_n(1), no(4), nio(4), (mo * mii * niiio)(128), (niio
-  // * mio * niiii)(8))
+  // (no(4), nio(4), (mo * mii * niiio)(128), (niio * mio * niiii)(8))
 
-  // Hard-coded shared memory index expects a single serial IterDomain
+  // Merge no and nio to create a single serial IterDomain
+  // This ^^^ is an artifact of matmul scheduling functions.
   abstract_tensor.merge(-4, -3);
+  // (no * nio)(16), (mo * mii * niiio)(128), (niio * mio * niiii)(8))
+
   return abstract_tensor;
 }
 
 // This test is an example of loading and storing a Tensor using TMA, LdMatrix,
 // and StMatrix.
-TEST_F(HopperLdStMatrixTutorial, LdStMatrixSet) {
+using LdStMatrixParams = std::tuple<MmaInputSmemSwizzle, int, int>;
+using HopperLdStMatrixTutorial = NVFuserFixtureParamTest<LdStMatrixParams>;
+TEST_P(HopperLdStMatrixTutorial, SetShmoo) {
+  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
   const auto dtype = DataType::BFloat16;
+
+  auto& [swizzle, cta_multiple_m, cta_multiple_n] = GetParam();
 
   // Fusion Definition
   Fusion fusion;
@@ -332,16 +412,17 @@ TEST_F(HopperLdStMatrixTutorial, LdStMatrixSet) {
   // ===========================================================================
 
   // Constants
-  constexpr int64_t cta_m = 128;
-  constexpr int64_t cta_n = 256;
   constexpr int64_t warp_m = 64;
   constexpr int64_t warp_n = 256;
+  int64_t cta_m = warp_m * cta_multiple_m;
+  int64_t cta_n = warp_n * cta_multiple_n;
   constexpr int64_t ldst_matrix_tile_m = 16;
-  constexpr int64_t ldst_matrix_tile_n = 16;
+  int64_t ldst_matrix_tile_n = (swizzle == MmaInputSmemSwizzle::None) ? 8 : 16;
   fusion.manage("ldst_matrix_m_tile", ldst_matrix_tile_m);
   fusion.manage("ldst_matrix_n_tile", ldst_matrix_tile_n);
-  fusion.manage("ldst_matrix_m_smem", warp_m);
-  fusion.manage("ldst_matrix_n_smem", warp_n);
+  fusion.manage("ldst_matrix_m_smem", cta_m);
+  fusion.manage(
+      "ldst_matrix_n_smem", getBytesFromSwizzle(swizzle) / dataTypeSizeByte(dtype));
 
   // ===========================================================================
   // Create cache intermediate TensorViews
@@ -352,7 +433,6 @@ TEST_F(HopperLdStMatrixTutorial, LdStMatrixSet) {
       LoadStoreOpType::CpAsyncBulkTensorTile);
   tv0_smem->setMemoryType(MemoryType::Shared);
 
-  // TODO Add ldmatrix support
   // The definition for tv0_reg is ldmatrix, which moves data from shared memory
   // to registers.
   TensorView* tv0_reg = tv0_smem->cacheAfter();
@@ -397,14 +477,10 @@ TEST_F(HopperLdStMatrixTutorial, LdStMatrixSet) {
   // Schedule shared memory tensors using TMA Load and Store
 
   // Schedule output from TMA Load
-  MmaInputSmemSwizzle input_swizzle =
-      mma_utils::tmaSwizzleSharedMemory(tv0_smem);
-  mma_utils::MmaSwizzler::scheduleTMALoadForMma(tv0_smem, input_swizzle);
+  mma_utils::MmaSwizzler::scheduleTMALoadForMma(tv0_smem, swizzle);
 
   // Schedule global memory output from TMA Store
-  MmaInputSmemSwizzle output_swizzle =
-      mma_utils::tmaSwizzleSharedMemory(tv1_smem);
-  mma_utils::scheduleTMAStoreForMmaOutput(tv1, output_swizzle);
+  mma_utils::scheduleTMAStoreForMmaOutput(tv1, swizzle);
 
   // ===========================================================================
   // Schedule register tensors using LdMatrix and StMatrix
@@ -417,15 +493,24 @@ TEST_F(HopperLdStMatrixTutorial, LdStMatrixSet) {
   // assertion in indexing pass.
 
   // Move data from tv0_reg to tv1_smem using StMatrix
+  AbstractTensor tv1_smem_base_tensor =
+      scheduleLdStMatrixBase(tv1_smem, swizzle);
   AbstractTensor tv1_smem_abstract_tensor =
-      scheduleLdStMatrix(tv1_smem);
+      scheduleLdStMatrixRegisters(tv1_smem_base_tensor);
   // Create tma store allocation domain with swizzle
-  if (output_swizzle != MmaInputSmemSwizzle::None) {
-    mma_utils::scheduleTMAStoreForMmaOutput(tv1_smem, output_swizzle);
-  }
+  mma_utils::scheduleTMAStoreForMmaOutput(tv1_smem, swizzle);
   tv1_smem->setLoopDomain(tv1_smem_abstract_tensor.as<IterDomain*>());
   // (GM(BDX), GN(BDY), cta_m(2), cta_n(1), (no * nio)(16), (mo * mii *
   // niiio)(128), (niio * mio * niiii)(8))
+
+  // tv1_smem is the consumer for stmatrix. tv0_reg is the consumer.
+  std::vector<IterDomain*> tv1_smem_stmatrix =
+      scheduleLdStMatrixSharedMemory(tv1_smem_base_tensor).as<IterDomain*>();
+  tv1_smem_stmatrix.at(tv1_smem_stmatrix.size() - 2)
+      ->parallelize(ParallelType::TIDx);
+  tv1_smem_stmatrix.at(tv1_smem_stmatrix.size() - 1)
+      ->parallelize(ParallelType::Vectorize);
+  tv1_smem->setAlternateLoopDomain(tv1_smem_stmatrix);
 
   // Use ParallelType::TIDx to launch four StMatrix.x4 in parallel.
   // Use ParallelType::Vectorize because StMatrix.x4 stores eight elements per
@@ -437,12 +522,22 @@ TEST_F(HopperLdStMatrixTutorial, LdStMatrixSet) {
 
   // ===========================================================================
 
-  // Move data from tv0_reg to tv1_smem using LdMatrix
+  // Move data from tv0_smem to tv0_reg using LdMatrix
+  AbstractTensor tv0_reg_base_tensor = scheduleLdStMatrixBase(tv0_reg, swizzle);
   AbstractTensor tv0_reg_abstract_tensor =
-      scheduleLdStMatrix(tv0_reg);
+      scheduleLdStMatrixRegisters(tv0_reg_base_tensor);
   tv0_reg->setLoopDomain(tv0_reg_abstract_tensor.as<IterDomain*>());
   // (GM(BDX), GN(BDY), cta_m(2), cta_n(1), (no * nio)(16), (mo * mii *
   // niiio)(128), (niio * mio * niiii)(8))
+
+  std::vector<IterDomain*> tv0_reg_ldmatrix =
+      scheduleLdStMatrixSharedMemory(tv0_reg_base_tensor).as<IterDomain*>();
+  tv0_reg_ldmatrix.at(tv0_reg_ldmatrix.size() - 2)
+      ->parallelize(ParallelType::TIDx);
+  tv0_reg_ldmatrix.at(tv0_reg_ldmatrix.size() - 1)
+      ->parallelize(ParallelType::Vectorize);
+  tv0_reg->setAlternateLoopDomain(tv0_reg_ldmatrix);
+  // tv0_reg is the consumer for ldmatrix and tv0_smem is the producer.
 
   // Set allocation domain according to loop domain
   tv0_reg->setAllocationDomain(
@@ -472,7 +567,27 @@ TEST_F(HopperLdStMatrixTutorial, LdStMatrixSet) {
   ASSERT_TRUE(kernel != nullptr);
   auto cg_outputs = ke.run({at_tv0});
   NVF_CHECK(at::allclose(cg_outputs[0].as<at::Tensor>(), at_tv0));
-} /*
+}
+// TODO MmaInputSmemSwizzle::None relies on hard-coded indexing, so it is
+// disabled.
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    HopperLdStMatrixTutorial,
+    ::testing::Combine(
+        ::testing::Values(
+            MmaInputSmemSwizzle::B32,
+            MmaInputSmemSwizzle::B64,
+            MmaInputSmemSwizzle::B128),
+        ::testing::Values(1, 2),
+        ::testing::Values(1, 2)),
+    [](const testing::TestParamInfo<LdStMatrixParams>& info) {
+      std::stringstream ss;
+      int64_t cta_m = 64 * std::get<1>(info.param);
+      int64_t cta_n = 256 * std::get<2>(info.param);
+      ss << "swizzle_" << toString(std::get<0>(info.param)) << "_cta_m_"
+         << cta_m << "_cta_n_" << cta_n;
+      return sanitizeTestName(ss.str());
+    }); /*
 ```
 <!--*/
 } // namespace nvfuser


### PR DESCRIPTION
This is the second out of three PRs which modifies IdModel indexing to use `alternate_loop_domain` to generate shared memory index for `ldmatrix` or `stmatrix`.

PR Stack:
1. #4578
2. #4579 **<<< This PR**
3. #4551

## Details
* Modified `TensorIndexer::buildLoopIndexMap` to use the same index variable for `alternate_loop_domain` and `loop_domain`
* `TensorIndexer` automatically uses `alternate_loop_domain` when it detects the shared memory TensorView for `ldmatrix` or `stmatrix`.
* Revised LdStMatrixSet tutorial to schedule `alternate_loop_domain`
* Created a shmoo test to exercise swizzle modes with different tile sizes.

## CUDA Kernel

<details>

<summary> HopperLdStMatrixTutorial.SetShmoo/swizzle_128B_cta_m_128_cta_n_256 </summary>

```cuda
__global__ void nvfuser_none_f0_c0_r0_g0(Tensor<__bfloat, 2, 2> T0, const __grid_constant__ TensorMap var0, const __grid_constant__ TensorMap var1, Tensor<__bfloat, 2, 2> T1) {
  alignas(16) extern __shared__ char array[];
  const unsigned smem_offset = 0;
  const TensorMap* ptr2;
  ptr2 = &var0;
  nvfuser_index_t i3;
  i3 = 256 * ((nvfuser_index_t)blockIdx.y);
  int i4;
  i4 = (int32_t)(((64 * ((nvfuser_index_t)threadIdx.y)) + (128 * ((nvfuser_index_t)blockIdx.x))));
  nvfuser_index_t i5;
  i5 = 32768 * ((nvfuser_index_t)threadIdx.y);
  __bfloat* T2 = reinterpret_cast<__bfloat*>(array + smem_offset + 0);
  uint32_t i6;
  i6 = toSmem(T2) + i5;
  // Alias Allocation - shared
  auto& T4 = T2;
  uint32_t i7;
  i7 = toSmem(T4) + i5;
  const TensorMap* ptr8;
  ptr8 = &var1;
  bool b9;
  b9 = ((nvfuser_index_t)threadIdx.x) < 32ULL;
  #pragma unroll
  for(nvfuser_index_t i10 = 0; i10 < 4; ++i10) {
    Array<int, 2, 1> a11;
    a11 = Array<int, 2, 1>{(int32_t)((i3 + (64 * i10))), i4};
    uint64_t* T5 = reinterpret_cast<uint64_t*>(array + smem_offset + 65536);
    mbarrier::init(toSmem(T5), 2U);
    __syncthreads();
    if ((Hopper::electSync(4294967295U) && b9)) {
      uint64_t i12;
      i12 = mbarrier::arriveExpectTX(toSmem(T5), 8192U);
      Hopper::cpAsyncBulkTensorTileG2S((Hopper::CpAsyncBulkTensorTileG2SIndex<2>{ ptr2, a11, toSmem(T5) }), (i6 + (8192 * i10)));
      mbarrier::wait(toSmem(T5), i12);
    }
    __syncthreads();
    mbarrier::inval(toSmem(T5));
  }
  #pragma unroll
  for(nvfuser_index_t i13 = 0; i13 < 16; ++i13) {
    Array<__bfloat, 8, 8> T3;
    ldmatrix4((*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T3[0])), (uint32_t)((toSmem(T2) + (((((((((nvfuser_index_t)threadIdx.y) * 16384) + ((i13 / 4) * 4096)) + ((((((((nvfuser_index_t)threadIdx.x) / 16) / 2) * 16) + (((nvfuser_index_t)threadIdx.x) % 16)) / 8) * 512)) + ((((((((nvfuser_index_t)threadIdx.x) / 16) / 2) * 16) + (((nvfuser_index_t)threadIdx.x) % 16)) % 8) * 64)) + (((((((((nvfuser_index_t)threadIdx.x) / 16) / 2) * 16) + (((nvfuser_index_t)threadIdx.x) % 16)) % 8) ^ ((((i13 % 4) * 16) + ((((((nvfuser_index_t)threadIdx.x) / 16) % 2) * 8) + 0)) / 8)) * 8)) + ((((i13 % 4) * 16) + ((((((nvfuser_index_t)threadIdx.x) / 16) % 2) * 8) + 0)) % 8)) * 2LL))));
    stmatrix4((uint32_t)((toSmem(T4) + (((((((((nvfuser_index_t)threadIdx.y) * 16384) + ((i13 / 4) * 4096)) + ((((((((nvfuser_index_t)threadIdx.x) / 16) / 2) * 16) + (((nvfuser_index_t)threadIdx.x) % 16)) / 8) * 512)) + ((((((((nvfuser_index_t)threadIdx.x) / 16) / 2) * 16) + (((nvfuser_index_t)threadIdx.x) % 16)) % 8) * 64)) + (((((((((nvfuser_index_t)threadIdx.x) / 16) / 2) * 16) + (((nvfuser_index_t)threadIdx.x) % 16)) % 8) ^ ((((i13 % 4) * 16) + ((((((nvfuser_index_t)threadIdx.x) / 16) % 2) * 8) + 0)) / 8)) * 8)) + ((((i13 % 4) * 16) + ((((((nvfuser_index_t)threadIdx.x) / 16) % 2) * 8) + 0)) % 8)) * 2LL))), (*reinterpret_cast<Array<uint32_t, 4, 1>*>(&T3[0])));
  }
  __syncthreads();
  #pragma unroll
  for(nvfuser_index_t i14 = 0; i14 < 4; ++i14) {
    fenceAsyncProxy();
    if (b9) {
      Hopper::cpAsyncBulkTensorTileS2G((Hopper::CpAsyncBulkTensorTileS2GIndex<2>{ ptr8, (Array<int, 2, 1>{(int32_t)((i3 + (64 * i14))), i4}) }), (i7 + (8192 * i14)));
    }
  }
  cpAsyncBulkCommitGroup();
  cpAsyncBulkWaitGroup<0LL>();
}
```

</details>