### PR TITLE
Make test_deepseek_v3.py a benchmark as well as a test

### DIFF
--- a/python/nvfuser/testing/benchmark_utils.py
+++ b/python/nvfuser/testing/benchmark_utils.py
@@ -4,6 +4,7 @@
 
 import torch
 
+
 def get_benchmark_fn(func, /, profile: bool):
     def wrapper(*args, **kwargs):
         if profile:

--- a/python/nvfuser/testing/benchmark_utils.py
+++ b/python/nvfuser/testing/benchmark_utils.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import torch
+
+def get_benchmark_fn(func, /, profile: bool):
+    def wrapper(*args, **kwargs):
+        if profile:
+            torch.cuda.cudart().cudaProfilerStart()
+        result = func(*args, **kwargs)
+        torch.cuda.synchronize()
+        if profile:
+            torch.cuda.cudart().cudaProfilerStop()
+        return result
+
+    return wrapper
+
+
+# Returns two functors, the first with profiler off and the second with profiler
+# on. The first functor is usually used for warmup and the second for actual
+# benchmarking.
+def get_benchmark_fns(func):
+    return get_benchmark_fn(func, profile=False), get_benchmark_fn(func, profile=True)

--- a/python/nvfuser/testing/benchmark_utils.py
+++ b/python/nvfuser/testing/benchmark_utils.py
@@ -20,6 +20,12 @@ def get_benchmark_fn(func, /, profile: bool):
 
 # Returns two functors, the first with profiler off and the second with profiler
 # on. The first functor is usually used for warmup and the second for actual
-# benchmarking.
+# benchmarking. This way, one
+# can collect stats of the first few non-warmup benchmark iterations using
+# ```bash
+# mpirun -np 1 nsys profile --capture-range=cudaProfilerApi --capture-range-end=repeat:<iterations> pytest tests/python/multidevice/<test_file>.py -k <filter> --only-mpi : -np <processes - 1> pytest tests/python/multidevice/<test_file>.py -k <filter> --only-mpi
+# ```
+# and then display the stats using e.g. `nsys stats --report=cuda_gpu_kern_sum
+# report1.nsys-rep`.
 def get_benchmark_fns(func):
     return get_benchmark_fn(func, profile=False), get_benchmark_fn(func, profile=True)

--- a/tests/python/multidevice/test_deepseek_v3.py
+++ b/tests/python/multidevice/test_deepseek_v3.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from enum import Enum, auto
 from functools import wraps
 from linear import TensorParallelLinear
+from nvfuser.testing.benchmark_utils import get_benchmark_fns
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.parallel import (
     parallelize_module,
@@ -149,7 +150,7 @@ def parallelize_module_with_nvfuser(
     [Executor.TORCH_TP, Executor.NVFUSER],
     ids=lambda e: e.name,
 )
-def test_transformer_layer(setup_default_process_group, executor: Executor):
+def test_transformer_layer(setup_default_process_group, benchmark, executor: Executor):
     config = load_config("deepseek-ai/deepseek-v3")
     # Create only one layer which is sufficient for the test.
     config.num_hidden_layers = 1
@@ -236,11 +237,11 @@ def test_transformer_layer(setup_default_process_group, executor: Executor):
         mask = transformers.modeling_attn_mask_utils._prepare_4d_causal_attention_mask(
             None, [batch_size, seq_len], inp, past_key_values_length=0
         )
-        (out,) = transformer_layer(inp, attention_mask=mask)
-        # Finish all computation and communication. Otherwise,
-        # destroy_process_group may deadlock.
-        torch.cuda.synchronize()
+        warmup_fn, benchmark_fn = get_benchmark_fns(lambda: transformer_layer(inp, attention_mask=mask))
 
+        (out,) = warmup_fn()
         assert out.size() == (batch_size, seq_len, config.hidden_size)
         assert out.dtype == config.torch_dtype
         assert out.is_cuda
+
+        benchmark.pedantic(benchmark_fn, rounds=5)

--- a/tests/python/multidevice/test_deepseek_v3.py
+++ b/tests/python/multidevice/test_deepseek_v3.py
@@ -237,7 +237,9 @@ def test_transformer_layer(setup_default_process_group, benchmark, executor: Exe
         mask = transformers.modeling_attn_mask_utils._prepare_4d_causal_attention_mask(
             None, [batch_size, seq_len], inp, past_key_values_length=0
         )
-        warmup_fn, benchmark_fn = get_benchmark_fns(lambda: transformer_layer(inp, attention_mask=mask))
+        warmup_fn, benchmark_fn = get_benchmark_fns(
+            lambda: transformer_layer(inp, attention_mask=mask)
+        )
 
         (out,) = warmup_fn()
         assert out.size() == (batch_size, seq_len, config.hidden_size)

--- a/tests/python/multidevice/test_transformer.py
+++ b/tests/python/multidevice/test_transformer.py
@@ -7,24 +7,7 @@ import torch
 import nvfuser
 from nvfuser import DataType, FusionDefinition
 from nvfuser.testing.utils import create_sdpa_rng_tensors, define_sdpa_rng_state
-
-
-def get_benchmark_fn(func, /, profile: bool):
-    def wrapper(*args, **kwargs):
-        if profile:
-            torch.cuda.cudart().cudaProfilerStart()
-        result = func(*args, **kwargs)
-        torch.cuda.synchronize()
-        if profile:
-            torch.cuda.cudart().cudaProfilerStop()
-        return result
-
-    return wrapper
-
-
-# Returns two functors, one with profiler off and the other with profiler on.
-def get_benchmark_fns(func):
-    return get_benchmark_fn(func, profile=False), get_benchmark_fn(func, profile=True)
+from nvfuser.testing.benchmark_utils import get_benchmark_fns
 
 
 def _sharded_linear_all_reduce(


### PR DESCRIPTION
```
me @ viking-prod-232 : dev | /opt/pytorch/nvfuser (wjy/benchmark)
$ mpirun -np 8 -output-filename /tmp/test_deepseek_v3 pytest tests/python/multidevice/test_deepseek_v3.py --only-mpi

# Other ranks show similar results.
$ cat /tmp/test_deepseek_v3/1/rank.0/stdout

----------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------
Name (time in ms)                        Min                Max               Mean             StdDev             Median                IQR            Outliers      OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_transformer_layer[TORCH_TP]     24.4076 (1.0)      29.4599 (1.0)      26.2417 (1.0)       2.0156 (1.0)      25.6295 (1.0)       2.7083 (1.0)           1;0  38.1073 (1.0)           5           1
test_transformer_layer[NVFUSER]      28.6499 (1.17)     75.5864 (2.57)     39.0602 (1.49)     20.4520 (10.15)    29.8216 (1.16)     13.5153 (4.99)          1;1  25.6015 (0.67)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```