### PR TITLE
Pass SchedulerType to makeExecutor

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -456,7 +456,7 @@ void HostIrEvaluator::handle(PostOnStream* post_ir) {
       auto it2 = executors_.insert(
           {hu,
            ExecutorDispatch::makeExecutor(
-               hu->fusion_to_execute(), 1, 1, 1, 1)});
+               hu->fusion_to_execute(), 1, 1, 1, 1, SchedulerType::None)});
       ExecutorAbstract* ea = it2.first->second.get();
       if (ea->isA<KernelExecutor>()) {
         ExecutorDispatch::compile(

--- a/csrc/runtime/executor_dispatch.cpp
+++ b/csrc/runtime/executor_dispatch.cpp
@@ -15,28 +15,41 @@
 
 namespace nvfuser {
 
-// Iterates through executors in priority order creating the first executor that
-// returns true when checking their "supported" method
 std::unique_ptr<ExecutorAbstract> ExecutorDispatch::makeExecutor(
     Fusion* fusion,
     int64_t fusion_id,
     int64_t concrete_id,
     int64_t runtime_id,
-    int64_t group_id) {
+    int64_t group_id,
+    SchedulerType scheduler_type) {
   FUSER_PERF_SCOPE("ExecutorDispatch::makeExecutor");
-  if (HostIrExecutor::supported(fusion)) {
-    return std::make_unique<HostIrExecutor>(
-        fusion_id, concrete_id, runtime_id, group_id);
+  if (scheduler_type == SchedulerType::None) {
+    if (HostIrExecutor::supported(fusion)) {
+      return std::make_unique<HostIrExecutor>(
+          fusion_id, concrete_id, runtime_id, group_id);
+    }
+    if (ExprEvalExecutor::supported(fusion)) {
+      return std::make_unique<ExprEvalExecutor>(
+          fusion_id, concrete_id, runtime_id, group_id);
+    }
+    if (KernelExecutor::supported(fusion)) {
+      return std::make_unique<KernelExecutor>(
+          fusion_id, concrete_id, runtime_id, group_id);
+    }
+    NVF_THROW("No executor supports provided fusion.");
   }
-  if (ExprEvalExecutor::supported(fusion)) {
-    return std::make_unique<ExprEvalExecutor>(
-        fusion_id, concrete_id, runtime_id, group_id);
-  }
-  if (KernelExecutor::supported(fusion)) {
-    return std::make_unique<KernelExecutor>(
-        fusion_id, concrete_id, runtime_id, group_id);
-  }
-  NVF_THROW("No executor supports provided fusion.");
+
+  switch (scheduler_type) {
+    case SchedulerType::Communication:
+      return std::make_unique<HostIrExecutor>(
+          fusion_id, concrete_id, runtime_id, group_id);
+    case SchedulerType::ExprEval:
+      return std::make_unique<ExprEvalExecutor>(
+          fusion_id, concrete_id, runtime_id, group_id);
+    default:
+      return std::make_unique<KernelExecutor>(
+          fusion_id, concrete_id, runtime_id, group_id);
+  };
 }
 
 void ExecutorDispatch::compile(ExecutorAbstract* executor, Fusion* fusion) {

--- a/csrc/runtime/executor_dispatch.h
+++ b/csrc/runtime/executor_dispatch.h
@@ -16,14 +16,20 @@ namespace nvfuser {
 // ExprEvalExecutor
 class ExecutorDispatch {
  public:
-  // Iterates through executors in priority order creating the first executor
-  // that returns true when checking their "supported" method
+  // If `scheduler_type` is `SchedulerType::None`, this function Iterates
+  // through executors in priority order creating the first executor that
+  // returns true when checking their "supported" method. Otherwise, create the
+  // executor according to `scheduler_type`, which is faster.
+  //
+  // The slow path (i.e. `SchedulerType::None`) is only used by
+  // MultiDeviceExecutor at this moment.
   static std::unique_ptr<ExecutorAbstract> makeExecutor(
       Fusion* fusion,
       int64_t fusion_id = -1,
       int64_t concrete_id = -1,
       int64_t runtime_id = -1,
-      int64_t group_id = -1);
+      int64_t group_id = -1,
+      SchedulerType scheduler_type);
 
   static void compile(ExecutorAbstract* executor, Fusion* fusion);
 

--- a/csrc/runtime/executor_dispatch.h
+++ b/csrc/runtime/executor_dispatch.h
@@ -16,7 +16,7 @@ namespace nvfuser {
 // ExprEvalExecutor
 class ExecutorDispatch {
  public:
-  // If `scheduler_type` is `SchedulerType::None`, this function Iterates
+  // If `scheduler_type` is `SchedulerType::None`, this function iterates
   // through executors in priority order creating the first executor that
   // returns true when checking their "supported" method. Otherwise, create the
   // executor according to `scheduler_type`, which is faster.

--- a/csrc/runtime/executor_dispatch.h
+++ b/csrc/runtime/executor_dispatch.h
@@ -29,7 +29,7 @@ class ExecutorDispatch {
       int64_t concrete_id = -1,
       int64_t runtime_id = -1,
       int64_t group_id = -1,
-      SchedulerType scheduler_type);
+      SchedulerType scheduler_type = SchedulerType::None);
 
   static void compile(ExecutorAbstract* executor, Fusion* fusion);
 

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -247,7 +247,12 @@ void FusionKernelRuntime::deserialize(
 
     // Initialize associated executors
     executors_[group_id] = ExecutorDispatch::makeExecutor(
-        fusion_to_run.get(), fusion_id_, concrete_id_, runtime_id_, group_id);
+        fusion_to_run.get(),
+        fusion_id_,
+        concrete_id_,
+        runtime_id_,
+        group_id,
+        sg->schedulerType());
 
     // Deserialize KernelExecutor; Otherwise use ExecutorDispatch
     if (auto ke =
@@ -853,7 +858,12 @@ void FusionKernelRuntime::compileKernel(
   } else {
     // Initialize associated executors
     executors_[group_id] = ExecutorDispatch::makeExecutor(
-        fusion_to_run.get(), fusion_id_, concrete_id_, runtime_id_, group_id);
+        fusion_to_run.get(),
+        fusion_id_,
+        concrete_id_,
+        runtime_id_,
+        group_id,
+        heuristic_params->scheduler_type);
 
     ExecutorDispatch::compile(
         executors_.at(group_id).get(),

--- a/tests/python/test_pointwise.py
+++ b/tests/python/test_pointwise.py
@@ -359,7 +359,9 @@ def test_issue2853():
 
     with FusionDefinition() as fd:
         fusion_func(fd)
-    with pytest.raises(RuntimeError, match="No executor supports provided fusion."):
+    with pytest.raises(
+        RuntimeError, match="KernelExecutor does not support the Fusion provided."
+    ):
         _ = fd.execute(inputs)
 
 
@@ -419,5 +421,7 @@ def test_single_segment_multi_device():
     with FusionDefinition() as fd:
         fusion_func(fd)
 
-    with pytest.raises(RuntimeError, match="No executor supports provided fusion."):
+    with pytest.raises(
+        RuntimeError, match="KernelExecutor does not support the Fusion provided."
+    ):
         _ = fd.execute(inputs)


### PR DESCRIPTION
to avoid unnecessary ::supported calls. HostIrExecutor::supported is expensive in particular, because it calls isResharding.

```
$ NVFUSER_TRACE=/dev/stdout pytest benchmarks/python/host/test_many_pointwise_ops_host.py -s | grep 'HostIrExecutor::supported' | wc -l               
```

Before this PR: 144
After this PR: 0