### PR TITLE
Call HostIrExecutor::supported the last

### DIFF
--- a/csrc/runtime/executor_dispatch.cpp
+++ b/csrc/runtime/executor_dispatch.cpp
@@ -24,14 +24,19 @@ std::unique_ptr<ExecutorAbstract> ExecutorDispatch::makeExecutor(
     int64_t runtime_id,
     int64_t group_id) {
   FUSER_PERF_SCOPE("ExecutorDispatch::makeExecutor");
+
   if (ExprEvalExecutor::supported(fusion)) {
     return std::make_unique<ExprEvalExecutor>(
         fusion_id, concrete_id, runtime_id, group_id);
   }
+
   if (KernelExecutor::supported(fusion)) {
     return std::make_unique<KernelExecutor>(
         fusion_id, concrete_id, runtime_id, group_id);
   }
+
+  // Calls HostIrExecutor::supported the last because it calls isResharding,
+  // which does expensive index calculation.
   if (HostIrExecutor::supported(fusion)) {
     return std::make_unique<HostIrExecutor>(
         fusion_id, concrete_id, runtime_id, group_id);

--- a/csrc/runtime/executor_dispatch.cpp
+++ b/csrc/runtime/executor_dispatch.cpp
@@ -24,16 +24,16 @@ std::unique_ptr<ExecutorAbstract> ExecutorDispatch::makeExecutor(
     int64_t runtime_id,
     int64_t group_id) {
   FUSER_PERF_SCOPE("ExecutorDispatch::makeExecutor");
-  if (HostIrExecutor::supported(fusion)) {
-    return std::make_unique<HostIrExecutor>(
-        fusion_id, concrete_id, runtime_id, group_id);
-  }
   if (ExprEvalExecutor::supported(fusion)) {
     return std::make_unique<ExprEvalExecutor>(
         fusion_id, concrete_id, runtime_id, group_id);
   }
   if (KernelExecutor::supported(fusion)) {
     return std::make_unique<KernelExecutor>(
+        fusion_id, concrete_id, runtime_id, group_id);
+  }
+  if (HostIrExecutor::supported(fusion)) {
+    return std::make_unique<HostIrExecutor>(
         fusion_id, concrete_id, runtime_id, group_id);
   }
   NVF_THROW("No executor supports provided fusion.");


### PR DESCRIPTION
```
NVFUSER_TRACE=/tmp/host.txt pytest benchmarks/python/host/test_many_pointwise_ops_host.py -s && grep 'HostIrExecutor::supported' /tmp/host.txt | wc -l
```

Before this PR: 144
After this PR: 0

Benchmarks are neutral. I guess making executors has never been the bottleneck. 