### PR TITLE
Enable host IR tests in test_multidevice_lower_communication

### DIFF
--- a/tests/cpp/test_multidevice_lower_communication.cpp
+++ b/tests/cpp/test_multidevice_lower_communication.cpp
@@ -777,7 +777,7 @@ INSTANTIATE_TEST_SUITE_P(
     LowerCollectiveTest,
     ::testing::Combine(
         testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
-        testing::Values(false)),
+        testing::Bool()),
     ([](const testing::TestParamInfo<std::tuple<CommunicatorBackend, bool>>&
             info) -> std::string {
       const auto& [backend_type, enable_host_ir_lowering] = info.param;


### PR DESCRIPTION
I thought this would trigger https://github.com/NVIDIA/Fuser/issues/4230? 